### PR TITLE
PianoRoll: fix odd time signature issues (bugs 274 and 172 at SF)

### DIFF
--- a/src/gui/piano_roll.cpp
+++ b/src/gui/piano_roll.cpp
@@ -2922,7 +2922,7 @@ void pianoRoll::paintEvent( QPaintEvent * _pe )
 	bool triplets = ( quantization() % 3 != 0 ); 
 
 	int spt = midiTime::stepsPerTact(); 
-	float pp16th = m_ppt / spt;
+	float pp16th = (float)m_ppt / spt;
 	int bpt = DefaultBeatsPerTact;
 	if ( triplets ) {
 		spt = static_cast<int>(1.5 * spt);
@@ -3855,7 +3855,7 @@ midiTime pianoRoll::newNoteLen() const
 	{
 		return m_lenOfNewNotes;
 	}
-	return midiTime::ticksPerTact() / m_noteLenModel.currentText().right(
+	return DefaultTicksPerTact / m_noteLenModel.currentText().right(
 				m_noteLenModel.currentText().length() -
 								2 ).toInt();
 }


### PR DESCRIPTION
Migrating a few oneliners over from Sourceforge. These should be pretty obvious:
- A cast makes divisions go right in drawing the grid.
- A whole note has the same length regardless of the time signature.
