### PR TITLE
Make cancelling an export work immediately

### DIFF
--- a/include/export_project_dialog.h
+++ b/include/export_project_dialog.h
@@ -69,6 +69,7 @@ private:
 	TrackVector m_unmutedBB;
 	ProjectRenderer::ExportFileFormats m_ft;
 	TrackVector m_tracksToRender;
+	ProjectRenderer* m_activeRenderer;
 } ;
 
 #endif

--- a/src/gui/export_project_dialog.cpp
+++ b/src/gui/export_project_dialog.cpp
@@ -105,6 +105,10 @@ void exportProjectDialog::reject()
 		(*it)->abortProcessing();
 	}
 
+	if( m_activeRenderer ) {
+		m_activeRenderer->abortProcessing();
+	}
+
 	QDialog::reject();
 }
 
@@ -144,6 +148,11 @@ void exportProjectDialog::closeEvent( QCloseEvent * _ce )
 			(*it)->abortProcessing();
 		}
 	}
+
+	if( m_activeRenderer && m_activeRenderer->isRunning() ) {
+		m_activeRenderer->abortProcessing();
+	}
+
 	QDialog::closeEvent( _ce );
 }
 
@@ -172,9 +181,9 @@ void exportProjectDialog::popRender()
 
 
 	// Pop next render job and start
-	ProjectRenderer* r = m_renderers.back();
+	m_activeRenderer = m_renderers.back();
 	m_renderers.pop_back();
-	render( r );
+	render( m_activeRenderer );
 }
 
 


### PR DESCRIPTION
In 0.4.15, cancelling an export (single or multitrack) doesn't stop exporting the track being exported at the time. Which means the engine still is connected to the output file, even if the export dialog closes.

This is because once a ProjectRenderer has been popped from the vector there is no pointer to it outside popRender(). This commit adds that missing pointer.

Migrated from patch 42 at Sourceforge.
