### PR TITLE
"Default preset" is not descriptive; change it to the actual plugin name

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -893,6 +893,7 @@ Instrument * InstrumentTrack::loadInstrument( const QString & _plugin_name )
 	m_instrument = Instrument::instantiate( _plugin_name, this );
 	engine::mixer()->unlock();
 
+	setName( m_instrument->displayName() );
 	emit instrumentChanged();
 
 	return m_instrument;


### PR DESCRIPTION
This makes it possibly easier to distinguish instruments by their type.
