### PR TITLE
Change default detuning type to linear

### DIFF
--- a/src/core/note.cpp
+++ b/src/core/note.cpp
@@ -272,6 +272,8 @@ void note::createDetuning()
 	m_detuning = new DetuningHelper;
 	(void) m_detuning->automationPattern();
 	m_detuning->setRange( -MaxDetuning, MaxDetuning, 0.1f );
+	m_detuning->automationPattern()->setProgressionType(
+		AutomationPattern::LinearProgression );
 }
 
 


### PR DESCRIPTION
Follow-up to #41; thought linear progression would be best for pitch automation
