### PR TITLE
Increase detuning interval to 0.5 semitones

### DIFF
--- a/src/core/note.cpp
+++ b/src/core/note.cpp
@@ -268,7 +268,7 @@ void note::createDetuning()
 	{
 		m_detuning = new DetuningHelper;
 		(void) m_detuning->automationPattern();
-		m_detuning->setRange( -MaxDetuning, MaxDetuning, 0.1f );
+		m_detuning->setRange( -MaxDetuning, MaxDetuning, 0.5f );
 		m_detuning->automationPattern()->setProgressionType( AutomationPattern::LinearProgression );
 	}
 }


### PR DESCRIPTION
[Current interval is 0.1](https://github.com/LMMS/lmms/blob/stable-0.4/src/core/note.cpp#L271), which makes it hard to make points fall on exact notes. Now LMMS can interpolate between points, precision might not be as important anymore.
