### PR TITLE
Loop marker: Changed tooltip text.

### DIFF
--- a/src/core/timeline.cpp
+++ b/src/core/timeline.cpp
@@ -312,7 +312,7 @@ void timeLine::mousePressEvent( QMouseEvent* event )
 	{
 		delete m_hint;
 		m_hint = textFloat::displayMessage( tr( "Hint" ),
-					tr( "Hold <Shift>+<Right click> to move the begin loop point; Press <Ctrl> to disable magnetic loop points." ),
+					tr( "Hold <Shift> to move the begin loop point; Press <Ctrl> to disable magnetic loop points." ),
 					embed::getIconPixmap( "hint" ), 0 );
 	}
 


### PR DESCRIPTION
After the changes of the issue https://github.com/LMMS/lmms/issues/81 , users probably can't figure out how to change the begin loop marker.
This commit changes the tooltip text to tell the user that they can press <Shift>+<Right Click> to move the begin loop marker.
