### PR TITLE
Fixed OpulenZ segfault bug when it is dropped on another instrument.

### DIFF
--- a/plugins/opl2/opl2instrument.cpp
+++ b/plugins/opl2/opl2instrument.cpp
@@ -148,6 +148,9 @@ opl2instrument::opl2instrument( InstrumentTrack * _instrument_track ) :
 	emulatorMutex.lock();
 	theEmulator = new CTemuopl(engine::mixer()->processingSampleRate(), true, false);
 	theEmulator->init();
+	// Enable waveform selection
+	theEmulator->write(0x01,0x20);
+	emulatorMutex.unlock();
 
 	//Initialize voice values
 	voiceNote[0] = 0;
@@ -156,10 +159,6 @@ opl2instrument::opl2instrument( InstrumentTrack * _instrument_track ) :
 		voiceNote[i] = OPL2_VOICE_FREE;
 		voiceLRU[i] = i;
 	}
-
-	// Enable waveform selection
-	theEmulator->write(0x01,0x20);
-	emulatorMutex.unlock();
 
 	updatePatch();
 


### PR DESCRIPTION
voiceNote should be initialized before updatePatch() is called. Otherwise, LMMS crashes when OpulenZ is dropped on another instrument

EDIT:
~~Do NOT merge now! OpulenZ produces weird sound per 9 keypresses.~~

EDIT2: Fixed. It should be **OK to merge** now.
