### PR TITLE
Fixes segfault when clearSelection() is called with a new instance of FileDialog

### DIFF
--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -59,7 +59,7 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 
 void FileDialog::clearSelection()
 {
-    QListView *view = findChild<QListView*>()
+    QListView *view = findChild<QListView*>();
 	Q_ASSERT( view );
 	view->clearSelection();
 }


### PR DESCRIPTION
The `static` keyword makes `view` is assigned once only.
If `firstFileDialog` is destructed and `newFileDialog->clearSelection()` is called. Then `view` would become a dangling pointer, which may cause segfault.
