### PR TITLE
Hide RANGE spinbox when the instrument is not bendable

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1332,6 +1332,7 @@ void InstrumentTrackWindow::modelChanged()
 	{
 		m_pitchKnob->hide();
 		m_pitchKnob->setModel( NULL );
+		m_pitchRangeSpinBox->hide();
 	}
 
 	m_ssView->setModel( &m_track->m_soundShaping );


### PR DESCRIPTION
I didn't set the model of `m_pitchRangeSpinBox` to NULL because this crashes LMMS. Anyway, there's no harm because the value loaded from `m_pitchKnob` and `m_pitchRangeSpinBox` are ignored for non-bendable instruments
