### PR TITLE
Fixes crash on loading instrument with peak controller

### DIFF
--- a/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
@@ -78,7 +78,7 @@ void PeakControllerEffectControls::loadSettings( const QDomElement & _this )
 		m_effect->m_effectId = rand();
 	}
 
-	if( m_effect->m_autoController && PresetPreviewPlayHandle::isPreviewing() == false )
+	if( m_effect->m_autoController && PresetPreviewPlayHandle::isPreviewing() == true )
 	{
 		delete m_effect->m_autoController;
 		m_effect->m_autoController = 0;

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -38,6 +38,7 @@
 #include "EffectChain.h"
 #include "ControllerDialog.h"
 #include "plugins/peak_controller_effect/peak_controller_effect.h"
+#include "PresetPreviewPlayHandle.h"
 
 PeakControllerEffectVector PeakController::s_effects;
 int PeakController::m_getCount;
@@ -62,7 +63,11 @@ PeakController::PeakController( Model * _parent,
 
 PeakController::~PeakController()
 {
-	if( m_peakEffect != NULL && m_peakEffect->effectChain() != NULL )
+	//EffectChain::loadSettings() appends effect to EffectChain::m_effects
+	//When it's previewing, EffectChain::loadSettings(<Controller Fx XML>) is not called
+	//Therefore, we shouldn't call removeEffect() as it is not even appended.
+	//NB: Most XML setting are loaded on preview, except controller fx.
+	if( m_peakEffect != NULL && m_peakEffect->effectChain() != NULL && PresetPreviewPlayHandle::isPreviewing() == false )
 	{
 		m_peakEffect->effectChain()->removeEffect( m_peakEffect );
 	}

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -88,8 +88,8 @@ public:
 
 	bool isPreviewing()
 	{
-		bool ret = m_dataMutex.tryLock();
-		if( ret == true )
+		bool ret = !m_dataMutex.tryLock();
+		if( ret == false )
 		{
 			m_dataMutex.unlock();
 		}


### PR DESCRIPTION
- Fixes crash on loading instrument with peak controller
- Fixed mistake of isPreviewing() . I swapped true and false accidentally.
