### PR TITLE
Fix compact track bug in BB_Editor fixes #73

### DIFF
--- a/src/gui/bb_editor.cpp
+++ b/src/gui/bb_editor.cpp
@@ -68,12 +68,12 @@ bbEditor::bbEditor( bbTrackContainer* tc ) :
 					  "compacttrackbuttons" ).toInt() )
 	{
 		setMinimumWidth( TRACK_OP_WIDTH_COMPACT + DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT
-			     + 2 * TCO_BORDER_WIDTH + 192 );
+			     + 2 * TCO_BORDER_WIDTH + 264 );
 	}
 	else
 	{
 		setMinimumWidth( TRACK_OP_WIDTH + DEFAULT_SETTINGS_WIDGET_WIDTH
-			     + 2 * TCO_BORDER_WIDTH + 192 );
+			     + 2 * TCO_BORDER_WIDTH + 264 );
 	}
 
 


### PR DESCRIPTION
changed the minimum bb_editor window size when using "compact track buttons" mode,  from 192 to 264 px
