### PR TITLE
Fix a segmentation fault

### DIFF
--- a/src/gui/export_project_dialog.cpp
+++ b/src/gui/export_project_dialog.cpp
@@ -40,7 +40,8 @@ exportProjectDialog::exportProjectDialog( const QString & _file_name,
 	Ui::ExportProjectDialog(),
 	m_fileName( _file_name ),
 	m_fileExtension(),
-	m_multiExport(multi_export)
+	m_multiExport( multi_export ),
+	m_activeRenderer( NULL )
 {
 	setupUi( this );
 	setWindowTitle( tr( "Export project to %1" ).arg( 


### PR DESCRIPTION
Fix the segmentation fault caused by clicking on the "Cancel" button of the export dialog, as in issue #249.
