### PR TITLE
Little things in RemoteVstPlugin behaviour

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -739,8 +739,6 @@ bool RemoteVstPlugin::load( const std::string & _plugin_file )
 		return false;
 	}
 
-	m_plugin->user = this;
-
 	if( m_plugin->magic != kEffectMagic )
 	{
 		debugMessage( "File is not a VST plugin\n" );


### PR DESCRIPTION
`RemoteVstPlugin::load()` assigns itself to `AEffect.user` but never does anything with that field.

I wrote a little test plugin and ran it in several hosts, and here are the test results:
https://gist.github.com/grejppi/9178616

It seems `ptr1` and `ptr2` are for the host to use; no other host touched `user` except LMMS. And LMMS doesn't even need it...

Also, I guess the host should deactivate the plugin properly, by sending `effMainsChanged`...
