### PR TITLE
Fix zynaddsubfx export with higher samplerates

### DIFF
--- a/plugins/zynaddsubfx/LocalZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/LocalZynAddSubFx.cpp
@@ -241,7 +241,7 @@ void LocalZynAddSubFx::processAudio( sampleFrame * _out )
 	REALTYPE outputl[SOUND_BUFFER_SIZE];
 	REALTYPE outputr[SOUND_BUFFER_SIZE];
 
-	m_master->AudioOut( outputl, outputr );
+	m_master->GetAudioOutSamples( SOUND_BUFFER_SIZE, SAMPLE_RATE, outputl, outputr );
 
 	for( int f = 0; f < SOUND_BUFFER_SIZE; ++f )
 	{

--- a/plugins/zynaddsubfx/LocalZynAddSubFx.h
+++ b/plugins/zynaddsubfx/LocalZynAddSubFx.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef _LOCAL_ZYNADDSUBFX_H
-#define _LOCAL_ZYNADDSUBFX_H
+#ifndef LOCAL_ZYNADDSUBFX_H
+#define LOCAL_ZYNADDSUBFX_H
 
 #include "MidiEvent.h"
 #include "note.h"


### PR DESCRIPTION
Fixes #126. 

We were using the "AudioOut" method for getting output from zyn, but after a brief perusal of the source code, it appears there's another method right next to it called "GetAudioOutSamples" which is intended for the kind of use we use Zyn for (controlling from an external program), which also takes buffer size and sample rate as arguments.

So I switched the code in localzynaddsubfx.cpp to use this other method, and it seems that after that, the export works perfectly on all sample rates.

It also appears that we've been restarting zynaddsubfx every time sample rate changes and hoped for it to change the output sample rate that way. With this update, we might not have to do that anymore, but I'm not actually sure about that so I didn't touch that part of the code. Let sleeping dogs lie, and such...
