### PR TITLE
Drumsynth: make rendering use mixer samplerate instead of hard coded 44100

### DIFF
--- a/include/drumsynth.h
+++ b/include/drumsynth.h
@@ -28,11 +28,12 @@
 #define _DRUMSYNTH_H__
 
 #include <stdint.h>
+#include "lmms_basics.h"
 
 class DrumSynth {
     public:
         DrumSynth() {};
-        int GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels);
+        int GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels, sample_rate_t Fs);
 
     private:
         float LoudestEnv(void);

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -593,7 +593,7 @@ f_cnt_t SampleBuffer::decodeSampleDS( const char * _f,
 						sample_rate_t & _samplerate )
 {
 	DrumSynth ds;
-	f_cnt_t frames = ds.GetDSFileSamples( _f, _buf, _channels );
+	f_cnt_t frames = ds.GetDSFileSamples( _f, _buf, _channels, _samplerate );
 
 	if ( frames > 0 && _buf != NULL )
 	{

--- a/src/core/drumsynth.cpp
+++ b/src/core/drumsynth.cpp
@@ -46,7 +46,7 @@ using namespace std;
 #define DWORD __u32
 #define WAVE_FORMAT_PCM			0x0001
 
-const int     Fs    =  44100;
+// const int     Fs    =  44100;
 const float   TwoPi =  6.2831853f;
 const int     MAX   =  0;
 const int     ENV   =  1;
@@ -255,7 +255,7 @@ float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float 
 //  an associative array or something once we have a datastructure to load in to.
 //  llama
 
-int DrumSynth::GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels)
+int DrumSynth::GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
 {
   //input file
   char sec[32];


### PR DESCRIPTION
All other sample buffers are normalized to the mixer sample rate on load, so should this.
