### PR TITLE
Pattern: fix beat pattern behaviour with different time signatures

### DIFF
--- a/include/pattern.h
+++ b/include/pattern.h
@@ -71,6 +71,8 @@ public:
 
 	void removeNote( const note * _note_to_del );
 
+	note * getNoteAtStep( int _step );
+
 	note * rearrangeNote( const note * _note_to_proc,
 						const bool _quant_pos = true );
 	void rearrangeAllNotes();


### PR DESCRIPTION
Fixes #337

Some caveats: there's still some odd behaviour if you have notes in a beat pattern and then change the numerator (or is it the denominator? anyway the lower part) of the time signature. This causes the existing notes sometimes to be "misaligned" with the new step grid. I didn't want to remove those notes because it'd be too easy to cause unfortunate accidents where a careless user could ruin ALL their beat patterns with a single flick of a mouse wheel, but this means that those notes will now stay behind as "invisible" (visible in piano roll only). They'll appear again when you change back to the time sig where they match the steps.

I don't think there's a good fix for this issue until/unless we take my suggestion of rethinking the way time signatures work (see mailing list). 

However the main issue is now fixed, in that the bb-editor is now at least usable with any time signature, and as long as you only use one time sig per project, it's now perfectly functional. Also I guess this does allow creating beats with multiple time sigs, in a way - just not very ergonomically.
