### PR TITLE
AutomationEditor: fix grid scrolling and non-4/4 time signatures

### DIFF
--- a/src/gui/AutomationEditor.cpp
+++ b/src/gui/AutomationEditor.cpp
@@ -39,7 +39,6 @@
 #include <QtGui/QWheelEvent>
 #include <QToolTip>
 
-#include <QtCore/QDebug>
 
 #ifndef __USE_XOPEN
 #define __USE_XOPEN


### PR DESCRIPTION
Closes #283 and closes #303.
BUT, please don't put this in 1.0.0, at least not without thorough testing! There might be some place where `DefaultTicksPerTact` should not be changed to `MidiTime::ticksPerTact()`.

If the time signature has an odd denominator, there will be two grids visible, one from the time signature and one from the quantization, not lining up nicely.
