### PR TITLE
100% velocity should be 100%

### DIFF
--- a/include/note.h
+++ b/include/note.h
@@ -178,7 +178,7 @@ public:
 
 	int midiVelocity() const
 	{
-		return qMin( MidiMaxVelocity, getVolume() * MidiMaxVelocity / MaxVolume );
+		return qMin( MidiMaxVelocity, getVolume() * MidiMaxVelocity / DefaultVolume );
 	}
 
 	inline panning_t getPanning() const

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -187,10 +187,10 @@ void InstrumentTrack::processAudioBuffer( sampleFrame* buf, const fpp_t frames, 
 
 	// We play MIDI-based instruments at velocity 63 for volume=100%. In order
 	// to get the same output volume, we need to scale it by 2
-	if( m_instrument->flags().testFlag( Instrument::IsMidiBased ) )
-	{
-		v_scale *= 2;
-	}
+	//~ if( m_instrument->flags().testFlag( Instrument::IsMidiBased ) )
+	//~ {
+		//~ v_scale *= 2;
+	//~ }
 
 	// instruments using instrument-play-handles will call this method
 	// without any knowledge about notes, so they pass NULL for n, which


### PR DESCRIPTION
Turns out many midi based instruments (soundfonts, zyn presets, etc) use the velocity data for more than just volume. A recent change (0ca3901ab86006d775125f6a5caf70d873bf008b) changed the scale so that what is 100% for lmms is only 50% (63) for midi based instruments. As a result the instruments may sound noticeably duller.

This change reverts 0ca3901ab86006d775125f6a5caf70d873bf008b and ba324f4aa86ef6362b0338b35dedc50ef2e5e42a so that midi velocity is now capped to 127.
