### PR TITLE
Export: check for end of export in ticks, not in tacts.

### DIFF
--- a/include/song.h
+++ b/include/song.h
@@ -170,12 +170,12 @@ public:
 		if ( m_exportLoop )
 		{
 			return m_exporting == true &&
-				m_playPos[Mode_PlaySong].getTact() >= length();
+				m_playPos[Mode_PlaySong].getTicks() >= length() * ticksPerTact();
 		}
 		else
 		{
 			return m_exporting == true &&
-				m_playPos[Mode_PlaySong].getTact() >= length() + 1;
+				m_playPos[Mode_PlaySong].getTicks() >= ( length() + 1 ) * ticksPerTact();
 		}
 	}
 


### PR DESCRIPTION
This works better with time signature changes. Closes #440.
lenght() will return the current song length in tacts, which multiplied by ticksPerTact() should yield the song length in ticks, rounded up to a whole tact (bar).
