### PR TITLE
Improve pattern name text visibility

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -310,16 +310,15 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	p.resetMatrix();
 	p.setFont( pointSize<8>( p.font() ) );
-	if( m_pat->isMuted() || m_pat->getTrack()->isMuted() )
-	{
-		p.setPen( QColor( 50, 50, 50 ) );
-	}
-	else
-	{
-		p.setPen( QColor( 0, 0, 0 ) );
-	}
 
-	p.drawText( 2, p.fontMetrics().height() - 1, m_pat->name() );
+	QColor text_color = ( m_pat->isMuted() || m_pat->getTrack()->isMuted() )
+		? QColor( 30, 30, 30 )
+		: QColor( 255, 255, 255 );
+
+	p.setPen( QColor( 0, 0, 0 ) );
+	p.drawText( 4, p.fontMetrics().height()+1, m_pat->name() );
+	p.setPen( text_color );
+	p.drawText( 3, p.fontMetrics().height(), m_pat->name() );
 
 	if( m_pat->isMuted() )
 	{

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -380,9 +380,13 @@ void SampleTCOView::paintEvent( QPaintEvent * _pe )
 	if( m_tco->isRecord() )
 	{
 		p.setFont( pointSize<7>( p.font() ) );
-		p.setPen( QColor( 224, 0, 0 ) );
-		p.drawText( 9, p.fontMetrics().height() - 1, "Rec" );
-		p.setBrush( QBrush( QColor( 224, 0, 0 ) ) );
+
+		p.setPen( QColor( 0, 0, 0 ) );	
+		p.drawText( 10, p.fontMetrics().height()+1, "Rec" );
+		p.setPen( QColor( 255, 60, 60 ) );	
+		p.drawText( 9, p.fontMetrics().height(), "Rec" );
+		
+		p.setBrush( QBrush( QColor( 255, 60, 60 ) ) );
 		p.drawEllipse( 4, 5, 4, 4 );
 	}
 }

--- a/src/tracks/bb_track.cpp
+++ b/src/tracks/bb_track.cpp
@@ -212,9 +212,12 @@ void bbTCOView::paintEvent( QPaintEvent * )
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
 
 	p.setFont( pointSize<8>( p.font() ) );
+	
 	p.setPen( QColor( 0, 0, 0 ) );
+	p.drawText( 4, p.fontMetrics().height()+1, m_bbTCO->name() );
+	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( 3, p.fontMetrics().height(), m_bbTCO->name() );
-
+	
 	if( m_bbTCO->isMuted() )
 	{
 		p.drawPixmap( 3, p.fontMetrics().height() + 1,

--- a/src/tracks/pattern.cpp
+++ b/src/tracks/pattern.cpp
@@ -607,7 +607,7 @@ patternView::patternView( pattern * _pattern, trackView * _parent ) :
 {
 	connect( engine::pianoRoll(), SIGNAL( currentPatternChanged() ),
 			this, SLOT( update() ) );
-			
+
 	if( s_stepBtnOn == NULL )
 	{
 		s_stepBtnOn = new QPixmap( embed::getIconPixmap(
@@ -970,7 +970,7 @@ void patternView::paintEvent( QPaintEvent * )
 	}
 
 // melody pattern paint event
-	
+
 	if( m_pat->m_patternType == pattern::MelodyPattern )
 	{
 		if( m_pat->m_notes.size() > 0 )
@@ -979,12 +979,12 @@ void patternView::paintEvent( QPaintEvent * )
 			// display the area where most of the m_notes are
 			// also calculate min/max tones so the tonal range can be
 			// properly stretched accross the pattern vertically
-			
+
 			int central_key = 0;
 			int max_key = 0;
 			int min_key = 9999999;
 			int total_notes = 0;
-			
+
 			for( NoteVector::Iterator it = m_pat->m_notes.begin();
 					it != m_pat->m_notes.end(); ++it )
 			{
@@ -1001,13 +1001,13 @@ void patternView::paintEvent( QPaintEvent * )
 			{
 				central_key = central_key / total_notes;
 				const int keyrange = qMax( qMax( max_key - central_key, central_key - min_key ), 1 );
-				
+
 				// debug code
 				// qDebug( "keyrange: %d", keyrange );
 
 				// determine height of the pattern view, sans borders
 				const int ht = height() - 1 - TCO_BORDER_WIDTH * 2;
-				
+
 				// determine maximum height value for drawing bounds checking
 				const int max_ht = height() - 1 - TCO_BORDER_WIDTH;
 
@@ -1032,7 +1032,7 @@ void patternView::paintEvent( QPaintEvent * )
 						( float( central_key - ( *it )->key() ) / keyrange + 1.0f ) / 2;
 					// multiply that by pattern height
 					const int y_pos = static_cast<int>( TCO_BORDER_WIDTH + y_key * ht );
-					
+
 					// debug code
 					// if( ( *it )->length() > 0 ) qDebug( "key %d, central_key %d, y_key %f, y_pos %d", ( *it )->key(), central_key, y_key, y_pos );
 
@@ -1048,7 +1048,7 @@ void patternView::paintEvent( QPaintEvent * )
 						const int x2 = x_base +
 							static_cast<int>
 							( ( ( *it )->pos() + ( *it )->length() ) * ( ppt  / MidiTime::ticksPerTact() ) );
-						
+
 						// check bounds, draw line
 						if( x1 < width() - TCO_BORDER_WIDTH )
 							p.drawLine( x1, y_pos,
@@ -1130,17 +1130,16 @@ void patternView::paintEvent( QPaintEvent * )
 	}
 
 	p.setFont( pointSize<8>( p.font() ) );
-	if( m_pat->isMuted() || m_pat->getTrack()->isMuted() )
-	{
-		p.setPen( QColor( 30, 30, 30 ) );
-	}
-	else
-	{
-		p.setPen( QColor( 0, 0, 0 ) );
-	}
+
+	QColor text_color = ( m_pat->isMuted() || m_pat->getTrack()->isMuted() )
+		? QColor( 30, 30, 30 )
+		: QColor( 255, 255, 255 );
 
 	if( m_pat->name() != m_pat->instrumentTrack()->name() )
 	{
+		p.setPen( QColor( 0, 0, 0 ) );
+		p.drawText( 4, p.fontMetrics().height()+1, m_pat->name() );
+		p.setPen( text_color );
 		p.drawText( 3, p.fontMetrics().height(), m_pat->name() );
 	}
 


### PR DESCRIPTION
Improve pattern name text visibility (all pattern types) by making the text white with a black drop shadow, this way it shows up better on all background colours.

In the future the text colour should be defined in CSS, but for now this is a good temporary solution.
