### PR TITLE
OpulenZ code improvements

### DIFF
--- a/plugins/opl2/fmopl.c
+++ b/plugins/opl2/fmopl.c
@@ -31,7 +31,7 @@
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-#define INLINE		__inline
+#define INLINE		static inline
 #define HAS_YM3812	1
 
 #include <stdio.h>
@@ -39,7 +39,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <math.h>
-//#include "driver.h"		/* use M.A.M.E. */
+/* #include "driver.h" */		/* use M.A.M.E. */
 #include "fmopl.h"
 
 #ifndef PI
@@ -236,10 +236,10 @@ INT32 feedback2;		/* connect for SLOT 2 */
 #define LOG_WAR  2      /* WARNING     */
 #define LOG_INF  1      /* INFORMATION */
 
-//#define LOG_LEVEL LOG_INF
+/* #define LOG_LEVEL LOG_INF */
 #define LOG_LEVEL	LOG_ERR
 
-//#define LOG(n,x) if( (n)>=LOG_LEVEL ) logerror x
+/* #define LOG(n,x) if( (n)>=LOG_LEVEL ) logerror x */
 #define LOG(n,x)
 
 /* --------------------- subroutines  --------------------- */
@@ -313,7 +313,7 @@ INLINE void OPL_KEYOFF(OPL_SLOT *SLOT)
 		/* set envelope counter from envleope output */
 		SLOT->evm = ENV_MOD_RR;
 		if( !(SLOT->evc&EG_DST) )
-			//SLOT->evc = (ENV_CURVE[SLOT->evc>>ENV_BITS]<<ENV_BITS) + EG_DST;
+			/* SLOT->evc = (ENV_CURVE[SLOT->evc>>ENV_BITS]<<ENV_BITS) + EG_DST; */
 			SLOT->evc = EG_DST;
 		SLOT->eve = EG_DED;
 		SLOT->evs = SLOT->evsr;
@@ -545,10 +545,10 @@ INLINE void OPL_CALC_RH( OPL_CH *CH )
 		outd[0] += OP_OUT(SLOT,env_out, feedback2)*2;
 	}
 
-	// SD  (17) = mul14[fnum7] + white noise
-	// TAM (15) = mul15[fnum8]
-	// TOP (18) = fnum6(mul18[fnum8]+whitenoise)
-	// HH  (14) = fnum7(mul18[fnum8]+whitenoise) + white noise
+	/* SD  (17) = mul14[fnum7] + white noise
+	   TAM (15) = mul15[fnum8]
+	   TOP (18) = fnum6(mul18[fnum8]+whitenoise)
+	   HH  (14) = fnum7(mul18[fnum8]+whitenoise) + white noise */
 	env_sd =OPL_CALC_SLOT(SLOT7_2) + whitenoise;
 	env_tam=OPL_CALC_SLOT(SLOT8_1);
 	env_top=OPL_CALC_SLOT(SLOT8_2);

--- a/plugins/opl2/fmopl.h
+++ b/plugins/opl2/fmopl.h
@@ -3,8 +3,8 @@
 
 /* --- select emulation chips --- */
 #define BUILD_YM3812 (HAS_YM3812)
-//#define BUILD_YM3526 (HAS_YM3526)
-//#define BUILD_Y8950  (HAS_Y8950)
+/* #define BUILD_YM3526 (HAS_YM3526) */
+/* #define BUILD_Y8950  (HAS_Y8950) */
 
 /* --- system optimize --- */
 /* select bit size of output : 8 or 16 */


### PR DESCRIPTION
Changed __inline to "static inline" in the emulator code, which should be safe as those functions aren't used from the outside. This should make it valid C99 code (and buildable for OSX?). And changed a bunch of C++ comments to valid C comments as well, in case someone turns on some pedantic warning mode.
