### PR TITLE
Update aeffectx.h

### DIFF
--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -113,12 +113,7 @@ const int effGetVstVersion = 58; // currently unused
 const int kEffectMagic = CCONST( 'V', 's', 't', 'P' );
 const int kVstLangEnglish = 1;
 const int kVstMidiType = 1;
-/*const int kVstParameterUsesFloatStep = 1 << 2;
-const int kVstPpqPosValid = 1 << 9;
-const int kVstTempoValid = 1 << 10;
-const int kVstBarsValid = 1 << 11;
-const int kVstCyclePosValid = 1 << 12;
-const int kVstTimeSigValid = 1 << 13;*/
+
 const int kVstTransportPlaying = 1 << 1;
 const int kVstTransportCycleActive = 1 << 2;
 const int kVstTransportChanged = 1;


### PR DESCRIPTION
Ok so what I did is, I took a closer look at Qtractor source code. Like I discovered earlier, they seem to use the same aeffectx.h that we use (even the comment at the beginning of the file is the same, still says "part of LMMS" and all that stuff) but there seems to be some differences...

Upon closer investigation, it looks to me like some further advancements have been made in the reverse-engineering efforts: some things labeled as "unknown" in our aeffectx.h are known in theirs, and there are also some new structs and constants which are missing from ours. 

I tried compiling with this file and it works fine, doesn't break any of my VST's, and I think one actually works better now - and another that didn't work at all now works, which is nice! In other plugins, I haven't seen much difference, but haven't had the chance to do much testing. Maybe, hopefully, this might solve some of the VST compatibility issues we've been having. (And hopefully, this will at least somewhat help towards the efforts of implementing LinuxVST support.)

Might need some cleanups though... 
