### PR TITLE
SampleBuffer: fix a segfault when moving a loop point while playing a no...

### DIFF
--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -71,7 +71,7 @@ public:
 		{
 			return m_isBackwards;
 		}
-		
+
 		inline void setBackwards( bool _backwards )
 		{
 			m_isBackwards = _backwards;
@@ -81,7 +81,7 @@ public:
 	private:
 		f_cnt_t m_frameIndex;
 		const bool m_varyingPitch;
-		bool m_isBackwards;		
+		bool m_isBackwards;
 		SRC_STATE * m_resamplingData;
 
 		friend class SampleBuffer;
@@ -145,6 +145,16 @@ public:
 	{
 		m_varLock.lock();
 		m_loopEndFrame = _end;
+		m_varLock.unlock();
+	}
+
+	void setAllPointFrames( f_cnt_t _start, f_cnt_t _end, f_cnt_t _loopstart, f_cnt_t _loopend )
+	{
+		m_varLock.lock();
+		m_startFrame = _start;
+		m_endFrame = _end;
+		m_loopStartFrame = _loopstart;
+		m_loopEndFrame = _loopend;
 		m_varLock.unlock();
 	}
 

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -356,10 +356,7 @@ void audioFileProcessor::loopPointChanged( void )
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;
 
-	m_sampleBuffer.setStartFrame( f_start );
-	m_sampleBuffer.setEndFrame( f_end );
-	m_sampleBuffer.setLoopStartFrame( f_loop );
-	m_sampleBuffer.setLoopEndFrame( f_end );
+	m_sampleBuffer.setAllPointFrames( f_start, f_end, f_loop, f_end );
 	emit dataChanged();
 }
 
@@ -734,11 +731,6 @@ void AudioFileProcessorWaveView::mousePressEvent( QMouseEvent * _me )
 	draggingType dt = sample_loop; int md = loop_dist;
 	if( start_dist < loop_dist ) { dt = sample_start; md = start_dist; }
 	else if( end_dist < loop_dist ) { dt = sample_end; md = end_dist; }
-
-/*	qDebug( "x %d", x );
-	qDebug( "loopframex %d", m_loopFrameX );
-	qDebug( "dt %d", dt );
-	qDebug( "md %d", md );*/
 
 	if( md < 4 )
 	{


### PR DESCRIPTION
...te, also do some sptring cleanup (some unused/redundant variables removed)

Also, some codepath optimization: add a method to SampleBuffer for setting all loop/start/endpoints at once, so we don't have to wait for mutex unlocks 4 times in a row. Then make AFP utilize this method.
