### PR TITLE
Song editor

### DIFF
--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -73,7 +73,7 @@
 
 /*! The width of the resize grip in pixels
  */
-const int RESIZE_GRIP_WIDTH = 4;
+const int RESIZE_GRIP_WIDTH = 8;
 
 /*! The size of the track buttons in pixels
  */
@@ -422,8 +422,8 @@ void trackContentObjectView::updateLength()
 	{
 		setFixedWidth(
 		static_cast<int>( m_tco->length() * pixelsPerTact() /
-					MidiTime::ticksPerTact() ) + 1 /*+
-						TCO_BORDER_WIDTH * 2-1*/ );
+                    MidiTime::ticksPerTact() ) + 1 /*+
+                        TCO_BORDER_WIDTH * 2-1*/ );
 	}
 	m_trackView->trackContainerView()->update();
 }


### PR DESCRIPTION
I hope I made it all right. In track.cpp I changed a line. Now the tracks snaps in the right tacs if I copy them per drag and drop. Before that the track snaps in the next tact if the mouse pointer in the near of the next tact. It's a little bit confusing behavoir. Now it works like expected.
