### PR TITLE
Track: depointerize qproperties

### DIFF
--- a/include/track.h
+++ b/include/track.h
@@ -238,8 +238,8 @@ private:
 	MidiTime m_oldTime;// used for undo/redo while mouse-button is pressed
 
 // qproperty fields
-	QColor * m_fgColor;
-	QColor * m_textColor;
+	QColor m_fgColor;
+	QColor m_textColor;
 } ;
 
 
@@ -249,18 +249,18 @@ private:
 class trackContentWidget : public QWidget, public JournallingObject
 {
 	Q_OBJECT
-	
+
 	// qproperties for track background gradients
 	Q_PROPERTY( QColor darkerColor1 READ darkerColor1 WRITE setDarkerColor1 )
 	Q_PROPERTY( QColor darkerColor2 READ darkerColor2 WRITE setDarkerColor2 )
 	Q_PROPERTY( QColor darkerColor3 READ darkerColor3 WRITE setDarkerColor3 )
-	
+
 	Q_PROPERTY( QColor lighterColor1 READ lighterColor1 WRITE setLighterColor1 )
 	Q_PROPERTY( QColor lighterColor2 READ lighterColor2 WRITE setLighterColor2 )
 	Q_PROPERTY( QColor lighterColor3 READ lighterColor3 WRITE setLighterColor3 )
-	
+
 	Q_PROPERTY( float gradMidPoint READ gradMidPoint WRITE setGradMidPoint )
-	
+
 public:
 	trackContentWidget( trackView * _parent );
 	virtual ~trackContentWidget();
@@ -291,15 +291,15 @@ public:
 	QColor lighterColor3() const;
 
 	float gradMidPoint() const;
-	
+
 	void setDarkerColor1( const QColor & _c );
 	void setDarkerColor2( const QColor & _c );
 	void setDarkerColor3( const QColor & _c );
-	
+
 	void setLighterColor1( const QColor & _c );
 	void setLighterColor2( const QColor & _c );
 	void setLighterColor3( const QColor & _c );
-	
+
 	void setGradMidPoint( float _g );
 
 public slots:
@@ -343,12 +343,12 @@ private:
 	QPixmap m_background;
 
 	// qproperty fields
-	QColor * m_darkerColor1;
-	QColor * m_darkerColor2;
-	QColor * m_darkerColor3;
-	QColor * m_lighterColor1;
-	QColor * m_lighterColor2;
-	QColor * m_lighterColor3;
+	QColor m_darkerColor1;
+	QColor m_darkerColor2;
+	QColor m_darkerColor3;
+	QColor m_lighterColor1;
+	QColor m_lighterColor2;
+	QColor m_lighterColor3;
 	float m_gradMidPoint;
 } ;
 

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -250,8 +250,8 @@ trackContentObjectView::trackContentObjectView( trackContentObject * _tco,
 	m_autoResize( false ),
 	m_initialMouseX( 0 ),
 	m_hint( NULL ),
-	m_fgColor( NULL ),
-	m_textColor( NULL )
+	m_fgColor( 0, 0, 0 ),
+	m_textColor( 0, 0, 0 )
 {
 	if( s_textFloat == NULL )
 	{
@@ -276,9 +276,6 @@ trackContentObjectView::trackContentObjectView( trackContentObject * _tco,
 			this, SLOT( updatePosition() ) );
 	connect( m_tco, SIGNAL( destroyedTCO() ), this, SLOT( close() ) );
 	setModel( m_tco );
-
-	setFgColor( QColor( 0,0,0 ) );
-	setTextColor( QColor( 0,0,0 ) );
 
 	m_trackView->getTrackContentWidget()->addTCOView( this );
 }
@@ -322,19 +319,19 @@ bool trackContentObjectView::fixedTCOs()
 // qproperty access functions, to be inherited & used by TCOviews
 //! \brief CSS theming qproperty access method
 QColor trackContentObjectView::fgColor() const
-{ if( m_fgColor ) return *m_fgColor; else return QColor( 0,0,0 ); }
+{ return m_fgColor; }
 
 //! \brief CSS theming qproperty access method
 QColor trackContentObjectView::textColor() const
-{ if( m_textColor ) return *m_textColor; else return QColor( 0,0,0 ); }
+{ return m_textColor; }
 
 //! \brief CSS theming qproperty access method
 void trackContentObjectView::setFgColor( const QColor & _c )
-{ if( m_fgColor ) *m_fgColor = _c; else m_fgColor = new QColor( 0,0,0 ); }
+{ m_fgColor = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
 void trackContentObjectView::setTextColor( const QColor & _c )
-{ if( m_textColor ) *m_textColor = _c; else m_textColor = new QColor( 0,0,0 ); }
+{ m_textColor = QColor( _c ); }
 
 
 /*! \brief Close a trackContentObjectView
@@ -840,12 +837,12 @@ void trackContentObjectView::setAutoResizeEnabled( bool _e )
 trackContentWidget::trackContentWidget( trackView * _parent ) :
 	QWidget( _parent ),
 	m_trackView( _parent ),
-	m_darkerColor1( NULL ),
-	m_darkerColor2( NULL ),
-	m_darkerColor3( NULL ),
-	m_lighterColor1( NULL ),
-	m_lighterColor2( NULL ),
-	m_lighterColor3( NULL ),
+	m_darkerColor1( 0, 0, 0 ),
+	m_darkerColor2( 0, 0, 0 ),
+	m_darkerColor3( 0, 0, 0 ),
+	m_lighterColor1( 0, 0, 0 ),
+	m_lighterColor2( 0, 0, 0 ),
+	m_lighterColor3( 0, 0, 0 ),
 	m_gradMidPoint( 0.0f )
 {
 	setAcceptDrops( true );
@@ -854,16 +851,8 @@ trackContentWidget::trackContentWidget( trackView * _parent ) :
 			SIGNAL( positionChanged( const MidiTime & ) ),
 			this, SLOT( changePosition( const MidiTime & ) ) );
 
-//initialize qproperties
-	setDarkerColor1( QColor( 0, 0, 0 ) );
-	setDarkerColor2( QColor( 0, 0, 0 ) );
-	setDarkerColor3( QColor( 0, 0, 0 ) );
-	setLighterColor1( QColor( 0, 0, 0 ) );
-	setLighterColor2( QColor( 0, 0, 0 ) );
-	setLighterColor3( QColor( 0, 0, 0 ) );
-	
 	setStyle( QApplication::style() );
-	
+
 	updateBackground();
 }
 
@@ -1236,59 +1225,59 @@ MidiTime trackContentWidget::endPosition( const MidiTime & _pos_start )
 
 // qproperty access methods
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor1() const 
-{ if( m_darkerColor1 ) return *m_darkerColor1; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::darkerColor1() const
+{ return m_darkerColor1; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor2() const 
-{ if( m_darkerColor2 ) return *m_darkerColor2; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::darkerColor2() const
+{ return m_darkerColor2; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor3() const 
-{ if( m_darkerColor3 ) return *m_darkerColor3; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::darkerColor3() const
+{ return m_darkerColor3; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor1() const 
-{ if( m_lighterColor1 ) return *m_lighterColor1; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::lighterColor1() const
+{ return m_lighterColor1; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor2() const 
-{ if( m_lighterColor2 ) return *m_lighterColor2; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::lighterColor2() const
+{ return m_lighterColor2; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor3() const 
-{ if( m_lighterColor3 ) return *m_lighterColor3; else return QColor( 0, 0, 0 ); }
+QColor trackContentWidget::lighterColor3() const
+{ return m_lighterColor3; }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor1( const QColor & _c ) 
-{ if( m_darkerColor1 ) *m_darkerColor1 = _c; else m_darkerColor1 = new QColor( _c ); }
+void trackContentWidget::setDarkerColor1( const QColor & _c )
+{ m_darkerColor1 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor2( const QColor & _c ) 
-{ if( m_darkerColor2 ) *m_darkerColor2 = _c; else m_darkerColor2 = new QColor( _c ); }
+void trackContentWidget::setDarkerColor2( const QColor & _c )
+{ m_darkerColor2 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor3( const QColor & _c ) 
-{ if( m_darkerColor3 ) *m_darkerColor3 = _c; else m_darkerColor3 = new QColor( _c ); }
+void trackContentWidget::setDarkerColor3( const QColor & _c )
+{ m_darkerColor3 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor1( const QColor & _c ) 
-{ if( m_lighterColor1 ) *m_lighterColor1 = _c; else m_lighterColor1 = new QColor( _c ); }
+void trackContentWidget::setLighterColor1( const QColor & _c )
+{ m_lighterColor1 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor2( const QColor & _c ) 
-{ if( m_lighterColor2 ) *m_lighterColor2 = _c; else m_lighterColor2 = new QColor( _c ); }
+void trackContentWidget::setLighterColor2( const QColor & _c )
+{ m_lighterColor2 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor3( const QColor & _c ) 
-{ if( m_lighterColor3 ) *m_lighterColor3 = _c; else m_lighterColor3 = new QColor( _c ); }
+void trackContentWidget::setLighterColor3( const QColor & _c )
+{ m_lighterColor3 = QColor( _c ); }
 
 //! \brief CSS theming qproperty access method
-float trackContentWidget::gradMidPoint() const 
+float trackContentWidget::gradMidPoint() const
 { return m_gradMidPoint; }
 
 //! \brief CSS theming qproperty access method
-void trackContentWidget::setGradMidPoint( float _g ) 
+void trackContentWidget::setGradMidPoint( float _g )
 { m_gradMidPoint = _g; }
 
 
@@ -2337,7 +2326,7 @@ void trackView::mouseMoveEvent( QMouseEvent * _me )
 
 // debug code
 //			qDebug( "y position %d", y_pos );
-			
+
 		// a track-widget not equal to ourself?
 		if( track_at_y != NULL && track_at_y != this )
 		{


### PR DESCRIPTION
As requested: use in-class QColors for storing styling qproperties, instead of pointers
