### PR TITLE
Fix broken command line rendering. 

### DIFF
--- a/src/tracks/pattern.cpp
+++ b/src/tracks/pattern.cpp
@@ -537,7 +537,7 @@ void pattern::updateBBTrack()
 		engine::getBBTrackContainer()->updateBBTrack( this );
 	}
 
-	if( engine::pianoRoll()->currentPattern() == this )
+	if( engine::pianoRoll() && engine::pianoRoll()->currentPattern() == this )
 	{
 		engine::pianoRoll()->update();
 	}


### PR DESCRIPTION
Should always check that editor windows exist before using them. Otherwise there are segmentation faults and unhappy users...
