### PR TITLE
Organic: make mixing of oscillators independent of lower oscs

### DIFF
--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -75,7 +75,7 @@ QPixmap * organicInstrumentView::s_artwork = NULL;
 
 organicInstrument::organicInstrument( InstrumentTrack * _instrument_track ) :
 	Instrument( _instrument_track, &organic_plugin_descriptor ),
-	m_modulationAlgo( Oscillator::SignalMix ),
+	m_modulationAlgo( Oscillator::SignalMix, Oscillator::SignalMix, Oscillator::SignalMix),
 	m_fx1Model( 0.0f, 0.0f, 0.99f, 0.01f , this, tr( "Distortion" ) ),
 	m_volModel( 100.0f, 0.0f, 200.0f, 1.0f, this, tr( "Volume" ) )
 {
@@ -117,8 +117,7 @@ organicInstrument::organicInstrument( InstrumentTrack * _instrument_track ) :
 	
 
 	connect( engine::mixer(), SIGNAL( sampleRateChanged() ),
-					this, SLOT( updateAllDetuning() ) );
-
+					this, SLOT( updateAllDetuning() ) );	
 }
 
 


### PR DESCRIPTION
Closes #590, but I can't say if there should be some compatibility code added to it. Might be wise, as the bug has probably been there for years... 

The issue was that the `m_ModulationAlgo` IntModel was constructed with `default=Oscillator::SignalMix, min=0, max=0` which forced the value to 0.
