### PR TITLE
Watsyn: use fast sinc instead of medium quality (not much diff in this c...

### DIFF
--- a/include/graph.h
+++ b/include/graph.h
@@ -150,7 +150,7 @@ public slots:
 
 	void setLength( int _size );
 
-	void setSampleAt( int _samplePos, float _value );
+	void setSampleAt( int x, float val );
 	void setSamples( const float * _value );
 
 	void setWaveToSine();
@@ -172,6 +172,7 @@ signals:
 	void rangeChanged();
 
 private:
+	void drawSampleAt( int x, float val );
 
 	QVector<float> m_samples;
 	float m_minValue;

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -116,14 +116,13 @@ void WatsynObject::renderOutput( fpp_t _frames )
 		/////////////   A-series   /////////////////
 
 		// A2
-		sample_t A2_L = m_A2wave[ static_cast<int>( m_lphase[A2_OSC] ) ] * m_parent->m_lvol[A2_OSC];
-							/*interpolate( m_A2wave[ static_cast<int>( m_lphase[A2_OSC] ) % WAVELEN ],
+		sample_t A2_L = linearInterpolate( m_A2wave[ static_cast<int>( m_lphase[A2_OSC] ) ],
 							m_A2wave[ static_cast<int>( m_lphase[A2_OSC] + 1 ) % WAVELEN ],
-							fraction( m_lphase[A2_OSC] ) ) * m_parent->m_lvol[A2_OSC];*/
-		sample_t A2_R = m_A2wave[ static_cast<int>( m_rphase[A2_OSC] ) ] * m_parent->m_rvol[A2_OSC];
-		/*interpolate( m_A2wave[ static_cast<int>( m_rphase[A2_OSC] ) % WAVELEN ],
+							fraction( m_lphase[A2_OSC] ) ) * m_parent->m_lvol[A2_OSC];
+		sample_t A2_R = linearInterpolate( m_A2wave[ static_cast<int>( m_rphase[A2_OSC] ) ],
 							m_A2wave[ static_cast<int>( m_rphase[A2_OSC] + 1 ) % WAVELEN ],
-							fraction( m_rphase[A2_OSC] ) ) * m_parent->m_rvol[A2_OSC];*/
+							fraction( m_rphase[A2_OSC] ) ) * m_parent->m_rvol[A2_OSC];
+
 		// if phase mod, add to phases
 		if( m_amod == MOD_PM )
 		{
@@ -143,14 +142,12 @@ void WatsynObject::renderOutput( fpp_t _frames )
 		/////////////   B-series   /////////////////
 
 		// B2
-		sample_t B2_L = m_B2wave[ static_cast<int>( m_lphase[B2_OSC] ) ] * m_parent->m_lvol[B2_OSC];
-						/*interpolate( m_B2wave[ static_cast<int>( m_lphase[B2_OSC] ) % WAVELEN ],
-						m_B2wave[ static_cast<int>( m_lphase[B2_OSC] + 1 ) % WAVELEN ],
-						fraction( m_lphase[B2_OSC] ) ) * m_parent->m_lvol[B2_OSC];*/
-		sample_t B2_R = m_B2wave[ static_cast<int>( m_rphase[B2_OSC] ) ] * m_parent->m_rvol[B2_OSC];
-						/*interpolate( m_B2wave[ static_cast<int>( m_rphase[B2_OSC] ) % WAVELEN ],
-						m_B2wave[ static_cast<int>( m_rphase[B2_OSC] + 1 ) % WAVELEN ],
-						fraction( m_rphase[B2_OSC] ) ) * m_parent->m_rvol[B2_OSC];*/
+		sample_t B2_L = linearInterpolate( m_B2wave[ static_cast<int>( m_lphase[B2_OSC] ) ],
+							m_B2wave[ static_cast<int>( m_lphase[B2_OSC] + 1 ) % WAVELEN ],
+							fraction( m_lphase[B2_OSC] ) ) * m_parent->m_lvol[B2_OSC];
+		sample_t B2_R = linearInterpolate( m_B2wave[ static_cast<int>( m_rphase[B2_OSC] ) ],
+							m_B2wave[ static_cast<int>( m_rphase[B2_OSC] + 1 ) % WAVELEN ],
+							fraction( m_rphase[B2_OSC] ) ) * m_parent->m_rvol[B2_OSC];
 
 		// if crosstalk active, add a1
 		const float xt = m_parent->m_xtalk.value();

--- a/plugins/watsyn/Watsyn.h
+++ b/plugins/watsyn/Watsyn.h
@@ -59,7 +59,7 @@
 
 const int GRAPHLEN = 220; // don't change - must be same as the size of the widget
 
-const int WAVERATIO = 25; // oversampling ratio
+const int WAVERATIO = 32; // oversampling ratio
 
 const int WAVELEN = GRAPHLEN * WAVERATIO;
 const int PMOD_AMT = WAVELEN / 2;
@@ -177,7 +177,7 @@ private:
 	inline void srccpy( float * _dst, float * _src )
 	{
 		int err;
-		SRC_STATE * src_state = src_new( SRC_SINC_MEDIUM_QUALITY, 1, &err );
+		SRC_STATE * src_state = src_new( SRC_SINC_FASTEST, 1, &err );
 		SRC_DATA src_data;
 		src_data.data_in = _src;
 		src_data.input_frames = GRAPHLEN;

--- a/src/gui/widgets/graph.cpp
+++ b/src/gui/widgets/graph.cpp
@@ -221,8 +221,11 @@ void graph::drawLineAt( int _x, int _y, int _lastx )
 	for ( int i = 0; i < linelen; i++ )
 	{
 		int x = (_x + (i * xstep));		// get x value
-		model()->setSampleAt( (int)( x * xscale ), val + (i * ystep));
+		model()->drawSampleAt( (int)( x * xscale ), val + (i * ystep));
 	}
+	int start = qMin( _x, _x + ( ( linelen - 1 ) * xstep ) );
+	int end = qMax( _x, _x + ( ( linelen - 1 ) * xstep ) );
+	model()->samplesChanged( start, end );
 }
 
 void graph::changeSampleAt( int _x, int _y )
@@ -488,18 +491,10 @@ void graphModel::setLength( int _length )
 
 
 
-void graphModel::setSampleAt( int _x, float _val )
+void graphModel::setSampleAt( int x, float val )
 {
-	//snap to the grid
-	_val -= ( m_step != 0.0 ) ? fmod( _val, m_step ) * m_step : 0;
-
-	// boundary crop
-	_x = qMax( 0, qMin( length()-1, _x ) );
-	_val = qMax( minValue(), qMin( maxValue(), _val ) );
-
-	// change sample shape
-	m_samples[_x] = _val;
-	emit samplesChanged( _x, _x );
+	drawSampleAt( x, val );
+	emit samplesChanged( x, x );
 }
 
 
@@ -687,6 +682,22 @@ void graphModel::shiftPhase( int _deg )
 	
 	emit samplesChanged( 0, length()-1 );
 }
+
+
+
+void graphModel::drawSampleAt( int x, float val )
+{
+	//snap to the grid
+	val -= ( m_step != 0.0 ) ? fmod( val, m_step ) * m_step : 0;
+
+	// boundary crop
+	x = qMax( 0, qMin( length()-1, x ) );
+	val = qMax( minValue(), qMin( maxValue(), val ) );
+
+	// change sample shape
+	m_samples[x] = val;
+}
+
 
 
 


### PR DESCRIPTION
...ase), increase oversampling to 32 because why not, also use linearInterpolate in both oscs because it's faster now

Graph: optimize graph widget codepaths so that we don't send redundant samplesChanged signals, which in watsyn cause recalculation of the wavetable
