### PR TITLE
Default ctors for LED checkbox and LCD spinbox. Fixes for knob.

### DIFF
--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -35,8 +35,8 @@ class EXPORT LcdWidget : public QWidget
 {
 	Q_OBJECT
 public:
+	LcdWidget( QWidget* parent, const QString& name = QString::null );
 	LcdWidget( int numDigits, QWidget* parent, const QString& name = QString::null );
-
 	LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name = QString::null );
 
 	virtual ~LcdWidget();
@@ -50,6 +50,10 @@ public:
 		update();
 	}
 
+	Q_PROPERTY( int numDigits READ numDigits WRITE setNumDigits )
+
+	inline int numDigits() const { return m_numDigits; }
+	inline void setNumDigits( int n ) { m_numDigits = n; updateSize(); }
 
 public slots:
 	virtual void setMarginWidth( int _width );
@@ -81,6 +85,8 @@ private:
 	int m_cellHeight;
 	int m_numDigits;
 	int m_marginWidth;
+
+	void initUi( const QString& name, const QString &style = QString("19green") ); //!< to be called by ctors
 
 } ;
 

--- a/include/knob.h
+++ b/include/knob.h
@@ -66,7 +66,8 @@ class EXPORT knob : public QWidget, public FloatModelView
 
 	Q_PROPERTY(knobTypes knobNum READ knobNum WRITE setknobNum)
 
-	void init( const QString & _name ); //!< to be called by ctors
+	void initUi( const QString & _name ); //!< to be called by ctors
+	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum
 
 public:
 	knob( knobTypes _knob_num, QWidget * _parent = NULL, const QString & _name = QString() );

--- a/include/led_checkbox.h
+++ b/include/led_checkbox.h
@@ -47,6 +47,10 @@ public:
 	ledCheckBox( const QString & _txt, QWidget * _parent,
 				const QString & _name = QString::null,
 						LedColors _color = Yellow );
+	ledCheckBox( QWidget * _parent,
+				const QString & _name = QString::null,
+						LedColors _color = Yellow );
+
 	virtual ~ledCheckBox();
 
 
@@ -55,6 +59,9 @@ public:
 		return( m_text );
 	}
 
+	void setText( const QString& s );
+
+	Q_PROPERTY( QString text READ text WRITE setText )
 
 protected:
 	virtual void paintEvent( QPaintEvent * _pe );
@@ -65,6 +72,9 @@ private:
 	QPixmap * m_ledOffPixmap;
 	
 	QString m_text;
+
+	void initUi( LedColors _color ); //!< to be called by ctors
+	void onTextUpdated(); //!< to be called when you updated @a m_text
 
 } ;
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -40,47 +40,40 @@
 
 
 
+
+//! @todo: in C++11, we can use delegating ctors
+#define DEFAULT_LCDWIDGET_INITIALIZER_LIST \
+	QWidget( parent ), \
+	m_label()
+
+LcdWidget::LcdWidget( QWidget* parent, const QString& name ) :
+	DEFAULT_LCDWIDGET_INITIALIZER_LIST,
+	m_numDigits( 1 )
+{
+	initUi( name );
+}
+
+
+
+
 LcdWidget::LcdWidget( int numDigits, QWidget* parent, const QString& name ) :
-	QWidget( parent ),
-	m_label(),
+	DEFAULT_LCDWIDGET_INITIALIZER_LIST,
 	m_numDigits( numDigits )
 {
-	setEnabled( true );
-
-	setWindowTitle( name );
-
-	m_lcdPixmap = new QPixmap( embed::getIconPixmap( "lcd_19green" ) );
-
-	m_cellWidth = m_lcdPixmap->size().width() / LcdWidget::charsPerPixmap;
-	m_cellHeight = m_lcdPixmap->size().height() / 2;
-
-	m_marginWidth =  m_cellWidth / 2;
-
-	updateSize();
+	initUi( name );
 }
 
 
 
 
 LcdWidget::LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name ) :
-	QWidget( parent ),
-	m_label(),
+	DEFAULT_LCDWIDGET_INITIALIZER_LIST,
 	m_numDigits( numDigits )
 {
-	setEnabled( true );
-
-	setWindowTitle( name );
-
-	// We should make a factory for these or something.
-	m_lcdPixmap = new QPixmap( embed::getIconPixmap( QString( "lcd_" + style ).toUtf8().constData() ) );
-
-	m_cellWidth = m_lcdPixmap->size().width() / LcdWidget::charsPerPixmap;
-	m_cellHeight = m_lcdPixmap->size().height() / 2;
-
-	m_marginWidth =  m_cellWidth / 2;
-
-	updateSize();
+	initUi( name, style );
 }
+
+#undef DEFAULT_LCDWIDGET_INITIALIZER_LIST
 
 
 
@@ -238,6 +231,28 @@ void LcdWidget::updateSize()
 	}
 
 	update();
+}
+
+
+
+
+void LcdWidget::initUi(const QString& name , const QString& style)
+{
+	setEnabled( true );
+
+	setWindowTitle( name );
+
+	// We should make a factory for these or something.
+	//m_lcdPixmap = new QPixmap( embed::getIconPixmap( QString( "lcd_" + style ).toUtf8().constData() ) );
+	//m_lcdPixmap = new QPixmap( embed::getIconPixmap( "lcd_19green" ) ); // TODO!!
+	m_lcdPixmap = new QPixmap( embed::getIconPixmap( QString( "lcd_" + style ).toUtf8().constData() ) );
+
+	m_cellWidth = m_lcdPixmap->size().width() / LcdWidget::charsPerPixmap;
+	m_cellHeight = m_lcdPixmap->size().height() / 2;
+
+	m_marginWidth =  m_cellWidth / 2;
+
+	updateSize();
 }
 
 

--- a/src/gui/widgets/knob.cpp
+++ b/src/gui/widgets/knob.cpp
@@ -70,14 +70,14 @@ knob::knob( knobTypes _knob_num, QWidget * _parent, const QString & _name ) :
 	DEFAULT_KNOB_INITIALIZER_LIST,
 	m_knobNum( _knob_num )
 {
-	init( _name );
+	initUi( _name );
 }
 
 knob::knob( QWidget * _parent, const QString & _name ) :
 	DEFAULT_KNOB_INITIALIZER_LIST,
 	m_knobNum( knobBright_26 )
 {
-	init( _name );
+	initUi( _name );
 }
 
 #undef DEFAULT_KNOB_INITIALIZER_LIST
@@ -85,7 +85,7 @@ knob::knob( QWidget * _parent, const QString & _name ) :
 
 
 
-void knob::init( const QString & _name )
+void knob::initUi( const QString & _name )
 {
 	if( s_textFloat == NULL )
 	{
@@ -94,6 +94,19 @@ void knob::init( const QString & _name )
 
 	setWindowTitle( _name );
 
+	onKnobNumUpdated();
+	setTotalAngle( 270.0f );
+	setInnerRadius( 1.0f );
+	setOuterRadius( 10.0f );
+	setFocusPolicy( Qt::ClickFocus );
+	doConnections();
+}
+
+
+
+
+void knob::onKnobNumUpdated()
+{
 	if( m_knobNum != knobStyled )
 	{
 		m_knobPixmap = new QPixmap( embed::getIconPixmap( QString( "knob0" +
@@ -101,11 +114,6 @@ void knob::init( const QString & _name )
 
 		setFixedSize( m_knobPixmap->width(), m_knobPixmap->height() );
 	}
-	setTotalAngle( 270.0f );
-	setInnerRadius( 1.0f );
-	setOuterRadius( 10.0f );
-	setFocusPolicy( Qt::ClickFocus );
-	doConnections();
 }
 
 
@@ -193,7 +201,11 @@ knobTypes knob::knobNum() const
 
 void knob::setknobNum( knobTypes _k )
 {
-	m_knobNum = _k;
+	if( m_knobNum != _k )
+	{
+		m_knobNum = _k;
+		onKnobNumUpdated();
+	}
 }
 
 

--- a/src/gui/widgets/led_checkbox.cpp
+++ b/src/gui/widgets/led_checkbox.cpp
@@ -38,25 +38,30 @@ static const QString names[ledCheckBox::NumColors] =
 
 
 
+
+//! @todo: in C++11, we can use delegating ctors
+#define DEFAULT_LEDCHECKBOX_INITIALIZER_LIST \
+	automatableButton( _parent, _name )
+
 ledCheckBox::ledCheckBox( const QString & _text, QWidget * _parent,
 				const QString & _name, LedColors _color ) :
-	automatableButton( _parent, _name ),
+	DEFAULT_LEDCHECKBOX_INITIALIZER_LIST,
 	m_text( _text )
 {
-	setCheckable( true );
-
-	if( _color >= NumColors || _color < Yellow )
-	{
-		_color = Yellow;
-	}
-	m_ledOnPixmap = new QPixmap( embed::getIconPixmap(
-					names[_color].toUtf8().constData() ) );
-	m_ledOffPixmap = new QPixmap( embed::getIconPixmap( "led_off" ) );
-
-	setFont( pointSize<7>( font() ) );
-	setFixedSize( m_ledOffPixmap->width() + 5 + QFontMetrics( font() ).width( text() ), m_ledOffPixmap->height() );
+	initUi( _color );
 }
 
+
+
+
+ledCheckBox::ledCheckBox( QWidget * _parent,
+				const QString & _name, LedColors _color ) :
+	DEFAULT_LEDCHECKBOX_INITIALIZER_LIST
+{
+	initUi( _color );
+}
+
+#undef DEFAULT_LEDCHECKBOX_INITIALIZER_LIST
 
 
 
@@ -69,14 +74,23 @@ ledCheckBox::~ledCheckBox()
 
 
 
+void ledCheckBox::setText( const QString &s )
+{
+	m_text = s;
+	onTextUpdated();
+}
+
+
+
+
 void ledCheckBox::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 	p.setFont( pointSize<7>( font() ) );
 
 	if( model()->value() == true )
-	{
-		p.drawPixmap( 0, 0, *m_ledOnPixmap );
+		{
+			p.drawPixmap( 0, 0, *m_ledOnPixmap );
 	}
 	else
 	{
@@ -87,6 +101,33 @@ void ledCheckBox::paintEvent( QPaintEvent * )
 	p.drawText( m_ledOffPixmap->width() + 4, 11, text() );
 	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( m_ledOffPixmap->width() + 3, 10, text() );
+}
+
+
+
+
+void ledCheckBox::initUi( LedColors _color )
+{
+	setCheckable( true );
+
+	if( _color >= NumColors || _color < Yellow )
+	{
+		_color = Yellow;
+	}
+	m_ledOnPixmap = new QPixmap( embed::getIconPixmap(
+					names[_color].toUtf8().constData() ) );
+	m_ledOffPixmap = new QPixmap( embed::getIconPixmap( "led_off" ) );
+
+	setFont( pointSize<7>( font() ) );
+	setText( m_text );
+}
+
+
+
+
+void ledCheckBox::onTextUpdated()
+{
+	setFixedSize( m_ledOffPixmap->width() + 5 + QFontMetrics( font() ).width( text() ), m_ledOffPixmap->height() );
 }
 
 


### PR DESCRIPTION
As it has been requested in the mailing list, this fix should bring the most important widgets with a default CTOR, so they can be used by qtcreator.

Contains fixes for the last knob patch.

This patch runs fine with valgrind, probably error-free.
