### PR TITLE
RemoteVstPlugin: really close the plugin

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -427,6 +427,7 @@ RemoteVstPlugin::~RemoteVstPlugin()
 		m_window = NULL;
 	}
 	pluginDispatch( effMainsChanged, 0, 0 );
+	pluginDispatch( effClose );
 #ifndef USE_QT_SHMEM
 	// detach shared memory segment
 	if( shmdt( m_vstSyncData ) == -1)


### PR DESCRIPTION
`effClose` is how VST plugins are told to free their memory. (This shouldn't be so big an issue though as we run each plugin in its own process, but there have been reports of RemoteVstPlugin processes not being killed properly.)
