### PR TITLE
Effect: change minimum gate to FLT_MIN

### DIFF
--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -27,6 +27,7 @@
 #include <QtXml/QDomElement>
 
 #include <cstdio>
+#include <cfloat>
 
 #include "Effect.h"
 #include "engine.h"
@@ -135,7 +136,7 @@ void Effect::checkGate( double _out_sum )
 {
 	// Check whether we need to continue processing input.  Restart the
 	// counter if the threshold has been exceeded.
-	if( _out_sum <= gate()+0.000001 )
+	if( _out_sum <= gate() + FLT_MIN )
 	{
 		incrementBufferCount();
 		if( bufferCount() > timeout() )


### PR DESCRIPTION
This helps reverbs (for example) to not get cut too soon (#424)
