### PR TITLE
AFP: Add interpolation selector, fix segfault-causing bug with reverse m...

### DIFF
--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -37,12 +37,16 @@
 #include "lmms_basics.h"
 #include "lmms_math.h"
 #include "shared_object.h"
+#include "Mixer.h"
 
 
 class QPainter;
 
-
-const f_cnt_t MARGIN = 4;
+// values for buffer margins, used for various libsamplerate interpolation modes
+// the array positions correspond to the converter_type parameter values in libsamplerate
+// if there appears problems with playback on some interpolation mode, then the value for that mode
+// may need to be higher - conversely, to optimize, some may work with lower values
+const f_cnt_t MARGIN[] = { 64, 64, 64, 4, 4 };
 
 class EXPORT SampleBuffer : public QObject, public sharedObject
 {
@@ -56,7 +60,7 @@ public:
 	class EXPORT handleState
 	{
 	public:
-		handleState( bool _varying_pitch = false );
+		handleState( bool _varying_pitch = false, int interp_mode = SRC_LINEAR );
 		virtual ~handleState();
 
 		inline const f_cnt_t frameIndex() const
@@ -78,6 +82,11 @@ public:
 		{
 			m_isBackwards = _backwards;
 		}
+		
+		inline int interpMode() const
+		{
+			return m_interpMode;
+		}
 
 
 	private:
@@ -85,6 +94,7 @@ public:
 		const bool m_varyingPitch;
 		bool m_isBackwards;
 		SRC_STATE * m_resamplingData;
+		int m_interpMode;
 
 		friend class SampleBuffer;
 

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -35,7 +35,7 @@
 #include "knob.h"
 #include "pixmap_button.h"
 #include "automatable_button.h"
-
+#include "combobox.h"
 
 
 class audioFileProcessor : public Instrument
@@ -94,6 +94,7 @@ private:
 	BoolModel m_reverseModel;
 	IntModel m_loopModel;
 	BoolModel m_stutterModel;
+	ComboBoxModel m_interpModel;
 
 	f_cnt_t m_nextPlayStartPoint;
 	bool m_nextPlayBackwards;
@@ -141,6 +142,7 @@ private:
 	pixmapButton * m_reverseButton;
 	automatableButtonGroup * m_loopGroup;
 	pixmapButton * m_stutterButton;
+	comboBox * m_interpBox;
 
 } ;
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -24,7 +24,6 @@
 
 
 #include "SampleBuffer.h"
-#include "Mixer.h"
 
 
 #include <QtCore/QBuffer>
@@ -664,7 +663,7 @@ bool SampleBuffer::play( sampleFrame * _ab, handleState * _state,
 	{
 		SRC_DATA src_data;
 		// Generate output
-		f_cnt_t fragment_size = (f_cnt_t)( _frames * freq_factor ) + MARGIN;
+		f_cnt_t fragment_size = (f_cnt_t)( _frames * freq_factor ) + MARGIN[ _state->interpMode() ];
 		src_data.data_in =
 			getSampleFragment( play_frame, fragment_size, _loopmode, &tmp, &is_backwards,
 			loopStartFrame, loopEndFrame, endFrame )[0];
@@ -1439,22 +1438,17 @@ QString SampleBuffer::tryToMakeAbsolute( const QString & _file )
 
 
 
-SampleBuffer::handleState::handleState( bool _varying_pitch ) :
+SampleBuffer::handleState::handleState( bool _varying_pitch, int interp_mode ) :
 	m_frameIndex( 0 ),
 	m_varyingPitch( _varying_pitch ),
 	m_isBackwards( false )
 {
 	int error;
+	m_interpMode = interp_mode;
 	
-	if( ( m_resamplingData = src_new(/*
-		( engine::mixer()->highQuality() == true ) ?
-					SRC_SINC_FASTEST :*/
-					engine::mixer()->currentQualitySettings().
-							libsrcInterpolation(),
-					/*SRC_LINEAR,*/
-					DEFAULT_CHANNELS, &error ) ) == NULL )
+	if( ( m_resamplingData = src_new( interp_mode, DEFAULT_CHANNELS, &error ) ) == NULL )
 	{
-		printf( "Error: src_new() failed in sample_buffer.cpp!\n" );
+		qDebug( "Error: src_new() failed in sample_buffer.cpp!\n" );
 	}
 }
 


### PR DESCRIPTION
...ode

Bug with reverse mode fixed - Closes #620 

The user can now choose from three interpolation modes: none (zero-order hold), linear and sinc (uses medium-quality always). I included none because the lo-fi sound may be desirable in some cases (eg. chiptunes and similar retro stuff). This also provides us with the groundwork and UI architecture to add pitch-shifting sample playback mode (using librubberband or similar) in the future if we so wish.
