### PR TITLE
InstrumentTrack: fix FX channel range

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -703,7 +703,7 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 	m_panningModel.loadSettings( thisElement, "pan" );
 	m_pitchRangeModel.loadSettings( thisElement, "pitchrange" );
 	m_pitchModel.loadSettings( thisElement, "pitch" );
-	m_effectChannelModel.setRange( 0, INT_MAX );
+	m_effectChannelModel.setRange( 0, engine::fxMixer()->numChannels()-1 );
 	m_effectChannelModel.loadSettings( thisElement, "fxch" );
 	m_baseNoteModel.loadSettings( thisElement, "basenote" );
 


### PR DESCRIPTION
Because it is set to INT_MAX by default and never corrected for
cloned instruments, it could go over the maximum and cause a
segmentation fault.

(Second try.)
