### PR TITLE
FXLine: add context menu with options to remove, move & rename FX channe...

### DIFF
--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef _FX_LINE_H
-#define _FX_LINE_H
+#ifndef FX_LINE_H
+#define FX_LINE_H
 
 #include <QWidget>
 #include <QLabel>
@@ -46,6 +46,7 @@ public:
 	virtual void paintEvent( QPaintEvent * );
 	virtual void mousePressEvent( QMouseEvent * );
 	virtual void mouseDoubleClickEvent( QMouseEvent * );
+	virtual void contextMenuEvent( QContextMenuEvent * );
 
 	inline int channelIndex() { return m_channelIndex; }
 	void setChannelIndex(int index);
@@ -56,11 +57,16 @@ public:
 private:
 	FxMixerView * m_mv;
 	LcdWidget* m_lcd;
-
-
 	int m_channelIndex;
 
-} ;
+private slots:
+	void renameChannel();
+	void removeChannel();
+	void moveChannelLeft();
+	void moveChannelRight();
+	void displayHelp();
+
+};
 
 
 #endif // FXLINE_H

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -29,9 +29,9 @@
 #include <stdint.h>
 #include "lmms_constants.h"
 
-#ifdef __INTEL_COMPILER
-
 #include <math.h>
+
+#ifdef __INTEL_COMPILER
 
 static inline float absFraction( const float _x )
 {


### PR DESCRIPTION
...ls
- Uses existing functionality in FxMixer & FxMixerView to manipulate channels
- Instruments sending to the manipulated channels get automatically updated
- In the future I hope to implement a drag/drop functionality instead of the clunky context menu but this is a good first step until then
- Also added in a little QWhatsThis help message for the FX line, also accessible from context menu

That lmms_math thing got mixed in accidentally, but it's also a good change: always include math.h in lmms_math - that way, other parts of the software can just #include lmms_math, and won't have to #include both math.h and lmms_math, also the yet unused sinc function in it seems to need it so this prevents problems down the line
