### PR TITLE
PianoRoll: improvements for note/panning widget

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -28,13 +28,14 @@
 #define PIANO_ROLL_H
 
 #include <QtGui/QWidget>
+#include <QtGui/QInputDialog>
 
 #include "ComboBoxModel.h"
 #include "SerializingObject.h"
 #include "note.h"
 #include "lmms_basics.h"
 #include "song.h"
-
+#include "tooltip.h"
 
 class QPainter;
 class QPixmap;
@@ -111,6 +112,8 @@ protected:
 	void selectAll();
 	void getSelectedNotes( NoteVector & _selected_notes );
 
+	// for entering values with dblclick in the vol/pan bars
+	void enterValue( note* n );
 
 protected slots:
 	void play();
@@ -144,7 +147,6 @@ protected slots:
 
 	void changeNoteEditMode( int i );
 	void markSemiTone( int i );
-
 
 signals:
 	void currentPatternChanged();
@@ -241,6 +243,7 @@ private:
 
 	static PianoRollKeyTypes prKeyOrder[];
 
+	static textFloat * s_textFloat;
 
 	QWidget * m_toolBar;
 


### PR DESCRIPTION
In short: make the volume/panning bars behave a bit more like knobs.
- Show the current value (volume/panning) as a textfloat when changing volume or panning
- Allow modifying the value with mouse wheel 
- Allow resetting to default (100% for volume, center for panning) with a middle-click
- Allow double-clicking to enter a value in text

There was some earlier functionality that had to be scrapped to implement the doubleclick functionality: doubleclicking the bar area used to clear the selection, but there are other ways to do that and I don't think it was that useful... but if it's needed, we could put it back so that it only happens when we're not near a note.
