### PR TITLE
add lib64 directories to search for ladspa plugins

### DIFF
--- a/src/core/ladspa_manager.cpp
+++ b/src/core/ladspa_manager.cpp
@@ -46,10 +46,11 @@ ladspaManager::ladspaManager()
 	ladspaDirectories.push_back( configManager::inst()->pluginDir() + "ladspa" );
 #ifndef LMMS_BUILD_WIN32
 	ladspaDirectories.push_back( qApp->applicationDirPath() + '/' + LIB_DIR + "ladspa" );
-	ladspaDirectories.push_back( "/usr/lib/lmms/ladspa" );
-	ladspaDirectories.push_back( "/usr/local/lib/lmms/ladspa" );
 	ladspaDirectories.push_back( "/usr/lib/ladspa" );
+	ladspaDirectories.push_back( "/usr/lib64/ladspa" );
 	ladspaDirectories.push_back( "/usr/local/lib/ladspa" );
+	ladspaDirectories.push_back( "/usr/local/lib64/ladspa" );
+	ladspaDirectories.push_back( "/Library/Audio/Plug-Ins/LADSPA" );
 #endif
 
 	for( QStringList::iterator it = ladspaDirectories.begin(); 


### PR DESCRIPTION
Under fedora, ladspa plugins are installed in _/lib64/_
