### PR TITLE
swh plugins:  Fix SWH destructors

### DIFF
--- a/plugins/LadspaEffect/swh/alias_1407.c
+++ b/plugins/LadspaEffect/swh/alias_1407.c
@@ -240,7 +240,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (aliasDescriptor) {
 		free((LADSPA_PortDescriptor *)aliasDescriptor->PortDescriptors);
 		free((char **)aliasDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/allpass_1895.c
+++ b/plugins/LadspaEffect/swh/allpass_1895.c
@@ -1346,7 +1346,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (allpass_nDescriptor) {
 		free((LADSPA_PortDescriptor *)allpass_nDescriptor->PortDescriptors);
 		free((char **)allpass_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/am_pitchshift_1433.c
+++ b/plugins/LadspaEffect/swh/am_pitchshift_1433.c
@@ -455,7 +455,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (amPitchshiftDescriptor) {
 		free((LADSPA_PortDescriptor *)amPitchshiftDescriptor->PortDescriptors);
 		free((char **)amPitchshiftDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/amp_1181.c
+++ b/plugins/LadspaEffect/swh/amp_1181.c
@@ -233,7 +233,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (ampDescriptor) {
 		free((LADSPA_PortDescriptor *)ampDescriptor->PortDescriptors);
 		free((char **)ampDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bandpass_a_iir_1893.c
+++ b/plugins/LadspaEffect/swh/bandpass_a_iir_1893.c
@@ -277,7 +277,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (bandpass_a_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bandpass_a_iirDescriptor->PortDescriptors);
 		free((char **)bandpass_a_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bandpass_iir_1892.c
+++ b/plugins/LadspaEffect/swh/bandpass_iir_1892.c
@@ -343,7 +343,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (bandpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bandpass_iirDescriptor->PortDescriptors);
 		free((char **)bandpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bode_shifter_1431.c
+++ b/plugins/LadspaEffect/swh/bode_shifter_1431.c
@@ -458,7 +458,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (bodeShifterDescriptor) {
 		free((LADSPA_PortDescriptor *)bodeShifterDescriptor->PortDescriptors);
 		free((char **)bodeShifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bode_shifter_cv_1432.c
+++ b/plugins/LadspaEffect/swh/bode_shifter_cv_1432.c
@@ -523,7 +523,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (bodeShifterCVDescriptor) {
 		free((LADSPA_PortDescriptor *)bodeShifterCVDescriptor->PortDescriptors);
 		free((char **)bodeShifterCVDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/butterworth_1902.c
+++ b/plugins/LadspaEffect/swh/butterworth_1902.c
@@ -741,7 +741,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (bwxover_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bwxover_iirDescriptor->PortDescriptors);
 		free((char **)bwxover_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/chebstortion_1430.c
+++ b/plugins/LadspaEffect/swh/chebstortion_1430.c
@@ -399,7 +399,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (chebstortionDescriptor) {
 		free((LADSPA_PortDescriptor *)chebstortionDescriptor->PortDescriptors);
 		free((char **)chebstortionDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_1190.c
+++ b/plugins/LadspaEffect/swh/comb_1190.c
@@ -340,7 +340,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (combDescriptor) {
 		free((LADSPA_PortDescriptor *)combDescriptor->PortDescriptors);
 		free((char **)combDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_1887.c
+++ b/plugins/LadspaEffect/swh/comb_1887.c
@@ -1352,7 +1352,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (comb_nDescriptor) {
 		free((LADSPA_PortDescriptor *)comb_nDescriptor->PortDescriptors);
 		free((char **)comb_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_splitter_1411.c
+++ b/plugins/LadspaEffect/swh/comb_splitter_1411.c
@@ -341,7 +341,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (combSplitterDescriptor) {
 		free((LADSPA_PortDescriptor *)combSplitterDescriptor->PortDescriptors);
 		free((char **)combSplitterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/const_1909.c
+++ b/plugins/LadspaEffect/swh/const_1909.c
@@ -250,7 +250,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (constDescriptor) {
 		free((LADSPA_PortDescriptor *)constDescriptor->PortDescriptors);
 		free((char **)constDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/crossover_dist_1404.c
+++ b/plugins/LadspaEffect/swh/crossover_dist_1404.c
@@ -276,7 +276,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (crossoverDistDescriptor) {
 		free((LADSPA_PortDescriptor *)crossoverDistDescriptor->PortDescriptors);
 		free((char **)crossoverDistDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dc_remove_1207.c
+++ b/plugins/LadspaEffect/swh/dc_remove_1207.c
@@ -235,7 +235,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (dcRemoveDescriptor) {
 		free((LADSPA_PortDescriptor *)dcRemoveDescriptor->PortDescriptors);
 		free((char **)dcRemoveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/decay_1886.c
+++ b/plugins/LadspaEffect/swh/decay_1886.c
@@ -325,7 +325,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (decayDescriptor) {
 		free((LADSPA_PortDescriptor *)decayDescriptor->PortDescriptors);
 		free((char **)decayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/decimator_1202.c
+++ b/plugins/LadspaEffect/swh/decimator_1202.c
@@ -335,7 +335,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (decimatorDescriptor) {
 		free((LADSPA_PortDescriptor *)decimatorDescriptor->PortDescriptors);
 		free((char **)decimatorDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/declip_1195.c
+++ b/plugins/LadspaEffect/swh/declip_1195.c
@@ -235,7 +235,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (declipDescriptor) {
 		free((LADSPA_PortDescriptor *)declipDescriptor->PortDescriptors);
 		free((char **)declipDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/delay_1898.c
+++ b/plugins/LadspaEffect/swh/delay_1898.c
@@ -1093,7 +1093,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (delay_nDescriptor) {
 		free((LADSPA_PortDescriptor *)delay_nDescriptor->PortDescriptors);
 		free((char **)delay_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/delayorama_1402.c
+++ b/plugins/LadspaEffect/swh/delayorama_1402.c
@@ -847,7 +847,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (delayoramaDescriptor) {
 		free((LADSPA_PortDescriptor *)delayoramaDescriptor->PortDescriptors);
 		free((char **)delayoramaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/diode_1185.c
+++ b/plugins/LadspaEffect/swh/diode_1185.c
@@ -264,7 +264,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (diodeDescriptor) {
 		free((LADSPA_PortDescriptor *)diodeDescriptor->PortDescriptors);
 		free((char **)diodeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/divider_1186.c
+++ b/plugins/LadspaEffect/swh/divider_1186.c
@@ -331,7 +331,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (dividerDescriptor) {
 		free((LADSPA_PortDescriptor *)dividerDescriptor->PortDescriptors);
 		free((char **)dividerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dj_eq_1901.c
+++ b/plugins/LadspaEffect/swh/dj_eq_1901.c
@@ -674,7 +674,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (dj_eq_monoDescriptor) {
 		free((LADSPA_PortDescriptor *)dj_eq_monoDescriptor->PortDescriptors);
 		free((char **)dj_eq_monoDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dj_flanger_1438.c
+++ b/plugins/LadspaEffect/swh/dj_flanger_1438.c
@@ -472,7 +472,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (djFlangerDescriptor) {
 		free((LADSPA_PortDescriptor *)djFlangerDescriptor->PortDescriptors);
 		free((char **)djFlangerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dyson_compress_1403.c
+++ b/plugins/LadspaEffect/swh/dyson_compress_1403.c
@@ -885,7 +885,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (dysonCompressDescriptor) {
 		free((LADSPA_PortDescriptor *)dysonCompressDescriptor->PortDescriptors);
 		free((char **)dysonCompressDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/fad_delay_1192.c
+++ b/plugins/LadspaEffect/swh/fad_delay_1192.c
@@ -388,7 +388,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (fadDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)fadDelayDescriptor->PortDescriptors);
 		free((char **)fadDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/fast_lookahead_limiter_1913.c
+++ b/plugins/LadspaEffect/swh/fast_lookahead_limiter_1913.c
@@ -703,7 +703,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (fastLookaheadLimiterDescriptor) {
 		free((LADSPA_PortDescriptor *)fastLookaheadLimiterDescriptor->PortDescriptors);
 		free((char **)fastLookaheadLimiterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/flanger_1191.c
+++ b/plugins/LadspaEffect/swh/flanger_1191.c
@@ -544,7 +544,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (flangerDescriptor) {
 		free((LADSPA_PortDescriptor *)flangerDescriptor->PortDescriptors);
 		free((char **)flangerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/foldover_1213.c
+++ b/plugins/LadspaEffect/swh/foldover_1213.c
@@ -255,7 +255,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (foldoverDescriptor) {
 		free((LADSPA_PortDescriptor *)foldoverDescriptor->PortDescriptors);
 		free((char **)foldoverDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/foverdrive_1196.c
+++ b/plugins/LadspaEffect/swh/foverdrive_1196.c
@@ -234,7 +234,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (foverdriveDescriptor) {
 		free((LADSPA_PortDescriptor *)foverdriveDescriptor->PortDescriptors);
 		free((char **)foverdriveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/freq_tracker_1418.c
+++ b/plugins/LadspaEffect/swh/freq_tracker_1418.c
@@ -319,7 +319,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (freqTrackerDescriptor) {
 		free((LADSPA_PortDescriptor *)freqTrackerDescriptor->PortDescriptors);
 		free((char **)freqTrackerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gate_1410.c
+++ b/plugins/LadspaEffect/swh/gate_1410.c
@@ -582,7 +582,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (gateDescriptor) {
 		free((LADSPA_PortDescriptor *)gateDescriptor->PortDescriptors);
 		free((char **)gateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/giant_flange_1437.c
+++ b/plugins/LadspaEffect/swh/giant_flange_1437.c
@@ -637,7 +637,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (giantFlangeDescriptor) {
 		free((LADSPA_PortDescriptor *)giantFlangeDescriptor->PortDescriptors);
 		free((char **)giantFlangeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gong_1424.c
+++ b/plugins/LadspaEffect/swh/gong_1424.c
@@ -947,7 +947,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (gongDescriptor) {
 		free((LADSPA_PortDescriptor *)gongDescriptor->PortDescriptors);
 		free((char **)gongDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gong_beater_1439.c
+++ b/plugins/LadspaEffect/swh/gong_beater_1439.c
@@ -400,7 +400,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (gongBeaterDescriptor) {
 		free((LADSPA_PortDescriptor *)gongBeaterDescriptor->PortDescriptors);
 		free((char **)gongBeaterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gsm_1215.c
+++ b/plugins/LadspaEffect/swh/gsm_1215.c
@@ -493,7 +493,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (gsmDescriptor) {
 		free((LADSPA_PortDescriptor *)gsmDescriptor->PortDescriptors);
 		free((char **)gsmDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gverb_1216.c
+++ b/plugins/LadspaEffect/swh/gverb_1216.c
@@ -429,7 +429,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (gverbDescriptor) {
 		free((LADSPA_PortDescriptor *)gverbDescriptor->PortDescriptors);
 		free((char **)gverbDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hard_limiter_1413.c
+++ b/plugins/LadspaEffect/swh/hard_limiter_1413.c
@@ -286,7 +286,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (hardLimiterDescriptor) {
 		free((LADSPA_PortDescriptor *)hardLimiterDescriptor->PortDescriptors);
 		free((char **)hardLimiterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/harmonic_gen_1220.c
+++ b/plugins/LadspaEffect/swh/harmonic_gen_1220.c
@@ -542,7 +542,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (harmonicGenDescriptor) {
 		free((LADSPA_PortDescriptor *)harmonicGenDescriptor->PortDescriptors);
 		free((char **)harmonicGenDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hermes_filter_1200.c
+++ b/plugins/LadspaEffect/swh/hermes_filter_1200.c
@@ -1998,7 +1998,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (hermesFilterDescriptor) {
 		free((LADSPA_PortDescriptor *)hermesFilterDescriptor->PortDescriptors);
 		free((char **)hermesFilterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/highpass_iir_1890.c
+++ b/plugins/LadspaEffect/swh/highpass_iir_1890.c
@@ -278,7 +278,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (highpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)highpass_iirDescriptor->PortDescriptors);
 		free((char **)highpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hilbert_1440.c
+++ b/plugins/LadspaEffect/swh/hilbert_1440.c
@@ -316,7 +316,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (hilbertDescriptor) {
 		free((LADSPA_PortDescriptor *)hilbertDescriptor->PortDescriptors);
 		free((char **)hilbertDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/imp_1199.c
+++ b/plugins/LadspaEffect/swh/imp_1199.c
@@ -628,7 +628,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (impDescriptor) {
 		free((LADSPA_PortDescriptor *)impDescriptor->PortDescriptors);
 		free((char **)impDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/impulse_1885.c
+++ b/plugins/LadspaEffect/swh/impulse_1885.c
@@ -257,7 +257,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (impulse_fcDescriptor) {
 		free((LADSPA_PortDescriptor *)impulse_fcDescriptor->PortDescriptors);
 		free((char **)impulse_fcDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/inv_1429.c
+++ b/plugins/LadspaEffect/swh/inv_1429.c
@@ -207,7 +207,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (invDescriptor) {
 		free((LADSPA_PortDescriptor *)invDescriptor->PortDescriptors);
 		free((char **)invDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/karaoke_1409.c
+++ b/plugins/LadspaEffect/swh/karaoke_1409.c
@@ -274,7 +274,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (karaokeDescriptor) {
 		free((LADSPA_PortDescriptor *)karaokeDescriptor->PortDescriptors);
 		free((char **)karaokeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/latency_1914.c
+++ b/plugins/LadspaEffect/swh/latency_1914.c
@@ -259,7 +259,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (artificialLatencyDescriptor) {
 		free((LADSPA_PortDescriptor *)artificialLatencyDescriptor->PortDescriptors);
 		free((char **)artificialLatencyDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/lcr_delay_1436.c
+++ b/plugins/LadspaEffect/swh/lcr_delay_1436.c
@@ -733,7 +733,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (lcrDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)lcrDelayDescriptor->PortDescriptors);
 		free((char **)lcrDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/lowpass_iir_1891.c
+++ b/plugins/LadspaEffect/swh/lowpass_iir_1891.c
@@ -280,7 +280,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (lowpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)lowpass_iirDescriptor->PortDescriptors);
 		free((char **)lowpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/ls_filter_1908.c
+++ b/plugins/LadspaEffect/swh/ls_filter_1908.c
@@ -308,7 +308,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (lsFilterDescriptor) {
 		free((LADSPA_PortDescriptor *)lsFilterDescriptor->PortDescriptors);
 		free((char **)lsFilterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_ms_st_1421.c
+++ b/plugins/LadspaEffect/swh/matrix_ms_st_1421.c
@@ -266,7 +266,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (matrixMSStDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixMSStDescriptor->PortDescriptors);
 		free((char **)matrixMSStDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_spatialiser_1422.c
+++ b/plugins/LadspaEffect/swh/matrix_spatialiser_1422.c
@@ -424,7 +424,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (matrixSpatialiserDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixSpatialiserDescriptor->PortDescriptors);
 		free((char **)matrixSpatialiserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_st_ms_1420.c
+++ b/plugins/LadspaEffect/swh/matrix_st_ms_1420.c
@@ -245,7 +245,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (matrixStMSDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixStMSDescriptor->PortDescriptors);
 		free((char **)matrixStMSDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/mbeq_1197.c
+++ b/plugins/LadspaEffect/swh/mbeq_1197.c
@@ -885,7 +885,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (mbeqDescriptor) {
 		free((LADSPA_PortDescriptor *)mbeqDescriptor->PortDescriptors);
 		free((char **)mbeqDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/mod_delay_1419.c
+++ b/plugins/LadspaEffect/swh/mod_delay_1419.c
@@ -318,7 +318,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (modDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)modDelayDescriptor->PortDescriptors);
 		free((char **)modDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/multivoice_chorus_1201.c
+++ b/plugins/LadspaEffect/swh/multivoice_chorus_1201.c
@@ -656,7 +656,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (multivoiceChorusDescriptor) {
 		free((LADSPA_PortDescriptor *)multivoiceChorusDescriptor->PortDescriptors);
 		free((char **)multivoiceChorusDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/notch_iir_1894.c
+++ b/plugins/LadspaEffect/swh/notch_iir_1894.c
@@ -343,7 +343,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (notch_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)notch_iirDescriptor->PortDescriptors);
 		free((char **)notch_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/phasers_1217.c
+++ b/plugins/LadspaEffect/swh/phasers_1217.c
@@ -1377,7 +1377,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (lfoPhaserDescriptor) {
 		free((LADSPA_PortDescriptor *)lfoPhaserDescriptor->PortDescriptors);
 		free((char **)lfoPhaserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pitch_scale_1193.c
+++ b/plugins/LadspaEffect/swh/pitch_scale_1193.c
@@ -327,7 +327,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (pitchScaleDescriptor) {
 		free((LADSPA_PortDescriptor *)pitchScaleDescriptor->PortDescriptors);
 		free((char **)pitchScaleDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pitch_scale_1194.c
+++ b/plugins/LadspaEffect/swh/pitch_scale_1194.c
@@ -311,7 +311,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (pitchScaleHQDescriptor) {
 		free((LADSPA_PortDescriptor *)pitchScaleHQDescriptor->PortDescriptors);
 		free((char **)pitchScaleHQDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/plate_1423.c
+++ b/plugins/LadspaEffect/swh/plate_1423.c
@@ -401,7 +401,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (plateDescriptor) {
 		free((LADSPA_PortDescriptor *)plateDescriptor->PortDescriptors);
 		free((char **)plateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pointer_cast_1910.c
+++ b/plugins/LadspaEffect/swh/pointer_cast_1910.c
@@ -310,7 +310,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (pointerCastDistortionDescriptor) {
 		free((LADSPA_PortDescriptor *)pointerCastDistortionDescriptor->PortDescriptors);
 		free((char **)pointerCastDistortionDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/rate_shifter_1417.c
+++ b/plugins/LadspaEffect/swh/rate_shifter_1417.c
@@ -314,7 +314,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (rateShifterDescriptor) {
 		free((LADSPA_PortDescriptor *)rateShifterDescriptor->PortDescriptors);
 		free((char **)rateShifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/retro_flange_1208.c
+++ b/plugins/LadspaEffect/swh/retro_flange_1208.c
@@ -581,7 +581,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (retroFlangeDescriptor) {
 		free((LADSPA_PortDescriptor *)retroFlangeDescriptor->PortDescriptors);
 		free((char **)retroFlangeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/revdelay_1605.c
+++ b/plugins/LadspaEffect/swh/revdelay_1605.c
@@ -540,7 +540,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (revdelayDescriptor) {
 		free((LADSPA_PortDescriptor *)revdelayDescriptor->PortDescriptors);
 		free((char **)revdelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/ringmod_1188.c
+++ b/plugins/LadspaEffect/swh/ringmod_1188.c
@@ -632,7 +632,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (ringmod_2i1oDescriptor) {
 		free((LADSPA_PortDescriptor *)ringmod_2i1oDescriptor->PortDescriptors);
 		free((char **)ringmod_2i1oDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/satan_maximiser_1408.c
+++ b/plugins/LadspaEffect/swh/satan_maximiser_1408.c
@@ -344,7 +344,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (satanMaximiserDescriptor) {
 		free((LADSPA_PortDescriptor *)satanMaximiserDescriptor->PortDescriptors);
 		free((char **)satanMaximiserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc1_1425.c
+++ b/plugins/LadspaEffect/swh/sc1_1425.c
@@ -473,7 +473,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sc1Descriptor) {
 		free((LADSPA_PortDescriptor *)sc1Descriptor->PortDescriptors);
 		free((char **)sc1Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc2_1426.c
+++ b/plugins/LadspaEffect/swh/sc2_1426.c
@@ -491,7 +491,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sc2Descriptor) {
 		free((LADSPA_PortDescriptor *)sc2Descriptor->PortDescriptors);
 		free((char **)sc2Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc3_1427.c
+++ b/plugins/LadspaEffect/swh/sc3_1427.c
@@ -562,7 +562,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sc3Descriptor) {
 		free((LADSPA_PortDescriptor *)sc3Descriptor->PortDescriptors);
 		free((char **)sc3Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc4_1882.c
+++ b/plugins/LadspaEffect/swh/sc4_1882.c
@@ -618,7 +618,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sc4Descriptor) {
 		free((LADSPA_PortDescriptor *)sc4Descriptor->PortDescriptors);
 		free((char **)sc4Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc4m_1916.c
+++ b/plugins/LadspaEffect/swh/sc4m_1916.c
@@ -568,7 +568,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sc4mDescriptor) {
 		free((LADSPA_PortDescriptor *)sc4mDescriptor->PortDescriptors);
 		free((char **)sc4mDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/se4_1883.c
+++ b/plugins/LadspaEffect/swh/se4_1883.c
@@ -614,7 +614,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (se4Descriptor) {
 		free((LADSPA_PortDescriptor *)se4Descriptor->PortDescriptors);
 		free((char **)se4Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/shaper_1187.c
+++ b/plugins/LadspaEffect/swh/shaper_1187.c
@@ -260,7 +260,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (shaperDescriptor) {
 		free((LADSPA_PortDescriptor *)shaperDescriptor->PortDescriptors);
 		free((char **)shaperDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sifter_1210.c
+++ b/plugins/LadspaEffect/swh/sifter_1210.c
@@ -438,7 +438,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sifterDescriptor) {
 		free((LADSPA_PortDescriptor *)sifterDescriptor->PortDescriptors);
 		free((char **)sifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sin_cos_1881.c
+++ b/plugins/LadspaEffect/swh/sin_cos_1881.c
@@ -296,7 +296,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sinCosDescriptor) {
 		free((LADSPA_PortDescriptor *)sinCosDescriptor->PortDescriptors);
 		free((char **)sinCosDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/single_para_1203.c
+++ b/plugins/LadspaEffect/swh/single_para_1203.c
@@ -312,7 +312,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (singleParaDescriptor) {
 		free((LADSPA_PortDescriptor *)singleParaDescriptor->PortDescriptors);
 		free((char **)singleParaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sinus_wavewrapper_1198.c
+++ b/plugins/LadspaEffect/swh/sinus_wavewrapper_1198.c
@@ -244,7 +244,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (sinusWavewrapperDescriptor) {
 		free((LADSPA_PortDescriptor *)sinusWavewrapperDescriptor->PortDescriptors);
 		free((char **)sinusWavewrapperDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/smooth_decimate_1414.c
+++ b/plugins/LadspaEffect/swh/smooth_decimate_1414.c
@@ -329,7 +329,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (smoothDecimateDescriptor) {
 		free((LADSPA_PortDescriptor *)smoothDecimateDescriptor->PortDescriptors);
 		free((char **)smoothDecimateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/split_1406.c
+++ b/plugins/LadspaEffect/swh/split_1406.c
@@ -240,7 +240,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (splitDescriptor) {
 		free((LADSPA_PortDescriptor *)splitDescriptor->PortDescriptors);
 		free((char **)splitDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/step_muxer_1212.c
+++ b/plugins/LadspaEffect/swh/step_muxer_1212.c
@@ -532,7 +532,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (stepMuxerDescriptor) {
 		free((LADSPA_PortDescriptor *)stepMuxerDescriptor->PortDescriptors);
 		free((char **)stepMuxerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/surround_encoder_1401.c
+++ b/plugins/LadspaEffect/swh/surround_encoder_1401.c
@@ -414,7 +414,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (surroundEncoderDescriptor) {
 		free((LADSPA_PortDescriptor *)surroundEncoderDescriptor->PortDescriptors);
 		free((char **)surroundEncoderDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/svf_1214.c
+++ b/plugins/LadspaEffect/swh/svf_1214.c
@@ -408,7 +408,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (svfDescriptor) {
 		free((LADSPA_PortDescriptor *)svfDescriptor->PortDescriptors);
 		free((char **)svfDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/tape_delay_1211.c
+++ b/plugins/LadspaEffect/swh/tape_delay_1211.c
@@ -645,7 +645,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (tapeDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)tapeDelayDescriptor->PortDescriptors);
 		free((char **)tapeDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/transient_1206.c
+++ b/plugins/LadspaEffect/swh/transient_1206.c
@@ -465,7 +465,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (transientDescriptor) {
 		free((LADSPA_PortDescriptor *)transientDescriptor->PortDescriptors);
 		free((char **)transientDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/triple_para_1204.c
+++ b/plugins/LadspaEffect/swh/triple_para_1204.c
@@ -593,7 +593,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (tripleParaDescriptor) {
 		free((LADSPA_PortDescriptor *)tripleParaDescriptor->PortDescriptors);
 		free((char **)tripleParaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/valve_1209.c
+++ b/plugins/LadspaEffect/swh/valve_1209.c
@@ -332,7 +332,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (valveDescriptor) {
 		free((LADSPA_PortDescriptor *)valveDescriptor->PortDescriptors);
 		free((char **)valveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/valve_rect_1405.c
+++ b/plugins/LadspaEffect/swh/valve_rect_1405.c
@@ -401,7 +401,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (valveRectDescriptor) {
 		free((LADSPA_PortDescriptor *)valveRectDescriptor->PortDescriptors);
 		free((char **)valveRectDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/vocoder_1337.c
+++ b/plugins/LadspaEffect/swh/vocoder_1337.c
@@ -420,9 +420,9 @@ void __attribute__((constructor)) swh_init() {
 
 /*****************************************************************************/
 
-/* _fini() is called automatically when the library is unloaded. */
+/*  __attribute__((destructor)) swh_fini() is called automatically when the library is unloaded. */
 void 
-_fini() {
+ __attribute__((destructor)) swh_fini() {
   long lIndex;
   if (g_psDescriptor) {
     free((char *)g_psDescriptor->Label);

--- a/plugins/LadspaEffect/swh/vynil_1905.c
+++ b/plugins/LadspaEffect/swh/vynil_1905.c
@@ -712,7 +712,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (vynilDescriptor) {
 		free((LADSPA_PortDescriptor *)vynilDescriptor->PortDescriptors);
 		free((char **)vynilDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/wave_terrain_1412.c
+++ b/plugins/LadspaEffect/swh/wave_terrain_1412.c
@@ -231,7 +231,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (waveTerrainDescriptor) {
 		free((LADSPA_PortDescriptor *)waveTerrainDescriptor->PortDescriptors);
 		free((char **)waveTerrainDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/xfade_1915.c
+++ b/plugins/LadspaEffect/swh/xfade_1915.c
@@ -598,7 +598,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (xfadeDescriptor) {
 		free((LADSPA_PortDescriptor *)xfadeDescriptor->PortDescriptors);
 		free((char **)xfadeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/zm1_1428.c
+++ b/plugins/LadspaEffect/swh/zm1_1428.c
@@ -232,7 +232,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void _fini() {
+void  __attribute__((destructor)) swh_fini() {
 	if (zm1Descriptor) {
 		free((LADSPA_PortDescriptor *)zm1Descriptor->PortDescriptors);
 		free((char **)zm1Descriptor->PortNames);


### PR DESCRIPTION
The constructors had been fixed with commit #83c2019, but I had missed
the destructors.  This corrects the `_fini()` destructors as well.
