### PR TITLE
Knob: make knob line/arc colours CSS-stylable

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -510,6 +510,23 @@ bbTCOView {
 	qproperty-textColor: rgb( 255, 255, 255 );
 }
 
+
+/* Knobs */
+
+knob {
+	qproperty-knobDark_28_lineColor: #f0f0f0;
+	qproperty-knobDark_28_arcColor: #f0f0f0;
+	qproperty-knobBright_26_lineColor: #f0f0f0;
+	qproperty-knobBright_26_arcColor: #f0f0f0;
+	qproperty-knobSmall_17_lineColor: #f0f0f0;
+	qproperty-knobSmall_17_arcColor: #f0f0f0;
+    qproperty-knobGreen_17_lineColor: #4afd85;
+    qproperty-knobGreen_17_arcColor: #4afd85;
+    qproperty-knobVintage_32_lineColor: #000;
+    qproperty-knobVintage_32_arcColor: #f0f0f0;
+}
+
+
 /* Plugins */
 
 TripleOscillatorView knob {

--- a/include/knob.h
+++ b/include/knob.h
@@ -41,7 +41,15 @@ enum knobTypes
 	knobDark_28, knobBright_26, knobSmall_17, knobGreen_17, knobVintage_32, knobStyled
 } ;
 
-
+#define KNOBTYPE_PROPERTIES_PUBLIC( knobtype ) \
+	QColor knobtype##_lineColor() const; \
+	QColor knobtype##_arcColor() const; \
+	void knobtype##_setLineColor( const QColor & c ); \
+	void knobtype##_setArcColor( const QColor & c ); 
+	
+#define KNOBTYPE_PROPERTIES_PRIVATE( knobtype ) \
+	QColor m_##knobtype##_lineColor; \
+	QColor m_##knobtype##_arcColor; 
 
 class EXPORT knob : public QWidget, public FloatModelView
 {
@@ -59,12 +67,32 @@ class EXPORT knob : public QWidget, public FloatModelView
 	// Unfortunately, the gradient syntax doesn't create our gradient
 	// correctly so we need to do this:
 	Q_PROPERTY(QColor outerColor READ outerColor WRITE setOuterColor)
-	Q_PROPERTY(QColor lineColor READ lineColor WRITE setlineColor)
-	Q_PROPERTY(QColor arcColor READ arcColor WRITE setarcColor)
+
+	// Even more Unfortunately, the CSS syntax by setting properties by another property just doesn't work,
+	// no matter what I do, so the only thing I can do is create separate properties for line/arc of
+	// each nonstyled knobtype
+	Q_PROPERTY( QColor knobDark_28_lineColor READ knobDark_28_lineColor WRITE knobDark_28_setLineColor )
+	Q_PROPERTY( QColor knobDark_28_arcColor READ knobDark_28_arcColor WRITE knobDark_28_setArcColor )
+	Q_PROPERTY( QColor knobBright_26_lineColor READ knobBright_26_lineColor WRITE knobBright_26_setLineColor )
+	Q_PROPERTY( QColor knobBright_26_arcColor READ knobBright_26_arcColor WRITE knobBright_26_setArcColor )
+	Q_PROPERTY( QColor knobSmall_17_lineColor READ knobSmall_17_lineColor WRITE knobSmall_17_setLineColor )
+	Q_PROPERTY( QColor knobSmall_17_arcColor READ knobSmall_17_arcColor WRITE knobSmall_17_setArcColor )
+	Q_PROPERTY( QColor knobGreen_17_lineColor READ knobGreen_17_lineColor WRITE knobGreen_17_setLineColor )
+	Q_PROPERTY( QColor knobGreen_17_arcColor READ knobGreen_17_arcColor WRITE knobGreen_17_setArcColor )
+	Q_PROPERTY( QColor knobVintage_32_lineColor READ knobVintage_32_lineColor WRITE knobVintage_32_setLineColor )
+	Q_PROPERTY( QColor knobVintage_32_arcColor READ knobVintage_32_arcColor WRITE knobVintage_32_setArcColor )
+	
+	KNOBTYPE_PROPERTIES_PUBLIC( knobDark_28 )
+	KNOBTYPE_PROPERTIES_PUBLIC( knobBright_26 )
+	KNOBTYPE_PROPERTIES_PUBLIC( knobSmall_17 )
+	KNOBTYPE_PROPERTIES_PUBLIC( knobGreen_17 )
+	KNOBTYPE_PROPERTIES_PUBLIC( knobVintage_32 )
+
+
 	mapPropertyFromModel(bool,isVolumeKnob,setVolumeKnob,m_volumeKnob);
 	mapPropertyFromModel(float,volumeRatio,setVolumeRatio,m_volumeRatio);
 
-	Q_PROPERTY(knobTypes knobNum READ knobNum WRITE setknobNum)
+	Q_PROPERTY(knobTypes knobNum READ knobNum WRITE setKnobNum)
 
 	void initUi( const QString & _name ); //!< to be called by ctors
 	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum
@@ -93,8 +121,8 @@ public:
 	void setOuterRadius( float _r );
 
 	knobTypes knobNum() const;
-	void setknobNum( knobTypes _k );
-
+	void setKnobNum( knobTypes k );
+	
 	QPointF centerPoint() const;
 	float centerPointX() const;
 	void setCenterPointX( float _c );
@@ -106,10 +134,9 @@ public:
 
 	QColor outerColor() const;
 	void setOuterColor( const QColor & _c );
+	
 	QColor lineColor() const;
-	void setlineColor( const QColor & _c );
 	QColor arcColor() const;
-	void setarcColor( const QColor & _c );
 
 
 signals:
@@ -184,8 +211,11 @@ private:
 	float m_outerRadius;
 	float m_lineWidth;
 	QColor m_outerColor;
-	QColor m_lineColor; //!< unused yet
-	QColor m_arcColor; //!< unused yet
+	KNOBTYPE_PROPERTIES_PRIVATE( knobDark_28 )
+	KNOBTYPE_PROPERTIES_PRIVATE( knobBright_26 )
+	KNOBTYPE_PROPERTIES_PRIVATE( knobSmall_17 )
+	KNOBTYPE_PROPERTIES_PRIVATE( knobGreen_17 )
+	KNOBTYPE_PROPERTIES_PRIVATE( knobVintage_32 )
 
 	knobTypes m_knobNum;
 

--- a/src/gui/widgets/knob.cpp
+++ b/src/gui/widgets/knob.cpp
@@ -199,11 +199,11 @@ knobTypes knob::knobNum() const
 
 
 
-void knob::setknobNum( knobTypes _k )
+void knob::setKnobNum( knobTypes k )
 {
-	if( m_knobNum != _k )
+	if( m_knobNum != k )
 	{
-		m_knobNum = _k;
+		m_knobNum = k;
 		onKnobNumUpdated();
 	}
 }
@@ -266,40 +266,74 @@ QColor knob::outerColor() const
 }
 
 
-
-void knob::setOuterColor( const QColor & _c )
+void knob::setOuterColor( const QColor & c )
 {
-	m_outerColor = _c;
+	m_outerColor = c;
 }
-
 
 
 QColor knob::lineColor() const
 {
-	return m_lineColor;
-}
-
-
-
-void knob::setlineColor( const QColor & _c )
-{
-	m_lineColor = _c;
+#define KNOBTYPE_SWITCH( knobtype ) \
+	case knobtype : \
+		return m_##knobtype##_lineColor; \
+		break;
+		
+	switch( m_knobNum )
+	{
+		KNOBTYPE_SWITCH( knobDark_28 )
+		KNOBTYPE_SWITCH( knobBright_26 )
+		KNOBTYPE_SWITCH( knobSmall_17 )
+		KNOBTYPE_SWITCH( knobGreen_17 )
+		KNOBTYPE_SWITCH( knobVintage_32 )
+		case knobStyled:
+		default:
+			break;
+	}
+	return QColor();
+#undef KNOBTYPE_SWITCH
 }
 
 
 
 QColor knob::arcColor() const
 {
-	return m_arcColor;
+#define KNOBTYPE_SWITCH( knobtype ) \
+	case knobtype : \
+		return m_##knobtype##_arcColor; \
+		break;
+		
+	switch( m_knobNum )
+	{
+		KNOBTYPE_SWITCH( knobDark_28 )
+		KNOBTYPE_SWITCH( knobBright_26 )
+		KNOBTYPE_SWITCH( knobSmall_17 )
+		KNOBTYPE_SWITCH( knobGreen_17 )
+		KNOBTYPE_SWITCH( knobVintage_32 )
+		case knobStyled:
+		default:
+			break;
+	}
+	return QColor();
+#undef KNOBTYPE_SWITCH
 }
 
 
+#define KNOBTYPE_PROPERTIES( knobtype ) \
+	QColor knob:: knobtype##_lineColor() const \
+	{ return m_##knobtype##_lineColor; } \
+	QColor knob:: knobtype##_arcColor() const \
+	{ return m_##knobtype##_arcColor; } \
+	void knob:: knobtype##_setLineColor( const QColor & c ) \
+	{ m_##knobtype##_lineColor = c; } \
+	void knob:: knobtype##_setArcColor( const QColor & c ) \
+	{ m_##knobtype##_arcColor = c; } 
 
-void knob::setarcColor( const QColor & _c )
-{
-	m_arcColor = _c;
-}
-
+	KNOBTYPE_PROPERTIES( knobDark_28 )
+	KNOBTYPE_PROPERTIES( knobBright_26 )
+	KNOBTYPE_PROPERTIES( knobSmall_17 )
+	KNOBTYPE_PROPERTIES( knobGreen_17 )
+	KNOBTYPE_PROPERTIES( knobVintage_32 )
 
 
 
@@ -393,34 +427,28 @@ void knob::drawKnob( QPainter * _p )
 	const int arcLineWidth = 2;
 	const int arcRectSize = m_knobPixmap->width() - arcLineWidth;
 
-	QColor col;
-	if( m_knobNum == knobVintage_32 )
-	{	col = QApplication::palette().color( QPalette::Active, QPalette::Shadow ); }
-	else
-	{	col = QApplication::palette().color( QPalette::Active, QPalette::WindowText ); }
+	QColor col = arcColor();
 	col.setAlpha( 70 );
 
 	p.setPen( QPen( col, 2 ) );
 	p.drawArc( mid.x() - arcRectSize/2, 1, arcRectSize, arcRectSize, 315*16, 16*m_totalAngle );
 
+	p.setPen( QPen( lineColor(), 2 ) );
+
 	switch( m_knobNum )
 	{
 		case knobSmall_17:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active,
-							QPalette::WindowText ), 2 ) );
 			p.drawLine( calculateLine( mid, radius-2 ) );
 			break;
 		}
 		case knobBright_26:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active, QPalette::WindowText ), 2 ) );
 			p.drawLine( calculateLine( mid, radius-5 ) );
 			break;
 		}
 		case knobDark_28:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active, QPalette::WindowText ), 2 ) );
 			const float rb = qMax<float>( ( radius - 10 ) / 3.0,
 									0.0 );
 			const float re = qMax<float>( ( radius - 4 ), 0.0 );
@@ -431,15 +459,11 @@ void knob::drawKnob( QPainter * _p )
 		}
 		case knobGreen_17:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active,
-							QPalette::BrightText), 2 ) );
 			p.drawLine( calculateLine( mid, radius ) );
 			break;
 		}
 		case knobVintage_32:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active,
-							QPalette::Shadow), 2 ) );
 			p.drawLine( calculateLine( mid, radius-2, 2 ) );
 			break;
 		}
@@ -447,6 +471,7 @@ void knob::drawKnob( QPainter * _p )
 			break;
 	}
 
+	p.setPen( QPen( arcColor(), 2 ) );
 	p.drawArc( mid.x() - arcRectSize/2, 1, arcRectSize, arcRectSize, (90-centerAngle)*16, -16*(m_angle-centerAngle) );
 
 	p.end();


### PR DESCRIPTION
Ok, so: according to Qt documentation it should be possible to set widget properties in the CSS based on the value of a qproperty, and I initially thought it would be possible to set the colours of the knob based on its knobnum-property.

Alas, no matter what I tried (and I tried _lots_ of things) this just doesn't seem to work. It seems like the properties just won't get applied properly, no matter what. I tried getting the knob to reload the stylesheet after the knobnum property was set, no effect... tried reloading the style... tried setting object names based on the knobnum property and even that didn't work. Tried changing the knobnum to an integer property in case the type isn't registered or recognized properly... still nothing.

So at this point the only thing I could think of was creating separate qproperties for each knobtype. So I removed the existing lineColor/arcColor properties and just added a pair of those properties for each knobtype. It's an ugly, convoluted and hackish solution, but it's the only one that seems to be working. If anyone can figure out a better, cleaner solution that works, be my guest...
