### PR TITLE
InstrumentTrack: skip processing entirely if the track is muted - a way ...

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -556,6 +556,12 @@ void InstrumentTrack::removeMidiPortNode( DataFile & _dataFile )
 bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 							const f_cnt_t _offset, int _tco_num )
 {
+	// if the track is muted, don't play anything
+	if( isMuted() ) 
+	{
+		return false;
+	}
+	
 	const float frames_per_tick = engine::framesPerTick();
 
 	tcoVector tcos;


### PR DESCRIPTION
...to conserve CPU power: notes won't be played at all on a muted track. If the user wants the notes to be processed without making a sound, the only use case for that is using a peak controller, and that has its own mute button anyway, so there's really no reason to process notes on a muted track, that I can think of.
