### PR TITLE
Fixes SF2/VST title rename bug #462

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -352,9 +352,9 @@ void sf2Instrument::openFile( const QString & _sf2File, bool updateTrackName )
 
 	delete[] sf2Ascii;
 
-	if( updateTrackName )
+	if( updateTrackName || instrumentTrack()->displayName() == sf2player_plugin_descriptor.displayName)
 	{
-		instrumentTrack()->setName( QFileInfo( _sf2File ).baseName() );
+   		instrumentTrack()->setName( QFileInfo( _sf2File ).baseName() );
 	}
 }
 

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -237,9 +237,12 @@ void vestigeInstrument::loadFile( const QString & _file )
 {
 	m_pluginMutex.lock();
 	const bool set_ch_name = ( m_plugin != NULL &&
-		instrumentTrack()->name() == m_plugin->name() ) ||
-			instrumentTrack()->name() ==
-				InstrumentTrack::tr( "Default preset" );
+        	instrumentTrack()->name() == m_plugin->name() ) ||
+            	instrumentTrack()->name() ==
+                	InstrumentTrack::tr( "Default preset" ) ||
+            	instrumentTrack()->name() == 
+                	vestige_plugin_descriptor.displayName;
+
 	m_pluginMutex.unlock();
 
 	if ( m_plugin != NULL )


### PR DESCRIPTION
Restores auto-name functionality to newly added SoundFont and VST tracks where the track name will take the name of the soundfont or vst plugin, respectively.

Tested with `.mmpz`, `.xpf` to maintain compatibility with tracks that have a name specified.

![screen shot 2014-05-26 at 12 55 19 pm](https://cloud.githubusercontent.com/assets/6345473/3084649/d30bc238-e4fc-11e3-9338-0ff0042ba6b2.png)
