### PR TITLE
Copy+Paste for rubberband selections in track editor

### DIFF
--- a/include/MidiTime.h
+++ b/include/MidiTime.h
@@ -3,7 +3,7 @@
  *              position- and length-variables
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- * 
+ *
  * This file is part of Linux MultiMedia Studio - http://lmms.sourceforge.net
  *
  * This program is free software; you can redistribute it and/or

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -79,7 +79,7 @@ public:
 
 	inline bool rubberBandActive() const
 	{
-		return( m_rubberBand->isVisible() );
+		return( m_rubberBand->isEnabled() && m_rubberBand->isVisible() );
 	}
 
 	inline QVector<selectableObject *> selectedObjects()

--- a/include/string_pair_drag.h
+++ b/include/string_pair_drag.h
@@ -3,7 +3,7 @@
  *                      for drag'n'drop of string-pairs
  *
  * Copyright (c) 2005-2007 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- * 
+ *
  * This file is part of Linux MultiMedia Studio - http://lmms.sourceforge.net
  *
  * This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@
 #include <QtGui/QDrag>
 #include <QtGui/QDragEnterEvent>
 #include <QtGui/QDropEvent>
+#include <QMimeData>
 
 #include "export.h"
 
@@ -44,6 +45,8 @@ public:
 
 	static bool processDragEnterEvent( QDragEnterEvent * _dee,
 						const QString & _allowed_keys );
+	static QString decodeMimeKey( const QMimeData * mimeData );
+	static QString decodeMimeValue( const QMimeData * mimeData );
 	static QString decodeKey( QDropEvent * _de );
 	static QString decodeValue( QDropEvent * _de );
 

--- a/include/track.h
+++ b/include/track.h
@@ -30,6 +30,7 @@
 #include <QtCore/QList>
 #include <QtGui/QWidget>
 #include <QColor>
+#include <QMimeData>
 
 #include "lmms_basics.h"
 #include "MidiTime.h"
@@ -37,6 +38,7 @@
 #include "JournallingObject.h"
 #include "AutomatableModel.h"
 #include "ModelView.h"
+#include "DataFile.h"
 
 
 class QMenu;
@@ -123,6 +125,16 @@ public:
 
 	virtual trackContentObjectView * createView( trackView * _tv ) = 0;
 
+	inline void selectViewOnCreate( bool select )
+	{
+		m_selectViewOnCreate = select;
+	}
+
+	inline bool getSelectViewOnCreate()
+	{
+		return m_selectViewOnCreate;
+	}
+
 
 public slots:
 	void copy();
@@ -153,6 +165,7 @@ private:
 	BoolModel m_mutedModel;
 	BoolModel m_soloModel;
 
+	bool m_selectViewOnCreate;
 
 	friend class trackContentObjectView;
 
@@ -210,6 +223,8 @@ protected:
 		return m_trackView;
 	}
 
+	DataFile createTCODataFiles(const QVector<trackContentObjectView *> & tcos) const;
+
 
 protected slots:
 	void updateLength();
@@ -222,7 +237,9 @@ private:
 		NoAction,
 		Move,
 		MoveSelection,
-		Resize
+		Resize,
+		CopySelection,
+		ToggleSelected
 	} ;
 
 	static textFloat * s_textFloat;
@@ -231,7 +248,8 @@ private:
 	trackView * m_trackView;
 	Actions m_action;
 	bool m_autoResize;
-	int m_initialMouseX;
+	QPoint m_initialMousePos;
+	QPoint m_initialMouseGlobalPos;
 
 	textFloat * m_hint;
 
@@ -240,6 +258,15 @@ private:
 // qproperty fields
 	QColor m_fgColor;
 	QColor m_textColor;
+
+	inline void setInitialMousePos( QPoint pos )
+	{
+		m_initialMousePos = pos;
+		m_initialMouseGlobalPos = mapToGlobal( pos );
+	}
+
+	bool mouseMovedDistance( QMouseEvent * _me, int distance );
+
 } ;
 
 
@@ -277,6 +304,9 @@ public:
 			removeTCOView( m_tcoViews[_tco_num] );
 		}
 	}
+
+	bool canPasteSelection( MidiTime tcoPos, const QMimeData * mimeData );
+	bool pasteSelection( MidiTime tcoPos, QDropEvent * _de );
 
 	MidiTime endPosition( const MidiTime & _pos_start );
 

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -77,6 +77,7 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 
 	m_scrollArea->show();
 	m_rubberBand->hide();
+	m_rubberBand->setEnabled( false );
 
 	setAcceptDrops( true );
 
@@ -381,6 +382,7 @@ void TrackContainerView::mousePressEvent( QMouseEvent * _me )
 	if( allowRubberband() == true )
 	{
 		m_origin = m_scrollArea->mapFromParent( _me->pos() );
+		m_rubberBand->setEnabled( true );
 		m_rubberBand->setGeometry( QRect( m_origin, QSize() ) );
 		m_rubberBand->show();
 	}
@@ -407,6 +409,7 @@ void TrackContainerView::mouseMoveEvent( QMouseEvent * _me )
 void TrackContainerView::mouseReleaseEvent( QMouseEvent * _me )
 {
 	m_rubberBand->hide();
+	m_rubberBand->setEnabled( false );
 	QWidget::mouseReleaseEvent( _me );
 }
 

--- a/src/gui/string_pair_drag.cpp
+++ b/src/gui/string_pair_drag.cpp
@@ -4,7 +4,7 @@
  *                        for all drag'n'drop-actions within LMMS
  *
  * Copyright (c) 2005-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- * 
+ *
  * This file is part of Linux MultiMedia Studio - http://lmms.sourceforge.net
  *
  * This program is free software; you can redistribute it and/or
@@ -93,10 +93,25 @@ bool stringPairDrag::processDragEnterEvent( QDragEnterEvent * _dee,
 
 
 
+QString stringPairDrag::decodeMimeKey( const QMimeData * mimeData )
+{
+	return( QString( mimeData->data( mimeType() ) ).section( ':', 0, 0 ) );
+}
+
+
+
+
+QString stringPairDrag::decodeMimeValue( const QMimeData * mimeData )
+{
+	return( QString( mimeData->data( mimeType() ) ).section( ':', 1, -1 ) );
+}
+
+
+
+
 QString stringPairDrag::decodeKey( QDropEvent * _de )
 {
-	return( QString( _de->mimeData()->data( mimeType()
-						) ).section( ':', 0, 0 ) );
+	return decodeMimeKey( _de->mimeData() );
 }
 
 
@@ -104,8 +119,5 @@ QString stringPairDrag::decodeKey( QDropEvent * _de )
 
 QString stringPairDrag::decodeValue( QDropEvent * _de )
 {
-	return( QString( _de->mimeData()->data( mimeType()
-						) ).section( ':', 1, -1 ) );
+	return decodeMimeValue( _de->mimeData() );
 }
-
-

--- a/src/gui/widgets/rubberband.cpp
+++ b/src/gui/widgets/rubberband.cpp
@@ -3,7 +3,7 @@
  *                               for Qt4
  *
  * Copyright (c) 2006-2011 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- * 
+ *
  * This file is part of Linux MultiMedia Studio - http://lmms.sourceforge.net
  *
  * This program is free software; you can redistribute it and/or
@@ -25,7 +25,6 @@
 
 
 #include "rubberband.h"
-
 
 
 rubberBand::rubberBand( QWidget * _parent ) :
@@ -67,14 +66,17 @@ QVector<selectableObject *> rubberBand::selectedObjects() const
 void rubberBand::resizeEvent( QResizeEvent * _re )
 {
 	QRubberBand::resizeEvent( _re );
-	QVector<selectableObject *> so = selectableObjects();
-	for( QVector<selectableObject *>::iterator it = so.begin();
-							it != so.end(); ++it )
+	if( isEnabled() )
 	{
-		( *it )->setSelected( QRect( pos(), size() ).intersects(
-				QRect( ( *it )->mapTo( parentWidget(),
-								QPoint() ),
-							( *it )->size() ) ) );
+		QVector<selectableObject *> so = selectableObjects();
+		for( QVector<selectableObject *>::iterator it = so.begin();
+								it != so.end(); ++it )
+		{
+			( *it )->setSelected( QRect( pos(), size() ).intersects(
+					QRect( ( *it )->mapTo( parentWidget(),
+									QPoint() ),
+								( *it )->size() ) ) );
+		}
 	}
 }
 


### PR DESCRIPTION
# Summary

Ctrl+click+drag copies selections.  Pasting onto the same grabbed TCO is prevented,
but pasting from one TCO onto another copies the whole selection.  
The selection is changed to the newly pasted group.  The "no" icon is displayed if the paste cannot occur (would result in out of bounds TCOs, TCOs on mismatched tracks, or pasting onto the same grabbed TCO).

While pasting onto the same grabbed TCO is prevented, if the slot next to the grabbed TCO is empty and we move to it then back to the grabbed TCO, the paste will not be prevented.  This is due to a mouseMoveEvent not being triggered when re-entering and is unintentional.

Pasting onto the same TCO is also prevent when not in rubberband.  It was effectively a no-op previously, now the "no" symbol is displayed.

I am not against pasting into the same TCO, except that more often than not it is a mistake, and you don't always realize you have two TCOs in the same slot until your headphones are blaring from double notes since there is no UI indication.

When in allowRubberband, ctrl+click toggles a single trackContentObjectView
when the mouse is released rather than pressed, and only if the mouse did not
move.  If the mouse moved, there was an intent to copy the selected trackContents, and a toggle will not occur.  "Move" is currently set at 2 pixels distance, in case of jitters with the user.

Disabled rendering of SizeHorCursor when click-dragging a TCO while in rubberBand mode.
Click-dragging an unselected TCO has no effect in this mode; what would happen is
the resize cursor would appear as long as you were to the right of the TCO's 
right boundary, which is only confusing since you can't do anything in this operation.

I think I fixed a pasting inaccuracy in non-rubberband mode as well, the wrong MidiTime getTact() function was being called, but I don't recall where it was.
# Review

The journalling API was not clear so I doubt I am doing that correctly.
# Todo
- Delete selection
- Better pasting UI indication.  We display the grabbed TCO's pixmap icon even for full selections.  I think showing the potential new TCOs ghosted onto the track view might work well.
- Ctrl+a selects all
