### PR TITLE
PianoRoll: Note Quick Resize

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -347,6 +347,9 @@ private:
 	void computeSelectedNotes( bool shift );
 	void clearSelectedNotes();
 
+	// did we start a mouseclick with shift pressed
+	bool m_startedWithShift;
+
 	friend class engine;
 
 


### PR DESCRIPTION
Basically, this works as such:
- if you click shift _after_ starting a note move OR after creating a new note, the note move action is switched into resize mode, so you can quickly resize the note you just created, or the note you just moved. This saves time and improves workflow - at least based on my own experience: I've always wished I could do this, this is a huge time saving when you want to quickly jot down notes of differing lengths.
- if shift is already pressed when you click, the above will not happen, because that would mess with the note copy function. Copying notes with shift-dragging works the same as before.
- note test playback is halted when you click shift while moving. This is purely because it was causing some crackling noise, probably because of the changing length of a note that is currently playing. Maybe that can be fixed later, although it's arguably better not to hear the note while resizing - it's consistent with the other resize.
- works on group of notes as well, if you start moving a group of notes and then click shift, it will go into resize. Exception is notes copied with shift-drag... for obvious reasons.
- that should be all. Testing appreciated.
