### PR TITLE
FxMixerView: fix crash when loading project while selected channel != 0

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -199,6 +199,9 @@ void FxMixerView::refreshDisplay()
 		chLayout->addWidget(m_fxChannelViews[i]->m_fxLine);
 	}
 	
+	// set selected fx line to 0
+	setCurrentFxLine( 0 );
+	
 	// update all fx lines
 	for( int i = 0; i < m_fxChannelViews.size(); ++i )
 	{


### PR DESCRIPTION
Fixes #782
