### PR TITLE
Sample-exact models: InstrumentTrack vol/pan knobs s.ex. support

### DIFF
--- a/include/AudioPort.h
+++ b/include/AudioPort.h
@@ -22,14 +22,15 @@
  *
  */
 
-#ifndef _AUDIO_PORT_H
-#define _AUDIO_PORT_H
+#ifndef AUDIO_PORT_H
+#define AUDIO_PORT_H
 
 #include <QtCore/QString>
 #include <QtCore/QMutex>
 #include <QtCore/QMutexLocker>
 
 #include "Mixer.h"
+#include "ValueBuffer.h"
 
 class EffectChain;
 
@@ -124,6 +125,17 @@ public:
 		BothBuffers
 	} ;
 
+	inline void setVolumeBuffer( ValueBuffer * vb )
+	{
+		m_volumeBuffer = vb;
+	}
+
+	inline void setPanningBuffer( ValueBuffer * vb )
+	{
+		m_panningBuffer = vb;
+	}
+
+	void applyValueBuffers();
 
 private:
 	volatile bufferUsages m_bufferUsage;
@@ -137,9 +149,11 @@ private:
 	fx_ch_t m_nextFxChannel;
 
 	QString m_name;
-	
+
 	EffectChain * m_effects;
 
+	ValueBuffer * m_volumeBuffer;
+	ValueBuffer * m_panningBuffer;
 
 	friend class Mixer;
 	friend class MixerWorkerThread;

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef _INSTRUMENT_TRACK_H
-#define _INSTRUMENT_TRACK_H
+#ifndef INSTRUMENT_TRACK_H
+#define INSTRUMENT_TRACK_H
 
 #include "AudioPort.h"
 #include "InstrumentFunctions.h"

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef _MIXER_H
-#define _MIXER_H
+#ifndef MIXER_H
+#define MIXER_H
 
 #include "lmmsconfig.h"
 
@@ -48,7 +48,7 @@
 #include "note.h"
 #include "fifo_buffer.h"
 
-
+class ValueBuffer;
 class AudioDevice;
 class MidiClient;
 class AudioPort;
@@ -94,7 +94,7 @@ public:
 			Interpolation_SincFastest,
 			Interpolation_SincMedium,
 			Interpolation_SincBest
-		} ; 
+		} ;
 
 		enum Oversampling
 		{
@@ -314,7 +314,9 @@ public:
 					const fpp_t _frames,
 					const f_cnt_t _offset,
 					stereoVolumeVector _volume_vector,
-					AudioPort * _port );
+					AudioPort * _port,
+					ValueBuffer * volumeBuf = NULL,
+					ValueBuffer * panningBuf = NULL  );
 
 	static void clearAudioBuffer( sampleFrame * _ab,
 						const f_cnt_t _frames,
@@ -337,7 +339,7 @@ public:
 	}
 
 	void pushInputFrames( sampleFrame * _ab, const f_cnt_t _frames );
-	
+
 	inline const sampleFrame * inputBuffer()
 	{
 		return m_inputBuffer[ m_inputBufferRead ];
@@ -409,10 +411,10 @@ private:
 	f_cnt_t m_inputBufferSize[2];
 	int m_inputBufferRead;
 	int m_inputBufferWrite;
-	
+
 	surroundSampleFrame * m_readBuf;
 	surroundSampleFrame * m_writeBuf;
-	
+
 	QVector<surroundSampleFrame *> m_bufferPool;
 	int m_readBuffer;
 	int m_writeBuffer;
@@ -423,7 +425,7 @@ private:
 	fpp_t m_halfStart[SURROUND_CHANNELS];
 	bool m_oldBuffer[SURROUND_CHANNELS];
 	bool m_newBuffer[SURROUND_CHANNELS];
-	
+
 	int m_cpuLoad;
 	QVector<MixerWorkerThread *> m_workers;
 	int m_numWorkers;

--- a/include/ValueBuffer.h
+++ b/include/ValueBuffer.h
@@ -121,6 +121,20 @@ public:
 			m_values[i] = linearInterpolate( start, end, f );
 		}
 	}
+	
+	void multiply( float f )
+	{
+		for( int i = 0; i < m_length; i++ )
+		{
+			m_values[i] *= f;
+		}
+	}
+	
+	ValueBuffer & operator*=( const float & f )
+	{
+		multiply( f );
+		return *this;
+	}
 
 	static ValueBuffer interpolatedBuffer( float start, float end, int length )
 	{

--- a/plugins/Amplifier/Amplifier.cpp
+++ b/plugins/Amplifier/Amplifier.cpp
@@ -115,10 +115,10 @@ bool AmplifierEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 			: m_ampControls.m_panModel.value();
 		const float left1 = pan <= 0
 			? 1.0
-			: 1.0 - m_ampControls.m_panModel.value( f ) * 0.01f;
+			: 1.0 - pan * 0.01f;
 		const float right1 = pan >= 0
 			? 1.0
-			: 1.0 + m_ampControls.m_panModel.value( ) * 0.01f;
+			: 1.0 + pan * 0.01f;
 
 		// second stage amplification
 		const float left2 = leftBuf

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -58,7 +58,7 @@
 #include "MidiDummy.h"
 
 #include "MemoryHelper.h"
-
+#include "ValueBuffer.h"
 
 
 
@@ -455,7 +455,9 @@ void Mixer::bufferToPort( const sampleFrame * _buf,
 					const fpp_t _frames,
 					const f_cnt_t _offset,
 					stereoVolumeVector _vv,
-						AudioPort * _port )
+						AudioPort * _port,
+						ValueBuffer * volumeBuf,
+						ValueBuffer * panningBuf )
 {
 	const int start_frame = _offset % m_framesPerPeriod;
 	int end_frame = start_frame + _frames;
@@ -466,6 +468,17 @@ void Mixer::bufferToPort( const sampleFrame * _buf,
 										_buf,							// src
 										_vv.vol[0], _vv.vol[1],			// coeff left/right
 										loop1_frame - start_frame );	// frame count
+
+	// pass on valuebuffers if we have them
+	if( volumeBuf )
+	{
+		_port->setVolumeBuffer( volumeBuf );
+	}
+	if( panningBuf )
+	{
+		_port->setPanningBuffer( panningBuf );
+	}
+										
 	_port->unlockFirstBuffer();
 
 	_port->lockSecondBuffer();


### PR DESCRIPTION
This was a bit tricky because instrumentTracks are inherently such that they may contain an offset, which would mean that the models wouldn't match up with the instruments.
I solved this by passing the ValueBuffers all the way from InstrumentTrack, via Mixer, to AudioPort, where the offset is compensated for, and doing the actual vol/pan modulation there. I think it's a pretty neat solution and seems to work fine, but this should be reviewed just to be safe, just to see that I'm not doing anything really stupid here...
