### PR TITLE
Make BB-tracks themeable

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -516,6 +516,7 @@ AutomationPatternView {
 
 /* bb-pattern */
 bbTCOView {
+	color: rgb( 128, 182, 175 ); /* default colour for bb-tracks, used when the colour hasn't been defined by the user */
 	qproperty-textColor: rgb( 255, 255, 255 );
 }
 

--- a/include/bb_track.h
+++ b/include/bb_track.h
@@ -39,7 +39,7 @@ class TrackContainer;
 class bbTCO : public trackContentObject
 {
 public:
-	bbTCO( track * _track, unsigned int _color = 0 );
+	bbTCO( track * _track );
 	virtual ~bbTCO();
 
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
@@ -49,13 +49,24 @@ public:
 		return( "bbtco" );
 	}
 
-	inline unsigned int color() const
+	unsigned int color() const
 	{
-		return( m_color );
+		return( m_color.rgb() );
 	}
-	inline static unsigned int defaultColor()
+	
+	QColor colorObj() const
 	{
-		return qRgb( 128, 182, 175 );
+		return m_color;
+	}
+
+	void setColor( const QColor & c )
+	{
+		m_color = QColor( c );
+	}
+
+	void setUseStyleColor( bool b )
+	{
+		m_useStyleColor = b;
 	}
 
 	int bbTrackIndex();
@@ -63,7 +74,8 @@ public:
 	virtual trackContentObjectView * createView( trackView * _tv );
 
 private:
-	unsigned int m_color;
+	QColor m_color;
+	bool m_useStyleColor;
 
 
 	friend class bbTCOView;
@@ -91,6 +103,7 @@ protected slots:
 	void resetName();
 	void changeName();
 	void changeColor();
+	void resetColor();
 
 
 protected:
@@ -144,6 +157,26 @@ public:
 		m_disabledTracks.removeAll( _track );
 	}
 
+	static void setLastTCOColor( const QColor & c )
+	{
+		if( ! s_lastTCOColor )
+		{
+			s_lastTCOColor = new QColor( c );
+		}
+		else
+		{
+			*s_lastTCOColor = QColor( c );
+		}
+	}
+	
+	static void clearLastTCOColor()
+	{
+		if( s_lastTCOColor )
+		{
+			delete s_lastTCOColor;
+		}
+		s_lastTCOColor = NULL;
+	}
 
 protected:
 	inline virtual QString nodeName() const
@@ -158,6 +191,7 @@ private:
 	typedef QMap<bbTrack *, int> infoMap;
 	static infoMap s_infoMap;
 
+	static QColor * s_lastTCOColor;
 
 	friend class bbTrackView;
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -683,18 +683,6 @@ void DataFile::upgrade()
 
 	}
 
-	// new default colour for B&B tracks
-	QDomNodeList list = elementsByTagName( "bbtco" );
-	for( int i = 0; !list.item( i ).isNull(); ++i )
-	{
-		QDomElement el = list.item( i ).toElement();
-		unsigned int rgb = el.attribute( "color" ).toUInt();
-		if( rgb == qRgb( 64, 128, 255 ) )
-		{
-			el.setAttribute( "color", bbTCO::defaultColor() );
-		}
-	}
-
 	// Time-signature
 	if ( !m_head.hasAttribute( "timesig_numerator" ) )
 	{


### PR DESCRIPTION
- This allows defining a default colour for BB-track patterns in the CSS
- The default colour is used for all bb-patterns which don't have a custom colour set by the user: in other words, the colour of a pattern can be any rgb-value OR "style colour"
- By default, all created bb-patterns use the style colour
- You can also reset colourized patterns to use style colour again
- Backwards compatibility: old projects will be loaded so that any pattern using either of the old default colours will be converted to use style colour

TODO: add a settings option that can disable custom colours (ie. always use style colour), and/or an option to reset all patterns in a project to style colour. This is needed, since themes can now change the song editor background, which can lead to unfortunate colour combinations with custom colours...
