### PR TITLE
Ensure that NotePlayHandles get processed before the InstrumentPlayHandl...

### DIFF
--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -119,13 +119,13 @@ public:
 
 	virtual bool isFromTrack( const track * _track ) const;
 
-
-protected:
 	inline InstrumentTrack * instrumentTrack() const
 	{
 		return m_instrumentTrack;
 	}
 
+
+protected:
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal
 	// desiredReleaseFrames() frames are left

--- a/plugins/sf2_player/sf2_player.h
+++ b/plugins/sf2_player/sf2_player.h
@@ -79,7 +79,7 @@ public:
 
 	virtual Flags flags() const
 	{
-		return IsSingleStreamed | IsMidiBased;
+		return IsSingleStreamed;
 	}
 
 	virtual PluginView * instantiateView( QWidget * _parent );


### PR DESCRIPTION
...e on instruments that use both NotePlayHandles and InstrumentPlayHandle, such as LB302 and SF2-Player

Issue: Currently, we use threads to process all PlayHandles, so there's no guarantee of the order they are processed in. This causes timing inaccuracy and jitter: notes of instruments that use both NPH's and IPH's can get randomly delayed by one entire period.
The issue is solved thusly:
- When processing an IPH, we check if the instrument is midi-based. If yes, we just process it normally (no NPH's to worry about).
- If it's not, then it also uses NPH's, so we'll have the IPH wait until all NPH's belonging to same instrument have been processed. There's some similar code in the new FX mixer, I pretty much just copied how we do it there.

(Also: sf2 was incorrectly announcing itself as midi-based, fixed that)
