### PR TITLE
Use QBrush instead of QColor on some theme properties

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -18,8 +18,15 @@ AutomationEditor {
 	color: #e0e0e0;
 	qproperty-vertexColor: #ff77af;
 	qproperty-gridColor: #808080;
-	qproperty-graphColor: #99afff;
-	qproperty-scaleColor: rgb( 32, 32, 32 );
+	
+	qproperty-graphColor: qlineargradient(spread:reflect,
+                     x1:0, y1:0, x2:0, y2:1,
+                     stop:0 rgba(153, 175, 255, 250),  stop:1 rgba(153, 175, 255, 100));
+	/*#99afff;*/
+	qproperty-scaleColor: qlineargradient(spread:reflect,
+                     x1:0, y1:0.5, x2:1, y2:0.5,
+                     stop:0 #333, stop:1 #202020);
+	/*rgb( 32, 32, 32 );*/
 }
 
 /* text box */
@@ -259,13 +266,10 @@ nStateButton {
 
 /* track background colors */
 trackContentWidget {
-	qproperty-darkerColor1: rgb( 50, 50, 50 );
-	qproperty-darkerColor2: rgb( 20, 20, 20 );
-	qproperty-darkerColor3: rgb( 15, 15, 15 );
-	qproperty-lighterColor1: rgb( 50, 50, 50 );
-	qproperty-lighterColor2: rgb( 40, 40, 40 );
-	qproperty-lighterColor3: rgb( 30, 30, 30 );
-	qproperty-gradMidPoint: 0.33;
+	qproperty-darkerColor: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
+							stop:0 rgb( 50, 50, 50 ), stop:0.33 rgb( 20, 20, 20 ), stop:1 rgb( 15, 15, 15 ) );
+	qproperty-lighterColor: qlineargradient(x1:0, y1:0, x2:0, y2:1, 
+							stop:0 rgb( 50, 50, 50 ), stop:0.33 rgb( 40, 40, 40 ), stop:1 rgb( 30, 30, 30 ) );
 }
 
 

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -51,9 +51,9 @@ class AutomationEditor : public QWidget, public JournallingObject
 {
 	Q_OBJECT
 	Q_PROPERTY( QColor gridColor READ gridColor WRITE setGridColor )
-	Q_PROPERTY( QColor graphColor READ graphColor WRITE setGraphColor )
 	Q_PROPERTY( QColor vertexColor READ vertexColor WRITE setVertexColor )
-	Q_PROPERTY( QColor scaleColor READ scaleColor WRITE setScaleColor )
+	Q_PROPERTY( QBrush scaleColor READ scaleColor WRITE setScaleColor )
+	Q_PROPERTY( QBrush graphColor READ graphColor WRITE setGraphColor )	
 public:
 	void setCurrentPattern( AutomationPattern * _new_pattern );
 
@@ -81,13 +81,13 @@ public:
 
 	// qproperty access methods
 	QColor gridColor() const;
-	QColor graphColor() const;
+	QBrush graphColor() const;
 	QColor vertexColor() const;
-	QColor scaleColor() const;
+	QBrush scaleColor() const;
 	void setGridColor( const QColor & c );
-	void setGraphColor( const QColor & c );
+	void setGraphColor( const QBrush & c );
 	void setVertexColor( const QColor & c );
-	void setScaleColor( const QColor & c );
+	void setScaleColor( const QBrush & c );
 
 public slots:
 	void update();
@@ -266,9 +266,9 @@ private:
 	bool inBBEditor();
 
 	QColor m_gridColor;
-	QColor m_graphColor;
+	QBrush m_graphColor;
 	QColor m_vertexColor;
-	QColor m_scaleColor;
+	QBrush m_scaleColor;
 
 	friend class engine;
 

--- a/include/track.h
+++ b/include/track.h
@@ -251,15 +251,8 @@ class trackContentWidget : public QWidget, public JournallingObject
 	Q_OBJECT
 
 	// qproperties for track background gradients
-	Q_PROPERTY( QColor darkerColor1 READ darkerColor1 WRITE setDarkerColor1 )
-	Q_PROPERTY( QColor darkerColor2 READ darkerColor2 WRITE setDarkerColor2 )
-	Q_PROPERTY( QColor darkerColor3 READ darkerColor3 WRITE setDarkerColor3 )
-
-	Q_PROPERTY( QColor lighterColor1 READ lighterColor1 WRITE setLighterColor1 )
-	Q_PROPERTY( QColor lighterColor2 READ lighterColor2 WRITE setLighterColor2 )
-	Q_PROPERTY( QColor lighterColor3 READ lighterColor3 WRITE setLighterColor3 )
-
-	Q_PROPERTY( float gradMidPoint READ gradMidPoint WRITE setGradMidPoint )
+	Q_PROPERTY( QBrush darkerColor READ darkerColor WRITE setDarkerColor )
+	Q_PROPERTY( QBrush lighterColor READ lighterColor WRITE setLighterColor )
 
 public:
 	trackContentWidget( trackView * _parent );
@@ -282,25 +275,11 @@ public:
 
 	// qproperty access methods
 
-	QColor darkerColor1() const;
-	QColor darkerColor2() const;
-	QColor darkerColor3() const;
+	QBrush darkerColor() const;
+	QBrush lighterColor() const;
 
-	QColor lighterColor1() const;
-	QColor lighterColor2() const;
-	QColor lighterColor3() const;
-
-	float gradMidPoint() const;
-
-	void setDarkerColor1( const QColor & _c );
-	void setDarkerColor2( const QColor & _c );
-	void setDarkerColor3( const QColor & _c );
-
-	void setLighterColor1( const QColor & _c );
-	void setLighterColor2( const QColor & _c );
-	void setLighterColor3( const QColor & _c );
-
-	void setGradMidPoint( float _g );
+	void setDarkerColor( const QBrush & _c );
+	void setLighterColor( const QBrush & _c );
 
 public slots:
 	void update();
@@ -343,13 +322,8 @@ private:
 	QPixmap m_background;
 
 	// qproperty fields
-	QColor m_darkerColor1;
-	QColor m_darkerColor2;
-	QColor m_darkerColor3;
-	QColor m_lighterColor1;
-	QColor m_lighterColor2;
-	QColor m_lighterColor3;
-	float m_gradMidPoint;
+	QBrush m_darkerColor;
+	QBrush m_lighterColor;
 } ;
 
 

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -847,14 +847,7 @@ void trackContentObjectView::setAutoResizeEnabled( bool _e )
  */
 trackContentWidget::trackContentWidget( trackView * _parent ) :
 	QWidget( _parent ),
-	m_trackView( _parent ),
-	m_darkerColor1( 0, 0, 0 ),
-	m_darkerColor2( 0, 0, 0 ),
-	m_darkerColor3( 0, 0, 0 ),
-	m_lighterColor1( 0, 0, 0 ),
-	m_lighterColor2( 0, 0, 0 ),
-	m_lighterColor3( 0, 0, 0 ),
-	m_gradMidPoint( 0.0f )
+	m_trackView( _parent )
 {
 	setAcceptDrops( true );
 
@@ -894,17 +887,8 @@ void trackContentWidget::updateBackground()
 	m_background = QPixmap( w * 2, height() );
 	QPainter pmp( &m_background );
 
-	QLinearGradient grad( 0,0, 0, h );
-	grad.setColorAt( 0.0, darkerColor1() );
-	grad.setColorAt( gradMidPoint(), darkerColor2() );
-	grad.setColorAt( 1.0, darkerColor3() );
-	pmp.fillRect( 0, 0, w, h, grad );
-
-	QLinearGradient grad2( 0,0, 0, h );
-	grad2.setColorAt( 0.0, lighterColor1() );
-	grad2.setColorAt( gradMidPoint(), lighterColor2() );
-	grad2.setColorAt( 1.0, lighterColor3() );
-	pmp.fillRect( w, 0, w , h, grad2 );
+	pmp.fillRect( 0, 0, w, h, darkerColor() );
+	pmp.fillRect( w, 0, w , h, lighterColor() );
 
 	// draw lines
 	pmp.setPen( QPen( QColor( 0, 0, 0, 160 ), 1 ) );
@@ -1236,61 +1220,20 @@ MidiTime trackContentWidget::endPosition( const MidiTime & _pos_start )
 
 // qproperty access methods
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor1() const
-{ return m_darkerColor1; }
+QBrush trackContentWidget::darkerColor() const
+{ return m_darkerColor; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor2() const
-{ return m_darkerColor2; }
+QBrush trackContentWidget::lighterColor() const
+{ return m_lighterColor; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::darkerColor3() const
-{ return m_darkerColor3; }
+void trackContentWidget::setDarkerColor( const QBrush & c )
+{ m_darkerColor = c; }
 
 //! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor1() const
-{ return m_lighterColor1; }
-
-//! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor2() const
-{ return m_lighterColor2; }
-
-//! \brief CSS theming qproperty access method
-QColor trackContentWidget::lighterColor3() const
-{ return m_lighterColor3; }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor1( const QColor & _c )
-{ m_darkerColor1 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor2( const QColor & _c )
-{ m_darkerColor2 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setDarkerColor3( const QColor & _c )
-{ m_darkerColor3 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor1( const QColor & _c )
-{ m_lighterColor1 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor2( const QColor & _c )
-{ m_lighterColor2 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setLighterColor3( const QColor & _c )
-{ m_lighterColor3 = QColor( _c ); }
-
-//! \brief CSS theming qproperty access method
-float trackContentWidget::gradMidPoint() const
-{ return m_gradMidPoint; }
-
-//! \brief CSS theming qproperty access method
-void trackContentWidget::setGradMidPoint( float _g )
-{ m_gradMidPoint = _g; }
-
+void trackContentWidget::setLighterColor( const QBrush & c )
+{ m_lighterColor = c; }
 
 
 

--- a/src/gui/AutomationEditor.cpp
+++ b/src/gui/AutomationEditor.cpp
@@ -98,9 +98,9 @@ AutomationEditor::AutomationEditor() :
 	m_editMode( DRAW ),
 	m_scrollBack( FALSE ),
 	m_gridColor( 0,0,0 ),
-	m_graphColor( 0,0,0 ),
+	m_graphColor(),
 	m_vertexColor( 0,0,0 ),
-	m_scaleColor( 0,0,0 )
+	m_scaleColor()
 {
 	connect( this, SIGNAL( currentPatternChanged() ),
 				this, SLOT( updateAfterPatternChange() ),
@@ -507,19 +507,19 @@ void AutomationEditor::setPauseIcon( bool pause )
 
 QColor AutomationEditor::gridColor() const
 { return m_gridColor; }
-QColor AutomationEditor::graphColor() const
+QBrush AutomationEditor::graphColor() const
 { return m_graphColor; }
 QColor AutomationEditor::vertexColor() const
 { return m_vertexColor; }
-QColor AutomationEditor::scaleColor() const
+QBrush AutomationEditor::scaleColor() const
 { return m_scaleColor; }
 void AutomationEditor::setGridColor( const QColor & c )
 { m_gridColor = c; }
-void AutomationEditor::setGraphColor( const QColor & c )
+void AutomationEditor::setGraphColor( const QBrush & c )
 { m_graphColor = c; }
 void AutomationEditor::setVertexColor( const QColor & c )
 { m_vertexColor = c; }
-void AutomationEditor::setScaleColor( const QColor & c )
+void AutomationEditor::setScaleColor( const QBrush & c )
 { m_scaleColor = c; }
 
 
@@ -1387,10 +1387,10 @@ void AutomationEditor::paintEvent( QPaintEvent * _pe )
 	QPainter p( this );
 	style()->drawPrimitive( QStyle::PE_Widget, &opt, &p, this );
 
-	// get foregrounf color
+	// get foreground color
 	QColor fgColor = p.pen().brush().color();
 	// get background color and fill background
-	QColor bgColor = p.background().color();
+	QBrush bgColor = p.background();
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
@@ -1768,12 +1768,11 @@ void AutomationEditor::drawLevelTick( QPainter & _p, int _tick, float _level,
 			rect_height = (int)( _level * m_y_delta );
 		}
 
-		QColor current_color( graphColor() );
-		if( _is_selected == TRUE )
-		{
-			current_color.setRgb( 0x00, 0x40, 0xC0 );
-		}
-		_p.fillRect( x, y_start, rect_width, rect_height, current_color );
+		QBrush currentColor = _is_selected
+			? QBrush( QColor( 0x00, 0x40, 0xC0 ) )
+			: graphColor();
+
+		_p.fillRect( x, y_start, rect_width, rect_height, currentColor );
 	}
 	
 	else

--- a/src/gui/PianoRoll.cpp
+++ b/src/gui/PianoRoll.cpp
@@ -2887,7 +2887,7 @@ void PianoRoll::paintEvent( QPaintEvent * _pe )
 	QPainter p( this );
 	style()->drawPrimitive( QStyle::PE_Widget, &opt, &p, this );
 
-	QColor bgColor = p.background().color();
+	QBrush bgColor = p.background();
 	
 	// fill with bg color
 	p.fillRect( 0,0, width(), height(), bgColor );


### PR DESCRIPTION
Apparently, we can use QBrush -typed properties in the CSS. This just never occured to me before!
So, this has several benefits. A QColor property only allows a singular RGB value, but a QBrush allows the same plus also qgradients, RGBA-colours and maybe even bitmap patterns. So I'm changing some properties to QBrush, where it makes sense to allow this additional functionality - no need to enable it for simple things like text colours or such.
- Song editor background: instead of the earlier hack with 7 qproperties just to set a limited background gradient, we can use only 2 properties and allow much more flexibility with Qt's own qgradient syntax
- Automation editor: background, graph colour, and the sidebar colour - @musikBear recently complained not seeing the grid through the graph, so transparency can help there, and qlineargradients in the graph can produce very cool visual effects. Grid is pointless to change, it should stay single-colour for now.
- Piano roll: here, I only made the background use QBrush - we don't really have much else here that can utilize QBrush, the notes have their own gradient system... maybe the 2nd colour of the note gradient could be customizable though.

There are probably more places where this change makes sense...
