### PR TITLE
Note filters: remove unnecessary calculations in Formantfilter

### DIFF
--- a/include/basic_filters.h
+++ b/include/basic_filters.h
@@ -138,7 +138,7 @@ public:
 			m_rclp1[_chnl] = m_rcbp1[_chnl] = m_rchp1[_chnl] = m_rclast1[_chnl] = 0.0f;
 			
 			for(int i=0; i<6; i++)
-			   m_vflp[i][_chnl] = m_vfbp[i][_chnl] = m_vfhp[i][_chnl] = m_vflast[i][_chnl] = 0.0f;
+			   m_vfbp[i][_chnl] = m_vfhp[i][_chnl] = m_vflast[i][_chnl] = 0.0f;
 		}
 	}
 
@@ -631,7 +631,7 @@ private:
 	frame m_rcbp1, m_rclp1, m_rchp1, m_rclast1;
 
 	// in/out history for Formant-filters
-	frame m_vfbp[6], m_vflp[6], m_vfhp[6], m_vflast[6];
+	frame m_vfbp[6], m_vfhp[6], m_vflast[6];
 	
 	FilterTypes m_type;
 	bool m_doubleFilter;


### PR DESCRIPTION
Formantfilter, being the heaviest of the utility filters in LMMS, has the most to gain from optimization. First, I'd like to chop off some unnecessary code: there are two LPFs being calculated and not used for anything.

I've checked and tested the change using this: https://github.com/softrabbit/filterbench and measured the speed benefit to be up to 25%. (32-bit Linux, compiled with `-msse2 -mfpmath=sse -ffast-math`)
