### PR TITLE
Fix for issue #837 - Compile issue on OS X - include file Qt/qglobal.h not found

### DIFF
--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -52,7 +52,7 @@
 #include <process.h>
 #endif
 
-#include <QtGlobal>
+#include <QtCore/QtGlobal>
 
 #if QT_VERSION >= 0x040400
 #include <QtCore/QSystemSemaphore>
@@ -75,7 +75,7 @@
 
 #ifdef USE_QT_SHMEM
 
-#include <QtGlobal>
+#include <QtCore/QtGlobal>
 
 #if QT_VERSION >= 0x040400
 #include <QtCore/QSharedMemory>


### PR DESCRIPTION
I updated two instances of the Qt/qglobal.h include in RemotePlugin.h to use QtGlobal as per the discussion in [Issue 837](https://github.com/LMMS/lmms/issues/837).

If i should include QtCore/qglobal.h instead, let me know and I can update.
