### PR TITLE
LB302: one last fix...

### DIFF
--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -720,7 +720,7 @@ void lb302Synth::initSlide()
 
 void lb302Synth::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 {
-	if( _n->isMasterNote() )
+	if( _n->isMasterNote() || ( _n->hasParent() && _n->isReleased() ) )
 	{
 		return;
 	}


### PR DESCRIPTION
Don't accept notes that will get deleted before we have a chance to process them... this really only seems to happen when both note stacking & arpeggio are enabled, but it's good to safeguard against it for now.
