### PR TITLE
SF2 player: fix playback issues

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -542,7 +542,7 @@ void sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	{
 		SF2PluginData * pluginData = new SF2PluginData;
 		pluginData->midiNote = midiNote;
-		pluginData->lastPanning = -1;
+		pluginData->lastPanning = 0;
 		pluginData->lastVelocity = 127;
 		pluginData->fluidVoice = NULL;
 
@@ -588,7 +588,7 @@ void sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		m_notesRunningMutex.unlock();
 	}
 
-	SF2PluginData * pluginData = static_cast<SF2PluginData *>(
+/*	SF2PluginData * pluginData = static_cast<SF2PluginData *>(
 							_n->m_pluginData );
 #ifdef SOMEONE_FIXED_PER_NOTE_PANNING
 	if( pluginData->fluidVoice &&
@@ -620,7 +620,7 @@ void sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		m_synthMutex.unlock();
 
 		pluginData->lastVelocity = currentVelocity;
-	}
+	}*/
 }
 
 

--- a/plugins/sf2_player/sf2_player.h
+++ b/plugins/sf2_player/sf2_player.h
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef _SF2_PLAYER_H
-#define _SF2_PLAYER_H
+#ifndef SF2_PLAYER_H
+#define SF2_PLAYER_H
 
 #include <QtCore/QMutex>
 


### PR DESCRIPTION
Changing the velocity after noteon doesn't really seem to work on fluidsynth (may be dependent on soundfont file) - seems like the panning changes when velocity is changed.
So I disabled that, after which everything works fine.
