### PR TITLE
Add loading of artwork in other formats as well as .png

### DIFF
--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -24,11 +24,11 @@
 
 
 #include <QtGui/QImage>
-
+#include <QHash>
+#include <QImageReader>
+#include <QList>
 #include "embed.h"
 #include "config_mgr.h"
-
-
 
 #ifndef PLUGIN_NAME
 namespace embed
@@ -37,6 +37,10 @@ namespace PLUGIN_NAME
 #endif
 {
 
+namespace
+{
+	static QHash<QString, QPixmap> s_pixmapCache;
+}
 
 #include "embedded_resources.h"
 
@@ -45,47 +49,71 @@ QPixmap getIconPixmap( const char * _name, int _w, int _h )
 {
 	if( _w == -1 || _h == -1 )
 	{
-		QString name = QString( _name ) + ".png";
+	        // Return cached pixmap
+                QPixmap cached = s_pixmapCache.value( _name );
+		if( !cached.isNull() )
+		{
+			return cached;
+		}
+
+		// Or try to load it
+		QList<QByteArray> formats = 
+			QImageReader::supportedImageFormats();
+		QList<QString> candidates;
+		QPixmap p;
+		QString name;
+		int i;
+		
+		for ( i = 0; i < formats.size() && p.isNull(); ++i )  
+		{
+			candidates << QString( _name ) + "." + formats.at( i ).data();
+		}
 
 #ifdef PLUGIN_NAME
-		QPixmap p( configManager::inst()->artworkDir() + "plugins/" +
-					STRINGIFY( PLUGIN_NAME ) + "_" + name );
-		if( p.isNull() )
-		{
-			p = QPixmap( configManager::inst()->artworkDir() +
-									name );
+		for ( i = 0; i < candidates.size() && p.isNull(); ++i )  {
+			name = candidates.at( i );
+			p = QPixmap( configManager::inst()->artworkDir() + "plugins/" +
+				     STRINGIFY( PLUGIN_NAME ) + "_" + name );
 		}
-#else
-		// look whether icon is in artwork-dir
-		QPixmap p( configManager::inst()->artworkDir() + name );
 #endif
-		if( p.isNull() )
-		{
-			// nothing found, so look in default-artwork-dir
-			p =
-		QPixmap( configManager::inst()->defaultArtworkDir() + name );
+		for ( i = 0; i < candidates.size() && p.isNull(); ++i )  {
+			name = candidates.at( i );
+			p = QPixmap( configManager::inst()->artworkDir() + name );
 		}
-		if( p.isNull() )
-		{
-			const embed::descriptor & e = findEmbeddedData(
-									name.toUtf8().constData() );
+		
+		// nothing found, so look in default-artwork-dir
+		for ( i = 0; i < candidates.size() && p.isNull(); ++i )  {
+			name = candidates.at( i );
+			p = QPixmap( configManager::inst()->defaultArtworkDir() 
+				     + name );
+		}
+		
+		for ( i = 0; i < candidates.size() && p.isNull(); ++i )  {
+			name = candidates.at( i );
+			const embed::descriptor & e = 
+				findEmbeddedData( name.toUtf8().constData() );
 			// found?
 			if( QString( e.name ) == name )
 			{
 				p.loadFromData( e.data, e.size );
 			}
-			else
-			{
-				p = QPixmap( 1, 1 );
-			}
 		}
+		
+		// Fallback
+		if(p.isNull()) 
+		{
+			p = QPixmap( 1, 1 );
+		}
+		// Save to cache and return
+		s_pixmapCache.insert( _name, p );
 		return p;
+
 	}
+
 	return getIconPixmap( _name ).
-			scaled( _w, _h, Qt::IgnoreAspectRatio, Qt::SmoothTransformation );
+		scaled( _w, _h, Qt::IgnoreAspectRatio, 
+			Qt::SmoothTransformation );
 }
-
-
 
 
 QString getText( const char * _name )


### PR DESCRIPTION
This is a patch I put out on Sourceforge some time ago, but it was forgotten somehow. It adds functionality to load images in all formats a QImageReader can handle. 

Also includes pixmap caching from old-master, that part's not my doing.

SVGs for 0.4.x era B&B editor loaded and resized to ridiculously wide:
![svgload](https://cloud.githubusercontent.com/assets/6411463/3376883/de3f1c06-fbd9-11e3-88c3-9a92abb1472d.png)
