### PR TITLE
FxMixer: fix channel naming when moving/deleting channels

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -117,14 +117,17 @@ public:
 	int createChannel();
 
 	// delete a channel from the FX mixer.
-	void deleteChannel(int index);
+	void deleteChannel( int index );
 
 	// delete all the mixer channels except master and remove all effects
 	void clear();
 
 	// re-arrange channels
-	void moveChannelLeft(int index);
-	void moveChannelRight(int index);
+	void moveChannelLeft( int index );
+	void moveChannelRight( int index );
+
+	// validate channel's name: if channel has been moved and still has its original name, change the name to fit new position
+	void validateChannelName( int index, int oldIndex );
 
 	// reset a channel's name, fx, sends, etc
 	void clearChannel(fx_ch_t channelIndex);
@@ -139,7 +142,7 @@ private:
 	QVector<FxChannel *> m_fxChannels;
 
 	// make sure we have at least num channels
-	void allocateChannelsTo(int num);
+	void allocateChannelsTo( int num );
 	QMutex m_sendsMutex;
 
 	void addChannelLeaf( int _ch, sampleFrame * _buf );

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -205,7 +205,7 @@ void FxMixer::deleteChannel(int index)
 			}
 		}
 	}
-
+	
 	// delete all of this channel's sends and receives
 	while( ! m_fxChannels[index]->m_sends.isEmpty() )
 	{
@@ -241,6 +241,12 @@ void FxMixer::deleteChannel(int index)
 	// actually delete the channel
 	delete m_fxChannels[index];
 	m_fxChannels.remove(index);
+	
+	// check names of all channels above the removal
+	for( int i = index; i < m_fxChannels.size(); ++i )
+	{
+		validateChannelName( i, i + 1 );
+	}
 }
 
 
@@ -314,6 +320,11 @@ void FxMixer::moveChannelLeft(int index)
 	FxChannel * tmpChannel = m_fxChannels[a];
 	m_fxChannels[a] = m_fxChannels[b];
 	m_fxChannels[b] = tmpChannel;
+	
+	// check names
+	validateChannelName( a, b );
+	validateChannelName( b, a );
+
 	m_sendsMutex.unlock();
 }
 
@@ -324,6 +335,15 @@ void FxMixer::moveChannelRight(int index)
 	moveChannelLeft(index+1);
 }
 
+
+void FxMixer::validateChannelName( int index, int oldIndex )
+{
+	FxChannel * fxc = m_fxChannels[ index ];
+	if( fxc->m_name == tr( "FX %1" ).arg( oldIndex ) )
+	{
+		fxc->m_name = tr( "FX %1" ).arg( index );
+	}
+}
 
 
 void FxMixer::createChannelSend(fx_ch_t fromChannel, fx_ch_t toChannel,


### PR DESCRIPTION
- When a channel is moved, directly or indirectly, check if the name matches the default "FX n" name, and if so, update it to match the new channel index
  Fixes #889
