### PR TITLE
basic_filters: optimize RC highpass & bandpass filters

### DIFF
--- a/include/basic_filters.h
+++ b/include/basic_filters.h
@@ -486,7 +486,7 @@ public:
 			m_rcc = (1.0f/(_freq*2.0f*M_PI)) / ( (1.0f/(_freq*2.0f*M_PI)) + (1.0f/(m_sampleRate*4)) );
 
 			// Stretch Q/resonance, as self-oscillation reliably starts at a q of ~2.5 - ~2.6
-			m_rcq = _q/4.f;
+			m_rcq = _q * 0.25f;
 			return;
 		}
 
@@ -502,7 +502,7 @@ public:
 			static const float freqRatio = 4.0f / 14000.0f;
 
 			// Stretch Q/resonance
-			m_vfq = _q/4.f;
+			m_vfq = _q * 0.25f;
 
 			// frequency in lmms ranges from 1Hz to 14000Hz
 			const float vowelf = _freq * freqRatio;


### PR DESCRIPTION
For both RC12 and RC24 filter types: handle lowpass separately, because we can then calculate highpass & bandpass with less operations.
This shouldn't affect the performance of lowpass, but probably will make highpass and bandpass a bit faster.

Addendum: some further optimizations added after IRC conversations with softrabbit, including some optimizations for the formant filter, and some optimizations to coeff calculations, which should help with modulated filters. 
