### PR TITLE
Backport to 1.0 branch - Fix Zyn GUI hard crash on Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ IF(LMMS_BUILD_WIN32)
 					"${MINGW_PREFIX}/bin/libvorbisenc-2.dll"
 					"${MINGW_PREFIX}/bin/libvorbisfile-3.dll"
 					"${MINGW_PREFIX}/bin/libogg-0.dll"
+					"${MINGW_PREFIX}/lib/libfltk.dll"
 					"${MINGW_PREFIX}/bin/libfluidsynth.dll"
 					"${MINGW_PREFIX}/bin/libfftw3f-3.dll"
 					"${MINGW_PREFIX}/bin/libFLAC-8.dll"


### PR DESCRIPTION
I can't explain why @tobydox doesn't have to do this in his builds but committing to push ahead with 1.0.3
