### PR TITLE
SF2: Make timing more accurate, also some fixes

### DIFF
--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -1246,7 +1246,7 @@ void MonstroInstrument::playNote( NotePlayHandle * _n,
 						sampleFrame * _working_buffer )
 {
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
-	const f_cnt_t offset = _n->offset();
+	const f_cnt_t offset = _n->noteOffset();
 
 	if ( _n->totalFramesPlayed() == 0 || _n->m_pluginData == NULL )
 	{

--- a/plugins/sf2_player/sf2_player.h
+++ b/plugins/sf2_player/sf2_player.h
@@ -45,6 +45,7 @@ class NotePlayHandle;
 class patchesDialog;
 class QLabel;
 
+struct SF2PluginData;
 
 class sf2Instrument : public Instrument
 {
@@ -149,9 +150,14 @@ private:
 	FloatModel m_chorusSpeed;
 	FloatModel m_chorusDepth;
 
+	QVector<NotePlayHandle *> m_playingNotes;
+	QMutex m_playingNotesMutex;
 
 private:
 	void freeFont();
+	void noteOn( SF2PluginData * n );
+	void noteOff( SF2PluginData * n );
+	void renderFrames( f_cnt_t frames, sampleFrame * buf );
 
 	friend class sf2InstrumentView;
 


### PR DESCRIPTION
I'm not saying sample-accurate, because it turns out, Fluidsynth has an internal buffer size and thus timing granularity of 64 frames. So 64 frames is the max. accuracy attainable for SF2. But it's better than nothing. Big thanks to David Henningsson of the Fluidsynth dev team, who very helpfully answered questions. A great guy.
In addition, there are some fixes to earlier commits here, which I ran into while working on the SF2 timing. 
