### PR TITLE
Effect plugins: don't set modified flag on control changes

### DIFF
--- a/plugins/Amplifier/AmplifierControls.cpp
+++ b/plugins/Amplifier/AmplifierControls.cpp
@@ -40,10 +40,10 @@ AmplifierControls::AmplifierControls( AmplifierEffect* effect ) :
 	m_leftModel( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Left gain" ) ),
 	m_rightModel( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Right gain" ) )
 {
-	connect( &m_volumeModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );
+/*	connect( &m_volumeModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );
 	connect( &m_panModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );
 	connect( &m_leftModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );
-	connect( &m_rightModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );
+	connect( &m_rightModel, SIGNAL( dataChanged() ), this, SLOT( changeControl() ) );*/
 }
 
 
@@ -51,7 +51,7 @@ AmplifierControls::AmplifierControls( AmplifierEffect* effect ) :
 
 void AmplifierControls::changeControl()
 {
-	engine::getSong()->setModified();
+//	engine::getSong()->setModified();
 }
 
 

--- a/plugins/dynamics_processor/dynamics_processor_controls.cpp
+++ b/plugins/dynamics_processor/dynamics_processor_controls.cpp
@@ -45,7 +45,7 @@ dynProcControls::dynProcControls( dynProcEffect * _eff ) :
 	m_wavegraphModel( 0.0f, 1.0f, 200, this ),
 	m_stereomodeModel( 0, 0, 2, this, tr( "Stereo mode" ) )
 {
-	connect( &m_inputModel, SIGNAL( dataChanged() ),
+/*	connect( &m_inputModel, SIGNAL( dataChanged() ),
 			this, SLOT( changeControl() ) );
 
 	connect( &m_outputModel, SIGNAL( dataChanged() ),
@@ -59,7 +59,7 @@ dynProcControls::dynProcControls( dynProcEffect * _eff ) :
 			
 	connect( &m_stereomodeModel, SIGNAL( dataChanged() ),
 			this, SLOT( changeControl() ) );
-
+*/
 	connect( &m_wavegraphModel, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( samplesChanged( int, int ) ) );
 
@@ -72,7 +72,7 @@ dynProcControls::dynProcControls( dynProcEffect * _eff ) :
 
 void dynProcControls::changeControl()
 {
-	engine::getSong()->setModified();
+//	engine::getSong()->setModified();
 }
 
 void dynProcControls::samplesChanged( int _begin, int _end)

--- a/plugins/waveshaper/waveshaper_controls.cpp
+++ b/plugins/waveshaper/waveshaper_controls.cpp
@@ -43,7 +43,7 @@ waveShaperControls::waveShaperControls( waveShaperEffect * _eff ) :
 	m_wavegraphModel( 0.0f, 1.0f, 200, this ),
 	m_clipModel( false, this )
 {
-	connect( &m_inputModel, SIGNAL( dataChanged() ),
+/*	connect( &m_inputModel, SIGNAL( dataChanged() ),
 			this, SLOT( changeInput() ) );
 
 	connect( &m_outputModel, SIGNAL( dataChanged() ),
@@ -51,7 +51,7 @@ waveShaperControls::waveShaperControls( waveShaperEffect * _eff ) :
 	
 	connect( &m_clipModel, SIGNAL( dataChanged() ),
 			this, SLOT( changeClip() ) );
-
+*/
 	connect( &m_wavegraphModel, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( samplesChanged( int, int ) ) );
 
@@ -64,17 +64,17 @@ waveShaperControls::waveShaperControls( waveShaperEffect * _eff ) :
 
 void waveShaperControls::changeInput()
 {
-	engine::getSong()->setModified();
+//	engine::getSong()->setModified();
 }
 
 void waveShaperControls::changeOutput()
 {
-	engine::getSong()->setModified();
+//	engine::getSong()->setModified();
 }
 
 void waveShaperControls::changeClip()
 {
-	engine::getSong()->setModified();
+//	engine::getSong()->setModified();
 }
 
 void waveShaperControls::samplesChanged( int _begin, int _end)


### PR DESCRIPTION
Fixing a bit of a silly error made by me, all control changes on my effect plugins were flagging the project as modified, which is annoying with automations etc. So I'm disabling it. Maybe later we can have flagging only when knobs are modified manually.
