### PR TITLE
ProjectJournal: cap the number of undo states to prevent infinite memory...

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef _PROJECT_JOURNAL_H
-#define _PROJECT_JOURNAL_H
+#ifndef PROJECT_JOURNAL_H
+#define PROJECT_JOURNAL_H
 
 #include <QtCore/QHash>
 #include <QtCore/QStack>
@@ -37,6 +37,8 @@ class JournallingObject;
 class ProjectJournal
 {
 public:
+	static const int MAX_UNDO_STATES;
+
 	ProjectJournal();
 	virtual ~ProjectJournal();
 
@@ -88,7 +90,7 @@ private:
 
 	struct CheckPoint
 	{
-		CheckPoint( jo_id_t initID = 0, const DataFile&initData = DataFile( DataFile::JournalData ) ) :
+		CheckPoint( jo_id_t initID = 0, const DataFile& initData = DataFile( DataFile::JournalData ) ) :
 			joID( initID ),
 			data( initData )
 		{

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -29,6 +29,7 @@
 #include "JournallingObject.h"
 #include "song.h"
 
+const int ProjectJournal::MAX_UNDO_STATES = 100; // TODO: make this configurable in settings
 
 ProjectJournal::ProjectJournal() :
 	m_joIDs(),
@@ -109,6 +110,10 @@ void ProjectJournal::addJournalCheckPoint( JournallingObject *jo )
 		jo->saveState( dataFile, dataFile.content() );
 
 		m_undoCheckPoints.push( CheckPoint( jo->id(), dataFile ) );
+		if( m_undoCheckPoints.size() > MAX_UNDO_STATES )
+		{
+			m_undoCheckPoints.remove( 0, m_undoCheckPoints.size() - MAX_UNDO_STATES );
+		}
 	}
 }
 
@@ -120,7 +125,7 @@ jo_id_t ProjectJournal::allocID( JournallingObject * _obj )
 	const jo_id_t EO_ID_MAX = (1 << 23)-1;
 	jo_id_t id;
 	while( m_joIDs.contains( id =
-			static_cast<jo_id_t>( (jo_id_t)rand()*(jo_id_t)rand() % 
+			static_cast<jo_id_t>( (jo_id_t)rand()*(jo_id_t)rand() %
 								 EO_ID_MAX ) ) )
 	{
 	}


### PR DESCRIPTION
... buildup

The cap is hardcoded to 100 for now, TODO: make this number configurable (or even better: use a max. memory amount instead of max number of states)
