### PR TITLE
Sanitize master output

### DIFF
--- a/include/MixHelpers.h
+++ b/include/MixHelpers.h
@@ -39,6 +39,8 @@ void add( sampleFrame* dst, const sampleFrame* src, int frames );
 /*! \brief Add samples from src multiplied by coeffSrc to dst */
 void addMultiplied( sampleFrame* dst, const sampleFrame* src, float coeffSrc, int frames );
 
+/*! \brief Same as addMultiplied, but sanitize output (strip out infs/nans) */
+void addSanitizedMultiplied( sampleFrame* dst, const sampleFrame* src, float coeffSrc, int frames );
 
 /*! \brief Add samples from src multiplied by coeffSrcLeft/coeffSrcRight to dst */
 void addMultipliedStereo( sampleFrame* dst, const sampleFrame* src, float coeffSrcLeft, float coeffSrcRight, int frames );

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -506,7 +506,7 @@ void FxMixer::masterMix( sampleFrame * _buf )
 	//m_sendsMutex.unlock();
 
 	const float v = m_fxChannels[0]->m_volumeModel.value();
-	MixHelpers::addMultiplied( _buf, m_fxChannels[0]->m_buffer, v, fpp );
+	MixHelpers::addSanitizedMultiplied( _buf, m_fxChannels[0]->m_buffer, v, fpp );
 
 	m_fxChannels[0]->m_peakLeft *= engine::mixer()->masterGain();
 	m_fxChannels[0]->m_peakRight *= engine::mixer()->masterGain();

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -22,8 +22,7 @@
  *
  */
 
-#include <math.h>
-
+#include "lmms_math.h"
 #include "MixHelpers.h"
 
 
@@ -102,6 +101,26 @@ struct AddMultipliedOp
 void addMultiplied( sampleFrame* dst, const sampleFrame* src, float coeffSrc, int frames )
 {
 	run<>( dst, src, frames, AddMultipliedOp(coeffSrc) );
+}
+
+
+
+struct AddSanitizedMultipliedOp
+{
+	AddSanitizedMultipliedOp( float coeff ) : m_coeff( coeff ) { }
+	
+	void operator()( sampleFrame& dst, const sampleFrame& src ) const
+	{
+		dst[0] += ( isinff( src[0] ) || isnanf( src[0] ) ) ? 0.0f : src[0] * m_coeff;
+		dst[1] += ( isinff( src[1] ) || isnanf( src[1] ) ) ? 0.0f : src[1] * m_coeff;
+	}
+
+	const float m_coeff;
+};
+
+void addSanitizedMultiplied( sampleFrame* dst, const sampleFrame* src, float coeffSrc, int frames )
+{
+	run<>( dst, src, frames, AddSanitizedMultipliedOp(coeffSrc) );
 }
 
 


### PR DESCRIPTION
Replace any inf/nan in master output with zero, to prevent corrupted files/audio.
