### PR TITLE
Add "clear track" option, fix copying of tracks from song ed -> bb ed

### DIFF
--- a/include/bb_editor.h
+++ b/include/bb_editor.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef _BB_EDITOR_H
-#define _BB_EDITOR_H
+#ifndef BB_EDITOR_H
+#define BB_EDITOR_H
 
 #include "TrackContainerView.h"
 
@@ -45,6 +45,8 @@ public:
 	{
 		return( true );
 	}
+	
+	virtual void dropEvent( QDropEvent * _de );
 
 	void removeBBView( int _bb );
 

--- a/include/track.h
+++ b/include/track.h
@@ -349,6 +349,7 @@ private slots:
 	void updateMenu();
 	void recordingOn();
 	void recordingOff();
+	void clearTrack();
 
 private:
 	static QPixmap * s_grip;
@@ -431,6 +432,7 @@ public:
 	trackContentObject * addTCO( trackContentObject * _tco );
 	void removeTCO( trackContentObject * _tco );
 	// -------------------------------------------------------
+	void deleteTCOs();
 
 	int numOfTCOs();
 	trackContentObject * getTCO( int _tco_num );

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -1405,6 +1405,14 @@ void trackOperationsWidget::cloneTrack()
 }
 
 
+/*! \brief Clear this track - clears all TCOs from the track */
+void trackOperationsWidget::clearTrack()
+{
+	engine::mixer()->lock();
+	m_trackView->getTrack()->deleteTCOs();
+	engine::mixer()->unlock();
+}
+
 
 
 /*! \brief Remove this track from the track list
@@ -1436,6 +1444,11 @@ void trackOperationsWidget::updateMenu()
 	to_menu->addAction( embed::getIconPixmap( "cancel", 16, 16 ),
 						tr( "Remove this track" ),
 						this, SLOT( removeTrack() ) );
+						
+	if( ! m_trackView->trackContainerView()->fixedTCOs() )
+	{
+		to_menu->addAction( tr( "Clear this track" ), this, SLOT( clearTrack() ) );
+	}
 
 	if( dynamic_cast<InstrumentTrackView *>( m_trackView ) )
 	{
@@ -1773,6 +1786,14 @@ void track::removeTCO( trackContentObject * _tco )
 }
 
 
+/*! \brief Remove all TCOs from this track */
+void track::deleteTCOs()
+{
+	while( ! m_trackContentObjects.isEmpty() )
+	{
+		delete m_trackContentObjects.first();
+	}
+}
 
 
 /*! \brief Return the number of trackContentObjects we contain

--- a/src/gui/bb_editor.cpp
+++ b/src/gui/bb_editor.cpp
@@ -35,6 +35,8 @@
 #include "song.h"
 #include "tool_button.h"
 #include "config_mgr.h"
+#include "DataFile.h"
+#include "string_pair_drag.h"
 
 #include "TrackContainer.h"
 #include "pattern.h"
@@ -157,6 +159,26 @@ bbEditor::~bbEditor()
 }
 
 
+void bbEditor::dropEvent( QDropEvent * de )
+{
+	QString type = stringPairDrag::decodeKey( de );
+	QString value = stringPairDrag::decodeValue( de );
+	
+	if( type.left( 6 ) == "track_" )
+	{
+		DataFile dataFile( value.toUtf8() );
+		track * t = track::create( dataFile.content().firstChild().toElement(), model() );
+		
+		t->deleteTCOs();
+		m_bbtc->updateAfterTrackAdd();
+		
+		de->accept();
+	}
+	else
+	{
+		TrackContainerView::dropEvent( de );
+	}
+}
 
 
 void bbEditor::removeBBView( int _bb )


### PR DESCRIPTION
- Tracks copied from song->bb will no longer be unusable
- Since doing this required creating a "delete TCOs from track" function, I also added the option to trackops menu to clear a track
  Fix #757
