### PR TITLE
Change redo shortcut from ctrl-r to ctrl-y

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -286,7 +286,7 @@ void MainWindow::finalize()
 	edit_menu->addAction( embed::getIconPixmap( "edit_redo" ),
 					tr( "Redo" ),
 					this, SLOT( redo() ),
-					Qt::CTRL + Qt::Key_R );
+					Qt::CTRL + Qt::Key_Y );
 	edit_menu->addSeparator();
 	edit_menu->addAction( embed::getIconPixmap( "setup_general" ),
 					tr( "Settings" ),


### PR DESCRIPTION
Ctrl-y is more standard and used in many applications, ctrl-r is used pretty much nowhere.
