### PR TITLE
AFP improvements

### DIFF
--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -999,13 +999,14 @@ void AudioFileProcessorWaveView::updateGraph()
 	{
 		reverse();
 	}
-	else if( m_last_from == m_from && m_last_to == m_to )
+	else if( m_last_from == m_from && m_last_to == m_to && m_sampleBuffer.amplification() == m_last_amp )
 	{
 		return;
 	}
 
 	m_last_from = m_from;
 	m_last_to = m_to;
+	m_last_amp = m_sampleBuffer.amplification();
 
 	m_graph.fill( Qt::transparent );
 	QPainter p( &m_graph );

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -239,6 +239,7 @@ private:
 	f_cnt_t m_to;
 	f_cnt_t m_last_from;
 	f_cnt_t m_last_to;
+	float m_last_amp;
 	knob * m_startKnob;
 	knob * m_endKnob;
 	knob * m_loopKnob;

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -915,7 +915,7 @@ void SampleBuffer::visualize( QPainter & _p, const QRect & _dr,
 	const int h = _dr.height();
 
 	const int yb = h / 2 + _dr.y();
-	const float y_space = h*0.25f;
+	const float y_space = h*0.5f;
 	const int nb_frames = focus_on_range ? _to_frame - _from_frame : m_frames;
 
 	if( nb_frames < 60000 )
@@ -1381,7 +1381,7 @@ void SampleBuffer::setEndFrame( const f_cnt_t _e )
 void SampleBuffer::setAmplification( float _a )
 {
 	m_amplification = _a;
-	update( true );
+	emit sampleUpdated();
 }
 
 


### PR DESCRIPTION
- Stop pointlessly reloading the sample everytime the amp knob is changed
- Also draw the amplitude of the waveform correctly (used to be it was drawn as 2x too "quiet")
