### PR TITLE
Allow uppercase letters in ladspa file names

### DIFF
--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -158,7 +158,7 @@ void LadspaSubPluginFeatures::listSubPluginKeys(
 ladspa_key_t LadspaSubPluginFeatures::subPluginKeyToLadspaKey(
 							const Key * _key )
 {
-	QString file = _key->attributes["file"].toLower();
+	QString file = _key->attributes["file"];
 	return( ladspa_key_t( file.remove( QRegExp( "\\.so$" ) ).
 				remove( QRegExp( "\\.dll$" ) ) +
 #ifdef LMMS_BUILD_WIN32


### PR DESCRIPTION
Per #1041

Tested against unfa-spoken.mmpz (uses dozens of LADSPA effects).
