### PR TITLE
FileDialog: Add `/Volume` directory on OS X

### DIFF
--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -52,11 +52,13 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 	urls << QUrl::fromLocalFile( QDesktopServices::storageLocation( QDesktopServices::MusicLocation ) );
 	urls << QUrl::fromLocalFile( configManager::inst()->workingDir() );
 
-	#ifdef LMMS_BUILD_APPLE
-		QDir volumesDir( QDir("/Volumes") );
-		if ( volumesDir.exists() )
-			urls << volumesDir;
-	#endif
+	// Add `/Volumes` directory on OS X systems, this allows the user to browse
+	// external disk drives.
+#ifdef LMMS_BUILD_APPLE
+	QDir volumesDir( QDir("/Volumes") );
+	if ( volumesDir.exists() )
+		urls << QUrl::fromLocalFile( volumesDir.absolutePath() );
+#endif
 
 	setSidebarUrls(urls);
 }


### PR DESCRIPTION
Closes #1058

Better someone test this out on his Mac, because I don't even have one.
