### PR TITLE
Win64 fix for missing _isnanf

### DIFF
--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -40,6 +40,12 @@
 #ifndef isinff
 #define isinff(x)	isinf(x)
 #endif
+#ifndef _isnanf
+#define _isnanf(x) isnan(x)
+#endif
+#ifndef _isinff
+#define _isinff(x) isinf(x)
+#endif
 #endif
 
 #ifdef __INTEL_COMPILER


### PR DESCRIPTION
Per discussion in #1108, mingw64 seems to erroneously add an underscore to `isnanf` function calls.  This fix prevents a crash of `unimplemented function msvcrt.dll._isnanf` when running the 64-bit build in Wine.

This potential bug was discovered while troubleshooting a win64 crash with vesa's new `memmgr` branch slated for the 1.2 release.
