### PR TITLE
More Presets

### DIFF
--- a/data/presets/LB302/AcidLead.xpf
+++ b/data/presets/LB302/AcidLead.xpf
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Acid Lead" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="45" vol="66">
+      <instrument name="lb302">
+        <lb302 db24="0" vcf_res="1.25" vcf_dec="0.26" dead="0" vcf_cut="0.2" vcf_mod="0.27" dist="1" slide_dec="0.19" slide="0" shape="5"/>
+      </instrument>
+      <eldata fres="9.6" ftype="7" fcut="3360" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="1" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="10">
+            <port04 data="144.113"/>
+            <port05 data="16"/>
+            <port06 data="8"/>
+            <port07 data="8"/>
+            <port08 data="0.5"/>
+            <port09 data="0.39"/>
+            <port010 data="2"/>
+            <port011 data="1"/>
+            <port012 data="1"/>
+            <port013 data="1"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="calf" name="file"/>
+            <attribute value="VintageDelay" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/LB302/AngryLead.xpf
+++ b/data/presets/LB302/AngryLead.xpf
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Angry Lead" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="100">
+      <instrument name="lb302">
+        <lb302 db24="0" vcf_res="0.765" vcf_dec="0.28" dead="1" vcf_cut="0.615" vcf_mod="0.27" dist="0.08" slide_dec="0.575" slide="1" shape="4"/>
+      </instrument>
+      <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
+      <fxchain numofeffects="1" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="4">
+            <port02 data="0.99897"/>
+            <port03 data="0.14231"/>
+            <port04 data="0.9995"/>
+            <port05 data="0.14625"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="Plate2x2" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/LB302/DroneArp.xpf
+++ b/data/presets/LB302/DroneArp.xpf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Drone Arp" solo="0">
+    <instrumenttrack pan="0" fxch="1" pitchrange="1" pitch="0" basenote="69" vol="100">
+      <instrument name="lb302">
+        <lb302 db24="1" vcf_res="0.37" vcf_dec="0.11" dead="0" vcf_cut="0.585" vcf_mod="0.33" dist="0.24" slide_dec="0.6" slide="0" shape="11"/>
+      </instrument>
+      <eldata fres="0.01" ftype="0" fcut="1681" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="1" x100="0" att="0" lpdel="0" hold="0.07" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="117" arprange="2" arptime_denominator="4" syncmode="6" arpmode="1" arp-enabled="1" arp="0" arptime_numerator="4" arpdir="2" arpgate="20"/>
+      <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="1"/>
+      <fxchain numofeffects="0" enabled="0"/>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/Organic/Pwnage.xpf
+++ b/data/presets/Organic/Pwnage.xpf
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Pwnage" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="100">
+      <instrument name="organic">
+        <organic newdetune0="0" newdetune1="0" newdetune2="0" newdetune3="0" newdetune4="0" newdetune5="0" newdetune6="0" newdetune7="0" vol0="97" vol1="84" vol2="93" vol3="20" vol4="25" vol5="52" wavetype0="3" vol6="3" wavetype1="0" wavetype2="4" vol7="69" num_osc="8" wavetype3="4" wavetype4="0" wavetype5="2" wavetype6="2" pan0="0" wavetype7="1" pan1="0" foldback="0" pan2="0" pan3="0" pan4="0" pan5="0" pan6="0" pan7="0" newharmonic0="0" newharmonic1="1" newharmonic2="2" newharmonic3="3" newharmonic4="4" newharmonic5="5" newharmonic6="6" newharmonic7="7" vol="100"/>
+      </instrument>
+      <eldata fres="0.66" ftype="6" fcut="11836" fwet="1">
+        <elvol lspd_denominator="4" sustain="0.762" pdel="0" userwavefile="" dec="2" lamt="0" syncmode="0" latt="0" rel="0.181" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.215" pdel="0" userwavefile="" dec="0.58" lamt="0" syncmode="0" latt="0" rel="0.1" amt="1" x100="0" att="0.035" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
+      <fxchain numofeffects="6" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="14">
+            <port01 link="1" data="2.8775"/>
+            <port02 link="1" data="0.999975"/>
+            <port03 link="1" data="-2.8"/>
+            <port04 link="1" data="7.7"/>
+            <port05 link="1" data="12.1"/>
+            <port06 link="1" data="8.4"/>
+            <port07 link="1" data="0.9999"/>
+            <port11 data="2.8775"/>
+            <port12 data="0.999975"/>
+            <port13 data="-2.8"/>
+            <port14 data="7.7"/>
+            <port15 data="12.1"/>
+            <port16 data="8.4"/>
+            <port17 data="0.9999"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="AmpIV" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="20">
+            <port00 link="1" data="1"/>
+            <port01 link="1" data="0.025"/>
+            <port02 link="1" data="0"/>
+            <port03 link="1" data="0"/>
+            <port04 link="1" data="0.4"/>
+            <port05 link="1" data="0"/>
+            <port06 link="1" data="0"/>
+            <port07 link="1" data="-0.025"/>
+            <port08 link="1" data="0"/>
+            <port09 link="1" data="-1"/>
+            <port10 data="1"/>
+            <port11 data="0.025"/>
+            <port12 data="0"/>
+            <port13 data="0"/>
+            <port14 data="0.4"/>
+            <port15 data="0"/>
+            <port16 data="0"/>
+            <port17 data="-0.025"/>
+            <port18 data="0"/>
+            <port19 data="-1"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="harmonic_gen_1220" name="file"/>
+            <attribute value="harmonicGen" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="6">
+            <port00 link="1" data="-9.375"/>
+            <port01 link="1" data="1"/>
+            <port02 link="1" data="0"/>
+            <port10 data="-9.375"/>
+            <port11 data="1"/>
+            <port12 data="0"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="hard_limiter_1413" name="file"/>
+            <attribute value="hardLimiter" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="10">
+            <port02 data="-47.97"/>
+            <port03 data="-47.97"/>
+            <port04 data="9.9"/>
+            <port05 data="-4.32"/>
+            <port06 data="0"/>
+            <port07 data="-2.88"/>
+            <port08 data="-3.06"/>
+            <port09 data="-16.02"/>
+            <port010 data="-12.78"/>
+            <port011 data="-10.8"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="Eq2x2" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="6">
+            <port00 link="1" data="-6.625"/>
+            <port01 link="1" data="1"/>
+            <port02 link="1" data="0"/>
+            <port10 data="-6.625"/>
+            <port11 data="1"/>
+            <port12 data="0"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="hard_limiter_1413" name="file"/>
+            <attribute value="hardLimiter" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="0" ports="20">
+            <port01 link="1" data="-47.97"/>
+            <port02 link="1" data="-35.28"/>
+            <port03 link="1" data="0"/>
+            <port04 link="1" data="-9"/>
+            <port05 link="1" data="-8.46"/>
+            <port06 link="1" data="3.06"/>
+            <port07 link="0" data="-5.04"/>
+            <port08 link="0" data="5.04"/>
+            <port09 link="0" data="-5.04"/>
+            <port010 link="0" data="5.04"/>
+            <port11 data="-47.97"/>
+            <port12 data="-35.28"/>
+            <port13 data="0"/>
+            <port14 data="-9"/>
+            <port15 data="-8.46"/>
+            <port16 data="3.06"/>
+            <port17 data="5.04"/>
+            <port18 data="-5.04"/>
+            <port19 data="5.04"/>
+            <port110 data="-5.04"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="Eq" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/Organic/Rubberband.xpf
+++ b/data/presets/Organic/Rubberband.xpf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Rubberband" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="69" vol="150">
+      <instrument name="organic">
+        <organic newdetune0="0" newdetune1="0" newdetune2="0" newdetune3="0" newdetune4="0" newdetune5="0" newdetune6="0" newdetune7="0" vol0="100" vol1="92" vol2="67" vol3="35" vol4="15" vol5="3" wavetype0="5" vol6="6" wavetype1="4" wavetype2="2" vol7="0" num_osc="8" wavetype3="1" wavetype4="3" wavetype5="0" wavetype6="0" pan0="0" wavetype7="0" pan1="0" foldback="0.34" pan2="0" pan3="0" pan4="0" pan5="0" pan6="0" pan7="0" newharmonic0="0" newharmonic1="1" newharmonic2="2" newharmonic3="3" newharmonic4="4" newharmonic5="5" newharmonic6="6" newharmonic7="7" vol="100"/>
+      </instrument>
+      <eldata fres="3.6" ftype="0" fcut="14000" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.57" lamt="0" syncmode="0" latt="0" rel="0.11" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="2" chord-enabled="1"/>
+      <arpeggiator arptime="250" arprange="2" arptime_denominator="4" syncmode="0" arpmode="1" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="32"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="0" enabled="0"/>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/Bass.xpf
+++ b/data/presets/SID/Bass.xpf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Bass" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="150">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="0" attack0="1" attack1="2" attack2="0" filterFC="1024" chipModel="1" decay0="8" decay1="8" decay2="0" volume="15" filtered0="0" filterResonance="8" filtered1="0" sustain0="6" filtered2="0" sustain1="0" sustain2="5" waveform0="2" ringmod0="0" waveform1="1" ringmod1="0" waveform2="2" ringmod2="0" filterMode="2" test0="0" test1="1" test2="1" coarse0="-12" coarse1="0" coarse2="0" release0="6" release1="7" release2="5" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="2048"/>
+      </instrument>
+      <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.46" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="0" enabled="0"/>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/CheesyGuitar.xpf
+++ b/data/presets/SID/CheesyGuitar.xpf
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="CheesyGuitar" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="100">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="1" attack0="0" attack1="0" attack2="8" filterFC="1024" chipModel="1" decay0="8" decay1="7" decay2="8" volume="15" filtered0="0" filterResonance="8" filtered1="0" sustain0="15" filtered2="0" sustain1="15" sustain2="15" waveform0="2" ringmod0="0" waveform1="0" ringmod1="0" waveform2="1" ringmod2="0" filterMode="2" test0="0" test1="0" test2="0" coarse0="0" coarse1="0" coarse2="0" release0="8" release1="8" release2="8" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="2048"/>
+      </instrument>
+      <eldata fres="5.31" ftype="14" fcut="1611" fwet="1">
+        <elvol lspd_denominator="4" sustain="0.664" pdel="0" userwavefile="" dec="0.38" lamt="0" syncmode="0" latt="0" rel="0.431" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="1" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="1" amt="1" x100="0" att="0.665" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="2" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="1">
+            <port00 data="5.4625"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="cmt" name="file"/>
+            <attribute value="amp_stereo" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="6">
+            <port00 link="1" data="-12.625"/>
+            <port01 link="1" data="1"/>
+            <port02 link="1" data="0"/>
+            <port10 data="-12.625"/>
+            <port11 data="1"/>
+            <port12 data="0"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="hard_limiter_1413" name="file"/>
+            <attribute value="hardLimiter" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/Lead.xpf
+++ b/data/presets/SID/Lead.xpf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Lead" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="100">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="0" attack0="0" attack1="0" attack2="0" filterFC="1782" chipModel="1" decay0="8" decay1="8" decay2="8" volume="15" filtered0="0" filterResonance="0" filtered1="0" sustain0="15" filtered2="0" sustain1="15" sustain2="15" waveform0="1" ringmod0="1" waveform1="1" ringmod1="0" waveform2="2" ringmod2="0" filterMode="2" test0="0" test1="0" test2="0" coarse0="0" coarse1="12" coarse2="0" release0="8" release1="8" release2="8" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="0"/>
+      </instrument>
+      <eldata fres="3.01" ftype="4" fcut="217" fwet="1">
+        <elvol lspd_denominator="4" sustain="0.636" pdel="0" userwavefile="" dec="0.416" lamt="0" syncmode="0" latt="0" rel="0.1" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0" pdel="0" userwavefile="" dec="1.361" lamt="0" syncmode="0" latt="0" rel="0.1" amt="1" x100="0" att="1.359" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="3" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="2" arpgate="49"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
+      <fxchain numofeffects="0" enabled="0"/>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/MadMind.xpf
+++ b/data/presets/SID/MadMind.xpf
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Mad Mind" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="83">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="1" attack0="0" attack1="0" attack2="8" filterFC="1024" chipModel="1" decay0="8" decay1="7" decay2="8" volume="15" filtered0="0" filterResonance="8" filtered1="0" sustain0="15" filtered2="0" sustain1="15" sustain2="15" waveform0="2" ringmod0="0" waveform1="0" ringmod1="0" waveform2="1" ringmod2="0" filterMode="2" test0="0" test1="0" test2="0" coarse0="0" coarse1="0" coarse2="0" release0="8" release1="8" release2="8" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="2048"/>
+      </instrument>
+      <eldata fres="4.63" ftype="14" fcut="1611" fwet="1">
+        <elvol lspd_denominator="4" sustain="0.581" pdel="0" userwavefile="" dec="0.357" lamt="0" syncmode="0" latt="0" rel="0.276" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="1" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="1" amt="1" x100="0" att="0.665" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.426" pdel="0" userwavefile="" dec="1" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0.625" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="1" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="1" arp="5" arptime_numerator="4" arpdir="3" arpgate="36"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="3" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="1">
+            <port00 data="5.4625"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="cmt" name="file"/>
+            <attribute value="amp_stereo" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="6">
+            <port00 link="1" data="-12.625"/>
+            <port01 link="1" data="1"/>
+            <port02 link="1" data="0"/>
+            <port10 data="-12.625"/>
+            <port11 data="1"/>
+            <port12 data="0"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="hard_limiter_1413" name="file"/>
+            <attribute value="hardLimiter" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="4">
+            <port02 data="0.50197"/>
+            <port03 data="0.3745"/>
+            <port04 data="0.249875"/>
+            <port05 data="0.25"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="Plate2x2" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/Overdrive.xpf
+++ b/data/presets/SID/Overdrive.xpf
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Overdrive" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="24" pitch="0" basenote="57" vol="100">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="1" attack0="0" attack1="0" attack2="8" filterFC="1096" chipModel="1" decay0="8" decay1="8" decay2="8" volume="15" filtered0="0" filterResonance="8" filtered1="0" sustain0="15" filtered2="0" sustain1="15" sustain2="15" waveform0="2" ringmod0="0" waveform1="1" ringmod1="0" waveform2="1" ringmod2="0" filterMode="2" test0="0" test1="0" test2="0" coarse0="0" coarse1="0" coarse2="0" release0="8" release1="8" release2="8" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="2048"/>
+      </instrument>
+      <eldata fres="5.92" ftype="14" fcut="6896" fwet="1">
+        <elvol lspd_denominator="4" sustain="0.439" pdel="0" userwavefile="" dec="0.509" lamt="0" syncmode="0" latt="0" rel="0.44" amt="1" x100="0" att="0" lpdel="0" hold="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="1" pdel="0" userwavefile="" dec="0" lamt="0" syncmode="0" latt="0" rel="1" amt="1" x100="0" att="0.891" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="3" enabled="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="1">
+            <port00 data="10"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="cmt" name="file"/>
+            <attribute value="amp_stereo" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols link="1" ports="6">
+            <port00 link="1" data="-14"/>
+            <port01 link="1" data="1"/>
+            <port02 link="1" data="0"/>
+            <port10 data="-14"/>
+            <port11 data="1"/>
+            <port12 data="0"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="hard_limiter_1413" name="file"/>
+            <attribute value="hardLimiter" name="plugin"/>
+          </key>
+        </effect>
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+          <ladspacontrols ports="4">
+            <port02 data="0.99897"/>
+            <port03 data="0.279003"/>
+            <port04 data="0.249875"/>
+            <port05 data="0.25"/>
+          </ladspacontrols>
+          <key>
+            <attribute value="caps" name="file"/>
+            <attribute value="Plate2x2" name="plugin"/>
+          </key>
+        </effect>
+      </fxchain>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>

--- a/data/presets/SID/Pad.xpf
+++ b/data/presets/SID/Pad.xpf
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE lmms-project>
+<lmms-project version="1.0" creator="LMMS" creatorversion="1.0.93" type="instrumenttracksettings">
+  <head/>
+  <instrumenttracksettings muted="0" type="0" name="Pad" solo="0">
+    <instrumenttrack pan="0" fxch="0" pitchrange="1" pitch="0" basenote="57" vol="59.8">
+      <instrument name="sid">
+        <sid sync0="0" sync1="0" sync2="0" voice3Off="1" attack0="2" attack1="8" attack2="4" filterFC="1024" chipModel="1" decay0="8" decay1="8" decay2="0" volume="15" filtered0="0" filterResonance="8" filtered1="0" sustain0="14" filtered2="0" sustain1="12" sustain2="1" waveform0="1" ringmod0="0" waveform1="2" ringmod1="0" waveform2="3" ringmod2="0" filterMode="2" test0="0" test1="0" test2="0" coarse0="0" coarse1="0" coarse2="0" release0="5" release1="7" release2="0" pulsewidth0="2048" pulsewidth1="2048" pulsewidth2="2048"/>
+      </instrument>
+      <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
+        <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+        <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" syncmode="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+      </eldata>
+      <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
+      <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
+      <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
+      <fxchain numofeffects="0" enabled="0"/>
+    </instrumenttrack>
+  </instrumenttracksettings>
+</lmms-project>


### PR DESCRIPTION
As requested, here are presets for instruments with no so many presets. I can make more is more are needed.

LB302:
  `AcidLead`
  `AngryLead`
  `DroneArp`
Organic:
  `Pwnage`
  `Rubberband`
SID:
  `Bass`
   `CheesyGuitar`
  `Lead`
  `MadMind`
  `Overdrive`
  `Pad`

No presets of any kind were removed or otherwise changed.
