### PR TITLE
Fix for doubleclick knob bug

### DIFF
--- a/include/JournallingObject.h
+++ b/include/JournallingObject.h
@@ -50,7 +50,7 @@ public:
 
 	void restoreJournallingState()
 	{
-		if( !isJournallingStackEmpty()) 
+		if( !isJournallingStateStackEmpty()) 
 		{
 			m_journalling = m_journallingStateStack.pop();
 		}
@@ -80,7 +80,7 @@ public:
 		return oldJournalling;
 	}
 
-	inline bool isJournallingStackEmpty() const
+	bool isJournallingStateStackEmpty() const
 	{
 		return m_journallingStateStack.isEmpty();
 	}


### PR DESCRIPTION
This fix adds an 'isEmpty' method to the JournallingObject class, and then checks this method when the mouse button is released, so as not to pop an empty stack.
