### PR TITLE
Fix for piano roll bug (1.0.93 - Play is silent inside piano-roll #1110)

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -199,18 +199,6 @@ public:
 	/*! Returns whether given NotePlayHandle instance is equal to *this */
 	bool operator==( const NotePlayHandle & _nph ) const;
 
-	/*! Returns whether NotePlayHandle belongs to BB track and BB track is muted */
-	bool isBbTrackMuted()
-	{
-		return m_bbTrack && m_bbTrack->isMuted();
-	}
-
-	/*! Sets attached BB track */
-	void setBBTrack( track* t )
-	{
-		m_bbTrack = t;
-	}
-
 	/*! Process note detuning automation */
 	void processMidiTime( const MidiTime& time );
 
@@ -270,7 +258,6 @@ private:
 	bool m_hasParent;
 	bool m_hadChildren;
 	bool m_muted;							// indicates whether note is muted
-	track* m_bbTrack;						// related BB track
 
 	// tempo reaction
 	bpm_t m_origTempo;						// original tempo

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -29,7 +29,6 @@
 #include "SampleBuffer.h"
 #include "AutomatableModel.h"
 
-class bbTrack;
 class SampleTCO;
 class track;
 class AudioPort;
@@ -64,11 +63,6 @@ public:
 		m_doneMayReturnTrue = _enable;
 	}
 
-	void setBBTrack( bbTrack * _bb_track )
-	{
-		m_bbTrack = _bb_track;
-	}
-
 	void setVolumeModel( FloatModel * _model )
 	{
 		m_volumeModel = _model;
@@ -88,8 +82,6 @@ private:
 	FloatModel m_defaultVolumeModel;
 	FloatModel * m_volumeModel;
 	track * m_track;
-
-	bbTrack * m_bbTrack;
 
 } ;
 

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -66,7 +66,6 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 	m_hasParent( parent != NULL  ),
 	m_hadChildren( false ),
 	m_muted( false ),
-	m_bbTrack( NULL ),
 	m_origTempo( engine::getSong()->getTempo() ),
 	m_origBaseNote( instrumentTrack->baseNote() ),
 	m_frequency( 0 ),
@@ -87,8 +86,6 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 
 		parent->m_subNotes.push_back( this );
 		parent->m_hadChildren = true;
-
-		m_bbTrack = parent->m_bbTrack;
 	}
 
 	updateFrequency();
@@ -333,7 +330,7 @@ fpp_t NotePlayHandle::framesLeftForCurrentPeriod() const
 
 bool NotePlayHandle::isFromTrack( const track * _track ) const
 {
-	return m_instrumentTrack == _track || m_bbTrack == _track;
+	return m_instrumentTrack == _track;
 }
 
 

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -24,7 +24,6 @@
 
 #include "SamplePlayHandle.h"
 #include "AudioPort.h"
-#include "bb_track.h"
 #include "engine.h"
 #include "InstrumentTrack.h"
 #include "pattern.h"
@@ -42,8 +41,7 @@ SamplePlayHandle::SamplePlayHandle( const QString& sampleFile ) :
 	m_ownAudioPort( true ),
 	m_defaultVolumeModel( DefaultVolume, MinVolume, MaxVolume, 1 ),
 	m_volumeModel( &m_defaultVolumeModel ),
-	m_track( NULL ),
-	m_bbTrack( NULL )
+	m_track( NULL )
 {
 }
 
@@ -59,8 +57,7 @@ SamplePlayHandle::SamplePlayHandle( SampleBuffer* sampleBuffer ) :
 	m_ownAudioPort( true ),
 	m_defaultVolumeModel( DefaultVolume, MinVolume, MaxVolume, 1 ),
 	m_volumeModel( &m_defaultVolumeModel ),
-	m_track( NULL ),
-	m_bbTrack( NULL )
+	m_track( NULL )
 {
 }
 
@@ -76,8 +73,7 @@ SamplePlayHandle::SamplePlayHandle( SampleTCO* tco ) :
 	m_ownAudioPort( false ),
 	m_defaultVolumeModel( DefaultVolume, MinVolume, MaxVolume, 1 ),
 	m_volumeModel( &m_defaultVolumeModel ),
-	m_track( tco->getTrack() ),
-	m_bbTrack( NULL )
+	m_track( tco->getTrack() )
 {
 }
 
@@ -105,8 +101,7 @@ void SamplePlayHandle::play( sampleFrame * _working_buffer )
 	}
 
 	const fpp_t frames = engine::mixer()->framesPerPeriod();
-	if( !( m_track && m_track->isMuted() )
-				&& !( m_bbTrack && m_bbTrack->isMuted() ) )
+	if( !( m_track && m_track->isMuted() ) )
 	{
 		stereoVolumeVector v =
 			{ { m_volumeModel->value() / DefaultVolume,
@@ -133,7 +128,7 @@ bool SamplePlayHandle::isFinished() const
 
 bool SamplePlayHandle::isFromTrack( const track * _track ) const
 {
-	return m_track == _track || m_bbTrack == _track;
+	return m_track == _track;
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -157,7 +157,7 @@ InstrumentTrack::~InstrumentTrack()
 void InstrumentTrack::processAudioBuffer( sampleFrame* buf, const fpp_t frames, NotePlayHandle* n )
 {
 	// we must not play the sound if this InstrumentTrack is muted...
-	if( isMuted() || ( n && n->isBbTrackMuted() ) )
+	if( isMuted() )
 	{
 		return;
 	}


### PR DESCRIPTION
Do not set the bbtrack for a note handle by searching for a bbtrack by tco_num. The bbtrack index and tco_num are unrelated.
