### PR TITLE
Removed the deprecated "Linux Multimedia Studio" name

### DIFF
--- a/src/gui/dialogs/about_dialog.ui
+++ b/src/gui/dialogs/about_dialog.ui
@@ -43,7 +43,7 @@
           <string notr="true" >font:12pt; font-weight:bold;</string>
          </property>
          <property name="text" >
-          <string>LMMS (Linux MultiMedia Studio)</string>
+          <string>LMMS</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Modified line 46 according to https://github.com/LMMS/lmms/issues/1209
