### PR TITLE
New filters: SV Lowpass, SV Bandpass, SV Highpass, DoubleMoog

### DIFF
--- a/plugins/DualFilter/DualFilterControls.cpp
+++ b/plugins/DualFilter/DualFilterControls.cpp
@@ -74,7 +74,10 @@ DualFilterControls::DualFilterControls( DualFilterEffect* effect ) :
 	m_filter1Model.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
 	m_filter1Model.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
 	m_filter1Model.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "SV Lowpass" ), new PixmapLoader( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
+	m_filter1Model.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
 
 	m_filter2Model.addItem( tr( "LowPass" ), new PixmapLoader( "filter_lp" ) );
 	m_filter2Model.addItem( tr( "HiPass" ), new PixmapLoader( "filter_hp" ) );
@@ -91,7 +94,10 @@ DualFilterControls::DualFilterControls( DualFilterEffect* effect ) :
 	m_filter2Model.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
 	m_filter2Model.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
 	m_filter2Model.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "SV Lowpass" ), new PixmapLoader( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
+	m_filter2Model.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
 
 	connect( engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateFilters() ) );
 }

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -94,7 +94,10 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 	m_filterModel.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
 	m_filterModel.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
 	m_filterModel.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );	
-	m_filterModel.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );	
+	m_filterModel.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
+	m_filterModel.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
+	m_filterModel.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
+	m_filterModel.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
 }
 
 


### PR DESCRIPTION
Adds a state-variant 4-pole lowpass filter into LMMS, which I swiped from Nekobee and slightly adapted to work in LMMS
It is possible that with some adjustments highpass/bandpass versions could also be produced (will have to look into that)

edit: have now done that, there is now SV low/band/highpass filters

The lowpass sounds really cool, kind of like the moog filter but has more character, esp. on high Q values... works really fast too, very low CPU usage even when modulating freq/Q

The band/highpass filters also sound pretty nice I think.

I added also a 4th new filter since the code was already there but not being used: a doubled version of the Moog filter. 
