### PR TITLE
Make autosave file name the same for save and load

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -422,7 +422,7 @@ int main( int argc, char * * argv )
 		srand( getpid() + time( 0 ) );
 
 		// recover a file?
-		QString recoveryFile = QDir(configManager::inst()->workingDir()).absoluteFilePath("recover.dataFile");
+		QString recoveryFile = QDir(configManager::inst()->workingDir()).absoluteFilePath("recover.mmp");
 		if( QFileInfo(recoveryFile).exists() &&
 			QMessageBox::question( engine::mainWindow(), MainWindow::tr( "Project recovery" ),
 						MainWindow::tr( "It looks like the last session did not end properly. "


### PR DESCRIPTION
I believe the change to the autosave file name in commit 2e7733eaa18c6b404a610048ac5f53d92f6dbe96 was a search&replace run without enough checking. This should fix #722
