### PR TITLE
undoable instrument-changes - #1262

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1528,6 +1528,7 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 {
 	QString type = stringPairDrag::decodeKey( event );
 	QString value = stringPairDrag::decodeValue( event );
+	m_track->addJournalCheckPoint();
 
 	if( type == "instrument" )
 	{


### PR DESCRIPTION
I started working on #1262 for a couple of time now.
I added a journal-checkpoint when an element is being dropped on the instrument-slot of an instrument track. the current result: i can ctrl-z back until i get the last instrument that was on that track but only after a few times ctrl-z-ing.
my guess: the plugin that is being loaded makes some more journalcheckpoints on load.
i made some debugoutput. the elements getting "undone" before the instrument itself are mostly analogmodels.

Will continue solving the riddle, but hints are appreciated ;)

P.S.: while unexpanding the file edited by me, i stumbled across some codestyle-violations (spaces instead of tabs).
