### PR TITLE
Improvement of FxMixer multithreading

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -69,6 +69,7 @@ class FxChannel : public ThreadableJob
 		
 		QAtomicInt m_dependenciesMet;
 		void incrementDeps();
+		void processed();
 		
 	private:
 		virtual void doProcessing( sampleFrame * _working_buffer );

--- a/include/ThreadableJob.h
+++ b/include/ThreadableJob.h
@@ -61,6 +61,11 @@ public:
 	{
 		m_state = Queued;
 	}
+	
+	inline void done()
+	{
+		m_state = Done;
+	}
 
 	void process( sampleFrame* workingBuffer = NULL )
 	{


### PR DESCRIPTION
Use dynamic building of jobqueues with dependency counting:
- At the start, each channel that has no dependencies is added automatically to the queue
- Then, after each channel is processed, it increments the dep.counter of all its recipients
- When a channel's dep.counter hits the amount of its dependencies (senders), it gets automatically added to the queue
- The queue is finished when the master channel has been processed
- Muted channels are automatically processed at the start regardless dependencies, because they don't have to care about senders, being muted

Hopefully this will improve Fx Mixer performance.
