### PR TITLE
Move the denormals protection to the run() function of the thread

### DIFF
--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -902,15 +902,6 @@ Mixer::fifoWriter::fifoWriter( Mixer* mixer, fifo * _fifo ) :
 	m_fifo( _fifo ),
 	m_writing( true )
 {
-	// set denormal protection for this thread
-	#ifdef __SSE3__
-	/* DAZ flag */
-	_MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
-	#endif
-	#ifdef __SSE__
-	/* FTZ flag */
-	_MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
-	#endif
 }
 
 
@@ -926,6 +917,16 @@ void Mixer::fifoWriter::finish()
 
 void Mixer::fifoWriter::run()
 {
+// set denormal protection for this thread
+#ifdef __SSE3__
+/* DAZ flag */
+	_MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
+#endif
+#ifdef __SSE__
+/* FTZ flag */
+	_MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
+#endif	
+	
 #if 0
 #ifdef LMMS_BUILD_LINUX
 #ifdef LMMS_HAVE_SCHED_H

--- a/src/core/MixerWorkerThread.cpp
+++ b/src/core/MixerWorkerThread.cpp
@@ -101,16 +101,6 @@ MixerWorkerThread::MixerWorkerThread( Mixer* mixer ) :
 	m_workingBuf( new sampleFrame[mixer->framesPerPeriod()] ),
 	m_quit( false )
 {
-	// set denormal protection for this thread
-	#ifdef __SSE3__
-	/* DAZ flag */
-	_MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
-	#endif
-	#ifdef __SSE__
-	/* FTZ flag */
-	_MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
-	#endif
-
 	// initialize global static data
 	if( queueReadyWaitCond == NULL )
 	{
@@ -162,6 +152,15 @@ void MixerWorkerThread::startAndWaitForJobs()
 
 void MixerWorkerThread::run()
 {
+// set denormal protection for this thread
+#ifdef __SSE3__
+/* DAZ flag */
+	_MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
+#endif
+#ifdef __SSE__
+/* FTZ flag */
+	_MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
+#endif	
 	QMutex m;
 	while( m_quit == false )
 	{


### PR DESCRIPTION
The constructor was probably the wrong place to put it, run() is definitely executed in the new thread so that's where the setting should be applied I think?
