### PR TITLE
fixed position of mute/solobuttons in compact trackbuttons mode

### DIFF
--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -1590,8 +1590,8 @@ trackOperationsWidget::trackOperationsWidget( trackView * _parent ) :
 	if( configManager::inst()->value( "ui",
 					  "compacttrackbuttons" ).toInt() )
 	{
-		m_muteBtn->move( 46, 0 );
-		m_soloBtn->move( 46, 16 );
+		m_muteBtn->move( 44, 0 );
+		m_soloBtn->move( 44, 16 );
 	}
 	else
 	{


### PR DESCRIPTION
fixing this:
![before](https://i.imgur.com/VtouTXi.png)
to this:
![after](https://i.imgur.com/Kuj7gnF.png)

don't know if this closes an issue somewhere. i just stumbled across it when i was clicking around.
