### PR TITLE
fix for underlying bug 1293 loop markers

### DIFF
--- a/src/core/timeline.cpp
+++ b/src/core/timeline.cpp
@@ -294,6 +294,7 @@ void timeLine::mousePressEvent( QMouseEvent* event )
 	}
 	else if( event->button() == Qt::RightButton || event->button() == Qt::MiddleButton )
 	{
+        m_moveXOff = s_posMarkerPixmap->width() / 2;
 		const MidiTime t = m_begin + static_cast<int>( event->x() * MidiTime::ticksPerTact() / m_ppt );
 		if( m_loopPos[0] > m_loopPos[1]  )
 		{


### PR DESCRIPTION
initialized m_moveXoff when moving loop markers.

Now when moving loopmarkers while snapping, They move to the nearest tick, this is not effected by zoom size anymore.
