### PR TITLE
Fix for issue 1242 Buffer size frame rate should not cause a delay/latency at the start of rendered audio file.

### DIFF
--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -160,6 +160,8 @@ void ProjectRenderer::run()
 
 
 	Engine::getSong()->startExport();
+    //skip first empty buffer
+    Engine::mixer()->nextBuffer();
 
 	Song::playPos & pp = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );


### PR DESCRIPTION
Removes the blank period at the start of a render.

![Image of Waveforms](http://studio6plus1.com/images/renderStartsAtZero.png)
