### PR TITLE
Master kill switch for journalling, useful when closing program.

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -74,7 +74,7 @@ public:
 	}
 
 	void clearJournal();
-
+	void stopAllJournalling();
 	JournallingObject * journallingObject( const jo_id_t _id )
 	{
 		if( m_joIDs.contains( _id ) )

--- a/src/core/JournallingObject.cpp
+++ b/src/core/JournallingObject.cpp
@@ -70,14 +70,19 @@ void JournallingObject::addJournalCheckPoint()
 QDomElement JournallingObject::saveState( QDomDocument & _doc,
 							QDomElement & _parent )
 {
-	QDomElement _this = SerializingObject::saveState( _doc, _parent );
+	if( isJournalling() ) 
+	{
+		QDomElement _this = SerializingObject::saveState( _doc, _parent );
 
-	QDomElement journalNode = _doc.createElement( "journallingObject" );
-	journalNode.setAttribute( "id", id() );
-	journalNode.setAttribute( "metadata", true );
-	_this.appendChild( journalNode );
+		QDomElement journalNode = _doc.createElement( "journallingObject" );
+		journalNode.setAttribute( "id", id() );
+		journalNode.setAttribute( "metadata", true );
+		_this.appendChild( journalNode );
 
-	return _this;
+		return _this;
+	} else {
+		return QDomElement();
+	}
 }
 
 

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -168,5 +168,17 @@ void ProjectJournal::clearJournal()
 	}
 }
 
+void ProjectJournal::stopAllJournalling()
+{
+	for( JoIdMap::Iterator it = m_joIDs.begin(); it != m_joIDs.end(); ++it)
+	{
+		if( it.value() != NULL ) 
+		{
+			it.value()->setJournalling(false);
+		}
+	}
+	setJournalling(false);
+}
+
 
 

--- a/src/core/engine.cpp
+++ b/src/core/engine.cpp
@@ -115,6 +115,7 @@ void engine::init( const bool _has_gui )
 
 void engine::destroy()
 {
+	s_projectJournal->stopAllJournalling();
 	s_mixer->stopProcessing();
 
 	deleteHelper( &s_projectNotes );


### PR DESCRIPTION
As was discovered in issue #1267, it can be tricky to have a clean exit with journalling turned on, because the objects are pretty intertwined. This solution would turn journalling off at a point where it won't be needed anymore, just before all windows are destroyed.
