### PR TITLE
Cleaning up null-pointer-deallocation warnings.

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -149,7 +149,9 @@ SampleBuffer::SampleBuffer( const f_cnt_t _frames ) :
 
 SampleBuffer::~SampleBuffer()
 {
-	MM_FREE( m_origData );
+	if( m_origData != NULL )
+		MM_FREE( m_origData );
+
 	MM_FREE( m_data );
 }
 


### PR DESCRIPTION
As of the latest commit (1d929d6ce7b5426b2ad3d0f56bf559d7e717f099 at the time of writing), null pointer deallocation warnings appear under multiple scenarios.  The easiest way to reproduce the problem is to launch LMMS from the command line, wait for it to load completely, then close it immediately without doing anything; upon checking the console one will see a slew of null-pointer deallocation warnings.  The MemoryManager catches these, so ultimately they're benign, but the pointers should be checked before attempting to deallocate them.
