### PR TITLE
Removing focus from child windows upon hiding them.

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -145,6 +145,7 @@ private:
 	void finalize();
 
 	void toggleWindow( QWidget *window, bool forceShow = false );
+	void refocus();
 
 
 	QMdiArea * m_workspace;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -879,7 +879,7 @@ void MainWindow::toggleWindow( QWidget *window, bool forceShow )
 	else
 	{
 		parent->hide();
-		this->setFocus();
+		refocus();
 	}
 
 	// Workaround for Qt Bug #260116
@@ -887,6 +887,38 @@ void MainWindow::toggleWindow( QWidget *window, bool forceShow )
 	m_workspace->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	m_workspace->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
 	m_workspace->setVerticalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+}
+
+
+
+
+/*
+ * When an editor window with focus is toggled off, attempt to set focus
+ * to the next visible editor window, or if none are visible, set focus
+ * to the parent window.
+ */
+void MainWindow::refocus()
+{
+	QList<QWidget*> editors;
+	editors
+		<< Engine::songEditor()->parentWidget()
+		<< Engine::getBBEditor()->parentWidget()
+		<< Engine::pianoRoll()->parentWidget()
+		<< Engine::automationEditor()->parentWidget();
+
+	bool found = false;
+	QList<QWidget*>::Iterator editor;
+	for( editor = editors.begin(); editor != editors.end(); ++editor )
+	{
+		if( ! (*editor)->isHidden() ) {
+			(*editor)->setFocus();
+			found = true;
+			break;
+		}
+	}
+
+	if( ! found )
+		this->setFocus();
 }
 
 


### PR DESCRIPTION
When any of the Song Editor, BB Editor, Automation Editor, or Piano Roll windows are hidden or toggled off, they retain focus and capture key events.  The problem here is that the user is unwittingly sending keys to the apparently-closed window rather than only to the main application window.

The problem can be demonstrated by the following steps:
1. Load a song/project.
2. Close all child windows other than the Song Editor.
3. Give focus to the Song Editor window by clicking its title bar.
4. Hit the [space] key to start playback.
5. Toggle off the Song Editor by using F5 or clicking the Song Editor toolbar button.
6. Press [space] again while no child windows are open.

It is then observed that the key events continue to be handled by the (apparently closed) child window, toggling playback.

This happens with any child window that can be toggled and that handles key events; whichever child window was hidden last will continue receiving key events until another child window is explicitly focused by toggling it on or clicking it.

The proposed change restores focus to the parent window when a child window is hidden.
