### PR TITLE
Remove white space from Knob.setHintText calls

### DIFF
--- a/plugins/Amplifier/AmplifierControlDialog.cpp
+++ b/plugins/Amplifier/AmplifierControlDialog.cpp
@@ -45,26 +45,26 @@ AmplifierControlDialog::AmplifierControlDialog( AmplifierControls* controls ) :
 	volumeKnob -> setVolumeKnob( true );
 	volumeKnob->setModel( &controls->m_volumeModel );
 	volumeKnob->setLabel( tr( "VOL" ) );
-    volumeKnob->setHintText( tr( "Volume:" ) , "%" );
+	volumeKnob->setHintText( tr( "Volume:" ) , "%" );
 
 	Knob * panKnob = new Knob( knobBright_26, this);
 	panKnob -> move( 60, 30 );
 	panKnob->setModel( &controls->m_panModel );
 	panKnob->setLabel( tr( "PAN" ) );
-    panKnob->setHintText( tr( "Panning:" ) , "" );
+	panKnob->setHintText( tr( "Panning:" ) , "" );
 
 	Knob * leftKnob = new Knob( knobBright_26, this);
 	leftKnob -> move( 20, 80 );
 	leftKnob -> setVolumeKnob( true );
 	leftKnob->setModel( &controls->m_leftModel );
 	leftKnob->setLabel( tr( "LEFT" ) );
-    leftKnob->setHintText( tr( "Left gain:" ) , "%" );
+	leftKnob->setHintText( tr( "Left gain:" ) , "%" );
 
 	Knob * rightKnob = new Knob( knobBright_26, this);
 	rightKnob -> move( 60, 80 );
 	rightKnob -> setVolumeKnob( true );
 	rightKnob->setModel( &controls->m_rightModel );
 	rightKnob->setLabel( tr( "RIGHT" ) );
-    rightKnob->setHintText( tr( "Right gain:" ) , "%" );
+	rightKnob->setHintText( tr( "Right gain:" ) , "%" );
 }
 

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -47,17 +47,17 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	Knob * freqKnob = new Knob( knobBright_26, this);
 	freqKnob->setModel( &controls->m_freqModel );
 	freqKnob->setLabel( tr( "FREQ" ) );
-    freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
+	freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
 
 	Knob * gainKnob = new Knob( knobBright_26, this );
 	gainKnob->setModel( &controls->m_gainModel );
 	gainKnob->setLabel( tr( "GAIN" ) );
-    gainKnob->setHintText( tr( "Gain:" ) , "" );
+	gainKnob->setHintText( tr( "Gain:" ) , "" );
 
 	Knob * ratioKnob = new Knob( knobBright_26, this );
 	ratioKnob->setModel( &controls->m_ratioModel );
 	ratioKnob->setLabel( tr( "RATIO" ) );
-    ratioKnob->setHintText( tr( "Ratio:" ) , "" );
+	ratioKnob->setHintText( tr( "Ratio:" ) , "" );
 
 	l->addWidget( freqKnob );
 	l->addWidget( gainKnob );

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -38,7 +38,7 @@
 	name -> move( x, y );									\
 	name ->setModel( &controls-> model );					\
 	name ->setLabel( tr( label ) );							\
-    name ->setHintText( tr( hint ) , unit );
+	name ->setHintText( tr( hint ) , unit );
 
 
 

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -82,19 +82,19 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
 	stepLength->setLabel( tr( "Length" ) );
-    stepLength->setHintText( tr( "Step length:" ) , " ms" );
+	stepLength->setHintText( tr( "Step length:" ) , " ms" );
 	
 	Knob * dryGain = new Knob( knobBright_26, this );
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
 	dryGain->setLabel( tr( "Dry" ) );
-    dryGain->setHintText( tr( "Dry Gain:" ) , " dBV" );
+	dryGain->setHintText( tr( "Dry Gain:" ) , " dBV" );
 
 	Knob * stages = new Knob( knobBright_26, this );
 	stages->move( 200, 245 );
 	stages->setModel( & controls->m_stages );
 	stages->setLabel( tr( "Stages" ) );
-    stages->setHintText( tr( "Lowpass stages:" ) , "x" );
+	stages->setHintText( tr( "Lowpass stages:" ) , "x" );
 	// switch led
 	
 	LedCheckBox * swapInputs = new LedCheckBox( "Swap inputs", this, tr( "Swap inputs" ), LedCheckBox::Green );

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -543,7 +543,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 	m_ampKnob = new Knob( knobBright_26, this );
 	m_ampKnob->setVolumeKnob( true );
 	m_ampKnob->move( 5, 108 );
-    m_ampKnob->setHintText( tr( "Amplify:" ), "%" );
+	m_ampKnob->setHintText( tr( "Amplify:" ), "%" );
 	m_ampKnob->setWhatsThis(
 		tr( "With this knob you can set the amplify ratio. When you "
 			"set a value of 100% your sample isn't changed. "
@@ -552,21 +552,21 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 
 	m_startKnob = new AudioFileProcessorWaveView::knob( this );
 	m_startKnob->move( 45, 108 );
-    m_startKnob->setHintText( tr( "Startpoint:" ), "" );
+	m_startKnob->setHintText( tr( "Startpoint:" ), "" );
 	m_startKnob->setWhatsThis(
 		tr( "With this knob you can set the point where "
 			"AudioFileProcessor should begin playing your sample. " ) );
 
 	m_endKnob = new AudioFileProcessorWaveView::knob( this );
 	m_endKnob->move( 125, 108 );
-    m_endKnob->setHintText( tr( "Endpoint:" ), "" );
+	m_endKnob->setHintText( tr( "Endpoint:" ), "" );
 	m_endKnob->setWhatsThis(
 		tr( "With this knob you can set the point where "
 			"AudioFileProcessor should stop playing your sample. " ) );
 
 	m_loopKnob = new AudioFileProcessorWaveView::knob( this );
 	m_loopKnob->move( 85, 108 );
-    m_loopKnob->setHintText( tr( "Loopback point:" ), "" );
+	m_loopKnob->setHintText( tr( "Loopback point:" ), "" );
 	m_loopKnob->setWhatsThis(
 		tr( "With this knob you can set the point where "
 			"the loop starts. " ) );

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -335,7 +335,7 @@ bitInvaderView::bitInvaderView( Instrument * _instrument,
 	
 	m_sampleLengthKnob = new Knob( knobDark_28, this );
 	m_sampleLengthKnob->move( 6, 201 );
-    m_sampleLengthKnob->setHintText( tr( "Sample Length" ), "" );
+	m_sampleLengthKnob->setHintText( tr( "Sample Length" ), "" );
 
 	m_graph = new Graph( this, Graph::NearestStyle, 204, 134 );
 	m_graph->move(23,59);	// 55,120 - 2px border

--- a/plugins/delay/delaycontrolsdialog.cpp
+++ b/plugins/delay/delaycontrolsdialog.cpp
@@ -31,40 +31,40 @@
 
 
 DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
-    EffectControlDialog( controls )
+	EffectControlDialog( controls )
 {
-    setAutoFillBackground( true );
-    QPalette pal;
-    pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
-    setPalette( pal );
-    setFixedSize( 200, 75 );
+	setAutoFillBackground( true );
+	QPalette pal;
+	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
+	setPalette( pal );
+	setFixedSize( 200, 75 );
 
-    TempoSyncKnob* sampleDelayKnob = new TempoSyncKnob( knobBright_26, this );
-    sampleDelayKnob->move( 20,10 );
-    sampleDelayKnob->setVolumeKnob( false );
-    sampleDelayKnob->setModel( &controls->m_delayTimeModel );
-    sampleDelayKnob->setLabel( tr( "Delay" ) );
-    sampleDelayKnob->setHintText( tr( "Delay Time Seconds:" ) + " ", "" );
+	TempoSyncKnob* sampleDelayKnob = new TempoSyncKnob( knobBright_26, this );
+	sampleDelayKnob->move( 20,10 );
+	sampleDelayKnob->setVolumeKnob( false );
+	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
+	sampleDelayKnob->setLabel( tr( "Delay" ) );
+	sampleDelayKnob->setHintText( tr( "Delay Time Seconds:" ) + " ", "" );
 
-    Knob * feedbackKnob = new Knob( knobBright_26, this );
-    feedbackKnob->move( 63,10 );
-    feedbackKnob->setVolumeKnob( true) ;
-    feedbackKnob->setModel( &controls->m_feedbackModel);
-    feedbackKnob->setLabel( tr( "Regen" ) );
-    feedbackKnob->setHintText( tr ( "Feedback Amount:" ) + " ", "" );
+	Knob * feedbackKnob = new Knob( knobBright_26, this );
+	feedbackKnob->move( 63,10 );
+	feedbackKnob->setVolumeKnob( true) ;
+	feedbackKnob->setModel( &controls->m_feedbackModel);
+	feedbackKnob->setLabel( tr( "Regen" ) );
+	feedbackKnob->setHintText( tr ( "Feedback Amount:" ) + " ", "" );
 
-    TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
-    lfoFreqKnob->move( 106,10 );
-    lfoFreqKnob->setVolumeKnob( false );
-    lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
-    lfoFreqKnob->setLabel( tr( "Rate" ) );
-    lfoFreqKnob->setHintText( tr ( "Lfo Seconds:" ) + " ", "" );
+	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	lfoFreqKnob->move( 106,10 );
+	lfoFreqKnob->setVolumeKnob( false );
+	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
+	lfoFreqKnob->setLabel( tr( "Rate" ) );
+	lfoFreqKnob->setHintText( tr ( "Lfo Seconds:" ) + " ", "" );
 
-    TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
-    lfoAmtKnob->move( 150,10 );
-    lfoAmtKnob->setVolumeKnob( false );
-    lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-    lfoAmtKnob->setLabel( tr( "Lfo" ) );
-    lfoAmtKnob->setHintText( tr ( "Lfo Amt:" ) + " ", "" );
+	TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
+	lfoAmtKnob->move( 150,10 );
+	lfoAmtKnob->setVolumeKnob( false );
+	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
+	lfoAmtKnob->setLabel( tr( "Lfo" ) );
+	lfoAmtKnob->setHintText( tr ( "Lfo Amt:" ) + " ", "" );
 
 }

--- a/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
+++ b/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
@@ -63,7 +63,7 @@ dynProcControlDialog::dynProcControlDialog(
 	inputKnob -> move( 14, 251 );
 	inputKnob->setModel( &_controls->m_inputModel );
 	inputKnob->setLabel( tr( "INPUT" ) );
-    inputKnob->setHintText( tr( "Input gain:" ) , "" );
+	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
 	Knob * outputKnob = new Knob( knobBright_26, this );
 	outputKnob -> setVolumeKnob( true );
@@ -71,19 +71,19 @@ dynProcControlDialog::dynProcControlDialog(
 	outputKnob -> move( 54, 251 );
 	outputKnob->setModel( &_controls->m_outputModel );
 	outputKnob->setLabel( tr( "OUTPUT" ) );
-    outputKnob->setHintText( tr( "Output gain:" ) , "" );
+	outputKnob->setHintText( tr( "Output gain:" ) , "" );
 	
 	Knob * attackKnob = new Knob( knobBright_26, this);
 	attackKnob -> move( 11, 291 );
 	attackKnob->setModel( &_controls->m_attackModel );
 	attackKnob->setLabel( tr( "ATTACK" ) );
-    attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
+	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
 
 	Knob * releaseKnob = new Knob( knobBright_26, this );
 	releaseKnob -> move( 52, 291 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
 	releaseKnob->setLabel( tr( "RELEASE" ) );
-    releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );
+	releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );
 
 //waveform control buttons
 

--- a/plugins/flanger/flangercontrolsdialog.cpp
+++ b/plugins/flanger/flangercontrolsdialog.cpp
@@ -32,51 +32,51 @@
 
 
 FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
-    EffectControlDialog( controls )
+	EffectControlDialog( controls )
 {
-    setAutoFillBackground( true );
-    QPalette pal;
-    pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
-    setPalette( pal );
-    setFixedSize( 200, 75 );
+	setAutoFillBackground( true );
+	QPalette pal;
+	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
+	setPalette( pal );
+	setFixedSize( 200, 75 );
 
-    Knob* delayKnob = new Knob( knobBright_26, this );
-    delayKnob->move( 20,10 );
-    delayKnob->setVolumeKnob( false );
-    delayKnob->setModel( &controls->m_delayTimeModel );
-    delayKnob->setLabel( tr( "Delay" ) );
-    delayKnob->setHintText( tr( "Delay Time:" ) + " ", "" );
+	Knob* delayKnob = new Knob( knobBright_26, this );
+	delayKnob->move( 20,10 );
+	delayKnob->setVolumeKnob( false );
+	delayKnob->setModel( &controls->m_delayTimeModel );
+	delayKnob->setLabel( tr( "Delay" ) );
+	delayKnob->setHintText( tr( "Delay Time:" ) + " ", "" );
 
-    TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
-    lfoFreqKnob->move( 53,10 );
-    lfoFreqKnob->setVolumeKnob( false );
-    lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
-    lfoFreqKnob->setLabel( tr( "Lfo Hz" ) );
-    lfoFreqKnob->setHintText( tr ( "Lfo:" ) , "s" );
+	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	lfoFreqKnob->move( 53,10 );
+	lfoFreqKnob->setVolumeKnob( false );
+	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
+	lfoFreqKnob->setLabel( tr( "Lfo Hz" ) );
+	lfoFreqKnob->setHintText( tr ( "Lfo:" ) , "s" );
 
-    Knob * lfoAmtKnob = new Knob( knobBright_26, this );
-    lfoAmtKnob->move( 86,10 );
-    lfoAmtKnob->setVolumeKnob( false );
-    lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-    lfoAmtKnob->setLabel( tr( "Amt" ) );
-    lfoAmtKnob->setHintText( tr ( "Amt:" ) , "" );
+	Knob * lfoAmtKnob = new Knob( knobBright_26, this );
+	lfoAmtKnob->move( 86,10 );
+	lfoAmtKnob->setVolumeKnob( false );
+	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
+	lfoAmtKnob->setLabel( tr( "Amt" ) );
+	lfoAmtKnob->setHintText( tr ( "Amt:" ) , "" );
 
-    Knob * feedbackKnob = new Knob( knobBright_26, this );
-    feedbackKnob->move( 119,10 );
-    feedbackKnob->setVolumeKnob( true) ;
-    feedbackKnob->setModel( &controls->m_feedbackModel );
-    feedbackKnob->setLabel( tr( "Regen" ) );
-    feedbackKnob->setHintText( tr ( "Feedback Amount:" ) , "" );
+	Knob * feedbackKnob = new Knob( knobBright_26, this );
+	feedbackKnob->move( 119,10 );
+	feedbackKnob->setVolumeKnob( true) ;
+	feedbackKnob->setModel( &controls->m_feedbackModel );
+	feedbackKnob->setLabel( tr( "Regen" ) );
+	feedbackKnob->setHintText( tr ( "Feedback Amount:" ) , "" );
 
-    Knob * whiteNoiseKnob = new Knob( knobBright_26, this );
-    whiteNoiseKnob->move( 150,10 );
-    whiteNoiseKnob->setVolumeKnob( true) ;
-    whiteNoiseKnob->setModel( &controls->m_whiteNoiseAmountModel );
-    whiteNoiseKnob->setLabel( tr( "Noise" ) );
-    whiteNoiseKnob->setHintText( tr ( "White Noise Amount:" ) , "" );
+	Knob * whiteNoiseKnob = new Knob( knobBright_26, this );
+	whiteNoiseKnob->move( 150,10 );
+	whiteNoiseKnob->setVolumeKnob( true) ;
+	whiteNoiseKnob->setModel( &controls->m_whiteNoiseAmountModel );
+	whiteNoiseKnob->setLabel( tr( "Noise" ) );
+	whiteNoiseKnob->setHintText( tr ( "White Noise Amount:" ) , "" );
 
-    LedCheckBox* invertCb = new LedCheckBox( tr( "" ), this );
-    invertCb->move( 15,55 );
+	LedCheckBox* invertCb = new LedCheckBox( tr( "" ), this );
+	invertCb->move( 15,55 );
 
 
 

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -280,43 +280,43 @@ kickerInstrumentView::kickerInstrumentView( Instrument * _instrument,
 	const int END_COL = COL1 + 48;
 	
 	m_startFreqKnob = new kickerLargeKnob( this );
-    m_startFreqKnob->setHintText( tr( "Start frequency:" ), "Hz" );
+	m_startFreqKnob->setHintText( tr( "Start frequency:" ), "Hz" );
 	m_startFreqKnob->move( COL1, ROW1 );
 
 	m_endFreqKnob = new kickerLargeKnob( this );
-    m_endFreqKnob->setHintText( tr( "End frequency:" ), "Hz" );
+	m_endFreqKnob->setHintText( tr( "End frequency:" ), "Hz" );
 	m_endFreqKnob->move( END_COL, ROW1 );
 
 	m_slopeKnob = new kickerKnob( this );
-    m_slopeKnob->setHintText( tr( "Frequency Slope:" ), "" );
+	m_slopeKnob->setHintText( tr( "Frequency Slope:" ), "" );
 	m_slopeKnob->move( COL3, ROW1 );
 
 	m_gainKnob = new kickerKnob( this );
-    m_gainKnob->setHintText( tr( "Gain:" ), "" );
+	m_gainKnob->setHintText( tr( "Gain:" ), "" );
 	m_gainKnob->move( COL1, ROW3 );
 
 	m_decayKnob = new kickerEnvKnob( this );
-    m_decayKnob->setHintText( tr( "Envelope Length:" ), "ms" );
+	m_decayKnob->setHintText( tr( "Envelope Length:" ), "ms" );
 	m_decayKnob->move( COL2, ROW3 );
 
 	m_envKnob = new kickerKnob( this );
-    m_envKnob->setHintText( tr( "Envelope Slope:" ), "" );
+	m_envKnob->setHintText( tr( "Envelope Slope:" ), "" );
 	m_envKnob->move( COL3, ROW3 );
 
 	m_clickKnob = new kickerKnob( this );
-    m_clickKnob->setHintText( tr( "Click:" ), "" );
+	m_clickKnob->setHintText( tr( "Click:" ), "" );
 	m_clickKnob->move( COL5, ROW1 );
 
 	m_noiseKnob = new kickerKnob( this );
-    m_noiseKnob->setHintText( tr( "Noise:" ), "" );
+	m_noiseKnob->setHintText( tr( "Noise:" ), "" );
 	m_noiseKnob->move( COL5, ROW3 );
 
 	m_distKnob = new kickerKnob( this );
-    m_distKnob->setHintText( tr( "Distortion Start:" ), "" );
+	m_distKnob->setHintText( tr( "Distortion Start:" ), "" );
 	m_distKnob->move( COL4, ROW2 );
 
 	m_distEndKnob = new kickerKnob( this );
-    m_distEndKnob->setHintText( tr( "Distortion End:" ), "" );
+	m_distEndKnob->setHintText( tr( "Distortion End:" ), "" );
 	m_distEndKnob->move( COL5, ROW2 );
 
 	m_startNoteToggle = new LedCheckBox( "", this, "", LedCheckBox::Green );

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -824,22 +824,22 @@ lb302SynthView::lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	// GUI
 	m_vcfCutKnob = new Knob( knobBright_26, this );
 	m_vcfCutKnob->move( 75, 130 );
-    m_vcfCutKnob->setHintText( tr( "Cutoff Freq:" ), "" );
+	m_vcfCutKnob->setHintText( tr( "Cutoff Freq:" ), "" );
 	m_vcfCutKnob->setLabel( "" );
 
 	m_vcfResKnob = new Knob( knobBright_26, this );
 	m_vcfResKnob->move( 120, 130 );
-    m_vcfResKnob->setHintText( tr( "Resonance:" ), "" );
+	m_vcfResKnob->setHintText( tr( "Resonance:" ), "" );
 	m_vcfResKnob->setLabel( "" );
 
 	m_vcfModKnob = new Knob( knobBright_26, this );
 	m_vcfModKnob->move( 165, 130 );
-    m_vcfModKnob->setHintText( tr( "Env Mod:" ), "" );
+	m_vcfModKnob->setHintText( tr( "Env Mod:" ), "" );
 	m_vcfModKnob->setLabel( "" );
 
 	m_vcfDecKnob = new Knob( knobBright_26, this );
 	m_vcfDecKnob->move( 210, 130 );
-    m_vcfDecKnob->setHintText( tr( "Decay:" ), "" );
+	m_vcfDecKnob->setHintText( tr( "Decay:" ), "" );
 	m_vcfDecKnob->setLabel( "" );
 
 	m_slideToggle = new LedCheckBox( "", this );
@@ -860,12 +860,12 @@ lb302SynthView::lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 
 	m_slideDecKnob = new Knob( knobBright_26, this );
 	m_slideDecKnob->move( 210, 75 );
-    m_slideDecKnob->setHintText( tr( "Slide Decay:" ), "" );
+	m_slideDecKnob->setHintText( tr( "Slide Decay:" ), "" );
 	m_slideDecKnob->setLabel( "");
 
 	m_distKnob = new Knob( knobBright_26, this );
 	m_distKnob->move( 210, 190 );
-    m_distKnob->setHintText( tr( "DIST:" ), "" );
+	m_distKnob->setHintText( tr( "DIST:" ), "" );
 	m_distKnob->setLabel( tr( ""));
 
 

--- a/plugins/monstro/Monstro.h
+++ b/plugins/monstro/Monstro.h
@@ -46,14 +46,14 @@
 #define makeknob( name, x, y, hint, unit, oname ) 		\
 	name = new Knob( knobStyled, view ); 				\
 	name ->move( x, y );								\
-    name ->setHintText( tr( hint ), unit );             \
+	name ->setHintText( tr( hint ), unit );             \
 	name ->setObjectName( oname );						\
 	name ->setFixedSize( 20, 20 );
 
 #define maketsknob( name, x, y, hint, unit, oname ) 		\
 	name = new TempoSyncKnob( knobStyled, view ); 				\
 	name ->move( x, y );								\
-    name ->setHintText( tr( hint ), unit );		\
+	name ->setHintText( tr( hint ), unit );		\
 	name ->setObjectName( oname );						\
 	name ->setFixedSize( 20, 20 );
 

--- a/plugins/nes/Nes.h
+++ b/plugins/nes/Nes.h
@@ -38,7 +38,7 @@
 #define makeknob( name, x, y, hint, unit, oname ) 		\
 	name = new Knob( knobStyled, this ); 				\
 	name ->move( x, y );								\
-    name ->setHintText( tr( hint ), unit );		\
+	name ->setHintText( tr( hint ), unit );		\
 	name ->setObjectName( oname );						\
 	name ->setFixedSize( 29, 29 );
 

--- a/plugins/opl2/opl2instrument.cpp
+++ b/plugins/opl2/opl2instrument.cpp
@@ -586,7 +586,7 @@ opl2instrumentView::opl2instrumentView( Instrument * _instrument,
 
 #define KNOB_GEN(knobname, hinttext, hintunit,xpos,ypos) \
 	knobname = new Knob( knobStyled, this );\
-    knobname->setHintText( tr(hinttext), hintunit );\
+	knobname->setHintText( tr(hinttext), hintunit );\
 	knobname->setFixedSize(22,22);\
 	knobname->setCenterPointX(11.0);\
 	knobname->setCenterPointY(11.0);\

--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -433,7 +433,7 @@ organicInstrumentView::organicInstrumentView( Instrument * _instrument,
 	m_fx1Knob = new organicKnob( this );
 	m_fx1Knob->move( 15, 201 );
 	m_fx1Knob->setFixedSize( 37, 47 );
-    m_fx1Knob->setHintText( tr( "Distortion:" ), QString() );
+	m_fx1Knob->setHintText( tr( "Distortion:" ), QString() );
 	m_fx1Knob->setObjectName( "fx1Knob" );
 	m_fx1Knob->setWhatsThis( tr( "The distortion knob adds distortion to the output of the instrument. " ) );
 
@@ -442,7 +442,7 @@ organicInstrumentView::organicInstrumentView( Instrument * _instrument,
 	m_volKnob->setVolumeKnob( true );
 	m_volKnob->move( 60, 201 );
 	m_volKnob->setFixedSize( 37, 47 );
-    m_volKnob->setHintText( tr( "Volume:" ), "%" );
+	m_volKnob->setHintText( tr( "Volume:" ), "%" );
 	m_volKnob->setObjectName( "volKnob" );
 	m_volKnob->setWhatsThis( tr( "The volume knob controls the volume of the output of the instrument. "
 									"It is cumulative with the instrument window's volume control. " ) );
@@ -513,7 +513,7 @@ void organicInstrumentView::modelChanged()
 		connect( &oi->m_osc[i]->m_oscModel, SIGNAL( dataChanged() ),
 			this, SLOT( updateKnobHint() ) );
 
-        oscKnob->setHintText( tr( "Osc %1 waveform:" ).arg( i + 1 ), QString() );
+		oscKnob->setHintText( tr( "Osc %1 waveform:" ).arg( i + 1 ), QString() );
 										
 		// setup volume-knob
 		Knob * volKnob = new Knob( knobStyled, this );
@@ -521,19 +521,19 @@ void organicInstrumentView::modelChanged()
 		volKnob->move( x + i * colWidth, y + rowHeight*1 );
 		volKnob->setFixedSize( 21, 21 );
 		volKnob->setHintText( tr( "Osc %1 volume:" ).arg(
-                            i + 1 ), "%" );
+								i + 1 ), "%" );
 							
 		// setup panning-knob
 		Knob * panKnob = new organicKnob( this );
 		panKnob->move( x + i  * colWidth, y + rowHeight*2 );
 		panKnob->setHintText( tr("Osc %1 panning:").arg(
-                            i + 1 ), "" );
+								i + 1 ), "" );
 							
 		// setup knob for fine-detuning
 		Knob * detuneKnob = new organicKnob( this );
 		detuneKnob->move( x + i * colWidth, y + rowHeight*3 );
 		detuneKnob->setHintText( tr( "Osc %1 stereo detuning" ).arg( i + 1 )
-                            , " " +
+							, " " +
 							tr( "cents" ) );
 
 		m_oscKnobs[i] = OscillatorKnobs( harmKnob, volKnob, oscKnob, panKnob, detuneKnob );
@@ -557,9 +557,9 @@ void organicInstrumentView::updateKnobHint()
 		const float harm = oi->m_osc[i]->m_harmModel.value();
 		const float wave = oi->m_osc[i]->m_oscModel.value();
 		
-        m_oscKnobs[i].m_harmKnob->setHintText( tr( "Osc %1 harmonic:" ), " (" +
+		m_oscKnobs[i].m_harmKnob->setHintText( tr( "Osc %1 harmonic:" ), " (" +
 			HARMONIC_NAMES[ static_cast<int>( harm ) ] + ")" );
-        m_oscKnobs[i].m_oscKnob->setHintText( tr( "Osc %1 waveform:" ), " (" +
+		m_oscKnobs[i].m_oscKnob->setHintText( tr( "Osc %1 waveform:" ), " (" +
 			WAVEFORM_NAMES[ static_cast<int>( wave ) ] + ")" );
 	}
 }

--- a/plugins/papu/papu_instrument.cpp
+++ b/plugins/papu/papu_instrument.cpp
@@ -456,7 +456,7 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 	setPalette( pal );
 
 	m_ch1SweepTimeKnob = new papuKnob( this );
-    m_ch1SweepTimeKnob->setHintText( tr( "Sweep Time:" ), "" );
+	m_ch1SweepTimeKnob->setHintText( tr( "Sweep Time:" ), "" );
 	m_ch1SweepTimeKnob->move( 5 + 4*32, 106 );
 	ToolTip::add( m_ch1SweepTimeKnob, tr( "Sweep Time" ) );
 	m_ch1SweepTimeKnob->setWhatsThis( tr( "The amount of increase or"
@@ -464,7 +464,7 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 	m_ch1SweepRtShiftKnob = new papuKnob( this );
 	m_ch1SweepRtShiftKnob->setHintText( tr( "Sweep RtShift amount:" )
-                                            , "" );
+										, "" );
 	m_ch1SweepRtShiftKnob->move( 5 + 3*32, 106 );
 	ToolTip::add( m_ch1SweepRtShiftKnob, tr( "Sweep RtShift amount" ) );
 	m_ch1SweepRtShiftKnob->setWhatsThis( tr( "The rate at which increase or"
@@ -472,7 +472,7 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 	m_ch1WavePatternDutyKnob = new papuKnob( this );
 	m_ch1WavePatternDutyKnob->setHintText( tr( "Wave pattern duty:" )
-                                            , "" );
+									, "" );
 	m_ch1WavePatternDutyKnob->move( 5 + 2*32, 106 );
 	ToolTip::add( m_ch1WavePatternDutyKnob, tr( "Wave Pattern Duty" ) );
 	m_ch1WavePatternDutyKnob->setWhatsThis( tr( "The duty cycle is the ratio of"
@@ -481,14 +481,14 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 	m_ch1VolumeKnob = new papuKnob( this );
 	m_ch1VolumeKnob->setHintText( tr( "Square Channel 1 Volume:" )
-                                            , "" );
+								, "" );
 	m_ch1VolumeKnob->move( 5, 106 );
 	ToolTip::add( m_ch1VolumeKnob, tr( "Square Channel 1 Volume:" ) );
 	m_ch1VolumeKnob->setWhatsThis( tr( "Square Channel 1 Volume" ) );
 
 	m_ch1SweepStepLengthKnob = new papuKnob( this );
 	m_ch1SweepStepLengthKnob->setHintText( tr( "Length of each step in sweep:" )
-                                            , "" );
+									, "" );
 	m_ch1SweepStepLengthKnob->move( 5 + 32, 106 );
 	ToolTip::add( m_ch1SweepStepLengthKnob, tr( "Length of each step in sweep" ) );
 	m_ch1SweepStepLengthKnob->setWhatsThis( tr( "The delay between step change" ) );
@@ -497,7 +497,7 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 	m_ch2WavePatternDutyKnob = new papuKnob( this );
 	m_ch2WavePatternDutyKnob->setHintText( tr( "Wave pattern duty:" )
-                                            , "" );
+									, "" );
 	m_ch2WavePatternDutyKnob->move( 5 + 2*32, 155 );
 	ToolTip::add( m_ch2WavePatternDutyKnob, tr( "Wave pattern duty" ) );
 	m_ch2WavePatternDutyKnob->setWhatsThis( tr( "The duty cycle is the ratio of"
@@ -506,14 +506,14 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 	m_ch2VolumeKnob = new papuKnob( this );
 	m_ch2VolumeKnob->setHintText( tr( "Square Channel 2 Volume:" )
-                                            , "" );
+							, "" );
 	m_ch2VolumeKnob->move( 5, 155 );
 	ToolTip::add( m_ch2VolumeKnob, tr( "Square Channel 2 Volume" ) );
 	m_ch2VolumeKnob->setWhatsThis( tr( "Square Channel 2 Volume" ) );
 
 	m_ch2SweepStepLengthKnob = new papuKnob( this );
 	m_ch2SweepStepLengthKnob->setHintText( tr( "Length of each step in sweep:" )
-                                            , "" );
+									, "" );
 	m_ch2SweepStepLengthKnob->move( 5 + 32, 155 );
 	ToolTip::add( m_ch2SweepStepLengthKnob, tr( "Length of each step in sweep" ) );
 	m_ch2SweepStepLengthKnob->setWhatsThis( tr( "The delay between step change" ) );
@@ -521,7 +521,7 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 
 	m_ch3VolumeKnob = new papuKnob( this );
-    m_ch3VolumeKnob->setHintText( tr( "Wave Channel Volume:" ), "" );
+	m_ch3VolumeKnob->setHintText( tr( "Wave Channel Volume:" ), "" );
 	m_ch3VolumeKnob->move( 5, 204 );
 	ToolTip::add( m_ch3VolumeKnob, tr( "Wave Channel Volume" ) );
 	m_ch3VolumeKnob->setWhatsThis( tr( "Wave Channel Volume" ) );
@@ -529,14 +529,14 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 
 	m_ch4VolumeKnob = new papuKnob( this );
-    m_ch4VolumeKnob->setHintText( tr( "Noise Channel Volume:" ), "" );
+	m_ch4VolumeKnob->setHintText( tr( "Noise Channel Volume:" ), "" );
 	m_ch4VolumeKnob->move( 144, 155 );
 	ToolTip::add( m_ch4VolumeKnob, tr( "Noise Channel Volume" ) );
 	m_ch4VolumeKnob->setWhatsThis( tr( "Noise Channel Volume" ) );
 
 	m_ch4SweepStepLengthKnob = new papuKnob( this );
 	m_ch4SweepStepLengthKnob->setHintText( tr( "Length of each step in sweep:" )
-                                            , "" );
+									, "" );
 	m_ch4SweepStepLengthKnob->move( 144 + 32, 155 );
 	ToolTip::add( m_ch4SweepStepLengthKnob, tr( "Length of each step in sweep" ) );
 	m_ch4SweepStepLengthKnob->setWhatsThis( tr( "The delay between step change" ) );
@@ -544,22 +544,22 @@ papuInstrumentView::papuInstrumentView( Instrument * _instrument,
 
 
 	m_so1VolumeKnob = new papuKnob( this );
-    m_so1VolumeKnob->setHintText( tr( "SO1 Volume (Right):" ), "" );
+	m_so1VolumeKnob->setHintText( tr( "SO1 Volume (Right):" ), "" );
 	m_so1VolumeKnob->move( 5, 58 );
 	ToolTip::add( m_so1VolumeKnob, tr( "SO1 Volume (Right)" ) );
 
 	m_so2VolumeKnob = new papuKnob( this );
-    m_so2VolumeKnob->setHintText( tr( "SO2 Volume (Left):" ), "" );
+	m_so2VolumeKnob->setHintText( tr( "SO2 Volume (Left):" ), "" );
 	m_so2VolumeKnob->move( 5 + 32, 58 );
 	ToolTip::add( m_so2VolumeKnob, tr( "SO2 Volume (Left)" ) );
 
 	m_trebleKnob = new papuKnob( this );
-    m_trebleKnob->setHintText( tr( "Treble:" ), "" );
+	m_trebleKnob->setHintText( tr( "Treble:" ), "" );
 	m_trebleKnob->move( 5 + 2*32, 58 );
 	ToolTip::add( m_trebleKnob, tr( "Treble" ) );
 
 	m_bassKnob = new papuKnob( this );
-    m_bassKnob->setHintText( tr( "Bass:" ), "" );
+	m_bassKnob->setHintText( tr( "Bass:" ), "" );
 	m_bassKnob->move( 5 + 3*32, 58 );
 	ToolTip::add( m_bassKnob, tr( "Bass" ) );
 

--- a/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
@@ -53,32 +53,32 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	m_baseKnob = new Knob( knobBright_26, this );
 	m_baseKnob->setLabel( tr( "BASE" ) );
 	m_baseKnob->setModel( &_controls->m_baseModel );
-    m_baseKnob->setHintText( tr( "Base amount:" ) , "" );
+	m_baseKnob->setHintText( tr( "Base amount:" ) , "" );
 
 	m_amountKnob = new Knob( knobBright_26, this );
 	m_amountKnob->setLabel( tr( "AMNT" ) );
 	m_amountKnob->setModel( &_controls->m_amountModel );
-    m_amountKnob->setHintText( tr( "Modulation amount:" ) , "" );
+	m_amountKnob->setHintText( tr( "Modulation amount:" ) , "" );
 
 	m_amountMultKnob = new Knob( knobBright_26, this );
 	m_amountMultKnob->setLabel( tr( "MULT" ) );
 	m_amountMultKnob->setModel( &_controls->m_amountMultModel );
-    m_amountMultKnob->setHintText( tr( "Amount Multiplicator:" ) , "" );
+	m_amountMultKnob->setHintText( tr( "Amount Multiplicator:" ) , "" );
 
 	m_attackKnob = new Knob( knobBright_26, this );
 	m_attackKnob->setLabel( tr( "ATCK" ) );
 	m_attackKnob->setModel( &_controls->m_attackModel );
-    m_attackKnob->setHintText( tr( "Attack:" ) , "" );
+	m_attackKnob->setHintText( tr( "Attack:" ) , "" );
 
 	m_decayKnob = new Knob( knobBright_26, this );
 	m_decayKnob->setLabel( tr( "DCAY" ) );
 	m_decayKnob->setModel( &_controls->m_decayModel );
-    m_decayKnob->setHintText( tr( "Release:" ) , "" );
+	m_decayKnob->setHintText( tr( "Release:" ) , "" );
 	
 	m_tresholdKnob = new Knob( knobBright_26, this );
 	m_tresholdKnob->setLabel( tr( "TRES" ) );
 	m_tresholdKnob->setModel( &_controls->m_tresholdModel );
-    m_tresholdKnob->setHintText( tr( "Treshold:" ) , "" );
+	m_tresholdKnob->setHintText( tr( "Treshold:" ) , "" );
 
 	l->addWidget( m_baseKnob );
 	l->addWidget( m_amountKnob );

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -870,7 +870,7 @@ sf2InstrumentView::sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 
 	// Gain
 	m_gainKnob = new sf2Knob( this );
-	m_gainKnob->setHintText( tr("Gain") + " ", "" );
+	m_gainKnob->setHintText( tr("Gain"), "" );
 	m_gainKnob->move( 86, 55 );
 //	vl->addWidget( m_gainKnob );
 
@@ -891,19 +891,19 @@ sf2InstrumentView::sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 
 
 	m_reverbRoomSizeKnob = new sf2Knob( this );
-	m_reverbRoomSizeKnob->setHintText( tr("Reverb Roomsize:") + " ", "" );
+	m_reverbRoomSizeKnob->setHintText( tr("Reverb Roomsize:"), "" );
 	m_reverbRoomSizeKnob->move( 93, 160 );
 
 	m_reverbDampingKnob = new sf2Knob( this );
-	m_reverbDampingKnob->setHintText( tr("Reverb Damping:") + " ", "" );
+	m_reverbDampingKnob->setHintText( tr("Reverb Damping:"), "" );
 	m_reverbDampingKnob->move( 130, 160 );
 
 	m_reverbWidthKnob = new sf2Knob( this );
-	m_reverbWidthKnob->setHintText( tr("Reverb Width:") + " ", "" );
+	m_reverbWidthKnob->setHintText( tr("Reverb Width:"), "" );
 	m_reverbWidthKnob->move( 167, 160 );
 
 	m_reverbLevelKnob = new sf2Knob( this );
-	m_reverbLevelKnob->setHintText( tr("Reverb Level:") + " ", "" );
+	m_reverbLevelKnob->setHintText( tr("Reverb Level:"), "" );
 	m_reverbLevelKnob->move( 204, 160 );
 
 /*	hl->addWidget( m_reverbOnLed );
@@ -930,19 +930,19 @@ sf2InstrumentView::sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 			"files that support it." ) );
 
 	m_chorusNumKnob = new sf2Knob( this );
-	m_chorusNumKnob->setHintText( tr("Chorus Lines:") + " ", "" );
+	m_chorusNumKnob->setHintText( tr("Chorus Lines:"), "" );
 	m_chorusNumKnob->move( 93, 206 );
 
 	m_chorusLevelKnob = new sf2Knob( this );
-	m_chorusLevelKnob->setHintText( tr("Chorus Level:") + " ", "" );
+	m_chorusLevelKnob->setHintText( tr("Chorus Level:"), "" );
 	m_chorusLevelKnob->move( 130 , 206 );
 
 	m_chorusSpeedKnob = new sf2Knob( this );
-	m_chorusSpeedKnob->setHintText( tr("Chorus Speed:") + " ", "" );
+	m_chorusSpeedKnob->setHintText( tr("Chorus Speed:"), "" );
 	m_chorusSpeedKnob->move( 167 , 206 );
 
 	m_chorusDepthKnob = new sf2Knob( this );
-	m_chorusDepthKnob->setHintText( tr("Chorus Depth:") + " ", "" );
+	m_chorusDepthKnob->setHintText( tr("Chorus Depth:"), "" );
 	m_chorusDepthKnob->move( 204 , 206 );
 /*
 	hl->addWidget( m_chorusOnLed );

--- a/plugins/sid/sid_instrument.cpp
+++ b/plugins/sid/sid_instrument.cpp
@@ -487,15 +487,15 @@ sidInstrumentView::sidInstrumentView( Instrument * _instrument,
 	setPalette( pal );
 
 	m_volKnob = new sidKnob( this );
-    m_volKnob->setHintText( tr( "Volume:" ), "" );
+	m_volKnob->setHintText( tr( "Volume:" ), "" );
 	m_volKnob->move( 7, 64 );
 
 	m_resKnob = new sidKnob( this );
-    m_resKnob->setHintText( tr( "Resonance:" ), "" );
+	m_resKnob->setHintText( tr( "Resonance:" ), "" );
 	m_resKnob->move( 7 + 28, 64 );
 
 	m_cutKnob = new sidKnob( this );
-    m_cutKnob->setHintText( tr( "Cutoff frequency:" ), "Hz" );
+	m_cutKnob->setHintText( tr( "Cutoff frequency:" ), "Hz" );
 	m_cutKnob->move( 7 + 2*28, 64 );
 
 	PixmapButton * hp_btn = new PixmapButton( this, NULL );
@@ -547,32 +547,32 @@ sidInstrumentView::sidInstrumentView( Instrument * _instrument,
 	for( int i = 0; i < 3; i++ ) 
 	{
 		Knob *ak = new sidKnob( this );
-        ak->setHintText( tr("Attack:"), "" );
+		ak->setHintText( tr("Attack:"), "" );
 		ak->move( 7, 114 + i*50 );
 		ak->setWhatsThis( tr ( "Attack rate determines how rapidly the output "
 				"of Voice %1 rises from zero to peak amplitude." ).arg( i+1 ) );
 
 		Knob *dk = new sidKnob( this );
-        dk->setHintText( tr("Decay:") , "" );
+		dk->setHintText( tr("Decay:") , "" );
 		dk->move( 7 + 28, 114 + i*50 );
 		dk->setWhatsThis( tr ( "Decay rate determines how rapidly the output "
 				"falls from the peak amplitude to the selected Sustain level." ) );
 
 		Knob *sk = new sidKnob( this );
-        sk->setHintText( tr("Sustain:"), "" );
+		sk->setHintText( tr("Sustain:"), "" );
 		sk->move( 7 + 2*28, 114 + i*50 );
 		sk->setWhatsThis( tr ( "Output of Voice %1 will remain at the selected "
 				"Sustain amplitude as long as the note is held." ).arg( i+1 ) );
 
 		Knob *rk = new sidKnob( this );
-        rk->setHintText( tr("Release:"), "" );
+		rk->setHintText( tr("Release:"), "" );
 		rk->move( 7 + 3*28, 114 + i*50 );
 		rk->setWhatsThis( tr ( "The output of of Voice %1 will fall from "
 				"Sustain amplitude to zero amplitude at the selected Release "
 				"rate." ).arg( i+1 ) );
 
 		Knob *pwk = new sidKnob( this );
-        pwk->setHintText( tr("Pulse Width:"), "" );
+		pwk->setHintText( tr("Pulse Width:"), "" );
 		pwk->move( 7 + 4*28, 114 + i*50 );
 		pwk->setWhatsThis( tr ( "The Pulse Width resolution allows the width "
 				"to be smoothly swept with no discernable stepping. The Pulse "
@@ -580,7 +580,7 @@ sidInstrumentView::sidInstrumentView( Instrument * _instrument,
 				" effect." ).arg( i+1 ) );
 
 		Knob *crsk = new sidKnob( this );
-        crsk->setHintText( tr("Coarse:"), " semitones" );
+		crsk->setHintText( tr("Coarse:"), " semitones" );
 		crsk->move( 147, 114 + i*50 );
 		crsk->setWhatsThis( tr ( "The Coarse detuning allows to detune Voice "
 				"%1 one octave up or down." ).arg( i+1 ) );

--- a/plugins/stereo_enhancer/stereoenhancer_control_dialog.cpp
+++ b/plugins/stereo_enhancer/stereoenhancer_control_dialog.cpp
@@ -40,7 +40,7 @@ stereoEnhancerControlDialog::stereoEnhancerControlDialog(
 	Knob * widthKnob = new Knob( knobBright_26, this );
 	widthKnob->setModel( &_controls->m_widthModel );
 	widthKnob->setLabel( tr( "WIDE" ) );
-    widthKnob->setHintText( tr( "Width:" ) , "samples" );
+	widthKnob->setHintText( tr( "Width:" ) , "samples" );
 
 	l->addWidget( widthKnob );
 

--- a/plugins/stereo_matrix/stereomatrix_control_dialog.cpp
+++ b/plugins/stereo_matrix/stereomatrix_control_dialog.cpp
@@ -49,22 +49,22 @@ stereoMatrixControlDialog::stereoMatrixControlDialog(
 
 	Knob * llKnob = new Knob( knobSmall_17, this );
 	llKnob->setModel( &_controls->m_llModel );
-    llKnob->setHintText( tr( "Left to Left Vol:" ) , "" );
+	llKnob->setHintText( tr( "Left to Left Vol:" ) , "" );
 	llKnob->move( 40, 60 );
 
 	Knob * lrKnob = new Knob( knobSmall_17, this );
 	lrKnob->setModel( &_controls->m_lrModel );
-    lrKnob->setHintText( tr( "Left to Right Vol:" ) , "" );
+	lrKnob->setHintText( tr( "Left to Right Vol:" ) , "" );
 	lrKnob->move( 40+28, 60);
 
 	Knob * rlKnob = new Knob( knobSmall_17, this );
 	rlKnob->setModel( &_controls->m_rlModel );
-    rlKnob->setHintText( tr( "Right to Left Vol:" ) , "" );
+	rlKnob->setHintText( tr( "Right to Left Vol:" ) , "" );
 	rlKnob->move( 40, 60+28 );
 
 	Knob * rrKnob = new Knob( knobSmall_17, this );
 	rrKnob->setModel( &_controls->m_rrModel );
-    rrKnob->setHintText( tr( "Right to Right Vol:" ) , "" );
+	rrKnob->setHintText( tr( "Right to Right Vol:" ) , "" );
 	rrKnob->move( 40+28, 60+28 );
 }
 

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -334,7 +334,7 @@ malletsInstrumentView::malletsInstrumentView( malletsInstrument * _instrument,
 	m_spreadKnob = new Knob( knobVintage_32, this );
 	m_spreadKnob->setLabel( tr( "Spread" ) );
 	m_spreadKnob->move( 190, 140 );
-	m_spreadKnob->setHintText( tr( "Spread:" ) + " ", "" );
+	m_spreadKnob->setHintText( tr( "Spread:" ), "" );
 }
 
 
@@ -366,27 +366,27 @@ QWidget * malletsInstrumentView::setupModalBarControls( QWidget * _parent )
 	m_hardnessKnob = new Knob( knobVintage_32, widget );
 	m_hardnessKnob->setLabel( tr( "Hardness" ) );
 	m_hardnessKnob->move( 30, 90 );
-	m_hardnessKnob->setHintText( tr( "Hardness:" ) + " ", "" );
+	m_hardnessKnob->setHintText( tr( "Hardness:" ), "" );
 
 	m_positionKnob = new Knob( knobVintage_32, widget );
 	m_positionKnob->setLabel( tr( "Position" ) );
 	m_positionKnob->move( 110, 90 );
-	m_positionKnob->setHintText( tr( "Position:" ) + " ", "" );
+	m_positionKnob->setHintText( tr( "Position:" ), "" );
 
 	m_vibratoGainKnob = new Knob( knobVintage_32, widget );
 	m_vibratoGainKnob->setLabel( tr( "Vib Gain" ) );
 	m_vibratoGainKnob->move( 30, 140 );
-	m_vibratoGainKnob->setHintText( tr( "Vib Gain:" ) + " ", "" );
+	m_vibratoGainKnob->setHintText( tr( "Vib Gain:" ), "" );
 
 	m_vibratoFreqKnob = new Knob( knobVintage_32, widget );
 	m_vibratoFreqKnob->setLabel( tr( "Vib Freq" ) );
 	m_vibratoFreqKnob->move( 110, 140 );
-	m_vibratoFreqKnob->setHintText( tr( "Vib Freq:" ) + " ", "" );
+	m_vibratoFreqKnob->setHintText( tr( "Vib Freq:" ), "" );
 
 	m_stickKnob = new Knob( knobVintage_32, widget );
 	m_stickKnob->setLabel( tr( "Stick Mix" ) );
 	m_stickKnob->move( 190, 90 );
-	m_stickKnob->setHintText( tr( "Stick Mix:" ) + " ", "" );
+	m_stickKnob->setHintText( tr( "Stick Mix:" ), "" );
 	
 	return( widget );
 }
@@ -402,27 +402,27 @@ QWidget * malletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 	m_modulatorKnob = new Knob( knobVintage_32, widget );
 	m_modulatorKnob->setLabel( tr( "Modulator" ) );
 	m_modulatorKnob->move( 30, 90 );
-	m_modulatorKnob->setHintText( tr( "Modulator:" ) + " ", "" );
+	m_modulatorKnob->setHintText( tr( "Modulator:" ), "" );
 
 	m_crossfadeKnob = new Knob( knobVintage_32, widget );
 	m_crossfadeKnob->setLabel( tr( "Crossfade" ) );
 	m_crossfadeKnob->move( 110, 90 );
-	m_crossfadeKnob->setHintText( tr( "Crossfade:" ) + " ", "" );
+	m_crossfadeKnob->setHintText( tr( "Crossfade:" ), "" );
 	
 	m_lfoSpeedKnob = new Knob( knobVintage_32, widget );
 	m_lfoSpeedKnob->setLabel( tr( "LFO Speed" ) );
 	m_lfoSpeedKnob->move( 30, 140 );
-	m_lfoSpeedKnob->setHintText( tr( "LFO Speed:" ) + " ", "" );
+	m_lfoSpeedKnob->setHintText( tr( "LFO Speed:" ), "" );
 	
 	m_lfoDepthKnob = new Knob( knobVintage_32, widget );
 	m_lfoDepthKnob->setLabel( tr( "LFO Depth" ) );
 	m_lfoDepthKnob->move( 110, 140 );
-	m_lfoDepthKnob->setHintText( tr( "LFO Depth:" ) + " ", "" );
+	m_lfoDepthKnob->setHintText( tr( "LFO Depth:" ), "" );
 	
 	m_adsrKnob = new Knob( knobVintage_32, widget );
 	m_adsrKnob->setLabel( tr( "ADSR" ) );
 	m_adsrKnob->move( 190, 90 );
-	m_adsrKnob->setHintText( tr( "ADSR:" ) + " ", "" );
+	m_adsrKnob->setHintText( tr( "ADSR:" ), "" );
 
 	return( widget );
 }
@@ -442,22 +442,22 @@ QWidget * malletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 	m_pressureKnob = new Knob( knobVintage_32, widget );
 	m_pressureKnob->setLabel( tr( "Pressure" ) );
 	m_pressureKnob->move( 30, 90 );
-	m_pressureKnob->setHintText( tr( "Pressure:" ) + " ", "" );
+	m_pressureKnob->setHintText( tr( "Pressure:" ), "" );
 
 	m_motionKnob = new Knob( knobVintage_32, widget );
 	m_motionKnob->setLabel( tr( "Motion" ) );
 	m_motionKnob->move( 110, 90 );
-	m_motionKnob->setHintText( tr( "Motion:" ) + " ", "" );
+	m_motionKnob->setHintText( tr( "Motion:" ), "" );
 	
 	m_velocityKnob = new Knob( knobVintage_32, widget );
 	m_velocityKnob->setLabel( tr( "Speed" ) );
 	m_velocityKnob->move( 30, 140 );
-	m_velocityKnob->setHintText( tr( "Speed:" ) + " ", "" );
+	m_velocityKnob->setHintText( tr( "Speed:" ), "" );
 	
 	m_vibratoKnob = new Knob( knobVintage_32, widget, tr( "Vibrato" ) );
 	m_vibratoKnob->setLabel( tr( "Vibrato" ) );
 	m_vibratoKnob->move( 110, 140 );
-	m_vibratoKnob->setHintText( tr( "Vibrato:" ) + " ", "" );
+	m_vibratoKnob->setHintText( tr( "Vibrato:" ), "" );
 	
 	return( widget );
 }

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -555,7 +555,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		vk->setFixedSize( 28, 35 );
 		vk->move( 6, knob_y );
 		vk->setHintText( tr( "Osc %1 volume:" ).arg(
-                            i+1 ), "%" );
+							 i+1 ), "%" );
 		vk->setWhatsThis(
 			tr( "With this knob you can set the volume of "
 				"oscillator %1. When setting a value of 0 the "
@@ -566,7 +566,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		// setup panning-knob
 		Knob * pk = new TripleOscKnob( this );
 		pk->move( 35, knob_y );
-        pk->setHintText( tr("Osc %1 panning:").arg( i + 1 ), "" );
+		pk->setHintText( tr("Osc %1 panning:").arg( i + 1 ), "" );
 		pk->setWhatsThis(
 			tr( "With this knob you can set the panning of the "
 				"oscillator %1. A value of -100 means 100% "
@@ -576,8 +576,8 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		// setup coarse-knob
 		Knob * ck = new TripleOscKnob( this );
 		ck->move( 82, knob_y );
-        ck->setHintText( tr( "Osc %1 coarse detuning:" ).arg( i + 1 )
-                        , " " + tr( "semitones" ) );
+		ck->setHintText( tr( "Osc %1 coarse detuning:" ).arg( i + 1 )
+						 , " " + tr( "semitones" ) );
 		ck->setWhatsThis(
 			tr( "With this knob you can set the coarse detuning of "
 				"oscillator %1. You can detune the oscillator "
@@ -590,7 +590,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		Knob * flk = new TripleOscKnob( this );
 		flk->move( 111, knob_y );
 		flk->setHintText( tr( "Osc %1 fine detuning left:" ).
-                        arg( i + 1 ),
+						  arg( i + 1 ),
 							" " + tr( "cents" ) );
 		flk->setWhatsThis(
 			tr( "With this knob you can set the fine detuning of "
@@ -603,7 +603,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		Knob * frk = new TripleOscKnob( this );
 		frk->move( 140, knob_y );
 		frk->setHintText( tr( "Osc %1 fine detuning right:" ).
-                        arg( i + 1 ),
+						  arg( i + 1 ),
 							" " + tr( "cents" ) );
 		frk->setWhatsThis(
 			tr( "With this knob you can set the fine detuning of "
@@ -617,7 +617,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		Knob * pok = new TripleOscKnob( this );
 		pok->move( 188, knob_y );
 		pok->setHintText( tr( "Osc %1 phase-offset:" ).
-                        arg( i + 1 ),
+						  arg( i + 1 ),
 							" " + tr( "degrees" ) );
 		pok->setWhatsThis(
 			tr( "With this knob you can set the phase-offset of "
@@ -633,7 +633,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		Knob * spdk = new TripleOscKnob( this );
 		spdk->move( 217, knob_y );
 		spdk->setHintText( tr("Osc %1 stereo phase-detuning:" ).
-                    arg( i + 1 ),
+						arg( i + 1 ),
 							" " + tr( "degrees" ) );
 		spdk->setWhatsThis(
 			tr( "With this knob you can set the stereo phase-"

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -361,14 +361,14 @@ vibedView::vibedView( Instrument * _instrument,
 	m_volumeKnob = new Knob( knobBright_26, this );
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->move( 103, 142 );
-    m_volumeKnob->setHintText( tr( "Volume:" ), "" );
+	m_volumeKnob->setHintText( tr( "Volume:" ), "" );
 	m_volumeKnob->setWhatsThis( tr( "The 'V' knob sets the volume "
 					"of the selected string." ) );
 
 	m_stiffnessKnob = new Knob( knobBright_26, this );
 	m_stiffnessKnob->move( 129, 142 );
-    m_stiffnessKnob->setHintText( tr( "String stiffness:" )
-                    , "" );
+	m_stiffnessKnob->setHintText( tr( "String stiffness:" )
+							, "" );
 	m_stiffnessKnob->setWhatsThis( tr(
 "The 'S' knob sets the stiffness of the selected string.  The stiffness "
 "of the string affects how long the string will ring out.  The lower "
@@ -377,15 +377,15 @@ vibedView::vibedView( Instrument * _instrument,
 	
 	m_pickKnob = new Knob( knobBright_26, this );
 	m_pickKnob->move( 153, 142 );
-    m_pickKnob->setHintText( tr( "Pick position:" ), "" );
+	m_pickKnob->setHintText( tr( "Pick position:" ), "" );
 	m_pickKnob->setWhatsThis( tr(
 "The 'P' knob sets the position where the selected string will be 'picked'.  "
 "The lower the setting the closer the pick is to the bridge." ) );
 
 	m_pickupKnob = new Knob( knobBright_26, this );
 	m_pickupKnob->move( 177, 142 );
-    m_pickupKnob->setHintText( tr( "Pickup position:" )
-                , "" );
+	m_pickupKnob->setHintText( tr( "Pickup position:" )
+						, "" );
 	m_pickupKnob->setWhatsThis( tr(
 "The 'PU' knob sets the position where the vibrations will be monitored "
 "for the selected string.  The lower the setting, the closer the "
@@ -400,7 +400,7 @@ vibedView::vibedView( Instrument * _instrument,
 	
 	m_detuneKnob = new Knob( knobBright_26, this );
 	m_detuneKnob->move( 150, 187 );
-    m_detuneKnob->setHintText( tr( "Detune:" ), "" );
+	m_detuneKnob->setHintText( tr( "Detune:" ), "" );
 	m_detuneKnob->setWhatsThis( tr(
 "The Detune knob modifies the pitch of the selected string.  Settings less "
 "than zero will cause the string to sound flat.  Settings greater than zero "
@@ -408,8 +408,8 @@ vibedView::vibedView( Instrument * _instrument,
 
 	m_randomKnob = new Knob( knobBright_26, this );
 	m_randomKnob->move( 194, 187 );
-    m_randomKnob->setHintText( tr( "Fuzziness:" )
-                , "" );
+	m_randomKnob->setHintText( tr( "Fuzziness:" )
+						, "" );
 	m_randomKnob->setWhatsThis( tr(
 "The Slap knob adds a bit of fuzz to the selected string which is most "
 "apparent during the attack, though it can also be used to make the string "
@@ -417,8 +417,8 @@ vibedView::vibedView( Instrument * _instrument,
 
 	m_lengthKnob = new Knob( knobBright_26, this );
 	m_lengthKnob->move( 23, 193 );
-    m_lengthKnob->setHintText( tr( "Length:" )
-                , "" );
+	m_lengthKnob->setHintText( tr( "Length:" )
+						, "" );
 	m_lengthKnob->setWhatsThis( tr(
 "The Length knob sets the length of the selected string.  Longer strings "
 "will both ring longer and sound brighter, however, they will also eat up "
@@ -427,7 +427,7 @@ vibedView::vibedView( Instrument * _instrument,
 	m_impulse = new LedCheckBox( "", this );
 	m_impulse->move( 23, 94 );
 	ToolTip::add( m_impulse,
-		      tr( "Impulse or initial state" ) );
+			tr( "Impulse or initial state" ) );
 	m_impulse->setWhatsThis( tr(
 "The 'Imp' selector determines whether the waveform in the graph is to be "
 "treated as an impulse imparted to the string by the pick or the initial "

--- a/plugins/watsyn/Watsyn.h
+++ b/plugins/watsyn/Watsyn.h
@@ -41,14 +41,14 @@
 #define makeknob( name, x, y, hint, unit, oname ) 		\
 	name = new Knob( knobStyled, this ); 				\
 	name ->move( x, y );								\
-    name ->setHintText( tr( hint ), unit );		\
+	name ->setHintText( tr( hint ), unit );		\
 	name ->setObjectName( oname );						\
 	name ->setFixedSize( 19, 19 );
 
 #define maketsknob( name, x, y, hint, unit, oname ) 		\
 	name = new TempoSyncKnob( knobStyled, this ); 				\
 	name ->move( x, y );								\
-    name ->setHintText( tr( hint ), unit );		\
+	name ->setHintText( tr( hint ), unit );		\
 	name ->setObjectName( oname );						\
 	name ->setFixedSize( 19, 19 );
 

--- a/plugins/waveshaper/waveshaper_control_dialog.cpp
+++ b/plugins/waveshaper/waveshaper_control_dialog.cpp
@@ -63,7 +63,7 @@ waveShaperControlDialog::waveShaperControlDialog(
 	inputKnob -> move( 14, 251 );
 	inputKnob->setModel( &_controls->m_inputModel );
 	inputKnob->setLabel( tr( "INPUT" ) );
-    inputKnob->setHintText( tr( "Input gain:" ) , "" );
+	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
 	Knob * outputKnob = new Knob( knobBright_26, this );
 	outputKnob -> setVolumeKnob( true );
@@ -71,7 +71,7 @@ waveShaperControlDialog::waveShaperControlDialog(
 	outputKnob -> move( 54, 251 );
 	outputKnob->setModel( &_controls->m_outputModel );
 	outputKnob->setLabel( tr( "OUTPUT" ) );
-    outputKnob->setHintText( tr( "Output gain:" ), "" );
+	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
 	PixmapButton * resetButton = new PixmapButton( this, tr("Reset waveform") );
 	resetButton -> move( 164, 251 );

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -498,31 +498,31 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	l->setHorizontalSpacing( 10 );
 
 	m_portamento = new Knob( knobBright_26, this );
-    m_portamento->setHintText( tr( "Portamento:" ), "" );
+	m_portamento->setHintText( tr( "Portamento:" ), "" );
 	m_portamento->setLabel( tr( "PORT" ) );
 
 	m_filterFreq = new Knob( knobBright_26, this );
-    m_filterFreq->setHintText( tr( "Filter Frequency:" ), "" );
+	m_filterFreq->setHintText( tr( "Filter Frequency:" ), "" );
 	m_filterFreq->setLabel( tr( "FREQ" ) );
 
 	m_filterQ = new Knob( knobBright_26, this );
-    m_filterQ->setHintText( tr( "Filter Resonance:" ), "" );
+	m_filterQ->setHintText( tr( "Filter Resonance:" ), "" );
 	m_filterQ->setLabel( tr( "RES" ) );
 
 	m_bandwidth = new Knob( knobBright_26, this );
-    m_bandwidth->setHintText( tr( "Bandwidth:" ), "" );
+	m_bandwidth->setHintText( tr( "Bandwidth:" ), "" );
 	m_bandwidth->setLabel( tr( "BW" ) );
 
 	m_fmGain = new Knob( knobBright_26, this );
-    m_fmGain->setHintText( tr( "FM Gain:" ), "" );
+	m_fmGain->setHintText( tr( "FM Gain:" ), "" );
 	m_fmGain->setLabel( tr( "FM GAIN" ) );
 
 	m_resCenterFreq = new Knob( knobBright_26, this );
-    m_resCenterFreq->setHintText( tr( "Resonance center frequency:" ), "" );
+	m_resCenterFreq->setHintText( tr( "Resonance center frequency:" ), "" );
 	m_resCenterFreq->setLabel( tr( "RES CF" ) );
 
 	m_resBandwidth = new Knob( knobBright_26, this );
-    m_resBandwidth->setHintText( tr( "Resonance bandwidth:" ), "" );
+	m_resBandwidth->setHintText( tr( "Resonance bandwidth:" ), "" );
 	m_resBandwidth->setLabel( tr( "RES BW" ) );
 
 	m_forwardMidiCC = new LedCheckBox( tr( "Forward MIDI Control Changes" ), this );

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -75,14 +75,14 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_baseKnob = new Knob( knobBright_26, this );
 	m_baseKnob->setLabel( tr( "BASE" ) );
 	m_baseKnob->move( CD_LFO_BASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
-    m_baseKnob->setHintText( tr( "Base amount:" ), "" );
+	m_baseKnob->setHintText( tr( "Base amount:" ), "" );
 	m_baseKnob->setWhatsThis( tr("todo") );
 
 
 	m_speedKnob = new TempoSyncKnob( knobBright_26, this );
 	m_speedKnob->setLabel( tr( "SPD" ) );
 	m_speedKnob->move( CD_LFO_SPEED_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
-    m_speedKnob->setHintText( tr( "LFO-speed:" ), "" );
+	m_speedKnob->setHintText( tr( "LFO-speed:" ), "" );
 	m_speedKnob->setWhatsThis(
 		tr( "Use this knob for setting speed of the LFO. The "
 			"bigger this value the faster the LFO oscillates and "
@@ -92,7 +92,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_amountKnob = new Knob( knobBright_26, this );
 	m_amountKnob->setLabel( tr( "AMT" ) );
 	m_amountKnob->move( CD_LFO_AMOUNT_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
-    m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
+	m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
 	m_amountKnob->setWhatsThis(
 		tr( "Use this knob for setting modulation amount of the "
 			"LFO. The bigger this value, the more the connected "
@@ -102,7 +102,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_phaseKnob = new Knob( knobBright_26, this );
 	m_phaseKnob->setLabel( tr( "PHS" ) );
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
-    m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( "degrees" ) );
+	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( "degrees" ) );
 	m_phaseKnob->setWhatsThis(
 			tr( "With this knob you can set the phase offset of "
 				"the LFO. That means you can move the "

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -67,7 +67,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_wetDry->setLabel( tr( "W/D" ) );
 	m_wetDry->move( 27, 5 );
 	m_wetDry->setEnabled( isEnabled );
-    m_wetDry->setHintText( tr( "Wet Level:" ), "" );
+	m_wetDry->setHintText( tr( "Wet Level:" ), "" );
 	m_wetDry->setWhatsThis( tr( "The Wet/Dry knob sets the ratio between "
 					"the input signal and the effect signal that "
 					"forms the output." ) );
@@ -77,7 +77,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_autoQuit->setLabel( tr( "DECAY" ) );
 	m_autoQuit->move( 60, 5 );
 	m_autoQuit->setEnabled( isEnabled );
-    m_autoQuit->setHintText( tr( "Time:" ), "ms" );
+	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 	m_autoQuit->setWhatsThis( tr(
 "The Decay knob controls how many buffers of silence must pass before the "
 "plugin stops processing.  Smaller values will reduce the CPU overhead but "
@@ -88,7 +88,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_gate->setLabel( tr( "GATE" ) );
 	m_gate->move( 93, 5 );
 	m_gate->setEnabled( isEnabled );
-    m_gate->setHintText( tr( "Gate:" ), "" );
+	m_gate->setHintText( tr( "Gate:" ), "" );
 	m_gate->setWhatsThis( tr(
 "The Gate knob controls the signal level that is considered to be 'silence' "
 "while deciding when to stop processing signals." ) );

--- a/src/gui/widgets/EnvelopeAndLfoView.cpp
+++ b/src/gui/widgets/EnvelopeAndLfoView.cpp
@@ -97,7 +97,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_predelayKnob = new Knob( knobBright_26, this );
 	m_predelayKnob->setLabel( tr( "DEL" ) );
 	m_predelayKnob->move( PREDELAY_KNOB_X, ENV_KNOBS_Y );
-    m_predelayKnob->setHintText( tr( "Predelay:" ), "" );
+	m_predelayKnob->setHintText( tr( "Predelay:" ), "" );
 	m_predelayKnob->setWhatsThis(
 		tr( "Use this knob for setting predelay of the current "
 			"envelope. The bigger this value the longer the time "
@@ -107,7 +107,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_attackKnob = new Knob( knobBright_26, this );
 	m_attackKnob->setLabel( tr( "ATT" ) );
 	m_attackKnob->move( ATTACK_KNOB_X, ENV_KNOBS_Y );
-    m_attackKnob->setHintText( tr( "Attack:" ), "" );
+	m_attackKnob->setHintText( tr( "Attack:" ), "" );
 	m_attackKnob->setWhatsThis(
 		tr( "Use this knob for setting attack-time of the current "
 			"envelope. The bigger this value the longer the "
@@ -118,7 +118,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_holdKnob = new Knob( knobBright_26, this );
 	m_holdKnob->setLabel( tr( "HOLD" ) );
 	m_holdKnob->move( HOLD_KNOB_X, ENV_KNOBS_Y );
-    m_holdKnob->setHintText( tr( "Hold:" ), "" );
+	m_holdKnob->setHintText( tr( "Hold:" ), "" );
 	m_holdKnob->setWhatsThis(
 		tr( "Use this knob for setting hold-time of the current "
 			"envelope. The bigger this value the longer the "
@@ -128,7 +128,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_decayKnob = new Knob( knobBright_26, this );
 	m_decayKnob->setLabel( tr( "DEC" ) );
 	m_decayKnob->move( DECAY_KNOB_X, ENV_KNOBS_Y );
-    m_decayKnob->setHintText( tr( "Decay:" ), "" );
+	m_decayKnob->setHintText( tr( "Decay:" ), "" );
 	m_decayKnob->setWhatsThis(
 		tr( "Use this knob for setting decay-time of the current "
 			"envelope. The bigger this value the longer the "
@@ -140,7 +140,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_sustainKnob = new Knob( knobBright_26, this );
 	m_sustainKnob->setLabel( tr( "SUST" ) );
 	m_sustainKnob->move( SUSTAIN_KNOB_X, ENV_KNOBS_Y );
-    m_sustainKnob->setHintText( tr( "Sustain:" ), "" );
+	m_sustainKnob->setHintText( tr( "Sustain:" ), "" );
 	m_sustainKnob->setWhatsThis(
 		tr( "Use this knob for setting sustain-level of the current "
 			"envelope. The bigger this value the higher the level "
@@ -163,7 +163,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_amountKnob = new Knob( knobBright_26, this );
 	m_amountKnob->setLabel( tr( "AMT" ) );
 	m_amountKnob->move( AMOUNT_KNOB_X, ENV_GRAPH_Y );
-    m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
+	m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
 	m_amountKnob->setWhatsThis(
 		tr( "Use this knob for setting modulation amount of the "
 			"current envelope. The bigger this value the more the "
@@ -176,7 +176,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoPredelayKnob = new Knob( knobBright_26, this );
 	m_lfoPredelayKnob->setLabel( tr( "DEL" ) );
 	m_lfoPredelayKnob->move( LFO_PREDELAY_KNOB_X, LFO_KNOB_Y );
-    m_lfoPredelayKnob->setHintText( tr( "LFO predelay:" ), "" );
+	m_lfoPredelayKnob->setHintText( tr( "LFO predelay:" ), "" );
 	m_lfoPredelayKnob->setWhatsThis(
 		tr( "Use this knob for setting predelay-time of the current "
 			"LFO. The bigger this value the the time until the "
@@ -186,7 +186,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoAttackKnob = new Knob( knobBright_26, this );
 	m_lfoAttackKnob->setLabel( tr( "ATT" ) );
 	m_lfoAttackKnob->move( LFO_ATTACK_KNOB_X, LFO_KNOB_Y );
-    m_lfoAttackKnob->setHintText( tr( "LFO- attack:" ), "" );
+	m_lfoAttackKnob->setHintText( tr( "LFO- attack:" ), "" );
 	m_lfoAttackKnob->setWhatsThis(
 		tr( "Use this knob for setting attack-time of the current LFO. "
 			"The bigger this value the longer the LFO needs to "
@@ -196,7 +196,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoSpeedKnob = new TempoSyncKnob( knobBright_26, this );
 	m_lfoSpeedKnob->setLabel( tr( "SPD" ) );
 	m_lfoSpeedKnob->move( LFO_SPEED_KNOB_X, LFO_KNOB_Y );
-    m_lfoSpeedKnob->setHintText( tr( "LFO speed:" ), "" );
+	m_lfoSpeedKnob->setHintText( tr( "LFO speed:" ), "" );
 	m_lfoSpeedKnob->setWhatsThis(
 		tr( "Use this knob for setting speed of the current LFO. The "
 			"bigger this value the faster the LFO oscillates and "
@@ -206,7 +206,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoAmountKnob = new Knob( knobBright_26, this );
 	m_lfoAmountKnob->setLabel( tr( "AMT" ) );
 	m_lfoAmountKnob->move( LFO_AMOUNT_KNOB_X, LFO_KNOB_Y );
-    m_lfoAmountKnob->setHintText( tr( "Modulation amount:" ), "" );
+	m_lfoAmountKnob->setHintText( tr( "Modulation amount:" ), "" );
 	m_lfoAmountKnob->setWhatsThis(
 		tr( "Use this knob for setting modulation amount of the "
 			"current LFO. The bigger this value the more the "

--- a/src/gui/widgets/InstrumentFunctionViews.cpp
+++ b/src/gui/widgets/InstrumentFunctionViews.cpp
@@ -60,7 +60,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	chordLabel->setFont( pointSize<8>( chordLabel->font() ) );
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
-    m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
+	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
 	m_chordRangeKnob->setWhatsThis(
 		tr( "Use this knob for setting the chord range in octaves. "
 			"The selected chord will be played within specified "
@@ -130,7 +130,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 
 
 	m_arpRangeKnob->setLabel( tr( "RANGE" ) );
-    m_arpRangeKnob->setHintText( tr( "Arpeggio range:" ), " " + tr( "octave(s)" ) );
+	m_arpRangeKnob->setHintText( tr( "Arpeggio range:" ), " " + tr( "octave(s)" ) );
 	m_arpRangeKnob->setWhatsThis(
 		tr( "Use this knob for setting the arpeggio range in octaves. "
 			"The selected arpeggio will be played within specified "
@@ -138,7 +138,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 
 
 	m_arpTimeKnob->setLabel( tr( "TIME" ) );
-    m_arpTimeKnob->setHintText( tr( "Arpeggio time:" ), " " + tr( "ms" ) );
+	m_arpTimeKnob->setHintText( tr( "Arpeggio time:" ), " " + tr( "ms" ) );
 	m_arpTimeKnob->setWhatsThis(
 		tr( "Use this knob for setting the arpeggio time in "
 			"milliseconds. The arpeggio time specifies how long "
@@ -146,7 +146,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 
 
 	m_arpGateKnob->setLabel( tr( "GATE" ) );
-    m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
+	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 	m_arpGateKnob->setWhatsThis(
 		tr( "Use this knob for setting the arpeggio gate. The "
 			"arpeggio gate specifies the percent of a whole "

--- a/src/gui/widgets/InstrumentSoundShapingView.cpp
+++ b/src/gui/widgets/InstrumentSoundShapingView.cpp
@@ -99,7 +99,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 	m_filterCutKnob = new Knob( knobBright_26, m_filterGroupBox );
 	m_filterCutKnob->setLabel( tr( "FREQ" ) );
 	m_filterCutKnob->move( 140, 18 );
-    m_filterCutKnob->setHintText( tr( "cutoff frequency:" ), " " + tr( "Hz" ) );
+	m_filterCutKnob->setHintText( tr( "cutoff frequency:" ), " " + tr( "Hz" ) );
 	m_filterCutKnob->setWhatsThis(
 		tr( "Use this knob for setting the cutoff frequency for the "
 			"selected filter. The cutoff frequency specifies the "
@@ -112,7 +112,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 	m_filterResKnob = new Knob( knobBright_26, m_filterGroupBox );
 	m_filterResKnob->setLabel( tr( "RESO" ) );
 	m_filterResKnob->move( 196, 18 );
-    m_filterResKnob->setHintText( tr( "Resonance:" ), "" );
+	m_filterResKnob->setHintText( tr( "Resonance:" ), "" );
 	m_filterResKnob->setWhatsThis(
 		tr( "Use this knob for setting Q/Resonance for the selected "
 			"filter. Q/Resonance tells the filter how much it "

--- a/src/gui/widgets/LadspaControlView.cpp
+++ b/src/gui/widgets/LadspaControlView.cpp
@@ -100,7 +100,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 			knb->setModel( m_ctl->tempoSyncKnobModel() );
 		}
 		knb->setLabel( m_ctl->port()->name );
-        knb->setHintText( tr( "Value:" ), "" );
+		knb->setHintText( tr( "Value:" ), "" );
 		knb->setWhatsThis( tr( "Sorry, no help available." ) );
 		layout->addWidget( knb );
 		if( link != NULL )

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -849,7 +849,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 							tr( "Volume" ) );
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_it->m_volumeModel );
-    m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
+	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
 	m_volumeKnob->move( widgetWidth-2*24, 2 );
 	m_volumeKnob->setLabel( tr( "VOL" ) );
 	m_volumeKnob->show();
@@ -1176,7 +1176,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// set up volume knob
 	m_volumeKnob = new Knob( knobBright_26, NULL, tr( "Instrument volume" ) );
 	m_volumeKnob->setVolumeKnob( true );
-    m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
+	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
 	m_volumeKnob->setLabel( tr( "VOL" ) );
 
 	m_volumeKnob->setWhatsThis( tr( volume_help ) );
@@ -1185,7 +1185,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// set up panning knob
 	m_panningKnob = new Knob( knobBright_26, NULL, tr( "Panning" ) );
-    m_panningKnob->setHintText( tr( "Panning:" ), "" );
+	m_panningKnob->setHintText( tr( "Panning:" ), "" );
 	m_panningKnob->setLabel( tr( "PAN" ) );
 
 	basicControlsLayout->addWidget( m_panningKnob );
@@ -1193,7 +1193,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// set up pitch knob
 	m_pitchKnob = new Knob( knobBright_26, NULL, tr( "Pitch" ) );
-    m_pitchKnob->setHintText( tr( "Pitch:" ), " " + tr( "cents" ) );
+	m_pitchKnob->setHintText( tr( "Pitch:" ), " " + tr( "cents" ) );
 	m_pitchKnob->setLabel( tr( "PITCH" ) );
 
 	basicControlsLayout->addWidget( m_pitchKnob );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -537,7 +537,7 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 						    tr( "Track volume" ) );
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_t->m_volumeModel );
-    m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
+	m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
 	if( ConfigManager::inst()->value( "ui",
 					  "compacttrackbuttons" ).toInt() )
 	{


### PR DESCRIPTION
All knobs were called using 

``` c++
knb->setHintText( tr( "Value:" ) + " ", "" );
```

have changed to 

``` c++
knb->setHintText( tr( "Value:" ), "" );
```

as the " " was not being used.

If it is felt the + " " is needed i feel it would be better placed in Knob.h

``` c++
inline void setHintText( const QString & _txt_before,
                        const QString & _txt_after )
    {
        setDescription( _txt_before );
        setUnit( _txt_after );
    }
```
