### PR TITLE
Bitcrush: small improvement, also add some stuff to math & constants

### DIFF
--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -25,15 +25,28 @@
 #ifndef LMMS_CONSTANTS_H
 #define LMMS_CONSTANTS_H
 
-const double D_PI = 3.14159265358979323846;
-const double D_2PI = D_PI * 2.0;
-const double D_PI_2 = D_PI * 0.5;
-const double D_E = 2.71828182845904523536; 
+const long double LD_PI = 3.14159265358979323846264338327950288419716939937510;
+const long double LD_2PI = LD_PI * 2.0;
+const long double LD_PI_2 = LD_PI * 0.5;
+const long double LD_PI_R = 1.0 / LD_PI;
+const long double LD_PI_SQR = LD_PI * LD_PI;
+const long double LD_E = 2.71828182845904523536028747135266249775724709369995;
+const long double LD_E_R = 1.0 / LD_E;
 
-const float F_PI = (float) D_PI;
-const float F_2PI = (float) D_2PI;
-const float F_PI_2 = (float) D_PI_2;
-const float F_E = (float) D_E;
+const double D_PI = (double) LD_PI;
+const double D_2PI = (double) LD_2PI;
+const double D_PI_2 = (double) LD_PI_2;
+const double D_PI_R = (double) LD_PI_R;
+const double D_PI_SQR = (double) LD_PI_SQR;
+const double D_E = (double) LD_E;
+const double D_E_R = (double) LD_E_R;
 
+const float F_PI = (float) LD_PI;
+const float F_2PI = (float) LD_2PI;
+const float F_PI_2 = (float) LD_PI_2;
+const float F_PI_R = (float) LD_PI_R;
+const float F_PI_SQR = (float) LD_PI_SQR;
+const float F_E = (float) LD_E;
+const float F_E_R = (float) LD_E_R;
 
 #endif

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -289,4 +289,18 @@ static inline float fastSqrt( float n )
 	return u.f;
 }
 
+//! returns value furthest from zero
+template<class T>
+static inline T absMax( T a, T b )
+{
+	return qAbs<T>(a) > qAbs<T>(b) ? a : b;
+}
+
+//! returns value nearest to zero
+template<class T>
+static inline T absMin( T a, T b )
+{
+	return qAbs<T>(a) < qAbs<T>(b) ? a : b;
+}
+
 #endif

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -30,6 +30,8 @@ const int OS_RATE = 5;
 const float OS_RATIO = 1.0f / OS_RATE;
 const float CUTOFF_RATIO = 0.353553391f;
 const int SILENCEFRAMES = 10;
+const float OS_RESAMPLE [5] = { 0.0001490062883964112, 0.1645978376763992, 0.6705063120704088,
+		0.1645978376763992, 0.0001490062883964112 };
 
 extern "C"
 {
@@ -219,8 +221,8 @@ bool BitcrushEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 		float rsum = 0.0f;
 		for( int o = 0; o < OS_RATE; ++o )
 		{
-			lsum += m_buffer[f * OS_RATE + o][0] * OS_RATIO;
-			rsum += m_buffer[f * OS_RATE + o][1] * OS_RATIO;
+			lsum += m_buffer[f * OS_RATE + o][0] * OS_RESAMPLE[o];
+			rsum += m_buffer[f * OS_RATE + o][1] * OS_RESAMPLE[o];
 		}
 		buf[f][0] = d * buf[f][0] + w * qBound( -m_outClip, lsum, m_outClip ) * m_outGain;
 		buf[f][1] = d * buf[f][1] + w * qBound( -m_outClip, rsum, m_outClip ) * m_outGain;


### PR DESCRIPTION
Constants:
- calculate all in long double so as to improve the accuracy of our pre-calculated constants
- add some possibly useful constants: reciprocal of pi, square of pi, and reciprocal of e
  Math:
- new math convenience functions: absMax, absMin
