### PR TITLE
Proposed fix for #1411 Crash on LB302 preset preview .

### DIFF
--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -780,10 +780,12 @@ void lb302Synth::processNote( NotePlayHandle * _n )
 
 void lb302Synth::play( sampleFrame * _working_buffer )
 {
+	m_notesMutex.lock();
 	while( ! m_notes.isEmpty() )
 	{
 		processNote( m_notes.takeFirst() );
 	};
+	m_notesMutex.unlock();
 	
 	const fpp_t frames = engine::mixer()->framesPerPeriod();
 


### PR DESCRIPTION
#1411

Mutex locked m_notes. to stop them getting destroyed while being played for preview
