### PR TITLE
Remove RackView widget before deleting the ChannelView

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -194,12 +194,13 @@ void FxMixerView::refreshDisplay()
 	for( int i = 1; i<m_fxChannelViews.size(); ++i )
 	{
 		chLayout->removeWidget(m_fxChannelViews[i]->m_fxLine);
+		m_racksLayout->removeWidget( m_fxChannelViews[i]->m_rackView );
 		delete m_fxChannelViews[i]->m_fader;
 		delete m_fxChannelViews[i]->m_muteBtn;
 		delete m_fxChannelViews[i]->m_soloBtn;
 		delete m_fxChannelViews[i]->m_fxLine;
+		delete m_fxChannelViews[i]->m_rackView;
 		delete m_fxChannelViews[i];
-		m_racksLayout->removeWidget( m_fxChannelViews[i]->m_rackView );
 	}
 	m_channelAreaWidget->adjustSize();
 
@@ -363,15 +364,14 @@ void FxMixerView::deleteChannel(int index)
 
 	// delete the view
 	chLayout->removeWidget(m_fxChannelViews[index]->m_fxLine);
+	m_racksLayout->removeWidget( m_fxChannelViews[index]->m_rackView );
 	delete m_fxChannelViews[index]->m_fader;
 	delete m_fxChannelViews[index]->m_muteBtn;
 	delete m_fxChannelViews[index]->m_soloBtn;
 	delete m_fxChannelViews[index]->m_fxLine;
+	delete m_fxChannelViews[index]->m_rackView;
 	delete m_fxChannelViews[index];
 	m_channelAreaWidget->adjustSize();
-
-	// delete the fx rack
-	m_racksLayout->removeWidget( m_fxChannelViews[index]->m_rackView );
 
 	// make sure every channel knows what index it is
 	for(int i=0; i<m_fxChannelViews.size(); ++i)


### PR DESCRIPTION
Fixes the following two errors I spotted using valgrind:
When deleting a channel;
==936== Invalid read of size 8
==936==    at 0x56FA1D: FxMixerView::deleteChannel(int) (FxMixerView.cpp:374)
==936==    by 0x60E9A79: QMetaObject::activate(QObject_, QMetaObject const_, int, void**) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.6)
==936==    by 0x5216BF1: QAction::triggered(bool) (in /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.6)
==936==    by 0x52185C2: QAction::activate(QAction::ActionEvent) (in /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.6)
==936==  Address 0x14d51b90 is 32 bytes inside a block of size 40 free'd
==936==    at 0x4C2C2E0: operator delete(void_) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==936==    by 0x56F9ED: FxMixerView::deleteChannel(int) (FxMixerView.cpp:370)
==936==    by 0x60E9A79: QMetaObject::activate(QObject_, QMetaObject const*, int, void**) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.6)
==936==    by 0x5216BF1: QAction::triggered(bool) (in /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.6)

When loading a new project after adding some channels:
==936== Invalid read of size 8
==936==    at 0x570785: FxMixerView::refreshDisplay() (FxMixerView.cpp:202)
==936==    by 0x4B590E: Song::clearProject() (Song.cpp:740)
==936==    by 0x4B7885: Song::createNewProject() (Song.cpp:817)
==936==    by 0x60E9A79: QMetaObject::activate(QObject_, QMetaObject const_, int, void*_) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.6)
==936==  Address 0x56a12ab0 is 32 bytes inside a block of size 40 free'd
==936==    at 0x4C2C2E0: operator delete(void_) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==936==    by 0x57075B: FxMixerView::refreshDisplay() (FxMixerView.cpp:201)
==936==    by 0x4B590E: Song::clearProject() (Song.cpp:740)
==936==    by 0x4B7885: Song::createNewProject() (Song.cpp:817)
