### PR TITLE
Proposed fix for issue 1432 LB302 preset preview audio cut-off

### DIFF
--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -789,7 +789,7 @@ void lb302Synth::play( sampleFrame * _working_buffer )
 
 	process( _working_buffer, frames );
 	instrumentTrack()->processAudioBuffer( _working_buffer, frames, NULL );
-	release_frame = 0;
+//	release_frame = 0; //removed for issue # 1432
 }
 
 


### PR DESCRIPTION
proposed fix for #1432 
Appears to be working, I am not overly familiar with this plugin
