### PR TITLE
Proposed fix for 1450 Mem leak in sample-track

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -942,6 +942,7 @@ void SampleBuffer::visualize( QPainter & _p, const QRect & _dr,
 	_p.drawPolyline( l, nb_frames / fpp );
 	_p.drawPolyline( r, nb_frames / fpp );
 	delete[] l;
+	delete[] r;
 }
 
 


### PR DESCRIPTION
proposed fix for #1450 

Lines 928 and 929 declare local variables l and r
however only l was deleted, never r.
