### PR TITLE
reset window title every time we change the state of a subwindow to show...

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -529,6 +529,11 @@ void MainWindow::finalize()
 		setupDialog sd( setupDialog::AudioSettings );
 		sd.exec();
 	}
+	// reset window title every time we change the state of a subwindow to show the correct title
+	foreach( QMdiSubWindow * subWindow, workspace()->subWindowList() )
+	{
+		connect( subWindow, SIGNAL( windowStateChanged(Qt::WindowStates,Qt::WindowStates) ), this, SLOT( resetWindowTitle() ) );
+	}
 }
 
 


### PR DESCRIPTION
... the correct title

When maximizing a subwindow it remembers the title the mainwindow had before and resets it after unmaximizing/closing.
As the title might have changed due to a project switch, we have to reset the title again as it would else show an incorrect/old title.
This addresses issue #1267
