### PR TITLE
Proposed fix for 1049 VST knobs won't remember settings

### DIFF
--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -420,7 +420,7 @@ void VstPlugin::setParameterDump( const QMap<QString, QString> & _pdump )
 		{
 			( *it ).section( ':', 0, 0 ).toInt(),
 			"",
-			( *it ).section( ':', 1, 1 ).toFloat()
+			( *it ).section( ':', 2, -1 ).toFloat()
 		} ;
 		m.addInt( item.index );
 		m.addString( item.shortLabel );


### PR DESCRIPTION
Proposed fix for #1049 VST knobs won't remember settings

When loading individual parameters , the string was getting incorrectly parsed. using the first character of the short name. and trying to use that as the float for the value.

have tested with GComp and various URS plugins that had this problem. 
