### PR TITLE
Render between loop markers

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -172,6 +172,10 @@ public:
 
 	bool isExportDone() const;
 
+	inline void setRenderBetweenMarkers( bool renderBetweenMarkers )
+	{
+		m_renderBetweenMarkers = renderBetweenMarkers;
+	}
 
 	inline PlayModes playMode() const
 	{
@@ -334,6 +338,7 @@ private:
 	volatile bool m_recording;
 	volatile bool m_exporting;
 	volatile bool m_exportLoop;
+	volatile bool m_renderBetweenMarkers;
 	volatile bool m_playing;
 	volatile bool m_paused;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -84,6 +84,7 @@ Song::Song() :
 	m_recording( false ),
 	m_exporting( false ),
 	m_exportLoop( false ),
+	m_renderBetweenMarkers( false ),
 	m_playing( false ),
 	m_paused( false ),
 	m_loadingProject( false ),
@@ -388,11 +389,15 @@ void Song::processNextBuffer()
 
 bool Song::isExportDone() const
 {
-	if ( m_exportLoop )
+	if ( m_renderBetweenMarkers )
 	{
 		return m_exporting == true &&
 			m_playPos[Mode_PlaySong].getTicks() >= m_playPos[Mode_PlaySong].m_timeLine->loopEnd().getTicks();
-
+	}
+	if( m_exportLoop)
+	{
+		return m_exporting == true &&
+				m_playPos[Mode_PlaySong].getTicks() >= length() * ticksPerTact();
 	}
 	else
 	{
@@ -634,7 +639,7 @@ void Song::stop()
 void Song::startExport()
 {
 	stop();
-	if(m_exportLoop)
+	if(m_renderBetweenMarkers)
 	{
 		m_playPos[Mode_PlaySong].setTicks( m_playPos[Mode_PlaySong].m_timeLine->loopBegin().getTicks() );
 	}

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -260,6 +260,7 @@ ProjectRenderer* ExportProjectDialog::prepRender()
 			static_cast<ProjectRenderer::Depths>( depthCB->currentIndex() ) );
 
 	Engine::getSong()->setExportLoop( exportLoopCB->isChecked() );
+	Engine::getSong()->setRenderBetweenMarkers( renderMarkersCB->isChecked() );
 
 	ProjectRenderer* renderer = new ProjectRenderer( qs, os, m_ft, m_fileName );
 

--- a/src/gui/dialogs/export_project.ui
+++ b/src/gui/dialogs/export_project.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>ExportProjectDialog</class>
- <widget class="QDialog" name="ExportProjectDialog" >
-  <property name="geometry" >
+ <widget class="QDialog" name="ExportProjectDialog">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,118 +10,127 @@
     <height>412</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Export project</string>
   </property>
-  <layout class="QVBoxLayout" >
+  <layout class="QVBoxLayout">
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <item>
-      <widget class="QGroupBox" name="outputGroupBox" >
-       <property name="title" >
+      <widget class="QGroupBox" name="outputGroupBox">
+       <property name="title">
         <string>Output</string>
        </property>
-       <layout class="QVBoxLayout" >
-        <property name="spacing" >
-         <number>-1</number>
+       <layout class="QVBoxLayout">
+        <property name="spacing">
+         <number>6</number>
         </property>
-        <property name="leftMargin" >
+        <property name="leftMargin">
          <number>9</number>
         </property>
         <item>
-         <widget class="QLabel" name="label" >
-          <property name="text" >
+         <widget class="QLabel" name="label">
+          <property name="text">
            <string>File format:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="fileFormatCB" />
+         <widget class="QComboBox" name="fileFormatCB"/>
         </item>
         <item>
-         <widget class="QLabel" name="label_3" >
-          <property name="text" >
+         <widget class="QLabel" name="label_3">
+          <property name="text">
            <string>Samplerate:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="samplerateCB" >
+         <widget class="QComboBox" name="samplerateCB">
           <item>
-           <property name="text" >
+           <property name="text">
             <string>44100 Hz</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>48000 Hz</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>88200 Hz</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>96000 Hz</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>192000 Hz</string>
            </property>
           </item>
          </widget>
         </item>
         <item>
-         <widget class="QWidget" native="1" name="bitrateWidget" >
-          <layout class="QVBoxLayout" >
-           <property name="spacing" >
-            <number>-1</number>
+         <widget class="QWidget" name="bitrateWidget" native="true">
+          <layout class="QVBoxLayout">
+           <property name="spacing">
+            <number>6</number>
            </property>
-           <property name="margin" >
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_5" >
-             <property name="text" >
+            <widget class="QLabel" name="label_5">
+             <property name="text">
               <string>Bitrate:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="bitrateCB" >
-             <property name="currentIndex" >
+            <widget class="QComboBox" name="bitrateCB">
+             <property name="currentIndex">
               <number>2</number>
              </property>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>64 KBit/s</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>128 KBit/s</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>160 KBit/s</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>192 KBit/s</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>256 KBit/s</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>320 KBit/s</string>
               </property>
              </item>
@@ -130,27 +140,36 @@
          </widget>
         </item>
         <item>
-         <widget class="QWidget" native="1" name="depthWidget" >
-          <layout class="QVBoxLayout" >
-           <property name="margin" >
+         <widget class="QWidget" name="depthWidget" native="true">
+          <layout class="QVBoxLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_6" >
-             <property name="text" >
+            <widget class="QLabel" name="label_6">
+             <property name="text">
               <string>Depth:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="depthCB" >
+            <widget class="QComboBox" name="depthCB">
              <item>
-              <property name="text" >
+              <property name="text">
                <string>16 Bit Integer</string>
               </property>
              </item>
              <item>
-              <property name="text" >
+              <property name="text">
                <string>32 Bit Float</string>
               </property>
              </item>
@@ -161,13 +180,13 @@
         </item>
         <item>
          <spacer>
-          <property name="orientation" >
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeType" >
+          <property name="sizeType">
            <enum>QSizePolicy::Fixed</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>1</width>
             <height>10</height>
@@ -176,21 +195,21 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="label_7" >
-          <property name="text" >
+         <widget class="QLabel" name="label_7">
+          <property name="text">
            <string>Please note that not all of the parameters above apply for all file formats.</string>
           </property>
-          <property name="wordWrap" >
+          <property name="wordWrap">
            <bool>true</bool>
           </property>
          </widget>
         </item>
         <item>
          <spacer>
-          <property name="orientation" >
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>163</width>
             <height>20</height>
@@ -202,71 +221,71 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="qualityGroupBox" >
-       <property name="title" >
+      <widget class="QGroupBox" name="qualityGroupBox">
+       <property name="title">
         <string>Quality settings</string>
        </property>
-       <layout class="QVBoxLayout" >
+       <layout class="QVBoxLayout">
         <item>
-         <widget class="QLabel" name="label_2" >
-          <property name="text" >
+         <widget class="QLabel" name="label_2">
+          <property name="text">
            <string>Interpolation:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="interpolationCB" >
-          <property name="currentIndex" >
+         <widget class="QComboBox" name="interpolationCB">
+          <property name="currentIndex">
            <number>1</number>
           </property>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>Zero Order Hold</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>Sinc Fastest</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>Sinc Medium (recommended)</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>Sinc Best (very slow!)</string>
            </property>
           </item>
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_4" >
-          <property name="text" >
+         <widget class="QLabel" name="label_4">
+          <property name="text">
            <string>Oversampling (use with care!):</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="oversamplingCB" >
+         <widget class="QComboBox" name="oversamplingCB">
           <item>
-           <property name="text" >
+           <property name="text">
             <string>1x (None)</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>2x</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>4x</string>
            </property>
           </item>
           <item>
-           <property name="text" >
+           <property name="text">
             <string>8x</string>
            </property>
           </item>
@@ -280,11 +299,18 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="renderMarkersCB">
+          <property name="text">
+           <string>Export between loop markers</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer>
-          <property name="orientation" >
+          <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <property name="sizeHint" stdset="0" >
+          <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
             <height>40</height>
@@ -298,13 +324,13 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" >
+    <layout class="QHBoxLayout">
      <item>
       <spacer>
-       <property name="orientation" >
+       <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="sizeHint" stdset="0" >
+       <property name="sizeHint" stdset="0">
         <size>
          <width>40</width>
          <height>20</height>
@@ -313,15 +339,15 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="startButton" >
-       <property name="text" >
+      <widget class="QPushButton" name="startButton">
+       <property name="text">
         <string>Start</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="cancelButton" >
-       <property name="text" >
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
         <string>Cancel</string>
        </property>
       </widget>
@@ -329,11 +355,11 @@
     </layout>
    </item>
    <item>
-    <widget class="QProgressBar" name="progressBar" >
-     <property name="enabled" >
+    <widget class="QProgressBar" name="progressBar">
+     <property name="enabled">
       <bool>false</bool>
      </property>
-     <property name="value" >
+     <property name="value">
       <number>0</number>
      </property>
     </widget>
@@ -348,11 +374,11 @@
    <receiver>ExportProjectDialog</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>357</x>
      <y>293</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>202</x>
      <y>175</y>
     </hint>


### PR DESCRIPTION
I could not find an exact issue for this, but was spoke about in #1476.

![image](https://cloud.githubusercontent.com/assets/7412852/5519537/6a4c1ba4-8951-11e4-979a-1ae5c7bedfa0.png)

When Export as loop is checked, the render is between the loop markers
