### PR TITLE
Proposed fix for #1408 Window Size in windowed and full screen modes.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -636,14 +636,20 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 		_w = _w->parentWidget();
 	}
 
-	_de.setAttribute( "x", _w->x() );
-	_de.setAttribute( "y", _w->y() );
 	_de.setAttribute( "visible", _w->isVisible() );
 	_de.setAttribute( "minimized", _w->isMinimized() );
 	_de.setAttribute( "maximized", _w->isMaximized() );
 
+	bool maxed = _w->isMaximized();
+	bool mined = _w->isMinimized();
+	if( mined || maxed ) { _w->showNormal(); }
+
+	_de.setAttribute( "x", _w->x() );
+	_de.setAttribute( "y", _w->y() );
 	_de.setAttribute( "width", _w->width() );
 	_de.setAttribute( "height", _w->height() );
+	if( maxed ) { _w->showMaximized(); }
+	if( mined ) { _w->showMinimized(); }
 }
 
 


### PR DESCRIPTION
Proposed fix for #1408 Window Size in windowed and full screen modes.

Tried saving QWidget::normalGeometry, but this was not the correct approach, instead now convert widget to normal size, save data, then revert back if minimised or maximised
