### PR TITLE
Fix size reset for maximized windows

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -662,8 +662,8 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 
 void MainWindow::restoreWidgetState( QWidget * _w, const QDomElement & _de )
 {
-	QRect r( qMax( 0, _de.attribute( "x" ).toInt() ),
-			qMax( 0, _de.attribute( "y" ).toInt() ),
+	QRect r( qMax( 1, _de.attribute( "x" ).toInt() ),
+			qMax( 1, _de.attribute( "y" ).toInt() ),
 			qMax( 100, _de.attribute( "width" ).toInt() ),
 			qMax( 100, _de.attribute( "height" ).toInt() ) );
 	if( _de.hasAttribute( "visible" ) && !r.isNull() )


### PR DESCRIPTION
When a window is maximized and a new project with the window saved as not maximized and positioned at the upper left corner, it doesn't display the window correctly. By moving the window down and right by 1, we can work around this behaviour. To test it out, maximize the song editor and open Popsip-Electronic Dancer.mmpz under CoolSongs. This is also described at issue #1267
