### PR TITLE
Hide windows instead of closing them when clicking on close

### DIFF
--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -61,6 +61,9 @@ public slots:
 	void addSteps();
 	void removeSteps();
 
+protected:
+	virtual void closeEvent( QCloseEvent * _ce );
+
 private:
 	virtual void keyPressEvent( QKeyEvent * _ke );
 

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -26,6 +26,7 @@
 #define CONTROLLER_RACK_VIEW_H
 
 #include <QWidget>
+#include <QCloseEvent>
 
 #include "SerializingObject.h"
 #include "lmms_basics.h"
@@ -56,6 +57,8 @@ public:
 public slots:
 	void deleteController( ControllerView * _view );
 
+protected:
+	virtual void closeEvent( QCloseEvent * _ce );
 
 private slots:
 	virtual void update();

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -99,6 +99,9 @@ public:
 	// make sure the display syncs up with the fx mixer.
 	// useful for loading projects
 	void refreshDisplay();
+
+protected:
+	virtual void closeEvent( QCloseEvent * _ce );
 	
 private slots:
 	void updateFaders();

--- a/include/ProjectNotes.h
+++ b/include/ProjectNotes.h
@@ -27,6 +27,7 @@
 #define PROJECT_NOTES_H
 
 #include <QMainWindow>
+#include <QCloseEvent>
 
 #include "JournallingObject.h"
 
@@ -56,6 +57,7 @@ public:
 
 
 protected:
+	virtual void closeEvent( QCloseEvent * _ce );
 	void setupActions();
 
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -65,6 +65,8 @@ public:
 public slots:
 	void scrolled( int _new_pos );
 
+protected:
+	virtual void closeEvent( QCloseEvent * _ce );
 
 private slots:
 	void setHighQuality( bool );

--- a/src/gui/BBEditor.cpp
+++ b/src/gui/BBEditor.cpp
@@ -322,4 +322,16 @@ void BBEditor::keyPressEvent( QKeyEvent * _ke )
 
 
 
+void BBEditor::closeEvent( QCloseEvent * _ce )
+ {
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+	_ce->ignore();
+ }
 

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -480,6 +480,21 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 
 
 
+void FxMixerView::closeEvent( QCloseEvent * _ce )
+ {
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+	_ce->ignore();
+ }
+
+
+
 void FxMixerView::setCurrentFxLine( int _line )
 {
 	if( _line >= 0 && _line < m_fxChannelViews.size() )

--- a/src/gui/SongEditor.cpp
+++ b/src/gui/SongEditor.cpp
@@ -576,6 +576,21 @@ void SongEditor::wheelEvent( QWheelEvent * _we )
 
 
 
+void SongEditor::closeEvent( QCloseEvent * _ce )
+ {
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+	_ce->ignore();
+ }
+
+
+
 
 void SongEditor::masterVolumeChanged( int _new_val )
 {

--- a/src/gui/widgets/ControllerRackView.cpp
+++ b/src/gui/widgets/ControllerRackView.cpp
@@ -195,4 +195,16 @@ void ControllerRackView::addController()
 
 
 
+void ControllerRackView::closeEvent( QCloseEvent * _ce )
+ {
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+	_ce->ignore();
+ }
 

--- a/src/gui/widgets/ProjectNotes.cpp
+++ b/src/gui/widgets/ProjectNotes.cpp
@@ -396,4 +396,17 @@ void ProjectNotes::loadSettings( const QDomElement & _this )
 
 
 
+void ProjectNotes::closeEvent( QCloseEvent * _ce )
+{
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+	_ce->ignore();
+ }
+
 


### PR DESCRIPTION
This implements event handlers to prevent the windows from being closed and hiding them instead. There is a difference between closing and hiding a window. When you close a window and open a project where this window is visible, it is empty, or in case of the FXMixerView, only displays the title bar. You can reproduce this by opening lmms, closing all windows and opening any project. All windows will be blank.