### PR TITLE
Fix PianoRoll changing editMode outside window

### DIFF
--- a/src/gui/PianoRoll.cpp
+++ b/src/gui/PianoRoll.cpp
@@ -1480,10 +1480,13 @@ void PianoRoll::keyPressEvent( QKeyEvent* event )
 		}
 
 		case Qt::Key_Control:
-			m_ctrlMode = m_editMode;
-			m_editMode = ModeSelect;
-			QApplication::changeOverrideCursor( Qt::ArrowCursor );
-			event->accept();
+			if ( isActiveWindow() )
+			{
+				m_ctrlMode = m_editMode;
+				m_editMode = ModeSelect;
+				QApplication::changeOverrideCursor( Qt::ArrowCursor );
+				event->accept();
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
If an user Ctrl+Clicked on a track, e.g. copying/muting it, but the
focus was still on the PianoRoll window the mode would change

Fix #1501 

Please bear in mind that this can be one of a class of bugs related to the keyPress event being triggered outside of the window without being keyReleased, this is a very simple fix for this specific case. A different `FocusPolicy` or a check in the beggining of this function may be better solutions.
