### PR TITLE
Proposed fix for 1150 Preset Browser: division between factory and user ...

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -161,6 +161,8 @@ private:
 	QStringList m_directories;
 	QString m_filter;
 
+	int m_dirCount;
+
 } ;
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -708,7 +708,8 @@ Directory::Directory(const QString & filename, const QString & path,
 						const QString & filter ) :
 	QTreeWidgetItem( QStringList( filename ), TypeDirectoryItem ),
 	m_directories( path ),
-	m_filter( filter )
+	m_filter( filter ),
+	m_dirCount( 0 )
 {
 	initPixmaps();
 
@@ -762,6 +763,7 @@ void Directory::update( void )
 	setIcon( 0, *s_folderOpenedPixmap );
 	if( !childCount() )
 	{
+		m_dirCount = 0;
 		for( QStringList::iterator it = m_directories.begin();
 					it != m_directories.end(); ++it )
 		{
@@ -776,7 +778,7 @@ void Directory::update( void )
 						"--- Factory files ---" ) );
 				sep->setIcon( 0, embed::getIconPixmap(
 							"factory_files" ) );
-				insertChild( top_index, sep );
+				insertChild(  m_dirCount + top_index - 1, sep );
 			}
 		}
 	}
@@ -814,6 +816,7 @@ bool Directory::addItems(const QString & path )
 					insertChild( i, new Directory( cur_file,
 							path, m_filter ) );
 					orphan = false;
+					m_dirCount++;
 					break;
 				}
 				else if( cur_file == d->text( 0 ) )
@@ -827,6 +830,7 @@ bool Directory::addItems(const QString & path )
 			{
 				addChild( new Directory( cur_file, path,
 								m_filter ) );
+				m_dirCount++;
 			}
 
 			added_something = true;


### PR DESCRIPTION
Proposed fix for  #1150 Preset Browser: division between factory and user files fails if factory has folders

![image](https://cloud.githubusercontent.com/assets/7412852/5557268/0204f98e-8cef-11e4-8bd2-a65722ec8ad3.png)

Simply added a counter to the Directory class. that is incremented for every child directory added.

Then used this counter to calc the position in tree of --Factory Presets --
