### PR TITLE
Use rounded rectangles to draw notes

### DIFF
--- a/src/gui/PianoRoll.cpp
+++ b/src/gui/PianoRoll.cpp
@@ -963,47 +963,29 @@ inline void PianoRoll::drawNoteRect( QPainter & _p, int _x, int _y,
 	{
 		//step note
 		col.setRgb( 0, 255, 0 );
-		_p.fillRect( _x, _y, _width, KEY_LINE_HEIGHT - 2, col );
 	}
 	else if( _n->selected() )
 	{
 		col.setRgb( 0x00, 0x40, 0xC0 );
-		_p.fillRect( _x, _y, _width, KEY_LINE_HEIGHT - 2, col );
-	}
-	else
-	{
-		// adjust note to make it a bit faded if it has a lower volume
-		// in stereo using gradients
-		QColor lcol = QColor::fromHsv( col.hue(), col.saturation(),
-							volVal * leftPercent );
-		QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
-							volVal * rightPercent );
-		col = QColor::fromHsv( col.hue(), col.saturation(), volVal );
-
-		QLinearGradient gradient( _x, _y, _x+_width,
-							_y+KEY_LINE_HEIGHT );
-		gradient.setColorAt( 0, lcol );
-		gradient.setColorAt( 1, rcol );
-		_p.setBrush( gradient );
-		_p.setPen( Qt::NoPen );
-		_p.drawRect( _x, _y, _width, KEY_LINE_HEIGHT-1 );
 	}
 
-	// hilighting lines around the note
-	_p.setPen( Qt::SolidLine );
-	_p.setBrush( Qt::NoBrush );
+	// adjust note to make it a bit faded if it has a lower volume
+	// in stereo using gradients
+	QColor lcol = QColor::fromHsv( col.hue(), col.saturation(),
+						volVal * leftPercent );
+	QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
+						volVal * rightPercent );
+	col = QColor::fromHsv( col.hue(), col.saturation(), volVal );
 
-	col = QColor( noteCol );
+	QLinearGradient gradient( _x, _y, _x+_width,
+						_y+KEY_LINE_HEIGHT );
+	gradient.setColorAt( 0, lcol );
+	gradient.setColorAt( 1, rcol );
+	_p.setBrush( gradient );
 	_p.setPen( QColor::fromHsv( col.hue(), col.saturation(),
 					qMin<float>( 255, volVal*1.7f ) ) );
-	_p.drawLine( _x, _y, _x + _width, _y );
-	_p.drawLine( _x, _y, _x, _y + KEY_LINE_HEIGHT - 2 );
-
-	col = QColor( noteCol );
-	_p.setPen( QColor::fromHsv( col.hue(), col.saturation(), volVal/1.7 ) );
-	_p.drawLine( _x + _width, _y, _x + _width, _y + KEY_LINE_HEIGHT - 2 );
-	_p.drawLine( _x, _y + KEY_LINE_HEIGHT - 2, _x + _width,
-						_y + KEY_LINE_HEIGHT - 2 );
+	_p.setRenderHint(QPainter::Antialiasing);
+	_p.drawRoundedRect( _x, _y, _width, KEY_LINE_HEIGHT-1, 5, 2 );
 
 	// that little tab thing on the end hinting at the user
 	// to resize the note


### PR DESCRIPTION
Improve the drawing method of the notes using a rounded rectangle, it is simpler and (at least for me) looks better.

Screenshot containing notes with different lengths, volumes and panning:

![2014-12-26-151211_416x349_scrot](https://cloud.githubusercontent.com/assets/347552/5558524/113092d8-8d12-11e4-984e-8a77af3582e2.png)

As @diizy pointed out on #64 this will be refactored into a collection of views instead of drawing the notes, but at least this is an improvement for the time being until it gets implemented. (I wanted to make it myself but I was having too much trouble).
