### PR TITLE
attempt to fix #1512

### DIFF
--- a/include/AudioPort.h
+++ b/include/AudioPort.h
@@ -35,13 +35,15 @@
 
 class EffectChain;
 class FloatModel;
+class BoolModel;
 
 class AudioPort : public ThreadableJob
 {
 	MM_OPERATORS
 public:
-	AudioPort( const QString & _name, bool _has_effect_chain = true, 
-		FloatModel * volumeModel = NULL, FloatModel * panningModel = NULL );
+	AudioPort( const QString & _name, bool _has_effect_chain = true,
+		FloatModel * volumeModel = NULL, FloatModel * panningModel = NULL,
+		BoolModel * mutedModel = NULL );
 	virtual ~AudioPort();
 
 	inline sampleFrame * buffer()
@@ -117,14 +119,15 @@ private:
 	fx_ch_t m_nextFxChannel;
 
 	QString m_name;
-	
+
 	EffectChain * m_effects;
 
 	PlayHandleList m_playHandles;
 	QMutex m_playHandleLock;
-	
+
 	FloatModel * m_volumeModel;
 	FloatModel * m_panningModel;
+	BoolModel * m_mutedModel;
 
 	friend class Mixer;
 	friend class MixerWorkerThread;

--- a/include/Track.h
+++ b/include/Track.h
@@ -120,7 +120,7 @@ public:
 	{
 		return m_length;
 	}
-	
+
 	virtual void movePosition( const MidiTime & _pos );
 	virtual void changeLength( const MidiTime & _length );
 
@@ -539,7 +539,9 @@ private:
 	QString m_name;
 	int m_height;
 
+protected:
 	BoolModel m_mutedModel;
+private:
 	BoolModel m_soloModel;
 	bool m_mutedBeforeSolo;
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -104,7 +104,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 							tr( "Base note" ) ),
 	m_volumeModel( DefaultVolume, MinVolume, MaxVolume, 0.1f, this, tr( "Volume" ) ),
 	m_panningModel( DefaultPanning, PanningLeft, PanningRight, 0.1f, this, tr( "Panning" ) ),
-	m_audioPort( tr( "unnamed_track" ), true, &m_volumeModel, &m_panningModel ),
+	m_audioPort( tr( "unnamed_track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel ),
 	m_pitchModel( 0, MinPitchDefault, MaxPitchDefault, 1, this, tr( "Pitch" ) ),
 	m_pitchRangeModel( 1, 1, 24, this, tr( "Pitch range" ) ),
 	m_effectChannelModel( 0, 0, 0, this, tr( "FX channel" ) ),
@@ -338,7 +338,7 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 					break;
 			}
 			break;
-			
+
 		default:
 			break;
 	}
@@ -840,7 +840,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	{
 		widgetWidth = DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT;
 	}
-	else 
+	else
 	{
 		widgetWidth = DEFAULT_SETTINGS_WIDGET_WIDTH;
 	}
@@ -949,8 +949,8 @@ InstrumentTrackWindow * InstrumentTrackView::topLevelInstrumentTrackWindow()
 
 
 
-// TODO: Add windows to free list on freeInstrumentTrackWindow. 
-// But, don't NULL m_window or disconnect signals.  This will allow windows 
+// TODO: Add windows to free list on freeInstrumentTrackWindow.
+// But, don't NULL m_window or disconnect signals.  This will allow windows
 // that are being show/hidden frequently to stay connected.
 void InstrumentTrackView::freeInstrumentTrackWindow()
 {
@@ -975,7 +975,7 @@ void InstrumentTrackView::freeInstrumentTrackWindow()
 		{
 			delete m_window;
 		}
-		
+
 		m_window = NULL;
 	}
 }
@@ -1002,7 +1002,7 @@ InstrumentTrackWindow * InstrumentTrackView::getInstrumentTrackWindow()
 	else if( !s_windowCache.isEmpty() )
 	{
 		m_window = s_windowCache.dequeue();
-		
+
 		m_window->setInstrumentTrackView( this );
 		m_window->setModel( model() );
 		m_window->updateInstrumentView();
@@ -1028,7 +1028,7 @@ InstrumentTrackWindow * InstrumentTrackView::getInstrumentTrackWindow()
 			s_windowCache << m_window;
 		}
 	}
-		
+
 	return m_window;
 }
 
@@ -1059,7 +1059,7 @@ void InstrumentTrackView::dropEvent( QDropEvent * _de )
 void InstrumentTrackView::toggleInstrumentWindow( bool _on )
 {
 	getInstrumentTrackWindow()->toggleVisibility( _on );
-	
+
 	if( !_on )
 	{
 		freeInstrumentTrackWindow();
@@ -1119,10 +1119,10 @@ void InstrumentTrackView::midiConfigChanged()
 
 
 
-class fxLineLcdSpinBox : public LcdSpinBox 
+class fxLineLcdSpinBox : public LcdSpinBox
 {
 	public:
-		fxLineLcdSpinBox( int _num_digits, QWidget * _parent, 
+		fxLineLcdSpinBox( int _num_digits, QWidget * _parent,
 				const QString & _name ) :
 			LcdSpinBox( _num_digits, _parent, _name ) {}
 
@@ -1336,7 +1336,7 @@ void InstrumentTrackWindow::modelChanged()
 			this, SLOT( updateName() ) );
 	connect( m_track, SIGNAL( instrumentChanged() ),
 			this, SLOT( updateInstrumentView() ) );
-	
+
 	m_volumeKnob->setModel( &m_track->m_volumeModel );
 	m_panningKnob->setModel( &m_track->m_panningModel );
 	m_effectChannelNumber->setModel( &m_track->m_effectChannelModel );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -387,11 +387,11 @@ void SampleTCOView::paintEvent( QPaintEvent * _pe )
 	{
 		p.setFont( pointSize<7>( p.font() ) );
 
-		p.setPen( QColor( 0, 0, 0 ) );	
+		p.setPen( QColor( 0, 0, 0 ) );
 		p.drawText( 10, p.fontMetrics().height()+1, "Rec" );
-		p.setPen( textColor() );	
+		p.setPen( textColor() );
 		p.drawText( 9, p.fontMetrics().height(), "Rec" );
-		
+
 		p.setBrush( QBrush( textColor() ) );
 		p.drawEllipse( 4, 5, 4, 4 );
 	}
@@ -408,7 +408,7 @@ SampleTrack::SampleTrack( TrackContainer* tc ) :
 							tr( "Volume" ) ),
 	m_panningModel( DefaultPanning, PanningLeft, PanningRight, 0.1f,
 					this, tr( "Panning" ) ),
-	m_audioPort( tr( "Sample track" ), true, &m_volumeModel, &m_panningModel )
+	m_audioPort( tr( "Sample track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel )
 {
 	setName( tr( "Sample track" ) );
 	m_panningModel.setCenterValue( DefaultPanning );
@@ -610,8 +610,3 @@ void SampleTrackView::modelChanged()
 
 	TrackView::modelChanged();
 }
-
-
-
-
-


### PR DESCRIPTION
yes, I am aware of #1514 

This approach is simpler: it passes the track's mute model to `AudioPort` and simply skips processing if its value is true. Sample track muting works too.