### PR TITLE
Proposed fix for 1352  Ifreeze when adding instruments or moving mixer tracks

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -33,6 +33,7 @@
 
 #include "Track.h"
 #include "JournallingObject.h"
+#include "InstrumentTrack.h"
 
 
 class QVBoxLayout;
@@ -182,6 +183,23 @@ signals:
 
 } ;
 
+class InstrumentLoaderThread : public QThread
+{
+	Q_OBJECT
+public:
+	InstrumentLoaderThread( QObject *parent = 0 , InstrumentTrack *it = 0, QString name = "" );
+
+	void run();
+
+
+private:
+
+	InstrumentTrack *m_it;
+	QString m_name;
+
+
+
+};
 
 
 #endif

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -47,6 +47,9 @@
 #include "Track.h"
 
 
+
+
+
 TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	QWidget(),
 	ModelView( NULL, this ),
@@ -325,7 +328,8 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
 				Track::create( Track::InstrumentTrack,
 								m_tc ) );
-		it->loadInstrument( value );
+		InstrumentLoaderThread *ilt = new InstrumentLoaderThread( this, it, value);
+		ilt->start();
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
@@ -449,6 +453,19 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 		QScrollArea::wheelEvent( _we );
 	}
 }
+
+ InstrumentLoaderThread::InstrumentLoaderThread( QObject *parent, InstrumentTrack *it, QString name) : QThread( parent )
+{
+	m_it = it;
+	m_name = name;
+}
+
+void InstrumentLoaderThread::run()
+{
+	m_it->loadInstrument( m_name );
+}
+
+
 
 
 


### PR DESCRIPTION
Proposed fix for #1352  Ifreeze when adding instruments or moving mixer tracks

The Instruments we being loaded on the main thread, and causing deadlock with MixerWorkerThread.
I have moved the loading of instruments from the gui into a separate thread, thus avoiding the deadlock.

You may want to check i have done this right, as I am out of my comfort zone.
