### PR TITLE
Collect effects errors to show on summary window

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -61,16 +61,6 @@ public:
 		return s_hasGUI;
 	}
 
-	static void setSuppressMessages( bool _on )
-	{
-		s_suppressMessages = _on;
-	}
-
-	static bool suppressMessages()
-	{
-		return !s_hasGUI || s_suppressMessages;
-	}
-
 	// core
 	static Mixer *mixer()
 	{
@@ -172,7 +162,6 @@ private:
 	}
 
 	static bool s_hasGUI;
-	static bool s_suppressMessages;
 	static float s_framesPerTick;
 
 	// core

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -39,6 +39,7 @@
 #include "ControllerConnection.h"
 #include "MemoryManager.h"
 #include "ValueBuffer.h"
+#include "MainWindow.h"
 
 #include "embed.cpp"
 
@@ -74,12 +75,11 @@ LadspaEffect::LadspaEffect( Model * _parent,
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 	if( manager->getDescription( m_key ) == NULL )
 	{
-		if( !Engine::suppressMessages() )
+		if ( Engine::hasGUI() )
 		{
-			QMessageBox::warning( 0, tr( "Effect" ), 
-				tr( "Unknown LADSPA plugin %1 requested." ).
-							arg( m_key.second ),
-				QMessageBox::Ok, QMessageBox::NoButton );
+			Engine::mainWindow()->collectError(
+				tr( "Unknown LADSPA plugin %1 requested." ).arg(
+					m_key.second ) );
 		}
 		setOkay( false );
 		return;

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -87,3 +87,6 @@ private:
 } ;
 
 #endif
+
+
+

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -47,7 +47,6 @@
 
 
 bool Engine::s_hasGUI = true;
-bool Engine::s_suppressMessages = false;
 float Engine::s_framesPerTick;
 Mixer* Engine::s_mixer = NULL;
 FxMixer * Engine::s_fxMixer = NULL;

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -126,8 +126,6 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 	const bool j = Engine::projectJournal()->isJournalling();
 	Engine::projectJournal()->setJournalling( false );
 
-	Engine::setSuppressMessages( true );
-
 	if( _load_by_plugin )
 	{
 		Instrument * i = s_previewTC->previewInstrumentTrack()->instrument();
@@ -151,8 +149,6 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 			loadTrackSpecificSettings(
 				dataFile.content().firstChild().toElement() );
 	}
-
-	Engine::setSuppressMessages( false );
 
 	// make sure, our preset-preview-track does not appear in any MIDI-
 	// devices list, so just disable receiving/sending MIDI-events at all


### PR DESCRIPTION
Instead of showing serial warning messages when loading a project when having problems with effects, collect them for posterior summarization.

This is similar to #55 but for errors when loading LADSPA effects.

Please note the removed `Engine::setSuppressMessages` calls due to the fact that these messages will already not be shown until `mainWindow()->showErrors` is called. This should not affect the errors for other songs as the list of errors is cleared on the beggining of the song opening function.

There are other places where we can already replace those message boxes with collect errors, for example [here](https://github.com/badosu/lmms/blob/collect-effects-errors/plugins/MidiImport/MidiImport.cpp#L98-L122). The main advantage is that we can abstract on `showErrors` if we are on GUI or CLI and then put the errors on standard out or the message box. We then can get rid of many `hasGUI` calls and probably enable visualization of errors on the CLI export (I guess they are hidden today?). But for now I am going to fix just the simple case.

Since this is an improvement over a feature that has broken CLI export feature, please merge #1513 before so that I can rebase this PR over on master, it is a very simple and straightforward bugfix.

Before (3 messages like this):

![2014-12-28-061002_534x171_scrot](https://cloud.githubusercontent.com/assets/347552/5565878/5050ac8e-8ef5-11e4-84ea-b5eb0e987c58.png)

After:

![2014-12-29-005242_592x347_scrot](https://cloud.githubusercontent.com/assets/347552/5565883/78e62322-8ef5-11e4-9920-4d78247025fa.png)
