### PR TITLE
[WIP] Refactor errors notification system

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -58,16 +58,6 @@ public:
 
 	static bool hasGUI();
 
-	static void setSuppressMessages( bool _on )
-	{
-		s_suppressMessages = _on;
-	}
-
-	static bool suppressMessages()
-	{
-		return !hasGUI() || s_suppressMessages;
-	}
-
 	// core
 	static Mixer *mixer()
 	{
@@ -127,7 +117,7 @@ private:
 		delete tmp;
 	}
 
-	static bool s_suppressMessages;
+	static bool s_hasGUI;
 	static float s_framesPerTick;
 
 	// core

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -117,7 +117,6 @@ private:
 		delete tmp;
 	}
 
-	static bool s_hasGUI;
 	static float s_framesPerTick;
 
 	// core

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -30,8 +30,6 @@
 #include <QtCore/QList>
 #include <QMainWindow>
 
-#include "export.h"
-
 class QAction;
 class QDomElement;
 class QGridLayout;
@@ -42,7 +40,7 @@ class PluginView;
 class ToolButton;
 
 
-class EXPORT MainWindow : public QMainWindow
+class MainWindow : public QMainWindow
 {
 	Q_OBJECT
 public:
@@ -96,12 +94,6 @@ public:
 
 	static void saveWidgetState( QWidget * _w, QDomElement & _de );
 	static void restoreWidgetState( QWidget * _w, const QDomElement & _de );
-
-	void collectErrors( const QList<QString>* errors );
-	void collectError( const QString & error );
-	void clearErrors();
-	void showErrors( const QString & reason );
-
 
 public slots:
 	void resetWindowTitle();
@@ -178,8 +170,6 @@ private:
 	QBasicTimer m_updateTimer;
 	QTimer m_autoSaveTimer;
 
-	QList<QString>* m_errors;
-
 	friend class GuiApplication;
 
 
@@ -199,4 +189,3 @@ signals:
 } ;
 
 #endif
-

--- a/include/Song.h
+++ b/include/Song.h
@@ -65,6 +65,10 @@ public:
 		Mode_Count
 	} ;
 
+	void clearErrors();
+	void collectError( const QString error );
+	bool hasErrors();
+	QString* errorSummary();
 
 	class playPos : public MidiTime
 	{
@@ -343,6 +347,8 @@ private:
 	volatile bool m_paused;
 
 	bool m_loadingProject;
+
+	QList<QString> * m_errors;
 
 	PlayModes m_playMode;
 	playPos m_playPos[Mode_Count];

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -39,7 +39,7 @@
 #include "ControllerConnection.h"
 #include "MemoryManager.h"
 #include "ValueBuffer.h"
-#include "MainWindow.h"
+#include "Song.h"
 
 #include "embed.cpp"
 
@@ -75,12 +75,8 @@ LadspaEffect::LadspaEffect( Model * _parent,
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 	if( manager->getDescription( m_key ) == NULL )
 	{
-		if ( Engine::hasGUI() )
-		{
-			Engine::mainWindow()->collectError(
-				tr( "Unknown LADSPA plugin %1 requested." ).arg(
-					m_key.second ) );
-		}
+		Engine::getSong()->collectError(tr( "Unknown LADSPA plugin %1 requested." ).arg(
+											m_key.second ) );
 		setOkay( false );
 		return;
 	}

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -39,6 +39,7 @@
 #include "ControllerConnection.h"
 #include "MemoryManager.h"
 #include "ValueBuffer.h"
+#include "MainWindow.h"
 
 #include "embed.cpp"
 
@@ -74,12 +75,11 @@ LadspaEffect::LadspaEffect( Model * _parent,
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 	if( manager->getDescription( m_key ) == NULL )
 	{
-		if( !Engine::suppressMessages() )
+		if ( Engine::hasGUI() )
 		{
-			QMessageBox::warning( 0, tr( "Effect" ), 
-				tr( "Unknown LADSPA plugin %1 requested." ).
-							arg( m_key.second ),
-				QMessageBox::Ok, QMessageBox::NoButton );
+			Engine::mainWindow()->collectError(
+				tr( "Unknown LADSPA plugin %1 requested." ).arg(
+					m_key.second ) );
 		}
 		setOkay( false );
 		return;

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -34,8 +34,6 @@
 #include "audio_file_processor.h"
 #include "Engine.h"
 #include "Song.h"
-#include "MainWindow.h"
-#include "GuiApplication.h"
 #include "InstrumentTrack.h"
 #include "NotePlayHandle.h"
 #include "interpolation.h"
@@ -242,7 +240,7 @@ void audioFileProcessor::loadSettings( const QDomElement & _this )
 		{
 			QString message = tr( "Sample not found: %1" ).arg( m_sampleBuffer.audioFile() );
 
-			gui->mainWindow()->collectError( message );
+			Engine::getSong()->collectError( message );
 		}
 	}
 	else if( _this.attribute( "sampledata" ) != "" )

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -40,7 +40,6 @@
 
 #include "GuiApplication.h"
 
-bool Engine::s_hasGUI = true;
 float Engine::s_framesPerTick;
 Mixer* Engine::s_mixer = NULL;
 FxMixer * Engine::s_fxMixer = NULL;

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -40,8 +40,7 @@
 
 #include "GuiApplication.h"
 
-
-bool Engine::s_suppressMessages = false;
+bool Engine::s_hasGUI = true;
 float Engine::s_framesPerTick;
 Mixer* Engine::s_mixer = NULL;
 FxMixer * Engine::s_fxMixer = NULL;

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -35,7 +35,7 @@
 #include "ConfigManager.h"
 #include "DummyPlugin.h"
 #include "AutomatableModel.h"
-#include "MainWindow.h"
+#include "Song.h"
 
 
 static PixmapLoader __dummy_loader;
@@ -128,7 +128,7 @@ Plugin * Plugin::instantiate( const QString & pluginName, Model * parent,
 
 void Plugin::collectErrorForUI( QString err_msg )
 {
-	gui->mainWindow()->collectError( err_msg );
+	Engine::getSong()->collectError( err_msg );
 }
 
 

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -126,8 +126,6 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 	const bool j = Engine::projectJournal()->isJournalling();
 	Engine::projectJournal()->setJournalling( false );
 
-	Engine::setSuppressMessages( true );
-
 	if( _load_by_plugin )
 	{
 		Instrument * i = s_previewTC->previewInstrumentTrack()->instrument();
@@ -161,8 +159,6 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 			s_previewTC->previewInstrumentTrack()->setVolume( 0 );
 		}
 	}
-
-	Engine::setSuppressMessages( false );
 
 	// make sure, our preset-preview-track does not appear in any MIDI-
 	// devices list, so just disable receiving/sending MIDI-events at all

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -190,8 +190,6 @@ MainWindow::MainWindow() :
 	vbox->addWidget( w );
 	setCentralWidget( main_widget );
 
-	m_errors = new QList<QString>();
-
 	m_updateTimer.start( 1000 / 20, this );	// 20 fps
 
 	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() )
@@ -1223,45 +1221,5 @@ void MainWindow::autoSave()
 	{
 		// try again in 10 seconds
 		QTimer::singleShot( 10*1000, this, SLOT( autoSave() ) );
-	}
-}
-
-
-
-void MainWindow::collectErrors(const QList<QString>* errors )
-{
-	m_errors->append( *errors );
-}
-
-
-
-void MainWindow::collectError( const QString & error )
-{
-	m_errors->append( error );
-}
-
-
-
-void MainWindow::clearErrors()
-{
-	m_errors->clear();
-}
-
-
-
-void MainWindow::showErrors( const QString & message )
-{
-    if ( m_errors->length() != 0 )
-	{   QString* errors = new QString();
-		for ( int i = 0 ; i < m_errors->length() ; i++ )
-		{
-			errors->append( m_errors->value( i ) + "\n" );
-		}
-		errors->prepend( "\n\n" );
-		errors->prepend( message );
-		QMessageBox::warning( NULL,
-			"LMMS Error report",
-			*errors,
-			QMessageBox::Ok );
 	}
 }


### PR DESCRIPTION
Refer to #1524 for the briefing of this PR.

Refactors the song errors notification system, now the export project displays when errors occurred:

![2014-12-29-035448_905x296_scrot](https://cloud.githubusercontent.com/assets/347552/5566454/7d6152fe-8f0f-11e4-9403-c2c3470c64c5.png)

Also collects errors when effects or plugins can't be loaded.

This PR has the implication that we are now able to replace all of those message boxes with the `hasGUI` check for the simple `collectError` call which displays when exporting as well.
