### PR TITLE
Proposed fix 1527 Channel note on indicator doesn't fire when a very high note is played.

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -38,6 +38,7 @@
 #include "Track.h"
 
 
+
 class QLineEdit;
 template<class T> class QQueue;
 class InstrumentFunctionArpeggioView;
@@ -202,10 +203,10 @@ public:
 		return &m_effectChannelModel;
 	}
 
+	void setIndicator( FadeButton *fb );
 
 signals:
 	void instrumentChanged();
-	void newNote();
 	void midiNoteOn( const Note& );
 	void midiNoteOff( const Note& );
 	void nameChanged();
@@ -249,6 +250,8 @@ private:
 	FloatModel m_pitchModel;
 	IntModel m_pitchRangeModel;
 	IntModel m_effectChannelModel;
+
+	FadeButton *m_fb;
 
 
 	Instrument * m_instrument;

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -49,6 +49,7 @@
 #include "EffectRackView.h"
 #include "embed.h"
 #include "Engine.h"
+#include "FadeButton.h"
 #include "FileBrowser.h"
 #include "FxMixer.h"
 #include "FxMixerView.h"
@@ -378,9 +379,10 @@ void InstrumentTrack::processOutEvent( const MidiEvent& event, const MidiTime& t
 				}
 				++m_runningMidiNotes[key];
 				m_instrument->handleMidiEvent( MidiEvent( MidiNoteOn, midiPort()->realOutputChannel(), key, event.velocity() ), time, offset );
+
 			}
 			m_midiNotesMutex.unlock();
-			emit newNote();
+			m_fb->activate();
 			break;
 
 		case MidiNoteOff:
@@ -560,6 +562,12 @@ void InstrumentTrack::removeMidiPortNode( DataFile & _dataFile )
 	QDomNodeList n = _dataFile.elementsByTagName( "midiport" );
 	n.item( 0 ).parentNode().removeChild( n.item( 0 ) );
 }
+
+void InstrumentTrack::setIndicator(FadeButton *fb)
+{
+	m_fb = fb;
+}
+
 
 
 
@@ -910,9 +918,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 				this, SLOT( activityIndicatorPressed() ) );
 	connect( m_activityIndicator, SIGNAL( released() ),
 				this, SLOT( activityIndicatorReleased() ) );
-	connect( _it, SIGNAL( newNote() ),
-				m_activityIndicator, SLOT( activate() ) );
-
+	_it->setIndicator( m_activityIndicator );
 
 	setModel( _it );
 }


### PR DESCRIPTION
Proposed fix 1527 Channel note on indicator doesn't fire when a very high note is played.

Now the Instrument activity indicator flashed when a note is played.
