### PR TITLE
Fix export for some locales

### DIFF
--- a/src/gui/export_project_dialog.cpp
+++ b/src/gui/export_project_dialog.cpp
@@ -253,8 +253,8 @@ ProjectRenderer* exportProjectDialog::prepRender()
 					static_cast<Mixer::qualitySettings::Interpolation>(interpolationCB->currentIndex()),
 					static_cast<Mixer::qualitySettings::Oversampling>(oversamplingCB->currentIndex()) );
 
-	int samplerates[5] = { 44100, 48000, 88200, 96000, 192000 };
-	int bitrates[6] = { 64, 128, 160, 192, 256, 320 };
+	const int samplerates[5] = { 44100, 48000, 88200, 96000, 192000 };
+	const int bitrates[6] = { 64, 128, 160, 192, 256, 320 };
 
 	ProjectRenderer::OutputSettings os = ProjectRenderer::OutputSettings(
 			samplerates[ samplerateCB->currentIndex() ],

--- a/src/gui/export_project_dialog.cpp
+++ b/src/gui/export_project_dialog.cpp
@@ -253,10 +253,13 @@ ProjectRenderer* exportProjectDialog::prepRender()
 					static_cast<Mixer::qualitySettings::Interpolation>(interpolationCB->currentIndex()),
 					static_cast<Mixer::qualitySettings::Oversampling>(oversamplingCB->currentIndex()) );
 
+	int samplerates[5] = { 44100, 48000, 88200, 96000, 192000 };
+	int bitrates[6] = { 64, 128, 160, 192, 256, 320 };
+
 	ProjectRenderer::OutputSettings os = ProjectRenderer::OutputSettings(
-			samplerateCB->currentText().section(" ", 0, 0).toUInt(),
+			samplerates[ samplerateCB->currentIndex() ],
 			false,
-			bitrateCB->currentText().section(" ", 0, 0).toUInt(),
+			bitrates[ bitrateCB->currentIndex() ],
 			static_cast<ProjectRenderer::Depths>( depthCB->currentIndex() ) );
 
 	engine::getSong()->setExportLoop( exportLoopCB->isChecked() );


### PR DESCRIPTION
Some translators might change a given frequency from Hz to KHz to make the phrase shorter or fit a specific style. But as we were reading out the string and passing the numbers to a function, this caused problems resulting in Export causing to frees LMMS. This addresses issue #1496
Now we simply store the corresponding bit-/samplerates for the Boxes in an array and get the values from it instead of trying to get the number from the translated string.