### PR TITLE
Add "Remove unused channels" option to FX-Mixer

### DIFF
--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -73,6 +73,7 @@ private:
 private slots:
 	void renameChannel();
 	void removeChannel();
+	void removeUnusedChannels();
 	void moveChannelLeft();
 	void moveChannelRight();
 	void displayHelp();

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -92,6 +92,9 @@ public:
 	// notify the view that an fx channel was deleted
 	void deleteChannel(int index);
 
+	// delete all unused channels
+	void deleteUnusedChannels();
+
 	// move the channel to the left or right
 	void moveChannelLeft(int index);
 	void moveChannelRight(int index);

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -402,7 +402,7 @@ void FxMixerView::deleteUnusedChannels()
 	tracks += Engine::getBBTrackContainer()->tracks();
 
 	// go through all FX Channels
-	for(int i = m_fxChannelViews.size()-1; i>0; --i)
+	for(int i = m_fxChannelViews.size()-1; i > 0; --i)
 	{
 		// check if an instrument references to the current channel
 		bool empty=true;

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -395,6 +395,39 @@ void FxMixerView::deleteChannel(int index)
 
 
 
+void FxMixerView::deleteUnusedChannels()
+{
+	TrackContainer::TrackList tracks;
+	tracks += Engine::getSong()->tracks();
+	tracks += Engine::getBBTrackContainer()->tracks();
+
+	// go through all FX Channels
+	for(int i = m_fxChannelViews.size()-1; i>0; --i)
+	{
+		// check if an instrument references to the current channel
+		bool empty=true;
+		foreach( Track* t, tracks )
+		{
+			if( t->type() == Track::InstrumentTrack )
+			{
+				InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
+				if( i == inst->effectChannelModel()->value(0) )
+				{
+					empty=false;
+					break;
+				}
+			}
+		}
+		// delete channel if no references found
+		if( empty )
+		{
+			deleteChannel( i );
+		}
+	}
+}
+
+
+
 void FxMixerView::moveChannelLeft(int index)
 {
 	// can't move master or first channel left or last channel right

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -418,8 +418,9 @@ void FxMixerView::deleteUnusedChannels()
 				}
 			}
 		}
+		FxChannel * ch = Engine::fxMixer()->effectChannel( i );
 		// delete channel if no references found
-		if( empty )
+		if( empty && ch->m_receives.isEmpty() )
 		{
 			deleteChannel( i );
 		}

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -192,14 +192,18 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 	}
 	contextMenu->addAction( tr( "Rename &channel" ), this, SLOT( renameChannel() ) );
 	contextMenu->addSeparator();
-	
+
 	if( m_channelIndex != 0 ) // no remove-option in master
 	{
 		contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "R&emove channel" ),
 							this, SLOT( removeChannel() ) );
 		contextMenu->addSeparator();
 	}
-	
+
+	contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "Remove &unused channels" ),
+						this, SLOT( removeUnusedChannels() ) );
+	contextMenu->addSeparator();
+
 	contextMenu->addHelpAction();
 	contextMenu->exec( QCursor::pos() );
 	delete contextMenu;
@@ -227,6 +231,13 @@ void FxLine::removeChannel()
 {
 	FxMixerView * mix = Engine::fxMixerView();
 	mix->deleteChannel( m_channelIndex );
+}
+
+
+void FxLine::removeUnusedChannels()
+{
+	FxMixerView * mix = Engine::fxMixerView();
+	mix->deleteUnusedChannels();
 }
 
 


### PR DESCRIPTION
This makes it easier to delete all FX-Channels that are not in use.
It addresses Issue #1206
Side effect: If many (20+) channels get removed, this causes a segmentation fault. I could reproduce it by opening Zakarra-OneDay.mmpz in CoolSongs and going to the end of the FX-Line, clicking on the last FX-Channel and holding delete. So this is not my fault, but should be fixed somewhere else.