### PR TITLE
Make saving of .bak files configurable

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -91,6 +91,7 @@ private slots:
 	void toggleWarnAfterSetup( bool _enabled );
 	void toggleDisplaydBV( bool _enabled );
 	void toggleMMPZ( bool _enabled );
+	void toggleDisableBackup( bool _enabled );
 	void toggleHQAudioDev( bool _enabled );
 
 	void openWorkingDir();
@@ -124,6 +125,7 @@ private:
 	bool m_warnAfterSetup;
 	bool m_displaydBV;
 	bool m_MMPZ;
+	bool m_disableBackup;
 	bool m_hqAudioDev;
 
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -248,10 +248,18 @@ bool DataFile::writeFile( const QString& filename )
 	// make sure the file has been written correctly
 	if( QFileInfo( outfile.fileName() ).size() > 0 )
 	{
-		// remove old backup file
-		QFile::remove( fullNameBak );
-		// move current file to backup file
-		QFile::rename( fullName, fullNameBak );
+		if( ConfigManager::inst()->value( "app", "disablebackup" ).toInt() )
+		{
+			// remove current file
+			QFile::remove( fullName );
+		}
+		else
+		{
+			// remove old backup file
+			QFile::remove( fullNameBak );
+			// move current file to backup file
+			QFile::rename( fullName, fullNameBak );
+		}
 		// move temporary file to current file
 		QFile::rename( fullNameTemp, fullName );
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -94,6 +94,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_displaydBV( ConfigManager::inst()->value( "app", 
 		      				"displaydbv" ).toInt() ),
 	m_MMPZ( !ConfigManager::inst()->value( "app", "nommpz" ).toInt() ),
+	m_disableBackup( !ConfigManager::inst()->value( "app",
+							"disablebackup" ).toInt() ),
 	m_hqAudioDev( ConfigManager::inst()->value( "mixer",
 							"hqaudio" ).toInt() ),
 	m_workingDir( ConfigManager::inst()->workingDir() ),
@@ -299,6 +301,15 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	disableAutoquit->setChecked( m_disableAutoQuit );
 	connect( disableAutoquit, SIGNAL( toggled( bool ) ),
 				this, SLOT( toggleDisableAutoquit( bool ) ) );
+
+	LedCheckBox * disableBackup = new LedCheckBox(
+				tr( "Create backup file when saving a project" ),
+								misc_tw );
+	labelNumber++;
+	disableBackup->move( XDelta, YDelta*labelNumber );
+	disableBackup->setChecked( m_disableBackup );
+	connect( disableBackup, SIGNAL( toggled( bool ) ),
+				this, SLOT( toggleDisableBackup( bool ) ) );
 
 	misc_tw->setFixedHeight( YDelta*labelNumber + HeaderSize );
 
@@ -806,6 +817,8 @@ void SetupDialog::accept()
 					QString::number( m_displaydBV ) );
 	ConfigManager::inst()->setValue( "app", "nommpz",
 						QString::number( !m_MMPZ ) );
+	ConfigManager::inst()->setValue( "app", "disablebackup",
+					QString::number( !m_disableBackup ) );
 	ConfigManager::inst()->setValue( "mixer", "hqaudio",
 					QString::number( m_hqAudioDev ) );
 	ConfigManager::inst()->setValue( "ui", "smoothscroll",
@@ -953,6 +966,14 @@ void SetupDialog::toggleDisplaydBV( bool _enabled )
 void SetupDialog::toggleMMPZ( bool _enabled )
 {
 	m_MMPZ = _enabled;
+}
+
+
+
+
+void SetupDialog::toggleDisableBackup( bool _enabled )
+{
+	m_disableBackup = _enabled;
 }
 
 


### PR DESCRIPTION
This adds a new check box to the settings, which allows a user to configure, whether to create a backup of the old project file or not. This addresses issue #1096