### PR TITLE
Get correct value for scrollbar width

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -52,7 +52,7 @@ public:
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _this );
 	virtual void loadSettings( const QDomElement & _this );
 
-	QWidget * contentWidget()
+	QScrollArea * contentWidget()
 	{
 		return( m_scrollArea );
 	}

--- a/src/gui/SongEditor.cpp
+++ b/src/gui/SongEditor.cpp
@@ -722,7 +722,7 @@ void SongEditor::updatePosition( const MidiTime & _t )
 	{
 		const int w = width() - widgetWidth
 							- trackOpWidth
-							- 32;	// rough estimation for width of right scrollbar
+							- contentWidget()->verticalScrollBar()->width(); // width of right scrollbar
 		if( _t > m_currentPosition + w * MidiTime::ticksPerTact() /
 							pixelsPerTact() )
 		{


### PR DESCRIPTION
Instead of using a (very) rough estimation for the scrollbar width, we can get the correct width directly from the scrollbar.