### PR TITLE
Proposed fix for 1352 Mk2, move the loaded instrument to the parent thre...

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -33,6 +33,7 @@
 
 #include "Track.h"
 #include "JournallingObject.h"
+#include "InstrumentTrack.h"
 
 
 class QVBoxLayout;
@@ -182,6 +183,19 @@ signals:
 
 } ;
 
+class InstrumentLoaderThread : public QThread
+{
+	Q_OBJECT
+public:
+	InstrumentLoaderThread( QObject *parent = 0, InstrumentTrack *it = 0,
+							QString name = "" );
 
+	void run();
+
+private:
+	InstrumentTrack *m_it;
+	QString m_name;
+	QThread *m_containerThread;
+};
 
 #endif

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -325,7 +325,9 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
 				Track::create( Track::InstrumentTrack,
 								m_tc ) );
-		it->loadInstrument( value );
+		InstrumentLoaderThread *ilt = new InstrumentLoaderThread(
+					this, it, value );
+		ilt->start();
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
@@ -453,6 +455,22 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 
 
 
+InstrumentLoaderThread::InstrumentLoaderThread( QObject *parent, InstrumentTrack *it, QString name ) :
+	QThread( parent ),
+	m_it( it ),
+	m_name( name )
+{
+	m_containerThread = thread();
+}
 
 
 
+
+void InstrumentLoaderThread::run()
+{
+	Instrument *i = m_it->loadInstrument( m_name );
+	QObject *parent = i->parent();
+	i->setParent( 0 );
+	i->moveToThread( m_containerThread );
+	i->setParent( parent );
+}


### PR DESCRIPTION
Proposed fix for #1352 Mk2, move the loaded instrument to the parent thread.

address the issue in #1550.

This moves the loaded instrument back to the parent thread, for thread affinity.

I did try another totally different implementation, using signals, and slot and QueuedConnecton, to process the loading in the event loop, as opposed to immediately, but this still caused the same deadlock. 

The issue with my previous pull request #1519, was the the instrument was loaded on a separate thread, and needed to be on the same thread as the parent TrackContainer to be able to use the Qt event loop