### PR TITLE
Proposed fix for 1522 Noise at the end of Sample previews

### DIFF
--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -98,14 +98,15 @@ SamplePlayHandle::~SamplePlayHandle()
 
 void SamplePlayHandle::play( sampleFrame * buffer )
 {
+	const fpp_t fpp = Engine::mixer()->framesPerPeriod();
 	//play( 0, _try_parallelizing );
 	if( framesDone() >= totalFrames() )
 	{
+		memset( buffer, 0, sizeof( sampleFrame ) * fpp );
 		return;
 	}
 
 	sampleFrame * workingBuffer = buffer;
-	const fpp_t fpp = Engine::mixer()->framesPerPeriod();
 	f_cnt_t frames = fpp;
 
 	// apply offset for the first period


### PR DESCRIPTION
Proposed fix for #1522

Simply cleared the buffer in SamplePlayhandle::play if there are no more frames to play.