### PR TITLE
Progressive coding conventions update

### DIFF
--- a/include/Note.h
+++ b/include/Note.h
@@ -81,36 +81,36 @@ const float MaxDetuning = 4 * 12.0f;
 class EXPORT Note : public SerializingObject
 {
 public:
-	Note( const MidiTime & _length = MidiTime( 0 ),
-		const MidiTime & _pos = MidiTime( 0 ),
+	Note( const MidiTime & length = MidiTime( 0 ),
+		const MidiTime & pos = MidiTime( 0 ),
 		int key = DefaultKey,
-		volume_t _volume = DefaultVolume,
-		panning_t _panning = DefaultPanning,
-		DetuningHelper * _detuning = NULL );
-	Note( const Note & _note );
+		volume_t volume = DefaultVolume,
+		panning_t panning = DefaultPanning,
+		DetuningHelper * detuning = NULL );
+	Note( const Note & note );
 	virtual ~Note();
 
 	// used by GUI
-	inline void setSelected( const bool _selected ){ m_selected = _selected; }
-	inline void setOldKey( const int _oldKey ){ m_oldKey = _oldKey; }
-	inline void setOldPos( const MidiTime & _oldPos ){ m_oldPos = _oldPos; }
-	inline void setOldLength( const MidiTime & _oldLength )
+	inline void setSelected( const bool selected ){ m_selected = selected; }
+	inline void setOldKey( const int oldKey ){ m_oldKey = oldKey; }
+	inline void setOldPos( const MidiTime & oldPos ){ m_oldPos = oldPos; }
+	inline void setOldLength( const MidiTime & oldLength )
 	{
-		m_oldLength = _oldLength;
+		m_oldLength = oldLength;
 	}
-	inline void setIsPlaying( const bool _isPlaying )
+	inline void setIsPlaying( const bool isPlaying )
 	{
-		m_isPlaying = _isPlaying;
+		m_isPlaying = isPlaying;
 	}
 
 
-	void setLength( const MidiTime & _length );
-	void setPos( const MidiTime & _pos );
-	void setKey( const int _key );
+	void setLength( const MidiTime & length );
+	void setPos( const MidiTime & pos );
+	void setKey( const int key );
 	virtual void setVolume( volume_t volume );
 	virtual void setPanning( panning_t panning );
-	void quantizeLength( const int _q_grid );
-	void quantizePos( const int _q_grid );
+	void quantizeLength( const int qGrid );
+	void quantizePos( const int qGrid );
 
 	static inline bool lessThan( Note * &lhs, Note * &rhs )
 	{
@@ -160,9 +160,9 @@ public:
 		return m_pos;
 	}
 
-	inline MidiTime pos( MidiTime _base_pos ) const
+	inline MidiTime pos( MidiTime basePos ) const
 	{
-		const int bp = _base_pos;
+		const int bp = basePos;
 		return m_pos - bp;
 	}
 
@@ -196,7 +196,7 @@ public:
 		return classNodeName();
 	}
 
-	static MidiTime quantized( const MidiTime & _m, const int _q_grid );
+	static MidiTime quantized( const MidiTime & m, const int qGrid );
 
 	DetuningHelper * detuning() const
 	{
@@ -209,8 +209,7 @@ public:
 
 
 protected:
-	virtual void saveSettings( QDomDocument & _doc,
-							QDomElement & _parent );
+	virtual void saveSettings( QDomDocument & doc, QDomElement & parent );
 	virtual void loadSettings( const QDomElement & _this );
 
 
@@ -238,4 +237,3 @@ typedef QVector<Note *> NoteVector;
 
 
 #endif
-

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -85,19 +85,19 @@ public:
 			{
 				typedef QMap<QString, QString> AttributeMap;
 
-				inline Key( const Plugin::Descriptor * _desc = NULL,
-							const QString & _name = QString(),
-							const AttributeMap & _am = AttributeMap() )
+				inline Key( const Plugin::Descriptor * desc = NULL,
+							const QString & name = QString(),
+							const AttributeMap & am = AttributeMap() )
 					:
-					desc( _desc ),
-					name( _name ),
-					attributes( _am )
+					desc( desc ),
+					name( name ),
+					attributes( am )
 				{
 				}
 
-				Key( const QDomElement & _key );
+				Key( const QDomElement & key );
 
-				QDomElement saveXML( QDomDocument & _doc ) const;
+				QDomElement saveXML( QDomDocument & doc ) const;
 
 				inline bool isValid() const
 				{
@@ -142,13 +142,15 @@ public:
 	typedef QList<Descriptor> DescriptorList;
 
 	// contructor of a plugin
-	Plugin( const Descriptor* descriptor, Model* parent );
+	Plugin( const Descriptor * descriptor, Model * parent );
 	virtual ~Plugin();
 
 	// returns display-name out of descriptor
 	virtual QString displayName() const
 	{
-		return Model::displayName().isEmpty() ?  m_descriptor->displayName : Model::displayName();
+		return Model::displayName().isEmpty() 
+			?  m_descriptor->displayName 
+			: Model::displayName();
 	}
 
 	// return plugin-type
@@ -158,41 +160,41 @@ public:
 	}
 
 	// return plugin-descriptor for further information
-	inline const Descriptor* descriptor() const
+	inline const Descriptor * descriptor() const
 	{
 		return m_descriptor;
 	}
 
 	// can be called if a file matching supportedFileTypes should be
 	// loaded/processed with the help of this plugin
-	virtual void loadFile( const QString& file );
+	virtual void loadFile( const QString & file );
 
 	// Called if external source needs to change something but we cannot
 	// reference the class header.  Should return null if not key not found.
-	virtual AutomatableModel* childModel( const QString& modelName );
+	virtual AutomatableModel* childModel( const QString & modelName );
 
 	// returns an instance of a plugin whose name matches to given one
 	// if specified plugin couldn't be loaded, it creates a dummy-plugin
 	static Plugin * instantiate( const QString& pluginName, Model * parent, void * data );
 
 	// fills given list with descriptors of all available plugins
-	static void getDescriptorsOfAvailPlugins( DescriptorList& pluginDescriptors );
+	static void getDescriptorsOfAvailPlugins( DescriptorList & pluginDescriptors );
 
 	// create a view for the model 
-	PluginView * createView( QWidget* parent );
+	PluginView * createView( QWidget * parent );
 
 
 protected:
 	// create a view for the model 
-	virtual PluginView* instantiateView( QWidget* ) = 0;
-	void collectErrorForUI( QString err_msg );
+	virtual PluginView* instantiateView( QWidget * ) = 0;
+	void collectErrorForUI( QString errMsg );
 
 
 private:
-	const Descriptor* m_descriptor;
+	const Descriptor * m_descriptor;
 
 	// pointer to instantiation-function in plugin
-	typedef Plugin * ( * InstantiationHook )( Model*, void* );
+	typedef Plugin * ( * InstantiationHook )( Model * , void * );
 
 } ;
 

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -32,22 +32,22 @@
 class ProjectVersion : public QString
 {
 public:
-	ProjectVersion( const QString & _s ) :
-		QString( _s )
+	ProjectVersion( const QString & s ) :
+		QString( s )
 	{
 	}
 
-	static int compare( const ProjectVersion & _v1,
-						const ProjectVersion & _v2 );
+	static int compare( const ProjectVersion & v1, 
+						const ProjectVersion & v2 );
 
 } ;
 
 
 
 
-inline bool operator<( const ProjectVersion & _v1, const char * _str )
+inline bool operator<( const ProjectVersion & v1, const char * str )
 {
-	return ProjectVersion::compare( _v1, ProjectVersion( _str ) ) < 0;
+	return ProjectVersion::compare( v1, ProjectVersion( str ) ) < 0;
 }
 
 

--- a/include/Song.h
+++ b/include/Song.h
@@ -49,10 +49,9 @@ const tick_t MaxSongLength = 9999 * DefaultTicksPerTact;
 class EXPORT Song : public TrackContainer
 {
 	Q_OBJECT
-	mapPropertyFromModel(int,getTempo,setTempo,m_tempoModel);
-	mapPropertyFromModel(int,masterPitch,setMasterPitch,m_masterPitchModel);
-	mapPropertyFromModel(int,masterVolume,setMasterVolume,
-							m_masterVolumeModel);
+	mapPropertyFromModel( int,getTempo,setTempo,m_tempoModel );
+	mapPropertyFromModel( int,masterPitch,setMasterPitch,m_masterPitchModel );
+	mapPropertyFromModel( int,masterVolume,setMasterVolume, m_masterVolumeModel );
 public:
 	enum PlayModes
 	{
@@ -66,19 +65,19 @@ public:
 	} ;
 
 
-	class playPos : public MidiTime
+	class PlayPos : public MidiTime
 	{
 	public:
-		playPos( const int _abs = 0 ) :
-			MidiTime( _abs ),
+		PlayPos( const int abs = 0 ) :
+			MidiTime( abs ),
 			m_timeLine( NULL ),
 			m_timeLineUpdate( true ),
 			m_currentFrame( 0.0f )
 		{
 		}
-		inline void setCurrentFrame( const float _f )
+		inline void setCurrentFrame( const float f )
 		{
-			m_currentFrame = _f;
+			m_currentFrame = f;
 		}
 		inline float currentFrame() const
 		{
@@ -100,9 +99,9 @@ public:
 	{
 		return m_elapsedMilliSeconds;
 	}
-	inline void setMilliSeconds( float _ellapsedMilliSeconds )
+	inline void setMilliSeconds( float ellapsedMilliSeconds )
 	{
-		m_elapsedMilliSeconds = (_ellapsedMilliSeconds);
+		m_elapsedMilliSeconds = ellapsedMilliSeconds;
 	}
 	inline int getTacts() const
 	{
@@ -119,14 +118,14 @@ public:
 	// Returns the beat position inside the bar, 0-based
 	inline int getBeat() const
 	{
-		return (currentTick() - currentTact()*ticksPerTact()) /
-			(ticksPerTact() / m_timeSigModel.getNumerator() );
+		return ( currentTick() - currentTact() * ticksPerTact() ) /
+			( ticksPerTact() / m_timeSigModel.getNumerator() );
 	}
 	// the remainder after bar and beat are removed
 	inline int getBeatTicks() const
 	{
-		return 	(currentTick() - currentTact()*ticksPerTact()) %
-			(ticksPerTact() / m_timeSigModel.getNumerator() );
+		return 	( currentTick() - currentTact() * ticksPerTact() ) %
+			( ticksPerTact() / m_timeSigModel.getNumerator() );
 	}
 	inline int getTicks() const
 	{
@@ -147,7 +146,7 @@ public:
 
 	inline bool isPlaying() const
 	{
-		return m_playing && m_exporting == false;
+		return m_playing == true && m_exporting == false;
 	}
 
 	inline bool isStopped() const
@@ -182,9 +181,9 @@ public:
 		return m_playMode;
 	}
 
-	inline playPos & getPlayPos( PlayModes _pm )
+	inline PlayPos & getPlayPos( PlayModes pm )
 	{
-		return m_playPos[_pm];
+		return m_playPos[pm];
 	}
 
 	void updateLength();
@@ -204,11 +203,11 @@ public:
 
 	// file management
 	void createNewProject();
-	void createNewProjectFromTemplate( const QString & _template );
-	void loadProject( const QString & _filename );
+	void createNewProjectFromTemplate( const QString & templ );
+	void loadProject( const QString & filename );
 	bool guiSaveProject();
-	bool guiSaveProjectAs( const QString & _filename );
-	bool saveProjectFile( const QString & _filename );
+	bool guiSaveProjectAs( const QString & filename );
+	bool saveProjectFile( const QString & filename );
 
 	const QString & projectFileName() const
 	{
@@ -235,8 +234,8 @@ public:
 		return false;
 	}
 
-	void addController( Controller * _c );
-	void removeController( Controller * _c );
+	void addController( Controller * c );
+	void removeController( Controller * c );
 	
 
 	const ControllerVector & controllers() const
@@ -255,14 +254,14 @@ public slots:
 	void playSong();
 	void record();
 	void playAndRecord();
-	void playTrack( Track * _trackToPlay );
+	void playTrack( Track * trackToPlay );
 	void playBB();
-	void playPattern(const Pattern* patternToPlay, bool _loop = true );
+	void playPattern( const Pattern * patternToPlay, bool loop = true );
 	void togglePause();
 	void stop();
 
 	void importProject();
-	void exportProject(bool multiExport=false);
+	void exportProject( bool multiExport = false );
 	void exportProjectTracks();
 
 	void startExport();
@@ -311,13 +310,14 @@ private:
 	
 	inline f_cnt_t currentFrame() const
 	{
-		return m_playPos[m_playMode].getTicks() * Engine::framesPerTick() + m_playPos[m_playMode].currentFrame();
+		return m_playPos[m_playMode].getTicks() * Engine::framesPerTick() + 
+			m_playPos[m_playMode].currentFrame();
 	}
 	
-	void setPlayPos( tick_t _ticks, PlayModes _play_mode );
+	void setPlayPos( tick_t ticks, PlayModes playMode );
 
-	void saveControllerStates( QDomDocument & _doc, QDomElement & _this );
-	void restoreControllerStates( const QDomElement & _this );
+	void saveControllerStates( QDomDocument & doc, QDomElement & element );
+	void restoreControllerStates( const QDomElement & element );
 
 
 	AutomationTrack * m_globalAutomationTrack;
@@ -345,7 +345,7 @@ private:
 	bool m_loadingProject;
 
 	PlayModes m_playMode;
-	playPos m_playPos[Mode_Count];
+	PlayPos m_playPos[Mode_Count];
 	tact_t m_length;
 
 	Track * m_trackToPlay;
@@ -368,10 +368,9 @@ signals:
 	void projectLoaded();
 	void playbackStateChanged();
 	void playbackPositionChanged();
-	void lengthChanged( int _tacts );
-	void tempoChanged( bpm_t _new_bpm );
-	void timeSignatureChanged( int _old_ticks_per_tact,
-							int _ticks_per_tact );
+	void lengthChanged( int tacts );
+	void tempoChanged( bpm_t newBPM );
+	void timeSignatureChanged( int oldTicksPerTact, int ticksPerTact );
 
 } ;
 

--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -60,11 +60,11 @@ public:
 	} ;
 
 
-	Timeline( int _xoff, int _yoff, float _ppt, Song::playPos & _pos,
+	Timeline( int _xoff, int _yoff, float _ppt, Song::PlayPos & _pos,
 				const MidiTime & _begin, QWidget * _parent );
 	virtual ~Timeline();
 
-	inline Song::playPos & pos()
+	inline Song::PlayPos & pos()
 	{
 		return( m_pos );
 	}
@@ -162,7 +162,7 @@ private:
 	int m_xOffset;
 	int m_posMarkerX;
 	float m_ppt;
-	Song::playPos & m_pos;
+	Song::PlayPos & m_pos;
 	const MidiTime & m_begin;
 	MidiTime m_loopPos[2];
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -80,7 +80,7 @@ class TrackContentObject : public Model, public JournallingObject
 	mapPropertyFromModel(bool,isMuted,setMuted,m_mutedModel);
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
-	TrackContentObject( Track * _track );
+	TrackContentObject( Track * track );
 	virtual ~TrackContentObject();
 
 	inline Track * getTrack() const
@@ -93,9 +93,9 @@ public:
 		return m_name;
 	}
 
-	inline void setName( const QString & _name )
+	inline void setName( const QString & name )
 	{
-		m_name = _name;
+		m_name = name;
 		emit dataChanged();
 	}
 
@@ -121,10 +121,10 @@ public:
 		return m_length;
 	}
 
-	virtual void movePosition( const MidiTime & _pos );
-	virtual void changeLength( const MidiTime & _length );
+	virtual void movePosition( const MidiTime & pos );
+	virtual void changeLength( const MidiTime & length );
 
-	virtual TrackContentObjectView * createView( TrackView * _tv ) = 0;
+	virtual TrackContentObjectView * createView( TrackView * tv ) = 0;
 
 	inline void selectViewOnCreate( bool select )
 	{
@@ -183,7 +183,7 @@ class TrackContentObjectView : public selectableObject, public ModelView
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 
 public:
-	TrackContentObjectView( TrackContentObject * _tco, TrackView * _tv );
+	TrackContentObjectView( TrackContentObject * tco, TrackView * tv );
 	virtual ~TrackContentObjectView();
 
 	bool fixedTCOs();
@@ -195,8 +195,8 @@ public:
 // qproperty access func
 	QColor fgColor() const;
 	QColor textColor() const;
-	void setFgColor( const QColor & _c );
-	void setTextColor( const QColor & _c );
+	void setFgColor( const QColor & c );
+	void setTextColor( const QColor & c );
 
 public slots:
 	virtual bool close();
@@ -208,15 +208,15 @@ protected:
 	{
 	}
 
-	virtual void contextMenuEvent( QContextMenuEvent * _cme );
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
-	virtual void leaveEvent( QEvent * _e );
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void mouseMoveEvent( QMouseEvent * _me );
-	virtual void mouseReleaseEvent( QMouseEvent * _me );
+	virtual void contextMenuEvent( QContextMenuEvent * cme );
+	virtual void dragEnterEvent( QDragEnterEvent * dee );
+	virtual void dropEvent( QDropEvent * de );
+	virtual void leaveEvent( QEvent * e );
+	virtual void mousePressEvent( QMouseEvent * me );
+	virtual void mouseMoveEvent( QMouseEvent * me );
+	virtual void mouseReleaseEvent( QMouseEvent * me );
 
-	void setAutoResizeEnabled( bool _e = false );
+	void setAutoResizeEnabled( bool e = false );
 	float pixelsPerTact();
 
 	inline TrackView * getTrackView()
@@ -266,7 +266,7 @@ private:
 		m_initialMouseGlobalPos = mapToGlobal( pos );
 	}
 
-	bool mouseMovedDistance( QMouseEvent * _me, int distance );
+	bool mouseMovedDistance( QMouseEvent * me, int distance );
 
 } ;
 
@@ -283,46 +283,46 @@ class TrackContentWidget : public QWidget, public JournallingObject
 	Q_PROPERTY( QBrush lighterColor READ lighterColor WRITE setLighterColor )
 
 public:
-	TrackContentWidget( TrackView * _parent );
+	TrackContentWidget( TrackView * parent );
 	virtual ~TrackContentWidget();
 
 	/*! \brief Updates the background tile pixmap. */
 	void updateBackground();
 
-	void addTCOView( TrackContentObjectView * _tcov );
-	void removeTCOView( TrackContentObjectView * _tcov );
-	void removeTCOView( int _tco_num )
+	void addTCOView( TrackContentObjectView * tcov );
+	void removeTCOView( TrackContentObjectView * tcov );
+	void removeTCOView( int tcoNum )
 	{
-		if( _tco_num >= 0 && _tco_num < m_tcoViews.size() )
+		if( tcoNum >= 0 && tcoNum < m_tcoViews.size() )
 		{
-			removeTCOView( m_tcoViews[_tco_num] );
+			removeTCOView( m_tcoViews[tcoNum] );
 		}
 	}
 
 	bool canPasteSelection( MidiTime tcoPos, const QMimeData * mimeData );
-	bool pasteSelection( MidiTime tcoPos, QDropEvent * _de );
+	bool pasteSelection( MidiTime tcoPos, QDropEvent * de );
 
-	MidiTime endPosition( const MidiTime & _pos_start );
+	MidiTime endPosition( const MidiTime & posStart );
 
 	// qproperty access methods
 
 	QBrush darkerColor() const;
 	QBrush lighterColor() const;
 
-	void setDarkerColor( const QBrush & _c );
-	void setLighterColor( const QBrush & _c );
+	void setDarkerColor( const QBrush & c );
+	void setLighterColor( const QBrush & c );
 
 public slots:
 	void update();
-	void changePosition( const MidiTime & _new_pos = MidiTime( -1 ) );
+	void changePosition( const MidiTime & newPos = MidiTime( -1 ) );
 
 
 protected:
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
-	virtual void resizeEvent( QResizeEvent * _re );
+	virtual void dragEnterEvent( QDragEnterEvent * dee );
+	virtual void dropEvent( QDropEvent * de );
+	virtual void mousePressEvent( QMouseEvent * me );
+	virtual void paintEvent( QPaintEvent * pe );
+	virtual void resizeEvent( QResizeEvent * re );
 
 	virtual QString nodeName() const
 	{
@@ -343,7 +343,7 @@ protected:
 
 private:
 	Track * getTrack();
-	MidiTime getPosition( int _mouse_x );
+	MidiTime getPosition( int mouseX );
 
 	TrackView * m_trackView;
 
@@ -365,13 +365,13 @@ class TrackOperationsWidget : public QWidget
 {
 	Q_OBJECT
 public:
-	TrackOperationsWidget( TrackView * _parent );
+	TrackOperationsWidget( TrackView * parent );
 	~TrackOperationsWidget();
 
 
 protected:
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
+	virtual void mousePressEvent( QMouseEvent * me );
+	virtual void paintEvent( QPaintEvent * pe );
 
 
 private slots:
@@ -395,7 +395,7 @@ private:
 	friend class TrackView;
 
 signals:
-	void trackRemovalScheduled( TrackView * _t );
+	void trackRemovalScheduled( TrackView * t );
 
 } ;
 
@@ -425,12 +425,12 @@ public:
 		NumTrackTypes
 	} ;
 
-	Track( TrackTypes _type, TrackContainer * _tc );
+	Track( TrackTypes type, TrackContainer * tc );
 	virtual ~Track();
 
-	static Track * create( TrackTypes _tt, TrackContainer * _tc );
-	static Track * create( const QDomElement & _this,
-							TrackContainer * _tc );
+	static Track * create( TrackTypes tt, TrackContainer * tc );
+	static Track * create( const QDomElement & element,
+							TrackContainer * tc );
 	void clone();
 
 
@@ -440,20 +440,20 @@ public:
 		return m_type;
 	}
 
-	virtual bool play( const MidiTime & _start, const fpp_t _frames,
-						const f_cnt_t _frame_base, int _tco_num = -1 ) = 0;
+	virtual bool play( const MidiTime & start, const fpp_t frames,
+						const f_cnt_t frameBase, int tcoNum = -1 ) = 0;
 
 
-	virtual TrackView * createView( TrackContainerView * _view ) = 0;
-	virtual TrackContentObject * createTCO( const MidiTime & _pos ) = 0;
+	virtual TrackView * createView( TrackContainerView * view ) = 0;
+	virtual TrackContentObject * createTCO( const MidiTime & pos ) = 0;
 
-	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
-						QDomElement & _parent ) = 0;
-	virtual void loadTrackSpecificSettings( const QDomElement & _this ) = 0;
+	virtual void saveTrackSpecificSettings( QDomDocument & doc,
+						QDomElement & parent ) = 0;
+	virtual void loadTrackSpecificSettings( const QDomElement & element ) = 0;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _this );
-	virtual void loadSettings( const QDomElement & _this );
+	virtual void saveSettings( QDomDocument & doc, QDomElement & element );
+	virtual void loadSettings( const QDomElement & element );
 
 	void setSimpleSerializing()
 	{
@@ -461,26 +461,26 @@ public:
 	}
 
 	// -- for usage by TrackContentObject only ---------------
-	TrackContentObject * addTCO( TrackContentObject * _tco );
-	void removeTCO( TrackContentObject * _tco );
+	TrackContentObject * addTCO( TrackContentObject * tco );
+	void removeTCO( TrackContentObject * tco );
 	// -------------------------------------------------------
 	void deleteTCOs();
 
 	int numOfTCOs();
-	TrackContentObject * getTCO( int _tco_num );
-	int getTCONum(const TrackContentObject* _tco );
+	TrackContentObject * getTCO( int tcoNum );
+	int getTCONum(const TrackContentObject* tco );
 
 	const tcoVector & getTCOs() const
 	{
-		return( m_trackContentObjects );
+		return m_trackContentObjects;
 	}
-	void getTCOsInRange( tcoVector & _tco_v, const MidiTime & _start,
-							const MidiTime & _end );
-	void swapPositionOfTCOs( int _tco_num1, int _tco_num2 );
+	void getTCOsInRange( tcoVector & tcoV, const MidiTime & start,
+							const MidiTime & end );
+	void swapPositionOfTCOs( int tcoNum1, int tcoNum2 );
 
 
-	void insertTact( const MidiTime & _pos );
-	void removeTact( const MidiTime & _pos );
+	void insertTact( const MidiTime & pos );
+	void removeTact( const MidiTime & pos );
 
 	tact_t length() const;
 
@@ -493,21 +493,25 @@ public:
 	// name-stuff
 	virtual const QString & name() const
 	{
-		return( m_name );
+		return m_name;
 	}
 
 	virtual QString displayName() const
 	{
-		return( name() );
+		return name();
 	}
 
 	using Model::dataChanged;
 
-	inline int getHeight() {
-	  return ( m_height >= MINIMAL_TRACK_HEIGHT ? m_height : DEFAULT_TRACK_HEIGHT );
+	inline int getHeight() 
+	{
+		return m_height >= MINIMAL_TRACK_HEIGHT
+			? m_height 
+			: DEFAULT_TRACK_HEIGHT;
 	}
-	inline void setHeight( int _height ) {
-	  m_height = _height;
+	inline void setHeight( int height ) 
+	{
+		m_height = height;
 	}
 
 	void lock()
@@ -524,9 +528,9 @@ public:
 	}
 
 public slots:
-	virtual void setName( const QString & _new_name )
+	virtual void setName( const QString & newName )
 	{
-		m_name = _new_name;
+		m_name = newName;
 		emit nameChanged();
 	}
 
@@ -573,12 +577,12 @@ public:
 
 	inline const Track * getTrack() const
 	{
-		return( m_track );
+		return m_track;
 	}
 
 	inline Track * getTrack()
 	{
-		return( m_track );
+		return m_track;
 	}
 
 	inline TrackContainerView* trackContainerView()
@@ -588,22 +592,22 @@ public:
 
 	inline TrackOperationsWidget * getTrackOperationsWidget()
 	{
-		return( &m_trackOperationsWidget );
+		return &m_trackOperationsWidget;
 	}
 
 	inline trackSettingsWidget * getTrackSettingsWidget()
 	{
-		return( &m_trackSettingsWidget );
+		return &m_trackSettingsWidget;
 	}
 
 	inline TrackContentWidget * getTrackContentWidget()
 	{
-		return( &m_trackContentWidget );
+		return &m_trackContentWidget;
 	}
 
 	bool isMovingTrack() const
 	{
-		return( m_action == MoveTrack );
+		return m_action == MoveTrack;
 	}
 
 	virtual void update();
@@ -633,13 +637,13 @@ protected:
 	}
 
 
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void mouseMoveEvent( QMouseEvent * _me );
-	virtual void mouseReleaseEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
-	virtual void resizeEvent( QResizeEvent * _re );
+	virtual void dragEnterEvent( QDragEnterEvent * dee );
+	virtual void dropEvent( QDropEvent * de );
+	virtual void mousePressEvent( QMouseEvent * me );
+	virtual void mouseMoveEvent( QMouseEvent * me );
+	virtual void mouseReleaseEvent( QMouseEvent * me );
+	virtual void paintEvent( QPaintEvent * pe );
+	virtual void resizeEvent( QResizeEvent * re );
 
 
 private:
@@ -664,7 +668,7 @@ private:
 
 
 private slots:
-	void createTCOView( TrackContentObject * _tco );
+	void createTCOView( TrackContentObject * tco );
 
 } ;
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -318,9 +318,9 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 {
 	m_profiler.startPeriod();
 
-	static Song::playPos last_metro_pos = -1;
+	static Song::PlayPos last_metro_pos = -1;
 
-	Song::playPos p = Engine::getSong()->getPlayPos(
+	Song::PlayPos p = Engine::getSong()->getPlayPos(
 						Song::Mode_PlayPattern );
 	if( Engine::getSong()->playMode() == Song::Mode_PlayPattern &&
 		Engine::pianoRoll()->isRecording() == true &&
@@ -965,9 +965,6 @@ void Mixer::fifoWriter::run()
 
 	m_fifo->write( NULL );
 }
-
-
-
 
 
 

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -35,24 +35,24 @@
 
 
 
-Note::Note( const MidiTime & _length, const MidiTime & _pos,
-		int _key, volume_t _volume, panning_t _panning,
-						DetuningHelper * _detuning ) :
+Note::Note( const MidiTime & length, const MidiTime & pos,
+		int key, volume_t volume, panning_t panning,
+						DetuningHelper * detuning ) :
 	m_selected( false ),
-	m_oldKey( qBound( 0, _key, NumKeys ) ),
-	m_oldPos( _pos ),
-	m_oldLength( _length ),
+	m_oldKey( qBound( 0, key, NumKeys ) ),
+	m_oldPos( pos ),
+	m_oldLength( length ),
 	m_isPlaying( false ),
-	m_key( qBound( 0, _key, NumKeys ) ),
-	m_volume( qBound( MinVolume, _volume, MaxVolume ) ),
-	m_panning( qBound( PanningLeft, _panning, PanningRight ) ),
-	m_length( _length ),
-	m_pos( _pos ),
+	m_key( qBound( 0, key, NumKeys ) ),
+	m_volume( qBound( MinVolume, volume, MaxVolume ) ),
+	m_panning( qBound( PanningLeft, panning, PanningRight ) ),
+	m_length( length ),
+	m_pos( pos ),
 	m_detuning( NULL )
 {
-	if( _detuning )
+	if( detuning )
 	{
-		m_detuning = sharedObject::ref( _detuning );
+		m_detuning = sharedObject::ref( detuning );
 	}
 	else
 	{
@@ -63,23 +63,23 @@ Note::Note( const MidiTime & _length, const MidiTime & _pos,
 
 
 
-Note::Note( const Note & _note ) :
-	SerializingObject( _note ),
-	m_selected( _note.m_selected ),
-	m_oldKey( _note.m_oldKey ),
-	m_oldPos( _note.m_oldPos ),
-	m_oldLength( _note.m_oldLength ),	
-	m_isPlaying( _note.m_isPlaying ),
-	m_key( _note.m_key),
-	m_volume( _note.m_volume ),
-	m_panning( _note.m_panning ),
-	m_length( _note.m_length ),
-	m_pos( _note.m_pos ),
+Note::Note( const Note & note ) :
+	SerializingObject( note ),
+	m_selected( note.m_selected ),
+	m_oldKey( note.m_oldKey ),
+	m_oldPos( note.m_oldPos ),
+	m_oldLength( note.m_oldLength ),	
+	m_isPlaying( note.m_isPlaying ),
+	m_key( note.m_key),
+	m_volume( note.m_volume ),
+	m_panning( note.m_panning ),
+	m_length( note.m_length ),
+	m_pos( note.m_pos ),
 	m_detuning( NULL )
 {
-	if( _note.m_detuning )
+	if( note.m_detuning )
 	{
-		m_detuning = sharedObject::ref( _note.m_detuning );
+		m_detuning = sharedObject::ref( note.m_detuning );
 	}
 }
 
@@ -97,93 +97,93 @@ Note::~Note()
 
 
 
-void Note::setLength( const MidiTime & _length )
+void Note::setLength( const MidiTime & length )
 {
-	m_length = _length;
+	m_length = length;
 }
 
 
 
 
-void Note::setPos( const MidiTime & _pos )
+void Note::setPos( const MidiTime & pos )
 {
-	m_pos = _pos;
+	m_pos = pos;
 }
 
 
 
 
-void Note::setKey( const int _key )
+void Note::setKey( const int key )
 {
-	const int k = qBound( 0, _key, NumKeys );
+	const int k = qBound( 0, key, NumKeys );
 	m_key = k;
 }
 
 
 
 
-void Note::setVolume( volume_t _volume )
+void Note::setVolume( volume_t volume )
 {
-	const volume_t v = qBound( MinVolume, _volume, MaxVolume );
+	const volume_t v = qBound( MinVolume, volume, MaxVolume );
 	m_volume = v;
 }
 
 
 
 
-void Note::setPanning( panning_t _panning )
+void Note::setPanning( panning_t panning )
 {
-	const panning_t p = qBound( PanningLeft, _panning, PanningRight );
+	const panning_t p = qBound( PanningLeft, panning, PanningRight );
 	m_panning = p;
 }
 
 
 
 
-MidiTime Note::quantized( const MidiTime & _m, const int _q_grid )
+MidiTime Note::quantized( const MidiTime & m, const int qGrid )
 {
-	float p = ( (float) _m / _q_grid );
+	float p = ( (float) m / qGrid );
 	if( p - floorf( p ) < 0.5f )
 	{
-		return( static_cast<int>( p ) * _q_grid );
+		return static_cast<int>( p ) * qGrid;
 	}
-	return( static_cast<int>( p + 1 ) * _q_grid );
+	return static_cast<int>( p + 1 ) * qGrid;
 }
 
 
 
 
-void Note::quantizeLength( const int _q_grid )
+void Note::quantizeLength( const int qGrid )
 {
-	setLength( quantized( length(), _q_grid ) );
+	setLength( quantized( length(), qGrid ) );
 	if( length() == 0 )
 	{
-		setLength( _q_grid );
+		setLength( qGrid );
 	}
 }
 
 
 
 
-void Note::quantizePos( const int _q_grid )
+void Note::quantizePos( const int qGrid )
 {
-	setPos( quantized( pos(), _q_grid ) );
+	setPos( quantized( pos(), qGrid ) );
 }
 
 
 
 
-void Note::saveSettings( QDomDocument & _doc, QDomElement & _this )
+void Note::saveSettings( QDomDocument & doc, QDomElement & parent )
 {
-	_this.setAttribute( "key", m_key );
-	_this.setAttribute( "vol", m_volume );
-	_this.setAttribute( "pan", m_panning );
-	_this.setAttribute( "len", m_length );
-	_this.setAttribute( "pos", m_pos );
+	parent.setAttribute( "key", m_key );
+	parent.setAttribute( "vol", m_volume );
+	parent.setAttribute( "pan", m_panning );
+	parent.setAttribute( "len", m_length );
+	parent.setAttribute( "pos", m_pos );
 
 	if( m_detuning && m_length )
 	{
-		m_detuning->saveSettings( _doc, _this );
+		m_detuning->saveSettings( doc, parent );
 	}
 }
 
@@ -236,7 +236,6 @@ bool Note::hasDetuningInfo() const
 {
 	return m_detuning && m_detuning->hasAutomation();
 }
-
 
 
 

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -37,9 +37,9 @@
 #include "MainWindow.h"
 
 
-static PixmapLoader __dummy_loader;
+static PixmapLoader __dummyLoader;
 
-static Plugin::Descriptor dummy_plugin_descriptor =
+static Plugin::Descriptor dummyPluginDescriptor =
 {
 	"dummy",
 	"dummy",
@@ -47,21 +47,21 @@ static Plugin::Descriptor dummy_plugin_descriptor =
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,
 	Plugin::Undefined,
-	&__dummy_loader,
+	&__dummyLoader,
 	NULL
 } ;
 
 
 
 
-Plugin::Plugin( const Descriptor * _descriptor, Model * parent ) :
+Plugin::Plugin( const Descriptor * descriptor, Model * parent ) :
 	Model( parent ),
 	JournallingObject(),
-	m_descriptor( _descriptor )
+	m_descriptor( descriptor )
 {
 	if( m_descriptor == NULL )
 	{
-		m_descriptor = &dummy_plugin_descriptor;
+		m_descriptor = &dummyPluginDescriptor;
 	}
 }
 
@@ -108,7 +108,7 @@ Plugin * Plugin::instantiate( const QString & pluginName, Model * parent,
 		return new DummyPlugin();
 	}
 
-	InstantiationHook instantiationHook = ( InstantiationHook ) pluginLibrary.resolve( "lmms_plugin_main" );
+	InstantiationHook instantiationHook = ( InstantiationHook )pluginLibrary.resolve( "lmms_plugin_main" );
 	if( instantiationHook == NULL )
 	{
 		if( Engine::hasGUI() )
@@ -125,10 +125,14 @@ Plugin * Plugin::instantiate( const QString & pluginName, Model * parent,
 	return inst;
 }
 
-void Plugin::collectErrorForUI( QString err_msg )
+
+
+
+void Plugin::collectErrorForUI( QString errMsg )
 {
-	Engine::mainWindow()->collectError( err_msg );
+	Engine::mainWindow()->collectError( errMsg );
 }
+
 
 
 
@@ -188,13 +192,13 @@ PluginView * Plugin::createView( QWidget * parent )
 
 
 
-Plugin::Descriptor::SubPluginFeatures::Key::Key(
-						const QDomElement & _key ) :
+
+Plugin::Descriptor::SubPluginFeatures::Key::Key( const QDomElement & key ) :
 	desc( NULL ),
-	name( _key.attribute( "key" ) ),
+	name( key.attribute( "key" ) ),
 	attributes()
 {
-	QDomNodeList l = _key.elementsByTagName( "attribute" );
+	QDomNodeList l = key.elementsByTagName( "attribute" );
 	for( int i = 0; !l.item( i ).isNull(); ++i )
 	{
 		QDomElement e = l.item( i ).toElement();
@@ -207,17 +211,19 @@ Plugin::Descriptor::SubPluginFeatures::Key::Key(
 
 
 QDomElement Plugin::Descriptor::SubPluginFeatures::Key::saveXML(
-						QDomDocument & _doc ) const
+						QDomDocument & doc ) const
 {
-	QDomElement e = _doc.createElement( "key" );
-	for( AttributeMap::ConstIterator it = attributes.begin();
-									it != attributes.end(); ++it )
+	QDomElement e = doc.createElement( "key" );
+	for( AttributeMap::ConstIterator it = attributes.begin(); 
+		it != attributes.end(); ++it )
 	{
-		QDomElement a = _doc.createElement( "attribute" );
+		QDomElement a = doc.createElement( "attribute" );
 		a.setAttribute( "name", it.key() );
 		a.setAttribute( "value", it.value() );
 		e.appendChild( a );
 	}
 	return e;
 }
+
+
 

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -163,7 +163,7 @@ void ProjectRenderer::run()
     //skip first empty buffer
     Engine::mixer()->nextBuffer();
 
-	Song::playPos & pp = Engine::getSong()->getPlayPos(
+	Song::PlayPos & pp = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );
 	m_progress = 0;
 	const int sl = ( Engine::getSong()->length() + 1 ) * 192;
@@ -227,8 +227,6 @@ void ProjectRenderer::updateConsoleProgress()
 	fprintf( stderr, "%s", buf );
 	fflush( stderr );
 }
-
-
 
 
 

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -31,38 +31,38 @@
 
 
 
-int ProjectVersion::compare( const ProjectVersion & _v1,
-						const ProjectVersion & _v2 )
+int ProjectVersion::compare( const ProjectVersion & v1, 
+						const ProjectVersion & v2 )
 {
 	int n1, n2;
 
 	// Major
-	n1 = _v1.section( '.', 0, 0 ).toInt();
-	n2 = _v2.section( '.', 0, 0 ).toInt();
+	n1 = v1.section( '.', 0, 0 ).toInt();
+	n2 = v2.section( '.', 0, 0 ).toInt();
 	if( n1 != n2 )
 	{
 		return n1 - n2;
 	}
 
 	// Minor
-	n1 = _v1.section( '.', 1, 1 ).toInt();
-	n2 = _v2.section( '.', 1, 1 ).toInt();
+	n1 = v1.section( '.', 1, 1 ).toInt();
+	n2 = v2.section( '.', 1, 1 ).toInt();
 	if( n1 != n2 )
 	{
 		return n1 - n2;
 	}
 
 	// Release
-	n1 = _v1.section( '.', 2 ).section( '-', 0, 0 ).toInt();
-	n2 = _v2.section( '.', 2 ).section( '-', 0, 0 ).toInt();
+	n1 = v1.section( '.', 2 ).section( '-', 0, 0 ).toInt();
+	n2 = v2.section( '.', 2 ).section( '-', 0, 0 ).toInt();
 	if( n1 != n2 )
 	{
 		return n1 - n2;
 	}
 
 	// Build
-	const QString b1 = _v1.section( '.', 2 ).section( '-', 1 );
-	const QString b2 = _v2.section( '.', 2 ).section( '-', 1 );
+	const QString b1 = v1.section( '.', 2 ).section( '-', 1 );
+	const QString b2 = v2.section( '.', 2 ).section( '-', 1 );
 
 	// make sure 0.x.y > 0.x.y-patch
 	if( b1.isEmpty() )
@@ -76,7 +76,6 @@ int ProjectVersion::compare( const ProjectVersion & _v1,
 
 	return QString::compare( b1, b2 );
 }
-
 
 
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -140,7 +140,7 @@ void Song::masterVolumeChanged()
 void Song::setTempo()
 {
 	Engine::mixer()->lockPlayHandleRemoval();
-	const bpm_t tempo = (bpm_t) m_tempoModel.value();
+	const bpm_t tempo = ( bpm_t ) m_tempoModel.value();
 	PlayHandleList & playHandles = Engine::mixer()->playHandles();
 	for( PlayHandleList::Iterator it = playHandles.begin();
 						it != playHandles.end(); ++it )
@@ -172,7 +172,8 @@ void Song::setTimeSignature()
 	emit dataChanged();
 	m_oldTicksPerTact = ticksPerTact();
 
-	m_vstSyncController.setTimeSignature( getTimeSigModel().getNumerator(), getTimeSigModel().getDenominator() );
+	m_vstSyncController.setTimeSignature( 
+		getTimeSigModel().getNumerator(), getTimeSigModel().getDenominator() );
 }
 
 
@@ -198,13 +199,13 @@ void Song::processNextBuffer()
 		return;
 	}
 
-	TrackList track_list;
-	int tco_num = -1;
+	TrackList trackList;
+	int tcoNum = -1;
 
 	switch( m_playMode )
 	{
 		case Mode_PlaySong:
-			track_list = tracks();
+			trackList = tracks();
 			// at song-start we have to reset the LFOs
 			if( m_playPos[Mode_PlaySong] == 0 )
 			{
@@ -213,25 +214,25 @@ void Song::processNextBuffer()
 			break;
 
 		case Mode_PlayTrack:
-			track_list.push_back( m_trackToPlay );
+			trackList.push_back( m_trackToPlay );
 			break;
 
 		case Mode_PlayBB:
 			if( Engine::getBBTrackContainer()->numOfBBs() > 0 )
 			{
-				tco_num = Engine::getBBTrackContainer()->
+				tcoNum = Engine::getBBTrackContainer()->
 								currentBB();
-				track_list.push_back( BBTrack::findBBTrack(
-								tco_num ) );
+				trackList.push_back( BBTrack::findBBTrack(
+								tcoNum ) );
 			}
 			break;
 
 		case Mode_PlayPattern:
 			if( m_patternToPlay != NULL )
 			{
-				tco_num = m_patternToPlay->getTrack()->
+				tcoNum = m_patternToPlay->getTrack()->
 						getTCONum( m_patternToPlay );
-				track_list.push_back(
+				trackList.push_back(
 						m_patternToPlay->getTrack() );
 			}
 			break;
@@ -241,41 +242,43 @@ void Song::processNextBuffer()
 
 	}
 
-	if( track_list.empty() == true )
+	if( trackList.empty() == true )
 	{
 		return;
 	}
 
 	// check for looping-mode and act if necessary
 	Timeline * tl = m_playPos[m_playMode].m_timeLine;
-	bool check_loop = tl != NULL && m_exporting == false &&
+	bool checkLoop = tl != NULL && m_exporting == false &&
 				tl->loopPointsEnabled();
-	if( check_loop )
+	if( checkLoop )
 	{
 		if( m_playPos[m_playMode] < tl->loopBegin() ||
 					m_playPos[m_playMode] >= tl->loopEnd() )
 		{
-			m_elapsedMilliSeconds = (tl->loopBegin().getTicks()*60*1000/48)/getTempo();
+			m_elapsedMilliSeconds = 
+				( tl->loopBegin().getTicks() * 60 * 1000 / 48 ) / getTempo();
 			m_playPos[m_playMode].setTicks(
 						tl->loopBegin().getTicks() );
 		}
 	}
 
-	f_cnt_t total_frames_played = 0;
-	const float frames_per_tick = Engine::framesPerTick();
+	f_cnt_t totalFramesPlayed = 0;
+	const float framesPerTick = Engine::framesPerTick();
 
-	while( total_frames_played
-				< Engine::mixer()->framesPerPeriod() )
+	while( totalFramesPlayed < Engine::mixer()->framesPerPeriod() )
 	{
 		m_vstSyncController.update();
 
-		f_cnt_t played_frames = Engine::mixer()->framesPerPeriod() - total_frames_played;
+		f_cnt_t playedFrames = Engine::mixer()->framesPerPeriod() - 
+			totalFramesPlayed;
 
-		float current_frame = m_playPos[m_playMode].currentFrame();
+		float currentFrame = m_playPos[m_playMode].currentFrame();
 		// did we play a tick?
-		if( current_frame >= frames_per_tick )
+		if( currentFrame >= framesPerTick )
 		{
-			int ticks = m_playPos[m_playMode].getTicks() + (int)( current_frame / frames_per_tick );
+			int ticks = m_playPos[m_playMode].getTicks() + 
+				( int )( currentFrame / framesPerTick );
 
 			m_vstSyncController.setAbsolutePosition( ticks );
 
@@ -285,14 +288,14 @@ void Song::processNextBuffer()
 				// per default we just continue playing even if
 				// there's no more stuff to play
 				// (song-play-mode)
-				int max_tact = m_playPos[m_playMode].getTact()
+				int maxTact = m_playPos[m_playMode].getTact()
 									+ 2;
 
 				// then decide whether to go over to next tact
 				// or to loop back to first tact
 				if( m_playMode == Mode_PlayBB )
 				{
-					max_tact = Engine::getBBTrackContainer()
+					maxTact = Engine::getBBTrackContainer()
 							->lengthOfCurrentBB();
 				}
 				else if( m_playMode == Mode_PlayPattern &&
@@ -300,34 +303,39 @@ void Song::processNextBuffer()
 					tl != NULL &&
 					tl->loopPointsEnabled() == false )
 				{
-					max_tact = m_patternToPlay->length()
+					maxTact = m_patternToPlay->length()
 								.getTact();
 				}
 
 				// end of played object reached?
 				if( m_playPos[m_playMode].getTact() + 1
-								>= max_tact )
+								>= maxTact )
 				{
 					// then start from beginning and keep
 					// offset
-					ticks = ticks % ( max_tact * MidiTime::ticksPerTact() );
+					ticks %= ( maxTact * MidiTime::ticksPerTact() );
 
 					// wrap milli second counter
-					m_elapsedMilliSeconds = ( ticks * 60 * 1000 / 48 ) / getTempo();
+					m_elapsedMilliSeconds = 
+						( ticks * 60 * 1000 / 48 ) / getTempo();
 
 					m_vstSyncController.setAbsolutePosition( ticks );
 				}
 			}
 			m_playPos[m_playMode].setTicks( ticks );
 
-			if( check_loop )
+			if( checkLoop )
 			{
-				m_vstSyncController.startCycle( tl->loopBegin().getTicks(), tl->loopEnd().getTicks() );
+				m_vstSyncController.startCycle( 
+					tl->loopBegin().getTicks(), tl->loopEnd().getTicks() );
 
 				if( m_playPos[m_playMode] >= tl->loopEnd() )
 				{
 					m_playPos[m_playMode].setTicks( tl->loopBegin().getTicks() );
-					m_elapsedMilliSeconds = ((tl->loopBegin().getTicks())*60*1000/48)/getTempo();
+
+					m_elapsedMilliSeconds = 
+						( ( tl->loopBegin().getTicks() ) * 60 * 1000 / 48 ) / 
+							getTempo();
 				}
 			}
 			else
@@ -335,55 +343,57 @@ void Song::processNextBuffer()
 				m_vstSyncController.stopCycle();
 			}
 
-			current_frame = fmodf( current_frame, frames_per_tick );
-			m_playPos[m_playMode].setCurrentFrame( current_frame );
+			currentFrame = fmodf( currentFrame, framesPerTick );
+			m_playPos[m_playMode].setCurrentFrame( currentFrame );
 		}
 
-		f_cnt_t last_frames = (f_cnt_t)frames_per_tick -
-						(f_cnt_t) current_frame;
+		f_cnt_t lastFrames = ( f_cnt_t )framesPerTick - 
+			( f_cnt_t )currentFrame;
 		// skip last frame fraction
-		if( last_frames == 0 )
+		if( lastFrames == 0 )
 		{
-			++total_frames_played;
-			m_playPos[m_playMode].setCurrentFrame( current_frame
+			++totalFramesPlayed;
+			m_playPos[m_playMode].setCurrentFrame( currentFrame
 								+ 1.0f );
 			continue;
 		}
 		// do we have some samples left in this tick but these are
 		// less then samples we have to play?
-		if( last_frames < played_frames )
+		if( lastFrames < playedFrames )
 		{
 			// then set played_samples to remaining samples, the
 			// rest will be played in next loop
-			played_frames = last_frames;
+			playedFrames = lastFrames;
 		}
 
-		if( (f_cnt_t) current_frame == 0 )
+		if( ( f_cnt_t ) currentFrame == 0 )
 		{
 			if( m_playMode == Mode_PlaySong )
 			{
 				m_globalAutomationTrack->play(
 						m_playPos[m_playMode],
-						played_frames,
-						total_frames_played, tco_num );
+						playedFrames,
+						totalFramesPlayed, tcoNum );
 			}
 
 			// loop through all tracks and play them
-			for( int i = 0; i < track_list.size(); ++i )
+			for( int i = 0; i < trackList.size(); ++i )
 			{
-				track_list[i]->play( m_playPos[m_playMode],
-						played_frames,
-						total_frames_played, tco_num );
+				trackList[i]->play( m_playPos[m_playMode],
+						playedFrames,
+						totalFramesPlayed, tcoNum );
 			}
 		}
 
 		// update frame-counters
-		total_frames_played += played_frames;
-		m_playPos[m_playMode].setCurrentFrame( played_frames +
-								current_frame );
-		m_elapsedMilliSeconds += (((played_frames/frames_per_tick)*60*1000/48)/getTempo());
+		totalFramesPlayed += playedFrames;
+		m_playPos[m_playMode].setCurrentFrame( playedFrames +
+								currentFrame );
+		m_elapsedMilliSeconds += 
+			( ( playedFrames / framesPerTick ) * 60 * 1000 / 48 ) 
+				/ getTempo();
 		m_elapsedTacts = m_playPos[Mode_PlaySong].getTact();
-		m_elapsedTicks = (m_playPos[Mode_PlaySong].getTicks()%ticksPerTact())/48;
+		m_elapsedTicks = ( m_playPos[Mode_PlaySong].getTicks() % ticksPerTact() ) / 48;
 	}
 }
 
@@ -392,17 +402,21 @@ bool Song::isExportDone() const
 	if ( m_renderBetweenMarkers )
 	{
 		return m_exporting == true &&
-			m_playPos[Mode_PlaySong].getTicks() >= m_playPos[Mode_PlaySong].m_timeLine->loopEnd().getTicks();
+			m_playPos[Mode_PlaySong].getTicks() >= 
+				m_playPos[Mode_PlaySong].m_timeLine->loopEnd().getTicks();
 	}
+
 	if( m_exportLoop)
 	{
 		return m_exporting == true &&
-				m_playPos[Mode_PlaySong].getTicks() >= length() * ticksPerTact();
+			m_playPos[Mode_PlaySong].getTicks() >= 
+				length() * ticksPerTact();
 	}
 	else
 	{
 		return m_exporting == true &&
-			m_playPos[Mode_PlaySong].getTicks() >= ( length() + 1 ) * ticksPerTact();
+			m_playPos[Mode_PlaySong].getTicks() >= 
+				( length() + 1 ) * ticksPerTact();
 	}
 }
 
@@ -450,13 +464,13 @@ void Song::playAndRecord()
 
 
 
-void Song::playTrack( Track * _trackToPlay )
+void Song::playTrack( Track * trackToPlay )
 {
 	if( isStopped() == false )
 	{
 		stop();
 	}
-	m_trackToPlay = _trackToPlay;
+	m_trackToPlay = trackToPlay;
 
 	m_playMode = Mode_PlayTrack;
 	m_playing = true;
@@ -493,7 +507,7 @@ void Song::playBB()
 
 
 
-void Song::playPattern( const Pattern* patternToPlay, bool _loop )
+void Song::playPattern( const Pattern* patternToPlay, bool loop )
 {
 	if( isStopped() == false )
 	{
@@ -501,7 +515,7 @@ void Song::playPattern( const Pattern* patternToPlay, bool _loop )
 	}
 
 	m_patternToPlay = patternToPlay;
-	m_loopPattern = _loop;
+	m_loopPattern = loop;
 
 	if( m_patternToPlay != NULL )
 	{
@@ -539,12 +553,14 @@ void Song::updateLength()
 
 
 
-void Song::setPlayPos( tick_t _ticks, PlayModes _play_mode )
+void Song::setPlayPos( tick_t ticks, PlayModes playMode )
 {
-	m_elapsedTicks += m_playPos[_play_mode].getTicks() - _ticks;
-	m_elapsedMilliSeconds += (((( _ticks - m_playPos[_play_mode].getTicks()))*60*1000/48)/getTempo());
-	m_playPos[_play_mode].setTicks( _ticks );
-	m_playPos[_play_mode].setCurrentFrame( 0.0f );
+	m_elapsedTicks += m_playPos[playMode].getTicks() - ticks;
+	m_elapsedMilliSeconds += 
+		( ( ( ( ticks - m_playPos[playMode].getTicks() ) ) * 60 * 1000 / 48) / 
+			getTempo() );
+	m_playPos[playMode].setTicks( ticks );
+	m_playPos[playMode].setCurrentFrame( 0.0f );
 
 // send a signal if playposition changes during playback
 	if( isPlaying() ) 
@@ -604,7 +620,9 @@ void Song::stop()
 				if( tl->savedPos() >= 0 )
 				{
 					m_playPos[m_playMode].setTicks( tl->savedPos().getTicks() );
-					m_elapsedMilliSeconds = (((tl->savedPos().getTicks())*60*1000/48)/getTempo());
+					m_elapsedMilliSeconds = 
+						( ( ( tl->savedPos().getTicks() ) * 60 * 1000 / 48 ) / 
+							getTempo() );
 					tl->savePos( -1 );
 				}
 				break;
@@ -709,7 +727,7 @@ void Song::addBBTrack()
 
 void Song::addSampleTrack()
 {
-	(void) Track::create( Track::SampleTrack, this );
+	( void )Track::create( Track::SampleTrack, this );
 }
 
 
@@ -717,7 +735,7 @@ void Song::addSampleTrack()
 
 void Song::addAutomationTrack()
 {
-	(void) Track::create( Track::AutomationTrack, this );
+	( void )Track::create( Track::AutomationTrack, this );
 }
 
 
@@ -725,7 +743,7 @@ void Song::addAutomationTrack()
 
 bpm_t Song::getTempo()
 {
-	return (bpm_t) m_tempoModel.value();
+	return ( bpm_t )m_tempoModel.value();
 }
 
 
@@ -819,24 +837,23 @@ void Song::clearProject()
 
 
 
-
 // create new file
 void Song::createNewProject()
 {
-	QString default_template = ConfigManager::inst()->userProjectsDir()
+	QString defaultTemplate = ConfigManager::inst()->userProjectsDir()
 						+ "templates/default.mpt";
 
-	if( QFile::exists( default_template ) )
+	if( QFile::exists( defaultTemplate ) )
 	{
-		createNewProjectFromTemplate( default_template );
+		createNewProjectFromTemplate( defaultTemplate );
 		return;
 	}
 
-	default_template = ConfigManager::inst()->factoryProjectsDir()
+	defaultTemplate = ConfigManager::inst()->factoryProjectsDir()
 						+ "templates/default.mpt";
-	if( QFile::exists( default_template ) )
+	if( QFile::exists( defaultTemplate ) )
 	{
-		createNewProjectFromTemplate( default_template );
+		createNewProjectFromTemplate( defaultTemplate );
 		return;
 	}
 
@@ -886,9 +903,9 @@ void Song::createNewProject()
 
 
 
-void Song::createNewProjectFromTemplate( const QString & _template )
+void Song::createNewProjectFromTemplate( const QString & templ )
 {
-	loadProject( _template );
+	loadProject( templ );
 	// clear file-name so that user doesn't overwrite template when
 	// saving...
 	m_fileName = m_oldFileName = "";
@@ -904,7 +921,7 @@ void Song::createNewProjectFromTemplate( const QString & _template )
 
 
 // load given song
-void Song::loadProject( const QString & _file_name )
+void Song::loadProject( const QString & fileName )
 {
 	QDomNode node;
 
@@ -916,8 +933,8 @@ void Song::loadProject( const QString & _file_name )
 		Engine::mainWindow()->clearErrors();
 	}
 
-	m_fileName = _file_name;
-	m_oldFileName = _file_name;
+	m_fileName = fileName;
+	m_oldFileName = fileName;
 
 	DataFile dataFile( m_fileName );
 	// if file could not be opened, head-node is null and we create
@@ -1020,7 +1037,7 @@ void Song::loadProject( const QString & _file_name )
 
 	Engine::mixer()->unlock();
 
-	ConfigManager::inst()->addRecentlyOpenedProject( _file_name );
+	ConfigManager::inst()->addRecentlyOpenedProject( fileName );
 
 	Engine::projectJournal()->setJournalling( true );
 
@@ -1042,7 +1059,7 @@ void Song::loadProject( const QString & _file_name )
 
 
 // only save current song as _filename and do nothing else
-bool Song::saveProjectFile( const QString & _filename )
+bool Song::saveProjectFile( const QString & filename )
 {
 	DataFile::LocaleHelper localeHelper( DataFile::LocaleHelper::ModeSave );
 
@@ -1068,7 +1085,7 @@ bool Song::saveProjectFile( const QString & _filename )
 
 	saveControllerStates( dataFile, dataFile.content() );
 
-	return dataFile.writeFile( _filename );
+	return dataFile.writeFile( filename );
 }
 
 
@@ -1146,23 +1163,23 @@ void Song::importProject()
 
 
 
-void Song::saveControllerStates( QDomDocument & _doc, QDomElement & _this )
+void Song::saveControllerStates( QDomDocument & doc, QDomElement & element )
 {
 	// save settings of controllers
-	QDomElement controllersNode =_doc.createElement( "controllers" );
-	_this.appendChild( controllersNode );
+	QDomElement controllersNode = doc.createElement( "controllers" );
+	element.appendChild( controllersNode );
 	for( int i = 0; i < m_controllers.size(); ++i )
 	{
-		m_controllers[i]->saveState( _doc, controllersNode );
+		m_controllers[i]->saveState( doc, controllersNode );
 	}
 }
 
 
 
 
-void Song::restoreControllerStates( const QDomElement & _this )
+void Song::restoreControllerStates( const QDomElement & element )
 {
-	QDomNode node = _this.firstChild();
+	QDomNode node = element.firstChild();
 	while( !node.isNull() )
 	{
 		Controller * c = Controller::create( node.toElement(), this );
@@ -1183,10 +1200,10 @@ void Song::restoreControllerStates( const QDomElement & _this )
 
 void Song::exportProjectTracks()
 {
-	exportProject(true);
+	exportProject( true );
 }
 
-void Song::exportProject(bool multiExport)
+void Song::exportProject( bool multiExport )
 {
 	if( isEmpty() )
 	{
@@ -1199,7 +1216,7 @@ void Song::exportProject(bool multiExport)
 	}
 
 	FileDialog efd( Engine::mainWindow() );
-	if (multiExport)
+	if ( multiExport )
 	{
 		efd.setFileMode( FileDialog::Directory);
 		efd.setWindowTitle( tr( "Select directory for writing exported tracks..." ) );
@@ -1219,18 +1236,18 @@ void Song::exportProject(bool multiExport)
 			++idx;
 		}
 		efd.setNameFilters( types );
-		QString base_filename;
+		QString baseFilename;
 		if( !m_fileName.isEmpty() )
 		{
 			efd.setDirectory( QFileInfo( m_fileName ).absolutePath() );
-			base_filename = QFileInfo( m_fileName ).completeBaseName();
+			baseFilename = QFileInfo( m_fileName ).completeBaseName();
 		}
 		else
 		{
 			efd.setDirectory( ConfigManager::inst()->userProjectsDir() );
-			base_filename = tr( "untitled" );
+			baseFilename = tr( "untitled" );
 		}
-		efd.selectFile( base_filename + __fileEncodeDevices[0].m_extension );
+		efd.selectFile( baseFilename + __fileEncodeDevices[0].m_extension );
 		efd.setWindowTitle( tr( "Select file for project-export..." ) );
 	}
 
@@ -1257,8 +1274,8 @@ void Song::exportProject(bool multiExport)
 			}
 		}
 
-		const QString export_file_name = efd.selectedFiles()[0] + suffix;
-		ExportProjectDialog epd( export_file_name, Engine::mainWindow(), multiExport );
+		const QString exportFileName = efd.selectedFiles()[0] + suffix;
+		ExportProjectDialog epd( exportFileName, Engine::mainWindow(), multiExport );
 		epd.exec();
 	}
 }
@@ -1290,11 +1307,11 @@ void Song::setModified()
 
 
 
-void Song::addController( Controller * _c )
+void Song::addController( Controller * c )
 {
-	if( _c != NULL && !m_controllers.contains( _c ) ) 
+	if( c != NULL && m_controllers.contains( c ) == false ) 
 	{
-		m_controllers.append( _c );
+		m_controllers.append( c );
 		emit dataChanged();
 	}
 }
@@ -1302,9 +1319,9 @@ void Song::addController( Controller * _c )
 
 
 
-void Song::removeController( Controller * _controller )
+void Song::removeController( Controller * controller )
 {
-	int index = m_controllers.indexOf( _controller );
+	int index = m_controllers.indexOf( controller );
 	if( index != -1 )
 	{
 		m_controllers.remove( index );
@@ -1316,8 +1333,6 @@ void Song::removeController( Controller * _controller )
 		emit dataChanged();
 	}
 }
-
-
 
 
 

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -51,7 +51,7 @@ QPixmap * Timeline::s_loopPointBeginPixmap = NULL;
 QPixmap * Timeline::s_loopPointEndPixmap = NULL;
 
 Timeline::Timeline( const int _xoff, const int _yoff, const float _ppt,
-			Song::playPos & _pos, const MidiTime & _begin,
+			Song::PlayPos & _pos, const MidiTime & _begin,
 							QWidget * _parent ) :
 	QWidget( _parent ),
 	m_autoScroll( AutoScrollEnabled ),
@@ -388,10 +388,6 @@ void Timeline::mouseReleaseEvent( QMouseEvent* event )
 	m_hint = NULL;
 	m_action = NoAction;
 }
-
-
-
-
 
 
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -99,9 +99,9 @@ TextFloat * TrackContentObjectView::s_textFloat = NULL;
  *
  * \param _track The track that will contain the new object
  */
-TrackContentObject::TrackContentObject( Track * _track ) :
-	Model( _track ),
-	m_track( _track ),
+TrackContentObject::TrackContentObject( Track * track ) :
+	Model( track ),
+	m_track( track ),
 	m_name( QString::null ),
 	m_startPosition(),
 	m_length(),
@@ -146,11 +146,11 @@ TrackContentObject::~TrackContentObject()
  *
  * \param _pos The new position of the track content object.
  */
-void TrackContentObject::movePosition( const MidiTime & _pos )
+void TrackContentObject::movePosition( const MidiTime & pos )
 {
-	if( m_startPosition != _pos )
+	if( m_startPosition != pos )
 	{
-		m_startPosition = _pos;
+		m_startPosition = pos;
 		Engine::getSong()->updateLength();
 	}
 	emit positionChanged();
@@ -166,11 +166,11 @@ void TrackContentObject::movePosition( const MidiTime & _pos )
  *
  * \param _length The new length of the track content object.
  */
-void TrackContentObject::changeLength( const MidiTime & _length )
+void TrackContentObject::changeLength( const MidiTime & length )
 {
-	if( m_length != _length )
+	if( m_length != length )
 	{
-		m_length = _length;
+		m_length = length;
 		Engine::getSong()->updateLength();
 	}
 	emit lengthChanged();
@@ -241,12 +241,12 @@ void TrackContentObject::toggleMute()
  * \param _tco The track content object to be displayed
  * \param _tv  The track view that will contain the new object
  */
-TrackContentObjectView::TrackContentObjectView( TrackContentObject * _tco,
-							TrackView * _tv ) :
-	selectableObject( _tv->getTrackContentWidget() ),
+TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
+							TrackView * tv ) :
+	selectableObject( tv->getTrackContentWidget() ),
 	ModelView( NULL, this ),
-	m_tco( _tco ),
-	m_trackView( _tv ),
+	m_tco( tco ),
+	m_trackView( tv ),
 	m_action( NoAction ),
 	m_autoResize( false ),
 	m_initialMousePos( QPoint( 0, 0 ) ),
@@ -268,7 +268,7 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * _tco,
 	move( 0, 1 );
 	show();
 
-	setFixedHeight( _tv->getTrackContentWidget()->height() - 2 );
+	setFixedHeight( tv->getTrackContentWidget()->height() - 2 );
 	setAcceptDrops( true );
 	setMouseTracking( true );
 
@@ -328,12 +328,12 @@ QColor TrackContentObjectView::textColor() const
 { return m_textColor; }
 
 //! \brief CSS theming qproperty access method
-void TrackContentObjectView::setFgColor( const QColor & _c )
-{ m_fgColor = QColor( _c ); }
+void TrackContentObjectView::setFgColor( const QColor & c )
+{ m_fgColor = QColor( c ); }
 
 //! \brief CSS theming qproperty access method
-void TrackContentObjectView::setTextColor( const QColor & _c )
-{ m_textColor = QColor( _c ); }
+void TrackContentObjectView::setTextColor( const QColor & c )
+{ m_textColor = QColor( c ); }
 
 
 /*! \brief Close a trackContentObjectView
@@ -434,19 +434,19 @@ void TrackContentObjectView::updatePosition()
  *  We need to notify Qt to change our display if something being
  *  dragged has entered our 'airspace'.
  *
- * \param _dee The QDragEnterEvent to watch.
+ * \param dee The QDragEnterEvent to watch.
  */
-void TrackContentObjectView::dragEnterEvent( QDragEnterEvent * _dee )
+void TrackContentObjectView::dragEnterEvent( QDragEnterEvent * dee )
 {
 	TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
 	MidiTime tcoPos = MidiTime( m_tco->startPosition().getTact(), 0 );
-	if( tcw->canPasteSelection( tcoPos, _dee->mimeData() ) == false )
+	if( tcw->canPasteSelection( tcoPos, dee->mimeData() ) == false )
 	{
-		_dee->ignore();
+		dee->ignore();
 	}
 	else
 	{
-		StringPairDrag::processDragEnterEvent( _dee, "tco_" +
+		StringPairDrag::processDragEnterEvent( dee, "tco_" +
 					QString::number( m_tco->getTrack()->type() ) );
 	}
 }
@@ -461,12 +461,12 @@ void TrackContentObjectView::dragEnterEvent( QDragEnterEvent * _dee )
  *  to take the xml of the track content object and turn it into something
  *  we can write over our current state.
  *
- * \param _de The QDropEvent to handle.
+ * \param de The QDropEvent to handle.
  */
-void TrackContentObjectView::dropEvent( QDropEvent * _de )
+void TrackContentObjectView::dropEvent( QDropEvent * de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
+	QString type = StringPairDrag::decodeKey( de );
+	QString value = StringPairDrag::decodeValue( de );
 
 	// Track must be the same type to paste into
 	if( type != ( "tco_" + QString::number( m_tco->getTrack()->type() ) ) )
@@ -479,15 +479,15 @@ void TrackContentObjectView::dropEvent( QDropEvent * _de )
 	{
 		TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
 		MidiTime tcoPos = MidiTime( m_tco->startPosition().getTact(), 0 );
-		if( tcw->pasteSelection( tcoPos, _de ) == true )
+		if( tcw->pasteSelection( tcoPos, de ) == true )
 		{
-			_de->accept();
+			de->accept();
 		}
 		return;
 	}
 
 	// Don't allow pasting a tco into itself.
-	QObject* qwSource = _de->source();
+	QObject* qwSource = de->source();
 	if( qwSource != NULL &&
 	    dynamic_cast<TrackContentObjectView *>( qwSource ) == this )
 	{
@@ -501,7 +501,7 @@ void TrackContentObjectView::dropEvent( QDropEvent * _de )
 	m_tco->restoreState( tcos.firstChildElement().firstChildElement() );
 	m_tco->movePosition( pos );
 	AutomationPattern::resolveAllIDs();
-	_de->accept();
+	de->accept();
 }
 
 
@@ -509,17 +509,17 @@ void TrackContentObjectView::dropEvent( QDropEvent * _de )
 
 /*! \brief Handle a dragged selection leaving our 'airspace'.
  *
- * \param _e The QEvent to watch.
+ * \param e The QEvent to watch.
  */
-void TrackContentObjectView::leaveEvent( QEvent * _e )
+void TrackContentObjectView::leaveEvent( QEvent * e )
 {
 	while( QApplication::overrideCursor() != NULL )
 	{
 		QApplication::restoreOverrideCursor();
 	}
-	if( _e != NULL )
+	if( e != NULL )
 	{
-		QWidget::leaveEvent( _e );
+		QWidget::leaveEvent( e );
 	}
 }
 
@@ -585,20 +585,20 @@ DataFile TrackContentObjectView::createTCODataFiles(
  *  * or if ctrl-middle button, mute the track content object
  *  * or if middle button, maybe delete the track content object.
  *
- * \param _me The QMouseEvent to handle.
+ * \param me The QMouseEvent to handle.
  */
-void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
+void TrackContentObjectView::mousePressEvent( QMouseEvent * me )
 {
-	setInitialMousePos( _me->pos() );
+	setInitialMousePos( me->pos() );
 	if( m_trackView->trackContainerView()->allowRubberband() == true &&
-	    _me->button() == Qt::LeftButton )
+	    me->button() == Qt::LeftButton )
 	{
 		if( m_trackView->trackContainerView()->rubberBandActive() == true )
 		{
 			// Propagate to trackView for rubberbanding
-			selectableObject::mousePressEvent( _me );
+			selectableObject::mousePressEvent( me );
 		}
-		else if ( _me->modifiers() & Qt::ControlModifier )
+		else if ( me->modifiers() & Qt::ControlModifier )
 		{
 			if( isSelected() == true )
 			{
@@ -609,7 +609,7 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
 				m_action = ToggleSelected;
 			}
 		}
-		else if( !_me->modifiers() )
+		else if( !me->modifiers() )
 		{
 			if( isSelected() == true )
 			{
@@ -617,8 +617,8 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
 			}
 		}
 	}
-	else if( _me->button() == Qt::LeftButton &&
-			 _me->modifiers() & Qt::ControlModifier )
+	else if( me->button() == Qt::LeftButton && 
+			 me->modifiers() & Qt::ControlModifier )
 	{
 		// start drag-action
 		QVector<TrackContentObjectView *> tcoViews;
@@ -632,7 +632,7 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
 						m_tco->getTrack()->type() ),
 					dataFile.toString(), thumbnail, this );
 	}
-	else if( _me->button() == Qt::LeftButton &&
+	else if( me->button() == Qt::LeftButton &&
 		/*	engine::mainWindow()->isShiftPressed() == false &&*/
 							fixedTCOs() == false )
 	{
@@ -641,9 +641,9 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
 		// move or resize
 		m_tco->setJournalling( false );
 
-		setInitialMousePos( _me->pos() );
+		setInitialMousePos( me->pos() );
 
-		if( _me->x() < width() - RESIZE_GRIP_WIDTH )
+		if( me->x() < width() - RESIZE_GRIP_WIDTH )
 		{
 			m_action = Move;
 			m_oldTime = m_tco->startPosition();
@@ -671,23 +671,23 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
 		}
 //		s_textFloat->reparent( this );
 		// setup text-float as if TCO was already moved/resized
-		mouseMoveEvent( _me );
+		mouseMoveEvent( me );
 		s_textFloat->show();
 	}
-	else if( _me->button() == Qt::RightButton )
+	else if( me->button() == Qt::RightButton )
 	{
-		if( _me->modifiers() & Qt::ControlModifier )
+		if( me->modifiers() & Qt::ControlModifier )
 		{
 			m_tco->toggleMute();
 		}
-		else if( _me->modifiers() & Qt::ShiftModifier && fixedTCOs() == false )
+		else if( me->modifiers() & Qt::ShiftModifier && fixedTCOs() == false )
 		{
 			remove();
 		}
 	}
-	else if( _me->button() == Qt::MidButton )
+	else if( me->button() == Qt::MidButton )
 	{
-		if( _me->modifiers() & Qt::ControlModifier )
+		if( me->modifiers() & Qt::ControlModifier )
 		{
 			m_tco->toggleMute();
 		}
@@ -711,17 +711,17 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * _me )
  *  * or if in resize mode, resize ourselves,
  *  * otherwise ???
  *
- * \param _me The QMouseEvent to handle.
+ * \param me The QMouseEvent to handle.
  * \todo what does the final else case do here?
  */
-void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
+void TrackContentObjectView::mouseMoveEvent( QMouseEvent * me )
 {
 	if( m_action == CopySelection )
 	{
-		if( mouseMovedDistance( _me, 2 ) == true &&
+		if( mouseMovedDistance( me, 2 ) == true &&
 		    m_trackView->trackContainerView()->allowRubberband() == true &&
 		    m_trackView->trackContainerView()->rubberBandActive() == false &&
-		    ( _me->modifiers() & Qt::ControlModifier ) )
+		    ( me->modifiers() & Qt::ControlModifier ) )
 		{
 			// Clear the action here because mouseReleaseEvent will not get
 			// triggered once we go into drag.
@@ -756,7 +756,7 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 		}
 	}
 
-	if( _me->modifiers() & Qt::ControlModifier )
+	if( me->modifiers() & Qt::ControlModifier )
 	{
 		delete m_hint;
 		m_hint = NULL;
@@ -765,13 +765,13 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 	const float ppt = m_trackView->trackContainerView()->pixelsPerTact();
 	if( m_action == Move )
 	{
-		const int x = mapToParent( _me->pos() ).x() - m_initialMousePos.x();
+		const int x = mapToParent( me->pos() ).x() - m_initialMousePos.x();
 		MidiTime t = qMax( 0, (int)
 			m_trackView->trackContainerView()->currentPosition()+
 				static_cast<int>( x * MidiTime::ticksPerTact() /
 									ppt ) );
-		if( ! ( _me->modifiers() & Qt::ControlModifier )
-		   && _me->button() == Qt::NoButton )
+		if( ! ( me->modifiers() & Qt::ControlModifier )
+		   && me->button() == Qt::NoButton )
 		{
 			t = t.toNearestTact();
 		}
@@ -786,7 +786,7 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 	}
 	else if( m_action == MoveSelection )
 	{
-		const int dx = _me->x() - m_initialMousePos.x();
+		const int dx = me->x() - m_initialMousePos.x();
 		QVector<selectableObject *> so =
 			m_trackView->trackContainerView()->selectedObjects();
 		QVector<TrackContentObject *> tcos;
@@ -815,8 +815,8 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 			t = ( *it )->startPosition() +
 				static_cast<int>( dx *MidiTime::ticksPerTact() /
 					 ppt )-smallest_pos;
-			if( ! ( _me->modifiers() & Qt::AltModifier )
-					   && _me->button() == Qt::NoButton )
+			if( ! ( me->modifiers() & Qt::AltModifier )
+					   && me->button() == Qt::NoButton )
 			{
 				t = t.toNearestTact();
 			}
@@ -825,8 +825,8 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 	}
 	else if( m_action == Resize )
 	{
-		MidiTime t = qMax( MidiTime::ticksPerTact() / 16, static_cast<int>( _me->x() * MidiTime::ticksPerTact() / ppt ) );
-		if( ! ( _me->modifiers() & Qt::ControlModifier ) && _me->button() == Qt::NoButton )
+		MidiTime t = qMax( MidiTime::ticksPerTact() / 16, static_cast<int>( me->x() * MidiTime::ticksPerTact() / ppt ) );
+		if( ! ( me->modifiers() & Qt::ControlModifier ) && me->button() == Qt::NoButton )
 		{
 			t = qMax<int>( MidiTime::ticksPerTact(), t.toNearestTact() );
 		}
@@ -846,7 +846,7 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
 	}
 	else
 	{
-		if( _me->x() > width() - RESIZE_GRIP_WIDTH && !_me->buttons() )
+		if( me->x() > width() - RESIZE_GRIP_WIDTH && !me->buttons() )
 		{
 			if( QApplication::overrideCursor() != NULL &&
 				QApplication::overrideCursor()->shape() !=
@@ -875,16 +875,16 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * _me )
  *  If we're in move or resize mode, journal the change as appropriate.
  *  Then tidy up.
  *
- * \param _me The QMouseEvent to handle.
+ * \param me The QMouseEvent to handle.
  */
-void TrackContentObjectView::mouseReleaseEvent( QMouseEvent * _me )
+void TrackContentObjectView::mouseReleaseEvent( QMouseEvent * me )
 {
 	// If the CopySelection was chosen as the action due to mouse movement,
 	// it will have been cleared.  At this point Toggle is the desired action.
 	// An active StringPairDrag will prevent this method from being called,
 	// so a real CopySelection would not have occurred.
 	if( m_action == CopySelection ||
-	    ( m_action == ToggleSelected && mouseMovedDistance( _me, 2 ) == false ) )
+	    ( m_action == ToggleSelected && mouseMovedDistance( me, 2 ) == false ) )
 	{
 		setSelected( !isSelected() );
 	}
@@ -898,7 +898,7 @@ void TrackContentObjectView::mouseReleaseEvent( QMouseEvent * _me )
 	m_hint = NULL;
 	s_textFloat->hide();
 	leaveEvent( NULL );
-	selectableObject::mouseReleaseEvent( _me );
+	selectableObject::mouseReleaseEvent( me );
 }
 
 
@@ -909,11 +909,11 @@ void TrackContentObjectView::mouseReleaseEvent( QMouseEvent * _me )
  *  Set up the various context menu events that can apply to a
  *  track content object view.
  *
- * \param _cme The QContextMenuEvent to add the actions to.
+ * \param cme The QContextMenuEvent to add the actions to.
  */
-void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * _cme )
+void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * cme )
 {
-	if( _cme->modifiers() )
+	if( cme->modifiers() )
 	{
 		return;
 	}
@@ -959,12 +959,12 @@ float TrackContentObjectView::pixelsPerTact()
 
 /*! \brief Set whether this trackContentObjectView can resize.
  *
- * \param _e The boolean state of whether this track content object view
+ * \param e The boolean state of whether this track content object view
  *  is allowed to resize.
  */
-void TrackContentObjectView::setAutoResizeEnabled( bool _e )
+void TrackContentObjectView::setAutoResizeEnabled( bool e )
 {
-	m_autoResize = _e;
+	m_autoResize = e;
 }
 
 
@@ -975,9 +975,9 @@ void TrackContentObjectView::setAutoResizeEnabled( bool _e )
  * \param _me The QMouseEvent.
  * \param distance The threshold distance that the mouse has moved to return true.
  */
-bool TrackContentObjectView::mouseMovedDistance( QMouseEvent * _me, int distance )
+bool TrackContentObjectView::mouseMovedDistance( QMouseEvent * me, int distance )
 {
-	QPoint dPos = mapToGlobal( _me->pos() ) - m_initialMouseGlobalPos;
+	QPoint dPos = mapToGlobal( me->pos() ) - m_initialMouseGlobalPos;
 	const int pixelsMoved = dPos.manhattanLength();
 	return ( pixelsMoved > distance || pixelsMoved < -distance );
 }
@@ -994,17 +994,17 @@ bool TrackContentObjectView::mouseMovedDistance( QMouseEvent * _me, int distance
  *  The content widget comprises the 'grip bar' and the 'tools' button
  *  for the track's context menu.
  *
- * \param _track The parent track.
+ * \param parent The parent track.
  */
-TrackContentWidget::TrackContentWidget( TrackView * _parent ) :
-	QWidget( _parent ),
-	m_trackView( _parent ),
+TrackContentWidget::TrackContentWidget( TrackView * parent ) :
+	QWidget( parent ),
+	m_trackView( parent ),
 	m_darkerColor( Qt::SolidPattern ),
 	m_lighterColor( Qt::SolidPattern )
 {
 	setAcceptDrops( true );
 
-	connect( _parent->trackContainerView(),
+	connect( parent->trackContainerView(),
 			SIGNAL( positionChanged( const MidiTime & ) ),
 			this, SLOT( changePosition( const MidiTime & ) ) );
 
@@ -1074,13 +1074,13 @@ void TrackContentWidget::updateBackground()
  *  Adds a(nother) trackContentObjectView to our list of views.  We also
  *  check that our position is up-to-date.
  *
- * \param _tcov The trackContentObjectView to add.
+ * \param tcov The trackContentObjectView to add.
  */
-void TrackContentWidget::addTCOView( TrackContentObjectView * _tcov )
+void TrackContentWidget::addTCOView( TrackContentObjectView * tcov )
 {
-	TrackContentObject * tco = _tcov->getTrackContentObject();
+	TrackContentObject * tco = tcov->getTrackContentObject();
 
-	m_tcoViews.push_back( _tcov );
+	m_tcoViews.push_back( tcov );
 
 	tco->saveJournallingState( false );
 	changePosition();
@@ -1094,13 +1094,13 @@ void TrackContentWidget::addTCOView( TrackContentObjectView * _tcov )
  *
  *  Removes the given trackContentObjectView from our list of views.
  *
- * \param _tcov The trackContentObjectView to add.
+ * \param tcov The trackContentObjectView to add.
  */
-void TrackContentWidget::removeTCOView( TrackContentObjectView * _tcov )
+void TrackContentWidget::removeTCOView( TrackContentObjectView * tcov )
 {
 	tcoViewVector::iterator it = qFind( m_tcoViews.begin(),
 						m_tcoViews.end(),
-						_tcov );
+						tcov );
 	if( it != m_tcoViews.end() )
 	{
 		m_tcoViews.erase( it );
@@ -1132,13 +1132,13 @@ void TrackContentWidget::update()
 // change of visible viewport
 /*! \brief Move the trackContentWidget to a new place in time
  *
- * \param _new_pos The MIDI time to move to.
+ * \param newPos The MIDI time to move to.
  */
-void TrackContentWidget::changePosition( const MidiTime & _new_pos )
+void TrackContentWidget::changePosition( const MidiTime & newPos )
 {
 	if( m_trackView->trackContainerView() == Engine::getBBEditor() )
 	{
-		const int cur_bb = Engine::getBBTrackContainer()->currentBB();
+		const int curBB = Engine::getBBTrackContainer()->currentBB();
 		setUpdatesEnabled( false );
 
 		// first show TCO for current BB...
@@ -1146,7 +1146,7 @@ void TrackContentWidget::changePosition( const MidiTime & _new_pos )
 						it != m_tcoViews.end(); ++it )
 		{
 		if( ( *it )->getTrackContentObject()->
-                            startPosition().getTact() == cur_bb )
+                            startPosition().getTact() == curBB )
 			{
 				( *it )->move( 0, ( *it )->y() );
 				( *it )->raise();
@@ -1162,7 +1162,7 @@ void TrackContentWidget::changePosition( const MidiTime & _new_pos )
 					it != m_tcoViews.end(); ++it )
 		{
 			if( ( *it )->getTrackContentObject()->
-	                            startPosition().getTact() != cur_bb )
+	                            startPosition().getTact() != curBB )
 			{
 				( *it )->hide();
 			}
@@ -1171,7 +1171,7 @@ void TrackContentWidget::changePosition( const MidiTime & _new_pos )
 		return;
 	}
 
-	MidiTime pos = _new_pos;
+	MidiTime pos = newPos;
 	if( pos < 0 )
 	{
 		pos = m_trackView->trackContainerView()->currentPosition();
@@ -1220,13 +1220,13 @@ void TrackContentWidget::changePosition( const MidiTime & _new_pos )
 
 /*! \brief Return the position of the trackContentWidget in Tacts.
  *
- * \param _mouse_x the mouse's current X position in pixels.
+ * \param mouseX the mouse's current X position in pixels.
  */
-MidiTime TrackContentWidget::getPosition( int _mouse_x )
+MidiTime TrackContentWidget::getPosition( int mouseX )
 {
 	TrackContainerView * tv = m_trackView->trackContainerView();
 	return MidiTime( tv->currentPosition() +
-					 _mouse_x *
+					 mouseX *
 					 MidiTime::ticksPerTact() /
 					 static_cast<int>( tv->pixelsPerTact() ) );
 }
@@ -1236,18 +1236,18 @@ MidiTime TrackContentWidget::getPosition( int _mouse_x )
 
 /*! \brief Respond to a drag enter event on the trackContentWidget
  *
- * \param _dee the Drag Enter Event to respond to
+ * \param dee the Drag Enter Event to respond to
  */
-void TrackContentWidget::dragEnterEvent( QDragEnterEvent * _dee )
+void TrackContentWidget::dragEnterEvent( QDragEnterEvent * dee )
 {
-	MidiTime tcoPos = MidiTime( getPosition( _dee->pos().x() ).getTact(), 0 );
-	if( canPasteSelection( tcoPos, _dee->mimeData() ) == false )
+	MidiTime tcoPos = MidiTime( getPosition( dee->pos().x() ).getTact(), 0 );
+	if( canPasteSelection( tcoPos, dee->mimeData() ) == false )
 	{
-		_dee->ignore();
+		dee->ignore();
 	}
 	else
 	{
-		StringPairDrag::processDragEnterEvent( _dee, "tco_" +
+		StringPairDrag::processDragEnterEvent( dee, "tco_" +
 						QString::number( getTrack()->type() ) );
 	}
 }
@@ -1258,7 +1258,7 @@ void TrackContentWidget::dragEnterEvent( QDragEnterEvent * _dee )
 /*! \brief Returns whether a selection of TCOs can be pasted into this
  *
  * \param tcoPos the position of the TCO slot being pasted on
- * \param _de the DropEvent generated
+ * \param de the DropEvent generated
  */
 bool TrackContentWidget::canPasteSelection( MidiTime tcoPos, const QMimeData * mimeData )
 {
@@ -1301,7 +1301,7 @@ bool TrackContentWidget::canPasteSelection( MidiTime tcoPos, const QMimeData * m
 	QDomNodeList tcoNodes = tcoParent.childNodes();
 
 	// Determine if all the TCOs will land on a valid track
-	for( int i = 0; i<tcoNodes.length(); i++ )
+	for( int i = 0; i < tcoNodes.length(); i++ )
 	{
 		QDomElement tcoElement = tcoNodes.item( i ).toElement();
 		int trackIndex = tcoElement.attributeNode( "trackIndex" ).value().toInt();
@@ -1328,17 +1328,17 @@ bool TrackContentWidget::canPasteSelection( MidiTime tcoPos, const QMimeData * m
 /*! \brief Pastes a selection of TCOs onto the track
  *
  * \param tcoPos the position of the TCO slot being pasted on
- * \param _de the DropEvent generated
+ * \param de the DropEvent generated
  */
-bool TrackContentWidget::pasteSelection( MidiTime tcoPos, QDropEvent * _de )
+bool TrackContentWidget::pasteSelection( MidiTime tcoPos, QDropEvent * de )
 {
-	if( canPasteSelection( tcoPos, _de->mimeData() ) == false )
+	if( canPasteSelection( tcoPos, de->mimeData() ) == false )
 	{
 		return false;
 	}
 
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
+	QString type = StringPairDrag::decodeKey( de );
+	QString value = StringPairDrag::decodeValue( de );
 
 	getTrack()->addJournalCheckPoint();
 
@@ -1412,14 +1412,14 @@ bool TrackContentWidget::pasteSelection( MidiTime tcoPos, QDropEvent * _de )
 
 /*! \brief Respond to a drop event on the trackContentWidget
  *
- * \param _de the Drop Event to respond to
+ * \param de the Drop Event to respond to
  */
-void TrackContentWidget::dropEvent( QDropEvent * _de )
+void TrackContentWidget::dropEvent( QDropEvent * de )
 {
-	MidiTime tcoPos = MidiTime( getPosition( _de->pos().x() ).getTact(), 0 );
-	if( pasteSelection( tcoPos, _de ) == true )
+	MidiTime tcoPos = MidiTime( getPosition( de->pos().x() ).getTact(), 0 );
+	if( pasteSelection( tcoPos, de ) == true )
 	{
-		_de->accept();
+		de->accept();
 	}
 }
 
@@ -1428,29 +1428,28 @@ void TrackContentWidget::dropEvent( QDropEvent * _de )
 
 /*! \brief Respond to a mouse press on the trackContentWidget
  *
- * \param _me the mouse press event to respond to
+ * \param me the mouse press event to respond to
  */
-void TrackContentWidget::mousePressEvent( QMouseEvent * _me )
+void TrackContentWidget::mousePressEvent( QMouseEvent * me )
 {
 	if( m_trackView->trackContainerView()->allowRubberband() == true )
 	{
-		QWidget::mousePressEvent( _me );
+		QWidget::mousePressEvent( me );
 	}
-	else if( _me->modifiers() & Qt::ShiftModifier )
+	else if( me->modifiers() & Qt::ShiftModifier )
 	{
-		QWidget::mousePressEvent( _me );
+		QWidget::mousePressEvent( me );
 	}
-	else if( _me->button() == Qt::LeftButton &&
+	else if( me->button() == Qt::LeftButton &&
 			!m_trackView->trackContainerView()->fixedTCOs() )
 	{
-		const MidiTime pos = getPosition( _me->x() ).getTact() *
+		const MidiTime pos = getPosition( me->x() ).getTact() *
 						MidiTime::ticksPerTact();
 		TrackContentObject * tco = getTrack()->createTCO( pos );
 
 		tco->saveJournallingState( false );
 		tco->movePosition( pos );
 		tco->restoreJournallingState();
-
 	}
 }
 
@@ -1459,9 +1458,9 @@ void TrackContentWidget::mousePressEvent( QMouseEvent * _me )
 
 /*! \brief Repaint the trackContentWidget on command
  *
- * \param _pe the Paint Event to respond to
+ * \param pe the Paint Event to respond to
  */
-void TrackContentWidget::paintEvent( QPaintEvent * _pe )
+void TrackContentWidget::paintEvent( QPaintEvent * pe )
 {
 	// Assume even-pixels-per-tact. Makes sense, should be like this anyways
 	const TrackContainerView * tcv = m_trackView->trackContainerView();
@@ -1506,13 +1505,13 @@ Track * TrackContentWidget::getTrack()
 
 /*! \brief Return the end position of the trackContentWidget in Tacts.
  *
- * \param _pos_start the starting position of the Widget (from getPosition())
+ * \param posStart the starting position of the Widget (from getPosition())
  */
-MidiTime TrackContentWidget::endPosition( const MidiTime & _pos_start )
+MidiTime TrackContentWidget::endPosition( const MidiTime & posStart )
 {
 	const float ppt = m_trackView->trackContainerView()->pixelsPerTact();
 	const int w = width();
-	return _pos_start + static_cast<int>( w * MidiTime::ticksPerTact() / ppt );
+	return posStart + static_cast<int>( w * MidiTime::ticksPerTact() / ppt );
 }
 
 
@@ -1549,11 +1548,11 @@ QPixmap * TrackOperationsWidget::s_grip = NULL;     /*!< grip pixmap */
  *
  * The trackOperationsWidget is the grip and the mute button of a track.
  *
- * \param _parent the trackView to contain this widget
+ * \param parent the trackView to contain this widget
  */
-TrackOperationsWidget::TrackOperationsWidget( TrackView * _parent ) :
-	QWidget( _parent ),             /*!< The parent widget */
-	m_trackView( _parent )          /*!< The parent track view */
+TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
+	QWidget( parent ),             /*!< The parent widget */
+	m_trackView( parent )          /*!< The parent track view */
 {
 	if( s_grip == NULL )
 	{
@@ -1564,9 +1563,9 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * _parent ) :
 	ToolTip::add( this, tr( "Press <Ctrl> while clicking on move-grip "
 				"to begin a new drag'n'drop-action." ) );
 
-	QMenu * to_menu = new QMenu( this );
-	to_menu->setFont( pointSize<9>( to_menu->font() ) );
-	connect( to_menu, SIGNAL( aboutToShow() ), this, SLOT( updateMenu() ) );
+	QMenu * toMenu = new QMenu( this );
+	toMenu->setFont( pointSize<9>( toMenu->font() ) );
+	connect( toMenu, SIGNAL( aboutToShow() ), this, SLOT( updateMenu() ) );
 
 
 	setObjectName( "automationEnabled" );
@@ -1575,7 +1574,7 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * _parent ) :
 	m_trackOps = new QPushButton( this );
 	m_trackOps->move( 12, 1 );
 	m_trackOps->setFocusPolicy( Qt::NoFocus );
-	m_trackOps->setMenu( to_menu );
+	m_trackOps->setMenu( toMenu );
 	ToolTip::add( m_trackOps, tr( "Actions for this track" ) );
 
 
@@ -1634,12 +1633,12 @@ TrackOperationsWidget::~TrackOperationsWidget()
  *
  *  Otherwise, ignore all other events.
  *
- *  \param _me The mouse event to respond to.
+ *  \param me The mouse event to respond to.
  */
-void TrackOperationsWidget::mousePressEvent( QMouseEvent * _me )
+void TrackOperationsWidget::mousePressEvent( QMouseEvent * me )
 {
-	if( _me->button() == Qt::LeftButton &&
-		_me->modifiers() & Qt::ControlModifier &&
+	if( me->button() == Qt::LeftButton &&
+		me->modifiers() & Qt::ControlModifier &&
 			m_trackView->getTrack()->type() != Track::BBTrack )
 	{
 		DataFile dataFile( DataFile::DragNDropData );
@@ -1650,13 +1649,12 @@ void TrackOperationsWidget::mousePressEvent( QMouseEvent * _me )
 				m_trackView->getTrackSettingsWidget() ),
 									this );
 	}
-	else if( _me->button() == Qt::LeftButton )
+	else if( me->button() == Qt::LeftButton )
 	{
 		// track-widget (parent-widget) initiates track-move
-		_me->ignore();
+		me->ignore();
 	}
 }
-
 
 
 
@@ -1670,9 +1668,9 @@ void TrackOperationsWidget::mousePressEvent( QMouseEvent * _me )
  *  Otherwise, hide ourselves.
  *
  *  \todo Flesh this out a bit - is it correct?
- *  \param _pe The paint event to respond to
+ *  \param pe The paint event to respond to
  */
-void TrackOperationsWidget::paintEvent( QPaintEvent * _pe )
+void TrackOperationsWidget::paintEvent( QPaintEvent * pe )
 {
 	QPainter p( this );
 	p.fillRect( rect(), palette().brush(QPalette::Background) );
@@ -1735,30 +1733,30 @@ void TrackOperationsWidget::removeTrack()
  */
 void TrackOperationsWidget::updateMenu()
 {
-	QMenu * to_menu = m_trackOps->menu();
-	to_menu->clear();
-	to_menu->addAction( embed::getIconPixmap( "edit_copy", 16, 16 ),
+	QMenu * toMenu = m_trackOps->menu();
+	toMenu->clear();
+	toMenu->addAction( embed::getIconPixmap( "edit_copy", 16, 16 ),
 						tr( "Clone this track" ),
 						this, SLOT( cloneTrack() ) );
-	to_menu->addAction( embed::getIconPixmap( "cancel", 16, 16 ),
+	toMenu->addAction( embed::getIconPixmap( "cancel", 16, 16 ),
 						tr( "Remove this track" ),
 						this, SLOT( removeTrack() ) );
 						
 	if( ! m_trackView->trackContainerView()->fixedTCOs() )
 	{
-		to_menu->addAction( tr( "Clear this track" ), this, SLOT( clearTrack() ) );
+		toMenu->addAction( tr( "Clear this track" ), this, SLOT( clearTrack() ) );
 	}
 
 	if( dynamic_cast<InstrumentTrackView *>( m_trackView ) )
 	{
-		to_menu->addSeparator();
-		to_menu->addMenu( dynamic_cast<InstrumentTrackView *>(
+		toMenu->addSeparator();
+		toMenu->addMenu( dynamic_cast<InstrumentTrackView *>(
 						m_trackView )->midiMenu() );
 	}
 	if( dynamic_cast<AutomationTrackView *>( m_trackView ) )
 	{
-		to_menu->addAction( tr( "Turn all recording on" ), this, SLOT( recordingOn() ) );
-		to_menu->addAction( tr( "Turn all recording off" ), this, SLOT( recordingOff() ) );
+		toMenu->addAction( tr( "Turn all recording on" ), this, SLOT( recordingOn() ) );
+		toMenu->addAction( tr( "Turn all recording off" ), this, SLOT( recordingOff() ) );
 	}
 }
 
@@ -1804,15 +1802,15 @@ void TrackOperationsWidget::recordingOff()
  *  The track object is the whole track, linking its contents, its
  *  automation, name, type, and so forth.
  *
- * \param _type The type of track (Song Editor or Beat+Bassline Editor)
- * \param _tc The track Container object to encapsulate in this track.
+ * \param type The type of track (Song Editor or Beat+Bassline Editor)
+ * \param tc The track Container object to encapsulate in this track.
  *
  * \todo check the definitions of all the properties - are they OK?
  */
-Track::Track( TrackTypes _type, TrackContainer * _tc ) :
-	Model( _tc ),                   /*!< The track Model */
-	m_trackContainer( _tc ),        /*!< The track container object */
-	m_type( _type ),                /*!< The track type */
+Track::Track( TrackTypes type, TrackContainer * tc ) :
+	Model( tc ),                   /*!< The track Model */
+	m_trackContainer( tc ),        /*!< The track container object */
+	m_type( type ),                /*!< The track type */
 	m_name(),                       /*!< The track's name */
 	m_mutedModel( false, this, tr( "Muted" ) ),
 					 /*!< For controlling track muting */
@@ -1857,27 +1855,27 @@ Track::~Track()
 
 /*! \brief Create a track based on the given track type and container.
  *
- *  \param _tt The type of track to create
- *  \param _tc The track container to attach to
+ *  \param tt The type of track to create
+ *  \param tc The track container to attach to
  */
-Track * Track::create( TrackTypes _tt, TrackContainer * _tc )
+Track * Track::create( TrackTypes tt, TrackContainer * tc )
 {
 	Track * t = NULL;
 
-	switch( _tt )
+	switch( tt )
 	{
-		case InstrumentTrack: t = new ::InstrumentTrack( _tc ); break;
-		case BBTrack: t = new ::BBTrack( _tc ); break;
-		case SampleTrack: t = new ::SampleTrack( _tc ); break;
+		case InstrumentTrack: t = new ::InstrumentTrack( tc ); break;
+		case BBTrack: t = new ::BBTrack( tc ); break;
+		case SampleTrack: t = new ::SampleTrack( tc ); break;
 //		case EVENT_TRACK:
 //		case VIDEO_TRACK:
-		case AutomationTrack: t = new ::AutomationTrack( _tc ); break;
+		case AutomationTrack: t = new ::AutomationTrack( tc ); break;
 		case HiddenAutomationTrack:
-						t = new ::AutomationTrack( _tc, true ); break;
+						t = new ::AutomationTrack( tc, true ); break;
 		default: break;
 	}
 
-	_tc->updateAfterTrackAdd();
+	tc->updateAfterTrackAdd();
 
 	return t;
 }
@@ -1887,17 +1885,17 @@ Track * Track::create( TrackTypes _tt, TrackContainer * _tc )
 
 /*! \brief Create a track inside TrackContainer from track type in a QDomElement and restore state from XML
  *
- *  \param _this The QDomElement containing the type of track to create
- *  \param _tc The track container to attach to
+ *  \param element The QDomElement containing the type of track to create
+ *  \param tc The track container to attach to
  */
-Track * Track::create( const QDomElement & _this, TrackContainer * _tc )
+Track * Track::create( const QDomElement & element, TrackContainer * tc )
 {
 	Track * t = create(
-		static_cast<TrackTypes>( _this.attribute( "type" ).toInt() ),
-									_tc );
+		static_cast<TrackTypes>( element.attribute( "type" ).toInt() ),
+									tc );
 	if( t != NULL )
 	{
-		t->restoreState( _this );
+		t->restoreState( element );
 	}
 	return t;
 }
@@ -1927,31 +1925,31 @@ void Track::clone()
  *  specific settings.  Then we iterate through the trackContentObjects
  *  and save all their states in turn.
  *
- *  \param _doc The QDomDocument to use to save
- *  \param _this The The QDomElement to save into
+ *  \param doc The QDomDocument to use to save
+ *  \param element The The QDomElement to save into
  *  \todo Does this accurately describe the parameters?  I think not!?
  *  \todo Save the track height
  */
-void Track::saveSettings( QDomDocument & _doc, QDomElement & _this )
+void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 {
 	if( !m_simpleSerializingMode )
 	{
-		_this.setTagName( "track" );
+		element.setTagName( "track" );
 	}
-	_this.setAttribute( "type", type() );
-	_this.setAttribute( "name", name() );
-	_this.setAttribute( "muted", isMuted() );
-	_this.setAttribute( "solo", isSolo() );
+	element.setAttribute( "type", type() );
+	element.setAttribute( "name", name() );
+	element.setAttribute( "muted", isMuted() );
+	element.setAttribute( "solo", isSolo() );
 	if( m_height >= MINIMAL_TRACK_HEIGHT )
 	{
-		_this.setAttribute( "height", m_height );
+		element.setAttribute( "height", m_height );
 	}
 
-	QDomElement ts_de = _doc.createElement( nodeName() );
+	QDomElement tsDe = doc.createElement( nodeName() );
 	// let actual track (InstrumentTrack, bbTrack, sampleTrack etc.) save
 	// its settings
-	_this.appendChild( ts_de );
-	saveTrackSpecificSettings( _doc, ts_de );
+	element.appendChild( tsDe );
+	saveTrackSpecificSettings( doc, tsDe );
 
 	if( m_simpleSerializingMode )
 	{
@@ -1963,7 +1961,7 @@ void Track::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	for( tcoVector::const_iterator it = m_trackContentObjects.begin();
 				it != m_trackContentObjects.end(); ++it )
 	{
-		( *it )->saveState( _doc, _this );
+		( *it )->saveState( doc, element );
 	}
 }
 
@@ -1979,26 +1977,26 @@ void Track::saveSettings( QDomDocument & _doc, QDomElement & _this )
  *  track-specific settings and trackContentObjects states from it
  *  one at a time.
  *
- *  \param _this the QDomElement to load track settings from
+ *  \param element the QDomElement to load track settings from
  *  \todo Load the track height.
  */
-void Track::loadSettings( const QDomElement & _this )
+void Track::loadSettings( const QDomElement & element )
 {
-	if( _this.attribute( "type" ).toInt() != type() )
+	if( element.attribute( "type" ).toInt() != type() )
 	{
 		qWarning( "Current track-type does not match track-type of "
 							"settings-node!\n" );
 	}
 
-	setName( _this.hasAttribute( "name" ) ? _this.attribute( "name" ) :
-			_this.firstChild().toElement().attribute( "name" ) );
+	setName( element.hasAttribute( "name" ) ? element.attribute( "name" ) :
+			element.firstChild().toElement().attribute( "name" ) );
 
-	setMuted( _this.attribute( "muted" ).toInt() );
-	setSolo( _this.attribute( "solo" ).toInt() );
+	setMuted( element.attribute( "muted" ).toInt() );
+	setSolo( element.attribute( "solo" ).toInt() );
 
 	if( m_simpleSerializingMode )
 	{
-		QDomNode node = _this.firstChild();
+		QDomNode node = element.firstChild();
 		while( !node.isNull() )
 		{
 			if( node.isElement() && node.nodeName() == nodeName() )
@@ -2018,7 +2016,7 @@ void Track::loadSettings( const QDomElement & _this )
 //		m_trackContentObjects.erase( m_trackContentObjects.begin() );
 	}
 
-	QDomNode node = _this.firstChild();
+	QDomNode node = element.firstChild();
 	while( !node.isNull() )
 	{
 		if( node.isElement() )
@@ -2040,10 +2038,10 @@ void Track::loadSettings( const QDomElement & _this )
 		node = node.nextSibling();
 	}
 
-	if( _this.attribute( "height" ).toInt() >= MINIMAL_TRACK_HEIGHT &&
-		_this.attribute( "height" ).toInt() <= DEFAULT_TRACK_HEIGHT )	// workaround for #3585927, tobydox/2012-11-11
+	if( element.attribute( "height" ).toInt() >= MINIMAL_TRACK_HEIGHT &&
+		element.attribute( "height" ).toInt() <= DEFAULT_TRACK_HEIGHT )	// workaround for #3585927, tobydox/2012-11-11
 	{
-		m_height = _this.attribute( "height" ).toInt();
+		m_height = element.attribute( "height" ).toInt();
 	}
 }
 
@@ -2052,15 +2050,15 @@ void Track::loadSettings( const QDomElement & _this )
 
 /*! \brief Add another TrackContentObject into this track
  *
- *  \param _tco The TrackContentObject to attach to this track.
+ *  \param tco The TrackContentObject to attach to this track.
  */
-TrackContentObject * Track::addTCO( TrackContentObject * _tco )
+TrackContentObject * Track::addTCO( TrackContentObject * tco )
 {
-	m_trackContentObjects.push_back( _tco );
+	m_trackContentObjects.push_back( tco );
 
-	emit trackContentObjectAdded( _tco );
+	emit trackContentObjectAdded( tco );
 
-	return _tco;		// just for convenience
+	return tco;		// just for convenience
 }
 
 
@@ -2068,13 +2066,13 @@ TrackContentObject * Track::addTCO( TrackContentObject * _tco )
 
 /*! \brief Remove a given TrackContentObject from this track
  *
- *  \param _tco The TrackContentObject to remove from this track.
+ *  \param tco The TrackContentObject to remove from this track.
  */
-void Track::removeTCO( TrackContentObject * _tco )
+void Track::removeTCO( TrackContentObject * tco )
 {
 	tcoVector::iterator it = qFind( m_trackContentObjects.begin(),
 					m_trackContentObjects.end(),
-					_tco );
+					tco );
 	if( it != m_trackContentObjects.end() )
 	{
 		m_trackContentObjects.erase( it );
@@ -2115,21 +2113,21 @@ int Track::numOfTCOs()
  *  numbered object from the array.  Otherwise we warn the user that
  *  we've somehow requested a TCO that is too large, and create a new
  *  TCO for them.
- *  \param _tco_number The number of the TrackContentObject to fetch.
+ *  \param tcoNum The number of the TrackContentObject to fetch.
  *  \return the given TrackContentObject or a new one if out of range.
  *  \todo reject TCO numbers less than zero.
  *  \todo if we create a TCO here, should we somehow attach it to the
  *     track?
  */
-TrackContentObject * Track::getTCO( int _tco_num )
+TrackContentObject * Track::getTCO( int tcoNum )
 {
-	if( _tco_num < m_trackContentObjects.size() )
+	if( tcoNum < m_trackContentObjects.size() )
 	{
-		return m_trackContentObjects[_tco_num];
+		return m_trackContentObjects[tcoNum];
 	}
 	printf( "called Track::getTCO( %d ), "
-			"but TCO %d doesn't exist\n", _tco_num, _tco_num );
-	return createTCO( _tco_num * MidiTime::ticksPerTact() );
+			"but TCO %d doesn't exist\n", tcoNum, tcoNum );
+	return createTCO( tcoNum * MidiTime::ticksPerTact() );
 
 }
 
@@ -2138,15 +2136,15 @@ TrackContentObject * Track::getTCO( int _tco_num )
 
 /*! \brief Determine the given TrackContentObject's number in our array.
  *
- *  \param _tco The TrackContentObject to search for.
+ *  \param tco The TrackContentObject to search for.
  *  \return its number in our array.
  */
-int Track::getTCONum( const TrackContentObject * _tco )
+int Track::getTCONum( const TrackContentObject * tco )
 {
 //	for( int i = 0; i < getTrackContentWidget()->numOfTCOs(); ++i )
 	tcoVector::iterator it = qFind( m_trackContentObjects.begin(),
 					m_trackContentObjects.end(),
-					_tco );
+					tco );
 	if( it != m_trackContentObjects.end() )
 	{
 /*		if( getTCO( i ) == _tco )
@@ -2171,31 +2169,31 @@ int Track::getTCONum( const TrackContentObject * _tco )
  *
  *  We return the TCOs we find in order by time, earliest TCOs first.
  *
- *  \param _tco_c The list to contain the found trackContentObjects.
- *  \param _start The MIDI start time of the range.
- *  \param _end   The MIDI endi time of the range.
+ *  \param tcoV The list to contain the found trackContentObjects.
+ *  \param start The MIDI start time of the range.
+ *  \param end   The MIDI endi time of the range.
  */
-void Track::getTCOsInRange( tcoVector & _tco_v, const MidiTime & _start,
-							const MidiTime & _end )
+void Track::getTCOsInRange( tcoVector & tcoV, const MidiTime & start,
+							const MidiTime & end )
 {
-	for( tcoVector::iterator it_o = m_trackContentObjects.begin();
-				it_o != m_trackContentObjects.end(); ++it_o )
+	for( tcoVector::iterator itO = m_trackContentObjects.begin();
+				itO != m_trackContentObjects.end(); ++itO )
 	{
-		TrackContentObject * tco = ( *it_o );
+		TrackContentObject * tco = ( *itO );
 		int s = tco->startPosition();
 		int e = tco->endPosition();
-		if( ( s <= _end ) && ( e >= _start ) )
+		if( ( s <= end ) && ( e >= start ) )
 		{
 			// ok, TCO is posated within given range
 			// now let's search according position for TCO in list
 			// 	-> list is ordered by TCO's position afterwards
 			bool inserted = false;
-			for( tcoVector::iterator it = _tco_v.begin();
-						it != _tco_v.end(); ++it )
+			for( tcoVector::iterator it = tcoV.begin();
+						it != tcoV.end(); ++it )
 			{
 				if( ( *it )->startPosition() >= s )
 				{
-					_tco_v.insert( it, tco );
+					tcoV.insert( it, tco );
 					inserted = true;
 					break;
 				}
@@ -2203,7 +2201,7 @@ void Track::getTCOsInRange( tcoVector & _tco_v, const MidiTime & _start,
 			if( inserted == false )
 			{
 				// no TCOs found posated behind current TCO...
-				_tco_v.push_back( tco );
+				tcoV.push_back( tco );
 			}
 		}
 	}
@@ -2217,19 +2215,19 @@ void Track::getTCOsInRange( tcoVector & _tco_v, const MidiTime & _start,
  *  First, we arrange to swap the positions of the two TCOs in the
  *  trackContentObjects list.  Then we swap their start times as well.
  *
- *  \param _tco_num1 The first TrackContentObject to swap.
- *  \param _tco_num2 The second TrackContentObject to swap.
+ *  \param tcoNum1 The first TrackContentObject to swap.
+ *  \param tcoNum2 The second TrackContentObject to swap.
  */
-void Track::swapPositionOfTCOs( int _tco_num1, int _tco_num2 )
+void Track::swapPositionOfTCOs( int tcoNum1, int tcoNum2 )
 {
-	qSwap( m_trackContentObjects[_tco_num1],
-					m_trackContentObjects[_tco_num2] );
+	qSwap( m_trackContentObjects[tcoNum1],
+					m_trackContentObjects[tcoNum2] );
 
-	const MidiTime pos = m_trackContentObjects[_tco_num1]->startPosition();
+	const MidiTime pos = m_trackContentObjects[tcoNum1]->startPosition();
 
-	m_trackContentObjects[_tco_num1]->movePosition(
-			m_trackContentObjects[_tco_num2]->startPosition() );
-	m_trackContentObjects[_tco_num2]->movePosition( pos );
+	m_trackContentObjects[tcoNum1]->movePosition(
+			m_trackContentObjects[tcoNum2]->startPosition() );
+	m_trackContentObjects[tcoNum2]->movePosition( pos );
 }
 
 
@@ -2237,19 +2235,19 @@ void Track::swapPositionOfTCOs( int _tco_num1, int _tco_num2 )
 
 /*! \brief Move all the trackContentObjects after a certain time later by one bar.
  *
- *  \param _pos The time at which we want to insert the bar.
+ *  \param pos The time at which we want to insert the bar.
  *  \todo if we stepped through this list last to first, and the list was
  *    in ascending order by TCO time, once we hit a TCO that was earlier
  *    than the insert time, we could fall out of the loop early.
  */
-void Track::insertTact( const MidiTime & _pos )
+void Track::insertTact( const MidiTime & pos )
 {
-	// we'll increase the position of every TCO, positioned behind _pos, by
+	// we'll increase the position of every TCO, positioned behind pos, by
 	// one tact
 	for( tcoVector::iterator it = m_trackContentObjects.begin();
 				it != m_trackContentObjects.end(); ++it )
 	{
-		if( ( *it )->startPosition() >= _pos )
+		if( ( *it )->startPosition() >= pos )
 		{
 			( *it )->movePosition( (*it)->startPosition() +
 						MidiTime::ticksPerTact() );
@@ -2262,16 +2260,16 @@ void Track::insertTact( const MidiTime & _pos )
 
 /*! \brief Move all the trackContentObjects after a certain time earlier by one bar.
  *
- *  \param _pos The time at which we want to remove the bar.
+ *  \param pos The time at which we want to remove the bar.
  */
-void Track::removeTact( const MidiTime & _pos )
+void Track::removeTact( const MidiTime & pos )
 {
-	// we'll decrease the position of every TCO, positioned behind _pos, by
+	// we'll decrease the position of every TCO, positioned behind pos, by
 	// one tact
 	for( tcoVector::iterator it = m_trackContentObjects.begin();
 				it != m_trackContentObjects.end(); ++it )
 	{
-		if( ( *it )->startPosition() >= _pos )
+		if( ( *it )->startPosition() >= pos )
 		{
 			( *it )->movePosition( qMax( ( *it )->startPosition() -
 						MidiTime::ticksPerTact(), 0 ) );
@@ -2317,7 +2315,7 @@ void Track::toggleSolo()
 {
 	const TrackContainer::TrackList & tl = m_trackContainer->tracks();
 
-	bool solo_before = false;
+	bool soloBefore = false;
 	for( TrackContainer::TrackList::const_iterator it = tl.begin();
 							it != tl.end(); ++it )
 	{
@@ -2325,7 +2323,7 @@ void Track::toggleSolo()
 		{
 			if( ( *it )->m_soloModel.value() )
 			{
-				solo_before = true;
+				soloBefore = true;
 				break;
 			}
 		}
@@ -2338,7 +2336,7 @@ void Track::toggleSolo()
 		if( solo )
 		{
 			// save mute-state in case no track was solo before
-			if( !solo_before )
+			if( !soloBefore )
 			{
 				( *it )->m_mutedBeforeSolo = ( *it )->isMuted();
 			}
@@ -2348,7 +2346,7 @@ void Track::toggleSolo()
 				( *it )->m_soloModel.setValue( false );
 			}
 		}
-		else if( !solo_before )
+		else if( !soloBefore )
 		{
 			( *it )->setMuted( ( *it )->m_mutedBeforeSolo );
 		}
@@ -2369,15 +2367,15 @@ void Track::toggleSolo()
  *  The track View is handles the actual display of the track, including
  *  displaying its various widgets and the track segments.
  *
- *  \param _track The track to display.
- *  \param _tcv The track Container View for us to be displayed in.
+ *  \param track The track to display.
+ *  \param tcv The track Container View for us to be displayed in.
  *  \todo Is my description of these properties correct?
  */
-TrackView::TrackView( Track * _track, TrackContainerView * _tcv ) :
-	QWidget( _tcv->contentWidget() ),   /*!< The Track Container View's content widget. */
+TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
+	QWidget( tcv->contentWidget() ),   /*!< The Track Container View's content widget. */
 	ModelView( NULL, this ),            /*!< The model view of this track */
-	m_track( _track ),                  /*!< The track we're displaying */
-	m_trackContainerView( _tcv ),       /*!< The track Container View we're displayed in */
+	m_track( track ),                  /*!< The track we're displaying */
+	m_trackContainerView( tcv ),       /*!< The track Container View we're displayed in */
 	m_trackOperationsWidget( this ),    /*!< Our trackOperationsWidget */
 	m_trackSettingsWidget( this ),      /*!< Our trackSettingsWidget */
 	m_trackContentWidget( this ),       /*!< Our trackContentWidget */
@@ -2441,9 +2439,9 @@ TrackView::~TrackView()
 
 /*! \brief Resize this track View.
  *
- *  \param _re the Resize Event to handle.
+ *  \param re the Resize Event to handle.
  */
-void TrackView::resizeEvent( QResizeEvent * _re )
+void TrackView::resizeEvent( QResizeEvent * re )
 {
 	if( ConfigManager::inst()->value( "ui",
 					  "compacttrackbuttons" ).toInt() )
@@ -2509,11 +2507,11 @@ void TrackView::modelChanged()
 
 /*! \brief Start a drag event on this track View.
  *
- *  \param _dee the DragEnterEvent to start.
+ *  \param dee the DragEnterEvent to start.
  */
-void TrackView::dragEnterEvent( QDragEnterEvent * _dee )
+void TrackView::dragEnterEvent( QDragEnterEvent * dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee, "track_" +
+	StringPairDrag::processDragEnterEvent( dee, "track_" +
 					QString::number( m_track->type() ) );
 }
 
@@ -2526,12 +2524,12 @@ void TrackView::dragEnterEvent( QDragEnterEvent * _dee )
  *  If so, we decode the data from the drop event by just feeding it
  *  back into the engine as a state.
  *
- *  \param _de the DropEvent to handle.
+ *  \param de the DropEvent to handle.
  */
-void TrackView::dropEvent( QDropEvent * _de )
+void TrackView::dropEvent( QDropEvent * de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
+	QString type = StringPairDrag::decodeKey( de );
+	QString value = StringPairDrag::decodeValue( de );
 	if( type == ( "track_" + QString::number( m_track->type() ) ) )
 	{
 		// value contains our XML-data so simply create a
@@ -2540,7 +2538,7 @@ void TrackView::dropEvent( QDropEvent * _de )
 		m_track->lock();
 		m_track->restoreState( dataFile.content().firstChild().toElement() );
 		m_track->unlock();
-		_de->accept();
+		de->accept();
 	}
 }
 
@@ -2558,14 +2556,14 @@ void TrackView::dropEvent( QDropEvent * _de )
  *
  *  Otherwise we let the widget handle the mouse event as normal.
  *
- *  \param _me the MouseEvent to handle.
+ *  \param me the MouseEvent to handle.
  */
-void TrackView::mousePressEvent( QMouseEvent * _me )
+void TrackView::mousePressEvent( QMouseEvent * me )
 {
 	// If previously dragged too small, restore on shift-leftclick
 	if( height() < DEFAULT_TRACK_HEIGHT &&
-		_me->modifiers() & Qt::ShiftModifier &&
-		_me->button() == Qt::LeftButton )
+		me->modifiers() & Qt::ShiftModifier &&
+		me->button() == Qt::LeftButton )
 	{
 		setFixedHeight( DEFAULT_TRACK_HEIGHT );
 		m_track->setHeight( DEFAULT_TRACK_HEIGHT );
@@ -2574,14 +2572,14 @@ void TrackView::mousePressEvent( QMouseEvent * _me )
 
 	if( m_trackContainerView->allowRubberband() == true )
 	{
-		QWidget::mousePressEvent( _me );
+		QWidget::mousePressEvent( me );
 	}
-	else if( _me->button() == Qt::LeftButton )
+	else if( me->button() == Qt::LeftButton )
 	{
-		if( _me->modifiers() & Qt::ShiftModifier )
+		if( me->modifiers() & Qt::ShiftModifier )
 		{
 			m_action = ResizeTrack;
-			QCursor::setPos( mapToGlobal( QPoint( _me->x(),
+			QCursor::setPos( mapToGlobal( QPoint( me->x(),
 								height() ) ) );
 			QCursor c( Qt::SizeVerCursor);
 			QApplication::setOverrideCursor( c );
@@ -2597,11 +2595,11 @@ void TrackView::mousePressEvent( QMouseEvent * _me )
 			m_trackOperationsWidget.update();
 		}
 
-		_me->accept();
+		me->accept();
 	}
 	else
 	{
-		QWidget::mousePressEvent( _me );
+		QWidget::mousePressEvent( me );
 	}
 }
 
@@ -2622,29 +2620,30 @@ void TrackView::mousePressEvent( QMouseEvent * _me )
  *  Likewise if we've started a resize process, handle this too, making
  *  sure that we never go below the minimum track height.
  *
- *  \param _me the MouseEvent to handle.
+ *  \param me the MouseEvent to handle.
  */
-void TrackView::mouseMoveEvent( QMouseEvent * _me )
+void TrackView::mouseMoveEvent( QMouseEvent * me )
 {
 
 	if( m_trackContainerView->allowRubberband() == true )
 	{
-		QWidget::mouseMoveEvent( _me );
+		QWidget::mouseMoveEvent( me );
 	}
 	else if( m_action == MoveTrack )
 	{
 		// look which track-widget the mouse-cursor is over
-		const int y_pos = m_trackContainerView->contentWidget()->mapFromGlobal( _me->globalPos() ).y();
-		const TrackView * track_at_y =	m_trackContainerView->trackViewAt( y_pos );
+		const int yPos = 
+			m_trackContainerView->contentWidget()->mapFromGlobal( me->globalPos() ).y();
+		const TrackView * trackAtY = m_trackContainerView->trackViewAt( yPos );
 
 // debug code
-//			qDebug( "y position %d", y_pos );
+//			qDebug( "y position %d", yPos );
 
 		// a track-widget not equal to ourself?
-		if( track_at_y != NULL && track_at_y != this )
+		if( trackAtY != NULL && trackAtY != this )
 		{
 			// then move us up/down there!
-			if( _me->y() < 0 )
+			if( me->y() < 0 )
 			{
 				m_trackContainerView->moveTrackViewUp( this );
 			}
@@ -2656,7 +2655,7 @@ void TrackView::mouseMoveEvent( QMouseEvent * _me )
 	}
 	else if( m_action == ResizeTrack )
 	{
-		setFixedHeight( qMax<int>( _me->y(), MINIMAL_TRACK_HEIGHT ) );
+		setFixedHeight( qMax<int>( me->y(), MINIMAL_TRACK_HEIGHT ) );
 		m_trackContainerView->realignTracks();
 		m_track->setHeight( height() );
 	}
@@ -2671,9 +2670,9 @@ void TrackView::mouseMoveEvent( QMouseEvent * _me )
 
 /*! \brief Handle a mouse release event on this track View.
  *
- *  \param _me the MouseEvent to handle.
+ *  \param me the MouseEvent to handle.
  */
-void TrackView::mouseReleaseEvent( QMouseEvent * _me )
+void TrackView::mouseReleaseEvent( QMouseEvent * me )
 {
 	m_action = NoAction;
 	while( QApplication::overrideCursor() != NULL )
@@ -2682,7 +2681,7 @@ void TrackView::mouseReleaseEvent( QMouseEvent * _me )
 	}
 	m_trackOperationsWidget.update();
 
-	QWidget::mouseReleaseEvent( _me );
+	QWidget::mouseReleaseEvent( me );
 }
 
 
@@ -2690,9 +2689,9 @@ void TrackView::mouseReleaseEvent( QMouseEvent * _me )
 
 /*! \brief Repaint this track View.
  *
- *  \param _pe the PaintEvent to start.
+ *  \param pe the PaintEvent to start.
  */
-void TrackView::paintEvent( QPaintEvent * _pe )
+void TrackView::paintEvent( QPaintEvent * pe )
 {
 	QStyleOption opt;
 	opt.initFrom( this );
@@ -2705,22 +2704,18 @@ void TrackView::paintEvent( QPaintEvent * _pe )
 
 /*! \brief Create a TrackContentObject View in this track View.
  *
- *  \param _tco the TrackContentObject to create the view for.
+ *  \param tco the TrackContentObject to create the view for.
  *  \todo is this a good description for what this method does?
  */
-void TrackView::createTCOView( TrackContentObject * _tco )
+void TrackView::createTCOView( TrackContentObject * tco )
 {
-	TrackContentObjectView * tv = _tco->createView( this );
-	if( _tco->getSelectViewOnCreate() == true )
+	TrackContentObjectView * tv = tco->createView( this );
+	if( tco->getSelectViewOnCreate() == true )
 	{
 		tv->setSelected( true );
 	}
-	_tco->selectViewOnCreate( false );
+	tco->selectViewOnCreate( false );
 }
-
-
-
-
 
 
 


### PR DESCRIPTION
The method saveSettings() had its second parameter named "_parent" in the header but "_this" in the CPP. Both have been renamed to "parent".

The method loadSetting() has a parameter named _this. Perhaps we should rename it to "parent", as done in saveSettings(). As all of you probably know, it cannot be called "this".