### PR TITLE
Fix muted track not highlighted on selection

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -259,11 +259,16 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	QLinearGradient lingrad( 0, 0, 0, height() );
 	QColor c;
+
 	if( !( m_pat->getTrack()->isMuted() || m_pat->isMuted() ) )
-		c = isSelected() ? QColor( 0, 0, 224 )
-						 : styleColor;
+		c = styleColor;
 	else
-		c = QColor( 80,80,80 );
+		c = QColor( 80, 80, 80 );
+
+	if( isSelected() == true )
+	{
+		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+	}
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -215,7 +215,7 @@ void BBTCOView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	QColor col = m_bbTCO->m_useStyleColor 
+	QColor col = m_bbTCO->m_useStyleColor
 		? p.pen().brush().color()
 		: m_bbTCO->colorObj();
 
@@ -223,10 +223,10 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	{
 		col = QColor( 160, 160, 160 );
 	}
+
 	if( isSelected() == true )
 	{
-		col = QColor( qMax( col.red() - 128, 0 ),
-					qMax( col.green() - 128, 0 ), 255 );
+		col = QColor( qMax( col.red() - 128, 0 ), qMax( col.green() - 128, 0 ), 255 );
 	}
 
 	QLinearGradient lingrad( 0, 0, 0, height() );

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -907,10 +907,14 @@ void PatternView::paintEvent( QPaintEvent * )
 
 	if(( m_pat->m_patternType != Pattern::BeatPattern ) &&
 				!( m_pat->getTrack()->isMuted() || m_pat->isMuted() ))
-		c = isSelected() ? QColor( 0, 0, 224 )
-	  				   : styleColor;
+		c = styleColor;
 	else
 		c = QColor( 80, 80, 80 );
+
+	if( isSelected() == true )
+	{
+		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+	}
 
 	if( m_pat->m_patternType != Pattern::BeatPattern )
 	{

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -340,9 +340,14 @@ void SampleTCOView::paintEvent( QPaintEvent * _pe )
 
 	QColor c;
 	if( !( m_tco->getTrack()->isMuted() || m_tco->isMuted() ) )
-		c = isSelected() ? QColor( 0, 0, 224 )
-						 : styleColor;
-	else c = QColor( 80, 80, 80 );
+		c = styleColor;
+	else
+		c = QColor( 80, 80, 80 );
+
+	if( isSelected() == true )
+	{
+		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+	}
 
 	QLinearGradient grad( 0, 0, 0, height() );
 


### PR DESCRIPTION
Only the BB tracks were being highlighted on selection when muted. I ported the idea to the other track types.

I'd like to not repeat code as I am doing here, if anyone can help me with this that would be great.

Fix #1239 

## The bug

![The bug](https://cloud.githubusercontent.com/assets/347552/5648346/f85c7bc0-9674-11e4-85cb-dee37c19edb1.png)

## Changes

### Unmuted

![2015-01-07-155049_146x138_scrot](https://cloud.githubusercontent.com/assets/347552/5650555/a7e0f772-9686-11e4-901f-cd344125b9ac.png)

### Muted

![2015-01-07-155135_153x146_scrot](https://cloud.githubusercontent.com/assets/347552/5650562/b160b080-9686-11e4-88f7-ef906cc49425.png)
