### PR TITLE
Proposed fix 888 Bar, Beat and Tick should follow dragged timeline

### DIFF
--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -106,12 +106,13 @@ void TimeDisplayWidget::updateTime()
 			break;
 
 		case BarsTicks:
-			m_majorLCD.setValue( s->getTacts() + 1 );
-			m_minorLCD.setValue( ( s->getTicks() % s->ticksPerTact() ) / 
-					     ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) +1 );
-;
-			m_milliSecondsLCD.setValue( ( s->getTicks() % s->ticksPerTact() ) %
-						    ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) );
+			int tick;
+			tick = ( s->getMilliseconds() * s->getTempo() * 48 ) / 60000 ;
+			m_majorLCD.setValue( (int)(tick / s->ticksPerTact() ) + 1);
+			m_minorLCD.setValue( ( tick % s->ticksPerTact() ) /
+						 ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) +1 );
+			m_milliSecondsLCD.setValue( ( tick % s->ticksPerTact() ) %
+							( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) );
 			break;
 
 		default: break;

--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -107,7 +107,7 @@ void TimeDisplayWidget::updateTime()
 
 		case BarsTicks:
 			int tick;
-			tick = ( s->getMilliseconds() * s->getTempo() * 48 ) / 60000 ;
+			tick = ( s->getMilliseconds() * s->getTempo() * (DefaultTicksPerTact / 4 ) ) / 60000 ;
 			m_majorLCD.setValue( (int)(tick / s->ticksPerTact() ) + 1);
 			m_minorLCD.setValue( ( tick % s->ticksPerTact() ) /
 						 ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) +1 );


### PR DESCRIPTION
Proposed fix #888 Bar, Beat and Tick should follow dragged timeline.

The widget was using 2 different sources of data, this fix uses just one, and converts. making the behaviour consistent.