### PR TITLE
Add "Assign to FX Channel" context button to track

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -7931,6 +7931,14 @@ Latència: %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -7933,6 +7933,14 @@ Zpoždění %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -8177,6 +8177,14 @@ Latenz: %2 ms</translation>
         <source>Clear this track</source>
         <translation>Diese Spur leeren</translation>
     </message>
+    <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>vestigeInstrument</name>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -7970,6 +7970,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -7913,6 +7913,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -7912,6 +7912,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -7947,6 +7947,14 @@ Latence : %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -7946,6 +7946,14 @@ Latencia: %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -7971,6 +7971,14 @@ Latenza: %2 ms</translation>
         <translation>Pulisci questa traccia</translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation>Accendi tutti i processi di registrazione</translation>
     </message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -7948,6 +7948,14 @@ Latency: %2 ms</source>
         <translation type="unfinished">このトラックをクリア</translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -7917,6 +7917,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -7916,6 +7916,14 @@ Vertraging: %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -7952,6 +7952,14 @@ Latencja: %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -7950,6 +7950,14 @@ Latência: %2 ms</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation>Associar a um novo Mixer de Efeitos</translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -7985,6 +7985,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -7915,6 +7915,14 @@ Latency: %2 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -7925,6 +7925,14 @@ Latency: %2 ms</source>
         <translation>清除此轨道</translation>
     </message>
     <message>
+        <source>Assign to new FX Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX %1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Turn all recording on</source>
         <translation>打开所有录制</translation>
     </message>

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -194,6 +194,11 @@ public:
 		return m_fxChannels.size();
 	}
 
+	inline QVector<FxChannel *> fxChannels() const
+	{
+		return m_fxChannels;
+	}
+
 	FxRouteVector m_fxRoutes;
 
 private:

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -103,12 +103,14 @@ public:
 	// useful for loading projects
 	void refreshDisplay();
 
+public slots:
+	int addNewChannel();
+
 protected:
 	virtual void closeEvent( QCloseEvent * _ce );
 	
 private slots:
 	void updateFaders();
-	void addNewChannel();
 	void toggledSolo();
 
 private:

--- a/include/Track.h
+++ b/include/Track.h
@@ -29,6 +29,7 @@
 #include <QtCore/QVector>
 #include <QtCore/QList>
 #include <QWidget>
+#include <QSignalMapper>
 #include <QColor>
 #include <QMimeData>
 
@@ -390,6 +391,8 @@ private slots:
 	void recordingOn();
 	void recordingOff();
 	void clearTrack();
+	void assignFxLine( int channelIndex );
+	void createFxLine();
 
 private:
 	static QPixmap * s_grip;

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -172,7 +172,7 @@ FxMixerView::~FxMixerView()
 
 
 
-void FxMixerView::addNewChannel()
+int FxMixerView::addNewChannel()
 {
 	// add new fx mixer channel and redraw the form.
 	FxMixer * mix = Engine::fxMixer();
@@ -186,6 +186,8 @@ void FxMixerView::addNewChannel()
 	updateFxLine(newChannelIndex);
 
 	updateMaxChannelSelector();
+
+	return newChannelIndex;
 }
 
 


### PR DESCRIPTION
Add a new submenu to assign quickly a new or existing FX Channel for a track. This should help a lot when creating songs as it's so cumbersome to assign them manually today.

The name of the channel is set as the name of the instrument when it's created.

This relates to #48 and maybe to #1215 

![2015-01-09-144059_1920x1080_scrot](https://cloud.githubusercontent.com/assets/347552/5683372/764dd502-980e-11e4-9af4-43244a65ba07.png)

