### PR TITLE
Proposed fix 1388 Remove auto-naming of copied blocks

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1402,6 +1402,11 @@ bool TrackContentWidget::pasteSelection( MidiTime tcoPos, QDropEvent * _de )
 		{
 			tco->selectViewOnCreate( true );
 		}
+		//check tco name, if the same as source track name dont copy
+		if( tco->name() == tracks[trackIndex]->name() )
+		{
+			tco->setName( "" );
+		}
 	}
 
 	AutomationPattern::resolveAllIDs();


### PR DESCRIPTION
Proposed fix #1388 Remove auto-naming of copied blocks

simple check to see if the tco name and the source track are equal, if so setting ""