### PR TITLE
Refactor redundant pattern color assignment

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -267,7 +267,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	if( isSelected() == true )
 	{
-		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+		c.setRgb( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
 	}
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -215,18 +215,23 @@ void BBTCOView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	QColor col = m_bbTCO->m_useStyleColor
-		? p.pen().brush().color()
-		: m_bbTCO->colorObj();
-
+	QColor col;
 	if( m_bbTCO->getTrack()->isMuted() || m_bbTCO->isMuted() )
 	{
 		col = QColor( 160, 160, 160 );
 	}
+	else if ( m_bbTCO->m_useStyleColor )
+	{
+		col =  p.pen().brush().color();
+	}
+	else
+	{
+		col = m_bbTCO->colorObj();
+	}
 
 	if( isSelected() == true )
 	{
-		col = QColor( qMax( col.red() - 128, 0 ), qMax( col.green() - 128, 0 ), 255 );
+		col.setRgb( qMax( col.red() - 128, 0 ), qMax( col.green() - 128, 0 ), 255 );
 	}
 
 	QLinearGradient lingrad( 0, 0, 0, height() );

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -904,16 +904,19 @@ void PatternView::paintEvent( QPaintEvent * )
 	QLinearGradient lingrad( 0, 0, 0, height() );
 
 	QColor c;
-
 	if(( m_pat->m_patternType != Pattern::BeatPattern ) &&
-				!( m_pat->getTrack()->isMuted() || m_pat->isMuted() ))
+		!( m_pat->getTrack()->isMuted() || m_pat->isMuted() ))
+	{
 		c = styleColor;
+	}
 	else
+	{
 		c = QColor( 80, 80, 80 );
+	}
 
 	if( isSelected() == true )
 	{
-		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+		c.setRgb( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
 	}
 
 	if( m_pat->m_patternType != Pattern::BeatPattern )

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -340,13 +340,17 @@ void SampleTCOView::paintEvent( QPaintEvent * _pe )
 
 	QColor c;
 	if( !( m_tco->getTrack()->isMuted() || m_tco->isMuted() ) )
+	{
 		c = styleColor;
+	}
 	else
+	{
 		c = QColor( 80, 80, 80 );
+	}
 
 	if( isSelected() == true )
 	{
-		c = QColor( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
+		c.setRgb( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
 	}
 
 	QLinearGradient grad( 0, 0, 0, height() );


### PR DESCRIPTION
Instead of creating a new QColor for each condition just use the
`setRgb` method or fix the conditions order.