### PR TITLE
Collect error for non existing samples

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -203,6 +203,10 @@ Wenn Sie daran interessiert sind LMMS in eine andere Sprache zu übersetzen oder
         <source>With this knob you can set the point where the loop starts. </source>
         <translation>Mit diesem Regler können Sie festlegen, wo die Wiederholung beginnt.</translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -195,6 +195,10 @@ Se lle interesa traducir o LMMS a outro idioma ou desexa mellorar as traducións
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -196,6 +196,10 @@ Se sei interessato a tradurre LMMS o vuoi migliorare una traduzione esistente, s
         <source>With this knob you can set the point where the loop starts. </source>
         <translation>Con questa modalità puoi impostare il punto dove la ripetizione comincia: la parte del suono tra il LoopBack e il punto di fine è quella che verà ripetuta.</translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -195,6 +195,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -199,6 +199,10 @@ Zauważone błędy i propozycje zmian tłumaczenia proszę zgłaszać na e-mail:
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -197,6 +197,10 @@ Esteban Viveros</translation>
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation>Amostra não encontrada: %1</translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -197,6 +197,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -193,6 +193,10 @@ If you&apos;re interested in translating LMMS in another language or want to imp
         <source>With this knob you can set the point where the loop starts. </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -201,6 +201,10 @@ Jeff Bai，邮箱：jeffbaichina@gmail.com</translation>
         <source>With this knob you can set the point where the loop starts. </source>
         <translation>调节此旋钮，以设置循环开始的地方。</translation>
     </message>
+    <message>
+        <source>Sample not found: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileProcessorWaveView</name>

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -234,6 +234,14 @@ void audioFileProcessor::loadSettings( const QDomElement & _this )
 	if( _this.attribute( "src" ) != "" )
 	{
 		setAudioFile( _this.attribute( "src" ), false );
+
+		QString absolutePath = m_sampleBuffer.tryToMakeAbsolute( m_sampleBuffer.audioFile() );
+		if ( !QFileInfo( absolutePath ).exists() )
+		{
+			QString message = tr( "Sample not found: %1" ).arg( m_sampleBuffer.audioFile() );
+
+			Engine::getSong()->collectError( message );
+		}
 	}
 	else if( _this.attribute( "sampledata" ) != "" )
 	{


### PR DESCRIPTION
When a sample can not be loaded on an AudioFileProcessor we should notify the user.

The current behaviour makes the user confused as to why they're not playing, this can happen if an external drive is not mounted or if the user renamed directories/files.

This PR depends on https://github.com/LMMS/lmms/pull/1525 to be merged first.

![2015-01-08-161236_598x376_scrot](https://cloud.githubusercontent.com/assets/347552/5667843/156e1fd8-9752-11e4-85b3-9bb6295f8d6a.png)
