### PR TITLE
ProjectVersion: Expose major/minor/release/build info

### DIFF
--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -32,26 +32,26 @@
 class ProjectVersion : public QString
 {
 public:
-	ProjectVersion( const QString & s ) : 
-		QString( s ), 
-		major( section( '.', 0, 0 ).toInt() ) ,
-		minor( section( '.', 1, 1 ).toInt() ) ,
-		release( section( '.', 2 ).section( '-', 0, 0 ).toInt() ) ,
-		build( section( '.', 2 ).section( '-', 1 ) )
+	ProjectVersion(const QString & s) : 
+		QString(s), 
+		m_major(section( '.', 0, 0 ).toInt()) ,
+		m_minor(section( '.', 1, 1 ).toInt()) ,
+		m_release(section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
+		m_build(section( '.', 2 ).section( '-', 1 ))
 	{
 	}
 
-	static int compare( const ProjectVersion & v1,
-						const ProjectVersion & v2 );
-	const int majorVersion() const { return major; }
-	const int minorVersion() const { return minor; }
-	const int releaseVersion() const { return release; }
-	const QString buildVersion() const { return build; }
+	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);
+	const int majorVersion() const { return m_major; }
+	const int minorVersion() const { return m_minor; }
+	const int releaseVersion() const { return m_release; }
+	const QString buildVersion() const { return m_build; }
+
 private:
-	const int major;
-	const int minor;
-	const int release;
-	const QString build;
+	const int m_major;
+	const int m_minor;
+	const int m_release;
+	const QString m_build;
 } ;
 
 

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -27,27 +27,39 @@
 #define PROJECT_VERSION_H
 
 #include <QtCore/QString>
-
+#include "export.h"
 
 class ProjectVersion : public QString
 {
 public:
-	ProjectVersion( const QString & _s ) :
-		QString( _s )
+	ProjectVersion( const QString & s ) : 
+		QString( s ), 
+		major( section( '.', 0, 0 ).toInt() ) ,
+		minor( section( '.', 1, 1 ).toInt() ) ,
+		release( section( '.', 2 ).section( '-', 0, 0 ).toInt() ) ,
+		build( section( '.', 2 ).section( '-', 1 ) )
 	{
 	}
 
-	static int compare( const ProjectVersion & _v1,
-						const ProjectVersion & _v2 );
-
+	static int compare( const ProjectVersion & v1,
+						const ProjectVersion & v2 );
+	const int majorVersion() const { return major; }
+	const int minorVersion() const { return minor; }
+	const int releaseVersion() const { return release; }
+	const QString buildVersion() const { return build; }
+private:
+	const int major;
+	const int minor;
+	const int release;
+	const QString build;
 } ;
 
 
 
 
-inline bool operator<( const ProjectVersion & _v1, const char * _str )
+inline bool operator<( const ProjectVersion & v1, const char * str )
 {
-	return ProjectVersion::compare( _v1, ProjectVersion( _str ) ) < 0;
+	return ProjectVersion::compare( v1, ProjectVersion( str ) ) < 0;
 }
 
 

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -58,9 +58,6 @@ public:
 	
 
 private:
-	static int compStr(const ProjectVersion & v1, const char * v2);
-	static int compStr(const ProjectVersion & v1, const QString & v2);
-
 	const int m_major;
 	const int m_minor;
 	const int m_release;
@@ -85,20 +82,6 @@ inline int compStr(const ProjectVersion & v1, const QString & v2)
 
 
 
-inline int compStr(const char * v1, const ProjectVersion & v2)
-{
-	return ProjectVersion::compare(ProjectVersion(v1), v2);
-}
-
-
-
-inline int compStr(const QString & v1, const ProjectVersion & v2)
-{
-	return ProjectVersion::compare(ProjectVersion(v1), v2);
-}
-
-
-
 /*
  * ProjectVersion v. char[]
  */
@@ -109,12 +92,12 @@ inline bool operator>=(const ProjectVersion & v1, const char * v2) { return comp
 inline bool operator==(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) == 0; }
 inline bool operator!=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) != 0; }
 
-inline bool operator<(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) < 0; }
-inline bool operator>(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) > 0; }
-inline bool operator<=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) <= 0; }
-inline bool operator>=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) >= 0; }
-inline bool operator==(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) == 0; }
-inline bool operator!=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) != 0; }
+inline bool operator<(const char * v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
+inline bool operator>(const char * v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
+inline bool operator<=(const char * v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
+inline bool operator>=(const char * v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
+inline bool operator==(const char * v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
+inline bool operator!=(const char * v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
 
 /*
  * ProjectVersion v. QString
@@ -126,12 +109,12 @@ inline bool operator>=(const ProjectVersion & v1, const QString & v2) { return c
 inline bool operator==(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) == 0; }
 inline bool operator!=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) != 0; }
 
-inline bool operator<(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) < 0; }
-inline bool operator>(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) > 0; }
-inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) <= 0; }
-inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) >= 0; }
-inline bool operator==(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) == 0; }
-inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) != 0; }
+inline bool operator<(const QString & v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
+inline bool operator>(const QString & v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
+inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
+inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
+inline bool operator==(const QString & v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
+inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
 
 /*
  * ProjectVersion v. ProjectVersion

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -2,6 +2,7 @@
  * ProjectVersion.h - version compared in import upgrades
  *
  * Copyright (c) 2007 Javier Serrano Polo <jasp00/at/users.sourceforge.net>
+ * Copyright (c) 2015 Tres Finocchiaro <tres.finocchiaro/at/gmail.com>
  *
  * This file is part of LMMS - http://lmms.io
  *
@@ -28,32 +29,37 @@
 
 #include <QtCore/QString>
 
+enum CompareType { Major, Minor, Release, Build };
+
 class ProjectVersion : public QString
 {
 public:
-	ProjectVersion(const QString & s) : 
+	ProjectVersion(const QString & s, const CompareType c = CompareType::Build) : 
 		QString(s), 
 		m_major(section( '.', 0, 0 ).toInt()) ,
 		m_minor(section( '.', 1, 1 ).toInt()) ,
 		m_release(section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
-		m_build(section( '.', 2 ).section( '-', 1 ))
+		m_build(section( '.', 2 ).section( '-', 1 )),
+		m_compareType(c)
 	{
 	}
 
-	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);
-	const int majorVersion() const { return m_major; }
-	const int minorVersion() const { return m_minor; }
-	const int releaseVersion() const { return m_release; }
-	const QString buildVersion() const { return m_build; }
+	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);	
+
+	const int getMajor() const { return m_major; }
+	const int getMinor() const { return m_minor; }
+	const int getRelease() const { return m_release; }
+	const QString getBuild() const { return m_build; }
+	const CompareType getCompareType() const { return m_compareType; }
+	
 
 private:
 	const int m_major;
 	const int m_minor;
 	const int m_release;
 	const QString m_build;
+	const CompareType m_compareType;
 } ;
-
-
 
 
 inline bool operator<( const ProjectVersion & v1, const char * str )

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -31,6 +31,24 @@
 
 enum CompareType { Major, Minor, Release, Build };
 
+
+static inline int parseMajor(QString & version) {
+	return version.section( '.', 0, 0 ).toInt();
+}
+
+static inline int parseMinor(QString & version) {
+	return version.section( '.', 1, 1 ).toInt();
+}
+
+static inline int parseRelease(QString & version) {
+	return version.section( '.', 2 ).section( '-', 0, 0 ).toInt();
+}
+
+static inline QString parseBuild(QString & version) {
+	return version.section( '.', 2 ).section( '-', 1 );
+}
+
+
 /*! \brief Version number parsing and comparison 
  *
  *  Parses and compares version information.  i.e. "1.0.3" < "1.0.10"
@@ -40,10 +58,20 @@ class ProjectVersion
 public:
 	ProjectVersion(QString version, CompareType c = CompareType::Build) : 
 		m_version(version), 
-		m_major(version.section( '.', 0, 0 ).toInt()) ,
-		m_minor(version.section( '.', 1, 1 ).toInt()) ,
-		m_release(version.section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
-		m_build(version.section( '.', 2 ).section( '-', 1 )),
+		m_major(parseMajor(m_version)),
+		m_minor(parseMinor(m_version)),
+		m_release(parseRelease(m_version)) ,
+		m_build(parseBuild(m_version)),
+		m_compareType(c)
+	{
+	}
+
+	ProjectVersion(const char * version, CompareType c = CompareType::Build) : 
+		m_version(QString(version)), 
+		m_major(parseMajor(m_version)),
+		m_minor(parseMinor(m_version)),
+		m_release(parseRelease(m_version)) ,
+		m_build(parseBuild(m_version)),
 		m_compareType(c)
 	{
 	}
@@ -55,7 +83,7 @@ public:
 	int getRelease() { return m_release; }
 	QString getBuild() { return m_build; }
 	CompareType getCompareType() { return m_compareType; }
-	void setCompareType(CompareType compareType) { m_compareType = compareType; }
+	ProjectVersion setCompareType(CompareType compareType) { m_compareType = compareType; return * this; }
 	
 
 private:
@@ -67,15 +95,10 @@ private:
 	CompareType m_compareType;
 } ;
 
-
-
-
 inline int compare(ProjectVersion v1, QString v2)
 {
 	return ProjectVersion::compare(v1, ProjectVersion(v2));
 }
-
-
 
 
 /*

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -27,7 +27,6 @@
 #define PROJECT_VERSION_H
 
 #include <QtCore/QString>
-#include "export.h"
 
 class ProjectVersion : public QString
 {

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -31,6 +31,10 @@
 
 enum CompareType { Major, Minor, Release, Build };
 
+/*! \brief Version number parsing and comparison utility
+ *
+ *  Parses and compares version information.  i.e. "1.0.3" < "1.0.10"
+ */
 class ProjectVersion : public QString
 {
 public:
@@ -44,7 +48,7 @@ public:
 	{
 	}
 
-	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);	
+	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);
 
 	const int getMajor() const { return m_major; }
 	const int getMinor() const { return m_minor; }
@@ -54,20 +58,74 @@ public:
 	
 
 private:
+	static int compStr(const ProjectVersion & v1, const char * v2);
+	static int compStr(const ProjectVersion & v1, const QString & v2);
+
 	const int m_major;
 	const int m_minor;
 	const int m_release;
-	const QString m_build;
-	const CompareType m_compareType;
+	const QString & m_build;
+	const CompareType & m_compareType;
 } ;
 
 
-inline bool operator<( const ProjectVersion & v1, const char * str )
+
+
+inline int compStr(const ProjectVersion & v1, const char * v2)
 {
-	return ProjectVersion::compare( v1, ProjectVersion( str ) ) < 0;
+	return ProjectVersion::compare(v1, ProjectVersion(v2));
 }
 
 
+
+inline int compStr(const ProjectVersion & v1, const QString & v2)
+{
+	return ProjectVersion::compare(v1, ProjectVersion(v2));
+}
+
+/*
+ * ProjectVersion v. char[]
+ */
+inline bool operator<(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) < 0; }
+inline bool operator>(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) > 0; }
+inline bool operator<=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) <= 0; }
+inline bool operator>=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) >= 0; }
+inline bool operator==(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) == 0; }
+inline bool operator!=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) != 0; }
+
+inline bool operator<(const char * v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
+inline bool operator>(const char * v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
+inline bool operator<=(const char * v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
+inline bool operator>=(const char * v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
+inline bool operator==(const char * v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
+inline bool operator!=(const char * v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+
+/*
+ * ProjectVersion v. QString
+ */
+inline bool operator<(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) < 0; }
+inline bool operator>(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) > 0; }
+inline bool operator<=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) <= 0; }
+inline bool operator>=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) >= 0; }
+inline bool operator==(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) == 0; }
+inline bool operator!=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) != 0; }
+
+inline bool operator<(const QString & v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
+inline bool operator>(const QString & v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
+inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
+inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
+inline bool operator==(const QString & v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
+inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+
+/*
+ * ProjectVersion v. ProjectVersion
+ */
+inline bool operator<(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) < 0; }
+inline bool operator>(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) > 0; }
+inline bool operator<=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) <= 0; }
+inline bool operator>=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) >= 0; }
+inline bool operator==(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) == 0; }
+inline bool operator!=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) != 0; }
 
 
 #endif

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -102,7 +102,7 @@ inline int compare(ProjectVersion v1, QString v2)
 
 
 /*
- * ProjectVersion v. char[]
+ * ProjectVersion v. QString
  */
 inline bool operator<(ProjectVersion v1, QString v2) { return compare(v1, v2) < 0; }
 inline bool operator>(ProjectVersion v1, QString v2) { return compare(v1, v2) > 0; }

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -35,96 +35,78 @@ enum CompareType { Major, Minor, Release, Build };
  *
  *  Parses and compares version information.  i.e. "1.0.3" < "1.0.10"
  */
-class ProjectVersion : public QString
+class ProjectVersion
 {
 public:
-	ProjectVersion(const QString & s, const CompareType c = CompareType::Build) : 
-		QString(s), 
-		m_major(s.section( '.', 0, 0 ).toInt()) ,
-		m_minor(s.section( '.', 1, 1 ).toInt()) ,
-		m_release(s.section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
-		m_build(s.section( '.', 2 ).section( '-', 1 )),
+	ProjectVersion(QString version, CompareType c = CompareType::Build) : 
+		m_version(version), 
+		m_major(version.section( '.', 0, 0 ).toInt()) ,
+		m_minor(version.section( '.', 1, 1 ).toInt()) ,
+		m_release(version.section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
+		m_build(version.section( '.', 2 ).section( '-', 1 )),
 		m_compareType(c)
 	{
 	}
 
-	static int compare(const ProjectVersion & v1, const ProjectVersion & v2);
+	static int compare(ProjectVersion v1, ProjectVersion v2);
 
-	const int getMajor() const { return m_major; }
-	const int getMinor() const { return m_minor; }
-	const int getRelease() const { return m_release; }
-	const QString getBuild() const { return m_build; }
-	const CompareType getCompareType() const { return m_compareType; }
+	int getMajor() { return m_major; }
+	int getMinor() { return m_minor; }
+	int getRelease() { return m_release; }
+	QString getBuild() { return m_build; }
+	CompareType getCompareType() { return m_compareType; }
+	void setCompareType(CompareType compareType) { m_compareType = compareType; }
 	
 
 private:
-	const int m_major;
-	const int m_minor;
-	const int m_release;
-	const QString m_build;
-	const CompareType m_compareType;
+	QString m_version;
+	int m_major;
+	int m_minor;
+	int m_release;
+	QString m_build;
+	CompareType m_compareType;
 } ;
 
 
 
 
-inline int compStr(const ProjectVersion & v1, const char * v2)
+inline int compare(ProjectVersion v1, QString v2)
 {
 	return ProjectVersion::compare(v1, ProjectVersion(v2));
 }
 
-
-
-inline int compStr(const ProjectVersion & v1, const QString & v2)
-{
-	return ProjectVersion::compare(v1, ProjectVersion(v2));
-}
 
 
 
 /*
  * ProjectVersion v. char[]
  */
-inline bool operator<(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) < 0; }
-inline bool operator>(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) > 0; }
-inline bool operator<=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) <= 0; }
-inline bool operator>=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) >= 0; }
-inline bool operator==(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) == 0; }
-inline bool operator!=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) != 0; }
+inline bool operator<(ProjectVersion v1, QString v2) { return compare(v1, v2) < 0; }
+inline bool operator>(ProjectVersion v1, QString v2) { return compare(v1, v2) > 0; }
+inline bool operator<=(ProjectVersion v1, QString v2) { return compare(v1, v2) <= 0; }
+inline bool operator>=(ProjectVersion v1, QString v2) { return compare(v1, v2) >= 0; }
+inline bool operator==(ProjectVersion v1, QString v2) { return compare(v1, v2) == 0; }
+inline bool operator!=(ProjectVersion v1, QString v2) { return compare(v1, v2) != 0; }
 
-inline bool operator<(const char * v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
-inline bool operator>(const char * v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
-inline bool operator<=(const char * v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
-inline bool operator>=(const char * v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
-inline bool operator==(const char * v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
-inline bool operator!=(const char * v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+inline bool operator<(QString v1, ProjectVersion v2) { return 0 < compare(v2, v1); }
+inline bool operator>(QString v1, ProjectVersion v2) { return 0 > compare(v2, v1); }
+inline bool operator<=(QString v1, ProjectVersion v2) { return 0 <= compare(v2, v1); }
+inline bool operator>=(QString v1, ProjectVersion v2) { return 0 >= compare(v2, v1); }
+inline bool operator==(QString v1, ProjectVersion v2) { return 0 == compare(v2, v1); }
+inline bool operator!=(QString v1, ProjectVersion v2) { return 0 != compare(v2, v1); }
 
-/*
- * ProjectVersion v. QString
- */
-inline bool operator<(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) < 0; }
-inline bool operator>(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) > 0; }
-inline bool operator<=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) <= 0; }
-inline bool operator>=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) >= 0; }
-inline bool operator==(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) == 0; }
-inline bool operator!=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) != 0; }
 
-inline bool operator<(const QString & v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
-inline bool operator>(const QString & v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
-inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
-inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
-inline bool operator==(const QString & v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
-inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+
 
 /*
  * ProjectVersion v. ProjectVersion
  */
-inline bool operator<(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) < 0; }
-inline bool operator>(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) > 0; }
-inline bool operator<=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) <= 0; }
-inline bool operator>=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) >= 0; }
-inline bool operator==(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) == 0; }
-inline bool operator!=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) != 0; }
+inline bool operator<(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) < 0; }
+inline bool operator>(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) > 0; }
+inline bool operator<=(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) <= 0; }
+inline bool operator>=(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) >= 0; }
+inline bool operator==(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) == 0; }
+inline bool operator!=(ProjectVersion & v1, ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) != 0; }
 
 
 #endif

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -31,7 +31,7 @@
 
 enum CompareType { Major, Minor, Release, Build };
 
-/*! \brief Version number parsing and comparison utility
+/*! \brief Version number parsing and comparison 
  *
  *  Parses and compares version information.  i.e. "1.0.3" < "1.0.10"
  */
@@ -40,10 +40,10 @@ class ProjectVersion : public QString
 public:
 	ProjectVersion(const QString & s, const CompareType c = CompareType::Build) : 
 		QString(s), 
-		m_major(section( '.', 0, 0 ).toInt()) ,
-		m_minor(section( '.', 1, 1 ).toInt()) ,
-		m_release(section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
-		m_build(section( '.', 2 ).section( '-', 1 )),
+		m_major(s.section( '.', 0, 0 ).toInt()) ,
+		m_minor(s.section( '.', 1, 1 ).toInt()) ,
+		m_release(s.section( '.', 2 ).section( '-', 0, 0 ).toInt()) ,
+		m_build(s.section( '.', 2 ).section( '-', 1 )),
 		m_compareType(c)
 	{
 	}
@@ -64,8 +64,8 @@ private:
 	const int m_major;
 	const int m_minor;
 	const int m_release;
-	const QString & m_build;
-	const CompareType & m_compareType;
+	const QString m_build;
+	const CompareType m_compareType;
 } ;
 
 
@@ -83,6 +83,22 @@ inline int compStr(const ProjectVersion & v1, const QString & v2)
 	return ProjectVersion::compare(v1, ProjectVersion(v2));
 }
 
+
+
+inline int compStr(const char * v1, const ProjectVersion & v2)
+{
+	return ProjectVersion::compare(ProjectVersion(v1), v2);
+}
+
+
+
+inline int compStr(const QString & v1, const ProjectVersion & v2)
+{
+	return ProjectVersion::compare(ProjectVersion(v1), v2);
+}
+
+
+
 /*
  * ProjectVersion v. char[]
  */
@@ -93,12 +109,12 @@ inline bool operator>=(const ProjectVersion & v1, const char * v2) { return comp
 inline bool operator==(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) == 0; }
 inline bool operator!=(const ProjectVersion & v1, const char * v2) { return compStr(v1, v2) != 0; }
 
-inline bool operator<(const char * v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
-inline bool operator>(const char * v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
-inline bool operator<=(const char * v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
-inline bool operator>=(const char * v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
-inline bool operator==(const char * v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
-inline bool operator!=(const char * v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+inline bool operator<(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) < 0; }
+inline bool operator>(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) > 0; }
+inline bool operator<=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) <= 0; }
+inline bool operator>=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) >= 0; }
+inline bool operator==(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) == 0; }
+inline bool operator!=(const char * v1, const ProjectVersion & v2) { return compStr(v1, v2) != 0; }
 
 /*
  * ProjectVersion v. QString
@@ -110,12 +126,12 @@ inline bool operator>=(const ProjectVersion & v1, const QString & v2) { return c
 inline bool operator==(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) == 0; }
 inline bool operator!=(const ProjectVersion & v1, const QString & v2) { return compStr(v1, v2) != 0; }
 
-inline bool operator<(const QString & v1, const ProjectVersion & v2) { return 0 < compStr(v2, v1); }
-inline bool operator>(const QString & v1, const ProjectVersion & v2) { return 0 > compStr(v2, v1); }
-inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return 0 <= compStr(v2, v1); }
-inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return 0 >= compStr(v2, v1); }
-inline bool operator==(const QString & v1, const ProjectVersion & v2) { return 0 == compStr(v2, v1); }
-inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return 0 != compStr(v2, v1); }
+inline bool operator<(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) < 0; }
+inline bool operator>(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) > 0; }
+inline bool operator<=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) <= 0; }
+inline bool operator>=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) >= 0; }
+inline bool operator==(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) == 0; }
+inline bool operator!=(const QString & v1, const ProjectVersion & v2) { return compStr(v1, v2) != 0; }
 
 /*
  * ProjectVersion v. ProjectVersion

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -25,8 +25,6 @@
  */
 
 
-
-
 #include "ProjectVersion.h"
 
 int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2)
@@ -38,7 +36,7 @@ int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2
 	
 	// return prematurely for Major comparison
 	if(v1.getCompareType() == CompareType::Major || 
-		v1.getCompareType() == CompareType::Major)
+		v2.getCompareType() == CompareType::Major)
 	{
 		return 0;
 	}
@@ -50,7 +48,7 @@ int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2
 
 	// return prematurely for Minor comparison
 	if(v1.getCompareType() == CompareType::Minor || 
-		v1.getCompareType() == CompareType::Minor)
+		v2.getCompareType() == CompareType::Minor)
 
 	if(v1.getRelease() != v2.getRelease())
 	{
@@ -58,7 +56,7 @@ int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2
 	}
 
 	if(v1.getCompareType() == CompareType::Build || 
-		v1.getCompareType() == CompareType::Build)
+		v2.getCompareType() == CompareType::Build)
 
 	// make sure 0.x.y > 0.x.y-patch
 	if(v1.getBuild().isEmpty())

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -76,4 +76,3 @@ int ProjectVersion::compare(ProjectVersion v1, ProjectVersion v2)
 	return QString::compare(v1.getBuild(), v2.getBuild());
 }
 
-

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -29,7 +29,6 @@
 
 #include "ProjectVersion.h"
 
-
 int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2)
 {
 	if(v1.getMajor() != v2.getMajor())

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -49,14 +49,19 @@ int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2
 	// return prematurely for Minor comparison
 	if(v1.getCompareType() == CompareType::Minor || 
 		v2.getCompareType() == CompareType::Minor)
+	{
+		return 0;
+	}
 
 	if(v1.getRelease() != v2.getRelease())
 	{
 		return v1.getRelease() - v2.getRelease();
 	}
 
-	if(v1.getCompareType() == CompareType::Build || 
-		v2.getCompareType() == CompareType::Build)
+	if(v1.getCompareType() == CompareType::Release || 
+		v2.getCompareType() == CompareType::Release) {
+		return 0;
+	}
 
 	// make sure 0.x.y > 0.x.y-patch
 	if(v1.getBuild().isEmpty())

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2007 Javier Serrano Polo <jasp00/at/users.sourceforge.net>
  * Copyright (c) 2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2015 Tres Finocchiaro <tres.finocchiaro/at/gmail.com>
  * 
  * This file is part of LMMS - http://lmms.io
  *
@@ -31,32 +32,46 @@
 
 int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2)
 {
-	if(v1.majorVersion() != v2.majorVersion())
+	if(v1.getMajor() != v2.getMajor())
 	{
-		return v1.majorVersion() - v2.majorVersion();
+		return v1.getMajor() - v2.getMajor();
+	}
+	
+	// return prematurely for Major comparison
+	if(v1.getCompareType() == CompareType::Major || 
+		v1.getCompareType() == CompareType::Major)
+	{
+		return 0;
 	}
 
-	if(v1.minorVersion() != v2.minorVersion())
+	if(v1.getMinor() != v2.getMinor())
 	{
-		return v1.minorVersion() - v2.minorVersion();
+		return v1.getMinor() - v2.getMinor();
 	}
 
-	if(v1.releaseVersion() != v2.releaseVersion())
+	// return prematurely for Minor comparison
+	if(v1.getCompareType() == CompareType::Minor || 
+		v1.getCompareType() == CompareType::Minor)
+
+	if(v1.getRelease() != v2.getRelease())
 	{
-		return v1.releaseVersion() - v2.releaseVersion();
+		return v1.getRelease() - v2.getRelease();
 	}
+
+	if(v1.getCompareType() == CompareType::Build || 
+		v1.getCompareType() == CompareType::Build)
 
 	// make sure 0.x.y > 0.x.y-patch
-	if(v1.buildVersion().isEmpty())
+	if(v1.getBuild().isEmpty())
 	{
 		return 1;
 	}
-	if(v2.buildVersion().isEmpty())
+	if(v2.getBuild().isEmpty())
 	{
 		return -1;
 	}
 
-	return QString::compare(v1.buildVersion(), v2.buildVersion());
+	return QString::compare(v1.getBuild(), v2.getBuild());
 }
 
 

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -27,7 +27,7 @@
 
 #include "ProjectVersion.h"
 
-int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2)
+int ProjectVersion::compare(ProjectVersion v1, ProjectVersion v2)
 {
 	if(v1.getMajor() != v2.getMajor())
 	{

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -29,35 +29,34 @@
 #include "ProjectVersion.h"
 
 
-int ProjectVersion::compare( const ProjectVersion & v1,
-						const ProjectVersion & v2 )
+int ProjectVersion::compare(const ProjectVersion & v1, const ProjectVersion & v2)
 {
-	if( v1.majorVersion() != v2.majorVersion() )
+	if(v1.majorVersion() != v2.majorVersion())
 	{
 		return v1.majorVersion() - v2.majorVersion();
 	}
 
-	if( v1.minorVersion() != v2.minorVersion() )
+	if(v1.minorVersion() != v2.minorVersion())
 	{
 		return v1.minorVersion() - v2.minorVersion();
 	}
 
-	if(  v1.releaseVersion() != v2.releaseVersion() )
+	if(v1.releaseVersion() != v2.releaseVersion())
 	{
 		return v1.releaseVersion() - v2.releaseVersion();
 	}
 
 	// make sure 0.x.y > 0.x.y-patch
-	if( v1.buildVersion().isEmpty() )
+	if(v1.buildVersion().isEmpty())
 	{
 		return 1;
 	}
-	if( v2.buildVersion().isEmpty() )
+	if(v2.buildVersion().isEmpty())
 	{
 		return -1;
 	}
 
-	return QString::compare( v1.buildVersion(), v2.buildVersion() );
+	return QString::compare(v1.buildVersion(), v2.buildVersion());
 }
 
 

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -29,54 +29,35 @@
 #include "ProjectVersion.h"
 
 
-
-
-int ProjectVersion::compare( const ProjectVersion & _v1,
-						const ProjectVersion & _v2 )
+int ProjectVersion::compare( const ProjectVersion & v1,
+						const ProjectVersion & v2 )
 {
-	int n1, n2;
-
-	// Major
-	n1 = _v1.section( '.', 0, 0 ).toInt();
-	n2 = _v2.section( '.', 0, 0 ).toInt();
-	if( n1 != n2 )
+	if( v1.majorVersion() != v2.majorVersion() )
 	{
-		return n1 - n2;
+		return v1.majorVersion() - v2.majorVersion();
 	}
 
-	// Minor
-	n1 = _v1.section( '.', 1, 1 ).toInt();
-	n2 = _v2.section( '.', 1, 1 ).toInt();
-	if( n1 != n2 )
+	if( v1.minorVersion() != v2.minorVersion() )
 	{
-		return n1 - n2;
+		return v1.minorVersion() - v2.minorVersion();
 	}
 
-	// Release
-	n1 = _v1.section( '.', 2 ).section( '-', 0, 0 ).toInt();
-	n2 = _v2.section( '.', 2 ).section( '-', 0, 0 ).toInt();
-	if( n1 != n2 )
+	if(  v1.releaseVersion() != v2.releaseVersion() )
 	{
-		return n1 - n2;
+		return v1.releaseVersion() - v2.releaseVersion();
 	}
-
-	// Build
-	const QString b1 = _v1.section( '.', 2 ).section( '-', 1 );
-	const QString b2 = _v2.section( '.', 2 ).section( '-', 1 );
 
 	// make sure 0.x.y > 0.x.y-patch
-	if( b1.isEmpty() )
+	if( v1.buildVersion().isEmpty() )
 	{
 		return 1;
 	}
-	if( b2.isEmpty() )
+	if( v2.buildVersion().isEmpty() )
 	{
 		return -1;
 	}
 
-	return QString::compare( b1, b2 );
+	return QString::compare( v1.buildVersion(), v2.buildVersion() );
 }
-
-
 
 


### PR DESCRIPTION
This is to help with @Spekular on version comparison in #1538.

The effect of this is something like this:

```cpp

QString proj = root.getElement('creatorversion');

if (ProjectVersion(proj, Minor) < LMMS_VERSION)
{
     // Project minor version is lower than lmms
}

if (ProjectVersion(proj, Major) > LMMS_VERSION)
{
     // Project minor version is higher than lmms
}
```
