### PR TITLE
Proposed fix for issue 300, preview vst crashes

### DIFF
--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -147,9 +147,17 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 	else
 	{
 		DataFile dataFile( _preset_file );
-		s_previewTC->previewInstrumentTrack()->
-			loadTrackSpecificSettings(
-				dataFile.content().firstChild().toElement() );
+		if(dataFile.content().elementsByTagName( "vestige" ).length() == 0 )
+		{
+			s_previewTC->previewInstrumentTrack()->
+					loadTrackSpecificSettings(
+						dataFile.content().firstChild().toElement() );
+		}
+		else
+		{
+			s_previewTC->previewInstrumentTrack()->loadInstrument("tripleoscillator");
+			s_previewTC->previewInstrumentTrack()->setVolume( 0 );
+		}
 	}
 
 	Engine::setSuppressMessages( false );


### PR DESCRIPTION
Proposed fix for issue #300, preview vst crashes

This is a temporary fix, that stops the previewing of vestige instruments.

It still required than an instrument be loaded, so simply loaded a triple oscillator, and set the volume to 0.

