### PR TITLE
update 1211 solo nolonger mutes master

### DIFF
--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -230,7 +230,7 @@ int FxMixer::createChannel()
 
 void FxMixer::activateSolo()
 {
-	for (int i = 0; i < m_fxChannels.size(); ++i)
+	for (int i = 1; i < m_fxChannels.size(); ++i)
 	{
 		m_fxChannels[i]->m_muteBeforeSolo = m_fxChannels[i]->m_muteModel.value();
 		m_fxChannels[i]->m_muteModel.setValue( true );
@@ -239,7 +239,7 @@ void FxMixer::activateSolo()
 
 void FxMixer::deactivateSolo()
 {
-	for (int i = 0; i < m_fxChannels.size(); ++i)
+	for (int i = 1; i < m_fxChannels.size(); ++i)
 	{
 		m_fxChannels[i]->m_muteModel.setValue( m_fxChannels[i]->m_muteBeforeSolo );
 	}


### PR DESCRIPTION
update 1211 solo nolonger mutes master

original patch muted mater channel on soloing any channel, resulting in silence.
This patch simply starts to mute from track 1 not 0(master) , and unmutes by the same logic