### PR TITLE
Enable GigPlayer Windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
     - sudo apt-get update -qq
 install:
     - if [ $TARGET_OS != linux ]; then sudo apt-get install -y nsis cloog-isl libmpc2 mingw32; fi
-    - if [ $TARGET_OS != linux ]; then sudo apt-get install -y mingw32-x-qt mingw32-x-sdl mingw32-x-libvorbis mingw32-x-fluidsynth mingw32-x-stk mingw32-x-glib2 mingw32-x-portaudio mingw32-x-libsndfile mingw32-x-fftw mingw32-x-flac mingw32-x-fltk mingw32-x-libsamplerate mingw32-x-pkgconfig mingw32-x-binutils mingw32-x-gcc mingw32-x-runtime; fi
-    - if [ $TARGET_OS == win64 ]; then sudo apt-get install -y mingw64-x-qt mingw64-x-sdl mingw64-x-libvorbis mingw64-x-fluidsynth mingw64-x-stk mingw64-x-glib2 mingw64-x-portaudio mingw64-x-libsndfile mingw64-x-fftw mingw64-x-flac mingw64-x-fltk mingw64-x-libsamplerate mingw64-x-pkgconfig mingw64-x-binutils mingw64-x-gcc mingw64-x-runtime; fi
+    - if [ $TARGET_OS != linux ]; then sudo apt-get install -y mingw32-x-qt mingw32-x-sdl mingw32-x-libvorbis mingw32-x-fluidsynth mingw32-x-stk mingw32-x-glib2 mingw32-x-portaudio mingw32-x-libsndfile mingw32-x-fftw mingw32-x-flac mingw32-x-fltk mingw32-x-libsamplerate mingw32-x-pkgconfig mingw32-x-binutils mingw32-x-gcc mingw32-x-runtime mingw32-x-libgig; fi
+    - if [ $TARGET_OS == win64 ]; then sudo apt-get install -y mingw64-x-qt mingw64-x-sdl mingw64-x-libvorbis mingw64-x-fluidsynth mingw64-x-stk mingw64-x-glib2 mingw64-x-portaudio mingw64-x-libsndfile mingw64-x-fftw mingw64-x-flac mingw64-x-fltk mingw64-x-libsamplerate mingw64-x-pkgconfig mingw64-x-binutils mingw64-x-gcc mingw64-x-runtime mingw64-x-libgig; fi
     - if [ $TARGET_OS == linux ]; then sudo apt-get install -y libqt4-dev libsndfile-dev fftw3-dev libvorbis-dev libogg-dev libasound2-dev libjack-dev libsdl-dev libsamplerate0-dev libstk0-dev libfluidsynth-dev portaudio19-dev wine-dev g++-multilib libfltk1.3-dev libgig-dev; fi
 before_script:
     - mkdir build && cd build

--- a/plugins/GigPlayer/CMakeLists.txt
+++ b/plugins/GigPlayer/CMakeLists.txt
@@ -6,8 +6,14 @@ if(LMMS_HAVE_GIG)
 	SET(GCC_COVERAGE_COMPILE_FLAGS "-fexceptions")
 	add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})
 
-    LINK_DIRECTORIES(${GIG_LIBRARY_DIRS})
-    LINK_LIBRARIES(${GIG_LIBRARIES})
+	# disable deprecated check for mingw-x-libgig
+	if(LMMS_BUILD_WIN32)
+		SET(GCC_GIG_COMPILE_FLAGS "-Wno-deprecated")
+		add_definitions(${GCC_GIG_COMPILE_FLAGS})
+	endif(LMMS_BUILD_WIN32)
+
+	LINK_DIRECTORIES(${GIG_LIBRARY_DIRS} ${SAMPLERATE_LIBRARY_DIRS})
+	LINK_LIBRARIES(${GIG_LIBRARIES} ${SAMPLERATE_LIBRARIES})
 	BUILD_PLUGIN(gigplayer GigPlayer.cpp GigPlayer.h PatchesDialog.cpp PatchesDialog.h PatchesDialog.ui MOCFILES GigPlayer.h PatchesDialog.h UICFILES PatchesDialog.ui EMBEDDED_RESOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.png")
 endif(LMMS_HAVE_GIG)
 


### PR DESCRIPTION
This enables GigPlayer builds for windows.
I had to add the -Wno-deprecated compiler flag to fix a bunch of these errors caused by an include file in the mingw-x-libgig package:
/opt/mingw32/include/gig.h:434:13: error: access declarations are deprecated in favour of using-declarations; suggestion: add the 'using' keyword [-Werror=deprecated]
             DLS::Sampler::UnityNote;
             ^