### PR TITLE
Fix locale generation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,7 @@ ENDIF()
 #
 # rules for building localizations
 #
-FILE(GLOB lmms_LOCALES data/locale/*.ts)
+FILE(GLOB lmms_LOCALES ${CMAKE_SOURCE_DIR}/data/locale/*.ts)
 SET(ts_targets "")
 SET(qm_targets "")
 FOREACH(_ts_file ${lmms_LOCALES})


### PR DESCRIPTION
Locales weren't generated after the recent CMake change due to an incorrect path.