### PR TITLE
proposed fix 1502 incorrect slash in windows

### DIFF
--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -100,18 +100,18 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 							"hqaudio" ).toInt() ),
 	m_lang( ConfigManager::inst()->value( "app",
 							"language" ) ),
-	m_workingDir( ConfigManager::inst()->workingDir() ),
-	m_vstDir( ConfigManager::inst()->vstDir() ),
-	m_artworkDir( ConfigManager::inst()->artworkDir() ),
-	m_flDir( ConfigManager::inst()->flDir() ),
-	m_ladDir( ConfigManager::inst()->ladspaDir() ),
+	m_workingDir( QDir::toNativeSeparators( ConfigManager::inst()->workingDir() ) ),
+	m_vstDir( QDir::toNativeSeparators( ConfigManager::inst()->vstDir() ) ),
+	m_artworkDir( QDir::toNativeSeparators( ConfigManager::inst()->artworkDir() ) ),
+	m_flDir( QDir::toNativeSeparators( ConfigManager::inst()->flDir() ) ),
+	m_ladDir( QDir::toNativeSeparators( ConfigManager::inst()->ladspaDir() ) ),
 #ifdef LMMS_HAVE_FLUIDSYNTH
-	m_defaultSoundfont( ConfigManager::inst()->defaultSoundfont() ),
+	m_defaultSoundfont( QDir::toNativeSeparators( ConfigManager::inst()->defaultSoundfont() ) ),
 #endif
 #ifdef LMMS_HAVE_STK
-	m_stkDir( ConfigManager::inst()->stkDir() ),
+	m_stkDir( QDir::toNativeSeparators( ConfigManager::inst()->stkDir() ) ),
 #endif
-	m_backgroundArtwork( ConfigManager::inst()->backgroundArtwork() ),
+	m_backgroundArtwork( QDir::toNativeSeparators( ConfigManager::inst()->backgroundArtwork() ) ),
 	m_smoothScroll( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() ),
 	m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() ),
 	m_oneInstrumentTrackWindow( ConfigManager::inst()->value( "ui",


### PR DESCRIPTION
proposed fix for issue #1502 Wrong slash in windows

This fix simply uses Qt's QDir::toNativeSeparators for the display values in the settings dialog.
The stored file paths remain untouched, I feel this is safest, from what i have read Qt automatically converts when accessing files.


@Sti2nd @StakeoutPunch @Umcaruje or @SecondFlight

Can you please test this on windows?