### PR TITLE
Fix moving channels

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -453,7 +453,6 @@ void FxMixerView::moveChannelLeft(int index)
 		delete m_fxChannelViews[i]->m_fader;
 		delete m_fxChannelViews[i]->m_muteBtn;
 		delete m_fxChannelViews[i]->m_soloBtn;
-		delete m_fxChannelViews[i]->m_fxLine;
 		delete m_fxChannelViews[i];
 
 		// add it again

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -186,7 +186,7 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 {
 	FxMixer * mix = Engine::fxMixer();
 	QPointer<CaptionMenu> contextMenu = new CaptionMenu( mix->effectChannel( m_channelIndex )->m_name, this );
-	if( m_channelIndex != 0 ) // no move-options in master 
+	if( m_channelIndex != 0 ) // no move-options in master
 	{
 		contextMenu->addAction( tr( "Move &left" ), this, SLOT( moveChannelLeft() ) );
 		contextMenu->addAction( tr( "Move &right" ), this, SLOT( moveChannelRight() ) );

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -188,7 +188,7 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 	QPointer<CaptionMenu> contextMenu = new CaptionMenu( mix->effectChannel( m_channelIndex )->m_name, this );
 	if( m_channelIndex != 0 ) // no move-options in master 
 	{
-		contextMenu->addAction( tr( "Move &left" ),	this, SLOT( moveChannelLeft() ) );
+		contextMenu->addAction( tr( "Move &left" ), this, SLOT( moveChannelLeft() ) );
 		contextMenu->addAction( tr( "Move &right" ), this, SLOT( moveChannelRight() ) );
 	}
 	contextMenu->addAction( tr( "Rename &channel" ), this, SLOT( renameChannel() ) );


### PR DESCRIPTION
The FxLine widget was being deleted before the contextMenu event returned sometimes.

Please verify whether the new deletion mechanism is adequate.

I still see some weird segfaults when clicking randomly and performing random actions on the Mixer widget about `index out of range` but this is probably a separate issue.

Fixes #1584