### PR TITLE
Add CPU prioritization support for Windows

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1877,6 +1877,13 @@ int main( int _argc, char * * _argv )
 #endif
 #endif
 
+#ifdef LMMS_BUILD_WIN32
+	if( !SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS ) )
+	{
+		printf( "Notice: could not set high priority.\n" );
+	}
+#endif
+
 	// constructor automatically will process messages until it receives
 	// a IdVstLoadPlugin message and processes it
 	__plugin = new RemoteVstPlugin( atoi( _argv[1] ), atoi( _argv[2] ) );

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -48,6 +48,10 @@
 #include <QPainter>
 #include <QSplashScreen>
 
+#ifdef LMMS_BUILD_WIN32
+#include <windows.h>
+#endif
+
 #ifdef LMMS_HAVE_SCHED_H
 #include <sched.h>
 #endif
@@ -420,6 +424,13 @@ int main( int argc, char * * argv )
 	}
 #endif
 #endif
+#endif
+
+#ifdef LMMS_BUILD_WIN32
+	if( !SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS ) )
+	{
+		printf( "Notice: could not set high priority.\n" );
+	}
 #endif
 
 	if( render_out.isEmpty() )


### PR DESCRIPTION
Helps address #967 by using the Windows API to set LMMS and RemoteVSTPlugin32/64 to Very High priority.