### PR TITLE
Play imported MIDI drum tracks with a drum kit patch

### DIFF
--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -497,6 +497,15 @@ bool MidiImport::readSMF( TrackContainer* tc )
 		}
 	}
 
+	// Set channel 10 to drums as per General MIDI's orders
+	if( chs[9].hasNotes && chs[9].it_inst && chs[9].isSF2 )
+	{
+		// AFAIK, 128 should be the standard bank for drums in SF2.
+		// If not, this has to be made configurable.
+		chs[9].it_inst->childModel( "bank" )->setValue( 128 );
+		chs[9].it_inst->childModel( "patch" )->setValue( 0 );
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
General MIDI says track 10 is drums, and from what info I can find bank 128, patch 0 is the most standard place for drums in a soundfont.