### PR TITLE
Fix segfault at startup

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -530,7 +530,7 @@ void MainWindow::finalize()
 	}
 
 	// Add editor subwindows
-	for (QWidget* widget : QList<QWidget*>()
+	foreach( QWidget* widget, QList<QWidget*>()
 			<< gui->automationEditor()
 			<< gui->getBBEditor()
 			<< gui->pianoRoll()


### PR DESCRIPTION
This fixes a segfault at startup introduced in c7e3ab3d46cc083dd2946b749416ac754ba295ae
Somehow the QList is empty when using for() instead of foreach(). Probably the empty list was used and the items appended were not considered.