### PR TITLE
Use delete[] instead of delete for sampleFrame

### DIFF
--- a/plugins/delay/stereodelay.cpp
+++ b/plugins/delay/stereodelay.cpp
@@ -48,7 +48,7 @@ StereoDelay::~StereoDelay()
 {
 	if( m_buffer )
 	{
-		delete m_buffer;
+		delete[] m_buffer;
 	}
 }
 
@@ -84,7 +84,7 @@ void StereoDelay::setSampleRate( int sampleRate )
 {
 	if( m_buffer )
 	{
-		delete m_buffer;
+		delete[] m_buffer;
 	}
 
 	int bufferSize = ( int )( sampleRate * m_maxTime );

--- a/src/core/RingBuffer.cpp
+++ b/src/core/RingBuffer.cpp
@@ -75,7 +75,7 @@ void RingBuffer::changeSize( f_cnt_t size )
 	m_buffer = new sampleFrame[ m_size ];
 	memset( m_buffer, 0, m_size * sizeof( sampleFrame ) );
 	m_position = 0;
-	delete tmp;
+	delete[] tmp;
 }
 
 


### PR DESCRIPTION
Fixes warning: 'delete' applied to a pointer-to-array type 'sampleFrame *' (aka 'sample_t (*)[2]') treated as delete[] in mac os build