### PR TITLE
proposed fix 821 Range-select in Song Editor

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -35,6 +35,7 @@ class QPixmap;
 class QToolBar;
 class NStateButton;
 class TextFloat;
+class SongEditor;
 
 
 class TimeLineWidget : public QWidget, public JournallingObject
@@ -171,6 +172,8 @@ private:
 
 
 	TextFloat * m_hint;
+	SongEditor *m_songEditor;
+	int m_initalXSelect;
 
 
 	enum actions
@@ -178,7 +181,8 @@ private:
 		NoAction,
 		MovePositionMarker,
 		MoveLoopBegin,
-		MoveLoopEnd
+		MoveLoopEnd,
+		SelectSongTCO,
 	} m_action;
 
 	int m_moveXOff;

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -129,6 +129,11 @@ public:
 					m_ppt / MidiTime::ticksPerTact() );
 	}
 
+signals:
+
+	void regionSelectedFromPixels( int, int );
+	void selectionFinished();
+
 
 public slots:
 	void updatePosition( const MidiTime & );
@@ -172,7 +177,6 @@ private:
 
 
 	TextFloat * m_hint;
-	SongEditor *m_songEditor;
 	int m_initalXSelect;
 
 

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -92,6 +92,26 @@ public:
 		return( QVector<selectableObject *>() );
 	}
 
+	///
+	/// \brief selectRegionFromPixels
+	/// \param x
+	/// \param y
+	/// Use the rubber band to select TCO from all tracks using x, y pixels
+	void selectRegionFromPixels(int x, int y)
+	{
+		m_rubberBand->setEnabled( true );
+		m_rubberBand->show();
+		m_rubberBand->setGeometry( min( x, y ), 0, max( x, y ) - min( x, y ), std::numeric_limits<int>::max() );
+	}
+
+	///
+	/// \brief stopRubberBand
+	/// Removes the rubber band from display when finished with.
+	void stopRubberBand()
+	{
+		m_rubberBand->hide();
+		m_rubberBand->setEnabled( false );
+	}
 
 	TrackContainer* model()
 	{

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -92,26 +92,6 @@ public:
 		return( QVector<selectableObject *>() );
 	}
 
-	///
-	/// \brief selectRegionFromPixels
-	/// \param x
-	/// \param y
-	/// Use the rubber band to select TCO from all tracks using x, y pixels
-	void selectRegionFromPixels(int x, int y)
-	{
-		m_rubberBand->setEnabled( true );
-		m_rubberBand->show();
-		m_rubberBand->setGeometry( min( x, y ), 0, max( x, y ) - min( x, y ), std::numeric_limits<int>::max() );
-	}
-
-	///
-	/// \brief stopRubberBand
-	/// Removes the rubber band from display when finished with.
-	void stopRubberBand()
-	{
-		m_rubberBand->hide();
-		m_rubberBand->setEnabled( false );
-	}
 
 	TrackContainer* model()
 	{
@@ -146,6 +126,17 @@ public slots:
 
 	virtual void dropEvent( QDropEvent * _de );
 	virtual void dragEnterEvent( QDragEnterEvent * _dee );
+	///
+	/// \brief selectRegionFromPixels
+	/// \param x
+	/// \param y
+	/// Use the rubber band to select TCO from all tracks using x, y pixels
+	void selectRegionFromPixels(int x, int y);
+
+	///
+	/// \brief stopRubberBand
+	/// Removes the rubber band from display when finished with.
+	void stopRubberBand();
 
 protected:
 	static const int DEFAULT_PIXELS_PER_TACT = 16;

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -106,7 +106,6 @@ TimeLineWidget::TimeLineWidget( const int _xoff, const int _yoff, const float _p
 	connect( update_timer, SIGNAL( timeout() ),
 					this, SLOT( updatePosition() ) );
 	update_timer->start( 50 );
-	m_songEditor = dynamic_cast<SongEditor*>(_parent);
 }
 
 
@@ -294,7 +293,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 			m_moveXOff = s_posMarkerPixmap->width() / 2;
 		}
 	}
-	else if( event->button() == Qt::LeftButton  && (event->modifiers() & Qt::ShiftModifier) && m_songEditor )
+	else if( event->button() == Qt::LeftButton  && (event->modifiers() & Qt::ShiftModifier) )
 	{
 		m_action = SelectSongTCO;
 		m_initalXSelect = event->x();
@@ -381,10 +380,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 			break;
 		}
 	case SelectSongTCO:
-		if( m_songEditor )
-		{
-			m_songEditor->selectRegionFromPixels( m_initalXSelect , event->x() );
-		}
+			emit regionSelectedFromPixels( m_initalXSelect , event->x() );
 		break;
 
 		default:
@@ -399,7 +395,7 @@ void TimeLineWidget::mouseReleaseEvent( QMouseEvent* event )
 {
 	delete m_hint;
 	m_hint = NULL;
-	if(m_action == SelectSongTCO && m_songEditor ) { m_songEditor->stopRubberBand(); }
+	if ( m_action == SelectSongTCO ) { emit selectionFinished(); }
 	m_action = NoAction;
 }
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -39,6 +39,7 @@
 #include "NStateButton.h"
 #include "GuiApplication.h"
 #include "TextFloat.h"
+#include "SongEditor.h"
 
 
 #if QT_VERSION < 0x040800
@@ -105,6 +106,7 @@ TimeLineWidget::TimeLineWidget( const int _xoff, const int _yoff, const float _p
 	connect( update_timer, SIGNAL( timeout() ),
 					this, SLOT( updatePosition() ) );
 	update_timer->start( 50 );
+	m_songEditor = dynamic_cast<SongEditor*>(_parent);
 }
 
 
@@ -280,7 +282,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	{
 		return;
 	}
-	if( event->button() == Qt::LeftButton )
+	if( event->button() == Qt::LeftButton  && !(event->modifiers() & Qt::ShiftModifier) )
 	{
 		m_action = MovePositionMarker;
 		if( event->x() - m_xOffset < s_posMarkerPixmap->width() )
@@ -291,6 +293,11 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 		{
 			m_moveXOff = s_posMarkerPixmap->width() / 2;
 		}
+	}
+	else if( event->button() == Qt::LeftButton  && (event->modifiers() & Qt::ShiftModifier) && m_songEditor )
+	{
+		m_action = SelectSongTCO;
+		m_initalXSelect = event->x();
 	}
 	else if( event->button() == Qt::RightButton || event->button() == Qt::MiddleButton )
 	{
@@ -373,6 +380,12 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 			update();
 			break;
 		}
+	case SelectSongTCO:
+		if( m_songEditor )
+		{
+			m_songEditor->selectRegionFromPixels( m_initalXSelect , event->x() );
+		}
+		break;
 
 		default:
 			break;
@@ -386,6 +399,7 @@ void TimeLineWidget::mouseReleaseEvent( QMouseEvent* event )
 {
 	delete m_hint;
 	m_hint = NULL;
+	if(m_action == SelectSongTCO && m_songEditor ) { m_songEditor->stopRubberBand(); }
 	m_action = NoAction;
 }
 

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -313,6 +313,19 @@ void TrackContainerView::dragEnterEvent( QDragEnterEvent * _dee )
 						arg( Track::SampleTrack ) );
 }
 
+void TrackContainerView::selectRegionFromPixels(int x, int y)
+{
+	m_rubberBand->setEnabled( true );
+	m_rubberBand->show();
+	m_rubberBand->setGeometry( min( x, y ), 0, max( x, y ) - min( x, y ), std::numeric_limits<int>::max() );
+}
+
+void TrackContainerView::stopRubberBand()
+{
+	m_rubberBand->hide();
+	m_rubberBand->setEnabled( false );
+}
+
 
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -98,6 +98,10 @@ SongEditor::SongEditor( Song * _song ) :
 			SLOT( updatePosition( const MidiTime & ) ) );
 	connect( m_timeLine, SIGNAL( positionChanged( const MidiTime & ) ),
 			this, SLOT( updatePosition( const MidiTime & ) ) );
+	connect( m_timeLine, SIGNAL( regionSelectedFromPixels( int, int ) ),
+			this, SLOT( selectRegionFromPixels( int, int ) ) );
+	connect( m_timeLine, SIGNAL( selectionFinished() ),
+			 this, SLOT( stopRubberBand() ) );
 
 	m_positionLine = new positionLine( this );
 


### PR DESCRIPTION
Proposed for issue #821 Range-select in Song Editor
The TimeLine widget checks to see if's parent is a SongEditor. if so Shift Click can be used on the time line to select all TCO in the time range.

I used the current TrackContainerView's rubber band to ensure consistency for selection code. 
Added 2 functions to TrackContainerView, 
  selectRegionFromPixels, the sets the rubberband using the x,y pixels
  StopRubberBand, that is used to remover the rubberband an mouseRelease