### PR TITLE
Fix SongEditorWindow resize when a project loads

### DIFF
--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -66,8 +66,8 @@ public:
 	SongEditor( Song * _song );
 	~SongEditor();
 
-	void saveSettings(QDomDocument& doc, QDomElement& element);
-	void loadSettings(QDomElement& element);
+	void saveSettings( QDomDocument& doc, QDomElement& element );
+	void loadSettings( const QDomElement& element );
 
 public slots:
 	void scrolled( int _new_pos );

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -259,12 +259,12 @@ SongEditor::~SongEditor()
 {
 }
 
-void SongEditor::saveSettings(QDomDocument& doc, QDomElement& element)
+void SongEditor::saveSettings( QDomDocument& doc, QDomElement& element )
 {
 	MainWindow::saveWidgetState(parentWidget(), element);
 }
 
-void SongEditor::loadSettings(QDomElement& element)
+void SongEditor::loadSettings( const QDomElement& element )
 {
 	MainWindow::restoreWidgetState(parentWidget(), element);
 }


### PR DESCRIPTION
This addresses the SongEditor part of issue #1621 