### PR TITLE
Fix beat pattern actions on melodies

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -761,12 +761,16 @@ void PatternView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "edit_rename" ),
 						tr( "Change name" ),
 						this, SLOT( changeName() ) );
-	_cm->addSeparator();
 
-	_cm->addAction( embed::getIconPixmap( "step_btn_add" ),
-		tr( "Add steps" ), m_pat, SLOT( addSteps() ) );
-	_cm->addAction( embed::getIconPixmap( "step_btn_remove" ),
-		tr( "Remove steps" ), m_pat, SLOT( removeSteps() ) );
+	if ( m_pat->type() == Pattern::BeatPattern )
+	{
+		_cm->addSeparator();
+
+		_cm->addAction( embed::getIconPixmap( "step_btn_add" ),
+			tr( "Add steps" ), m_pat, SLOT( addSteps() ) );
+		_cm->addAction( embed::getIconPixmap( "step_btn_remove" ),
+			tr( "Remove steps" ), m_pat, SLOT( removeSteps() ) );
+	}
 }
 
 


### PR DESCRIPTION
There should be no "Add Steps"/"Remove Steps" actions on melody patterns.

![2015-01-22-171116_1920x1080_scrot](https://cloud.githubusercontent.com/assets/347552/5862709/18cead5a-a25b-11e4-921d-5afb2c84a758.png)
