### PR TITLE
Proposed fix 1685 Automation Copy/Paste from Context Menu

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -49,6 +49,7 @@
 
 #include "AutomationPattern.h"
 #include "AutomationTrack.h"
+#include "AutomationEditor.h"
 #include "BBEditor.h"
 #include "BBTrack.h"
 #include "BBTrackContainer.h"
@@ -207,6 +208,8 @@ void TrackContentObject::paste()
 		restoreState( *( Clipboard::getContent( nodeName() ) ) );
 		movePosition( pos );
 	}
+	AutomationPattern::resolveAllIDs();
+	GuiApplication::instance()->automationEditor()->m_editor->updateAfterPatternChange();
 }
 
 


### PR DESCRIPTION
Proposed fix for #1685 Automation Copy/Paste from Context Menu

Drag and drop was using
```
 AutomationPattern::resolveAllIDs();
```
 so simple copied that to the context menu copy function.


Added 
```
	GuiApplication::instance()->automationEditor()->m_editor->updateAfterPatternChange();
```

to update the editor if it is open on the automation pattern being pasted into.



