### PR TITLE
Renamed parameters on selectRegionFromPixels

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -131,7 +131,7 @@ public slots:
 	/// \param x
 	/// \param y
 	/// Use the rubber band to select TCO from all tracks using x, y pixels
-	void selectRegionFromPixels(int x, int y);
+	void selectRegionFromPixels(int xStart, int xEnd);
 
 	///
 	/// \brief stopRubberBand

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -313,11 +313,11 @@ void TrackContainerView::dragEnterEvent( QDragEnterEvent * _dee )
 						arg( Track::SampleTrack ) );
 }
 
-void TrackContainerView::selectRegionFromPixels(int x, int y)
+void TrackContainerView::selectRegionFromPixels(int xStart, int xEnd)
 {
 	m_rubberBand->setEnabled( true );
 	m_rubberBand->show();
-	m_rubberBand->setGeometry( min( x, y ), 0, max( x, y ) - min( x, y ), std::numeric_limits<int>::max() );
+	m_rubberBand->setGeometry( min( xStart, xEnd ), 0, max( xStart, xEnd ) - min( xStart, xEnd ), std::numeric_limits<int>::max() );
 }
 
 void TrackContainerView::stopRubberBand()


### PR DESCRIPTION
Renamed parameters on selectRegionFromPixels to 

```
void TrackContainerView::selectRegionFromPixels(int xStart, int xEnd)
```
as per discussion in #1674
