### PR TITLE
Fix cloned track position

### DIFF
--- a/include/Track.h
+++ b/include/Track.h
@@ -441,7 +441,7 @@ public:
 	static Track * create( TrackTypes tt, TrackContainer * tc );
 	static Track * create( const QDomElement & element,
 							TrackContainer * tc );
-	void clone();
+	Track * clone();
 
 
 	// pure virtual functions

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -103,6 +103,11 @@ public:
 		return m_tc;
 	}
 
+	const QList<TrackView *> & trackViews() const
+	{
+		return( m_trackViews );
+	}
+
 	void moveTrackView( TrackView * trackView, int indexTo );
 	void moveTrackViewUp( TrackView * trackView );
 	void moveTrackViewDown( TrackView * trackView );
@@ -122,7 +127,7 @@ public:
 
 public slots:
 	void realignTracks();
-	void createTrackView( Track * _t );
+	TrackView * createTrackView( Track * _t );
 	void deleteTrackView( TrackView * _tv );
 
 	virtual void dropEvent( QDropEvent * _de );
@@ -141,11 +146,6 @@ public slots:
 
 protected:
 	static const int DEFAULT_PIXELS_PER_TACT = 16;
-
-	const QList<TrackView *> & trackViews() const
-	{
-		return( m_trackViews );
-	}
 
 	virtual void mousePressEvent( QMouseEvent * _me );
 	virtual void mouseMoveEvent( QMouseEvent * _me );

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -103,8 +103,9 @@ public:
 		return m_tc;
 	}
 
-	void moveTrackViewUp( TrackView * _tv );
-	void moveTrackViewDown( TrackView * _tv );
+	void moveTrackView( TrackView * trackView, int indexTo );
+	void moveTrackViewUp( TrackView * trackView );
+	void moveTrackViewDown( TrackView * trackView );
 
 	// -- for usage by trackView only ---------------
 	TrackView * addTrackView( TrackView * _tv );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1688,13 +1688,18 @@ void TrackOperationsWidget::paintEvent( QPaintEvent * pe )
 
 
 
-
 /*! \brief Clone this track
  *
  */
 void TrackOperationsWidget::cloneTrack()
 {
-	m_trackView->getTrack()->clone();
+	TrackContainerView *tcView = m_trackView->trackContainerView();
+
+	Track *newTrack = m_trackView->getTrack()->clone();
+	TrackView *newTrackView = tcView->createTrackView( newTrack );
+
+	int index = tcView->trackViews().indexOf( m_trackView );
+	tcView->moveTrackView( newTrackView, index + 1 );
 }
 
 
@@ -1904,12 +1909,12 @@ Track * Track::create( const QDomElement & element, TrackContainer * tc )
 /*! \brief Clone a track from this track
  *
  */
-void Track::clone()
+Track * Track::clone()
 {
 	QDomDocument doc;
 	QDomElement parent = doc.createElement( "clone" );
 	saveState( doc, parent );
-	create( parent.firstChild().toElement(), m_trackContainer );
+	return create( parent.firstChild().toElement(), m_trackContainer );
 }
 
 

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -156,45 +156,48 @@ void TrackContainerView::removeTrackView( TrackView * _tv )
 
 
 
-void TrackContainerView::moveTrackViewUp( TrackView * _tv )
+void TrackContainerView::moveTrackView( TrackView * trackView, int indexTo )
 {
-	for( int i = 1; i < m_trackViews.size(); ++i )
-	{
-		TrackView * t = m_trackViews[i];
-		if( t == _tv )
-		{
-			BBTrack::swapBBTracks( t->getTrack(),
-					m_trackViews[i - 1]->getTrack() );
-			m_scrollLayout->removeWidget( t );
-			m_scrollLayout->insertWidget( i - 1, t );
-			qSwap( m_tc->m_tracks[i-1], m_tc->m_tracks[i] );
-			m_trackViews.swap( i - 1, i );
-			realignTracks();
-			break;
-		}
-	}
+	// Can't move out of bounds
+	if ( indexTo >= m_trackViews.size() || indexTo < 0 ) { return; }
+
+	// Does not need to move to itself
+	int indexFrom = m_trackViews.indexOf( trackView );
+	if ( indexFrom == indexTo ) { return; }
+
+	BBTrack::swapBBTracks( trackView->getTrack(),
+			m_trackViews[indexTo]->getTrack() );
+
+	m_scrollLayout->removeWidget( trackView );
+	m_scrollLayout->insertWidget( indexTo, trackView );
+
+	Track * track = m_tc->m_tracks[indexFrom];
+
+	m_tc->m_tracks.remove( indexFrom );
+	m_tc->m_tracks.insert( indexTo, track );
+	m_trackViews.move( indexFrom, indexTo );
+
+	realignTracks();
 }
 
 
 
 
-void TrackContainerView::moveTrackViewDown( TrackView * _tv )
+void TrackContainerView::moveTrackViewUp( TrackView * trackView )
 {
-	for( int i = 0; i < m_trackViews.size()-1; ++i )
-	{
-		TrackView * t = m_trackViews[i];
-		if( t == _tv )
-		{
-			BBTrack::swapBBTracks( t->getTrack(),
-					m_trackViews[i + 1]->getTrack() );
-			m_scrollLayout->removeWidget( t );
-			m_scrollLayout->insertWidget( i + 1, t );
-			qSwap( m_tc->m_tracks[i], m_tc->m_tracks[i+1] );
-			m_trackViews.swap( i, i + 1 );
-			realignTracks();
-			break;
-		}
-	}
+	int index = m_trackViews.indexOf( trackView );
+
+	moveTrackView( trackView, index - 1 );
+}
+
+
+
+
+void TrackContainerView::moveTrackViewDown( TrackView * trackView )
+{
+	int index = m_trackViews.indexOf( trackView );
+
+	moveTrackView( trackView, index + 1 );
 }
 
 

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -222,11 +222,18 @@ void TrackContainerView::realignTracks()
 
 
 
-void TrackContainerView::createTrackView( Track * _t )
+TrackView * TrackContainerView::createTrackView( Track * _t )
 {
 	//m_tc->addJournalCheckPoint();
 
-	_t->createView( this );
+	// Avoid duplicating track views
+	for( trackViewList::iterator it = m_trackViews.begin();
+						it != m_trackViews.end(); ++it )
+	{
+		if ( ( *it )->getTrack() == _t ) { return ( *it ); }
+	}
+
+	return _t->createView( this );
 }
 
 


### PR DESCRIPTION
I provided a solution for the original ask-for-review of this PR, I bypass the signal creating a view myself before or retrieving it.

This is ready for review.

See original thread below:

> I am opening this as a call for help, I really don't know how to work around an architectural problem to be able to fix #170.
> 
> The problem is that when we clone a track we just create another one with the same settings from the original. This would not be a problem if there wasn't the fact that we add a TrackView asynchronously waiting for track creation signals, see: https://github.com/LMMS/lmms/blob/7b5084c53bd4b036ae6a4790c027ecfab625b8a1/src/gui/TrackContainerView.cpp#L87-89 .
> 
> This PR would work if not for this fact, and I am just pushing this so that you can see what I was trying to do. My PR assumes that after `Track::clone()` returns, a TrackView was already created, so I get the last one and put it under the original one, which of course does not happens because the TrackView will only be created later on the event loop.
> 
> This is a very core part of LMMS and I don't know how to solve this, since this would probably require a change on how we create views from tracks or a crazy workaround.
> 
> The only possibility I see right now is to remove the trackAdded signal listening and explicitly adding a TrackView every time a new track gets created, this would increase the amount of boilerplate but would make things explicit. However I am not sure whether this would affect DSP capabilities or not.
> 
> Any ideas @Lukas-W @diizy @curlymorphic ?