### PR TITLE
Fix crash when removing channels

### DIFF
--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -113,6 +113,9 @@ private slots:
 	void updateFaders();
 	void toggledSolo();
 
+	// Remove the real mixer channel
+	void deleteMixerChannel(int index);
+
 private:
 
 	QVector<FxChannelView *> m_fxChannelViews;
@@ -128,6 +131,11 @@ private:
 	void updateMaxChannelSelector();
 	
 	friend class FxChannelView;
+
+signals:
+	// Signal to schedule channel removal through deleteMixerChannel
+	void deletedChannel(int index);
+
 } ;
 
 #endif


### PR DESCRIPTION
Sometimes the application could crash when deleting a channel because it
would still be used when the method returned.

This commit makes the channel be deleted only after the stack returns to
the event loop.

Fixes #1679 