### PR TITLE
Fix crash when removing last channel

### DIFF
--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -529,7 +529,10 @@ FloatModel * FxMixer::channelSendModel( fx_ch_t fromChannel, fx_ch_t toChannel )
 
 void FxMixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
 {
-	if( m_fxChannels[_ch]->m_muteModel.value() == false )
+	// The first check is for the case where the last fxchannel was deleted but
+	// there was a race condition where it had to be processed.
+	if( _ch < m_fxChannels.size() &&
+			m_fxChannels[_ch]->m_muteModel.value() == false )
 	{
 		m_fxChannels[_ch]->m_lock.lock();
 		MixHelpers::add( m_fxChannels[_ch]->m_buffer, _buf, Engine::mixer()->framesPerPeriod() );


### PR DESCRIPTION
Sometimes the last channel still had processing to do when it got
deleted.

This is a different class of bug than #1707, please take care to not reproduce one when checking for another.

We still have an issue though, we are pushing data to a channel that does not exists and when it's not the last, we'll push it to a different mixer: causing unwanted sounds.

Changing this to a pull model instead of a push would fix this issue completely, see: https://github.com/LMMS/lmms/blob/master/src/core/audio/AudioPort.cpp#L225-226.