### PR TITLE
Proposed fix for #1595 Instrument track activity LED lights when muted.

### DIFF
--- a/include/FadeButton.h
+++ b/include/FadeButton.h
@@ -39,6 +39,7 @@ public:
 					_activated_color, QWidget * _parent );
 
 	virtual ~FadeButton();
+	void setActiveColor( const QColor & activated_color );
 
 
 public slots:

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -225,6 +225,7 @@ protected slots:
 	void updateBaseNote();
 	void updatePitch();
 	void updatePitchRange();
+	void muteHasChanged();
 
 
 private:

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -225,7 +225,6 @@ protected slots:
 	void updateBaseNote();
 	void updatePitch();
 	void updatePitchRange();
-	void muteHasChanged();
 
 
 private:
@@ -321,6 +320,7 @@ private slots:
 	void midiInSelected();
 	void midiOutSelected();
 	void midiConfigChanged();
+	void muteHasChanged();
 
 
 private:

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -320,7 +320,7 @@ private slots:
 	void midiInSelected();
 	void midiOutSelected();
 	void midiConfigChanged();
-	void muteHasChanged();
+	void muteChanged();
 
 
 private:

--- a/src/gui/widgets/FadeButton.cpp
+++ b/src/gui/widgets/FadeButton.cpp
@@ -55,6 +55,11 @@ FadeButton::~FadeButton()
 {
 }
 
+void FadeButton::setActiveColor( const QColor & activated_color )
+{
+	m_activatedColor = activated_color;
+}
+
 
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -554,7 +554,8 @@ void InstrumentTrack::muteHasChanged()
 {
 	if( m_mutedModel.value() )
 	{
-		m_fb->setActiveColor( QColor( 0x282828 ) );
+		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,
+															 QPalette::Highlight ) );
 	} else
 	{
 		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -554,7 +554,7 @@ void InstrumentTrack::muteHasChanged()
 {
 	if( m_mutedModel.value() )
 	{
-		m_fb->setActiveColor( QColor( "red" ) );
+		m_fb->setActiveColor( QColor( 0x282828 ) );
 	} else
 	{
 		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -124,7 +124,6 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 	connect( &m_baseNoteModel, SIGNAL( dataChanged() ), this, SLOT( updateBaseNote() ) );
 	connect( &m_pitchModel, SIGNAL( dataChanged() ), this, SLOT( updatePitch() ) );
 	connect( &m_pitchRangeModel, SIGNAL( dataChanged() ), this, SLOT( updatePitchRange() ) );
-	connect( &m_mutedModel, SIGNAL( dataChanged() ), this, SLOT( muteHasChanged() ) );
 
 	m_effectChannelModel.setRange( 0, Engine::fxMixer()->numChannels()-1, 1);
 
@@ -550,20 +549,6 @@ void InstrumentTrack::updatePitchRange()
 	processOutEvent( MidiEvent( MidiControlChange, midiPort()->realOutputChannel(), MidiControllerDataEntry, midiPitchRange() ) );
 }
 
-void InstrumentTrack::muteHasChanged()
-{
-	if( m_mutedModel.value() )
-	{
-		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,
-															 QPalette::Highlight ) );
-	} else
-	{
-		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,
-															 QPalette::BrightText ) );
-	}
-
-}
-
 
 
 
@@ -941,6 +926,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	connect( m_activityIndicator, SIGNAL( released() ),
 				this, SLOT( activityIndicatorReleased() ) );
 	_it->setIndicator( m_activityIndicator );
+	connect( &_it->m_mutedModel, SIGNAL( dataChanged() ), this, SLOT( muteHasChanged() ) );
 
 	setModel( _it );
 }
@@ -1140,6 +1126,22 @@ void InstrumentTrackView::midiConfigChanged()
 {
 	m_midiInputAction->setChecked( model()->m_midiPort.isReadable() );
 	m_midiOutputAction->setChecked( model()->m_midiPort.isWritable() );
+}
+
+
+
+
+void InstrumentTrackView::muteHasChanged()
+{
+	if(model()->m_mutedModel.value() )
+	{
+		m_activityIndicator->setActiveColor( QApplication::palette().color( QPalette::Active,
+															 QPalette::Highlight ) );
+	} else
+	{
+		m_activityIndicator->setActiveColor( QApplication::palette().color( QPalette::Active,
+															 QPalette::BrightText ) );
+	}
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -124,6 +124,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 	connect( &m_baseNoteModel, SIGNAL( dataChanged() ), this, SLOT( updateBaseNote() ) );
 	connect( &m_pitchModel, SIGNAL( dataChanged() ), this, SLOT( updatePitch() ) );
 	connect( &m_pitchRangeModel, SIGNAL( dataChanged() ), this, SLOT( updatePitchRange() ) );
+	connect( &m_mutedModel, SIGNAL( dataChanged() ), this, SLOT( muteHasChanged() ) );
 
 	m_effectChannelModel.setRange( 0, Engine::fxMixer()->numChannels()-1, 1);
 
@@ -135,6 +136,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 
 
 	setName( tr( "Default preset" ) );
+
 
 }
 
@@ -547,6 +549,19 @@ void InstrumentTrack::updatePitchRange()
 	processOutEvent( MidiEvent( MidiControlChange, midiPort()->realOutputChannel(),
 								MidiControllerRegisteredParameterNumberMSB, ( MidiPitchBendSensitivityRPN >> 8 ) & 0x7F ) );
 	processOutEvent( MidiEvent( MidiControlChange, midiPort()->realOutputChannel(), MidiControllerDataEntry, midiPitchRange() ) );
+}
+
+void InstrumentTrack::muteHasChanged()
+{
+	if( m_mutedModel.value() )
+	{
+		m_fb->setActiveColor( QColor( "red" ) );
+	} else
+	{
+		m_fb->setActiveColor( QApplication::palette().color( QPalette::Active,
+															 QPalette::BrightText ) );
+	}
+
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -137,7 +137,6 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 
 	setName( tr( "Default preset" ) );
 
-
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -926,7 +926,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	connect( m_activityIndicator, SIGNAL( released() ),
 				this, SLOT( activityIndicatorReleased() ) );
 	_it->setIndicator( m_activityIndicator );
-	connect( &_it->m_mutedModel, SIGNAL( dataChanged() ), this, SLOT( muteHasChanged() ) );
+	connect( &_it->m_mutedModel, SIGNAL( dataChanged() ), this, SLOT( muteChanged() ) );
 
 	setModel( _it );
 }
@@ -1131,7 +1131,7 @@ void InstrumentTrackView::midiConfigChanged()
 
 
 
-void InstrumentTrackView::muteHasChanged()
+void InstrumentTrackView::muteChanged()
 {
 	if(model()->m_mutedModel.value() )
 	{


### PR DESCRIPTION
Proposed fix for #1595 Instrument track activity LED lights when muted.

The issue mentioned using blue to show muted, I chose to use red, because it keeps inline with the rest of the lmms gui. 