### PR TITLE
Proposed fix for 1692 Missing CLI option for rendering

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -298,8 +298,8 @@ int main( int argc, char * * argv )
 			++i;
 		}
 		else if ( argc > i &&
-				  ( QString( argv[i] ) =="--float") ||
-						QString( argv[i] ) == "-32" )
+				  ( QString( argv[i] ) =="--float" ||
+						QString( argv[i] ) == "-32" ) )
 		{
 			os.depth = ProjectRenderer::Depth_32Bit;
 		}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -191,6 +191,7 @@ int main( int argc, char * * argv )
 	"-x, --oversampling <value>	specify oversampling\n"
 	"				possible values: 1, 2, 4, 8\n"
 	"				default: 2\n"
+	"-32, --float			32bit float bit depth\n"
 	"-u, --upgrade <in> [out]	upgrade file <in> and save as <out>\n"
 	"       standard out is used if no output file is specifed\n"
 	"-d, --dump <in>			dump XML of compressed file <in>\n"
@@ -295,6 +296,12 @@ int main( int argc, char * * argv )
 				return( EXIT_FAILURE );
 			}
 			++i;
+		}
+		else if ( argc > i &&
+				  ( QString( argv[i] ) =="--float") ||
+						QString( argv[i] ) == "-32" )
+		{
+			os.depth = ProjectRenderer::Depth_32Bit;
 		}
 		else if( argc > i &&
 				( QString( argv[i] ) == "--interpolation" ||

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -191,7 +191,7 @@ int main( int argc, char * * argv )
 	"-x, --oversampling <value>	specify oversampling\n"
 	"				possible values: 1, 2, 4, 8\n"
 	"				default: 2\n"
-	"-32, --float			32bit float bit depth\n"
+	"-a, --float			32bit float bit depth\n"
 	"-u, --upgrade <in> [out]	upgrade file <in> and save as <out>\n"
 	"       standard out is used if no output file is specifed\n"
 	"-d, --dump <in>			dump XML of compressed file <in>\n"
@@ -299,7 +299,7 @@ int main( int argc, char * * argv )
 		}
 		else if ( argc > i &&
 				  ( QString( argv[i] ) =="--float" ||
-						QString( argv[i] ) == "-32" ) )
+						QString( argv[i] ) == "-a" ) )
 		{
 			os.depth = ProjectRenderer::Depth_32Bit;
 		}


### PR DESCRIPTION
Proposed fix for #1692 Missing CLI option for rendering

add -32 and --float  as command line options, to enable 32 bit float rendering.
added description to --help text.