### PR TITLE
Change Shift+Resize selected notes on Piano Roll

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -231,7 +231,7 @@ private:
 	inline int noteEditRight() const;
 	inline int noteEditLeft() const;
 
-	void dragNotes( int x, int y, bool alt, bool shift );
+	void dragNotes( int x, int y, bool alt, bool shift, bool ctrl );
 
 	static const int cm_scrollAmtHoriz = 10;
 	static const int cm_scrollAmtVert = 1;


### PR DESCRIPTION
Selected notes: when resized would offset posterior, non-selected notes
to mantain some kind of melodic structure. This is referred to
as *sticky* behaviour.

It also assumes some kind of intention that may not be the case and
adds complexity to a simple feature.

This commit makes only the the selected notes be offset. It also adds a
new shortcut to the old behaviour `<Shift-Ctrl-drag to the note tip>`.

Fixes #1666 

@Sti2nd @tresf Can you help me figure out how we can document this new shortcut addition?