### PR TITLE
Remove the file extensions from the translations in the saveAsDialog

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -3557,6 +3557,14 @@ Per favor, visita http://lmms.sf.net/wiki per a documentació sobre LMMS.</trans
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>My Projects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -3557,6 +3557,14 @@ Navštivte prosím stránku s dokumentací k LMMS na adrese http://lmms.sf.net/w
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>My Projects</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3574,12 +3574,12 @@ Bitte besuchen Sie http://lmms.sf.net/wiki für Dokumentationen über LMMS.</tra
         <translation>LMMS Projekt (*.mmpz *.mmp);;LMMS Projektvorlage (*.mpt)</translation>
     </message>
     <message>
-        <source>LMMS Project </source>
-        <translation>LMMS Projekt </translation>
+		<source>LMMS Project</source>
+		<translation>LMMS Projekt</translation>
     </message>
     <message>
-        <source>LMMS Project Template </source>
-        <translation>LMMS Projektvorlage </translation>
+		<source>LMMS Project Template</source>
+		<translation>LMMS Projektvorlage</translation>
     </message>
     <message>
         <source>Volumes</source>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3574,6 +3574,14 @@ Bitte besuchen Sie http://lmms.sf.net/wiki für Dokumentationen über LMMS.</tra
         <translation>LMMS Projekt (*.mmpz *.mmp);;LMMS Projektvorlage (*.mpt)</translation>
     </message>
     <message>
+        <source>LMMS Project </source>
+        <translation>LMMS Projekt </translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
+        <translation>LMMS Projektvorlage </translation>
+    </message>
+    <message>
         <source>Volumes</source>
         <translation>Volumes</translation>
     </message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -3550,7 +3550,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -3550,7 +3550,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -3550,7 +3550,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -3566,7 +3566,11 @@ Veuillez visiter http://lmms.sf.net/wiki pour la documentation de LMMS.</transla
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -3566,7 +3566,11 @@ Visitehttp://lmms.sf.net/wiki para documentación sobre o LMMS.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3574,11 +3574,11 @@ Visitare http://lmms.sf.net/wiki  per la documentazione di LMMS.</translation>
         <translation>Rifai</translation>
     </message>
     <message>
-        <source>LMMS Project </source>
+		<source>LMMS Project</source>
         <translation>Progetto LMMS</translation>
     </message>
     <message>
-        <source>LMMS Project Template </source>
+		<source>LMMS Project Template</source>
         <translation>Progetto Template LMMS</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3574,8 +3574,12 @@ Visitare http://lmms.sf.net/wiki  per la documentazione di LMMS.</translation>
         <translation>Rifai</translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
-        <translation>Progetto LMMS (*mmpz *.mmp);;Progetto Template LMMS (*.mpt)</translation>
+        <source>LMMS Project </source>
+        <translation>Progetto LMMS</translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
+        <translation>Progetto Template LMMS</translation>
     </message>
     <message>
         <source>My Projects</source>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3569,7 +3569,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -3551,7 +3551,11 @@ LMMS 문서는 http://lmms.sf.net/wiki를 방문하세요.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -3550,7 +3550,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3571,7 +3571,11 @@ Odwiedź witrynę http://lmms.sf.net/wiki for documentation on LMMS.</translatio
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -3569,7 +3569,11 @@ Por favor certifique-se que você tem permissão de escrita para este arquivo e 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -3597,7 +3597,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>Возврат действия</translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -3550,7 +3550,11 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
+        <source>LMMS Project </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -3557,12 +3557,12 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>重做</translation>
     </message>
     <message>
-        <source>LMMS Project </source>
+		<source>LMMS Project</source>
         <translation>LMMS 工程</translation>
     </message>
     <message>
-        <source>LMMS Project Template </source>
-        <translation>LMMS 工程模板 </translation>
+		<source>LMMS Project Template</source>
+		<translation>LMMS 工程模板</translation>
     </message>
     <message>
         <source>Volumes</source>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -3557,8 +3557,12 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>重做</translation>
     </message>
     <message>
-        <source>LMMS Project (*.mmpz *.mmp);;LMMS Project Template (*.mpt)</source>
-        <translation>LMMS 工程 (*.mmpz *.mmp);;LMMS 工程模板 (*.mpt)</translation>
+        <source>LMMS Project </source>
+        <translation>LMMS 工程</translation>
+    </message>
+    <message>
+        <source>LMMS Project Template </source>
+        <translation>LMMS 工程模板 </translation>
     </message>
     <message>
         <source>Volumes</source>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -828,8 +828,8 @@ bool MainWindow::saveProject()
 bool MainWindow::saveProjectAs()
 {
 	VersionedSaveDialog sfd( this, tr( "Save Project" ), "",
-			tr( "LMMS Project " ) + "(*.mmpz *.mmp);;" +
-				tr( "LMMS Project Template " ) + "(*.mpt)" );
+			tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
+				tr( "LMMS Project Template" ) + " (*.mpt)" );
 	QString f = Engine::getSong()->projectFileName();
 	if( f != "" )
 	{

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -828,8 +828,8 @@ bool MainWindow::saveProject()
 bool MainWindow::saveProjectAs()
 {
 	VersionedSaveDialog sfd( this, tr( "Save Project" ), "",
-			tr( "LMMS Project (*.mmpz *.mmp);;"
-				"LMMS Project Template (*.mpt)" ) );
+			tr( "LMMS Project " ) + "(*.mmpz *.mmp);;" +
+				tr( "LMMS Project Template " ) + "(*.mpt)" );
 	QString f = Engine::getSong()->projectFileName();
 	if( f != "" )
 	{


### PR DESCRIPTION
Moved the file extensions outside the translations, as per a discussion in #1709.