### PR TITLE
Changed the Song Editor time position line to correctly draw from under the timeline widget

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -579,7 +579,7 @@ void SongEditor::updatePosition( const MidiTime & _t )
 	if( x >= trackOpWidth + widgetWidth -1 )
 	{
 		m_positionLine->show();
-		m_positionLine->move( x, 50 );
+		m_positionLine->move( x, m_timeLine->height() );
 	}
 	else
 	{


### PR DESCRIPTION
fixes #1724 

Used the height of the timeline widget instead of the value of 50.