### PR TITLE
1.1-based RT-safe fix for race condition causing #1662

### DIFF
--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -98,8 +98,8 @@ inline void FxChannel::processed()
 
 void FxChannel::incrementDeps()
 {
-	m_dependenciesMet.ref();
-	if( m_dependenciesMet >= m_receives.size() && ! m_queued )
+	int i = m_dependenciesMet.fetchAndAddOrdered( 1 ) + 1;
+	if( i >= m_receives.size() && ! m_queued )
 	{
 		m_queued = true;
 		MixerWorkerThread::addJob( this );


### PR DESCRIPTION
I couldn't find a way to rebase my [existing pull request](https://github.com/LMMS/lmms/pull/1745), so here's another one, this time against stable-1.1. Tested and works for me.  Original description:

Ok, I fixed things the atomic way. By setting and reading `m_dependenciesMet` simultaneously atomically, the race condition is eliminated without adding a lock. It even gives me less clicks and pops than the lock fix I proposed earlier :) #1662