### PR TITLE
Remove semaphores from JACK backend

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -97,8 +97,6 @@ private:
 	bool m_active;
 	bool m_stopped;
 
-	QSemaphore m_stopSemaphore;
-
 	QVector<jack_port_t *> m_outputPorts;
 	jack_default_audio_sample_t * * m_tempOutBufs;
 	surroundSampleFrame * m_outBuf;


### PR DESCRIPTION
Seemed useless and only caused blocking, which resulted in audible artifacts and xruns when opening projects for example.