### PR TITLE
Delay the deleting of a track view until the next event loop, this stops...

### DIFF
--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -237,7 +237,7 @@ void TrackContainerView::deleteTrackView( TrackView * _tv )
 	removeTrackView( _tv );
 	delete _tv;
 
-	delete t;
+	t->deleteLater();
 }
 
 


### PR DESCRIPTION
Delay the deleting of a track view until the next event loop, this stops the segfault when deleting BB tracks during playback.

fixes #1683 