### PR TITLE
Stop quantizing copied notes, leaving them at there original timings.

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1535,7 +1535,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 							//put notes from vector into piano roll
 							for( int i = 0; i < newNotes.size(); ++i)
 							{
-								Note * newNote = m_pattern->addNote( newNotes[i] );
+								Note * newNote = m_pattern->addNote( newNotes[i], false );
 								newNote->setSelected( false );
 							}
 


### PR DESCRIPTION
 Notes that were quantised remain so.

fixes #1720 

simply set the ````_quant_pos```` parameter of ````Pattern::addNote()```` to false so copied notes remain at the original location.

![image](https://cloud.githubusercontent.com/assets/7412852/6286503/037ce51e-b900-11e4-9abe-8e242ca97260.png)

