### PR TITLE
Double clicking in BBEditor nolonger changes pattern

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -31,10 +31,12 @@
 #include <QDialog>
 #include <QtCore/QThread>
 #include <QPixmap>
+#include <QTime>
 
 
 #include "Note.h"
 #include "Track.h"
+#include "ProjectJournal.h"
 
 
 class QAction;
@@ -199,6 +201,7 @@ private:
 	Pattern* m_pat;
 	QPixmap m_paintPixmap;
 	bool m_needsUpdate;
+	QTime m_lastClickChange;
 } ;
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -653,6 +653,7 @@ PatternView::PatternView( Pattern* pattern, TrackView* parent ) :
 	m_paintPixmap(),
 	m_needsUpdate( true )
 {
+	m_lastClickChange = QTime::currentTime();
 	connect( gui->pianoRoll(), SIGNAL( currentPatternChanged() ),
 			this, SLOT( update() ) );
 
@@ -789,6 +790,10 @@ void PatternView::mouseDoubleClickEvent( QMouseEvent * _me )
 	  			m_pat->m_steps != MidiTime::stepsPerTact() ) &&
 		_me->y() > height() - s_stepBtnOff->height() ) )
 	{
+		if( m_lastClickChange.msecsTo( QTime::currentTime() ) < QApplication::doubleClickInterval() )
+		{
+			Engine::projectJournal()->undo();
+		}
 		openInPianoRoll();
 	}
 }
@@ -839,6 +844,7 @@ void PatternView::mousePressEvent( QMouseEvent * _me )
 		else // note at step found
 		{
 			m_pat->addJournalCheckPoint();
+			m_lastClickChange = QTime::currentTime();
 			if( n->length() < 0 )
 			{
 				n->setLength( 0 );	// set note as enabled beat note


### PR DESCRIPTION
fixes #1682 

In the BBEditor, When changes are made to the pattern by clicking, the current time is saved. On double click we now check if the last change was within ````QApplication::doubleClickInterval() ```` and if so undo before opening the piano roll.

This stops notes erroneously being entered or removed on double click.