### PR TITLE
Removed Double click to open piano roll, in the BBeditor,

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -179,7 +179,6 @@ protected slots:
 
 protected:
 	virtual void constructContextMenu( QMenu * );
-	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 	virtual void mousePressEvent( QMouseEvent * _me );
 	virtual void paintEvent( QPaintEvent * _pe );
 	virtual void resizeEvent( QResizeEvent * _re )

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -776,26 +776,6 @@ void PatternView::constructContextMenu( QMenu * _cm )
 
 
 
-void PatternView::mouseDoubleClickEvent( QMouseEvent * _me )
-{
-	if( _me->button() != Qt::LeftButton )
-	{
-		_me->ignore();
-		return;
-	}
-	if( m_pat->type() == Pattern::MelodyPattern ||
-		!( m_pat->type() == Pattern::BeatPattern &&
-		( pixelsPerTact() >= 192 ||
-	  			m_pat->m_steps != MidiTime::stepsPerTact() ) &&
-		_me->y() > height() - s_stepBtnOff->height() ) )
-	{
-		openInPianoRoll();
-	}
-}
-
-
-
-
 void PatternView::mousePressEvent( QMouseEvent * _me )
 {
 	if( _me->button() == Qt::LeftButton &&


### PR DESCRIPTION
Removed Double click to open piano roll, in the BBeditor, this is to stop notes being added in error

fixes #1682

replaces #1776 