### PR TITLE
Extend the creation of default lmms folder, and default template.

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -41,6 +41,7 @@ class Engine;
 
 
 const QString PROJECTS_PATH = "projects/";
+const QString TEMPLATE_PATH = "templates/";
 const QString PRESETS_PATH = "presets/";
 const QString SAMPLES_PATH = "samples/";
 const QString DEFAULT_THEME_PATH = "themes/default/";

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -77,6 +77,11 @@ public:
 		return workingDir() + PROJECTS_PATH;
 	}
 
+	QString userTemplateDir() const
+	{
+		return workingDir() + TEMPLATE_PATH;
+	}
+
 	QString userPresetsDir() const
 	{
 		return workingDir() + PRESETS_PATH;

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -423,7 +423,7 @@ void ConfigManager::loadConfigFile()
 	if( QDir( m_workingDir ).exists() )
 	{
 		QDir().mkpath( userProjectsDir() );
-		QDir().mkpath( userProjectsDir() + TEMPLATE_PATH );
+		QDir().mkpath( userTemplateDir() );
 		QDir().mkpath( userSamplesDir() );
 		QDir().mkpath( userPresetsDir() );
 	}

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -423,6 +423,7 @@ void ConfigManager::loadConfigFile()
 	if( QDir( m_workingDir ).exists() )
 	{
 		QDir().mkpath( userProjectsDir() );
+		QDir().mkpath( userProjectsDir() + TEMPLATE_PATH );
 		QDir().mkpath( userSamplesDir() );
 		QDir().mkpath( userPresetsDir() );
 	}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -847,8 +847,10 @@ void Song::clearProject()
 // create new file
 void Song::createNewProject()
 {
-	QString defaultTemplate = ConfigManager::inst()->userProjectsDir()
-						+ "templates/default.mpt";
+
+	QString defaultTemplate = ConfigManager::inst()->userTemplateDir()
+						+ "default.mpt";
+
 
 	if( QFile::exists( defaultTemplate ) )
 	{

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -738,6 +738,15 @@ void MainWindow::createNewProject()
 	{
 		Engine::getSong()->createNewProject();
 	}
+	QString default_template = ConfigManager::inst()->userProjectsDir()
+						+ "templates/default.mpt";
+
+	//if we dont have a user default template, make one
+	if( !QFile::exists( default_template ) )
+	{
+		Engine::getSong()->saveProjectFile( ConfigManager::inst()->userProjectsDir()
+						 + "templates/default.mpt" );
+	}
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -738,14 +738,13 @@ void MainWindow::createNewProject()
 	{
 		Engine::getSong()->createNewProject();
 	}
-	QString default_template = ConfigManager::inst()->userProjectsDir()
-						+ "templates/default.mpt";
+	QString default_template = ConfigManager::inst()->userTemplateDir()
+						+ "default.mpt";
 
 	//if we dont have a user default template, make one
 	if( !QFile::exists( default_template ) )
 	{
-		Engine::getSong()->saveProjectFile( ConfigManager::inst()->userProjectsDir()
-						 + "templates/default.mpt" );
+		Engine::getSong()->saveProjectFile( default_template );
 	}
 }
 


### PR DESCRIPTION
Added the following folders to the users lmms folder

- templates
- themes
- plugin
- plugin/vst
- plugin/ladspa
- plugin/gig

If no default project template is found, one is saved upon creation. This allows users to delete there default template to return to factory settings

fixes #1702 
