### PR TITLE
Reinstate Double Click opening the piano roll from song editor

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -180,6 +180,7 @@ protected slots:
 protected:
 	virtual void constructContextMenu( QMenu * );
 	virtual void mousePressEvent( QMouseEvent * _me );
+	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 	virtual void paintEvent( QPaintEvent * _pe );
 	virtual void resizeEvent( QResizeEvent * _re )
 	{

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -846,6 +846,19 @@ void PatternView::mousePressEvent( QMouseEvent * _me )
 	}
 }
 
+void PatternView::mouseDoubleClickEvent(QMouseEvent *_me)
+{
+	if( _me->button() != Qt::LeftButton )
+	{
+		_me->ignore();
+		return;
+	}
+	if( !fixedTCOs() )
+	{
+		openInPianoRoll();
+	}
+}
+
 
 
 


### PR DESCRIPTION
This fixes a bug introduced when removing double click from
BB patterns. It Now checks if we use fixedTCO's (bb tomb stones),
only disable double clikc if so, leaving it working correcly in the
song editor

fixes bug introduced in #1783 