### PR TITLE
Fixed bug where cross hairs were incorrectly draw in Automation Editor

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1314,8 +1314,9 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		m_leftRightScroll->setPageStep( l );
 	}
 
-	if( validPattern() )
+	if( validPattern() && GuiApplication::instance()->automationEditor()->hasFocus() )
 	{
+
 		drawCross( p );
 	}
 


### PR DESCRIPTION
The cross hairs in the automation editor were incorrectly drawn
when moving another window infront.
This change only draws the cross hairs when the window has focus.

fixes #1052 