### PR TITLE
Fix piano roll select and move issue

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -862,6 +862,8 @@ void PianoRoll::shiftPos( int amount ) //shift notes pos by amount
 		}
 	}
 
+	m_pattern->rearrangeAllNotes();
+
 	// we modified the song
 	update();
 	gui->songEditor()->update();


### PR DESCRIPTION
After hours doing uncountable tests, I finally found that issue #1818 can be fixed by simply calling `m_pattern->rearrangeAllNotes()` near the end of `PianoRoll::shiftPos()`.