### PR TITLE
Added toggle for smooth scrolling in song editor to view menu

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1079,13 +1079,12 @@ void MainWindow::updateViewMenu()
 	*/
 
 	// Should be doable.
-	/* qa = new QAction(tr( "Smooth scroll" ), this);
+	qa = new QAction(tr( "Smooth scroll" ), this);
 	qa->setData("smoothscroll");
 	qa->setCheckable( true );
 	qa->setChecked( ConfigManager::inst()->value( "ui", "smoothscroll" ).
 			toInt() ? true : false );
 	m_viewMenu->addAction(qa);
-	*/
 
 	// Not yet.
 	/* qa = new QAction(tr( "One instrument track window" ), this);

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -555,6 +555,7 @@ void SongEditor::updatePosition( const MidiTime & _t )
 		  && m_timeLine->autoScroll() == TimeLineWidget::AutoScrollEnabled) ||
 							m_scrollBack == true )
 	{
+		m_smoothScroll = ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt();
 		const int w = width() - widgetWidth
 							- trackOpWidth
 							- contentWidget()->verticalScrollBar()->width(); // width of right scrollbar


### PR DESCRIPTION
Smooth scrolling in the song editor seems to work fine with turning on and off while running, and so it can appear in the view menu.