### PR TITLE
Fix song editor pattern view update bug

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -863,6 +863,7 @@ void PianoRoll::shiftPos( int amount ) //shift notes pos by amount
 	}
 
 	m_pattern->rearrangeAllNotes();
+	m_pattern->dataChanged();
 
 	// we modified the song
 	update();


### PR DESCRIPTION
After fixing #1818 thanks to pull request #1855, there was still a bug left: moving a selection with Shift+Left/Right Arrow in the piano roll did not update the pattern view in the song editor. This pull request fixes this bug.