### PR TITLE
Triple Oscillator: crude translations for the CRS knob

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -6156,7 +6156,7 @@ Per favor, assegura&apos;t que tens permís de lectura per al fitxer i el direct
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation type="unfinished">Amb aquesta roda pots ajustar el desafinament gruixut de l&apos;oscil·lador %1. Pots desafinar l&apos;oscil·lador 12 semitons (1 octava) cap a dalt i a baix. Això és útil per a crear sons amb un acord.</translation>
+        <translation type="unfinished">Amb aquesta roda pots ajustar el desafinament gruixut de l&apos;oscil·lador %1. Pots desafinar l&apos;oscil·lador 24 semitons (1 octavaes) cap a dalt i a baix. Això és útil per a crear sons amb un acord.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -6194,7 +6194,7 @@ Bitte stellen Sie sicher, dass Sie Leserechte auf diese Datei sowie das Verzeich
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Mit diesem Regler können Sie die grobe Verstimmung von Oszillator %1 setzen. Sie können den Oszillator 12 Halbtöne (1 Oktave) nach oben und unten verstimmen. Das ist nützlich, wenn Sie einen Sound mit einem Akkord erstellen möchten.</translation>
+        <translation>Mit diesem Regler können Sie die grobe Verstimmung von Oszillator %1 setzen. Sie können den Oszillator 24 Halbtöne (2 Oktaven) nach oben und unten verstimmen. Das ist nützlich, wenn Sie einen Sound mit einem Akkord erstellen möchten.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -6145,7 +6145,7 @@ Please make sure you have read-permission to the file and the directory containi
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation type="unfinished">Con este control usted podrá establecer la desintonización gruesa del oscilador %1. Usted puede desintonizar el oscilador 12 semitonos (1 octava) arriba y abajo. Esto es útil para la creación de sonidos con acorde.</translation>
+        <translation type="unfinished">Con este control usted podrá establecer la desintonización gruesa del oscilador %1. Usted puede desintonizar el oscilador 24 semitonos (2 octavas) arriba y abajo. Esto es útil para la creación de sonidos con acorde.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -6167,7 +6167,7 @@ Veuillez vérifier que vous avez les droits en lecture pour ce fichier et le ré
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Avec ce bouton vous pouvez régler le désaccord grossier de l&apos;oscillateur %1. Vous pouvez désaccorder l&apos;oscillateur de 12 demi-tons (1 octave) vers le haut et vers le bas. Ceci est utile pour la création de sons avec un accord.</translation>
+        <translation>Avec ce bouton vous pouvez régler le désaccord grossier de l&apos;oscillateur %1. Vous pouvez désaccorder l&apos;oscillateur de 24 demi-tons (2 octaves) vers le haut et vers le bas. Ceci est utile pour la création de sons avec un accord.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -6166,7 +6166,7 @@ Asegúrese de ter permiso de lectura sobre o ficheiro e o directorio que o cont�
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Con este botón pódese definir a desafinación bruta do oscilador %1. Pódese desafinar o oscilador 12 semitóns (unha oitava) para arriba e para abaixo. Isto é útil para crear sons cun acorde.</translation>
+        <translation>Con este botón pódese definir a desafinación bruta do oscilador %1. Pódese desafinar o oscilador 24 semitóns (2 oitavas) para arriba e para abaixo. Isto é útil para crear sons cun acorde.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -6149,7 +6149,7 @@ Zorg ervoor dat je schrijf-bevoegdheid hebt voor deze bestanden en mapen en prob
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation type="unfinished">Met deze knop stel je de grove ontstemming van oscillator %1 in. Je kunt de oscillator 12 seminote (1oktaaf) naar boven of beneden ontstemmen.Dit is bruikbaar voor het maken van geluiden met een akkoord.</translation>
+        <translation type="unfinished">Met deze knop stel je de grove ontstemming van oscillator %1 in. Je kunt de oscillator 24 seminote (2 oktaven) naar boven of beneden ontstemmen.Dit is bruikbaar voor het maken van geluiden met een akkoord.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -6172,7 +6172,7 @@ Upewnij się, że masz uprawnienia do odczytu tego pliku i katalogu zawierające
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Za pomocą tego pokrętła możesz ustawić zgrubne odstrojenie oscylatora %1. Możesz odstrajać oscylator o 12 półtonów (całą oktawę) w górę lub w dół.</translation>
+        <translation>Za pomocą tego pokrętła możesz ustawić zgrubne odstrojenie oscylatora %1. Możesz odstrajać oscylator o 24 półtonów (dwie oktawy) w górę lub w dół.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -6122,7 +6122,7 @@ Por favor certifique-se que você tem permissões de leitura para o arquivo e pa
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Com este botão você pode modificar Ajuste bruto do oscilador %1. Você pode descer o tom  do oscilador 12 semitons (1 oitava) para cima e para baixo. Isto é útil para criar sons com um acorde.</translation>
+        <translation>Com este botão você pode modificar Ajuste bruto do oscilador %1. Você pode descer o tom  do oscilador 24 semitons (2 oitavas) para cima e para baixo. Isto é útil para criar sons com um acorde.</translation>
     </message>
     <message>
         <source>Use phase modulation for modulating oscillator 3 with oscillator 2</source>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -6223,7 +6223,7 @@ Please make sure you have read-permission to the file and the directory containi
     </message>
     <message>
         <source>With this knob you can set the coarse detuning of oscillator %1. You can detune the oscillator 24 semitones (2 octaves) up and down. This is useful for creating sounds with a chord.</source>
-        <translation>Грубая регулировка подстройки осциллятора %1. Возможна подстройка до 12 полутонов (до одной октавы) вверх и вниз. Полезно для создания аккордов.</translation>
+        <translation>Грубая регулировка подстройки осциллятора %1. Возможна подстройка до 24 полутонов (до 2 октавы) вверх и вниз. Полезно для создания аккордов.</translation>
     </message>
     <message>
         <source>Osc %1 fine detuning left:</source>


### PR DESCRIPTION
Some of these languages might now have a wrong plural for octaves, but better to have the numbers right and the declinations off than the other way around. 

Didn't touch the line in fa.ts, couldn't even find the numbers.