### PR TITLE
SFXR: Avoid NaNs by making envelope length minimum 1 sample

### DIFF
--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -139,8 +139,9 @@ void SfxrSynth::resetSample( bool restart )
 		env_length[2]=(int)(s->m_decModel.value()*s->m_decModel.value()*100000.0f);
 
 		// These will be used as divisors later, let's avoid division by 0
-		for(int i=0; i<3; ++i) {
-		  env_length[i] = (env_length[i] == 0 ) ? 1 : env_length[i];
+		for(int i = 0; i < 3; ++i) 
+		{
+			env_length[i] = (env_length[i] == 0) ? 1 : env_length[i];
 		}
 
 		fphase=pow(s->m_phaserOffsetModel.value(), 2.0f)*1020.0f;

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -139,7 +139,7 @@ void SfxrSynth::resetSample( bool restart )
 		env_length[2]=(int)(s->m_decModel.value()*s->m_decModel.value()*100000.0f);
 
 		// These will be used as divisors later, let's avoid division by 0
-		for(int i=0; i<=3; ++i) {
+		for(int i=0; i<3; ++i) {
 		  env_length[i] = (env_length[i] == 0 ) ? 1 : env_length[i];
 		}
 

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -133,9 +133,15 @@ void SfxrSynth::resetSample( bool restart )
 		env_vol=0.0f;
 		env_stage=0;
 		env_time=0;
+
 		env_length[0]=(int)(s->m_attModel.value()*s->m_attModel.value()*100000.0f);
 		env_length[1]=(int)(s->m_holdModel.value()*s->m_holdModel.value()*100000.0f);
 		env_length[2]=(int)(s->m_decModel.value()*s->m_decModel.value()*100000.0f);
+
+		// These will be used as divisors later, let's avoid division by 0
+		for(int i=0; i<=3; ++i) {
+		  env_length[i] = (env_length[i] == 0 ) ? 1 : env_length[i];
+		}
 
 		fphase=pow(s->m_phaserOffsetModel.value(), 2.0f)*1020.0f;
 		if(s->m_phaserOffsetModel.value()<0.0f) fphase=-fphase;


### PR DESCRIPTION
The values in the ```env_length``` array are used as divisors, so if they are allowed a range down to 0 the divisions will result in NaN, which propagates through ```env_vol``` all the way to ```ssample```, which is the output. This change might remove some minimal amount of "snap" from the sound, but that would in many cases be the sound of some component not liking NaNs.

This should at least partly fix #1877. I'm not saying SFXR doesn't include other calculations that might lead to NaN.