### PR TITLE
FileBrowser, revert to not loading xiz files into DataFile

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -458,6 +458,10 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 			m_previewPlayHandle = s;
 			delete tf;
 		}
+		else if( f->extension ()== "xiz" && Engine::pluginFileHandling().contains( f->extension() ) )
+		{
+			m_previewPlayHandle = new PresetPreviewPlayHandle( f->fullName(), f->handling() == FileItem::LoadByPlugin );
+		}
 		else if( f->type() != FileItem::VstPluginFile &&
 				( f->handling() == FileItem::LoadAsPreset ||
 				f->handling() == FileItem::LoadByPlugin ) )


### PR DESCRIPTION
xiz files are again, correctly not passed into a DataFile. DataFile is for
LMMS xml files.

During my efforts on #1838 XmlChecker to remove the loading of the data from the PresetPreviewPlayHandler, I missed that fact that xiz files are not passed to DataFile. This pull request rectifies this, and fixes #1880 

This does not address the addition of the enum, thats a seperate issue being continued in #1838

