### PR TITLE
Sf2player, OpulenZ: addPlayHandle moved to end of constructor.

### DIFF
--- a/plugins/opl2/opl2instrument.cpp
+++ b/plugins/opl2/opl2instrument.cpp
@@ -141,9 +141,6 @@ opl2instrument::opl2instrument( InstrumentTrack * _instrument_track ) :
 	vib_depth_mdl(false, this, tr( "Vibrato Depth" )   ),
 	trem_depth_mdl(false, this, tr( "Tremolo Depth" )   )
 {
-	// Connect the plugin to the mixer...
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
-	Engine::mixer()->addPlayHandle( iph );
 
 	// Create an emulator - samplerate, 16 bit, mono
 	emulatorMutex.lock();
@@ -220,6 +217,10 @@ opl2instrument::opl2instrument( InstrumentTrack * _instrument_track ) :
 	MOD_CON( fm_mdl );
 	MOD_CON( vib_depth_mdl );
 	MOD_CON( trem_depth_mdl );
+
+	// Connect the plugin to the mixer...
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	Engine::mixer()->addPlayHandle( iph );
 }
 
 opl2instrument::~opl2instrument() {

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -118,9 +118,6 @@ sf2Instrument::sf2Instrument( InstrumentTrack * _instrument_track ) :
 	// everytime we load a new soundfont.
 	m_synth = new_fluid_synth( m_settings );
 
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
-	Engine::mixer()->addPlayHandle( iph );
-
 	loadFile( ConfigManager::inst()->defaultSoundfont() );
 
 	updateSampleRate();
@@ -152,6 +149,8 @@ sf2Instrument::sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusSpeed, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	Engine::mixer()->addPlayHandle( iph );
 }
 
 


### PR DESCRIPTION
I'm pretty sure it's unwise for a instrument plugin to add its playhandle to the mixer prematurely, it should be more or less the last line in the constructor. This commit fixes that problem for the 2 worst offenders among the instruments.

Especially Sf2player sucked in this regard, doing a lot of of stuff after adding its playhandle to the mixer, see https://github.com/LMMS/lmms/pull/1555#issuecomment-69555602 for a dump where the plugin is still in the middle of its constructor and the mixer is doing its thing to it already...