### PR TITLE
Fix for #1907 - inconsistent clamping behavior in automation editor

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -624,11 +624,6 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 		float level = getLevel( mouseEvent->y() );
 		int x = mouseEvent->x();
 
-		if( mouseEvent->x() <= VALUES_WIDTH )
-		{
-			update();
-			return;
-		}
 		x -= VALUES_WIDTH;
 		if( m_action == MOVE_VALUE )
 		{
@@ -699,12 +694,12 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			{
 				if( QApplication::overrideCursor() )
 				{
-	if( QApplication::overrideCursor()->shape() != Qt::SizeAllCursor )
+					if( QApplication::overrideCursor()->shape() != Qt::SizeAllCursor )
 					{
-				while( QApplication::overrideCursor() != NULL )
-				{
-					QApplication::restoreOverrideCursor();
-				}
+						while( QApplication::overrideCursor() != NULL )
+						{
+							QApplication::restoreOverrideCursor();
+						}
 
 						QCursor c( Qt::SizeAllCursor );
 						QApplication::setOverrideCursor(


### PR DESCRIPTION
The safety check for x < 0 at the topmost level was mostly redundant. The check to make sure we don't move an automation point to some t < 0 is handled on line 640 instead, as well as line 894 for the case where m_editMode == SELECT.

This slightly changes behavior for deleting automation points as well. Previously, it had a similar inconsistency: you could delete points off to the right of the view, but not off to the left. Now you can delete points from both the left and right side. 

I also fixed some inconsistent tab formatting.