### PR TITLE
Provide status messages on splash screen when loading (#1696)

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -27,6 +27,9 @@
 #define ENGINE_H
 
 #include <QtCore/QMap>
+#include <QtCore/QString>
+#include <QtCore/QObject>
+
 
 #include "export.h"
 
@@ -39,8 +42,9 @@ class Song;
 class Ladspa2LMMS;
 
 
-class EXPORT Engine
+class EXPORT Engine : public QObject
 {
+	Q_OBJECT
 public:
 	static void init();
 	static void destroy();
@@ -94,6 +98,18 @@ public:
 		return s_pluginFileHandling;
 	}
 
+	static inline Engine * inst()
+	{
+		if( s_instanceOfMe == NULL )
+		{
+			s_instanceOfMe = new Engine();
+		}
+		return s_instanceOfMe;
+	}
+
+signals:
+	void initProgress(const QString &msg);
+
 
 private:
 	// small helper function which sets the pointer to NULL before actually deleting
@@ -119,6 +135,9 @@ private:
 	static Ladspa2LMMS * s_ladspaManager;
 
 	static QMap<QString, QString> s_pluginFileHandling;
+
+	// even though most methods are static, an instance is needed for Qt slots/signals
+	static Engine * s_instanceOfMe;
 
 	static void initPluginFileHandling();
 

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -25,7 +25,11 @@
 #ifndef GUIAPPLICATION_H
 #define GUIAPPLICATION_H
 
+#include <QtCore/QObject>
+
 #include "export.h"
+
+class QLabel;
 
 class AutomationEditorWindow;
 class BBEditor;
@@ -36,8 +40,9 @@ class PianoRollWindow;
 class ProjectNotes;
 class SongEditorWindow;
 
-class EXPORT GuiApplication
+class EXPORT GuiApplication : public QObject
 {
+	Q_OBJECT;
 public:
 	explicit GuiApplication();
 	~GuiApplication();
@@ -53,6 +58,9 @@ public:
 	AutomationEditorWindow* automationEditor() { return m_automationEditor; }
 	ControllerRackView* getControllerRackView() { return m_controllerRackView; }
 
+public slots:
+	void displayInitProgress(const QString &msg);
+
 private:
 	static GuiApplication* s_instance;
 
@@ -64,6 +72,7 @@ private:
 	PianoRollWindow* m_pianoRoll;
 	ProjectNotes* m_projectNotes;
 	ControllerRackView* m_controllerRackView;
+	QLabel* m_loadingProgressLabel;
 };
 
 #define gui GuiApplication::instance()

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -190,6 +190,7 @@ private slots:
 
 signals:
 	void periodicUpdate();
+	void initProgress(const QString &msg);
 
 } ;
 

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -52,11 +52,16 @@ QMap<QString, QString> Engine::s_pluginFileHandling;
 
 void Engine::init()
 {
+	Engine *engine = inst();
+
+	emit engine->initProgress(tr("Generating wavetables"));
 	// generate (load from file) bandlimited wavetables
 	BandLimitedWave::generateWaves();
 
+	emit engine->initProgress(tr("Locating plugins"));
 	initPluginFileHandling();
 
+	emit engine->initProgress(tr("Initializing data structures"));
 	s_projectJournal = new ProjectJournal;
 	s_mixer = new Mixer;
 	s_song = new Song;
@@ -67,11 +72,13 @@ void Engine::init()
 
 	s_projectJournal->setJournalling( true );
 
+	emit engine->initProgress(tr("Opening audio and midi devices"));
 	s_mixer->initDevices();
 
 	PresetPreviewPlayHandle::init();
 	s_dummyTC = new DummyTrackContainer;
 
+	emit engine->initProgress(tr("Launching mixer threads"));
 	s_mixer->startProcessing();
 }
 
@@ -142,3 +149,4 @@ void Engine::initPluginFileHandling()
 }
 
 
+Engine * Engine::s_instanceOfMe = NULL;

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -108,7 +108,7 @@ GuiApplication::GuiApplication()
 	m_controllerRackView = new ControllerRackView;
 	displayInitProgress(tr("Preparing project notes"));
 	m_projectNotes = new ProjectNotes;
-	displayInitProgress(tr("Preparing beat/baseline editor"));
+	displayInitProgress(tr("Preparing beat/bassline editor"));
 	m_bbEditor = new BBEditor(Engine::getBBTrackContainer());
 	displayInitProgress(tr("Preparing piano roll"));
 	m_pianoRoll = new PianoRollWindow();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -96,7 +96,9 @@ MainWindow::MainWindow() :
 
 	ConfigManager* confMgr = ConfigManager::inst();
 
+	emit initProgress(tr("Preparing plugin browser"));
 	sideBar->appendTab( new PluginBrowser( splitter ) );
+	emit initProgress(tr("Preparing file browsers"));
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userProjectsDir() + "*" +
 				confMgr->factoryProjectsDir(),
@@ -150,6 +152,7 @@ MainWindow::MainWindow() :
 	m_workspace = new QMdiArea( splitter );
 
 	// Load background
+	emit initProgress(tr("Loading background artwork"));
 	QString bgArtwork = ConfigManager::inst()->backgroundArtwork();
 	QImage bgImage;
 	if( !bgArtwork.isEmpty() )


### PR DESCRIPTION
Based on the discussion about #1696, this updates the splash screen to look like this:

![lmms-splash-with-progress](https://cloud.githubusercontent.com/assets/1210751/6960498/8b3e37fa-d912-11e4-9571-cc3791538337.png)

No progress bars or anything, just a discreet status message in the lower-left that updates to reflect the current component being initialized.