### PR TITLE
Model::isValueChanged correctly returns if sample exactness is used.

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -255,7 +255,7 @@ public:
 	// has to be accessed by more than one object, then this function shouldn't be used.
 	bool isValueChanged()
 	{
-		if( m_valueChanged )
+		if( m_valueChanged || valueBuffer() )
 		{
 			m_valueChanged = false;
 			return true;


### PR DESCRIPTION
The introduction of sample exactness introduced a bug, if The value was
changed using sample exactness Model::isValueChanged was incorectly returning
false.

This bug has initially shown its self in the BassBooster plugin.

fixes #1927