### PR TITLE
Removed Duplicate Entries in the File Browser

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -871,8 +871,6 @@ bool Directory::addItems(const QString & path )
 				addChild( new Directory( cur_file, path,
 								m_filter ) );
 				m_dirCount++;
-				//recurse for each dir
-				addItems( path + cur_file + QDir::separator() );
 			}
 
 			added_something = true;


### PR DESCRIPTION
4206705ed216f4ec0418f5343ee84c14a79f3951 #1611 Improve search field ,
was incorrectly adding the files twice to the file browser, one in the correct location, and one in the parent directory.  This pull request removes the additional entry.

fixes #1925