### PR TITLE
View menu: added toggle for piano roll note labels

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1073,40 +1073,35 @@ void MainWindow::updateViewMenu()
 	qa = new QAction(tr( "Volume as dBV" ), this);
 	qa->setData("displaydbv");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "app", "displaydbv" ).
-		       toInt() ? true : false );
+	qa->setChecked( ConfigManager::inst()->value( "app", "displaydbv" ).toInt() );
 	m_viewMenu->addAction(qa);
 
 	// Maybe this is impossible?
 	/* qa = new QAction(tr( "Tooltips" ), this);
 	qa->setData("tooltips");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "tooltips", "disabled" ).
-			toInt() ? false : true );
+	qa->setChecked( !ConfigManager::inst()->value( "tooltips", "disabled" ).toInt() );
 	m_viewMenu->addAction(qa);
 	*/
 
 	qa = new QAction(tr( "Smooth scroll" ), this);
 	qa->setData("smoothscroll");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "ui", "smoothscroll" ).
-			toInt() ? true : false );
+	qa->setChecked( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() );
 	m_viewMenu->addAction(qa);
 
 	// Not yet.
 	/* qa = new QAction(tr( "One instrument track window" ), this);
 	qa->setData("oneinstrument");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "ui", "oneinstrumenttrackwindow" ).
-			toInt() ? true : false );
+	qa->setChecked( ConfigManager::inst()->value( "ui", "oneinstrumenttrackwindow" ).toInt() );
 	m_viewMenu->addAction(qa);
 	*/
 
 	qa = new QAction(tr( "Enable note labels in piano roll" ), this);
 	qa->setData("printnotelabels");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "ui", "printnotelabels" ).
-			toInt() ? true : false );
+	qa->setChecked( ConfigManager::inst()->value( "ui", "printnotelabels" ).toInt() );
 	m_viewMenu->addAction(qa);
 
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1086,7 +1086,6 @@ void MainWindow::updateViewMenu()
 	m_viewMenu->addAction(qa);
 	*/
 
-	// Should be doable.
 	qa = new QAction(tr( "Smooth scroll" ), this);
 	qa->setData("smoothscroll");
 	qa->setCheckable( true );
@@ -1102,6 +1101,14 @@ void MainWindow::updateViewMenu()
 			toInt() ? true : false );
 	m_viewMenu->addAction(qa);
 	*/
+
+	qa = new QAction(tr( "Enable note labels in piano roll" ), this);
+	qa->setData("printnotelabels");
+	qa->setCheckable( true );
+	qa->setChecked( ConfigManager::inst()->value( "ui", "printnotelabels" ).
+			toInt() ? true : false );
+	m_viewMenu->addAction(qa);
+
 }
 
 
@@ -1128,6 +1135,11 @@ void MainWindow::updateConfig( QAction * _who )
 	else if ( tag == "oneinstrument" )
 	{
 		ConfigManager::inst()->setValue( "ui", "oneinstrumenttrackwindow",
+						 QString::number(checked) );
+	}
+	else if ( tag == "printnotelabels" )
+	{
+		ConfigManager::inst()->setValue( "ui", "printnotelabels",
 						 QString::number(checked) );
 	}
 }


### PR DESCRIPTION
Note labels in the piano roll seem to work well enough to be toggleable "live", i.e. without a restart.