### PR TITLE
AFP update parameters of wave display when loading sample

### DIFF
--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -716,7 +716,7 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 void AudioFileProcessorView::sampleUpdated( void )
 {
-	m_waveView->updateFromTo();
+	m_waveView->updateSampleRange();
 	m_waveView->update();
 	update();
 }
@@ -733,7 +733,7 @@ void AudioFileProcessorView::openAudioFile( void )
 	{
 		castModel<audioFileProcessor>()->setAudioFile( af );
 		Engine::getSong()->setModified();
-		m_waveView->updateFromTo();
+		m_waveView->updateSampleRange();
 	}
 }
 
@@ -759,7 +759,7 @@ void AudioFileProcessorView::modelChanged( void )
 
 
 
-void AudioFileProcessorWaveView::updateFromTo()
+void AudioFileProcessorWaveView::updateSampleRange()
 {
 	if( m_sampleBuffer.frames() > 1 )
 	{
@@ -789,7 +789,7 @@ AudioFileProcessorWaveView::AudioFileProcessorWaveView( QWidget * _parent, int _
 	setFixedSize( _w, _h );
 	setMouseTracking( true );
 
-	updateFromTo();
+	updateSampleRange();
 
 	m_graph.fill( Qt::transparent );
 	update();

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -716,7 +716,7 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 void AudioFileProcessorView::sampleUpdated( void )
 {
-	newWaveView();
+	m_waveView->updateFromTo();
 	m_waveView->update();
 	update();
 }
@@ -733,7 +733,7 @@ void AudioFileProcessorView::openAudioFile( void )
 	{
 		castModel<audioFileProcessor>()->setAudioFile( af );
 		Engine::getSong()->setModified();
-		newWaveView();
+		m_waveView->updateFromTo();
 	}
 }
 
@@ -759,6 +759,16 @@ void AudioFileProcessorView::modelChanged( void )
 
 
 
+void AudioFileProcessorWaveView::updateFromTo()
+{
+	if( m_sampleBuffer.frames() > 1 )
+	{
+		const f_cnt_t marging = ( m_sampleBuffer.endFrame() - m_sampleBuffer.startFrame() ) * 0.1;
+		m_from = qMax( 0, m_sampleBuffer.startFrame() - marging );
+		m_to = qMin( m_sampleBuffer.endFrame() + marging, m_sampleBuffer.frames() );
+	}
+}
+
 AudioFileProcessorWaveView::AudioFileProcessorWaveView( QWidget * _parent, int _w, int _h, SampleBuffer& buf ) :
 	QWidget( _parent ),
 	m_sampleBuffer( buf ),
@@ -779,12 +789,7 @@ AudioFileProcessorWaveView::AudioFileProcessorWaveView( QWidget * _parent, int _
 	setFixedSize( _w, _h );
 	setMouseTracking( true );
 
-	if( m_sampleBuffer.frames() > 1 )
-	{
-		const f_cnt_t marging = ( m_sampleBuffer.endFrame() - m_sampleBuffer.startFrame() ) * 0.1;
-		m_from = qMax( 0, m_sampleBuffer.startFrame() - marging );
-		m_to = qMin( m_sampleBuffer.endFrame() + marging, m_sampleBuffer.frames() );
-	}
+	updateFromTo();
 
 	m_graph.fill( Qt::transparent );
 	update();

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -261,6 +261,7 @@ public:
 	void setKnobs(knob *_start, knob *_end, knob *_loop );
 
 
+	void updateFromTo();
 private:
 	void zoom( const bool _out = false );
 	void slide( int _px );

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -261,7 +261,7 @@ public:
 	void setKnobs(knob *_start, knob *_end, knob *_loop );
 
 
-	void updateFromTo();
+	void updateSampleRange();
 private:
 	void zoom( const bool _out = false );
 	void slide( int _px );


### PR DESCRIPTION
This is changing from opening a new wave display with each sample.
This fixes an issue where the play position cursor was not being drawn.

fixes #1939 