### PR TITLE
Properly initialize Knob lineWidth

### DIFF
--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -65,7 +65,8 @@ TextFloat * Knob::s_textFloat = NULL;
 	m_volumeKnob( false ), \
 	m_volumeRatio( 100.0, 0.0, 1000000.0 ), \
 	m_buttonPressed( false ), \
-	m_angle( -10 )
+	m_angle( -10 ), \
+	m_lineWidth(0)
 
 Knob::Knob( knobTypes _knob_num, QWidget * _parent, const QString & _name ) :
 	DEFAULT_KNOB_INITIALIZER_LIST,


### PR DESCRIPTION
This fixes a Qt warning caused by not initializing m_lineWidth. Specifically, the warning was
```
QPen::setWidth: Setting a pen width with a negative value is not defined
```

Steps to reproduce the original warning message:
Open the default LMMS template.
Open the triple-osc gui. This should trigger the warning messages.