### PR TITLE
Add ctrl+shift+a to deselect all notes in piano roll (#1488)

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1081,7 +1081,16 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 			if( ke->modifiers() & Qt::ControlModifier )
 			{
 				ke->accept();
-				selectAll();
+				if (ke->modifiers() & Qt::ShiftModifier)
+				{
+					// Ctrl + Shift + A = deselect all notes
+					clearSelectedNotes();
+				}
+				else
+				{
+					// Ctrl + A = select all notes
+					selectAll();
+				}
 				update();
 			}
 			break;


### PR DESCRIPTION
Should be self-explanatory. 

It is somewhat picky about the behavior though. If you press ctrl+shift+a, all notes are properly deselected, but if you release shift *before* releasing either ctrl or a, then the ctrl+a shortcut will activate and all the notes will be reselected. In practice, I think most people tend to release the modifiers before the alphabet keys, and especially ctrl before shift, so I don't think this is a big deal.