### PR TITLE
MIDI import: fix crash introduced in commit c1ad8d0ae2f3981baba5ef3b95a9...

### DIFF
--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -384,9 +384,9 @@ bool MidiImport::readSMF( TrackContainer* tc )
 				}
 				if(!handled) {
 					printf("MISSING GLOBAL THINGY\n");
-					printf("     %d %d %f %s %s\n", (int) evt->chan,
+					printf("     %d %d %f %s\n", (int) evt->chan,
 					       evt->get_type_code(), evt->time,
-					       evt->get_attribute(), evt->get_atom_value() );
+					       evt->get_attribute() );
 					// Global stuff
 				}
 			}


### PR DESCRIPTION
All events coming in without a channel aren't of the kind you can call get_atom_value()
on, so let's restore the old behavior instead of letting LMMS crash on some files. 
