### PR TITLE
Delay and Flanger, removed noise from delay when automating length

### DIFF
--- a/plugins/Delay/DelayControls.cpp
+++ b/plugins/Delay/DelayControls.cpp
@@ -32,10 +32,10 @@
 DelayControls::DelayControls( DelayEffect* effect ):
 	EffectControls( effect ),
 	m_effect ( effect ),
-	m_delayTimeModel( 0.5, 0.01, 20.0, 0.0001, 20000.0, this, tr( "Delay Samples" )) ,
+	m_delayTimeModel( 0.5, 0.01, 5.0, 0.0001, 20000.0, this, tr( "Delay Samples" )) ,
 	m_feedbackModel(0.0f,0.0f,1.0f,0.01f,this,tr( "Feedback" ) ),
-	m_lfoTimeModel(2.0, 0.01, 20.0, 0.0001, 20000.0, this, tr( "Lfo Frequency" ) ),
-	m_lfoAmountModel(0.0, 0.0, 2.0, 0.0001, 2000.0, this, tr ( "Lfo Amount" ) ),
+	m_lfoTimeModel(2.0, 0.01, 5.0, 0.0001, 20000.0, this, tr( "Lfo Frequency" ) ),
+	m_lfoAmountModel(0.0, 0.0, 0.5, 0.0001, 2000.0, this, tr ( "Lfo Amount" ) ),
 	m_outGainModel( 0.0, -60.0, 20.0, 0.01, this, tr( "Output gain" ) )
 {
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changeSampleRate() ) );

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -118,7 +118,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 		m_delay->setFeedback( *feedbackPtr );
 		m_lfo->setFrequency( *lfoTimePtr );
 		sampleLength = *lengthPtr * Engine::mixer()->processingSampleRate();
-		m_currentLength = linearInterpolate( sampleLength, m_currentLength, 0.9999 );
+		m_currentLength = sampleLength;
 		m_delay->setLength( m_currentLength + ( *amplitudePtr * ( float )m_lfo->tick() ) );
 		m_delay->tick( buf[f] );
 

--- a/plugins/Delay/StereoDelay.cpp
+++ b/plugins/Delay/StereoDelay.cpp
@@ -57,24 +57,15 @@ StereoDelay::~StereoDelay()
 
 void StereoDelay::tick( sampleFrame frame )
 {
-	m_buffer[m_index][0] = frame[0];
-	m_buffer[m_index][1] = frame[1];
-
-	int readIndex = m_index - ( int )m_length - 1;
-	if( readIndex < 0 )
-	{
-		readIndex += m_maxLength;
-	}
-	float fract = 1.0f -  fraction( m_length );
-	frame[0] = linearInterpolate( m_buffer[readIndex][0] ,
-			m_buffer[( readIndex+1) % m_maxLength][0], fract );
-	frame[1] = linearInterpolate( m_buffer[readIndex][1] ,
-			m_buffer[( readIndex+1) % m_maxLength][1], fract );
-
-	m_buffer[m_index][0] += frame[0] * m_feedback;
-	m_buffer[m_index][1] += frame[1] * m_feedback;
-
-	m_index = ( m_index + 1) % (int) m_maxLength;
+	m_index = ( int )m_length > 0
+			? ( m_index + 1 ) % ( int ) m_length
+			: m_index;
+	float lOut = m_buffer[ m_index ][ 0 ];
+	float rOut = m_buffer[ m_index ] [1 ];
+	m_buffer[ m_index ][ 0 ] = frame[ 0 ] + ( lOut * m_feedback );
+	m_buffer[ m_index ][ 1 ] = frame[ 1 ] + ( rOut * m_feedback );
+	frame[ 0 ] = lOut;
+	frame[ 1 ] = rOut;
 }
 
 

--- a/plugins/Flanger/MonoDelay.cpp
+++ b/plugins/Flanger/MonoDelay.cpp
@@ -55,7 +55,7 @@ MonoDelay::~MonoDelay()
 void MonoDelay::tick( sample_t* sample )
 {
 	m_index = ( int )m_length > 0
-			? ( m_index + 1 ) % ( int ) m_length
+			? ( m_index + 1 ) % ( int )m_length
 			: m_index;
 	float out = m_buffer[ m_index ];
 	m_buffer[ m_index ] = *sample + ( out * m_feedback );

--- a/plugins/Flanger/MonoDelay.cpp
+++ b/plugins/Flanger/MonoDelay.cpp
@@ -25,6 +25,7 @@
 #include "MonoDelay.h"
 #include "interpolation.h"
 #include "lmms_math.h"
+#include "string.h"
 
 MonoDelay::MonoDelay( int maxTime , int sampleRate )
 {
@@ -51,27 +52,14 @@ MonoDelay::~MonoDelay()
 
 
 
-
 void MonoDelay::tick( sample_t* sample )
 {
-	m_buffer[m_index] = *sample;
-	int readIndex = m_index - ( int )m_length - 1;
-	if(readIndex < 0)
-	{
-		readIndex += m_maxLength;
-	}
-	float fract = 1.0f - fraction( m_length );
-	if(readIndex != m_maxLength-1 )
-	{
-		*sample = linearInterpolate(m_buffer[readIndex] ,
-									m_buffer[readIndex+1], fract );
-	} else
-	{
-		*sample = linearInterpolate(m_buffer[readIndex] ,
-									m_buffer[0], fract );
-	}
-	m_buffer[m_index] += *sample * m_feedback;
-	m_index = ( m_index +1 ) % m_maxLength;
+	m_index = ( int )m_length > 0
+			? ( m_index + 1 ) % ( int ) m_length
+			: m_index;
+	float out = m_buffer[ m_index ];
+	m_buffer[ m_index ] = *sample + ( out * m_feedback );
+	*sample = out;
 }
 
 
@@ -85,5 +73,6 @@ void MonoDelay::setSampleRate( int sampleRate )
 	}
 
 
-	m_buffer = new sample_t[( int )( sampleRate * m_maxTime )];
+	m_buffer = new sample_t[( int )( sampleRate * m_maxTime ) ];
+	memset( m_buffer, 0, sizeof(float) * ( int )( sampleRate * m_maxTime ) );
 }


### PR DESCRIPTION
The original delay code, was setting it read index relative to the length
of the delay. This fixes that, now when the length is changed the read
index stays in the correct place in the buffer.