### PR TITLE
Fix 'Squre' typo in sfxr plugin

### DIFF
--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -337,8 +337,8 @@ sfxrInstrument::sfxrInstrument( InstrumentTrack * _instrument_track ) :
 	m_changeAmtModel(0.0f, this, "Change Amount"),
 	m_changeSpeedModel(0.0f, this, "Change Speed"),
 
-	m_sqrDutyModel(0.0f, this, "Squre Duty"),
-	m_sqrSweepModel(0.0f, this, "Squre Sweep"),
+	m_sqrDutyModel(0.0f, this, "Square Duty"),
+	m_sqrSweepModel(0.0f, this, "Duty Sweep"),
 
 	m_repeatSpeedModel(0.0f, this, "Repeat Speed"),
 
@@ -633,8 +633,8 @@ sfxrInstrumentView::sfxrInstrumentView( Instrument * _instrument,
 	m_changeAmtKnob		->setObjectName( "changeKnob" );
 	m_changeSpeedKnob	->setObjectName( "changeKnob" );
 
-	createKnob(m_sqrDutyKnob, 	KNOBS_BASE_X+KNOB_BLOCK_SIZE_X*3, KNOBS_BASE_Y+KNOB_BLOCK_SIZE_Y*2, "Squre Duty(Square wave only)");
-    createKnob(m_sqrSweepKnob, 	KNOBS_BASE_X+KNOB_BLOCK_SIZE_X*4, KNOBS_BASE_Y+KNOB_BLOCK_SIZE_Y*2, "Squre Sweep(Square wave only)");
+	createKnob(m_sqrDutyKnob, 	KNOBS_BASE_X+KNOB_BLOCK_SIZE_X*3, KNOBS_BASE_Y+KNOB_BLOCK_SIZE_Y*2, "Square Duty (Square wave only)");
+    createKnob(m_sqrSweepKnob, 	KNOBS_BASE_X+KNOB_BLOCK_SIZE_X*4, KNOBS_BASE_Y+KNOB_BLOCK_SIZE_Y*2, "Duty Sweep (Square wave only)");
 
 	m_sqrDutyKnob	->setObjectName( "sqrKnob" );
 	m_sqrSweepKnob	->setObjectName( "sqrKnob" );

--- a/plugins/sfxr/sfxr.h
+++ b/plugins/sfxr/sfxr.h
@@ -263,8 +263,8 @@ private:
 	Knob * m_changeAmtKnob; //Change Amount
 	Knob * m_changeSpeedKnob; //Change Speed
 
-	Knob * m_sqrDutyKnob; //Squre Duty
-    Knob * m_sqrSweepKnob; //Squre Sweep
+	Knob * m_sqrDutyKnob; //Square Wave Duty
+    Knob * m_sqrSweepKnob; //Square Wave Duty Sweep
 
 	Knob * m_repeatSpeedKnob; //Repeat Speed
 
@@ -278,8 +278,8 @@ private:
 	Knob * m_hpFilCutSweepKnob; //HP Filter Cutoff Sweep
 
 	automatableButtonGroup * m_waveBtnGroup;
-	PixmapButton * m_sqrWaveBtn; //NOTE: This button has Squre Duty
-								//and Squre Speed configurable
+	PixmapButton * m_sqrWaveBtn; //NOTE: This button has Square Duty
+								//and Square Speed configurable
 	PixmapButton * m_sawWaveBtn;
 	PixmapButton * m_sinWaveBtn;
 	PixmapButton * m_noiseWaveBtn;


### PR DESCRIPTION
This fixes #1973.

I tested this change with an empty project and with a project that made extensive use of SFXR - everything seems to work fine.