### PR TITLE
Give focus to the PianoRoll widget when its window is opened

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -384,6 +384,8 @@ signals:
 	void currentPatternChanged();
 
 private:
+	void focusInEvent(QFocusEvent * event);
+
 	PianoRoll* m_editor;
 
 	ComboBox * m_zoomingComboBox;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4236,3 +4236,9 @@ QSize PianoRollWindow::sizeHint() const
 {
 	return {m_toolBar->sizeHint().width() + 10, INITIAL_PIANOROLL_HEIGHT};
 }
+
+void PianoRollWindow::focusInEvent(QFocusEvent * event)
+{
+	// when the window is given focus, also give focus to the actual piano roll
+	m_editor->setFocus(event->reason());
+}


### PR DESCRIPTION
This implements the feature requested in #1972. Whenever focus is given to the piano roll window (but not one of its children), focus is passed onto the actual piano roll widget too. This way, whenever the window bar is clicked, or when another part of the program calls `gui->pianoRoll()->setFocus()`, the actual piano roll *widget* will be able to receive keyboard events, etc.

This code could be applied to the BB and Automation Editors as well, but I didn't see any benefit to that at this point so I left it out for simplicity.