### PR TITLE
ZynSubAddFx routed all MIDI cc messages to channel 0

### DIFF
--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -350,14 +350,16 @@ bool ZynAddSubFxInstrument::handleMidiEvent( const MidiEvent& event, const MidiT
 		return true;
 	}
 
+	MidiEvent localEvent = event;
+	localEvent.setChannel( 0 );
 	m_pluginMutex.lock();
 	if( m_remotePlugin )
 	{
-		m_remotePlugin->processMidiEvent( event, 0 );
+		m_remotePlugin->processMidiEvent( localEvent, 0 );
 	}
 	else
 	{
-		m_plugin->processMidiEvent( event );
+		m_plugin->processMidiEvent( localEvent );
 	}
 	m_pluginMutex.unlock();
 


### PR DESCRIPTION
Lmms routes all midi notes to ZSAF on channel 0, however the CC messages are
not routed, and could erronusoly be sent to other channels. This would
lead to ZSAF not acting on these midi commands.

This pull request routes All Midi CC messages to channel 0

fixes #1953