### PR TITLE
Add <Insert> keyboard shortcut to create a new FX channel

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -511,7 +511,10 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 			}
 			break;
 		case Qt::Key_Insert:
-			addNewChannel();
+			if ( e->modifiers() & Qt::ShiftModifier )
+			{
+				addNewChannel();
+			}
 			break;
 	}
 }

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -510,6 +510,9 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 				setCurrentFxLine( m_currentFxLine->channelIndex()+1 );
 			}
 			break;
+		case Qt::Key_Insert:
+			addNewChannel();
+			break;
 	}
 }
 


### PR DESCRIPTION
This implements a keyboard shortcut from #1488 for quickly creating a new mixer channel. 

The discussion wasn't clear as to *where* the channel should be inserted (e.g. to the right of the current channel or to the right of the rightmost channel). So I decided upon having the `Insert` shortcut mimic the behavior of the "+" button for consistency & ease of implementation. 

I tested this change by making some channels, connecting them to a source and swapping them around; seemed to work as expected.