### PR TITLE
Might fix 1981 ("Midi Import crash in master branch")

### DIFF
--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -374,19 +374,22 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			if( evt->chan == -1 )
 			{
 				bool handled = false;
-				if( evt->is_update() )
+                if( evt->is_update() )
 				{
 					QString attr = evt->get_attribute();
-					if( attr == "tracknames" ) {
+                    if( attr == "tracknames" && evt->get_update_type() == 'a' ) {
 						trackName = evt->get_atom_value();
 						handled = true;
 					}
 				}
-				if(!handled) {
+                if( !handled ) {
 					printf("MISSING GLOBAL THINGY\n");
-					printf("     %d %d %f %s %s\n", (int) evt->chan,
-					       evt->get_type_code(), evt->time,
-					       evt->get_attribute(), evt->get_atom_value() );
+                    if ( evt->is_update() && evt->get_update_type() == 'a' )
+                    {
+                        printf("     %d %d %f %s %s\n", (int) evt->chan,
+                               evt->get_type_code(), evt->time,
+                               evt->get_attribute(), evt->get_atom_value() );
+                    }
 					// Global stuff
 				}
 			}

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -383,14 +383,19 @@ bool MidiImport::readSMF( TrackContainer* tc )
 					}
 				}
                 if( !handled ) {
-					printf("MISSING GLOBAL THINGY\n");
-                    if ( evt->is_update() && evt->get_update_type() == 'a' )
+                    // Write debug output
+                    printf("MISSING GLOBAL HANDLER\n");
+                    printf("     Chn: %d, Type Code: %d, Time: %f", (int) evt->chan,
+                           evt->get_type_code(), evt->time );
+                    if ( evt->is_update() )
                     {
-                        printf("     %d %d %f %s %s\n", (int) evt->chan,
-                               evt->get_type_code(), evt->time,
-                               evt->get_attribute(), evt->get_atom_value() );
+                        printf( ", Update Type: %s", evt->get_attribute() );
+                        if ( evt->get_update_type() == 'a' )
+                        {
+                            printf( ", Atom: %s", evt->get_atom_value() );
+                        }
                     }
-					// Global stuff
+                    printf( "\n" );
 				}
 			}
 			else if( evt->is_note() && evt->chan < 256 )


### PR DESCRIPTION
This is a pull request for #1981.

The commit adds checks for conditions that are asserted during calls to
get_atom_value.

It might fix a crash that is described in 1981. Unfortunately no files
have been attached to that issue. However, I was able to crash LMMS
using a local file and this crash is gone with this fix. So hopefully this
change also fixes the crashes described in 1981.