### PR TITLE
Show native plugin info in the effect selection dialog

### DIFF
--- a/src/gui/EffectSelectDialog.cpp
+++ b/src/gui/EffectSelectDialog.cpp
@@ -29,6 +29,8 @@
 #include "gui_templates.h"
 #include "embed.h"
 
+#include <QLabel>
+
 
 EffectSelectDialog::EffectSelectDialog( QWidget * _parent ) :
 	QDialog( _parent ),
@@ -173,25 +175,64 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 	{
 		m_currentSelection = m_effectKeys[m_model.mapToSource( _idx ).row()];
 	}
-	if( m_currentSelection.desc && m_currentSelection.desc->subPluginFeatures )
+    if( m_currentSelection.desc )
 	{
 		m_descriptionWidget = new QWidget;
-		QVBoxLayout * l = new QVBoxLayout( m_descriptionWidget );
-		l->setMargin( 4 );
-		l->setSpacing( 0 );
 
-		ui->scrollArea->setWidget( m_descriptionWidget );
+        QHBoxLayout *hbox = new QHBoxLayout( m_descriptionWidget );
 
-		m_currentSelection.desc->subPluginFeatures->
-			fillDescriptionWidget( m_descriptionWidget, &m_currentSelection );
-		foreach( QWidget * w, m_descriptionWidget->findChildren<QWidget *>() )
-		{
-			if( w->parent() == m_descriptionWidget )
-			{
-				l->addWidget( w );
-			}
-		}
-		l->setSizeConstraint( QLayout::SetFixedSize );
+        Plugin::Descriptor const & descriptor = *( m_currentSelection.desc );
+
+        if ( descriptor.logo )
+        {
+            QLabel *logoLabel = new QLabel( m_descriptionWidget );
+            logoLabel->setPixmap( descriptor.logo->pixmap() );
+            logoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+
+            hbox->addWidget( logoLabel );
+            hbox->setAlignment( logoLabel, Qt::AlignTop);
+        }
+
+        QWidget *textualInfoWidget = new QWidget( m_descriptionWidget );
+
+        hbox->addWidget(textualInfoWidget);
+
+        QVBoxLayout * textWidgetLayout = new QVBoxLayout( textualInfoWidget);
+        textWidgetLayout->setMargin( 4 );
+        textWidgetLayout->setSpacing( 0 );
+
+        std::string stdName(descriptor.name);
+        if ( stdName != "ladspaeffect" )
+        {
+            QLabel *label = new QLabel(m_descriptionWidget);
+            QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
+            labelText += "<p><b>" + tr("Description") + ":</b> " + QString::fromUtf8(descriptor.description) + "</p>";
+            labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author) + "</p>";
+
+            label->setText(labelText);
+            textWidgetLayout->addWidget(label);
+        }
+
+        if ( m_currentSelection.desc->subPluginFeatures )
+        {
+            QWidget *subWidget = new QWidget(textualInfoWidget);
+            QVBoxLayout * subLayout = new QVBoxLayout( subWidget );
+            subLayout->setMargin( 4 );
+            subLayout->setSpacing( 0 );
+            m_currentSelection.desc->subPluginFeatures->
+                fillDescriptionWidget( subWidget, &m_currentSelection );
+            foreach( QWidget * w, subWidget->findChildren<QWidget *>() )
+            {
+                if( w->parent() == subWidget )
+                {
+                    subLayout->addWidget( w );
+                }
+            }
+
+            textWidgetLayout->addWidget(subWidget);
+        }
+
+        ui->scrollArea->setWidget( m_descriptionWidget );
 		m_descriptionWidget->show();
 	}
 }

--- a/src/gui/Forms/EffectSelectDialog.ui
+++ b/src/gui/Forms/EffectSelectDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>585</width>
-    <height>547</height>
+    <height>550</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,41 +40,20 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>200</height>
-      </size>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>210</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Plugin description</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QScrollArea" name="scrollArea">
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <widget class="QWidget" name="scrollAreaWidgetContents">
-         <property name="geometry">
-          <rect>
-           <x>0</x>
-           <y>0</y>
-           <width>497</width>
-           <height>109</height>
-          </rect>
-         </property>
-        </widget>
-       </widget>
-      </item>
-     </layout>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>497</width>
+        <height>109</height>
+       </rect>
+      </property>
+     </widget>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
The effect selection dialog now also shows the information for the native
plugins. This included name, description, author as well as the plugin
icon.

Also removed the group box with the title "Plugin description" because
it should be rather obvious to the user that further information about
the plugin is shown. This removes some clutter from the dialog.