### PR TITLE
Add instrument switcher buttons to InstrumentTrackWindow

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -52,6 +52,7 @@ class InstrumentMidiIOView;
 class InstrumentMiscView;
 class Knob;
 class LcdSpinBox;
+class LeftRightNav;
 class midiPortMenu;
 class DataFile;
 class PluginView;
@@ -416,16 +417,19 @@ protected:
 
 protected slots:
 	void saveSettingsBtnClicked();
-
+	void viewNextInstrument();
+	void viewPrevInstrument();
 
 private:
 	virtual void modelChanged();
+	void viewInstrumentInDirection(int d);
 
 	InstrumentTrack * m_track;
 	InstrumentTrackView * m_itv;
 
 	// widgets on the top of an instrument-track-window
 	QLineEdit * m_nameLineEdit;
+	LeftRightNav * m_leftRightNav;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
 	Knob * m_pitchKnob;

--- a/include/LeftRightNav.h
+++ b/include/LeftRightNav.h
@@ -1,0 +1,49 @@
+/*
+ * LeftRightNav.cpp - side-by-side left-facing and right-facing arrows for navigation (looks like < > )
+ *
+ * Copyright (c) 2015 Colin Wallace <wallacoloo/at/gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LEFT_RIGHT_NAV_H
+#define LEFT_RIGHT_NAV_H
+
+#include "PixmapButton.h"
+
+#include <QLayout>
+
+class LeftRightNav : public QWidget
+{
+	Q_OBJECT
+public:
+	LeftRightNav(QWidget *parent=NULL);
+	PixmapButton* getLeftBtn();
+	PixmapButton* getRightBtn();
+	void setShortcuts(const QKeySequence &leftShortcut=Qt::Key_Minus, const QKeySequence &rightShortcut=Qt::Key_Plus);
+signals:
+	void onNavLeft();
+	void onNavRight();
+private:
+	QHBoxLayout m_layout;
+	PixmapButton m_leftBtn;
+	PixmapButton m_rightBtn;
+};
+
+#endif

--- a/include/PixmapButton.h
+++ b/include/PixmapButton.h
@@ -42,6 +42,7 @@ public:
 	void setActiveGraphic( const QPixmap & _pm );
 	void setInactiveGraphic( const QPixmap & _pm, bool _update = true );
 
+	QSize sizeHint() const;
 
 signals:
 	void doubleClicked();

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -111,6 +111,7 @@ public:
 	void moveTrackView( TrackView * trackView, int indexTo );
 	void moveTrackViewUp( TrackView * trackView );
 	void moveTrackViewDown( TrackView * trackView );
+	void scrollToTrackView( TrackView * _tv );
 
 	// -- for usage by trackView only ---------------
 	TrackView * addTrackView( TrackView * _tv );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,6 +55,7 @@ SET(LMMS_SRCS
 	gui/widgets/InstrumentFunctionViews.cpp
 	gui/widgets/InstrumentMidiIOView.cpp
 	gui/widgets/InstrumentSoundShapingView.cpp
+	gui/widgets/LeftRightNav.cpp
 	gui/widgets/Knob.cpp
 	gui/widgets/LadspaControlView.cpp
 	gui/widgets/LcdSpinBox.cpp

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <algorithm>
 
 #include <QApplication>
 #include <QLayout>
@@ -200,6 +201,28 @@ void TrackContainerView::moveTrackViewDown( TrackView * trackView )
 	moveTrackView( trackView, index + 1 );
 }
 
+void TrackContainerView::scrollToTrackView( TrackView * _tv )
+{
+	if (!m_trackViews.contains(_tv))
+	{
+		qWarning("TrackContainerView::scrollToTrackView: TrackView is not owned by this");
+	}
+	else
+	{
+		int currentScrollTop = m_scrollArea->verticalScrollBar()->value();
+		int scrollAreaHeight = m_scrollArea->size().height();
+		int trackViewTop = _tv->pos().y();
+		int trackViewBottom = trackViewTop + _tv->size().height();
+
+		// displayed_location = widget_location - currentScrollTop
+		// want to make sure that the widget top has displayed location > 0,
+		// and widget bottom < scrollAreaHeight
+		// trackViewTop - scrollY > 0 && trackViewBottom - scrollY < scrollAreaHeight
+		// therefore scrollY < trackViewTop && scrollY > trackViewBottom - scrollAreaHeight
+		int newScroll = std::max( trackViewBottom-scrollAreaHeight, std::min(currentScrollTop, trackViewTop) );
+		m_scrollArea->verticalScrollBar()->setValue(newScroll);
+	}
+}
 
 
 

--- a/src/gui/widgets/LeftRightNav.cpp
+++ b/src/gui/widgets/LeftRightNav.cpp
@@ -1,0 +1,91 @@
+/*
+ * LeftRightNav.cpp - side-by-side left-facing and right-facing arrows for navigation (looks like < > )
+ *
+ * Copyright (c) 2015 Colin Wallace <wallacoloo/at/gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#include "LeftRightNav.h"
+#include "ToolTip.h"
+#include "embed.h"
+
+
+LeftRightNav::LeftRightNav(QWidget *parent)
+ : QWidget(parent),
+   m_layout(this),
+   m_leftBtn(this, tr("Previous")),
+   m_rightBtn(this, tr("Next"))
+{
+	m_layout.setContentsMargins(0, 0, 0, 0);
+	m_layout.setSpacing(2);
+
+	m_leftBtn.setCheckable(false);
+	m_rightBtn.setCheckable(false);
+
+	m_leftBtn.setCursor(Qt::PointingHandCursor);
+	m_rightBtn.setCursor(Qt::PointingHandCursor);
+
+	m_leftBtn.setActiveGraphic(embed::getIconPixmap(
+							"stepper-left-press"));
+	m_rightBtn.setActiveGraphic(embed::getIconPixmap(
+							"stepper-right-press" ));
+
+	m_leftBtn.setInactiveGraphic(embed::getIconPixmap(
+							"stepper-left" ));
+	m_rightBtn.setInactiveGraphic(embed::getIconPixmap(
+							"stepper-right"));
+
+	connect(&m_leftBtn, SIGNAL(clicked()), this,
+						SIGNAL(onNavLeft()));
+	connect(&m_rightBtn, SIGNAL(clicked()), this,
+						SIGNAL(onNavRight()));
+
+	ToolTip::add(&m_leftBtn, tr("Previous"));
+	ToolTip::add(&m_rightBtn, tr("Next"));
+
+	m_leftBtn.setWindowTitle(tr("Previous"));
+	m_rightBtn.setWindowTitle(tr("Next"));
+
+	// AutomatableButton's right click menu (contains irrelevant options like copying and pasting values)
+	m_leftBtn.setContextMenuPolicy(Qt::NoContextMenu);
+	m_rightBtn.setContextMenuPolicy(Qt::NoContextMenu);
+
+	m_layout.addWidget(&m_leftBtn);
+	m_layout.addWidget(&m_rightBtn);
+}
+
+PixmapButton* LeftRightNav::getLeftBtn()
+{
+	return &m_leftBtn;
+}
+PixmapButton* LeftRightNav::getRightBtn()
+{
+	return &m_rightBtn;
+}
+
+void LeftRightNav::setShortcuts(const QKeySequence &leftShortcut, const QKeySequence &rightShortcut)
+{
+	m_leftBtn.setShortcut(leftShortcut);
+	m_rightBtn.setShortcut(rightShortcut);
+
+	ToolTip::add(&m_leftBtn, tr("Previous (%1)").arg(leftShortcut.toString()));
+	ToolTip::add(&m_rightBtn, tr("Next (%1)").arg(rightShortcut.toString()));
+}

--- a/src/gui/widgets/PixmapButton.cpp
+++ b/src/gui/widgets/PixmapButton.cpp
@@ -130,7 +130,17 @@ void PixmapButton::setInactiveGraphic( const QPixmap & _pm, bool _update )
 	}
 }
 
-
+QSize PixmapButton::sizeHint() const
+{
+	if( ( model() != NULL && model()->value() ) || m_pressed )
+	{
+		return m_activePixmap.size();
+	}
+	else 
+	{
+		return m_inactivePixmap.size();
+	}
+}
 
 
 


### PR DESCRIPTION
This implements the feature described in #1937, or at least how I interpreted the request.

![lmms-instrument-switcher](https://cloud.githubusercontent.com/assets/1210751/7222802/507d39b2-e705-11e4-9091-734795e4b9c6.gif)

It treats instruments inside the B/B editor as a separate group from those inside the song editor, so if you're iterating through B/B instruments, it skips over the ones in the main song editor and vice-versa. Additionally, it *does* work with multiple instrument windows. If clicking the next/prev arrow would cause the InstrumentTrackWindow to be editing another instrument already open, then it simply closes the other editor.

There are currently no shortcuts for activating the next/previous arrows (which I believe the original feature request included), but it would be trivial to add if they can be agreed upon.