### PR TITLE
Remove unused m_instrumentTrack variable

### DIFF
--- a/include/InstrumentPlayHandle.h
+++ b/include/InstrumentPlayHandle.h
@@ -84,7 +84,6 @@ public:
 
 private:
 	Instrument* m_instrument;
-	InstrumentTrack * m_instrumentTrack;
 
 } ;
 

--- a/src/core/InstrumentPlayHandle.cpp
+++ b/src/core/InstrumentPlayHandle.cpp
@@ -28,8 +28,7 @@
 
 InstrumentPlayHandle::InstrumentPlayHandle( Instrument * instrument, InstrumentTrack* instrumentTrack ) :
 		PlayHandle( TypeInstrumentPlayHandle ),
-		m_instrument( instrument ),
-		m_instrumentTrack( instrumentTrack )
+		m_instrument( instrument )
 {
 	setAudioPort( instrumentTrack->audioPort() );
 }


### PR DESCRIPTION
Building with clang revealed the following unused variable, so I've removed it. Lmms compiles and runs fine without it.

```
[  3%] Building CXX object src/CMakeFiles/lmmsobjs.dir/core/InstrumentPlayHandle.cpp.o
In file included from /home/colin/proj/lmms/src/core/InstrumentPlayHandle.cpp:26:
/home/colin/proj/lmms/include/InstrumentPlayHandle.h:87:20: warning: private field 'm_instrumentTrack' is not used [-Wunused-private-field]
        InstrumentTrack * m_instrumentTrack;
```