### PR TITLE
Display the 'muted' attribute as "mute" to match the wording of "solo"

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -5936,7 +5936,7 @@ Latència: %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -5938,7 +5938,7 @@ Zpoždění %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Ztlumený</translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -5974,7 +5974,7 @@ Latenz: %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Stumm</translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -5927,7 +5927,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -5927,7 +5927,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -5927,7 +5927,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -5947,7 +5947,7 @@ Veuillez vérifier que vous avez les droits en lecture pour ce fichier et le ré
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Coupée</translation>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -5946,7 +5946,7 @@ Latencia: %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Silenciado</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -5971,7 +5971,7 @@ Assicurati di avere almeno i permessi di lettura del file e prova di nuovo.</tra
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Muto</translation>
     </message>
     <message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -5950,7 +5950,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">ミュート</translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -5932,7 +5932,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">무음</translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -5929,7 +5929,7 @@ Vertraging: %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -5952,7 +5952,7 @@ Upewnij się, że masz przynajmniej uprawnienia odczytu tego pliku a następnie 
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Wyciszone</translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -5950,7 +5950,7 @@ Latência: %2 ms</translation>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">Mudo</translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -6003,7 +6003,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation>Тихо</translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -5928,7 +5928,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -5942,7 +5942,7 @@ Latency: %2 ms</source>
 <context>
     <name>Track</name>
     <message>
-        <source>Muted</source>
+        <source>Mute</source>
         <translation type="unfinished">静音</translation>
     </message>
     <message>

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -103,7 +103,7 @@ TrackContentObject::TrackContentObject( Track * track ) :
 	m_name( QString::null ),
 	m_startPosition(),
 	m_length(),
-	m_mutedModel( false, this, tr( "Muted" ) ),
+	m_mutedModel( false, this, tr( "Mute" ) ),
 	m_selectViewOnCreate( false )
 {
 	if( getTrack() )
@@ -1810,7 +1810,7 @@ Track::Track( TrackTypes type, TrackContainer * tc ) :
 	m_trackContainer( tc ),        /*!< The track container object */
 	m_type( type ),                /*!< The track type */
 	m_name(),                       /*!< The track's name */
-	m_mutedModel( false, this, tr( "Muted" ) ),
+	m_mutedModel( false, this, tr( "Mute" ) ),
 					 /*!< For controlling track muting */
 	m_soloModel( false, this, tr( "Solo" ) ),
 					/*!< For controlling track soloing */


### PR DESCRIPTION
This fixes the inconsistent wording described in #1993.