### PR TITLE
Midi import: various small improvements

### DIFF
--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -160,6 +160,9 @@ public:
 	{
 		if( !at )
 		{
+			// Keep LMMS responsive, for now the import runs 
+			// in the main thread. This should probably be 
+			// removed if that ever changes.
 			qApp->processEvents();
 			at = dynamic_cast<AutomationTrack *>( Track::create( Track::AutomationTrack, tc ) );
 		}
@@ -224,6 +227,7 @@ public:
 	smfMidiChannel * create( TrackContainer* tc, QString tn )
 	{
 		if( !it ) {
+			// Keep LMMS responsive
 			qApp->processEvents();
 			it = dynamic_cast<InstrumentTrack *>( Track::create( Track::InstrumentTrack, tc ) );
 
@@ -409,7 +413,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
 				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
-				double ticks = MidiTime( noteEvt->get_duration() * ticksPerBeat );
+				int ticks = noteEvt->get_duration() * ticksPerBeat;
 				Note n( (ticks < 1 ? 1 : ticks ),
 						noteEvt->get_start_time() * ticksPerBeat,
 						noteEvt->get_identifier() - 12,

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -249,6 +249,8 @@ public:
 				it->setName( tn );
 			}
 			lastEnd = 0;
+			// General MIDI default
+			it->pitchRangeModel()->setInitValue( 2 );
 		}
 		return this;
 	}

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -160,6 +160,7 @@ public:
 	{
 		if( !at )
 		{
+			qApp->processEvents();
 			at = dynamic_cast<AutomationTrack *>( Track::create( Track::AutomationTrack, tc ) );
 		}
 		if( tn != "") {
@@ -223,6 +224,7 @@ public:
 	smfMidiChannel * create( TrackContainer* tc, QString tn )
 	{
 		if( !it ) {
+			qApp->processEvents();
 			it = dynamic_cast<InstrumentTrack *>( Track::create( Track::InstrumentTrack, tc ) );
 
 #ifdef LMMS_HAVE_FLUIDSYNTH

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -182,8 +182,8 @@ public:
 			ap = dynamic_cast<AutomationPattern*>(
 				at->createTCO(0) );
 			ap->movePosition( pPos );
+			ap->addObject( objModel );
 		}
-		ap->addObject( objModel );
 
 		lastPos = time;
 		time = time - ap->startPosition();

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -357,7 +357,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	// Tracks
 	for( int t = 0; t < seq->tracks(); ++t )
 	{
-		QString trackName = "";
+		QString trackName = QString("Track %1").arg(t);
 		Alg_track_ptr trk = seq->track( t );
 		pd.setValue( t + preTrackSteps );
 
@@ -402,8 +402,8 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
 				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
-
-				Note n( noteEvt->get_duration() * ticksPerBeat,
+				double ticks = MidiTime( noteEvt->get_duration() * ticksPerBeat );
+				Note n( (ticks < 1 ? 1 : ticks ),
 						noteEvt->get_start_time() * ticksPerBeat,
 						noteEvt->get_identifier() - 12,
 						noteEvt->get_loud());

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -368,7 +368,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	// Tracks
 	for( int t = 0; t < seq->tracks(); ++t )
 	{
-		QString trackName = QString("Track %1").arg(t);
+		QString trackName = QString( tr( "Track" ) + " %1" ).arg( t );
 		Alg_track_ptr trk = seq->track( t );
 		pd.setValue( t + preTrackSteps );
 
@@ -388,8 +388,8 @@ bool MidiImport::readSMF( TrackContainer* tc )
                 if( evt->is_update() )
 				{
 					QString attr = evt->get_attribute();
-                    if( attr == "tracknames" && evt->get_update_type() == 'a' ) {
-						trackName = evt->get_atom_value();
+                    if( attr == "tracknames" && evt->get_update_type() == 's' ) {
+						trackName = evt->get_string_value();
 						handled = true;
 					}
 				}
@@ -488,6 +488,9 @@ bool MidiImport::readSMF( TrackContainer* tc )
 								objModel = ch->it->pitchModel();
 								cc = cc * 100.0f;
 								break;
+							default:
+								//TODO: something useful for other CCs
+								break;
 						}
 
 						if( objModel )
@@ -499,9 +502,10 @@ bool MidiImport::readSMF( TrackContainer* tc )
 							else
 							{
 								if( ccs[ccid].at == NULL ) {
-									ccs[ccid].create( tc, trackName + 
-											  (ccid == 128 ? " Pitch bend" : 
-											   QString(" CC %1").arg(ccid) ) );
+									ccs[ccid].create( tc, trackName + " > " + (
+										  objModel != NULL ? 
+										  objModel->displayName() : 
+										  QString("CC %1").arg(ccid) ) );
 								}
 								ccs[ccid].putValue( time, objModel, cc );
 							}

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -156,11 +156,14 @@ public:
 	AutomationPattern * ap;
 	MidiTime lastPos;
 	
-	smfMidiCC & create( TrackContainer* tc )
+	smfMidiCC & create( TrackContainer* tc, QString tn )
 	{
 		if( !at )
 		{
 			at = dynamic_cast<AutomationTrack *>( Track::create( Track::AutomationTrack, tc ) );
+		}
+		if( tn != "") {
+			at->setName( tn );
 		}
 		return *this;
 	}
@@ -487,7 +490,11 @@ bool MidiImport::readSMF( TrackContainer* tc )
 							}
 							else
 							{
-								ccs[ccid].create( tc );
+								if( ccs[ccid].at == NULL ) {
+									ccs[ccid].create( tc, trackName + 
+											  (ccid == 128 ? " Pitch bend" : 
+											   QString(" CC %1").arg(ccid) ) );
+								}
 								ccs[ccid].putValue( time, objModel, cc );
 							}
 						}

--- a/plugins/MidiImport/portsmf/allegro.cpp
+++ b/plugins/MidiImport/portsmf/allegro.cpp
@@ -517,7 +517,7 @@ char *Alg_event::get_string_value()
     assert(is_update());
     Alg_update* update = (Alg_update *) this;
     assert(get_update_type() == 's');
-    return update->parameter.attr_name();
+    return update->parameter.a;
 }
 
 


### PR DESCRIPTION
A little mixed bag of short modifications here, longer descriptions are with their respective commits.

* Don't call AutomationPattern::addObject all the time
* Ensure minimum note length 1 tick
* Add naming of AutomationTracks
* Call qApp->processEvents() before creating tracks (as @Wallacoloo hinted, https://github.com/LMMS/lmms/issues/1971#issuecomment-94179378)
* Set pitch bend range to 2 semitones on instrument load, GM compatible (half of issue #1967)