### PR TITLE
Make the application menu-bar hideable

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -202,6 +202,7 @@ private slots:
 
 	void toggleAppMenuVisible();
 	void revealAppMenu();
+	void hideAppMenu();
 	void autoSave();
 
 signals:

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -138,6 +138,7 @@ protected:
 	virtual void keyPressEvent( QKeyEvent * _ke );
 	virtual void keyReleaseEvent( QKeyEvent * _ke );
 	virtual void timerEvent( QTimerEvent * _ev );
+	bool eventFilter(QObject *obj, QEvent *event);
 
 
 private:
@@ -173,6 +174,8 @@ private:
 		bool m_alt;
 	} m_keyMods;
 
+	int m_numKeysPressedAfterAlt;
+
 	QMenu * m_toolsMenu;
 	QAction * m_undoAction;
 	QAction * m_redoAction;
@@ -197,7 +200,8 @@ private slots:
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
 
-
+	void toggleAppMenuVisible();
+	void revealAppMenu();
 	void autoSave();
 
 signals:

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -151,6 +151,10 @@ private:
 	void toggleWindow( QWidget *window, bool forceShow = false );
 	void refocus();
 
+	bool isMenuBarHideable() const;
+	void revealMenuBar();
+	void tryHideMenuBar();
+	void toggleMenuBarVisible();
 
 	QMdiArea * m_workspace;
 
@@ -200,9 +204,6 @@ private slots:
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
 
-	void toggleAppMenuVisible();
-	void revealAppMenu();
-	void hideAppMenu();
 	void autoSave();
 
 signals:

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -97,6 +97,7 @@ private slots:
 	void toggleWarnAfterSetup( bool _enabled );
 	void toggleDisplaydBV( bool _enabled );
 	void toggleMMPZ( bool _enabled );
+	void toggleHideableMenuBar( bool _enabled );
 	void toggleDisableBackup( bool _enabled );
 	void toggleOpenLastProject( bool _enabled );
 	void toggleHQAudioDev( bool _enabled );
@@ -182,6 +183,7 @@ private:
 	bool m_printNoteLabels;
 	bool m_displayWaveform;
 	bool m_disableAutoQuit;
+	bool m_hideableMenuBar;
 
 	typedef QMap<QString, AudioDeviceSetupWidget *> AswMap;
 	typedef QMap<QString, MidiSetupWidget *> MswMap;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -385,7 +385,7 @@ void MainWindow::finalize()
 	help_menu->addAction( embed::getIconPixmap( "icon" ), tr( "About" ),
 				  this, SLOT( aboutLMMS() ) );
 
-	menuBar()->hide();
+	hideAppMenu();
 
 	// create tool-buttons
 	ToolButton * project_new = new ToolButton(
@@ -1431,7 +1431,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 
 		if (!wasMenuBarClicked)
 		{
-			menuBar()->hide();
+			hideAppMenu();
 		}
 	}
 	// return false to propagate the event
@@ -1500,8 +1500,14 @@ void MainWindow::browseHelp()
 
 void MainWindow::toggleAppMenuVisible()
 {
-	menuBar()->setVisible(!menuBar()->isVisible());
-	menuBar()->setEnabled(true);
+	if (menuBar()->isVisible()) 
+	{
+		hideAppMenu();
+	} 
+	else 
+	{
+		revealAppMenu();
+	}
 }
 
 void MainWindow::revealAppMenu()
@@ -1510,6 +1516,15 @@ void MainWindow::revealAppMenu()
 	// shortcuts aren't delivered to the keyPressEvent function, but keyReleaseEvent does get triggered, 
 	// so have to manually track m_numKeysPressedAfterAlt here.
 	m_numKeysPressedAfterAlt += 1;
+}
+
+void MainWindow::hideAppMenu()
+{
+	// only hide the menu bar if the user configured that
+	if (ConfigManager::inst()->value( "ui", "hideablemenubar").toInt())
+	{
+		menuBar()->hide();
+	}
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1424,13 +1424,18 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 {
 	if (event->type() == QEvent::MouseButtonRelease)
 	{
-		// Unless the mouse event was targeted at the menuBar(), hide it
+		// Unless the mouse event was targeted at the menuBar() or at a different window, hide it
 		bool wasMenuBarClicked = false;
+		bool wasMyWindowClicked = false;
 		for(QWidget *target = static_cast<QWidget*>(obj); target != NULL; target=target->parentWidget())
 		{
 			if (target == menuBar())
 			{
 				wasMenuBarClicked = true;
+			}
+			if (target == this)
+			{
+				wasMyWindowClicked = true;
 			}
 		}
 
@@ -1439,7 +1444,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
 			// in case the setting was disabled, re-enable the menu bar.
 			revealMenuBar();
 		}
-		else if (!wasMenuBarClicked)
+		else if (!wasMenuBarClicked && wasMyWindowClicked)
 		{
 			tryHideMenuBar();
 		}

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -315,7 +315,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 				this, SLOT( toggleDisableAutoquit( bool ) ) );
 
 	LedCheckBox * hideableMenuBar = new LedCheckBox(
-				tr( "Allow hiding of the application menu bar with <tab>" ),
+				tr( "Auto-hide the application menu bar (toggle visibility with <tab>)" ),
 								misc_tw );
 	labelNumber++;
 	hideableMenuBar->move( XDelta, YDelta*labelNumber );

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -135,7 +135,9 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_displayWaveform(ConfigManager::inst()->value( "ui",
 						   "displaywaveform").toInt() ),
 	m_disableAutoQuit(ConfigManager::inst()->value( "ui",
-						   "disableautoquit").toInt() )
+						   "disableautoquit").toInt() ),
+	m_hideableMenuBar(ConfigManager::inst()->value( "ui",
+							"hideablemenubar").toInt() )
 {
 	setWindowIcon( embed::getIconPixmap( "setup_general" ) );
 	setWindowTitle( tr( "Setup LMMS" ) );
@@ -311,6 +313,15 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	disableAutoquit->setChecked( m_disableAutoQuit );
 	connect( disableAutoquit, SIGNAL( toggled( bool ) ),
 				this, SLOT( toggleDisableAutoquit( bool ) ) );
+
+	LedCheckBox * hideableMenuBar = new LedCheckBox(
+				tr( "Allow hiding of the application menu bar with <tab>" ),
+								misc_tw );
+	labelNumber++;
+	hideableMenuBar->move( XDelta, YDelta*labelNumber );
+	hideableMenuBar->setChecked( m_hideableMenuBar );
+	connect( hideableMenuBar, SIGNAL( toggled( bool ) ),
+				this, SLOT( toggleHideableMenuBar( bool ) ) );
 
 	LedCheckBox * disableBackup = new LedCheckBox(
 				tr( "Create backup file when saving a project" ),
@@ -999,6 +1010,8 @@ void SetupDialog::accept()
 					QString::number( m_displayWaveform ) );
 	ConfigManager::inst()->setValue( "ui", "disableautoquit",
 					QString::number( m_disableAutoQuit ) );
+	ConfigManager::inst()->setValue( "ui", "hideablemenubar",
+					QString::number( m_hideableMenuBar ) );
 	ConfigManager::inst()->setValue( "app", "language", m_lang );
 
 
@@ -1129,6 +1142,14 @@ void SetupDialog::toggleDisplaydBV( bool _enabled )
 void SetupDialog::toggleMMPZ( bool _enabled )
 {
 	m_MMPZ = _enabled;
+}
+
+
+
+
+void SetupDialog::toggleHideableMenuBar( bool _enabled)
+{
+	m_hideableMenuBar = _enabled;
 }
 
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -315,7 +315,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 				this, SLOT( toggleDisableAutoquit( bool ) ) );
 
 	LedCheckBox * hideableMenuBar = new LedCheckBox(
-				tr( "Auto-hide the application menu bar (toggle visibility with <tab>)" ),
+				tr( "Auto-hide the application menu bar (toggle visibility with <Alt>)" ),
 								misc_tw );
 	labelNumber++;
 	hideableMenuBar->move( XDelta, YDelta*labelNumber );


### PR DESCRIPTION
This is inspired by an old suggestion by @tresf to **optimize the toolbar space**: #387 and also by the way Firefox deals with the application menubar.

The gist is that by pressing Alt (and *only* alt - any more complex key release event is ignored, which allows for shortcuts to still use alt), the visibility of the menu bar (the bar at the top with file, edit, view submenus, etc) is toggled. It still supports the previous shortcuts of `Alt+E` to open the Edit menu, etc. Furthermore, clicking anywhere outside of the menu bar will cause it to automatically be hidden.

In order to avoid any confusion until we implement something like a chrome menu button to go with it, this setting has to be explicitly enabled under the settings menu.

Here's a short gif, but it still won't explain the functionality as much as a test-drive since you can't tell when I press alt, or click, etc.

![Hiding Menubar](https://cloud.githubusercontent.com/assets/1210751/7331012/db7b242a-eaed-11e4-9336-0f821324dd22.gif)



Would appreciate some testing with this if possible (don't forget to enable the behavior under settings).