### PR TITLE
Fix plurality of 'recently opened project'

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -3435,7 +3435,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished">Obre projecte existent</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished">Projecte obert recentment</translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -3435,7 +3435,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Otevřít existující projekt</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished">Naposledy otevřené projekty</translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3456,7 +3456,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Existierendes Projekt öffnen</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Zuletzt geöffnete Projekte</translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Abrir proyecto existente</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">باز کردن پروژه ی موجود</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -3448,7 +3448,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Ouvrir un projet existant</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Projets ouverts récemment</translation>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -3448,7 +3448,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Abrir un projecto existente</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Proxecto aberto recentemente</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3456,7 +3456,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Apri un progetto esistente</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Progetti aperti di recente</translation>
     </message>
     <message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3450,7 +3450,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">既存プロジェクトを開く</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished">最近開いたプロジェクト</translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">기존 프로젝트 열기</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished">최근 열린 프로젝트</translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Open bestaand project</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3453,7 +3453,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Otwórz istniejący projekt</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Ostatnio otwierane projekty</translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -3489,7 +3489,7 @@ Double click to pick a file.</source>
         <translation>Mostrar/esconder Editor de Automação</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Projetos usados recentemente</translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Открыть существующий проект</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>Недавние проекты</translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -3433,7 +3433,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Öppna existerande projekt</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -3443,7 +3443,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>打开已有工程</translation>
     </message>
     <message>
-        <source>Recently opened project</source>
+        <source>Recently opened projects</source>
         <translation>最近打开的工程</translation>
     </message>
     <message>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -385,7 +385,7 @@ void MainWindow::finalize()
 
 	ToolButton * project_open_recent = new ToolButton(
 				embed::getIconPixmap( "project_open_recent" ),
-					tr( "Recently opened project" ),
+					tr( "Recently opened projects" ),
 					this, SLOT( emptySlot() ), m_toolBar );
 	project_open_recent->setMenu( m_recentlyOpenedProjectsMenu );
 	project_open_recent->setPopupMode( ToolButton::InstantPopup );


### PR DESCRIPTION
The tool-tip for the "Recently opened projects" icon in the toolbar used to read "Recently opened project". This fixes the plurality to be consistent with the same action in the File menu.

Additionally, the case convention seems to vary from icon to icon. E.g. "Show/hide FX Mixer" v.s. "Show/hide project notes" - the first is cased as a title & the second is cased as an ordinary sentence. Any input on what's best for consistency? Title Casing is used in the File/Edit/... menus. Reusing it here would have the advantage of reusing translations, but I don't know which option looks more natural.