### PR TITLE
Grey out edit->undo/redo actions if there's nothing left to undo/redo

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -121,6 +121,7 @@ public slots:
 
 	void updatePlayPauseIcons();
 
+	void updateUndoRedoButtons();
 	void undo();
 	void redo();
 
@@ -167,6 +168,8 @@ private:
 	} m_keyMods;
 
 	QMenu * m_toolsMenu;
+	QAction * m_undoAction;
+	QAction * m_redoAction;
 	QList<PluginView *> m_tools;
 
 	QBasicTimer m_updateTimer;

--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -45,6 +45,9 @@ public:
 	void undo();
 	void redo();
 
+	bool canUndo() const;
+	bool canRedo() const;
+
 	void addJournalCheckPoint( JournallingObject *jo );
 
 	bool isJournalling() const

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -97,6 +97,15 @@ void ProjectJournal::redo()
 	}
 }
 
+bool ProjectJournal::canUndo() const
+{
+	return !m_undoCheckPoints.isEmpty();
+}
+
+bool ProjectJournal::canRedo() const
+{
+	return !m_redoCheckPoints.isEmpty();
+}
 
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -288,11 +288,11 @@ void MainWindow::finalize()
 
 	QMenu * edit_menu = new QMenu( this );
 	menuBar()->addMenu( edit_menu )->setText( tr( "&Edit" ) );
-	edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
+	m_undoAction = edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
 					tr( "Undo" ),
 					this, SLOT( undo() ),
 					Qt::CTRL + Qt::Key_Z );
-	edit_menu->addAction( embed::getIconPixmap( "edit_redo" ),
+	m_redoAction = edit_menu->addAction( embed::getIconPixmap( "edit_redo" ),
 					tr( "Redo" ),
 					this, SLOT( redo() ),
 					Qt::CTRL + Qt::Key_Y );
@@ -300,6 +300,7 @@ void MainWindow::finalize()
 	edit_menu->addAction( embed::getIconPixmap( "setup_general" ),
 					tr( "Settings" ),
 					this, SLOT( showSettingsDialog() ) );
+	connect( edit_menu, SIGNAL(aboutToShow()), this, SLOT(updateUndoRedoButtons()) );
 
 	m_viewMenu = new QMenu( this );
 	menuBar()->addMenu( m_viewMenu )->setText( tr( "&View" ) );
@@ -1181,6 +1182,14 @@ void MainWindow::updatePlayPauseIcons()
 	}
 }
 
+
+void MainWindow::updateUndoRedoButtons()
+{
+	// when the edit menu is shown, grey out the undo/redo buttons if there's nothing to undo/redo
+	// else, un-grey them
+	m_undoAction->setEnabled(Engine::projectJournal()->canUndo());
+	m_redoAction->setEnabled(Engine::projectJournal()->canRedo());
+}
 
 
 


### PR DESCRIPTION
Should be self-explanatory. This makes it more obvious once you've reached the end of the undo/redo stack and is a pretty standard.