### PR TITLE
Remove unused code in Song.cpp

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -57,7 +57,6 @@ public:
 	{
 		Mode_None,
 		Mode_PlaySong,
-		Mode_PlayTrack,
 		Mode_PlayBB,
 		Mode_PlayPattern,
 		Mode_PlayAutomationPattern,
@@ -352,7 +351,6 @@ private:
 	PlayPos m_playPos[Mode_Count];
 	tact_t m_length;
 
-	Track * m_trackToPlay;
 	const Pattern* m_patternToPlay;
 	bool m_loopPattern;
 

--- a/include/Song.h
+++ b/include/Song.h
@@ -256,7 +256,6 @@ public slots:
 	void playSong();
 	void record();
 	void playAndRecord();
-	void playTrack( Track * trackToPlay );
 	void playBB();
 	void playPattern( const Pattern * patternToPlay, bool loop = true );
 	void togglePause();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -479,28 +479,6 @@ void Song::playAndRecord()
 
 
 
-void Song::playTrack( Track * trackToPlay )
-{
-	if( isStopped() == false )
-	{
-		stop();
-	}
-	m_trackToPlay = trackToPlay;
-
-	m_playMode = Mode_PlayTrack;
-	m_playing = true;
-	m_paused = false;
-
-	m_vstSyncController.setPlaybackState( true );
-
-	savePos();
-
-	emit playbackStateChanged();
-}
-
-
-
-
 void Song::playBB()
 {
 	if( isStopped() == false )

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -94,7 +94,6 @@ Song::Song() :
 	m_errors( new QList<QString>() ),
 	m_playMode( Mode_None ),
 	m_length( 0 ),
-	m_trackToPlay( NULL ),
 	m_patternToPlay( NULL ),
 	m_loopPattern( false ),
 	m_elapsedMilliSeconds( 0 ),
@@ -219,10 +218,6 @@ void Song::processNextBuffer()
 			{
 				EnvelopeAndLfoParameters::instances()->reset();
 			}
-			break;
-
-		case Mode_PlayTrack:
-			trackList.push_back( m_trackToPlay );
 			break;
 
 		case Mode_PlayBB:


### PR DESCRIPTION
This function, enum option and variable were all unused. After removing them, LMMS runs identically and `grep -r "playTrack" .`, `grep -r "Mode_PlayTrack" .` and `grep -r "m_trackToPlay" .` don't return any results, so they should be 100% safe to remove.

As for whether it's a good idea to remove unused code or not: removed code is still accessible through the repository history if it ever needs to be restored, meanwhile not having it clutter the source makes any refactoring efforts quite a bit easier. The discussion of #1988 might be useful to refer to as well.