### PR TITLE
Minor formatting fixes in ConfigManager

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -356,10 +356,10 @@ void ConfigManager::loadConfigFile()
 			!QDir( m_vstDir ).exists() )
 	{
 #ifdef LMMS_BUILD_WIN32
-		QString programFiles = getenv("ProgramFiles");
-		m_vstDir =  programFiles + QDir::separator() + "VstPlugins";
+		QString programFiles = QString::fromLocal8Bit( getenv( "ProgramFiles" ) );
+		m_vstDir =  programFiles + QDir::separator() + "VstPlugins" + QDir::separator();
 #else
-		m_vstDir =  m_workingDir + "plugins/vst" + QDir::separator();
+		m_vstDir =  m_workingDir + "plugins/vst/";
 #endif
 	}
 


### PR DESCRIPTION
 * After fixing #1952, the `fromLocal8Bit()` function had been stripped out.  This brings it back in. 
 * Also, to remain consistent with other directories, added a trailing backslash to the VstDir.
 * Last, removed a rather pointless `QDir::separator()` usage and replace with `\`.