### PR TITLE
Add ctrl+f shortcut to FileBrowser & default focus to filter widget when opened

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -64,7 +64,6 @@ private slots:
 private:
 	bool filterItems( QTreeWidgetItem * item, const QString & filter );
 	virtual void keyPressEvent( QKeyEvent * ke );
-	void focusInEvent(QFocusEvent * event);
 
 	void addItems( const QString & path );
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -58,10 +58,13 @@ public slots:
 	void filterItems( const QString & filter );
 	void reloadTree( void );
 
+private slots:
+	void giveFocusToFilter();
 
 private:
 	bool filterItems( QTreeWidgetItem * item, const QString & filter );
 	virtual void keyPressEvent( QKeyEvent * ke );
+	void focusInEvent(QFocusEvent * event);
 
 	void addItems( const QString & path );
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -99,7 +99,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	addContentWidget( ops );
 
 	// Whenever the FileBrowser has focus, Ctrl+F should direct focus to its filter box.
-	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_F ), this, SLOT(giveFocusToFilter()) );
+	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( QKeySequence::Find ), this, SLOT(giveFocusToFilter()) );
 	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
 	reloadTree();

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -268,12 +268,6 @@ void FileBrowser::giveFocusToFilter()
 	}
 }
 
-void FileBrowser::focusInEvent(QFocusEvent * event)
-{
-	// when the FileBrowser is opened, direct focus to the filter for quick filtering
-	giveFocusToFilter();
-}
-
 
 void FileBrowser::addItems(const QString & path )
 {

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -32,6 +32,7 @@
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QMessageBox>
+#include <QShortcut>
 
 #include "FileBrowser.h"
 #include "BBTrackContainer.h"
@@ -96,6 +97,10 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	opl->addWidget( reload_btn );
 
 	addContentWidget( ops );
+
+	// Whenever the FileBrowser has focus, Ctrl+F should direct focus to its filter box.
+	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( Qt::CTRL + Qt::Key_F ), this, SLOT(giveFocusToFilter()) );
+	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
 	reloadTree();
 	show();
@@ -253,7 +258,21 @@ void FileBrowser::reloadTree( void )
 	filterItems( text );
 }
 
+void FileBrowser::giveFocusToFilter()
+{
+	if (!m_filterEdit->hasFocus())
+	{
+		// give focus to filter text box and highlight its text for quick editing if not previously focused
+		m_filterEdit->setFocus();
+		m_filterEdit->selectAll();
+	}
+}
 
+void FileBrowser::focusInEvent(QFocusEvent * event)
+{
+	// when the FileBrowser is opened, direct focus to the filter for quick filtering
+	giveFocusToFilter();
+}
 
 
 void FileBrowser::addItems(const QString & path )

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -158,10 +158,6 @@ void SideBar::toggleButton( QAbstractButton * button )
 		activeWidget->setVisible( button->isChecked() );
 		toolButton->setToolButtonStyle( button->isChecked() ?
 				Qt::ToolButtonTextBesideIcon : Qt::ToolButtonIconOnly );
-		if ( button->isChecked() )
-		{
-			activeWidget->setFocus();
-		}
 	}
 }
 

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -158,6 +158,10 @@ void SideBar::toggleButton( QAbstractButton * button )
 		activeWidget->setVisible( button->isChecked() );
 		toolButton->setToolButtonStyle( button->isChecked() ?
 				Qt::ToolButtonTextBesideIcon : Qt::ToolButtonIconOnly );
+		if ( button->isChecked() )
+		{
+			activeWidget->setFocus();
+		}
 	}
 }
 


### PR DESCRIPTION
I had some spare time to kill while waiting for some extremely slow software, so I went ahead and implemented #2013. Whenever one of the file browsers in the left pane has focus, `ctrl+f` will quickly give focus to the filter widget. When the panes are initially opened, focus is also sent to the filter widget. Whenever focus is given to the filter widget *in one of these ways* (i.e. if you explicitly click the filter box, this isn't applicable), all of its text is auto-selected to make filtering even easier.