### PR TITLE
Adds a focusOutEvent to PianoRoll as solution for Issue #1866

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -120,6 +120,7 @@ protected:
 	virtual void paintEvent( QPaintEvent * _pe );
 	virtual void resizeEvent( QResizeEvent * _re );
 	virtual void wheelEvent( QWheelEvent * _we );
+    virtual void focusOutEvent( QFocusEvent * );
 
 	int getKey( int _y ) const;
 	static inline void drawNoteRect( QPainter & _p, int _x, int _y,

--- a/src/gui/PianoRoll.cpp
+++ b/src/gui/PianoRoll.cpp
@@ -3624,7 +3624,17 @@ void PianoRoll::wheelEvent( QWheelEvent * _we )
 	{
 		m_topBottomScroll->setValue( m_topBottomScroll->value() -
 							_we->delta() / 30 );
-	}
+    }
+}
+
+void PianoRoll::focusOutEvent( QFocusEvent * )
+{
+    for( int i = 0; i < NumKeys; ++i )
+        {
+            m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
+            m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
+        }
+        update();
 }
 
 


### PR DESCRIPTION
Piano roll: playing a note on PC Keyboard and clicking outside, the playing note don't stop.
https://github.com/LMMS/lmms/issues/1866