### PR TITLE
Solves issue #2028 (Slow MIDI import due to repeated message)

### DIFF
--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -56,7 +56,7 @@ public:
 	AutomationPattern( const AutomationPattern & _pat_to_copy );
 	virtual ~AutomationPattern();
 
-	void addObject( AutomatableModel * _obj, bool _search_dup = true );
+    bool addObject( AutomatableModel * _obj, bool _search_dup = true );
 
 	const AutomatableModel * firstObject() const;
 

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -56,7 +56,7 @@ public:
 	AutomationPattern( const AutomationPattern & _pat_to_copy );
 	virtual ~AutomationPattern();
 
-    bool addObject( AutomatableModel * _obj, bool _search_dup = true );
+	bool addObject( AutomatableModel * _obj, bool _search_dup = true );
 
 	const AutomatableModel * firstObject() const;
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -31,7 +31,6 @@
 #include "ProjectJournal.h"
 #include "BBTrackContainer.h"
 #include "Song.h"
-#include "TextFloat.h"
 #include "embed.h"
 
 int AutomationPattern::s_quantization = 1;
@@ -107,7 +106,7 @@ AutomationPattern::~AutomationPattern()
 
 
 
-void AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
+bool AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 {
 	if( _search_dup )
 	{
@@ -115,10 +114,8 @@ void AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 					it != m_objects.end(); ++it )
 		{
 			if( *it == _obj )
-			{
-				TextFloat::displayMessage( _obj->displayName(), tr( "Model is already connected "
-												"to this pattern." ), embed::getIconPixmap( "automation" ), 2000 );
-				return;
+			{				
+                return false;
 			}
 		}
 	}
@@ -138,6 +135,7 @@ void AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 
 	emit dataChanged();
 
+    return true;
 }
 
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -115,7 +115,7 @@ bool AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 		{
 			if( *it == _obj )
 			{				
-                return false;
+				return false;
 			}
 		}
 	}
@@ -135,7 +135,7 @@ bool AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 
 	emit dataChanged();
 
-    return true;
+	return true;
 }
 
 

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -421,15 +421,15 @@ void AutomationPatternView::dropEvent( QDropEvent * _de )
 					journallingObject( val.toInt() ) );
 		if( mod != NULL )
 		{
-            bool added = m_pat->addObject( mod );
-            if ( !added )
-            {
-                TextFloat::displayMessage( mod->displayName(),
-                                           tr( "Model is already connected "
-                                               "to this pattern." ),
-                                           embed::getIconPixmap( "automation" ),
-                                           2000 );
-            }
+			bool added = m_pat->addObject( mod );
+			if ( !added )
+			{
+				TextFloat::displayMessage( mod->displayName(),
+										   tr( "Model is already connected "
+											   "to this pattern." ),
+										   embed::getIconPixmap( "automation" ),
+										   2000 );
+			}
 		}
 		update();
 

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -425,10 +425,10 @@ void AutomationPatternView::dropEvent( QDropEvent * _de )
 			if ( !added )
 			{
 				TextFloat::displayMessage( mod->displayName(),
-										   tr( "Model is already connected "
-											   "to this pattern." ),
-										   embed::getIconPixmap( "automation" ),
-										   2000 );
+							   tr( "Model is already connected "
+							   "to this pattern." ),
+							   embed::getIconPixmap( "automation" ),
+							   2000 );
 			}
 		}
 		update();

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -35,6 +35,7 @@
 #include "ProjectJournal.h"
 #include "RenameDialog.h"
 #include "StringPairDrag.h"
+#include "TextFloat.h"
 #include "ToolTip.h"
 
 
@@ -420,7 +421,15 @@ void AutomationPatternView::dropEvent( QDropEvent * _de )
 					journallingObject( val.toInt() ) );
 		if( mod != NULL )
 		{
-			m_pat->addObject( mod );
+            bool added = m_pat->addObject( mod );
+            if ( !added )
+            {
+                TextFloat::displayMessage( mod->displayName(),
+                                           tr( "Model is already connected "
+                                               "to this pattern." ),
+                                           embed::getIconPixmap( "automation" ),
+                                           2000 );
+            }
 		}
 		update();
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2299,7 +2299,15 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 					journallingObject( val.toInt() ) );
 		if( mod != NULL )
 		{
-			m_editor->m_pattern->addObject( mod );
+            bool added = m_editor->m_pattern->addObject( mod );
+            if ( !added )
+            {
+                TextFloat::displayMessage( mod->displayName(),
+                                           tr( "Model is already connected "
+                                               "to this pattern." ),
+                                           embed::getIconPixmap( "automation" ),
+                                           2000 );
+            }
 			setCurrentPattern( m_editor->m_pattern );
 		}
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2299,15 +2299,15 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 					journallingObject( val.toInt() ) );
 		if( mod != NULL )
 		{
-            bool added = m_editor->m_pattern->addObject( mod );
-            if ( !added )
-            {
-                TextFloat::displayMessage( mod->displayName(),
-                                           tr( "Model is already connected "
-                                               "to this pattern." ),
-                                           embed::getIconPixmap( "automation" ),
-                                           2000 );
-            }
+			bool added = m_editor->m_pattern->addObject( mod );
+			if ( !added )
+			{
+				TextFloat::displayMessage( mod->displayName(),
+										   tr( "Model is already connected "
+											   "to this pattern." ),
+										   embed::getIconPixmap( "automation" ),
+										   2000 );
+			}
 			setCurrentPattern( m_editor->m_pattern );
 		}
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2303,10 +2303,10 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 			if ( !added )
 			{
 				TextFloat::displayMessage( mod->displayName(),
-										   tr( "Model is already connected "
-											   "to this pattern." ),
-										   embed::getIconPixmap( "automation" ),
-										   2000 );
+							   tr( "Model is already connected "
+							   "to this pattern." ),
+							   embed::getIconPixmap( "automation" ),
+							   2000 );
 			}
 			setCurrentPattern( m_editor->m_pattern );
 		}


### PR DESCRIPTION
AutomationPattern::addObject now returns a boolean which indicates
whether the object was added or not. This change enables the removal of
the error message that is shown in the case that a model is already
connected from AutomationPattern::addObject. Instead all interactive
callers now check for the return value and show the message in case it
is needed.

This change set improves the import of MIDI files significantly. These
have been slowed down quite a lot due to the message being shown
repeatedly during the MIDI import.