### PR TITLE
Move core and gui classes into a 'lmms' namespace

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -11,7 +11,7 @@ QMdiArea {
 	background-image: url(resources:background_artwork.png);
 }
 
-AutomationEditor {
+lmms--AutomationEditor {
 	background-color: rgb(0, 0, 0);
 	color: #e0e0e0;
 	qproperty-vertexColor: #ff77af;
@@ -51,7 +51,7 @@ QToolTip {
 	color: #4afd85;
 }
 
-TextFloat {
+lmms--TextFloat {
 	border-radius: 4px;
 	background: qlineargradient(spread:reflect, x1:0.5, y1:0.5, x2:0.5, y2:0, stop:0 rgba(0, 0, 0, 255), stop:1 rgba(50, 50, 50, 220));
 	opacity: 175;
@@ -109,7 +109,7 @@ QMenu::indicator:selected {
 	background-color: #747474;
 }
 
-PianoRoll {
+lmms--PianoRoll {
 	background-color: rgb(0, 0, 0);
 	qproperty-gridColor: rgb( 128, 128, 128 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
@@ -119,14 +119,14 @@ PianoRoll {
 
 /* main toolbar oscilloscope - can have transparent bg now */
 
-VisualizationWidget  {
+lmms--VisualizationWidget  {
 	background: none;
 	border: none;
 }
 
 /* main toolbar cpu load widget - this can have transparent bg now */
 
-CPULoadWidget {
+lmms--CPULoadWidget {
 	border: none;
 	background: url(resources:cpuload_bg.png);
 }
@@ -255,13 +255,13 @@ QScrollBar::down-arrow:vertical:disabled { background-image: url(resources:sbarr
 
 /* background for song editor and bb-editor */
 
-TrackContainerView QFrame{
+lmms--TrackContainerView QFrame {
 	background-color: #49515b;
 }
 
 /* autoscroll, loop, stop behaviour toggle buttons */
 
-NStateButton {
+lmms--NStateButton {
 	max-height: 26px;
 	max-width: 26px;
 	min-height: 26px;
@@ -269,7 +269,7 @@ NStateButton {
 }
 
 /* track background colors */
-TrackContentWidget {
+lmms--TrackContentWidget {
 	qproperty-darkerColor: qlineargradient(x1:0, y1:0, x2:0, y2:1,
 							stop:0 rgb( 50, 50, 50 ), stop:0.33 rgb( 20, 20, 20 ), stop:1 rgb( 15, 15, 15 ) );
 	qproperty-lighterColor: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -279,7 +279,7 @@ TrackContentWidget {
 
 /* gear button in tracks */
 
-TrackOperationsWidget > QPushButton {
+lmms--TrackOperationsWidget > QPushButton {
 	max-height: 26px;
 	max-width: 26px;
 	min-height: 26px;
@@ -288,7 +288,7 @@ TrackOperationsWidget > QPushButton {
 	border:none;
 }
 
-TrackOperationsWidget > QPushButton::menu-indicator {
+lmms--TrackOperationsWidget > QPushButton::menu-indicator {
 	image: url(resources:trackop.png);
 	subcontrol-origin: padding;
 	subcontrol-position: center;
@@ -296,13 +296,13 @@ TrackOperationsWidget > QPushButton::menu-indicator {
 	top: 2px;
 }
 
-TrackOperationsWidget > QPushButton::menu-indicator:hover {
+lmms--TrackOperationsWidget > QPushButton::menu-indicator:hover {
 	image: url(resources:trackop_h.png);
 }
 
 
-TrackOperationsWidget > QPushButton::menu-indicator:pressed,
-TrackOperationsWidget > QPushButton::menu-indicator:checked
+lmms--TrackOperationsWidget > QPushButton::menu-indicator:pressed,
+lmms--TrackOperationsWidget > QPushButton::menu-indicator:checked
  {
 	image: url(resources:trackop_c.png);
 	position: relative;
@@ -317,13 +317,13 @@ TrackOperationsWidget > QPushButton::menu-indicator:checked
 
 /* font sizes */
 
-nameLabel, effectLabel, sf2InstrumentView > QLabel {
+lmms--nameLabel, lmms--effectLabel, sf2InstrumentView > QLabel {
 	font-size:10px;
 }
 
 /* main toolbar sliders (master vol, master pitch) */
 
-AutomatableSlider::groove:vertical {
+lmms--AutomatableSlider::groove:vertical {
 	background: rgba(0,0,0, 128);
 	border: 1px inset rgba(100,100,100, 64);
 	border-radius: 2px;
@@ -331,7 +331,7 @@ AutomatableSlider::groove:vertical {
 	margin: 2px 2px;
 }
 
-AutomatableSlider::handle:vertical {
+lmms--AutomatableSlider::handle:vertical {
 	background: none;
 	border-image: url(resources:main_slider.png);
 	width: 26px;
@@ -342,13 +342,13 @@ AutomatableSlider::handle:vertical {
 
 /* window that shows up when you add effects */
 
-EffectSelectDialog QScrollArea {
+lmms--EffectSelectDialog QScrollArea {
 	background: #5b6571;
 }
 
 /* the inner boxes in LADSPA effect windows */
 
-EffectControlDialog QGroupBox {
+lmms--EffectControlDialog QGroupBox {
 	background: #49515b;
 	margin-top: 1ex;
 	padding: 10px 2px 1px;
@@ -358,7 +358,7 @@ EffectControlDialog QGroupBox {
 
 /* the inner box titles when present (channel 1, channel 2...) */
 
-EffectControlDialog QGroupBox::title {
+lmms--EffectControlDialog QGroupBox::title {
 	subcontrol-origin: margin;
 	subcontrol-position: top left;
 	background: #7b838d;
@@ -436,7 +436,7 @@ QToolButton:checked  {
 
 /* track label buttons - the part that contains the icon and track title */
 
-TrackLabelButton {
+lmms--TrackLabelButton {
 	background-color: #5b6571;
 	color: #c9c9c9;
 	font-size: 11px;
@@ -446,7 +446,7 @@ TrackLabelButton {
 	padding: 2px 1px;
 }
 
-TrackLabelButton:hover {
+lmms--TrackLabelButton:hover {
 	background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:0.5, stop:0 #5b6571, stop:0.75 #7b838d, stop:1 #7b838d );
 	color: white;
 	border: 1px solid rgba(0,0,0,64);
@@ -454,7 +454,7 @@ TrackLabelButton:hover {
 	margin: 0px;
 }
 
-TrackLabelButton:pressed {
+lmms--TrackLabelButton:pressed {
 	background: qlineargradient(spread:reflect, x1:0.5, y1:0, x2:0.5, y2:1, stop:0 #49515b, stop:0.3 #5b6571, stop:1 #6b7581 );
 	color: white;
 	border: 1px solid rgba(0,0,0,64);
@@ -462,7 +462,7 @@ TrackLabelButton:pressed {
 	font-weight: bold;
 }
 
-TrackLabelButton:checked {
+lmms--TrackLabelButton:checked {
 	background: qlineargradient(spread:reflect, x1:0.5, y1:0, x2:0.5, y2:1, stop:0 #49515b, stop:0.3 #5b6571, stop:1 #6b7581 );
 	color: white;
 	border: 1px solid rgba(0,0,0,128);
@@ -470,31 +470,31 @@ TrackLabelButton:checked {
 	font-weight: bold;
 }
 
-TrackLabelButton:checked:hover {
+lmms--TrackLabelButton:checked:hover {
 	background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:0.5, stop:0 #5b6571, stop:0.75 #7b838d, stop:1 #7b838d );
 }
 
-TrackLabelButton:checked:pressed {
+lmms--TrackLabelButton:checked:pressed {
 	background: qlineargradient(spread:reflect, x1:0.5, y1:0, x2:0.5, y2:1, stop:0 #49515b, stop:0.3 #5b6571, stop:1 #6b7581 );
 }
 
 /* sidebar, sidebar buttons */
 
-SideBar {
+lmms--SideBar {
 	background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop: 0 #98a2a7, stop: 1.0 #5b646f);
 }
 
-SideBar QToolButton {
+lmms--SideBar QToolButton {
 	font-size: 12px;
 }
 
 /* font sizes for text buttons */
 
-FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
+lmms--FxMixerView QPushButton, lmms--EffectRackView QPushButton, lmms--ControllerRackView QPushButton {
 	font-size: 10px;
 }
 
-FxLine {
+lmms--FxLine {
 	background: #5b6571;
 	color: #e0e0e0;
 	qproperty-backgroundActive: qlineargradient(spread:reflect, x1:0, y1:0, x2:1, y2:0,
@@ -502,12 +502,12 @@ FxLine {
 }
 
 /* persistent peak markers for fx peak meters */
-Fader {
+lmms--Fader {
 	qproperty-peakGreen: rgb( 74, 253, 133);
 	qproperty-peakRed: rgb( 255, 100, 100);
 }
 
-TimeLine {
+lmms--TimeLine {
 	font-size: 8px;
 }
 
@@ -515,7 +515,7 @@ QTreeView {
 	alternate-background-color: #747474;
 }
 
-TrackContainerView QLabel
+lmms--TrackContainerView QLabel
 {
 	background: none;
 }
@@ -523,28 +523,28 @@ TrackContainerView QLabel
 /* Patterns */
 
 /* instrument pattern */
-PatternView {
+lmms--PatternView {
 	color: rgb( 119, 199, 216 );
 	qproperty-fgColor: rgb( 187, 227, 236 );
 	qproperty-textColor: rgb( 255, 255, 255 );
 }
 
 /* sample track pattern */
-SampleTCOView {
+lmms--SampleTCOView {
 	color: rgb( 74, 253, 133 );
 	qproperty-fgColor: rgb( 187, 227, 236 );
 	qproperty-textColor: rgb( 255, 60, 60 );
 }
 
 /* automation pattern */
-AutomationPatternView {
+lmms--AutomationPatternView {
 	color: #99afff;
 	qproperty-fgColor: rgb( 204, 215, 255 );
 	qproperty-textColor: rgb( 255, 255, 255 );
 }
 
 /* bb-pattern */
-BBTCOView {
+lmms--BBTCOView {
 	color: rgb( 128, 182, 175 ); /* default colour for bb-tracks, used when the colour hasn't been defined by the user */
 	qproperty-textColor: rgb( 255, 255, 255 );
 }
@@ -747,7 +747,7 @@ NesInstrumentView Knob {
 
 /* palette information  */
 
-LmmsPalette {
+lmms--LmmsPalette {
 	qproperty-background: #5b6571;
 	qproperty-windowText: #f0f0f0;
 	qproperty-base: #808080;

--- a/include/AboutDialog.h
+++ b/include/AboutDialog.h
@@ -31,6 +31,10 @@
 #include "ui_about_dialog.h"
 
 
+namespace lmms
+{
+
+
 class AboutDialog : public QDialog, public Ui::AboutDialog
 {
 public:
@@ -39,5 +43,6 @@ public:
 } ;
 
 
-#endif
+}
 
+#endif

--- a/include/ActionGroup.h
+++ b/include/ActionGroup.h
@@ -28,6 +28,11 @@
 
 #include <QActionGroup>
 
+
+namespace lmms
+{
+
+
 /// \brief Convenience subclass of QActionGroup
 ///
 /// This class provides the same functionality as QActionGroup, but in addition
@@ -54,4 +59,6 @@ private:
 	QList<QAction*> m_actions;
 };
 
+
+}
 #endif

--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -37,6 +37,11 @@
 #include "AudioDevice.h"
 
 
+
+namespace lmms
+{
+
+
 class LcdSpinBox;
 class QLineEdit;
 
@@ -94,6 +99,9 @@ private:
 
 } ;
 
+
+
+}
 #endif
 
 #endif

--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -37,13 +37,14 @@
 #include "AudioDevice.h"
 
 
+class QLineEdit;
+
 
 namespace lmms
 {
 
 
 class LcdSpinBox;
-class QLineEdit;
 
 
 class AudioAlsa : public AudioDevice, public QThread

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -33,6 +33,10 @@
 #include "TabWidget.h"
 
 
+namespace lmms
+{
+
+
 class AudioPort;
 
 
@@ -180,4 +184,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -29,6 +29,10 @@
 #include "MicroTimer.h"
 
 
+namespace lmms
+{
+
+
 class AudioDummy : public AudioDevice, public QThread
 {
 public:
@@ -113,4 +117,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AudioFileDevice.h
+++ b/include/AudioFileDevice.h
@@ -31,6 +31,10 @@
 #include "AudioDevice.h"
 
 
+namespace lmms
+{
+
+
 class AudioFileDevice : public AudioDevice
 {
 public:
@@ -111,4 +115,5 @@ typedef AudioFileDevice * ( * AudioFileDeviceInstantiaton )
 						Mixer* mixer );
 
 
+}
 #endif

--- a/include/AudioFileOgg.h
+++ b/include/AudioFileOgg.h
@@ -35,6 +35,9 @@
 #include "AudioFileDevice.h"
 
 
+namespace lmms
+{
+
 class AudioFileOgg : public AudioFileDevice
 {
 public:
@@ -102,6 +105,7 @@ private:
 } ;
 
 
+}
 #endif
 
 #endif

--- a/include/AudioFileWave.h
+++ b/include/AudioFileWave.h
@@ -32,6 +32,10 @@
 #include <sndfile.h>
 
 
+namespace lmms
+{
+
+
 class AudioFileWave : public AudioFileDevice
 {
 public:
@@ -81,4 +85,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -37,6 +37,10 @@
 #include "AudioDevice.h"
 
 
+namespace lmms
+{
+
+
 class QLineEdit;
 class LcdSpinBox;
 
@@ -120,6 +124,9 @@ signals:
 
 } ;
 
+
+
+}
 #endif
 
 #endif

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -37,11 +37,13 @@
 #include "AudioDevice.h"
 
 
+class QLineEdit;
+
+
 namespace lmms
 {
 
 
-class QLineEdit;
 class LcdSpinBox;
 
 

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -32,12 +32,14 @@
 #include "AudioDevice.h"
 
 
+class QLineEdit;
+
+
 namespace lmms
 {
 
 
 class LcdSpinBox;
-class QLineEdit;
 
 
 class AudioOss : public AudioDevice, public QThread

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -32,6 +32,10 @@
 #include "AudioDevice.h"
 
 
+namespace lmms
+{
+
+
 class LcdSpinBox;
 class QLineEdit;
 
@@ -78,6 +82,7 @@ private:
 } ;
 
 
+}
 #endif
 
 #endif

--- a/include/AudioPort.h
+++ b/include/AudioPort.h
@@ -33,6 +33,11 @@
 #include "MemoryManager.h"
 #include "PlayHandle.h"
 
+
+namespace lmms
+{
+
+
 class EffectChain;
 class FloatModel;
 class BoolModel;
@@ -135,4 +140,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -48,6 +48,9 @@ public:
 } ;
 
 
+} // namespace lmms
+
+
 #ifdef LMMS_HAVE_PORTAUDIO
 
 #if defined(__FreeBSD__)
@@ -63,6 +66,10 @@ public:
 #else
 #	define PORTAUDIO_V18
 #endif
+
+
+namespace lmms
+{
 
 
 class ComboBox;
@@ -158,5 +165,5 @@ private:
 #endif
 
 
-}
+} // namespace lmms
 #endif

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -30,6 +30,11 @@
 #include "lmmsconfig.h"
 #include "ComboBoxModel.h"
 
+
+namespace lmms
+{
+
+
 class AudioPortAudioSetupUtil : public QObject
 {
 	Q_OBJECT
@@ -152,4 +157,6 @@ private:
 
 #endif
 
+
+}
 #endif

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -34,13 +34,14 @@
 #include "AudioDevice.h"
 
 
+class QLineEdit;
+
 
 namespace lmms
 {
 
 
 class LcdSpinBox;
-class QLineEdit;
 
 
 class AudioPulseAudio : public AudioDevice, public QThread

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -34,6 +34,11 @@
 #include "AudioDevice.h"
 
 
+
+namespace lmms
+{
+
+
 class LcdSpinBox;
 class QLineEdit;
 
@@ -85,6 +90,8 @@ private:
 
 } ;
 
+
+}
 #endif
 
 #endif

--- a/include/AudioSampleRecorder.h
+++ b/include/AudioSampleRecorder.h
@@ -31,6 +31,11 @@
 
 #include "AudioDevice.h"
 
+
+namespace lmms
+{
+
+
 class SampleBuffer;
 
 
@@ -56,4 +61,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -34,6 +34,11 @@
 
 #include "AudioDevice.h"
 
+
+namespace lmms
+{
+
+
 class QLineEdit;
 
 
@@ -86,6 +91,8 @@ private:
 
 } ;
 
+
+}
 #endif
 
 #endif

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -35,11 +35,11 @@
 #include "AudioDevice.h"
 
 
+class QLineEdit;
+
+
 namespace lmms
 {
-
-
-class QLineEdit;
 
 
 class AudioSdl : public AudioDevice

--- a/include/AutomatableButton.h
+++ b/include/AutomatableButton.h
@@ -31,6 +31,10 @@
 #include "AutomatableModelView.h"
 
 
+namespace lmms
+{
+
+
 class automatableButtonGroup;
 
 
@@ -106,4 +110,5 @@ private:
 
 
 
+}
 #endif

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -60,6 +60,10 @@
 
 
 
+namespace lmms
+{
+
+
 class ControllerConnection;
 
 class EXPORT AutomatableModel : public Model, public JournallingObject
@@ -444,5 +448,6 @@ public:
 } ;
 
 
-#endif
 
+}
+#endif

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -29,13 +29,13 @@
 #include "AutomatableModel.h"
 
 
+class QMenu;
+class QMouseEvent;
+
 
 namespace lmms
 {
 
-
-class QMenu;
-class QMouseEvent;
 
 class EXPORT AutomatableModelView : public ModelView
 {

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -28,6 +28,12 @@
 #include "ModelView.h"
 #include "AutomatableModel.h"
 
+
+
+namespace lmms
+{
+
+
 class QMenu;
 class QMouseEvent;
 
@@ -128,5 +134,6 @@ generateTypedModelView(Int);
 generateTypedModelView(Bool);
 
 
-#endif
 
+}
+#endif

--- a/include/AutomatableSlider.h
+++ b/include/AutomatableSlider.h
@@ -31,6 +31,9 @@
 #include "AutomatableModelView.h"
 
 
+namespace lmms
+{
+
 
 class AutomatableSlider : public QSlider, public IntModelView
 {
@@ -74,4 +77,5 @@ private slots:
 typedef IntModel sliderModel;
 
 
+}
 #endif

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -39,18 +39,19 @@
 #include "Knob.h"
 
 
-namespace lmms
-{
-
 
 class QPainter;
 class QPixmap;
 class QScrollBar;
 
+
+namespace lmms
+{
+
+
 class ComboBox;
 class NotePlayHandle;
 class TimeLineWidget;
-
 
 
 class AutomationEditor : public QWidget, public JournallingObject

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -38,6 +38,11 @@
 #include "ComboBoxModel.h"
 #include "Knob.h"
 
+
+namespace lmms
+{
+
+
 class QPainter;
 class QPixmap;
 class QScrollBar;
@@ -299,4 +304,6 @@ private:
 };
 
 
+
+}
 #endif

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -33,6 +33,10 @@
 #include "Track.h"
 
 
+namespace lmms
+{
+
+
 class AutomationTrack;
 class MidiTime;
 
@@ -193,4 +197,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/AutomationPatternView.h
+++ b/include/AutomationPatternView.h
@@ -27,6 +27,11 @@
 
 #include "Track.h"
 
+
+namespace lmms
+{
+
+
 class AutomationPattern;
 
 
@@ -80,4 +85,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/AutomationTrack.h
+++ b/include/AutomationTrack.h
@@ -30,6 +30,10 @@
 #include "Track.h"
 
 
+namespace lmms
+{
+
+
 class AutomationTrack : public Track
 {
 	Q_OBJECT
@@ -71,4 +75,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -30,6 +30,10 @@
 #include "TrackContainerView.h"
 
 
+namespace lmms
+{
+
+
 class BBTrackContainer;
 class ComboBox;
 
@@ -96,4 +100,6 @@ private:
 };
 
 
+
+}
 #endif

--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -32,6 +32,11 @@
 
 #include "Track.h"
 
+
+namespace lmms
+{
+
+
 class TrackLabelButton;
 class TrackContainer;
 
@@ -226,4 +231,5 @@ private:
 
 
 
+}
 #endif

--- a/include/BBTrackContainer.h
+++ b/include/BBTrackContainer.h
@@ -30,6 +30,10 @@
 #include "ComboBoxModel.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT BBTrackContainer : public TrackContainer
 {
 	Q_OBJECT
@@ -79,4 +83,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -43,6 +43,11 @@ class QString;
 #define MINTLEN 2 << 0
 #define MAXTLEN 3 << MAXLEN
 
+
+namespace lmms
+{
+
+
 // table for table sizes
 const int TLENS[MAXTBL+1] = { 2 << 0, 3 << 0, 2 << 1, 3 << 1,
 					2 << 2, 3 << 2, 2 << 3, 3 << 3,
@@ -208,4 +213,6 @@ public:
 };
 
 
+
+}
 #endif

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -45,6 +45,11 @@
 #include "interpolation.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 template<ch_cnt_t CHANNELS> class BasicFilters;
 
 template<ch_cnt_t CHANNELS>
@@ -915,4 +920,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/BufferManager.h
+++ b/include/BufferManager.h
@@ -31,6 +31,11 @@
 
 class QAtomicInt;
 
+
+namespace lmms
+{
+
+
 const int BM_INITIAL_BUFFERS = 512;
 //const int BM_INCREMENT = 64;
 
@@ -53,4 +58,6 @@ private:
 	static int s_size;
 };
 
+
+}
 #endif

--- a/include/CPULoadWidget.h
+++ b/include/CPULoadWidget.h
@@ -34,6 +34,10 @@
 #include "lmms_basics.h"
 
 
+namespace lmms
+{
+
+
 class CPULoadWidget : public QWidget
 {
 	Q_OBJECT
@@ -64,4 +68,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/CaptionMenu.h
+++ b/include/CaptionMenu.h
@@ -30,6 +30,10 @@
 
 #include "export.h"
 
+
+namespace lmms
+{
+
 ///
 /// \brief A context menu with a caption
 ///
@@ -50,5 +54,5 @@ public:
 
 
 
-
+}
 #endif

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -29,6 +29,10 @@
 #include <QDomElement>
 
 
+namespace lmms
+{
+
+
 class JournallingObject;
 
 class Clipboard
@@ -50,4 +54,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/ComboBox.h
+++ b/include/ComboBox.h
@@ -33,6 +33,9 @@
 #include "AutomatableModelView.h"
 
 
+namespace lmms
+{
+
 
 class EXPORT ComboBox : public QWidget, public IntModelView
 {
@@ -80,4 +83,6 @@ private slots:
 
 } ;
 
+
+}
 #endif

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -30,6 +30,11 @@
 
 #include "AutomatableModel.h"
 
+
+namespace lmms
+{
+
+
 class PixmapLoader;
 
 
@@ -89,4 +94,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -37,6 +37,10 @@
 #include "MemoryManager.h"
 #include "lmmsversion.h"
 
+
+namespace lmms
+{
+
 class Engine;
 
 
@@ -282,4 +286,7 @@ private:
 
 } ;
 
+
+
+}
 #endif

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -33,6 +33,11 @@
 #include "JournallingObject.h"
 #include "ValueBuffer.h"
 
+
+namespace lmms
+{
+
+
 class ControllerDialog;
 class Controller;
 class ControllerConnection;
@@ -174,5 +179,7 @@ signals:
 
 } ;
 
-#endif
 
+
+}
+#endif

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -37,6 +37,11 @@
 #include "JournallingObject.h"
 #include "ValueBuffer.h"
 
+
+namespace lmms
+{
+
+
 class ControllerConnection;
 
 typedef QVector<ControllerConnection *> ControllerConnectionVector;
@@ -119,5 +124,7 @@ signals:
 	friend class ControllerConnectionDialog;
 };
 
-#endif
 
+
+}
+#endif

--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -38,6 +38,11 @@
 class QLineEdit;
 class QListView;
 class QScrollArea;
+
+
+namespace lmms
+{
+
 class AutoDetectMidiController;
 class ComboBox;
 class GroupBox;
@@ -98,4 +103,6 @@ private:
 	AutoDetectMidiController * m_midiController;
 } ;
 
+
+}
 #endif

--- a/include/ControllerDialog.h
+++ b/include/ControllerDialog.h
@@ -30,6 +30,11 @@
 
 #include "ModelView.h"
 
+
+namespace lmms
+{
+
+
 class Controller;
 
 
@@ -51,4 +56,6 @@ protected:
 
 } ;
 
+
+}
 #endif

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -35,6 +35,10 @@
 class QPushButton;
 class QScrollArea;
 
+
+namespace lmms
+{
+
 class ControllerView;
 
 
@@ -73,4 +77,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/ControllerView.h
+++ b/include/ControllerView.h
@@ -36,6 +36,11 @@ class QLabel;
 class QPushButton;
 class QMdiSubWindow;
 
+
+namespace lmms
+{
+
+
 class LedCheckBox;
 
 
@@ -83,4 +88,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -34,6 +34,11 @@
 
 class QTextStream;
 
+
+namespace lmms
+{
+
+
 class EXPORT DataFile : public QDomDocument
 {
 	MM_OPERATORS
@@ -133,5 +138,5 @@ const int LDF_MINOR_VERSION = 0;
 const QString LDF_VERSION_STRING = QString::number( LDF_MAJOR_VERSION ) + "." + QString::number( LDF_MINOR_VERSION );
 
 
+}
 #endif
-

--- a/include/Delay.h
+++ b/include/Delay.h
@@ -32,6 +32,11 @@
 #include "interpolation.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 // brief usage 
 
 // Classes:
@@ -360,4 +365,7 @@ typedef CombFeedfwd<2> StereoCombFeedfwd;
 typedef CombFeedbackDualtap<2> StereoCombFeedbackDualtap;
 typedef AllpassDelay<2> StereoAllpassDelay;
 
+
+
+}
 #endif

--- a/include/DetuningHelper.h
+++ b/include/DetuningHelper.h
@@ -29,6 +29,11 @@
 #include "InlineAutomation.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 class DetuningHelper : public InlineAutomation
 {
 	MM_OPERATORS
@@ -60,4 +65,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/DrumSynth.h
+++ b/include/DrumSynth.h
@@ -30,6 +30,11 @@
 #include <stdint.h>
 #include "lmms_basics.h"
 
+
+namespace lmms
+{
+
+
 class DrumSynth {
     public:
         DrumSynth() {};
@@ -49,4 +54,6 @@ class DrumSynth {
 
 };
 
+
+}
 #endif

--- a/include/DspEffectLibrary.h
+++ b/include/DspEffectLibrary.h
@@ -32,6 +32,10 @@
 #include "lmms_basics.h"
 
 
+
+namespace lmms
+{
+
 namespace DspEffectLibrary
 {
 
@@ -347,4 +351,6 @@ namespace DspEffectLibrary
 } ;
 
 
+
+}
 #endif

--- a/include/DummyEffect.h
+++ b/include/DummyEffect.h
@@ -30,6 +30,10 @@
 #include "EffectControlDialog.h"
 
 
+namespace lmms
+{
+
+
 class DummyEffectControlDialog : public EffectControlDialog
 {
 public:
@@ -139,4 +143,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/DummyInstrument.h
+++ b/include/DummyInstrument.h
@@ -30,6 +30,11 @@
 #include "InstrumentView.h"
 
 
+
+namespace lmms
+{
+
+
 class DummyInstrument : public Instrument
 {
 public:
@@ -66,4 +71,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/DummyPlugin.h
+++ b/include/DummyPlugin.h
@@ -30,6 +30,11 @@
 #include "PluginView.h"
 
 
+
+namespace lmms
+{
+
+
 class DummyPlugin : public Plugin
 {
 public:
@@ -65,4 +70,5 @@ protected:
 } ;
 
 
+}
 #endif

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -32,6 +32,11 @@
 #include "TimeLineWidget.h"
 #include "ToolButton.h"
 
+
+namespace lmms
+{
+
+
 class DropToolBar;
 
 /// \brief Superclass for editors with a toolbar.
@@ -91,4 +96,6 @@ protected:
 };
 
 
+
+}
 #endif

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -33,6 +33,11 @@
 #include "TempoSyncKnobModel.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 class EffectChain;
 class EffectControls;
 
@@ -231,4 +236,5 @@ typedef Effect::Descriptor::SubPluginFeatures::Key EffectKey;
 typedef Effect::Descriptor::SubPluginFeatures::KeyList EffectKeyList;
 
 
+}
 #endif

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -31,6 +31,11 @@
 #include "Mixer.h"
 #include "AutomatableModel.h"
 
+
+namespace lmms
+{
+
+
 class Effect;
 
 
@@ -79,5 +84,7 @@ signals:
 
 } ;
 
-#endif
 
+
+}
+#endif

--- a/include/EffectControlDialog.h
+++ b/include/EffectControlDialog.h
@@ -30,6 +30,12 @@
 
 #include "ModelView.h"
 
+
+
+namespace lmms
+{
+
+
 class EffectControls;
 
 
@@ -52,4 +58,6 @@ protected:
 
 } ;
 
+
+}
 #endif

--- a/include/EffectControls.h
+++ b/include/EffectControls.h
@@ -29,6 +29,12 @@
 #include "JournallingObject.h"
 #include "Effect.h"
 
+
+
+namespace lmms
+{
+
+
 class EffectControlDialog;
 
 
@@ -73,4 +79,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/EffectRackView.h
+++ b/include/EffectRackView.h
@@ -35,6 +35,11 @@
 class QScrollArea;
 class QVBoxLayout;
 
+
+namespace lmms
+{
+
+
 class EffectView;
 class GroupBox;
 
@@ -82,4 +87,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/EffectSelectDialog.h
+++ b/include/EffectSelectDialog.h
@@ -36,6 +36,9 @@
 namespace Ui { class EffectSelectDialog; }
 
 
+namespace lmms
+{
+
 class EffectSelectDialog : public QDialog
 {
 	Q_OBJECT
@@ -66,5 +69,5 @@ private:
 } ;
 
 
-
+}
 #endif

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -35,6 +35,10 @@ class QLabel;
 class QPushButton;
 class QMdiSubWindow;
 
+
+namespace lmms
+{
+
 class EffectControlDialog;
 class Knob;
 class LedCheckBox;
@@ -90,4 +94,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -33,6 +33,11 @@
 
 #include "export.h"
 
+
+namespace lmms
+{
+
+
 class BBTrackContainer;
 class DummyTrackContainer;
 class FxMixer;
@@ -146,5 +151,5 @@ private:
 
 
 
-
+}
 #endif

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -34,6 +34,11 @@
 #include "lmms_basics.h"
 
 
+
+namespace lmms
+{
+
+
 class EXPORT EnvelopeAndLfoParameters : public Model, public JournallingObject
 {
 	Q_OBJECT
@@ -183,4 +188,7 @@ private:
 
 } ;
 
+
+
+}
 #endif

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -34,6 +34,8 @@
 #include "lmms_basics.h"
 
 
+// need to forward-declare plugins/flp_import to give C++ friend status
+class FlpImport;
 
 namespace lmms
 {
@@ -184,7 +186,7 @@ private:
 
 
 	friend class EnvelopeAndLfoView;
-	friend class FlpImport;
+	friend class ::FlpImport;
 
 } ;
 

--- a/include/EnvelopeAndLfoView.h
+++ b/include/EnvelopeAndLfoView.h
@@ -33,6 +33,11 @@
 class QPaintEvent;
 class QPixmap;
 
+
+namespace lmms
+{
+
+
 class EnvelopeAndLfoParameters;
 
 class automatableButtonGroup;
@@ -94,4 +99,6 @@ private:
 	float m_randomGraph;
 } ;
 
+
+}
 #endif

--- a/include/ExportFilter.h
+++ b/include/ExportFilter.h
@@ -32,6 +32,11 @@
 #include "Plugin.h"
 
 
+
+namespace lmms
+{
+
+
 class EXPORT ExportFilter : public Plugin
 {
 public:
@@ -61,4 +66,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/ExportProjectDialog.h
+++ b/include/ExportProjectDialog.h
@@ -34,6 +34,10 @@
 #include "ProjectRenderer.h"
 
 
+namespace lmms
+{
+
+
 class ExportProjectDialog : public QDialog, public Ui::ExportProjectDialog
 {
 	Q_OBJECT
@@ -72,4 +76,6 @@ private:
 	ProjectRenderer* m_activeRenderer;
 } ;
 
+
+}
 #endif

--- a/include/FadeButton.h
+++ b/include/FadeButton.h
@@ -31,6 +31,10 @@
 #include <QColor>
 
 
+namespace lmms
+{
+
+
 class FadeButton : public QAbstractButton
 {
 	Q_OBJECT
@@ -61,5 +65,6 @@ private:
 } ;
 
 
+}
 #endif
 

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -145,4 +145,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -54,6 +54,11 @@
 
 #include "AutomatableModelView.h"
 
+
+namespace lmms
+{
+
+
 class TextFloat;
 
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -36,6 +36,11 @@
 
 class QLineEdit;
 
+
+namespace lmms
+{
+
+
 class FileItem;
 class InstrumentTrack;
 class FileBrowserTreeWidget;
@@ -242,4 +247,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -30,6 +30,11 @@
 
 #include "export.h"
 
+
+namespace lmms
+{
+
+
 class EXPORT FileDialog : public QFileDialog
 {
 	Q_OBJECT
@@ -41,4 +46,5 @@ public:
 	void clearSelection();
 };
 
+}
 #endif // FILEDIALOG_HPP

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -33,6 +33,11 @@
 #include "LcdWidget.h"
 #include "SendButtonIndicator.h"
 
+
+namespace lmms
+{
+
+
 class FxMixerView;
 class SendButtonIndicator;
 
@@ -81,4 +86,5 @@ private slots:
 };
 
 
+}
 #endif // FXLINE_H

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -32,6 +32,10 @@
 #include "ThreadableJob.h"
 
 
+namespace lmms
+{
+
+
 class FxRoute;
 typedef QVector<FxRoute *> FxRouteVector;
 
@@ -217,4 +221,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -41,6 +41,12 @@
 #include "EffectRackView.h"
 
 class QButtonGroup;
+
+
+namespace lmms
+{
+
+
 class FxLine;
 
 class EXPORT FxMixerView : public QWidget, public ModelView,
@@ -133,4 +139,6 @@ private:
 	friend class FxChannelView;
 } ;
 
+
+}
 #endif

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -35,6 +35,11 @@
 #include "ModelView.h"
 #include "lmms_basics.h"
 
+
+namespace lmms
+{
+
+
 class graphModel;
 
 
@@ -184,4 +189,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -122,7 +122,7 @@ public:
 	graphModel( float _min,
 			float _max,
 			int _size,
-			:: Model * _parent,
+			Model * _parent,
 			bool _default_constructed = false,
 			float _step = 0.0 );
 

--- a/include/GroupBox.h
+++ b/include/GroupBox.h
@@ -35,6 +35,10 @@
 class QPixmap;
 
 
+namespace lmms
+{
+
+
 class GroupBox : public QWidget, public BoolModelView
 {
 	Q_OBJECT
@@ -73,4 +77,5 @@ private:
 typedef BoolModel groupBoxModel;
 
 
+}
 #endif

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -80,7 +80,7 @@ private:
 	QLabel* m_loadingProgressLabel;
 };
 
-#define gui GuiApplication::instance()
+#define gui lmms::GuiApplication::instance()
 
 
 }

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -31,6 +31,11 @@
 
 class QLabel;
 
+
+namespace lmms
+{
+
+
 class AutomationEditorWindow;
 class BBEditor;
 class ControllerRackView;
@@ -77,4 +82,6 @@ private:
 
 #define gui GuiApplication::instance()
 
+
+}
 #endif // GUIAPPLICATION_H

--- a/include/ImportFilter.h
+++ b/include/ImportFilter.h
@@ -31,6 +31,10 @@
 #include "Plugin.h"
 
 
+namespace lmms
+{
+
+
 class TrackContainer;
 
 
@@ -103,4 +107,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -29,6 +29,10 @@
 #include "shared_object.h"
 
 
+namespace lmms
+{
+
+
 class InlineAutomation : public FloatModel, public sharedObject
 {
 public:
@@ -89,4 +93,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -35,6 +35,10 @@
 #include "Plugin.h"
 
 
+namespace lmms
+{
+
+
 // forward-declarations
 class InstrumentTrack;
 class MidiEvent;
@@ -141,4 +145,6 @@ private:
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Instrument::Flags)
 
+
+}
 #endif

--- a/include/InstrumentFunctionViews.h
+++ b/include/InstrumentFunctionViews.h
@@ -30,6 +30,12 @@
 #include <QWidget>
 
 class QLabel;
+
+
+namespace lmms
+{
+
+
 class ComboBox;
 class GroupBox;
 class Knob;
@@ -87,4 +93,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -32,6 +32,10 @@
 #include "ComboBoxModel.h"
 
 
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class NotePlayHandle;
 
@@ -209,4 +213,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -32,6 +32,9 @@
 #include "ComboBoxModel.h"
 
 
+// need to forward-declare plugins/flp_import to give C++ friend status
+class FlpImport;
+
 namespace lmms
 {
 
@@ -206,7 +209,7 @@ private:
 	ComboBoxModel m_arpModeModel;
 
 
-	friend class FlpImport;
+	friend class ::FlpImport;
 	friend class InstrumentTrack;
 	friend class InstrumentFunctionArpeggioView;
 

--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -31,6 +31,10 @@
 #include "ModelView.h"
 
 
+namespace lmms
+{
+
+
 class GroupBox;
 class LcdSpinBox;
 class QToolButton;
@@ -78,4 +82,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -31,13 +31,15 @@
 #include "ModelView.h"
 
 
+class QToolButton;
+
+
 namespace lmms
 {
 
 
 class GroupBox;
 class LcdSpinBox;
-class QToolButton;
 class LedCheckBox;
 class InstrumentTrack;
 

--- a/include/InstrumentPlayHandle.h
+++ b/include/InstrumentPlayHandle.h
@@ -30,6 +30,11 @@
 #include "NotePlayHandle.h"
 #include "export.h"
 
+
+namespace lmms
+{
+
+
 class EXPORT InstrumentPlayHandle : public PlayHandle
 {
 public:
@@ -87,4 +92,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -29,6 +29,10 @@
 #include "ComboBoxModel.h"
 
 
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class EnvelopeAndLfoParameters;
 class NotePlayHandle;
@@ -85,4 +89,5 @@ private:
 extern const QString __targetNames[InstrumentSoundShaping::NumTargets][3];
 
 
+}
 #endif

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -29,6 +29,9 @@
 #include "ComboBoxModel.h"
 
 
+// need to forward-declare plugins/flp_import to give C++ friend status
+class FlpImport;
+
 namespace lmms
 {
 
@@ -81,7 +84,7 @@ private:
 
 
 	friend class InstrumentSoundShapingView;
-	friend class FlpImport;
+	friend class ::FlpImport;
 
 } ;
 

--- a/include/InstrumentSoundShapingView.h
+++ b/include/InstrumentSoundShapingView.h
@@ -32,6 +32,11 @@
 
 class QLabel;
 
+
+namespace lmms
+{
+
+
 class EnvelopeAndLfoView;
 class ComboBox;
 class GroupBox;
@@ -67,4 +72,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -42,6 +42,8 @@
 class QLineEdit;
 template<class T> class QQueue;
 
+// need to forward-declare plugins/flp_import to give C++ friend status
+class FlpImport;
 
 namespace lmms
 {
@@ -275,7 +277,7 @@ private:
 	friend class InstrumentTrackView;
 	friend class InstrumentTrackWindow;
 	friend class NotePlayHandle;
-	friend class FlpImport;
+	friend class ::FlpImport;
 	friend class InstrumentMiscView;
 
 } ;

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -41,6 +41,12 @@
 
 class QLineEdit;
 template<class T> class QQueue;
+
+
+namespace lmms
+{
+
+
 class InstrumentFunctionArpeggioView;
 class InstrumentFunctionNoteStackingView;
 class EffectRackView;
@@ -458,4 +464,5 @@ private:
 
 
 
+}
 #endif

--- a/include/InstrumentView.h
+++ b/include/InstrumentView.h
@@ -29,6 +29,11 @@
 #include "Instrument.h"
 #include "PluginView.h"
 
+
+namespace lmms
+{
+
+
 class InstrumentTrackWindow;
 
 
@@ -55,4 +60,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/JournallingObject.h
+++ b/include/JournallingObject.h
@@ -31,6 +31,11 @@
 #include "SerializingObject.h"
 
 
+
+namespace lmms
+{
+
+
 class EXPORT JournallingObject : public SerializingObject
 {
 public:
@@ -99,5 +104,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -34,6 +34,12 @@
 
 
 class QPixmap;
+
+
+namespace lmms
+{
+
+
 class TextFloat;
 
 enum knobTypes
@@ -191,4 +197,7 @@ private:
 
 } ;
 
+
+
+}
 #endif

--- a/include/Ladspa2LMMS.h
+++ b/include/Ladspa2LMMS.h
@@ -30,6 +30,10 @@
 #include "LadspaManager.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT Ladspa2LMMS : public LadspaManager
 {
 public:
@@ -75,4 +79,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/LadspaBase.h
+++ b/include/LadspaBase.h
@@ -29,6 +29,11 @@
 #include "LadspaManager.h"
 #include "Plugin.h"
 
+
+namespace lmms
+{
+
+
 class LadspaControl;
 
 
@@ -87,4 +92,5 @@ inline Plugin::Descriptor::SubPluginFeatures::Key ladspaKeyToSubPluginKey(
 }
 
 
+}
 #endif

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -33,6 +33,10 @@
 #include "ValueBuffer.h"
 
 
+namespace lmms
+{
+
+
 typedef struct PortDescription port_desc_t;
 
 
@@ -119,4 +123,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/LadspaControlView.h
+++ b/include/LadspaControlView.h
@@ -30,6 +30,12 @@
 
 #include "ModelView.h"
 
+
+
+namespace lmms
+{
+
+
 class LadspaControl;
 
 
@@ -45,4 +51,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/LadspaManager.h
+++ b/include/LadspaManager.h
@@ -40,6 +40,11 @@
 #include "lmms_basics.h"
 
 
+
+namespace lmms
+{
+
+
 const float NOHINT = -99342.2243f;
 
 typedef QPair<QString, QString> ladspa_key_t;
@@ -335,4 +340,7 @@ private:
 
 } ;
 
+
+
+}
 #endif

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -30,6 +30,10 @@
 #include "AutomatableModelView.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT LcdSpinBox : public LcdWidget, public IntModelView
 {
 	Q_OBJECT
@@ -85,4 +89,6 @@ signals:
 
 typedef IntModel LcdSpinBoxModel;
 
+
+}
 #endif

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -31,6 +31,11 @@
 
 #include "export.h"
 
+
+namespace lmms
+{
+
+
 class EXPORT LcdWidget : public QWidget
 {
 	Q_OBJECT
@@ -90,4 +95,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/LedCheckbox.h
+++ b/include/LedCheckbox.h
@@ -32,6 +32,10 @@
 class QPixmap;
 
 
+namespace lmms
+{
+
+
 class EXPORT LedCheckBox : public AutomatableButton
 {
 	Q_OBJECT
@@ -78,4 +82,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/LeftRightNav.h
+++ b/include/LeftRightNav.h
@@ -29,6 +29,11 @@
 
 #include <QLayout>
 
+
+namespace lmms
+{
+
+
 class LeftRightNav : public QWidget
 {
 	Q_OBJECT
@@ -46,4 +51,6 @@ private:
 	PixmapButton m_rightBtn;
 };
 
+
+}
 #endif

--- a/include/LfoController.h
+++ b/include/LfoController.h
@@ -34,6 +34,11 @@
 #include "TempoSyncKnobModel.h"
 #include "Oscillator.h"
 
+
+namespace lmms
+{
+
+
 class automatableButtonGroup;
 class Knob;
 class LedCheckBox;
@@ -120,4 +125,6 @@ private slots:
 
 } ;
 
+
+}
 #endif

--- a/include/LmmsPalette.h
+++ b/include/LmmsPalette.h
@@ -30,6 +30,10 @@
 #define LMMSPALETTE_H
 
 
+namespace lmms
+{
+
+
 class EXPORT LmmsPalette : public QWidget
 {
 	Q_OBJECT
@@ -89,5 +93,5 @@ private:
 
 
 
-
+}
 #endif

--- a/include/LmmsStyle.h
+++ b/include/LmmsStyle.h
@@ -30,6 +30,9 @@
 #include <QProxyStyle>
 
 
+namespace lmms
+{
+
 
 class LmmsStyle : public QProxyStyle
 {
@@ -92,4 +95,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -35,6 +35,11 @@ class QDomElement;
 class QGridLayout;
 class QMdiArea;
 
+
+namespace lmms
+{
+
+
 class ConfigManager;
 class PluginView;
 class ToolButton;
@@ -197,4 +202,6 @@ signals:
 
 } ;
 
+
+}
 #endif

--- a/include/MemoryHelper.h
+++ b/include/MemoryHelper.h
@@ -25,6 +25,11 @@
 #ifndef MEMORY_HELPER_H
 #define MEMORY_HELPER_H
 
+
+namespace lmms
+{
+
+
 /**
  * Helper class to alocate aligned memory and free it.
  */
@@ -38,5 +43,7 @@ public:
 private:
 };
 
+
+}
 #endif
 

--- a/include/MemoryManager.h
+++ b/include/MemoryManager.h
@@ -34,6 +34,11 @@
 
 class QReadWriteLock;
 
+
+namespace lmms
+{
+
+
 const int MM_CHUNK_SIZE = 64; // granularity of managed memory
 const int MM_INITIAL_CHUNKS = 1024 * 1024; // how many chunks to allocate at startup - TODO: make configurable
 const int MM_INCREMENT_CHUNKS = 16 * 1024; // min. amount of chunks to increment at a time
@@ -156,4 +161,5 @@ static void operator delete[] ( void * ptr )						\
 }
 
 
+}
 #endif

--- a/include/MeterDialog.h
+++ b/include/MeterDialog.h
@@ -30,6 +30,11 @@
 
 #include "ModelView.h"
 
+
+namespace lmms
+{
+
+
 class LcdSpinBox;
 
 
@@ -49,4 +54,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/MeterModel.h
+++ b/include/MeterModel.h
@@ -28,6 +28,10 @@
 #include "AutomatableModel.h"
 
 
+namespace lmms
+{
+
+
 class MeterModel : public Model
 {
 	Q_OBJECT
@@ -62,4 +66,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/MicroTimer.h
+++ b/include/MicroTimer.h
@@ -35,6 +35,11 @@
 #include "lmms_basics.h"
 
 
+
+namespace lmms
+{
+
+
 class MicroTimer
 {
 public:
@@ -67,4 +72,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/Midi.h
+++ b/include/Midi.h
@@ -28,6 +28,10 @@
 #include "lmms_basics.h"
 
 
+namespace lmms
+{
+
+
 enum MidiEventTypes
 {
 	// messages
@@ -137,4 +141,6 @@ const int MidiMinPanning = -128;
 const int MidiMinPitchBend = 0;
 const int MidiMaxPitchBend = 16383;
 
+
+}
 #endif

--- a/include/MidiAlsaRaw.h
+++ b/include/MidiAlsaRaw.h
@@ -40,6 +40,10 @@ struct pollfd;
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class MidiAlsaRaw : public MidiClientRaw , public QThread
 {
 public:
@@ -85,6 +89,8 @@ private:
 
 } ;
 
+
+}
 #endif
 
 #endif

--- a/include/MidiAlsaSeq.h
+++ b/include/MidiAlsaSeq.h
@@ -42,6 +42,10 @@ struct pollfd;
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class MidiAlsaSeq : public QThread, public MidiClient
 {
 	Q_OBJECT
@@ -158,6 +162,8 @@ signals:
 
 } ;
 
+
+}
 #endif
 
 #endif

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -34,6 +34,10 @@
 #include "TabWidget.h"
 
 
+namespace lmms
+{
+
+
 class MidiPort;
 
 
@@ -194,5 +198,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -33,6 +33,10 @@
 #include "MidiPort.h"
 
 
+namespace lmms
+{
+
+
 class MidiPort;
 
 
@@ -82,4 +86,5 @@ protected:
 } ;
 
 
+}
 #endif

--- a/include/MidiDummy.h
+++ b/include/MidiDummy.h
@@ -28,6 +28,10 @@
 #include "MidiClient.h"
 
 
+namespace lmms
+{
+
+
 class MidiDummy : public MidiClientRaw
 {
 public:
@@ -78,4 +82,5 @@ protected:
 } ;
 
 
+}
 #endif

--- a/include/MidiEvent.h
+++ b/include/MidiEvent.h
@@ -30,6 +30,11 @@
 #include "panning_constants.h"
 #include "volume.h"
 
+
+namespace lmms
+{
+
+
 class MidiEvent
 {
 public:
@@ -207,4 +212,7 @@ private:
 
 } ;
 
+
+
+}
 #endif

--- a/include/MidiEventProcessor.h
+++ b/include/MidiEventProcessor.h
@@ -29,6 +29,11 @@
 #include "MidiTime.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 // all classes being able to process MIDI-events should inherit from this
 class MidiEventProcessor
 {
@@ -48,4 +53,6 @@ public:
 
 } ;
 
+
+}
 #endif

--- a/include/MidiOss.h
+++ b/include/MidiOss.h
@@ -38,6 +38,10 @@
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class MidiOss : public MidiClientRaw, public QThread
 {
 public:
@@ -80,6 +84,8 @@ private:
 
 } ;
 
+
+}
 #endif
 
 

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -35,6 +35,10 @@
 #include "AutomatableModel.h"
 
 
+namespace lmms
+{
+
+
 class MidiClient;
 class MidiEvent;
 class MidiEventProcessor;
@@ -175,4 +179,5 @@ signals:
 typedef QList<MidiPort *> MidiPortList;
 
 
+}
 #endif

--- a/include/MidiPortMenu.h
+++ b/include/MidiPortMenu.h
@@ -34,6 +34,10 @@
 class QAction;
 
 
+namespace lmms
+{
+
+
 class MidiPortMenu : public QMenu, public ModelView
 {
 	Q_OBJECT
@@ -58,4 +62,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/MidiTime.h
+++ b/include/MidiTime.h
@@ -30,6 +30,11 @@
 #include "lmms_basics.h"
 #include "export.h"
 
+
+namespace lmms
+{
+
+
 const int DefaultTicksPerTact = 192;
 const int DefaultStepsPerTact = 16;
 const int DefaultBeatsPerTact = DefaultTicksPerTact / DefaultStepsPerTact;
@@ -155,5 +160,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/MidiWinMM.h
+++ b/include/MidiWinMM.h
@@ -38,6 +38,10 @@
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class MidiWinMM : public QObject, public MidiClient
 {
 	Q_OBJECT
@@ -146,7 +150,8 @@ signals:
 
 } ;
 
+
+}
 #endif
 
 #endif
-

--- a/include/MixHelpers.h
+++ b/include/MixHelpers.h
@@ -27,6 +27,10 @@
 
 #include "lmms_basics.h"
 
+
+namespace lmms
+{
+
 class ValueBuffer;
 namespace MixHelpers
 {
@@ -71,5 +75,6 @@ void multiplyAndAddMultipliedJoined( sampleFrame* dst, const sample_t* srcLeft, 
 
 }
 
-#endif
 
+}
+#endif

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -52,6 +52,10 @@
 #include "MixerProfiler.h"
 
 
+
+namespace lmms
+{
+
 class AudioDevice;
 class MidiClient;
 class AudioPort;
@@ -462,4 +466,6 @@ private:
 } ;
 
 
+
+}
 #endif

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -50,6 +50,7 @@
 #include "Note.h"
 #include "fifo_buffer.h"
 #include "MixerProfiler.h"
+#include "PlayHandle.h"
 
 
 
@@ -74,9 +75,6 @@ const float OUTPUT_SAMPLE_MULTIPLIER = 32767.0f;
 const float BaseFreq = 440.0f;
 const Keys BaseKey = Key_A;
 const Octaves BaseOctave = DefaultOctave;
-
-
-#include "PlayHandle.h"
 
 
 class MixerWorkerThread;

--- a/include/MixerProfiler.h
+++ b/include/MixerProfiler.h
@@ -29,6 +29,11 @@
 
 #include "MicroTimer.h"
 
+
+namespace lmms
+{
+
+
 class MixerProfiler
 {
 public:
@@ -57,4 +62,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/MixerWorkerThread.h
+++ b/include/MixerWorkerThread.h
@@ -29,6 +29,12 @@
 #include <QtCore/QThread>
 
 class QWaitCondition;
+
+
+namespace lmms
+{
+
+
 class Mixer;
 class ThreadableJob;
 
@@ -114,4 +120,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/Model.h
+++ b/include/Model.h
@@ -31,6 +31,10 @@
 #include "export.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT Model : public QObject
 {
 	Q_OBJECT
@@ -88,5 +92,5 @@ signals:
 } ;
 
 
+}
 #endif
-

--- a/include/ModelView.h
+++ b/include/ModelView.h
@@ -29,6 +29,10 @@
 #include "Model.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT ModelView
 {
 public:
@@ -81,5 +85,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/NStateButton.h
+++ b/include/NStateButton.h
@@ -33,6 +33,10 @@
 #include "ToolButton.h"
 
 
+namespace lmms
+{
+
+
 class NStateButton : public ToolButton
 {
 	Q_OBJECT
@@ -72,4 +76,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/Note.h
+++ b/include/Note.h
@@ -33,6 +33,12 @@
 #include "MidiTime.h"
 #include "SerializingObject.h"
 
+
+
+namespace lmms
+{
+
+
 class DetuningHelper;
 
 
@@ -234,4 +240,5 @@ private:
 typedef QVector<Note *> NoteVector;
 
 
+}
 #endif

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -33,6 +33,12 @@
 
 class QAtomicInt;
 class QReadWriteLock;
+
+
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class NotePlayHandle;
 
@@ -340,4 +346,5 @@ private:
 };
 
 
+}
 #endif

--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -36,6 +36,12 @@
 #include "SampleBuffer.h"
 #include "lmms_constants.h"
 
+
+
+namespace lmms
+{
+
+
 class IntModel;
 
 
@@ -211,4 +217,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -41,6 +41,11 @@ class QAction;
 class QProgressBar;
 class QPushButton;
 
+
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class SampleBuffer;
 
@@ -204,4 +209,5 @@ private:
 
 
 
+}
 #endif

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -33,13 +33,15 @@
 #include "ControllerDialog.h"
 
 
+class PeakControllerEffect;
+class PeakControllerDialog;
+
 namespace lmms
 {
 
 
 class automatableButtonGroup;
 class Knob;
-class PeakControllerEffect;
 
 typedef QVector<PeakControllerEffect *> PeakControllerEffectVector;
 

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -32,6 +32,11 @@
 #include "Controller.h"
 #include "ControllerDialog.h"
 
+
+namespace lmms
+{
+
+
 class automatableButtonGroup;
 class Knob;
 class PeakControllerEffect;
@@ -102,4 +107,6 @@ protected:
 
 } ;
 
+
+}
 #endif

--- a/include/Piano.h
+++ b/include/Piano.h
@@ -28,6 +28,11 @@
 #include "Note.h"
 #include "Model.h"
 
+
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class MidiEventProcessor;
 
@@ -76,5 +81,6 @@ private:
 
 } ;
 
-#endif
 
+}
+#endif

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -45,6 +45,11 @@ class QString;
 class QMenu;
 class QSignalMapper;
 
+
+namespace lmms
+{
+
+
 class ComboBox;
 class NotePlayHandle;
 class Pattern;
@@ -397,5 +402,5 @@ private:
 };
 
 
+}
 #endif
-

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -30,6 +30,12 @@
 
 #include "ModelView.h"
 
+
+
+namespace lmms
+{
+
+
 class Piano;
 
 
@@ -85,5 +91,5 @@ signals:
 } ;
 
 
+}
 #endif
-

--- a/include/Pitch.h
+++ b/include/Pitch.h
@@ -28,6 +28,11 @@
 #include "lmms_basics.h"
 #include "Midi.h"
 
+
+namespace lmms
+{
+
+
 typedef int16_t pitch_t;
 
 const pitch_t CentsPerSemitone = 100;
@@ -35,4 +40,6 @@ const pitch_t MinPitchDefault = -CentsPerSemitone;
 const pitch_t MaxPitchDefault = CentsPerSemitone;
 const pitch_t DefaultPitch = 0;
 
+
+}
 #endif

--- a/include/PixmapButton.h
+++ b/include/PixmapButton.h
@@ -31,6 +31,10 @@
 #include "AutomatableButton.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT PixmapButton : public AutomatableButton
 {
 	Q_OBJECT
@@ -62,4 +66,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/PlayHandle.h
+++ b/include/PlayHandle.h
@@ -32,6 +32,11 @@
 #include "ThreadableJob.h"
 #include "lmms_basics.h"
 
+
+namespace lmms
+{
+
+
 class Track;
 class AudioPort;
 
@@ -158,4 +163,5 @@ typedef QList<PlayHandle *> PlayHandleList;
 typedef QList<const PlayHandle *> ConstPlayHandleList;
 
 
+}
 #endif

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -36,6 +36,11 @@
 
 class QWidget;
 
+
+namespace lmms
+{
+
+
 class PixmapLoader;
 class PluginView;
 class AutomatableModel;
@@ -199,4 +204,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -32,6 +32,10 @@
 #include "Plugin.h"
 
 
+namespace lmms
+{
+
+
 class trackContainer;
 
 
@@ -94,4 +98,5 @@ private:
 };
 
 
+}
 #endif

--- a/include/PluginView.h
+++ b/include/PluginView.h
@@ -31,6 +31,10 @@
 #include "ModelView.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT PluginView  : public QWidget, public ModelView
 {
 public:
@@ -43,4 +47,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/PresetPreviewPlayHandle.h
+++ b/include/PresetPreviewPlayHandle.h
@@ -29,6 +29,10 @@
 #include "NotePlayHandle.h"
 
 
+namespace lmms
+{
+
+
 class InstrumentTrack;
 class PreviewTrackContainer;
 
@@ -58,4 +62,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -31,6 +31,11 @@
 #include "lmms_basics.h"
 #include "DataFile.h"
 
+
+namespace lmms
+{
+
+
 class JournallingObject;
 
 
@@ -113,5 +118,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/ProjectNotes.h
+++ b/include/ProjectNotes.h
@@ -37,6 +37,10 @@ class QTextCharFormat;
 class QTextEdit;
 
 
+namespace lmms
+{
+
+
 class EXPORT ProjectNotes : public QMainWindow, public SerializingObject
 {
 	Q_OBJECT
@@ -90,4 +94,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -29,6 +29,10 @@
 #include "lmmsconfig.h"
 
 
+namespace lmms
+{
+
+
 class ProjectRenderer : public QThread
 {
 	Q_OBJECT
@@ -115,4 +119,6 @@ struct FileEncodeDevice
 
 extern FileEncodeDevice __fileEncodeDevices[];
 
+
+}
 #endif

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -29,6 +29,11 @@
 
 #include <QtCore/QString>
 
+
+namespace lmms
+{
+
+
 enum CompareType { Major, Minor, Release, Build };
 
 
@@ -71,4 +76,6 @@ inline bool operator>=(const ProjectVersion & v1, const ProjectVersion & v2) { r
 inline bool operator==(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) == 0; }
 inline bool operator!=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) != 0; }
 
+
+}
 #endif

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -85,6 +85,12 @@ typedef int32_t key_t;
 #include <QtCore/QThread>
 #endif
 
+
+
+namespace lmms
+{
+
+
 // sometimes we need to exchange bigger messages (e.g. for VST parameter dumps)
 // so set a usable value here
 const int SHM_FIFO_SIZE = 512*1024;
@@ -771,7 +777,7 @@ private:
 	friend class ProcessWatcher;
 } ;
 
-#endif
+#endif //BUILD_REMOTE_PLUGIN_CLIENT
 
 
 #ifdef BUILD_REMOTE_PLUGIN_CLIENT
@@ -863,7 +869,7 @@ private:
 
 } ;
 
-#endif
+#endif //BUILD_REMOTE_PLUGIN_CLIENT
 
 
 
@@ -967,7 +973,7 @@ RemotePluginBase::message RemotePluginBase::waitForMessage(
 }
 
 
-#endif
+#endif //COMPILE_REMOTE_PLUGIN_BASE
 
 
 
@@ -1186,8 +1192,11 @@ void RemotePluginClient::doProcessing()
 
 
 
-#endif
+#endif //BUILD_REMOTE_PLUGIN_CLIENT
 
 #define QSTR_TO_STDSTR(s)	std::string( s.toUtf8().constData() )
 
+
+
+}
 #endif

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -86,6 +86,12 @@ typedef int32_t key_t;
 #endif
 
 
+#ifdef COMPILE_REMOTE_PLUGIN_BASE
+#ifndef BUILD_REMOTE_PLUGIN_CLIENT
+#include <QtCore/QCoreApplication>
+#endif
+#endif
+
 
 namespace lmms
 {
@@ -876,10 +882,6 @@ private:
 
 
 #ifdef COMPILE_REMOTE_PLUGIN_BASE
-
-#ifndef BUILD_REMOTE_PLUGIN_CLIENT
-#include <QtCore/QCoreApplication>
-#endif
 
 
 RemotePluginBase::RemotePluginBase( shmFifo * _in, shmFifo * _out ) :

--- a/include/RenameDialog.h
+++ b/include/RenameDialog.h
@@ -33,6 +33,10 @@
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class RenameDialog : public QDialog
 {
 	Q_OBJECT
@@ -57,5 +61,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/RingBuffer.h
+++ b/include/RingBuffer.h
@@ -32,6 +32,11 @@
 #include "lmms_math.h"
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 class EXPORT RingBuffer : public QObject
 {
 	Q_OBJECT
@@ -214,4 +219,7 @@ private:
 	volatile unsigned int m_position;
 
 };
+
+
+}
 #endif

--- a/include/RmsHelper.h
+++ b/include/RmsHelper.h
@@ -28,6 +28,11 @@
 
 #include "lmms_math.h"
 
+
+namespace lmms
+{
+
+
 class RmsHelper
 {
 public:
@@ -91,4 +96,5 @@ private:
 };
 
 
+}
 #endif

--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -31,6 +31,11 @@
 #include <QtCore/QVector>
 
 
+
+namespace lmms
+{
+
+
 class selectableObject : public QWidget
 {
 	Q_OBJECT
@@ -90,5 +95,5 @@ private:
 };
 
 
+}
 #endif
-

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -43,6 +43,12 @@
 
 class QPainter;
 
+
+
+namespace lmms
+{
+
+
 // values for buffer margins, used for various libsamplerate interpolation modes
 // the array positions correspond to the converter_type parameter values in libsamplerate
 // if there appears problems with playback on some interpolation mode, then the value for that mode
@@ -317,4 +323,5 @@ signals:
 } ;
 
 
+}
 #endif

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -29,6 +29,11 @@
 #include "SampleBuffer.h"
 #include "AutomatableModel.h"
 
+
+namespace lmms
+{
+
+
 class BBTrack;
 class SampleTCO;
 class Track;
@@ -93,4 +98,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/SampleRecordHandle.h
+++ b/include/SampleRecordHandle.h
@@ -32,6 +32,11 @@
 #include "Mixer.h"
 #include "SampleBuffer.h"
 
+
+namespace lmms
+{
+
+
 class BBTrack;
 class SampleTCO;
 class Track;
@@ -68,4 +73,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -30,6 +30,11 @@
 #include "AudioPort.h"
 #include "Track.h"
 
+
+namespace lmms
+{
+
+
 class EffectRackView;
 class Knob;
 class SampleBuffer;
@@ -188,4 +193,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/SendButtonIndicator.h
+++ b/include/SendButtonIndicator.h
@@ -5,14 +5,12 @@
 #include <QLabel>
 #include <QPixmap>
 
-#include "FxLine.h"
-#include "FxMixerView.h"
-
 
 namespace lmms
 {
 
 
+class FloatModel;
 class FxLine;
 class FxMixerView;
 

--- a/include/SendButtonIndicator.h
+++ b/include/SendButtonIndicator.h
@@ -8,6 +8,11 @@
 #include "FxLine.h"
 #include "FxMixerView.h"
 
+
+namespace lmms
+{
+
+
 class FxLine;
 class FxMixerView;
 
@@ -30,4 +35,6 @@ private:
 	FloatModel * getSendModel();
 };
 
+
+}
 #endif // SENDBUTTONINDICATOR_H

--- a/include/SerializingObject.h
+++ b/include/SerializingObject.h
@@ -33,6 +33,11 @@
 class QDomDocument;
 class QDomElement;
 
+
+namespace lmms
+{
+
+
 class SerializingObjectHook;
 
 
@@ -96,5 +101,5 @@ private:
 } ;
 
 
+}
 #endif
-

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -39,6 +39,11 @@ class QLabel;
 class QLineEdit;
 class QSlider;
 
+
+namespace lmms
+{
+
+
 class TabBar;
 
 
@@ -194,4 +199,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/SideBar.h
+++ b/include/SideBar.h
@@ -30,6 +30,12 @@
 #include <QToolBar>
 
 class QToolButton;
+
+
+namespace lmms
+{
+
+
 class SideBarWidget;
 
 
@@ -54,4 +60,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/SideBarWidget.h
+++ b/include/SideBarWidget.h
@@ -30,6 +30,11 @@
 #include <QWidget>
 
 
+
+namespace lmms
+{
+
+
 class SideBarWidget : public QWidget
 {
 	Q_OBJECT
@@ -79,4 +84,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/Song.h
+++ b/include/Song.h
@@ -35,6 +35,11 @@
 #include "VstSyncController.h"
 
 
+
+namespace lmms
+{
+
+
 class AutomationTrack;
 class Pattern;
 class TimeLineWidget;
@@ -377,4 +382,5 @@ signals:
 } ;
 
 
+}
 #endif

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -33,6 +33,11 @@
 class QLabel;
 class QScrollBar;
 
+
+namespace lmms
+{
+
+
 class AutomatableSlider;
 class ComboBox;
 class ComboBoxModel;
@@ -161,4 +166,6 @@ private:
 	ComboBox * m_zoomingComboBox;
 };
 
+
+}
 #endif

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -36,6 +36,10 @@
 class QPixmap;
 
 
+namespace lmms
+{
+
+
 class EXPORT StringPairDrag : public QDrag
 {
 public:
@@ -58,4 +62,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/SweepOscillator.h
+++ b/include/SweepOscillator.h
@@ -29,6 +29,11 @@
 #include "DspEffectLibrary.h"
 
 
+
+namespace lmms
+{
+
+
 template<class FX = DspEffectLibrary::StereoBypass>
 class SweepOscillator
 {
@@ -67,4 +72,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/TabBar.h
+++ b/include/TabBar.h
@@ -33,6 +33,10 @@
 #include "export.h"
 
 
+namespace lmms
+{
+
+
 class TabButton;
 
 
@@ -85,4 +89,5 @@ signals:
 } ;
 
 
+}
 #endif

--- a/include/TabButton.h
+++ b/include/TabButton.h
@@ -29,6 +29,10 @@
 #include <QPushButton>
 
 
+namespace lmms
+{
+
+
 class TabButton : public QPushButton
 {
 	Q_OBJECT
@@ -63,4 +67,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -30,6 +30,11 @@
 #include <QtCore/QMap>
 
 
+
+namespace lmms
+{
+
+
 class TabWidget : public QWidget
 {
 	Q_OBJECT
@@ -69,4 +74,6 @@ private:
 	quint8 m_tabheight;
 } ;
 
+
+}
 #endif

--- a/include/TempoSyncKnob.h
+++ b/include/TempoSyncKnob.h
@@ -32,6 +32,11 @@
 #include "Knob.h"
 #include "TempoSyncKnobModel.h"
 
+
+namespace lmms
+{
+
+
 class MeterDialog;
 
 class EXPORT TempoSyncKnob : public Knob
@@ -78,5 +83,5 @@ private:
 } ;
 
 
-
+}
 #endif

--- a/include/TempoSyncKnobModel.h
+++ b/include/TempoSyncKnobModel.h
@@ -30,6 +30,11 @@
 
 class QAction;
 
+
+namespace lmms
+{
+
+
 class EXPORT TempoSyncKnobModel : public FloatModel
 {
 	Q_OBJECT
@@ -101,4 +106,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/TextFloat.h
+++ b/include/TextFloat.h
@@ -32,6 +32,10 @@
 #include "export.h"
 
 
+namespace lmms
+{
+
+
 class EXPORT TextFloat : public QWidget
 {
 	Q_OBJECT
@@ -79,4 +83,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/ThreadableJob.h
+++ b/include/ThreadableJob.h
@@ -30,6 +30,10 @@
 #include "lmms_basics.h"
 
 
+namespace lmms
+{
+
+
 class ThreadableJob
 {
 public:
@@ -86,4 +90,6 @@ protected:
 
 } ;
 
+
+}
 #endif

--- a/include/TimeDisplayWidget.h
+++ b/include/TimeDisplayWidget.h
@@ -32,6 +32,10 @@
 #include "LcdWidget.h"
 
 
+namespace lmms
+{
+
+
 class TimeDisplayWidget : public QWidget
 {
 	Q_OBJECT
@@ -67,4 +71,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -33,6 +33,12 @@
 
 class QPixmap;
 class QToolBar;
+
+
+namespace lmms
+{
+
+
 class NStateButton;
 class TextFloat;
 class SongEditor;
@@ -199,4 +205,5 @@ signals:
 } ;
 
 
+}
 #endif

--- a/include/ToolButton.h
+++ b/include/ToolButton.h
@@ -30,6 +30,10 @@
 #include <QColor>
 
 
+namespace lmms
+{
+
+
 class ToolButton : public QToolButton
 {
 	Q_OBJECT
@@ -46,5 +50,6 @@ public:
 
 } ;
 
-#endif
 
+}
+#endif

--- a/include/ToolPlugin.h
+++ b/include/ToolPlugin.h
@@ -29,6 +29,11 @@
 
 #include "Plugin.h"
 
+
+namespace lmms
+{
+
+
 class EXPORT ToolPlugin : public Plugin
 {
 public:
@@ -42,4 +47,6 @@ public:
 
 } ;
 
+
+}
 #endif

--- a/include/ToolPluginView.h
+++ b/include/ToolPluginView.h
@@ -28,6 +28,11 @@
 
 #include "PluginView.h"
 
+
+namespace lmms
+{
+
+
 class ToolPlugin;
 
 class EXPORT ToolPluginView : public PluginView
@@ -38,4 +43,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/ToolTip.h
+++ b/include/ToolTip.h
@@ -33,10 +33,15 @@
 class QWidget;
 
 
+namespace lmms
+{
+
+
 struct ToolTip
 {
 	static void EXPORT add( QWidget * _w, const QString & _txt );
 } ;
 
 
+}
 #endif

--- a/include/Track.h
+++ b/include/Track.h
@@ -45,6 +45,11 @@
 class QMenu;
 class QPushButton;
 
+
+namespace lmms
+{
+
+
 class PixmapButton;
 class TextFloat;
 class Track;
@@ -684,4 +689,5 @@ private slots:
 
 
 
+}
 #endif

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -32,6 +32,11 @@
 #include "JournallingObject.h"
 
 
+
+namespace lmms
+{
+
+
 class AutomationPattern;
 class InstrumentTrack;
 class TrackContainerView;
@@ -138,4 +143,5 @@ private:
 } ;
 
 
+}
 #endif

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -37,6 +37,11 @@
 
 
 class QVBoxLayout;
+
+namespace lmms
+{
+
+
 class TrackContainer;
 
 
@@ -211,4 +216,6 @@ private:
 	QThread *m_containerThread;
 };
 
+
+}
 #endif

--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -29,6 +29,10 @@
 #include <QToolButton>
 
 
+namespace lmms
+{
+
+
 class TrackView;
 
 
@@ -58,4 +62,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/ValueBuffer.h
+++ b/include/ValueBuffer.h
@@ -31,6 +31,11 @@
 #include <string.h>
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
+
 class ValueBuffer
 {
 	MM_OPERATORS
@@ -160,4 +165,6 @@ private:
 	int m_length;
 };
 
+
+}
 #endif

--- a/include/VersionedSaveDialog.h
+++ b/include/VersionedSaveDialog.h
@@ -33,6 +33,10 @@
 class QLineEdit;
 
 
+namespace lmms
+{
+
+
 class VersionedSaveDialog : public FileDialog
 {
 	Q_OBJECT
@@ -50,4 +54,6 @@ public slots:
 	void decrementVersion();
 };
 
+
+}
 #endif // VERSIONEDSAVEDIALOG_H

--- a/include/VisualizationWidget.h
+++ b/include/VisualizationWidget.h
@@ -32,6 +32,10 @@
 #include "Mixer.h"
 
 
+namespace lmms
+{
+
+
 class VisualizationWidget : public QWidget
 {
 	Q_OBJECT
@@ -66,4 +70,6 @@ private:
 
 } ;
 
+
+}
 #endif

--- a/include/VstSyncController.h
+++ b/include/VstSyncController.h
@@ -32,6 +32,10 @@
 #include "VstSyncData.h"
 
 
+namespace lmms
+{
+
+
 class VstSyncController : public QObject
 {
 	Q_OBJECT
@@ -96,4 +100,6 @@ private:
 
 };
 
+
+}
 #endif

--- a/include/VstSyncData.h
+++ b/include/VstSyncData.h
@@ -38,6 +38,9 @@
 //#define VST_SNC_SHM_RND_KEY 3561653564469
 
 
+namespace lmms
+{
+
 
 struct VstSyncData
 {
@@ -58,4 +61,6 @@ struct VstSyncData
 #endif
 } ;
 
+
+}
 #endif

--- a/include/base64.h
+++ b/include/base64.h
@@ -30,6 +30,9 @@
 #include <QtCore/QString>
 #include <QtCore/QVariant>
 
+namespace lmms
+{
+
 
 namespace base64
 {
@@ -55,4 +58,6 @@ namespace base64
 
 }
 
+
+}
 #endif

--- a/include/custom_events.h
+++ b/include/custom_events.h
@@ -29,6 +29,9 @@
 
 #include <QtCore/QEvent>
 
+namespace lmms
+{
+
 
 namespace customEvents
 {
@@ -41,6 +44,5 @@ namespace customEvents
 }
 
 
-
-
+}
 #endif

--- a/include/denormals.h
+++ b/include/denormals.h
@@ -13,6 +13,10 @@
 #endif
 
 
+namespace lmms
+{
+
+
 // Set denormal protection for this thread. 
 // To be on the safe side, don't set the DAZ flag for SSE2 builds, 
 // even if most SSE2 CPUs can handle it. 
@@ -28,5 +32,6 @@ void inline disable_denormals() {
 #endif
 }
 
-#endif
 
+}
+#endif

--- a/include/embed.h
+++ b/include/embed.h
@@ -32,6 +32,10 @@
 #include "lmms_basics.h"
 
 
+namespace lmms
+{
+
+
 namespace embed
 {
 
@@ -126,4 +130,5 @@ public:
 
 
 
+}
 #endif

--- a/include/endian_handling.h
+++ b/include/endian_handling.h
@@ -30,6 +30,10 @@
 #include "lmms_basics.h"
 
 
+namespace lmms
+{
+
+
 inline bool isLittleEndian()
 {
 	return( QSysInfo::ByteOrder == QSysInfo::LittleEndian );
@@ -50,4 +54,6 @@ inline int32_t swap32IfBE( int32_t i )
 					( ( i & 0x000000ff ) << 24 ) );
 }
 
+
+}
 #endif

--- a/include/fft_helpers.h
+++ b/include/fft_helpers.h
@@ -30,6 +30,11 @@
 
 #include <fftw3.h>
 
+
+namespace lmms
+{
+
+
 const int FFT_BUFFER_SIZE = 2048;
 
 enum WINDOWS
@@ -81,4 +86,6 @@ int EXPORT calc13octaveband31( float * _absspec_buffer, float * _subbands,
  */
 float EXPORT signalpower(float *timesignal, int num_values);
 
+
+}
 #endif

--- a/include/fifo_buffer.h
+++ b/include/fifo_buffer.h
@@ -28,6 +28,10 @@
 #include <QtCore/QSemaphore>
 
 
+namespace lmms
+{
+
+
 template<typename T>
 class fifoBuffer
 {
@@ -84,5 +88,5 @@ private:
 
 
 
-
+}
 #endif

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -34,6 +34,10 @@
 
 
 
+namespace lmms
+{
+
+
 // return DPI-independent font-size - font with returned font-size has always
 // the same size in pixels
 template<int SIZE>
@@ -65,4 +69,5 @@ inline QFont pointSizeF( QFont _f, float SIZE )
 }
 
 
+}
 #endif

--- a/include/interpolation.h
+++ b/include/interpolation.h
@@ -34,6 +34,11 @@
 #include "lmms_constants.h"
 #include "lmms_math.h"
 
+
+namespace lmms
+{
+
+
 inline float hermiteInterpolate( float x0, float x1, float x2, float x3,
 								float frac_pos )
 {
@@ -135,6 +140,5 @@ inline float lagrangeInterpolate( float v0, float v1, float v2, float v3, float 
 
 
 
-
-
+}
 #endif

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -35,6 +35,10 @@
 #endif
 
 
+namespace lmms
+{
+
+
 typedef int32_t tact_t;
 typedef int32_t tick_t;
 typedef uint8_t volume_t;
@@ -139,4 +143,5 @@ typedef sample_t sampleFrameA[DEFAULT_CHANNELS] __attribute__((__aligned__(ALIGN
 #define STR(PN)	#PN
 
 
+}
 #endif

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -25,6 +25,11 @@
 #ifndef LMMS_CONSTANTS_H
 #define LMMS_CONSTANTS_H
 
+
+namespace lmms
+{
+
+
 const long double LD_PI = 3.14159265358979323846264338327950288419716939937510;
 const long double LD_2PI = LD_PI * 2.0;
 const long double LD_PI_2 = LD_PI * 0.5;
@@ -49,4 +54,6 @@ const float F_PI_SQR = (float) LD_PI_SQR;
 const float F_E = (float) LD_E;
 const float F_E_R = (float) LD_E_R;
 
+
+}
 #endif

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -32,6 +32,11 @@
 #include <QtCore/QtGlobal>
 
 #include <cmath>
+
+
+namespace lmms
+{
+
 using namespace std;
 
 #if defined (LMMS_BUILD_WIN32) || defined (LMMS_BUILD_APPLE) || defined(LMMS_BUILD_HAIKU)  || defined (__FreeBSD__)
@@ -325,4 +330,7 @@ static inline T absMin( T a, T b )
 	return qAbs<T>(a) < qAbs<T>(b) ? a : b;
 }
 
+
+
+}
 #endif

--- a/include/panning.h
+++ b/include/panning.h
@@ -32,6 +32,11 @@
 #include "panning_constants.h"
 #include "Midi.h"
 
+
+namespace lmms
+{
+
+
 inline stereoVolumeVector panningToVolumeVector( panning_t _p,
 							float _scale = 1.0f )
 {
@@ -50,4 +55,6 @@ inline int panningToMidi( panning_t _p )
 			  ( (float)( MidiMaxPanning - MidiMinPanning ) ) );
 }
 
+
+}
 #endif

--- a/include/panning_constants.h
+++ b/include/panning_constants.h
@@ -26,9 +26,16 @@
 #ifndef PANNING_CONSTANTS_H
 #define PANNING_CONSTANTS_H
 
+
+namespace lmms
+{
+
+
 const panning_t PanningRight = ( 0 + 100 );
 const panning_t PanningLeft = - PanningRight;
 const panning_t PanningCenter = 0;
 const panning_t DefaultPanning = PanningCenter;
 
+
+}
 #endif

--- a/include/shared_object.h
+++ b/include/shared_object.h
@@ -29,6 +29,10 @@
 #include <QtCore/QMutex>
 
 
+namespace lmms
+{
+
+
 class sharedObject
 {
 public:
@@ -78,7 +82,5 @@ private:
 } ;
 
 
-
-
+}
 #endif
-

--- a/include/templates.h
+++ b/include/templates.h
@@ -28,6 +28,9 @@
 
 #include <QtCore/QtAlgorithms>
 
+namespace lmms
+{
+
 
 template<class T>
 inline T tLimit( const T x, const T x1, const T x2 )
@@ -36,4 +39,5 @@ inline T tLimit( const T x, const T x1, const T x2 )
 }
 
 
+}
 #endif

--- a/include/update_event.h
+++ b/include/update_event.h
@@ -29,6 +29,9 @@
 #include "custom_events.h"
 
 
+namespace lmms
+{
+
 
 class updateEvent : public QEvent
 {
@@ -41,4 +44,5 @@ public:
 } ;
 
 
+}
 #endif

--- a/include/volume.h
+++ b/include/volume.h
@@ -31,6 +31,11 @@
 #include "lmms_basics.h"
 #include "Midi.h"
 
+
+namespace lmms
+{
+
+
 const volume_t MinVolume = 0;
 const volume_t MaxVolume = 200;
 const volume_t DefaultVolume = 100;
@@ -40,4 +45,6 @@ typedef struct
 	float vol[2];
 } stereoVolumeVector;
 
+
+}
 #endif

--- a/plugins/Amplifier/Amplifier.h
+++ b/plugins/Amplifier/Amplifier.h
@@ -31,6 +31,9 @@
 #include "AmplifierControls.h"
 #include "ValueBuffer.h"
 
+
+using namespace lmms;
+
 class AmplifierEffect : public Effect
 {
 public:

--- a/plugins/Amplifier/AmplifierControlDialog.h
+++ b/plugins/Amplifier/AmplifierControlDialog.h
@@ -32,6 +32,9 @@
 class AmplifierControls;
 
 
+using namespace lmms;
+
+
 class AmplifierControlDialog : public EffectControlDialog
 {
 	Q_OBJECT

--- a/plugins/Amplifier/AmplifierControls.h
+++ b/plugins/Amplifier/AmplifierControls.h
@@ -34,6 +34,9 @@
 class AmplifierEffect;
 
 
+using namespace lmms;
+
+
 class AmplifierControls : public EffectControls
 {
 	Q_OBJECT

--- a/plugins/BassBooster/BassBooster.h
+++ b/plugins/BassBooster/BassBooster.h
@@ -31,6 +31,8 @@
 #include "BassBoosterControls.h"
 
 
+using namespace lmms;
+
 class BassBoosterEffect : public Effect
 {
 public:

--- a/plugins/BassBooster/BassBoosterControlDialog.h
+++ b/plugins/BassBooster/BassBoosterControlDialog.h
@@ -27,6 +27,8 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
 
 class BassBoosterControls;
 

--- a/plugins/BassBooster/BassBoosterControls.h
+++ b/plugins/BassBooster/BassBoosterControls.h
@@ -29,6 +29,8 @@
 #include "BassBoosterControlDialog.h"
 #include "Knob.h"
 
+using namespace lmms;
+
 
 class BassBoosterEffect;
 

--- a/plugins/Bitcrush/Bitcrush.h
+++ b/plugins/Bitcrush/Bitcrush.h
@@ -33,6 +33,9 @@
 #include "lmms_math.h"
 #include "BasicFilters.h"
 
+using namespace lmms;
+
+
 class BitcrushEffect : public Effect
 {
 public:

--- a/plugins/Bitcrush/BitcrushControlDialog.h
+++ b/plugins/Bitcrush/BitcrushControlDialog.h
@@ -29,6 +29,9 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class BitcrushControls;
 
 class BitcrushControlDialog : public EffectControlDialog

--- a/plugins/Bitcrush/BitcrushControls.h
+++ b/plugins/Bitcrush/BitcrushControls.h
@@ -29,6 +29,9 @@
 #include "EffectControls.h"
 #include "BitcrushControlDialog.h"
 
+using namespace lmms;
+
+
 class BitcrushEffect;
 
 class BitcrushControls : public EffectControls

--- a/plugins/CrossoverEQ/CrossoverEQ.h
+++ b/plugins/CrossoverEQ/CrossoverEQ.h
@@ -33,6 +33,9 @@
 #include "lmms_math.h"
 #include "BasicFilters.h"
 
+using namespace lmms;
+
+
 class CrossoverEQEffect : public Effect
 {
 public:

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.h
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.h
@@ -30,6 +30,9 @@
 #include <QPixmap>
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class CrossoverEQControls;
 
 class CrossoverEQControlDialog : public EffectControlDialog

--- a/plugins/CrossoverEQ/CrossoverEQControls.h
+++ b/plugins/CrossoverEQ/CrossoverEQControls.h
@@ -30,6 +30,9 @@
 #include "EffectControls.h"
 #include "CrossoverEQControlDialog.h"
 
+using namespace lmms;
+
+
 class CrossoverEQEffect;
 
 class CrossoverEQControls : public EffectControls

--- a/plugins/Delay/DelayControls.h
+++ b/plugins/Delay/DelayControls.h
@@ -29,6 +29,7 @@
 #include "Knob.h"
 #include "DelayControlsDialog.h"
 
+using namespace lmms;
 
 
 class DelayEffect;

--- a/plugins/Delay/DelayControlsDialog.h
+++ b/plugins/Delay/DelayControlsDialog.h
@@ -28,6 +28,9 @@
 #include "EffectControlDialog.h"
 #include "AutomatableModel.h"
 
+using namespace lmms;
+
+
 class DelayControls;
 
 class DelayControlsDialog : public EffectControlDialog

--- a/plugins/Delay/DelayEffect.h
+++ b/plugins/Delay/DelayEffect.h
@@ -31,6 +31,9 @@
 #include "StereoDelay.h"
 #include "ValueBuffer.h"
 
+using namespace lmms;
+
+
 class DelayEffect : public Effect
 {
 public:

--- a/plugins/Delay/Lfo.h
+++ b/plugins/Delay/Lfo.h
@@ -27,6 +27,9 @@
 
 #include "lmms_math.h"
 
+using namespace lmms;
+
+
 class Lfo
 {
 public:

--- a/plugins/Delay/StereoDelay.h
+++ b/plugins/Delay/StereoDelay.h
@@ -27,6 +27,9 @@
 
 #include "lmms_basics.h"
 
+using namespace lmms;
+
+
 class StereoDelay
 {
 public:

--- a/plugins/DualFilter/DualFilter.h
+++ b/plugins/DualFilter/DualFilter.h
@@ -31,6 +31,9 @@
 #include "DualFilterControls.h"
 #include "BasicFilters.h"
 
+using namespace lmms;
+
+
 class DualFilterEffect : public Effect
 {
 public:

--- a/plugins/DualFilter/DualFilterControlDialog.h
+++ b/plugins/DualFilter/DualFilterControlDialog.h
@@ -28,6 +28,8 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
 
 class DualFilterControls;
 

--- a/plugins/DualFilter/DualFilterControls.h
+++ b/plugins/DualFilter/DualFilterControls.h
@@ -31,6 +31,9 @@
 #include "Knob.h"
 #include "ComboBoxModel.h"
 
+using namespace lmms;
+
+
 class DualFilterEffect;
 
 

--- a/plugins/Eq/EqControls.h
+++ b/plugins/Eq/EqControls.h
@@ -29,6 +29,8 @@
 #include "EqControlsDialog.h"
 #include "Knob.h"
 
+using namespace lmms;
+
 
 class EqEffect;
 

--- a/plugins/Eq/EqControlsDialog.h
+++ b/plugins/Eq/EqControlsDialog.h
@@ -34,6 +34,8 @@
 #include "qpushbutton.h"
 #include "EqSpectrumView.h"
 
+using namespace lmms;
+
 
 class EqControls;
 

--- a/plugins/Eq/EqEffect.h
+++ b/plugins/Eq/EqEffect.h
@@ -31,6 +31,7 @@
 #include "BasicFilters.h"
 #include "EqFilter.h"
 
+using namespace lmms;
 
 
 class EqEffect : public Effect

--- a/plugins/Eq/EqFader.h
+++ b/plugins/Eq/EqFader.h
@@ -32,6 +32,8 @@
 #include "qlist.h"
 
 
+using namespace lmms;
+
 
 class EqFader : public Fader
 {

--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -28,6 +28,9 @@
 #include "BasicFilters.h"
 #include "lmms_math.h"
 
+using namespace lmms;
+
+
 ///
 /// \brief The EqFilter class.
 /// A wrapper for the StereoBiQuad class, giving it freq, res, and gain controls.

--- a/plugins/Eq/EqParameterWidget.h
+++ b/plugins/Eq/EqParameterWidget.h
@@ -29,6 +29,9 @@
 #include "EffectControls.h"
 #include "TextFloat.h"
 
+using namespace lmms;
+
+
 class EqControls;
 
 

--- a/plugins/Eq/EqSpectrumView.h
+++ b/plugins/Eq/EqSpectrumView.h
@@ -29,6 +29,8 @@
 #include "fft_helpers.h"
 #include "Engine.h"
 
+using namespace lmms;
+
 
 const int MAX_BANDS = 2048;
 

--- a/plugins/Flanger/FlangerControls.h
+++ b/plugins/Flanger/FlangerControls.h
@@ -29,6 +29,8 @@
 #include "Knob.h"
 #include "FlangerControlsDialog.h"
 
+using namespace lmms;
+
 
 class FlangerEffect;
 

--- a/plugins/Flanger/FlangerControlsDialog.h
+++ b/plugins/Flanger/FlangerControlsDialog.h
@@ -27,6 +27,9 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class FlangerControls;
 
 class FlangerControlsDialog : public EffectControlDialog

--- a/plugins/Flanger/FlangerEffect.h
+++ b/plugins/Flanger/FlangerEffect.h
@@ -32,6 +32,8 @@
 #include "MonoDelay.h"
 #include "Noise.h"
 
+using namespace lmms;
+
 
 class FlangerEffect : public Effect
 {

--- a/plugins/Flanger/MonoDelay.h
+++ b/plugins/Flanger/MonoDelay.h
@@ -27,6 +27,9 @@
 
 #include "lmms_basics.h"
 
+using namespace lmms;
+
+
 class MonoDelay
 {
 public:

--- a/plugins/Flanger/Noise.cpp
+++ b/plugins/Flanger/Noise.cpp
@@ -25,6 +25,9 @@
 #include "Noise.h"
 #include "lmms_math.h"
 
+using namespace lmms;
+
+
 Noise::Noise()
 {
 	inv_randmax = 1.0/FAST_RAND_MAX; /* for range of 0 - 1.0 */

--- a/plugins/Flanger/QuadratureLfo.h
+++ b/plugins/Flanger/QuadratureLfo.h
@@ -27,6 +27,9 @@
 
 #include "lmms_math.h"
 
+using namespace lmms;
+
+
 class QuadratureLfo
 {
 public:

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -42,12 +42,16 @@
 #include "gig.h"
 
 class GigInstrumentView;
-class NotePlayHandle;
 
 class PatchesDialog;
 class QLabel;
 
+namespace lmms
+{
+class NotePlayHandle;
+}
 
+using namespace lmms;
 
 
 struct GIGPluginData

--- a/plugins/GigPlayer/PatchesDialog.h
+++ b/plugins/GigPlayer/PatchesDialog.h
@@ -34,6 +34,8 @@
 #include <QWidget>
 #include <QLabel>
 
+using namespace lmms;
+
 //----------------------------------------------------------------------------
 // qsynthPresetForm -- UI wrapper form.
 

--- a/plugins/HydrogenImport/HydrogenImport.h
+++ b/plugins/HydrogenImport/HydrogenImport.h
@@ -7,6 +7,8 @@
 
 #include "ImportFilter.h"
 
+using namespace lmms;
+
 
 class HydrogenImport : public ImportFilter
 {

--- a/plugins/LadspaEffect/LadspaControlDialog.h
+++ b/plugins/LadspaEffect/LadspaControlDialog.h
@@ -32,7 +32,13 @@
 
 class QHBoxLayout;
 class LadspaControls;
+
+namespace lmms
+{
 class LedCheckBox;
+}
+
+using namespace lmms;
 
 
 class LadspaControlDialog : public EffectControlDialog

--- a/plugins/LadspaEffect/LadspaControls.h
+++ b/plugins/LadspaEffect/LadspaControls.h
@@ -29,6 +29,8 @@
 #include "LadspaControl.h"
 #include "LadspaControlDialog.h"
 
+using namespace lmms;
+
 
 typedef QVector<LadspaControl *> control_list_t;
 

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -32,6 +32,8 @@
 #include "LadspaBase.h"
 #include "LadspaControls.h"
 
+using namespace lmms;
+
 
 typedef QVector<port_desc_t *> multi_proc_t;
 

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.h
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.h
@@ -31,6 +31,8 @@
 #include "LadspaManager.h"
 #include "Plugin.h"
 
+using namespace lmms;
+
 
 class LadspaSubPluginFeatures : public Plugin::Descriptor::SubPluginFeatures
 {

--- a/plugins/MidiExport/MidiExport.h
+++ b/plugins/MidiExport/MidiExport.h
@@ -31,6 +31,8 @@
 #include "MidiFile.hpp"
 
 
+using namespace lmms;
+
 
 class MidiExport: public ExportFilter
 {

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -32,6 +32,8 @@
 #include "MidiEvent.h"
 #include "ImportFilter.h"
 
+using namespace lmms;
+
 
 class MidiImport : public ImportFilter
 {

--- a/plugins/MultitapEcho/MultitapEcho.h
+++ b/plugins/MultitapEcho/MultitapEcho.h
@@ -33,6 +33,9 @@
 #include "lmms_math.h"
 #include "BasicFilters.h"
 
+using namespace lmms;
+
+
 class MultitapEchoEffect : public Effect
 {
 public:

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.h
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.h
@@ -29,6 +29,9 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class MultitapEchoControls;
 
 class MultitapEchoControlDialog : public EffectControlDialog

--- a/plugins/MultitapEcho/MultitapEchoControls.h
+++ b/plugins/MultitapEcho/MultitapEchoControls.h
@@ -31,6 +31,8 @@
 #include "Knob.h"
 #include "Graph.h"
 
+using namespace lmms;
+
 
 class MultitapEchoEffect;
 

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzer.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzer.h
@@ -30,6 +30,8 @@
 #include "fft_helpers.h"
 #include "SpectrumAnalyzerControls.h"
 
+using namespace lmms;
+
 
 const int MAX_BANDS = 249;
 

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.h
@@ -27,6 +27,8 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
 
 class SpectrumAnalyzerControls;
 

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzerControls.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzerControls.h
@@ -29,6 +29,8 @@
 #include "SpectrumAnalyzerControlDialog.h"
 #include "Knob.h"
 
+using namespace lmms;
+
 
 class SpectrumAnalyzer;
 

--- a/plugins/VstEffect/VstEffect.h
+++ b/plugins/VstEffect/VstEffect.h
@@ -32,6 +32,8 @@
 #include "VstEffectControlDialog.h"
 #include "VstEffectControls.h"
 
+using namespace lmms;
+
 
 class VstEffect : public Effect
 {

--- a/plugins/VstEffect/VstEffectControlDialog.h
+++ b/plugins/VstEffect/VstEffectControlDialog.h
@@ -34,10 +34,14 @@
 
 
 class VstEffectControls;
-class PixmapButton;
 class QPixmap;
 class QPushButton;
+
+namespace lmms
+{
 class PixmapButton;
+}
+using namespace lmms;
 
 
 class VstEffectControlDialog : public EffectControlDialog

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -39,6 +39,8 @@
 #include <QPainter>
 #include <QObject>
 
+using namespace lmms;
+
 
 class VstEffect;
 

--- a/plugins/VstEffect/VstSubPluginFeatures.h
+++ b/plugins/VstEffect/VstSubPluginFeatures.h
@@ -29,6 +29,8 @@
 
 #include "Effect.h"
 
+using namespace lmms;
+
 
 class VstSubPluginFeatures : public Plugin::Descriptor::SubPluginFeatures
 {
@@ -46,7 +48,4 @@ private:
 
 
 
-
-
 #endif
-

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -38,6 +38,8 @@
 #include "ComboBox.h"
 
 
+using namespace lmms;
+
 class audioFileProcessor : public Instrument
 {
 	Q_OBJECT

--- a/plugins/bit_invader/bit_invader.h
+++ b/plugins/bit_invader/bit_invader.h
@@ -38,6 +38,10 @@
 class oscillator;
 class bitInvaderView;
 
+
+using namespace lmms;
+
+
 class bSynth
 {
 	MM_OPERATORS

--- a/plugins/carlabase/carla.h
+++ b/plugins/carlabase/carla.h
@@ -32,6 +32,9 @@
 
 class QPushButton;
 
+
+using namespace lmms;
+
 class PLUGIN_EXPORT CarlaInstrument : public Instrument
 {
     Q_OBJECT

--- a/plugins/dynamics_processor/dynamics_processor.h
+++ b/plugins/dynamics_processor/dynamics_processor.h
@@ -32,6 +32,9 @@
 #include "RmsHelper.h"
 
 
+using namespace lmms;
+
+
 class dynProcEffect : public Effect
 {
 public:

--- a/plugins/dynamics_processor/dynamics_processor_control_dialog.h
+++ b/plugins/dynamics_processor/dynamics_processor_control_dialog.h
@@ -28,6 +28,8 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
 
 class dynProcControls;
 

--- a/plugins/dynamics_processor/dynamics_processor_controls.h
+++ b/plugins/dynamics_processor/dynamics_processor_controls.h
@@ -34,6 +34,9 @@
 class dynProcEffect;
 
 
+using namespace lmms;
+
+
 class dynProcControls : public EffectControls
 {
 	Q_OBJECT

--- a/plugins/flp_import/FlpImport.h
+++ b/plugins/flp_import/FlpImport.h
@@ -37,6 +37,10 @@
 class instrument;
 struct FL_Channel;
 
+
+using namespace lmms;
+
+
 class FlpImport : public ImportFilter
 {
 public:

--- a/plugins/kicker/KickerOsc.h
+++ b/plugins/kicker/KickerOsc.h
@@ -34,6 +34,8 @@
 #include "MemoryManager.h"
 
 
+using namespace lmms;
+
 template<class FX = DspEffectLibrary::StereoBypass>
 class KickerOsc
 {

--- a/plugins/kicker/kicker.h
+++ b/plugins/kicker/kicker.h
@@ -39,8 +39,13 @@
 
 
 class kickerInstrumentView;
-class NotePlayHandle;
 
+namespace lmms
+{
+class NotePlayHandle;
+}
+
+using namespace lmms;
 
 class kickerInstrument : public Instrument
 {

--- a/plugins/ladspa_browser/ladspa_browser.h
+++ b/plugins/ladspa_browser/ladspa_browser.h
@@ -31,8 +31,12 @@
 #include "ToolPlugin.h"
 #include "ToolPluginView.h"
 
+namespace lmms
+{
 class TabBar;
+}
 
+using namespace lmms;
 
 class ladspaBrowserView : public ToolPluginView
 {

--- a/plugins/ladspa_browser/ladspa_description.h
+++ b/plugins/ladspa_browser/ladspa_description.h
@@ -36,6 +36,8 @@ class QListWidgetItem;
 class QScrollArea;
 
 
+using namespace lmms;
+
 class ladspaDescription : public QWidget
 {
 	Q_OBJECT

--- a/plugins/ladspa_browser/ladspa_port_dialog.h
+++ b/plugins/ladspa_browser/ladspa_port_dialog.h
@@ -32,6 +32,7 @@
 #include "LadspaManager.h"
 
 
+using namespace lmms;
 
 
 class ladspaPortDialog : public QDialog

--- a/plugins/lb302/lb302.h
+++ b/plugins/lb302/lb302.h
@@ -41,10 +41,18 @@
 #include "NotePlayHandle.h"
 #include <QMutex>
 
+
+namespace lmms
+{
+class NotePlayHandle;
+}
+
+using namespace lmms;
+
+
 static const int NUM_FILTERS = 2;
 
 class lb302SynthView;
-class NotePlayHandle;
 
 class lb302FilterKnobState
 {

--- a/plugins/lb303/lb303.h
+++ b/plugins/lb303/lb303.h
@@ -39,8 +39,15 @@
 #include "Knob.h"
 #include "Mixer.h"
 
-class lb303SynthView;
+
+namespace lmms
+{
 class NotePlayHandle;
+}
+
+using namespace lmms;
+
+class lb303SynthView;
 
 class lb303FilterKnobState
 {

--- a/plugins/monstro/Monstro.h
+++ b/plugins/monstro/Monstro.h
@@ -39,6 +39,8 @@
 #include "lmms_math.h"
 #include "BandLimitedWave.h"
 
+using namespace lmms;
+
 //
 //	UI Macros
 //

--- a/plugins/nes/Nes.h
+++ b/plugins/nes/Nes.h
@@ -34,6 +34,8 @@
 #include "PixmapButton.h"
 #include "MemoryManager.h"
 
+using namespace lmms;
+
 
 #define makeknob( name, x, y, hint, unit, oname ) 		\
 	name = new Knob( knobStyled, this ); 				\

--- a/plugins/opl2/opl2instrument.h
+++ b/plugins/opl2/opl2instrument.h
@@ -41,6 +41,9 @@
 // The "normal" range for LMMS pitchbends
 #define DEFAULT_BEND_CENTS 100
 
+
+using namespace lmms;
+
 class opl2instrument : public Instrument
 {
 	Q_OBJECT

--- a/plugins/organic/organic.h
+++ b/plugins/organic/organic.h
@@ -35,9 +35,14 @@
 
 class QPixmap;
 
+namespace lmms
+{
 class Knob;
 class NotePlayHandle;
 class PixmapButton;
+}
+
+using namespace lmms;
 
 const int NUM_HARMONICS = 18;
 const QString HARMONIC_NAMES[NUM_HARMONICS] =  {

--- a/plugins/papu/Basic_Gb_Apu.h
+++ b/plugins/papu/Basic_Gb_Apu.h
@@ -10,6 +10,8 @@
 #include "gb_apu/Multi_Buffer.h"
 #include "MemoryManager.h"
 
+using namespace lmms;
+
 class Basic_Gb_Apu {
 	MM_OPERATORS
 public:

--- a/plugins/papu/papu_instrument.h
+++ b/plugins/papu/papu_instrument.h
@@ -33,8 +33,14 @@
 #include "Graph.h"
 
 class papuInstrumentView;
+
+namespace lmms
+{
 class NotePlayHandle;
 class PixmapButton;
+}
+
+using namespace lmms;
 
 class papuInstrument : public Instrument
 {

--- a/plugins/patman/patman.h
+++ b/plugins/patman/patman.h
@@ -32,8 +32,12 @@
 #include "AutomatableModel.h"
 #include "MemoryManager.h"
 
+namespace lmms
+{
 class PixmapButton;
+}
 
+using namespace lmms;
 
 #define MODES_16BIT	( 1 << 0 )
 #define MODES_UNSIGNED	( 1 << 1 )

--- a/plugins/peak_controller_effect/peak_controller_effect.h
+++ b/plugins/peak_controller_effect/peak_controller_effect.h
@@ -29,6 +29,9 @@
 #include "Effect.h"
 #include "peak_controller_effect_controls.h"
 
+
+using namespace lmms;
+
 class PeakControllerEffect : public Effect
 {
 public:

--- a/plugins/peak_controller_effect/peak_controller_effect_control_dialog.h
+++ b/plugins/peak_controller_effect/peak_controller_effect_control_dialog.h
@@ -29,9 +29,15 @@
 #include "EffectControlDialog.h"
 
 class PeakControllerEffectControls;
+
+namespace lmms
+{
 class Knob;
 class LedCheckBox;
+}
 
+
+using namespace lmms;
 
 class PeakControllerEffectControlDialog : public EffectControlDialog
 {

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.h
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.h
@@ -30,7 +30,10 @@
 #include "peak_controller_effect_control_dialog.h"
 #include "Knob.h"
 
+
 class PeakControllerEffect;
+
+using namespace lmms;
 
 class PeakControllerEffectControls : public EffectControls
 {

--- a/plugins/sf2_player/patches_dialog.h
+++ b/plugins/sf2_player/patches_dialog.h
@@ -33,6 +33,9 @@
 #include <QWidget>
 #include <QLabel>
 
+
+using namespace lmms;
+
 //----------------------------------------------------------------------------
 // qsynthPresetForm -- UI wrapper form.
 

--- a/plugins/sf2_player/sf2_player.h
+++ b/plugins/sf2_player/sf2_player.h
@@ -41,12 +41,18 @@
 
 class sf2InstrumentView;
 class sf2Font;
-class NotePlayHandle;
 
 class patchesDialog;
 class QLabel;
 
 struct SF2PluginData;
+
+namespace lmms
+{
+class NotePlayHandle;
+}
+
+using namespace lmms;
 
 class sf2Instrument : public Instrument
 {

--- a/plugins/sfxr/sfxr.h
+++ b/plugins/sfxr/sfxr.h
@@ -37,6 +37,8 @@
 #include "MemoryManager.h"
 
 
+using namespace lmms;
+
 enum SfxrWaves
 {
 	SQR_WAVE, SAW_WAVE, SINE_WAVE, NOISE_WAVE, WAVES_NUM

--- a/plugins/sid/sid_instrument.h
+++ b/plugins/sid/sid_instrument.h
@@ -34,9 +34,16 @@
 
 
 class sidInstrumentView;
+
+namespace lmms
+{
 class NotePlayHandle;
 class automatableButtonGroup;
 class PixmapButton;
+}
+
+using namespace lmms;
+
 
 class voiceObject : public Model
 {

--- a/plugins/stereo_enhancer/stereo_enhancer.h
+++ b/plugins/stereo_enhancer/stereo_enhancer.h
@@ -31,6 +31,10 @@
 #include "Engine.h"
 #include "stereoenhancer_controls.h"
 
+
+using namespace lmms;
+
+
 class stereoEnhancerEffect : public Effect
 {
 public:

--- a/plugins/stereo_enhancer/stereoenhancer_control_dialog.h
+++ b/plugins/stereo_enhancer/stereoenhancer_control_dialog.h
@@ -27,6 +27,9 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class stereoEnhancerControls;
 
 

--- a/plugins/stereo_enhancer/stereoenhancer_controls.h
+++ b/plugins/stereo_enhancer/stereoenhancer_controls.h
@@ -29,6 +29,9 @@
 #include "stereoenhancer_control_dialog.h"
 #include "Knob.h"
 
+
+using namespace lmms;
+
 class stereoEnhancerEffect;
 
 class stereoEnhancerControls : public EffectControls

--- a/plugins/stereo_matrix/stereo_matrix.h
+++ b/plugins/stereo_matrix/stereo_matrix.h
@@ -29,6 +29,9 @@
 #include "Effect.h"
 #include "stereomatrix_controls.h"
 
+
+using namespace lmms;
+
 class stereoMatrixEffect : public Effect
 {
 public:

--- a/plugins/stereo_matrix/stereomatrix_control_dialog.h
+++ b/plugins/stereo_matrix/stereomatrix_control_dialog.h
@@ -27,6 +27,9 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
+
+
 class stereoMatrixControls;
 
 

--- a/plugins/stereo_matrix/stereomatrix_controls.h
+++ b/plugins/stereo_matrix/stereomatrix_controls.h
@@ -29,7 +29,11 @@
 #include "stereomatrix_control_dialog.h"
 #include "Knob.h"
 
+using namespace lmms;
+
+
 class stereoMatrixEffect;
+
 
 class stereoMatrixControls : public EffectControls
 {

--- a/plugins/stk/mallets/mallets.h
+++ b/plugins/stk/mallets/mallets.h
@@ -36,6 +36,9 @@
 #include "NotePlayHandle.h"
 #include "LedCheckbox.h"
 
+using namespace lmms;
+
+
 // As of Stk 4.4 all classes and types have been moved to the namespace "stk".
 // However in older versions this namespace does not exist, therefore declare it
 // so this plugin builds with all versions of Stk.

--- a/plugins/triple_oscillator/TripleOscillator.h
+++ b/plugins/triple_oscillator/TripleOscillator.h
@@ -31,12 +31,16 @@
 #include "Oscillator.h"
 #include "AutomatableModel.h"
 
-
+namespace lmms
+{
 class automatableButtonGroup;
 class Knob;
 class NotePlayHandle;
 class PixmapButton;
 class SampleBuffer;
+}
+
+using namespace lmms;
 
 const int NUM_OF_OSCILLATORS = 3;
 

--- a/plugins/vestige/vestige.h
+++ b/plugins/vestige/vestige.h
@@ -43,8 +43,15 @@
 class QPixmap;
 class QPushButton;
 
-class PixmapButton;
 class VstPlugin;
+
+namespace lmms
+{
+class PixmapButton;
+}
+
+using namespace lmms;
+
 
 
 class vestigeInstrument : public Instrument

--- a/plugins/vibed/nine_button_selector.h
+++ b/plugins/vibed/nine_button_selector.h
@@ -27,6 +27,7 @@
 
 #include "PixmapButton.h"
 
+using namespace lmms;
 
 class nineButtonSelector: public QWidget , public IntModelView
 {

--- a/plugins/vibed/string_container.h
+++ b/plugins/vibed/string_container.h
@@ -29,6 +29,7 @@
 #include "vibrating_string.h"
 #include "MemoryManager.h"
 
+using namespace lmms;
 
 class stringContainer
 {

--- a/plugins/vibed/vibed.h
+++ b/plugins/vibed/vibed.h
@@ -33,7 +33,14 @@
 #include "nine_button_selector.h"
 
 class vibedView;
+
+namespace lmms
+{
 class NotePlayHandle;
+}
+
+using namespace lmms;
+
 
 class vibed : public Instrument
 {

--- a/plugins/vibed/vibrating_string.h
+++ b/plugins/vibed/vibrating_string.h
@@ -29,6 +29,8 @@
 
 #include "lmms_basics.h"
 
+using namespace lmms;
+
 class vibratingString
 {
 

--- a/plugins/vst_base/VstPlugin.h
+++ b/plugins/vst_base/VstPlugin.h
@@ -36,6 +36,8 @@
 #include "JournallingObject.h"
 #include "communication.h"
 
+using namespace lmms;
+
 
 class PLUGIN_EXPORT VstPlugin : public QObject, public JournallingObject,
 								public RemotePlugin

--- a/plugins/vst_base/communication.h
+++ b/plugins/vst_base/communication.h
@@ -29,6 +29,7 @@
 
 #include "RemotePlugin.h"
 
+using namespace lmms;
 
 struct VstParameterDumpItem
 {

--- a/plugins/vst_base/vst_base.cpp
+++ b/plugins/vst_base/vst_base.cpp
@@ -27,6 +27,7 @@
 #include "Plugin.h"
 #include "embed.h"
 
+using namespace lmms;
 
 extern "C"
 {

--- a/plugins/watsyn/Watsyn.h
+++ b/plugins/watsyn/Watsyn.h
@@ -37,6 +37,7 @@
 #include <samplerate.h>
 #include "MemoryManager.h"
 
+using namespace lmms;
 
 #define makeknob( name, x, y, hint, unit, oname ) 		\
 	name = new Knob( knobStyled, this ); 				\

--- a/plugins/waveshaper/waveshaper.h
+++ b/plugins/waveshaper/waveshaper.h
@@ -30,6 +30,7 @@
 #include "Effect.h"
 #include "waveshaper_controls.h"
 
+using namespace lmms;
 
 
 class waveShaperEffect : public Effect

--- a/plugins/waveshaper/waveshaper_control_dialog.h
+++ b/plugins/waveshaper/waveshaper_control_dialog.h
@@ -28,6 +28,7 @@
 
 #include "EffectControlDialog.h"
 
+using namespace lmms;
 
 class waveShaperControls;
 

--- a/plugins/waveshaper/waveshaper_controls.h
+++ b/plugins/waveshaper/waveshaper_controls.h
@@ -31,6 +31,9 @@
 #include "Knob.h"
 #include "Graph.h"
 
+using namespace lmms;
+
+
 class waveShaperEffect;
 
 

--- a/plugins/zynaddsubfx/LocalZynAddSubFx.h
+++ b/plugins/zynaddsubfx/LocalZynAddSubFx.h
@@ -28,6 +28,8 @@
 #include "MidiEvent.h"
 #include "Note.h"
 
+using namespace lmms;
+
 class Master;
 class NulEngine;
 

--- a/plugins/zynaddsubfx/RemoteZynAddSubFx.h
+++ b/plugins/zynaddsubfx/RemoteZynAddSubFx.h
@@ -27,6 +27,8 @@
 
 #include "RemotePlugin.h"
 
+using namespace lmms;
+
 enum ZasfRemoteMessageIDs
 {
 	IdZasfPresetDirectory = IdUserBase,

--- a/plugins/zynaddsubfx/ZynAddSubFx.h
+++ b/plugins/zynaddsubfx/ZynAddSubFx.h
@@ -39,9 +39,15 @@ class QPushButton;
 
 class LocalZynAddSubFx;
 class ZynAddSubFxView;
+
+namespace lmms
+{
 class NotePlayHandle;
 class Knob;
 class LedCheckBox;
+}
+
+using namespace lmms;
 
 
 class ZynAddSubFxRemotePlugin : public QObject, public RemotePlugin

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -28,6 +28,10 @@
 #include "ControllerConnection.h"
 #include "lmms_math.h"
 
+
+namespace lmms
+{
+
 float AutomatableModel::s_copiedValue = 0;
 long AutomatableModel::s_periodCounter = 0;
 
@@ -707,4 +711,4 @@ float AutomatableModel::globalAutomationValueAt( const MidiTime& time )
 
 
 
-
+}

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -248,7 +248,7 @@ void AutomatableModel::setValue( const float value )
 
 template<class T> T AutomatableModel::logToLinearScale( T value ) const
 {
-	return castValue<T>( ::logToLinearScale( minValue<float>(), maxValue<float>(), static_cast<float>( value ) ) );
+	return castValue<T>( lmms::logToLinearScale( minValue<float>(), maxValue<float>(), static_cast<float>( value ) ) );
 }
 
 
@@ -264,7 +264,7 @@ float AutomatableModel::inverseScaledValue( float value ) const
 {
 	return m_scaleType == Linear
 		? value
-		: ::linearToLogScale( minValue<float>(), maxValue<float>(), value );
+		: lmms::linearToLogScale( minValue<float>(), maxValue<float>(), value );
 }
 
 
@@ -299,7 +299,7 @@ void roundAt( T& value, const T& where, const T& step_size )
 template<class T>
 void AutomatableModel::roundAt( T& value, const T& where ) const
 {
-	::roundAt(value, where, m_step);
+	lmms::roundAt(value, where, m_step);
 }
 
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -33,6 +33,10 @@
 #include "Song.h"
 #include "embed.h"
 
+
+namespace lmms
+{
+
 int AutomationPattern::s_quantization = 1;
 const float AutomationPattern::DEFAULT_MIN_VALUE = 0;
 const float AutomationPattern::DEFAULT_MAX_VALUE = 1;
@@ -895,4 +899,4 @@ void AutomationPattern::generateTangents( timeMap::const_iterator it,
 
 
 
-
+}

--- a/src/core/BBTrackContainer.cpp
+++ b/src/core/BBTrackContainer.cpp
@@ -30,6 +30,9 @@
 
 
 
+namespace lmms
+{
+
 BBTrackContainer::BBTrackContainer() :
 	TrackContainer(),
 	m_bbComboBoxModel( this )
@@ -262,4 +265,4 @@ void BBTrackContainer::createTCOsForBB( int _bb )
 
 
 
-
+}

--- a/src/core/BandLimitedWave.cpp
+++ b/src/core/BandLimitedWave.cpp
@@ -27,6 +27,10 @@
 
 #include "ConfigManager.h"
 
+
+namespace lmms
+{
+
 WaveMipMap BandLimitedWave::s_waveforms[4] = {  };
 bool BandLimitedWave::s_wavesGenerated = false;
 QString BandLimitedWave::s_wavetableDir = "";
@@ -268,5 +272,8 @@ moogout << s_waveforms[ BandLimitedWave::BLMoog ];
 moogfile.close();
 
 */
+
+}
+
 
 }

--- a/src/core/BufferManager.cpp
+++ b/src/core/BufferManager.cpp
@@ -30,6 +30,10 @@
 
 #include "MemoryManager.h"
 
+
+namespace lmms
+{
+
 sampleFrame ** BufferManager::s_available;
 QAtomicInt BufferManager::s_availableIndex = 0;
 sampleFrame ** BufferManager::s_released;
@@ -112,3 +116,6 @@ void BufferManager::extend( int c )
 		b += Engine::mixer()->framesPerPeriod();
 	}
 }*/
+
+
+}

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -26,6 +26,9 @@
 #include "JournallingObject.h"
 
 
+namespace lmms
+{
+
 Clipboard::Map Clipboard::content;
 
 
@@ -51,3 +54,4 @@ const QDomElement * Clipboard::getContent( const QString & _node_name )
 
 
 
+}

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -26,6 +26,8 @@
 #include "embed.h"
 
 
+namespace lmms
+{
 
 void ComboBoxModel::addItem( const QString& item, PixmapLoader* loader )
 {
@@ -67,4 +69,4 @@ int ComboBoxModel::findText( const QString& txt ) const
 
 
 
-
+}

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -33,6 +33,10 @@
 #include "ProjectVersion.h"
 
 
+
+namespace lmms
+{
+
 static inline QString ensureTrailingSlash( const QString & _s )
 {
 	if( _s.right( 1 ) != QDir::separator() )
@@ -497,3 +501,4 @@ void ConfigManager::saveConfigFile()
 }
 
 
+}

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -40,6 +40,10 @@
 #include "PeakController.h"
 
 
+
+namespace lmms
+{
+
 long Controller::s_periods = 0;
 QVector<Controller *> Controller::s_controllers;
 
@@ -351,4 +355,4 @@ int Controller::connectionCount() const{
 
 
 
-
+}

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -217,7 +217,7 @@ Controller * Controller::create( ControllerTypes _ct, Model * _parent )
 			break;
 
 		case Controller::LfoController:
-			c = new ::LfoController( _parent );
+			c = new lmms::LfoController( _parent );
 			break;
 
 		case Controller::PeakController:
@@ -226,7 +226,7 @@ Controller * Controller::create( ControllerTypes _ct, Model * _parent )
 			break;
 
 		case Controller::MidiController:
-			c = new ::MidiController( _parent );
+			c = new lmms::MidiController( _parent );
 			break;
 
 		default: 

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -33,6 +33,10 @@
 #include "ControllerConnection.h"
 
 
+
+namespace lmms
+{
+
 ControllerConnectionVector ControllerConnection::s_connections;
 
 
@@ -221,4 +225,4 @@ void ControllerConnection::deleteConnection()
 
 
 
-
+}

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -45,6 +45,10 @@
 
 
 
+namespace lmms
+{
+
+
 DataFile::typeDescStruct
 		DataFile::s_types[DataFile::TypeCount] =
 {
@@ -879,3 +883,4 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 							item( 0 ).toElement();
 }
 
+}

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -45,6 +45,11 @@ using namespace std;
 #define DWORD __u32
 #define WAVE_FORMAT_PCM			0x0001
 
+
+
+namespace lmms
+{
+
 // const int     Fs    =  44100;
 const float   TwoPi =  6.2831853f;
 const int     MAX   =  0;
@@ -732,3 +737,5 @@ int DrumSynth::GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels
   return Length;
 }
 
+
+}

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -34,6 +34,10 @@
 #include "ConfigManager.h"
 
 
+namespace lmms
+{
+
+
 Effect::Effect( const Plugin::Descriptor * _desc,
 			Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
@@ -217,3 +221,5 @@ void Effect::resample( int _i, const sampleFrame * _src_buf,
 	}
 }
 
+
+}

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -34,6 +34,10 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
+
 EffectChain::EffectChain( Model * _parent ) :
 	Model( _parent ),
 	SerializingObject(),
@@ -265,4 +269,4 @@ void EffectChain::clear()
 
 
 
-
+}

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -37,6 +37,11 @@
 
 #include "GuiApplication.h"
 
+
+namespace lmms
+{
+
+
 float Engine::s_framesPerTick;
 Mixer* Engine::s_mixer = NULL;
 FxMixer * Engine::s_fxMixer = NULL;
@@ -150,3 +155,5 @@ void Engine::initPluginFileHandling()
 
 
 Engine * Engine::s_instanceOfMe = NULL;
+
+}

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -30,6 +30,10 @@
 #include "Oscillator.h"
 
 
+namespace lmms
+{
+
+
 // how long should be each envelope-segment maximal (e.g. attack)?
 extern const float SECS_PER_ENV_SEGMENT = 5.0f;
 // how long should be one LFO-oscillation maximal?
@@ -540,5 +544,5 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 
 
 
-
+}
 

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -33,6 +33,11 @@
 #include "BBTrackContainer.h"
 #include "ValueBuffer.h"
 
+
+namespace lmms
+{
+
+
 FxRoute::FxRoute( FxChannel * from, FxChannel * to, float amount ) :
 	m_from( from ),
 	m_to( to ),
@@ -771,3 +776,5 @@ void FxMixer::validateChannelName( int index, int oldIndex )
 	}
 }
 
+
+}

--- a/src/core/ImportFilter.cpp
+++ b/src/core/ImportFilter.cpp
@@ -31,6 +31,9 @@
 #include "ProjectJournal.h"
 
 
+namespace lmms
+{
+
 
 ImportFilter::ImportFilter( const QString & _file_name,
 							const Descriptor * _descriptor ) :
@@ -124,3 +127,4 @@ bool ImportFilter::openFile()
 
 
 
+}

--- a/src/core/InlineAutomation.cpp
+++ b/src/core/InlineAutomation.cpp
@@ -27,6 +27,10 @@
 #include "InlineAutomation.h"
 
 
+namespace lmms
+{
+
+
 void InlineAutomation::saveSettings( QDomDocument & _doc,
 							QDomElement & _parent )
 {
@@ -58,3 +62,5 @@ void InlineAutomation::loadSettings( const QDomElement & _this )
 	}
 }
 
+
+}

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -29,6 +29,10 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
+
 Instrument::Instrument( InstrumentTrack * _instrument_track,
 					const Descriptor * _descriptor ) :
 	Plugin( _descriptor, NULL/* _instrument_track*/ ),
@@ -126,4 +130,4 @@ QString Instrument::fullDisplayName() const
 }
 
 
-
+}

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -32,6 +32,9 @@
 #include "PresetPreviewPlayHandle.h"
 
 
+namespace lmms
+{
+
 
 InstrumentFunctionNoteStacking::ChordTable::Init InstrumentFunctionNoteStacking::ChordTable::s_initTable[] =
 {
@@ -527,4 +530,4 @@ void InstrumentFunctionArpeggio::loadSettings( const QDomElement & _this )
 }
 
 
-
+}

--- a/src/core/InstrumentPlayHandle.cpp
+++ b/src/core/InstrumentPlayHandle.cpp
@@ -26,9 +26,17 @@
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
 
+
+namespace lmms
+{
+
+
 InstrumentPlayHandle::InstrumentPlayHandle( Instrument * instrument, InstrumentTrack* instrumentTrack ) :
 		PlayHandle( TypeInstrumentPlayHandle ),
 		m_instrument( instrument )
 {
 	setAudioPort( instrumentTrack->audioPort() );
+}
+
+
 }

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -35,6 +35,10 @@
 
 
 
+namespace lmms
+{
+
+
 const float CUT_FREQ_MULTIPLIER = 6000.0f;
 const float RES_MULTIPLIER = 2.0f;
 const float RES_PRECISION = 1000.0f;
@@ -367,6 +371,6 @@ void InstrumentSoundShaping::loadSettings( const QDomElement & _this )
 
 
 
-
+}
 
 

--- a/src/core/JournallingObject.cpp
+++ b/src/core/JournallingObject.cpp
@@ -32,6 +32,9 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
 
 JournallingObject::JournallingObject() :
 	SerializingObject(),
@@ -141,3 +144,5 @@ void JournallingObject::changeID( jo_id_t _id )
 }
 
 
+
+}

--- a/src/core/Ladspa2LMMS.cpp
+++ b/src/core/Ladspa2LMMS.cpp
@@ -27,6 +27,10 @@
 #include "Ladspa2LMMS.h"
 
 
+namespace lmms
+{
+
+
 Ladspa2LMMS::Ladspa2LMMS()
 {
 	l_sortable_plugin_t plugins = getSortedPlugins();
@@ -126,3 +130,5 @@ QString Ladspa2LMMS::getShortName( const ladspa_key_t & _key )
 	return name;
 }
 
+
+}

--- a/src/core/LadspaControl.cpp
+++ b/src/core/LadspaControl.cpp
@@ -29,6 +29,10 @@
 #include "LadspaBase.h"
 
 
+namespace lmms
+{
+
+
 LadspaControl::LadspaControl( Model * _parent, port_desc_t * _port,
 								bool _link ) :
 	Model( _parent ),
@@ -339,4 +343,4 @@ void LadspaControl::setLink( bool _state )
 
 
 
-
+}

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -37,6 +37,10 @@
 
 
 
+namespace lmms
+{
+
+
 LadspaManager::LadspaManager()
 {
 	QStringList ladspaDirectories = QString( getenv( "LADSPA_PATH" ) ).
@@ -993,4 +997,7 @@ bool LadspaManager::cleanup( const ladspa_key_t & _plugin,
 		}
 	}
 	return( false );
+}
+
+
 }

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -34,6 +34,10 @@
 #include "lmms_math.h"
 
 
+namespace lmms
+{
+
+
 LfoController::LfoController( Model * _parent ) :
 	Controller( Controller::LfoController, _parent, tr( "LFO Controller" ) ),
 	m_baseModel( 0.5, 0.0, 1.0, 0.001, this, tr( "Base value" ) ),
@@ -230,5 +234,5 @@ ControllerDialog * LfoController::createDialog( QWidget * _parent )
 
 
 
-
+}
 

--- a/src/core/MemoryHelper.cpp
+++ b/src/core/MemoryHelper.cpp
@@ -26,6 +26,11 @@
 #include "lmms_basics.h"
 #include "MemoryHelper.h"
 
+
+namespace lmms
+{
+
+
 /**
  * Allocate a number of bytes and return them.
  * @param byteNum is the number of bytes
@@ -63,3 +68,5 @@ void MemoryHelper::alignedFree( void* _buffer )
 	}
 }
 
+
+}

--- a/src/core/MemoryManager.cpp
+++ b/src/core/MemoryManager.cpp
@@ -30,6 +30,10 @@
 #include <stdint.h>
 
 
+namespace lmms
+{
+
+
 MemoryPoolVector MemoryManager::s_memoryPools;
 QReadWriteLock MemoryManager::s_poolMutex;
 PointerInfoMap MemoryManager::s_pointerInfo;
@@ -216,4 +220,7 @@ void MemoryPool::releaseChunks( void * ptr, int chunks )
 	memset( &m_free[ start ], 1, chunks );
 
 	m_mutex.unlock();
+}
+
+
 }

--- a/src/core/MeterModel.cpp
+++ b/src/core/MeterModel.cpp
@@ -31,7 +31,7 @@ namespace lmms
 {
 
 
-MeterModel::MeterModel( ::Model * _parent ) :
+MeterModel::MeterModel( Model * _parent ) :
 	Model( _parent ),
 	m_numeratorModel( 4, 1, 32, this, tr( "Numerator" ) ),
 	m_denominatorModel( 4, 1, 32, this, tr( "Denominator" ) )

--- a/src/core/MeterModel.cpp
+++ b/src/core/MeterModel.cpp
@@ -27,6 +27,10 @@
 #include "AutomationPattern.h"
 
 
+namespace lmms
+{
+
+
 MeterModel::MeterModel( ::Model * _parent ) :
 	Model( _parent ),
 	m_numeratorModel( 4, 1, 32, this, tr( "Numerator" ) ),
@@ -79,5 +83,5 @@ void MeterModel::loadSettings( const QDomElement & _this,
 
 
 
-
+}
 

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -27,6 +27,10 @@
 #include "ValueBuffer.h"
 
 
+namespace lmms
+{
+
+
 namespace MixHelpers
 {
 
@@ -269,3 +273,5 @@ void multiplyAndAddMultipliedJoined( sampleFrame* dst,
 
 }
 
+
+}

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -56,6 +56,9 @@
 #include "BufferManager.h"
 
 
+namespace lmms
+{
+
 
 Mixer::Mixer() :
 	m_framesPerPeriod( DEFAULT_BUFFER_SIZE ),
@@ -957,3 +960,4 @@ void Mixer::fifoWriter::run()
 
 
 
+}

--- a/src/core/MixerProfiler.cpp
+++ b/src/core/MixerProfiler.cpp
@@ -25,6 +25,10 @@
 #include "MixerProfiler.h"
 
 
+namespace lmms
+{
+
+
 MixerProfiler::MixerProfiler() :
 	m_periodTimer(),
 	m_cpuLoad( 0 ),
@@ -61,3 +65,6 @@ void MixerProfiler::setOutputFile( const QString& outputFile )
 	m_outputFile.open( QFile::WriteOnly | QFile::Truncate );
 }
 
+
+
+}

--- a/src/core/MixerWorkerThread.cpp
+++ b/src/core/MixerWorkerThread.cpp
@@ -31,6 +31,11 @@
 
 #include "denormals.h"
 
+
+namespace lmms
+{
+
+
 MixerWorkerThread::JobQueue MixerWorkerThread::globalJobQueue;
 QWaitCondition * MixerWorkerThread::queueReadyWaitCond = NULL;
 QList<MixerWorkerThread *> MixerWorkerThread::workerThreads;
@@ -167,3 +172,5 @@ void MixerWorkerThread::run()
 }
 
 
+
+}

--- a/src/core/Model.cpp
+++ b/src/core/Model.cpp
@@ -25,6 +25,10 @@
 #include "Model.h"
 
 
+namespace lmms
+{
+
+
 QString Model::fullDisplayName() const
 {
 	const QString & n = displayName();
@@ -46,5 +50,5 @@ QString Model::fullDisplayName() const
 
 
 
-
+}
 

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -33,6 +33,8 @@
 
 
 
+namespace lmms
+{
 
 
 Note::Note( const MidiTime & length, const MidiTime & pos,
@@ -235,4 +237,8 @@ bool Note::withinRange(int tickStart, int tickEnd) const
 {
 	return pos().getTicks() >= tickStart && pos().getTicks() <= tickEnd
 		&& length().getTicks() != 0;
+}
+
+
+
 }

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -34,6 +34,10 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
+
 NotePlayHandle::BaseDetuning::BaseDetuning( DetuningHelper *detuning ) :
 	m_value( detuning ? detuning->automationPattern()->valueAt( 0 ) : 0 )
 {
@@ -625,4 +629,8 @@ void NotePlayHandleManager::extend( int c )
 		s_available[ s_availableIndex.fetchAndAddOrdered( 1 ) + 1 ] = n;
 		++n;
 	}
+}
+
+
+
 }

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -29,6 +29,10 @@
 
 
 
+namespace lmms
+{
+
+
 Oscillator::Oscillator( const IntModel * _wave_shape_model,
 				const IntModel * _mod_algo_model,
 				const float & _freq,
@@ -548,4 +552,4 @@ inline sample_t Oscillator::getSample<Oscillator::UserDefinedWave>(
 
 
 
-
+}

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -36,6 +36,11 @@
 #include "plugins/peak_controller_effect/peak_controller_effect.h"
 #include "PresetPreviewPlayHandle.h"
 
+
+namespace lmms
+{
+
+
 class ControllerDialog;
 
 PeakControllerEffectVector PeakController::s_effects;
@@ -260,4 +265,4 @@ ControllerDialog * PeakController::createDialog( QWidget * _parent )
 
 
 
-
+}

--- a/src/core/Piano.cpp
+++ b/src/core/Piano.cpp
@@ -42,6 +42,10 @@
 #include "MidiEventProcessor.h"
 
 
+namespace lmms
+{
+
+
 /*! \brief Create a new keyboard display
  *
  *  \param _it the InstrumentTrack window to attach to
@@ -126,5 +130,4 @@ void Piano::handleKeyRelease( int key )
 
 
 
-
-
+}

--- a/src/core/PlayHandle.cpp
+++ b/src/core/PlayHandle.cpp
@@ -26,6 +26,10 @@
 #include "BufferManager.h"
 
 
+namespace lmms
+{
+
+
 PlayHandle::PlayHandle( const Type type, f_cnt_t offset ) :
 		m_type( type ),
 		m_offset( offset ),
@@ -59,4 +63,8 @@ void PlayHandle::releaseBuffer()
 {
 	if( m_playHandleBuffer ) BufferManager::release( m_playHandleBuffer );
 	m_playHandleBuffer = NULL;
+}
+
+
+
 }

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -38,6 +38,11 @@
 #include "Song.h"
 
 
+
+namespace lmms
+{
+
+
 static PixmapLoader __dummyLoader;
 
 static Plugin::Descriptor dummyPluginDescriptor =
@@ -228,3 +233,4 @@ QDomElement Plugin::Descriptor::SubPluginFeatures::Key::saveXML(
 
 
 
+}

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -38,6 +38,10 @@
 
 
 
+namespace lmms
+{
+
+
 // invisible track-container which is needed as parent for preview-channels
 class PreviewTrackContainer : public TrackContainer
 {
@@ -276,3 +280,4 @@ bool PresetPreviewPlayHandle::isPreviewing()
 
 
 
+}

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -29,6 +29,12 @@
 #include "JournallingObject.h"
 #include "Song.h"
 
+
+
+namespace lmms
+{
+
+
 const int ProjectJournal::MAX_UNDO_STATES = 100; // TODO: make this configurable in settings
 
 ProjectJournal::ProjectJournal() :
@@ -191,3 +197,4 @@ void ProjectJournal::stopAllJournalling()
 
 
 
+}

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -37,6 +37,12 @@
 #endif
 #include <QMutexLocker>
 
+
+
+namespace lmms
+{
+
+
 FileEncodeDevice __fileEncodeDevices[] =
 {
 
@@ -230,3 +236,4 @@ void ProjectRenderer::updateConsoleProgress()
 
 
 
+}

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -27,6 +27,11 @@
 
 #include "ProjectVersion.h"
 
+
+namespace lmms
+{
+
+
 int parseMajor(QString & version) {
 	return version.section( '.', 0, 0 ).toInt();
 }
@@ -134,3 +139,4 @@ int ProjectVersion::compare(ProjectVersion v1, ProjectVersion v2)
 
 
 
+}

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -40,6 +40,10 @@
 #endif
 
 
+namespace lmms
+{
+
+
 // simple helper thread monitoring our RemotePlugin - if process terminates
 // unexpectedly invalidate plugin so LMMS doesn't lock up
 ProcessWatcher::ProcessWatcher( RemotePlugin * _p ) :
@@ -396,4 +400,4 @@ bool RemotePlugin::processMessage( const message & _m )
 
 
 
-
+}

--- a/src/core/RingBuffer.cpp
+++ b/src/core/RingBuffer.cpp
@@ -29,6 +29,10 @@
 #include <string.h>
 #include "MixHelpers.h"
 
+
+namespace lmms
+{
+
  
 RingBuffer::RingBuffer( f_cnt_t size ) : 
 	m_fpp( Engine::mixer()->framesPerPeriod() ),
@@ -315,3 +319,5 @@ void RingBuffer::updateSamplerate()
 }
 
 
+
+}

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -64,6 +64,11 @@
 #include "MemoryManager.h"
 
 
+
+namespace lmms
+{
+
+
 SampleBuffer::SampleBuffer( const QString & _audio_file,
 							bool _is_base64_data ) :
 	m_audioFile( ( _is_base64_data == true ) ? "" : _audio_file ),
@@ -1479,4 +1484,8 @@ SampleBuffer::handleState::handleState( bool _varying_pitch, int interpolation_m
 SampleBuffer::handleState::~handleState()
 {
 	src_delete( m_resamplingData );
+}
+
+
+
 }

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -33,6 +33,10 @@
 
 
 
+namespace lmms
+{
+
+
 SamplePlayHandle::SamplePlayHandle( const QString& sampleFile ) :
 	PlayHandle( TypeSamplePlayHandle ),
 	m_sampleBuffer( new SampleBuffer( sampleFile ) ),
@@ -159,4 +163,4 @@ f_cnt_t SamplePlayHandle::totalFrames() const
 
 
 
-
+}

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -33,6 +33,10 @@
 #include "debug.h"
 
 
+namespace lmms
+{
+
+
 SampleRecordHandle::SampleRecordHandle( SampleTCO* tco ) :
 	PlayHandle( TypeSamplePlayHandle ),
 	m_framesRecorded( 0 ),
@@ -152,3 +156,4 @@ void SampleRecordHandle::writeBuffer( const sampleFrame * _ab,
 
 
 
+}

--- a/src/core/SerializingObject.cpp
+++ b/src/core/SerializingObject.cpp
@@ -28,6 +28,10 @@
 
 
 
+namespace lmms
+{
+
+
 SerializingObject::SerializingObject() :
 	m_hook( NULL )
 {
@@ -111,3 +115,5 @@ void SerializingObject::loadSettings( const QDomElement& element )
 }
 
 
+
+}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -67,6 +67,10 @@
 #include "PeakController.h"
 
 
+namespace lmms
+{
+
+
 tick_t MidiTime::s_ticksPerTact = DefaultTicksPerTact;
 
 
@@ -1431,4 +1435,4 @@ QString* Song::errorSummary()
 
 
 
-
+}

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -31,6 +31,10 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
+
 TempoSyncKnobModel::TempoSyncKnobModel( const float _val, const float _min,
 				const float _max, const float _step,
 				const float _scale, Model * _parent,
@@ -180,7 +184,4 @@ void TempoSyncKnobModel::updateCustom()
 
 
 
-
-
-
-
+}

--- a/src/core/ToolPlugin.cpp
+++ b/src/core/ToolPlugin.cpp
@@ -26,6 +26,10 @@
 #include "ToolPlugin.h"
 
 
+namespace lmms
+{
+
+
 ToolPlugin::ToolPlugin( const Descriptor * _descriptor, Model * _parent ) :
 	Plugin( _descriptor, _parent )
 {
@@ -56,3 +60,6 @@ ToolPlugin * ToolPlugin::instantiate( const QString & _plugin_name, Model * _par
 	return NULL;
 }
 
+
+
+}

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -74,6 +74,11 @@
 #include "TrackContainer.h"
 
 
+
+namespace lmms
+{
+
+
 /*! The width of the resize grip in pixels
  */
 const int RESIZE_GRIP_WIDTH = 4;
@@ -2724,3 +2729,4 @@ void TrackView::createTCOView( TrackContentObject * tco )
 
 
 
+}

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1867,14 +1867,14 @@ Track * Track::create( TrackTypes tt, TrackContainer * tc )
 
 	switch( tt )
 	{
-		case InstrumentTrack: t = new ::InstrumentTrack( tc ); break;
-		case BBTrack: t = new ::BBTrack( tc ); break;
-		case SampleTrack: t = new ::SampleTrack( tc ); break;
+		case InstrumentTrack: t = new lmms::InstrumentTrack( tc ); break;
+		case BBTrack: t = new lmms::BBTrack( tc ); break;
+		case SampleTrack: t = new lmms::SampleTrack( tc ); break;
 //		case EVENT_TRACK:
 //		case VIDEO_TRACK:
-		case AutomationTrack: t = new ::AutomationTrack( tc ); break;
+		case AutomationTrack: t = new lmms::AutomationTrack( tc ); break;
 		case HiddenAutomationTrack:
-						t = new ::AutomationTrack( tc, true ); break;
+						t = new lmms::AutomationTrack( tc, true ); break;
 		default: break;
 	}
 

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -35,6 +35,10 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
+
 TrackContainer::TrackContainer() :
 	Model( NULL ),
 	JournallingObject(),
@@ -246,6 +250,4 @@ DummyTrackContainer::DummyTrackContainer() :
 
 
 
-
-
-
+}

--- a/src/core/VstSyncController.cpp
+++ b/src/core/VstSyncController.cpp
@@ -42,6 +42,11 @@
 #endif
 
 
+
+namespace lmms
+{
+
+
 VstSyncController::VstSyncController() :
 	m_syncData( NULL ),
 	m_shmID( -1 ),
@@ -191,5 +196,4 @@ void VstSyncController::updateSampleRate()
 
 
 
-
-
+}

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -37,6 +37,9 @@
 #include "templates.h"
 
 
+namespace lmms
+{
+
 
 AudioAlsa::AudioAlsa( bool & _success_ful, Mixer*  _mixer ) :
 	AudioDevice( tLimit<ch_cnt_t>(
@@ -537,6 +540,8 @@ void AudioAlsa::setupWidget::saveSettings()
 				QString::number( m_channels->value<int>() ) );
 }
 
+
+}
 
 #endif
 

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -29,6 +29,9 @@
 #include "debug.h"
 
 
+namespace lmms
+{
+
 
 AudioDevice::AudioDevice( const ch_cnt_t _channels, Mixer*  _mixer ) :
 	m_supportsCapture( false ),
@@ -252,3 +255,4 @@ bool AudioDevice::hqAudio() const
 }
 
 
+}

--- a/src/core/audio/AudioFileDevice.cpp
+++ b/src/core/audio/AudioFileDevice.cpp
@@ -29,6 +29,9 @@
 #include "ExportProjectDialog.h"
 
 
+namespace lmms
+{
+
 AudioFileDevice::AudioFileDevice( const sample_rate_t _sample_rate,
 					const ch_cnt_t _channels,
 					const QString & _file,
@@ -85,3 +88,4 @@ int AudioFileDevice::writeData( const void* data, int len )
 	return -1;
 }
 
+}

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -35,6 +35,9 @@
 #include <cstring>
 
 
+namespace lmms
+{
+
 AudioFileOgg::AudioFileOgg( const sample_rate_t _sample_rate,
 				const ch_cnt_t _channels,
 				bool & _success_ful,
@@ -265,6 +268,8 @@ void AudioFileOgg::finishEncoding()
 	}
 }
 
+
+}
 
 #endif
 

--- a/src/core/audio/AudioFileWave.cpp
+++ b/src/core/audio/AudioFileWave.cpp
@@ -27,6 +27,9 @@
 #include "endian_handling.h"
 
 
+namespace lmms
+{
+
 AudioFileWave::AudioFileWave( const sample_rate_t _sample_rate,
 				const ch_cnt_t _channels, bool & _success_ful,
 				const QString & _file,
@@ -123,3 +126,4 @@ void AudioFileWave::finishEncoding()
 	}
 }
 
+}

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -42,7 +42,8 @@
 #include "MainWindow.h"
 
 
-
+namespace lmms
+{
 
 AudioJack::AudioJack( bool & _success_ful, Mixer*  _mixer ) :
 	AudioDevice( tLimit<int>( ConfigManager::inst()->value(
@@ -473,6 +474,6 @@ void AudioJack::setupWidget::saveSettings()
 
 
 
-
+}
 
 #endif

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -71,6 +71,9 @@
 
 
 
+namespace lmms
+{
+
 AudioOss::AudioOss( bool & _success_ful, Mixer*  _mixer ) :
 	AudioDevice( tLimit<ch_cnt_t>(
 		ConfigManager::inst()->value( "audiooss", "channels" ).toInt(),
@@ -370,6 +373,8 @@ void AudioOss::setupWidget::saveSettings()
 				QString::number( m_channels->value<int>() ) );
 }
 
+
+}
 
 #endif
 

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -33,6 +33,9 @@
 #include "panning.h"
 
 
+namespace lmms
+{
+
 AudioPort::AudioPort( const QString & _name, bool _has_effect_chain,
 		FloatModel * volumeModel, FloatModel * panningModel,
 		BoolModel * mutedModel ) :
@@ -248,4 +251,6 @@ void AudioPort::removePlayHandle( PlayHandle * handle )
 			m_playHandles.erase( it );
 		}
 	m_playHandleLock.unlock();
+}
+
 }

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -27,12 +27,18 @@
 #include "AudioPortAudio.h"
 
 #ifndef LMMS_HAVE_PORTAUDIO
+
+namespace lmms
+{
+
 void AudioPortAudioSetupUtil::updateDevices()
 {
 }
 
 void AudioPortAudioSetupUtil::updateChannels()
 {
+}
+
 }
 #endif
 
@@ -49,6 +55,9 @@ void AudioPortAudioSetupUtil::updateChannels()
 #include "ComboBox.h"
 #include "LcdSpinBox.h"
 
+
+namespace lmms
+{
 
 AudioPortAudio::AudioPortAudio( bool & _success_ful, Mixer * _mixer ) :
 	AudioDevice( tLimit<ch_cnt_t>(
@@ -484,6 +493,8 @@ void AudioPortAudio::setupWidget::saveSettings()
 
 }
 
+
+}
 
 #endif
 

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -37,6 +37,9 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
 static void stream_write_callback(pa_stream *s, size_t length, void *userdata)
 {
 	static_cast<AudioPulseAudio *>( userdata )->streamWriteCallback( s, length );
@@ -321,6 +324,8 @@ void AudioPulseAudio::setupWidget::saveSettings()
 				QString::number( m_channels->value<int>() ) );
 }
 
+
+}
 
 #endif
 

--- a/src/core/audio/AudioSampleRecorder.cpp
+++ b/src/core/audio/AudioSampleRecorder.cpp
@@ -30,6 +30,9 @@
 
 
 
+namespace lmms
+{
+
 AudioSampleRecorder::AudioSampleRecorder( const ch_cnt_t _channels,
 							bool & _success_ful,
 							Mixer * _mixer ) :
@@ -111,4 +114,4 @@ void AudioSampleRecorder::writeBuffer( const surroundSampleFrame * _ab,
 }
 
 
-
+}

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -36,7 +36,8 @@
 #include "templates.h"
 
 
-
+namespace lmms
+{
 
 AudioSdl::AudioSdl( bool & _success_ful, Mixer*  _mixer ) :
 	AudioDevice( DEFAULT_CHANNELS, _mixer ),
@@ -231,6 +232,8 @@ void AudioSdl::setupWidget::saveSettings()
 							m_device->text() );
 }
 
+
+}
 
 #endif
 

--- a/src/core/base64.cpp
+++ b/src/core/base64.cpp
@@ -30,6 +30,10 @@
 #include <QBuffer>
 #include <QVariant>
 
+
+namespace lmms
+{
+
 namespace base64
 {
 
@@ -73,3 +77,4 @@ QVariant decode( const QString & _b64, QVariant::Type _force_type )
 
 } ;
 
+}

--- a/src/core/fft_helpers.cpp
+++ b/src/core/fft_helpers.cpp
@@ -28,6 +28,11 @@
 #include <cmath>
 #include "lmms_constants.h"
 
+
+namespace lmms
+{
+
+
 /* returns biggest value from abs_spectrum[spec_size] array
 
    returns -1 on error
@@ -241,3 +246,5 @@ float signalpower(float *timesignal, int num_values)
 	return power;
 }
 
+
+}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -68,6 +68,9 @@
 #include "DataFile.h"
 #include "Song.h"
 
+
+using namespace lmms;
+
 static inline QString baseName( const QString & _file )
 {
 	return( QFileInfo( _file ).absolutePath() + "/" +

--- a/src/core/midi/MidiAlsaRaw.cpp
+++ b/src/core/midi/MidiAlsaRaw.cpp
@@ -32,6 +32,8 @@
 
 #ifdef LMMS_HAVE_ALSA
 
+namespace lmms
+{
 
 MidiAlsaRaw::MidiAlsaRaw() :
 	MidiClientRaw(),
@@ -203,6 +205,8 @@ void MidiAlsaRaw::setupWidget::saveSettings()
 							m_device->text() );
 }
 
+
+}
 
 #endif
 

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -37,6 +37,9 @@
 
 #ifdef LMMS_HAVE_ALSA
 
+namespace lmms
+{
+
 const int EventPollTimeOut = 250;
 
 
@@ -736,7 +739,7 @@ void MidiAlsaSeq::setupWidget::saveSettings()
 
 
 
-
+}
 
 #endif
 

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -28,6 +28,9 @@
 #include "Note.h"
 
 
+namespace lmms
+{
+
 MidiClient::MidiClient()
 {
 }
@@ -319,3 +322,4 @@ int MidiClientRaw::eventLength( const unsigned char event )
 }
 
 
+}

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -34,6 +34,9 @@
 #include "MidiController.h"
 
 
+namespace lmms
+{
+
 MidiController::MidiController( Model * _parent ) :
 	Controller( Controller::MidiController, _parent, tr( "MIDI Controller" ) ),
 	MidiEventProcessor(),
@@ -158,4 +161,4 @@ ControllerDialog * MidiController::createDialog( QWidget * _parent )
 
 
 
-
+}

--- a/src/core/midi/MidiOss.cpp
+++ b/src/core/midi/MidiOss.cpp
@@ -41,6 +41,8 @@
 #include "gui_templates.h"
 
 
+namespace lmms
+{
 
 MidiOss::MidiOss() :
 	MidiClientRaw(),
@@ -142,6 +144,7 @@ void MidiOss::setupWidget::saveSettings()
 }
 
 
+}
 
 #endif
 

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -30,6 +30,8 @@
 #include "Song.h"
 
 
+namespace lmms
+{
 
 MidiPort::MidiPort( const QString& name,
 					MidiClient* client,
@@ -405,5 +407,5 @@ void MidiPort::updateOutputProgram()
 
 
 
-
+}
 

--- a/src/core/midi/MidiWinMM.cpp
+++ b/src/core/midi/MidiWinMM.cpp
@@ -36,6 +36,9 @@
 #ifdef LMMS_BUILD_WIN32
 
 
+namespace lmms
+{
+
 MidiWinMM::MidiWinMM() :
 	MidiClient(),
 	m_inputDevices(),
@@ -324,7 +327,7 @@ MidiWinMM::setupWidget::~setupWidget()
 
 
 
-
+}
 
 
 #endif

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -29,6 +29,9 @@
 #include "versioninfo.h"
 
 
+namespace lmms
+{
+
 
 AboutDialog::AboutDialog(QWidget* parent) :
 	QDialog(parent),
@@ -51,4 +54,8 @@ AboutDialog::AboutDialog(QWidget* parent) :
 	licenseLabel->setPlainText( embed::getText( "COPYING" ) );
 
 	involvedLabel->setPlainText( embed::getText( "CONTRIBUTORS" ) );
+}
+
+
+
 }

--- a/src/gui/ActionGroup.cpp
+++ b/src/gui/ActionGroup.cpp
@@ -24,6 +24,11 @@
 
 #include "ActionGroup.h"
 
+
+namespace lmms
+{
+
+
 ActionGroup::ActionGroup(QObject* parent) : QActionGroup(parent)
 {
 	connect(this, SIGNAL(triggered(QAction*)), this, SLOT(actionTriggered_(QAction*)));
@@ -52,4 +57,8 @@ void ActionGroup::actionTriggered_(QAction* action)
 	Q_ASSERT(actions().contains(action));
 
 	emit triggered(actions().indexOf(action));
+}
+
+
+
 }

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -41,7 +41,7 @@ namespace lmms
 {
 
 
-AutomatableModelView::AutomatableModelView( ::Model* model, QWidget* _this ) :
+AutomatableModelView::AutomatableModelView( Model* model, QWidget* _this ) :
 	ModelView( model, _this ),
 	m_description( QString::null ),
 	m_unit( QString::null )

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -37,6 +37,9 @@
 #include "AutomationEditor.h"
 
 
+namespace lmms
+{
+
 
 AutomatableModelView::AutomatableModelView( ::Model* model, QWidget* _this ) :
 	ModelView( model, _this ),
@@ -247,3 +250,4 @@ void AutomatableModelViewSlots::unlinkAllModels()
 
 
 
+}

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -39,6 +39,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 QPixmap * AutomationPatternView::s_pat_rec = NULL;
 
 AutomationPatternView::AutomationPatternView( AutomationPattern * _pattern,
@@ -480,5 +484,4 @@ void AutomationPatternView::scaleTimemapToFit( float oldMin, float oldMax )
 
 
 
-
-
+}

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -46,6 +46,10 @@
 #include "embed.h"
 
 
+namespace lmms
+{
+
+
 class AutoDetectMidiController : public MidiController
 {
 public:
@@ -432,5 +436,4 @@ void ControllerConnectionDialog::enableAutoDetect( QAction * _a )
 
 
 
-
-
+}

--- a/src/gui/ControllerDialog.cpp
+++ b/src/gui/ControllerDialog.cpp
@@ -29,6 +29,10 @@
 #include "Controller.h"
 
 
+namespace lmms
+{
+
+
 ControllerDialog::ControllerDialog( Controller * _controller,
 							QWidget * _parent ) :
 	QWidget( _parent ),
@@ -52,4 +56,4 @@ void ControllerDialog::closeEvent( QCloseEvent * _ce )
 
 
 
-
+}

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -31,6 +31,10 @@
 #include "Effect.h"
 
 
+namespace lmms
+{
+
+
 EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
 	QWidget( NULL ),
 	ModelView( _controls, this ),
@@ -57,5 +61,4 @@ void EffectControlDialog::closeEvent( QCloseEvent * _ce )
 
 
 
-
-
+}

--- a/src/gui/EffectSelectDialog.cpp
+++ b/src/gui/EffectSelectDialog.cpp
@@ -32,6 +32,10 @@
 #include <QLabel>
 
 
+namespace lmms
+{
+
+
 EffectSelectDialog::EffectSelectDialog( QWidget * _parent ) :
 	QDialog( _parent ),
 	ui( new Ui::EffectSelectDialog ),
@@ -254,5 +258,4 @@ void EffectSelectDialog::updateSelection()
 
 
 
-
-
+}

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -34,6 +34,10 @@
 #include "BBTrack.h"
 
 
+namespace lmms
+{
+
+
 ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 							QWidget * _parent, bool multi_export=false ) :
 	QDialog( _parent ),
@@ -343,4 +347,8 @@ void ExportProjectDialog::updateTitleBar( int _prog )
 {
 	gui->mainWindow()->setWindowTitle(
 					tr( "Rendering: %1%" ).arg( _prog ) );
+}
+
+
+
 }

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -55,6 +55,10 @@
 
 
 
+namespace lmms
+{
+
+
 enum TreeWidgetItemTypes
 {
 	TypeFileItem = QTreeWidgetItem::UserType,
@@ -1109,4 +1113,4 @@ QString FileItem::extension(const QString & file )
 
 
 
-
+}

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -48,6 +48,11 @@
 #include "Song.h"
 #include "BBTrackContainer.h"
 
+
+namespace lmms
+{
+
+
 FxMixerView::FxMixerView() :
 	QWidget(),
 	ModelView( NULL, this ),
@@ -593,5 +598,4 @@ void FxMixerView::updateFaders()
 
 
 
-
-
+}

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -42,6 +42,11 @@
 #include <QApplication>
 #include <QSplashScreen>
 
+
+namespace lmms
+{
+
+
 GuiApplication* GuiApplication::s_instance = nullptr;
 
 GuiApplication* GuiApplication::instance()
@@ -136,4 +141,8 @@ void GuiApplication::displayInitProgress(const QString &msg)
 	// must force a UI update and process events, as there may be long gaps between processEvents() calls during init
 	m_loadingProgressLabel->repaint();
 	qApp->processEvents();
+}
+
+
+
 }

--- a/src/gui/InstrumentView.cpp
+++ b/src/gui/InstrumentView.cpp
@@ -31,6 +31,10 @@
 #include "StringPairDrag.h"
 
 
+namespace lmms
+{
+
+
 InstrumentView::InstrumentView( Instrument * _Instrument, QWidget * _parent ) :
 	PluginView( _Instrument, _parent )
 {
@@ -72,3 +76,6 @@ InstrumentTrackWindow * InstrumentView::instrumentTrackWindow( void )
 					parentWidget()->parentWidget() ) );
 }
 
+
+
+}

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -44,6 +44,12 @@
 #include "TempoSyncKnob.h"
 #include "PixmapButton.h"
 
+
+
+namespace lmms
+{
+
+
 const int CD_ENV_KNOBS_LBL_Y = 20;
 const int CD_KNOB_X_SPACING = 32;
 
@@ -299,3 +305,5 @@ void LfoControllerDialog::modelChanged()
 }
 
 
+
+}

--- a/src/gui/LmmsPalette.cpp
+++ b/src/gui/LmmsPalette.cpp
@@ -29,6 +29,11 @@
 #include "LmmsStyle.h"
 
 
+
+namespace lmms
+{
+
+
 LmmsPalette::LmmsPalette( QWidget * parent, QStyle * stylearg ) : 
 	QWidget( parent ),
 	
@@ -98,3 +103,4 @@ QPalette LmmsPalette::palette() const
 
 
 
+}

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -35,6 +35,11 @@
 #include "LmmsStyle.h"
 #include "LmmsPalette.h"
 
+
+namespace lmms
+{
+
+
 QPalette * LmmsStyle::s_palette = NULL;
 
 QLinearGradient getGradient( const QColor & _col, const QRectF & _rect )
@@ -368,3 +373,6 @@ void LmmsStyle::hoverColors( bool sunken, bool hover, bool active, QColor& color
 	}
 }
 
+
+
+}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -69,6 +69,9 @@
 
 
 
+namespace lmms
+{
+
 
 MainWindow::MainWindow() :
 	m_workspace( NULL ),
@@ -1380,4 +1383,8 @@ void MainWindow::autoSave()
 		// try again in 10 seconds
 		QTimer::singleShot( 10*1000, this, SLOT( autoSave() ) );
 	}
+}
+
+
+
 }

--- a/src/gui/ModelView.cpp
+++ b/src/gui/ModelView.cpp
@@ -27,6 +27,9 @@
 #include "ModelView.h"
 
 
+namespace lmms
+{
+
 
 ModelView::ModelView( Model* model, QWidget* widget ) :
 	m_widget( widget ),
@@ -84,3 +87,5 @@ void ModelView::doConnections()
 }
 
 
+
+}

--- a/src/gui/PeakControllerDialog.cpp
+++ b/src/gui/PeakControllerDialog.cpp
@@ -44,6 +44,11 @@
 #include "PixmapButton.h"
 
 
+
+namespace lmms
+{
+
+
 PeakControllerDialog::PeakControllerDialog( Controller * _model, QWidget * _parent ) :
 	ControllerDialog( _model, _parent )
 {
@@ -107,3 +112,5 @@ void PeakControllerDialog::modelChanged()
 }
 
 
+
+}

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -58,6 +58,11 @@
 #include "update_event.h"
 
 
+
+namespace lmms
+{
+
+
 /*! The black / white order of keys as they appear on the keyboard.
  */
 const Piano::KeyTypes KEY_ORDER[] =
@@ -917,6 +922,4 @@ void PianoView::paintEvent( QPaintEvent * )
 
 
 
-
-
-
+}

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -38,6 +38,10 @@
 #include "StringPairDrag.h"
 
 
+namespace lmms
+{
+
+
 bool pluginBefore( const Plugin::Descriptor& d1, const Plugin::Descriptor& d2 )
 {
 	return qstricmp( d1.displayName, d2.displayName ) < 0 ? true : false;
@@ -240,7 +244,4 @@ void PluginDescWidget::updateHeight()
 
 
 
-
-
-
-
+}

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -67,6 +67,10 @@
 
 
 
+namespace lmms
+{
+
+
 inline void labelWidget( QWidget * _w, const QString & _txt )
 {
 	QLabel * title = new QLabel( _txt, _w );
@@ -1495,4 +1499,4 @@ void SetupDialog::displayMIDIHelp()
 
 
 
-
+}

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -35,6 +35,10 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
+
+
 StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
 					const QPixmap & _icon, QWidget * _w ) :
 	QDrag( _w )
@@ -120,4 +124,8 @@ QString StringPairDrag::decodeKey( QDropEvent * _de )
 QString StringPairDrag::decodeValue( QDropEvent * _de )
 {
 	return decodeMimeValue( _de->mimeData() );
+}
+
+
+
 }

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -47,6 +47,10 @@
 #endif
 
 
+namespace lmms
+{
+
+
 QPixmap * TimeLineWidget::s_timeLinePixmap = NULL;
 QPixmap * TimeLineWidget::s_posMarkerPixmap = NULL;
 QPixmap * TimeLineWidget::s_loopPointBeginPixmap = NULL;
@@ -401,3 +405,4 @@ void TimeLineWidget::mouseReleaseEvent( QMouseEvent* event )
 
 
 
+}

--- a/src/gui/ToolPluginView.cpp
+++ b/src/gui/ToolPluginView.cpp
@@ -35,6 +35,10 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
+
+
 ToolPluginView::ToolPluginView( ToolPlugin * _toolPlugin ) :
 	PluginView( _toolPlugin, NULL )
 {
@@ -46,3 +50,5 @@ ToolPluginView::ToolPluginView( ToolPlugin * _toolPlugin ) :
 }
 
 
+
+}

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -49,6 +49,11 @@
 #include "GuiApplication.h"
 
 
+
+namespace lmms
+{
+
+
 TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	QWidget(),
 	ModelView( NULL, this ),
@@ -530,4 +535,8 @@ void InstrumentLoaderThread::run()
 	i->setParent( 0 );
 	i->moveToThread( m_containerThread );
 	i->setParent( parent );
+}
+
+
+
 }

--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -31,6 +31,10 @@
 #include "FileDialog.h"
 
 
+namespace lmms
+{
+
+
 FileDialog::FileDialog( QWidget *parent, const QString &caption,
 					   const QString &directory, const QString &filter ) :
 	QFileDialog( parent, caption, directory, filter )
@@ -86,3 +90,4 @@ void FileDialog::clearSelection()
 
 
 
+}

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -32,6 +32,9 @@
 
 
 
+namespace lmms
+{
+
 
 VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 										  const QString &caption,
@@ -137,3 +140,5 @@ void VersionedSaveDialog::decrementVersion()
 }
 
 
+
+}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -68,6 +68,10 @@
 #include "ProjectJournal.h"
 
 
+namespace lmms
+{
+
+
 QPixmap * AutomationEditor::s_toolDraw = NULL;
 QPixmap * AutomationEditor::s_toolErase = NULL;
 QPixmap * AutomationEditor::s_toolSelect = NULL;
@@ -2348,4 +2352,8 @@ void AutomationEditorWindow::play()
 void AutomationEditorWindow::stop()
 {
 	m_editor->stop();
+}
+
+
+
 }

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -44,6 +44,10 @@
 
 
 
+namespace lmms
+{
+
+
 BBEditor::BBEditor( BBTrackContainer* tc ) :
 	Editor(false),
 	m_trackContainerView( new BBTrackContainerView(tc) )
@@ -284,4 +288,8 @@ void BBTrackContainerView::makeSteps( bool clone )
 			}
 		}
 	}
+}
+
+
+
 }

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -33,6 +33,10 @@
 #include <QShortcut>
 
 
+namespace lmms
+{
+
+
 void Editor::setPauseIcon(bool displayPauseIcon)
 {
 	// If we're playing, show a pause icon
@@ -113,4 +117,8 @@ void DropToolBar::dragEnterEvent(QDragEnterEvent* event)
 void DropToolBar::dropEvent(QDropEvent* event)
 {
 	dropped(event);
+}
+
+
+
 }

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -77,6 +77,10 @@
 #endif
 
 
+namespace lmms
+{
+
+
 typedef AutomationPattern::timeMap timeMap;
 
 
@@ -4310,4 +4314,7 @@ void PianoRollWindow::focusInEvent(QFocusEvent * event)
 {
 	// when the window is given focus, also give focus to the actual piano roll
 	m_editor->setFocus(event->reason());
+}
+
+
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -57,6 +57,10 @@
 
 
 
+namespace lmms
+{
+
+
 positionLine::positionLine( QWidget * _parent ) :
 	QWidget( _parent )
 {
@@ -733,4 +737,8 @@ void SongEditorWindow::adjustUiAfterProjectLoad()
 	gui->mainWindow()->workspace()->setActiveSubWindow(
 			qobject_cast<QMdiSubWindow *>( parentWidget() ) );
 	m_editor->scrolled(0);
+}
+
+
+
 }

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -30,6 +30,11 @@
 #include "embed.h"
 #include "ConfigManager.h"
 
+
+namespace lmms
+{
+
+
 #ifndef PLUGIN_NAME
 namespace embed
 #else
@@ -123,3 +128,5 @@ QString getText( const char * _name )
 }
 
 
+
+}

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -36,6 +36,10 @@
 
 
 
+namespace lmms
+{
+
+
 AutomatableButton::AutomatableButton( QWidget * _parent,
 						const QString & _name ) :
 	QPushButton( _parent ),
@@ -270,4 +274,4 @@ void automatableButtonGroup::updateButtons()
 
 
 
-
+}

--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -35,6 +35,9 @@
 
 
 
+namespace lmms
+{
+
 
 AutomatableSlider::AutomatableSlider( QWidget * _parent,
 						const QString & _name ) :
@@ -143,6 +146,4 @@ void AutomatableSlider::updateSlider()
 
 
 
-
-
-
+}

--- a/src/gui/widgets/CPULoadWidget.cpp
+++ b/src/gui/widgets/CPULoadWidget.cpp
@@ -32,6 +32,10 @@
 #include "Mixer.h"
 
 
+namespace lmms
+{
+
+
 CPULoadWidget::CPULoadWidget( QWidget * _parent ) :
 	QWidget( _parent ),
 	m_currentLoad( 0 ),
@@ -103,6 +107,4 @@ void CPULoadWidget::updateCpuLoad()
 
 
 
-
-
-
+}

--- a/src/gui/widgets/CaptionMenu.cpp
+++ b/src/gui/widgets/CaptionMenu.cpp
@@ -27,6 +27,8 @@
 #include "embed.h"
 
 
+namespace lmms
+{
 
 
 CaptionMenu::CaptionMenu( const QString & _title, QWidget * _parent ) :
@@ -61,4 +63,8 @@ void CaptionMenu::addHelpAction()
 		QAction* helpAction = addAction( embed::getIconPixmap("help"), tr("Help (not available)") );
 		helpAction->setDisabled(true);
 	}
+}
+
+
+
 }

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -41,6 +41,10 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
+
+
 QPixmap * ComboBox::s_background = NULL;
 QPixmap * ComboBox::s_arrow = NULL;
 QPixmap * ComboBox::s_arrowSelected = NULL;
@@ -270,6 +274,4 @@ void ComboBox::setItem( QAction* item )
 
 
 
-
-
-
+}

--- a/src/gui/widgets/ControllerRackView.cpp
+++ b/src/gui/widgets/ControllerRackView.cpp
@@ -42,6 +42,10 @@
 #include "LfoController.h"
 
 
+namespace lmms
+{
+
+
 ControllerRackView::ControllerRackView( ) :
 	QWidget()
 {
@@ -197,7 +201,7 @@ void ControllerRackView::addController()
 
 
 void ControllerRackView::closeEvent( QCloseEvent * _ce )
- {
+{
 	if( parentWidget() )
 	{
 		parentWidget()->hide();
@@ -207,5 +211,8 @@ void ControllerRackView::closeEvent( QCloseEvent * _ce )
 		hide();
 	}
 	_ce->ignore();
- }
+}
 
+
+
+}

--- a/src/gui/widgets/ControllerView.cpp
+++ b/src/gui/widgets/ControllerView.cpp
@@ -45,6 +45,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 	QWidget( _parent ),
 	ModelView( _model, this ),
@@ -197,5 +201,4 @@ void ControllerView::displayHelp()
 
 
 
-
-
+}

--- a/src/gui/widgets/EffectRackView.cpp
+++ b/src/gui/widgets/EffectRackView.cpp
@@ -35,6 +35,10 @@
 #include "GroupBox.h"
 
 
+namespace lmms
+{
+
+
 EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( NULL, this )
@@ -264,5 +268,4 @@ void EffectRackView::modelChanged()
 
 
 
-
-
+}

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -46,6 +46,11 @@
 #include "ToolTip.h"
 
 
+
+namespace lmms
+{
+
+
 EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	PluginView( _model, _parent ),
 	m_bg( embed::getIconPixmap( "effect_plugin" ) ),
@@ -294,5 +299,4 @@ void EffectView::modelChanged()
 
 
 
-
-
+}

--- a/src/gui/widgets/EnvelopeAndLfoView.cpp
+++ b/src/gui/widgets/EnvelopeAndLfoView.cpp
@@ -44,6 +44,10 @@
 #include "Track.h"
 
 
+namespace lmms
+{
+
+
 extern const float SECS_PER_ENV_SEGMENT;
 extern const float SECS_PER_LFO_OSCILLATION;
 
@@ -590,7 +594,4 @@ void EnvelopeAndLfoView::lfoUserWaveChanged()
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/FadeButton.cpp
+++ b/src/gui/widgets/FadeButton.cpp
@@ -33,6 +33,10 @@
 #include "update_event.h"
 
 
+namespace lmms
+{
+
+
 const float FadeDuration = 300;
 
 
@@ -122,7 +126,4 @@ void FadeButton::signalUpdate()
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -59,6 +59,10 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
+
+
 TextFloat * Fader::s_textFloat = NULL;
 QPixmap * Fader::s_back = NULL;
 QPixmap * Fader::s_leds = NULL;
@@ -400,3 +404,4 @@ void Fader::setPeakRed( const QColor & c )
 
 
 
+}

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -40,6 +40,11 @@
 #include "gui_templates.h"
 #include "CaptionMenu.h"
 
+
+namespace lmms
+{
+
+
 const int FxLine::FxLineHeight = 287;
 QPixmap * FxLine::s_sendBgArrow = NULL;
 QPixmap * FxLine::s_receiveBgArrow = NULL;
@@ -274,3 +279,4 @@ void FxLine::setBackgroundActive( const QBrush & c )
 
 
 
+}

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -448,7 +448,7 @@ void Graph::updateGraph()
 
 
 graphModel::graphModel( float _min, float _max, int _length,
-			::Model * _parent, bool _default_constructed,  float _step ) :
+			Model * _parent, bool _default_constructed,  float _step ) :
 	Model( _parent, tr( "Graph" ), _default_constructed ),
 	m_samples( _length ),
 	m_length( _length ),

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -34,6 +34,10 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
+
 Graph::Graph( QWidget * _parent, graphStyle _style, int _width,
 		int _height ) :
 	QWidget( _parent ),
@@ -708,5 +712,4 @@ void graphModel::drawSampleAt( int x, float val )
 
 
 
-
-
+}

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -36,6 +36,9 @@
 #include "gui_templates.h"
 
 
+namespace lmms
+{
+
 
 GroupBox::GroupBox( const QString & _caption, QWidget * _parent ) :
 	QWidget( _parent ),
@@ -139,7 +142,4 @@ void GroupBox::updatePixmap()
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/InstrumentFunctionViews.cpp
+++ b/src/gui/widgets/InstrumentFunctionViews.cpp
@@ -38,6 +38,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( InstrumentFunctionNoteStacking* cc, QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( NULL, this ),
@@ -203,4 +207,4 @@ void InstrumentFunctionArpeggioView::modelChanged()
 
 
 
-
+}

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -42,6 +42,10 @@
 #include "QLabel"
 
 
+namespace lmms
+{
+
+
 InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( NULL, this ),
@@ -222,5 +226,9 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 
 InstrumentMiscView::~InstrumentMiscView()
 {
+
+}
+
+
 
 }

--- a/src/gui/widgets/InstrumentSoundShapingView.cpp
+++ b/src/gui/widgets/InstrumentSoundShapingView.cpp
@@ -34,6 +34,9 @@
 #include "TabWidget.h"
 
 
+namespace lmms
+{
+
 
 const int TARGETS_TABWIDGET_X = 4;
 const int TARGETS_TABWIDGET_Y = 5;
@@ -163,5 +166,4 @@ void InstrumentSoundShapingView::modelChanged()
 
 
 
-
-	
+}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -52,6 +52,10 @@
 #include "TextFloat.h"
 
 
+namespace lmms
+{
+
+
 TextFloat * Knob::s_textFloat = NULL;
 
 
@@ -813,6 +817,4 @@ void Knob::displayHelp()
 
 
 
-
-
-
+}

--- a/src/gui/widgets/LadspaControlView.cpp
+++ b/src/gui/widgets/LadspaControlView.cpp
@@ -33,6 +33,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 LadspaControlView::LadspaControlView( QWidget * _parent,
 						LadspaControl * _ctl ) :
 	QWidget( _parent ),
@@ -124,5 +128,4 @@ LadspaControlView::~LadspaControlView()
 
 
 
-
-
+}

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -42,6 +42,10 @@
 
 
 
+namespace lmms
+{
+
+
 LcdSpinBox::LcdSpinBox( int numDigits, QWidget* parent, const QString& name ) :
 	LcdWidget( numDigits, parent, name ),
 	IntModelView( new IntModel( 0, 0, 0, NULL, name, true ), this ),
@@ -193,3 +197,4 @@ void LcdSpinBox::enterValue()
 
 
 
+}

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -39,6 +39,8 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
 
 
 //! @todo: in C++11, we can use delegating ctors
@@ -257,5 +259,4 @@ void LcdWidget::initUi(const QString& name , const QString& style)
 
 
 
-
-
+}

--- a/src/gui/widgets/LedCheckbox.cpp
+++ b/src/gui/widgets/LedCheckbox.cpp
@@ -31,6 +31,10 @@
 #include "gui_templates.h"
 
 
+namespace lmms
+{
+
+
 static const QString names[LedCheckBox::NumColors] =
 {
 	"led_yellow", "led_green", "led_red"
@@ -132,5 +136,4 @@ void LedCheckBox::onTextUpdated()
 
 
 
-
-
+}

--- a/src/gui/widgets/LeftRightNav.cpp
+++ b/src/gui/widgets/LeftRightNav.cpp
@@ -28,6 +28,10 @@
 #include "embed.h"
 
 
+namespace lmms
+{
+
+
 LeftRightNav::LeftRightNav(QWidget *parent)
  : QWidget(parent),
    m_layout(this),
@@ -88,4 +92,8 @@ void LeftRightNav::setShortcuts(const QKeySequence &leftShortcut, const QKeySequ
 
 	ToolTip::add(&m_leftBtn, tr("Previous (%1)").arg(leftShortcut.toString()));
 	ToolTip::add(&m_rightBtn, tr("Next (%1)").arg(rightShortcut.toString()));
+}
+
+
+
 }

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -35,6 +35,10 @@
 #include "LcdSpinBox.h"
 
 
+namespace lmms
+{
+
+
 MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	QWidget( _parent ),
 	ModelView( NULL, this )
@@ -113,3 +117,6 @@ void MeterDialog::modelChanged()
 	m_denominator->setModel( &mm->denominatorModel() );
 }
 
+
+
+}

--- a/src/gui/widgets/MidiPortMenu.cpp
+++ b/src/gui/widgets/MidiPortMenu.cpp
@@ -28,6 +28,10 @@
 
 
 
+namespace lmms
+{
+
+
 MidiPortMenu::MidiPortMenu( MidiPort::Modes _mode ) :
 	ModelView( NULL, this ),
 	m_mode( _mode )
@@ -100,5 +104,4 @@ void MidiPortMenu::updateMenu()
 
 
 
-
-
+}

--- a/src/gui/widgets/NStateButton.cpp
+++ b/src/gui/widgets/NStateButton.cpp
@@ -30,6 +30,9 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
 
 NStateButton::NStateButton( QWidget * _parent ) :
 	ToolButton( _parent ),
@@ -99,7 +102,4 @@ void NStateButton::mousePressEvent( QMouseEvent * _me )
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/PixmapButton.cpp
+++ b/src/gui/widgets/PixmapButton.cpp
@@ -32,6 +32,9 @@
 #include "embed.h"
 
 
+namespace lmms
+{
+
 
 PixmapButton::PixmapButton( QWidget * _parent, const QString & _name ) :
 	AutomatableButton( _parent, _name ),
@@ -144,5 +147,4 @@ QSize PixmapButton::sizeHint() const
 
 
 
-
-
+}

--- a/src/gui/widgets/ProjectNotes.cpp
+++ b/src/gui/widgets/ProjectNotes.cpp
@@ -45,6 +45,10 @@
 
 
 
+namespace lmms
+{
+
+
 ProjectNotes::ProjectNotes() :
 	QMainWindow( gui->mainWindow()->workspace() )
 {
@@ -411,3 +415,5 @@ void ProjectNotes::closeEvent( QCloseEvent * _ce )
  }
 
 
+
+}

--- a/src/gui/widgets/RenameDialog.cpp
+++ b/src/gui/widgets/RenameDialog.cpp
@@ -29,6 +29,9 @@
 #include "RenameDialog.h"
 
 
+namespace lmms
+{
+
 
 RenameDialog::RenameDialog( QString & _string ) :
 	QDialog(),
@@ -75,6 +78,4 @@ void RenameDialog::textChanged( const QString & _new_string )
 
 
 
-
-
-
+}

--- a/src/gui/widgets/Rubberband.cpp
+++ b/src/gui/widgets/Rubberband.cpp
@@ -27,6 +27,10 @@
 #include "Rubberband.h"
 
 
+namespace lmms
+{
+
+
 RubberBand::RubberBand( QWidget * _parent ) :
 	QRubberBand( Rectangle, _parent )
 {
@@ -103,7 +107,4 @@ QVector<selectableObject *> RubberBand::selectableObjects() const
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/SendButtonIndicator.cpp
+++ b/src/gui/widgets/SendButtonIndicator.cpp
@@ -4,6 +4,11 @@
 #include "FxMixer.h"
 #include "Model.h"
 
+
+namespace lmms
+{
+
+
 QPixmap * SendButtonIndicator::s_qpmOff = NULL;
 QPixmap * SendButtonIndicator::s_qpmOn = NULL;
 
@@ -60,4 +65,8 @@ FloatModel * SendButtonIndicator::getSendModel()
 void SendButtonIndicator::updateLightStatus()
 {
 	setPixmap( getSendModel() == NULL ? *s_qpmOff : *s_qpmOn );
+}
+
+
+
 }

--- a/src/gui/widgets/SendButtonIndicator.cpp
+++ b/src/gui/widgets/SendButtonIndicator.cpp
@@ -4,6 +4,9 @@
 #include "FxMixer.h"
 #include "Model.h"
 
+#include "FxLine.h"
+#include "FxMixerView.h"
+
 
 namespace lmms
 {

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -31,6 +31,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 // internal helper class allowing to create QToolButtons with
 // vertical orientation
 class SideBarButton : public QToolButton
@@ -163,4 +167,4 @@ void SideBar::toggleButton( QAbstractButton * button )
 
 
 
-
+}

--- a/src/gui/widgets/SideBarWidget.cpp
+++ b/src/gui/widgets/SideBarWidget.cpp
@@ -30,6 +30,9 @@
 #include "gui_templates.h"
 
 
+namespace lmms
+{
+
 
 SideBarWidget::SideBarWidget( const QString & _title, const QPixmap & _icon,
 							QWidget * _parent ) :
@@ -85,5 +88,4 @@ void SideBarWidget::resizeEvent( QResizeEvent * )
 
 
 
-
-
+}

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -30,6 +30,10 @@
 
 
 
+namespace lmms
+{
+
+
 TabBar::TabBar( QWidget * _parent, QBoxLayout::Direction _dir ) :
 	QWidget( _parent ),
 	m_layout( new QBoxLayout( _dir, this ) ),
@@ -241,8 +245,4 @@ bool TabBar::allHidden()
 
 
 
-
-
-
-
-
+}

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -33,6 +33,9 @@
 #include "gui_templates.h"
 
 
+namespace lmms
+{
+
 
 TabWidget::TabWidget( const QString & _caption, QWidget * _parent ) :
 	QWidget( _parent ),
@@ -231,7 +234,4 @@ void TabWidget::wheelEvent( QWheelEvent * _we )
 
 
 
-
-
-
-
+}

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -36,6 +36,9 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
 
 TempoSyncKnob::TempoSyncKnob( knobTypes _knob_num, QWidget * _parent,
 						const QString & _name ) :
@@ -303,6 +306,4 @@ void TempoSyncKnob::showCustom()
 
 
 
-
-
-
+}

--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -33,6 +33,9 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
 
 TextFloat::TextFloat() :
 	QWidget( gui->mainWindow(), Qt::ToolTip ),
@@ -201,4 +204,4 @@ void TextFloat::updateSize()
 
 
 
-
+}

--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -32,6 +32,9 @@
 #include "Song.h"
 
 
+namespace lmms
+{
+
 
 TimeDisplayWidget::TimeDisplayWidget() :
 	QWidget(),
@@ -140,6 +143,4 @@ void TimeDisplayWidget::mousePressEvent( QMouseEvent* mouseEvent )
 
 
 
-
-
-
+}

--- a/src/gui/widgets/ToolButton.cpp
+++ b/src/gui/widgets/ToolButton.cpp
@@ -27,6 +27,10 @@
 #include "ToolTip.h"
 
 
+namespace lmms
+{
+
+
 ToolButton::ToolButton( const QPixmap & _pixmap, const QString & _tooltip,
 			QObject * _receiver, const char * _slot,
 			QWidget * _parent ) :
@@ -52,6 +56,4 @@ ToolButton::~ToolButton()
 
 
 
-
-
-
+}

--- a/src/gui/widgets/ToolTip.cpp
+++ b/src/gui/widgets/ToolTip.cpp
@@ -29,6 +29,10 @@
 #include "ConfigManager.h"
 
 
+namespace lmms
+{
+
+
 void ToolTip::add( QWidget * _w, const QString & _txt )
 {
 	if( !ConfigManager::inst()->value( "tooltips", "disabled" ).toInt() )
@@ -38,3 +42,4 @@ void ToolTip::add( QWidget * _w, const QString & _txt )
 }
 
 
+}

--- a/src/gui/widgets/TrackLabelButton.cpp
+++ b/src/gui/widgets/TrackLabelButton.cpp
@@ -37,6 +37,9 @@
 #include "Engine.h"
 
 
+namespace lmms
+{
+
 
 TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	QToolButton( _parent ),
@@ -163,5 +166,4 @@ void TrackLabelButton::paintEvent( QPaintEvent * _pe )
 
 
 
-
-
+}

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -38,6 +38,9 @@
 #include "ConfigManager.h"
 
 
+namespace lmms
+{
+
 
 VisualizationWidget::VisualizationWidget( const QPixmap & _bg, QWidget * _p,
 						visualizationTypes _vtype ) :
@@ -192,6 +195,4 @@ void VisualizationWidget::mousePressEvent( QMouseEvent * _me )
 
 
 
-
-
-
+}

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -34,6 +34,11 @@
 #include "TrackLabelButton.h"
 
 
+namespace lmms
+{
+
+
+
 AutomationTrack::AutomationTrack( TrackContainer* tc, bool _hidden ) :
 	Track( _hidden ? HiddenAutomationTrack : Track::AutomationTrack, tc )
 {
@@ -192,3 +197,5 @@ void AutomationTrackView::dropEvent( QDropEvent * _de )
 }
 
 
+
+}

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -43,6 +43,10 @@
 #include "TrackLabelButton.h"
 
 
+namespace lmms
+{
+
+
 
 BBTrack::infoMap BBTrack::s_infoMap;
 
@@ -635,7 +639,4 @@ void BBTrackView::clickedTrackLabel()
 
 
 
-
-
-
-
+}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -86,6 +86,11 @@
 #include "volume.h"
 
 
+namespace lmms
+{
+
+
+
 const char * volume_help = QT_TRANSLATE_NOOP( "InstrumentTrack",
 						"With this knob you can set "
 						"the volume of the opened "
@@ -1774,4 +1779,8 @@ void InstrumentTrackWindow::viewNextInstrument()
 void InstrumentTrackWindow::viewPrevInstrument()
 {
 	viewInstrumentInDirection(-1);
+}
+
+
+
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -596,7 +596,7 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 	const float frames_per_tick = Engine::framesPerTick();
 
 	tcoVector tcos;
-	::BBTrack * bb_track = NULL;
+	lmms::BBTrack * bb_track = NULL;
 	if( _tco_num >= 0 )
 	{
 		TrackContentObject * tco = getTCO( _tco_num );

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -51,6 +51,10 @@
 #include "MainWindow.h"
 
 
+namespace lmms
+{
+
+
 QPixmap * PatternView::s_stepBtnOn = NULL;
 QPixmap * PatternView::s_stepBtnOverlay = NULL;
 QPixmap * PatternView::s_stepBtnOff = NULL;
@@ -1222,3 +1226,5 @@ void PatternView::paintEvent( QPaintEvent * )
 }
 
 
+
+}

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -51,6 +51,10 @@
 #include "panning_constants.h"
 
 
+namespace lmms
+{
+
+
 SampleTCO::SampleTCO( Track * _track ) :
 	TrackContentObject( _track ),
 	m_sampleBuffer( new SampleBuffer )
@@ -631,4 +635,8 @@ void SampleTrackView::modelChanged()
 	m_volumeKnob->setModel( &st->m_volumeModel );
 
 	TrackView::modelChanged();
+}
+
+
+
 }


### PR DESCRIPTION
This change places all classes necessary to build lmms (i.e. everything in the src directory) into a namespace named "lmms". Notably, plugins are not namespaced, which made sense to me because many plugins (e.g. zynaddsubfx) aren't specific to lmms.

The motivation for this change is to fix #2049, as well as #2053, #2035 and possibly some other bugs that arose due to having one of the plugin classes (zynaddsubfx's `Engine` class) sharing the same name, and therefore vtable, as an lmms class.

It's a pretty significant change, so I think it deserves some testing. **Note that this does break theme compatibility** (see #2049 for an explanation of why). If the default theme still appears broken for you, open `settings` and make sure lmms isn't accidentally using an outdated version of it (e.g. in my case, I have a stable build of lmms in /usr/local and I install dev builds to ~/dev/lmms, but the dev builds will default to using the theme in /usr/local/share unless I explicitly specify it).