### PR TITLE
Sets Focus to InstrumentTrackWindow 

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1505,6 +1505,7 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 		engine::getSong()->setModified();
 
 		event->accept();
+		setFocus();
 	}
 	else if( type == "presetfile" )
 	{
@@ -1516,6 +1517,7 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 		engine::getSong()->setModified();
 
 		event->accept();
+		setFocus();
 	}
 	else if( type == "pluginpresetfile" )
 	{
@@ -1530,6 +1532,7 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 		i->loadFile( value );
 
 		event->accept();
+		setFocus();
 	}
 }
 


### PR DESCRIPTION
If a sample or a preset droped to an InstrumentTrackWindow, the keyboard focus is still on the preset browser. If the user wants to play the instrument on the PC-keyboard, the browser got the focus and the cursor jumps crazy through the preset list. 

With this fix the Instrument gots the focus and the user can immediately play it on the Pc-keyboard. 

I think it's a bug: therefore stable-1.1