### PR TITLE
Don't save templates in "recently opened" list

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -196,15 +196,16 @@ void ConfigManager::setSF2Dir(const QString &sfd)
 
 void ConfigManager::addRecentlyOpenedProject( const QString & _file )
 {
-	if( !_file.endsWith(".mpt", Qt::CaseInsensitive) ) {
-		m_recentlyOpenedProjects.removeAll( _file );
-		if( m_recentlyOpenedProjects.size() > 15 )
-			{
-				m_recentlyOpenedProjects.removeLast();
-			}
-		m_recentlyOpenedProjects.push_front( _file );
-		ConfigManager::inst()->saveConfigFile();
-	}
+	if( !_file.endsWith( ".mpt", Qt::CaseInsensitive ) ) 
+		{
+			m_recentlyOpenedProjects.removeAll( _file );
+			if( m_recentlyOpenedProjects.size() > 15 )
+				{
+					m_recentlyOpenedProjects.removeLast();
+				}
+			m_recentlyOpenedProjects.push_front( _file );
+			ConfigManager::inst()->saveConfigFile();
+		}
 }
 
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -196,13 +196,15 @@ void ConfigManager::setSF2Dir(const QString &sfd)
 
 void ConfigManager::addRecentlyOpenedProject( const QString & _file )
 {
-	m_recentlyOpenedProjects.removeAll( _file );
-	if( m_recentlyOpenedProjects.size() > 15 )
-	{
-		m_recentlyOpenedProjects.removeLast();
+	if( !_file.endsWith(".mpt", Qt::CaseInsensitive) ) {
+		m_recentlyOpenedProjects.removeAll( _file );
+		if( m_recentlyOpenedProjects.size() > 15 )
+			{
+				m_recentlyOpenedProjects.removeLast();
+			}
+		m_recentlyOpenedProjects.push_front( _file );
+		ConfigManager::inst()->saveConfigFile();
 	}
-	m_recentlyOpenedProjects.push_front( _file );
-	ConfigManager::inst()->saveConfigFile();
 }
 
 


### PR DESCRIPTION
Don't save templates in "recently opened" list anymore.
TBH this was almost entirely the work of @tresf in the comments to #1812. 