### PR TITLE
No longer try to validate sf2 and gig files

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -471,7 +471,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 			m_previewPlayHandle = s;
 			delete tf;
 		}
-		else if( f->extension ()== "xiz" && Engine::pluginFileHandling().contains( f->extension() ) )
+		else if( ( f->extension ()== "xiz" || f->extension() == "sf2" || f->extension() == "gig" )  && Engine::pluginFileHandling().contains( f->extension() ) )
 		{
 			m_previewPlayHandle = new PresetPreviewPlayHandle( f->fullName(), f->handling() == FileItem::LoadByPlugin );
 		}


### PR DESCRIPTION
Removed trying to validate non lmms files when clicked in the file browser.
This had been the cause of erronus dialog boxes, and caused a bug, not allowing
drag and drop of sf2 files.

fixes #2094