### PR TITLE
Remove MessageBox warning of incomplete stk installation from mallets

### DIFF
--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -81,16 +81,6 @@ malletsInstrument::malletsInstrument( InstrumentTrack * _instrument_track ):
 		!QFileInfo( ConfigManager::inst()->stkDir() + QDir::separator()
 						+ "sinewave.raw" ).exists() )
 {
-	// try to inform user about missing Stk-installation
-	if( m_filesMissing && Engine::hasGUI() )
-	{
-		QMessageBox::information( 0, tr( "Missing files" ),
-				tr( "Your Stk-installation seems to be "
-					"incomplete. Please make sure "
-					"the full Stk-package is installed!" ),
-				QMessageBox::Ok );
-	}
-
 	// ModalBar
 	m_presetsModel.addItem( tr( "Marimba" ) );
 	m_scalers.append( 4.0 );


### PR DESCRIPTION
The merge of stable 1.1 into master introduced the messagebox into the incorrect
place in the code. It is already present in the correct place in master,
 so simply removed the extra instance.

This stops the segfault and fixes #1660