### PR TITLE
Fix for #2087: Issues with saving projects in X11 when one subwindow is maximized

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -60,7 +60,7 @@ public:
 	void addSpacingToToolBar( int _size );
 
 	// wrap the widget with a window decoration and add it to the workspace
-	SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags=0);
+	EXPORT SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags=0);
 
 
 	///

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -30,6 +30,8 @@
 #include <QtCore/QList>
 #include <QMainWindow>
 
+#include "SubWindow.h"
+
 class QAction;
 class QDomElement;
 class QGridLayout;
@@ -56,6 +58,9 @@ public:
 
 	int addWidgetToToolBar( QWidget * _w, int _row = -1, int _col = -1 );
 	void addSpacingToToolBar( int _size );
+
+	// wrap the widget with a window decoration and add it to the workspace
+	SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags=0);
 
 
 	///

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -1,0 +1,56 @@
+/*
+ * SubWindow.h - Implementation of QMdiSubWindow that correctly tracks
+ *   the geometry that windows should be restored to.
+ *   Workaround for https://bugreports.qt.io/browse/QTBUG-256
+ *
+ * Copyright (c) 2015 Colin Wallace <wallace.colin.a@gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef SUBWINDOW_H
+#define SUBWINDOW_H
+
+
+#include <QMdiSubWindow>
+#include <QRect>
+
+
+class QMoveEvent;
+class QResizeEvent;
+class QWidget;
+
+
+class SubWindow : public QMdiSubWindow
+{
+	Q_OBJECT
+public:
+	SubWindow(QWidget *parent=NULL, Qt::WindowFlags windowFlags=0);
+	// same as QWidet::normalGeometry, but works properly under X11 (see https://bugreports.qt.io/browse/QTBUG-256)
+	QRect getTrueNormalGeometry() const;
+protected:
+	// hook the QWidget move/resize events to update the tracked geometry
+	virtual void moveEvent(QMoveEvent * event);
+	virtual void resizeEvent(QResizeEvent * event);
+private:
+	QRect m_trackedNormalGeom;
+};
+
+#endif

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -32,13 +32,15 @@
 #include <QMdiSubWindow>
 #include <QRect>
 
+#include "export.h"
+
 
 class QMoveEvent;
 class QResizeEvent;
 class QWidget;
 
 
-class SubWindow : public QMdiSubWindow
+class EXPORT SubWindow : public QMdiSubWindow
 {
 	Q_OBJECT
 public:

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -310,7 +310,7 @@ manageVSTEffectView::manageVSTEffectView( VstEffect * _eff, VstEffectControls * 
         m_vi->m_scrollArea = new QScrollArea( widget );
 	l = new QGridLayout( widget );
 
-	m_vi->m_subWindow = gui->mainWindow()->workspace()->addSubWindow(new QMdiSubWindow, Qt::SubWindow | 
+	m_vi->m_subWindow = gui->mainWindow()->addWindowedWidget(NULL, Qt::SubWindow | 
 			Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 	m_vi->m_subWindow->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
 	m_vi->m_subWindow->setFixedSize( 960, 300);

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -874,7 +874,7 @@ manageVestigeInstrumentView::manageVestigeInstrumentView( Instrument * _instrume
 	widget = new QWidget(this);
 	l = new QGridLayout( this );
 
-	m_vi->m_subWindow = gui->mainWindow()->workspace()->addSubWindow(new QMdiSubWindow, Qt::SubWindow |
+	m_vi->m_subWindow = gui->mainWindow()->addWindowedWidget(NULL, Qt::SubWindow |
 			Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 	m_vi->m_subWindow->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::MinimumExpanding );
 	m_vi->m_subWindow->setFixedWidth( 960 );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(LMMS_SRCS
 	gui/PluginBrowser.cpp
 	gui/SetupDialog.cpp
 	gui/StringPairDrag.cpp
+	gui/SubWindow.cpp
 	gui/TimeLineWidget.cpp
 	gui/ToolPluginView.cpp
 	gui/TrackContainerView.cpp

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -147,8 +147,7 @@ FxMixerView::FxMixerView() :
 
 
 	// add ourself to workspace
-	QMdiSubWindow * subWin =
-		gui->mainWindow()->workspace()->addSubWindow( this );
+	QMdiSubWindow * subWin = gui->mainWindow()->addWindowedWidget( this );
 	Qt::WindowFlags flags = subWin->windowFlags();
 	flags &= ~Qt::WindowMaximizeButtonHint;
 	subWin->setWindowFlags( flags );

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -1,0 +1,67 @@
+/*
+ * SubWindow.cpp - Implementation of QMdiSubWindow that correctly tracks
+ *   the geometry that windows should be restored to.
+ *   Workaround for https://bugreports.qt.io/browse/QTBUG-256
+ *
+ * Copyright (c) 2015 Colin Wallace <wallace.colin.a@gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "SubWindow.h"
+
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QWidget>
+
+
+SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags)
+  : QMdiSubWindow(parent, windowFlags)
+{
+	// initialize the tracked geometry to whatever Qt thinks the normal geometry currently is.
+	// this should always work, since QMdiSubWindows will not start as maximized
+	m_trackedNormalGeom = normalGeometry();
+}
+
+QRect SubWindow::getTrueNormalGeometry() const
+{
+	return m_trackedNormalGeom;
+}
+
+void SubWindow::moveEvent(QMoveEvent * event)
+{
+	QMdiSubWindow::moveEvent(event);
+	// if the window was moved and ISN'T minimized/maximized/fullscreen,
+	//   then save the current position
+	if (!isMaximized() && !isMinimized() && !isFullScreen())
+	{
+		m_trackedNormalGeom.moveTopLeft(event->pos());
+	}
+}
+
+void SubWindow::resizeEvent(QResizeEvent * event)
+{
+	QMdiSubWindow::resizeEvent(event);
+	// if the window was resized and ISN'T minimized/maximized/fullscreen,
+	//   then save the current size
+	if (!isMaximized() && !isMinimized() && !isFullScreen())
+	{
+		m_trackedNormalGeom.setSize(event->size());
+	}
+}

--- a/src/gui/ToolPluginView.cpp
+++ b/src/gui/ToolPluginView.cpp
@@ -38,7 +38,7 @@
 ToolPluginView::ToolPluginView( ToolPlugin * _toolPlugin ) :
 	PluginView( _toolPlugin, NULL )
 {
-	gui->mainWindow()->workspace()->addSubWindow( this );
+	gui->mainWindow()->addWindowedWidget( this );
 	parentWidget()->setAttribute( Qt::WA_DeleteOnClose, false );
 
 	setWindowTitle( _toolPlugin->displayName() );

--- a/src/gui/widgets/ControllerRackView.cpp
+++ b/src/gui/widgets/ControllerRackView.cpp
@@ -75,8 +75,7 @@ ControllerRackView::ControllerRackView( ) :
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
-	QMdiSubWindow * subWin =
-			gui->mainWindow()->workspace()->addSubWindow( this );
+	QMdiSubWindow * subWin = gui->mainWindow()->addWindowedWidget( this );
 
 	// No maximize button
 	Qt::WindowFlags flags = subWin->windowFlags();

--- a/src/gui/widgets/ControllerView.cpp
+++ b/src/gui/widgets/ControllerView.cpp
@@ -65,8 +65,7 @@ ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 
 	m_controllerDlg = getController()->createDialog( gui->mainWindow()->workspace() );
 
-	m_subWindow = gui->mainWindow()->workspace()->addSubWindow( 
-                m_controllerDlg );
+	m_subWindow = gui->mainWindow()->addWindowedWidget( m_controllerDlg );
 	
 	Qt::WindowFlags flags = m_subWindow->windowFlags();
 	flags &= ~Qt::WindowMaximizeButtonHint;

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -110,7 +110,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 		m_controlView = effect()->controls()->createView();
 		if( m_controlView )
 		{
-			m_subWindow = gui->mainWindow()->workspace()->addSubWindow(
+			m_subWindow = gui->mainWindow()->addWindowedWidget(
 								m_controlView,
 				Qt::SubWindow | Qt::CustomizeWindowHint  |
 					Qt::WindowTitleHint | Qt::WindowSystemMenuHint );

--- a/src/gui/widgets/ProjectNotes.cpp
+++ b/src/gui/widgets/ProjectNotes.cpp
@@ -71,7 +71,7 @@ ProjectNotes::ProjectNotes() :
 	setWindowTitle( tr( "Project notes" ) );
 	setWindowIcon( embed::getIconPixmap( "project_notes" ) );
 
-	gui->mainWindow()->workspace()->addSubWindow( this );
+	gui->mainWindow()->addWindowedWidget( this );
 	parentWidget()->setAttribute( Qt::WA_DeleteOnClose, false );
 	parentWidget()->move( 700, 10 );
 	parentWidget()->resize( 400, 300 );

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -293,7 +293,7 @@ void TempoSyncKnob::showCustom()
 	if( m_custom == NULL )
 	{
 		m_custom = new MeterDialog( gui->mainWindow()->workspace() );
-		gui->mainWindow()->workspace()->addSubWindow( m_custom );
+		gui->mainWindow()->addWindowedWidget( m_custom );
 		m_custom->setWindowTitle( "Meter" );
 		m_custom->setModel( &model()->m_custom );
 	}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1423,19 +1423,19 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	setFixedWidth( INSTRUMENT_WIDTH );
 	resize( sizeHint() );
 
-	QMdiSubWindow * subWin = gui->mainWindow()->workspace()->addSubWindow( this );
+	QMdiSubWindow * subWin = gui->mainWindow()->addWindowedWidget( this );
 	Qt::WindowFlags flags = subWin->windowFlags();
 	flags |= Qt::MSWindowsFixedSizeDialogHint;
 	flags &= ~Qt::WindowMaximizeButtonHint;
 	subWin->setWindowFlags( flags );
 
-  // Hide the Size and Maximize options from the system menu
-  // since the dialog size is fixed.
-  QMenu * systemMenu = subWin->systemMenu();
-  systemMenu->actions().at( 2 )->setVisible( false ); // Size
-  systemMenu->actions().at( 4 )->setVisible( false ); // Maximize
+	// Hide the Size and Maximize options from the system menu
+	// since the dialog size is fixed.
+	QMenu * systemMenu = subWin->systemMenu();
+	systemMenu->actions().at( 2 )->setVisible( false ); // Size
+	systemMenu->actions().at( 4 )->setVisible( false ); // Maximize
 
-  subWin->setWindowIcon( embed::getIconPixmap( "instrument_track" ) );
+	subWin->setWindowIcon( embed::getIconPixmap( "instrument_track" ) );
 	subWin->setFixedSize( subWin->size() );
 	subWin->hide();
 }

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -589,7 +589,7 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_effectRack = new EffectRackView( _t->audioPort()->effects() );
 	m_effectRack->setFixedSize( 240, 242 );
 
-	m_effWindow = gui->mainWindow()->workspace()->addSubWindow( m_effectRack );
+	m_effWindow = gui->mainWindow()->addWindowedWidget( m_effectRack );
 	m_effWindow->setAttribute( Qt::WA_DeleteOnClose, false );
 	m_effWindow->layout()->setSizeConstraint( QLayout::SetFixedSize );
  	m_effWindow->setWindowTitle( _t->name() );


### PR DESCRIPTION
See #2087 for design decisions, etc. Ultimately, these errors arose from [this](https://bugreports.qt.io/browse/QTBUG-256) bug in Qt, in which the `normalGeometry()` function (which returns the position and size that a window would be if the user clicked on its restore button) behaves incorrectly under X11. This function is needed when saving the project so as to retain the correct window layout when the project is reopened.

The solution is to add a new class, `SubWindow`, which inherits from a similar Qt class but also records the geometry of itself whenever it's resized/moved, so long as it's not minimized/maximized (i.e. whereas `QWidget::normalGeometry()` queries X11 for the relevant data, `SubWindow` tracks it explicitly). Some additional restructuring was needed to ensure that all widgets are placed inside the new `SubWindow` class and not the old `QMdiSubWindow`. I also took the liberty of alphabetizing the includes in MainWindow.cpp and replacing some spaces with tabs in InstrumentTrack.cpp.

The changes seem stable on my system, however I was unable to verify Vestige's operation due to a borked Wine installation (2 lines in Vestige were modified). I would appreciate it if somebody could do some basic testing there  -just open a project with Vestige, make some small changes, save it+reload it and make sure nothing bad happens.