### PR TITLE
Correct filenames within documentation strings

### DIFF
--- a/include/ActionGroup.h
+++ b/include/ActionGroup.h
@@ -1,5 +1,5 @@
 /*
- * Editor.h - declaration of Editor class
+ * ActionGroup.h - wrapper around QActionGroup to provide a more useful triggered(int) slot
  *
  * Copyright (c) 2014 Lukas W <lukaswhl/at/gmail.com>
  *

--- a/include/DetuningHelper.h
+++ b/include/DetuningHelper.h
@@ -1,5 +1,5 @@
 /*
- * detuning_helper.h - detuning automation helper
+ * DetuningHelper.h - detuning automation helper
  *
  * Copyright (c) 2007 Javier Serrano Polo <jasp00/at/users.sourceforge.net>
  * Copyright (c) 2008-2010 Tobias Doerffel <tobydox/at/users.sourceforge.net>

--- a/include/EffectRackView.h
+++ b/include/EffectRackView.h
@@ -1,5 +1,5 @@
 /*
- * effect_rack_view.h - view for effectChain-model
+ * EffectRackView.h - view for effectChain-model
  *
  * Copyright (c) 2006-2007 Danny McRae <khjklujn@netscape.net>
  * Copyright (c) 2008-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>

--- a/include/InstrumentView.h
+++ b/include/InstrumentView.h
@@ -1,5 +1,5 @@
 /*
- * instrument_view.h - definition of instrumentView-class
+ * InstrumentView.h - definition of InstrumentView-class
  *
  * Copyright (c) 2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/include/LeftRightNav.h
+++ b/include/LeftRightNav.h
@@ -1,5 +1,5 @@
 /*
- * LeftRightNav.cpp - side-by-side left-facing and right-facing arrows for navigation (looks like < > )
+ * LeftRightNav.h - side-by-side left-facing and right-facing arrows for navigation (looks like < > )
  *
  * Copyright (c) 2015 Colin Wallace <wallacoloo/at/gmail.com>
  *

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -1,5 +1,5 @@
 /*
- * plugin_browser.h - include file for pluginBrowser
+ * PluginBrowser.h - include file for pluginBrowser
  *
  * Copyright (c) 2005-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -1,5 +1,5 @@
 /*
- * types.h - typedefs for common types that are used in the whole app
+ * lmms_basics.h - typedefs for common types that are used in the whole app
  *
  * Copyright (c) 2004-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/src/core/BandLimitedWave.cpp
+++ b/src/core/BandLimitedWave.cpp
@@ -1,5 +1,5 @@
 /*
- * BandLimitedWave.h - helper functions for band-limited
+ * BandLimitedWave.cpp - helper functions for band-limited
  *                    	waveform generation
  *
  * Copyright (c) 2014 Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -1,5 +1,5 @@
 /*
- * drumsynth.cpp - DrumSynth DS file renderer
+ * DrumSynth.cpp - DrumSynth DS file renderer
  *
  * Copyright (c) 1998-2000 Paul Kellett (mda-vst.com)
  * Copyright (c) 2007 Paul Giblock <drfaygo/at/gmail.com>

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -1,5 +1,5 @@
 /*
- * note.cpp - implementation of class note
+ * Note.cpp - implementation of class note
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1,5 +1,5 @@
 /*
- * song.cpp - root of the model tree
+ * Song.cpp - root of the model tree
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -1,5 +1,5 @@
 /*
- * audio_alsa.cpp - device-class which implements ALSA-PCM-output
+ * AudioAlsa.cpp - device-class which implements ALSA-PCM-output
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/src/gui/ActionGroup.cpp
+++ b/src/gui/ActionGroup.cpp
@@ -1,5 +1,5 @@
 /*
- * Editor.h - declaration of Editor class
+ * ActionGroup.cpp - wrapper around QActionGroup to provide a more useful triggered(int) slot
  *
  * Copyright (c) 2014 Lukas W <lukaswhl/at/gmail.com>
  *

--- a/src/gui/PeakControllerDialog.cpp
+++ b/src/gui/PeakControllerDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * PeakController_Dialog.cpp - per-controller-specific view for changing a
+ * PeakControllerDialog.cpp - per-controller-specific view for changing a
  * controller's settings
  *
  * Copyright (c) 2008-2009 Paul Giblock <drfaygo/at/gmail.com>

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -1,5 +1,5 @@
 /*
- * Piano.cpp - implementation of piano-widget used in instrument-track-window
+ * PianoView.cpp - implementation of piano-widget used in instrument-track-window
  *             for testing + according model class
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -1,5 +1,5 @@
 /*
- * plugin_browser.cpp - implementation of the plugin-browser
+ * PluginBrowser.cpp - implementation of the plugin-browser
  *
  * Copyright (c) 2005-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -1,5 +1,5 @@
 /*
- * Combobox.cpp - implementation of LMMS combobox
+ * ComboBox.cpp - implementation of LMMS combobox
  *
  * Copyright (c) 2006-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * Copyright (c) 2008-2009 Paul Giblock <pgib/at/users.sourceforge.net>

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -1,5 +1,5 @@
 /*
- * lcd_spinbox.cpp - class LcdSpinBox, an improved QLCDNumber
+ * LcdSpinBox.cpp - class LcdSpinBox, an improved QLCDNumber
  *
  * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * Copyright (c) 2008 Paul Giblock <pgllama/at/gmail.com>

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1,5 +1,5 @@
 /*
- * pattern.cpp - implementation of class pattern which holds notes
+ * Pattern.cpp - implementation of class pattern which holds notes
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * Copyright (c) 2005-2007 Danny McRae <khjklujn/at/yahoo.com>


### PR DESCRIPTION
Fixes some documentation issues such as how the top-level documentation string for ActionGroup.h/.cpp was actually copied verbatim from Editor.h, and was totally inaccurate :P