### PR TITLE
Replace 'Engine::hasGUI()' with 'gui != nullptr'

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -49,10 +49,6 @@ public:
 	static void init();
 	static void destroy();
 
-	// TODO: Remove me. Replace calls like `if( Engine::hasGUI() )` with
-	// `if (gui)` (gui defined in "GuiApplication.h"
-	static bool hasGUI();
-
 	// core
 	static Mixer *mixer()
 	{

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -97,7 +97,7 @@ bool MidiImport::tryImport( TrackContainer* tc )
 	}
 
 #ifdef LMMS_HAVE_FLUIDSYNTH
-	if( Engine::hasGUI() &&
+	if( gui != NULL &&
 		ConfigManager::inst()->defaultSoundfont().isEmpty() )
 	{
 		QMessageBox::information( gui->mainWindow(),
@@ -110,7 +110,7 @@ bool MidiImport::tryImport( TrackContainer* tc )
 				"settings dialog and try again." ) );
 	}
 #else
-	if( Engine::hasGUI() )
+	if( gui )
 	{
 		QMessageBox::information( gui->mainWindow(),
 			tr( "Setup incomplete" ),

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -34,6 +34,7 @@
 
 #include "Engine.h"
 #include "gui_templates.h"
+#include "GuiApplication.h"
 #include "InstrumentTrack.h"
 
 #include "embed.cpp"
@@ -327,7 +328,7 @@ malletsInstrumentView::malletsInstrumentView( malletsInstrument * _instrument,
 	m_spreadKnob->setHintText( tr( "Spread:" ), "" );
 
 	// try to inform user about missing Stk-installation
-	if( _instrument->m_filesMissing && Engine::hasGUI() )
+	if( _instrument->m_filesMissing && gui != NULL )
 	{
 		QMessageBox::information( 0, tr( "Missing files" ),
 				tr( "Your Stk-installation seems to be "

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -31,18 +31,18 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
-#include <QTextStream>
 #include <QMessageBox>
+#include <QTextStream>
 
-
+#include "base64.h"
 #include "ConfigManager.h"
+#include "Effect.h"
+#include "GuiApplication.h"
+#include "lmmsversion.h"
 #include "PluginFactory.h"
 #include "ProjectVersion.h"
-#include "ProjectVersion.h"
 #include "SongEditor.h"
-#include "Effect.h"
-#include "lmmsversion.h"
-#include "base64.h"
+
 
 
 
@@ -126,7 +126,7 @@ DataFile::DataFile( const QString & _fileName ) :
 	QFile inFile( _fileName );
 	if( !inFile.open( QIODevice::ReadOnly ) )
 	{
-		if( Engine::hasGUI() )
+		if( gui )
 		{
 			QMessageBox::critical( NULL,
 				SongEditor::tr( "Could not open file" ),
@@ -272,7 +272,7 @@ bool DataFile::writeFile( const QString& filename )
 
 	if( !outfile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
 	{
-		if( Engine::hasGUI() )
+		if( gui )
 		{
 			QMessageBox::critical( NULL,
 				SongEditor::tr( "Could not write file" ),
@@ -822,7 +822,7 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 		if( line >= 0 && col >= 0 )
 		{
 			qWarning() << "at line" << line << "column" << errorMsg;
-			if( Engine::hasGUI() )
+			if( gui )
 			{
 				QMessageBox::critical( NULL,
 					SongEditor::tr( "Error in file" ),
@@ -852,7 +852,7 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 			// only one compareType needs to be set, and we can compare on one line because setCompareType returns ProjectVersion
 			if ( createdWith.setCompareType(Minor) != openedWith)
 			{
-				if( Engine::hasGUI() && root.attribute( "type" ) == "song" ) //documentElement()
+				if( gui != nullptr && root.attribute( "type" ) == "song" )
 				{
 					QMessageBox::information( NULL,
 						SongEditor::tr( "Project Version Mismatch" ),

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -107,11 +107,6 @@ void Engine::destroy()
 	delete ConfigManager::inst();
 }
 
-bool Engine::hasGUI()
-{
-	return gui != nullptr;
-}
-
 
 
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -83,7 +83,7 @@ Mixer::Mixer() :
 	}
 
 	// just rendering?
-	if( !Engine::hasGUI() )
+	if( !gui )
 	{
 		m_framesPerPeriod = DEFAULT_BUFFER_SIZE;
 		m_fifo = new fifo( 1 );

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -98,7 +98,7 @@ Plugin * Plugin::instantiate( const QString& pluginName, Model * parent,
 	const PluginFactory::PluginInfo& pi = pluginFactory->pluginInfo(pluginName.toUtf8());
 	if( pi.isNull() )
 	{
-		if( Engine::hasGUI() )
+		if( gui )
 		{
 			QMessageBox::information( NULL,
 				tr( "Plugin not found" ),
@@ -112,7 +112,7 @@ Plugin * Plugin::instantiate( const QString& pluginName, Model * parent,
 	InstantiationHook instantiationHook = ( InstantiationHook ) pi.library->resolve( "lmms_plugin_main" );
 	if( instantiationHook == NULL )
 	{
-		if( Engine::hasGUI() )
+		if( gui )
 		{
 			QMessageBox::information( NULL,
 				tr( "Error while loading plugin" ),

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -965,7 +965,7 @@ void Song::loadProject( const QString & fileName )
 	if( !node.isNull() )
 	{
 		Engine::fxMixer()->restoreState( node.toElement() );
-		if( Engine::hasGUI() )
+		if( gui )
 		{
 			// refresh FxMixerView
 			gui->fxMixerView()->refreshDisplay();
@@ -985,7 +985,7 @@ void Song::loadProject( const QString & fileName )
 			{
 				restoreControllerStates( node.toElement() );
 			}
-			else if( Engine::hasGUI() )
+			else if( gui )
 			{
 				if( node.nodeName() == gui->getControllerRackView()->nodeName() )
 				{
@@ -1034,7 +1034,7 @@ void Song::loadProject( const QString & fileName )
 
 	if ( hasErrors())
 	{
-		if ( Engine::hasGUI() )
+		if ( gui )
 		{
 			QMessageBox::warning( NULL, "LMMS Error report", *errorSummary(),
 							QMessageBox::Ok );
@@ -1071,7 +1071,7 @@ bool Song::saveProjectFile( const QString & filename )
 
 	m_globalAutomationTrack->saveState( dataFile, dataFile.content() );
 	Engine::fxMixer()->saveState( dataFile, dataFile.content() );
-	if( Engine::hasGUI() )
+	if( gui )
 	{
 		gui->getControllerRackView()->saveState( dataFile, dataFile.content() );
 		gui->pianoRoll()->saveState( dataFile, dataFile.content() );
@@ -1092,7 +1092,7 @@ bool Song::guiSaveProject()
 {
 	DataFile dataFile( DataFile::SongProject );
 	m_fileName = dataFile.nameWithExtension( m_fileName );
-	if( saveProjectFile( m_fileName ) && Engine::hasGUI() )
+	if( saveProjectFile( m_fileName ) && gui != nullptr )
 	{
 		TextFloat::displayMessage( tr( "Project saved" ),
 					tr( "The project %1 is now saved."
@@ -1103,7 +1103,7 @@ bool Song::guiSaveProject()
 		m_modified = false;
 		gui->mainWindow()->resetWindowTitle();
 	}
-	else if( Engine::hasGUI() )
+	else if( gui != nullptr )
 	{
 		TextFloat::displayMessage( tr( "Project NOT saved." ),
 				tr( "The project %1 was not saved!" ).arg(
@@ -1352,7 +1352,7 @@ void Song::setModified()
 	if( !m_loadingProject )
 	{
 		m_modified = true;
-		if( Engine::hasGUI() && gui->mainWindow() &&
+		if( gui != nullptr && gui->mainWindow() &&
 			QThread::currentThread() == gui->mainWindow()->thread() )
 		{
 			gui->mainWindow()->resetWindowTitle();

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -82,7 +82,7 @@ void TrackContainer::loadSettings( const QDomElement & _this )
 	static QProgressDialog * pd = NULL;
 	bool was_null = ( pd == NULL );
 	int start_val = 0;
-	if( !journalRestore && Engine::hasGUI() )
+	if( !journalRestore && gui != nullptr )
 	{
 		if( pd == NULL )
 		{


### PR DESCRIPTION
@Lukas-W added a comment about how calls to `if (Engine::hasGUI())` should just be replaced by `if (gui)` in commit https://github.com/LMMS/lmms/commit/35e1c4ed899dde640e298129fde8c957fef05671 . That was back in February, so I just went ahead and took care of it for him.

Seems like a pretty benign change, so I only tested this branch by opening LMMS, loading a project, playing it, saving it, and closing it.