### PR TITLE
Fix wording inconsistency in View menu (~~Show/Hide~~ Controller Rack)

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -3447,7 +3447,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished">Exporta projecte actual</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">Mostra/amaga Editor de Cançó</translation>
     </message>
     <message>
@@ -3455,7 +3455,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished">Mostra/amaga Editor de Ritme Base</translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished">Mostra/amaga Rotlle de Piano</translation>
     </message>
     <message>
@@ -3471,7 +3471,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished">Mostra/amaga Editor d&apos;Automatització</translation>
     </message>
     <message>
@@ -3479,7 +3479,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished">Mostra/amaga Mesclador FX</translation>
     </message>
     <message>
@@ -3487,7 +3487,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">Mostra/amaga les notes del projecte</translation>
     </message>
     <message>

--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -3495,7 +3495,7 @@ Per favor, comprova que tens permís d&apos;escriptura per a aquest fitxer i tor
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -3447,7 +3447,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Exportovat aktuální projekt</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">Ukaž/schovej Editor skladby</translation>
     </message>
     <message>
@@ -3455,7 +3455,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Zmačknutím tohoto knoflíku zobrazíte nebo schováte Editor skladby. S jeho pomocí můžete editovat playlist skladby a specifikovat, kdy a která stopa má být přehrána. Můžete také vložit a přesunovat samply (např. rapové) přímo do playlistu.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished">Ukaž/schovej Beat+Bassline editor</translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Zmačknutím tohoto knoflíku zobrazíte nebo schováte Beat+Bassline editor. Beat+Bassline editor je nezbytný pro tvorbu beatů a pro otevírání, přidávání a odebírání kanálů. Dále pro vyjmutí, kopírování a vložení beatů, Beat+Bassline patternů a dalších podobných věcí.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished">Ukaž/schovej Piano-Roll</translation>
     </message>
     <message>
@@ -3471,7 +3471,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Klikněte zde, pokud chcete ukázat nebo schovat Piano-Roll. S pomocí Piano-Roll můžete jednoduchým způsobem editovat melodie.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished">Ukaž/schovej Automatizační editor</translation>
     </message>
     <message>
@@ -3479,7 +3479,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Klikněte zde, pokud chcete ukázat nebo schovat Automatizační editor. S pomocí Automatizačního editoru můžete jednoduchým způsobem editovat dynamické hodnoty.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished">Ukaž/schovej FX Mixer</translation>
     </message>
     <message>
@@ -3487,7 +3487,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Klikněte zde, pokud chcete ukázat nebo schovat FX Mixer. FX Mixer je velmi mocný nástroj pro správu efektů ve vaší skladbě. Efekty můžete vkládat do různých efektových kanálů.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">Ukaž/schovej poznámky k projektu</translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -3495,7 +3495,7 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation type="unfinished">Klikněte zde, pokud chcete ukázat nebo schovat okno pro poznámky. V tomto okně lze vkládat vaše poznámky k projektu.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished">Ukaž/schovej kontrolér rack</translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3468,7 +3468,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Aktuelles Projekt exportieren</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Zeige/verstecke Song-Editor</translation>
     </message>
     <message>
@@ -3476,7 +3476,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Mit diesem Knopf können Sie den Song-Editor zeigen oder verstecken. Mit Hilfe des Song-Editors können Sie die Song-Playliste bearbeiten und angeben, wann welche Spur abgespielt werden soll. Außerdem können Sie Samples (z.B. Rap samples) direkt in die Playliste einfügen und verschieben.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Zeige/verstecke Beat+Bassline Editor</translation>
     </message>
     <message>
@@ -3484,7 +3484,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Mit diesem Knopf können Sie den Beat+Bassline-Editor zeigen oder verstecken. Mit dem Beat+Bassline-Editor kann man Beats erstellen, Bassline-Patterns bearbeiten uvm.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Zeige/verstecke Piano-Roll</translation>
     </message>
     <message>
@@ -3492,7 +3492,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Hier klicken, um das Piano-Roll zu zeigen oder verstecken. Mit Hilfe des Piano-Rolls können Sie Melodien auf einfache Art und Weise bearbeiten.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Zeige/Verstecke Automation-Editor</translation>
     </message>
     <message>
@@ -3500,7 +3500,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Hier klicken, um den Automation-Editor zu zeigen oder verstecken. Mit Hilfe des Automation-Editors können Sie Automation-Patterns auf einfache Art und Weise bearbeiten.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Zeige/verstecke FX-Mixer</translation>
     </message>
     <message>
@@ -3508,7 +3508,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Hier klicken, um den FX-Mixer zu zeigen oder verstecken. Der FX-Mixer ist ein leistungsfähiges Werkzeug, um Effekte für Ihren Song zu verwalten. Sie können verschiedene Effekte in unterschiedliche Effekt-Kanäle einfügen.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Zeige/verstecke Projekt-Notizen</translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3516,7 +3516,7 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Hier klicken, um die Projektnotizen zu zeigen oder verstecken.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Zeige/verstecke Controller-Rack</translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Exportar proyecto actual</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">استخراج پروژه ی جاری</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -3670,7 +3670,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Cliquez ici pour montrer et cacher la fenêtre de notes du projet. Dans cette fenêtre vous pouvez inscrire les notes de votre projet.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Montrer/Cacher le rack de contrôleurs</translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -3622,7 +3622,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Exporter le projet</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Montrer/Cacher l&apos;éditeur de morceau</translation>
     </message>
     <message>
@@ -3630,7 +3630,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>En appuyant sur ce bouton, vous pouvez montrer ou cacher l&apos;éditeur de morceau. À l&apos;aide de l&apos;éditeur de morceau vous pouvez éditer la liste de lecture du morceau et indiquer quelle piste devra être jouée. Vous pouvez également insérer et déplacer des échantillons (p. ex. des échantillons de Rap) directement dans la liste de lecture.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Montrer/Cacher l&apos;éditeur de rythme et de ligne de basse</translation>
     </message>
     <message>
@@ -3638,7 +3638,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>En appuyant sur ce bouton, vous pouvez montrer ou cacher l&apos;éditeur de rythme et de ligne de basse. L&apos;éditeur de rythme et de ligne de basse est nécessaire pour la création de rythmes, pour ouvrir, ajouter et supprimer des canaux, pour couper, copier et coller des motifs rythmiques, et pour d&apos;autres choses similaires.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Montrer/Cacher le piano virtuel</translation>
     </message>
     <message>
@@ -3646,7 +3646,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Cliquez ici pour montrer ou cacher le piano virtuel. À l&apos;aide du piano virtuel vous pouvez éditer facilement des mélodies.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Montrer/Cacher l&apos;éditeur d&apos;automation</translation>
     </message>
     <message>
@@ -3654,7 +3654,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Cliquez ici pour montrer ou cacher l&apos;éditeur d&apos;automation. À l&apos;aide de l&apos;éditeur d&apos;automation vous pouvez éditer facilement des valeurs dynamiques.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Montrer/Cacher le mélangeur d&apos;effets</translation>
     </message>
     <message>
@@ -3662,7 +3662,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Cliquez ici pour montrer et cacher le mélangeur d&apos;effets. Le mélangeur d&apos;effet est un outil très puissant pour la gestion des effets de votre morceau. Vous pouvez insérer des effets dans différents canaux d&apos;effets.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Montrer/Cacher les notes du projet</translation>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -3460,7 +3460,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Exportar este proxecto</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Mostrar/Agochar o editor de cancións</translation>
     </message>
     <message>
@@ -3468,7 +3468,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Premendo este botón pódese mostrar ou agochar o Editor de Cancións. Coa axuda do Editor de Cancións pódese editar listas de reprodución e indicar cando tocar unha pista. Tamén se poden inserir e mover mostras (p.ex. mostras de rap) directamente na lista de reprodución.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Mostrar/Agochar o Editor de ritmos e liña do baixo</translation>
     </message>
     <message>
@@ -3476,7 +3476,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Premendo este botón pódese mostrar ou agochar o Editor de ritmos e liña do baixo. Este Editor de ritmos e liña do baixo é necesario para crear ritmos e para abrir, engadir e eliminar canles, así como para recortar, copiar e pegar ritmos e padróns de liñas do baixo e para outras cousas semellantes.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Mostrar/Agochar a pianola</translation>
     </message>
     <message>
@@ -3484,7 +3484,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Prema aquí para mostrar ou agochar a pianola. Coa axuda da pianola pódense editar melodías facilmente.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Mostrar/Agochar o Editor de automatización</translation>
     </message>
     <message>
@@ -3492,7 +3492,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Prema aquí para mostrar ou agochar o Editor de automatización. Coa axuda do Editor de automatización pódense editar os valores dinámicos facilmente.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Mostrar/Agochar os Mesturador de efectos especiais</translation>
     </message>
     <message>
@@ -3500,7 +3500,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Prema aquí para mostrar ou agochar o Mesturador de efectos especiais. O Mesturador de efectos especiais é unha ferramenta potente para xestionar os efectos das cancións. Pódense inserir efectos nas diferentes canles de efectos.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Mostrar/Agochar as notas do proxecto</translation>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -3508,7 +3508,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Prema aquí para mostrar ou agochar a xanela coas notas do proxecto. Nela pódense apuntar as notas do proxecto.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Mostrar/Agochar o bastidor de controladores</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3468,7 +3468,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Esporta questo progetto</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Mostra/nascondi il Song-Editor</translation>
     </message>
     <message>
@@ -3476,7 +3476,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde il Song-Editor. Con l&apos;aiuto del Song-Editor è possibile modificare la playlist e specificare quando ogni traccia viene riprodotta. Si possono anche inserire e spostare i campioni (ad es. campioni rap) direttamente nella lista di riproduzione.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Mostra/nascondi il Beat+Bassline Editor</translation>
     </message>
     <message>
@@ -3484,7 +3484,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde il Beat+Bassline Editor. Il Beat+Bassline Editor serve per creare beats, aprire, aggiungere e togliere canali, tagliare, copiare e incollare pattern beat e pattern bassline.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Mostra/nascondi il Piano-Roll</translation>
     </message>
     <message>
@@ -3492,7 +3492,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde il Piano-Roll. Con l&apos;aiuto del Piano-Roll è possibile modificare sequenze melodiche in modo semplice.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Mostra/nascondi l&apos;Editor dell&apos;automazione</translation>
     </message>
     <message>
@@ -3500,7 +3500,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde l&apos;editor dell&apos;automazione. Con l&apos;aiuto dell&apos;editor dell&apos;automazione è possibile rendere dinamici alcuni valori in modo semplice.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Mostra/nascondi il mixer degli effetti</translation>
     </message>
     <message>
@@ -3508,7 +3508,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde il mixer degli effetti. Il mixer degli effetti è uno strumento molto potente per gestire gli effetti della canzone. È possibile inserire effetti in più canali.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Mostra/nascondi le note del progetto</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3516,7 +3516,7 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde la finestra delle note del progetto. Qui è possibile scrivere le note per il progetto.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Mostra/nascondi il rack di controller</translation>
     </message>
     <message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3511,7 +3511,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">ここをクリックして　ノートウインドウの表示非表示を切り替えます。ノートウインドウにプロジェクトノートを記入します。</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished">コントローラトラック　表示/非表示</translation>
     </message>
     <message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3462,7 +3462,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">現在のプロジェクトをエクスポート</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">ソングエディタ 表示/非表示</translation>
     </message>
     <message>
@@ -3470,7 +3470,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">このボタンを押すと。ソングエディタ表示/非表示にできます。ソングエディタの利用によってプレイリストの編集とどのトラックをいつ演奏するかを編集できます。プレイリストの中で直接サンプルを挿入したり移動（rap samples)したりすることもできます。</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished">ビート+
 ベースラインエディタ　表示/非表示</translation>
     </message>
@@ -3479,7 +3479,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">このボタンで、ビート＋ベースラインエディタの表示/非表示を切り替えます。ビート＋ベースラインエディタで、ビートをつくったり、チャンネルを開いたり足したり除去したり、ベースラインパターンをカット・コピー・ペーストしたり、いろいろできます。</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished">ピアノロール 表示/非表示</translation>
     </message>
     <message>
@@ -3487,7 +3487,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">ここをクリックして　ピアノロールの表示/非表示を切り替えます。　ピアノロールを使うとメロディを簡単に編集できます。</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished">オートメーションエディタ　表示/非表示</translation>
     </message>
     <message>
@@ -3495,7 +3495,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">ここをクリックして　オートメーションエディタの表示/非表示を切り替えます。オートメーションエディタでダイナミックな値を簡単に編集できます。</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished">エフェクトミキサー　表示/非表示</translation>
     </message>
     <message>
@@ -3503,7 +3503,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">ここをクリックして　エフェクトミキサーの表示/非表示を切り替えます。エフェクトミキサーは曲のエフェクトを管理するパワフルなツールです。エフェクトを異なったエフェクトチャンネルに挿入することができます。</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">プロジェクトノート　表示/非表示</translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished">제어기 랙 보이기/숨기기</translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">현재 프로젝트 내보내기</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">노래 편집기 보이기/숨기기</translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished">Beat+Bassline 편집기 보이기/숨기기</translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished">피아노-롤 보이기/숨기기</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished">자동화 편집기 보이기/숨기기</translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished">FX 믹서 보이기/숨기기</translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">프로젝트 박자 보이기/숨기기</translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Exporteer huidig project</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">Toon/Verberg Song-Bewerker</translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished">Toon/Verberg Beat+Bassline Bewerker</translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished">Toon/Verberg Piano-Roll</translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished">Toon/verberg Automation Editor</translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">Toon/Verberg Project notities</translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3513,7 +3513,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Kliknij tutaj aby pokazać lub ukryć okno z notatkami do projektu. W tym oknie możesz zapisywać wszystko co przychodzi Ci na myśl w związku z projektem.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Pokaż/ukryj rack kontrolerów</translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3465,7 +3465,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Eksportuj bieżący projekt</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Pokaż/ukryj Edytor Kompozycji</translation>
     </message>
     <message>
@@ -3473,7 +3473,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Poprzez naciśnięcie tego przycisku możesz pokazać lub ukryć Edytor Kompozycji. Za pomocą Edytora Kompozycji możesz modyfikować playlistę utworu oraz określić gdzie i kiedy ścieżki będą odtwarzane. Możesz też wstawiać sample bezpośrednio na playlistę.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Pokaż/ukryj Edytor Perkusji i Basu</translation>
     </message>
     <message>
@@ -3481,7 +3481,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Poprzez naciśnięcie tego przycisku możesz pokazać lub ukryć Edytor Perkusji i Basu. Edytor Perkusji i Basu służy do stworzenia linii perkusyjnej i basowej utworu. Możesz wprowadzać w nim zmiany podobne jak w Edytorze Piosenki.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Pokaż/ukryj Edytor Pianolowy</translation>
     </message>
     <message>
@@ -3489,7 +3489,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Kliknij tutaj aby pokazać lub ukryć Edytor Pianolowy. Za jego pomocą możesz w prosty sposób modyfikować melodię.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Pokaż/ukryj Edytor Automatyki</translation>
     </message>
     <message>
@@ -3497,7 +3497,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Kliknij tutaj aby pokazać lub ukryć Edytor Automatyki. Za jego pomocą możesz w prosty sposób modyfikować dynamiczne wartości wszelkich regulatorów.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Pokaż/ukryj Mikser Efektów</translation>
     </message>
     <message>
@@ -3505,7 +3505,7 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Kliknij tutaj aby pokazać lub ukryć Mikser Efektów. Mikser Efektów jest potężnym narzędziem wspomagającym zarządzanie efektami i ścieżkami w Twojej produkcji. Możesz wstawiać wtyczki efektowe na różne kanały dodatkowo wzbogacając brzmienie utworu.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Pokaż/ukryj notatki do projektu</translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -3553,7 +3553,7 @@ Por favor certifique-se que você tem permissão de escrita para este arquivo e 
         <translation>Pressionando este botão você pode mostrar ou esconder o Editor de Bases. No Editor de Bases você pode criar as batidas e a linha de baixo para sua base adicionando ou removendo canais, copiando e colando sequências de batidas e/ou sequências de linha de baixo, ou o que mais você quiser.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Mostrar/esconder a Estante de Controladorer</translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -3393,7 +3393,7 @@ Double click to pick a file.</source>
         <translation>Sobre</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Mostrar/esconder Editor de Arranjo</translation>
     </message>
     <message>
@@ -3413,7 +3413,7 @@ Double click to pick a file.</source>
         <translation>LMMS %1</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Mostrar/esconder Mixer de Efeitos</translation>
     </message>
     <message>
@@ -3421,7 +3421,7 @@ Double click to pick a file.</source>
         <translation>Abrir projeto existente</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Mostrar/esconder Editor de Notas MIDI</translation>
     </message>
     <message>
@@ -3441,7 +3441,7 @@ Double click to pick a file.</source>
         <translation>Clique aqui para mostrar ou esconder o Editor de Notas MIDI. Com ele você pode editar melodias facilmente.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Mostrar/esconder comentários do projeto</translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Double click to pick a file.</source>
         <translation>Salvar projeto atual</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Mostrar/esconder Editor de Automação</translation>
     </message>
     <message>
@@ -3545,7 +3545,7 @@ Por favor certifique-se que você tem permissão de escrita para este arquivo e 
         <translation>A pasta de trabalho do LMMS %1 não existe. Posso criá-la? Você pode mudá-la depois indo em Editar -&gt; Opções.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Mostrar/esconder Editor de Bases</translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -3538,7 +3538,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Эта кнопка показывает/прячет окно с заметками. В этом окне вы можете помещать любые комментарии к своей композиции.</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>Показать/скрыть управление контроллерами</translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -3489,7 +3489,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Экспорт проекта</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>Показать/скрыть музыкальный редактор</translation>
     </message>
     <message>
@@ -3498,7 +3498,7 @@ Please make sure you have write-access to the file and try again.</source>
 Также вы можете вставлять и передвигать записи прямо в списке воспроизведения.</translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>Показать/скрыть ритм-бас редактор</translation>
     </message>
     <message>
@@ -3506,7 +3506,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Сим запускается ритм-бас редактор. Он необходим для установки ритма, открытия, добавления и удаления каналов, а также  вырезания, копирования и вставки ритм-бас шаблонов, мелодий и т. п.</translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>Показать/скрыть нотный редактор</translation>
     </message>
     <message>
@@ -3514,7 +3514,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Запуск редатора нот. С его помощью вы можете легко редактировать мелодии.</translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>Показать/скрыть редактор автоматизации</translation>
     </message>
     <message>
@@ -3522,7 +3522,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Показать/скрыть окно редактора автоматизации. С его помощью вы можете легко редактироватьдинамику выбранных величин.</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>Показать/скрыть микшер ЭФ</translation>
     </message>
     <message>
@@ -3530,7 +3530,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Скрыть/показать микшер ЭФфектов. Он является мощным инструментом для управления эффектами. Вы можете вставлять эффекты в различные каналы.</translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>Показать/скрыть заметки к проекту</translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -3445,7 +3445,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished">Exportera aktuellt projekt</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation type="unfinished">Visa/göm Sång-Editor</translation>
     </message>
     <message>
@@ -3453,7 +3453,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3461,7 +3461,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3469,7 +3469,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3477,7 +3477,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3485,7 +3485,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation type="unfinished">Visa/göm projektanteckningar</translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -3493,7 +3493,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -3455,7 +3455,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>导出当前工程</translation>
     </message>
     <message>
-        <source>Show/hide Song-Editor</source>
+        <source>Song Editor</source>
         <translation>显示/隐藏歌曲编辑器</translation>
     </message>
     <message>
@@ -3463,7 +3463,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Beat+Bassline Editor</source>
+        <source>Pattern Editor</source>
         <translation>显示/隐藏节拍+旋律编辑器</translation>
     </message>
     <message>
@@ -3471,7 +3471,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Piano-Roll</source>
+        <source>Piano Roll</source>
         <translation>显示/隐藏钢琴窗</translation>
     </message>
     <message>
@@ -3479,7 +3479,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide Automation Editor</source>
+        <source>Automation Editor</source>
         <translation>显示/隐藏自动控制编辑器</translation>
     </message>
     <message>
@@ -3487,7 +3487,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>FX Mixer</source>
         <translation>显示/隐藏混音器</translation>
     </message>
     <message>
@@ -3495,7 +3495,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show/hide project notes</source>
+        <source>Project Notes</source>
         <translation>显示/隐藏工程注释</translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -3503,7 +3503,7 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>点击这里显示或隐藏工程注释窗。在此窗口中你可以写下工程的注释。</translation>
     </message>
     <message>
-        <source>Show/hide controller rack</source>
+        <source>Controller Rack</source>
         <translation>显示/隐藏控制器机架</translation>
     </message>
     <message>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1073,7 +1073,7 @@ void MainWindow::updateViewMenu()
 			      this, SLOT( toggleProjectNotesWin() )
 		);
 	m_viewMenu->addAction(embed::getIconPixmap( "controller" ),
-			      tr( "Show/hide controller rack" ) +
+			      tr( "Controller Rack" ) +
 			      " (F11)",
 			      this, SLOT( toggleControllerRack() )
 		);


### PR DESCRIPTION
This fixes #2110 

Additionally, as I was updating the translation sources, I saw that the `<source>` tags were out-of-date for many of the options in the View menu. I updated those `<source>`s without touching the bodies. My rationale is that sub-par translations are better than no translations. However I can easily roll back that last commit if preferable.