### PR TITLE
Qt5 building fixes: casting QAtomic* isn't allowed anymore

### DIFF
--- a/include/ThreadableJob.h
+++ b/include/ThreadableJob.h
@@ -49,7 +49,7 @@ public:
 
 	inline ProcessingState state() const
 	{
-		return static_cast<ProcessingState>( (int) m_state );
+		return static_cast<ProcessingState>( m_state.loadAcquire() );
 	}
 
 	inline void reset()

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -469,7 +469,7 @@ int lb302Synth::process(sampleFrame *outbuf, const int size)
 	float samp;
 
 	// Hold on to the current VCF, and use it throughout this period
-	lb302Filter *filter = vcf;
+	lb302Filter *filter = vcf.loadAcquire();
 
 	if( release_frame == 0 || ! m_playingNote ) 
 	{

--- a/src/core/MixerWorkerThread.cpp
+++ b/src/core/MixerWorkerThread.cpp
@@ -64,10 +64,10 @@ void MixerWorkerThread::JobQueue::addJob( ThreadableJob * _job )
 void MixerWorkerThread::JobQueue::run()
 {
 	bool processedJob = true;
-	while( processedJob && (int) m_itemsDone < (int) m_queueSize )
+	while( processedJob && m_itemsDone.loadAcquire() < m_queueSize.loadAcquire() )
 	{
 		processedJob = false;
-		for( int i = 0; i < m_queueSize; ++i )
+		for( int i = 0; i < m_queueSize.loadAcquire(); ++i )
 		{
 			ThreadableJob * job = m_items[i].fetchAndStoreOrdered( NULL );
 			if( job )
@@ -87,7 +87,7 @@ void MixerWorkerThread::JobQueue::run()
 
 void MixerWorkerThread::JobQueue::wait()
 {
-	while( (int) m_itemsDone < (int) m_queueSize )
+	while( m_itemsDone.load() < m_queueSize.loadAcquire() )
 	{
 #if defined(LMMS_HOST_X86) || defined(LMMS_HOST_X86_64)
 		asm( "pause" );

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -587,10 +587,10 @@ NotePlayHandle * NotePlayHandleManager::acquire( InstrumentTrack* instrumentTrac
 				int midiEventChannel,
 				NotePlayHandle::Origin origin )
 {
-	if( s_availableIndex < 0 )
+	if( s_availableIndex.loadAcquire() < 0 )
 	{
 		s_mutex.lockForWrite();
-		if( s_availableIndex < 0 ) extend( NPH_CACHE_INCREMENT );
+		if( s_availableIndex.loadAcquire() < 0 ) extend( NPH_CACHE_INCREMENT );
 		s_mutex.unlock();
 	}
 	s_mutex.lockForRead();


### PR DESCRIPTION
Casting QAtomicInt to int and QAtomicPointer to a pointer was removed in Qt 5.0.
Out of the alternatives load() and loadAcquire() the latter should be the safer.