### PR TITLE
Removed legacy friend declarations

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -238,7 +238,6 @@ private:
 	QColor m_vertexColor;
 	QBrush m_scaleColor;
 
-	//friend class Engine;
 	friend class AutomationEditorWindow;
 
 
@@ -294,8 +293,6 @@ private:
 	ComboBox * m_zoomingXComboBox;
 	ComboBox * m_zoomingYComboBox;
 	ComboBox * m_quantizeComboBox;
-
-	friend class Engine;
 };
 
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -332,7 +332,6 @@ private:
 	// did we start a mouseclick with shift pressed
 	bool m_startedWithShift;
 
-	friend class Engine;
 	friend class PianoRollWindow;
 
 	// qproperty fields


### PR DESCRIPTION
There was an unnecessary "friend" declaration in both the AutomationEditor and PianoRoll classes giving the Engine class access to private members. I'm guessing this may have been a remnant from some point where the gui was even more intertwined with the core. But LMMS compiles fine without these classes being friends, so I say we remove these declarations.