### PR TITLE
Temporary workaround for ZynAddSubFx name clashes

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -37,7 +37,7 @@
 #include "MemoryManager.h"
 #include "lmmsversion.h"
 
-class Engine;
+class LmmsCore;
 
 
 const QString PROJECTS_PATH = "projects/";
@@ -284,7 +284,7 @@ private:
 	settingsMap m_settings;
 
 
-	friend class Engine;
+	friend class LmmsCore;
 
 } ;
 

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -42,7 +42,19 @@ class Song;
 class Ladspa2LMMS;
 
 
-class EXPORT Engine : public QObject
+// Note: This class is called 'LmmsCore' instead of 'Engine' because of naming
+// conflicts caused by ZynAddSubFX. See https://github.com/LMMS/lmms/issues/2269
+// and https://github.com/LMMS/lmms/pull/2118 for more details.
+//
+// The workaround was to rename Lmms' Engine so that it has a different symbol
+// name in the object files, but typedef it back to 'Engine' and keep it inside
+// of Engine.h so that the rest of the codebase can be oblivious to this issue
+// (and it could be fixed without changing every single file).
+
+class LmmsCore;
+typedef LmmsCore Engine;
+
+class EXPORT LmmsCore : public QObject
 {
 	Q_OBJECT
 public:
@@ -91,11 +103,11 @@ public:
 	}
 	static void updateFramesPerTick();
 
-	static inline Engine * inst()
+	static inline LmmsCore * inst()
 	{
 		if( s_instanceOfMe == NULL )
 		{
-			s_instanceOfMe = new Engine();
+			s_instanceOfMe = new LmmsCore();
 		}
 		return s_instanceOfMe;
 	}
@@ -128,12 +140,11 @@ private:
 	static Ladspa2LMMS * s_ladspaManager;
 
 	// even though most methods are static, an instance is needed for Qt slots/signals
-	static Engine * s_instanceOfMe;
+	static LmmsCore * s_instanceOfMe;
 
 	friend class GuiApplication;
 };
 
 
-
-
 #endif
+

--- a/include/Ladspa2LMMS.h
+++ b/include/Ladspa2LMMS.h
@@ -71,7 +71,7 @@ private:
 	l_sortable_plugin_t m_analysisTools;
 	l_sortable_plugin_t m_otherPlugins;
 	
-	friend class Engine;
+	friend class LmmsCore;
 
 } ;
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -445,7 +445,7 @@ private:
 
 	bool m_metronomeActive;
 
-	friend class Engine;
+	friend class LmmsCore;
 	friend class MixerWorkerThread;
 
 } ;

--- a/include/Song.h
+++ b/include/Song.h
@@ -366,7 +366,7 @@ private:
 	VstSyncController m_vstSyncController;
 
 
-	friend class Engine;
+	friend class LmmsCore;
 	friend class SongEditor;
 	friend class mainWindow;
 	friend class ControllerRackView;

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -38,21 +38,21 @@
 
 #include "GuiApplication.h"
 
-float Engine::s_framesPerTick;
-Mixer* Engine::s_mixer = NULL;
-FxMixer * Engine::s_fxMixer = NULL;
-BBTrackContainer * Engine::s_bbTrackContainer = NULL;
-Song * Engine::s_song = NULL;
-ProjectJournal * Engine::s_projectJournal = NULL;
-Ladspa2LMMS * Engine::s_ladspaManager = NULL;
-DummyTrackContainer * Engine::s_dummyTC = NULL;
+float LmmsCore::s_framesPerTick;
+Mixer* LmmsCore::s_mixer = NULL;
+FxMixer * LmmsCore::s_fxMixer = NULL;
+BBTrackContainer * LmmsCore::s_bbTrackContainer = NULL;
+Song * LmmsCore::s_song = NULL;
+ProjectJournal * LmmsCore::s_projectJournal = NULL;
+Ladspa2LMMS * LmmsCore::s_ladspaManager = NULL;
+DummyTrackContainer * LmmsCore::s_dummyTC = NULL;
 
 
 
 
-void Engine::init( bool renderOnly )
+void LmmsCore::init( bool renderOnly )
 {
-	Engine *engine = inst();
+	LmmsCore *engine = inst();
 
 	emit engine->initProgress(tr("Generating wavetables"));
 	// generate (load from file) bandlimited wavetables
@@ -82,7 +82,7 @@ void Engine::init( bool renderOnly )
 
 
 
-void Engine::destroy()
+void LmmsCore::destroy()
 {
 	s_projectJournal->stopAllJournalling();
 	s_mixer->stopProcessing();
@@ -110,10 +110,10 @@ void Engine::destroy()
 
 
 
-void Engine::updateFramesPerTick()
+void LmmsCore::updateFramesPerTick()
 {
 	s_framesPerTick = s_mixer->processingSampleRate() * 60.0f * 4 /
 				DefaultTicksPerTact / s_song->getTempo();
 }
 
-Engine * Engine::s_instanceOfMe = NULL;
+LmmsCore * LmmsCore::s_instanceOfMe = NULL;


### PR DESCRIPTION
Once Zyn 2.5 is ready to be merged, that should solve all the issues we've been having with the conflicting LMMS Engine and Zyn Engine classnames. Until then, this is the small patch that I've been using on my system in order to work around the issue (#2049, #2053, etc). It just renames Engine as LmmsCore, so that the two classes now have different symbol names, but then it typedefs it back to Engine so that the rest of LMMS doesn't need to be modified (for the most part).

I'm sharing this in case anyone else would find such a patch useful, and to see if there's demand for something like this to be merged while we work on readying Zyn 2.5. I must emphasize that this is meant to be temporary - I would not like to see this reside in the LMMS codebase for very long, if at all. Luckily, if people think this is worth merging, it's easy to revert once @curlymorphic's Zyn branch is merged.