### PR TITLE
Check for valid pattern when focussing out pianoroll

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3344,12 +3344,14 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 
 void PianoRoll::focusOutEvent( QFocusEvent * )
 {
-	for( int i = 0; i < NumKeys; ++i )
-	{
-		m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
-		m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
+	if( hasValidPattern() ) {
+		for( int i = 0; i < NumKeys; ++i )
+		{
+			m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
+			m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
+		}
+		update();
 	}
-	update();
 }
 
 


### PR DESCRIPTION
This prevents a segmentation fault when closing an empty piano roll,
fixing issue #2050.