### PR TITLE
Refactor MidiTime implementation

### DIFF
--- a/include/MidiTime.h
+++ b/include/MidiTime.h
@@ -60,135 +60,43 @@ private:
 class EXPORT MidiTime
 {
 public:
-	MidiTime( const tact_t tact, const tick_t ticks ) :
-		m_ticks( tact * s_ticksPerTact + ticks )
-	{
-	}
+	MidiTime( const tact_t tact, const tick_t ticks );
+	MidiTime( const tick_t ticks = 0 );
+	MidiTime( const MidiTime& time );
 
-	MidiTime( const tick_t ticks = 0 ) :
-		m_ticks( ticks )
-	{
-	}
+	MidiTime toNearestTact() const;
+	MidiTime toAbsoluteTact() const;
 
-	MidiTime( const MidiTime& time ) :
-		m_ticks( time.m_ticks )
-	{
-	}
-
-	MidiTime toNearestTact() const
-	{
-		if( m_ticks % s_ticksPerTact >= s_ticksPerTact/2 )
-		{
-			return ( getTact() + 1 ) * s_ticksPerTact;
-		}
-		return getTact() * s_ticksPerTact;
-	}
-
-	MidiTime toAbsoluteTact() const
-	{
-		return getTact() * s_ticksPerTact;
-	}
-
-	MidiTime& operator=( const MidiTime& time )
-	{
-		m_ticks = time.m_ticks;
-		return *this;
-	}
-
-	MidiTime& operator+=( const MidiTime& time )
-	{
-		m_ticks += time.m_ticks;
-		return *this;
-	}
-
-	MidiTime& operator-=( const MidiTime& time )
-	{
-		m_ticks -= time.m_ticks;
-		return *this;
-	}
+	MidiTime& operator=( const MidiTime& time );
+	MidiTime& operator+=( const MidiTime& time );
+	MidiTime& operator-=( const MidiTime& time );
 
 	// return the tact, rounded down and 0-based
-	tact_t getTact() const
-	{
-		return m_ticks / s_ticksPerTact;
-	}
+	tact_t getTact() const;
+	// return the tact, rounded up and 0-based
+	tact_t nextFullTact() const;
 
-	tact_t nextFullTact() const
-	{
-		return (m_ticks + (s_ticksPerTact-1)) / s_ticksPerTact;
-	}
+	void setTicks( tick_t ticks );
+	tick_t getTicks() const;
 
-	void setTicks( tick_t ticks )
-	{
-		m_ticks = ticks;
-	}
+	operator int() const;
 
-	tick_t getTicks() const
-	{
-		return m_ticks;
-	}
-
-	operator int() const
-	{
-		return m_ticks;
-	}
-
-	tick_t ticksPerBeat( const TimeSig &sig ) const
-	{
-		return ticksPerTact(sig) / sig.numerator();
-	}
+	tick_t ticksPerBeat( const TimeSig &sig ) const;
 	// Remainder ticks after bar is removed
-	tick_t getTickWithinBar( const TimeSig &sig ) const
-	{
-		return m_ticks % ticksPerTact(sig);
-	}
+	tick_t getTickWithinBar( const TimeSig &sig ) const;
 	// Returns the beat position inside the bar, 0-based
-	tick_t getBeatWithinBar( const TimeSig &sig ) const
-	{
-		return getTickWithinBar(sig) / ticksPerBeat(sig);
-	}
+	tick_t getBeatWithinBar( const TimeSig &sig ) const;
 	// Remainder ticks after bar and beat are removed
-	tick_t getTickWithinBeat( const TimeSig &sig ) const
-	{
-		return getTickWithinBar(sig) % ticksPerBeat(sig);
-	}
+	tick_t getTickWithinBeat( const TimeSig &sig ) const;
 
 	// calculate number of frame that are needed this time
-	f_cnt_t frames( const float framesPerTick ) const
-	{
-		if( m_ticks >= 0 )
-		{
-			return static_cast<f_cnt_t>( m_ticks * framesPerTick );
-		}
-		return 0;
-	}
+	f_cnt_t frames( const float framesPerTick ) const;
 
-	static MidiTime fromFrames( const f_cnt_t frames, const float framesPerTick )
-	{
-		return MidiTime( static_cast<int>( frames / framesPerTick ) );
-	}
-
-
-	static tick_t ticksPerTact()
-	{
-		return s_ticksPerTact;
-	}
-	static tick_t ticksPerTact( const TimeSig &sig ) const
-	{
-		return DefaultTicksPerTact * sig.numerator() / sig.denominator();
-	}
-
-	static int stepsPerTact()
-	{
-		int steps = ticksPerTact() / DefaultBeatsPerTact;
-		return qMax( 1, steps );
-	}
-
-	static void setTicksPerTact( tick_t _tpt )
-	{
-		s_ticksPerTact = _tpt;
-	}
-
+	static MidiTime fromFrames( const f_cnt_t frames, const float framesPerTick );
+	static tick_t ticksPerTact();
+	static tick_t ticksPerTact( const TimeSig &sig );
+	static int stepsPerTact();
+	static void setTicksPerTact( tick_t tpt );
 
 private:
 	tick_t m_ticks;

--- a/include/MidiTime.h
+++ b/include/MidiTime.h
@@ -30,6 +30,7 @@
 #include "lmms_basics.h"
 #include "export.h"
 
+// note: 1 "Tact" = 1 Measure
 const int DefaultTicksPerTact = 192;
 const int DefaultStepsPerTact = 16;
 const int DefaultBeatsPerTact = DefaultTicksPerTact / DefaultStepsPerTact;
@@ -85,6 +86,7 @@ public:
 		return *this;
 	}
 
+	// return the tact, rounded down and 0-based
 	tact_t getTact() const
 	{
 		return m_ticks / s_ticksPerTact;
@@ -92,11 +94,7 @@ public:
 
 	tact_t nextFullTact() const
 	{
-		if( m_ticks % s_ticksPerTact == 0 )
-		{
-			return m_ticks / s_ticksPerTact;
-		}
-		return m_ticks / s_ticksPerTact + 1;
+		return (m_ticks + (s_ticksPerTact-1)) / s_ticksPerTact;
 	}
 
 	void setTicks( tick_t ticks )

--- a/include/Song.h
+++ b/include/Song.h
@@ -136,10 +136,6 @@ public:
 	{
 		return currentFrame();
 	}
-	inline bool isTempoAutomated()
-	{
-		return m_tempoModel.isAutomated();
-	}
 	inline bool isPaused() const
 	{
 		return m_paused;

--- a/include/Song.h
+++ b/include/Song.h
@@ -186,6 +186,10 @@ public:
 	{
 		return m_playPos[pm];
 	}
+	inline const PlayPos & getPlayPos( PlayModes pm ) const
+	{
+		return m_playPos[pm];
+	}
 
 	void updateLength();
 	tact_t length() const

--- a/include/Song.h
+++ b/include/Song.h
@@ -111,22 +111,18 @@ public:
 
 	inline int ticksPerTact() const
 	{
-		return DefaultTicksPerTact *
-				m_timeSigModel.getNumerator() /
-					 m_timeSigModel.getDenominator();
+		return MidiTime::ticksPerTact(m_timeSigModel);
 	}
 
 	// Returns the beat position inside the bar, 0-based
 	inline int getBeat() const
 	{
-		return ( currentTick() - currentTact() * ticksPerTact() ) /
-			( ticksPerTact() / m_timeSigModel.getNumerator() );
+		return getPlayPos().getBeatWithinBar(m_timeSigModel);
 	}
 	// the remainder after bar and beat are removed
 	inline int getBeatTicks() const
 	{
-		return 	( currentTick() - currentTact() * ticksPerTact() ) %
-			( ticksPerTact() / m_timeSigModel.getNumerator() );
+		return getPlayPos().getTickWithinBeat(m_timeSigModel);
 	}
 	inline int getTicks() const
 	{
@@ -185,6 +181,10 @@ public:
 	inline const PlayPos & getPlayPos( PlayModes pm ) const
 	{
 		return m_playPos[pm];
+	}
+	inline const PlayPos & getPlayPos() const
+	{
+		return getPlayPos(m_playMode);
 	}
 
 	void updateLength();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -82,6 +82,7 @@ set(LMMS_SRCS
 	core/midi/MidiController.cpp
 	core/midi/MidiOss.cpp
 	core/midi/MidiPort.cpp
+	core/midi/MidiTime.cpp
 	core/midi/MidiWinMM.cpp
 
 	PARENT_SCOPE

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -163,7 +163,7 @@ void ProjectRenderer::run()
     //skip first empty buffer
     Engine::mixer()->nextBuffer();
 
-	Song::PlayPos & pp = Engine::getSong()->getPlayPos(
+	const Song::PlayPos & pp = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );
 	m_progress = 0;
 	const int sl = ( Engine::getSong()->length() + 1 ) * 192;

--- a/src/core/midi/MidiTime.cpp
+++ b/src/core/midi/MidiTime.cpp
@@ -39,11 +39,162 @@ TimeSig::TimeSig( const MeterModel &model ) :
 {
 }
 
+
 int TimeSig::numerator() const
 {
 	return m_num;
 }
+
 int TimeSig::denominator() const
 {
 	return m_denom;
+}
+
+
+
+
+MidiTime::MidiTime( const tact_t tact, const tick_t ticks ) :
+	m_ticks( tact * s_ticksPerTact + ticks )
+{
+}
+
+MidiTime::MidiTime( const tick_t ticks ) :
+	m_ticks( ticks )
+{
+}
+
+MidiTime::MidiTime( const MidiTime& time ) :
+	m_ticks( time.m_ticks )
+{
+}
+
+
+MidiTime MidiTime::toNearestTact() const
+{
+	if( m_ticks % s_ticksPerTact >= s_ticksPerTact/2 )
+	{
+		return ( getTact() + 1 ) * s_ticksPerTact;
+	}
+	return getTact() * s_ticksPerTact;
+}
+
+
+MidiTime MidiTime::toAbsoluteTact() const
+{
+	return getTact() * s_ticksPerTact;
+}
+
+
+MidiTime& MidiTime::operator=( const MidiTime& time )
+{
+	m_ticks = time.m_ticks;
+	return *this;
+}
+
+
+MidiTime& MidiTime::operator+=( const MidiTime& time )
+{
+	m_ticks += time.m_ticks;
+	return *this;
+}
+
+
+MidiTime& MidiTime::operator-=( const MidiTime& time )
+{
+	m_ticks -= time.m_ticks;
+	return *this;
+}
+
+
+tact_t MidiTime::getTact() const
+{
+	return m_ticks / s_ticksPerTact;
+}
+
+
+tact_t MidiTime::nextFullTact() const
+{
+	return (m_ticks + (s_ticksPerTact-1)) / s_ticksPerTact;
+}
+
+
+void MidiTime::setTicks( tick_t ticks )
+{
+	m_ticks = ticks;
+}
+
+
+tick_t MidiTime::getTicks() const
+{
+	return m_ticks;
+}
+
+
+MidiTime::operator int() const
+{
+	return m_ticks;
+}
+
+
+tick_t MidiTime::ticksPerBeat( const TimeSig &sig ) const
+{
+	// (number of ticks per bar) divided by (number of beats per bar)
+	return ticksPerTact(sig) / sig.numerator();
+}
+
+
+tick_t MidiTime::getTickWithinBar( const TimeSig &sig ) const
+{
+	return m_ticks % ticksPerTact(sig);
+}
+
+tick_t MidiTime::getBeatWithinBar( const TimeSig &sig ) const
+{
+	return getTickWithinBar(sig) / ticksPerBeat(sig);
+}
+
+tick_t MidiTime::getTickWithinBeat( const TimeSig &sig ) const
+{
+	return getTickWithinBar(sig) % ticksPerBeat(sig);
+}
+
+
+f_cnt_t MidiTime::frames( const float framesPerTick ) const
+{
+	if( m_ticks >= 0 )
+	{
+		return static_cast<f_cnt_t>( m_ticks * framesPerTick );
+	}
+	return 0;
+}
+
+
+MidiTime MidiTime::fromFrames( const f_cnt_t frames, const float framesPerTick )
+{
+	return MidiTime( static_cast<int>( frames / framesPerTick ) );
+}
+
+
+tick_t MidiTime::ticksPerTact()
+{
+	return s_ticksPerTact;
+}
+
+
+tick_t MidiTime::ticksPerTact( const TimeSig &sig )
+{
+	return DefaultTicksPerTact * sig.numerator() / sig.denominator();
+}
+
+
+int MidiTime::stepsPerTact()
+{
+	int steps = ticksPerTact() / DefaultBeatsPerTact;
+	return qMax( 1, steps );
+}
+
+
+void MidiTime::setTicksPerTact( tick_t tpt )
+{
+	s_ticksPerTact = tpt;
 }

--- a/src/core/midi/MidiTime.cpp
+++ b/src/core/midi/MidiTime.cpp
@@ -1,0 +1,49 @@
+/*
+ * MidiTime.cpp - Class that encapsulates the position of a note/event in terms of
+ *   its bar, beat and tick.
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "MidiTime.h"
+
+#include "MeterModel.h"
+
+TimeSig::TimeSig( int num, int denom ) :
+	m_num(num),
+	m_denom(denom)
+{
+}
+
+TimeSig::TimeSig( const MeterModel &model ) :
+	m_num(model.getNumerator()),
+	m_denom(model.getDenominator())
+{
+}
+
+int TimeSig::numerator() const
+{
+	return m_num;
+}
+int TimeSig::denominator() const
+{
+	return m_denom;
+}


### PR DESCRIPTION
I broke this down into some smaller commits so that it might be easier to follow.

Behaviorally, nothing has really changed. Structurally, I tried to move most of the logic that dealt with manipulating midi time values out of the Song class and into the MidiTime class. Then I separated MidiTime.h into a header and source file, rather than having its implementation in the header as before.