### PR TITLE
Enforce tighter permissions in FxMixer

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -211,9 +211,6 @@ private:
 
 	int m_lastSoloed;
 
-	friend class MixerWorkerThread;
-	friend class FxMixerView;
-
 } ;
 
 

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -380,6 +380,9 @@ void FxMixer::moveChannelLeft( int index )
 			}
 		}
 	}
+
+	// Swap positions in array
+	qSwap(m_fxChannels[index], m_fxChannels[index - 1]);
 }
 
 

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -455,11 +455,8 @@ void FxMixerView::moveChannelLeft(int index, int focusIndex)
 	m->moveChannelLeft( index );
 
 	// Update widgets models
-	m_fxChannelViews[index]->setChannelIndex( index - 1 );
-	m_fxChannelViews[index - 1]->setChannelIndex( index );
-
-	// Swap positions in array
-	qSwap(m->m_fxChannels[index], m->m_fxChannels[index - 1]);
+	m_fxChannelViews[index]->setChannelIndex( index );
+	m_fxChannelViews[index - 1]->setChannelIndex( index - 1 );
 
 	// Focus on new position
 	setCurrentFxLine( focusIndex );
@@ -561,28 +558,28 @@ void FxMixerView::updateFaders()
 	FxMixer * m = Engine::fxMixer();
 
 	// apply master gain
-	m->m_fxChannels[0]->m_peakLeft *= Engine::mixer()->masterGain();
-	m->m_fxChannels[0]->m_peakRight *= Engine::mixer()->masterGain();
+	m->effectChannel(0)->m_peakLeft *= Engine::mixer()->masterGain();
+	m->effectChannel(0)->m_peakRight *= Engine::mixer()->masterGain();
 
 	for( int i = 0; i < m_fxChannelViews.size(); ++i )
 	{
 		const float opl = m_fxChannelViews[i]->m_fader->getPeak_L();
 		const float opr = m_fxChannelViews[i]->m_fader->getPeak_R();
 		const float fall_off = 1.2;
-		if( m->m_fxChannels[i]->m_peakLeft > opl )
+		if( m->effectChannel(i)->m_peakLeft > opl )
 		{
-			m_fxChannelViews[i]->m_fader->setPeak_L( m->m_fxChannels[i]->m_peakLeft );
-			m->m_fxChannels[i]->m_peakLeft = 0;
+			m_fxChannelViews[i]->m_fader->setPeak_L( m->effectChannel(i)->m_peakLeft );
+			m->effectChannel(i)->m_peakLeft = 0;
 		}
 		else
 		{
 			m_fxChannelViews[i]->m_fader->setPeak_L( opl/fall_off );
 		}
 
-		if( m->m_fxChannels[i]->m_peakRight > opr )
+		if( m->effectChannel(i)->m_peakRight > opr )
 		{
-			m_fxChannelViews[i]->m_fader->setPeak_R( m->m_fxChannels[i]->m_peakRight );
-			m->m_fxChannels[i]->m_peakRight = 0;
+			m_fxChannelViews[i]->m_fader->setPeak_R( m->effectChannel(i)->m_peakRight );
+			m->effectChannel(i)->m_peakRight = 0;
 		}
 		else
 		{


### PR DESCRIPTION
This PR removes FxMixer friendship privileges from FxMixerView and MixerWorkerThread, so that they now have the same access rights as all the other classes.

It's a relatively benign commit, and tighter permissions make things easier to deal with in the future. Nothing had to be done to MixerWorkerThread (it didn't make use of its special permissions). On the FxMixerView side, I just replaced all uses of `FxMixer::m_fxChannels[i]` with `FxMixer::effectChannel(i)`, which behaves identically. 

The only notable thing is that `qSwap(m->m_fxChannels[index], m->m_fxChannels[index - 1])` was moved out of `FxMixerView::moveChannelLeft()` and into `FxMixer::moveChannelLeft()`. This seems like the more natural place for it anyway, since otherwise FxMixer::moveChannelLeft isn't fully functional (it's only called by FxMixerView::moveChannelLeft, by the way, so this doesn't affect any other code).

By moving the swap statement to before the following block of code in FxMixerView::moveChannelLeft():
```c++
 	m_fxChannelViews[index]->setChannelIndex( index - 1 );
 	m_fxChannelViews[index - 1]->setChannelIndex( index );
```
the statements had to be modified to reflect that `index-1` and `index` have swapped meanings. For reference, the setChannelIndex function can be found [here](https://github.com/LMMS/lmms/blob/master/src/gui/FxMixerView.cpp#L310-318) (it just updates the UI models to point to the right data).

I've verified that the behavior of this changed code is still correct on my machine.