### PR TITLE
Update knob after changing response 'lin/log'

### DIFF
--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -497,6 +497,7 @@ void Knob::contextMenuEvent( QContextMenuEvent * )
 void Knob::toggleScale()
 {
 	model()->setScaleLogarithmic( ! model()->isScaleLogarithmic() );
+	update();
 }
 
 


### PR DESCRIPTION
Looks a bit crude when it doesn't update and instead jumps to it's new position first when you move it next time.