### PR TITLE
Export percentage calculation now takes into account loop markers when necessary

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -25,6 +25,8 @@
 #ifndef SONG_H
 #define SONG_H
 
+#include <utility>
+
 #include <QtCore/QSharedMemory>
 #include <QtCore/QVector>
 
@@ -163,6 +165,7 @@ public:
 	}
 
 	bool isExportDone() const;
+	std::pair<MidiTime, MidiTime> getExportEndpoints() const;
 
 	inline void setRenderBetweenMarkers( bool renderBetweenMarkers )
 	{

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -163,17 +163,20 @@ void ProjectRenderer::run()
     //skip first empty buffer
     Engine::mixer()->nextBuffer();
 
-	const Song::PlayPos & pp = Engine::getSong()->getPlayPos(
+	const Song::PlayPos & exportPos = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );
 	m_progress = 0;
-	const int sl = ( Engine::getSong()->length() + 1 ) * 192;
+	std::pair<MidiTime, MidiTime> exportEndpoints = Engine::getSong()->getExportEndpoints();
+	tick_t startTick = exportEndpoints.first.getTicks();
+	tick_t lengthTicks = exportEndpoints.second.getTicks() - startTick;
 
+	// Continually track and emit progress percentage to listeners
 	while( Engine::getSong()->isExportDone() == false &&
 				Engine::getSong()->isExporting() == true
 							&& !m_abort )
 	{
 		m_fileDev->processNextBuffer();
-		const int nprog = pp * 100 / sl;
+		const int nprog = lengthTicks == 0 ? 100 : (exportPos.getTicks()-startTick) * 100 / lengthTicks;
 		if( m_progress != nprog )
 		{
 			m_progress = nprog;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -416,7 +416,7 @@ bool Song::isExportDone() const
 				m_playPos[Mode_PlaySong].m_timeLine->loopEnd().getTicks();
 	}
 
-	if( m_exportLoop)
+	if( m_exportLoop )
 	{
 		return m_exporting == true &&
 			m_playPos[Mode_PlaySong].getTicks() >= 
@@ -427,6 +427,26 @@ bool Song::isExportDone() const
 		return m_exporting == true &&
 			m_playPos[Mode_PlaySong].getTicks() >= 
 				( length() + 1 ) * ticksPerTact();
+	}
+}
+
+std::pair<MidiTime, MidiTime> Song::getExportEndpoints() const
+{
+	if ( m_renderBetweenMarkers )
+	{
+		return std::pair<MidiTime, MidiTime>(
+			m_playPos[Mode_PlaySong].m_timeLine->loopBegin(),
+			m_playPos[Mode_PlaySong].m_timeLine->loopEnd()
+		);
+	}
+	else if ( m_exportLoop )
+	{
+		return std::pair<MidiTime, MidiTime>( MidiTime(0, 0), MidiTime(m_length, 0) );
+	}
+	else
+	{
+		// if not exporting as a loop, we leave one bar of padding at the end of the song to accomodate reverb, etc.
+		return std::pair<MidiTime, MidiTime>( MidiTime(0, 0), MidiTime(m_length+1, 0) );
 	}
 }
 


### PR DESCRIPTION
This is a fix for #2138. 

I tested exporting with and without using loop endpoints and it behaves correctly under both conditions, including consideration of the extra bar of padding that gets rendered if exporting the full song when not under loop-mode.