### PR TITLE
[WIP] Open last active project. Fixes #503

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -95,6 +95,7 @@ private slots:
 	void toggleDisplaydBV( bool _enabled );
 	void toggleMMPZ( bool _enabled );
 	void toggleDisableBackup( bool _enabled );
+	void toggleOpenLastProject( bool _enabled );
 	void toggleHQAudioDev( bool _enabled );
 
 	void openWorkingDir();
@@ -133,6 +134,7 @@ private:
 	bool m_displaydBV;
 	bool m_MMPZ;
 	bool m_disableBackup;
+	bool m_openLastProject;
 	bool m_hqAudioDev;
 	QString m_lang;
 	QStringList m_languages;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -67,6 +67,7 @@
 #include "ProjectRenderer.h"
 #include "DataFile.h"
 #include "Song.h"
+#include "SetupDialog.h"
 
 static inline QString baseName( const QString & _file )
 {
@@ -494,7 +495,30 @@ int main( int argc, char * * argv )
 		}
 		else
 		{
-			Engine::getSong()->createNewProject();
+
+		// If enabled, open last project if there is one. Else, create
+		// a new one.
+		if( ConfigManager::inst()->
+				value( "app", "openlastproject" ).toInt() &&
+		!ConfigManager::inst()->recentlyOpenedProjects().isEmpty() )
+		{
+			QString f = ConfigManager::inst()->
+						recentlyOpenedProjects().first();
+			QFileInfo recentFile( f );
+
+			if ( recentFile.exists() )
+			{
+				Engine::getSong()->loadProject( f );
+			}
+			else
+			{
+				Engine::getSong()->createNewProject();
+			}
+		}
+		else
+		{
+		Engine::getSong()->createNewProject();
+		}
 
 			// [Settel] workaround: showMaximized() doesn't work with
 			// FVWM2 unless the window is already visible -> show() first

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -97,6 +97,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_MMPZ( !ConfigManager::inst()->value( "app", "nommpz" ).toInt() ),
 	m_disableBackup( !ConfigManager::inst()->value( "app",
 							"disablebackup" ).toInt() ),
+	m_openLastProject( ConfigManager::inst()->value( "app",
+							"openlastproject" ).toInt() ),
 	m_hqAudioDev( ConfigManager::inst()->value( "mixer",
 							"hqaudio" ).toInt() ),
 	m_lang( ConfigManager::inst()->value( "app",
@@ -315,6 +317,15 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	disableBackup->setChecked( m_disableBackup );
 	connect( disableBackup, SIGNAL( toggled( bool ) ),
 				this, SLOT( toggleDisableBackup( bool ) ) );
+
+	LedCheckBox * openLastProject = new LedCheckBox(
+				tr( "Reopen last project on start" ),
+								misc_tw );
+	labelNumber++;
+	openLastProject->move( XDelta, YDelta*labelNumber );
+	openLastProject->setChecked( m_openLastProject );
+	connect( openLastProject, SIGNAL( toggled( bool ) ),
+				this, SLOT( toggleOpenLastProject( bool ) ) );
 
 	misc_tw->setFixedHeight( YDelta*labelNumber + HeaderSize );
 
@@ -953,6 +964,8 @@ void SetupDialog::accept()
 						QString::number( !m_MMPZ ) );
 	ConfigManager::inst()->setValue( "app", "disablebackup",
 					QString::number( !m_disableBackup ) );
+	ConfigManager::inst()->setValue( "app", "openlastproject",
+					QString::number( m_openLastProject ) );
 	ConfigManager::inst()->setValue( "mixer", "hqaudio",
 					QString::number( m_hqAudioDev ) );
 	ConfigManager::inst()->setValue( "ui", "smoothscroll",
@@ -1111,6 +1124,14 @@ void SetupDialog::toggleMMPZ( bool _enabled )
 void SetupDialog::toggleDisableBackup( bool _enabled )
 {
 	m_disableBackup = _enabled;
+}
+
+
+
+
+void SetupDialog::toggleOpenLastProject( bool _enabled )
+{
+	m_openLastProject = _enabled;
 }
 
 


### PR DESCRIPTION
Issue #503, #1694

This should take care of issue #503 and implement automatic open of the last project. It has an option in 'Settings' to switch it off but is on by default.