### PR TITLE
Map missing email to @tresf and 'support@lmms.io'

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,6 +13,7 @@ Vesa <contact.diizy@nbl.fi> <vesa@isokone.(none)>
 Vesa <contact.diizy@nbl.fi> <diizy@users.noreply.github.com>
 Tres Finocchiaro <tres.finocchiaro@gmail.com>
 Tres Finocchiaro <tres.finocchiaro@gmail.com> <tres@ubuntu-1204.(none)>
+Tres Finocchiaro <tres.finocchiaro@gmail.com> <ubuntu@ubuntu-1204.(none)>
 Tres Finocchiaro <tres.finocchiaro@gmail.com> <tresf@github.com>
 Rüdiger Ranft <rudi@qzzq.de> <_rdi_@web.de>
 Spekular <Spekularr@gmail.com> <Spekular@users.noreply.github.com>
@@ -21,3 +22,4 @@ mikobuntu <chrissy.mc.1@hotmail.co.uk> <mikobuntu@mikobuntu-Aspire-5332.(none)>
 Jonathan Aquilina <eagles051387@gmail.com>
 midi-pascal <midi-pascal@videotron.ca>
 midi-pascal <midi-pascal@videotron.ca> <pascal@TDE.(none)>
+anonymous <support@lmms.io> Locale updater <>


### PR DESCRIPTION
Fixes the rest of #2137.

This gives the `<ubuntu@ubuntu-1204.(none)>` email address to @tresf and maps `Locale editor <>` to ~~`anonymous < >`.~~ `support@lmms.io` (A valid email address managed primarily by @tresf) 

~~Note: the anonymous user's email address is **not** an empty string - it's a space. The statement seemed to be ignored when using an empty string.~~