### PR TITLE
Fix deadlock in SampleBuffer

### DIFF
--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -218,8 +218,8 @@ public:
 		return m_data;
 	}
 
-    QString openAudioFile() const;
-    QString openAndSetAudioFile();
+	QString openAudioFile() const;
+	QString openAndSetAudioFile();
 	QString openAndSetWaveformFile();
 
 	QString & toBase64( QString & _dst ) const;
@@ -268,8 +268,8 @@ public slots:
 private:
 	void update( bool _keep_settings = false );
 
-    void convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, int _channels);
-    void directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _channels);
+	void convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, int _channels);
+	void directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _channels);
 
 	f_cnt_t decodeSampleSF( const char * _f, sample_t * & _buf,
 						ch_cnt_t & _channels,

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -29,6 +29,7 @@
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QObject>
 #include <QtCore/QRect>
+#include <QtCore/QWriteLocker>
 
 #include <samplerate.h>
 
@@ -151,26 +152,23 @@ public:
 
 	void setLoopStartFrame( f_cnt_t _start )
 	{
-		m_varLock.lockForWrite();
+		QWriteLocker writeLocker(&m_varLock);
 		m_loopStartFrame = _start;
-		m_varLock.unlock();
 	}
 
 	void setLoopEndFrame( f_cnt_t _end )
 	{
-		m_varLock.lockForWrite();
+		QWriteLocker writeLocker(&m_varLock);
 		m_loopEndFrame = _end;
-		m_varLock.unlock();
 	}
 
 	void setAllPointFrames( f_cnt_t _start, f_cnt_t _end, f_cnt_t _loopstart, f_cnt_t _loopend )
 	{
-		m_varLock.lockForWrite();
+		QWriteLocker writeLocker(&m_varLock);
 		m_startFrame = _start;
 		m_endFrame = _end;
 		m_loopStartFrame = _loopstart;
 		m_loopEndFrame = _loopend;
-		m_varLock.unlock();
 	}
 
 	inline f_cnt_t frames() const
@@ -205,16 +203,14 @@ public:
 
 	inline void setFrequency( float _freq )
 	{
-		m_varLock.lockForWrite();
+		QWriteLocker writeLocker(&m_varLock);
 		m_frequency = _freq;
-		m_varLock.unlock();
 	}
 
 	inline void setSampleRate( sample_rate_t _rate )
 	{
-		m_varLock.lockForWrite();
+		QWriteLocker writeLocker(&m_varLock);
 		m_sampleRate = _rate;
-		m_varLock.unlock();
 	}
 
 	inline const sampleFrame * data() const

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -210,33 +210,33 @@ void SampleBuffer::update( bool _keep_settings )
 		{
 
 #ifdef LMMS_HAVE_OGGVORBIS
-		// workaround for a bug in libsndfile or our libsndfile decoder
-		// causing some OGG files to be distorted -> try with OGG Vorbis
-		// decoder first if filename extension matches "ogg"
-		if( m_frames == 0 && fileInfo.suffix() == "ogg" )
-		{
-			m_frames = decodeSampleOGGVorbis( f, buf, channels, samplerate );
-		}
+			// workaround for a bug in libsndfile or our libsndfile decoder
+			// causing some OGG files to be distorted -> try with OGG Vorbis
+			// decoder first if filename extension matches "ogg"
+			if( m_frames == 0 && fileInfo.suffix() == "ogg" )
+			{
+				m_frames = decodeSampleOGGVorbis( f, buf, channels, samplerate );
+			}
 #endif
-		if( m_frames == 0 )
-		{
-			m_frames = decodeSampleSF( f, fbuf, channels,
-								samplerate );
-		}
+			if( m_frames == 0 )
+			{
+				m_frames = decodeSampleSF( f, fbuf, channels,
+									samplerate );
+			}
 #ifdef LMMS_HAVE_OGGVORBIS
-		if( m_frames == 0 )
-		{
-			m_frames = decodeSampleOGGVorbis( f, buf, channels,
-								samplerate );
-		}
+			if( m_frames == 0 )
+			{
+				m_frames = decodeSampleOGGVorbis( f, buf, channels,
+									samplerate );
+			}
 #endif
-		if( m_frames == 0 )
-		{
-			m_frames = decodeSampleDS( f, buf, channels,
-								samplerate );
-		}
+			if( m_frames == 0 )
+			{
+				m_frames = decodeSampleDS( f, buf, channels,
+									samplerate );
+			}
 
-		delete[] f;
+			delete[] f;
 
 			if ( m_frames == 0 )  // if still no frames, bail
 			{
@@ -254,9 +254,6 @@ void SampleBuffer::update( bool _keep_settings )
 			}
 
 		}
-
-
-
 	}
 	else
 	{
@@ -280,81 +277,73 @@ void SampleBuffer::update( bool _keep_settings )
 
 void SampleBuffer::convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, int _channels)
 {
-			// following code transforms int-samples into
-			// float-samples and does amplifying & reversing
-			const float fac = 1 / OUTPUT_SAMPLE_MULTIPLIER;
-			m_data = MM_ALLOC( sampleFrame, _frames );
-			const int ch = ( _channels > 1 ) ? 1 : 0;
+	// following code transforms int-samples into
+	// float-samples and does amplifying & reversing
+	const float fac = 1 / OUTPUT_SAMPLE_MULTIPLIER;
+	m_data = MM_ALLOC( sampleFrame, _frames );
+	const int ch = ( _channels > 1 ) ? 1 : 0;
 
-			// if reversing is on, we also reverse when
-			// scaling
-			if( m_reversed )
-			{
-				int idx = ( _frames - 1 ) * _channels;
-				for( f_cnt_t frame = 0; frame < _frames;
-								++frame )
-				{
-					m_data[frame][0] = _ibuf[idx+0] * fac;
-					m_data[frame][1] = _ibuf[idx+ch] * fac;
-					idx -= _channels;
-				}
-			}
-			else
-			{
-				int idx = 0;
-				for( f_cnt_t frame = 0; frame < _frames;
-								++frame )
-				{
-					m_data[frame][0] = _ibuf[idx+0] * fac;
-					m_data[frame][1] = _ibuf[idx+ch] * fac;
-					idx += _channels;
-				}
-			}
+	// if reversing is on, we also reverse when
+	// scaling
+	if( m_reversed )
+	{
+		int idx = ( _frames - 1 ) * _channels;
+		for( f_cnt_t frame = 0; frame < _frames;
+						++frame )
+		{
+			m_data[frame][0] = _ibuf[idx+0] * fac;
+			m_data[frame][1] = _ibuf[idx+ch] * fac;
+			idx -= _channels;
+		}
+	}
+	else
+	{
+		int idx = 0;
+		for( f_cnt_t frame = 0; frame < _frames;
+						++frame )
+		{
+			m_data[frame][0] = _ibuf[idx+0] * fac;
+			m_data[frame][1] = _ibuf[idx+ch] * fac;
+			idx += _channels;
+		}
+	}
 
-			delete[] _ibuf;
-
-
-
-
-
+	delete[] _ibuf;
 }
 
 void SampleBuffer::directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _channels)
 
 {
 
-		m_data = MM_ALLOC( sampleFrame, _frames );
-		const int ch = ( _channels > 1 ) ? 1 : 0;
+	m_data = MM_ALLOC( sampleFrame, _frames );
+	const int ch = ( _channels > 1 ) ? 1 : 0;
 
-			// if reversing is on, we also reverse when
-			// scaling
-			if( m_reversed )
-			{
-				int idx = ( _frames - 1 ) * _channels;
-				for( f_cnt_t frame = 0; frame < _frames;
-								++frame )
-				{
-					m_data[frame][0] = _fbuf[idx+0];
-					m_data[frame][1] = _fbuf[idx+ch];
-					idx -= _channels;
-				}
-			}
-			else
-			{
-				int idx = 0;
-				for( f_cnt_t frame = 0; frame < _frames;
-								++frame )
-				{
-					m_data[frame][0] = _fbuf[idx+0];
-					m_data[frame][1] = _fbuf[idx+ch];
-					idx += _channels;
-				}
-			}
+	// if reversing is on, we also reverse when
+	// scaling
+	if( m_reversed )
+	{
+		int idx = ( _frames - 1 ) * _channels;
+		for( f_cnt_t frame = 0; frame < _frames;
+						++frame )
+		{
+			m_data[frame][0] = _fbuf[idx+0];
+			m_data[frame][1] = _fbuf[idx+ch];
+			idx -= _channels;
+		}
+	}
+	else
+	{
+		int idx = 0;
+		for( f_cnt_t frame = 0; frame < _frames;
+						++frame )
+		{
+			m_data[frame][0] = _fbuf[idx+0];
+			m_data[frame][1] = _fbuf[idx+ch];
+			idx += _channels;
+		}
+	}
 
-			delete[] _fbuf;
-
-
-
+	delete[] _fbuf;
 }
 
 
@@ -421,12 +410,12 @@ f_cnt_t SampleBuffer::decodeSampleSF( const char * _f,
 				"sample %s: %s", _f, sf_strerror( NULL ) );
 #endif
 	}
-    //write down either directly or convert i->f depending on file type
+	//write down either directly or convert i->f depending on file type
 
-    if ( frames > 0 && _buf != NULL )
-    {
-        directFloatWrite ( _buf, frames, _channels);
-    }
+	if ( frames > 0 && _buf != NULL )
+	{
+		directFloatWrite ( _buf, frames, _channels);
+	}
 
 	return frames;
 }
@@ -795,7 +784,9 @@ sampleFrame * SampleBuffer::getSampleFragment( f_cnt_t _index,
 	else
 	{
 		if( ! *_backwards && _index + _frames < _loopend )
-		return m_data + _index;
+		{
+			return m_data + _index;
+		}
 	}
 
 	*_tmp = MM_ALLOC( sampleFrame, _frames );


### PR DESCRIPTION
This fixes a possible deadlock scenario in `SampleBuffer::play()` caused by locking a lock and failing to unlock it before returning. 

In fixing this, I've opted to apply the much safer [RAII-style](http://www.cs.wustl.edu/~schmidt/PDF/ScopedLocking.pdf) of locking through the use of [QReadLocker](http://doc.qt.io/qt-4.8/qreadlocker.html) and [QWriteLocker](http://doc.qt.io/qt-4.8/qwritelocker.html) in places that previously manipulated the lock manually (No need to read the `RAII-style` link if you're already familiar with the concept of scoped locks). This will help to prevent errors like this from arising in the future.

While I was at it, I also applied some trivial formatting fixes (i.e. tabbing fixes).