### PR TITLE
Initialize all fields of EqFilter upon construction

### DIFF
--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -38,7 +38,12 @@
 class EqFilter : public StereoBiQuad
 {
 public:
-	EqFilter()
+	EqFilter() : 
+		m_sampleRate(0),
+		m_freq(0),
+		m_res(0),
+		m_gain(0),
+		m_bw(0)
 	{
 
 	}

--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -38,7 +38,7 @@
 class EqFilter : public StereoBiQuad
 {
 public:
-	EqFilter() : 
+	EqFilter() :
 		m_sampleRate(0),
 		m_freq(0),
 		m_res(0),
@@ -99,29 +99,18 @@ public:
 
 	virtual inline void setParameters( float sampleRate, float freq, float res, float gain )
 	{
-		bool hasChanged = false;
-		if( sampleRate != m_sampleRate )
+		bool hasChanged = ( sampleRate != m_sampleRate ||
+		                    freq != m_freq ||
+		                    res != m_res ||
+		                    gain != m_gain );
+		if ( hasChanged )
 		{
 			m_sampleRate = sampleRate;
-			hasChanged = true;
-		}
-		if ( freq != m_freq )
-		{
 			m_freq = freq;
-			hasChanged = true;
-		}
-		if ( res != m_res )
-		{
 			m_res = res;
-			hasChanged = true;
-		}
-		if ( gain != m_gain )
-		{
 			m_gain = gain;
-			hasChanged = true;
+			calcCoefficents();
 		}
-
-		if ( hasChanged ) { calcCoefficents(); }
 	}
 
 


### PR DESCRIPTION
This fixes a warning by valgrind in which "conditional jumps depend on uninitialized values" when entering the `setParameters` function. Additionally, it simplifies the code in said function.