### PR TITLE
Recent file menu fixes

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -197,7 +197,7 @@ void ConfigManager::addRecentlyOpenedProject( const QString & _file )
 	if( !_file.endsWith( ".mpt", Qt::CaseInsensitive ) ) 
 	{
 		m_recentlyOpenedProjects.removeAll( _file );
-		if( m_recentlyOpenedProjects.size() > 15 )
+		if( m_recentlyOpenedProjects.size() > 30 )
 		{
 			m_recentlyOpenedProjects.removeLast();
 		}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -830,10 +830,23 @@ void MainWindow::updateRecentlyOpenedProjectsMenu()
 {
 	m_recentlyOpenedProjectsMenu->clear();
 	QStringList rup = ConfigManager::inst()->recentlyOpenedProjects();
+
+//	The file history goes 30 deep but we only show the 15
+//	most recent ones that we can open.
+	int shownInMenu = 0;
 	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
 	{
-		m_recentlyOpenedProjectsMenu->addAction(
-				embed::getIconPixmap( "project_file" ), *it );
+		QFileInfo recentFile( *it );
+		if ( recentFile.exists() )
+		{
+			m_recentlyOpenedProjectsMenu->addAction(
+					embed::getIconPixmap( "project_file" ), *it );
+			shownInMenu++;
+			if( shownInMenu >= 15 )
+			{
+				return;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
In Issue https://github.com/LMMS/lmms/pull/2140 I implement automatic opening of most recent file. Here are some suggested changes for the 'Recently Opened Projects" menu in the mainWindow.

Issues.
 - Currently when you delete/move/rename a project it will still show as a recent project. But when you try to open it LMMS can no longer find it and will return an empty project with no tracks but carrying the name of the project that can't be found. I don't think this is intended or feels like a good behaviour so I've added a check to assure that the project exists.
 - When you delete a bunch of projects, as one does from time to time, suddenly the 'Recently Opened Projects" menu can look a bit barren. I've increased the number of projects remembered and introduced a counter so now it will fill up with older projects in the menu when you delete anything up to 15 projects.

I've pondered an infobox about 'projects that can't be found and not shown in the menu' but I think it's a bit overdoing it. The missing projects are still in the lmmsrc.xml and will sort of 'bubble' out of the history.