### PR TITLE
Recover file work over

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -81,6 +81,29 @@ public:
 	///
 	bool mayChangeProject(bool stopPlayback);
 
+	void autoSaveTimerStart()
+	{
+		m_autoSaveTimer.start( 1000 * 60 );  // 1 minute
+	}
+
+	enum SessionState
+	{
+		Normal,
+		Recover,
+		Limited,
+	};
+
+	void setSession( SessionState session )
+	{
+		m_session = session;
+	}
+
+	SessionState getSession()
+	{
+		return m_session;
+	}
+
+	void sessionCleanup();
 
 	void clearKeyModifiers();
 
@@ -131,6 +154,8 @@ public slots:
 	void undo();
 	void redo();
 
+	void autoSave();
+	void runAutoSave();
 
 protected:
 	virtual void closeEvent( QCloseEvent * _ce );
@@ -149,7 +174,6 @@ private:
 
 	void toggleWindow( QWidget *window, bool forceShow = false );
 	void refocus();
-
 
 	QMdiArea * m_workspace;
 
@@ -187,6 +211,8 @@ private:
 
 	ToolButton * m_metronomeToggle;
 
+	SessionState m_session;
+
 private slots:
 	void browseHelp();
 	void fillTemplatesMenu();
@@ -197,8 +223,6 @@ private slots:
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
 
-
-	void autoSave();
 
 signals:
 	void periodicUpdate();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -28,6 +28,7 @@
 #include <QCloseEvent>
 #include <QDesktopServices>
 #include <QDomElement>
+#include <QFileInfo>
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QMenuBar>
@@ -79,7 +80,8 @@ MainWindow::MainWindow() :
 	m_toolsMenu( NULL ),
 	m_autoSaveTimer( this ),
 	m_viewMenu( NULL ),
-	m_metronomeToggle( 0 )
+	m_metronomeToggle( 0 ),
+	m_session( Normal )
 {
 	setAttribute( Qt::WA_DeleteOnClose );
 
@@ -201,7 +203,10 @@ MainWindow::MainWindow() :
 	{
 		// connect auto save
 		connect(&m_autoSaveTimer, SIGNAL(timeout()), this, SLOT(autoSave()));
-		m_autoSaveTimer.start(1000 * 60);  // 1 minute
+		// The auto save function mustn't run until there is a project
+		// to save or it will run over recover.mmp if you hesitate at the
+		// recover messagebox for a minute. It is now started in main.
+		// See autoSaveTimerStart() in MainWindow.h
 	}
 
 	connect( Engine::getSong(), SIGNAL( playbackStateChanged() ),
@@ -650,6 +655,14 @@ void MainWindow::resetWindowTitle()
 	{
 		title += '*';
 	}
+	if( getSession() == Recover )
+	{
+		title += " - " + tr( "Recover session. Please save your work!" );
+	}
+	if( getSession() == Limited )
+	{
+		title += " - " + tr( "Automatic backup disabled. Remember to save your work!" );
+	}
 	setWindowTitle( title + " - " + tr( "LMMS %1" ).arg( LMMS_VERSION ) );
 }
 
@@ -659,17 +672,31 @@ void MainWindow::resetWindowTitle()
 bool MainWindow::mayChangeProject(bool stopPlayback)
 {
 	if( stopPlayback )
+	{
 		Engine::getSong()->stop();
+	}
 
-	if( !Engine::getSong()->isModified() )
+	if( !Engine::getSong()->isModified() && getSession() != Recover )
 	{
 		return( true );
 	}
 
-	QMessageBox mb( tr( "Project not saved" ),
-				tr( "The current project was modified since "
+	// Separate message strings for modified and recovered files
+	QString messageTitleRecovered = tr( "Recovered project not saved" );
+	QString messageRecovered = tr( "This project was recovered from the "
+					"previous session. It is currently "
+					"unsaved and will be lost if you don't "
+					"save it. Do you want to save it now?" );
+
+	QString messageTitleUnsaved = tr( "Project not saved" );
+	QString messageUnsaved = tr( "The current project was modified since "
 					"last saving. Do you want to save it "
-								"now?" ),
+								"now?" );
+
+	QMessageBox mb( ( getSession() == Recover ?
+				messageTitleRecovered : messageTitleUnsaved ),
+			( getSession() == Recover ?
+					messageRecovered : messageUnsaved ),
 				QMessageBox::Question,
 				QMessageBox::Save,
 				QMessageBox::Discard,
@@ -683,6 +710,10 @@ bool MainWindow::mayChangeProject(bool stopPlayback)
 	}
 	else if( answer == QMessageBox::Discard )
 	{
+		if( getSession() == Recover )
+		{
+			sessionCleanup();
+		}
 		return( true );
 	}
 
@@ -789,6 +820,7 @@ void MainWindow::createNewProject()
 	{
 		Engine::getSong()->createNewProject();
 	}
+	runAutoSave();
 }
 
 
@@ -807,6 +839,7 @@ void MainWindow::createNewProjectFromTemplate( QAction * _idx )
 		Engine::getSong()->createNewProjectFromTemplate(
 			dirBase + _idx->text() + ".mpt" );
 	}
+	runAutoSave();
 }
 
 
@@ -831,6 +864,7 @@ void MainWindow::openProject()
 			setCursor( Qt::ArrowCursor );
 		}
 	}
+	runAutoSave();
 }
 
 
@@ -874,6 +908,7 @@ void MainWindow::openRecentlyOpenedProject( QAction * _action )
 		ConfigManager::inst()->addRecentlyOpenedProject( f );
 		setCursor( Qt::ArrowCursor );
 	}
+	runAutoSave();
 }
 
 
@@ -888,6 +923,10 @@ bool MainWindow::saveProject()
 	else
 	{
 		Engine::getSong()->guiSaveProject();
+		if( getSession() == Recover )
+		{
+			sessionCleanup();
+		}
 	}
 	return( true );
 }
@@ -919,8 +958,11 @@ bool MainWindow::saveProjectAs()
 		{
 			fname += ".mpt";
 		}
-		Engine::getSong()->guiSaveProjectAs(
-						fname );
+		Engine::getSong()->guiSaveProjectAs( fname );
+		if( getSession() == Recover )
+		{
+			sessionCleanup();
+		}
 		return( true );
 	}
 	return( false );
@@ -1189,6 +1231,8 @@ void MainWindow::updateViewMenu()
 }
 
 
+
+
 void MainWindow::updateConfig( QAction * _who )
 {
 	QString tag = _who->data().toString();
@@ -1306,13 +1350,27 @@ void MainWindow::closeEvent( QCloseEvent * _ce )
 	if( mayChangeProject(true) )
 	{
 		// delete recovery file
-		QFile::remove(ConfigManager::inst()->recoveryFile());
-		_ce->accept();
+		if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt()
+			&& getSession() != Limited )
+		{
+			sessionCleanup();
+			_ce->accept();
+		}
 	}
 	else
 	{
 		_ce->ignore();
 	}
+}
+
+
+
+
+void MainWindow::sessionCleanup()
+{
+	// delete recover session files
+	QFile::remove( ConfigManager::inst()->recoveryFile() );
+	setSession( Normal );
 }
 
 
@@ -1457,5 +1515,17 @@ void MainWindow::autoSave()
 	{
 		// try again in 10 seconds
 		QTimer::singleShot( 10*1000, this, SLOT( autoSave() ) );
+	}
+}
+
+
+// For the occasional auto save action that isn't run
+// from the timer where we need to do extra tests.
+void MainWindow::runAutoSave()
+{
+	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() &&
+		getSession() != Limited )
+	{
+		autoSave();
 	}
 }


### PR DESCRIPTION
Fixes issue: #2174
Edit: I've started a feedback thread in the forum https://lmms.io/forum/viewtopic.php?f=15&t=3479

In summary: Multiple fixes for the recovery file system that introduces clear session states for LMMS.
It won't allow overwriting of ```recover.mmp``` if you run multiple instances but it will only do autosave for the first instance of LMMS launched. 

![recovery-final](https://cloud.githubusercontent.com/assets/6368949/11822709/3b6f9830-a370-11e5-832a-6fee16945a96.png)

---

Bugs and fixes!
 - If you start LMMS with a recovery file present and don't do anything at all the auto save will write it over with an all empty project after a minute. It's been ticking on in the background. We solve this by starting the timer the very last thing in main() after a project is loaded( if it's not a limited session or auto save is disabled altogether ).

 - When starting if you escape from the recover message the default is to delete recover.mmp  This is probably not expected or wanted behaviour for everyone. Escaping from the dialogue had better be non destructive.
I fix this by defaulting 'Escape' to button 'Exit' instead close the app.

 - If you press yes to recover and immediately shut down LMMS you will not be asked any questions and recover.mmp is deleted. This is a bit rough. Fixed in the new file save dialogue. ( MainWindow::mayChangeProject() message box )

 - If you run multiple sessions of LMMS they will simply take turns to write over recover.mmp  :P
I solve this by introducing the limited session, that will be set if the user press 'Ignore' at the recovery dialogue.  This allows you to launch another session that doesn't write to recover.mmp. This way LMMS will launch a slightly limited session which simply turns off autosave for this instance. This together with running autosave() the first thing of all (described below) should minimise the risk of recover.mmp being overwritten.

 - On starting LMMS the autosave() function takes a minute to kick in. This is problematic especially since the introduction of different sessions, because this minute of no backup file is actually a logic state of it's own, and it's an ill defined one. We take care of this by executing ```MainWindow::autosave()``` in main() once as a very last step after loading a project, but only if there is no recover file present. For this to work I made MainWindow::autosave() public.

 - Clarity. Brushed up the dialogues involved and update window title to signal session.

I know it's not 100% what users have asked for but it is a solid solution for recover files which has no uncertain states and is hopefully clear enough to use. It's intended as a modification/bugfix for the upcoming 1.2 release.
Separate files for multiple sessions as has been in demand will most likely have to wait until later.
The actual action of the MainWindow::autosave() when it's running however will be one of my next areas to look at.

Last updated on 15 Dec 2015