### PR TITLE
Hide recover.mmp in Recent files

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -837,7 +837,8 @@ void MainWindow::updateRecentlyOpenedProjectsMenu()
 	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
 	{
 		QFileInfo recentFile( *it );
-		if ( recentFile.exists() )
+		if ( recentFile.exists() && 
+				*it != ConfigManager::inst()->recoveryFile() )
 		{
 			m_recentlyOpenedProjectsMenu->addAction(
 					embed::getIconPixmap( "project_file" ), *it );


### PR DESCRIPTION
recover.mmp shows up in recent files after recover action. It points to most recently saved recover.mmp which is the same as the project in use... probably. Best to hide it in any case to save the confusion.