### PR TITLE
Basic support for MIDI input note range limiting

### DIFF
--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -52,6 +52,8 @@ private:
 	GroupBox * m_midiInputGroupBox;
 	LcdSpinBox * m_inputChannelSpinBox;
 	LcdSpinBox * m_fixedInputVelocitySpinBox;
+	LcdSpinBox * m_lowerInputNoteLimitSpinBox;
+	LcdSpinBox * m_upperInputNoteLimitSpinBox;
 	QToolButton * m_rpBtn;
 
 	GroupBox * m_midiOutputGroupBox;

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -54,6 +54,8 @@ class MidiPort : public Model, public SerializingObject
 	mapPropertyFromModel(int,fixedOutputNote,setFixedOutputNote,m_fixedOutputNoteModel);
 	mapPropertyFromModel(int,outputProgram,setOutputProgram,m_outputProgramModel);
 	mapPropertyFromModel(int,baseVelocity,setBaseVelocity,m_baseVelocityModel);
+	mapPropertyFromModel(int,lowerInputNoteLimit,setlowerInputNoteLimit,m_lowerInputNoteLimitModel);
+	mapPropertyFromModel(int,upperInputNoteLimit,setupperInputNoteLimit,m_upperInputNoteLimitModel);
 	mapPropertyFromModel(bool,isReadable,setReadable,m_readableModel);
 	mapPropertyFromModel(bool,isWritable,setWritable,m_writableModel);
 public:
@@ -153,6 +155,8 @@ private:
 	IntModel m_fixedOutputNoteModel;
 	IntModel m_outputProgramModel;
 	IntModel m_baseVelocityModel;
+	IntModel m_lowerInputNoteLimitModel;
+	IntModel m_upperInputNoteLimitModel;
 	BoolModel m_readableModel;
 	BoolModel m_writableModel;
 

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -51,6 +51,8 @@ MidiPort::MidiPort( const QString& name,
 	m_fixedOutputNoteModel( -1, -1, MidiMaxKey, this, tr( "Fixed output note" ) ),
 	m_outputProgramModel( 1, 1, MidiProgramCount, this, tr( "Output MIDI program" ) ),
 	m_baseVelocityModel( MidiMaxVelocity/2, 1, MidiMaxVelocity, this, tr( "Base velocity" ) ),
+	m_lowerInputNoteLimitModel(-1, -1, MidiMaxKey, this, tr( "Lower input note limit" ) ),
+	m_upperInputNoteLimitModel(-1, -1, MidiMaxKey, this, tr( "Upper input note limit" ) ),
 	m_readableModel( false, this, tr( "Receive MIDI-events" ) ),
 	m_writableModel( false, this, tr( "Send MIDI-events" ) )
 {
@@ -128,6 +130,16 @@ void MidiPort::processInEvent( const MidiEvent& event, const MidiTime& time )
 			{
 				return;
 			}
+
+			if( lowerInputNoteLimit() > -1 && inEvent.key() < lowerInputNoteLimit() )
+			{
+				return;
+			}
+
+			if( upperInputNoteLimit() > -1 && inEvent.key() > upperInputNoteLimit() )
+			{
+				return;
+			}
 		}
 
 		if( fixedInputVelocity() >= 0 && inEvent.velocity() > 0 )
@@ -173,6 +185,8 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 	m_fixedOutputNoteModel.saveSettings( doc, thisElement, "fixedoutputnote" );
 	m_outputProgramModel.saveSettings( doc, thisElement, "outputprogram" );
 	m_baseVelocityModel.saveSettings( doc, thisElement, "basevelocity" );
+	m_lowerInputNoteLimitModel.saveSettings( doc, thisElement, "lowerinputnotelimit" );
+	m_upperInputNoteLimitModel.saveSettings( doc, thisElement, "upperinputnotelimit" );
 	m_readableModel.saveSettings( doc, thisElement, "readable" );
 	m_writableModel.saveSettings( doc, thisElement, "writable" );
 
@@ -226,6 +240,8 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_fixedOutputVelocityModel.loadSettings( thisElement, "fixedoutputvelocity" );
 	m_outputProgramModel.loadSettings( thisElement, "outputprogram" );
 	m_baseVelocityModel.loadSettings( thisElement, "basevelocity" );
+	m_lowerInputNoteLimitModel.loadSettings( thisElement, "lowerinputnotelimit" );
+	m_upperInputNoteLimitModel.loadSettings( thisElement, "upperinputnotelimit" );
 	m_readableModel.loadSettings( thisElement, "readable" );
 	m_writableModel.loadSettings( thisElement, "writable" );
 

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -69,12 +69,31 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_fixedInputVelocitySpinBox->setLabel( tr( "VELOCITY" ) );
 	m_fixedInputVelocitySpinBox->setEnabled( false );
 	midiInputLayout->addWidget( m_fixedInputVelocitySpinBox );
+
+	m_lowerInputNoteLimitSpinBox = new LcdSpinBox( 3, m_midiInputGroupBox );
+	m_lowerInputNoteLimitSpinBox->setDisplayOffset( 1 );
+	m_lowerInputNoteLimitSpinBox->addTextForValue( 0, "---" );
+	m_lowerInputNoteLimitSpinBox->setLabel( tr( "NOTE MIN" ) );
+	m_lowerInputNoteLimitSpinBox->setEnabled( false );
+	midiInputLayout->addWidget( m_lowerInputNoteLimitSpinBox );
+
+	m_upperInputNoteLimitSpinBox = new LcdSpinBox( 3, m_midiInputGroupBox );
+	m_upperInputNoteLimitSpinBox->setDisplayOffset( 1 );
+	m_upperInputNoteLimitSpinBox->addTextForValue( 0, "---" );
+	m_upperInputNoteLimitSpinBox->setLabel( tr( "NOTE MAX" ) );
+	m_upperInputNoteLimitSpinBox->setEnabled( false );
+	midiInputLayout->addWidget( m_upperInputNoteLimitSpinBox );
 	midiInputLayout->addStretch();
 
 	connect( m_midiInputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
-			m_inputChannelSpinBox, SLOT( setEnabled( bool ) ) );
+		m_inputChannelSpinBox, SLOT( setEnabled( bool ) ) );
 	connect( m_midiInputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
 		m_fixedInputVelocitySpinBox, SLOT( setEnabled( bool ) ) );
+
+	connect( m_midiInputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
+		m_lowerInputNoteLimitSpinBox, SLOT( setEnabled( bool ) ) );
+	connect( m_midiInputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
+		m_upperInputNoteLimitSpinBox, SLOT( setEnabled( bool ) ) );
 
 
 
@@ -149,7 +168,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 
 	QLabel* baseVelocityHelp = new QLabel( tr( "Specify the velocity normalization base for MIDI-based instruments at note volume 100%" ) );
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont( pointSize<8>( baseVelocityHelp->font() ) );
+	baseVelocityHelp->setFont( pointSize<8>( baseVelocityHelp->font() ) );
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 
@@ -182,6 +201,8 @@ void InstrumentMidiIOView::modelChanged()
 	m_midiInputGroupBox->setModel( &mp->m_readableModel );
 	m_inputChannelSpinBox->setModel( &mp->m_inputChannelModel );
 	m_fixedInputVelocitySpinBox->setModel( &mp->m_fixedInputVelocityModel );
+	m_lowerInputNoteLimitSpinBox->setModel( &mp->m_lowerInputNoteLimitModel );
+	m_upperInputNoteLimitSpinBox->setModel( &mp->m_upperInputNoteLimitModel );
 
 	m_midiOutputGroupBox->setModel( &mp->m_writableModel );
 	m_outputChannelSpinBox->setModel( &mp->m_outputChannelModel );


### PR DESCRIPTION
A very simple solution to limit MIDI input note ranges on
instruments. Using this function it is possible to create an
arbitrary number of zones on a MIDI keyboard, assigning each zone
to a different instrument. Relates to issues #1792 and #1381