### PR TITLE
Fixes #2186; double-clicking the Fx Channel selector will show Mixer window if hidden

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1227,6 +1227,7 @@ class fxLineLcdSpinBox : public LcdSpinBox
 		{
 			gui->fxMixerView()->setCurrentFxLine( model()->value() );
 
+			gui->fxMixerView()->parentWidget()->show();
 			gui->fxMixerView()->show();// show fxMixer window
 			gui->fxMixerView()->setFocus();// set focus to fxMixer window
 			//engine::getFxMixerView()->raise();


### PR DESCRIPTION
Pretty simple fix. I just copied the missing code from [MainWindow.cpp:979](https://github.com/LMMS/lmms/blob/master/src/gui/MainWindow.cpp#L979).