### PR TITLE
Remove deprecated base64::encode(QVariant) version

### DIFF
--- a/include/base64.h
+++ b/include/base64.h
@@ -47,8 +47,6 @@ namespace base64
 		*_data = new T[*_size / sizeof(T)];
 		memcpy( *_data, data.constData(), *_size );
 	}
-	// deprecated!!
-	QString encode( const QVariant & _data );
 	// for compatibility-code only
 	QVariant decode( const QString & _b64,
 			QVariant::Type _force_type = QVariant::Invalid );

--- a/src/core/base64.cpp
+++ b/src/core/base64.cpp
@@ -35,21 +35,6 @@ namespace base64
 {
 
 
-QString encode( const QVariant & _data )
-{
-	QBuffer buf;
-	buf.open( QBuffer::WriteOnly );
-	QDataStream out( &buf );
-	out << _data;
-	QByteArray data = buf.buffer();
-	QString dst;
-	encode( data.constData(), data.size(), dst );
-	return( dst );
-}
-
-
-
-
 QVariant decode( const QString & _b64, QVariant::Type _force_type )
 {
 	char * dst = NULL;


### PR DESCRIPTION
The function was clearly marked deprecated, and nobody was using it, so I removed it.

Upon inspection, it appears the QVariant version of base64::encode was used in LMMS versions prior to 0.4.0-beta1, as indicated in the [DataFile::upgrade](https://github.com/LMMS/lmms/blob/860d419c14908c6153e6282e4f696f530d76a556/src/core/DataFile.cpp#L730) function.