### PR TITLE
Correctly use the ladspa plugin folder

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -369,16 +369,16 @@ void ConfigManager::loadConfigFile()
 		m_flDir = ensureTrailingSlash( QDir::home().absolutePath() );
 	}
 
-	if( m_ladDir.isEmpty() || m_ladDir == QDir::separator() ||
-			( !m_ladDir.contains( ':' ) && !QDir( m_ladDir ).exists() ) )
+	if( m_ladDir.isEmpty()  )
 	{
 #if defined(LMMS_BUILD_WIN32)
 		m_ladDir = qApp->applicationDirPath() + "/plugins/ladspa" + QDir::separator();
 #elif defined(LMMS_BUILD_APPLE)
 		m_ladDir = qApp->applicationDirPath() + "/../lib/lmms/ladspa/";
 #else
-		m_ladDir = qApp->applicationDirPath() + '/' + LIB_DIR + "/ladspa/";
+		m_ladDir = qApp->applicationDirPath() + '/' + LIB_DIR + "/lmms/ladspa/";
 #endif
+		m_ladDir = QDir::cleanPath( m_ladDir );
 		m_ladDir += ","+userLadspaDir();
 	}
 


### PR DESCRIPTION
The config manager was not using the loaded value for the ladspa folder
The default Ladspa plugin folder was incorrect under linux

This pull request fixes this.

Fixes #2159 Master branch can't find ladspa effects

Were introduced in #1908 Re organizing of the user lmms directory