### PR TITLE
Edit BBEditor Mouse tool tip

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -706,8 +706,7 @@ PatternView::PatternView( Pattern* pattern, TrackView* parent ) :
 	setFixedHeight( parentWidget()->height() - 2 );
 
 	ToolTip::add( this,
-		tr( "double-click to open this pattern in piano-roll\n"
-			"use mouse wheel to set volume of a step" ) );
+		tr( "use mouse wheel to set volume of a step" ) );
 	setStyle( QApplication::style() );
 }
 


### PR DESCRIPTION
Edit the tool tip to remove The Double click top open in piano roll text 
as per the changes #1776 #1783