### PR TITLE
Calculate rendering extension on a separate line

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -516,11 +516,8 @@ int main( int argc, char * * argv )
 		printf( "done\n" );
 
 		// create renderer
-		ProjectRenderer * r = new ProjectRenderer( qs, os, eff,
-			render_out +
-				QString( ( eff ==
-					ProjectRenderer::WaveFile ) ?
-						"wav" : "ogg" ) );
+		QString extension = ( eff == ProjectRenderer::WaveFile ) ? "wav" : "ogg";
+		ProjectRenderer * r = new ProjectRenderer( qs, os, eff, render_out + extension );
 		QCoreApplication::instance()->connect( r,
 				SIGNAL( finished() ), SLOT( quit() ) );
 


### PR DESCRIPTION
I broke out the calculation of the output file extension (when rendering a file from the command line) onto its own line. This is a notable readability improvement to my eyes.