### PR TITLE
First fix for #2209: Gets rid of too small fonts in all file browsers

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -372,8 +372,6 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 	headerItem()->setHidden( true );
 	setSortingEnabled( false );
 
-	setFont( pointSizeF( font(), 7.5f ) );
-
 	connect( this, SIGNAL( itemDoubleClicked( QTreeWidgetItem *, int ) ),
 			SLOT( activateListItem( QTreeWidgetItem *, int ) ) );
 	connect( this, SIGNAL( itemCollapsed( QTreeWidgetItem * ) ),


### PR DESCRIPTION
A first fix for #2209. Removes one of the several calls to `pointSizeF`. This method seems to
return a font which has the same height in pixels on all displays
(regardless of the display's actual DPI value). In the long run these
calls will all have to be removed to make LMMS usable on high DPI
displays.