### PR TITLE
Don't use native file saving/loading dialogs

### DIFF
--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -39,6 +39,8 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 	setOption( QFileDialog::DontUseCustomDirectoryIcons );
 #endif
 
+	setOption( QFileDialog::DontUseNativeDialog );
+
 	// Add additional locations to the sidebar
 	QList<QUrl> urls = sidebarUrls();
 #if QT_VERSION >= 0x050000


### PR DESCRIPTION
LMMS tries to modify the save dialog, This causes a segfault if native
file dialogs are used instead of the Qt ones.  At least on Linux, Qt 5
seems to make file dialogs native by default, so LMMS is unable to save
projects when compiled with `-DWANT_QT5=true`.