### PR TITLE
Set default suffix in "Save as..." file save dialog

### DIFF
--- a/include/VersionedSaveDialog.h
+++ b/include/VersionedSaveDialog.h
@@ -44,6 +44,7 @@ public:
 
 	// Returns true if file name was changed, returns false if it wasn't
 	static bool changeFileNameVersion( QString &fileName, bool increment );
+	static bool fileExistsQuery( QString FileName, QString WindowTitle );
 
 public slots:
 	void incrementVersion();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -66,6 +66,7 @@
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
 #include "PeakController.h"
+#include "VersionedSaveDialog.h"
 
 
 tick_t MidiTime::s_ticksPerTact = DefaultTicksPerTact;
@@ -1295,9 +1296,11 @@ void Song::exportProject( bool multiExport )
 	efd.setAcceptMode( FileDialog::AcceptSave );
 
 
-	if( efd.exec() == QDialog::Accepted && !efd.selectedFiles().isEmpty() && !efd.selectedFiles()[0].isEmpty() )
+	if( efd.exec() == QDialog::Accepted && !efd.selectedFiles().isEmpty() &&
+					 !efd.selectedFiles()[0].isEmpty() )
 	{
 		QString suffix = "";
+		QString exportFileName = efd.selectedFiles()[0];
 		if ( !multiExport )
 		{
 			int stx = efd.selectedNameFilter().indexOf( "(*." );
@@ -1315,7 +1318,12 @@ void Song::exportProject( bool multiExport )
 			}
 		}
 
-		const QString exportFileName = efd.selectedFiles()[0] + suffix;
+		if( VersionedSaveDialog::fileExistsQuery( exportFileName + suffix,
+				tr( "Save project" ) ) )
+		{
+			exportFileName += suffix;
+		}
+
 		ExportProjectDialog epd( exportFileName, gui->mainWindow(), multiExport );
 		epd.exec();
 	}
@@ -1353,6 +1361,7 @@ void Song::exportProjectMidi()
 		base_filename = tr( "untitled" );
 	}
 	efd.selectFile( base_filename + ".mid" );
+	efd.setDefaultSuffix( "mid");
 	efd.setWindowTitle( tr( "Select file for project-export..." ) );
 
 	efd.setAcceptMode( FileDialog::AcceptSave );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -957,13 +957,29 @@ bool MainWindow::saveProjectAs()
 		sfd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 	}
 
+	// Don't write over file with suffix if no suffix is provided.
+	QString suffix = ConfigManager::inst()->value( "app",
+							"nommpz" ).toInt() == 0
+						? "mmpz"
+						: "mmp" ;
+	sfd.setDefaultSuffix( suffix );
+
 	if( sfd.exec () == FileDialog::Accepted &&
 		!sfd.selectedFiles().isEmpty() && sfd.selectedFiles()[0] != "" )
 	{
 		QString fname = sfd.selectedFiles()[0] ;
-		if( sfd.selectedNameFilter().contains( "(*.mpt)" ) && !sfd.selectedFiles()[0].endsWith( ".mpt" ) )
+		if( sfd.selectedNameFilter().contains( "(*.mpt)" ) )
 		{
-			fname += ".mpt";
+			// Remove the default suffix
+			fname.remove( "." + suffix );
+			if( !sfd.selectedFiles()[0].endsWith( ".mpt" ) )
+			{
+				if( VersionedSaveDialog::fileExistsQuery( fname + ".mpt",
+						tr( "Save project template" ) ) )
+				{
+					fname += ".mpt";
+				}
+			}
 		}
 		Engine::getSong()->guiSaveProjectAs( fname );
 		if( getSession() == Recover )

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -23,10 +23,11 @@
  */
 
 
-#include <QLayout>
-#include <QPushButton>
 #include <QFontMetrics>
+#include <QLayout>
 #include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
 
 #include "VersionedSaveDialog.h"
 
@@ -137,3 +138,25 @@ void VersionedSaveDialog::decrementVersion()
 }
 
 
+
+
+bool VersionedSaveDialog::fileExistsQuery( QString FileName, QString WindowTitle )
+{
+	bool fileExists = false;
+	if( QFile( FileName ).exists() )
+	{
+		QMessageBox mb;
+		mb.setWindowTitle( WindowTitle );
+		mb.setText( FileName + tr( " already exists. "
+			"Do you want to replace it?" ) );
+		mb.setIcon( QMessageBox::Warning );
+		mb.setStandardButtons(
+			QMessageBox::Yes | QMessageBox::No );
+
+		if( mb.exec() == QMessageBox::Yes )
+		{
+			fileExists = true;
+		}
+	}
+	return fileExists;
+}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1577,6 +1577,7 @@ void InstrumentTrackWindow::saveSettingsBtnClicked()
 	sfd.setFileMode( FileDialog::AnyFile );
 	QString fname = m_track->name();
 	sfd.selectFile( fname.remove(QRegExp("[^a-zA-Z0-9_\\-\\d\\s]")) );
+	sfd.setDefaultSuffix( "xpf");
 
 	if( sfd.exec() == QDialog::Accepted &&
 		!sfd.selectedFiles().isEmpty() &&


### PR DESCRIPTION
When you "save as..." without adding suffix manually, LMMS will add a suffix but not test if the file "name + suffix" exists and will gladly write over an existing file.
This is true on Ubuntu Mate at least.
This patch adds suffix mmp/mmpz as default to VersionedSaveDialog when called in saveProjectAs() which fixes the issue.
When I searched the issue I got the impression that this could be mostly a Linux thing but I have not possibility to test on any other OS.
