### PR TITLE
Fix #1878

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -46,7 +46,7 @@ class EXPORT Engine : public QObject
 {
 	Q_OBJECT
 public:
-	static void init();
+	static void init( bool renderOnly );
 	static void destroy();
 
 	// core

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -382,7 +382,7 @@ private:
 	} ;
 
 
-	Mixer();
+	Mixer( bool renderOnly );
 	virtual ~Mixer();
 
 	void startProcessing( bool _needs_fifo = true );

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -57,6 +57,7 @@ class MidiClient;
 class AudioPort;
 
 
+const fpp_t MINIMUM_BUFFER_SIZE = 32;
 const fpp_t DEFAULT_BUFFER_SIZE = 256;
 
 const int BYTES_PER_SAMPLE = sizeof( sample_t );

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -50,7 +50,7 @@ DummyTrackContainer * Engine::s_dummyTC = NULL;
 
 
 
-void Engine::init()
+void Engine::init( bool renderOnly )
 {
 	Engine *engine = inst();
 
@@ -60,7 +60,7 @@ void Engine::init()
 
 	emit engine->initProgress(tr("Initializing data structures"));
 	s_projectJournal = new ProjectJournal;
-	s_mixer = new Mixer;
+	s_mixer = new Mixer( renderOnly );
 	s_song = new Song;
 	s_fxMixer = new FxMixer;
 	s_bbTrackContainer = new BBTrackContainer;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -85,22 +85,26 @@ Mixer::Mixer( bool renderOnly ) :
 	// determine FIFO size and number of frames per period
 	int fifoSize = 1;
 
+	// if not only rendering (that is, using the GUI), load the buffer
+	// size from user configuration
 	if( renderOnly == false )
 	{
 		m_framesPerPeriod = 
 			( fpp_t ) ConfigManager::inst()->
 				value( "mixer", "framesperaudiobuffer" ).toInt();
 
-		if( m_framesPerPeriod < 32 )
+		// if the value read from user configuration is not set or
+		// lower than the minimum allowed, use the default value and
+		// save it to the configuration
+		if( m_framesPerPeriod < MINIMUM_BUFFER_SIZE )
 		{
 			ConfigManager::inst()->setValue( "mixer",
-									"framesperaudiobuffer",
+						"framesperaudiobuffer",
 						QString::number( DEFAULT_BUFFER_SIZE ) );
 
 			m_framesPerPeriod = DEFAULT_BUFFER_SIZE;
 		}
-
-		if( m_framesPerPeriod > DEFAULT_BUFFER_SIZE )
+		else if( m_framesPerPeriod > DEFAULT_BUFFER_SIZE )
 		{
 			fifoSize = m_framesPerPeriod / DEFAULT_BUFFER_SIZE;
 			m_framesPerPeriod = DEFAULT_BUFFER_SIZE;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -85,13 +85,13 @@ Mixer::Mixer( bool renderOnly ) :
 	// determine FIFO size and number of frames per period
 	int fifoSize = 1;
 
-	if (!renderOnly)
+	if( renderOnly == false )
 	{
 		m_framesPerPeriod = 
 			( fpp_t ) ConfigManager::inst()->
 				value( "mixer", "framesperaudiobuffer" ).toInt();
 
-		if (m_framesPerPeriod < 32)
+		if( m_framesPerPeriod < 32 )
 		{
 			ConfigManager::inst()->setValue( "mixer",
 									"framesperaudiobuffer",

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -509,7 +509,7 @@ int main( int argc, char * * argv )
 	else
 	{
 		// we're going to render our song
-		Engine::init();
+		Engine::init( true );
 
 		printf( "loading project...\n" );
 		Engine::getSong()->loadProject( file_to_load );

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -90,7 +90,7 @@ GuiApplication::GuiApplication()
 		this, SLOT(displayInitProgress(const QString&)));
 
 	// Init central engine which handles all components of LMMS
-	Engine::init();
+	Engine::init(false);
 
 	s_instance = this;
 


### PR DESCRIPTION
This not only fixes issue #1878 but also refactors `Mixer`'s constructor by making it shorter and more readable while it still does what it is supposed to.

The buffer size value is now loaded correctly.