### PR TITLE
Fix 'create working dir' prompt & move it from ConfigManager to GuiApplication

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -214,6 +214,9 @@ public:
 		return m_recentlyOpenedProjects;
 	}
 
+	// returns true if the working dir (e.g. ~/lmms) exists on disk
+	bool hasWorkingDir() const;
+
 	void addRecentlyOpenedProject( const QString & _file );
 
 	const QString & value( const QString & _class,
@@ -236,6 +239,9 @@ public:
 	void setBackgroundArtwork( const QString & _ba );
 	void setGIGDir( const QString & gd );
 	void setSF2Dir( const QString & sfd );
+
+	// creates the working directory & subdirectories on disk.
+	void createWorkingDir();
 
 
 private:

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -135,6 +135,11 @@ void ConfigManager::upgrade()
 	m_version = LMMS_VERSION;
 }
 
+bool ConfigManager::hasWorkingDir() const
+{
+	return QDir( m_workingDir ).exists();
+}
+
 
 void ConfigManager::setWorkingDir( const QString & _wd )
 {
@@ -213,6 +218,20 @@ void ConfigManager::setSF2Dir(const QString &sfd)
 	m_sf2Dir = sfd;
 }
 
+
+void ConfigManager::createWorkingDir()
+{
+	QDir().mkpath( m_workingDir );
+
+	QDir().mkpath( userProjectsDir() );
+	QDir().mkpath( userTemplateDir() );
+	QDir().mkpath( userSamplesDir() );
+	QDir().mkpath( userPresetsDir() );
+	QDir().mkpath( userGigDir() );
+	QDir().mkpath( userSf2Dir() );
+	QDir().mkpath( userVstDir() );
+	QDir().mkpath( userLadspaDir() );
+}
 
 
 
@@ -426,28 +445,10 @@ void ConfigManager::loadConfigFile()
 	searchPaths << artworkDir() << defaultArtworkDir();
 	QDir::setSearchPaths( "resources", searchPaths);
 
-	if( !QDir( m_workingDir ).exists() && gui &&
-		QMessageBox::question( 0,
-			MainWindow::tr( "Working directory" ),
-			MainWindow::tr( "The LMMS working directory %1 does not "
-				"exist. Create it now? You can change the directory "
-				"later via Edit -> Settings." ).arg( m_workingDir ),
-					QMessageBox::Yes, QMessageBox::No ) == QMessageBox::Yes )
+	// Create any missing subdirectories in the working dir, but only if the working dir exists
+	if( hasWorkingDir() )
 	{
-		QDir().mkpath( m_workingDir );
-	}
-
-	if( QDir( m_workingDir ).exists() )
-	{
-		QDir().mkpath( userProjectsDir() );
-		QDir().mkpath( userTemplateDir() );
-		QDir().mkpath( userSamplesDir() );
-		QDir().mkpath( userPresetsDir() );
-		QDir().mkpath( userGigDir() );
-		QDir().mkpath( userSf2Dir() );
-		QDir().mkpath( userVstDir() );
-		QDir().mkpath( userLadspaDir() );
-
+		createWorkingDir();
 	}
 
 	upgrade();

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -31,6 +31,7 @@
 
 #include "AutomationEditor.h"
 #include "BBEditor.h"
+#include "ConfigManager.h"
 #include "ControllerRackView.h"
 #include "FxMixerView.h"
 #include "InstrumentTrack.h"
@@ -40,6 +41,7 @@
 #include "SongEditor.h"
 
 #include <QApplication>
+#include <QMessageBox>
 #include <QSplashScreen>
 
 GuiApplication* GuiApplication::s_instance = nullptr;
@@ -52,6 +54,17 @@ GuiApplication* GuiApplication::instance()
 
 GuiApplication::GuiApplication()
 {
+	// prompt the user to create the LMMS working directory (e.g. ~/lmms) if it doesn't exist
+	if ( !ConfigManager::inst()->hasWorkingDir() &&
+		QMessageBox::question( NULL,
+				tr( "Working directory" ),
+				tr( "The LMMS working directory %1 does not "
+				"exist. Create it now? You can change the directory "
+				"later via Edit -> Settings." ).arg( ConfigManager::inst()->workingDir() ),
+					QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes ) == QMessageBox::Yes)
+	{
+		ConfigManager::inst()->createWorkingDir();
+	}
 	// Init style and palette
 	LmmsStyle* lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);


### PR DESCRIPTION
This performs the same role as #2233, but it is a superior implementation in that it does not affect command-line usage and the gui code is moved all the way out of the core (into gui/GuiApplication.cpp instead of core/main.cpp).

I also made a slight modification such that the default button for the prompt is 'Yes' (do create working directory) instead of 'No'.