### PR TITLE
Fix SF2 pitch and gain problems

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -524,6 +524,11 @@ void sf2Instrument::updateSampleRate()
 	updateChorus();
 	updateReverbOn();
 	updateChorusOn();
+
+	// Reset last MIDI pitch properties, which will be set to the correct values
+	// upon playing the next note
+	m_lastMidiPitch = -1;
+	m_lastMidiPitchRange = -1;
 }
 
 

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -483,7 +483,6 @@ void sf2Instrument::updateSampleRate()
 
 		// synth program change (set bank and patch)
 		updatePatch();
-		updateGain();
 	}
 	else
 	{
@@ -524,6 +523,7 @@ void sf2Instrument::updateSampleRate()
 	updateChorus();
 	updateReverbOn();
 	updateChorusOn();
+	updateGain();
 
 	// Reset last MIDI pitch properties, which will be set to the correct values
 	// upon playing the next note


### PR DESCRIPTION
Fixes #2204. 

The problem happened because, while the synth was reinitialized, the pitch bend properties were not.