### PR TITLE
Fixes #2262

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -575,6 +575,13 @@ int main( int argc, char * * argv )
 	{
 		Engine::init( true );
 
+		QFileInfo fileInfo( fileToLoad );
+		if ( !fileInfo.exists() )
+		{
+			printf("The file %s does not exist!\n", fileToLoad.toStdString().c_str());
+			exit( 1 );
+		}
+
 		printf( "Loading project...\n" );
 		Engine::getSong()->loadProject( fileToLoad );
 		printf( "Done\n" );


### PR DESCRIPTION
Added a check for the existence of the file that should be rendered from
the command line. LMMS now exits with an error message in case the file
does not exist.