### PR TITLE
Enable it to hide BB Editor in default template

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -569,7 +569,7 @@ void MainWindow::finalize()
 
 	gui->automationEditor()->parentWidget()->hide();
 	gui->getBBEditor()->parentWidget()->move( 610, 5 );
-	gui->getBBEditor()->parentWidget()->show();
+	gui->getBBEditor()->parentWidget()->hide();
 	gui->pianoRoll()->parentWidget()->move(5, 5);
 	gui->pianoRoll()->parentWidget()->hide();
 	gui->songEditor()->parentWidget()->move(5, 5);


### PR DESCRIPTION
The Beat+Bassline Editor is now hidden by default but shown if the default template determines so.

Fixes #2256.