### PR TITLE
Fixes #2272 and other problems with the templates

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -120,6 +120,11 @@ public:
 		return dataDir() + PROJECTS_PATH;
 	}
 
+	QString factoryTemplatesDir() const
+	{
+		return factoryProjectsDir() + TEMPLATE_PATH;
+	}
+
 	QString factoryPresetsDir() const
 	{
 		return dataDir() + PRESETS_PATH;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -113,6 +113,7 @@ public slots:
 	bool saveProject();
 	bool saveProjectAs();
 	bool saveProjectAsNewVersion();
+	void saveProjectAsDefaultTemplate();
 	void showSettingsDialog();
 	void aboutLMMS();
 	void help();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -277,6 +277,9 @@ void MainWindow::finalize()
 					this, SLOT( saveProjectAsNewVersion() ),
 					Qt::CTRL + Qt::ALT + Qt::Key_S );
 
+	project_menu->addAction( tr( "Save as default template" ),
+				     this, SLOT( saveProjectAsDefaultTemplate() ) );
+
 	project_menu->addSeparator();
 	project_menu->addAction( embed::getIconPixmap( "project_import" ),
 					tr( "Import..." ),
@@ -928,6 +931,29 @@ bool MainWindow::saveProjectAsNewVersion()
 		Engine::getSong()->guiSaveProjectAs( fileName );
 		return true;
 	}
+}
+
+
+
+
+void MainWindow::saveProjectAsDefaultTemplate()
+{
+	QString defaultTemplate = ConfigManager::inst()->userTemplateDir() + "default.mpt";
+
+	QFileInfo fileInfo(defaultTemplate);
+	if (fileInfo.exists())
+	{
+		if (QMessageBox::warning(this,
+					 tr("Overwrite default template?"),
+					 tr("This will overwrite your current default template."),
+					 QMessageBox::Ok,
+					 QMessageBox::Cancel) != QMessageBox::Ok)
+		{
+			return;
+		}
+	}
+
+	Engine::getSong()->saveProjectFile( defaultTemplate );
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -787,12 +787,12 @@ void MainWindow::createNewProjectFromTemplate( QAction * _idx )
 	{
 		int indexOfTemplate = m_templatesMenu->actions().indexOf( _idx );
 		bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
-		QString dir_base =  isFactoryTemplate ?
+		QString dirBase =  isFactoryTemplate ?
 				ConfigManager::inst()->factoryTemplatesDir() :
 				ConfigManager::inst()->userTemplateDir();
 
 		Engine::getSong()->createNewProjectFromTemplate(
-			dir_base + _idx->text() + ".mpt" );
+			dirBase + _idx->text() + ".mpt" );
 	}
 }
 


### PR DESCRIPTION
Fixes #2272 by removing the non-intuitive saving of the default template in `MainWindow::createNewProject`.

Other fixed problems:
* User entries were not shown in the menu of the tool button that
creates new projects from templates. Now they are shown as well.

Other changes:
* Adds a new option "New from template" in the file menu. It shows the
same menu as the tool button.