### PR TITLE
Breaks down the piano roll's toolbar into multiple smaller ones (#2286)

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -261,13 +261,6 @@ TrackContainerView QFrame{
 
 /* autoscroll, loop, stop behaviour toggle buttons */
 
-NStateButton {
-	max-height: 26px;
-	max-width: 26px;
-	min-height: 26px;
-	min-width: 26px;
-}
-
 /* track background colors */
 TrackContentWidget {
 	qproperty-darkerColor: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -377,9 +370,9 @@ QWidget#mainToolbar {
 /* smaller toolbars */
 
 QToolBar {
-	background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #98a2a7, stop:1 #5b646f);
+	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #98a2a7, stop:1 #5b646f);
 	border: none;
-	padding: 1px;
+	padding: 2px;
 	spacing: 0;
 }
 
@@ -390,9 +383,9 @@ QToolBar::separator {
 
 QToolButton {
 	padding: 1px 1px 1px 1px;
-	border-radius: 2px;
-	border: 1px solid rgba(0,0,0,32);
-	background: qradialgradient(cx:0.3, cy:0.3, radius:0.8, fx:0.3, fy:0.3, stop:0 #c9c9c9, stop:1 #969696 );
+	border-radius: 5px;
+	border: 1px solid rgba(63, 63, 63, 128);
+	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #98a2a7, stop:1 #5b646f);
 	font-size:10px;
 	color: black;
 }
@@ -400,13 +393,13 @@ QToolButton {
 /* separate corner rounding for play and stop buttons! */
 
 QToolButton#playButton {
-	border-top-left-radius: 5px 15px;
-	border-bottom-left-radius: 5px 15px;
+	border-top-left-radius: 10px 10px;
+	border-bottom-left-radius: 10px 10px;
 }
 
 QToolButton#stopButton {
-	border-top-right-radius: 5px 15px;
-	border-bottom-right-radius: 5px 15px;
+	border-top-right-radius: 10px 10px;
+	border-bottom-right-radius: 10px 10px;
 }
 
 /* record and record-accompany can be styled with #recordButton and #recordAccompanyButton respectively */
@@ -414,23 +407,19 @@ QToolButton#stopButton {
 /* all tool buttons */
 
 QToolButton:hover {
-	background: qradialgradient(cx:0.3, cy:0.3, radius:0.8, fx:0.3, fy:0.3, stop:0 #e0e0e0, stop:0.5 #c9c9c9, stop:1 #969696 );
-	border: 1px solid rgba(0,0,0,128);
+	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #c0cdd3, stop:1 #71797d);
 	color: white;
 }
 
 QToolButton:pressed {
 	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #969696, stop:0.5 #c9c9c9, stop:1 #969696 );
 	padding: 2px 1px 0px 1px;
-	border: 1px solid rgba(0,0,0,128);
 	color: white;
 }
 
 QToolButton:checked  {
 	background: qradialgradient(cx:0.3, cy:0.3, radius:0.8, fx:0.3, fy:0.3, stop:0 #e0e0e0, stop:0.8 #c9c9c9, stop:1 #c0c0c0 );
-	border-radius: 3px;
 	padding: 2px 1px 0px 1px;
-	border: 1px solid rgba(0,0,0,255);
 	color: black;
 }
 

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -44,6 +44,11 @@ class Editor : public QMainWindow
 public:
 	void setPauseIcon(bool displayPauseIcon=true);
 
+protected:
+	DropToolBar * addDropToolBarToTop(QString const & windowTitle);
+	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);
+	DropToolBar * addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle);
+
 protected slots:
 	virtual void play() {}
 	virtual void record() {}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2024,9 +2024,12 @@ AutomationEditorWindow::AutomationEditorWindow() :
 			"current pattern." ) );
 
 	// Edit mode buttons
+	DropToolBar *editActionsToolBar = addDropToolBarToTop(tr("Edit actions"));
+
 	ActionGroup* editModeGroup = new ActionGroup(this);
 	QAction* drawAction = editModeGroup->addAction(embed::getIconPixmap("edit_draw"), tr("Draw mode (Shift+D)"));
 	drawAction->setShortcut(Qt::SHIFT | Qt::Key_D);
+	drawAction->setChecked(true);
 
 	QAction* eraseAction = editModeGroup->addAction(embed::getIconPixmap("edit_erase"), tr("Erase mode (Shift+E)"));
 	eraseAction->setShortcut(Qt::SHIFT | Qt::Key_E);
@@ -2069,11 +2072,23 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	connect(editModeGroup, SIGNAL(triggered(int)), m_editor, SLOT(setEditMode(int)));
 
-	// Progression type buttons
+	editActionsToolBar->addAction(drawAction);
+	editActionsToolBar->addAction(eraseAction);
+//	editActionsToolBar->addAction(m_selectButton);
+//	editActionsToolBar->addAction(m_moveButton);
+	editActionsToolBar->addAction(m_flipXAction);
+	editActionsToolBar->addAction(m_flipYAction);
+
+
+	// Interpolation actions
+	DropToolBar *interpolationActionsToolBar = addDropToolBarToTop(tr("Interpolation controls"));
+
 	ActionGroup* progression_type_group = new ActionGroup(this);
 
 	m_discreteAction = progression_type_group->addAction(
 				embed::getIconPixmap("progression_discrete"), tr("Discrete progression"));
+	m_discreteAction->setChecked(true);
+
 	m_linearAction = progression_type_group->addAction(
 				embed::getIconPixmap("progression_linear"), tr("Linear progression"));
 	m_cubicHermiteAction = progression_type_group->addAction(
@@ -2111,7 +2126,18 @@ AutomationEditorWindow::AutomationEditorWindow() :
 			"object will change in a smooth curve and ease in to "
 			"the peaks and valleys." ) );
 
+	interpolationActionsToolBar->addSeparator();
+	interpolationActionsToolBar->addAction(m_discreteAction);
+	interpolationActionsToolBar->addAction(m_linearAction);
+	interpolationActionsToolBar->addAction(m_cubicHermiteAction);
+	interpolationActionsToolBar->addSeparator();
+	interpolationActionsToolBar->addWidget( new QLabel( tr("Tension: "), interpolationActionsToolBar ));
+	interpolationActionsToolBar->addWidget( m_tensionKnob );
+
+
+
 	// Copy paste buttons
+	/*DropToolBar *copyPasteActionsToolBar = addDropToolBarToTop(tr("Copy paste actions"));*/
 
 	QAction* cutAction = new QAction(embed::getIconPixmap("edit_cut"),
 					tr("Cut selected values (Ctrl+X)"), this);
@@ -2140,12 +2166,26 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	connect(copyAction,  SIGNAL(triggered()), m_editor, SLOT(copySelectedValues()));
 	connect(pasteAction, SIGNAL(triggered()), m_editor, SLOT(pasteValues()));
 
-	// Zoom controls
+	//	Select is broken
+	//	copyPasteActionsToolBar->addAction( cutAction );
+	//	copyPasteActionsToolBar->addAction( copyAction );
+	//	copyPasteActionsToolBar->addAction( pasteAction );
 
-	QLabel * zoom_x_label = new QLabel( m_toolBar );
+
+	DropToolBar *timeLineToolBar = addDropToolBarToTop(tr("Timeline controls"));
+	m_editor->m_timeLine->addToolButtons(timeLineToolBar);
+
+
+	addToolBarBreak();
+
+
+	// Zoom controls
+	DropToolBar *zoomToolBar = addDropToolBarToTop(tr("Zoom controls"));
+
+	QLabel * zoom_x_label = new QLabel( zoomToolBar );
 	zoom_x_label->setPixmap( embed::getIconPixmap( "zoom_x" ) );
 
-	m_zoomingXComboBox = new ComboBox( m_toolBar );
+	m_zoomingXComboBox = new ComboBox( zoomToolBar );
 	m_zoomingXComboBox->setFixedSize( 80, 22 );
 
 	for( int i = 0; i < 6; ++i )
@@ -2160,10 +2200,10 @@ AutomationEditorWindow::AutomationEditorWindow() :
 			m_editor, SLOT( zoomingXChanged() ) );
 
 
-	QLabel * zoom_y_label = new QLabel( m_toolBar );
+	QLabel * zoom_y_label = new QLabel( zoomToolBar );
 	zoom_y_label->setPixmap( embed::getIconPixmap( "zoom_y" ) );
 
-	m_zoomingYComboBox = new ComboBox( m_toolBar );
+	m_zoomingYComboBox = new ComboBox( zoomToolBar );
 	m_zoomingYComboBox->setFixedSize( 80, 22 );
 
 	m_editor->m_zoomingYModel.addItem( "Auto" );
@@ -2178,9 +2218,16 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	connect( &m_editor->m_zoomingYModel, SIGNAL( dataChanged() ),
 			m_editor, SLOT( zoomingYChanged() ) );
 
+	zoomToolBar->addWidget( zoom_x_label );
+	zoomToolBar->addWidget( m_zoomingXComboBox );
+	zoomToolBar->addSeparator();
+	zoomToolBar->addWidget( zoom_y_label );
+	zoomToolBar->addWidget( m_zoomingYComboBox );
+
 
 
 	// Quantization controls
+	DropToolBar *quantizationActionsToolBar = addDropToolBarToTop(tr("Quantization controls"));
 
 	QLabel * quantize_lbl = new QLabel( m_toolBar );
 	quantize_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
@@ -2190,40 +2237,9 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	m_quantizeComboBox->setModel( &m_editor->m_quantizeModel );
 
+	quantizationActionsToolBar->addWidget( quantize_lbl );
+	quantizationActionsToolBar->addWidget( m_quantizeComboBox );
 
-	m_toolBar->addSeparator();;
-	m_toolBar->addAction(drawAction);
-	m_toolBar->addAction(eraseAction);
-//	m_toolBar->addAction(m_selectButton);
-//	m_toolBar->addAction(m_moveButton);
-	m_toolBar->addAction(m_flipXAction);
-	m_toolBar->addAction(m_flipYAction);
-	m_toolBar->addSeparator();
-	m_toolBar->addAction(m_discreteAction);
-	m_toolBar->addAction(m_linearAction);
-	m_toolBar->addAction(m_cubicHermiteAction);
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( new QLabel( tr("Tension: "), m_toolBar ));
-	m_toolBar->addWidget( m_tensionKnob );
-	m_toolBar->addSeparator();
-//	Select is broken
-//	m_toolBar->addAction( cutAction );
-//	m_toolBar->addAction( copyAction );
-//	m_toolBar->addAction( pasteAction );
-	m_toolBar->addSeparator();
-	m_editor->m_timeLine->addToolButtons(m_toolBar);
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( zoom_x_label );
-	m_toolBar->addWidget( m_zoomingXComboBox );
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( zoom_y_label );
-	m_toolBar->addWidget( m_zoomingYComboBox );
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( quantize_lbl );
-	m_toolBar->addWidget( m_quantizeComboBox );
-
-	drawAction->setChecked(true);
-	m_discreteAction->setChecked(true);
 
 	// Setup our actual window
 	setFocusPolicy( Qt::StrongFocus );

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -82,33 +82,42 @@ BBEditor::BBEditor( BBTrackContainer* tc ) :
 		tr( "Click here to stop playing of current "
 							"beat/bassline." ) );
 
+
+	// Beat selector
+	DropToolBar *beatSelectionToolBar = addDropToolBarToTop(tr("Beat selector"));
+
 	m_bbComboBox = new ComboBox( m_toolBar );
 	m_bbComboBox->setFixedSize( 200, 22 );
 	m_bbComboBox->setModel( &tc->m_bbComboBoxModel );
 
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( m_bbComboBox );
+	beatSelectionToolBar->addWidget( m_bbComboBox );
 
-	m_toolBar->addSeparator();
-	m_toolBar->addAction(embed::getIconPixmap("add_bb_track"), tr("Add beat/bassline"),
+
+	// Track actions
+	DropToolBar *trackAndStepActionsToolBar = addDropToolBarToTop(tr("Track and step actions"));
+
+
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_bb_track"), tr("Add beat/bassline"),
 						 Engine::getSong(), SLOT(addBBTrack()));
-	m_toolBar->addAction(embed::getIconPixmap("add_automation"), tr("Add automation-track"),
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_automation"), tr("Add automation-track"),
 						 m_trackContainerView, SLOT(addAutomationTrack()));
 
 	QWidget* stretch = new QWidget(m_toolBar);
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	m_toolBar->addWidget(stretch);
+	trackAndStepActionsToolBar->addWidget(stretch);
 
-	m_toolBar->addAction(embed::getIconPixmap("step_btn_remove"), tr("Remove steps"),
+
+	// Step actions
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("step_btn_remove"), tr("Remove steps"),
 						 m_trackContainerView, SLOT(removeSteps()));
-	m_toolBar->addAction(embed::getIconPixmap("step_btn_add"), tr("Add steps"),
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("step_btn_add"), tr("Add steps"),
 						 m_trackContainerView, SLOT( addSteps()));
-	m_toolBar->addAction( embed::getIconPixmap( "step_btn_duplicate" ), tr( "Clone Steps" ),
+	trackAndStepActionsToolBar->addAction( embed::getIconPixmap( "step_btn_duplicate" ), tr( "Clone Steps" ),
 						  m_trackContainerView, SLOT( cloneSteps() ) );
-	m_toolBar->addSeparator();
 
 	connect( &tc->m_bbComboBoxModel, SIGNAL( dataChanged() ),
 			m_trackContainerView, SLOT( updatePosition() ) );
+
 
 	QAction* viewNext = new QAction(this);
 	connect(viewNext, SIGNAL(triggered()), m_bbComboBox, SLOT(selectNext()));

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -42,6 +42,27 @@ void Editor::setPauseIcon(bool displayPauseIcon)
 		m_playAction->setIcon(embed::getIconPixmap("play"));
 }
 
+DropToolBar * Editor::addDropToolBarToTop(QString const & windowTitle)
+{
+	return addDropToolBar(Qt::TopToolBarArea, windowTitle);
+}
+
+DropToolBar * Editor::addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle)
+{
+	return addDropToolBar(this, whereToAdd, windowTitle);
+}
+
+DropToolBar * Editor::addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle)
+{
+	DropToolBar *toolBar = new DropToolBar(parent);
+	addToolBar(whereToAdd, toolBar);
+	toolBar->setMovable(false);
+	toolBar->setFloatable(false);
+	toolBar->setWindowTitle(windowTitle);
+
+	return toolBar;
+}
+
 void Editor::togglePlayStop()
 {
 	if (Engine::getSong()->isPlaying())
@@ -57,8 +78,7 @@ Editor::Editor(bool record) :
 	m_recordAccompanyAction(nullptr),
 	m_stopAction(nullptr)
 {
-	m_toolBar->setContextMenuPolicy(Qt::PreventContextMenu);
-	m_toolBar->setMovable(false);
+	m_toolBar = addDropToolBarToTop(tr("Transport controls"));
 
 	auto addButton = [this](QAction* action, QString objectName) {
 		m_toolBar->addAction(action);
@@ -78,9 +98,6 @@ Editor::Editor(bool record) :
 	connect(m_recordAccompanyAction, SIGNAL(triggered()), this, SLOT(recordAccompany()));
 	connect(m_stopAction, SIGNAL(triggered()), this, SLOT(stop()));
 	new QShortcut(Qt::Key_Space, this, SLOT(togglePlayStop()));
-
-	// Add toolbar to window
-	addToolBar(Qt::TopToolBarArea, m_toolBar);
 
 	// Add actions to toolbar
 	addButton(m_playAction, "playButton");

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3906,6 +3906,8 @@ PianoRollWindow::PianoRollWindow() :
 	m_stopAction->setWhatsThis(
 		tr( "Click here to stop playback of current pattern." ) );
 
+	DropToolBar *notesActionsToolBar = addDropToolBarToTop(tr("Edit actions"));
+
 	// init edit-buttons at the top
 	ActionGroup* editModeGroup = new ActionGroup(this);
 	QAction* drawAction = editModeGroup->addAction(embed::getIconPixmap("edit_draw"), tr("Draw mode (Shift+D)"));
@@ -3945,7 +3947,14 @@ PianoRollWindow::PianoRollWindow() :
 
 	connect(editModeGroup, SIGNAL(triggered(int)), m_editor, SLOT(setEditMode(int)));
 
+	notesActionsToolBar->addAction( drawAction );
+	notesActionsToolBar->addAction( eraseAction );
+	notesActionsToolBar->addAction( selectAction );
+	notesActionsToolBar->addAction( detuneAction );
+
 	// Copy + paste actions
+	DropToolBar *copyPasteActionsToolBar =  addDropToolBarToTop(tr("Copy paste controls"));
+
 	QAction* cutAction = new QAction(embed::getIconPixmap("edit_cut"),
 							  tr("Cut selected notes (Ctrl+X)"), this);
 
@@ -3974,6 +3983,20 @@ PianoRollWindow::PianoRollWindow() :
 	connect(cutAction, SIGNAL(triggered()), m_editor, SLOT(cutSelectedNotes()));
 	connect(copyAction, SIGNAL(triggered()), m_editor, SLOT(copySelectedNotes()));
 	connect(pasteAction, SIGNAL(triggered()), m_editor, SLOT(pasteNotes()));
+
+	copyPasteActionsToolBar->addAction(cutAction);
+	copyPasteActionsToolBar->addAction(copyAction);
+	copyPasteActionsToolBar->addAction(pasteAction);
+
+
+	DropToolBar *timeLineToolBar = addDropToolBarToTop(tr("Timeline controls"));
+	m_editor->m_timeLine->addToolButtons(timeLineToolBar);
+
+
+	addToolBarBreak();
+
+
+	DropToolBar *zoomAndNotesToolBar = addDropToolBarToTop(tr("Zoom and note controls"));
 
 	QLabel * zoom_lbl = new QLabel( m_toolBar );
 	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
@@ -4017,39 +4040,24 @@ PianoRollWindow::PianoRollWindow() :
 	m_chordComboBox->setFixedSize( 105, 22 );
 
 
-	m_toolBar->addSeparator();
-	m_toolBar->addAction( drawAction );
-	m_toolBar->addAction( eraseAction );
-	m_toolBar->addAction( selectAction );
-	m_toolBar->addAction( detuneAction );
+	zoomAndNotesToolBar->addWidget( zoom_lbl );
+	zoomAndNotesToolBar->addWidget( m_zoomingComboBox );
 
-	m_toolBar->addSeparator();
-	m_toolBar->addAction( cutAction );
-	m_toolBar->addAction( copyAction );
-	m_toolBar->addAction( pasteAction );
+	zoomAndNotesToolBar->addSeparator();
+	zoomAndNotesToolBar->addWidget( quantize_lbl );
+	zoomAndNotesToolBar->addWidget( m_quantizeComboBox );
 
-	m_toolBar->addSeparator();
-	m_editor->m_timeLine->addToolButtons(m_toolBar);
+	zoomAndNotesToolBar->addSeparator();
+	zoomAndNotesToolBar->addWidget( note_len_lbl );
+	zoomAndNotesToolBar->addWidget( m_noteLenComboBox );
 
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( zoom_lbl );
-	m_toolBar->addWidget( m_zoomingComboBox );
+	zoomAndNotesToolBar->addSeparator();
+	zoomAndNotesToolBar->addWidget( scale_lbl );
+	zoomAndNotesToolBar->addWidget( m_scaleComboBox );
 
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( quantize_lbl );
-	m_toolBar->addWidget( m_quantizeComboBox );
-
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( note_len_lbl );
-	m_toolBar->addWidget( m_noteLenComboBox );
-
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( scale_lbl );
-	m_toolBar->addWidget( m_scaleComboBox );
-
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( chord_lbl );
-	m_toolBar->addWidget( m_chordComboBox );
+	zoomAndNotesToolBar->addSeparator();
+	zoomAndNotesToolBar->addWidget( chord_lbl );
+	zoomAndNotesToolBar->addWidget( m_chordComboBox );
 
 	m_zoomingComboBox->setWhatsThis(
 				tr(

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -632,6 +632,18 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_recordAccompanyAction->setToolTip(tr( "Record samples from Audio-device while playing song or BB track"));
 	m_stopAction->setToolTip(tr( "Stop song (Space)" ));
 
+	m_playAction->setWhatsThis(
+				tr("Click here, if you want to play your whole song. "
+				   "Playing will be started at the song-position-marker (green). "
+				   "You can also move it while playing."));
+	m_stopAction->setWhatsThis(
+				tr("Click here, if you want to stop playing of your song. "
+				   "The song-position-marker will be set to the start of your song."));
+
+
+	// Track actions
+	DropToolBar *trackActionsToolBar = addDropToolBarToTop(tr("Track actions"));
+
 	m_addBBTrackAction = new QAction(embed::getIconPixmap("add_bb_track"),
 									 tr("Add beat/bassline"), this);
 
@@ -645,6 +657,14 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	connect(m_addSampleTrackAction, SIGNAL(triggered()), m_editor->m_song, SLOT(addSampleTrack()));
 	connect(m_addAutomationTrackAction, SIGNAL(triggered()), m_editor->m_song, SLOT(addAutomationTrack()));
 
+	trackActionsToolBar->addAction( m_addBBTrackAction );
+	trackActionsToolBar->addAction( m_addSampleTrackAction );
+	trackActionsToolBar->addAction( m_addAutomationTrackAction );
+
+
+	// Edit actions
+	DropToolBar *editActionsToolBar = addDropToolBarToTop(tr("Edit actions"));
+
 	ActionGroup* editModeGroup = new ActionGroup(this);
 	m_drawModeAction = editModeGroup->addAction(embed::getIconPixmap("edit_draw"), tr("Draw mode"));
 	m_selectModeAction = editModeGroup->addAction(embed::getIconPixmap("edit_select"), tr("Edit mode (select and move)"));
@@ -654,15 +674,14 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	connect(m_drawModeAction, SIGNAL(triggered()), m_editor, SLOT(setEditModeDraw()));
 	connect(m_selectModeAction, SIGNAL(triggered()), m_editor, SLOT(setEditModeSelect()));
 
+	editActionsToolBar->addAction( m_drawModeAction );
+	editActionsToolBar->addAction( m_selectModeAction );
 
-	m_playAction->setWhatsThis(
-				tr("Click here, if you want to play your whole song. "
-				   "Playing will be started at the song-position-marker (green). "
-				   "You can also move it while playing."));
-	m_stopAction->setWhatsThis(
-				tr("Click here, if you want to stop playing of your song. "
-				   "The song-position-marker will be set to the start of your song."));
+	DropToolBar *timeLineToolBar = addDropToolBarToTop(tr("Timeline controls"));
+	m_editor->m_timeLine->addToolButtons(timeLineToolBar);
 
+
+	DropToolBar *zoomToolBar = addDropToolBarToTop(tr("Zoom controls"));
 
 	QLabel * zoom_lbl = new QLabel( m_toolBar );
 	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
@@ -673,19 +692,8 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_zoomingComboBox->move( 580, 4 );
 	m_zoomingComboBox->setModel(m_editor->m_zoomingModel);
 
-
-	m_toolBar->addSeparator();
-	m_toolBar->addAction( m_addBBTrackAction );
-	m_toolBar->addAction( m_addSampleTrackAction );
-	m_toolBar->addAction( m_addAutomationTrackAction );
-	m_toolBar->addSeparator();
-	m_toolBar->addAction( m_drawModeAction );
-	m_toolBar->addAction( m_selectModeAction );
-	m_toolBar->addSeparator();
-	m_editor->m_timeLine->addToolButtons(m_toolBar);
-	m_toolBar->addSeparator();
-	m_toolBar->addWidget( zoom_lbl );
-	m_toolBar->addWidget( m_zoomingComboBox );
+	zoomToolBar->addWidget( zoom_lbl );
+	zoomToolBar->addWidget( m_zoomingComboBox );
 
 	connect(song, SIGNAL(projectLoaded()), this, SLOT(adjustUiAfterProjectLoad()));
 }

--- a/src/gui/widgets/NStateButton.cpp
+++ b/src/gui/widgets/NStateButton.cpp
@@ -58,8 +58,6 @@ void NStateButton::addState( const QPixmap & _pm, const QString & _tooltip )
 	// first inserted pixmap?
 	if( m_states.size() == 1 )
 	{
-		// then resize ourself
-		setFixedSize( _pm.width() + 6, _pm.height() + 6 );
 		// and set state to first pixmap
 		changeState( 0 );
 	}
@@ -96,10 +94,3 @@ void NStateButton::mousePressEvent( QMouseEvent * _me )
 	}
 	ToolButton::mousePressEvent( _me );
 }
-
-
-
-
-
-
-

--- a/src/gui/widgets/ToolButton.cpp
+++ b/src/gui/widgets/ToolButton.cpp
@@ -39,7 +39,6 @@ ToolButton::ToolButton( const QPixmap & _pixmap, const QString & _tooltip,
 		connect( this, SIGNAL( clicked() ), _receiver, _slot );
 	}
 	ToolTip::add( this, _tooltip );
-	setFixedSize( 30, 30 );
 	setIcon( _pixmap );
 }
 
@@ -49,9 +48,3 @@ ToolButton::ToolButton( const QPixmap & _pixmap, const QString & _tooltip,
 ToolButton::~ToolButton()
 {
 }
-
-
-
-
-
-


### PR DESCRIPTION
Solves #2286 by grouping the piano roll's actions into several toolbars. There
are now five groups / tool bars: "Transport controls", "Note controls",
"Copy paste controls", "Timeline controls" and "Zoom and note controls"
(this group is a bit mixed). Each group can be turned off and on using
the standard toolbar context menu provided by Qt.

The new default layout of the toolbars saves horizontal space by putting
the "Zoom and note controls" below the other toolbars. The toolbars can
be moved but their positions are not saved. Floating toolbars are
disabled, i.e. the toolbars will always stay inside the window (top,
bottom, left, right).

![pianorollchanges-movabletoolsbars](https://cloud.githubusercontent.com/assets/9293269/9428756/25249618-49b9-11e5-9f12-4c9638e28cf1.png)