### PR TITLE
Consolidate midi config widgets & move them out of the core

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -224,10 +224,10 @@ public:
 
 	void addRecentlyOpenedProject( const QString & _file );
 
-	const QString & value( const QString & _class,
-					const QString & _attribute ) const;
-	void setValue( const QString & _class, const QString & _attribute,
-						const QString & _value );
+	const QString & value( const QString & cls,
+					const QString & attribute ) const;
+	void setValue( const QString & cls, const QString & attribute,
+						const QString & value );
 	void deleteValue( const QString & cls, const QString & attribute);
 
 	void loadConfigFile();

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -258,7 +258,6 @@ private:
 	~ConfigManager();
 
 	void upgrade_1_1_90();
-	void upgrade_1_2_0();
 	void upgrade();
 
 	const QString m_lmmsRcFile;

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -228,6 +228,7 @@ public:
 					const QString & _attribute ) const;
 	void setValue( const QString & _class, const QString & _attribute,
 						const QString & _value );
+	void deleteValue( const QString & cls, const QString & attribute);
 
 	void loadConfigFile();
 	void saveConfigFile();
@@ -256,7 +257,8 @@ private:
 	ConfigManager( const ConfigManager & _c );
 	~ConfigManager();
 
-	
+	void upgrade_1_1_90();
+	void upgrade_1_2_0();
 	void upgrade();
 
 	const QString m_lmmsRcFile;

--- a/include/MidiAlsaRaw.h
+++ b/include/MidiAlsaRaw.h
@@ -51,23 +51,14 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget",
+		return QT_TRANSLATE_NOOP( "MidiSetupWidget",
 			"ALSA Raw-MIDI (Advanced Linux Sound Architecture)" );
 	}
 
-
-	class setupWidget : public MidiClientRaw::setupWidget
+	inline static QString configSection()
 	{
-	public:
-		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
-
-		virtual void saveSettings();
-
-	private:
-		QLineEdit * m_device;
-
-	} ;
+		return "MidiAlsaRaw";
+	}
 
 
 protected:

--- a/include/MidiAlsaSeq.h
+++ b/include/MidiAlsaSeq.h
@@ -54,9 +54,14 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget",
+		return QT_TRANSLATE_NOOP( "MidiSetupWidget",
 			"ALSA-Sequencer (Advanced Linux Sound "
 							"Architecture)" );
+	}
+
+	inline static QString configSection()
+	{
+		return "Midialsaseq";
 	}
 
 
@@ -105,20 +110,6 @@ public:
 		connect( this, SIGNAL( writablePortsChanged() ),
 							_receiver, _member );
 	}
-
-
-	class setupWidget : public MidiClient::setupWidget
-	{
-	public:
-		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
-
-		virtual void saveSettings();
-
-	private:
-		QLineEdit * m_device;
-
-	} ;
 
 
 private slots:

--- a/include/MidiApple.h
+++ b/include/MidiApple.h
@@ -45,12 +45,18 @@ public:
 	MidiApple();
 	virtual ~MidiApple();
 
-	static QString probeDevice();
-
+	inline static QString probeDevice()
+	{
+		return QString::Null(); // no midi device name
+	}
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "Apple MIDI" );
+		return QT_TRANSLATE_NOOP( "MidiSetupWidget", "Apple MIDI" );
+	}
+	inline static QString configSection()
+	{
+		return QString::Null(); // no configuration settings
 	}
 	
 	virtual void processOutEvent( const MidiEvent & _me,
@@ -104,18 +110,6 @@ public:
 	{
 		return false;
 	}
-
-
-	class setupWidget : public MidiClient::setupWidget
-	{
-	public:
-		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
-
-		void saveSettings()
-		{
-		}
-	} ;
 
 
 private:// slots:

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -106,32 +106,6 @@ public:
 	// any other working
 	static MidiClient * openMidiClient();
 
-
-	class setupWidget : public TabWidget
-	{
-	public:
-		setupWidget( const QString & _caption, QWidget * _parent ) :
-			TabWidget( TabWidget::tr( "Settings for %1" ).arg(
-					tr( _caption.toLatin1() ) ).toUpper(),
-								_parent )
-		{
-		}
-
-		virtual ~setupWidget()
-		{
-		}
-
-		virtual void saveSettings() = 0;
-
-		virtual void show()
-		{
-			parentWidget()->show();
-			QWidget::show();
-		}
-
-	} ;
-
-
 protected:
 	QVector<MidiPort *> m_midiPorts;
 

--- a/include/MidiDummy.h
+++ b/include/MidiDummy.h
@@ -40,34 +40,19 @@ public:
 
 	inline static QString name()
 	{
-		return( QT_TRANSLATE_NOOP( "setupWidget",
+		return( QT_TRANSLATE_NOOP( "MidiSetupWidget",
 			"Dummy (no MIDI support)" ) );
 	}
 
-
-	class setupWidget : public MidiClient::setupWidget
+	inline static QString probeDevice()
 	{
-	public:
-		setupWidget( QWidget * _parent ) :
-			MidiClientRaw::setupWidget( MidiDummy::name(), _parent )
-		{
-		}
+		return QString::Null(); // no midi device name
+	}
 
-		virtual ~setupWidget()
-		{
-		}
-
-		virtual void saveSettings()
-		{
-		}
-
-		virtual void show()
-		{
-			parentWidget()->hide();
-			QWidget::show();
-		}
-
-	} ;
+	inline static QString configSection()
+	{
+		return QString::Null(); // no configuration settings
+	}
 
 
 protected:

--- a/include/MidiSetupWidget.h
+++ b/include/MidiSetupWidget.h
@@ -1,5 +1,5 @@
 /*
- * MidiOss.h - OSS raw MIDI client
+ * MidiSetupWidget - class for configuring midi sources in the settings window
  *
  * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -22,55 +22,35 @@
  *
  */
 
-#ifndef MIDI_OSS_H
-#define MIDI_OSS_H
+#ifndef MIDISETUPWIDGET_H
+#define MIDISETUPWIDGET_H
 
-#include "lmmsconfig.h"
+#include <QLabel>
 
-#ifdef LMMS_HAVE_OSS
-
-#include <QtCore/QThread>
-#include <QtCore/QFile>
-
-#include "MidiClient.h"
-
+#include "TabWidget.h"
 
 class QLineEdit;
 
-
-class MidiOss : public MidiClientRaw, public QThread
+class MidiSetupWidget : public TabWidget
 {
+	MidiSetupWidget( const QString & caption, const QString & configSection,
+		const QString & devName, QWidget * parent );
 public:
-	MidiOss();
-	virtual ~MidiOss();
-
-	static QString probeDevice();
-
-
-	inline static QString name()
+	// create a widget with editors for all of @MidiClientType's fields
+	template <typename MidiClientType> static MidiSetupWidget* create( QWidget * parent )
 	{
-		return( QT_TRANSLATE_NOOP( "MidiSetupWidget",
-			"OSS Raw-MIDI (Open Sound System)" ) );
+		QString configSection = MidiClientType::configSection();
+		QString dev = MidiClientType::probeDevice();
+		return new MidiSetupWidget(MidiClientType::name(), configSection, dev, parent);
 	}
 
-	inline static QString configSection()
-	{
-		return "midioss";
-	}
+	void saveSettings();
 
-protected:
-	virtual void sendByte( const unsigned char c );
-	virtual void run();
-
-
+	void show();
 private:
-	QFile m_midiDev;
+	QString m_configSection;
+	QLineEdit *m_device;
 
-	volatile bool m_quit;
-
-} ;
-
-#endif
-
+};
 
 #endif

--- a/include/MidiWinMM.h
+++ b/include/MidiWinMM.h
@@ -45,12 +45,20 @@ public:
 	MidiWinMM();
 	virtual ~MidiWinMM();
 
-	static QString probeDevice();
+	inline static QString probeDevice()
+	{
+		return QString::Null(); // no midi device name
+	}
 
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "WinMM MIDI" );
+		return QT_TRANSLATE_NOOP( "MidiSetupWidget", "WinMM MIDI" );
+	}
+
+	inline static QString configSection()
+	{
+		return QString::Null(); // no configuration settings
 	}
 
 
@@ -102,19 +110,6 @@ public:
 	{
 		return false;
 	}
-
-
-	class setupWidget : public MidiClient::setupWidget
-	{
-	public:
-		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
-
-		virtual void saveSettings()
-		{
-		}
-
-	} ;
 
 
 private:// slots:

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -32,6 +32,7 @@
 #include "lmmsconfig.h"
 #include "AudioDevice.h"
 #include "MidiClient.h"
+#include "MidiSetupWidget.h"
 
 #include "AudioDeviceSetupWidget.h"
 
@@ -181,7 +182,7 @@ private:
 	bool m_disableAutoQuit;
 
 	typedef QMap<QString, AudioDeviceSetupWidget *> AswMap;
-	typedef QMap<QString, MidiClient::setupWidget *> MswMap;
+	typedef QMap<QString, MidiSetupWidget *> MswMap;
 	typedef QMap<QString, QString> trMap;
 
 	QComboBox * m_audioInterfaces;

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -111,10 +111,7 @@ void ConfigManager::upgrade_1_1_90()
 	{
 		setValue("mixer", "audiodev", "PulseAudio");
 	}
-}
 
-void ConfigManager::upgrade_1_2_0()
-{
 	// MidiAlsaRaw used to store the device info as "Device" instead of "device"
 	if ( value( "MidiAlsaRaw", "device" ).isNull() )
 	{
@@ -130,6 +127,7 @@ void ConfigManager::upgrade_1_2_0()
 	}
 }
 
+
 void ConfigManager::upgrade()
 {
 	// Skip the upgrade if versions match
@@ -143,11 +141,6 @@ void ConfigManager::upgrade()
 	if ( createdWith.setCompareType(Build) < "1.1.90" )
 	{
 		upgrade_1_1_90();
-	}
-
-	if ( createdWith.setCompareType(Build) < "1.2.0" )
-	{
-		upgrade_1_2_0();
 	}
 	
 	// Don't use old themes as they break the UI (i.e. 0.4 != 1.0, etc)

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -277,16 +277,16 @@ void ConfigManager::addRecentlyOpenedProject( const QString & _file )
 
 
 
-const QString & ConfigManager::value( const QString & _class,
-					const QString & _attribute ) const
+const QString & ConfigManager::value( const QString & cls,
+					const QString & attribute ) const
 {
-	if( m_settings.contains( _class ) )
+	if( m_settings.contains( cls ) )
 	{
 		for( stringPairVector::const_iterator it =
-						m_settings[_class].begin();
-					it != m_settings[_class].end(); ++it )
+						m_settings[cls].begin();
+					it != m_settings[cls].end(); ++it )
 		{
-			if( ( *it ).first == _attribute )
+			if( ( *it ).first == attribute )
 			{
 				return ( *it ).second ;
 			}
@@ -299,24 +299,24 @@ const QString & ConfigManager::value( const QString & _class,
 
 
 
-void ConfigManager::setValue( const QString & _class,
-				const QString & _attribute,
-				const QString & _value )
+void ConfigManager::setValue( const QString & cls,
+				const QString & attribute,
+				const QString & value )
 {
-	if( m_settings.contains( _class ) )
+	if( m_settings.contains( cls ) )
 	{
-		for( stringPairVector::iterator it = m_settings[_class].begin();
-					it != m_settings[_class].end(); ++it )
+		for( stringPairVector::iterator it = m_settings[cls].begin();
+					it != m_settings[cls].end(); ++it )
 		{
-			if( ( *it ).first == _attribute )
+			if( ( *it ).first == attribute )
 			{
-				( *it ).second = _value;
+				( *it ).second = value;
 				return;
 			}
 		}
 	}
 	// not in map yet, so we have to add it...
-	m_settings[_class].push_back( qMakePair( _attribute, _value ) );
+	m_settings[cls].push_back( qMakePair( attribute, value ) );
 }
 
 

--- a/src/core/midi/MidiAlsaRaw.cpp
+++ b/src/core/midi/MidiAlsaRaw.cpp
@@ -22,9 +22,6 @@
  *
  */
 
-#include <QLabel>
-#include <QLineEdit>
-
 #include "MidiAlsaRaw.h"
 #include "ConfigManager.h"
 #include "gui_templates.h"
@@ -80,7 +77,7 @@ MidiAlsaRaw::~MidiAlsaRaw()
 
 QString MidiAlsaRaw::probeDevice()
 {
-	QString dev = ConfigManager::inst()->value( "MidiAlsaRaw", "Device" );
+	QString dev = ConfigManager::inst()->value( "MidiAlsaRaw", "device" );
 	if( dev == "" )
 	{
 		if( getenv( "MIDIDEV" ) != NULL )
@@ -172,37 +169,6 @@ void MidiAlsaRaw::run()
 	}
 
 }
-
-
-
-
-MidiAlsaRaw::setupWidget::setupWidget( QWidget * _parent ) :
-	MidiClientRaw::setupWidget( MidiAlsaRaw::name(), _parent )
-{
-	m_device = new QLineEdit( MidiAlsaRaw::probeDevice(), this );
-	m_device->setGeometry( 10, 20, 160, 20 );
-
-	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
-	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
-	dev_lbl->setGeometry( 10, 40, 160, 10 );
-}
-
-
-
-
-MidiAlsaRaw::setupWidget::~setupWidget()
-{
-}
-
-
-
-
-void MidiAlsaRaw::setupWidget::saveSettings()
-{
-	ConfigManager::inst()->setValue( "MidiAlsaRaw", "Device",
-							m_device->text() );
-}
-
 
 #endif
 

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -22,9 +22,6 @@
  *
  */
 
-#include <QLabel>
-#include <QLineEdit>
-
 #include "MidiAlsaSeq.h"
 #include "ConfigManager.h"
 #include "Engine.h"
@@ -700,42 +697,6 @@ void MidiAlsaSeq::updatePortList()
 		emit writablePortsChanged();
 	}
 }
-
-
-
-
-
-
-
-MidiAlsaSeq::setupWidget::setupWidget( QWidget * _parent ) :
-	MidiClient::setupWidget( MidiAlsaSeq::name(), _parent )
-{
-	m_device = new QLineEdit( MidiAlsaSeq::probeDevice(), this );
-	m_device->setGeometry( 10, 20, 160, 20 );
-
-	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
-	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
-	dev_lbl->setGeometry( 10, 40, 160, 10 );
-}
-
-
-
-
-MidiAlsaSeq::setupWidget::~setupWidget()
-{
-}
-
-
-
-
-void MidiAlsaSeq::setupWidget::saveSettings()
-{
-	ConfigManager::inst()->setValue( "Midialsaseq", "device",
-							m_device->text() );
-}
-
-
-
 
 
 #endif

--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -26,8 +26,6 @@
 
 #include "MidiApple.h"
 
-#include <QLabel>
-#include <QLineEdit>
 #include <QtAlgorithms>
 #include <algorithm>
 
@@ -622,20 +620,6 @@ char * MidiApple::getFullName(MIDIEndpointRef &endpoint_ref)
 	sprintf(fullName, "%s:%s", deviceName,endPointName);
 	return fullName;
 }
-
-
-
-MidiApple::setupWidget::setupWidget( QWidget* parent ) :
-MidiClient::setupWidget( MidiApple::name(), parent )
-{
-}
-
-
-
-MidiApple::setupWidget::~setupWidget()
-{
-}
-
 
 
 #endif

--- a/src/core/midi/MidiOss.cpp
+++ b/src/core/midi/MidiOss.cpp
@@ -28,9 +28,6 @@
 #ifdef LMMS_HAVE_OSS
 
 
-#include <QLabel>
-#include <QLineEdit>
-
 
 #ifdef LMMS_HAVE_STDLIB_H
 #include <stdlib.h>
@@ -109,38 +106,6 @@ void MidiOss::run()
 		parseData( c );
 	}
 }
-
-
-
-
-
-MidiOss::setupWidget::setupWidget( QWidget * _parent ) :
-	MidiClientRaw::setupWidget( MidiOss::name(), _parent )
-{
-	m_device = new QLineEdit( MidiOss::probeDevice(), this );
-	m_device->setGeometry( 10, 20, 160, 20 );
-
-	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
-	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
-	dev_lbl->setGeometry( 10, 40, 160, 10 );
-}
-
-
-
-
-MidiOss::setupWidget::~setupWidget()
-{
-}
-
-
-
-
-void MidiOss::setupWidget::saveSettings()
-{
-	ConfigManager::inst()->setValue( "midioss", "device",
-							m_device->text() );
-}
-
 
 
 #endif

--- a/src/core/midi/MidiWinMM.cpp
+++ b/src/core/midi/MidiWinMM.cpp
@@ -22,9 +22,6 @@
  *
  */
 
-#include <QLabel>
-#include <QLineEdit>
-
 #include "MidiWinMM.h"
 #include "ConfigManager.h"
 #include "Engine.h"
@@ -305,26 +302,6 @@ void MidiWinMM::openDevices()
 		}
 	}
 }
-
-
-
-
-MidiWinMM::setupWidget::setupWidget( QWidget* parent ) :
-	MidiClient::setupWidget( MidiWinMM::name(), parent )
-{
-}
-
-
-
-
-MidiWinMM::setupWidget::~setupWidget()
-{
-}
-
-
-
-
-
 
 
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(LMMS_SRCS
 	gui/LmmsPalette.cpp
 	gui/LmmsStyle.cpp
 	gui/MainWindow.cpp
+	gui/MidiSetupWidget.cpp
 	gui/ModelView.cpp
 	gui/PeakControllerDialog.cpp
 	gui/PianoView.cpp

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -1,0 +1,68 @@
+/*
+ * MidiSetupWidget - class for configuring midi sources in the settings window
+ *
+ * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "MidiSetupWidget.h"
+
+#include <QLineEdit>
+
+#include "ConfigManager.h"
+#include "gui_templates.h"
+
+MidiSetupWidget::MidiSetupWidget( const QString & caption, const QString & configSection,
+	const QString & devName, QWidget * parent ) :
+	TabWidget( TabWidget::tr( "Settings for %1" ).arg(
+		tr( caption.toLatin1() ) ).toUpper(), parent ),
+	m_configSection(configSection),
+	m_device(nullptr)
+{
+	// supply devName=QString::Null() (distinct from QString(""))
+	//   to indicate that there is no editable DEVICE field
+	if (!devName.isNull())
+	{
+		m_device = new QLineEdit( devName, this );
+		m_device->setGeometry( 10, 20, 160, 20 );
+
+		QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
+		dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
+		dev_lbl->setGeometry( 10, 40, 160, 10 );
+	}
+}
+
+void MidiSetupWidget::saveSettings()
+{
+	if (!m_configSection.isEmpty() && m_device)
+	{
+		ConfigManager::inst()->setValue( m_configSection, "device",
+							m_device->text() );
+	}
+}
+
+void MidiSetupWidget::show()
+{
+	// the setup widget should only be visible if the device has some configurable attributes
+	bool visible = !m_configSection.isEmpty();
+	parentWidget()->setVisible(visible);
+	QWidget::setVisible(visible);
+}
+

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -817,28 +817,28 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 
 #ifdef LMMS_HAVE_ALSA
 	m_midiIfaceSetupWidgets[MidiAlsaSeq::name()] =
-					new MidiAlsaSeq::setupWidget( msw );
+					MidiSetupWidget::create<MidiAlsaSeq>( msw );
 	m_midiIfaceSetupWidgets[MidiAlsaRaw::name()] =
-					new MidiAlsaRaw::setupWidget( msw );
+					MidiSetupWidget::create<MidiAlsaRaw>( msw );
 #endif
 
 #ifdef LMMS_HAVE_OSS
 	m_midiIfaceSetupWidgets[MidiOss::name()] =
-					new MidiOss::setupWidget( msw );
+					MidiSetupWidget::create<MidiOss>( msw );
 #endif
 
 #ifdef LMMS_BUILD_WIN32
 	m_midiIfaceSetupWidgets[MidiWinMM::name()] =
-					new MidiWinMM::setupWidget( msw );
+					MidiSetupWidget::create<MidiWinMM>( msw );
 #endif
 
 #ifdef LMMS_BUILD_APPLE
     m_midiIfaceSetupWidgets[MidiApple::name()] =
-                    new MidiApple::setupWidget( msw );
+                    MidiSetupWidget::create<MidiApple>( msw );
 #endif
 
 	m_midiIfaceSetupWidgets[MidiDummy::name()] =
-					new MidiDummy::setupWidget( msw );
+					MidiSetupWidget::create<MidiDummy>( msw );
 
 
 	for( MswMap::iterator it = m_midiIfaceSetupWidgets.begin();


### PR DESCRIPTION
This takes `MidiAlsaRaw::setupWidget`, `MidiAlsaSeq::setupWidget`, `MidiApple::setupWidget`, `MidiOss::setupWidget`, `MidiDummy::setupWidget` and `MidiWinMM::setupWidget` and implements them all through a generic `MidiSetupWidget` class.

This offers the advantage of removing a significant amount of duplicated code (thus making it easier to change the setup widget appearance for all midi backends) as well as further decoupling the core from the gui.

Behaviorally, nothing has changed except:
* Previously, MidiAlsaRaw stored its device setting under the field `ConfigManager::inst()->getValue("MidiAlsaRaw", "Device")`. Now, the field is `("MidiAlsaRaw", "device")`, using a lowercase "device" just like all the other backends. The consequence is that the user will lose their midi device setting the first time they open LMMS after applying this patch if using MidiAlsaRaw (very minor side-effect IMO).
* Previously, MidiWinMM showed a "Settings for WinMM" configuration section, despite the section being empty. This section is no longer displayed (just like with MidiDummy).


For context, all of the code changed is just responsible for showing the below "Settings for ..." section:
![lmms-midi-guicore](https://cloud.githubusercontent.com/assets/1210751/9430896/291d0a7a-49b9-11e5-84ab-95565af3b514.png)
