### PR TITLE
Increase pitch range knob limit to 60. Fixes #2250

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -112,7 +112,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 	m_panningModel( DefaultPanning, PanningLeft, PanningRight, 0.1f, this, tr( "Panning" ) ),
 	m_audioPort( tr( "unnamed_track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel ),
 	m_pitchModel( 0, MinPitchDefault, MaxPitchDefault, 1, this, tr( "Pitch" ) ),
-	m_pitchRangeModel( 1, 1, 24, this, tr( "Pitch range" ) ),
+	m_pitchRangeModel( 1, 1, 60, this, tr( "Pitch range" ) ),
 	m_effectChannelModel( 0, 0, 0, this, tr( "FX channel" ) ),
 	m_useMasterPitchModel( true, this, tr( "Master Pitch") ),
 	m_instrument( NULL ),


### PR DESCRIPTION
Quote @michaelgregorius:
> What should be the new maximum value? 36? 48? 60?

Of these, I chose 60 (= +/- 5 octaves) for this PR, which allows one to start a note at 20 Hz and sweep it all the way up to (but not further than) 20 kHz. These, conveniently, are the approximate limits of human hearing.