### PR TITLE
Fix vestige by removing linux shm and semaphores and use Qt ones. Fixes #1875

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,14 +551,24 @@ MESSAGE(
 "* GIG player                  : ${STATUS_GIG}\n"
 )
 
+#MESSAGE(
+#"\n"
+#"-----------------------------------------------------------------\n"
+#"IMPORTANT:\n"
+#"after installing missing packages, remove CMakeCache.txt before\n"
+#"running cmake again!\n"
+#"-----------------------------------------------------------------\n"
+#"\n\n")
+
+IF(LMMS_HOST_X86_64 AND LMMS_SUPPORT_VST)
 MESSAGE(
 "\n"
 "-----------------------------------------------------------------\n"
 "IMPORTANT:\n"
-"after installing missing packages, remove CMakeCache.txt before\n"
-"running cmake again!\n"
+"For VST we need 32bit QtCore libraries installed but cmake will not check for 32bit version.\n"
 "-----------------------------------------------------------------\n"
 "\n\n")
+ENDIF()
 
 INCLUDE(InstallRequiredSystemLibraries)
 

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -35,6 +35,10 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+#include <sys/types.h>
+#include <sys/shm.h>
+#include <sys/ipc.h>
+#include <semaphore.h>
 
 #ifdef LMMS_HAVE_PROCESS_H
 #include <process.h>
@@ -42,11 +46,13 @@
 #include <QtCore/QtGlobal>
 #include <QtCore/QSystemSemaphore>
 
+#include <sys/shm.h>
 #ifdef LMMS_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 #include <QtCore/QtGlobal>
 #include <QtCore/QSharedMemory>
+
 
 #if !defined(LMMS_HAVE_SYS_TYPES_H) || defined(LMMS_BUILD_WIN32)
 typedef int32_t key_t;

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -49,7 +49,6 @@
 #include <QtCore/QtGlobal>
 #include <QtCore/QSystemSemaphore>
 
-#include <sys/shm.h>
 #ifdef LMMS_HAVE_UNISTD_H
 #include <unistd.h>
 #endif

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -35,10 +35,13 @@
 #include <cstring>
 #include <string>
 #include <cassert>
+
+#if !defined(LMMS_BUILD_WIN32)
 #include <sys/types.h>
 #include <sys/shm.h>
 #include <sys/ipc.h>
 #include <semaphore.h>
+#endif
 
 #ifdef LMMS_HAVE_PROCESS_H
 #include <process.h>

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -36,37 +36,20 @@
 #include <string>
 #include <cassert>
 
-
-#if defined(LMMS_HAVE_SYS_IPC_H) && defined(LMMS_HAVE_SEMAPHORE_H)
-#include <sys/ipc.h>
-#include <semaphore.h>
-#else
-#define USE_QT_SEMAPHORES
-
 #ifdef LMMS_HAVE_PROCESS_H
 #include <process.h>
 #endif
-
 #include <QtCore/QtGlobal>
 #include <QtCore/QSystemSemaphore>
-#endif
-
-
-#ifdef LMMS_HAVE_SYS_SHM_H
-#include <sys/shm.h>
 
 #ifdef LMMS_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#else
-#define USE_QT_SHMEM
-
 #include <QtCore/QtGlobal>
 #include <QtCore/QSharedMemory>
 
 #if !defined(LMMS_HAVE_SYS_TYPES_H) || defined(LMMS_BUILD_WIN32)
 typedef int32_t key_t;
-#endif
 #endif
 
 
@@ -97,9 +80,6 @@ class shmFifo
 	// and 64 bit platforms
 	union sem32_t
 	{
-#ifndef USE_QT_SEMAPHORES
-		sem_t sem;
-#endif
 		int semKey;
 		char fill[32];
 	} ;
@@ -119,22 +99,12 @@ public:
 		m_invalid( false ),
 		m_master( true ),
 		m_shmKey( 0 ),
-#ifdef USE_QT_SHMEM
 		m_shmObj(),
-#else
-		m_shmID( -1 ),
-#endif
 		m_data( NULL ),
-#ifdef USE_QT_SEMAPHORES
 		m_dataSem( QString::null ),
 		m_messageSem( QString::null ),
-#else
-		m_dataSem( NULL ),
-		m_messageSem( NULL ),
-#endif
 		m_lockDepth( 0 )
 	{
-#ifdef USE_QT_SHMEM
 		do
 		{
 			m_shmObj.setKey( QString( "%1" ).arg( ++m_shmKey ) );
@@ -142,16 +112,8 @@ public:
 		} while( m_shmObj.error() != QSharedMemory::NoError );
 
 		m_data = (shmData *) m_shmObj.data();
-#else
-		while( ( m_shmID = shmget( ++m_shmKey, sizeof( shmData ),
-					IPC_CREAT | IPC_EXCL | 0600 ) ) == -1 )
-		{
-		}
-		m_data = (shmData *) shmat( m_shmID, 0, 0 );
-#endif
 		assert( m_data != NULL );
 		m_data->startPtr = m_data->endPtr = 0;
-#ifdef USE_QT_SEMAPHORES
 		static int k = 0;
 		m_data->dataSem.semKey = ( getpid()<<10 ) + ++k;
 		m_data->messageSem.semKey = ( getpid()<<10 ) + ++k;
@@ -160,20 +122,6 @@ public:
 		m_messageSem.setKey( QString::number(
 						m_data->messageSem.semKey ),
 						0, QSystemSemaphore::Create );
-#else
-		m_dataSem = &m_data->dataSem.sem;
-		m_messageSem = &m_data->messageSem.sem;
-
-		if( sem_init( m_dataSem, 1, 1 ) )
-		{
-			fprintf( stderr, "could not initialize m_dataSem\n" );
-		}
-		if( sem_init( m_messageSem, 1, 0 ) )
-		{
-			fprintf( stderr, "could not initialize "
-							"m_messageSem\n" );
-		}
-#endif
 	}
 
 	// constructor for remote-/client-side - use _shm_key for making up
@@ -182,59 +130,28 @@ public:
 		m_invalid( false ),
 		m_master( false ),
 		m_shmKey( 0 ),
-#ifdef USE_QT_SHMEM
 		m_shmObj( QString::number( _shm_key ) ),
-#else
-		m_shmID( shmget( _shm_key, 0, 0 ) ),
-#endif
 		m_data( NULL ),
-#ifdef USE_QT_SEMAPHORES
 		m_dataSem( QString::null ),
 		m_messageSem( QString::null ),
-#else
-		m_dataSem( NULL ),
-		m_messageSem( NULL ),
-#endif
 		m_lockDepth( 0 )
 	{
-#ifdef USE_QT_SHMEM
 		if( m_shmObj.attach() )
 		{
 			m_data = (shmData *) m_shmObj.data();
 		}
-#else
-		if( m_shmID != -1 )
-		{
-			m_data = (shmData *) shmat( m_shmID, 0, 0 );
-		}
-#endif
 		assert( m_data != NULL );
-#ifdef USE_QT_SEMAPHORES
 		m_dataSem.setKey( QString::number( m_data->dataSem.semKey ) );
 		m_messageSem.setKey( QString::number(
 						m_data->messageSem.semKey ) );
-#else
-		m_dataSem = &m_data->dataSem.sem;
-		m_messageSem = &m_data->messageSem.sem;
-#endif
 	}
 
 	~shmFifo()
 	{
-#ifndef USE_QT_SHMEM
-		shmdt( m_data );
-#endif
 		// master?
-		if( m_master )
+		/*if( m_master )
 		{
-#ifndef USE_QT_SHMEM
-			shmctl( m_shmID, IPC_RMID, NULL );
-#endif
-#ifndef USE_QT_SEMAPHORES
-			sem_destroy( m_dataSem );
-			sem_destroy( m_messageSem );
-#endif
-		}
+		}*/
 	}
 
 	inline bool isInvalid() const
@@ -258,11 +175,7 @@ public:
 	{
 		if( !isInvalid() && __sync_add_and_fetch( &m_lockDepth, 1 ) == 1 )
 		{
-#ifdef USE_QT_SEMAPHORES
 			m_dataSem.acquire();
-#else
-			sem_wait( m_dataSem );
-#endif
 		}
 	}
 
@@ -271,11 +184,7 @@ public:
 	{
 		if( __sync_sub_and_fetch( &m_lockDepth, 1) <= 0 )
 		{
-#ifdef USE_QT_SEMAPHORES
 			m_dataSem.release();
-#else
-			sem_post( m_dataSem );
-#endif
 		}
 	}
 
@@ -284,22 +193,14 @@ public:
 	{
 		if( !isInvalid() )
 		{
-#ifdef USE_QT_SEMAPHORES
 			m_messageSem.acquire();
-#else
-			sem_wait( m_messageSem );
-#endif
 		}
 	}
 
 	// increase message-semaphore
 	inline void messageSent()
 	{
-#ifdef USE_QT_SEMAPHORES
 		m_messageSem.release();
-#else
-		sem_post( m_messageSem );
-#endif
 	}
 
 
@@ -345,16 +246,10 @@ public:
 		{
 			return false;
 		}
-#ifdef USE_QT_SEMAPHORES
 		lock();
 		const bool empty = ( m_data->startPtr == m_data->endPtr );
 		unlock();
 		return !empty;
-#else
-		int v;
-		sem_getvalue( m_messageSem, &v );
-		return v > 0;
-#endif
 	}
 
 
@@ -440,19 +335,10 @@ private:
 	volatile bool m_invalid;
 	bool m_master;
 	key_t m_shmKey;
-#ifdef USE_QT_SHMEM
 	QSharedMemory m_shmObj;
-#else
-	int m_shmID;
-#endif
 	shmData * m_data;
-#ifdef USE_QT_SEMAPHORES
 	QSystemSemaphore m_dataSem;
 	QSystemSemaphore m_messageSem;
-#else
-	sem_t * m_dataSem;
-	sem_t * m_messageSem;
-#endif
 	volatile int m_lockDepth;
 
 } ;
@@ -757,11 +643,7 @@ private:
 
 	QMutex m_commMutex;
 	bool m_splitChannels;
-#ifdef USE_QT_SHMEM
 	QSharedMemory m_shmObj;
-#else
-	int m_shmID;
-#endif
 	size_t m_shmSize;
 	float * m_shm;
 
@@ -781,9 +663,7 @@ class RemotePluginClient : public RemotePluginBase
 public:
 	RemotePluginClient( key_t _shm_in, key_t _shm_out );
 	virtual ~RemotePluginClient();
-#ifdef USE_QT_SHMEM
 	VstSyncData * getQtVSTshm();
-#endif
 	virtual bool processMessage( const message & _m );
 
 	virtual void process( const sampleFrame * _in_buf,
@@ -848,10 +728,8 @@ private:
 	void setShmKey( key_t _key, int _size );
 	void doProcessing();
 
-#ifdef USE_QT_SHMEM
 	QSharedMemory m_shmObj;
 	QSharedMemory m_shmQtID;
-#endif
 	VstSyncData * m_vstSyncData;
 	float * m_shm;
 
@@ -978,10 +856,8 @@ RemotePluginBase::message RemotePluginBase::waitForMessage(
 
 RemotePluginClient::RemotePluginClient( key_t _shm_in, key_t _shm_out ) :
 	RemotePluginBase( new shmFifo( _shm_in ), new shmFifo( _shm_out ) ),
-#ifdef USE_QT_SHMEM
 	m_shmObj(),
 	m_shmQtID( "/usr/bin/lmms" ),
-#endif
 	m_vstSyncData( NULL ),
 	m_shm( NULL ),
 	m_inputCount( 0 ),
@@ -989,7 +865,6 @@ RemotePluginClient::RemotePluginClient( key_t _shm_in, key_t _shm_out ) :
 	m_sampleRate( 44100 ),
 	m_bufferSize( 0 )
 {
-#ifdef USE_QT_SHMEM
 	if( m_shmQtID.attach( QSharedMemory::ReadOnly ) )
 	{
 		m_vstSyncData = (VstSyncData *) m_shmQtID.data();
@@ -997,42 +872,6 @@ RemotePluginClient::RemotePluginClient( key_t _shm_in, key_t _shm_out ) :
 		m_sampleRate = m_vstSyncData->m_sampleRate;
 		return;
 	}
-#else
-	key_t key;
-	int m_shmID;
-
-	if( ( key = ftok( VST_SNC_SHM_KEY_FILE, 'R' ) ) == -1 )
-	{
-		perror( "RemotePluginClient::ftok" );
-	}
-	else
-	{	// connect to shared memory segment
-		if( ( m_shmID = shmget( key, 0, 0 ) ) == -1 )
-		{
-			perror( "RemotePluginClient::shmget" );
-		}
-		else
-		{	// attach segment
-			m_vstSyncData = (VstSyncData *)shmat(m_shmID, 0, 0);
-			if( m_vstSyncData == (VstSyncData *)( -1 ) )
-			{
-				perror( "RemotePluginClient::shmat" );
-			}
-			else
-			{
-				m_bufferSize = m_vstSyncData->m_bufferSize;
-				m_sampleRate = m_vstSyncData->m_sampleRate;
-
-				// detach segment
-				if( shmdt(m_vstSyncData) == -1 )
-				{
-					perror("RemotePluginClient::shmdt");
-				}
-				return;
-			}
-		}
-	}
-#endif
 	// if attaching shared memory fails
 	sendMessage( IdSampleRateInformation );
 	sendMessage( IdBufferSizeInformation );
@@ -1043,25 +882,14 @@ RemotePluginClient::RemotePluginClient( key_t _shm_in, key_t _shm_out ) :
 
 RemotePluginClient::~RemotePluginClient()
 {
-#ifdef USE_QT_SHMEM
 	m_shmQtID.detach();
-#endif
 	sendMessage( IdQuit );
-
-#ifndef USE_QT_SHMEM
-	shmdt( m_shm );
-#endif
 }
 
-
-
-#ifdef USE_QT_SHMEM
 VstSyncData * RemotePluginClient::getQtVSTshm()
 {
 	return m_vstSyncData;
 }
-#endif
-
 
 
 bool RemotePluginClient::processMessage( const message & _m )
@@ -1130,7 +958,6 @@ bool RemotePluginClient::processMessage( const message & _m )
 
 void RemotePluginClient::setShmKey( key_t _key, int _size )
 {
-#ifdef USE_QT_SHMEM
 	m_shmObj.setKey( QString::number( _key ) );
 	if( m_shmObj.attach() || m_shmObj.error() == QSharedMemory::NoError )
 	{
@@ -1142,29 +969,6 @@ void RemotePluginClient::setShmKey( key_t _key, int _size )
 		sprintf( buf, "failed getting shared memory: %d\n", m_shmObj.error() );
 		debugMessage( buf );
 	}
-#else
-	if( m_shm != NULL )
-	{
-		shmdt( m_shm );
-		m_shm = NULL;
-	}
-
-	// only called for detaching SHM?
-	if( _key == 0 )
-	{
-		return;
-	}
-
-	int shm_id = shmget( _key, _size, 0 );
-	if( shm_id == -1 )
-	{
-		debugMessage( "failed getting shared memory\n" );
-	}
-	else
-	{
-		m_shm = (float *) shmat( shm_id, 0, 0 );
-	}
-#endif
 }
 
 

--- a/plugins/vst_base/CMakeLists.txt
+++ b/plugins/vst_base/CMakeLists.txt
@@ -1,6 +1,9 @@
 IF(LMMS_SUPPORT_VST)
 
 INCLUDE(BuildPlugin)
+FIND_PACKAGE(Qt4 COMPONENTS QtCore REQUIRED)
+INCLUDE(${QT_USE_FILE})
+
 
 IF(LMMS_BUILD_WIN32)
 	ADD_DEFINITIONS(-DPTW32_STATIC_LIB)
@@ -41,7 +44,7 @@ ENDIF(LMMS_HOST_X86_64)
 ADD_CUSTOM_COMMAND(
 		SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp"
 		COMMAND ${WINE_CXX}
-		ARGS "-I\"${CMAKE_BINARY_DIR}\"" "-I\"${CMAKE_SOURCE_DIR}/include\"" "-I\"${CMAKE_INSTALL_PREFIX}/include/wine/windows\"" "-I\"${CMAKE_INSTALL_PREFIX}/include\"" -I/usr/include/wine/windows "\"${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp\"" -ansi -mwindows -lpthread ${EXTRA_FLAGS} -o RemoteVstPlugin
+ 		ARGS "-I\"${CMAKE_BINARY_DIR}\"" "-I\"${CMAKE_SOURCE_DIR}/include\"" "-I\"${CMAKE_INSTALL_PREFIX}/include/wine/windows\"" "-I\"${CMAKE_INSTALL_PREFIX}/include\"" -I/usr/include/wine/windows -I"${QT_INCLUDE_DIR}" "\"${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp\"" -ansi -mwindows -lpthread -lQtCore ${EXTRA_FLAGS} -o RemoteVstPlugin
 		COMMAND find -name RemoteVstPlugin.exe -exec mv "'{}'" RemoteVstPlugin "';'"
 		TARGET vstbase
 		OUTPUTS RemoteVstPlugin


### PR DESCRIPTION
As mentioned in the bug thread, there is still a problem.
Compiling on a Linux x64 without qt4 32bit version installed will fail with a linker error. Nothing I tried really worked to fix this so I just added a big warning in the main cmake file.

Perhaps somebody else who knows cmake better can take a stab at it.