### PR TITLE
Remove double-underscore variable prefixes & prefer static member variables over globals

### DIFF
--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -75,14 +75,13 @@ private:
 	FloatModel m_filterCutModel;
 	FloatModel m_filterResModel;
 
+	static const QString targetNames[InstrumentSoundShaping::NumTargets][3];
+
 
 	friend class InstrumentSoundShapingView;
 	friend class FlpImport;
 
 } ;
-
-
-extern const QString __targetNames[InstrumentSoundShaping::NumTargets][3];
 
 
 #endif

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -64,6 +64,14 @@ public:
 		}
 	} ;
 
+	struct FileEncodeDevice
+	{
+		ExportFileFormats m_fileFormat;
+		const char * m_description;
+		const char * m_extension;
+		AudioFileDeviceInstantiaton m_getDevInst;
+	} ;
+
 
 	ProjectRenderer( const Mixer::qualitySettings & _qs,
 				const OutputSettings & _os,
@@ -78,6 +86,8 @@ public:
 
 	static ExportFileFormats getFileFormatFromExtension(
 							const QString & _ext );
+
+	static const FileEncodeDevice fileEncodeDevices[];
 
 
 public slots:
@@ -102,17 +112,5 @@ private:
 	volatile bool m_abort;
 
 } ;
-
-
-struct FileEncodeDevice
-{
-	ProjectRenderer::ExportFileFormats m_fileFormat;
-	const char * m_description;
-	const char * m_extension;
-	AudioFileDeviceInstantiaton m_getDevInst;
-} ;
-
-
-extern FileEncodeDevice __fileEncodeDevices[];
 
 #endif

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -42,7 +42,7 @@ const float RES_PRECISION = 1000.0f;
 
 // names for env- and lfo-targets - first is name being displayed to user
 // and second one is used internally, e.g. for saving/restoring settings
-const QString __targetNames[InstrumentSoundShaping::NumTargets][3] =
+const QString InstrumentSoundShaping::targetNames[InstrumentSoundShaping::NumTargets][3] =
 {
 	{ InstrumentSoundShaping::tr( "VOLUME" ), "vol",
 			InstrumentSoundShaping::tr( "Volume" ) },
@@ -76,7 +76,7 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 										value_for_zero_amount, 
 										this );
 		m_envLfoParameters[i]->setDisplayName(
-			tr( __targetNames[i][2].toUtf8().constData() ) );
+			tr( targetNames[i][2].toUtf8().constData() ) );
 	}
 
 	m_filterModel.addItem( tr( "LowPass" ), new PixmapLoader( "filter_lp" ) );
@@ -331,7 +331,7 @@ void InstrumentSoundShaping::saveSettings( QDomDocument & _doc, QDomElement & _t
 	{
 		m_envLfoParameters[i]->saveState( _doc, _this ).setTagName(
 			m_envLfoParameters[i]->nodeName() +
-				QString( __targetNames[i][1] ).toLower() );
+				QString( targetNames[i][1] ).toLower() );
 	}
 }
 
@@ -354,7 +354,7 @@ void InstrumentSoundShaping::loadSettings( const QDomElement & _this )
 			{
 				if( node.nodeName() ==
 					m_envLfoParameters[i]->nodeName() +
-					QString( __targetNames[i][1] ).
+					QString( targetNames[i][1] ).
 								toLower() )
 				{
 					m_envLfoParameters[i]->restoreState( node.toElement() );

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -38,7 +38,7 @@
 #include "Song.h"
 
 
-static PixmapLoader __dummyLoader;
+static PixmapLoader dummyLoader;
 
 static Plugin::Descriptor dummyPluginDescriptor =
 {
@@ -48,7 +48,7 @@ static Plugin::Descriptor dummyPluginDescriptor =
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,
 	Plugin::Undefined,
-	&__dummyLoader,
+	&dummyLoader,
 	NULL
 } ;
 

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -37,7 +37,7 @@
 #endif
 #include <QMutexLocker>
 
-FileEncodeDevice __fileEncodeDevices[] =
+const ProjectRenderer::FileEncodeDevice ProjectRenderer::fileEncodeDevices[] =
 {
 
 	{ ProjectRenderer::WaveFile,
@@ -73,13 +73,13 @@ ProjectRenderer::ProjectRenderer( const Mixer::qualitySettings & _qs,
 	m_progress( 0 ),
 	m_abort( false )
 {
-	if( __fileEncodeDevices[_file_format].m_getDevInst == NULL )
+	if( fileEncodeDevices[_file_format].m_getDevInst == NULL )
 	{
 		return;
 	}
 
 	bool success_ful = false;
-	m_fileDev = __fileEncodeDevices[_file_format].m_getDevInst(
+	m_fileDev = fileEncodeDevices[_file_format].m_getDevInst(
 				_os.samplerate, DEFAULT_CHANNELS, success_ful,
 				_out_file, _os.vbr,
 				_os.bitrate, _os.bitrate - 64, _os.bitrate + 64,
@@ -109,11 +109,11 @@ ProjectRenderer::ExportFileFormats ProjectRenderer::getFileFormatFromExtension(
 							const QString & _ext )
 {
 	int idx = 0;
-	while( __fileEncodeDevices[idx].m_fileFormat != NumFileFormats )
+	while( fileEncodeDevices[idx].m_fileFormat != NumFileFormats )
 	{
-		if( QString( __fileEncodeDevices[idx].m_extension ) == _ext )
+		if( QString( fileEncodeDevices[idx].m_extension ) == _ext )
 		{
-			return( __fileEncodeDevices[idx].m_fileFormat );
+			return( fileEncodeDevices[idx].m_fileFormat );
 		}
 		++idx;
 	}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1257,9 +1257,9 @@ void Song::exportProject( bool multiExport )
 		efd.setFileMode( FileDialog::AnyFile );
 		int idx = 0;
 		QStringList types;
-		while( __fileEncodeDevices[idx].m_fileFormat != ProjectRenderer::NumFileFormats )
+		while( ProjectRenderer::fileEncodeDevices[idx].m_fileFormat != ProjectRenderer::NumFileFormats )
 		{
-			types << tr( __fileEncodeDevices[idx].m_description );
+			types << tr( ProjectRenderer::fileEncodeDevices[idx].m_description );
 			++idx;
 		}
 		efd.setNameFilters( types );
@@ -1274,7 +1274,7 @@ void Song::exportProject( bool multiExport )
 			efd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 			baseFilename = tr( "untitled" );
 		}
-		efd.selectFile( baseFilename + __fileEncodeDevices[0].m_extension );
+		efd.selectFile( baseFilename + ProjectRenderer::fileEncodeDevices[0].m_extension );
 		efd.setWindowTitle( tr( "Select file for project-export..." ) );
 	}
 

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -41,7 +41,7 @@ const int EventPollTimeOut = 250;
 
 
 // static helper functions
-static QString __portName( snd_seq_client_info_t * _cinfo,
+static QString portName( snd_seq_client_info_t * _cinfo,
 								snd_seq_port_info_t * _pinfo )
 {
 	return QString( "%1:%2 %3:%4" ).
@@ -51,7 +51,7 @@ static QString __portName( snd_seq_client_info_t * _cinfo,
 					arg( snd_seq_port_info_get_name( _pinfo ) );
 }
 
-static QString __portName( snd_seq_t * _seq, const snd_seq_addr_t * _addr )
+static QString portName( snd_seq_t * _seq, const snd_seq_addr_t * _addr )
 {
 	snd_seq_client_info_t * cinfo;
 	snd_seq_port_info_t * pinfo;
@@ -62,7 +62,7 @@ static QString __portName( snd_seq_t * _seq, const snd_seq_addr_t * _addr )
 	snd_seq_get_any_port_info( _seq, _addr->client, _addr->port, pinfo );
 	snd_seq_get_any_client_info( _seq, _addr->client, cinfo );
 
-	const QString name = __portName( cinfo, pinfo );
+	const QString name = portName( cinfo, pinfo );
 
 	snd_seq_client_info_free( cinfo );
 	snd_seq_port_info_free( pinfo );
@@ -357,7 +357,7 @@ QString MidiAlsaSeq::sourcePortName( const MidiEvent & _event ) const
 	{
 		const snd_seq_addr_t * addr =
 			static_cast<const snd_seq_addr_t *>( _event.sourcePort() );
-		return __portName( m_seqHandle, addr );
+		return portName( m_seqHandle, addr );
 	}
 	return MidiClient::sourcePortName( _event );
 }
@@ -669,7 +669,7 @@ void MidiAlsaSeq::updatePortList()
 					( SND_SEQ_PORT_CAP_READ |
 					  	SND_SEQ_PORT_CAP_SUBS_READ ) )
 			{
-				readablePorts.push_back( __portName( cinfo, pinfo ) );
+				readablePorts.push_back( portName( cinfo, pinfo ) );
 			}
 			if( ( snd_seq_port_info_get_capability( pinfo )
 			     & ( SND_SEQ_PORT_CAP_WRITE |
@@ -677,7 +677,7 @@ void MidiAlsaSeq::updatePortList()
 					( SND_SEQ_PORT_CAP_WRITE |
 					  	SND_SEQ_PORT_CAP_SUBS_WRITE ) )
 			{
-				writablePorts.push_back( __portName( cinfo, pinfo ) );
+				writablePorts.push_back( portName( cinfo, pinfo ) );
 			}
 		}
 	}

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -58,14 +58,14 @@ ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 	int cbIndex = 0;
 	for( int i = 0; i < ProjectRenderer::NumFileFormats; ++i )
 	{
-		if( __fileEncodeDevices[i].m_getDevInst != NULL )
+		if( ProjectRenderer::fileEncodeDevices[i].m_getDevInst != NULL )
 		{
 			// get the extension of this format
-			QString renderExt = __fileEncodeDevices[i].m_extension;
+			QString renderExt = ProjectRenderer::fileEncodeDevices[i].m_extension;
 
 			// add to combo box
 			fileFormatCB->addItem( ProjectRenderer::tr(
-				__fileEncodeDevices[i].m_description ) );
+				ProjectRenderer::fileEncodeDevices[i].m_description ) );
 
 			// if this is our extension, select it
 			if( QString::compare( renderExt, fileExt,
@@ -302,10 +302,10 @@ void ExportProjectDialog::startBtnClicked()
 	{
 		if( fileFormatCB->currentText() ==
 			ProjectRenderer::tr(
-				__fileEncodeDevices[i].m_description ) )
+				ProjectRenderer::fileEncodeDevices[i].m_description ) )
 		{
-			m_ft = __fileEncodeDevices[i].m_fileFormat;
-			m_fileExtension = QString( QLatin1String( __fileEncodeDevices[i].m_extension ) );
+			m_ft = ProjectRenderer::fileEncodeDevices[i].m_fileFormat;
+			m_fileExtension = QString( QLatin1String( ProjectRenderer::fileEncodeDevices[i].m_extension ) );
 			break;
 		}
 	}

--- a/src/gui/widgets/InstrumentSoundShapingView.cpp
+++ b/src/gui/widgets/InstrumentSoundShapingView.cpp
@@ -76,7 +76,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 	{
 		m_envLfoViews[i] = new EnvelopeAndLfoView( m_targetsTabWidget );
 		m_targetsTabWidget->addTab( m_envLfoViews[i],
-						tr( __targetNames[i][0].toUtf8().constData() ) );
+						tr( InstrumentSoundShaping::targetNames[i][0].toUtf8().constData() ) );
 	}
 
 


### PR DESCRIPTION
This fixes #2312 in which LMMS uses variable/function names that are reserved by the compiler.

This fix also takes some variables that were global and makes them static member variables of the most relevant class to avoid polluting the global namespace.