### PR TITLE
Fixes the units used for the flanger plugin's LFO frequency (#2319)

### DIFF
--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -52,7 +52,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
 	lfoFreqKnob->setLabel( tr( "Lfo Hz" ) );
-	lfoFreqKnob->setHintText( tr ( "Lfo:" ) , "s" );
+	lfoFreqKnob->setHintText( tr ( "Lfo:" ) , "Hz" );
 
 	Knob * lfoAmtKnob = new Knob( knobBright_26, this );
 	lfoAmtKnob->move( 86,10 );


### PR DESCRIPTION
Units have been switched from seconds to Hertz.