### PR TITLE
Make the Win32 version use SSE math

### DIFF
--- a/cmake/build_mingw32.sh
+++ b/cmake/build_mingw32.sh
@@ -3,7 +3,7 @@
 MINGW=/opt/mingw32
 export PATH=$PATH:$MINGW/bin
 #export CFLAGS="-march=pentium3 -mtune=generic -mpreferred-stack-boundary=5 -fno-tree-vectorize"
-export CFLAGS="-march=pentium3 -mtune=generic -mpreferred-stack-boundary=5"
+export CFLAGS="-march=pentium3 -mtune=generic -mpreferred-stack-boundary=5 -mfpmath=sse"
 export CXXFLAGS="$CFLAGS"
 
 if [ "$1" = "-qt5" ] ; then


### PR DESCRIPTION
This should be both safe and useful. Rationale:
* **32-bit Windows systems are still being sold**, e.g. low-end laptops may well be 32-bitters, as I discovered when shopping around in June. Saves disk space and uses less memory, I guess.
* LMMS has **protection against denormals**, which is a good thing, but it requires SSE math in its current form. See http://raine.infa.fi/pub/lmms-ladspa.html for a little benchmarking of our LADSPAs, note the differences between column 2/4 and 3/5, I'd say the trend is pretty clear. The "FTZ"-columns have protection turned on.
* LMMS has built the win32 version with ```-march=pentium3``` since December 2012, meaning **non-SSE systems haven't been supported on Windows for ages**. https://github.com/LMMS/lmms/blame/master/cmake/build_mingw32.sh. 

