### PR TITLE
Refactor FileBrowser's filterItems function

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -53,16 +53,13 @@ public:
 			QWidget * parent, bool dirs_as_items = false, bool recurse = false );
 	virtual ~FileBrowser();
 
-
-public slots:
-	void filterItems( const QString & filter );
-	void reloadTree( void );
-
 private slots:
+	void reloadTree( void );
+	// call with item=NULL to filter the entire tree
+	bool filterItems( const QString & filter, QTreeWidgetItem * item=NULL );
 	void giveFocusToFilter();
 
 private:
-	bool filterItems( QTreeWidgetItem * item, const QString & filter );
 	virtual void keyPressEvent( QKeyEvent * ke );
 
 	void addItems( const QString & path );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -120,13 +120,12 @@ FileBrowser::~FileBrowser()
 bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 {
 	// call with item=NULL to filter the entire tree
-	bool matched = false;
+	bool anyMatched = false;
 
 	int numChildren = item ? item->childCount() : m_l->topLevelItemCount();
 	for( int i = 0; i < numChildren; ++i )
 	{
 		QTreeWidgetItem * it = item ? item->child( i ) : m_l->topLevelItem(i);
-		bool cm = false;	// whether current item matched
 
 		// is directory?
 		if( it->childCount() )
@@ -138,13 +137,14 @@ bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 				// yes, then show everything below
 				it->setHidden( false );
 				filterItems( QString::null, it );
-				cm = true;
+				anyMatched = true;
 			}
 			else
 			{
 				// only show if item below matches filter
-				cm = filterItems( filter, it );
-				it->setHidden( !cm );
+				bool didMatch = filterItems( filter, it );
+				it->setHidden( !didMatch );
+				anyMatched = anyMatched || didMatch;
 			}
 		}
 		// a standard item (i.e. no file or directory item?)
@@ -156,18 +156,14 @@ bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 		else
 		{
 			// file matches filter?
-			cm = it->text( 0 ).
+			bool didMatch = it->text( 0 ).
 				contains( filter, Qt::CaseInsensitive );
-			it->setHidden( !cm );
-		}
-	
-		if( cm )
-		{
-			matched = true;
+			it->setHidden( !didMatch );
+			anyMatched = anyMatched || didMatch;
 		}
 	}
 
-	return matched;
+	return anyMatched;
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -458,35 +458,35 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 			switch( f->type() )
 			{
 				case FileItem::PresetFile:
-	new StringPairDrag( f->handling() == FileItem::LoadAsPreset ?
-					"presetfile" : "pluginpresetfile",
-				f->fullName(),
-				embed::getIconPixmap( "preset_file" ), this );
+					new StringPairDrag( f->handling() == FileItem::LoadAsPreset ?
+							"presetfile" : "pluginpresetfile",
+							f->fullName(),
+							embed::getIconPixmap( "preset_file" ), this );
 					break;
 
 				case FileItem::SampleFile:
-	new StringPairDrag( "samplefile", f->fullName(),
-				embed::getIconPixmap( "sample_file" ), this );
+					new StringPairDrag( "samplefile", f->fullName(),
+							embed::getIconPixmap( "sample_file" ), this );
 					break;
 				case FileItem::SoundFontFile:
- 	new StringPairDrag( "soundfontfile", f->fullName(),
- 				embed::getIconPixmap( "soundfont_file" ), this );
- 					break;
+					new StringPairDrag( "soundfontfile", f->fullName(),
+							embed::getIconPixmap( "soundfont_file" ), this );
+					break;
 				case FileItem::VstPluginFile:
-	new StringPairDrag( "vstpluginfile", f->fullName(),
-				embed::getIconPixmap( "vst_plugin_file" ), this );
+					new StringPairDrag( "vstpluginfile", f->fullName(),
+							embed::getIconPixmap( "vst_plugin_file" ), this );
 					break;
 				case FileItem::MidiFile:
 // don't allow dragging FLP-files as FLP import filter clears project
 // without asking
 //				case fileItem::FlpFile:
-	new StringPairDrag( "importedproject", f->fullName(),
-				embed::getIconPixmap( "midi_file" ), this );
+					new StringPairDrag( "importedproject", f->fullName(),
+							embed::getIconPixmap( "midi_file" ), this );
 					break;
-			case FileItem::ProjectFile:
-				new StringPairDrag( "projectfile", f->fullName(),
+				case FileItem::ProjectFile:
+					new StringPairDrag( "projectfile", f->fullName(),
 							embed::getIconPixmap( "project_file" ), this );
-								break;
+					break;
 
 				default:
 					break;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -120,8 +120,6 @@ FileBrowser::~FileBrowser()
 bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 {
 	// call with item=NULL to filter the entire tree
-
-	const bool showAll = filter.isEmpty();
 	bool matched = false;
 
 	int numChildren = item ? item->childCount() : m_l->topLevelItemCount();
@@ -129,17 +127,9 @@ bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 	{
 		QTreeWidgetItem * it = item ? item->child( i ) : m_l->topLevelItem(i);
 		bool cm = false;	// whether current item matched
-		// show all items if filter is empty
-		if( showAll )
-		{
-			it->setHidden( false );
-			if( it->childCount() )
-			{
-				filterItems( filter, it );
-			}
-		}
+
 		// is directory?
-		else if( it->childCount() )
+		if( it->childCount() )
 		{
 			// matches filter?
 			if( it->text( 0 ).
@@ -160,8 +150,8 @@ bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 		// a standard item (i.e. no file or directory item?)
 		else if( it->type() == QTreeWidgetItem::Type )
 		{
-			// hide in every case when filtering
-			it->setHidden( true );
+			// hide if there's any filter
+			it->setHidden( !filter.isEmpty() );
 		}
 		else
 		{

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -117,74 +117,25 @@ FileBrowser::~FileBrowser()
 
 
 
-void FileBrowser::filterItems( const QString & filter )
+bool FileBrowser::filterItems(const QString & filter, QTreeWidgetItem * item)
 {
-	const bool show_all = filter.isEmpty();
+	// call with item=NULL to filter the entire tree
 
-	for( int i = 0; i < m_l->topLevelItemCount(); ++i )
-	{
-		QTreeWidgetItem * it = m_l->topLevelItem( i );
-		// show all items if filter is empty
-		if( show_all )
-		{
-			it->setHidden( false );
-			if( it->childCount() )
-			{
-				filterItems( it, filter );
-			}
-		}
-		// is directory?
-		else if( it->childCount() )
-		{
-			// matches filter?
-			if( it->text( 0 ).
-				contains( filter, Qt::CaseInsensitive ) )
-			{
-				// yes, then show everything below
-				it->setHidden( false );
-				filterItems( it, QString::null );
-			}
-			else
-			{
-				// only show if item below matches filter
-				it->setHidden( !filterItems( it, filter ) );
-			}
-		}
-		// a standard item (i.e. no file or directory item?)
-		else if( it->type() == QTreeWidgetItem::Type )
-		{
-			// hide in every case when filtering
-			it->setHidden( true );
-		}
-		else
-		{
-			// file matches filter?
-			it->setHidden( !it->text( 0 ).
-				contains( filter, Qt::CaseInsensitive ) );
-		}
-	
-	}
-}
-
-
-
-
-bool FileBrowser::filterItems(QTreeWidgetItem * item, const QString & filter )
-{
-	const bool show_all = filter.isEmpty();
+	const bool showAll = filter.isEmpty();
 	bool matched = false;
 
-	for( int i = 0; i < item->childCount(); ++i )
+	int numChildren = item ? item->childCount() : m_l->topLevelItemCount();
+	for( int i = 0; i < numChildren; ++i )
 	{
-		QTreeWidgetItem * it = item->child( i );
+		QTreeWidgetItem * it = item ? item->child( i ) : m_l->topLevelItem(i);
 		bool cm = false;	// whether current item matched
 		// show all items if filter is empty
-		if( show_all )
+		if( showAll )
 		{
 			it->setHidden( false );
 			if( it->childCount() )
 			{
-				filterItems( it, filter );
+				filterItems( filter, it );
 			}
 		}
 		// is directory?
@@ -196,13 +147,13 @@ bool FileBrowser::filterItems(QTreeWidgetItem * item, const QString & filter )
 			{
 				// yes, then show everything below
 				it->setHidden( false );
-				filterItems( it, QString::null );
+				filterItems( QString::null, it );
 				cm = true;
 			}
 			else
 			{
 				// only show if item below matches filter
-				cm = filterItems( it, filter );
+				cm = filterItems( filter, it );
 				it->setHidden( !cm );
 			}
 		}
@@ -403,11 +354,11 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 						this,
 					SLOT( sendToActiveInstrumentTrack() ) );
 		contextMenu.addAction( tr( "Open in new instrument-track/"
-								"Song-Editor" ),
+								"Song Editor" ),
 						this,
 					SLOT( openInNewInstrumentTrackSE() ) );
 		contextMenu.addAction( tr( "Open in new instrument-track/"
-								"B+B Editor" ),
+								"Pattern Editor" ),
 						this,
 					SLOT( openInNewInstrumentTrackBBE() ) );
 		contextMenu.exec( e->globalPos() );
@@ -427,7 +378,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 	}
 
 	QTreeWidgetItem * i = itemAt( me->pos() );
-        if ( i )
+	if ( i )
 	{
 		// TODO: Restrict to visible selection
 //		if ( _me->x() > header()->cellPos( header()->mapToActual( 0 ) )


### PR DESCRIPTION
FileBrowser used to have two `filterItems` functions that shared 90% of the same code (one for filtering the root items and one for recursively filtering their children).

This PR merges these two functions to decrease the amount of duplicate code. Additionally, I made the function private instead of public and I fixed some formatting throughout the file. Lastly, I changed the context menu entries when right-clicking on presets to use "Pattern Editor" instead of "B+B Editor", to be consistent with the rest of the program.