### PR TITLE
Fixes an inconsistent behavior of the tension knob (#2333)

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2265,12 +2265,15 @@ void AutomationEditorWindow::setCurrentPattern(AutomationPattern* pattern)
 	{
 	case AutomationPattern::DiscreteProgression:
 		m_discreteAction->setChecked(true);
+		m_tensionKnob->setEnabled(false);
 		break;
 	case AutomationPattern::LinearProgression:
 		m_linearAction->setChecked(true);
+		m_tensionKnob->setEnabled(false);
 		break;
 	case AutomationPattern::CubicHermiteProgression:
 		m_cubicHermiteAction->setChecked(true);
+		m_tensionKnob->setEnabled(true);
 		break;
 	}
 


### PR DESCRIPTION
Until now the tension knob was only disabled for discrete and linear
mode if the cubic hermite mode was selected at least once. This behavior
is fixed with this commit.