### PR TITLE
Fixes the storage of the windows state for invisible windows

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -99,7 +99,7 @@ public:
 		return m_keyMods.m_alt;
 	}
 
-	static void saveWidgetState( QWidget * _w, QDomElement & _de );
+	static void saveWidgetState( QWidget * _w, QDomElement & _de, QSize const & sizeIfInvisible = QSize(0, 0) );
 	static void restoreWidgetState( QWidget * _w, const QDomElement & _de );
 
 public slots:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -701,7 +701,7 @@ void MainWindow::clearKeyModifiers()
 
 
 
-void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
+void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de, QSize const & sizeIfInvisible )
 {
 	// If our widget is the main content of a window (e.g. piano roll, FxMixer, etc), 
 	// we really care about the position of the *window* - not the position of the widget within its window
@@ -716,14 +716,17 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 	SubWindow *asSubWindow = qobject_cast<SubWindow*>(_w);
 	QRect normalGeom = asSubWindow != nullptr ? asSubWindow->getTrueNormalGeometry() : _w->normalGeometry();
 
-	_de.setAttribute( "visible", _w->isVisible() );
+	bool visible = _w->isVisible();
+	_de.setAttribute( "visible", visible );
 	_de.setAttribute( "minimized", _w->isMinimized() );
 	_de.setAttribute( "maximized", _w->isMaximized() );
 
 	_de.setAttribute( "x", normalGeom.x() );
 	_de.setAttribute( "y", normalGeom.y() );
-	_de.setAttribute( "width", normalGeom.width() );
-	_de.setAttribute( "height", normalGeom.height() );
+
+	QSize sizeToStore = visible ? normalGeom.size() : sizeIfInvisible;
+	_de.setAttribute( "width", sizeToStore.width() );
+	_de.setAttribute( "height", sizeToStore.height() );
 }
 
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -228,7 +228,7 @@ void AutomationEditor::setCurrentPattern(AutomationPattern * new_pattern )
 
 void AutomationEditor::saveSettings(QDomDocument & doc, QDomElement & dom_parent)
 {
-	MainWindow::saveWidgetState(parentWidget(), dom_parent);
+	MainWindow::saveWidgetState(parentWidget(), dom_parent, QSize( 640, 400 ));
 }
 
 

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -230,7 +230,7 @@ void BBTrackContainerView::removeBBView(int bb)
 
 void BBTrackContainerView::saveSettings(QDomDocument& doc, QDomElement& element)
 {
-	MainWindow::saveWidgetState(parentWidget(), element);
+	MainWindow::saveWidgetState(parentWidget(), element, QSize( 640, 400 ) );
 }
 
 void BBTrackContainerView::loadSettings(const QDomElement& element)

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4180,7 +4180,7 @@ void PianoRollWindow::reset()
 
 void PianoRollWindow::saveSettings(QDomDocument & doc, QDomElement & de)
 {
-	MainWindow::saveWidgetState(this, de);
+	MainWindow::saveWidgetState(this, de, QSize( 640, 480 ) );
 }
 
 void PianoRollWindow::loadSettings(const QDomElement & de)

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -265,7 +265,7 @@ SongEditor::~SongEditor()
 
 void SongEditor::saveSettings( QDomDocument& doc, QDomElement& element )
 {
-	MainWindow::saveWidgetState(parentWidget(), element);
+	MainWindow::saveWidgetState(parentWidget(), element, QSize( 640, 400 ));
 }
 
 void SongEditor::loadSettings( const QDomElement& element )

--- a/src/gui/widgets/ControllerRackView.cpp
+++ b/src/gui/widgets/ControllerRackView.cpp
@@ -103,7 +103,7 @@ ControllerRackView::~ControllerRackView()
 void ControllerRackView::saveSettings( QDomDocument & _doc,
 							QDomElement & _this )
 {
-	MainWindow::saveWidgetState( this, _this );
+	MainWindow::saveWidgetState( this, _this, QSize( 400, 300) );
 }
 
 

--- a/src/gui/widgets/ProjectNotes.cpp
+++ b/src/gui/widgets/ProjectNotes.cpp
@@ -379,7 +379,7 @@ void ProjectNotes::alignmentChanged( int _a )
 
 void ProjectNotes::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
-	MainWindow::saveWidgetState( this, _this );
+	MainWindow::saveWidgetState( this, _this, QSize( 640, 400 ) );
 
 	QDomCDATASection ds = _doc.createCDATASection( m_edit->toHtml() );
 	_this.appendChild( ds );


### PR DESCRIPTION
Until now windows/widgets that were invisible during the call to
MainWindow::saveWidgetState had their size stored as (0, 0). This
resulted in problems when the default template was created with
invisible windows because in new projects these windows then opened up
at a very small size.

This patch fixes the problem by introducing a new parameter of type
QSize to MainWindow::saveWidgetState. It can be used to communicate the
size that should be stored in case the widget that calls the method is
invisible. The code of most callers (PianoRollWindow, SongEditor, etc.)
has been updated to use good default sizes.

Fixes #2288.