### PR TITLE
Make sure desktop systems know how to pass files to lmms.

### DIFF
--- a/cmake/linux/lmms.desktop
+++ b/cmake/linux/lmms.desktop
@@ -6,7 +6,7 @@ GenericName[de]=Software zur Musik-Produktion
 Comment=easy music production for everyone!
 Comment[ca]=Producció fàcil de música per a tothom!
 Icon=lmms
-Exec=env QT_X11_NO_NATIVE_MENUBAR=1 lmms
+Exec=env QT_X11_NO_NATIVE_MENUBAR=1 lmms %f
 Terminal=false
 Type=Application
 Categories=Qt;AudioVideo;Audio;Midi;


### PR DESCRIPTION
For LMMS files to be clickable in a Linux desktop environment, there
need to be a program accepting such files as an argument.  This patch
change the lmms desktop file to affect files to open on the command line.
I did not know if lmms accepted URLs to remote files, so I went with the
safer %f for local files.

This patch originated in the Debian packaging, see for example
<URL: https://sources.debian.net/src/lmms/1.0.3-5/debian/patches/ >.