### PR TITLE
Fix build problems with gcc 5.2 in Debian.

### DIFF
--- a/plugins/LadspaEffect/swh/hermes_filter_1200.c
+++ b/plugins/LadspaEffect/swh/hermes_filter_1200.c
@@ -117,7 +117,7 @@ inline void setup_f_svf(sv_filter *sv, const float fs, const float fc) {
 
 /* Run one sample through the SV filter. Filter is by andy@vellocet */
 
-inline float run_svf(sv_filter *sv, float in) {
+static inline float run_svf(sv_filter *sv, float in) {
         float out;
         int i;
 
@@ -144,7 +144,7 @@ inline float run_svf(sv_filter *sv, float in) {
         return out;
 }
 
-inline int wave_tbl(const float wave) {
+static inline int wave_tbl(const float wave) {
         switch (f_round(wave)) {
                 case 0:
                 return BLO_SINE;

--- a/plugins/LadspaEffect/swh/imp_1199.c
+++ b/plugins/LadspaEffect/swh/imp_1199.c
@@ -63,7 +63,7 @@ typedef rfftw_plan fft_plan;
 
 #define MK_IMP(i) impulse2freq(c, i, IMP_LENGTH(i), impulse_freq[c]); c++
 
-inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
+static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
 
 #include "impulses/all.h"
 
@@ -77,7 +77,7 @@ unsigned int fft_length[IMPULSES];
 #ifdef __clang__
 void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #else
-inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #endif
 {
   fftw_real impulse_time[MAX_FFT_LENGTH];

--- a/plugins/LadspaEffect/swh/impulses/all.h
+++ b/plugins/LadspaEffect/swh/impulses/all.h
@@ -27,7 +27,7 @@
 #ifdef __clang__
 void mk_imps(fftw_real **impulse_freq)
 #else
-inline void mk_imps(fftw_real **impulse_freq)
+static inline void mk_imps(fftw_real **impulse_freq)
 #endif
 {
 	int c = 0;

--- a/plugins/LadspaEffect/swh/retro_flange_1208.c
+++ b/plugins/LadspaEffect/swh/retro_flange_1208.c
@@ -31,7 +31,7 @@ void __attribute__((constructor)) swh_init(); // forward declaration
 
 #define BASE_BUFFER 0.001 // Base buffer length (s)
 
-inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
+static inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
         if (x == q) {
                 return 1.0f / dist + q / (1.0f - f_exp(dist * q));
         }


### PR DESCRIPTION
The compiler complain about static inline functions being used from
inline functions.  This patch rewrite the inline to static inline
functions to avoid the compiler complaining.

This is related to https://bugs.debian.org/777989 and based on a patch
in the Debian packaging, see
http://anonscm.debian.org/cgit/debian-edu/pkg-team/lmms.git/tree/debian/patches .