### PR TITLE
Fix manpage formatting of AUTHOR block.

### DIFF
--- a/doc/lmms.1
+++ b/doc/lmms.1
@@ -77,4 +77,4 @@ Show usage information and exit.
 .BR https://lmms.io/documentation/
 .BR https://github.com/LMMS/lmms
 .SH AUTHORS
-.BR Tobias Doerffel <tobydox/at/users.sourceforge.net>, Paul Giblock and others. See AUTHORS for details.
+Tobias Doerffel <tobydox/at/users.sourceforge.net>, Paul Giblock and others. See AUTHORS for details.


### PR DESCRIPTION
The AUTHOR block was formatted using fixed with font and no line
break by mistake.  Change this to normal text formatting.

The problem was discovered by Debian thanks to lintian, and is fixed
there in using a local change in debian/patches/man-page-adjustment.patch.