### PR TITLE
Partially fix "Dummy" actually using ALSA

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -175,6 +175,10 @@ public:
 	{
 		return m_audioDevName;
 	}
+	inline bool audioDevStartFailed() const
+	{
+		return m_audioDevStartFailed;
+	}
 
 	void setAudioDevice( AudioDevice * _dev );
 	void setAudioDevice( AudioDevice * _dev,
@@ -421,6 +425,7 @@ private:
 	AudioDevice * m_audioDev;
 	AudioDevice * m_oldAudioDev;
 	QString m_audioDevName;
+	bool m_audioDevStartFailed;
 
 	// MIDI device stuff
 	MidiClient * m_midiClient;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -71,6 +71,7 @@ Mixer::Mixer( bool renderOnly ) :
 	m_masterGain( 1.0f ),
 	m_audioDev( NULL ),
 	m_oldAudioDev( NULL ),
+	m_audioDevStartFailed( false ),
 	m_globalMutex( QMutex::Recursive ),
 	m_profiler(),
 	m_metronomeActive(false)
@@ -717,10 +718,7 @@ AudioDevice * Mixer::tryAudioDevices()
 	AudioDevice * dev = NULL;
 	QString dev_name = ConfigManager::inst()->value( "mixer", "audiodev" );
 
-	if( dev_name == AudioDummy::name() )
-	{
-		dev_name = "";
-	}
+	m_audioDevStartFailed = false;
 
 #ifdef LMMS_HAVE_SDL
 	if( dev_name == AudioSdl::name() || dev_name == "" )
@@ -828,9 +826,14 @@ AudioDevice * Mixer::tryAudioDevices()
 	//}
 	//delete dev
 
-	printf( "No audio-driver working - falling back to dummy-audio-"
-		"driver\nYou can render your songs and listen to the output "
-		"files...\n" );
+	if( dev_name != AudioDummy::name() )
+	{
+		printf( "No audio-driver working - falling back to dummy-audio-"
+			"driver\nYou can render your songs and listen to the output "
+			"files...\n" );
+
+		m_audioDevStartFailed = true;
+	}
 
 	m_audioDevName = AudioDummy::name();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -559,10 +559,11 @@ void MainWindow::finalize()
 		SetupDialog sd;
 		sd.exec();
 	}
-	// look whether mixer could use a audio-interface beside AudioDummy
-	else if( Engine::mixer()->audioDevName() == AudioDummy::name() )
+	// look whether mixer failed to start the audio device selected by the
+	// user and is using AudioDummy as a fallback
+	else if( Engine::mixer()->audioDevStartFailed() )
 	{
-		// no, so we offer setup-dialog with audio-settings...
+		// if so, offer the audio settings section of the setup dialog
 		SetupDialog sd( SetupDialog::AudioSettings );
 		sd.exec();
 	}


### PR DESCRIPTION
Partial fix for #2349.

Even without this fix, an error opening the desired device seems to cause the setup dialog to be shown instead of simply falling back to Dummy. Also, the following message is shown on the console:
```
*** Error in `lmms': free(): invalid size: 0x00000000020169b0 ***
```