### PR TITLE
Add functionality to allow octave-marking feature mentioned in #2193.

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -198,6 +198,7 @@ private:
 	{
 		stmaUnmarkAll,
 		stmaMarkCurrentSemiTone,
+		stmaMarkAllOctaveSemiTones,
 		stmaMarkCurrentScale,
 		stmaMarkCurrentChord,
 		stmaCopyAllNotesOnKey
@@ -231,6 +232,8 @@ private:
 	void testPlayNote( Note * n );
 	void testPlayKey( int _key, int _vol, int _pan );
 	void pauseTestNotes(bool pause = true );
+
+	QList<int> getAllOctavesForKey( int keyToMirror ) const;
 
 	int noteEditTop() const;
 	int keyAreaBottom() const;


### PR DESCRIPTION
Fix declaration of return value.

Add mapping and new menu option for octave-marking of semitones.

Finish switch case for add/remove multiple octave semitones.

Fix segfault due to illogical access using iterators from one collection on another.