### PR TITLE
Move Mixer::clearAudioBuffer() to BufferManager

### DIFF
--- a/include/BufferManager.h
+++ b/include/BufferManager.h
@@ -40,6 +40,13 @@ class EXPORT BufferManager
 public:
 	static void init( fpp_t framesPerPeriod );
 	static sampleFrame * acquire();
+	// audio-buffer-mgm
+	static void clear( sampleFrame * ab, const f_cnt_t frames, 
+						const f_cnt_t offset = 0 );
+#ifndef LMMS_DISABLE_SURROUND
+	static void clear( surroundSampleFrame * ab, const f_cnt_t frames,
+						const f_cnt_t offset = 0 );
+#endif
 	static void release( sampleFrame * buf );
 	static void refresh();
 //	static void extend( int c );

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -315,16 +315,6 @@ public:
 		m_playHandleRemovalMutex.unlock();
 	}
 
-	// audio-buffer-mgm
-	static void clearAudioBuffer( sampleFrame * _ab,
-						const f_cnt_t _frames,
-						const f_cnt_t _offset = 0 );
-#ifndef LMMS_DISABLE_SURROUND
-	static void clearAudioBuffer( surroundSampleFrame * _ab,
-						const f_cnt_t _frames,
-						const f_cnt_t _offset = 0 );
-#endif
-
 	static float peakValueLeft( sampleFrame * _ab, const f_cnt_t _frames );
 	static float peakValueRight( sampleFrame * _ab, const f_cnt_t _frames );
 

--- a/src/core/BufferManager.cpp
+++ b/src/core/BufferManager.cpp
@@ -71,6 +71,22 @@ sampleFrame * BufferManager::acquire()
 }
 
 
+void BufferManager::clear( sampleFrame * ab, const f_cnt_t frames,
+							const f_cnt_t offset )
+{
+	memset( ab + offset, 0, sizeof( *ab ) * frames );
+}
+
+
+#ifndef LMMS_DISABLE_SURROUND
+void BufferManager::clear( surroundSampleFrame * ab, const f_cnt_t frames,
+							const f_cnt_t offset )
+{
+	memset( ab + offset, 0, sizeof( *ab ) * frames );
+}
+#endif
+
+
 void BufferManager::release( sampleFrame * buf )
 {
 	int i = s_releasedIndex.fetchAndAddOrdered( 1 );

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -24,6 +24,7 @@
 
 #include <QDomElement>
 
+#include "BufferManager.h"
 #include "FxMixer.h"
 #include "MixerWorkerThread.h"
 #include "MixHelpers.h"
@@ -72,8 +73,7 @@ FxChannel::FxChannel( int idx, Model * _parent ) :
 	m_queued( false ),
 	m_dependenciesMet( 0 )
 {
-	Engine::mixer()->clearAudioBuffer( m_buffer,
-					Engine::mixer()->framesPerPeriod() );
+	BufferManager::clear( m_buffer, Engine::mixer()->framesPerPeriod() );
 }
 
 
@@ -553,7 +553,7 @@ void FxMixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
 
 void FxMixer::prepareMasterMix()
 {
-	Engine::mixer()->clearAudioBuffer( m_fxChannels[0]->m_buffer,
+	BufferManager::clear( m_fxChannels[0]->m_buffer, 
 					Engine::mixer()->framesPerPeriod() );
 }
 
@@ -613,7 +613,8 @@ void FxMixer::masterMix( sampleFrame * _buf )
 	// reset channel process state
 	for( int i = 0; i < numChannels(); ++i)
 	{
-		Engine::mixer()->clearAudioBuffer( m_fxChannels[i]->m_buffer, Engine::mixer()->framesPerPeriod() );
+		BufferManager::clear( m_fxChannels[i]->m_buffer, 
+				Engine::mixer()->framesPerPeriod() );
 		m_fxChannels[i]->reset();
 		m_fxChannels[i]->m_queued = false;
 		// also reset hasInput

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -82,7 +82,7 @@ Mixer::Mixer( bool renderOnly ) :
 		m_inputBufferFrames[i] = 0;
 		m_inputBufferSize[i] = DEFAULT_BUFFER_SIZE * 100;
 		m_inputBuffer[i] = new sampleFrame[ DEFAULT_BUFFER_SIZE * 100 ];
-		clearAudioBuffer( m_inputBuffer[i], m_inputBufferSize[i] );
+		BufferManager::clear( m_inputBuffer[i], m_inputBufferSize[i] );
 	}
 
 	// determine FIFO size and number of frames per period
@@ -128,7 +128,7 @@ Mixer::Mixer( bool renderOnly ) :
 			MemoryHelper::alignedMalloc( m_framesPerPeriod *
 						sizeof( surroundSampleFrame ) );
 
-		clearAudioBuffer( m_readBuf, m_framesPerPeriod );
+		BufferManager::clear( m_readBuf, m_framesPerPeriod );
 		m_bufferPool.push_back( m_readBuf );
 	}
 
@@ -390,7 +390,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 	m_readBuf = m_bufferPool[m_readBuffer];
 
 	// clear last audio-buffer
-	clearAudioBuffer( m_writeBuf, m_framesPerPeriod );
+	BufferManager::clear( m_writeBuf, m_framesPerPeriod );
 
 	// prepare master mix (clear internal buffers etc.)
 	FxMixer * fxMixer = Engine::fxMixer();
@@ -483,25 +483,6 @@ void Mixer::clear()
 	}
 	unlock();
 }
-
-
-
-
-void Mixer::clearAudioBuffer( sampleFrame * _ab, const f_cnt_t _frames,
-							const f_cnt_t _offset )
-{
-	memset( _ab+_offset, 0, sizeof( *_ab ) * _frames );
-}
-
-
-
-#ifndef LMMS_DISABLE_SURROUND
-void Mixer::clearAudioBuffer( surroundSampleFrame * _ab, const f_cnt_t _frames,
-							const f_cnt_t _offset )
-{
-	memset( _ab+_offset, 0, sizeof( *_ab ) * _frames );
-}
-#endif
 
 
 

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -23,6 +23,8 @@
  */
 
 #include "Oscillator.h"
+
+#include "BufferManager.h"
 #include "Engine.h"
 #include "Mixer.h"
 #include "AutomatableModel.h"
@@ -57,7 +59,7 @@ void Oscillator::update( sampleFrame * _ab, const fpp_t _frames,
 {
 	if( m_freq >= Engine::mixer()->processingSampleRate() / 2 )
 	{
-		Mixer::clearAudioBuffer( _ab, _frames );
+		BufferManager::clear( _ab, _frames );
 		return;
 	}
 	if( m_subOsc != NULL )

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -28,6 +28,7 @@
 #include <QDebug>
 #endif
 
+#include "BufferManager.h"
 #include "RemotePlugin.h"
 #include "Mixer.h"
 #include "Engine.h"
@@ -168,8 +169,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf,
 	{
 		if( _out_buf != NULL )
 		{
-			Engine::mixer()->clearAudioBuffer( _out_buf,
-								frames );
+			BufferManager::clear( _out_buf, frames );
 		}
 		return false;
 	}
@@ -188,8 +188,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf,
 		}
 		if( _out_buf != NULL )
 		{
-			Engine::mixer()->clearAudioBuffer( _out_buf,
-								frames );
+			BufferManager::clear( _out_buf, frames );
 		}
 		return false;
 	}
@@ -263,7 +262,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf,
 		sampleFrame * o = (sampleFrame *) ( m_shm +
 							m_inputCount*frames );
 		// clear buffer, if plugin didn't fill up both channels
-		Engine::mixer()->clearAudioBuffer( _out_buf, frames );
+		BufferManager::clear( _out_buf, frames );
 
 		for( ch_cnt_t ch = 0; ch <
 				qMin<int>( DEFAULT_CHANNELS, outputs ); ++ch )

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -111,9 +111,9 @@ void AudioPort::doProcessing()
 
 	const fpp_t fpp = Engine::mixer()->framesPerPeriod();
 
-	m_portBuffer = BufferManager::acquire(); // get buffer for processing
-
-	Engine::mixer()->clearAudioBuffer( m_portBuffer, fpp ); // clear the audioport buffer so we can use it
+	// get a buffer por processing and clear it
+	m_portBuffer = BufferManager::acquire();
+	BufferManager::clear( m_portBuffer, fpp );
 
 	//qDebug( "Playhandles: %d", m_playHandles.size() );
 	foreach( PlayHandle * ph, m_playHandles ) // now we mix all playhandle buffers into the audioport buffer

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -111,7 +111,7 @@ void AudioPort::doProcessing()
 
 	const fpp_t fpp = Engine::mixer()->framesPerPeriod();
 
-	// get a buffer por processing and clear it
+	// get a buffer for processing and clear it
 	m_portBuffer = BufferManager::acquire();
 	BufferManager::clear( m_portBuffer, fpp );
 

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -35,6 +35,7 @@
 #include "ToolTip.h"
 #include "Song.h"
 
+#include "BufferManager.h"
 #include "ConfigManager.h"
 
 
@@ -53,7 +54,7 @@ VisualizationWidget::VisualizationWidget( const QPixmap & _bg, QWidget * _p,
 	const fpp_t frames = Engine::mixer()->framesPerPeriod();
 	m_buffer = new sampleFrame[frames];
 
-	Engine::mixer()->clearAudioBuffer( m_buffer, frames );
+	BufferManager::clear( m_buffer, frames );
 
 
 	ToolTip::add( this, tr( "click to enable/disable visualization of "


### PR DESCRIPTION
The old location of the method was a notable source of circular dependency. Thus, this is another step to reduce the coupling.

The method has been also renamed to `clear()`, as its new containing class makes it easy to deduce that it acts on audio buffers.

Sorry for the almost unrelated branch name `audiobuffercontainer`. I forgot to rename it after doing some experiments.