### PR TITLE
Partially decouple VisualizationWidget from Mixer

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -400,8 +400,6 @@ private:
 
 	fpp_t m_framesPerPeriod;
 
-	sampleFrame * m_workingBuf;
-
 	sampleFrame * m_inputBuffer[2];
 	f_cnt_t m_inputBufferFrames[2];
 	f_cnt_t m_inputBufferSize[2];

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -231,11 +231,6 @@ public:
 		return m_framesPerPeriod;
 	}
 
-	inline const surroundSampleFrame * currentReadBuffer() const
-	{
-		return m_readBuf;
-	}
-
 
 	MixerProfiler& profiler()
 	{
@@ -362,7 +357,7 @@ public:
 signals:
 	void qualitySettingsChanged();
 	void sampleRateChanged();
-	void nextAudioBuffer();
+	void nextAudioBuffer( const surroundSampleFrame * buffer );
 
 
 private:

--- a/include/VisualizationWidget.h
+++ b/include/VisualizationWidget.h
@@ -54,7 +54,7 @@ protected:
 
 
 protected slots:
-	void updateAudioBuffer();
+	void updateAudioBuffer( const surroundSampleFrame * buffer );
 
 
 private:

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -447,7 +447,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 	unlock();
 
 
-	emit nextAudioBuffer();
+	emit nextAudioBuffer( m_readBuf );
 
 	// and trigger LFOs
 	EnvelopeAndLfoParameters::instances()->trigger();

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -61,7 +61,6 @@
 
 Mixer::Mixer( bool renderOnly ) :
 	m_framesPerPeriod( DEFAULT_BUFFER_SIZE ),
-	m_workingBuf( NULL ),
 	m_inputBufferRead( 0 ),
 	m_inputBufferWrite( 1 ),
 	m_readBuf( NULL ),
@@ -119,8 +118,6 @@ Mixer::Mixer( bool renderOnly ) :
 	// now that framesPerPeriod is fixed initialize global BufferManager
 	BufferManager::init( m_framesPerPeriod );
 
-	m_workingBuf = (sampleFrame*) MemoryHelper::alignedMalloc( m_framesPerPeriod *
-							sizeof( sampleFrame ) );
 	for( int i = 0; i < 3; i++ )
 	{
 		m_readBuf = (surroundSampleFrame*)
@@ -176,8 +173,6 @@ Mixer::~Mixer()
 	{
 		MemoryHelper::alignedFree( m_bufferPool[i] );
 	}
-
-	MemoryHelper::alignedFree( m_workingBuf );
 
 	for( int i = 0; i < 2; ++i )
 	{

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -72,14 +72,12 @@ VisualizationWidget::~VisualizationWidget()
 
 
 
-void VisualizationWidget::updateAudioBuffer()
+void VisualizationWidget::updateAudioBuffer( const surroundSampleFrame * buffer )
 {
 	if( !Engine::getSong()->isExporting() )
 	{
-		const surroundSampleFrame * c = Engine::mixer()->
-							currentReadBuffer();
 		const fpp_t fpp = Engine::mixer()->framesPerPeriod();
-		memcpy( m_buffer, c, sizeof( surroundSampleFrame ) * fpp );
+		memcpy( m_buffer, buffer, sizeof( surroundSampleFrame ) * fpp );
 	}
 }
 
@@ -95,8 +93,8 @@ void VisualizationWidget::setActive( bool _active )
 					SIGNAL( periodicUpdate() ),
 					this, SLOT( update() ) );
 		connect( Engine::mixer(),
-					SIGNAL( nextAudioBuffer() ),
-				this, SLOT( updateAudioBuffer() ) );
+			SIGNAL( nextAudioBuffer( const surroundSampleFrame* ) ),
+			this, SLOT( updateAudioBuffer( const surroundSampleFrame* ) ) );
 	}
 	else
 	{
@@ -104,8 +102,8 @@ void VisualizationWidget::setActive( bool _active )
 					SIGNAL( periodicUpdate() ),
 					this, SLOT( update() ) );
 		disconnect( Engine::mixer(),
-					SIGNAL( nextAudioBuffer() ),
-				this, SLOT( updateAudioBuffer() ) );
+			SIGNAL( nextAudioBuffer( const surroundSampleFrame* ) ),
+			this, SLOT( updateAudioBuffer( const surroundSampleFrame* ) ) );
 		// we have to update (remove last waves),
 		// because timer doesn't do that anymore
 		update();


### PR DESCRIPTION
Partially decouple `VisualizationWidget` from `Mixer` with the help of a Qt signal. Also remove the now unused `Mixer::currentReadBuffer()`.

At present, the dependency of `VisualizationWidget` on `Mixer::samplesPerFrame()` will be left there because many different objects depend on this method and it is better to decide what to do in the future.

The second commit additionally removes `Mixer::m_workingBuf`, which is an unused dynamically allocated memory area.