### PR TITLE
Disables automations for some widgets (mostly ComboBoxes)

### DIFF
--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -68,6 +68,8 @@ public:
 
 	void addDefaultActions( QMenu* menu );
 
+	inline void enableAutomations( bool value ) { m_enableAutomations = value; }
+	inline bool automationsEnabled() const { return m_enableAutomations; }
 
 protected:
 	virtual void mousePressEvent( QMouseEvent* event );
@@ -75,6 +77,7 @@ protected:
 	QString m_description;
 	QString m_unit;
 
+	bool m_enableAutomations;
 } ;
 
 

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -41,7 +41,8 @@
 AutomatableModelView::AutomatableModelView( ::Model* model, QWidget* _this ) :
 	ModelView( model, _this ),
 	m_description( QString::null ),
-	m_unit( QString::null )
+	m_unit( QString::null ),
+	m_enableAutomations( true )
 {
 	widget()->setAcceptDrops( true );
 	widget()->setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
@@ -147,7 +148,7 @@ void AutomatableModelView::setModel( Model* model, bool isOldModelValid )
 
 void AutomatableModelView::mousePressEvent( QMouseEvent* event )
 {
-	if( event->button() == Qt::LeftButton && event->modifiers() & Qt::ControlModifier )
+	if( event->button() == Qt::LeftButton && event->modifiers() & Qt::ControlModifier && automationsEnabled() )
 	{
 		new StringPairDrag( "automatable_model", QString::number( modelUntyped()->id() ), QPixmap(), widget() );
 		event->accept();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2099,6 +2099,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	// setup tension-stuff
 	m_tensionKnob = new Knob( knobSmall_17, this, "Tension" );
 	m_tensionKnob->setModel(m_editor->m_tensionModel);
+	m_tensionKnob->enableAutomations( false );
 	ToolTip::add(m_tensionKnob, tr("Tension value for spline"));
 	m_tensionKnob->setWhatsThis(
 				tr("A higher tension value may make a smoother curve "
@@ -2187,6 +2188,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	m_zoomingXComboBox = new ComboBox( zoomToolBar );
 	m_zoomingXComboBox->setFixedSize( 80, 22 );
+	m_zoomingXComboBox->enableAutomations( false );
 
 	for( int i = 0; i < 6; ++i )
 	{
@@ -2205,6 +2207,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	m_zoomingYComboBox = new ComboBox( zoomToolBar );
 	m_zoomingYComboBox->setFixedSize( 80, 22 );
+	m_zoomingYComboBox->enableAutomations( false );
 
 	m_editor->m_zoomingYModel.addItem( "Auto" );
 	for( int i = 0; i < 7; ++i )
@@ -2234,6 +2237,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	m_quantizeComboBox = new ComboBox( m_toolBar );
 	m_quantizeComboBox->setFixedSize( 60, 22 );
+	m_quantizeComboBox->enableAutomations( false );
 
 	m_quantizeComboBox->setModel( &m_editor->m_quantizeModel );
 

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -88,6 +88,7 @@ BBEditor::BBEditor( BBTrackContainer* tc ) :
 
 	m_bbComboBox = new ComboBox( m_toolBar );
 	m_bbComboBox->setFixedSize( 200, 22 );
+	m_bbComboBox->enableAutomations( false );
 	m_bbComboBox->setModel( &tc->m_bbComboBoxModel );
 
 	beatSelectionToolBar->addWidget( m_bbComboBox );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4063,6 +4063,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_zoomingComboBox = new ComboBox( m_toolBar );
 	m_zoomingComboBox->setModel( &m_editor->m_zoomingModel );
 	m_zoomingComboBox->setFixedSize( 64, 22 );
+	m_zoomingComboBox->enableAutomations( false );
 
 	// setup quantize-stuff
 	QLabel * quantize_lbl = new QLabel( m_toolBar );
@@ -4071,6 +4072,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_quantizeComboBox = new ComboBox( m_toolBar );
 	m_quantizeComboBox->setModel( &m_editor->m_quantizeModel );
 	m_quantizeComboBox->setFixedSize( 64, 22 );
+	m_quantizeComboBox->enableAutomations( false );
 
 
 	// setup note-len-stuff
@@ -4081,6 +4083,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_noteLenComboBox = new ComboBox( m_toolBar );
 	m_noteLenComboBox->setModel( &m_editor->m_noteLenModel );
 	m_noteLenComboBox->setFixedSize( 105, 22 );
+	m_noteLenComboBox->enableAutomations( false );
 
 	// setup scale-stuff
 	QLabel * scale_lbl = new QLabel( m_toolBar );
@@ -4089,6 +4092,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_scaleComboBox = new ComboBox( m_toolBar );
 	m_scaleComboBox->setModel( &m_editor->m_scaleModel );
 	m_scaleComboBox->setFixedSize( 105, 22 );
+	m_scaleComboBox->enableAutomations( false );
 
 	// setup chord-stuff
 	QLabel * chord_lbl = new QLabel( m_toolBar );
@@ -4097,6 +4101,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_chordComboBox = new ComboBox( m_toolBar );
 	m_chordComboBox->setModel( &m_editor->m_chordModel );
 	m_chordComboBox->setFixedSize( 105, 22 );
+	m_chordComboBox->enableAutomations( false );
 
 
 	zoomAndNotesToolBar->addWidget( zoom_lbl );

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -688,6 +688,7 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	// setup zooming-stuff
 	m_zoomingComboBox = new ComboBox( m_toolBar );
+	m_zoomingComboBox->enableAutomations( false );
 	m_zoomingComboBox->setFixedSize( 80, 22 );
 	m_zoomingComboBox->move( 580, 4 );
 	m_zoomingComboBox->setModel(m_editor->m_zoomingModel);

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -129,9 +129,12 @@ void ComboBox::contextMenuEvent( QContextMenuEvent * event )
 		return;
 	}
 
-	CaptionMenu contextMenu( model()->displayName() );
-	addDefaultActions( &contextMenu );
-	contextMenu.exec( QCursor::pos() );
+	if ( automationsEnabled() )
+	{
+		CaptionMenu contextMenu( model()->displayName() );
+		addDefaultActions( &contextMenu );
+		contextMenu.exec( QCursor::pos() );
+	}
 }
 
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -483,14 +483,17 @@ void Knob::contextMenuEvent( QContextMenuEvent * )
 	// an QApplication::restoreOverrideCursor()-call...
 	mouseReleaseEvent( NULL );
 
-	CaptionMenu contextMenu( model()->displayName(), this );
-	addDefaultActions( &contextMenu );
-	contextMenu.addAction( QPixmap(),
-		model()->isScaleLogarithmic() ? tr( "Set linear" ) : tr( "Set logarithmic" ),
-		this, SLOT( toggleScale() ) );
-	contextMenu.addSeparator();
-	contextMenu.addHelpAction();
-	contextMenu.exec( QCursor::pos() );
+	if ( automationsEnabled() )
+	{
+		CaptionMenu contextMenu( model()->displayName(), this );
+		addDefaultActions( &contextMenu );
+		contextMenu.addAction( QPixmap(),
+			model()->isScaleLogarithmic() ? tr( "Set linear" ) : tr( "Set logarithmic" ),
+			this, SLOT( toggleScale() ) );
+		contextMenu.addSeparator();
+		contextMenu.addHelpAction();
+		contextMenu.exec( QCursor::pos() );
+	}
 }
 
 


### PR DESCRIPTION
Extends `AutomatableModelView` by a new method to enable or disable
automations. The state of the variable is taken into account with
regards to the ability to drag & drop automations and to show the
context menu in the classes `ComboBox` and `Knob`.

Disables automations for all `ComboBoxes` in the editors (Song-Editor,
Piano Roll, Automation-Editor and BB-Editor).

Also disables automations for the tension knob in the Automation-Editor.

Fixes issue #2382
