### PR TITLE
Removes an unnecessary warning in MemoryManager::free

### DIFF
--- a/src/core/MemoryManager.cpp
+++ b/src/core/MemoryManager.cpp
@@ -105,10 +105,9 @@ void * MemoryManager::alloc( size_t size )
 
 void MemoryManager::free( void * ptr )
 {
-	if( ptr == NULL )
+	if( !ptr )
 	{
-		qDebug( "MemoryManager: Null pointer deallocation attempted" );
-		return; // let's not try to deallocate null pointers, ok?
+		return; // Null pointer deallocations are OK but do not need to be handled
 	}
 
 	// fetch info on the ptr and remove


### PR DESCRIPTION
Removes the warning "MemoryManager: Null pointer deallocation attempted"
from `MemoryManager`. The warning does not make sense because
deallocations of null pointers are ok in C++.

Fixes #2023.