### PR TITLE
EffectChain: check if effect exists before removing

### DIFF
--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -133,10 +133,20 @@ void EffectChain::appendEffect( Effect * _effect )
 void EffectChain::removeEffect( Effect * _effect )
 {
 	Engine::mixer()->lock();
-	m_effects.erase( qFind( m_effects.begin(), m_effects.end(), _effect ) );
-	Engine::mixer()->unlock();
 
+	Effect ** found = qFind( m_effects.begin(), m_effects.end(), _effect );
+	if( found == m_effects.end() )
+	{
+		goto fail;
+	}
+	m_effects.erase( found );
+
+	Engine::mixer()->unlock();
 	emit dataChanged();
+	return;
+
+fail:
+	Engine::mixer()->unlock();
 }
 
 
@@ -261,8 +271,3 @@ void EffectChain::clear()
 	}
 	m_effects.clear();
 }
-
-
-
-
-


### PR DESCRIPTION
There are two ways to remove a peak controller: either from the controller rack or from its effect chain. This adds a safety check to `EffectChain::removeEffect()` to break the circular dependency described in #2407.