### PR TITLE
Fix missing scroll back when stop in Song Editor

### DIFF
--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -72,7 +72,7 @@ public:
 public slots:
 	void scrolled( int new_pos );
 
-	void setEditMode(EditMode mode);
+	void setEditMode( EditMode mode );
 	void setEditModeDraw();
 	void setEditModeSelect();
 
@@ -137,7 +137,7 @@ class SongEditorWindow : public Editor
 {
 	Q_OBJECT
 public:
-	SongEditorWindow(Song* song);
+	SongEditorWindow( Song* song );
 
 	QSize sizeHint() const;
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -76,6 +76,8 @@ public slots:
 	void setEditModeDraw();
 	void setEditModeSelect();
 
+	void updatePosition( const MidiTime & _t );
+
 protected:
 	virtual void closeEvent( QCloseEvent * _ce );
 
@@ -93,7 +95,6 @@ private slots:
 	void hideMasterPitchFloat();
 
 	void updateScrollBar( int );
-	void updatePosition( const MidiTime & _t );
 
 	void zoomingChanged();
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -45,10 +45,10 @@ class TimeLineWidget;
 class positionLine : public QWidget
 {
 public:
-	positionLine( QWidget * _parent );
+	positionLine( QWidget * parent );
 
 private:
-	virtual void paintEvent( QPaintEvent * _pe );
+	virtual void paintEvent( QPaintEvent * pe );
 
 } ;
 
@@ -63,44 +63,44 @@ public:
 		SelectMode
 	};
 
-	SongEditor( Song * _song );
+	SongEditor( Song * song );
 	~SongEditor();
 
 	void saveSettings( QDomDocument& doc, QDomElement& element );
 	void loadSettings( const QDomElement& element );
 
 public slots:
-	void scrolled( int _new_pos );
+	void scrolled( int new_pos );
 
 	void setEditMode(EditMode mode);
 	void setEditModeDraw();
 	void setEditModeSelect();
 
-	void updatePosition( const MidiTime & _t );
+	void updatePosition( const MidiTime & t );
 
 protected:
-	virtual void closeEvent( QCloseEvent * _ce );
+	virtual void closeEvent( QCloseEvent * ce );
 
 private slots:
 	void setHighQuality( bool );
 
-	void setMasterVolume( int _new_val );
+	void setMasterVolume( int new_val );
 	void showMasterVolumeFloat();
-	void updateMasterVolumeFloat( int _new_val );
+	void updateMasterVolumeFloat( int new_val );
 	void hideMasterVolumeFloat();
 
-	void setMasterPitch( int _new_val );
+	void setMasterPitch( int new_val );
 	void showMasterPitchFloat();
-	void updateMasterPitchFloat( int _new_val );
+	void updateMasterPitchFloat( int new_val );
 	void hideMasterPitchFloat();
 
-	void updateScrollBar( int );
+	void updateScrollBar(int len);
 
 	void zoomingChanged();
 
 private:
-	virtual void keyPressEvent( QKeyEvent * _ke );
-	virtual void wheelEvent( QWheelEvent * _we );
+	virtual void keyPressEvent( QKeyEvent * ke );
+	virtual void wheelEvent( QWheelEvent * we );
 
 	virtual bool allowRubberband() const;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -610,7 +610,6 @@ void Song::stop()
 	}
 
 	TimeLineWidget * tl = m_playPos[m_playMode].m_timeLine;
-	m_playing = false;
 	m_paused = false;
 	m_recording = true;
 
@@ -625,7 +624,7 @@ void Song::stop()
 				if( gui && gui->songEditor() &&
 						( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 				{
-					gui->songEditor()->m_editor->scrolled( 0 );
+					gui->songEditor()->m_editor->updatePosition(0);
 				}
 				break;
 
@@ -636,13 +635,12 @@ void Song::stop()
 					m_elapsedMilliSeconds = 
 						( ( ( tl->savedPos().getTicks() ) * 60 * 1000 / 48 ) / 
 							getTempo() );
-					tl->savePos( -1 );
 					if( gui && gui->songEditor() &&
 							( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 					{
-						gui->songEditor()->m_editor->scrolled( m_playPos[m_playMode].getTicks() /
-							m_playPos[m_playMode].ticksPerTact() );
+						gui->songEditor()->m_editor->updatePosition( MidiTime(tl->savedPos().getTicks() ) );
 					}
+					tl->savePos( -1 );
 				}
 				break;
 
@@ -656,6 +654,7 @@ void Song::stop()
 		m_playPos[m_playMode].setTicks( 0 );
 		m_elapsedMilliSeconds = 0;
 	}
+	m_playing = false;
 
 	m_playPos[m_playMode].setCurrentFrame( 0 );
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -622,7 +622,8 @@ void Song::stop()
 			case TimeLineWidget::BackToZero:
 				m_playPos[m_playMode].setTicks( 0 );
 				m_elapsedMilliSeconds = 0;
-				if( gui && gui->songEditor() )
+				if( gui && gui->songEditor() &&
+						( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 				{
 					gui->songEditor()->m_editor->scrolled( 0 );
 				}
@@ -636,7 +637,8 @@ void Song::stop()
 						( ( ( tl->savedPos().getTicks() ) * 60 * 1000 / 48 ) / 
 							getTempo() );
 					tl->savePos( -1 );
-					if( gui && gui->songEditor() )
+					if( gui && gui->songEditor() &&
+							( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 					{
 						gui->songEditor()->m_editor->scrolled( m_playPos[m_playMode].getTicks() /
 							m_playPos[m_playMode].ticksPerTact() );

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -622,6 +622,10 @@ void Song::stop()
 			case TimeLineWidget::BackToZero:
 				m_playPos[m_playMode].setTicks( 0 );
 				m_elapsedMilliSeconds = 0;
+				if( gui && gui->songEditor() )
+				{
+					gui->songEditor()->m_editor->scrolled( 0 );
+				}
 				break;
 
 			case TimeLineWidget::BackToStart:
@@ -632,6 +636,11 @@ void Song::stop()
 						( ( ( tl->savedPos().getTicks() ) * 60 * 1000 / 48 ) / 
 							getTempo() );
 					tl->savePos( -1 );
+					if( gui && gui->songEditor() )
+					{
+						gui->songEditor()->m_editor->scrolled( m_playPos[m_playMode].getTicks() /
+							m_playPos[m_playMode].ticksPerTact() );
+					}
 				}
 				break;
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -57,8 +57,8 @@
 
 
 
-positionLine::positionLine( QWidget * _parent ) :
-	QWidget( _parent )
+positionLine::positionLine(QWidget * parent ) :
+	QWidget( parent )
 {
 	setFixedWidth( 1 );
 	setAttribute( Qt::WA_NoSystemBackground, true );
@@ -67,7 +67,7 @@ positionLine::positionLine( QWidget * _parent ) :
 
 
 
-void positionLine::paintEvent( QPaintEvent * _pe )
+void positionLine::paintEvent(QPaintEvent * pe )
 {
 	QPainter p( this );
 	p.fillRect( rect(), QColor( 255, 255, 255, 153 ) );
@@ -76,9 +76,9 @@ void positionLine::paintEvent( QPaintEvent * _pe )
 
 
 
-SongEditor::SongEditor( Song * _song ) :
-	TrackContainerView( _song ),
-	m_song( _song ),
+SongEditor::SongEditor(Song * song ) :
+	TrackContainerView( song ),
+	m_song( song ),
 	m_zoomingModel(new ComboBoxModel()),
 	m_scrollBack( false ),
 	m_smoothScroll( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() ),
@@ -276,20 +276,20 @@ void SongEditor::loadSettings( const QDomElement& element )
 
 
 
-void SongEditor::setHighQuality( bool _hq )
+void SongEditor::setHighQuality( bool hq )
 {
 	Engine::mixer()->changeQuality( Mixer::qualitySettings(
-			_hq ? Mixer::qualitySettings::Mode_HighQuality :
+			hq ? Mixer::qualitySettings::Mode_HighQuality :
 				Mixer::qualitySettings::Mode_Draft ) );
 }
 
 
 
 
-void SongEditor::scrolled( int _new_pos )
+void SongEditor::scrolled(int new_pos )
 {
 	update();
-	emit positionChanged( m_currentPosition = MidiTime( _new_pos, 0 ) );
+	emit positionChanged( m_currentPosition = MidiTime( new_pos, 0 ) );
 }
 
 
@@ -313,21 +313,21 @@ void SongEditor::setEditModeSelect()
 
 
 
-void SongEditor::keyPressEvent( QKeyEvent * _ke )
+void SongEditor::keyPressEvent(QKeyEvent * ke )
 {
 	if( /*_ke->modifiers() & Qt::ShiftModifier*/
 		gui->mainWindow()->isShiftPressed() == true &&
-						_ke->key() == Qt::Key_Insert )
+						ke->key() == Qt::Key_Insert )
 	{
 		m_song->insertBar();
 	}
 	else if(/* _ke->modifiers() & Qt::ShiftModifier &&*/
 			gui->mainWindow()->isShiftPressed() == true &&
-						_ke->key() == Qt::Key_Delete )
+						ke->key() == Qt::Key_Delete )
 	{
 		m_song->removeBar();
 	}
-	else if( _ke->key() == Qt::Key_Left )
+	else if( ke->key() == Qt::Key_Left )
 	{
 		tick_t t = m_song->currentTick() - MidiTime::ticksPerTact();
 		if( t >= 0 )
@@ -335,7 +335,7 @@ void SongEditor::keyPressEvent( QKeyEvent * _ke )
 			m_song->setPlayPos( t, Song::Mode_PlaySong );
 		}
 	}
-	else if( _ke->key() == Qt::Key_Right )
+	else if( ke->key() == Qt::Key_Right )
 	{
 		tick_t t = m_song->currentTick() + MidiTime::ticksPerTact();
 		if( t < MaxSongLength )
@@ -343,24 +343,24 @@ void SongEditor::keyPressEvent( QKeyEvent * _ke )
 			m_song->setPlayPos( t, Song::Mode_PlaySong );
 		}
 	}
-	else if( _ke->key() == Qt::Key_Home )
+	else if( ke->key() == Qt::Key_Home )
 	{
 		m_song->setPlayPos( 0, Song::Mode_PlaySong );
 	}
 	else
 	{
-		QWidget::keyPressEvent( _ke );
+		QWidget::keyPressEvent( ke );
 	}
 }
 
 
 
 
-void SongEditor::wheelEvent( QWheelEvent * _we )
+void SongEditor::wheelEvent(QWheelEvent * we )
 {
 	if( gui->mainWindow()->isCtrlPressed() == true )
 	{
-		if( _we->delta() > 0 )
+		if( we->delta() > 0 )
 		{
 			setPixelsPerTact( (int) qMin( pixelsPerTact() * 2,
 								256.0f ) );
@@ -382,22 +382,22 @@ void SongEditor::wheelEvent( QWheelEvent * _we )
 		// and make sure, all TCO's are resized and relocated
 		realignTracks();
 	}
-	else if( gui->mainWindow()->isShiftPressed() == true || _we->orientation() == Qt::Horizontal )
+	else if( gui->mainWindow()->isShiftPressed() == true || we->orientation() == Qt::Horizontal )
 	{
 		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							_we->delta() / 30 );
+							we->delta() / 30 );
 	}
 	else
 	{
-		_we->ignore();
+		we->ignore();
 		return;
 	}
-	_we->accept();
+	we->accept();
 }
 
 
 
-void SongEditor::closeEvent( QCloseEvent * _ce )
+void SongEditor::closeEvent(QCloseEvent * ce )
  {
 	if( parentWidget() )
 	{
@@ -407,15 +407,15 @@ void SongEditor::closeEvent( QCloseEvent * _ce )
 	{
 		hide();
 	}
-	_ce->ignore();
+	ce->ignore();
  }
 
 
 
 
-void SongEditor::setMasterVolume( int _new_val )
+void SongEditor::setMasterVolume(int new_val )
 {
-	updateMasterVolumeFloat( _new_val );
+	updateMasterVolumeFloat( new_val );
 
 	if( !m_mvsStatus->isVisible() && !m_song->m_loadingProject
 					&& m_masterVolumeSlider->showStatus() )
@@ -424,7 +424,7 @@ void SongEditor::setMasterVolume( int _new_val )
 			QPoint( m_masterVolumeSlider->width() + 2, -2 ) );
 		m_mvsStatus->setVisibilityTimeOut( 1000 );
 	}
-	Engine::mixer()->setMasterGain( _new_val / 100.0f );
+	Engine::mixer()->setMasterGain( new_val / 100.0f );
 }
 
 
@@ -441,9 +441,9 @@ void SongEditor::showMasterVolumeFloat( void )
 
 
 
-void SongEditor::updateMasterVolumeFloat( int _new_val )
+void SongEditor::updateMasterVolumeFloat(int new_val )
 {
-	m_mvsStatus->setText( tr( "Value: %1%" ).arg( _new_val ) );
+	m_mvsStatus->setText( tr( "Value: %1%" ).arg( new_val ) );
 }
 
 
@@ -457,9 +457,9 @@ void SongEditor::hideMasterVolumeFloat( void )
 
 
 
-void SongEditor::setMasterPitch( int _new_val )
+void SongEditor::setMasterPitch(int new_val )
 {
-	updateMasterPitchFloat( _new_val );
+	updateMasterPitchFloat( new_val );
 	if( m_mpsStatus->isVisible() == false && m_song->m_loadingProject == false
 					&& m_masterPitchSlider->showStatus() )
 	{
@@ -483,9 +483,9 @@ void SongEditor::showMasterPitchFloat( void )
 
 
 
-void SongEditor::updateMasterPitchFloat( int _new_val )
+void SongEditor::updateMasterPitchFloat( int new_val )
 {
-	m_mpsStatus->setText( tr( "Value: %1 semitones").arg( _new_val ) );
+	m_mpsStatus->setText( tr( "Value: %1 semitones").arg( new_val ) );
 
 }
 
@@ -500,9 +500,9 @@ void SongEditor::hideMasterPitchFloat( void )
 
 
 
-void SongEditor::updateScrollBar( int _len )
+void SongEditor::updateScrollBar( int len )
 {
-	m_leftRightScroll->setMaximum( _len );
+	m_leftRightScroll->setMaximum( len );
 }
 
 
@@ -539,7 +539,7 @@ static inline void animateScroll( QScrollBar *scrollBar, int newVal, bool smooth
 
 
 
-void SongEditor::updatePosition( const MidiTime & _t )
+void SongEditor::updatePosition( const MidiTime & t )
 {
 	int widgetWidth, trackOpWidth;
 	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
@@ -561,20 +561,20 @@ void SongEditor::updatePosition( const MidiTime & _t )
 		const int w = width() - widgetWidth
 							- trackOpWidth
 							- contentWidget()->verticalScrollBar()->width(); // width of right scrollbar
-		if( _t > m_currentPosition + w * MidiTime::ticksPerTact() /
+		if( t > m_currentPosition + w * MidiTime::ticksPerTact() /
 							pixelsPerTact() )
 		{
-			animateScroll( m_leftRightScroll, _t.getTact(), m_smoothScroll );
+			animateScroll( m_leftRightScroll, t.getTact(), m_smoothScroll );
 		}
-		else if( _t < m_currentPosition )
+		else if( t < m_currentPosition )
 		{
-			animateScroll( m_leftRightScroll, _t.getTact(), m_smoothScroll );
+			animateScroll( m_leftRightScroll, t.getTact(), m_smoothScroll );
 		}
 		m_scrollBack = false;
 	}
 
 	const int x = m_song->m_playPos[Song::Mode_PlaySong].m_timeLine->
-							markerX( _t ) + 8;
+							markerX( t ) + 8;
 	if( x >= trackOpWidth + widgetWidth -1 )
 	{
 		m_positionLine->show();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -57,7 +57,7 @@
 
 
 
-positionLine::positionLine(QWidget * parent ) :
+positionLine::positionLine( QWidget * parent ) :
 	QWidget( parent )
 {
 	setFixedWidth( 1 );
@@ -67,7 +67,7 @@ positionLine::positionLine(QWidget * parent ) :
 
 
 
-void positionLine::paintEvent(QPaintEvent * pe )
+void positionLine::paintEvent( QPaintEvent * pe )
 {
 	QPainter p( this );
 	p.fillRect( rect(), QColor( 255, 255, 255, 153 ) );
@@ -76,7 +76,7 @@ void positionLine::paintEvent(QPaintEvent * pe )
 
 
 
-SongEditor::SongEditor(Song * song ) :
+SongEditor::SongEditor( Song * song ) :
 	TrackContainerView( song ),
 	m_song( song ),
 	m_zoomingModel(new ComboBoxModel()),
@@ -286,7 +286,7 @@ void SongEditor::setHighQuality( bool hq )
 
 
 
-void SongEditor::scrolled(int new_pos )
+void SongEditor::scrolled( int new_pos )
 {
 	update();
 	emit positionChanged( m_currentPosition = MidiTime( new_pos, 0 ) );
@@ -295,7 +295,7 @@ void SongEditor::scrolled(int new_pos )
 
 
 
-void SongEditor::setEditMode(EditMode mode)
+void SongEditor::setEditMode( EditMode mode )
 {
 	m_mode = mode;
 }
@@ -313,7 +313,7 @@ void SongEditor::setEditModeSelect()
 
 
 
-void SongEditor::keyPressEvent(QKeyEvent * ke )
+void SongEditor::keyPressEvent( QKeyEvent * ke )
 {
 	if( /*_ke->modifiers() & Qt::ShiftModifier*/
 		gui->mainWindow()->isShiftPressed() == true &&
@@ -356,7 +356,7 @@ void SongEditor::keyPressEvent(QKeyEvent * ke )
 
 
 
-void SongEditor::wheelEvent(QWheelEvent * we )
+void SongEditor::wheelEvent( QWheelEvent * we )
 {
 	if( gui->mainWindow()->isCtrlPressed() == true )
 	{
@@ -397,7 +397,7 @@ void SongEditor::wheelEvent(QWheelEvent * we )
 
 
 
-void SongEditor::closeEvent(QCloseEvent * ce )
+void SongEditor::closeEvent( QCloseEvent * ce )
  {
 	if( parentWidget() )
 	{
@@ -413,7 +413,7 @@ void SongEditor::closeEvent(QCloseEvent * ce )
 
 
 
-void SongEditor::setMasterVolume(int new_val )
+void SongEditor::setMasterVolume( int new_val )
 {
 	updateMasterVolumeFloat( new_val );
 
@@ -441,7 +441,7 @@ void SongEditor::showMasterVolumeFloat( void )
 
 
 
-void SongEditor::updateMasterVolumeFloat(int new_val )
+void SongEditor::updateMasterVolumeFloat( int new_val )
 {
 	m_mvsStatus->setText( tr( "Value: %1%" ).arg( new_val ) );
 }
@@ -457,7 +457,7 @@ void SongEditor::hideMasterVolumeFloat( void )
 
 
 
-void SongEditor::setMasterPitch(int new_val )
+void SongEditor::setMasterPitch( int new_val )
 {
 	updateMasterPitchFloat( new_val );
 	if( m_mpsStatus->isVisible() == false && m_song->m_loadingProject == false
@@ -609,7 +609,7 @@ bool SongEditor::allowRubberband() const
 }
 
 
-SongEditorWindow::SongEditorWindow(Song* song) :
+SongEditorWindow::SongEditorWindow( Song* song ) :
 	Editor(Engine::mixer()->audioDev()->supportsCapture()),
 	m_editor(new SongEditor(song))
 {

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -568,11 +568,7 @@ void SongEditor::updatePosition( const MidiTime & _t )
 		}
 		else if( _t < m_currentPosition )
 		{
-			MidiTime t = qMax(
-				(int)( _t - w * MidiTime::ticksPerTact() /
-							pixelsPerTact() ),
-									0 );
-			animateScroll( m_leftRightScroll, t.getTact(), m_smoothScroll );
+			animateScroll( m_leftRightScroll, _t.getTact(), m_smoothScroll );
 		}
 		m_scrollBack = false;
 	}


### PR DESCRIPTION
fixes #2145 via meta-issue 2291
Make the Song Editor scroll back to the beginning of song or to the time line position depending on what is selected with the 3 states stop button.