### PR TITLE
Find relative LADSPA plugins when running from build

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -77,10 +77,17 @@ ConfigManager::ConfigManager() :
 			QString line = stream.readLine();
 
 			if (line.startsWith("lmms_SOURCE_DIR:")) {
+				// Current source directory contains respective data directory
 				QString srcDir = line.section('=', -1).trimmed();
 				QDir::addSearchPath("data", srcDir + "/data/");
-				break;
 			}
+			if (line.startsWith("lmms_BINARY_DIR:")) {
+				// Current build directory contains respective LADSPA plugins
+				QString binDir = line.section('=', -1).trimmed();
+				m_ladDir = binDir + "/plugins/ladspa/";
+				m_ladDir += "," + userLadspaDir();
+			}
+	
 		}
 
 		cmakeCache.close();


### PR DESCRIPTION
Related #2426 #2270 #2428

Initializes the member variable `m_ladDir` using the same `CMakeCache` logic that is used for the data directory.  Added `userLadspaDir()` too so that it won't get forgotten.