### PR TITLE
Remove hard-coded grid from SongEditor

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -267,6 +267,8 @@ TrackContentWidget {
 							stop:0 rgb( 50, 50, 50 ), stop:0.33 rgb( 20, 20, 20 ), stop:1 rgb( 15, 15, 15 ) );
 	qproperty-lighterColor: qlineargradient(x1:0, y1:0, x2:0, y2:1,
 							stop:0 rgb( 50, 50, 50 ), stop:0.33 rgb( 40, 40, 40 ), stop:1 rgb( 30, 30, 30 ) );
+	qproperty-gridColor: rgba( 0, 0, 0, 160 );
+	qproperty-embossColor: rgba( 140, 140, 140, 64 );
 }
 
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -291,6 +291,8 @@ class TrackContentWidget : public QWidget, public JournallingObject
 	// qproperties for track background gradients
 	Q_PROPERTY( QBrush darkerColor READ darkerColor WRITE setDarkerColor )
 	Q_PROPERTY( QBrush lighterColor READ lighterColor WRITE setLighterColor )
+	Q_PROPERTY( QBrush gridColor READ gridColor WRITE setGridColor )
+	Q_PROPERTY( QBrush embossColor READ embossColor WRITE setEmbossColor )
 
 public:
 	TrackContentWidget( TrackView * parent );
@@ -318,9 +320,13 @@ public:
 
 	QBrush darkerColor() const;
 	QBrush lighterColor() const;
+	QBrush gridColor() const;
+	QBrush embossColor() const;
 
 	void setDarkerColor( const QBrush & c );
 	void setLighterColor( const QBrush & c );
+	void setGridColor( const QBrush & c );
+	void setEmbossColor( const QBrush & c);
 
 public slots:
 	void update();
@@ -365,6 +371,8 @@ private:
 	// qproperty fields
 	QBrush m_darkerColor;
 	QBrush m_lighterColor;
+	QBrush m_gridColor;
+	QBrush m_embossColor;
 } ;
 
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -986,7 +986,9 @@ TrackContentWidget::TrackContentWidget( TrackView * parent ) :
 	QWidget( parent ),
 	m_trackView( parent ),
 	m_darkerColor( Qt::SolidPattern ),
-	m_lighterColor( Qt::SolidPattern )
+	m_lighterColor( Qt::SolidPattern ),
+	m_gridColor( Qt::SolidPattern ),
+	m_embossColor( Qt::SolidPattern )
 {
 	setAcceptDrops( true );
 
@@ -1030,7 +1032,7 @@ void TrackContentWidget::updateBackground()
 	pmp.fillRect( w, 0, w , h, lighterColor() );
 
 	// draw lines
-	pmp.setPen( QPen( QColor( 0, 0, 0, 160 ), 1 ) );
+	pmp.setPen( QPen( gridColor(), 1 ) );
 	// horizontal line
 	pmp.drawLine( 0, h-1, w*2, h-1 );
 
@@ -1040,7 +1042,7 @@ void TrackContentWidget::updateBackground()
 		pmp.drawLine( QLineF( x, 0.0, x, h ) );
 	}
 
-	pmp.setPen( QPen( QColor( 140, 140, 140, 64 ), 1 ) );
+	pmp.setPen( QPen( embossColor(), 1 ) );
 	for( float x = 1.0; x < w * 2; x += ppt )
 	{
 		pmp.drawLine( QLineF( x, 0.0, x, h ) );
@@ -1519,6 +1521,14 @@ QBrush TrackContentWidget::lighterColor() const
 { return m_lighterColor; }
 
 //! \brief CSS theming qproperty access method
+QBrush TrackContentWidget::gridColor() const
+{ return m_gridColor; }
+
+//! \brief CSS theming qproperty access method
+QBrush TrackContentWidget::embossColor() const
+{ return m_embossColor; }
+
+//! \brief CSS theming qproperty access method
 void TrackContentWidget::setDarkerColor( const QBrush & c )
 { m_darkerColor = c; }
 
@@ -1526,6 +1536,13 @@ void TrackContentWidget::setDarkerColor( const QBrush & c )
 void TrackContentWidget::setLighterColor( const QBrush & c )
 { m_lighterColor = c; }
 
+//! \brief CSS theming qproperty access method
+void TrackContentWidget::setGridColor( const QBrush & c )
+{ m_gridColor = c; }
+
+//! \brief CSS theming qproperty access method
+void TrackContentWidget::setEmbossColor( const QBrush & c )
+{ m_embossColor = c; }
 
 
 // ===========================================================================


### PR DESCRIPTION
Closes https://github.com/HDDigitizerMusic/lmms-alt-theme/issues/2

Makes this possible:

**Flattened CSS Example**

![image](https://cloud.githubusercontent.com/assets/6345473/11159072/91e75856-8a2a-11e5-9f27-0bf149e3873b.png)

via

```css
/* track background colors */
TrackContentWidget {
        qproperty-darkerColor: rgb( 45, 50, 57 );
        qproperty-lighterColor: rgb( 54, 61, 68 );
        qproperty-gridColor: rgba( 128, 128, 128, 84 );
        qproperty-embossColor: rgba( 0, 0, 0, 0 );
}

```
