### PR TITLE
Song: Don't remove controller just to be sure

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1198,12 +1198,6 @@ void Song::restoreControllerStates( const QDomElement & element )
 		Controller * c = Controller::create( node.toElement(), this );
 		Q_ASSERT( c != NULL );
 
-		/* For PeakController, addController() was called in
-		 * PeakControllerEffect::PeakControllerEffect().
-		 * This line removes the previously added controller for PeakController
-		 * without affecting the order of controllers in Controller Rack
-		 */
-		Engine::getSong()->removeController( c );
 		addController( c );
 
 		node = node.nextSibling();


### PR DESCRIPTION
Don't remove controller just to be sure before adding it in Song::restoreControllerStates, Song::addController handles double adds.
Fixes #2318.

