### PR TITLE
Organic: make oscillator phase offsets per-note

### DIFF
--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -81,7 +81,7 @@ organicInstrument::organicInstrument( InstrumentTrack * _instrument_track ) :
 	m_fx1Model( 0.0f, 0.0f, 0.99f, 0.01f , this, tr( "Distortion" ) ),
 	m_volModel( 100.0f, 0.0f, 200.0f, 1.0f, this, tr( "Volume" ) )
 {
-	m_numOscillators = 8;
+	m_numOscillators = NUM_OSCILLATORS;
 
 	m_osc = new OscillatorObject*[ m_numOscillators ];
 	for (int i=0; i < m_numOscillators; i++)
@@ -234,14 +234,15 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 	{
 		Oscillator * oscs_l[m_numOscillators];
 		Oscillator * oscs_r[m_numOscillators];
-		float * phaseOffsetLeft = new float[m_numOscillators];
-		float * phaseOffsetRight = new float[m_numOscillators];
+
+		_n->m_pluginData = new oscPtr;
 
 		for( int i = m_numOscillators - 1; i >= 0; --i )
 		{
-			
-			phaseOffsetLeft[i] = rand() / ( RAND_MAX + 1.0f );
-			phaseOffsetRight[i] = rand() / ( RAND_MAX + 1.0f );
+			static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetLeft[i] 
+				= rand() / ( RAND_MAX + 1.0f );
+			static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetRight[i] 
+				= rand() / ( RAND_MAX + 1.0f );
 			
 			// initialise ocillators
 			
@@ -253,7 +254,7 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 						&m_modulationAlgo,
 						_n->frequency(),
 						m_osc[i]->m_detuningLeft,
-						phaseOffsetLeft[i],
+						static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetLeft[i],
 						m_osc[i]->m_volumeLeft );
 				// create right oscillator
 				oscs_r[i] = new Oscillator(
@@ -261,7 +262,7 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 						&m_modulationAlgo,
 						_n->frequency(),
 						m_osc[i]->m_detuningRight,
-						phaseOffsetRight[i],
+						static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetRight[i],
 						m_osc[i]->m_volumeRight );
 			}
 			else
@@ -272,7 +273,7 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 						&m_modulationAlgo,
 						_n->frequency(),
 						m_osc[i]->m_detuningLeft,
-						phaseOffsetLeft[i],
+						static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetLeft[i],
 						m_osc[i]->m_volumeLeft,
 						oscs_l[i + 1] );
 				// create right oscillator
@@ -281,7 +282,7 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 						&m_modulationAlgo,
 						_n->frequency(),
 						m_osc[i]->m_detuningRight,
-						phaseOffsetRight[i],
+						static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetRight[i],
 						m_osc[i]->m_volumeRight,
 						oscs_r[i + 1] );
 			}
@@ -289,11 +290,8 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 				
 		}
 
-		_n->m_pluginData = new oscPtr;
 		static_cast<oscPtr *>( _n->m_pluginData )->oscLeft = oscs_l[0];
 		static_cast<oscPtr *>( _n->m_pluginData )->oscRight = oscs_r[0];
-		static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetLeft = phaseOffsetLeft;
-		static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetRight = phaseOffsetRight;
 	}
 
 	Oscillator * osc_l = static_cast<oscPtr *>( _n->m_pluginData )->oscLeft;
@@ -330,9 +328,7 @@ void organicInstrument::deleteNotePluginData( NotePlayHandle * _n )
 						_n->m_pluginData )->oscLeft );
 	delete static_cast<Oscillator *>( static_cast<oscPtr *>(
 						_n->m_pluginData )->oscRight );
-	delete[] static_cast<oscPtr *>(	_n->m_pluginData )->phaseOffsetLeft;
-	delete[] static_cast<oscPtr *>(	_n->m_pluginData )->phaseOffsetRight;
-
+	
 	delete static_cast<oscPtr *>( _n->m_pluginData );
 }
 

--- a/plugins/organic/organic.h
+++ b/plugins/organic/organic.h
@@ -39,6 +39,7 @@ class Knob;
 class NotePlayHandle;
 class PixmapButton;
 
+const int NUM_OSCILLATORS = 8;
 const int NUM_HARMONICS = 18;
 const QString HARMONIC_NAMES[NUM_HARMONICS] =  {
 	"Octave below",
@@ -153,8 +154,8 @@ private:
 		MM_OPERATORS
 		Oscillator * oscLeft;
 		Oscillator * oscRight;
-		float * phaseOffsetLeft;
-		float * phaseOffsetRight;		
+		float phaseOffsetLeft[NUM_OSCILLATORS];
+		float phaseOffsetRight[NUM_OSCILLATORS];		
 	} ;
 
 	const IntModel m_modulationAlgo;


### PR DESCRIPTION
Fixes some glitches mentioned in #1499 by creating an array on phase offsets for each note instead of the earlier array that was shared by the entire plugin instance and re-randomized on every note start.