### PR TITLE
Add Quantize button to Piano Roll (WIP)

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -159,6 +159,7 @@ protected slots:
 
 	void zoomingChanged();
 	void quantizeChanged();
+	void quantizeNotes();
 
 	void updateSemiToneMarkerMenu();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3859,6 +3859,28 @@ int PianoRoll::quantization() const
 }
 
 
+void PianoRoll::quantizeNotes()
+{
+	NoteVector selected = getSelectedNotes();
+
+	for (Note* n : selected.empty() ? m_pattern->notes() : selected)
+	{
+		if (n->length() == MidiTime(0))
+		{
+			continue;
+		}
+
+		Note copy(*n);
+		m_pattern->removeNote(n);
+		copy.quantizeLength(quantization());
+		m_pattern->addNote(copy);
+	}
+
+	update();
+	gui->songEditor()->update();
+}
+
+
 
 
 void PianoRoll::updateSemiToneMarkerMenu()
@@ -4006,10 +4028,15 @@ PianoRollWindow::PianoRollWindow() :
 
 	connect(editModeGroup, SIGNAL(triggered(int)), m_editor, SLOT(setEditMode(int)));
 
+	QAction* quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
+	connect(quantizeAction, SIGNAL(triggered()), m_editor, SLOT(quantizeNotes()));
+
 	notesActionsToolBar->addAction( drawAction );
 	notesActionsToolBar->addAction( eraseAction );
 	notesActionsToolBar->addAction( selectAction );
 	notesActionsToolBar->addAction( detuneAction );
+	notesActionsToolBar->addSeparator();
+	notesActionsToolBar->addAction( quantizeAction );
 
 	// Copy + paste actions
 	DropToolBar *copyPasteActionsToolBar =  addDropToolBarToTop(tr("Copy paste controls"));

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3880,7 +3880,7 @@ void PianoRoll::quantizeNotes()
 
 		Note copy(*n);
 		m_pattern->removeNote(n);
-		copy.quantizeLength(quantization());
+		copy.quantizePos(quantization());
 		m_pattern->addNote(copy);
 	}
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3861,9 +3861,17 @@ int PianoRoll::quantization() const
 
 void PianoRoll::quantizeNotes()
 {
-	NoteVector selected = getSelectedNotes();
+	NoteVector notes = getSelectedNotes();
 
-	for (Note* n : selected.empty() ? m_pattern->notes() : selected)
+	if (notes.empty())
+	{
+		for (Note* n : m_pattern->notes())
+		{
+			notes.push_back(n);
+		}
+	}
+
+	for (Note* n : notes)
 	{
 		if (n->length() == MidiTime(0))
 		{


### PR DESCRIPTION
# WORK IN PROGRESS

Inspired by a conversation on #lmms:

```
14:03 < klopsi-u3> is there a way to force an already recorded track to a lower 
                   quantisation?
...
14:42 < grejppi> klopsi-u3: none in the interface
14:42 < grejppi> that would be a useful feature though
14:44 < klopsi-u3> ok
14:45  * grejppi might hack that in
14:45 < klopsi-u3> :)
14:45 < grejppi> or at least try
14:46 < grejppi> I've already been sidetracked by so many things today c:
14:50 < klopsi-u3> i think there should be a seperate button for 'quantise 
                   piano roll'
14:50 < klopsi-u3> iow, not automatically shift quantisation if the 
                   quantisation dropdown is changed
14:51 < grejppi> yeah
14:51 < klopsi-u3> maybe even only quantise selected notes
```

There is now a new button in the Piano Roll editor toolbar:

![toolbr](https://cloud.githubusercontent.com/assets/772336/11762364/a238f164-a0ec-11e5-9240-599110d89e55.png)

If there is a selection, it will quantize the selected area to the current quantization level (1/4 in these screenshots for clarity):

![quantize_sel](https://cloud.githubusercontent.com/assets/772336/11762375/fed3effa-a0ec-11e5-8227-120f69a7d6c7.png)

Without a selection the entire pattern is quantized.

![quantizeproper](https://cloud.githubusercontent.com/assets/772336/11767058/4688f05e-a1a9-11e5-840e-6ed185470ddb.png)


## Known issues:
* ~~As you can see from the [last screenshot](https://cloud.githubusercontent.com/assets/772336/11762384/484eefb8-a0ed-11e5-9e53-b93a866bd1db.png), there are still cases where some notes are left as-is. I will investigate this.~~
* This has absolutely not been tested yet. At least it builds for now.

