### PR TITLE
Fix "associted"/"associated" typo

### DIFF
--- a/src/gui/widgets/ControllerRackView.cpp
+++ b/src/gui/widgets/ControllerRackView.cpp
@@ -127,7 +127,7 @@ void ControllerRackView::deleteController( ControllerView * _view )
 		msgBox.setIcon( QMessageBox::Question );
 		msgBox.setWindowTitle( tr("Confirm Delete") );
 		msgBox.setText( tr("Confirm delete? There are existing connection(s) "
-				"associted with this controller. There is no way to undo.") );
+				"associated with this controller. There is no way to undo.") );
 		msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
 		if( msgBox.exec() != QMessageBox::Ok )
 		{


### PR DESCRIPTION
This will presumably also affect the translation files. (But I'm making this change within the GitHub editor which provides no easy way to do a 17 file search and replace. :) )