### PR TITLE
Add finer zoom, 12.5%

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -27,6 +27,7 @@
 #define AUTOMATION_EDITOR_H
 
 #include <QtCore/QMutex>
+#include <QVector>
 #include <QWidget>
 
 #include "Editor.h"
@@ -186,6 +187,8 @@ private:
 	ComboBoxModel m_zoomingYModel;
 	ComboBoxModel m_quantizeModel;
 
+	static const QVector<double> m_zoomXLevels;
+
 	FloatModel * m_tensionModel;
 
 	QMutex m_patternMutex;
@@ -249,6 +252,7 @@ signals:
 	void currentPatternChanged();
 	void positionChanged( const MidiTime & );
 } ;
+
 
 
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -27,6 +27,7 @@
 #ifndef PIANO_ROLL_H
 #define PIANO_ROLL_H
 
+#include <QVector>
 #include <QWidget>
 #include <QInputDialog>
 
@@ -292,6 +293,7 @@ private:
 	ComboBoxModel m_scaleModel;
 	ComboBoxModel m_chordModel;
 
+	static const QVector<double> m_zoomLevels;
 
 	Pattern* m_pattern;
 	QScrollBar * m_leftRightScroll;
@@ -384,6 +386,8 @@ signals:
 	void positionChanged( const MidiTime & );
 
 } ;
+
+
 
 
 class PianoRollWindow : public Editor, SerializingObject

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -27,6 +27,8 @@
 #ifndef SONG_EDITOR_H
 #define SONG_EDITOR_H
 
+#include <QVector>
+
 #include "Editor.h"
 #include "TrackContainerView.h"
 
@@ -124,6 +126,8 @@ private:
 
 	ComboBoxModel* m_zoomingModel;
 
+	static const QVector<double> m_zoomLevels;
+
 	bool m_scrollBack;
 	bool m_smoothScroll;
 
@@ -132,6 +136,9 @@ private:
 	friend class SongEditorWindow;
 
 } ;
+
+
+
 
 class SongEditorWindow : public Editor
 {

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -75,6 +75,8 @@ QPixmap * AutomationEditor::s_toolMove = NULL;
 QPixmap * AutomationEditor::s_toolYFlip = NULL;
 QPixmap * AutomationEditor::s_toolXFlip = NULL;
 
+const QVector<double> AutomationEditor::m_zoomXLevels =
+		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
 
 
 
@@ -1491,11 +1493,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 		int x = m_zoomingXModel.value();
 		if( we->delta() > 0 )
 		{
-			x++;
+			x--;
 		}
 		if( we->delta() < 0 )
 		{
-			x--;
+			x++;
 		}
 		x = qBound( 0, x, m_zoomingXModel.size() - 1 );
 		m_zoomingXModel.setValue( x );
@@ -1917,8 +1919,7 @@ void AutomationEditor::updatePosition(const MidiTime & t )
 
 void AutomationEditor::zoomingXChanged()
 {
-	const QString & zfac = m_zoomingXModel.currentText();
-	m_ppt = zfac.left( zfac.length() - 1 ).toInt() * DEFAULT_PPT / 100;
+	m_ppt = m_zoomXLevels[m_zoomingXModel.value()] * DEFAULT_PPT;
 
 	assert( m_ppt > 0 );
 
@@ -2208,9 +2209,9 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	m_zoomingXComboBox = new ComboBox( zoomToolBar );
 	m_zoomingXComboBox->setFixedSize( 80, 22 );
 
-	for( int i = 0; i < 6; ++i )
+	for( float const & zoomLevel : m_editor->m_zoomXLevels )
 	{
-		m_editor->m_zoomingXModel.addItem( QString::number( 25 << i ) + "%" );
+		m_editor->m_zoomingXModel.addItem( QString( "%1\%" ).arg( zoomLevel * 100 ) );
 	}
 	m_editor->m_zoomingXModel.setValue( m_editor->m_zoomingXModel.findText( "100%" ) );
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -152,6 +152,9 @@ PianoRoll::PianoRollKeyTypes PianoRoll::prKeyOrder[] =
 
 const int DEFAULT_PR_PPT = KEY_LINE_HEIGHT * DefaultStepsPerTact;
 
+const QVector<double> PianoRoll::m_zoomLevels =
+			{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
+
 
 PianoRoll::PianoRoll() :
 	m_nemStr( QVector<QString>() ),
@@ -350,9 +353,9 @@ PianoRoll::PianoRoll() :
 						SLOT( verScrolled( int ) ) );
 
 	// setup zooming-stuff
-	for( int i = 0; i < 6; ++i )
+	for( float const & zoomLevel : m_zoomLevels )
 	{
-		m_zoomingModel.addItem( QString::number( 25 << i ) + "%" );
+		m_zoomingModel.addItem( QString( "%1\%" ).arg( zoomLevel * 100 ) );
 	}
 	m_zoomingModel.setValue( m_zoomingModel.findText( "100%" ) );
 	connect( &m_zoomingModel, SIGNAL( dataChanged() ),
@@ -3255,11 +3258,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		int z = m_zoomingModel.value();
 		if( we->delta() > 0 )
 		{
-			z++;
+			z--;
 		}
 		if( we->delta() < 0 )
 		{
-			z--;
+			z++;
 		}
 		z = qBound( 0, z, m_zoomingModel.size() - 1 );
 		// update combobox with zooming-factor
@@ -3853,8 +3856,7 @@ void PianoRoll::updatePositionAccompany( const MidiTime & t )
 
 void PianoRoll::zoomingChanged()
 {
-	const QString & zfac = m_zoomingModel.currentText();
-	m_ppt = zfac.left( zfac.length() - 1 ).toInt() * DEFAULT_PR_PPT / 100;
+	m_ppt = m_zoomLevels[m_zoomingModel.value()] * DEFAULT_PR_PPT;
 
 	assert( m_ppt > 0 );
 
@@ -3869,6 +3871,8 @@ void PianoRoll::quantizeChanged()
 {
 	update();
 }
+
+
 
 
 int PianoRoll::quantization() const


### PR DESCRIPTION
Closes issue #2

I added an extra 12% in front of the setup loop. I did this in three places for the Song Editor,  Piano Roll and the Automation Editor. The Automation Editor has a second zoom model that I a. didn't grasp, b. failed to test even unmodified... the other (left) is changed though and works fine.

