### PR TITLE
Fix colour of selected beat notes in Piano Roll

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -785,12 +785,7 @@ void PianoRoll::drawNoteRect(QPainter & p, int x, int y,
 
 	QColor col = QColor( noteCol );
 
-	if( n->length() < 0 )
-	{
-		//step note
-		col.setRgb( 0, 255, 0 );
-	}
-	else if( n->selected() )
+	if( n->selected() )
 	{
 		col.setRgb( 0x00, 0x40, 0xC0 );
 	}


### PR DESCRIPTION
Fixes the bug where selected beat notes in the Piano Roll aren't set to selected colour.
This is one part of #2491 but the rest couldn't be easily fixed so I commit this separately.

![beatnotecolour](https://cloud.githubusercontent.com/assets/6368949/12618921/4b1ca468-c516-11e5-9eb6-af52ccfd868a.png)
