### PR TITLE
Some tweaks to the recent files list

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -25,6 +25,7 @@
 #include <QDomElement>
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QApplication>
 #include <QtCore/QTextStream>
@@ -253,16 +254,18 @@ void ConfigManager::createWorkingDir()
 
 
 
-void ConfigManager::addRecentlyOpenedProject( const QString & _file )
+void ConfigManager::addRecentlyOpenedProject( const QString & file )
 {
-	if( !_file.endsWith( ".mpt", Qt::CaseInsensitive ) ) 
+	QFileInfo recentFile( file );
+	if( recentFile.suffix().toLower() == "mmp" ||
+			recentFile.suffix().toLower() == "mmpz" )
 	{
-		m_recentlyOpenedProjects.removeAll( _file );
-		if( m_recentlyOpenedProjects.size() > 30 )
+		m_recentlyOpenedProjects.removeAll( file );
+		if( m_recentlyOpenedProjects.size() > 50 )
 		{
 			m_recentlyOpenedProjects.removeLast();
 		}
-		m_recentlyOpenedProjects.push_front( _file );
+		m_recentlyOpenedProjects.push_front( file );
 		ConfigManager::inst()->saveConfigFile();
 	}
 }


### PR DESCRIPTION
.mpt files was already sorted out from the list but any other file is go. Instead we ban any file that isn't either .mmp or .mmpz from entering the list.
I also increase the number of remembered files to 50 ( Only 20 is shown in the menu and the rest is to fill out the space left from deleted files or removed external drives ).

Edit: Example of stuff let through to the list. The numbers are command line arguments leaked through. 
```
  <recentfiles>
    <file path="../build/openlast.patch"/>
    <file path="3000"/>
    <file path="70"/>
    <file path="/home/zonkmachine/lmms/recover.mmp"/>
    <file path="300"/>
    <file path="30"/>
  </recentfiles>
```