### PR TITLE
Fix bar display breaking at 999

### DIFF
--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -37,8 +37,8 @@ TimeDisplayWidget::TimeDisplayWidget() :
 	QWidget(),
 	m_displayMode( MinutesSeconds ),
 	m_spinBoxesLayout( this ),
-	m_majorLCD( 3, this ),
-	m_minorLCD( 3, this ),
+	m_majorLCD( 4, this ),
+	m_minorLCD( 2, this ),
 	m_milliSecondsLCD( 3, this )
 {
 	m_spinBoxesLayout.setSpacing( 0 );
@@ -137,9 +137,3 @@ void TimeDisplayWidget::mousePressEvent( QMouseEvent* mouseEvent )
 		}
 	}
 }
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #2469 

I first tried to actualy truncate first, so `1001` becomes `001`, but  `m_majorLCD.setValue` actually accepts integers rather than strings, so the bar would actually appear to reset after `999`, and that's not desireable. 

So, I extented the major LCD to 4 digits, and shrinked the minor one to 2 digits. I didn't want to seperate it and have the min/sec/msec side stay at 3:3:3, since there really is no sense to have the second counter have 3 digits, because there are only 60 seconds in a minute. 

Anyway here's how it looks now: 
![screenshot from 2016-01-29 15 25 16](https://cloud.githubusercontent.com/assets/6282045/12678130/a0acc34e-c69d-11e5-98b3-64b67e78f6db.png)
