### PR TITLE
Fix bad button position in setup dialog, make the SetupDialog fixed size and EffectDialog resizeable

### DIFF
--- a/include/RenameDialog.h
+++ b/include/RenameDialog.h
@@ -43,6 +43,7 @@ public:
 
 protected:
 	void keyPressEvent( QKeyEvent * _ke );
+	virtual void resizeEvent(QResizeEvent * event);
 
 
 protected slots:
@@ -58,4 +59,3 @@ private:
 
 
 #endif
-

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -140,6 +140,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	setWindowIcon( embed::getIconPixmap( "setup_general" ) );
 	setWindowTitle( tr( "Setup LMMS" ) );
 	setModal( true );
+	setFixedSize( 452, 520 );
 
 	Engine::projectJournal()->setJournalling( false );
 
@@ -411,8 +412,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	pathScroll->move( 0, 30 );
 	pathSelectors->resize( 360, pathsHeight - 50 );
 
-	const int txtLength = 285;
-	const int btnStart = 305;
+	const int txtLength = 284;
+	const int btnStart = 297;
 
 
 	// working-dir
@@ -1526,7 +1527,3 @@ void SetupDialog::displayMIDIHelp()
 					"controls to setup the selected "
 					"MIDI-interface." ) );
 }
-
-
-
-

--- a/src/gui/widgets/RenameDialog.cpp
+++ b/src/gui/widgets/RenameDialog.cpp
@@ -36,6 +36,7 @@ RenameDialog::RenameDialog( QString & _string ) :
 	m_originalString( _string )
 {
 	setWindowTitle( tr("Rename...") );
+	setFixedHeight( 30 );
 	m_stringLE = new QLineEdit( this );
 	m_stringLE->setText( _string );
 	m_stringLE->setGeometry ( 10, 5, 220, 20 );
@@ -51,6 +52,13 @@ RenameDialog::RenameDialog( QString & _string ) :
 
 RenameDialog::~RenameDialog()
 {
+}
+
+
+
+
+void RenameDialog::resizeEvent (QResizeEvent * event) {
+	m_stringLE->setGeometry ( 10, 5, width() - 20, 20 );	
 }
 
 
@@ -72,9 +80,3 @@ void RenameDialog::textChanged( const QString & _new_string )
 {
 	m_stringToEdit = _new_string;
 }
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #1849 

Before & After: 

![screenshot from 2016-01-29 16 38 42](https://cloud.githubusercontent.com/assets/6282045/12679986/b21ae67e-c6a7-11e5-92f0-7d0c2efa719c.png) ![screenshot from 2016-01-29 16 38 14](https://cloud.githubusercontent.com/assets/6282045/12679987/b220a60e-c6a7-11e5-9424-73fbe2152307.png) 
