### PR TITLE
AboutDialog: make version line selectable

### DIFF
--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -45,6 +45,9 @@ AboutDialog::AboutDialog(QWidget* parent) :
 					arg( MACHINE ).
 					arg( QT_VERSION_STR ).
 					arg( GCC_VERSION ) );
+	versionLabel->setTextInteractionFlags(
+					versionLabel->textInteractionFlags() |
+					Qt::TextSelectableByMouse );
 
 	authorLabel->setPlainText( embed::getText( "AUTHORS" ) );
 


### PR DESCRIPTION
I always try to to copy and paste the version line from the about box when I need the exact version info, so why not make that possible? Will self-merge in 24h unless someone objects.