### PR TITLE
Make the note border radius themeable, fix rendering of notes and volume/pan sliders

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -115,6 +115,8 @@ PianoRoll {
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
 	qproperty-barColor: #4afd85;
+	qproperty-noteBorderRadiusX: 5;
+	qproperty-noteBorderRadiusY: 2;
 }
 
 /* main toolbar oscilloscope - can have transparent bg now */

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -57,6 +57,8 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor noteModeColor READ noteModeColor WRITE setNoteModeColor )
 	Q_PROPERTY( QColor noteColor READ noteColor WRITE setNoteColor )
 	Q_PROPERTY( QColor barColor READ barColor WRITE setBarColor )
+	Q_PROPERTY( float noteBorderRadiusX READ noteBorderRadiusX WRITE setNoteBorderRadiusX )
+	Q_PROPERTY( float noteBorderRadiusY READ noteBorderRadiusY WRITE setNoteBorderRadiusY )
 public:
 	enum EditModes
 	{
@@ -109,6 +111,10 @@ public:
 	void setNoteColor( const QColor & c );
 	QColor barColor() const;
 	void setBarColor( const QColor & c );
+	float noteBorderRadiusX() const;
+	void setNoteBorderRadiusX( float b );
+	float noteBorderRadiusY() const;
+	void setNoteBorderRadiusY( float b );
 
 
 protected:
@@ -126,7 +132,8 @@ protected:
 
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
-					int  width, const Note * n, const QColor & noteCol );
+					int  width, const Note * n, const QColor & noteCol,
+				 	float radiusX, float radiusY );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -349,6 +356,8 @@ private:
 	QColor m_noteModeColor;
 	QColor m_noteColor;
 	QColor m_barColor;
+	float m_noteBorderRadiusX;
+	float m_noteBorderRadiusY;
 
 signals:
 	void positionChanged( const MidiTime & );
@@ -408,4 +417,3 @@ private:
 
 
 #endif
-


### PR DESCRIPTION
Per discussion in: #1651 

I added two new QProperies: `noteBorderRadiusX` and `noteBorderRadiusY`, So you can make your notes look like this: 
![screenshot from 2016-02-03 00 30 20](https://cloud.githubusercontent.com/assets/6282045/12768171/3b5840ee-ca0e-11e5-94af-865155ae50a8.png)

I also noticed that the notes appear blurry, and realised that's because of Qt's antialiasing. I converted the rectrangle to `QRectF` and added 0.5 to both coordinates so it renders properly, and not on the pixel boundaries. I also did the same for the volume/pan sliders. Comparison between the current and new (Zoomed in):

![screenshot from 2016-02-03 00 40 11](https://cloud.githubusercontent.com/assets/6282045/12768253/bdab5b12-ca0e-11e5-88da-6524efef8a0b.png)
![screenshot from 2016-02-03 00 40 20](https://cloud.githubusercontent.com/assets/6282045/12768252/bdaa380e-ca0e-11e5-90c4-894282fb700f.png)

Comparison between current and new volume sliders: 

![screenshot from 2016-02-03 00 41 58](https://cloud.githubusercontent.com/assets/6282045/12768282/f584b290-ca0e-11e5-9223-afd2a28a102f.png) ![screenshot from 2016-02-03 00 41 43](https://cloud.githubusercontent.com/assets/6282045/12768283/f5867332-ca0e-11e5-8e6f-e8a459238e63.png)

