### PR TITLE
Move isWhiteKey, isBlackKey into Piano.h

### DIFF
--- a/include/Piano.h
+++ b/include/Piano.h
@@ -63,6 +63,9 @@ public:
 		return m_midiEvProc;
 	}
 
+	static bool isWhiteKey(int key);
+	static bool isBlackKey(int key);
+
 
 private:
 	static bool isValidKey( int key )

--- a/src/core/Piano.cpp
+++ b/src/core/Piano.cpp
@@ -37,9 +37,11 @@
  */
 
 #include "Piano.h"
+
 #include "InstrumentTrack.h"
 #include "MidiEvent.h"
 #include "MidiEventProcessor.h"
+#include "Note.h"
 
 
 /*! \brief Create a new keyboard display
@@ -125,6 +127,26 @@ void Piano::handleKeyRelease( int key )
 
 
 
+bool Piano::isBlackKey( int key )
+{
+	int keyCode = key % KeysPerOctave;
+
+	switch (keyCode)
+	{
+	case 1:
+	case 3:
+	case 6:
+	case 8:
+	case 10:
+		return true;
+	}
+
+	return false;
+}
 
 
+bool Piano::isWhiteKey( int key )
+{
+	return !isBlackKey( key );
+}
 

--- a/src/core/Piano.cpp
+++ b/src/core/Piano.cpp
@@ -44,6 +44,19 @@
 #include "Note.h"
 
 
+/*! The black / white order of keys as they appear on the keyboard.
+ */
+static const Piano::KeyTypes KEY_ORDER[] =
+{
+//	C                CIS              D                DIS
+	Piano::WhiteKey, Piano::BlackKey, Piano::WhiteKey, Piano::BlackKey,
+//	E                F                FIS              G
+	Piano::WhiteKey, Piano::WhiteKey, Piano::BlackKey, Piano::WhiteKey,
+//	GIS              A                AIS              B
+	Piano::BlackKey, Piano::WhiteKey, Piano::BlackKey, Piano::WhiteKey
+} ;
+
+
 /*! \brief Create a new keyboard display
  *
  *  \param _it the InstrumentTrack window to attach to
@@ -131,17 +144,7 @@ bool Piano::isBlackKey( int key )
 {
 	int keyCode = key % KeysPerOctave;
 
-	switch (keyCode)
-	{
-	case 1:
-	case 3:
-	case 6:
-	case 8:
-	case 10:
-		return true;
-	}
-
-	return false;
+	return KEY_ORDER[keyCode] == Piano::BlackKey;
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -139,27 +139,7 @@ static QString getNoteString( int key )
 	return s_noteStrings[key % 12] + QString::number( static_cast<int>( key / KeysPerOctave ) );
 }
 
-static bool isBlackKey( int key )
-{
-	int keyCode = key % KeysPerOctave;
 
-	switch (keyCode)
-	{
-	case 1:
-	case 3:
-	case 6:
-	case 8:
-	case 10:
-		return true;
-	}
-
-	return false;
-}
-
-static bool isWhiteKey( int key )
-{
-	return !isBlackKey( key );
-}
 
 // used for drawing of piano
 PianoRoll::PianoRollKeyTypes PianoRoll::prKeyOrder[] =
@@ -2691,7 +2671,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			break;
 		}
 
-		if ( isWhiteKey( key ) )
+		if ( Piano::isWhiteKey( key ) )
 		{
 			// Draw note names if activated in the preferences, C notes are always drawn
 			if ( key % 12 == 0 || drawNoteNames )


### PR DESCRIPTION
`PianoRoll.cpp` contained implementations for `isBlackKey(int key)`, `isWhiteKey(int key)`. Other files (`Piano.cpp`) were doing these calculations inline. It made sense to move these functions into a common file wherein they could also be used by `Piano.cpp` for increased clarity.

I did some sanity testing, and the behavior of the piano roll appears to have not changed (this is as intended).