### PR TITLE
Make the instrument section of the sidebar themeable

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -479,6 +479,23 @@ SideBar QToolButton {
 	font-size: 12px;
 }
 
+/* Instrument plugin list */
+
+PluginDescList {
+	background-color: #5b6571;
+}
+
+PluginDescWidget {
+	background-color: #e0e0e0;
+	color: #404040;
+	border: 1px solid rgb(64, 64, 64);
+	margin: 0px;
+}
+
+PluginDescWidget:hover {
+	background-color: #e0e0e0;
+}
+
 /* font sizes for text buttons */
 
 FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -31,6 +31,7 @@
 #include <QCursor>
 #include <QMouseEvent>
 #include <QScrollArea>
+#include <QStyleOption>
 
 #include "embed.h"
 #include "debug.h"
@@ -135,21 +136,22 @@ PluginDescWidget::~PluginDescWidget()
 
 
 
-void PluginDescWidget::paintEvent( QPaintEvent * )
+void PluginDescWidget::paintEvent( QPaintEvent * e )
 {
-	const QColor fill_color = m_mouseOver ? QColor( 224, 224, 224 ) :
-						QColor( 192, 192, 192 );
 
 	QPainter p( this );
-	p.fillRect( rect(), fill_color );
 
+	// Paint everything according to the style sheet
+	QStyleOption o;
+	o.initFrom( this );
+	style()->drawPrimitive( QStyle::PE_Widget, &o, &p, this );
+
+	// Draw the rest
 	const int s = 16 + ( 32 * ( tLimit( height(), 24, 60 ) - 24 ) ) /
 								( 60 - 24 );
 	const QSize logo_size( s, s );
 	QPixmap logo = m_logo.scaled( logo_size, Qt::KeepAspectRatio,
 						Qt::SmoothTransformation );
-	p.setPen( QColor( 64, 64, 64 ) );
-	p.drawRect( 0, 0, rect().right(), rect().bottom() );
 	p.drawPixmap( 4, 4, logo );
 
 	QFont f = p.font();


### PR DESCRIPTION
Fixes #2329 

Based off of @michaelgregorius's patch: https://github.com/LMMS/lmms/issues/2329#issuecomment-138976075

You can do this now: 
![screenshot from 2016-02-05 01 30 44](https://cloud.githubusercontent.com/assets/6282045/12834592/dc038bc0-cba8-11e5-8d4e-4c7a313a9e85.png)

As always, testing and comments welcome.