### PR TITLE
Fix inconsistent scrollbars

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -159,7 +159,7 @@ private:
 	} ;
 
 	// some constants...
-	static const int SCROLLBAR_SIZE = 16;
+	static const int SCROLLBAR_SIZE = 14;
 	static const int TOP_MARGIN = 16;
 
 	static const int DEFAULT_Y_DELTA = 6;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -83,7 +83,7 @@ typedef AutomationPattern::timeMap timeMap;
 // some constants...
 const int INITIAL_PIANOROLL_HEIGHT = 480;
 
-const int SCROLLBAR_SIZE = 16;
+const int SCROLLBAR_SIZE = 14;
 const int PIANO_X = 0;
 
 const int WHITE_KEY_WIDTH = 64;


### PR DESCRIPTION
Per https://github.com/HDDigitizerMusic/lmms-alt-theme/issues/11

The Piano Roll and Automation had scrollbars that were 2 pixels wider/higher than the other ones.

Before: 
![screenshot from 2016-02-06 14 31 51](https://cloud.githubusercontent.com/assets/6282045/12866905/938a0ce8-ccde-11e5-8c38-941beb338dcc.png)

After:
![screenshot from 2016-02-06 12 13 33](https://cloud.githubusercontent.com/assets/6282045/12866907/a5839eaa-ccde-11e5-967a-150a23b7ed96.png)

Ideally we would want to get rid of the hard-coding, so all is done through CSS like in other editors. I'll look into that, and probably issue a follow-up PR.