### PR TITLE
Make FxLine Stroke Themeable

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -492,6 +492,10 @@ FxLine {
 	color: #e0e0e0;
 	qproperty-backgroundActive: qlineargradient(spread:reflect, x1:0, y1:0, x2:1, y2:0,
 								stop:0 #7b838d, stop:1 #6b7581 );
+	qproperty-strokeOuterActive: rgb( 0, 0, 0 );	
+	qproperty-strokeOuterInactive: rgba( 0, 0, 0, 50 );	
+	qproperty-strokeInnerActive: rgba( 255, 255, 255, 100 );	
+	qproperty-strokeInnerInactive: rgba( 255, 255, 255, 50 );					
 }
 
 /* persistent peak markers for fx peak meters */

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -41,6 +41,10 @@ class FxLine : public QWidget
 	Q_OBJECT
 public:
 	Q_PROPERTY( QBrush backgroundActive READ backgroundActive WRITE setBackgroundActive )
+	Q_PROPERTY( QColor strokeOuterActive READ strokeOuterActive WRITE setStrokeOuterActive )
+	Q_PROPERTY( QColor strokeOuterInactive READ strokeOuterInactive WRITE setStrokeOuterInactive )
+	Q_PROPERTY( QColor strokeInnerActive READ strokeInnerActive WRITE setStrokeInnerActive )
+	Q_PROPERTY( QColor strokeInnerInactive READ strokeInnerInactive WRITE setStrokeInnerInactive )
 	FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex);
 	~FxLine();
 
@@ -57,6 +61,19 @@ public:
 
 	QBrush backgroundActive() const;
 	void setBackgroundActive( const QBrush & c );
+	
+	QColor strokeOuterActive() const;
+	void setStrokeOuterActive( const QColor & c );
+	
+	QColor strokeOuterInactive() const;
+	void setStrokeOuterInactive( const QColor & c );
+	
+	QColor strokeInnerActive() const;
+	void setStrokeInnerActive( const QColor & c );
+	
+	QColor strokeInnerInactive() const;
+	void setStrokeInnerInactive( const QColor & c );
+
 
 	static const int FxLineHeight;
 
@@ -67,6 +84,10 @@ private:
 	LcdWidget* m_lcd;
 	int m_channelIndex;
 	QBrush m_backgroundActive;
+	QColor m_strokeOuterActive;
+	QColor m_strokeOuterInactive;
+	QColor m_strokeInnerActive;
+	QColor m_strokeInnerInactive;
 	static QPixmap * s_sendBgArrow;
 	static QPixmap * s_receiveBgArrow;
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -48,7 +48,11 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	QWidget( _parent ),
 	m_mv( _mv ),
 	m_channelIndex( _channelIndex ),
-	m_backgroundActive( Qt::SolidPattern )
+	m_backgroundActive( Qt::SolidPattern ),
+	m_strokeOuterActive( 0, 0, 0 ),
+	m_strokeOuterInactive( 0, 0, 0 ),
+	m_strokeInnerActive( 0, 0, 0 ),
+	m_strokeInnerInactive( 0, 0, 0 )
 {
 	if( ! s_sendBgArrow )
 	{
@@ -126,11 +130,13 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name,
 
 
 	p->fillRect( fxLine->rect(), isActive ? fxLine->backgroundActive() : p->background() );
-
-	p->setPen( QColor( 255, 255, 255, isActive ? 100 : 50 ) );
+	
+	// inner border
+	p->setPen( isActive ? fxLine->strokeInnerActive() : fxLine->strokeInnerInactive() );
 	p->drawRect( 1, 1, width-3, height-3 );
-
-	p->setPen( isActive ? sh_color : QColor( 0, 0, 0, 50 ) );
+	
+	// outer border
+	p->setPen( isActive ? fxLine->strokeOuterActive() : fxLine->strokeOuterInactive() );
 	p->drawRect( 0, 0, width-1, height-1 );
 
 	// draw the mixer send background
@@ -276,5 +282,42 @@ void FxLine::setBackgroundActive( const QBrush & c )
 	m_backgroundActive = c;
 }
 
+QColor FxLine::strokeOuterActive() const
+{
+	return m_strokeOuterActive;
+}
 
+void FxLine::setStrokeOuterActive( const QColor & c )
+{
+	m_strokeOuterActive = c;
+}
 
+QColor FxLine::strokeOuterInactive() const
+{
+	return m_strokeOuterInactive;
+}
+
+void FxLine::setStrokeOuterInactive( const QColor & c )
+{
+	m_strokeOuterInactive = c;
+}
+
+QColor FxLine::strokeInnerActive() const
+{
+	return m_strokeInnerActive;
+}
+
+void FxLine::setStrokeInnerActive( const QColor & c )
+{
+	m_strokeInnerActive = c;
+}
+
+QColor FxLine::strokeInnerInactive() const
+{
+	return m_strokeInnerInactive;
+}
+
+void FxLine::setStrokeInnerInactive( const QColor & c )
+{
+	m_strokeInnerInactive = c;
+}


### PR DESCRIPTION
Per https://github.com/HDDigitizerMusic/lmms-alt-theme/issues/9

You can do this now: 
![screenshot from 2016-02-07 01 33 23](https://cloud.githubusercontent.com/assets/6282045/12870227/3f92587c-cd3b-11e5-92f8-074991d995c6.png)

Added 4 new `QPropertys` for the inner and outer stroke in their active/inactive state.
