### PR TITLE
Removes lots of static calls to Engine

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -37,6 +37,7 @@
 #include "AutomationPattern.h"
 #include "ComboBoxModel.h"
 #include "Knob.h"
+#include "EngineClient.h"
 
 class QPainter;
 class QPixmap;
@@ -48,7 +49,7 @@ class TimeLineWidget;
 
 
 
-class AutomationEditor : public QWidget, public JournallingObject
+class AutomationEditor : public QWidget, public JournallingObject, public EngineClient
 {
 	Q_OBJECT
 	Q_PROPERTY(QColor gridColor READ gridColor WRITE setGridColor)
@@ -168,7 +169,7 @@ private:
 
 	static const int VALUES_WIDTH = 64;
 
-	AutomationEditor();
+	AutomationEditor( Engine * engine );
 	AutomationEditor( const AutomationEditor & );
 	virtual ~AutomationEditor();
 
@@ -255,7 +256,7 @@ class AutomationEditorWindow : public Editor
 	static const int INITIAL_WIDTH = 860;
 	static const int INITIAL_HEIGHT = 480;
 public:
-	AutomationEditorWindow();
+	AutomationEditorWindow(Engine * engine);
 	~AutomationEditorWindow();
 
 	void setCurrentPattern(AutomationPattern* pattern);

--- a/include/DummyEffect.h
+++ b/include/DummyEffect.h
@@ -82,8 +82,8 @@ public:
 class DummyEffect : public Effect
 {
 public:
-	DummyEffect( Model * _parent, const QDomElement& originalPluginData ) :
-		Effect( NULL, _parent, NULL ),
+	DummyEffect( Model * _parent, Engine * engine, const QDomElement& originalPluginData ) :
+		Effect( NULL, _parent, engine, NULL ),
 		m_controls( this ),
 		m_originalPluginData( originalPluginData )
 	{

--- a/include/DummyInstrument.h
+++ b/include/DummyInstrument.h
@@ -33,8 +33,8 @@
 class DummyInstrument : public Instrument
 {
 public:
-	DummyInstrument( InstrumentTrack * _instrument_track ) :
-		Instrument( _instrument_track, NULL )
+	DummyInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+		Instrument( _instrument_track, NULL, engine )
 	{
 	}
 

--- a/include/DummyPlugin.h
+++ b/include/DummyPlugin.h
@@ -33,8 +33,8 @@
 class DummyPlugin : public Plugin
 {
 public:
-	DummyPlugin() :
-		Plugin( NULL, NULL )
+	DummyPlugin(Engine * engine) :
+		Plugin( NULL, NULL, engine )
 	{
 	}
 

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -44,6 +44,7 @@ class EXPORT Effect : public Plugin
 public:
 	Effect( const Plugin::Descriptor * _desc,
 			Model * _parent,
+			Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~Effect();
 
@@ -103,8 +104,8 @@ public:
 
 	inline f_cnt_t timeout() const
 	{
-		const float samples = Engine::mixer()->processingSampleRate() * m_autoQuitModel.value() / 1000.0f;
-		return 1 + ( static_cast<int>( samples ) / Engine::mixer()->framesPerPeriod() );
+		const float samples = getProcessingSampleRate() * m_autoQuitModel.value() / 1000.0f;
+		return 1 + ( static_cast<int>( samples ) / getFramesPerPeriod() );
 	}
 
 	inline float wetLevel() const
@@ -177,9 +178,9 @@ protected:
 							sample_rate_t _dst_sr )
 	{
 		resample( 0, _src_buf,
-				Engine::mixer()->processingSampleRate(),
-					_dst_buf, _dst_sr,
-					Engine::mixer()->framesPerPeriod() );
+			  getProcessingSampleRate(),
+			  _dst_buf, _dst_sr,
+			  getFramesPerPeriod() );
 	}
 
 	inline void sampleBack( const sampleFrame * _src_buf,
@@ -187,9 +188,9 @@ protected:
 							sample_rate_t _src_sr )
 	{
 		resample( 1, _src_buf, _src_sr, _dst_buf,
-				Engine::mixer()->processingSampleRate(),
-			Engine::mixer()->framesPerPeriod() * _src_sr /
-				Engine::mixer()->processingSampleRate() );
+				getProcessingSampleRate(),
+				getFramesPerPeriod() * _src_sr /
+				getProcessingSampleRate() );
 	}
 	void reinitSRC();
 

--- a/include/EngineClient.h
+++ b/include/EngineClient.h
@@ -1,7 +1,7 @@
 /*
- * carlapatchbay.cpp - Carla for LMMS (Patchbay)
+ * EngineClient.h - Interface to the engine-system of LMMS
  *
- * Copyright (C) 2014 Filipe Coelho <falktx@falktx.com>
+ * Copyright (c) 2016 Michael Gregorius
  *
  * This file is part of LMMS - http://lmms.io
  *
@@ -22,30 +22,36 @@
  *
  */
 
-#include "carla.h"
 
-#include "embed.cpp"
+#ifndef ENGINECLIENT_H
+#define ENGINECLIENT_H
 
-extern "C"
+#include "export.h"
+
+#include "Engine.h"
+
+class Song;
+class Mixer;
+class FxMixer;
+class BBTrackContainer;
+class ProjectJournal;
+
+class EXPORT EngineClient
 {
+public:
+	EngineClient( Engine * engine) : m_engine(engine) {}
 
-Plugin::Descriptor PLUGIN_EXPORT carlapatchbay_plugin_descriptor =
-{
-    STRINGIFY( PLUGIN_NAME ),
-    "Carla Patchbay",
-    QT_TRANSLATE_NOOP( "pluginBrowser",
-                       "Carla Patchbay Instrument" ),
-    "falkTX <falktx/at/falktx.com>",
-    0x0195,
-    Plugin::Instrument,
-    new PluginPixmapLoader( "logo" ),
-    NULL,
-    NULL
-} ;
+	Engine * getEngine() const { return m_engine; }
+	Song * getSong() const { return m_engine->getSong(); }
+	Mixer * getMixer() const { return m_engine->mixer(); }
+	FxMixer * getFxMixer() const { return m_engine->fxMixer(); }
+	BBTrackContainer * getBBTrackContainer() const { return m_engine->getBBTrackContainer(); }
+	ProjectJournal * getProjectJournal() const { return m_engine->projectJournal(); }
 
-Plugin* PLUGIN_EXPORT lmms_plugin_main(Model*, Engine * engine, void* data)
-{
-    return new CarlaInstrument(static_cast<InstrumentTrack*>(data), &carlapatchbay_plugin_descriptor, engine, true);
-}
+private:
+	Engine * m_engine;
+};
 
-}
+
+#endif
+

--- a/include/ExportFilter.h
+++ b/include/ExportFilter.h
@@ -35,7 +35,7 @@
 class EXPORT ExportFilter : public Plugin
 {
 public:
-	ExportFilter( const Descriptor * _descriptor ) : Plugin( _descriptor, NULL ) {}
+	ExportFilter( const Descriptor * _descriptor, Engine * engine ) : Plugin( _descriptor, NULL, engine ) {}
 	virtual ~ExportFilter() {}
 
 

--- a/include/ImportFilter.h
+++ b/include/ImportFilter.h
@@ -38,7 +38,7 @@ class EXPORT ImportFilter : public Plugin
 {
 public:
 	ImportFilter( const QString & _file_name,
-					const Descriptor * _descriptor );
+					const Descriptor * _descriptor, Engine * engine );
 	virtual ~ImportFilter();
 
 

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -56,8 +56,9 @@ public:
 
 	Q_DECLARE_FLAGS(Flags, Flag);
 
-	Instrument( InstrumentTrack * _instrument_track,
-					const Descriptor * _descriptor );
+	Instrument(InstrumentTrack * _instrument_track,
+		   const Descriptor * _descriptor,
+		   Engine * engine);
 	virtual ~Instrument();
 
 	// --------------------------------------------------------------------

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -41,6 +41,11 @@ class ConfigManager;
 class PluginView;
 class ToolButton;
 
+class Song;
+class Mixer;
+class BBTrackContainer;
+class ProjectJournal;
+
 
 class MainWindow : public QMainWindow
 {
@@ -175,6 +180,13 @@ private:
 	void toggleWindow( QWidget *window, bool forceShow = false );
 	void refocus();
 
+	// Convenience function to get rid of several Engine::getSong
+	// calls so we only have to adjust very few places in the end
+	Song * getSong() const;
+	Mixer * getMixer() const;
+	BBTrackContainer * getBBTrackContainer() const;
+	ProjectJournal * getProjectJournal() const;
+
 	QMdiArea * m_workspace;
 
 	QWidget * m_toolBar;
@@ -222,6 +234,7 @@ private slots:
 	void updateViewMenu( void );
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
+	void exportMIDI();
 
 
 signals:

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -37,6 +37,7 @@
 #include "lmms_basics.h"
 #include "Song.h"
 #include "ToolTip.h"
+#include "EngineClient.h"
 
 class QPainter;
 class QPixmap;
@@ -50,7 +51,7 @@ class NotePlayHandle;
 class Pattern;
 class TimeLineWidget;
 
-class PianoRoll : public QWidget
+class PianoRoll : public QWidget, public EngineClient
 {
 	Q_OBJECT
 	Q_PROPERTY( QColor gridColor READ gridColor WRITE setGridColor )
@@ -224,7 +225,7 @@ private:
 	QList<int> m_markedSemiTones;
 	QMenu * m_semiToneMarkerMenu; // when you right click on the key area
 
-	PianoRoll();
+	PianoRoll( Engine * engine );
 	PianoRoll( const PianoRoll & );
 	virtual ~PianoRoll();
 
@@ -369,7 +370,7 @@ class PianoRollWindow : public Editor, SerializingObject
 {
 	Q_OBJECT
 public:
-	PianoRollWindow();
+	PianoRollWindow( Engine * engine );
 
 	const Pattern* currentPattern() const;
 	void setCurrentPattern(Pattern* pattern);

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -32,7 +32,9 @@
 #include "JournallingObject.h"
 #include "Model.h"
 #include "MemoryManager.h"
+#include "Mixer.h"
 
+#include "EngineClient.h"
 
 class QWidget;
 
@@ -41,7 +43,7 @@ class PluginView;
 class AutomatableModel;
 
 
-class EXPORT Plugin : public Model, public JournallingObject
+class EXPORT Plugin : public Model, public JournallingObject, public EngineClient
 {
 	MM_OPERATORS
 	Q_OBJECT
@@ -141,7 +143,7 @@ public:
 	typedef QList<Descriptor*> DescriptorList;
 
 	// contructor of a plugin
-	Plugin( const Descriptor * descriptor, Model * parent );
+	Plugin( const Descriptor * descriptor, Model * parent, Engine * engine );
 	virtual ~Plugin();
 
 	// returns display-name out of descriptor
@@ -179,18 +181,20 @@ public:
 	// create a view for the model 
 	PluginView * createView( QWidget * parent );
 
+	sample_rate_t getProcessingSampleRate() const { return getMixer()->processingSampleRate(); }
+	fpp_t getFramesPerPeriod() const { return getMixer()->framesPerPeriod(); }
+
 
 protected:
 	// create a view for the model 
 	virtual PluginView* instantiateView( QWidget * ) = 0;
 	void collectErrorForUI( QString errMsg );
 
-
 private:
 	const Descriptor * m_descriptor;
 
 	// pointer to instantiation-function in plugin
-	typedef Plugin * ( * InstantiationHook )( Model * , void * );
+    typedef Plugin * ( * InstantiationHook )( Model * , Engine * , void * );
 
 } ;
 

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -74,6 +74,9 @@ public:
 	/// It can be retrieved by calling this function.
 	QString errorString(QString pluginName) const;
 
+	Engine * getEngine() const { return m_engine; }
+	void setEngine(Engine * engine) { m_engine = engine; }
+
 public slots:
 	void discoverPlugins();
 
@@ -83,6 +86,8 @@ private:
 	QMap<QString, PluginInfo*> m_pluginByExt;
 
 	QHash<QString, QString> m_errors;
+
+	Engine * m_engine;
 
 	static PluginFactory* s_instance;
 };

--- a/include/Song.h
+++ b/include/Song.h
@@ -253,6 +253,8 @@ public:
 		return m_timeSigModel;
 	}
 
+	void exportProjectMidi(TrackContainer::TrackList & tracks, bpm_t bpm, QString const & exportFilename);
+
 
 public slots:
 	void playSong();
@@ -266,7 +268,6 @@ public slots:
 	void importProject();
 	void exportProject( bool multiExport = false );
 	void exportProjectTracks();
-	void exportProjectMidi();
 
 	void startExport();
 	void stopExport();

--- a/include/ToolPlugin.h
+++ b/include/ToolPlugin.h
@@ -32,7 +32,7 @@
 class EXPORT ToolPlugin : public Plugin
 {
 public:
-	ToolPlugin( const Descriptor * _descriptor, Model * _parent );
+	ToolPlugin( const Descriptor * _descriptor, Model * _parent, Engine * engine );
 	virtual ~ToolPlugin();
 
 	// instantiate tool-plugin with given name or return NULL

--- a/plugins/Amplifier/Amplifier.cpp
+++ b/plugins/Amplifier/Amplifier.cpp
@@ -48,8 +48,8 @@ Plugin::Descriptor PLUGIN_EXPORT amplifier_plugin_descriptor =
 
 
 
-AmplifierEffect::AmplifierEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &amplifier_plugin_descriptor, parent, key ),
+AmplifierEffect::AmplifierEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &amplifier_plugin_descriptor, parent, engine, key ),
 	m_ampControls( this )
 {
 }
@@ -138,9 +138,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new AmplifierEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new AmplifierEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/Amplifier/Amplifier.h
+++ b/plugins/Amplifier/Amplifier.h
@@ -34,7 +34,7 @@
 class AmplifierEffect : public Effect
 {
 public:
-	AmplifierEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	AmplifierEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~AmplifierEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/BassBooster/BassBooster.cpp
+++ b/plugins/BassBooster/BassBooster.cpp
@@ -47,8 +47,8 @@ Plugin::Descriptor PLUGIN_EXPORT bassbooster_plugin_descriptor =
 
 
 
-BassBoosterEffect::BassBoosterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &bassbooster_plugin_descriptor, parent, key ),
+BassBoosterEffect::BassBoosterEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &bassbooster_plugin_descriptor, parent, engine, key ),
 	m_frequencyChangeNeeded( false ),
 	m_bbFX( DspEffectLibrary::FastBassBoost( 70.0f, 1.0f, 2.8f ) ),
 	m_bbControls( this )
@@ -132,7 +132,7 @@ bool BassBoosterEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 
 inline void BassBoosterEffect::changeFrequency()
 {
-	const sample_t fac = Engine::mixer()->processingSampleRate() / 44100.0f;
+	const sample_t fac = getProcessingSampleRate() / 44100.0f;
 
 	m_bbFX.leftFX().setFrequency( m_bbControls.m_freqModel.value() * fac );
 	m_bbFX.rightFX().setFrequency( m_bbControls.m_freqModel.value() * fac );
@@ -163,9 +163,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new BassBoosterEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new BassBoosterEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/BassBooster/BassBooster.h
+++ b/plugins/BassBooster/BassBooster.h
@@ -34,7 +34,7 @@
 class BassBoosterEffect : public Effect
 {
 public:
-	BassBoosterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	BassBoosterEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~BassBoosterEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/BassBooster/BassBoosterControls.cpp
+++ b/plugins/BassBooster/BassBoosterControls.cpp
@@ -37,7 +37,7 @@ BassBoosterControls::BassBoosterControls( BassBoosterEffect* effect ) :
 	m_gainModel( 1.0f, 0.1f, 5.0f, 0.05f, this, tr( "Gain" ) ),
 	m_ratioModel( 2.0f, 0.1f, 10.0f, 0.1f, this, tr( "Ratio" ) )
 {
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changeFrequency() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changeFrequency() ) );
 }
 
 

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -51,13 +51,13 @@ Plugin::Descriptor PLUGIN_EXPORT bitcrush_plugin_descriptor =
 
 }
 
-BitcrushEffect::BitcrushEffect( Model * parent, const Descriptor::SubPluginFeatures::Key * key ) :
-	Effect( &bitcrush_plugin_descriptor, parent, key ),
+BitcrushEffect::BitcrushEffect( Model * parent, Engine * engine, const Descriptor::SubPluginFeatures::Key * key ) :
+	Effect( &bitcrush_plugin_descriptor, parent, engine, key ),
 	m_controls( this ),
-	m_sampleRate( Engine::mixer()->processingSampleRate() ),
+	m_sampleRate( getProcessingSampleRate() ),
 	m_filter( m_sampleRate )
 {
-	m_buffer = MM_ALLOC( sampleFrame, Engine::mixer()->framesPerPeriod() * OS_RATE );
+	m_buffer = MM_ALLOC( sampleFrame, getFramesPerPeriod() * OS_RATE );
 	m_filter.setLowpass( m_sampleRate * ( CUTOFF_RATIO * OS_RATIO ) );
 	m_needsUpdate = true;
 	
@@ -78,7 +78,7 @@ BitcrushEffect::~BitcrushEffect()
 
 void BitcrushEffect::sampleRateChanged()
 {
-	m_sampleRate = Engine::mixer()->processingSampleRate();
+	m_sampleRate = getProcessingSampleRate();
 	m_filter.setSampleRate( m_sampleRate );
 	m_filter.setLowpass( m_sampleRate * ( CUTOFF_RATIO * OS_RATIO ) );
 	m_needsUpdate = true;
@@ -244,9 +244,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new BitcrushEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new BitcrushEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/Bitcrush/Bitcrush.h
+++ b/plugins/Bitcrush/Bitcrush.h
@@ -36,7 +36,7 @@
 class BitcrushEffect : public Effect
 {
 public:
-	BitcrushEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	BitcrushEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~BitcrushEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/Bitcrush/BitcrushControls.cpp
+++ b/plugins/Bitcrush/BitcrushControls.cpp
@@ -47,7 +47,7 @@ BitcrushControls::BitcrushControls( BitcrushEffect * eff ) :
 	m_rate.setStrictStepSize( true );
 	m_levels.setStrictStepSize( true );
 	
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
 }
 
 BitcrushControls::~BitcrushControls()

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -47,10 +47,10 @@ Plugin::Descriptor PLUGIN_EXPORT crossovereq_plugin_descriptor =
 }
 
 
-CrossoverEQEffect::CrossoverEQEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &crossovereq_plugin_descriptor, parent, key ),
+CrossoverEQEffect::CrossoverEQEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &crossovereq_plugin_descriptor, parent, engine, key ),
 	m_controls( this ),
-	m_sampleRate( Engine::mixer()->processingSampleRate() ),
+	m_sampleRate( getProcessingSampleRate() ),
 	m_lp1( m_sampleRate ),
 	m_lp2( m_sampleRate ),
 	m_lp3( m_sampleRate ),
@@ -59,9 +59,10 @@ CrossoverEQEffect::CrossoverEQEffect( Model* parent, const Descriptor::SubPlugin
 	m_hp4( m_sampleRate ),
 	m_needsUpdate( true )
 {
-	m_tmp1 = MM_ALLOC( sampleFrame, Engine::mixer()->framesPerPeriod() );
-	m_tmp2 = MM_ALLOC( sampleFrame, Engine::mixer()->framesPerPeriod() );
-	m_work = MM_ALLOC( sampleFrame, Engine::mixer()->framesPerPeriod() );
+	fpp_t framesPerPeriod = getFramesPerPeriod();
+	m_tmp1 = MM_ALLOC( sampleFrame, framesPerPeriod );
+	m_tmp2 = MM_ALLOC( sampleFrame, framesPerPeriod );
+	m_work = MM_ALLOC( sampleFrame, framesPerPeriod );
 }
 
 CrossoverEQEffect::~CrossoverEQEffect()
@@ -73,7 +74,7 @@ CrossoverEQEffect::~CrossoverEQEffect()
 
 void CrossoverEQEffect::sampleRateChanged()
 {
-	m_sampleRate = Engine::mixer()->processingSampleRate();
+	m_sampleRate = getProcessingSampleRate();
 	m_lp1.setSampleRate( m_sampleRate );
 	m_lp2.setSampleRate( m_sampleRate );
 	m_lp3.setSampleRate( m_sampleRate );
@@ -211,9 +212,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new CrossoverEQEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new CrossoverEQEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/CrossoverEQ/CrossoverEQ.h
+++ b/plugins/CrossoverEQ/CrossoverEQ.h
@@ -36,7 +36,7 @@
 class CrossoverEQEffect : public Effect
 {
 public:
-	CrossoverEQEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	CrossoverEQEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~CrossoverEQEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/CrossoverEQ/CrossoverEQControls.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControls.cpp
@@ -42,7 +42,7 @@ CrossoverEQControls::CrossoverEQControls( CrossoverEQEffect * eff ) :
 	m_mute3( false, this, "Mute Band 3" ),
 	m_mute4( false, this, "Mute Band 4" )
 {
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
 	connect( &m_xover12, SIGNAL( dataChanged() ), this, SLOT( xover12Changed() ) );
 	connect( &m_xover23, SIGNAL( dataChanged() ), this, SLOT( xover23Changed() ) );
 	connect( &m_xover34, SIGNAL( dataChanged() ), this, SLOT( xover34Changed() ) );

--- a/plugins/Delay/DelayControls.cpp
+++ b/plugins/Delay/DelayControls.cpp
@@ -38,7 +38,7 @@ DelayControls::DelayControls( DelayEffect* effect ):
 	m_lfoAmountModel(0.0, 0.0, 0.5, 0.0001, 2000.0, this, tr ( "Lfo Amount" ) ),
 	m_outGainModel( 0.0, -60.0, 20.0, 0.01, this, tr( "Output gain" ) )
 {
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changeSampleRate() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changeSampleRate() ) );
 	m_outPeakL = 0.0;
 	m_outPeakR = 0.0;
 }

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -47,13 +47,13 @@ Plugin::Descriptor PLUGIN_EXPORT delay_plugin_descriptor =
 
 
 
-DelayEffect::DelayEffect( Model* parent, const Plugin::Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &delay_plugin_descriptor, parent, key ),
+DelayEffect::DelayEffect( Model* parent, Engine * engine, const Plugin::Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &delay_plugin_descriptor, parent, engine, key ),
 	m_delayControls( this )
 {
 	m_delay = 0;
-	m_delay = new StereoDelay( 20, Engine::mixer()->processingSampleRate() );
-	m_lfo = new Lfo( Engine::mixer()->processingSampleRate() );
+	m_delay = new StereoDelay( 20, getProcessingSampleRate() );
+	m_lfo = new Lfo( getProcessingSampleRate() );
 	m_outGain = 1.0;
 }
 
@@ -82,7 +82,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 		return( false );
 	}
 	double outSum = 0.0;
-	const float sr = Engine::mixer()->processingSampleRate();
+	const float sr = getProcessingSampleRate();
 	const float d = dryLevel();
 	const float w = wetLevel();
 	sample_t dryS[2];
@@ -117,7 +117,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 		m_delay->setFeedback( *feedbackPtr );
 		m_lfo->setFrequency( *lfoTimePtr );
-		sampleLength = *lengthPtr * Engine::mixer()->processingSampleRate();
+		sampleLength = *lengthPtr * getProcessingSampleRate();
 		m_currentLength = sampleLength;
 		m_delay->setLength( m_currentLength + ( *amplitudePtr * ( float )m_lfo->tick() ) );
 		m_delay->tick( buf[f] );
@@ -146,8 +146,8 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 void DelayEffect::changeSampleRate()
 {
-	m_lfo->setSampleRate( Engine::mixer()->processingSampleRate() );
-	m_delay->setSampleRate( Engine::mixer()->processingSampleRate() );
+	m_lfo->setSampleRate( getProcessingSampleRate() );
+	m_delay->setSampleRate( getProcessingSampleRate() );
 }
 
 
@@ -157,9 +157,9 @@ extern "C"
 {
 
 //needed for getting plugin out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new DelayEffect( parent , static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new DelayEffect( parent , engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }}

--- a/plugins/Delay/DelayEffect.h
+++ b/plugins/Delay/DelayEffect.h
@@ -34,7 +34,7 @@
 class DelayEffect : public Effect
 {
 public:
-	DelayEffect(Model* parent , const Descriptor::SubPluginFeatures::Key* key );
+	DelayEffect(Model* parent , Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~DelayEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 	virtual EffectControls* controls()

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -49,12 +49,12 @@ Plugin::Descriptor PLUGIN_EXPORT dualfilter_plugin_descriptor =
 
 
 
-DualFilterEffect::DualFilterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &dualfilter_plugin_descriptor, parent, key ),
+DualFilterEffect::DualFilterEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &dualfilter_plugin_descriptor, parent, engine, key ),
 	m_dfControls( this )
 {
-	m_filter1 = new BasicFilters<2>( Engine::mixer()->processingSampleRate() );
-	m_filter2 = new BasicFilters<2>( Engine::mixer()->processingSampleRate() );
+	m_filter1 = new BasicFilters<2>( getProcessingSampleRate() );
+	m_filter2 = new BasicFilters<2>( getProcessingSampleRate() );
 
 	// ensure filters get updated
 	m_filter1changed = true;
@@ -222,9 +222,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new DualFilterEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new DualFilterEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/DualFilter/DualFilter.h
+++ b/plugins/DualFilter/DualFilter.h
@@ -34,7 +34,7 @@
 class DualFilterEffect : public Effect
 {
 public:
-	DualFilterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	DualFilterEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~DualFilterEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/DualFilter/DualFilterControls.cpp
+++ b/plugins/DualFilter/DualFilterControls.cpp
@@ -97,7 +97,7 @@ DualFilterControls::DualFilterControls( DualFilterEffect* effect ) :
 	m_filter2Model.addItem( tr( "Fast Formant" ), new PixmapLoader( "filter_hp" ) );
 	m_filter2Model.addItem( tr( "Tripole" ), new PixmapLoader( "filter_lp" ) );
 
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateFilters() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateFilters() ) );
 }
 
 
@@ -108,8 +108,8 @@ void DualFilterControls::updateFilters()
 	
 	delete m_effect->m_filter1;
 	delete m_effect->m_filter2;
-	m_effect->m_filter1 = new BasicFilters<2>( Engine::mixer()->processingSampleRate() );
-	m_effect->m_filter2 = new BasicFilters<2>( Engine::mixer()->processingSampleRate() );
+	m_effect->m_filter1 = new BasicFilters<2>( m_effect->getProcessingSampleRate() );
+	m_effect->m_filter2 = new BasicFilters<2>( m_effect->getProcessingSampleRate() );
 	
 	// flag filters as needing recalculation
 	

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -50,8 +50,8 @@ Plugin::Descriptor PLUGIN_EXPORT eq_plugin_descriptor =
 }
 
 
-EqEffect::EqEffect(Model *parent, const Plugin::Descriptor::SubPluginFeatures::Key *key) :
-	Effect( &eq_plugin_descriptor, parent, key ),
+EqEffect::EqEffect(Model *parent, Engine * engine, const Plugin::Descriptor::SubPluginFeatures::Key *key) :
+	Effect( &eq_plugin_descriptor, parent, engine, key ),
 	m_eqControls( this ),
 	m_inGain( 1.0 ),
 	m_outGain( 1.0 )
@@ -185,12 +185,12 @@ bool EqEffect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 		outSum += buf[f][0]*buf[f][0] + buf[f][1]*buf[f][1];
 	}
 	const float outGain =  m_outGain;
-	const int sampleRate = Engine::mixer()->processingSampleRate();
+	const int sampleRate = getProcessingSampleRate();
 	sampleFrame m_inPeak = { 0, 0 };
 
 	if(m_eqControls.m_analyseIn )
 	{
-		m_eqControls.m_inFftBands.analyze( buf, frames );
+		m_eqControls.m_inFftBands.analyze( buf, frames, getProcessingSampleRate() );
 	}
 	else
 	{
@@ -328,7 +328,7 @@ bool EqEffect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 	checkGate( outSum / frames );
 	if(m_eqControls.m_analyseOut )
 	{
-		m_eqControls.m_outFftBands.analyze( buf, frames );
+		m_eqControls.m_outFftBands.analyze( buf, frames, getProcessingSampleRate() );
 		setBandPeaks( &m_eqControls.m_outFftBands , ( int )( sampleRate * 0.5 ) );
 	}
 	else
@@ -405,9 +405,9 @@ extern "C"
 {
 
 //needed for getting plugin out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new EqEffect( parent , static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new EqEffect( parent , engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/Eq/EqEffect.h
+++ b/plugins/Eq/EqEffect.h
@@ -36,7 +36,7 @@
 class EqEffect : public Effect
 {
 public:
-	EqEffect( Model* parent , const Descriptor::SubPluginFeatures::Key* key );
+	EqEffect( Model* parent , Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~EqEffect();
 	virtual bool processAudioBuffer( sampleFrame *buf, const fpp_t frames );
 	virtual EffectControls* controls()

--- a/plugins/Eq/EqSpectrumView.h
+++ b/plugins/Eq/EqSpectrumView.h
@@ -83,7 +83,7 @@ public:
 
 
 
-	void analyze( sampleFrame *buf, const fpp_t frames )
+	void analyze( sampleFrame *buf, const fpp_t frames, const sample_rate_t processingSampleRate )
 	{
 		if ( m_active )
 		{
@@ -109,7 +109,7 @@ public:
 				return;
 			}
 
-			m_sr = Engine::mixer()->processingSampleRate();
+			m_sr = processingSampleRate;
 			const int LOWEST_FREQ = 0;
 			const int HIGHEST_FREQ = m_sr / 2;
 

--- a/plugins/Flanger/FlangerControls.cpp
+++ b/plugins/Flanger/FlangerControls.cpp
@@ -42,7 +42,7 @@ FlangerControls::FlangerControls( FlangerEffect *effect ) :
 	m_invertFeedbackModel ( false , this, tr( "Invert" ) )
 
 {
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changedSampleRate() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changedSampleRate() ) );
 }
 
 

--- a/plugins/Flanger/FlangerEffect.h
+++ b/plugins/Flanger/FlangerEffect.h
@@ -36,7 +36,7 @@
 class FlangerEffect : public Effect
 {
 public:
-	FlangerEffect( Model* parent , const Descriptor::SubPluginFeatures::Key* key );
+	FlangerEffect( Model* parent , Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~FlangerEffect();
 	virtual bool processAudioBuffer( sampleFrame *buf, const fpp_t frames );
 	virtual EffectControls* controls()

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -232,7 +232,7 @@ class GigInstrument : public Instrument
 	mapPropertyFromModel( int, getPatch, setPatch, m_patchNum );
 
 public:
-	GigInstrument( InstrumentTrack * _instrument_track );
+	GigInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~GigInstrument();
 
 	virtual void play( sampleFrame * _working_buffer );

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -124,8 +124,8 @@ public:
 	}
 
 };
-HydrogenImport::HydrogenImport( const QString & _file ) :
-	ImportFilter( _file, &hydrogenimport_plugin_descriptor )
+HydrogenImport::HydrogenImport( const QString & _file, Engine * engine ) :
+	ImportFilter( _file, &hydrogenimport_plugin_descriptor, engine )
 {
 	filename = _file;
 }
@@ -143,7 +143,7 @@ bool HydrogenImport::readSong()
 	QHash<QString, int> pattern_length;
 	QHash<QString, int> pattern_id;
 
-	Song *s = Engine::getSong();
+	Song *s = getSong();
 	int song_num_tracks = s->tracks().size();
 	if ( QFile( filename ).exists() == false ) 
 	{
@@ -213,7 +213,7 @@ bool HydrogenImport::readSong()
 
 					if ( nLayer == 0 ) 
 					{
-						drum_track[sId] = ( InstrumentTrack * ) Track::create( Track::InstrumentTrack,Engine::getBBTrackContainer() );
+						drum_track[sId] = ( InstrumentTrack * ) Track::create( Track::InstrumentTrack, getBBTrackContainer() );
 						drum_track[sId]->volumeModel()->setValue( fVolume * 100 );
 						drum_track[sId]->panningModel()->setValue( ( fPan_R - fPan_L ) * 100 );
 						ins = drum_track[sId]->loadInstrument( "audiofileprocessor" );
@@ -237,7 +237,7 @@ bool HydrogenImport::readSong()
 	}
 	QDomNode patterns = songNode.firstChildElement( "patternList" );
 	int pattern_count = 0;
-	int nbb = Engine::getBBTrackContainer()->numOfBBs();
+	int nbb = getBBTrackContainer()->numOfBBs();
 	QDomNode patternNode =  patterns.firstChildElement( "pattern" );
 	int pn = 1;
 	while (  !patternNode.isNull()  ) 
@@ -340,10 +340,10 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
 	return new HydrogenImport( QString::fromUtf8(
-									static_cast<const char *>( _data ) ) );
+									static_cast<const char *>( _data ) ), engine );
 }
 
 

--- a/plugins/HydrogenImport/HydrogenImport.h
+++ b/plugins/HydrogenImport/HydrogenImport.h
@@ -11,7 +11,7 @@
 class HydrogenImport : public ImportFilter
 {
 public:
-	HydrogenImport( const QString & _file );
+	HydrogenImport( const QString & _file, Engine * engine );
         bool readSong();
 
 	virtual ~HydrogenImport();

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -39,7 +39,7 @@ class LadspaEffect : public Effect
 {
 	Q_OBJECT
 public:
-	LadspaEffect( Model * _parent,
+	LadspaEffect( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~LadspaEffect();
 
@@ -67,7 +67,7 @@ private:
 	void pluginInstantiation();
 	void pluginDestruction();
 
-	static sample_rate_t maxSamplerate( const QString & _name );
+	sample_rate_t maxSamplerate( const QString & _name );
 
 
 	QMutex m_pluginMutex;

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -55,7 +55,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiexport_plugin_descriptor =
 }
 
 
-MidiExport::MidiExport() : ExportFilter( &midiexport_plugin_descriptor)
+MidiExport::MidiExport(Engine * engine) : ExportFilter( &midiexport_plugin_descriptor, engine)
 {
 }
 
@@ -173,9 +173,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new MidiExport();
+	return new MidiExport(engine);
 }
 
 

--- a/plugins/MidiExport/MidiExport.h
+++ b/plugins/MidiExport/MidiExport.h
@@ -36,7 +36,7 @@ class MidiExport: public ExportFilter
 {
 // 	Q_OBJECT
 public:
-	MidiExport( );
+	MidiExport( Engine * engine );
 	~MidiExport();
 
 	virtual PluginView * instantiateView( QWidget * )

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -72,8 +72,8 @@ Plugin::Descriptor PLUGIN_EXPORT midiimport_plugin_descriptor =
 }
 
 
-MidiImport::MidiImport( const QString & _file ) :
-	ImportFilter( _file, &midiimport_plugin_descriptor ),
+MidiImport::MidiImport( const QString & _file, Engine * engine ) :
+	ImportFilter( _file, &midiimport_plugin_descriptor, engine ),
 	m_events(),
 	m_timingDivision( 0 )
 {
@@ -301,7 +301,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	smfMidiCC ccs[129];
 	smfMidiChannel chs[256];
 
-	MeterModel & timeSigMM = Engine::getSong()->getTimeSigModel();
+	MeterModel & timeSigMM = getSong()->getTimeSigModel();
 	AutomationPattern * timeSigNumeratorPat = 
 		AutomationPattern::globalAutomationPattern( &timeSigMM.numeratorModel() );
 	AutomationPattern * timeSigDenominatorPat = 
@@ -607,10 +607,10 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
 	return new MidiImport( QString::fromUtf8(
-									static_cast<const char *>( _data ) ) );
+									static_cast<const char *>( _data ) ), engine );
 }
 
 

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -37,7 +37,7 @@ class MidiImport : public ImportFilter
 {
 	Q_OBJECT
 public:
-	MidiImport( const QString & _file );
+	MidiImport( const QString & _file, Engine * engine );
 	virtual ~MidiImport();
 
 	virtual PluginView * instantiateView( QWidget * )

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -46,15 +46,15 @@ Plugin::Descriptor PLUGIN_EXPORT multitapecho_plugin_descriptor =
 }
 
 
-MultitapEchoEffect::MultitapEchoEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
-	Effect( &multitapecho_plugin_descriptor, parent, key ),
+MultitapEchoEffect::MultitapEchoEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key ) :
+	Effect( &multitapecho_plugin_descriptor, parent, engine, key ),
 	m_stages( 1 ),
 	m_controls( this ),
 	m_buffer( 16100.0f ),
-	m_sampleRate( Engine::mixer()->processingSampleRate() ),
+	m_sampleRate( getProcessingSampleRate() ),
 	m_sampleRatio( 1.0f / m_sampleRate )
 {
-	m_work = MM_ALLOC( sampleFrame, Engine::mixer()->framesPerPeriod() );
+	m_work = MM_ALLOC( sampleFrame, getFramesPerPeriod() );
 	m_buffer.reset();
 	m_stages = static_cast<int>( m_controls.m_stages.value() );
 	updateFilters( 0, 19 );
@@ -164,9 +164,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new MultitapEchoEffect( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new MultitapEchoEffect( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/MultitapEcho/MultitapEcho.h
+++ b/plugins/MultitapEcho/MultitapEcho.h
@@ -36,7 +36,7 @@
 class MultitapEchoEffect : public Effect
 {
 public:
-	MultitapEchoEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
+	MultitapEchoEffect( Model* parent, Engine * engine, const Descriptor::SubPluginFeatures::Key* key );
 	virtual ~MultitapEchoEffect();
 	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
 

--- a/plugins/MultitapEcho/MultitapEchoControls.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControls.cpp
@@ -47,7 +47,7 @@ MultitapEchoControls::MultitapEchoControls( MultitapEchoEffect * eff ) :
 	connect( &m_lpGraph, SIGNAL( samplesChanged( int, int ) ), this, SLOT( lpSamplesChanged( int, int ) ) );
 
 	connect( &m_steps, SIGNAL( dataChanged() ), this, SLOT( lengthChanged() ) );
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
 
 	setDefaultAmpShape();
 	setDefaultLpShape();
@@ -173,7 +173,7 @@ void MultitapEchoControls::lengthChanged()
 
 void MultitapEchoControls::sampleRateChanged()
 {
-	m_effect->m_sampleRate = Engine::mixer()->processingSampleRate();
+	m_effect->m_sampleRate = m_effect->getProcessingSampleRate();
 	m_effect->m_sampleRatio = 1.0f / m_effect->m_sampleRate;
 	m_effect->updateFilters( 0, 19 );
 }

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzer.cpp
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzer.cpp
@@ -47,9 +47,9 @@ Plugin::Descriptor PLUGIN_EXPORT spectrumanalyzer_plugin_descriptor =
 
 
 
-SpectrumAnalyzer::SpectrumAnalyzer( Model * _parent,
+SpectrumAnalyzer::SpectrumAnalyzer( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Effect( &spectrumanalyzer_plugin_descriptor, _parent, _key ),
+	Effect( &spectrumanalyzer_plugin_descriptor, _parent, engine, _key ),
 	m_saControls( this ),
 	m_framesFilledUp( 0 ),
 	m_energy( 0 )
@@ -127,7 +127,7 @@ bool SpectrumAnalyzer::processAudioBuffer( sampleFrame* _buf, const fpp_t _frame
 
 //	hanming( m_buffer, FFT_BUFFER_SIZE, HAMMING );
 
-	const sample_rate_t sr = Engine::mixer()->processingSampleRate();
+	const sample_rate_t sr = getProcessingSampleRate();
 	const int LOWEST_FREQ = 0;
 	const int HIGHEST_FREQ = sr / 2;
 
@@ -163,9 +163,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model* parent, Engine * engine, void* data )
 {
-	return new SpectrumAnalyzer( parent, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
+	return new SpectrumAnalyzer( parent, engine, static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( data ) );
 }
 
 }

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzer.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzer.h
@@ -44,7 +44,7 @@ public:
 		RightChannel
 	} ;
 
-	SpectrumAnalyzer( Model * _parent,
+	SpectrumAnalyzer( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~SpectrumAnalyzer();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/VstEffect/VstEffect.h
+++ b/plugins/VstEffect/VstEffect.h
@@ -36,7 +36,7 @@
 class VstEffect : public Effect
 {
 public:
-	VstEffect( Model * _parent,
+    VstEffect( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~VstEffect();
 

--- a/plugins/audio_file_processor/audio_file_processor.h
+++ b/plugins/audio_file_processor/audio_file_processor.h
@@ -42,7 +42,7 @@ class audioFileProcessor : public Instrument
 {
 	Q_OBJECT
 public:
-	audioFileProcessor( InstrumentTrack * _instrument_track );
+	audioFileProcessor( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~audioFileProcessor();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -135,8 +135,8 @@ sample_t bSynth::nextStringSample()
 ***********************************************************************/
 
 
-bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &bitinvader_plugin_descriptor ),
+bitInvader::bitInvader( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &bitinvader_plugin_descriptor, engine ),
 	m_sampleLength( 128, 4, 200, 1, this, tr( "Samplelength" ) ),
 	m_graph( -1.0f, 1.0f, 128, this ),
 	m_interpolation( false, this ),
@@ -279,7 +279,7 @@ void bitInvader::playNote( NotePlayHandle * _n,
 					m_graph.length(),
 					_n,
 					m_interpolation.value(), factor,
-				Engine::mixer()->processingSampleRate() );
+					getProcessingSampleRate() );
 	}
 
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
@@ -472,7 +472,7 @@ void bitInvaderView::modelChanged()
 void bitInvaderView::sinWaveClicked()
 {
 	m_graph->model()->setWaveToSine();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -481,7 +481,7 @@ void bitInvaderView::sinWaveClicked()
 void bitInvaderView::triangleWaveClicked()
 {
 	m_graph->model()->setWaveToTriangle();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -490,7 +490,7 @@ void bitInvaderView::triangleWaveClicked()
 void bitInvaderView::sawWaveClicked()
 {
 	m_graph->model()->setWaveToSaw();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -499,7 +499,7 @@ void bitInvaderView::sawWaveClicked()
 void bitInvaderView::sqrWaveClicked()
 {
 	m_graph->model()->setWaveToSquare();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -508,7 +508,7 @@ void bitInvaderView::sqrWaveClicked()
 void bitInvaderView::noiseWaveClicked()
 {
 	m_graph->model()->setWaveToNoise();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -518,10 +518,10 @@ void bitInvaderView::usrWaveClicked()
 {
 	QString fileName = m_graph->model()->setWaveToUser();
 	ToolTip::add( m_usrWaveBtn, fileName );
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 	/*
 	m_graph->model()->setWaveToNoise();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 	// zero sample_shape
 	for (int i = 0; i < sample_length; i++)
 	{
@@ -554,7 +554,7 @@ void bitInvaderView::usrWaveClicked()
 void bitInvaderView::smoothClicked()
 {
 	m_graph->model()->smooth();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -563,7 +563,7 @@ void bitInvaderView::smoothClicked()
 void bitInvaderView::interpolationToggled( bool value )
 {
 	m_graph->setGraphStyle( value ? Graph::LinearStyle : Graph::NearestStyle);
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -571,7 +571,7 @@ void bitInvaderView::interpolationToggled( bool value )
 
 void bitInvaderView::normalizeToggled( bool value )
 {
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -581,9 +581,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return( new bitInvader( static_cast<InstrumentTrack *>( _data ) ) );
+	return( new bitInvader( static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/bit_invader/bit_invader.h
+++ b/plugins/bit_invader/bit_invader.h
@@ -66,7 +66,7 @@ class bitInvader : public Instrument
 {
 	Q_OBJECT
 public:
-	bitInvader(InstrumentTrack * _instrument_track );
+	bitInvader(InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~bitInvader();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/carlabase/carla.h
+++ b/plugins/carlabase/carla.h
@@ -39,7 +39,7 @@ class PLUGIN_EXPORT CarlaInstrument : public Instrument
 public:
     static const uint32_t kMaxMidiEvents = 512;
 
-    CarlaInstrument(InstrumentTrack* const instrumentTrack, const Descriptor* const descriptor, const bool isPatchbay);
+    CarlaInstrument(InstrumentTrack* const instrumentTrack, const Descriptor* const descriptor, Engine * engine, const bool isPatchbay );
     virtual ~CarlaInstrument();
 
     // CarlaNative functions

--- a/plugins/carlarack/carlarack.cpp
+++ b/plugins/carlarack/carlarack.cpp
@@ -43,9 +43,9 @@ Plugin::Descriptor PLUGIN_EXPORT carlarack_plugin_descriptor =
     NULL
 } ;
 
-Plugin* PLUGIN_EXPORT lmms_plugin_main(Model*, void* data)
+Plugin* PLUGIN_EXPORT lmms_plugin_main(Model*, Engine * engine, void* data)
 {
-    return new CarlaInstrument(static_cast<InstrumentTrack*>(data), &carlarack_plugin_descriptor, false);
+    return new CarlaInstrument(static_cast<InstrumentTrack*>(data), &carlarack_plugin_descriptor, engine, false);
 }
 
 }

--- a/plugins/dynamics_processor/dynamics_processor.h
+++ b/plugins/dynamics_processor/dynamics_processor.h
@@ -35,7 +35,7 @@
 class dynProcEffect : public Effect
 {
 public:
-	dynProcEffect( Model * _parent,
+	dynProcEffect( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~dynProcEffect();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/dynamics_processor/dynamics_processor_controls.cpp
+++ b/plugins/dynamics_processor/dynamics_processor_controls.cpp
@@ -48,7 +48,7 @@ dynProcControls::dynProcControls( dynProcEffect * _eff ) :
 {
 	connect( &m_wavegraphModel, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( samplesChanged( int, int ) ) );
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
+	connect( m_effect->getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
 
 	setDefaultShape();
 
@@ -63,7 +63,7 @@ void dynProcControls::sampleRateChanged()
 
 void dynProcControls::samplesChanged( int _begin, int _end)
 {
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 
@@ -126,13 +126,13 @@ void dynProcControls::setDefaultShape()
 void dynProcControls::resetClicked()
 {
 	setDefaultShape();
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void dynProcControls::smoothClicked()
 {
 	m_wavegraphModel.smoothNonCyclic();
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void dynProcControls::addOneClicked()
@@ -141,7 +141,7 @@ void dynProcControls::addOneClicked()
 	{
 		m_wavegraphModel.setSampleAt( i, qBound( 0.0f, m_wavegraphModel.samples()[i] * onedB, 1.0f ) );
 	}
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void dynProcControls::subOneClicked()
@@ -150,7 +150,7 @@ void dynProcControls::subOneClicked()
 	{
 		m_wavegraphModel.setSampleAt( i, qBound( 0.0f, m_wavegraphModel.samples()[i] / onedB, 1.0f ) );
 	}
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 

--- a/plugins/flp_import/FlpImport.h
+++ b/plugins/flp_import/FlpImport.h
@@ -40,7 +40,7 @@ struct FL_Channel;
 class FlpImport : public ImportFilter
 {
 public:
-	FlpImport( const QString & _file );
+	FlpImport( const QString & _file, Engine * engine );
 	virtual ~FlpImport();
 
 	virtual PluginView * instantiateView( QWidget * )

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -57,8 +57,8 @@ Plugin::Descriptor PLUGIN_EXPORT kicker_plugin_descriptor =
 }
 
 
-kickerInstrument::kickerInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &kicker_plugin_descriptor ),
+kickerInstrument::kickerInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &kicker_plugin_descriptor, engine ),
 	m_startFreqModel( 150.0f, 5.0f, 1000.0f, 1.0f, this, tr( "Start frequency" ) ),
 	m_endFreqModel( 40.0f, 5.0f, 1000.0f, 1.0f, this, tr( "End frequency" ) ),
 	m_decayModel( 440.0f, 5.0f, 5000.0f, 1.0f, 5000.0f, this, tr( "Length" ) ),
@@ -166,7 +166,7 @@ void kickerInstrument::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 	const float decfr = m_decayModel.value() *
-		Engine::mixer()->processingSampleRate() / 1000.0f;
+		getProcessingSampleRate() / 1000.0f;
 	const f_cnt_t tfp = _n->totalFramesPlayed();
 
 	if ( tfp == 0 )
@@ -190,7 +190,7 @@ void kickerInstrument::playNote( NotePlayHandle * _n,
 	}
 
 	SweepOsc * so = static_cast<SweepOsc *>( _n->m_pluginData );
-	so->update( _working_buffer + offset, frames, Engine::mixer()->processingSampleRate() );
+	so->update( _working_buffer + offset, frames, getProcessingSampleRate() );
 
 	if( _n->isReleased() )
 	{
@@ -366,9 +366,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new kickerInstrument( static_cast<InstrumentTrack *>( _data ) );
+	return new kickerInstrument( static_cast<InstrumentTrack *>( _data ), engine );
 }
 
 

--- a/plugins/kicker/kicker.h
+++ b/plugins/kicker/kicker.h
@@ -46,7 +46,7 @@ class kickerInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	kickerInstrument( InstrumentTrack * _instrument_track );
+	kickerInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~kickerInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/ladspa_browser/ladspa_browser.h
+++ b/plugins/ladspa_browser/ladspa_browser.h
@@ -58,7 +58,7 @@ private:
 class ladspaBrowser : public ToolPlugin
 {
 public:
-	ladspaBrowser();
+	ladspaBrowser(Engine * engine);
 	virtual ~ladspaBrowser();
 
 	virtual PluginView * instantiateView( QWidget * )

--- a/plugins/ladspa_browser/ladspa_description.cpp
+++ b/plugins/ladspa_browser/ladspa_description.cpp
@@ -30,18 +30,17 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
-#include "AudioDevice.h"
-#include "Engine.h"
 #include "Ladspa2LMMS.h"
-#include "Mixer.h"
-
 
 
 ladspaDescription::ladspaDescription( QWidget * _parent,
-						ladspaPluginType _type ) :
-	QWidget( _parent )
+				      ladspaPluginType _type,
+				      Ladspa2LMMS * ladspaManager,
+				      ch_cnt_t const numberOfChannels) :
+	QWidget( _parent ),
+	m_ladspaManager(ladspaManager)
 {
-	Ladspa2LMMS * manager = Engine::getLADSPAManager();
+	Ladspa2LMMS * manager = getLADSPAManager();
 
 	l_sortable_plugin_t plugins;
 	switch( _type )
@@ -74,7 +73,7 @@ ladspaDescription::ladspaDescription( QWidget * _parent,
 	{
 		if( _type != VALID || 
 			manager->getDescription( ( *it ).second )->inputChannels
-				<= Engine::mixer()->audioDev()->channels() )
+				<= numberOfChannels )
 		{ 
 			pluginNames.push_back( ( *it ).first );
 			m_pluginKeys.push_back( ( *it ).second );
@@ -128,7 +127,7 @@ void ladspaDescription::update( const ladspa_key_t & _key )
 	QVBoxLayout * layout = new QVBoxLayout( description );
 	layout->setSizeConstraint( QLayout::SetFixedSize );
 
-	Ladspa2LMMS * manager = Engine::getLADSPAManager();
+	Ladspa2LMMS * manager = getLADSPAManager();
 
 	QLabel * name = new QLabel( description );
 	name->setText( QWidget::tr( "Name: " ) + manager->getName( _key ) );

--- a/plugins/ladspa_browser/ladspa_description.h
+++ b/plugins/ladspa_browser/ladspa_description.h
@@ -32,6 +32,8 @@
 #include "LadspaManager.h"
 
 
+class Ladspa2LMMS;
+
 class QListWidgetItem;
 class QScrollArea;
 
@@ -40,7 +42,7 @@ class ladspaDescription : public QWidget
 {
 	Q_OBJECT
 public:
-	ladspaDescription( QWidget * _parent, ladspaPluginType _type );
+	ladspaDescription( QWidget * _parent, ladspaPluginType _type, Ladspa2LMMS * m_ladspaManager, ch_cnt_t const );
 	virtual ~ladspaDescription();
 
 
@@ -60,6 +62,12 @@ private:
 private slots:
 	void rowChanged( int _pluginIndex );
 	void onDoubleClicked( QListWidgetItem * _item );
+
+private:
+	Ladspa2LMMS * getLADSPAManager() const { return m_ladspaManager; }
+
+private:
+	Ladspa2LMMS * m_ladspaManager;
 
 } ;
 

--- a/plugins/ladspa_browser/ladspa_port_dialog.cpp
+++ b/plugins/ladspa_browser/ladspa_port_dialog.cpp
@@ -29,15 +29,11 @@
 #include <QTableWidget>
 
 #include "embed.h"
-#include "Engine.h"
 #include "Ladspa2LMMS.h"
-#include "Mixer.h"
 
 
-ladspaPortDialog::ladspaPortDialog( const ladspa_key_t & _key )
+ladspaPortDialog::ladspaPortDialog( const ladspa_key_t & _key, Ladspa2LMMS * manager, sample_rate_t processingSampleRate )
 {
-	Ladspa2LMMS * manager = Engine::getLADSPAManager();
-
 	setWindowIcon( embed::getIconPixmap( "ports" ) );
 	setWindowTitle( tr( "Ports" ) );
 	setModal( true );
@@ -87,11 +83,11 @@ ladspaPortDialog::ladspaPortDialog( const ladspa_key_t & _key )
 		{
 			if( min != NOHINT )
 			{
-				min *= Engine::mixer()->processingSampleRate();
+				min *= processingSampleRate;
 			}
 			if( max != NOHINT )
 			{
-				max *= Engine::mixer()->processingSampleRate();
+				max *= processingSampleRate;
 			}
 		}
 

--- a/plugins/ladspa_browser/ladspa_port_dialog.h
+++ b/plugins/ladspa_browser/ladspa_port_dialog.h
@@ -31,14 +31,14 @@
 
 #include "LadspaManager.h"
 
-
+class Ladspa2LMMS;
 
 
 class ladspaPortDialog : public QDialog
 {
 	Q_OBJECT
 public:
-	ladspaPortDialog( const ladspa_key_t & _key );
+	ladspaPortDialog( const ladspa_key_t & _key, Ladspa2LMMS * manager, sample_rate_t processingSampleRate );
 	virtual ~ladspaPortDialog();
 
 };

--- a/plugins/lb302/lb302.h
+++ b/plugins/lb302/lb302.h
@@ -63,8 +63,8 @@ class lb302Filter
 	lb302Filter(lb302FilterKnobState* p_fs);
 	virtual ~lb302Filter() {};
 
-	virtual void recalc();
-	virtual void envRecalc();
+	virtual void recalc( sample_rate_t processingSampleRate );
+	virtual void envRecalc( sample_rate_t processingSampleRate );
 	virtual float process(const float& samp)=0;
 	virtual void playNote();
 
@@ -84,8 +84,8 @@ class lb302FilterIIR2 : public lb302Filter
 	lb302FilterIIR2(lb302FilterKnobState* p_fs);
 	virtual ~lb302FilterIIR2();
 
-	virtual void recalc();
-	virtual void envRecalc();
+	virtual void recalc( sample_rate_t processingSampleRate );
+	virtual void envRecalc( sample_rate_t processingSampleRate );
 	virtual float process(const float& samp);
 
 	protected:
@@ -108,8 +108,8 @@ class lb302Filter3Pole : public lb302Filter
 	lb302Filter3Pole(lb302FilterKnobState* p_fs);
 
 	//virtual void recalc();
-	virtual void envRecalc();
-	virtual void recalc();
+	virtual void envRecalc( sample_rate_t processingSampleRate );
+	virtual void recalc( sample_rate_t processingSampleRate );
 	virtual float process(const float& samp);
 
 	protected:
@@ -139,7 +139,7 @@ class lb302Synth : public Instrument
 {
 	Q_OBJECT
 public:
-	lb302Synth( InstrumentTrack * _instrument_track );
+	lb302Synth( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~lb302Synth();
 
 	virtual void play( sampleFrame * _working_buffer );

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -825,8 +825,8 @@ inline sample_t MonstroSynth::calcSlope( int slope, sample_t s )
 }
 
 
-MonstroInstrument::MonstroInstrument( InstrumentTrack * _instrument_track ) :
-		Instrument( _instrument_track, &monstro_plugin_descriptor ),
+MonstroInstrument::MonstroInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+		Instrument( _instrument_track, &monstro_plugin_descriptor, engine ),
 
 		m_osc1Vol( 33.0, 0.0, 200.0, 0.1, this, tr( "Osc 1 Volume" ) ),
 		m_osc1Pan( 0.0, -100.0, 100.0, 0.1, this, tr( "Osc 1 Panning" ) ),
@@ -1005,9 +1005,9 @@ MonstroInstrument::MonstroInstrument( InstrumentTrack * _instrument_track ) :
 
 // updateSampleRate
 
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateSamplerate() ) );
+	connect( getMixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateSamplerate() ) );
 
-	m_fpp = Engine::mixer()->framesPerPeriod();
+	m_fpp = getFramesPerPeriod();
 
 	updateSamplerate();
 	updateVolume1();
@@ -1418,7 +1418,7 @@ void MonstroInstrument::updateLFOAtts()
 
 void MonstroInstrument::updateSamplerate()
 {
-	m_samplerate = Engine::mixer()->processingSampleRate();
+	m_samplerate = getProcessingSampleRate();
 	
 	m_integrator = 0.5f - ( 0.5f - INTEGRATOR ) * 44100.0f / m_samplerate;
 	m_fmCorrection = 44100.f / m_samplerate * FM_AMOUNT;
@@ -1963,9 +1963,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new MonstroInstrument( static_cast<InstrumentTrack *>( _data ) );
+	return new MonstroInstrument( static_cast<InstrumentTrack *>( _data ), engine );
 }
 
 

--- a/plugins/monstro/Monstro.h
+++ b/plugins/monstro/Monstro.h
@@ -336,7 +336,7 @@ class MonstroInstrument : public Instrument
 		name .addItem( tr( "Random smooth" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "rand" ) ) );
 
 public:
-	MonstroInstrument( InstrumentTrack * _instrument_track );
+	MonstroInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~MonstroInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/nes/Nes.cpp
+++ b/plugins/nes/Nes.cpp
@@ -483,8 +483,8 @@ void NesObject::updatePitch()
 
 
 
-NesInstrument::NesInstrument( InstrumentTrack * instrumentTrack ) :
-	Instrument( instrumentTrack, &nes_plugin_descriptor ),
+NesInstrument::NesInstrument( InstrumentTrack * instrumentTrack, Engine * engine ) :
+	Instrument( instrumentTrack, &nes_plugin_descriptor, engine ),
 	m_ch1Enabled( true, this ),
 	m_ch1Crs( 0.f, -24.f, 24.f, 1.f, this, tr( "Channel 1 Coarse detune" ) ),
 	m_ch1Volume( 15.f, 0.f, 15.f, 1.f, this, tr( "Channel 1 Volume" ) ),
@@ -560,7 +560,7 @@ void NesInstrument::playNote( NotePlayHandle * n, sampleFrame * workingBuffer )
 	
 	if ( n->totalFramesPlayed() == 0 || n->m_pluginData == NULL )
 	{	
-		NesObject * nes = new NesObject( this, Engine::mixer()->processingSampleRate(), n );
+		NesObject * nes = new NesObject( this, getProcessingSampleRate(), n );
 		n->m_pluginData = nes;
 	}
 	
@@ -917,9 +917,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return( new NesInstrument( static_cast<InstrumentTrack *>( _data ) ) );
+	return( new NesInstrument( static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/nes/Nes.h
+++ b/plugins/nes/Nes.h
@@ -199,7 +199,7 @@ class NesInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	NesInstrument( InstrumentTrack * instrumentTrack );
+	NesInstrument( InstrumentTrack * instrumentTrack, Engine * engine );
 	virtual ~NesInstrument();
 	
 	virtual void playNote( NotePlayHandle * n,

--- a/plugins/opl2/opl2instrument.h
+++ b/plugins/opl2/opl2instrument.h
@@ -45,7 +45,7 @@ class opl2instrument : public Instrument
 {
 	Q_OBJECT
 public:
-	opl2instrument( InstrumentTrack * _instrument_track );
+	opl2instrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~opl2instrument();
 
 	virtual QString nodeName() const;

--- a/plugins/organic/organic.h
+++ b/plugins/organic/organic.h
@@ -32,6 +32,7 @@
 #include "InstrumentView.h"
 #include "Oscillator.h"
 #include "AutomatableModel.h"
+#include "EngineClient.h"
 
 class QPixmap;
 
@@ -72,7 +73,7 @@ const QString WAVEFORM_NAMES[6] = {
 	
 const float CENT = 1.0f / 1200.0f;
 
-class OscillatorObject : public Model
+class OscillatorObject : public Model, public EngineClient
 {
 	Q_OBJECT
 	MM_OPERATORS
@@ -94,7 +95,7 @@ private:
 	float m_phaseOffsetLeft;
 	float m_phaseOffsetRight;
 
-	OscillatorObject( Model * _parent, int _index );
+	OscillatorObject( Model * _parent, int _index, Engine * engine );
 	virtual ~OscillatorObject();
 
 	friend class organicInstrument;
@@ -113,7 +114,7 @@ class organicInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	organicInstrument( InstrumentTrack * _instrument_track );
+	organicInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~organicInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/papu/papu_instrument.cpp
+++ b/plugins/papu/papu_instrument.cpp
@@ -59,8 +59,8 @@ Plugin::Descriptor PLUGIN_EXPORT papu_plugin_descriptor =
 }
 
 
-papuInstrument::papuInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &papu_plugin_descriptor ),
+papuInstrument::papuInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &papu_plugin_descriptor, engine ),
 
 	m_ch1SweepTimeModel( 4.0f, 0.0f, 7.0f, 1.0f, this, tr( "Sweep time" ) ),
 	m_ch1SweepDirModel( false, this, tr( "Sweep direction" ) ),
@@ -215,7 +215,7 @@ QString papuInstrument::nodeName() const
 
 /*f_cnt_t papuInstrument::desiredReleaseFrames() const
 {
-	const float samplerate = Engine::mixer()->processingSampleRate();
+	const float samplerate = getSampleRate();
 	int maxrel = 0;
 	for( int i = 0 ; i < 3 ; ++i )
 	{
@@ -237,7 +237,7 @@ void papuInstrument::playNote( NotePlayHandle * _n,
 						sampleFrame * _working_buffer )
 {
 	const f_cnt_t tfp = _n->totalFramesPlayed();
-	const int samplerate = Engine::mixer()->processingSampleRate();
+	const int samplerate = getProcessingSampleRate();
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
@@ -736,10 +736,10 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
 	return( new papuInstrument(
-				static_cast<InstrumentTrack *>( _data ) ) );
+				static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/papu/papu_instrument.h
+++ b/plugins/papu/papu_instrument.h
@@ -41,7 +41,7 @@ class papuInstrument : public Instrument
 	Q_OBJECT
 public:
 
-	papuInstrument( InstrumentTrack * _instrument_track );
+	papuInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~papuInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/patman/patman.cpp
+++ b/plugins/patman/patman.cpp
@@ -64,9 +64,9 @@ Plugin::Descriptor PLUGIN_EXPORT patman_plugin_descriptor =
 
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new patmanInstrument( static_cast<InstrumentTrack *>( _data ) );
+	return new patmanInstrument( static_cast<InstrumentTrack *>( _data ), engine );
 }
 
 }
@@ -74,8 +74,8 @@ Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
 
 
 
-patmanInstrument::patmanInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &patman_plugin_descriptor ),
+patmanInstrument::patmanInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &patman_plugin_descriptor, engine ),
 	m_patchFile( QString::null ),
 	m_loopedModel( true, this ),
 	m_tunedModel( true, this )
@@ -551,7 +551,7 @@ void PatmanView::openFile( void )
 		if( f != "" )
 		{
 			m_pi->setFile( f );
-			Engine::getSong()->setModified();
+			model()->getSong()->setModified();
 		}
 	}
 }

--- a/plugins/patman/patman.h
+++ b/plugins/patman/patman.h
@@ -49,7 +49,7 @@ class patmanInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	patmanInstrument( InstrumentTrack * _track );
+	patmanInstrument( InstrumentTrack * _track, Engine * engine );
 	virtual ~patmanInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -58,16 +58,16 @@ Plugin::Descriptor PLUGIN_EXPORT peakcontrollereffect_plugin_descriptor =
 //QVector<PeakControllerEffect *> PeakControllerEffect::s_effects;
 
 PeakControllerEffect::PeakControllerEffect(
-			Model * _parent,
+			Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Effect( &peakcontrollereffect_plugin_descriptor, _parent, _key ),
+	Effect( &peakcontrollereffect_plugin_descriptor, _parent, engine, _key ),
 	m_effectId( rand() ),
 	m_peakControls( this ),
 	m_lastSample( 0 ),
 	m_autoController( NULL )
 {
-	m_autoController = new PeakController( Engine::getSong(), this );
-	Engine::getSong()->addController( m_autoController );
+	m_autoController = new PeakController( getSong(), this );
+	getSong()->addController( m_autoController );
 	PeakController::s_effects.append( this );
 }
 
@@ -80,7 +80,7 @@ PeakControllerEffect::~PeakControllerEffect()
 	if( idx >= 0 )
 	{
 		PeakController::s_effects.remove( idx );
-		Engine::getSong()->removeController( m_autoController );
+		getSong()->removeController( m_autoController );
 	}
 }
 
@@ -145,9 +145,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, Engine * engine, void * _data )
 {
-	return new PeakControllerEffect( _parent,
+	return new PeakControllerEffect( _parent, engine,
 		static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>( _data ) );
 }
 

--- a/plugins/peak_controller_effect/peak_controller_effect.h
+++ b/plugins/peak_controller_effect/peak_controller_effect.h
@@ -32,7 +32,7 @@
 class PeakControllerEffect : public Effect
 {
 public:
-	PeakControllerEffect( Model * parent, 
+	PeakControllerEffect( Model * parent, Engine * engine,
 						const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~PeakControllerEffect();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
@@ -72,7 +72,7 @@ void PeakControllerEffectControls::loadSettings( const QDomElement & _this )
 	 * m_effectId is copied, then there would be two instruments
 	 * having the same id.
 	 */
-	if( Engine::getSong()->isLoadingProject() == true )
+	if( m_effect->getSong()->isLoadingProject() == true )
 	{
 		m_effect->m_effectId = _this.attribute( "effectId" ).toInt();
 	}

--- a/plugins/sf2_player/sf2_player.h
+++ b/plugins/sf2_player/sf2_player.h
@@ -55,7 +55,7 @@ class sf2Instrument : public Instrument
 	mapPropertyFromModel(int,getPatch,setPatch,m_patchNum);
 
 public:
-	sf2Instrument( InstrumentTrack * _instrument_track );
+	sf2Instrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~sf2Instrument();
 
 	virtual void play( sampleFrame * _working_buffer );

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -321,8 +321,8 @@ bool SfxrSynth::isPlaying() const
 
 
 
-sfxrInstrument::sfxrInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &sfxr_plugin_descriptor ),
+sfxrInstrument::sfxrInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &sfxr_plugin_descriptor, engine ),
 	m_attModel(0.0f, this, "Attack Time"),
 	m_holdModel(0.3f, this, "Sustain Time"),
 	m_susModel(0.0f, this, "Sustain Punch"),
@@ -452,7 +452,7 @@ QString sfxrInstrument::nodeName() const
 
 void sfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 {
-	float currentSampleRate = Engine::mixer()->processingSampleRate();
+	float currentSampleRate = getProcessingSampleRate();
 
     fpp_t frameNum = _n->framesLeftForCurrentPeriod();
     const f_cnt_t offset = _n->noteOffset();
@@ -1117,9 +1117,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model*, void* data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model*, Engine * engine, void* data )
 {
-	return new sfxrInstrument( static_cast<InstrumentTrack *>( data ) );
+	return new sfxrInstrument( static_cast<InstrumentTrack *>( data ), engine );
 }
 
 

--- a/plugins/sfxr/sfxr.h
+++ b/plugins/sfxr/sfxr.h
@@ -168,7 +168,7 @@ class sfxrInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	sfxrInstrument(InstrumentTrack * _instrument_track );
+	sfxrInstrument(InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~sfxrInstrument();
 
 	virtual void playNote( NotePlayHandle * _n, sampleFrame * _working_buffer );

--- a/plugins/sid/sid_instrument.cpp
+++ b/plugins/sid/sid_instrument.cpp
@@ -116,8 +116,8 @@ voiceObject::~voiceObject()
 }
 
 
-sidInstrument::sidInstrument( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &sid_plugin_descriptor ),
+sidInstrument::sidInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &sid_plugin_descriptor, engine ),
 	// filter	
 	m_filterFCModel( 1024.0f, 0.0f, 2047.0f, 1.0f, this, tr( "Cutoff" ) ),
 	m_filterResonanceModel( 8.0f, 0.0f, 15.0f, 1.0f, this, tr( "Resonance" ) ),
@@ -230,7 +230,7 @@ QString sidInstrument::nodeName() const
 
 f_cnt_t sidInstrument::desiredReleaseFrames() const
 {
-	const float samplerate = Engine::mixer()->processingSampleRate();
+	const float samplerate = getProcessingSampleRate();
 	int maxrel = 0;
 	for( int i = 0 ; i < 3 ; ++i )
 	{
@@ -305,7 +305,7 @@ void sidInstrument::playNote( NotePlayHandle * _n,
 	const f_cnt_t tfp = _n->totalFramesPlayed();
 
 	const int clockrate = C64_PAL_CYCLES_PER_SEC;
-	const int samplerate = Engine::mixer()->processingSampleRate();
+	const int samplerate = getProcessingSampleRate();
 
 	if ( tfp == 0 )
 	{
@@ -820,10 +820,10 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
 	return( new sidInstrument(
-				static_cast<InstrumentTrack *>( _data ) ) );
+				static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/sid/sid_instrument.h
+++ b/plugins/sid/sid_instrument.h
@@ -89,7 +89,7 @@ public:
 	};
 
 
-	sidInstrument( InstrumentTrack * _instrument_track );
+	sidInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~sidInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/stereo_enhancer/stereo_enhancer.cpp
+++ b/plugins/stereo_enhancer/stereo_enhancer.cpp
@@ -50,9 +50,9 @@ Plugin::Descriptor PLUGIN_EXPORT stereoenhancer_plugin_descriptor =
 
 
 stereoEnhancerEffect::stereoEnhancerEffect(
-			Model * _parent,
+			Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Effect( &stereoenhancer_plugin_descriptor, _parent, _key ),
+	Effect( &stereoenhancer_plugin_descriptor, _parent, engine, _key ),
 	m_seFX( DspEffectLibrary::StereoEnhancer( 0.0f ) ),
 	m_delayBuffer( new sampleFrame[DEFAULT_BUFFER_SIZE] ),
 	m_currFrame( 0 ),
@@ -163,9 +163,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, Engine * engine, void * _data )
 {
-	return( new stereoEnhancerEffect( _parent,
+	return( new stereoEnhancerEffect( _parent, engine,
 		static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>(
 								_data ) ) );
 }

--- a/plugins/stereo_enhancer/stereo_enhancer.h
+++ b/plugins/stereo_enhancer/stereo_enhancer.h
@@ -34,7 +34,7 @@
 class stereoEnhancerEffect : public Effect
 {
 public:
-	stereoEnhancerEffect( Model * parent,
+	stereoEnhancerEffect( Model * parent, Engine * engine,
 	                      const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~stereoEnhancerEffect();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/stereo_matrix/stereo_matrix.cpp
+++ b/plugins/stereo_matrix/stereo_matrix.cpp
@@ -50,9 +50,9 @@ Plugin::Descriptor PLUGIN_EXPORT stereomatrix_plugin_descriptor =
 
 
 stereoMatrixEffect::stereoMatrixEffect(
-			Model * _parent,
+			Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Effect( &stereomatrix_plugin_descriptor, _parent, _key ),
+	Effect( &stereomatrix_plugin_descriptor, _parent, engine, _key ),
 	m_smControls( this )
 {
 }
@@ -113,9 +113,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, Engine * engine, void * _data )
 {
-	return( new stereoMatrixEffect( _parent,
+	return( new stereoMatrixEffect( _parent, engine,
 		static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>(
 								_data ) ) );
 }

--- a/plugins/stereo_matrix/stereo_matrix.h
+++ b/plugins/stereo_matrix/stereo_matrix.h
@@ -32,7 +32,7 @@
 class stereoMatrixEffect : public Effect
 {
 public:
-	stereoMatrixEffect( Model * parent, 
+	stereoMatrixEffect( Model * parent, Engine * engine,
 	                      const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~stereoMatrixEffect();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -60,8 +60,8 @@ Plugin::Descriptor PLUGIN_EXPORT malletsstk_plugin_descriptor =
 }
 
 
-malletsInstrument::malletsInstrument( InstrumentTrack * _instrument_track ):
-	Instrument( _instrument_track, &malletsstk_plugin_descriptor ),
+malletsInstrument::malletsInstrument( InstrumentTrack * _instrument_track, Engine * engine ):
+	Instrument( _instrument_track, &malletsstk_plugin_descriptor, engine ),
 	m_hardnessModel(64.0f, 0.0f, 128.0f, 0.1f, this, tr( "Hardness" )),
 	m_positionModel(64.0f, 0.0f, 128.0f, 0.1f, this, tr( "Position" )),
 	m_vibratoGainModel(64.0f, 0.0f, 128.0f, 0.1f, this, tr( "Vibrato Gain" )),
@@ -224,7 +224,7 @@ void malletsInstrument::playNote( NotePlayHandle * _n,
 						m_vibratoFreqModel.value(),
 						p,
 						(uint8_t) m_spreadModel.value(),
-				Engine::mixer()->processingSampleRate() );
+						getProcessingSampleRate() );
 		}
 		else if( p == 9 )
 		{
@@ -237,7 +237,7 @@ void malletsInstrument::playNote( NotePlayHandle * _n,
 						m_lfoSpeedModel.value(),
 						m_adsrModel.value(),
 						(uint8_t) m_spreadModel.value(),
-				Engine::mixer()->processingSampleRate() );
+						getProcessingSampleRate() );
 		}
 		else
 		{
@@ -250,7 +250,7 @@ void malletsInstrument::playNote( NotePlayHandle * _n,
 						m_strikeModel.value() * 128.0,
 						m_velocityModel.value(),
 						(uint8_t) m_spreadModel.value(),
-				Engine::mixer()->processingSampleRate() );
+						getProcessingSampleRate() );
 		}
 		m.unlock();
 	}
@@ -661,9 +661,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new malletsInstrument( static_cast<InstrumentTrack *>( _data ) );
+	return new malletsInstrument( static_cast<InstrumentTrack *>( _data ), engine );
 }
 
 

--- a/plugins/stk/mallets/mallets.h
+++ b/plugins/stk/mallets/mallets.h
@@ -135,7 +135,7 @@ class malletsInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	malletsInstrument( InstrumentTrack * _instrument_track );
+	malletsInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~malletsInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -63,8 +63,9 @@ Plugin::Descriptor PLUGIN_EXPORT tripleoscillator_plugin_descriptor =
 
 
 
-OscillatorObject::OscillatorObject( Model * _parent, int _idx ) :
+OscillatorObject::OscillatorObject( Model * _parent, int _idx, Engine * engine ) :
 	Model( _parent ),
+	EngineClient( engine ),
 	m_volumeModel( DefaultVolume / NUM_OF_OSCILLATORS, MinVolume,
 			MaxVolume, 1.0f, this, tr( "Osc %1 volume" ).arg( _idx+1 ) ),
 	m_panModel( DefaultPanning, PanningLeft, PanningRight, 1.0f, this,
@@ -175,7 +176,7 @@ void OscillatorObject::updateDetuningLeft()
 {
 	m_detuningLeft = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
 				+ (float)m_fineLeftModel.value() ) / 1200.0f )
-				/ Engine::mixer()->processingSampleRate();
+				/ getEngine()->mixer()->processingSampleRate();
 }
 
 
@@ -185,7 +186,7 @@ void OscillatorObject::updateDetuningRight()
 {
 	m_detuningRight = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
 				+ (float)m_fineRightModel.value() ) / 1200.0f )
-				/ Engine::mixer()->processingSampleRate();
+				/ getEngine()->mixer()->processingSampleRate();
 }
 
 
@@ -208,16 +209,16 @@ void OscillatorObject::updatePhaseOffsetRight()
 
  
 
-TripleOscillator::TripleOscillator( InstrumentTrack * _instrument_track ) :
-	Instrument( _instrument_track, &tripleoscillator_plugin_descriptor )
+TripleOscillator::TripleOscillator( InstrumentTrack * _instrument_track, Engine * engine ) :
+	Instrument( _instrument_track, &tripleoscillator_plugin_descriptor, engine )
 {
 	for( int i = 0; i < NUM_OF_OSCILLATORS; ++i )
 	{
-		m_osc[i] = new OscillatorObject( this, i );
+		m_osc[i] = new OscillatorObject( this, i, engine );
 
 	}
 
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ),
+	connect( getMixer(), SIGNAL( sampleRateChanged() ),
 			this, SLOT( updateAllDetuning() ) );
 }
 
@@ -790,9 +791,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return new TripleOscillator( static_cast<InstrumentTrack *>( _data ) );
+	return new TripleOscillator( static_cast<InstrumentTrack *>( _data ), engine );
 }
 
 }

--- a/plugins/triple_oscillator/TripleOscillator.h
+++ b/plugins/triple_oscillator/TripleOscillator.h
@@ -30,6 +30,7 @@
 #include "InstrumentView.h"
 #include "Oscillator.h"
 #include "AutomatableModel.h"
+#include "EngineClient.h"
 
 
 class automatableButtonGroup;
@@ -41,12 +42,12 @@ class SampleBuffer;
 const int NUM_OF_OSCILLATORS = 3;
 
 
-class OscillatorObject : public Model
+class OscillatorObject : public Model, public EngineClient
 {
 	MM_OPERATORS
 	Q_OBJECT
 public:
-	OscillatorObject( Model * _parent, int _idx );
+	OscillatorObject( Model * _parent, int _idx, Engine * engine );
 	virtual ~OscillatorObject();
 
 
@@ -94,7 +95,7 @@ class TripleOscillator : public Instrument
 {
 	Q_OBJECT
 public:
-	TripleOscillator( InstrumentTrack * _track );
+	TripleOscillator( InstrumentTrack * _track, Engine * engine );
 	virtual ~TripleOscillator();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/vestige/vestige.h
+++ b/plugins/vestige/vestige.h
@@ -51,7 +51,7 @@ class vestigeInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	vestigeInstrument( InstrumentTrack * _instrument_track );
+    vestigeInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~vestigeInstrument();
 
 	virtual void play( sampleFrame * _working_buffer );

--- a/plugins/vibed/string_container.cpp
+++ b/plugins/vibed/string_container.cpp
@@ -51,7 +51,8 @@ void stringContainer::addString(int _harm,
 				const float _detune,
 				const int _oversample,
 				const bool _state,
-				const int _id )
+				const int _id,
+				const sample_rate_t baseSampleRate)
 {
 	float harm;
 	switch( _harm )
@@ -97,6 +98,7 @@ void stringContainer::addString(int _harm,
 						_randomize,
 						_string_loss,
 						_detune,
-						_state ) );
+						_state,
+						baseSampleRate ) );
 	m_exists[_id] = true;
 }

--- a/plugins/vibed/string_container.h
+++ b/plugins/vibed/string_container.h
@@ -48,7 +48,8 @@ public:
 			const float _detune,
 			const int _oversample,
 			const bool _state,
-			const int _id );
+			const int _id,
+			const sample_rate_t baseSampleRate );
 	
 	bool exists( int _id ) const
 	{

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -62,8 +62,8 @@ Plugin::Descriptor PLUGIN_EXPORT vibedstrings_plugin_descriptor =
 }
 
 
-vibed::vibed( InstrumentTrack * _instrumentTrack ) :
-	Instrument( _instrumentTrack, &vibedstrings_plugin_descriptor )
+vibed::vibed( InstrumentTrack * _instrumentTrack, Engine * engine ) :
+	Instrument( _instrumentTrack, &vibedstrings_plugin_descriptor, engine )
 {
 
 	FloatModel * knob;
@@ -277,8 +277,8 @@ void vibed::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 	if ( _n->totalFramesPlayed() == 0 || _n->m_pluginData == NULL )
 	{
 		_n->m_pluginData = new stringContainer( _n->frequency(),
-				Engine::mixer()->processingSampleRate(),
-						__sampleLength );
+							getProcessingSampleRate(),
+							__sampleLength );
 		
 		for( int i = 0; i < 9; ++i )
 		{
@@ -296,7 +296,8 @@ void vibed::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 				static_cast<int>(
 					m_lengthKnobs[i]->value() ),
 				m_impulses[i]->value(),
-				i );
+				i,
+				getMixer()->baseSampleRate() );
 			}
 		}
 	}
@@ -690,7 +691,7 @@ void vibedView::showString( int _string )
 void vibedView::sinWaveClicked()
 {
 	m_graph->model()->setWaveToSine();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -698,7 +699,7 @@ void vibedView::sinWaveClicked()
 void vibedView::triangleWaveClicked()
 {
 	m_graph->model()->setWaveToTriangle();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -706,7 +707,7 @@ void vibedView::triangleWaveClicked()
 void vibedView::sawWaveClicked()
 {
 	m_graph->model()->setWaveToSaw();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -714,7 +715,7 @@ void vibedView::sawWaveClicked()
 void vibedView::sqrWaveClicked()
 {
 	m_graph->model()->setWaveToSquare();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -722,7 +723,7 @@ void vibedView::sqrWaveClicked()
 void vibedView::noiseWaveClicked()
 {
 	m_graph->model()->setWaveToNoise();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -731,7 +732,7 @@ void vibedView::usrWaveClicked()
 {
 	QString fileName = m_graph->model()->setWaveToUser();
 	ToolTip::add( m_usrWaveBtn, fileName );
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -739,7 +740,7 @@ void vibedView::usrWaveClicked()
 void vibedView::smoothClicked()
 {
 	m_graph->model()->smooth();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -747,7 +748,7 @@ void vibedView::smoothClicked()
 void vibedView::normalizeClicked()
 {
 	m_graph->model()->normalize();
-	Engine::getSong()->setModified();
+	model()->getSong()->setModified();
 }
 
 
@@ -776,9 +777,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return( new vibed( static_cast<InstrumentTrack *>( _data ) ) );
+	return( new vibed( static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/vibed/vibed.h
+++ b/plugins/vibed/vibed.h
@@ -39,7 +39,7 @@ class vibed : public Instrument
 {
 	Q_OBJECT
 public:
-	vibed( InstrumentTrack * _instrument_track );
+	vibed( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~vibed();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/vibed/vibrating_string.cpp
+++ b/plugins/vibed/vibrating_string.cpp
@@ -26,8 +26,6 @@
 #include "vibrating_string.h"
 #include "templates.h"
 #include "interpolation.h"
-#include "Mixer.h"
-#include "Engine.h"
 
 
 vibratingString::vibratingString(	float _pitch, 
@@ -40,9 +38,10 @@ vibratingString::vibratingString(	float _pitch,
 					float _randomize,
 					float _string_loss,
 					float _detune,
-					bool _state ) :
+					bool _state,
+					sample_rate_t baseSampleRate ) :
 	m_oversample( 2 * _oversample / (int)( _sample_rate /
-				Engine::mixer()->baseSampleRate() ) ),
+				baseSampleRate ) ),
 	m_randomize( _randomize ),
 	m_stringLoss( 1.0f - _string_loss ),
 	m_state( 0.1f )

--- a/plugins/vibed/vibrating_string.h
+++ b/plugins/vibed/vibrating_string.h
@@ -43,7 +43,8 @@ public:
 				float _randomize,
 				float _string_loss,
 				float _detune,
-				bool _state );
+				bool _state,
+				sample_rate_t baseSampleRate );
 	
 	inline ~vibratingString()
 	{

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -79,10 +79,11 @@ public:
 
 
 
-VstPlugin::VstPlugin( const QString & _plugin ) :
+VstPlugin::VstPlugin( const QString & _plugin, Engine * engine ) :
 	QObject(),
 	JournallingObject(),
 	RemotePlugin(),
+	EngineClient( engine ),
 	m_plugin( _plugin ),
 	m_pluginWidget( NULL ),
 	m_pluginWindowID( 0 ),
@@ -108,11 +109,11 @@ VstPlugin::VstPlugin( const QString & _plugin ) :
 	}
 #endif
 
-	setTempo( Engine::getSong()->getTempo() );
+	setTempo( getSong()->getTempo() );
 
-	connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ),
+	connect( getSong(), SIGNAL( tempoChanged( bpm_t ) ),
 			this, SLOT( setTempo( bpm_t ) ) );
-	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ),
+	connect( getMixer(), SIGNAL( sampleRateChanged() ),
 				this, SLOT( updateSampleRate() ) );
 
 	// update once per second
@@ -378,7 +379,7 @@ void VstPlugin::updateSampleRate()
 {
 	lock();
 	sendMessage( message( IdSampleRateInformation ).
-			addInt( Engine::mixer()->processingSampleRate() ) );
+			addInt( getMixer()->processingSampleRate() ) );
 	unlock();
 }
 

--- a/plugins/vst_base/VstPlugin.h
+++ b/plugins/vst_base/VstPlugin.h
@@ -35,14 +35,15 @@
 #include "Mixer.h"
 #include "JournallingObject.h"
 #include "communication.h"
+#include "EngineClient.h"
 
 
 class PLUGIN_EXPORT VstPlugin : public QObject, public JournallingObject,
-								public RemotePlugin
+				public RemotePlugin, public EngineClient
 {
 	Q_OBJECT
 public:
-	VstPlugin( const QString & _plugin );
+	VstPlugin( const QString & _plugin, Engine * engine );
 	virtual ~VstPlugin();
 
 	void tryLoad( const QString &remoteVstPluginExecutable );

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -227,8 +227,8 @@ void WatsynObject::renderOutput( fpp_t _frames )
 
 
 
-WatsynInstrument::WatsynInstrument( InstrumentTrack * _instrument_track ) :
-		Instrument( _instrument_track, &watsyn_plugin_descriptor ),
+WatsynInstrument::WatsynInstrument( InstrumentTrack * _instrument_track, Engine * engine ) :
+		Instrument( _instrument_track, &watsyn_plugin_descriptor, engine ),
 
 		a1_vol( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Volume A1" ) ),
 		a2_vol( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Volume A2" ) ),
@@ -337,8 +337,8 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 				&B1_wave[0],
 				&B2_wave[0],
 				m_amod.value(), m_bmod.value(),
-				Engine::mixer()->processingSampleRate(), _n,
-				Engine::mixer()->framesPerPeriod(), this );
+				getProcessingSampleRate(), _n,
+				getFramesPerPeriod(), this );
 
 		_n->m_pluginData = w;
 	}
@@ -985,21 +985,20 @@ void WatsynView::sinWaveClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->setWaveToSine();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->setWaveToSine();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->setWaveToSine();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->setWaveToSine();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1009,21 +1008,20 @@ void WatsynView::triWaveClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->setWaveToTriangle();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->setWaveToTriangle();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->setWaveToTriangle();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->setWaveToTriangle();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1033,21 +1031,20 @@ void WatsynView::sawWaveClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->setWaveToSaw();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->setWaveToSaw();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->setWaveToSaw();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->setWaveToSaw();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1057,21 +1054,20 @@ void WatsynView::sqrWaveClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->setWaveToSquare();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->setWaveToSquare();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->setWaveToSquare();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->setWaveToSquare();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1081,21 +1077,20 @@ void WatsynView::normalizeClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->normalize();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->normalize();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->normalize();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->normalize();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1105,21 +1100,20 @@ void WatsynView::invertClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->invert();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->invert();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->invert();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->invert();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1129,21 +1123,20 @@ void WatsynView::smoothClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->smooth();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->smooth();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->smooth();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->smooth();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1153,21 +1146,20 @@ void WatsynView::phaseLeftClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->shiftPhase( -15 );
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->shiftPhase( -15 );
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->shiftPhase( -15 );
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->shiftPhase( -15 );
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1177,21 +1169,20 @@ void WatsynView::phaseRightClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->shiftPhase( 15 );
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->shiftPhase( 15 );
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->shiftPhase( 15 );
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->shiftPhase( 15 );
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1202,21 +1193,20 @@ void WatsynView::loadClicked()
 	{
 		case A1_OSC:
 			a1_graph->model()->setWaveToUser();
-			Engine::getSong()->setModified();
 			break;
 		case A2_OSC:
 			a2_graph->model()->setWaveToUser();
-			Engine::getSong()->setModified();
 			break;
 		case B1_OSC:
 			b1_graph->model()->setWaveToUser();
-			Engine::getSong()->setModified();
 			break;
 		case B2_OSC:
 			b2_graph->model()->setWaveToUser();
-			Engine::getSong()->setModified();
 			break;
 	}
+
+	Song * song = model()->getSong();
+	song->setModified();
 }
 
 
@@ -1277,9 +1267,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model *, Engine * engine, void * _data )
 {
-	return( new WatsynInstrument( static_cast<InstrumentTrack *>( _data ) ) );
+	return( new WatsynInstrument( static_cast<InstrumentTrack *>( _data ), engine ) );
 }
 
 

--- a/plugins/watsyn/Watsyn.h
+++ b/plugins/watsyn/Watsyn.h
@@ -131,7 +131,7 @@ class WatsynInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	WatsynInstrument( InstrumentTrack * _instrument_track );
+	WatsynInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~WatsynInstrument();
 
 	virtual void playNote( NotePlayHandle * _n,

--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -51,9 +51,9 @@ Plugin::Descriptor PLUGIN_EXPORT waveshaper_plugin_descriptor =
 
 
 
-waveShaperEffect::waveShaperEffect( Model * _parent,
+waveShaperEffect::waveShaperEffect( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Effect( &waveshaper_plugin_descriptor, _parent, _key ),
+	Effect( &waveshaper_plugin_descriptor, _parent, engine, _key ),
 	m_wsControls( this )
 {
 }
@@ -161,9 +161,9 @@ extern "C"
 {
 
 // necessary for getting instance out of shared lib
-Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, void * _data )
+Plugin * PLUGIN_EXPORT lmms_plugin_main( Model * _parent, Engine * engine, void * _data )
 {
-	return( new waveShaperEffect( _parent,
+	return( new waveShaperEffect( _parent, engine,
 		static_cast<const Plugin::Descriptor::SubPluginFeatures::Key *>(
 								_data ) ) );
 }

--- a/plugins/waveshaper/waveshaper.h
+++ b/plugins/waveshaper/waveshaper.h
@@ -35,7 +35,7 @@
 class waveShaperEffect : public Effect
 {
 public:
-	waveShaperEffect( Model * _parent,
+	waveShaperEffect( Model * _parent, Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key );
 	virtual ~waveShaperEffect();
 	virtual bool processAudioBuffer( sampleFrame * _buf,

--- a/plugins/waveshaper/waveshaper_controls.cpp
+++ b/plugins/waveshaper/waveshaper_controls.cpp
@@ -55,7 +55,7 @@ waveShaperControls::waveShaperControls( waveShaperEffect * _eff ) :
 
 void waveShaperControls::samplesChanged( int _begin, int _end)
 {
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 
@@ -115,13 +115,13 @@ void waveShaperControls::setDefaultShape()
 void waveShaperControls::resetClicked()
 {
 	setDefaultShape();
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void waveShaperControls::smoothClicked()
 {
 	m_wavegraphModel.smoothNonCyclic();
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void waveShaperControls::addOneClicked()
@@ -130,7 +130,7 @@ void waveShaperControls::addOneClicked()
 	{
 		m_wavegraphModel.setSampleAt( i, qBound( 0.0f, m_wavegraphModel.samples()[i] * onedB, 1.0f ) );
 	}
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 void waveShaperControls::subOneClicked()
@@ -139,7 +139,7 @@ void waveShaperControls::subOneClicked()
 	{
 		m_wavegraphModel.setSampleAt( i, qBound( 0.0f, m_wavegraphModel.samples()[i] / onedB, 1.0f ) );
 	}
-	Engine::getSong()->setModified();
+	m_effect->getSong()->setModified();
 }
 
 

--- a/plugins/zynaddsubfx/ZynAddSubFx.h
+++ b/plugins/zynaddsubfx/ZynAddSubFx.h
@@ -65,7 +65,7 @@ class ZynAddSubFxInstrument : public Instrument
 {
 	Q_OBJECT
 public:
-	ZynAddSubFxInstrument( InstrumentTrack * _instrument_track );
+	ZynAddSubFxInstrument( InstrumentTrack * _instrument_track, Engine * engine );
 	virtual ~ZynAddSubFxInstrument();
 
 	virtual void play( sampleFrame * _working_buffer );

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -36,8 +36,9 @@
 
 Effect::Effect( const Plugin::Descriptor * _desc,
 			Model * _parent,
+			Engine * engine,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
-	Plugin( _desc, _parent ),
+	Plugin( _desc, _parent, engine ),
 	m_parent( NULL ),
 	m_key( _key ? *_key : Descriptor::SubPluginFeatures::Key()  ),
 	m_processors( 1 ),

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -32,6 +32,7 @@
 #include "DummyEffect.h"
 #include "MixHelpers.h"
 #include "Song.h"
+#include "PluginFactory.h"
 
 
 EffectChain::EffectChain( Model * _parent ) :
@@ -103,7 +104,8 @@ void EffectChain::loadSettings( const QDomElement & _this )
 			else
 			{
 				delete e;
-				e = new DummyEffect( parentModel(), effectData );
+				Engine * engine = PluginFactory::instance()->getEngine();
+				e = new DummyEffect( parentModel(), engine, effectData );
 			}
 
 			m_effects.push_back( e );

--- a/src/core/ImportFilter.cpp
+++ b/src/core/ImportFilter.cpp
@@ -33,8 +33,8 @@
 
 
 ImportFilter::ImportFilter( const QString & _file_name,
-							const Descriptor * _descriptor ) :
-	Plugin( _descriptor, NULL ),
+							const Descriptor * _descriptor, Engine * engine ) :
+	Plugin( _descriptor, NULL, engine ),
 	m_file( _file_name )
 {
 }

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -27,11 +27,12 @@
 #include "DummyInstrument.h"
 #include "NotePlayHandle.h"
 #include "Engine.h"
+#include "PluginFactory.h"
 
 
 Instrument::Instrument( InstrumentTrack * _instrument_track,
-					const Descriptor * _descriptor ) :
-	Plugin( _descriptor, NULL/* _instrument_track*/ ),
+					const Descriptor * _descriptor, Engine * engine ) :
+	Plugin( _descriptor, NULL/* _instrument_track*/, engine ),
 	m_instrumentTrack( _instrument_track )
 {
 }
@@ -82,7 +83,8 @@ Instrument * Instrument::instantiate( const QString & _plugin_name,
 
 	// not quite... so delete plugin and return dummy instrument
 	delete p;
-	return( new DummyInstrument( _instrument_track ) );
+	Engine * engine = pluginFactory->getEngine();
+	return( new DummyInstrument( _instrument_track, engine ) );
 }
 
 

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -55,9 +55,10 @@ static Plugin::Descriptor dummyPluginDescriptor =
 
 
 
-Plugin::Plugin( const Descriptor * descriptor, Model * parent ) :
+Plugin::Plugin( const Descriptor * descriptor, Model * parent, Engine * engine ) :
 	Model( parent ),
 	JournallingObject(),
+	EngineClient(engine),
 	m_descriptor( descriptor )
 {
 	if( m_descriptor == NULL )
@@ -95,6 +96,8 @@ AutomatableModel * Plugin::childModel( const QString & )
 Plugin * Plugin::instantiate( const QString& pluginName, Model * parent,
 								void * data )
 {
+	Engine * engine = pluginFactory->getEngine();
+
 	const PluginFactory::PluginInfo& pi = pluginFactory->pluginInfo(pluginName.toUtf8());
 	if( pi.isNull() )
 	{
@@ -106,7 +109,7 @@ Plugin * Plugin::instantiate( const QString& pluginName, Model * parent,
 						arg( pluginName ).arg( pluginFactory->errorString(pluginName) ),
 				QMessageBox::Ok | QMessageBox::Default );
 		}
-		return new DummyPlugin();
+		return new DummyPlugin(engine);
 	}
 
 	InstantiationHook instantiationHook = ( InstantiationHook ) pi.library->resolve( "lmms_plugin_main" );
@@ -119,10 +122,10 @@ Plugin * Plugin::instantiate( const QString& pluginName, Model * parent,
 				tr( "Failed to load plugin \"%1\"!").arg( pluginName ),
 				QMessageBox::Ok | QMessageBox::Default );
 		}
-		return new DummyPlugin();
+		return new DummyPlugin(engine);
 	}
 
-	Plugin * inst = instantiationHook( parent, data );
+	Plugin * inst = instantiationHook( parent, engine, data );
 	return inst;
 }
 

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -40,7 +40,8 @@
 
 PluginFactory* PluginFactory::s_instance = nullptr;
 
-PluginFactory::PluginFactory()
+PluginFactory::PluginFactory() :
+	m_engine(nullptr)
 {
 	// Adds a search path relative to the main executable to if the path exists.
 	auto addRelativeIfExists = [this] (const QString& path) {

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -452,6 +452,20 @@ std::pair<MidiTime, MidiTime> Song::getExportEndpoints() const
 
 
 
+void Song::exportProjectMidi(TrackContainer::TrackList & tracks, bpm_t bpm, QString const & exportFilename)
+{
+	ExportFilter *exf = dynamic_cast<ExportFilter *> (Plugin::instantiate("midiexport", NULL, NULL));
+	if (exf==NULL)
+	{
+		qDebug() << "failed to load midi export filter!";
+		return;
+	}
+
+	exf->tryExport(tracks, bpm, exportFilename);
+}
+
+
+
 
 void Song::playSong()
 {
@@ -1300,66 +1314,6 @@ void Song::exportProject( bool multiExport )
 		epd.exec();
 	}
 }
-
-
-void Song::exportProjectMidi()
-{
-	if( isEmpty() )
-	{
-		QMessageBox::information( gui->mainWindow(),
-				tr( "Empty project" ),
-				tr( "This project is empty so exporting makes "
-					"no sense. Please put some items into "
-					"Song Editor first!" ) );
-		return;
-	}
-
-	FileDialog efd( gui->mainWindow() );
-	
-	efd.setFileMode( FileDialog::AnyFile );
-	
-	QStringList types;
-	types << tr("MIDI File (*.mid)");
-	efd.setNameFilters( types );
-	QString base_filename;
-	if( !m_fileName.isEmpty() )
-	{
-		efd.setDirectory( QFileInfo( m_fileName ).absolutePath() );
-		base_filename = QFileInfo( m_fileName ).completeBaseName();
-	}
-	else
-	{
-		efd.setDirectory( ConfigManager::inst()->userProjectsDir() );
-		base_filename = tr( "untitled" );
-	}
-	efd.selectFile( base_filename + ".mid" );
-	efd.setWindowTitle( tr( "Select file for project-export..." ) );
-
-	efd.setAcceptMode( FileDialog::AcceptSave );
-
-
-	if( efd.exec() == QDialog::Accepted && !efd.selectedFiles().isEmpty() && !efd.selectedFiles()[0].isEmpty() )
-	{
-		const QString suffix = ".mid";
-
-		QString export_filename = efd.selectedFiles()[0];
-		if (!export_filename.endsWith(suffix)) export_filename += suffix;
-		
-		// NOTE start midi export
-		
-		// instantiate midi export plugin
-		TrackContainer::TrackList tracks;
-		tracks += Engine::getSong()->tracks();
-		tracks += Engine::getBBTrackContainer()->tracks();
-		ExportFilter *exf = dynamic_cast<ExportFilter *> (Plugin::instantiate("midiexport", NULL, NULL));
-		if (exf==NULL) {
-			qDebug() << "failed to load midi export filter!";
-			return;
-		}
-		exf->tryExport(tracks, Engine::getSong()->getTempo(), export_filename);
-	}
-}
-
 
 
 void Song::updateFramesPerTick()

--- a/src/core/ToolPlugin.cpp
+++ b/src/core/ToolPlugin.cpp
@@ -26,8 +26,8 @@
 #include "ToolPlugin.h"
 
 
-ToolPlugin::ToolPlugin( const Descriptor * _descriptor, Model * _parent ) :
-	Plugin( _descriptor, _parent )
+ToolPlugin::ToolPlugin( const Descriptor * _descriptor, Model * _parent, Engine * engine ) :
+	Plugin( _descriptor, _parent, engine )
 {
 }
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -72,6 +72,7 @@
 #include "DataFile.h"
 #include "Song.h"
 #include "SetupDialog.h"
+#include "PluginFactory.h"
 
 static inline QString baseName( const QString & file )
 {
@@ -578,7 +579,12 @@ int main( int argc, char * * argv )
 	// without starting the GUI
 	if( !renderOut.isEmpty() )
 	{
+		// Initialize the engine
 		Engine::init( true );
+
+		// Initialize the plugin factory with the engine so that
+		// plugins can later be injected with the Engine
+		PluginFactory::instance()->setEngine(Engine::inst());
 
 		QFileInfo fileInfo( fileToLoad );
 		if ( !fileInfo.exists() )

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -39,6 +39,7 @@
 #include "PianoRoll.h"
 #include "ProjectNotes.h"
 #include "SongEditor.h"
+#include "PluginFactory.h"
 
 #include <QApplication>
 #include <QMessageBox>
@@ -99,11 +100,13 @@ GuiApplication::GuiApplication()
 	splashScreen.update();
 	qApp->processEvents();
 
-	connect(Engine::inst(), SIGNAL(initProgress(const QString&)), 
-		this, SLOT(displayInitProgress(const QString&)));
-
 	// Init central engine which handles all components of LMMS
 	Engine::init(false);
+	Engine * engine = Engine::inst();
+	connect(engine, SIGNAL(initProgress(const QString&)),
+		this, SLOT(displayInitProgress(const QString&)));
+
+	PluginFactory::instance()->setEngine(engine);
 
 	s_instance = this;
 
@@ -135,11 +138,11 @@ GuiApplication::GuiApplication()
 	connect(m_bbEditor, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing piano roll"));
-	m_pianoRoll = new PianoRollWindow();
+	m_pianoRoll = new PianoRollWindow( engine );
 	connect(m_pianoRoll, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing automation editor"));
-	m_automationEditor = new AutomationEditorWindow;
+	m_automationEditor = new AutomationEditorWindow( engine );
 	connect(m_automationEditor, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	m_mainWindow->finalize();


### PR DESCRIPTION
There are many places in the code where static methods of the class Engine are called. The existance of a static instance of Engine makes it hard to control which components (e.g. Core, GUI, etc.) have access to which
information. This changeset is a first step towards getting rid of these static calls.

The most important step is the introduction of an interface / a class called EngineClient. Classes that inherit from EngineClient can use simple member getters and setters to retrieve the Engine instance and as well as
associated other instances like Mixer, FxMixer, Song, etc. The constructor of EngineClient takes a pointer to the Engine as the sole parameter. Therefore the constructors of all classes that inherit from EngineClient had
to be adjusted. The following classes inherit from EngineClient:
- Plugin
- The oscillators of TripleOscillator and Organic
- VstPlugin
- AutomationEditor
- PianoRoll

Making the class Plugin an EngineClient enables all plugins in the plugin folder to use the member methods instead of the static calls. To be able to provide the Engine to the plugins constructors it was necessary to
adjust the typedef for InstantiationHook to also include a pointer to an Engine in the parameters. The plugin factory function "lmms_plugin_main" was changed for all plugins and their constructors have been adjusted
accordingly. The plugins folder is now free of static calls to Engine except for LadspaSubPluginFeatures.

Additionally the convenience methods getProcessingSampleRate and getFramesPerPeriod were added to the class Plugin.

In other cases code was adjusted to take the needed parameters instead of fetching them from the static Engine instance.
