### PR TITLE
Rename note volume into note velocity

### DIFF
--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -2775,7 +2775,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4603,7 +4603,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>pica dos cops per a obrir aquest patró al rotlle de piano
 usa la roda del ratolí per a ajustar el volum d&apos;un pas</translation>
     </message>
@@ -4767,7 +4767,7 @@ usa la roda del ratolí per a ajustar el volum d&apos;un pas</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4799,7 +4799,7 @@ usa la roda del ratolí per a ajustar el volum d&apos;un pas</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -2775,7 +2775,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4603,7 +4603,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>dvojitým kliknutím otevřete tento pattern v piano-roll
 k nastavení zesílení kroku použijte kolečko myši</translation>
     </message>
@@ -4767,7 +4767,7 @@ k nastavení zesílení kroku použijte kolečko myši</translation>
         <translation>Zámek noty</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4799,7 +4799,7 @@ k nastavení zesílení kroku použijte kolečko myši</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -2795,7 +2795,7 @@ Sie können FX Kanäle im Kontextmenü entfernen und verschieben, welches durch 
         <translation>BENUTZERDEFINIERTE GRUNDLAUTSTÄRKE</translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation>Geben Sie die Lautstärken-Normalisationsbasis für MIDI-basierende Instrumente bei einer Notenlautstärke von 100% an</translation>
     </message>
     <message>
@@ -4640,7 +4640,7 @@ PM bedeutet Phasen-Modulation: Die Phase von Oszillator 3 wird durch Oszillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>Doppelklick, um dieses Pattern im Piano-Roll zu öffnen
 Lautstärke eines Schritts kann mit dem Mausrad geändert werden</translation>
     </message>
@@ -4804,7 +4804,7 @@ Lautstärke eines Schritts kann mit dem Mausrad geändert werden</translation>
         <translation>Notenraster</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Noten-Lautstärke</translation>
     </message>
     <message>
@@ -4836,7 +4836,7 @@ Lautstärke eines Schritts kann mit dem Mausrad geändert werden</translation>
         <translation>Kein Akkord</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation>Lautstärke: %1%</translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4596,7 +4596,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4759,7 +4759,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4791,7 +4791,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4596,7 +4596,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4759,7 +4759,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4791,7 +4791,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4596,7 +4596,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4759,7 +4759,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4791,7 +4791,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -2922,7 +2922,7 @@ Vous pouvez supprimer et déplacer les canaux d&apos;effet avec le menu contextu
         <translation>VÉLOCITÉ DE BASE PERSONNALISÉE</translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation>Spécifiez la vélocité normalisée de base des instruments MIDI pour un volume de note de 100%</translation>
     </message>
     <message>
@@ -5087,7 +5087,7 @@ Le mode PM signifie modulation de phase: la phase de l&apos;oscillateur 3 est mo
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>double-cliquer pour ouvrir ce motif dans le piano virtuel
 utilisez la molette de la souris pour régler le volume d&apos;un pas</translation>
     </message>
@@ -5251,7 +5251,7 @@ utilisez la molette de la souris pour régler le volume d&apos;un pas</translati
         <translation>Vérouiller la note</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Volume de note </translation>
     </message>
     <message>
@@ -5283,8 +5283,8 @@ utilisez la molette de la souris pour régler le volume d&apos;un pas</translati
         <translation>Pas d&apos;accord</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
-        <translation>Volume: %1%</translation>
+        <source>Velocity: %1%</source>
+        <translation>Velocity: %1%</translation>
     </message>
     <message>
         <source>Panning: %1% left</source>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -2789,7 +2789,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4612,7 +4612,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>faga duplo clic para abrir este padrón na pianola
 empregue a roda do rato para modificar o volume un paso</translation>
     </message>
@@ -4776,7 +4776,7 @@ empregue a roda do rato para modificar o volume un paso</translation>
         <translation>Bloqueo de notas</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Volume das notas</translation>
     </message>
     <message>
@@ -4808,7 +4808,7 @@ empregue a roda do rato para modificar o volume un paso</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -2795,7 +2795,7 @@ Puoi rimuovere e muovere i canali con il menù contestuale, cliccando con il tas
         <translation>VELOCITY BASE PERSONALIZZATA</translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation>Specifica la normalizzazione della velocity per strumenti MIDI al volume della nota 100%</translation>
     </message>
     <message>
@@ -4636,7 +4636,7 @@ Vi sono due forme speciali: &quot;Random&quot; e &quot;Random morbido&quot; sono
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>un doppio click apre questo pattern nel piano-roll
 la rotellina del mouse impostare il volume delle note</translation>
     </message>
@@ -4800,7 +4800,7 @@ la rotellina del mouse impostare il volume delle note</translation>
         <translation>Note lock</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Volume Note</translation>
     </message>
     <message>
@@ -4832,8 +4832,8 @@ la rotellina del mouse impostare il volume delle note</translation>
         <translation>- Accordi</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
-        <translation>Volume: %1%</translation>
+        <source>Velocity: %1%</source>
+        <translation>Velocity: %1%</translation>
     </message>
     <message>
         <source>Panning: %1% left</source>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -2790,7 +2790,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4614,7 +4614,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>ダプルクリックでこのパターンをピアノロールで開きます
 マウスホイールでステップの音量をセットします</translation>
     </message>
@@ -4778,7 +4778,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished">ノートをロック</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished">ノートの音量</translation>
     </message>
     <message>
@@ -4810,7 +4810,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation>音量: %1%</translation>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4597,7 +4597,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>피아노-롤에서 이 패턴을 열기위해 이중 클릭
 한 단계 볼륨을 설정하기위하여 마우스 휠 사용</translation>
     </message>
@@ -4761,7 +4761,7 @@ use mouse wheel to set volume of a step</source>
         <translation>박자 잠금</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4793,7 +4793,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4596,7 +4596,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation type="unfinished">dubbel-klik om deze pattern in Piano-Roll te openen
 volume van de steps is met het muiswiel te veranderen</translation>
     </message>
@@ -4760,7 +4760,7 @@ volume van de steps is met het muiswiel te veranderen</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4792,7 +4792,7 @@ volume van de steps is met het muiswiel te veranderen</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -2793,7 +2793,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4617,7 +4617,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>Podwójne kliknięcie otwiera pattern w Edytorze Pianolowym
 użyj kółka myszy aby ustawić głośność poszczególnych kroków</translation>
     </message>
@@ -4781,7 +4781,7 @@ użyj kółka myszy aby ustawić głośność poszczególnych kroków</translati
         <translation>Blokada nuty</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Głośność Nuty</translation>
     </message>
     <message>
@@ -4813,7 +4813,7 @@ użyj kółka myszy aby ustawić głośność poszczególnych kroków</translati
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -2791,7 +2791,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4631,7 +4631,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     </message>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>duplo clique para abrir esta sequência no Editor de notas MDll
 use a roda do mouse para midificar o volume de cada passo</translation>
     </message>
@@ -4771,7 +4771,7 @@ use a roda do mouse para midificar o volume de cada passo</translation>
         <translation>Panorâmico da nota</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Volume da nota</translation>
     </message>
     <message>
@@ -4811,7 +4811,7 @@ use a roda do mouse para midificar o volume de cada passo</translation>
         <translation>Por favor abra um a sequência com um duplo clique sobre ela!</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -2809,7 +2809,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation>ПРОИЗВОЛЬНАЯ БАЗОВАЯ СКОРОСТЬ</translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation>Опрделяет базовую скорость нормальизации для MiDi инструментов при громкости ноты 100%</translation>
     </message>
     <message>
@@ -4666,7 +4666,7 @@ PM (ФМ) режим значит фазовая модуляция: Осцил�
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>Чтобы открыть эту мелодию в нотном редакторе, дважды на нём щёлкните
 Используйте колёсико мыши для установки громкости отдельного такта</translation>
     </message>
@@ -4830,7 +4830,7 @@ use mouse wheel to set volume of a step</source>
         <translation>Фиксация нот</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Громкость нот</translation>
     </message>
     <message>
@@ -4862,7 +4862,7 @@ use mouse wheel to set volume of a step</source>
         <translation>Убрать аккорды</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation>Громкость %1%</translation>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -2774,7 +2774,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4596,7 +4596,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4759,7 +4759,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4791,7 +4791,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -2974,7 +2974,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation>СВОЯ БАЗОВА ШВИДКІСТЬ</translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation>Визначає базову швидкість нормальізаціі для MiDi інструментів при гучності ноти 100%</translation>
     </message>
     <message>
@@ -5186,7 +5186,7 @@ PM (ФМ) режим означає Фазова Модуляція: Осцил�
         <translation>Видалити такти</translation>
     </message>
     <message>
-        <source>use mouse wheel to set volume of a step</source>
+        <source>use mouse wheel to set velocity of a step</source>
         <translation>використовуйте колесо миші для встановлення кроку гучності</translation>
     </message>
 </context>
@@ -5318,7 +5318,7 @@ PM (ФМ) режим означає Фазова Модуляція: Осцил�
         <translation>Стереофонія нот</translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>Гучність нот</translation>
     </message>
     <message>
@@ -5350,7 +5350,7 @@ PM (ФМ) режим означає Фазова Модуляція: Осцил�
         <translation>Відкрийте шаблон за допомогою подвійного клацання мишею!</translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation>Гучність %1%</translation>
     </message>
     <message>

--- a/data/locale/zh.ts
+++ b/data/locale/zh.ts
@@ -2783,7 +2783,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Specify the velocity normalization base for MIDI-based instruments at note volume 100%</source>
+        <source>Specify the velocity normalization base for MIDI-based instruments at 100% note velocity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4607,7 +4607,7 @@ PM means phase modulation: Oscillator 3&apos;s phase is modulated by oscillator 
     <name>PatternView</name>
     <message>
         <source>double-click to open this pattern in piano-roll
-use mouse wheel to set volume of a step</source>
+use mouse wheel to set velocity of a step</source>
         <translation>双击在钢琴窗中打开此片段
 使用鼠标滑轮设置此音阶的音量</translation>
     </message>
@@ -4771,7 +4771,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Note Volume</source>
+        <source>Note Velocity</source>
         <translation>音符音量</translation>
     </message>
     <message>
@@ -4803,7 +4803,7 @@ use mouse wheel to set volume of a step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume: %1%</source>
+        <source>Velocity: %1%</source>
         <translation>音量：%1%</translation>
     </message>
     <message>

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -214,7 +214,7 @@ PianoRoll::PianoRoll() :
 	m_noteBorderRadiusY( 0 )
 {
 	// gui names of edit modes
-	m_nemStr.push_back( tr( "Note Volume" ) );
+	m_nemStr.push_back( tr( "Note Velocity" ) );
 	m_nemStr.push_back( tr( "Note Panning" ) );
 
 	QSignalMapper * signalMapper = new QSignalMapper( this );
@@ -490,7 +490,7 @@ void PianoRoll::showVolTextFloat(volume_t vol, const QPoint &pos, int timeout)
 {
 	//! \todo display velocity for MIDI-based instruments
 	// possibly dBV values too? not sure if it makes sense for note volumes...
-	showTextFloat( tr("Volume: %1%").arg( vol ), pos, timeout );
+	showTextFloat( tr("Velocity: %1%").arg( vol ), pos, timeout );
 }
 
 
@@ -3575,7 +3575,7 @@ void PianoRoll::enterValue( NoteVector* nv )
 	{
 		bool ok;
 		int new_val;
-		new_val = QInputDialog::getInt(	this, "Piano roll: note volume",
+		new_val = QInputDialog::getInt(	this, "Piano roll: note velocity",
 					tr( "Please enter a new value between %1 and %2:" ).
 						arg( MinVolume ).arg( MaxVolume ),
 					(*nv)[0]->getVolume(),

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -147,7 +147,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	baseVelocityLayout->setContentsMargins( 8, 18, 8, 8 );
 	baseVelocityLayout->setSpacing( 6 );
 
-	QLabel* baseVelocityHelp = new QLabel( tr( "Specify the velocity normalization base for MIDI-based instruments at note volume 100%" ) );
+	QLabel* baseVelocityHelp = new QLabel( tr( "Specify the velocity normalization base for MIDI-based instruments at 100% note velocity" ) );
 	baseVelocityHelp->setWordWrap( true );
     baseVelocityHelp->setFont( pointSize<8>( baseVelocityHelp->font() ) );
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -706,7 +706,7 @@ PatternView::PatternView( Pattern* pattern, TrackView* parent ) :
 	setFixedHeight( parentWidget()->height() - 2 );
 
 	ToolTip::add( this,
-		tr( "use mouse wheel to set volume of a step" ) );
+		tr( "use mouse wheel to set velocity of a step" ) );
 	setStyle( QApplication::style() );
 }
 


### PR DESCRIPTION
Fixes #2316

Note that this is a cosmetic change, I haven't touched the name of the internal functions, and probably won't, since there is no such thing as the concept of velocity in the current codebase. For example, the [maximum volume of an oscillator in TripleOscillator](https://github.com/LMMS/lmms/blob/317cc74bace043ace463d280efb67f2e891ce940/plugins/triple_oscillator/TripleOscillator.cpp#L69) and [the maximum velocity of a note](https://github.com/LMMS/lmms/blob/de7d83d15897407b6300e2e3475ce6f7c62903a2/src/core/Note.cpp#L127) are defined by the [same variable](https://github.com/LMMS/lmms/blob/de7d83d15897407b6300e2e3475ce6f7c62903a2/include/volume.h#L35).