### PR TITLE
Get rid of hardcoded colors in the Piano Roll and Automation Editor

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -16,15 +16,14 @@ AutomationEditor {
 	color: #e0e0e0;
 	qproperty-vertexColor: #ff77af;
 	qproperty-gridColor: #808080;
+	qproperty-crossColor: rgb( 255, 51, 51 );
 
 	qproperty-graphColor: qlineargradient(spread:reflect,
                      x1:0, y1:0, x2:0, y2:1,
                      stop:0 rgba(153, 175, 255, 250),  stop:1 rgba(153, 175, 255, 100));
-	/*#99afff;*/
 	qproperty-scaleColor: qlineargradient(spread:reflect,
                      x1:0, y1:0.5, x2:1, y2:0.5,
                      stop:0 #333, stop:1 #202020);
-	/*rgb( 32, 32, 32 );*/
 }
 
 /* text box */
@@ -114,9 +113,15 @@ PianoRoll {
 	qproperty-gridColor: rgb( 128, 128, 128 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
-	qproperty-barColor: #4afd85;
 	qproperty-noteBorderRadiusX: 5;
 	qproperty-noteBorderRadiusY: 2;
+	qproperty-selectedNoteColor: rgb( 0, 64, 192 );
+	qproperty-barColor: #4afd85;
+	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );
+	/* Text on the white piano keys */
+	qproperty-textColor: rgb( 0, 0, 0 );
+	qproperty-textColorLight: rgb( 128, 128, 128);
+	qproperty-textShadow: rgb( 240, 240, 240 );
 }
 
 /* main toolbar oscilloscope - can have transparent bg now */

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -55,6 +55,7 @@ class AutomationEditor : public QWidget, public JournallingObject
 	Q_PROPERTY(QColor vertexColor READ vertexColor WRITE setVertexColor)
 	Q_PROPERTY(QBrush scaleColor READ scaleColor WRITE setScaleColor)
 	Q_PROPERTY(QBrush graphColor READ graphColor WRITE setGraphColor)
+	Q_PROPERTY(QColor crossColor READ crossColor WRITE setCrossColor)
 public:
 	void setCurrentPattern(AutomationPattern * new_pattern);
 
@@ -80,10 +81,12 @@ public:
 	QBrush graphColor() const;
 	QColor vertexColor() const;
 	QBrush scaleColor() const;
+	QColor crossColor() const;
 	void setGridColor(const QColor& c);
 	void setGraphColor(const QBrush& c);
 	void setVertexColor(const QColor& c);
 	void setScaleColor(const QBrush& c);
+	void setCrossColor(const QColor& c);
 
 	enum EditModes
 	{
@@ -237,6 +240,7 @@ private:
 	QBrush m_graphColor;
 	QColor m_vertexColor;
 	QBrush m_scaleColor;
+	QColor m_crossColor;
 
 	friend class AutomationEditorWindow;
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -59,6 +59,11 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor barColor READ barColor WRITE setBarColor )
 	Q_PROPERTY( float noteBorderRadiusX READ noteBorderRadiusX WRITE setNoteBorderRadiusX )
 	Q_PROPERTY( float noteBorderRadiusY READ noteBorderRadiusY WRITE setNoteBorderRadiusY )
+	Q_PROPERTY( QColor selectedNoteColor READ selectedNoteColor WRITE setSelectedNoteColor )
+	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
+	Q_PROPERTY( QColor textColorLight READ textColorLight WRITE setTextColorLight )
+	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
+	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
 public:
 	enum EditModes
 	{
@@ -115,6 +120,16 @@ public:
 	void setNoteBorderRadiusX( float b );
 	float noteBorderRadiusY() const;
 	void setNoteBorderRadiusY( float b );
+	QColor selectedNoteColor() const;
+	void setSelectedNoteColor( const QColor & c );
+	QColor textColor() const;
+	void setTextColor( const QColor & c );
+	QColor textColorLight() const;
+	void setTextColorLight( const QColor & c );
+	QColor textShadow() const;
+	void setTextShadow( const QColor & c );
+	QColor markedSemitoneColor() const;
+	void setMarkedSemitoneColor( const QColor & c );
 
 
 protected:
@@ -133,7 +148,7 @@ protected:
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol,
-				 	float radiusX, float radiusY );
+				 	float radiusX, float radiusY, const QColor & selCol );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -358,6 +373,11 @@ private:
 	QColor m_barColor;
 	float m_noteBorderRadiusX;
 	float m_noteBorderRadiusY;
+	QColor m_selectedNoteColor;
+	QColor m_textColor;
+	QColor m_textColorLight;
+	QColor m_textShadow;
+	QColor m_markedSemitoneColor;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -105,7 +105,8 @@ AutomationEditor::AutomationEditor() :
 	m_gridColor( 0,0,0 ),
 	m_graphColor( Qt::SolidPattern ),
 	m_vertexColor( 0,0,0 ),
-	m_scaleColor( Qt::SolidPattern )
+	m_scaleColor( Qt::SolidPattern ),
+	m_crossColor( 0, 0, 0 )
 {
 	connect( this, SIGNAL( currentPatternChanged() ),
 				this, SLOT( updateAfterPatternChange() ),
@@ -251,6 +252,8 @@ QColor AutomationEditor::vertexColor() const
 { return m_vertexColor; }
 QBrush AutomationEditor::scaleColor() const
 { return m_scaleColor; }
+QColor AutomationEditor::crossColor() const
+{ return m_crossColor; }
 void AutomationEditor::setGridColor( const QColor & c )
 { m_gridColor = c; }
 void AutomationEditor::setGraphColor( const QBrush & c )
@@ -259,6 +262,8 @@ void AutomationEditor::setVertexColor( const QColor & c )
 { m_vertexColor = c; }
 void AutomationEditor::setScaleColor( const QBrush & c )
 { m_scaleColor = c; }
+void AutomationEditor::setCrossColor( const QColor & c )
+{ m_crossColor = c; }
 
 
 
@@ -972,7 +977,7 @@ inline void AutomationEditor::drawCross( QPainter & p )
 				/ (float)( m_maxLevel - m_minLevel ) ) :
 		grid_bottom - ( level - m_bottomLevel ) * m_y_delta;
 
-	p.setPen( QColor( 0xFF, 0x33, 0x33 ) );
+	p.setPen( crossColor() );
 	p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
 	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(),
 						height() - SCROLLBAR_SIZE );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -211,7 +211,12 @@ PianoRoll::PianoRoll() :
 	m_noteColor( 0, 0, 0 ),
 	m_barColor( 0, 0, 0 ),
 	m_noteBorderRadiusX( 0 ),
-	m_noteBorderRadiusY( 0 )
+	m_noteBorderRadiusY( 0 ),
+	m_selectedNoteColor( 0, 0, 0 ),
+	m_textColor( 0, 0, 0 ),
+	m_textColorLight( 0, 0, 0 ),
+	m_textShadow( 0, 0, 0 ),
+	m_markedSemitoneColor( 0, 0, 0 )
 {
 	// gui names of edit modes
 	m_nemStr.push_back( tr( "Note Volume" ) );
@@ -773,10 +778,39 @@ float PianoRoll::noteBorderRadiusY() const
 void PianoRoll::setNoteBorderRadiusY( float b )
 { m_noteBorderRadiusY = b; }
 
+QColor PianoRoll::selectedNoteColor() const
+{ return m_selectedNoteColor; }
+
+void PianoRoll::setSelectedNoteColor( const QColor & c )
+{ m_selectedNoteColor = c; }
+
+QColor PianoRoll::textColor() const
+{ return m_textColor; }
+
+void PianoRoll::setTextColor( const QColor & c )
+{ m_textColor = c; }
+
+QColor PianoRoll::textColorLight() const
+{ return m_textColorLight; }
+
+void PianoRoll::setTextColorLight( const QColor & c )
+{ m_textColorLight = c; }
+
+QColor PianoRoll::textShadow() const
+{ return m_textShadow; }
+
+void PianoRoll::setTextShadow( const QColor & c )
+{ m_textShadow = c; }
+
+QColor PianoRoll::markedSemitoneColor() const
+{ return m_markedSemitoneColor; }
+
+void PianoRoll::setMarkedSemitoneColor( const QColor & c )
+{ m_markedSemitoneColor = c; }
 
 void PianoRoll::drawNoteRect(QPainter & p, int x, int y, 
 				int width, const Note * n, const QColor & noteCol,
-						float radiusX, float radiusY )
+						float radiusX, float radiusY, const QColor & selCol )
 {
 	++x;
 	++y;
@@ -801,7 +835,7 @@ void PianoRoll::drawNoteRect(QPainter & p, int x, int y,
 
 	if( n->selected() )
 	{
-		col.setRgb( 0x00, 0x40, 0xC0 );
+		col = QColor( selCol );
 	}
 
 	// adjust note to make it a bit faded if it has a lower volume
@@ -2609,7 +2643,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 
 		p.fillRect( WHITE_KEY_WIDTH + 1, y - KEY_LINE_HEIGHT / 2, width() - 10, KEY_LINE_HEIGHT,
-			    QColor( 40, 40, 40, 200 ) );
+			    markedSemitoneColor() );
 	}
 
 
@@ -2717,16 +2751,16 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				QPoint textStart( WHITE_KEY_WIDTH - 18, key_line_y );
 				textStart += QPoint( 0, yCorrectionForNoteLabels );
 
-				p.setPen( QColor( 240, 240, 240 ) );
+				p.setPen( textShadow() );
 				p.drawText( textStart + QPoint( 1, 1 ), noteString );
 				// The C key is painted darker than the other ones
 				if ( key % 12 == 0 )
 				{
-					p.setPen( QColor( 0, 0, 0 ) );
+					p.setPen( textColor() );
 				}
 				else
 				{
-					p.setPen( QColor( 128, 128, 128 ) );
+					p.setPen( textColorLight() );
 				}
 				p.drawText( textStart, noteString );
 			}
@@ -2952,7 +2986,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				// note
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
 						y_base - key * KEY_LINE_HEIGHT,
-								note_width, note, noteColor(), noteBorderRadiusX(), noteBorderRadiusY() );
+								note_width, note, noteColor(), noteBorderRadiusX(), noteBorderRadiusY(), selectedNoteColor() );
 			}
 
 			// draw note editing stuff
@@ -2962,7 +2996,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				QColor color = barColor().lighter( 30 + ( note->getVolume() * 90 / MaxVolume ) );
 				if( note->selected() )
 				{
-					color.setRgb( 0x00, 0x40, 0xC0 );
+					color = selectedNoteColor();
 				}
 				p.setPen( QPen( color, NOTE_EDIT_LINE_WIDTH ) );
 
@@ -2977,10 +3011,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			}
 			else if( m_noteEditMode == NoteEditPanning )
 			{
-				QColor color( noteColor() );
+				QColor color = noteColor();
 				if( note->selected() )
 				{
-					color.setRgb( 0x00, 0x40, 0xC0 );
+					color = selectedNoteColor();
 				}
 
 				p.setPen( QPen( color, NOTE_EDIT_LINE_WIDTH ) );
@@ -3032,7 +3066,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 						MidiTime::ticksPerTact() ) - x;
 	int y = (int) y_base - sel_key_start * KEY_LINE_HEIGHT;
 	int h = (int) y_base - sel_key_end * KEY_LINE_HEIGHT - y;
-	p.setPen( QColor( 0, 64, 192 ) );
+	p.setPen( selectedNoteColor() );
 	p.setBrush( Qt::NoBrush );
 	p.drawRect( x + WHITE_KEY_WIDTH, y, w, h );
 


### PR DESCRIPTION
This should help with https://github.com/LMMS/lmms/issues/1935#issuecomment-105506475

Changes done: 

* The color of the cross in the Automation editor is now themeable
* The color of the marked semitones/scales is now themeable
* The shadow and color of the Note label texts in the piano roll is now themeable.
* The color of selected notes is now themeable.

The only thing I left hard-coded was the color of selected nodes inside the automation editor, simply because that feature is broken and disabled, so I had no way of testing it.

@RebeccaDeField this should also help with #880.

As always, testing and comments welcome.