### PR TITLE
In pianoroll: Escape key drops selected notes

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1093,6 +1093,11 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 			}
 			break;
 
+		case Qt::Key_Escape:
+			// Same as Ctrl + Shift + A
+			clearSelectedNotes();
+			break;
+
 		case Qt::Key_Delete:
 			deleteSelectedNotes();
 			ke->accept();


### PR DESCRIPTION
Tried it, liked it...

Hit 'Esc' is equal to 'Ctrl + Shift + A', much more efficient.