### PR TITLE
Change spacing on hovered items in the context menus

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -69,14 +69,12 @@ QMenu {
 QMenu::separator {
 	height: 1px;
 	background: #8d8d8d;
-	margin-left: 5px;
-	margin-right: 5px;
 }
 
 QMenu::item {
 	color: black;
-	padding: 2px 32px 2px 20px;
-	margin:3px;
+	padding: 2px 35px 2px 23px;
+	margin: 3px 0px 3px 0px;
 }
 
 QMenu::item:selected {


### PR DESCRIPTION
Per: https://github.com/HDDigitizerMusic/lmms-alt-theme/issues/13

I also extended the separators to the edges.

Before and after: 
![screenshot from 2016-02-14 11 41 59](https://cloud.githubusercontent.com/assets/6282045/13033258/17eeaf8e-d310-11e5-8bc8-a752a56fd751.png) ![screenshot from 2016-02-14 11 32 20](https://cloud.githubusercontent.com/assets/6282045/13033247/d47850de-d30f-11e5-8c65-91662977d148.png)

I think this adds a touch of modern to the current look, and its prettier imo.