### PR TITLE
Refactor the drawing of TCO's; Get rid of hardcoded colors in TCOs; Even out the color scheme

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -115,7 +115,7 @@ PianoRoll {
 	qproperty-noteColor: rgb( 119, 199, 216 );
 	qproperty-noteBorderRadiusX: 5;
 	qproperty-noteBorderRadiusY: 2;
-	qproperty-selectedNoteColor: rgb( 0, 64, 192 );
+	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );
 	/* Text on the white piano keys */
@@ -537,31 +537,37 @@ TrackContainerView QLabel
 
 /* Patterns */
 
+/* common pattern colors */
+TrackContentObjectView   {
+	qproperty-mutedColor: rgb( 128, 128, 128 );
+	qproperty-mutedBackgroundColor: rgb( 80, 80, 80 );
+	qproperty-selectedColor: rgb( 0, 125, 255 );
+	qproperty-textColor: rgb( 255, 255, 255 );
+	qproperty-textShadowColor: rgb( 0, 0, 0 );
+	qproperty-gradient: true;
+}
+
 /* instrument pattern */
 PatternView {
-	color: rgb( 119, 199, 216 );
-	qproperty-fgColor: rgb( 187, 227, 236 );
-	qproperty-textColor: rgb( 255, 255, 255 );
+	background-color: rgb( 119, 199, 216 );
+	color: rgb( 187, 227, 236 );
 }
 
 /* sample track pattern */
 SampleTCOView {
-	color: rgb( 74, 253, 133 );
-	qproperty-fgColor: rgb( 187, 227, 236 );
-	qproperty-textColor: rgb( 255, 60, 60 );
+	background-color: rgb( 74, 253, 133 );
+	color: rgb( 187, 227, 236 );
 }
 
 /* automation pattern */
 AutomationPatternView {
-	color: #99afff;
-	qproperty-fgColor: rgb( 204, 215, 255 );
-	qproperty-textColor: rgb( 255, 255, 255 );
+	background-color: #99afff;
+	color: rgb( 204, 215, 255 );
 }
 
 /* bb-pattern */
 BBTCOView {
-	color: rgb( 128, 182, 175 ); /* default colour for bb-tracks, used when the colour hasn't been defined by the user */
-	qproperty-textColor: rgb( 255, 255, 255 );
+	background-color: rgb( 128, 182, 175 ); /* default colour for bb-tracks */
 }
 
 /* Plugins */

--- a/include/AutomationPatternView.h
+++ b/include/AutomationPatternView.h
@@ -25,6 +25,8 @@
 #ifndef AUTOMATION_PATTERN_VIEW_H
 #define AUTOMATION_PATTERN_VIEW_H
 
+#include <QStaticText>
+
 #include "Track.h"
 
 class AutomationPattern;
@@ -34,9 +36,6 @@ class AutomationPatternView : public TrackContentObjectView
 {
 	Q_OBJECT
 
-// theming qproperties
-	Q_PROPERTY( QColor fgColor READ fgColor WRITE setFgColor )
-	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 
 public:
 	AutomationPatternView( AutomationPattern * _pat, TrackView * _parent );
@@ -59,12 +58,7 @@ protected slots:
 protected:
 	virtual void constructContextMenu( QMenu * );
 	virtual void mouseDoubleClickEvent(QMouseEvent * me );
-	virtual void paintEvent( QPaintEvent * _pe );
-	virtual void resizeEvent( QResizeEvent * _re )
-	{
-		m_needsUpdate = true;
-		TrackContentObjectView::resizeEvent( _re );
-	}
+	virtual void paintEvent( QPaintEvent * pe );
 	virtual void dragEnterEvent( QDragEnterEvent * _dee );
 	virtual void dropEvent( QDropEvent * _de );
 
@@ -72,7 +66,8 @@ protected:
 private:
 	AutomationPattern * m_pat;
 	QPixmap m_paintPixmap;
-	bool m_needsUpdate;
+	
+	QStaticText m_staticTextName;
 	
 	static QPixmap * s_pat_rec;
 

--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -29,6 +29,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QMap>
+#include <QStaticText>
 
 #include "Track.h"
 
@@ -107,14 +108,16 @@ protected slots:
 
 
 protected:
-	void paintEvent( QPaintEvent * );
-	void mouseDoubleClickEvent( QMouseEvent * _me );
+	virtual void paintEvent( QPaintEvent * pe );
+	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 	virtual void constructContextMenu( QMenu * );
 
 
 private:
 	BBTCO * m_bbTCO;
-
+	QPixmap m_paintPixmap;
+	
+	QStaticText m_staticTextName;
 } ;
 
 

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -31,6 +31,7 @@
 #include <QDialog>
 #include <QtCore/QThread>
 #include <QPixmap>
+#include <QStaticText>
 
 
 #include "Note.h"
@@ -159,9 +160,6 @@ class PatternView : public TrackContentObjectView
 {
 	Q_OBJECT
 
-// theming qproperties
-	Q_PROPERTY( QColor fgColor READ fgColor WRITE setFgColor )
-	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 public:
 	PatternView( Pattern* pattern, TrackView* parent );
 	virtual ~PatternView();
@@ -182,12 +180,7 @@ protected:
 	virtual void constructContextMenu( QMenu * );
 	virtual void mousePressEvent( QMouseEvent * _me );
 	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
-	virtual void resizeEvent( QResizeEvent * _re )
-	{
-		m_needsUpdate = true;
-		TrackContentObjectView::resizeEvent( _re );
-	}
+	virtual void paintEvent( QPaintEvent * pe );
 	virtual void wheelEvent( QWheelEvent * _we );
 
 
@@ -199,7 +192,8 @@ private:
 
 	Pattern* m_pat;
 	QPixmap m_paintPixmap;
-	bool m_needsUpdate;
+	
+	QStaticText m_staticTextName;
 } ;
 
 

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -88,10 +88,6 @@ signals:
 class SampleTCOView : public TrackContentObjectView
 {
 	Q_OBJECT
-	
-// theming qproperties
-	Q_PROPERTY( QColor fgColor READ fgColor WRITE setFgColor )
-	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 
 public:
 	SampleTCOView( SampleTCO * _tco, TrackView * _tv );
@@ -100,6 +96,7 @@ public:
 
 public slots:
 	void updateSample();
+
 
 
 protected:
@@ -113,6 +110,7 @@ protected:
 
 private:
 	SampleTCO * m_tco;
+	QPixmap m_paintPixmap;
 } ;
 
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -191,8 +191,12 @@ class TrackContentObjectView : public selectableObject, public ModelView
 	Q_OBJECT
 
 // theming qproperties
-	Q_PROPERTY( QColor fgColor READ fgColor WRITE setFgColor )
+	Q_PROPERTY( QColor mutedColor READ mutedColor WRITE setMutedColor )
+	Q_PROPERTY( QColor mutedBackgroundColor READ mutedBackgroundColor WRITE setMutedBackgroundColor )
+	Q_PROPERTY( QColor selectedColor READ selectedColor WRITE setSelectedColor )
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
+	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
+	Q_PROPERTY( bool gradient READ gradient WRITE setGradient )
 
 public:
 	TrackContentObjectView( TrackContentObject * tco, TrackView * tv );
@@ -204,16 +208,29 @@ public:
 	{
 		return m_tco;
 	}
-// qproperty access func
-	QColor fgColor() const;
+	// qproperty access func
+	QColor mutedColor() const;
+	QColor mutedBackgroundColor() const;
+	QColor selectedColor() const;
 	QColor textColor() const;
-	void setFgColor( const QColor & c );
+	QColor textShadowColor() const;
+	bool gradient() const;
+	void setMutedColor( const QColor & c );
+	void setMutedBackgroundColor( const QColor & c );
+	void setSelectedColor( const QColor & c );
 	void setTextColor( const QColor & c );
+	void setTextShadowColor( const QColor & c );
+	void setGradient( const bool & b );
 
+	// access needsUpdate member variable
+	bool needsUpdate();
+	void setNeedsUpdate( bool b );
+	
 public slots:
 	virtual bool close();
 	void cut();
 	void remove();
+	virtual void update();
 
 protected:
 	virtual void constructContextMenu( QMenu * )
@@ -227,6 +244,11 @@ protected:
 	virtual void mousePressEvent( QMouseEvent * me );
 	virtual void mouseMoveEvent( QMouseEvent * me );
 	virtual void mouseReleaseEvent( QMouseEvent * me );
+	virtual void resizeEvent( QResizeEvent * re )
+	{
+		m_needsUpdate = true;
+		selectableObject::resizeEvent( re );
+	}
 
 	float pixelsPerTact();
 
@@ -267,9 +289,14 @@ private:
 	MidiTime m_oldTime;// used for undo/redo while mouse-button is pressed
 
 // qproperty fields
-	QColor m_fgColor;
+	QColor m_mutedColor;
+	QColor m_mutedBackgroundColor;
+	QColor m_selectedColor;
 	QColor m_textColor;
+	QColor m_textShadowColor;
+	bool m_gradient;
 
+ 	bool m_needsUpdate;
 	inline void setInitialMousePos( QPoint pos )
 	{
 		m_initialMousePos = pos;

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -903,9 +903,7 @@ void SampleBuffer::visualize( QPainter & _p, const QRect & _dr,
 
 	const bool focus_on_range = _to_frame <= m_frames
 					&& 0 <= _from_frame && _from_frame < _to_frame;
-//	_p.setClipRect( _clip );
-//	_p.setPen( QColor( 0x22, 0xFF, 0x44 ) );
-	//_p.setPen( QColor( 64, 224, 160 ) );
+	//_p.setClipRect( _clip );
 	const int w = _dr.width();
 	const int h = _dr.height();
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -251,8 +251,13 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	m_initialMousePos( QPoint( 0, 0 ) ),
 	m_initialMouseGlobalPos( QPoint( 0, 0 ) ),
 	m_hint( NULL ),
-	m_fgColor( 0, 0, 0 ),
-	m_textColor( 0, 0, 0 )
+	m_mutedColor( 0, 0, 0 ),
+	m_mutedBackgroundColor( 0, 0, 0 ),
+	m_selectedColor( 0, 0, 0 ),
+	m_textColor( 0, 0, 0 ),
+	m_textShadowColor( 0, 0, 0 ),
+	m_gradient( true ),
+	m_needsUpdate( true )
 {
 	if( s_textFloat == NULL )
 	{
@@ -264,10 +269,10 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	setAttribute( Qt::WA_DeleteOnClose, true );
 	setFocusPolicy( Qt::StrongFocus );
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
-	move( 0, 1 );
+	move( 0, 0 );
 	show();
 
-	setFixedHeight( tv->getTrackContentWidget()->height() - 2 );
+	setFixedHeight( tv->getTrackContentWidget()->height() - 1);
 	setAcceptDrops( true );
 	setMouseTracking( true );
 
@@ -300,6 +305,19 @@ TrackContentObjectView::~TrackContentObjectView()
 }
 
 
+/*! \brief Update a TrackContentObjectView
+ *
+ *  TCO's get drawn only when needed, 
+ *  and when a TCO is updated, 
+ *  it needs to be redrawn.
+ *
+ */
+void TrackContentObjectView::update()
+{
+	m_needsUpdate = true;
+	selectableObject::update();
+}
+
 
 
 /*! \brief Does this trackContentObjectView have a fixed TCO?
@@ -319,21 +337,48 @@ bool TrackContentObjectView::fixedTCOs()
 
 // qproperty access functions, to be inherited & used by TCOviews
 //! \brief CSS theming qproperty access method
-QColor TrackContentObjectView::fgColor() const
-{ return m_fgColor; }
+QColor TrackContentObjectView::mutedColor() const
+{ return m_mutedColor; }
 
-//! \brief CSS theming qproperty access method
+QColor TrackContentObjectView::mutedBackgroundColor() const
+{ return m_mutedBackgroundColor; }
+
+QColor TrackContentObjectView::selectedColor() const
+{ return m_selectedColor; }
+
 QColor TrackContentObjectView::textColor() const
 { return m_textColor; }
 
-//! \brief CSS theming qproperty access method
-void TrackContentObjectView::setFgColor( const QColor & c )
-{ m_fgColor = QColor( c ); }
+QColor TrackContentObjectView::textShadowColor() const
+{ return m_textShadowColor; }
+
+bool TrackContentObjectView::gradient() const
+{ return m_gradient; }
 
 //! \brief CSS theming qproperty access method
+void TrackContentObjectView::setMutedColor( const QColor & c )
+{ m_mutedColor = QColor( c ); }
+
+void TrackContentObjectView::setMutedBackgroundColor( const QColor & c )
+{ m_mutedBackgroundColor = QColor( c ); }
+
+void TrackContentObjectView::setSelectedColor( const QColor & c )
+{ m_selectedColor = QColor( c ); }
+
 void TrackContentObjectView::setTextColor( const QColor & c )
 { m_textColor = QColor( c ); }
 
+void TrackContentObjectView::setTextShadowColor( const QColor & c )
+{ m_textShadowColor = QColor( c ); }
+
+void TrackContentObjectView::setGradient( const bool & b )
+{ m_gradient = b; }
+
+// access needsUpdate member variable
+bool TrackContentObjectView::needsUpdate()
+{ return m_needsUpdate; }
+void TrackContentObjectView::setNeedsUpdate( bool b )
+{ m_needsUpdate = b; }
 
 /*! \brief Close a trackContentObjectView
  *
@@ -1047,11 +1092,8 @@ void TrackContentWidget::updateBackground()
 	pmp.fillRect( w, 0, w , h, lighterColor() );
 
 	// draw lines
-	pmp.setPen( QPen( gridColor(), 1 ) );
-	// horizontal line
-	pmp.drawLine( 0, h-1, w*2, h-1 );
-
 	// vertical lines
+	pmp.setPen( QPen( gridColor(), 1 ) );	
 	for( float x = 0; x < w * 2; x += ppt )
 	{
 		pmp.drawLine( QLineF( x, 0.0, x, h ) );
@@ -1062,6 +1104,10 @@ void TrackContentWidget::updateBackground()
 	{
 		pmp.drawLine( QLineF( x, 0.0, x, h ) );
 	}
+	
+	// horizontal line
+	pmp.setPen( QPen( gridColor(), 1 ) );	
+	pmp.drawLine( 0, h-1, w*2, h-1 );
 
 	pmp.end();
 
@@ -1122,7 +1168,7 @@ void TrackContentWidget::update()
 	for( tcoViewVector::iterator it = m_tcoViews.begin();
 				it != m_tcoViews.end(); ++it )
 	{
-		( *it )->setFixedHeight( height() - 2 );
+		( *it )->setFixedHeight( height() - 1 );
 		( *it )->update();
 	}
 	QWidget::update();

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -21,12 +21,12 @@
  * Boston, MA 02110-1301 USA.
  *
  */
+#include "AutomationPatternView.h"
 
 #include <QMouseEvent>
 #include <QPainter>
 #include <QMenu>
 
-#include "AutomationPatternView.h"
 #include "AutomationEditor.h"
 #include "AutomationPattern.h"
 #include "embed.h"
@@ -45,8 +45,7 @@ AutomationPatternView::AutomationPatternView( AutomationPattern * _pattern,
 						TrackView * _parent ) :
 	TrackContentObjectView( _pattern, _parent ),
 	m_pat( _pattern ),
-	m_paintPixmap(),
-	m_needsUpdate( true )
+	m_paintPixmap()
 {
 	connect( m_pat, SIGNAL( dataChanged() ),
 			this, SLOT( update() ) );
@@ -54,7 +53,6 @@ AutomationPatternView::AutomationPatternView( AutomationPattern * _pattern,
 			this, SLOT( update() ) );
 
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
-	setFixedHeight( parentWidget()->height() - 2 );
 
 	ToolTip::add( this, tr( "double-click to open this pattern in "
 						"automation editor" ) );
@@ -85,7 +83,6 @@ void AutomationPatternView::openInAutomationEditor()
 
 void AutomationPatternView::update()
 {
-	m_needsUpdate = true;
 	if( fixedTCOs() )
 	{
 		m_pat->changeLength( m_pat->length() );
@@ -245,82 +242,66 @@ void AutomationPatternView::mouseDoubleClickEvent( QMouseEvent * me )
 
 void AutomationPatternView::paintEvent( QPaintEvent * )
 {
-	if( m_needsUpdate == false )
+	QPainter painter( this );
+
+	if( !needsUpdate() )
 	{
-		QPainter p( this );
-		p.drawPixmap( 0, 0, m_paintPixmap );
+		painter.drawPixmap( 0, 0, m_paintPixmap );
 		return;
 	}
 
-	QPainter _p( this );
-	const QColor styleColor = _p.pen().brush().color();
+	setNeedsUpdate( false );
 
-	m_needsUpdate = false;
-
-	if( m_paintPixmap.isNull() == true || m_paintPixmap.size() != size() )
-	{
-		m_paintPixmap = QPixmap( size() );
-	}
+	m_paintPixmap = m_paintPixmap.isNull() == true || m_paintPixmap.size() != size()
+		? QPixmap( size() ) : m_paintPixmap;
 
 	QPainter p( &m_paintPixmap );
 
 	QLinearGradient lingrad( 0, 0, 0, height() );
 	QColor c;
-
-	if( !( m_pat->getTrack()->isMuted() || m_pat->isMuted() ) )
-		c = styleColor;
-	else
-		c = QColor( 80, 80, 80 );
-
-	if( isSelected() == true )
-	{
-		c.setRgb( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
-	}
+	bool muted = m_pat->getTrack()->isMuted() || m_pat->isMuted();
+	bool current = gui->automationEditor()->currentPattern() == m_pat;
+	
+	// state: selected, muted, normal
+	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
+		:	painter.background().color() );
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );
-
-	p.setBrush( lingrad );
-	if( gui->automationEditor()->currentPattern() == m_pat )
-		p.setPen( c.lighter( 160 ) );
+	
+	if( gradient() )
+	{
+		p.fillRect( rect(), lingrad );
+	}
 	else
-		p.setPen( c.lighter( 130 ) );
-	p.drawRect( 1, 1, width()-3, height()-3 );
-
-
+	{
+		p.fillRect( rect(), c );
+	}
+	
 	const float ppt = fixedTCOs() ?
 			( parentWidget()->width() - 2 * TCO_BORDER_WIDTH )
 					/ (float) m_pat->length().getTact() :
 								pixelsPerTact();
 
 	const int x_base = TCO_BORDER_WIDTH;
-	p.setPen( c.darker( 300 ) );
-
-	for( tact_t t = 1; t < m_pat->length().getTact(); ++t )
-	{
-		const int tx = x_base + static_cast<int>( ppt * t ) - 1;
-		if( tx < ( width() - TCO_BORDER_WIDTH*2 ) )
-		{
-			p.drawLine( tx, TCO_BORDER_WIDTH, tx, 5 );
-			p.drawLine( tx,	height() - ( 4 + 2 * TCO_BORDER_WIDTH ),
-						tx,	height() - 2 * TCO_BORDER_WIDTH );
-		}
-	}
-
+	
 	const float min = m_pat->firstObject()->minValue<float>();
 	const float max = m_pat->firstObject()->maxValue<float>();
 
 	const float y_scale = max - min;
-	const float h = ( height() - 2*TCO_BORDER_WIDTH ) / y_scale;
+	const float h = ( height() - 2 * TCO_BORDER_WIDTH ) / y_scale;
 
 	p.translate( 0.0f, max * height() / y_scale - TCO_BORDER_WIDTH );
 	p.scale( 1.0f, -h );
 
 	QLinearGradient lin2grad( 0, min, 0, max );
+	QColor col;
+	
+	col = !muted ? painter.pen().brush().color() : mutedColor();
 
-	lin2grad.setColorAt( 1, fgColor().lighter( 150 ) );
-	lin2grad.setColorAt( 0.5, fgColor() );
-	lin2grad.setColorAt( 0, fgColor().darker( 150 ) );
+	lin2grad.setColorAt( 1, col.lighter( 150 ) );
+	lin2grad.setColorAt( 0.5, col );
+	lin2grad.setColorAt( 0, col.darker( 150 ) );
 
 	for( AutomationPattern::timeMap::const_iterator it =
 						m_pat->getTimeMap().begin();
@@ -332,67 +313,105 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 						MidiTime::ticksPerTact();
 			const float x2 = (float)( width() - TCO_BORDER_WIDTH );
 			if( x1 > ( width() - TCO_BORDER_WIDTH ) ) break;
-
-			p.fillRect( QRectF( x1, 0.0f, x2-x1, it.value() ),
-								lin2grad );
+			if( gradient() )
+			{
+				p.fillRect( QRectF( x1, 0.0f, x2 - x1, it.value() ), lin2grad );
+			}
+			else
+			{
+				p.fillRect( QRectF( x1, 0.0f, x2 - x1, it.value() ), col );
+			}
 			break;
 		}
 
 		float *values = m_pat->valuesAfter( it.key() );
-		for( int i = it.key(); i < (it+1).key(); i++ )
+		for( int i = it.key(); i < (it + 1).key(); i++ )
 		{
 			float value = values[i - it.key()];
 			const float x1 = x_base + i * ppt /
 						MidiTime::ticksPerTact();
-			const float x2 = x_base + (i+1) * ppt /
+			const float x2 = x_base + (i + 1) * ppt /
 						MidiTime::ticksPerTact();
 			if( x1 > ( width() - TCO_BORDER_WIDTH ) ) break;
 
-			p.fillRect( QRectF( x1, 0.0f, x2-x1, value ),
-								lin2grad );
+			if( gradient() )
+			{
+				p.fillRect( QRectF( x1, 0.0f, x2 - x1, value ), lin2grad );
+			}
+			else
+			{
+				p.fillRect( QRectF( x1, 0.0f, x2 - x1, value ), col );
+			}
 		}
 		delete [] values;
 	}
 
 	p.resetMatrix();
+	
+	// bar lines
+	const int lineSize = 3;
+	p.setPen( c.darker( 300 ) );
+
+	for( tact_t t = 1; t < m_pat->length().getTact(); ++t )
+	{
+		const int tx = x_base + static_cast<int>( ppt * t ) - 2;
+		if( tx < ( width() - TCO_BORDER_WIDTH * 2 ) )
+		{
+			p.drawLine( tx, TCO_BORDER_WIDTH, tx, TCO_BORDER_WIDTH + lineSize );
+			p.drawLine( tx,	rect().bottom() - ( lineSize + TCO_BORDER_WIDTH ),
+						tx, rect().bottom() - TCO_BORDER_WIDTH );
+		}
+	}
 
 	// recording icon for when recording automation
 	if( m_pat->isRecording() )
 	{
-		p.drawPixmap( 4, 14, *s_pat_rec );
+		p.drawPixmap( 1, rect().bottom() - s_pat_rec->height(),
+		 	*s_pat_rec );
 	}
-
-	// outer edge
-	p.setBrush( QBrush() );
-	if( gui->automationEditor()->currentPattern() == m_pat )
-		p.setPen( c.lighter( 130 ) );
-	else
-		p.setPen( c.darker( 300 ) );
-	p.drawRect( 0, 0, width()-1, height()-1 );
-
+	
 	// pattern name
-	p.setFont( pointSize<8>( p.font() ) );
+	p.setRenderHint( QPainter::TextAntialiasing );
+	
+	if(  m_staticTextName.text() != m_pat->name() )
+	{
+		m_staticTextName.setText( m_pat->name() );
+	}
+	
+	QFont font;
+	font.setHintingPreference( QFont::PreferFullHinting );
+	font.setPointSize( 8 );
+	p.setFont( font );
+	
+	const int textTop = TCO_BORDER_WIDTH + 1;
+	const int textLeft = TCO_BORDER_WIDTH + 1;
+	
+	p.setPen( textShadowColor() );
+	p.drawStaticText( textLeft + 1, textTop + 1, m_staticTextName );
+	p.setPen( textColor() );
+	p.drawStaticText( textLeft, textTop, m_staticTextName );
+	
+	// inner border
+	p.setPen( c.lighter( current ? 160 : 130 ) );
+	p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH, 
+		rect().bottom() - TCO_BORDER_WIDTH );
+		
+	// outer border	
+	p.setPen( current? c.lighter( 130 ) : c.darker( 300 ) );
+	p.drawRect( 0, 0, rect().right(), rect().bottom() );	
 
-	QColor text_color = ( m_pat->isMuted() || m_pat->getTrack()->isMuted() )
-		? QColor( 30, 30, 30 )
-		: textColor();
-
-	p.setPen( QColor( 0, 0, 0 ) );
-	p.drawText( 4, p.fontMetrics().height()+1, m_pat->name() );
-	p.setPen( text_color );
-	p.drawText( 3, p.fontMetrics().height(), m_pat->name() );
-
+	// draw the 'muted' pixmap only if the pattern was manualy muted
 	if( m_pat->isMuted() )
 	{
-		p.drawPixmap( 3, p.fontMetrics().height() + 1,
-				embed::getIconPixmap( "muted", 16, 16 ) );
+		const int spacing = TCO_BORDER_WIDTH;
+		const int size = 14;
+		p.drawPixmap( spacing, height() - ( size + spacing ),
+			embed::getIconPixmap( "muted", size, size ) );
 	}
-
 
 	p.end();
 
-	_p.drawPixmap( 0, 0, m_paintPixmap );
-
+	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 
 

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -22,6 +22,7 @@
  * Boston, MA 02110-1301 USA.
  *
  */
+#include "SampleTrack.h"
 
 #include <QDomElement>
 #include <QDropEvent>
@@ -33,7 +34,6 @@
 #include <QPushButton>
 
 #include "gui_templates.h"
-#include "SampleTrack.h"
 #include "Song.h"
 #include "embed.h"
 #include "Engine.h"
@@ -200,15 +200,10 @@ TrackContentObjectView * SampleTCO::createView( TrackView * _tv )
 
 
 
-
-
-
-
-
-
 SampleTCOView::SampleTCOView( SampleTCO * _tco, TrackView * _tv ) :
 	TrackContentObjectView( _tco, _tv ),
-	m_tco( _tco )
+	m_tco( _tco ),
+	m_paintPixmap()
 {
 	// update UI and tooltip
 	updateSample();
@@ -273,9 +268,9 @@ void SampleTCOView::contextMenuEvent( QContextMenuEvent * _cme )
 					"Ctrl"),
 					#endif
 						m_tco, SLOT( toggleMute() ) );
-	contextMenu.addAction( embed::getIconPixmap( "record" ),
+	/*contextMenu.addAction( embed::getIconPixmap( "record" ),
 				tr( "Set/clear record" ),
-						m_tco, SLOT( toggleRecord() ) );
+						m_tco, SLOT( toggleRecord() ) );*/
 	constructContextMenu( &contextMenu );
 
 	contextMenu.exec( QCursor::pos() );
@@ -351,77 +346,98 @@ void SampleTCOView::mouseDoubleClickEvent( QMouseEvent * )
 
 
 
-void SampleTCOView::paintEvent( QPaintEvent * _pe )
+void SampleTCOView::paintEvent( QPaintEvent * pe )
 {
-	QPainter p( this );
-	const QColor styleColor = p.pen().brush().color();
+	QPainter painter( this );
 
+	if( !needsUpdate() )
+	{
+		painter.drawPixmap( 0, 0, m_paintPixmap );
+		return;
+	}
+
+	setNeedsUpdate( false );
+
+	m_paintPixmap = m_paintPixmap.isNull() == true || m_paintPixmap.size() != size() 
+		? QPixmap( size() ) : m_paintPixmap;
+
+	QPainter p( &m_paintPixmap );
+
+	QLinearGradient lingrad( 0, 0, 0, height() );
 	QColor c;
-	if( !( m_tco->getTrack()->isMuted() || m_tco->isMuted() ) )
+	bool muted = m_tco->getTrack()->isMuted() || m_tco->isMuted();
+	
+	// state: selected, muted, normal
+	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
+		: painter.background().color() );
+
+	lingrad.setColorAt( 1, c.darker( 300 ) );
+	lingrad.setColorAt( 0, c );
+	
+	if( gradient() )
 	{
-		c = styleColor;
+		p.fillRect( rect(), lingrad );
 	}
 	else
 	{
-		c = QColor( 80, 80, 80 );
+		p.fillRect( rect(), c );
 	}
 
-	if( isSelected() == true )
-	{
-		c.setRgb( qMax( c.red() - 128, 0 ), qMax( c.green() - 128, 0 ), 255 );
-	}
-
-	QLinearGradient grad( 0, 0, 0, height() );
-
-	grad.setColorAt( 1, c.darker( 300 ) );
-	grad.setColorAt( 0, c );
-
-	p.setBrush( grad );
-	p.setPen( c.lighter( 160 ) );
-	p.drawRect( 1, 1, width()-3, height()-3 );
-
-	p.setBrush( QBrush() );
-	p.setPen( c.darker( 300 ) );
-	p.drawRect( 0, 0, width()-1, height()-1 );
-
-
-	if( m_tco->getTrack()->isMuted() || m_tco->isMuted() )
-	{
-		p.setPen( QColor( 128, 128, 128 ) );
-	}
-	else
-	{
-		p.setPen( fgColor() );
-	}
-	QRect r = QRect( 1, 1,
+	p.setPen( !muted ? painter.pen().brush().color() : mutedColor() );
+	
+	const int spacing = TCO_BORDER_WIDTH + 1;
+	
+	QRect r = QRect( TCO_BORDER_WIDTH, spacing,
 			qMax( static_cast<int>( m_tco->sampleLength() *
 				pixelsPerTact() / DefaultTicksPerTact ), 1 ),
-								height() - 4 );
-	p.setClipRect( QRect( 1, 1, width() - 2, height() - 2 ) );
-	m_tco->m_sampleBuffer->visualize( p, r, _pe->rect() );
+					rect().bottom() - 2 * spacing );
+	m_tco->m_sampleBuffer->visualize( p, r, pe->rect() );
+
+	// disable antialiasing for borders, since its not needed
+	p.setRenderHint( QPainter::Antialiasing, false );
+
 	if( r.width() < width() - 1 )
 	{
-		p.drawLine( r.x() + r.width(), r.y() + r.height() / 2,
-				width() - 2, r.y() + r.height() / 2 );
+		p.drawLine( r.x(), r.y() + r.height() / 2,
+			rect().right() - TCO_BORDER_WIDTH, r.y() + r.height() / 2 );
 	}
 
-	p.translate( 0, 0 );
+	// inner border
+	p.setPen( c.lighter( 160 ) );
+	p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH, 
+		rect().bottom() - TCO_BORDER_WIDTH );
+		
+	// outer border
+	p.setPen( c.darker( 300 ) );
+	p.drawRect( 0, 0, rect().right(), rect().bottom() );
+	
+	// draw the 'muted' pixmap only if the pattern was manualy muted
 	if( m_tco->isMuted() )
 	{
-		p.drawPixmap( 3, 8, embed::getIconPixmap( "muted", 16, 16 ) );
+		const int spacing = TCO_BORDER_WIDTH;
+		const int size = 14;
+		p.drawPixmap( spacing, height() - ( size + spacing ),
+			embed::getIconPixmap( "muted", size, size ) );
 	}
-	if( m_tco->isRecord() )
+	
+	// recording sample tracks is not possible at the moment 
+	
+	/* if( m_tco->isRecord() )
 	{
 		p.setFont( pointSize<7>( p.font() ) );
 
-		p.setPen( QColor( 0, 0, 0 ) );
+		p.setPen( textShadowColor() );
 		p.drawText( 10, p.fontMetrics().height()+1, "Rec" );
 		p.setPen( textColor() );
 		p.drawText( 9, p.fontMetrics().height(), "Rec" );
 
 		p.setBrush( QBrush( textColor() ) );
 		p.drawEllipse( 4, 5, 4, 4 );
-	}
+	}*/
+	
+	p.end();
+	
+	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 
 


### PR DESCRIPTION
Per https://github.com/HDDigitizerMusic/lmms-alt-theme/issues/8

Fixes #2148

This PR does several things:

1. Fixes incorrect rendering of TCO's: they was a one pixel gap between the grid and the TCOs. Also fix the incorect rendering of the bar-lines on Instrument pattern TCO's:
Before & after
![screenshot from 2016-02-16 22 36 26](https://cloud.githubusercontent.com/assets/6282045/13092401/031899b6-d500-11e5-9cf4-535731f54c30.png)     ![screenshot from 2016-02-16 22 36 48](https://cloud.githubusercontent.com/assets/6282045/13092402/031bab4c-d500-11e5-85b2-c80b8aae5cca.png)

2. Adds a Boolean `qproperty-gradient` that allows themers to get rid of the hardcoded gradients on TCO's. 

3. Removes all of the hard coded colors, so now you can change the color of a muted and selected TCO, as well as the shadow of the text.

4. Evens out the muted and selected colors, so they all are the same.

5. Implements missing muted foreground color for automation patterns.

6. All pattern text stays the same color when the pattern is muted, for better readability.

Comparison:

Old
![screenshot from 2016-02-16 22 30 25](https://cloud.githubusercontent.com/assets/6282045/13092345/b5363c62-d4ff-11e5-8bdc-5f864a407c2f.png)

New
![screenshot from 2016-02-16 23 27 32](https://cloud.githubusercontent.com/assets/6282045/13093364/26ede986-d505-11e5-977e-820a9ebb7212.png)

New with gradients off
![screenshot from 2016-02-16 23 28 28](https://cloud.githubusercontent.com/assets/6282045/13093369/2aaec4c8-d505-11e5-8182-e18100162ed9.png)