### PR TITLE
Fixes several performance problems found with Valgrind

### DIFF
--- a/include/ComboBox.h
+++ b/include/ComboBox.h
@@ -51,8 +51,6 @@ public:
 		return castModel<ComboBoxModel>();
 	}
 
-	virtual QSize sizeHint() const;
-
 public slots:
 	void selectNext();
 	void selectPrevious();

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -28,6 +28,7 @@
 
 #include <QWidget>
 #include <QLabel>
+#include <QStaticText>
 
 #include "Knob.h"
 #include "LcdWidget.h"
@@ -78,7 +79,7 @@ public:
 	static const int FxLineHeight;
 
 private:
-	static void drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name, bool isActive, bool sendToThis, bool receiveFromThis );
+	void drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name, bool isActive, bool sendToThis, bool receiveFromThis );
 
 	FxMixerView * m_mv;
 	LcdWidget* m_lcd;
@@ -90,6 +91,8 @@ private:
 	QColor m_strokeInnerInactive;
 	static QPixmap * s_sendBgArrow;
 	static QPixmap * s_receiveBgArrow;
+
+	QStaticText m_staticTextName;
 
 private slots:
 	void renameChannel();

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -314,8 +314,7 @@ public:
 		m_playHandleRemovalMutex.unlock();
 	}
 
-	static float peakValueLeft( sampleFrame * _ab, const f_cnt_t _frames );
-	static float peakValueRight( sampleFrame * _ab, const f_cnt_t _frames );
+	void getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & peakLeft, float & peakRight ) const;
 
 
 	bool criticalXRuns() const;

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -175,8 +175,11 @@ void FxChannel::doProcessing()
 
 		m_stillRunning = m_fxChain.processAudioBuffer( m_buffer, fpp, m_hasInput );
 
-		m_peakLeft = qMax( m_peakLeft, Engine::mixer()->peakValueLeft( m_buffer, fpp ) * v );
-		m_peakRight = qMax( m_peakRight, Engine::mixer()->peakValueRight( m_buffer, fpp ) * v );
+		float peakLeft = 0.;
+		float peakRight = 0.;
+		Engine::mixer()->getPeakValues( m_buffer, fpp, peakLeft, peakRight );
+		m_peakLeft = qMax( m_peakLeft, peakLeft * v );
+		m_peakRight = qMax( m_peakRight, peakRight * v );
 	}
 	else
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -484,27 +484,25 @@ void Mixer::clear()
 
 
 
-float Mixer::peakValueLeft( sampleFrame * _ab, const f_cnt_t _frames )
+void Mixer::getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & peakLeft, float & peakRight ) const
 {
-	float p = 0.0f;
+	peakLeft = 0.0f;
+	peakRight = 0.0f;
+
 	for( f_cnt_t f = 0; f < _frames; ++f )
 	{
-		p = qMax( p, qAbs( _ab[f][0] ) );
+		float const absLeft = qAbs( _ab[f][0] );
+		float const absRight = qAbs( _ab[f][1] );
+		if (absLeft > peakLeft)
+		{
+			peakLeft = absLeft;
+		}
+
+		if (absRight > peakRight)
+		{
+			peakRight = absRight;
+		}
 	}
-	return p;
-}
-
-
-
-
-float Mixer::peakValueRight( sampleFrame * _ab, const f_cnt_t _frames )
-{
-	float p = 0.0f;
-	for( f_cnt_t f = 0; f < _frames; ++f )
-	{
-		p = qMax( p, qAbs( _ab[f][1] ) );
-	}
-	return p;
 }
 
 

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -88,24 +88,6 @@ ComboBox::~ComboBox()
 
 
 
-QSize ComboBox::sizeHint() const
-{
-	int maxTextWidth = 0;
-	for( int i = 0; model() && i < model()->size(); ++i )
-	{
-		int w = fontMetrics().width( model()->itemText( i ) );
-		if( w > maxTextWidth )
-		{
-			maxTextWidth = w;
-		}
-	}
-
-	return QSize( 32 + maxTextWidth, 22 );
-}
-
-
-
-
 void ComboBox::selectNext()
 {
 	model()->setInitValue( model()->value() + 1 );

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -150,16 +150,25 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name,
 	}
 
 	// draw the channel name
+	if( m_staticTextName.text() != name )
+	{
+		m_staticTextName.setText( name );
+	}
 	p->rotate( -90 );
 
-	p->setFont( pointSizeF( fxLine->font(), 7.5f ) );	
+	p->setFont( pointSizeF( fxLine->font(), 7.5f ) );
+
+	// Coordinates of the foreground text
+	int const textLeft = -145;
+	int const textTop = 9;
+
+	// Draw text shadow
 	p->setPen( sh_color );
-	p->drawText( -146, 21, name ); 
+	p->drawStaticText( textLeft - 1, textTop + 1, m_staticTextName );
 	
+	// Draw foreground text
 	p->setPen( isActive ? bt_color : te_color );
-
-	p->drawText( -145, 20, name );
-
+	p->drawStaticText( textLeft, textTop, m_staticTextName );
 }
 
 

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -122,7 +122,9 @@ void VisualizationWidget::paintEvent( QPaintEvent * )
 
 	if( m_active && !Engine::getSong()->isExporting() )
 	{
-		float master_output = Engine::mixer()->masterGain();
+		Mixer const * mixer = Engine::mixer();
+
+		float master_output = mixer->masterGain();
 		int w = width()-4;
 		const float half_h = -( height() - 6 ) / 3.0 * master_output - 1;
 		int x_base = 2;
@@ -131,11 +133,11 @@ void VisualizationWidget::paintEvent( QPaintEvent * )
 //		p.setClipRect( 2, 2, w, height()-4 );
 
 
-		const fpp_t frames =
-				Engine::mixer()->framesPerPeriod();
-		const float max_level = qMax<float>(
-				Mixer::peakValueLeft( m_buffer, frames ),
-				Mixer::peakValueRight( m_buffer, frames ) );
+		const fpp_t frames = mixer->framesPerPeriod();
+		float peakLeft;
+		float peakRight;
+		mixer->getPeakValues( m_buffer, frames, peakLeft, peakRight );
+		const float max_level = qMax<float>( peakLeft, peakRight );
 
 		// and set color according to that...
 		if( max_level * master_output < 0.9 )


### PR DESCRIPTION
Removes some repeated calls to Qt's font layouting:
* `FxLine::drawFxLine` now uses a `QStaticText` instance to render the channel names. The method `drawFxLine` was turned into a member method so that the `QStaticText` member can be accessed.
* Removing the overridden method `ComboBox::sizeHint`.

Unifies `Mixer::peakValueLeft` and `Mixer::peakValueRight` into
`Mixer::getPeakValues` so the array is only iterated once.