### PR TITLE
Fix #2588 by making Piano Roll's Alt+Right shortcut mirror the Alt+Left shortcut

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1081,7 +1081,8 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 				}
 				else if( ke->modifiers() & Qt::AltModifier)
 				{
-					Pattern * p = m_pattern->previousPattern();
+					// switch to editing a pattern adjacent to this one in the song editor
+					Pattern * p = direction > 0 ? m_pattern->nextPattern() : m_pattern->previousPattern();
 					if(p != NULL)
 					{
 						setCurrentPattern(p);


### PR DESCRIPTION
After 8504633103f665cb69d6732b110d5c8cb40a6c6c, the Alt+Right shortcut in the piano roll was broken such that it now behaves the same as Alt+Left. This PR fixes that; Alt+Left causes the piano roll to edit the pattern to the left of the selected one in the song editor, and Alt+Right causes it to edit the pattern to the *right*.