### PR TITLE
Fix EQ labels back to resonance.

### DIFF
--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -103,7 +103,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		mainLayout->setAlignment( m_resKnob, Qt::AlignHCenter );
 		m_resKnob->setVolumeKnob(false);
 		m_resKnob->setModel( m_parameterWidget->getBandModels( i )->res );
-		if(i > 0 && i < 7) { m_resKnob->setHintText( tr( "Bandwidth: " ) , tr( " Octave" ) ); }
+		if(i > 1 && i < 6) { m_resKnob->setHintText( tr( "Bandwidth: " ) , tr( " Octave" ) ); }
 		else { m_resKnob->setHintText( tr( "Resonance : " ) , "" ); }
 
 		m_freqKnob = new Knob( knobBright_26, this );


### PR DESCRIPTION
Fix for translation issue in #2583 with rolled back changes to actual EQ knob labeling.