### PR TITLE
Update two NotePlayHandle methods to ignore child NotePlayHandles

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -206,11 +206,13 @@ public:
 	void mute();
 
 	/*! Returns index of NotePlayHandle in vector of note-play-handles
-        belonging to this instrument track - used by arpeggiator */
+	    belonging to this instrument track - used by arpeggiator.
+	    Ignores child note-play-handles, returns -1 when called on one */
 	int index() const;
 
-	/*! returns list of note-play-handles belonging to given instrument track,
-	    if allPlayHandles = true, also released note-play-handles are returned */
+	/*! Returns list of note-play-handles belonging to given instrument track.
+	    If allPlayHandles = true, also released note-play-handles and children
+	    are returned */
 	static ConstNotePlayHandleList nphsOfInstrumentTrack( const InstrumentTrack* Track, bool allPlayHandles = false );
 
 	/*! Returns whether given NotePlayHandle instance is equal to *this */

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -449,17 +449,17 @@ int NotePlayHandle::index() const
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
 		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
-		if( nph == NULL || nph->m_instrumentTrack != m_instrumentTrack || nph->isReleased() )
+		if( nph == NULL || nph->m_instrumentTrack != m_instrumentTrack || nph->isReleased() || nph->hasParent() )
 		{
 			continue;
 		}
 		if( nph == this )
 		{
-			break;
+			return idx;
 		}
 		++idx;
 	}
-	return idx;
+	return -1;
 }
 
 
@@ -473,7 +473,7 @@ ConstNotePlayHandleList NotePlayHandle::nphsOfInstrumentTrack( const InstrumentT
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
 		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
-		if( nph != NULL && nph->m_instrumentTrack == _it && ( nph->isReleased() == false || _all_ph == true ) )
+		if( nph != NULL && nph->m_instrumentTrack == _it && ( ( nph->isReleased() == false && nph->hasParent() == false ) || _all_ph == true ) )
 		{
 			cnphv.push_back( nph );
 		}


### PR DESCRIPTION
The methods NotePlayHandle::index and NotePlayHandle::nphsOfInstrumentTrack
had not yet been brought up-to-date with the new system of attaching child
NotePlayHandles directly to the mixer. This caused strange glitches when
arpeggio was used in sort mode.