### PR TITLE
Add Mac/Qt5 build directives for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ matrix:
         - env: TARGET_OS=win64
         - env: QT5=True
         - os: osx
+        - os: osx
+          env: QT5=True
 before_install:
    - sh ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.before_install.sh
 install:

--- a/.travis/linux..before_install.sh
+++ b/.travis/linux..before_install.sh
@@ -1,7 +1,8 @@
+#!/usr/bin/env bash
+
 sudo add-apt-repository ppa:kalakris/cmake -y;
 sudo add-apt-repository ppa:andrewrk/libgroove -y;
-if [ $QT5 ]
-	then
+if [ $QT5 ]; then
 	sudo add-apt-repository ppa:ubuntu-sdk-team/ppa -y
 fi
 sudo apt-get update -qq

--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 PACKAGES="cmake libsndfile-dev fftw3-dev libvorbis-dev  libogg-dev
 	libasound2-dev libjack-dev libsdl-dev libsamplerate0-dev libstk0-dev
 	libfluidsynth-dev portaudio19-dev wine-dev g++-multilib libfltk1.3-dev

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_WERROR=ON -DWANT_QT5=$QT5 ..

--- a/.travis/linux.win32.before_install.sh
+++ b/.travis/linux.win32.before_install.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 sudo add-apt-repository ppa:tobydox/mingw-x-precise -y
 sudo apt-get update -qq

--- a/.travis/linux.win32.install.sh
+++ b/.travis/linux.win32.install.sh
@@ -1,7 +1,9 @@
+#!/usr/bin/env bash
+
 sudo apt-get install -y nsis cloog-isl libmpc2 mingw32
 
-sudo apt-get install -y mingw32-x-qt mingw32-x-sdl mingw32-x-libvorbis 			\
-	mingw32-x-fluidsynth mingw32-x-stk mingw32-x-glib2 mingw32-x-portaudio		\
-	mingw32-x-libsndfile mingw32-x-fftw mingw32-x-flac mingw32-x-fltk			\
-	mingw32-x-libsamplerate mingw32-x-pkgconfig mingw32-x-binutils				\
+sudo apt-get install -y mingw32-x-qt mingw32-x-sdl mingw32-x-libvorbis \
+	mingw32-x-fluidsynth mingw32-x-stk mingw32-x-glib2 mingw32-x-portaudio	\
+	mingw32-x-libsndfile mingw32-x-fftw mingw32-x-flac mingw32-x-fltk \
+	mingw32-x-libsamplerate mingw32-x-pkgconfig mingw32-x-binutils \
 	mingw32-x-gcc mingw32-x-runtime mingw32-x-libgig mingw32-x-libsoundio

--- a/.travis/linux.win32.script.sh
+++ b/.travis/linux.win32.script.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 export CMAKE_OPTS="-DUSE_WERROR=ON"
 ../cmake/build_mingw32.sh || ../cmake/build_mingw32.sh

--- a/.travis/linux.win64.before_install.sh
+++ b/.travis/linux.win64.before_install.sh
@@ -1,1 +1,3 @@
-sh .travis/linux.win32.before_install.sh
+#!/usr/bin/env bash
+
+. .travis/linux.win32.before_install.sh

--- a/.travis/linux.win64.install.sh
+++ b/.travis/linux.win64.install.sh
@@ -1,7 +1,9 @@
-sh .travis/linux.win32.install.sh
+#!/usr/bin/env bash
 
-sudo apt-get install -y mingw64-x-qt mingw64-x-sdl mingw64-x-libvorbis			\
-	mingw64-x-fluidsynth mingw64-x-stk mingw64-x-glib2 mingw64-x-portaudio		\
-	mingw64-x-libsndfile mingw64-x-fftw mingw64-x-flac mingw64-x-fltk			\
-	mingw64-x-libsamplerate mingw64-x-pkgconfig mingw64-x-binutils mingw64-x-gcc\
+. .travis/linux.win32.install.sh
+
+sudo apt-get install -y mingw64-x-qt mingw64-x-sdl mingw64-x-libvorbis \
+	mingw64-x-fluidsynth mingw64-x-stk mingw64-x-glib2 mingw64-x-portaudio \
+	mingw64-x-libsndfile mingw64-x-fftw mingw64-x-flac mingw64-x-fltk \
+	mingw64-x-libsamplerate mingw64-x-pkgconfig mingw64-x-binutils mingw64-x-gcc \
 	mingw64-x-runtime mingw64-x-libgig mingw64-x-libsoundio

--- a/.travis/linux.win64.script.sh
+++ b/.travis/linux.win64.script.sh
@@ -1,2 +1,4 @@
+#!/usr/bin/env bash
+
 export CMAKE_OPTS="-DUSE_WERROR=ON"
 ../cmake/build_mingw64.sh || ../cmake/build_mingw64.sh

--- a/.travis/osx..before_install.sh
+++ b/.travis/osx..before_install.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 brew update

--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -1,4 +1,15 @@
-brew reinstall cmake pkgconfig qt fftw libogg libvorbis libsndfile libsamplerate jack sdl stk fluid-synth portaudio node
+#!/usr/bin/env bash
+
+PACKAGES="cmake pkgconfig fftw libogg libvorbis libsndfile libsamplerate jack sdl stk fluid-synth portaudio node"
+
+if [ $QT5 ]; then
+	PACKAGES="$PACKAGES qt5"
+else
+	PACKAGES="$PACKAGES qt"
+fi
+
+brew reinstall $PACKAGES
+
 sudo npm install -g appdmg
 
 # Workaround per Homebrew bug #44806

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -1,1 +1,8 @@
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo .. -DUSE_WERROR=OFF
+#!/usr/bin/env bash
+
+if [ $QT5 ]; then
+        # Workaround; No FindQt5.cmake module exists
+        export CMAKE_PREFIX_PATH="$(brew --prefix qt5)"
+fi
+
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWANT_QT5=$QT5 -DUSE_WERROR=OFF ..


### PR DESCRIPTION
This will add a new Mac build task which compiles against Qt5 (default is Qt4).
 * Since cmake is missing the PkgConfig files for Qt5, adding the libraries is a manual step, `CMAKE_PREFIX_PATH="$(brew --prefix qt5)"` help found here https://github.com/Cockatrice/Cockatrice/issues/205
 * Unrelated to this PR, but for consistency, explicitly defines bash as shell interpreter for all Travis related scripts.

Like all Travis-related PRs, this will need to be monitored and adjusted until all targets pass.
In addition, the `install` and `dmg` targets should be tested as part of this PR.
