### PR TITLE
Fix regression that caused faulty FX channel index numbers

### DIFF
--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -383,6 +383,10 @@ void FxMixer::moveChannelLeft( int index )
 
 	// Swap positions in array
 	qSwap(m_fxChannels[index], m_fxChannels[index - 1]);
+
+	// Update m_channelIndex of both channels
+	m_fxChannels[index]->m_channelIndex = index;
+	m_fxChannels[index - 1]->m_channelIndex = index -1;
 }
 
 


### PR DESCRIPTION
Commit e919912 changed the behavior of the FX channel swapping code so that
it no longer updated the m_channelIndex member of the swapped channels. This
caused sends/receives of swapped FX channels to move about when a project
was saved and loaded again.

**Edit @tresf** Closes #2641