### PR TITLE
Fixes #2624 ("Controls window of LFO controller is not destroyed upon closing a project")

### DIFF
--- a/src/gui/widgets/ControllerView.cpp
+++ b/src/gui/widgets/ControllerView.cpp
@@ -104,6 +104,10 @@ ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 
 ControllerView::~ControllerView()
 {
+	if (m_subWindow)
+	{
+		delete m_subWindow;
+	}
 }
 
 


### PR DESCRIPTION
When it is destroyed the `ControllerView` now deletes the controller sub window in case it has one. Fixes #2624.