### PR TITLE
Replace every use of the foreach macro with an iterator loop

### DIFF
--- a/include/InstrumentPlayHandle.h
+++ b/include/InstrumentPlayHandle.h
@@ -56,9 +56,9 @@ public:
 		do
 		{
 			nphsLeft = false;
-			foreach( const NotePlayHandle * cnph, nphv )
+			for( ConstNotePlayHandleList::const_iterator it = nphv.constBegin(); it != nphv.constEnd(); ++it )
 			{
-				NotePlayHandle * nph = const_cast<NotePlayHandle *>( cnph );
+				NotePlayHandle * nph = const_cast<NotePlayHandle *>( *it );
 				if( nph->state() != ThreadableJob::Done && ! nph->isFinished() )
 				{
 					nphsLeft = true;

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -83,7 +83,13 @@ bool MidiExport::tryExport( const TrackContainer::TrackList &tracks, int tempo, 
 	uint8_t buffer[BUFFER_SIZE];
 	uint32_t size;
 
-	foreach( Track* track, tracks ) if( track->type() == Track::InstrumentTrack ) nTracks++;
+	for( TrackContainer::TrackList::const_iterator it = tracks.constBegin(); it != tracks.constEnd(); ++it )
+	{
+		if( ( *it )->type() == Track::InstrumentTrack )
+		{
+			nTracks++;
+		}
+	}
 
 	// midi header
 	MidiFile::MIDIHeader header(nTracks);
@@ -91,21 +97,21 @@ bool MidiExport::tryExport( const TrackContainer::TrackList &tracks, int tempo, 
 	midiout.writeRawData((char *)buffer, size);
 
 	// midi tracks
-	foreach( Track* track, tracks )
+	for( TrackContainer::TrackList::const_iterator it = tracks.constBegin(); it != tracks.constEnd(); ++it )
 	{
 		DataFile dataFile( DataFile::SongProject );
 		MidiFile::MIDITrack<BUFFER_SIZE> mtrack;
 	
-		if( track->type() != Track::InstrumentTrack ) continue;
+		if( ( *it )->type() != Track::InstrumentTrack ) continue;
 
-		//qDebug() << "exporting " << track->name();
+		//qDebug() << "exporting " << ( *it )->name();
 	
 	
-		mtrack.addName(track->name().toStdString(), 0);
+		mtrack.addName(( *it )->name().toStdString(), 0);
 		//mtrack.addProgramChange(0, 0);
 		mtrack.addTempo(tempo, 0);
 	
-		instTrack = dynamic_cast<InstrumentTrack *>( track );
+		instTrack = dynamic_cast<InstrumentTrack *>( *it );
 		element = instTrack->saveState( dataFile, dataFile.content() );
 	
 		// instrumentTrack

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -262,11 +262,12 @@ void ZynAddSubFxInstrument::loadSettings( const QDomElement & _this )
 		m_pluginMutex.unlock();
 
 		m_modifiedControllers.clear();
-		foreach( const QString & c, _this.attribute( "modifiedcontrollers" ).split( ',' ) )
+		QStringList modifiedControllers = _this.attribute( "modifiedcontrollers" ).split( ',' );
+		for( QStringList::const_iterator it = modifiedControllers.constBegin(); it != modifiedControllers.constEnd(); ++it )
 		{
-			if( !c.isEmpty() )
+			if( !( *it ).isEmpty() )
 			{
-				switch( c.toInt() )
+				switch( ( *it ).toInt() )
 				{
 					case C_portamento: updatePortamento(); break;
 					case C_filtercutoff: updateFilterFreq(); break;

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -450,9 +450,9 @@ void AutomatableModel::unlinkModels( AutomatableModel* model1, AutomatableModel*
 
 void AutomatableModel::unlinkAllModels()
 {
-	foreach( AutomatableModel* model, m_linkedModels )
+	for( AutoModelVector::const_iterator it = m_linkedModels.constBegin(); it != m_linkedModels.constEnd(); ++it )
 	{
-		unlinkModels( this, model );
+		unlinkModels( this, *it );
 	}
 
 	m_hasLinkedModels = false;

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -39,9 +39,9 @@ void ComboBoxModel::addItem( const QString& item, PixmapLoader* loader )
 void ComboBoxModel::clear()
 {
 	setRange( 0, 0 );
-	foreach( const Item& i, m_items )
+	for( QVector<Item>::const_iterator it = m_items.constBegin(); it != m_items.constEnd(); ++it )
 	{
-		delete i.second;
+		delete ( *it ).second;
 	}
 
 	m_items.clear();

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -301,17 +301,6 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 		}
 	}
 
-	// play sub-notes (e.g. chords)
-	// handled by mixer now
-/*	foreach( NotePlayHandle * n, m_subNotes )
-	{
-		n->play( _working_buffer );
-		if( n->isFinished() )
-		{
-			NotePlayHandleManager::release( n );
-		}
-	}*/
-
 	// update internal data
 	m_totalFramesPlayed += framesThisPeriod;
 	unlock();
@@ -369,11 +358,11 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 	m_released = true;
 
 	// first note-off all sub-notes
-	foreach( NotePlayHandle * n, m_subNotes )
+	for( NotePlayHandleList::const_iterator it = m_subNotes.constBegin(); it != m_subNotes.constEnd(); ++it )
 	{
-		n->lock();
-		n->noteOff( _s );
-		n->unlock();
+		( *it )->lock();
+		( *it )->noteOff( _s );
+		( *it )->unlock();
 	}
 
 	// then set some variables indicating release-state

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -116,17 +116,18 @@ void AudioPort::doProcessing()
 	BufferManager::clear( m_portBuffer, fpp );
 
 	//qDebug( "Playhandles: %d", m_playHandles.size() );
-	foreach( PlayHandle * ph, m_playHandles ) // now we mix all playhandle buffers into the audioport buffer
+	// now we mix all playhandle buffers into the audioport buffer
+	for( PlayHandleList::const_iterator it = m_playHandles.constBegin(); it != m_playHandles.constEnd(); ++it )
 	{
-		if( ph->buffer() )
+		if( ( *it )->buffer() )
 		{
-			if( ph->usesBuffer() )
+			if( ( *it )->usesBuffer() )
 			{
 				m_bufferUsage = true;
-				MixHelpers::add( m_portBuffer, ph->buffer(), fpp );
+				MixHelpers::add( m_portBuffer, ( *it )->buffer(), fpp );
 			}
-			ph->releaseBuffer(); 	// gets rid of playhandle's buffer and sets
-									// pointer to null, so if it doesn't get re-acquired we know to skip it next time
+			( *it )->releaseBuffer(); 	// gets rid of playhandle's buffer and sets
+										// pointer to null, so if it doesn't get re-acquired we know to skip it next time
 		}
 	}
 

--- a/src/core/fft_helpers.cpp
+++ b/src/core/fft_helpers.cpp
@@ -134,7 +134,7 @@ int compressbands(float *absspec_buffer, float *compressedband, int num_old, int
 
 	ratio=(float)usefromold/(float)num_new;
 
-	// foreach new subband
+	// for each new subband
 	for ( i=0; i<num_new; i++ )
 	{
 		compressedband[i]=0;

--- a/src/gui/EffectSelectDialog.cpp
+++ b/src/gui/EffectSelectDialog.cpp
@@ -216,11 +216,12 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
             subLayout->setSpacing( 0 );
             m_currentSelection.desc->subPluginFeatures->
                 fillDescriptionWidget( subWidget, &m_currentSelection );
-            foreach( QWidget * w, subWidget->findChildren<QWidget *>() )
+            QList<QWidget *> subChildren = subWidget->findChildren<QWidget *>();
+            for( QList<QWidget *>::const_iterator it = subChildren.constBegin(); it != subChildren.constEnd(); ++it )
             {
-                if( w->parent() == subWidget )
+                if( ( *it )->parent() == subWidget )
                 {
-                    subLayout->addWidget( w );
+                    subLayout->addWidget( *it );
                 }
             }
 

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -420,11 +420,11 @@ void FxMixerView::deleteUnusedChannels()
 	{
 		// check if an instrument references to the current channel
 		bool empty=true;
-		foreach( Track* t, tracks )
+		for( TrackContainer::TrackList::const_iterator it = tracks.constBegin(); it != tracks.constEnd(); ++it )
 		{
-			if( t->type() == Track::InstrumentTrack )
+			if( ( *it )->type() == Track::InstrumentTrack )
 			{
-				InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
+				InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( *it );
 				if( i == inst->effectChannelModel()->value(0) )
 				{
 					empty=false;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -145,9 +145,9 @@ MainWindow::MainWindow() :
 
 #if ! defined(LMMS_BUILD_APPLE)
 	QFileInfoList drives = QDir::drives();
-	foreach( const QFileInfo & drive, drives )
+	for( QFileInfoList::const_iterator it = drives.constBegin(); it != drives.constEnd(); ++it )
 	{
-		root_paths += drive.absolutePath();
+		root_paths += ( *it ).absolutePath();
 	}
 #endif
 
@@ -602,9 +602,10 @@ void MainWindow::finalize()
 	gui->songEditor()->parentWidget()->show();
 
 	// reset window title every time we change the state of a subwindow to show the correct title
-	foreach( QMdiSubWindow * subWindow, workspace()->subWindowList() )
+	QList<QMdiSubWindow *> subWindowList = workspace()->subWindowList();
+	for( QList<QMdiSubWindow *>::const_iterator it = subWindowList.constBegin(); it != subWindowList.constEnd(); ++it )
 	{
-		connect( subWindow, SIGNAL( windowStateChanged(Qt::WindowStates,Qt::WindowStates) ), this, SLOT( resetWindowTitle() ) );
+		connect( *it, SIGNAL( windowStateChanged(Qt::WindowStates,Qt::WindowStates) ), this, SLOT( resetWindowTitle() ) );
 	}
 }
 

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -220,9 +220,10 @@ void BBTrackContainerView::addAutomationTrack()
 
 void BBTrackContainerView::removeBBView(int bb)
 {
-	foreach( TrackView* view, trackViews() )
+	QList<TrackView *> tvs = trackViews();
+	for( QList<TrackView *>::const_iterator it = tvs.constBegin(); it != tvs.constEnd(); ++it )
 	{
-		view->getTrackContentWidget()->removeTCOView( bb );
+		( *it )->getTrackContentWidget()->removeTCOView( bb );
 	}
 }
 

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -236,9 +236,9 @@ void automatableButtonGroup::activateButton( AutomatableButton * _btn )
 					m_buttons.indexOf( _btn ) != -1 )
 	{
 		model()->setValue( m_buttons.indexOf( _btn ) );
-		foreach( AutomatableButton * btn, m_buttons )
+		for( QList<AutomatableButton *>::const_iterator it = m_buttons.constBegin(); it != m_buttons.constEnd(); ++it )
 		{
-			btn->update();
+			( *it )->update();
 		}
 	}
 }
@@ -261,9 +261,9 @@ void automatableButtonGroup::updateButtons()
 {
 	model()->setRange( 0, m_buttons.size() - 1 );
 	int i = 0;
-	foreach( AutomatableButton * btn, m_buttons )
+	for( QList<AutomatableButton *>::const_iterator it = m_buttons.constBegin(); it != m_buttons.constEnd(); ++it )
 	{
-		btn->model()->setValue( i == model()->value() );
+		( *it )->model()->setValue( i == model()->value() );
 		++i;
 	}
 }

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -664,17 +664,5 @@ void BBTrackView::clickedTrackLabel()
 {
 	Engine::getBBTrackContainer()->setCurrentBB( m_bbTrack->index() );
 	gui->getBBEditor()->show();
-/*	foreach( bbTrackView * tv,
-			trackContainerView()->findChildren<bbTrackView *>() )
-	{
-		tv->m_trackLabel->update();
-	}*/
-
 }
-
-
-
-
-
-
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -949,13 +949,12 @@ InstrumentTrackView::~InstrumentTrackView()
 InstrumentTrackWindow * InstrumentTrackView::topLevelInstrumentTrackWindow()
 {
 	InstrumentTrackWindow * w = NULL;
-	foreach( QMdiSubWindow * sw,
-				gui->mainWindow()->workspace()->subWindowList(
-											QMdiArea::ActivationHistoryOrder ) )
+	QList<QMdiSubWindow *> subWindowList = gui->mainWindow()->workspace()->subWindowList( QMdiArea::ActivationHistoryOrder );
+	for( QList<QMdiSubWindow *>::const_iterator it = subWindowList.constBegin(); it != subWindowList.constEnd(); ++it )
 	{
-		if( sw->isVisible() && sw->widget()->inherits( "InstrumentTrackWindow" ) )
+		if( ( *it )->isVisible() && ( *it )->widget()->inherits( "InstrumentTrackWindow" ) )
 		{
-			w = qobject_cast<InstrumentTrackWindow *>( sw->widget() );
+			w = qobject_cast<InstrumentTrackWindow *>( ( *it )->widget() );
 		}
 	}
 


### PR DESCRIPTION
This prevents a race condition with Qt5. A foreach loop makes a copy of its
Qt container, increasing the reference count to the container's internal
data. Qt5 often asserts isDetached(), which requires the reference count to
be <= 1. This assertion fails when the foreach loop increases the reference
count at exactly the wrong moment. Using an iterator loop prevents an
unnecessary copy from being made and ensures this race condition isn't
triggered.