### PR TITLE
Mallets

### DIFF
--- a/plugins/stk/mallets/mallets.h
+++ b/plugins/stk/mallets/mallets.h
@@ -42,6 +42,7 @@
 namespace stk { } ;
 using namespace stk;
 
+static const int MALLETS_PRESET_VERSION = 1;
 
 class malletsSynth
 {
@@ -173,6 +174,8 @@ private:
 
 	ComboBoxModel m_presetsModel;
 	FloatModel m_spreadModel;
+	IntModel m_versionModel;
+	BoolModel m_isOldVersionModel;
 
 	QVector<sample_t> m_scalers;
 
@@ -219,10 +222,10 @@ private:
 
 	QWidget * m_bandedWGWidget;
 	Knob * m_pressureKnob;
-	Knob * m_motionKnob;
-	Knob * m_vibratoKnob;
+//	Knob * m_motionKnob;
+//	Knob * m_vibratoKnob;
 	Knob * m_velocityKnob;
-	LedCheckBox * m_strikeLED;
+//	LedCheckBox * m_strikeLED;
 
 	ComboBox * m_presetsCombo;
 	Knob * m_spreadKnob;


### PR DESCRIPTION
Fixes #2455 

Issues fixed so far is:

 * Mallets redraws as modal after reopening no matter what widget is used.

Modal bar ( Marimba - Clump )

 * No controls. The vibrato frequency works but the amplitude doesn't so only Vibraphone works here as it has a default amplitude ( in stk ) . Fixed by switching preset as first control change.
 * 'Stick mix' and 'Vibrato Gain' knobs have swapped functions with each other. Fixed.
 * Better default values.
 * The Position knob is a bit confusing to use since it's mirrored. It has the same effect moving left/right from center as it's a physical simulation of banging something. I changed it to center and out to make it more useful for a musician.

BandedWG ( Uniform Bar - Tibetan Bowl )

 * Uniform Bar is way to loud, fixed.
 * There is glitchy sound in some extreme positions. Fixed by not allowing 0.0 for some sounds.
 * Loud noise when switching from Tubular Bells to Banded WG. Fixed for new preset but still there if opening an old preset based on Uniform Bar and switching to Tubular Bells and back again.

---

Bugs left - Banded WG
 * Knob Vibrato is unimplemented and therefore 'stuck'.
 * Knob Motion has no effect.
 * Bowed silent when off (plucked).