### PR TITLE
Elide channel names to prevent text overflow in FxLine

### DIFF
--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -152,7 +152,11 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name,
 	// draw the channel name
 	if( m_staticTextName.text() != name )
 	{
-		m_staticTextName.setText( name );
+		// elide the name of the fxLine when its too long
+		const int maxTextHeight = 78;
+		QFontMetrics metrics( fxLine->font() );
+		QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextHeight );
+		m_staticTextName.setText( elidedName );
 	}
 	p->rotate( -90 );
 


### PR DESCRIPTION
Before:
![screenshot from 2016-03-13 22 49 25](https://cloud.githubusercontent.com/assets/6282045/13731623/10eee02c-e96e-11e5-9aba-ca734a918a44.png)
After:
![screenshot from 2016-03-13 22 48 28](https://cloud.githubusercontent.com/assets/6282045/13731625/14bb997a-e96e-11e5-86b0-6c9460a8810b.png)

