### PR TITLE
Fix crashes on deleting an FX channel

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -56,7 +56,6 @@ class FxChannel : public ThreadableJob
 		BoolModel m_soloModel;
 		FloatModel m_volumeModel;
 		QString m_name;
-		QMutex m_lock;
 		int m_channelIndex; // what channel index are we
 		bool m_queued; // are we queued up for rendering yet?
 		bool m_muted; // are we muted? updated per period so we don't have to call m_muteModel.value() twice

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -227,6 +227,7 @@ protected slots:
 	void updateBaseNote();
 	void updatePitch();
 	void updatePitchRange();
+	void updateEffectChannel();
 
 
 private:

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -382,7 +382,9 @@ void FxMixerView::deleteChannel(int index)
 	delete m_fxChannelViews[index]->m_fader;
 	delete m_fxChannelViews[index]->m_muteBtn;
 	delete m_fxChannelViews[index]->m_soloBtn;
-	delete m_fxChannelViews[index]->m_fxLine;
+	// delete fxLine later to prevent a crash when deleting from context menu
+	m_fxChannelViews[index]->m_fxLine->hide();
+	m_fxChannelViews[index]->m_fxLine->deleteLater();
 	delete m_fxChannelViews[index]->m_rackView;
 	delete m_fxChannelViews[index];
 	m_channelAreaWidget->adjustSize();

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -139,6 +139,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 	connect( &m_baseNoteModel, SIGNAL( dataChanged() ), this, SLOT( updateBaseNote() ) );
 	connect( &m_pitchModel, SIGNAL( dataChanged() ), this, SLOT( updatePitch() ) );
 	connect( &m_pitchRangeModel, SIGNAL( dataChanged() ), this, SLOT( updatePitchRange() ) );
+	connect( &m_effectChannelModel, SIGNAL( dataChanged() ), this, SLOT( updateEffectChannel() ) );
 }
 
 
@@ -220,8 +221,6 @@ void InstrumentTrack::processAudioBuffer( sampleFrame* buf, const fpp_t frames, 
 			}
 		}
 	}
-
-	m_audioPort.setNextFxChannel( m_effectChannelModel.value() );
 }
 
 
@@ -553,6 +552,14 @@ void InstrumentTrack::updatePitchRange()
 	processOutEvent( MidiEvent( MidiControlChange, midiPort()->realOutputChannel(),
 								MidiControllerRegisteredParameterNumberMSB, ( MidiPitchBendSensitivityRPN >> 8 ) & 0x7F ) );
 	processOutEvent( MidiEvent( MidiControlChange, midiPort()->realOutputChannel(), MidiControllerDataEntry, midiPitchRange() ) );
+}
+
+
+
+
+void InstrumentTrack::updateEffectChannel()
+{
+	m_audioPort.setNextFxChannel( m_effectChannelModel.value() );
 }
 
 


### PR DESCRIPTION
This PR fixes three crashes that would happen when deleting an FX channel. Now that #2669 has been merged, using LMMS with this PR should be pretty much random-crash-free. At least I can't produce any :yum:. So go on, go wild, do everything crazy you can come up with concerning the FX mixer, and post what you did plus the backtrace if you still manage to make it crash :bowtie: