### PR TITLE
Add C++11 compile flag to the carla plugin as well

### DIFF
--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -1,4 +1,7 @@
 if(LMMS_HAVE_CARLA)
+        # Enable C++11
+        ADD_DEFINITIONS(-std=c++0x)
+
         INCLUDE(BuildPlugin)
         INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
         LINK_DIRECTORIES(${CARLA_LIBRARY_DIRS})


### PR DESCRIPTION
Fixes the carla plugin not compiling anymore after switching to C++11
range-based for loops.