### PR TITLE
Kicker 'version' 0 on first save

### DIFF
--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -71,7 +71,7 @@ kickerInstrument::kickerInstrument( InstrumentTrack * _instrument_track ) :
 	m_slopeModel( 0.06f, 0.001f, 1.0f, 0.001f, this, tr( "Frequency Slope" ) ),
 	m_startNoteModel( true, this, tr( "Start from note" ) ),
 	m_endNoteModel( false, this, tr( "End to note" ) ),
-	m_versionModel( 0, 0, KICKER_PRESET_VERSION, this, "" )
+	m_versionModel( KICKER_PRESET_VERSION, 0, KICKER_PRESET_VERSION, this, "" )
 {
 }
 
@@ -137,7 +137,7 @@ void kickerInstrument::loadSettings( const QDomElement & _this )
 	// Try to maintain backwards compatibility
 	if( !_this.hasAttribute( "version" ) )
 	{
-
+		m_startNoteModel.setValue( false );
 		m_decayModel.setValue( m_decayModel.value() * 1.33f );
 		m_envModel.setValue( 1.0f );
 		m_slopeModel.setValue( 1.0f );


### PR DESCRIPTION
New kicker instruments are saved wrong as it's set to version 0 by default so `m_startNoteModel` will be set 'false' on reload.