### PR TITLE
Enables style sheets for knob line colors for all knob types

### DIFF
--- a/include/Track.h
+++ b/include/Track.h
@@ -54,7 +54,6 @@ class TrackContainerView;
 class TrackContentWidget;
 class TrackView;
 
-typedef QWidget trackSettingsWidget;
 
 const int DEFAULT_SETTINGS_WIDGET_WIDTH = 224;
 const int TRACK_OP_WIDTH = 78;
@@ -640,7 +639,7 @@ public:
 		return &m_trackOperationsWidget;
 	}
 
-	inline trackSettingsWidget * getTrackSettingsWidget()
+	inline QWidget * getTrackSettingsWidget()
 	{
 		return &m_trackSettingsWidget;
 	}
@@ -703,7 +702,7 @@ private:
 	TrackContainerView * m_trackContainerView;
 
 	TrackOperationsWidget m_trackOperationsWidget;
-	trackSettingsWidget m_trackSettingsWidget;
+	QWidget m_trackSettingsWidget;
 	TrackContentWidget m_trackContentWidget;
 
 	Actions m_action;

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -101,6 +101,28 @@ void Knob::initUi( const QString & _name )
 	setInnerRadius( 1.0f );
 	setOuterRadius( 10.0f );
 	setFocusPolicy( Qt::ClickFocus );
+
+	// This is a workaround to enable style sheets for knobs which are not styled knobs.
+	//
+	// It works as follows: the palette colors that are assigned as the line color previously
+	// had been hard coded in the drawKnob method for the different knob types. Now the
+	// drawKnob method uses the line color to draw the lines. By assigning the palette colors
+	// as the line colors here the knob lines will be drawn in this color unless the stylesheet
+	// overrides that color.
+	switch (knobNum())
+	{
+	case knobSmall_17:
+	case knobBright_26:
+	case knobDark_28:
+		setlineColor(QApplication::palette().color( QPalette::Active, QPalette::WindowText ));
+		break;
+	case knobVintage_32:
+		setlineColor(QApplication::palette().color( QPalette::Active, QPalette::Shadow ));
+		break;
+	default:
+		break;
+	}
+
 	doConnections();
 }
 
@@ -428,20 +450,19 @@ void Knob::drawKnob( QPainter * _p )
 	{
 		case knobSmall_17:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active,
-							QPalette::WindowText ), 2 ) );
+			p.setPen( QPen( lineColor(), 2 ) );
 			p.drawLine( calculateLine( mid, radius-2 ) );
 			break;
 		}
 		case knobBright_26:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active, QPalette::WindowText ), 2 ) );
+			p.setPen( QPen( lineColor(), 2 ) );
 			p.drawLine( calculateLine( mid, radius-5 ) );
 			break;
 		}
 		case knobDark_28:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active, QPalette::WindowText ), 2 ) );
+			p.setPen( QPen( lineColor(), 2 ) );
 			const float rb = qMax<float>( ( radius - 10 ) / 3.0,
 									0.0 );
 			const float re = qMax<float>( ( radius - 4 ), 0.0 );
@@ -452,8 +473,7 @@ void Knob::drawKnob( QPainter * _p )
 		}
 		case knobVintage_32:
 		{
-			p.setPen( QPen( QApplication::palette().color( QPalette::Active,
-							QPalette::Shadow), 2 ) );
+			p.setPen( QPen( lineColor(), 2 ) );
 			p.drawLine( calculateLine( mid, radius-2, 2 ) );
 			break;
 		}


### PR DESCRIPTION
The fix works as follows: until now the method `Knob::drawKnob` has used
hard coded palette colors to draw the knob lines for the different knob
types. These palette colors are now assigned to the line color property
in `Knob::initUi`. The method `Knob::drawKnob` in turn now uses the line
color property for almost all knob types. This means that all knobs
lines will be painted in the same color as before unless that property
is overridden by the stylesheet.

Also removes an unnecessary `typedef` from `QWidget` to `trackSettingsWidget`
in `Track.h`.

This commit fixes the problem described in HDDigitizerMusic/lmms-alt-theme#3.