### PR TITLE
Get rid of another copy constructor call to prevent Qt5 crashes

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -194,11 +194,6 @@ public:
 		return m_fxChannels.size();
 	}
 
-	inline QVector<FxChannel *> fxChannels() const
-	{
-		return m_fxChannels;
-	}
-
 	FxRouteVector m_fxRoutes;
 
 private:

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1191,9 +1191,9 @@ QMenu * InstrumentTrackView::createFxMenu(QString title, QString newFxLabel)
 	fxMenu->addAction( newFxLabel, this, SLOT( createFxLine() ) );
 	fxMenu->addSeparator();
 
-	for (int i = 0; i < Engine::fxMixer()->fxChannels().size(); ++i)
+	for (int i = 0; i < Engine::fxMixer()->numChannels(); ++i)
 	{
-		FxChannel * currentChannel = Engine::fxMixer()->fxChannels()[i];
+		FxChannel * currentChannel = Engine::fxMixer()->effectChannel( i );
 
 		if ( currentChannel != fxChannel )
 		{


### PR DESCRIPTION
Cf. the commit message of 3c7bfba