### PR TITLE
Crash at clearing path in settings manager

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -38,7 +38,7 @@
 
 static inline QString ensureTrailingSlash( const QString & s )
 {
-	if(s.at(s.length()-1) != '/')
+	if( ! s.isEmpty() && !s.endsWith('/') && !s.endsWith('\\') )
 	{
 		return s + '/';
 	}


### PR DESCRIPTION
Got a crash when clearing the path to the themes directory.
When you clear out a path the test for if there is a trailing slash will test the char at position 0 - 1.