### PR TITLE
Enable antialiasing for the automation editor patterns

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -259,6 +259,9 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	QPainter p( &m_paintPixmap );
 
+	// Enabling antialiasing does not hurt as we cache in a pixmap anyway
+	p.setRenderHint(QPainter::Antialiasing);
+
 	QLinearGradient lingrad( 0, 0, 0, height() );
 	QColor c;
 	bool muted = m_pat->getTrack()->isMuted() || m_pat->isMuted();


### PR DESCRIPTION
Fixes #2688 by enabling antialiasing in the `paint` method of `AutomationPatternView`.