### PR TITLE
BBTrack fixes

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -800,6 +800,8 @@ void PatternView::constructContextMenu( QMenu * _cm )
 			tr( "Add steps" ), m_pat, SLOT( addSteps() ) );
 		_cm->addAction( embed::getIconPixmap( "step_btn_remove" ),
 			tr( "Remove steps" ), m_pat, SLOT( removeSteps() ) );
+		_cm->addAction( embed::getIconPixmap( "step_btn_duplicate" ),
+			tr( "Clone Steps" ), m_pat, SLOT( cloneSteps() ) );
 	}
 }
 


### PR DESCRIPTION
Some nip/tuck in the BBTrack.
 * There is add/remove steps for either the whole BBTrack or the separate patterns in the context menu. Clone is only available for the whole BBTrack however but there's not reason for that. Added.
 * ~~Secondly I swap position of the Add/Remove steps. Just because...~~