### PR TITLE
Restore the FX channel lock to its former glory

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -56,6 +56,7 @@ class FxChannel : public ThreadableJob
 		BoolModel m_soloModel;
 		FloatModel m_volumeModel;
 		QString m_name;
+		QMutex m_lock;
 		int m_channelIndex; // what channel index are we
 		bool m_queued; // are we queued up for rendering yet?
 		bool m_muted; // are we muted? updated per period so we don't have to call m_muteModel.value() twice

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -68,6 +68,7 @@ FxChannel::FxChannel( int idx, Model * _parent ) :
 	m_soloModel( false, _parent ),
 	m_volumeModel( 1.0, 0.0, 2.0, 0.001, _parent ),
 	m_name(),
+	m_lock(),
 	m_channelIndex( idx ),
 	m_queued( false ),
 	m_dependenciesMet( 0 )
@@ -547,8 +548,10 @@ void FxMixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
 {
 	if( m_fxChannels[_ch]->m_muteModel.value() == false )
 	{
+		m_fxChannels[_ch]->m_lock.lock();
 		MixHelpers::add( m_fxChannels[_ch]->m_buffer, _buf, Engine::mixer()->framesPerPeriod() );
 		m_fxChannels[_ch]->m_hasInput = true;
+		m_fxChannels[_ch]->m_lock.unlock();
 	}
 }
 


### PR DESCRIPTION
In the course of 32b7e04, I removed the channel lock from FxChannel because
I was under the impression that it was only needed to prevent crashes on
channel delete. However, at least two people experience crackling audio
after it was removed (#2708). Therefore, this commit reinstates it.