### PR TITLE
Get rid of mixer and effects chain padding

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -69,6 +69,9 @@ FxMixerView::FxMixerView() :
 	// main-layout
 	QHBoxLayout * ml = new QHBoxLayout;
 
+	// Set margins
+	ml->setContentsMargins( 0, 4, 0, 0 );
+	
 	// Channel area
 	m_channelAreaWidget = new QWidget;
 	chLayout = new QHBoxLayout( m_channelAreaWidget );

--- a/src/gui/widgets/EffectRackView.cpp
+++ b/src/gui/widgets/EffectRackView.cpp
@@ -40,7 +40,7 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	ModelView( NULL, this )
 {
 	QVBoxLayout* mainLayout = new QVBoxLayout( this );
-	mainLayout->setMargin( 5 );
+	mainLayout->setMargin( 0 );
 
 	m_effectsGroupBox = new GroupBox( tr( "EFFECTS CHAIN" ) );
 	mainLayout->addWidget( m_effectsGroupBox );


### PR DESCRIPTION
Fixes #2593 
Before: 
![screenshot from 2016-03-27 20 37 03](https://cloud.githubusercontent.com/assets/6282045/14067052/d6e54cba-f45b-11e5-92d7-4669a494325d.png)
![screenshot from 2016-03-27 20 37 12](https://cloud.githubusercontent.com/assets/6282045/14067053/d6e90a12-f45b-11e5-8c53-0daee4961bb3.png)
After:
![screenshot from 2016-03-27 19 41 17](https://cloud.githubusercontent.com/assets/6282045/14067055/ddb0a60c-f45b-11e5-938d-26d1593c8d9e.png)
![screenshot from 2016-03-27 19 41 29](https://cloud.githubusercontent.com/assets/6282045/14067056/ddca4cc4-f45b-11e5-9083-31ffa302c9a3.png)


