### PR TITLE
Fix hard-coding of knob and LCDWidget text color

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -65,6 +65,8 @@ class EXPORT Knob : public QWidget, public FloatModelView
 	mapPropertyFromModel(float,volumeRatio,setVolumeRatio,m_volumeRatio);
 
 	Q_PROPERTY(knobTypes knobNum READ knobNum WRITE setknobNum)
+	
+	Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor)
 
 	void initUi( const QString & _name ); //!< to be called by ctors
 	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum
@@ -81,35 +83,38 @@ public:
 		setDescription( _txt_before );
 		setUnit( _txt_after );
 	}
-	void setLabel( const QString & _txt );
+	void setLabel( const QString & txt );
 
-	void setTotalAngle( float _angle );
+	void setTotalAngle( float angle );
 
 	// Begin styled knob accessors
 	float innerRadius() const;
-	void setInnerRadius( float _r );
+	void setInnerRadius( float r );
 
 	float outerRadius() const;
-	void setOuterRadius( float _r );
+	void setOuterRadius( float r );
 
 	knobTypes knobNum() const;
-	void setknobNum( knobTypes _k );
+	void setknobNum( knobTypes k );
 
 	QPointF centerPoint() const;
 	float centerPointX() const;
-	void setCenterPointX( float _c );
+	void setCenterPointX( float c );
 	float centerPointY() const;
-	void setCenterPointY( float _c );
+	void setCenterPointY( float c );
 
 	float lineWidth() const;
-	void setLineWidth( float _w );
+	void setLineWidth( float w );
 
 	QColor outerColor() const;
-	void setOuterColor( const QColor & _c );
+	void setOuterColor( const QColor & c );
 	QColor lineColor() const;
-	void setlineColor( const QColor & _c );
+	void setlineColor( const QColor & c );
 	QColor arcColor() const;
-	void setarcColor( const QColor & _c );
+	void setarcColor( const QColor & c );
+	
+	QColor textColor() const;
+	void setTextColor( const QColor & c );
 
 
 signals:
@@ -186,6 +191,8 @@ private:
 	QColor m_outerColor;
 	QColor m_lineColor; //!< unused yet
 	QColor m_arcColor; //!< unused yet
+	
+	QColor m_textColor;
 
 	knobTypes m_knobNum;
 

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -34,6 +34,11 @@
 class EXPORT LcdWidget : public QWidget
 {
 	Q_OBJECT
+	
+	// theming qproperties
+	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
+	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
+	
 public:
 	LcdWidget( QWidget* parent, const QString& name = QString::null );
 	LcdWidget( int numDigits, QWidget* parent, const QString& name = QString::null );
@@ -54,13 +59,19 @@ public:
 
 	inline int numDigits() const { return m_numDigits; }
 	inline void setNumDigits( int n ) { m_numDigits = n; updateSize(); }
+	
+	QColor textColor() const;
+	void setTextColor( const QColor & c );
+	
+	QColor textShadowColor() const;
+	void setTextShadowColor( const QColor & c );
 
 public slots:
-	virtual void setMarginWidth( int _width );
+	virtual void setMarginWidth( int width );
 
 
 protected:
-	virtual void paintEvent( QPaintEvent * _me );
+	virtual void paintEvent( QPaintEvent * pe );
 
 	virtual void updateSize();
 
@@ -80,6 +91,9 @@ private:
 
 	QString m_label;
 	QPixmap* m_lcdPixmap;
+
+	QColor m_textColor;
+	QColor m_textShadowColor;
 
 	int m_cellWidth;
 	int m_cellHeight;

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -66,7 +66,8 @@ TextFloat * Knob::s_textFloat = NULL;
 	m_volumeRatio( 100.0, 0.0, 1000000.0 ), \
 	m_buttonPressed( false ), \
 	m_angle( -10 ), \
-	m_lineWidth(0)
+	m_lineWidth( 0 ), \
+	m_textColor( 255, 255, 255 )
 
 Knob::Knob( knobTypes _knob_num, QWidget * _parent, const QString & _name ) :
 	DEFAULT_KNOB_INITIALIZER_LIST,
@@ -173,9 +174,9 @@ Knob::~Knob()
 
 
 
-void Knob::setLabel( const QString & _txt )
+void Knob::setLabel( const QString & txt )
 {
-	m_label = _txt;
+	m_label = txt;
 	if( m_knobPixmap )
 	{
 		setFixedSize( qMax<int>( m_knobPixmap->width(),
@@ -188,15 +189,15 @@ void Knob::setLabel( const QString & _txt )
 
 
 
-void Knob::setTotalAngle( float _angle )
+void Knob::setTotalAngle( float angle )
 {
-	if( _angle < 10.0 )
+	if( angle < 10.0 )
 	{
 		m_totalAngle = 10.0;
 	}
 	else
 	{
-		m_totalAngle = _angle;
+		m_totalAngle = angle;
 	}
 
 	update();
@@ -212,9 +213,9 @@ float Knob::innerRadius() const
 
 
 
-void Knob::setInnerRadius( float _r )
+void Knob::setInnerRadius( float r )
 {
-	m_innerRadius = _r;
+	m_innerRadius = r;
 }
 
 
@@ -226,9 +227,9 @@ float Knob::outerRadius() const
 
 
 
-void Knob::setOuterRadius( float _r )
+void Knob::setOuterRadius( float r )
 {
-	m_outerRadius = _r;
+	m_outerRadius = r;
 }
 
 
@@ -242,11 +243,11 @@ knobTypes Knob::knobNum() const
 
 
 
-void Knob::setknobNum( knobTypes _k )
+void Knob::setknobNum( knobTypes k )
 {
-	if( m_knobNum != _k )
+	if( m_knobNum != k )
 	{
-		m_knobNum = _k;
+		m_knobNum = k;
 		onKnobNumUpdated();
 	}
 }
@@ -268,9 +269,9 @@ float Knob::centerPointX() const
 
 
 
-void Knob::setCenterPointX( float _c )
+void Knob::setCenterPointX( float c )
 {
-	m_centerPoint.setX( _c );
+	m_centerPoint.setX( c );
 }
 
 
@@ -282,9 +283,9 @@ float Knob::centerPointY() const
 
 
 
-void Knob::setCenterPointY( float _c )
+void Knob::setCenterPointY( float c )
 {
-	m_centerPoint.setY( _c );
+	m_centerPoint.setY( c );
 }
 
 
@@ -296,9 +297,9 @@ float Knob::lineWidth() const
 
 
 
-void Knob::setLineWidth( float _w )
+void Knob::setLineWidth( float w )
 {
-	m_lineWidth = _w;
+	m_lineWidth = w;
 }
 
 
@@ -310,9 +311,9 @@ QColor Knob::outerColor() const
 
 
 
-void Knob::setOuterColor( const QColor & _c )
+void Knob::setOuterColor( const QColor & c )
 {
-	m_outerColor = _c;
+	m_outerColor = c;
 }
 
 
@@ -324,9 +325,9 @@ QColor Knob::lineColor() const
 
 
 
-void Knob::setlineColor( const QColor & _c )
+void Knob::setlineColor( const QColor & c )
 {
-	m_lineColor = _c;
+	m_lineColor = c;
 }
 
 
@@ -338,11 +339,25 @@ QColor Knob::arcColor() const
 
 
 
-void Knob::setarcColor( const QColor & _c )
+void Knob::setarcColor( const QColor & c )
 {
-	m_arcColor = _c;
+	m_arcColor = c;
 }
 
+
+
+
+QColor Knob::textColor() const
+{
+	return m_textColor;
+}
+
+
+
+void Knob::setTextColor( const QColor & c )
+{
+	m_textColor = c;
+}
 
 
 
@@ -680,7 +695,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 		p.drawText( width() / 2 -
 			p.fontMetrics().width( m_label ) / 2 + 1,
 				height() - 1, m_label );*/
-		p.setPen( QColor( 255, 255, 255 ) );
+		p.setPen( textColor() );
 		p.drawText( width() / 2 -
 				p.fontMetrics().width( m_label ) / 2,
 				height() - 2, m_label );

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -44,7 +44,9 @@
 //! @todo: in C++11, we can use delegating ctors
 #define DEFAULT_LCDWIDGET_INITIALIZER_LIST \
 	QWidget( parent ), \
-	m_label()
+	m_label(), \
+	m_textColor( 255, 255, 255 ), \
+	m_textShadowColor( 64, 64, 64 )
 
 LcdWidget::LcdWidget( QWidget* parent, const QString& name ) :
 	DEFAULT_LCDWIDGET_INITIALIZER_LIST,
@@ -104,6 +106,32 @@ void LcdWidget::setValue( int value )
 	m_display = s;
 
 	update();
+}
+
+
+
+
+QColor LcdWidget::textColor() const
+{
+	return m_textColor;
+}
+
+void LcdWidget::setTextColor( const QColor & c )
+{
+	m_textColor = c;
+}
+
+
+
+
+QColor LcdWidget::textShadowColor() const
+{
+	return m_textShadowColor;
+}
+
+void LcdWidget::setTextShadowColor( const QColor & c )
+{
+	m_textShadowColor = c;
 }
 
 
@@ -182,11 +210,11 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	if( !m_label.isEmpty() )
 	{
 		p.setFont( pointSizeF( p.font(), 6.5 ) );
-		p.setPen( QColor( 64, 64, 64 ) );
+		p.setPen( textShadowColor() );
 		p.drawText( width() / 2 -
 				p.fontMetrics().width( m_label ) / 2 + 1,
 						height(), m_label );
-		p.setPen( QColor( 255, 255, 255 ) );
+		p.setPen( textColor() );
 		p.drawText( width() / 2 -
 				p.fontMetrics().width( m_label ) / 2,
 						height() - 1, m_label );
@@ -197,18 +225,18 @@ void LcdWidget::paintEvent( QPaintEvent* )
 
 
 
-void LcdWidget::setLabel( const QString & _txt )
+void LcdWidget::setLabel( const QString& label )
 {
-	m_label = _txt;
+	m_label = label;
 	updateSize();
 }
 
 
 
 
-void LcdWidget::setMarginWidth( int _width )
+void LcdWidget::setMarginWidth( int width )
 {
-	m_marginWidth = _width;
+	m_marginWidth = width;
 
 	updateSize();
 }


### PR DESCRIPTION
Fixes #2695 

Example CSS:
```
Knob {
	qproperty-textColor: blue;
}

LcdWidget {
	qproperty-textColor: blue;
	qproperty-textShadowColor: red;
}
```

![screenshot from 2016-04-02 01 36 46](https://cloud.githubusercontent.com/assets/6282045/14222752/d8f02f26-f874-11e5-91f6-c3bf2d4ac628.png)  ![screenshot from 2016-04-02 01 36 51](https://cloud.githubusercontent.com/assets/6282045/14222753/d8f3a2c8-f874-11e5-899c-44a40b4c7826.png)

If there's no property defined in the CSS, it inits to default colors.