### PR TITLE
Fix for issue #2713

### DIFF
--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -115,7 +115,7 @@ void Note::setPos( const MidiTime & pos )
 
 void Note::setKey( const int key )
 {
-	const int k = qBound( 0, key, NumKeys );
+	const int k = qBound( 0, key, NumKeys - 1 );
 	m_key = k;
 }
 


### PR DESCRIPTION
This change corrects the root cause of the crash in issue #2713. The upper bound on Note::setKey was one off the end of the usable keyboard notes. I updated the upper bound argument to qBound to prevent this.