### PR TITLE
Switch to PulseAudio back end on likely ALSA interception

### DIFF
--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -757,7 +757,21 @@ AudioDevice * Mixer::tryAudioDevices()
 
 
 #ifdef LMMS_HAVE_ALSA
-	if( dev_name == AudioAlsa::name() || dev_name == "" )
+	bool tryAlsa = true;
+
+#ifdef LMMS_HAVE_PULSEAUDIO
+	if( AudioAlsa::probeDevice() == "default" &&
+		QFile( "/usr/share/alsa/alsa.conf.d/pulse.conf" ).exists() )
+	{
+		tryAlsa = false;
+		if( dev_name == AudioAlsa::name() )
+		{
+			dev_name = AudioPulseAudio::name();
+		}
+	}
+#endif
+
+	if( tryAlsa && ( dev_name == AudioAlsa::name() || dev_name == "" ) )
 	{
 		dev = new AudioAlsa( success_ful, this );
 		if( success_ful )


### PR DESCRIPTION
If `pulse.conf` exists, it is likely that there will be an interception. The back end next to ALSA is selected, which is PulseAudio.
This should be a fix for #158.