### PR TITLE
Pass build flags to wineg++

### DIFF
--- a/plugins/vst_base/CMakeLists.txt
+++ b/plugins/vst_base/CMakeLists.txt
@@ -41,10 +41,13 @@ IF(LMMS_HOST_X86_64)
 	ENDIF()
 ENDIF(LMMS_HOST_X86_64)
 
+SET(WINE_CXX_FLAGS "" CACHE STRING "Extra flags passed to wineg++")
+
+STRING(REPLACE " " ";" WINE_BUILD_FLAGS ${CMAKE_CXX_FLAGS} ${CMAKE_EXE_LINKER_FLAGS} " " ${WINE_CXX_FLAGS})
 ADD_CUSTOM_COMMAND(
 		SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp"
 		COMMAND ${WINE_CXX}
-		ARGS "-I\"${CMAKE_BINARY_DIR}\"" "-I\"${CMAKE_SOURCE_DIR}/include\"" "-I\"${CMAKE_INSTALL_PREFIX}/include/wine/windows\"" "-I\"${CMAKE_INSTALL_PREFIX}/include\"" -I/usr/include/wine/windows "\"${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp\"" -ansi -mwindows -lpthread ${EXTRA_FLAGS} -o ../RemoteVstPlugin
+		ARGS "-I\"${CMAKE_BINARY_DIR}\"" "-I\"${CMAKE_SOURCE_DIR}/include\"" "-I\"${CMAKE_INSTALL_PREFIX}/include/wine/windows\"" "-I\"${CMAKE_INSTALL_PREFIX}/include\"" -I/usr/include/wine/windows "\"${CMAKE_CURRENT_SOURCE_DIR}/RemoteVstPlugin.cpp\"" -ansi -mwindows -lpthread ${EXTRA_FLAGS} -fno-omit-frame-pointer ${WINE_BUILD_FLAGS} -o ../RemoteVstPlugin
 		COMMAND sh -c "mv ../RemoteVstPlugin.exe ../RemoteVstPlugin || true"
 		TARGET vstbase
 		OUTPUTS ../RemoteVstPlugin


### PR DESCRIPTION
The build of RemoteVstPlugin did not use flags from normal builds, such as debugging information and some warnings. Omitting the frame pointer in optimization does not work.
`WINE_CXX_FLAGS` allows packagers to set extra flags, such as RUNPATH information.