### PR TITLE
Make clear that ZynAddSubFX is under GPL-2+

### DIFF
--- a/plugins/zynaddsubfx/README.txt
+++ b/plugins/zynaddsubfx/README.txt
@@ -3,7 +3,7 @@ ZynAddSubFX
 It is a realtime software synthesizer for Linux and Windows with many features. Please see the docs for details.
 Copyright (c) 2002-2009 Nasca Octavian Paul and others contributors
 e-mail: zynaddsubfx AT yahoo D0T com
-ZynAddSubFX is free program and is distributed WITH NO WARRANTY. It is licensed under GNU General Public License version 2 (and only version 2) - see the file COPYING.
+ZynAddSubFX is free program and is distributed WITH NO WARRANTY. It is licensed under GNU General Public License version 2 (or later) - see the file COPYING.
 
     --==## PLEASE SHARE YOUR INSTRUMENTS/MASTER SETTINGS ##==--
               --==## MADE WITH ZynAddSubFX ##==--

--- a/plugins/zynaddsubfx/zynaddsubfx/README.txt
+++ b/plugins/zynaddsubfx/zynaddsubfx/README.txt
@@ -3,7 +3,7 @@ ZynAddSubFX
 It is a realtime software synthesizer for Linux and Windows with many features. Please see the docs for details.
 Copyright (c) 2002-2014 Nasca Octavian Paul and others contributors
 e-mail: zynaddsubfx AT yahoo D0T com
-ZynAddSubFX is free program and is distributed WITH NO WARRANTY. It is licensed under GNU General Public License version 2 (and only version 2) - see the file COPYING.
+ZynAddSubFX is free program and is distributed WITH NO WARRANTY. It is licensed under GNU General Public License version 2 (or later) - see the file COPYING.
 
     --==## PLEASE SHARE YOUR INSTRUMENTS/MASTER SETTINGS ##==--
               --==## MADE WITH ZynAddSubFX ##==--

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/AnalogFilter.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/AnalogFilter.cpp
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/AnalogFilter.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/AnalogFilter.h
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Filter.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Filter.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Filter.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Filter.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FormantFilter.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FormantFilter.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FormantFilter.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FormantFilter.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/SVFilter.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/SVFilter.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/SVFilter.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/SVFilter.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Unison.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Unison.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Unison.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/Unison.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Alienwah.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Alienwah.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Alienwah.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Alienwah.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Chorus.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Chorus.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Chorus.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Chorus.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Distorsion.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Distorsion.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Distorsion.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Distorsion.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/DynamicFilter.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/DynamicFilter.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/DynamicFilter.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/DynamicFilter.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EQ.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EQ.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EQ.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EQ.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Echo.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Echo.cpp
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Echo.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Echo.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Effect.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Effect.cpp
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Effect.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Effect.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectLFO.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectLFO.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectLFO.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectLFO.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectMgr.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectMgr.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectMgr.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/EffectMgr.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Phaser.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Phaser.cpp
@@ -15,8 +15,9 @@
   DSP analog modeling theory & practice largely influenced by various CCRMA publications, particularly works by Julius O. Smith.
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Phaser.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Phaser.h
@@ -10,8 +10,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Reverb.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Reverb.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Reverb.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Effects/Reverb.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Config.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Config.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Config.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Config.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Control.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Control.h
@@ -7,8 +7,9 @@
   Author: Harald Hvaal
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Dump.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Dump.cpp
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Dump.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Dump.h
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/LASHClient.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/LASHClient.cpp
@@ -6,8 +6,9 @@
   Author: Lars Luthman
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/LASHClient.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/LASHClient.h
@@ -6,8 +6,9 @@
   Author: Lars Luthman
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Master.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Master.cpp
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Master.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Master.h
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Microtonal.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Microtonal.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Microtonal.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Microtonal.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Part.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Part.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Part.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Part.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/QtXmlWrapper.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/QtXmlWrapper.cpp
@@ -33,8 +33,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/QtXmlWrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/QtXmlWrapper.h
@@ -33,8 +33,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Recorder.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Recorder.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Recorder.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Recorder.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Stereo.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Stereo.cpp
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Stereo.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Stereo.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Util.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Util.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Util.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Util.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WavFile.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WavFile.cpp
@@ -4,8 +4,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WavFile.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WavFile.h
@@ -7,8 +7,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WaveShapeSmps.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WaveShapeSmps.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WaveShapeSmps.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/WaveShapeSmps.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/XMLwrapper.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/XMLwrapper.cpp
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/XMLwrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/XMLwrapper.h
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AlsaEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AlsaEngine.cpp
@@ -7,7 +7,7 @@
     This file is part of ZynAddSubFX, which is free software: you can
     redistribute it and/or modify it under the terms of the GNU General
     Public License as published by the Free Software Foundation, either
-    version 3 of the License, or (at your option) any later version.
+    version 2 of the License, or (at your option) any later version.
 
     ZynAddSubFX is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AlsaEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AlsaEngine.h
@@ -7,7 +7,7 @@
     This file is part of ZynAddSubFX, which is free software: you can
     redistribute it and/or modify it under the terms of the GNU General
     Public License as published by the Free Software Foundation, either
-    version 3 of the License, or (at your option) any later version.
+    version 2 of the License, or (at your option) any later version.
 
     ZynAddSubFX is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AudioOut.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AudioOut.cpp
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AudioOut.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/AudioOut.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/Engine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/Engine.cpp
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/Engine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/Engine.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/JackEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/JackEngine.cpp
@@ -6,7 +6,7 @@
     This file is part of yoshimi, which is free software: you can
     redistribute it and/or modify it under the terms of the GNU General
     Public License as published by the Free Software Foundation, either
-    version 3 of the License, or (at your option) any later version.
+    version 2 of the License, or (at your option) any later version.
 
     yoshimi is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/JackEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/JackEngine.h
@@ -6,7 +6,7 @@
     This file is part of yoshimi, which is free software: you can
     redistribute it and/or modify it under the terms of the GNU General
     Public License as published by the Free Software Foundation, either
-    version 3 of the License, or (at your option) any later version.
+    version 2 of the License, or (at your option) any later version.
 
     yoshimi is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/MidiIn.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/MidiIn.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/MidiIn.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/MidiIn.h
@@ -8,8 +8,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/NulEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/NulEngine.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/NulEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/NulEngine.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/OssEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/OssEngine.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/OssEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/OssEngine.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/PaEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/PaEngine.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/PaEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/PaEngine.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/WavEngine.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/WavEngine.cpp
@@ -3,8 +3,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Nio/WavEngine.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Nio/WavEngine.h
@@ -7,8 +7,9 @@
           Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Output/DSSIaudiooutput.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Output/DSSIaudiooutput.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Output/DSSIaudiooutput.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Output/DSSIaudiooutput.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/ADnoteParameters.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/ADnoteParameters.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/ADnoteParameters.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/ADnoteParameters.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/EnvelopeParams.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/EnvelopeParams.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/EnvelopeParams.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/EnvelopeParams.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/FilterParams.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/FilterParams.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/FilterParams.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/FilterParams.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/LFOParams.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/LFOParams.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/LFOParams.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/LFOParams.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/Presets.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/Presets.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/Presets.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/Presets.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsArray.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsArray.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsArray.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsArray.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsStore.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsStore.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsStore.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PresetsStore.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/SUBnoteParameters.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/SUBnoteParameters.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/SUBnoteParameters.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/SUBnoteParameters.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/ADnote.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/ADnote.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/ADnote.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/ADnote.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Envelope.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Envelope.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Envelope.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Envelope.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/LFO.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/LFO.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/LFO.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/LFO.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/PADnote.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/PADnote.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/PADnote.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/PADnote.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Resonance.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Resonance.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Resonance.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/Resonance.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SUBnote.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SUBnote.cpp
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SUBnote.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SUBnote.h
@@ -6,8 +6,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SynthNote.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/SynthNote.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/AdNoteTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/AdNoteTest.h
@@ -7,8 +7,9 @@
   Authors: Mark McCurry, Harald Hvaal
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/ControllerTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/ControllerTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/EchoTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/EchoTest.h
@@ -7,8 +7,9 @@
   Authors: Mark McCurry, Harald Hvaal
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/MicrotonalTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/MicrotonalTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/OscilGenTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/OscilGenTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/PadNoteTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/PadNoteTest.h
@@ -6,8 +6,9 @@
   Author: zco
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/PluginTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/PluginTest.h
@@ -6,8 +6,9 @@
   Authors: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/RandTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/RandTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/SubNoteTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/SubNoteTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/UnisonTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/UnisonTest.h
@@ -7,8 +7,9 @@
   Authors: Mark McCurry, Harald Hvaal
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Tests/XMLwrapperTest.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Tests/XMLwrapperTest.h
@@ -6,8 +6,9 @@
   Author: Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/globals.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/globals.h
@@ -7,8 +7,9 @@
   Author: Nasca Octavian Paul
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/plugins/zynaddsubfx/zynaddsubfx/src/main.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/main.cpp
@@ -6,8 +6,9 @@
   Copyright (C) 2012-2014 Mark McCurry
 
   This program is free software; you can redistribute it and/or modify
-  it under the terms of version 2 of the GNU General Public License
-  as published by the Free Software Foundation.
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Despite what the files say, ZynAddSubFX is under GPL-2+, see #2752.