### PR TITLE
Revert unnecessary link

### DIFF
--- a/plugins/zynaddsubfx/CMakeLists.txt
+++ b/plugins/zynaddsubfx/CMakeLists.txt
@@ -180,10 +180,6 @@ ENDIF()
 TARGET_LINK_LIBRARIES(RemoteZynAddSubFx zynaddsubfx_gui -L.. -lZynAddSubFxCore ${FLTK_FILTERED_LDFLAGS} -lpthread )
 ADD_DEPENDENCIES(RemoteZynAddSubFx ZynAddSubFxCore)
 
-IF(QT5)
-	TARGET_LINK_LIBRARIES(RemoteZynAddSubFx Qt5::Core)
-ENDIF(QT5)
-
 # link Qt libraries when on win32
 IF(LMMS_BUILD_WIN32)
 	TARGET_LINK_LIBRARIES(RemoteZynAddSubFx ${QT_LIBRARIES})


### PR DESCRIPTION
RemoteZynAddSubFx does not depend on Qt5::Core. The patch proposed in #2755 should be reverted.