### PR TITLE
Fix style for Qt5 about dialog

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -344,6 +344,11 @@ AutomatableSlider::handle:vertical {
 	margin: -4px -12px -2px;
 }
 
+/* about dialog */
+QTabWidget, QTabWidget QWidget {
+	background: #5b6571;
+}
+
 /* window that shows up when you add effects */
 
 EffectSelectDialog QScrollArea {


### PR DESCRIPTION
Feedback/merging from the themers is appreciated.

Qt5 doesn't theme the About dialog properly with the default theme, per #2611.

Before:
![image](https://cloud.githubusercontent.com/assets/6345473/15272381/728be892-1a43-11e6-8f39-adb0f42f71af.png)

After:
![image](https://cloud.githubusercontent.com/assets/6345473/15272373/2d98b008-1a43-11e6-849a-740e9dcee8cb.png)