### PR TITLE
Support qt_version_tag in Qt 5.6

### DIFF
--- a/plugins/zynaddsubfx/CMakeLists.txt
+++ b/plugins/zynaddsubfx/CMakeLists.txt
@@ -180,6 +180,11 @@ ENDIF()
 TARGET_LINK_LIBRARIES(RemoteZynAddSubFx zynaddsubfx_gui -L.. -lZynAddSubFxCore ${FLTK_FILTERED_LDFLAGS} -lpthread )
 ADD_DEPENDENCIES(RemoteZynAddSubFx ZynAddSubFxCore)
 
+# Support qt_version_tag in Qt 5.6
+IF(QT5)
+	TARGET_LINK_LIBRARIES(RemoteZynAddSubFx Qt5::Core)
+ENDIF(QT5)
+
 # link Qt libraries when on win32
 IF(LMMS_BUILD_WIN32)
 	TARGET_LINK_LIBRARIES(RemoteZynAddSubFx ${QT_LIBRARIES})


### PR DESCRIPTION
This reverts #2771. Qt 5.6 [adds `qt_version_tag`](https://codereview.qt-project.org/#/c/113559/4). Since there is an indirect link from a private library anyway, it is not worth to avoid this symbol.