### PR TITLE
Remove redundant mingw invocation

### DIFF
--- a/.travis/linux.win32.script.sh
+++ b/.travis/linux.win32.script.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CMAKE_OPTS="-DUSE_WERROR=ON"
-../cmake/build_mingw32.sh || ../cmake/build_mingw32.sh
+../cmake/build_mingw32.sh

--- a/.travis/linux.win64.script.sh
+++ b/.travis/linux.win64.script.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 export CMAKE_OPTS="-DUSE_WERROR=ON"
-../cmake/build_mingw64.sh || ../cmake/build_mingw64.sh
+../cmake/build_mingw64.sh


### PR DESCRIPTION
This was needed in Precise.  AFAIK it's no longer needed in Trusty because cmake no longer suffers the same problems.

If I'm wrong, we close out this PR and leave the old logic as the `||` operator safely skips the second invocation if the first succeeds.

**Edit:** Failed, closing.