### PR TITLE
Adds null pointer check to fix crash on exit with peak controller

### DIFF
--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -276,7 +276,10 @@ ConstNotePlayHandleList PresetPreviewPlayHandle::nphsOfInstrumentTrack(
 
 bool PresetPreviewPlayHandle::isPreviewing()
 {
-	return s_previewTC->isPreviewing();
+	if (s_previewTC) {
+		return s_previewTC->isPreviewing();
+	}
+	return false;
 }
 
 


### PR DESCRIPTION
Closes #2604 
Peak controller destructor was calling PresetPreviewPlayHandle::isPreviewing() after PresetPreviewPlayHandle static member s_previewTC was already destroyed. Added a null pointer test to PresetPreviewPlayHandle::isPreviewing(), returning false if s_previewTC is null.