### PR TITLE
Make scrollbars consistent over the software; Add padding to the scrollbars; Make the PianoView background themeable

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -140,15 +140,15 @@ CPULoadWidget {
 /* scrollbar: trough */
 
 QScrollBar:horizontal {
-    border: none;
+    border-top: 3px solid #262b30;
     background: #262b30;
-    height: 9px;
+    height: 12px;
     margin: 0px 12px;
 }
 QScrollBar:vertical {
-    border: none;
+    border-left: 3px solid #262b30;
     background: #262b30;
-    width: 9px;
+    width: 12px;
     margin: 12px 0px;
 }
 
@@ -236,6 +236,14 @@ QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
     background-color: none;
     width: 5px;
     height: 5px;
+}
+
+QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal {
+	margin-top: 3px;
+}
+
+QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical {
+	margin-left: 3px;
 }
 
 QScrollBar::left-arrow:horizontal { background-image: url(resources:sbarrow_left.png);}
@@ -500,6 +508,12 @@ PluginDescWidget:hover {
 	color: #d1d8e4;
 }
 
+/* piano widget */
+
+PianoView {
+	background-color: #14171a;
+}
+
 /* font sizes for text buttons */
 
 FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
@@ -550,7 +564,7 @@ TrackContentObjectView   {
 /* instrument pattern */
 PatternView {
 	background-color: #21A14F;
-	color: rgba(255,255,255,220)
+	color: rgba(255,255,255,220);
 }
 
 /* sample track pattern */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -174,7 +174,7 @@ QScrollBar::handle:horizontal {
 }
 
 QScrollBar::handle:horizontal:hover {
-	background: #49535d;
+	background: #525e69;
 }
 
 QScrollBar::handle:horizontal:pressed {
@@ -189,7 +189,7 @@ QScrollBar::handle:vertical {
 }
 
 QScrollBar::handle:vertical:hover {
-	background: #49535d;
+	background: #525e69;
 }
 
 QScrollBar::handle:vertical:pressed {

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -162,7 +162,7 @@ private:
 	} ;
 
 	// some constants...
-	static const int SCROLLBAR_SIZE = 14;
+	static const int SCROLLBAR_SIZE = 12;
 	static const int TOP_MARGIN = 16;
 
 	static const int DEFAULT_Y_DELTA = 6;

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -779,15 +779,11 @@ void PianoView::paintEvent( QPaintEvent * )
 	p.setFont( pointSize<LABEL_TEXT_SIZE>( p.font() ) );
 
 
-	// draw blue bar above the actual keyboard (there will be the labels
+	// draw bar above the keyboard (there will be the labels
 	// for all C's)
-	QLinearGradient g( 0, 0, 0, PIANO_BASE-3 );
-	g.setColorAt( 0, Qt::black );
-	g.setColorAt( 0.1, QColor( 96, 96, 96 ) );
-	g.setColorAt( 1, Qt::black );
-	p.fillRect( QRect( 0, 1, width(), PIANO_BASE-2 ), g );
+	p.fillRect( QRect( 0, 1, width(), PIANO_BASE-2 ), p.background() );
 
-	// draw stuff above the actual keyboard
+	// draw the line above the keyboard
 	p.setPen( Qt::black );
 	p.drawLine( 0, 0, width(), 0 );
 	p.drawLine( 0, PIANO_BASE-1, width(), PIANO_BASE-1 );
@@ -796,21 +792,18 @@ void PianoView::paintEvent( QPaintEvent * )
 
 	const int base_key = ( m_piano != NULL ) ?
 		m_piano->instrumentTrack()->baseNoteModel()->value() : 0;
-	g.setColorAt( 0, QApplication::palette().color( QPalette::Active,
-							QPalette::BrightText ).darker(220) );
-	g.setColorAt( 0.1, QApplication::palette().color( QPalette::Active,
-							QPalette::BrightText ) );
-	g.setColorAt( 1, QApplication::palette().color( QPalette::Active,
-							QPalette::BrightText ) );
+
+	QColor baseKeyColor = QApplication::palette().color( QPalette::Active,
+							QPalette::BrightText );
 	if( Piano::isWhiteKey( base_key ) )
 	{
 		p.fillRect( QRect( getKeyX( base_key ), 1, PW_WHITE_KEY_WIDTH-1,
-							PIANO_BASE-2 ), g );
+							PIANO_BASE-2 ), baseKeyColor );
 	}
 	else
 	{
 		p.fillRect( QRect( getKeyX( base_key ) + 1, 1,
-				PW_BLACK_KEY_WIDTH - 1, PIANO_BASE - 2 ), g );
+				PW_BLACK_KEY_WIDTH - 1, PIANO_BASE - 2 ), baseKeyColor);
 	}
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -83,7 +83,7 @@ typedef AutomationPattern::timeMap timeMap;
 // some constants...
 const int INITIAL_PIANOROLL_HEIGHT = 480;
 
-const int SCROLLBAR_SIZE = 14;
+const int SCROLLBAR_SIZE = 12;
 const int PIANO_X = 0;
 
 const int WHITE_KEY_WIDTH = 64;

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -93,7 +93,7 @@ const char * volume_help = QT_TRANSLATE_NOOP( "InstrumentTrack",
 
 const int INSTRUMENT_WIDTH	= 254;
 const int INSTRUMENT_HEIGHT	= INSTRUMENT_WIDTH;
-const int PIANO_HEIGHT		= 82;
+const int PIANO_HEIGHT		= 80;
 const int INSTRUMENT_WINDOW_CACHE_SIZE = 8;
 
 


### PR DESCRIPTION
Per the discussion in #2806.

I did several things with this PR. First, I adjusted the hard-coded parts of the software to accompany the new scrollbar size. I also increased the scrollbar to 12px, but kept the 9px size, by adding a 3px left and top border for the vertical and horizontal scrollbar, respectively. I did this because all our windows have a 3px border around them, and with the new borders, the scrollbars look a lot better and balanced.
Screenshots: 
![screenshot from 2016-05-31 22 04 10](https://cloud.githubusercontent.com/assets/6282045/15688711/9f116212-277b-11e6-926c-ed1f1b6aa517.png)
![screenshot from 2016-05-31 22 03 31](https://cloud.githubusercontent.com/assets/6282045/15688712/9f2d3a1e-277b-11e6-87a3-49211fe7bf56.png)


I also made the background of the PianoView widget themeable (The line above the piano in instrument windows):
![screenshot from 2016-05-31 22 02 25](https://cloud.githubusercontent.com/assets/6282045/15688651/62effdf2-277b-11e6-9b38-77ff8987f738.png)
 @RebeccaDeField please note if you don't like the color I chose for its background, we can easily have it changed.

As always, feedback and suggestions welcome.