### PR TITLE
Fix removal of track when notes are playing

### DIFF
--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -28,12 +28,14 @@
 #include <QtCore/QPair>
 #include <QtCore/QMutex>
 #include <QtCore/QThread>
+#include <samplerate.h>
 
-#include "Mixer.h"
+#include "lmms_basics.h"
 #include "TabWidget.h"
 
 
 class AudioPort;
+class Mixer;
 
 
 class AudioDevice

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -28,6 +28,7 @@
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
 #include "MicroTimer.h"
+#include "Mixer.h"
 
 
 class AudioDummy : public AudioDevice, public QThread

--- a/include/AudioPort.h
+++ b/include/AudioPort.h
@@ -29,7 +29,6 @@
 #include <QtCore/QMutex>
 #include <QtCore/QMutexLocker>
 
-#include "Mixer.h"
 #include "MemoryManager.h"
 #include "PlayHandle.h"
 

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -51,6 +51,8 @@ public:
 #include <portaudio.h>
 #endif
 
+#include <QtCore/QSemaphore>
+
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
 

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -39,7 +39,6 @@
 #include <math.h>
 
 #include "lmms_basics.h"
-#include "Mixer.h"
 #include "templates.h"
 #include "lmms_constants.h"
 #include "interpolation.h"

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -28,9 +28,9 @@
 #define CONTROLLER_H
 
 #include "Engine.h"
-#include "Mixer.h"
 #include "Model.h"
 #include "JournallingObject.h"
+#include "templates.h"
 #include "ValueBuffer.h"
 
 class ControllerDialog;

--- a/include/DummyInstrument.h
+++ b/include/DummyInstrument.h
@@ -32,6 +32,8 @@
 
 #include <string.h>
 
+#include "Mixer.h"
+
 
 class DummyInstrument : public Instrument
 {

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -28,7 +28,6 @@
 
 #include "Model.h"
 #include "SerializingObject.h"
-#include "Mixer.h"
 #include "AutomatableModel.h"
 
 class Effect;

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -26,7 +26,6 @@
 #define FX_MIXER_H
 
 #include "Model.h"
-#include "Mixer.h"
 #include "EffectChain.h"
 #include "JournallingObject.h"
 #include "ThreadableJob.h"

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -25,7 +25,6 @@
 #ifndef INSTRUMENT_SOUND_SHAPING_H
 #define INSTRUMENT_SOUND_SHAPING_H
 
-#include "Mixer.h"
 #include "ComboBoxModel.h"
 
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -29,21 +29,11 @@
 
 #include "lmmsconfig.h"
 
-#ifndef LMMS_USE_3RDPARTY_LIBSRC
-#include <samplerate.h>
-#else
-#ifndef OUT_OF_TREE_BUILD
-#include "src/3rdparty/samplerate/samplerate.h"
-#else
-#include <samplerate.h>
-#endif
-#endif
-
-
 #include <QtCore/QMutex>
 #include <QtCore/QThread>
 #include <QtCore/QVector>
 #include <QtCore/QWaitCondition>
+#include <samplerate.h>
 
 
 #include "lmms_basics.h"
@@ -346,6 +336,9 @@ public:
 	inline bool isMetronomeActive() const { return m_metronomeActive; }
 	inline void setMetronomeActive(bool value = true) { m_metronomeActive = value; }
 
+	void requestChangeInModel();
+	void doneChangeInModel();
+
 
 signals:
 	void qualitySettingsChanged();
@@ -388,6 +381,9 @@ private:
 	const surroundSampleFrame * renderNextBuffer();
 
 
+	void runChangesInModel();
+
+
 
 	QVector<AudioPort *> m_audioPorts;
 
@@ -420,6 +416,8 @@ private:
 	struct qualitySettings m_qualitySettings;
 	float m_masterGain;
 
+	bool m_isProcessing;
+
 	// audio device stuff
 	AudioDevice * m_audioDev;
 	AudioDevice * m_oldAudioDev;
@@ -443,6 +441,15 @@ private:
 	MixerProfiler m_profiler;
 
 	bool m_metronomeActive;
+
+	bool m_changesSignal;
+	bool m_waitForMixer;
+	unsigned int m_changes;
+	QMutex m_changesMutex;
+	QMutex m_doChangesMutex;
+	QMutex m_waitChangesMutex;
+	QWaitCondition m_changesMixerCondition;
+	QWaitCondition m_changesRequestCondition;
 
 	friend class LmmsCore;
 	friend class MixerWorkerThread;

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -27,6 +27,7 @@
 
 #include "AudioFileDevice.h"
 #include "lmmsconfig.h"
+#include "Mixer.h"
 
 
 class ProjectRenderer : public QThread

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -38,7 +38,6 @@
 #include "lmms_basics.h"
 #include "lmms_math.h"
 #include "shared_object.h"
-#include "Mixer.h"
 #include "MemoryManager.h"
 
 

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -25,9 +25,9 @@
 #ifndef SAMPLE_PLAY_HANDLE_H
 #define SAMPLE_PLAY_HANDLE_H
 
-#include "Mixer.h"
 #include "SampleBuffer.h"
 #include "AutomatableModel.h"
+#include "PlayHandle.h"
 
 class BBTrack;
 class SampleTCO;

--- a/include/SampleRecordHandle.h
+++ b/include/SampleRecordHandle.h
@@ -29,7 +29,8 @@
 #include <QtCore/QList>
 #include <QtCore/QPair>
 
-#include "Mixer.h"
+#include "MidiTime.h"
+#include "PlayHandle.h"
 #include "SampleBuffer.h"
 
 class BBTrack;

--- a/include/VisualizationWidget.h
+++ b/include/VisualizationWidget.h
@@ -29,7 +29,7 @@
 #include <QWidget>
 #include <QPixmap>
 
-#include "Mixer.h"
+#include "lmms_basics.h"
 
 
 class VisualizationWidget : public QWidget

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -40,6 +40,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "InstrumentPlayHandle.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "Knob.h"
 #include "Song.h"

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -35,6 +35,7 @@
 #include "Engine.h"
 #include "Song.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "interpolation.h"
 #include "gui_templates.h"

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -32,6 +32,7 @@
 #include "InstrumentTrack.h"
 #include "Knob.h"
 #include "LedCheckbox.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "Oscillator.h"
 #include "PixmapButton.h"

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -32,6 +32,7 @@
 #include "gui_templates.h"
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 
 #include <QApplication>
 #include <QFileDialog>

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -31,6 +31,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "KickerOsc.h"
 

--- a/plugins/lb302/lb302.h
+++ b/plugins/lb302/lb302.h
@@ -37,7 +37,6 @@
 #include "InstrumentView.h"
 #include "LedCheckbox.h"
 #include "Knob.h"
-#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include <QMutex>
 

--- a/plugins/nes/Nes.cpp
+++ b/plugins/nes/Nes.cpp
@@ -33,6 +33,7 @@
 #include "Song.h"
 #include "lmms_math.h"
 #include "interpolation.h"
+#include "Mixer.h"
 #include "Oscillator.h"
 
 #include "embed.cpp"

--- a/plugins/opl2/opl2instrument.cpp
+++ b/plugins/opl2/opl2instrument.cpp
@@ -40,6 +40,7 @@
 #include "Engine.h"
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 
 #include <QDomDocument>
 #include <QFile>

--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -33,6 +33,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "Oscillator.h"
 #include "PixmapButton.h"

--- a/plugins/papu/papu_instrument.cpp
+++ b/plugins/papu/papu_instrument.cpp
@@ -32,6 +32,7 @@
 #include "base64.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"
 #include "ToolTip.h"

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -33,6 +33,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "InstrumentPlayHandle.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "Knob.h"
 #include "Song.h"

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -49,6 +49,7 @@ float frnd(float range)
 #include "Song.h"
 #include "MidiEvent.h"
 #include "MidiTime.h"
+#include "Mixer.h"
 
 #include "embed.cpp"
 

--- a/plugins/sid/sid_instrument.cpp
+++ b/plugins/sid/sid_instrument.cpp
@@ -35,6 +35,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"
 #include "ToolTip.h"

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -37,6 +37,7 @@
 #include "gui_templates.h"
 #include "GuiApplication.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 
 #include "embed.cpp"
 

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -33,6 +33,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"
 #include "SampleBuffer.h"

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -38,6 +38,7 @@
 #include "InstrumentTrack.h"
 #include "VstPlugin.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "GuiApplication.h"
 #include "PixmapButton.h"
 #include "StringPairDrag.h"

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -29,6 +29,7 @@
 #include "vibed.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "ToolTip.h"
 #include "base64.h"

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -48,6 +48,7 @@
 #include "ConfigManager.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "Song.h"
 #include "templates.h"
 #include "FileDialog.h"

--- a/plugins/vst_base/VstPlugin.h
+++ b/plugins/vst_base/VstPlugin.h
@@ -32,7 +32,6 @@
 #include <QTimer>
 #include <QWidget>
 
-#include "Mixer.h"
 #include "JournallingObject.h"
 #include "communication.h"
 

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -32,6 +32,7 @@
 #include "ToolTip.h"
 #include "Song.h"
 #include "lmms_math.h"
+#include "Mixer.h"
 #include "interpolation.h"
 
 #include "embed.cpp"

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -42,6 +42,7 @@
 #include "StringPairDrag.h"
 #include "RemoteZynAddSubFx.h"
 #include "LocalZynAddSubFx.h"
+#include "Mixer.h"
 #include "ControllerConnection.h"
 
 #include "embed.cpp"

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -27,6 +27,7 @@
 #include "AutomationPattern.h"
 #include "ControllerConnection.h"
 #include "lmms_math.h"
+#include "Mixer.h"
 
 float AutomatableModel::s_copiedValue = 0;
 long AutomatableModel::s_periodCounter = 0;

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -28,6 +28,7 @@
 
 #include "AutomationPatternView.h"
 #include "AutomationTrack.h"
+#include "Note.h"
 #include "ProjectJournal.h"
 #include "BBTrackContainer.h"
 #include "Song.h"

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -26,6 +26,7 @@
 
 #include "BufferManager.h"
 #include "FxMixer.h"
+#include "Mixer.h"
 #include "MixerWorkerThread.h"
 #include "MixHelpers.h"
 #include "Song.h"

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -28,6 +28,7 @@
 #include "embed.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 #include "PresetPreviewPlayHandle.h"
 

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -31,6 +31,7 @@
 #include "EnvelopeAndLfoParameters.h"
 #include "Instrument.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "NotePlayHandle.h"
 
 

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -31,6 +31,7 @@
 #include "Instrument.h"
 #include "MidiEvent.h"
 #include "MidiPort.h"
+#include "Mixer.h"
 #include "Song.h"
 
 

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -31,6 +31,7 @@
 #include "Instrument.h"
 #include "InstrumentTrack.h"
 #include "MidiPort.h"
+#include "Mixer.h"
 #include "DataFile.h"
 #include "NotePlayHandle.h"
 #include "PluginFactory.h"

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -59,6 +59,7 @@
 #include "endian_handling.h"
 #include "Engine.h"
 #include "interpolation.h"
+#include "Mixer.h"
 #include "templates.h"
 
 #include "FileDialog.h"

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -27,6 +27,7 @@
 #include "BBTrack.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "Pattern.h"
 #include "SampleBuffer.h"
 #include "SampleTrack.h"

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -27,6 +27,7 @@
 #include "BBTrack.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
+#include "Mixer.h"
 #include "Pattern.h"
 #include "SampleBuffer.h"
 #include "SampleTrack.h"

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -34,6 +34,7 @@
 #include "ConfigManager.h"
 #include "Engine.h"
 #include "LcdSpinBox.h"
+#include "Mixer.h"
 #include "gui_templates.h"
 #include "templates.h"
 

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -27,6 +27,7 @@
 #include "AudioDevice.h"
 #include "ConfigManager.h"
 #include "debug.h"
+#include "Mixer.h"
 
 
 

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -34,6 +34,8 @@
 #include <vorbis/vorbisenc.h>
 #include <cstring>
 
+#include "Mixer.h"
+
 
 AudioFileOgg::AudioFileOgg( const sample_rate_t _sample_rate,
 				const ch_cnt_t _channels,

--- a/src/core/audio/AudioFileWave.cpp
+++ b/src/core/audio/AudioFileWave.cpp
@@ -25,6 +25,7 @@
 
 #include "AudioFileWave.h"
 #include "endian_handling.h"
+#include "Mixer.h"
 
 
 AudioFileWave::AudioFileWave( const sample_rate_t _sample_rate,

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -40,6 +40,7 @@
 #include "LcdSpinBox.h"
 #include "AudioPort.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 
 
 

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -32,6 +32,7 @@
 
 #include "endian_handling.h"
 #include "LcdSpinBox.h"
+#include "Mixer.h"
 #include "Engine.h"
 #include "gui_templates.h"
 #include "templates.h"

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -27,6 +27,7 @@
 #include "EffectChain.h"
 #include "FxMixer.h"
 #include "Engine.h"
+#include "Mixer.h"
 #include "MixHelpers.h"
 #include "BufferManager.h"
 #include "ValueBuffer.h"

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -48,6 +48,7 @@ void AudioPortAudioSetupUtil::updateChannels()
 #include "templates.h"
 #include "ComboBox.h"
 #include "LcdSpinBox.h"
+#include "Mixer.h"
 
 
 AudioPortAudio::AudioPortAudio( bool & _success_ful, Mixer * _mixer ) :

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -32,6 +32,7 @@
 #include "endian_handling.h"
 #include "ConfigManager.h"
 #include "LcdSpinBox.h"
+#include "Mixer.h"
 #include "gui_templates.h"
 #include "templates.h"
 #include "Engine.h"

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -33,6 +33,7 @@
 #include "debug.h"
 #include "ConfigManager.h"
 #include "gui_templates.h"
+#include "Mixer.h"
 #include "templates.h"
 
 

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -36,6 +36,7 @@
 #include "templates.h"
 #include "ComboBox.h"
 #include "LcdSpinBox.h"
+#include "Mixer.h"
 
 AudioSoundIo::AudioSoundIo( bool & outSuccessful, Mixer * _mixer ) :
 	AudioDevice( tLimit<ch_cnt_t>(

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -27,6 +27,7 @@
 
 #include "MidiPort.h"
 #include "MidiClient.h"
+#include "Note.h"
 #include "Song.h"
 
 

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -34,6 +34,7 @@
 #include "MidiController.h"
 #include "MidiClient.h"
 #include "MidiPortMenu.h"
+#include "Mixer.h"
 #include "LcdSpinBox.h"
 #include "LedCheckbox.h"
 #include "ComboBox.h"

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -46,6 +46,7 @@
 #include "Instrument.h"
 #include "InstrumentTrack.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "DataFile.h"
 #include "PluginFactory.h"
 #include "PresetPreviewPlayHandle.h"

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -43,6 +43,7 @@
 #include "embed.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "gui_templates.h"
 #include "InstrumentTrack.h"
 #include "Song.h"

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -47,6 +47,7 @@
 #include "LcdSpinBox.h"
 #include "MainWindow.h"
 #include "MeterDialog.h"
+#include "Mixer.h"
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
 #include "ToolTip.h"

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -30,6 +30,7 @@
 #include "GuiApplication.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "embed.h"
 #include "Engine.h"
 #include "ToolTip.h"

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -69,6 +69,7 @@
 #include "MainWindow.h"
 #include "MidiClient.h"
 #include "MidiPortMenu.h"
+#include "Mixer.h"
 #include "MixHelpers.h"
 #include "DataFile.h"
 #include "NotePlayHandle.h"
@@ -154,11 +155,15 @@ int InstrumentTrack::baseNote() const
 
 InstrumentTrack::~InstrumentTrack()
 {
+	Engine::mixer()->requestChangeInModel();
+
 	// kill all running notes and the iph
 	silenceAllNotes( true );
 
 	// now we're save deleting the instrument
 	if( m_instrument ) delete m_instrument;
+
+	Engine::mixer()->doneChangeInModel();
 }
 
 

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -44,11 +44,13 @@
 #include "StringPairDrag.h"
 #include "Knob.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "GuiApplication.h"
 #include "EffectRackView.h"
 #include "TrackLabelButton.h"
 #include "ConfigManager.h"
 #include "panning_constants.h"
+#include "volume.h"
 
 
 SampleTCO::SampleTCO( Track * _track ) :


### PR DESCRIPTION
When a track is removed and there are notes playing, use after free (crash) and deadlock may happen. This is more frequent when removing VeSTige. The fix is in the files
````
include/Mixer.h
src/core/Mixer.cpp
src/tracks/InstrumentTrack.cpp
````
The rest of the modifications is about headers, an effort to decouple the mixer by removing `#include "Mixer.h"` from other headers, since working with the mixer interface is tiresome.