### PR TITLE
Draw flat, borderless, semi-transparent and sharp-cornered notes

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -116,6 +116,7 @@ PianoRoll {
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
 	qproperty-noteOpacity: 128;
+	qproperty-noteBorderWidth: 5;
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -116,7 +116,7 @@ PianoRoll {
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
 	qproperty-noteOpacity: 128;
-	qproperty-noteBorderWidth: 5;
+	qproperty-borderlessNotes: false; /* boolean property, set true to have borderless notes */
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );
@@ -555,7 +555,7 @@ TrackContentObjectView   {
 	qproperty-selectedColor: rgb( 0, 125, 255 );
 	qproperty-textColor: rgb( 255, 255, 255 );
 	qproperty-textShadowColor: rgb( 0, 0, 0 );
-	qproperty-gradient: true;
+	qproperty-gradient: true; /* boolean property, set true to have a gradient */
 }
 
 /* instrument pattern */

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -115,7 +115,7 @@ PianoRoll {
 	qproperty-gridColor: rgb( 128, 128, 128 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
-	qproperty-noteOpacity: 0.65;
+	qproperty-noteOpacity: 128;
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -115,8 +115,7 @@ PianoRoll {
 	qproperty-gridColor: rgb( 128, 128, 128 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
-	qproperty-noteBorderRadiusX: 5;
-	qproperty-noteBorderRadiusY: 2;
+	qproperty-noteOpacity: 0.5;
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -116,7 +116,7 @@ PianoRoll {
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
 	qproperty-noteOpacity: 128;
-	qproperty-borderlessNotes: false; /* boolean property, set true to have borderless notes */
+	qproperty-noteBorders: true; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -115,7 +115,7 @@ PianoRoll {
 	qproperty-gridColor: rgb( 128, 128, 128 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
-	qproperty-noteOpacity: 0.5;
+	qproperty-noteOpacity: 0.65;
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 40, 40, 40, 200 );

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -112,8 +112,8 @@ PianoRoll {
 	qproperty-gridColor: #2d3339;
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
-	qproperty-noteOpacity: 128;
-	qproperty-noteBorderWidth: 1;
+	qproperty-noteOpacity: 165;
+	qproperty-borderlessNotes: true; /* boolean property, set true to have borderless notes */
 	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -112,7 +112,7 @@ PianoRoll {
 	qproperty-gridColor: #2d3339;
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
-	qproperty-noteOpacity: 0.5;
+	qproperty-noteOpacity: 128;
 	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -113,6 +113,7 @@ PianoRoll {
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
 	qproperty-noteOpacity: 128;
+	qproperty-noteBorderWidth: 1;
 	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -113,7 +113,7 @@ PianoRoll {
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
 	qproperty-noteOpacity: 165;
-	qproperty-borderlessNotes: true; /* boolean property, set true to have borderless notes */
+	qproperty-noteBorders: false; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -15,7 +15,7 @@ AutomationEditor {
 	background-color: #040506;
 	color: #ffffff;
 	qproperty-vertexColor: #7f0a1d;
-	qproperty-gridColor: #171a1d;
+	qproperty-gridColor: #2d3339;
 	qproperty-crossColor: #FE143A;
 
 	qproperty-graphColor: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1,
@@ -109,12 +109,11 @@ QMenu::indicator:selected {
 
 PianoRoll {
 	background-color: #040506;
-	qproperty-gridColor: #171a1d;
+	qproperty-gridColor: #2d3339;
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
-	qproperty-noteBorderRadiusX: 0;
-	qproperty-noteBorderRadiusY: 0;
-	qproperty-selectedNoteColor: #044d1f;
+	qproperty-noteOpacity: 0.5;
+	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;
 	/* Text on the white piano keys */
@@ -544,7 +543,7 @@ TrackContentObjectView   {
 	qproperty-selectedColor: #006B65;
 	qproperty-textColor: #fff;
 	qproperty-textShadowColor: rgb(0,0,0,200);
-	qproperty-gradient: false;
+	qproperty-gradient: false; /* boolean property, set true to have a gradient */
 }
 
 /* instrument pattern */

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -63,6 +63,7 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
 	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
 	Q_PROPERTY( int noteOpacity READ noteOpacity WRITE setNoteOpacity )
+	Q_PROPERTY( int noteBorderWidth READ noteBorderWidth WRITE setNoteBorderWidth )
 public:
 	enum EditModes
 	{
@@ -127,6 +128,8 @@ public:
 	void setMarkedSemitoneColor( const QColor & c );
 	int noteOpacity() const;
 	void setNoteOpacity( const int i );
+	int noteBorderWidth() const;
+	void setNoteBorderWidth( const int i );
 
 
 protected:
@@ -145,7 +148,7 @@ protected:
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol,
-					const QColor & selCol, const int noteOpc );
+					const QColor & selCol, const int noteOpc, const int borderWidth );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -375,6 +378,7 @@ private:
 	QColor m_textShadow;
 	QColor m_markedSemitoneColor;
 	int m_noteOpacity;
+	int m_noteBorderWidth;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -57,13 +57,12 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor noteModeColor READ noteModeColor WRITE setNoteModeColor )
 	Q_PROPERTY( QColor noteColor READ noteColor WRITE setNoteColor )
 	Q_PROPERTY( QColor barColor READ barColor WRITE setBarColor )
-	Q_PROPERTY( float noteBorderRadiusX READ noteBorderRadiusX WRITE setNoteBorderRadiusX )
-	Q_PROPERTY( float noteBorderRadiusY READ noteBorderRadiusY WRITE setNoteBorderRadiusY )
 	Q_PROPERTY( QColor selectedNoteColor READ selectedNoteColor WRITE setSelectedNoteColor )
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 	Q_PROPERTY( QColor textColorLight READ textColorLight WRITE setTextColorLight )
 	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
 	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
+	Q_PROPERTY( float noteOpacity READ noteOpacity WRITE setNoteOpacity )
 public:
 	enum EditModes
 	{
@@ -116,10 +115,6 @@ public:
 	void setNoteColor( const QColor & c );
 	QColor barColor() const;
 	void setBarColor( const QColor & c );
-	float noteBorderRadiusX() const;
-	void setNoteBorderRadiusX( float b );
-	float noteBorderRadiusY() const;
-	void setNoteBorderRadiusY( float b );
 	QColor selectedNoteColor() const;
 	void setSelectedNoteColor( const QColor & c );
 	QColor textColor() const;
@@ -130,6 +125,8 @@ public:
 	void setTextShadow( const QColor & c );
 	QColor markedSemitoneColor() const;
 	void setMarkedSemitoneColor( const QColor & c );
+	float noteOpacity() const;
+	void setNoteOpacity( const float f );
 
 
 protected:
@@ -148,7 +145,7 @@ protected:
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol,
-				 	float radiusX, float radiusY, const QColor & selCol );
+					const QColor & selCol, const float noteOpc );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -372,13 +369,12 @@ private:
 	QColor m_noteModeColor;
 	QColor m_noteColor;
 	QColor m_barColor;
-	float m_noteBorderRadiusX;
-	float m_noteBorderRadiusY;
 	QColor m_selectedNoteColor;
 	QColor m_textColor;
 	QColor m_textColorLight;
 	QColor m_textShadow;
 	QColor m_markedSemitoneColor;
+	float m_noteOpacity;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -63,7 +63,7 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
 	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
 	Q_PROPERTY( int noteOpacity READ noteOpacity WRITE setNoteOpacity )
-	Q_PROPERTY( bool borderlessNotes READ borderlessNotes WRITE setBorderlessNotes )
+	Q_PROPERTY( bool noteBorders READ noteBorders WRITE setNoteBorders )
 public:
 	enum EditModes
 	{
@@ -128,8 +128,8 @@ public:
 	void setMarkedSemitoneColor( const QColor & c );
 	int noteOpacity() const;
 	void setNoteOpacity( const int i );
-	bool borderlessNotes() const;
-	void setBorderlessNotes( const bool b );
+	bool noteBorders() const;
+	void setNoteBorders( const bool b );
 
 
 protected:
@@ -378,7 +378,7 @@ private:
 	QColor m_textShadow;
 	QColor m_markedSemitoneColor;
 	int m_noteOpacity;
-	bool m_borderlessNotes;
+	bool m_noteBorders;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -63,7 +63,7 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
 	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
 	Q_PROPERTY( int noteOpacity READ noteOpacity WRITE setNoteOpacity )
-	Q_PROPERTY( int noteBorderWidth READ noteBorderWidth WRITE setNoteBorderWidth )
+	Q_PROPERTY( bool borderlessNotes READ borderlessNotes WRITE setBorderlessNotes )
 public:
 	enum EditModes
 	{
@@ -128,8 +128,8 @@ public:
 	void setMarkedSemitoneColor( const QColor & c );
 	int noteOpacity() const;
 	void setNoteOpacity( const int i );
-	int noteBorderWidth() const;
-	void setNoteBorderWidth( const int i );
+	bool borderlessNotes() const;
+	void setBorderlessNotes( const bool b );
 
 
 protected:
@@ -148,7 +148,7 @@ protected:
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol,
-					const QColor & selCol, const int noteOpc, const int borderWidth );
+					const QColor & selCol, const int noteOpc, const bool borderless );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -378,7 +378,7 @@ private:
 	QColor m_textShadow;
 	QColor m_markedSemitoneColor;
 	int m_noteOpacity;
-	int m_noteBorderWidth;
+	bool m_borderlessNotes;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -62,7 +62,7 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor textColorLight READ textColorLight WRITE setTextColorLight )
 	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
 	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
-	Q_PROPERTY( float noteOpacity READ noteOpacity WRITE setNoteOpacity )
+	Q_PROPERTY( int noteOpacity READ noteOpacity WRITE setNoteOpacity )
 public:
 	enum EditModes
 	{
@@ -125,8 +125,8 @@ public:
 	void setTextShadow( const QColor & c );
 	QColor markedSemitoneColor() const;
 	void setMarkedSemitoneColor( const QColor & c );
-	float noteOpacity() const;
-	void setNoteOpacity( const float f );
+	int noteOpacity() const;
+	void setNoteOpacity( const int i );
 
 
 protected:
@@ -145,7 +145,7 @@ protected:
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol,
-					const QColor & selCol, const float noteOpc );
+					const QColor & selCol, const int noteOpc );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -374,7 +374,7 @@ private:
 	QColor m_textColorLight;
 	QColor m_textShadow;
 	QColor m_markedSemitoneColor;
-	float m_noteOpacity;
+	int m_noteOpacity;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -808,7 +808,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 			( (float)( PanningRight - n->getPanning() ) ) /
 			( (float)( PanningRight - PanningLeft ) ) * 2.0f );
 
-	QColor col = QColor( noteCol );	
+	QColor col = QColor( noteCol );
 
 	if( n->selected() )
 	{
@@ -822,7 +822,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	QColor lcol = QColor::fromHsv( col.hue(), col.saturation(),
 						volVal * leftPercent, noteOpc );
 	QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
-						volVal * rightPercent, noteOpc );	
+						volVal * rightPercent, noteOpc );
 
 	QLinearGradient gradient( x, y, x + width, y + noteHeight );
 	gradient.setColorAt( 1, rcol );
@@ -833,7 +833,6 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	p.drawRect( x, y, width, noteHeight );
 
 	// draw the note endmark, to hint the user to resize
-	p.setPen( col );
 	p.setBrush( col );
 	if( width > 2 )
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -195,7 +195,7 @@ PianoRoll::PianoRoll() :
 	m_textColorLight( 0, 0, 0 ),
 	m_textShadow( 0, 0, 0 ),
 	m_markedSemitoneColor( 0, 0, 0 ),
-	m_noteOpacity( 1 )
+	m_noteOpacity( 255 )
 {
 	// gui names of edit modes
 	m_nemStr.push_back( tr( "Note Velocity" ) );
@@ -775,11 +775,11 @@ QColor PianoRoll::markedSemitoneColor() const
 void PianoRoll::setMarkedSemitoneColor( const QColor & c )
 { m_markedSemitoneColor = c; }
 
-float PianoRoll::noteOpacity() const
+int PianoRoll::noteOpacity() const
 { return m_noteOpacity; }
 
-void PianoRoll::setNoteOpacity( const float f )
-{ m_noteOpacity = f; }
+void PianoRoll::setNoteOpacity( const int i )
+{ m_noteOpacity = i; }
 
 
 
@@ -787,7 +787,7 @@ void PianoRoll::setNoteOpacity( const float f )
 
 void PianoRoll::drawNoteRect( QPainter & p, int x, int y, 
 				int width, const Note * n, const QColor & noteCol,
-				const QColor & selCol, const float noteOpc )
+				const QColor & selCol, const int noteOpc )
 {
 	++x;
 	++y;
@@ -808,41 +808,38 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 			( (float)( PanningRight - n->getPanning() ) ) /
 			( (float)( PanningRight - PanningLeft ) ) * 2.0f );
 
-	QColor col = QColor( noteCol );
-	const int noteHeight = KEY_LINE_HEIGHT - 1;
+	QColor col = QColor( noteCol );	
 
 	if( n->selected() )
 	{
 		col = QColor( selCol );
 	}
 
+	const int noteHeight = KEY_LINE_HEIGHT - 2;
+
 	// adjust note to make it a bit faded if it has a lower volume
 	// in stereo using gradients
 	QColor lcol = QColor::fromHsv( col.hue(), col.saturation(),
-						volVal * leftPercent );
+						volVal * leftPercent, noteOpc );
 	QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
-						volVal * rightPercent );
+						volVal * rightPercent, noteOpc );	
 
-	QLinearGradient gradient( x, y, x, y + noteHeight );
-	gradient.setColorAt( 0, rcol );
-	gradient.setColorAt( 1, lcol );
+	QLinearGradient gradient( x, y, x + width, y + noteHeight );
+	gradient.setColorAt( 1, rcol );
+	gradient.setColorAt( 0, lcol );
 	p.setBrush( gradient );
 
-	p.setPen( Qt::NoPen );
-	p.setOpacity( noteOpc );
-	p.drawRect( x, y, width + 1, noteHeight );
+	p.setPen( col );
+	p.drawRect( x, y, width, noteHeight );
 
 	// draw the note endmark, to hint the user to resize
-	p.setPen( Qt::NoPen );
+	p.setPen( col );
 	p.setBrush( col );
 	if( width > 2 )
 	{
-		const int endmarkWidth = 3;
-		p.drawRect( x + width + 1 - endmarkWidth, y, 
-				endmarkWidth, noteHeight );
+		const int endmarkWidth = 2;
+		p.drawRect( x + width - endmarkWidth, y, endmarkWidth, noteHeight );
 	}
-	// reset opacity
-	p.setOpacity( 1 );
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -195,7 +195,8 @@ PianoRoll::PianoRoll() :
 	m_textColorLight( 0, 0, 0 ),
 	m_textShadow( 0, 0, 0 ),
 	m_markedSemitoneColor( 0, 0, 0 ),
-	m_noteOpacity( 255 )
+	m_noteOpacity( 255 ),
+	m_noteBorderWidth( 0 )
 {
 	// gui names of edit modes
 	m_nemStr.push_back( tr( "Note Velocity" ) );
@@ -781,13 +782,19 @@ int PianoRoll::noteOpacity() const
 void PianoRoll::setNoteOpacity( const int i )
 { m_noteOpacity = i; }
 
+int PianoRoll::noteBorderWidth() const
+{ return m_noteBorderWidth; }
+
+void PianoRoll::setNoteBorderWidth( const int i )
+{ m_noteBorderWidth = i; }
+
 
 
 
 
 void PianoRoll::drawNoteRect( QPainter & p, int x, int y, 
 				int width, const Note * n, const QColor & noteCol,
-				const QColor & selCol, const int noteOpc )
+				const QColor & selCol, const int noteOpc, const int borderWidth )
 {
 	++x;
 	++y;
@@ -809,13 +816,15 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 			( (float)( PanningRight - PanningLeft ) ) * 2.0f );
 
 	QColor col = QColor( noteCol );
+	QPen pen;
 
 	if( n->selected() )
 	{
 		col = QColor( selCol );
 	}
 
-	const int noteHeight = KEY_LINE_HEIGHT - 2;
+	const int noteHeight = KEY_LINE_HEIGHT - 1 - borderWidth;
+	int noteWidth = width + 1 - borderWidth;
 
 	// adjust note to make it a bit faded if it has a lower volume
 	// in stereo using gradients
@@ -829,15 +838,24 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	gradient.setColorAt( 0, lcol );
 	p.setBrush( gradient );
 
-	p.setPen( col );
-	p.drawRect( x, y, width, noteHeight );
+	if ( borderWidth == 0 )
+	{
+		p.setPen( Qt::NoPen );
+	}
+	else
+	{
+		pen.setColor( col );
+		pen.setWidth( borderWidth );
+		p.setPen( pen );
+	}
+	p.drawRect( x, y, noteWidth, noteHeight );
 
 	// draw the note endmark, to hint the user to resize
 	p.setBrush( col );
 	if( width > 2 )
 	{
-		const int endmarkWidth = 2;
-		p.drawRect( x + width - endmarkWidth, y, endmarkWidth, noteHeight );
+		const int endmarkWidth = 3 - borderWidth;
+		p.drawRect( x + noteWidth - endmarkWidth, y, endmarkWidth, noteHeight );
 	}
 }
 
@@ -2968,7 +2986,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
 						y_base - key * KEY_LINE_HEIGHT,
 								note_width, note, noteColor(), selectedNoteColor(),
-							 	noteOpacity() );
+							 	noteOpacity(), noteBorderWidth() );
 			}
 
 			// draw note editing stuff

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -196,7 +196,7 @@ PianoRoll::PianoRoll() :
 	m_textShadow( 0, 0, 0 ),
 	m_markedSemitoneColor( 0, 0, 0 ),
 	m_noteOpacity( 255 ),
-	m_borderlessNotes( true )
+	m_noteBorders( true )
 {
 	// gui names of edit modes
 	m_nemStr.push_back( tr( "Note Velocity" ) );
@@ -782,11 +782,11 @@ int PianoRoll::noteOpacity() const
 void PianoRoll::setNoteOpacity( const int i )
 { m_noteOpacity = i; }
 
-bool PianoRoll::borderlessNotes() const
-{ return m_borderlessNotes; }
+bool PianoRoll::noteBorders() const
+{ return m_noteBorders; }
 
-void PianoRoll::setBorderlessNotes( const bool b )
-{ m_borderlessNotes = b; }
+void PianoRoll::setNoteBorders( const bool b )
+{ m_noteBorders = b; }
 
 
 
@@ -794,7 +794,7 @@ void PianoRoll::setBorderlessNotes( const bool b )
 
 void PianoRoll::drawNoteRect( QPainter & p, int x, int y, 
 				int width, const Note * n, const QColor & noteCol,
-				const QColor & selCol, const int noteOpc, const bool borderless )
+				const QColor & selCol, const int noteOpc, const bool borders )
 {
 	++x;
 	++y;
@@ -823,7 +823,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 		col = QColor( selCol );
 	}
 
-	const int borderWidth = borderless ? 0 : 1;
+	const int borderWidth = borders ? 1 : 0;
 
 	const int noteHeight = KEY_LINE_HEIGHT - 1 - borderWidth;
 	int noteWidth = width + 1 - borderWidth;
@@ -840,13 +840,13 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	gradient.setColorAt( 1, lcol );
 	p.setBrush( gradient );
 
-	if ( borderless )
+	if ( borders )
 	{
-		p.setPen( Qt::NoPen );
+		p.setPen( col );
 	}
 	else
 	{
-		p.setPen( col );
+		p.setPen( Qt::NoPen );
 	}
 
 	p.drawRect( x, y, noteWidth, noteHeight );
@@ -2987,7 +2987,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
 						y_base - key * KEY_LINE_HEIGHT,
 								note_width, note, noteColor(), selectedNoteColor(),
-							 	noteOpacity(), borderlessNotes() );
+							 	noteOpacity(), noteBorders() );
 			}
 
 			// draw note editing stuff

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -196,7 +196,7 @@ PianoRoll::PianoRoll() :
 	m_textShadow( 0, 0, 0 ),
 	m_markedSemitoneColor( 0, 0, 0 ),
 	m_noteOpacity( 255 ),
-	m_noteBorderWidth( 0 )
+	m_borderlessNotes( true )
 {
 	// gui names of edit modes
 	m_nemStr.push_back( tr( "Note Velocity" ) );
@@ -782,11 +782,11 @@ int PianoRoll::noteOpacity() const
 void PianoRoll::setNoteOpacity( const int i )
 { m_noteOpacity = i; }
 
-int PianoRoll::noteBorderWidth() const
-{ return m_noteBorderWidth; }
+bool PianoRoll::borderlessNotes() const
+{ return m_borderlessNotes; }
 
-void PianoRoll::setNoteBorderWidth( const int i )
-{ m_noteBorderWidth = i; }
+void PianoRoll::setBorderlessNotes( const bool b )
+{ m_borderlessNotes = b; }
 
 
 
@@ -794,7 +794,7 @@ void PianoRoll::setNoteBorderWidth( const int i )
 
 void PianoRoll::drawNoteRect( QPainter & p, int x, int y, 
 				int width, const Note * n, const QColor & noteCol,
-				const QColor & selCol, const int noteOpc, const int borderWidth )
+				const QColor & selCol, const int noteOpc, const bool borderless )
 {
 	++x;
 	++y;
@@ -823,6 +823,8 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 		col = QColor( selCol );
 	}
 
+	const int borderWidth = borderless ? 0 : 1;
+
 	const int noteHeight = KEY_LINE_HEIGHT - 1 - borderWidth;
 	int noteWidth = width + 1 - borderWidth;
 
@@ -833,21 +835,20 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
 						volVal * rightPercent, noteOpc );
 
-	QLinearGradient gradient( x, y, x + width, y + noteHeight );
-	gradient.setColorAt( 1, rcol );
-	gradient.setColorAt( 0, lcol );
+	QLinearGradient gradient( x, y, x, y + noteHeight );
+	gradient.setColorAt( 0, rcol );
+	gradient.setColorAt( 1, lcol );
 	p.setBrush( gradient );
 
-	if ( borderWidth == 0 )
+	if ( borderless )
 	{
 		p.setPen( Qt::NoPen );
 	}
 	else
 	{
-		pen.setColor( col );
-		pen.setWidth( borderWidth );
-		p.setPen( pen );
+		p.setPen( col );
 	}
+
 	p.drawRect( x, y, noteWidth, noteHeight );
 
 	// draw the note endmark, to hint the user to resize
@@ -2986,7 +2987,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
 						y_base - key * KEY_LINE_HEIGHT,
 								note_width, note, noteColor(), selectedNoteColor(),
-							 	noteOpacity(), noteBorderWidth() );
+							 	noteOpacity(), borderlessNotes() );
 			}
 
 			// draw note editing stuff

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -823,9 +823,9 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	QColor rcol = QColor::fromHsv( col.hue(), col.saturation(),
 						volVal * rightPercent );
 
-	QLinearGradient gradient( x, y, x + width, y + noteHeight );
-	gradient.setColorAt( 0, lcol );
-	gradient.setColorAt( 1, rcol );
+	QLinearGradient gradient( x, y, x, y + noteHeight );
+	gradient.setColorAt( 0, rcol );
+	gradient.setColorAt( 1, lcol );
 	p.setBrush( gradient );
 
 	p.setPen( Qt::NoPen );


### PR DESCRIPTION
Closes #2777.
![screenshot from 2016-06-07 00 08 37](https://cloud.githubusercontent.com/assets/6282045/15839611/82133dc0-2c44-11e6-8377-8fd1fb2b384d.png)
 
Flat notes with the end-point were the most popular choice, and I added transparency (adjustable by a qproperty) so the user can distinguish overlapping notes.

I also changed the selected notes color to the same color TCO's have when selected, because the current selected notes color had the same hue and saturation as the normal note color, and as such it did not affect the notes at all. 
Here's a not selected and a selected note: 
![screenshot from 2016-06-07 00 16 22](https://cloud.githubusercontent.com/assets/6282045/15839698/1ecd630c-2c45-11e6-9aaf-dc0a11695fb8.png)

I increased the grid color lightness, as I was having a hard time distinguishing the grid.

As always, review and comments welcome.