### PR TITLE
Replace information obtained from the web in aeffectx.h

### DIFF
--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -118,17 +118,6 @@ const int kVstTransportPlaying = 1 << 1;
 const int kVstTransportCycleActive = 1 << 2;
 const int kVstTransportChanged = 1;
 
-/* validity flags for a VstTimeInfo structure, this info comes from the web */
-
-const int kVstNanosValid (1 << 8);
-const int kVstPpqPosValid (1 << 9);
-const int kVstTempoValid (1 << 10);
-const int kVstBarsValid (1 << 11);
-const int kVstCyclePosValid (1 << 12);
-const int kVstTimeSigValid (1 << 13);
-const int kVstSmpteValid (1 << 14);
-const int kVstClockValid (1 << 15);
-
 
 
 
@@ -186,52 +175,6 @@ public:
 	VstEvent* events[1];
 
 } ;
-
-
-/* constants from http://www.rawmaterialsoftware.com/juceforum/viewtopic.php?t=3740&sid=183f74631fee71a493316735e2b9f28b */
-enum Vestige2StringConstants
-{
-        VestigeMaxNameLen       = 64,
-        VestigeMaxLabelLen      = 64,
-        VestigeMaxShortLabelLen = 8,
-        VestigeMaxCategLabelLen = 24,
-        VestigeMaxFileNameLen   = 100
-};
-
-
-/* this struct taken from http://asseca.com/vst-24-specs/efGetParameterProperties.html */
-struct VstParameterProperties
-{
-    float stepFloat;              /* float step */
-    float smallStepFloat;         /* small float step */
-    float largeStepFloat;         /* large float step */
-    char label[VestigeMaxLabelLen];  /* parameter label */
-    int32_t flags;               /* @see VstParameterFlags */
-    int32_t minInteger;          /* integer minimum */
-    int32_t maxInteger;          /* integer maximum */
-    int32_t stepInteger;         /* integer step */
-    int32_t largeStepInteger;    /* large integer step */
-    char shortLabel[VestigeMaxShortLabelLen]; /* short label, recommended: 6 + delimiter */
-    int16_t displayIndex;        /* index where this parameter should be displayed (starting with 0) */
-    int16_t category;            /* 0: no category, else group index + 1 */
-    int16_t numParametersInCategory; /* number of parameters in category */
-    int16_t reserved;            /* zero */
-    char categoryLabel[VestigeMaxCategLabelLen]; /* category label, e.g. "Osc 1"  */
-    char future[16];              /* reserved for future use */
-};
-
-
-/* this enum taken from http://asseca.com/vst-24-specs/efGetParameterProperties.html */
-enum VstParameterFlags
-{
-        kVstParameterIsSwitch                = 1 << 0,  /* parameter is a switch (on/off) */
-        kVstParameterUsesIntegerMinMax       = 1 << 1,  /* minInteger, maxInteger valid */
-        kVstParameterUsesFloatStep           = 1 << 2,  /* stepFloat, smallStepFloat, largeStepFloat valid */
-        kVstParameterUsesIntStep             = 1 << 3,  /* stepInteger, largeStepInteger valid */
-        kVstParameterSupportsDisplayIndex    = 1 << 4,  /* displayIndex valid */
-        kVstParameterSupportsDisplayCategory = 1 << 5,  /* category, etc. valid */
-        kVstParameterCanRamp                 = 1 << 6   /* set if parameter value can ramp up/down */
-};
 
 
 class AEffect

--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -103,7 +103,6 @@ const int effEditIdle = 19;
 const int effEditTop = 20;
 const int effProcessEvents = 25;
 const int effGetEffectName = 45;
-const int effGetParameterProperties = 47; // missing
 const int effGetVendorString = 47;
 const int effGetProductString = 48;
 const int effGetVendorVersion = 49;
@@ -114,14 +113,33 @@ const int kEffectMagic = CCONST( 'V', 's', 't', 'P' );
 const int kVstLangEnglish = 1;
 const int kVstMidiType = 1;
 
+const int kVstTransportChanged = 1;
 const int kVstTransportPlaying = 1 << 1;
 const int kVstTransportCycleActive = 1 << 2;
-const int kVstTransportChanged = 1;
+const int kVstTransportRecording = 1 << 3; // currently unused
+const int kVstPpqPosValid = 1 << 9;
+const int kVstTempoValid = 1 << 10;
+const int kVstBarsValid = 1 << 11;
+const int kVstCyclePosValid = 1 << 12;
+const int kVstTimeSigValid = 1 << 13;
+const int kVstSmpteValid = 1 << 14; // currently unused
+const int kVstClockValid = 1 << 15; // currently unused
+
+// currently unused
+const int kVstSmpte24fps = 0;
+const int kVstSmpte25fps = 1;
+const int kVstSmpte2997fps = 2;
+const int kVstSmpte30fps = 3;
+const int kVstSmpte2997dfps = 4;
+const int kVstSmpte30dfps = 5;
+const int kVstSmpteFilm16mm = 6; // very likely
+const int kVstSmpteFilm35mm = 7; // very likely
+const int kVstSmpte239fps = 10;
+const int kVstSmpte249fps = 11;
+const int kVstSmpte599fps = 12;
+const int kVstSmpte60fps = 13;
 
 
-
-
-class RemoteVstPlugin;
 
 
 class VstMidiEvent
@@ -207,7 +225,7 @@ public:
 	// Zeroes 2c-2f 30-33 34-37 38-3b
 	char empty3[4 + 4 + 4];
 	// 1.0f 3c-3f
-	float unkown_float;
+	float unknown_float;
 	// An object? pointer 40-43
 	void *ptr3;
 	// Zeroes 44-47
@@ -235,22 +253,24 @@ public:
 	double nanoSeconds;
 	// 18
 	double ppqPos;
-	// 20?
+	// 20
 	double tempo;
 	// 28
 	double barStartPos;
-	// 30?
+	// 30
 	double cycleStartPos;
-	// 38?
+	// 38
 	double cycleEndPos;
-	// 40?
+	// 40
 	int32_t timeSigNumerator;
-	// 44?
+	// 44
 	int32_t timeSigDenominator;
-
-    int32_t   smpteOffset;
-    int32_t   smpteFrameRate;
-    int32_t   samplesToNextClock;
+	// 48 unused
+	int32_t smpteOffset;
+	// 4c unused
+	int32_t smpteFrameRate;
+	// 50? unused, where does this come from?
+	int32_t samplesToNextClock;
 	// 54
 	int32_t flags;
 

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -192,9 +192,6 @@ public:
 	// read parameter-dump and set it for plugin
 	void setParameterDump( const message & _m );
 
-	// post properties of specified parameter
-	void getParameterProperties( const int _idx );
-
 	// save settings chunk of plugin into file
 	void saveChunkToFile( const std::string & _file );
 
@@ -501,10 +498,6 @@ bool RemoteVstPlugin::processMessage( const message & _m )
 
 		case IdVstSetParameterDump:
 			setParameterDump( _m );
-			break;
-
-		case IdVstGetParameterProperties:
-			getParameterProperties( _m.getInt() );
 			break;
 
 		case IdSaveSettingsToFile:
@@ -979,37 +972,6 @@ void RemoteVstPlugin::setParameterDump( const message & _m )
 		m_plugin->setParameter( m_plugin, item.index, item.value );
 	}
 	unlock();
-}
-
-
-
-
-void RemoteVstPlugin::getParameterProperties( const int _idx )
-{
-	VstParameterProperties p;
-	pluginDispatch( effGetParameterProperties, _idx, 0, &p );
-	message m( IdVstParameterProperties );
-	m.addString( p.label );
-	m.addString( p.shortLabel );
-	m.addString(
-#if kVstVersion > 2
-			p.categoryLabel
-#else
-			""
-#endif
-					);
-	m.addFloat( p.minInteger );
-	m.addFloat( p.maxInteger );
-	m.addFloat( ( p.flags & kVstParameterUsesFloatStep ) ?
-						p.stepFloat : p.stepInteger );
-	m.addInt(
-#if kVstVersion > 2
-			p.category
-#else
-			0
-#endif
-				);
-	sendMessage( m );
 }
 
 

--- a/plugins/vst_base/communication.h
+++ b/plugins/vst_base/communication.h
@@ -63,7 +63,6 @@ enum VstRemoteMessageIDs
 	IdVstGetParameterCount,
 	IdVstGetParameterDump,
 	IdVstSetParameterDump,
-	IdVstGetParameterProperties,
 	IdVstProgramNames,
 	IdVstCurrentProgram,
 	IdVstCurrentProgramName,
@@ -84,8 +83,7 @@ enum VstRemoteMessageIDs
 	IdVstPluginUniqueID,
 	IdVstSetParameter,
 	IdVstParameterCount,
-	IdVstParameterDump,
-	IdVstParameterProperties
+	IdVstParameterDump
 
 } ;
 


### PR DESCRIPTION
I fear that information obtained from the web was copied from the Steinberg SDK. I would like to replace that information with safe data. This pull request should be handled in two commits rather than one, because changes should not be compared: the first one is the commit that erases the information, and the second one is the following squashed commits that add the discovered data.