### PR TITLE
Remove more locks from the mixer

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -216,8 +216,6 @@ public:
 
 	void removePlayHandlesOfTypes( Track * _track, const quint8 types );
 
-	bool hasNotePlayHandles();
-
 
 	// methods providing information for other classes
 	inline fpp_t framesPerPeriod() const
@@ -272,27 +270,6 @@ public:
 		return _s;
 	}
 
-
-	// methods needed by other threads to alter knob values, waveforms, etc
-	void lockInputFrames()
-	{
-		m_inputFramesMutex.lock();
-	}
-
-	void unlockInputFrames()
-	{
-		m_inputFramesMutex.unlock();
-	}
-
-	void lockPlayHandleRemoval()
-	{
-		m_playHandleRemovalMutex.lock();
-	}
-
-	void unlockPlayHandleRemoval()
-	{
-		m_playHandleRemovalMutex.unlock();
-	}
 
 	void getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & peakLeft, float & peakRight ) const;
 
@@ -417,11 +394,6 @@ private:
 	// MIDI device stuff
 	MidiClient * m_midiClient;
 	QString m_midiClientName;
-
-	// mutexes
-	QMutex m_inputFramesMutex;
-	QMutex m_playHandleMutex;			// mutex used only for adding playhandles
-	QMutex m_playHandleRemovalMutex;
 
 	// FIFO stuff
 	fifo * m_fifo;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -143,7 +143,7 @@ void Song::masterVolumeChanged()
 
 void Song::setTempo()
 {
-	Engine::mixer()->lockPlayHandleRemoval();
+	Engine::mixer()->requestChangeInModel();
 	const bpm_t tempo = ( bpm_t ) m_tempoModel.value();
 	PlayHandleList & playHandles = Engine::mixer()->playHandles();
 	for( PlayHandleList::Iterator it = playHandles.begin();
@@ -157,7 +157,7 @@ void Song::setTempo()
 			nph->unlock();
 		}
 	}
-	Engine::mixer()->unlockPlayHandleRemoval();
+	Engine::mixer()->doneChangeInModel();
 
 	Engine::updateFramesPerTick();
 


### PR DESCRIPTION
Some locks are removed from the mixer operation. The functions `requestChangeInModel()` and `doneChangeInModel()` now work almost like `lock()` and `unlock()`, but for the mixer they do nothing. This fixes a freeze when using the metronome.
`hasNotePlayHandles()` is dropped because it is unused.