### PR TITLE
fix midi sustain not working with sf2 player

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -581,11 +581,6 @@ void sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		SF2PluginData * pluginData = static_cast<SF2PluginData *>( _n->m_pluginData );
 		pluginData->offset = _n->framesBeforeRelease();
 		pluginData->isNew = false;
-		
-		m_playingNotesMutex.lock();
-		m_playingNotes.append( _n );
-		m_playingNotesMutex.unlock();
-
 	}
 }
 


### PR DESCRIPTION
Removed the appendage of the NotePlayHandle to the PlayingNotes array when a sustained note is released because is not needed and is causing the bug.
fixes #2758