### PR TITLE
Fix infinite loop in FxMixer and some resource releases

### DIFF
--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -201,7 +201,6 @@ private:
 
 	// make sure we have at least num channels
 	void allocateChannelsTo(int num);
-	QMutex m_sendsMutex;
 
 	int m_lastSoloed;
 

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -30,8 +30,6 @@
 #include <QStackedLayout>
 #include <QScrollArea>
 
-#include "FxLine.h"
-#include "FxMixer.h"
 #include "ModelView.h"
 #include "Engine.h"
 #include "Fader.h"

--- a/src/core/JournallingObject.cpp
+++ b/src/core/JournallingObject.cpp
@@ -135,6 +135,7 @@ void JournallingObject::changeID( jo_id_t _id )
 			return;
 		}
 
+		Engine::projectJournal()->freeID( m_id );
 		Engine::projectJournal()->reallocID( _id, this );
 		m_id = _id;
 	}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -25,6 +25,7 @@
 #include "Song.h"
 #include <QTextStream>
 #include <QCoreApplication>
+#include <QDebug>
 #include <QFile>
 #include <QFileInfo>
 #include <QMessageBox>

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -341,7 +341,10 @@ void MidiPort::updateMidiPortMode()
 	emit writablePortsChanged();
 	emit modeChanged();
 
-	Engine::getSong()->setModified();
+	if( Engine::getSong() )
+	{
+		Engine::getSong()->setModified();
+	}
 }
 
 

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -41,6 +41,8 @@
 #include "Knob.h"
 #include "Engine.h"
 #include "embed.h"
+#include "FxLine.h"
+#include "FxMixer.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
 #include "Mixer.h"

--- a/src/gui/widgets/EffectRackView.cpp
+++ b/src/gui/widgets/EffectRackView.cpp
@@ -84,12 +84,12 @@ EffectRackView::~EffectRackView()
 
 void EffectRackView::clearViews()
 {
-	for( QVector<EffectView *>::Iterator it = m_effectViews.begin();
-					it != m_effectViews.end(); ++it )
+	while( m_effectViews.size() )
 	{
-		delete *it;
+		EffectView * e = m_effectViews[m_effectViews.size() - 1];
+		m_effectViews.pop_back();
+		delete e;
 	}
-	m_effectViews.clear();
 }
 
 


### PR DESCRIPTION
This commit fixes the following:

* An infinite loop that can be observed when loading twice `Greippi - Krem Kaakkuja (Second Flight Remix).mmpz` and the CPU meter going full.
* In this scenario, LMMS does not close correctly; the commit fixes the spotted problems.
* One mutex used in the normal mixing process is removed.
* Clean-up of `FxMixerView.h`.