### PR TITLE
Split journal ID range between new and loaded elements

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -76,6 +76,8 @@ public:
 		reallocID( _id, NULL );
 	}
 
+	static jo_id_t idToSave( jo_id_t id );
+
 	void clearJournal();
 	void stopAllJournalling();
 	JournallingObject * journallingObject( const jo_id_t _id )

--- a/include/ProjectNotes.h
+++ b/include/ProjectNotes.h
@@ -29,7 +29,7 @@
 #include <QMainWindow>
 #include <QCloseEvent>
 
-#include "JournallingObject.h"
+#include "SerializingObject.h"
 
 class QAction;
 class QComboBox;

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -28,6 +28,7 @@
 #include "ControllerConnection.h"
 #include "lmms_math.h"
 #include "Mixer.h"
+#include "ProjectJournal.h"
 
 float AutomatableModel::s_copiedValue = 0;
 long AutomatableModel::s_periodCounter = 0;
@@ -98,7 +99,7 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 		// scale type also needs an extra value
 		// => it must be appended as a node
 		QDomElement me = doc.createElement( name );
-		me.setAttribute( "id", id() );
+		me.setAttribute( "id", ProjectJournal::idToSave( id() ) );
 		me.setAttribute( "value", m_value );
 		me.setAttribute( "scale_type", m_scaleType == Logarithmic ? "log" : "linear" );
 		element.appendChild( me );

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -535,7 +535,8 @@ void AutomationPattern::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		if( *it )
 		{
 			QDomElement element = _doc.createElement( "object" );
-			element.setAttribute( "id", ( *it )->id() );
+			element.setAttribute( "id",
+				ProjectJournal::idToSave( ( *it )->id() ) );
 			_this.appendChild( element );
 		}
 	}

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -29,6 +29,8 @@
 #include "JournallingObject.h"
 #include "Song.h"
 
+static const int EO_ID_MSB = 1 << 23;
+
 const int ProjectJournal::MAX_UNDO_STATES = 100; // TODO: make this configurable in settings
 
 ProjectJournal::ProjectJournal() :
@@ -131,11 +133,9 @@ void ProjectJournal::addJournalCheckPoint( JournallingObject *jo )
 
 jo_id_t ProjectJournal::allocID( JournallingObject * _obj )
 {
-	const jo_id_t EO_ID_MAX = (1 << 23)-1;
 	jo_id_t id;
-	while( m_joIDs.contains( id =
-			static_cast<jo_id_t>( (jo_id_t)rand()*(jo_id_t)rand() %
-								 EO_ID_MAX ) ) )
+	for( jo_id_t tid = rand(); m_joIDs.contains( id = tid % EO_ID_MSB
+							| EO_ID_MSB ); tid++ )
 	{
 	}
 
@@ -154,6 +154,14 @@ void ProjectJournal::reallocID( const jo_id_t _id, JournallingObject * _obj )
 	{
 		m_joIDs[_id] = _obj;
 	}
+}
+
+
+
+
+jo_id_t ProjectJournal::idToSave( jo_id_t id )
+{
+	return id & ~EO_ID_MSB;
 }
 
 


### PR DESCRIPTION
Sometimes when loading projects like `Greippi - Krem Kaakkuja (Second Flight Remix).mmpz`, there are ID collisions and messages like `JO-ID %d already in use by %s!`. This may affect automation. To solve this, the range of IDs for new elements is different than for loaded ones. Another improvement is the optimization of assigning a random ID.