### PR TITLE
adds shadow to Subwindow

### DIFF
--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -78,7 +78,8 @@ private:
 	QPoint m_position;
 	QRect m_trackedNormalGeom;
 	QLabel * m_windowTitle;
-	QGraphicsDropShadowEffect * m_shadow;
+	QLabel * m_titleShadow;
+	QGraphicsDropShadowEffect * m_windowShadow;
 
 	static void elideText( QLabel *label, QString text );
 	bool isMaximized();

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -83,15 +83,20 @@ SubWindow::SubWindow( QWidget *parent, Qt::WindowFlags windowFlags ) :
 	connect( m_restoreBtn, SIGNAL( clicked( bool ) ), this, SLOT( showNormal() ) );
 
 	// QLabel for the window title and the shadow effect
-	m_shadow = new QGraphicsDropShadowEffect();
-	m_shadow->setColor( m_textShadowColor );
-	m_shadow->setXOffset( 1 );
-	m_shadow->setYOffset( 1 );
-
 	m_windowTitle = new QLabel( this );
 	m_windowTitle->setFocusPolicy( Qt::NoFocus );
 	m_windowTitle->setAttribute( Qt::WA_TransparentForMouseEvents, true );
-	m_windowTitle->setGraphicsEffect( m_shadow );
+
+	m_titleShadow = new QLabel( this );
+	m_titleShadow->setFocusPolicy( Qt::NoFocus );
+	m_titleShadow->setAttribute( Qt::WA_TransparentForMouseEvents, true );
+
+	//Shadow effect for the subwindow
+	m_windowShadow = new QGraphicsDropShadowEffect();
+	m_windowShadow->setBlurRadius( 15.0 );
+	m_windowShadow->setColor( QColor( 0, 0, 0, 255 ) );
+	m_windowShadow->setOffset( 0 );
+	SubWindow::setGraphicsEffect( m_windowShadow );
 }
 
 
@@ -267,6 +272,11 @@ void SubWindow::resizeEvent( QResizeEvent * event )
 	m_windowTitle->setFixedWidth( widget()->width() - ( menuButtonSpace + buttonBarWidth ) );
 	m_windowTitle->move( menuButtonSpace,
 		( m_titleBarHeight / 2 ) - ( m_windowTitle->sizeHint().height() / 2 ) - 1 );
+	m_titleShadow->setAlignment( Qt::AlignHCenter );
+	m_titleShadow->setFixedWidth( widget()->width() - ( menuButtonSpace + buttonBarWidth ) + 1 );
+	m_titleShadow->move( menuButtonSpace,
+		( m_titleBarHeight / 2 ) - ( m_windowTitle->sizeHint().height() / 2 )  );
+	m_titleShadow->setStyleSheet( "color: black" );
 
 	// if minimized we can't use widget()->width(). We have to hard code the width,
 	// as the width of all minimized windows is the same.
@@ -274,12 +284,17 @@ void SubWindow::resizeEvent( QResizeEvent * event )
 	{
 		m_restoreBtn->move(  m_maximizeBtn->isHidden() ?  middleButtonPos : leftButtonPos );
 		m_windowTitle->setFixedWidth( 120 );
+		m_titleShadow->setFixedWidth( 120 );
 	}
 
 	// truncate the label string if the window is to small. Adds "..."
 	elideText( m_windowTitle, widget()->windowTitle() );
+	elideText( m_titleShadow, widget()->windowTitle() );
 	m_windowTitle->setTextInteractionFlags( Qt::NoTextInteraction );
 	m_windowTitle->adjustSize();
+	m_titleShadow->setTextInteractionFlags( Qt::NoTextInteraction );
+	m_titleShadow->adjustSize();
+	m_windowTitle->raise();
 
 	QMdiSubWindow::resizeEvent( event );
 


### PR DESCRIPTION
See discussion on https://github.com/LMMS/lmms/issues/2867

I had to fake the title label shadow with a second QLabel with black color. There seems to be a bug in Qt that makes the QLabel disappear if the drop shadow is on it and we add another drop shadow to the subwindow.

![subwindowshaddow2](https://cloud.githubusercontent.com/assets/6502580/16379727/8adf79fc-3c73-11e6-88b0-5154c541b702.png)
