### PR TITLE
Fix freeze when finishing export

### DIFF
--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -33,6 +33,7 @@
 #define ALSA_PCM_NEW_HW_PARAMS_API
 
 #include <alsa/asoundlib.h>
+#include <QThread>
 
 #include "AudioDevice.h"
 

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -25,17 +25,15 @@
 #ifndef AUDIO_DEVICE_H
 #define AUDIO_DEVICE_H
 
-#include <QtCore/QPair>
 #include <QtCore/QMutex>
-#include <QtCore/QThread>
 #include <samplerate.h>
 
 #include "lmms_basics.h"
-#include "TabWidget.h"
 
 
 class AudioPort;
 class Mixer;
+class QThread;
 
 
 class AudioDevice
@@ -134,6 +132,8 @@ protected:
 	}
 
 	bool hqAudio() const;
+
+	static void stopProcessingThread( QThread * thread );
 
 
 protected:

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -84,11 +84,7 @@ private:
 
 	virtual void stopProcessing()
 	{
-		if( isRunning() )
-		{
-			wait( 1000 );
-			terminate();
-		}
+		stopProcessingThread( this );
 	}
 
 	virtual void run()

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -29,6 +29,8 @@
 
 #ifdef LMMS_HAVE_OSS
 
+#include <QThread>
+
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
 

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -30,6 +30,7 @@
 #ifdef LMMS_HAVE_PULSEAUDIO
 
 #include <pulse/pulseaudio.h>
+#include <QThread>
 
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -5,6 +5,7 @@
 
 #ifdef LMMS_HAVE_SNDIO
 
+#include <QThread>
 #include <sndio.h>
 
 #include "AudioDevice.h"

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -331,6 +331,8 @@ private:
 
 		virtual void run();
 
+		void write( surroundSampleFrame * buffer );
+
 	} ;
 
 
@@ -347,6 +349,7 @@ private:
 
 	const surroundSampleFrame * renderNextBuffer();
 
+	void clearInternal();
 
 	void runChangesInModel();
 
@@ -402,6 +405,8 @@ private:
 	MixerProfiler m_profiler;
 
 	bool m_metronomeActive;
+
+	bool m_clearSignal;
 
 	bool m_changesSignal;
 	bool m_waitForMixer;

--- a/include/fifo_buffer.h
+++ b/include/fifo_buffer.h
@@ -57,6 +57,18 @@ public:
 		m_reader_sem.release();
 	}
 
+	bool tryWrite( T _element )
+	{
+		if( m_writer_sem.tryAcquire() )
+		{
+			m_buffer[m_writer_index++] = _element;
+			m_writer_index %= m_size;
+			m_reader_sem.release();
+			return true;
+		}
+		return false;
+	}
+
 	T read()
 	{
 		m_reader_sem.acquire();

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -245,11 +245,7 @@ void AudioAlsa::startProcessing()
 
 void AudioAlsa::stopProcessing()
 {
-	if( isRunning() )
-	{
-		wait( 1000 );
-		terminate();
-	}
+	stopProcessingThread( this );
 }
 
 

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -131,6 +131,22 @@ void AudioDevice::stopProcessing()
 
 
 
+void AudioDevice::stopProcessingThread( QThread * thread )
+{
+	if( !thread->wait( 30000 ) )
+	{
+		fprintf( stderr, "Terminating audio device thread\n" );
+		thread->terminate();
+		if( !thread->wait( 1000 ) )
+		{
+			fprintf( stderr, "Thread not terminated yet\n" );
+		}
+	}
+}
+
+
+
+
 void AudioDevice::applyQualitySettings()
 {
 	src_delete( m_srcState );

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -255,11 +255,7 @@ void AudioOss::startProcessing()
 
 void AudioOss::stopProcessing()
 {
-	if( isRunning() )
-	{
-		wait( 1000 );
-		terminate();
-	}
+	stopProcessingThread( this );
 }
 
 

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -105,11 +105,7 @@ void AudioPulseAudio::startProcessing()
 
 void AudioPulseAudio::stopProcessing()
 {
-	if( isRunning() )
-	{
-		wait( 1000 );
-		terminate();
-	}
+	stopProcessingThread( this );
 }
 
 

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -114,11 +114,7 @@ void AudioSndio::startProcessing( void )
 
 void AudioSndio::stopProcessing( void )
 {
-	if( isRunning() )
-	{
-		wait( 1000 );
-		terminate();
-	}
+	stopProcessingThread( this );
 }
 
 


### PR DESCRIPTION
This fixes #2874. It also fixes restarting threaded audio back ends, such as the ALSA one, after the export. Calls to [`terminate()`](http://doc.qt.io/qt-4.8/qthread.html#terminate) should be avoided.