### PR TITLE
Fixes a bug with the beat+bassline editor

### DIFF
--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -89,10 +89,12 @@ public slots:
 protected slots:
 	void dropEvent(QDropEvent * de );
 	void updatePosition();
+	void postTrackWasAdded(Track * track);
 
 private:
 	BBTrackContainer * m_bbtc;
 	void makeSteps( bool clone );
+	void resizeNewTrack(Track * track);
 };
 
 

--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -94,6 +94,7 @@ protected slots:
 private:
 	BBTrackContainer * m_bbtc;
 	void makeSteps( bool clone );
+	// Resizes a newly added track to match size of pre-existing tracks in the BB
 	void resizeNewTrack(Track * track);
 };
 

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -121,6 +121,9 @@ public:
 	using Model::dataChanged;
 
 
+	const int getSteps() const;
+
+
 protected:
 	void ensureBeatNotes();
 	void updateBBTrack();

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -67,7 +67,7 @@ public:
 	void addTrack( Track * _track );
 	void removeTrack( Track * _track );
 
-	virtual void updateAfterTrackAdd();
+	virtual void updateAfterTrackAdd( Track * track );
 
 	void clearAllTracks();
 
@@ -96,6 +96,7 @@ public:
 
 signals:
 	void trackAdded( Track * _track );
+	void postTrackAdded( Track * _track );
 
 protected:
 	mutable QReadWriteLock m_tracksMutex;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1956,7 +1956,7 @@ Track * Track::create( TrackTypes tt, TrackContainer * tc )
 		default: break;
 	}
 
-	tc->updateAfterTrackAdd();
+	tc->updateAfterTrackAdd(t);
 
 	return t;
 }

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -199,8 +199,9 @@ void TrackContainer::removeTrack( Track * _track )
 
 
 
-void TrackContainer::updateAfterTrackAdd()
+void TrackContainer::updateAfterTrackAdd( Track * track )
 {
+	emit postTrackAdded( track );
 }
 
 

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -333,14 +333,12 @@ void BBTrackContainerView::resizeNewTrack(Track * track)
 		if( ( *it )->type() == Track::InstrumentTrack &&
 			( *it ) != track )
 		{
-			std::cout << m_bbtc->currentBB() << std::endl;
 			Pattern* p = static_cast<Pattern *>( ( *it )->getTCO( m_bbtc->currentBB() ) );
 			steps = p->getSteps();
 			break;
 		}
 	}
 
-	std::cout << m_bbtc->currentBB() << std::endl;
 	Pattern* p = static_cast<Pattern *>( track->getTCO( m_bbtc->currentBB() ) );
 
 	// If the track already has the same amount of steps, no need to resize

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -319,41 +319,44 @@ void BBTrackContainerView::resizeNewTrack(Track * track)
 		return;
 	}
 
-	// Ensure that the newly added track has a TCO
+	// Ensure that the newly added track has at least one TCO
 	m_bbtc->updateAfterTrackAdd();
 
-	// Default a single tact if there does not exist tracks in the Beat/Baseline
-	// editor
-	int steps = MidiTime::stepsPerTact();
-
-	// get size of pre-existing track
-	for( TrackContainer::TrackList::iterator it = tl.begin();
-		it != tl.end(); ++it)
+	for(unsigned int currentBB=0; currentBB < m_bbtc->numOfBBs(); ++currentBB)
 	{
-		if( ( *it )->type() == Track::InstrumentTrack &&
-			( *it ) != track )
+		// Default a single tact if there does not exist tracks in the Beat/Baseline
+		// editor
+		int steps = MidiTime::stepsPerTact();
+
+		// get size of pre-existing track
+		for( TrackContainer::TrackList::iterator it = tl.begin();
+			it != tl.end(); ++it)
 		{
-			Pattern* p = static_cast<Pattern *>( ( *it )->getTCO( m_bbtc->currentBB() ) );
-			steps = p->getSteps();
-			break;
+			if( ( *it )->type() == Track::InstrumentTrack &&
+				( *it ) != track )
+			{
+				Pattern* p = static_cast<Pattern *>( ( *it )->getTCO( currentBB ) );
+				steps = p->getSteps();
+				break;
+			}
 		}
-	}
 
-	Pattern* p = static_cast<Pattern *>( track->getTCO( m_bbtc->currentBB() ) );
+		Pattern* p = static_cast<Pattern *>( track->getTCO( currentBB ) );
 
-	// If the track already has the same amount of steps, no need to resize
-	// (For example, when cloning a track)
-	if(p->getSteps() == steps)
-	{
-		return;
-	}
+		// If the track already has the same amount of steps, no need to resize
+		// (For example, when cloning a track)
+		if(p->getSteps() == steps)
+		{
+			continue;
+		}
 
-	// convert steps to tacts
-	int tacts = steps / MidiTime::stepsPerTact();
+		// convert steps to tacts
+		int tacts = steps / MidiTime::stepsPerTact();
 
-	// A newly created track has 1 tact, so increment tacts by "tacts - 1"
-	while(--tacts > 0)
-	{
-		p->addSteps();
+		// A newly created track has 1 tact, so increment tacts by "tacts - 1"
+		while(--tacts > 0)
+		{
+			p->addSteps();
+		}
 	}
 }

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -541,6 +541,13 @@ TrackContentObjectView * Pattern::createView( TrackView * _tv )
 
 
 
+const int Pattern::getSteps() const
+{
+	return m_steps;
+}
+
+
+
 
 void Pattern::ensureBeatNotes()
 {


### PR DESCRIPTION
Before, adding a new track to the beat+bassline editor would have the default size regardless
of the width of other tracks.

This change fixes this, where the newly added track will have the
same width as existing ones.

This bug is mentioned in issue #2476 .