### PR TITLE
Fixes newly added tracks in BB having wrong size

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -65,6 +65,26 @@ Pattern::Pattern( InstrumentTrack * _instrument_track ) :
 	m_steps( MidiTime::stepsPerTact() )
 {
 	setName( _instrument_track->name() );
+
+	// Resize this track to be the same as existing tracks in the BB
+	const TrackContainer::TrackList & tracks =
+		m_instrumentTrack->trackContainer()->tracks();
+	for(unsigned int trackID = 0; trackID < tracks.size(); ++trackID)
+	{
+		if(tracks.at(trackID)->type() == Track::InstrumentTrack)
+		{
+			if(tracks.at(trackID) != m_instrumentTrack)
+			{
+				unsigned int currentTCO = m_instrumentTrack->
+					getTCOs().indexOf(this);
+				m_steps = static_cast<Pattern *>
+					(tracks.at(trackID)->getTCO(currentTCO))
+					->m_steps;
+			}
+			break;
+		}
+	}
+
 	init();
 	setAutoResize( true );
 }


### PR DESCRIPTION
This PR is technically a continuation of https://github.com/LMMS/lmms/pull/2880 , with better fixes made as suggested by @jasp00 .

This bug is mentioned in issue #2476 .