### PR TITLE
Fix fault on note off and remove one mutex for notes

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -234,7 +234,6 @@ private:
 	MidiPort m_midiPort;
 
 	NotePlayHandle* m_notes[NumKeys];
-	QMutex m_notesMutex;
 
 	int m_runningMidiNotes[NumKeys];
 	QMutex m_midiNotesMutex;


### PR DESCRIPTION
This fixes a segmentation fault that could happen on note off, when a master note was finished before subnotes went off. This happened in the scenario described in #2886. There was also an increase in CPU usage, which I guess were note resources that were not released. @mamins1376 or @zonkmachine, could you confirm if that issue is fixed too?