### PR TITLE
Split BBEditor and BBContainerView out into two pieces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /plugins/zynaddsubfx/zynaddsubfx/doc/Makefile
 /plugins/zynaddsubfx/zynaddsubfx/doc/gen/Makefile
 /data/locale/*.qm
+.idea

--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -27,8 +27,7 @@
 #define BB_EDITOR_H
 
 #include "Editor.h"
-#include "TrackContainerView.h"
-
+#include "BBTrackContainerView.h"
 
 class BBTrackContainer;
 class ComboBox;
@@ -40,6 +39,7 @@ class BBEditor : public Editor
 	Q_OBJECT
 public:
 	BBEditor( BBTrackContainer * _tc );
+	BBEditor( BBTrackContainer * _tc, BBTrackContainerView * _tcView );
 	~BBEditor();
 
 	QSize sizeHint() const;
@@ -58,42 +58,10 @@ public slots:
 	void stop();
 
 private:
+	void initialize(BBTrackContainer * _tc);
+
 	BBTrackContainerView* m_trackContainerView;
 	ComboBox * m_bbComboBox;
 } ;
-
-
-
-class BBTrackContainerView : public TrackContainerView
-{
-	Q_OBJECT
-public:
-	BBTrackContainerView(BBTrackContainer* tc);
-
-	bool fixedTCOs() const
-	{
-		return true;
-	}
-
-	void removeBBView(int bb);
-
-	void saveSettings(QDomDocument& doc, QDomElement& element);
-	void loadSettings(const QDomElement& element);
-
-public slots:
-	void addSteps();
-	void cloneSteps();
-	void removeSteps();
-	void addAutomationTrack();
-
-protected slots:
-	void dropEvent(QDropEvent * de );
-	void updatePosition();
-
-private:
-	BBTrackContainer * m_bbtc;
-	void makeSteps( bool clone );
-};
-
 
 #endif

--- a/include/BBTrackContainerView.h
+++ b/include/BBTrackContainerView.h
@@ -1,0 +1,42 @@
+//
+// Created by Nicholas Wertzberger on 7/4/16.
+//
+
+#ifndef LMMS_BBTRACKCONTAINERVIEW_H
+#define LMMS_BBTRACKCONTAINERVIEW_H
+
+#include "TrackContainerView.h"
+#include "BBTrackContainer.h"
+
+class BBTrackContainerView : public TrackContainerView
+{
+	Q_OBJECT
+public:
+	BBTrackContainerView(BBTrackContainer* tc);
+
+	bool fixedTCOs() const
+	{
+		return true;
+	}
+
+	void removeBBView(int bb);
+
+	void saveSettings(QDomDocument& doc, QDomElement& element);
+	void loadSettings(const QDomElement& element);
+
+public slots:
+	void addSteps();
+	void cloneSteps();
+	void removeSteps();
+	void addAutomationTrack();
+
+protected slots:
+	void dropEvent(QDropEvent * de );
+	void updatePosition();
+
+private:
+	BBTrackContainer * m_bbtc;
+	void makeSteps( bool clone );
+};
+
+#endif //LMMS_BBTRACKCONTAINERVIEW_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,7 @@ IF(CMAKE_VERSION VERSION_GREATER "2.8.7")
 		${LMMS_INCLUDES}
 		${LMMS_UI_OUT}
 		${LMMS_ER_H}
-	)
+			gui/editors/BBTrackContainerView.cpp ../include/BBTrackContainerView.h)
 	ADD_EXECUTABLE(lmms
 		core/main.cpp
 		$<TARGET_OBJECTS:lmmsobjs>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -105,6 +105,7 @@ MainWindow::MainWindow() :
 	emit initProgress(tr("Preparing plugin browser"));
 	sideBar->appendTab( new PluginBrowser( splitter ) );
 	emit initProgress(tr("Preparing file browsers"));
+	
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userProjectsDir() + "*" +
 				confMgr->factoryProjectsDir(),
@@ -112,12 +113,14 @@ MainWindow::MainWindow() :
 							tr( "My Projects" ),
 					embed::getIconPixmap( "project_file" ).transformed( QTransform().rotate( 90 ) ),
 							splitter, false, true ) );
+	
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userSamplesDir() + "*" +
 				confMgr->factorySamplesDir(),
 					"*", tr( "My Samples" ),
 					embed::getIconPixmap( "sample_file" ).transformed( QTransform().rotate( 90 ) ),
 							splitter, false, true ) );
+	
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userPresetsDir() + "*" +
 				confMgr->factoryPresetsDir(),
@@ -125,6 +128,7 @@ MainWindow::MainWindow() :
 					tr( "My Presets" ),
 					embed::getIconPixmap( "preset_file" ).transformed( QTransform().rotate( 90 ) ),
 							splitter , false, true  ) );
+	
 	sideBar->appendTab( new FileBrowser( QDir::homePath(), "*",
 							tr( "My Home" ),
 					embed::getIconPixmap( "home" ).transformed( QTransform().rotate( 90 ) ),
@@ -1416,9 +1420,6 @@ void MainWindow::keyPressEvent( QKeyEvent * _ke )
 	}
 }
 
-
-
-
 void MainWindow::keyReleaseEvent( QKeyEvent * _ke )
 {
 	switch( _ke->key() )
@@ -1427,11 +1428,11 @@ void MainWindow::keyReleaseEvent( QKeyEvent * _ke )
 		case Qt::Key_Shift: m_keyMods.m_shift = false; break;
 		case Qt::Key_Alt: m_keyMods.m_alt = false; break;
 		default:
-			if( InstrumentTrackView::topLevelInstrumentTrackWindow() )
-			{
-				InstrumentTrackView::topLevelInstrumentTrackWindow()->
-					pianoView()->keyReleaseEvent( _ke );
-			}
+            InstrumentTrackWindow *pInstrumentTrackWindow = InstrumentTrackView::topLevelInstrumentTrackWindow();
+            if(pInstrumentTrackWindow)
+            {
+                pInstrumentTrackWindow->pianoView()->keyReleaseEvent(_ke );
+            }
 			if( !_ke->isAccepted() )
 			{
 				QMainWindow::keyReleaseEvent( _ke );
@@ -1439,16 +1440,10 @@ void MainWindow::keyReleaseEvent( QKeyEvent * _ke )
 	}
 }
 
-
-
-
 void MainWindow::timerEvent( QTimerEvent * _te)
 {
 	emit periodicUpdate();
 }
-
-
-
 
 void MainWindow::fillTemplatesMenu()
 {

--- a/src/gui/editors/BBTrackContainerView.cpp
+++ b/src/gui/editors/BBTrackContainerView.cpp
@@ -1,0 +1,142 @@
+//
+// Created by Nicholas Wertzberger on 7/4/16.
+//
+
+#include <include/Pattern.h>
+#include <include/MainWindow.h>
+#include <include/StringPairDrag.h>
+#include "BBTrackContainerView.h"
+
+
+BBTrackContainerView::BBTrackContainerView(BBTrackContainer* tc) :
+		TrackContainerView(tc),
+		m_bbtc(tc)
+{
+	setModel( tc );
+}
+
+
+
+
+void BBTrackContainerView::addSteps()
+{
+	printf("BBTrackContainerView::addSteps()\n");
+	makeSteps( false );
+}
+
+void BBTrackContainerView::cloneSteps()
+{
+	printf("BBTrackContainerView::cloneSteps()\n");
+	makeSteps( true );
+}
+
+
+
+
+void BBTrackContainerView::removeSteps()
+{
+	printf("BBTrackContainerView::removeSteps()\n");
+	TrackContainer::TrackList tl = model()->tracks();
+
+	for( TrackContainer::TrackList::iterator it = tl.begin(); it != tl.end(); ++it )
+	{
+		if( ( *it )->type() == Track::InstrumentTrack )
+		{
+			Pattern* p = static_cast<Pattern *>( ( *it )->getTCO( m_bbtc->currentBB() ) );
+			p->removeSteps();
+		}
+	}
+}
+
+
+
+
+void BBTrackContainerView::addAutomationTrack()
+{
+	printf("BBTrackContainerView::addAutomationTrack()\n");
+	(void) Track::create( Track::AutomationTrack, model() );
+}
+
+
+
+
+void BBTrackContainerView::removeBBView(int bb)
+{
+	for( TrackView* view : trackViews() )
+	{
+		view->getTrackContentWidget()->removeTCOView( bb );
+	}
+}
+
+
+
+void BBTrackContainerView::saveSettings(QDomDocument& doc, QDomElement& element)
+{
+	printf("BBTrackContainerView::saveSettings()\n");
+	MainWindow::saveWidgetState(parentWidget(), element, QSize( 640, 400 ) );
+}
+
+void BBTrackContainerView::loadSettings(const QDomElement& element)
+{
+	printf("BBTrackContainerView::loadSettings()\n");
+	MainWindow::restoreWidgetState(parentWidget(), element);
+}
+
+
+
+
+void BBTrackContainerView::dropEvent(QDropEvent* de)
+{
+	printf("BBTrackContainerView::dropEvent()\n");
+	QString type = StringPairDrag::decodeKey( de );
+	QString value = StringPairDrag::decodeValue( de );
+
+	if( type.left( 6 ) == "track_" )
+	{
+		DataFile dataFile( value.toUtf8() );
+		Track * t = Track::create( dataFile.content().firstChild().toElement(), model() );
+
+		t->deleteTCOs();
+		m_bbtc->updateAfterTrackAdd();
+
+		de->accept();
+	}
+	else
+	{
+		TrackContainerView::dropEvent( de );
+	}
+}
+
+
+
+
+void BBTrackContainerView::updatePosition()
+{
+	printf("BBTrackContainerView::updatePosition()\n");
+	//realignTracks();
+	emit positionChanged( m_currentPosition );
+}
+
+
+
+
+void BBTrackContainerView::makeSteps( bool clone )
+{
+	printf("BBTrackContainerView::makeSteps(%s)\n", clone ? "true" : "false");
+	TrackContainer::TrackList tl = model()->tracks();
+
+	for( TrackContainer::TrackList::iterator it = tl.begin(); it != tl.end(); ++it )
+	{
+		if( ( *it )->type() == Track::InstrumentTrack )
+		{
+			Pattern* p = static_cast<Pattern *>( ( *it )->getTCO( m_bbtc->currentBB() ) );
+			if( clone )
+			{
+				p->cloneSteps();
+			} else
+			{
+				p->addSteps();
+			}
+		}
+	}
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ ADD_EXECUTABLE(tests
 	$<TARGET_OBJECTS:lmmsobjs>
 
 	src/core/ProjectVersionTest.cpp
-)
+	src/gui/MainWindowTest.cpp
+	src/gui/editors/BBEditorTest.cpp)
 TARGET_LINK_LIBRARIES(tests ${QT_LIBRARIES} ${QT_QTTEST_LIBRARY})
 TARGET_LINK_LIBRARIES(tests ${LMMS_REQUIRED_LIBS})

--- a/tests/src/gui/MainWindowTest.cpp
+++ b/tests/src/gui/MainWindowTest.cpp
@@ -1,0 +1,20 @@
+//
+// Created by Nicholas Wertzberger on 6/30/16.
+//
+
+#include "QTestSuite.h"
+#include "MainWindow.h"
+
+class MainWindowTest : QTestSuite
+{
+    Q_OBJECT
+private slots:
+
+    void KeyPressEventTest()
+    {
+        // TODO
+    }
+
+} MainWindowTests;
+
+#include "MainWindowTest.moc"

--- a/tests/src/gui/editors/BBEditorTest.cpp
+++ b/tests/src/gui/editors/BBEditorTest.cpp
@@ -1,0 +1,22 @@
+//
+// Created by Nicholas Wertzberger on 7/4/16.
+//
+
+#include "QTestSuite.h"
+#include "BBEditor.h"
+
+class BBEditorTest : QTestSuite
+{
+    Q_OBJECT
+private slots:
+
+    void AddTrack_AddsTracksInCorrectOrder()
+    {
+        //BBEditor * editor = new BBEditor((BBTrackContainer *) NULL);
+
+        //delete editor;
+    }
+
+} BBEditorTests;
+
+#include "BBEditorTest.moc"


### PR DESCRIPTION
So in order to get familiar with the codebase, I'm trying to do something:
- I'm trying to fix a bug where when you add a track, it doesn't put the track in with the same number of beats as the other tracks.
- I'm trying to capture the issue in a test, so that the quality of the code goes up.

In the process of trying to make things testable, I saw two classes in the same header file and source file. I split them out, because I only wanted to test one of them. Let me know if anything I did looks bad to you.

You can deny this pull request if you don't like something, there's no functionality yet. I just wanted to make sure this looked like the sort of stuff that you'd want committed in the future.
