### PR TITLE
Fix #2698 - hang on start

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -128,7 +128,7 @@ MainWindow::MainWindow() :
 	sideBar->appendTab( new FileBrowser( QDir::homePath(), "*",
 							tr( "My Home" ),
 					embed::getIconPixmap( "home" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, false, true ) );
+							splitter, false, false ) );
 
 
 	QStringList root_paths;


### PR DESCRIPTION
Fixes #2698 by turning off the `recurse` parameter in order to stop LMMS from scanning subdirectories when starting, as suggested by @michaelgregorius.