### PR TITLE
Fix #2698 ("LMMS scans entire home directory on first launch")

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -128,7 +128,7 @@ MainWindow::MainWindow() :
 	sideBar->appendTab( new FileBrowser( QDir::homePath(), "*",
 							tr( "My Home" ),
 					embed::getIconPixmap( "home" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, false, true ) );
+							splitter, false, false ) );
 
 
 	QStringList root_paths;


### PR DESCRIPTION
Prevent the recursive loading of directories in the "My Home" folder
list.