### PR TITLE
Auto close the project version mismatch dialog

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -33,6 +33,7 @@
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QTextStream>
+#include <QTimer>
 
 #include "base64.h"
 #include "ConfigManager.h"
@@ -959,9 +960,10 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 			{
 				if( gui != nullptr && root.attribute( "type" ) == "song" )
 				{
-					QMessageBox::information( NULL,
-						SongEditor::tr( "Project Version Mismatch" ),
-						SongEditor::tr( 
+					QMessageBox *mb = new QMessageBox();
+					mb->setWindowTitle( SongEditor::tr( "Project Version Mismatch" ) );
+					mb->setIcon(QMessageBox::Information);
+					mb->setText( SongEditor::tr( 
 								"This %1 was created with "
 								"LMMS version %2, but version %3 "
 								"is installed")
@@ -970,6 +972,8 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
                                                                         SongEditor::tr("project") )
 								.arg( root.attribute( "creatorversion" ) )
 								.arg( LMMS_VERSION ) );
+					QTimer::singleShot(5000, mb, SLOT( close() ) );
+					mb->exec();					
 				}
 			}
 


### PR DESCRIPTION
Reasoning behind this: the Version mismatch dialog blocks out the loading of the song, and as long as the user doesn't click the ok button, the project won't load.

 I found myself just leaving my project load in the foreground, but after that realizing that didn't happen since I didn't click 'Ok' on an information dialog. 

This PR fixes that by adding a 5 second timeout before the message gets automatically closed. If you think the timeout should be longer, let me know.