### PR TITLE
rename tracks directly on TrackLableButton in a QLineEdit

### DIFF
--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -27,6 +27,7 @@
 #define TRACK_LABEL_BUTTON_H
 
 #include <QToolButton>
+#include <QLineEdit>
 
 
 class TrackView;
@@ -42,6 +43,7 @@ public:
 
 public slots:
 	void rename();
+	void renameFinished();
 
 
 protected:
@@ -55,6 +57,7 @@ protected:
 private:
 	TrackView * m_trackView;
 	QString m_iconName;
+	QLineEdit * m_renameLineEdit;
 
 } ;
 

--- a/src/gui/widgets/TrackLabelButton.cpp
+++ b/src/gui/widgets/TrackLabelButton.cpp
@@ -48,21 +48,23 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 
-	if( ConfigManager::inst()->value( "ui",
-					  "compacttrackbuttons" ).toInt() )
+	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
 	{
 		setFixedSize( 32, 29 );
 	}
 	else
 	{
 		setFixedSize( 160, 29 );
+		m_renameLineEdit = new QLineEdit( this );
+		m_renameLineEdit->move( 30, ( height() / 2 ) - ( m_renameLineEdit->sizeHint().height() / 2 ) );
+		m_renameLineEdit->setFixedWidth( width() - 33 );
+		m_renameLineEdit->hide();
+		connect( m_renameLineEdit, SIGNAL( editingFinished() ), this, SLOT( renameFinished() ) );
 	}
 
 	setIconSize( QSize( 24, 24 ) );
 	setText( " " );
-
-	connect( m_trackView->getTrack(), SIGNAL( dataChanged() ),
-					this, SLOT( update() ) );
+	connect( m_trackView->getTrack(), SIGNAL( dataChanged() ), this, SLOT( update() ) );
 }
 
 
@@ -77,12 +79,36 @@ TrackLabelButton::~TrackLabelButton()
 
 void TrackLabelButton::rename()
 {
-	QString txt = m_trackView->getTrack()->name();
-	RenameDialog rename_dlg( txt );
-	rename_dlg.exec();
-	if( txt != text() )
+	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
 	{
-		m_trackView->getTrack()->setName( txt );
+		QString txt = m_trackView->getTrack()->name();
+		RenameDialog rename_dlg( txt );
+		rename_dlg.exec();
+		if( txt != text() )
+		{
+			m_trackView->getTrack()->setName( txt );
+		}
+	}
+	else
+	{
+		QString txt = m_trackView->getTrack()->name();
+		m_renameLineEdit->show();
+		m_renameLineEdit->setText( txt );
+		m_renameLineEdit->selectAll();
+		m_renameLineEdit->setFocus();
+	}
+}
+
+
+
+
+void TrackLabelButton::renameFinished()
+{
+	if( !( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() ) )
+	{
+		m_renameLineEdit->hide();
+		setText( m_renameLineEdit->text() );
+		m_trackView->getTrack()->setName( m_renameLineEdit->text() );
 	}
 }
 
@@ -134,8 +160,7 @@ void TrackLabelButton::paintEvent( QPaintEvent * _pe )
 	if( m_trackView->getTrack()->type() == Track::InstrumentTrack )
 	{
 		InstrumentTrack * it =
-			dynamic_cast<InstrumentTrack *>(
-						m_trackView->getTrack() );
+			dynamic_cast<InstrumentTrack *>( m_trackView->getTrack() );
 		const PixmapLoader * pl;
 		if( it && it->instrument() &&
 			it->instrument()->descriptor() &&
@@ -148,11 +173,10 @@ void TrackLabelButton::paintEvent( QPaintEvent * _pe )
 			}
 		}
 	}
-	if( ConfigManager::inst()->value( "ui",
-					  "compacttrackbuttons" ).toInt() )
+	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
 	{
-		setText("");
-		setToolTip(  m_trackView->getTrack()->displayName() );
+		setText( " " );
+		setToolTip( m_trackView->getTrack()->displayName() );
 	}
 	else
 	{
@@ -160,8 +184,3 @@ void TrackLabelButton::paintEvent( QPaintEvent * _pe )
 	}
 	QToolButton::paintEvent( _pe );
 }
-
-
-
-
-


### PR DESCRIPTION
![renametrack](https://cloud.githubusercontent.com/assets/6502580/16842051/43e81790-49dc-11e6-8247-0399b8fafad4.png)

With this one we can edit the track name directly in the track. This avoids a dialog window. 
