### PR TITLE
Resize only patterns from BB editor

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -135,6 +135,8 @@ protected slots:
 
 
 private:
+	void resizeToFirstTrack();
+
 	InstrumentTrack * m_instrumentTrack;
 
 	PatternTypes m_patternType;

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -65,26 +65,11 @@ Pattern::Pattern( InstrumentTrack * _instrument_track ) :
 	m_steps( MidiTime::stepsPerTact() )
 {
 	setName( _instrument_track->name() );
-
-	// Resize this track to be the same as existing tracks in the BB
-	const TrackContainer::TrackList & tracks =
-		m_instrumentTrack->trackContainer()->tracks();
-	for(unsigned int trackID = 0; trackID < tracks.size(); ++trackID)
+	if( _instrument_track->trackContainer()
+					== Engine::getBBTrackContainer() )
 	{
-		if(tracks.at(trackID)->type() == Track::InstrumentTrack)
-		{
-			if(tracks.at(trackID) != m_instrumentTrack)
-			{
-				unsigned int currentTCO = m_instrumentTrack->
-					getTCOs().indexOf(this);
-				m_steps = static_cast<Pattern *>
-					(tracks.at(trackID)->getTCO(currentTCO))
-					->m_steps;
-			}
-			break;
-		}
+		resizeToFirstTrack();
 	}
-
 	init();
 	setAutoResize( true );
 }
@@ -130,6 +115,31 @@ Pattern::~Pattern()
 	}
 
 	m_notes.clear();
+}
+
+
+
+
+void Pattern::resizeToFirstTrack()
+{
+	// Resize this track to be the same as existing tracks in the BB
+	const TrackContainer::TrackList & tracks =
+		m_instrumentTrack->trackContainer()->tracks();
+	for(unsigned int trackID = 0; trackID < tracks.size(); ++trackID)
+	{
+		if(tracks.at(trackID)->type() == Track::InstrumentTrack)
+		{
+			if(tracks.at(trackID) != m_instrumentTrack)
+			{
+				unsigned int currentTCO = m_instrumentTrack->
+					getTCOs().indexOf(this);
+				m_steps = static_cast<Pattern *>
+					(tracks.at(trackID)->getTCO(currentTCO))
+					->m_steps;
+			}
+			break;
+		}
+	}
 }
 
 


### PR DESCRIPTION
The fix in #2883 resizes patterns from the song editor. This is a bug that creates TCOs in the first instrument track when TCOs are created in another instrument track.