### PR TITLE
rename FxLine directly in a QLineEdit

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -35,6 +35,12 @@ QLineEdit {
 	color: #e0e0e0;
 }
 
+
+QLineEdit:read-only {
+	border-style: none;
+	background: transparent;
+}
+
 /* text box when it wants text */
 
 QLineEdit:focus {

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -32,6 +32,11 @@ QLineEdit {
 	color: #d1d8e4;
 }
 
+QLineEdit:read-only {
+	border-style: none;
+	background: transparent;
+}
+
 /* text box when it wants text */
 
 QLineEdit:focus {

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -26,9 +26,7 @@
 #ifndef FX_LINE_H
 #define FX_LINE_H
 
-#include <QGraphicsScene>
 #include <QGraphicsView>
-#include <QGraphicsProxyWidget>
 #include <QLineEdit>
 #include <QWidget>
 
@@ -96,12 +94,8 @@ private:
 	static QPixmap * s_sendBgArrow;
 	static QPixmap * s_receiveBgArrow;
 	bool m_inRename;
-	QString m_newName;
 	QLineEdit * m_renameLineEdit;
-	QGraphicsProxyWidget * m_proxyWidget;
 	QGraphicsView * m_view;
-	QGraphicsScene * m_scene;
-	QString m_name;
 
 private slots:
 	void renameChannel();

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -26,13 +26,17 @@
 #ifndef FX_LINE_H
 #define FX_LINE_H
 
+#include <QGraphicsScene>
+#include <QGraphicsView>
+#include <QGraphicsProxyWidget>
+#include <QLineEdit>
 #include <QWidget>
-#include <QLabel>
-#include <QStaticText>
 
 #include "Knob.h"
 #include "LcdWidget.h"
 #include "SendButtonIndicator.h"
+
+
 
 class FxMixerView;
 class SendButtonIndicator;
@@ -75,11 +79,11 @@ public:
 	QColor strokeInnerInactive() const;
 	void setStrokeInnerInactive( const QColor & c );
 
-
 	static const int FxLineHeight;
 
 private:
-	void drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name, bool isActive, bool sendToThis, bool receiveFromThis );
+	void drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis );
+	QString elideName( QString name );
 
 	FxMixerView * m_mv;
 	LcdWidget* m_lcd;
@@ -91,17 +95,22 @@ private:
 	QColor m_strokeInnerInactive;
 	static QPixmap * s_sendBgArrow;
 	static QPixmap * s_receiveBgArrow;
-
-	QStaticText m_staticTextName;
+	bool m_inRename;
+	QString m_newName;
+	QLineEdit * m_renameLineEdit;
+	QGraphicsProxyWidget * m_proxyWidget;
+	QGraphicsView * m_view;
+	QGraphicsScene * m_scene;
+	QString m_name;
 
 private slots:
 	void renameChannel();
+	void renameFinished();
 	void removeChannel();
 	void removeUnusedChannels();
 	void moveChannelLeft();
 	void moveChannelRight();
 	void displayHelp();
-
 };
 
 

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -81,7 +81,7 @@ public:
 
 private:
 	void drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis );
-	QString elideName( QString name );
+	QString elideName( const QString & name );
 
 	FxMixerView * m_mv;
 	LcdWidget* m_lcd;

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -105,7 +105,7 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	m_renameLineEdit = new QLineEdit();
 	m_renameLineEdit->setText( name );
 	m_renameLineEdit->setFixedWidth( 65 );
-	m_renameLineEdit->setFont( pointSizeF( FxLine::font(), 7.5f ) );
+	m_renameLineEdit->setFont( pointSizeF( font(), 7.5f ) );
 	m_renameLineEdit->setReadOnly( true );
 
 	QGraphicsScene * scene = new QGraphicsScene();
@@ -193,13 +193,11 @@ QString FxLine::elideName( QString name )
 
 void FxLine::paintEvent( QPaintEvent * )
 {
-	bool sendToThis = Engine::fxMixer()->channelSendModel(
-		m_mv->currentFxLine()->m_channelIndex, m_channelIndex ) != NULL;
-	bool receiveFromThis = Engine::fxMixer()->channelSendModel(
-		m_channelIndex, m_mv->currentFxLine()->m_channelIndex ) != NULL;
+	bool sendToThis = Engine::fxMixer()->channelSendModel( m_mv->currentFxLine()->m_channelIndex, m_channelIndex ) != NULL;
+	bool receiveFromThis = Engine::fxMixer()->channelSendModel( m_channelIndex, m_mv->currentFxLine()->m_channelIndex ) != NULL;
 	QPainter painter;
 	painter.begin( this );
-	drawFxLine( &painter, this,	m_mv->currentFxLine() == this, sendToThis, receiveFromThis );
+	drawFxLine( &painter, this, m_mv->currentFxLine() == this, sendToThis, receiveFromThis );
 	painter.end();
 }
 
@@ -238,7 +236,6 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 		contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "R&emove channel" ), this, SLOT( removeChannel() ) );
 		contextMenu->addSeparator();
 	}
-
 	contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "Remove &unused channels" ), this, SLOT( removeUnusedChannels() ) );
 	contextMenu->addSeparator();
 	contextMenu->addHelpAction();
@@ -322,8 +319,7 @@ void FxLine::moveChannelRight()
 
 void FxLine::displayHelp()
 {
-	QWhatsThis::showText( mapToGlobal( rect().bottomRight() ),
-								whatsThis() );
+	QWhatsThis::showText( mapToGlobal( rect().bottomRight() ), whatsThis() );
 }
 
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -25,6 +25,8 @@
 
 #include "FxLine.h"
 
+#include <QGraphicsProxyWidget>
+#include <QGraphicsScene>
 #include <QPainter>
 #include <QLineEdit>
 #include <QWhatsThis>
@@ -97,28 +99,28 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	"You can remove and move FX channels in the context menu, which is accessed "
 	"by right-clicking the FX channel.\n" ) );
 
-	m_name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
-	setToolTip( m_name );
+	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	setToolTip( name );
 
 	m_renameLineEdit = new QLineEdit();
-	m_renameLineEdit->setText( m_name );
+	m_renameLineEdit->setText( name );
 	m_renameLineEdit->setFixedWidth( 65 );
 	m_renameLineEdit->setFont( pointSizeF( FxLine::font(), 7.5f ) );
 	m_renameLineEdit->setReadOnly( true );
 
-	m_scene = new QGraphicsScene();
-	m_scene->setSceneRect( 0, 0, 33, FxLineHeight );
+	QGraphicsScene * scene = new QGraphicsScene();
+	scene->setSceneRect( 0, 0, 33, FxLineHeight );
 
 	m_view = new QGraphicsView( this );
 	m_view->setStyleSheet( "border-style: none; background: transparent;" );
 	m_view->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	m_view->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	m_view->setAttribute( Qt::WA_TransparentForMouseEvents, true );
-	m_view->setScene( m_scene );
+	m_view->setScene( scene );
 
-	m_proxyWidget = m_scene->addWidget( m_renameLineEdit );
-	m_proxyWidget->setRotation( -90 );
-	m_proxyWidget->setPos( 8, 145 );
+	QGraphicsProxyWidget * proxyWidget = scene->addWidget( m_renameLineEdit );
+	proxyWidget->setRotation( -90 );
+	proxyWidget->setPos( 8, 145 );
 
 	connect( m_renameLineEdit, SIGNAL( editingFinished() ), this, SLOT( renameFinished() ) );
 }
@@ -145,10 +147,10 @@ void FxLine::setChannelIndex( int index )
 
 void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis )
 {
-	m_name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
-	if( !m_inRename && m_renameLineEdit->text() != elideName( m_name ) )
+	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	if( !m_inRename && m_renameLineEdit->text() != elideName( name ) )
 	{
-		m_renameLineEdit->setText( elideName( m_name ) );
+		m_renameLineEdit->setText( elideName( name ) );
 	}
 
 	int width = fxLine->rect().width();
@@ -181,7 +183,7 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool 
 QString FxLine::elideName( QString name )
 {
 	const int maxTextHeight = 70;
-	QFontMetrics metrics( FxLine::font() );
+	QFontMetrics metrics( font() );
 	QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextHeight );
 	return elidedName;
 }
@@ -268,13 +270,13 @@ void FxLine::renameFinished()
 	m_renameLineEdit->setReadOnly( true );
 	m_renameLineEdit->setFixedWidth( 65 );
 	m_lcd->show();
-	m_newName = m_renameLineEdit->text();
+	QString newName = m_renameLineEdit->text();
 	setFocus();
-	if( !m_newName.isEmpty() && Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != m_newName )
+	if( !newName.isEmpty() && Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != newName )
 	{
-		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
-		setToolTip( m_newName );
-		m_renameLineEdit->setText( elideName( m_newName ) );
+		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = newName;
+		setToolTip( newName );
+		m_renameLineEdit->setText( elideName( newName ) );
 		Engine::getSong()->setModified();
 	}
 }

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -272,11 +272,14 @@ void FxLine::renameFinished()
 	setFocus();
 	if( !m_newName.isEmpty() )
 	{
-		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
-		setToolTip( m_newName );
+		if( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != m_newName )
+		{
+			Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
+			setToolTip( m_newName );
+			m_renameLineEdit->setText( elideName( m_newName ) );
+			Engine::getSong()->setModified();
+		}
 	}
-	m_renameLineEdit->setText( elideName( m_newName ) );
-	Engine::getSong()->setModified();
 }
 
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -25,20 +25,20 @@
 
 #include "FxLine.h"
 
-#include <QDebug>
-#include <QInputDialog>
 #include <QPainter>
 #include <QLineEdit>
 #include <QWhatsThis>
 
-#include "FxMixer.h"
-#include "FxMixerView.h"
+#include "CaptionMenu.h"
 #include "embed.h"
 #include "Engine.h"
+#include "FxMixer.h"
+#include "FxMixerView.h"
+#include "gui_templates.h"
 #include "GuiApplication.h"
 #include "SendButtonIndicator.h"
-#include "gui_templates.h"
-#include "CaptionMenu.h"
+#include "Song.h"
+
 
 const int FxLine::FxLineHeight = 287;
 QPixmap * FxLine::s_sendBgArrow = NULL;
@@ -52,13 +52,14 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	m_strokeOuterActive( 0, 0, 0 ),
 	m_strokeOuterInactive( 0, 0, 0 ),
 	m_strokeInnerActive( 0, 0, 0 ),
-	m_strokeInnerInactive( 0, 0, 0 )
+	m_strokeInnerInactive( 0, 0, 0 ),
+	m_inRename( false )
 {
-	if( ! s_sendBgArrow )
+	if( !s_sendBgArrow )
 	{
 		s_sendBgArrow = new QPixmap( embed::getIconPixmap( "send_bg_arrow", 29, 56 ) );
 	}
-	if( ! s_receiveBgArrow )
+	if( !s_receiveBgArrow )
 	{
 		s_receiveBgArrow = new QPixmap( embed::getIconPixmap( "receive_bg_arrow", 29, 56 ) );
 	}
@@ -68,9 +69,9 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 
 	// mixer sends knob
-	m_sendKnob = new Knob( knobBright_26, this, tr("Channel send amount") );
+	m_sendKnob = new Knob( knobBright_26, this, tr( "Channel send amount" ) );
 	m_sendKnob->move( 3, 22 );
-	m_sendKnob->setVisible(false);
+	m_sendKnob->setVisible( false );
 
 	// send button indicator
 	m_sendBtn = new SendButtonIndicator( this, this, m_mv );
@@ -94,11 +95,34 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 	"to the channel.\n\n"
 	
 	"You can remove and move FX channels in the context menu, which is accessed "
-	"by right-clicking the FX channel.\n") );
+	"by right-clicking the FX channel.\n" ) );
 
-	FxMixer * mix = Engine::fxMixer();
-	setToolTip( mix->effectChannel( m_channelIndex )->m_name );
+	m_name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	setToolTip( m_name );
+
+	m_renameLineEdit = new QLineEdit();
+	m_renameLineEdit->setText( m_name );
+	m_renameLineEdit->setFixedWidth( 65 );
+	m_renameLineEdit->setFont( pointSizeF( FxLine::font(), 7.5f ) );
+	m_renameLineEdit->setReadOnly( true );
+
+	m_scene = new QGraphicsScene();
+	m_scene->setSceneRect( 0, 0, 33, FxLineHeight );
+
+	m_view = new QGraphicsView( this );
+	m_view->setStyleSheet( "border-style: none; background: transparent;" );
+	m_view->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	m_view->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+	m_view->setAttribute( Qt::WA_TransparentForMouseEvents, true );
+	m_view->setScene( m_scene );
+
+	m_proxyWidget = m_scene->addWidget( m_renameLineEdit );
+	m_proxyWidget->setRotation( -90 );
+	m_proxyWidget->setPos( 8, 145 );
+
+	connect( m_renameLineEdit, SIGNAL( editingFinished() ), this, SLOT( renameFinished() ) );
 }
+
 
 
 FxLine::~FxLine()
@@ -109,25 +133,26 @@ FxLine::~FxLine()
 }
 
 
-void FxLine::setChannelIndex(int index) {
+void FxLine::setChannelIndex( int index )
+{
 	m_channelIndex = index;
-
 	m_lcd->setValue( m_channelIndex );
 	m_lcd->update();
 }
 
 
-void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name, bool isActive, bool sendToThis, bool receiveFromThis )
+
+
+void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis )
 {
+	m_name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	if( !m_inRename )
+	{
+		m_renameLineEdit->setText( elideName( m_name ) );
+	}
+
 	int width = fxLine->rect().width();
 	int height = fxLine->rect().height();
-
-	QColor sh_color = QApplication::palette().color( QPalette::Active,
-							QPalette::Shadow );
-	QColor te_color = p->pen().brush().color();
-	QColor bt_color = QApplication::palette().color( QPalette::Active,
-							QPalette::BrightText );
-
 
 	p->fillRect( fxLine->rect(), isActive ? fxLine->backgroundActive() : p->background() );
 	
@@ -148,48 +173,35 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, const QString& name,
 	{
 		p->drawPixmap( 2, 0, 29, 56, *s_receiveBgArrow );
 	}
-
-	// draw the channel name
-	if( m_staticTextName.text() != name )
-	{
-		// elide the name of the fxLine when its too long
-		const int maxTextHeight = 78;
-		QFontMetrics metrics( fxLine->font() );
-		QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextHeight );
-		m_staticTextName.setText( elidedName );
-	}
-	p->rotate( -90 );
-
-	p->setFont( pointSizeF( fxLine->font(), 7.5f ) );
-
-	// Coordinates of the foreground text
-	int const textLeft = -145;
-	int const textTop = 9;
-
-	// Draw text shadow
-	p->setPen( sh_color );
-	p->drawStaticText( textLeft - 1, textTop + 1, m_staticTextName );
-	
-	// Draw foreground text
-	p->setPen( isActive ? bt_color : te_color );
-	p->drawStaticText( textLeft, textTop, m_staticTextName );
 }
+
+
+
+
+QString FxLine::elideName( QString name )
+{
+	const int maxTextHeight = 70;
+	QFontMetrics metrics( FxLine::font() );
+	QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextHeight );
+	return elidedName;
+}
+
+
 
 
 void FxLine::paintEvent( QPaintEvent * )
 {
-	FxMixer * mix = Engine::fxMixer();
-	bool sendToThis = mix->channelSendModel(
+	bool sendToThis = Engine::fxMixer()->channelSendModel(
 		m_mv->currentFxLine()->m_channelIndex, m_channelIndex ) != NULL;
-	bool receiveFromThis = mix->channelSendModel(
+	bool receiveFromThis = Engine::fxMixer()->channelSendModel(
 		m_channelIndex, m_mv->currentFxLine()->m_channelIndex ) != NULL;
 	QPainter painter;
 	painter.begin( this );
-	drawFxLine( &painter, this,
-		mix->effectChannel( m_channelIndex )->m_name,
-		m_mv->currentFxLine() == this, sendToThis, receiveFromThis );
+	drawFxLine( &painter, this,	m_mv->currentFxLine() == this, sendToThis, receiveFromThis );
 	painter.end();
 }
+
+
 
 
 void FxLine::mousePressEvent( QMouseEvent * )
@@ -198,16 +210,19 @@ void FxLine::mousePressEvent( QMouseEvent * )
 }
 
 
+
+
 void FxLine::mouseDoubleClickEvent( QMouseEvent * )
 {
 	renameChannel();
 }
 
 
+
+
 void FxLine::contextMenuEvent( QContextMenuEvent * )
 {
-	FxMixer * mix = Engine::fxMixer();
-	QPointer<CaptionMenu> contextMenu = new CaptionMenu( mix->effectChannel( m_channelIndex )->m_name, this );
+	QPointer<CaptionMenu> contextMenu = new CaptionMenu( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name, this );
 	if( m_channelIndex != 0 ) // no move-options in master 
 	{
 		contextMenu->addAction( tr( "Move &left" ),	this, SLOT( moveChannelLeft() ) );
@@ -218,37 +233,53 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 
 	if( m_channelIndex != 0 ) // no remove-option in master
 	{
-		contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "R&emove channel" ),
-							this, SLOT( removeChannel() ) );
+		contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "R&emove channel" ), this, SLOT( removeChannel() ) );
 		contextMenu->addSeparator();
 	}
 
-	contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "Remove &unused channels" ),
-						this, SLOT( removeUnusedChannels() ) );
+	contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "Remove &unused channels" ), this, SLOT( removeUnusedChannels() ) );
 	contextMenu->addSeparator();
-
 	contextMenu->addHelpAction();
 	contextMenu->exec( QCursor::pos() );
 	delete contextMenu;
 }
 
 
+
+
 void FxLine::renameChannel()
 {
-	bool ok;
-	FxMixer * mix = Engine::fxMixer();
-	QString new_name = QInputDialog::getText( this,
-			FxMixerView::tr( "Rename FX channel" ),
-			FxMixerView::tr( "Enter the new name for this "
-						"FX channel" ),
-			QLineEdit::Normal, mix->effectChannel(m_channelIndex)->m_name, &ok );
-	if( ok && !new_name.isEmpty() )
-	{
-		mix->effectChannel( m_channelIndex )->m_name = new_name;
-		setToolTip( new_name );
-		update();
-	}
+	m_inRename = true;
+	m_renameLineEdit->setReadOnly( false );
+	m_lcd->hide();
+	m_renameLineEdit->setFixedWidth( 135 );
+	m_renameLineEdit->setText( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name );
+	m_view->setFocus();
+	m_renameLineEdit->selectAll();
+	m_renameLineEdit->setFocus();
 }
+
+
+
+
+void FxLine::renameFinished()
+{
+	m_inRename = false;
+	m_renameLineEdit->setReadOnly( true );
+	m_renameLineEdit->setFixedWidth( 65 );
+	m_lcd->show();
+	m_newName = m_renameLineEdit->text();
+	setFocus();
+	if( !m_newName.isEmpty() )
+	{
+		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
+		setToolTip( m_newName );
+	}
+	m_renameLineEdit->setText( elideName( m_newName ) );
+	Engine::getSong()->setModified();
+}
+
+
 
 
 void FxLine::removeChannel()
@@ -258,11 +289,15 @@ void FxLine::removeChannel()
 }
 
 
+
+
 void FxLine::removeUnusedChannels()
 {
 	FxMixerView * mix = gui->fxMixerView();
 	mix->deleteUnusedChannels();
 }
+
+
 
 
 void FxLine::moveChannelLeft()
@@ -272,11 +307,15 @@ void FxLine::moveChannelLeft()
 }
 
 
+
+
 void FxLine::moveChannelRight()
 {
 	FxMixerView * mix = gui->fxMixerView();
 	mix->moveChannelRight( m_channelIndex );
 }
+
+
 
 
 void FxLine::displayHelp()
@@ -285,50 +324,80 @@ void FxLine::displayHelp()
 								whatsThis() );
 }
 
+
+
+
 QBrush FxLine::backgroundActive() const
 {
 	return m_backgroundActive;
 }
+
+
+
 
 void FxLine::setBackgroundActive( const QBrush & c )
 {
 	m_backgroundActive = c;
 }
 
+
+
+
 QColor FxLine::strokeOuterActive() const
 {
 	return m_strokeOuterActive;
 }
+
+
+
 
 void FxLine::setStrokeOuterActive( const QColor & c )
 {
 	m_strokeOuterActive = c;
 }
 
+
+
+
 QColor FxLine::strokeOuterInactive() const
 {
 	return m_strokeOuterInactive;
 }
+
+
+
 
 void FxLine::setStrokeOuterInactive( const QColor & c )
 {
 	m_strokeOuterInactive = c;
 }
 
+
+
+
 QColor FxLine::strokeInnerActive() const
 {
 	return m_strokeInnerActive;
 }
+
+
+
 
 void FxLine::setStrokeInnerActive( const QColor & c )
 {
 	m_strokeInnerActive = c;
 }
 
+
+
+
 QColor FxLine::strokeInnerInactive() const
 {
 	return m_strokeInnerInactive;
 }
+
+
+
 
 void FxLine::setStrokeInnerInactive( const QColor & c )
 {

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -146,7 +146,7 @@ void FxLine::setChannelIndex( int index )
 void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis )
 {
 	m_name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
-	if( !m_inRename )
+	if( !m_inRename && m_renameLineEdit->text() != elideName( m_name ) )
 	{
 		m_renameLineEdit->setText( elideName( m_name ) );
 	}
@@ -270,15 +270,12 @@ void FxLine::renameFinished()
 	m_lcd->show();
 	m_newName = m_renameLineEdit->text();
 	setFocus();
-	if( !m_newName.isEmpty() )
+	if( !m_newName.isEmpty() && Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != m_newName )
 	{
-		if( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != m_newName )
-		{
-			Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
-			setToolTip( m_newName );
-			m_renameLineEdit->setText( elideName( m_newName ) );
-			Engine::getSong()->setModified();
-		}
+		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = m_newName;
+		setToolTip( m_newName );
+		m_renameLineEdit->setText( elideName( m_newName ) );
+		Engine::getSong()->setModified();
 	}
 }
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -46,7 +46,7 @@ const int FxLine::FxLineHeight = 287;
 QPixmap * FxLine::s_sendBgArrow = NULL;
 QPixmap * FxLine::s_receiveBgArrow = NULL;
 
-FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
+FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex ) :
 	QWidget( _parent ),
 	m_mv( _mv ),
 	m_channelIndex( _channelIndex ),
@@ -127,12 +127,15 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex) :
 
 
 
+
 FxLine::~FxLine()
 {
 	delete m_sendKnob;
 	delete m_sendBtn;
 	delete m_lcd;
 }
+
+
 
 
 void FxLine::setChannelIndex( int index )
@@ -148,9 +151,10 @@ void FxLine::setChannelIndex( int index )
 void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis )
 {
 	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
-	if( !m_inRename && m_renameLineEdit->text() != elideName( name ) )
+	QString elidedName = elideName( name );
+	if( !m_inRename && m_renameLineEdit->text() != elidedName )
 	{
-		m_renameLineEdit->setText( elideName( name ) );
+		m_renameLineEdit->setText( elidedName );
 	}
 
 	int width = fxLine->rect().width();
@@ -180,7 +184,7 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool 
 
 
 
-QString FxLine::elideName( QString name )
+QString FxLine::elideName( const QString & name )
 {
 	const int maxTextHeight = 70;
 	QFontMetrics metrics( font() );
@@ -249,6 +253,7 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 void FxLine::renameChannel()
 {
 	m_inRename = true;
+	setToolTip( "" );
 	m_renameLineEdit->setReadOnly( false );
 	m_lcd->hide();
 	m_renameLineEdit->setFixedWidth( 135 );
@@ -272,10 +277,11 @@ void FxLine::renameFinished()
 	if( !newName.isEmpty() && Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != newName )
 	{
 		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = newName;
-		setToolTip( newName );
 		m_renameLineEdit->setText( elideName( newName ) );
 		Engine::getSong()->setModified();
 	}
+	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	setToolTip( name );
 }
 
 


### PR DESCRIPTION
Same as https://github.com/LMMS/lmms/pull/2916. For avoiding dialog window we can use a QLineEdit for renaming the FxLine. I used a QGraphicsView for rotating the QLineEdit.

![renamefxline](https://cloud.githubusercontent.com/assets/6502580/16871938/20c836ce-4a8a-11e6-9e96-64d9234a9ceb.png)
