### PR TITLE
Update SWH, fix GCC 5.3.1 warnings

### DIFF
--- a/plugins/LadspaEffect/swh/alias_1407.c
+++ b/plugins/LadspaEffect/swh/alias_1407.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -161,7 +161,7 @@ static void runAddingAlias(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -239,7 +239,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (aliasDescriptor) {
 		free((LADSPA_PortDescriptor *)aliasDescriptor->PortDescriptors);
 		free((char **)aliasDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/allpass_1895.c
+++ b/plugins/LadspaEffect/swh/allpass_1895.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -1149,7 +1149,7 @@ static void runAddingAllpass_c(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->write_phase = write_phase;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -1406,7 +1406,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (allpass_nDescriptor) {
 		free((LADSPA_PortDescriptor *)allpass_nDescriptor->PortDescriptors);
 		free((char **)allpass_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/am_pitchshift_1433.c
+++ b/plugins/LadspaEffect/swh/am_pitchshift_1433.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -359,7 +359,7 @@ static void runAddingAmPitchshift(LADSPA_Handle instance, unsigned long sample_c
     *(plugin_data->latency) = delay_ofs/2;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -454,7 +454,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (amPitchshiftDescriptor) {
 		free((LADSPA_PortDescriptor *)amPitchshiftDescriptor->PortDescriptors);
 		free((char **)amPitchshiftDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/amp_1181.c
+++ b/plugins/LadspaEffect/swh/amp_1181.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -154,7 +154,7 @@ static void runAddingAmp(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -232,7 +232,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (ampDescriptor) {
 		free((LADSPA_PortDescriptor *)ampDescriptor->PortDescriptors);
 		free((char **)ampDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/analogue_osc_1416.c
+++ b/plugins/LadspaEffect/swh/analogue_osc_1416.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -201,7 +201,7 @@ static void runAnalogueOsc(LADSPA_Handle instance, unsigned long sample_count) {
 	  y = (x - q) / (1.0f - f_exp(-1.2f * (x - q))) +
 	        q / (1.0f - f_exp(1.2f * q));
 	  /* Catch the case where x ~= q */
-	  if (fabs(y) > 1.0f) {
+	  if (isnan(y) || fabs(y) > 1.0f) {
 	          y = 0.83333f + q / (1.0f - f_exp(1.2f * q));
 	  }
 	  otm2 = otm1;
@@ -280,7 +280,7 @@ static void runAddingAnalogueOsc(LADSPA_Handle instance, unsigned long sample_co
 	  y = (x - q) / (1.0f - f_exp(-1.2f * (x - q))) +
 	        q / (1.0f - f_exp(1.2f * q));
 	  /* Catch the case where x ~= q */
-	  if (fabs(y) > 1.0f) {
+	  if (isnan(y) || fabs(y) > 1.0f) {
 	          y = 0.83333f + q / (1.0f - f_exp(1.2f * q));
 	  }
 	  otm2 = otm1;
@@ -297,7 +297,7 @@ static void runAddingAnalogueOsc(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->rndb = rndb;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -398,7 +398,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (analogueOscDescriptor) {
 		free((LADSPA_PortDescriptor *)analogueOscDescriptor->PortDescriptors);
 		free((char **)analogueOscDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bandpass_a_iir_1893.c
+++ b/plugins/LadspaEffect/swh/bandpass_a_iir_1893.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -203,7 +203,7 @@ static void runAddingBandpass_a_iir(LADSPA_Handle instance, unsigned long sample
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -291,7 +291,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (bandpass_a_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bandpass_a_iirDescriptor->PortDescriptors);
 		free((char **)bandpass_a_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bandpass_iir_1892.c
+++ b/plugins/LadspaEffect/swh/bandpass_iir_1892.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -262,7 +262,7 @@ static void runAddingBandpass_iir(LADSPA_Handle instance, unsigned long sample_c
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -360,7 +360,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (bandpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bandpass_iirDescriptor->PortDescriptors);
 		free((char **)bandpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bode_shifter_1431.c
+++ b/plugins/LadspaEffect/swh/bode_shifter_1431.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -365,7 +365,7 @@ static void runAddingBodeShifter(LADSPA_Handle instance, unsigned long sample_co
 	*(plugin_data->latency) = 99;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -457,7 +457,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (bodeShifterDescriptor) {
 		free((LADSPA_PortDescriptor *)bodeShifterDescriptor->PortDescriptors);
 		free((char **)bodeShifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/bode_shifter_cv_1432.c
+++ b/plugins/LadspaEffect/swh/bode_shifter_cv_1432.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -393,7 +393,7 @@ static void runAddingBodeShifterCV(LADSPA_Handle instance, unsigned long sample_
 	*(plugin_data->latency) = 99;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -522,7 +522,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (bodeShifterCVDescriptor) {
 		free((LADSPA_PortDescriptor *)bodeShifterCVDescriptor->PortDescriptors);
 		free((char **)bodeShifterCVDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/butterworth_1902.c
+++ b/plugins/LadspaEffect/swh/butterworth_1902.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -537,7 +537,7 @@ static void runAddingButthigh_iir(LADSPA_Handle instance, unsigned long sample_c
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -780,7 +780,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (bwxover_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)bwxover_iirDescriptor->PortDescriptors);
 		free((char **)bwxover_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/chebstortion_1430.c
+++ b/plugins/LadspaEffect/swh/chebstortion_1430.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -314,7 +314,7 @@ static void runAddingChebstortion(LADSPA_Handle instance, unsigned long sample_c
 	plugin_data->count = count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -398,7 +398,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (chebstortionDescriptor) {
 		free((LADSPA_PortDescriptor *)chebstortionDescriptor->PortDescriptors);
 		free((char **)chebstortionDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_1190.c
+++ b/plugins/LadspaEffect/swh/comb_1190.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -251,7 +251,7 @@ static void runAddingComb(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->last_offset = offset;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -339,7 +339,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (combDescriptor) {
 		free((LADSPA_PortDescriptor *)combDescriptor->PortDescriptors);
 		free((char **)combDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_1887.c
+++ b/plugins/LadspaEffect/swh/comb_1887.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -1134,7 +1134,7 @@ static void runAddingComb_c(LADSPA_Handle instance, unsigned long sample_count) 
 	plugin_data->write_phase = write_phase;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -1391,7 +1391,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (comb_nDescriptor) {
 		free((LADSPA_PortDescriptor *)comb_nDescriptor->PortDescriptors);
 		free((char **)comb_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/comb_splitter_1411.c
+++ b/plugins/LadspaEffect/swh/comb_splitter_1411.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -255,7 +255,7 @@ static void runAddingCombSplitter(LADSPA_Handle instance, unsigned long sample_c
 	plugin_data->last_offset = offset;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -340,7 +340,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (combSplitterDescriptor) {
 		free((LADSPA_PortDescriptor *)combSplitterDescriptor->PortDescriptors);
 		free((char **)combSplitterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/const_1909.c
+++ b/plugins/LadspaEffect/swh/const_1909.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -171,7 +171,7 @@ static void runAddingConst(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->last_amp = amp;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -249,7 +249,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (constDescriptor) {
 		free((LADSPA_PortDescriptor *)constDescriptor->PortDescriptors);
 		free((char **)constDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/crossover_dist_1404.c
+++ b/plugins/LadspaEffect/swh/crossover_dist_1404.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -187,7 +187,7 @@ static void runAddingCrossoverDist(LADSPA_Handle instance, unsigned long sample_
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -275,7 +275,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (crossoverDistDescriptor) {
 		free((LADSPA_PortDescriptor *)crossoverDistDescriptor->PortDescriptors);
 		free((char **)crossoverDistDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dc_remove_1207.c
+++ b/plugins/LadspaEffect/swh/dc_remove_1207.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -166,7 +166,7 @@ static void runAddingDcRemove(LADSPA_Handle instance, unsigned long sample_count
 	plugin_data->otm1 = otm1;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -234,7 +234,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (dcRemoveDescriptor) {
 		free((LADSPA_PortDescriptor *)dcRemoveDescriptor->PortDescriptors);
 		free((char **)dcRemoveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/decay_1886.c
+++ b/plugins/LadspaEffect/swh/decay_1886.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -258,7 +258,7 @@ static void runAddingDecay(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->y = y;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -335,7 +335,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (decayDescriptor) {
 		free((LADSPA_PortDescriptor *)decayDescriptor->PortDescriptors);
 		free((char **)decayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/decimator_1202.c
+++ b/plugins/LadspaEffect/swh/decimator_1202.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -240,7 +240,7 @@ static void runAddingDecimator(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->count = count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -334,7 +334,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (decimatorDescriptor) {
 		free((LADSPA_PortDescriptor *)decimatorDescriptor->PortDescriptors);
 		free((char **)decimatorDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/declip_1195.c
+++ b/plugins/LadspaEffect/swh/declip_1195.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -160,7 +160,7 @@ static void runAddingDeclip(LADSPA_Handle instance, unsigned long sample_count) 
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -234,7 +234,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (declipDescriptor) {
 		free((LADSPA_PortDescriptor *)declipDescriptor->PortDescriptors);
 		free((char **)declipDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/delay_1898.c
+++ b/plugins/LadspaEffect/swh/delay_1898.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -932,7 +932,7 @@ static void runAddingDelay_c(LADSPA_Handle instance, unsigned long sample_count)
 	(void)(max_delay);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -1162,7 +1162,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (delay_nDescriptor) {
 		free((LADSPA_PortDescriptor *)delay_nDescriptor->PortDescriptors);
 		free((char **)delay_nDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/delayorama_1402.c
+++ b/plugins/LadspaEffect/swh/delayorama_1402.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -668,7 +668,7 @@ static void runAddingDelayorama(LADSPA_Handle instance, unsigned long sample_cou
 	plugin_data->last_out = out;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -846,7 +846,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (delayoramaDescriptor) {
 		free((LADSPA_PortDescriptor *)delayoramaDescriptor->PortDescriptors);
 		free((char **)delayoramaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/diode_1185.c
+++ b/plugins/LadspaEffect/swh/diode_1185.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -185,7 +185,7 @@ static void runAddingDiode(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -263,7 +263,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (diodeDescriptor) {
 		free((LADSPA_PortDescriptor *)diodeDescriptor->PortDescriptors);
 		free((char **)diodeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/divider_1186.c
+++ b/plugins/LadspaEffect/swh/divider_1186.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -249,7 +249,7 @@ static void runAddingDivider(LADSPA_Handle instance, unsigned long sample_count)
 	plugin_data->out = out;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -330,7 +330,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (dividerDescriptor) {
 		free((LADSPA_PortDescriptor *)dividerDescriptor->PortDescriptors);
 		free((char **)dividerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dj_eq_1901.c
+++ b/plugins/LadspaEffect/swh/dj_eq_1901.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -469,7 +469,7 @@ static void runAddingDj_eq(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->latency) = 3; //XXX is this right?
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -679,7 +679,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (dj_eq_monoDescriptor) {
 		free((LADSPA_PortDescriptor *)dj_eq_monoDescriptor->PortDescriptors);
 		free((char **)dj_eq_monoDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dj_flanger_1438.c
+++ b/plugins/LadspaEffect/swh/dj_flanger_1438.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -366,7 +366,7 @@ static void runAddingDjFlanger(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -471,7 +471,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (djFlangerDescriptor) {
 		free((LADSPA_PortDescriptor *)djFlangerDescriptor->PortDescriptors);
 		free((char **)djFlangerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/dyson_compress_1403.c
+++ b/plugins/LadspaEffect/swh/dyson_compress_1403.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -776,7 +776,7 @@ static void runAddingDysonCompress(LADSPA_Handle instance, unsigned long sample_
 	plugin_data->extra_maxlevel = extra_maxlevel;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -884,7 +884,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (dysonCompressDescriptor) {
 		free((LADSPA_PortDescriptor *)dysonCompressDescriptor->PortDescriptors);
 		free((char **)dysonCompressDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/fad_delay_1192.c
+++ b/plugins/LadspaEffect/swh/fad_delay_1192.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -305,7 +305,7 @@ static void runAddingFadDelay(LADSPA_Handle instance, unsigned long sample_count
 	plugin_data->last_in = last_in;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -393,7 +393,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (fadDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)fadDelayDescriptor->PortDescriptors);
 		free((char **)fadDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/fast_lookahead_limiter_1913.c
+++ b/plugins/LadspaEffect/swh/fast_lookahead_limiter_1913.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -574,7 +574,7 @@ static void runAddingFastLookaheadLimiter(LADSPA_Handle instance, unsigned long 
 	*(plugin_data->latency) = delay;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -703,7 +703,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (fastLookaheadLimiterDescriptor) {
 		free((LADSPA_PortDescriptor *)fastLookaheadLimiterDescriptor->PortDescriptors);
 		free((char **)fastLookaheadLimiterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/flanger_1191.c
+++ b/plugins/LadspaEffect/swh/flanger_1191.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -435,7 +435,7 @@ static void runAddingFlanger(LADSPA_Handle instance, unsigned long sample_count)
 	plugin_data->old_d_base = new_d_base;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -543,7 +543,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (flangerDescriptor) {
 		free((LADSPA_PortDescriptor *)flangerDescriptor->PortDescriptors);
 		free((char **)flangerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/fm_osc_1415.c
+++ b/plugins/LadspaEffect/swh/fm_osc_1415.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -179,7 +179,7 @@ static void runAddingFmOsc(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -260,7 +260,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (fmOscDescriptor) {
 		free((LADSPA_PortDescriptor *)fmOscDescriptor->PortDescriptors);
 		free((char **)fmOscDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/foldover_1213.c
+++ b/plugins/LadspaEffect/swh/foldover_1213.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -166,7 +166,7 @@ static void runAddingFoldover(LADSPA_Handle instance, unsigned long sample_count
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -254,7 +254,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (foldoverDescriptor) {
 		free((LADSPA_PortDescriptor *)foldoverDescriptor->PortDescriptors);
 		free((char **)foldoverDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/foverdrive_1196.c
+++ b/plugins/LadspaEffect/swh/foverdrive_1196.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -155,7 +155,7 @@ static void runAddingFoverdrive(LADSPA_Handle instance, unsigned long sample_cou
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -233,7 +233,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (foverdriveDescriptor) {
 		free((LADSPA_PortDescriptor *)foverdriveDescriptor->PortDescriptors);
 		free((char **)foverdriveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/freq_tracker_1418.c
+++ b/plugins/LadspaEffect/swh/freq_tracker_1418.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -240,7 +240,7 @@ static void runAddingFreqTracker(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->cross_time = cross_time;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -318,7 +318,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (freqTrackerDescriptor) {
 		free((LADSPA_PortDescriptor *)freqTrackerDescriptor->PortDescriptors);
 		free((char **)freqTrackerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gate_1410.c
+++ b/plugins/LadspaEffect/swh/gate_1410.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -433,7 +433,7 @@ static void runAddingGate(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->hold_count = hold_count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -581,7 +581,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (gateDescriptor) {
 		free((LADSPA_PortDescriptor *)gateDescriptor->PortDescriptors);
 		free((char **)gateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/giant_flange_1437.c
+++ b/plugins/LadspaEffect/swh/giant_flange_1437.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -501,7 +501,7 @@ static void runAddingGiantFlange(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -636,7 +636,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (giantFlangeDescriptor) {
 		free((LADSPA_PortDescriptor *)giantFlangeDescriptor->PortDescriptors);
 		free((char **)giantFlangeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gong_1424.c
+++ b/plugins/LadspaEffect/swh/gong_1424.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -608,7 +608,7 @@ static void runAddingGong(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -946,7 +946,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (gongDescriptor) {
 		free((LADSPA_PortDescriptor *)gongDescriptor->PortDescriptors);
 		free((char **)gongDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gong_beater_1439.c
+++ b/plugins/LadspaEffect/swh/gong_beater_1439.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -301,7 +301,7 @@ static void runAddingGongBeater(LADSPA_Handle instance, unsigned long sample_cou
 	plugin_data->imp_level = imp_level;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -399,7 +399,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (gongBeaterDescriptor) {
 		free((LADSPA_PortDescriptor *)gongBeaterDescriptor->PortDescriptors);
 		free((char **)gongBeaterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gsm_1215.c
+++ b/plugins/LadspaEffect/swh/gsm_1215.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -387,7 +387,7 @@ static void runAddingGsm(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->latency) = 160 * resamp;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -492,7 +492,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (gsmDescriptor) {
 		free((LADSPA_PortDescriptor *)gsmDescriptor->PortDescriptors);
 		free((char **)gsmDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/gverb_1216.c
+++ b/plugins/LadspaEffect/swh/gverb_1216.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -283,7 +283,7 @@ static void runAddingGverb(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -428,7 +428,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (gverbDescriptor) {
 		free((LADSPA_PortDescriptor *)gverbDescriptor->PortDescriptors);
 		free((char **)gverbDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hard_limiter_1413.c
+++ b/plugins/LadspaEffect/swh/hard_limiter_1413.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -187,7 +187,7 @@ static void runAddingHardLimiter(LADSPA_Handle instance, unsigned long sample_co
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -285,7 +285,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (hardLimiterDescriptor) {
 		free((LADSPA_PortDescriptor *)hardLimiterDescriptor->PortDescriptors);
 		free((char **)hardLimiterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/harmonic_gen_1220.c
+++ b/plugins/LadspaEffect/swh/harmonic_gen_1220.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -367,7 +367,7 @@ static void runAddingHarmonicGen(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->otm1 = otm1;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -541,7 +541,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (harmonicGenDescriptor) {
 		free((LADSPA_PortDescriptor *)harmonicGenDescriptor->PortDescriptors);
 		free((char **)harmonicGenDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hermes_filter_1200.c
+++ b/plugins/LadspaEffect/swh/hermes_filter_1200.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -117,7 +117,7 @@ inline void setup_f_svf(sv_filter *sv, const float fs, const float fc) {
 
 /* Run one sample through the SV filter. Filter is by andy@vellocet */
 
-inline float run_svf(sv_filter *sv, float in) {
+static inline float run_svf(sv_filter *sv, float in) {
         float out;
         int i;
 
@@ -144,7 +144,7 @@ inline float run_svf(sv_filter *sv, float in) {
         return out;
 }
 
-inline int wave_tbl(const float wave) {
+static inline int wave_tbl(const float wave) {
         switch (f_round(wave)) {
                 case 0:
                 return BLO_SINE;
@@ -1403,7 +1403,7 @@ static void runAddingHermesFilter(LADSPA_Handle instance, unsigned long sample_c
 	plugin_data->lfo2_phase = lfo2_phase;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -1997,7 +1997,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (hermesFilterDescriptor) {
 		free((LADSPA_PortDescriptor *)hermesFilterDescriptor->PortDescriptors);
 		free((char **)hermesFilterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/highpass_iir_1890.c
+++ b/plugins/LadspaEffect/swh/highpass_iir_1890.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -203,7 +203,7 @@ static void runAddingHighpass_iir(LADSPA_Handle instance, unsigned long sample_c
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -291,7 +291,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (highpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)highpass_iirDescriptor->PortDescriptors);
 		free((char **)highpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/hilbert_1440.c
+++ b/plugins/LadspaEffect/swh/hilbert_1440.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -233,7 +233,7 @@ static void runAddingHilbert(LADSPA_Handle instance, unsigned long sample_count)
 	*(plugin_data->latency) = 99;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -315,7 +315,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (hilbertDescriptor) {
 		free((LADSPA_PortDescriptor *)hilbertDescriptor->PortDescriptors);
 		free((char **)hilbertDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/imp_1199.c
+++ b/plugins/LadspaEffect/swh/imp_1199.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -63,7 +63,7 @@ typedef rfftw_plan fft_plan;
 
 #define MK_IMP(i) impulse2freq(c, i, IMP_LENGTH(i), impulse_freq[c]); c++
 
-inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
+static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out);
 
 #include "impulses/all.h"
 
@@ -75,9 +75,9 @@ static fftw_real *real_in, *real_out, *comp_in, *comp_out;
 unsigned int fft_length[IMPULSES];
 
 #ifdef __clang__
-void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+static void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #else
-inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
+static inline void impulse2freq(int id, float *imp, unsigned int length, fftw_real *out)
 #endif
 {
   fftw_real impulse_time[MAX_FFT_LENGTH];
@@ -531,7 +531,7 @@ static void runAddingImp(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->latency) = SEG_LENGTH;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -636,7 +636,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (impDescriptor) {
 		free((LADSPA_PortDescriptor *)impDescriptor->PortDescriptors);
 		free((char **)impDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/impulse_1885.c
+++ b/plugins/LadspaEffect/swh/impulse_1885.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -186,7 +186,7 @@ static void runAddingImpulse_fc(LADSPA_Handle instance, unsigned long sample_cou
 	plugin_data->phase = phase;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -256,7 +256,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (impulse_fcDescriptor) {
 		free((LADSPA_PortDescriptor *)impulse_fcDescriptor->PortDescriptors);
 		free((char **)impulse_fcDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/impulses/all.h
+++ b/plugins/LadspaEffect/swh/impulses/all.h
@@ -1,6 +1,6 @@
 /* Generated file, do not edit */
 
-#define IMPULSES      21
+#define IMPULSES 21
 
 #include "impulses/01-unit.h"
 #include "impulses/02-steves-flat.h"
@@ -25,7 +25,7 @@
 #include "impulses/21-matchless-chieftain-sm57-off.h"
 
 #ifdef __clang__
-void mk_imps(fftw_real **impulse_freq)
+static void mk_imps(fftw_real **impulse_freq)
 #else
 static inline void mk_imps(fftw_real **impulse_freq)
 #endif

--- a/plugins/LadspaEffect/swh/inv_1429.c
+++ b/plugins/LadspaEffect/swh/inv_1429.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -138,7 +138,7 @@ static void runAddingInv(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -206,7 +206,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (invDescriptor) {
 		free((LADSPA_PortDescriptor *)invDescriptor->PortDescriptors);
 		free((char **)invDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/karaoke_1409.c
+++ b/plugins/LadspaEffect/swh/karaoke_1409.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -181,7 +181,7 @@ static void runAddingKaraoke(LADSPA_Handle instance, unsigned long sample_count)
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -273,7 +273,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (karaokeDescriptor) {
 		free((LADSPA_PortDescriptor *)karaokeDescriptor->PortDescriptors);
 		free((char **)karaokeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/latency_1914.c
+++ b/plugins/LadspaEffect/swh/latency_1914.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -173,7 +173,7 @@ static void runAddingArtificialLatency(LADSPA_Handle instance, unsigned long sam
 	*(plugin_data->latency) = (float)delay_fr;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -258,7 +258,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (artificialLatencyDescriptor) {
 		free((LADSPA_PortDescriptor *)artificialLatencyDescriptor->PortDescriptors);
 		free((char **)artificialLatencyDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/lcr_delay_1436.c
+++ b/plugins/LadspaEffect/swh/lcr_delay_1436.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -540,7 +540,7 @@ static void runAddingLcrDelay(LADSPA_Handle instance, unsigned long sample_count
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -732,7 +732,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (lcrDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)lcrDelayDescriptor->PortDescriptors);
 		free((char **)lcrDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/lowpass_iir_1891.c
+++ b/plugins/LadspaEffect/swh/lowpass_iir_1891.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -205,7 +205,7 @@ static void runAddingLowpass_iir(LADSPA_Handle instance, unsigned long sample_co
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -293,7 +293,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (lowpass_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)lowpass_iirDescriptor->PortDescriptors);
 		free((char **)lowpass_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/ls_filter_1908.c
+++ b/plugins/LadspaEffect/swh/ls_filter_1908.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -209,7 +209,7 @@ static void runAddingLsFilter(LADSPA_Handle instance, unsigned long sample_count
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -307,7 +307,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (lsFilterDescriptor) {
 		free((LADSPA_PortDescriptor *)lsFilterDescriptor->PortDescriptors);
 		free((char **)lsFilterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_ms_st_1421.c
+++ b/plugins/LadspaEffect/swh/matrix_ms_st_1421.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -173,7 +173,7 @@ static void runAddingMatrixMSSt(LADSPA_Handle instance, unsigned long sample_cou
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -265,7 +265,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (matrixMSStDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixMSStDescriptor->PortDescriptors);
 		free((char **)matrixMSStDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_spatialiser_1422.c
+++ b/plugins/LadspaEffect/swh/matrix_spatialiser_1422.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -331,7 +331,7 @@ static void runAddingMatrixSpatialiser(LADSPA_Handle instance, unsigned long sam
 	plugin_data->current_s_gain = current_s_gain;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -423,7 +423,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (matrixSpatialiserDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixSpatialiserDescriptor->PortDescriptors);
 		free((char **)matrixSpatialiserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/matrix_st_ms_1420.c
+++ b/plugins/LadspaEffect/swh/matrix_st_ms_1420.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -162,7 +162,7 @@ static void runAddingMatrixStMS(LADSPA_Handle instance, unsigned long sample_cou
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -244,7 +244,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (matrixStMSDescriptor) {
 		free((LADSPA_PortDescriptor *)matrixStMSDescriptor->PortDescriptors);
 		free((char **)matrixStMSDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/mbeq_1197.c
+++ b/plugins/LadspaEffect/swh/mbeq_1197.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -659,7 +659,7 @@ static void runAddingMbeq(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->latency) = fft_latency;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -884,7 +884,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (mbeqDescriptor) {
 		free((LADSPA_PortDescriptor *)mbeqDescriptor->PortDescriptors);
 		free((char **)mbeqDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/mod_delay_1419.c
+++ b/plugins/LadspaEffect/swh/mod_delay_1419.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -229,7 +229,7 @@ static void runAddingModDelay(LADSPA_Handle instance, unsigned long sample_count
 	plugin_data->write_ptr = write_ptr;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -317,7 +317,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (modDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)modDelayDescriptor->PortDescriptors);
 		free((char **)modDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/multivoice_chorus_1201.c
+++ b/plugins/LadspaEffect/swh/multivoice_chorus_1201.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -527,7 +527,7 @@ static void runAddingMultivoiceChorus(LADSPA_Handle instance, unsigned long samp
 	plugin_data->delay_pos = delay_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -655,7 +655,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (multivoiceChorusDescriptor) {
 		free((LADSPA_PortDescriptor *)multivoiceChorusDescriptor->PortDescriptors);
 		free((char **)multivoiceChorusDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/notch_iir_1894.c
+++ b/plugins/LadspaEffect/swh/notch_iir_1894.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -258,7 +258,7 @@ static void runAddingNotch_iir(LADSPA_Handle instance, unsigned long sample_coun
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -356,7 +356,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (notch_iirDescriptor) {
 		free((LADSPA_PortDescriptor *)notch_iirDescriptor->PortDescriptors);
 		free((char **)notch_iirDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/phasers_1217.c
+++ b/plugins/LadspaEffect/swh/phasers_1217.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -1030,7 +1030,7 @@ static void runAddingAutoPhaser(LADSPA_Handle instance, unsigned long sample_cou
 	plugin_data->ym1 = ym1;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -1376,7 +1376,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (lfoPhaserDescriptor) {
 		free((LADSPA_PortDescriptor *)lfoPhaserDescriptor->PortDescriptors);
 		free((char **)lfoPhaserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pitch_scale_1193.c
+++ b/plugins/LadspaEffect/swh/pitch_scale_1193.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -241,7 +241,7 @@ static void runAddingPitchScale(LADSPA_Handle instance, unsigned long sample_cou
 	                                OVER_SAMP);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -326,7 +326,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (pitchScaleDescriptor) {
 		free((LADSPA_PortDescriptor *)pitchScaleDescriptor->PortDescriptors);
 		free((char **)pitchScaleDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pitch_scale_1194.c
+++ b/plugins/LadspaEffect/swh/pitch_scale_1194.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -225,7 +225,7 @@ static void runAddingPitchScaleHQ(LADSPA_Handle instance, unsigned long sample_c
 	                                / OVER_SAMP);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -310,7 +310,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (pitchScaleHQDescriptor) {
 		free((LADSPA_PortDescriptor *)pitchScaleHQDescriptor->PortDescriptors);
 		free((char **)pitchScaleHQDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/plate_1423.c
+++ b/plugins/LadspaEffect/swh/plate_1423.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -295,7 +295,7 @@ static void runAddingPlate(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -400,7 +400,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (plateDescriptor) {
 		free((LADSPA_PortDescriptor *)plateDescriptor->PortDescriptors);
 		free((char **)plateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/pointer_cast_1910.c
+++ b/plugins/LadspaEffect/swh/pointer_cast_1910.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -221,7 +221,7 @@ static void runAddingPointerCastDistortion(LADSPA_Handle instance, unsigned long
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -309,7 +309,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (pointerCastDistortionDescriptor) {
 		free((LADSPA_PortDescriptor *)pointerCastDistortionDescriptor->PortDescriptors);
 		free((char **)pointerCastDistortionDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/rate_shifter_1417.c
+++ b/plugins/LadspaEffect/swh/rate_shifter_1417.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -235,7 +235,7 @@ static void runAddingRateShifter(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->write_ptr = write_ptr;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -313,7 +313,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (rateShifterDescriptor) {
 		free((LADSPA_PortDescriptor *)rateShifterDescriptor->PortDescriptors);
 		free((char **)rateShifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/retro_flange_1208.c
+++ b/plugins/LadspaEffect/swh/retro_flange_1208.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -31,7 +31,7 @@ void __attribute__((constructor)) swh_init(); // forward declaration
 
 #define BASE_BUFFER 0.001 // Base buffer length (s)
 
-inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
+static inline LADSPA_Data sat(LADSPA_Data x, float q,  float dist) {
         if (x == q) {
                 return 1.0f / dist + q / (1.0f - f_exp(dist * q));
         }
@@ -492,7 +492,7 @@ static void runAddingRetroFlange(LADSPA_Handle instance, unsigned long sample_co
 	plugin_data->z2 = z2;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -580,7 +580,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (retroFlangeDescriptor) {
 		free((LADSPA_PortDescriptor *)retroFlangeDescriptor->PortDescriptors);
 		free((char **)retroFlangeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/revdelay_1605.c
+++ b/plugins/LadspaEffect/swh/revdelay_1605.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -427,7 +427,7 @@ static void runAddingRevdelay(LADSPA_Handle instance, unsigned long sample_count
 	plugin_data->write_phase = write_phase;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -545,7 +545,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (revdelayDescriptor) {
 		free((LADSPA_PortDescriptor *)revdelayDescriptor->PortDescriptors);
 		free((char **)revdelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/ringmod_1188.c
+++ b/plugins/LadspaEffect/swh/ringmod_1188.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -429,7 +429,7 @@ static void runAddingRingmod_1i1o1l(LADSPA_Handle instance, unsigned long sample
 	plugin_data->offset = offset;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -631,7 +631,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (ringmod_2i1oDescriptor) {
 		free((LADSPA_PortDescriptor *)ringmod_2i1oDescriptor->PortDescriptors);
 		free((char **)ringmod_2i1oDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/satan_maximiser_1408.c
+++ b/plugins/LadspaEffect/swh/satan_maximiser_1408.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -255,7 +255,7 @@ static void runAddingSatanMaximiser(LADSPA_Handle instance, unsigned long sample
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -343,7 +343,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (satanMaximiserDescriptor) {
 		free((LADSPA_PortDescriptor *)satanMaximiserDescriptor->PortDescriptors);
 		free((char **)satanMaximiserDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc1_1425.c
+++ b/plugins/LadspaEffect/swh/sc1_1425.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -344,7 +344,7 @@ static void runAddingSc1(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->count = count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -472,7 +472,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sc1Descriptor) {
 		free((LADSPA_PortDescriptor *)sc1Descriptor->PortDescriptors);
 		free((char **)sc1Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc2_1426.c
+++ b/plugins/LadspaEffect/swh/sc2_1426.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -355,7 +355,7 @@ static void runAddingSc2(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->count = count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -490,7 +490,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sc2Descriptor) {
 		free((LADSPA_PortDescriptor *)sc2Descriptor->PortDescriptors);
 		free((char **)sc2Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc3_1427.c
+++ b/plugins/LadspaEffect/swh/sc3_1427.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -402,7 +402,7 @@ static void runAddingSc3(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->count = count;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -561,7 +561,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sc3Descriptor) {
 		free((LADSPA_PortDescriptor *)sc3Descriptor->PortDescriptors);
 		free((char **)sc3Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc4_1882.c
+++ b/plugins/LadspaEffect/swh/sc4_1882.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -445,7 +445,7 @@ static void runAddingSc4(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->gain_red) = lin2db(gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -617,7 +617,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sc4Descriptor) {
 		free((LADSPA_PortDescriptor *)sc4Descriptor->PortDescriptors);
 		free((char **)sc4Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sc4m_1916.c
+++ b/plugins/LadspaEffect/swh/sc4m_1916.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -409,7 +409,7 @@ static void runAddingSc4m(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->gain_red) = lin2db(gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -567,7 +567,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sc4mDescriptor) {
 		free((LADSPA_PortDescriptor *)sc4mDescriptor->PortDescriptors);
 		free((char **)sc4mDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/se4_1883.c
+++ b/plugins/LadspaEffect/swh/se4_1883.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -441,7 +441,7 @@ static void runAddingSe4(LADSPA_Handle instance, unsigned long sample_count) {
 	*(plugin_data->gain_exp) = lin2db(gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -613,7 +613,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (se4Descriptor) {
 		free((LADSPA_PortDescriptor *)se4Descriptor->PortDescriptors);
 		free((char **)se4Descriptor->PortNames);

--- a/plugins/LadspaEffect/swh/shaper_1187.c
+++ b/plugins/LadspaEffect/swh/shaper_1187.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -175,7 +175,7 @@ static void runAddingShaper(LADSPA_Handle instance, unsigned long sample_count) 
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -259,7 +259,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (shaperDescriptor) {
 		free((LADSPA_PortDescriptor *)shaperDescriptor->PortDescriptors);
 		free((char **)shaperDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sifter_1210.c
+++ b/plugins/LadspaEffect/swh/sifter_1210.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -355,7 +355,7 @@ static void runAddingSifter(LADSPA_Handle instance, unsigned long sample_count) 
 	plugin_data->b2ptr = b2ptr;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -433,7 +433,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sifterDescriptor) {
 		free((LADSPA_PortDescriptor *)sifterDescriptor->PortDescriptors);
 		free((char **)sifterDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sin_cos_1881.c
+++ b/plugins/LadspaEffect/swh/sin_cos_1881.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -207,7 +207,7 @@ static void runAddingSinCos(LADSPA_Handle instance, unsigned long sample_count) 
 	plugin_data->last_om = target_om;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -295,7 +295,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sinCosDescriptor) {
 		free((LADSPA_PortDescriptor *)sinCosDescriptor->PortDescriptors);
 		free((char **)sinCosDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/single_para_1203.c
+++ b/plugins/LadspaEffect/swh/single_para_1203.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -207,7 +207,7 @@ static void runAddingSinglePara(LADSPA_Handle instance, unsigned long sample_cou
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -311,7 +311,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (singleParaDescriptor) {
 		free((LADSPA_PortDescriptor *)singleParaDescriptor->PortDescriptors);
 		free((char **)singleParaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/sinus_wavewrapper_1198.c
+++ b/plugins/LadspaEffect/swh/sinus_wavewrapper_1198.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -159,7 +159,7 @@ static void runAddingSinusWavewrapper(LADSPA_Handle instance, unsigned long samp
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -243,7 +243,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (sinusWavewrapperDescriptor) {
 		free((LADSPA_PortDescriptor *)sinusWavewrapperDescriptor->PortDescriptors);
 		free((char **)sinusWavewrapperDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/smooth_decimate_1414.c
+++ b/plugins/LadspaEffect/swh/smooth_decimate_1414.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -240,7 +240,7 @@ static void runAddingSmoothDecimate(LADSPA_Handle instance, unsigned long sample
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -328,7 +328,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (smoothDecimateDescriptor) {
 		free((LADSPA_PortDescriptor *)smoothDecimateDescriptor->PortDescriptors);
 		free((char **)smoothDecimateDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/split_1406.c
+++ b/plugins/LadspaEffect/swh/split_1406.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -155,7 +155,7 @@ static void runAddingSplit(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -239,7 +239,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (splitDescriptor) {
 		free((LADSPA_PortDescriptor *)splitDescriptor->PortDescriptors);
 		free((char **)splitDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/step_muxer_1212.c
+++ b/plugins/LadspaEffect/swh/step_muxer_1212.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -397,7 +397,7 @@ static void runAddingStepMuxer(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->last_clock = last_clock;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -531,7 +531,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (stepMuxerDescriptor) {
 		free((LADSPA_PortDescriptor *)stepMuxerDescriptor->PortDescriptors);
 		free((char **)stepMuxerDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/surround_encoder_1401.c
+++ b/plugins/LadspaEffect/swh/surround_encoder_1401.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -317,7 +317,7 @@ static void runAddingSurroundEncoder(LADSPA_Handle instance, unsigned long sampl
 	plugin_data->buffer_pos = buffer_pos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -413,7 +413,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (surroundEncoderDescriptor) {
 		free((LADSPA_PortDescriptor *)surroundEncoderDescriptor->PortDescriptors);
 		free((char **)surroundEncoderDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/svf_1214.c
+++ b/plugins/LadspaEffect/swh/svf_1214.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -293,7 +293,7 @@ static void runAddingSvf(LADSPA_Handle instance, unsigned long sample_count) {
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -407,7 +407,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (svfDescriptor) {
 		free((LADSPA_PortDescriptor *)svfDescriptor->PortDescriptors);
 		free((char **)svfDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/tape_delay_1211.c
+++ b/plugins/LadspaEffect/swh/tape_delay_1211.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -476,7 +476,7 @@ static void runAddingTapeDelay(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->z2 = z2;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -644,7 +644,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (tapeDelayDescriptor) {
 		free((LADSPA_PortDescriptor *)tapeDelayDescriptor->PortDescriptors);
 		free((char **)tapeDelayDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/transient_1206.c
+++ b/plugins/LadspaEffect/swh/transient_1206.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -370,7 +370,7 @@ static void runAddingTransient(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->slow_buffer_sum = slow_buffer_sum;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -464,7 +464,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (transientDescriptor) {
 		free((LADSPA_PortDescriptor *)transientDescriptor->PortDescriptors);
 		free((char **)transientDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/triple_para_1204.c
+++ b/plugins/LadspaEffect/swh/triple_para_1204.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -368,7 +368,7 @@ static void runAddingTriplePara(LADSPA_Handle instance, unsigned long sample_cou
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -592,7 +592,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (tripleParaDescriptor) {
 		free((LADSPA_PortDescriptor *)tripleParaDescriptor->PortDescriptors);
 		free((char **)tripleParaDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/util/buffer.h
+++ b/plugins/LadspaEffect/swh/util/buffer.h
@@ -8,10 +8,8 @@
 
 static inline void buffer_sub(const float* a, const float *b, float *c, int cnt) {
 	int i;
-	float *h;
-	h = c;
 	for(i=0;i<cnt;++i)
-		*h++ = *a++ - *b++;
+		*c++ = *a++ - *b++;
 }
 
 #endif

--- a/plugins/LadspaEffect/swh/valve_1209.c
+++ b/plugins/LadspaEffect/swh/valve_1209.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -243,7 +243,7 @@ static void runAddingValve(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->otm1 = otm1;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -331,7 +331,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (valveDescriptor) {
 		free((LADSPA_PortDescriptor *)valveDescriptor->PortDescriptors);
 		free((char **)valveDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/valve_rect_1405.c
+++ b/plugins/LadspaEffect/swh/valve_rect_1405.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -312,7 +312,7 @@ static void runAddingValveRect(LADSPA_Handle instance, unsigned long sample_coun
 	plugin_data->apos = apos;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -400,7 +400,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (valveRectDescriptor) {
 		free((LADSPA_PortDescriptor *)valveRectDescriptor->PortDescriptors);
 		free((char **)valveRectDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/vocoder_1337.c
+++ b/plugins/LadspaEffect/swh/vocoder_1337.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -704,7 +704,7 @@ static void runAddingVocoder(LADSPA_Handle instance, unsigned long sample_count)
 	(void)(run_adding_gain);
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -966,7 +966,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (vocoderDescriptor) {
 		free((LADSPA_PortDescriptor *)vocoderDescriptor->PortDescriptors);
 		free((char **)vocoderDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/vynil_1905.c
+++ b/plugins/LadspaEffect/swh/vynil_1905.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -580,7 +580,7 @@ static void runAddingVynil(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->phi = phi;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -712,7 +712,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (vynilDescriptor) {
 		free((LADSPA_PortDescriptor *)vynilDescriptor->PortDescriptors);
 		free((char **)vynilDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/wave_terrain_1412.c
+++ b/plugins/LadspaEffect/swh/wave_terrain_1412.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -155,7 +155,7 @@ static void runAddingWaveTerrain(LADSPA_Handle instance, unsigned long sample_co
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -230,7 +230,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (waveTerrainDescriptor) {
 		free((LADSPA_PortDescriptor *)waveTerrainDescriptor->PortDescriptors);
 		free((char **)waveTerrainDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/xfade_1915.c
+++ b/plugins/LadspaEffect/swh/xfade_1915.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -385,7 +385,7 @@ static void runAddingXfade4(LADSPA_Handle instance, unsigned long sample_count) 
 	}
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -597,7 +597,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (xfadeDescriptor) {
 		free((LADSPA_PortDescriptor *)xfadeDescriptor->PortDescriptors);
 		free((char **)xfadeDescriptor->PortNames);

--- a/plugins/LadspaEffect/swh/zm1_1428.c
+++ b/plugins/LadspaEffect/swh/zm1_1428.c
@@ -20,7 +20,7 @@
 #ifdef WIN32
 #define _WINDOWS_DLL_EXPORT_ __declspec(dllexport)
 int bIsFirstTime = 1; 
-void __attribute__((constructor)) swh_init(); // forward declaration
+static void __attribute__((constructor)) swh_init(); // forward declaration
 #else
 #define _WINDOWS_DLL_EXPORT_ 
 #endif
@@ -163,7 +163,7 @@ static void runAddingZm1(LADSPA_Handle instance, unsigned long sample_count) {
 	plugin_data->xm1 = xm1;
 }
 
-void __attribute__((constructor)) swh_init() {
+static void __attribute__((constructor)) swh_init() {
 	char **port_names;
 	LADSPA_PortDescriptor *port_descriptors;
 	LADSPA_PortRangeHint *port_range_hints;
@@ -231,7 +231,7 @@ void __attribute__((constructor)) swh_init() {
 	}
 }
 
-void __attribute__((destructor)) swh_fini() {
+static void __attribute__((destructor)) swh_fini() {
 	if (zm1Descriptor) {
 		free((LADSPA_PortDescriptor *)zm1Descriptor->PortDescriptors);
 		free((char **)zm1Descriptor->PortNames);


### PR DESCRIPTION
This includes the fix from https://github.com/swh/ladspa/pull/35.