### PR TITLE
Run dummy loop when PulseAudio fails connection

### DIFF
--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -30,6 +30,7 @@
 #ifdef LMMS_HAVE_PULSEAUDIO
 
 #include <pulse/pulseaudio.h>
+#include <QSemaphore>
 #include <QThread>
 
 #include "AudioDevice.h"
@@ -71,6 +72,8 @@ public:
 
 	void streamWriteCallback( pa_stream * s, size_t length );
 
+	void signalConnected( bool connected );
+
 	pa_stream * m_s;
 	pa_sample_spec m_sampleSpec;
 
@@ -84,6 +87,9 @@ private:
 	volatile bool m_quit;
 
 	bool m_convertEndian;
+
+	bool m_connected;
+	QSemaphore m_connectedSemaphore;
 
 } ;
 

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -187,6 +187,7 @@ static void context_state_callback(pa_context *c, void *userdata)
 										PA_STREAM_ADJUST_LATENCY,
 										NULL,	// volume
 										NULL );
+			_this->signalConnected( true );
 			break;
 		}
 
@@ -196,6 +197,7 @@ static void context_state_callback(pa_context *c, void *userdata)
 		case PA_CONTEXT_FAILED:
 		default:
 			qCritical( "Connection failure: %s\n", pa_strerror( pa_context_errno( c ) ) );
+			_this->signalConnected( false );
 	}
 }
 
@@ -219,19 +221,36 @@ void AudioPulseAudio::run()
 		return;
 	}
 
+	m_connected = false;
+
 	pa_context_set_state_callback( context, context_state_callback, this  );
 	// connect the context
 	pa_context_connect( context, NULL, (pa_context_flags) 0, NULL );
 
-	// run the main loop
-	int ret = 0;
-	m_quit = false;
-	while( m_quit == false && pa_mainloop_iterate( mainLoop, 1, &ret ) >= 0 )
-	{
-	}
+	m_connectedSemaphore.acquire();
 
-	pa_stream_disconnect( m_s );
-	pa_stream_unref( m_s );
+	// run the main loop
+	if( m_connected )
+	{
+		int ret = 0;
+		m_quit = false;
+		while( m_quit == false
+			&& pa_mainloop_iterate( mainLoop, 1, &ret ) >= 0 )
+		{
+		}
+
+		pa_stream_disconnect( m_s );
+		pa_stream_unref( m_s );
+	}
+	else
+	{
+		const fpp_t fpp = mixer()->framesPerPeriod();
+		surroundSampleFrame * temp = new surroundSampleFrame[fpp];
+		while( getNextBuffer( temp ) )
+		{
+		}
+		delete[] temp;
+	}
 
 	pa_context_disconnect( context );
 	pa_context_unref( context );
@@ -271,6 +290,18 @@ void AudioPulseAudio::streamWriteCallback( pa_stream *s, size_t length )
 
 	pa_xfree( pcmbuf );
 	delete[] temp;
+}
+
+
+
+
+void AudioPulseAudio::signalConnected( bool connected )
+{
+	if( !m_connected )
+	{
+		m_connected = connected;
+		m_connectedSemaphore.release();
+	}
 }
 
 


### PR DESCRIPTION
The PulseAudio driver locked if it failed to connect to the server. The dummy loop detects if shutdown is requested.