### PR TITLE
Add Linux installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,12 @@ ADD_CUSTOM_TARGET(dist
 			COMMAND tar cjf lmms-${VERSION}-src.tar.bz2 "${TMP}"
 			COMMAND rm -rf "${TMP}")
 
+# Installer targets
+IF(LMMS_BUILD_LINUX)
+	ADD_CUSTOM_TARGET(makeself DEPENDS makeself-linux)
+	ADD_CUSTOM_TARGET(bundled-source DEPENDS bundled-source-linux)
+ENDIF()
+
 #
 # display configuration information
 #

--- a/cmake/linux/CMakeLists.txt
+++ b/cmake/linux/CMakeLists.txt
@@ -2,3 +2,24 @@ INSTALL(FILES lmms.png                  DESTINATION "${DATA_DIR}/pixmaps")
 INSTALL(FILES lmms                      DESTINATION "${DATA_DIR}/menu")
 INSTALL(FILES lmms.desktop              DESTINATION "${DATA_DIR}/applications")
 INSTALL(FILES lmms.xml                  DESTINATION "${DATA_DIR}/mime/packages")
+
+CONFIGURE_FILE("build-installer.in" "${CMAKE_BINARY_DIR}/build-installer" @ONLY)
+
+IF(LMMS_HOST_X86)
+	SET(HOST_ARCH i386-linux-gnu)
+ELSEIF(LMMS_HOST_X86_64)
+	SET(HOST_ARCH x86_64-linux-gnu)
+ELSE()
+	SET(HOST_ARCH unknown-linux-gnu)
+ENDIF()
+SET(RUN_FILE "${CMAKE_PROJECT_NAME}-${VERSION}-${HOST_ARCH}.run")
+ADD_CUSTOM_TARGET(makeself-linux
+	COMMAND "${CMAKE_BINARY_DIR}/build-installer" "\"${CMAKE_BINARY_DIR}\""
+		"\"${RUN_FILE}\""
+	COMMENT "Generating installer")
+
+SET(BUNDLE_FILE "${CMAKE_PROJECT_NAME}-${VERSION}-bundled-source-linux.tar.gz")
+ADD_CUSTOM_TARGET(bundled-source-linux
+	COMMAND "${CMAKE_SOURCE_DIR}/cmake/linux/fetch-sources"
+		"\"${CMAKE_BINARY_DIR}\"" "\"${BUNDLE_FILE}\""
+	COMMENT "Fetching source for bundled libraries")

--- a/cmake/linux/build-installer.in
+++ b/cmake/linux/build-installer.in
@@ -1,0 +1,115 @@
+#!/bin/sh
+set -e
+BINDIR="$1"
+RUNFILE="$2"
+[ "$BINDIR" -a "$RUNFILE" ]
+
+VERSION=@VERSION@
+
+cd "$BINDIR"
+[ -e CMakeCache.txt ]
+
+rm -fr installer.root
+mkdir installer.root
+make install DESTDIR=installer.root
+cd installer.root
+
+if [ ! -e usr/bin/lmms ]
+then
+	mkdir -p usr
+	mv ./"@CMAKE_INSTALL_PREFIX@"/* usr
+	rmdir -p --ignore-fail-on-non-empty \
+		../installer.root/"@CMAKE_INSTALL_PREFIX@"
+fi
+
+strip usr/bin/lmms usr/lib/lmms/RemoteZynAddSubFx usr/lib/lmms/*.so \
+	usr/lib/lmms/ladspa/*
+
+rm -f ../download.log
+
+download_and_unpack_packages()
+{
+	sort -u |
+	xargs apt-get download |
+	tee -a ../download.log
+
+	ls *.deb |
+	while read DEB
+	do
+		dpkg-deb -x $DEB .
+	done
+	rm *.deb
+}
+
+# Find required libraries and download the deb files that contain them;
+# RemoteVstPlugin.exe.so is not considered
+ldd usr/bin/lmms usr/lib/lmms/RemoteZynAddSubFx usr/lib/lmms/lib*.so \
+	usr/lib/lmms/ladspa/* |
+grep = |
+cut -d " " -f 3 |
+grep -v usr/lib/lmms |
+sort -u |
+xargs dpkg -S |
+cut -d : -f 1 |
+download_and_unpack_packages
+
+# Fetch missing copyright files
+PACKAGES=$(find -L usr/share/doc -maxdepth 1 -type l -printf "%l\n")
+if [ "$PACKAGES" ]
+then
+	echo "$PACKAGES" |
+	download_and_unpack_packages
+fi
+
+mv usr/share/applications/lmms.desktop lmms-$VERSION.desktop
+sed -e "
+/^Name=/ s/LMMS/LMMS $VERSION/
+/^Icon=/ s/lmms/lmms-$VERSION/
+" -i lmms-$VERSION.desktop
+
+mv usr/share/pixmaps/lmms.png lmms-$VERSION.png
+rmdir --ignore-fail-on-non-empty usr/share/pixmaps
+
+mv usr/share/mime/packages/lmms.xml .
+
+rm -fr lib64 usr/include usr/share/applications usr/share/doc-base \
+	usr/share/lintian usr/share/man usr/share/menu usr/share/mime
+
+find usr/share/doc -mindepth 2 ! -name copyright -delete
+
+# Convert RPATH to RUNPATH
+find lib usr/lib -type f |
+while read FILE
+do
+	if readelf -d "$FILE" 2> /dev/null | grep "(RPATH)" |
+		grep -v '\[\$ORIGIN\]' > /dev/null
+	then
+		chrpath -c "$FILE"
+	fi
+done
+
+# libc6 is included, so its loader should be used instead of the system one;
+# move the loader to usr/bin because of Qt applicationDirPath() usage
+MULTIARCH=$(dpkg-architecture -qDEB_HOST_MULTIARCH)
+mv lib/$MULTIARCH/ld-*.so usr/bin/ld.so
+
+find -type l -execdir \[ ! -e '{}' \] \; -delete
+
+# FHS requires /opt programs to be in /opt/<package>/bin
+mkdir -p bin
+
+cat > bin/lmms-launcher << EOF
+#!/bin/sh
+DIR=\$(dirname \$(readlink -f "\$0"))
+DIR=\${DIR%/bin}
+export LD_LIBRARY_PATH="\$DIR"/lib/$MULTIARCH:"\$DIR"/usr/lib/$MULTIARCH\
+:"\$DIR"/usr/lib/$MULTIARCH/pulseaudio:"\$DIR"/usr/lib
+"\$DIR"/usr/bin/ld.so "\$DIR"/usr/bin/lmms "\$@"
+EOF
+
+chmod a+x bin/lmms-launcher
+
+cp -a ../../cmake/linux/installer .
+
+cd ..
+makeself --xz --complevel 6 installer.root "$RUNFILE" LMMS ./installer $VERSION

--- a/cmake/linux/fetch-sources
+++ b/cmake/linux/fetch-sources
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+BINDIR="$1"
+BUNDLE_FILE="$2"
+[ "$BINDIR" -a "$BUNDLE_FILE" ]
+
+cd "$BINDIR"
+[ -e download.log ]
+
+rm -fr bundled-source
+mkdir bundled-source
+cd bundled-source
+
+grep "^Get:" ../download.log |
+sed -re "s/.* ([^ ]+) [^ ]+ ([^ ]+) \[.*/\1=\2/" |
+xargs apt-get -d source
+
+cd ..
+tar zcf "$BUNDLE_FILE" bundled-source

--- a/cmake/linux/installer
+++ b/cmake/linux/installer
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+[ "$1" ]
+
+VERSION="$1"
+
+if [ $(id -u) -eq 0 ]
+then
+	DIR=/opt/lmms-$VERSION
+	PREFIX=/usr
+	umask 022
+	chmod -R +rX *
+else
+	DIR="$HOME"/.lmms-$VERSION
+	PREFIX="$HOME"/.local
+fi
+echo Installing to $DIR
+mkdir -p "$DIR"
+
+rm -fr "$DIR"/bin "$DIR"/etc "$DIR"/lib "$DIR"/usr
+mv bin etc lib usr "$DIR"
+
+sed -e "/^Exec=/ s#lmms#\"$DIR\"/bin/lmms-launcher#" -i lmms-$VERSION.desktop
+
+ICONDIR="$PREFIX"/share/icons
+mkdir -p "$ICONDIR"
+mv lmms-$VERSION.png "$ICONDIR"
+
+MENUDIR="$PREFIX"/share/applications
+mkdir -p "$MENUDIR"
+mv lmms-$VERSION.desktop "$MENUDIR"
+if [ "$(which update-desktop-database)" ]
+then
+	update-desktop-database "$MENUDIR"
+fi
+
+MIMEDIR="$PREFIX"/share/mime/packages
+if [ ! \( -e "$MIMEDIR"/lmms.xml -o -e /usr/share/mime/packages/lmms.xml -o \
+	-e /usr/local/share/mime/packages/lmms.xml \) ]
+then
+	mkdir -p "$MIMEDIR"
+	mv lmms.xml "$MIMEDIR"
+	if [ "$(which update-mime-database)" ]
+	then
+		update-mime-database "$PREFIX"/share/mime
+	fi
+fi


### PR DESCRIPTION
This allows a Debian-based host to build an installer with `makeself`, running `make makeself`. It should take up about 29 MiB. This should address #1620 and #2556, in the sense that a Linux binary is provided, not Debian or Ubuntu packages.

I have added a script that fetches the source for bundled libraries in the Linux installer; this takes care of #2937 partly. After building the installer, run `make bundled-source`. There is a lot to download.
