### PR TITLE
Make the background of BB patterns themeable

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -573,6 +573,7 @@ TrackContentObjectView   {
 	qproperty-mutedColor: rgb( 128, 128, 128 );
 	qproperty-mutedBackgroundColor: rgb( 80, 80, 80 );
 	qproperty-selectedColor: rgb( 0, 125, 255 );
+	qproperty-BBPatternBackground: rgb( 80, 80, 80 );
 	qproperty-textColor: rgb( 255, 255, 255 );
 	qproperty-textShadowColor: rgb( 0, 0, 0 );
 	qproperty-gradient: true; /* boolean property, set true to have a gradient */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -582,9 +582,9 @@ TrackContainerView QLabel
 /* common pattern colors */
 TrackContentObjectView   {
 	qproperty-mutedColor: rgb(255,255,255,100);
-	qproperty-mutedBackgroundColor: #0A0B0D;
+	qproperty-mutedBackgroundColor: #373d48;
 	qproperty-selectedColor: #006B65;
-	qproperty-BBPatternBackground: #0A0B0D;
+	qproperty-BBPatternBackground: #373d48;
 	qproperty-textColor: #fff;
 	qproperty-textShadowColor: rgb(0,0,0,200);
 	qproperty-gradient: false; /* boolean property, set true to have a gradient */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -584,6 +584,7 @@ TrackContentObjectView   {
 	qproperty-mutedColor: rgb(255,255,255,100);
 	qproperty-mutedBackgroundColor: #0A0B0D;
 	qproperty-selectedColor: #006B65;
+	qproperty-BBPatternBackground: #0A0B0D;
 	qproperty-textColor: #fff;
 	qproperty-textShadowColor: rgb(0,0,0,200);
 	qproperty-gradient: false; /* boolean property, set true to have a gradient */

--- a/include/Track.h
+++ b/include/Track.h
@@ -195,6 +195,7 @@ class TrackContentObjectView : public selectableObject, public ModelView
 	Q_PROPERTY( QColor selectedColor READ selectedColor WRITE setSelectedColor )
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
 	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
+	Q_PROPERTY( QColor BBPatternBackground READ BBPatternBackground WRITE setBBPatternBackground )
 	Q_PROPERTY( bool gradient READ gradient WRITE setGradient )
 
 public:
@@ -213,12 +214,14 @@ public:
 	QColor selectedColor() const;
 	QColor textColor() const;
 	QColor textShadowColor() const;
+	QColor BBPatternBackground() const;
 	bool gradient() const;
 	void setMutedColor( const QColor & c );
 	void setMutedBackgroundColor( const QColor & c );
 	void setSelectedColor( const QColor & c );
 	void setTextColor( const QColor & c );
 	void setTextShadowColor( const QColor & c );
+	void setBBPatternBackground( const QColor & c );
 	void setGradient( const bool & b );
 
 	// access needsUpdate member variable
@@ -293,6 +296,7 @@ private:
 	QColor m_selectedColor;
 	QColor m_textColor;
 	QColor m_textShadowColor;
+	QColor m_BBPatternBackground;
 	bool m_gradient;
 
  	bool m_needsUpdate;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -257,6 +257,7 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	m_selectedColor( 0, 0, 0 ),
 	m_textColor( 0, 0, 0 ),
 	m_textShadowColor( 0, 0, 0 ),
+	m_BBPatternBackground( 0, 0, 0 ),
 	m_gradient( true ),
 	m_needsUpdate( true )
 {
@@ -353,6 +354,9 @@ QColor TrackContentObjectView::textColor() const
 QColor TrackContentObjectView::textShadowColor() const
 { return m_textShadowColor; }
 
+QColor TrackContentObjectView::BBPatternBackground() const
+{ return m_BBPatternBackground; }
+
 bool TrackContentObjectView::gradient() const
 { return m_gradient; }
 
@@ -371,6 +375,9 @@ void TrackContentObjectView::setTextColor( const QColor & c )
 
 void TrackContentObjectView::setTextShadowColor( const QColor & c )
 { m_textShadowColor = QColor( c ); }
+
+void TrackContentObjectView::setBBPatternBackground( const QColor & c )
+{ m_BBPatternBackground = QColor( c ); }
 
 void TrackContentObjectView::setGradient( const bool & b )
 { m_gradient = b; }

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1237,12 +1237,11 @@ void PatternView::paintEvent( QPaintEvent * )
 		p.setPen( c.lighter( current ? 160 : 130 ) );
 		p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH, 
 			rect().bottom() - TCO_BORDER_WIDTH );
-	}
 	
 	// outer border
 	p.setPen( ( current && !beatPattern ) ? c.lighter( 130 ) : c.darker( 300 ) );
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
-
+	}
 	// draw the 'muted' pixmap only if the pattern was manualy muted
 	if( m_pat->isMuted() )
 	{

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1007,9 +1007,10 @@ void PatternView::paintEvent( QPaintEvent * )
 	bool current = gui->pianoRoll()->currentPattern() == m_pat;
 	bool beatPattern = m_pat->m_patternType == Pattern::BeatPattern;
 	
-	// state: selected, muted, normal
+	// state: selected, normal, beat pattern, muted
 	c = isSelected() ? selectedColor() : ( ( !muted && !beatPattern ) 
-		? painter.background().color() : mutedBackgroundColor() );
+		? painter.background().color() : ( beatPattern 
+		? BBPatternBackground() : mutedBackgroundColor() ) );
 
 	// invert the gradient for the background in the B&B editor
 	lingrad.setColorAt( beatPattern ? 0 : 1, c.darker( 300 ) );


### PR DESCRIPTION
Fixes #2634 
![screenshot from 2016-07-28 01 02 20](https://cloud.githubusercontent.com/assets/6282045/17195592/f49deae2-545e-11e6-833a-8161f230cd0b.png)

Screenshot for demonstration purposes only. The colors in both themes are set to the same color as muted tracks.