### PR TITLE
Light up the color of active FxLine

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -528,7 +528,7 @@ FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushBut
 FxLine {
 	background: #14161A;
 	color: #d1d8e4;
-	qproperty-backgroundActive: qlineargradient(spread:reflect, x2:0, y1:0, x2:0, y2:1, stop:0 #21242B, stop:1 #14161A);
+	qproperty-backgroundActive: #3B424A;
 	qproperty-strokeOuterActive: #262B30;
 	qproperty-strokeOuterInactive: #262B30;
 	qproperty-strokeInnerActive: #0C0D0F;


### PR DESCRIPTION
Light up the color of active FxLine. The color should be the same as the color of TrackView. Gradient removed.

![fxlinelighter](https://cloud.githubusercontent.com/assets/6502580/17241804/14fbc780-5574-11e6-8cc9-e50392e67d21.png)
