### PR TITLE
Waveshaper symmetry

### DIFF
--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -105,13 +105,13 @@ bool waveShaperEffect::processAudioBuffer( sampleFrame * _buf,
 	{
 		float s[2] = { _buf[f][0], _buf[f][1] };
 
-// apply symmetry
-		s[0] += *symmetryPtr;
-		s[1] += *symmetryPtr;
-
 // apply input gain
 		s[0] *= *inputPtr;
 		s[1] *= *inputPtr;
+
+// apply symmetry
+		s[0] += *symmetryPtr;
+		s[1] += *symmetryPtr;
 
 // clip if clip enabled
 		if( clip )

--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -85,21 +85,29 @@ bool waveShaperEffect::processAudioBuffer( sampleFrame * _buf,
 	const float w = wetLevel();
 	float input = m_wsControls.m_inputModel.value();
 	float output = m_wsControls.m_outputModel.value();
+	float symmetry = m_wsControls.m_symmetryModel.value();
 	const float * samples = m_wsControls.m_wavegraphModel.samples();
 	const bool clip = m_wsControls.m_clipModel.value();
 
 	ValueBuffer *inputBuffer = m_wsControls.m_inputModel.valueBuffer();
 	ValueBuffer *outputBufer = m_wsControls.m_outputModel.valueBuffer();
+	ValueBuffer *symmetryBuffer = m_wsControls.m_symmetryModel.valueBuffer();
 
 	int inputInc = inputBuffer ? 1 : 0;
 	int outputInc = outputBufer ? 1 : 0;
+	int symmetryInc = symmetryBuffer ? 1 : 0;
 
 	const float *inputPtr = inputBuffer ? &( inputBuffer->values()[ 0 ] ) : &input;
 	const float *outputPtr = outputBufer ? &( outputBufer->values()[ 0 ] ) : &output;
+	const float *symmetryPtr = symmetryBuffer ? &( symmetryBuffer->values()[ 0 ] ) : &symmetry;
 
 	for( fpp_t f = 0; f < _frames; ++f )
 	{
 		float s[2] = { _buf[f][0], _buf[f][1] };
+
+// apply symmetry
+		s[0] += *symmetryPtr;
+		s[1] += *symmetryPtr;
 
 // apply input gain
 		s[0] *= *inputPtr;
@@ -147,6 +155,7 @@ bool waveShaperEffect::processAudioBuffer( sampleFrame * _buf,
 
 		outputPtr += outputInc;
 		inputPtr += inputInc;
+		symmetryPtr += symmetryInc;
 	}
 
 	checkGate( out_sum / _frames );

--- a/plugins/waveshaper/waveshaper_control_dialog.cpp
+++ b/plugins/waveshaper/waveshaper_control_dialog.cpp
@@ -62,16 +62,22 @@ waveShaperControlDialog::waveShaperControlDialog(
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 225 );
 	inputKnob->setModel( &_controls->m_inputModel );
-	inputKnob->setLabel( tr( "INPUT" ) );
+	inputKnob->setLabel( tr( "IN" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
 	Knob * outputKnob = new Knob( knobBright_26, this );
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
-	outputKnob -> move( 76, 225 );
+	outputKnob -> move( 52, 225 );
 	outputKnob->setModel( &_controls->m_outputModel );
-	outputKnob->setLabel( tr( "OUTPUT" ) );
+	outputKnob->setLabel( tr( "OUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
+
+	Knob * symmetryKnob = new Knob( knobBright_26, this );
+	symmetryKnob -> move( 86, 225 );
+	symmetryKnob->setModel( &_controls->m_symmetryModel );
+	symmetryKnob->setLabel( tr( "SYM" ) );
+	symmetryKnob->setHintText( tr( "DC Component:" ), "" );
 
 	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
 	resetButton -> move( 162, 221 );

--- a/plugins/waveshaper/waveshaper_control_dialog.cpp
+++ b/plugins/waveshaper/waveshaper_control_dialog.cpp
@@ -60,7 +60,7 @@ waveShaperControlDialog::waveShaperControlDialog(
 	Knob * inputKnob = new Knob( knobBright_26, this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
-	inputKnob -> move( 26, 225 );
+	inputKnob -> move( 20, 225 );
 	inputKnob->setModel( &_controls->m_inputModel );
 	inputKnob->setLabel( tr( "IN" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
@@ -68,13 +68,13 @@ waveShaperControlDialog::waveShaperControlDialog(
 	Knob * outputKnob = new Knob( knobBright_26, this );
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
-	outputKnob -> move( 52, 225 );
+	outputKnob -> move( 56, 225 );
 	outputKnob->setModel( &_controls->m_outputModel );
 	outputKnob->setLabel( tr( "OUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
 	Knob * symmetryKnob = new Knob( knobBright_26, this );
-	symmetryKnob -> move( 86, 225 );
+	symmetryKnob -> move( 92, 225 );
 	symmetryKnob->setModel( &_controls->m_symmetryModel );
 	symmetryKnob->setLabel( tr( "SYM" ) );
 	symmetryKnob->setHintText( tr( "DC Component:" ), "" );

--- a/plugins/waveshaper/waveshaper_controls.cpp
+++ b/plugins/waveshaper/waveshaper_controls.cpp
@@ -41,6 +41,7 @@ waveShaperControls::waveShaperControls( waveShaperEffect * _eff ) :
 	m_effect( _eff ),
 	m_inputModel( 1.0f, 0.0f, 5.0f, 0.01f, this, tr( "Input gain" ) ),
 	m_outputModel( 1.0f, 0.0f, 5.0f, 0.01f, this, tr( "Output gain" ) ),
+	m_symmetryModel( 0.0f, -0.5f, 0.5f, 0.01f, this, tr( "Symmetry" ) ),
 	m_wavegraphModel( 0.0f, 1.0f, 200, this ),
 	m_clipModel( false, this )
 {
@@ -66,6 +67,7 @@ void waveShaperControls::loadSettings( const QDomElement & _this )
 //load input, output knobs
 	m_inputModel.loadSettings( _this, "inputGain" );
 	m_outputModel.loadSettings( _this, "outputGain" );
+	m_symmetryModel.loadSettings( _this, "symmetry" );
 	
 	m_clipModel.loadSettings( _this, "clipInput" );
 
@@ -88,6 +90,7 @@ void waveShaperControls::saveSettings( QDomDocument & _doc,
 //save input, output knobs
 	m_inputModel.saveSettings( _doc, _this, "inputGain" );
 	m_outputModel.saveSettings( _doc, _this, "outputGain" );
+	m_symmetryModel.saveSettings( _doc, _this, "symmetry" );
 
 	m_clipModel.saveSettings( _doc, _this, "clipInput" );
 

--- a/plugins/waveshaper/waveshaper_controls.h
+++ b/plugins/waveshaper/waveshaper_controls.h
@@ -76,6 +76,7 @@ private:
 	waveShaperEffect * m_effect;
 	FloatModel m_inputModel;
 	FloatModel m_outputModel;
+	FloatModel m_symmetryModel;
 	graphModel m_wavegraphModel;
 	BoolModel  m_clipModel;
 


### PR DESCRIPTION
closes #2208

![waveshapersymmetry](https://cloud.githubusercontent.com/assets/6368949/21187147/423647b0-c217-11e6-96fa-54e40b61f240.png)

Symmetry. Add +/-0.5 DC component to the input.
