### PR TITLE
SF_INFO.format init to 0

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -384,6 +384,7 @@ f_cnt_t SampleBuffer::decodeSampleSF( const char * _f,
 {
 	SNDFILE * snd_file;
 	SF_INFO sf_info;
+	sf_info.format = 0;
 	f_cnt_t frames = 0;
 	bool sf_rr = false;
 


### PR DESCRIPTION
closes #2042

@Bloody95 dropped a patch on us...

http://www.mega-nerd.com/libsndfile/api.html#open

> When opening a file for read, the format field should be set to zero before calling sf_open().