### PR TITLE
Pattern::changeTimeSignature(), off by one

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -665,7 +665,7 @@ bool Pattern::empty()
 
 void Pattern::changeTimeSignature()
 {
-	MidiTime last_pos = MidiTime::ticksPerTact();
+	MidiTime last_pos = MidiTime::ticksPerTact() - 1;
 	for( NoteVector::ConstIterator cit = m_notes.begin();
 						cit != m_notes.end(); ++cit )
 	{


### PR DESCRIPTION
Fixes #2926

OK. This is bit deeper in the code than I usually go...

I didn't manage to wrap my head around MidiTime positions, but it looks like it's supposed to go from 0, as that's the way it's done in other places ( [`Pattern::ensureBeatNotes()`](https://github.com/LMMS/lmms/blob/master/src/tracks/Pattern.cpp#L578:L601) , so the last position must be one lower.

With this fix the last note will instead be first in a new second beat.

_Edit: Fixed links..._