### PR TITLE
Beat note bug at the end of bars

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -125,6 +125,7 @@ private:
 	void upgrade_1_0_99();
 	void upgrade_1_1_0();
 	void upgrade_1_1_91();
+	void upgrade_1_2_0_rc3();
 
 	void upgrade();
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -901,6 +901,32 @@ void DataFile::upgrade_1_1_91()
 }
 
 
+void DataFile::upgrade_1_2_0_rc3()
+{
+	// Upgrade from earlier bbtrack beat note behaviour of adding
+	// steps if a note is placed after the last step.
+	QDomNodeList list = elementsByTagName( "bbtrack" );
+	for( int i = 0; !list.item( i ).isNull(); ++i )
+	{
+		list = elementsByTagName( "pattern" );
+		for( int i = 0; !list.item( i ).isNull(); ++i )
+		{
+			int patternLength, steps;
+			QDomElement el = list.item( i ).toElement();
+			for( int i = 0; !list.item( i ).isNull(); ++i )
+			{
+				if( el.attribute( "len" ) != "" )
+				{
+					patternLength = el.attribute( "len" ).toInt();
+					steps = patternLength / 12;
+					el.setAttribute( "steps", steps );
+				}
+			}
+		}
+	}
+}
+
+
 void DataFile::upgrade()
 {
 	ProjectVersion version =
@@ -976,6 +1002,10 @@ void DataFile::upgrade()
 	if( version < "1.1.91-0" )
 	{
 		upgrade_1_1_91();
+	}
+	if( version < "1.2.0-rc3" )
+	{
+		upgrade_1_2_0_rc3();
 	}
 
 	// update document meta data

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -196,20 +196,21 @@ MidiTime Pattern::beatPatternLength() const
 		if( ( *it )->length() < 0 )
 		{
 			max_length = qMax<tick_t>( max_length,
-				( *it )->pos() +
-					MidiTime::ticksPerTact() /
-						MidiTime::stepsPerTact() );
+				( *it )->pos() + 1 );
 		}
 	}
 
 	if( m_steps != MidiTime::stepsPerTact() )
 	{
 		max_length = m_steps * MidiTime::ticksPerTact() /
-						MidiTime::stepsPerTact() ;
+						MidiTime::stepsPerTact();
 	}
 
 	return MidiTime( max_length ).nextFullTact() * MidiTime::ticksPerTact();
 }
+
+
+
 
 Note * Pattern::addNote( const Note & _new_note, const bool _quant_pos )
 {


### PR DESCRIPTION
Fixes #1105 

I had a go at fixing the problem with beat notes on position near the end of the beat forcing the insert of an extra bar. ~~I also tweaked the Piano Roll notes to not do the same depending on where they end but on the start position. To me that's more logical behaviour.~~

_Edit2: This is now a pure fix for #1105 and the rest is edited out and will be a separate PR._
