### PR TITLE
Add option to set the list of plug-ins to build

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -5,50 +5,83 @@ INCLUDE_DIRECTORIES(
 	${SAMPLERATE_INCLUDE_DIRS}
 )
 
-ADD_SUBDIRECTORY(Amplifier)
-ADD_SUBDIRECTORY(audio_file_processor)
-ADD_SUBDIRECTORY(BassBooster)
-ADD_SUBDIRECTORY(bit_invader)
-ADD_SUBDIRECTORY(Bitcrush)
-ADD_SUBDIRECTORY(carlabase)
-ADD_SUBDIRECTORY(carlapatchbay)
-ADD_SUBDIRECTORY(carlarack)
-ADD_SUBDIRECTORY(CrossoverEQ)
-ADD_SUBDIRECTORY(Delay)
-ADD_SUBDIRECTORY(DualFilter)
-ADD_SUBDIRECTORY(dynamics_processor)
-ADD_SUBDIRECTORY(Eq)
-ADD_SUBDIRECTORY(Flanger)
-ADD_SUBDIRECTORY(HydrogenImport)
-ADD_SUBDIRECTORY(kicker)
-ADD_SUBDIRECTORY(ladspa_browser)
-ADD_SUBDIRECTORY(LadspaEffect)
-ADD_SUBDIRECTORY(lb302)
-ADD_SUBDIRECTORY(MidiImport)
-ADD_SUBDIRECTORY(MidiExport)
-ADD_SUBDIRECTORY(MultitapEcho)
-ADD_SUBDIRECTORY(monstro)
-ADD_SUBDIRECTORY(nes)
-ADD_SUBDIRECTORY(opl2)
-ADD_SUBDIRECTORY(organic)
-ADD_SUBDIRECTORY(papu)
-ADD_SUBDIRECTORY(patman)
-ADD_SUBDIRECTORY(peak_controller_effect)
-IF(NOT LMMS_BUILD_APPLE)
-   ADD_SUBDIRECTORY(sf2_player)
+SET(PLUGIN_LIST "" CACHE STRING "List of plug-ins to build")
+
+STRING(REPLACE " " ";" PLUGIN_LIST "${PLUGIN_LIST}")
+
+OPTION(LMMS_MINIMAL "Build a minimal list of plug-ins" OFF)
+
+SET(MINIMAL_LIST
+	audio_file_processor
+	kicker
+	triple_oscillator
+)
+
+IF(LMMS_MINIMAL)
+	IF("${PLUGIN_LIST}" STREQUAL "")
+		STRING(REPLACE ";" " " MINIMAL_LIST_STRING "${MINIMAL_LIST}")
+		MESSAGE(
+"-- Using minimal plug-ins: ${MINIMAL_LIST_STRING}\n"
+"   Note: You can specify specific plug-ins using -DPLUGIN_LIST=\"foo bar\""
+		)
+	ENDIF()
+	SET(PLUGIN_LIST ${MINIMAL_LIST} ${PLUGIN_LIST})
 ENDIF()
-ADD_SUBDIRECTORY(GigPlayer)
-ADD_SUBDIRECTORY(sfxr)
-ADD_SUBDIRECTORY(sid)
-ADD_SUBDIRECTORY(SpectrumAnalyzer)
-ADD_SUBDIRECTORY(stereo_enhancer)
-ADD_SUBDIRECTORY(stereo_matrix)
-ADD_SUBDIRECTORY(stk)
-ADD_SUBDIRECTORY(triple_oscillator)
-ADD_SUBDIRECTORY(vestige)
-ADD_SUBDIRECTORY(vst_base)
-ADD_SUBDIRECTORY(VstEffect)
-ADD_SUBDIRECTORY(watsyn)
-ADD_SUBDIRECTORY(waveshaper)
-ADD_SUBDIRECTORY(vibed)
-ADD_SUBDIRECTORY(zynaddsubfx)
+
+IF("${PLUGIN_LIST}" STREQUAL "")
+	SET(PLUGIN_LIST
+		${MINIMAL_LIST}
+		Amplifier
+		BassBooster
+		bit_invader
+		Bitcrush
+		carlabase
+		carlapatchbay
+		carlarack
+		CrossoverEQ
+		Delay
+		DualFilter
+		dynamics_processor
+		Eq
+		Flanger
+		HydrogenImport
+		ladspa_browser
+		LadspaEffect
+		lb302
+		MidiImport
+		MidiExport
+		MultitapEcho
+		monstro
+		nes
+		opl2
+		organic
+		papu
+		patman
+		peak_controller_effect
+		GigPlayer
+		sfxr
+		sid
+		SpectrumAnalyzer
+		stereo_enhancer
+		stereo_matrix
+		stk
+		vestige
+		vst_base
+		VstEffect
+		watsyn
+		waveshaper
+		vibed
+		zynaddsubfx
+	)
+
+	IF(NOT LMMS_BUILD_APPLE)
+		SET(PLUGIN_LIST
+			${PLUGIN_LIST}
+			sf2_player
+		)
+	ENDIF()
+ENDIF("${PLUGIN_LIST}" STREQUAL "")
+
+FOREACH(PLUGIN ${PLUGIN_LIST})
+	ADD_SUBDIRECTORY(${PLUGIN})
+ENDFOREACH()


### PR DESCRIPTION
This fixes #2580. Configure with `-DPLUGIN_LIST="audio_file_processor kicker triple_oscillator"`.