### PR TITLE
Do not make preset names all lowercase

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1583,7 +1583,7 @@ void InstrumentTrackWindow::saveSettingsBtnClicked()
 	sfd.setDirectory( presetRoot + m_track->instrumentName() );
 	sfd.setFileMode( FileDialog::AnyFile );
 	QString fname = m_track->name();
-	sfd.selectFile(fname.remove(QRegExp("[^a-zA-Z0-9\\d\\s]")).toLower().replace( " ", "_" ) );
+	sfd.selectFile( fname.remove(QRegExp("[^a-zA-Z0-9_\\-\\d\\s]")) );
 
 	if( sfd.exec() == QDialog::Accepted &&
 		!sfd.selectedFiles().isEmpty() &&


### PR DESCRIPTION
Fixes #2839

I removed the call to make the preset name lowercase and the call to replace all spaces with underscores. Furthermore, I modified the regex so it also allows dashes and underscores in the name.

![screenshot from 2016-08-13 01 14 58](https://cloud.githubusercontent.com/assets/6282045/17639536/769b8cde-60f3-11e6-84e9-a001c0317201.png)
![screenshot from 2016-08-13 01 15 21](https://cloud.githubusercontent.com/assets/6282045/17639534/76820f34-60f3-11e6-9e32-3322e0e6cc9e.png)


