### PR TITLE
Honor CONTRIBUTORS override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,9 +458,13 @@ FILE(REMOVE include/lmmsconfig.h)
 FILE(GLOB LMMS_INCLUDES "${CMAKE_SOURCE_DIR}/include/*.h")
 LIST(SORT LMMS_INCLUDES)
 
-# Get list of all committers from git history, ordered by number of commits
+# Get list of all committers from git history, ordered by number of commits.
+# The CONTRIBUTORS file is used by AboutDialog. This information can be provided
+# with -DCONTRIBUTORS=/path/to/CONTRIBUTORS instead. For instance, to generate
+# this file for version 1.1.3, the command is:
+# 	git shortlog -sne v1.1.3 | cut -c8-
 FIND_PACKAGE(Git)
-IF(GIT_FOUND)
+IF(GIT_FOUND AND NOT CONTRIBUTORS)
 	SET(CONTRIBUTORS "${CMAKE_BINARY_DIR}/CONTRIBUTORS")
 	EXECUTE_PROCESS(
 		COMMAND "${GIT_EXECUTABLE}" shortlog -sne
@@ -468,7 +472,7 @@ IF(GIT_FOUND)
 		OUTPUT_FILE "${CONTRIBUTORS}"
 		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 		TIMEOUT 1)
-ENDIF(GIT_FOUND)
+ENDIF()
 
 # embedded resources stuff
 IF(WIN32 OR WIN64)


### PR DESCRIPTION
When building from the source tarball, there is no Git history from LMMS and no `CONTRIBUTORS` file, which is used by `AboutDialog`. When packaging in Debian, the `CONTRIBUTORS` file can be added and configured with `-DCONTRIBUTORS=/path/to/CONTRIBUTORS`. However, there is Git history from the Debian packaging and that information is the one embedded in the program. With this patch, Git history is ignored if `-DCONTRIBUTORS` is set.