### PR TITLE
Request change in model when deleting a track

### DIFF
--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -22,6 +22,8 @@
  *
  */
 
+#include "TrackContainerView.h"
+
 #include <algorithm>
 
 #include <QApplication>
@@ -32,10 +34,10 @@
 #include <QWheelEvent>
 
 
-#include "TrackContainerView.h"
 #include "TrackContainer.h"
 #include "BBTrack.h"
 #include "MainWindow.h"
+#include "Mixer.h"
 #include "debug.h"
 #include "FileBrowser.h"
 #include "ImportFilter.h"
@@ -271,7 +273,9 @@ void TrackContainerView::deleteTrackView( TrackView * _tv )
 	removeTrackView( _tv );
 	delete _tv;
 
-	t->deleteLater();
+	Engine::mixer()->requestChangeInModel();
+	delete t;
+	Engine::mixer()->doneChangeInModel();
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -155,15 +155,11 @@ int InstrumentTrack::baseNote() const
 
 InstrumentTrack::~InstrumentTrack()
 {
-	Engine::mixer()->requestChangeInModel();
-
 	// kill all running notes and the iph
 	silenceAllNotes( true );
 
 	// now we're save deleting the instrument
 	if( m_instrument ) delete m_instrument;
-
-	Engine::mixer()->doneChangeInModel();
 }
 
 


### PR DESCRIPTION
When removing an instrument track while playing, it is not disconnected after `~InstrumentTrack()` and it is still used by the mixer (segfault). The disconnection is done at `~Track()`, so the request to change the model should cover all destructors, not just `~InstrumentTrack()`.