### PR TITLE
Create BB-related TCOs along with BB-related tracks

### DIFF
--- a/include/Track.h
+++ b/include/Track.h
@@ -526,6 +526,8 @@ public:
 							const MidiTime & end );
 	void swapPositionOfTCOs( int tcoNum1, int tcoNum2 );
 
+	void createTCOsForBB( int bb );
+
 
 	void insertTact( const MidiTime & pos );
 	void removeTact( const MidiTime & pos );

--- a/src/core/BBTrackContainer.cpp
+++ b/src/core/BBTrackContainer.cpp
@@ -85,12 +85,6 @@ void BBTrackContainer::updateAfterTrackAdd()
 	{
 		Engine::getSong()->addBBTrack();
 	}
-
-	// make sure, new track(s) have TCOs for every beat/bassline
-	for( int i = 0; i < qMax<int>( 1, numOfBBs() ); ++i )
-	{
-		createTCOsForBB( i );
-	}
 }
 
 
@@ -221,9 +215,6 @@ void BBTrackContainer::updateComboBox()
 
 void BBTrackContainer::currentBBChanged()
 {
-	// first make sure, all channels have a TCO at current BB
-	createTCOsForBB( currentBB() );
-
 	// now update all track-labels (the current one has to become white,
 	// the others gray)
 	TrackList tl = Engine::getSong()->tracks();
@@ -241,21 +232,10 @@ void BBTrackContainer::currentBBChanged()
 
 void BBTrackContainer::createTCOsForBB( int _bb )
 {
-	if( numOfBBs() == 0 || Engine::getSong()->isLoadingProject() )
-	{
-		return;
-	}
-
 	TrackList tl = tracks();
 	for( int i = 0; i < tl.size(); ++i )
 	{
-		while( tl[i]->numOfTCOs() < _bb + 1 )
-		{
-			MidiTime position = MidiTime( tl[i]->numOfTCOs(), 0 );
-			TrackContentObject * tco = tl[i]->createTCO( position );
-			tco->movePosition( position );
-			tco->changeLength( MidiTime( 1, 0 ) );
-		}
+		tl[i]->createTCOsForBB( _bb );
 	}
 }
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1954,6 +1954,8 @@ Track::~Track()
  */
 Track * Track::create( TrackTypes tt, TrackContainer * tc )
 {
+	Engine::mixer()->requestChangeInModel();
+
 	Track * t = NULL;
 
 	switch( tt )
@@ -1969,7 +1971,15 @@ Track * Track::create( TrackTypes tt, TrackContainer * tc )
 		default: break;
 	}
 
+	if( tc == Engine::getBBTrackContainer() && t )
+	{
+		t->createTCOsForBB( Engine::getBBTrackContainer()->numOfBBs()
+									- 1 );
+	}
+
 	tc->updateAfterTrackAdd();
+
+	Engine::mixer()->doneChangeInModel();
 
 	return t;
 }
@@ -2327,6 +2337,20 @@ void Track::swapPositionOfTCOs( int tcoNum1, int tcoNum2 )
 	m_trackContentObjects[tcoNum1]->movePosition(
 			m_trackContentObjects[tcoNum2]->startPosition() );
 	m_trackContentObjects[tcoNum2]->movePosition( pos );
+}
+
+
+
+
+void Track::createTCOsForBB( int bb )
+{
+	while( numOfTCOs() < bb + 1 )
+	{
+		MidiTime position = MidiTime( numOfTCOs(), 0 );
+		TrackContentObject * tco = createTCO( position );
+		tco->movePosition( position );
+		tco->changeLength( MidiTime( 1, 0 ) );
+	}
 }
 
 

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -412,6 +412,7 @@ BBTrack::BBTrack( TrackContainer* tc ) :
 	s_infoMap[this] = bbNum;
 
 	setName( tr( "Beat/Bassline %1" ).arg( bbNum ) );
+	Engine::getBBTrackContainer()->createTCOsForBB( bbNum );
 	Engine::getBBTrackContainer()->setCurrentBB( bbNum );
 	Engine::getBBTrackContainer()->updateComboBox();
 
@@ -548,7 +549,6 @@ void BBTrack::loadTrackSpecificSettings( const QDomElement & _this )
 	{
 		const int src = _this.attribute( "clonebbt" ).toInt();
 		const int dst = s_infoMap[this];
-		Engine::getBBTrackContainer()->createTCOsForBB( dst );
 		TrackContainer::TrackList tl =
 					Engine::getBBTrackContainer()->tracks();
 		// copy TCOs of all tracks from source BB (at bar "src") to destination


### PR DESCRIPTION
This should have fixed #2957. BB-related TCOs were created on updates, which is not the right moment, and could cause the mixer to render tracks without these TCOs.