### PR TITLE
Return NULL when asking for 0 bytes with MM_ALLOC

### DIFF
--- a/src/core/MemoryManager.cpp
+++ b/src/core/MemoryManager.cpp
@@ -50,6 +50,11 @@ bool MemoryManager::init()
 
 void * MemoryManager::alloc( size_t size )
 {
+	if( !size )
+	{
+		return NULL;
+	}
+
 	int requiredChunks = size / MM_CHUNK_SIZE + ( size % MM_CHUNK_SIZE > 0 ? 1 : 0 );
 
 	MemoryPool * mp = NULL;

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -151,9 +151,7 @@ SampleBuffer::SampleBuffer( const f_cnt_t _frames ) :
 
 SampleBuffer::~SampleBuffer()
 {
-	if( m_origData != NULL )
-		MM_FREE( m_origData );
-
+	MM_FREE( m_origData );
 	MM_FREE( m_data );
 }
 


### PR DESCRIPTION
Consecutive calls to `MM_ALLOC` with a size of 0 return the same pointer, then the second call to `MM_FREE` aborts the program.