### PR TITLE
Avoid interception by PulseAudio

### DIFF
--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -54,6 +54,12 @@ AudioAlsa::AudioAlsa( bool & _success_ful, Mixer*  _mixer ) :
 {
 	_success_ful = false;
 
+	if( setenv( "PULSE_ALSA_HOOK_CONF", "/dev/null", 0 ) )
+	{
+		fprintf( stderr,
+		"Could not avoid possible interception by PulseAudio\n" );
+	}
+
 	int err;
 
 	if( ( err = snd_pcm_open( &m_handle,


### PR DESCRIPTION
This is another workaround for #158. It is better than #2743 because it does not depend on the PulseAudio back end, and it allows to use the real default ALSA device.

There should be a way for an ALSA application not to be intercepted by PulseAudio; for instance, by setting an environment variable. In a Debian system, the following procedure would need to be pushed to the `pulseaudio` package:
- Rename `/usr/share/alsa/alsa.conf.d/pulse.conf` to `/usr/share/alsa/pulse-hook.conf`.
- Add new `/usr/share/alsa/alsa.conf.d/pulse.conf` with this content:

```
@hooks [
    {
        func load
        files [
            {
                @func getenv
                vars [
                    PULSE_ALSA_HOOK_CONF
                ]
                default "/usr/share/alsa/pulse-hook.conf"
            }
        ]
        errors false
    }
]
```
