### PR TITLE
Request change in model when dropping a track

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2658,9 +2658,9 @@ void TrackView::dropEvent( QDropEvent * de )
 		// value contains our XML-data so simply create a
 		// DataFile which does the rest for us...
 		DataFile dataFile( value.toUtf8() );
-		m_track->lock();
+		Engine::mixer()->requestChangeInModel();
 		m_track->restoreState( dataFile.content().firstChild().toElement() );
-		m_track->unlock();
+		Engine::mixer()->doneChangeInModel();
 		de->accept();
 	}
 }


### PR DESCRIPTION
Dragging an instrument track on another one will lock the interface; this patch removes the lock. When dragging between the song editor and the BB editor, the new track has unexpected patterns, but that is another issue.