### PR TITLE
Fix sample track view in BB editor

### DIFF
--- a/include/AutomationPatternView.h
+++ b/include/AutomationPatternView.h
@@ -44,7 +44,6 @@ public:
 public slots:
 	/// Opens this view's pattern in the global automation editor
 	void openInAutomationEditor();
-	virtual void update();
 
 
 protected slots:

--- a/include/BBEditor.h
+++ b/include/BBEditor.h
@@ -84,6 +84,7 @@ public slots:
 	void addSteps();
 	void cloneSteps();
 	void removeSteps();
+	void addSampleTrack();
 	void addAutomationTrack();
 
 protected slots:

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -316,6 +316,10 @@ TrackContentObjectView::~TrackContentObjectView()
  */
 void TrackContentObjectView::update()
 {
+	if( fixedTCOs() )
+	{
+		updateLength();
+	}
 	m_needsUpdate = true;
 	selectableObject::update();
 }

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -82,19 +82,6 @@ void AutomationPatternView::openInAutomationEditor()
 
 
 
-
-void AutomationPatternView::update()
-{
-	if( fixedTCOs() )
-	{
-		m_pat->changeLength( m_pat->length() );
-	}
-	TrackContentObjectView::update();
-}
-
-
-
-
 void AutomationPatternView::resetName()
 {
 	m_pat->setName( QString::null );

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -99,6 +99,10 @@ BBEditor::BBEditor( BBTrackContainer* tc ) :
 
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_bb_track"), tr("Add beat/bassline"),
 						 Engine::getSong(), SLOT(addBBTrack()));
+	trackAndStepActionsToolBar->addAction(
+				embed::getIconPixmap("add_sample_track"),
+				tr("Add sample-track"), m_trackContainerView,
+				SLOT(addSampleTrack()));
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_automation"), tr("Add automation-track"),
 						 m_trackContainerView, SLOT(addAutomationTrack()));
 
@@ -205,6 +209,14 @@ void BBTrackContainerView::removeSteps()
 			p->removeSteps();
 		}
 	}
+}
+
+
+
+
+void BBTrackContainerView::addSampleTrack()
+{
+	(void) Track::create( Track::SampleTrack, model() );
 }
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -752,8 +752,6 @@ PatternView::~PatternView()
 
 void PatternView::update()
 {
-	m_pat->changeLength( m_pat->length() );
-	
 	if ( m_pat->m_patternType == Pattern::BeatPattern )
 	{
 		ToolTip::add( this,

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -368,14 +368,14 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	QLinearGradient lingrad( 0, 0, 0, height() );
 	QColor c;
 	bool muted = m_tco->getTrack()->isMuted() || m_tco->isMuted();
-	
+
 	// state: selected, muted, normal
 	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
 		: painter.background().color() );
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );
-	
+
 	if( gradient() )
 	{
 		p.fillRect( rect(), lingrad );
@@ -386,13 +386,17 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	}
 
 	p.setPen( !muted ? painter.pen().brush().color() : mutedColor() );
-	
+
 	const int spacing = TCO_BORDER_WIDTH + 1;
-	
+	const float ppt = fixedTCOs() ?
+			( parentWidget()->width() - 2 * TCO_BORDER_WIDTH )
+					/ (float) m_tco->length().getTact() :
+								pixelsPerTact();
+
 	QRect r = QRect( TCO_BORDER_WIDTH, spacing,
-			qMax( static_cast<int>( m_tco->sampleLength() *
-				pixelsPerTact() / DefaultTicksPerTact ), 1 ),
-					rect().bottom() - 2 * spacing );
+			qMax( static_cast<int>( m_tco->sampleLength() * ppt
+						/ DefaultTicksPerTact ), 1 ),
+						rect().bottom() - 2 * spacing );
 	m_tco->m_sampleBuffer->visualize( p, r, pe->rect() );
 
 	// disable antialiasing for borders, since its not needed
@@ -408,11 +412,11 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	p.setPen( c.lighter( 160 ) );
 	p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH, 
 		rect().bottom() - TCO_BORDER_WIDTH );
-		
+
 	// outer border
 	p.setPen( c.darker( 300 ) );
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
-	
+
 	// draw the 'muted' pixmap only if the pattern was manualy muted
 	if( m_tco->isMuted() )
 	{
@@ -421,9 +425,9 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 		p.drawPixmap( spacing, height() - ( size + spacing ),
 			embed::getIconPixmap( "muted", size, size ) );
 	}
-	
+
 	// recording sample tracks is not possible at the moment 
-	
+
 	/* if( m_tco->isRecord() )
 	{
 		p.setFont( pointSize<7>( p.font() ) );
@@ -436,9 +440,9 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 		p.setBrush( QBrush( textColor() ) );
 		p.drawEllipse( 4, 5, 4, 4 );
 	}*/
-	
+
 	p.end();
-	
+
 	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 


### PR DESCRIPTION
The goal is not mentioned in #1471. A sample track can be added to the BB editor by copying the track from the song editor. The pattern works, but the display is neglected. This patch fixes the view and includes a button to add a sample track to the BB editor.