### PR TITLE
Fix LFO drifting

### DIFF
--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -221,7 +221,7 @@ void AutomatableModel::setValue( const float value )
 	++m_setValueDepth;
 	const float old_val = m_value;
 
-	m_value = fittedValue( value, true );
+	m_value = fittedValue( value );
 	if( old_val != m_value )
 	{
 		// add changes to history so user can undo it

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -138,9 +138,9 @@ void TempoSyncKnobModel::saveSettings( QDomDocument & _doc, QDomElement & _this,
 void TempoSyncKnobModel::loadSettings( const QDomElement & _this,
 							const QString & _name )
 {
- 	setSyncMode( ( TempoSyncMode ) _this.attribute( "syncmode" ).toInt() );
-	m_custom.loadSettings( _this, _name );
 	FloatModel::loadSettings( _this, _name );
+	m_custom.loadSettings( _this, _name );
+	setSyncMode( ( TempoSyncMode ) _this.attribute( "syncmode" ).toInt() );
 }
 
 


### PR DESCRIPTION
This fixes #2501, a regression from 44f1d3df85afba439706ec01cc2b4b877a368001. I don't know why the `true` parameter was added, so I don't know if reverting the change will have any negative side-effects.