### PR TITLE
Fix undefined reference to vtable for AudioSoundIoSetupUtil

### DIFF
--- a/include/AudioSoundIo.h
+++ b/include/AudioSoundIo.h
@@ -45,6 +45,8 @@ class AudioSoundIoSetupUtil : public QObject
 {
 	Q_OBJECT
 public:
+	virtual ~AudioSoundIoSetupUtil();
+
 	void *m_setupWidget;
 public slots:
 	void updateDevices();

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -282,6 +282,10 @@ void AudioSoundIo::writeCallback(int frameCountMin, int frameCountMax)
 	}
 }
 
+AudioSoundIoSetupUtil::~AudioSoundIoSetupUtil()
+{
+}
+
 void AudioSoundIoSetupUtil::reconnectSoundIo()
 {
 	((AudioSoundIo::setupWidget *)m_setupWidget)->reconnectSoundIo();


### PR DESCRIPTION
This fixes the compilation error ``undefined reference to `vtable for AudioSoundIoSetupUtil'``. The environment is Debian Sid, G++ 6.2.0.