### PR TITLE
Fix regressions on loading broken projects

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -340,6 +340,7 @@ private:
 	QString m_fileName;
 	QString m_oldFileName;
 	bool m_modified;
+	bool m_loadOnLaunch;
 
 	volatile bool m_recording;
 	volatile bool m_exporting;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -85,6 +85,7 @@ Song::Song() :
 	m_fileName(),
 	m_oldFileName(),
 	m_modified( false ),
+	m_loadOnLaunch( true ),
 	m_recording( false ),
 	m_exporting( false ),
 	m_exportLoop( false ),
@@ -911,6 +912,7 @@ void Song::createNewProject()
 	QCoreApplication::sendPostedEvents();
 
 	m_modified = false;
+	m_loadOnLaunch = false;
 
 	if( gui->mainWindow() )
 	{
@@ -928,11 +930,11 @@ void Song::createNewProjectFromTemplate( const QString & templ )
 	// saving...
 	m_fileName = m_oldFileName = "";
 	// update window title
+	m_loadOnLaunch = false;
 	if( gui->mainWindow() )
 	{
 		gui->mainWindow()->resetWindowTitle();
 	}
-
 }
 
 
@@ -947,16 +949,23 @@ void Song::loadProject( const QString & fileName )
 
 	Engine::projectJournal()->setJournalling( false );
 
+	m_oldFileName = m_fileName;
 	m_fileName = fileName;
-	m_oldFileName = fileName;
 
 	DataFile dataFile( m_fileName );
 	// if file could not be opened, head-node is null and we create
 	// new project
-	if( dataFile.validate( fileName.right( fileName.lastIndexOf(".") ) ) )
+	if( dataFile.head().isNull() )
 	{
+		if( m_loadOnLaunch )
+		{
+			createNewProject();
+		}
+		m_fileName = m_oldFileName;
 		return;
 	}
+
+	m_oldFileName = m_fileName;
 
 	clearProject();
 
@@ -1074,6 +1083,7 @@ void Song::loadProject( const QString & fileName )
 
 	m_loadingProject = false;
 	m_modified = false;
+	m_loadOnLaunch = false;
 
 	if( gui && gui->mainWindow() )
 	{
@@ -1180,6 +1190,7 @@ void Song::importProject()
 	{
 		ImportFilter::import( ofd.selectedFiles()[0], this );
 	}
+	m_loadOnLaunch = false;
 }
 
 


### PR DESCRIPTION
The original issue #781 concerned active projects being overwritten by a default project on failing to load another project.
This was closed in #1258 which worked indeed but broke handing a default project on failing to load from the command line. Also, failing to open a project, be it from the command line or gui, still sets the project title.
Enter #1838 which breaks testing of if the project could be opened. It replaces this with a suffix test. I simply revert that line.

This should fix #781 without breaking anything.