### PR TITLE
Multiple instance recover files

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -182,7 +182,7 @@ public:
 
 	const QString recoveryFile() const
 	{
-		return m_workingDir + "recover.mmp";
+		return m_workingDir + m_uniqueSessionString + ".recover.mmp";
 	}
 	
 	const QString & version() const
@@ -216,6 +216,11 @@ public:
 
 	// returns true if the working dir (e.g. ~/lmms) exists on disk
 	bool hasWorkingDir() const;
+
+	void setUniqueSessionName( QString uniqueString )
+	{
+		m_uniqueSessionString = uniqueString;
+	}
 
 	void addRecentlyOpenedProject( const QString & _file );
 
@@ -254,6 +259,7 @@ private:
 	void upgrade_1_1_90();
 	void upgrade();
 
+	QString m_uniqueSessionString;
 	QString m_lmmsRcFile;
 	QString m_workingDir;
 	QString m_dataDir;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -110,8 +110,7 @@ public:
 	enum SessionState
 	{
 		Normal,
-		Recover,
-		Limited,
+		Recover
 	};
 
 	void setSession( SessionState session )

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -257,8 +257,9 @@ void ConfigManager::createWorkingDir()
 void ConfigManager::addRecentlyOpenedProject( const QString & file )
 {
 	QFileInfo recentFile( file );
-	if( recentFile.suffix().toLower() == "mmp" ||
-			recentFile.suffix().toLower() == "mmpz" )
+	if( ( recentFile.suffix().toLower() == "mmp" ||
+			recentFile.suffix().toLower() == "mmpz" ) &&
+				file != recoveryFile() )
 	{
 		m_recentlyOpenedProjects.removeAll( file );
 		if( m_recentlyOpenedProjects.size() > 50 )

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -751,11 +751,6 @@ int main( int argc, char * * argv )
 					QStringList() << "*.recover.mmp", QDir::Files );
 		while( it.hasNext() )
 		{
-			if( ! QFile( it.filePath() ).size() )
-			{
-				QFile::remove( it.filePath() );
-				qDebug() << "Removing empty file " << it.filePath();
-			}
 			if( QFileInfo( it.filePath() ).created() > created )
 			{
 				created = QFileInfo( it.filePath() ).created();
@@ -873,29 +868,16 @@ int main( int argc, char * * argv )
 			}
 		}
 
-
 		// Create unique recover file
 		session = createRandomFileName();
-		QFileInfo fileToCheck( session );
-		while( fileToCheck.exists() )
+		while( QFileInfo(ConfigManager::inst()->workingDir()
+					+ session + ".recover.mmp" ).exists() )
 		{
 			session = createRandomFileName();
-	//		fileToCheck( session );
 		}
 		ConfigManager::inst()->setUniqueSessionName( session );
 
 		qDebug() << ConfigManager::inst()->recoveryFile();
-
-		QFile file( ConfigManager::inst()->recoveryFile() );
-		if ( ! file.open(QIODevice::ReadWrite) )
-		{
-			printf( "Couldn't create unique a unique recover \
-				file for this session." );
-			printf( "You may not have the permission to write \
-				to %s", ConfigManager::inst()->
-					workingDir().toUtf8().constData() );
-		}
-
 
 		gui->mainWindow()->show();
 		if( fullscreen )

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -208,7 +208,10 @@ QString createRandomFileName()
 		hashString.append( rand() % 256 );
 	}
 
-	return QString( QCryptographicHash::hash( hashString, QCryptographicHash::Md5 ).toHex() );
+	QString recoverFile;
+	recoverFile = QString( QCryptographicHash::hash( hashString, QCryptographicHash::Md5 ).toHex() );
+	recoverFile.truncate( 8 );
+	return recoverFile += ".recover.mmp";
 }
 
 
@@ -231,7 +234,9 @@ int main( int argc, char * * argv )
 	bool allowRoot = false;
 	bool renderLoop = false;
 	bool renderTracks = false;
-	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
+	QString session, fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
+
+	QString filename="Data.txt";
 
 	// first of two command-line parsing stages
 	for( int i = 1; i < argc; ++i )
@@ -824,6 +829,29 @@ int main( int argc, char * * argv )
 			{
 				return 0;
 			}
+		}
+
+		// Create unique recover file
+		session = createRandomFileName();
+		QFileInfo fileToCheck( session );
+		while( fileToCheck.exists() )
+		{
+			session = createRandomFileName();
+	//		fileToCheck( session );
+		}
+
+		QFile file( session );
+		if ( ! file.open(QIODevice::ReadWrite) )
+		{
+			printf( "Couldn't create unique a unique recover file for this session." );
+			printf( "You may not have the permission to write to this directory?" );
+		}
+		else
+		{
+		    QTextStream stream( &file );
+		    stream << "" << endl;
+		    file.close();
+		qDebug() << "Creating file " << session << ".";
 		}
 
 		// first show the Main Window and then try to load given file

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -745,7 +745,6 @@ int main( int argc, char * * argv )
 		// recover a file?
 		QString recoveryFile;
 		int numRecoveryFiles = 0;
-		QString newestFile;
 		QDateTime created;
 		created.setTime_t( 0 );
 		QDirIterator it( ConfigManager::inst()->workingDir(),
@@ -753,12 +752,11 @@ int main( int argc, char * * argv )
 		while( it.hasNext() )
 		{
 			it.next();
-			recoveryFile = it.filePath();
 			numRecoveryFiles++;
 			if( QFileInfo( it.filePath() ).created() > created )
 			{
 				created = QFileInfo( it.filePath() ).created();
-				newestFile = it.filePath();
+				recoveryFile = it.filePath();
 			}
 		}
 
@@ -769,7 +767,7 @@ int main( int argc, char * * argv )
 					"It looks like the last session did not end "
 					"properly. Do you want to recover the "
 					"project of this session?" );
-			QString manyRecoverFiles = MainWindow::tr( 
+			QString manyRecoverFiles = MainWindow::tr(
 					"There is more than one recover file "
 					"present. Do you want to open the "
 					"latest one?" );
@@ -848,9 +846,9 @@ int main( int argc, char * * argv )
 			mb.exec();
 			if( mb.clickedButton() == discard )
 			{
-				if( !newestFile.isEmpty() )
+				if( !recoveryFile.isEmpty() )
 				{
-					QFile::remove( newestFile );
+					QFile::remove( recoveryFile );
 				}
 				gui->mainWindow()->sessionCleanup();
 			}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -742,10 +742,6 @@ int main( int argc, char * * argv )
 				"    <td><b>%4</b></td>"
 				"    <td>%5</td>"
 				"  </tr>"
-				"  <tr>"
-				"    <td><b>%6</b></td>"
-				"    <td>%7</td>"
-				"  </tr>"
 				"</table>"
 				"</html>" ).arg(
 				MainWindow::tr( "There is a recovery file present. "
@@ -756,10 +752,6 @@ int main( int argc, char * * argv )
 				MainWindow::tr( "Recover" ),
 				MainWindow::tr( "Recover the file. Please don't run "
 					"multiple instances of LMMS when you do this." ),
-				MainWindow::tr( "Ignore" ),
-				MainWindow::tr( "Launch LMMS as usual but with "
-					"automatic backup disabled to prevent the "
-					"present recover file from being overwritten." ),
 				MainWindow::tr( "Discard" ),
 				MainWindow::tr( "Launch a default session and delete "
 					"the restored files. This is not reversible." )
@@ -771,7 +763,6 @@ int main( int argc, char * * argv )
 
 			QPushButton * recover;
 			QPushButton * discard;
-			QPushButton * ignore;
 			QPushButton * exit;
 			
 			#if QT_VERSION >= 0x050000
@@ -779,16 +770,12 @@ int main( int argc, char * * argv )
 				// to have a custom layout
 				discard = mb.addButton( MainWindow::tr( "Discard" ),
 									QMessageBox::AcceptRole );
-				ignore = mb.addButton( MainWindow::tr( "Ignore" ),
-									QMessageBox::AcceptRole );
 				recover = mb.addButton( MainWindow::tr( "Recover" ),
 									QMessageBox::AcceptRole );
 
 			# else 
 				// in qt4 the button order is reversed
 				recover = mb.addButton( MainWindow::tr( "Recover" ),
-									QMessageBox::AcceptRole );
-				ignore = mb.addButton( MainWindow::tr( "Ignore" ),
 									QMessageBox::AcceptRole );
 				discard = mb.addButton( MainWindow::tr( "Discard" ),
 									QMessageBox::AcceptRole );
@@ -802,7 +789,6 @@ int main( int argc, char * * argv )
 			// set icons
 			recover->setIcon( embed::getIconPixmap( "recover" ) );
 			discard->setIcon( embed::getIconPixmap( "discard" ) );
-			ignore->setIcon( embed::getIconPixmap( "ignore" ) );
 
 			mb.setDefaultButton( recover );
 			mb.setEscapeButton( exit );
@@ -816,13 +802,6 @@ int main( int argc, char * * argv )
 			{
 				fileToLoad = recoveryFile;
 				gui->mainWindow()->setSession( MainWindow::SessionState::Recover );
-			}
-			else if( mb.clickedButton() == ignore )
-			{
-				if( autoSaveEnabled )
-				{
-					gui->mainWindow()->setSession( MainWindow::SessionState::Limited );
-				}
 			}
 			else // Exit
 			{
@@ -860,14 +839,11 @@ int main( int argc, char * * argv )
 			}
 		}
 		// If enabled, open last project if there is one. Else, create
-		// a new one. Also skip recently opened file if limited session to
-		// lower the chance of opening an already opened file.
+		// a new one.
 		else if( ConfigManager::inst()->
 				value( "app", "openlastproject" ).toInt() &&
 			!ConfigManager::inst()->
-				recentlyOpenedProjects().isEmpty() &&
-			gui->mainWindow()->getSession() !=
-				MainWindow::SessionState::Limited )
+				recentlyOpenedProjects().isEmpty() )
 		{
 			QString f = ConfigManager::inst()->
 					recentlyOpenedProjects().first();
@@ -890,8 +866,7 @@ int main( int argc, char * * argv )
 		// Finally we start the auto save timer and also trigger the
 		// autosave one time as recover.mmp is a signal to possible other
 		// instances of LMMS.
-		if( autoSaveEnabled &&
-			gui->mainWindow()->getSession() != MainWindow::SessionState::Limited )
+		if( autoSaveEnabled )
 		{
 			gui->mainWindow()->autoSaveTimerReset();
 			gui->mainWindow()->autoSave();

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -29,6 +29,9 @@
 
 #include "denormals.h"
 
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QFile>
 #include <QFileInfo>
 #include <QLocale>
 #include <QDate>
@@ -192,6 +195,20 @@ void fileCheck( QString &file )
 				file.toUtf8().constData() );
 		exit( EXIT_FAILURE );
 	}
+}
+
+
+
+
+QString createRandomFileName()
+{
+	QByteArray hashString;
+	for( int x = 0; x < 16; x++ )
+	{
+		hashString.append( rand() % 256 );
+	}
+
+	return QString( QCryptographicHash::hash( hashString, QCryptographicHash::Md5 ).toHex() );
 }
 
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -208,10 +208,10 @@ QString createRandomFileName()
 		hashString.append( rand() % 256 );
 	}
 
-	QString recoverFile;
-	recoverFile = QString( QCryptographicHash::hash( hashString, QCryptographicHash::Md5 ).toHex() );
-	recoverFile.truncate( 8 );
-	return recoverFile += ".recover.mmp";
+	QString randFileName;
+	randFileName = QString( QCryptographicHash::hash( hashString, QCryptographicHash::Md5 ).toHex() );
+	randFileName.truncate( 8 );
+	return randFileName;
 }
 
 
@@ -742,6 +742,9 @@ int main( int argc, char * * argv )
 		srand( getpid() + time( 0 ) );
 
 		// recover a file?
+		QDir workingDirectory = ConfigManager::inst()->workingDir();
+		int numRecoveryFiles = 0;
+		while( m_workingDir + wildcard + .mmp )
 		QString recoveryFile = ConfigManager::inst()->recoveryFile();
 
 		bool recoveryFilePresent = QFileInfo( recoveryFile ).exists() &&
@@ -831,6 +834,7 @@ int main( int argc, char * * argv )
 			}
 		}
 
+
 		// Create unique recover file
 		session = createRandomFileName();
 		QFileInfo fileToCheck( session );
@@ -839,25 +843,18 @@ int main( int argc, char * * argv )
 			session = createRandomFileName();
 	//		fileToCheck( session );
 		}
+		ConfigManager::inst()->setUniqueSessionName( session );
 
-		QFile file( session );
+		qDebug() << ConfigManager::inst()->recoveryFile();
+
+		QFile file( ConfigManager::inst()->recoveryFile() );
 		if ( ! file.open(QIODevice::ReadWrite) )
 		{
 			printf( "Couldn't create unique a unique recover file for this session." );
-			printf( "You may not have the permission to write to this directory?" );
-		}
-		else
-		{
-		    QTextStream stream( &file );
-		    stream << "" << endl;
-		    file.close();
-		qDebug() << "Creating file " << session << ".";
+			printf( "You may not have the permission to write to %s", ConfigManager::inst()->workingDir() );
 		}
 
-		// first show the Main Window and then try to load given file
 
-		// [Settel] workaround: showMaximized() doesn't work with
-		// FVWM2 unless the window is already visible -> show() first
 		gui->mainWindow()->show();
 		if( fullscreen )
 		{

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -883,8 +883,7 @@ void MainWindow::updateRecentlyOpenedProjectsMenu()
 	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
 	{
 		QFileInfo recentFile( *it );
-		if ( recentFile.exists() && 
-				*it != ConfigManager::inst()->recoveryFile() )
+		if ( recentFile.exists() )
 		{
 			m_recentlyOpenedProjectsMenu->addAction(
 					embed::getIconPixmap( "project_file" ), *it );
@@ -907,7 +906,6 @@ void MainWindow::openRecentlyOpenedProject( QAction * _action )
 		const QString & f = _action->text();
 		setCursor( Qt::WaitCursor );
 		Engine::getSong()->loadProject( f );
-		ConfigManager::inst()->addRecentlyOpenedProject( f );
 		setCursor( Qt::ArrowCursor );
 	}
 	runAutoSave();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -665,10 +665,6 @@ void MainWindow::resetWindowTitle()
 	{
 		title += " - " + tr( "Recover session. Please save your work!" );
 	}
-	if( getSession() == Limited )
-	{
-		title += " - " + tr( "Automatic backup disabled. Remember to save your work!" );
-	}
 	setWindowTitle( title + " - " + tr( "LMMS %1" ).arg( LMMS_VERSION ) );
 }
 
@@ -1356,8 +1352,8 @@ void MainWindow::closeEvent( QCloseEvent * _ce )
 	if( mayChangeProject(true) )
 	{
 		// delete recovery file
-		if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt()
-			&& getSession() != Limited )
+		if( ConfigManager::inst()->
+				value( "ui", "enableautosave" ).toInt() )
 		{
 			sessionCleanup();
 			_ce->accept();
@@ -1534,8 +1530,7 @@ void MainWindow::autoSave()
 // from the timer where we need to do extra tests.
 void MainWindow::runAutoSave()
 {
-	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() &&
-		getSession() != Limited )
+	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() )
 	{
 		autoSave();
 		autoSaveTimerReset();  // Reset timer


### PR DESCRIPTION
Fixes #181

Design request. Not ready for code review but I'm curious as to how y'all think the recover file system should behave.
It is currently a working rudimentary implementation of recovery files for multiple sessions.
LMMS is given a unique 8 char hex ID and sticks this to the recover files belonging to the session. On recovery the ID is reused as session ID. The files are sorted so if you have more than one `.recover.mmp` the system will suggest the most recent for recovery.
Limited Session is dropped and maybe all sessions should be dropped?
Maybe we shouldn't prompt for recover files at all on program launch but just open up a session and if you had a crash there could be an indicator (red R or something) on the MainWindow, maybe superimposed upon the `open existing project` icon.? Don't know. Ideas?
