### PR TITLE
Update Pattern and AutomationPattern length

### DIFF
--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -73,7 +73,8 @@ public:
 	}
 	void setTension( QString _new_tension );
 
-	virtual MidiTime length() const;
+	MidiTime timeMapLength() const;
+	void updateLength();
 
 	MidiTime putValue( const MidiTime & _time, const float _value,
 						const bool _quant_pos = true );

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -63,9 +63,7 @@ public:
 
 	void init();
 
-
-	virtual MidiTime length() const;
-	MidiTime beatPatternLength() const;
+	void updateLength();
 
 	// note management
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
@@ -74,8 +72,6 @@ public:
 
 	Note * noteAtStep( int _step );
 
-	Note * rearrangeNote( Note * _note_to_proc,
-						const bool _quant_pos = true );
 	void rearrangeAllNotes();
 	void clearNotes();
 
@@ -92,8 +88,6 @@ public:
 	{
 		return m_patternType;
 	}
-	void setType( PatternTypes _new_pattern_type );
-	void checkType();
 
 
 	// next/previous track based on position in the containing track
@@ -135,6 +129,11 @@ protected slots:
 
 
 private:
+	MidiTime beatPatternLength() const;
+
+	void setType( PatternTypes _new_pattern_type );
+	void checkType();
+
 	void resizeToFirstTrack();
 
 	InstrumentTrack * m_instrumentTrack;

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -28,7 +28,6 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Mixer.h"
-#include "Pattern.h"
 #include "SampleBuffer.h"
 #include "SampleTrack.h"
 

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -2,7 +2,7 @@
  * SampleRecordHandle.cpp - implementation of class SampleRecordHandle
  *
  * Copyright (c) 2008 Csaba Hruska <csaba.hruska/at/gmail.com>
- * 
+ *
  * This file is part of LMMS - http://lmms.io
  *
  * This program is free software; you can redistribute it and/or
@@ -28,7 +28,6 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Mixer.h"
-#include "Pattern.h"
 #include "SampleBuffer.h"
 #include "SampleTrack.h"
 #include "debug.h"

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -152,8 +152,7 @@ void AutomationPatternView::flipY()
 
 void AutomationPatternView::flipX()
 {
-	//m_pat->flipX( m_pat->length() );
-	m_pat->flipX( m_pat->TrackContentObject::length() );
+	m_pat->flipX( m_pat->length() );
 	update();
 }
 
@@ -269,7 +268,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	
 	const float ppt = fixedTCOs() ?
 			( parentWidget()->width() - 2 * TCO_BORDER_WIDTH )
-					/ (float) m_pat->length().getTact() :
+				/ (float) m_pat->timeMapLength().getTact() :
 								pixelsPerTact();
 
 	const int x_base = TCO_BORDER_WIDTH;
@@ -341,7 +340,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	const int lineSize = 3;
 	p.setPen( c.darker( 300 ) );
 
-	for( tact_t t = 1; t < m_pat->length().getTact(); ++t )
+	for( tact_t t = 1; t < m_pat->timeMapLength().getTact(); ++t )
 	{
 		const int tx = x_base + static_cast<int>( ppt * t ) - 2;
 		if( tx < ( width() - TCO_BORDER_WIDTH * 2 ) )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1442,7 +1442,6 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				{
 					is_new_note = true;
 					m_pattern->addJournalCheckPoint();
-					m_pattern->setType( Pattern::MelodyPattern );
 
 					// then set new note
 
@@ -2426,7 +2425,18 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 		{
 			if( note->selected() )
 			{
-				if( ! ( shift && ! m_startedWithShift ) )
+				if( shift && ! m_startedWithShift )
+				{
+					// quick resize, toggled by holding shift after starting a note move, but not before
+					int ticks_new = note->oldLength().getTicks() + off_ticks;
+					if( ticks_new <= 0 )
+					{
+						ticks_new = 1;
+					}
+					note->setLength( MidiTime( ticks_new ) );
+					m_lenOfNewNotes = note->length();
+				}
+				else
 				{
 					// moving note
 					int pos_ticks = note->oldPos().getTicks() + off_ticks;
@@ -2440,17 +2450,6 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 					note->setPos( MidiTime( pos_ticks ) );
 					note->setKey( key_num );
-				}
-				else if( shift && ! m_startedWithShift )
-				{
-					// quick resize, toggled by holding shift after starting a note move, but not before
-					int ticks_new = note->oldLength().getTicks() + off_ticks;
-					if( ticks_new <= 0 )
-					{
-						ticks_new = 1;
-					}
-					note->setLength( MidiTime( ticks_new ) );
-					m_lenOfNewNotes = note->length();
 				}
 			}
 		}
@@ -2563,6 +2562,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 		}
 	}
 
+	m_pattern->updateLength();
 	m_pattern->dataChanged();
 	Engine::getSong()->setModified();
 }


### PR DESCRIPTION
This fixes the issue with pattern lengths not being updated after #3002 was merged.

Related issues:
- `AutomationPattern::length()` is renamed because it has a different meaning from the length of a track content object.
- `rearrangeNote()` is not used.