### PR TITLE
Standardize the color of TCO bar markers

### DIFF
--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -251,6 +251,7 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	
 	// bar lines
 	const int lineSize = 3;
+	p.setPen( c.darker( 200 ) );
 
 	tact_t t = Engine::getBBTrackContainer()->lengthOfBB( m_bbTCO->bbTrackIndex() );
 	if( m_bbTCO->length() > MidiTime::ticksPerTact() && t > 0 )
@@ -259,9 +260,7 @@ void BBTCOView::paintEvent( QPaintEvent * )
 								x < width() - 2;
 			x += static_cast<int>( t * pixelsPerTact() ) )
 		{
-			p.setPen( c.light( 80 ) );
 			p.drawLine( x, TCO_BORDER_WIDTH, x, TCO_BORDER_WIDTH + lineSize );
-			p.setPen( c.light( 120 ) );
 			p.drawLine( x, rect().bottom() - ( TCO_BORDER_WIDTH + lineSize ),
 			 	x, rect().bottom() - TCO_BORDER_WIDTH );
 		}
@@ -666,4 +665,3 @@ void BBTrackView::clickedTrackLabel()
 	Engine::getBBTrackContainer()->setCurrentBB( m_bbTrack->index() );
 	gui->getBBEditor()->show();
 }
-

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1068,7 +1068,7 @@ void PatternView::paintEvent( QPaintEvent * )
 	
 	// bar lines
 	const int lineSize = 3;
-	p.setPen( c.darker( 300 ) );
+	p.setPen( c.darker( 200 ) );
 
 	for( tact_t t = 1; t < m_pat->length().getTact(); ++t )
 	{
@@ -1132,5 +1132,3 @@ void PatternView::paintEvent( QPaintEvent * )
 	painter.drawPixmap( 0, 0, m_paintPixmap );
 
 }
-
-


### PR DESCRIPTION
Per https://github.com/LMMS/lmms/pull/3042#issuecomment-249352201
Before:
![screenshot from 2016-09-27 17 46 46](https://cloud.githubusercontent.com/assets/6282045/18881083/61e46ed6-84da-11e6-88f8-cf4321be4e41.png)

After: 
![screenshot from 2016-09-27 17 43 55](https://cloud.githubusercontent.com/assets/6282045/18881047/3c47baac-84da-11e6-966a-0f3c17447657.png)

Made the color a bit lighter for patterns, as I thought the markers were too dark before. BB TCO's now use the same color as the patterns do.
