### PR TITLE
Enable antialiasing for all sample visualizing

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -911,27 +911,22 @@ void SampleBuffer::visualize( QPainter & _p, const QRect & _dr,
 	const float y_space = h*0.5f;
 	const int nb_frames = focus_on_range ? _to_frame - _from_frame : m_frames;
 
-	if( nb_frames < 60000 )
-	{
-		_p.setRenderHint( QPainter::Antialiasing );
-		QColor c = _p.pen().color();
-		_p.setPen( QPen( c, 0.7 ) );
-	}
 	const int fpp = tLimit<int>( nb_frames / w, 1, 20 );
-	QPoint * l = new QPoint[nb_frames / fpp + 1];
-	QPoint * r = new QPoint[nb_frames / fpp + 1];
+	QPointF * l = new QPointF[nb_frames / fpp + 1];
+	QPointF * r = new QPointF[nb_frames / fpp + 1];
 	int n = 0;
 	const int xb = _dr.x();
 	const int first = focus_on_range ? _from_frame : 0;
 	const int last = focus_on_range ? _to_frame : m_frames;
 	for( int frame = first; frame < last; frame += fpp )
 	{
-		l[n] = QPoint( xb + ( (frame - first) * double( w ) / nb_frames ),
-			(int)( yb - ( m_data[frame][0] * y_space * m_amplification ) ) );
-		r[n] = QPoint( xb + ( (frame - first) * double( w ) / nb_frames ),
-			(int)( yb - ( m_data[frame][1] * y_space * m_amplification ) ) );
+		l[n] = QPointF( xb + ( (frame - first) * double( w ) / nb_frames ),
+			( yb - ( m_data[frame][0] * y_space * m_amplification ) ) );
+		r[n] = QPointF( xb + ( (frame - first) * double( w ) / nb_frames ),
+			( yb - ( m_data[frame][1] * y_space * m_amplification ) ) );
 		++n;
 	}
+	_p.setRenderHint( QPainter::Antialiasing );
 	_p.drawPolyline( l, nb_frames / fpp );
 	_p.drawPolyline( r, nb_frames / fpp );
 	delete[] l;


### PR DESCRIPTION
Before:
![screenshot from 2016-09-28 21 06 27](https://cloud.githubusercontent.com/assets/6282045/18928252/98b5e7e2-85bf-11e6-8233-49c00b3c895e.png)
![screenshot from 2016-09-28 21 06 22](https://cloud.githubusercontent.com/assets/6282045/18928254/98c18692-85bf-11e6-8074-345d3ae1c120.png)

After:
![screenshot from 2016-09-28 21 03 38](https://cloud.githubusercontent.com/assets/6282045/18928277/add54848-85bf-11e6-8d13-773bf377c8e0.png)
![screenshot from 2016-09-28 21 03 34](https://cloud.githubusercontent.com/assets/6282045/18928276/add292f6-85bf-11e6-9248-c8974bdc4256.png)

Before, only small samples were anti-aliased, but that didn't matter too much, since all the points were in integer. Now we use `QPointF`, which give smoother visuals, and all sample views are anti-aliased. 
