### PR TITLE
Arpeggiator Cycle function.

### DIFF
--- a/include/InstrumentFunctionViews.h
+++ b/include/InstrumentFunctionViews.h
@@ -78,6 +78,7 @@ private:
 	GroupBox * m_arpGroupBox;
 	ComboBox * m_arpComboBox;
 	Knob * m_arpRangeKnob;
+	Knob * m_arpCycleKnob;
 	Knob * m_arpSkipKnob;
 	Knob * m_arpMissKnob;
 	TempoSyncKnob * m_arpTimeKnob;

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -196,6 +196,7 @@ private:
 	BoolModel m_arpEnabledModel;
 	ComboBoxModel m_arpModel;
 	FloatModel m_arpRangeModel;
+	FloatModel m_arpCycleModel;
 	FloatModel m_arpSkipModel;
 	FloatModel m_arpMissModel;
 	TempoSyncKnobModel m_arpTimeModel;

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -303,6 +303,7 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	m_arpEnabledModel( false ),
 	m_arpModel( this, tr( "Arpeggio type" ) ),
 	m_arpRangeModel( 1.0f, 1.0f, 9.0f, 1.0f, this, tr( "Arpeggio range" ) ),
+	m_arpCycleModel( 0.0f, 0.0f, 6.0f, 1.0f, this, tr( "Cycle steps" ) ),
 	m_arpSkipModel( 0.0f, 0.0f, 100.0f, 1.0f, this, tr( "Skip rate" ) ),
 	m_arpMissModel( 0.0f, 0.0f, 100.0f, 1.0f, this, tr( "Miss rate" ) ),
 	m_arpTimeModel( 100.0f, 25.0f, 2000.0f, 1.0f, 2000, this, tr( "Arpeggio time" ) ),
@@ -483,6 +484,13 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			cur_arp_idx = (int)( range * ( (float) rand() / (float) RAND_MAX ) );
 		}
 
+		// Cycle notes
+		if( m_arpCycleModel.value() && dir != ArpDirRandom )
+		{
+			cur_arp_idx *= m_arpCycleModel.value() + 1;
+			cur_arp_idx %= range;
+		}
+
 		// now calculate final key for our arp-note
 		const int sub_note_key = base_note_key + (cur_arp_idx / cur_chord_size ) *
 							KeysPerOctave + chord_table[selected_arp][cur_arp_idx % cur_chord_size];
@@ -528,6 +536,7 @@ void InstrumentFunctionArpeggio::saveSettings( QDomDocument & _doc, QDomElement 
 	m_arpEnabledModel.saveSettings( _doc, _this, "arp-enabled" );
 	m_arpModel.saveSettings( _doc, _this, "arp" );
 	m_arpRangeModel.saveSettings( _doc, _this, "arprange" );
+	m_arpCycleModel.saveSettings( _doc, _this, "arpcycle" );
 	m_arpSkipModel.saveSettings( _doc, _this, "arpskip" );
 	m_arpMissModel.saveSettings( _doc, _this, "arpmiss" );
 	m_arpTimeModel.saveSettings( _doc, _this, "arptime" );
@@ -545,6 +554,7 @@ void InstrumentFunctionArpeggio::loadSettings( const QDomElement & _this )
 	m_arpEnabledModel.loadSettings( _this, "arp-enabled" );
 	m_arpModel.loadSettings( _this, "arp" );
 	m_arpRangeModel.loadSettings( _this, "arprange" );
+	m_arpCycleModel.loadSettings( _this, "arpcycle" );
 	m_arpSkipModel.loadSettings( _this, "arpskip" );
 	m_arpMissModel.loadSettings( _this, "arpmiss" );
 	m_arpTimeModel.loadSettings( _this, "arptime" );

--- a/src/gui/widgets/InstrumentFunctionViews.cpp
+++ b/src/gui/widgets/InstrumentFunctionViews.cpp
@@ -103,6 +103,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGroupBox( new GroupBox( tr( "ARPEGGIO" ) ) ),
 	m_arpComboBox( new ComboBox() ),
 	m_arpRangeKnob( new Knob( knobBright_26 ) ),
+	m_arpCycleKnob( new Knob( knobBright_26 ) ),
 	m_arpSkipKnob( new Knob( knobBright_26 ) ),
 	m_arpMissKnob( new Knob( knobBright_26 ) ),
 	m_arpTimeKnob( new TempoSyncKnob( knobBright_26 ) ),
@@ -137,6 +138,15 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 		tr( "Use this knob for setting the arpeggio range in octaves. "
 			"The selected arpeggio will be played within specified "
 			"number of octaves." ) );
+
+
+	m_arpCycleKnob->setLabel( tr( "CYCLE" ) );
+	m_arpCycleKnob->setHintText( tr( "Cycle notes:" ) + " ", " " + tr( "note(s)" ) );
+	m_arpCycleKnob->setWhatsThis(
+		tr( "Jumps over n steps in the arpeggio and cycles around "
+			"if we're over the note range. If the total note range is evenly "
+			"divisible by the number of steps jumped over you will get stuck "
+			"in a shorter arpeggio or even on one note." ) );
 
 
 	m_arpSkipKnob->setLabel( tr( "SKIP" ) );
@@ -189,6 +199,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	mainLayout->addWidget( m_arpModeComboBox, 7, 0 );
 
 	mainLayout->addWidget( m_arpRangeKnob, 0, 1, 2, 1, Qt::AlignHCenter );
+	mainLayout->addWidget( m_arpCycleKnob, 0, 2, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpSkipKnob, 3, 1, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpMissKnob, 3, 2, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpGateKnob, 6, 1, 2, 1, Qt::AlignHCenter );
@@ -215,6 +226,7 @@ void InstrumentFunctionArpeggioView::modelChanged()
 	m_arpGroupBox->setModel( &m_a->m_arpEnabledModel );
 	m_arpComboBox->setModel( &m_a->m_arpModel );
 	m_arpRangeKnob->setModel( &m_a->m_arpRangeModel );
+	m_arpCycleKnob->setModel( &m_a->m_arpCycleModel );
 	m_arpSkipKnob->setModel( &m_a->m_arpSkipModel );
 	m_arpMissKnob->setModel( &m_a->m_arpMissModel );
 	m_arpTimeKnob->setModel( &m_a->m_arpTimeModel );


### PR DESCRIPTION
![cycle](https://cloud.githubusercontent.com/assets/6368949/19406897/4af3eb3e-9290-11e6-91a8-079a1efc42d0.png)

See #2080 

From the Cycle Knob's help text:
```
Jumps over n steps in the arpeggio and cycles around if we're over the note range.
If the total note range is evenly divisible by the number of steps jumped over you will
get stuck in a shorter arpeggio or even on one note.
```
...and if you do get stuck in a shorter sequence you can just turn up the `Miss` Knob to reach the other notes.