### PR TITLE
Option to allow auto save while playing

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -29,6 +29,7 @@
 #include <QDialog>
 #include <QtCore/QMap>
 
+#include "LedCheckbox.h"
 #include "lmmsconfig.h"
 #include "AudioDevice.h"
 #include "MidiClient.h"
@@ -84,7 +85,7 @@ private slots:
 
 	// performance settings widget
 	void setAutoSaveInterval( int time );
-	void resetAutoSaveInterval();
+	void resetAutoSave();
 	void displaySaveIntervalHelp();
 
 	// audio settings widget
@@ -116,6 +117,7 @@ private slots:
 
 	void toggleSmoothScroll( bool _enabled );
 	void toggleAutoSave( bool _enabled );
+	void toggleRunningAutoSave( bool _enabled );
 	void toggleOneInstrumentTrackWindow( bool _enabled );
 	void toggleCompactTrackButtons( bool _enabled );
 	void toggleSyncVSTPlugins( bool _enabled );
@@ -174,10 +176,13 @@ private:
 	QString m_backgroundArtwork;
 
 	bool m_smoothScroll;
-	bool m_enableAutoSave;
+	bool m_disableAutoSave;
+	bool m_disableRunningAutoSave;
 	int m_saveInterval;
 	QSlider * m_saveIntervalSlider;
 	QLabel * m_saveIntervalLbl;
+	LedCheckBox * m_autoSave;
+	LedCheckBox * m_runningAutoSave;
 
 	bool m_oneInstrumentTrackWindow;
 	bool m_compactTrackButtons;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -725,7 +725,7 @@ int main( int argc, char * * argv )
 		bool recoveryFilePresent = QFileInfo( recoveryFile ).exists() &&
 				QFileInfo( recoveryFile ).isFile();
 		bool autoSaveEnabled =
-			ConfigManager::inst()->value( "ui", "enableautosave" ).toInt();
+			!ConfigManager::inst()->value( "ui", "disableautosave" ).toInt();
 		if( recoveryFilePresent )
 		{
 			QMessageBox mb;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -199,7 +199,7 @@ MainWindow::MainWindow() :
 
 	m_updateTimer.start( 1000 / 20, this );  // 20 fps
 
-	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() )
+	if( !ConfigManager::inst()->value( "ui", "disableautosave" ).toInt() )
 	{
 		// connect auto save
 		connect(&m_autoSaveTimer, SIGNAL(timeout()), this, SLOT(autoSave()));
@@ -1373,7 +1373,7 @@ void MainWindow::closeEvent( QCloseEvent * _ce )
 	if( mayChangeProject(true) )
 	{
 		// delete recovery file
-		if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt()
+		if( !ConfigManager::inst()->value( "ui", "disableautosave" ).toInt()
 			&& getSession() != Limited )
 		{
 			sessionCleanup();
@@ -1529,9 +1529,10 @@ void MainWindow::browseHelp()
 
 void MainWindow::autoSave()
 {
-	if( !( Engine::getSong()->isPlaying() ||
-			Engine::getSong()->isExporting() ||
-				QApplication::mouseButtons() ) )
+	if( ( !ConfigManager::inst()->value( "ui", "disablerunningautosave" ).toInt() ||
+		! Engine::getSong()->isPlaying() ) &&
+		!( Engine::getSong()->isExporting() ||
+		QApplication::mouseButtons() ) )
 	{
 		Engine::getSong()->saveProjectFile(ConfigManager::inst()->recoveryFile());
 		autoSaveTimerReset();  // Reset timer
@@ -1551,7 +1552,7 @@ void MainWindow::autoSave()
 // from the timer where we need to do extra tests.
 void MainWindow::runAutoSave()
 {
-	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() &&
+	if( !ConfigManager::inst()->value( "ui", "disableautosave" ).toInt() &&
 		getSession() != Limited )
 	{
 		autoSave();

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -1217,7 +1217,6 @@ void SetupDialog::toggleAutoSave( bool _enabled )
 {
 	m_disableAutoSave = _enabled;
 	m_saveIntervalSlider->setEnabled( _enabled );
-	//m_runningAutoSave->setEnabled( _enabled );
 	m_runningAutoSave->setVisible( _enabled );
 	setAutoSaveInterval( m_saveIntervalSlider->value() );
 }
@@ -1535,7 +1534,7 @@ void SetupDialog::displaySaveIntervalHelp()
 	QWhatsThis::showText( QCursor::pos(),
 			tr( "Set the time between automatic backup to %1.\n"
 			"Remember to also save your project manually. "
-			"You can also choose to allow saving while playing, "
+			"You can also choose to disable saving while playing, "
 			"something some older systems find difficult." ).arg(
 			ConfigManager::inst()->recoveryFile() ) );
 }

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -45,7 +45,7 @@
 #include "Engine.h"
 #include "debug.h"
 #include "ToolTip.h"
-#include "LedCheckbox.h"
+
 #include "LcdSpinBox.h"
 #include "FileDialog.h"
 
@@ -124,7 +124,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 #endif
 	m_backgroundArtwork( QDir::toNativeSeparators( ConfigManager::inst()->backgroundArtwork() ) ),
 	m_smoothScroll( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() ),
-	m_enableAutoSave( ConfigManager::inst()->value(	"ui", "enableautosave" ).toInt() ),
+	m_disableAutoSave( !ConfigManager::inst()->value( "ui", "disableautosave" ).toInt() ),
+	m_disableRunningAutoSave( !ConfigManager::inst()->value( "ui", "disablerunningautosave" ).toInt() ),
 	m_saveInterval(	ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() < 1 ?
 					MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES :
 			ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() ),
@@ -645,7 +646,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 
 	TabWidget * auto_save_tw = new TabWidget(
 			tr( "Auto save" ).toUpper(), performance );
-	auto_save_tw->setFixedHeight( 100 );
+	auto_save_tw->setFixedHeight( 110 );
 
 	m_saveIntervalSlider = new QSlider( Qt::Horizontal, auto_save_tw );
 	m_saveIntervalSlider->setRange( 1, 20 );
@@ -662,25 +663,37 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_saveIntervalLbl->setGeometry( 10, 40, 200, 24 );
 	setAutoSaveInterval( m_saveIntervalSlider->value() );
 
-	LedCheckBox * autoSave = new LedCheckBox(
-			tr( "Enable auto save feature" ), auto_save_tw );
-	autoSave->move( 10, 70 );
-	autoSave->setChecked( m_enableAutoSave );
-	connect( autoSave, SIGNAL( toggled( bool ) ),
+	m_autoSave = new LedCheckBox(
+			tr( "Enable auto-save" ), auto_save_tw );
+	m_autoSave->move( 10, 70 );
+	m_autoSave->setChecked( m_disableAutoSave );
+	connect( m_autoSave, SIGNAL( toggled( bool ) ),
 				this, SLOT( toggleAutoSave( bool ) ) );
-	if( ! m_enableAutoSave ){ m_saveIntervalSlider->setEnabled( false ); }
 
-	QPushButton * saveIntervalResetBtn = new QPushButton(
+	m_runningAutoSave = new LedCheckBox(
+			tr( "Allow auto-save while playing" ), auto_save_tw );
+	m_runningAutoSave->move( 20, 90 );
+	m_runningAutoSave->setChecked( m_disableRunningAutoSave );
+	connect( m_runningAutoSave, SIGNAL( toggled( bool ) ),
+				this, SLOT( toggleRunningAutoSave( bool ) ) );
+
+	if( ! m_disableAutoSave )
+	{
+		m_saveIntervalSlider->setEnabled( false );
+		m_runningAutoSave->setHidden( true );
+	}
+
+	QPushButton * autoSaveResetBtn = new QPushButton(
 			embed::getIconPixmap( "reload" ), "", auto_save_tw );
-	saveIntervalResetBtn->setGeometry( 290, 50, 28, 28 );
-	connect( saveIntervalResetBtn, SIGNAL( clicked() ), this,
-						SLOT( resetAutoSaveInterval() ) );
+	autoSaveResetBtn->setGeometry( 290, 70, 28, 28 );
+	connect( autoSaveResetBtn, SIGNAL( clicked() ), this,
+						SLOT( resetAutoSave() ) );
 	ToolTip::add( bufsize_reset_btn, tr( "Reset to default-value" ) );
 
-	QPushButton * saventervalBtn = new QPushButton(
+	QPushButton * saveIntervalBtn = new QPushButton(
 			embed::getIconPixmap( "help" ), "", auto_save_tw );
-	saventervalBtn->setGeometry( 320, 50, 28, 28 );
-	connect( saventervalBtn, SIGNAL( clicked() ), this,
+	saveIntervalBtn->setGeometry( 320, 70, 28, 28 );
+	connect( saveIntervalBtn, SIGNAL( clicked() ), this,
 						SLOT( displaySaveIntervalHelp() ) );
 
 	perf_layout->addWidget( auto_save_tw );
@@ -1017,10 +1030,12 @@ void SetupDialog::accept()
 					QString::number( m_hqAudioDev ) );
 	ConfigManager::inst()->setValue( "ui", "smoothscroll",
 					QString::number( m_smoothScroll ) );
-	ConfigManager::inst()->setValue( "ui", "enableautosave",
-					QString::number( m_enableAutoSave ) );
+	ConfigManager::inst()->setValue( "ui", "disableautosave",
+					QString::number( !m_disableAutoSave ) );
 	ConfigManager::inst()->setValue( "ui", "saveinterval",
 					QString::number( m_saveInterval ) );
+	ConfigManager::inst()->setValue( "ui", "disablerunningautosave",
+					QString::number( !m_disableRunningAutoSave ) );
 	ConfigManager::inst()->setValue( "ui", "oneinstrumenttrackwindow",
 					QString::number( m_oneInstrumentTrackWindow ) );
 	ConfigManager::inst()->setValue( "ui", "compacttrackbuttons",
@@ -1202,11 +1217,19 @@ void SetupDialog::toggleSmoothScroll( bool _enabled )
 
 void SetupDialog::toggleAutoSave( bool _enabled )
 {
-	m_enableAutoSave = _enabled;
+	m_disableAutoSave = _enabled;
 	m_saveIntervalSlider->setEnabled( _enabled );
+	m_runningAutoSave->setHidden( ! _enabled );
+	setAutoSaveInterval( m_saveIntervalSlider->value() );
 }
 
 
+
+
+void SetupDialog::toggleRunningAutoSave( bool _enabled )
+{
+	m_disableRunningAutoSave = _enabled;
+}
 
 
 
@@ -1489,20 +1512,19 @@ void SetupDialog::setAutoSaveInterval( int value )
 	m_saveInterval = value;
 	m_saveIntervalSlider->setValue( m_saveInterval );
 	QString minutes = m_saveInterval > 1 ? tr( "minutes" ) : tr( "minute" );
-	m_saveIntervalLbl->setText( tr( "Auto save interval: %1 %2" ).arg(
-				 QString::number( m_saveInterval ), minutes ) );
+	minutes = QString( "%1 %2" ).arg( QString::number( m_saveInterval ), minutes );
+	minutes = m_disableAutoSave ?  minutes : tr( "Disabled" );
+	m_saveIntervalLbl->setText( tr( "Auto-save interval: %1" ).arg( minutes ) );
 }
 
 
 
 
-void SetupDialog::resetAutoSaveInterval()
+void SetupDialog::resetAutoSave()
 {
-	if( m_enableAutoSave )
-	{
-		setAutoSaveInterval( MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES );
-	}
-
+	setAutoSaveInterval( MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES );
+	m_autoSave->setChecked( true );
+	m_runningAutoSave->setChecked( true );
 }
 
 
@@ -1512,7 +1534,9 @@ void SetupDialog::displaySaveIntervalHelp()
 {
 	QWhatsThis::showText( QCursor::pos(),
 			tr( "Set the time between automatic backup to %1.\n"
-			"Remember to also save your project manually." ).arg(
+			"Remember to also save your project manually. "
+			"You can also choose to allow saving while playing, "
+			"something some older systems find difficult." ).arg(
 			ConfigManager::inst()->recoveryFile() ) );
 }
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -677,24 +677,22 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	connect( m_runningAutoSave, SIGNAL( toggled( bool ) ),
 				this, SLOT( toggleRunningAutoSave( bool ) ) );
 
-	if( ! m_disableAutoSave )
-	{
-		m_saveIntervalSlider->setEnabled( false );
-		m_runningAutoSave->setHidden( true );
-	}
-
 	QPushButton * autoSaveResetBtn = new QPushButton(
 			embed::getIconPixmap( "reload" ), "", auto_save_tw );
 	autoSaveResetBtn->setGeometry( 290, 70, 28, 28 );
 	connect( autoSaveResetBtn, SIGNAL( clicked() ), this,
 						SLOT( resetAutoSave() ) );
-	ToolTip::add( bufsize_reset_btn, tr( "Reset to default-value" ) );
+	ToolTip::add( autoSaveResetBtn, tr( "Reset to default-value" ) );
 
 	QPushButton * saveIntervalBtn = new QPushButton(
 			embed::getIconPixmap( "help" ), "", auto_save_tw );
 	saveIntervalBtn->setGeometry( 320, 70, 28, 28 );
 	connect( saveIntervalBtn, SIGNAL( clicked() ), this,
 						SLOT( displaySaveIntervalHelp() ) );
+
+	m_saveIntervalSlider->setEnabled( m_disableAutoSave );
+	m_runningAutoSave->setVisible( m_disableAutoSave );
+
 
 	perf_layout->addWidget( auto_save_tw );
 	perf_layout->addSpacing( 10 );
@@ -835,7 +833,6 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	audio_layout->addSpacing( 20 );
 	audio_layout->addWidget( asw );
 	audio_layout->addStretch();
-
 
 
 
@@ -1215,11 +1212,13 @@ void SetupDialog::toggleSmoothScroll( bool _enabled )
 
 
 
+
 void SetupDialog::toggleAutoSave( bool _enabled )
 {
 	m_disableAutoSave = _enabled;
 	m_saveIntervalSlider->setEnabled( _enabled );
-	m_runningAutoSave->setHidden( ! _enabled );
+	//m_runningAutoSave->setEnabled( _enabled );
+	m_runningAutoSave->setVisible( _enabled );
 	setAutoSaveInterval( m_saveIntervalSlider->value() );
 }
 
@@ -1230,6 +1229,7 @@ void SetupDialog::toggleRunningAutoSave( bool _enabled )
 {
 	m_disableRunningAutoSave = _enabled;
 }
+
 
 
 


### PR DESCRIPTION
Since most systems have no problems saving a project while playing we could add this as an option.
The problem here is that if you edit a project while playing (or just do very short stops so the autosave doesn't have time enough to start) you may end up not getting a backup for a very long time and you wouldn't know about it.

![autosaveagain](https://cloud.githubusercontent.com/assets/6368949/19650447/ab2fadb4-9a09-11e6-84a5-663baf351045.png)
