### PR TITLE
Redesign dual filter (and enable theme based styling of effect control dialogs)

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -854,6 +854,11 @@ NesInstrumentView Knob {
 	qproperty-lineWidth: 2;
 }
 
+DualFilterControlDialog  {
+	background: red;
+  color: blue;
+}
+
 /* palette information  */
 
 LmmsPalette {

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -349,11 +349,13 @@ EffectSelectDialog QScrollArea {
 /* the inner boxes in LADSPA effect windows */
 
 EffectControlDialog QGroupBox {
-	background: #262b30;
-	margin-top: 1ex;
-	padding: 10px 2px 1px;
-	border-radius: 4px;
-	border: none;
+  background: qlineargradient( x1:0 y1:0, x2:0 y2:1, stop:0 #22282e, stop:1 #1c202a);
+	padding-top: 1ex;
+  border: none;
+  border-top-style: solid;
+  border-top-width: 1px;
+	border-radius: 1px;
+  border-top-color: rgba(255, 255, 255, 11%);
 }
 
 /* the inner box titles when present (channel 1, channel 2...) */
@@ -855,8 +857,13 @@ NesInstrumentView Knob {
 }
 
 DualFilterControlDialog  {
-	background: red;
-  color: blue;
+  background-color: #0f1114;
+}
+
+DualFilterControlDialog ComboBox {
+  min-height: 22px;
+  min-width: 10em;
+  font-size: 8pt;
 }
 
 /* palette information  */

--- a/include/DummyEffect.h
+++ b/include/DummyEffect.h
@@ -33,8 +33,8 @@
 class DummyEffectControlDialog : public EffectControlDialog
 {
 public:
-	DummyEffectControlDialog( EffectControls * _controls ) :
-		EffectControlDialog( _controls )
+	DummyEffectControlDialog(EffectControls *_controls, QWidget *_parent) :
+            EffectControlDialog(_controls, _parent)
 	{
 	}
 
@@ -71,9 +71,9 @@ public:
 		return "DummyControls";
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new DummyEffectControlDialog( this );
+		return new DummyEffectControlDialog(this, nullptr);
 	}
 } ;
 

--- a/include/EffectControlDialog.h
+++ b/include/EffectControlDialog.h
@@ -37,7 +37,7 @@ class EXPORT EffectControlDialog : public QWidget, public ModelView
 {
 	Q_OBJECT
 public:
-	EffectControlDialog( EffectControls * _controls );
+    EffectControlDialog(EffectControls *_controls, QWidget *_parent);
 	virtual ~EffectControlDialog();
 
 

--- a/include/EffectControls.h
+++ b/include/EffectControls.h
@@ -48,7 +48,7 @@ public:
 	}
 
 	virtual int controlCount() = 0;
-	virtual EffectControlDialog * createView() = 0;
+	virtual EffectControlDialog *createView(QWidget *_parent) = 0;
 
 
 	void setViewVisible( bool _visible )

--- a/plugins/Amplifier/AmplifierControlDialog.cpp
+++ b/plugins/Amplifier/AmplifierControlDialog.cpp
@@ -31,8 +31,8 @@
 
 
 
-AmplifierControlDialog::AmplifierControlDialog( AmplifierControls* controls ) :
-	EffectControlDialog( controls )
+AmplifierControlDialog::AmplifierControlDialog(AmplifierControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Amplifier/AmplifierControlDialog.h
+++ b/plugins/Amplifier/AmplifierControlDialog.h
@@ -36,7 +36,7 @@ class AmplifierControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	AmplifierControlDialog( AmplifierControls* controls );
+	AmplifierControlDialog(AmplifierControls *controls, QWidget *_parent);
 	virtual ~AmplifierControlDialog()
 	{
 	}

--- a/plugins/Amplifier/AmplifierControls.h
+++ b/plugins/Amplifier/AmplifierControls.h
@@ -55,9 +55,9 @@ public:
 		return 4;
 	}
 
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new AmplifierControlDialog( this );
+		return new AmplifierControlDialog(this, NULL);
 	}
 
 

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -30,8 +30,8 @@
 
 
 
-BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* controls ) :
-	EffectControlDialog( controls )
+BassBoosterControlDialog::BassBoosterControlDialog(BassBoosterControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/BassBooster/BassBoosterControlDialog.h
+++ b/plugins/BassBooster/BassBoosterControlDialog.h
@@ -35,7 +35,7 @@ class BassBoosterControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	BassBoosterControlDialog( BassBoosterControls* controls );
+	BassBoosterControlDialog(BassBoosterControls *controls, QWidget *_parent);
 	virtual ~BassBoosterControlDialog()
 	{
 	}

--- a/plugins/BassBooster/BassBoosterControls.h
+++ b/plugins/BassBooster/BassBoosterControls.h
@@ -54,9 +54,9 @@ public:
 		return 3;
 	}
 
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new BassBoosterControlDialog( this );
+		return new BassBoosterControlDialog(this, NULL);
 	}
 
 

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -34,8 +34,8 @@
 #include "LedCheckbox.h"
 #include "Knob.h"
 
-BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
-	EffectControlDialog( controls )
+BitcrushControlDialog::BitcrushControlDialog(BitcrushControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Bitcrush/BitcrushControlDialog.h
+++ b/plugins/Bitcrush/BitcrushControlDialog.h
@@ -35,7 +35,7 @@ class BitcrushControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	BitcrushControlDialog( BitcrushControls * controls );
+	BitcrushControlDialog(BitcrushControls *controls, QWidget *_parent);
 	virtual ~BitcrushControlDialog()
 	{
 	}

--- a/plugins/Bitcrush/BitcrushControls.h
+++ b/plugins/Bitcrush/BitcrushControls.h
@@ -50,9 +50,9 @@ public:
 		return( 9 );
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return( new BitcrushControlDialog( this ) );
+		return(new BitcrushControlDialog(this, NULL));
 	}
 
 private slots:

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -1,5 +1,5 @@
 /*
- * CrossoverEQControlDialog.cpp - A native 4-band Crossover Equalizer 
+ * CrossoverEQControlDialog.cpp - A native 4-band Crossover Equalizer
  * good for simulating tonestacks or simple peakless (flat-band) equalization
  *
  * Copyright (c) 2014 Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>
@@ -35,8 +35,8 @@
 #include "Knob.h"
 #include "Fader.h"
 
-CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * controls ) :
-	EffectControlDialog( controls )
+CrossoverEQControlDialog::CrossoverEQControlDialog(CrossoverEQControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.h
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.h
@@ -1,5 +1,5 @@
 /*
- * CrossoverEQControlDialog.h - A native 4-band Crossover Equalizer 
+ * CrossoverEQControlDialog.h - A native 4-band Crossover Equalizer
  * good for simulating tonestacks or simple peakless (flat-band) equalization
  *
  * Copyright (c) 2014 Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>
@@ -36,7 +36,7 @@ class CrossoverEQControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	CrossoverEQControlDialog( CrossoverEQControls * controls );
+	CrossoverEQControlDialog(CrossoverEQControls *controls, QWidget *_parent);
 	virtual ~CrossoverEQControlDialog()
 	{
 	}

--- a/plugins/CrossoverEQ/CrossoverEQControls.h
+++ b/plugins/CrossoverEQ/CrossoverEQControls.h
@@ -51,9 +51,9 @@ public:
 		return( 11 );
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return( new CrossoverEQControlDialog( this ) );
+		return(new CrossoverEQControlDialog(this, NULL));
 	}
 
 private slots:

--- a/plugins/Delay/DelayControls.h
+++ b/plugins/Delay/DelayControls.h
@@ -50,9 +50,9 @@ public:
 	virtual int controlCount(){
 		return 5;
 	}
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new DelayControlsDialog( this );
+		return new DelayControlsDialog(this, NULL);
 	}
 
 	float m_outPeakL;

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -33,8 +33,8 @@
 
 
 
-DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
-	EffectControlDialog( controls )
+DelayControlsDialog::DelayControlsDialog(DelayControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Delay/DelayControlsDialog.h
+++ b/plugins/Delay/DelayControlsDialog.h
@@ -34,7 +34,7 @@ class DelayControlsDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	DelayControlsDialog( DelayControls* controls );
+	DelayControlsDialog(DelayControls *controls, QWidget *_parent);
 	virtual ~DelayControlsDialog()
 	{
 	}

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -24,64 +24,83 @@
  */
 
 #include <QLayout>
+#include <QtGui/QStyleOption>
+#include <QtGui/QPainter>
+#include <QtGui/QGroupBox>
 
 #include "DualFilterControlDialog.h"
 #include "DualFilterControls.h"
-#include "embed.h"
 #include "LedCheckbox.h"
 #include "ComboBox.h"
 #include "ToolTip.h"
 #include "gui_templates.h"
 
-#define makeknob( name, x, y, model, label, hint, unit ) 	\
-	Knob * name = new Knob( knobBright_26, this); 			\
-	name -> move( x, y );									\
-	name ->setModel( &controls-> model );					\
-	name ->setLabel( label );							\
-	name ->setHintText( hint, unit );
-
+#define makeknob( name, model, label, hint, unit, volume, container )   \
+	Knob * name = new Knob( knobBright_26, this); 			            \
+	name ->setModel( &controls-> model );					            \
+	name ->setLabel( label );							                \
+	name ->setHintText( hint, unit );                                   \
+    name ->setVolumeKnob( volume );                                     \
+    container ->addWidget(name);
 
 
 DualFilterControlDialog::DualFilterControlDialog(DualFilterControls *controls, QWidget *_parent) :
 	EffectControlDialog( controls , _parent)
 {
-	setAutoFillBackground( true );
-	QPalette pal;
-	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
-	setPalette( pal );
-	setFixedSize( 150, 220 );
+    // filter1
+    QHBoxLayout *mainLayout = new QHBoxLayout;
+    QGroupBox *filter1GroupBox = new QGroupBox( this );
+    QVBoxLayout *filter1GroupBoxLayout = new QVBoxLayout;
+    QHBoxLayout *filter1KnobsLayout = new QHBoxLayout;
+    filter1GroupBoxLayout->addLayout(filter1KnobsLayout);
+    filter1GroupBox->setLayout(filter1GroupBoxLayout);
+    mainLayout->addWidget(filter1GroupBox);
 
-	makeknob( cut1Knob, 33, 30, m_cut1Model, tr( "FREQ" ), tr( "Cutoff frequency" ), "Hz" )
-	makeknob( res1Knob, 75, 30, m_res1Model, tr( "RESO" ), tr( "Resonance" ), "" )
-	makeknob( gain1Knob, 117, 30, m_gain1Model, tr( "GAIN" ), tr( "Gain" ), "%" )
-	makeknob( mixKnob, 62, 100, m_mixModel, tr( "MIX" ), tr( "Mix" ), "" )
-	makeknob( cut2Knob, 33, 145, m_cut2Model, tr( "FREQ" ), tr( "Cutoff frequency" ), "Hz" )
-	makeknob( res2Knob, 75, 145, m_res2Model, tr( "RESO" ), tr( "Resonance" ), "" )
-	makeknob( gain2Knob, 117, 145, m_gain2Model, tr( "GAIN" ), tr( "Gain" ), "%" )
+    makeknob( mixKnob, m_mixModel, tr( "MIX" ), tr( "Mix" ), "", false, mainLayout)
 
-	gain1Knob-> setVolumeKnob( true );
-	gain2Knob-> setVolumeKnob( true );
+    // filter 2
+    QGroupBox *filter2GroupBox = new QGroupBox( this );
+    QVBoxLayout *filter2GroupBoxLayout = new QVBoxLayout;
+    QHBoxLayout *filter2KnobsLayout = new QHBoxLayout;
+    filter2GroupBoxLayout->addLayout(filter2KnobsLayout);
+    filter2GroupBox->setLayout(filter2GroupBoxLayout);
+    mainLayout->addWidget(filter2GroupBox);
 
-	LedCheckBox * enabled1Toggle = new LedCheckBox( "", this,
-				tr( "Filter 1 enabled" ), LedCheckBox::Green );
-	LedCheckBox * enabled2Toggle = new LedCheckBox( "", this,
-				tr( "Filter 2 enabled" ), LedCheckBox::Green );
+    this->setLayout(mainLayout);
 
-	enabled1Toggle -> move( 5, 30 );
-	enabled1Toggle -> setModel( &controls -> m_enabled1Model );
-	ToolTip::add( enabled1Toggle, tr( "Click to enable/disable Filter 1" ) );
-	enabled2Toggle -> move( 5, 145 );
-	enabled2Toggle -> setModel( &controls -> m_enabled2Model );
-	ToolTip::add( enabled2Toggle, tr( "Click to enable/disable Filter 2" ) );
+    // filter 1 controls
+    makeknob( cut1Knob, m_cut1Model, tr( "FREQ" ), tr( "Cutoff frequency:" ), tr( "Hz" ), false, filter1KnobsLayout)
+    makeknob( res1Knob, m_res1Model, tr( "RESO" ), tr( "Resonance:" ), tr( "" ), false, filter1KnobsLayout)
+    makeknob( gain1Knob, m_gain1Model, tr( "GAIN" ), tr( "Gain:" ), tr( "%" ), true, filter1KnobsLayout)
 
-	ComboBox * m_filter1ComboBox = new ComboBox( this );
-	m_filter1ComboBox->setGeometry( 5, 70, 140, 22 );
-	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
-	m_filter1ComboBox->setModel( &controls->m_filter1Model );
+    ComboBox * m_filter1ComboBox = new ComboBox( this );
+    m_filter1ComboBox->setModel( &controls->m_filter1Model );
+    filter1GroupBoxLayout->addWidget(m_filter1ComboBox);
 
-	ComboBox * m_filter2ComboBox = new ComboBox( this );
-	m_filter2ComboBox->setGeometry( 5, 185, 140, 22 );
-	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
-	m_filter2ComboBox->setModel( &controls->m_filter2Model );
+    LedCheckBox * filter1Toggle = new LedCheckBox( "", this, tr( "Filter 1 enabled" ), LedCheckBox::Green );
+	filter1Toggle -> move( 11,11 );
+    filter1Toggle -> setModel( &controls -> m_enabled1Model );
+    ToolTip::add( filter1Toggle, tr( "Click to enable/disable Filter 1" ) );
+
+    // filter 2 controls
+    makeknob( cut2Knob, m_cut2Model, tr( "FREQ" ), tr( "Cutoff frequency:" ), tr( "Hz" ), false, filter2KnobsLayout)
+    makeknob( res2Knob, m_res2Model, tr( "RESO" ), tr( "Resonance:" ), tr( "" ), false, filter2KnobsLayout)
+    makeknob( gain2Knob, m_gain2Model, tr( "GAIN" ), tr( "Gain:" ), tr( "%" ), true, filter2KnobsLayout)
+
+    ComboBox * m_filter2ComboBox = new ComboBox( this );
+    m_filter2ComboBox->setModel( &controls->m_filter2Model );
+    filter2GroupBoxLayout->addWidget(m_filter2ComboBox);
+
+    LedCheckBox * filter2Toggle = new LedCheckBox( "", this, tr( "Filter 2 enabled" ), LedCheckBox::Green );
+	filter2Toggle -> move( 228, 11 );
+    filter2Toggle -> setModel( &controls -> m_enabled2Model );
+    ToolTip::add( filter2Toggle, tr( "Click to enable/disable Filter 2" ) );
 }
 
+void DualFilterControlDialog::paintEvent(QPaintEvent *)
+{
+    QStyleOption opt;
+    opt.init(this);
+    QPainter p(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+}

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -42,8 +42,8 @@
 
 
 
-DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls ) :
-	EffectControlDialog( controls )
+DualFilterControlDialog::DualFilterControlDialog(DualFilterControls *controls, QWidget *_parent) :
+	EffectControlDialog( controls , _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/DualFilter/DualFilterControlDialog.h
+++ b/plugins/DualFilter/DualFilterControlDialog.h
@@ -41,6 +41,7 @@ public:
 	{
 	}
 
+	void paintEvent(QPaintEvent *);
 } ;
 
 #endif

--- a/plugins/DualFilter/DualFilterControlDialog.h
+++ b/plugins/DualFilter/DualFilterControlDialog.h
@@ -36,7 +36,7 @@ class DualFilterControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	DualFilterControlDialog( DualFilterControls* controls );
+	DualFilterControlDialog(DualFilterControls *controls, QWidget *_parent);
 	virtual ~DualFilterControlDialog()
 	{
 	}

--- a/plugins/DualFilter/DualFilterControls.h
+++ b/plugins/DualFilter/DualFilterControls.h
@@ -55,9 +55,9 @@ public:
 		return 11;
 	}
 
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new DualFilterControlDialog( this );
+		return new DualFilterControlDialog(this, _parent);
 	}
 
 

--- a/plugins/Eq/EqControls.h
+++ b/plugins/Eq/EqControls.h
@@ -54,9 +54,9 @@ public:
 		return 42;
 	}
 
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new EqControlsDialog( this );
+		return new EqControlsDialog(this, NULL);
 	}
 
 	float m_inPeakL;

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -38,8 +38,8 @@
 #include "LedCheckbox.h"
 
 
-EqControlsDialog::EqControlsDialog( EqControls *controls ) :
-	EffectControlDialog( controls ),
+EqControlsDialog::EqControlsDialog(EqControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent),
 	m_controls( controls )
 {
 	setAutoFillBackground( true );

--- a/plugins/Eq/EqControlsDialog.h
+++ b/plugins/Eq/EqControlsDialog.h
@@ -45,7 +45,7 @@ class EqControlsDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	EqControlsDialog( EqControls * controls );
+	EqControlsDialog(EqControls *controls, QWidget *_parent);
 	virtual ~EqControlsDialog()
 	{
 	}

--- a/plugins/Flanger/FlangerControls.h
+++ b/plugins/Flanger/FlangerControls.h
@@ -50,9 +50,9 @@ public:
 	{
 		return 5;
 	}
-	virtual EffectControlDialog* createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new FlangerControlsDialog( this );
+		return new FlangerControlsDialog(this, NULL);
 	}
 
 private slots:

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -31,8 +31,8 @@
 
 
 
-FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
-	EffectControlDialog( controls )
+FlangerControlsDialog::FlangerControlsDialog(FlangerControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Flanger/FlangerControlsDialog.h
+++ b/plugins/Flanger/FlangerControlsDialog.h
@@ -33,7 +33,7 @@ class FlangerControlsDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	FlangerControlsDialog( FlangerControls* controls );
+	FlangerControlsDialog(FlangerControls *controls, QWidget *_parent);
 	virtual ~FlangerControlsDialog()
 	{
 	}

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -35,8 +35,8 @@
 
 
 
-LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
-	EffectControlDialog( _ctl ),
+LadspaControlDialog::LadspaControlDialog(LadspaControls *_ctl, QWidget *_parent) :
+        EffectControlDialog(_ctl, _parent),
 	m_effectLayout( NULL ),
 	m_stereoLink( NULL )
 {

--- a/plugins/LadspaEffect/LadspaControlDialog.h
+++ b/plugins/LadspaEffect/LadspaControlDialog.h
@@ -39,7 +39,7 @@ class LadspaControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	LadspaControlDialog( LadspaControls * _ctl );
+	LadspaControlDialog(LadspaControls *_ctl, QWidget *_parent);
 	~LadspaControlDialog();
 
 

--- a/plugins/LadspaEffect/LadspaControls.h
+++ b/plugins/LadspaEffect/LadspaControls.h
@@ -54,9 +54,9 @@ public:
 		return "ladspacontrols";
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new LadspaControlDialog( this );
+		return new LadspaControlDialog(this, NULL);
 	}
 
 

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -37,8 +37,8 @@
 #include "LcdSpinBox.h"
 
 
-MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * controls ) :
-	EffectControlDialog( controls )
+MultitapEchoControlDialog::MultitapEchoControlDialog(MultitapEchoControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.h
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.h
@@ -35,7 +35,7 @@ class MultitapEchoControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	MultitapEchoControlDialog( MultitapEchoControls * controls );
+	MultitapEchoControlDialog(MultitapEchoControls *controls, QWidget *_parent);
 	virtual ~MultitapEchoControlDialog()
 	{
 	}

--- a/plugins/MultitapEcho/MultitapEchoControls.h
+++ b/plugins/MultitapEcho/MultitapEchoControls.h
@@ -56,9 +56,9 @@ public:
 		return( 5 );
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return( new MultitapEchoControlDialog( this ) );
+		return(new MultitapEchoControlDialog(this, NULL));
 	}
 
 private slots:

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.cpp
@@ -143,8 +143,8 @@ private:
 
 
 
-SpectrumAnalyzerControlDialog::SpectrumAnalyzerControlDialog( SpectrumAnalyzerControls* controls ) :
-	EffectControlDialog( controls ),
+SpectrumAnalyzerControlDialog::SpectrumAnalyzerControlDialog(SpectrumAnalyzerControls *controls, QWidget *_parent) :
+        EffectControlDialog(controls, _parent),
 	m_controls( controls ),
 	m_logXAxis( PLUGIN_NAME::getIconPixmap( "log_x_axis" ) ),
 	m_logYAxis( PLUGIN_NAME::getIconPixmap( "log_y_axis" ) )

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzerControlDialog.h
@@ -35,7 +35,7 @@ class SpectrumAnalyzerControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	SpectrumAnalyzerControlDialog( SpectrumAnalyzerControls* controls );
+	SpectrumAnalyzerControlDialog(SpectrumAnalyzerControls *controls, QWidget *_parent);
 	virtual ~SpectrumAnalyzerControlDialog()
 	{
 	}

--- a/plugins/SpectrumAnalyzer/SpectrumAnalyzerControls.h
+++ b/plugins/SpectrumAnalyzer/SpectrumAnalyzerControls.h
@@ -54,9 +54,9 @@ public:
 		return 1;
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new SpectrumAnalyzerControlDialog( this );
+		return new SpectrumAnalyzerControlDialog(this, NULL);
 	}
 
 

--- a/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
+++ b/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
@@ -35,9 +35,8 @@
 #include "LedCheckbox.h"
 
 
-dynProcControlDialog::dynProcControlDialog(
-					dynProcControls * _controls ) :
-	EffectControlDialog( _controls )
+dynProcControlDialog::dynProcControlDialog(dynProcControls *_controls, QWidget *_parent) :
+        EffectControlDialog(_controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/dynamics_processor/dynamics_processor_control_dialog.h
+++ b/plugins/dynamics_processor/dynamics_processor_control_dialog.h
@@ -36,7 +36,7 @@ class dynProcControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	dynProcControlDialog( dynProcControls * _controls );
+	dynProcControlDialog(dynProcControls *_controls, QWidget *_parent);
 	virtual ~dynProcControlDialog()
 	{
 	}

--- a/plugins/dynamics_processor/dynamics_processor_controls.h
+++ b/plugins/dynamics_processor/dynamics_processor_controls.h
@@ -64,9 +64,9 @@ public:
 		return( 6 );
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return( new dynProcControlDialog( this ) );
+		return(new dynProcControlDialog(this, NULL));
 	}
 
 

--- a/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
@@ -35,9 +35,9 @@
 #include "embed.h"
 
 
-PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
-				PeakControllerEffectControls * _controls ) :
-	EffectControlDialog( _controls )
+PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(PeakControllerEffectControls *_controls,
+																	 QWidget *_parent) :
+        EffectControlDialog(_controls, _parent)
 {
 	setWindowIcon( embed::getIconPixmap( "controller" ) );
 	setAutoFillBackground( true );

--- a/plugins/peak_controller_effect/peak_controller_effect_control_dialog.h
+++ b/plugins/peak_controller_effect/peak_controller_effect_control_dialog.h
@@ -37,8 +37,8 @@ class PeakControllerEffectControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	PeakControllerEffectControlDialog(
-				PeakControllerEffectControls * _controls );
+	PeakControllerEffectControlDialog(PeakControllerEffectControls *_controls,
+                                          QWidget *_parent);
 	virtual ~PeakControllerEffectControlDialog()
 	{
 	}

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.h
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.h
@@ -52,9 +52,9 @@ public:
 	{
 		return 1;
 	}
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new PeakControllerEffectControlDialog( this );
+		return new PeakControllerEffectControlDialog(this, NULL);
 	}
 
 

--- a/plugins/stereo_enhancer/stereoenhancer_control_dialog.cpp
+++ b/plugins/stereo_enhancer/stereoenhancer_control_dialog.cpp
@@ -31,9 +31,8 @@
 
 
 
-stereoEnhancerControlDialog::stereoEnhancerControlDialog(
-	stereoEnhancerControls * _controls ) :
-	EffectControlDialog( _controls )
+stereoEnhancerControlDialog::stereoEnhancerControlDialog(stereoEnhancerControls *_controls, QWidget *_parent) :
+        EffectControlDialog(_controls, _parent)
 {
 	QHBoxLayout * l = new QHBoxLayout( this );
 

--- a/plugins/stereo_enhancer/stereoenhancer_control_dialog.h
+++ b/plugins/stereo_enhancer/stereoenhancer_control_dialog.h
@@ -34,7 +34,7 @@ class stereoEnhancerControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	stereoEnhancerControlDialog( stereoEnhancerControls * _controls );
+	stereoEnhancerControlDialog(stereoEnhancerControls *_controls, QWidget *_parent);
 	virtual ~stereoEnhancerControlDialog()
 	{
 	}

--- a/plugins/stereo_enhancer/stereoenhancer_controls.h
+++ b/plugins/stereo_enhancer/stereoenhancer_controls.h
@@ -52,9 +52,9 @@ public:
 		return( 1 );
 	}
 	
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new stereoEnhancerControlDialog( this );
+		return new stereoEnhancerControlDialog(this, NULL);
 	}
 
 

--- a/plugins/stereo_matrix/stereomatrix_control_dialog.cpp
+++ b/plugins/stereo_matrix/stereomatrix_control_dialog.cpp
@@ -33,9 +33,8 @@
 
 
 
-stereoMatrixControlDialog::stereoMatrixControlDialog(
-	stereoMatrixControls * _controls ) :
-	EffectControlDialog( _controls )
+stereoMatrixControlDialog::stereoMatrixControlDialog(stereoMatrixControls *_controls, QWidget *_parent) :
+        EffectControlDialog(_controls, _parent)
 {
 
 	setFixedSize( 160, 185 );

--- a/plugins/stereo_matrix/stereomatrix_control_dialog.h
+++ b/plugins/stereo_matrix/stereomatrix_control_dialog.h
@@ -34,7 +34,7 @@ class stereoMatrixControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	stereoMatrixControlDialog( stereoMatrixControls * _controls );
+	stereoMatrixControlDialog(stereoMatrixControls *_controls, QWidget *_parent);
 	virtual ~stereoMatrixControlDialog()
 	{
 	}

--- a/plugins/stereo_matrix/stereomatrix_controls.h
+++ b/plugins/stereo_matrix/stereomatrix_controls.h
@@ -52,9 +52,9 @@ public:
 		return( 1 );
 	}
 	
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return new stereoMatrixControlDialog( this );
+		return new stereoMatrixControlDialog(this, NULL);
 	}
 
 

--- a/plugins/waveshaper/waveshaper_control_dialog.cpp
+++ b/plugins/waveshaper/waveshaper_control_dialog.cpp
@@ -35,9 +35,8 @@
 #include "LedCheckbox.h"
 
 
-waveShaperControlDialog::waveShaperControlDialog(
-					waveShaperControls * _controls ) :
-	EffectControlDialog( _controls )
+waveShaperControlDialog::waveShaperControlDialog(waveShaperControls *_controls, QWidget *_parent) :
+        EffectControlDialog(_controls, _parent)
 {
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/waveshaper/waveshaper_control_dialog.h
+++ b/plugins/waveshaper/waveshaper_control_dialog.h
@@ -36,7 +36,7 @@ class waveShaperControlDialog : public EffectControlDialog
 {
 	Q_OBJECT
 public:
-	waveShaperControlDialog( waveShaperControls * _controls );
+	waveShaperControlDialog(waveShaperControls *_controls, QWidget *_parent);
 	virtual ~waveShaperControlDialog()
 	{
 	}

--- a/plugins/waveshaper/waveshaper_controls.h
+++ b/plugins/waveshaper/waveshaper_controls.h
@@ -57,9 +57,9 @@ public:
 		return( 4 );
 	}
 
-	virtual EffectControlDialog * createView()
+	virtual EffectControlDialog *createView(QWidget *_parent)
 	{
-		return( new waveShaperControlDialog( this ) );
+		return(new waveShaperControlDialog(this, NULL));
 	}
 
 

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -31,8 +31,8 @@
 #include "Effect.h"
 
 
-EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
-	QWidget( NULL ),
+EffectControlDialog::EffectControlDialog(EffectControls *_controls, QWidget *_parent) :
+	QWidget( _parent ),
 	ModelView( _controls, this ),
 	m_effectControls( _controls )
 {

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -107,7 +107,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 		connect( ctls_btn, SIGNAL( clicked() ),
 					this, SLOT( editControls() ) );
 
-		m_controlView = effect()->controls()->createView();
+		m_controlView = effect()->controls()->createView( _parent );
 		if( m_controlView )
 		{
 			m_subWindow = gui->mainWindow()->addWindowedWidget( m_controlView );


### PR DESCRIPTION
Fixes part of #2831

![image](https://cloud.githubusercontent.com/assets/204286/19784369/d01448f4-9c95-11e6-85d0-97f6c147180c.png)

This uses proper layouts and CSS styling from the theme to layout and style the Dual Filter control dialog instead of hardcoded pixel values and pixmaps.

I had to change a relatively large amount of files to enable the styling using the theme/CSS for the plugin/effect control dialogs. I believe passing the parent is the correct way to do it, but please let me know if that's not the case.

P.S. The whitespace seems to a bit messed up, just noticed there's a [coding conventions page](https://github.com/LMMS/lmms/wiki/Coding-conventions), I'll fix those up after/when I get some feedback.
