### PR TITLE
dBV is actually mislabeled dBFS

### DIFF
--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -3422,7 +3422,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Please enter a new value between -96.0 dBV and 6.0 dBV:</source>
+        <source>Please enter a new value between -96.0 dBFS and 6.0 dBFS:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4019,7 +4019,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume as dBV</source>
+        <source>Volume as dBFS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6010,7 +6010,7 @@ Reason: &quot;%2&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Display volume as dBV </source>
+        <source>Display volume as dBFS </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -252,6 +252,7 @@ private:
 	~ConfigManager();
 
 	void upgrade_1_1_90();
+	void upgrade_1_1_91();
 	void upgrade();
 
 	QString m_lmmsRcFile;

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -98,7 +98,7 @@ private slots:
 
 	void toggleToolTips( bool _enabled );
 	void toggleWarnAfterSetup( bool _enabled );
-	void toggleDisplaydBV( bool _enabled );
+	void toggleDisplaydBFS( bool _enabled );
 	void toggleMMPZ( bool _enabled );
 	void toggleDisableBackup( bool _enabled );
 	void toggleOpenLastProject( bool _enabled );
@@ -136,7 +136,7 @@ private:
 
 	bool m_toolTips;
 	bool m_warnAfterSetup;
-	bool m_displaydBV;
+	bool m_displaydBFS;
 	bool m_MMPZ;
 	bool m_disableBackup;
 	bool m_openLastProject;

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -243,10 +243,10 @@ static inline float linearToLogScale( float min, float max, float value )
 
 
 
-//! @brief Converts linear amplitude (0-1.0) to dBV scale. Handles zeroes as -inf.
-//! @param amp Linear amplitude, where 1.0 = 0dBV. 
-//! @return Amplitude in dBV. -inf for 0 amplitude.
-static inline float safeAmpToDbv( float amp )
+//! @brief Converts linear amplitude (0-1.0) to dBFS scale. Handles zeroes as -inf.
+//! @param amp Linear amplitude, where 1.0 = 0dBFS. 
+//! @return Amplitude in dBFS. -inf for 0 amplitude.
+static inline float safeAmpToDbfs( float amp )
 {
 	return amp == 0.0f
 		? -INFINITY
@@ -254,32 +254,32 @@ static inline float safeAmpToDbv( float amp )
 }
 
 
-//! @brief Converts dBV-scale to linear amplitude with 0dBV = 1.0. Handles infinity as zero.
-//! @param dbv The dBV value to convert: all infinites are treated as -inf and result in 0
+//! @brief Converts dBFS-scale to linear amplitude with 0dBFS = 1.0. Handles infinity as zero.
+//! @param dbfs The dBFS value to convert: all infinites are treated as -inf and result in 0
 //! @return Linear amplitude
-static inline float safeDbvToAmp( float dbv )
+static inline float safeDbfsToAmp( float dbfs )
 {
-	return isinff( dbv )
+	return isinff( dbfs )
 		? 0.0f
-		: exp10f( dbv * 0.05f );
+		: exp10f( dbfs * 0.05f );
 }
 
 
-//! @brief Converts linear amplitude (>0-1.0) to dBV scale. 
-//! @param amp Linear amplitude, where 1.0 = 0dBV. ** Must be larger than zero! **
-//! @return Amplitude in dBV. 
-static inline float ampToDbv( float amp )
+//! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 
+//! @param amp Linear amplitude, where 1.0 = 0dBFS. ** Must be larger than zero! **
+//! @return Amplitude in dBFS. 
+static inline float ampToDbfs( float amp )
 {
 	return log10f( amp ) * 20.0f;
 }
 
 
-//! @brief Converts dBV-scale to linear amplitude with 0dBV = 1.0
-//! @param dbv The dBV value to convert. ** Must be a real number - not inf/nan! **
+//! @brief Converts dBFS-scale to linear amplitude with 0dBFS = 1.0
+//! @param dbfs The dBFS value to convert. ** Must be a real number - not inf/nan! **
 //! @return Linear amplitude
-static inline float dbvToAmp( float dbv )
+static inline float dbfsToAmp( float dbfs )
 {
-	return exp10f( dbv * 0.05f );
+	return exp10f( dbfs * 0.05f );
 }
 
 

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -131,15 +131,15 @@ bool BitcrushEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 	}
 	if( m_needsUpdate || m_controls.m_inGain.isValueChanged() )
 	{
-		m_inGain = dbvToAmp( m_controls.m_inGain.value() );
+		m_inGain = dbfsToAmp( m_controls.m_inGain.value() );
 	}
 	if( m_needsUpdate || m_controls.m_outGain.isValueChanged() )
 	{
-		m_outGain = dbvToAmp( m_controls.m_outGain.value() );
+		m_outGain = dbfsToAmp( m_controls.m_outGain.value() );
 	}
 	if( m_needsUpdate || m_controls.m_outClip.isValueChanged() )
 	{
-		m_outClip = dbvToAmp( m_controls.m_outClip.value() );
+		m_outClip = dbfsToAmp( m_controls.m_outClip.value() );
 	}
 	m_needsUpdate = false;
 	

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -55,7 +55,7 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	inGain->move( 12, 25 );
 	inGain->setModel( & controls->m_inGain );
 	inGain->setLabel( tr( "GAIN" ) );
-	inGain->setHintText( tr( "Input Gain:" ) + " ", " dBV" );
+	inGain->setHintText( tr( "Input Gain:" ) + " ", " dBFS" );
 	
 	Knob * inNoise = new Knob( knobBright_26, this );
 	inNoise->move( 12, 70 );
@@ -69,7 +69,7 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	outGain->move( 176, 25 );
 	outGain->setModel( & controls->m_outGain );
 	outGain->setLabel( tr( "GAIN" ) );
-	outGain->setHintText( tr( "Output Gain:" ) + " ", " dBV" );
+	outGain->setHintText( tr( "Output Gain:" ) + " ", " dBFS" );
 	
 	Knob * outClip = new Knob( knobBright_26, this );
 	outClip->move( 176, 70 );

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -117,19 +117,19 @@ bool CrossoverEQEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 	// gain values update
 	if( m_needsUpdate || m_controls.m_gain1.isValueChanged() )
 	{
-		m_gain1 = dbvToAmp( m_controls.m_gain1.value() );
+		m_gain1 = dbfsToAmp( m_controls.m_gain1.value() );
 	}
 	if( m_needsUpdate || m_controls.m_gain2.isValueChanged() )
 	{
-		m_gain2 = dbvToAmp( m_controls.m_gain2.value() );
+		m_gain2 = dbfsToAmp( m_controls.m_gain2.value() );
 	}
 	if( m_needsUpdate || m_controls.m_gain3.isValueChanged() )
 	{
-		m_gain3 = dbvToAmp( m_controls.m_gain3.value() );
+		m_gain3 = dbfsToAmp( m_controls.m_gain3.value() );
 	}
 	if( m_needsUpdate || m_controls.m_gain4.isValueChanged() )
 	{
-		m_gain4 = dbvToAmp( m_controls.m_gain4.value() );
+		m_gain4 = dbfsToAmp( m_controls.m_gain4.value() );
 	}
 	
 	// mute values update

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -72,25 +72,25 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain1->move( 7, 56 );
 	gain1->setDisplayConversion( false );
-	gain1->setHintText( tr( "Band 1 Gain:" ), " dBV" );
+	gain1->setHintText( tr( "Band 1 Gain:" ), " dBFS" );
 	
 	Fader * gain2 = new Fader( &controls->m_gain2, "Band 2 Gain", this, 
 		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain2->move( 47, 56 );
 	gain2->setDisplayConversion( false );
-	gain2->setHintText( tr( "Band 2 Gain:" ), " dBV" );
+	gain2->setHintText( tr( "Band 2 Gain:" ), " dBFS" );
 	
 	Fader * gain3 = new Fader( &controls->m_gain3, "Band 3 Gain", this, 
 		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain3->move( 87, 56 );
 	gain3->setDisplayConversion( false );
-	gain3->setHintText( tr( "Band 3 Gain:" ), " dBV" );
+	gain3->setHintText( tr( "Band 3 Gain:" ), " dBFS" );
 	
 	Fader * gain4 = new Fader( &controls->m_gain4, "Band 4 Gain", this, 
 		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain4->move( 127, 56 );
 	gain4->setDisplayConversion( false );
-	gain4->setHintText( tr( "Band 4 Gain:" ), " dBV" );
+	gain4->setHintText( tr( "Band 4 Gain:" ), " dBFS" );
 	
 	// leds
 	LedCheckBox * mute1 = new LedCheckBox( "", this, tr( "Band 1 Mute" ), LedCheckBox::Green );

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -75,7 +75,7 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 42 );
 	outFader->setDisplayConversion( false );
-	outFader->setHintText( tr( "Gain" ), "dBv" );
+	outFader->setHintText( tr( "Gain" ), "dBFS" );
 
 	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
 	pad->resize( 196, 196 );

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -107,7 +107,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 	if( m_delayControls.m_outGainModel.isValueChanged() )
 	{
-		m_outGain = dbvToAmp( m_delayControls.m_outGainModel.value() );
+		m_outGain = dbfsToAmp( m_delayControls.m_outGainModel.value() );
 	}
 	int sampleLength;
 	for( fpp_t f = 0; f < frames; ++f )

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -72,12 +72,12 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	EqFader *inGainFader = new EqFader( &controls->m_inGainModel, tr( "In Gain" ), this, &controls->m_inPeakL, &controls->m_inPeakR );
 	mainLayout->addWidget( inGainFader, 0, 0 );
 	inGainFader->setDisplayConversion( false );
-	inGainFader->setHintText( tr( "Gain" ), "dBv");
+	inGainFader->setHintText( tr( "Gain" ), "dBFS");
 
 	EqFader *outGainFader = new EqFader( &controls->m_outGainModel, tr( "Out Gain" ), this, &controls->m_outPeakL, &controls->m_outPeakR );
 	mainLayout->addWidget( outGainFader, 0, 9 );
 	outGainFader->setDisplayConversion( false );
-	outGainFader->setHintText( tr( "Gain" ), "dBv" );
+	outGainFader->setHintText( tr( "Gain" ), "dBFS" );
 
 	// Gain Fader for each Filter exepts the pass filter
 	for( int i = 1; i < m_parameterWidget->bandCount() - 1; i++ )

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -171,12 +171,12 @@ bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 
 	if( m_eqControls.m_outGainModel.isValueChanged() )
 	{
-		m_outGain = dbvToAmp(m_eqControls.m_outGainModel.value());
+		m_outGain = dbfsToAmp(m_eqControls.m_outGainModel.value());
 	}
 
 	if( m_eqControls.m_inGainModel.isValueChanged() )
 	{
-		m_inGain = dbvToAmp(m_eqControls.m_inGainModel.value());
+		m_inGain = dbfsToAmp(m_eqControls.m_inGainModel.value());
 	}
 
 	m_eqControls.m_inProgress = true;

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -103,7 +103,7 @@ bool MultitapEchoEffect::processAudioBuffer( sampleFrame * buf, const fpp_t fram
 	// get processing vars
 	const int steps = m_controls.m_steps.value();
 	const float stepLength = m_controls.m_stepLength.value();
-	const float dryGain = dbvToAmp( m_controls.m_dryGain.value() );
+	const float dryGain = dbfsToAmp( m_controls.m_dryGain.value() );
 	const bool swapInputs = m_controls.m_swapInputs.value();
 	
 	// check if number of stages has changed

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -88,7 +88,7 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
 	dryGain->setLabel( tr( "Dry" ) );
-	dryGain->setHintText( tr( "Dry Gain:" ) , " dBV" );
+	dryGain->setHintText( tr( "Dry Gain:" ) , " dBFS" );
 
 	Knob * stages = new Knob( knobBright_26, this );
 	stages->move( 200, 245 );

--- a/plugins/MultitapEcho/MultitapEchoControls.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControls.cpp
@@ -131,7 +131,7 @@ void MultitapEchoControls::ampSamplesChanged( int begin, int end )
 	const float * samples = m_ampGraph.samples();
 	for( int i = begin; i <= end; ++i )
 	{
-		m_effect->m_amp[i] = dbvToAmp( samples[i] );
+		m_effect->m_amp[i] = dbfsToAmp( samples[i] );
 	}
 }
 

--- a/plugins/dynamics_processor/dynamics_processor.cpp
+++ b/plugins/dynamics_processor/dynamics_processor.cpp
@@ -49,7 +49,7 @@ Plugin::Descriptor PLUGIN_EXPORT dynamicsprocessor_plugin_descriptor =
 
 }
 
-const float DYN_NOISE_FLOOR = 0.00001f; // -100dBV noise floor
+const float DYN_NOISE_FLOOR = 0.00001f; // -100dBFS noise floor
 const double DNF_LOG = 5.0;
 
 dynProcEffect::dynProcEffect( Model * _parent,

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -154,7 +154,7 @@ void ConfigManager::upgrade()
 	{
 		return;
 	}
-	
+
 	ProjectVersion createdWith = m_version;
 	
 	if ( createdWith.setCompareType(ProjectVersion::Build) < "1.1.90" )

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -136,6 +136,16 @@ void ConfigManager::upgrade_1_1_90()
 	}
 }
 
+	
+void ConfigManager::upgrade_1_1_91()
+{		
+	// rename displaydbv to displaydbfs
+	if ( !value( "app", "displaydbv" ).isNull() ) {
+		setValue( "app", "displaydbfs", value( "app", "displaydbv" ) );
+		deleteValue( "app", "displaydbv" );
+	}
+}
+
 
 void ConfigManager::upgrade()
 {
@@ -144,12 +154,17 @@ void ConfigManager::upgrade()
 	{
 		return;
 	}
-
+	
 	ProjectVersion createdWith = m_version;
 	
 	if ( createdWith.setCompareType(ProjectVersion::Build) < "1.1.90" )
 	{
 		upgrade_1_1_90();
+	}
+	
+	if ( createdWith.setCompareType(ProjectVersion::Build) < "1.1.91" )
+	{
+		upgrade_1_1_91();
 	}
 	
 	// Don't use old themes as they break the UI (i.e. 0.4 != 1.0, etc)
@@ -546,5 +561,3 @@ void ConfigManager::saveConfigFile()
 	outfile.write( xml.toUtf8() );
 	outfile.close();
 }
-
-

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -282,9 +282,8 @@ FxMixerView::FxChannelView::FxChannelView(QWidget * _parent, FxMixerView * _mv,
 	m_fader = new Fader( &fxChannel->m_volumeModel,
 					tr( "FX Fader %1" ).arg( channelIndex ), m_fxLine );
 	m_fader->setLevelsDisplayedInDBFS();
-	// TODO dbvToAmp is really dBFSToAmp. Rename in later commit.
-	m_fader->setMinPeak(dbvToAmp(-42));
-	m_fader->setMaxPeak(dbvToAmp(9));
+	m_fader->setMinPeak(dbfsToAmp(-42));
+	m_fader->setMaxPeak(dbfsToAmp(9));
 
 	m_fader->move( 16-m_fader->width()/2,
 					m_fxLine->height()-

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1200,10 +1200,10 @@ void MainWindow::updateViewMenu()
 	// that is safe to change on the fly. There is probably some
 	// more elegant way to do this.
 	QAction *qa;
-	qa = new QAction(tr( "Volume as dBV" ), this);
-	qa->setData("displaydbv");
+	qa = new QAction(tr( "Volume as dBFS" ), this);
+	qa->setData("displaydbfs");
 	qa->setCheckable( true );
-	qa->setChecked( ConfigManager::inst()->value( "app", "displaydbv" ).toInt() );
+	qa->setChecked( ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() );
 	m_viewMenu->addAction(qa);
 
 	// Maybe this is impossible?
@@ -1244,9 +1244,9 @@ void MainWindow::updateConfig( QAction * _who )
 	QString tag = _who->data().toString();
 	bool checked = _who->isChecked();
 
-	if( tag == "displaydbv" )
+	if( tag == "displaydbfs" )
 	{
-		ConfigManager::inst()->setValue( "app", "displaydbv",
+		ConfigManager::inst()->setValue( "app", "displaydbfs",
 						 QString::number(checked) );
 	}
 	else if ( tag == "tooltips" )

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -98,8 +98,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 							"disabled" ).toInt() ),
 	m_warnAfterSetup( !ConfigManager::inst()->value( "app",
 						"nomsgaftersetup" ).toInt() ),
-	m_displaydBV( ConfigManager::inst()->value( "app", 
-		      				"displaydbv" ).toInt() ),
+	m_displaydBFS( ConfigManager::inst()->value( "app", 
+		      				"displaydbfs" ).toInt() ),
 	m_MMPZ( !ConfigManager::inst()->value( "app", "nommpz" ).toInt() ),
 	m_disableBackup( !ConfigManager::inst()->value( "app",
 							"disablebackup" ).toInt() ),
@@ -236,13 +236,13 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 				this, SLOT( toggleWarnAfterSetup( bool ) ) );
 
 
-	LedCheckBox * dbv = new LedCheckBox( tr( "Display volume as dBV " ),
+	LedCheckBox * dbfs = new LedCheckBox( tr( "Display volume as dBFS " ),
 								misc_tw );
 	labelNumber++;
-	dbv->move( XDelta, YDelta*labelNumber );
-	dbv->setChecked( m_displaydBV );
-	connect( dbv, SIGNAL( toggled( bool ) ),
-				this, SLOT( toggleDisplaydBV( bool ) ) );
+	dbfs->move( XDelta, YDelta*labelNumber );
+	dbfs->setChecked( m_displaydBFS );
+	connect( dbfs, SIGNAL( toggled( bool ) ),
+				this, SLOT( toggleDisplaydBFS( bool ) ) );
 
 
 	LedCheckBox * mmpz = new LedCheckBox(
@@ -999,8 +999,8 @@ void SetupDialog::accept()
 					QString::number( !m_toolTips ) );
 	ConfigManager::inst()->setValue( "app", "nomsgaftersetup",
 					QString::number( !m_warnAfterSetup ) );
-	ConfigManager::inst()->setValue( "app", "displaydbv",
-					QString::number( m_displaydBV ) );
+	ConfigManager::inst()->setValue( "app", "displaydbfs",
+					QString::number( m_displaydBFS ) );
 	ConfigManager::inst()->setValue( "app", "nommpz",
 						QString::number( !m_MMPZ ) );
 	ConfigManager::inst()->setValue( "app", "disablebackup",
@@ -1147,9 +1147,9 @@ void SetupDialog::toggleWarnAfterSetup( bool _enabled )
 
 
 
-void SetupDialog::toggleDisplaydBV( bool _enabled )
+void SetupDialog::toggleDisplaydBFS( bool _enabled )
 {
-	m_displaydBV = _enabled;
+	m_displaydBFS = _enabled;
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -477,7 +477,7 @@ void PianoRoll::showTextFloat(const QString &text, const QPoint &pos, int timeou
 void PianoRoll::showVolTextFloat(volume_t vol, const QPoint &pos, int timeout)
 {
 	//! \todo display velocity for MIDI-based instruments
-	// possibly dBV values too? not sure if it makes sense for note volumes...
+	// possibly dBFS values too? not sure if it makes sense for note volumes...
 	showTextFloat( tr("Velocity: %1%").arg( vol ), pos, timeout );
 }
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -321,9 +321,9 @@ void Fader::setPeak_R( float fPeak )
 // update tooltip showing value and adjust position while changing fader value
 void Fader::updateTextFloat()
 {
-	if( ConfigManager::inst()->value( "app", "displaydbv" ).toInt() && m_displayConversion )
+	if( ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() && m_displayConversion )
 	{
-		s_textFloat->setText( QString("Volume: %1 dBV").
+		s_textFloat->setText( QString("Volume: %1 dBFS").
 				arg( 20.0 * log10( model()->value() ), 3, 'f', 2 ) );
 	}
 	else
@@ -369,8 +369,8 @@ void Fader::paintDBFSLevels(QPaintEvent * ev, QPainter & painter)
 	int width = m_back->width() / 2;
 	int center = m_back->width() - width;
 
-	float const maxDB(ampToDbv(m_fMaxPeak));
-	float const minDB(ampToDbv(m_fMinPeak));
+	float const maxDB(ampToDbfs(m_fMaxPeak));
+	float const minDB(ampToDbfs(m_fMinPeak));
 
 	// We will need to divide by the span between min and max several times. It's more
 	// efficient to calculate the reciprocal once and then to multiply.
@@ -378,12 +378,12 @@ void Fader::paintDBFSLevels(QPaintEvent * ev, QPainter & painter)
 
 
 	// Draw left levels
-	float const leftSpan = ampToDbv(m_fPeakValue_L) - minDB;
+	float const leftSpan = ampToDbfs(m_fPeakValue_L) - minDB;
 	int peak_L = height * leftSpan * fullSpanReciprocal;
 	QRect drawRectL( 0, height - peak_L, width, peak_L ); // Source and target are identical
 	painter.drawPixmap( drawRectL, *m_leds, drawRectL );
 
-	float const persistentLeftPeakDBFS = ampToDbv(m_persistentPeak_L);
+	float const persistentLeftPeakDBFS = ampToDbfs(m_persistentPeak_L);
 	int persistentPeak_L = height * (1 - (persistentLeftPeakDBFS - minDB) * fullSpanReciprocal);
 	// the LED's have a  4px padding and we don't want the peaks
 	// to draw on the fader background
@@ -400,12 +400,12 @@ void Fader::paintDBFSLevels(QPaintEvent * ev, QPainter & painter)
 
 
 	// Draw right levels
-	float const rightSpan = ampToDbv(m_fPeakValue_R) - minDB;
+	float const rightSpan = ampToDbfs(m_fPeakValue_R) - minDB;
 	int peak_R = height * rightSpan * fullSpanReciprocal;
 	QRect const drawRectR( center, height - peak_R, width, peak_R ); // Source and target are identical
 	painter.drawPixmap( drawRectR, *m_leds, drawRectR );
 
-	float const persistentRightPeakDBFS = ampToDbv(m_persistentPeak_R);
+	float const persistentRightPeakDBFS = ampToDbfs(m_persistentPeak_R);
 	int persistentPeak_R = height * (1 - (persistentRightPeakDBFS - minDB) * fullSpanReciprocal);
 	// the LED's have a  4px padding and we don't want the peaks
 	// to draw on the fader background

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -770,12 +770,12 @@ void Knob::enterValue()
 	bool ok;
 	float new_val;
 	if( isVolumeKnob() &&
-		ConfigManager::inst()->value( "app", "displaydbv" ).toInt() )
+		ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() )
 	{
 		new_val = QInputDialog::getDouble(
 			this, windowTitle(),
 			tr( "Please enter a new value between "
-					"-96.0 dBV and 6.0 dBV:" ),
+					"-96.0 dBFS and 6.0 dBFS:" ),
 				20.0 * log10( model()->value() / 100.0 ),
 							-96.0, 6.0, 4, &ok );
 		if( new_val <= -96.0 )
@@ -784,7 +784,7 @@ void Knob::enterValue()
 		}
 		else
 		{
-			new_val = dbvToAmp( new_val ) * 100.0;
+			new_val = dbfsToAmp( new_val ) * 100.0;
 		}
 	}
 	else
@@ -825,9 +825,9 @@ void Knob::friendlyUpdate()
 QString Knob::displayValue() const
 {
 	if( isVolumeKnob() &&
-		ConfigManager::inst()->value( "app", "displaydbv" ).toInt() )
+		ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() )
 	{
-		return m_description.trimmed() + QString( " %1 dBV" ).
+		return m_description.trimmed() + QString( " %1 dBFS" ).
 				arg( 20.0 * log10( model()->value() / volumeRatio() ),
 								3, 'f', 2 );
 	}
@@ -858,9 +858,3 @@ void Knob::displayHelp()
 	QWhatsThis::showText( mapToGlobal( rect().bottomRight() ),
 								whatsThis() );
 }
-
-
-
-
-
-


### PR DESCRIPTION
So, after some looking around, I realised LMMS already used dBFS values but labeled them as dBV. according to wikipedia, dBV is a decibel that's relative to 1V of voltage, which does not quite fit in software. 

dBFS on the other hand is relative to the maximum value of a digital full scale, which in our case is 1 in the linear scale, so the conclusion is that we are indeed actually using dBFS in LMMS.

Also @michaelgregorius also came to this conclusion in #2672 but probably never got around to this rename job.
