### PR TITLE
Fix several i18n-related defects

### DIFF
--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -4088,6 +4088,19 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
     </message>
 </context>
 <context>
+    <name>MidiJack</name>
+    <message>
+        <source>JACK server down</source>
+        <extracomment>When JACK(JACK Audio Connection Kit) disconnects, it will show the following message (title)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The JACK server seems to be shuted down.</source>
+        <extracomment>When JACK(JACK Audio Connection Kit) disconnects, it will show the following message (dialog message)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MidiPort</name>
     <message>
         <source>Input channel</source>

--- a/include/MidiJack.h
+++ b/include/MidiJack.h
@@ -42,8 +42,9 @@
 
 class QLineEdit;
 
-class MidiJack : public MidiClientRaw, public QThread
+class MidiJack : public QThread, public MidiClientRaw
 {
+        Q_OBJECT
 public:
 	MidiJack();
 	virtual ~MidiJack();

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -58,10 +58,11 @@ static int JackMidiProcessCallback(jack_nframes_t nframes, void *arg)
 
 static void JackMidiShutdown(void *arg)
 {
-	// TODO: support translations here
-	const QString mess_short = "JACK server down";
-	const QString mess_long = "The JACK server seems to have been shutdown.";
-	QMessageBox::information( gui->mainWindow(), mess_short, mess_long );
+        //: When JACK(JACK Audio Connection Kit) disconnects, it will show the following message (title)
+	QString msg_short = MidiJack::tr("JACK server down");
+        //: When JACK(JACK Audio Connection Kit) disconnects, it will show the following message (dialog message)
+	QString msg_long = MidiJack::tr("The JACK server seems to be shuted down.");
+	QMessageBox::information( gui->mainWindow(), msg_short, msg_long );
 }
 
 MidiJack::MidiJack() :

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1214,6 +1214,7 @@ QMenu * InstrumentTrackView::createFxMenu(QString title, QString newFxLabel)
 
 class fxLineLcdSpinBox : public LcdSpinBox
 {
+        Q_OBJECT
 	public:
 		fxLineLcdSpinBox( int _num_digits, QWidget * _parent,
 				const QString & _name ) :
@@ -1820,3 +1821,5 @@ void InstrumentTrackWindow::viewPrevInstrument()
 {
 	viewInstrumentInDirection(-1);
 }
+
+#include "InstrumentTrack.moc"


### PR DESCRIPTION
Fix the problem that some translations unable to render to the interface.
Mostly caused by lacking `Q_OBJECT` and the order of multiple inheritance.

Add translation support for `MidiJACK`

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lmms/lmms/3111)
<!-- Reviewable:end -->
