### PR TITLE
Disable MIDI export temporarily

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -49,7 +49,7 @@ IF("${PLUGIN_LIST}" STREQUAL "")
 		LadspaEffect
 		lb302
 		MidiImport
-		MidiExport
+		# MidiExport - temporarily disabled, MIDI export is broken
 		MultitapEcho
 		monstro
 		nes

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -308,11 +308,12 @@ void MainWindow::finalize()
 					SLOT( exportProjectTracks() ),
 					Qt::CTRL + Qt::SHIFT + Qt::Key_E );
 
-	project_menu->addAction( embed::getIconPixmap( "midi_file" ),
+	// temporarily disabled broken MIDI export				
+	/*project_menu->addAction( embed::getIconPixmap( "midi_file" ),
 					tr( "Export &MIDI..." ),
 					Engine::getSong(),
 					SLOT( exportProjectMidi() ),
-					Qt::CTRL + Qt::Key_M );
+					Qt::CTRL + Qt::Key_M );*/
 
 	project_menu->addSeparator();
 	project_menu->addAction( embed::getIconPixmap( "exit" ), tr( "&Quit" ),


### PR DESCRIPTION
So we can move on and release the RC2. If its necessary, we even release 1.2 without midi export.

This, if it gets merged should take the 'critical' badge off of #2384 

Another option is to make midi export an easter egg, as a value in `.lmmsrc.xml` that you would edit to get experimental midi export