### PR TITLE
Add Goto feature to TimeDisplayWidget

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -277,6 +277,7 @@ public slots:
 	void clearProject();
 
 	void addBBTrack();
+    void setPlayPos(qint64 ticks, PlayModes playMode );
 
 
 private slots:
@@ -317,8 +318,6 @@ private:
 		return m_playPos[m_playMode].getTicks() * Engine::framesPerTick() + 
 			m_playPos[m_playMode].currentFrame();
 	}
-	
-	void setPlayPos( tick_t ticks, PlayModes playMode );
 
 	void saveControllerStates( QDomDocument & doc, QDomElement & element );
 	void restoreControllerStates( const QDomElement & element );

--- a/include/TimeDisplayWidget.h
+++ b/include/TimeDisplayWidget.h
@@ -30,6 +30,7 @@
 #include <QHBoxLayout>
 
 #include "LcdWidget.h"
+#include "TimeInputDialog.h"
 
 
 class TimeDisplayWidget : public QWidget
@@ -42,10 +43,12 @@ public:
 
 protected:
 	virtual void mousePressEvent( QMouseEvent* mouseEvent );
+    virtual void contextMenuEvent( QContextMenuEvent *event );
 
 
 private slots:
 	void updateTime();
+    void timeJump();
 
 
 private:
@@ -64,6 +67,7 @@ private:
 	LcdWidget m_majorLCD;
 	LcdWidget m_minorLCD;
 	LcdWidget m_milliSecondsLCD;
+    TimeInputDialog* m_timeinputbox;
 
 } ;
 

--- a/include/TimeInputDialog.h
+++ b/include/TimeInputDialog.h
@@ -1,0 +1,69 @@
+/*
+ * TimeInputDialog.h - dialog for input playback time
+ *
+ * Copyright (c) 2016 liushuyu <liushuyu011/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef TIMEINPUTDIALOG_H
+#define TIMEINPUTDIALOG_H
+
+#include <QDialog>
+#include <QPair>
+
+#include "Song.h"
+#include "ui_timeinputdialog.h"
+
+namespace Ui
+{
+class TimeInputDialog;
+}
+
+class TimeInputDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit TimeInputDialog(QWidget *parent = 0);
+    ~TimeInputDialog();
+    void setTimeModel(int time_mode);
+    void setMilliSeconds(qint64 milliseconds);
+    qint64 getTicks();  // User input
+
+private:
+    enum DisplayModes {
+        MinutesSeconds,
+        BarsTicks,
+        DisplayModeCount
+    };
+    typedef DisplayModes DisplayMode;
+
+    Ui::TimeInputDialog *ui;
+    qint64 millisecsToTicks(qint64 milliseconds, qint32 tempo);
+    qint64 totalTicks(qint32 bars, qint32 beats, qint32 ticks);
+    qint64 totalMilliseconds(qint32 mins, qint32 secs, qint32 milli);
+    qint32 m_timemode;
+    qint64 m_milliseconds;
+    typedef QPair<qint32, qint32> range;
+    Song* s;
+    void setSpinRange(range Major, range Minor, range Milli);
+};
+
+#endif // TIMEINPUTDIALOG_H

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -563,7 +563,7 @@ void Song::updateLength()
 
 
 
-void Song::setPlayPos( tick_t ticks, PlayModes playMode )
+void Song::setPlayPos( qint64 ticks, PlayModes playMode )
 {
 	m_elapsedTicks += m_playPos[playMode].getTicks() - ticks;
 	m_elapsedMilliSeconds += 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -81,6 +81,7 @@ SET(LMMS_SRCS
 	gui/widgets/TempoSyncKnob.cpp
 	gui/widgets/TextFloat.cpp
 	gui/widgets/TimeDisplayWidget.cpp
+        gui/widgets/TimeInputDialog.cpp
 	gui/widgets/ToolButton.cpp
 	gui/widgets/ToolTip.cpp
 	gui/widgets/TrackLabelButton.cpp
@@ -93,7 +94,7 @@ set(LMMS_UIS
 	${LMMS_UIS}
 	gui/dialogs/about_dialog.ui
 	gui/dialogs/export_project.ui
-
+        gui/dialogs/timeinputdialog.ui
 	gui/Forms/EffectSelectDialog.ui
 
 	PARENT_SCOPE

--- a/src/gui/dialogs/timeinputdialog.ui
+++ b/src/gui/dialogs/timeinputdialog.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TimeInputDialog</class>
+ <widget class="QDialog" name="TimeInputDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>120</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Input a New Time</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QSpinBox" name="majorInput"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="majorLabel">
+       <property name="text">
+        <string>m</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="minorInput"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="minorLabel">
+       <property name="text">
+        <string>i</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="milliInput"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="milliLabel">
+       <property name="text">
+        <string>s</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="actionButton">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>actionButton</sender>
+   <signal>accepted()</signal>
+   <receiver>TimeInputDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionButton</sender>
+   <signal>rejected()</signal>
+   <receiver>TimeInputDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/gui/widgets/TimeInputDialog.cpp
+++ b/src/gui/widgets/TimeInputDialog.cpp
@@ -1,0 +1,128 @@
+/*
+ * TimeInputDialog.cpp - dialog for input playback time
+ *
+ * Copyright (c) 2016 liushuyu <liushuyu011/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "TimeInputDialog.h"
+
+TimeInputDialog::TimeInputDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::TimeInputDialog)
+{
+    s = Engine::getSong();
+    ui->setupUi(this);
+}
+
+TimeInputDialog::~TimeInputDialog()
+{
+    delete ui;
+}
+
+void TimeInputDialog::setTimeModel(int time_mode)
+{
+    m_timemode = time_mode;
+    switch (m_timemode) {
+    case MinutesSeconds:
+        ui->majorLabel->setText( tr( "MIN" ) );
+        ui->minorLabel->setText( tr( "SEC" ) );
+        ui->milliLabel->setText( tr( "MSEC" ) );
+        setSpinRange(range(0, 9999), range(0, 59), range(0, 999));
+        break;
+
+    case BarsTicks:
+        ui->majorLabel->setText( tr( "BAR" ) );
+        ui->minorLabel->setText( tr( "BEAT" ) );
+        ui->milliLabel->setText( tr( "TICK" ) );
+        setSpinRange(range(1, 9999), range(1, s->getTimeSigModel().getNumerator()), range(0, s->ticksPerTact() / s->getTimeSigModel().getNumerator() - 1));
+        break;
+
+    default: break;
+    }
+    return;
+}
+
+void TimeInputDialog::setMilliSeconds( qint64 milliseconds )
+{
+    m_milliseconds = ( ( milliseconds > 0 ) ? milliseconds : 0 );
+    qint64 ticks;
+    switch (m_timemode) {
+    case MinutesSeconds:
+        ui->majorInput->setValue( m_milliseconds / 60000 );
+        ui->minorInput->setValue( (m_milliseconds / 1000) % 60 );
+        ui->milliInput->setValue( m_milliseconds % 1000 );
+        break;
+    case BarsTicks:
+        ticks = millisecsToTicks( m_milliseconds, s->getTempo() );
+        ui->majorInput->setValue( ticks / s->ticksPerTact() + 1 );
+        ui->minorInput->setValue( ( ticks % s->ticksPerTact() ) /
+                                  ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) +1);
+        ui->milliInput->setValue( ( ticks % s->ticksPerTact() ) %
+                                  ( s->ticksPerTact() / s->getTimeSigModel().getNumerator() ) );
+    default:
+        break;
+    }
+}
+
+qint64 TimeInputDialog::millisecsToTicks( qint64 milliseconds, qint32 tempo )
+{
+    return ( ( milliseconds * tempo * ( DefaultTicksPerTact / 4 ) ) / 60000 );
+}
+
+qint64 TimeInputDialog::totalTicks(qint32 bars, qint32 beats, qint32 ticks)
+{
+    qint64 ticksTotal = 0;
+    ticksTotal += ( bars - 1 ) * s->ticksPerTact();
+    ticksTotal += ( ( beats -1 ) * s->ticksPerTact() ) / s->getTimeSigModel().getNumerator();
+    ticksTotal += ticks;
+    return ticksTotal;
+}
+
+qint64 TimeInputDialog::totalMilliseconds(qint32 mins, qint32 secs, qint32 milli)
+{
+    return ( mins * 60000 + secs * 1000 + milli);
+}
+
+void TimeInputDialog::setSpinRange(range Major, range Minor, range Milli)
+{
+    ui->majorInput->setRange(Major.first, Major.second);
+    ui->minorInput->setRange(Minor.first, Minor.second);
+    ui->milliInput->setRange(Milli.first, Milli.second);
+}
+
+qint64 TimeInputDialog::getTicks()
+{
+    qint64 ticks = 0;
+    switch (m_timemode) {
+    case MinutesSeconds:
+        ticks = millisecsToTicks( totalMilliseconds( ui->majorInput->value(), ui->minorInput->value(), ui->milliInput->value() ),  s->getTempo());
+        return ( ticks > 0 ? ticks : 0 );  // Try to prevent from overflow
+        break;
+
+    case BarsTicks:
+        ticks = totalTicks( ui->majorInput->value(), ui->minorInput->value(), ui->milliInput->value() );
+        return ( ticks > 0 ? ticks : 0 );
+
+    default:
+        return 0;
+        break;
+    }
+}


### PR DESCRIPTION
I have tried to implement the proposed feature in #3079 . Not sure if it will fulfill the request.
There are changes/fixes made to `Song.h`: 
1. I have changed some `int` type to `qint64` type (on most common machines, this should be `long long`) to prevent from overflow.
2. I have to move `setPlayPos` from `private` to `public`.

Some known problems:
1. The `goto` dialog is unable to input the value over 9999 minutes.
2. Sometimes the LCD meter will still display negative value despite the fact that I have changed the data type.
3. Because the time is converted to milliseconds after `getMilliseconds` and then converted to ticks before `setPlayPos`, so there are around 50 ms of offset in minutes/milliseconds mode, around 1 tick of offset in bars/ticks mode.