### PR TITLE
Change noncyclic smoothing behaviour

### DIFF
--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -624,12 +624,12 @@ void graphModel::smoothNonCyclic()
 	QVector<float> temp = m_samples;
 
 	// Smoothing
-	m_samples[0] = ( ( temp[0] * 3 ) + temp[1] ) * 0.25f;
+	//m_samples[0] = ( ( temp[0] * 3 ) + temp[1] ) * 0.25f;
 	for ( int i=1; i < ( length()-1 ); i++ )
 	{
 		m_samples[i] = ( temp[i-1] + ( temp[i] * 2 ) + temp[i+1] ) * 0.25f;
 	}
-	m_samples[length()-1] = ( temp[length()-2] + ( temp[length()-1] * 3 ) ) * 0.25f;
+	//m_samples[length()-1] = ( temp[length()-2] + ( temp[length()-1] * 3 ) ) * 0.25f;
 
 	emit samplesChanged(0, length()-1);
 }


### PR DESCRIPTION
LMMS Waveshaper (and Dynamics Processor) work with a non-bipolar graph, mirroring the changes made in the positive domain to the negative domain.

This means that if the first value of the graph isn't at 0, it will create a jump right at the graph origin, between negative and positive, resulting in distortion.
Which is fine, of course, but the current smoothing method actually smooths the first (and the final) points of the graph, creating a jump when the user didn't draw one.

How to reproduce unwanted distortion:
- Open a Waveshaper in master and any sine-wave instrument (preferably with some attack time to listen the distortion better)
- Don't edit the waveshape graph manually, just apply the Smooth button many times
- Play the sine-wave instrument

Without having touched the graph, you created distortion.
The effect's even easier to listen if you use the Waveshaper as a compressor, with a steeper line from origin to about point (0.8, 0.5), and then applying smooth: you will have a smoother curve at (0.8, 0.5), but also a non-zero initial point.

This change disables smoothing to the initial and final points. As a result, smoothing a default, 45°, Waveshaper won't affect it.

For now I put the unwanted lines in comments.

(the only plugins affected are waveshaper and dynamics processor, other plugins use the normal, cyclic, smooth method)