### PR TITLE
Graph: add Control+click feature for compressor usage

### DIFF
--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -159,20 +159,7 @@ void Graph::mousePressEvent( QMouseEvent * _me )
 {
 	if( _me->button() == Qt::LeftButton )
 	{
-		if ( !( _me->modifiers() & Qt::ShiftModifier ) )
-		{
-			// get position
-			int x = _me->x();
-			int y = _me->y();
-
-			changeSampleAt( x, y );
-
-			// toggle mouse state
-			m_mouseDown = true;
-			setCursor( Qt::BlankCursor );
-			m_lastCursorX = x;
-		}
-		else
+		if ( _me->modifiers() & Qt::ShiftModifier )
 		{
 			//when shift-clicking, draw a line from last position to current
 			//position
@@ -181,6 +168,39 @@ void Graph::mousePressEvent( QMouseEvent * _me )
 
 			drawLineAt( x, y, m_lastCursorX );
 
+			m_mouseDown = true;
+			setCursor( Qt::BlankCursor );
+			m_lastCursorX = x;
+		}
+		else if ( _me->modifiers() & Qt::ControlModifier )
+		{
+			//when control-clicking, draw a line from 0 to current and a line
+			//from current to max value
+
+			int x = _me->x();
+			int y = _me->y();
+
+			changeSampleAt( 0, height() - 1 );
+			changeSampleAt( width() - 1, 0 );
+			drawLineAt(x, y, 0);
+			drawLineAt(x, y, width() - 1);
+
+			// toggle mouse state
+			m_mouseDown = true;
+			setCursor( Qt::BlankCursor );
+			m_lastCursorX = x;
+
+		}
+		else
+		{
+
+			// get position
+			int x = _me->x();
+			int y = _me->y();
+
+			changeSampleAt( x, y );
+
+			// toggle mouse state
 			m_mouseDown = true;
 			setCursor( Qt::BlankCursor );
 			m_lastCursorX = x;


### PR DESCRIPTION
Ctrl+click now creates two lines for a compressor-like graph, to use in Waveshaper and Dynamics Processor.

I had to set the initial and start values because the drawLineAt method changes the final values of the line slightly, so using ctrl+click multiple times would result in first and last values being changed.

In my opinion, this needs some fixes, but I felt like sharing it anyway.

My original intent was not to reset initial and final values, but to keep old ones and draw lines using those values and the mouse position. This would have allowed for more generalist usage, like for Multitap Echo.

![pizza3](https://cloud.githubusercontent.com/assets/6437521/20807756/7ab94fea-b800-11e6-8ad5-80bee0487d22.png)
(in this screen, I used the new feature and then pressed "-1dB" some times)