### PR TITLE
Fix #2047 ("TripleOscillator: Oscillators are getting out of sync")

### DIFF
--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -71,7 +71,7 @@ public:
 			const IntModel * _mod_algo_model,
 			const float & _freq,
 			const float & _detuning,
-			const float & _phase_offset,
+			const double & _phase_offset,
 			const float & _volume,
 			Oscillator * _m_subOsc = NULL );
 	virtual ~Oscillator()
@@ -160,10 +160,10 @@ private:
 	const float & m_freq;
 	const float & m_detuning;
 	const float & m_volume;
-	const float & m_ext_phaseOffset;
+	const double & m_ext_phaseOffset;
 	Oscillator * m_subOsc;
-	float m_phaseOffset;
-	float m_phase;
+	double m_phaseOffset;
+	double m_phase;
 	const SampleBuffer * m_userWave;
 
 

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -35,7 +35,7 @@ Oscillator::Oscillator( const IntModel * _wave_shape_model,
 				const IntModel * _mod_algo_model,
 				const float & _freq,
 				const float & _detuning,
-				const float & _phase_offset,
+				const double & _phase_offset,
 				const float & _volume,
 			Oscillator * _sub_osc ) :
 	m_waveShapeModel( _wave_shape_model ),
@@ -310,7 +310,7 @@ void Oscillator::updateFM( sampleFrame * _ab, const fpp_t _frames,
 // should be called every time phase-offset is changed...
 inline void Oscillator::recalcPhase()
 {
-	if( !typeInfo<float>::isEqual( m_phaseOffset, m_ext_phaseOffset ) )
+	if( !typeInfo<double>::isEqual( m_phaseOffset, m_ext_phaseOffset ) )
 	{
 		m_phase -= m_phaseOffset;
 		m_phaseOffset = m_ext_phaseOffset;
@@ -325,10 +325,10 @@ inline void Oscillator::recalcPhase()
 
 inline bool Oscillator::syncOk( float _osc_coeff )
 {
-	const float v1 = m_phase;
+	const double v1 = m_phase;
 	m_phase += _osc_coeff;
 	// check whether m_phase is in next period
-	return( floorf( m_phase ) > floorf( v1 ) );
+	return( floor( m_phase ) > floor( v1 ) );
 }
 
 


### PR DESCRIPTION
Fix for #2047

Change all phase related variables in `Oscillator` from `float` to `double`.
The parameters for the `getSample` methods have not been changed to `double`
as it should suffice to only update the phase variables with `double`
precision.