### PR TITLE
No newline after render

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -909,5 +909,11 @@ int main( int argc, char * * argv )
 	// cleanup memory managers
 	MemoryManager::cleanup();
 
+	// ProjectRenderer::updateConsoleProgress() doesn't return line after render
+	if( coreOnly )
+	{
+		printf( "\n" );
+	}
+
 	return ret;
 }


### PR DESCRIPTION
Before:

```
zonkmachine@zonkmachine:~/builds/lmms/lmms/build$ ./lmms -r ~/lmms/projects/test.mmp 
Notice: could not set realtime priority.
VST sync support disabled in your configuration
Loading project...
Done
|-----------------------------------               |     68%   /  zonkmachine@zonkmachine:~/builds/lmms/lmms/build$
```

After:

```
zonkmachine@zonkmachine:~/builds/lmms/lmms/build$ ./lmms -r ~/lmms/projects/test.mmp 
Notice: could not set realtime priority.
VST sync support disabled in your configuration
Loading project...
Done
|-----------------------------------               |     68%   / 
zonkmachine@zonkmachine:~/builds/lmms/lmms/build$
```