### PR TITLE
Mallets, turn off excessive warnings

### DIFF
--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -620,6 +620,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
 						.toLatin1().constData() );
+		Stk::showWarnings( false );
 	
 		m_voice = new ModalBar();
 	
@@ -667,6 +668,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
 						.toLatin1().constData() );
+		Stk::showWarnings( false );
 	
 		m_voice = new TubeBell();
 	
@@ -712,6 +714,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
 						.toLatin1().constData() );
+		Stk::showWarnings( false );
 
 		m_voice = new BandedWG();
 	


### PR DESCRIPTION
STK is a bit too happy about messaging and I think we can spare the user from this. I also thought it could be a good idea to make the warnings visible if on a debug build `-DCMAKE_BUILD_TYPE=DEBUG` but that has failed me so far and it isn't a big thing to turn the messages on when needed anyway.

Note:
The warnings still need to be addressed though. I've taken care of most of them but at least one remains:
`OnePole::setPole: argument (1) should be less than 1.0!`