### PR TITLE
Don't run metronome when project is empty

### DIFF
--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -349,7 +349,9 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 					 currentPlayMode == Song::Mode_PlayBB;
 
 	if( playModeSupportsMetronome && m_metronomeActive && !song->isExporting() &&
-		p != last_metro_pos )
+		p != last_metro_pos &&
+			// Stop crash with metronome if empty project
+				Engine::getSong()->countTracks() )
 	{
 		tick_t ticksPerTact = MidiTime::ticksPerTact();
 		if ( p.getTicks() % (ticksPerTact / 1 ) == 0 )


### PR DESCRIPTION
On completely empty project we get a crash when the metronome is activated so we test for this.

_Edit, bug description moved from #3169: The fastest crash I get with the metronome is if I delete all tracks or create an empty track from template and then hit play. I think this is a separate problem though as earlier versions you could access the metronome only from within the Piano Roll so there had to be at least one track to run it._