### PR TITLE
Move private functions to private files (example)

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -104,39 +104,9 @@ public:
 
 
 private:
-	static Type type( const QString& typeName );
-	static QString typeName( Type type );
-
-	void cleanMetaNodes( QDomElement de );
-
-	// helper upgrade routines
-	void upgrade_0_2_1_20070501();
-	void upgrade_0_2_1_20070508();
-	void upgrade_0_3_0_rc2();
-	void upgrade_0_3_0();
-	void upgrade_0_4_0_20080104();
-	void upgrade_0_4_0_20080118();
-	void upgrade_0_4_0_20080129();
-	void upgrade_0_4_0_20080409();
-	void upgrade_0_4_0_20080607();
-	void upgrade_0_4_0_20080622();
-	void upgrade_0_4_0_beta1();
-	void upgrade_0_4_0_rc2();
-	void upgrade_1_0_99();
-	void upgrade_1_1_0();
-	void upgrade_1_1_91();
-
-	void upgrade();
-
-	void loadData( const QByteArray & _data, const QString & _sourceFile );
-
-
-	struct EXPORT typeDescStruct
-	{
-		Type m_type;
-		QString m_name;
-	} ;
-	static typeDescStruct s_types[TypeCount];
+	#ifdef DATA_FILE_PRIVATE_HEADER
+	#include DATA_FILE_PRIVATE_HEADER
+	#endif
 
 	QDomElement m_content;
 	QDomElement m_head;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ INCLUDE_DIRECTORIES(
 	"${CMAKE_BINARY_DIR}/include"
 	"${CMAKE_SOURCE_DIR}"
 	"${CMAKE_SOURCE_DIR}/include"
+	"${CMAKE_SOURCE_DIR}/src/include"
 )
 
 IF(WIN32)

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -24,6 +24,7 @@
  */
 
 
+#include "DataFile_priv.h"
 #include "DataFile.h"
 
 #include <math.h>

--- a/src/include/DataFile_priv.h
+++ b/src/include/DataFile_priv.h
@@ -1,0 +1,39 @@
+#ifndef DATA_FILE_PRIVATE_HEADER
+#define DATA_FILE_PRIVATE_HEADER "DataFile_priv.h"
+#else
+
+static Type type( const QString& typeName );
+static QString typeName( Type type );
+
+void cleanMetaNodes( QDomElement de );
+
+// helper upgrade routines
+void upgrade_0_2_1_20070501();
+void upgrade_0_2_1_20070508();
+void upgrade_0_3_0_rc2();
+void upgrade_0_3_0();
+void upgrade_0_4_0_20080104();
+void upgrade_0_4_0_20080118();
+void upgrade_0_4_0_20080129();
+void upgrade_0_4_0_20080409();
+void upgrade_0_4_0_20080607();
+void upgrade_0_4_0_20080622();
+void upgrade_0_4_0_beta1();
+void upgrade_0_4_0_rc2();
+void upgrade_1_0_99();
+void upgrade_1_1_0();
+void upgrade_1_1_91();
+
+void upgrade();
+
+void loadData( const QByteArray & _data, const QString & _sourceFile );
+
+
+struct EXPORT typeDescStruct
+{
+	Type m_type;
+	QString m_name;
+} ;
+static typeDescStruct s_types[TypeCount];
+
+#endif


### PR DESCRIPTION
One frequently asked question is how to avoid writing private member functions to public headers. I propose the following solution: move all private information that is not required to be known to a private file; this comprises non-virtual functions, non-slots, static members, and types. Runtime behavior does not change.

`DataFile` is a good example. You may add a private helper function, such as an upgrade method, and `make` will just recompile `DataFile.cpp`.