### PR TITLE
Fix calf plugin compilation on Clang

### DIFF
--- a/plugins/LadspaEffect/calf/src/modules_eq.cpp
+++ b/plugins/LadspaEffect/calf/src/modules_eq.cpp
@@ -337,7 +337,7 @@ float equalizerNband_audio_module<BaseClass, use_hplp>::freq_gain(int index, dou
     return ret;
 }
 
-template class equalizerNband_audio_module<equalizer5band_metadata, false>;
-template class equalizerNband_audio_module<equalizer8band_metadata, true>;
-template class equalizerNband_audio_module<equalizer12band_metadata, true>;
+template class calf_plugins::equalizerNband_audio_module<equalizer5band_metadata, false>;
+template class calf_plugins::equalizerNband_audio_module<equalizer8band_metadata, true>;
+template class calf_plugins::equalizerNband_audio_module<equalizer12band_metadata, true>;
 


### PR DESCRIPTION
Fixes calf plugin compilation on Clang compiler per https://github.com/LMMS/lmms/issues/3051#issuecomment-262421021.

@jasp00 if this collides with changes in #3208, please adjust as needed.  These are required for RC2 on macOS.