### PR TITLE
Iterate PulseAudio mainLoop and wait for context state

### DIFF
--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -227,9 +227,9 @@ void AudioPulseAudio::run()
 	// connect the context
 	pa_context_connect( context, NULL, (pa_context_flags) 0, NULL );
 
-        while (!m_connectedSemaphore.tryAcquire()) {
-          pa_mainloop_iterate(mainLoop, 1, NULL);
-        }
+	while (!m_connectedSemaphore.tryAcquire()) {
+		pa_mainloop_iterate(mainLoop, 1, NULL);
+	}
 
 	// run the main loop
 	if( m_connected )

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -227,7 +227,9 @@ void AudioPulseAudio::run()
 	// connect the context
 	pa_context_connect( context, NULL, (pa_context_flags) 0, NULL );
 
-	m_connectedSemaphore.acquire();
+        while (!m_connectedSemaphore.tryAcquire()) {
+          pa_mainloop_iterate(mainLoop, 1, NULL);
+        }
 
 	// run the main loop
 	if( m_connected )


### PR DESCRIPTION
Hi,

after looking into an issue where Pulse Audio did not produce sound, I came to the following conclusion:
in order for the context state to advance, mainloop have to iterate