### PR TITLE
Fix opening of project files on macOS

### DIFF
--- a/include/MainApplication.h
+++ b/include/MainApplication.h
@@ -1,0 +1,43 @@
+/*
+ * MainApplication.h - Main QApplication handler
+ *
+ * Copyright (c) 2017-2017 Tres Finocchiaro <tres.finocchiaro/at/gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef MAINAPPLICATION_H
+#define MAINAPPLICATION_H
+
+#include <QApplication>
+
+class MainApplication : public QApplication
+{
+public:
+	MainApplication(int& argc, char** argv);
+	bool event(QEvent* event);
+	inline QString& queuedFile()
+	{
+	    return m_queuedFile;
+	}
+private:
+	QString m_queuedFile;
+};
+
+#endif // MAINAPPLICATION_H

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -61,6 +61,7 @@
 
 #include <signal.h>
 
+#include "MainApplication.h"
 #include "MemoryManager.h"
 #include "ConfigManager.h"
 #include "NotePlayHandle.h"
@@ -261,7 +262,7 @@ int main( int argc, char * * argv )
 
 	QCoreApplication * app = coreOnly ?
 			new QCoreApplication( argc, argv ) :
-					new QApplication( argc, argv ) ;
+					new MainApplication( argc, argv );
 
 	Mixer::qualitySettings qs( Mixer::qualitySettings::Mode_HighQuality );
 	ProjectRenderer::OutputSettings os( 44100, false, 160,
@@ -838,6 +839,12 @@ int main( int argc, char * * argv )
 		if( fullscreen )
 		{
 			gui->mainWindow()->showMaximized();
+		}
+
+		// Handle macOS-style FileOpen QEvents
+		QString queuedFile = static_cast<MainApplication *>( app )->queuedFile();
+		if ( !queuedFile.isEmpty() ) {
+			fileToLoad = queuedFile;
 		}
 
 		if( !fileToLoad.isEmpty() )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(LMMS_SRCS
 	gui/LfoControllerDialog.cpp
 	gui/LmmsPalette.cpp
 	gui/LmmsStyle.cpp
+	gui/MainApplication.cpp
 	gui/MainWindow.cpp
 	gui/MidiSetupWidget.cpp
 	gui/ModelView.cpp

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -1,0 +1,68 @@
+/*
+ * MainApplication.cpp - Main QApplication handler
+ *
+ * Copyright (c) 2017-2017 Tres Finocchiaro <tres.finocchiaro/at/gmail.com>
+ *
+ * This file is part of LMMS - http://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+#include "MainApplication.h"
+
+#include <QDebug>
+#include <QFileOpenEvent>
+
+#include "Engine.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
+#include "Song.h"
+
+MainApplication::MainApplication(int& argc, char** argv) :
+	QApplication(argc, argv),
+	m_queuedFile() {}
+
+bool MainApplication::event(QEvent* event)
+{
+	switch(event->type())
+	{
+		case QEvent::FileOpen:
+		{
+			QFileOpenEvent * fileEvent = static_cast<QFileOpenEvent *>(event);
+			if(event)
+			{
+				// Handle the project file
+				m_queuedFile = fileEvent->file();
+				if(Engine::getSong())
+				{
+					if(gui->mainWindow()->mayChangeProject(true))
+					{
+						qDebug() << "Loading file " << m_queuedFile;
+						Engine::getSong()->loadProject(m_queuedFile);
+					}
+				}
+				else
+				{
+					qDebug() << "Queuing file " << m_queuedFile;
+				}
+				return true;
+			}
+			// Fall through to default
+		}
+		default:
+			return QApplication::event(event);
+	}
+}


### PR DESCRIPTION
This is intended to fix the problem where LMMS won't open a project that has been double-clicked on macOS.

Closes #665

Although this fix is Mac-specific, it should have no negative impact on Windows or Linux.

