### PR TITLE
Small fixes:

### DIFF
--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -668,8 +668,10 @@ void PianoView::focusOutEvent( QFocusEvent * )
 	// window we live in?
 	if( parentWidget()->parentWidget()->focusWidget() != this &&
 		parentWidget()->parentWidget()->focusWidget() != NULL &&
-		!parentWidget()->parentWidget()->
-				focusWidget()->inherits( "QLineEdit" ) )
+		!(parentWidget()->parentWidget()->
+				focusWidget()->inherits( "QLineEdit" ) ||
+		parentWidget()->parentWidget()->
+				focusWidget()->inherits( "QPlainTextEdit" ) ))
 	{
 		// then reclaim keyboard focus!
 		setFocus();

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -66,7 +66,8 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	m_origin()
 {
 	m_tc->setHook( this );
-
+	//keeps the direction of the widget, undepended on the locale
+	setLayoutDirection( Qt::LeftToRight );
 	QVBoxLayout * layout = new QVBoxLayout( this );
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -118,6 +118,9 @@ AutomationEditor::AutomationEditor() :
 
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
 
+	//keeps the direction of the widget, undepended on the locale
+	setLayoutDirection( Qt::LeftToRight );
+
 	m_tensionModel = new FloatModel(1.0, 0.0, 1.0, 0.01);
 	connect( m_tensionModel, SIGNAL( dataChanged() ),
 				this, SLOT( setTension() ) );


### PR DESCRIPTION
In PianoView.cpp fixed the focus policy so that if one would like to use
a QPlainTextEdit in his plugin, he'd be able to do so.
In TrackContainerView.cpp and AutomationEditor.cpp there's a problem
that if you use a Right To Left locale, all the GUI turn RTL, but in
those specific editors, things get very messy, because they were made up
with the assumption of LTR.