### PR TITLE
SoundIO- fixed up crashes when device cannot be opened.

### DIFF
--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -46,6 +46,7 @@ AudioSoundIo::AudioSoundIo( bool & outSuccessful, Mixer * _mixer ) :
 	outSuccessful = false;
 	m_soundio = NULL;
 	m_outstream = NULL;
+	m_outBuf = NULL;
 	m_disconnectErr = 0;
 	m_outBufFrameIndex = 0;
 	m_outBufFramesTotal = 0;
@@ -195,7 +196,8 @@ void AudioSoundIo::onBackendDisconnect(int err)
 AudioSoundIo::~AudioSoundIo()
 {
 	stopProcessing();
-	soundio_destroy(m_soundio);
+	if (m_soundio)
+		soundio_destroy(m_soundio);
 }
 
 void AudioSoundIo::startProcessing()
@@ -215,11 +217,17 @@ void AudioSoundIo::startProcessing()
 
 void AudioSoundIo::stopProcessing()
 {
-	soundio_outstream_destroy(m_outstream);
-	m_outstream = NULL;
+	if (m_outstream)
+	{
+		soundio_outstream_destroy(m_outstream);
+		m_outstream = NULL;
+	}
 
-	delete[] m_outBuf;
-	m_outBuf = NULL;
+	if (m_outBuf)
+	{
+		delete[] m_outBuf;
+		m_outBuf = NULL;
+	}
 }
 
 void AudioSoundIo::errorCallback(int err)

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -197,7 +197,10 @@ AudioSoundIo::~AudioSoundIo()
 {
 	stopProcessing();
 	if (m_soundio)
+	{
 		soundio_destroy(m_soundio);
+		m_soundio = NULL;
+	}
 }
 
 void AudioSoundIo::startProcessing()
@@ -448,7 +451,11 @@ AudioSoundIo::setupWidget::~setupWidget()
 {
 	bool ok = disconnect( &m_backendModel, SIGNAL( dataChanged() ), &m_setupUtil, SLOT( reconnectSoundIo() ) );
 	assert(ok);
-	soundio_destroy(m_soundio);
+	if (m_soundio)
+	{
+		soundio_destroy(m_soundio);
+		m_soundio = NULL;
+	}
 }
 
 void AudioSoundIo::setupWidget::saveSettings()


### PR DESCRIPTION
LMMS crashes when soundio cannot open device. it tries to free pointer with unset value.