### PR TITLE
Updated Title and "Enter Your Project Notes Here"

### DIFF
--- a/src/gui/widgets/ProjectNotes.cpp
+++ b/src/gui/widgets/ProjectNotes.cpp
@@ -68,7 +68,7 @@ ProjectNotes::ProjectNotes() :
 	setupActions();
 
 	setCentralWidget( m_edit );
-	setWindowTitle( tr( "Project notes" ) );
+	setWindowTitle( tr( "Project Notes" ) );
 	setWindowIcon( embed::getIconPixmap( "project_notes" ) );
 
 	gui->mainWindow()->addWindowedWidget( this );
@@ -90,7 +90,7 @@ ProjectNotes::~ProjectNotes()
 
 void ProjectNotes::clear()
 {
-	m_edit->setHtml( tr( "Put down your project notes here." ) );
+	m_edit->setHtml( tr( "Enter Your Project Notes Here" ) );
 	m_edit->selectAll();
 	m_edit->setTextColor( QColor( 224, 224, 224 ) );
 	QTextCursor cursor = m_edit->textCursor();


### PR DESCRIPTION
@liushuyu
Applied Proper Case to the Title Bar

and updated the message that gets typed into editor to....
"Enter Your Project Notes Here"

Although this should probably be removed entirely, because I think most know what they are supposed to do with a word processor, especially one that is called "Project Notes" :)

Hopefully I am doing this correctly