### PR TITLE
Fixed a spelling error in a debug message in RemoteVstPlugin::load.

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -737,7 +737,7 @@ bool RemoteVstPlugin::load( const std::string & _plugin_file )
 	m_plugin = mainEntry( hostCallback );
 	if( m_plugin == NULL )
 	{
-		debugMessage( "mainEntry prodecure returned NULL\n" );
+		debugMessage( "mainEntry procedure returned NULL\n" );
 		return false;
 	}
 


### PR DESCRIPTION
This is nothing but a spelling fix for a debug message, but since I got a message from @zonkmachine asking me to make a PR, feel free to grab it.