### PR TITLE
Fix importing MIDI file from command line

### DIFF
--- a/src/core/ImportFilter.cpp
+++ b/src/core/ImportFilter.cpp
@@ -90,6 +90,8 @@ void ImportFilter::import( const QString & _file_to_import,
 					QMessageBox::Ok,
 					QMessageBox::NoButton );
 	}
+
+	Engine::updateFramesPerTick();
 }
 
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -41,6 +41,7 @@
 #include "ConfigManager.h"
 #include "ControllerRackView.h"
 #include "ControllerConnection.h"
+#include "debug.h"
 #include "embed.h"
 #include "EnvelopeAndLfoParameters.h"
 #include "ExportProjectDialog.h"
@@ -285,6 +286,7 @@ void Song::processNextBuffer()
 		// did we play a tick?
 		if( currentFrame >= framesPerTick )
 		{
+			assert( framesPerTick > 0 );
 			int ticks = m_playPos[m_playMode].getTicks() + 
 				( int )( currentFrame / framesPerTick );
 


### PR DESCRIPTION
Fixes #2562 

Call `Engine::updateFramesPerTick()` as suggested by @michaelgregorius 