### PR TITLE
Some issues with large files

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-
 #include "SampleBuffer.h"
 
 
@@ -58,6 +57,7 @@
 #include "DrumSynth.h"
 #include "endian_handling.h"
 #include "Engine.h"
+#include "GuiApplication.h"
 #include "interpolation.h"
 #include "Mixer.h"
 #include "templates.h"
@@ -223,7 +223,7 @@ void SampleBuffer::update( bool _keep_settings )
 			}
 		}
 
-		if( ! fileLoadError )
+		if( !fileLoadError )
 		{
 #ifdef LMMS_HAVE_OGGVORBIS
 			// workaround for a bug in libsndfile or our libsndfile decoder
@@ -291,11 +291,19 @@ void SampleBuffer::update( bool _keep_settings )
 
 	if( fileLoadError )
 	{
-		QMessageBox::information( NULL,
-				"Fail to open file",
-				"Audio files are limited to 100 MB "
-				"in size and 1 hour of playing time",
+		QString message = "Audio files are limited to 100 MB "
+				"in size and 1 hour of playing time";
+		if( gui )
+		{
+			QMessageBox::information( NULL,
+				"Fail to open file", message,
 					QMessageBox::Ok );
+		}
+		else
+		{
+			fprintf( stderr, "%s\n", message.toUtf8().constData() );
+			exit( EXIT_FAILURE );
+		}
 	}
 }
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -173,6 +173,7 @@ void SampleBuffer::update( bool _keep_settings )
 		MM_FREE( m_data );
 	}
 
+	bool fileLoadError = false;
 	if( m_audioFile.isEmpty() && m_origData != NULL && m_origFrames > 0 )
 	{
 		// TODO: reverse- and amplification-property is not covered
@@ -200,7 +201,6 @@ void SampleBuffer::update( bool _keep_settings )
 		sample_rate_t samplerate = Engine::mixer()->baseSampleRate();
 		m_frames = 0;
 
-		bool fileLoadError = false;
 		const QFileInfo fileInfo( file );
 		if( fileInfo.size() > 100*1024*1024 )
 		{
@@ -223,15 +223,7 @@ void SampleBuffer::update( bool _keep_settings )
 			}
 		}
 
-		if( fileLoadError )
-		{
-			QMessageBox::information( NULL,
-					"Fail to open file",
-					"Audio files are limited to 100 MB "
-					"in size and 1 hour of playing time",
-						QMessageBox::Ok );
-		}
-		else
+		if( ! fileLoadError )
 		{
 #ifdef LMMS_HAVE_OGGVORBIS
 			// workaround for a bug in libsndfile or our libsndfile decoder
@@ -296,6 +288,15 @@ void SampleBuffer::update( bool _keep_settings )
 	}
 
 	emit sampleUpdated();
+
+	if( fileLoadError )
+	{
+		QMessageBox::information( NULL,
+				"Fail to open file",
+				"Audio files are limited to 100 MB "
+				"in size and 1 hour of playing time",
+					QMessageBox::Ok );
+	}
 }
 
 


### PR DESCRIPTION
In response to two related crashes in SampleBuffer.cpp as [commented in](https://github.com/LMMS/lmms/issues/3205#issuecomment-274969914) #3205
I substituted the command line messages for a message box.
I haven't touched the original 100 MB size limit and have added a 1 hour length check.

----

FIx explained: 
I add a bool, `fileLoadError`, which is set to false, should the file fail on one of the tests. I add a test for file length as a compressed file of small size when decompressed will take a much bigger size so the important fact to know for LMMS is not the file size but the length of the sample. This operation takes a bit of time to carry out compared to the file size test so we wait to see if that one passes and then carry on testing the length of the sample.
If the file is marked fileLoadError == true, the buffer will be written with one sample, value 0, and after removing possible locks a message is shown. The message is only for information and is shown after the locks are removed so the project isn't frozen while waiting for 'OK' to be pressed. The old message was to the command line and of little use to an ordinary user.

Some issues that remain with opening large files:
 - Previewing large files is sluggish. The file tests works however but large file within the limit are still loaded in their entirety. If you open large files you do it from the track container rather than the menu.
 - After failing to load a file on being to large the buffer is zeored and you might want to keep the old file in case of  a fail. In order to fix this you (probably) need to test the file earlier, before calling `SampleBuffer::update()` .