### PR TITLE
Ladspastuff

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -32,8 +32,10 @@
 // additional range-checkings) should be compiled
 
 #ifdef LMMS_DEBUG
+#define LADSPA_DEBUG TRUE
 	#include <assert.h>
 #else
+#define LADSPA_DEBUG FALSE
 	#define assert(x) ((void)(x))
 #endif
 #include <cstdio>

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -24,8 +24,10 @@
  */
 
 
+#include <QDebug>
 #include <QMessageBox>
 
+#include "debug.h"
 #include "LadspaEffect.h"
 #include "DataFile.h"
 #include "AudioDevice.h"
@@ -241,6 +243,15 @@ bool LadspaEffect::processAudioBuffer( sampleFrame * _buf,
 					for( fpp_t frame = 0; 
 						frame < frames; ++frame )
 					{
+						if (	LADSPA_DEBUG &&
+							( isnan( pp->buffer[frame] ) ||
+							isinf( pp->buffer[frame] ) ) )
+						{
+							qDebug() << "name: " << m_descriptor->Label;
+							assert( ! isnan( pp->buffer[frame] ) );
+							assert( ! isinf( pp->buffer[frame] ) );
+						}
+
 						_buf[frame][channel] = d * _buf[frame][channel] + w * pp->buffer[frame];
 						out_sum += _buf[frame][channel] * _buf[frame][channel];
 					}

--- a/plugins/LadspaEffect/swh/dyson_compress_1403.c
+++ b/plugins/LadspaEffect/swh/dyson_compress_1403.c
@@ -14,6 +14,7 @@
 #define         __USE_ISOC9X    1
 
 #include <math.h>
+#include <float.h>
 
 #include "ladspa.h"
 
@@ -836,7 +837,7 @@ static void __attribute__((constructor)) swh_init() {
 		 D_("Release time (s)");
 		port_range_hints[DYSONCOMPRESS_RELEASE_TIME].HintDescriptor =
 		 LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE | LADSPA_HINT_DEFAULT_LOW;
-		port_range_hints[DYSONCOMPRESS_RELEASE_TIME].LowerBound = 0;
+		port_range_hints[DYSONCOMPRESS_RELEASE_TIME].LowerBound = FLT_MIN;
 		port_range_hints[DYSONCOMPRESS_RELEASE_TIME].UpperBound = 1;
 
 		/* Parameters for Fast compression ratio */

--- a/plugins/LadspaEffect/swh/shaper_1187.c
+++ b/plugins/LadspaEffect/swh/shaper_1187.c
@@ -115,8 +115,8 @@ static void runShaper(LADSPA_Handle instance, unsigned long sample_count) {
 	
 	if (shapep < 1.0f && shapep > -1.0f) {
 	        shape = 1.0f;
-	} else if (shape < 0) {
-	        shape = -1.0f / shape;
+	} else if (shapep < 0) {
+	        shape = -1.0f / shapep;
 	} else {
 	        shape = shapep;
 	}
@@ -160,8 +160,8 @@ static void runAddingShaper(LADSPA_Handle instance, unsigned long sample_count) 
 	
 	if (shapep < 1.0f && shapep > -1.0f) {
 	        shape = 1.0f;
-	} else if (shape < 0) {
-	        shape = -1.0f / shape;
+	} else if (shapep < 0) {
+	        shape = -1.0f / shapep;
 	} else {
 	        shape = shapep;
 	}


### PR DESCRIPTION
Dyson Compressor

 NaN - Release time 0.0f  = divide with 0 [here](https://github.com/LMMS/lmms/blob/master/plugins/LadspaEffect/swh/dyson_compress_1403.c#L375):
`	float rgainfilter = 1.0f / (release_time * sample_rate);`

In the solution: `port_range_hints[DYSONCOMPRESS_RELEASE_TIME].LowerBound = 0.0000001; `
Maybe use a constant for 0.0000001 ... 'weeLittleFloat' = 0.0000001 ?
Are there any suitable math constants to use? I just put in the smalles number that would give 0 and 1 back in the knobs extreme positions.

Also, I found a generally odd looking line [here](
https://github.com/LMMS/lmms/blob/master/plugins/LadspaEffect/swh/dyson_compress_1403.c#L446:L452)
`if (compressionratio == 0.50f)` should probably be `<` or `>`
I thought it could potentionally produce a glitch if you sweep the compression knob across 0.5f as it would change to another algorithm for that value only but I haven't managed to produce anything buggy because of it. I haven't dived into the math of it yet.

---

LADSPA debugging code

Put general debugging code for LADSPA so we can stop those NaN's and whatever may be hiding in there. In response to #1048 and discussion [here](https://github.com/LMMS/lmms/pull/3145#issuecomment-267848275) .
@tresf :) I've looked at cmakedefine01 but I don't think any of that applies to this case, right?
