### PR TITLE
Fix issue #3339 by not clearing filter history on control change

### DIFF
--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -95,23 +95,17 @@ bool CrossoverEQEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 	if( m_needsUpdate || m_controls.m_xover12.isValueChanged() )
 	{
 		m_lp1.setLowpass( m_controls.m_xover12.value() );
-		m_lp1.clearHistory();
 		m_hp2.setHighpass( m_controls.m_xover12.value() );
-		m_hp2.clearHistory();
 	}
 	if( m_needsUpdate || m_controls.m_xover23.isValueChanged() )
 	{
 		m_lp2.setLowpass( m_controls.m_xover23.value() );
-		m_lp2.clearHistory();
 		m_hp3.setHighpass( m_controls.m_xover23.value() );
-		m_hp3.clearHistory();
 	}
 	if( m_needsUpdate || m_controls.m_xover34.isValueChanged() )
 	{
 		m_lp3.setLowpass( m_controls.m_xover34.value() );
-		m_lp3.clearHistory();
 		m_hp4.setHighpass( m_controls.m_xover34.value() );
-		m_hp4.clearHistory();
 	}
 	
 	// gain values update
@@ -204,6 +198,16 @@ bool CrossoverEQEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 	checkGate( outSum );
 	
 	return isRunning();
+}
+
+void CrossoverEQEffect::clearFilterHistories()
+{
+	m_lp1.clearHistory();
+	m_lp2.clearHistory();
+	m_lp3.clearHistory();
+	m_hp2.clearHistory();
+	m_hp3.clearHistory();
+	m_hp4.clearHistory();
 }
 
 

--- a/plugins/CrossoverEQ/CrossoverEQ.h
+++ b/plugins/CrossoverEQ/CrossoverEQ.h
@@ -44,6 +44,8 @@ public:
 	{
 		return &m_controls;
 	}
+
+	void clearFilterHistories();
 	
 private:
 	CrossoverEQControls m_controls;

--- a/plugins/CrossoverEQ/CrossoverEQControls.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControls.cpp
@@ -86,6 +86,7 @@ void CrossoverEQControls::loadSettings( const QDomElement & elem )
 	m_mute4.loadSettings( elem, "mute4" );
 	
 	m_effect->m_needsUpdate = true;
+	m_effect->clearFilterHistories();
 }
 
 void CrossoverEQControls::xover12Changed()


### PR DESCRIPTION
Do not clear the filter histories when the crossover control has changed,
e.g. via automation.

Add a new method CrossoverEQEffect::clearFilterHistories that's called
whenever the filter histories need to be cleared, e.g. after loading a
crossover EQ. It would be beneficial to also call this method when the
effect is enabled again after being disabled but it seems there is no
was to find out that this event has happened. One could implement it in
the process method by storing the current state in a member and
comparing it to the state at the time of the last process call but this
is something that should be provided by the framework.