### PR TITLE
Workaround Qt5 bug that fails to remove separator at end of File/Help menus

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -315,7 +315,16 @@ void MainWindow::finalize()
 					SLOT( exportProjectMidi() ),
 					Qt::CTRL + Qt::Key_M );*/
 
+//
+// Conditional compilation to workaround Qt5 bug that fails to remove
+// separator at end of menu when the Quit menu item is relocated to
+// Application Menu on Mac OS X / macOS. For details see:
+//  * <https://github.com/LMMS/lmms/issues/3345>
+//  * <https://bugreports.qt.io/browse/QTBUG-40071>
+//
+#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
 	project_menu->addSeparator();
+#endif
 	project_menu->addAction( embed::getIconPixmap( "exit" ), tr( "&Quit" ),
 					qApp, SLOT( closeAllWindows() ),
 					Qt::CTRL + Qt::Key_Q );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -399,7 +399,16 @@ void MainWindow::finalize()
 					tr( "What's This?" ),
 					this, SLOT( enterWhatsThisMode() ) );
 
+//
+// Conditional compilation to workaround Qt5 bug that fails to remove
+// separator at end of menu when the About menu item is relocated to
+// Application Menu on Mac OS X / macOS. For details see:
+//  * <https://github.com/LMMS/lmms/issues/3345>
+//  * <https://bugreports.qt.io/browse/QTBUG-40071>
+//
+#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
 	help_menu->addSeparator();
+#endif
 	help_menu->addAction( embed::getIconPixmap( "icon" ), tr( "About" ),
 				  this, SLOT( aboutLMMS() ) );
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -315,13 +315,7 @@ void MainWindow::finalize()
 					SLOT( exportProjectMidi() ),
 					Qt::CTRL + Qt::Key_M );*/
 
-//
-// Conditional compilation to workaround Qt5 bug that fails to remove
-// separator at end of menu when the Quit menu item is relocated to
-// Application Menu on Mac OS X / macOS. For details see:
-//  * <https://github.com/LMMS/lmms/issues/3345>
-//  * <https://bugreports.qt.io/browse/QTBUG-40071>
-//
+// Prevent dangling separator at end of menu per https://bugreports.qt.io/browse/QTBUG-40071
 #if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
 	project_menu->addSeparator();
 #endif
@@ -399,13 +393,7 @@ void MainWindow::finalize()
 					tr( "What's This?" ),
 					this, SLOT( enterWhatsThisMode() ) );
 
-//
-// Conditional compilation to workaround Qt5 bug that fails to remove
-// separator at end of menu when the About menu item is relocated to
-// Application Menu on Mac OS X / macOS. For details see:
-//  * <https://github.com/LMMS/lmms/issues/3345>
-//  * <https://bugreports.qt.io/browse/QTBUG-40071>
-//
+// Prevent dangling separator at end of menu per https://bugreports.qt.io/browse/QTBUG-40071
 #if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
 	help_menu->addSeparator();
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -316,7 +316,7 @@ void MainWindow::finalize()
 					Qt::CTRL + Qt::Key_M );*/
 
 // Prevent dangling separator at end of menu per https://bugreports.qt.io/browse/QTBUG-40071
-#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
+#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000) && (QT_VERSION < 0x050600))
 	project_menu->addSeparator();
 #endif
 	project_menu->addAction( embed::getIconPixmap( "exit" ), tr( "&Quit" ),
@@ -394,7 +394,7 @@ void MainWindow::finalize()
 					this, SLOT( enterWhatsThisMode() ) );
 
 // Prevent dangling separator at end of menu per https://bugreports.qt.io/browse/QTBUG-40071
-#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000))
+#if !(defined(LMMS_BUILD_APPLE) && (QT_VERSION >= 0x050000) && (QT_VERSION < 0x050600))
 	help_menu->addSeparator();
 #endif
 	help_menu->addAction( embed::getIconPixmap( "icon" ), tr( "About" ),


### PR DESCRIPTION
See #3345 for details.