### PR TITLE
Some automation pattern fixes

### DIFF
--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -79,11 +79,10 @@ public:
 	MidiTime putValue( const MidiTime & _time, const float _value,
 						const bool _quant_pos = true );
 
-	void removeValue( const MidiTime & _time,
-					  const bool _quant_pos = true );
+	void removeValue( const MidiTime & time );
 
 	MidiTime setDragValue( const MidiTime & _time, const float _value,
-						   const bool _quant_pos = true );
+						const bool _quant_pos = true );
 
 	void applyDragValue();
 

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -76,13 +76,17 @@ public:
 	MidiTime timeMapLength() const;
 	void updateLength();
 
-	MidiTime putValue( const MidiTime & _time, const float _value,
-						const bool _quant_pos = true );
+	MidiTime putValue( const MidiTime & time,
+				const float value,
+				const bool quantPos = true,
+				const bool controlKey = false );
 
 	void removeValue( const MidiTime & time );
 
-	MidiTime setDragValue( const MidiTime & _time, const float _value,
-						const bool _quant_pos = true );
+	MidiTime setDragValue( const MidiTime & time,
+				const float value,
+				const bool quantPos = true,
+				const bool controlKey = false );
 
 	void applyDragValue();
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -237,18 +237,13 @@ MidiTime AutomationPattern::putValue( const MidiTime & _time,
 
 
 
-void AutomationPattern::removeValue( const MidiTime & _time,
-									 const bool _quant_pos )
+void AutomationPattern::removeValue( const MidiTime & time )
 {
 	cleanObjects();
 
-	MidiTime newTime = _quant_pos ?
-				Note::quantized( _time, quantization() ) :
-				_time;
-
-	m_timeMap.remove( newTime );
-	m_tangents.remove( newTime );
-	timeMap::const_iterator it = m_timeMap.lowerBound( newTime );
+	m_timeMap.remove( time );
+	m_tangents.remove( time );
+	timeMap::const_iterator it = m_timeMap.lowerBound( time );
 	if( it != m_timeMap.begin() )
 	{
 		--it;
@@ -267,7 +262,7 @@ void AutomationPattern::removeValue( const MidiTime & _time,
 
 
 /**
- * @brief Set the position of the point that is being draged.
+ * @brief Set the position of the point that is being dragged.
  *        Calling this function will also automatically set m_dragging to true,
  *        which applyDragValue() have to be called to m_dragging.
  * @param the time(x position) of the point being dragged
@@ -648,7 +643,7 @@ void AutomationPattern::processMidiTime( const MidiTime & time )
 			}
 			else if( valueAt( time ) != value )
 			{
-				removeValue( time, false );
+				removeValue( time );
 			}
 		}
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -721,8 +721,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			// int resolution needed to improve the sensitivity of
 			// the erase manoeuvre with zoom levels < 100%
 			int zoom = m_zoomingXModel.value();
-			int resolution = 1 + ( zoom * zoom );
-			resolution *= zoom > 3 ? 2 : 1;
+			int resolution = 3 + zoom * zoom;
 			for( int i = -resolution; i < resolution; ++i )
 			{
 				m_pattern->removeValue( MidiTime( pos_ticks + i ) );
@@ -2359,7 +2358,12 @@ AutomationEditorWindow::AutomationEditorWindow() :
 
 	quantizationActionsToolBar->addWidget( quantize_lbl );
 	quantizationActionsToolBar->addWidget( m_quantizeComboBox );
-
+	m_quantizeComboBox->setToolTip( tr( "Quantization" ) );
+	m_quantizeComboBox->setWhatsThis( tr( "Quantization. Sets the smallest "
+				"step size for the Automation Point. By default "
+				"this also sets the length, clearing out other "
+				"points in the range. Press <Ctrl> to override "
+				"this behaviour." ) );
 
 	// Setup our actual window
 	setFocusPolicy( Qt::StrongFocus );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -720,8 +720,9 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 		{
 			// int resolution needed to improve the sensitivity of
 			// the erase manoeuvre with zoom levels < 100%
-			int resolution = 1 + m_zoomingXModel.value() * m_zoomingXModel.value();
-			resolution *= m_zoomingXModel.value() > 3 ? 2 : 1;
+			int zoom = m_zoomingXModel.value();
+			int resolution = 1 + ( zoom * zoom );
+			resolution *= zoom > 3 ? 2 : 1;
 			for( int i = -resolution; i < resolution; ++i )
 			{
 				m_pattern->removeValue( MidiTime( pos_ticks + i ) );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -135,11 +135,12 @@ AutomationEditor::AutomationEditor() :
 	for( int i = 0; i < 5; ++i )
 	{
 		m_quantizeModel.addItem( "1/" +
-					QString::number( (1 << i) * 3 ) );
+					QString::number( ( 1 << i ) * 3 ) );
 	}
 	m_quantizeModel.addItem( "1/192" );
 
-	connect(&m_quantizeModel, SIGNAL(dataChanged()), this, SLOT(setQuantization()));
+	connect( &m_quantizeModel, SIGNAL(dataChanged() ),
+					this, SLOT( setQuantization() ) );
 	m_quantizeModel.setValue( m_quantizeModel.findText( "1/8" ) );
 
 	if( s_toolYFlip == NULL )

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -713,7 +713,10 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				( mouseEvent->buttons() & Qt::LeftButton &&
 						m_editMode == ERASE ) )
 		{
-			int resolution = 1 + m_zoomingXModel.value() * 2;
+			// int resolution needed to improve the sensitivity of
+			// the erase manoeuvre with zoom levels < 100%
+			int resolution = 1 + m_zoomingXModel.value() * m_zoomingXModel.value();
+			resolution *= m_zoomingXModel.value() > 3 ? 2 : 1;
 			for( int i = -resolution; i < resolution; ++i )
 			{
 				m_pattern->removeValue( MidiTime( pos_ticks + i ) );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -132,6 +132,13 @@ AutomationEditor::AutomationEditor() :
 	{
 		m_quantizeModel.addItem( "1/" + QString::number( 1 << i ) );
 	}
+	for( int i = 0; i < 5; ++i )
+	{
+		m_quantizeModel.addItem( "1/" +
+					QString::number( (1 << i) * 3 ) );
+	}
+	m_quantizeModel.addItem( "1/192" );
+
 	if( s_toolYFlip == NULL )
 	{
 		s_toolYFlip = new QPixmap( embed::getIconPixmap(
@@ -706,7 +713,11 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				( mouseEvent->buttons() & Qt::LeftButton &&
 						m_editMode == ERASE ) )
 		{
-			m_pattern->removeValue( MidiTime( pos_ticks ) );
+			int resolution = 1 + m_zoomingXModel.value() * 2;
+			for( int i = -resolution; i < resolution; ++i )
+			{
+				m_pattern->removeValue( MidiTime( pos_ticks + i ) );
+			}
 		}
 		else if( mouseEvent->buttons() & Qt::NoButton && m_editMode == DRAW )
 		{
@@ -2015,8 +2026,22 @@ void AutomationEditor::zoomingYChanged()
 
 void AutomationEditor::setQuantization()
 {
-	int quantization = DefaultTicksPerTact / (1 << m_quantizeModel.value());;
-	AutomationPattern::setQuantization(quantization);
+	int quantization = m_quantizeModel.value();
+	if( quantization < 7 )
+	{
+		quantization = 1 << quantization;
+	}
+	else if( quantization < 12 )
+	{
+		quantization = 1 << ( quantization - 7 );
+		quantization *= 3;
+	}
+	else
+	{
+		quantization = DefaultTicksPerTact;
+	}
+	quantization = DefaultTicksPerTact / quantization;
+	AutomationPattern::setQuantization( quantization );
 }
 
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -562,7 +562,9 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 
 					MidiTime new_time =
 						m_pattern->setDragValue( value_pos,
-									level );
+									level, true,
+							mouseEvent->modifiers() &
+								Qt::ControlModifier );
 
 					// reset it so that it can be used for
 					// ops (move, resize) after this
@@ -702,7 +704,9 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				// moved properly according to new starting-
 				// time in the time map of pattern
 				m_pattern->setDragValue( MidiTime( pos_ticks ),
-								level );
+								level, true,
+							mouseEvent->modifiers() &
+								Qt::ControlModifier );
 			}
 
 			Engine::getSong()->setModified();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -721,7 +721,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			// int resolution needed to improve the sensitivity of
 			// the erase manoeuvre with zoom levels < 100%
 			int zoom = m_zoomingXModel.value();
-			int resolution = 3 + zoom * zoom;
+			int resolution = 1 + zoom * zoom;
 			for( int i = -resolution; i < resolution; ++i )
 			{
 				m_pattern->removeValue( MidiTime( pos_ticks + i ) );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -139,6 +139,9 @@ AutomationEditor::AutomationEditor() :
 	}
 	m_quantizeModel.addItem( "1/192" );
 
+	connect(&m_quantizeModel, SIGNAL(dataChanged()), this, SLOT(setQuantization()));
+	m_quantizeModel.setValue( m_quantizeModel.findText( "1/8" ) );
+
 	if( s_toolYFlip == NULL )
 	{
 		s_toolYFlip = new QPixmap( embed::getIconPixmap(
@@ -149,9 +152,6 @@ AutomationEditor::AutomationEditor() :
 		s_toolXFlip = new QPixmap( embed::getIconPixmap(
 							"flip_x" ) );
 	}
-
-	connect(&m_quantizeModel, SIGNAL(dataChanged()), this, SLOT(setQuantization()));
-	m_quantizeModel.setValue( m_quantizeModel.findText( "1/16" ) );
 
 	// add time-line
 	m_timeLine = new TimeLineWidget( VALUES_WIDTH, 0, m_ppt,


### PR DESCRIPTION
Fixes #391
 * In response to one part of issue https://github.com/LMMS/lmms/issues/391, comment [here](https://github.com/LMMS/lmms/issues/391#issuecomment-72783217), in which you can't delete Automation Points that were made under a finer quantization. Don't consider quantization when deleting and just delete the value at the position.
We should maybe iterate through the neighbouring positions if there are no values at the current positon as it's a bit hard currently to hit the right spot for deletion. You have a similar problem when dragging an Automation Point which I haven't touched in this PR. When you select an Automation Point made under finer quantization you will instead create a new point at the quantized position.
 * Let an automation point clear the area it covers.
 * Triplets and no quantization option. This gives the Automation Editor the same quantization options as the other editors.
 * Improved erase action when moving mouse across Automation Points.
 * Eighth note, new default quantization value.