### PR TITLE
Offbeatnotes

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -88,7 +88,7 @@ public:
 	{
 		return m_patternType;
 	}
-
+	void checkType();
 
 	// next/previous track based on position in the containing track
 	Pattern * previousPattern() const;
@@ -132,7 +132,6 @@ private:
 	MidiTime beatPatternLength() const;
 
 	void setType( PatternTypes _new_pattern_type );
-	void checkType();
 
 	void resizeToFirstTrack();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2451,6 +2451,11 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 					note->setPos( MidiTime( pos_ticks ) );
 					note->setKey( key_num );
+					// If dragging beat notes check if pattern should be MelodyPattern
+					if( note->length() < 0 )
+					{
+						m_pattern->checkType();
+					}
 				}
 			}
 		}

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -369,7 +369,9 @@ void Pattern::checkType()
 	NoteVector::Iterator it = m_notes.begin();
 	while( it != m_notes.end() )
 	{
-		if( ( *it )->length() > 0 )
+		if( ( *it )->length() > 0 ||
+			( *it )->pos() % ( MidiTime::ticksPerTact() /
+						MidiTime::stepsPerTact() ) )
 		{
 			setType( MelodyPattern );
 			return;


### PR DESCRIPTION
Fixes #1681

From a discussion that starts here: https://github.com/LMMS/lmms/issues/1681#issuecomment-277537185
 - ~~When you add an ordinary note to a beat pattern the pattern is visually turned into a melody pattern, but the beat notes aren't represented in it.~~ _Fixed in #3375_
 - When a beat note is shifted off it's 16th part position it's no longer visible. Instead, turn the pattern into a melody pattern.


![offbeatnotes](https://cloud.githubusercontent.com/assets/6368949/23142534/c4a1a1e2-f7bc-11e6-9c20-22d3bff51c88.png)
_Suggested fix: Pattern switch to MelodyPattern when one or more beat notes are not visible in the BBEditor._