### PR TITLE
Fixes build errors under mingw (3113)

### DIFF
--- a/cmake/build_mingw32.sh
+++ b/cmake/build_mingw32.sh
@@ -8,7 +8,7 @@ else
 	CMAKE_OPTS="$CMAKE_OPTS -DLMMS_BUILD_MSYS=1"
 fi
 
-export PATH=$PATH:$MINGW/bin
+export PATH=$MINGW/bin:$PATH
 export CFLAGS="-march=pentium3 -mtune=generic -mpreferred-stack-boundary=5 -mfpmath=sse"
 export CXXFLAGS="$CFLAGS"
 

--- a/cmake/build_mingw64.sh
+++ b/cmake/build_mingw64.sh
@@ -8,7 +8,7 @@ else
 	CMAKE_OPTS="$CMAKE_OPTS -DLMMS_BUILD_MSYS=1"
 fi
 
-export PATH=$PATH:$MINGW/bin
+export PATH=$MINGW/bin:$PATH
 
 if [ "$1" = "-qt5" ]; then
         QT5=True

--- a/cmake/msys/fetch_ppa.sh
+++ b/cmake/msys/fetch_ppa.sh
@@ -20,8 +20,8 @@ temp_file=/tmp/ppa_listing_$$
 temp_temp_file=/tmp/ppa_listing_temp_$$
 
 skip_files="binutils openssl flac libgig libogg libvorbis x-bootstrap zlib"
-skip_files="$skip_files x-runtime gcc qt_4 qt5 fltk x-stk pkgconfig" 
-skip_files="$skip_files libjpeg glib2 libpng"
+skip_files="$skip_files x-runtime gcc qt_4 qt5 x-stk pkgconfig" 
+skip_files="$skip_files glib2 libpng"
 
 echo "Connecting to $PPA_HOST to get list of packages..."
 wget -qO- $PPA_URL |grep "Filename:" > $temp_file

--- a/cmake/msys/fetch_ppa.sh
+++ b/cmake/msys/fetch_ppa.sh
@@ -17,9 +17,19 @@ PPA_URL=$PPA_ROOT/dists/$PPA_DISTRO/main/binary-$PPA_ARCH/Packages
 ppa_dir=./ppa/
 
 temp_file=/tmp/ppa_listing_$$
+temp_temp_file=/tmp/ppa_listing_temp_$$
+
+skip_files="binutils openssl flac libgig libogg libvorbis x-bootstrap zlib"
+skip_files="$skip_files x-runtime gcc qt_4 qt5 fltk x-stk pkgconfig" 
+skip_files="$skip_files libjpeg glib2 libpng"
 
 echo "Connecting to $PPA_HOST to get list of packages..."
 wget -qO- $PPA_URL |grep "Filename:" > $temp_file
+
+for j in $skip_files ; do
+	grep -v $j $temp_file > $temp_temp_file
+	mv $temp_temp_file $temp_file
+done
 
 line_count=`wc -l $temp_file |awk '{print $1}'`
 

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -80,7 +80,7 @@ if [ $? -ne 0 ]; then
 	pushd $HOME/fltk-$fltkver
 
 	info "  - Compiling fltk $fltkver..."
-	./configure --prefix=$mingw_root
+	./configure --prefix=$mingw_root --enable-shared
 
 	make
 

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -221,6 +221,9 @@ if [ ! -e $mingw_root/lib/libgig/libgig.dll.a ]; then
 	info "  - Installing libgig..."
 	make install
 
+	mv $mingw_root/lib/bin/libakai-0.dll $mingw_root/bin
+	mv $mingw_root/lib/bin/libgig-7.dll $mingw_root/bin
+
 	if [ $? -ne 0 ]; then
         	err "ERROR: Could not build/install libgig -- gigplayer needs this.  Exiting."
 	fi

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -232,7 +232,7 @@ fi
 
 info "Downloading and building stk $stkver"
 
-if [ ! -e $mingw_root/lib/stkfile ]; then 
+if [ ! -e $mingw_root/lib/libstk.dll ]; then 
 	wget http://ccrma.stanford.edu/software/stk/release/stk-$stkver.tar.gz -O $HOME/stk-source.tar.xz
 	if [ $? -ne 0 ]; then
 		err "ERROR: Could not download stk.  Exiting."
@@ -251,6 +251,9 @@ if [ ! -e $mingw_root/lib/stkfile ]; then
 	if [ $? -ne 0 ]; then
         	err "ERROR: Could not build/install stk -- mallotstk needs this.  Exiting."
 	fi
+
+	# Because some yutz over at Stanford decided to put an .so 
+	# extension on a Windows dll.  Yes I verified it twice
 	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
 	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
 	

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -65,6 +65,7 @@ oggver="1.3.2"
 vorbisver="1.3.5"
 flacver="1.3.2"
 gigver="4.0.0"
+stkver="4.5.1"
 
 info "Downloading and building fltk $fltkver"
 
@@ -229,6 +230,39 @@ else
 	warn "  - Skipping, libgig binary already exists" 
 fi
 
+info "Downloading and building stk $stkver"
+
+if [ ! -e $mingw_root/lib/stkfile ]; then 
+	wget http://ccrma.stanford.edu/software/stk/release/stk-$stkver.tar.gz -O $HOME/stk-source.tar.xz
+	if [ $? -ne 0 ]; then
+		err "ERROR: Could not download stk.  Exiting."
+	fi
+	tar xf $HOME/stk-source.tar.xz -C $HOME/
+	pushd $HOME/stk-$stkver
+
+	info "  - Compiling stk $stkver..."
+	./configure --prefix=$mingw_root
+
+	make
+
+	info "  - Installing stk..."
+	make install
+
+	if [ $? -ne 0 ]; then
+        	err "ERROR: Could not build/install stk -- mallotstk needs this.  Exiting."
+	fi
+	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
+	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
+	
+	popd
+else
+	warn "  - Skipping, stk binary already exists" 
+fi
+
+# make a symlink to make cmake happy
+if [ ! -e /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config ]; then 
+	ln -s /usr/bin/pkg-config /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config
+fi
 
 info "Cleaning up..."
 rm -rf $HOME/fltk-$fltkver
@@ -236,4 +270,5 @@ rm -rf $HOME/libogg-$oggver
 rm -rf $HOME/libvorbis-$vorbisver
 rm -rf $HOME/flac-$flacver
 rm -rf $HOME/libgig-$gigver
+rm -rf $HOME/stk-$stkver
 info "Done."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -253,7 +253,7 @@ if [ ! -e $mingw_root/lib/libstk.dll ]; then
 	fi
 
 	# Because some yutz over at Stanford decided to put an .so 
-	# extension on a Windows dll.  Yes I verified it twice
+	# extension on a Windows dll.  Yes I verified it twice -EAS
 	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
 	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
 	

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -63,6 +63,7 @@ fi
 fltkver="1.3.3"
 oggver="1.3.2"
 vorbisver="1.3.5"
+flacver="1.3.2"
 
 info "Downloading and building fltk $fltkver"
 
@@ -133,7 +134,7 @@ fi
 info "Downloading and building libvorbis $vorbisver"
 
 if [ ! -e $mingw_root/lib/libvorbis.dll.a ]; then 
-	wget http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz -O $HOME/libvorbis-source.tar.xz
+	wget http://downloads.xiph.org/releases/vorbis/libvorbis-$vorbisver.tar.xz -O $HOME/libvorbis-source.tar.xz
 	if [ $? -ne 0 ]; then
 		err "ERROR: Could not download libogg.  Exiting."	
 	fi
@@ -165,9 +166,45 @@ else
 	warn "  - Skipping, libvorbis binary already exists" 
 fi
 
+info "Downloading and building flac $flacver"
+
+if [ ! -e $mingw_root/lib/libFLAC.dll.a ]; then 
+	wget http://downloads.xiph.org/releases/flac/flac-$flacver.tar.xz -O $HOME/flac-source.tar.xz
+	if [ $? -ne 0 ]; then
+		err "ERROR: Could not download flac.  Exiting."	
+	fi
+	tar xf $HOME/flac-source.tar.xz -C $HOME/
+	pushd $HOME/flac-$flacver
+
+	info "  - Compiling flac $flacver..."
+	./configure --prefix=$mingw_root
+
+	make
+
+	info "  - Installing flac..."
+	make install
+
+	# for some reason libgig needs this
+	./configure --prefix=/opt$mingw_root
+
+	make
+
+	info "  - Installing flac..."
+	make install
+
+	if [ $? -ne 0 ]; then
+        	err "ERROR: Could not build/install flac -- lmms needs this.  Exiting."
+	fi
+	
+	popd
+else
+	warn "  - Skipping, libvorbis binary already exists" 
+fi
+
 
 info "Cleaning up..."
 rm -rf $HOME/fltk-$fltkver
 rm -rf $HOME/libogg-$oggver
 rm -rf $HOME/libvorbis-$vorbisver
+rm -rf $HOME/flac-$flacver
 info "Done."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -62,6 +62,7 @@ fi
 
 fltkver="1.3.3"
 oggver="1.3.2"
+vorbisver="1.3.5"
 
 info "Downloading and building fltk $fltkver"
 
@@ -88,11 +89,10 @@ if [ $? -ne 0 ]; then
 	fi
 	
 #	ln -s $mingw_root/usr/local/bin/fluid.exe $mingw_root/bin/fluid.exe 	
+	popd
 else
 	warn "  - Skipping, fluid binary already exists" 
 fi
-
-popd
 
 info "Downloading and building libogg $oggver"
 
@@ -121,16 +121,53 @@ if [ ! -e $mingw_root/lib/libogg.dll.a ]; then
 	make install
 
 	if [ $? -ne 0 ]; then
-        	err "ERROR: Could not build/install fltk -- Zyn needs this.  Exiting."
+        	err "ERROR: Could not build/install fltk -- lmms needs this.  Exiting."
 	fi
 	
+	popd
 else
 	warn "  - Skipping, libogg binary already exists" 
 fi
 
-popd
+
+info "Downloading and building libvorbis $vorbisver"
+
+if [ ! -e $mingw_root/lib/libvorbis.dll.a ]; then 
+	wget http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.xz -O $HOME/libvorbis-source.tar.xz
+	if [ $? -ne 0 ]; then
+		err "ERROR: Could not download libogg.  Exiting."	
+	fi
+	tar xf $HOME/libvorbis-source.tar.xz -C $HOME/
+	pushd $HOME/libvorbis-$vorbisver
+
+	info "  - Compiling libvorbis $vorbisver..."
+	./configure --prefix=$mingw_root
+
+	make
+
+	info "  - Installing libvorbis..."
+	make install
+
+	# for some reason libgig needs this
+	./configure --prefix=/opt$mingw_root
+
+	make
+
+	info "  - Installing libvorbis..."
+	make install
+
+	if [ $? -ne 0 ]; then
+        	err "ERROR: Could not build/install libvorbis -- lmms needs this.  Exiting."
+	fi
+	
+	popd
+else
+	warn "  - Skipping, libvorbis binary already exists" 
+fi
+
 
 info "Cleaning up..."
 rm -rf $HOME/fltk-$fltkver
 rm -rf $HOME/libogg-$oggver
+rm -rf $HOME/libvorbis-$vorbisver
 info "Done."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -75,18 +75,18 @@ if [ $? -ne 0 ]; then
 	pushd $HOME/fltk-$fltkver
 
 	info "  - Compiling fltk $fltkver..."
-	./configure
+	./configure --prefix=$mingw_root
 
 	make
 
 	info "  - Installing fltk..."
-	make install DESTDIR=$mingw_root
+	make install
 
 	if [ $? -ne 0 ]; then
         	err "ERROR: Could not build/install fltk -- Zyn needs this.  Exiting."
 	fi
 	
-	ln -s $mingw_root/usr/local/bin/fluid.exe $mingw_root/bin/fluid.exe 	
+#	ln -s $mingw_root/usr/local/bin/fluid.exe $mingw_root/bin/fluid.exe 	
 else
 	warn "  - Skipping, fluid binary already exists" 
 fi

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -132,4 +132,5 @@ popd
 
 info "Cleaning up..."
 rm -rf $HOME/fltk-$fltkver
+rm -rf $HOME/libogg-$oggver
 info "Done."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -64,6 +64,7 @@ fltkver="1.3.3"
 oggver="1.3.2"
 vorbisver="1.3.5"
 flacver="1.3.2"
+gigver="4.0.0"
 
 info "Downloading and building fltk $fltkver"
 
@@ -198,7 +199,34 @@ if [ ! -e $mingw_root/lib/libFLAC.dll.a ]; then
 	
 	popd
 else
-	warn "  - Skipping, libvorbis binary already exists" 
+	warn "  - Skipping, libvorbis flac already exists" 
+fi
+
+info "Downloading and building libgig $gigver"
+
+if [ ! -e $mingw_root/lib/libgig/libgig.dll.a ]; then 
+	wget http://download.linuxsampler.org/packages/libgig-$gigver.tar.bz2 -O $HOME/gig-source.tar.xz
+	if [ $? -ne 0 ]; then
+		err "ERROR: Could not download libgig.  Exiting."	
+	fi
+	tar xf $HOME/gig-source.tar.xz -C $HOME/
+	pushd $HOME/libgig-$gigver
+
+	info "  - Compiling libgig $gigver..."
+	./configure --prefix=$mingw_root
+
+	make
+
+	info "  - Installing libgig..."
+	make install
+
+	if [ $? -ne 0 ]; then
+        	err "ERROR: Could not build/install libgig -- gigplayer needs this.  Exiting."
+	fi
+	
+	popd
+else
+	warn "  - Skipping, libgig binary already exists" 
 fi
 
 
@@ -207,4 +235,5 @@ rm -rf $HOME/fltk-$fltkver
 rm -rf $HOME/libogg-$oggver
 rm -rf $HOME/libvorbis-$vorbisver
 rm -rf $HOME/flac-$flacver
+rm -rf $HOME/libgig-$gigver
 info "Done."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -252,18 +252,9 @@ if [ ! -e $mingw_root/lib/libstk.dll ]; then
         	err "ERROR: Could not build/install stk -- mallotstk needs this.  Exiting."
 	fi
 
-	mv $mingw_root/lib/libstk.so $mingw_root/bin/libstk.dll
-	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/bin/libstk-$stkver.dll
+	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
+	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
 
-	dlltool -z libstk.def --export-all-symbol $mingw_root/bin/libstk.dll
-	dlltool -z libstk-$stkver.def --export-all-symbol $mingw_root/bin/libstk-$stkver.dll
-
-	dlltool -d libstk.def -l libstk.dll.a
-	dlltool -d libstk-$stkver.def -l libstk-$stkver.dll.a
-
-	mv libstk.dll.a $mingw_root/lib
-	mv libstk-$stkver.dll.a $mingw_root/lib
-	
 	popd
 else
 	warn "  - Skipping, stk binary already exists" 

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -61,6 +61,7 @@ else
 fi
 
 fltkver="1.3.3"
+oggver="1.3.2"
 
 info "Downloading and building fltk $fltkver"
 
@@ -89,6 +90,42 @@ if [ $? -ne 0 ]; then
 #	ln -s $mingw_root/usr/local/bin/fluid.exe $mingw_root/bin/fluid.exe 	
 else
 	warn "  - Skipping, fluid binary already exists" 
+fi
+
+popd
+
+info "Downloading and building libogg $oggver"
+
+if [ ! -e $mingw_root/lib/libogg.dll.a ]; then 
+	wget http://downloads.xiph.org/releases/ogg/libogg-$oggver.tar.xz -O $HOME/libogg-source.tar.xz
+	if [ $? -ne 0 ]; then
+		err "ERROR: Could not download libogg.  Exiting."	
+	fi
+	tar xf $HOME/libogg-source.tar.xz -C $HOME/
+	pushd $HOME/libogg-$oggver
+
+	info "  - Compiling libogg $oggver..."
+	./configure --prefix=$mingw_root
+
+	make
+
+	info "  - Installing libogg..."
+	make install
+
+	# for some reason libgig needs this
+	./configure --prefix=/opt$mingw_root
+
+	make
+
+	info "  - Installing libogg..."
+	make install
+
+	if [ $? -ne 0 ]; then
+        	err "ERROR: Could not build/install fltk -- Zyn needs this.  Exiting."
+	fi
+	
+else
+	warn "  - Skipping, libogg binary already exists" 
 fi
 
 popd

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -256,6 +256,8 @@ if [ ! -e $mingw_root/lib/libstk.dll ]; then
 	# extension on a Windows dll.  Yes I verified it twice -EAS
 	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
 	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
+	ln -s $mingw_root/lib/libstk.dll $mingw_root/bin
+	ln -s $mingw_root/lib/libstk-$stkver.dll $mingw_root/bin
 	
 	popd
 else
@@ -263,8 +265,16 @@ else
 fi
 
 # make a symlink to make cmake happy
-if [ ! -e /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config ]; then 
-	ln -s /usr/bin/pkg-config /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config
+if [ $mingw_root = "/mingw64" ]; then
+	if [ ! -e /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config ]; then 
+		ln -s /usr/bin/pkg-config /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config
+	fi
+fi
+if [ $mingw_root = "/mingw32" ]; then
+
+	if [ ! -e /opt/mingw32/bin/i686-w64-mingw32-pkg-config ]; then 
+		ln -s /usr/bin/pkg-config /opt/mingw32/bin/i686-w64-mingw32-pkg-config
+	fi
 fi
 
 info "Cleaning up..."

--- a/cmake/msys/msys_helper.sh
+++ b/cmake/msys/msys_helper.sh
@@ -252,12 +252,17 @@ if [ ! -e $mingw_root/lib/libstk.dll ]; then
         	err "ERROR: Could not build/install stk -- mallotstk needs this.  Exiting."
 	fi
 
-	# Because some yutz over at Stanford decided to put an .so 
-	# extension on a Windows dll.  Yes I verified it twice -EAS
-	mv $mingw_root/lib/libstk.so $mingw_root/lib/libstk.dll
-	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/lib/libstk-$stkver.dll
-	ln -s $mingw_root/lib/libstk.dll $mingw_root/bin
-	ln -s $mingw_root/lib/libstk-$stkver.dll $mingw_root/bin
+	mv $mingw_root/lib/libstk.so $mingw_root/bin/libstk.dll
+	mv $mingw_root/lib/libstk-$stkver.so $mingw_root/bin/libstk-$stkver.dll
+
+	dlltool -z libstk.def --export-all-symbol $mingw_root/bin/libstk.dll
+	dlltool -z libstk-$stkver.def --export-all-symbol $mingw_root/bin/libstk-$stkver.dll
+
+	dlltool -d libstk.def -l libstk.dll.a
+	dlltool -d libstk-$stkver.def -l libstk-$stkver.dll.a
+
+	mv libstk.dll.a $mingw_root/lib
+	mv libstk-$stkver.dll.a $mingw_root/lib
 	
 	popd
 else


### PR DESCRIPTION
Modified build bash scripts for mingw to fix errors when building under mingw.  Specifically when compiling gigplayer and malletstk.  The build now compiles without error on mingw systems with a clean install. There are still some issues with make package and some dlls that can't be found, but the program compiles and runs.  It is beyond my abilities with cmake to fix these.

-E. Allen Soard