### PR TITLE
[WIP] Fixes Ailiasing in AutomationPatternView

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -291,6 +291,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	lin2grad.setColorAt( 0.5, col );
 	lin2grad.setColorAt( 0, col.darker( 150 ) );
 
+	p.setRenderHints( QPainter::Antialiasing, true );
 	for( AutomationPattern::timeMap::const_iterator it =
 						m_pat->getTimeMap().begin();
 					it != m_pat->getTimeMap().end(); ++it )
@@ -315,25 +316,37 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 		float *values = m_pat->valuesAfter( it.key() );
 		for( int i = it.key(); i < (it + 1).key(); i++ )
 		{
-			float value = values[i - it.key()];
+			float x1value = values[i - it.key()];
+			float x2value = values[i - it.key() + 1];
+			if (i+1 == (it + 1).key()) x2value = x1value; //Catches last value not being there
+
 			const float x1 = x_base + i * ppt /
 						MidiTime::ticksPerTact();
 			const float x2 = x_base + (i + 1) * ppt /
 						MidiTime::ticksPerTact();
 			if( x1 > ( width() - TCO_BORDER_WIDTH ) ) break;
 
+			//Creates Polygon
+			QPainterPath path;
+			path.moveTo(QPoint(x1,0));
+			path.lineTo(QPoint(x1,x1value));
+			path.lineTo(QPoint(x2,x2value));
+			path.lineTo(QPoint(x2,0));
+			path.lineTo(QPoint(x1,0));
+
 			if( gradient() )
 			{
-				p.fillRect( QRectF( x1, 0.0f, x2 - x1, value ), lin2grad );
+				p.fillPath(path,lin2grad);
 			}
 			else
 			{
-				p.fillRect( QRectF( x1, 0.0f, x2 - x1, value ), col );
+				p.fillPath(path,col);
 			}
 		}
 		delete [] values;
 	}
 
+	p.setRenderHints( QPainter::Antialiasing, false );
 	p.resetMatrix();
 	
 	// bar lines


### PR DESCRIPTION
This is in reference to #2688. This is however not complete since the Automation editor also needs to be Anti-Aliased and there is still a bug:

_The graph/pattern is not being drawn in certain circumstances. It seems to be when it isn't referencing anything but still has a set of data points. The picture below shows the pattern in the editor and right above it it can be seen to not be displaying in the PatternView._
![auto](https://cloud.githubusercontent.com/assets/17950515/23335177/388a4448-fbb8-11e6-9747-907c68ec3bb5.png)

PS: (Please let me know if I'm doing anything in the wrong way. Submitting issues, pull requests etc. This is the first time trying to)
