### PR TITLE
Barlines now end at end of automation

### DIFF
--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -344,7 +344,8 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	{
 		const int tx = x_base + static_cast<int>( ppt * t ) - 2;
 		p.drawLine( tx, TCO_BORDER_WIDTH, tx, TCO_BORDER_WIDTH + lineSize );
-		p.drawLine( tx,	rect().bottom() - ( lineSize + TCO_BORDER_WIDTH ), tx, rect().bottom() - TCO_BORDER_WIDTH );
+		p.drawLine( tx,	rect().bottom() - ( lineSize + TCO_BORDER_WIDTH ),
+					tx, rect().bottom() - TCO_BORDER_WIDTH );
 	}
 
 	// recording icon for when recording automation

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -343,12 +343,8 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	for( tact_t t = 1; t < width() - TCO_BORDER_WIDTH; ++t )
 	{
 		const int tx = x_base + static_cast<int>( ppt * t ) - 2;
-		if( tx < ( width() - TCO_BORDER_WIDTH * 2 ) )
-		{
-			p.drawLine( tx, TCO_BORDER_WIDTH, tx, TCO_BORDER_WIDTH + lineSize );
-			p.drawLine( tx,	rect().bottom() - ( lineSize + TCO_BORDER_WIDTH ),
-						tx, rect().bottom() - TCO_BORDER_WIDTH );
-		}
+		p.drawLine( tx, TCO_BORDER_WIDTH, tx, TCO_BORDER_WIDTH + lineSize );
+		p.drawLine( tx,	rect().bottom() - ( lineSize + TCO_BORDER_WIDTH ), tx, rect().bottom() - TCO_BORDER_WIDTH );
 	}
 
 	// recording icon for when recording automation

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -340,7 +340,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	const int lineSize = 3;
 	p.setPen( c.darker( 300 ) );
 
-	for( tact_t t = 1; t < m_pat->timeMapLength().getTact(); ++t )
+	for( tact_t t = 1; t < width() - TCO_BORDER_WIDTH; ++t )
 	{
 		const int tx = x_base + static_cast<int>( ppt * t ) - 2;
 		if( tx < ( width() - TCO_BORDER_WIDTH * 2 ) )


### PR DESCRIPTION
The barlines in the Automation pattern view ended "early" where the data points ended for the pattern. It looks more consistent to end wherever the pattern is dragged to.

Before:
![before](https://cloud.githubusercontent.com/assets/17950515/23343295/85eb7716-fc71-11e6-8695-8adc841a08d9.png)

After:
![after](https://cloud.githubusercontent.com/assets/17950515/23343298/920a9bb2-fc71-11e6-9a16-96f7bbf6e1d1.png)

I'm not sure that the limit I changed is the right limit. It's a good idea for someone who knows exactly what each variable represents to have a look over. It does seem to work and not cause any problems.
