### PR TITLE
Don't count muted tracks in track length

### DIFF
--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -167,8 +167,8 @@ void ProjectRenderer::run()
 #endif
 #endif
 
-
 	Engine::getSong()->startExport();
+	Engine::getSong()->updateLength();
     //skip first empty buffer
     Engine::mixer()->nextBuffer();
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -555,6 +555,12 @@ void Song::updateLength()
 	for( TrackList::const_iterator it = tracks().begin();
 						it != tracks().end(); ++it )
 	{
+		if( Engine::getSong()->isExporting() &&
+				( *it )->isMuted() )
+		{
+			continue;
+		}
+
 		const tact_t cur = ( *it )->length();
 		if( cur > m_length )
 		{

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2421,6 +2421,12 @@ tact_t Track::length() const
 	for( tcoVector::const_iterator it = m_trackContentObjects.begin();
 				it != m_trackContentObjects.end(); ++it )
 	{
+		if( Engine::getSong()->isExporting() &&
+				( *it )->isMuted() )
+		{
+			continue;
+		}
+
 		const tick_t cur = ( *it )->endPosition();
 		if( cur > last )
 		{


### PR DESCRIPTION
Fixes #1733

When rendering, don't count muted tracks in `Song::updateLength()`  or muted TCO's in `Track::length()`

_Edit2: This seem to work just fine._

Name | Muting track | Muting TCO 
--- | --- | ---
Instrument Track | :white_check_mark: |  :white_check_mark: 
BBTrack |  :white_check_mark:  | :white_check_mark: 
Sample Track | :white_check_mark:  | :white_check_mark: 
Automation Track | :white_check_mark:  | :white_check_mark: 
