### PR TITLE
Fixes to CLI renderer

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -157,7 +157,7 @@ public:
 		}
 	} ;
 
-	void initDevices();
+	void initDevices( bool renderOnly );
 	void clear();
 
 

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -70,7 +70,7 @@ void LmmsCore::init( bool renderOnly )
 	s_projectJournal->setJournalling( true );
 
 	emit engine->initProgress(tr("Opening audio and midi devices"));
-	s_mixer->initDevices();
+	s_mixer->initDevices( renderOnly );
 
 	PresetPreviewPlayHandle::init();
 	s_dummyTC = new DummyTrackContainer;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -203,10 +203,18 @@ Mixer::~Mixer()
 
 
 
-void Mixer::initDevices()
+void Mixer::initDevices( bool renderOnly )
 {
-	m_audioDev = tryAudioDevices();
-	m_midiClient = tryMidiClients();
+	bool success_ful = false;
+	if( renderOnly ) {
+		m_audioDev = new AudioDummy( success_ful, this );
+		m_audioDevName = AudioDummy::name();
+		m_midiClient = new MidiDummy;
+		m_midiClientName = MidiDummy::name();
+	} else {
+		m_audioDev = tryAudioDevices();
+		m_midiClient = tryMidiClients();
+	}
 }
 
 


### PR DESCRIPTION
This PR contains some tweaks which address #3402 

This fix should now allow individuals to render audio using "lmms -r" without having to worry about the glitches or pops from before. 

I noticed that calling the CLI renderer was unnecessarily calling JACK, and possibly interfering with the renderer processing thread. What I did was ensure that the audio/MIDI devices were set to "dummy" when renderOnly mode was set to true. After applying this fix, I was able to render offline without having things skip or crash. 

Note that this fix is only for the CLI renderer, and not for the internal LMMS exporter (this still crashes for me). 