### PR TITLE
Bump up sample limits to 300MB and 90 minutes

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -202,7 +202,7 @@ void SampleBuffer::update( bool _keep_settings )
 		m_frames = 0;
 
 		const QFileInfo fileInfo( file );
-		if( fileInfo.size() > 100*1024*1024 )
+		if( fileInfo.size() > 300*1024*1024 )
 		{
 			fileLoadError = true;
 		}
@@ -215,7 +215,7 @@ void SampleBuffer::update( bool _keep_settings )
 			{
 				f_cnt_t frames = sf_info.frames;
 				int rate = sf_info.samplerate;
-				if( frames / rate > 60 * 60 ) // 60 minutes
+				if( frames / rate > 90 * 60 ) // 90 minutes
 				{
 					fileLoadError = true;
 				}


### PR DESCRIPTION
See issue https://github.com/LMMS/lmms/issues/3205
I probably have the weakest hardware of the developers and 300MB/90 minutes works. It isn't a smooth ride if you need to zoom in/out a lot or change play position as these changes takes a whole lot of time but LMMS won't crash and the sound works fine so these makes reasonable new upper limits.