### PR TITLE
Fix crash when rendering from command line and no write access to config file

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -547,14 +547,21 @@ void ConfigManager::saveConfigFile()
 	QFile outfile( m_lmmsRcFile );
 	if( !outfile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
 	{
-		QMessageBox::critical( NULL,
-			MainWindow::tr( "Could not save config-file" ),
-			MainWindow::tr( "Could not save configuration file %1. "
-					"You're probably not permitted to "
-					"write to this file.\n"
-					"Please make sure you have write-"
-					"access to the file and try again." ).
-							arg( m_lmmsRcFile  ) );
+		QString title, message;
+		title = MainWindow::tr( "Could not open file" );
+		message = MainWindow::tr( "Could not open file %1 "
+					"for writing.\nPlease make "
+					"sure you have write "
+					"permission to the file and "
+					"the directory containing the "
+					"file and try again!"
+						).arg( m_lmmsRcFile );
+		if( gui )
+		{
+			QMessageBox::critical( NULL, title, message,
+						QMessageBox::Ok,
+						QMessageBox::NoButton );
+		}
 		return;
 	}
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -922,7 +922,6 @@ void MainWindow::openRecentlyOpenedProject( QAction * _action )
 		const QString & f = _action->text();
 		setCursor( Qt::WaitCursor );
 		Engine::getSong()->loadProject( f );
-		ConfigManager::inst()->addRecentlyOpenedProject( f );
 		setCursor( Qt::ArrowCursor );
 	}
 	runAutoSave();


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/2245

This is basically commit https://github.com/LMMS/lmms/commit/e40a6bc627d43c6c148ce73d9c80e2a8900fe569 without the '**else**'

I also removed writing the config file from MainWindow.cpp when opening a recent project as this is done already from Song.cpp .