### PR TITLE
corrected wet/dry knob range

### DIFF
--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -46,7 +46,7 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_running( false ),
 	m_bufferCount( 0 ),
 	m_enabledModel( true, this, tr( "Effect enabled" ) ),
-	m_wetDryModel( 1.0f, -1.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
+	m_wetDryModel( 1.0f, 0.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
 	m_gateModel( 0.0f, 0.0f, 1.0f, 0.01f, this, tr( "Gate" ) ),
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )


### PR DESCRIPTION
Fixes #3261. 

After examining git commit history, I found a  [bug](https://github.com/LMMS/lmms/commit/f39c9641abd9f223f16084d41c70a7445b008a22#diff-4707ec0d66434cc27ae2716b4a33c04fL46) introduced nearly 10 years ago! While making some sweeping changes in the LMMS codebase, someone accidentally changed the range of the knob, which has given us the strange behavior we see today. In the git diff I linked to above, you can see the correct ranges being overridden with the incorrect ranges with no explanation.
