### PR TITLE
Initialise m_previousValue

### DIFF
--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -39,7 +39,8 @@ MidiController::MidiController( Model * _parent ) :
 	MidiEventProcessor(),
 	m_midiPort( tr( "unnamed_midi_controller" ),
 			Engine::mixer()->midiClient(), this, this, MidiPort::Input ),
-	m_lastValue( 0.0f )
+	m_lastValue( 0.0f ),
+	m_previousValue( 0.0f )
 {
 	setSampleExact( true );
 	connect( &m_midiPort, SIGNAL( modeChanged() ),


### PR DESCRIPTION
Uninitialised value in MidiController.cpp gave floating point error on automation of envelope.
```
Program received signal SIGFPE, Arithmetic exception.
[Switching to Thread 0x7fffde071700 (LWP 30037)]
0x000000000050c1fa in linearInterpolate (v0=1.40129846e-45, v1=0, x=0) at /home/zonkmachine/builds/lmms/lmms/include/interpolation.h:90
90		return fastFmaf( x, v1-v0, v0 );
(gdb) bt full
#0  0x000000000050c1fa in linearInterpolate (v0=1.40129846e-45, v1=0, x=0) at /home/zonkmachine/builds/lmms/lmms/include/interpolation.h:90
No locals.
#1  0x0000000000561ad7 in ValueBuffer::__lambda0::operator() (__closure=0x7fffde070b40) at /home/zonkmachine/builds/lmms/lmms/src/core/ValueBuffer.cpp:40
        start = @0x7fffde070b64: 1.40129846e-45
        end_ = @0x7fffde070b60: 0
        i = @0x7fffde070b7c: 1
        this = 0x7fffeaebd2a0
```