### PR TITLE
Scan for native LMMS plugins in home lmms directory (#3392)

### DIFF
--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -74,6 +74,9 @@ public:
 	/// It can be retrieved by calling this function.
 	QString errorString(QString pluginName) const;
 
+    void loadPluginDirectory(QDir directory, PluginInfoList *pluginInfos, DescriptorMap *descriptors);
+
+
 public slots:
 	void discoverPlugins();
 

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -74,7 +74,7 @@ public:
 	/// It can be retrieved by calling this function.
 	QString errorString(QString pluginName) const;
 
-    void loadPluginDirectory(QDir directory, PluginInfoList *pluginInfos, DescriptorMap *descriptors);
+	void loadPluginDirectory(QDir directory, PluginInfoList *pluginInfos, DescriptorMap *descriptors);
 
 
 public slots:

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -124,16 +124,11 @@ QString PluginFactory::errorString(QString pluginName) const
 	return m_errors.value(pluginName, notfound);
 }
 
-void PluginFactory::discoverPlugins()
+void PluginFactory::loadPluginDirectory(QDir directory, PluginInfoList *pluginInfos, DescriptorMap *descriptors)
 {
-	DescriptorMap descriptors;
-	PluginInfoList pluginInfos;
-	m_pluginByExt.clear();
+	const QFileInfoList& files = directory.entryInfoList(nameFilters);
 
-	const QFileInfoList& files = QDir("plugins:").entryInfoList(nameFilters);
 
-	// Cheap dependency handling: zynaddsubfx needs ZynAddSubFxCore. By loading
-	// all libraries twice we ensure that libZynAddSubFxCore is found.
 	for (const QFileInfo& file : files)
 	{
 		QLibrary(file.absoluteFilePath()).load();
@@ -169,17 +164,42 @@ void PluginFactory::discoverPlugins()
 		info->file = file;
 		info->library = library;
 		info->descriptor = pluginDescriptor;
-		pluginInfos << info;
+		*pluginInfos << info;
 
 		for (const QString& ext : QString(info->descriptor->supportedFileTypes).split(','))
 		{
 			m_pluginByExt.insert(ext, info);
 		}
 
-		descriptors.insert(info->descriptor->type, info->descriptor);
+		descriptors->insert(info->descriptor->type, info->descriptor);
 	}
+}
 
+void PluginFactory::discoverPlugins()
+{
+	DescriptorMap descriptors;
+	PluginInfoList pluginInfos;
+	m_pluginByExt.clear();
+    QStringList directoryList;
+	QString env_path;
 
+	// Cheap dependency handling: zynaddsubfx needs ZynAddSubFxCore. By loading
+	// all libraries twice we ensure that libZynAddSubFxCore is found.
+
+    directoryList.push_back( "plugins:" );
+    directoryList.push_back( QDir::homePath() + "/lmms/plugins/lmms" );
+
+	if (!(env_path = qgetenv("LMMS_PLUGIN_DIR")).isEmpty()) {
+        directoryList.push_back( env_path );
+    }
+
+    for(QStringList::iterator it = directoryList.begin(); 
+            it != directoryList.end(); 
+            ++it) {
+
+        QDir dir( (*it) );
+        loadPluginDirectory(dir, &pluginInfos, &descriptors);
+    }
 	for (PluginInfo* info : m_pluginInfos)
 	{
 		delete info->library;

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -180,26 +180,25 @@ void PluginFactory::discoverPlugins()
 	DescriptorMap descriptors;
 	PluginInfoList pluginInfos;
 	m_pluginByExt.clear();
-    QStringList directoryList;
+	QStringList directoryList;
 	QString env_path;
 
 	// Cheap dependency handling: zynaddsubfx needs ZynAddSubFxCore. By loading
 	// all libraries twice we ensure that libZynAddSubFxCore is found.
 
-    directoryList.push_back( "plugins:" );
-    directoryList.push_back( QDir::homePath() + "/lmms/plugins/lmms" );
+	directoryList.push_back( "plugins:" );
+	directoryList.push_back( QDir::homePath() + "/lmms/plugins/lmms" );
 
 	if (!(env_path = qgetenv("LMMS_PLUGIN_DIR")).isEmpty()) {
-        directoryList.push_back( env_path );
-    }
+		directoryList.push_back( env_path );
+	}
 
-    for(QStringList::iterator it = directoryList.begin(); 
-            it != directoryList.end(); 
-            ++it) {
+	for(QStringList::iterator it = directoryList.begin(); 
+		it != directoryList.end(); ++it) {
+		QDir dir( (*it) );
+		loadPluginDirectory(dir, &pluginInfos, &descriptors);
+	}
 
-        QDir dir( (*it) );
-        loadPluginDirectory(dir, &pluginInfos, &descriptors);
-    }
 	for (PluginInfo* info : m_pluginInfos)
 	{
 		delete info->library;


### PR DESCRIPTION
This PR should make it possible to look for LMMS plugins in two new places: the environment variable LMMS_PLUGIN_DIR, and the folder ~/lmms/plugins/lmms (not sure if my current solution will work on Windows).

It doesn't seem like the search paths are working properly, so I am creating ``QStringList`` paths and loading them up that way. Also did some minor refactoring and added a new private method called ``PluginFactory::loadPluginDirectory``.

Most of the new code here is borrowed from [LadspaManager](https://github.com/LMMS/lmms/blob/master/src/core/LadspaManager.cpp#L41), which does a similar thing.