### PR TITLE
fixes the wrong order of controller by loading a project

### DIFF
--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -67,7 +67,10 @@ PeakControllerEffect::PeakControllerEffect(
 	m_autoController( NULL )
 {
 	m_autoController = new PeakController( Engine::getSong(), this );
-	Engine::getSong()->addController( m_autoController );
+	if( !Engine::getSong()->isLoadingProject() )
+	{
+		Engine::getSong()->addController( m_autoController );
+	}
 	PeakController::s_effects.append( this );
 }
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1419,17 +1419,8 @@ void Song::setModified()
 
 void Song::addController( Controller * controller )
 {
-	if( controller )
+	if( controller && !m_controllers.contains( controller ) )
 	{
-		if( m_controllers.contains( controller ) )
-		{
-			int index = m_controllers.indexOf( controller );
-			if( index != -1 )
-			{
-				m_controllers.remove( index );
-				emit controllerRemoved( controller );
-			}
-		}
 		m_controllers.append( controller );
 		emit controllerAdded( controller );
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1419,8 +1419,17 @@ void Song::setModified()
 
 void Song::addController( Controller * controller )
 {
-	if( controller && !m_controllers.contains( controller ) )
+	if( controller )
 	{
+		if( m_controllers.contains( controller ) )
+		{
+			int index = m_controllers.indexOf( controller );
+			if( index != -1 )
+			{
+				m_controllers.remove( index );
+				emit controllerRemoved( controller );
+			}
+		}
 		m_controllers.append( controller );
 		emit controllerAdded( controller );
 


### PR DESCRIPTION
fixes https://github.com/LMMS/lmms/issues/2869

the problem:

> Here's what happens:
> 1. LMMS loads the FX Mixer from the file. Because the Peak Controller is a mix between an FX and a controller it gets loaded as an FX when the mixer "FX 1" is restored. In `PeakControllerEffect::PeakControllerEffect` the Peak Controller is added to the list of controllers by calling `Engine::getSong()->addController( m_autoController )`. Because no controllers have been loaded yet the Peak Controller is now the **first** controller in the list.
> 2. LMMS loads the controllers and adds them via `Song::addController`. For each controller this method checks whether the controller is already contained in the list and only adds it if it's not:
>    - The LFO controller is loaded first from the file. It is added because it is not contained in the list of controllers.
>    - The Peak Controller is now also loaded from the file. It is not added because it is already contained in the list of controllers as it was added during the load of the FX chains.


What I did:

On adding a controller it checks if the controller is in the list. If so it removes the controller from the list and appends it again. So it is in the right order.

```
if( controller )
	{
		if( m_controllers.contains( controller ) )
		{
			int index = m_controllers.indexOf( controller );
			if( index != -1 )
			{
				m_controllers.remove( index );
				emit controllerRemoved( controller );
			}
		}
		m_controllers.append( controller );
		emit controllerAdded( controller );

		this->setModified();
	}
```