### PR TITLE
Fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,7 +487,7 @@ IF(USE_CCACHE)
     ELSE()
         MESSAGE(WARNING "USE_CCACHE enabled, but no ccache found")
     ENDIF()
-ENDIF(CCACHE_FOUND)
+ENDIF()
 
 # make sub-directories
 ADD_SUBDIRECTORY(cmake)


### PR DESCRIPTION
Hi,

Found while looking at the Travis build logs:

```sh
CMake Warning (dev) in CMakeLists.txt:

  A logical block opening on the line

    /home/travis/build/LMMS/lmms/CMakeLists.txt:481 (IF)

  closes on the line

    /home/travis/build/LMMS/lmms/CMakeLists.txt:490 (ENDIF)
```