### PR TITLE
Always highlight the beats in PianoRoll and AutomationEditor using only time signature

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1253,13 +1253,6 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		int ticksPerBeat = DefaultTicksPerTact /
 			Engine::getSong()->getTimeSigModel().getDenominator();
 
-		// triplet mode occurs if the note quantization isn't a multiple of 3
-		// note that the automation editor does not support triplets yet
-		if( AutomationPattern::quantization() % 3 != 0 )
-		{
-			ticksPerBeat = static_cast<int>( ticksPerBeat * 2.0/3.0 );
-		}
-
 		for( tick = m_currentPosition - m_currentPosition % ticksPerBeat,
 				 x = xCoordOfTick( tick );
 			 x<=width();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2869,10 +2869,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		// First we draw the vertical quantization lines
 		for( tick = m_currentPosition - m_currentPosition % q, x = xCoordOfTick( tick );
 			x <= width(); tick += q, x = xCoordOfTick( tick ) )
-		{
+        {
 			p.setPen( lineColor() );
 			p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
-		}
+        }
 
 		// Draw horizontal lines
 		key = m_startKey;
@@ -2913,19 +2913,13 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		int ticksPerBeat = DefaultTicksPerTact /
 			Engine::getSong()->getTimeSigModel().getDenominator();
 
-		// triplet mode occurs if the note quantization isn't a multiple of 3
-		if( quantization() % 3 != 0 )
-		{
-			ticksPerBeat = static_cast<int>( ticksPerBeat * 2.0/3.0 );
-		}
-
 		for( tick = m_currentPosition - m_currentPosition % ticksPerBeat,
 			x = xCoordOfTick( tick ); x <= width();
 			tick += ticksPerBeat, x = xCoordOfTick( tick ) )
 		{
-			p.setPen( beatLineColor() );
-			p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
-		}
+            p.setPen( beatLineColor() );
+            p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
+        }
 
 		// Draw the vertical bar lines
 		for( tick = m_currentPosition - m_currentPosition % MidiTime::ticksPerTact(),

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2869,10 +2869,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		// First we draw the vertical quantization lines
 		for( tick = m_currentPosition - m_currentPosition % q, x = xCoordOfTick( tick );
 			x <= width(); tick += q, x = xCoordOfTick( tick ) )
-        {
+		{
 			p.setPen( lineColor() );
 			p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
-        }
+		}
 
 		// Draw horizontal lines
 		key = m_startKey;
@@ -2917,9 +2917,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			x = xCoordOfTick( tick ); x <= width();
 			tick += ticksPerBeat, x = xCoordOfTick( tick ) )
 		{
-            p.setPen( beatLineColor() );
-            p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
-        }
+			p.setPen( beatLineColor() );
+			p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
+		}
 
 		// Draw the vertical bar lines
 		for( tick = m_currentPosition - m_currentPosition % MidiTime::ticksPerTact(),


### PR DESCRIPTION
The wrong lines were highlighted in PianoRoll and Automation Editor when using triplets.

Duration of the beat is defined only by the denominator of the time signature and it does not depend on whether or not you use triplets. In the previous version of the code the beat duration changed, when you used triplets.

When using triplets you could also highlight the BEGINNING of each triplet. But in the previous version of the code, when you chose for example 1/12 in the quantization level, each 1/6 note was highlighted, that is the first and the third note of the first triplet, the second note of the second triplet, the first and third notes of the third triplet, and so on, which does not make any sense.

In this version of code, simply each beat (defined only by the time signature) is highlighted.

screenshots illustrating the issues.
![image](https://cloud.githubusercontent.com/assets/2879917/24375130/84f803b0-1337-11e7-9c6b-a3f27bf7b508.png)
![image](https://cloud.githubusercontent.com/assets/2879917/24375132/87a5c700-1337-11e7-8002-1cb0422e5c2b.png)

Edit by @Lukas-W: Included images from external hoster