### PR TITLE
Automation Pattern - Rename 'controlKey'

### DIFF
--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -79,7 +79,7 @@ public:
 	MidiTime putValue( const MidiTime & time,
 				const float value,
 				const bool quantPos = true,
-				const bool controlKey = false );
+				const bool ignoreSurroundingPoints = false );
 
 	void removeValue( const MidiTime & time );
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -208,7 +208,7 @@ void AutomationPattern::updateLength()
 MidiTime AutomationPattern::putValue( const MidiTime & time,
 					const float value,
 					const bool quantPos,
-					const bool controlKey )
+					const bool ignoreSurroundingPoints )
 {
 	cleanObjects();
 
@@ -221,7 +221,7 @@ MidiTime AutomationPattern::putValue( const MidiTime & time,
 
 	// Remove control points that are covered by the new points
 	// quantization value. Control Key to override
-	if( ! controlKey )
+	if( ! ignoreSurroundingPoints )
 	{
 		for( int i = newTime + 1; i < newTime + quantization(); ++i )
 		{


### PR DESCRIPTION
Separate core and UI. Fix from PR #3352
See comment here: https://github.com/LMMS/lmms/pull/3352#pullrequestreview-27534195