### PR TITLE
[WIP] Add KWStyle and AStyle to the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
         - $HOME/.ccache
 matrix:
     include:
+        - env: TYPE=style
         - env: TARGET_OS=win32
         - env: TARGET_OS=win64
         - os: osx
@@ -18,17 +19,13 @@ matrix:
         - os: osx
           env: QT5=True
 before_install:
-   - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.before_install.sh
+    - . ${TRAVIS_BUILD_DIR}/.travis/before_install.sh
 install:
-    - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.install.sh
+    - . ${TRAVIS_BUILD_DIR}/.travis/install.sh
 before_script:
-    - mkdir build && cd build
-    - export CMAKE_FLAGS="-DWANT_QT5=$QT5 -DUSE_WERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
-    - if [ -z "$TRAVIS_TAG" ]; then export CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_CCACHE=ON"; fi
+    - . ${TRAVIS_BUILD_DIR}/.travis/before_script.sh
 script:
-    - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.script.sh
-    - make -j4
-    - if [[ $TARGET_OS != win* ]]; then make tests && ./tests/tests; fi;
+    - . ${TRAVIS_BUILD_DIR}/.travis/script.sh
 after_script:
     - ccache -s
 before_deploy: make package
@@ -49,4 +46,4 @@ notifications:
            - https://webhooks.gitter.im/e/1ac7fc698195981a9227
        on_success: change  # options: [always|never|change] default: always
        on_failure: always  # options: [always|never|change] default: always
-       on_start: never     # options: [always|never|change] default: always 
+       on_start: never     # options: [always|never|change] default: always

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ "$TYPE" != 'style' ]; then
+  # shellcheck disable=SC1090
+  . "$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.before_install.sh"
+fi

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ "$TYPE" != 'style' ]; then
+  mkdir build && cd build || exit
+
+  export CMAKE_FLAGS="-DWANT_QT5=$QT5 -DUSE_WERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+
+  if [ -z "$TRAVIS_TAG" ]; then export CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_CCACHE=ON"; fi
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [ "$TYPE" = 'style' ]; then
+  sudo apt install astyle kwstyle shellcheck
+else
+  # shellcheck disable=SC1090
+  . "$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.install.sh"
+fi

--- a/.travis/linux.win32.install.sh
+++ b/.travis/linux.win32.install.sh
@@ -29,6 +29,6 @@ sudo apt-get install -y $PACKAGES
 # to use @file command line passing, which in turn ccache 3.1.9 doesn't support
 pushd /tmp
 wget http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.2.4-1_amd64.deb
-sha256sum -c $TRAVIS_BUILD_DIR/.travis/ccache.sha256
+sha256sum -c "$TRAVIS_BUILD_DIR/.travis/ccache.sha256"
 sudo dpkg -i ccache_3.2.4-1_amd64.deb
 popd

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+if [ "$TYPE" = 'style' ]; then
+
+  # shellcheck disable=SC2046
+  shellcheck $(find -O3 "$TRAVIS_BUILD_DIR/.travis/" "$TRAVIS_BUILD_DIR/cmake/" -type f -name '*.sh')
+
+  files=$(find -O3 "$TRAVIS_BUILD_DIR/src/" "$TRAVIS_BUILD_DIR/include/" "$TRAVIS_BUILD_DIR/tests/" -type f -regex '.*\.\(cpp\|hpp\|c\|h\)')
+
+  for f in $files
+  do
+    KWStyle -v -xml "$TRAVIS_BUILD_DIR/kwstyle.xml" "$f" >> kwstyle-output.txt
+  done;
+
+  if [ "$(grep -c Error < kwstyle-output.txt)" -gt 0 ]; then
+    cat kwstyle-output.txt
+    rm -f kwstyle-output.txt
+    exit 1;
+  fi
+
+  rm -f kwstyle-output.txt
+
+  for f in $files
+  do
+    astyle --ascii "$f" >> astyle-output.txt
+  done;
+
+  # debug
+  cat astyle-output.txt
+
+  if [ "$(grep -c Error < astyle.txt)" -gt 0 ]; then
+    cat astyle-output.txt
+    rm -f astyle-output.txt
+    exit 1;
+  fi
+
+  rm -f astyle-output.txt
+
+
+else
+  # shellcheck disable=SC1090
+  . "$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.script.sh"
+
+  make -j4
+
+  if [[ $TARGET_OS != win* ]]; then make tests && ./tests/tests; fi;
+fi

--- a/kwstyle.xml
+++ b/kwstyle.xml
@@ -1,0 +1,129 @@
+<!-- Max. line length -->
+<LineLength>250</LineLength>
+
+<!-- Internal var. regex -->
+<InternalVariables>
+  <regex>[ms]_[a-z]+([A-Z][a-z])*</regex>
+  <alignment>0</alignment>
+</InternalVariables>
+
+<!-- Internal var. which should be private or protected -->
+<InternalVariables>
+  <regex>[ms]_[a-z]+([A-Z][a-z])*</regex>
+  <alignment>0</alignment>
+  <private>0</private>
+</InternalVariables>
+
+<!-- Number of space before a semicolon -->
+<SemicolonSpace>0</SemicolonSpace>
+
+<!-- Intervnal var. declaration order -->
+<DeclarationOrder>
+  <public>0</public>
+  <protected>1</protected>
+  <private>2</private>
+</DeclarationOrder>
+
+<!-- Do we want a new line at the eof -->
+<EndOfFileNewLine>true</EndOfFileNewLine>
+
+<!-- The file shouldn't have tabulation -->
+<Tabs>1</Tabs>
+
+<!-- Max. number of space at the eol -->
+<Spaces>0</Spaces>
+
+<!-- Indentation pattern -->
+<Indent>
+  <type>SPACE</type>
+  <size>4</size>
+  <noHeader>true</noHeader>
+  <allowBlockLine>true</allowBlockLine>
+</Indent>
+
+<!-- TODO
+<Header>
+<location>/Web/headers/IGSTKSandbox</location>
+<checkSpacesEndOfLine>false</checkSpacesEndOfLine>
+<cvsFormat>true</cvsFormat>
+</Header>
+
+<IfNDefDefine>__[NameOfClass]_[Extension]</IfNDefDefine>
+-->
+
+<!-- typedefs regex and should they be aligned together-->
+<Typedefs>
+  <regex>([A-Z][a-z]*)+</regex>
+  <alignment>true</alignment>
+</Typedefs>
+
+<!-- TODO
+<Namespace>igstk</Namespace>
+
+<NameOfClass>
+  <name>[NameOfClass]</name>
+  <prefix>igstk</prefix>
+</NameOfClass>
+
+<Comments>
+  <begin>/**</begin>
+  <middle> *</middle>
+  <end>*/<end>
+  <emptyLineBeforeClass>true</emptyLineBeforeClass>
+  <checkWrongComment>true</checkWrongComment>
+  <checkMissingComment>true</checkMissingComment>
+</Comments>
+-->
+
+<!-- Max. number of successive empty lines -->
+<EmptyLines>1</EmptyLines>
+
+<!-- TODO
+<Template>T</Template>
+-->
+
+<!-- Space before and after operators -->
+<Operator>
+  <spaceBefore>1</spaceBefore>
+  <spaceAfter>1</spaceAfter>
+</Operator>
+
+<!-- TODO
+<BlackList>myBlackList.txt</BlackList>
+-->
+
+<!-- Struct regex -->
+<Struct>
+  <regex>([A-Z][a-z]*)+</regex>
+</Struct>
+
+<!-- TODO
+<StatementPerLine>
+  <maxNumber>1</maxNumber>
+  <checkInline>0</checkInline> // default is true
+</StatementPerLine>
+-->
+
+<!-- Max. number of var. per line ; TODO: check if this is about var. declaration or something else -->
+<VariablePerLine>
+  <maxNumber>1</maxNumber>
+</VariablePerLine>
+
+<!-- Check if we're using non-ASCII char. TODO: check why adding this prints files -->
+<BadCharacters>true</BadCharacters>
+
+<!-- Member functions regex and max size -->
+<MemberFunctions>
+  <regex>[a-z]([A-Z][a-z]*)*</regex>
+  <length>100</length>
+</MemberFunctions>
+
+<!-- Member functions regex and max size -->
+<Functions>
+  <regex>[a-z]([A-Z][a-z]*)*</regex>
+  <length>100</length>
+</Functions>
+
+<!-- TODO
+<ErrorThreshold>10</ErrorThreshold>
+-->


### PR DESCRIPTION
Hi,

First, I'd like to say that this is far from being finished.

So, as it's been said in #3071, I started following the current conventions.

I'd like to first talk about max. line length and space vs. tabs.

Current convention is to try to limit line length to 80 char. I didn't checked all files, but I found lines with 211 char. I think we should just stop breaking lines. I don't know which software are used by LMMS developer, but personally, I'm using atom or nvim and they both display too long lines in a convenient way, e.g. :

![capture du 2017-03-31 19-33-14](https://cloud.githubusercontent.com/assets/16472988/24561904/ebe52080-1648-11e7-852a-3bd70bafd819.png)

I think, nowadays this is not useful anymore as every text editor should be handling this for you.

Would like to hear what do you think about this.

Currently, I set the limit to 250. I think we could set it to something even bigger, just to prevent some abuse, like 1000 char. Or we could just disable this check.

Then, tabs. I don't see a single reason why to use tabs over spaces nowadays. I don't know a single editor who can't replace tabs by space for you when you press tab. Tabs leads to strange display depending on your editor, so we won't see the same thing depending on our editor etc. So, I'd like that we switch to a 4 space indentation.

I'd like to fix those two points first, because they're leading to troubles with other checks.

To test the current KWStyle config, from the `lmms` folder:

```sh
KWStyle -v -xml KWStyle.xml -d src/core
```