### PR TITLE
Add shellcheck to the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
         - $HOME/.ccache
 matrix:
     include:
+        - env: TYPE=style
         - env: TARGET_OS=win32
         - env: TARGET_OS=win64
         - os: osx
@@ -17,20 +18,9 @@ matrix:
         - env: QT5=True TARGET_OS=win64
         - os: osx
           env: QT5=True
-before_install:
-   - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.before_install.sh
-install:
-    - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.install.sh
-before_script:
-    - mkdir build && cd build
-    - export CMAKE_FLAGS="-DWANT_QT5=$QT5 -DUSE_WERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
-    - if [ -z "$TRAVIS_TAG" ]; then export CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_CCACHE=ON"; fi
-script:
-    - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.script.sh
-    - make -j4
-    - if [[ $TARGET_OS != win* ]]; then make tests && ./tests/tests; fi;
-after_script:
-    - ccache -s
+install: ${TRAVIS_BUILD_DIR}/.travis/install.sh
+script: ${TRAVIS_BUILD_DIR}/.travis/script.sh
+after_script: ${TRAVIS_BUILD_DIR}/.travis/after_script.sh
 before_deploy: make package
 deploy:
     provider: releases
@@ -43,10 +33,3 @@ deploy:
         all_branches: true
         condition: '("$TARGET_OS" = win??) && "$QT5"'
     repo: LMMS/lmms
-notifications:
-    webhooks:
-       urls:
-           - https://webhooks.gitter.im/e/1ac7fc698195981a9227
-       on_success: change  # options: [always|never|change] default: always
-       on_failure: always  # options: [always|never|change] default: always
-       on_start: never     # options: [always|never|change] default: always 

--- a/.travis/after_script.sh
+++ b/.travis/after_script.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$TYPE" != 'style' ]; then
+	ccache -s
+fi

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$TYPE" = 'style' ]; then
+	sudo apt-get -yqq update
+	sudo apt-get install shellcheck
+else
+	"$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.before_install.sh"
+	"$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.install.sh"
+fi

--- a/.travis/linux..before_install.sh
+++ b/.travis/linux..before_install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 sudo add-apt-repository ppa:andrewrk/libgroove -y
 sudo sed -e "s/trusty/precise/" -i \
 	/etc/apt/sources.list.d/andrewrk-libgroove-trusty.list

--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 PACKAGES="cmake libsndfile-dev fftw3-dev libvorbis-dev  libogg-dev
 	libasound2-dev libjack-dev libsdl-dev libsamplerate0-dev libstk0-dev
 	libfluidsynth-dev portaudio19-dev wine-dev g++-multilib libfltk1.3-dev

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
+
 # shellcheck disable=SC2086
 cmake -DUSE_WERROR=ON $CMAKE_FLAGS ..

--- a/.travis/linux.win.download.sh
+++ b/.travis/linux.win.download.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -e
 
 CACHE_DIR=$TRAVIS_BUILD_DIR/apt_mingw_cache/$1

--- a/.travis/linux.win32.before_install.sh
+++ b/.travis/linux.win32.before_install.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
+
 sudo add-apt-repository ppa:tobydox/mingw-x-trusty -y
 sudo apt-get update -qq

--- a/.travis/linux.win32.install.sh
+++ b/.travis/linux.win32.install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -e
 
 if [ "$QT5" ]; then
@@ -15,10 +16,7 @@ MINGW_PACKAGES="mingw32-x-sdl mingw32-x-libvorbis mingw32-x-fluidsynth mingw32-x
 
 export MINGW_PACKAGES
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-# shellcheck disable=SC1090
-. "$DIR/linux.win.download.sh" win32
+"$TRAVIS_BUILD_DIR/.travis/linux.win.download.sh" win32
 
 PACKAGES="nsis cloog-isl libmpc3 qt4-linguist-tools mingw32 $MINGW_PACKAGES"
 
@@ -29,6 +27,6 @@ sudo apt-get install -y $PACKAGES
 # to use @file command line passing, which in turn ccache 3.1.9 doesn't support
 pushd /tmp
 wget http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.2.4-1_amd64.deb
-sha256sum -c $TRAVIS_BUILD_DIR/.travis/ccache.sha256
+sha256sum -c "$TRAVIS_BUILD_DIR/.travis/ccache.sha256"
 sudo dpkg -i ccache_3.2.4-1_amd64.deb
 popd

--- a/.travis/linux.win32.script.sh
+++ b/.travis/linux.win32.script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
+
 export CMAKE_OPTS="$CMAKE_FLAGS -DUSE_WERROR=ON"
 ../cmake/build_mingw32.sh

--- a/.travis/linux.win64.before_install.sh
+++ b/.travis/linux.win64.before_install.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-. .travis/linux.win32.before_install.sh
+set -e
+
+"$TRAVIS_BUILD_DIR/.travis/linux.win32.before_install.sh"

--- a/.travis/linux.win64.install.sh
+++ b/.travis/linux.win64.install.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
+
 set -e
 
 # First, install 32-bit deps
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# shellcheck disable=SC1090
-. "$DIR/linux.win32.install.sh"
-
+"$TRAVIS_BUILD_DIR/.travis/linux.win32.install.sh"
 
 if [ "$QT5" ]; then
 	MINGW_PACKAGES="mingw64-x-qt5base"
@@ -21,9 +19,7 @@ MINGW_PACKAGES="mingw64-x-sdl mingw64-x-libvorbis mingw64-x-fluidsynth mingw64-x
 
 export MINGW_PACKAGES
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# shellcheck disable=SC1090
-. "$DIR/linux.win.download.sh" win64
+"$TRAVIS_BUILD_DIR/.travis/linux.win.download.sh" win64
 
 # shellcheck disable=SC2086
 sudo apt-get install -y $MINGW_PACKAGES

--- a/.travis/linux.win64.script.sh
+++ b/.travis/linux.win64.script.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
+
 export CMAKE_OPTS="$CMAKE_FLAGS -DUSE_WERROR=ON"
 ../cmake/build_mingw64.sh

--- a/.travis/osx..before_install.sh
+++ b/.travis/osx..before_install.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -e
+
 brew update

--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -1,20 +1,40 @@
 #!/usr/bin/env bash
 
-PACKAGES="cmake pkgconfig fftw libogg libvorbis libsndfile libsamplerate jack sdl stk portaudio node fltk"
+set -e
+
+PACKAGES="cmake pkg-config fftw libogg libvorbis libsndfile libsamplerate jack sdl stk portaudio node fltk"
 
 if [ "$QT5" ]; then
-	PACKAGES="$PACKAGES homebrew/versions/qt55"
+	PACKAGES="$PACKAGES qt@5.5"
 else
-	PACKAGES="$PACKAGES cartr/qt4/qt"
+	PACKAGES="$PACKAGES cartr/qt4/qt@4"
 fi
 
+if "${TRAVIS}"; then
+   PACKAGES="$PACKAGES ccache"
+fi
+
+# removing already installed packages from the list
+for p in $(brew list); do
+	PACKAGES=${PACKAGES//$p/}
+done;
+
 # shellcheck disable=SC2086
-brew install $PACKAGES ccache
+brew install $PACKAGES
 
 # Recompile fluid-synth without CoreAudio per issues #649
 # Changes to fluid-synth.rb must be pushed to URL prior to use
-url=$(git remote get-url origin)
-branch=$(git symbolic-ref --short HEAD)
-brew install --build-from-source "$url/raw/$branch/cmake/apple/fluid-synth.rb"
+if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
+	slug=$TRAVIS_PULL_REQUEST_SLUG
+	branch=$TRAVIS_PULL_REQUEST_BRANCH
+elif "${TRAVIS}"; then
+	slug=$TRAVIS_REPO_SLUG
+	branch=$TRAVIS_BRANCH
+else
+	slug="LMMS/lmms"
+	branch=$(git symbolic-ref --short HEAD)
+fi
+
+brew install --build-from-source "https://raw.githubusercontent.com/${slug}/${branch}/cmake/apple/fluid-synth.rb"
 
 sudo npm install -g appdmg

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ "$QT5" ]; then
         # Workaround; No FindQt5.cmake module exists
         CMAKE_PREFIX_PATH="$(brew --prefix qt55)"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$TYPE" = 'style' ]; then
+
+	# shellcheck disable=SC2046
+	shellcheck $(find -O3 "$TRAVIS_BUILD_DIR/.travis/" "$TRAVIS_BUILD_DIR/cmake/" -type f -name '*.sh' -o -name "*.sh.in")
+
+else
+
+	mkdir build
+	cd build
+
+	export CMAKE_FLAGS="-DWANT_QT5=$QT5 -DUSE_WERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+
+	if [ -z "$TRAVIS_TAG" ]; then
+		export CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_CCACHE=ON"
+	fi
+
+	"$TRAVIS_BUILD_DIR/.travis/$TRAVIS_OS_NAME.$TARGET_OS.script.sh"
+
+	make -j4
+
+	if [[ $TARGET_OS != win* ]]; then
+
+		make tests
+		tests/tests
+
+	fi
+fi

--- a/cmake/apple/install_apple.sh.in
+++ b/cmake/apple/install_apple.sh.in
@@ -4,13 +4,16 @@
 #   Examine linkings using `otool -L somelib.so`
 #   Debug the loading of dynamic libraries using `export DYLD_PRINT_LIBRARIES=1`
 
+set -e
+
 # STK rawwaves directory
-STK_RAWWAVE=$HOME/stk-*/rawwaves
+STK_RAWWAVE_LIST=( $HOME/stk-*/rawwaves )
+STK_RAWWAVE=${STK_RAWWAVE_LIST[0]}
 
 if [ ! -d "$STK_RAWWAVE" ]; then
    STK_RAWWAVE=$(brew --prefix stk)/share/stk/rawwaves
 fi
- 
+
 # Place to create ".app" bundle
 APP="@CMAKE_BINARY_DIR@/@PROJECT_NAME_UCASE@.app"
 
@@ -24,29 +27,30 @@ if [ $? -ne 0 ]; then
   brew --prefix qt55 > /dev/null 2>&1
   if [ $? -eq 0 ]; then
     # Prefer Qt 5.5 (QTBUG-53533)
-    export PATH=$PATH:$(brew --prefix qt55)/bin
+    PATH=$PATH:$(brew --prefix qt55)/bin
   else
     # Fallback Qt 5.6+
-  	export PATH=$PATH:$(brew --prefix qt5)/bin
+  	PATH=$PATH:$(brew --prefix qt5)/bin
   fi
+  export PATH
 fi
- 
+
 # Remove any old .app bundles
 rm -Rf "$APP"
 
 # Copy/overwrite Info.plist
-\cp  "@CMAKE_BINARY_DIR@/Info.plist" "@CMAKE_INSTALL_PREFIX@/"
- 
+command cp  "@CMAKE_BINARY_DIR@/Info.plist" "@CMAKE_INSTALL_PREFIX@/"
+
 # Create .app bundle containing contents from CMAKE_INSTALL_PREFIX
 mkdir -p "$APP/Contents/MacOS"
 mkdir -p "$APP/Contents/Frameworks"
 mkdir -p "$APP/Contents/Resources"
 mkdir -p "$APP/Contents/share/stk/rawwaves"
 cd "@CMAKE_INSTALL_PREFIX@"
-cp -R * "$APP/Contents"
+cp -R ./* "$APP/Contents"
 cp "@CMAKE_SOURCE_DIR@/cmake/apple/"*.icns "$APP/Contents/Resources/"
-cp $STK_RAWWAVE/*.raw "$APP/Contents/share/stk/rawwaves" > /dev/null 2>&1
- 
+cp "$STK_RAWWAVE"/*.raw "$APP/Contents/share/stk/rawwaves" > /dev/null 2>&1
+
 # Make all libraries writable for macdeployqt
 cd "$APP"
 find . -type f -print0 | xargs -0 chmod u+w
@@ -55,11 +59,11 @@ lmmsbin="MacOS/@CMAKE_PROJECT_NAME@"
 zynlib="lib/lmms/libzynaddsubfx.so"
 zynfmk="Frameworks/libZynAddSubFxCore.dylib"
 zynbin="MacOS/RemoteZynAddSubFx"
- 
+
 # Move lmms binary
 mv "$APP/Contents/bin/@CMAKE_PROJECT_NAME@" "$APP/Contents/$lmmsbin"
- 
-# Fix zyn linking 
+
+# Fix zyn linking
 mv "$APP/Contents/lib/lmms/RemoteZynAddSubFx" "$APP/Contents/$zynbin"
 mv "$APP/Contents/lib/lmms/libZynAddSubFxCore.dylib" "$APP/Contents/$zynfmk"
 
@@ -70,17 +74,17 @@ install_name_tool -change @rpath/libZynAddSubFxCore.dylib \
 install_name_tool -change @rpath/libZynAddSubFxCore.dylib \
    @loader_path/../../$zynfmk \
   "$APP/Contents/$zynlib"
-  
+
 # Link lmms binary
 _executables="${_executables} -executable=$APP/Contents/$zynbin"
 _executables="${_executables} -executable=$APP/Contents/$zynfmk"
- 
+
 # Build a list of shared objects in target/lib/lmms
 for file in "$APP/Contents/lib/lmms/"*.so; do
    _thisfile="$APP/Contents/lib/lmms/${file##*/}"
    _executables="${_executables} -executable=$_thisfile"
 done
- 
+
 # Build a list of shared objects in target/lib/lmms/ladspa
 for file in "$APP/Contents/lib/lmms/ladspa/"*.so; do
    _thisfile="$APP/Contents/lib/lmms/ladspa/${file##*/}"
@@ -88,6 +92,7 @@ for file in "$APP/Contents/lib/lmms/ladspa/"*.so; do
 done
 
 # Finalize .app
+# shellcheck disable=SC2086
 macdeployqt "$APP" $_executables
 
 # Cleanup


### PR DESCRIPTION
Hi,

Just add a build called 'style', which will be used for kwstyle and astyle too (I hope at least).

Currently it's checking for each `.sh` file in `.travis/` and in `.cmake/`, others scripts are not ours so we won't check against them. If there are others scripts I forgot, just tell me.

I also moved some of the code in `.travis.yml` to separated `.sh` files as @jasp00 advised, so they can be checked (shellcheck found a few things in them btw) and also to ease the process of adding a "style build" which has nothing in common with other builds.