### PR TITLE
Do not use cache on release

### DIFF
--- a/.travis/linux.win32.install.sh
+++ b/.travis/linux.win32.install.sh
@@ -17,8 +17,10 @@ export MINGW_PACKAGES
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# shellcheck disable=SC1090
-. "$DIR/linux.win.download.sh" win32
+if [ -z "$TRAVIS_TAG" ]; then
+	# shellcheck disable=SC1090
+	. "$DIR/linux.win.download.sh" win32
+fi
 
 PACKAGES="nsis cloog-isl libmpc3 qt4-linguist-tools mingw32 $MINGW_PACKAGES"
 
@@ -27,8 +29,10 @@ sudo apt-get install -y $PACKAGES
 
 # ccache 3.2 is needed because mingw32-x-gcc is version 4.9, which causes cmake
 # to use @file command line passing, which in turn ccache 3.1.9 doesn't support
-pushd /tmp
-wget http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.2.4-1_amd64.deb
-sha256sum -c $TRAVIS_BUILD_DIR/.travis/ccache.sha256
-sudo dpkg -i ccache_3.2.4-1_amd64.deb
-popd
+if [ -z "$TRAVIS_TAG" ]; then
+	pushd /tmp
+	wget http://archive.ubuntu.com/ubuntu/pool/main/c/ccache/ccache_3.2.4-1_amd64.deb
+	sha256sum -c "$TRAVIS_BUILD_DIR/.travis/ccache.sha256"
+	sudo dpkg -i ccache_3.2.4-1_amd64.deb
+	popd
+fi

--- a/.travis/linux.win64.install.sh
+++ b/.travis/linux.win64.install.sh
@@ -21,9 +21,12 @@ MINGW_PACKAGES="mingw64-x-sdl mingw64-x-libvorbis mingw64-x-fluidsynth mingw64-x
 
 export MINGW_PACKAGES
 
+# TODO: Remove this line after removing sourcing, DIR is already set
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-# shellcheck disable=SC1090
-. "$DIR/linux.win.download.sh" win64
+if [ -z "$TRAVIS_TAG" ]; then
+	# shellcheck disable=SC1090
+	. "$DIR/linux.win.download.sh" win64
+fi
 
 # shellcheck disable=SC2086
 sudo apt-get install -y $MINGW_PACKAGES


### PR DESCRIPTION
On release, packages from the cache should not be used and ccache should not be downloaded.