### PR TITLE
Make factory samples relative

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -63,7 +63,12 @@ ConfigManager::ConfigManager() :
 
 	// If we're in development (lmms is not installed) let's get the source and
 	// binary directories by reading the CMake Cache
-	QFile cmakeCache(qApp->applicationDirPath() + "/CMakeCache.txt");
+	QDir appPath = qApp->applicationDirPath();
+	// If in tests, get parent directory
+	if (appPath.dirName() == "tests") {
+		appPath.cdUp();
+	}
+	QFile cmakeCache(appPath.absoluteFilePath("CMakeCache.txt"));
 	if (cmakeCache.exists()) {
 		cmakeCache.open(QFile::ReadOnly);
 		QTextStream stream(&cmakeCache);

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1422,7 +1422,7 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 		QString samplesSuffix = ConfigManager::inst()->factorySamplesDir().mid( ConfigManager::inst()->dataDir().length() );
 
 		// Iterate over all valid "data:/" searchPaths
-		foreach ( const QString& path, QDir::searchPaths( "data" ) )
+		for ( const QString & path : QDir::searchPaths( "data" ) )
 		{
 			QString samplesPath = QString( path + samplesSuffix ).replace( QDir::separator(), '/' );
 			if ( f.startsWith( samplesPath ) )

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -34,9 +34,6 @@
 
 #include <sndfile.h>
 
-// FIXME TODO
-#include <QDebug>
-
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #ifdef LMMS_HAVE_OGGVORBIS
 #include <vorbis/vorbisfile.h>

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1422,9 +1422,11 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 		QString samplesSuffix = ConfigManager::inst()->factorySamplesDir().mid( ConfigManager::inst()->dataDir().length() );
 
 		// Iterate over all valid "data:/" searchPaths
-		foreach ( const QString& path, QDir::searchPaths( "data" ) ) {
+		foreach ( const QString& path, QDir::searchPaths( "data" ) )
+		{
 			QString samplesPath = QString( path + samplesSuffix ).replace( QDir::separator(), '/' );
-			if ( f.startsWith( samplesPath ) ) {
+			if ( f.startsWith( samplesPath ) )
+			{
 				return QString( f ).mid( samplesPath.length() );
 			}
 		}

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -34,6 +34,9 @@
 
 #include <sndfile.h>
 
+// FIXME TODO
+#include <QDebug>
+
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #ifdef LMMS_HAVE_OGGVORBIS
 #include <vorbis/vorbisfile.h>
@@ -1411,25 +1414,33 @@ void SampleBuffer::setReversed( bool _on )
 
 
 
-QString SampleBuffer::tryToMakeRelative( const QString & _file )
+QString SampleBuffer::tryToMakeRelative( const QString & file )
 {
-	if( QFileInfo( _file ).isRelative() == false )
+	if( QFileInfo( file ).isRelative() == false )
 	{
-		QString f = QString( _file ).replace( QDir::separator(), '/' );
-		QString fsd = ConfigManager::inst()->factorySamplesDir();
-		QString usd = ConfigManager::inst()->userSamplesDir();
-		fsd.replace( QDir::separator(), '/' );
-		usd.replace( QDir::separator(), '/' );
-		if( f.startsWith( fsd ) )
-		{
-			return QString( f ).mid( fsd.length() );
+		QString f = QString( file ).replace( QDir::separator(), '/' );
+
+		// First, look in factory samples
+		// Isolate "samples/" from "data:/samples/"
+		QString samplesSuffix = ConfigManager::inst()->factorySamplesDir().mid( ConfigManager::inst()->dataDir().length() );
+
+		// Iterate over all valid "data:/" searchPaths
+		foreach ( const QString& path, QDir::searchPaths( "data" ) ) {
+			QString samplesPath = QString( path + samplesSuffix ).replace( QDir::separator(), '/' );
+			if ( f.startsWith( samplesPath ) ) {
+				return QString( f ).mid( samplesPath.length() );
+			}
 		}
-		else if( f.startsWith( usd ) )
+
+		// Next, look in user samples
+		QString usd = ConfigManager::inst()->userSamplesDir();
+		usd.replace( QDir::separator(), '/' );
+		if( f.startsWith( usd ) )
 		{
 			return QString( f ).mid( usd.length() );
 		}
 	}
-	return _file;
+	return file;
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ ADD_EXECUTABLE(tests
 	$<TARGET_OBJECTS:lmmsobjs>
 
 	src/core/ProjectVersionTest.cpp
+	src/core/RelativePathsTest.cpp
 
 	src/tracks/AutomationTrackTest.cpp
 )

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -24,6 +24,7 @@
 
 #include "QTestSuite.h"
 
+#include "ConfigManager.h"
 #include "SampleBuffer.h"
 
 #include <QDir>
@@ -34,8 +35,13 @@ class RelativePathsTest : QTestSuite
 private slots:
 	void RelativePathComparisonTests()
 	{
-		QVERIFY(SampleBuffer::tryToMakeRelative(QDir::currentPath() + "/data/samples/drums/kick01.ogg") == "drums/kick01.ogg");
-		QVERIFY(SampleBuffer::tryToMakeAbsolute("drums/kick01.ogg") == QDir::currentPath() + "/data/samples/drums/kick01.ogg");
+		QFileInfo fi(ConfigManager::inst()->factorySamplesDir() + "/drums/kick01.ogg");
+		QVERIFY(fi.exists());
+
+		QString absPath = fi.absoluteFilePath();
+		QString relPath = "drums/kick01.ogg";
+		QCOMPARE(SampleBuffer::tryToMakeRelative(absPath), relPath);
+		QCOMPARE(SampleBuffer::tryToMakeAbsolute(relPath), absPath);
 	}
 } RelativePathTests;
 

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -1,0 +1,42 @@
+/*
+ * ProjectVersionTest.cpp
+ *
+ * Copyright (c) 2015 Lukas W <lukaswhl/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "QTestSuite.h"
+
+#include "SampleBuffer.h"
+
+#include <QDebug>
+
+class RelativePathsTest : QTestSuite
+{
+	Q_OBJECT
+private slots:
+	void RelativePathComparisonTests()
+	{
+		QVERIFY(SampleBuffer::tryToMakeRelative(QDir::currentPath() + "/data/samples/drums/kick01.ogg") == "drums/kick01.ogg");
+		QVERIFY(SampleBuffer::tryToMakeAbsolute("drums/kick01.ogg") == QDir::currentPath() + "/data/samples/drums/kick01.ogg");
+	}
+} RelativePathTests;
+
+#include "RelativePathsTest.moc"

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -26,7 +26,7 @@
 
 #include "SampleBuffer.h"
 
-#include <QDebug>
+#include <QDir>
 
 class RelativePathsTest : QTestSuite
 {

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -1,7 +1,7 @@
 /*
- * ProjectVersionTest.cpp
+ * RelativePathsTest.cpp
  *
- * Copyright (c) 2015 Lukas W <lukaswhl/at/gmail.com>
+ * Copyright (c) 2017 Tres Finocchiaro <tres/dot/finocchiaro/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *


### PR DESCRIPTION
Factory samples were broken in #1719.

This patch attempts to fix the problem by patching `tryToMakeRelative` by looping through all valid `data:/` search paths and making a sample relative if contained within `<path>/samples/`.

This DOES NOT have an upgrade routine to relativize existing samples (e.g. in broken RC2 projects).  Newly dragged samples should be fixed.  Clicking "browse" and reselecting samples will fix existing tracks.

Closes #3491