### PR TITLE
Revert "'Off beat' beat notes to MelodyPattern"

### DIFF
--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -88,7 +88,7 @@ public:
 	{
 		return m_patternType;
 	}
-	void checkType();
+
 
 	// next/previous track based on position in the containing track
 	Pattern * previousPattern() const;
@@ -132,6 +132,7 @@ private:
 	MidiTime beatPatternLength() const;
 
 	void setType( PatternTypes _new_pattern_type );
+	void checkType();
 
 	void resizeToFirstTrack();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2459,11 +2459,6 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 					note->setPos( MidiTime( pos_ticks ) );
 					note->setKey( key_num );
-					// If dragging beat notes check if pattern should be MelodyPattern
-					if( note->length() < 0 )
-					{
-						m_pattern->checkType();
-					}
 				}
 			}
 		}

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -361,9 +361,7 @@ void Pattern::checkType()
 	NoteVector::Iterator it = m_notes.begin();
 	while( it != m_notes.end() )
 	{
-		if( ( *it )->length() > 0 ||
-			( *it )->pos() % ( MidiTime::ticksPerTact() /
-						MidiTime::stepsPerTact() ) )
+		if( ( *it )->length() > 0 )
 		{
 			setType( MelodyPattern );
 			return;


### PR DESCRIPTION
This reverts commit e4474af091e9e94fbe06740e680c3fe9289a2178.

In response to issues with PR #3361 mentioned in comment [here](https://github.com/LMMS/lmms/pull/3361#issuecomment-293593672).