### PR TITLE
Flanger LFO rate syncronised

### DIFF
--- a/plugins/Flanger/FlangerControls.cpp
+++ b/plugins/Flanger/FlangerControls.cpp
@@ -35,7 +35,7 @@ FlangerControls::FlangerControls( FlangerEffect *effect ) :
 	EffectControls ( effect ),
 	m_effect ( effect ),
 	m_delayTimeModel(0.001, 0.0001, 0.050, 0.0001,  this, tr( "Delay Samples" ) ) ,
-	m_lfoFrequencyModel( 0.25, 0.01, 5, 0.0001, 20000.0 ,this, tr( "Lfo Frequency" ) ),
+	m_lfoFrequencyModel( 0.25, 0.01, 60, 0.0001, 60000.0 ,this, tr( "Lfo Frequency" ) ),
 	m_lfoAmountModel( 0.0, 0.0, 0.0025 , 0.0001 , this , tr( "Seconds" ) ),
 	m_feedbackModel( 0.0 , 0.0 , 1.0 , 0.0001, this, tr( "Regen" ) ),
 	m_whiteNoiseAmountModel( 0.0 , 0.0 , 0.05 , 0.0001, this, tr( "Noise" ) ),

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -52,7 +52,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
-	lfoFreqKnob->setHintText( tr ( "Rate:" ) , "Hz" );
+	lfoFreqKnob->setHintText( tr ( "Period:" ) , " Sec" );
 
 	Knob * lfoAmtKnob = new Knob( knobBright_26, this );
 	lfoAmtKnob->move( 85,10 );

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -94,7 +94,7 @@ bool FlangerEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 	const float noise = m_flangerControls.m_whiteNoiseAmountModel.value();
 	float amplitude = m_flangerControls.m_lfoAmountModel.value() * Engine::mixer()->processingSampleRate();
 	bool invertFeedback = m_flangerControls.m_invertFeedbackModel.value();
-	m_lfo->setFrequency(  m_flangerControls.m_lfoFrequencyModel.value() );
+	m_lfo->setFrequency(  1.0/m_flangerControls.m_lfoFrequencyModel.value() );
 	m_lDelay->setFeedback( m_flangerControls.m_feedbackModel.value() );
 	m_rDelay->setFeedback( m_flangerControls.m_feedbackModel.value() );
 	sample_t dryS[2];


### PR DESCRIPTION
The LFO rate was not correctly synchronizing to tempo

This has been rectified, to utilize the TempoSyncKnob as intended, returning a period,
instead of a frequency. The knob now reports the correct values in the GUI.

fixes #3335 