### PR TITLE
Remove glitching from the Flanger and Delay plugins

### DIFF
--- a/plugins/Delay/StereoDelay.cpp
+++ b/plugins/Delay/StereoDelay.cpp
@@ -36,7 +36,7 @@ StereoDelay::StereoDelay( int maxTime, int sampleRate )
 	m_maxLength = maxTime * sampleRate;
 	m_length = m_maxLength;
 
-	m_index = 0;
+	m_writeIndex = 0;
 	m_feedback = 0.0f;
 	setSampleRate( sampleRate );
 }
@@ -57,16 +57,18 @@ StereoDelay::~StereoDelay()
 
 void StereoDelay::tick( sampleFrame frame )
 {
-	m_index = ( int )m_length > 0
-			? ( m_index + 1 ) % ( int ) m_length
-			: m_index;
-	float lOut = m_buffer[ m_index ][ 0 ];
-	float rOut = m_buffer[ m_index ] [1 ];
-	m_buffer[ m_index ][ 0 ] = frame[ 0 ] + ( lOut * m_feedback );
-	m_buffer[ m_index ][ 1 ] = frame[ 1 ] + ( rOut * m_feedback );
+	m_writeIndex = ( m_writeIndex + 1 ) % ( int )m_maxLength;
+	int readIndex = m_writeIndex - m_length;
+	if (readIndex < 0 ) { readIndex += m_maxLength; }
+	float lOut = m_buffer[ readIndex ][ 0 ];
+	float rOut = m_buffer[ readIndex ] [1 ];
+	m_buffer[ m_writeIndex ][ 0 ] = frame[ 0 ] + ( lOut * m_feedback );
+	m_buffer[ m_writeIndex ][ 1 ] = frame[ 1 ] + ( rOut * m_feedback );
 	frame[ 0 ] = lOut;
 	frame[ 1 ] = rOut;
 }
+
+
 
 
 

--- a/plugins/Delay/StereoDelay.h
+++ b/plugins/Delay/StereoDelay.h
@@ -52,7 +52,7 @@ private:
 	sampleFrame* m_buffer;
 	int m_maxLength;
 	float m_length;
-	int m_index;
+	int m_writeIndex;
 	float m_feedback;
 	float m_maxTime;
 };

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -107,8 +107,8 @@ bool FlangerEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 		dryS[0] = buf[f][0];
 		dryS[1] = buf[f][1];
 		m_lfo->tick(&leftLfo, &rightLfo);
-		m_lDelay->setLength( ( float )length + ( amplitude * leftLfo ) );
-		m_rDelay->setLength( ( float )length+ ( amplitude * rightLfo ) );
+		m_lDelay->setLength( ( float )length + amplitude * (leftLfo+1.0)  );
+		m_rDelay->setLength( ( float )length + amplitude * (rightLfo+1.0)  );
 		if(invertFeedback)
 		{
 			m_lDelay->tick( &buf[f][1] );

--- a/plugins/Flanger/MonoDelay.cpp
+++ b/plugins/Flanger/MonoDelay.cpp
@@ -34,7 +34,7 @@ MonoDelay::MonoDelay( int maxTime , int sampleRate )
 	m_maxLength = maxTime * sampleRate;
 	m_length = m_maxLength;
 
-	m_index = 0;
+	m_writeIndex = 0;
 	m_feedback = 0.0f;
 	setSampleRate( sampleRate );
 }
@@ -54,11 +54,11 @@ MonoDelay::~MonoDelay()
 
 void MonoDelay::tick( sample_t* sample )
 {
-	m_index = ( int )m_length > 0
-			? ( m_index + 1 ) % ( int )m_length
-			: m_index;
-	float out = m_buffer[ m_index ];
-	m_buffer[ m_index ] = *sample + ( out * m_feedback );
+	m_writeIndex = ( m_writeIndex + 1 ) % ( int )m_maxLength;
+	int readIndex = m_writeIndex - m_length;
+	if (readIndex < 0 ) { readIndex += m_maxLength; }
+	float out = m_buffer[ readIndex ];
+	m_buffer[ m_writeIndex ] = *sample + ( out * m_feedback );
 	*sample = out;
 }
 

--- a/plugins/Flanger/MonoDelay.h
+++ b/plugins/Flanger/MonoDelay.h
@@ -52,7 +52,7 @@ private:
 	sample_t* m_buffer;
 	int m_maxLength;
 	float m_length;
-	int m_index;
+	int m_writeIndex;
 	float m_feedback;
 	float m_maxTime;
 };


### PR DESCRIPTION
The previous delay code was incorrectly not utalising the whole buffer, causing glitches when
incressing the delay time, due to outputting incorrect data, This was apparent when using the
lfo in the Delay and Flanger plugins.

This has been rectified. The read index is now offset from the write index. and the complete buffer
is used in a circular fashon.