### PR TITLE
Fix export - double dialog windows on writing over existing file

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1398,13 +1398,14 @@ void Song::exportProject( bool multiExport )
 		efd.setWindowTitle( tr( "Select file for project-export..." ) );
 	}
 
+	QString suffix = "wav";
+	efd.setDefaultSuffix( suffix );
 	efd.setAcceptMode( FileDialog::AcceptSave );
-
 
 	if( efd.exec() == QDialog::Accepted && !efd.selectedFiles().isEmpty() &&
 					 !efd.selectedFiles()[0].isEmpty() )
 	{
-		QString suffix = "";
+
 		QString exportFileName = efd.selectedFiles()[0];
 		if ( !multiExport )
 		{
@@ -1416,17 +1417,16 @@ void Song::exportProject( bool multiExport )
 				// Get first extension from selected dropdown.
 				// i.e. ".wav" from "WAV-File (*.wav), Dummy-File (*.dum)"
 				suffix = efd.selectedNameFilter().mid( stx + 2, etx - stx - 2 ).split( " " )[0].trimmed();
+				exportFileName.remove( "." + suffix );
 				if ( efd.selectedFiles()[0].endsWith( suffix ) )
 				{
-					suffix = "";
+					if( VersionedSaveDialog::fileExistsQuery( exportFileName + suffix,
+							tr( "Save project" ) ) )
+					{
+						exportFileName += suffix;
+					}
 				}
 			}
-		}
-
-		if( VersionedSaveDialog::fileExistsQuery( exportFileName + suffix,
-				tr( "Save project" ) ) )
-		{
-			exportFileName += suffix;
 		}
 
 		ExportProjectDialog epd( exportFileName, gui->mainWindow(), multiExport );

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1417,7 +1417,7 @@ void Song::exportProject( bool multiExport )
 				// Get first extension from selected dropdown.
 				// i.e. ".wav" from "WAV-File (*.wav), Dummy-File (*.dum)"
 				suffix = efd.selectedNameFilter().mid( stx + 2, etx - stx - 2 ).split( " " )[0].trimmed();
-				exportFileName.remove( "." + suffix );
+				exportFileName.remove( "." + suffix, Qt::CaseInsensitive );
 				if ( efd.selectedFiles()[0].endsWith( suffix ) )
 				{
 					if( VersionedSaveDialog::fileExistsQuery( exportFileName + suffix,


### PR DESCRIPTION
If writing over an existing file on export you are prompted twice. See comment here:
https://github.com/LMMS/lmms/pull/3516#issuecomment-298184068
Issue introduced here: https://github.com/LMMS/lmms/pull/2230

@Umcaruje I had this fix lying around already but hadn't tested it properly. It looks like a fix but needs more testing.
