### PR TITLE
Disable HiDPI on Windows

### DIFF
--- a/cmake/nsis/CMakeLists.txt
+++ b/cmake/nsis/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(CPACK_PACKAGE_FILE_NAME             "${CMAKE_PROJECT_NAME}-${VERSION}-win32"
 SET(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
   \\\${registerExtension} \\\"$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe\\\" \\\".mmp\\\" \\\"${PROJECT_NAME_UCASE} Project\\\"
   \\\${registerExtension} \\\"$INSTDIR\\\\${CMAKE_PROJECT_NAME}.exe\\\" \\\".mmpz\\\" \\\"${PROJECT_NAME_UCASE} Project (compressed)\\\"
+  WriteRegDWORD HKLM \\\"Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\SideBySide\\\" \\\"PreferExternalManifest\\\" \\\"1\\\"
   " PARENT_SCOPE)
 SET(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
   \\\${unregisterExtension} \\\".mmp\\\" \\\"${PROJECT_NAME_UCASE} Project\\\"
@@ -64,3 +65,4 @@ IF(LMMS_HAVE_STK)
 	INSTALL(FILES ${RAWWAVES} DESTINATION "${DATA_DIR}/stk/rawwaves")
 ENDIF()
 
+INSTALL(FILES "lmms.exe.manifest" DESTINATION .)

--- a/cmake/nsis/lmms.exe.manifest
+++ b/cmake/nsis/lmms.exe.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">
+        <ms_windowsSettings:dpiAware xmlns:ms_windowsSettings="http://schemas.microsoft.com/SMI/2005/WindowsSettings">false</ms_windowsSettings:dpiAware>
+    </asmv3:windowsSettings>
+</asmv3:application>
+</assembly>


### PR DESCRIPTION
This will address #2510 on Windows by disabling High DPI in LMMS until proper Hi-DPI support is added to the codebase.  Thanks @BaraMGB for pointing me to the [forums](https://lmms.io/forum/viewtopic.php?f=7&t=24335&p=44747#p44747) where this was being evaluated.

Installer available for testing here: [`lmms-rc2.hidpi-win64.exe`](https://github.com/tresf/lmms/releases/download/v1.2.0-rc2.113/lmms-1.2.0-rc2.hidpi-win64.exe)

Before:
![image](https://cloud.githubusercontent.com/assets/6345473/25716285/8cde7020-30cc-11e7-807a-d06391ecd84a.png)


After:
![image](https://cloud.githubusercontent.com/assets/6345473/25716301/9aa1529a-30cc-11e7-88a2-4770c6b093c3.png)
