### PR TITLE
LFO controller now has correct frequency with multiple connections.

### DIFF
--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -113,6 +113,7 @@ void LfoController::updateValueBuffer()
 	}
 
 	m_currentPhase = absFraction( phase - m_phaseOffset );
+	m_bufferLastUpdated = s_periods;
 }
 
 void LfoController::updatePhase()


### PR DESCRIPTION
The LFO controller was playing at incorrect frequencies when their were multiple connections.

This was caused by the buffer counters not being correctly set.

m_bufferLastUpdated is now correctly set to the current frame upon updating
the buffer.

fixes #3064 

@Umcaruje 
Can you test this for me please, as you confirmed you could reproduce the bug in the original report