### PR TITLE
Fix non-relative samples

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -129,6 +129,7 @@ private:
 	void upgrade_1_2_0_rc2_42();
 
 	void upgrade();
+	void fixPaths();
 
 	void loadData( const QByteArray & _data, const QString & _sourceFile );
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1052,34 +1052,35 @@ void DataFile::upgrade()
 	}
 
 	// Fix relative samples
-	QDomNodeList instruments = elementsByTagName( "instrument" );
-	for( int i = 0; !instruments.item( i ).isNull(); ++i )
+	QDomNodeList list = elementsByTagName( "instrument" );
+	for( int i = 0; !list.item( i ).isNull(); ++i )
 	{
-		QDomElement child = instruments.item( i ).toElement().firstChildElement();
-		while( !child.isNull() ) 
+		QDomElement el = list.item( i ).toElement().firstChildElement();
+		qDebug() << "##### PARENT: " << list.item( i ).toElement().tagName();
+		while( !el.isNull() ) 
 		{
-			qDebug() << "##### TAGNAME: " << child.tagName();
-			QString src = child.attribute( "src" );
+			qDebug() << "##### CHILD: " << el.tagName();
+			QString src = el.attribute( "src" );
 			if ( QFileInfo( src ).isAbsolute() ) {
-				qDebug() << "##### SRC:" << child.attribute( "src" );
-				child.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
+				qDebug() << "##### SRC: " << el.attribute( "src" );
+				el.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
 			}
-			child = child.nextSiblingElement();
+			el = el.nextSiblingElement();
 		}
 	}
 
 	// Fix relative samples for sampletrack edge-case
-	QDomNodeList sampletracks = elementsByTagName( "sampletco" );
-	for( int i = 0; !sampletracks.item( i ).isNull(); ++i )
+	list = elementsByTagName( "sampletco" );
+	for( int i = 0; !list.item( i ).isNull(); ++i )
 	{
-		QDomElement sampletrack = sampletracks.item( i ).toElement();
-		qDebug() << "##### TAGNAME: " << sampletrack.tagName();
-		if( !sampletrack.isNull() ) 
+		QDomElement el = list.item( i ).toElement();
+		qDebug() << "##### TAGNAME: " << el.tagName();
+		if( !el.isNull() ) 
 		{
-			qDebug() << "##### SRC:" << sampletrack.attribute( "src" );
-			QString src = sampletrack.attribute( "src" );
+			qDebug() << "##### SRC: " << el.attribute( "src" );
+			QString src = el.attribute( "src" );
 			if ( QFileInfo( src ).isAbsolute() ) {
-				sampletrack.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
+				el.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
 			}
 		}
 	}

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -40,6 +40,7 @@
 #include "GuiApplication.h"
 #include "PluginFactory.h"
 #include "ProjectVersion.h"
+#include "SampleBuffer.h"
 #include "SongEditor.h"
 #include "TextFloat.h"
 
@@ -1048,6 +1049,39 @@ void DataFile::upgrade()
 	{
 		upgrade_1_2_0_rc3();
 		upgrade_1_2_0_rc2_42();
+	}
+
+	// Fix relative samples
+	QDomNodeList instruments = elementsByTagName( "instrument" );
+	for( int i = 0; !instruments.item( i ).isNull(); ++i )
+	{
+		QDomElement child = instruments.item( i ).toElement().firstChildElement();
+		while( !child.isNull() ) 
+		{
+			qDebug() << "##### TAGNAME: " << child.tagName();
+			QString src = child.attribute( "src" );
+			if ( QFileInfo( src ).isAbsolute() ) {
+				qDebug() << "##### SRC:" << child.attribute( "src" );
+				child.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
+			}
+			child = child.nextSiblingElement();
+		}
+	}
+
+	// Fix relative samples for sampletrack edge-case
+	QDomNodeList sampletracks = elementsByTagName( "sampletco" );
+	for( int i = 0; !sampletracks.item( i ).isNull(); ++i )
+	{
+		QDomElement sampletrack = sampletracks.item( i ).toElement();
+		qDebug() << "##### TAGNAME: " << sampletrack.tagName();
+		if( !sampletrack.isNull() ) 
+		{
+			qDebug() << "##### SRC:" << sampletrack.attribute( "src" );
+			QString src = sampletrack.attribute( "src" );
+			if ( QFileInfo( src ).isAbsolute() ) {
+				sampletrack.setAttribute( "src", SampleBuffer::tryToMakeRelative( src ) );
+			}
+		}
 	}
 
 	// update document meta data


### PR DESCRIPTION
Closes #3533

This adds a `fixPaths` function to `DataFile` to attempt to:

* Provide an upgrade path for projects created with 1.2.0-rc1 or 1.2.0-rc2
* Fix non-relative samples which will occur if a project containing external samples is accidentally saved using a custom lmms working directory prior to setting the preference.

Easiest way to test this out is to re-save an existing `1.2.0-rc2` project as an `.mmp` file (without the "z") and validate the full paths for built-in samples or lmms working directory samples have been corrected.