### PR TITLE
VeSTige opens correct folder

### DIFF
--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -1066,7 +1066,6 @@ void GigInstrumentView::showFileDialog()
 	types << tr( "GIG Files (*.gig)" );
 	ofd.setNameFilters( types );
 
-	QString dir;
 	if( k->m_filename != "" )
 	{
 		QString f = SampleBuffer::tryToMakeAbsolute( k->m_filename );

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -1080,7 +1080,6 @@ void sf2InstrumentView::showFileDialog()
 	types << tr( "SoundFont2 Files (*.sf2)" );
 	ofd.setNameFilters( types );
 
-	QString dir;
 	if( k->m_filename != "" )
 	{
 		QString f = SampleBuffer::tryToMakeAbsolute( k->m_filename );

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -253,7 +253,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 	m_plugin = new VstPlugin( m_pluginDLL );
 	if( m_plugin->failed() )
 	{
-        m_pluginDLL = "";
+		m_pluginDLL = "";
 		m_pluginMutex.unlock();
 		closePlugin();
 		delete tf;

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -41,6 +41,7 @@
 #include "Mixer.h"
 #include "GuiApplication.h"
 #include "PixmapButton.h"
+#include "SampleBuffer.h"
 #include "StringPairDrag.h"
 #include "TextFloat.h"
 #include "ToolTip.h"
@@ -173,17 +174,6 @@ void vestigeInstrument::setParameter( void )
 
 void vestigeInstrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
-	if( QFileInfo( m_pluginDLL ).isAbsolute() )
-	{
-		QString f = QString( m_pluginDLL ).replace( QDir::separator(), '/' );
-		QString vd = QString( ConfigManager::inst()->vstDir() ).replace( QDir::separator(), '/' );
-        	QString relativePath;
-		if( !( relativePath = f.section( vd, 1, 1 ) ).isEmpty() )
-		{
-			m_pluginDLL = relativePath;
-		}
-	}
-
 	_this.setAttribute( "plugin", m_pluginDLL );
 	m_pluginMutex.lock();
 	if( m_plugin != NULL )
@@ -253,8 +243,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 	{
 		closePlugin();
 	}
-
-	m_pluginDLL = _file;
+	m_pluginDLL = SampleBuffer::tryToMakeRelative( _file );
 	TextFloat * tf = TextFloat::displayMessage(
 			tr( "Loading plugin" ),
 			tr( "Please wait while loading VST-plugin..." ),
@@ -267,7 +256,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 		m_pluginMutex.unlock();
 		closePlugin();
 		delete tf;
-		collectErrorForUI( VstPlugin::tr( "The VST plugin %1 could not be loaded." ).arg( m_pluginDLL ) );
+		collectErrorForUI( VstPlugin::tr( "The VST plugin %1 could not be loaded." ).arg( QFileInfo( _file ).baseName() ) );
 		return;
 	}
 
@@ -613,29 +602,22 @@ void VestigeInstrumentView::openPlugin()
 {
 	FileDialog ofd( NULL, tr( "Open VST-plugin" ) );
 
-	QString dir;
-	if( m_vi->m_pluginDLL != "" )
-	{
-		dir = QFileInfo( m_vi->m_pluginDLL ).absolutePath();
-	}
-	else
-	{
-		dir = ConfigManager::inst()->vstDir();
-	}
-	// change dir to position of previously opened file
-	ofd.setDirectory( dir );
-	ofd.setFileMode( FileDialog::ExistingFiles );
-
 	// set filters
 	QStringList types;
 	types << tr( "DLL-files (*.dll)" )
 		<< tr( "EXE-files (*.exe)" )
 		;
 	ofd.setNameFilters( types );
+
 	if( m_vi->m_pluginDLL != "" )
 	{
-		// select previously opened file
-		ofd.selectFile( QFileInfo( m_vi->m_pluginDLL ).fileName() );
+		QString f = SampleBuffer::tryToMakeAbsolute( m_vi->m_pluginDLL );
+		ofd.setDirectory( QFileInfo( f ).absolutePath() );
+		ofd.selectFile( QFileInfo( f ).fileName() );
+	}
+	else
+	{
+		ofd.setDirectory( ConfigManager::inst()->vstDir() );
 	}
 
 	if ( ofd.exec () == QDialog::Accepted )

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -253,11 +253,11 @@ void vestigeInstrument::loadFile( const QString & _file )
 	m_plugin = new VstPlugin( m_pluginDLL );
 	if( m_plugin->failed() )
 	{
-		m_pluginDLL = "";
 		m_pluginMutex.unlock();
 		closePlugin();
 		delete tf;
-		collectErrorForUI( VstPlugin::tr( "The VST plugin %1 could not be loaded." ).arg( QFileInfo( _file ).baseName() ) );
+		collectErrorForUI( VstPlugin::tr( "The VST plugin %1 could not be loaded." ).arg( m_pluginDLL ) );
+		m_pluginDLL = "";
 		return;
 	}
 

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -253,6 +253,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 	m_plugin = new VstPlugin( m_pluginDLL );
 	if( m_plugin->failed() )
 	{
+        m_pluginDLL = "";
 		m_pluginMutex.unlock();
 		closePlugin();
 		delete tf;


### PR DESCRIPTION
This pull request fixes opening correct VST folder in previously saved projects with existing VeSTige instruments. Project has to be saved using code in this PR. After next project load VST folders open correctly. Copied logic from SF2 and GIG Players.