### PR TITLE
Provide support for fallback config values

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -217,6 +217,9 @@ public:
 
 	const QString & value( const QString & cls,
 					const QString & attribute ) const;
+	const QString & value( const QString & cls,
+					const QString & attribute,
+					const QString & defaultVal) const;
 	void setValue( const QString & cls, const QString & attribute,
 						const QString & value );
 	void deleteValue( const QString & cls, const QString & attribute);

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -219,7 +219,7 @@ public:
 					const QString & attribute ) const;
 	const QString & value( const QString & cls,
 					const QString & attribute,
-					const QString & defaultVal) const;
+					const QString & defaultVal ) const;
 	void setValue( const QString & cls, const QString & attribute,
 						const QString & value );
 	void deleteValue( const QString & cls, const QString & attribute);

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -318,6 +318,16 @@ const QString & ConfigManager::value( const QString & cls,
 
 
 
+const QString & ConfigManager::value( const QString & cls,
+				      const QString & attribute,
+				      const QString & defaultVal ) const
+{
+	const QString & val = value( cls, attribute );
+	return val.isEmpty() ? defaultVal : val;
+}
+
+
+
 
 void ConfigManager::setValue( const QString & cls,
 				const QString & attribute,

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -131,7 +131,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_syncVSTPlugins( ConfigManager::inst()->value( "ui",
 							"syncvstplugins" ).toInt() ),
 	m_animateAFP(ConfigManager::inst()->value( "ui",
-						   "animateafp", "1").toInt() ),
+						   "animateafp", "1" ).toInt() ),
 	m_printNoteLabels(ConfigManager::inst()->value( "ui",
 						   "printnotelabels").toInt() ),
 	m_displayWaveform(ConfigManager::inst()->value( "ui",

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -119,8 +119,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 #endif
 	m_backgroundArtwork( QDir::toNativeSeparators( ConfigManager::inst()->backgroundArtwork() ) ),
 	m_smoothScroll( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() ),
-	m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() ),
-	m_enableRunningAutoSave( ConfigManager::inst()->value( "ui", "enablerunningautosave" ).toInt() ),
+	m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave", "1" ).toInt() ),
+	m_enableRunningAutoSave( ConfigManager::inst()->value( "ui", "enablerunningautosave", "1" ).toInt() ),
 	m_saveInterval(	ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() < 1 ?
 					MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES :
 			ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() ),
@@ -131,7 +131,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_syncVSTPlugins( ConfigManager::inst()->value( "ui",
 							"syncvstplugins" ).toInt() ),
 	m_animateAFP(ConfigManager::inst()->value( "ui",
-						   "animateafp").toInt() ),
+						   "animateafp", "1").toInt() ),
 	m_printNoteLabels(ConfigManager::inst()->value( "ui",
 						   "printnotelabels").toInt() ),
 	m_displayWaveform(ConfigManager::inst()->value( "ui",


### PR DESCRIPTION
Supersedes #3541 to address autosave regression https://github.com/LMMS/lmms/issues/181#issuecomment-299703956.

Previous to this PR, there was no way to provide a "default on" style config value.  The effect of this was variable names such as `disableautosave` causing double negatives in our codebase making it hard to read.  Attempts to change them have resulted in a mismatch between desired default and actual default.  This should allow config values to have default values.

e.g. 

```diff
- m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() ),
+ m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave", "1" ).toInt() ),
```

Booleans are parsed as integers.  A default value of `1` will make a checkbox true.  This will allow us to start moving toward more properly named variables as explained very well here https://github.com/LMMS/lmms/pull/3088#discussion_r99468228.