### PR TITLE
Automatically change pattern lengths after shifting note positions(Fixes #3563)

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -997,6 +997,7 @@ void PianoRoll::shiftPos( int amount ) //shift notes pos by amount
 	}
 
 	m_pattern->rearrangeAllNotes();
+	m_pattern->updateLength();
 	m_pattern->dataChanged();
 
 	// we modified the song


### PR DESCRIPTION
Fixes #3563.
Added m_pattern->updateLength(); in PianoRoll::shiftPos().
I think it is also needed for master branch.