### PR TITLE
Fix loop condition in project rendering (#3105, #2030)

### DIFF
--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -172,10 +172,11 @@ void ProjectRenderer::run()
 	m_progress = 0;
 	std::pair<MidiTime, MidiTime> exportEndpoints = Engine::getSong()->getExportEndpoints();
 	tick_t startTick = exportEndpoints.first.getTicks();
-	tick_t lengthTicks = exportEndpoints.second.getTicks() - startTick;
+	tick_t endTick = exportEndpoints.second.getTicks();
+	tick_t lengthTicks = endTick - startTick;
 
 	// Continually track and emit progress percentage to listeners
-	while( Engine::getSong()->isExportDone() == false &&
+	while( exportPos.getTicks() < endTick &&
 				Engine::getSong()->isExporting() == true
 							&& !m_abort )
 	{

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -464,29 +464,6 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 	}
 }
 
-bool Song::isExportDone() const
-{
-	if ( m_renderBetweenMarkers )
-	{
-		return m_exporting == true &&
-			m_playPos[Mode_PlaySong].getTicks() >= 
-				m_playPos[Mode_PlaySong].m_timeLine->loopEnd().getTicks();
-	}
-
-	if( m_exportLoop )
-	{
-		return m_exporting == true &&
-			m_playPos[Mode_PlaySong].getTicks() >= 
-				length() * ticksPerTact();
-	}
-	else
-	{
-		return m_exporting == true &&
-			m_playPos[Mode_PlaySong].getTicks() >= 
-				( length() + 1 ) * ticksPerTact();
-	}
-}
-
 std::pair<MidiTime, MidiTime> Song::getExportEndpoints() const
 {
 	if ( m_renderBetweenMarkers )


### PR DESCRIPTION
Fix loop condition in ProjectRenderer::run().
It fixes #2030 clearly.
@DeRobyJ Could you test this for #3105?

Based on https://github.com/LMMS/lmms/issues/3105#issuecomment-2626364333
(The idea from @softrabbit)