### PR TITLE
Add more brew packages

### DIFF
--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PACKAGES="cmake pkgconfig fftw libogg libvorbis libsndfile libsamplerate jack sdl stk portaudio node fltk"
+PACKAGES="cmake pkgconfig fftw libogg libvorbis libsndfile libsamplerate jack sdl libgig libsoundio stk portaudio node fltk"
 
 if [ $QT5 ]; then
 	PACKAGES="$PACKAGES homebrew/versions/qt55"

--- a/plugins/GigPlayer/CMakeLists.txt
+++ b/plugins/GigPlayer/CMakeLists.txt
@@ -2,6 +2,9 @@ if(LMMS_HAVE_GIG)
 	INCLUDE(BuildPlugin)
 	INCLUDE_DIRECTORIES(${GIG_INCLUDE_DIRS})
 
+	# Disable C++11
+	REMOVE_DEFINITIONS(-std=c++0x)
+
 	# Required for not crashing loading files with libgig
 	SET(GCC_COVERAGE_COMPILE_FLAGS "-fexceptions")
 	add_definitions(${GCC_COVERAGE_COMPILE_FLAGS})

--- a/plugins/GigPlayer/CMakeLists.txt
+++ b/plugins/GigPlayer/CMakeLists.txt
@@ -2,8 +2,10 @@ if(LMMS_HAVE_GIG)
 	INCLUDE(BuildPlugin)
 	INCLUDE_DIRECTORIES(${GIG_INCLUDE_DIRS})
 
-	# Disable C++11
-	REMOVE_DEFINITIONS(-std=c++0x)
+	# Disable C++11 on Clang until gig.h is patched
+	IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		REMOVE_DEFINITIONS(-std=c++0x)
+	ENDIF()
 
 	# Required for not crashing loading files with libgig
 	SET(GCC_COVERAGE_COMPILE_FLAGS "-fexceptions")

--- a/plugins/GigPlayer/PatchesDialog.h
+++ b/plugins/GigPlayer/PatchesDialog.h
@@ -30,7 +30,6 @@
 #include "LcdSpinBox.h"
 #include "GigPlayer.h"
 
-#include <fluidsynth.h>
 #include <QWidget>
 #include <QLabel>
 


### PR DESCRIPTION
Travis as well as [the MacOS wiki](https://github.com/LMMS/lmms/wiki/dependencies-macos#qt5) are missing some packages for building on Mac.  Adds `libgig` and `libsoundio` for Mac.

* Remove C++11 for GigPlayer on Clang
* Fix non-Clang environments

See also #3208