### PR TITLE
Fixed LMMS crash when pressing Q in not existing piano roll.

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3918,31 +3918,33 @@ int PianoRoll::quantization() const
 
 void PianoRoll::quantizeNotes()
 {
-	NoteVector notes = getSelectedNotes();
+	if( m_pattern != NULL ) {
+		NoteVector notes = getSelectedNotes();
 
-	if (notes.empty())
-	{
-		for (Note* n : m_pattern->notes())
+		if( notes.empty() )
 		{
-			notes.push_back(n);
-		}
-	}
-
-	for (Note* n : notes)
-	{
-		if (n->length() == MidiTime(0))
-		{
-			continue;
+			for( Note* n : m_pattern->notes() )
+			{
+				notes.push_back(n);
+			}
 		}
 
-		Note copy(*n);
-		m_pattern->removeNote(n);
-		copy.quantizePos(quantization());
-		m_pattern->addNote(copy);
-	}
+		for( Note* n : notes )
+		{
+			if (n->length() == MidiTime(0))
+			{
+				continue;
+			}
 
-	update();
-	gui->songEditor()->update();
+			Note copy(*n);
+			m_pattern->removeNote(n);
+			copy.quantizePos(quantization());
+			m_pattern->addNote(copy);
+		}
+
+		update();
+		gui->songEditor()->update();
+	}
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -805,7 +805,7 @@ void PianoRoll::setBackgroundShade( const QColor & c )
 
 
 
-void PianoRoll::drawNoteRect( QPainter & p, int x, int y, 
+void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 				int width, const Note * n, const QColor & noteCol,
 				const QColor & selCol, const int noteOpc, const bool borders )
 {
@@ -1918,7 +1918,7 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 		{
 			// select the notes within the selection rectangle and
 			// then destroy the selection rectangle
-			computeSelectedNotes( 
+			computeSelectedNotes(
 					me->modifiers() & Qt::ShiftModifier );
 		}
 		else if( m_action == ActionMoveNote )
@@ -2463,7 +2463,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				}
 			}
 		}
-	} 
+	}
 	else if (m_action == ActionResizeNote)
 	{
 		// When resizing notes:
@@ -2471,7 +2471,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 		// If shift is pressed we resize and rearrange only the selected notes
 		// If shift + ctrl then we also rearrange all posterior notes (sticky)
 		// If shift is pressed but only one note is selected, apply sticky
-			
+
 		if (shift)
 		{
 			// Algorithm:
@@ -2491,8 +2491,8 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			const Note *posteriorNote = nullptr;
 			for (const Note *note : notes)
 			{
-				if (note->selected() && (posteriorNote == nullptr || 
-					note->oldPos().getTicks() + note->oldLength().getTicks() > 
+				if (note->selected() && (posteriorNote == nullptr ||
+					note->oldPos().getTicks() + note->oldLength().getTicks() >
 					posteriorNote->oldPos().getTicks() + posteriorNote->oldLength().getTicks()))
 				{
 					posteriorNote = note;
@@ -2512,9 +2512,9 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				if(note->selected())
 				{
 					// scale relative start and end positions by scaleFactor
-					int newStart = stretchStartTick + scaleFactor * 
+					int newStart = stretchStartTick + scaleFactor *
 						(note->oldPos().getTicks() - stretchStartTick);
-					int newEnd = stretchStartTick + scaleFactor * 
+					int newEnd = stretchStartTick + scaleFactor *
 						(note->oldPos().getTicks()+note->oldLength().getTicks() - stretchStartTick);
 					// if  not holding alt, quantize the offsets
 					if(!alt)
@@ -2533,7 +2533,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 					int newLength = qMax(1, newEnd-newStart);
 					if (note == posteriorNote)
 					{
-						posteriorDeltaThisFrame = (newStart+newLength) - 
+						posteriorDeltaThisFrame = (newStart+newLength) -
 							(note->pos().getTicks() + note->length().getTicks());
 					}
 					note->setLength( MidiTime(newLength) );
@@ -3918,28 +3918,28 @@ int PianoRoll::quantization() const
 
 void PianoRoll::quantizeNotes()
 {
-	if( m_pattern != NULL ) {
+	if( hasValidPattern() ) {
 		NoteVector notes = getSelectedNotes();
 
 		if( notes.empty() )
 		{
 			for( Note* n : m_pattern->notes() )
 			{
-				notes.push_back(n);
+				notes.push_back( n );
 			}
 		}
 
 		for( Note* n : notes )
 		{
-			if (n->length() == MidiTime(0))
+			if( n->length() == MidiTime( 0 ) )
 			{
 				continue;
 			}
 
 			Note copy(*n);
-			m_pattern->removeNote(n);
-			copy.quantizePos(quantization());
-			m_pattern->addNote(copy);
+			m_pattern->removeNote( n );
+			copy.quantizePos( quantization() );
+			m_pattern->addNote( copy );
 		}
 
 		update();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3918,33 +3918,36 @@ int PianoRoll::quantization() const
 
 void PianoRoll::quantizeNotes()
 {
-	if( hasValidPattern() ) {
-		NoteVector notes = getSelectedNotes();
-
-		if( notes.empty() )
-		{
-			for( Note* n : m_pattern->notes() )
-			{
-				notes.push_back( n );
-			}
-		}
-
-		for( Note* n : notes )
-		{
-			if( n->length() == MidiTime( 0 ) )
-			{
-				continue;
-			}
-
-			Note copy(*n);
-			m_pattern->removeNote( n );
-			copy.quantizePos( quantization() );
-			m_pattern->addNote( copy );
-		}
-
-		update();
-		gui->songEditor()->update();
+	if( ! hasValidPattern() )
+	{
+		return;
 	}
+
+	NoteVector notes = getSelectedNotes();
+
+	if( notes.empty() )
+	{
+		for( Note* n : m_pattern->notes() )
+		{
+			notes.push_back( n );
+		}
+	}
+
+	for( Note* n : notes )
+	{
+		if( n->length() == MidiTime( 0 ) )
+		{
+			continue;
+		}
+
+		Note copy(*n);
+		m_pattern->removeNote( n );
+		copy.quantizePos( quantization() );
+		m_pattern->addNote( copy );
+	}
+
+	update();
+	gui->songEditor()->update();
 }
 
 


### PR DESCRIPTION
Steps to reproduce:
1. Open LMMS
2. Open Piano-Roll
3. Click on Q
4. LMMS crashes.

This change fixes it.
Link to issue: #3608.