### PR TITLE
Open .mpt files via the file open dialogue.

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -854,7 +854,9 @@ void MainWindow::openProject()
 {
 	if( mayChangeProject(false) )
 	{
-		FileDialog ofd( this, tr( "Open Project" ), "", tr( "LMMS (*.mmp *.mmpz)" ) );
+		FileDialog ofd( this, tr( "Open Project" ), "",
+				tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
+				tr( "LMMS Project Template" ) + " (*.mpt)" );
 
 		ofd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 		ofd.setFileMode( FileDialog::ExistingFiles );


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/6368949/27007562-56bfbf78-4e57-11e7-8b1f-e22f3240dcce.png)

Just found myself needing this again for the tenth time or so.
I also omitted the project suffixes from translation as is done in `MainWindow::saveProjectAs()`