### PR TITLE
Sample Tracks: FX Mixer Support

### DIFF
--- a/include/FxLineLcdSpinBox.h
+++ b/include/FxLineLcdSpinBox.h
@@ -35,7 +35,7 @@ class FxLineLcdSpinBox : public LcdSpinBox
 	Q_OBJECT
 public:
 	FxLineLcdSpinBox(int numDigits, QWidget * parent, const QString& name, TrackView * tv = NULL) :
-		LcdSpinBox(numDigits, parent, name), m_tv( tv )
+		LcdSpinBox(numDigits, parent, name), m_tv(tv)
 	{}
 	virtual ~FxLineLcdSpinBox() {}
 

--- a/include/FxLineLcdSpinBox.h
+++ b/include/FxLineLcdSpinBox.h
@@ -1,0 +1,48 @@
+/*
+ * FxLineLcdSpinBox.h - a specialization of LcdSpnBox for setting FX channels
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef FX_LINE_LCD_SPIN_BOX_H
+#define FX_LINE_LCD_SPIN_BOX_H
+
+#include "LcdSpinBox.h"
+
+class InstrumentTrackWindow;
+
+
+class FxLineLcdSpinBox : public LcdSpinBox
+{
+	Q_OBJECT
+public:
+	FxLineLcdSpinBox(int numDigits, QWidget * parent, const QString& name) :
+		LcdSpinBox(numDigits, parent, name)
+	{}
+	virtual ~FxLineLcdSpinBox() {}
+
+protected:
+	virtual void mouseDoubleClickEvent(QMouseEvent* event);
+	virtual void contextMenuEvent(QContextMenuEvent* event);
+
+};
+
+#endif

--- a/include/FxLineLcdSpinBox.h
+++ b/include/FxLineLcdSpinBox.h
@@ -27,21 +27,25 @@
 
 #include "LcdSpinBox.h"
 
-class InstrumentTrackWindow;
+class TrackView;
 
 
 class FxLineLcdSpinBox : public LcdSpinBox
 {
 	Q_OBJECT
 public:
-	FxLineLcdSpinBox(int numDigits, QWidget * parent, const QString& name) :
-		LcdSpinBox(numDigits, parent, name)
+	FxLineLcdSpinBox(int numDigits, QWidget * parent, const QString& name, TrackView * tv = NULL) :
+		LcdSpinBox(numDigits, parent, name), m_tv( tv )
 	{}
 	virtual ~FxLineLcdSpinBox() {}
+
 
 protected:
 	virtual void mouseDoubleClickEvent(QMouseEvent* event);
 	virtual void contextMenuEvent(QContextMenuEvent* event);
+
+private:
+	TrackView * m_tv;
 
 };
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -51,6 +51,7 @@ class InstrumentTrackWindow;
 class InstrumentMidiIOView;
 class InstrumentMiscView;
 class Knob;
+class FxLineLcdSpinBox;
 class LcdSpinBox;
 class LeftRightNav;
 class midiPortMenu;
@@ -438,7 +439,7 @@ private:
 	QLabel * m_pitchLabel;
 	LcdSpinBox* m_pitchRangeSpinBox;
 	QLabel * m_pitchRangeLabel;
-	LcdSpinBox * m_effectChannelNumber;
+	FxLineLcdSpinBox * m_effectChannelNumber;
 
 
 

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -36,6 +36,9 @@
 class EffectRackView;
 class Knob;
 class SampleBuffer;
+class SampleTrackWindow;
+class TrackLabelButton;
+class QLineEdit;
 
 
 class SampleTCO : public TrackContentObject
@@ -173,6 +176,7 @@ private:
 
 
 	friend class SampleTrackView;
+	friend class SampleTrackWindow;
 
 } ;
 
@@ -184,6 +188,21 @@ class SampleTrackView : public TrackView
 public:
 	SampleTrackView( SampleTrack* Track, TrackContainerView* tcv );
 	virtual ~SampleTrackView();
+
+	SampleTrackWindow * getSampleTrackWindow()
+	{
+		return m_window;
+	}
+
+	SampleTrack * model()
+	{
+		return castModel<SampleTrack>();
+	}
+
+	const SampleTrack * model() const
+	{
+		return castModel<SampleTrack>();
+	}
 
 
 public slots:
@@ -201,9 +220,72 @@ protected:
 private:
 	EffectRackView * m_effectRack;
 	QWidget * m_effWindow;
+	SampleTrackWindow * m_window;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
 	LcdSpinBox * m_effectChannelNumber;
+
+	TrackLabelButton * m_tlb;
+
+
+	friend class SampleTrackWindow;
+
+} ;
+
+
+
+class SampleTrackWindow : public QWidget, public ModelView,
+								public SerializingObjectHook
+{
+	Q_OBJECT
+public:
+	SampleTrackWindow(SampleTrackView * _tv);
+	virtual ~SampleTrackWindow();
+
+	SampleTrack * model()
+	{
+		return castModel<SampleTrack>();
+	}
+
+	const SampleTrack * model() const
+	{
+		return castModel<SampleTrack>();
+	}
+
+	void setSampleTrackView(SampleTrackView * _tv);
+
+	SampleTrackView *sampleTrackView()
+	{
+		return m_stv;
+	}
+
+
+public slots:
+	void textChanged(const QString & _new_name);
+	void toggleVisibility(bool _on);
+	void updateName();
+
+
+protected:
+	// capture close-events for toggling sample-track-button
+	virtual void closeEvent(QCloseEvent * _ce);
+
+	virtual void saveSettings(QDomDocument & _doc, QDomElement & _this);
+	virtual void loadSettings(const QDomElement & _this);
+
+private:
+	virtual void modelChanged();
+
+	SampleTrack * m_track;
+	SampleTrackView * m_stv;
+
+	// widgets on the top of an sample-track-window
+	QLineEdit * m_nameLineEdit;
+	Knob * m_volumeKnob;
+	Knob * m_panningKnob;
+	FxLineLcdSpinBox * m_effectChannelNumber;
+
+	EffectRackView * m_effectRack;
 
 } ;
 

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -205,6 +205,9 @@ public:
 	}
 
 
+	virtual QMenu * createFxMenu( QString title, QString newFxLabel );
+
+
 public slots:
 	void showEffects();
 
@@ -217,13 +220,15 @@ protected:
 	}
 
 
+private slots:
+	void assignFxLine( int channelIndex );
+	void createFxLine();
+
+
 private:
-	EffectRackView * m_effectRack;
-	QWidget * m_effWindow;
 	SampleTrackWindow * m_window;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
-	LcdSpinBox * m_effectChannelNumber;
 
 	TrackLabelButton * m_tlb;
 

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -244,7 +244,7 @@ class SampleTrackWindow : public QWidget, public ModelView,
 {
 	Q_OBJECT
 public:
-	SampleTrackWindow(SampleTrackView * _tv);
+	SampleTrackWindow(SampleTrackView * tv);
 	virtual ~SampleTrackWindow();
 
 	SampleTrack * model()
@@ -257,7 +257,7 @@ public:
 		return castModel<SampleTrack>();
 	}
 
-	void setSampleTrackView(SampleTrackView * _tv);
+	void setSampleTrackView(SampleTrackView * tv);
 
 	SampleTrackView *sampleTrackView()
 	{
@@ -266,17 +266,17 @@ public:
 
 
 public slots:
-	void textChanged(const QString & _new_name);
-	void toggleVisibility(bool _on);
+	void textChanged(const QString & new_name);
+	void toggleVisibility(bool on);
 	void updateName();
 
 
 protected:
 	// capture close-events for toggling sample-track-button
-	virtual void closeEvent(QCloseEvent * _ce);
+	virtual void closeEvent(QCloseEvent * ce);
 
-	virtual void saveSettings(QDomDocument & _doc, QDomElement & _this);
-	virtual void loadSettings(const QDomElement & _this);
+	virtual void saveSettings(QDomDocument & doc, QDomElement & element);
+	virtual void loadSettings(const QDomElement & element);
 
 private:
 	virtual void modelChanged();

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -26,8 +26,11 @@
 #define SAMPLE_TRACK_H
 
 #include <QDialog>
+#include <QLayout>
 
 #include "AudioPort.h"
+#include "FxMixer.h"
+#include "FxLineLcdSpinBox.h"
 #include "Track.h"
 
 class EffectRackView;
@@ -141,6 +144,11 @@ public:
 							QDomElement & _parent );
 	virtual void loadTrackSpecificSettings( const QDomElement & _this );
 
+	inline IntModel * effectChannelModel()
+	{
+		return &m_effectChannelModel;
+	}
+
 	inline AudioPort * audioPort()
 	{
 		return &m_audioPort;
@@ -154,10 +162,12 @@ public:
 public slots:
 	void updateTcos();
 	void setPlayingTcos( bool isPlaying );
+	void updateEffectChannel();
 
 private:
 	FloatModel m_volumeModel;
 	FloatModel m_panningModel;
+	IntModel m_effectChannelModel;
 	AudioPort m_audioPort;
 
 
@@ -193,6 +203,7 @@ private:
 	QWidget * m_effWindow;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
+	LcdSpinBox * m_effectChannelNumber;
 
 } ;
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -666,6 +666,10 @@ public:
 
 	virtual void update();
 
+	// Create a menu for assigning/creating channels for this track
+	// Currently instrument track and sample track supports it
+	virtual QMenu * createFxMenu( QString title, QString newFxLabel );
+
 
 public slots:
 	virtual bool close();

--- a/include/Track.h
+++ b/include/Track.h
@@ -668,7 +668,7 @@ public:
 
 	// Create a menu for assigning/creating channels for this track
 	// Currently instrument track and sample track supports it
-	virtual QMenu * createFxMenu( QString title, QString newFxLabel );
+	virtual QMenu * createFxMenu(QString title, QString newFxLabel);
 
 
 public slots:

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -32,6 +32,7 @@
 #include "Song.h"
 
 #include "InstrumentTrack.h"
+#include "SampleTrack.h"
 #include "BBTrackContainer.h"
 
 FxRoute::FxRoute( FxChannel * from, FxChannel * to, float amount ) :
@@ -312,6 +313,22 @@ void FxMixer::deleteChannel( int index )
 				inst->effectChannelModel()->setValue(val-1);
 			}
 		}
+		else if( t->type() == Track::SampleTrack )
+		{
+			SampleTrack* strk = dynamic_cast<SampleTrack *>( t );
+			int val = strk->effectChannelModel()->value(0);
+			if( val == index )
+			{
+				// we are deleting this track's fx send
+				// send to master
+				strk->effectChannelModel()->setValue(0);
+			}
+			else if( val > index )
+			{
+				// subtract 1 to make up for the missing channel
+				strk->effectChannelModel()->setValue(val-1);
+			}
+		}
 	}
 
 	FxChannel * ch = m_fxChannels[index];
@@ -384,6 +401,19 @@ void FxMixer::moveChannelLeft( int index )
 				else if( val == b )
 				{
 					inst->effectChannelModel()->setValue(a);
+				}
+			}
+			else if( trackList[i]->type() == Track::SampleTrack )
+			{
+				SampleTrack * strk = (SampleTrack *) trackList[i];
+				int val = strk->effectChannelModel()->value(0);
+				if( val == a )
+				{
+					strk->effectChannelModel()->setValue(b);
+				}
+				else if( val == b )
+				{
+					strk->effectChannelModel()->setValue(a);
 				}
 			}
 		}
@@ -787,4 +817,3 @@ void FxMixer::validateChannelName( int index, int oldIndex )
 		m_fxChannels[index]->m_name = tr( "FX %1" ).arg( index );
 	}
 }
-

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1842,12 +1842,12 @@ void TrackOperationsWidget::updateMenu()
 	{
 		toMenu->addAction( tr( "Clear this track" ), this, SLOT( clearTrack() ) );
 	}
-	if(QMenu *fxMenu = m_trackView->createFxMenu(tr("FX %1: %2"), tr("Assign to new FX Channel")))
+	if (QMenu *fxMenu = m_trackView->createFxMenu(tr("FX %1: %2"), tr("Assign to new FX Channel")))
 	{
 		toMenu->addMenu(fxMenu);
 	}
 
-	if(InstrumentTrackView * trackView = dynamic_cast<InstrumentTrackView *>(m_trackView))
+	if (InstrumentTrackView * trackView = dynamic_cast<InstrumentTrackView *>(m_trackView))
 	{
 		toMenu->addSeparator();
 		toMenu->addMenu(trackView->midiMenu());
@@ -2602,7 +2602,7 @@ void TrackView::update()
 /*! \brief Create a menu for assigning/creating channels for this track.
  *
  */
-QMenu * TrackView::createFxMenu( QString title, QString newFxLabel )
+QMenu * TrackView::createFxMenu(QString title, QString newFxLabel)
 {
 	Q_UNUSED(title)
 	Q_UNUSED(newFxLabel)

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1842,13 +1842,15 @@ void TrackOperationsWidget::updateMenu()
 	{
 		toMenu->addAction( tr( "Clear this track" ), this, SLOT( clearTrack() ) );
 	}
-	if( InstrumentTrackView * trackView = dynamic_cast<InstrumentTrackView *>( m_trackView ) )
+	if(QMenu *fxMenu = m_trackView->createFxMenu(tr("FX %1: %2"), tr("Assign to new FX Channel")))
 	{
-		QMenu *fxMenu = trackView->createFxMenu( tr( "FX %1: %2" ), tr( "Assign to new FX Channel" ));
 		toMenu->addMenu(fxMenu);
+	}
 
+	if(InstrumentTrackView * trackView = dynamic_cast<InstrumentTrackView *>(m_trackView))
+	{
 		toMenu->addSeparator();
-		toMenu->addMenu( trackView->midiMenu() );
+		toMenu->addMenu(trackView->midiMenu());
 	}
 	if( dynamic_cast<AutomationTrackView *>( m_trackView ) )
 	{
@@ -2592,6 +2594,19 @@ void TrackView::update()
 		m_trackContentWidget.changePosition();
 	}
 	QWidget::update();
+}
+
+
+
+
+/*! \brief Create a menu for assigning/creating channels for this track.
+ *
+ */
+QMenu * TrackView::createFxMenu( QString title, QString newFxLabel )
+{
+	Q_UNUSED(title)
+	Q_UNUSED(newFxLabel)
+	return NULL;
 }
 
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -56,6 +56,7 @@ SET(LMMS_SRCS
 	gui/widgets/FadeButton.cpp
 	gui/widgets/Fader.cpp
 	gui/widgets/FxLine.cpp
+	gui/widgets/FxLineLcdSpinBox.cpp
 	gui/widgets/Graph.cpp
 	gui/widgets/GroupBox.cpp
 	gui/widgets/InstrumentFunctionViews.cpp

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -47,6 +47,7 @@
 #include "Mixer.h"
 #include "gui_templates.h"
 #include "InstrumentTrack.h"
+#include "SampleTrack.h"
 #include "Song.h"
 #include "BBTrackContainer.h"
 
@@ -73,7 +74,7 @@ FxMixerView::FxMixerView() :
 
 	// Set margins
 	ml->setContentsMargins( 0, 4, 0, 0 );
-	
+
 	// Channel area
 	m_channelAreaWidget = new QWidget;
 	chLayout = new QHBoxLayout( m_channelAreaWidget );
@@ -138,9 +139,9 @@ FxMixerView::FxMixerView() :
 	ml->addWidget( newChannelBtn, 0, Qt::AlignTop );
 
 
-	// add the stacked layout for the effect racks of fx channels 
+	// add the stacked layout for the effect racks of fx channels
 	ml->addWidget( m_racksWidget, 0, Qt::AlignTop | Qt::AlignRight );
-	
+
 	setCurrentFxLine( m_fxChannelViews[0]->m_fxLine );
 
 	setLayout( ml );
@@ -219,10 +220,10 @@ void FxMixerView::refreshDisplay()
 		chLayout->addWidget(m_fxChannelViews[i]->m_fxLine);
 		m_racksLayout->addWidget( m_fxChannelViews[i]->m_rackView );
 	}
-	
+
 	// set selected fx line to 0
 	setCurrentFxLine( 0 );
-	
+
 	// update all fx lines
 	for( int i = 0; i < m_fxChannelViews.size(); ++i )
 	{
@@ -249,6 +250,12 @@ void FxMixerView::updateMaxChannelSelector()
 			{
 				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
 				inst->effectChannelModel()->setRange(0,
+					m_fxChannelViews.size()-1,1);
+			}
+			else if( trackList[i]->type() == Track::SampleTrack )
+			{
+				SampleTrack * strk = (SampleTrack *) trackList[i];
+				strk->effectChannelModel()->setRange(0,
 					m_fxChannelViews.size()-1,1);
 			}
 		}
@@ -308,7 +315,7 @@ FxMixerView::FxChannelView::FxChannelView(QWidget * _parent, FxMixerView * _mv,
 	connect(&fxChannel->m_soloModel, SIGNAL( dataChanged() ),
 			_mv, SLOT ( toggledSolo() ) );
 	ToolTip::add( m_soloBtn, tr( "Solo FX channel" ) );
-	
+
 	// Create EffectRack for the channel
 	m_rackView = new EffectRackView( &fxChannel->m_fxChain, _mv->m_racksWidget );
 	m_rackView->setFixedSize( 245, FxLine::FxLineHeight );

--- a/src/gui/widgets/FxLineLcdSpinBox.cpp
+++ b/src/gui/widgets/FxLineLcdSpinBox.cpp
@@ -1,0 +1,67 @@
+/*
+ * FxLineLcdSpinBox.cpp - a specialization of LcdSpnBox for setting FX channels
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "FxLineLcdSpinBox.h"
+
+#include "CaptionMenu.h"
+#include "FxMixerView.h"
+#include "GuiApplication.h"
+#include "InstrumentTrack.h"
+
+
+void FxLineLcdSpinBox::mouseDoubleClickEvent(QMouseEvent* event)
+{
+	gui->fxMixerView()->setCurrentFxLine(model()->value());
+
+	gui->fxMixerView()->parentWidget()->show();
+	gui->fxMixerView()->show();// show fxMixer window
+	gui->fxMixerView()->setFocus();// set focus to fxMixer window
+	//engine::getFxMixerView()->raise();
+}
+
+void FxLineLcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
+{
+	// for the case, the user clicked right while pressing left mouse-
+	// button, the context-menu appears while mouse-cursor is still hidden
+	// and it isn't shown again until user does something which causes
+	// an QApplication::restoreOverrideCursor()-call...
+	mouseReleaseEvent(nullptr);
+
+	QPointer<CaptionMenu> contextMenu = new CaptionMenu(model()->displayName(), this);
+
+	// This condition is here just as a safety check, fxLineLcdSpinBox is aways
+	// created inside a TabWidget inside an InstrumentTrackWindow
+	// FIXME this won't necessarily be true anymore
+	if (InstrumentTrackWindow* window =
+		dynamic_cast<InstrumentTrackWindow*>((QWidget*)this->parent()->parent()))
+	{
+		QMenu *fxMenu = window->instrumentTrackView()->createFxMenu(
+			tr("Assign to:"), tr("New FX Channel"));
+		contextMenu->addMenu(fxMenu);
+
+		contextMenu->addSeparator();
+	}
+	addDefaultActions(contextMenu);
+	contextMenu->exec(QCursor::pos());
+}

--- a/src/gui/widgets/FxLineLcdSpinBox.cpp
+++ b/src/gui/widgets/FxLineLcdSpinBox.cpp
@@ -27,7 +27,7 @@
 #include "CaptionMenu.h"
 #include "FxMixerView.h"
 #include "GuiApplication.h"
-#include "InstrumentTrack.h"
+#include "Track.h"
 
 
 void FxLineLcdSpinBox::mouseDoubleClickEvent(QMouseEvent* event)
@@ -50,14 +50,9 @@ void FxLineLcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
 
 	QPointer<CaptionMenu> contextMenu = new CaptionMenu(model()->displayName(), this);
 
-	// This condition is here just as a safety check, fxLineLcdSpinBox is aways
-	// created inside a TabWidget inside an InstrumentTrackWindow
-	// FIXME this won't necessarily be true anymore
-	if (InstrumentTrackWindow* window =
-		dynamic_cast<InstrumentTrackWindow*>((QWidget*)this->parent()->parent()))
+	if ( QMenu *fxMenu = m_tv->createFxMenu(
+				tr( "Assign to:" ), tr( "New FX Channel" ) ) )
 	{
-		QMenu *fxMenu = window->instrumentTrackView()->createFxMenu(
-			tr("Assign to:"), tr("New FX Channel"));
 		contextMenu->addMenu(fxMenu);
 
 		contextMenu->addSeparator();

--- a/src/gui/widgets/FxLineLcdSpinBox.cpp
+++ b/src/gui/widgets/FxLineLcdSpinBox.cpp
@@ -50,8 +50,8 @@ void FxLineLcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
 
 	QPointer<CaptionMenu> contextMenu = new CaptionMenu(model()->displayName(), this);
 
-	if ( QMenu *fxMenu = m_tv->createFxMenu(
-				tr( "Assign to:" ), tr( "New FX Channel" ) ) )
+	if (QMenu *fxMenu = m_tv->createFxMenu(
+				tr("Assign to:"), tr( "New FX Channel" )))
 	{
 		contextMenu->addMenu(fxMenu);
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1336,7 +1336,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 
 	// setup spinbox for selecting FX-channel
-	m_effectChannelNumber = new FxLineLcdSpinBox( 2, NULL, tr( "FX channel" ) );
+	m_effectChannelNumber = new FxLineLcdSpinBox( 2, NULL, tr( "FX channel" ), m_itv );
 
 	basicControlsLayout->addWidget( m_effectChannelNumber, 0, 6 );
 	basicControlsLayout->setAlignment( m_effectChannelNumber, widgetAlignment );

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -47,6 +47,7 @@
 #include "EffectRackView.h"
 #include "embed.h"
 #include "FileBrowser.h"
+#include "FxLineLcdSpinBox.h"
 #include "FxMixer.h"
 #include "FxMixerView.h"
 #include "GuiApplication.h"
@@ -1212,52 +1213,6 @@ QMenu * InstrumentTrackView::createFxMenu(QString title, QString newFxLabel)
 
 
 
-class fxLineLcdSpinBox : public LcdSpinBox
-{
-        Q_OBJECT
-	public:
-		fxLineLcdSpinBox( int _num_digits, QWidget * _parent,
-				const QString & _name ) :
-			LcdSpinBox( _num_digits, _parent, _name ) {}
-
-	protected:
-		virtual void mouseDoubleClickEvent ( QMouseEvent * _me )
-		{
-			gui->fxMixerView()->setCurrentFxLine( model()->value() );
-
-			gui->fxMixerView()->parentWidget()->show();
-			gui->fxMixerView()->show();// show fxMixer window
-			gui->fxMixerView()->setFocus();// set focus to fxMixer window
-			//engine::getFxMixerView()->raise();
-		}
-
-		virtual void contextMenuEvent( QContextMenuEvent* event )
-		{
-			// for the case, the user clicked right while pressing left mouse-
-			// button, the context-menu appears while mouse-cursor is still hidden
-			// and it isn't shown again until user does something which causes
-			// an QApplication::restoreOverrideCursor()-call...
-			mouseReleaseEvent( NULL );
-
-			QPointer<CaptionMenu> contextMenu = new CaptionMenu( model()->displayName(), this );
-
-			// This condition is here just as a safety check, fxLineLcdSpinBox is aways
-			// created inside a TabWidget inside an InstrumentTrackWindow
-			if ( InstrumentTrackWindow* window = dynamic_cast<InstrumentTrackWindow*>( (QWidget *)this->parent()->parent() ) )
-			{
-				QMenu *fxMenu = window->instrumentTrackView()->createFxMenu( tr( "Assign to:" ), tr( "New FX Channel" ) );
-				contextMenu->addMenu( fxMenu );
-
-				contextMenu->addSeparator();
-			}
-			addDefaultActions( contextMenu );
-			contextMenu->exec( QCursor::pos() );
-		}
-
-};
-
-
-
 // #### ITW:
 InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	QWidget(),
@@ -1381,7 +1336,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 
 	// setup spinbox for selecting FX-channel
-	m_effectChannelNumber = new fxLineLcdSpinBox( 2, NULL, tr( "FX channel" ) );
+	m_effectChannelNumber = new FxLineLcdSpinBox( 2, NULL, tr( "FX channel" ) );
 
 	basicControlsLayout->addWidget( m_effectChannelNumber, 0, 6 );
 	basicControlsLayout->setAlignment( m_effectChannelNumber, widgetAlignment );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -471,7 +471,7 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	bool muted = m_tco->getTrack()->isMuted() || m_tco->isMuted();
 
 	// state: selected, muted, normal
-	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
+	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor()
 		: painter.background().color() );
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
@@ -507,7 +507,7 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 
 	// inner border
 	p.setPen( c.lighter( 160 ) );
-	p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH, 
+	p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH,
 		rect().bottom() - TCO_BORDER_WIDTH );
 
 	// outer border
@@ -523,7 +523,7 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 			embed::getIconPixmap( "muted", size, size ) );
 	}
 
-	// recording sample tracks is not possible at the moment 
+	// recording sample tracks is not possible at the moment
 
 	/* if( m_tco->isRecord() )
 	{
@@ -554,10 +554,12 @@ SampleTrack::SampleTrack( TrackContainer* tc ) :
 							tr( "Volume" ) ),
 	m_panningModel( DefaultPanning, PanningLeft, PanningRight, 0.1f,
 					this, tr( "Panning" ) ),
+	m_effectChannelModel( 0, 0, 0, this, tr( "FX channel" ) ),
 	m_audioPort( tr( "Sample track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel )
 {
 	setName( tr( "Sample track" ) );
 	m_panningModel.setCenterValue( DefaultPanning );
+	connect( &m_effectChannelModel, SIGNAL( dataChanged() ), this, SLOT( updateEffectChannel() ) );
 }
 
 
@@ -682,6 +684,7 @@ void SampleTrack::saveTrackSpecificSettings( QDomDocument & _doc,
 #endif
 	m_volumeModel.saveSettings( _doc, _this, "vol" );
 	m_panningModel.saveSettings( _doc, _this, "pan" );
+	m_effectChannelModel.saveSettings( _doc, _this, "fxch" );
 }
 
 
@@ -704,6 +707,8 @@ void SampleTrack::loadTrackSpecificSettings( const QDomElement & _this )
 	}
 	m_volumeModel.loadSettings( _this, "vol" );
 	m_panningModel.loadSettings( _this, "pan" );
+	m_effectChannelModel.setRange( 0, Engine::fxMixer()->numChannels() - 1 );
+	m_effectChannelModel.loadSettings( _this, "fxch" );
 }
 
 
@@ -726,6 +731,14 @@ void SampleTrack::setPlayingTcos( bool isPlaying )
 		SampleTCO * sTco = dynamic_cast<SampleTCO*>( tco );
 		sTco->setIsPlaying( isPlaying );
 	}
+}
+
+
+
+
+void SampleTrack::updateEffectChannel()
+{
+	m_audioPort.setNextFxChannel( m_effectChannelModel.value() );
 }
 
 
@@ -771,10 +784,21 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_panningKnob->setLabel( tr( "PAN" ) );
 	m_panningKnob->show();
 
+	QGridLayout * layout = new QGridLayout();
+	QWidget * layoutWrap = new QWidget();
+	layoutWrap->setLayout( layout );
+
+	m_effectChannelNumber = new FxLineLcdSpinBox( 2, NULL, tr( "FX channel" ) );
+	m_effectChannelNumber->setModel( &_t->m_effectChannelModel );
+	layout->addWidget( m_effectChannelNumber, 0, 1 );
+
+	layout->addWidget( new QLabel( "Someone with more time on their hands\nplease implement the knobs here" ), 0, 0 );
+
 	m_effectRack = new EffectRackView( _t->audioPort()->effects() );
 	m_effectRack->setFixedSize( 240, 242 );
+	layout->addWidget( m_effectRack, 1, 0 );
 
-	m_effWindow = gui->mainWindow()->addWindowedWidget( m_effectRack );
+	m_effWindow = gui->mainWindow()->addWindowedWidget( layoutWrap );
 	m_effWindow->setAttribute( Qt::WA_DeleteOnClose, false );
 	m_effWindow->layout()->setSizeConstraint( QLayout::SetFixedSize );
  	m_effWindow->setWindowTitle( _t->name() );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -812,29 +812,29 @@ QMenu * SampleTrackView::createFxMenu(QString title, QString newFxLabel)
 {
 	int channelIndex = model()->effectChannelModel()->value();
 
-	FxChannel *fxChannel = Engine::fxMixer()->effectChannel( channelIndex );
+	FxChannel *fxChannel = Engine::fxMixer()->effectChannel(channelIndex);
 
 	// If title allows interpolation, pass channel index and name
-	if ( title.contains( "%2" ) )
+	if (title.contains("%2"))
 	{
-		title = title.arg( channelIndex ).arg( fxChannel->m_name );
+		title = title.arg(channelIndex).arg(fxChannel->m_name);
 	}
 
-	QMenu *fxMenu = new QMenu( title );
+	QMenu *fxMenu = new QMenu(title);
 
 	QSignalMapper * fxMenuSignalMapper = new QSignalMapper(fxMenu);
 
-	fxMenu->addAction( newFxLabel, this, SLOT( createFxLine() ) );
+	fxMenu->addAction(newFxLabel, this, SLOT(createFxLine()));
 	fxMenu->addSeparator();
 
 	for (int i = 0; i < Engine::fxMixer()->numChannels(); ++i)
 	{
-		FxChannel * currentChannel = Engine::fxMixer()->effectChannel( i );
+		FxChannel * currentChannel = Engine::fxMixer()->effectChannel(i);
 
-		if ( currentChannel != fxChannel )
+		if (currentChannel != fxChannel)
 		{
-			QString label = tr( "FX %1: %2" ).arg( currentChannel->m_channelIndex ).arg( currentChannel->m_name );
-			QAction * action = fxMenu->addAction( label, fxMenuSignalMapper, SLOT( map() ) );
+			QString label = tr("FX %1: %2").arg(currentChannel->m_channelIndex).arg(currentChannel->m_name);
+			QAction * action = fxMenu->addAction(label, fxMenuSignalMapper, SLOT(map()));
 			fxMenuSignalMapper->setMapping(action, currentChannel->m_channelIndex);
 		}
 	}
@@ -864,11 +864,11 @@ void SampleTrackView::modelChanged()
 
 
 
-SampleTrackWindow::SampleTrackWindow(SampleTrackView * _stv) :
+SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	QWidget(),
 	ModelView(NULL, this),
-	m_track(_stv->model()),
-	m_stv(_stv)
+	m_track(tv->model()),
+	m_stv(tv)
 {
 	// init own layout + widgets
 	setFocusPolicy(Qt::StrongFocus);
@@ -954,14 +954,14 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * _stv) :
 
 	generalSettingsLayout->addLayout(basicControlsLayout);
 
-	m_effectRack = new EffectRackView(_stv->model()->audioPort()->effects());
+	m_effectRack = new EffectRackView(tv->model()->audioPort()->effects());
 	m_effectRack->setFixedSize(240, 242);
 
 	vlayout->addWidget(generalSettingsWidget);
 	vlayout->addWidget(m_effectRack);
 
 
-	setModel(_stv->model());
+	setModel(tv->model());
 
 	QMdiSubWindow * subWin = gui->mainWindow()->addWindowedWidget(this);
 	Qt::WindowFlags flags = subWin->windowFlags();
@@ -988,14 +988,14 @@ SampleTrackWindow::~SampleTrackWindow()
 
 
 
-void SampleTrackWindow::setSampleTrackView(SampleTrackView* view)
+void SampleTrackWindow::setSampleTrackView(SampleTrackView* tv)
 {
-	if(m_stv && view)
+	if(m_stv && tv)
 	{
 		m_stv->m_tlb->setChecked(false);
 	}
 
-	m_stv = view;
+	m_stv = tv;
 }
 
 
@@ -1025,7 +1025,7 @@ void SampleTrackView::createFxLine()
 {
 	int channelIndex = gui->fxMixerView()->addNewChannel();
 
-	Engine::fxMixer()->effectChannel( channelIndex )->m_name = getTrack()->name();
+	Engine::fxMixer()->effectChannel(channelIndex)->m_name = getTrack()->name();
 
 	assignFxLine(channelIndex);
 }
@@ -1036,9 +1036,9 @@ void SampleTrackView::createFxLine()
 /*! \brief Assign a specific FX Channel for this track */
 void SampleTrackView::assignFxLine(int channelIndex)
 {
-	model()->effectChannelModel()->setValue( channelIndex );
+	model()->effectChannelModel()->setValue(channelIndex);
 
-	gui->fxMixerView()->setCurrentFxLine( channelIndex );
+	gui->fxMixerView()->setCurrentFxLine(channelIndex);
 }
 
 
@@ -1055,9 +1055,9 @@ void SampleTrackWindow::updateName()
 
 
 
-void SampleTrackWindow::textChanged(const QString& newName)
+void SampleTrackWindow::textChanged(const QString& new_name)
 {
-	m_track->setName(newName);
+	m_track->setName(new_name);
 	Engine::getSong()->setModified();
 }
 
@@ -1080,9 +1080,9 @@ void SampleTrackWindow::toggleVisibility(bool on)
 
 
 
-void SampleTrackWindow::closeEvent(QCloseEvent* event)
+void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 {
-	event->ignore();
+	ce->ignore();
 
 	if(gui->mainWindow()->workspace())
 	{
@@ -1099,15 +1099,17 @@ void SampleTrackWindow::closeEvent(QCloseEvent* event)
 
 
 
-void SampleTrackWindow::saveSettings(QDomDocument& doc, QDomElement & thisElement)
+void SampleTrackWindow::saveSettings(QDomDocument& doc, QDomElement & element)
 {
+	Q_UNUSED(doc)
+	Q_UNUSED(element)
 }
 
 
 
-void SampleTrackWindow::loadSettings(const QDomElement& thisElement)
+void SampleTrackWindow::loadSettings(const QDomElement& element)
 {
-	MainWindow::restoreWidgetState(this, thisElement);
+	MainWindow::restoreWidgetState(this, element);
 	if(isVisible())
 	{
 		m_stv->m_tlb->setChecked(true);

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -27,6 +27,7 @@
 #include <QDropEvent>
 #include <QMenu>
 #include <QLayout>
+#include <QLineEdit>
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QPainter>
@@ -47,6 +48,7 @@
 #include "MainWindow.h"
 #include "Mixer.h"
 #include "EffectRackView.h"
+#include "TabWidget.h"
 #include "TrackLabelButton.h"
 
 SampleTCO::SampleTCO( Track * _track ) :
@@ -751,13 +753,13 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 {
 	setFixedHeight( 32 );
 
-	TrackLabelButton * tlb = new TrackLabelButton( this,
-						getTrackSettingsWidget() );
-	connect( tlb, SIGNAL( clicked( bool ) ),
-			this, SLOT( showEffects() ) );
-	tlb->setIcon( embed::getIconPixmap( "sample_track" ) );
-	tlb->move( 3, 1 );
-	tlb->show();
+	m_tlb = new TrackLabelButton(this, getTrackSettingsWidget());
+	m_tlb->setCheckable(true);
+	connect(m_tlb, SIGNAL(clicked( bool )),
+			this, SLOT(showEffects()));
+	m_tlb->setIcon(embed::getIconPixmap("sample_track"));
+	m_tlb->move(3, 1);
+	m_tlb->show();
 
 	m_volumeKnob = new Knob( knobSmall_17, getTrackSettingsWidget(),
 						    tr( "Track volume" ) );
@@ -784,27 +786,10 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_panningKnob->setLabel( tr( "PAN" ) );
 	m_panningKnob->show();
 
-	QGridLayout * layout = new QGridLayout();
-	QWidget * layoutWrap = new QWidget();
-	layoutWrap->setLayout( layout );
-
-	m_effectChannelNumber = new FxLineLcdSpinBox( 2, NULL, tr( "FX channel" ) );
-	m_effectChannelNumber->setModel( &_t->m_effectChannelModel );
-	layout->addWidget( m_effectChannelNumber, 0, 1 );
-
-	layout->addWidget( new QLabel( "Someone with more time on their hands\nplease implement the knobs here" ), 0, 0 );
-
-	m_effectRack = new EffectRackView( _t->audioPort()->effects() );
-	m_effectRack->setFixedSize( 240, 242 );
-	layout->addWidget( m_effectRack, 1, 0 );
-
-	m_effWindow = gui->mainWindow()->addWindowedWidget( layoutWrap );
-	m_effWindow->setAttribute( Qt::WA_DeleteOnClose, false );
-	m_effWindow->layout()->setSizeConstraint( QLayout::SetFixedSize );
- 	m_effWindow->setWindowTitle( _t->name() );
-	m_effWindow->hide();
-
 	setModel( _t );
+
+	m_window = new SampleTrackWindow(this);
+	m_window->toggleVisibility(false);
 }
 
 
@@ -812,7 +797,12 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 
 SampleTrackView::~SampleTrackView()
 {
-	m_effWindow->deleteLater();
+	if(m_window != NULL)
+	{
+		m_window->setSampleTrackView(NULL);
+		m_window->parentWidget()->hide();
+	}
+	m_window = NULL;
 }
 
 
@@ -820,16 +810,7 @@ SampleTrackView::~SampleTrackView()
 
 void SampleTrackView::showEffects()
 {
-	if( m_effWindow->isHidden() )
-	{
-		m_effectRack->show();
-		m_effWindow->show();
-		m_effWindow->raise();
-	}
-	else
-	{
-		m_effWindow->hide();
-	}
+	m_window->toggleVisibility(m_window->parentWidget()->isHidden());
 }
 
 
@@ -837,7 +818,238 @@ void SampleTrackView::showEffects()
 void SampleTrackView::modelChanged()
 {
 	SampleTrack * st = castModel<SampleTrack>();
-	m_volumeKnob->setModel( &st->m_volumeModel );
+	m_volumeKnob->setModel(&st->m_volumeModel);
 
 	TrackView::modelChanged();
 }
+
+
+
+SampleTrackWindow::SampleTrackWindow(SampleTrackView * _stv) :
+	QWidget(),
+	ModelView(NULL, this),
+	m_track(_stv->model()),
+	m_stv(_stv)
+{
+	// init own layout + widgets
+	setFocusPolicy(Qt::StrongFocus);
+	QVBoxLayout * vlayout = new QVBoxLayout(this);
+	vlayout->setMargin(0);
+	vlayout->setSpacing(0);
+
+	TabWidget* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
+
+	QVBoxLayout* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
+
+	generalSettingsLayout->setContentsMargins(8, 18, 8, 8);
+	generalSettingsLayout->setSpacing(6);
+
+	QWidget* nameWidget = new QWidget(generalSettingsWidget);
+	QHBoxLayout* nameLayout = new QHBoxLayout(nameWidget);
+	nameLayout->setContentsMargins(0, 0, 0, 0);
+	nameLayout->setSpacing(2);
+
+	// setup line edit for changing sample track name
+	m_nameLineEdit = new QLineEdit;
+	m_nameLineEdit->setFont(pointSize<9>(m_nameLineEdit->font()));
+	connect(m_nameLineEdit, SIGNAL(textChanged(const QString &)),
+				this, SLOT(textChanged(const QString &)));
+
+	m_nameLineEdit->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred));
+	nameLayout->addWidget(m_nameLineEdit);
+
+
+	generalSettingsLayout->addWidget(nameWidget);
+
+
+	QGridLayout* basicControlsLayout = new QGridLayout;
+	basicControlsLayout->setHorizontalSpacing(3);
+	basicControlsLayout->setVerticalSpacing(0);
+	basicControlsLayout->setContentsMargins(0, 0, 0, 0);
+
+	QString labelStyleSheet = "font-size: 6pt;";
+	Qt::Alignment labelAlignment = Qt::AlignHCenter | Qt::AlignTop;
+	Qt::Alignment widgetAlignment = Qt::AlignHCenter | Qt::AlignCenter;
+
+	// set up volume knob
+	m_volumeKnob = new Knob(knobBright_26, NULL, tr("Sample volume"));
+	m_volumeKnob->setVolumeKnob(true);
+	m_volumeKnob->setHintText(tr("Volume:"), "%");
+	//m_volumeKnob->setWhatsThis(tr(volume_help));
+
+	basicControlsLayout->addWidget(m_volumeKnob, 0, 0);
+	basicControlsLayout->setAlignment(m_volumeKnob, widgetAlignment);
+
+	QLabel *label = new QLabel(tr("VOL"), this);
+	label->setStyleSheet(labelStyleSheet);
+	basicControlsLayout->addWidget(label, 1, 0);
+	basicControlsLayout->setAlignment(label, labelAlignment);
+
+
+	// set up panning knob
+	m_panningKnob = new Knob(knobBright_26, NULL, tr("Panning"));
+	m_panningKnob->setHintText(tr("Panning:"), "");
+
+	basicControlsLayout->addWidget(m_panningKnob, 0, 1);
+	basicControlsLayout->setAlignment(m_panningKnob, widgetAlignment);
+
+	label = new QLabel(tr("PAN"),this);
+	label->setStyleSheet(labelStyleSheet);
+	basicControlsLayout->addWidget(label, 1, 1);
+	basicControlsLayout->setAlignment(label, labelAlignment);
+
+
+	basicControlsLayout->setColumnStretch(2, 1);
+
+
+	// setup spinbox for selecting FX-channel
+	m_effectChannelNumber = new FxLineLcdSpinBox(2, NULL, tr("FX channel"));
+
+	basicControlsLayout->addWidget(m_effectChannelNumber, 0, 3);
+	basicControlsLayout->setAlignment(m_effectChannelNumber, widgetAlignment);
+
+	label = new QLabel(tr("FX"), this);
+	label->setStyleSheet(labelStyleSheet);
+	basicControlsLayout->addWidget(label, 1, 3);
+	basicControlsLayout->setAlignment(label, labelAlignment);
+
+	generalSettingsLayout->addLayout(basicControlsLayout);
+
+	m_effectRack = new EffectRackView(_stv->model()->audioPort()->effects());
+	m_effectRack->setFixedSize(240, 242);
+
+	vlayout->addWidget(generalSettingsWidget);
+	vlayout->addWidget(m_effectRack);
+
+
+	setModel(_stv->model());
+
+	QMdiSubWindow * subWin = gui->mainWindow()->addWindowedWidget(this);
+	Qt::WindowFlags flags = subWin->windowFlags();
+	flags |= Qt::MSWindowsFixedSizeDialogHint;
+	flags &= ~Qt::WindowMaximizeButtonHint;
+	subWin->setWindowFlags(flags);
+
+	// Hide the Size and Maximize options from the system menu
+	// since the dialog size is fixed.
+	QMenu * systemMenu = subWin->systemMenu();
+	systemMenu->actions().at(2)->setVisible(false); // Size
+	systemMenu->actions().at(4)->setVisible(false); // Maximize
+
+	subWin->setWindowIcon(embed::getIconPixmap("sample_track"));
+	subWin->setFixedSize(subWin->size());
+	subWin->hide();
+}
+
+
+
+SampleTrackWindow::~SampleTrackWindow()
+{
+}
+
+
+
+void SampleTrackWindow::setSampleTrackView(SampleTrackView* view)
+{
+	if(m_stv && view)
+	{
+		m_stv->m_tlb->setChecked(false);
+	}
+
+	m_stv = view;
+}
+
+
+
+void SampleTrackWindow::modelChanged()
+{
+	m_track = castModel<SampleTrack>();
+
+	m_nameLineEdit->setText(m_track->name());
+
+	m_track->disconnect(SIGNAL(nameChanged()), this);
+
+	connect(m_track, SIGNAL(nameChanged()),
+			this, SLOT(updateName()));
+
+	m_volumeKnob->setModel(&m_track->m_volumeModel);
+	m_panningKnob->setModel(&m_track->m_panningModel);
+	m_effectChannelNumber->setModel(&m_track->m_effectChannelModel);
+
+	updateName();
+}
+
+
+
+void SampleTrackWindow::updateName()
+{
+	setWindowTitle(m_track->name().length() > 25 ? (m_track->name().left(24) + "...") : m_track->name());
+
+	if(m_nameLineEdit->text() != m_track->name())
+	{
+		m_nameLineEdit->setText(m_track->name());
+	}
+}
+
+
+
+void SampleTrackWindow::textChanged(const QString& newName)
+{
+	m_track->setName(newName);
+	Engine::getSong()->setModified();
+}
+
+
+
+void SampleTrackWindow::toggleVisibility(bool on)
+{
+	if(on)
+	{
+		show();
+		parentWidget()->show();
+		parentWidget()->raise();
+	}
+	else
+	{
+		parentWidget()->hide();
+	}
+}
+
+
+
+
+void SampleTrackWindow::closeEvent(QCloseEvent* event)
+{
+	event->ignore();
+
+	if(gui->mainWindow()->workspace())
+	{
+		parentWidget()->hide();
+	}
+	else
+	{
+		hide();
+	}
+
+	m_stv->m_tlb->setFocus();
+	m_stv->m_tlb->setChecked(false);
+}
+
+
+
+void SampleTrackWindow::saveSettings(QDomDocument& doc, QDomElement & thisElement)
+{
+}
+
+
+
+void SampleTrackWindow::loadSettings(const QDomElement& thisElement)
+{
+	MainWindow::restoreWidgetState(this, thisElement);
+	if(isVisible())
+	{
+		m_stv->m_tlb->setChecked(true);
+	}
+}
+
+#include "SampleTrack.moc"


### PR DESCRIPTION
Part of #1471 (#133)

[GIF of this feature](https://cdn.discordapp.com/attachments/250805775646064641/323215142001049622/Peek_2017-06-11_00-40.gif) (3.8 MB)

* [x] Sample Tracks can be sent to a FX channel
* [x] The selected FX channel can be saved and loaded into project files
* [ ] `DataFile::upgrade()` *(possibly not needed since the channel seems to default to 0)*
* [x] Move `fxLineLcdSpinBox` class into its own file *(and update its coding style)*
* [x] `FxLineLcdSpinBox` has special features that apply to instrument tracks only
* [x] Once closed using the `X` button and opened again, the controls no longer appear and the window is tiny
* [x] No Volume and Panning controls in the window

Collaboration would be greatly appreciated! 😊

---

Right now instrument track properties are in its own class `InstrumentTrackWindow` while sample tracks have no equivalent. That class contains the volume, panning, pitch, etc. controls.

![Proposed option(s), from #133](https://camo.githubusercontent.com/03f569685f9f04275e4aeae38a7d7c3545037199/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f363334353437332f313939373631392f63396237313635342d383532372d313165332d383536342d6631343130616166333465332e706e67)

To create the options seen in this mockup from #133 I would suggest that a new class (`TrackWindow`?) be created to contain the general options which for now are in `InstrumentTrackWindow` only. That class can then be inherited by (the currently non-existent) `SampleTrackWindow` class -- and possibly `AutomationTrackWindow` should that ever be needed.