### PR TITLE
Ogg files - Silence warning message and fix obsolete vorbis tag message

### DIFF
--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -70,8 +70,7 @@ inline int AudioFileOgg::writePage()
 bool AudioFileOgg::startEncoding()
 {
 	vorbis_comment vc;
-	const char * comments = "Cool=This song has been made using Linux "
-							"MultiMedia Studio";
+	const char * comments = "Cool=This song has been made using LMMS";
 	int comment_length = strlen( comments );
 	char * user_comments = new char[comment_length + 1];
 	strcpy( user_comments, comments );
@@ -100,7 +99,7 @@ bool AudioFileOgg::startEncoding()
 		m_rate = 48000;
 		setSampleRate( 48000 );
 	}
-	m_serialNo 	= 0;			// track-num?
+
 	m_comments 	= &vc;			// comments for ogg-file
 
 	// Have vorbisenc choose a mode for us
@@ -135,6 +134,10 @@ bool AudioFileOgg::startEncoding()
 	vorbis_analysis_init( &m_vd, &m_vi );
 	vorbis_block_init( &m_vd, &m_vb );
 
+	// We give our ogg file a random serial number and avoid
+	// 0 and UINT32_MAX which can get you into trouble.
+	qsrand( time( 0 ) );
+	m_serialNo = 0xD0000000 + qrand() % 0x0FFFFFFF;
 	ogg_stream_init( &m_os, m_serialNo );
 
 	// Now, build the three header packets and send through to the stream


### PR DESCRIPTION
We set the serial number on our generated Ogg files to 0 but it's supposed to be a [unique number](https://www.xiph.org/ogg/doc/libogg/ogg_stream_init.html).
Furthermore `0 and UINT_32_MAX `are to be avoided for some reason and that's what the message is about. Better give it some good numbers... :)
The documentation and code comments use `int` and `uint32_t` interchangeably and `uint32_t` was what we used previously so it should be fine.
Also, we stick the obsolete Linux Multimedia Studio to the end of the exported file. I change that to LMMS.

```
zonkmachine@zonkmachine:~/builds/lmms/lmms$ ogginfo ~/lmms/projects/*.ogg 
Processing file "/home/zonkmachine/lmms/projects/testfail.ogg"...

Note: Stream 1 has serial number 0, which is legal but may cause problems with some tools.
New logical stream (#1, serial: 00000000): type vorbis
Vorbis headers parsed for stream 1, information follows...
Version: 0
Vendor: Xiph.Org libVorbis I 20101101 (Schaufenugget)
Channels: 2
Rate: 44100

Nominal bitrate: 160.000000 kb/s
Upper bitrate: 160.000000 kb/s
Lower bitrate: 160.000000 kb/s
User comments section follows...
	Cool=This song has been made using Linux MultiMedia Studio
Vorbis stream 1:
	Total data length: 329973 bytes
	Playback length: 0m:16.486s
	Average bitrate: 160.121141 kb/s
Logical stream 1 ended
```

Fixed serial number (serial: faf21bb8) and message is updated.
```
Processing file "/home/zonkmachine/lmms/projects/testfixed.ogg"...

New logical stream (#1, serial: faf21bb8): type vorbis
Vorbis headers parsed for stream 1, information follows...
Version: 0
...
User comments section follows...
	Cool=This song has been made using LMMS
Vorbis stream 1:
...
Logical stream 1 ended
```