### PR TITLE
Implement command line export for MP3 (#2000)

### DIFF
--- a/doc/lmms.1
+++ b/doc/lmms.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH LMMS 1 "February 17, 2016"
+.TH LMMS 1 "June 15, 2017"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -52,6 +52,9 @@ lmms \- software for easy music production
 .RB "[ \--\fBloop\fP ]"
 .br
 .B lmms
+.RB "[ \--\fBmode\fP \fIstereomode\fP ]"
+.br
+.B lmms
 .RB "[ \--\fBoutput\fP \fIpath\fP ]"
 .br
 .B lmms
@@ -94,7 +97,7 @@ Get the configuration from \fIconfigfile\fP instead of ~/.lmmsrc.xml (default)
 .IP "\fB\-d, --dump\fP \fIin\fP
 Dump XML of compressed file \fIin\fP (i.e. MMPZ-file)
 .IP "\fB\-f, --format\fP \fIformat\fP
-Specify format of render-output where \fIformat\fP is either 'wav' or 'ogg'
+Specify format of render-output where \fIformat\fP is either 'wav', 'ogg' or 'mp3'.
 .IP "\fB\    --geometry\fP \fIgeometry\fP
 Specify the prefered size and position of the main window
 .br
@@ -111,6 +114,8 @@ Import MIDI file \fIin\fP
 If -e is specified lmms exits after importing the file.
 .IP "\fB\-l, --loop
 Render the given file as a loop, i.e. stop rendering at exactly the end of the song. Additional silence or reverb tails at the end of the song are not rendered.
+.IP "\fB\-m, --mode\fP \fIstereomode\fP
+Set the stereo mode used for the MP3 export. \fIstereomode\fP can be either 's' (stereo mode), 'j' (joint stereo) or 'm' (mono). If no mode is given 'j' is used as the default.
 .IP "\fB\-o, --output\fP \fIpath\fP
 Render into \fIpath\fP
 .br

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -124,6 +124,7 @@ void printHelp()
 		"            [ -i <method> ]\n"
 		"            [ --import <in> [-e]]\n"
 		"            [ -l ]\n"
+		"            [ -m <mode>]\n"
 		"            [ -o <path> ]\n"
 		"            [ -p <out> ]\n"
 		"            [ -r <project file> ] [ options ]\n"
@@ -138,7 +139,7 @@ void printHelp()
 		"-c, --config <configfile>     Get the configuration from <configfile>\n"
 		"-d, --dump <in>               Dump XML of compressed file <in>\n"
 		"-f, --format <format>         Specify format of render-output where\n"
-		"       Format is either 'wav' or 'ogg'.\n"
+		"       Format is either 'wav', 'ogg' or 'mp3'.\n"
 		"    --geometry <geometry>     Specify the size and position of the main window\n"
 		"       geometry is <xsizexysize+xoffset+yoffsety>.\n"
 		"-h, --help                    Show this usage information and exit.\n"
@@ -151,6 +152,12 @@ void printHelp()
 		"    --import <in> [-e]        Import MIDI file <in>.\n"
 		"       If -e is specified lmms exits after importing the file.\n"
 		"-l, --loop                    Render as a loop\n"
+		"-m, --mode                    Stereo mode used for MP3 export\n"
+		"       Possible values: s, j, m\n"
+		"         s: Stereo\n"
+		"         j: Joint Stereo\n"
+		"         m: Mono\n"
+		"       Default: j\n"
 		"-o, --output <path>           Render into <path>\n"
 		"       For --render, provide a file path\n"
 		"       For --rendertracks, provide a directory path\n"
@@ -260,7 +267,7 @@ int main( int argc, char * * argv )
 					new MainApplication( argc, argv );
 
 	Mixer::qualitySettings qs( Mixer::qualitySettings::Mode_HighQuality );
-	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::Depth_16Bit );
+	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::Depth_16Bit, OutputSettings::StereoMode_JointStereo );
 	ProjectRenderer::ExportFileFormats eff = ProjectRenderer::WaveFile;
 
 	// second of two command-line parsing stages
@@ -392,6 +399,12 @@ int main( int argc, char * * argv )
 				eff = ProjectRenderer::OggFile;
 			}
 #endif
+#ifdef LMMS_HAVE_MP3LAME
+			else if( ext == "mp3" )
+			{
+				eff = ProjectRenderer::MP3File;
+			}
+#endif
 			else
 			{
 				printf( "\nInvalid output format %s.\n\n"
@@ -446,6 +459,38 @@ int main( int argc, char * * argv )
 			else
 			{
 				printf( "\nInvalid bitrate %s.\n\n"
+	"Try \"%s --help\" for more information.\n\n", argv[i], argv[0] );
+				return EXIT_FAILURE;
+			}
+		}
+		else if( arg == "--mode" || arg == "-m" )
+		{
+			++i;
+
+			if( i == argc )
+			{
+				printf( "\nNo stereo mode specified.\n\n"
+	"Try \"%s --help\" for more information.\n\n", argv[0] );
+				return EXIT_FAILURE;
+			}
+
+			QString const mode( argv[i] );
+
+			if( mode == "s" )
+			{
+				os.setStereoMode(OutputSettings::StereoMode_Stereo);
+			}
+			else if( mode == "j" )
+			{
+				os.setStereoMode(OutputSettings::StereoMode_JointStereo);
+			}
+			else if( mode == "m" )
+			{
+				os.setStereoMode(OutputSettings::StereoMode_Mono);
+			}
+			else
+			{
+				printf( "\nInvalid stereo mode %s.\n\n"
 	"Try \"%s --help\" for more information.\n\n", argv[i], argv[0] );
 				return EXIT_FAILURE;
 			}


### PR DESCRIPTION
Add the option 'mp3' to the format switch (-f / --format) if LMMS is compiled with MP3 support. Add the new switch 'mode' which can be used to set the stereo mode used for the MP3 export.

Adjust the man page for the new options.