### PR TITLE
Add tooltip for refresh button in FileBrowser

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -92,6 +92,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	QPushButton * reload_btn = new QPushButton(
 				embed::getIconPixmap( "reload" ),
 						QString::null, searchWidget );
+	reload_btn->setToolTip( tr( "Refresh list" ) );
 	connect( reload_btn, SIGNAL( clicked() ), this, SLOT( reloadTree() ) );
 
 	searchWidgetLayout->addWidget( m_filterEdit );


### PR DESCRIPTION
It seems that some users (on Discord) don't know what this button does, and I noticed that it doesn't have a tooltip. This patch should help at least a bit.