### PR TITLE
Ensure midi port exists before removing

### DIFF
--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -67,6 +67,11 @@ void MidiClient::addPort( MidiPort* port )
 
 void MidiClient::removePort( MidiPort* port )
 {
+	if( ! port )
+	{
+		return;
+	}
+
 	QVector<MidiPort *>::Iterator it =
 		qFind( m_midiPorts.begin(), m_midiPorts.end(), port );
 	if( it != m_midiPorts.end() )


### PR DESCRIPTION
I got a crash on closing so I reference this to issue https://github.com/LMMS/lmms/issues/2633.

Unfortunately I can't replicate the crash to test the fix. I've tried turning on/off my midi keyboard before closing but so far I haven't had the fortune of another malfunction.

In this crash in particular it failed on qFind ([here](https://github.com/LMMS/lmms/blob/stable-1.2/src/core/midi/MidiClient.cpp#L71)) so I suspect it was because of bad data in.
`#9  0x0000000000579043 in MidiClient::removePort (this=0x29758f0, port=0x7fa4c40a89a8) at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiClient.cpp:71`

Does this sound plausible?


```

Program terminated with signal SIGABRT, Aborted.
#0  0x00007fa4cd366c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
56	../nptl/sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  0x00007fa4cd366c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#1  0x00007fa4cd36a028 in __GI_abort () at abort.c:89
#2  0x00007fa4cfae8c92 in qt_message_output (msgType=msgType@entry=QtFatalMsg, 
    buf=0x285dec8 "ASSERT: \"asize <= aalloc\" in file /usr/include/qt4/QtCore/qvector.h, line 474") at global/qglobal.cpp:2383
#3  0x00007fa4cfae8ff9 in qt_message(QtMsgType, const char *, typedef __va_list_tag __va_list_tag *) (msgType=msgType@entry=QtFatalMsg, 
    msg=0x7fa4cfc56a20 "ASSERT: \"%s\" in file %s, line %d", ap=ap@entry=0x7ffcf27f81f8) at global/qglobal.cpp:2429
#4  0x00007fa4cfae9804 in qFatal (msg=<optimized out>) at global/qglobal.cpp:2612
#5  0x0000000000579bbf in QVector<MidiPort*>::realloc (this=0x29758f8, asize=56747520, aalloc=0) at /usr/include/qt4/QtCore/qvector.h:474
#6  0x0000000000579eb2 in QVector<MidiPort*>::detach_helper (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:337
#7  0x0000000000579a24 in QVector<MidiPort*>::detach (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:147
#8  0x00000000005797c2 in QVector<MidiPort*>::end (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:250
#9  0x0000000000579043 in MidiClient::removePort (this=0x29758f0, port=0x7fa4c40a89a8) at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiClient.cpp:71
#10 0x000000000057bffa in MidiPort::~MidiPort (this=0x7fa4c40a89a8, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiPort.cpp:93
#11 0x000000000057a109 in MidiController::~MidiController (this=0x7fa4c40a8920, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiController.cpp:51
#12 0x000000000057a166 in MidiController::~MidiController (this=0x7fa4c40a8920, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiController.cpp:53
#13 0x00007fa4cfc0c168 in QObjectPrivate::deleteChildren (this=this@entry=0x26f38e0) at kernel/qobject.cpp:1907
```

```

(gdb) bt full
#0  0x00007fa4cd366c37 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
        resultvar = 0
        pid = 11019
        selftid = 11019
#1  0x00007fa4cd36a028 in __GI_abort () at abort.c:89
        save_stage = 2
        act = {__sigaction_handler = {sa_handler = 0x7ffcf27f8190, sa_sigaction = 0x7ffcf27f8190}, sa_mask = {__val = {140724376928672, 42327752, 
              140345858389751, 140720308486149, 0, 140345835254464, 140345794063664, 3, 42327752, 140724376928544, 140345858418341, 1, 2147483648, 
              140345840351168, 10, 140345840351192}}, sa_flags = -786049088, sa_restorer = 0x726f4374512f3474}
        sigs = {__val = {32, 0 <repeats 15 times>}}
#2  0x00007fa4cfae8c92 in qt_message_output (msgType=msgType@entry=QtFatalMsg, 
    buf=0x285dec8 "ASSERT: \"asize <= aalloc\" in file /usr/include/qt4/QtCore/qvector.h, line 474") at global/qglobal.cpp:2383
No locals.
#3  0x00007fa4cfae8ff9 in qt_message(QtMsgType, const char *, typedef __va_list_tag __va_list_tag *) (msgType=msgType@entry=QtFatalMsg, 
    msg=0x7fa4cfc56a20 "ASSERT: \"%s\" in file %s, line %d", ap=ap@entry=0x7ffcf27f81f8) at global/qglobal.cpp:2429
        buf = {static shared_null = {ref = {_q_value = 79}, alloc = 0, size = 0, data = 0x7fa4cff5b7d8 <QByteArray::shared_null+24> "", array = ""}, 
          static shared_empty = {ref = {_q_value = 2}, alloc = 0, size = 0, data = 0x7fa4cff5b7b8 <QByteArray::shared_empty+24> "", array = ""}, 
          d = 0x285deb0}
#4  0x00007fa4cfae9804 in qFatal (msg=<optimized out>) at global/qglobal.cpp:2612
        ap = {{gp_offset = 32, fp_offset = 48, overflow_arg_area = 0x7ffcf27f82d0, reg_save_area = 0x7ffcf27f8210}}
#5  0x0000000000579bbf in QVector<MidiPort*>::realloc (this=0x29758f8, asize=56747520, aalloc=0) at /usr/include/qt4/QtCore/qvector.h:474
        x = {d = 0x2edbe6ff, p = 0x2edbe6ff}
#6  0x0000000000579eb2 in QVector<MidiPort*>::detach_helper (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:337
No locals.
#7  0x0000000000579a24 in QVector<MidiPort*>::detach (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:147
No locals.
#8  0x00000000005797c2 in QVector<MidiPort*>::end (this=0x29758f8) at /usr/include/qt4/QtCore/qvector.h:250
No locals.
#9  0x0000000000579043 in MidiClient::removePort (this=0x29758f0, port=0x7fa4c40a89a8) at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiClient.cpp:71
        it = 0x7fa4c40a9180
#10 0x000000000057bffa in MidiPort::~MidiPort (this=0x7fa4c40a89a8, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiPort.cpp:93
No locals.
#11 0x000000000057a109 in MidiController::~MidiController (this=0x7fa4c40a8920, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiController.cpp:51
No locals.
#12 0x000000000057a166 in MidiController::~MidiController (this=0x7fa4c40a8920, __in_chrg=<optimized out>)
    at /home/zonkmachine/builds/lmms/lmms/src/core/midi/MidiController.cpp:53
No locals.
#13 0x00007fa4cfc0c168 in QObjectPrivate::deleteChildren (this=this@entry=0x26f38e0) at kernel/qobject.cpp:1907
        i = 0
        reallyWasDeleted = true

```