### PR TITLE
Move the search bar on top of the file browser for sidebar pages (#3657)

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -65,7 +65,7 @@ private:
 
 	void addItems( const QString & path );
 
-	FileBrowserTreeWidget * m_l;
+	FileBrowserTreeWidget * m_fileBrowserTreeWidget;
 
 	QLineEdit * m_filterEdit;
 


### PR DESCRIPTION
Move the search bar on top of the file browser for the following sidebar windows:
* "My Projects"
* "My Samples"
* "My Presets"
* "My Home"
* "My Computer"

Also rename some variable names to something more meaningful. Rename the member `m_l` of `FileBrowser` to `m_fileBrowserTreeWidget`. Rename the following local variables in the constructor of `FileBrowser`:
* `ops` -> `searchWidget`
* `opl` -> `searchWidgetLayout`