### PR TITLE
Cancel track rename by pressing Escape key

### DIFF
--- a/include/TrackRenameLineEdit.h
+++ b/include/TrackRenameLineEdit.h
@@ -1,7 +1,8 @@
 /*
- * TrackLabelButton.h - class trackLabelButton
+ * TrackRenameLineEdit.h - class TrackRenameLineEdit
  *
  * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2017 Alexandre Almeida <http://m374lx.users.sourceforge.net/>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -23,48 +24,23 @@
  */
 
 
-#ifndef TRACK_LABEL_BUTTON_H
-#define TRACK_LABEL_BUTTON_H
+#ifndef TRACK_RENAME_LINE_EDIT_H
+#define TRACK_RENAME_LINE_EDIT_H
 
-#include <QToolButton>
 #include <QLineEdit>
 
-class TrackView;
-
-class TrackRenameLineEdit;
-
-
-class TrackLabelButton : public QToolButton
+class TrackRenameLineEdit : public QLineEdit
 {
 	Q_OBJECT
 public:
-	TrackLabelButton( TrackView * _tv, QWidget * _parent );
-	virtual ~TrackLabelButton();
-
-
-public slots:
-	void rename();
-	void renameFinished();
-	void nameChanged();
-
-
+	TrackRenameLineEdit( QWidget * parent );
+	void show();
+	
 protected:
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
-	virtual void mouseReleaseEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
-	virtual void resizeEvent( QResizeEvent * _re );
-
-
+	virtual void keyPressEvent( QKeyEvent * ke );
+	
 private:
-	TrackView * m_trackView;
-	QString m_iconName;
-	TrackRenameLineEdit * m_renameLineEdit;
-	QRect m_buttonRect;
-	QString elideName( const QString &name );
-
+	QString m_oldName;
 } ;
 
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(LMMS_SRCS
 	gui/widgets/ToolButton.cpp
 	gui/widgets/ToolTip.cpp
 	gui/widgets/TrackLabelButton.cpp
+	gui/widgets/TrackRenameLineEdit.cpp
 	gui/widgets/VisualizationWidget.cpp
 
 	PARENT_SCOPE

--- a/src/gui/widgets/TrackLabelButton.cpp
+++ b/src/gui/widgets/TrackLabelButton.cpp
@@ -36,6 +36,7 @@
 #include "InstrumentTrack.h"
 #include "RenameDialog.h"
 #include "Song.h"
+#include "TrackRenameLineEdit.h"
 
 
 
@@ -48,7 +49,7 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	setAcceptDrops( true );
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
-	m_renameLineEdit = new QLineEdit( this );
+	m_renameLineEdit = new TrackRenameLineEdit( this );
 	m_renameLineEdit->hide();
 	
 	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
@@ -83,8 +84,8 @@ void TrackLabelButton::rename()
 	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
 	{
 		QString txt = m_trackView->getTrack()->name();
-		RenameDialog rename_dlg( txt );
-		rename_dlg.exec();
+		RenameDialog renameDlg( txt );
+		renameDlg.exec();
 		if( txt != text() )
 		{
 			m_trackView->getTrack()->setName( txt );

--- a/src/gui/widgets/TrackRenameLineEdit.cpp
+++ b/src/gui/widgets/TrackRenameLineEdit.cpp
@@ -1,0 +1,61 @@
+/*
+ * TrackRenameLineEdit.cpp - implementation of class TrackRenameLineEdit, which
+ * 							 represents the text field that appears when one
+ *							 double-clicks a track's label to rename it
+ *
+ * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2017 Alexandre Almeida <http://m374lx.users.sourceforge.net/>
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#include "TrackRenameLineEdit.h"
+
+#include <QKeyEvent>
+
+
+
+TrackRenameLineEdit::TrackRenameLineEdit( QWidget * parent ) :
+	QLineEdit( parent )
+{
+}
+
+
+
+
+void TrackRenameLineEdit::show()
+{
+	m_oldName = text();
+	QLineEdit::show();
+}
+
+
+
+
+void TrackRenameLineEdit::keyPressEvent( QKeyEvent * ke )
+{
+	if( ke->key() == Qt::Key_Escape ) 
+	{
+		setText( m_oldName );
+		hide();
+	}
+	
+	QLineEdit::keyPressEvent( ke );
+}


### PR DESCRIPTION
With this pull request, the user is able to cancel a track rename action by pressing the Escape key.

Also renamed ```rename_dlg``` to ```renameDlg``` in ```TrackLabelButton::rename()``` so it complies to the naming conventions.

Fixes #3675. 