### PR TITLE
MIDI - Don't apply base velocity to all controller values

### DIFF
--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -129,11 +129,11 @@ void MidiPort::processInEvent( const MidiEvent& event, const MidiTime& time )
 			{
 				return;
 			}
-		}
 
-		if( fixedInputVelocity() >= 0 && inEvent.velocity() > 0 )
-		{
-			inEvent.setVelocity( fixedInputVelocity() );
+			if( fixedInputVelocity() >= 0 && inEvent.velocity() > 0 )
+			{
+				inEvent.setVelocity( fixedInputVelocity() );
+			}
 		}
 
 		m_midiEventProcessor->processInEvent( inEvent, time );


### PR DESCRIPTION
I noticed the sustain pedal was affected by setting the base velocity. Turn down the velocity under MIDI settings and eventually the threshold for value 'on' (64) is no longer reached. I've moved that part of the code in `MidiPort::processInEvent()` to within the part handling note on/off/keypressure.
I haven't tried this with other control messages than sustain yet.