### PR TITLE
Clean up after render in ProjectRenderer destructor

### DIFF
--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -103,6 +103,8 @@ ProjectRenderer::ProjectRenderer( const Mixer::qualitySettings & qualitySettings
 
 ProjectRenderer::~ProjectRenderer()
 {
+	Engine::mixer()->restoreAudioDevice();  // also deletes audio-dev
+	Engine::mixer()->changeQuality( m_oldQualitySettings );
 }
 
 
@@ -201,12 +203,8 @@ void ProjectRenderer::run()
 
 	Engine::getSong()->stopExport();
 
-	const QString f = m_fileDev->outputFile();
-
-	Engine::mixer()->restoreAudioDevice();  // also deletes audio-dev
-	Engine::mixer()->changeQuality( m_oldQualitySettings );
-
 	// if the user aborted export-process, the file has to be deleted
+	const QString f = m_fileDev->outputFile();
 	if( m_abort )
 	{
 		QFile( f ).remove();


### PR DESCRIPTION
We need to wait with calling Mixer::restoreAudioDevice() and
Mixer::changeQuality() after render until all threads have stopped.
Moving these calls to ProjectRenderer::~ProjectRenderer() ensures
all render theads are done.

Fixes #3555 

_Edit: This works just fine..._