### PR TITLE
Add CMake option to enable the debugging of floating point exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ OPTION(WANT_VST		"Include VST support" ON)
 OPTION(WANT_VST_NOWINE	"Include partial VST support (without wine)" OFF)
 OPTION(WANT_WINMM	"Include WinMM MIDI support" OFF)
 OPTION(WANT_QT5		"Build with Qt5" OFF)
+OPTION(WANT_DEBUG_FPE	"Debug floating point exceptions" OFF)
 
 
 IF(LMMS_BUILD_APPLE)
@@ -420,6 +421,17 @@ IF(LMMS_BUILD_WIN32)
 	SET(STATUS_VST "OK")
 ENDIF(LMMS_BUILD_WIN32)
 
+IF(WANT_DEBUG_FPE)
+	IF(LMMS_BUILD_LINUX)
+		SET(LMMS_DEBUG_FPE TRUE)
+		SET (STATUS_DEBUG_FPE "Enabled")
+	ELSE()
+		SET (STATUS_DEBUG_FPE "Wanted but disabled due to unsupported platform")
+	ENDIF()
+ELSE()
+	SET (STATUS_DEBUG_FPE "Disabled")
+ENDIF(WANT_DEBUG_FPE)
+
 
 # check for libsamplerate
 PKG_CHECK_MODULES(SAMPLERATE REQUIRED samplerate>=0.1.8)
@@ -597,6 +609,12 @@ MESSAGE(
 "* TAP LADSPA plugins          : ${STATUS_TAP}\n"
 "* SWH LADSPA plugins          : ${STATUS_SWH}\n"
 "* GIG player                  : ${STATUS_GIG}\n"
+)
+
+MESSAGE(
+"Developer options\n"
+"-----------------------------------------\n"
+"* Debug FP exceptions         : ${STATUS_DEBUG_FPE}\n"
 )
 
 MESSAGE(

--- a/src/lmmsconfig.h.in
+++ b/src/lmmsconfig.h.in
@@ -21,6 +21,8 @@
 #cmakedefine LMMS_HAVE_STK
 #cmakedefine LMMS_HAVE_VST
 
+#cmakedefine LMMS_DEBUG_FPE
+
 #cmakedefine LMMS_HAVE_STDINT_H
 #cmakedefine LMMS_HAVE_STDLIB_H
 #cmakedefine LMMS_HAVE_PTHREAD_H


### PR DESCRIPTION
Add a new CMake option `WANT_DEBUG_FPE` which adds the define
`LMMS_DEBUG_FPE` if activated. Extend `lmmsconfig.h.in` with regards to that
define. Include information about development options to the CMake
output.

Install a signal handler to trap floating point exceptions when starting
LMMS in case it is compiled using the option described above. The
current implementation of the signal handler prints a stack trace and
then exits the application.

Currently this option is only enabled for Linux builds due to
uncertainty with regards to which of the needed headers are supported by
Windows and Apple.