### PR TITLE
Fix #3674: Pattern names difficult to read

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -596,6 +596,7 @@ TrackContentObjectView   {
 PatternView {
 	background-color: rgb( 119, 199, 216 );
 	color: rgb( 187, 227, 236 );
+	font-size: 11px;
 }
 
 /* sample track pattern */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -615,6 +615,7 @@ TrackContentObjectView   {
 PatternView {
 	background-color: #21A14F;
 	color: rgba(255,255,255,220);
+	font-size: 11px;
 }
 
 /* sample track pattern */

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1076,15 +1076,14 @@ void PatternView::paintEvent( QPaintEvent * )
 	{
 		p.setRenderHint( QPainter::TextAntialiasing );
 
-		QFont font;
-		font.setHintingPreference( QFont::PreferFullHinting );
-		font.setPointSize( 8 );
-		p.setFont( font );
+		QFont labelFont = this->font();
+		labelFont.setHintingPreference( QFont::PreferFullHinting );
+		p.setFont( labelFont );
 
 		const int textTop = TCO_BORDER_WIDTH + 1;
 		const int textLeft = TCO_BORDER_WIDTH + 3;
 
-		QFontMetrics fontMetrics(font);
+		QFontMetrics fontMetrics(labelFont);
 		QString elidedPatternName = fontMetrics.elidedText(m_pat->name(), Qt::ElideMiddle, width() - 2 * textLeft);
 
 		QColor transparentBlack(0, 0, 0, 75);
@@ -1110,7 +1109,7 @@ void PatternView::paintEvent( QPaintEvent * )
 	p.setPen( ( current && !beatPattern ) ? c.lighter( 130 ) : c.darker( 300 ) );
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
 	}
-	// draw the 'muted' pixmap only if the pattern was manualy muted
+	// draw the 'muted' pixmap only if the pattern was manually muted
 	if( m_pat->isMuted() )
 	{
 		const int spacing = TCO_BORDER_WIDTH;

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1070,27 +1070,31 @@ void PatternView::paintEvent( QPaintEvent * )
 	}
 
 	// pattern name
-	p.setRenderHint( QPainter::TextAntialiasing );
-
 	bool isDefaultName = m_pat->name() == m_pat->instrumentTrack()->name();
 
-	if( !isDefaultName && m_staticTextName.text() != m_pat->name() )
+	if (!beatPattern && !isDefaultName)
 	{
-		m_staticTextName.setText( m_pat->name() );
-	}
+		p.setRenderHint( QPainter::TextAntialiasing );
 
-	QFont font;
-	font.setHintingPreference( QFont::PreferFullHinting );
-	font.setPointSize( 8 );
-	p.setFont( font );
+		QFont font;
+		font.setHintingPreference( QFont::PreferFullHinting );
+		font.setPointSize( 8 );
+		p.setFont( font );
 
-	const int textTop = TCO_BORDER_WIDTH + 1;
-	const int textLeft = TCO_BORDER_WIDTH + 1;
+		const int textTop = TCO_BORDER_WIDTH + 1;
+		const int textLeft = TCO_BORDER_WIDTH + 3;
 
-	if( !isDefaultName )
-	{
-		p.setPen( textShadowColor() );
-		p.drawStaticText( textLeft + 1, textTop + 1, m_staticTextName );
+		QFontMetrics fontMetrics(font);
+		QString elidedPatternName = fontMetrics.elidedText(m_pat->name(), Qt::ElideMiddle, width() - 2 * textLeft);
+
+		QColor transparentBlack(0, 0, 0, 75);
+		p.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), transparentBlack);
+
+		if( m_staticTextName.text() != elidedPatternName )
+		{
+			m_staticTextName.setText( elidedPatternName );
+		}
+
 		p.setPen( textColor() );
 		p.drawStaticText( textLeft, textTop, m_staticTextName );
 	}


### PR DESCRIPTION
Make the pattern names better readable by rendering them on top of a semitransparent black rectangle. Elide the text and make it render a bit more to the right.

Use the font properties that are defined in the CSS to draw the pattern labels. This provides flexibility with regards to the font properties that are used (size, font family, etc.).

Adjust the CSS for the default theme and the classic theme.