### PR TITLE
Restore the track height when loading files

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2150,10 +2150,10 @@ void Track::loadSettings( const QDomElement & element )
 		node = node.nextSibling();
 	}
 
-	if( element.attribute( "height" ).toInt() >= MINIMAL_TRACK_HEIGHT &&
-		element.attribute( "height" ).toInt() <= DEFAULT_TRACK_HEIGHT )	// workaround for #3585927, tobydox/2012-11-11
+	int storedHeight = element.attribute( "height" ).toInt();
+	if( storedHeight >= MINIMAL_TRACK_HEIGHT )
 	{
-		m_height = element.attribute( "height" ).toInt();
+		m_height = storedHeight;
 	}
 }
 


### PR DESCRIPTION
The track height is already stored for every file that is saved. Remove a
condition that prevents its retrieval from files.

The removed condition was added as a fix for an issue with the number
3585927 but it was not possible anymore to find out what this issue was
about.