### PR TITLE
Draw notes as rectangles and only move them below the text label at small heights

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -624,6 +624,11 @@ TrackContentObjectView   {
 PatternView {
 	background-color: rgb( 119, 199, 216 );
 	color: rgb( 187, 227, 236 );
+
+	qproperty-noteFillColor: rgb( 187, 227, 236 );
+	qproperty-noteBorderColor: rgb( 119, 199, 216 );
+	qproperty-mutedNoteFillColor: rgb( 128, 128, 128 );
+	qproperty-mutedNoteBorderColor: rgb( 80, 80, 80 );
 }
 
 /* sample track pattern */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -631,6 +631,11 @@ TrackContentObjectView   {
 PatternView {
 	background-color: #21A14F;
 	color: rgba(255,255,255,220);
+
+	qproperty-noteFillColor: rgba(255, 255, 255, 220);
+	qproperty-noteBorderColor: rgb(33, 161, 79);
+	qproperty-mutedNoteFillColor: rgba(100, 100, 100, 220);
+	qproperty-mutedNoteBorderColor: rgb(55, 61, 72);
 }
 
 /* sample track pattern */

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -165,6 +165,22 @@ public:
 	PatternView( Pattern* pattern, TrackView* parent );
 	virtual ~PatternView();
 
+	Q_PROPERTY(QColor noteFillColor READ getNoteFillColor WRITE setNoteFillColor)
+	Q_PROPERTY(QColor noteBorderColor READ getNoteBorderColor WRITE setNoteBorderColor)
+	Q_PROPERTY(QColor mutedNoteFillColor READ getMutedNoteFillColor WRITE setMutedNoteFillColor)
+	Q_PROPERTY(QColor mutedNoteBorderColor READ getMutedNoteBorderColor WRITE setMutedNoteBorderColor)
+
+	QColor const & getNoteFillColor() const { return m_noteFillColor; }
+	void setNoteFillColor(QColor const & color) { m_noteFillColor = color; }
+
+	QColor const & getNoteBorderColor() const { return m_noteBorderColor; }
+	void setNoteBorderColor(QColor const & color) { m_noteBorderColor = color; }
+
+	QColor const & getMutedNoteFillColor() const { return m_mutedNoteFillColor; }
+	void setMutedNoteFillColor(QColor const & color) { m_mutedNoteFillColor = color; }
+
+	QColor const & getMutedNoteBorderColor() const { return m_mutedNoteBorderColor; }
+	void setMutedNoteBorderColor(QColor const & color) { m_mutedNoteBorderColor = color; }
 
 public slots:
 	virtual void update();
@@ -193,6 +209,11 @@ private:
 
 	Pattern* m_pat;
 	QPixmap m_paintPixmap;
+
+	QColor m_noteFillColor;
+	QColor m_noteBorderColor;
+	QColor m_mutedNoteFillColor;
+	QColor m_mutedNoteBorderColor;
 
 	QStaticText m_staticTextName;
 } ;

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -599,7 +599,11 @@ void Pattern::changeTimeSignature()
 PatternView::PatternView( Pattern* pattern, TrackView* parent ) :
 	TrackContentObjectView( pattern, parent ),
 	m_pat( pattern ),
-	m_paintPixmap()
+	m_paintPixmap(),
+	m_noteFillColor(255, 255, 255, 220),
+	m_noteBorderColor(255, 255, 255, 220),
+	m_mutedNoteFillColor(100, 100, 100, 220),
+	m_mutedNoteBorderColor(100, 100, 100, 220)
 {
 	connect( gui->pianoRoll(), SIGNAL( currentPatternChanged() ),
 			this, SLOT( update() ) );
@@ -910,9 +914,9 @@ void PatternView::paintEvent( QPaintEvent * )
 	bool const isDefaultName = m_pat->name() == m_pat->instrumentTrack()->name();
 	bool const drawTextBox = !beatPattern && !isDefaultName;
 
+	// TODO Warning! This might cause problems if TrackContentObjectView::paintTextLabel changes
 	int textBoxHeight = 0;
 	const int textTop = TCO_BORDER_WIDTH + 1;
-	const int textLeft = TCO_BORDER_WIDTH + 3;
 	if (drawTextBox)
 	{
 		QFont labelFont = this->font();
@@ -997,16 +1001,17 @@ void PatternView::paintEvent( QPaintEvent * )
 		p.scale(width(), height() - distanceToTop - 2 * notesBorder);
 
 		// set colour based on mute status
-		QColor const noteColor = muted ? mutedColor() : painter.pen().brush().color();
+		QColor noteFillColor = muted ? getMutedNoteFillColor() : getNoteFillColor();
+		QColor noteBorderColor = muted ? getMutedNoteBorderColor() : getNoteBorderColor();
 
 		bool const drawAsLines = height() < 64;
 		if (drawAsLines)
 		{
-			p.setPen( noteColor );
+			p.setPen(noteFillColor);
 		}
 		else
 		{
-			p.setPen( noteColor.darker() );
+			p.setPen(noteBorderColor);
 			p.setRenderHint(QPainter::Antialiasing);
 		}
 
@@ -1038,7 +1043,7 @@ void PatternView::paintEvent( QPaintEvent * )
 			}
 			else
 			{
-				p.fillRect( noteRectF, noteColor );
+				p.fillRect( noteRectF, noteFillColor );
 				p.drawRect( noteRectF );
 			}
 		}


### PR DESCRIPTION
Draw the notes as antialiased rectangles with a slightly darker border if the height of the pattern is larger than 64 pixels. Otherwise draw them as lines (as before).

Move the notes underneath the text label at small sizes but otherwise draw them below to enhance readability.

Always draw at least an octave of notes onto the pattern, so that patterns with just a single note will not look strange, i.e. make sure that a patterns is not completely filled with a single note. If there is additional space to fill it will be rather filled at the top of the pattern so that single notes have a high chance of being drawn below the pattern text.

Add a border of four pixels at the top and bottom of the area where the notes are drawn so they don't get pushed under the pattern borders.

Set the transparency of the text label to 100.

Technical details:
Transform the `QPainter` so that notes drawn into a [0,1] x [0,1] coordinate system are drawn at the correct position on the pattern widget. 

Other fixes:
* Remove some redundant checks whether the pattern holds notes and decrease the indentation depth by two tabs for most of the code.
* Simplify the drawing of the inner and outer border.
* Use `numeric_limits` to initialize the minimum and maximum key.
* Remove an unnecessary assignment to a pixmap
* Move code closer to where it is needed
* Remove an unnecessary call to `QPainter::end()`