### PR TITLE
Calling delete[] without new[]

### DIFF
--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -93,7 +93,8 @@ private:
 		while( true )
 		{
 			timer.reset();
-			const surroundSampleFrame* b = mixer()->nextBuffer();
+			const surroundSampleFrame* b = new surroundSampleFrame[ mixer()->framesPerPeriod() ];
+			b = mixer()->nextBuffer();
 			if( !b )
 			{
 				break;


### PR DESCRIPTION
Possible fix for https://github.com/LMMS/lmms/issues/2633
Crashing on close with DummyAudio

A [comment](https://github.com/LMMS/lmms/issues/2633#issuecomment-195655709) from @Lukas-W points to the crash taking place on [deleting a pointer](https://github.com/LMMS/lmms/blob/master/include/AudioDummy.h#L104) to an array. The latter wasn't created with new[] and that's supposedly a no-no. I've tested this but since I couldn't replicate the crash itself I can't verify the fix.