### PR TITLE
Remove explicit time calculations from Song and TimeLineWidget

### DIFF
--- a/include/MidiTime.h
+++ b/include/MidiTime.h
@@ -90,12 +90,15 @@ public:
 	// calculate number of frame that are needed this time
 	f_cnt_t frames( const float framesPerTick ) const;
 
+	double getTimeInMilliseconds(bpm_t beatsPerMinute) const;
+
 	static MidiTime fromFrames( const f_cnt_t frames, const float framesPerTick );
 	static tick_t ticksPerTact();
 	static tick_t ticksPerTact( const TimeSig &sig );
 	static int stepsPerTact();
 	static void setTicksPerTact( tick_t tpt );
 	static MidiTime stepPosition( int step );
+	static double ticksToMilliseconds(tick_t ticks, bpm_t beatsPerMinute);
 
 private:
 	tick_t m_ticks;

--- a/include/Song.h
+++ b/include/Song.h
@@ -101,14 +101,22 @@ public:
 	{
 		return m_nLoadingTrack;
 	}
+
 	inline int getMilliseconds() const
 	{
 		return m_elapsedMilliSeconds;
 	}
-	inline void setMilliSeconds( float ellapsedMilliSeconds )
+
+	inline void setToTime( MidiTime const & midiTime )
 	{
-		m_elapsedMilliSeconds = ellapsedMilliSeconds;
+		m_elapsedMilliSeconds = midiTime.getTimeInMilliseconds(getTempo());
 	}
+
+	inline void setToTimeByTicks(tick_t ticks)
+	{
+		m_elapsedMilliSeconds = MidiTime::ticksToMilliseconds(ticks, getTempo());
+	}
+
 	inline int getTacts() const
 	{
 		return currentTact();

--- a/src/core/midi/MidiTime.cpp
+++ b/src/core/midi/MidiTime.cpp
@@ -155,6 +155,10 @@ f_cnt_t MidiTime::frames( const float framesPerTick ) const
 	return 0;
 }
 
+double MidiTime::getTimeInMilliseconds(bpm_t beatsPerMinute) const
+{
+	return ticksToMilliseconds(getTicks(), beatsPerMinute);
+}
 
 MidiTime MidiTime::fromFrames( const f_cnt_t frames, const float framesPerTick )
 {
@@ -190,4 +194,10 @@ void MidiTime::setTicksPerTact( tick_t tpt )
 MidiTime MidiTime::stepPosition( int step )
 {
 	return step * ticksPerTact() / stepsPerTact();
+}
+
+double MidiTime::ticksToMilliseconds(tick_t ticks, bpm_t beatsPerMinute)
+{
+	// 60 * 1000 / 48 = 1250
+	return ( ticks * 1250 ) / beatsPerMinute;
 }

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -371,9 +371,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 	{
 		case MovePositionMarker:
 			m_pos.setTicks( t.getTicks() );
-			Engine::getSong()->setMilliSeconds( ( t.getTicks() *
-					( 60 * 1000 / 48 ) ) /
-						Engine::getSong()->getTempo() );
+			Engine::getSong()->setToTime(t);
 			m_pos.setCurrentFrame( 0 );
 			updatePosition();
 			positionMarkerMoved();


### PR DESCRIPTION
Removes some explicit time calculations from `Song` and `TimeLineWidget` as part of #3284. See [this comment](https://github.com/LMMS/lmms/issues/3284#issuecomment-315542540).