### PR TITLE
Consistent text rendering for different pattern types and exposure of the background color to style sheets

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -613,6 +613,7 @@ TrackContentObjectView   {
 	qproperty-selectedColor: rgb( 0, 125, 255 );
 	qproperty-BBPatternBackground: rgb( 80, 80, 80 );
 	qproperty-textColor: rgb( 255, 255, 255 );
+	qproperty-textBackgroundColor: rgba(0, 0, 0, 75);
 	qproperty-textShadowColor: rgb( 0, 0, 0 );
 	qproperty-gradient: true; /* boolean property, set true to have a gradient */
 	

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -615,13 +615,14 @@ TrackContentObjectView   {
 	qproperty-textColor: rgb( 255, 255, 255 );
 	qproperty-textShadowColor: rgb( 0, 0, 0 );
 	qproperty-gradient: true; /* boolean property, set true to have a gradient */
+	
+	font-size: 11px;
 }
 
 /* instrument pattern */
 PatternView {
 	background-color: rgb( 119, 199, 216 );
 	color: rgb( 187, 227, 236 );
-	font-size: 11px;
 }
 
 /* sample track pattern */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -620,6 +620,7 @@ TrackContentObjectView   {
 	qproperty-selectedColor: #006B65;
 	qproperty-BBPatternBackground: #373d48;
 	qproperty-textColor: #fff;
+	qproperty-textBackgroundColor: rgba(0, 0, 0, 75);
 	qproperty-textShadowColor: rgb(0,0,0,200);
 	qproperty-gradient: false; /* boolean property, set true to have a gradient */
 	

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -622,13 +622,14 @@ TrackContentObjectView   {
 	qproperty-textColor: #fff;
 	qproperty-textShadowColor: rgb(0,0,0,200);
 	qproperty-gradient: false; /* boolean property, set true to have a gradient */
+	
+	font-size: 11px;
 }
 
 /* instrument pattern */
 PatternView {
 	background-color: #21A14F;
 	color: rgba(255,255,255,220);
-	font-size: 11px;
 }
 
 /* sample track pattern */

--- a/include/Track.h
+++ b/include/Track.h
@@ -263,6 +263,8 @@ protected:
 
 	DataFile createTCODataFiles(const QVector<TrackContentObjectView *> & tcos) const;
 
+	virtual void paintTextLabel(QString const & text, QPainter & painter);
+
 
 protected slots:
 	void updateLength();

--- a/include/Track.h
+++ b/include/Track.h
@@ -196,6 +196,7 @@ class TrackContentObjectView : public selectableObject, public ModelView
 	Q_PROPERTY( QColor mutedBackgroundColor READ mutedBackgroundColor WRITE setMutedBackgroundColor )
 	Q_PROPERTY( QColor selectedColor READ selectedColor WRITE setSelectedColor )
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
+	Q_PROPERTY( QColor textBackgroundColor READ textBackgroundColor WRITE setTextBackgroundColor )
 	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
 	Q_PROPERTY( QColor BBPatternBackground READ BBPatternBackground WRITE setBBPatternBackground )
 	Q_PROPERTY( bool gradient READ gradient WRITE setGradient )
@@ -215,6 +216,7 @@ public:
 	QColor mutedBackgroundColor() const;
 	QColor selectedColor() const;
 	QColor textColor() const;
+	QColor textBackgroundColor() const;
 	QColor textShadowColor() const;
 	QColor BBPatternBackground() const;
 	bool gradient() const;
@@ -222,6 +224,7 @@ public:
 	void setMutedBackgroundColor( const QColor & c );
 	void setSelectedColor( const QColor & c );
 	void setTextColor( const QColor & c );
+	void setTextBackgroundColor( const QColor & c );
 	void setTextShadowColor( const QColor & c );
 	void setBBPatternBackground( const QColor & c );
 	void setGradient( const bool & b );
@@ -299,6 +302,7 @@ private:
 	QColor m_mutedBackgroundColor;
 	QColor m_selectedColor;
 	QColor m_textColor;
+	QColor m_textBackgroundColor;
 	QColor m_textShadowColor;
 	QColor m_BBPatternBackground;
 	bool m_gradient;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -663,8 +663,11 @@ void TrackContentObjectView::paintTextLabel(QString const & text, QPainter & pai
 
 	painter.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), textBackgroundColor());
 
+	int const finalTextTop = textTop + fontMetrics.ascent();
+	painter.setPen(textShadowColor());
+	painter.drawText( textLeft + 1, finalTextTop + 1, elidedPatternName );
 	painter.setPen( textColor() );
-	painter.drawText( textLeft, textTop + fontMetrics.ascent(), elidedPatternName );
+	painter.drawText( textLeft, finalTextTop, elidedPatternName );
 }
 
 /*! \brief Handle a mouse press on this trackContentObjectView.

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -627,6 +627,32 @@ DataFile TrackContentObjectView::createTCODataFiles(
 	return dataFile;
 }
 
+void TrackContentObjectView::paintTextLabel(QString const & text, QPainter & painter)
+{
+	if (text.trimmed() == "")
+	{
+		return;
+	}
+
+	painter.setRenderHint( QPainter::TextAntialiasing );
+
+	QFont labelFont = this->font();
+	labelFont.setHintingPreference( QFont::PreferFullHinting );
+	painter.setFont( labelFont );
+
+	const int textTop = TCO_BORDER_WIDTH + 1;
+	const int textLeft = TCO_BORDER_WIDTH + 3;
+
+	QFontMetrics fontMetrics(labelFont);
+	QString elidedPatternName = fontMetrics.elidedText(text, Qt::ElideMiddle, width() - 2 * textLeft);
+
+	QColor transparentBlack(0, 0, 0, 75);
+	painter.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), transparentBlack);
+
+	painter.setPen( textColor() );
+	painter.drawText( textLeft, textTop + fontMetrics.ascent(), elidedPatternName );
+}
+
 /*! \brief Handle a mouse press on this trackContentObjectView.
  *
  *  Handles the various ways in which a trackContentObjectView can be

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -354,6 +354,11 @@ QColor TrackContentObjectView::selectedColor() const
 QColor TrackContentObjectView::textColor() const
 { return m_textColor; }
 
+QColor TrackContentObjectView::textBackgroundColor() const
+{
+	return m_textBackgroundColor;
+}
+
 QColor TrackContentObjectView::textShadowColor() const
 { return m_textShadowColor; }
 
@@ -375,6 +380,11 @@ void TrackContentObjectView::setSelectedColor( const QColor & c )
 
 void TrackContentObjectView::setTextColor( const QColor & c )
 { m_textColor = QColor( c ); }
+
+void TrackContentObjectView::setTextBackgroundColor( const QColor & c )
+{
+	m_textBackgroundColor = c;
+}
 
 void TrackContentObjectView::setTextShadowColor( const QColor & c )
 { m_textShadowColor = QColor( c ); }
@@ -646,8 +656,7 @@ void TrackContentObjectView::paintTextLabel(QString const & text, QPainter & pai
 	QFontMetrics fontMetrics(labelFont);
 	QString elidedPatternName = fontMetrics.elidedText(text, Qt::ElideMiddle, width() - 2 * textLeft);
 
-	QColor transparentBlack(0, 0, 0, 75);
-	painter.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), transparentBlack);
+	painter.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), textBackgroundColor());
 
 	painter.setPen( textColor() );
 	painter.drawText( textLeft, textTop + fontMetrics.ascent(), elidedPatternName );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -656,6 +656,11 @@ void TrackContentObjectView::paintTextLabel(QString const & text, QPainter & pai
 	QFontMetrics fontMetrics(labelFont);
 	QString elidedPatternName = fontMetrics.elidedText(text, Qt::ElideMiddle, width() - 2 * textLeft);
 
+	if (elidedPatternName.length() < 2)
+	{
+		elidedPatternName = text.trimmed();
+	}
+
 	painter.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), textBackgroundColor());
 
 	painter.setPen( textColor() );

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -369,25 +369,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	}
 	
 	// pattern name
-	p.setRenderHint( QPainter::TextAntialiasing );
-	
-	if(  m_staticTextName.text() != m_pat->name() )
-	{
-		m_staticTextName.setText( m_pat->name() );
-	}
-	
-	QFont font;
-	font.setHintingPreference( QFont::PreferFullHinting );
-	font.setPointSize( 8 );
-	p.setFont( font );
-	
-	const int textTop = TCO_BORDER_WIDTH + 1;
-	const int textLeft = TCO_BORDER_WIDTH + 1;
-	
-	p.setPen( textShadowColor() );
-	p.drawStaticText( textLeft + 1, textTop + 1, m_staticTextName );
-	p.setPen( textColor() );
-	p.drawStaticText( textLeft, textTop, m_staticTextName );
+	paintTextLabel(m_pat->name(), p);
 	
 	// inner border
 	p.setPen( c.lighter( current ? 160 : 130 ) );

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -267,25 +267,7 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	}
 
 	// pattern name
-	p.setRenderHint( QPainter::TextAntialiasing );
-
-	if(  m_staticTextName.text() != m_bbTCO->name() )
-	{
-		m_staticTextName.setText( m_bbTCO->name() );
-	}
-
-	QFont font;
-	font.setHintingPreference( QFont::PreferFullHinting );
-	font.setPointSize( 8 );
-	p.setFont( font );
-
-	const int textTop = TCO_BORDER_WIDTH + 1;
-	const int textLeft = TCO_BORDER_WIDTH + 1;
-
-	p.setPen( textShadowColor() );
-	p.drawStaticText( textLeft + 1, textTop + 1, m_staticTextName );
-	p.setPen( textColor() );
-	p.drawStaticText( textLeft, textTop, m_staticTextName );
+	paintTextLabel(m_bbTCO->name(), p);
 
 	// inner border
 	p.setPen( c.lighter( 130 ) );

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1074,28 +1074,7 @@ void PatternView::paintEvent( QPaintEvent * )
 
 	if (!beatPattern && !isDefaultName)
 	{
-		p.setRenderHint( QPainter::TextAntialiasing );
-
-		QFont labelFont = this->font();
-		labelFont.setHintingPreference( QFont::PreferFullHinting );
-		p.setFont( labelFont );
-
-		const int textTop = TCO_BORDER_WIDTH + 1;
-		const int textLeft = TCO_BORDER_WIDTH + 3;
-
-		QFontMetrics fontMetrics(labelFont);
-		QString elidedPatternName = fontMetrics.elidedText(m_pat->name(), Qt::ElideMiddle, width() - 2 * textLeft);
-
-		QColor transparentBlack(0, 0, 0, 75);
-		p.fillRect(QRect(0, 0, width(), fontMetrics.height() + 2 * textTop), transparentBlack);
-
-		if( m_staticTextName.text() != elidedPatternName )
-		{
-			m_staticTextName.setText( elidedPatternName );
-		}
-
-		p.setPen( textColor() );
-		p.drawStaticText( textLeft, textTop, m_staticTextName );
+		paintTextLabel(m_pat->name(), p);
 	}
 
 	// inner border


### PR DESCRIPTION
Render the text labels of the different types of pattern consistently:
![3674-consistent-patterns](https://user-images.githubusercontent.com/9293269/28248352-a0891a20-6a43-11e7-8f3b-18d2f932c827.png)

Do not render any label in case the trimmed text becomes empty, i.e. if the user enters a single space (" ") for the name this would not be rendered.

Expose the background color of the pattern text label to the style sheets.