### PR TITLE
Allways remove infs/nans

### DIFF
--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -202,11 +202,8 @@ bool EffectChain::processAudioBuffer( sampleFrame * _buf, const fpp_t _frames, b
 	{
 		return false;
 	}
-	const bool exporting = Engine::getSong()->isExporting();
-	if( exporting ) // strip infs/nans if exporting
-	{
-		MixHelpers::sanitize( _buf, _frames );
-	}
+
+	MixHelpers::sanitize( _buf, _frames );
 
 	bool moreEffects = false;
 	for( EffectList::Iterator it = m_effects.begin(); it != m_effects.end(); ++it )
@@ -214,10 +211,7 @@ bool EffectChain::processAudioBuffer( sampleFrame * _buf, const fpp_t _frames, b
 		if( hasInputNoise || ( *it )->isRunning() )
 		{
 			moreEffects |= ( *it )->processAudioBuffer( _buf, _frames );
-			if( exporting ) // strip infs/nans if exporting
-			{
-				MixHelpers::sanitize( _buf, _frames );
-			}
+			MixHelpers::sanitize( _buf, _frames );
 		}
 	}
 

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -117,7 +117,6 @@ void FxChannel::unmuteForSolo()
 void FxChannel::doProcessing()
 {
 	const fpp_t fpp = Engine::mixer()->framesPerPeriod();
-	const bool exporting = Engine::getSong()->isExporting();
 
 	if( m_muted == false )
 	{
@@ -140,25 +139,21 @@ void FxChannel::doProcessing()
 				if( ! volBuf && ! sendBuf ) // neither volume nor send has sample-exact data...
 				{
 					const float v = sender->m_volumeModel.value() * sendModel->value();
-					if( exporting ) { MixHelpers::addSanitizedMultiplied( m_buffer, ch_buf, v, fpp ); }
-					else { MixHelpers::addMultiplied( m_buffer, ch_buf, v, fpp ); }
+					MixHelpers::addSanitizedMultiplied( m_buffer, ch_buf, v, fpp );
 				}
 				else if( volBuf && sendBuf ) // both volume and send have sample-exact data
 				{
-					if( exporting ) { MixHelpers::addSanitizedMultipliedByBuffers( m_buffer, ch_buf, volBuf, sendBuf, fpp ); }
-					else { MixHelpers::addMultipliedByBuffers( m_buffer, ch_buf, volBuf, sendBuf, fpp ); }
+					MixHelpers::addSanitizedMultipliedByBuffers( m_buffer, ch_buf, volBuf, sendBuf, fpp );
 				}
 				else if( volBuf ) // volume has sample-exact data but send does not
 				{
 					const float v = sendModel->value();
-					if( exporting ) { MixHelpers::addSanitizedMultipliedByBuffer( m_buffer, ch_buf, v, volBuf, fpp ); }
-					else { MixHelpers::addMultipliedByBuffer( m_buffer, ch_buf, v, volBuf, fpp ); }
+					MixHelpers::addSanitizedMultipliedByBuffer( m_buffer, ch_buf, v, volBuf, fpp );
 				}
 				else // vice versa
 				{
 					const float v = sender->m_volumeModel.value();
-					if( exporting ) { MixHelpers::addSanitizedMultipliedByBuffer( m_buffer, ch_buf, v, sendBuf, fpp ); }
-					else { MixHelpers::addMultipliedByBuffer( m_buffer, ch_buf, v, sendBuf, fpp ); }
+					MixHelpers::addSanitizedMultipliedByBuffer( m_buffer, ch_buf, v, sendBuf, fpp );
 				}
 				m_hasInput = true;
 			}

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -82,6 +82,10 @@ bool sanitize( sampleFrame * src, int frames )
 				src[f][c] = 0.0f;
 				found = true;
 			}
+			else
+			{
+				src[f][c] = qBound( -4.0f, src[f][c], 4.0f );
+			}
 		}
 	}
 	return found;


### PR DESCRIPTION

Brief

Testing to switch the inf/nan tests that are performed on export to be 'on' allways.
This seem to work well. For some 2.5% increase in cycles most of the NaN oriented bugs can be transformed from a project cutting out all sound at a specific point or from start, to just a moderate glitch.
I currently lack real test cases to assess this.

---

Verbose

I split the original PR into two separate commits and added a new one.

2fc1802 Turn on sanitizers in the FX-Mixer. This effectively prevents the whole projects to go silent because of one channel with a bad signal.

a85b02c Turn on sanitizers in the effect chains. This prevents bad data from shutting down the channel. Basically all NaN ( Warning! Will get loud without 47ac277 )

47ac277 As of the previious commit some dangerously large signals can come through the mix.

> ... has some amazing new noise going on with this PR

Fixed. Clamp values to, for the time being, +/-1.0f . I understand introducing hard limiting like this could trigger some but I see no reason to allow overly large signals. Don't other projects perform some form of clipping?
At this level a glitch will propagate through a reverb with long decay more like a distinct tick. A slight performance hit. +~0.2%.

---

Profiling

Test Project: Skiessi - Onion
Result: ~2.5% is spent in `MixHelpers::sanitize()` and `MixHelpers::addSanitizedMultiplied()`routines.

```
$ operf ./lmms

zonkmachine@zonkmachine:~/builds/lmms/lmms/build$ opreport --callgraph
CPU: AMD64 family15h, speed 3.4e+06 MHz (estimated)
Counted CPU_CLK_UNHALTED events (CPU Clocks not Halted) with a unit mask of 0x00 (No unit mask) count 100000
samples  %        image name               symbol name
-------------------------------------------------------------------------------
433771   14.1108  caps.so                  void Clip::one_cycle<&(store_func(float*, int, float, float))>(int)
  433771   100.000  caps.so                  void Clip::one_cycle<&(store_func(float*, int, float, float))>(int) [self]
-------------------------------------------------------------------------------
390387   12.6995  libQtGui.so.4.8.6        /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.6
  390387   100.000  libQtGui.so.4.8.6        /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.6 [self]

/////

61433     1.9870  lmms                     MixHelpers::sanitize(float (*) [2], int)
  61433    100.000  lmms                     MixHelpers::sanitize(float (*) [2], int) [self]
8048      0.2603  lmms                     MixHelpers::addSanitizedMultiplied(float (*) [2], float const (*) [2], float, int)
  8048     100.000  lmms                     MixHelpers::addSanitizedMultiplied(float (*) [2], float const (*) [2], float, int) [self]
```

fixes #1048 #3685
