### PR TITLE
Show the names of patterns in their tool tip

### DIFF
--- a/include/AutomationPatternView.h
+++ b/include/AutomationPatternView.h
@@ -44,6 +44,7 @@ public:
 public slots:
 	/// Opens this view's pattern in the global automation editor
 	void openInAutomationEditor();
+	virtual void update();
 
 
 protected slots:

--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -98,6 +98,8 @@ public:
 	}
 	void setColor( QColor _new_color );
 
+public slots:
+	virtual void update();
 
 protected slots:
 	void openInBBEditor();

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -55,8 +55,7 @@ AutomationPatternView::AutomationPatternView( AutomationPattern * _pattern,
 
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
 
-	ToolTip::add( this, tr( "double-click to open this pattern in "
-						"automation editor" ) );
+	ToolTip::add(this, m_pat->name());
 	setStyle( QApplication::style() );
 	
 	if( s_pat_rec == NULL ) { s_pat_rec = new QPixmap( embed::getIconPixmap(
@@ -80,6 +79,13 @@ void AutomationPatternView::openInAutomationEditor()
 	if(gui) gui->automationEditor()->open(m_pat);
 }
 
+
+void AutomationPatternView::update()
+{
+	ToolTip::add(this, m_pat->name());
+
+	TrackContentObjectView::update();
+}
 
 
 

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -38,6 +38,7 @@
 #include "RenameDialog.h"
 #include "Song.h"
 #include "SongEditor.h"
+#include "ToolTip.h"
 #include "TrackLabelButton.h"
 
 
@@ -381,6 +382,12 @@ void BBTCOView::setColor( QColor new_color )
 }
 
 
+void BBTCOView::update()
+{
+	ToolTip::add(this, m_bbTCO->name());
+
+	TrackContentObjectView::update();
+}
 
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -652,16 +652,7 @@ PatternView::~PatternView()
 
 void PatternView::update()
 {
-	if ( m_pat->m_patternType == Pattern::BeatPattern )
-	{
-		ToolTip::add( this,
-			tr( "use mouse wheel to set velocity of a step" ) );
-	}
-	else
-	{
-		ToolTip::add( this,
-			tr( "double-click to open in Piano Roll" ) );
-	}
+	ToolTip::add(this, m_pat->name());
 
 	TrackContentObjectView::update();
 }


### PR DESCRIPTION
Adjust `PatternView::update` to show the name of the pattern as the tool tip (regardless of whether it is a beat and bassline or a melody pattern).

Override the public slot `TrackContentObjectView::update` for `AutomationPatternView` and `BBTCOView`. Implement it similar to `PatternView::update`.