### PR TITLE
fixed recording of sustained midi notes

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -378,10 +378,13 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 	}
 
 	// inform attached components about MIDI finished (used for recording in Piano Roll)
-	if( m_origin == OriginMidiInput )
+	if (!instrumentTrack()->isSustainPedalPressed())
 	{
-		setLength( MidiTime( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
-		m_instrumentTrack->midiNoteOff( *this );
+		if( m_origin == OriginMidiInput )
+		{
+			setLength( MidiTime( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
+			m_instrumentTrack->midiNoteOff( *this );
+		}
 	}
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -309,25 +309,22 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 				{
 					m_sustainPedalPressed = true;
 				}
-				else
+				else if (isSustainPedalPressed())
 				{
-					if (isSustainPedalPressed())
+					for (NotePlayHandle*& nph : m_notes)
 					{
-						for (NotePlayHandle*& nph : m_notes)
+						if (nph && nph->isReleased())
 						{
-							if (nph && nph->isReleased())
+							if( nph->origin() ==
+								nph->OriginMidiInput)
 							{
-								if( nph->origin() ==
-									nph->OriginMidiInput)
-								{
-									nph->setLength(
+								nph->setLength(
 									MidiTime( static_cast<f_cnt_t>(
 									nph->totalFramesPlayed() /
 									Engine::framesPerTick() ) ) );
-									midiNoteOff( *nph );
-								}
-								nph = NULL;
+								midiNoteOff( *nph );
 							}
+							nph = NULL;
 						}
 					}
 					m_sustainPedalPressed = false;

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -273,7 +273,14 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 				// be deleted later automatically)
 				Engine::mixer()->requestChangeInModel();
 				m_notes[event.key()]->noteOff( offset );
-				m_notes[event.key()] = NULL;
+
+				if (!(isSustainPedalPressed()) ||
+					!(m_notes[event.key()]->origin() ==
+					m_notes[event.key()]->OriginMidiInput))
+				{
+					m_notes[event.key()] = NULL;
+				}
+
 				Engine::mixer()->doneChangeInModel();
 			}
 			eventHandled = true;
@@ -304,6 +311,28 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 				}
 				else
 				{
+					if (isSustainPedalPressed())
+					{
+						for (NotePlayHandle*& nph : m_notes)
+						{
+							if (nph != NULL)
+							{
+								if (nph->isReleased())
+								{
+									if( nph->origin() ==
+										nph->OriginMidiInput)
+									{
+										nph->setLength(
+										MidiTime( static_cast<f_cnt_t>(
+										nph->totalFramesPlayed() /
+										Engine::framesPerTick() ) ) );
+										midiNoteOff( *nph );
+									}
+									nph = NULL;
+								}
+							}
+						}
+					}
 					m_sustainPedalPressed = false;
 				}
 			}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -315,21 +315,18 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 					{
 						for (NotePlayHandle*& nph : m_notes)
 						{
-							if (nph != NULL)
+							if (nph && nph->isReleased())
 							{
-								if (nph->isReleased())
+								if( nph->origin() ==
+									nph->OriginMidiInput)
 								{
-									if( nph->origin() ==
-										nph->OriginMidiInput)
-									{
-										nph->setLength(
-										MidiTime( static_cast<f_cnt_t>(
-										nph->totalFramesPlayed() /
-										Engine::framesPerTick() ) ) );
-										midiNoteOff( *nph );
-									}
-									nph = NULL;
+									nph->setLength(
+									MidiTime( static_cast<f_cnt_t>(
+									nph->totalFramesPlayed() /
+									Engine::framesPerTick() ) ) );
+									midiNoteOff( *nph );
 								}
+								nph = NULL;
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #1700.
This recovers the behavior done by 4b340f7d5f10297bd3f7198bb86877823fe89ede, and later lost.
When a midinoteff comes from midi, and sustain pedal is pressed, the noteplayhandle pointer don't get nullified, so later, when sustain pedal is released, it can catch that pointer to emit the signal that recording of note is finished.