### PR TITLE
Respect build options in ExportProjectDialog

### DIFF
--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -35,7 +35,7 @@ class ProjectRenderer : public QThread
 {
 	Q_OBJECT
 public:
-	enum ExportFileFormats
+	enum ExportFileFormats: int
 	{
 		WaveFile,
 		OggFile,

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1328,10 +1328,11 @@ void Song::exportProject( bool multiExport )
 		efd.setFileMode( FileDialog::AnyFile );
 		int idx = 0;
 		QStringList types;
-		while( ProjectRenderer::fileEncodeDevices[idx].m_fileFormat != ProjectRenderer::NumFileFormats &&
-		       ProjectRenderer::fileEncodeDevices[idx].isAvailable())
+		while( ProjectRenderer::fileEncodeDevices[idx].m_fileFormat != ProjectRenderer::NumFileFormats)
 		{
-			types << tr( ProjectRenderer::fileEncodeDevices[idx].m_description );
+			if(ProjectRenderer::fileEncodeDevices[idx].isAvailable()) {
+				types << tr(ProjectRenderer::fileEncodeDevices[idx].m_description);
+			}
 			++idx;
 		}
 		efd.setNameFilters( types );

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -194,9 +194,13 @@ ProjectRenderer::ExportFileFormats convertIndexToExportFileFormat(int index)
 	case 0:
 		return ProjectRenderer::WaveFile;
 	case 1:
+#ifdef LMMS_HAVE_OGGVORBIS
 		return ProjectRenderer::OggFile;
 	case 2:
+#endif
+#ifdef LMMS_HAVE_MP3LAME
 		return ProjectRenderer::MP3File;
+#endif // If neither ogg nor mp3 are available, index 1 is OOB; fall through to default case
 	default:
 		Q_ASSERT(false);
 		break;

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -66,8 +66,8 @@ ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 			// add to combo box
 			fileFormatCB->addItem( ProjectRenderer::tr(
 				ProjectRenderer::fileEncodeDevices[i].m_description ),
-                QVariant(ProjectRenderer::fileEncodeDevices[i].m_fileFormat) // format tag; later used for identification
-            );
+				QVariant(ProjectRenderer::fileEncodeDevices[i].m_fileFormat) // format tag; later used for identification
+			);
 
 			// if this is our extension, select it
 			if( QString::compare( renderExt, fileExt,
@@ -191,14 +191,14 @@ void ExportProjectDialog::startExport()
 
 void ExportProjectDialog::onFileFormatChanged(int index)
 {
-    // Extract the format tag from the currently selected item,
-    // and adjust the UI properly.
-    QVariant format_tag = fileFormatCB->itemData(index);
-    bool successful_conversion = false;
+	// Extract the format tag from the currently selected item,
+	// and adjust the UI properly.
+	QVariant format_tag = fileFormatCB->itemData(index);
+	bool successful_conversion = false;
 	auto exportFormat = static_cast<ProjectRenderer::ExportFileFormats>(
-        format_tag.toInt(&successful_conversion)
-    );
-    Q_ASSERT(successful_conversion);
+		format_tag.toInt(&successful_conversion)
+	);
+	Q_ASSERT(successful_conversion);
 
 	bool stereoModeVisible = exportFormat == ProjectRenderer::MP3File;
 
@@ -225,25 +225,25 @@ void ExportProjectDialog::startBtnClicked()
 {
 	m_ft = ProjectRenderer::NumFileFormats;
 
-    //Get file format from current menu selection.
-    bool successful_conversion = false;
-    QVariant tag = fileFormatCB->itemData(fileFormatCB->currentIndex());
-    m_ft = static_cast<ProjectRenderer::ExportFileFormats>(tag.toInt(&successful_conversion));
+	//Get file format from current menu selection.
+	bool successful_conversion = false;
+	QVariant tag = fileFormatCB->itemData(fileFormatCB->currentIndex());
+	m_ft = static_cast<ProjectRenderer::ExportFileFormats>(tag.toInt(&successful_conversion));
 
-    if( !successful_conversion )
-    {
-        QMessageBox::information( this, tr( "Error" ),
-                                  tr( "Error while determining file-encoder device. "
-                                          "Please try to choose a different output "
-                                          "format." ) );
-        reject();
-        return;
-    }
+	if( !successful_conversion )
+	{
+		QMessageBox::information( this, tr( "Error" ),
+								  tr( "Error while determining file-encoder device. "
+										  "Please try to choose a different output "
+										  "format." ) );
+		reject();
+		return;
+	}
 
-    // Find proper file extension.
+	// Find proper file extension.
 	for( int i = 0; i < ProjectRenderer::NumFileFormats; ++i )
 	{
-        if (m_ft == ProjectRenderer::fileEncodeDevices[i].m_fileFormat)
+		if (m_ft == ProjectRenderer::fileEncodeDevices[i].m_fileFormat)
 		{
 			m_fileExtension = QString( QLatin1String( ProjectRenderer::fileEncodeDevices[i].m_extension ) );
 			break;

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -65,7 +65,9 @@ ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 
 			// add to combo box
 			fileFormatCB->addItem( ProjectRenderer::tr(
-				ProjectRenderer::fileEncodeDevices[i].m_description ) );
+				ProjectRenderer::fileEncodeDevices[i].m_description ),
+                QVariant(ProjectRenderer::fileEncodeDevices[i].m_fileFormat) // format tag; later used for identification
+            );
 
 			// if this is our extension, select it
 			if( QString::compare( renderExt, fileExt,
@@ -187,33 +189,16 @@ void ExportProjectDialog::startExport()
 }
 
 
-ProjectRenderer::ExportFileFormats convertIndexToExportFileFormat(int index)
-{
-	switch (index)
-	{
-	case 0:
-		return ProjectRenderer::WaveFile;
-	case 1:
-#ifdef LMMS_HAVE_OGGVORBIS
-		return ProjectRenderer::OggFile;
-	case 2:
-#endif
-#ifdef LMMS_HAVE_MP3LAME
-		return ProjectRenderer::MP3File;
-#endif // If neither ogg nor mp3 are available, index 1 is OOB; fall through to default case
-	default:
-		Q_ASSERT(false);
-		break;
-	}
-
-	return ProjectRenderer::NumFileFormats;
-}
-
-
 void ExportProjectDialog::onFileFormatChanged(int index)
 {
-	ProjectRenderer::ExportFileFormats exportFormat =
-			convertIndexToExportFileFormat(index);
+    // Extract the format tag from the currently selected item,
+    // and adjust the UI properly.
+    QVariant format_tag = fileFormatCB->itemData(index);
+    bool successful_conversion = false;
+	auto exportFormat = static_cast<ProjectRenderer::ExportFileFormats>(
+        format_tag.toInt(&successful_conversion)
+    );
+    Q_ASSERT(successful_conversion);
 
 	bool stereoModeVisible = exportFormat == ProjectRenderer::MP3File;
 
@@ -240,26 +225,29 @@ void ExportProjectDialog::startBtnClicked()
 {
 	m_ft = ProjectRenderer::NumFileFormats;
 
+    //Get file format from current menu selection.
+    bool successful_conversion = false;
+    QVariant tag = fileFormatCB->itemData(fileFormatCB->currentIndex());
+    m_ft = static_cast<ProjectRenderer::ExportFileFormats>(tag.toInt(&successful_conversion));
+
+    if( !successful_conversion )
+    {
+        QMessageBox::information( this, tr( "Error" ),
+                                  tr( "Error while determining file-encoder device. "
+                                          "Please try to choose a different output "
+                                          "format." ) );
+        reject();
+        return;
+    }
+
+    // Find proper file extension.
 	for( int i = 0; i < ProjectRenderer::NumFileFormats; ++i )
 	{
-		if( fileFormatCB->currentText() ==
-			ProjectRenderer::tr(
-				ProjectRenderer::fileEncodeDevices[i].m_description ) )
+        if (m_ft == ProjectRenderer::fileEncodeDevices[i].m_fileFormat)
 		{
-			m_ft = ProjectRenderer::fileEncodeDevices[i].m_fileFormat;
 			m_fileExtension = QString( QLatin1String( ProjectRenderer::fileEncodeDevices[i].m_extension ) );
 			break;
 		}
-	}
-
-	if( m_ft == ProjectRenderer::NumFileFormats )
-	{
-		QMessageBox::information( this, tr( "Error" ),
-			tr( "Error while determining file-encoder device. "
-				"Please try to choose a different output "
-							"format." ) );
-		reject();
-		return;
 	}
 
 	startButton->setEnabled( false );


### PR DESCRIPTION
Addresses issue #3713 by implementing a workaround on the existing hard-coded ordering. This is obviously not the optimal solution because the core problem is the hard-coded ordering itself.