### PR TITLE
Recover file fixes

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -105,8 +105,6 @@ public:
 		return m_autoSaveTimer.interval();
 	}
 
-	void runAutoSave();
-
 	enum SessionState
 	{
 		Normal,

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -919,7 +919,6 @@ int main( int argc, char * * argv )
 		if( autoSaveEnabled )
 		{
 			gui->mainWindow()->autoSaveTimerReset();
-			gui->mainWindow()->autoSave();
 		}
 	}
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -821,7 +821,6 @@ void MainWindow::createNewProject()
 	{
 		Engine::getSong()->createNewProject();
 	}
-	runAutoSave();
 }
 
 
@@ -840,7 +839,6 @@ void MainWindow::createNewProjectFromTemplate( QAction * _idx )
 		Engine::getSong()->createNewProjectFromTemplate(
 			dirBase + _idx->text() + ".mpt" );
 	}
-	runAutoSave();
 }
 
 
@@ -865,7 +863,6 @@ void MainWindow::openProject()
 			setCursor( Qt::ArrowCursor );
 		}
 	}
-	runAutoSave();
 }
 
 
@@ -917,7 +914,6 @@ void MainWindow::openRecentlyOpenedProject( QAction * _action )
 		Engine::getSong()->loadProject( f );
 		setCursor( Qt::ArrowCursor );
 	}
-	runAutoSave();
 }
 
 
@@ -1555,17 +1551,5 @@ void MainWindow::autoSave()
 		{
 			autoSaveTimerReset( m_autoSaveShortTime );
 		}
-	}
-}
-
-
-// For the occasional auto save action that isn't run
-// from the timer where we need to do extra tests.
-void MainWindow::runAutoSave()
-{
-	if( ConfigManager::inst()->value( "ui", "enableautosave" ).toInt() )
-	{
-		autoSave();
-		autoSaveTimerReset();  // Reset timer
 	}
 }

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -120,7 +120,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_backgroundArtwork( QDir::toNativeSeparators( ConfigManager::inst()->backgroundArtwork() ) ),
 	m_smoothScroll( ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt() ),
 	m_enableAutoSave( ConfigManager::inst()->value( "ui", "enableautosave", "1" ).toInt() ),
-	m_enableRunningAutoSave( ConfigManager::inst()->value( "ui", "enablerunningautosave", "1" ).toInt() ),
+	m_enableRunningAutoSave( ConfigManager::inst()->value( "ui", "enablerunningautosave", "0" ).toInt() ),
 	m_saveInterval(	ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() < 1 ?
 					MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES :
 			ConfigManager::inst()->value( "ui", "saveinterval" ).toInt() ),
@@ -1518,7 +1518,7 @@ void SetupDialog::resetAutoSave()
 {
 	setAutoSaveInterval( MainWindow::DEFAULT_SAVE_INTERVAL_MINUTES );
 	m_autoSave->setChecked( true );
-	m_runningAutoSave->setChecked( true );
+	m_runningAutoSave->setChecked( false );
 }
 
 


### PR DESCRIPTION
I'll collect a bunch of, hopefully, last tweaks to the recover file system here.

 - Remove extra calls to autoSave() and a separate function runAutoSave() which was only related to the Limited Session that was dropped from the code in 290556e43d200952e85a9f54607af9501621d484.

 - Don't auto-save while playing by default. ( From criticism after RC3 where it created issues with glitches for users with weaker machines )