### PR TITLE
Midi sustain working when envelope is on

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -156,6 +156,11 @@ public:
 		return m_released;
 	}
 
+	bool isReleaseStarted() const
+	{
+		return m_releaseStarted;
+	}
+
 	/*! Returns total numbers of frames played so far */
 	f_cnt_t totalFramesPlayed() const
 	{
@@ -258,11 +263,6 @@ public:
 		m_frequencyNeedsUpdate = true;
 	}
 
-	bool isReleaseStarted() const
-	{
-		return m_releaseStarted;
-	}
-
 private:
 	class BaseDetuning
 	{
@@ -302,6 +302,7 @@ private:
 											// release of note
 	NotePlayHandleList m_subNotes;			// used for chords and arpeggios
 	volatile bool m_released;				// indicates whether note is released
+	bool m_releaseStarted;
 	bool m_hasParent;						// indicates whether note has parent
 	NotePlayHandle * m_parent;			// parent note
 	bool m_hadChildren;
@@ -324,8 +325,6 @@ private:
 	Origin m_origin;
 
 	bool m_frequencyNeedsUpdate;				// used to update pitch
-
-	bool m_releaseStarted;
 } ;
 
 

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -258,6 +258,11 @@ public:
 		m_frequencyNeedsUpdate = true;
 	}
 
+	bool isReleaseStarted() const
+	{
+		return m_releaseStarted;
+	}
+
 private:
 	class BaseDetuning
 	{
@@ -319,6 +324,8 @@ private:
 	Origin m_origin;
 
 	bool m_frequencyNeedsUpdate;				// used to update pitch
+
+	bool m_releaseStarted;
 } ;
 
 

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -137,7 +137,7 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 	const f_cnt_t envTotalFrames = n->totalFramesPlayed();
 	f_cnt_t envReleaseBegin = envTotalFrames - n->releaseFramesDone() + n->framesBeforeRelease();
 
-	if( n->isReleased() == false )
+	if( n->isReleased() == false || n->instrumentTrack()->isSustainPedalPressed() )
 	{
 		envReleaseBegin += frames;
 	}

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -137,7 +137,8 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 	const f_cnt_t envTotalFrames = n->totalFramesPlayed();
 	f_cnt_t envReleaseBegin = envTotalFrames - n->releaseFramesDone() + n->framesBeforeRelease();
 
-	if( n->isReleased() == false || n->instrumentTrack()->isSustainPedalPressed() )
+	if( n->isReleased() == false || ( n->instrumentTrack()->isSustainPedalPressed() &&
+		!n->isReleaseStarted() ) )
 	{
 		envReleaseBegin += frames;
 	}

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -137,7 +137,7 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 	const f_cnt_t envTotalFrames = n->totalFramesPlayed();
 	f_cnt_t envReleaseBegin = envTotalFrames - n->releaseFramesDone() + n->framesBeforeRelease();
 
-	if( n->isReleased() == false || ( n->instrumentTrack()->isSustainPedalPressed() &&
+	if( !n->isReleased() || ( n->instrumentTrack()->isSustainPedalPressed() &&
 		!n->isReleaseStarted() ) )
 	{
 		envReleaseBegin += frames;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -75,7 +75,8 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 	m_songGlobalParentOffset( 0 ),
 	m_midiChannel( midiEventChannel >= 0 ? midiEventChannel : instrumentTrack->midiPort()->realOutputChannel() ),
 	m_origin( origin ),
-	m_frequencyNeedsUpdate( false )
+	m_frequencyNeedsUpdate( false ),
+	m_releaseStarted( false )
 {
 	lock();
 	if( hasParent() == false )
@@ -248,8 +249,11 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 		m_instrumentTrack->playNote( this, _working_buffer );
 	}
 
-	if( m_released && !instrumentTrack()->isSustainPedalPressed() )
+	if( m_released && (!instrumentTrack()->isSustainPedalPressed() ||
+		m_releaseStarted) )
 	{
+		m_releaseStarted = true;
+
 		f_cnt_t todo = framesThisPeriod;
 
 		// if this note is base-note for arpeggio, always set

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -62,6 +62,7 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 	m_releaseFramesDone( 0 ),
 	m_subNotes(),
 	m_released( false ),
+	m_releaseStarted( false ),
 	m_hasParent( parent != NULL  ),
 	m_parent( parent ),
 	m_hadChildren( false ),
@@ -75,8 +76,7 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 	m_songGlobalParentOffset( 0 ),
 	m_midiChannel( midiEventChannel >= 0 ? midiEventChannel : instrumentTrack->midiPort()->realOutputChannel() ),
 	m_origin( origin ),
-	m_frequencyNeedsUpdate( false ),
-	m_releaseStarted( false )
+	m_frequencyNeedsUpdate( false )
 {
 	lock();
 	if( hasParent() == false )

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -248,7 +248,7 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 		m_instrumentTrack->playNote( this, _working_buffer );
 	}
 
-	if( m_released )
+	if( m_released && !instrumentTrack()->isSustainPedalPressed() )
 	{
 		f_cnt_t todo = framesThisPeriod;
 


### PR DESCRIPTION
Fixes #3537.
When sustain pedal is pressed `NotePlayHandle::play()` doesn't enter release phase.
And in `InstrumentSoundShaping::processAudioBuffer()`, the envelope's release is posponed until the sustain pedal is released.