### PR TITLE
Fix deadlock when exporting is finished, if the project has any Sample TCO(s).

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -421,6 +421,7 @@ private:
 
 	friend class LmmsCore;
 	friend class MixerWorkerThread;
+	friend class ProjectRenderer;
 
 } ;
 

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -176,8 +176,8 @@ void ProjectRenderer::run()
 
 	Engine::getSong()->startExport();
 	Engine::getSong()->updateLength();
-	//skip first empty buffer
-	Engine::mixer()->nextBuffer();
+    //skip first empty buffer
+    Engine::mixer()->nextBuffer();
 
 	const Song::PlayPos & exportPos = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );
@@ -201,7 +201,9 @@ void ProjectRenderer::run()
 		}
 	}
 
+	// notify mixer of the end of processing
 	Engine::mixer()->stopProcessing();
+
 	Engine::getSong()->stopExport();
 
 	// if the user aborted export-process, the file has to be deleted

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -176,8 +176,8 @@ void ProjectRenderer::run()
 
 	Engine::getSong()->startExport();
 	Engine::getSong()->updateLength();
-    //skip first empty buffer
-    Engine::mixer()->nextBuffer();
+	//skip first empty buffer
+	Engine::mixer()->nextBuffer();
 
 	const Song::PlayPos & exportPos = Engine::getSong()->getPlayPos(
 							Song::Mode_PlaySong );
@@ -201,6 +201,7 @@ void ProjectRenderer::run()
 		}
 	}
 
+	Engine::mixer()->stopProcessing();
 	Engine::getSong()->stopExport();
 
 	// if the user aborted export-process, the file has to be deleted


### PR DESCRIPTION
Fixes #3344.
Calls `stopProcessing()` when the rendering ends, to prevent `requsetChangeInModels()` from waiting for `runChangesInModels()`, which causes a deadlock.
https://github.com/LMMS/lmms/issues/3344#issuecomment-318878520 is another solution, but this one is more fundamental than https://github.com/LMMS/lmms/issues/3344#issuecomment-318878520.

Tested for both GUI and CLI, and both single-file rendering and rendering per track, works well.