### PR TITLE
"misc" view now shows the model state, of the track use of master pitch

### DIFF
--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -72,6 +72,11 @@ public:
 	InstrumentMiscView( InstrumentTrack *it, QWidget* parent );
 	~InstrumentMiscView();
 
+	GroupBox * getPitchGroupBox()
+	{
+		return m_pitchGroupBox;
+	}
+
 private:
 
 	GroupBox * m_pitchGroupBox;

--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -72,7 +72,7 @@ public:
 	InstrumentMiscView( InstrumentTrack *it, QWidget* parent );
 	~InstrumentMiscView();
 
-	GroupBox * getPitchGroupBox()
+	GroupBox * PitchGroupBox()
 	{
 		return m_pitchGroupBox;
 	}

--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -72,7 +72,7 @@ public:
 	InstrumentMiscView( InstrumentTrack *it, QWidget* parent );
 	~InstrumentMiscView();
 
-	GroupBox * PitchGroupBox()
+	GroupBox * pitchGroupBox()
 	{
 		return m_pitchGroupBox;
 	}

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -27,6 +27,7 @@
 #define INSTRUMENT_TRACK_H
 
 #include "AudioPort.h"
+#include "GroupBox.h"
 #include "InstrumentFunctions.h"
 #include "InstrumentSoundShaping.h"
 #include "MidiEventProcessor.h"

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1575,7 +1575,7 @@ void InstrumentTrackWindow::modelChanged()
 	m_arpeggioView->setModel( &m_track->m_arpeggio );
 	m_midiView->setModel( &m_track->m_midiPort );
 	m_effectView->setModel( m_track->m_audioPort.effects() );
-	m_miscView->getPitchGroupBox()->setModel(&m_track->m_useMasterPitchModel);
+	m_miscView->PitchGroupBox()->setModel(&m_track->m_useMasterPitchModel);
 	updateName();
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1575,7 +1575,7 @@ void InstrumentTrackWindow::modelChanged()
 	m_arpeggioView->setModel( &m_track->m_arpeggio );
 	m_midiView->setModel( &m_track->m_midiPort );
 	m_effectView->setModel( m_track->m_audioPort.effects() );
-	m_miscView->PitchGroupBox()->setModel(&m_track->m_useMasterPitchModel);
+	m_miscView->pitchGroupBox()->setModel(&m_track->m_useMasterPitchModel);
 	updateName();
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1575,6 +1575,7 @@ void InstrumentTrackWindow::modelChanged()
 	m_arpeggioView->setModel( &m_track->m_arpeggio );
 	m_midiView->setModel( &m_track->m_midiPort );
 	m_effectView->setModel( m_track->m_audioPort.effects() );
+	m_miscView->getPitchGroupBox()->setModel(&m_track->m_useMasterPitchModel);
 	updateName();
 }
 


### PR DESCRIPTION
Fix for #2612.
When an already created instance of `InstrumentTrackWindow` is used, the master pitch `GroupBox` isn't refreshed.
Now, if this is the case, when `modelChanged()` is invoked, the refresh is done.