### PR TITLE
Add a border on non-fixed BB patterns

### DIFF
--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -1094,7 +1094,7 @@ void PatternView::paintEvent( QPaintEvent * )
 	}
 
 	// inner border
-	if( !beatPattern )
+	if( !( fixedTCOs() && beatPattern ) )
 	{
 		p.setPen( c.lighter( current ? 160 : 130 ) );
 		p.drawRect( 1, 1, rect().right() - TCO_BORDER_WIDTH,


### PR DESCRIPTION
Fixes #3606 

Just made the already existing border code affect BB patterns not in the BB editor. Screenshots: 
![screenshot from 2017-08-08 13 13 00](https://user-images.githubusercontent.com/6282045/29069655-13788a84-7c3c-11e7-8616-87c433609412.png)
![screenshot from 2017-08-08 13 12 38](https://user-images.githubusercontent.com/6282045/29069656-13797d90-7c3c-11e7-8b12-e6ea9fe503e6.png)
![image](https://user-images.githubusercontent.com/6282045/29069668-2371ee80-7c3c-11e7-92cb-94f81fe4a110.png)
