### PR TITLE
Paint a black rectangle under patterns to prevent glitches

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -615,12 +615,12 @@ TrackContainerView QLabel
 
 /* common pattern colors */
 TrackContentObjectView   {
-	qproperty-mutedColor: rgb(255,255,255,100);
+	qproperty-mutedColor: rgba(255,255,255,100);
 	qproperty-mutedBackgroundColor: #373d48;
 	qproperty-selectedColor: #006B65;
 	qproperty-BBPatternBackground: #373d48;
 	qproperty-textColor: #fff;
-	qproperty-textShadowColor: rgb(0,0,0,200);
+	qproperty-textShadowColor: rgba(0,0,0,200);
 	qproperty-gradient: false; /* boolean property, set true to have a gradient */
 }
 

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -257,7 +257,10 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );
-	
+
+	// paint a black rectangle under the pattern to prevent glitches with transparent backgrounds
+	p.fillRect( rect(), QColor( 0, 0, 0 ) );
+
 	if( gradient() )
 	{
 		p.fillRect( rect(), lingrad );
@@ -492,8 +495,3 @@ void AutomationPatternView::scaleTimemapToFit( float oldMin, float oldMax )
 
 	m_pat->generateTangents();
 }
-
-
-
-
-

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -237,7 +237,10 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	
 	lingrad.setColorAt( 0, c.light( 130 ) );
 	lingrad.setColorAt( 1, c.light( 70 ) );
-	
+
+	// paint a black rectangle under the pattern to prevent glitches with transparent backgrounds
+	p.fillRect( rect(), QColor( 0, 0, 0 ) );
+
 	if( gradient() )
 	{
 		p.fillRect( rect(), lingrad );

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -890,6 +890,9 @@ void PatternView::paintEvent( QPaintEvent * )
 	lingrad.setColorAt( beatPattern ? 0 : 1, c.darker( 300 ) );
 	lingrad.setColorAt( beatPattern ? 1 : 0, c );
 
+	// paint a black rectangle under the pattern to prevent glitches with transparent backgrounds
+	p.fillRect( rect(), QColor( 0, 0, 0 ) );
+
 	if( gradient() )
 	{
 		p.fillRect( rect(), lingrad );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -475,6 +475,9 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );
 
+	// paint a black rectangle under the pattern to prevent glitches with transparent backgrounds
+	p.fillRect( rect(), QColor( 0, 0, 0 ) );
+
 	if( gradient() )
 	{
 		p.fillRect( rect(), lingrad );


### PR DESCRIPTION
Fixes #3709

As suggested by @michaelgregorius I added a black rectangle to act as a background for the patterns. No more glitches. Here are transparent patterns with some random-ass colors: 
![screenshot from 2017-08-08 14 33 27](https://user-images.githubusercontent.com/6282045/29072188-045870d6-7c47-11e7-9adc-2020b75852c5.png)
