### PR TITLE
Fix hang when remote plugin is missing

### DIFF
--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -196,6 +196,7 @@ bool RemotePlugin::init( const QString &pluginExecutable,
 		qWarning( "Remote plugin '%s' not found.",
 						exec.toUtf8().constData() );
 		m_failed = true;
+		invalidate();
 		unlock();
 		return failed();
 	}


### PR DESCRIPTION
Invalidate the plugin if the remote plugin executable is missing, so LMMS doesn't hang on RemotePlugin::waitForInitDone.