### PR TITLE
UI: New behavior for the Plugin Browser

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -537,7 +537,7 @@ PluginDescWidget {
 }
 
 PluginDescWidget:hover {
-	background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #2E343B, stop:1 #1E2326);
+	background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #363F4B, stop:1 #4A545F);
 	color: #d1d8e4;
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -537,7 +537,7 @@ PluginDescWidget {
 }
 
 PluginDescWidget:hover {
-	background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #363F4B, stop:1 #4A545F);
+	background: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #7C8799, stop:1 #343840);
 	color: #d1d8e4;
 }
 

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -62,14 +62,13 @@ class PluginDescWidget : public QWidget
 	Q_OBJECT
 public:
 	PluginDescWidget( const Plugin::Descriptor & _pd, QWidget * _parent );
-	virtual ~PluginDescWidget();
 
 
 protected:
-	virtual void enterEvent( QEvent * _e );
-	virtual void leaveEvent( QEvent * _e );
-	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void paintEvent( QPaintEvent * _pe );
+	void enterEvent( QEvent * _e ) override;
+	void leaveEvent( QEvent * _e ) override;
+	void mousePressEvent( QMouseEvent * _me ) override;
+	void paintEvent( QPaintEvent * _pe ) override;
 
 
 private slots:
@@ -78,7 +77,7 @@ private slots:
 
 private:
 	constexpr static int DEFAULT_HEIGHT{24};
-	constexpr static int HEIGHT_INCREMENT{4};
+	constexpr static int ANIMATION_STEPS{4};
 
 	QTimer m_updateTimer;
 
@@ -87,6 +86,7 @@ private:
 
 	bool m_mouseOver;
 	int m_targetHeight;
+	int m_heightIncrement;
 
 };
 

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -27,6 +27,8 @@
 
 #include <QtCore/QTimer>
 #include <QPixmap>
+#include <QtGui/QLabel>
+#include <memory>
 
 #include "SideBarWidget.h"
 #include "Plugin.h"
@@ -37,11 +39,18 @@ class PluginBrowser : public SideBarWidget
 	Q_OBJECT
 public:
 	PluginBrowser( QWidget * _parent );
-	virtual ~PluginBrowser();
+	virtual ~PluginBrowser() = default;
+
+private slots:
+	void highlightPlugin(Plugin::Descriptor const& pd);
+	void highlightNone();
 
 
 private:
 	QWidget * m_view;
+
+	std::unique_ptr<QLabel> m_hint;
+
 };
 
 
@@ -52,6 +61,14 @@ class PluginDescList : public QWidget
 	Q_OBJECT
 public:
 	PluginDescList(QWidget* parent);
+
+signals:
+	void highlight(Plugin::Descriptor const&);
+	void unhighlight();
+
+private slots:
+	void receiveHighlight(Plugin::Descriptor const&);
+	void receiveUnhighlight();
 };
 
 
@@ -70,14 +87,13 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
 
-
-private slots:
-	void updateHeight();
+	signals:
+	void highlight(Plugin::Descriptor const& pd);
+	void unhighlight();
 
 
 private:
 	constexpr static int DEFAULT_HEIGHT{24};
-	constexpr static int ANIMATION_STEPS{4};
 
 	QTimer m_updateTimer;
 
@@ -85,9 +101,6 @@ private:
 	QPixmap m_logo;
 
 	bool m_mouseOver;
-	int m_targetHeight;
-	int m_heightIncrement;
-
 };
 
 

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -77,6 +77,9 @@ private slots:
 
 
 private:
+	constexpr static int DEFAULT_HEIGHT{24};
+	constexpr static int HEIGHT_INCREMENT{4};
+
 	QTimer m_updateTimer;
 
 	const Plugin::Descriptor & m_pluginDescriptor;

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -27,9 +27,6 @@
 
 #include <QtCore/QTimer>
 #include <QPixmap>
-#include <QLabel>
-
-#include <memory>
 
 #include "SideBarWidget.h"
 #include "Plugin.h"
@@ -42,16 +39,8 @@ public:
 	PluginBrowser( QWidget * _parent );
 	virtual ~PluginBrowser() = default;
 
-private slots:
-	void highlightPlugin(Plugin::Descriptor const& pd);
-	void highlightNone();
-
-
 private:
 	QWidget * m_view;
-
-	std::unique_ptr<QLabel> m_hint;
-
 };
 
 
@@ -62,14 +51,6 @@ class PluginDescList : public QWidget
 	Q_OBJECT
 public:
 	PluginDescList(QWidget* parent);
-
-signals:
-	void highlight(Plugin::Descriptor const&);
-	void unhighlight();
-
-private slots:
-	void receiveHighlight(Plugin::Descriptor const&);
-	void receiveUnhighlight();
 };
 
 
@@ -88,15 +69,8 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
 
-	signals:
-	void highlight(Plugin::Descriptor const& pd);
-	void unhighlight();
-
-
 private:
 	constexpr static int DEFAULT_HEIGHT{24};
-
-	QTimer m_updateTimer;
 
 	const Plugin::Descriptor & m_pluginDescriptor;
 	QPixmap m_logo;

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -27,7 +27,8 @@
 
 #include <QtCore/QTimer>
 #include <QPixmap>
-#include <QtGui/QLabel>
+#include <QLabel>
+
 #include <memory>
 
 #include "SideBarWidget.h"

--- a/include/SideBarWidget.h
+++ b/include/SideBarWidget.h
@@ -70,6 +70,16 @@ protected:
 		m_layout->addLayout( _l );
 	}
 
+	void changeIcon(QPixmap const& icon)
+	{
+		m_icon=icon;
+	}
+
+	void changeTitle(QString const& title)
+	{
+		m_title=title;
+	}
+
 
 private:
 	QWidget * m_contents;

--- a/include/SideBarWidget.h
+++ b/include/SideBarWidget.h
@@ -70,17 +70,6 @@ protected:
 		m_layout->addLayout( _l );
 	}
 
-	void changeIcon(QPixmap const& icon)
-	{
-		m_icon=icon;
-	}
-
-	void changeTitle(QString const& title)
-	{
-		m_title=title;
-	}
-
-
 private:
 	QWidget * m_contents;
 	QVBoxLayout * m_layout;

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -114,7 +114,7 @@ PluginDescWidget::PluginDescWidget( const Plugin::Descriptor & _pd,
 	m_pluginDescriptor( _pd ),
 	m_logo( _pd.logo->pixmap() ),
 	m_mouseOver( false ),
-	m_targetHeight( 24 )
+	m_targetHeight( DEFAULT_HEIGHT )
 {
 	connect( &m_updateTimer, SIGNAL( timeout() ), SLOT( updateHeight() ) );
 	setFixedHeight( m_targetHeight );
@@ -160,7 +160,7 @@ void PluginDescWidget::paintEvent( QPaintEvent * e )
 	p.drawText( 10 + logo_size.width(), 15,
 					m_pluginDescriptor.displayName );
 
-	if( height() > 24 || m_mouseOver )
+	if( height() > DEFAULT_HEIGHT || m_mouseOver )
 	{
 		f.setBold( false );
 		p.setFont( f );
@@ -182,7 +182,7 @@ void PluginDescWidget::paintEvent( QPaintEvent * e )
 void PluginDescWidget::enterEvent( QEvent * _e )
 {
 	m_mouseOver = true;
-	m_targetHeight = height() + 1;
+	m_targetHeight = height() + HEIGHT_INCREMENT;
 	updateHeight();
 	QWidget::enterEvent( _e );
 }
@@ -193,7 +193,7 @@ void PluginDescWidget::enterEvent( QEvent * _e )
 void PluginDescWidget::leaveEvent( QEvent * _e )
 {
 	m_mouseOver = false;
-	m_targetHeight = 24;
+	m_targetHeight = DEFAULT_HEIGHT;
 	updateHeight();
 	QWidget::leaveEvent( _e );
 }
@@ -218,11 +218,11 @@ void PluginDescWidget::updateHeight()
 {
 	if( m_targetHeight > height() )
 	{
-		setFixedHeight( height() + 1 );
+		setFixedHeight( height() + HEIGHT_INCREMENT );
 	}
 	else if( m_targetHeight < height() )
 	{
-		setFixedHeight( height() - 1 );
+		setFixedHeight( height() - HEIGHT_INCREMENT );
 	}
 	else
 	{

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -69,7 +69,10 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 								m_view )
 	);
 	m_hint->setWordWrap( true );
-	m_hint->setFixedHeight(m_hint->sizeHint().height());
+	// TODO fixed height causes some descriptions to be cropped;
+	// variable height causes layout resizing.
+	// Maybe pre-set to a height where resizing is never needed.
+	m_hint->setFixedHeight( m_hint->sizeHint().height() );
 
 	QScrollArea* scrollarea = new QScrollArea( m_view );
 	PluginDescList* descList = new PluginDescList( m_view );

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -24,8 +24,6 @@
 
 #include "PluginBrowser.h"
 
-#include <iostream>
-
 #include <QLabel>
 #include <QPainter>
 #include <QMouseEvent>

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -39,14 +39,6 @@
 #include "PluginFactory.h"
 
 
-static auto pluginBefore = []( const Plugin::Descriptor* d1, const Plugin::Descriptor* d2 )
-{
-	return qstricmp( d1->displayName, d2->displayName ) < 0 ? true : false;
-};
-
-
-
-
 PluginBrowser::PluginBrowser( QWidget * _parent ) :
 	SideBarWidget( tr( "Instrument Plugins" ),
 				embed::getIconPixmap( "plugins" ).transformed( QTransform().rotate( 90 ) ), _parent )
@@ -125,7 +117,14 @@ PluginDescList::PluginDescList(QWidget *parent) :
 	QVBoxLayout* layout = new QVBoxLayout(this);
 
 	QList<Plugin::Descriptor*> descs = pluginFactory->descriptors(Plugin::Instrument);
-	std::sort(descs.begin(), descs.end(), pluginBefore);
+	std::sort(
+			descs.begin(),
+			descs.end(),
+			[]( const Plugin::Descriptor* d1, const Plugin::Descriptor* d2 ) -> bool
+			{
+				return qstricmp( d1->displayName, d2->displayName ) < 0 ? true : false;
+			}
+	);
 	for (const Plugin::Descriptor* desc : descs)
 	{
 		PluginDescWidget* p = new PluginDescWidget( *desc, this );


### PR DESCRIPTION
This PR makes the following changes to the GUI:  
* Plugin browser widgets no longer resize on mouse-over; the list stays at a fixed size at all times.
* The detailed information for every plugin is no longer displayed within the plugin widgets. Instead, the title, icon and text of the header widget above the list is updated on the fly.
* The default theme now highlights plugin widgets on mouse-over.
  
See the following demonstration.
![Demo](http://i.imgur.com/r3OivZg.gif)
  
~~**Note** This PR is currently _not_ ready to merge. There's still a major issue regarding the height of the description text label, causing said text to be cropped in some circumstances. The main reason I'm opening it anyway is for people to look over it, review it and suggest improvements and solutions to existing problems.~~  
Edit2: Since we're now using tool-tips to display plugin details, the header height problem is obsolete. The PR is ready for merging.
  
Edit: This PR sort-of implements #3507 in that it removes the resizing behaviour altogether.