### PR TITLE
same note layering when sustain pedal is pressed

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -252,8 +252,17 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 	if( m_released && (!instrumentTrack()->isSustainPedalPressed() ||
 		m_releaseStarted) )
 	{
-		m_releaseStarted = true;
+		if (m_releaseStarted == false)
+		{
 
+			if( m_origin == OriginMidiInput )
+			{
+				setLength( MidiTime( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
+				m_instrumentTrack->midiNoteOff( *this );
+			}
+
+			m_releaseStarted = true;
+		}
 		f_cnt_t todo = framesThisPeriod;
 
 		// if this note is base-note for arpeggio, always set
@@ -379,16 +388,6 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 				MidiEvent( MidiNoteOff, midiChannel(), midiKey(), 0 ),
 				MidiTime::fromFrames( _s, Engine::framesPerTick() ),
 				_s );
-	}
-
-	// inform attached components about MIDI finished (used for recording in Piano Roll)
-	if (!instrumentTrack()->isSustainPedalPressed())
-	{
-		if( m_origin == OriginMidiInput )
-		{
-			setLength( MidiTime( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
-			m_instrumentTrack->midiNoteOff( *this );
-		}
 	}
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -273,14 +273,7 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 				// be deleted later automatically)
 				Engine::mixer()->requestChangeInModel();
 				m_notes[event.key()]->noteOff( offset );
-
-				if (!(isSustainPedalPressed()) ||
-					!(m_notes[event.key()]->origin() ==
-					m_notes[event.key()]->OriginMidiInput))
-				{
-					m_notes[event.key()] = NULL;
-				}
-
+				m_notes[event.key()] = NULL;
 				Engine::mixer()->doneChangeInModel();
 			}
 			eventHandled = true;
@@ -309,24 +302,8 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 				{
 					m_sustainPedalPressed = true;
 				}
-				else if (isSustainPedalPressed())
+				else
 				{
-					for (NotePlayHandle*& nph : m_notes)
-					{
-						if (nph && nph->isReleased())
-						{
-							if( nph->origin() ==
-								nph->OriginMidiInput)
-							{
-								nph->setLength(
-									MidiTime( static_cast<f_cnt_t>(
-									nph->totalFramesPlayed() /
-									Engine::framesPerTick() ) ) );
-								midiNoteOff( *nph );
-							}
-							nph = NULL;
-						}
-					}
 					m_sustainPedalPressed = false;
 				}
 			}


### PR DESCRIPTION
fix for #3757 
I moved the signal emission for note ended to where all notes (sustained and not sustained) go, the release process on `NotePlayHandle:play`