### PR TITLE
Fix some VST deadlocks/hangs

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -29,6 +29,7 @@
 #include <QtCore/QTimer>
 #include <QtCore/QList>
 #include <QMainWindow>
+#include <QThread>
 
 #include "ConfigManager.h"
 #include "SubWindow.h"
@@ -246,6 +247,13 @@ signals:
 	void periodicUpdate();
 	void initProgress(const QString &msg);
 
+} ;
+
+class AutoSaveThread : public QThread
+{
+	Q_OBJECT
+public:
+	void run();
 } ;
 
 #endif

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -424,6 +424,7 @@ enum RemoteMessageIDs
 	IdChangeSharedMemoryKey,
 	IdChangeInputCount,
 	IdChangeOutputCount,
+	IdChangeInputOutputCount,
 	IdShowUI,
 	IdHideUI,
 	IdSaveSettingsToString,
@@ -917,6 +918,15 @@ public:
 	{
 		m_outputCount = _i;
 		sendMessage( message( IdChangeOutputCount ).addInt( _i ) );
+	}
+
+	void setInputOutputCount( int i, int o )
+	{
+		m_inputCount = i;
+		m_outputCount = o;
+		sendMessage( message( IdChangeInputOutputCount )
+				.addInt( i )
+				.addInt( o ) );
 	}
 
 	virtual int inputCount() const

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -1072,6 +1072,14 @@ RemotePluginBase::message RemotePluginBase::waitForMessage(
 							const message & _wm,
 							bool _busy_waiting )
 {
+#ifndef BUILD_REMOTE_PLUGIN_CLIENT
+	if( _busy_waiting )
+	{
+		// No point processing events outside of the main thread
+		_busy_waiting = QThread::currentThread() ==
+					QCoreApplication::instance()->thread();
+	}
+#endif
 	while( !isInvalid() )
 	{
 #ifndef BUILD_REMOTE_PLUGIN_CLIENT

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -389,7 +389,7 @@ int VstPlugin::currentProgram()
 {
 	lock();
 	sendMessage( message( IdVstCurrentProgram ) );
-	waitForMessage( IdVstCurrentProgram );
+	waitForMessage( IdVstCurrentProgram, true );
 	unlock();
 
 	return m_currentProgram;
@@ -401,7 +401,7 @@ const QMap<QString, QString> & VstPlugin::parameterDump()
 {
 	lock();
 	sendMessage( IdVstGetParameterDump );
-	waitForMessage( IdVstParameterDump );
+	waitForMessage( IdVstParameterDump, true );
 	unlock();
 
 	return m_parameterDump;
@@ -528,7 +528,7 @@ void VstPlugin::openPreset( )
 				QSTR_TO_STDSTR(
 					QDir::toNativeSeparators( ofd.selectedFiles()[0] ) ) )
 			);
-		waitForMessage( IdLoadPresetFile );
+		waitForMessage( IdLoadPresetFile, true );
 		unlock();
 	}
 }
@@ -540,7 +540,7 @@ void VstPlugin::setProgram( int index )
 {
 	lock();
 	sendMessage( message( IdVstSetProgram ).addInt( index ) );
-	waitForMessage( IdVstSetProgram );
+	waitForMessage( IdVstSetProgram, true );
 	unlock();
 }
 
@@ -551,7 +551,7 @@ void VstPlugin::rotateProgram( int offset )
 {
 	lock();
 	sendMessage( message( IdVstRotateProgram ).addInt( offset ) );
-	waitForMessage( IdVstRotateProgram );
+	waitForMessage( IdVstRotateProgram, true );
 	unlock();
 }
 
@@ -562,7 +562,7 @@ void VstPlugin::loadProgramNames()
 {
 	lock();
 	sendMessage( message( IdVstProgramNames ) );
-	waitForMessage( IdVstProgramNames );
+	waitForMessage( IdVstProgramNames, true );
 	unlock();
 }
 
@@ -599,7 +599,7 @@ void VstPlugin::savePreset( )
 				QSTR_TO_STDSTR(
 					QDir::toNativeSeparators( fns ) ) )
 			);
-		waitForMessage( IdSavePresetFile );
+		waitForMessage( IdSavePresetFile, true );
 		unlock();
 	}
 }
@@ -611,7 +611,7 @@ void VstPlugin::setParam( int i, float f )
 {
 	lock();
 	sendMessage( message( IdVstSetParameter ).addInt( i ).addFloat( f ) );
-	//waitForMessage( IdVstSetParameter );
+	//waitForMessage( IdVstSetParameter, true );
 	unlock();
 }
 
@@ -640,7 +640,7 @@ void VstPlugin::loadChunk( const QByteArray & _chunk )
 					QSTR_TO_STDSTR(
 						QDir::toNativeSeparators( tf.fileName() ) ) ).
 				addInt( _chunk.size() ) );
-		waitForMessage( IdLoadSettingsFromFile );
+		waitForMessage( IdLoadSettingsFromFile, true );
 		unlock();
 	}
 }
@@ -659,7 +659,7 @@ QByteArray VstPlugin::saveChunk()
 				addString(
 					QSTR_TO_STDSTR(
 						QDir::toNativeSeparators( tf.fileName() ) ) ) );
-		waitForMessage( IdSaveSettingsToFile );
+		waitForMessage( IdSaveSettingsToFile, true );
 		unlock();
 		a = tf.readAll();
 	}

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -481,6 +481,12 @@ bool RemotePlugin::processMessage( const message & _m )
 			resizeSharedProcessingMemory();
 			break;
 
+		case IdChangeInputOutputCount:
+			m_inputCount = _m.getInt( 0 );
+			m_outputCount = _m.getInt( 1 );
+			resizeSharedProcessingMemory();
+			break;
+
 		case IdDebugMessage:
 			fprintf( stderr, "RemotePlugin::DebugMessage: %s",
 						_m.getString( 0 ).c_str() );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1541,7 +1541,9 @@ void MainWindow::autoSave()
 					"enablerunningautosave" ).toInt() ||
 				! Engine::getSong()->isPlaying() ) )
 	{
-		Engine::getSong()->saveProjectFile(ConfigManager::inst()->recoveryFile());
+		AutoSaveThread * ast = new AutoSaveThread();
+		connect( ast, SIGNAL( finished() ), ast, SLOT( deleteLater() ) );
+		ast->start();
 		autoSaveTimerReset();  // Reset timer
 	}
 	else
@@ -1552,4 +1554,12 @@ void MainWindow::autoSave()
 			autoSaveTimerReset( m_autoSaveShortTime );
 		}
 	}
+}
+
+
+
+
+void AutoSaveThread::run()
+{
+	Engine::getSong()->saveProjectFile(ConfigManager::inst()->recoveryFile());
 }


### PR DESCRIPTION
Fixes #1008, fixes #1183, fixes #3274.

All problems referred to here I've (re)produced on 64-bit Windows 10.

I've experienced #1183 (or something matching the description), and it is caused by a deadlock during autosave. During the autosave, LMMS sends a message to the plugin (generally `IdSaveSettingsToFile`) and waits for a response. This message is picked up by the processing thread in RemoteVstPlugin and posted to the main UI thread. Usually the UI thread then receives the message, saves a chunk to a temporary file and sends a response. However, in the case of the crash, the main thread is processing some other window message (from what I've found, it always seems to be [`WM_SETCURSOR`](https://msdn.microsoft.com/en-us/library/windows/desktop/ms648382(v=vs.85).aspx)). Messages such as this one, if not handled by a window's WindowProc, are instead sent to the parent window. Thus if the plugin doesn't handle WM_SETCURSOR, it is forwarded to LMMS and the OS waits for the message to be processed. This is the deadlock; LMMS's UI thread is blocking on RemoteVstPlugin's, and vice versa.

This PR fixes the issue by passing `true` as a second argument to `RemotePluginBase::waitForMessage` in any method which may be called from LMMS's UI thread, causing LMMS to continue to process events while waiting for the reply. Note that this does not need to be done for ZynAddSubFx, as it runs in a separate window and thus will not forward such window messages to LMMS.

This does, however, introduce a new issue, where the UI thread may attempt to communicate with RemoteVstPlugin in response to a new event while still waiting on a reply to an earlier message. This will cause the UI thread to attempt to acquire the plugin mutex twice and thus block on itself. This isn't an issue usually, as such events tend to be user-input driven and the message loop in `RemotePluginBase::waitForMessage` specifies `QEventLoop::ExcludeUserInputEvents` as an argument to `QCoreApplication::processEvents`. However, autosaving is carried out on the UI thread and is triggered by a timer, and so may cause an issue here. Thus this PR moves autosaving to a new thread, and in general any automatic VST communication should be carried out in a different thread from now on so as to avoid deadlock. Additionally, this also causes message-waiting code that is sometimes called from the UI thread, and sometimes from other threads, to always run a message loop in `RemotePluginBase::waitForMessage`. This is unnecessary when not on the UI thread and will waste CPU cycles, so this PR also modifies `waitForMessage` to ignore its second argument if not called from the UI thread.

\#1008 is a similar issue, and has the same fix. Kontakt, when loading settings back in, attempts to display a modal dialog. This appears to involve dispatching a message to the VST's parent window, although I have been unable to discover which message this is as it is dispatched and remains undelivered entirely inside the Windows kernel. Nevertheless, the previous changes have fixed this and projects using Kontakt can now be loaded successfully.

This PR also fixes another VST-related hang. Currently, RemoteVstPlugin receives messages in its processing thread, and, unless these are messages designed to be processed in real time (i.e. MIDI events and sound processing), they are sent to be handled by the UI thread by wrapping them in a Windows user message and passing it to `PostThreadMessage` along with a handle to the UI thread. The UI thread then processes these messages in its message loop as it receives them. However, there is a problem: [thread messages are eaten by modal loops](https://blogs.msdn.microsoft.com/oldnewthing/20050426-18/?p=35783). Such modal loops are how Windows implements modal dialogs; thus any message that is sent while a modal dialog is open will disappear, causing a hang if LMMS is waiting for a reply. This can be seen, for example, on 1.2.0-rc3 by opening a modal dialog on a VST plugin (e.g. by clicking Kontakt's 'Options' button), then leaving it open while the autosave kicks in. Autosaving has been moved to a new thread, but there are other messages from which LMMS expects a reply, so the problem should be addressed. This is fixed by using a standard WindowProc as a callback. The dummy window currently used for receiving timer events has been repurposed to receive all messages sent to the UI thread, and the `PostThreadMessage` calls have been replaced by `PostMessage`. There are a couple of new synchronization constructs introduced as it is now possible for the VST to re-call the WindowProc whilst handling a message.

Now fixes #2784, fixes #2157, fixes #1468 too.