### PR TITLE
Suppress midi in events on export

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -237,6 +237,11 @@ MidiEvent InstrumentTrack::applyMasterKey( const MidiEvent& event )
 
 void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
 {
+	if( Engine::getSong()->isExporting() )
+	{
+		return;
+	}
+
 	bool eventHandled = false;
 
 	switch( event.type() )


### PR DESCRIPTION
Addresses https://github.com/LMMS/lmms/issues/3747. This suppresses midi events (sustain pedal, key press) triggered during export. It does however not clear out midi events in effect while starting the export.