### PR TITLE
Fix Vibed when the "P" parameter has non-zero value

### DIFF
--- a/plugins/vibed/vibrating_string.h
+++ b/plugins/vibed/vibrating_string.h
@@ -130,7 +130,7 @@ private:
 				offset =  ( m_randomize / 2.0f -
 						m_randomize ) * r;
 				_dl->data[i] = _scale *
-						_values[_dl->length - i] +
+						_values[_dl->length - i - 1] +
 						offset;
 			}
 			for( int i = _pick; i < _dl->length; i++ )


### PR DESCRIPTION
Fixes #3663. Current code reads value data from wrong indexes.
To correct it, ` - 1` have been added.