### PR TITLE
Fix empty VST tracks creating noise in playback

### DIFF
--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -32,6 +32,7 @@
 #include <QMenu>
 #include <QDomElement>
 
+#include "BufferManager.h"
 #include "Engine.h"
 #include "gui_templates.h"
 #include "InstrumentPlayHandle.h"
@@ -281,15 +282,18 @@ void vestigeInstrument::loadFile( const QString & _file )
 void vestigeInstrument::play( sampleFrame * _buf )
 {
 	m_pluginMutex.lock();
+
+	const fpp_t frames = Engine::mixer()->framesPerPeriod();
+
 	if( m_plugin == NULL )
 	{
+		BufferManager::clear( _buf, frames );
+
 		m_pluginMutex.unlock();
 		return;
 	}
 
 	m_plugin->process( NULL, _buf );
-
-	const fpp_t frames = Engine::mixer()->framesPerPeriod();
 
 	instrumentTrack()->processAudioBuffer( _buf, frames, NULL );
 


### PR DESCRIPTION
Fixes #3308. Clear the buffer in `vestigeInstrument::play` if no plugin is present.