### PR TITLE
Fix sound while playing from piano roll, when BB tracks are muted

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -586,7 +586,10 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 	{
 		TrackContentObject * tco = getTCO( _tco_num );
 		tcos.push_back( tco );
-		bb_track = BBTrack::findBBTrack( _tco_num );
+		if (trackContainer() == (TrackContainer*)Engine::getBBTrackContainer())
+		{
+			bb_track = BBTrack::findBBTrack( _tco_num );
+		}
 	}
 	else
 	{

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -157,7 +157,8 @@ InstrumentTrack::~InstrumentTrack()
 void InstrumentTrack::processAudioBuffer( sampleFrame* buf, const fpp_t frames, NotePlayHandle* n )
 {
 	// we must not play the sound if this InstrumentTrack is muted...
-	if( isMuted() || ( n && n->isBbTrackMuted() ) || ! m_instrument )
+	if( isMuted() || ( Engine::getSong()->playMode() != Song::Mode_PlayPattern &&
+				n && n->isBbTrackMuted() ) || ! m_instrument )
 	{
 		return;
 	}

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -587,7 +587,10 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 			return false;
 		}
 		tcos.push_back( getTCO( _tco_num ) );
-		bb_track = BBTrack::findBBTrack( _tco_num );
+		if (trackContainer() == (TrackContainer*)Engine::getBBTrackContainer())
+		{
+			bb_track = BBTrack::findBBTrack( _tco_num );
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #1947, fixes #3379.
First commit fixes playback for patterns in main song. If a track is not in the `BBTrackContainer`, we don't need to set parent BB track of play handle.
Second commit is about pattens in BB. A pattern in BB editor won't be played if the parent BB track is muted. The only exception is playing the pattern in Piano-Roll. So this commit fixes this exceptional case.