### PR TITLE
Don't use VST-provided memory when loading chunks

### DIFF
--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -101,6 +101,7 @@ const int effEditOpen = 14;
 const int effEditClose = 15;
 const int effEditIdle = 19;
 const int effEditTop = 20;
+const int effSetChunk = 24;
 const int effProcessEvents = 25;
 const int effGetEffectName = 45;
 const int effGetVendorString = 47;

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1385,20 +1385,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 
 void RemoteVstPlugin::loadChunkFromFile( const std::string & _file, int _len )
 {
-	char * buf = NULL;
-
-	void * chunk = NULL;
-	// various plugins need this in order to not crash when setting
-	// chunk (also we let the plugin allocate "safe" memory this way)
-	const int actualLen = pluginDispatch( 23, 0, 0, &chunk );
-
-	// allocated buffer big enough?
-	if( _len > actualLen )
-	{
-		// no, then manually allocate a buffer
-		buf = new char[_len];
-		chunk = buf;
-	}
+	char * chunk = new char[_len];
 
 	const int fd = open( _file.c_str(), O_RDONLY | O_BINARY );
 	if ( ::read( fd, chunk, _len ) != _len )
@@ -1406,9 +1393,10 @@ void RemoteVstPlugin::loadChunkFromFile( const std::string & _file, int _len )
 		fprintf( stderr, "Error loading chunk from file.\n" );
 	}
 	close( fd );
-	pluginDispatch( 24, 0, _len, chunk );
 
-	delete[] buf;
+	pluginDispatch( effSetChunk, 0, _len, chunk );
+
+	delete[] chunk;
 }
 
 


### PR DESCRIPTION
Fixes #493. May potentially break some other plugins, see [this comment on the issue](https://github.com/LMMS/lmms/issues/493#issuecomment-328919040).