### PR TITLE
Don't let plugins make the main window transparent

### DIFF
--- a/include/MainApplication.h
+++ b/include/MainApplication.h
@@ -25,13 +25,22 @@
 #ifndef MAINAPPLICATION_H
 #define MAINAPPLICATION_H
 
+#include "lmmsconfig.h"
+
 #include <QApplication>
+
+#ifdef LMMS_BUILD_WIN32
+#include <windows.h>
+#endif
 
 class MainApplication : public QApplication
 {
 public:
 	MainApplication(int& argc, char** argv);
 	bool event(QEvent* event);
+#ifdef LMMS_BUILD_WIN32
+	bool winEventFilter(MSG* msg, long* result);
+#endif
 	inline QString& queuedFile()
 	{
 	    return m_queuedFile;

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -62,3 +62,24 @@ bool MainApplication::event(QEvent* event)
 			return QApplication::event(event);
 	}
 }
+
+#ifdef LMMS_BUILD_WIN32
+bool MainApplication::winEventFilter(MSG* msg, long* result)
+{
+	switch(msg->message)
+	{
+		case WM_STYLECHANGING:
+			if(msg->wParam == GWL_EXSTYLE)
+			{
+				// Prevent plugins making the main window transparent
+				STYLESTRUCT * style = reinterpret_cast<STYLESTRUCT *>(msg->lParam);
+				style->styleNew &= ~WS_EX_LAYERED;
+				*result = 0;
+				return true;
+			}
+			return false;
+		default:
+			return false;
+	}
+}
+#endif

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -73,7 +73,10 @@ bool MainApplication::winEventFilter(MSG* msg, long* result)
 			{
 				// Prevent plugins making the main window transparent
 				STYLESTRUCT * style = reinterpret_cast<STYLESTRUCT *>(msg->lParam);
-				style->styleNew &= ~WS_EX_LAYERED;
+				if(!(style->styleOld & WS_EX_LAYERED))
+				{
+					style->styleNew &= ~WS_EX_LAYERED;
+				}
 				*result = 0;
 				return true;
 			}


### PR DESCRIPTION
Some plugins, e.g. Blue Cat's VSTs, have an opacity control which, in LMMS, makes the main window transparent. This PR blocks this behaviour under Windows by preventing the `WS_EX_LAYERED` extended window style from being set.