### PR TITLE
fixing C abs/C++ abs mix up

### DIFF
--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -104,7 +104,7 @@ AudioSndio::AudioSndio(bool & _success_ful, Mixer * _mixer) :
 	if (reqpar.pchan != m_par.pchan ||
 		reqpar.bits != m_par.bits ||
 		reqpar.le != m_par.le ||
-		(abs(reqpar.rate - m_par.rate) * 100)/reqpar.rate > 2)
+		(::abs(static_cast<int>(reqpar.rate) - static_cast<int>(m_par.rate)) * 100)/reqpar.rate > 2)
 	{
 		printf( "sndio: returned params not as requested\n" );
 		return;


### PR DESCRIPTION
from 6.2, it will clang/libc++ thus moving from gcc 4.9 to this compiler for testing openbsd build which raised a little issue with abs call mixing up with its C++ counterpart. casting rate field to int explicitly. A similar fix would follow for stable-1.2