### PR TITLE
Stop some autosave crashes

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -249,11 +249,4 @@ signals:
 
 } ;
 
-class AutoSaveThread : public QThread
-{
-	Q_OBJECT
-public:
-	void run();
-} ;
-
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -54,6 +54,7 @@
 #include "PluginView.h"
 #include "ProjectJournal.h"
 #include "ProjectNotes.h"
+#include "RemotePlugin.h"
 #include "SetupDialog.h"
 #include "SideBar.h"
 #include "SongEditor.h"
@@ -1535,14 +1536,14 @@ void MainWindow::browseHelp()
 void MainWindow::autoSave()
 {
 	if( !Engine::getSong()->isExporting() &&
+		!Engine::getSong()->isLoadingProject() &&
+		!RemotePluginBase::isMainThreadWaiting() &&
 		!QApplication::mouseButtons() &&
-			( ConfigManager::inst()->value( "ui",
-					"enablerunningautosave" ).toInt() ||
-				! Engine::getSong()->isPlaying() ) )
+		( ConfigManager::inst()->value( "ui",
+				"enablerunningautosave" ).toInt() ||
+			! Engine::getSong()->isPlaying() ) )
 	{
-		AutoSaveThread * ast = new AutoSaveThread();
-		connect( ast, SIGNAL( finished() ), ast, SLOT( deleteLater() ) );
-		ast->start();
+		Engine::getSong()->saveProjectFile(ConfigManager::inst()->recoveryFile());
 		autoSaveTimerReset();  // Reset timer
 	}
 	else
@@ -1553,12 +1554,4 @@ void MainWindow::autoSave()
 			autoSaveTimerReset( m_autoSaveShortTime );
 		}
 	}
-}
-
-
-
-
-void AutoSaveThread::run()
-{
-	Engine::getSong()->saveProjectFile(ConfigManager::inst()->recoveryFile());
 }


### PR DESCRIPTION
Move autosaving back to the main thread as `Song::saveProjectFile` doesn't appear to be thread-safe. Instead prevent autosave triggering during main thread VST communication by tracking call depth to `RemotePlugin::waitForMessage`.

Prevent autosave triggering during project load.