### PR TITLE
Fix #3842: Opening a project with LB302 with specific waveforms produces a noise burst.

### DIFF
--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -284,8 +284,12 @@ lb302Synth::lb302Synth( InstrumentTrack * _instrumentTrack ) :
 	slideToggle( false, this, tr( "Slide" ) ),
 	accentToggle( false, this, tr( "Accent" ) ),
 	deadToggle( false, this, tr( "Dead" ) ),
-	db24Toggle( false, this, tr( "24dB/oct Filter" ) )
-
+	db24Toggle( false, this, tr( "24dB/oct Filter" ) ),
+	vca_attack(1.0 - 0.96406088),
+	vca_decay(0.99897516),
+	vca_a0(0.5),
+	vca_a(0.),
+	vca_mode(3)
 {
 
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged( ) ),
@@ -327,19 +331,7 @@ lb302Synth::lb302Synth( InstrumentTrack * _instrumentTrack ) :
 
 	vcf_envpos = ENVINC;
 
-	// Start VCA on an attack.
-	vca_mode = 3;
-	vca_a = 0;
-
-	//vca_attack = 1.0 - 0.94406088;
-	vca_attack = 1.0 - 0.96406088;
-	vca_decay = 0.99897516;
-
 	vco_shape = BL_SAWTOOTH;
-
-	// Experimenting with a0 between original (0.5) and 1.0
-	vca_a0 = 0.5;
-	vca_mode = 3;
 
 	vcfs[0] = new lb302FilterIIR2(&fs);
 	vcfs[1] = new lb302Filter3Pole(&fs);

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -339,7 +339,6 @@ lb302Synth::lb302Synth( InstrumentTrack * _instrumentTrack ) :
 
 	// Experimenting with a0 between original (0.5) and 1.0
 	vca_a0 = 0.5;
-	vca_a = 9;
 	vca_mode = 3;
 
 	vcfs[0] = new lb302FilterIIR2(&fs);

--- a/plugins/lb302/lb302.h
+++ b/plugins/lb302/lb302.h
@@ -224,7 +224,14 @@ private:
 	      vca_a;            // Amplifier coefficient.
 
 	// Envelope State
-	int   vca_mode;         // 0: attack, 1: decay, 2: idle, 3: never played
+	enum VCA_Mode
+	{
+		attack = 0,
+		decay = 1,
+		idle = 2,
+		never_played = 3
+	};
+	VCA_Mode vca_mode;
 
 	// My hacks
 	int   sample_cnt;


### PR DESCRIPTION
Fix the problem described in #3842 by removing a duplicate initialization of a VCA variable. Also clean up some code by
* moving the initialization of the VCA related variables into the constructor initializer list and
* introducing an enum for the VCA mode.