### PR TITLE
Update the grid after changing the quantization value in automation editor.

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2100,6 +2100,8 @@ void AutomationEditor::setQuantization()
 	}
 	quantization = DefaultTicksPerTact / quantization;
 	AutomationPattern::setQuantization( quantization );
+
+	update();
 }
 
 


### PR DESCRIPTION
Fixes that changing the quantization value in automation editor doesn't update the grid until clicking or moving inside of it, by adding a call to `update()` at the end of `setQuantization()`.