### PR TITLE
Fixing the arpeggiator

### DIFF
--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -305,7 +305,7 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	m_arpCycleModel( 0.0f, 0.0f, 6.0f, 1.0f, this, tr( "Cycle steps" ) ),
 	m_arpSkipModel( 0.0f, 0.0f, 100.0f, 1.0f, this, tr( "Skip rate" ) ),
 	m_arpMissModel( 0.0f, 0.0f, 100.0f, 1.0f, this, tr( "Miss rate" ) ),
-	m_arpTimeModel( 100.0f, 25.0f, 2000.0f, 1.0f, 2000, this, tr( "Arpeggio time" ) ),
+	m_arpTimeModel( 200.0f, 25.0f, 2000.0f, 1.0f, 2000, this, tr( "Arpeggio time" ) ),
 	m_arpGateModel( 100.0f, 1.0f, 200.0f, 1.0f, this, tr( "Arpeggio gate" ) ),
 	m_arpDirectionModel( this, tr( "Arpeggio direction" ) ),
 	m_arpModeModel( this, tr( "Arpeggio mode" ) )
@@ -396,14 +396,13 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		frames_processed += remaining_frames_for_cur_arp;
 
-		// init with zero
-		int cur_arp_idx = 0;
-
 		// in sorted mode: is it our turn or do we have to be quiet for
 		// now?
 		if( m_arpModeModel.value() == SortMode &&
 				( ( cur_frame / arp_frames ) % total_range ) / range != (f_cnt_t) _n->index() )
 		{
+			// Set master note if not playing arp note or it will play as an ordinary note
+			_n->setMasterNote();
 			// update counters
 			frames_processed += arp_frames;
 			cur_frame += arp_frames;
@@ -416,10 +415,9 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 			if( 100 * ( (float) rand() / (float)( RAND_MAX + 1.0f ) ) < m_arpSkipModel.value() )
 			{
-				if( cur_arp_idx == 0 )
-				{
-					_n->setMasterNote();
-				}
+				// Set master note to prevent the note to extend over skipped notes
+				// This may only be needed for lb302
+				_n->setMasterNote();
 				// update counters
 				frames_processed += arp_frames;
 				cur_frame += arp_frames;
@@ -440,6 +438,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			}
 		}
 
+		int cur_arp_idx = 0;
 		// process according to arpeggio-direction...
 		if( dir == ArpDirUp )
 		{


### PR DESCRIPTION
Fixing some of the issues with the arpeggiator.

-  [ ] The decay of the last arpeggio note is added to the length of the master note so after the first run there will be extra notes played along with the arpeggio, forming chords or doubling the notes for increased volume.
 `* * *Fix reverted* * *`

-  [x] Sort mode. If the envelopes are off, the notes that should be silent are playing as ordinary notes while waiting for their turn. Solving this by using the same hack as the 'skip' algorithm as it had the same issue.
Set as master note.

-  [ ]  Sort mode. All notes are playing at the beginning of the notes. Fixed this by simplifying the algorithm to set
`int cur_frame` . A bit experimental this one. This issue was introduced in 1.1 .
`* * *Fix reverted* * * `

Adresses https://github.com/LMMS/lmms/issues/3342

---

**Issues remaining**

 * Sort mode. Sometimes notes are skipped.
 * Sort mode. There is no way to know in which order the notes are being handled without displacing them. This is a pretty good way to deal with it actually but it would be better if the default would be to start with the lowest note and then work our way up. To fix this we probably need to sort the cnphv after key value.
 * Skip function. This may only apply to lb302... If you drag an lb302 over a track with envelopes those affect the lb302 in such a way that notes keep sounding, in a legato kind of way, for as long as notes after it are skipped.