### PR TITLE
Fix arpeggio sort mode

### DIFF
--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -524,6 +524,13 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		frames_processed += arp_frames;
 		cur_frame += arp_frames;
 	}
+
+	// make sure note is handled as arp-base-note, even
+	// if we didn't add a sub-note so far
+	if( m_arpModeModel.value() != FreeMode )
+	{
+		_n->setMasterNote();
+	}
 }
 
 


### PR DESCRIPTION
When in sort mode and playing over multiple base notes, in the
beginning of the notes there is a chance that the notes will play
together as an ordinary chord instead of arpeggiate.
This is a regression from 6650dd3.

The fix reimplements [this part](https://github.com/LMMS/lmms/blob/c7e7748bc3bef0ece230e0dd8fd8daac8b335ded/src/core/InstrumentFunctions.cpp#L502:L507) that was dropped.

Fixes #3342