### PR TITLE
Note sorting algorithm rework

### DIFF
--- a/include/Note.h
+++ b/include/Note.h
@@ -113,11 +113,19 @@ public:
 	void quantizeLength( const int qGrid );
 	void quantizePos( const int qGrid );
 
-	static inline bool lessThan( Note * &lhs, Note * &rhs )
+	static inline bool lessThan( const Note * lhs, const Note * rhs )
 	{
 		// function to compare two notes - must be called explictly when
 		// using qSort
-		return (bool) ((int) ( *lhs ).pos() < (int) ( *rhs ).pos());
+		if( (int)( *lhs ).pos() < (int)( *rhs ).pos() )
+		{
+			return true;
+		}
+		else if( (int)( *lhs ).pos() > (int)( *rhs ).pos() )
+		{
+			return false;
+		}
+		return ( (int)( *lhs ).key() > (int)( *rhs ).key() );
 	}
 
 	inline bool selected() const

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -271,7 +271,7 @@ Note * Pattern::noteAtStep( int _step )
 void Pattern::rearrangeAllNotes()
 {
 	// sort notes by start time
-	qSort(m_notes.begin(), m_notes.end(), Note::lessThan );
+	std::sort(m_notes.begin(), m_notes.end(), Note::lessThan);
 }
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -213,28 +213,7 @@ Note * Pattern::addNote( const Note & _new_note, const bool _quant_pos )
 	}
 
 	instrumentTrack()->lock();
-	if( m_notes.size() == 0 || m_notes.back()->pos() <= new_note->pos() )
-	{
-		m_notes.push_back( new_note );
-	}
-	else
-	{
-		// simple algorithm for inserting the note between two
-		// notes with smaller and greater position
-		// maybe it could be optimized by starting in the middle and
-		// going forward or backward but note-inserting isn't that
-		// time-critical since it is usually not done while playing...
-		long new_note_abs_time = new_note->pos();
-		NoteVector::Iterator it = m_notes.begin();
-
-		while( it != m_notes.end() &&
-					( *it )->pos() < new_note_abs_time )
-		{
-			++it;
-		}
-
-		m_notes.insert( it, new_note );
-	}
+	m_notes.insert(std::upper_bound(m_notes.begin(), m_notes.end(), new_note, Note::lessThan), new_note);
 	instrumentTrack()->unlock();
 
 	checkType();


### PR DESCRIPTION
Addresses some of the issues in https://github.com/LMMS/lmms/issues/3880

 Sorting after position and key. Probably only needed with the arpeggiator. This works well and doesn't seem to use a whole lot cpu cycles. The notes are sorted on input from mouse or keyboard in ` Pattern::addNote()`. Actions on the notes in the Piano Roll also triggers a sort via `Pattern::rearrangeAllNotes()` with a helper function in note.h . The sorting is duplicated when adding notes in the Piano Roll and this has its own post in https://github.com/LMMS/lmms/issues/3880 but is probably a wontfix.

I've pulled these against stable-1.2 but they can just as well go into master or be split over the two.







