### PR TITLE
Benchmark the user/system time usage for exports. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ OPTION(WANT_VST_NOWINE	"Include partial VST support (without wine)" OFF)
 OPTION(WANT_WINMM	"Include WinMM MIDI support" OFF)
 OPTION(WANT_QT5		"Build with Qt5" OFF)
 OPTION(WANT_DEBUG_FPE	"Debug floating point exceptions" OFF)
+OPTION(WANT_DEBUG_RTIME "Debug render times" OFF)
 
 
 IF(LMMS_BUILD_APPLE)
@@ -469,6 +470,17 @@ ELSE()
 	SET (STATUS_DEBUG_FPE "Disabled")
 ENDIF(WANT_DEBUG_FPE)
 
+IF(WANT_DEBUG_RTIME)
+	IF(LMMS_BUILD_LINUX)
+		SET(LMMS_DEBUG_RENDERTIME TRUE)
+		SET (STATUS_DEBUG_RTIME "Enabled")
+	ELSE()
+		SET (STATUS_DEBUG_RTIME "Wanted but disabled due to unsupported platform")
+	ENDIF()
+ELSE()
+	SET (STATUS_DEBUG_RTIME "Disabled")
+ENDIF(WANT_DEBUG_RTIME)
+
 
 # check for libsamplerate
 PKG_CHECK_MODULES(SAMPLERATE REQUIRED samplerate>=0.1.8)
@@ -654,6 +666,7 @@ MESSAGE(
 "Developer options\n"
 "-----------------------------------------\n"
 "* Debug FP exceptions         : ${STATUS_DEBUG_FPE}\n"
+"* Debug render times          : ${STATUS_DEBUG_RTIME}\n"
 )
 
 MESSAGE(

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -37,6 +37,11 @@
 #include "sched.h"
 #endif
 
+#ifdef LMMS_DEBUG_RENDERTIME
+#include <sys/times.h>
+#include <unistd.h>
+#endif
+
 const ProjectRenderer::FileEncodeDevice ProjectRenderer::fileEncodeDevices[] =
 {
 
@@ -179,6 +184,13 @@ void ProjectRenderer::run()
 #endif
 #endif
 #endif
+#ifdef LMMS_DEBUG_RENDERTIME
+	static clock_t t1;
+	static clock_t t2;
+	static struct tms t1_cpu;
+	static struct tms t2_cpu;
+	t1=times(&t1_cpu);
+#endif
 
 	Engine::getSong()->startExport();
 	Engine::getSong()->updateLength();
@@ -211,7 +223,16 @@ void ProjectRenderer::run()
 	Engine::mixer()->stopProcessing();
 
 	Engine::getSong()->stopExport();
-
+	
+#ifdef LMMS_DEBUG_RENDERTIME
+	long cputicks = sysconf(_SC_CLK_TCK);
+	t2 = times(&t2_cpu);
+	
+	fprintf(stderr,"Real Time: %.2f, User Time %.2f, System Time %.2f\n",
+	       (float)(t2 - t1)/cputicks,
+	       (float)(t2_cpu.tms_utime - t1_cpu.tms_utime)/cputicks,
+	       (float)(t2_cpu.tms_stime - t1_cpu.tms_stime)/cputicks);
+#endif
 	// if the user aborted export-process, the file has to be deleted
 	const QString f = m_fileDev->outputFile();
 	if( m_abort )

--- a/src/lmmsconfig.h.in
+++ b/src/lmmsconfig.h.in
@@ -25,6 +25,7 @@
 #cmakedefine LMMS_HAVE_SF_COMPLEVEL
 
 #cmakedefine LMMS_DEBUG_FPE
+#cmakedefine LMMS_DEBUG_RENDERTIME
 
 #cmakedefine LMMS_HAVE_STDINT_H
 #cmakedefine LMMS_HAVE_STDLIB_H


### PR DESCRIPTION
I think this could be useful for quick checks on what the effects on performance are when modifying code. Startup, project loading and teardown are ignored as this only concerns the export phase.

Add -DWANT_DEBUG_RTIME=true to the cmake options to enable this feature.

