### PR TITLE
Fix sfxr buffer noise

### DIFF
--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -464,6 +464,7 @@ void sfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffe
 	}
 	else if( static_cast<SfxrSynth*>(_n->m_pluginData)->isPlaying() == false )
 	{
+		memset(_working_buffer + offset, 0, sizeof(sampleFrame) * frameNum);
 		_n->noteOff();
 		return;
 	}


### PR DESCRIPTION
Fixes #3383 by zeroing buffer out. Actually I don't exactly know why it works...