### PR TITLE
Fix destructor call in NotePlayHandleManager

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -66,8 +66,7 @@ public:
 					NotePlayHandle* parent = NULL,
 					int midiEventChannel = -1,
 					Origin origin = OriginPattern );
-	virtual ~NotePlayHandle() {}
-	void done();
+	virtual ~NotePlayHandle();
 
 	void * operator new ( size_t size, void * p )
 	{

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -128,7 +128,7 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 }
 
 
-void NotePlayHandle::done()
+NotePlayHandle::~NotePlayHandle()
 {
 	lock();
 	noteOff( 0 );
@@ -599,7 +599,7 @@ NotePlayHandle * NotePlayHandleManager::acquire( InstrumentTrack* instrumentTrac
 
 void NotePlayHandleManager::release( NotePlayHandle * nph )
 {
-	nph->done();
+	nph->NotePlayHandle::~NotePlayHandle();
 	s_mutex.lockForRead();
 	s_available[ s_availableIndex.fetchAndAddOrdered( 1 ) + 1 ] = nph;
 	s_mutex.unlock();


### PR DESCRIPTION
Fixes a regression from #3783 due to missing destructor call. It should have been added in 42e67d2, but not.
Since `BufferManager::releaseBuffer()` call is moved in #3783, buffer isn't freed(by `MM_FREE()`) in `NotePlayHandle::done()`. It isn't a memory leak because  `MemoryManager` works as a garbage collector, but decreases usable memory.
This PR also makes sure `PlayHandle::m_processingLock`'s destructor is called.