### PR TITLE
Switch Travis-CI to Qt5.8

### DIFF
--- a/.travis/linux..before_install.sh
+++ b/.travis/linux..before_install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
 sudo add-apt-repository ppa:andrewrk/libgroove -y
 sudo sed -e "s/trusty/precise/" -i \
 	/etc/apt/sources.list.d/andrewrk-libgroove-trusty.list

--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -9,7 +9,7 @@ PACKAGES="cmake libsndfile-dev fftw3-dev libvorbis-dev libogg-dev libmp3lame-dev
 PACKAGES="$PACKAGES libjack0"
 
 if [ $QT5 ]; then
-	PACKAGES="$PACKAGES qtbase5-dev qttools5-dev-tools qttools5-dev"
+	PACKAGES="$PACKAGES qt58base qt58translations qt58tools"
 else
 	PACKAGES="$PACKAGES libqt4-dev"
 fi

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
+if [ $QT5 ]; then
+	unset QTDIR QT_PLUGIN_PATH LD_LIBRARY_PATH
+	source /opt/qt58/bin/qt58-env.sh
+fi
 
 cmake -DUSE_WERROR=ON $CMAKE_FLAGS ..


### PR DESCRIPTION
Per #3688, the `.AppImage` installers should ship with Qt 5.8 or higher.  Travis-CI needs this as part of its build steps for automated `.AppImage` downloads.

If someone has a newer PPA for Qt, please post it here.  A follow-up task of updating our documentation should happen once this is merged so that developers too have access to the latest Qt version.