### PR TITLE
ZynAddSubFx: Fix preset loading

### DIFF
--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -445,8 +445,8 @@ void ZynAddSubFxInstrument::initPlugin()
 			RemotePlugin::message( IdZasfPresetDirectory ).
 				addString(
 					QSTR_TO_STDSTR(
-						QString( ConfigManager::inst()->factoryPresetsDir() +
-								QDir::separator() + "ZynAddSubFX" ) ) ) );
+						QDir( ConfigManager::inst()->factoryPresetsDir() +
+								"/ZynAddSubFX" ).absolutePath() ) ) );
 
 		m_remotePlugin->updateSampleRate( Engine::mixer()->processingSampleRate() );
 


### PR DESCRIPTION
@tresf I can't reproduce the "Zyn exports as sine-wave" part from #3886. Does this change fix that issue as well?

Here's an AppImage for testing: https://transfer.sh/12r7NT/lmms-1.2.0-rc4.12-linux-x86_64.AppImage.zip

Fixes #3886, a regression from #1719