### PR TITLE
Ignore release frames for single-streamed instruments

### DIFF
--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -299,13 +299,18 @@ f_cnt_t InstrumentSoundShaping::envFrames( const bool _only_vol ) const
 
 f_cnt_t InstrumentSoundShaping::releaseFrames() const
 {
+	f_cnt_t ret_val = m_instrumentTrack->instrument()
+		? m_instrumentTrack->instrument()->desiredReleaseFrames()
+		: 0;
+	if( !m_instrumentTrack->instrument()->flags().testFlag( Instrument::IsSingleStreamed ) )
+	{
+		return ret_val;
+	}
+
 	if( m_envLfoParameters[Volume]->isUsed() )
 	{
 		return m_envLfoParameters[Volume]->releaseFrames();
 	}
-	f_cnt_t ret_val = m_instrumentTrack->instrument() 
-		? m_instrumentTrack->instrument()->desiredReleaseFrames()
-		: 0;
 
 	for( int i = Volume+1; i < NumTargets; ++i )
 	{

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -303,9 +303,9 @@ f_cnt_t InstrumentSoundShaping::releaseFrames() const
 	{
 		return 0;
 	}
-	
+
 	f_cnt_t ret_val = m_instrumentTrack->instrument()->desiredReleaseFrames();
-	
+
 	if( !m_instrumentTrack->instrument()->flags().testFlag( Instrument::IsSingleStreamed ) )
 	{
 		return ret_val;

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -306,7 +306,7 @@ f_cnt_t InstrumentSoundShaping::releaseFrames() const
 
 	f_cnt_t ret_val = m_instrumentTrack->instrument()->desiredReleaseFrames();
 
-	if( !m_instrumentTrack->instrument()->flags().testFlag( Instrument::IsSingleStreamed ) )
+	if( m_instrumentTrack->instrument()->flags().testFlag( Instrument::IsSingleStreamed ) )
 	{
 		return ret_val;
 	}

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -299,9 +299,13 @@ f_cnt_t InstrumentSoundShaping::envFrames( const bool _only_vol ) const
 
 f_cnt_t InstrumentSoundShaping::releaseFrames() const
 {
-	f_cnt_t ret_val = m_instrumentTrack->instrument()
-		? m_instrumentTrack->instrument()->desiredReleaseFrames()
-		: 0;
+	if( !m_instrumentTrack->instrument() )
+	{
+		return 0;
+	}
+	
+	f_cnt_t ret_val = m_instrumentTrack->instrument()->desiredReleaseFrames();
+	
 	if( !m_instrumentTrack->instrument()->flags().testFlag( Instrument::IsSingleStreamed ) )
 	{
 		return ret_val;


### PR DESCRIPTION
Fixes #3899 by letting `InstrumentSoundShaping::releaseFrames()` check `Instrument::IsSingleStreamed` flag.
There is one further option, disabling volume envelope when a single-streamed instrument is dropped(or even loaded). However, this change seems enough.