### PR TITLE
Fix Automation Point delete radius and size

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -132,6 +132,7 @@ protected:
 	void getSelectedValues(timeMap & selected_values );
 
 	void drawLine( int x0, float y0, int x1, float y1 );
+	void removePoints( int x0, int x1 );
 
 protected slots:
 	void play();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1100,7 +1100,7 @@ inline void AutomationEditor::drawAutomationPoint( QPainter & p, timeMap::iterat
 {
 	int x = xCoordOfTick( it.key() );
 	int y = yCoordOfLevel( it.value() );
-	const int outerRadius = qBound( 2, ( m_ppt * AutomationPattern::quantization() ) / 576, 5 ); // man, getting this calculation right took forever
+	const int outerRadius = qBound( 3, ( m_ppt * AutomationPattern::quantization() ) / 576, 5 ); // man, getting this calculation right took forever
 	p.setPen( QPen( vertexColor().lighter( 200 ) ) );
 	p.setBrush( QBrush( vertexColor() ) );
 	p.drawEllipse( x - outerRadius, y - outerRadius, outerRadius * 2, outerRadius * 2 );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -589,6 +589,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 							m_editMode == DRAW ) ||
 					m_editMode == ERASE )
 			{
+				m_drawLastTick = pos_ticks;
 				m_pattern->addJournalCheckPoint();
 				// erase single value
 				if( it != time_map.end() )
@@ -680,6 +681,39 @@ void AutomationEditor::mouseReleaseEvent(QMouseEvent * mouseEvent )
 
 
 
+
+void AutomationEditor::removePoints( int x0, int x1 )
+{
+	int deltax = qAbs( x1 - x0 );
+	int x = x0;
+	int xstep;
+
+	if( deltax < AutomationPattern::quantization() )
+	{
+		return;
+	}
+
+	if( x0 < x1 )
+	{
+		xstep = 1;
+	}
+	else
+	{
+		xstep = -1;
+	}
+
+	int i = 0;
+	while( i <= deltax )
+	{
+		m_pattern->removeValue( MidiTime( x ) );
+		x += xstep;
+		i += 1;
+	}
+}
+
+
+
+
 void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 {
 	QMutexLocker m( &m_patternMutex );
@@ -735,14 +769,13 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				( mouseEvent->buttons() & Qt::LeftButton &&
 						m_editMode == ERASE ) )
 		{
-			// int resolution needed to improve the sensitivity of
-			// the erase manoeuvre with zoom levels < 100%
-			int zoom = m_zoomingXModel.value();
-			int resolution = 1 + zoom * zoom;
-			for( int i = -resolution; i < resolution; ++i )
+			// removing automation point
+			if( pos_ticks < 0 )
 			{
-				m_pattern->removeValue( MidiTime( pos_ticks + i ) );
+				pos_ticks = 0;
 			}
+			removePoints( m_drawLastTick, pos_ticks );
+			Engine::getSong()->setModified();
 		}
 		else if( mouseEvent->buttons() & Qt::NoButton && m_editMode == DRAW )
 		{


### PR DESCRIPTION
Exchange defective algorithm for Automatin Point delete radius with a new function adapted from `AutomationEditor::drawLine()`,
Increase minimal Automation Point radius by 50%.

The sensitivity for grabbing/moving an Automation Point is still a bit off on the fines quantization levels.

Fixes https://github.com/LMMS/lmms/issues/3896