### PR TITLE
Fix preset preview issues with peak controller(s)

### DIFF
--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -26,6 +26,7 @@
 
 #include "Controller.h"
 #include "Song.h"
+#include "PresetPreviewPlayHandle.h"
 #include "PeakController.h"
 #include "peak_controller_effect.h"
 #include "lmms_math.h"
@@ -67,7 +68,7 @@ PeakControllerEffect::PeakControllerEffect(
 	m_autoController( NULL )
 {
 	m_autoController = new PeakController( Engine::getSong(), this );
-	if( !Engine::getSong()->isLoadingProject() )
+	if( !Engine::getSong()->isLoadingProject() && !PresetPreviewPlayHandle::isPreviewing() )
 	{
 		Engine::getSong()->addController( m_autoController );
 	}

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
@@ -29,7 +29,6 @@
 #include "PeakController.h"
 #include "peak_controller_effect_controls.h"
 #include "peak_controller_effect.h"
-#include "PresetPreviewPlayHandle.h"
 #include "Song.h"
 
 
@@ -79,12 +78,6 @@ void PeakControllerEffectControls::loadSettings( const QDomElement & _this )
 	else
 	{
 		m_effect->m_effectId = rand();
-	}
-
-	if( m_effect->m_autoController && PresetPreviewPlayHandle::isPreviewing() == true )
-	{
-		delete m_effect->m_autoController;
-		m_effect->m_autoController = 0;
 	}
 }
 

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -33,7 +33,6 @@
 #include "Mixer.h"
 #include "EffectChain.h"
 #include "plugins/peak_controller_effect/peak_controller_effect.h"
-#include "PresetPreviewPlayHandle.h"
 
 PeakControllerEffectVector PeakController::s_effects;
 int PeakController::m_getCount;
@@ -64,11 +63,7 @@ PeakController::PeakController( Model * _parent,
 
 PeakController::~PeakController()
 {
-	//EffectChain::loadSettings() appends effect to EffectChain::m_effects
-	//When it's previewing, EffectChain::loadSettings(<Controller Fx XML>) is not called
-	//Therefore, we shouldn't call removeEffect() as it is not even appended.
-	//NB: Most XML setting are loaded on preview, except controller fx.
-	if( m_peakEffect != NULL && m_peakEffect->effectChain() != NULL && PresetPreviewPlayHandle::isPreviewing() == false )
+	if( m_peakEffect != NULL && m_peakEffect->effectChain() != NULL )
 	{
 		m_peakEffect->effectChain()->removeEffect( m_peakEffect );
 	}


### PR DESCRIPTION
Fixes #3897.
This PR ensures peak controller effects from preview track don't instantiate a peak controller and replaces itself to a dummy effect by setting `m_okay` to `false`.
Here's a preset for test: [PeakController.xpf.zip](https://github.com/LMMS/lmms/files/1407220/PeakController.xpf.zip)