### PR TITLE
Fix crashes and deadlocks with previewing preset

### DIFF
--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -67,12 +67,20 @@ public:
 
 	NotePlayHandle* previewNote()
 	{
+	#if QT_VERSION >= 0x050000
 		return m_previewNote.loadAcquire();
+	#else
+		return m_previewNote;
+	#endif
 	}
 
 	void setPreviewNote( NotePlayHandle * _note )
 	{
+	#if QT_VERSION >= 0x050000
 		m_previewNote.storeRelease( _note );
+	#else
+		m_previewNote = _note;
+	#endif
 	}
 
 	bool testAndSetPreviewNote( NotePlayHandle * expectedVal, NotePlayHandle * newVal )

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -228,7 +228,7 @@ bool PresetPreviewPlayHandle::isFinished() const
 
 bool PresetPreviewPlayHandle::isFromTrack( const Track * _track ) const
 {
-	return s_previewTC->previewInstrumentTrack() == _track;
+	return s_previewTC && s_previewTC->previewInstrumentTrack() == _track;
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -442,12 +442,15 @@ void InstrumentTrack::silenceAllNotes( bool removeIPH )
 	m_midiNotesMutex.unlock();
 
 	lock();
-	// invalidate all NotePlayHandles linked to this track
+	// invalidate all NotePlayHandles and PresetPreviewHandles linked to this track
 	m_processHandles.clear();
-	Engine::mixer()->removePlayHandlesOfTypes( this, removeIPH
-				? PlayHandle::TypeNotePlayHandle
-					| PlayHandle::TypeInstrumentPlayHandle
-				: PlayHandle::TypeNotePlayHandle );
+
+	quint8 flags = PlayHandle::TypeNotePlayHandle | PlayHandle::TypePresetPreviewHandle;
+	if( removeIPH )
+	{
+		flags |= PlayHandle::TypeInstrumentPlayHandle;
+	}
+	Engine::mixer()->removePlayHandlesOfTypes( this, flags );
 	unlock();
 }
 


### PR DESCRIPTION
While investigating #3897, I found another bug.
Steps to reproduce:

1. Click any preset on sidebar **and hold it**.
2. Close LMMS with Alt+F4 or Ctrl+Q(**while previewing**).
3. LMMS will crash.

Edit: clarified steps to reproduce.

Here's a part of a backtrace:
```
Thread 1 (Thread 0x7ffff7ee1900 (LWP 11830)):
#0  0x000000000053c74a in PresetPreviewPlayHandle::isFromTrack(Track const*) const ()
#1  0x0000000000526e8c in Mixer::removePlayHandlesOfTypes(Track*, unsigned char) ()
#2  0x00000000006275a7 in InstrumentTrack::silenceAllNotes(bool) ()
#3  0x000000000062c86d in InstrumentTrack::~InstrumentTrack() ()
#4  0x000000000062ca59 in InstrumentTrack::~InstrumentTrack() ()
#5  0x00000000005c54ba in TrackContainerView::clearAllTracks() ()
#6  0x0000000000552a5c in Song::clearProject() ()
#7  0x00000000004fc74f in LmmsCore::destroy() ()
```

So I added `PlayHandle::TypePresetPreviewHandle` in `InstrumentTrack::silenceAllNotes()`. I also add simple safety check code in `PresetPreviewPlayHandle::isFromTrack()`.

Note: `PresetPreviewPlayHandle::play()` does nothing since #2586, so the code below is no longer needed. However, leaving it as-is looks fine for me.
https://github.com/LMMS/lmms/blob/fbfcb43aeb31595433e72cd960d8b807f1ba85ea/src/gui/FileBrowser.cpp#L448-L455


**Edit**: I added a commit which fixes #3456, per https://github.com/LMMS/lmms/pull/3905#issuecomment-339313022.