### PR TITLE
Allow individual velocity/pan changes with alt

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2118,9 +2118,14 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				bool isUnderPosition = n->withinRange( ticks_start, ticks_end );
 				// Play note under the cursor
 				if ( isUnderPosition ) { testPlayNote( n ); }
-				// If note is the one under the cursor or is selected when alt is
-				// not pressed
-				if ( ( isUnderPosition && !isSelection() ) || ( n->selected() && !altPressed ) )
+				// If note is:
+				// Under the cursor, when there is no selection
+				// Selected, and alt is not pressed
+				// Under the cursor, selected, and alt is pressed
+				if ( ( isUnderPosition && !isSelection() ) ||
+					  ( n->selected() && !altPressed ) ||
+					  ( isUnderPosition && n->selected() && altPressed )
+					)
 				{
 					if( m_noteEditMode == NoteEditVolume )
 					{


### PR DESCRIPTION
This commit changes the behavior introduced in 6e3d4f431 to allow using
alt to change the velocity/panning of multiple *selected* notes by dragging.

![Screencapture showing piano roll velocity/pan click+drag behavior with and without Alt held](https://user-images.githubusercontent.com/11167504/32137850-9643f14e-bbdc-11e7-8f3c-791c3712430b.gif (Screencapture showing piano roll velocity/pan click+drag behavior with and without Alt held))

I believe this was the originally intended behavior, but it never worked for me.

Fixes https://github.com/LMMS/lmms/issues/3914