### PR TITLE
linearToLogScale() - Input validation

### DIFF
--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -229,11 +229,12 @@ static inline float logToLinearScale( float min, float max, float value )
 static inline float linearToLogScale( float min, float max, float value )
 {
 	static const float EXP = 1.0f / F_E;
-	const float val = ( value - min ) / ( max - min );
+	const float valueLimited = qBound( min, value, max);
+	const float val = ( valueLimited - min ) / ( max - min );
 	if( min < 0 )
 	{
 		const float mmax = qMax( qAbs( min ), qAbs( max ) );
-		float result = signedPowf( value / mmax, EXP ) * mmax;
+		float result = signedPowf( valueLimited / mmax, EXP ) * mmax;
 		return isnan( result ) ? 0 : result;
 	}
 	float result = powf( val, EXP ) * ( max - min ) + min;


### PR DESCRIPTION
`linearToLogScale()` seem to be called only in `AutomatableModel::inverseScaledValue()` and I don't know what possible issues could come from this. Binding the input value to the max/min values seem like the way to go and pleases the fpe check.

Crash with fpe debug option when opening an LADSPA gui.
```
Program received signal SIGFPE, Arithmetic exception.
0x00007ffff459893f in __ieee754_powf (x=x@entry=-0,00100100099, y=y@entry=0,36787945) at ../sysdeps/ieee754/flt-32/e_powf.c:125
125	../sysdeps/ieee754/flt-32/e_powf.c: No such file or directory.
(gdb) bt full
#0  0x00007ffff459893f in __ieee754_powf (x=x@entry=-0,00100100099, y=y@entry=0,36787945) at ../sysdeps/ieee754/flt-32/e_powf.c:125
        z = <optimized out>
        ax = <optimized out>
...
        iy = 1052531378
        is = <optimized out>
#1  0x00007ffff459d1db in __powf (x=-0,00100100099, y=0,36787945) at w_powf.c:27
        z = <optimized out>
#2  0x00000000004f0954 in linearToLogScale (min=1, max=1000, value=0) at /home/zonkmachine/builds/lmms/lmms/include/lmms_math.h:222
        EXP = 0,36787945
        val = -0,00100100099
        result = 0
#3  0x00000000004f19cb in AutomatableModel::inverseScaledValue (this=0x1924cc0, value=0)
    at /home/zonkmachine/builds/lmms/lmms/src/core/AutomatableModel.cpp:271
No locals.
```