### PR TITLE
Add libjack.so.0 fallback logic for AppImages

### DIFF
--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -109,6 +109,12 @@ if lsmod |grep vboxguest > /dev/null 2>&1; then
    echo "VirtualBox detected.  Forcing libgl software rendering."
    export LIBGL_ALWAYS_SOFTWARE=1;
 fi
+if ldconfig -p | grep libjack.so.0 > /dev/null 2>&1; then
+   echo "Jack appears to be installed on this system, so we'll use it."
+else
+   echo "Jack does not appear to be installed.  That's OK, we'll use a dummy version instead."
+   export LD_LIBRARY_PATH=\$DIR/usr/lib/lmms/optional:\$LD_LIBRARY_PATH
+fi
 QT_X11_NO_NATIVE_MENUBAR=1 QT_AUTO_SCREEN_SCALE_FACTOR=1 \$DIR/usr/bin/lmms.real "\$@"
 EOL
 
@@ -163,6 +169,12 @@ ln -sr  "$VSTBIN" "$VSTLIB"
 
 # Remove wine library conflict
 rm -f "${APPDIR}/usr/lib/libwine.so.1"
+
+# Remove bundled jack library
+rm -f "${APPDIR}/usr/lib/libjack.so.0"
+
+# Make a symlink to a dummy libjack.so.0
+ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -170,11 +170,13 @@ ln -sr  "$VSTBIN" "$VSTLIB"
 # Remove wine library conflict
 rm -f "${APPDIR}/usr/lib/libwine.so.1"
 
-# Remove bundled jack library
-rm -f "${APPDIR}/usr/lib/libjack.so.0"
-
-# Make a symlink to a dummy libjack.so.0
-ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
+# Remove problematic jack library, replace with weakjack
+if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
+   rm -f "${APPDIR}/usr/lib/libjack.so.0"
+   mkdir -p "${APPDIR}usr/lib/lmms/optional/"
+   cp "@CMAKE_BINARY_DIR@/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/weakjack.so"
+   ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
+fi
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,11 +1,12 @@
 IF(LMMS_HAVE_WEAKJACK)
 	set(WEAKJACK core/audio/AudioWeakJack.c)
 
-	# Build libjack.so.0 stub as weakjack.so
+	# Build libjack.so.0 stub as weakjack.so for AppImages
 	IF(LMMS_BUILD_LINUX)
 		ADD_LIBRARY(weakjack MODULE ../../src/core/audio/AudioWeakJack.c)
 		INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/include")
-		INSTALL(TARGETS weakjack LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/lmms/optional")
+		# We can't predict an AppImage build, so stash the build artifact for later
+		INSTALL(TARGETS weakjack LIBRARY DESTINATION "${CMAKE_BINARY_DIR}/optional")
 		SET_TARGET_PROPERTIES(weakjack PROPERTIES PREFIX "" SUFFIX ".so")
 	ENDIF()
 ENDIF()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,13 @@
 IF(LMMS_HAVE_WEAKJACK)
 	set(WEAKJACK core/audio/AudioWeakJack.c)
+
+	# Build libjack.so.0 stub as weakjack.so
+	IF(LMMS_BUILD_LINUX)
+		ADD_LIBRARY(weakjack MODULE ../../src/core/audio/AudioWeakJack.c)
+		INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/include")
+		INSTALL(TARGETS weakjack LIBRARY DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/lmms/optional")
+		SET_TARGET_PROPERTIES(weakjack PROPERTIES PREFIX "" SUFFIX ".so")
+	ENDIF()
 ENDIF()
 	
 set(LMMS_SRCS


### PR DESCRIPTION
Coerce `weakjack` into a library to provide the entry points, but only add it to `LD_LIBRARY_PATH` if `ldconfig` can't find `libjack.so.0`.

Closes #3719