### PR TITLE
Update patterns in song editor after shifting their notes by semitones in piano roll.

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -961,6 +961,7 @@ void PianoRoll::shiftSemiTone( int amount ) // shift notes by amount semitones
 		}
 	}
 
+	m_pattern->rearrangeAllNotes();
 	m_pattern->dataChanged();
 
 	// we modified the song

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -961,6 +961,8 @@ void PianoRoll::shiftSemiTone( int amount ) // shift notes by amount semitones
 		}
 	}
 
+	m_pattern->dataChanged();
+
 	// we modified the song
 	update();
 	gui->songEditor()->update();


### PR DESCRIPTION
Fixes that shifting notes by semitones in piano roll doesn't update their pattern in song editor, by adding a call to `m_pattern->dataChanged()` in `PianoRoll::shiftSemiTone()`.