### PR TITLE
Patch exprtk on Clang

### DIFF
--- a/plugins/Xpressive/CMakeLists.txt
+++ b/plugins/Xpressive/CMakeLists.txt
@@ -10,6 +10,12 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dexprtk_disable_rtl_io_file")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Dexprtk_disable_rtl_vecops")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WERROR_FLAGS} -fexceptions")
 
+# See https://github.com/ArashPartow/exprtk/pull/9
+IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+	EXECUTE_PROCESS(COMMAND patch exprtk/exprtk.hpp exprtk.hpp.patch
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_QUIET)
+ENDIF()
+
 IF(LMMS_BUILD_WIN32)
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj -Dexprtk_disable_enhanced_features")
 ENDIF()

--- a/plugins/Xpressive/exprtk.hpp.patch
+++ b/plugins/Xpressive/exprtk.hpp.patch
@@ -1,0 +1,13 @@
+diff --git a/exprtk.hpp b/exprtk.hpp
+index 916e74b..ae7de24 100644
+--- a/exprtk.hpp
++++ b/exprtk.hpp
+@@ -1962,7 +1962,7 @@ namespace exprtk
+       template <typename T>
+       inline bool string_to_real(const std::string& s, T& t)
+       {
+-         const typename numeric::details::number_type<T>::type num_type;
++         typename numeric::details::number_type<T>::type num_type;
+ 
+          const char_t* begin = s.data();
+          const char_t* end   = s.data() + s.size();


### PR DESCRIPTION
Attempts to fix the Travis-CI environment by patching exprtk to workaround a bug with Clang.

More information about the bug is here: https://github.com/LMMS/lmms/pull/3965#issuecomment-344102990