### PR TITLE
Fix CAPS plugin build with some compilers

### DIFF
--- a/plugins/LadspaEffect/caps/SweepVF.cc
+++ b/plugins/LadspaEffect/caps/SweepVF.cc
@@ -28,9 +28,9 @@
 	02111-1307, USA or point your web browser to http://www.gnu.org.
 */
 
-#include <algorithm>
-
 #include "basics.h"
+
+#include <algorithm>
 
 #include "SweepVF.h"
 #include "Descriptor.h"


### PR DESCRIPTION
Fix build errors because `<cmath>` undefines some C99 math macros which is needed in `basic.h`. Fixes #3959.