### PR TITLE
Fix automation pattern regressions in #3352

### DIFF
--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -80,7 +80,7 @@ public:
 	MidiTime putValue( const MidiTime & time,
 				const float value,
 				const bool quantPos = true,
-				const bool ignoreSurroundingPoints = false );
+				const bool ignoreSurroundingPoints = true );
 
 	void removeValue( const MidiTime & time );
 


### PR DESCRIPTION
Fixes #3952 by passing `true` to `putValue()`'s `ignoreSurroundingPoint` argument.
Its default value is `false`, which makes positions of automation points incorrect or remove some points which should stay on its position. Thus, passing `true` fixes this problem.