### PR TITLE
Unsolo mixer channels on delete

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -382,6 +382,10 @@ void FxMixerView::deleteChannel(int index)
 	// remember selected line
 	int selLine = m_currentFxLine->channelIndex();
 
+	// in case the deleted channel is soloed or the remaining
+	// channels will be left in a muted state
+	Engine::fxMixer()->clearChannel(index);
+
 	// delete the real channel
 	Engine::fxMixer()->deleteChannel(index);
 


### PR DESCRIPTION
If you remove a channel in the Fx-Mixer while it's soloed, the other channels are left muted. Clear channels before deleting and the remaining channels are restored to their pre-solo values.