### PR TITLE
Automation Editor - delete automation point

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -523,7 +523,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 					( it+1==time_map.end() ||
 						pos_ticks <= (it+1).key() ) &&
 		( pos_ticks<= it.key() + MidiTime::ticksPerTact() *4 / m_ppt ) &&
-					level == it.value() )
+		( level == it.value() || mouseEvent->button() == Qt::RightButton ) )
 				{
 					break;
 				}


### PR DESCRIPTION
Fix regression from b68dc572a3a58ad2187efe3ef5b4848ef7254abd where deleting a point by right clicking without dragging is defunct.

I misunderstood the algorithm. The selection for add/delete was dual.
```
   Left mouse button and above a point, move it.
   Right mouse button and below a point, delete it.
```
The latter appeared to me to be an obvious glitch so I pushed a fix to stable-1.2, messed up and was set for hours of fun with git and submodules. :skull_and_crossbones:  The final bug fixed in this PR removes the dual action altogether.