### PR TITLE
Limit note length to quantization value

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2811,7 +2811,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				if (note->selected())
 				{
 					int newLength = note->oldLength() + off_ticks;
-					newLength = qMax(alt ? 1 : quantization(), newLength);
+					if (newLength <= 0) { newLength = alt ? 1 : quantization(); }
 					note->setLength(MidiTime(newLength));
 
 					m_lenOfNewNotes = note->length();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2810,8 +2810,10 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			{
 				if (note->selected())
 				{
-					int newLength = note->oldLength() + off_ticks;
-					if (newLength <= 0) { newLength = alt ? 1 : quantization(); }
+					int oldLength = note->oldLength();
+					int newLength = oldLength + off_ticks;
+					int minLength = qMin(oldLength,quantization());
+					newLength = qMax(alt ? 1 : minLength, newLength);
 					note->setLength(MidiTime(newLength));
 
 					m_lenOfNewNotes = note->length();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2811,8 +2811,8 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				if (note->selected())
 				{
 					int newLength = note->oldLength() + off_ticks;
-					newLength = qMax(1, newLength);
-					note->setLength( MidiTime(newLength) );
+					newLength = qMax(alt ? 1 : quantization(), newLength);
+					note->setLength(MidiTime(newLength));
 
 					m_lenOfNewNotes = note->length();
 				}


### PR DESCRIPTION
Draging a note to it's minimum value of 1 will add this new length to
the note if you later choose to stretch it which will not be clearly
visible in the Piano Roll unless you zoom in a bit. Limit the note
length to the quantization value and use <shift> key to set a smaller
value.

PR explained in depth here: https://github.com/LMMS/lmms/issues/3989#issuecomment-626233964

Fixes https://github.com/LMMS/lmms/issues/3989

