### PR TITLE
Fix sendEvent assert

### DIFF
--- a/include/shared_object.h
+++ b/include/shared_object.h
@@ -61,7 +61,7 @@ public:
 
 		if ( deleteObject )
 		{
-			delete object;
+			object->deleteLater();
 		}
 	}
 


### PR DESCRIPTION
This makes `shared_object::unref()` safe when it's not called from within the object's thread.

Fixes #4009