### PR TITLE
Handle shrank automation patterns correctly

### DIFF
--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -296,6 +296,9 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 				continue;
 			}
 			MidiTime relTime = time - p->startPosition();
+			if (! p->getAutoResize()) {
+				relTime = qMin(relTime, p->length());
+			}
 			float value = p->valueAt(relTime);
 
 			for (AutomatableModel* model : p->objects())


### PR DESCRIPTION
Fix automation processing for shrank patterns. Retain the behavior before #3382 for those patterns.
Fixes #3800.