### PR TITLE
i18n for #4017

### DIFF
--- a/plugins/ladspa_browser/ladspa_browser.cpp
+++ b/plugins/ladspa_browser/ladspa_browser.cpp
@@ -48,7 +48,7 @@ extern "C"
 Plugin::Descriptor PLUGIN_EXPORT ladspabrowser_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
-	QT_TRANSLATE_NOOP( "LADSPA Plugin Browser" ),
+	QT_TRANSLATE_NOOP( "MainWindow", "LADSPA Plugin Browser" ),
 	QT_TRANSLATE_NOOP( "pluginBrowser",
 				"List installed LADSPA plugins" ),
 	"Danny McRae <khjklujn/at/users.sourceforge.net>",

--- a/plugins/ladspa_browser/ladspa_browser.cpp
+++ b/plugins/ladspa_browser/ladspa_browser.cpp
@@ -48,7 +48,7 @@ extern "C"
 Plugin::Descriptor PLUGIN_EXPORT ladspabrowser_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
-	"LADSPA Plugin Browser",
+	QT_TRANSLATE_NOOP( "LADSPA Plugin Browser" ),
 	QT_TRANSLATE_NOOP( "pluginBrowser",
 				"List installed LADSPA plugins" ),
 	"Danny McRae <khjklujn/at/users.sourceforge.net>",


### PR DESCRIPTION
> In plugins/ladspa_browser/ladspa_browser.cpp line 51, the string "LADSPA Plugin Browser" is not translatable.

See https://github.com/LMMS/lmms/issues/4017 .

*Edited by @tresf, added description*