### PR TITLE
Enable SC2185 again

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -9,6 +9,7 @@ if [ "$TYPE" = 'style' ]; then
 	# shellcheck disable=SC2185
 	# shellcheck disable=SC2046
 	shellcheck $(find -O3 . -maxdepth 3 -type f -name '*.sh' -o -name "*.sh.in")
+	shellcheck doc/bash-completion/lmms
 
 else
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -8,7 +8,7 @@ if [ "$TYPE" = 'style' ]; then
 	# once it's fixed, it should be enabled again
 	# shellcheck disable=SC2185
 	# shellcheck disable=SC2046
-	shellcheck $(find -O3 "$TRAVIS_BUILD_DIR/.travis/" "$TRAVIS_BUILD_DIR/cmake/" -type f -name '*.sh' -o -name "*.sh.in")
+	shellcheck $(find -O3 . -maxdepth 3 -type f -name '*.sh' -o -name "*.sh.in")
 
 else
 

--- a/doc/bash-completion/lmms
+++ b/doc/bash-completion/lmms
@@ -1,3 +1,4 @@
+#/usr/bin/env bash
 # lmms(1) completion                                       -*- shell-script -*-
 # use shellcheck: "shellcheck -e bash <filename>"
 

--- a/doc/bash-completion/lmms
+++ b/doc/bash-completion/lmms
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 # lmms(1) completion                                       -*- shell-script -*-
 # use shellcheck: "shellcheck -e bash <filename>"
 


### PR DESCRIPTION
**Edit:** @tresf, repurposed this PR.

Original: 
> **Title:** Enable SC2185 again
> 
> Fix #3684.
> 
> If it doesn't pass now, we will have to wait until a more recent version of ShellCheck is available in the CI.

Reusing this PR to shellcheck all lmms directories up to 3 directories deep.