### PR TITLE
Add Carla Support to AppImage

### DIFF
--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -15,3 +15,11 @@ else
 fi
 
 sudo apt-get install -y $PACKAGES
+
+# Carla depends on kxstudio which creates some package conflicts (wine, etc)
+# If run too early in the dependency process.  Once provided by PPA, "carla-git"
+# can simply be added to $PACKAGES
+sudo apt-get install -y apt-transport-https software-properties-common wget
+wget https://launchpad.net/~kxstudio-debian/+archive/kxstudio/+files/kxstudio-repos_9.4.6~kxstudio1_all.deb
+sudo dpkg -i kxstudio-repos_9.4.6~kxstudio1_all.deb
+sudo apt-get install -y carla-git

--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -16,8 +16,7 @@ fi
 
 sudo apt-get install -y $PACKAGES
 
-# Carla depends on kxstudio which creates some package conflicts (wine, etc) if
-# run too early in the dependency process.
+# kxstudio repo offers Carla; avoid package conflicts (wine, etc) by running last
 sudo add-apt-repository -y ppa:kxstudio-debian/libs
 sudo add-apt-repository -y ppa:kxstudio-debian/apps
 sudo apt-get update

--- a/.travis/linux..install.sh
+++ b/.travis/linux..install.sh
@@ -16,10 +16,9 @@ fi
 
 sudo apt-get install -y $PACKAGES
 
-# Carla depends on kxstudio which creates some package conflicts (wine, etc)
-# If run too early in the dependency process.  Once provided by PPA, "carla-git"
-# can simply be added to $PACKAGES
-sudo apt-get install -y apt-transport-https software-properties-common wget
-wget https://launchpad.net/~kxstudio-debian/+archive/kxstudio/+files/kxstudio-repos_9.4.6~kxstudio1_all.deb
-sudo dpkg -i kxstudio-repos_9.4.6~kxstudio1_all.deb
+# Carla depends on kxstudio which creates some package conflicts (wine, etc) if
+# run too early in the dependency process.
+sudo add-apt-repository -y ppa:kxstudio-debian/libs
+sudo add-apt-repository -y ppa:kxstudio-debian/apps
+sudo apt-get update
 sudo apt-get install -y carla-git

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -103,7 +103,7 @@ mv "${APPDIR}usr/bin/lmms" "${APPDIR}usr/bin/lmms.real"
 cat >"${APPDIR}usr/bin/lmms" <<EOL
 #!/usr/bin/env bash
 DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=\$DIR/usr/lib/:\$DIR/usr/lib/lmms:\$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=\$DIR/usr/lib/:\$DIR/usr/lib/lmms:/usr/lib/carla/:/usr/lib64/carla/:\$LD_LIBRARY_PATH
 # Prevent segfault on VirualBox
 if lsmod |grep vboxguest > /dev/null 2>&1; then
    echo "VirtualBox detected.  Forcing libgl software rendering."
@@ -170,6 +170,9 @@ ln -sr  "$VSTBIN" "$VSTLIB"
 # Remove wine library conflict
 rm -f "${APPDIR}/usr/lib/libwine.so.1"
 
+# Use system-provided carla
+rm -f "${APPDIR}usr/lib/"libcarla*.so
+
 # Remove problematic jack library, replace with weakjack
 if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
    rm -f "${APPDIR}/usr/lib/libjack.so.0"
@@ -177,16 +180,6 @@ if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
    cp "@CMAKE_BINARY_DIR@/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/weakjack.so"
    ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
 fi
-
-# Use system-provided Carla files
-CARLABIN="/usr/share/carla/resources"
-if [ -d "${CARLABIN}" ]; then
-   rm -f "${APPDIR}/usr/lib/libcarla*.so"
-   mkdir -p "${APPDIR}${CARLABIN}"
-   ln -sf "${CARLABIN}/carla-plugin" "${APPDIR}${CARLABIN}/carla-plugin"
-   ln -sf "${CARLABIN}/carla-plugin-patchbay" "${APPDIR}${CARLABIN}/carla-plugin-patchbay"
-fi
-
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -103,7 +103,15 @@ mv "${APPDIR}usr/bin/lmms" "${APPDIR}usr/bin/lmms.real"
 cat >"${APPDIR}usr/bin/lmms" <<EOL
 #!/usr/bin/env bash
 DIR="\$( cd "\$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
-export LD_LIBRARY_PATH=\$DIR/usr/lib/:\$DIR/usr/lib/lmms:/usr/lib/carla/:/usr/lib64/carla/:\$LD_LIBRARY_PATH
+if which carla > /dev/null 2>&1; then
+   CARLAPATH="$(which carla)"
+   CARLAPREFIX="\${CARLAPATH%/bin*}"
+   echo "Carla appears to be installed on this system at \$CARLAPREFIX/lib[64]/carla so we'll use it."
+   export LD_LIBRARY_PATH=\$CARLAPREFIX/lib/carla:\$CARLAPREFIX/lib64/carla:\$LD_LIBRARY_PATH
+else
+   echo "Carla does not appear to be installed.  That's OK, please ignore any related library errors."
+fi
+export LD_LIBRARY_PATH=\$DIR/usr/lib/:\$DIR/usr/lib/lmms:\$LD_LIBRARY_PATH
 # Prevent segfault on VirualBox
 if lsmod |grep vboxguest > /dev/null 2>&1; then
    echo "VirtualBox detected.  Forcing libgl software rendering."

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -123,7 +123,7 @@ else
    echo "Jack does not appear to be installed.  That's OK, we'll use a dummy version instead."
    export LD_LIBRARY_PATH=\$DIR/usr/lib/lmms/optional:\$LD_LIBRARY_PATH
 fi
-QT_X11_NO_NATIVE_MENUBAR=1 QT_AUTO_SCREEN_SCALE_FACTOR=1 \$DIR/usr/bin/lmms.real "\$@"
+QT_X11_NO_NATIVE_MENUBAR=1 \$DIR/usr/bin/lmms.real "\$@"
 EOL
 
 chmod +x "${APPDIR}usr/bin/lmms"

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -178,6 +178,16 @@ if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
    ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
 fi
 
+# Use system-provided Carla files
+CARLABIN="/usr/share/carla/resources"
+if [ -d "${CARLABIN}" ]; then
+   rm -f "${APPDIR}/usr/lib/libcarla*.so"
+   mkdir -p "${APPDIR}${CARLABIN}"
+   ln -sf "${CARLABIN}/carla-plugin" "${APPDIR}${CARLABIN}/carla-plugin"
+   ln -sf "${CARLABIN}/carla-plugin-patchbay" "${APPDIR}${CARLABIN}/carla-plugin-patchbay"
+fi
+
+
 # Create AppImage
 echo -e "\nFinishing the AppImage..."
 echo -e "\n\n>>>>> appimagetool" >> "$LOGFILE"

--- a/include/AudioWeakJack.def
+++ b/include/AudioWeakJack.def
@@ -71,7 +71,10 @@ JPFUN(1, const char *,   port_type, (const jack_port_t *p), (p), 0)
 JPFUN(1, const char **,  port_get_connections, (const jack_port_t *p), (p), 0)
 JPFUN(1, const char **,  port_get_all_connections, (const jack_client_t *c, const jack_port_t *p), (c,p), 0)
 JPFUN(1, int,            port_set_name, (jack_port_t *p, const char *n), (p,n), -1)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 JXFUN(0, int,            port_rename, (jack_client_t *c, jack_port_t *p, const char *n), (c,p,n), return jack_port_set_name (p,n);)
+#pragma GCC diagnostic pop
 JPFUN(1, int,            port_get_aliases, (const jack_port_t *port, char* const aliases[2]), (port,aliases), 0)
 JPFUN(1, int,            port_disconnect, (jack_client_t *c, jack_port_t *p), (c,p), 0)
 JPFUN(1, int,            connect, (jack_client_t *c, const char *s, const char *d), (c,s,d), -1)

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -154,7 +154,7 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     QString dllName(carla_get_library_filename());
 
 #if defined(CARLA_OS_LINUX)
-    fHost.resourceDir = strdup(QString(dllName.split("/lib/carla")[0] + "/share/carla/resources/").toUtf8().constData());
+    fHost.resourceDir = strdup(QString(dllName.split("/lib")[0] + "/share/carla/resources/").toUtf8().constData());
 #else
     fHost.resourceDir = NULL;
 #endif

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -260,21 +260,14 @@ intptr_t CarlaInstrument::handleDispatcher(const NativeHostDispatcherOpcode opco
 
     switch (opcode)
     {
-    case NATIVE_HOST_OPCODE_NULL:
-        break;
-    case NATIVE_HOST_OPCODE_UPDATE_PARAMETER:
-    case NATIVE_HOST_OPCODE_UPDATE_MIDI_PROGRAM:
-    case NATIVE_HOST_OPCODE_RELOAD_PARAMETERS:
-    case NATIVE_HOST_OPCODE_RELOAD_MIDI_PROGRAMS:
-    case NATIVE_HOST_OPCODE_RELOAD_ALL:
-        // nothing
-        break;
     case NATIVE_HOST_OPCODE_UI_UNAVAILABLE:
         handleUiClosed();
         break;
     case NATIVE_HOST_OPCODE_HOST_IDLE:
         qApp->processEvents();
         break;
+    default:
+	break;
     }
 
     return ret;

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -153,7 +153,7 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
 
     // carla/resources contains PyQt scripts required for launch
     QString dllName(carla_get_library_filename());
-    QString resourcesPath = QString();
+    QString resourcesPath;
 #if defined(CARLA_OS_LINUX)
     // parse prefix from dll filename
     QDir path = QFileInfo(dllName).dir();

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -36,6 +36,7 @@
 
 #include <QApplication>
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QPushButton>
 #include <QTimerEvent>
 #include <QVBoxLayout>
@@ -150,15 +151,22 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     fHost.uiName      = NULL;
     fHost.uiParentId  = 0;
 
-    // figure out prefix from dll filename
+    // carla/resources contains PyQt scripts required for launch
     QString dllName(carla_get_library_filename());
-
+    QString resourcesPath = QString();
 #if defined(CARLA_OS_LINUX)
-    fHost.resourceDir = strdup(QString(dllName.split("/lib")[0] + "/share/carla/resources/").toUtf8().constData());
-#else
-    fHost.resourceDir = NULL;
+    // parse prefix from dll filename
+    QDir path = QFileInfo(dllName).dir();
+    path.cdUp();
+    path.cdUp();
+    resourcesPath = path.absolutePath() + "/share/carla/resources";
+#elif defined(CARLA_OS_MAC)
+    // assume standard install location
+    resourcesPath = "/Applications/Carla.app/Contents/MacOS/resources";
+#elif defined(CARLA_OS_WIN32) || defined(CARLA_OS_WIN64)
+    // not yet supported
 #endif
-
+    fHost.resourceDir            = strdup(resourcesPath.toUtf8().constData());
     fHost.get_buffer_size        = host_get_buffer_size;
     fHost.get_sample_rate        = host_get_sample_rate;
     fHost.is_offline             = host_is_offline;


### PR DESCRIPTION
This adds the following functionality to the AppImage:
* If Carla IS found, uses the system provided version (e.g. `/usr/share/carla/resources/carla-plugin`)
* If Carla is NOT found, notifies the user via console that Carla won't be available, removes it from the plugin listing.  Some console warnings appear, these are safe to ignore.

**Download**: https://github.com/tresf/lmms/releases/download/v1.2.0-rc4/lmms-1.2.0-rc4.117-linux-x86_64.AppImage

**Note:** This PR also disables HiDPI in the AppImage due to [some issues found during testing](https://github.com/LMMS/lmms/commit/8bc9e9d9b4785c47a2c809bdc7de907f11381c04#commitcomment-25979076).  It can be re-enabled via `export QT_AUTO_SCREEN_SCALE_FACTOR=1`.

Closes #3976, #2429
Supersedes #2643