### PR TITLE
Fix some more VST bugs

### DIFF
--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -419,6 +419,7 @@ enum RemoteMessageIDs
 	IdQuit,
 	IdSampleRateInformation,
 	IdBufferSizeInformation,
+	IdInformationUpdated,
 	IdMidiEvent,
 	IdStartProcessing,
 	IdProcessingDone,
@@ -807,6 +808,7 @@ public:
 	{
 		lock();
 		sendMessage( message( IdSampleRateInformation ).addInt( _sr ) );
+		waitForMessage( IdInformationUpdated, true );
 		unlock();
 	}
 
@@ -1318,9 +1320,14 @@ bool RemotePluginClient::processMessage( const message & _m )
 		case IdSampleRateInformation:
 			m_sampleRate = _m.getInt();
 			updateSampleRate();
+			reply_message.id = IdInformationUpdated;
+			reply = true;
 			break;
 
 		case IdBufferSizeInformation:
+			// Should LMMS gain the ability to change buffer size
+			// without a restart, it must wait for this message to
+			// complete processing or else risk VST crashes
 			m_bufferSize = _m.getInt();
 			updateBufferSize();
 			break;

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1499,7 +1499,7 @@ intptr_t RemoteVstPlugin::hostCallback( AEffect * _effect, int32_t _opcode,
 			// value is 0 for input and != 0 otherwise. note: the
 			// return value is 0 for <true> such that older versions
 			// will always return true.
-			return 1;
+			return 0;
 
 		case audioMasterGetTime:
 			SHOW_CALLBACK( "amc: audioMasterGetTime\n" );

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -635,6 +635,7 @@ void RemoteVstPlugin::init( const std::string & _plugin_file )
 	}
 
 	updateInOutCount();
+	updateBufferSize();
 
 	// some plugins have to set samplerate during init
 	if( m_vstSyncData->hasSHM )

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -636,12 +636,7 @@ void RemoteVstPlugin::init( const std::string & _plugin_file )
 
 	updateInOutCount();
 	updateBufferSize();
-
-	// some plugins have to set samplerate during init
-	if( m_vstSyncData->hasSHM )
-	{
-		updateSampleRate();
-	}
+	updateSampleRate();
 
 	/* set program to zero */
 	/* i comment this out because it breaks dfx Geometer

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -237,19 +237,14 @@ public:
 	// has to be called as soon as input- or output-count changes
 	void updateInOutCount();
 
-	inline void lock()
-	{
-		pthread_mutex_lock( &m_pluginLock );
-	}
-
-	inline void unlock()
-	{
-		pthread_mutex_unlock( &m_pluginLock );
-	}
-
 	inline void lockShm()
 	{
 		pthread_mutex_lock( &m_shmLock );
+	}
+
+	inline bool tryLockShm()
+	{
+		return pthread_mutex_trylock( &m_shmLock ) == 0;
 	}
 
 	inline void unlockShm()
@@ -318,22 +313,8 @@ private:
 
 	bool load( const std::string & _plugin_file );
 
-	// thread-safe dispatching of plugin
 	int pluginDispatch( int cmd, int param1 = 0, int param2 = 0,
 					void * p = NULL, float f = 0 )
-	{
-		int ret = 0;
-		lock();
-		if( m_plugin )
-		{
-			ret = m_plugin->dispatcher( m_plugin, cmd, param1, param2, p, f );
-		}
-		unlock();
-		return ret;
-	}
-
-	// thread-safe dispatching of plugin
-	int pluginDispatchNoLocking( int cmd, int param1 = 0, int param2 = 0, void * p = NULL, float f = 0 )
 	{
 		if( m_plugin )
 		{
@@ -356,7 +337,6 @@ private:
 	bool m_initialized;
 	bool m_registeredWindowClass;
 
-	pthread_mutex_t m_pluginLock;
 	bool m_processing;
 
 	std::queue<message> m_messageList;
@@ -408,7 +388,6 @@ RemoteVstPlugin::RemoteVstPlugin( const char * socketPath ) :
 	m_windowHeight( 0 ),
 	m_initialized( false ),
 	m_registeredWindowClass( false ),
-	m_pluginLock(),
 	m_processing( false ),
 	m_messageList(),
 	m_shouldGiveIdle( false ),
@@ -424,7 +403,6 @@ RemoteVstPlugin::RemoteVstPlugin( const char * socketPath ) :
 	m_shmID( -1 ),
 	m_vstSyncData( NULL )
 {
-	pthread_mutex_init( &m_pluginLock, NULL );
 	pthread_mutex_init( &m_shmLock, NULL );
 
 	__plugin = this;
@@ -518,7 +496,6 @@ RemoteVstPlugin::~RemoteVstPlugin()
 	delete[] m_outputs;
 
 	pthread_mutex_destroy( &m_shmLock );
-	pthread_mutex_destroy( &m_pluginLock );
 }
 
 
@@ -623,9 +600,7 @@ bool RemoteVstPlugin::processMessage( const message & _m )
 			break;
 
 		case IdVstSetParameter:
-			lock();
 			m_plugin->setParameter( m_plugin, _m.getInt( 0 ), _m.getFloat( 1 ) );
-			unlock();
 			//sendMessage( IdVstSetParameter );
 			break;
 
@@ -906,13 +881,14 @@ void RemoteVstPlugin::process( const sampleFrame * _in, sampleFrame * _out )
 
 	// now we're ready to fetch sound from VST-plugin
 
-	lock();
-	lockShm();
+	if( !tryLockShm() )
+	{
+		return;
+	}
 
 	if( !isShmValid() )
 	{
 		unlockShm();
-		unlock();
 		return;
 	}
 
@@ -943,7 +919,6 @@ void RemoteVstPlugin::process( const sampleFrame * _in, sampleFrame * _out )
 #endif
 
 	unlockShm();
-	unlock();
 
 	m_currentSamplePos += bufferSize();
 }
@@ -1050,8 +1025,6 @@ void RemoteVstPlugin::sendCurrentProgramName()
 
 void RemoteVstPlugin::getParameterDump()
 {
-	lock();
-
 	message m( IdVstParameterDump );
 	m.addInt( m_plugin->numParams );
 
@@ -1059,15 +1032,13 @@ void RemoteVstPlugin::getParameterDump()
 	{
 		char paramName[32];
 		memset( paramName, 0, sizeof( paramName ) );
-		pluginDispatchNoLocking( effGetParamName, i, 0, paramName );
+		pluginDispatch( effGetParamName, i, 0, paramName );
 		paramName[sizeof(paramName)-1] = 0;
 
 		m.addInt( i );
 		m.addString( paramName );
 		m.addFloat( m_plugin->getParameter( m_plugin, i ) );
 	}
-
-	unlock();
 
 	sendMessage( m );
 }
@@ -1077,7 +1048,6 @@ void RemoteVstPlugin::getParameterDump()
 
 void RemoteVstPlugin::setParameterDump( const message & _m )
 {
-	lock();
 	const int n = _m.getInt( 0 );
 	const int params = ( n > m_plugin->numParams ) ?
 					m_plugin->numParams : n;
@@ -1090,7 +1060,6 @@ void RemoteVstPlugin::setParameterDump( const message & _m )
 		item.value = _m.getFloat( ++p );
 		m_plugin->setParameter( m_plugin, item.index, item.value );
 	}
-	unlock();
 }
 
 
@@ -1243,14 +1212,12 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 			chunk_size = m_plugin->numParams * sizeof( float );
 			data = new char[ chunk_size ];
 			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( data );
-			lock();
 			for ( int i = 0; i < m_plugin->numParams; i++ )
 			{
 				float value = m_plugin->getParameter( m_plugin, i );
 				unsigned int * pValue = ( unsigned int * ) &value;
 				toUIntArray[ i ] = endian_swap( *pValue );
 			}
-			unlock();
 		} else chunk_size = (((m_plugin->numParams * sizeof( float )) + 56)*m_plugin->numPrograms);
 	}
 
@@ -1296,14 +1263,12 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 			pluginDispatch( effSetProgram, 0, j );
 			pluginDispatch( effGetProgramName, 0, 0, pBank->prgName );
 			fwrite ( pBank, 1, 56, stream );
-			lock();
 			for ( int i = 0; i < m_plugin->numParams; i++ )
 			{
 				value = m_plugin->getParameter( m_plugin, i );
 				pValue = ( unsigned int * ) &value;
 				toUIntArray[ i ] = endian_swap( *pValue );
 			}
-			unlock();
 			fwrite ( data, 1, chunk_size, stream );
 		}
 		pluginDispatch( effSetProgram, 0, currProgram );
@@ -1370,7 +1335,6 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 			pluginDispatch( 24, 1, len, chunk );
 		else
 		{
-			lock();
 			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( chunk );
 			for (int i = 0; i < pBank->numPrograms; i++ )
 			{
@@ -1378,7 +1342,6 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 				pFloat = ( float* ) &toUInt;
 				m_plugin->setParameter( m_plugin, i, *pFloat );
 			}
-			unlock();
 		}
 	} else {
 		if(pBank->fxMagic != 0x6B427846) {
@@ -1389,7 +1352,6 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 			int currProgram = pluginDispatch( effGetProgram );
 			chunk = new char[ len = sizeof(float)*m_plugin->numParams ];
 			toUIntArray = reinterpret_cast<unsigned int *>( chunk );
-			lock();
 			for (int i =0; i < numPrograms; i++) {
 				if ( fread (pBank, 1, 56, stream) != 56 )
 				{
@@ -1410,7 +1372,6 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 					m_plugin->setParameter( m_plugin, j, *pFloat );
 				}
 			}
-			unlock();
 			pluginDispatch( effSetProgram, 0, currProgram );
 			fclose( stream );
 		}

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -306,6 +306,7 @@ void VstPlugin::updateSampleRate()
 	lock();
 	sendMessage( message( IdSampleRateInformation ).
 			addInt( Engine::mixer()->processingSampleRate() ) );
+	waitForMessage( IdInformationUpdated, true );
 	unlock();
 }
 


### PR DESCRIPTION
Remove the lock synchronising access to the VST plugin's methods. The only methods which are called outside of the UI thread are `process`, `processReplacing` and `dispatcher(effProcessEvents, ...)`, all of which are intended to be called concurrently with other methods in order to facilitate real-time audio processing. This fixes a deadlock which occurs when a plugin waits on window messages sent to LMMS during an idle call.

I've also taken the opportunity to replace `lockShm()` with `tryLockShm()` in `RemoteVstPlugin::process` so as to remove all potentially blocking calls from that method.

The message `sampleRateInformation` now waits for a reply since, now we don't have a lock, audio processing shouldn't start before it's complete.

We now always tell the plugin the sample rate and buffer size on load as some plugins (e.g. Amplitube) crash if not given this information.

Fixes #4052.

The `audioMasterPinConnected` host callback returns `0` now to indicate that all pins are connected. This message is deprecated but some plugins (e.g. iZotope effects) still rely on it and won't produce sound unless told that they are connected.

Fixes #4095.