### PR TITLE
Use "Set value" as title for QInputDialog of some widgets.

### DIFF
--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -218,7 +218,7 @@ void Fader::mouseDoubleClickEvent( QMouseEvent* mouseEvent )
 	// TODO: dbV handling
 	if( m_displayConversion )
 	{
-		newValue = QInputDialog::getDouble( this, windowTitle(),
+		newValue = QInputDialog::getDouble( this, tr( "Set value" ),
 					tr( "Please enter a new value between %1 and %2:" ).
 							arg( model()->minValue() * 100 ).
 							arg( model()->maxValue() * 100 ),
@@ -228,7 +228,7 @@ void Fader::mouseDoubleClickEvent( QMouseEvent* mouseEvent )
 	}
 	else
 	{
-		newValue = QInputDialog::getDouble( this, windowTitle(),
+		newValue = QInputDialog::getDouble( this, tr( "Set value" ),
 					tr( "Please enter a new value between %1 and %2:" ).
 							arg( model()->minValue() ).
 							arg( model()->maxValue() ),

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -771,7 +771,7 @@ void Knob::enterValue()
 		ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() )
 	{
 		new_val = QInputDialog::getDouble(
-			this, windowTitle(),
+			this, tr( "Set value" ),
 			tr( "Please enter a new value between "
 					"-96.0 dBFS and 6.0 dBFS:" ),
 				20.0 * log10( model()->getRoundedValue() / 100.0 ),
@@ -788,7 +788,7 @@ void Knob::enterValue()
 	else
 	{
 		new_val = QInputDialog::getDouble(
-				this, windowTitle(),
+				this, tr( "Set value" ),
 				tr( "Please enter a new value between "
 						"%1 and %2:" ).
 						arg( model()->minValue() ).

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -172,7 +172,7 @@ void LcdSpinBox::enterValue()
 	int new_val;
 
 	new_val = QInputDialog::getInt(
-			this, windowTitle(),
+			this, tr( "Set value" ),
 			tr( "Please enter a new value between %1 and %2:" ).
 			arg( model()->minValue() ).
 			arg( model()->maxValue() ),


### PR DESCRIPTION
These widgets are the Fader, Knob and LcdSpinBox.
The QInputDialog shows when a widget from the above is double-clicked.
I propose this change because the current title `windowTitle()` usually doesn't have a specified value and defaults to `lmms`:
![Before](https://user-images.githubusercontent.com/25503477/34249179-def425d4-e649-11e7-8a5f-c1827c86ccb9.png)
With this change, it will always default to `Set value`:
![After](https://user-images.githubusercontent.com/25503477/34249202-f54b14dc-e649-11e7-9146-eef60673030e.png)
