### PR TITLE
Don't restore audio device during exporting

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -175,6 +175,7 @@ public:
 	void setAudioDevice( AudioDevice * _dev,
 				const struct qualitySettings & _qs,
 							bool _needs_fifo );
+	void storeAudioDevice();
 	void restoreAudioDevice();
 	inline AudioDevice * audioDev()
 	{

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -88,7 +88,6 @@ private:
 
 	AudioFileDevice * m_fileDev;
 	Mixer::qualitySettings m_qualitySettings;
-	Mixer::qualitySettings m_oldQualitySettings;
 
 	volatile int m_progress;
 	volatile bool m_abort;

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -65,6 +65,7 @@ private:
 	void restoreMutedState();
 
 	const Mixer::qualitySettings m_qualitySettings;
+	const Mixer::qualitySettings m_oldQualitySettings;
 	const OutputSettings m_outputSettings;
 	ProjectRenderer::ExportFileFormats m_format;
 	QString m_outputPath;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -579,8 +579,6 @@ void Mixer::setAudioDevice( AudioDevice * _dev )
 {
 	stopProcessing();
 
-	m_oldAudioDev = m_audioDev;
-
 	if( _dev == NULL )
 	{
 		printf( "param _dev == NULL in Mixer::setAudioDevice(...). "
@@ -608,7 +606,6 @@ void Mixer::setAudioDevice( AudioDevice * _dev,
 	stopProcessing();
 
 	m_qualitySettings = _qs;
-	m_oldAudioDev = m_audioDev;
 
 	if( _dev == NULL )
 	{
@@ -625,6 +622,17 @@ void Mixer::setAudioDevice( AudioDevice * _dev,
 	emit sampleRateChanged();
 
 	startProcessing( _needs_fifo );
+}
+
+
+
+
+void Mixer::storeAudioDevice()
+{
+	if( !m_oldAudioDev )
+	{
+		m_oldAudioDev = m_audioDev;
+	}
 }
 
 

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -77,7 +77,6 @@ ProjectRenderer::ProjectRenderer( const Mixer::qualitySettings & qualitySettings
 	QThread( Engine::mixer() ),
 	m_fileDev( NULL ),
 	m_qualitySettings( qualitySettings ),
-	m_oldQualitySettings( Engine::mixer()->currentQualitySettings() ),
 	m_progress( 0 ),
 	m_abort( false )
 {
@@ -103,8 +102,6 @@ ProjectRenderer::ProjectRenderer( const Mixer::qualitySettings & qualitySettings
 
 ProjectRenderer::~ProjectRenderer()
 {
-	Engine::mixer()->restoreAudioDevice();  // also deletes audio-dev
-	Engine::mixer()->changeQuality( m_oldQualitySettings );
 }
 
 

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -37,16 +37,21 @@ RenderManager::RenderManager(
 		ProjectRenderer::ExportFileFormats fmt,
 		QString outputPath) :
 	m_qualitySettings(qualitySettings),
+	m_oldQualitySettings( Engine::mixer()->currentQualitySettings() ),
 	m_outputSettings(outputSettings),
 	m_format(fmt),
 	m_outputPath(outputPath),
 	m_activeRenderer(NULL)
 {
+	Engine::mixer()->storeAudioDevice();
 }
 
 RenderManager::~RenderManager()
 {
 	delete m_activeRenderer;
+
+	Engine::mixer()->restoreAudioDevice();  // Also deletes audio dev.
+	Engine::mixer()->changeQuality( m_oldQualitySettings );
 }
 
 void RenderManager::abortProcessing()

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -49,6 +49,7 @@ RenderManager::RenderManager(
 RenderManager::~RenderManager()
 {
 	delete m_activeRenderer;
+	m_activeRenderer = NULL;
 
 	Engine::mixer()->restoreAudioDevice();  // Also deletes audio dev.
 	Engine::mixer()->changeQuality( m_oldQualitySettings );


### PR DESCRIPTION
This PR fixes deadlock on multi-track export with SDL.
Fixes #4032.