### PR TITLE
Using the cmake variable will insure the proper value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,7 +381,7 @@ IF(WANT_JACK)
 			SET(STATUS_JACK "OK (weak linking enabled)")
 			SET(JACK_INCLUDE_DIRS "")
 			# use dlsym instead
-			SET(JACK_LIBRARIES "dl")
+			SET(JACK_LIBRARIES ${CMAKE_DL_LIBS})
 		ELSE()
 			SET(STATUS_JACK "OK")
 		ENDIF()


### PR DESCRIPTION
regardless of the platform (already available in 2.0.7 version)