### PR TITLE
Piano Roll - Erase on mouse button drag in erase mode

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2254,9 +2254,11 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				--m_selectedKeys;
 			}
 		}
-		else if( m_editMode == ModeDraw && me->buttons() & Qt::RightButton )
+		else if( ( m_editMode == ModeDraw && me->buttons() & Qt::RightButton )
+				|| ( m_editMode == ModeErase && me->buttons() ) )
 		{
-			// holding down right-click to delete notes
+			// holding down right-click to delete notes or holding down
+			// any key if in erase mode
 
 			// get tick in which the user clicked
 			int pos_ticks = x * MidiTime::ticksPerTact() / m_ppt +

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2059,7 +2059,8 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				pauseTestNotes( false );
 			}
 		}
-		else if( ( edit_note || m_action == ActionChangeNoteProperty ) &&
+		else if( m_editMode != ModeErase &&
+			( edit_note || m_action == ActionChangeNoteProperty ) &&
 				( me->buttons() & Qt::LeftButton || me->buttons() & Qt::MiddleButton
 				|| ( me->buttons() & Qt::RightButton && me->modifiers() & Qt::ShiftModifier ) ) )
 		{


### PR DESCRIPTION
Erase tool in Piano Roll will erase on clicking a note but not when keeping a button down while moving the cursor over a note. With this fix keeping any key down and moving over a note will delete it.

Fixes https://github.com/LMMS/lmms/issues/980