### PR TITLE
Fix glitch where title would not revert after render

### DIFF
--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -119,6 +119,8 @@ void ExportProjectDialog::accept()
 {
 	m_renderManager.reset(nullptr);
 	QDialog::accept();
+	
+	gui->mainWindow()->resetWindowTitle();
 }
 
 


### PR DESCRIPTION
Fixes a bug where the main window title would remain as "Rendering: 100%" even after render. 

See #4160 for details.