### PR TITLE
Change portamento controller from toggle to set value

### DIFF
--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/Controller.cpp
@@ -56,7 +56,7 @@ void Controller::defaults()
     portamento.propRate     = 80;
     portamento.propDepth    = 90;
     portamento.receive      = 1;
-    portamento.time = 64;
+    portamento.time = 0;
     portamento.updowntimestretch = 64;
     portamento.pitchthresh     = 3;
     portamento.pitchthreshtype = 1;
@@ -197,8 +197,9 @@ void Controller::setsustain(int value)
 void Controller::setportamento(int value)
 {
     portamento.data = value;
+    portamento.time = value;
     if(portamento.receive != 0)
-        portamento.portamento = ((value < 64) ? 0 : 1);
+        portamento.portamento = ((value <= 0) ? 0 : 1);
 }
 
 int Controller::initportamento(float oldfreq,


### PR DESCRIPTION
In response to https://github.com/LMMS/lmms/issues/3936

This PR turns the portamento off at a portamento setting of 0 and forwards the same setting to the zynaddsubfx controller value `portamento.time`.

 - ZynAddSubFx seem to have separate portamento settings for each partial sound. This I'm not addressing in this PR.
 - Currently no backward compatibility. ~~Easy to fix though as long as the portamento isn't automated. Just set portamento over 64 to 64 and under 64 to 0.~~

_Caveat. I know preciously little about ZynAddSubFX..._