### PR TITLE
Use bundled jack if missing

### DIFF
--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -181,12 +181,10 @@ rm -f "${APPDIR}/usr/lib/libwine.so.1"
 # Use system-provided carla
 rm -f "${APPDIR}usr/lib/"libcarla*.so
 
-# Remove problematic jack library, replace with weakjack
+# Move jack out of LD_LIBRARY_PATH
 if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
-   rm -f "${APPDIR}/usr/lib/libjack.so.0"
    mkdir -p "${APPDIR}usr/lib/lmms/optional/"
-   cp "@CMAKE_BINARY_DIR@/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/weakjack.so"
-   ln -sr "${APPDIR}usr/lib/lmms/optional/weakjack.so" "${APPDIR}usr/lib/lmms/optional/libjack.so.0"
+   mv "${APPDIR}/usr/lib/libjack.so.0" "${APPDIR}usr/lib/lmms/optional/"
 fi
 
 # Create AppImage

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -8,9 +8,7 @@
 
 set -e
 
-USERBIN="$HOME/bin"
-LINUXDEPLOYQT="$USERBIN/linuxdeployqt"
-APPIMAGETOOL="$USERBIN/appimagetool"
+LINUXDEPLOYQT="@CMAKE_BINARY_DIR@/linuxdeployqt"
 VERBOSITY=2 # 3=debug
 LOGFILE="@CMAKE_BINARY_DIR@/appimage.log"
 APPDIR="@CMAKE_BINARY_DIR@/@PROJECT_NAME_UCASE@.AppDir/"
@@ -71,12 +69,8 @@ elif ! find "$LINUXDEPLOYQT" -mtime -$DAYSOLD 2>/dev/null|grep -q "." > /dev/nul
 	touch "$LINUXDEPLOYQT"
 	success "Downloaded $LINUXDEPLOYQT"
 	"$LINUXDEPLOYQT" --appimage-extract > /dev/null 2>&1
-	mv "squashfs-root/usr/bin/appimagetool" "$APPIMAGETOOL"
+	APPIMAGETOOL="squashfs-root/usr/bin/appimagetool"
 	success "Extracted $APPIMAGETOOL"
-	mv "squashfs-root/usr/bin/mksquashfs" "$USERBIN/mksquashfs"
-	success "Extracted $USERBIN/mksquashfs"
-	rm -rf "squashfs-root/"
-
 else
 	skipped "$LINUXDEPLOYQT is less than $DAYSOLD days old"
 fi

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,14 +1,5 @@
 IF(LMMS_HAVE_WEAKJACK)
 	set(WEAKJACK core/audio/AudioWeakJack.c)
-
-	# Build libjack.so.0 stub as weakjack.so for AppImages
-	IF(LMMS_BUILD_LINUX)
-		ADD_LIBRARY(weakjack MODULE ../../src/core/audio/AudioWeakJack.c)
-		INCLUDE_DIRECTORIES("${CMAKE_SOURCE_DIR}/include")
-		# We can't predict an AppImage build, so stash the build artifact for later
-		INSTALL(TARGETS weakjack LIBRARY DESTINATION "${CMAKE_BINARY_DIR}/optional")
-		SET_TARGET_PROPERTIES(weakjack PROPERTIES PREFIX "" SUFFIX ".so")
-	ENDIF()
 ENDIF()
 	
 set(LMMS_SRCS


### PR DESCRIPTION
Several systems don't ship with a jack version by default leaving missing symbols on launch.

This attempts to fix that by bundling a version of jack from the system and adding it to `LD_LIBRARY_PATH` at launch time if the launcher script can't find a suitable one.

This might still crash with undefined symbols on systems using jack1 instead of jack2, but we don't have the luxury to recompile some of our dependant libraries with `weakjack` so I'm not sure we can easily fix that.  One possibility is to take the script a bit further and inspect the exact jack version and still do the override for jack1 systems, but I'm not sure how difficult this is.  Anyway... 

Closes #4094