### PR TITLE
Fix crash when cancelling rendering of a project with VSTs

### DIFF
--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -52,6 +52,8 @@ RenderManager::~RenderManager()
 void RenderManager::abortProcessing()
 {
 	if ( m_activeRenderer ) {
+		disconnect( m_activeRenderer, SIGNAL( finished() ),
+				this, SLOT( renderNextTrack() ) );
 		m_activeRenderer->abortProcessing();
 	}
 	restoreMutedState();


### PR DESCRIPTION
Previously the `RenderManager` was deleted before the `finished()` signal was processed, but since https://github.com/LMMS/lmms/commit/d0b3be7f00e732dd1c5dbb43cb7030d42ff6a346, when VST plugins are present an event loop is run waiting for a reply from a sample rate update message, which processes the `finished()` signal and calls the `renderNextTrack()` slot, resulting in a second call to `~ProjectRenderer()`. Disconnecting the slot manually fixes the problem.