### PR TITLE
Fix theme after upgrade

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -553,6 +553,8 @@ void ConfigManager::loadConfigFile( const QString & configFile )
 	}
 #endif
 
+	upgrade();
+
 	QStringList searchPaths;
 	if(! qgetenv("LMMS_THEME_PATH").isNull())
 		searchPaths << qgetenv("LMMS_THEME_PATH");
@@ -564,8 +566,6 @@ void ConfigManager::loadConfigFile( const QString & configFile )
 	{
 		createWorkingDir();
 	}
-
-	upgrade();
 }
 
 


### PR DESCRIPTION
The theme folder is supposed to reset for major version changes.  This was implemented after the large number of bug reports we encountered with the stable-1.0 theme but unfortunately the logic has broken over time due to refactoring of code.

Closes #4199