### PR TITLE
Use Canonical Paths for Relative Paths Calculations

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -225,9 +225,9 @@ bool ConfigManager::hasWorkingDir() const
 }
 
 
-void ConfigManager::setWorkingDir( const QString & _wd )
+void ConfigManager::setWorkingDir( const QString & wd )
 {
-	m_workingDir = ensureTrailingSlash( _wd );
+	m_workingDir = ensureTrailingSlash( QFileInfo( wd ).canonicalFilePath() );
 }
 
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1415,7 +1415,8 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 {
 	if( QFileInfo( file ).isRelative() == false )
 	{
-		QString f = QString( file ).replace( QDir::separator(), '/' );
+		// Normalize the path
+		QString f = QFileInfo( file ).canonicalFilePath().replace( QDir::separator(), '/' );
 
 		// First, look in factory samples
 		// Isolate "samples/" from "data:/samples/"

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -40,8 +40,10 @@ private slots:
 
 		QString absPath = fi.absoluteFilePath();
 		QString relPath = "drums/kick01.ogg";
+		QString fuzPath = absPath.replace(relPath, "drums/.///kick01.ogg");
 		QCOMPARE(SampleBuffer::tryToMakeRelative(absPath), relPath);
 		QCOMPARE(SampleBuffer::tryToMakeAbsolute(relPath), absPath);
+		QCOMPARE(SampleBuffer::tryToMakeRelative(fuzPath), relPath);
 	}
 } RelativePathTests;
 

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -40,7 +40,8 @@ private slots:
 
 		QString absPath = fi.absoluteFilePath();
 		QString relPath = "drums/kick01.ogg";
-		QString fuzPath = absPath.replace(relPath, "drums/.///kick01.ogg");
+		QString fuzPath = absPath;
+		fuzPath.replace(relPath, "drums/.///kick01.ogg");
 		QCOMPARE(SampleBuffer::tryToMakeRelative(absPath), relPath);
 		QCOMPARE(SampleBuffer::tryToMakeAbsolute(relPath), absPath);
 		QCOMPARE(SampleBuffer::tryToMakeRelative(fuzPath), relPath);


### PR DESCRIPTION
Forces strange paths like `/path/.///to/../from/foo/////` to be `/path/from/foo`.

Closes #4173