### PR TITLE
Fix some bugs with LFO waveform drag&drop

### DIFF
--- a/src/gui/widgets/EnvelopeAndLfoView.cpp
+++ b/src/gui/widgets/EnvelopeAndLfoView.cpp
@@ -394,13 +394,17 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 					StringPairDrag::decodeValue( _de ) );
 		m_userLfoBtn->model()->setValue( true );
 		_de->accept();
+		update();
 	}
 	else if( type == QString( "tco_%1" ).arg( Track::SampleTrack ) )
 	{
 		DataFile dataFile( value.toUtf8() );
-		m_params->m_userWave.setAudioFile( dataFile.content().firstChild().toElement().  attribute( "src" ) );
+		m_params->m_userWave.setAudioFile( dataFile.content().
+					firstChildElement().firstChildElement().
+					firstChildElement().attribute( "src" ) );
 		m_userLfoBtn->model()->setValue( true );
 		_de->accept();
+		update();
 	}
 }
 

--- a/src/gui/widgets/EnvelopeAndLfoView.cpp
+++ b/src/gui/widgets/EnvelopeAndLfoView.cpp
@@ -393,6 +393,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 		m_params->m_userWave.setAudioFile(
 					StringPairDrag::decodeValue( _de ) );
 		m_userLfoBtn->model()->setValue( true );
+		m_params->m_lfoWaveModel.setValue(EnvelopeAndLfoParameters::UserDefinedWave);
 		_de->accept();
 		update();
 	}
@@ -403,6 +404,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 					firstChildElement().firstChildElement().
 					firstChildElement().attribute( "src" ) );
 		m_userLfoBtn->model()->setValue( true );
+		m_params->m_lfoWaveModel.setValue(EnvelopeAndLfoParameters::UserDefinedWave);
 		_de->accept();
 		update();
 	}


### PR DESCRIPTION
Update LFO waveform display after dropping a sample file. Fixes #3307.
This PR also fixes a broken functionality, "drag&drop from sample tracks".