### PR TITLE
Draw the entire length of a notes pitch bend info

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -889,10 +889,6 @@ void PianoRoll::drawDetuningInfo( QPainter & _p, const Note * _n, int _x,
 	for( timeMap::ConstIterator it = map.begin(); it != map.end(); ++it )
 	{
 		int pos_ticks = it.key();
-		if( pos_ticks > _n->length() )
-		{
-			break;
-		}
 		int pos_x = _x + pos_ticks * m_ppt / MidiTime::ticksPerTact();
 
 		const float level = it.value();


### PR DESCRIPTION
The detuning/pitch info is only drawn for the length of the note. The actual detuning is carried out for the duration of the automation and while the note is playing including the decay. This commit removes the note length test from drawDetuningInfo() which will allow for the full length of the detuning to be drawn.

Fixes #4231 