### PR TITLE
refactor: Use unique_ptr for memory management

### DIFF
--- a/include/AudioPort.h
+++ b/include/AudioPort.h
@@ -25,6 +25,7 @@
 #ifndef AUDIO_PORT_H
 #define AUDIO_PORT_H
 
+#include <memory>
 #include <QtCore/QString>
 #include <QtCore/QMutex>
 #include <QtCore/QMutexLocker>
@@ -79,7 +80,7 @@ public:
 
 	inline EffectChain * effects()
 	{
-		return m_effects;
+		return m_effects.get();
 	}
 
 	void setNextFxChannel( const fx_ch_t _chnl )
@@ -119,7 +120,7 @@ private:
 
 	QString m_name;
 
-	EffectChain * m_effects;
+	std::unique_ptr<EffectChain> m_effects;
 
 	PlayHandleList m_playHandles;
 	QMutex m_playHandleLock;

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -49,7 +49,7 @@ public:
 		clear();
 	}
 
-	void addItem( const QString& item, std::unique_ptr<PixmapLoader> loader = nullptr );
+	void addItem( QString item, std::unique_ptr<PixmapLoader> loader = nullptr );
 
 	void clear();
 

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -25,12 +25,12 @@
 #ifndef COMBOBOX_MODEL_H
 #define COMBOBOX_MODEL_H
 
-#include <QtCore/QVector>
-#include <QtCore/QPair>
+#include <memory>
+#include <utility>
+#include <vector>
 
 #include "AutomatableModel.h"
-
-class PixmapLoader;
+#include "embed.h"
 
 
 class EXPORT ComboBoxModel : public IntModel
@@ -49,7 +49,7 @@ public:
 		clear();
 	}
 
-	void addItem( const QString& item, PixmapLoader* loader = NULL );
+	void addItem( const QString& item, std::unique_ptr<PixmapLoader> loader = nullptr );
 
 	void clear();
 
@@ -62,7 +62,7 @@ public:
 
 	const PixmapLoader* currentData() const
 	{
-		return m_items[value()].second;
+		return m_items[value()].second.get();
 	}
 
 	const QString & itemText( int i ) const
@@ -72,7 +72,7 @@ public:
 
 	const PixmapLoader* itemPixmap( int i ) const
 	{
-		return m_items[qBound<int>( minValue(), i, maxValue() )].second;
+		return m_items[qBound<int>( minValue(), i, maxValue() )].second.get();
 	}
 
 	int size() const
@@ -82,9 +82,9 @@ public:
 
 
 private:
-	typedef QPair<QString, PixmapLoader *> Item;
+	typedef std::pair<QString, std::unique_ptr<PixmapLoader> > Item;
 
-	QVector<Item> m_items;
+	std::vector<Item> m_items;
 
 } ;
 

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -1,14 +1,17 @@
 //! Shims for std:: functions that aren't available in the current C++ versions
 //! we target.
 
-#pragma once
+#ifndef STDSHIMS_H
+#define STDSHIMS_H
 
 #include <memory>
 #include <utility>
 
 #if (__cplusplus >= 201402L)
 #warning "This file should now be removed! The functions it provides are part of the C++14 standard."
-#endif
+using std::unique_ptr;
+
+#else
 
 /// Shim for http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
 template<typename T, typename... Args>
@@ -16,4 +19,7 @@ std::unique_ptr<T> make_unique(Args&&... args)
 {
 	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+#endif
+
+#endif // include guard
 

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
 /// Shim for http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args)

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -6,6 +6,10 @@
 #include <memory>
 #include <utility>
 
+#if (__cplusplus >= 201402L)
+#warning "This file should now be removed! The functions it provides are part of the C++14 standard."
+#endif
+
 /// Shim for http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
 template<typename T, typename... Args>
 std::unique_ptr<T> make_unique(Args&&... args)

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -9,7 +9,7 @@
 
 #if (__cplusplus >= 201402L)
 #warning "This file should now be removed! The functions it provides are part of the C++14 standard."
-using std::unique_ptr;
+using std::make_unique;
 
 #else
 

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -1,0 +1,12 @@
+//! Shims for std:: functions that aren't available in the current C++ versions
+//! we target.
+
+#pragma once
+
+/// Shim for http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+

--- a/plugins/DualFilter/DualFilterControls.cpp
+++ b/plugins/DualFilter/DualFilterControls.cpp
@@ -26,12 +26,13 @@
 
 #include <QDomElement>
 
+#include "BasicFilters.h"
 #include "DualFilterControls.h"
 #include "DualFilter.h"
+#include "embed.h"
 #include "Engine.h"
 #include "Song.h"
-#include "BasicFilters.h"
-#include "embed.h"
+#include "stdshims.h"
 
 DualFilterControls::DualFilterControls( DualFilterEffect* effect ) :
 	EffectControls( effect ),
@@ -51,51 +52,51 @@ DualFilterControls::DualFilterControls( DualFilterEffect* effect ) :
 	m_res2Model( 0.5, BasicFilters<>::minQ(), 10.0, 0.01, this, tr( "Q/Resonance 2" ) ),
 	m_gain2Model( 100.0f, 0.0f, 200.0f, 0.1f, this, tr( "Gain 2" ) )
 {
-	m_filter1Model.addItem( tr( "LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filter1Model.addItem( tr( "HiPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "BandPass csg" ), new PixmapLoader( "filter_bp" ) );
-	m_filter1Model.addItem( tr( "BandPass czpg" ), new PixmapLoader( "filter_bp" ) );
-	m_filter1Model.addItem( tr( "Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filter1Model.addItem( tr( "Allpass" ), new PixmapLoader( "filter_ap" ) );
-	m_filter1Model.addItem( tr( "Moog" ), new PixmapLoader( "filter_lp" ) );
-	m_filter1Model.addItem( tr( "2x LowPass" ), new PixmapLoader( "filter_2lp" ) );
-	m_filter1Model.addItem( tr( "RC LowPass 12dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filter1Model.addItem( tr( "RC BandPass 12dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filter1Model.addItem( tr( "RC HighPass 12dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "RC LowPass 24dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filter1Model.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filter1Model.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
-	m_filter1Model.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filter1Model.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
-	m_filter1Model.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "SV Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filter1Model.addItem( tr( "Fast Formant" ), new PixmapLoader( "filter_hp" ) );
-	m_filter1Model.addItem( tr( "Tripole" ), new PixmapLoader( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "HiPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "BandPass csg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "BandPass czpg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filter1Model.addItem( tr( "Allpass" ), make_unique<PixmapLoader>( "filter_ap" ) );
+	m_filter1Model.addItem( tr( "Moog" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "2x LowPass" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filter1Model.addItem( tr( "RC LowPass 12dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "RC BandPass 12dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "RC HighPass 12dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "RC LowPass 24dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "RC BandPass 24dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "RC HighPass 24dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "Vocal Formant Filter" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "2x Moog" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filter1Model.addItem( tr( "SV LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter1Model.addItem( tr( "SV BandPass" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter1Model.addItem( tr( "SV HighPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "SV Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filter1Model.addItem( tr( "Fast Formant" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter1Model.addItem( tr( "Tripole" ), make_unique<PixmapLoader>( "filter_lp" ) );
 
-	m_filter2Model.addItem( tr( "LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filter2Model.addItem( tr( "HiPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "BandPass csg" ), new PixmapLoader( "filter_bp" ) );
-	m_filter2Model.addItem( tr( "BandPass czpg" ), new PixmapLoader( "filter_bp" ) );
-	m_filter2Model.addItem( tr( "Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filter2Model.addItem( tr( "Allpass" ), new PixmapLoader( "filter_ap" ) );
-	m_filter2Model.addItem( tr( "Moog" ), new PixmapLoader( "filter_lp" ) );
-	m_filter2Model.addItem( tr( "2x LowPass" ), new PixmapLoader( "filter_2lp" ) );
-	m_filter2Model.addItem( tr( "RC LowPass 12dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filter2Model.addItem( tr( "RC BandPass 12dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filter2Model.addItem( tr( "RC HighPass 12dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "RC LowPass 24dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filter2Model.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filter2Model.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
-	m_filter2Model.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filter2Model.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
-	m_filter2Model.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "SV Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filter2Model.addItem( tr( "Fast Formant" ), new PixmapLoader( "filter_hp" ) );
-	m_filter2Model.addItem( tr( "Tripole" ), new PixmapLoader( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "HiPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "BandPass csg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "BandPass czpg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filter2Model.addItem( tr( "Allpass" ), make_unique<PixmapLoader>( "filter_ap" ) );
+	m_filter2Model.addItem( tr( "Moog" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "2x LowPass" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filter2Model.addItem( tr( "RC LowPass 12dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "RC BandPass 12dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "RC HighPass 12dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "RC LowPass 24dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "RC BandPass 24dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "RC HighPass 24dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "Vocal Formant Filter" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "2x Moog" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filter2Model.addItem( tr( "SV LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filter2Model.addItem( tr( "SV BandPass" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filter2Model.addItem( tr( "SV HighPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "SV Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filter2Model.addItem( tr( "Fast Formant" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filter2Model.addItem( tr( "Tripole" ), make_unique<PixmapLoader>( "filter_lp" ) );
 
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateFilters() ) );
 }

--- a/plugins/monstro/Monstro.h
+++ b/plugins/monstro/Monstro.h
@@ -38,6 +38,7 @@
 #include "Oscillator.h"
 #include "lmms_math.h"
 #include "BandLimitedWave.h"
+#include "stdshims.h"
 
 //
 //	UI Macros
@@ -305,35 +306,35 @@ class MonstroInstrument : public Instrument
 	Q_OBJECT
 
 #define setwavemodel( name ) 												\
-		name .addItem( tr( "Sine wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sin" ) ) );		\
-		name .addItem( tr( "Bandlimited Triangle wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "tri" ) ) );	\
-		name .addItem( tr( "Bandlimited Saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "saw" ) ) );			\
-		name .addItem( tr( "Bandlimited Ramp wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "ramp" ) ) );		\
-		name .addItem( tr( "Bandlimited Square wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sqr" ) ) );		\
-		name .addItem( tr( "Bandlimited Moog saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "moog" ) ) );	\
-		name .addItem( tr( "Soft square wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sqrsoft" ) ) );		\
-		name .addItem( tr( "Absolute sine wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sinabs" ) ) );		\
-		name .addItem( tr( "Exponential wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "exp" ) ) );	\
-		name .addItem( tr( "White noise" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "noise" ) ) );	\
-		name .addItem( tr( "Digital Triangle wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "tri" ) ) );	\
-		name .addItem( tr( "Digital Saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "saw" ) ) );			\
-		name .addItem( tr( "Digital Ramp wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "ramp" ) ) );		\
-		name .addItem( tr( "Digital Square wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sqr" ) ) );		\
-		name .addItem( tr( "Digital Moog saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "moog" ) ) );
+		name .addItem( tr( "Sine wave" ), make_unique<PluginPixmapLoader>( "sin" ) );		\
+		name .addItem( tr( "Bandlimited Triangle wave" ), make_unique<PluginPixmapLoader>( "tri" ) );	\
+		name .addItem( tr( "Bandlimited Saw wave" ), make_unique<PluginPixmapLoader>( "saw" ) );			\
+		name .addItem( tr( "Bandlimited Ramp wave" ), make_unique<PluginPixmapLoader>( "ramp" ) );		\
+		name .addItem( tr( "Bandlimited Square wave" ), make_unique<PluginPixmapLoader>( "sqr" ) );		\
+		name .addItem( tr( "Bandlimited Moog saw wave" ), make_unique<PluginPixmapLoader>( "moog" ) );	\
+		name .addItem( tr( "Soft square wave" ), make_unique<PluginPixmapLoader>( "sqrsoft" ) );		\
+		name .addItem( tr( "Absolute sine wave" ), make_unique<PluginPixmapLoader>( "sinabs" ) );		\
+		name .addItem( tr( "Exponential wave" ), make_unique<PluginPixmapLoader>( "exp" ) );	\
+		name .addItem( tr( "White noise" ), make_unique<PluginPixmapLoader>( "noise" ) );	\
+		name .addItem( tr( "Digital Triangle wave" ), make_unique<PluginPixmapLoader>( "tri" ) );	\
+		name .addItem( tr( "Digital Saw wave" ), make_unique<PluginPixmapLoader>( "saw" ) );			\
+		name .addItem( tr( "Digital Ramp wave" ), make_unique<PluginPixmapLoader>( "ramp" ) );		\
+		name .addItem( tr( "Digital Square wave" ), make_unique<PluginPixmapLoader>( "sqr" ) );		\
+		name .addItem( tr( "Digital Moog saw wave" ), make_unique<PluginPixmapLoader>( "moog" ) );
 
 
 #define setlfowavemodel( name ) 												\
-		name .addItem( tr( "Sine wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sin" ) ) );		\
-		name .addItem( tr( "Triangle wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "tri" ) ) );	\
-		name .addItem( tr( "Saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "saw" ) ) );			\
-		name .addItem( tr( "Ramp wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "ramp" ) ) );		\
-		name .addItem( tr( "Square wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sqr" ) ) );		\
-		name .addItem( tr( "Moog saw wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "moog" ) ) );	\
-		name .addItem( tr( "Soft square wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sqrsoft" ) ) );		\
-		name .addItem( tr( "Abs. sine wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "sinabs" ) ) );		\
-		name .addItem( tr( "Exponential wave" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "exp" ) ) );	\
-		name .addItem( tr( "Random" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "rand" ) ) );	\
-		name .addItem( tr( "Random smooth" ), static_cast<PixmapLoader*>( new PluginPixmapLoader( "rand" ) ) );
+		name .addItem( tr( "Sine wave" ), make_unique<PluginPixmapLoader>( "sin" ) );		\
+		name .addItem( tr( "Triangle wave" ), make_unique<PluginPixmapLoader>( "tri" ) );	\
+		name .addItem( tr( "Saw wave" ), make_unique<PluginPixmapLoader>( "saw" ) );			\
+		name .addItem( tr( "Ramp wave" ), make_unique<PluginPixmapLoader>( "ramp" ) );		\
+		name .addItem( tr( "Square wave" ), make_unique<PluginPixmapLoader>( "sqr" ) );		\
+		name .addItem( tr( "Moog saw wave" ), make_unique<PluginPixmapLoader>( "moog" ) );	\
+		name .addItem( tr( "Soft square wave" ), make_unique<PluginPixmapLoader>( "sqrsoft" ) );		\
+		name .addItem( tr( "Abs. sine wave" ), make_unique<PluginPixmapLoader>( "sinabs" ) );		\
+		name .addItem( tr( "Exponential wave" ), make_unique<PluginPixmapLoader>( "exp" ) );	\
+		name .addItem( tr( "Random" ), make_unique<PluginPixmapLoader>( "rand" ) );	\
+		name .addItem( tr( "Random smooth" ), make_unique<PluginPixmapLoader>( "rand" ) );
 
 public:
 	MonstroInstrument( InstrumentTrack * _instrument_track );

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -25,11 +25,11 @@
 #include "ComboBoxModel.h"
 #include "embed.h"
 
+using namespace std;
 
-
-void ComboBoxModel::addItem( QString item, std::unique_ptr<PixmapLoader> loader )
+void ComboBoxModel::addItem( QString item, unique_ptr<PixmapLoader> loader )
 {
-	m_items.emplace_back( std::move(item), std::move(loader) );
+	m_items.emplace_back( move(item), move(loader) );
 	setRange( 0, m_items.size() - 1 );
 }
 

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -25,7 +25,8 @@
 #include "ComboBoxModel.h"
 #include "embed.h"
 
-using namespace std;
+using std::unique_ptr;
+using std::move;
 
 void ComboBoxModel::addItem( QString item, unique_ptr<PixmapLoader> loader )
 {

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -27,9 +27,9 @@
 
 
 
-void ComboBoxModel::addItem( const QString& item, PixmapLoader* loader )
+void ComboBoxModel::addItem( const QString& item, std::unique_ptr<PixmapLoader> loader )
 {
-	m_items.push_back( qMakePair( item, loader ) );
+	m_items.push_back( std::make_pair( item, std::move(loader) ) );
 	setRange( 0, m_items.size() - 1 );
 }
 
@@ -39,10 +39,6 @@ void ComboBoxModel::addItem( const QString& item, PixmapLoader* loader )
 void ComboBoxModel::clear()
 {
 	setRange( 0, 0 );
-	for( const Item& i : m_items )
-	{
-		delete i.second;
-	}
 
 	m_items.clear();
 
@@ -54,7 +50,7 @@ void ComboBoxModel::clear()
 
 int ComboBoxModel::findText( const QString& txt ) const
 {
-	for( QVector<Item>::ConstIterator it = m_items.begin(); it != m_items.end(); ++it )
+	for( auto it = m_items.begin(); it != m_items.end(); ++it )
 	{
 		if( ( *it ).first == txt )
 		{

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -27,9 +27,9 @@
 
 
 
-void ComboBoxModel::addItem( const QString& item, std::unique_ptr<PixmapLoader> loader )
+void ComboBoxModel::addItem( QString item, std::unique_ptr<PixmapLoader> loader )
 {
-	m_items.push_back( std::make_pair( item, std::move(loader) ) );
+	m_items.emplace_back( std::move(item), std::move(loader) );
 	setRange( 0, m_items.size() - 1 );
 }
 

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -30,7 +30,7 @@
 #include "InstrumentTrack.h"
 #include "Mixer.h"
 #include "PresetPreviewPlayHandle.h"
-
+#include "stdshims.h"
 
 
 InstrumentFunctionNoteStacking::ChordTable::Init InstrumentFunctionNoteStacking::ChordTable::s_initTable[] =
@@ -316,16 +316,16 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 		m_arpModel.addItem( chord_table[i].getName() );
 	}
 
-	m_arpDirectionModel.addItem( tr( "Up" ), new PixmapLoader( "arp_up" ) );
-	m_arpDirectionModel.addItem( tr( "Down" ), new PixmapLoader( "arp_down" ) );
-	m_arpDirectionModel.addItem( tr( "Up and down" ), new PixmapLoader( "arp_up_and_down" ) );
-	m_arpDirectionModel.addItem( tr( "Down and up" ), new PixmapLoader( "arp_up_and_down" ) );
-	m_arpDirectionModel.addItem( tr( "Random" ), new PixmapLoader( "arp_random" ) );
+	m_arpDirectionModel.addItem( tr( "Up" ), make_unique<PixmapLoader>( "arp_up" ) );
+	m_arpDirectionModel.addItem( tr( "Down" ), make_unique<PixmapLoader>( "arp_down" ) );
+	m_arpDirectionModel.addItem( tr( "Up and down" ), make_unique<PixmapLoader>( "arp_up_and_down" ) );
+	m_arpDirectionModel.addItem( tr( "Down and up" ), make_unique<PixmapLoader>( "arp_up_and_down" ) );
+	m_arpDirectionModel.addItem( tr( "Random" ), make_unique<PixmapLoader>( "arp_random" ) );
 	m_arpDirectionModel.setInitValue( ArpDirUp );
 
-	m_arpModeModel.addItem( tr( "Free" ), new PixmapLoader( "arp_free" ) );
-	m_arpModeModel.addItem( tr( "Sort" ), new PixmapLoader( "arp_sort" ) );
-	m_arpModeModel.addItem( tr( "Sync" ), new PixmapLoader( "arp_sync" ) );
+	m_arpModeModel.addItem( tr( "Free" ), make_unique<PixmapLoader>( "arp_free" ) );
+	m_arpModeModel.addItem( tr( "Sort" ), make_unique<PixmapLoader>( "arp_sort" ) );
+	m_arpModeModel.addItem( tr( "Sync" ), make_unique<PixmapLoader>( "arp_sync" ) );
 }
 
 

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -33,6 +33,7 @@
 #include "Instrument.h"
 #include "InstrumentTrack.h"
 #include "Mixer.h"
+#include "stdshims.h"
 
 
 const float CUT_FREQ_MULTIPLIER = 6000.0f;
@@ -79,28 +80,28 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 			tr( targetNames[i][2].toUtf8().constData() ) );
 	}
 
-	m_filterModel.addItem( tr( "LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filterModel.addItem( tr( "HiPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filterModel.addItem( tr( "BandPass csg" ), new PixmapLoader( "filter_bp" ) );
-	m_filterModel.addItem( tr( "BandPass czpg" ), new PixmapLoader( "filter_bp" ) );
-	m_filterModel.addItem( tr( "Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filterModel.addItem( tr( "Allpass" ), new PixmapLoader( "filter_ap" ) );
-	m_filterModel.addItem( tr( "Moog" ), new PixmapLoader( "filter_lp" ) );
-	m_filterModel.addItem( tr( "2x LowPass" ), new PixmapLoader( "filter_2lp" ) );
-	m_filterModel.addItem( tr( "RC LowPass 12dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filterModel.addItem( tr( "RC BandPass 12dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filterModel.addItem( tr( "RC HighPass 12dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filterModel.addItem( tr( "RC LowPass 24dB" ), new PixmapLoader( "filter_lp" ) );
-	m_filterModel.addItem( tr( "RC BandPass 24dB" ), new PixmapLoader( "filter_bp" ) );
-	m_filterModel.addItem( tr( "RC HighPass 24dB" ), new PixmapLoader( "filter_hp" ) );
-	m_filterModel.addItem( tr( "Vocal Formant Filter" ), new PixmapLoader( "filter_hp" ) );	
-	m_filterModel.addItem( tr( "2x Moog" ), new PixmapLoader( "filter_2lp" ) );
-	m_filterModel.addItem( tr( "SV LowPass" ), new PixmapLoader( "filter_lp" ) );
-	m_filterModel.addItem( tr( "SV BandPass" ), new PixmapLoader( "filter_bp" ) );
-	m_filterModel.addItem( tr( "SV HighPass" ), new PixmapLoader( "filter_hp" ) );
-	m_filterModel.addItem( tr( "SV Notch" ), new PixmapLoader( "filter_notch" ) );
-	m_filterModel.addItem( tr( "Fast Formant" ), new PixmapLoader( "filter_hp" ) );
-	m_filterModel.addItem( tr( "Tripole" ), new PixmapLoader( "filter_lp" ) );
+	m_filterModel.addItem( tr( "LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filterModel.addItem( tr( "HiPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "BandPass csg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filterModel.addItem( tr( "BandPass czpg" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filterModel.addItem( tr( "Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filterModel.addItem( tr( "Allpass" ), make_unique<PixmapLoader>( "filter_ap" ) );
+	m_filterModel.addItem( tr( "Moog" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filterModel.addItem( tr( "2x LowPass" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filterModel.addItem( tr( "RC LowPass 12dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filterModel.addItem( tr( "RC BandPass 12dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filterModel.addItem( tr( "RC HighPass 12dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "RC LowPass 24dB" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filterModel.addItem( tr( "RC BandPass 24dB" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filterModel.addItem( tr( "RC HighPass 24dB" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "Vocal Formant Filter" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "2x Moog" ), make_unique<PixmapLoader>( "filter_2lp" ) );
+	m_filterModel.addItem( tr( "SV LowPass" ), make_unique<PixmapLoader>( "filter_lp" ) );
+	m_filterModel.addItem( tr( "SV BandPass" ), make_unique<PixmapLoader>( "filter_bp" ) );
+	m_filterModel.addItem( tr( "SV HighPass" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "SV Notch" ), make_unique<PixmapLoader>( "filter_notch" ) );
+	m_filterModel.addItem( tr( "Fast Formant" ), make_unique<PixmapLoader>( "filter_hp" ) );
+	m_filterModel.addItem( tr( "Tripole" ), make_unique<PixmapLoader>( "filter_lp" ) );
 }
 
 

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -56,7 +56,6 @@ AudioPort::~AudioPort()
 {
 	setExtOutputEnabled( false );
 	Engine::mixer()->removeAudioPort( this );
-	delete m_effects;
 	BufferManager::release( m_portBuffer );
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -67,7 +67,7 @@
 #define MiddleButton MidButton
 #endif
 
-using namespace std;
+using std::move;
 
 typedef AutomationPattern::timeMap timeMap;
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #include <math.h>
+#include <utility>
 
 #include "AutomationEditor.h"
 #include "ActionGroup.h"
@@ -57,6 +58,7 @@
 #include "MainWindow.h"
 #include "Pattern.h"
 #include "SongEditor.h"
+#include "stdshims.h"
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
 
@@ -65,6 +67,7 @@
 #define MiddleButton MidButton
 #endif
 
+using namespace std;
 
 typedef AutomationPattern::timeMap timeMap;
 
@@ -370,7 +373,7 @@ PianoRoll::PianoRoll() :
 
 	// Set up note length model
 	m_noteLenModel.addItem( tr( "Last note" ),
-					new PixmapLoader( "edit_draw" ) );
+					make_unique<PixmapLoader>( "edit_draw" ) );
 	const QString pixmaps[] = { "whole", "half", "quarter", "eighth",
 						"sixteenth", "thirtysecond", "triplethalf",
 						"tripletquarter", "tripleteighth",
@@ -378,13 +381,13 @@ PianoRoll::PianoRoll() :
 
 	for( int i = 0; i < NUM_EVEN_LENGTHS; ++i )
 	{
-		PixmapLoader *loader = new PixmapLoader( "note_" + pixmaps[i] );
-		m_noteLenModel.addItem( "1/" + QString::number( 1 << i ), loader );
+		auto loader = make_unique<PixmapLoader>( "note_" + pixmaps[i] );
+		m_noteLenModel.addItem( "1/" + QString::number( 1 << i ), ::move(loader) );
 	}
 	for( int i = 0; i < NUM_TRIPLET_LENGTHS; ++i )
 	{
-		PixmapLoader *loader = new PixmapLoader( "note_" + pixmaps[i+NUM_EVEN_LENGTHS] );
-		m_noteLenModel.addItem( "1/" + QString::number( (1 << i) * 3 ), loader );
+		auto loader = make_unique<PixmapLoader>( "note_" + pixmaps[i+NUM_EVEN_LENGTHS] );
+		m_noteLenModel.addItem( "1/" + QString::number( (1 << i) * 3 ), ::move(loader) );
 	}
 	m_noteLenModel.setValue( 0 );
 


### PR DESCRIPTION
Hi!

A huge hurdle when I used to contribute regularly to LMMS was lifetime management. Pointers get passed around throughout the codebase and it's not clear who's supposed to delete them. That leads to double-frees, or memory leaks, and this made it exceedingly difficult to edit any of the core code. That, in turn, raises the barrier of entry to development & drives away good developers, etc. A good path forward is to use owning pointers ("smart pointers"), as they make ownership obvious across interfaces and lesson the likelihood of missing a `delete` or accidentally `delete`ing something that somebody else expected to remain alive.

So, I'll be combing the codebase and switching things over to owning pointers throughout the future. Starting off small with this PR so as to not surprise anyone. This PR changes `AudioPort::m_effects` to be `unique_ptr`, as it's always owned by `AudioPort`. It also changes `ComboBoxModel::addItem` to accept `unique_ptr<PixmapLoader>` instead of `PixmapLoader*`, to indicate that the ownership of the loader is transferred into the class.

I had to update ComboBoxModel to use `std::pair` instead of `QPair`, because the latter doesn't support move semantics, which is required when moving a `unique_ptr`.

Also added a `stdshims.h` header file for access to `make_unique`, since `std::make_unique` is only available in C++14 or greater & we use C++11.