### PR TITLE
Fix marked semitones in the piano roll

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -146,7 +146,7 @@ PianoRoll {
 	qproperty-noteBorders: false; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: #006b65;
 	qproperty-barColor: #078f3a;
-	qproperty-markedSemitoneColor: #06170E;
+	qproperty-markedSemitoneColor: rgba(255, 255, 255, 20);
 	/* Grid colors */
 	qproperty-lineColor: #292929;
 	qproperty-beatLineColor: #2d6b45;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2633,23 +2633,6 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 	int key = m_startKey;
 
-	// display note marks before drawing other lines
-	for( int i = 0; i < m_markedSemiTones.size(); i++ )
-	{
-		const int key_num = m_markedSemiTones.at( i );
-		const int y = keyAreaBottom() + 5
-			- KEY_LINE_HEIGHT * ( key_num - m_startKey + 1 );
-
-		if( y > keyAreaBottom() )
-		{
-			break;
-		}
-
-		p.fillRect( WHITE_KEY_WIDTH + 1, y - KEY_LINE_HEIGHT / 2, width() - 10, KEY_LINE_HEIGHT,
-			    markedSemitoneColor() );
-	}
-
-
 	// draw all white keys...
 	for( int y = key_line_y + 1 + y_offset; y > PR_TOP_MARGIN;
 			key_line_y -= KEY_LINE_HEIGHT, ++keys_processed )
@@ -2936,6 +2919,21 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 	}
 
+	// draw marked semitones after the grid
+	for( int i = 0; i < m_markedSemiTones.size(); i++ )
+	{
+		const int key_num = m_markedSemiTones.at( i );
+		const int y = keyAreaBottom() + 5
+			- KEY_LINE_HEIGHT * ( key_num - m_startKey + 1 );
+
+		if( y > keyAreaBottom() )
+		{
+			break;
+		}
+
+		p.fillRect( WHITE_KEY_WIDTH + 1, y - KEY_LINE_HEIGHT / 2, width() - 10, KEY_LINE_HEIGHT + 1,
+			    markedSemitoneColor() );
+	}
 
 	// following code draws all notes in visible area
 	// and the note editing stuff (volume, panning, etc)


### PR DESCRIPTION
Fixes #3651 
Went with option `#2` from the issue. @musikBear @RebeccaDeField 
Screenshots: 
![image](https://user-images.githubusercontent.com/6282045/37300486-64fd4ef0-2626-11e8-990d-0c9df92517dd.png)
![image](https://user-images.githubusercontent.com/6282045/37300501-69674086-2626-11e8-934c-5bbe6a6b8392.png)

The marked semitones now draw over the whole grid and are a transparent overlay. This will break any existing user themes for 1.2 but it's as easy to fix as adding transparency to your color.
