### PR TITLE
Fix MDI subwindow buttons contrast in the MenuBar

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -33,6 +33,26 @@ QMdiArea {
 	background-color: #111314;
 }
 
+QPushButton, QComboBox {
+	background: #3f4750;
+}
+
+QSlider::handle:horizontal {
+	background-color: #5a6572;
+	border: 1px solid #212020;
+	border-radius: 4px;
+}
+
+QSlider::add-page:horizontal {
+  background-color: #5a626b;
+	border: 1px solid #212020;
+}
+
+QSlider::sub-page:horizontal {
+  background-color: #3a3f45;
+	border: 1px solid #212020;
+}
+
 AutomationEditor {
 	color: #ffffff;
 	background-color: #141616;
@@ -904,7 +924,7 @@ LmmsPalette {
 	qproperty-windowText: #1de276;
 	qproperty-base: #101213;
 	qproperty-text: #d1d8e4;
-	qproperty-button: #3f4750;
+	qproperty-button: #dfe4ec;
 	qproperty-shadow: rgb(0,0,0);
 	qproperty-buttonText: #d1d8e4;
 	qproperty-brightText: #d1d8e4;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -33,26 +33,6 @@ QMdiArea {
 	background-color: #111314;
 }
 
-QPushButton, QComboBox {
-	background: #3f4750;
-}
-
-QSlider::handle:horizontal {
-	background-color: #5a6572;
-	border: 1px solid #212020;
-	border-radius: 4px;
-}
-
-QSlider::add-page:horizontal {
-  background-color: #5a626b;
-	border: 1px solid #212020;
-}
-
-QSlider::sub-page:horizontal {
-  background-color: #3a3f45;
-	border: 1px solid #212020;
-}
-
 AutomationEditor {
 	color: #ffffff;
 	background-color: #141616;
@@ -924,7 +904,7 @@ LmmsPalette {
 	qproperty-windowText: #1de276;
 	qproperty-base: #101213;
 	qproperty-text: #d1d8e4;
-	qproperty-button: #dfe4ec;
+	qproperty-button: #3f4750;
 	qproperty-shadow: rgb(0,0,0);
 	qproperty-buttonText: #d1d8e4;
 	qproperty-brightText: #d1d8e4;

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -176,7 +176,8 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 							painter, widget );
 			return;
 		}
-	} else if (control == CC_MdiControls)
+	}
+	else if (control == CC_MdiControls)
 	{
 		QStyleOptionComplex so(*option);
 		so.palette.setColor(QPalette::Button, QColor(223, 228, 236));

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -176,6 +176,12 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 							painter, widget );
 			return;
 		}
+	} else if (control == CC_MdiControls)
+	{
+		QStyleOptionComplex so(*option);
+		so.palette.setColor(QPalette::Button, QColor(223, 228, 236));
+		QProxyStyle::drawComplexControl(control, &so, painter, widget);
+		return;
 	}
 /*	else if( control == CC_ScrollBar )
 	{
@@ -365,4 +371,3 @@ void LmmsStyle::hoverColors( bool sunken, bool hover, bool active, QColor& color
 		blend = QColor( 33, 33, 33 );
 	}
 }
-


### PR DESCRIPTION
Fixes #4215

Fixed this by applying the idea @tresf had and changing the `qproperty-button` of our pallete to a light color. Then, I restyled all the other QPushButtons in the software as well as the `QComboBox`es and `QSlider`s which were inheriting the colors. 
![image](https://user-images.githubusercontent.com/6282045/37305769-e1b71c00-2635-11e8-9264-827076f54b1c.png)
The QSlider was also restyled.
![image](https://user-images.githubusercontent.com/6282045/37305642-6aca1f3e-2635-11e8-9ccd-877a588bab62.png)

