### PR TITLE
Change selected notes color

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -144,7 +144,7 @@ PianoRoll {
 	qproperty-noteColor: #0bd556;
 	qproperty-noteOpacity: 165;
 	qproperty-noteBorders: false; /* boolean property, set false to have borderless notes */
-	qproperty-selectedNoteColor: #006b65;
+	qproperty-selectedNoteColor: #064d79;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: #06170E;
 	/* Grid colors */


### PR DESCRIPTION
Fixes #4111
Before:
![screenshot from 2018-03-12 21 18 38](https://user-images.githubusercontent.com/6282045/37308965-c1245f98-263f-11e8-8b7c-bab0aacefbf8.png)
After:
![screenshot from 2018-03-12 21 43 43](https://user-images.githubusercontent.com/6282045/37308615-dddf88e8-263e-11e8-9a32-20756ca95fab.png)

I tested this with http://www.color-blindness.com/coblis-color-blindness-simulator/ and it seems to provide sufficient contrast for color blind people. 

@raindropsfromsky @musikBear