### PR TITLE
Replace more instances new/delete with owning types

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -26,6 +26,8 @@
 #ifndef NOTE_PLAY_HANDLE_H
 #define NOTE_PLAY_HANDLE_H
 
+#include <memory>
+
 #include "AtomicInt.h"
 #include "BasicFilters.h"
 #include "Note.h"
@@ -46,7 +48,7 @@ class EXPORT NotePlayHandle : public PlayHandle, public Note
 	MM_OPERATORS
 public:
 	void * m_pluginData;
-	BasicFilters<> * m_filter;
+	std::unique_ptr<BasicFilters<>> m_filter;
 
 	// specifies origin of NotePlayHandle
 	enum Origins

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -26,7 +26,7 @@
 #ifndef RENDER_MANAGER_H
 #define RENDER_MANAGER_H
 
-#include <vector>
+#include <memory>
 
 #include "ProjectRenderer.h"
 #include "OutputSettings.h"
@@ -70,7 +70,7 @@ private:
 	ProjectRenderer::ExportFileFormats m_format;
 	QString m_outputPath;
 
-	ProjectRenderer* m_activeRenderer;
+	std::unique_ptr<ProjectRenderer> m_activeRenderer;
 
 	QVector<Track*> m_tracksToRender;
 	QVector<Track*> m_unmuted;

--- a/src/core/ImportFilter.cpp
+++ b/src/core/ImportFilter.cpp
@@ -23,6 +23,7 @@
  */
 
 
+#include <memory>
 #include <QMessageBox>
 
 #include "ImportFilter.h"
@@ -31,6 +32,8 @@
 #include "PluginFactory.h"
 #include "ProjectJournal.h"
 
+
+using std::unique_ptr;
 
 ImportFilter::ImportFilter( const QString & _file_name,
 							const Descriptor * _descriptor ) :
@@ -54,7 +57,8 @@ void ImportFilter::import( const QString & _file_to_import,
 {
 	bool successful = false;
 
-	char * s = qstrdup( _file_to_import.toUtf8().constData() );
+	QByteArray s = _file_to_import.toUtf8();
+	s.detach();
 
 	// do not record changes while importing files
 	const bool j = Engine::projectJournal()->isJournalling();
@@ -62,20 +66,16 @@ void ImportFilter::import( const QString & _file_to_import,
 
 	for (const Plugin::Descriptor* desc : pluginFactory->descriptors(Plugin::ImportFilter))
 	{
-		Plugin * p = Plugin::instantiate( desc->name, NULL, s );
-		if( dynamic_cast<ImportFilter *>( p ) != NULL &&
-			dynamic_cast<ImportFilter *>( p )->tryImport( tc ) == true )
+		unique_ptr<Plugin> p(Plugin::instantiate( desc->name, NULL, s.data() ));
+		if( dynamic_cast<ImportFilter *>( p.get() ) != NULL &&
+			dynamic_cast<ImportFilter *>( p.get() )->tryImport( tc ) )
 		{
-			delete p;
 			successful = true;
 			break;
 		}
-		delete p;
 	}
 
 	Engine::projectJournal()->setJournalling( j );
-
-	delete[] s;
 
 	if( successful == false )
 	{

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -161,9 +161,9 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 		int old_filter_cut = 0;
 		int old_filter_res = 0;
 
-		if( n->m_filter == NULL )
+		if( n->m_filter == nullptr )
 		{
-			n->m_filter = new BasicFilters<>( Engine::mixer()->processingSampleRate() );
+			n->m_filter = make_unique<BasicFilters<>>( Engine::mixer()->processingSampleRate() );
 		}
 		n->m_filter->setFilterType( m_filterModel.value() );
 

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -53,7 +53,6 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 	PlayHandle( TypeNotePlayHandle, _offset ),
 	Note( n.length(), n.pos(), n.key(), n.getVolume(), n.getPanning(), n.detuning() ),
 	m_pluginData( NULL ),
-	m_filter( NULL ),
 	m_instrumentTrack( instrumentTrack ),
 	m_frames( 0 ),
 	m_totalFramesPlayed( 0 ),
@@ -154,8 +153,6 @@ NotePlayHandle::~NotePlayHandle()
 	}
 
 	m_subNotes.clear();
-
-	delete m_filter;
 
 	if( buffer() ) releaseBuffer();
 

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -29,6 +29,7 @@
 #include "Song.h"
 #include "BBTrackContainer.h"
 #include "BBTrack.h"
+#include "stdshims.h"
 
 
 RenderManager::RenderManager(
@@ -40,17 +41,13 @@ RenderManager::RenderManager(
 	m_oldQualitySettings( Engine::mixer()->currentQualitySettings() ),
 	m_outputSettings(outputSettings),
 	m_format(fmt),
-	m_outputPath(outputPath),
-	m_activeRenderer(NULL)
+	m_outputPath(outputPath)
 {
 	Engine::mixer()->storeAudioDevice();
 }
 
 RenderManager::~RenderManager()
 {
-	delete m_activeRenderer;
-	m_activeRenderer = NULL;
-
 	Engine::mixer()->restoreAudioDevice();  // Also deletes audio dev.
 	Engine::mixer()->changeQuality( m_oldQualitySettings );
 }
@@ -58,7 +55,7 @@ RenderManager::~RenderManager()
 void RenderManager::abortProcessing()
 {
 	if ( m_activeRenderer ) {
-		disconnect( m_activeRenderer, SIGNAL( finished() ),
+		disconnect( m_activeRenderer.get(), SIGNAL( finished() ),
 				this, SLOT( renderNextTrack() ) );
 		m_activeRenderer->abortProcessing();
 	}
@@ -68,8 +65,7 @@ void RenderManager::abortProcessing()
 // Called to render each new track when rendering tracks individually.
 void RenderManager::renderNextTrack()
 {
-	delete m_activeRenderer;
-	m_activeRenderer = NULL;
+	m_activeRenderer.reset();
 
 	if( m_tracksToRender.isEmpty() )
 	{
@@ -93,7 +89,7 @@ void RenderManager::renderNextTrack()
 		int trackNum = m_tracksToRender.size() + 1;
 
 		// create a renderer for this track
-		m_activeRenderer = new ProjectRenderer(
+		m_activeRenderer = make_unique<ProjectRenderer>(
 				m_qualitySettings,
 				m_outputSettings,
 				m_format,
@@ -102,11 +98,11 @@ void RenderManager::renderNextTrack()
 		if ( m_activeRenderer->isReady() )
 		{
 			// pass progress signals through
-			connect( m_activeRenderer, SIGNAL( progressChanged( int ) ),
+			connect( m_activeRenderer.get(), SIGNAL( progressChanged( int ) ),
 					this, SIGNAL( progressChanged( int ) ) );
 
 			// when it is finished, render the next track
-			connect( m_activeRenderer, SIGNAL( finished() ),
+			connect( m_activeRenderer.get(), SIGNAL( finished() ),
 					this, SLOT( renderNextTrack() ) );
 
 			m_activeRenderer->startProcessing();
@@ -158,7 +154,7 @@ void RenderManager::renderTracks()
 // Render the song into a single track
 void RenderManager::renderProject()
 {
-	m_activeRenderer = new ProjectRenderer(
+	m_activeRenderer = make_unique<ProjectRenderer>(
 			m_qualitySettings,
 			m_outputSettings,
 			m_format,
@@ -167,11 +163,11 @@ void RenderManager::renderProject()
 	if( m_activeRenderer->isReady() )
 	{
 		// pass progress signals through
-		connect( m_activeRenderer, SIGNAL( progressChanged( int ) ),
+		connect( m_activeRenderer.get(), SIGNAL( progressChanged( int ) ),
 				this, SIGNAL( progressChanged( int ) ) );
 
 		// as we have not queued any tracks, renderNextTrack will just clean up
-		connect( m_activeRenderer, SIGNAL( finished() ),
+		connect( m_activeRenderer.get(), SIGNAL( finished() ),
 				this, SLOT( renderNextTrack() ) );
 
 		m_activeRenderer->startProcessing();

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -31,6 +31,7 @@
 #ifdef LMMS_HAVE_OGGVORBIS
 
 
+#include <string>
 #include <vorbis/vorbisenc.h>
 
 #include "Mixer.h"
@@ -71,9 +72,9 @@ bool AudioFileOgg::startEncoding()
 {
 	vorbis_comment vc;
 	const char * comments = "Cool=This song has been made using LMMS";
-	int comment_length = strlen( comments );
-	char * user_comments = new char[comment_length + 1];
-	strcpy( user_comments, comments );
+	std::string user_comments_str(comments);
+	int comment_length = user_comments_str.size();
+	char * user_comments = &user_comments_str[0];
 
 	vc.user_comments = &user_comments;
 	vc.comment_lengths = &comment_length;
@@ -113,7 +114,6 @@ bool AudioFileOgg::startEncoding()
 		printf( "Mode initialization failed: invalid parameters for "
 								"bitrate\n" );
 		vorbis_info_clear( &m_vi );
-		delete[] user_comments;
 		return false;
 	}
 
@@ -169,12 +169,10 @@ bool AudioFileOgg::startEncoding()
 		{
 			// clean up
 			finishEncoding();
-			delete[] user_comments;
 			return false;
 		}
 	}
 
-	delete[] user_comments;
 	return true;
 }
 


### PR DESCRIPTION
i.e. use more `unique_ptr`, but also replace an instance of `qstrdup` & subsequent `delete` with a `QByteArray`, and replace some c-string manipulations with `std::string`.