### PR TITLE
keeps relative positions of TCOs on group moving

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -856,6 +856,7 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * me )
 			m_trackView->trackContainerView()->selectedObjects();
 		QVector<TrackContentObject *> tcos;
 		MidiTime smallest_pos, t;
+		TrackContentObject * mostLeftTCO = dynamic_cast<TrackContentObjectView *>(so.first())->getTrackContentObject();
 		// find out smallest position of all selected objects for not
 		// moving an object before zero
 		for( QVector<selectableObject *>::iterator it = so.begin();
@@ -867,15 +868,22 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * me )
 			{
 				continue;
 			}
+
 			TrackContentObject * tco = tcov->m_tco;
 			tcos.push_back( tco );
+
+			if(tco->startPosition() < mostLeftTCO->startPosition() )
+			{
+				mostLeftTCO = tco;
+			}
+
 			smallest_pos = qMin<int>( smallest_pos,
 					(int)tco->startPosition() +
 				static_cast<int>( dx *
 					MidiTime::ticksPerTact() / ppt ) );
 		}
-		MidiTime oldPos = tcos.first()->startPosition();
-		t = tcos.first()->startPosition() +
+		MidiTime oldPos = mostLeftTCO->startPosition();
+		t = mostLeftTCO->startPosition() +
 				static_cast<int>( dx *MidiTime::ticksPerTact() /
 								  ppt )-smallest_pos;
 
@@ -884,12 +892,15 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * me )
 		{
 			t = t.toNearestTact();
 		}
-		tcos.first()->movePosition( t );
-		MidiTime offs = oldPos - tcos.first()->startPosition();
-		for( QVector<TrackContentObject *>::iterator it = tcos.begin()+1;
+		mostLeftTCO->movePosition( t );
+		MidiTime offs = oldPos - mostLeftTCO->startPosition();
+		for( QVector<TrackContentObject *>::iterator it = tcos.begin();
 							it != tcos.end(); ++it )
 		{
-			( *it )->movePosition( (*it)->startPosition() - offs);
+			if( (*it) != mostLeftTCO )
+			{
+				( *it )->movePosition( (*it)->startPosition() - offs);
+			}
 		}
 	}
 	else if( m_action == Resize )

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -874,18 +874,22 @@ void TrackContentObjectView::mouseMoveEvent( QMouseEvent * me )
 				static_cast<int>( dx *
 					MidiTime::ticksPerTact() / ppt ) );
 		}
-		for( QVector<TrackContentObject *>::iterator it = tcos.begin();
+		MidiTime oldPos = tcos.first()->startPosition();
+		t = tcos.first()->startPosition() +
+				static_cast<int>( dx *MidiTime::ticksPerTact() /
+								  ppt )-smallest_pos;
+
+		if( !( me->modifiers() & Qt::ControlModifier )
+				&& me->button() == Qt::NoButton)
+		{
+			t = t.toNearestTact();
+		}
+		tcos.first()->movePosition( t );
+		MidiTime offs = oldPos - tcos.first()->startPosition();
+		for( QVector<TrackContentObject *>::iterator it = tcos.begin()+1;
 							it != tcos.end(); ++it )
 		{
-			t = ( *it )->startPosition() +
-				static_cast<int>( dx *MidiTime::ticksPerTact() /
-					 ppt )-smallest_pos;
-			if( ! ( me->modifiers() & Qt::AltModifier )
-					   && me->button() == Qt::NoButton )
-			{
-				t = t.toNearestTact();
-			}
-			( *it )->movePosition( t );
+			( *it )->movePosition( (*it)->startPosition() - offs);
 		}
 	}
 	else if( m_action == Resize )


### PR DESCRIPTION
fixes https://github.com/LMMS/lmms/issues/2300
This is an alternative approach to: https://github.com/LMMS/lmms/pull/4043
All selected TCOs will be moved with there relatives positions to each other. The selected group snaped with the most left TCO toNearestTact. 

