### PR TITLE
Make *ModelView a templated type instead of macro-based class

### DIFF
--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -1,5 +1,6 @@
 /*
- * AutomatableModelView.h - class AutomatableModelView
+ * AutomatableModelView.h - provides AutomatableModelView base class and
+ * provides BoolModelView, FloatModelView, IntModelView subclasses.
  *
  * Copyright (c) 2008-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -101,31 +102,26 @@ protected:
 
 
 
+template <typename ModelType> class EXPORT TypedModelView : public AutomatableModelView
+{
+public:
+	TypedModelView( Model* model, QWidget* _this) :
+		AutomatableModelView( model, _this )
+	{}
 
-#define generateTypedModelView(type)							\
-class EXPORT type##ModelView : public AutomatableModelView		\
-{																\
-public:															\
-	type##ModelView( Model* model, QWidget* _this ) :			\
-		AutomatableModelView( model, _this )					\
-	{															\
-	}															\
-																\
-	type##Model* model()										\
-	{															\
-		return castModel<type##Model>();						\
-	}															\
-																\
-	const type##Model* model() const							\
-	{															\
-		return castModel<type##Model>();						\
-	}															\
-}
+	ModelType* model()
+	{
+		return castModel<ModelType>();
+	}
+	const ModelType* model() const
+	{
+		return castModel<ModelType>();
+	}
+};
 
-
-generateTypedModelView(Float);
-generateTypedModelView(Int);
-generateTypedModelView(Bool);
+using FloatModelView = TypedModelView<FloatModel>;
+using IntModelView = TypedModelView<IntModel>;
+using BoolModelView = TypedModelView<BoolModel>;
 
 
 #endif


### PR DESCRIPTION
Among other things, this makes it easier to grep for FloatModelView, BoolModelView, IntModelView in the code base.