### PR TITLE
Copy/paste model values to system clipboard

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -96,11 +96,6 @@ public:
 	virtual ~AutomatableModel();
 
 
-	static float copiedValue()
-	{
-		return s_copiedValue;
-	}
-
 	bool isAutomated() const;
 	bool isAutomatedOrControlled() const
 	{
@@ -288,8 +283,6 @@ public:
 
 public slots:
 	virtual void reset();
-	virtual void copyValue();
-	virtual void pasteValue();
 	void unlinkControllerConnection();
 
 
@@ -351,8 +344,6 @@ private:
 	//! NULL if not appended to controller, otherwise connection info
 	ControllerConnection* m_controllerConnection;
 
-
-	static float s_copiedValue;
 
 	ValueBuffer m_valueBuffer;
 	long m_lastUpdatedPeriod;

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -75,7 +75,6 @@ protected:
 
 	QString m_description;
 	QString m_unit;
-
 } ;
 
 
@@ -94,6 +93,11 @@ public slots:
 	void unlinkAllModels();
 	void removeSongGlobalAutomation();
 
+private slots:
+	/// Copy the model's value to the clipboard.
+	void copyToClipboard();
+	/// Paste the model's value from the clipboard.
+	void pasteFromClipboard();
 
 protected:
 	AutomatableModelView* m_amv;

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -31,7 +31,6 @@
 #include "Mixer.h"
 #include "ProjectJournal.h"
 
-float AutomatableModel::s_copiedValue = 0;
 long AutomatableModel::s_periodCounter = 0;
 
 
@@ -632,21 +631,6 @@ void AutomatableModel::reset()
 	setValue( initValue<float>() );
 }
 
-
-
-
-void AutomatableModel::copyValue()
-{
-	s_copiedValue = value<float>();
-}
-
-
-
-
-void AutomatableModel::pasteValue()
-{
-	setValue( copiedValue() );
-}
 
 
 


### PR DESCRIPTION
Seeking feedback for this, since it changes a central behavior which hasn't been discussed.

Previously, values for knobs and such were copy/pasted internally, and were not visible across LMMS
instances. This PR moves the clipboard logic out of AutomatableModel.h (a `core` file), allowing the gui to copy/paste to the system clipboard instead. Now one can paste a value copied from some other application, or another instance of lmms, and vice versa.

Additionally, I now grey out the `Paste value` option if there is no valid clipboard data to paste.