### PR TITLE
Remove unused method and extraneous state from AutomatableModelView

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -118,7 +118,7 @@ public:
 	template<class T>
 	inline T value( int frameOffset = 0 ) const
 	{
-		if( unlikely( m_hasLinkedModels || m_controllerConnection != NULL ) )
+		if( unlikely( hasLinkedModels() || m_controllerConnection != NULL ) )
 		{
 			return castValue<T>( controllerValue( frameOffset ) );
 		}
@@ -234,7 +234,7 @@ public:
 
 	bool hasLinkedModels() const
 	{
-		return m_hasLinkedModels;
+		return !m_linkedModels.empty();
 	}
 
 	// a way to track changed values in the model and avoid using signals/slots - useful for speed-critical code.
@@ -334,7 +334,6 @@ private:
 	bool m_hasStrictStepSize;
 
 	AutoModelVector m_linkedModels;
-	bool m_hasLinkedModels;
 
 
 	//! NULL if not appended to controller, otherwise connection info

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -252,11 +252,6 @@ public:
 
 	float globalAutomationValueAt( const MidiTime& time );
 
-	bool hasStrictStepSize() const
-	{
-		return m_hasStrictStepSize;
-	}
-
 	void setStrictStepSize( const bool b )
 	{
 		m_hasStrictStepSize = b;

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -77,21 +77,7 @@ public:
 		Decibel
 	};
 
-	enum DataType
-	{
-		Float,
-		Integer,
-		Bool
-	} ;
-
-	AutomatableModel( DataType type,
-						const float val = 0,
-						const float min = 0,
-						const float max = 0,
-						const float step = 0,
-						Model* parent = NULL,
-						const QString& displayName = QString(),
-						bool defaultConstructed = false );
+public:
 
 	virtual ~AutomatableModel();
 
@@ -244,7 +230,7 @@ public:
 		return "automatablemodel";
 	}
 
-	QString displayValue( const float val ) const;
+	virtual QString displayValue( const float val ) const = 0;
 
 	bool hasLinkedModels() const
 	{
@@ -294,6 +280,15 @@ public slots:
 
 
 protected:
+	// Not meant to be directly instantiated
+	AutomatableModel(
+						const float val = 0,
+						const float min = 0,
+						const float max = 0,
+						const float step = 0,
+						Model* parent = NULL,
+						const QString& displayName = QString(),
+						bool defaultConstructed = false );
 	//! returns a value which is in range between min() and
 	//! max() and aligned according to the step size (step size 0.05 -> value
 	//! 0.12345 becomes 0.10 etc.). You should always call it at the end after
@@ -324,7 +319,6 @@ private:
 	template<class T> void roundAt( T &value, const T &where ) const;
 
 
-	DataType m_dataType;
 	ScaleType m_scaleType; //! scale type, linear by default
 	float m_value;
 	float m_initValue;
@@ -405,11 +399,12 @@ public:
 				Model * parent = NULL,
 				const QString& displayName = QString(),
 				bool defaultConstructed = false ) :
-		AutomatableModel( Float, val, min, max, step, parent, displayName, defaultConstructed )
+		AutomatableModel( val, min, max, step, parent, displayName, defaultConstructed )
 	{
 	}
 	float getRoundedValue() const;
 	int getDigitCount() const;
+	QString displayValue( const float val ) const override;
 	defaultTypedMethods(float);
 
 } ;
@@ -423,9 +418,10 @@ public:
 				Model* parent = NULL,
 				const QString& displayName = QString(),
 				bool defaultConstructed = false ) :
-		AutomatableModel( Integer, val, min, max, 1, parent, displayName, defaultConstructed )
+		AutomatableModel( val, min, max, 1, parent, displayName, defaultConstructed )
 	{
 	}
+	QString displayValue( const float val ) const override;
 
 	defaultTypedMethods(int);
 
@@ -440,9 +436,10 @@ public:
 				Model* parent = NULL,
 				const QString& displayName = QString(),
 				bool defaultConstructed = false ) :
-		AutomatableModel( Bool, val, false, true, 1, parent, displayName, defaultConstructed )
+		AutomatableModel( val, false, true, 1, parent, displayName, defaultConstructed )
 	{
 	}
+	QString displayValue( const float val ) const override;
 
 	defaultTypedMethods(bool);
 

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -77,7 +77,6 @@ public:
 		Decibel
 	};
 
-public:
 
 	virtual ~AutomatableModel();
 
@@ -268,7 +267,6 @@ public slots:
 
 
 protected:
-	// Not meant to be directly instantiated
 	AutomatableModel(
 						const float val = 0,
 						const float min = 0,

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -36,11 +36,10 @@ long AutomatableModel::s_periodCounter = 0;
 
 
 
-AutomatableModel::AutomatableModel( DataType type,
+AutomatableModel::AutomatableModel(
 						const float val, const float min, const float max, const float step,
 						Model* parent, const QString & displayName, bool defaultConstructed ) :
 	Model( parent, displayName, defaultConstructed ),
-	m_dataType( type ),
 	m_scaleType( Linear ),
 	m_minValue( min ),
 	m_maxValue( max ),
@@ -269,19 +268,6 @@ float AutomatableModel::inverseScaledValue( float value ) const
 	return m_scaleType == Linear
 		? value
 		: ::linearToLogScale( minValue<float>(), maxValue<float>(), value );
-}
-
-
-
-QString AutomatableModel::displayValue( const float val ) const
-{
-	switch( m_dataType )
-	{
-		case Float: return QString::number( castValue<float>( scaledValue( val ) ) );
-		case Integer: return QString::number( castValue<int>( scaledValue( val ) ) );
-		case Bool: return QString::number( castValue<bool>( scaledValue( val ) ) );
-	}
-	return "0";
 }
 
 
@@ -728,3 +714,19 @@ int FloatModel::getDigitCount() const
 	return digits;
 }
 
+
+
+QString FloatModel::displayValue( const float val ) const
+{
+	return QString::number( castValue<float>( scaledValue( val ) ) );
+}
+
+QString IntModel::displayValue( const float val ) const
+{
+	return QString::number( castValue<int>( scaledValue( val ) ) );
+}
+
+QString BoolModel::displayValue( const float val ) const
+{
+	return QString::number( castValue<bool>( scaledValue( val ) ) );
+}

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -49,7 +49,6 @@ AutomatableModel::AutomatableModel(
 	m_valueChanged( false ),
 	m_setValueDepth( 0 ),
 	m_hasStrictStepSize( false ),
-	m_hasLinkedModels( false ),
 	m_controllerConnection( NULL ),
 	m_valueBuffer( static_cast<int>( Engine::mixer()->framesPerPeriod() ) ),
 	m_lastUpdatedPeriod( -1 ),
@@ -397,7 +396,6 @@ void AutomatableModel::linkModel( AutomatableModel* model )
 	if( !m_linkedModels.contains( model ) && model != this )
 	{
 		m_linkedModels.push_back( model );
-		m_hasLinkedModels = true;
 
 		if( !model->hasLinkedModels() )
 		{
@@ -416,7 +414,6 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 	{
 		m_linkedModels.erase( it );
 	}
-	m_hasLinkedModels = !m_linkedModels.isEmpty();
 }
 
 
@@ -448,8 +445,6 @@ void AutomatableModel::unlinkAllModels()
 	{
 		unlinkModels( this, model );
 	}
-
-	m_hasLinkedModels = false;
 }
 
 
@@ -552,7 +547,7 @@ ValueBuffer * AutomatableModel::valueBuffer()
 		}
 	}
 	AutomatableModel* lm = NULL;
-	if( m_hasLinkedModels )
+	if( hasLinkedModels() )
 	{
 		lm = m_linkedModels.first();
 	}


### PR DESCRIPTION
- Removed `AutomatableModel::m_dataType`. Either the `AutomatableModel` should handle _all_ functions dependent on its data type (i.e. there are no specialized `FloatModel`, `IntModel`, `BoolModel`), or it should defer datatype-dependent to the derived type via virtual methods - but not both.  
- Removed `m_hasLinkedModels`. Keeping track of it is just extra complexity when `m_linkedModels.empty()` allows the same functionality with essentially the same performance.
- Removed `hasStrictStepSize()` accessor, since nothing uses it.