### PR TITLE
Fix C++ standards library portability issue.

### DIFF
--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
@@ -24,7 +24,6 @@
 #ifndef FFT_WRAPPER_H
 #define FFT_WRAPPER_H
 #include <fftw3.h>
-#include <cmath>
 #include <complex>
 typedef float	fftw_real;
 typedef std::complex<fftw_real> fft_t;
@@ -61,10 +60,10 @@ std::complex<_Tp>
 FFTpolar(const _Tp& __rho, const _Tp& __theta = _Tp(0))
 {
         _Tp __x = __rho * cos(__theta);
-        if (isnan(__x))
+        if (std::isnan(__x))
                 __x = 0;
         _Tp __y = __rho * sin(__theta);
-        if (isnan(__y))
+        if (std::isnan(__y))
                 __y = 0;
         return std::complex<_Tp>(__x, __y);
 }

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
@@ -24,6 +24,7 @@
 #ifndef FFT_WRAPPER_H
 #define FFT_WRAPPER_H
 #include <fftw3.h>
+#include <cmath>
 #include <complex>
 typedef float	fftw_real;
 typedef std::complex<fftw_real> fft_t;

--- a/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/DSP/FFTwrapper.h
@@ -49,5 +49,24 @@ class FFTwrapper
         fftwf_plan     planfftw, planfftw_inv;
 };
 
+/*
+ * The "std::polar" template has no clear definition for the range of
+ * the input parameters, and some C++ standard library implementations
+ * don't accept negative amplitude among others. Define our own
+ * FFTpolar template, which works like we expect it to.
+ */
+template<class _Tp>
+std::complex<_Tp>
+FFTpolar(const _Tp& __rho, const _Tp& __theta = _Tp(0))
+{
+        _Tp __x = __rho * cos(__theta);
+        if (isnan(__x))
+                __x = 0;
+        _Tp __y = __rho * sin(__theta);
+        if (isnan(__y))
+                __y = 0;
+        return std::complex<_Tp>(__x, __y);
+}
+
 void FFT_cleanup();
 #endif

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Params/PADnoteParameters.cpp
@@ -615,7 +615,7 @@ void PADnoteParameters::applyparameters(bool lockmutex)
 
         newsample.smp[0] = 0.0f;
         for(int i = 1; i < spectrumsize; ++i) //randomize the phases
-            fftfreqs[i] = std::polar(spectrum[i], (float)RND * 6.29f);
+            fftfreqs[i] = FFTpolar(spectrum[i], (float)RND * 6.29f);
         fft->freqs2smps(fftfreqs, newsample.smp); //that's all; here is the only ifft for the whole sample; no windows are used ;-)
 
 

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Synth/OscilGen.cpp
@@ -533,7 +533,7 @@ void OscilGen::spectrumadjust()
                     mag = 1.0f;
                 break;
         }
-        oscilFFTfreqs[i] = std::polar<fftw_real>(mag, phase);
+        oscilFFTfreqs[i] = FFTpolar<fftw_real>(mag, phase);
     }
 }
 
@@ -629,7 +629,7 @@ void OscilGen::prepare()
                 int k = i * (j + 1);
                 if(k >= synth->oscilsize / 2)
                     break;
-                oscilFFTfreqs[k] += basefuncFFTfreqs[i] * std::polar<fftw_real>(
+                oscilFFTfreqs[k] += basefuncFFTfreqs[i] * FFTpolar<fftw_real>(
                     hmag[j],
                     hphase[j] * k);
             }
@@ -857,7 +857,7 @@ short int OscilGen::get(float *smps, float freqHz, int resonance)
         const float rnd = PI * powf((Prand - 64.0f) / 64.0f, 2.0f);
         for(int i = 1; i < nyquist - 1; ++i) //to Nyquist only for AntiAliasing
             outoscilFFTfreqs[i] *=
-                std::polar<fftw_real>(1.0f, (float)(rnd * i * RND));
+                FFTpolar<fftw_real>(1.0f, (float)(rnd * i * RND));
     }
 
     //Harmonic Amplitude Randomness


### PR DESCRIPTION
Fixes zyn instrument playback on Mac for certain presets.

This PR is a partial cherry-pick of upstream 2.5 patches: zynaddsubfx/zynaddsubfx@417d49b, zynaddsubfx/zynaddsubfx@edca8ab

Quoting the author, @hselasky from 2014:
> The `std::polar` template has no clear definition for the range of
> the input parameters, and some C++ standard library implementations
> don't accept negative amplitude among others. Define our own
> `FFTpolar` template, which works like we expect it to.

Closes #4152