### PR TITLE
Add ZynAddSubFX status to build summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,7 +398,11 @@ PKG_CHECK_MODULES(FFTW3F REQUIRED fftw3f>=3.0.0)
 
 # check for FLTK
 FIND_PACKAGE(FLTK)
-
+IF(FLTK_FOUND)
+	SET(STATUS_ZYN "OK")
+ELSE()
+	SET(STATUS_ZYN "not found, please install fltk")
+ENDIF()
 
 # check for Fluidsynth
 IF(WANT_SF2)
@@ -650,6 +654,7 @@ MESSAGE(
 MESSAGE(
 "Optional plugins\n"
 "----------------\n"
+"* ZynAddSubFX instrument      : ${STATUS_ZYN}\n"
 "* Carla Patchbay & Rack       : ${STATUS_CARLA}\n"
 "* SoundFont2 player           : ${STATUS_FLUIDSYNTH}\n"
 "* Stk Mallets                 : ${STATUS_STK}\n"


### PR DESCRIPTION
Add `ZynAddSubFX` to summary screen.

Much like the rest of our plugins, stating something is `OK` is quite arbitrary regarding whether or not it will compile, so this is mostly for first-time builders to know if `ZynAddSubFX` will be missing from the project.  Inspired by @GuessWhatBBQ on [Discord](https://lmms.io/chat).

Disclaimer... 
* This PR doesn't take into consideration stuff like a missing submodule; It's just to remain accurate with the way we list the rest of the plugins today.
* This PR doesn't add anything like `-DWANT_ZYN=Off` flag, which would be a bit more consistent with our other plugins but perhaps redundant with #2968.
* To the previous point, currently, we turn off plugins using the `-DLMMS_MINIMAL` and optionally `-DPLUGIN_LIST=zynaddsubfx`.  We don't take any of that into consideration here and it's out of scope for this PR.  We'll need a more holistic approach to summarizing plugins, preferably in `plugins/CMakeList.txt`, but a more involved discussion...

```diff
  Optional plugins
  ----------------
+ * ZynAddSubFX instrument      : OK
- * ZynAddSubFX instrument      : not found, please install fltk
  * Carla Patchbay & Rack       : OK
  * SoundFont2 player           : OK
  * Stk Mallets                 : OK
  * VST-instrument hoster       : OK, with workaround linking /usr/lib/i386-linux-gnu/
  * VST-effect hoster           : OK, with workaround linking /usr/lib/i386-linux-gnu/
  * CALF LADSPA plugins         : OK
  * CAPS LADSPA plugins         : OK
  * CMT LADSPA plugins          : OK
  * TAP LADSPA plugins          : OK
  * SWH LADSPA plugins          : OK
  * GIG player                  : OK
```