### PR TITLE
Allow relative paths on non-existent directories

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -227,7 +227,7 @@ bool ConfigManager::hasWorkingDir() const
 
 void ConfigManager::setWorkingDir( const QString & wd )
 {
-	m_workingDir = ensureTrailingSlash( QFileInfo( wd ).canonicalFilePath() );
+	m_workingDir = ensureTrailingSlash( QDir::cleanPath( wd ) );
 }
 
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1416,7 +1416,7 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 	if( QFileInfo( file ).isRelative() == false )
 	{
 		// Normalize the path
-		QString f( QDir::cleanPath( file ).replace( QDir::separator(), '/' ) );
+		QString f( QDir::cleanPath( file ) );
 
 		// First, look in factory samples
 		// Isolate "samples/" from "data:/samples/"

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1425,7 +1425,7 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 		// Iterate over all valid "data:/" searchPaths
 		for ( const QString & path : QDir::searchPaths( "data" ) )
 		{
-			QString samplesPath = QString( path + samplesSuffix ).replace( QDir::separator(), '/' );
+			QString samplesPath = QDir::cleanPath( path + samplesSuffix ) + "/";
 			if ( f.startsWith( samplesPath ) )
 			{
 				return QString( f ).mid( samplesPath.length() );

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1416,7 +1416,6 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 	if( QFileInfo( file ).isRelative() == false )
 	{
 		// Normalize the path
-		QFileInfo fileInfo( file );
 		QString f( QDir::cleanPath( file ) + QDir::separator() + QFileInfo( file ).fileName() );
 		f.replace( QDir::separator(), '/' );
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1416,8 +1416,7 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 	if( QFileInfo( file ).isRelative() == false )
 	{
 		// Normalize the path
-		QString f( QDir::cleanPath( file ) + QDir::separator() + QFileInfo( file ).fileName() );
-		f.replace( QDir::separator(), '/' );
+		QString f( QDir::cleanPath( file ).replace( QDir::separator(), '/' ) );
 
 		// First, look in factory samples
 		// Isolate "samples/" from "data:/samples/"

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1416,7 +1416,9 @@ QString SampleBuffer::tryToMakeRelative( const QString & file )
 	if( QFileInfo( file ).isRelative() == false )
 	{
 		// Normalize the path
-		QString f = QFileInfo( file ).canonicalFilePath().replace( QDir::separator(), '/' );
+		QFileInfo fileInfo( file );
+		QString f( QDir::cleanPath( file ) + QDir::separator() + QFileInfo( file ).fileName() );
+		f.replace( QDir::separator(), '/' );
 
 		// First, look in factory samples
 		// Isolate "samples/" from "data:/samples/"


### PR DESCRIPTION
Switch `SampleBuffer::tryToMakeRelative(...)` to use `cleanPath` instead of `canonicalFilePath`.

`canonicalFilePath` has several limitations including:
1. Failure to handle a non-existant path (#4267)
2. Possible undesired symlink handling