### PR TITLE
Fix stack overflow in RemoteVstPlugin

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1450,7 +1450,6 @@ intptr_t RemoteVstPlugin::hostCallback( AEffect * _effect, int32_t _opcode,
 		case audioMasterAutomate:
 			SHOW_CALLBACK( "amc: audioMasterAutomate\n" );
 			// index, value, returns 0
-			_effect->setParameter( _effect, _index, _opt );
 			return 0;
 
 		case audioMasterVersion:


### PR DESCRIPTION
Fixes #4142.

VST plugins use the `audioMasterAutomate` callback to notify the host of parameter changes from within the plugin, and the host uses the `setParameter` function to update the plugin with parameter changes from the host. Neither of these should be called in response to the other as the other party already has the necessary information. The issue arises because both Transient and LMMS both do this, so it could be considered a bug in the plugin as much as one in LMMS, but we can and probably ought to fix the issue on our end at least.

This PR removes the `setParameter` call from the `audioMasterAutomate` handler.