### PR TITLE
Better default working directory

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -26,7 +26,11 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QApplication>
+#if QT_VERSION >= 0x050000
 #include <QStandardPaths>
+#else
+#include <QDesktopServices>
+#endif
 #include <QtCore/QTextStream>
 
 #include "ConfigManager.h"
@@ -51,7 +55,7 @@ ConfigManager * ConfigManager::s_instanceOfMe = NULL;
 
 ConfigManager::ConfigManager() :
 	m_lmmsRcFile( QDir::home().absolutePath() +"/.lmmsrc.xml" ),
-	#if QT_VERSION >= 0x050100
+	#if QT_VERSION >= 0x050000
 	m_workingDir( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/lmms/"),
 	#else
 	m_workingDir( QDesktopServices::storageLocation( QDesktopServices::DocumentsLocation ) + "/lmms/"),

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -26,6 +26,7 @@
 #include <QDir>
 #include <QMessageBox>
 #include <QApplication>
+#include <QStandardPaths>
 #include <QtCore/QTextStream>
 
 #include "ConfigManager.h"
@@ -50,7 +51,11 @@ ConfigManager * ConfigManager::s_instanceOfMe = NULL;
 
 ConfigManager::ConfigManager() :
 	m_lmmsRcFile( QDir::home().absolutePath() +"/.lmmsrc.xml" ),
-	m_workingDir( QDir::home().absolutePath() + "/lmms/"),
+	#if QT_VERSION >= 0x050100
+	m_workingDir( QStandardPaths::writableLocation( QStandardPaths::DocumentsLocation ) + "/lmms/"),
+	#else
+	m_workingDir( QDesktopServices::storageLocation( QDesktopServices::DocumentsLocation ) + "/lmms/"),
+	#endif
 	m_dataDir( "data:/" ),
 	m_artworkDir( defaultArtworkDir() ),
 	m_vstDir( m_workingDir + "vst/" ),

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -67,6 +67,10 @@ ConfigManager::ConfigManager() :
 	m_sf2Dir( m_workingDir + SF2_PATH ),
 	m_version( defaultVersion() )
 {
+	// Detect < 1.2.0 working directory as a courtesy
+	if ( QFileInfo( QDir::home().absolutePath() + "/lmms/projects/" ).exists() )
+                m_workingDir = QDir::home().absolutePath() + "/lmms/";
+
 	if (! qgetenv("LMMS_DATA_DIR").isEmpty())
 		QDir::addSearchPath("data", QString::fromLocal8Bit(qgetenv("LMMS_DATA_DIR")));
 

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -58,18 +58,10 @@ GuiApplication::GuiApplication()
 	#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
 	#endif
-	
-	// prompt the user to create the LMMS working directory (e.g. ~/lmms) if it doesn't exist
-	if ( !ConfigManager::inst()->hasWorkingDir() &&
-		QMessageBox::question( NULL,
-				tr( "Working directory" ),
-				tr( "The LMMS working directory %1 does not "
-				"exist. Create it now? You can change the directory "
-				"later via Edit -> Settings." ).arg( ConfigManager::inst()->workingDir() ),
-					QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes ) == QMessageBox::Yes)
-	{
-		ConfigManager::inst()->createWorkingDir();
-	}
+
+	// Create the LMMS working directory and subdirectories (e.g. ~/Documents/lmms)
+	ConfigManager::inst()->createWorkingDir();
+
 	// Init style and palette
 	LmmsStyle* lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -58,10 +58,18 @@ GuiApplication::GuiApplication()
 	#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 		QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
 	#endif
-
-	// Create the LMMS working directory and subdirectories (e.g. ~/Documents/lmms)
-	ConfigManager::inst()->createWorkingDir();
-
+	
+	// prompt the user to create the LMMS working directory (e.g. ~/Documents/lmms) if it doesn't exist
+	if ( !ConfigManager::inst()->hasWorkingDir() &&
+		QMessageBox::question( NULL,
+				tr( "Working directory" ),	
+				tr( "The LMMS working directory %1 does not "	
+				"exist. Create it now? You can change the directory "	
+				"later via Edit -> Settings." ).arg( ConfigManager::inst()->workingDir() ),	
+					QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes ) == QMessageBox::Yes)	
+	{	
+		ConfigManager::inst()->createWorkingDir();	
+	}
 	// Init style and palette
 	LmmsStyle* lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -62,13 +62,13 @@ GuiApplication::GuiApplication()
 	// prompt the user to create the LMMS working directory (e.g. ~/Documents/lmms) if it doesn't exist
 	if ( !ConfigManager::inst()->hasWorkingDir() &&
 		QMessageBox::question( NULL,
-				tr( "Working directory" ),	
-				tr( "The LMMS working directory %1 does not "	
-				"exist. Create it now? You can change the directory "	
-				"later via Edit -> Settings." ).arg( ConfigManager::inst()->workingDir() ),	
-					QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes ) == QMessageBox::Yes)	
-	{	
-		ConfigManager::inst()->createWorkingDir();	
+				tr( "Working directory" ),
+				tr( "The LMMS working directory %1 does not "
+				"exist. Create it now? You can change the directory "
+				"later via Edit -> Settings." ).arg( ConfigManager::inst()->workingDir() ),
+					QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes ) == QMessageBox::Yes)
+	{
+		ConfigManager::inst()->createWorkingDir();
 	}
 	// Init style and palette
 	LmmsStyle* lmmsstyle = new LmmsStyle();


### PR DESCRIPTION
Better behavior of default working directory:

* Fresh installs of LMMS (e.g. no `~/.lmmsrc.xml`) will default to the more browsable, more sane and less conflicting `~/Documents/lmms`.
~~* No longer prompt to create the home directory.~~

**Note:** The Qt4 logic is currently untested.

Closes #1135