### PR TITLE
Minimum framesPerPeriod() effect decay

### DIFF
--- a/include/Effect.h
+++ b/include/Effect.h
@@ -104,7 +104,8 @@ public:
 	inline f_cnt_t timeout() const
 	{
 		const float samples = Engine::mixer()->processingSampleRate() * m_autoQuitModel.value() / 1000.0f;
-		return 1 + ( static_cast<int>( samples ) / Engine::mixer()->framesPerPeriod() );
+		int frames = Engine::mixer()->framesPerPeriod();
+		return frames + static_cast<int>( samples ) / frames;
 	}
 
 	inline float wetLevel() const


### PR DESCRIPTION
In response to https://github.com/LMMS/lmms/issues/4284
Increase the 1 minimum frame to `Engine::mixer()->framesPerPeriod();`