### PR TITLE
Deselect FX channels' name text when losing focus

### DIFF
--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -262,6 +262,7 @@ void FxLine::renameChannel()
 void FxLine::renameFinished()
 {
 	m_inRename = false;
+	m_renameLineEdit->deselect();
 	m_renameLineEdit->setReadOnly( true );
 	m_renameLineEdit->setFixedWidth( 65 );
 	m_lcd->show();


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/3861#issuecomment-334941292.
To reproduce on any platforms:
1. Double-click any FX channel
2. Press Alt + Tab while text is selected
3. Back to LMMS