### PR TITLE
Fix VST effect bugs

### DIFF
--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -41,7 +41,6 @@
 #include <QToolBar>
 #include <QLabel>
 
-
 VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	EffectControlDialog( _ctl ),
 	m_pluginWidget( NULL ),
@@ -271,6 +270,17 @@ void VstEffectControlDialog::paintEvent( QPaintEvent * )
 		tbLabel->setText( tr( "Effect by: " ) + m_plugin->vendorString() +
 			tr( "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br />" ) +
 			m_plugin->currentProgramName() );
+	}
+}
+
+void VstEffectControlDialog::showEvent(QShowEvent *_se)
+{
+	EffectControlDialog::showEvent( _se );
+	// Workaround for a (unexplained) bug where on project-load the effect
+	// control window has size 0 and would only restore to the proper size upon
+	// moving the window or interacting with it.
+	if (parentWidget()) {
+		parentWidget()->adjustSize();
 	}
 }
 

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -45,6 +45,7 @@
 VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	EffectControlDialog( _ctl ),
 	m_pluginWidget( NULL ),
+
 	m_plugin( NULL ),
 	tbLabel( NULL )
 {
@@ -62,16 +63,10 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		embed_vst = m_plugin->embedMethod() != "none";
 
 		if (embed_vst) {
-			m_plugin->createUI( nullptr, true );
-			m_pluginWidget = m_plugin->pluginWidget( false );
-
-#ifdef LMMS_BUILD_WIN32
-			if( !m_pluginWidget )
-			{
-				m_pluginWidget = m_plugin->pluginWidget( false );
+			if (! m_plugin->pluginWidget()) {
+				m_plugin->createUI(nullptr);
 			}
-#endif
-
+			m_pluginWidget = m_plugin->pluginWidget();
 		}
 	}
 
@@ -79,7 +74,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	{
 		setWindowTitle( m_plugin->name() );
 
-		QPushButton * btn = new QPushButton( tr( "Show/hide" ) );
+		QPushButton * btn = new QPushButton( tr( "Show/hide" ));
 
 		if (embed_vst) {
 			btn->setCheckable( true );
@@ -95,6 +90,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		btn->setMaximumWidth( 78 );
 		btn->setMinimumHeight( 24 );
 		btn->setMaximumHeight( 24 );
+		m_togglePluginButton = btn;
 
 		m_managePluginButton = new PixmapButton( this, "" );
 		m_managePluginButton->setCheckable( false );
@@ -295,6 +291,14 @@ void VstEffectControlDialog::togglePluginUI( bool checked )
 		return;
 	}
 
-	m_plugin->toggleUI();
+	if ( m_togglePluginButton->isChecked() != checked ) {
+		m_togglePluginButton->setChecked( checked );
+	}
+
+	if ( checked ) {
+		m_plugin->showUI();
+	} else {
+		m_plugin->hideUI();
+	}
 }
 

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -82,8 +82,8 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 			connect( btn, SIGNAL( toggled( bool ) ),
 						SLOT( togglePluginUI( bool ) ) );
 		} else {
-			connect( btn, SIGNAL( clicked( bool ) ),
-						SLOT( togglePluginUI( bool ) ) );
+			connect( btn, SIGNAL( clicked() ),
+						m_plugin.data(), SLOT( toggleUI() ) );
 		}
 
 		btn->setMinimumWidth( 78 );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -62,14 +62,14 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		embed_vst = m_plugin->embedMethod() != "none";
 
 		if (embed_vst) {
-			if (! m_plugin->pluginWidget()) {
+			if (m_plugin->hasEditor() && ! m_plugin->pluginWidget()) {
 				m_plugin->createUI(this);
 			}
 			m_pluginWidget = m_plugin->pluginWidget();
 		}
 	}
 
-	if ( m_plugin && (!embed_vst || m_pluginWidget) )
+	if (m_plugin)
 	{
 		setWindowTitle( m_plugin->name() );
 
@@ -218,7 +218,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 
 		int newSize = 0;
 
-		if (embed_vst) {
+		if (m_pluginWidget) {
 			newSize = m_pluginWidget->width() + 20;
 		}
 		newSize = std::max(newSize, 250);
@@ -234,7 +234,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		l->addItem( new QSpacerItem( newSize - 20, 30, QSizePolicy::Fixed,
 						QSizePolicy::Fixed ), 1, 0 );
 		l->addWidget( resize, 2, 0, 1, 1, Qt::AlignCenter );
-		if (embed_vst) {
+		if (m_pluginWidget) {
 			l->addWidget( m_pluginWidget, 3, 0, 1, 1, Qt::AlignCenter );
 		}
 		l->setRowStretch( 5, 1 );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -64,7 +64,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 
 		if (embed_vst) {
 			if (! m_plugin->pluginWidget()) {
-				m_plugin->createUI(nullptr);
+				m_plugin->createUI(this);
 			}
 			m_pluginWidget = m_plugin->pluginWidget();
 		}

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -289,7 +289,12 @@ void VstEffectControlDialog::showEvent(QShowEvent *_se)
 
 VstEffectControlDialog::~VstEffectControlDialog()
 {
-	//delete m_pluginWidget;
+#if !(QT_VERSION < 0x050000 && defined(LMMS_BUILD_LINUX))
+	if (m_pluginWidget && layout()) {
+		layout()->removeWidget(m_pluginWidget);
+		m_pluginWidget->setParent(nullptr);
+	}
+#endif
 }
 
 

--- a/plugins/VstEffect/VstEffectControlDialog.h
+++ b/plugins/VstEffect/VstEffectControlDialog.h
@@ -54,6 +54,7 @@ protected:
 private:
 	QWidget * m_pluginWidget;
 
+	QPushButton * m_togglePluginButton;
 	PixmapButton * m_openPresetButton;
 	PixmapButton * m_rolLPresetButton;
 	PixmapButton * m_rolRPresetButton;
@@ -64,7 +65,7 @@ private:
 
 	QLabel * tbLabel;
 
-private slots:
+public slots:
 	void togglePluginUI( bool checked );
 } ;
 

--- a/plugins/VstEffect/VstEffectControlDialog.h
+++ b/plugins/VstEffect/VstEffectControlDialog.h
@@ -50,6 +50,7 @@ public:
 
 protected:
 	virtual void paintEvent( QPaintEvent * _pe );
+	virtual void showEvent( QShowEvent* _se ) override;
 
 private:
 	QWidget * m_pluginWidget;

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -40,7 +40,8 @@ VstEffectControls::VstEffectControls( VstEffect * _eff ) :
 	m_subWindow( NULL ),
 	knobFModel( NULL ),
 	ctrHandle( NULL ),
-	lastPosInMenu (0)
+	lastPosInMenu (0),
+	m_vstGuiVisible ( true )
 //	m_presetLabel ( NULL )
 {
 }
@@ -64,6 +65,8 @@ void VstEffectControls::loadSettings( const QDomElement & _this )
 	m_effect->m_pluginMutex.lock();
 	if( m_effect->m_plugin != NULL )
 	{
+		m_vstGuiVisible = _this.attribute( "guivisible" ).toInt();
+
 		m_effect->m_plugin->loadSettings( _this );
 
 		const QMap<QString, QString> & dump = m_effect->m_plugin->parameterDump();
@@ -140,6 +143,15 @@ int VstEffectControls::controlCount()
 {
 	return m_effect->m_plugin != NULL &&
 		m_effect->m_plugin->hasEditor() ?  1 : 0;
+}
+
+
+
+EffectControlDialog *VstEffectControls::createView()
+{
+	auto dialog = new VstEffectControlDialog( this );
+	dialog->togglePluginUI( m_vstGuiVisible );
+	return dialog;
 }
 
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -317,7 +317,7 @@ manageVSTEffectView::manageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 	m_vi->m_subWindow->setWidget(m_vi->m_scrollArea);
 	m_vi->m_subWindow->setWindowTitle( _eff->m_plugin->name() + tr( " - VST parameter control" ) );
 	m_vi->m_subWindow->setWindowIcon( PLUGIN_NAME::getIconPixmap( "logo" ) );
-	//m_vi->m_subWindow->setAttribute(Qt::WA_DeleteOnClose);
+	m_vi->m_subWindow->setAttribute(Qt::WA_DeleteOnClose, false);
 
 
 	l->setContentsMargins( 20, 10, 10, 10 );

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -141,8 +141,7 @@ void VstEffectControls::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 int VstEffectControls::controlCount()
 {
-	return m_effect->m_plugin != NULL &&
-		m_effect->m_plugin->hasEditor() ?  1 : 0;
+	return m_effect->m_plugin != NULL ? 1 : 0;
 }
 
 

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -59,10 +59,7 @@ public:
 
 	virtual int controlCount();
 
-	virtual EffectControlDialog * createView()
-	{
-		return new VstEffectControlDialog( this );
-	}
+	virtual EffectControlDialog * createView();
 
 
 protected slots:
@@ -96,6 +93,7 @@ private:
 	friend class VstEffectControlDialog;
 	friend class manageVSTEffectView;
 
+	bool m_vstGuiVisible;
 } ;
 
 

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -107,10 +107,12 @@ public:
 	void createUI( QWidget *parent ) override
 	{
 		Q_UNUSED(parent);
-		VstPlugin::createUI( nullptr );
 		if ( embedMethod() != "none" ) {
 			m_pluginSubWindow.reset(new vstSubWin( gui->mainWindow()->workspace() ));
+			VstPlugin::createUI( m_pluginSubWindow.get() );
 			m_pluginSubWindow->setWidget(pluginWidget());
+		} else {
+			VstPlugin::createUI( nullptr );
 		}
 	}
 

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -24,6 +24,8 @@
 
 #include "vestige.h"
 
+#include <memory>
+
 #include <QDropEvent>
 #include <QMessageBox>
 #include <QPainter>
@@ -71,6 +73,57 @@ Plugin::Descriptor PLUGIN_EXPORT vestige_plugin_descriptor =
 } ;
 
 }
+
+
+class vstSubWin : public QMdiSubWindow
+{
+public:
+	vstSubWin( QWidget * _parent ) :
+		QMdiSubWindow( _parent )
+	{
+		setAttribute( Qt::WA_DeleteOnClose, false );
+		setWindowFlags( Qt::WindowCloseButtonHint );
+	}
+
+	virtual ~vstSubWin()
+	{
+	}
+
+	virtual void closeEvent( QCloseEvent * e )
+	{
+		// ignore close-events - for some reason otherwise the VST GUI
+		// remains hidden when re-opening
+		hide();
+		e->ignore();
+	}
+};
+
+
+class VstInstrumentPlugin : public VstPlugin
+{
+public:
+	using VstPlugin::VstPlugin;
+
+	void createUI( QWidget *parent ) override
+	{
+		Q_UNUSED(parent);
+		VstPlugin::createUI( nullptr );
+		if ( embedMethod() != "none" ) {
+			m_pluginSubWindow.reset(new vstSubWin( gui->mainWindow()->workspace() ));
+			m_pluginSubWindow->setWidget(pluginWidget());
+		}
+	}
+
+	/// Overwrite editor() to return the sub window instead of the embed widget
+	/// itself. This makes toggleUI() and related functions toggle the
+	/// sub window's visibility.
+	QWidget* editor() override
+	{
+		return m_pluginSubWindow.get();
+	}
+private:
+	unique_ptr<QMdiSubWindow> m_pluginSubWindow;
+};
 
 
 QPixmap * VestigeInstrumentView::s_artwork = NULL;
@@ -126,6 +179,12 @@ void vestigeInstrument::loadSettings( const QDomElement & _this )
 	if( m_plugin != NULL )
 	{
 		m_plugin->loadSettings( _this );
+
+		if ( _this.attribute( "guivisible" ).toInt() ) {
+			m_plugin->showUI();
+		} else {
+			m_plugin->hideUI();
+		}
 
 		const QMap<QString, QString> & dump = m_plugin->parameterDump();
 		paramCount = dump.size();
@@ -267,7 +326,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 	}
 
 	m_pluginMutex.lock();
-	m_plugin = new VstPlugin( m_pluginDLL );
+	m_plugin = new VstInstrumentPlugin( m_pluginDLL );
 	if( m_plugin->failed() )
 	{
 		m_pluginMutex.unlock();
@@ -278,6 +337,7 @@ void vestigeInstrument::loadFile( const QString & _file )
 		return;
 	}
 
+	m_plugin->createUI(nullptr);
 	m_plugin->showUI();
 
 	if( set_ch_name )

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -730,8 +730,10 @@ void RemoteVstPlugin::initEditor()
 	m_windowWidth = er->right - er->left;
 	m_windowHeight = er->bottom - er->top;
 
-	SetWindowPos( m_window, 0, 0, 0, m_windowWidth + 8,
-			m_windowHeight + 26, SWP_NOACTIVATE |
+	RECT windowSize = { 0, 0, m_windowWidth, m_windowHeight };
+	AdjustWindowRect( &windowSize, dwStyle, false );
+	SetWindowPos( m_window, 0, 0, 0, windowSize.right - windowSize.left,
+			windowSize.bottom - windowSize.top, SWP_NOACTIVATE |
 						SWP_NOMOVE | SWP_NOZORDER );
 	pluginDispatch( effEditTop );
 
@@ -1968,7 +1970,7 @@ LRESULT CALLBACK RemoteVstPlugin::wndProc( HWND hwnd, UINT uMsg,
 				break;
 		}
 	}
-	else if( uMsg == WM_SYSCOMMAND && wParam == SC_CLOSE )
+	else if( uMsg == WM_SYSCOMMAND && (wParam & 0xfff0) == SC_CLOSE )
 	{
 		__plugin->hideEditor();
 		return 0;

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -293,8 +293,8 @@ public:
 	static DWORD WINAPI processingThread( LPVOID _param );
 	static bool setupMessageWindow();
 	static DWORD WINAPI guiEventLoop();
-	static LRESULT CALLBACK messageWndProc( HWND hwnd, UINT uMsg,
-						WPARAM wParam, LPARAM lParam );
+	static LRESULT CALLBACK wndProc( HWND hwnd, UINT uMsg,
+					WPARAM wParam, LPARAM lParam );
 
 
 private:
@@ -1884,8 +1884,6 @@ bool RemoteVstPlugin::setupMessageWindow()
 	__MessageHwnd = CreateWindowEx( 0, "LVSL", "dummy",
 						0, 0, 0, 0, 0, NULL, NULL,
 								hInst, NULL );
-	SetWindowLongPtr( __MessageHwnd, GWLP_WNDPROC,
-		reinterpret_cast<LONG_PTR>( RemoteVstPlugin::messageWndProc ) );
 	// install GUI update timer
 	SetTimer( __MessageHwnd, 1000, 50, NULL );
 
@@ -1910,7 +1908,7 @@ DWORD WINAPI RemoteVstPlugin::guiEventLoop()
 
 
 
-LRESULT CALLBACK RemoteVstPlugin::messageWndProc( HWND hwnd, UINT uMsg,
+LRESULT CALLBACK RemoteVstPlugin::wndProc( HWND hwnd, UINT uMsg,
 						WPARAM wParam, LPARAM lParam )
 {
 	if( uMsg == WM_TIMER && __plugin->isInitialized() )
@@ -2004,7 +2002,7 @@ int main( int _argc, char * * _argv )
 
 	WNDCLASS wc;
 	wc.style = CS_HREDRAW | CS_VREDRAW;
-	wc.lpfnWndProc = DefWindowProc;
+	wc.lpfnWndProc = RemoteVstPlugin::wndProc;
 	wc.cbClsExtra = 0;
 	wc.cbWndExtra = 0;
 	wc.hInstance = hInst;

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -656,6 +656,10 @@ void VstPlugin::createUI( QWidget * parent )
 #ifdef LMMS_BUILD_LINUX
 	if (m_embedMethod == "xembed" )
 	{
+		if (parent)
+		{
+			parent->setAttribute(Qt::WA_NativeWindow);
+		}
 		QX11EmbedContainer * embedContainer = new QX11EmbedContainer( parent );
 		connect(embedContainer, SIGNAL(clientIsEmbedded()), this, SLOT(handleClientEmbed()));
 		embedContainer->embedClient( m_pluginWindowID );
@@ -671,8 +675,6 @@ void VstPlugin::createUI( QWidget * parent )
 	container->setWindowTitle( name() );
 
 	m_pluginWidget = container;
-
-	container->setFixedSize( m_pluginGeometry );
 }
 
 bool VstPlugin::eventFilter(QObject *obj, QEvent *event)

--- a/plugins/vst_base/VstPlugin.h
+++ b/plugins/vst_base/VstPlugin.h
@@ -54,8 +54,10 @@ public:
 		return m_pluginWindowID != 0;
 	}
 
-	void hideEditor();
-	void toggleEditor();
+	/// Same as pluginWidget(), but can be overwritten in sub-classes to modify
+	/// behavior the UI. This is used in VstInstrumentPlugin to wrap the VST UI
+	/// in a QMdiSubWindow
+	virtual QWidget* editor();
 
 	inline const QString & name() const
 	{
@@ -93,7 +95,7 @@ public:
 	void setParameterDump( const QMap<QString, QString> & _pdump );
 
 
-	QWidget * pluginWidget( bool _top_widget = true );
+	QWidget * pluginWidget();
 
 	virtual void loadSettings( const QDomElement & _this );
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _this );
@@ -103,9 +105,8 @@ public:
 		return "vstplugin";
 	}
 
-	void toggleUI() override;
 
-	void createUI( QWidget *parent, bool isEffect );
+	virtual void createUI(QWidget *parent);
 	bool eventFilter(QObject *obj, QEvent *event);
 
 	QString embedMethod() const;
@@ -123,6 +124,7 @@ public slots:
 
 	void showUI() override;
 	void hideUI() override;
+	void toggleUI() override;
 
 	void handleClientEmbed();
 
@@ -130,9 +132,10 @@ private:
 	void loadChunk( const QByteArray & _chunk );
 	QByteArray saveChunk();
 
+	void toggleEditorVisibility(int visible = -1);
+
 	QString m_plugin;
 	QPointer<QWidget> m_pluginWidget;
-	QPointer<vstSubWin> m_pluginSubWindow;
 	int m_pluginWindowID;
 	QSize m_pluginGeometry;
 	const QString m_embedMethod;

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -113,8 +113,11 @@ void SubWindow::paintEvent( QPaintEvent * )
 	p.drawLine( width() - 1, m_titleBarHeight, width() - 1, height() - 1 );
 
 	// window icon
-	QPixmap winicon( widget()->windowIcon().pixmap( m_buttonSize ) );
-	p.drawPixmap( 3, 3, m_buttonSize.width(), m_buttonSize.height(), winicon );
+	if( widget() )
+	{
+		QPixmap winicon( widget()->windowIcon().pixmap( m_buttonSize ) );
+		p.drawPixmap( 3, 3, m_buttonSize.width(), m_buttonSize.height(), winicon );
+	}
 }
 
 
@@ -267,25 +270,31 @@ void SubWindow::adjustTitleBar()
 	// we're keeping the restore button around if we open projects
 	// from older versions that have saved minimized windows
 	m_restoreBtn->setVisible( isMaximized() || isMinimized() );
-
-	// title QLabel adjustments
-	m_windowTitle->setAlignment( Qt::AlignHCenter );
-	m_windowTitle->setFixedWidth( widget()->width() - ( menuButtonSpace + buttonBarWidth ) );
-	m_windowTitle->move( menuButtonSpace,
-		( m_titleBarHeight / 2 ) - ( m_windowTitle->sizeHint().height() / 2 ) - 1 );
-
-	// if minimized we can't use widget()->width(). We have to hard code the width,
-	// as the width of all minimized windows is the same.
 	if( isMinimized() )
 	{
 		m_restoreBtn->move( m_maximizeBtn->isHidden() ?  middleButtonPos : leftButtonPos );
-		m_windowTitle->setFixedWidth( 120 );
 	}
 
-	// truncate the label string if the window is to small. Adds "..."
-	elideText( m_windowTitle, widget()->windowTitle() );
-	m_windowTitle->setTextInteractionFlags( Qt::NoTextInteraction );
-	m_windowTitle->adjustSize();
+	if( widget() )
+	{
+		// title QLabel adjustments
+		m_windowTitle->setAlignment( Qt::AlignHCenter );
+		m_windowTitle->setFixedWidth( widget()->width() - ( menuButtonSpace + buttonBarWidth ) );
+		m_windowTitle->move( menuButtonSpace,
+			( m_titleBarHeight / 2 ) - ( m_windowTitle->sizeHint().height() / 2 ) - 1 );
+
+		// if minimized we can't use widget()->width(). We have to hard code the width,
+		// as the width of all minimized windows is the same.
+		if( isMinimized() )
+		{
+			m_windowTitle->setFixedWidth( 120 );
+		}
+
+		// truncate the label string if the window is to small. Adds "..."
+		elideText( m_windowTitle, widget()->windowTitle() );
+		m_windowTitle->setTextInteractionFlags( Qt::NoTextInteraction );
+		m_windowTitle->adjustSize();
+	}
 }
 
 

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -29,6 +29,7 @@
 #include <QMdiSubWindow>
 #include <QPainter>
 #include <QWhatsThis>
+#include <QLayout>
 
 #include "EffectView.h"
 #include "DummyEffect.h"
@@ -109,7 +110,9 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 		{
 			m_subWindow = gui->mainWindow()->addWindowedWidget( m_controlView );
 			m_subWindow->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
-			m_subWindow->setFixedSize( m_subWindow->size() );
+			if (m_subWindow->layout()) {
+				m_subWindow->layout()->setSizeConstraint(QLayout::SetFixedSize);
+			}
 
 			Qt::WindowFlags flags = m_subWindow->windowFlags();
 			flags &= ~Qt::WindowMaximizeButtonHint;

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -164,18 +164,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 EffectView::~EffectView()
 {
-
-#ifdef LMMS_BUILD_LINUX
-
 	delete m_subWindow;
-#else
-	if( m_subWindow )
-	{
-		// otherwise on win32 build VST GUI can get lost
-		m_subWindow->hide();
-	}
-#endif
-
 }
 
 


### PR DESCRIPTION
Fixes #4110, and a couple of other VST effect bugs.

Summary of my changes, since I neglected to put any with my commits (Lukas-W's are with his commits):
* __Fix X11 embedding on Qt4__: see https://github.com/LMMS/lmms/issues/4110#issuecomment-375494925.
* __Fix VST effect load crash on non-primary monitor__: LMMS would crash when on a non-primary monitor if the first embedded VST opened was an effect. Upon embedding a VST, the chain of parent windows needs to be made native, and if the main window is not on the primary monitor, this triggers a repaint/relayout before the `VstEffectControlDialog` is added to the `SubWindow`. `SubWindow` then causes a segfault trying to access properties of its `widget()`, which is still null. I've just added null checks where appropriate.
* __Fix toggling UI for non-embedded VST effects__: Fixes a bug from earlier on this branch, behaviour is the same as `stable-1.2`.
* __Fix RemoteVstPlugin not exiting when effect removed__: ~this was a regression on Windows only, caused by a8311a7. On Windows, effect control dialogs are kept around even when the view that opened them is deleted: https://github.com/LMMS/lmms/blob/e554a4c4b093ea4c319cceed98f4495484da37b0/src/gui/widgets/EffectView.cpp#L162-L176
As a result, the `QSharedPointer` in `VstEffectControlDialog` keeps the `VstPlugin` instance alive even when the effect has been removed. I've changed this to a plain `QPointer`, so it maintains the nullify-on-delete behaviour but lets the plugin exit properly.~ Now cbf8cbd8c0c66a79a1fd2965613ad5f4d38a8d99 replaces it.

**Edited** by @PhysSong: Original fix eb560a780f8bb02cc4bbc02ca893eb1b850b9b47 have been dropped and cbf8cbd8c0c66a79a1fd2965613ad5f4d38a8d99 have been added instead. Another new commit d6ae46eaddbd60027ecd8a550d630a7fb8702b59 fixes #1727.