### PR TITLE
Responsive "Effects chain" & "User controller" LEDs

### DIFF
--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -66,6 +66,7 @@ public slots:
 	void selectController();
 	void midiToggled();
 	void userToggled();
+	void userSelected();
 	void autoDetectToggled();
 	void enableAutoDetect( QAction * _a );
 

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -57,11 +57,6 @@ public:
 
 	void clear();
 
-	void setEnabled( bool _on )
-	{
-		m_enabledModel.setValue( _on );
-	}
-
 
 private:
 	typedef QVector<Effect *> EffectList;

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -125,6 +125,8 @@ void EffectChain::appendEffect( Effect * _effect )
 	m_effects.append( _effect );
 	Engine::mixer()->doneChangeInModel();
 
+	m_enabledModel.setValue( true );
+
 	emit dataChanged();
 }
 
@@ -144,6 +146,12 @@ void EffectChain::removeEffect( Effect * _effect )
 	m_effects.erase( found );
 
 	Engine::mixer()->doneChangeInModel();
+
+	if( m_effects.isEmpty() )
+	{
+		m_enabledModel.setValue( false );
+	}
+
 	emit dataChanged();
 }
 
@@ -250,7 +258,6 @@ void EffectChain::clear()
 
 	Engine::mixer()->requestChangeInModel();
 
-	m_enabledModel.setValue( false );
 	while( m_effects.count() )
 	{
 		Effect * e = m_effects[m_effects.count() - 1];
@@ -259,4 +266,6 @@ void EffectChain::clear()
 	}
 
 	Engine::mixer()->doneChangeInModel();
+
+	m_enabledModel.setValue( false );
 }

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -188,13 +188,16 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 
 	m_userController = new ComboBox( m_userGroupBox, "Controller" );
 	m_userController->setGeometry( 10, 24, 200, 22 );
-
 	for( int i = 0; i < Engine::getSong()->controllers().size(); ++i )
 	{
 		Controller * c = Engine::getSong()->controllers().at( i );
 		m_userController->model()->addItem( c->name() );
 	}
-	
+	connect( m_userController->model(), SIGNAL( dataUnchanged() ),
+			this, SLOT( userSelected() ) );
+	connect( m_userController->model(), SIGNAL( dataChanged() ),
+			this, SLOT( userSelected() ) );
+
 
 	// Mapping functions
 	m_mappingBox = new TabWidget( tr( "MAPPING FUNCTION" ), this );
@@ -383,6 +386,15 @@ void ControllerConnectionDialog::midiToggled()
 
 
 
+void ControllerConnectionDialog::userSelected()
+{
+	m_userGroupBox->model()->setValue( 1 );
+	userToggled();
+}
+
+
+
+
 void ControllerConnectionDialog::userToggled()
 {
 	int enabled = m_userGroupBox->model()->value();
@@ -390,8 +402,6 @@ void ControllerConnectionDialog::userToggled()
 	{
 		m_midiGroupBox->model()->setValue( 0 );
 	}
-
-	m_userController->setEnabled( enabled );
 }
 
 

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -385,15 +385,6 @@ void ControllerConnectionDialog::midiToggled()
 
 
 
-void ControllerConnectionDialog::userSelected()
-{
-	m_userGroupBox->model()->setValue( 1 );
-	userToggled();
-}
-
-
-
-
 void ControllerConnectionDialog::userToggled()
 {
 	int enabled = m_userGroupBox->model()->value();
@@ -401,6 +392,15 @@ void ControllerConnectionDialog::userToggled()
 	{
 		m_midiGroupBox->model()->setValue( 0 );
 	}
+}
+
+
+
+
+void ControllerConnectionDialog::userSelected()
+{
+	m_userGroupBox->model()->setValue( 1 );
+	userToggled();
 }
 
 

--- a/src/gui/widgets/EffectRackView.cpp
+++ b/src/gui/widgets/EffectRackView.cpp
@@ -138,6 +138,10 @@ void EffectRackView::deletePlugin( EffectView* view )
 	Effect * e = view->effect();
 	m_effectViews.erase( qFind( m_effectViews.begin(), m_effectViews.end(), view ) );
 	delete view;
+	if( m_effectViews.size() == 0 )
+	{
+		fxChain()->m_enabledModel.setValue( false );
+	}
 	fxChain()->removeEffect( e );
 	e->deleteLater();
 	update();

--- a/src/gui/widgets/EffectRackView.cpp
+++ b/src/gui/widgets/EffectRackView.cpp
@@ -138,10 +138,6 @@ void EffectRackView::deletePlugin( EffectView* view )
 	Effect * e = view->effect();
 	m_effectViews.erase( qFind( m_effectViews.begin(), m_effectViews.end(), view ) );
 	delete view;
-	if( m_effectViews.size() == 0 )
-	{
-		fxChain()->m_enabledModel.setValue( false );
-	}
 	fxChain()->removeEffect( e );
 	e->deleteLater();
 	update();
@@ -235,7 +231,6 @@ void EffectRackView::addEffect()
 
 	Effect * fx = esd.instantiateSelectedPlugin( fxChain() );
 
-	fxChain()->m_enabledModel.setValue( true );
 	fxChain()->appendEffect( fx );
 	update();
 


### PR DESCRIPTION
- Turn off the effects chain LED when its chain is empty.
- Turn on the user controller LED when a controller is selected.

Also, removed an unused function: `setEnabled()`

Closes #3620.