### PR TITLE
Use themed file dialogs everywhere

### DIFF
--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -38,6 +38,16 @@ public:
 						const QString &directory = QString(),
 						const QString &filter = QString() );
 
+	static QString getExistingDirectory(QWidget *parent,
+										const QString &caption,
+										const QString &directory,
+										QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+    static QString getOpenFileName(QWidget *parent = 0,
+									const QString &caption = QString(),
+									const QString &directory = QString(),
+									const QString &filter = QString(),
+									QString *selectedFilter = 0,
+									QFileDialog::Options options = 0);
 	void clearSelection();
 };
 

--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -78,6 +78,39 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 }
 
 
+QString FileDialog::getExistingDirectory(QWidget *parent,
+										const QString &caption,
+										const QString &directory,
+										QFileDialog::Options options)
+{
+	FileDialog dialog(parent, caption, directory, QString());
+	dialog.setFileMode(QFileDialog::Directory);
+	dialog.setOptions(dialog.options() | options);
+	if (dialog.exec() == QDialog::Accepted) {
+		return dialog.selectedFiles().value(0);
+	}
+	return QString();
+}
+
+QString FileDialog::getOpenFileName(QWidget *parent,
+									const QString &caption,
+									const QString &directory,
+									const QString &filter,
+									QString *selectedFilter,
+									QFileDialog::Options options)
+{
+	FileDialog dialog(parent, caption, directory, filter);
+	dialog.setOptions(dialog.options() | options);
+	if (selectedFilter && !selectedFilter->isEmpty())
+		dialog.selectNameFilter(*selectedFilter);
+	if (dialog.exec() == QDialog::Accepted) {
+		if (selectedFilter)
+			*selectedFilter = dialog.selectedNameFilter();
+		return dialog.selectedFiles().value(0);
+	}
+	return QString();
+}
+
 
 void FileDialog::clearSelection()
 {
@@ -85,6 +118,4 @@ void FileDialog::clearSelection()
 	Q_ASSERT( view );
 	view->clearSelection();
 }
-
-
 


### PR DESCRIPTION
Previously lmms used themed dialogs for project saving/opening, but not when changing settings (edit -> settings).

With this change, the settings editor also uses themed dialogs. I believe that means every file dialog in lmms now uses our own `FileDialog` themed dialog type.

------

Since everything's going through `FileDialog`, it's just one line of code to enable/disable theming should I someday manage to convince you all that we should use OS-native dialogs instead of custom-themed ones (because, say, the gtk file chooser includes previews for image types whereas custom dialogs don't, or because OS-native file choosers include user-bookmarked locations, whereas custom dialogs don't, ...).

But regardless of your views when it comes to themed vs native dialogs (hint: native is better), hopefully everyone agrees at the very least that making the application internally consistent is better than mixing themed _and_ native dialogs, which is what this PR accomplishes.