### PR TITLE
Re-enable upstream libgig formulae

### DIFF
--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-PACKAGES="cmake pkg-config libogg libvorbis lame libsndfile libsamplerate jack sdl libsoundio stk portaudio node fltk qt5"
+PACKAGES="cmake pkg-config libogg libvorbis lame libsndfile libsamplerate jack sdl libgig libsoundio stk portaudio node fltk qt5"
 
 if "${TRAVIS}"; then
    PACKAGES="$PACKAGES ccache"
@@ -23,8 +23,5 @@ brew install fftw --ignore-dependencies
 # Ruby formula must be a URL
 
 brew install --build-from-source "https://gist.githubusercontent.com/tresf/c9260c43270abd4ce66ff40359588435/raw/fluid-synth.rb"
-
-# Build libgig 4.1.0 from source to avoid 3.3.0 "ISO C++11 does not allow access declarations"
-brew install --build-from-source "https://raw.githubusercontent.com/tresf/homebrew-core/gig/Formula/libgig.rb"
 
 sudo npm install -g appdmg


### PR DESCRIPTION
Quoting @PhysSong from [Discord](https://lmms.io/chat):

> @tresf Homebrew updated libgig to 4.1.0 last year. I think we can switch back to the bottle instead of building.