### PR TITLE
Limit the automation-editor scaled-level tooltip to the grid

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -173,6 +173,7 @@ private:
 
 	// some constants...
 	static const int SCROLLBAR_SIZE = 12;
+	static const int LEFT_MARGIN = 63;
 	static const int TOP_MARGIN = 16;
 
 	static const int DEFAULT_Y_DELTA = 6;

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -173,7 +173,6 @@ private:
 
 	// some constants...
 	static const int SCROLLBAR_SIZE = 12;
-	static const int LEFT_MARGIN = 63;
 	static const int TOP_MARGIN = 16;
 
 	static const int DEFAULT_Y_DELTA = 6;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1084,7 +1084,6 @@ inline void AutomationEditor::drawCross( QPainter & p )
 				/ (float)( m_maxLevel - m_minLevel ) ) :
 		grid_bottom - ( level - m_bottomLevel ) * m_y_delta;
 
-	int right_margin = width() - SCROLLBAR_SIZE;
 	int bottom_margin = height() - SCROLLBAR_SIZE;
 
 	p.setPen( crossColor() );
@@ -1099,8 +1098,8 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
 
 	// Limit the scaled-level tooltip to the grid
-	if( mouse_pos.x() > LEFT_MARGIN &&
-		mouse_pos.x() < right_margin &&
+	if( mouse_pos.x() > VALUES_WIDTH - 1 && // left_margin
+		mouse_pos.x() < width() - SCROLLBAR_SIZE && // right_margin
 		mouse_pos.y() > TOP_MARGIN &&
 		mouse_pos.y() < bottom_margin )
 	{

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1099,7 +1099,7 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
 
 	// Limit the scaled-level tooltip to the grid
-	if(	mouse_pos.x() > LEFT_MARGIN &&
+	if( mouse_pos.x() > LEFT_MARGIN &&
 		mouse_pos.x() < right_margin &&
 		mouse_pos.y() > TOP_MARGIN &&
 		mouse_pos.y() < bottom_margin )

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1076,6 +1076,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 inline void AutomationEditor::drawCross( QPainter & p )
 {
 	QPoint mouse_pos = mapFromGlobal( QCursor::pos() );
+
 	int grid_bottom = height() - SCROLLBAR_SIZE - 1;
 	float level = getLevel( mouse_pos.y() );
 	float cross_y = m_y_auto ?
@@ -1087,8 +1088,16 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	int bottom_margin = height() - SCROLLBAR_SIZE;
 
 	p.setPen( crossColor() );
-	p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
-	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
+
+	// Limit the cross to the grid
+	if( mouse_pos.x() > VALUES_WIDTH - 1 &&
+		mouse_pos.x() < width() - SCROLLBAR_SIZE - 1 &&
+		mouse_pos.y() > TOP_MARGIN + 1 &&
+		mouse_pos.y() < grid_bottom )
+	{
+		p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
+		p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
+	}
 
 
 	QPoint tt_pos =  QCursor::pos();
@@ -1098,8 +1107,8 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
 
 	// Limit the scaled-level tooltip to the grid
-	if( mouse_pos.x() > VALUES_WIDTH - 1 && // left_margin
-		mouse_pos.x() < width() - SCROLLBAR_SIZE && // right_margin
+	if( mouse_pos.x() > VALUES_WIDTH - 1 &&
+		mouse_pos.x() < width() - SCROLLBAR_SIZE &&
 		mouse_pos.y() > TOP_MARGIN &&
 		mouse_pos.y() < bottom_margin )
 	{
@@ -1484,7 +1493,6 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 	if( validPattern() && GuiApplication::instance()->automationEditor()->hasFocus() )
 	{
-
 		drawCross( p );
 	}
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1076,23 +1076,36 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 inline void AutomationEditor::drawCross( QPainter & p )
 {
 	QPoint mouse_pos = mapFromGlobal( QCursor::pos() );
-	float level = getLevel( mouse_pos.y() );
 	int grid_bottom = height() - SCROLLBAR_SIZE - 1;
+	float level = getLevel( mouse_pos.y() );
 	float cross_y = m_y_auto ?
 		grid_bottom - ( ( grid_bottom - TOP_MARGIN )
 				* ( level - m_minLevel )
 				/ (float)( m_maxLevel - m_minLevel ) ) :
 		grid_bottom - ( level - m_bottomLevel ) * m_y_delta;
 
+	int right_margin = width() - SCROLLBAR_SIZE;
+	int bottom_margin = height() - SCROLLBAR_SIZE;
+
 	p.setPen( crossColor() );
 	p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
-	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(),
-						height() - SCROLLBAR_SIZE );
+	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
+
+
 	QPoint tt_pos =  QCursor::pos();
-	tt_pos.ry() -= 64;
-	tt_pos.rx() += 32;
+	tt_pos.ry() -= 51;
+	tt_pos.rx() += 26;
+
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
-	QToolTip::showText( tt_pos, QString::number( scaledLevel ), this );
+
+	// Limit the scaled-level tooltip to the grid
+	if(	mouse_pos.x() > LEFT_MARGIN &&
+		mouse_pos.x() < right_margin &&
+		mouse_pos.y() > TOP_MARGIN &&
+		mouse_pos.y() < bottom_margin )
+	{
+		QToolTip::showText( tt_pos, QString::number( scaledLevel ), this );
+	}
 }
 
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1076,7 +1076,6 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 inline void AutomationEditor::drawCross( QPainter & p )
 {
 	QPoint mouse_pos = mapFromGlobal( QCursor::pos() );
-
 	int grid_bottom = height() - SCROLLBAR_SIZE - 1;
 	float level = getLevel( mouse_pos.y() );
 	float cross_y = m_y_auto ?
@@ -1088,16 +1087,8 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	int bottom_margin = height() - SCROLLBAR_SIZE;
 
 	p.setPen( crossColor() );
-
-	// Limit the cross to the grid
-	if( mouse_pos.x() > VALUES_WIDTH - 1 &&
-		mouse_pos.x() < width() - SCROLLBAR_SIZE - 1 &&
-		mouse_pos.y() > TOP_MARGIN + 1 &&
-		mouse_pos.y() < grid_bottom )
-	{
-		p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
-		p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
-	}
+	p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
+	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
 
 
 	QPoint tt_pos =  QCursor::pos();
@@ -1107,8 +1098,8 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
 
 	// Limit the scaled-level tooltip to the grid
-	if( mouse_pos.x() > VALUES_WIDTH - 1 &&
-		mouse_pos.x() < width() - SCROLLBAR_SIZE &&
+	if( mouse_pos.x() > VALUES_WIDTH - 1 && // left_margin
+		mouse_pos.x() < width() - SCROLLBAR_SIZE && // right_margin
 		mouse_pos.y() > TOP_MARGIN &&
 		mouse_pos.y() < bottom_margin )
 	{
@@ -1493,6 +1484,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 	if( validPattern() && GuiApplication::instance()->automationEditor()->hasFocus() )
 	{
+
 		drawCross( p );
 	}
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1084,11 +1084,9 @@ inline void AutomationEditor::drawCross( QPainter & p )
 				/ (float)( m_maxLevel - m_minLevel ) ) :
 		grid_bottom - ( level - m_bottomLevel ) * m_y_delta;
 
-	int bottom_margin = height() - SCROLLBAR_SIZE;
-
 	p.setPen( crossColor() );
 	p.drawLine( VALUES_WIDTH, (int) cross_y, width(), (int) cross_y );
-	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), bottom_margin );
+	p.drawLine( mouse_pos.x(), TOP_MARGIN, mouse_pos.x(), height() - SCROLLBAR_SIZE );
 
 
 	QPoint tt_pos =  QCursor::pos();
@@ -1098,10 +1096,10 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	float scaledLevel = m_pattern->firstObject()->scaledValue( level );
 
 	// Limit the scaled-level tooltip to the grid
-	if( mouse_pos.x() > VALUES_WIDTH - 1 && // left_margin
-		mouse_pos.x() < width() - SCROLLBAR_SIZE && // right_margin
-		mouse_pos.y() > TOP_MARGIN &&
-		mouse_pos.y() < bottom_margin )
+	if( mouse_pos.x() >= 0 &&
+		mouse_pos.x() <= width() - SCROLLBAR_SIZE &&
+		mouse_pos.y() >= 0 &&
+		mouse_pos.y() <= height() - SCROLLBAR_SIZE )
 	{
 		QToolTip::showText( tt_pos, QString::number( scaledLevel ), this );
 	}


### PR DESCRIPTION
Fixes #3746.