### PR TITLE
Fix detuning crash after deleting the note being edited

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -31,6 +31,7 @@
 #include <QLayout>
 #include <QMdiArea>
 #include <QPainter>
+#include <QPointer>
 #include <QScrollBar>
 #include <QStyleOption>
 #include <QSignalMapper>
@@ -1334,8 +1335,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 	if( m_editMode == ModeEditDetuning && noteUnderMouse() )
 	{
-		static AutomationPattern* detuningPattern = nullptr;
-		if (detuningPattern != nullptr)
+		static QPointer<AutomationPattern> detuningPattern = nullptr;
+		if (detuningPattern.data() != nullptr)
 		{
 			detuningPattern->disconnect(this);
 		}
@@ -1345,7 +1346,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			n->createDetuning();
 		}
 		detuningPattern = n->detuning()->automationPattern();
-		connect(detuningPattern, SIGNAL(dataChanged()), this, SLOT(update()));
+		connect(detuningPattern.data(), SIGNAL(dataChanged()), this, SLOT(update()));
 		gui->automationEditor()->open(detuningPattern);
 		return;
 	}


### PR DESCRIPTION
Fixes #4168 by using `QPointer` instead of plain pointer.
The nullify-on-delete behavior of `QPointer` will prevent calling `disconnect` for deleted patterns, so fixes the crash.