### PR TITLE
Add dummy CircleCI config file for stable-1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+# Dummy CircleCI Config File
+version: 2
+jobs:
+  build:
+    machine: true
+    branches:
+      ignore: stable-1.2
+    steps:
+      - run:
+          name: Dummy
+          command: echo "Dummy command to prevent error"


### PR DESCRIPTION
This will prevent CircleCI build failure from `stable-1.2`. Unfortunately, this can't prevent failure from some pull requests because [currently CircleCI doesn't pull merged code](https://discuss.circleci.com/t/checkout-merged-code-for-pull-requests/15398).