### PR TITLE
Do not rename track labels when they are double-clicked

### DIFF
--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -52,7 +52,6 @@ protected:
 	virtual void dragEnterEvent( QDragEnterEvent * _dee );
 	virtual void dropEvent( QDropEvent * _de );
 	virtual void mousePressEvent( QMouseEvent * _me );
-	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 	virtual void mouseReleaseEvent( QMouseEvent * _me );
 	virtual void paintEvent( QPaintEvent * _pe );
 	virtual void resizeEvent( QResizeEvent * _re );

--- a/src/gui/widgets/TrackLabelButton.cpp
+++ b/src/gui/widgets/TrackLabelButton.cpp
@@ -167,14 +167,6 @@ void TrackLabelButton::mousePressEvent( QMouseEvent * _me )
 
 
 
-void TrackLabelButton::mouseDoubleClickEvent( QMouseEvent * _me )
-{
-	rename();
-}
-
-
-
-
 void TrackLabelButton::mouseReleaseEvent( QMouseEvent *_me )
 {
 	if( m_buttonRect.contains( _me->globalPos(), true ) && m_renameLineEdit->isHidden() )


### PR DESCRIPTION
When a track-label-button is clicked to open/close an instrument/sample window, it can be easily double-clicked by mistake, which will show its label line-edit, and that is unwanted. This change prevents that.

This has been suggested by a user on our forum: https://lmms.io/forum/viewtopic.php?f=15&t=27239

Closes #4985.