### PR TITLE
Default some empty destructors

### DIFF
--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -36,7 +36,7 @@ class EXPORT AutomatableModelView : public ModelView
 {
 public:
 	AutomatableModelView( Model* model, QWidget* _this );
-	virtual ~AutomatableModelView();
+	virtual ~AutomatableModelView() = default;
 
 	// some basic functions for convenience
 	AutomatableModel* modelUntyped()

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -54,7 +54,7 @@ public:
 
 	AutomationPattern( AutomationTrack * _auto_track );
 	AutomationPattern( const AutomationPattern & _pat_to_copy );
-	virtual ~AutomationPattern();
+	virtual ~AutomationPattern() = default;
 
 	bool addObject( AutomatableModel * _obj, bool _search_dup = true );
 

--- a/include/AutomationTrack.h
+++ b/include/AutomationTrack.h
@@ -35,7 +35,7 @@ class AutomationTrack : public Track
 	Q_OBJECT
 public:
 	AutomationTrack( TrackContainer* tc, bool _hidden = false );
-	virtual ~AutomationTrack();
+	virtual ~AutomationTrack() = default;
 
 	virtual bool play( const MidiTime & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
@@ -63,7 +63,7 @@ class AutomationTrackView : public TrackView
 {
 public:
 	AutomationTrackView( AutomationTrack* at, TrackContainerView* tcv );
-	virtual ~AutomationTrackView();
+	virtual ~AutomationTrackView() = default;
 
 	virtual void dragEnterEvent( QDragEnterEvent * _dee );
 	virtual void dropEvent( QDropEvent * _de );

--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -41,7 +41,7 @@ class BBTCO : public TrackContentObject
 {
 public:
 	BBTCO( Track * _track );
-	virtual ~BBTCO();
+	virtual ~BBTCO() = default;
 
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
 	virtual void loadSettings( const QDomElement & _this );
@@ -90,7 +90,7 @@ class BBTCOView : public TrackContentObjectView
 	Q_OBJECT
 public:
 	BBTCOView( TrackContentObject * _tco, TrackView * _tv );
-	virtual ~BBTCOView();
+	virtual ~BBTCOView() = default;
 
 	QColor color() const
 	{

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -68,7 +68,7 @@ public:
 
 	Fader( FloatModel * _model, const QString & _name, QWidget * _parent );
 	Fader( FloatModel * _model, const QString & _name, QWidget * _parent, QPixmap * back, QPixmap * leds, QPixmap * knob );
-	virtual ~Fader();
+	virtual ~Fader() = default;
 
 	void init(FloatModel * model, QString const & name);
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -51,7 +51,7 @@ public:
 	FileBrowser( const QString & directories, const QString & filter,
 			const QString & title, const QPixmap & pm,
 			QWidget * parent, bool dirs_as_items = false, bool recurse = false );
-	virtual ~FileBrowser();
+	virtual ~FileBrowser() = default;
 
 private slots:
 	void reloadTree( void );
@@ -85,7 +85,7 @@ class FileBrowserTreeWidget : public QTreeWidget
 	Q_OBJECT
 public:
 	FileBrowserTreeWidget( QWidget * parent );
-	virtual ~FileBrowserTreeWidget();
+	virtual ~FileBrowserTreeWidget() = default;
 
 
 protected:

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -55,7 +55,7 @@ public:
 		int _width = 132,
 		int _height = 104
 	);
-	virtual ~Graph();
+	virtual ~Graph() = default;
 
 	void setForeground( const QPixmap & _pixmap );
 
@@ -122,7 +122,7 @@ public:
 			bool _default_constructed = false,
 			float _step = 0.0 );
 
-	virtual ~graphModel();
+	virtual ~graphModel() = default;
 
 	// TODO: saveSettings, loadSettings?
 

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -57,7 +57,7 @@ public:
 
 	Instrument( InstrumentTrack * _instrument_track,
 					const Descriptor * _descriptor );
-	virtual ~Instrument();
+	virtual ~Instrument() = default;
 
 	// --------------------------------------------------------------------
 	// functions that can/should be re-implemented:

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -38,7 +38,7 @@ public:
 
 	LcdSpinBox( int numDigits, const QString& style, QWidget* parent, const QString& name = QString::null );
 
-	virtual ~LcdSpinBox();
+	virtual ~LcdSpinBox() = default;
 
 	virtual void modelChanged()
 	{

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -163,7 +163,7 @@ class PatternView : public TrackContentObjectView
 
 public:
 	PatternView( Pattern* pattern, TrackView* parent );
-	virtual ~PatternView();
+	virtual ~PatternView() = default;
 
 	Q_PROPERTY(QColor noteFillColor READ getNoteFillColor WRITE setNoteFillColor)
 	Q_PROPERTY(QColor noteBorderColor READ getNoteBorderColor WRITE setNoteBorderColor)

--- a/include/Piano.h
+++ b/include/Piano.h
@@ -31,7 +31,7 @@
 class InstrumentTrack;
 class MidiEventProcessor;
 
-class Piano : public Model
+class Piano final : public Model
 {
 public:
 	enum KeyTypes
@@ -41,7 +41,6 @@ public:
 	} ;
 
 	Piano( InstrumentTrack* track );
-	virtual ~Piano();
 
 	void setKeyState( int key, bool state );
 

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -38,7 +38,7 @@ class PianoView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	PianoView( QWidget * _parent );
-	virtual ~PianoView();
+	virtual ~PianoView() = default;
 
 	static int getKeyFromKeyEvent( QKeyEvent * _ke );
 

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -98,8 +98,7 @@ class SampleTCOView : public TrackContentObjectView
 
 public:
 	SampleTCOView( SampleTCO * _tco, TrackView * _tv );
-	virtual ~SampleTCOView();
-
+	virtual ~SampleTCOView() = default;
 
 public slots:
 	void updateSample();

--- a/include/TabBar.h
+++ b/include/TabBar.h
@@ -42,7 +42,7 @@ class EXPORT TabBar : public QWidget
 public:
 	TabBar( QWidget * _parent,
 			QBoxLayout::Direction _dir = QBoxLayout::LeftToRight );
-	virtual ~TabBar();
+	virtual ~TabBar() = default;
 
 	TabButton * addTab( QWidget * _w, const QString & _text,
 					int _id, bool _add_stretch = false,

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -37,7 +37,7 @@ class TabWidget : public QWidget
 	Q_OBJECT
 public:
 	TabWidget( const QString & _caption, QWidget * _parent, bool usePixmap = false );
-	virtual ~TabWidget();
+	virtual ~TabWidget() = default;
 
 	void addTab( QWidget * w, const QString & name, const char *pixmap = NULL, int idx = -1 );
 

--- a/include/TimeDisplayWidget.h
+++ b/include/TimeDisplayWidget.h
@@ -37,7 +37,7 @@ class TimeDisplayWidget : public QWidget
 	Q_OBJECT
 public:
 	TimeDisplayWidget();
-	virtual ~TimeDisplayWidget();
+	virtual ~TimeDisplayWidget() = default;
 
 
 protected:

--- a/include/ToolButton.h
+++ b/include/ToolButton.h
@@ -42,7 +42,7 @@ public:
 		QToolButton(_parent)
 	{ }
 
-	virtual ~ToolButton();
+	virtual ~ToolButton() = default;
 
 } ;
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -98,16 +98,6 @@ AutomationPattern::AutomationPattern( const AutomationPattern & _pat_to_copy ) :
 	}
 }
 
-
-
-
-AutomationPattern::~AutomationPattern()
-{
-}
-
-
-
-
 bool AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 {
 	if( _search_dup && m_objects.contains(_obj) )

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -34,16 +34,6 @@ Instrument::Instrument( InstrumentTrack * _instrument_track,
 {
 }
 
-
-
-
-Instrument::~Instrument()
-{
-}
-
-
-
-
 void Instrument::play( sampleFrame * )
 {
 }

--- a/src/core/Piano.cpp
+++ b/src/core/Piano.cpp
@@ -70,19 +70,6 @@ Piano::Piano( InstrumentTrack* track ) :
 
 }
 
-
-
-
-/*! \brief Destroy this new keyboard display
- *
- */
-Piano::~Piano()
-{
-}
-
-
-
-
 /*! \brief Turn a key on or off
  *
  *  \param key the key number to change

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -50,16 +50,6 @@ AutomatableModelView::AutomatableModelView( ::Model* model, QWidget* _this ) :
 	widget()->setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 }
 
-
-
-
-AutomatableModelView::~AutomatableModelView()
-{
-}
-
-
-
-
 void AutomatableModelView::addDefaultActions( QMenu* menu )
 {
 	AutomatableModel* model = modelUntyped();

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -112,16 +112,6 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	show();
 }
 
-
-
-
-FileBrowser::~FileBrowser()
-{
-}
-
-
-
-
 bool FileBrowser::filterItems( const QString & filter, QTreeWidgetItem * item )
 {
 	// call with item=NULL to filter the entire tree
@@ -337,16 +327,6 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 				SLOT( updateDirectory( QTreeWidgetItem * ) ) );
 
 }
-
-
-
-
-FileBrowserTreeWidget::~FileBrowserTreeWidget()
-{
-}
-
-
-
 
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -130,19 +130,6 @@ PianoView::PianoView( QWidget * _parent ) :
 
 }
 
-
-
-
-/*! \brief Destroy this piano display view
- *
- */
-PianoView::~PianoView()
-{
-}
-
-
-
-
 /*! \brief Map a keyboard key being pressed to a note in our keyboard view
  *
  *  \param _k The keyboard scan code of the key being pressed.

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -133,12 +133,6 @@ Fader::Fader( FloatModel * model, const QString & name, QWidget * parent, QPixma
 	init(model, name);
 }
 
-
-Fader::~Fader()
-{
-}
-
-
 void Fader::init(FloatModel * model, QString const & name)
 {
 	setWindowTitle( name );

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -56,13 +56,6 @@ Graph::Graph( QWidget * _parent, graphStyle _style, int _width,
 			this, SLOT( updateGraph( ) ) );
 }
 
-
-Graph::~Graph()
-{
-}
-
-
-
 void Graph::setForeground( const QPixmap &_pixmap )
 {
 	m_foreground = _pixmap;
@@ -469,14 +462,6 @@ graphModel::graphModel( float _min, float _max, int _length,
 	m_step( _step )
 {
 }
-
-
-
-graphModel::~graphModel()
-{
-}
-
-
 
 void graphModel::setRange( float _min, float _max )
 {

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -58,14 +58,6 @@ LcdSpinBox::LcdSpinBox( int numDigits, const QString& style, QWidget* parent, co
 {
 }
 
-
-
-LcdSpinBox::~LcdSpinBox()
-{
-}
-
-
-
 void LcdSpinBox::update()
 {
 	setValue( model()->value() + m_displayOffset );

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -41,9 +41,8 @@ public:
 		m_orientation( _orientation )
 	{
 	}
-	virtual ~SideBarButton()
-	{
-	}
+
+	virtual ~SideBarButton() = default;
 
 	Qt::Orientation orientation() const
 	{

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -41,16 +41,6 @@ TabBar::TabBar( QWidget * _parent, QBoxLayout::Direction _dir ) :
 	setLayout( m_layout );
 }
 
-
-
-
-TabBar::~TabBar()
-{
-}
-
-
-
-
 TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 				bool _add_stretch, bool _text_is_tooltip )
 {

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -61,12 +61,6 @@ TabWidget::TabWidget( const QString & caption, QWidget * parent, bool usePixmap 
 
 }
 
-
-TabWidget::~TabWidget()
-{
-}
-
-
 void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, int idx )
 {
 	setFont( pointSize<8>( font() ) );

--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -58,17 +58,6 @@ TimeDisplayWidget::TimeDisplayWidget() :
 					this, SLOT( updateTime() ) );
 }
 
-
-
-
-TimeDisplayWidget::~TimeDisplayWidget()
-{
-}
-
-
-
-
-
 void TimeDisplayWidget::setDisplayMode( DisplayMode displayMode )
 {
 	m_displayMode = displayMode;

--- a/src/gui/widgets/ToolButton.cpp
+++ b/src/gui/widgets/ToolButton.cpp
@@ -41,10 +41,3 @@ ToolButton::ToolButton( const QPixmap & _pixmap, const QString & _tooltip,
 	ToolTip::add( this, _tooltip );
 	setIcon( _pixmap );
 }
-
-
-
-
-ToolButton::~ToolButton()
-{
-}

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -40,16 +40,6 @@ AutomationTrack::AutomationTrack( TrackContainer* tc, bool _hidden ) :
 	setName( tr( "Automation track" ) );
 }
 
-
-
-
-AutomationTrack::~AutomationTrack()
-{
-}
-
-
-
-
 bool AutomationTrack::play( const MidiTime & time_start, const fpp_t _frames,
 							const f_cnt_t _frame_base, int _tco_num )
 {
@@ -107,16 +97,6 @@ AutomationTrackView::AutomationTrackView( AutomationTrack * _at, TrackContainerV
 	tlb->show();
 	setModel( _at );
 }
-
-
-
-
-AutomationTrackView::~AutomationTrackView()
-{
-}
-
-
-
 
 void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
 {

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -61,16 +61,6 @@ BBTCO::BBTCO( Track * _track ) :
 	setAutoResize( false );
 }
 
-
-
-
-BBTCO::~BBTCO()
-{
-}
-
-
-
-
 void BBTCO::saveSettings( QDomDocument & doc, QDomElement & element )
 {
 	element.setAttribute( "name", name() );
@@ -167,16 +157,6 @@ BBTCOView::BBTCOView( TrackContentObject * _tco, TrackView * _tv ) :
 
 	setStyle( QApplication::style() );
 }
-
-
-
-
-BBTCOView::~BBTCOView()
-{
-}
-
-
-
 
 void BBTCOView::constructContextMenu( QMenu * _cm )
 {

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -616,19 +616,6 @@ PatternView::PatternView( Pattern* pattern, TrackView* parent ) :
 	setStyle( QApplication::style() );
 }
 
-
-
-
-
-
-PatternView::~PatternView()
-{
-}
-
-
-
-
-
 void PatternView::update()
 {
 	ToolTip::add(this, m_pat->name());

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -302,16 +302,6 @@ SampleTCOView::SampleTCOView( SampleTCO * _tco, TrackView * _tv ) :
 	setStyle( QApplication::style() );
 }
 
-
-
-
-SampleTCOView::~SampleTCOView()
-{
-}
-
-
-
-
 void SampleTCOView::updateSample()
 {
 	update();


### PR DESCRIPTION
Moving empty destructors out of the .cpp files and into headers
allows them to be devirtualized in certain cases.
(When the compiler can't "see" a function in a header, it must largely
assume it's some black box that the linker will resolve.)

While we're at it, use C++11's `= default` to define empty virtual
desturctors for us.

For some classes (e.g., Piano), nothing is derived from it, so we can
mark the class as final and remove any explicit virtual dtor.

There are many other places where this can be done, but this is a large
enough patch as-is.