### PR TITLE
Allow renaming of FX mixer channels with the F2 and enter keys.

### DIFF
--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -79,6 +79,8 @@ public:
 
 	static const int FxLineHeight;
 
+	void renameChannel();
+
 private:
 	void drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis );
 	QString elideName( const QString & name );
@@ -98,7 +100,6 @@ private:
 	QGraphicsView * m_view;
 
 private slots:
-	void renameChannel();
 	void renameFinished();
 	void removeChannel();
 	void removeUnusedChannels();

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -81,6 +81,8 @@ public:
 
 	void renameChannel();
 
+	bool eventFilter (QObject *dist, QEvent *event);
+
 private:
 	void drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis );
 	QString elideName( const QString & name );

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -100,6 +100,9 @@ public:
 	void moveChannelLeft(int index, int focusIndex);
 	void moveChannelRight(int index);
 
+	// rename the channel
+	void renameChannel(int index);
+
 	// make sure the display syncs up with the fx mixer.
 	// useful for loading projects
 	void refreshDisplay();

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -100,7 +100,6 @@ public:
 	void moveChannelLeft(int index, int focusIndex);
 	void moveChannelRight(int index);
 
-	// rename the channel
 	void renameChannel(int index);
 
 	// make sure the display syncs up with the fx mixer.

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -535,11 +535,6 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 			break;
 		case Qt::Key_Enter:
 		case Qt::Key_Return:
-		{
-			/*bool accepted = e->isAccepted();
-			if ( e->isAccepted() )
-				break;*/
-		}
 		case Qt::Key_F2:
 			renameChannel( m_currentFxLine->channelIndex() );
 			break;

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -491,6 +491,12 @@ void FxMixerView::moveChannelRight(int index)
 }
 
 
+void FxMixerView::renameChannel(int index)
+{
+	m_fxChannelViews[index]->m_fxLine->renameChannel();
+}
+
+
 
 void FxMixerView::keyPressEvent(QKeyEvent * e)
 {
@@ -527,6 +533,10 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 				addNewChannel();
 			}
 			break;
+		case Qt::Key_F2:
+			renameChannel( m_currentFxLine->channelIndex() );
+		case Qt::Key_Enter:
+			renameChannel( m_currentFxLine->channelIndex() );
 	}
 }
 

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -533,9 +533,14 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 				addNewChannel();
 			}
 			break;
-		case Qt::Key_F2:
 		case Qt::Key_Enter:
 		case Qt::Key_Return:
+		{
+			/*bool accepted = e->isAccepted();
+			if ( e->isAccepted() )
+				break;*/
+		}
+		case Qt::Key_F2:
 			renameChannel( m_currentFxLine->channelIndex() );
 			break;
 	}

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -534,9 +534,10 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 			}
 			break;
 		case Qt::Key_F2:
-			renameChannel( m_currentFxLine->channelIndex() );
 		case Qt::Key_Enter:
+		case Qt::Key_Return:
 			renameChannel( m_currentFxLine->channelIndex() );
+			break;
 	}
 }
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -34,6 +34,24 @@
 #include "GuiApplication.h"
 #include "Song.h"
 
+bool FxLine::eventFilter( QObject *dist, QEvent *event )
+{
+	// If we are in a rename, capture the enter/return events and handle them
+	if ( event->type() == QEvent::KeyPress )
+	{
+		QKeyEvent * keyEvent = static_cast<QKeyEvent*>(event);
+		if( keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return )
+		{
+			if( m_inRename )
+			{
+				renameFinished();
+				event->accept(); // Stop the event from propagating
+				return true;
+			}
+		}
+	}
+	return false;
+}
 
 const int FxLine::FxLineHeight = 287;
 QPixmap * FxLine::s_sendBgArrow = NULL;
@@ -100,6 +118,7 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex ) :
 	m_renameLineEdit->setFixedWidth( 65 );
 	m_renameLineEdit->setFont( pointSizeF( font(), 7.5f ) );
 	m_renameLineEdit->setReadOnly( true );
+	m_renameLineEdit->installEventFilter( this );
 
 	QGraphicsScene * scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, 33, FxLineHeight );


### PR DESCRIPTION
Will resolve #3157. Currently the enter key isn't being hit, and I have no idea why.


```c++
case Qt::Key_F2:
	renameChannel( m_currentFxLine->channelIndex() );
case Qt::Key_Enter:
	renameChannel( m_currentFxLine->channelIndex() );
```

I don't like the code duplication here, but I don't believe there's a way to capture multiple cases in one case statement. It could be reasonable to change to an if/else block just to avoid that.