### PR TITLE
FPTruncateMode: Removed unused variables on non-386

### DIFF
--- a/plugins/LadspaEffect/CMakeLists.txt
+++ b/plugins/LadspaEffect/CMakeLists.txt
@@ -4,13 +4,7 @@ BUILD_PLUGIN(ladspaeffect LadspaEffect.cpp LadspaControls.cpp LadspaControlDialo
 
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ladspa")
 
-# Enable C++11 for all except mingw builds
-# TODO: Validate against modern mingw compiler
-IF(NOT MINGW_PREFIX)
-	SET(CMAKE_CXX_STANDARD 11)
-ELSE()
-	SET(CMAKE_CXX_STANDARD 98)
-ENDIF()
+SET(CMAKE_CXX_STANDARD 11)
 
 IF(WANT_CAPS)
 ADD_SUBDIRECTORY(caps)

--- a/plugins/LadspaEffect/caps/dsp/FPTruncateMode.h
+++ b/plugins/LadspaEffect/caps/dsp/FPTruncateMode.h
@@ -24,11 +24,9 @@
 	#define fistp(f,i) \
 		__asm__ ("fistpl %0" : "=m" (i) : "t" (f) : "st")
 #else /* ! __i386__ */
-	#define fstcw(i)
-	#define fldcw(i)
+	#include <cstdint>
 
-	#define fistp(f,i) \
-			i = (int) f
+	inline void fistp(float f, int32_t& i) { i = static_cast<int32_t>(f); }
 #endif
 
 namespace DSP {
@@ -36,12 +34,13 @@ namespace DSP {
 class FPTruncateMode
 {
 	public:
-		int cw0, cw1; /* fp control word */
+#ifdef __i386__
+		int cw0; /* fp control word */
 
 		FPTruncateMode()
 			{
 				fstcw (cw0);
-				cw1 = cw0 | 0xC00;
+				const int cw1 = cw0 | 0xC00;
 				fldcw (cw1);
 			}
 
@@ -49,6 +48,11 @@ class FPTruncateMode
 			{
 				fldcw (cw0);
 			}
+#else
+	// Avoid warnings about unused variables
+	FPTruncateMode() { (void)0; }
+	~FPTruncateMode() { (void)0; }
+#endif
 };
 
 } /* namespace DSP */


### PR DESCRIPTION
While we're at it, make fistp an inline function. Type safety is nice.

There are several other warnings GCC 8 generates, but most are in `zynaddsubfx`. What's the best procedure to follow there? PRs against the LMMS copy? Against upstream?