### PR TITLE
Ensure flanger LFO starts at the same position on render

### DIFF
--- a/plugins/Flanger/FlangerControls.cpp
+++ b/plugins/Flanger/FlangerControls.cpp
@@ -43,6 +43,7 @@ FlangerControls::FlangerControls( FlangerEffect *effect ) :
 
 {
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( changedSampleRate() ) );
+	connect( Engine::getSong(), SIGNAL( playbackStateChanged() ), this, SLOT( changedPlaybackState() ) );
 }
 
 
@@ -78,6 +79,13 @@ void FlangerControls::saveSettings( QDomDocument &doc, QDomElement &parent )
 void FlangerControls::changedSampleRate()
 {
 	m_effect->changeSampleRate();
+}
+
+
+
+void FlangerControls::changedPlaybackState()
+{
+	m_effect->restartLFO();
 }
 
 

--- a/plugins/Flanger/FlangerControls.h
+++ b/plugins/Flanger/FlangerControls.h
@@ -57,6 +57,7 @@ public:
 
 private slots:
 	void changedSampleRate();
+	void changedPlaybackState();
 
 private:
 	FlangerEffect* m_effect;

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -25,7 +25,6 @@
 #include "FlangerEffect.h"
 #include "Engine.h"
 #include "embed.h"
-#include "Song.h"
 
 extern "C"
 {

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -25,6 +25,7 @@
 #include "FlangerEffect.h"
 #include "Engine.h"
 #include "embed.h"
+#include "Song.h"
 
 extern "C"
 {
@@ -112,7 +113,7 @@ bool FlangerEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 		if(invertFeedback)
 		{
 			m_lDelay->tick( &buf[f][1] );
-			m_rDelay->tick(&buf[f][0] );
+			m_rDelay->tick( &buf[f][0] );
 		} else
 		{
 			m_lDelay->tick( &buf[f][0] );
@@ -135,6 +136,13 @@ void FlangerEffect::changeSampleRate()
 	m_lfo->setSampleRate( Engine::mixer()->processingSampleRate() );
 	m_lDelay->setSampleRate( Engine::mixer()->processingSampleRate() );
 	m_rDelay->setSampleRate( Engine::mixer()->processingSampleRate() );
+}
+
+
+
+void FlangerEffect::restartLFO()
+{
+	m_lfo->restart();
 }
 
 

--- a/plugins/Flanger/FlangerEffect.h
+++ b/plugins/Flanger/FlangerEffect.h
@@ -44,6 +44,7 @@ public:
 		return &m_flangerControls;
 	}
 	void changeSampleRate();
+	void restartLFO();
 
 private:
 	FlangerControls m_flangerControls;

--- a/plugins/Flanger/QuadratureLfo.h
+++ b/plugins/Flanger/QuadratureLfo.h
@@ -54,7 +54,7 @@ public:
 
 	inline void restart()
 	{
-		m_phase = 0; // Change to allow a phase offset?
+		m_phase = 0;
 	}
 
 

--- a/plugins/Flanger/QuadratureLfo.h
+++ b/plugins/Flanger/QuadratureLfo.h
@@ -52,6 +52,12 @@ public:
 
 
 
+	inline void restart()
+	{
+		m_phase = 0; // Change to allow a phase offset?
+	}
+
+
 
 	inline void setSampleRate ( int samplerate )
 	{


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/3689

Here are two GUI renders:

![image](https://user-images.githubusercontent.com/6700184/40093898-2c3a31f2-5892-11e8-8b1b-d82eb374ddb6.png)

The two renders weren't identical, and that doesn't sit well with me. Regardless, the LFO works exactly the same on both renders.