### PR TITLE
Remove FluidSynth requirement for background pic

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -292,9 +292,7 @@ void ConfigManager::setDefaultSoundfont( const QString & _sf )
 
 void ConfigManager::setBackgroundArtwork( const QString & _ba )
 {
-#ifdef LMMS_HAVE_FLUIDSYNTH
 	m_backgroundArtwork = _ba;
-#endif
 }
 
 void ConfigManager::setGIGDir(const QString &gd)

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -1525,9 +1525,7 @@ void SetupDialog::setDefaultSoundfont( const QString & _sf )
 
 void SetupDialog::setBackgroundArtwork( const QString & _ba )
 {
-#ifdef LMMS_HAVE_FLUIDSYNTH
 	m_backgroundArtwork = _ba;
-#endif
 }
 
 


### PR DESCRIPTION
Because it is irrelevant.

As @PhysSong mentioned on Discord, the requirement was introduced in https://github.com/LMMS/lmms/commit/ae03f9f3b16aa8fe799caf8f38df5282583633b2.