### PR TITLE
RemoteVST: process all remaining messages after the process has quit

### DIFF
--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -54,7 +54,7 @@ ProcessWatcher::ProcessWatcher( RemotePlugin * _p ) :
 
 void ProcessWatcher::run()
 {
-	while( !m_quit && m_plugin->isRunning() )
+	while( !m_quit && (m_plugin->messagesLeft() || m_plugin->isRunning()) )
 	{
 		msleep( 200 );
 	}


### PR DESCRIPTION
If the process exits, keep processing the remaining messages. Some might be debug messages or a msg that the vst loaded was 32 bits.