### PR TITLE
Wacom Tablet support

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -28,6 +28,7 @@
 
 #include <QWidget>
 #include <QtCore/QPoint>
+#include <QTabletEvent>
 
 #include "AutomatableModelView.h"
 #include "templates.h"
@@ -134,6 +135,10 @@ protected:
 	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 	virtual void paintEvent( QPaintEvent * _me );
 	virtual void wheelEvent( QWheelEvent * _me );
+	virtual void tabletEvent( QTabletEvent * _te );
+	virtual void tabletPressEvent( QTabletEvent * _te );
+	virtual void tabletReleaseEvent( QTabletEvent * event );
+	virtual void tabletMoveEvent( QTabletEvent * _te );
 
 	virtual float getValue( const QPoint & _p );
 
@@ -178,6 +183,9 @@ private:
 	QPoint m_origMousePos;
 	float m_leftOver;
 	bool m_buttonPressed;
+
+	QPointF m_prevTabletPos;
+	bool m_tabletPressed;
 
 	float m_totalAngle;
 	int m_angle;

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -61,6 +61,7 @@ TextFloat * Knob::s_textFloat = NULL;
 	m_volumeKnob( false ), \
 	m_volumeRatio( 100.0, 0.0, 1000000.0 ), \
 	m_buttonPressed( false ), \
+	m_tabletPressed( false ), \
 	m_angle( -10 ), \
 	m_lineWidth( 0 ), \
 	m_textColor( 255, 255, 255 )
@@ -805,13 +806,15 @@ void Knob::tabletReleaseEvent( QTabletEvent * event )
 		event->ignore();
 	}
 
-	m_tabletPressed = false;
+	if (m_tabletPressed) {
+		m_tabletPressed = false;
 
-	emit sliderReleased();
+		emit sliderReleased();
 
-	QApplication::restoreOverrideCursor();
+		QApplication::restoreOverrideCursor();
 
-	s_textFloat->hide();
+		s_textFloat->hide();
+	}
 }
 
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -740,8 +740,6 @@ void Knob::tabletPressEvent( QTabletEvent * _te )
 			thisModel->saveJournallingState( false );
 		}
 
-		const QPoint & p = _te->pos();
-		m_origMousePos = p;
 		m_prevTabletPos = _te->posF();
 		m_mouseOffset = QPoint(0, 0);
 		m_leftOver = 0.0f;
@@ -754,7 +752,9 @@ void Knob::tabletPressEvent( QTabletEvent * _te )
 				QPoint( width() + 2, 0 ) );
 		s_textFloat->show();
 		m_tabletPressed = true;
-	} else {
+	}
+	else
+	{
 		_te->ignore();
 	}
 
@@ -806,7 +806,6 @@ void Knob::tabletReleaseEvent( QTabletEvent * event )
 	}
 
 	m_tabletPressed = false;
-	QCursor::setPos( mapToGlobal( m_origMousePos ) );
 
 	emit sliderReleased();
 


### PR DESCRIPTION
Hi,

I have just started learning LMMS and found it quite difficult to control the Knobs with my Wacom pen tablet. I use my tablet to alleviate RSI strain of using the mouse, and have gotten quite used to it.

Unfortunately, the current implementation of the Knob is incompatible with a tablet set to Absolute mode (pixels on tablet are mapped roughly 1:1 to pixels on screen). Since in Knob::mouseMoveEvent

`QCursor::setPos( mapToGlobal( m_origMousePos ) );`

the cursor position gets reset, which then triggers a new QMouseEvent because now the cursor position is far away from the current tablet position (which is absolute). First I tried to hack the existing code, but my effort has proven fruitless, due to the nature of the Knob mouse handling implementation (though, I couldn't figure out a better way to do it either)

So I have implemented the TabletEvent interface. Any events that aren't handled by the new code get 
`event->ignore()`ed and then Qt spawns a regular QMouseEvent which then propagates as usual.

So far, Knob is the only GUI element which I found that behaved strangely with my tablet, I will add support to any other elements if I find them.