### PR TITLE
Fix journaling system bugs

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -76,7 +76,7 @@ public:
 		reallocID( _id, NULL );
 	}
 
-	static jo_id_t idToSave( jo_id_t id );
+	void changeID(const jo_id_t oldID, const jo_id_t newID);
 
 	void clearJournal();
 	void stopAllJournalling();

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -29,7 +29,6 @@
 #include "AutomationPattern.h"
 #include "ControllerConnection.h"
 #include "Mixer.h"
-#include "ProjectJournal.h"
 
 float AutomatableModel::s_copiedValue = 0;
 long AutomatableModel::s_periodCounter = 0;
@@ -99,7 +98,7 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 		// scale type also needs an extra value
 		// => it must be appended as a node
 		QDomElement me = doc.createElement( name );
-		me.setAttribute( "id", ProjectJournal::idToSave( id() ) );
+		me.setAttribute( "id", id() );
 		me.setAttribute( "value", m_value );
 		me.setAttribute( "scale_type", m_scaleType == Logarithmic ? "log" : "linear" );
 		element.appendChild( me );

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -563,8 +563,7 @@ void AutomationPattern::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		if( *it )
 		{
 			QDomElement element = _doc.createElement( "object" );
-			element.setAttribute( "id",
-				ProjectJournal::idToSave( ( *it )->id() ) );
+			element.setAttribute( "id", ( *it )->id() );
 			_this.appendChild( element );
 		}
 	}

--- a/src/core/JournallingObject.cpp
+++ b/src/core/JournallingObject.cpp
@@ -118,23 +118,15 @@ void JournallingObject::changeID( jo_id_t _id )
 	{
 		JournallingObject * jo = Engine::projectJournal()->
 											journallingObject( _id );
+		// Fix ID collision
 		if( jo != NULL )
 		{
-			QString used_by = jo->nodeName();
-			if( used_by == "automatablemodel" &&
-				dynamic_cast<AutomatableModel *>( jo ) )
-			{
-				used_by += ":" +
-					dynamic_cast<AutomatableModel *>( jo )->
-								displayName();
-			}
-			fprintf( stderr, "JO-ID %d already in use by %s!\n",
-				(int) _id, used_by.toUtf8().constData() );
-			return;
+			jo->changeID( Engine::projectJournal()->allocID( NULL ) );
 		}
 
 		Engine::projectJournal()->freeID( m_id );
 		Engine::projectJournal()->reallocID( _id, this );
+		Engine::projectJournal()->changeID( m_id, _id );
 		m_id = _id;
 	}
 }

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -134,10 +134,7 @@ void ProjectJournal::addJournalCheckPoint( JournallingObject *jo )
 jo_id_t ProjectJournal::allocID( JournallingObject * _obj )
 {
 	jo_id_t id;
-	for( jo_id_t tid = rand(); m_joIDs.contains( id = tid % EO_ID_MSB
-							| EO_ID_MSB ); tid++ )
-	{
-	}
+	for(jo_id_t tid = rand(); m_joIDs.contains(id = tid & (EO_ID_MSB - 1)); ++tid);
 
 	m_joIDs[id] = _obj;
 	//printf("new id: %d\n", id );
@@ -156,16 +153,15 @@ void ProjectJournal::reallocID( const jo_id_t _id, JournallingObject * _obj )
 	}
 }
 
-
-
-
-jo_id_t ProjectJournal::idToSave( jo_id_t id )
+void ProjectJournal::changeID(const jo_id_t oldID, const jo_id_t newID)
 {
-	return id & ~EO_ID_MSB;
+	auto changeFunc = [oldID, newID](CheckPoint& c)
+	{
+		if (c.joID == oldID) {c.joID = newID;}
+	};
+	std::for_each(m_undoCheckPoints.begin(), m_undoCheckPoints.end(), changeFunc);
+	std::for_each(m_redoCheckPoints.begin(), m_redoCheckPoints.end(), changeFunc);
 }
-
-
-
 
 void ProjectJournal::clearJournal()
 {


### PR DESCRIPTION
Previously `JournallingObject::changeID` failed if `_id` is being used. This commit adds handling of ID collision and partially reverts #2875. So it will fix regressions in #2875, too.
Fixes #3781, fixes #3359.