### PR TITLE
FX autoquit disabled by default

### DIFF
--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -135,7 +135,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_displayWaveform(ConfigManager::inst()->value( "ui",
 						   "displaywaveform").toInt() ),
 	m_disableAutoQuit(ConfigManager::inst()->value( "ui",
-						   "disableautoquit").toInt() ),
+						   "disableautoquit", "1" ).toInt() ),
 	m_vstEmbedMethod( ConfigManager::inst()->vstEmbedMethod() )
 {
 	setWindowIcon( embed::getIconPixmap( "setup_general" ) );

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -74,7 +74,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_autoQuit = new TempoSyncKnob( knobBright_26, this );
 	m_autoQuit->setLabel( tr( "DECAY" ) );
 	m_autoQuit->move( 60, 5 );
-	m_autoQuit->setEnabled( isEnabled );
+	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 	m_autoQuit->setWhatsThis( tr(
 "The Decay knob controls how many buffers of silence must pass before the "

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -85,7 +85,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_gate = new Knob( knobBright_26, this );
 	m_gate->setLabel( tr( "GATE" ) );
 	m_gate->move( 93, 5 );
-	m_gate->setEnabled( isEnabled );
+	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_gate->setHintText( tr( "Gate:" ), "" );
 	m_gate->setWhatsThis( tr(
 "The Gate knob controls the signal level that is considered to be 'silence' "


### PR DESCRIPTION
Really short notes doesn't work well with delay based effects with the
default decay settings of the FX autoquit system. disable autoquit by
default.

In response to #4284
Supersedes #4291