### PR TITLE
Fix automation processing priority

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -816,7 +816,7 @@ AutomationPattern * Song::tempoAutomationPattern()
 
 AutomatedValueMap Song::automatedValuesAt(MidiTime time, int tcoNum) const
 {
-	return TrackContainer::automatedValuesFromTracks(TrackList(tracks()) << m_globalAutomationTrack, time, tcoNum);
+	return TrackContainer::automatedValuesFromTracks(TrackList{m_globalAutomationTrack} << tracks(), time, tcoNum);
 }
 
 

--- a/tests/src/tracks/AutomationTrackTest.cpp
+++ b/tests/src/tracks/AutomationTrackTest.cpp
@@ -195,6 +195,30 @@ private slots:
 		QCOMPARE(song->automatedValuesAt(5)[&model], 0.5f);
 		QCOMPARE(song->automatedValuesAt(MidiTime::ticksPerTact() + 5)[&model], 0.5f);
 	}
+
+	void testGlobalAutomation()
+	{
+		// Global automation should not have priority, see https://github.com/LMMS/lmms/issues/4268
+		// Tests regression caused by 75077f6200a5aee3a5821aae48a3b8466ed8714a
+		auto song = Engine::getSong();
+
+		auto globalTrack = song->globalAutomationTrack();
+		AutomationPattern globalPattern(globalTrack);
+
+		AutomationTrack localTrack(song);
+		AutomationPattern localPattern(&localTrack);
+
+		FloatModel model;
+		globalPattern.setProgressionType(AutomationPattern::DiscreteProgression);
+		localPattern.setProgressionType(AutomationPattern::DiscreteProgression);
+		globalPattern.addObject(&model);
+		localPattern.addObject(&model);
+		globalPattern.putValue(0, 100.0f, false);
+		localPattern.putValue(0, 50.0f, false);
+
+		QCOMPARE(song->automatedValuesAt(0)[&model], 50.0f);
+	}
+
 } AutomationTrackTest;
 
 #include "AutomationTrackTest.moc"


### PR DESCRIPTION
Fixes a regression from 75077f6200a5aee3a5821aae48a3b8466ed8714a that caused global automation tracks to have priority in processing. Adds a test checking for the desired behaviour.

Thanks @zonkmachine and @PhysSong for investigating.

Closes #4268