### PR TITLE
Piano roll: fix some crashes when no pattern is open

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -949,6 +949,8 @@ void PianoRoll::clearSelectedNotes()
 
 void PianoRoll::shiftSemiTone( int amount ) // shift notes by amount semitones
 {
+	if (!hasValidPattern()) {return;}
+
 	bool useAllNotes = ! isSelection();
 	for( Note *note : m_pattern->notes() )
 	{
@@ -973,6 +975,8 @@ void PianoRoll::shiftSemiTone( int amount ) // shift notes by amount semitones
 
 void PianoRoll::shiftPos( int amount ) //shift notes pos by amount
 {
+	if (!hasValidPattern()) {return;}
+
 	bool useAllNotes = ! isSelection();
 
 	bool first = true;
@@ -1112,9 +1116,12 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 				else if( ke->modifiers() & Qt::ShiftModifier && m_action == ActionNone)
 				{
 					// move notes
-					bool quantized = ! ( ke->modifiers() & Qt::AltModifier );
-					int amt = quantized ? quantization() : 1;
-					shiftPos( direction * amt );
+					if (hasValidPattern())
+					{
+						bool quantized = ! ( ke->modifiers() & Qt::AltModifier );
+						int amt = quantized ? quantization() : 1;
+						shiftPos( direction * amt );
+					}
 				}
 				else if( ke->modifiers() & Qt::AltModifier)
 				{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1063,12 +1063,18 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 				{
 					// shift selection up an octave
 					// if nothing selected, shift _everything_
-					shiftSemiTone( 12 * direction );
+					if (hasValidPattern())
+					{
+						shiftSemiTone( 12 * direction );
+					}
 				}
 				else if((ke->modifiers() & Qt::ShiftModifier) && m_action == ActionNone)
 				{
 					// Move selected notes up by one semitone
-					shiftSemiTone( 1 * direction );
+					if (hasValidPattern())
+					{
+						shiftSemiTone( 1 * direction );
+					}
 				}
 				else
 				{
@@ -1098,7 +1104,10 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 				if( ke->modifiers() & Qt::ControlModifier && m_action == ActionNone )
 				{
 					// Move selected notes by one bar to the left
-					shiftPos( direction * MidiTime::ticksPerTact() );
+					if (hasValidPattern())
+					{
+						shiftPos( direction * MidiTime::ticksPerTact() );
+					}
 				}
 				else if( ke->modifiers() & Qt::ShiftModifier && m_action == ActionNone)
 				{
@@ -1110,10 +1119,14 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 				else if( ke->modifiers() & Qt::AltModifier)
 				{
 					// switch to editing a pattern adjacent to this one in the song editor
-					Pattern * p = direction > 0 ? m_pattern->nextPattern() : m_pattern->previousPattern();
-					if(p != NULL)
+					if (hasValidPattern())
 					{
-						setCurrentPattern(p);
+						Pattern * p = direction > 0 ? m_pattern->nextPattern()
+										: m_pattern->previousPattern();
+						if(p != NULL)
+						{
+							setCurrentPattern(p);
+						}
 					}
 				}
 				else
@@ -3188,6 +3201,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	if( we->x() > noteEditLeft() && we->x() < noteEditRight()
 	&& we->y() > noteEditTop() && we->y() < noteEditBottom() )
 	{
+		if (!hasValidPattern()) {return;}
 		// get values for going through notes
 		int pixel_range = 8;
 		int x = we->x() - WHITE_KEY_WIDTH;


### PR DESCRIPTION
Fixes #4388 and some more crashes when no pattern is open in the piano roll editor.
- Shifting note position/pitch (Ctrl/Shift + arrow keys)
- Switching pattern (Alt + L/R arrow keys)
- Scrolling in note edit area