### PR TITLE
Piano roll: reset editing mode when lost focus

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3322,8 +3322,9 @@ void PianoRoll::focusOutEvent( QFocusEvent * )
 			m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
 			m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
 		}
-		update();
 	}
+	m_editMode = m_ctrlMode;
+	update();
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -177,6 +177,7 @@ PianoRoll::PianoRoll() :
 	m_startKey( INITIAL_START_KEY ),
 	m_lastKey( 0 ),
 	m_editMode( ModeDraw ),
+	m_ctrlMode( ModeDraw ),
 	m_mouseDownRight( false ),
 	m_scrollBack( false ),
 	m_barLineColor( 0, 0, 0 ),
@@ -3532,7 +3533,7 @@ void PianoRoll::verScrolled( int new_pos )
 
 void PianoRoll::setEditMode(int mode)
 {
-	m_editMode = (EditModes) mode;
+	m_ctrlMode = m_editMode = (EditModes) mode;
 }
 
 


### PR DESCRIPTION
Set `m_editMode` back to `m_ctrlMode` as if the Control key is released in `PianoRoll::focusOutEvent`. Fixes #4390, and partially #3833.
The handler is also called when the editor is closed(in Qt, hiding focused widget generates focus out event). If this works, similar patch can be applied for song editor in `master` branch(current fix #3796 is incomplete, it doesn't work when switching window).