### PR TITLE
Equaliser, Disable analyser when not visible

### DIFF
--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -165,7 +165,7 @@ bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 	const float outGain =  m_outGain;
 	sampleFrame m_inPeak = { 0, 0 };
 
-	if(m_eqControls.m_analyseInModel.value( true ) &&  outSum > 0 )
+	if(m_eqControls.m_analyseInModel.value( true ) &&  outSum > 0 && m_eqControls.isViewVisible()  )
 	{
 		m_eqControls.m_inFftBands.analyze( buf, frames );
 	}
@@ -276,7 +276,7 @@ bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 
 	checkGate( outSum / frames );
 
-	if(m_eqControls.m_analyseOutModel.value( true ) && outSum > 0 )
+	if(m_eqControls.m_analyseOutModel.value( true ) && outSum > 0 && m_eqControls.isViewVisible() )
 	{
 		m_eqControls.m_outFftBands.analyze( buf, frames );
 		setBandPeaks( &m_eqControls.m_outFftBands , ( int )( sampleRate ) );

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -196,8 +196,6 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 
 void EqSpectrumView::paintEvent(QPaintEvent *event)
 {
-	//only analyse if the view is visible
-	m_analyser->setActive( isVisible() );
 	const float energy =  m_analyser->getEnergy();
 	if( energy <= 0 && m_peakSum <= 0 )
 	{		
@@ -291,5 +289,6 @@ float EqSpectrumView::bandToFreq( int index )
 void EqSpectrumView::periodicalUpdate()
 {
 	m_periodicalUpdate = true;
+	m_analyser->setActive( isVisible() );
 	update();
 }


### PR DESCRIPTION
Previously the Equalizer plugin, would continue to perform FFT analysis on the audio when the plugin was not viable. This has a negative affect on performance.

This pull request, suspends the FFT while the plugin is not visible
fixes #4389 
