### PR TITLE
Fix some encoding issues (mostly on Windows)

### DIFF
--- a/include/AudioFileDevice.h
+++ b/include/AudioFileDevice.h
@@ -56,6 +56,10 @@ protected:
 		return m_outputFile.isOpen();
 	}
 
+	inline int outputFileHandle() const
+	{
+		return m_outputFile.handle();
+	}
 
 private:
 	QFile m_outputFile;

--- a/include/DrumSynth.h
+++ b/include/DrumSynth.h
@@ -30,22 +30,24 @@
 #include <stdint.h>
 #include "lmms_basics.h"
 
+class QString;
+
 class DrumSynth {
     public:
         DrumSynth() {};
-        int GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels, sample_rate_t Fs);
+        int GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs);
 
     private:
         float LoudestEnv(void);
         int   LongestEnv(void);
         void  UpdateEnv(int e, long t);
-        void  GetEnv(int env, const char *sec, const char *key, const char *ini);
+        void  GetEnv(int env, const char *sec, const char *key, QString ini);
 
         float waveform(float ph, int form);
 
-        int GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, const char *file);
-        int GetPrivateProfileInt(const char *sec, const char *key, int def, const char *file);
-        float GetPrivateProfileFloat(const char *sec, const char *key, float def, const char *file);
+        int GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file);
+        int GetPrivateProfileInt(const char *sec, const char *key, int def, QString file);
+        float GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file);
 
 };
 

--- a/include/ImportFilter.h
+++ b/include/ImportFilter.h
@@ -78,6 +78,11 @@ protected:
 		return m_file.read( _data, _len );
 	}
 
+	inline QByteArray readAllData()
+	{
+		return m_file.readAll();
+	}
+
 	inline void ungetChar( char _ch )
 	{
 		m_file.ungetChar( _ch );

--- a/include/IoHelper.h
+++ b/include/IoHelper.h
@@ -1,0 +1,72 @@
+/*
+ * IoHelper.h - helper functions for file I/O
+ *
+ * Copyright (c) 2018 Hyunjin Song <tteu.ingog/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#include "lmmsconfig.h"
+
+#include <cstdio>
+
+
+#ifdef _WIN32
+#include <windows.h>
+
+std::wstring toWString(const std::string& s)
+{
+	std::wstring ret;
+	int len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(),
+			s.length(), nullptr, 0);
+	if (len == 0)
+	{
+		return ret;
+	}
+	ret.resize(len);
+	MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s.data(), s.length(), &ret[0], len);
+	return ret;
+}
+#endif
+
+#ifdef LMMS_BUILD_WIN32
+#include <io.h>
+#define F_OPEN_UTF8(a, b) _wfopen(toWString(a).data(), L##b)
+#else
+#ifdef LMMS_HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#define F_OPEN_UTF8(a, b) fopen((a).data(), b)
+#endif
+
+int fileToDescriptor(FILE* f, bool closeFile = true)
+{
+	int fh;
+	if (f == NULL) {return -1;}
+
+#ifdef LMMS_BUILD_WIN32
+	fh = _dup(_fileno(f));
+#else
+	fh = dup(fileno(f));
+#endif
+
+	if (closeFile) {fclose(f);}
+	return fh;
+}

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -270,15 +270,15 @@ private:
 	void convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, int _channels);
 	void directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _channels);
 
-	f_cnt_t decodeSampleSF( const char * _f, sample_t * & _buf,
+	f_cnt_t decodeSampleSF( QString _f, sample_t * & _buf,
 						ch_cnt_t & _channels,
 						sample_rate_t & _sample_rate );
 #ifdef LMMS_HAVE_OGGVORBIS
-	f_cnt_t decodeSampleOGGVorbis( const char * _f, int_sample_t * & _buf,
+	f_cnt_t decodeSampleOGGVorbis( QString _f, int_sample_t * & _buf,
 						ch_cnt_t & _channels,
 						sample_rate_t & _sample_rate );
 #endif
-	f_cnt_t decodeSampleDS( const char * _f, int_sample_t * & _buf,
+	f_cnt_t decodeSampleDS( QString _f, int_sample_t * & _buf,
 						ch_cnt_t & _channels,
 						sample_rate_t & _sample_rate );
 

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -26,8 +26,11 @@
 #include <QDomDocument>
 #include <QDir>
 #include <QApplication>
+#include <QFile>
 #include <QMessageBox>
 #include <QProgressDialog>
+
+#include <sstream>
 
 #include "MidiImport.h"
 #include "TrackContainer.h"
@@ -279,8 +282,6 @@ public:
 
 bool MidiImport::readSMF( TrackContainer* tc )
 {
-	QString filename = file().fileName();
-	closeFile();
 
 	const int preTrackSteps = 2;
 	QProgressDialog pd( TrackContainer::tr( "Importing MIDI-file..." ),
@@ -291,7 +292,11 @@ bool MidiImport::readSMF( TrackContainer* tc )
 
 	pd.setValue( 0 );
 
-	Alg_seq_ptr seq = new Alg_seq(filename.toLocal8Bit(), true);
+	std::stringstream stream;
+	QByteArray arr = readAllData();
+	stream.str(std::string(arr.constData(), arr.size()));
+
+	Alg_seq_ptr seq = new Alg_seq(stream, true);
 	seq->convert_to_beats();
 
 	pd.setMaximum( seq->tracks()  + preTrackSteps );

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -620,7 +620,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 	{
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
-						.toLatin1().constData() );
+						.toLocal8Bit().constData() );
 #ifndef LMMS_DEBUG
 		Stk::showWarnings( false );
 #endif
@@ -670,7 +670,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 	{
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
-						.toLatin1().constData() );
+						.toLocal8Bit().constData() );
 #ifndef LMMS_DEBUG
 		Stk::showWarnings( false );
 #endif
@@ -718,7 +718,7 @@ malletsSynth::malletsSynth( const StkFloat _pitch,
 	{
 		Stk::setSampleRate( _sample_rate );
 		Stk::setRawwavePath( QDir( ConfigManager::inst()->stkDir() ).absolutePath()
-						.toLatin1().constData() );
+						.toLocal8Bit().constData() );
 #ifndef LMMS_DEBUG
 		Stk::showWarnings( false );
 #endif

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -26,10 +26,12 @@
 
 #include "DrumSynth.h"
 
-#include <fstream>
+#include <sstream>
 #include <cstring>
 
 #include <math.h>     //sin(), exp(), etc.
+
+#include <QFile>
 
 #ifdef LMMS_BUILD_WIN32
 #define powf pow
@@ -112,7 +114,7 @@ void DrumSynth::UpdateEnv(int e, long t)
 }
 
 
-void DrumSynth::GetEnv(int env, const char *sec, const char *key, const char *ini)
+void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
 {
   char en[256], s[8];
   int i=0, o=0, ep=0;
@@ -162,9 +164,9 @@ float DrumSynth::waveform(float ph, int form)
 }
 
 
-int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, const char *file)
+int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file)
 {
-    ifstream is;
+    stringstream is;
     bool inSection = false;
     char *line;
     char *k, *b;
@@ -172,7 +174,12 @@ int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const c
 
     line = (char*)malloc(200);
 
-    is.open (file, ifstream::in);
+    // Use QFile to handle unicode file name on Windows
+    // Previously we used ifstream directly
+    QFile f(file);
+    f.open(QIODevice::ReadOnly);
+    QByteArray dat = f.readAll().constData();
+    is.str(string(dat.constData(), dat.size()));
 
     while (is.good()) {
         if (!inSection) {
@@ -218,13 +225,12 @@ int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const c
         strncpy(buffer, def, size);
     }
 
-    is.close();
     free(line);
 
     return len;
 }
 
-int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, const char *file)
+int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, QString file)
 {
   char tmp[16];
   int i=0;
@@ -235,7 +241,7 @@ int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, c
   return i;
 }
 
-float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float def, const char *file)
+float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file)
 {
     char tmp[16];
     float f=0.f;
@@ -252,7 +258,7 @@ float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float 
 //  an associative array or something once we have a datastructure to load in to.
 //  llama
 
-int DrumSynth::GetDSFileSamples(const char *dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
+int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
 {
   //input file
   char sec[32];


### PR DESCRIPTION
This pull request fixes several encoding issue. Every issue except STK one are Windows-specific.
- ZynAddSubFX setting loading/saving
- VST DLL loading
- VST setting loading/saving
- Sample file decoding
- MIDI import
- STK rawwave path (incomplete on Windows due to upstream issue)

Issues remaining on Windows:
- .pat file loading
- .gig file loading
- STK rawwave path (which `toLocal8Bit` fails to handle)

I'm planning to track remaining issues in #1191.

Fixes #3855, Fixes #2662, and almost #1191.