### PR TITLE
Better handling of invalid audio/MIDI backend

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -308,6 +308,9 @@ public:
 	void requestChangeInModel();
 	void doneChangeInModel();
 
+	static bool isAudioDevNameValid(QString name);
+	static bool isMidiDevNameValid(QString name);
+
 
 signals:
 	void qualitySettingsChanged();

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -829,14 +829,138 @@ void Mixer::runChangesInModel()
 	}
 }
 
+bool Mixer::isAudioDevNameValid(QString name)
+{
+#ifdef LMMS_HAVE_SDL
+	if (name == AudioSdl::name())
+	{
+		return true;
+	}
+#endif
 
 
+#ifdef LMMS_HAVE_ALSA
+	if (name == AudioAlsa::name())
+	{
+		return true;
+	}
+#endif
+
+
+#ifdef LMMS_HAVE_PULSEAUDIO
+	if (name == AudioPulseAudio::name())
+	{
+		return true;
+	}
+#endif
+
+
+#ifdef LMMS_HAVE_OSS
+	if (name == AudioOss::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_HAVE_SNDIO
+	if (name == AudioSndio::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_HAVE_JACK
+	if (name == AudioJack::name())
+	{
+		return true;
+	}
+#endif
+
+
+#ifdef LMMS_HAVE_PORTAUDIO
+	if (name == AudioPortAudio::name())
+	{
+		return true;
+	}
+#endif
+
+
+#ifdef LMMS_HAVE_SOUNDIO
+	if (name == AudioSoundIo::name())
+	{
+		return true;
+	}
+#endif
+
+	if (name == AudioDummy::name())
+	{
+		return true;
+	}
+
+	return false;
+}
+
+bool Mixer::isMidiDevNameValid(QString name)
+{
+#ifdef LMMS_HAVE_ALSA
+	if (name == MidiAlsaSeq::name() || name == MidiAlsaRaw::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_HAVE_JACK
+	if (name == MidiJack::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_HAVE_OSS
+	if (name == MidiOss::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_HAVE_SNDIO
+	if (name == MidiSndio::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_BUILD_WIN32
+	if (name == MidiWinMM::name())
+	{
+		return true;
+	}
+#endif
+
+#ifdef LMMS_BUILD_APPLE
+    if (name == MidiApple::name())
+    {
+		return true;
+    }
+#endif
+
+    if (name == MidiDummy::name())
+    {
+		return true;
+    }
+
+	return false;
+}
 
 AudioDevice * Mixer::tryAudioDevices()
 {
 	bool success_ful = false;
 	AudioDevice * dev = NULL;
 	QString dev_name = ConfigManager::inst()->value( "mixer", "audiodev" );
+	if( !isAudioDevNameValid( dev_name ) )
+	{
+		dev_name = "";
+	}
 
 	m_audioDevStartFailed = false;
 
@@ -980,6 +1104,10 @@ MidiClient * Mixer::tryMidiClients()
 {
 	QString client_name = ConfigManager::inst()->value( "mixer",
 								"mididev" );
+	if( !isMidiDevNameValid( client_name ) )
+	{
+		client_name = "";
+	}
 
 #ifdef LMMS_HAVE_ALSA
 	if( client_name == MidiAlsaSeq::name() || client_name == "" )

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -590,7 +590,9 @@ void MainWindow::finalize()
 	}
 	// look whether mixer failed to start the audio device selected by the
 	// user and is using AudioDummy as a fallback
-	else if( Engine::mixer()->audioDevStartFailed() )
+	// or the audio device is set to invalid one
+	else if( Engine::mixer()->audioDevStartFailed() || !Mixer::isAudioDevNameValid(
+		ConfigManager::inst()->value( "mixer", "audiodev" ) ) )
 	{
 		// if so, offer the audio settings section of the setup dialog
 		SetupDialog sd( SetupDialog::AudioSettings );

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -833,7 +833,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	// If no preferred audio device is saved, save the current one
 	QString audioDevName = 
 		ConfigManager::inst()->value( "mixer", "audiodev" );
-	if( audioDevName.length() == 0 )
+	if( m_audioInterfaces->findText(audioDevName) < 0 )
 	{
 		audioDevName = Engine::mixer()->audioDevName();
 		ConfigManager::inst()->setValue(
@@ -936,7 +936,7 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 
 	QString midiDevName = 
 		ConfigManager::inst()->value( "mixer", "mididev" );
-	if( midiDevName.length() == 0 )
+	if( m_midiInterfaces->findText(midiDevName) < 0 )
 	{
 		midiDevName = Engine::mixer()->midiClientName();
 		ConfigManager::inst()->setValue(


### PR DESCRIPTION
Fix crash when nonexistent/not supported audio/MIDI backend is written in `.lmmsrc.xml`.
Supersedes #4372.