### PR TITLE
Equalizer plugin has antialiasing enabled in the spectrum analyzer  

### DIFF
--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -209,6 +209,7 @@ void EqSpectrumView::paintEvent(QPaintEvent *event)
 	const int LOWER_Y = -36;	// dB
 	QPainter painter( this );
 	painter.setPen( QPen( m_color, 1, Qt::SolidLine, Qt::RoundCap, Qt::BevelJoin ) );
+	painter.setRenderHint(QPainter::Antialiasing, true);
 
 	if( m_analyser->getInProgress() || m_periodicalUpdate == false )
 	{


### PR DESCRIPTION
As general maintenance of the EQ ui, It has been suggested that anti-aliasing be used to improve the display of the spectrum analyzer.

Part of #4395 