### PR TITLE
Fix occasional audio interface deadlock

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -37,7 +37,6 @@
 #include <QtCore/QVector>
 #include <QtCore/QList>
 #include <QtCore/QMap>
-#include <QMutexLocker>
 
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
@@ -108,7 +107,6 @@ private:
 
 	bool m_active;
 	bool m_stopped;
-	QMutex m_processingMutex;
 
 	MidiJack *m_midiClient;
 	QVector<jack_port_t *> m_outputPorts;

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -145,7 +145,6 @@ private:
 	int m_outBufSize;
 
 	bool m_stopped;
-	QSemaphore m_stopSemaphore;
 
 } ;
 

--- a/include/AudioSoundIo.h
+++ b/include/AudioSoundIo.h
@@ -109,6 +109,8 @@ private:
 	fpp_t m_outBufFramesTotal;
 	fpp_t m_outBufFrameIndex;
 
+	bool m_stopped;
+
 	int m_disconnectErr;
 	void onBackendDisconnect(int err);
 

--- a/include/fifo_buffer.h
+++ b/include/fifo_buffer.h
@@ -66,6 +66,12 @@ public:
 		return( element );
 	}
 
+	void waitUntilRead()
+	{
+		m_writer_sem.acquire( m_size );
+		m_writer_sem.release( m_size );
+	}
+
 	bool available()
 	{
 		return( m_reader_sem.available() );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -640,7 +640,7 @@ void Mixer::storeAudioDevice()
 
 void Mixer::restoreAudioDevice()
 {
-	if( m_oldAudioDev != NULL )
+	if( m_oldAudioDev && m_audioDev != m_oldAudioDev )
 	{
 		stopProcessing();
 		delete m_audioDev;
@@ -648,9 +648,9 @@ void Mixer::restoreAudioDevice()
 		m_audioDev = m_oldAudioDev;
 		emit sampleRateChanged();
 
-		m_oldAudioDev = NULL;
 		startProcessing();
 	}
+	m_oldAudioDev = NULL;
 }
 
 
@@ -1127,7 +1127,9 @@ void Mixer::fifoWriter::run()
 		write( buffer );
 	}
 
+	// Let audio backend stop processing
 	write( NULL );
+	m_fifo->waitUntilRead();
 }
 
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -201,7 +201,6 @@ bool AudioJack::initJackClient()
 
 void AudioJack::startProcessing()
 {
-	QMutexLocker m( &m_processingMutex );
 	m_stopped = false;
 
 	if( m_active || m_client == NULL )
@@ -254,7 +253,6 @@ void AudioJack::startProcessing()
 
 void AudioJack::stopProcessing()
 {
-	QMutexLocker m( &m_processingMutex );
 	m_stopped = true;
 }
 
@@ -342,7 +340,6 @@ void AudioJack::renamePort( AudioPort * _port )
 
 int AudioJack::processCallback( jack_nframes_t _nframes, void * _udata )
 {
-	QMutexLocker m( &m_processingMutex );
 
 	// do midi processing first so that midi input can
 	// add to the following sound processing
@@ -406,6 +403,7 @@ int AudioJack::processCallback( jack_nframes_t _nframes, void * _udata )
 			m_framesDoneInCurBuf = 0;
 			if( !m_framesToDoInCurBuf )
 			{
+				m_stopped = true;
 				break;
 			}
 		}

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -103,6 +103,7 @@ void AudioPulseAudio::startProcessing()
 
 void AudioPulseAudio::stopProcessing()
 {
+	m_quit = true;
 	stopProcessingThread( this );
 }
 

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -168,6 +168,7 @@ void AudioSdl::sdlAudioCallback( Uint8 * _buf, int _len )
 			const fpp_t frames = getNextBuffer( m_outBuf );
 			if( !frames )
 			{
+				m_stopped = true;
 				memset( _buf, 0, _len );
 				return;
 			}


### PR DESCRIPTION
Fixes #4406 by ensuring audio thread has read the `NULL` buffer before stop processing. Dropping them have caused several regressions(#4406, #3397, #3396, etc.) because `stopProcessing` of backend can be called before it receives `NULL` buffer.
Instead of relying on per-backend semaphores(Dropped for SDL in 98346f7a9a7a7c07e91bdad953229f1ba7523c2e, for JACK in 1dcacbb95e5182f784d8a951dee63c96c7487830), `Mixer::fifoWriter` now checks it.