### PR TITLE
Use tryLock in audio threads for VST/ZynAddSubFX

### DIFF
--- a/plugins/VstEffect/VstEffect.cpp
+++ b/plugins/VstEffect/VstEffect.cpp
@@ -95,9 +95,11 @@ bool VstEffect::processAudioBuffer( sampleFrame * _buf, const fpp_t _frames )
 		sampleFrame * buf = new sampleFrame[_frames];
 #endif
 		memcpy( buf, _buf, sizeof( sampleFrame ) * _frames );
-		m_pluginMutex.lock();
-		m_plugin->process( buf, buf );
-		m_pluginMutex.unlock();
+		if (m_pluginMutex.tryLock())
+		{
+			m_plugin->process( buf, buf );
+			m_pluginMutex.unlock();
+		}
 
 		double out_sum = 0.0;
 		const float w = wetLevel();

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -62,7 +62,7 @@ void VstEffectControls::loadSettings( const QDomElement & _this )
 {
 	//m_effect->closePlugin();
 	//m_effect->openPlugin( _this.attribute( "plugin" ) );
-	if (!m_effect->m_pluginMutex.tryLock()) {return;}
+	m_effect->m_pluginMutex.lock();
 	if( m_effect->m_plugin != NULL )
 	{
 		m_vstGuiVisible = _this.attribute( "guivisible" ).toInt();

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -62,7 +62,7 @@ void VstEffectControls::loadSettings( const QDomElement & _this )
 {
 	//m_effect->closePlugin();
 	//m_effect->openPlugin( _this.attribute( "plugin" ) );
-	m_effect->m_pluginMutex.lock();
+	if (!m_effect->m_pluginMutex.tryLock()) {return;}
 	if( m_effect->m_plugin != NULL )
 	{
 		m_vstGuiVisible = _this.attribute( "guivisible" ).toInt();

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -359,14 +359,12 @@ void vestigeInstrument::loadFile( const QString & _file )
 
 void vestigeInstrument::play( sampleFrame * _buf )
 {
-	m_pluginMutex.lock();
+	if (!m_pluginMutex.tryLock()) {return;}
 
 	const fpp_t frames = Engine::mixer()->framesPerPeriod();
 
 	if( m_plugin == NULL )
 	{
-		BufferManager::clear( _buf, frames );
-
 		m_pluginMutex.unlock();
 		return;
 	}

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -326,7 +326,7 @@ QString ZynAddSubFxInstrument::nodeName() const
 
 void ZynAddSubFxInstrument::play( sampleFrame * _buf )
 {
-	m_pluginMutex.lock();
+	if (!m_pluginMutex.tryLock()) {return;}
 	if( m_remotePlugin )
 	{
 		m_remotePlugin->process( NULL, _buf );


### PR DESCRIPTION
Prevent loading VST or toggling ZynAddSubFX GUI from blocking entire audio processing. It still blocks audio output from specific VeSTige/ZynAddSubFX but not whole playback.
Address #1825.