### PR TITLE
Add option to show note values on notes in Piano Roll (#4466)

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -123,6 +123,7 @@ PianoRoll {
 	qproperty-backgroundShade: rgba( 255, 255, 255, 10 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
+        qproperty-noteTextColor: rgb( 255, 255, 255 );
 	qproperty-noteOpacity: 128;
 	qproperty-noteBorders: true; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -123,7 +123,7 @@ PianoRoll {
 	qproperty-backgroundShade: rgba( 255, 255, 255, 10 );
 	qproperty-noteModeColor: rgb( 255, 255, 255 );
 	qproperty-noteColor: rgb( 119, 199, 216 );
-        qproperty-noteTextColor: rgb( 255, 255, 255 );
+	qproperty-noteTextColor: rgb( 255, 255, 255 );
 	qproperty-noteOpacity: 128;
 	qproperty-noteBorders: true; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: rgb( 0, 125, 255 );

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -142,6 +142,7 @@ PianoRoll {
 	qproperty-backgroundShade: rgba(255, 255, 255, 10);
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
+        qproperty-noteTextColor: #ffffff;
 	qproperty-noteOpacity: 165;
 	qproperty-noteBorders: false; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: #064d79;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -142,7 +142,7 @@ PianoRoll {
 	qproperty-backgroundShade: rgba(255, 255, 255, 10);
 	qproperty-noteModeColor: #0bd556;
 	qproperty-noteColor: #0bd556;
-        qproperty-noteTextColor: #ffffff;
+	qproperty-noteTextColor: #ffffff;
 	qproperty-noteOpacity: 165;
 	qproperty-noteBorders: false; /* boolean property, set false to have borderless notes */
 	qproperty-selectedNoteColor: #064d79;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -59,6 +59,7 @@ class PianoRoll : public QWidget
 	Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor )
 	Q_PROPERTY( QColor noteModeColor READ noteModeColor WRITE setNoteModeColor )
 	Q_PROPERTY( QColor noteColor READ noteColor WRITE setNoteColor )
+	Q_PROPERTY( QColor noteTextColor READ noteTextColor WRITE setNoteTextColor )
 	Q_PROPERTY( QColor barColor READ barColor WRITE setBarColor )
 	Q_PROPERTY( QColor selectedNoteColor READ selectedNoteColor WRITE setSelectedNoteColor )
 	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
@@ -122,6 +123,8 @@ public:
 	void setNoteModeColor( const QColor & c );
 	QColor noteColor() const;
 	void setNoteColor( const QColor & c );
+	QColor noteTextColor() const;
+	void setNoteTextColor( const QColor & c );
 	QColor barColor() const;
 	void setBarColor( const QColor & c );
 	QColor selectedNoteColor() const;
@@ -157,8 +160,8 @@ protected:
 
 	int getKey( int y ) const;
 	static void drawNoteRect( QPainter & p, int x, int y,
-					int  width, const Note * n, const QColor & noteCol,
-					const QColor & selCol, const int noteOpc, const bool borderless );
+					int  width, const Note * n, const QColor & noteCol, const QColor & noteTextColor,
+					const QColor & selCol, const int noteOpc, const bool borderless, bool drawNoteName );
 	void removeSelection();
 	void selectAll();
 	NoteVector getSelectedNotes();
@@ -384,6 +387,7 @@ private:
 	QColor m_lineColor;
 	QColor m_noteModeColor;
 	QColor m_noteColor;
+	QColor m_noteTextColor;
 	QColor m_barColor;
 	QColor m_selectedNoteColor;
 	QColor m_textColor;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -894,12 +894,13 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 
 			int const distanceToBorder = 2;
 			int const xOffset = borderWidth + distanceToBorder;
+			int const yOffset = (noteHeight + noteTextHeight) / 2;
 
 			if (textSize.width() < noteWidth - xOffset)
 			{
 				p.setPen(noteTextColor);
 				p.setFont(noteFont);
-				QPoint textStart(x + xOffset, y + (noteTextHeight + (noteHeight - noteTextHeight) / 2));
+				QPoint textStart(x + xOffset, y + yOffset);
 
 				p.drawText(textStart, noteKeyString);
 			}


### PR DESCRIPTION
Add the option to show note values on notes in the Piano Roll. This
functionality is currently coupled with the option "Enable note labels
in piano roll" which can be found in the main menu.

The notes are rendered at about 80% of the notes height. They are only
rendered if they fit on the whole note and if the font does not become
too tiny.

Enable the configuration of the note value text's color via the
stylesheets and set the value to white for both shipped themes.

Other changes:
* Clean up some warnings about old school casts and implicit casts.

![lmms-4466-notetext](https://user-images.githubusercontent.com/9293269/42412102-59b8904a-8206-11e8-9c09-e9b878ed162e.gif)
