### PR TITLE
Fix some formatting issues in translations

### DIFF
--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -1034,7 +1034,7 @@ Máte-li zájem o překlad LMMS do jiného jazyka, nebo chcete-li vylepšit exis
     </message>
     <message>
         <source>FDBK</source>
-        <translation>ZP. VAZBA</translation>
+        <translation>FDBK</translation>
     </message>
     <message>
         <source>RATE</source>
@@ -2172,7 +2172,7 @@ Please make sure you have write permission to the file and the directory contain
     </message>
     <message>
         <source>FDBK</source>
-        <translation>ZP. VAZBA</translation>
+        <translation>FDBK</translation>
     </message>
     <message>
         <source>NOISE</source>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -1030,7 +1030,7 @@ Wenn Sie daran interessiert sind LMMS in eine andere Sprache zu übersetzen oder
     </message>
     <message>
         <source>DELAY</source>
-        <translation>VERZÖGERUNG</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>FDBK</source>
@@ -2164,7 +2164,7 @@ Please make sure you have write permission to the file and the directory contain
     </message>
     <message>
         <source>DELAY</source>
-        <translation>VERZÖGERUNG</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>RATE</source>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -700,11 +700,11 @@ Si te interesa traducir LMMS a otros idiomas o mejorar las traducciones existent
     <name>BitcrushControlDialog</name>
     <message>
         <source>IN</source>
-        <translation>ENTRADA</translation>
+        <translation>IN</translation>
     </message>
     <message>
         <source>OUT</source>
-        <translation>SALIDA</translation>
+        <translation>OUT</translation>
     </message>
     <message>
         <source>GAIN</source>
@@ -728,7 +728,7 @@ Si te interesa traducir LMMS a otros idiomas o mejorar las traducciones existent
     </message>
     <message>
         <source>CLIP</source>
-        <translation>RECORTE</translation>
+        <translation>CLIP</translation>
     </message>
     <message>
         <source>Output Clip:</source>
@@ -1031,7 +1031,7 @@ Si te interesa traducir LMMS a otros idiomas o mejorar las traducciones existent
     </message>
     <message>
         <source>DELAY</source>
-        <translation>RETRASO</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>FDBK</source>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -1218,7 +1218,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     </message>
     <message>
         <source>DECAY</source>
-        <translation type="unfinished">محو-DECAY</translation>
+        <translation type="unfinished">DECAY</translation>
     </message>
     <message>
         <source>Time:</source>
@@ -1360,7 +1360,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     </message>
     <message>
         <source>HOLD</source>
-        <translation type="unfinished">نگهداری-HOLD</translation>
+        <translation type="unfinished">HOLD</translation>
     </message>
     <message>
         <source>Hold:</source>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -699,11 +699,11 @@ Si vous êtes intéressé par la traduction de LMMS dans une nouvelle langue ou 
     <name>BitcrushControlDialog</name>
     <message>
         <source>IN</source>
-        <translation>ENTRÉE</translation>
+        <translation>IN</translation>
     </message>
     <message>
         <source>OUT</source>
-        <translation>SORTIE</translation>
+        <translation>OUT</translation>
     </message>
     <message>
         <source>GAIN</source>
@@ -2173,7 +2173,7 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture à ce fic
     </message>
     <message>
         <source>DELAY</source>
-        <translation>DE RETARD</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>RATE</source>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -1468,7 +1468,7 @@ Ao premer co botón dereito aparece un menú de contexto no que se pode cambiar 
     <name>EnvelopeAndLfoView</name>
     <message>
         <source>DEL</source>
-        <translation>TMP REV</translation>
+        <translation>DEL</translation>
     </message>
     <message>
         <source>Predelay:</source>
@@ -1540,7 +1540,7 @@ Ao premer co botón dereito aparece un menú de contexto no que se pode cambiar 
     </message>
     <message>
         <source>AMT</source>
-        <translation>CANTIDADE</translation>
+        <translation>AMT</translation>
     </message>
     <message>
         <source>Modulation amount:</source>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -1033,7 +1033,7 @@ Se sei interessato a tradurre LMMS o vuoi migliorare una traduzione esistente, s
     </message>
     <message>
         <source>DELAY</source>
-        <translation>RITARDO</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>FDBK</source>
@@ -1041,7 +1041,7 @@ Se sei interessato a tradurre LMMS o vuoi migliorare una traduzione esistente, s
     </message>
     <message>
         <source>RATE</source>
-        <translation>FREQUENZA</translation>
+        <translation>RATE</translation>
     </message>
     <message>
         <source>AMNT</source>
@@ -2168,11 +2168,11 @@ Si prega di controllare i permessi di scrittura sul file e la cartella che lo co
     </message>
     <message>
         <source>DELAY</source>
-        <translation>RITARDO</translation>
+        <translation>DELAY</translation>
     </message>
     <message>
         <source>RATE</source>
-        <translation>FREQUENZA</translation>
+        <translation>RATE</translation>
     </message>
     <message>
         <source>Rate:</source>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3277,7 +3277,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>PAN</source>
-        <translation>パニング</translation>
+        <translation>PAN</translation>
     </message>
     <message>
         <source>MIDI</source>
@@ -5984,7 +5984,7 @@ Reason: &quot;%2&quot;</source>
     </message>
     <message>
         <source>PAN</source>
-        <translation>パニング</translation>
+        <translation>PAN</translation>
     </message>
 </context>
 <context>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -80,7 +80,7 @@ Esteban Viveros</translation>
     </message>
     <message>
         <source>LEFT</source>
-        <translation>ESQUERDA</translation>
+        <translation>LEFT</translation>
     </message>
     <message>
         <source>Left gain:</source>
@@ -88,7 +88,7 @@ Esteban Viveros</translation>
     </message>
     <message>
         <source>RIGHT</source>
-        <translation>DIREITA</translation>
+        <translation>RIGHT</translation>
     </message>
     <message>
         <source>Right gain:</source>
@@ -701,11 +701,11 @@ Esteban Viveros</translation>
     <name>BitcrushControlDialog</name>
     <message>
         <source>IN</source>
-        <translation>DENTRO</translation>
+        <translation>IN</translation>
     </message>
     <message>
         <source>OUT</source>
-        <translation>FORA</translation>
+        <translation>OUT</translation>
     </message>
     <message>
         <source>GAIN</source>
@@ -3000,7 +3000,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>VELOCITY</source>
-        <translation>INTENSIDADE</translation>
+        <translation>VELOCITY</translation>
     </message>
     <message>
         <source>ENABLE MIDI OUTPUT</source>
@@ -7776,7 +7776,7 @@ Por favor certifique-se que você tem permissões de leitura para o arquivo e pa
     </message>
     <message>
         <source>RELEASE</source>
-        <translation>LANÇAMENTO</translation>
+        <translation>RELEASE</translation>
     </message>
     <message>
         <source>Peak release time:</source>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -703,11 +703,11 @@ Oe Ai &lt;oeai/at/symbiants/dot/com&gt;</translation>
     <name>BitcrushControlDialog</name>
     <message>
         <source>IN</source>
-        <translation>ВХОД</translation>
+        <translation>IN</translation>
     </message>
     <message>
         <source>OUT</source>
-        <translation>ВЫХОД</translation>
+        <translation>OUT</translation>
     </message>
     <message>
         <source>GAIN</source>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -1063,7 +1063,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     </message>
     <message>
         <source>FREQ</source>
-        <translation>FREKV.</translation>
+        <translation>FREQ</translation>
     </message>
     <message>
         <source>Cutoff frequency</source>
@@ -1443,7 +1443,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     </message>
     <message>
         <source>Freq x 100</source>
-        <translation>Frekv. x 100</translation>
+        <translation>Freq x 100</translation>
     </message>
     <message>
         <source>Modulate Env-Amount</source>
@@ -1454,7 +1454,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     <name>EnvelopeAndLfoView</name>
     <message>
         <source>DEL</source>
-        <translation>RADERA</translation>
+        <translation>DEL</translation>
     </message>
     <message>
         <source>Predelay:</source>
@@ -1526,7 +1526,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     </message>
     <message>
         <source>AMT</source>
-        <translation>MÄNGD</translation>
+        <translation>AMT</translation>
     </message>
     <message>
         <source>Modulation amount:</source>
@@ -1590,7 +1590,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     </message>
     <message>
         <source>FREQ x 100</source>
-        <translation>FREKV. x 100</translation>
+        <translation>FREQ x 100</translation>
     </message>
     <message>
         <source>Click here if the frequency of this LFO should be multiplied by 100.</source>
@@ -1883,7 +1883,7 @@ Right clicking will bring up a context menu where you can change the order in wh
     </message>
     <message>
         <source>Freq: </source>
-        <translation>Frekv.:</translation>
+        <translation>Freq:</translation>
     </message>
 </context>
 <context>
@@ -3197,7 +3197,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>FREQ</source>
-        <translation>FREKV.</translation>
+        <translation>FREQ</translation>
     </message>
     <message>
         <source>cutoff frequency:</source>
@@ -3275,7 +3275,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>PAN</source>
-        <translation>PANORERA</translation>
+        <translation>PAN</translation>
     </message>
     <message>
         <source>MIDI</source>
@@ -3322,7 +3322,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>PAN</source>
-        <translation>PANORERA</translation>
+        <translation>PAN</translation>
     </message>
     <message>
         <source>Pitch</source>
@@ -5982,14 +5982,14 @@ Orsak: &quot;%2&quot;</translation>
     </message>
     <message>
         <source>PAN</source>
-        <translation>PANORERA</translation>
+        <translation>PAN</translation>
     </message>
 </context>
 <context>
     <name>SetupDialog</name>
     <message>
         <source>Setup LMMS</source>
-        <translation>Ställ in LMMS</translation>
+        <translation>Inställningar</translation>
     </message>
     <message>
         <source>General settings</source>
@@ -6077,7 +6077,7 @@ Orsak: &quot;%2&quot;</translation>
     </message>
     <message>
         <source>STK rawwave directory</source>
-        <translation>Katalog för STK rå-vågform</translation>
+        <translation>Katalog för STK vågformer</translation>
     </message>
     <message>
         <source>Default Soundfont File</source>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -1341,7 +1341,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     </message>
     <message>
         <source>DECAY</source>
-        <translation>ЗГАСАННЯ</translation>
+        <translation>DECAY</translation>
     </message>
     <message>
         <source>Time:</source>


### PR DESCRIPTION
Many translations seem to have been done without verifying against a compiled version of lmms. Maybe on the Transifex online editor. Especially the instrument pluggin editor and the native instruments/effects has many short terms and acronyms that must stay short or the layout will go south. I've gone through all translation files and reverted the worst cases. It may be that my machine won't show all problematic translations so a second pair of eyes would be nice here.
Fixes https://github.com/LMMS/lmms/issues/4436
Fixes https://github.com/LMMS/lmms/issues/4285

PS. I've also fixed up some general issues in the Swedish translation.