### PR TITLE
InstrumentFunctions - Arpeggiator code refactoring

### DIFF
--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -349,8 +349,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		return;
 	}
 
-	// Set master note to prevent the note to extend over skipped notes
-	// This may only be needed for lb302
+	// Set master note if not playing arp note or it will play as an ordinary note
 	_n->setMasterNote();
 
 	const int selected_arp = m_arpModel.value();

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -349,8 +349,8 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		return;
 	}
 
-	// make sure note is handled as arp-base-note, even
-	// if we didn't add a sub-note so far
+	// Set master note to prevent the note to extend over skipped notes
+	// This may only be needed for lb302
 	_n->setMasterNote();
 
 	const int selected_arp = m_arpModel.value();

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -349,6 +349,9 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		return;
 	}
 
+	// make sure note is handled as arp-base-note, even
+	// if we didn't add a sub-note so far
+	_n->setMasterNote();
 
 	const int selected_arp = m_arpModel.value();
 
@@ -401,8 +404,6 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		if( m_arpModeModel.value() == SortMode &&
 				( ( cur_frame / arp_frames ) % total_range ) / range != (f_cnt_t) _n->index() )
 		{
-			// Set master note if not playing arp note or it will play as an ordinary note
-			_n->setMasterNote();
 			// update counters
 			frames_processed += arp_frames;
 			cur_frame += arp_frames;
@@ -414,9 +415,6 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		{
 			if( 100 * ( (float) rand() / (float)( RAND_MAX + 1.0f ) ) < m_arpSkipModel.value() )
 			{
-				// Set master note to prevent the note to extend over skipped notes
-				// This may only be needed for lb302
-				_n->setMasterNote();
 				// update counters
 				frames_processed += arp_frames;
 				cur_frame += arp_frames;
@@ -516,13 +514,6 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		// update counters
 		frames_processed += arp_frames;
 		cur_frame += arp_frames;
-	}
-
-	// make sure note is handled as arp-base-note, even
-	// if we didn't add a sub-note so far
-	if( m_arpModeModel.value() != FreeMode )
-	{
-		_n->setMasterNote();
 	}
 }
 


### PR DESCRIPTION
When I was fixing #3342 I failed to document some parts of the code that was based on earlier lmms code.

[This part](https://github.com/LMMS/lmms/blob/3cf2afd8312252a0f1842cda25d81c064ed84beb/src/core/InstrumentFunctions.cpp#L521:L526)
```
	// make sure note is handled as arp-base-note, even
	// if we didn't add a sub-note so far
	if( m_arpModeModel.value() != FreeMode )
	{
		_n->setMasterNote();
	}
```

[...was based on this earlier snippet](https://github.com/LMMS/lmms/blob/c7e7748bc3bef0ece230e0dd8fd8daac8b335ded/src/core/InstrumentFunctions.cpp#L502:L507)
```
	// make sure, note is handled as arp-base-note, even if we didn't add a
	// sub-note so far
	if( m_arpModeModel.value() != FreeMode )
	{
		_n->setPartOfArpeggio( true );
	}
```
...which had been removed in 6650dd356dbdd08739ad69153b0c7020e39787b9 and this introduced issues in the arpeggiator.

While working on the PR I remember vaguely thinking that I should probably research the reason for excluding FreeMode in the earlier code but it kind of slipped into oblivion. I still haven't done that but I've tried and remove the test and it works just fine. It also simplifies the code. Basically we call `setMasterNote()` as soon as possible in `InstrumentFunctionArpeggio::processNote()`  and then we're done. It's a one-liner.

