### PR TITLE
Don't use dummy controllers for connections if not loading projects

### DIFF
--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -121,9 +121,6 @@ void LadspaEffect::changeSampleRate()
 	// the IDs of re-created controls have been saved and now need to be
 	// resolved again
 	AutomationPattern::resolveAllIDs();
-
-	// make sure, connections are ok
-	ControllerConnection::finalizeConnections();
 }
 
 

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -645,8 +645,6 @@ void ZynAddSubFxView::toggleUI()
 			connect( model->m_remotePlugin, SIGNAL( clickedCloseButton() ),
 						m_toggleUIButton, SLOT( toggle() ) );
 		}
-
-		ControllerConnection::finalizeConnections();
 	}
 }
 

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -204,16 +204,22 @@ void ControllerConnection::loadSettings( const QDomElement & _this )
 	}
 	else
 	{
-		if( _this.attribute( "id", "-1" ).toInt() >= 0 )
-		{
-			m_controllerId = _this.attribute( "id" ).toInt();
-		}
-		else
+		m_controllerId = _this.attribute( "id", "-1" ).toInt();
+		if( m_controllerId < 0 )
 		{
 			qWarning( "controller index invalid\n" );
 			m_controllerId = -1;
 		}
-		m_controller = Controller::create( Controller::DummyController, NULL );
+
+		if (!Engine::getSong()->isLoadingProject() && m_controllerId != -1)
+		{
+			setController( Engine::getSong()->
+					controllers().at( m_controllerId ) );
+		}
+		else
+		{
+			m_controller = Controller::create( Controller::DummyController, NULL );
+		}
 	}
 }
 


### PR DESCRIPTION
Finalize connections instead of using dummy controllers in `loadSettings` if not loading projects.
Remove the need of `ControllerConnection::finalizeConnections` when not loading projects.
Fixes #4484.