### PR TITLE
Fix invisible editors on project load by validating size

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -802,7 +802,10 @@ void MainWindow::restoreWidgetState( QWidget * _w, const QDomElement & _de )
 		// first restore the window, as attempting to resize a maximized window causes graphics glitching
 		_w->setWindowState( _w->windowState() & ~(Qt::WindowMaximized | Qt::WindowMinimized) );
 
-		_w->resize( r.size() );
+		// Check isEmpty() to work around corrupt project files with empty size
+		if ( ! r.size().isEmpty() ) {
+			_w->resize( r.size() );
+		}
 		_w->move( r.topLeft() );
 
 		// set the window to its correct minimized/maximized/restored state


### PR DESCRIPTION
Validate an editor's size when loading and ignore it if it's empty. Fixes #4270. This only fixes the symptom, not the cause. I don't know why a project file with a zero size would be created in the first place, but I'm not sure if it's really worth investigating.