### PR TITLE
MIDI import: Reset the seek pointer after parsing magic bytes.

### DIFF
--- a/include/ImportFilter.h
+++ b/include/ImportFilter.h
@@ -73,6 +73,11 @@ protected:
 		return -1;
 	}
 
+	inline void resetReadPosition()
+	{
+		m_file.seek(0);
+	}
+
 	inline int readBlock( char * _data, int _len )
 	{
 		return m_file.read( _data, _len );

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -127,7 +127,11 @@ bool MidiImport::tryImport( TrackContainer* tc )
 	}
 #endif
 
-	switch( readID() )
+	auto id = readID();
+	// Reset the seek pointer on the file so the subsequent routines
+	// don't choke when trying to read the first 4 bytes again.
+	resetReadPosition();
+	switch( id )
 	{
 		case makeID( 'M', 'T', 'h', 'd' ):
 			printf( "MidiImport::tryImport(): found MThd\n");


### PR DESCRIPTION
Fixes a silent bug that prevented any and all SMF midi import due to the Alg_midifile_reader's parse() function erroneously reading bytes 4 to 7 instead of 0 to 3.