### PR TITLE
MSVC: Fix SID

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -94,9 +94,7 @@ IF(MSVC)
 		monstro
 		organic
 		ReverbSC
-		sid
 		vibed
-		#VstEffect
 		Xpressive
 		zynaddsubfx
 	)

--- a/plugins/sid/sid_instrument.cpp
+++ b/plugins/sid/sid_instrument.cpp
@@ -324,7 +324,7 @@ void sidInstrument::playNote( NotePlayHandle * _n,
 
 	cSID *sid = static_cast<cSID *>( _n->m_pluginData );
 	int delta_t = clockrate * frames / samplerate + 4;
-	short buf[frames];
+	short* buf = reinterpret_cast<short*>(_working_buffer + offset);
 	unsigned char sidreg[NUMSIDREGS];
 
 	for (int c = 0; c < NUMSIDREGS; c++)
@@ -429,7 +429,7 @@ void sidInstrument::playNote( NotePlayHandle * _n,
 	if(num!=frames)
 		printf("!!!Not enough samples\n");
 
-	for( fpp_t frame = 0; frame < frames; ++frame )
+	for( fpp_t frame = frames - 1; frame >= 0; frame-- )
 	{
 		sample_t s = float(buf[frame])/32768.0;
 		for( ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch )


### PR DESCRIPTION
Fixes SID for MSVC by using the provided working buffer instead of a local one to avoid the use of VLA. Changed the loop to go backwards to avoid overwriting data in the short-to-float conversion. Hope this logic is correct (it appears to sound right).