### PR TITLE
Knob: Shortcut automation

### DIFF
--- a/include/AutoDetectMidiController.h
+++ b/include/AutoDetectMidiController.h
@@ -1,0 +1,64 @@
+/*
+ * AutoDetectMidiController.h - says from which controller last event is
+ *
+ * Copyright (c) 2008 Paul Giblock <drfaygo/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef AUTO_DETECT_MIDI_CONTROLLER_H
+#define AUTO_DETECT_MIDI_CONTROLLER_H
+
+#include <QString>
+
+#include "MidiController.h"
+#include "MidiClient.h"
+#include "MidiTime.h"
+
+
+class AutoDetectMidiController : public MidiController
+{
+	Q_OBJECT
+public:
+	AutoDetectMidiController( Model* parent );
+
+	virtual ~AutoDetectMidiController();
+
+	virtual void processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset = 0 );
+
+	MidiController* copyToMidiController( Model* parent );
+
+	void useDetected();
+
+
+public slots:
+	void reset();
+
+
+private:
+	int m_detectedMidiChannel;
+	int m_detectedMidiController;
+	QString m_detectedMidiPort;
+
+	friend class ControllerRackView;
+
+} ;
+
+#endif

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -261,6 +261,14 @@ public:
 		s_periodCounter = 0;
 	}
 
+	void setAutoRecordToggle( bool value );
+
+	void setRecording( bool value );
+
+	void setRecordingWhereToggleIsAuto( bool value );
+
+	void automate();
+
 public slots:
 	virtual void reset();
 	void unlinkControllerConnection();

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -92,6 +92,9 @@ public slots:
 	void editSongGlobalAutomation();
 	void unlinkAllModels();
 	void removeSongGlobalAutomation();
+	void recordingOff();
+	void recordingOn();
+	void automate();
 
 private slots:
 	/// Copy the model's value to the clipboard.

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -173,6 +173,7 @@ public:
 
 	bool isControlled() const;
 	void connectController( ControllerConnection * cc );
+	void disconnectController();
 
 public slots:
 	void clear();

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -155,7 +155,18 @@ public:
 	static void resolveAllIDs();
 
 	bool isRecording() const { return m_isRecording; }
-	void setRecording( const bool b ) { m_isRecording = b; }
+	void setRecording( const bool b )
+	{
+		m_isRecording = b;
+		emit dataChanged();
+	}
+
+	bool autoRecordToggle() const { return m_autoRecordToggle; }
+	void setAutoRecordToggle( const bool b )
+	{
+		m_autoRecordToggle = b;
+		emit dataChanged();
+	}
 
 	static int quantization() { return s_quantization; }
 	static void setQuantization(int q) { s_quantization = q; }
@@ -187,6 +198,7 @@ private:
 	
 	bool m_isRecording;
 	float m_lastRecordedValue;
+	bool m_autoRecordToggle;
 
 	static int s_quantization;
 

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -171,6 +171,9 @@ public:
 	static int quantization() { return s_quantization; }
 	static void setQuantization(int q) { s_quantization = q; }
 
+	bool isControlled() const;
+	void connectController( ControllerConnection * cc );
+
 public slots:
 	void clear();
 	void objectDestroyed( jo_id_t );

--- a/include/AutomationPatternView.h
+++ b/include/AutomationPatternView.h
@@ -51,6 +51,7 @@ protected slots:
 	void resetName();
 	void changeName();
 	void disconnectObject( QAction * _a );
+	void autoRecordToggle();
 	void toggleRecording();
 	void flipY();
 	void flipX();

--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -31,14 +31,14 @@
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
 
-#include "Controller.h"
+#include "AutoDetectMidiController.h"
 #include "AutomatableModel.h"
+#include "Controller.h"
 
 
 class QLineEdit;
 class QListView;
 class QScrollArea;
-class AutoDetectMidiController;
 class ComboBox;
 class GroupBox;
 class TabWidget;

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -68,6 +68,8 @@ protected:
 private slots:
 	void addController();
 	void connectUncontrolledAutomationTrack();
+	void disconnectAutomation();
+	void resetAutoConnect();
 
 
 private:

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -30,6 +30,7 @@
 
 #include "SerializingObject.h"
 #include "lmms_basics.h"
+#include "AutoDetectMidiController.h"
 
 
 class QPushButton;
@@ -66,6 +67,7 @@ protected:
 
 private slots:
 	void addController();
+	void connectUncontrolledAutomationTrack();
 
 
 private:
@@ -74,6 +76,9 @@ private:
 	QScrollArea * m_scrollArea;
 	QVBoxLayout * m_scrollAreaLayout;
 	QPushButton * m_addButton;
+
+	BoolModel m_autoConnect;
+	AutoDetectMidiController * m_midiController;
 
 	// Stores the index of where to insert the next ControllerView.
 	// Needed so that the StretchItem always stays at the last position.

--- a/include/EffectControlDialog.h
+++ b/include/EffectControlDialog.h
@@ -50,6 +50,9 @@ protected:
 
 	EffectControls * m_effectControls;
 
+private slots:
+	void updateTitle();
+
 } ;
 
 #endif

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -58,6 +58,7 @@ public:
 
 	// Used by controllerConnectionDialog to copy
 	void subscribeReadablePorts( const MidiPort::Map & _map );
+	void setPortName( QString displayName );
 
 
 public slots:

--- a/src/core/AutoDetectMidiController.cpp
+++ b/src/core/AutoDetectMidiController.cpp
@@ -1,0 +1,103 @@
+/*
+ * AutoDetectMidiController.cpp - says from which controller last event is
+ *
+ * Copyright (c) 2008 Paul Giblock <drfaygo/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "AutoDetectMidiController.h"
+#include "MidiController.h"
+#include "MidiEvent.h"
+#include "MidiPort.h"
+#include "MidiTime.h"
+#include "Mixer.h"
+#include "Model.h"
+
+
+AutoDetectMidiController::AutoDetectMidiController( Model* parent ) :
+	MidiController( parent ),
+	m_detectedMidiChannel( 0 ),
+	m_detectedMidiController( 0 )
+{
+	updateName();
+
+	MidiPort::Map map = m_midiPort.readablePorts();
+
+	for( MidiPort::Map::Iterator it = map.begin(); it != map.end(); ++it )
+	{
+		it.value() = true;
+	}
+
+	subscribeReadablePorts( map );
+}
+
+
+AutoDetectMidiController::~AutoDetectMidiController()
+{
+}
+
+
+void AutoDetectMidiController::processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+{
+	if( event.type() == MidiControlChange &&
+		( m_midiPort.inputChannel() == 0 || m_midiPort.inputChannel() == event.channel() + 1 ) )
+	{
+		m_detectedMidiChannel = event.channel() + 1;
+		m_detectedMidiController = event.controllerNumber() + 1;
+		m_detectedMidiPort = Engine::mixer()->midiClient()->sourcePortName( event );
+
+		emit valueChanged();
+	}
+}
+
+
+// Would be a nice copy ctor, but too hard to add copy ctor because
+// model has none.
+MidiController* AutoDetectMidiController::copyToMidiController( Model* parent )
+{
+	MidiController* c = new MidiController( parent );
+	c->m_midiPort.setInputChannel( m_midiPort.inputChannel() );
+	c->m_midiPort.setInputController( m_midiPort.inputController() );
+	c->subscribeReadablePorts( m_midiPort.readablePorts() );
+	c->updateName();
+
+	return c;
+}
+
+
+void AutoDetectMidiController::useDetected()
+{
+	m_midiPort.setInputChannel( m_detectedMidiChannel );
+	m_midiPort.setInputController( m_detectedMidiController );
+
+	const MidiPort::Map& map = m_midiPort.readablePorts();
+	for( MidiPort::Map::ConstIterator it = map.begin(); it != map.end(); ++it )
+	{
+		m_midiPort.subscribeReadablePort( it.key(),
+						m_detectedMidiPort.isEmpty() || ( it.key() == m_detectedMidiPort ) );
+	}
+}
+
+
+void AutoDetectMidiController::reset()
+{
+	m_midiPort.setInputChannel( 0 );
+	m_midiPort.setInputController( 0 );
+}

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -722,6 +722,11 @@ void AutomatableModel::setRecordingWhereToggleIsAuto( bool value )
 
 void AutomatableModel::automate()
 {
+	if( isAutomated() )
+	{
+		return;
+	}
+
 	AutomationTrack *track = nullptr;
 	TrackContainer::TrackList l = Engine::getSong()->tracks();
 
@@ -751,6 +756,7 @@ void AutomatableModel::automate()
 	AutomationPattern *pattern = new AutomationPattern( track );
 	pattern->changeLength( MidiTime( Engine::getSong()->length(), 0 ) );
 	pattern->addObject( this );
+	pattern->setRecording( true );
 	QString patternName = pattern->name();
 
 	// shorten to fit meaning in default grid

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -882,4 +882,31 @@ void AutomationPattern::generateTangents( timeMap::const_iterator it,
 
 
 
+bool AutomationPattern::isControlled() const
+{
+	for( objectVector::const_iterator it = m_objects.begin();
+			it != m_objects.end(); ++it )
+	{
+		if( *it && ( *it )->controllerConnection() )
+		{
+			return true;
+		}
+	}
 
+	return false;
+}
+
+
+
+
+void AutomationPattern::connectController( ControllerConnection * cc )
+{
+	for( objectVector::iterator it = m_objects.begin();
+			it != m_objects.end(); ++it )
+	{
+		if( *it )
+		{
+			( * it )->setControllerConnection( cc );
+		}
+	}
+}

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -28,6 +28,7 @@
 
 #include "AutomationPatternView.h"
 #include "AutomationTrack.h"
+#include "ControllerConnection.h"
 #include "Note.h"
 #include "ProjectJournal.h"
 #include "BBTrackContainer.h"
@@ -907,6 +908,24 @@ void AutomationPattern::connectController( ControllerConnection * cc )
 		if( *it )
 		{
 			( * it )->setControllerConnection( cc );
+			( * it )->setRecording( true );
+		}
+	}
+}
+
+
+
+
+void AutomationPattern::disconnectController()
+{
+	for( objectVector::iterator it = m_objects.begin();
+			it != m_objects.end(); ++it )
+	{
+		if( *it && ( * it )->controllerConnection() )
+		{
+			delete ( * it )->controllerConnection();
+			( * it )->setControllerConnection( NULL );
+			( * it )->setRecording( false );
 		}
 	}
 }

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -48,7 +48,8 @@ AutomationPattern::AutomationPattern( AutomationTrack * _auto_track ) :
 	m_progressionType( DiscreteProgression ),
 	m_dragging( false ),
 	m_isRecording( false ),
-	m_lastRecordedValue( 0 )
+	m_lastRecordedValue( 0 ),
+	m_autoRecordToggle( true )
 {
 	changeLength( MidiTime( 1, 0 ) );
 	if( getTrack() )

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(LMMS_SRCS
 	${LMMS_SRCS}
+	core/AutoDetectMidiController.cpp
 	core/AutomatableModel.cpp
 	core/AutomationPattern.cpp
 	core/BandLimitedWave.cpp

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -29,6 +29,8 @@
 #include "EffectChain.h"
 #include "Effect.h"
 #include "DummyEffect.h"
+#include "Engine.h"
+#include "FxMixer.h"
 #include "MixHelpers.h"
 #include "Song.h"
 

--- a/src/core/Model.cpp
+++ b/src/core/Model.cpp
@@ -23,11 +23,32 @@
  */
 
 #include "Model.h"
+#include "Effect.h"
+#include "EffectChain.h"
+#include "Engine.h"
+#include "FxMixer.h"
 
 
 QString Model::fullDisplayName() const
 {
 	const QString & n = displayName();
+	const Effect *effect = dynamic_cast<const Effect *>( this );
+	if( effect )
+	{
+		EffectChain *chain = effect->effectChain();
+		FxMixer *mixer = Engine::fxMixer();
+		fx_ch_t numChannels = mixer->numChannels();
+
+		for( int i = 0; i < numChannels; ++i)
+		{
+			FxChannel *channel = mixer->effectChannel( i );
+
+			if( &channel->m_fxChain == chain )
+			{
+				return channel->m_name + ">" + n;
+			}
+		}
+	}
 	if( parentModel() ) 
 	{
 		const QString p = parentModel()->fullDisplayName();

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1931,8 +1931,12 @@ void TrackOperationsWidget::updateMenu()
 	}
 	if( dynamic_cast<AutomationTrackView *>( m_trackView ) )
 	{
-		toMenu->addAction( tr( "Turn all recording on" ), this, SLOT( recordingOn() ) );
-		toMenu->addAction( tr( "Turn all recording off" ), this, SLOT( recordingOff() ) );
+		toMenu->addAction( tr( "Turn all recording on" ) +
+							" / " + tr( "Disable auto toggle" ),
+							this, SLOT( recordingOn() ) );
+		toMenu->addAction( tr( "Turn all recording off" ) +
+							" / " + tr( "Enable auto toggle" ),
+							this, SLOT( recordingOff() ) );
 	}
 }
 
@@ -1945,9 +1949,11 @@ void TrackOperationsWidget::toggleRecording( bool on )
 		for( TrackContentObject * tco : atv->getTrack()->getTCOs() )
 		{
 			AutomationPattern * ap = dynamic_cast<AutomationPattern *>( tco );
-			if( ap ) { ap->setRecording( on ); }
+			if( ap ) {
+				ap->setAutoRecordToggle ( !on );
+				ap->setRecording( on );
+			}
 		}
-		atv->update();
 	}
 }
 

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -150,6 +150,14 @@ QString MidiController::nodeName() const
 
 
 
+void MidiController::setPortName( QString displayName )
+{
+	m_midiPort.setName( displayName );
+}
+
+
+
+
 ControllerDialog * MidiController::createDialog( QWidget * _parent )
 {
 	return NULL;

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -94,11 +94,34 @@ void AutomatableModelView::addDefaultActions( QMenu* menu )
 
 	if( model->hasLinkedModels() )
 	{
-		menu->addAction( embed::getIconPixmap( "edit-delete" ),
+		menu->addAction( embed::getIconPixmap( "edit_erase" ),
 							AutomatableModel::tr( "Remove all linked controls" ),
 							amvSlots, SLOT( unlinkAllModels() ) );
+
 		menu->addSeparator();
 	}
+
+	if( model->isAutomated() )
+	{
+		menu->addAction( embed::getIconPixmap( "record" ),
+							AutomatableModel::tr( "Turn all recording on" ) +
+							" / " + AutomatableModel::tr( "Disable auto toggle" ),
+							amvSlots, SLOT( recordingOn() ) );
+
+		menu->addAction( QPixmap(),
+							AutomatableModel::tr( "Turn all recording off" ) +
+							" / " + AutomatableModel::tr( "Enable auto toggle" ),
+							amvSlots, SLOT( recordingOff() ) );
+
+	}
+	else
+	{
+		menu->addAction( embed::getIconPixmap( "record" ),
+							AutomatableModel::tr( "Add automation-track" ),
+							amvSlots, SLOT( automate() ) );
+	}
+
+	menu->addSeparator();
 
 	QString controllerTxt;
 	if( model->controllerConnection() )
@@ -235,6 +258,8 @@ void AutomatableModelViewSlots::removeSongGlobalAutomation()
 }
 
 
+
+
 void AutomatableModelViewSlots::unlinkAllModels()
 {
 	m_amv->modelUntyped()->unlinkAllModels();
@@ -262,4 +287,30 @@ static float floatFromClipboard(bool* ok)
 	const QClipboard* clipboard = QApplication::clipboard();
 	return clipboard->text().toFloat(ok);
 }
+
+
+void AutomatableModelViewSlots::recordingOn()
+{
+	m_amv->modelUntyped()->setAutoRecordToggle( false );
+	m_amv->modelUntyped()->setRecording( true );
+}
+
+
+
+
+void AutomatableModelViewSlots::recordingOff()
+{
+	m_amv->modelUntyped()->setAutoRecordToggle( true );
+	m_amv->modelUntyped()->setRecording( false );
+}
+
+
+
+
+void AutomatableModelViewSlots::automate()
+{
+	m_amv->modelUntyped()->automate();
+}
+
+
 

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -142,7 +142,13 @@ void AutomationPatternView::disconnectObject( QAction * _a )
 void AutomationPatternView::toggleRecording()
 {
 	m_pat->setRecording( ! m_pat->isRecording() );
-	update();
+	m_pat->setAutoRecordToggle( false );
+}
+
+
+void AutomationPatternView::autoRecordToggle()
+{
+	m_pat->setAutoRecordToggle( true );
 }
 
 
@@ -185,9 +191,26 @@ void AutomationPatternView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "edit_rename" ),
 						tr( "Change name" ),
 						this, SLOT( changeName() ) );
-	_cm->addAction( embed::getIconPixmap( "record" ),
-						tr( "Set/clear record" ),
-						this, SLOT( toggleRecording() ) );
+	_cm->addSeparator();
+
+	if( m_pat->autoRecordToggle() )
+	{
+		_cm->addAction( embed::getIconPixmap( "record" ),
+							tr( "Set/clear record" ) +
+							" / " + tr( "Disable auto toggle" ),
+							this, SLOT( toggleRecording() ) );
+	}
+	else
+	{
+		_cm->addAction( embed::getIconPixmap( "record" ),
+							tr( "Set/clear record" ),
+							this, SLOT( toggleRecording() ) );
+		_cm->addAction( QPixmap(),
+							tr( "Enable auto toggle" ),
+							this, SLOT( autoRecordToggle() ) );
+	}
+	_cm->addSeparator();
+
 	_cm->addAction( embed::getIconPixmap( "flip_y" ),
 						tr( "Flip Vertically (Visible)" ),
 						this, SLOT( flipY() ) );

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -28,6 +28,8 @@
 
 #include "EffectControlDialog.h"
 #include "EffectControls.h"
+#include "Engine.h"
+#include "Song.h"
 
 
 EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
@@ -35,7 +37,10 @@ EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
 	ModelView( _controls, this ),
 	m_effectControls( _controls )
 {
-	setWindowTitle( m_effectControls->effect()->displayName() );
+	updateTitle();
+
+	connect( Engine::getSong(), SIGNAL( dataChanged() ),
+				this, SLOT( updateTitle() ) );
 }
 
 
@@ -52,6 +57,14 @@ void EffectControlDialog::closeEvent( QCloseEvent * _ce )
 {
 	_ce->ignore();
 	emit closed();
+}
+
+
+
+
+void EffectControlDialog::updateTitle()
+{
+	setWindowTitle( m_effectControls->effect()->fullDisplayName() );
 }
 
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -267,7 +267,8 @@ void Fader::mouseReleaseEvent( QMouseEvent * mouseEvent )
 		{
 			thisModel->restoreJournallingState();
 
-			if( Engine::getSong()->isPlaying() )
+			if( Engine::getSong()->isPlaying() &&
+					!thisModel->controllerConnection() )
 			{
 				thisModel->setRecordingWhereToggleIsAuto( false );
 			}

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -54,6 +54,7 @@
 #include "embed.h"
 #include "CaptionMenu.h"
 #include "ConfigManager.h"
+#include "Song.h"
 #include "TextFloat.h"
 #include "MainWindow.h"
 
@@ -187,6 +188,17 @@ void Fader::mousePressEvent( QMouseEvent* mouseEvent )
 		{
 			thisModel->addJournalCheckPoint();
 			thisModel->saveJournallingState( false );
+
+			if( ( mouseEvent->modifiers() & Qt::AltModifier ) &&
+				!thisModel->isAutomated() )
+			{
+				thisModel->automate();
+			}
+
+			if( Engine::getSong()->isPlaying() )
+			{
+				thisModel->setRecordingWhereToggleIsAuto( true );
+			}
 		}
 
 		if( mouseEvent->y() >= knobPosY() - ( *m_knob ).height() && mouseEvent->y() < knobPosY() )
@@ -254,6 +266,11 @@ void Fader::mouseReleaseEvent( QMouseEvent * mouseEvent )
 		if( thisModel )
 		{
 			thisModel->restoreJournallingState();
+
+			if( Engine::getSong()->isPlaying() )
+			{
+				thisModel->setRecordingWhereToggleIsAuto( false );
+			}
 		}
 	}
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -655,7 +655,8 @@ void Knob::mouseReleaseEvent( QMouseEvent* event )
 		{
 			thisModel->restoreJournallingState();
 
-			if( Engine::getSong()->isPlaying() )
+			if( Engine::getSong()->isPlaying() &&
+					!thisModel->controllerConnection() )
 			{
 				thisModel->setRecordingWhereToggleIsAuto( false );
 			}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -588,6 +588,17 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 		{
 			thisModel->addJournalCheckPoint();
 			thisModel->saveJournallingState( false );
+
+			if( ( _me->modifiers() & Qt::AltModifier ) &&
+				!thisModel->isAutomated() )
+			{
+				thisModel->automate();
+			}
+
+			if( Engine::getSong()->isPlaying() )
+			{
+				thisModel->setRecordingWhereToggleIsAuto( true );
+			}
 		}
 
 		const QPoint & p = _me->pos();
@@ -643,6 +654,11 @@ void Knob::mouseReleaseEvent( QMouseEvent* event )
 		if( thisModel )
 		{
 			thisModel->restoreJournallingState();
+
+			if( Engine::getSong()->isPlaying() )
+			{
+				thisModel->setRecordingWhereToggleIsAuto( false );
+			}
 		}
 	}
 


### PR DESCRIPTION
Resolves #4485, implements all the enhancements I suggested.

Hold Alt, and drag a knob or a fader, to instantly add a meaningfully named automation-track (if no matching or empty automation-track exists) and start recording changes. Release mouse, and existing automation starts playing again without getting overwritten by a constant value.

You can still manually set/clear record. For example, this is handy when you want to indeed overwrite with a constant value, or to disable changes. Knob context menu then lets you re-enable auto toggle.

Also fixed icon for "Remove all linked controls" which is in the same menu.

Effect control window titles, as well as automation patterns in the song enditor, now include the channel name, to help you adjust same effect on different channels side by side.

Please review.