### PR TITLE
Make the oscilloscope colors available as properties

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -157,6 +157,9 @@ GroupBox {
 VisualizationWidget  {
 	background: none;
 	border: none;
+	qproperty-normalColor: rgb(71, 253, 133);
+	qproperty-warningColor: rgb(255, 192, 64);
+	qproperty-clippingColor: rgb(255, 64, 64);
 }
 
 /* main toolbar cpu load widget - this can have transparent bg now */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -176,6 +176,9 @@ GroupBox {
 VisualizationWidget  {
 	background: none;
 	border: none;
+	qproperty-normalColor: rgb(71, 253, 133);
+	qproperty-warningColor: rgb(255, 192, 64);
+	qproperty-clippingColor: rgb(255, 64, 64);
 }
 
 /* main toolbar cpu load widget - this can have transparent bg now */

--- a/include/VisualizationWidget.h
+++ b/include/VisualizationWidget.h
@@ -36,6 +36,9 @@ class VisualizationWidget : public QWidget
 {
 	Q_OBJECT
 public:
+	Q_PROPERTY( QColor normalColor READ normalColor WRITE setNormalColor )
+	Q_PROPERTY( QColor warningColor READ warningColor WRITE setWarningColor )
+	Q_PROPERTY( QColor clippingColor READ clippingColor WRITE setClippingColor )
 	enum visualizationTypes
 	{
 		Simple		// add more here
@@ -47,6 +50,15 @@ public:
 
 	void setActive( bool _active );
 
+	QColor const & normalColor() const;
+	void setNormalColor(QColor const & normalColor);
+
+	QColor const & warningColor() const;
+	void setWarningColor(QColor const & warningColor);
+
+	QColor const & clippingColor() const;
+	void setClippingColor(QColor const & clippingColor);
+
 
 protected:
 	virtual void paintEvent( QPaintEvent * _pe );
@@ -56,6 +68,8 @@ protected:
 protected slots:
 	void updateAudioBuffer( const surroundSampleFrame * buffer );
 
+private:
+	QColor const & determineLineColor(float level) const;
 
 private:
 	QPixmap s_background;
@@ -64,6 +78,9 @@ private:
 	sampleFrame * m_buffer;
 	bool m_active;
 
+	QColor m_normalColor;
+	QColor m_warningColor;
+	QColor m_clippingColor;
 } ;
 
 #endif

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -43,7 +43,10 @@ VisualizationWidget::VisualizationWidget( const QPixmap & _bg, QWidget * _p,
 	QWidget( _p ),
 	s_background( _bg ),
 	m_points( new QPointF[Engine::mixer()->framesPerPeriod()] ),
-	m_active( false )
+	m_active( false ),
+	m_normalColor(71, 253, 133),
+	m_warningColor(255, 192, 64),
+	m_clippingColor(255, 64, 64)
 {
 	setFixedSize( s_background.width(), s_background.height() );
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
@@ -110,6 +113,35 @@ void VisualizationWidget::setActive( bool _active )
 }
 
 
+QColor const & VisualizationWidget::normalColor() const
+{
+	return m_normalColor;
+}
+
+void VisualizationWidget::setNormalColor(QColor const & normalColor)
+{
+	m_normalColor = normalColor;
+}
+
+QColor const & VisualizationWidget::warningColor() const
+{
+	return m_warningColor;
+}
+
+void VisualizationWidget::setWarningColor(QColor const & warningColor)
+{
+	m_warningColor = warningColor;
+}
+
+QColor const & VisualizationWidget::clippingColor() const
+{
+	return m_clippingColor;
+}
+
+void VisualizationWidget::setClippingColor(QColor const & clippingColor)
+{
+	m_clippingColor = clippingColor;
+}
 
 
 void VisualizationWidget::paintEvent( QPaintEvent * )
@@ -123,13 +155,6 @@ void VisualizationWidget::paintEvent( QPaintEvent * )
 		Mixer const * mixer = Engine::mixer();
 
 		float master_output = mixer->masterGain();
-		int w = width()-4;
-		const float half_h = -( height() - 6 ) / 3.0 * master_output - 1;
-		int x_base = 2;
-		const float y_base = height()/2 - 0.5f;
-
-//		p.setClipRect( 2, 2, w, height()-4 );
-
 
 		const fpp_t frames = mixer->framesPerPeriod();
 		float peakLeft;
@@ -137,35 +162,27 @@ void VisualizationWidget::paintEvent( QPaintEvent * )
 		mixer->getPeakValues( m_buffer, frames, peakLeft, peakRight );
 		const float max_level = qMax<float>( peakLeft, peakRight );
 
-		// and set color according to that...
-		if( max_level * master_output < 0.9 )
-		{
-			p.setPen( QColor( 71, 253, 133 ) );
-		}
-		else if( max_level * master_output < 1.0 )
-		{
-			p.setPen( QColor( 255, 192, 64 ) );
-		}
-		else
-		{
-			p.setPen( QColor( 255, 64, 64 ) );
-		}
+		// Set the color of the line according to the maximum level
+		float const maxLevelWithAppliedMasterGain = max_level * master_output;
+		p.setPen(QPen(determineLineColor(maxLevelWithAppliedMasterGain), 0.7));
 
-		p.setPen( QPen( p.pen().color(), 0.7 ) );
-
-		const float xd = (float) w / frames;
 		p.setRenderHint( QPainter::Antialiasing );
 
 		// now draw all that stuff
+		int w = width() - 4;
+		const qreal xd = static_cast<qreal>(w) / frames;
+		const qreal half_h = -( height() - 6 ) / 3.0 * static_cast<qreal>(master_output) - 1;
+		int x_base = 2;
+		const qreal y_base = height() / 2 - 0.5;
+
 		for( ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch )
 		{
 			for( int frame = 0; frame < frames; ++frame )
 			{
+				sample_t const clippedSample = Mixer::clip(m_buffer[frame][ch]);
 				m_points[frame] = QPointF(
-					x_base + (float) frame * xd,
-					y_base + ( Mixer::clip(
-						m_buffer[frame][ch] ) *
-								half_h ) );
+					x_base + static_cast<qreal>(frame) * xd,
+					y_base + ( static_cast<qreal>(clippedSample) * half_h ) );
 			}
 			p.drawPolyline( m_points, frames );
 		}
@@ -190,7 +207,21 @@ void VisualizationWidget::mousePressEvent( QMouseEvent * _me )
 }
 
 
-
+QColor const & VisualizationWidget::determineLineColor(float level) const
+{
+	if( level < 0.9f )
+	{
+		return normalColor();
+	}
+	else if( level < 1.0f )
+	{
+		return warningColor();
+	}
+	else
+	{
+		return clippingColor();
+	}
+}
 
 
 


### PR DESCRIPTION
Fix #4459 by making the oscilloscope colors available as properties so that they can be changed via style sheets. Adjust the existing styles to use the colors that have been hard coded previously.

Cleanup the `paintEvent` method of `VisualizationWidget`, e.g. by extracting a method to determine the color to use for the line and by pulling variables to the place where they are used. Fix some Clang warnings.