### PR TITLE
Remove peak value references from Mixer::getPeakValues

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -273,7 +273,13 @@ public:
 	}
 
 
-	void getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & peakLeft, float & peakRight ) const;
+	struct StereoSample
+	{
+		StereoSample(sample_t _left, sample_t _right) : left(_left), right(_right) {}
+		sample_t left;
+		sample_t right;
+	};
+	StereoSample getPeakValues(sampleFrame * _ab, const f_cnt_t _frames) const;
 
 
 	bool criticalXRuns() const;

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -170,11 +170,9 @@ void FxChannel::doProcessing()
 
 		m_stillRunning = m_fxChain.processAudioBuffer( m_buffer, fpp, m_hasInput );
 
-		float peakLeft = 0.;
-		float peakRight = 0.;
-		Engine::mixer()->getPeakValues( m_buffer, fpp, peakLeft, peakRight );
-		m_peakLeft = qMax( m_peakLeft, peakLeft * v );
-		m_peakRight = qMax( m_peakRight, peakRight * v );
+		Mixer::StereoSample peakSamples = Engine::mixer()->getPeakValues(m_buffer, fpp);
+		m_peakLeft = qMax( m_peakLeft, peakSamples.left * v );
+		m_peakRight = qMax( m_peakRight, peakSamples.right * v );
 	}
 	else
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -534,10 +534,10 @@ void Mixer::clearInternal()
 
 
 
-void Mixer::getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & peakLeft, float & peakRight ) const
+Mixer::StereoSample Mixer::getPeakValues(sampleFrame * _ab, const f_cnt_t _frames) const
 {
-	peakLeft = 0.0f;
-	peakRight = 0.0f;
+	sample_t peakLeft = 0.0f;
+	sample_t peakRight = 0.0f;
 
 	for( f_cnt_t f = 0; f < _frames; ++f )
 	{
@@ -553,6 +553,8 @@ void Mixer::getPeakValues( sampleFrame * _ab, const f_cnt_t _frames, float & pea
 			peakRight = absRight;
 		}
 	}
+
+	return StereoSample(peakLeft, peakRight);
 }
 
 

--- a/src/gui/widgets/VisualizationWidget.cpp
+++ b/src/gui/widgets/VisualizationWidget.cpp
@@ -131,10 +131,8 @@ void VisualizationWidget::paintEvent( QPaintEvent * )
 
 
 		const fpp_t frames = mixer->framesPerPeriod();
-		float peakLeft;
-		float peakRight;
-		mixer->getPeakValues( m_buffer, frames, peakLeft, peakRight );
-		const float max_level = qMax<float>( peakLeft, peakRight );
+		Mixer::StereoSample peakValues = mixer->getPeakValues(m_buffer, frames);
+		const float max_level = qMax<float>( peakValues.left, peakValues.right );
 
 		// and set color according to that...
 		if( max_level * master_output < 0.9 )


### PR DESCRIPTION
Adjust `Mixer::getPeakValues` so client do not have to allocate the variables that will store the peak values.

Adjust both existing clients: `FxMixer` and `VisualizationWidget`.