### PR TITLE
Fix shim launcher

### DIFF
--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -55,6 +55,7 @@ echo -e "\nWriting verbose output to \"${LOGFILE}\""
 export PATH="$(pwd -P)/squashfs-root/usr/bin:$(dirname "@QT_QMAKE_EXECUTABLE@")":$PATH
 
 # Fetch portable linuxdeployqt if cache is older than $DAYSOLD
+APPIMAGETOOL="squashfs-root/usr/bin/appimagetool"
 echo -e "\nDownloading linuxdeployqt to ${LINUXDEPLOYQT}..."
 mkdir -p "$HOME/bin"
 DAYSOLD=2
@@ -69,7 +70,6 @@ elif ! find "$LINUXDEPLOYQT" -mtime -$DAYSOLD 2>/dev/null|grep -q "." > /dev/nul
 	touch "$LINUXDEPLOYQT"
 	success "Downloaded $LINUXDEPLOYQT"
 	"$LINUXDEPLOYQT" --appimage-extract > /dev/null 2>&1
-	APPIMAGETOOL="squashfs-root/usr/bin/appimagetool"
 	success "Extracted $APPIMAGETOOL"
 else
 	skipped "$LINUXDEPLOYQT is less than $DAYSOLD days old"
@@ -182,7 +182,8 @@ if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
 fi
 
 # Point the AppRun to the shim launcher
-ln -sfr "${APPDIR}/usr/bin/lmms" "${APPDIR}/AppRun"
+rm -f "${APPDIR}/AppRun"
+ln -sr "${APPDIR}/usr/bin/lmms" "${APPDIR}/AppRun"
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -181,6 +181,9 @@ if [ -e "${APPDIR}/usr/lib/libjack.so.0" ]; then
    mv "${APPDIR}/usr/lib/libjack.so.0" "${APPDIR}usr/lib/lmms/optional/"
 fi
 
+# Point the AppRun to the shim launcher
+ln -sfr "${APPDIR}/usr/bin/lmms" "${APPDIR}/AppRun"
+
 # Create AppImage
 echo -e "\nFinishing the AppImage..."
 echo -e "\n\n>>>>> appimagetool" >> "$LOGFILE"


### PR DESCRIPTION
Closes #4515

Upstream `linuxdeployqt` [patched behavior](https://github.com/probonopd/linuxdeployqt/issues/289) that allowed us to bundle our `.AppImage` using again `lmms.real` while the `AppRun` symlink would point to a shim script called `lmms`.  This was an undocumented and non-intuitive feature and it's been removed.

In reaction to this change, we  just need to repoint the `AppRun` ourselves to the `lmms` shim script.