### PR TITLE
Change universal key shortcut to insert bars

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -318,6 +318,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 						ke->key() == Qt::Key_Insert )
 	{
 		m_song->insertBar();
+	}
     #ifdef LMMS_BUILD_APPLE
         if( /*_ke->modifiers() & Qt::ShiftModifier*/
            gui->mainWindow()->isShiftPressed() == true &&

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -318,7 +318,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 						ke->key() == Qt::Key_Insert )
 	{
 		m_song->insertBar();
-    #ifdef Q_OS_MACOS
+    #ifdef LMMS_BUILD_APPLE
         if( /*_ke->modifiers() & Qt::ShiftModifier*/
            gui->mainWindow()->isShiftPressed() == true &&
                             ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return )

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -315,10 +315,17 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 {
 	if( /*_ke->modifiers() & Qt::ShiftModifier*/
 		gui->mainWindow()->isShiftPressed() == true &&
-						ke->key() == Qt::Key_Enter )
+						ke->key() == Qt::Key_Insert )
 	{
 		m_song->insertBar();
-	}
+    #ifdef Q_OS_MACOS
+        if( /*_ke->modifiers() & Qt::ShiftModifier*/
+           gui->mainWindow()->isShiftPressed() == true &&
+                            ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return )
+        {
+            m_song->insertBar();
+        }
+    #endif
 	else if(/* _ke->modifiers() & Qt::ShiftModifier &&*/
 			gui->mainWindow()->isShiftPressed() == true &&
 						ke->key() == Qt::Key_Delete )

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -315,7 +315,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 {
 	if( /*_ke->modifiers() & Qt::ShiftModifier*/
 		gui->mainWindow()->isShiftPressed() == true &&
-						ke->key() == Qt::Key_Insert )
+						ke->key() == Qt::Key_Enter )
 	{
 		m_song->insertBar();
 	}


### PR DESCRIPTION
the Ins key is absent/non-functional on macOS devices, a change is necessary for this functionality to work

**Edit by @tresf** Closes #4522 