### PR TITLE
Add CMake 2 support

### DIFF
--- a/cmake/modules/MinGWCrossCompile.cmake
+++ b/cmake/modules/MinGWCrossCompile.cmake
@@ -51,6 +51,10 @@ ELSE()
 	SET(STRIP                       ${MINGW_TOOL_PREFIX}strip)
 	SET(WINDRES                     ${MINGW_TOOL_PREFIX}windres)
 	SET(ENV{PKG_CONFIG}             ${MINGW_TOOL_PREFIX}pkg-config)
+	IF(CMAKE_VERSION LESS 3)
+		SET(PKG_CONFIG_EXECUTABLE       $ENV{PKG_CONFIG})
+		SET(PKG_CONFIG_FOUND            TRUE)
+	ENDIF()
 	
 	# Search for programs in the build host directories
 	SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
Partially reverts d599955 and fixes CMake 2 support when building with MingGW.  Originally reported by @Umcaruje on `#programming` channel on [Discord](https://lmms.io/chat), CMake 3 `git blame` discovered by @PhysSong.

This patch does not need to be fast-forwarded to `master` branch because `master` requires CMake 3 already although it should be at least hand-patched because d599955 was accidentally reverted at some point.

Ubuntu 14.04 still defaults to CMake 2 by default (e.g. `apt-get install cmake`), so this can help avoid unobvious dependency issues.

**Before:**
```
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.26")
```


**After:**
```
-- Found PkgConfig: /opt/mingw64/bin/x86_64-w64-mingw32-pkg-config (found version "0.26")
```

Keywords: 
```
-- checking for module 'sndfile>=1.0.11'
--   package 'sndfile>=1.0.11' not found
CMake Error at /usr/share/cmake-2.8/Modules/FindPkgConfig.cmake:283 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-2.8/Modules/FindPkgConfig.cmake:337 (_pkg_check_modules_internal)
  CMakeLists.txt:189 (PKG_CHECK_MODULES)


CMake Error at CMakeLists.txt:191 (MESSAGE):
  LMMS requires libsndfile1 and libsndfile1-dev >= 1.0.11 - please install,
  remove CMakeCache.txt and try again!
```

