### PR TITLE
Fix Freeboy noise channel playback for srw = 1.

### DIFF
--- a/plugins/papu/papu_instrument.cpp
+++ b/plugins/papu/papu_instrument.cpp
@@ -276,9 +276,6 @@ void papuInstrument::playNote( NotePlayHandle * _n,
 		data += m_ch4SweepStepLengthModel.value();
 		papu->write_register( 0xff21, data );
 
-		//channel 4 init
-		papu->write_register( 0xff23, 128 );
-
 		_n->m_pluginData = papu;
 	}
 
@@ -380,6 +377,10 @@ void papuInstrument::playNote( NotePlayHandle * _n,
 		data = data << 3;
 		data += ropt;
 		papu->write_register( 0xff22, data );
+
+		//channel 4 init
+		papu->write_register( 0xff23, 128 );
+
 	}
 
 	int const buf_size = 2048;


### PR DESCRIPTION
In order for `GB_apu` to correctly generate samples when the LSFR width is
set to `7`, the trigger write to `0xff23` must happen after all other
writes.