### PR TITLE
Don't try to clear null buffer in NotePlayHandle::play

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -238,13 +238,6 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 	// decreasing release of an instrument-track while the note is active
 	if( framesLeft() > 0 )
 	{
-		// clear offset frames if we're at the first period
-		// skip for single-streamed instruments, because in their case NPH::play() could be called from an IPH without a buffer argument
-		// ... also, they don't actually render the sound in NPH's, which is an even better reason to skip...
-		if( m_totalFramesPlayed == 0 && ! ( m_instrumentTrack->instrument()->flags() & Instrument::IsSingleStreamed ) )
-		{
-			memset( _working_buffer, 0, sizeof( sampleFrame ) * offset() );
-		}
 		// play note!
 		m_instrumentTrack->playNote( this, _working_buffer );
 	}


### PR DESCRIPTION
This is a workaround for rare crashes when changing tempo while playing notes with stacking and/or arpeggio.
When playing the master note, `_working_buffer` is null. Tempo change causes false positive in the check because `NotePlayHandle::resize` changes `m_totalFramesPlayed`.
Thanks to 6fc4577f102e5bb60cc246a426fb9ed8b4ac3be9, we can safely drop the memset call.

Fixes #4537.