### PR TITLE
Divide knob step size by 1000 for LADSPA effects, and tweak mouse wheel behavior to fit the change

### DIFF
--- a/src/core/LadspaControl.cpp
+++ b/src/core/LadspaControl.cpp
@@ -76,7 +76,7 @@ LadspaControl::LadspaControl( Model * _parent, port_desc_t * _port,
 				( m_port->max - m_port->min )
 				/ ( m_port->name.toUpper() == "GAIN"
 					&& m_port->max == 10.0f ? 4000.0f :
-								( m_port->suggests_logscale ? 8000.0f : 800.0f ) ) );
+								( m_port->suggests_logscale ? 8000000.0f : 800000.0f ) ) );
 			m_knobModel.setInitValue( m_port->def );
 			connect( &m_knobModel, SIGNAL( dataChanged() ),
 						 this, SLOT( knobChanged() ) );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -699,11 +699,11 @@ void Knob::paintEvent( QPaintEvent * _me )
 
 
 
-
 void Knob::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
-	const int inc = ( _we->delta() > 0 ) ? 1 : -1;
+	const float step = model()->step<float>();
+	const int inc = ( ( _we->delta() > 0 ) ? 1 : -1 ) * ( ( step < 1 ) * 999 + 1 ); // inc is -1000 or 1000 if the step size is less than 1; otherwise, inc is -1 or 1.
 	model()->incValue( inc );
 
 


### PR DESCRIPTION
Sorry if the title isn't good, I couldn't think of anything better.

These changes change the knob value step size for certain knobs to 1/1000th of what it was previously.  This makes the step sizes extremely small, allowing a significantly larger amount of precision when choosing knob values.  This is necessary for a variety of reasons.  For example, before this change, when using a Decimator, the Sample Rate can be set to 55.0699 or 110.14, but nothing in between.  That only allows precision of 55.0701Hz, which is not nearly as precise as most would want.  This change allows you to be precise within 0.00550701 Hz, which is so precise that I highly doubt anybody would want anything more precise.  It is a significant improvement in comparison to where it was before.  Of course, that was just an example, this change applies to all knobs that don't require a set step size (like the Type for C* Cabinet, which must stay set to 1 for obvious reasons).

When scrolling the mouse wheel over a knob, it increments the value by 1 step.  Since this change massively decreases the step size, it renders use of the mouse wheel quite useless.  So, another change has been added.  While the step size has been divided by 1000, the number of steps the mouse wheel changes the value by is increased to 1000.  So visually, the mouse wheel functions identically to how it functioned before, but the decrease in step size still allows more precise values to be chosen with all other methods of setting a knob value, whether it be clicking and dragging, double clicking and typing the value, and via automation and controllers (which, as a consequence, should cause both to sound better and smoother than before).

Even if further improvements are to be made for this (I'm sure they will), I strongly suggest that we make these changes to LMMS for now, so that people can have the benefits of smaller step sizes for all future versions of LMMS.