### PR TITLE
Divide knob step size by 1000 for LADSPA effects, and minor changes to scroll wheel behavior

### DIFF
--- a/src/core/LadspaControl.cpp
+++ b/src/core/LadspaControl.cpp
@@ -79,7 +79,7 @@ LadspaControl::LadspaControl( Model * _parent, port_desc_t * _port,
 				( m_port->max - m_port->min )
 				/ ( m_port->name.toUpper() == "GAIN"
 					&& m_port->max == 10.0f ? 4000.0f :
-								( m_port->suggests_logscale ? 8000.0f : 800.0f ) ) );
+								( m_port->suggests_logscale ? 8000000.0f : 800000.0f ) ) );
 			m_knobModel.setInitValue( m_port->def );
 			connect( &m_knobModel, SIGNAL( dataChanged() ),
 						 this, SLOT( knobChanged() ) );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -701,7 +701,8 @@ void Knob::paintEvent( QPaintEvent * _me )
 void Knob::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
-	const int inc = ( _we->delta() > 0 ) ? 1 : -1;
+	const float stepMult = model()->range() / 2000 / model()->step<float>();
+	const int inc = ( ( _we->delta() > 0 ) ? 1 : -1 ) * ( ( stepMult < 1 ) ? 1 : stepMult );
 	model()->incValue( inc );
 
 


### PR DESCRIPTION
These changes change the knob value step size for certain knobs to 1/1000th of what it was previously. This makes the step sizes extremely small, allowing a significantly larger amount of precision when choosing knob values. This is necessary for a variety of reasons. For example, before this change, when using a Decimator, the Sample Rate can be set to 55.0699 or 110.14, but nothing in between. That only allows precision of 55.0701Hz, which is not nearly as precise as most would want. This change allows you to be precise within 0.00550701 Hz, which is so precise that I highly doubt anybody would want anything more precise. It is a significant improvement in comparison to where it was before. Of course, that was just an example, this change applies to all knobs that don't require a set step size (like the Type for C* Cabinet, which must stay set to 1 for obvious reasons).

When scrolling the mouse wheel over a knob, it increments the value by 1 step. Since this change massively decreases the step size, it renders use of the mouse wheel quite useless. So, another change has been added. The number of steps the mouse wheel changes the knob by has been changed, here is the formula that fit the best:

`Number of Steps = Knob Value Range / 2000 / Knob Step Size`

I spent about an hour doing nothing but testing out different knobs making sure this change didn't have any negative UI effects, and then left it on there for a day while I just normally made music. I didn't notice anything negative, and actually eventually forgot the change was even on there, which is a good sign.

The decrease in step size allows more precise values to be chosen with all methods of setting a knob value, whether it be clicking and dragging, double clicking and typing the value, and via automation and controllers (which, as a consequence, should cause both to sound better and smoother than before)!

Even if further improvements are to be made for this (I'm sure they will), I strongly suggest that we make these changes to LMMS for now, so that people can have the benefits of smaller step sizes for all future versions of LMMS.

Fixes #4565.