### PR TITLE
Enable compiled-in XPM pixmaps (#4578)

### DIFF
--- a/include/embed.h
+++ b/include/embed.h
@@ -35,7 +35,17 @@
 namespace embed
 {
 
-QPixmap LMMS_EXPORT getIconPixmap( const QString&  _name, int _w = -1, int _h = -1 );
+/**
+ * Return an image for the icon pixmap cache.
+ *
+ * @param _name Identifier for the pixmap. If it is not in the icon pixmap
+ *   cache, it will be loaded from the artwork QDir search paths (exceptions are
+ *   compiled-in XPMs, you need to provide @p xpm for loading them).
+ * @param xpm Must be XPM data if the source should be raw XPM data instead of
+ *   a file
+ */
+QPixmap LMMS_EXPORT getIconPixmap( const QString&  _name,
+	int _w = -1, int _h = -1 , const char** xpm = nullptr );
 QString LMMS_EXPORT getText( const char * _name );
 
 }
@@ -45,9 +55,10 @@ QString LMMS_EXPORT getText( const char * _name );
 namespace PLUGIN_NAME
 {
 
-inline QPixmap getIconPixmap( const QString&  _name, int _w = -1, int _h = -1 )
+inline QPixmap getIconPixmap( const QString&  _name,
+	int _w = -1, int _h = -1, const char** xpm = nullptr )
 {
-	return embed::getIconPixmap(QString("%1/%2").arg(STRINGIFY(PLUGIN_NAME), _name), _w, _h);
+	return embed::getIconPixmap(QString("%1/%2").arg(STRINGIFY(PLUGIN_NAME), _name), _w, _h, xpm);
 }
 //QString getText( const char * _name );
 
@@ -60,12 +71,15 @@ class PixmapLoader
 {
 public:
 	PixmapLoader( const PixmapLoader * _ref ) :
-		m_name( _ref != NULL ? _ref->m_name : QString() )
+		m_name( _ref != NULL ? _ref->m_name : QString() ),
+		m_xpm( _ref->m_xpm )
 	{
 	}
 
-	PixmapLoader( const QString & _name = QString() ) :
-		m_name( _name )
+	PixmapLoader( const QString & _name = QString(),
+		const char** xpm = nullptr ) :
+		m_name( _name ),
+		m_xpm(xpm)
 	{
 	}
 
@@ -73,7 +87,8 @@ public:
 	{
 		if( !m_name.isEmpty() )
 		{
-			return( embed::getIconPixmap( m_name.toLatin1().constData() ) );
+			return( embed::getIconPixmap(
+				m_name.toLatin1().constData(), -1, -1, m_xpm ));
 		}
 		return( QPixmap() );
 	}
@@ -89,6 +104,7 @@ public:
 
 protected:
 	QString m_name;
+	const char** m_xpm = nullptr;
 } ;
 
 

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -31,8 +31,8 @@
 namespace embed
 {
 
-
-QPixmap getIconPixmap(const QString& pixmapName, int width, int height )
+QPixmap getIconPixmap(const QString& pixmapName,
+	int width, int height, const char** xpm )
 {
 	QString cacheName;
 	if (width > 0 && height > 0)
@@ -50,19 +50,28 @@ QPixmap getIconPixmap(const QString& pixmapName, int width, int height )
 	{
 		return pixmap;
 	}
-	QImageReader reader(QString("artwork:%1").arg(pixmapName));
 
-	if (width > 0 && height > 0)
+	if(xpm)
 	{
-		reader.setScaledSize(QSize(width, height));
+		pixmap = QPixmap(xpm);
 	}
-
-	pixmap = QPixmap::fromImageReader(&reader);
-	if (pixmap.isNull())
+	else
 	{
-		qWarning().nospace() << "Error loading icon pixmap " << pixmapName << ": " <<
-								reader.errorString().toLocal8Bit().data();
-		return QPixmap(1,1);
+		QImageReader reader(QString("artwork:%1").arg(pixmapName));
+
+		if (width > 0 && height > 0)
+		{
+			reader.setScaledSize(QSize(width, height));
+		}
+
+		pixmap = QPixmap::fromImageReader(&reader);
+
+		if (pixmap.isNull())
+		{
+			qWarning().nospace() << "Error loading icon pixmap " << pixmapName << ": " <<
+									reader.errorString().toLocal8Bit().data();
+			return QPixmap(1,1);
+		}
 	}
 
 	// Save to cache and return


### PR DESCRIPTION
Should I merge this to master? It's practical and may help coders in the future, but it's also currently unused code (as it's only inside my osc-plugin branch), so coders have no example about how it must be used.