### PR TITLE
Rendering looped sections multiple times on export (#4624)

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -103,8 +103,6 @@ public:
 
 	} ;
 
-
-
 	void processNextBuffer();
 
 	inline int getLoadingTrackCount() const
@@ -210,6 +208,7 @@ public:
 			m_loopRenderCount = 1;
 		else
 			m_loopRenderCount = count;
+		m_loopRenderRemaining = m_loopRenderCount;
 	}
     
 	inline int getLoopRenderCount() const
@@ -218,7 +217,7 @@ public:
 	}
 
 	bool isExportDone() const;
-	std::pair<MidiTime, MidiTime> getExportEndpoints() const;
+	int getExportProgress() const;
 
 	inline void setRenderBetweenMarkers( bool renderBetweenMarkers )
 	{
@@ -439,7 +438,12 @@ private:
 	VstSyncController m_vstSyncController;
     
 	int m_loopRenderCount;
-
+	int m_loopRenderRemaining;
+	MidiTime m_exportSongBegin;
+	MidiTime m_exportLoopBegin;
+	MidiTime m_exportLoopEnd;
+	MidiTime m_exportSongEnd;
+	MidiTime m_exportEffectiveLength;
 
 	friend class LmmsCore;
 	friend class SongEditor;

--- a/include/Song.h
+++ b/include/Song.h
@@ -203,6 +203,19 @@ public:
 	{
 		return m_recording;
 	}
+	
+	inline void setLoopRenderCount( int count )
+	{
+		if( count < 1 )
+			m_loopRenderCount = 1;
+		else
+			m_loopRenderCount = count;
+	}
+    
+	inline int getLoopRenderCount() const
+	{
+		return m_loopRenderCount;
+	}
 
 	bool isExportDone() const;
 	std::pair<MidiTime, MidiTime> getExportEndpoints() const;
@@ -424,6 +437,8 @@ private:
 	tact_t m_elapsedTacts;
 
 	VstSyncController m_vstSyncController;
+    
+	int m_loopRenderCount;
 
 
 	friend class LmmsCore;

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -185,21 +185,13 @@ void ProjectRenderer::run()
 	// Skip first empty buffer.
 	Engine::mixer()->nextBuffer();
 
-	const Song::PlayPos & exportPos = Engine::getSong()->getPlayPos(
-							Song::Mode_PlaySong );
 	m_progress = 0;
-	std::pair<MidiTime, MidiTime> exportEndpoints = Engine::getSong()->getExportEndpoints();
-	tick_t startTick = exportEndpoints.first.getTicks();
-	tick_t endTick = exportEndpoints.second.getTicks();
-	tick_t lengthTicks = endTick - startTick;
 
 	// Continually track and emit progress percentage to listeners.
-	while( exportPos.getTicks() < endTick &&
-				Engine::getSong()->isExporting() == true
-							&& !m_abort )
+	while( !Engine::getSong()->isExportDone() && !m_abort )
 	{
 		m_fileDev->processNextBuffer();
-		const int nprog = lengthTicks == 0 ? 100 : (exportPos.getTicks()-startTick) * 100 / lengthTicks;
+		const int nprog = Engine::getSong()->getExportProgress();
 		if( m_progress != nprog )
 		{
 			m_progress = nprog;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -86,7 +86,8 @@ Song::Song() :
 	m_patternToPlay( NULL ),
 	m_loopPattern( false ),
 	m_elapsedTicks( 0 ),
-	m_elapsedTacts( 0 )
+	m_elapsedTacts( 0 ),
+	m_loopRenderCount ( 1 )
 {
 	for(int i = 0; i < Mode_Count; ++i) m_elapsedMilliSeconds[i] = 0;
 	connect( &m_tempoModel, SIGNAL( dataChanged() ),
@@ -330,7 +331,7 @@ void Song::processNextBuffer()
 			}
 			m_playPos[m_playMode].setTicks( ticks );
 
-			if( checkLoop )
+			if( checkLoop || m_loopRenderCount > 1 )
 			{
 				m_vstSyncController.startCycle(
 					tl->loopBegin().getTicks(), tl->loopEnd().getTicks() );
@@ -340,6 +341,8 @@ void Song::processNextBuffer()
 				// beginning of the range
 				if( m_playPos[m_playMode] >= tl->loopEnd() )
 				{
+					if( m_loopRenderCount > 1 ) 
+						m_loopRenderCount--;
 					ticks = tl->loopBegin().getTicks();
 					m_playPos[m_playMode].setTicks( ticks );
 					setToTime(tl->loopBegin());
@@ -745,6 +748,7 @@ void Song::stopExport()
 	stop();
 	m_exporting = false;
 	m_exportLoop = false;
+	m_loopRenderCount = 1;
 
 	m_vstSyncController.setPlaybackState( m_playing );
 }

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -87,7 +87,8 @@ Song::Song() :
 	m_loopPattern( false ),
 	m_elapsedTicks( 0 ),
 	m_elapsedTacts( 0 ),
-	m_loopRenderCount ( 1 )
+	m_loopRenderCount ( 1 ),
+	m_loopRenderRemaining( 1 )
 {
 	for(int i = 0; i < Mode_Count; ++i) m_elapsedMilliSeconds[i] = 0;
 	connect( &m_tempoModel, SIGNAL( dataChanged() ),
@@ -331,7 +332,7 @@ void Song::processNextBuffer()
 			}
 			m_playPos[m_playMode].setTicks( ticks );
 
-			if( checkLoop || m_loopRenderCount > 1 )
+			if( checkLoop || m_loopRenderRemaining > 1 )
 			{
 				m_vstSyncController.startCycle(
 					tl->loopBegin().getTicks(), tl->loopEnd().getTicks() );
@@ -341,8 +342,8 @@ void Song::processNextBuffer()
 				// beginning of the range
 				if( m_playPos[m_playMode] >= tl->loopEnd() )
 				{
-					if( m_loopRenderCount > 1 ) 
-						m_loopRenderCount--;
+					if( m_loopRenderRemaining > 1 ) 
+						m_loopRenderRemaining--;
 					ticks = tl->loopBegin().getTicks();
 					m_playPos[m_playMode].setTicks( ticks );
 					setToTime(tl->loopBegin());
@@ -481,28 +482,39 @@ void Song::setModified(bool value)
 	}
 }
 
-std::pair<MidiTime, MidiTime> Song::getExportEndpoints() const
+bool Song::isExportDone() const
 {
-	if ( m_renderBetweenMarkers )
+	return !isExporting() || m_playPos[m_playMode] >= m_exportSongEnd;
+}
+
+int Song::getExportProgress() const
+{
+	MidiTime pos = m_playPos[m_playMode];
+    
+	if ( pos >= m_exportSongEnd )
 	{
-		return std::pair<MidiTime, MidiTime>(
-			m_playPos[Mode_PlaySong].m_timeLine->loopBegin(),
-			m_playPos[Mode_PlaySong].m_timeLine->loopEnd()
-		);
+		return 100;
 	}
-	else if ( m_exportLoop )
+	else if ( pos <= m_exportSongBegin )
 	{
-		return std::pair<MidiTime, MidiTime>( MidiTime(0, 0), MidiTime(m_length, 0) );
+		return 0;
+	}
+	else if ( pos >= m_exportLoopEnd )
+	{
+		pos = (m_exportLoopBegin-m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin)*m_loopRenderCount + (pos - m_exportLoopEnd);
+	}
+	else if ( pos >= m_exportLoopBegin )
+	{
+		pos = (m_exportLoopBegin-m_exportSongBegin) + ((m_exportLoopEnd - m_exportLoopBegin)*(m_loopRenderCount - m_loopRenderRemaining)) 
+			+ (pos - m_exportLoopBegin);
 	}
 	else
 	{
-		// if not exporting as a loop, we leave one bar of padding at the end of the song to accomodate reverb, etc.
-		return std::pair<MidiTime, MidiTime>( MidiTime(0, 0), MidiTime(m_length+1, 0) );
+		pos = (pos - m_exportSongBegin);
 	}
+
+	return (float)pos/(float)m_exportEffectiveLength*100.0f;
 }
-
-
-
 
 void Song::playSong()
 {
@@ -724,14 +736,40 @@ void Song::stop()
 void Song::startExport()
 {
 	stop();
-	if(m_renderBetweenMarkers)
+	if( m_renderBetweenMarkers )
 	{
+		m_exportSongBegin = m_exportLoopBegin = m_playPos[Mode_PlaySong].m_timeLine->loopBegin();
+		m_exportSongEnd = m_exportLoopEnd = m_playPos[Mode_PlaySong].m_timeLine->loopEnd();
+
 		m_playPos[Mode_PlaySong].setTicks( m_playPos[Mode_PlaySong].m_timeLine->loopBegin().getTicks() );
 	}
 	else
 	{
+		m_exportSongEnd = MidiTime(m_length, 0);
+        
+		// Handle potentially ridiculous loop points gracefully.
+		if ( m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd ) 
+		{
+			m_exportSongEnd = m_playPos[Mode_PlaySong].m_timeLine->loopEnd();
+		}
+
+		if ( !m_exportLoop ) 
+			m_exportSongEnd += MidiTime(1,0);
+        
+		m_exportSongBegin = MidiTime(0,0);
+		m_exportLoopBegin = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
+			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
+			m_playPos[Mode_PlaySong].m_timeLine->loopBegin() : MidiTime(0,0);
+		m_exportLoopEnd = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
+			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
+			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() : MidiTime(0,0);
+
 		m_playPos[Mode_PlaySong].setTicks( 0 );
 	}
+
+	m_exportEffectiveLength = (m_exportLoopBegin - m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin) * m_loopRenderCount +
+		(m_exportSongEnd - m_exportLoopEnd);
+	m_loopRenderRemaining = m_loopRenderCount;
 
 	playSong();
 
@@ -748,7 +786,6 @@ void Song::stopExport()
 	stop();
 	m_exporting = false;
 	m_exportLoop = false;
-	m_loopRenderCount = 1;
 
 	m_vstSyncController.setPlaybackState( m_playing );
 }

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -187,6 +187,7 @@ void ExportProjectDialog::startExport()
 
 	Engine::getSong()->setExportLoop( exportLoopCB->isChecked() );
 	Engine::getSong()->setRenderBetweenMarkers( renderMarkersCB->isChecked() );
+	Engine::getSong()->setLoopRenderCount(loopCountSB->value());
 
 	connect( m_renderManager.get(), SIGNAL( progressChanged( int ) ),
 			progressBar, SLOT( setValue( int ) ) );

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -128,6 +128,7 @@ void ExportProjectDialog::accept()
 
 void ExportProjectDialog::closeEvent( QCloseEvent * _ce )
 {
+	Engine::getSong()->setLoopRenderCount(1);
 	if( m_renderManager ) {
 		m_renderManager->abortProcessing();
 	}

--- a/src/gui/dialogs/export_project.ui
+++ b/src/gui/dialogs/export_project.ui
@@ -13,13 +13,13 @@
   <property name="minimumSize">
    <size>
     <width>379</width>
-    <height>374</height>
+    <height>400</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>379</width>
-    <height>374</height>
+    <height>400</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -38,6 +38,47 @@
      <property name="text">
       <string>Export between loop markers</string>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="loopRepeatWidget" native="true">
+     <layout class="QHBoxLayout" name="loopRepeatHL">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelLoopRepeat">
+        <property name="text">
+         <string>Render Looped Section:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="loopCountSB">
+        <property name="suffix">
+         <string> time(s)</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
@tresf suggested in https://github.com/LMMS/lmms/issues/4624 that this feature might be useful for inclusion in LMMS.

This pull request adds the ability to render looped sections multiple times when exporting. A spinbox is added to the export dialog that allows one to specify how many times the looped section would be rendered while exporting. This defaults to 1  but the user can specify a value to allow the section between looping markers to be rendered up to 9 times (change the spinbox maximum in export_project.ui to increase this if a greater number than 9 is desired).

Feature was tested with both Export Project and Export Tracks but is not applicable to Export to MIDI. The method for calculating export progress needed to be changed to allow the progress bar to give a correct estimate for the percentage completion. There are no known limitations or side effects other than what is described above.