### PR TITLE
Fix minor sample track playback/export glitches

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -171,10 +171,11 @@ public:
 		return m_audioDevStartFailed;
 	}
 
-	void setAudioDevice( AudioDevice * _dev );
+	void setAudioDevice( AudioDevice * _dev , bool startNow );
 	void setAudioDevice( AudioDevice * _dev,
 				const struct qualitySettings & _qs,
-							bool _needs_fifo );
+				bool _needs_fifo,
+				bool startNow );
 	void storeAudioDevice();
 	void restoreAudioDevice();
 	inline AudioDevice * audioDev()

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -575,7 +575,8 @@ void Mixer::changeQuality( const struct qualitySettings & _qs )
 
 
 
-void Mixer::setAudioDevice( AudioDevice * _dev )
+void Mixer::setAudioDevice( AudioDevice * _dev,
+			    bool startNow )
 {
 	stopProcessing();
 
@@ -592,7 +593,7 @@ void Mixer::setAudioDevice( AudioDevice * _dev )
 
 	emit sampleRateChanged();
 
-	startProcessing();
+	if (startNow) {startProcessing();}
 }
 
 
@@ -600,7 +601,8 @@ void Mixer::setAudioDevice( AudioDevice * _dev )
 
 void Mixer::setAudioDevice( AudioDevice * _dev,
 				const struct qualitySettings & _qs,
-				bool _needs_fifo )
+				bool _needs_fifo,
+				bool startNow )
 {
 	// don't delete the audio-device
 	stopProcessing();
@@ -621,7 +623,7 @@ void Mixer::setAudioDevice( AudioDevice * _dev,
 	emit qualitySettingsChanged();
 	emit sampleRateChanged();
 
-	startProcessing( _needs_fifo );
+	if (startNow) {startProcessing( _needs_fifo );}
 }
 
 

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -146,7 +146,7 @@ void ProjectRenderer::startProcessing()
 		// make slots connected to sampleRateChanged()-signals being
 		// called immediately
 		Engine::mixer()->setAudioDevice( m_fileDev,
-						m_qualitySettings, false );
+						m_qualitySettings, false, false );
 
 		start(
 #ifndef LMMS_BUILD_WIN32
@@ -184,6 +184,9 @@ void ProjectRenderer::run()
 	tick_t startTick = exportEndpoints.first.getTicks();
 	tick_t endTick = exportEndpoints.second.getTicks();
 	tick_t lengthTicks = endTick - startTick;
+
+	// Now start processing
+	Engine::mixer()->startProcessing(false);
 
 	// Continually track and emit progress percentage to listeners
 	while( exportPos.getTicks() < endTick &&

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -356,9 +356,7 @@ void Song::processNextBuffer()
 
 					m_vstSyncController.setAbsolutePosition( ticks );
 					m_vstSyncController.setPlaybackJumped( true );
-				}
-				else if( m_playPos[m_playMode] == tl->loopEnd() - 1 )
-				{
+
 					emit updateSampleTracks();
 				}
 			}

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -72,13 +72,16 @@ SampleTCO::SampleTCO( Track * _track ) :
 		connect( timeLine, SIGNAL( positionMarkerMoved() ), this, SLOT( playbackPositionChanged() ) );
 	}
 	//playbutton clicked or space key / on Export Song set isPlaying to false
-	connect( Engine::getSong(), SIGNAL( playbackStateChanged() ), this, SLOT( playbackPositionChanged() ) );
+	connect( Engine::getSong(), SIGNAL( playbackStateChanged() ),
+			this, SLOT( playbackPositionChanged() ), Qt::DirectConnection );
 	//care about loops
-	connect( Engine::getSong(), SIGNAL( updateSampleTracks() ), this, SLOT( playbackPositionChanged() ) );
+	connect( Engine::getSong(), SIGNAL( updateSampleTracks() ),
+			this, SLOT( playbackPositionChanged() ), Qt::DirectConnection );
 	//care about mute TCOs
 	connect( this, SIGNAL( dataChanged() ), this, SLOT( playbackPositionChanged() ) );
 	//care about mute track
-	connect( getTrack()->getMutedModel(), SIGNAL( dataChanged() ),this, SLOT( playbackPositionChanged() ) );
+	connect( getTrack()->getMutedModel(), SIGNAL( dataChanged() ),
+			this, SLOT( playbackPositionChanged() ), Qt::DirectConnection );
 	//care about TCO position
 	connect( this, SIGNAL( positionChanged() ), this, SLOT( updateTrackTcos() ) );
 


### PR DESCRIPTION
This PR makes LMMS handle loop points correctly and export samples without glitches. Switches some signal-slot connections to `Qt::DirectConnection` and change `Song::processNextBuffer` to emit the `updateSampleTracks` signal correctly. I believe queued connections caused https://github.com/LMMS/lmms/pull/3133#issuecomment-269922978, so I removed the old workaround.
Also tweaks some Mixer-related code to avoid deadlocks on export. Due to how `Mixer::requestChangeInModel` works, Mixer's processing state should be set properly based on whether `Mixer::renderNextBuffer` can be called or not. So I touched `Mixer` and `ProjectRenderer` a bit.
Fixes #4362.