### PR TITLE
Fix not saving some automations (#4632)

### DIFF
--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -53,7 +53,7 @@ EffectChain::~EffectChain()
 
 void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
-	_this.setAttribute( "enabled", m_enabledModel.value() );
+	m_enabledModel.saveSettings( _doc, _this, "enabled" );
 	_this.setAttribute( "numofeffects", m_effects.count() );
 
 	for( Effect* effect : m_effects)
@@ -80,7 +80,7 @@ void EffectChain::loadSettings( const QDomElement & _this )
 
 	// TODO This method should probably also lock the mixer
 
-	m_enabledModel.setValue( _this.attribute( "enabled" ).toInt() );
+	m_enabledModel.loadSettings( _this, "enabled" );
 
 	const int plugin_cnt = _this.attribute( "numofeffects" ).toInt();
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2063,8 +2063,9 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	}
 	element.setAttribute( "type", type() );
 	element.setAttribute( "name", name() );
-	element.setAttribute( "muted", isMuted() );
-	element.setAttribute( "solo", isSolo() );
+	m_mutedModel.saveSettings( doc, element, "muted" );
+	m_soloModel.saveSettings( doc, element, "solo" );
+
 	if( m_height >= MINIMAL_TRACK_HEIGHT )
 	{
 		element.setAttribute( "height", m_height );
@@ -2116,8 +2117,8 @@ void Track::loadSettings( const QDomElement & element )
 	setName( element.hasAttribute( "name" ) ? element.attribute( "name" ) :
 			element.firstChild().toElement().attribute( "name" ) );
 
-	setMuted( element.attribute( "muted" ).toInt() );
-	setSolo( element.attribute( "solo" ).toInt() );
+	m_mutedModel.loadSettings( element, "muted" );
+	m_soloModel.loadSettings( element, "solo" );
 
 	if( m_simpleSerializingMode )
 	{
@@ -2150,8 +2151,9 @@ void Track::loadSettings( const QDomElement & element )
 			{
 				loadTrackSpecificSettings( node.toElement() );
 			}
-			else if(
-			!node.toElement().attribute( "metadata" ).toInt() )
+			else if( node.nodeName() != "muted"
+			&& node.nodeName() != "solo"
+			&& !node.toElement().attribute( "metadata" ).toInt() )
 			{
 				TrackContentObject * tco = createTCO(
 								MidiTime( 0 ) );


### PR DESCRIPTION
OK, tested:
* saving + loading all 3 Models with this patch works
* saving with the patch + loading without will discard the automation... ugly, but we can't get any better here...
* saving without the patch (i.e. doing no automation) + loading with the patch works (the knobs are simply not automated, but keep their values)

I would say let's just merge it in.