### PR TITLE
Add .clang-format and .clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,68 @@
+---
+# Language
+Language:        Cpp
+Standard:        Cpp11  # Cpp14 and Cpp17 are not supported by clang 11
+
+# Indentation
+TabWidth:        4
+UseTab:          Always
+IndentWidth:     4
+ColumnLimit:     0
+
+# Indentation detail
+AlignAfterOpenBracket: DontAlign
+ContinuationIndentWidth: 4
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerIndentWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+BinPackParameters: true
+BinPackArguments: true
+AlignOperands: false
+AlignEscapedNewlines: DontAlign
+AccessModifierOffset: -4
+
+# Includes
+IncludeBlocks:   Regroup
+IncludeCategories:
+  # the "main header" implicitly gets priority 0
+  # system headers
+  - Regex:           '^<[^>]+>$'
+    Priority:        1
+  # non-system headers
+  - Regex:           '.*'
+    Priority:        2
+SortIncludes:    true
+
+# Spaces
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+
+# Brace wrapping
+# Not directly mentioned in the coding conventions,
+# but required to avoid tons of auto reformatting
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+  
+# Pointers
+# Use pointer close to type: `const char* const* function()`
+PointerAlignment: Left
+
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,33 @@
+---
+Checks:          'bugprone-macro-parentheses,bugprone-macro-repeated-side-effects,modernize-use-override,readability-identifier-naming,readability-misleading-indentation,readability-simplify-boolean-expr,readability-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFilterRegex: '' # don't show errors from headers
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            user
+CheckOptions:    
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.TypedefCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StructCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+# not yet working, as it currently applies both for static and object members
+# - key:             readability-identifier-naming.MemberPrefix
+#   value:           'm_'
+  # currently only working for local static variables:
+  - key:             readability-identifier-naming.StaticVariablePrefix
+    value:           's_'
+# not yet working
+# - key:             readability-identifier-naming.VariableCase
+#   value:           camelBack
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+...
+


### PR DESCRIPTION
Don't merge yet, needs discussion, see below.

The following patch provides style files for ~2/3 of the [LMMS coding conventions](https://github.com/LMMS/lmms/wiki/Coding-conventions) (~4/5 if clang-tidy will accept a PR I'll need to create).
clang-format and clang-tidy provide functionality to find style issues (the former for whitespace, the latter for code) and to fix them automatically.

The following works as an example (assuming you're in the main LMMS folder and use a build dir `build`). For best results, use what `make VERBOSE=1` spits out.

```
# clang-format -style=file <filename>
clang-format -style=file src/core/AutomatableModel.cpp
# clang-tidy -config= <filename> -- <compile-flags>
clang-tidy -config-file=.clang-tidy src/core/AutomatableModel.cpp -- -Iinclude -Ibuild/{src,} -I/usr/include/qt/{QtCore,QtWidgets,QtGui,QtXml,}
```

QtCreator:
Full support for clang-format and clang-tidy :smile: 
* clang-tidy:
  - Analyze -> Clang-Tidy and Clazy
  - Select custom style, click manage, duplicate existing one, select Clang-Tidy tab, choose to read style from file
  - Select the files that you want to analyze (selecting all takes a long time!), click "Analyze"
* clang-format
  - Enable Help -> About Plugins -> C++ -> Beautifier
  - Restart
  - Tools -> Options -> Beautifier, do your settings, but especially, go to the "Clang Format" tab, use predefined style "file"


clang-format output for Mixer.cpp:

[click here](https://imgur.com/a/8Va0svF) for examples.


clang-tidy output for Mixer.cpp:

```
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:109:20: warning: redundant boolean literal supplied to boolean operator [readability-simplify-boolean-expr]
        if( renderOnly == false )
            ~~~~~~~~~~~~~~^~~~~
            !renderOnly                                                                                                                                                                                                                      
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:306:64: warning: redundant boolean literal supplied to boolean operator [readability-simplify-boolean-expr]
        return cpuLoad() >= 99 && Engine::getSong()->isExporting() == false;
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
                                  !Engine::getSong()->isExporting()                                                                                                                                                                          
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:348:23: warning: invalid case style for static variable 'last_metro_pos' [readability-identifier-naming]
        static Song::PlayPos last_metro_pos = -1;
                             ^~~~~~~~~~~~~~
                             s_last_metro_pos                                                                                                                                                                                                
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:374:18: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]
                last_metro_pos = p;
                               ^
[...]

/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:405:8: warning: statement should be inside braces [readability-braces-around-statements]
                        else delete *it;
                            ^
                             {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:459:8: warning: statement should be inside braces [readability-braces-around-statements]
                        else delete *it;
                            ^
                             {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:679:25: warning: redundant boolean literal supplied to boolean operator [readability-simplify-boolean-expr]
        if( criticalXRuns() == false )
            ~~~~~~~~~~~~~~~~~~~^~~~~
            !criticalXRuns()
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:690:6: warning: statement should be inside braces [readability-braces-around-statements]
        else delete handle;
            ^
             {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:743:8: warning: statement should be inside braces [readability-braces-around-statements]
                        else delete _ph;
                            ^
                             {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:769:8: warning: statement should be inside braces [readability-braces-around-statements]
                        else delete *it;
                            ^
                             {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:785:25: warning: statement should be inside braces [readability-braces-around-statements]
        if( s_renderingThread )
                               ^
                                {
/home/johannes/cprogs/lmms/master/src/core/Mixer.cpp:807:25: warning: statement should be inside braces [readability-braces-around-statements]
        if( s_renderingThread )
                               ^
                                {
Suppressed 13365 warnings (13365 in non-user code).
```

Things to discuss:
* CMake integration: multiple possibilities:
  - No CMake integration
    * Users must use clang-tidy from their IDE, if they use an IDE supporting it,
      otherwise they have to run clang-tidy manually, passing command line args to it
    * No Continous integation!
  - Let CMake only [export compile commands](https://cmake.org/cmake/help/v3.5/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html)
    * No full automation
  - Always run clang-tidy at compile, if a flag is set
    * Compile time overhead!
    * The need to set that CMake flag may confuse users
  - Add a target for CMakeLists to fix (and alternatively just to scan) all source files
    * Disadvantage: Can only accept all fixes, where in an IDE you can select what to fix
* Line length: The coding conventions say "80", but it seems to look better using "100".
  With 80, many `QObject::connect` calls are broken into 4 lines.

For the future, I hope we can fix the complete LMMS sources after stable-1.2 is being merged.