### PR TITLE
Handle automation on processing thread

### DIFF
--- a/include/Model.h
+++ b/include/Model.h
@@ -41,6 +41,10 @@ public:
 		m_displayName( _display_name ),
 		m_defaultConstructed( _default_constructed )
 	{
+#if QT_VERSION < 0x050000
+		connect( this, SIGNAL( dataChanged() ), this,
+			SLOT( thisDataChanged() ), Qt::DirectConnection );
+#endif
 	}
 
 	virtual ~Model()
@@ -85,6 +89,19 @@ signals:
 	// emitted if properties of the model (e.g. ranges) have changed
 	void propertiesChanged();
 
+#if QT_VERSION < 0x050000
+	// emitted along with dataChanged(), but with this model as an argument
+	// workaround for when QObject::sender() and Qt5 are unavailable
+	void dataChanged( Model * );
+
+private slots:
+	void thisDataChanged()
+	{
+		emit dataChanged( this );
+	}
+
+signals:
+#endif
 } ;
 
 

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -70,7 +70,7 @@ protected slots:
 	void rollPreset( void );
 	void rolrPreset( void );
 	void selPreset( void );
-	void setParameter( void );
+	void setParameter( Model * action );
 
 protected:
 	virtual void paintEvent( QPaintEvent * _pe );
@@ -110,7 +110,7 @@ public:
 protected slots:
 	void syncPlugin( void );
 	void displayAutomatedOnly( void );
-	void setParameter( void );
+	void setParameter( Model * action );
 	void closeWindow();
 
 private:

--- a/plugins/vestige/vestige.h
+++ b/plugins/vestige/vestige.h
@@ -73,7 +73,7 @@ public:
 	virtual PluginView * instantiateView( QWidget * _parent );
 
 protected slots:
-	void setParameter( void );
+	void setParameter( Model * action );
 	void handleConfigChange( QString cls, QString attr, QString value );
 	void reloadPlugin();
 
@@ -109,7 +109,7 @@ public:
 protected slots:
 	void syncPlugin( void );
 	void displayAutomatedOnly( void );
-	void setParameter( void );
+	void setParameter( Model * action );
 	void closeWindow();
 
 

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1936,7 +1936,9 @@ DWORD WINAPI RemoteVstPlugin::processingThread( LPVOID _param )
 	RemotePluginClient::message m;
 	while( ( m = _this->receiveMessage() ).id != IdQuit )
         {
-		if( m.id == IdStartProcessing || m.id == IdMidiEvent )
+		if( m.id == IdStartProcessing
+			|| m.id == IdMidiEvent
+			|| m.id == IdVstSetParameter )
 		{
 			_this->processMessage( m );
 		}

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -122,13 +122,20 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 {
 	initPlugin();
 
-	connect( &m_portamentoModel, SIGNAL( dataChanged() ), this, SLOT( updatePortamento() ) );
-	connect( &m_filterFreqModel, SIGNAL( dataChanged() ), this, SLOT( updateFilterFreq() ) );
-	connect( &m_filterQModel, SIGNAL( dataChanged() ), this, SLOT( updateFilterQ() ) );
-	connect( &m_bandwidthModel, SIGNAL( dataChanged() ), this, SLOT( updateBandwidth() ) );
-	connect( &m_fmGainModel, SIGNAL( dataChanged() ), this, SLOT( updateFmGain() ) );
-	connect( &m_resCenterFreqModel, SIGNAL( dataChanged() ), this, SLOT( updateResCenterFreq() ) );
-	connect( &m_resBandwidthModel, SIGNAL( dataChanged() ), this, SLOT( updateResBandwidth() ) );
+	connect( &m_portamentoModel, SIGNAL( dataChanged() ),
+			this, SLOT( updatePortamento() ), Qt::DirectConnection );
+	connect( &m_filterFreqModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateFilterFreq() ), Qt::DirectConnection );
+	connect( &m_filterQModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateFilterQ() ), Qt::DirectConnection );
+	connect( &m_bandwidthModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateBandwidth() ), Qt::DirectConnection );
+	connect( &m_fmGainModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateFmGain() ), Qt::DirectConnection );
+	connect( &m_resCenterFreqModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateResCenterFreq() ), Qt::DirectConnection );
+	connect( &m_resBandwidthModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateResBandwidth() ), Qt::DirectConnection );
 
 	// now we need a play-handle which cares for calling play()
 	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
@@ -138,7 +145,7 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 			this, SLOT( reloadPlugin() ) );
 
 	connect( instrumentTrack()->pitchRangeModel(), SIGNAL( dataChanged() ),
-				this, SLOT( updatePitchRange() ) );
+			this, SLOT( updatePitchRange() ), Qt::DirectConnection );
 }
 
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -417,7 +417,8 @@ void AutomatableModel::linkModel( AutomatableModel* model )
 
 		if( !model->hasLinkedModels() )
 		{
-			QObject::connect( this, SIGNAL( dataChanged() ), model, SIGNAL( dataChanged() ) );
+			QObject::connect( this, SIGNAL( dataChanged() ),
+					model, SIGNAL( dataChanged() ), Qt::DirectConnection );
 		}
 	}
 }
@@ -476,7 +477,8 @@ void AutomatableModel::setControllerConnection( ControllerConnection* c )
 	m_controllerConnection = c;
 	if( c )
 	{
-		QObject::connect( m_controllerConnection, SIGNAL( valueChanged() ), this, SIGNAL( dataChanged() ) );
+		QObject::connect( m_controllerConnection, SIGNAL( valueChanged() ),
+				this, SIGNAL( dataChanged() ), Qt::DirectConnection );
 		QObject::connect( m_controllerConnection, SIGNAL( destroyed() ), this, SLOT( unlinkControllerConnection() ) );
 		m_valueChanged = true;
 		emit dataChanged();

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -117,7 +117,7 @@ void ControllerConnection::setController( Controller * _controller )
 	{
 		_controller->addConnection( this );
 		QObject::connect( _controller, SIGNAL( valueChanged() ),
-				this, SIGNAL( valueChanged() ) );
+				this, SIGNAL( valueChanged() ), Qt::DirectConnection );
 	}
 
 	m_ownsController =

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -126,10 +126,14 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 
 	setName( tr( "Default preset" ) );
 
-	connect( &m_baseNoteModel, SIGNAL( dataChanged() ), this, SLOT( updateBaseNote() ) );
-	connect( &m_pitchModel, SIGNAL( dataChanged() ), this, SLOT( updatePitch() ) );
-	connect( &m_pitchRangeModel, SIGNAL( dataChanged() ), this, SLOT( updatePitchRange() ) );
-	connect( &m_effectChannelModel, SIGNAL( dataChanged() ), this, SLOT( updateEffectChannel() ) );
+	connect( &m_baseNoteModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateBaseNote() ), Qt::DirectConnection );
+	connect( &m_pitchModel, SIGNAL( dataChanged() ),
+			this, SLOT( updatePitch() ), Qt::DirectConnection );
+	connect( &m_pitchRangeModel, SIGNAL( dataChanged() ),
+			this, SLOT( updatePitchRange() ), Qt::DirectConnection );
+	connect( &m_effectChannelModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateEffectChannel() ), Qt::DirectConnection );
 }
 
 


### PR DESCRIPTION
Connections that update values for remote plugins are now all `DirectConnection`s. The result is that changes to these values no longer always come from the main thread, but instead from the thread that changed them, which in the case of automation or controllers will be the processing thread.

This fixes the following issues:
* Hangs occurring when the project is saved while Zyn or VSTs are being automated. Value updates were sometimes sent while LMMS was waiting to receive the save data from the remote plugin, resulting in a deadlock trying to lock the plugin mutex twice on the same thread. Sending the update on a different thread solves this. (Fixes #4543, fixes #4584.)
* Stuttering audio during automation of Zyn or VSTs. Since #4460, the plugin mutex is locked using `tryLock` before getting audio from the remote plugin. If a value was being automated, the main thread was sometimes holding the lock to update the value which caused a buffer of audio to be skipped for the plugin. Sending the automation on the processing thread ensures the updates are finished before audio is rendered. (Fixes #4625.)
* Choppy/laggy/missing VST automation, especially during export. The automation used to get caught up on the main thread (a problem that was much worse on export), but is now delivered immediately on the processing thread. (I can't find an issue for this, but I've seen it mentioned from time to time on the Discord server.)