### PR TITLE
Initialize Peak Controller with Base Value fix

### DIFF
--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -65,7 +65,7 @@ PeakControllerEffect::PeakControllerEffect(
 	Effect( &peakcontrollereffect_plugin_descriptor, _parent, _key ),
 	m_effectId( rand() ),
 	m_peakControls( this ),
-	m_lastSample( m_peakControls.m_baseModel.value() ), //sets the value to the Peak Controller's Base value (rather than 0 like in previous versions)
+	m_lastSample( 0 ),
 	m_autoController( NULL )
 {
 	m_autoController = new PeakController( Engine::getSong(), this );

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
@@ -53,6 +53,7 @@ PeakControllerEffectControls( PeakControllerEffect * _eff ) :
 void PeakControllerEffectControls::loadSettings( const QDomElement & _this )
 {
 	m_baseModel.loadSettings( _this, "base" );
+	m_effect->m_lastSample = m_baseModel.value(); //Set initial Peak Controller output to Base
 	m_amountModel.loadSettings( _this, "amount" );
 	m_muteModel.loadSettings( _this, "mute" );
 


### PR DESCRIPTION
This should fix the bug (present in both master and stable 1.2) I accidentally introduced with #4382, the bug being that the Peak Controllers would initialize with a base value of 0.5 after that change, and 0 before that change.  @DomClark luckily pointed out the problem.