### PR TITLE
Fix song editor visualization after maximizing

### DIFF
--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -155,6 +155,7 @@ public:
 
 protected:
 	virtual void resizeEvent( QResizeEvent * event );
+	virtual void changeEvent( QEvent * );
 
 protected slots:
 	void play();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -723,6 +723,16 @@ void SongEditorWindow::resizeEvent(QResizeEvent *event)
 }
 
 
+void SongEditorWindow::changeEvent(QEvent *event)
+{
+	QWidget::changeEvent(event);
+	if (event->type() == QEvent::WindowStateChange)
+	{
+		m_editor->realignTracks();
+	}
+}
+
+
 void SongEditorWindow::play()
 {
 	emit playTriggered();


### PR DESCRIPTION
Fixes #70 by overriding `changeEvent` in the `SongEditorWindow` class.