### PR TITLE
Initialize peak controller last sample with base value fix (Stable 1.2)

### DIFF
--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -64,7 +64,7 @@ PeakControllerEffect::PeakControllerEffect(
 	Effect( &peakcontrollereffect_plugin_descriptor, _parent, _key ),
 	m_effectId( rand() ),
 	m_peakControls( this ),
-	m_lastSample( m_peakControls.m_baseModel.value() ), //sets the value to the Peak Controller's Base value (rather than 0 like in previous versions)
+	m_lastSample( 0 ),
 	m_autoController( NULL )
 {
 	m_autoController = new PeakController( Engine::getSong(), this );

--- a/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_controls.cpp
@@ -53,6 +53,7 @@ PeakControllerEffectControls( PeakControllerEffect * _eff ) :
 void PeakControllerEffectControls::loadSettings( const QDomElement & _this )
 {
 	m_baseModel.loadSettings( _this, "base" );
+	m_effect->m_lastSample = m_baseModel.value(); //Set initial Peak Controller output to Base
 	m_amountModel.loadSettings( _this, "amount" );
 	m_muteModel.loadSettings( _this, "mute" );
 


### PR DESCRIPTION
@PhysSong requested that I make a pull request for this for Stable 1.2 as well, which is probably a good idea.  Sorry if making a separate pull request isn't the best way to do this (I'm still learning Github physics), but I'm assuming it's fine.

This is the same fix as #4696, and fixes the bug introduced in #4382.