### PR TITLE
Allow mid-note automation of BitInvader sample length

### DIFF
--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -144,6 +144,8 @@ bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
 	m_interpolation( false, this ),
 	m_normalize( false, this )
 {
+		
+	lengthChanged();
 
 	m_graph.setWaveToSine();
 

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -140,7 +140,7 @@ sample_t bSynth::nextStringSample( float sample_length )
 bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
 	Instrument( _instrument_track, &bitinvader_plugin_descriptor ),
 	m_sampleLength( 128, 4, 200, 1, this, tr( "Sample length" ) ),
-	m_graph( -1.0f, 1.0f, 128, this ),
+	m_graph( -1.0f, 1.0f, 200, this ),
 	m_interpolation( false, this ),
 	m_normalize( false, this )
 {

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -65,17 +65,16 @@ Plugin::Descriptor PLUGIN_EXPORT bitinvader_plugin_descriptor =
 }
 
 
-bSynth::bSynth( float * _shape, int _length, NotePlayHandle * _nph, bool _interpolation,
+bSynth::bSynth( float * _shape, NotePlayHandle * _nph, bool _interpolation,
 				float _factor, const sample_rate_t _sample_rate ) :
 	sample_index( 0 ),
 	sample_realindex( 0 ),
 	nph( _nph ),
-	sample_length( _length ),
 	sample_rate( _sample_rate ),
 	interpolation( _interpolation)
 {
-	sample_shape = new float[sample_length];
-	for (int i=0; i < _length; ++i)
+	sample_shape = new float[200];
+	for (int i=0; i < 200; ++i)
 	{
 		sample_shape[i] = _shape[i] * _factor;
 	}
@@ -88,7 +87,7 @@ bSynth::~bSynth()
 }
 
 
-sample_t bSynth::nextStringSample()
+sample_t bSynth::nextStringSample( float sample_length )
 {
 	float sample_step = 
 		static_cast<float>( sample_length / ( sample_rate / nph->frequency() ) );
@@ -279,7 +278,6 @@ void bitInvader::playNote( NotePlayHandle * _n,
 
 		_n->m_pluginData = new bSynth(
 					const_cast<float*>( m_graph.samples() ),
-					m_graph.length(),
 					_n,
 					m_interpolation.value(), factor,
 				Engine::mixer()->processingSampleRate() );
@@ -291,7 +289,7 @@ void bitInvader::playNote( NotePlayHandle * _n,
 	bSynth * ps = static_cast<bSynth *>( _n->m_pluginData );
 	for( fpp_t frame = offset; frame < frames + offset; ++frame )
 	{
-		const sample_t cur = ps->nextStringSample();
+		const sample_t cur = ps->nextStringSample( m_graph.length() );
 		for( ch_cnt_t chnl = 0; chnl < DEFAULT_CHANNELS; ++chnl )
 		{
 			_working_buffer[frame][chnl] = cur;
@@ -591,7 +589,3 @@ PLUGIN_EXPORT Plugin * lmms_plugin_main( Model *, void * _data )
 
 
 }
-
-
-
-

--- a/plugins/bit_invader/bit_invader.h
+++ b/plugins/bit_invader/bit_invader.h
@@ -42,12 +42,12 @@ class bSynth
 {
 	MM_OPERATORS
 public:
-	bSynth( float * sample, int length, NotePlayHandle * _nph,
+	bSynth( float * sample, NotePlayHandle * _nph,
 			bool _interpolation, float factor, 
 			const sample_rate_t _sample_rate );
 	virtual ~bSynth();
 	
-	sample_t nextStringSample();
+	sample_t nextStringSample( float sample_length );
 
 
 private:
@@ -55,7 +55,6 @@ private:
 	float sample_realindex;
 	float* sample_shape;
 	NotePlayHandle* nph;
-	const int sample_length;
 	const sample_rate_t sample_rate;
 
 	bool interpolation;


### PR DESCRIPTION
This is one of the things requested in #4238.  It simply updates the sample length value while in the middle of playing a note in BitInvader rather than only reading the value at the beginning of the note.  You can get some very cool sounds out of this!