### PR TITLE
Fix lost control links in copied automation patterns

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -77,6 +77,7 @@ public:
 	}
 
 	static jo_id_t idToSave( jo_id_t id );
+	static jo_id_t idFromSave( jo_id_t id );
 
 	void clearJournal();
 	void stopAllJournalling();

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -791,7 +791,7 @@ void AutomationPattern::resolveAllIDs()
 						{
 							// FIXME: Remove this block once the automation system gets fixed
 							// This is a temporary fix for https://github.com/LMMS/lmms/issues/3781
-							o = Engine::projectJournal()->journallingObject( *k + ( 1 << 23 ) );
+							o = Engine::projectJournal()->journallingObject(ProjectJournal::idFromSave(*k));
 							if( o && dynamic_cast<AutomatableModel *>( o ) )
 							{
 								a->addObject( dynamic_cast<AutomatableModel *>( o ), false );

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -787,6 +787,16 @@ void AutomationPattern::resolveAllIDs()
 						{
 							a->addObject( dynamic_cast<AutomatableModel *>( o ), false );
 						}
+						else
+						{
+							// FIXME: Remove this block once the automation system gets fixed
+							// This is a temporary fix for https://github.com/LMMS/lmms/issues/3781
+							o = Engine::projectJournal()->journallingObject( *k + ( 1 << 23 ) );
+							if( o && dynamic_cast<AutomatableModel *>( o ) )
+							{
+								a->addObject( dynamic_cast<AutomatableModel *>( o ), false );
+							}
+						}
 					}
 					a->m_idsToResolve.clear();
 					a->dataChanged();

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -164,6 +164,11 @@ jo_id_t ProjectJournal::idToSave( jo_id_t id )
 	return id & ~EO_ID_MSB;
 }
 
+jo_id_t ProjectJournal::idFromSave( jo_id_t id )
+{
+	return id | EO_ID_MSB;
+}
+
 
 
 


### PR DESCRIPTION
As I said in #3781, I decided to work around the bug temporarily, at least in `stable-1.2`. I believe we can fix underlying issues as well, but the required change is too large for stable releases.
I think the ultimate solution is to decouple journaling and automation(see https://github.com/LMMS/lmms/issues/3781#issuecomment-407301931). I'll create a new issue to keep track on it once this PR gets merged.

Fixes #3781, fixes #3359.