### PR TITLE
Improve handling of nan/inf

### DIFF
--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -95,7 +95,7 @@ bool sanitize( sampleFrame * src, int frames )
 			}
 			else
 			{
-				src[f][c] = qBound( -100.0f, src[f][c], 100.0f );
+				src[f][c] = qBound( -4.0f, src[f][c], 4.0f );
 			}
 		}
 	}

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -79,12 +79,23 @@ bool sanitize( sampleFrame * src, int frames )
 		{
 			if( isinff( src[f][c] ) || isnanf( src[f][c] ) )
 			{
-				src[f][c] = 0.0f;
+				#ifdef LMMS_DEBUG
+					printf("Bad data, clearing buffer. frame: ");
+					printf("%d: value %f\n", f, src[f][c]);
+				#endif
+				for( int f = 0; f < frames; ++f )
+				{
+					for( int c = 0; c < 2; ++c )
+					{
+						src[f][c] = 0.0f;
+					}
+				}
 				found = true;
+				return found;
 			}
 			else
 			{
-				src[f][c] = qBound( -4.0f, src[f][c], 4.0f );
+				src[f][c] = qBound( -100.0f, src[f][c], 100.0f );
 			}
 		}
 	}

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -95,7 +95,7 @@ bool sanitize( sampleFrame * src, int frames )
 			}
 			else
 			{
-				src[f][c] = qBound( -4.0f, src[f][c], 4.0f );
+				src[f][c] = qBound( -10.0f, src[f][c], 10.0f );
 			}
 		}
 	}


### PR DESCRIPTION
If we find nan/inf, we declare the whole buffer bad and set it to 0.0f. I'm still clipping the signal, for now at least, but set the level at ~~+/-100.0f~~ **+/-10.0f**.

Fixes https://github.com/LMMS/lmms/issues/4665

None of the example projects used to test nan/inf works any longer as each of their specific issues has been fixed. To test this PR properly you need to cherry-pick it on top of an older version of lmms like rc2.