### PR TITLE
Don't render Automation tracks in the Beat/Bassline

### DIFF
--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -142,7 +142,10 @@ void RenderManager::renderTracks()
 	for( auto it = t2.begin(); it != t2.end(); ++it )
 	{
 		Track* tk = (*it);
-		if ( tk->isMuted() == false )
+		Track::TrackTypes type = tk->type();
+
+		if ( tk->isMuted() == false &&
+				( type == Track::InstrumentTrack || type == Track::SampleTrack ) )
 		{
 			m_unmuted.push_back(tk);
 		}

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -130,7 +130,7 @@ void RenderManager::renderTracks()
 		Track* tk = (*it);
 		Track::TrackTypes type = tk->type();
 
-		// Don't mute automation tracks
+		// Don't render automation tracks
 		if ( tk->isMuted() == false &&
 				( type == Track::InstrumentTrack || type == Track::SampleTrack ) )
 		{
@@ -144,6 +144,7 @@ void RenderManager::renderTracks()
 		Track* tk = (*it);
 		Track::TrackTypes type = tk->type();
 
+		// Don't render automation tracks
 		if ( tk->isMuted() == false &&
 				( type == Track::InstrumentTrack || type == Track::SampleTrack ) )
 		{


### PR DESCRIPTION
Copy/paste of related code in `RenderManager::renderTracks()`

Fixes https://github.com/LMMS/lmms/issues/4746