### PR TITLE
Extend quoting for AutomatableModels

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -283,6 +283,8 @@ protected:
 
 
 private:
+	static bool mustQuoteName(const QString &name);
+
 	virtual void saveSettings( QDomDocument& doc, QDomElement& element )
 	{
 		saveSettings( doc, element, "value" );


### PR DESCRIPTION
This now also quotes, if required:

- non automated models
- models controlled by controller