### PR TITLE
Prepare source: set project year

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: cpp
 compiler: gcc
 dist: trusty
 sudo: required
+git:
+    depth: false
 cache:
     directories:
         - apt_mingw_cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 install:
     - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.install.sh
 before_script:
+    - run-parts ${TRAVIS_BUILD_DIR}/.travis/prep-source
     - export CMAKE_FLAGS="-DWANT_QT5=$QT5 -DUSE_WERROR=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo"
     - if [ -z "$TRAVIS_TAG" ]; then export CMAKE_FLAGS="$CMAKE_FLAGS -DUSE_CCACHE=ON"; fi
 script:

--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PACKAGES="cmake pkgconfig fftw libogg libvorbis lame libsndfile libsamplerate jack sdl libgig libsoundio stk fluid-synth portaudio node fltk carla"
+PACKAGES="cmake debianutils pkgconfig fftw libogg libvorbis lame libsndfile libsamplerate jack sdl libgig libsoundio stk fluid-synth portaudio node fltk carla"
 
 if [ $QT5 ]; then
 	PACKAGES="$PACKAGES qt5"

--- a/.travis/prep-source/project-year
+++ b/.travis/prep-source/project-year
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+grep -Eq "^SET\(PROJECT_YEAR +[0-9]+\)" CMakeLists.txt
+
+YEAR=$(date +%Y)
+sed -E "s/^SET\(PROJECT_YEAR +[0-9]+\)/SET(PROJECT_YEAR $YEAR)/" \
+	CMakeLists.txt > CMakeLists.txt.new
+mv CMakeLists.txt.new CMakeLists.txt

--- a/.travis/prep-source/project-year
+++ b/.travis/prep-source/project-year
@@ -13,6 +13,6 @@ do
 	YEAR=$((YEAR - 1))
 done
 
-sed "/^SET(PROJECT_YEAR / c SET(PROJECT_YEAR $YEAR)" CMakeLists.txt \
-	> CMakeLists.txt.new
+sed "/^SET(PROJECT_YEAR / c \\
+SET(PROJECT_YEAR $YEAR)" CMakeLists.txt > CMakeLists.txt.new
 mv CMakeLists.txt.new CMakeLists.txt

--- a/.travis/prep-source/project-year
+++ b/.travis/prep-source/project-year
@@ -1,9 +1,18 @@
 #!/bin/sh
 set -e
 
-grep -Eq "^SET\(PROJECT_YEAR +[0-9]+\)" CMakeLists.txt
+grep -q "^SET(PROJECT_YEAR " CMakeLists.txt
 
-YEAR=$(date +%Y)
-sed -E "s/^SET\(PROJECT_YEAR +[0-9]+\)/SET(PROJECT_YEAR $YEAR)/" \
-	CMakeLists.txt > CMakeLists.txt.new
+YEAR=$(date -u +%Y)
+while true
+do
+	if [ "$(git log -n 1 --since=$YEAR-01-01T00:00:00Z)" ]
+	then
+		break
+	fi
+	YEAR=$((YEAR - 1))
+done
+
+sed "/^SET(PROJECT_YEAR / c SET(PROJECT_YEAR $YEAR)" CMakeLists.txt \
+	> CMakeLists.txt.new
 mv CMakeLists.txt.new CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ INCLUDE(FindPkgConfig)
 
 STRING(TOUPPER          "${CMAKE_PROJECT_NAME}" PROJECT_NAME_UCASE)
 
+# Updated in Travis CI builds
 SET(PROJECT_YEAR 2018)
 
 SET(PROJECT_AUTHOR      "LMMS Developers")


### PR DESCRIPTION
Prepare source by processing Git history, which helps reproducible builds. This first patch updates the project year.