### PR TITLE
Fix JACK crash on exit

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -57,6 +57,7 @@ public:
 	// the jack callback is handled here, we call the midi client so that it can read
 	// it's midi data during the callback
 	AudioJack * addMidiClient(MidiJack *midiClient);
+	void removeMidiClient();
 	jack_client_t * jackClient() {return m_client;};
 
 	inline static QString name()

--- a/include/MidiJack.h
+++ b/include/MidiJack.h
@@ -52,7 +52,8 @@ class MidiJack : public QThread, public MidiClientRaw
 public:
 	MidiJack();
 	virtual ~MidiJack();
-
+	void removeJackAudio();
+	
 	jack_client_t* jackClient();
 
 	static QString probeDevice();

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -78,7 +78,9 @@ AudioJack::~AudioJack()
 		unregisterPort( m_portMap.begin().key() );
 	}
 #endif
-
+	if(m_midiClient) {
+		m_midiClient->removeJackAudio();
+	}
 	if( m_client != nullptr )
 	{
 		if( m_active )
@@ -86,7 +88,6 @@ AudioJack::~AudioJack()
 			jack_deactivate( m_client );
 		}
 		jack_client_close( m_client );
-		m_client = nullptr;
 	}
 
 	delete[] m_tempOutBufs;
@@ -132,6 +133,10 @@ AudioJack* AudioJack::addMidiClient(MidiJack *midiClient)
 	m_midiClient = midiClient;
 
 	return this;
+}
+
+void AudioJack::removeMidiClient() {
+	m_midiClient = nullptr;
 }
 
 bool AudioJack::initJackClient()

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -79,13 +79,14 @@ AudioJack::~AudioJack()
 	}
 #endif
 
-	if( m_client != NULL )
+	if( m_client != nullptr )
 	{
 		if( m_active )
 		{
 			jack_deactivate( m_client );
 		}
 		jack_client_close( m_client );
+		m_client = nullptr;
 	}
 
 	delete[] m_tempOutBufs;

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -75,6 +75,7 @@ MidiJack::MidiJack() :
 	{
 		// if a jack connection has been created for audio we use that
 		m_jackAudio->addMidiClient(this);
+		m_jackClient = NULL;
 	}else{
 		m_jackAudio = NULL;
 		m_jackClient = jack_client_open(probeDevice().toLatin1().data(),
@@ -113,6 +114,9 @@ MidiJack::MidiJack() :
 
 MidiJack::~MidiJack()
 {
+	if( m_jackAudio ) {
+		m_jackAudio->removeMidiClient();
+	}
 	if(jackClient())
 	{
 		if( jack_port_unregister( jackClient(), m_input_port) != 0){
@@ -143,14 +147,15 @@ MidiJack::~MidiJack()
 	}
 }
 
+void MidiJack::removeJackAudio() {
+	m_jackAudio = nullptr;
+}
+
 jack_client_t* MidiJack::jackClient()
 {
-	if( m_jackAudio == NULL && m_jackClient == NULL)
-		return NULL;
-
-	if( m_jackAudio == NULL && m_jackClient )
+	if( m_jackAudio == NULL )
 		return m_jackClient;
-
+	
 	return m_jackAudio->jackClient();
 }
 

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -155,7 +155,7 @@ jack_client_t* MidiJack::jackClient()
 {
 	if( m_jackAudio == NULL )
 		return m_jackClient;
-	
+
 	return m_jackAudio->jackClient();
 }
 


### PR DESCRIPTION
Fix segfault on exit when using JACK for both audio and MIDI. This is picked from an old commit (https://github.com/LMMS/lmms/commit/abb13bd9378c22c0647a7958f8f779d4bd63e273) by @justnope. 