### PR TITLE
Fix infinite MIDI note with VST made in Cabbage (LMMS#4380)

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -180,11 +180,6 @@ void NotePlayHandle::setVolume( volume_t _volume )
 void NotePlayHandle::setPanning( panning_t panning )
 {
 	Note::setPanning( panning );
-
-	MidiEvent event( MidiMetaEvent, midiChannel(), midiKey(), panningToMidi( panning ) );
-	event.setMetaEvent( MidiNotePanning );
-
-	m_instrumentTrack->processOutEvent( event );
 }
 
 


### PR DESCRIPTION
As explained in #4380 this commit fixes the infinite MIDI note bug that happened when the user clicked to add a note in the pianoroll of a VST made in Cabbage.

Thanks in advance for reviewing it.

(This is my first PR, let me know if I made any mistake)