### PR TITLE
Disable built-in NaN handler through hidden setting

### DIFF
--- a/include/MixHelpers.h
+++ b/include/MixHelpers.h
@@ -33,6 +33,10 @@ namespace MixHelpers
 
 bool isSilent( const sampleFrame* src, int frames );
 
+bool useNaNHandler();
+
+void setNaNHandler( bool use );
+
 bool sanitize( sampleFrame * src, int frames );
 
 /*! \brief Add samples from src to dst */

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -142,6 +142,7 @@ private:
 	bool m_MMPZ;
 	bool m_disableBackup;
 	bool m_openLastProject;
+	bool m_NaNHandler;
 	bool m_hqAudioDev;
 	QString m_lang;
 	QStringList m_languages;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -64,6 +64,7 @@
 #include "GuiApplication.h"
 #include "ImportFilter.h"
 #include "MainWindow.h"
+#include "MixHelpers.h"
 #include "OutputSettings.h"
 #include "ProjectRenderer.h"
 #include "RenderManager.h"
@@ -632,6 +633,10 @@ int main( int argc, char * * argv )
 	}
 
 	ConfigManager::inst()->loadConfigFile(configFile);
+
+	// Hidden settings
+	MixHelpers::setNaNHandler( ConfigManager::inst()->value( "app",
+						"nanhandler", "1" ).toInt() );
 
 	// set language
 	QString pos = ConfigManager::inst()->value( "app", "language" );

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -99,6 +99,8 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 							"disablebackup" ).toInt() ),
 	m_openLastProject( ConfigManager::inst()->value( "app",
 							"openlastproject" ).toInt() ),
+	m_NaNHandler( ConfigManager::inst()->value( "app",
+							"nanhandler", "1" ).toInt() ),
 	m_hqAudioDev( ConfigManager::inst()->value( "mixer",
 							"hqaudio" ).toInt() ),
 	m_lang( ConfigManager::inst()->value( "app",
@@ -333,6 +335,15 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 				this, SLOT( toggleOpenLastProject( bool ) ) );
 
 	misc_tw->setFixedHeight( YDelta*labelNumber + HeaderSize );
+
+	// Advanced setting, hidden for now
+	if( false )
+	{
+		LedCheckBox * useNaNHandler = new LedCheckBox(
+				tr( "Use built-in NaN handler" ),
+								misc_tw );
+		useNaNHandler->setChecked( m_NaNHandler );
+	}
 
 	TabWidget* embed_tw = new TabWidget( tr( "PLUGIN EMBEDDING" ), general);
 	embed_tw->setFixedHeight( 48 );
@@ -1055,6 +1066,8 @@ void SetupDialog::accept()
 					QString::number( !m_disableBackup ) );
 	ConfigManager::inst()->setValue( "app", "openlastproject",
 					QString::number( m_openLastProject ) );
+	ConfigManager::inst()->setValue( "app", "nanhandler",
+					QString::number( m_NaNHandler ) );
 	ConfigManager::inst()->setValue( "mixer", "hqaudio",
 					QString::number( m_hqAudioDev ) );
 	ConfigManager::inst()->setValue( "ui", "smoothscroll",


### PR DESCRIPTION
Disable built-in handler for NaN and huge values; this allows the user to control these cases. Default is to use the handler.