### PR TITLE
Don't let silent instruments wake up sleeping effects

### DIFF
--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -119,7 +119,9 @@ void AudioPort::doProcessing()
 	{
 		if( ph->buffer() )
 		{
-			if( ph->usesBuffer() )
+			if( ph->usesBuffer()
+				&& ( ph->type() == PlayHandle::TypeNotePlayHandle
+					|| !MixHelpers::isSilent( ph->buffer(), fpp ) ) )
 			{
 				m_bufferUsage = true;
 				MixHelpers::add( m_portBuffer, ph->buffer(), fpp );


### PR DESCRIPTION
Fixes #4564.

Ensures a `PlayHandle`'s buffer is not silent before mixing it in to the audio port. This avoids waking up all downstream effects unless there is some audio present. The test is not performed for `NotePlayHandle`s for performance reasons, in line with similar code in `InstrumentTrack::processAudioBuffer`. https://github.com/LMMS/lmms/blob/c1ae1ed5f4246de40c3cfe5327d7dfbd5cd4470b/src/tracks/InstrumentTrack.cpp#L170-L175

Using a slightly different approach from https://github.com/LMMS/lmms/issues/4564#issuecomment-456479396 as suggested by gi0e5b06.