### PR TITLE
Follow instructions from cartr/homebrew-qt4

### DIFF
--- a/.travis/osx..install.sh
+++ b/.travis/osx..install.sh
@@ -4,10 +4,14 @@ PACKAGES="cmake pkgconfig fftw libogg libvorbis lame libsndfile libsamplerate ja
 
 if [ $QT5 ]; then
 	PACKAGES="$PACKAGES qt5"
-else
-	PACKAGES="$PACKAGES cartr/qt4/qt"
 fi
 
 brew install $PACKAGES ccache
+
+if [ -z "$QT5" ]; then
+	brew tap cartr/qt4
+	brew tap-pin cartr/qt4
+	brew install qt@4
+fi
 
 sudo npm install -g appdmg


### PR DESCRIPTION
Recently, the build with Qt4 on macOS has stopped working. Following these [instructions](https://github.com/cartr/homebrew-qt4#homebrew-qt4) restores the build.