### PR TITLE
Move QT_X11_NO_NATIVE_MENUBAR to code

### DIFF
--- a/cmake/linux/lmms.desktop
+++ b/cmake/linux/lmms.desktop
@@ -8,7 +8,7 @@ Comment=Music sequencer and synthesizer
 Comment[ca]=Producció fàcil de música per a tothom!
 Comment[fr]=Production facile de musique pour tout le monde !
 Icon=lmms
-Exec=env QT_X11_NO_NATIVE_MENUBAR=1 lmms %f
+Exec=lmms %f
 Terminal=false
 Type=Application
 Categories=Qt;AudioVideo;Audio;Midi;

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -194,11 +194,6 @@ void fileCheck( QString &file )
 
 int main( int argc, char * * argv )
 {
-#if defined( LMMS_BUILD_LINUX ) && QT_VERSION < 0x050000
-	if( setenv( "QT_X11_NO_NATIVE_MENUBAR", "1", 0 ) )
-		fprintf( stderr, "Error setting default environment.\n" );
-#endif
-
 	// initialize memory managers
 	NotePlayHandleManager::init();
 
@@ -256,6 +251,9 @@ int main( int argc, char * * argv )
 		printf( "LMMS cannot be run as root.\nUse \"--allowroot\" to override.\n\n" );
 		return EXIT_FAILURE;
 	}	
+#endif
+#if defined( LMMS_BUILD_LINUX ) && QT_VERSION < 0x050000
+	QCoreApplication::setAttribute( Qt::AA_DontUseNativeMenuBar );
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -194,7 +194,7 @@ void fileCheck( QString &file )
 
 int main( int argc, char * * argv )
 {
-#ifdef LMMS_BUILD_LINUX
+#if defined( LMMS_BUILD_LINUX ) && QT_VERSION < 0x050000
 	if( setenv( "QT_X11_NO_NATIVE_MENUBAR", "1", 0 ) )
 		fprintf( stderr, "Error setting default environment.\n" );
 #endif

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -252,7 +252,8 @@ int main( int argc, char * * argv )
 		return EXIT_FAILURE;
 	}	
 #endif
-#if defined( LMMS_BUILD_LINUX ) && QT_VERSION < 0x050000
+#ifdef LMMS_BUILD_LINUX
+	// don't let OS steal the menu bar. FIXME: only effective on Qt4
 	QCoreApplication::setAttribute( Qt::AA_DontUseNativeMenuBar );
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -194,9 +194,10 @@ void fileCheck( QString &file )
 
 int main( int argc, char * * argv )
 {
-	// default environment
+#ifdef LMMS_BUILD_LINUX
 	if( setenv( "QT_X11_NO_NATIVE_MENUBAR", "1", 0 ) )
 		fprintf( stderr, "Error setting default environment.\n" );
+#endif
 
 	// initialize memory managers
 	NotePlayHandleManager::init();

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -194,6 +194,10 @@ void fileCheck( QString &file )
 
 int main( int argc, char * * argv )
 {
+	// default environment
+	if( setenv( "QT_X11_NO_NATIVE_MENUBAR", "1", 0 ) )
+		fprintf( stderr, "Error setting default environment.\n" );
+
 	// initialize memory managers
 	NotePlayHandleManager::init();
 


### PR DESCRIPTION
Enable `QT_X11_NO_NATIVE_MENUBAR` by default. Clean up the desktop entry.