### PR TITLE
Ensure the restore button of a subwindow shows up correctly 

### DIFF
--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -81,7 +81,6 @@ private:
 	QGraphicsDropShadowEffect * m_shadow;
 
 	static void elideText( QLabel *label, QString text );
-	bool isMaximized();
 	void adjustTitleBar();
 };
 

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -302,8 +302,11 @@ void SubWindow::adjustTitleBar()
 
 void SubWindow::resizeEvent( QResizeEvent * event )
 {
-	adjustTitleBar();
+	// When the parent QMdiArea gets resized, maximized subwindows also gets resized, if any.
+	// In that case, we should call QMdiSubWindow::resizeEvent first
+	// to ensure we get the correct window state.
 	QMdiSubWindow::resizeEvent( event );
+	adjustTitleBar();
 
 	// if the window was resized and ISN'T minimized/maximized/fullscreen,
 	// then save the current size

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -148,23 +148,6 @@ void SubWindow::elideText( QLabel *label, QString text )
 
 
 
-bool SubWindow::isMaximized()
-{
-#ifdef LMMS_BUILD_APPLE
-	// check if subwindow size is identical to the MdiArea size, accounting for scrollbars
-	int hScrollBarHeight = mdiArea()->horizontalScrollBar()->isVisible() ? mdiArea()->horizontalScrollBar()->size().height() : 0;
-	int vScrollBarWidth = mdiArea()->verticalScrollBar()->isVisible() ? mdiArea()->verticalScrollBar()->size().width() : 0;
-	QSize areaSize( this->mdiArea()->size().width() - vScrollBarWidth, this->mdiArea()->size().height() - hScrollBarHeight );
-
-	return areaSize == this->size();
-#else
-	return QMdiSubWindow::isMaximized();
-#endif
-}
-
-
-
-
 QRect SubWindow::getTrueNormalGeometry() const
 {
 	return m_trackedNormalGeom;


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/488#issuecomment-462098257 correctly, as described in https://github.com/LMMS/lmms/issues/488#issuecomment-462101363. Also removes a Mac-specific workaround introduced in #2798.