### PR TITLE
lmms_math: Fix build with musl

### DIFF
--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -34,7 +34,7 @@
 #include <cmath>
 using namespace std;
 
-#if defined (LMMS_BUILD_WIN32) || defined (LMMS_BUILD_APPLE) || defined(LMMS_BUILD_HAIKU)  || defined (__FreeBSD__) || defined(__OpenBSD__)
+#ifndef __GLIBC__
 #ifndef isnanf
 #define isnanf(x)	isnan(x)
 #endif


### PR DESCRIPTION
When deciding to polyfill glibc features, check if the standard library claims to be glibc, instead of enumerating platforms in the condition. Unlike master branch which in de3b344 changes math function calls to standard, stable-1.2 keeps their glibc names and fails to build on Linux with another libc such as musl.