### PR TITLE
Sync Debian version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
           osx_image: xcode8.2
           env: QT5=True
         - env: TARGET_OS=debian-sid TARGET_DEPLOY=True
+          git:
+              depth: false
         - env: TARGET_OS=debian-sid TARGET_ARCH=i386
         - compiler: clang
           env: TARGET_OS=debian-sid

--- a/.travis/linux.debian-sid.script.sh
+++ b/.travis/linux.debian-sid.script.sh
@@ -61,8 +61,6 @@ sync_version() {
 
 	sed "1 s/@VERSION@/$VERSION/" -i debian/changelog
 	echo Set Debian version to $VERSION
-# temporary
-head debian/changelog
 }
 
 sync_version

--- a/.travis/linux.debian-sid.script.sh
+++ b/.travis/linux.debian-sid.script.sh
@@ -31,6 +31,42 @@ else
 	sudo pbuilder --update --basetgz "$BASETGZ"
 fi
 
+sync_version() {
+	local VERSION
+	local MMR
+	local STAGE
+	local EXTRA
+
+	VERSION=$(git describe --tags --match v[0-9].[0-9].[0-9]*)
+	VERSION=${VERSION#v}
+	MMR=${VERSION%%-*}
+	case $VERSION in
+	*-*-*-*)
+		VERSION=${VERSION%-*}
+		STAGE=${VERSION#*-}
+		STAGE=${STAGE%-*}
+		EXTRA=${VERSION##*-}
+		VERSION=$MMR~$STAGE.$EXTRA
+		;;
+	*-*-*)
+		VERSION=${VERSION%-*}
+		EXTRA=${VERSION##*-}
+		VERSION=$MMR.$EXTRA
+		;;
+	*-*)
+		STAGE=${VERSION#*-}
+		VERSION=$MMR~$STAGE
+		;;
+	esac
+
+	sed "1 s/@VERSION@/$VERSION/" -i debian/changelog
+	echo Set Debian version to $VERSION
+# temporary
+head debian/changelog
+}
+
+sync_version
+
 DIR="$PWD"
 cd ..
 dpkg-source -b "$DIR"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-lmms (1.2.0~rc7.1) unstable; urgency=low
+lmms (@VERSION@) unstable; urgency=low
 
   * Upstream integration.
   * Drop Debian menu entry (policy 9.6).


### PR DESCRIPTION
Set Debian version following rules from `cmake/modules/VersionInfo.cmake`.

Fixes release issue uncovered by https://github.com/LMMS/lmms/commit/55eb831507250b236de80e63d376083dde0b3ae1.