### PR TITLE
Move apt_mingw_cache out of build directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 sudo: required
 cache:
     directories:
-        - apt_mingw_cache
+        - $HOME/apt_mingw_cache
         - $HOME/.ccache
         - $HOME/pbuilder-bases
 matrix:

--- a/.travis/linux.win.download.sh
+++ b/.travis/linux.win.download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-CACHE_DIR=$TRAVIS_BUILD_DIR/apt_mingw_cache/$1
+CACHE_DIR=$HOME/apt_mingw_cache/$1
 mkdir -p $CACHE_DIR
 
 pushd $CACHE_DIR


### PR DESCRIPTION
Source tarball contains `apt_mingw_cache`, which is unnecessary. So move this cache directory to a better location.