### PR TITLE
Test deployment preparation in regular builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ script:
     - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.script.sh
 after_script:
     - ccache -s
-before_deploy:
-    - if [ "$TARGET_OS" != debian-sid ]; then make package; fi
 deploy:
     provider: releases
     api_key:

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -7,10 +7,11 @@ if [ $QT5 ]; then
 	source /opt/qt59/bin/qt59-env.sh
 fi
 
-cmake -DUSE_WERROR=ON $CMAKE_FLAGS ..
+cmake -DCMAKE_INSTALL_PREFIX=../target/ -DUSE_WERROR=ON $CMAKE_FLAGS ..
 
 make -j4
 make tests
 ./tests/tests
 
-sudo make package
+make install
+make appimage

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -13,4 +13,4 @@ make -j4
 make tests
 ./tests/tests
 
-make package
+sudo make package

--- a/.travis/linux..script.sh
+++ b/.travis/linux..script.sh
@@ -12,3 +12,5 @@ cmake -DUSE_WERROR=ON $CMAKE_FLAGS ..
 make -j4
 make tests
 ./tests/tests
+
+make package

--- a/.travis/linux.win32.script.sh
+++ b/.travis/linux.win32.script.sh
@@ -6,3 +6,5 @@ export CMAKE_OPTS="$CMAKE_FLAGS -DUSE_WERROR=ON"
 ../cmake/build_mingw32.sh
 
 make -j4
+
+make package

--- a/.travis/linux.win64.script.sh
+++ b/.travis/linux.win64.script.sh
@@ -6,3 +6,5 @@ export CMAKE_OPTS="$CMAKE_FLAGS -DUSE_WERROR=ON"
 ../cmake/build_mingw64.sh
 
 make -j4
+
+make package

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -12,3 +12,5 @@ cmake $CMAKE_FLAGS -DUSE_WERROR=OFF ..
 make -j4
 make tests
 ./tests/tests
+
+make package

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -7,11 +7,11 @@ if [ $QT5 ]; then
         export CMAKE_PREFIX_PATH="$(brew --prefix qt5)"
 fi
 
-cmake $CMAKE_FLAGS -DUSE_WERROR=OFF ..
+cmake -DCMAKE_INSTALL_PREFIX=../target/ $CMAKE_FLAGS -DUSE_WERROR=OFF ..
 
 make -j4
 make tests
 ./tests/tests
 
-# TODO
-#sudo make package
+make install
+make dmg

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -13,4 +13,4 @@ make -j4
 make tests
 ./tests/tests
 
-make package
+sudo make package

--- a/.travis/osx..script.sh
+++ b/.travis/osx..script.sh
@@ -13,4 +13,5 @@ make -j4
 make tests
 ./tests/tests
 
-sudo make package
+# TODO
+#sudo make package


### PR DESCRIPTION
Deployment steps should be tested in regular builds because contributions may break this process inadvertently.