### PR TITLE
Add needed macOS shortcuts

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -404,6 +404,7 @@ void AutomationEditor::keyPressEvent(QKeyEvent * ke )
 			}
 			break;
 
+		case Qt::Key_Backspace:
 		case Qt::Key_Delete:
 			deleteSelectedValues();
 			ke->accept();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1184,6 +1184,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke )
 			clearSelectedNotes();
 			break;
 
+		case Qt::Key_Backspace:
 		case Qt::Key_Delete:
 			deleteSelectedNotes();
 			ke->accept();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -321,7 +321,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 	}
 	else if(/* _ke->modifiers() & Qt::ShiftModifier &&*/
 			gui->mainWindow()->isShiftPressed() == true &&
-						ke->key() == Qt::Key_Delete )
+						( ke->key() == Qt::Key_Delete || ke->key() == Qt::Key_Backspace ) )
 	{
 		m_song->removeBar();
 	}

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -315,7 +315,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 {
 	if( /*_ke->modifiers() & Qt::ShiftModifier*/
 		gui->mainWindow()->isShiftPressed() == true &&
-						ke->key() == Qt::Key_Insert )
+						( ke->key() == Qt::Key_Insert || ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return ) )
 	{
 		m_song->insertBar();
 	}


### PR DESCRIPTION
* Configures `Qt::Key_Backspace` (i.e. what Mac calls <kbd>Delete</kbd>) the ability to behave like the regular PC <kbd>Del</kbd>  key.
* Configures  <kbd>Shift</kbd> + <kbd>Return</kbd> (and subsequently, <kbd>Shift</kbd>  + <kbd>Enter</kbd> ) to behave like <kbd>Shift</kbd>  + <kbd>Ins</kbd> for inserting bars in the SongEditor  (credits to @lookitsnicholas in #4526 for the key combinations)
* Configures  <kbd>Shift</kbd>  + `Qt::Key_Backspace` (i.e. what Mac calls <kbd>Delete</kbd>) to behave like <kbd>Shift</kbd>  + <kbd>Del</kbd> for deleting bars in the SongEditor

Note, this will allow PC users to use these shortcuts as well.  I didn't find any code conflicts (e.g. other uses of Backspace/Enter)  that suggests this is a bad idea.  The consistency will have the added benefit of edge-cases with mixed hardware too (e.g. PC keyboard on Mac, Mac keyboard on PC).  I can't find any downside to providing both.

Previously there was no way to perform these operations on an Apple keyboard.

Closes #4522
Supersedes #4526 