### PR TITLE
Automation Editor: Don't accept drag events when there's no pattern

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2565,6 +2565,9 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 
 void AutomationEditorWindow::dragEnterEvent( QDragEnterEvent *_dee )
 {
+	if (! m_editor->validPattern() ) {
+		return;
+	}
 	StringPairDrag::processDragEnterEvent( _dee, "automatable_model" );
 }
 


### PR DESCRIPTION
Fixes #4857 by not accepting drag events in an empty automation editor.