### PR TITLE
Add CLI flag to disconnect all MIDI controllers when loading a project

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -304,6 +304,16 @@ public:
 		return false;
 	}
 
+	inline void setDisconnectMidiControllersOnLoad( bool val )
+	{
+		m_disconnectMidiControllersOnLoad = val;
+	}
+
+	inline bool getDisconnectMidiControllersOnLoad()
+	{
+		return m_disconnectMidiControllersOnLoad;
+	}
+
 	void addController( Controller * c );
 	void removeController( Controller * c );
 
@@ -418,6 +428,8 @@ private:
 	volatile bool m_renderBetweenMarkers;
 	volatile bool m_playing;
 	volatile bool m_paused;
+
+	bool m_disconnectMidiControllersOnLoad;
 
 	bool m_loadingProject;
 	bool m_isCancelled;

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -198,9 +198,19 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 void ControllerConnection::loadSettings( const QDomElement & _this )
 {
 	QDomNode node = _this.firstChild();
+
+	bool disconnectMidiControllers = Engine::getSong()->getDisconnectMidiControllersOnLoad();
+
 	if( !node.isNull() )
 	{
-		setController( Controller::create( node.toElement(), Engine::getSong() ) );
+		if ( disconnectMidiControllers )
+		{
+			deleteConnection();
+		}
+		else
+		{
+			setController( Controller::create( node.toElement(), Engine::getSong() ) );
+		}
 	}
 	else
 	{

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -300,6 +300,7 @@ int main( int argc, char * * argv )
 	bool allowRoot = false;
 	bool renderLoop = false;
 	bool renderTracks = false;
+	bool disconnectMidiControllers = false;
 	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
 
 	// first of two command-line parsing stages
@@ -673,6 +674,10 @@ int main( int argc, char * * argv )
 
 			configFile = QString::fromLocal8Bit( argv[i] );
 		}
+		else if( arg == "--disconnect-midi-controllers" )
+		{
+			disconnectMidiControllers = true;
+		}
 		else
 		{
 			if( argv[i][0] == '-' )
@@ -922,6 +927,7 @@ int main( int argc, char * * argv )
 			}
 			else
 			{
+				Engine::getSong()->setDisconnectMidiControllersOnLoad( disconnectMidiControllers );
 				Engine::getSong()->loadProject( fileToLoad );
 			}
 		}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -170,6 +170,8 @@ void printHelp()
 		"      --allowroot                Bypass root user startup check (use with\n"
 		"          caution).\n"
 		"  -c, --config <configfile>      Get the configuration from <configfile>\n"
+		"      --disconnect-midi-controllers\n"
+		"                                 Disconnect all MIDI inputs and controllers.\n"
 		"  -h, --help                     Show this usage information and exit.\n"
 		"  -v, --version                  Show version information and exit.\n"
 		"\nOptions if no action is given:\n"

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -235,7 +235,9 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 
 	// restore connections
 
-	if( isInputEnabled() )
+	bool disconnectMidiControllers = Engine::getSong()->getDisconnectMidiControllersOnLoad();
+
+	if( isInputEnabled() && !disconnectMidiControllers )
 	{
 		QStringList rp = thisElement.attribute( "inports" ).split( ',' );
 		for( Map::ConstIterator it = m_readablePorts.begin(); it != m_readablePorts.end(); ++it )


### PR DESCRIPTION
This is a redo of #4874, using master as base branch.

==

Hi!

Consider this PR as a request for comment, as this is my first attempt at hacking on LMMS.

This introduces a CLI flag (--disconnect-midi-controllers) used to disconnect all MIDI inputs from instrument tracks, as well as all MIDI controllers from instrument, FX and other global/song parameters. Other user controllers should be left untouched.

In and of itself, I find it useful to have a quick way to remove all midi connections from an existing project. For example, consider moving a project that has an extensive MIDI configuration for a specific hardware controller, over to another type of hardware controller. As I understand it, the current workflow would require disconnecting each individual controller mapping, one by one.

Also, it could be thought of as a quick fix for the following issues:
#4385
#2625
#193

Is this idea of any interest to anyone else?

If so, I understand that this is probably a naive approach and would welcome your feedback!

Many thanks!