### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Bug Summary
+
+#### Steps to reproduce
+
+#### Expected behavior
+
+#### Actual behavior
+
+#### Screenshot
+
+#### Logs
+<details>
+  <summary>Click to expand</summary>
+<pre>
+# paste here
+</pre>
+</details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+# Please search the issue tracker for existing bug reports before submitting your own. Delete this line to confirm no similar report has been posted yet.
+
 ### Bug Summary
 
 #### Steps to reproduce
@@ -17,10 +19,12 @@ assignees: ''
 
 #### Screenshot
 
+#### LMMS version used
+
 #### Logs
 <details>
   <summary>Click to expand</summary>
 <pre>
-# paste here
+<!-- paste logs here -->
 </pre>
 </details>

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+- name: Get help on Discord
+  url: https://lmms.io/chat/
+  about: Need help? Have a question? Reach out to other LMMS users on our Discord server!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,8 +7,12 @@ assignees: ''
 
 ---
 
+# Please search the issue tracker for existing feature requests before submitting your own. Delete this line to confirm no similar request has been posted yet.
+
 ### Enhancement Summary
 
 #### Justification
 
 #### Mockup
+
+<!-- If your request encompasses changes to the user interface, provide a mockup of your proposal here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+### Enhancement Summary
+
+#### Justification
+
+#### Mockup


### PR DESCRIPTION
This adds @tresf's issue templates for bug reports and feature requests as proposed in https://github.com/LMMS/lmms/pull/4196#issuecomment-372880674. When this is merged, clicking on `New Issue` will result in something similar to this example:

![image](https://user-images.githubusercontent.com/2879917/54085909-75d0d180-4343-11e9-9197-58d2c30dddbf.png)

Issues created using these templates will automatically be assigned the `bug` or `enhancement` label respectively.

Supersedes  #4196.
