### PR TITLE
Avoid shallow clones in all Debian sid builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,12 @@ matrix:
           git:
               depth: false
         - env: TARGET_OS=debian-sid TARGET_ARCH=i386
+          git:
+              depth: false
         - compiler: clang
           env: TARGET_OS=debian-sid
+          git:
+              depth: false
 before_install:
    - . ${TRAVIS_BUILD_DIR}/.travis/${TRAVIS_OS_NAME}.${TARGET_OS}.before_install.sh
 install:


### PR DESCRIPTION
Shallow clone may break version detection. This is fatal in Debian builds, so use full clone.