### PR TITLE
Rename "FX-Mixer" to "Mixer".

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Features
 * Song-Editor for composing songs
 * A Beat+Bassline-Editor for creating beats and basslines
 * An easy-to-use Piano-Roll for editing patterns and melodies
-* An FX mixer with unlimited FX channels and arbitrary number of effects
+* An mixer with unlimited FX channels and arbitrary number of effects
 * Many powerful instrument and effect-plugins out of the box
 * Full user-defined track-based automation and computer-controlled automation sources
 * Compatible with many standards such as SoundFont2, VST(i), LADSPA, GUS Patches, and full MIDI support

--- a/data/locale/ar.ts
+++ b/data/locale/ar.ts
@@ -2221,7 +2221,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/ar.ts
+++ b/data/locale/ar.ts
@@ -3758,11 +3758,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3963,7 +3963,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ar.ts
+++ b/data/locale/ar.ts
@@ -2234,7 +2234,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/bs.ts
+++ b/data/locale/bs.ts
@@ -2760,7 +2760,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     <name>FxMixerView</name>
     <message>
         <location filename="src/gui/FxMixerView.cpp" line="66"/>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/bs.ts
+++ b/data/locale/bs.ts
@@ -2742,49 +2742,49 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
-        <location filename="src/core/FxMixer.cpp" line="655"/>
+        <location filename="src/core/Mixer.cpp" line="655"/>
         <source>Master</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/core/FxMixer.cpp" line="655"/>
-        <location filename="src/core/FxMixer.cpp" line="779"/>
-        <location filename="src/core/FxMixer.cpp" line="781"/>
+        <location filename="src/core/Mixer.cpp" line="655"/>
+        <location filename="src/core/Mixer.cpp" line="779"/>
+        <location filename="src/core/Mixer.cpp" line="781"/>
         <source>FX %1</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="66"/>
+        <location filename="src/gui/MixerView.cpp" line="66"/>
         <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="276"/>
+        <location filename="src/gui/MixerView.cpp" line="276"/>
         <source>FX Fader %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="281"/>
+        <location filename="src/gui/MixerView.cpp" line="281"/>
         <source>Mute</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="289"/>
+        <location filename="src/gui/MixerView.cpp" line="289"/>
         <source>Mute this FX channel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="291"/>
+        <location filename="src/gui/MixerView.cpp" line="291"/>
         <source>Solo</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="src/gui/FxMixerView.cpp" line="301"/>
+        <location filename="src/gui/MixerView.cpp" line="301"/>
         <source>Solo FX channel</source>
         <translation type="unfinished"/>
     </message>
@@ -2802,8 +2802,8 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxRoute</name>
     <message>
-        <location filename="src/core/FxMixer.cpp" line="41"/>
-        <location filename="src/core/FxMixer.cpp" line="56"/>
+        <location filename="src/core/Mixer.cpp" line="41"/>
+        <location filename="src/core/Mixer.cpp" line="56"/>
         <source>Amount to send from channel %1 to channel %2</source>
         <translation type="unfinished"/>
     </message>

--- a/data/locale/bs.ts
+++ b/data/locale/bs.ts
@@ -4780,12 +4780,12 @@ Please make sure you have write-access to the file and try again.</source>
     </message>
     <message>
         <location filename="src/gui/MainWindow.cpp" line="526"/>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
         <location filename="src/gui/MainWindow.cpp" line="531"/>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -4911,7 +4911,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
     </message>
     <message>
         <location filename="src/gui/MainWindow.cpp" line="1184"/>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -2219,7 +2219,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2230,7 +2230,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/ca.ts
+++ b/data/locale/ca.ts
@@ -3756,11 +3756,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3961,7 +3961,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -2234,7 +2234,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>FX mixážní panel</translation>
     </message>
     <message>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -2221,7 +2221,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>FX mixážní panel</translation>

--- a/data/locale/cs.ts
+++ b/data/locale/cs.ts
@@ -3760,11 +3760,11 @@ Ujistěte se prosím, že máte k souboru právo zápisu a zkuste to znovu.</tra
         <translation>Klikněte sem, pokud chcete ukázat nebo schovat Automatizační editor. S pomocí Automatizačního editoru můžete jednoduchým způsobem editovat dynamické hodnoty.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>FX mixážní panel</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Klikněte sem, pokud chcete ukázat nebo skrýt FX mixážní panel. FX mixážní panel je velmi silný nástroj pro správu efektů ve vaší skladbě. Efekty můžete vkládat do různých efektových kanálů.</translation>
     </message>
     <message>
@@ -3966,7 +3966,7 @@ Navštivte prosím stránku s dokumentací k LMMS na adrese http://lmms.sf.net/w
         <translation>Zobrazit/skrýt editor automatizace</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Zobrazit/skrýt FX mixážní panel</translation>
     </message>
     <message>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -2239,7 +2239,7 @@ Sie können FX Kanäle im Kontextmenü entfernen und verschieben, welches durch 
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Master</translation>
@@ -2250,7 +2250,7 @@ Sie können FX Kanäle im Kontextmenü entfernen und verschieben, welches durch 
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer</translation>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -2252,8 +2252,8 @@ Sie können FX Kanäle im Kontextmenü entfernen und verschieben, welches durch 
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
-        <translation>FX-Mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>FX Fader %1</source>
@@ -3779,11 +3779,11 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
     </message>
     <message>
         <source>FX Mixer</source>
-        <translation>Zeige/verstecke FX-Mixer</translation>
+        <translation>Zeige/verstecke Mixer</translation>
     </message>
     <message>
         <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
-        <translation>Hier klicken, um den FX-Mixer zu zeigen oder verstecken. Der FX-Mixer ist ein leistungsfähiges Werkzeug, um Effekte für Ihren Song zu verwalten. Sie können verschiedene Effekte in unterschiedliche Effekt-Kanäle einfügen.</translation>
+        <translation>Hier klicken, um den Mixer zu zeigen oder verstecken. Der Mixer ist ein leistungsfähiges Werkzeug, um Effekte für Ihren Song zu verwalten. Sie können verschiedene Effekte in unterschiedliche Effekt-Kanäle einfügen.</translation>
     </message>
     <message>
         <source>Project Notes</source>

--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -3778,11 +3778,11 @@ Bitte überprüfen Sie Ihre Rechte und versuchen es erneut.</translation>
         <translation>Hier klicken, um den Automation-Editor zu zeigen oder verstecken. Mit Hilfe des Automation-Editors können Sie Automation-Patterns auf einfache Art und Weise bearbeiten.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Zeige/verstecke Mixer</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Hier klicken, um den Mixer zu zeigen oder verstecken. Der Mixer ist ein leistungsfähiges Werkzeug, um Effekte für Ihren Song zu verwalten. Sie können verschiedene Effekte in unterschiedliche Effekt-Kanäle einfügen.</translation>
     </message>
     <message>
@@ -3984,8 +3984,8 @@ Bitte besuchen Sie http://lmms.sf.net/wiki für Dokumentationen über LMMS.</tra
         <translation>Zeige/Verstecke Automations Editor</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
-        <translation>Zeige/Verstecke FX Mixer</translation>
+        <source>Show/hide Mixer</source>
+        <translation>Zeige/Verstecke Mixer</translation>
     </message>
     <message>
         <source>Show/hide project notes</source>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -4898,12 +4898,12 @@ Please make sure you have write permission to the file and the directory contain
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="544"/>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="549"/>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5029,7 +5029,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="1223"/>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -2830,7 +2830,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     <name>FxMixerView</name>
     <message>
         <location filename="../../src/gui/FxMixerView.cpp" line="68"/>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/en.ts
+++ b/data/locale/en.ts
@@ -2797,64 +2797,64 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="665"/>
+        <location filename="../../src/core/Mixer.cpp" line="665"/>
         <source>Master</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="665"/>
-        <location filename="../../src/core/FxMixer.cpp" line="780"/>
-        <location filename="../../src/core/FxMixer.cpp" line="782"/>
+        <location filename="../../src/core/Mixer.cpp" line="665"/>
+        <location filename="../../src/core/Mixer.cpp" line="780"/>
+        <location filename="../../src/core/Mixer.cpp" line="782"/>
         <source>FX %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="666"/>
+        <location filename="../../src/core/Mixer.cpp" line="666"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="667"/>
+        <location filename="../../src/core/Mixer.cpp" line="667"/>
         <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="668"/>
+        <location filename="../../src/core/Mixer.cpp" line="668"/>
         <source>Solo</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="68"/>
+        <location filename="../../src/gui/MixerView.cpp" line="68"/>
         <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="281"/>
+        <location filename="../../src/gui/MixerView.cpp" line="281"/>
         <source>FX Fader %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="290"/>
+        <location filename="../../src/gui/MixerView.cpp" line="290"/>
         <source>Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="298"/>
+        <location filename="../../src/gui/MixerView.cpp" line="298"/>
         <source>Mute this FX channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="300"/>
+        <location filename="../../src/gui/MixerView.cpp" line="300"/>
         <source>Solo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="310"/>
+        <location filename="../../src/gui/MixerView.cpp" line="310"/>
         <source>Solo FX channel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2862,8 +2862,8 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxRoute</name>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="41"/>
-        <location filename="../../src/core/FxMixer.cpp" line="56"/>
+        <location filename="../../src/core/Mixer.cpp" line="41"/>
+        <location filename="../../src/core/Mixer.cpp" line="56"/>
         <source>Amount to send from channel %1 to channel %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -3779,11 +3779,11 @@ Por favor asegúrate de tener los permisos necesarios e inténtalo de nuevo.</tr
         <translation>Haz click aquí para mostrar u ocultar el Editor de Automatización. Con la ayuda del Editor de Automatización puedes editar valores dinámicos fácilmente.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mezcladora FX</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Haz click aquí para mostrar u ocultar la Mezcladora FX. La Mezcladora FX es una herramienta muy poderosa para administrar los efectos en tu canción. Puedes insertar efectos en diferentes canales.</translation>
     </message>
     <message>
@@ -3985,7 +3985,7 @@ Por favor visita http://lmms.sf.net/wiki para obtener documentación acerca de L
         <translation>Mostrar/ocultar Editor de Automatización</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Mostrar/ocultar Mezcladora FX</translation>
     </message>
     <message>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -2240,7 +2240,7 @@ Puedes quitar y mover los canales FX a través del menú contextual. Accede a es
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Maestro</translation>
@@ -2251,7 +2251,7 @@ Puedes quitar y mover los canales FX a través del menú contextual. Accede a es
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mezcladora FX</translation>

--- a/data/locale/es.ts
+++ b/data/locale/es.ts
@@ -2253,7 +2253,7 @@ Puedes quitar y mover los canales FX a través del menú contextual. Accede a es
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Mezcladora FX</translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -3477,11 +3477,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -2098,7 +2098,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/locale/fa.ts
+++ b/data/locale/fa.ts
@@ -2077,7 +2077,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"></translation>
@@ -2088,7 +2088,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Rename FX channel</source>
         <translation type="unfinished"></translation>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -3786,11 +3786,11 @@ Veuillez vérifier que vous avez les droits d&apos;accès en écriture pour ce f
         <translation>Cliquez ici pour montrer ou cacher l&apos;éditeur d&apos;automation. À l&apos;aide de l&apos;éditeur d&apos;automation vous pouvez éditer facilement des valeurs dynamiques.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mélangeur d&apos;effets</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Cliquez ici pour montrer et cacher le mélangeur d&apos;effets. Le mélangeur d&apos;effet est un outil très puissant pour la gestion des effets de votre morceau. Vous pouvez insérer des effets dans différents canaux d&apos;effets.</translation>
     </message>
     <message>
@@ -3996,7 +3996,7 @@ Veuillez visiter http://lmms.sf.net/wiki pour la documentation de LMMS.</transla
         <translation>Afficher/cacher l&apos;éditeur d&apos;automation</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Afficher/cacher le mixeur d&apos;effets</translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -2260,7 +2260,7 @@ Vous pouvez supprimer et déplacer les canaux d&apos;effets dans le menu context
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Mélangeur d&apos;effets</translation>
     </message>
     <message>

--- a/data/locale/fr.ts
+++ b/data/locale/fr.ts
@@ -2247,7 +2247,7 @@ Vous pouvez supprimer et déplacer les canaux d&apos;effets dans le menu context
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Général</translation>
@@ -2258,7 +2258,7 @@ Vous pouvez supprimer et déplacer les canaux d&apos;effets dans le menu context
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mélangeur d&apos;effets</translation>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -3770,11 +3770,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Prema aquí para mostrar ou agochar o Editor de automatización. Coa axuda do Editor de automatización pódense editar os valores dinámicos facilmente.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mostrar/Agochar os Mesturador de efectos especiais</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Prema aquí para mostrar ou agochar o Mesturador de efectos especiais. O Mesturador de efectos especiais é unha ferramenta potente para xestionar os efectos das cancións. Pódense inserir efectos nas diferentes canles de efectos.</translation>
     </message>
     <message>
@@ -3976,7 +3976,7 @@ Visitehttp://lmms.sf.net/wiki para documentación sobre o LMMS.</translation>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -2233,7 +2233,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Global</translation>
@@ -2244,7 +2244,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mesturador de efectos especiais</translation>

--- a/data/locale/gl.ts
+++ b/data/locale/gl.ts
@@ -2246,7 +2246,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Mesturador de efectos especiais</translation>
     </message>
     <message>

--- a/data/locale/hu_HU.ts
+++ b/data/locale/hu_HU.ts
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/hu_HU.ts
+++ b/data/locale/hu_HU.ts
@@ -2219,7 +2219,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2230,7 +2230,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/hu_HU.ts
+++ b/data/locale/hu_HU.ts
@@ -3756,11 +3756,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3961,7 +3961,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/id.ts
+++ b/data/locale/id.ts
@@ -2836,8 +2836,8 @@ Anda dapat menghapus dan memindahkan saluran FX dalam menu konteks, yang diakses
     <name>FxMixerView</name>
     <message>
         <location filename="../../src/gui/FxMixerView.cpp" line="68"/>
-        <source>FX-Mixer</source>
-        <translation>FX-Mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <location filename="../../src/gui/FxMixerView.cpp" line="281"/>

--- a/data/locale/id.ts
+++ b/data/locale/id.ts
@@ -4907,13 +4907,13 @@ Please make sure you have write permission to the file and the directory contain
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="544"/>
-        <source>Show/hide FX Mixer</source>
-        <translation>Tampilkan/sembunyikan FX Mixer</translation>
+        <source>Show/hide Mixer</source>
+        <translation>Tampilkan/sembunyikan Mixer</translation>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="549"/>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
-        <translation>Klik disini untuk menampilkan atau menyembunyikan FX Mixer. FX Mixer adalah alat yang sangat ampuh untuk mengelola efek untuk lagu Anda. Anda bisa memasukkan efek ke saluran efek yang berbeda.</translation>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <translation>Klik disini untuk menampilkan atau menyembunyikan Mixer. Mixer adalah alat yang sangat ampuh untuk mengelola efek untuk lagu Anda. Anda bisa memasukkan efek ke saluran efek yang berbeda.</translation>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="556"/>
@@ -5039,8 +5039,8 @@ Silakan kunjungi http://lmms.sf.net/wiki untuk dokumentasi LMMS.</translation>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="1223"/>
-        <source>FX Mixer</source>
-        <translation>FX Mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <location filename="../../src/gui/MainWindow.cpp" line="1227"/>

--- a/data/locale/id.ts
+++ b/data/locale/id.ts
@@ -2803,64 +2803,64 @@ Anda dapat menghapus dan memindahkan saluran FX dalam menu konteks, yang diakses
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="665"/>
+        <location filename="../../src/core/Mixer.cpp" line="665"/>
         <source>Master</source>
         <translation>Master</translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="665"/>
-        <location filename="../../src/core/FxMixer.cpp" line="780"/>
-        <location filename="../../src/core/FxMixer.cpp" line="782"/>
+        <location filename="../../src/core/Mixer.cpp" line="665"/>
+        <location filename="../../src/core/Mixer.cpp" line="780"/>
+        <location filename="../../src/core/Mixer.cpp" line="782"/>
         <source>FX %1</source>
         <translation>FX %1</translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="666"/>
+        <location filename="../../src/core/Mixer.cpp" line="666"/>
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="667"/>
+        <location filename="../../src/core/Mixer.cpp" line="667"/>
         <source>Mute</source>
         <translation>Bisu</translation>
     </message>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="668"/>
+        <location filename="../../src/core/Mixer.cpp" line="668"/>
         <source>Solo</source>
         <translation>Solo</translation>
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="68"/>
+        <location filename="../../src/gui/MixerView.cpp" line="68"/>
         <source>Mixer</source>
         <translation>Mixer</translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="281"/>
+        <location filename="../../src/gui/MixerView.cpp" line="281"/>
         <source>FX Fader %1</source>
         <translation>FX Pemudar %1</translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="290"/>
+        <location filename="../../src/gui/MixerView.cpp" line="290"/>
         <source>Mute</source>
         <translation>Bisu</translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="298"/>
+        <location filename="../../src/gui/MixerView.cpp" line="298"/>
         <source>Mute this FX channel</source>
         <translation>Bisukan saluran FX ini</translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="300"/>
+        <location filename="../../src/gui/MixerView.cpp" line="300"/>
         <source>Solo</source>
         <translation>Solo</translation>
     </message>
     <message>
-        <location filename="../../src/gui/FxMixerView.cpp" line="310"/>
+        <location filename="../../src/gui/MixerView.cpp" line="310"/>
         <source>Solo FX channel</source>
         <translation>Saluran FX Solo</translation>
     </message>
@@ -2868,8 +2868,8 @@ Anda dapat menghapus dan memindahkan saluran FX dalam menu konteks, yang diakses
 <context>
     <name>FxRoute</name>
     <message>
-        <location filename="../../src/core/FxMixer.cpp" line="41"/>
-        <location filename="../../src/core/FxMixer.cpp" line="56"/>
+        <location filename="../../src/core/Mixer.cpp" line="41"/>
+        <location filename="../../src/core/Mixer.cpp" line="56"/>
         <source>Amount to send from channel %1 to channel %2</source>
         <translation>Jumlah untuk kirim dari saluran %1 ke saluran %2</translation>
     </message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -3784,11 +3784,11 @@ Assicurati di avere i permessi in scrittura per il file e riprova.</translation>
         <translation>Questo pulsante mostra o nasconde l&apos;editor dell&apos;automazione. Con l&apos;aiuto dell&apos;editor dell&apos;automazione è possibile rendere dinamici alcuni valori in modo semplice.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mostra/nascondi il mixer degli effetti</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Questo pulsante mostra o nasconde il mixer degli effetti. Il mixer degli effetti è uno strumento molto potente per gestire gli effetti della canzone. È possibile inserire effetti in più canali.</translation>
     </message>
     <message>
@@ -3990,7 +3990,7 @@ Visitare http://lmms.sf.net/wiki  per la documentazione di LMMS.</translation>
         <translation>Mostra/nascondi l&apos;Editor dell&apos;automazione</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Mostra/nascondi il mixer degli effetti</translation>
     </message>
     <message>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -2255,7 +2255,7 @@ Puoi rimuovere e muovere i canali con il menù contestuale, cliccando con il tas
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Mixer FX</translation>
     </message>
 </context>

--- a/data/locale/it.ts
+++ b/data/locale/it.ts
@@ -2242,7 +2242,7 @@ Puoi rimuovere e muovere i canali con il menù contestuale, cliccando con il tas
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Master</translation>
@@ -2253,14 +2253,14 @@ Puoi rimuovere e muovere i canali con il menù contestuale, cliccando con il tas
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer FX</translation>
     </message>
 </context>
 <context>
-    <name>FxMixerView::FxChannelView</name>
+    <name>MixerView::FxChannelView</name>
     <message>
         <source>FX Fader %1</source>
         <translation>Volume FX %1</translation>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -2221,7 +2221,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>エフェクトミキサー</translation>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -2234,7 +2234,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>エフェクトミキサー</translation>
     </message>
     <message>

--- a/data/locale/ja.ts
+++ b/data/locale/ja.ts
@@ -3759,11 +3759,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>ここをクリックしてオートメーション エディターの表示/非表示を切り替えます。オートメーション エディターで動的な値を簡単に編集できます。</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>エフェクトミキサー</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>ここをクリックしてエフェクトミキサーの表示/非表示を切り替えます。エフェクトミキサーは曲のエフェクトを管理する強力なツールです。エフェクトを異なったエフェクトチャンネルに挿入することができます。</translation>
     </message>
     <message>
@@ -3965,7 +3965,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -2219,7 +2219,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2230,7 +2230,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/ko.ts
+++ b/data/locale/ko.ts
@@ -3756,11 +3756,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3961,7 +3961,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -3783,11 +3783,11 @@ Dubbelklikken om een bestand te selecteren.</translation>
         <translation>Klik hier om de automatisering-editor weer te geven of te verbergen. Met behulp van de automatisering-editor kunt u dynamische waardes op een eenvoudige manier bewerken.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mixer</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Klik hier om de Mixer weer te geven of te verbergen. De Mixer is een krachtige tool voor het beheren van effecten voor uw song. U kunt effecten invoegen in verschillende effect-kanalen.</translation>
     </message>
     <message>
@@ -3989,7 +3989,7 @@ Bezoek http://lmms.sf.net/wiki voor documentatie over LMMS.</translation>
         <translation>Automatisering-editor weergeven/verbergen</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Mixer weergeven/verbergen</translation>
     </message>
     <message>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -2254,7 +2254,7 @@ U kunt FX-kanalen verwijderen en verplaatsen in het contextmenu, dat toegankelij
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Master</translation>
@@ -2265,7 +2265,7 @@ U kunt FX-kanalen verwijderen en verplaatsen in het contextmenu, dat toegankelij
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer</translation>

--- a/data/locale/nl.ts
+++ b/data/locale/nl.ts
@@ -2267,8 +2267,8 @@ U kunt FX-kanalen verwijderen en verplaatsen in het contextmenu, dat toegankelij
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
-        <translation>FX-mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>FX Fader %1</source>
@@ -3784,11 +3784,11 @@ Dubbelklikken om een bestand te selecteren.</translation>
     </message>
     <message>
         <source>FX Mixer</source>
-        <translation>FX-mixer</translation>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
-        <translation>Klik hier om de FX-mixer weer te geven of te verbergen. De FX-mixer is een krachtige tool voor het beheren van effecten voor uw song. U kunt effecten invoegen in verschillende effect-kanalen.</translation>
+        <translation>Klik hier om de Mixer weer te geven of te verbergen. De Mixer is een krachtige tool voor het beheren van effecten voor uw song. U kunt effecten invoegen in verschillende effect-kanalen.</translation>
     </message>
     <message>
         <source>Project Notes</source>
@@ -3990,7 +3990,7 @@ Bezoek http://lmms.sf.net/wiki voor documentatie over LMMS.</translation>
     </message>
     <message>
         <source>Show/hide FX Mixer</source>
-        <translation>FX-mixer weergeven/verbergen</translation>
+        <translation>Mixer weergeven/verbergen</translation>
     </message>
     <message>
         <source>Show/hide project notes</source>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3775,11 +3775,11 @@ Upewnij się, że masz prawo zapisu do tego pliku i spróbuj ponownie.</translat
         <translation>Kliknij tutaj aby pokazać lub ukryć Edytor Automatyki. Za jego pomocą możesz w prosty sposób modyfikować dynamiczne wartości wszelkich regulatorów.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Pokaż/ukryj Mikser Efektów</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Kliknij tutaj aby pokazać lub ukryć Mikser Efektów. Mikser Efektów jest potężnym narzędziem wspomagającym zarządzanie efektami i ścieżkami w Twojej produkcji. Możesz wstawiać wtyczki efektowe na różne kanały dodatkowo wzbogacając brzmienie utworu.</translation>
     </message>
     <message>
@@ -3981,7 +3981,7 @@ Odwiedź witrynę http://lmms.sf.net/wiki for documentation on LMMS.</translatio
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -2237,7 +2237,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Master</translation>
@@ -2248,7 +2248,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer</translation>

--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -2250,8 +2250,8 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
-        <translation>FX-Mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>FX Fader %1</source>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -2235,7 +2235,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Mestre</translation>
@@ -2246,7 +2246,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer de Efeitos</translation>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -2248,7 +2248,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Mixer de Efeitos</translation>
     </message>
     <message>

--- a/data/locale/pt.ts
+++ b/data/locale/pt.ts
@@ -3773,11 +3773,11 @@ Por favor certifique-se que você tem permissão de escrita para este arquivo e 
         <translation>Clique aqui para mostrar ou esconder o Editor de Automação. Com ele você pode editar os valores dinâmicos de automação facilmente.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Mostrar/esconder Mixer de Efeitos</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Clique aqui para mostrar ou esconder o Mixer de Efeitos. O Mixer de Efeitos é uma poderosa ferramenta para gerenciar os efeitos utilizados na sua música. Você pode inserir efeitos em diferentes canais de efeito.</translation>
     </message>
     <message>
@@ -3979,7 +3979,7 @@ Por favor visite http://lmms.sf.net/wiki para ter acesso a mais infromações so
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -3783,11 +3783,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Показать/скрыть окно редактора автоматизации. С его помощью вы можете легко редактироватьдинамику выбранных величин.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Показать/скрыть микшер ЭФ</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Скрыть/показать микшер ЭФфектов. Он является мощным инструментом для управления эффектами. Вы можете вставлять эффекты в различные каналы.</translation>
     </message>
     <message>
@@ -3990,7 +3990,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>Показать/скрыть редактор автоматизации</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Показать/скрыть микшер ЭФ</translation>
     </message>
     <message>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -2242,7 +2242,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Главный</translation>
@@ -2253,7 +2253,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Микшер Эффектов</translation>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -2255,7 +2255,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Микшер Эффектов</translation>
     </message>
     <message>

--- a/data/locale/sl.ts
+++ b/data/locale/sl.ts
@@ -2232,7 +2232,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/sl.ts
+++ b/data/locale/sl.ts
@@ -2219,7 +2219,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2230,7 +2230,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/sl.ts
+++ b/data/locale/sl.ts
@@ -3756,11 +3756,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3961,7 +3961,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>Prikaži/skrij Samodejnik</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/sr.ts
+++ b/data/locale/sr.ts
@@ -2215,7 +2215,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation type="unfinished"/>
@@ -2226,7 +2226,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation type="unfinished"/>

--- a/data/locale/sr.ts
+++ b/data/locale/sr.ts
@@ -2228,7 +2228,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/sr.ts
+++ b/data/locale/sr.ts
@@ -3692,11 +3692,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3901,7 +3901,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -2219,7 +2219,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Master</translation>
@@ -2230,7 +2230,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Mixer</translation>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -2232,8 +2232,8 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
-        <translation>FX-Mixer</translation>
+        <source>Mixer</source>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>FX Fader %1</source>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -3756,11 +3756,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation type="unfinished"/>
     </message>
     <message>
@@ -3962,8 +3962,8 @@ Besök https://lmms.io/documentation/ för dokumentation (Engelska).</translatio
         <translation>Visa/dölj Automations-editor</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
-        <translation>Visa/dölj FX Mixer</translation>
+        <source>Show/hide Mixer</source>
+        <translation>Visa/dölj Mixer</translation>
     </message>
     <message>
         <source>Show/hide project notes</source>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -3781,11 +3781,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>Показати / сховати вікно редактора автоматизації. З його допомогою ви можете легко редагувати динаміку обраних величин.</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>Мікшер Ефектів</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>Сховати / показати мікшер ефектів. Він є потужним інструментом для управління ефектами. Ви можете вставляти ефекти в різні канали.</translation>
     </message>
     <message>
@@ -3987,7 +3987,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>Показати/сховати редактор автоматизації</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>Показати/сховати мікшер ЕФ</translation>
     </message>
     <message>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -2253,7 +2253,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>Мікшер Ефектів</translation>
     </message>
     <message>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -2240,7 +2240,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>Головний</translation>
@@ -2251,7 +2251,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>Мікшер Ефектів</translation>

--- a/data/locale/zh_CN.ts
+++ b/data/locale/zh_CN.ts
@@ -3773,11 +3773,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>点击这里显示或隐藏自动控制编辑器。在自动控制编辑器的帮助下, 你可以很简单地控制动态数值。</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>显示/隐藏混音器</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>点击这里显示或隐藏 FX 混音器。FX 混音器是管理你歌曲中不同音效的强大工具。你可以向不同的通道添加不同的效果。</translation>
     </message>
     <message>
@@ -3979,7 +3979,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>显示/隐藏自动控制编辑器</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>显示/隐藏混音器</translation>
     </message>
     <message>

--- a/data/locale/zh_CN.ts
+++ b/data/locale/zh_CN.ts
@@ -2234,7 +2234,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>主控</translation>
@@ -2245,7 +2245,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>效果混合器</translation>

--- a/data/locale/zh_CN.ts
+++ b/data/locale/zh_CN.ts
@@ -2247,7 +2247,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>效果混合器</translation>
     </message>
     <message>

--- a/data/locale/zh_TW.ts
+++ b/data/locale/zh_TW.ts
@@ -2242,7 +2242,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
 <context>
     <name>FxMixerView</name>
     <message>
-        <source>FX-Mixer</source>
+        <source>Mixer</source>
         <translation>效果混合器</translation>
     </message>
     <message>

--- a/data/locale/zh_TW.ts
+++ b/data/locale/zh_TW.ts
@@ -2229,7 +2229,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixer</name>
+    <name>Mixer</name>
     <message>
         <source>Master</source>
         <translation>主控</translation>
@@ -2240,7 +2240,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
 </context>
 <context>
-    <name>FxMixerView</name>
+    <name>MixerView</name>
     <message>
         <source>Mixer</source>
         <translation>效果混合器</translation>

--- a/data/locale/zh_TW.ts
+++ b/data/locale/zh_TW.ts
@@ -3767,11 +3767,11 @@ Please make sure you have write-access to the file and try again.</source>
         <translation>點擊這裏顯示或隱藏自動控制編輯器。在自動控制編輯器的幫助下, 你可以很簡單地控制動態數值。</translation>
     </message>
     <message>
-        <source>FX Mixer</source>
+        <source>Mixer</source>
         <translation>顯示/隱藏混音器</translation>
     </message>
     <message>
-        <source>Click here to show or hide the FX Mixer. The FX Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
+        <source>Click here to show or hide the Mixer. The Mixer is a very powerful tool for managing effects for your song. You can insert effects into different effect-channels.</source>
         <translation>點擊這裏顯示或隱藏 FX 混音器。FX 混音器是管理你歌曲中不同音效的強大工具。你可以向不同的通道添加不同的效果。</translation>
     </message>
     <message>
@@ -3973,7 +3973,7 @@ Please visit http://lmms.sf.net/wiki for documentation on LMMS.</source>
         <translation>顯示/隱藏自動控制編輯器</translation>
     </message>
     <message>
-        <source>Show/hide FX Mixer</source>
+        <source>Show/hide Mixer</source>
         <translation>顯示/隱藏混音器</translation>
     </message>
     <message>

--- a/data/projects/demos/StrictProduction-DearJonDoe.mmp
+++ b/data/projects/demos/StrictProduction-DearJonDoe.mmp
@@ -673,11 +673,11 @@
         <time pos="384" value="-846"/>
       </automationpattern>
     </track>
-    <fxmixer maximized="0" height="332" visible="1" minimized="0" x="9" y="530" width="530">
+    <mixer maximized="0" height="332" visible="1" minimized="0" x="9" y="530" width="530">
       <fxchannel muted="0" num="0" name="Master" volume="0.31" soloed="0">
         <fxchain enabled="0" numofeffects="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView maximized="0" height="300" visible="0" minimized="0" x="955" y="413" width="400"/>
     <pianoroll maximized="0" height="480" visible="0" minimized="0" x="37" y="69" width="640"/>
     <automationeditor maximized="0" height="400" visible="0" minimized="0" x="1" y="1" width="640"/>

--- a/data/projects/shorties/Crunk(Demo).mmp
+++ b/data/projects/shorties/Crunk(Demo).mmp
@@ -187,7 +187,7 @@
         <time pos="0" value="0"/>
       </automationpattern>
     </track>
-    <fxmixer maximized="0" height="332" visible="1" minimized="0" x="1" y="463" width="530">
+    <mixer maximized="0" height="332" visible="1" minimized="0" x="1" y="463" width="530">
       <fxchannel muted="0" num="0" name="Master" volume="1" soloed="0">
         <fxchain enabled="0" numofeffects="0"/>
       </fxchannel>
@@ -203,7 +203,7 @@
         <fxchain enabled="0" numofeffects="0"/>
         <send amount="1" channel="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView maximized="0" height="300" visible="0" minimized="0" x="880" y="310" width="400"/>
     <pianoroll maximized="0" height="480" visible="0" minimized="0" x="1" y="120" width="640"/>
     <automationeditor maximized="0" height="400" visible="0" minimized="0" x="516" y="228" width="640"/>

--- a/data/projects/templates/AcousticDrumset.mpt
+++ b/data/projects/templates/AcousticDrumset.mpt
@@ -114,11 +114,11 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
+    <mixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="142" x="608" y="307" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="1" maximized="0" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="56" y="255" maximized="0" minimized="0"/>

--- a/data/projects/templates/CR8000.mpt
+++ b/data/projects/templates/CR8000.mpt
@@ -232,7 +232,7 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
+    <mixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
@@ -240,7 +240,7 @@
         <fxchain numofeffects="0" enabled="0"/>
         <send amount="1" channel="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="142" x="608" y="307" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="200" maximized="0" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="56" y="255" maximized="0" minimized="0"/>

--- a/data/projects/templates/ClubMix.mpt
+++ b/data/projects/templates/ClubMix.mpt
@@ -131,11 +131,11 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
+    <mixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="142" x="608" y="307" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="1" maximized="0" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="56" y="255" maximized="0" minimized="0"/>

--- a/data/projects/templates/Empty.mpt
+++ b/data/projects/templates/Empty.mpt
@@ -17,11 +17,11 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="561" height="332" x="5" y="310" maximized="0" minimized="0">
+    <mixer visible="1" width="561" height="332" x="5" y="310" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="142" x="836" y="407" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="1" maximized="0" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="56" y="255" maximized="0" minimized="0"/>

--- a/data/projects/templates/TR808.mpt
+++ b/data/projects/templates/TR808.mpt
@@ -300,7 +300,7 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
+    <mixer visible="1" width="561" height="332" x="10" y="314" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
@@ -308,7 +308,7 @@
         <fxchain numofeffects="0" enabled="0"/>
         <send amount="1" channel="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="142" x="608" y="307" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="200" maximized="0" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="56" y="255" maximized="0" minimized="0"/>

--- a/data/projects/templates/default.mpt
+++ b/data/projects/templates/default.mpt
@@ -70,11 +70,11 @@
         <object id="5865711"/>
       </automationpattern>
     </track>
-    <fxmixer width="543" x="5" y="310" maximized="0" height="335" visible="1" minimized="0">
+    <mixer width="543" x="5" y="310" maximized="0" height="335" visible="1" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView width="350" x="680" y="310" maximized="0" height="200" visible="1" minimized="0"/>
     <pianoroll width="640" x="5" y="5" maximized="0" height="480" visible="0" minimized="0"/>
     <automationeditor width="640" x="-36" y="0" maximized="0" height="400" visible="0" minimized="0"/>

--- a/data/projects/tutorials/editing_note_volumes.mmp
+++ b/data/projects/tutorials/editing_note_volumes.mmp
@@ -67,11 +67,11 @@
       <automationpattern prog="0" mute="0" name="Master volume" pos="0" tens="1" len="192"/>
       <automationpattern prog="0" mute="0" name="Master pitch" pos="0" tens="1" len="192"/>
     </track>
-    <fxmixer visible="1" width="647" height="332" x="9" y="441" maximized="0" minimized="0">
+    <mixer visible="1" width="647" height="332" x="9" y="441" maximized="0" minimized="0">
       <fxchannel num="0" muted="0" volume="1" name="Master" soloed="0">
         <fxchain numofeffects="0" enabled="0"/>
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <ControllerRackView visible="1" width="258" height="173" x="664" y="444" maximized="0" minimized="0"/>
     <pianoroll visible="0" width="640" height="480" x="1" y="1" maximized="1" minimized="0"/>
     <automationeditor visible="0" width="640" height="400" x="356" y="129" maximized="0" minimized="0"/>

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -552,7 +552,7 @@ PianoView {
 
 /* font sizes for text buttons */
 
-FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
+MixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
 	font-size: 10px;
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -574,7 +574,7 @@ PianoView {
 
 /* font sizes for text buttons */
 
-FxMixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
+MixerView QPushButton, EffectRackView QPushButton, ControllerRackView QPushButton {
 	font-size: 10px;
 }
 

--- a/doc/lmms.1
+++ b/doc/lmms.1
@@ -29,7 +29,7 @@ lmms \- software for easy music production
 .B LMMS
 is a free cross-platform alternative to commercial programs like FL Studio®, which allow you to produce music with your computer. This includes the creation of melodies and beats, the synthesis and mixing of sounds, and arranging of samples. You can have fun with your MIDI-keyboard and much more; all in a user-friendly and modern interface.
 
-LMMS features components such as a Song Editor, a Beat+Bassline Editor, a Piano Roll, an FX Mixer as well as many powerful instruments and effects.
+LMMS features components such as a Song Editor, a Beat+Bassline Editor, a Piano Roll, an Mixer as well as many powerful instruments and effects.
 
 .SH ACTIONS
 

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -66,9 +66,9 @@ public:
 		return s_mixer;
 	}
 
-	static Mixer * fxMixer()
+	static Mixer * mixer()
 	{
-		return s_fxMixer;
+		return s_mixer;
 	}
 
 	static Song * getSong()
@@ -130,7 +130,7 @@ private:
 
 	// core
 	static Mixer *s_mixer;
-	static Mixer * s_fxMixer;
+	static Mixer * s_mixer;
 	static Song * s_song;
 	static BBTrackContainer * s_bbTrackContainer;
 	static ProjectJournal * s_projectJournal;

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -34,7 +34,7 @@
 
 class BBTrackContainer;
 class DummyTrackContainer;
-class FxMixer;
+class Mixer;
 class ProjectJournal;
 class Mixer;
 class Song;
@@ -66,7 +66,7 @@ public:
 		return s_mixer;
 	}
 
-	static FxMixer * fxMixer()
+	static Mixer * fxMixer()
 	{
 		return s_fxMixer;
 	}
@@ -130,7 +130,7 @@ private:
 
 	// core
 	static Mixer *s_mixer;
-	static FxMixer * s_fxMixer;
+	static Mixer * s_fxMixer;
 	static Song * s_song;
 	static BBTrackContainer * s_bbTrackContainer;
 	static ProjectJournal * s_projectJournal;

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -1,5 +1,5 @@
 /*
- * Fader.h - fader-widget used in FX-mixer - partly taken from Hydrogen
+ * Fader.h - fader-widget used in Mixer - partly taken from Hydrogen
  *
  * Copyright (c) 2008-2012 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * 

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -36,7 +36,7 @@
 
 
 
-class FxMixerView;
+class MixerView;
 class SendButtonIndicator;
 
 class FxLine : public QWidget
@@ -48,7 +48,7 @@ public:
 	Q_PROPERTY( QColor strokeOuterInactive READ strokeOuterInactive WRITE setStrokeOuterInactive )
 	Q_PROPERTY( QColor strokeInnerActive READ strokeInnerActive WRITE setStrokeInnerActive )
 	Q_PROPERTY( QColor strokeInnerInactive READ strokeInnerInactive WRITE setStrokeInnerInactive )
-	FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex);
+	FxLine( QWidget * _parent, MixerView * _mv, int _channelIndex);
 	~FxLine();
 
 	virtual void paintEvent( QPaintEvent * );
@@ -83,7 +83,7 @@ private:
 	void drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis );
 	QString elideName( const QString & name );
 
-	FxMixerView * m_mv;
+	MixerView * m_mv;
 	LcdWidget* m_lcd;
 	int m_channelIndex;
 	QBrush m_backgroundActive;

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -1,5 +1,5 @@
 /*
- * FxMixer.h - effect-mixer for LMMS
+ * Mixer.h - effect-mixer for LMMS
  *
  * Copyright (c) 2008-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -120,12 +120,12 @@ class FxRoute : public QObject
 };
 
 
-class EXPORT FxMixer : public Model, public JournallingObject
+class EXPORT Mixer : public Model, public JournallingObject
 {
 	Q_OBJECT
 public:
-	FxMixer();
-	virtual ~FxMixer();
+	Mixer();
+	virtual ~Mixer();
 
 	void mixToChannel( const sampleFrame * _buf, fx_ch_t _ch );
 

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -164,11 +164,11 @@ public:
 	// toChannel. NULL if there is no send.
 	FloatModel * channelSendModel(fx_ch_t fromChannel, fx_ch_t toChannel);
 
-	// add a new channel to the Fx Mixer.
+	// add a new channel to the mixer.
 	// returns the index of the channel that was just added
 	int createChannel();
 
-	// delete a channel from the FX mixer.
+	// delete a channel from the mixer.
 	void deleteChannel(int index);
 
 	// delete all the mixer channels except master and remove all effects

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -137,7 +137,7 @@ public:
 
 	virtual QString nodeName() const
 	{
-		return "fxmixer";
+		return "mixer";
 	}
 
 	FxChannel * effectChannel( int _ch )

--- a/include/FxMixer.h
+++ b/include/FxMixer.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef FX_MIXER_H
-#define FX_MIXER_H
+#ifndef MIXER_H
+#define MIXER_H
 
 #include "Model.h"
 #include "EffectChain.h"

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -100,7 +100,7 @@ public:
 	void moveChannelLeft(int index, int focusIndex);
 	void moveChannelRight(int index);
 
-	// make sure the display syncs up with the fx mixer.
+	// make sure the display syncs up with the mixer.
 	// useful for loading projects
 	void refreshDisplay();
 

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef FX_MIXER_VIEW_H
-#define FX_MIXER_VIEW_H
+#ifndef MIXER_VIEW_H
+#define MIXER_VIEW_H
 
 #include <QWidget>
 #include <QHBoxLayout>

--- a/include/FxMixerView.h
+++ b/include/FxMixerView.h
@@ -1,5 +1,5 @@
 /*
- * FxMixerView.h - effect-mixer-view for LMMS
+ * MixerView.h - effect-mixer-view for LMMS
  *
  * Copyright (c) 2008-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * 
@@ -41,7 +41,7 @@
 class QButtonGroup;
 class FxLine;
 
-class EXPORT FxMixerView : public QWidget, public ModelView,
+class EXPORT MixerView : public QWidget, public ModelView,
 					public SerializingObjectHook
 {
 	Q_OBJECT
@@ -49,7 +49,7 @@ public:
 	class FxChannelView
 	{
 	public:
-		FxChannelView(QWidget * _parent, FxMixerView * _mv, int _chIndex );
+		FxChannelView(QWidget * _parent, MixerView * _mv, int _chIndex );
 
 		void setChannelIndex( int index );
 
@@ -61,8 +61,8 @@ public:
 	};
 
 
-	FxMixerView();
-	virtual ~FxMixerView();
+	MixerView();
+	virtual ~MixerView();
 
 	virtual void keyPressEvent(QKeyEvent * e);
 

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -50,7 +50,7 @@ public:
 	static GuiApplication* instance();
 
 	MainWindow* mainWindow() { return m_mainWindow; }
-	MixerView* fxMixerView() { return m_fxMixerView; }
+	MixerView* mixerView() { return m_mixerView; }
 	SongEditorWindow* songEditor() { return m_songEditor; }
 	BBEditor* getBBEditor() { return m_bbEditor; }
 	PianoRollWindow* pianoRoll() { return m_pianoRoll; }
@@ -68,7 +68,7 @@ private:
 	static GuiApplication* s_instance;
 
 	MainWindow* m_mainWindow;
-	MixerView* m_fxMixerView;
+	MixerView* m_mixerView;
 	SongEditorWindow* m_songEditor;
 	AutomationEditorWindow* m_automationEditor;
 	BBEditor* m_bbEditor;

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -34,7 +34,7 @@ class QLabel;
 class AutomationEditorWindow;
 class BBEditor;
 class ControllerRackView;
-class FxMixerView;
+class MixerView;
 class MainWindow;
 class PianoRollWindow;
 class ProjectNotes;
@@ -50,7 +50,7 @@ public:
 	static GuiApplication* instance();
 
 	MainWindow* mainWindow() { return m_mainWindow; }
-	FxMixerView* fxMixerView() { return m_fxMixerView; }
+	MixerView* fxMixerView() { return m_fxMixerView; }
 	SongEditorWindow* songEditor() { return m_songEditor; }
 	BBEditor* getBBEditor() { return m_bbEditor; }
 	PianoRollWindow* pianoRoll() { return m_pianoRoll; }
@@ -68,7 +68,7 @@ private:
 	static GuiApplication* s_instance;
 
 	MainWindow* m_mainWindow;
-	FxMixerView* m_fxMixerView;
+	MixerView* m_fxMixerView;
 	SongEditorWindow* m_songEditor;
 	AutomationEditorWindow* m_automationEditor;
 	BBEditor* m_bbEditor;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -163,7 +163,7 @@ public slots:
 	void toggleBBEditorWin( bool forceShow = false );
 	void toggleSongEditorWin();
 	void toggleProjectNotesWin();
-	void toggleFxMixerWin();
+	void toggleMixerWin();
 	void togglePianoRollWin();
 	void toggleControllerRack();
 

--- a/include/SendButtonIndicator.h
+++ b/include/SendButtonIndicator.h
@@ -6,16 +6,16 @@
 #include <QPixmap>
 
 #include "FxLine.h"
-#include "FxMixerView.h"
+#include "MixerView.h"
 
 class FxLine;
-class FxMixerView;
+class MixerView;
 
 class SendButtonIndicator : public QLabel 
 {
 public:
 	SendButtonIndicator( QWidget * _parent, FxLine * _owner,
-						 FxMixerView * _mv);
+						 MixerView * _mv);
 
 	virtual void mousePressEvent( QMouseEvent * e );
 	void updateLightStatus();
@@ -23,7 +23,7 @@ public:
 private:
 
 	FxLine * m_parent;
-	FxMixerView * m_mv;
+	MixerView * m_mv;
 	static QPixmap * s_qpmOn;
 	static QPixmap * s_qpmOff;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LMMS_SRCS
 	core/Engine.cpp
 	core/EnvelopeAndLfoParameters.cpp
 	core/fft_helpers.cpp
-	core/FxMixer.cpp
+	core/Mixer.cpp
 	core/ImportFilter.cpp
 	core/InlineAutomation.cpp
 	core/Instrument.cpp

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -26,7 +26,7 @@
 #include "Engine.h"
 #include "BBTrackContainer.h"
 #include "ConfigManager.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "Ladspa2LMMS.h"
 #include "Mixer.h"
 #include "PresetPreviewPlayHandle.h"
@@ -36,7 +36,7 @@
 
 float LmmsCore::s_framesPerTick;
 Mixer* LmmsCore::s_mixer = NULL;
-FxMixer * LmmsCore::s_fxMixer = NULL;
+Mixer * LmmsCore::s_fxMixer = NULL;
 BBTrackContainer * LmmsCore::s_bbTrackContainer = NULL;
 Song * LmmsCore::s_song = NULL;
 ProjectJournal * LmmsCore::s_projectJournal = NULL;
@@ -58,7 +58,7 @@ void LmmsCore::init( bool renderOnly )
 	s_projectJournal = new ProjectJournal;
 	s_mixer = new Mixer( renderOnly );
 	s_song = new Song;
-	s_fxMixer = new FxMixer;
+	s_fxMixer = new Mixer;
 	s_bbTrackContainer = new BBTrackContainer;
 
 	s_ladspaManager = new Ladspa2LMMS;

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -36,7 +36,7 @@
 
 float LmmsCore::s_framesPerTick;
 Mixer* LmmsCore::s_mixer = NULL;
-Mixer * LmmsCore::s_fxMixer = NULL;
+Mixer * LmmsCore::s_mixer = NULL;
 BBTrackContainer * LmmsCore::s_bbTrackContainer = NULL;
 Song * LmmsCore::s_song = NULL;
 ProjectJournal * LmmsCore::s_projectJournal = NULL;
@@ -58,7 +58,7 @@ void LmmsCore::init( bool renderOnly )
 	s_projectJournal = new ProjectJournal;
 	s_mixer = new Mixer( renderOnly );
 	s_song = new Song;
-	s_fxMixer = new Mixer;
+	s_mixer = new Mixer;
 	s_bbTrackContainer = new BBTrackContainer;
 
 	s_ladspaManager = new Ladspa2LMMS;
@@ -90,7 +90,7 @@ void LmmsCore::destroy()
 	deleteHelper( &s_bbTrackContainer );
 	deleteHelper( &s_dummyTC );
 
-	deleteHelper( &s_fxMixer );
+	deleteHelper( &s_mixer );
 	deleteHelper( &s_mixer );
 
 	deleteHelper( &s_ladspaManager );

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -439,7 +439,7 @@ FxRoute * Mixer::createRoute( FxChannel * from, FxChannel * to, float amount )
 	// add us to to's receives
 	to->m_receives.append( route );
 
-	// add us to fxmixer's list
+	// add us to mixer's list
 	Engine::fxMixer()->m_fxRoutes.append( route );
 	Engine::mixer()->doneChangeInModel();
 
@@ -473,7 +473,7 @@ void Mixer::deleteChannelSend( FxRoute * route )
 	route->sender()->m_sends.remove( route->sender()->m_sends.indexOf( route ) );
 	// remove us from to's receives
 	route->receiver()->m_receives.remove( route->receiver()->m_receives.indexOf( route ) );
-	// remove us from fxmixer's list
+	// remove us from mixer's list
 	Engine::fxMixer()->m_fxRoutes.remove( Engine::fxMixer()->m_fxRoutes.indexOf( route ) );
 	delete route;
 	Engine::mixer()->doneChangeInModel();

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -440,7 +440,7 @@ FxRoute * Mixer::createRoute( FxChannel * from, FxChannel * to, float amount )
 	to->m_receives.append( route );
 
 	// add us to mixer's list
-	Engine::fxMixer()->m_fxRoutes.append( route );
+	Engine::mixer()->m_fxRoutes.append( route );
 	Engine::mixer()->doneChangeInModel();
 
 	return route;
@@ -474,7 +474,7 @@ void Mixer::deleteChannelSend( FxRoute * route )
 	// remove us from to's receives
 	route->receiver()->m_receives.remove( route->receiver()->m_receives.indexOf( route ) );
 	// remove us from mixer's list
-	Engine::fxMixer()->m_fxRoutes.remove( Engine::fxMixer()->m_fxRoutes.indexOf( route ) );
+	Engine::mixer()->m_fxRoutes.remove( Engine::mixer()->m_fxRoutes.indexOf( route ) );
 	delete route;
 	Engine::mixer()->doneChangeInModel();
 }

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -1,5 +1,5 @@
 /*
- * FxMixer.cpp - effect mixer for LMMS
+ * Mixer.cpp - effect mixer for LMMS
  *
  * Copyright (c) 2008-2011 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -25,7 +25,7 @@
 #include <QDomElement>
 
 #include "BufferManager.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "Mixer.h"
 #include "MixerWorkerThread.h"
 #include "MixHelpers.h"
@@ -187,7 +187,7 @@ void FxChannel::doProcessing()
 
 
 
-FxMixer::FxMixer() :
+Mixer::Mixer() :
 	Model( NULL ),
 	JournallingObject(),
 	m_fxChannels()
@@ -199,7 +199,7 @@ FxMixer::FxMixer() :
 
 
 
-FxMixer::~FxMixer()
+Mixer::~Mixer()
 {
 	while( ! m_fxRoutes.isEmpty() )
 	{
@@ -215,7 +215,7 @@ FxMixer::~FxMixer()
 
 
 
-int FxMixer::createChannel()
+int Mixer::createChannel()
 {
 	const int index = m_fxChannels.size();
 	// create new channel
@@ -227,7 +227,7 @@ int FxMixer::createChannel()
 	return index;
 }
 
-void FxMixer::activateSolo()
+void Mixer::activateSolo()
 {
 	for (int i = 1; i < m_fxChannels.size(); ++i)
 	{
@@ -236,7 +236,7 @@ void FxMixer::activateSolo()
 	}
 }
 
-void FxMixer::deactivateSolo()
+void Mixer::deactivateSolo()
 {
 	for (int i = 1; i < m_fxChannels.size(); ++i)
 	{
@@ -244,7 +244,7 @@ void FxMixer::deactivateSolo()
 	}
 }
 
-void FxMixer::toggledSolo()
+void Mixer::toggledSolo()
 {
 	int soloedChan = -1;
 	bool resetSolo = m_lastSoloed != -1;
@@ -279,7 +279,7 @@ void FxMixer::toggledSolo()
 
 
 
-void FxMixer::deleteChannel( int index )
+void Mixer::deleteChannel( int index )
 {
 	// channel deletion is performed between mixer rounds
 	Engine::mixer()->requestChangeInModel();
@@ -348,7 +348,7 @@ void FxMixer::deleteChannel( int index )
 
 
 
-void FxMixer::moveChannelLeft( int index )
+void Mixer::moveChannelLeft( int index )
 {
 	// can't move master or first channel
 	if( index <= 1 || index >= m_fxChannels.size() )
@@ -394,14 +394,14 @@ void FxMixer::moveChannelLeft( int index )
 
 
 
-void FxMixer::moveChannelRight( int index )
+void Mixer::moveChannelRight( int index )
 {
 	moveChannelLeft( index + 1 );
 }
 
 
 
-FxRoute * FxMixer::createChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel,
+FxRoute * Mixer::createChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel,
 								float amount )
 {
 //	qDebug( "requested: %d to %d", fromChannel, toChannel );
@@ -424,7 +424,7 @@ FxRoute * FxMixer::createChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel,
 }
 
 
-FxRoute * FxMixer::createRoute( FxChannel * from, FxChannel * to, float amount )
+FxRoute * Mixer::createRoute( FxChannel * from, FxChannel * to, float amount )
 {
 	if( from == to )
 	{
@@ -448,7 +448,7 @@ FxRoute * FxMixer::createRoute( FxChannel * from, FxChannel * to, float amount )
 
 
 // delete the connection made by createChannelSend
-void FxMixer::deleteChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel )
+void Mixer::deleteChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel )
 {
 	// delete the send
 	FxChannel * from = m_fxChannels[fromChannel];
@@ -466,7 +466,7 @@ void FxMixer::deleteChannelSend( fx_ch_t fromChannel, fx_ch_t toChannel )
 }
 
 
-void FxMixer::deleteChannelSend( FxRoute * route )
+void Mixer::deleteChannelSend( FxRoute * route )
 {
 	Engine::mixer()->requestChangeInModel();
 	// remove us from from's sends
@@ -480,7 +480,7 @@ void FxMixer::deleteChannelSend( FxRoute * route )
 }
 
 
-bool FxMixer::isInfiniteLoop( fx_ch_t sendFrom, fx_ch_t sendTo )
+bool Mixer::isInfiniteLoop( fx_ch_t sendFrom, fx_ch_t sendTo )
 {
 	if( sendFrom == sendTo ) return true;
 	FxChannel * from = m_fxChannels[sendFrom];
@@ -490,7 +490,7 @@ bool FxMixer::isInfiniteLoop( fx_ch_t sendFrom, fx_ch_t sendTo )
 }
 
 
-bool FxMixer::checkInfiniteLoop( FxChannel * from, FxChannel * to )
+bool Mixer::checkInfiniteLoop( FxChannel * from, FxChannel * to )
 {
 	// can't send master to anything
 	if( from == m_fxChannels[0] )
@@ -519,7 +519,7 @@ bool FxMixer::checkInfiniteLoop( FxChannel * from, FxChannel * to )
 
 
 // how much does fromChannel send its output to the input of toChannel?
-FloatModel * FxMixer::channelSendModel( fx_ch_t fromChannel, fx_ch_t toChannel )
+FloatModel * Mixer::channelSendModel( fx_ch_t fromChannel, fx_ch_t toChannel )
 {
 	if( fromChannel == toChannel )
 	{
@@ -541,7 +541,7 @@ FloatModel * FxMixer::channelSendModel( fx_ch_t fromChannel, fx_ch_t toChannel )
 
 
 
-void FxMixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
+void Mixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
 {
 	if( m_fxChannels[_ch]->m_muteModel.value() == false )
 	{
@@ -555,7 +555,7 @@ void FxMixer::mixToChannel( const sampleFrame * _buf, fx_ch_t _ch )
 
 
 
-void FxMixer::prepareMasterMix()
+void Mixer::prepareMasterMix()
 {
 	BufferManager::clear( m_fxChannels[0]->m_buffer,
 					Engine::mixer()->framesPerPeriod() );
@@ -563,7 +563,7 @@ void FxMixer::prepareMasterMix()
 
 
 
-void FxMixer::masterMix( sampleFrame * _buf )
+void Mixer::masterMix( sampleFrame * _buf )
 {
 	const int fpp = Engine::mixer()->framesPerPeriod();
 
@@ -643,7 +643,7 @@ void FxMixer::masterMix( sampleFrame * _buf )
 
 
 
-void FxMixer::clear()
+void Mixer::clear()
 {
 	while( m_fxChannels.size() > 1 )
 	{
@@ -655,7 +655,7 @@ void FxMixer::clear()
 
 
 
-void FxMixer::clearChannel(fx_ch_t index)
+void Mixer::clearChannel(fx_ch_t index)
 {
 	FxChannel * ch = m_fxChannels[index];
 	ch->m_fxChain.clear();
@@ -687,7 +687,7 @@ void FxMixer::clearChannel(fx_ch_t index)
 	}
 }
 
-void FxMixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
+void Mixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	// save channels
 	for( int i = 0; i < m_fxChannels.size(); ++i )
@@ -717,7 +717,7 @@ void FxMixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
 }
 
 // make sure we have at least num channels
-void FxMixer::allocateChannelsTo(int num)
+void Mixer::allocateChannelsTo(int num)
 {
 	while( num > m_fxChannels.size() - 1 )
 	{
@@ -729,7 +729,7 @@ void FxMixer::allocateChannelsTo(int num)
 }
 
 
-void FxMixer::loadSettings( const QDomElement & _this )
+void Mixer::loadSettings( const QDomElement & _this )
 {
 	clear();
 	QDomNode node = _this.firstChild();
@@ -775,7 +775,7 @@ void FxMixer::loadSettings( const QDomElement & _this )
 }
 
 
-void FxMixer::validateChannelName( int index, int oldIndex )
+void Mixer::validateChannelName( int index, int oldIndex )
 {
 	if( m_fxChannels[index]->m_name == tr( "FX %1" ).arg( oldIndex ) )
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -29,7 +29,7 @@
 #include "lmmsconfig.h"
 
 #include "AudioPort.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "MixerWorkerThread.h"
 #include "Song.h"
 #include "EnvelopeAndLfoParameters.h"
@@ -420,7 +420,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 	BufferManager::clear( m_writeBuf, m_framesPerPeriod );
 
 	// prepare master mix (clear internal buffers etc.)
-	FxMixer * fxMixer = Engine::fxMixer();
+	Mixer * fxMixer = Engine::fxMixer();
 	fxMixer->prepareMasterMix();
 
 	// create play-handles for new notes, samples etc.

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -420,8 +420,8 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 	BufferManager::clear( m_writeBuf, m_framesPerPeriod );
 
 	// prepare master mix (clear internal buffers etc.)
-	Mixer * fxMixer = Engine::fxMixer();
-	fxMixer->prepareMasterMix();
+	Mixer * mixer = Engine::mixer();
+	mixer->prepareMasterMix();
 
 	// create play-handles for new notes, samples etc.
 	song->processNextBuffer();
@@ -471,7 +471,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 
 
 	// STAGE 3: do master mix in FX mixer
-	fxMixer->masterMix( m_writeBuf );
+	mixer->masterMix( m_writeBuf );
 
 
 	emit nextAudioBuffer( m_readBuf );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -470,7 +470,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 	MixerWorkerThread::startAndWaitForJobs();
 
 
-	// STAGE 3: do master mix in FX mixer
+	// STAGE 3: do master mix in mixer
 	mixer->masterMix( m_writeBuf );
 
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -43,8 +43,8 @@
 #include "embed.h"
 #include "EnvelopeAndLfoParameters.h"
 #include "ExportProjectDialog.h"
-#include "FxMixer.h"
-#include "FxMixerView.h"
+#include "Mixer.h"
+#include "MixerView.h"
 #include "GuiApplication.h"
 #include "ImportFilter.h"
 #include "ExportFilter.h"
@@ -1069,7 +1069,7 @@ void Song::loadProject( const QString & fileName )
 		Engine::fxMixer()->restoreState( node.toElement() );
 		if( gui )
 		{
-			// refresh FxMixerView
+			// refresh MixerView
 			gui->fxMixerView()->refreshDisplay();
 		}
 	}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -870,15 +870,15 @@ void Song::clearProject()
 	{
 		gui->songEditor()->m_editor->clearAllTracks();
 	}
-	if( gui && gui->fxMixerView() )
+	if( gui && gui->mixerView() )
 	{
-		gui->fxMixerView()->clear();
+		gui->mixerView()->clear();
 	}
 	QCoreApplication::sendPostedEvents();
 	Engine::getBBTrackContainer()->clearAllTracks();
 	clearAllTracks();
 
-	Engine::fxMixer()->clear();
+	Engine::mixer()->clear();
 
 	if( gui && gui->automationEditor() )
 	{
@@ -1063,14 +1063,14 @@ void Song::loadProject( const QString & fileName )
 	PeakController::initGetControllerBySetting();
 
 	// Load mixer first to be able to set the correct range for FX channels
-	node = dataFile.content().firstChildElement( Engine::fxMixer()->nodeName() );
+	node = dataFile.content().firstChildElement( Engine::mixer()->nodeName() );
 	if( !node.isNull() )
 	{
-		Engine::fxMixer()->restoreState( node.toElement() );
+		Engine::mixer()->restoreState( node.toElement() );
 		if( gui )
 		{
 			// refresh MixerView
-			gui->fxMixerView()->refreshDisplay();
+			gui->mixerView()->refreshDisplay();
 		}
 	}
 
@@ -1204,7 +1204,7 @@ bool Song::saveProjectFile( const QString & filename )
 	saveState( dataFile, dataFile.content() );
 
 	m_globalAutomationTrack->saveState( dataFile, dataFile.content() );
-	Engine::fxMixer()->saveState( dataFile, dataFile.content() );
+	Engine::mixer()->saveState( dataFile, dataFile.content() );
 	if( gui )
 	{
 		gui->getControllerRackView()->saveState( dataFile, dataFile.content() );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -57,7 +57,7 @@
 #include "embed.h"
 #include "Engine.h"
 #include "GuiApplication.h"
-#include "FxMixerView.h"
+#include "MixerView.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
 #include "Mixer.h"

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -25,7 +25,7 @@
 #include "AudioPort.h"
 #include "AudioDevice.h"
 #include "EffectChain.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "Engine.h"
 #include "Mixer.h"
 #include "MixHelpers.h"

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -223,7 +223,7 @@ void AudioPort::doProcessing()
 	const bool me = processEffects();
 	if( me || m_bufferUsage )
 	{
-		Engine::fxMixer()->mixToChannel( m_portBuffer, m_nextFxChannel ); 	// send output to fx mixer
+		Engine::mixer()->mixToChannel( m_portBuffer, m_nextFxChannel ); 	// send output to fx mixer
 																			// TODO: improve the flow here - convert to pull model
 		m_bufferUsage = false;
 	}

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -223,7 +223,7 @@ void AudioPort::doProcessing()
 	const bool me = processEffects();
 	if( me || m_bufferUsage )
 	{
-		Engine::mixer()->mixToChannel( m_portBuffer, m_nextFxChannel ); 	// send output to fx mixer
+		Engine::mixer()->mixToChannel( m_portBuffer, m_nextFxChannel ); 	// send output to mixer
 																			// TODO: improve the flow here - convert to pull model
 		m_bufferUsage = false;
 	}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -13,7 +13,7 @@ SET(LMMS_SRCS
 	gui/embed.cpp
 	gui/ExportProjectDialog.cpp
 	gui/FileBrowser.cpp
-	gui/FxMixerView.cpp
+	gui/MixerView.cpp
 	gui/GuiApplication.cpp
 	gui/InstrumentView.cpp
 	gui/LfoControllerDialog.cpp

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -65,7 +65,7 @@ FxMixerView::FxMixerView() :
 	setAutoFillBackground( true );
 	setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
 
-	setWindowTitle( tr( "FX-Mixer" ) );
+	setWindowTitle( tr( "Mixer" ) );
 	setWindowIcon( embed::getIconPixmap( "fx_mixer" ) );
 
 	// main-layout

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -55,7 +55,7 @@ MixerView::MixerView() :
 	ModelView( NULL, this ),
 	SerializingObjectHook()
 {
-	Mixer * m = Engine::fxMixer();
+	Mixer * m = Engine::mixer();
 	m->setHook( this );
 
 	//QPalette pal = palette();
@@ -179,7 +179,7 @@ MixerView::~MixerView()
 int MixerView::addNewChannel()
 {
 	// add new fx mixer channel and redraw the form.
-	Mixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::mixer();
 
 	int newChannelIndex = mix->createChannel();
 	m_fxChannelViews.push_back(new FxChannelView(m_channelAreaWidget, this,
@@ -212,7 +212,7 @@ void MixerView::refreshDisplay()
 	m_channelAreaWidget->adjustSize();
 
 	// re-add the views
-	m_fxChannelViews.resize(Engine::fxMixer()->numChannels());
+	m_fxChannelViews.resize(Engine::mixer()->numChannels());
 	for( int i = 1; i < m_fxChannelViews.size(); ++i )
 	{
 		m_fxChannelViews[i] = new FxChannelView(m_channelAreaWidget, this, i);
@@ -275,7 +275,7 @@ MixerView::FxChannelView::FxChannelView(QWidget * _parent, MixerView * _mv,
 {
 	m_fxLine = new FxLine(_parent, _mv, channelIndex);
 
-	FxChannel *fxChannel = Engine::fxMixer()->effectChannel(channelIndex);
+	FxChannel *fxChannel = Engine::mixer()->effectChannel(channelIndex);
 
 	m_fader = new Fader( &fxChannel->m_volumeModel,
 					tr( "FX Fader %1" ).arg( channelIndex ), m_fxLine );
@@ -317,7 +317,7 @@ MixerView::FxChannelView::FxChannelView(QWidget * _parent, MixerView * _mv,
 
 void MixerView::FxChannelView::setChannelIndex( int index )
 {
-	FxChannel* fxChannel = Engine::fxMixer()->effectChannel( index );
+	FxChannel* fxChannel = Engine::mixer()->effectChannel( index );
 
 	m_fader->setModel( &fxChannel->m_volumeModel );
 	m_muteBtn->setModel( &fxChannel->m_muteModel );
@@ -328,7 +328,7 @@ void MixerView::FxChannelView::setChannelIndex( int index )
 
 void MixerView::toggledSolo()
 {
-	Engine::fxMixer()->toggledSolo();
+	Engine::mixer()->toggledSolo();
 }
 
 
@@ -349,12 +349,12 @@ void MixerView::setCurrentFxLine( FxLine * _line )
 
 void MixerView::updateFxLine(int index)
 {
-	Mixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::mixer();
 
 	// does current channel send to this channel?
 	int selIndex = m_currentFxLine->channelIndex();
 	FxLine * thisLine = m_fxChannelViews[index]->m_fxLine;
-	thisLine->setToolTip( Engine::fxMixer()->effectChannel( index )->m_name );
+	thisLine->setToolTip( Engine::mixer()->effectChannel( index )->m_name );
 
 	FloatModel * sendModel = mix->channelSendModel(selIndex, index);
 	if( sendModel == NULL )
@@ -386,10 +386,10 @@ void MixerView::deleteChannel(int index)
 
 	// in case the deleted channel is soloed or the remaining
 	// channels will be left in a muted state
-	Engine::fxMixer()->clearChannel(index);
+	Engine::mixer()->clearChannel(index);
 
 	// delete the real channel
-	Engine::fxMixer()->deleteChannel(index);
+	Engine::mixer()->deleteChannel(index);
 
 	// delete the view
 	chLayout->removeWidget(m_fxChannelViews[index]->m_fxLine);
@@ -449,7 +449,7 @@ void MixerView::deleteUnusedChannels()
 				}
 			}
 		}
-		FxChannel * ch = Engine::fxMixer()->effectChannel( i );
+		FxChannel * ch = Engine::mixer()->effectChannel( i );
 		// delete channel if no references found
 		if( empty && ch->m_receives.isEmpty() )
 		{
@@ -465,7 +465,7 @@ void MixerView::moveChannelLeft(int index, int focusIndex)
 	// can't move master or first channel left or last channel right
 	if( index <= 1 || index >= m_fxChannelViews.size() ) return;
 
-	Mixer *m = Engine::fxMixer();
+	Mixer *m = Engine::mixer();
 
 	// Move instruments channels
 	m->moveChannelLeft( index );
@@ -561,7 +561,7 @@ void MixerView::setCurrentFxLine( int _line )
 
 void MixerView::clear()
 {
-	Engine::fxMixer()->clear();
+	Engine::mixer()->clear();
 
 	refreshDisplay();
 }
@@ -571,7 +571,7 @@ void MixerView::clear()
 
 void MixerView::updateFaders()
 {
-	Mixer * m = Engine::fxMixer();
+	Mixer * m = Engine::mixer();
 
 	// apply master gain
 	m->effectChannel(0)->m_peakLeft *= Engine::mixer()->masterGain();

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -1,5 +1,5 @@
 /*
- * FxMixerView.cpp - effect-mixer-view for LMMS
+ * MixerView.cpp - effect-mixer-view for LMMS
  *
  * Copyright (c) 2008-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -38,10 +38,10 @@
 
 #include "lmms_math.h"
 
-#include "FxMixerView.h"
+#include "MixerView.h"
 #include "Knob.h"
 #include "FxLine.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
 #include "Mixer.h"
@@ -50,12 +50,12 @@
 #include "Song.h"
 #include "BBTrackContainer.h"
 
-FxMixerView::FxMixerView() :
+MixerView::MixerView() :
 	QWidget(),
 	ModelView( NULL, this ),
 	SerializingObjectHook()
 {
-	FxMixer * m = Engine::fxMixer();
+	Mixer * m = Engine::fxMixer();
 	m->setHook( this );
 
 	//QPalette pal = palette();
@@ -111,7 +111,7 @@ FxMixerView::FxMixerView() :
 	class ChannelArea : public QScrollArea
 	{
 		public:
-			ChannelArea( QWidget * parent, FxMixerView * mv ) :
+			ChannelArea( QWidget * parent, MixerView * mv ) :
 				QScrollArea( parent ), m_mv( mv ) {}
 			~ChannelArea() {}
 			virtual void keyPressEvent( QKeyEvent * e )
@@ -119,7 +119,7 @@ FxMixerView::FxMixerView() :
 				m_mv->keyPressEvent( e );
 			}
 		private:
-			FxMixerView * m_mv;
+			MixerView * m_mv;
 	};
 	channelArea = new ChannelArea( this, this );
 	channelArea->setWidget( m_channelAreaWidget );
@@ -166,7 +166,7 @@ FxMixerView::FxMixerView() :
 	setModel( m );
 }
 
-FxMixerView::~FxMixerView()
+MixerView::~MixerView()
 {
 	for (int i=0; i<m_fxChannelViews.size(); i++)
 	{
@@ -176,10 +176,10 @@ FxMixerView::~FxMixerView()
 
 
 
-int FxMixerView::addNewChannel()
+int MixerView::addNewChannel()
 {
 	// add new fx mixer channel and redraw the form.
-	FxMixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::fxMixer();
 
 	int newChannelIndex = mix->createChannel();
 	m_fxChannelViews.push_back(new FxChannelView(m_channelAreaWidget, this,
@@ -195,7 +195,7 @@ int FxMixerView::addNewChannel()
 }
 
 
-void FxMixerView::refreshDisplay()
+void MixerView::refreshDisplay()
 {
 	// delete all views and re-add them
 	for( int i = 1; i<m_fxChannelViews.size(); ++i )
@@ -234,7 +234,7 @@ void FxMixerView::refreshDisplay()
 
 
 // update the and max. channel number for every instrument
-void FxMixerView::updateMaxChannelSelector()
+void MixerView::updateMaxChannelSelector()
 {
 	QVector<Track *> songTrackList = Engine::getSong()->tracks();
 	QVector<Track *> bbTrackList = Engine::getBBTrackContainer()->tracks();
@@ -256,7 +256,7 @@ void FxMixerView::updateMaxChannelSelector()
 }
 
 
-void FxMixerView::saveSettings( QDomDocument & _doc, QDomElement & _this )
+void MixerView::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	MainWindow::saveWidgetState( this, _this );
 }
@@ -264,13 +264,13 @@ void FxMixerView::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 
 
-void FxMixerView::loadSettings( const QDomElement & _this )
+void MixerView::loadSettings( const QDomElement & _this )
 {
 	MainWindow::restoreWidgetState( this, _this );
 }
 
 
-FxMixerView::FxChannelView::FxChannelView(QWidget * _parent, FxMixerView * _mv,
+MixerView::FxChannelView::FxChannelView(QWidget * _parent, MixerView * _mv,
 										  int channelIndex )
 {
 	m_fxLine = new FxLine(_parent, _mv, channelIndex);
@@ -315,7 +315,7 @@ FxMixerView::FxChannelView::FxChannelView(QWidget * _parent, FxMixerView * _mv,
 }
 
 
-void FxMixerView::FxChannelView::setChannelIndex( int index )
+void MixerView::FxChannelView::setChannelIndex( int index )
 {
 	FxChannel* fxChannel = Engine::fxMixer()->effectChannel( index );
 
@@ -326,14 +326,14 @@ void FxMixerView::FxChannelView::setChannelIndex( int index )
 }
 
 
-void FxMixerView::toggledSolo()
+void MixerView::toggledSolo()
 {
 	Engine::fxMixer()->toggledSolo();
 }
 
 
 
-void FxMixerView::setCurrentFxLine( FxLine * _line )
+void MixerView::setCurrentFxLine( FxLine * _line )
 {
 	// select
 	m_currentFxLine = _line;
@@ -347,9 +347,9 @@ void FxMixerView::setCurrentFxLine( FxLine * _line )
 }
 
 
-void FxMixerView::updateFxLine(int index)
+void MixerView::updateFxLine(int index)
 {
-	FxMixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::fxMixer();
 
 	// does current channel send to this channel?
 	int selIndex = m_currentFxLine->channelIndex();
@@ -376,7 +376,7 @@ void FxMixerView::updateFxLine(int index)
 }
 
 
-void FxMixerView::deleteChannel(int index)
+void MixerView::deleteChannel(int index)
 {
 	// can't delete master
 	if( index == 0 ) return;
@@ -426,7 +426,7 @@ void FxMixerView::deleteChannel(int index)
 
 
 
-void FxMixerView::deleteUnusedChannels()
+void MixerView::deleteUnusedChannels()
 {
 	TrackContainer::TrackList tracks;
 	tracks += Engine::getSong()->tracks();
@@ -460,12 +460,12 @@ void FxMixerView::deleteUnusedChannels()
 
 
 
-void FxMixerView::moveChannelLeft(int index, int focusIndex)
+void MixerView::moveChannelLeft(int index, int focusIndex)
 {
 	// can't move master or first channel left or last channel right
 	if( index <= 1 || index >= m_fxChannelViews.size() ) return;
 
-	FxMixer *m = Engine::fxMixer();
+	Mixer *m = Engine::fxMixer();
 
 	// Move instruments channels
 	m->moveChannelLeft( index );
@@ -480,21 +480,21 @@ void FxMixerView::moveChannelLeft(int index, int focusIndex)
 
 
 
-void FxMixerView::moveChannelLeft(int index)
+void MixerView::moveChannelLeft(int index)
 {
 	moveChannelLeft( index, index - 1 );
 }
 
 
 
-void FxMixerView::moveChannelRight(int index)
+void MixerView::moveChannelRight(int index)
 {
 	moveChannelLeft( index + 1, index + 1 );
 }
 
 
 
-void FxMixerView::keyPressEvent(QKeyEvent * e)
+void MixerView::keyPressEvent(QKeyEvent * e)
 {
 	switch(e->key())
 	{
@@ -534,7 +534,7 @@ void FxMixerView::keyPressEvent(QKeyEvent * e)
 
 
 
-void FxMixerView::closeEvent( QCloseEvent * _ce )
+void MixerView::closeEvent( QCloseEvent * _ce )
  {
 	if( parentWidget() )
 	{
@@ -549,7 +549,7 @@ void FxMixerView::closeEvent( QCloseEvent * _ce )
 
 
 
-void FxMixerView::setCurrentFxLine( int _line )
+void MixerView::setCurrentFxLine( int _line )
 {
 	if( _line >= 0 && _line < m_fxChannelViews.size() )
 	{
@@ -559,7 +559,7 @@ void FxMixerView::setCurrentFxLine( int _line )
 
 
 
-void FxMixerView::clear()
+void MixerView::clear()
 {
 	Engine::fxMixer()->clear();
 
@@ -569,9 +569,9 @@ void FxMixerView::clear()
 
 
 
-void FxMixerView::updateFaders()
+void MixerView::updateFaders()
 {
-	FxMixer * m = Engine::fxMixer();
+	Mixer * m = Engine::fxMixer();
 
 	// apply master gain
 	m->effectChannel(0)->m_peakLeft *= Engine::mixer()->masterGain();

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -66,7 +66,7 @@ MixerView::MixerView() :
 	setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Fixed );
 
 	setWindowTitle( tr( "Mixer" ) );
-	setWindowIcon( embed::getIconPixmap( "fx_mixer" ) );
+	setWindowIcon( embed::getIconPixmap( "mixer" ) );
 
 	// main-layout
 	QHBoxLayout * ml = new QHBoxLayout;

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -178,7 +178,7 @@ MixerView::~MixerView()
 
 int MixerView::addNewChannel()
 {
-	// add new fx mixer channel and redraw the form.
+	// add new mixer channel and redraw the form.
 	Mixer * mix = Engine::mixer();
 
 	int newChannelIndex = mix->createChannel();

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -123,8 +123,8 @@ GuiApplication::GuiApplication()
 	connect(m_songEditor, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing mixer"));
-	m_fxMixerView = new MixerView;
-	connect(m_fxMixerView, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
+	m_mixerView = new MixerView;
+	connect(m_mixerView, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing controller rack"));
 	m_controllerRackView = new ControllerRackView;
@@ -171,15 +171,15 @@ void GuiApplication::displayInitProgress(const QString &msg)
 
 void GuiApplication::childDestroyed(QObject *obj)
 {
-	// when any object that can be reached via gui->mainWindow(), gui->fxMixerView(), etc
+	// when any object that can be reached via gui->mainWindow(), gui->mixerView(), etc
 	//   is destroyed, ensure that their accessor functions will return null instead of a garbage pointer.
 	if (obj == m_mainWindow)
 	{
 		m_mainWindow = nullptr;
 	}
-	else if (obj == m_fxMixerView)
+	else if (obj == m_mixerView)
 	{
-		m_fxMixerView = nullptr;
+		m_mixerView = nullptr;
 	}
 	else if (obj == m_songEditor)
 	{

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -33,7 +33,7 @@
 #include "BBEditor.h"
 #include "ConfigManager.h"
 #include "ControllerRackView.h"
-#include "FxMixerView.h"
+#include "MixerView.h"
 #include "MainWindow.h"
 #include "PianoRoll.h"
 #include "ProjectNotes.h"
@@ -123,7 +123,7 @@ GuiApplication::GuiApplication()
 	connect(m_songEditor, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing mixer"));
-	m_fxMixerView = new FxMixerView;
+	m_fxMixerView = new MixerView;
 	connect(m_fxMixerView, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing controller rack"));

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1192,7 +1192,7 @@ void MainWindow::toggleAutomationEditorWin()
 
 void MainWindow::toggleMixerWin()
 {
-	toggleWindow( gui->fxMixerView() );
+	toggleWindow( gui->mixerView() );
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -47,7 +47,7 @@
 #include "Engine.h"
 #include "FileBrowser.h"
 #include "FileDialog.h"
-#include "FxMixerView.h"
+#include "MixerView.h"
 #include "GuiApplication.h"
 #include "PianoRoll.h"
 #include "PluginBrowser.h"
@@ -542,7 +542,7 @@ void MainWindow::finalize()
 	ToolButton * fx_mixer_window = new ToolButton(
 					embed::getIconPixmap( "fx_mixer" ),
 					tr( "Show/hide FX Mixer" ) + " (F9)",
-					this, SLOT( toggleFxMixerWin() ),
+					this, SLOT( toggleMixerWin() ),
 					m_toolBar );
 	fx_mixer_window->setShortcut( Qt::Key_F9 );
 	fx_mixer_window->setWhatsThis(
@@ -757,7 +757,7 @@ void MainWindow::clearKeyModifiers()
 
 void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 {
-	// If our widget is the main content of a window (e.g. piano roll, FxMixer, etc), 
+	// If our widget is the main content of a window (e.g. piano roll, Mixer, etc), 
 	// we really care about the position of the *window* - not the position of the widget within its window
 	if( _w->parentWidget() != NULL &&
 			_w->parentWidget()->inherits( "QMdiSubWindow" ) )
@@ -794,7 +794,7 @@ void MainWindow::restoreWidgetState( QWidget * _w, const QDomElement & _de )
 			qMax( _w->minimumHeight(), _de.attribute( "height" ).toInt() ) );
 	if( _de.hasAttribute( "visible" ) && !r.isNull() )
 	{
-		// If our widget is the main content of a window (e.g. piano roll, FxMixer, etc), 
+		// If our widget is the main content of a window (e.g. piano roll, Mixer, etc), 
 		// we really care about the position of the *window* - not the position of the widget within its window
 		if ( _w->parentWidget() != NULL &&
 			_w->parentWidget()->inherits( "QMdiSubWindow" ) )
@@ -1190,7 +1190,7 @@ void MainWindow::toggleAutomationEditorWin()
 
 
 
-void MainWindow::toggleFxMixerWin()
+void MainWindow::toggleMixerWin()
 {
 	toggleWindow( gui->fxMixerView() );
 }
@@ -1221,7 +1221,7 @@ void MainWindow::updateViewMenu()
 		);
 	m_viewMenu->addAction(embed::getIconPixmap( "fx_mixer" ),
 			      tr( "FX Mixer" ) + " (F9)",
-			      this, SLOT( toggleFxMixerWin() )
+			      this, SLOT( toggleMixerWin() )
 		);
 	m_viewMenu->addAction(embed::getIconPixmap( "project_notes" ),
 			      tr( "Project Notes" ) +	" (F10)",

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -539,13 +539,13 @@ void MainWindow::finalize()
 				"in an easy way."
 				) );
 
-	ToolButton * fx_mixer_window = new ToolButton(
-					embed::getIconPixmap( "fx_mixer" ),
+	ToolButton * mixer_window = new ToolButton(
+					embed::getIconPixmap( "mixer" ),
 					tr( "Show/hide Mixer" ) + " (F9)",
 					this, SLOT( toggleMixerWin() ),
 					m_toolBar );
-	fx_mixer_window->setShortcut( Qt::Key_F9 );
-	fx_mixer_window->setWhatsThis(
+	mixer_window->setShortcut( Qt::Key_F9 );
+	mixer_window->setWhatsThis(
 		tr( "Click here to show or hide the "
 			"Mixer. The Mixer is a very powerful tool "
 			"for managing effects for your song. You can insert "
@@ -575,7 +575,7 @@ void MainWindow::finalize()
 	m_toolBarLayout->addWidget( bb_editor_window, 1, 2 );
 	m_toolBarLayout->addWidget( piano_roll_window, 1, 3 );
 	m_toolBarLayout->addWidget( automation_editor_window, 1, 4 );
-	m_toolBarLayout->addWidget( fx_mixer_window, 1, 5 );
+	m_toolBarLayout->addWidget( mixer_window, 1, 5 );
 	m_toolBarLayout->addWidget( project_notes_window, 1, 6 );
 	m_toolBarLayout->addWidget( controllers_window, 1, 7 );
 	m_toolBarLayout->setColumnStretch( 100, 1 );
@@ -1219,7 +1219,7 @@ void MainWindow::updateViewMenu()
 			      this,
 			      SLOT( toggleAutomationEditorWin())
 		);
-	m_viewMenu->addAction(embed::getIconPixmap( "fx_mixer" ),
+	m_viewMenu->addAction(embed::getIconPixmap( "mixer" ),
 			      tr( "Mixer" ) + " (F9)",
 			      this, SLOT( toggleMixerWin() )
 		);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -541,13 +541,13 @@ void MainWindow::finalize()
 
 	ToolButton * fx_mixer_window = new ToolButton(
 					embed::getIconPixmap( "fx_mixer" ),
-					tr( "Show/hide FX Mixer" ) + " (F9)",
+					tr( "Show/hide Mixer" ) + " (F9)",
 					this, SLOT( toggleMixerWin() ),
 					m_toolBar );
 	fx_mixer_window->setShortcut( Qt::Key_F9 );
 	fx_mixer_window->setWhatsThis(
 		tr( "Click here to show or hide the "
-			"FX Mixer. The FX Mixer is a very powerful tool "
+			"Mixer. The Mixer is a very powerful tool "
 			"for managing effects for your song. You can insert "
 			"effects into different effect-channels." ) );
 
@@ -1220,7 +1220,7 @@ void MainWindow::updateViewMenu()
 			      SLOT( toggleAutomationEditorWin())
 		);
 	m_viewMenu->addAction(embed::getIconPixmap( "fx_mixer" ),
-			      tr( "FX Mixer" ) + " (F9)",
+			      tr( "Mixer" ) + " (F9)",
 			      this, SLOT( toggleMixerWin() )
 		);
 	m_viewMenu->addAction(embed::getIconPixmap( "project_notes" ),

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -29,7 +29,7 @@
 #include <QWhatsThis>
 
 #include "CaptionMenu.h"
-#include "FxMixer.h"
+#include "Mixer.h"
 #include "gui_templates.h"
 #include "GuiApplication.h"
 #include "Song.h"
@@ -39,7 +39,7 @@ const int FxLine::FxLineHeight = 287;
 QPixmap * FxLine::s_sendBgArrow = NULL;
 QPixmap * FxLine::s_receiveBgArrow = NULL;
 
-FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex ) :
+FxLine::FxLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	QWidget( _parent ),
 	m_mv( _mv ),
 	m_channelIndex( _channelIndex ),
@@ -283,7 +283,7 @@ void FxLine::renameFinished()
 
 void FxLine::removeChannel()
 {
-	FxMixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->fxMixerView();
 	mix->deleteChannel( m_channelIndex );
 }
 
@@ -292,7 +292,7 @@ void FxLine::removeChannel()
 
 void FxLine::removeUnusedChannels()
 {
-	FxMixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->fxMixerView();
 	mix->deleteUnusedChannels();
 }
 
@@ -301,7 +301,7 @@ void FxLine::removeUnusedChannels()
 
 void FxLine::moveChannelLeft()
 {
-	FxMixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->fxMixerView();
 	mix->moveChannelLeft( m_channelIndex );
 }
 
@@ -310,7 +310,7 @@ void FxLine::moveChannelLeft()
 
 void FxLine::moveChannelRight()
 {
-	FxMixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->fxMixerView();
 	mix->moveChannelRight( m_channelIndex );
 }
 

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -92,7 +92,7 @@ FxLine::FxLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	"You can remove and move FX channels in the context menu, which is accessed "
 	"by right-clicking the FX channel.\n" ) );
 
-	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	QString name = Engine::mixer()->effectChannel( m_channelIndex )->m_name;
 	setToolTip( name );
 
 	m_renameLineEdit = new QLineEdit();
@@ -143,7 +143,7 @@ void FxLine::setChannelIndex( int index )
 
 void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool sendToThis, bool receiveFromThis )
 {
-	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	QString name = Engine::mixer()->effectChannel( m_channelIndex )->m_name;
 	QString elidedName = elideName( name );
 	if( !m_inRename && m_renameLineEdit->text() != elidedName )
 	{
@@ -190,8 +190,8 @@ QString FxLine::elideName( const QString & name )
 
 void FxLine::paintEvent( QPaintEvent * )
 {
-	bool sendToThis = Engine::fxMixer()->channelSendModel( m_mv->currentFxLine()->m_channelIndex, m_channelIndex ) != NULL;
-	bool receiveFromThis = Engine::fxMixer()->channelSendModel( m_channelIndex, m_mv->currentFxLine()->m_channelIndex ) != NULL;
+	bool sendToThis = Engine::mixer()->channelSendModel( m_mv->currentFxLine()->m_channelIndex, m_channelIndex ) != NULL;
+	bool receiveFromThis = Engine::mixer()->channelSendModel( m_channelIndex, m_mv->currentFxLine()->m_channelIndex ) != NULL;
 	QPainter painter;
 	painter.begin( this );
 	drawFxLine( &painter, this, m_mv->currentFxLine() == this, sendToThis, receiveFromThis );
@@ -219,7 +219,7 @@ void FxLine::mouseDoubleClickEvent( QMouseEvent * )
 
 void FxLine::contextMenuEvent( QContextMenuEvent * )
 {
-	QPointer<CaptionMenu> contextMenu = new CaptionMenu( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name, this );
+	QPointer<CaptionMenu> contextMenu = new CaptionMenu( Engine::mixer()->effectChannel( m_channelIndex )->m_name, this );
 	if( m_channelIndex != 0 ) // no move-options in master 
 	{
 		contextMenu->addAction( tr( "Move &left" ),	this, SLOT( moveChannelLeft() ) );
@@ -250,7 +250,7 @@ void FxLine::renameChannel()
 	m_renameLineEdit->setReadOnly( false );
 	m_lcd->hide();
 	m_renameLineEdit->setFixedWidth( 135 );
-	m_renameLineEdit->setText( Engine::fxMixer()->effectChannel( m_channelIndex )->m_name );
+	m_renameLineEdit->setText( Engine::mixer()->effectChannel( m_channelIndex )->m_name );
 	m_view->setFocus();
 	m_renameLineEdit->selectAll();
 	m_renameLineEdit->setFocus();
@@ -268,13 +268,13 @@ void FxLine::renameFinished()
 	m_lcd->show();
 	QString newName = m_renameLineEdit->text();
 	setFocus();
-	if( !newName.isEmpty() && Engine::fxMixer()->effectChannel( m_channelIndex )->m_name != newName )
+	if( !newName.isEmpty() && Engine::mixer()->effectChannel( m_channelIndex )->m_name != newName )
 	{
-		Engine::fxMixer()->effectChannel( m_channelIndex )->m_name = newName;
+		Engine::mixer()->effectChannel( m_channelIndex )->m_name = newName;
 		m_renameLineEdit->setText( elideName( newName ) );
 		Engine::getSong()->setModified();
 	}
-	QString name = Engine::fxMixer()->effectChannel( m_channelIndex )->m_name;
+	QString name = Engine::mixer()->effectChannel( m_channelIndex )->m_name;
 	setToolTip( name );
 }
 
@@ -283,7 +283,7 @@ void FxLine::renameFinished()
 
 void FxLine::removeChannel()
 {
-	MixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->mixerView();
 	mix->deleteChannel( m_channelIndex );
 }
 
@@ -292,7 +292,7 @@ void FxLine::removeChannel()
 
 void FxLine::removeUnusedChannels()
 {
-	MixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->mixerView();
 	mix->deleteUnusedChannels();
 }
 
@@ -301,7 +301,7 @@ void FxLine::removeUnusedChannels()
 
 void FxLine::moveChannelLeft()
 {
-	MixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->mixerView();
 	mix->moveChannelLeft( m_channelIndex );
 }
 
@@ -310,7 +310,7 @@ void FxLine::moveChannelLeft()
 
 void FxLine::moveChannelRight()
 {
-	MixerView * mix = gui->fxMixerView();
+	MixerView * mix = gui->mixerView();
 	mix->moveChannelRight( m_channelIndex );
 }
 

--- a/src/gui/widgets/SendButtonIndicator.cpp
+++ b/src/gui/widgets/SendButtonIndicator.cpp
@@ -1,12 +1,12 @@
 #include "SendButtonIndicator.h"
 
-#include "FxMixer.h"
+#include "Mixer.h"
 
 QPixmap * SendButtonIndicator::s_qpmOff = NULL;
 QPixmap * SendButtonIndicator::s_qpmOn = NULL;
 
 SendButtonIndicator:: SendButtonIndicator( QWidget * _parent, FxLine * _owner,
-										   FxMixerView * _mv) :
+										   MixerView * _mv) :
 	QLabel( _parent ),
 	m_parent( _owner ),
 	m_mv( _mv )
@@ -21,7 +21,7 @@ SendButtonIndicator:: SendButtonIndicator( QWidget * _parent, FxLine * _owner,
 		s_qpmOn = new QPixmap( embed::getIconPixmap( "mixer_send_on", 29, 20 ) );
 	}
 	
-	// don't do any initializing yet, because the FxMixerView and FxLine
+	// don't do any initializing yet, because the MixerView and FxLine
 	// that were passed to this constructor are not done with their constructors
 	// yet.
 	setPixmap( *s_qpmOff );
@@ -29,7 +29,7 @@ SendButtonIndicator:: SendButtonIndicator( QWidget * _parent, FxLine * _owner,
 
 void SendButtonIndicator::mousePressEvent( QMouseEvent * e )
 {
-	FxMixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::fxMixer();
 	int from = m_mv->currentFxLine()->channelIndex();
 	int to = m_parent->channelIndex();
 	FloatModel * sendModel = mix->channelSendModel(from, to);
@@ -50,7 +50,7 @@ void SendButtonIndicator::mousePressEvent( QMouseEvent * e )
 
 FloatModel * SendButtonIndicator::getSendModel()
 {
-	FxMixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::fxMixer();
 	return mix->channelSendModel(
 		m_mv->currentFxLine()->channelIndex(), m_parent->channelIndex());
 }

--- a/src/gui/widgets/SendButtonIndicator.cpp
+++ b/src/gui/widgets/SendButtonIndicator.cpp
@@ -29,7 +29,7 @@ SendButtonIndicator:: SendButtonIndicator( QWidget * _parent, FxLine * _owner,
 
 void SendButtonIndicator::mousePressEvent( QMouseEvent * e )
 {
-	Mixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::mixer();
 	int from = m_mv->currentFxLine()->channelIndex();
 	int to = m_parent->channelIndex();
 	FloatModel * sendModel = mix->channelSendModel(from, to);
@@ -50,7 +50,7 @@ void SendButtonIndicator::mousePressEvent( QMouseEvent * e )
 
 FloatModel * SendButtonIndicator::getSendModel()
 {
-	Mixer * mix = Engine::fxMixer();
+	Mixer * mix = Engine::mixer();
 	return mix->channelSendModel(
 		m_mv->currentFxLine()->channelIndex(), m_parent->channelIndex());
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -47,8 +47,8 @@
 #include "EffectRackView.h"
 #include "embed.h"
 #include "FileBrowser.h"
-#include "FxMixer.h"
-#include "FxMixerView.h"
+#include "Mixer.h"
+#include "MixerView.h"
 #include "GuiApplication.h"
 #include "InstrumentSoundShapingView.h"
 #include "FadeButton.h"
@@ -1266,7 +1266,7 @@ class fxLineLcdSpinBox : public LcdSpinBox
 			gui->fxMixerView()->parentWidget()->show();
 			gui->fxMixerView()->show();// show fxMixer window
 			gui->fxMixerView()->setFocus();// set focus to fxMixer window
-			//engine::getFxMixerView()->raise();
+			//engine::getMixerView()->raise();
 		}
 
 		virtual void contextMenuEvent( QContextMenuEvent* event )

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -115,7 +115,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 	m_panningModel.setCenterValue( DefaultPanning );
 	m_baseNoteModel.setInitValue( DefaultKey );
 
-	m_effectChannelModel.setRange( 0, Engine::fxMixer()->numChannels()-1, 1);
+	m_effectChannelModel.setRange( 0, Engine::mixer()->numChannels()-1, 1);
 
 	for( int i = 0; i < NumKeys; ++i )
 	{
@@ -762,7 +762,7 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 	m_panningModel.loadSettings( thisElement, "pan" );
 	m_pitchRangeModel.loadSettings( thisElement, "pitchrange" );
 	m_pitchModel.loadSettings( thisElement, "pitch" );
-	m_effectChannelModel.setRange( 0, Engine::fxMixer()->numChannels()-1 );
+	m_effectChannelModel.setRange( 0, Engine::mixer()->numChannels()-1 );
 	if ( !m_previewMode )
 	{
 		m_effectChannelModel.loadSettings( thisElement, "fxch" );
@@ -1007,9 +1007,9 @@ InstrumentTrackWindow * InstrumentTrackView::topLevelInstrumentTrackWindow()
 /*! \brief Create and assign a new FX Channel for this track */
 void InstrumentTrackView::createFxLine()
 {
-	int channelIndex = gui->fxMixerView()->addNewChannel();
+	int channelIndex = gui->mixerView()->addNewChannel();
 
-	Engine::fxMixer()->effectChannel( channelIndex )->m_name = getTrack()->name();
+	Engine::mixer()->effectChannel( channelIndex )->m_name = getTrack()->name();
 
 	assignFxLine(channelIndex);
 }
@@ -1022,7 +1022,7 @@ void InstrumentTrackView::assignFxLine(int channelIndex)
 {
 	model()->effectChannelModel()->setValue( channelIndex );
 
-	gui->fxMixerView()->setCurrentFxLine( channelIndex );
+	gui->mixerView()->setCurrentFxLine( channelIndex );
 }
 
 
@@ -1215,7 +1215,7 @@ QMenu * InstrumentTrackView::createFxMenu(QString title, QString newFxLabel)
 {
 	int channelIndex = model()->effectChannelModel()->value();
 
-	FxChannel *fxChannel = Engine::fxMixer()->effectChannel( channelIndex );
+	FxChannel *fxChannel = Engine::mixer()->effectChannel( channelIndex );
 
 	// If title allows interpolation, pass channel index and name
 	if ( title.contains( "%2" ) )
@@ -1230,9 +1230,9 @@ QMenu * InstrumentTrackView::createFxMenu(QString title, QString newFxLabel)
 	fxMenu->addAction( newFxLabel, this, SLOT( createFxLine() ) );
 	fxMenu->addSeparator();
 
-	for (int i = 0; i < Engine::fxMixer()->numChannels(); ++i)
+	for (int i = 0; i < Engine::mixer()->numChannels(); ++i)
 	{
-		FxChannel * currentChannel = Engine::fxMixer()->effectChannel( i );
+		FxChannel * currentChannel = Engine::mixer()->effectChannel( i );
 
 		if ( currentChannel != fxChannel )
 		{
@@ -1261,11 +1261,11 @@ class fxLineLcdSpinBox : public LcdSpinBox
 	protected:
 		virtual void mouseDoubleClickEvent ( QMouseEvent * _me )
 		{
-			gui->fxMixerView()->setCurrentFxLine( model()->value() );
+			gui->mixerView()->setCurrentFxLine( model()->value() );
 
-			gui->fxMixerView()->parentWidget()->show();
-			gui->fxMixerView()->show();// show fxMixer window
-			gui->fxMixerView()->setFocus();// set focus to fxMixer window
+			gui->mixerView()->parentWidget()->show();
+			gui->mixerView()->show();// show mixer window
+			gui->mixerView()->setFocus();// set focus to mixer window
 			//engine::getMixerView()->raise();
 		}
 

--- a/tests/emptyproject.mmp
+++ b/tests/emptyproject.mmp
@@ -68,7 +68,7 @@
         <object id="948063" />
       </automationpattern>
     </track>
-    <fxmixer width="865" x="5" y="310" maximized="0" height="278" visible="1" minimized="0" >
+    <mixer width="865" x="5" y="310" maximized="0" height="278" visible="1" minimized="0" >
       <fxchannel num="0" muted="0" volume="1" name="Master" >
         <fxchain numofeffects="0" enabled="0" />
       </fxchannel>
@@ -264,7 +264,7 @@
       <fxchannel num="64" muted="0" volume="1" name="FX 64" >
         <fxchain numofeffects="0" enabled="0" />
       </fxchannel>
-    </fxmixer>
+    </mixer>
     <controllerrackview width="258" x="880" y="310" maximized="0" height="278" visible="1" minimized="0" />
     <pianoroll width="840" x="-11" y="0" maximized="0" height="480" visible="0" minimized="0" />
     <automationeditor width="740" x="0" y="0" maximized="0" height="480" visible="0" minimized="0" />


### PR DESCRIPTION
Closes #3300 (hopefully, if not sorry for wasting your time!).

I currently only renamed String texts imho, but can also rename classes, variable names etc.

Not tested.