### PR TITLE
Fix Blackman-Harris window formula, adjust formatting

### DIFF
--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -47,9 +47,9 @@ EqAnalyser::EqAnalyser() :
 
 	for (int i = 0; i < FFT_BUFFER_SIZE; i++)
 	{
-		m_fftWindow[i] =	(a0 - a1 * cos( 2 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
-								+ a2 * cos( 4 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
-								- a3 * cos( 6 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0)));
+		m_fftWindow[i] = (a0 - a1 * cos(2 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
+								+ a2 * cos(4 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
+								- a3 * cos(6 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0)));
 	}
 	clear();
 }

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -45,11 +45,11 @@ EqAnalyser::EqAnalyser() :
 	const float a2 = 0.14128;
 	const float a3 = 0.01168;
 
-	for(int i = 0; i < FFT_BUFFER_SIZE; i++)
+	for (int i = 0; i < FFT_BUFFER_SIZE; i++)
 	{
-		m_fftWindow[i] = ( a0 - a1 * cosf( 2 * F_PI * i / (float)FFT_BUFFER_SIZE - 1 )
-									  + a2 * cosf( 4 * F_PI * i / (float)FFT_BUFFER_SIZE-1)
-									  - a3 * cos( 6 * F_PI * i / (float)FFT_BUFFER_SIZE - 1.0 ));
+		m_fftWindow[i] =	(a0 - a1 * cos( 2 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
+								+ a2 * cos( 4 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
+								- a3 * cos( 6 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0)));
 	}
 	clear();
 }


### PR DESCRIPTION
This fixes the formula used to generate Blackman-Harris window created in the Eq plugin. Cosf() was replaced by cos() to make all 3 lines consistent; parentheses were added where they should have been.

I also changed the formatting so that subsequent lines align better with the first one (when tab spaces = 4 which seems to be quite common value).
Before change (white noise + 3 sine waves at 100 Hz, 1 kHz and 10 kHz at different amplitudes):
![eq_before](https://user-images.githubusercontent.com/20932751/54359914-ea698000-4663-11e9-9c85-5074d3fd62cf.png)
After change (improvement mainly noticeable for the 100 Hz signal):
![ex_fixed](https://user-images.githubusercontent.com/20932751/54359930-f35a5180-4663-11e9-92aa-d83bf5ecce64.png)

