### PR TITLE
Make instrument window's piano optional

### DIFF
--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -63,6 +63,8 @@ public:
 	// functions that can/should be re-implemented:
 	// --------------------------------------------------------------------
 
+	virtual bool hasNoteInput() const { return true; }
+
 	// if the plugin doesn't play each note, it can create an instrument-
 	// play-handle and re-implement this method, so that it mixes its
 	// output buffer only once per mixer-period

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1650,6 +1650,8 @@ void InstrumentTrackWindow::updateInstrumentView()
 
 		modelChanged(); 		// Get the instrument window to refresh
 		m_track->dataChanged(); // Get the text on the trackButton to change
+
+		m_pianoView->setVisible(m_track->m_instrument->hasNoteInput());
 	}
 }
 
@@ -1704,7 +1706,9 @@ void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 
 void InstrumentTrackWindow::focusInEvent( QFocusEvent* )
 {
-	m_pianoView->setFocus();
+	if(m_pianoView->isVisible()) {
+		m_pianoView->setFocus();
+	}
 }
 
 
@@ -1836,6 +1840,9 @@ void InstrumentTrackWindow::viewInstrumentInDirection(int d)
 
 		// scroll the SongEditor/BB-editor to make sure the new trackview label is visible
 		bringToFront->trackContainerView()->scrollToTrackView(bringToFront);
+
+		// get the instrument window to refresh
+		modelChanged();
 	}
 	bringToFront->getInstrumentTrackWindow()->setFocus();
 }


### PR DESCRIPTION
The piano widget in the instrument window should not be displayed if the instrument has no input for that. That's currently only the case for Lv2 (I guess), but it's a generic feature.