### PR TITLE
Add PluginIssue class

### DIFF
--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -40,8 +40,8 @@ enum PluginIssueType
 	portHasNoDef,
 	portHasNoMin,
 	portHasNoMax,
-	featureNotSupported,
-	badPortType,
+	featureNotSupported, //!< plugin requires functionality LMMS can't offer
+	badPortType, //!< port type not supported
 	noIssue
 };
 

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -1,0 +1,66 @@
+/*
+ * PluginIssue.h - PluginIssue class
+ *
+ * Copyright (c) 2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef PLUGINISSUE_H
+#define PLUGINISSUE_H
+
+#include <QDebug>
+#include <string>
+
+//! Types of issues that can cause LMMS to not load a plugin
+//! LMMS Plugins should use this to indicate errors
+enum PluginIssueType
+{
+	unknownPortFlow,
+	unknownPortType,
+	tooManyInputChannels,
+	tooManyOutputChannels,
+	noOutputChannel,
+	portHasNoDef,
+	portHasNoMin,
+	portHasNoMax,
+	featureNotSupported,
+	badPortType,
+	noIssue
+};
+
+//! Issue type bundled with informational string
+class PluginIssue
+{
+	static const char* msgFor(const PluginIssueType& it);
+
+	PluginIssueType m_issueType;
+	std::string m_info;
+
+public:
+	PluginIssue(PluginIssueType it, std::string msg = std::string())
+		: m_issueType(it), m_info(msg)
+	{
+	}
+	friend QDebug operator<<(QDebug stream, const PluginIssue& iss);
+};
+
+QDebug operator<<(QDebug stream, const PluginIssue& iss);
+
+#endif // PLUGINISSUE_H

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -48,6 +48,7 @@ set(LMMS_SRCS
 	core/Piano.cpp
 	core/PlayHandle.cpp
 	core/Plugin.cpp
+	core/PluginIssue.cpp
 	core/PluginFactory.cpp
 	core/PresetPreviewPlayHandle.cpp
 	core/ProjectJournal.cpp

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -1,0 +1,72 @@
+/*
+ * PluginIssue.h - PluginIssue class
+ *
+ * Copyright (c) 2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <QDebug>
+
+#include "PluginIssue.h"
+
+const char *PluginIssue::msgFor(const PluginIssueType &it)
+{
+	switch (it)
+	{
+		case unknownPortFlow:
+			return "unknown port flow for mandatory port";
+		case unknownPortType:
+			return "unknown port type for mandatory port";
+		case tooManyInputChannels:
+			return "too many audio input channels";
+		case tooManyOutputChannels:
+			return "too many audio output channels";
+		case noOutputChannel:
+			return "no audio output channel";
+		case portHasNoDef:
+			return "port is missing default value";
+		case portHasNoMin:
+			return "port is missing min value";
+		case portHasNoMax:
+			return "port is missing max value";
+		case featureNotSupported:
+			return "required feature not supported";
+		case badPortType:
+			return "unsupported port Type";
+		case noIssue:
+			return nullptr;
+	}
+	return nullptr;
+}
+
+
+
+
+QDebug operator<<(QDebug stream, const PluginIssue &iss)
+{
+	stream << PluginIssue::msgFor(iss.m_issueType);
+	if(iss.m_info.length())
+	{
+		stream.nospace() << ": " << iss.m_info.c_str();
+	}
+	return stream;
+}
+
+

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -49,7 +49,7 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 		case featureNotSupported:
 			return "required feature not supported";
 		case badPortType:
-			return "unsupported port Type";
+			return "unsupported port type";
 		case noIssue:
 			return nullptr;
 	}
@@ -62,7 +62,7 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 QDebug operator<<(QDebug stream, const PluginIssue &iss)
 {
 	stream << PluginIssue::msgFor(iss.m_issueType);
-	if(iss.m_info.length())
+	if (iss.m_info.length())
 	{
 		stream.nospace() << ": " << iss.m_info.c_str();
 	}


### PR DESCRIPTION
This adds a class for error diagnostics when loading any kind of plugin. Currently only used in the Lv2 branch, but it's a generic feature.