### PR TITLE
Make Model class visitable

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -92,18 +92,25 @@ public:
 	virtual void accept(ConstModelVisitor& v) const = 0;
 
 public:
-	//! Return this class casted to Target, or nullptr if impossible
+	/**
+	   @brief Return this class casted to Target
+	   @test AutomatableModelTest.cpp
+	   @param doThrow throw an assertion if the cast fails, instead of
+	     returning a nullptr
+	   @return the casted class if Target is the exact or a base class of
+	     *this, nullptr otherwise
+	*/
 	template<class Target>
-	Target* dcast(bool doThrow = false)
+	Target* dynamicCast(bool doThrow = false)
 	{
 		DCastVisitor<Target> vis; accept(vis);
 		if(doThrow && !vis.result) Q_ASSERT(false);
 		return vis.result;
 	}
 
-	//! Return this class casted to const Target, or nullptr if impossible
+	//! const overload, see overloaded function
 	template<class Target>
-	const Target* dcast(bool doThrow = false) const
+	const Target* dynamicCast(bool doThrow = false) const
 	{
 		ConstDCastVisitor<Target> vis; accept(vis);
 		if(doThrow && !vis.result) Q_ASSERT(false);
@@ -312,6 +319,7 @@ protected:
 
 
 private:
+	// dynamicCast implementation
 	template<class Target>
 	struct DCastVisitor : public ModelVisitor
 	{
@@ -319,6 +327,7 @@ private:
 		void visit(Target& tar) { result = &tar; }
 	};
 
+	// dynamicCast implementation
 	template<class Target>
 	struct ConstDCastVisitor : public ConstModelVisitor
 	{

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -60,6 +60,11 @@
 				modelname.setValue( (float) val );				\
 			}
 
+// use this to make subclasses visitable
+#define MODEL_IS_VISITABLE \
+	void accept(ModelVisitor& v) override { v.visit(*this); } \
+	void accept(ConstModelVisitor& v) const override { v.visit(*this); }
+
 
 
 class ControllerConnection;
@@ -85,10 +90,6 @@ public:
 	// Implement those by using the MODEL_IS_VISITABLE macro
 	virtual void accept(ModelVisitor& v) = 0;
 	virtual void accept(ConstModelVisitor& v) const = 0;
-	// use this to make subclasses visitable
-#define MODEL_IS_VISITABLE \
-	void accept(ModelVisitor& v) override { v.visit(*this); } \
-	void accept(ConstModelVisitor& v) const override { v.visit(*this); }
 
 public:
 	//! Return this class casted to Target, or nullptr if impossible

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -104,7 +104,7 @@ public:
 	Target* dynamicCast(bool doThrow = false)
 	{
 		DCastVisitor<Target> vis; accept(vis);
-		if(doThrow && !vis.result) Q_ASSERT(false);
+		if (doThrow && !vis.result) { Q_ASSERT(false); }
 		return vis.result;
 	}
 
@@ -113,7 +113,7 @@ public:
 	const Target* dynamicCast(bool doThrow = false) const
 	{
 		ConstDCastVisitor<Target> vis; accept(vis);
-		if(doThrow && !vis.result) Q_ASSERT(false);
+		if (doThrow && !vis.result) { Q_ASSERT(false); }
 		return vis.result;
 	}
 

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -36,6 +36,7 @@
 class LMMS_EXPORT ComboBoxModel : public IntModel
 {
 	Q_OBJECT
+	MODEL_IS_VISITABLE
 public:
 	ComboBoxModel( Model* parent = NULL,
 					const QString& displayName = QString(),

--- a/include/ModelVisitor.h
+++ b/include/ModelVisitor.h
@@ -25,6 +25,7 @@
 #ifndef MODELVISITOR_H
 #define MODELVISITOR_H
 
+class AutomatableModel;
 class BoolModel;
 class IntModel;
 class FloatModel;
@@ -32,21 +33,28 @@ class ComboBoxModel;
 
 class ModelVisitor
 {
+	template<class ParentType = AutomatableModel, class ModelType>
+	void up(ModelType& m) { visit(static_cast<ParentType&>(m)); }
 public:
-	virtual void visit(BoolModel& ) {}
-	virtual void visit(IntModel& ) {}
-	virtual void visit(FloatModel& ) {}
-	virtual void visit(ComboBoxModel& ) {}
+	virtual void visit(AutomatableModel& ) {}
+	virtual void visit(BoolModel& m);
+	virtual void visit(IntModel& );
+	virtual void visit(FloatModel& );
+	virtual void visit(ComboBoxModel& );
 	virtual ~ModelVisitor();
 };
 
 class ConstModelVisitor
 {
+	template<class ParentType = AutomatableModel, class ModelType>
+	void up(const ModelType& m) {
+		visit(static_cast<const ParentType&>(m)); }
 public:
-	virtual void visit(const BoolModel& ) {}
-	virtual void visit(const IntModel& ) {}
-	virtual void visit(const FloatModel& ) {}
-	virtual void visit(const ComboBoxModel& ) {}
+	virtual void visit(const AutomatableModel& ) {}
+	virtual void visit(const BoolModel& m);
+	virtual void visit(const IntModel& m);
+	virtual void visit(const FloatModel& m);
+	virtual void visit(const ComboBoxModel& m);
 	virtual ~ConstModelVisitor();
 };
 

--- a/include/ModelVisitor.h
+++ b/include/ModelVisitor.h
@@ -30,6 +30,7 @@ class BoolModel;
 class IntModel;
 class FloatModel;
 class ComboBoxModel;
+class TempoSyncKnobModel;
 
 class ModelVisitor
 {
@@ -38,9 +39,10 @@ class ModelVisitor
 public:
 	virtual void visit(AutomatableModel& ) {}
 	virtual void visit(BoolModel& m);
-	virtual void visit(IntModel& );
-	virtual void visit(FloatModel& );
-	virtual void visit(ComboBoxModel& );
+	virtual void visit(IntModel& m);
+	virtual void visit(FloatModel& m);
+	virtual void visit(ComboBoxModel& m);
+	virtual void visit(TempoSyncKnobModel& m);
 	virtual ~ModelVisitor();
 };
 
@@ -55,6 +57,7 @@ public:
 	virtual void visit(const IntModel& m);
 	virtual void visit(const FloatModel& m);
 	virtual void visit(const ComboBoxModel& m);
+	virtual void visit(const TempoSyncKnobModel& m);
 	virtual ~ConstModelVisitor();
 };
 

--- a/include/ModelVisitor.h
+++ b/include/ModelVisitor.h
@@ -1,0 +1,53 @@
+/*
+ * ModelVisitor.h - visitors for automatable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef MODELVISITOR_H
+#define MODELVISITOR_H
+
+class BoolModel;
+class IntModel;
+class FloatModel;
+class ComboBoxModel;
+
+class ModelVisitor
+{
+public:
+	virtual void visit(BoolModel& ) {}
+	virtual void visit(IntModel& ) {}
+	virtual void visit(FloatModel& ) {}
+	virtual void visit(ComboBoxModel& ) {}
+	virtual ~ModelVisitor();
+};
+
+class ConstModelVisitor
+{
+public:
+	virtual void visit(const BoolModel& ) {}
+	virtual void visit(const IntModel& ) {}
+	virtual void visit(const FloatModel& ) {}
+	virtual void visit(const ComboBoxModel& ) {}
+	virtual ~ConstModelVisitor();
+};
+
+#endif // MODELVISITOR_H

--- a/include/TempoSyncKnobModel.h
+++ b/include/TempoSyncKnobModel.h
@@ -33,6 +33,7 @@ class QAction;
 class LMMS_EXPORT TempoSyncKnobModel : public FloatModel
 {
 	Q_OBJECT
+	MODEL_IS_VISITABLE
 public:
 	enum TempoSyncMode
 	{

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LMMS_SRCS
 	core/MixerWorkerThread.cpp
 	core/MixHelpers.cpp
 	core/Model.cpp
+	core/ModelVisitor.cpp
 	core/Note.cpp
 	core/NotePlayHandle.cpp
 	core/Oscillator.cpp

--- a/src/core/ModelVisitor.cpp
+++ b/src/core/ModelVisitor.cpp
@@ -1,0 +1,28 @@
+/*
+ * ModelVisitor.cpp - visitors for automatable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "ModelVisitor.h"
+
+ModelVisitor::~ModelVisitor() {}
+ConstModelVisitor::~ConstModelVisitor() {}

--- a/src/core/ModelVisitor.cpp
+++ b/src/core/ModelVisitor.cpp
@@ -26,16 +26,19 @@
 
 #include "AutomatableModel.h"
 #include "ComboBoxModel.h"
+#include "TempoSyncKnobModel.h"
 
 void ModelVisitor::visit(BoolModel &m) { up(m); }
 void ModelVisitor::visit(IntModel &m) { up(m); }
 void ModelVisitor::visit(FloatModel &m) { up(m); }
 void ModelVisitor::visit(ComboBoxModel &m) { up<IntModel>(m); }
+void ModelVisitor::visit(TempoSyncKnobModel &m) { up<FloatModel>(m); }
 
 void ConstModelVisitor::visit(const BoolModel &m) { up(m); }
 void ConstModelVisitor::visit(const IntModel &m) { up(m); }
 void ConstModelVisitor::visit(const FloatModel &m) { up(m); }
 void ConstModelVisitor::visit(const ComboBoxModel &m) { up<IntModel>(m); }
+void ConstModelVisitor::visit(const TempoSyncKnobModel &m) { up<FloatModel>(m); }
 
 ModelVisitor::~ModelVisitor() {}
 ConstModelVisitor::~ConstModelVisitor() {}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ ADD_EXECUTABLE(tests
 	QTestSuite
 	$<TARGET_OBJECTS:lmmsobjs>
 
+	src/core/AutomatableModelTest.cpp
 	src/core/ProjectVersionTest.cpp
 	src/core/RelativePathsTest.cpp
 

--- a/tests/src/core/AutomatableModelTest.cpp
+++ b/tests/src/core/AutomatableModelTest.cpp
@@ -32,21 +32,23 @@ class AutomatableModelTest : QTestSuite
 	Q_OBJECT
 
 private slots:
+	//! Test that upcast and exact casts work,
+	//! but no downcast or any other casts
 	void CastTests()
 	{
 		ComboBoxModel comboModel;
 		AutomatableModel* amPtr = &comboModel;
-		QCOMPARE(nullptr, amPtr->dynamicCast<FloatModel>());
-		QVERIFY(nullptr != amPtr->dynamicCast<AutomatableModel>());
-		QVERIFY(nullptr != amPtr->dynamicCast<IntModel>());
-		QVERIFY(nullptr != amPtr->dynamicCast<ComboBoxModel>());
+		QCOMPARE(nullptr, amPtr->dynamicCast<FloatModel>()); // not a parent class
+		QCOMPARE(&comboModel, amPtr->dynamicCast<AutomatableModel>()); // parent class
+		QCOMPARE(&comboModel, amPtr->dynamicCast<IntModel>()); // parent class
+		QCOMPARE(&comboModel, amPtr->dynamicCast<ComboBoxModel>()); // same class
 
 		IntModel intModel;
 		IntModel* imPtr = &intModel;
-		QCOMPARE(nullptr, imPtr->dynamicCast<FloatModel>());
-		QVERIFY(nullptr != imPtr->dynamicCast<AutomatableModel>());
-		QVERIFY(nullptr != imPtr->dynamicCast<IntModel>());
-		QCOMPARE(nullptr, imPtr->dynamicCast<ComboBoxModel>());
+		QCOMPARE(nullptr, imPtr->dynamicCast<FloatModel>()); // not a parent class
+		QCOMPARE(&intModel, imPtr->dynamicCast<AutomatableModel>()); // parent class
+		QCOMPARE(&intModel, imPtr->dynamicCast<IntModel>()); // same class
+		QCOMPARE(nullptr, imPtr->dynamicCast<ComboBoxModel>()); // child class
 	}
 } AutomatableModelTests;
 

--- a/tests/src/core/AutomatableModelTest.cpp
+++ b/tests/src/core/AutomatableModelTest.cpp
@@ -38,17 +38,17 @@ private slots:
 	{
 		ComboBoxModel comboModel;
 		AutomatableModel* amPtr = &comboModel;
-		QCOMPARE(nullptr, amPtr->dynamicCast<FloatModel>()); // not a parent class
+		QVERIFY(nullptr == amPtr->dynamicCast<FloatModel>()); // not a parent class
 		QCOMPARE(&comboModel, amPtr->dynamicCast<AutomatableModel>()); // parent class
 		QCOMPARE(&comboModel, amPtr->dynamicCast<IntModel>()); // parent class
 		QCOMPARE(&comboModel, amPtr->dynamicCast<ComboBoxModel>()); // same class
 
 		IntModel intModel;
 		IntModel* imPtr = &intModel;
-		QCOMPARE(nullptr, imPtr->dynamicCast<FloatModel>()); // not a parent class
+		QVERIFY(nullptr == imPtr->dynamicCast<FloatModel>()); // not a parent class
 		QCOMPARE(&intModel, imPtr->dynamicCast<AutomatableModel>()); // parent class
 		QCOMPARE(&intModel, imPtr->dynamicCast<IntModel>()); // same class
-		QCOMPARE(nullptr, imPtr->dynamicCast<ComboBoxModel>()); // child class
+		QVERIFY(nullptr == imPtr->dynamicCast<ComboBoxModel>()); // child class
 	}
 } AutomatableModelTests;
 

--- a/tests/src/core/AutomatableModelTest.cpp
+++ b/tests/src/core/AutomatableModelTest.cpp
@@ -1,5 +1,5 @@
 /*
- * ModelVisitor.cpp - visitors for automatable models
+ * AutomatableModelTest.cpp
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -22,20 +22,32 @@
  *
  */
 
-#include "ModelVisitor.h"
+#include "QTestSuite.h"
 
 #include "AutomatableModel.h"
 #include "ComboBoxModel.h"
 
-void ModelVisitor::visit(BoolModel &m) { up(m); }
-void ModelVisitor::visit(IntModel &m) { up(m); }
-void ModelVisitor::visit(FloatModel &m) { up(m); }
-void ModelVisitor::visit(ComboBoxModel &m) { up<IntModel>(m); }
+class AutomatableModelTest : QTestSuite
+{
+	Q_OBJECT
 
-void ConstModelVisitor::visit(const BoolModel &m) { up(m); }
-void ConstModelVisitor::visit(const IntModel &m) { up(m); }
-void ConstModelVisitor::visit(const FloatModel &m) { up(m); }
-void ConstModelVisitor::visit(const ComboBoxModel &m) { up<IntModel>(m); }
+private slots:
+	void CastTests()
+	{
+		ComboBoxModel comboModel;
+		AutomatableModel* amPtr = &comboModel;
+		QCOMPARE(nullptr, amPtr->dynamicCast<FloatModel>());
+		QVERIFY(nullptr != amPtr->dynamicCast<AutomatableModel>());
+		QVERIFY(nullptr != amPtr->dynamicCast<IntModel>());
+		QVERIFY(nullptr != amPtr->dynamicCast<ComboBoxModel>());
 
-ModelVisitor::~ModelVisitor() {}
-ConstModelVisitor::~ConstModelVisitor() {}
+		IntModel intModel;
+		IntModel* imPtr = &intModel;
+		QCOMPARE(nullptr, imPtr->dynamicCast<FloatModel>());
+		QVERIFY(nullptr != imPtr->dynamicCast<AutomatableModel>());
+		QVERIFY(nullptr != imPtr->dynamicCast<IntModel>());
+		QCOMPARE(nullptr, imPtr->dynamicCast<ComboBoxModel>());
+	}
+} AutomatableModelTests;
+
+#include "AutomatableModelTest.moc"


### PR DESCRIPTION
This makes the different `AutomatableModel`s [visitable](https://en.wikipedia.org/wiki/Visitor_pattern) and adds a visitor based cast function for cleaner code and more type safety. Currently only used in the Lv2 branch, but it's a generic feature.