### PR TITLE
Allow new Zyn bank creation on Linux

### DIFF
--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
@@ -260,7 +260,7 @@ int Bank::newbank(string newbankdirname)
     normalizedirsuffix(bankdir);
 
 // FIXME: Zyn should automatically handle creation of parent directory
-#ifdef LMMS_BUILD_WIN32
+#ifdef WIN32
 	if(mkdir(bankdir.c_str()) < 0)) return -1;
 #else
 	if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
@@ -261,9 +261,9 @@ int Bank::newbank(string newbankdirname)
 
 // FIXME: Zyn should automatically handle creation of parent directory
 #ifdef WIN32
-	if(mkdir(bankdir.c_str()) < 0) return -1;
+    if(mkdir(bankdir.c_str()) < 0) return -1;
 #else
-	if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;
+    if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;
 #endif
 
     bankdir += newbankdirname;

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
@@ -188,6 +188,7 @@ void Bank::loadfromslot(unsigned int ninstrument, Part *part)
  */
 int Bank::loadbank(string bankdirname)
 {
+    normalizedirsuffix(bankdirname);
     DIR *dir = opendir(bankdirname.c_str());
     clearbank();
 
@@ -255,9 +256,15 @@ int Bank::newbank(string newbankdirname)
     string bankdir;
     bankdir = config.cfg.bankRootDirList[0];
 
-    if(((bankdir[bankdir.size() - 1]) != '/')
-       && ((bankdir[bankdir.size() - 1]) != '\\'))
-        bankdir += "/";
+    expanddirname(bankdir);
+    normalizedirsuffix(bankdir);
+
+// FIXME: Zyn should automatically handle creation of parent directory
+#ifdef LMMS_BUILD_WIN32
+	if(mkdir(bankdir.c_str()) < 0)) return -1;
+#else
+	if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;
+#endif
 
     bankdir += newbankdirname;
 #ifdef WIN32
@@ -355,6 +362,8 @@ void Bank::rescanforbanks()
 
 void Bank::scanrootdir(string rootdir)
 {
+    expanddirname(rootdir);
+
     DIR *dir = opendir(rootdir.c_str());
     if(dir == NULL)
         return;
@@ -471,4 +480,24 @@ Bank::ins_t::ins_t()
     :used(false), name(""), filename("")
 {
     info.PADsynth_used = false;
+}
+
+void Bank::expanddirname(std::string &dirname) {
+    if (dirname.empty())
+        return;
+
+    // if the directory name starts with a ~ and the $HOME variable is
+    // defined in the environment, replace ~ by the content of $HOME
+    if (dirname.at(0) == '~') {
+        char *home_dirname = getenv("HOME");
+        if (home_dirname != NULL) {
+            dirname = std::string(home_dirname) + dirname.substr(1);
+        }
+    }
+}
+
+void Bank::normalizedirsuffix(string &dirname) const {
+    if(((dirname[dirname.size() - 1]) != '/')
+       && ((dirname[dirname.size() - 1]) != '\\'))
+        dirname += "/";
 }

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.cpp
@@ -261,7 +261,7 @@ int Bank::newbank(string newbankdirname)
 
 // FIXME: Zyn should automatically handle creation of parent directory
 #ifdef WIN32
-	if(mkdir(bankdir.c_str()) < 0)) return -1;
+	if(mkdir(bankdir.c_str()) < 0) return -1;
 #else
 	if(mkdir(bankdir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH)) return -1;
 #endif

--- a/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.h
+++ b/plugins/zynaddsubfx/zynaddsubfx/src/Misc/Bank.h
@@ -99,6 +99,13 @@ class Bank
         std::string dirname;
 
         void scanrootdir(std::string rootdir); //scans a root dir for banks
+
+        /** Expends ~ prefix in dirname, if any */
+        void expanddirname(std::string &dirname);
+
+        /** Ensure that the directory name is suffixed by a
+         * directory separator */
+        void normalizedirsuffix(std::string &dirname) const;
 };
 
 #endif


### PR DESCRIPTION
This PR cherry-picks upstream patch https://github.com/zynaddsubfx/zynaddsubfx/commit/ca9ec78952fc51616a684203fc4cff2fe101b11f, but per https://github.com/LMMS/lmms/issues/4642#issuecomment-473668507, there appears to be a bug with the upstream implementation and it still won't work without an additional call to `mkdir(...)`.

Closes #4642