### PR TITLE
Fix notes getting stuck under high CPU conditions

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -302,6 +302,7 @@ private:
 	NotePlayHandleList m_subNotes;			// used for chords and arpeggios
 	volatile bool m_released;				// indicates whether note is released
 	bool m_releaseStarted;
+	bool m_hasMidiNote;
 	bool m_hasParent;						// indicates whether note has parent
 	NotePlayHandle * m_parent;			// parent note
 	bool m_hadChildren;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -199,7 +199,7 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 
 	lock();
 
-	if( m_totalFramesPlayed == 0
+	if( m_totalFramesPlayed == 0 && !m_hasMidiNote
 		&& ( hasParent() || ! m_instrumentTrack->isArpeggioEnabled() ) )
 	{
 		m_hasMidiNote = true;


### PR DESCRIPTION
Fixes #4826. Also happens to fix a bug where notes get stuck for MIDI-based instruments if the arpeggiator is turned on while the note is playing.

This PR changes `NotePlayHandle`s so they send a note-on message when they are first played, rather than when they are constructed. This means that `NotePlayHandle`s that are immediately discarded due to high CPU usage no longer send note-on messages to their plugins.