### PR TITLE
ControllerConnection: Don't connect controllers that do not exist.

### DIFF
--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -211,10 +211,12 @@ void ControllerConnection::loadSettings( const QDomElement & _this )
 			m_controllerId = -1;
 		}
 
-		if (!Engine::getSong()->isLoadingProject() && m_controllerId != -1)
+		if (!Engine::getSong()->isLoadingProject()
+			&& m_controllerId != -1
+			&& m_controllerId < Engine::getSong()->controllers().size())
 		{
 			setController( Engine::getSong()->
-					controllers().at( m_controllerId ) );
+				controllers().at( m_controllerId ) );
 		}
 		else
 		{
@@ -224,11 +226,9 @@ void ControllerConnection::loadSettings( const QDomElement & _this )
 }
 
 
+
+
 void ControllerConnection::deleteConnection()
 {
 	delete this;
 }
-
-
-
-


### PR DESCRIPTION
This fixes a crash when attempting to load a preset that was saved with controller connections into a project with no controllers (or fewer controllers than the preset's `m_controllerId`)

See issue #4927 for more info.