### PR TITLE
Make more connections direct for automation

### DIFF
--- a/plugins/LadspaEffect/LadspaControls.cpp
+++ b/plugins/LadspaEffect/LadspaControls.cpp
@@ -36,7 +36,8 @@ LadspaControls::LadspaControls( LadspaEffect * _eff ) :
 {
 
 	connect( &m_stereoLinkModel, SIGNAL( dataChanged() ),
-				this, SLOT( updateLinkStatesFromGlobal() ) );
+				this, SLOT( updateLinkStatesFromGlobal() ),
+				Qt::DirectConnection );
 
 	multi_proc_t controls = m_effect->getPortControls();
 	m_controlCount = controls.count();
@@ -59,7 +60,8 @@ LadspaControls::LadspaControls( LadspaEffect * _eff ) :
 				if( linked_control )
 				{
 					connect( (*it)->control, SIGNAL( linkChanged( int, bool ) ),
-								this, SLOT( linkPort( int, bool ) ) );
+								this, SLOT( linkPort( int, bool ) ),
+								Qt::DirectConnection );
 				}
 			}
 		}

--- a/plugins/VstEffect/VstEffect.cpp
+++ b/plugins/VstEffect/VstEffect.cpp
@@ -145,9 +145,6 @@ void VstEffect::openPlugin( const QString & _plugin )
 		return;
 	}
 
-	VstPlugin::connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ), m_plugin.data(), SLOT( setTempo( bpm_t ) ) );
-	m_plugin->setTempo( Engine::getSong()->getTempo() );
-
 	delete tf;
 
 	m_key.attributes["file"] = _plugin;

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1953,7 +1953,8 @@ DWORD WINAPI RemoteVstPlugin::processingThread( LPVOID _param )
         {
 		if( m.id == IdStartProcessing
 			|| m.id == IdMidiEvent
-			|| m.id == IdVstSetParameter )
+			|| m.id == IdVstSetParameter
+			|| m.id == IdVstSetTempo )
 		{
 			_this->processMessage( m );
 		}

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -92,7 +92,7 @@ VstPlugin::VstPlugin( const QString & _plugin ) :
 	setTempo( Engine::getSong()->getTempo() );
 
 	connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ),
-			this, SLOT( setTempo( bpm_t ) ) );
+			this, SLOT( setTempo( bpm_t ) ), Qt::DirectConnection );
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ),
 				this, SLOT( updateSampleRate() ) );
 

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -129,32 +129,32 @@ EnvelopeAndLfoParameters::EnvelopeAndLfoParameters(
 	instances()->add( this );
 
 	connect( &m_predelayModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_attackModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_holdModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_decayModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_sustainModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_releaseModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_amountModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 
 	connect( &m_lfoPredelayModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_lfoAttackModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_lfoSpeedModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_lfoAmountModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_lfoWaveModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 	connect( &m_x100Model, SIGNAL( dataChanged() ),
-				this, SLOT( updateSampleVars() ) );
+			this, SLOT( updateSampleVars() ), Qt::DirectConnection );
 
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ),
 				this, SLOT( updateSampleVars() ) );

--- a/src/core/LadspaControl.cpp
+++ b/src/core/LadspaControl.cpp
@@ -42,7 +42,8 @@ LadspaControl::LadspaControl( Model * _parent, port_desc_t * _port,
 	if( m_link )
 	{
 		connect( &m_linkEnabledModel, SIGNAL( dataChanged() ),
-					 this, SLOT( linkStateChanged() ) );
+					 this, SLOT( linkStateChanged() ),
+					 Qt::DirectConnection );
 	}
 
 	switch( m_port->data_type )

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -49,12 +49,12 @@ LfoController::LfoController( Model * _parent ) :
 {
 	setSampleExact( true );
 	connect( &m_waveModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateSampleFunction() ) );
+			this, SLOT( updateSampleFunction() ), Qt::DirectConnection );
 
 	connect( &m_speedModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateDuration() ) );
+			this, SLOT( updateDuration() ), Qt::DirectConnection );
 	connect( &m_multiplierModel, SIGNAL( dataChanged() ),
-			this, SLOT( updateDuration() ) );
+			this, SLOT( updateDuration() ), Qt::DirectConnection );
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ),
 			this, SLOT( updateDuration() ) );
 

--- a/src/core/MeterModel.cpp
+++ b/src/core/MeterModel.cpp
@@ -33,9 +33,9 @@ MeterModel::MeterModel( ::Model * _parent ) :
 	m_denominatorModel( 4, 1, 32, this, tr( "Denominator" ) )
 {
 	connect( &m_numeratorModel, SIGNAL( dataChanged() ), 
-				this, SIGNAL( dataChanged() ) );
+			this, SIGNAL( dataChanged() ), Qt::DirectConnection );
 	connect( &m_denominatorModel, SIGNAL( dataChanged() ), 
-				this, SIGNAL( dataChanged() ) );
+			this, SIGNAL( dataChanged() ), Qt::DirectConnection );
 }
 
 

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -53,8 +53,10 @@ PeakController::PeakController( Model * _parent,
 			this, SLOT( handleDestroyedEffect( ) ) );
 	}
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( updateCoeffs() ) );
-	connect( m_peakEffect->attackModel(), SIGNAL( dataChanged() ), this, SLOT( updateCoeffs() ) );
-	connect( m_peakEffect->decayModel(), SIGNAL( dataChanged() ), this, SLOT( updateCoeffs() ) );
+	connect( m_peakEffect->attackModel(), SIGNAL( dataChanged() ),
+			this, SLOT( updateCoeffs() ), Qt::DirectConnection );
+	connect( m_peakEffect->decayModel(), SIGNAL( dataChanged() ),
+			this, SLOT( updateCoeffs() ), Qt::DirectConnection );
 	m_coeffNeedsUpdate = true;
 }
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -96,18 +96,18 @@ Song::Song() :
 	m_elapsedTacts( 0 )
 {
 	connect( &m_tempoModel, SIGNAL( dataChanged() ),
-						this, SLOT( setTempo() ) );
+			this, SLOT( setTempo() ), Qt::DirectConnection );
 	connect( &m_tempoModel, SIGNAL( dataUnchanged() ),
-						this, SLOT( setTempo() ) );
+			this, SLOT( setTempo() ), Qt::DirectConnection );
 	connect( &m_timeSigModel, SIGNAL( dataChanged() ),
-					this, SLOT( setTimeSignature() ) );
+			this, SLOT( setTimeSignature() ), Qt::DirectConnection );
 
 
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this,
 						SLOT( updateFramesPerTick() ) );
 
 	connect( &m_masterVolumeModel, SIGNAL( dataChanged() ),
-			this, SLOT( masterVolumeChanged() ) );
+			this, SLOT( masterVolumeChanged() ), Qt::DirectConnection );
 /*	connect( &m_masterPitchModel, SIGNAL( dataChanged() ),
 			this, SLOT( masterPitchChanged() ) );*/
 

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -42,7 +42,8 @@ TempoSyncKnobModel::TempoSyncKnobModel( const float _val, const float _min,
 	m_custom( _parent )
 {
 	connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ),
-			this, SLOT( calculateTempoSyncTime( bpm_t ) ) );
+			this, SLOT( calculateTempoSyncTime( bpm_t ) ),
+			Qt::DirectConnection );
 }
 
 
@@ -154,7 +155,8 @@ void TempoSyncKnobModel::setSyncMode( TempoSyncMode _new_mode )
 		if( _new_mode == SyncCustom )
 		{
 			connect( &m_custom, SIGNAL( dataChanged() ),
-					this, SLOT( updateCustom() ) );
+					this, SLOT( updateCustom() ),
+					Qt::DirectConnection );
 		}
 	}
 	calculateTempoSyncTime( Engine::getSong()->getTempo() );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2560,7 +2560,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 			&m_trackContentWidget, SLOT( update() ) );
 
 	connect( &m_track->m_soloModel, SIGNAL( dataChanged() ),
-			m_track, SLOT( toggleSolo() ) );
+			m_track, SLOT( toggleSolo() ), Qt::DirectConnection );
 	// create views for already existing TCOs
 	for( Track::tcoVector::iterator it =
 					m_track->m_trackContentObjects.begin();

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -100,7 +100,7 @@ MidiAlsaSeq::MidiAlsaSeq() :
 	snd_seq_start_queue( m_seqHandle, m_queueID, NULL );
 	changeQueueTempo( Engine::getSong()->getTempo() );
 	connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ),
-			this, SLOT( changeQueueTempo( bpm_t ) ) );
+			this, SLOT( changeQueueTempo( bpm_t ) ), Qt::DirectConnection );
 
 	// initial list-update
 	updatePortList();

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -63,9 +63,12 @@ MidiPort::MidiPort( const QString& name,
 	m_readableModel.setValue( m_mode == Input || m_mode == Duplex );
 	m_writableModel.setValue( m_mode == Output || m_mode == Duplex );
 
-	connect( &m_readableModel, SIGNAL( dataChanged() ), this, SLOT( updateMidiPortMode() ) );
-	connect( &m_writableModel, SIGNAL( dataChanged() ), this, SLOT( updateMidiPortMode() ) );
-	connect( &m_outputProgramModel, SIGNAL( dataChanged() ), this, SLOT( updateOutputProgram() ) );
+	connect( &m_readableModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateMidiPortMode() ), Qt::DirectConnection );
+	connect( &m_writableModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateMidiPortMode() ), Qt::DirectConnection );
+	connect( &m_outputProgramModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateOutputProgram() ), Qt::DirectConnection );
 
 
 	// when using with non-raw-clients we can provide buttons showing

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -306,7 +306,7 @@ FxMixerView::FxChannelView::FxChannelView(QWidget * _parent, FxMixerView * _mv,
 	m_soloBtn->setCheckable( true );
 	m_soloBtn->move( 9,  m_fader->y()-21);
 	connect(&fxChannel->m_soloModel, SIGNAL( dataChanged() ),
-			_mv, SLOT ( toggledSolo() ) );
+			_mv, SLOT ( toggledSolo() ), Qt::DirectConnection );
 	ToolTip::add( m_soloBtn, tr( "Solo FX channel" ) );
 
 	// Create EffectRack for the channel

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -61,7 +61,7 @@ SampleTCO::SampleTCO( Track * _track ) :
 	// we need to receive bpm-change-events, because then we have to
 	// change length of this TCO
 	connect( Engine::getSong(), SIGNAL( tempoChanged( bpm_t ) ),
-					this, SLOT( updateLength() ) );
+					this, SLOT( updateLength() ), Qt::DirectConnection );
 	connect( Engine::getSong(), SIGNAL( timeSignatureChanged( int,int ) ),
 					this, SLOT( updateLength() ) );
 


### PR DESCRIPTION
Follows on from #4692. This converts all the remaining connections involved in automating core controls to direct connections, so the changes take effect immediately, rather than when the main thread is next scheduled. Controls for instrument and effect plugins have mostly been left alone, since there are a lot of changes required there to properly update the connections.

Automatable controls affected here:
* LADSPA global and parameter-specific channel links
* All envelope and LFO controls
* LFO controller wave, speed and amount
* Peak controller attack and decay
* Tempo
* Time signature
* Master volume
* Tempo-sync knob custom time signature
* Track solo
* FX channel solo
* MIDI input enabled, output enabled and output channel

Other changes in this pull request:
* The tempo-change connection in the `VstEffect` plugin has been removed rather than made direct, since it duplicates the connection already made in `vst_base`.
* RemoteVstPlugin now processes tempo changes immediately on the processing thread, rather than handing them to the main UI thread.

Using direct connections for tempo changes fixes #4546 and fixes #4928.