### PR TITLE
Linked model groups

### DIFF
--- a/include/ControlLayout.h
+++ b/include/ControlLayout.h
@@ -1,5 +1,5 @@
 /*
- * LinkedModelGroupLayout.h - layout for LinkedModelGroup class
+ * ControlLayout.h - layout for controls
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -70,8 +70,8 @@
 **
 ****************************************************************************/
 
-#ifndef LINKEDMODELGROUPLAYOUT_H
-#define LINKEDMODELGROUPLAYOUT_H
+#ifndef CONTROLLAYOUT_H
+#define CONTROLLAYOUT_H
 
 #include <QLayout>
 #include <QMultiMap>
@@ -81,19 +81,21 @@ class QRect;
 class QString;
 
 /**
-	Layout for models
+	Layout for controls (models)
+
+	Originally token from Qt's FlowLayout example. Modified.
 
 	Features a search bar, as well as looking up widgets with string keys
 	Keys have to be provided in the widgets' objectNames
 */
-class LinkedModelGroupLayout : public QLayout
+class ControlLayout : public QLayout
 {
 	Q_OBJECT
 
 public:
-	explicit LinkedModelGroupLayout(QWidget *parent,
+	explicit ControlLayout(QWidget *parent,
 		int margin = -1, int hSpacing = -1, int vSpacing = -1);
-	~LinkedModelGroupLayout() override;
+	~ControlLayout() override;
 
 	void addItem(QLayoutItem *item) override;
 	int horizontalSpacing() const;
@@ -126,4 +128,4 @@ private:
 	class QLineEdit* m_searchBar;
 };
 
-#endif // LINKEDMODELGROUPLAYOUT_H
+#endif // CONTROLLAYOUT_H

--- a/include/ControlLayout.h
+++ b/include/ControlLayout.h
@@ -126,6 +126,8 @@ private:
 	// 400 looks good and is ~4 knobs in a row
 	constexpr const static int m_minWidth = 400;
 	class QLineEdit* m_searchBar;
+	//! name of search bar, must be ASCII sorted before any alpha numerics
+	static constexpr const char* s_searchBarName = "!!searchBar!!";
 };
 
 #endif // CONTROLLAYOUT_H

--- a/include/Controls.h
+++ b/include/Controls.h
@@ -45,7 +45,7 @@ class AutomatableModel;
 		(justification: setting the wrong typed model to a widget will cause
 		hard-to-find runtime errors)
 */
-class ControlBase
+class Control
 {
 public:
 	virtual QWidget* topWidget() = 0;
@@ -54,11 +54,11 @@ public:
 	virtual void setModel(AutomatableModel* model) = 0;
 	virtual AutomatableModel* model() = 0;
 
-	virtual ~ControlBase();
+	virtual ~Control();
 };
 
 
-class KnobControl : public ControlBase
+class KnobControl : public Control
 {
 	class Knob* m_knob;
 
@@ -74,7 +74,7 @@ public:
 };
 
 
-class ComboControl : public ControlBase
+class ComboControl : public Control
 {
 	QWidget* m_widget;
 	class ComboBox* m_combo;
@@ -92,7 +92,7 @@ public:
 };
 
 
-class LcdControl : public ControlBase
+class LcdControl : public Control
 {
 	class LcdSpinBox* m_lcd;
 
@@ -108,7 +108,7 @@ public:
 };
 
 
-class CheckControl : public ControlBase
+class CheckControl : public Control
 {
 	QWidget* m_widget;
 	class LedCheckBox* m_checkBox;

--- a/include/Controls.h
+++ b/include/Controls.h
@@ -1,0 +1,129 @@
+/*
+ * Controls.h - labeled control widgets
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef CONTROLS_H
+#define CONTROLS_H
+
+
+#include "Model.h"
+
+// headers only required for covariance
+#include "AutomatableModel.h"
+#include "ComboBoxModel.h"
+
+
+class QString;
+class QWidget;
+class AutomatableModel;
+
+
+/**
+	These classes provide
+	- a control with a text label
+	- a type safe way to set a model
+		(justification: setting the wrong typed model to a widget will cause
+		hard-to-find runtime errors)
+*/
+class ControlBase
+{
+public:
+	virtual QWidget* topWidget() = 0;
+	virtual void setText(const QString& text) = 0;
+
+	virtual void setModel(AutomatableModel* model) = 0;
+	virtual AutomatableModel* model() = 0;
+
+	virtual ~ControlBase();
+};
+
+
+class KnobControl : public ControlBase
+{
+	class Knob* m_knob;
+
+public:
+	void setText(const QString& text) override;
+	QWidget* topWidget() override;
+
+	void setModel(AutomatableModel* model) override;
+	FloatModel* model() override;
+
+	KnobControl(QWidget* parent = nullptr);
+	~KnobControl() override;
+};
+
+
+class ComboControl : public ControlBase
+{
+	QWidget* m_widget;
+	class ComboBox* m_combo;
+	class QLabel* m_label;
+
+public:
+	void setText(const QString& text) override;
+	QWidget* topWidget() override { return m_widget; }
+
+	void setModel(AutomatableModel* model) override;
+	ComboBoxModel* model() override;
+
+	ComboControl(QWidget* parent = nullptr);
+	~ComboControl() override;
+};
+
+
+class LcdControl : public ControlBase
+{
+	class LcdSpinBox* m_lcd;
+
+public:
+	void setText(const QString& text) override;
+	QWidget* topWidget() override;
+
+	void setModel(AutomatableModel* model) override;
+	IntModel* model() override;
+
+	LcdControl(int numDigits, QWidget* parent = nullptr);
+	~LcdControl() override;
+};
+
+
+class CheckControl : public ControlBase
+{
+	QWidget* m_widget;
+	class LedCheckBox* m_checkBox;
+	QLabel* m_label;
+
+public:
+	void setText(const QString& text) override;
+	QWidget* topWidget() override;
+
+	void setModel(AutomatableModel* model) override;
+	BoolModel *model() override;
+
+	CheckControl(QWidget* parent = nullptr);
+	~CheckControl() override;
+};
+
+
+#endif // CONTROLS_H

--- a/include/Controls.h
+++ b/include/Controls.h
@@ -53,6 +53,7 @@ public:
 
 	virtual void setModel(AutomatableModel* model) = 0;
 	virtual AutomatableModel* model() = 0;
+	virtual class AutomatableModelView* modelView() = 0;
 
 	virtual ~Control();
 };
@@ -68,6 +69,7 @@ public:
 
 	void setModel(AutomatableModel* model) override;
 	FloatModel* model() override;
+	class AutomatableModelView* modelView() override;
 
 	KnobControl(QWidget* parent = nullptr);
 	~KnobControl() override;
@@ -86,6 +88,7 @@ public:
 
 	void setModel(AutomatableModel* model) override;
 	ComboBoxModel* model() override;
+	class AutomatableModelView* modelView() override;
 
 	ComboControl(QWidget* parent = nullptr);
 	~ComboControl() override;
@@ -102,6 +105,7 @@ public:
 
 	void setModel(AutomatableModel* model) override;
 	IntModel* model() override;
+	class AutomatableModelView* modelView() override;
 
 	LcdControl(int numDigits, QWidget* parent = nullptr);
 	~LcdControl() override;
@@ -120,6 +124,7 @@ public:
 
 	void setModel(AutomatableModel* model) override;
 	BoolModel *model() override;
+	class AutomatableModelView* modelView() override;
 
 	CheckControl(QWidget* parent = nullptr);
 	~CheckControl() override;

--- a/include/LinkedModelGroupLayout.h
+++ b/include/LinkedModelGroupLayout.h
@@ -1,0 +1,129 @@
+/*
+ * LinkedModelGroupLayout.h - layout for LinkedModelGroup class
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+#ifndef LINKEDMODELGROUPLAYOUT_H
+#define LINKEDMODELGROUPLAYOUT_H
+
+#include <QLayout>
+#include <QMultiMap>
+#include <QStyle>
+class QLayoutItem;
+class QRect;
+class QString;
+
+/**
+	Layout for models
+
+	Features a search bar, as well as looking up widgets with string keys
+	Keys have to be provided in the widgets' objectNames
+*/
+class LinkedModelGroupLayout : public QLayout
+{
+	Q_OBJECT
+
+public:
+	explicit LinkedModelGroupLayout(QWidget *parent,
+		int margin = -1, int hSpacing = -1, int vSpacing = -1);
+	~LinkedModelGroupLayout() override;
+
+	void addItem(QLayoutItem *item) override;
+	int horizontalSpacing() const;
+	int verticalSpacing() const;
+	Qt::Orientations expandingDirections() const override;
+	bool hasHeightForWidth() const override;
+	int heightForWidth(int) const override;
+	int count() const override;
+	QLayoutItem *itemAt(int index) const override;
+	QLayoutItem *itemByString(const QString& key) const;
+	QSize minimumSize() const override;
+	void setGeometry(const QRect &rect) override;
+	QSize sizeHint() const override;
+	QLayoutItem *takeAt(int index) override;
+
+private slots:
+	void onTextChanged(const QString&);
+
+private:
+	int doLayout(const QRect &rect, bool testOnly) const;
+	int smartSpacing(QStyle::PixelMetric pm) const;
+	QMap<QString, QLayoutItem *>::const_iterator pairAt(int index) const;
+
+	QMultiMap<QString, QLayoutItem *> m_itemMap;
+	int m_hSpace;
+	int m_vSpace;
+	// relevant dimension is width, as later, heightForWidth() will be called
+	// 400 looks good and is ~4 knobs in a row
+	constexpr const static int m_minWidth = 400;
+	class QLineEdit* m_searchBar;
+};
+
+#endif // LINKEDMODELGROUPLAYOUT_H

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -85,7 +85,8 @@ protected:
 	LedCheckBox* globalLinkLed() { return m_multiChannelLink.get(); }
 
 private:
-	//! The base class must return the adressed group view
+	//! The base class must return the adressed group view, or nullptr if index
+	//! is out of range
 	virtual LinkedModelGroupViewBase* getGroupView(std::size_t idx) = 0;
 
 	// Implement deletion in the CPP file:

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -1,0 +1,90 @@
+/*
+ * LinkedModelGroupViews.h - views for groups of linkable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LINKEDMODELGROUPVIEWS_H
+#define LINKEDMODELGROUPVIEWS_H
+
+
+#include <QGroupBox>
+
+
+/**
+	@file LinkedModelGroupViews.h
+	See Lv2ViewBase.h for example usage
+*/
+
+
+//! View for one processor, LinkedModelGroupsViewBase contains 2
+//! of those for mono plugins
+class LinkedModelGroupViewBase : public QGroupBox
+{
+public:
+	//! @param colNum numbers of columns for the controls
+	//!   (link LEDs not counted)
+	LinkedModelGroupViewBase(QWidget *parent, bool isLinking,
+		int colNum, int curProc, int nProc, const QString &name = QString());
+	~LinkedModelGroupViewBase();
+
+	//! Reconnect models if model changed
+	void modelChanged(class LinkedModelGroup *linkedModelGroup);
+
+protected:
+	//! Add a control to this widget
+	void addControl(class ControlBase *ctrl);
+
+private:
+	void makeAllGridCellsEqualSized();
+
+	int m_colNum; //!< column number in surrounding grid in Lv2ViewBase
+	bool m_isLinking;
+	class QGridLayout* m_grid;
+	QVector<class ControlBase*> m_controls;
+	QVector<class LedCheckBox*> m_leds;
+};
+
+
+//! Base class for view for one plugin with linkable models.
+//! Provides a global channel link LED.
+class LinkedModelGroupsViewBase
+{
+protected:
+	//! @param pluginWidget A child class which inherits QWidget
+	LinkedModelGroupsViewBase(class LinkedModelGroups *ctrlBase);
+	~LinkedModelGroupsViewBase();
+
+	//! Reconnect models if model changed; to be called by child virtuals
+	void modelChanged(class LinkedModelGroups* ctrlBase);
+
+	//! Access to the global multi channel link LED
+	LedCheckBox* globalLinkLed() { return m_multiChannelLink; }
+
+private:
+	//! The base class must return the adressed group view
+	virtual LinkedModelGroupViewBase* getGroupView(std::size_t idx) = 0;
+
+	class LedCheckBox *m_multiChannelLink = nullptr;
+};
+
+
+#endif // LINKEDMODELGROUPVIEWS_H

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -42,10 +42,14 @@
 class LinkedModelGroupViewBase : public QGroupBox
 {
 public:
-	//! @param colNum numbers of columns for the controls
-	//!   (link LEDs not counted)
-	LinkedModelGroupViewBase(QWidget *parent, bool isLinking,
-		int colNum, int curProc, int nProc, const QString &name = QString());
+	/**
+		@param colNum numbers of columns for the controls
+			(link LEDs not counted)
+		@param name Name for the group, like "Left" or "Group 1",
+			automatically set if not given
+	*/
+	LinkedModelGroupViewBase(QWidget *parent, class LinkedModelGroup* model,
+		int colNum, const QString &name = QString());
 	~LinkedModelGroupViewBase();
 
 	//! Reconnect models if model changed
@@ -71,7 +75,6 @@ private:
 class LinkedModelGroupsViewBase
 {
 protected:
-	//! @param pluginWidget A child class which inherits QWidget
 	LinkedModelGroupsViewBase(class LinkedModelGroups *ctrlBase);
 	~LinkedModelGroupsViewBase() = default;
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -72,7 +72,7 @@ private:
 
 	//! column number in surrounding grid in LinkedModelGroupsView
 	std::size_t m_colNum;
-	class LinkedModelGroupLayout* m_layout;
+	class ControlLayout* m_layout;
 	std::map<std::string, std::unique_ptr<class Control>> m_widgets;
 };
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -77,12 +77,10 @@ private:
 
 	//! column number in surrounding grid in LinkedModelGroupsView
 	std::size_t m_colNum;
-	bool m_isLinking;
 	class LinkedModelGroupLayout* m_layout;
 	struct WidgetsPerModel
 	{
 		std::unique_ptr<class Control> m_ctrl;
-		class LedCheckBox* m_led = nullptr;
 	};
 
 	std::map<std::string, WidgetsPerModel> m_widgets;
@@ -104,18 +102,10 @@ protected:
 	//! Reconnect models if model changed; to be called by child virtuals
 	void modelChanged(class LinkedModelGroups* ctrlBase);
 
-	//! Access to the global multi channel link LED
-	LedCheckBox* globalLinkLed() { return m_multiChannelLink.get(); }
-
 private:
 	//! The base class must return the adressed group view, or nullptr if index
 	//! is out of range
 	virtual LinkedModelGroupView* getGroupView(std::size_t idx) = 0;
-
-	// Implement deletion in the CPP file:
-	struct MultiChannelLinkDeleter { void operator()(LedCheckBox* l); };
-	std::unique_ptr<class LedCheckBox, MultiChannelLinkDeleter>
-		m_multiChannelLink = nullptr;
 };
 
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -1,5 +1,5 @@
 /*
- * LinkedModelGroupViews.h - views for groups of linkable models
+ * LinkedModelGroupViews.h - view for groups of linkable models
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -39,8 +39,7 @@
 
 
 /**
-	View for one processor, LinkedModelGroupsViewBase contains 2
-	of those for mono plugins.
+	View for a representative processor
 
 	@note Neither this class, nor any inheriting classes, shall inherit
 		ModelView. The "view" in the name is just for consistency
@@ -52,8 +51,6 @@ public:
 	/**
 		@param colNum numbers of columns for the controls
 			(link LEDs not counted)
-		@param name Name for the group, like "Left" or "Group 1",
-			automatically set if not given
 	*/
 	LinkedModelGroupView(QWidget *parent, class LinkedModelGroup* model,
 		std::size_t colNum);
@@ -78,18 +75,12 @@ private:
 	//! column number in surrounding grid in LinkedModelGroupsView
 	std::size_t m_colNum;
 	class LinkedModelGroupLayout* m_layout;
-	struct WidgetsPerModel
-	{
-		std::unique_ptr<class Control> m_ctrl;
-	};
-
-	std::map<std::string, WidgetsPerModel> m_widgets;
+	std::map<std::string, std::unique_ptr<class Control>> m_widgets;
 };
 
 
 /**
-	Base class for view for one plugin with linkable models.
-	Provides a global channel link LED.
+	Container class for one LinkedModelGroupView
 
 	@note It's intended this class does not inherit from ModelView.
 		Inheriting classes need to do that, see e.g. Lv2Instrument.h
@@ -103,8 +94,8 @@ protected:
 	void modelChanged(class LinkedModelGroups* ctrlBase);
 
 private:
-	//! The base class must return the adressed group view, or nullptr if index
-	//! is out of range
+	//! The base class must return the adressed group view,
+	//! which has the same value as "this"
 	virtual LinkedModelGroupView* getGroupView() = 0;
 };
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -64,17 +64,28 @@ public:
 
 protected:
 	//! Add a control to this widget
-	void addControl(class Control *ctrl);
+	//! @warning This widget will own this control, do not free it
+	void addControl(class Control *ctrl, const std::string &id,
+					const std::string& display, bool removable);
+
+	void removeControl(const QString &key);
 
 private:
 	void makeAllGridCellsEqualSized();
 
+	class LinkedModelGroup* m_model;
+
 	//! column number in surrounding grid in LinkedModelGroupsView
 	std::size_t m_colNum;
 	bool m_isLinking;
-	class QGridLayout* m_grid;
-	std::vector<std::unique_ptr<class Control>> m_controls;
-	std::vector<std::unique_ptr<class LedCheckBox>> m_leds;
+	class LinkedModelGroupLayout* m_layout;
+	struct WidgetsPerModel
+	{
+		std::unique_ptr<class Control> m_ctrl;
+		class LedCheckBox* m_led = nullptr;
+	};
+
+	std::map<std::string, WidgetsPerModel> m_widgets;
 };
 
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -41,6 +41,10 @@
 /**
 	View for a representative processor
 
+	Features:
+	* Remove button for removable models
+	* Simple handling of adding, removing and model changing
+
 	@note Neither this class, nor any inheriting classes, shall inherit
 		ModelView. The "view" in the name is just for consistency
 		with LinkedModelGroupsView.

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -68,8 +68,6 @@ protected:
 	void removeControl(const QString &key);
 
 private:
-	void makeAllGridCellsEqualSized();
-
 	class LinkedModelGroup* m_model;
 
 	//! column number in surrounding grid in LinkedModelGroupsView

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -26,6 +26,8 @@
 #define LINKEDMODELGROUPVIEWS_H
 
 
+#include <memory>
+#include <vector>
 #include <QGroupBox>
 
 
@@ -59,8 +61,8 @@ private:
 	int m_colNum; //!< column number in surrounding grid in Lv2ViewBase
 	bool m_isLinking;
 	class QGridLayout* m_grid;
-	QVector<class ControlBase*> m_controls;
-	QVector<class LedCheckBox*> m_leds;
+	std::vector<std::unique_ptr<class ControlBase>> m_controls;
+	std::vector<std::unique_ptr<class LedCheckBox>> m_leds;
 };
 
 
@@ -71,19 +73,22 @@ class LinkedModelGroupsViewBase
 protected:
 	//! @param pluginWidget A child class which inherits QWidget
 	LinkedModelGroupsViewBase(class LinkedModelGroups *ctrlBase);
-	~LinkedModelGroupsViewBase();
+	~LinkedModelGroupsViewBase() = default;
 
 	//! Reconnect models if model changed; to be called by child virtuals
 	void modelChanged(class LinkedModelGroups* ctrlBase);
 
 	//! Access to the global multi channel link LED
-	LedCheckBox* globalLinkLed() { return m_multiChannelLink; }
+	LedCheckBox* globalLinkLed() { return m_multiChannelLink.get(); }
 
 private:
 	//! The base class must return the adressed group view
 	virtual LinkedModelGroupViewBase* getGroupView(std::size_t idx) = 0;
 
-	class LedCheckBox *m_multiChannelLink = nullptr;
+	// Implement deletion in the CPP file:
+	struct MultiChannelLinkDeleter { void operator()(LedCheckBox* l); };
+	std::unique_ptr<class LedCheckBox, MultiChannelLinkDeleter>
+		m_multiChannelLink = nullptr;
 };
 
 

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -26,6 +26,7 @@
 #define LINKEDMODELGROUPVIEWS_H
 
 
+#include <cstddef>
 #include <memory>
 #include <vector>
 #include <QGroupBox>
@@ -41,8 +42,8 @@
 	View for one processor, LinkedModelGroupsViewBase contains 2
 	of those for mono plugins.
 
-	@note This class, and no inheriting classes, shall inherit ModelView.
-		The "view" in the name is just for consistency
+	@note Neither this class, nor any inheriting classes, shall inherit
+		ModelView. The "view" in the name is just for consistency
 		with LinkedModelGroupsView.
 */
 class LinkedModelGroupView : public QGroupBox
@@ -55,7 +56,7 @@ public:
 			automatically set if not given
 	*/
 	LinkedModelGroupView(QWidget *parent, class LinkedModelGroup* model,
-		int colNum, int nProc, const QString &name = QString());
+		std::size_t colNum, std::size_t nProc, const QString &name = QString());
 	~LinkedModelGroupView();
 
 	//! Reconnect models if model changed
@@ -68,7 +69,8 @@ protected:
 private:
 	void makeAllGridCellsEqualSized();
 
-	int m_colNum; //!< column number in surrounding grid in Lv2ViewBase
+	//! column number in surrounding grid in LinkedModelGroupsView
+	std::size_t m_colNum;
 	bool m_isLinking;
 	class QGridLayout* m_grid;
 	std::vector<std::unique_ptr<class Control>> m_controls;
@@ -81,7 +83,7 @@ private:
 	Provides a global channel link LED.
 
 	@note It's intended this class does not inherit from ModelView.
-		Inheriting classes need to do that, see Lv2Instrument.h
+		Inheriting classes need to do that, see e.g. Lv2Instrument.h
 */
 class LinkedModelGroupsView
 {

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -37,9 +37,15 @@
 */
 
 
-//! View for one processor, LinkedModelGroupsViewBase contains 2
-//! of those for mono plugins
-class LinkedModelGroupViewBase : public QGroupBox
+/**
+	View for one processor, LinkedModelGroupsViewBase contains 2
+	of those for mono plugins.
+
+	@note This class, and no inheriting classes, shall inherit ModelView.
+		The "view" in the name is just for consistency
+		with LinkedModelGroupsView.
+*/
+class LinkedModelGroupView : public QGroupBox
 {
 public:
 	/**
@@ -48,16 +54,16 @@ public:
 		@param name Name for the group, like "Left" or "Group 1",
 			automatically set if not given
 	*/
-	LinkedModelGroupViewBase(QWidget *parent, class LinkedModelGroup* model,
+	LinkedModelGroupView(QWidget *parent, class LinkedModelGroup* model,
 		int colNum, int nProc, const QString &name = QString());
-	~LinkedModelGroupViewBase();
+	~LinkedModelGroupView();
 
 	//! Reconnect models if model changed
 	void modelChanged(class LinkedModelGroup *linkedModelGroup);
 
 protected:
 	//! Add a control to this widget
-	void addControl(class ControlBase *ctrl);
+	void addControl(class Control *ctrl);
 
 private:
 	void makeAllGridCellsEqualSized();
@@ -65,18 +71,23 @@ private:
 	int m_colNum; //!< column number in surrounding grid in Lv2ViewBase
 	bool m_isLinking;
 	class QGridLayout* m_grid;
-	std::vector<std::unique_ptr<class ControlBase>> m_controls;
+	std::vector<std::unique_ptr<class Control>> m_controls;
 	std::vector<std::unique_ptr<class LedCheckBox>> m_leds;
 };
 
 
-//! Base class for view for one plugin with linkable models.
-//! Provides a global channel link LED.
-class LinkedModelGroupsViewBase
+/**
+	Base class for view for one plugin with linkable models.
+	Provides a global channel link LED.
+
+	@note It's intended this class does not inherit from ModelView.
+		Inheriting classes need to do that, see Lv2Instrument.h
+*/
+class LinkedModelGroupsView
 {
 protected:
-	LinkedModelGroupsViewBase(class LinkedModelGroups *ctrlBase);
-	~LinkedModelGroupsViewBase() = default;
+	LinkedModelGroupsView(class LinkedModelGroups *ctrlBase);
+	~LinkedModelGroupsView() = default;
 
 	//! Reconnect models if model changed; to be called by child virtuals
 	void modelChanged(class LinkedModelGroups* ctrlBase);
@@ -87,7 +98,7 @@ protected:
 private:
 	//! The base class must return the adressed group view, or nullptr if index
 	//! is out of range
-	virtual LinkedModelGroupViewBase* getGroupView(std::size_t idx) = 0;
+	virtual LinkedModelGroupView* getGroupView(std::size_t idx) = 0;
 
 	// Implement deletion in the CPP file:
 	struct MultiChannelLinkDeleter { void operator()(LedCheckBox* l); };

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -99,7 +99,6 @@ private:
 class LinkedModelGroupsView
 {
 protected:
-	LinkedModelGroupsView(class LinkedModelGroups *ctrlBase);
 	~LinkedModelGroupsView() = default;
 
 	//! Reconnect models if model changed; to be called by child virtuals

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -49,7 +49,7 @@ public:
 			automatically set if not given
 	*/
 	LinkedModelGroupViewBase(QWidget *parent, class LinkedModelGroup* model,
-		int colNum, const QString &name = QString());
+		int colNum, int nProc, const QString &name = QString());
 	~LinkedModelGroupViewBase();
 
 	//! Reconnect models if model changed

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -29,7 +29,7 @@
 #include <cstddef>
 #include <memory>
 #include <vector>
-#include <QGroupBox>
+#include <QWidget>
 
 
 /**
@@ -46,7 +46,7 @@
 		ModelView. The "view" in the name is just for consistency
 		with LinkedModelGroupsView.
 */
-class LinkedModelGroupView : public QGroupBox
+class LinkedModelGroupView : public QWidget
 {
 public:
 	/**
@@ -56,7 +56,7 @@ public:
 			automatically set if not given
 	*/
 	LinkedModelGroupView(QWidget *parent, class LinkedModelGroup* model,
-		std::size_t colNum, std::size_t nProc, const QString &name = QString());
+		std::size_t colNum);
 	~LinkedModelGroupView();
 
 	//! Reconnect models if model changed
@@ -105,7 +105,7 @@ protected:
 private:
 	//! The base class must return the adressed group view, or nullptr if index
 	//! is out of range
-	virtual LinkedModelGroupView* getGroupView(std::size_t idx) = 0;
+	virtual LinkedModelGroupView* getGroupView() = 0;
 };
 
 

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -1,0 +1,157 @@
+﻿/*
+ * LinkedModelGroups.h - base classes for groups of linkable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LINKEDMODELGROUPS_H
+#define LINKEDMODELGROUPS_H
+
+
+#include <memory>
+#include <vector>
+
+#include "Model.h"
+
+
+/**
+	@file LinkedModelGroups.h
+	See Lv2ControlBase.h and Lv2Proc.h for example usage
+*/
+
+
+/**
+	Base class for a group of linkable models
+
+	See the LinkedModelGroup class for explenations
+*/
+class LinkedModelGroup : public Model
+{
+	Q_OBJECT
+signals:
+	//! Signal emitted after any of the per-control link-enabled models switch
+	void linkStateChanged(int id, bool value);
+
+public:
+	/*
+		Initialization
+	*/
+	//! @param parent model of the LinkedModelGroups class
+	LinkedModelGroup(Model* parent) : Model(parent) {}
+	//! After all models have been added, make this processor the one which
+	//! will contain link models associated with its controls
+	void makeLinkingProc();
+
+	/*
+		Linking
+	*/
+	//! Set all per-control link-enabled models to @p state, which will
+	//! also link or unlink them (via `Lv2ControlBase::linkPort()`)
+	void linkAllModels(bool state);
+	//! Link specified port with the associated port of @p other
+	//! @param id id of the port, conforming to m_models
+	void linkControls(LinkedModelGroup* other, int id);
+	//! @see linkControls
+	void unlinkControls(LinkedModelGroup *other, int id);
+	//! Return whether this is the first of more than one processors
+	bool isLinking() { return m_linkEnabled.size(); }
+
+	/*
+		Models
+	*/
+	class BoolModel* linkEnabledModel(std::size_t id) {
+		return m_linkEnabled[id]; }
+	std::vector<class AutomatableModel*> models() { return m_models; }
+
+protected:
+	//! Register a further model
+	void addModel(class AutomatableModel* model);
+
+private slots:
+	//! Callback called after any of the per-control link-enabled models switch
+	void linkStateChangedSlot();
+
+private:
+	//! models for the per-control link-enabled models
+	std::vector<class BoolModel*> m_linkEnabled;
+	//! models for the controls; the vector defines indices for the controls
+	std::vector<class AutomatableModel*> m_models;
+};
+
+
+/**
+	Container for multiple equal groups of linked models
+
+	Each group contains the same models and model types. The models are
+	numbered, and equal numbered models are associated and can be linked.
+
+	A typical application are two mono plugins making a stereo plugin.
+
+	Inheriting classes need to do the following connections, where the slots
+	must be defined by those classes and call the equal named functions of this
+	class:
+
+	\code
+		if(multiChannelLinkModel()) {
+			connect(multiChannelLinkModel(), SIGNAL(dataChanged()),
+				this, SLOT(updateLinkStatesFromGlobal()));
+			connect(getGroup(0), SIGNAL(linkStateChanged(int, bool)),
+					this, SLOT(linkPort(int, bool)));
+		}
+	\endcode
+*/
+class LinkedModelGroups
+{
+public:
+	virtual ~LinkedModelGroups();
+
+	//! Return the model for multi channel linking
+	BoolModel* multiChannelLinkModel() { return m_multiChannelLinkModel.get(); }
+	//! Create the model for multi channel linking
+	void createMultiChannelLinkModel();
+
+	/*
+		to be called by slots
+	*/
+	//! Take a specified port from the first Lv2Proc and link or unlink it
+	//! from the associated port of every other Lv2Proc
+	//! @param port number conforming to Lv2Proc::m_modelVector
+	//! @param state True iff it should be linked
+	void linkPort(int port, bool state);
+	//! Callback for the global linking LED
+	void updateLinkStatesFromGlobal();
+
+	//! Derived classes must return the group with index @p idx,
+	//! or nullptr if @p is out of range
+	virtual LinkedModelGroup* getGroup(std::size_t idx) = 0;
+
+private:
+	//! Model for the "global" linking
+	//! Only allocated if #processors > 1
+	std::unique_ptr<class BoolModel> m_multiChannelLinkModel;
+
+	//! Force updateLinkStatesFromGlobal() to not unlink any ports
+	//! Implementation detail, see linkPort() implementation
+	bool m_noLink = false;
+};
+
+
+#endif // LINKEDMODELGROUPS_H

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -94,6 +94,7 @@ public:
 	}
 
 	std::size_t modelNum() const { return m_models.size(); }
+	bool containsModel(const QString& name) const;
 
 	// this is bad style (redirecting into the sub-class), but this class
 	// will be married with the sub-classes (Lv2Proc, SpaProc) anyways,

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -108,8 +108,17 @@ public:
 	void loadValues(const class QDomElement& that);
 
 protected:
+	AutomatableModel* getModel(const std::string& s)
+	{
+		auto itr = m_models.find(s);
+		return (itr == m_models.end()) ? nullptr : itr->second.m_model;
+	}
+
 	//! Register a further model
 	void addModel(class AutomatableModel* model, const QString& name);
+	//! Unregister a model, return true if a model was erased
+	bool eraseModel(const QString& name);
+
 	//! Remove all models
 	void clearModels();
 

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -57,8 +57,8 @@ public:
 	//! @param parent model of the LinkedModelGroups class
 	//! @param curProc number of this processor, counted from 0
 	//! @param nProc total number of processors
-	LinkedModelGroup(Model* parent, int curProc, int nProc) :
-		Model(parent), m_curProc(curProc), m_nProc(nProc) {}
+	LinkedModelGroup(Model* parent, int curProc) :
+		Model(parent), m_curProc(curProc) {}
 	//! After all models have been added, make this processor the one which
 	//! will contain link models associated with its controls
 	void makeLinkingProc();
@@ -87,7 +87,6 @@ public:
 	/*
 		General
 	 */
-	int nProc() const { return m_nProc; }
 	int curProc() const { return m_curProc; }
 
 protected:

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -138,17 +138,17 @@ private:
 
 	A typical application are two mono plugins making a stereo plugin.
 
-	Inheriting classes need to do the following connections, where the slots
-	must be defined by those classes and call the equal named functions of this
-	class:
+	Inheriting classes need to do the following connections:
 
 	\code
 		if (multiChannelLinkModel())
 		{
-			connect(multiChannelLinkModel(), SIGNAL(dataChanged()),
-				this, SLOT(updateLinkStatesFromGlobal()));
-			connect(getGroup(0), SIGNAL(linkStateChanged(std::size_t, bool)),
-					this, SLOT(linkPort(std::size_t, bool)));
+			connect(multiChannelLinkModel(), &BoolModel::dataChanged,
+				this, [this](){updateLinkStatesFromGlobal();},
+				Qt::DirectConnection);
+			connect(getGroup(0), &LinkedModelGroup::linkStateChanged,
+				this, [this](std::size_t id, bool value){
+				linkModel(id, value);}, Qt::DirectConnection);
 		}
 	\endcode
 

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -69,7 +69,7 @@ public:
 	{
 		QString m_name;
 		class AutomatableModel* m_model;
-		ModelInfo() { /* hopefully no one will use this */ } // TODO: remove?
+		ModelInfo() = delete;
 		ModelInfo(const QString& name, AutomatableModel* model)
 			: m_name(name), m_model(model) {}
 	};

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -76,7 +76,7 @@ public:
 	//! @see linkControls
 	void unlinkControls(LinkedModelGroup *other, std::size_t id);
 	//! Return whether this is the first of more than one processors
-	bool isLinking() const { return m_linkEnabled.size(); }
+	bool isLinking() const { return d.m_linkEnabled.size(); }
 
 	/*
 		Models
@@ -91,14 +91,14 @@ public:
 
 	class BoolModel* linkEnabledModel(std::size_t id)
 	{
-		return m_linkEnabled[id];
+		return d.m_linkEnabled[id];
 	}
 	const class BoolModel* linkEnabledModel(std::size_t id) const
 	{
-		return m_linkEnabled[id];
+		return d.m_linkEnabled[id];
 	}
-	std::vector<ModelInfo>& models() { return m_models; }
-	const std::vector<ModelInfo>& models() const { return m_models; }
+	std::vector<ModelInfo>& models() { return d.m_models; }
+	const std::vector<ModelInfo>& models() const { return d.m_models; }
 
 	/*
 		Load/Save
@@ -121,10 +121,13 @@ protected:
 	void addModel(class AutomatableModel* model, const QString& name);
 
 private:
-	//! models for the per-control link-enabled models
-	std::vector<class BoolModel*> m_linkEnabled;
-	//! models for the controls; the vector defines indices for the controls
-	std::vector<ModelInfo> m_models;
+	struct
+	{
+		//! models for the per-control link-enabled models
+		std::vector<class BoolModel*> m_linkEnabled;
+		//! models for the controls; the vector defines indices for the controls
+		std::vector<ModelInfo> m_models;
+	} d;
 
 	std::size_t m_curProc;
 };

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * LinkedModelGroups.h - base classes for groups of linkable models
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
@@ -80,13 +80,22 @@ public:
 	/*
 		Models
 	*/
+	struct ModelInfo
+	{
+		class AutomatableModel* m_model;
+		// if you want to hide widgets, or prevent models from being saved,
+		// add bools here
+		ModelInfo(class AutomatableModel* m) : m_model(m)
+		{
+		}
+	};
+
 	class BoolModel* linkEnabledModel(std::size_t id) {
 		return m_linkEnabled[id]; }
 	const class BoolModel* linkEnabledModel(std::size_t id) const {
 		return m_linkEnabled[id]; }
-	std::vector<class AutomatableModel*>& models() { return m_models; }
-	const std::vector<class AutomatableModel*>& models() const {
-		return m_models; }
+	std::vector<ModelInfo>& models() { return m_models; }
+	const std::vector<ModelInfo>& models() const { return m_models; }
 
 	/*
 		General
@@ -105,7 +114,7 @@ private:
 	//! models for the per-control link-enabled models
 	std::vector<class BoolModel*> m_linkEnabled;
 	//! models for the controls; the vector defines indices for the controls
-	std::vector<class AutomatableModel*> m_models;
+	std::vector<ModelInfo> m_models;
 
 	int m_curProc, m_nProc;
 };

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -121,7 +121,7 @@ private:
 	class:
 
 	\code
-		if(multiChannelLinkModel()) {
+		if (multiChannelLinkModel()) {
 			connect(multiChannelLinkModel(), SIGNAL(dataChanged()),
 				this, SLOT(updateLinkStatesFromGlobal()));
 			connect(getGroup(0), SIGNAL(linkStateChanged(int, bool)),

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -126,7 +126,7 @@ private:
 	//! models for the controls; the vector defines indices for the controls
 	std::vector<ModelInfo> m_models;
 
-	int m_curProc, m_nProc;
+	int m_curProc;
 };
 
 

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -78,7 +78,7 @@ public:
 	template<class Functor>
 	void foreach_model(const Functor& ftor)
 	{
-		for(auto itr = m_models.begin(); itr != m_models.end(); ++itr)
+		for (auto itr = m_models.begin(); itr != m_models.end(); ++itr)
 		{
 			ftor(itr->first, itr->second);
 		}
@@ -87,7 +87,7 @@ public:
 	template<class Functor>
 	void foreach_model(const Functor& ftor) const
 	{
-		for(auto itr = m_models.cbegin(); itr != m_models.cend(); ++itr)
+		for (auto itr = m_models.cbegin(); itr != m_models.cend(); ++itr)
 		{
 			ftor(itr->first, itr->second);
 		}

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -97,8 +97,14 @@ public:
 	{
 		return d.m_linkEnabled[id];
 	}
-	std::vector<ModelInfo>& models() { return d.m_models; }
-	const std::vector<ModelInfo>& models() const { return d.m_models; }
+
+	AutomatableModel* model(std::size_t i) { return d.m_models[i].m_model; }
+	const AutomatableModel* model(std::size_t i) const
+	{
+		return d.m_models[i].m_model;
+	}
+	AutomatableModel* modelWithName(const QString& name) const;
+	std::size_t modelNum() const { return models().size(); }
 
 	/*
 		Load/Save
@@ -123,6 +129,10 @@ protected:
 	void clearModels();
 
 private:
+	// TODO: remove
+	std::vector<ModelInfo>& models() { return d.m_models; }
+	const std::vector<ModelInfo>& models() const { return d.m_models; }
+
 	struct
 	{
 		//! models for the per-control link-enabled models

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -50,6 +50,7 @@
 */
 class LinkedModelGroup : public Model
 {
+	Q_OBJECT
 public:
 	/*
 		Initialization
@@ -95,11 +96,7 @@ public:
 
 	std::size_t modelNum() const { return m_models.size(); }
 	bool containsModel(const QString& name) const;
-
-	// this is bad style (redirecting into the sub-class), but this class
-	// will be married with the sub-classes (Lv2Proc, SpaProc) anyways,
-	// so let's do the dirty trick for now...
-	virtual void removeControl(AutomatableModel *) {}
+	void removeControl(AutomatableModel *);
 
 	/*
 		Load/Save
@@ -107,7 +104,15 @@ public:
 	void saveValues(class QDomDocument& doc, class QDomElement& that);
 	void loadValues(const class QDomElement& that);
 
-protected:
+signals:
+	// NOTE: when separating core from UI, this will need to be removed
+	// (who would kno if the client is Qt, i.e. it may not have slots at all)
+	// In this case you'd e.g. send the UI something like
+	// "/added <model meta info>"
+	void modelAdded(AutomatableModel* added);
+	void modelRemoved(AutomatableModel* removed);
+
+public:
 	AutomatableModel* getModel(const std::string& s)
 	{
 		auto itr = m_models.find(s);

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -88,10 +88,14 @@ public:
 			: m_name(name), m_model(model) {}
 	};
 
-	class BoolModel* linkEnabledModel(std::size_t id) {
-		return m_linkEnabled[id]; }
-	const class BoolModel* linkEnabledModel(std::size_t id) const {
-		return m_linkEnabled[id]; }
+	class BoolModel* linkEnabledModel(std::size_t id)
+	{
+		return m_linkEnabled[id];
+	}
+	const class BoolModel* linkEnabledModel(std::size_t id) const
+	{
+		return m_linkEnabled[id];
+	}
 	std::vector<ModelInfo>& models() { return m_models; }
 	const std::vector<ModelInfo>& models() const { return m_models; }
 
@@ -139,7 +143,8 @@ private:
 	class:
 
 	\code
-		if (multiChannelLinkModel()) {
+		if (multiChannelLinkModel())
+		{
 			connect(multiChannelLinkModel(), SIGNAL(dataChanged()),
 				this, SLOT(updateLinkStatesFromGlobal()));
 			connect(getGroup(0), SIGNAL(linkStateChanged(int, bool)),

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -82,12 +82,10 @@ public:
 	*/
 	struct ModelInfo
 	{
+		QString m_name;
 		class AutomatableModel* m_model;
-		// if you want to hide widgets, or prevent models from being saved,
-		// add bools here
-		ModelInfo(class AutomatableModel* m) : m_model(m)
-		{
-		}
+		ModelInfo(const QString& name, AutomatableModel* model)
+			: m_name(name), m_model(model) {}
 	};
 
 	class BoolModel* linkEnabledModel(std::size_t id) {
@@ -98,13 +96,21 @@ public:
 	const std::vector<ModelInfo>& models() const { return m_models; }
 
 	/*
+		Load/Save
+	*/
+	void saveValues(class QDomDocument& doc, class QDomElement& that);
+	void saveLinksEnabled(QDomDocument &doc, QDomElement &that);
+	void loadValues(const class QDomElement& that);
+	void loadLinksEnabled(const class QDomElement &that);
+
+	/*
 		General
-	 */
+	*/
 	int curProc() const { return m_curProc; }
 
 protected:
 	//! Register a further model
-	void addModel(class AutomatableModel* model);
+	void addModel(class AutomatableModel* model, const QString& name);
 
 private slots:
 	//! Callback called after any of the per-control link-enabled models switch
@@ -165,6 +171,15 @@ public:
 	//! Callback for the global linking LED
 	void updateLinkStatesFromGlobal();
 
+	/*
+		Load/Save
+	*/
+	void saveSettings(class QDomDocument& doc, class QDomElement& that);
+	void loadSettings(const class QDomElement& that);
+
+	/*
+		General
+	*/
 	//! Derived classes must return the group with index @p idx,
 	//! or nullptr if @p is out of range
 	virtual LinkedModelGroup* getGroup(std::size_t idx) = 0;

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -75,7 +75,7 @@ public:
 	//! @see linkControls
 	void unlinkControls(LinkedModelGroup *other, int id);
 	//! Return whether this is the first of more than one processors
-	bool isLinking() { return m_linkEnabled.size(); }
+	bool isLinking() const { return m_linkEnabled.size(); }
 
 	/*
 		Models
@@ -102,9 +102,12 @@ public:
 	/*
 		Load/Save
 	*/
-	void saveValues(class QDomDocument& doc, class QDomElement& that);
+	//! @param lmg0 The linking model group with index 0
+	void saveValues(class QDomDocument& doc, class QDomElement& that,
+					const LinkedModelGroup *lmg0);
 	void saveLinksEnabled(QDomDocument &doc, QDomElement &that);
-	void loadValues(const class QDomElement& that);
+	//! @param lmg0 The linking model group with index 0
+	void loadValues(const class QDomElement& that, const LinkedModelGroup *lmg0);
 	void loadLinksEnabled(const class QDomElement &that);
 
 	/*

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -208,9 +208,12 @@ public:
 	virtual const LinkedModelGroup* getGroup(std::size_t idx) const = 0;
 
 private:
+	// Implement deletion in the CPP file:
+	struct BoolModelDeleter { void operator()(class BoolModel* l); };
+
 	//! Model for the "global" linking
 	//! Only allocated if #processors > 1
-	std::unique_ptr<class BoolModel> m_multiChannelLinkModel;
+	std::unique_ptr<class BoolModel, BoolModelDeleter> m_multiChannelLinkModel;
 
 	//! Force updateLinkStatesFromGlobal() to not unlink any ports
 	//! Implementation detail, see linkPort() implementation

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -82,7 +82,11 @@ public:
 	*/
 	class BoolModel* linkEnabledModel(std::size_t id) {
 		return m_linkEnabled[id]; }
-	std::vector<class AutomatableModel*> models() { return m_models; }
+	const class BoolModel* linkEnabledModel(std::size_t id) const {
+		return m_linkEnabled[id]; }
+	std::vector<class AutomatableModel*>& models() { return m_models; }
+	const std::vector<class AutomatableModel*>& models() const {
+		return m_models; }
 
 	/*
 		General
@@ -155,6 +159,8 @@ public:
 	//! Derived classes must return the group with index @p idx,
 	//! or nullptr if @p is out of range
 	virtual LinkedModelGroup* getGroup(std::size_t idx) = 0;
+	//! @see getGroup
+	virtual const LinkedModelGroup* getGroup(std::size_t idx) const = 0;
 
 private:
 	//! Model for the "global" linking

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -119,6 +119,8 @@ public:
 protected:
 	//! Register a further model
 	void addModel(class AutomatableModel* model, const QString& name);
+	//! Remove all models and all link-enabled models
+	void clearModels();
 
 private:
 	struct

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -69,7 +69,7 @@ public:
 	{
 		QString m_name;
 		class AutomatableModel* m_model;
-		ModelInfo() = delete;
+		ModelInfo() { /* hopefully no one will use this */ } // TODO: remove?
 		ModelInfo(const QString& name, AutomatableModel* model)
 			: m_name(name), m_model(model) {}
 	};

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -55,7 +55,10 @@ public:
 		Initialization
 	*/
 	//! @param parent model of the LinkedModelGroups class
-	LinkedModelGroup(Model* parent) : Model(parent) {}
+	//! @param curProc number of this processor, counted from 0
+	//! @param nProc total number of processors
+	LinkedModelGroup(Model* parent, int curProc, int nProc) :
+		Model(parent), m_curProc(curProc), m_nProc(nProc) {}
 	//! After all models have been added, make this processor the one which
 	//! will contain link models associated with its controls
 	void makeLinkingProc();
@@ -81,6 +84,12 @@ public:
 		return m_linkEnabled[id]; }
 	std::vector<class AutomatableModel*> models() { return m_models; }
 
+	/*
+		General
+	 */
+	int nProc() const { return m_nProc; }
+	int curProc() const { return m_curProc; }
+
 protected:
 	//! Register a further model
 	void addModel(class AutomatableModel* model);
@@ -94,6 +103,8 @@ private:
 	std::vector<class BoolModel*> m_linkEnabled;
 	//! models for the controls; the vector defines indices for the controls
 	std::vector<class AutomatableModel*> m_models;
+
+	int m_curProc, m_nProc;
 };
 
 
@@ -117,6 +128,9 @@ private:
 					this, SLOT(linkPort(int, bool)));
 		}
 	\endcode
+
+	@note Though called "container", this class does not contain, but only
+	know the single groups. The inheriting classes are responsible for storage.
 */
 class LinkedModelGroups
 {

--- a/include/stdshims.h
+++ b/include/stdshims.h
@@ -21,6 +21,13 @@ std::unique_ptr<T> make_unique(Args&&... args)
 {
 	return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
+
+//! Overload for the case a deleter should be specified
+template<typename T, typename Deleter, typename... Args>
+std::unique_ptr<T, Deleter> make_unique(Args&&... args)
+{
+	return std::unique_ptr<T, Deleter>(new T(std::forward<Args>(args)...));
+}
 #endif
 
 #endif // include guard

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LMMS_SRCS
 	core/LadspaControl.cpp
 	core/LadspaManager.cpp
 	core/LfoController.cpp
+	core/LinkedModelGroups.cpp
 	core/LocklessAllocator.cpp
 	core/MemoryHelper.cpp
 	core/MemoryManager.cpp

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -1,0 +1,174 @@
+/*
+ * LinkedModelGroups.cpp - base classes for groups of linkable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "LinkedModelGroups.h"
+
+#include "AutomatableModel.h"
+
+
+
+
+/*
+	LinkedModelGroup
+*/
+
+
+
+
+void LinkedModelGroup::makeLinkingProc()
+{
+	for(std::size_t i = 0; i < m_models.size(); ++i)
+	{
+		BoolModel* bmo = new BoolModel(true, this, tr("Link channels"));
+		m_linkEnabled.push_back(bmo);
+		connect(bmo, SIGNAL(dataChanged()), this, SLOT(linkStateChangedSlot()));
+	}
+}
+
+
+
+
+void LinkedModelGroup::linkAllModels(bool state)
+{
+	for(BoolModel* bmo : m_linkEnabled) { bmo->setValue(state); }
+}
+
+
+
+
+void LinkedModelGroup::linkControls(LinkedModelGroup *other, int id)
+{
+	Q_ASSERT(id >= 0);
+	std::size_t id2 = static_cast<std::size_t>(id);
+	AutomatableModel::linkModels(m_models[id2], other->m_models[id2]);
+}
+
+
+
+
+void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, int id)
+{
+	Q_ASSERT(id >= 0);
+	std::size_t id2 = static_cast<std::size_t>(id);
+	AutomatableModel::unlinkModels(
+		m_models[id2], other->m_models[id2]);
+}
+
+
+
+
+void LinkedModelGroup::linkStateChangedSlot()
+{
+	QObject* sender = QObject::sender();
+	Q_ASSERT(sender);
+	BoolModel* bmo = qobject_cast<BoolModel*>(sender);
+	Q_ASSERT(bmo);
+	int modelNo = -1, count = 0;
+	for(BoolModel* bmo2 : m_linkEnabled)
+	{
+		if(bmo2 == bmo) { modelNo = count; }
+		++count;
+	}
+	Q_ASSERT(modelNo >= 0);
+	emit linkStateChanged(modelNo, bmo->value());
+}
+
+
+
+
+void LinkedModelGroup::addModel(AutomatableModel *model) {
+	m_models.push_back(model); }
+
+
+
+
+/*
+	LinkedModelGroups
+*/
+
+
+
+
+LinkedModelGroups::~LinkedModelGroups() {}
+
+
+
+
+void LinkedModelGroups::createMultiChannelLinkModel() {
+	m_multiChannelLinkModel.reset(new BoolModel(true, nullptr));
+}
+
+
+
+
+void LinkedModelGroups::linkPort(int port, bool state)
+{
+	LinkedModelGroup* first = getGroup(0);
+	LinkedModelGroup* cur;
+
+	if(state)
+	{
+		for(std::size_t i = 1; (cur=getGroup(i)); ++i)
+		{
+			first->linkControls(cur, port);
+		}
+	}
+	else
+	{
+		for(std::size_t i = 1; (cur=getGroup(i)); ++i)
+		{
+			first->unlinkControls(cur, port);
+		}
+
+		// m_multiChannelLinkModel.setValue() will call
+		// updateLinkStatesFromGlobal()...
+		// m_noLink will make sure that this will not unlink any other ports
+		m_noLink = true;
+		m_multiChannelLinkModel->setValue( false );
+	}
+}
+
+
+
+
+void LinkedModelGroups::updateLinkStatesFromGlobal()
+{
+	LinkedModelGroup* first = getGroup(0);
+	if(m_multiChannelLinkModel->value())
+	{
+		first->linkAllModels(true);
+	}
+	else if( !m_noLink )
+	{
+		first->linkAllModels(false);
+	}
+
+	// if global channel link state has changed, always ignore link
+	// status of individual ports in the future
+	m_noLink = false;
+}
+
+
+
+

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -38,7 +38,7 @@
 
 void LinkedModelGroup::makeLinkingProc()
 {
-	for(std::size_t i = 0; i < m_models.size(); ++i)
+	for (std::size_t i = 0; i < m_models.size(); ++i)
 	{
 		BoolModel* bmo = new BoolModel(true, this, tr("Link channels"));
 		m_linkEnabled.push_back(bmo);
@@ -51,7 +51,7 @@ void LinkedModelGroup::makeLinkingProc()
 
 void LinkedModelGroup::linkAllModels(bool state)
 {
-	for(BoolModel* bmo : m_linkEnabled) { bmo->setValue(state); }
+	for (BoolModel* bmo : m_linkEnabled) { bmo->setValue(state); }
 }
 
 
@@ -85,9 +85,9 @@ void LinkedModelGroup::linkStateChangedSlot()
 	BoolModel* bmo = qobject_cast<BoolModel*>(sender);
 	Q_ASSERT(bmo);
 	int modelNo = -1, count = 0;
-	for(BoolModel* bmo2 : m_linkEnabled)
+	for (BoolModel* bmo2 : m_linkEnabled)
 	{
-		if(bmo2 == bmo) { modelNo = count; }
+		if (bmo2 == bmo) { modelNo = count; }
 		++count;
 	}
 	Q_ASSERT(modelNo >= 0);
@@ -127,16 +127,16 @@ void LinkedModelGroups::linkPort(int port, bool state)
 	LinkedModelGroup* first = getGroup(0);
 	LinkedModelGroup* cur;
 
-	if(state)
+	if (state)
 	{
-		for(std::size_t i = 1; (cur=getGroup(i)); ++i)
+		for (std::size_t i = 1; (cur=getGroup(i)); ++i)
 		{
 			first->linkControls(cur, port);
 		}
 	}
 	else
 	{
-		for(std::size_t i = 1; (cur=getGroup(i)); ++i)
+		for (std::size_t i = 1; (cur=getGroup(i)); ++i)
 		{
 			first->unlinkControls(cur, port);
 		}
@@ -155,11 +155,11 @@ void LinkedModelGroups::linkPort(int port, bool state)
 void LinkedModelGroups::updateLinkStatesFromGlobal()
 {
 	LinkedModelGroup* first = getGroup(0);
-	if(m_multiChannelLinkModel->value())
+	if (m_multiChannelLinkModel->value())
 	{
 		first->linkAllModels(true);
 	}
-	else if( !m_noLink )
+	else if (!m_noLink)
 	{
 		first->linkAllModels(false);
 	}

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -83,7 +83,8 @@ void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, std::size_t id)
 void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that,
 	const LinkedModelGroup *lmg0)
 {
-	Q_ASSERT(lmg0->isLinking());
+	// if multiple lmgs, the first one must currently be the linking one
+	Q_ASSERT(this == lmg0 || lmg0->isLinking());
 	for (std::size_t idx = 0; idx < m_models.size(); ++idx)
 	{
 		if (this == lmg0 || !lmg0->linkEnabledModel(idx)->value())

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -152,6 +152,16 @@ void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 
 
 
+void LinkedModelGroup::clearModels()
+{
+	using datatype = decltype(d);
+	d.~datatype();
+	new (&d) datatype();
+}
+
+
+
+
 /*
 	LinkedModelGroups
 */

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -91,6 +91,14 @@ void LinkedModelGroup::clearModels()
 
 
 
+bool LinkedModelGroup::containsModel(const QString &name) const
+{
+	return m_models.find(name.toStdString()) != m_models.end();
+}
+
+
+
+
 /*
 	LinkedModelGroups
 */

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -78,6 +78,31 @@ void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 {
 	model->setObjectName(name);
 	m_models.emplace(std::string(name.toUtf8().data()), ModelInfo(name, model));
+	connect(model, &AutomatableModel::destroyed,
+				this, [this, model](jo_id_t){
+					if(containsModel(model->objectName()))
+					{
+						emit modelRemoved(model);
+						eraseModel(model->objectName());
+					}
+				},
+				Qt::DirectConnection);
+
+	// View needs to create another child view, e.g. a new knob:
+	emit modelAdded(model);
+	emit dataChanged();
+}
+
+
+
+
+void LinkedModelGroup::removeControl(AutomatableModel* mdl)
+{
+	if(containsModel(mdl->objectName()))
+	{
+		emit modelRemoved(mdl);
+		eraseModel(mdl->objectName());
+	}
 }
 
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -42,10 +42,10 @@
 
 void LinkedModelGroup::makeLinkingProc()
 {
-	for (std::size_t i = 0; i < m_models.size(); ++i)
+	for (std::size_t i = 0; i < models().size(); ++i)
 	{
 		BoolModel* bmo = new BoolModel(true, this, tr("Link channels"));
-		m_linkEnabled.push_back(bmo);
+		d.m_linkEnabled.push_back(bmo);
 		connect(bmo, &BoolModel::dataChanged, this,
 				[this, bmo, i]() { emit linkStateChanged(i, bmo->value()); });
 	}
@@ -56,7 +56,7 @@ void LinkedModelGroup::makeLinkingProc()
 
 void LinkedModelGroup::linkAllModels(bool state)
 {
-	for (BoolModel* bmo : m_linkEnabled) { bmo->setValue(state); }
+	for (BoolModel* bmo : d.m_linkEnabled) { bmo->setValue(state); }
 }
 
 
@@ -65,7 +65,7 @@ void LinkedModelGroup::linkAllModels(bool state)
 void LinkedModelGroup::linkControls(LinkedModelGroup *other, std::size_t id)
 {
 	AutomatableModel::linkModels(
-		m_models[id].m_model, other->m_models[id].m_model);
+		models()[id].m_model, other->models()[id].m_model);
 }
 
 
@@ -74,7 +74,7 @@ void LinkedModelGroup::linkControls(LinkedModelGroup *other, std::size_t id)
 void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, std::size_t id)
 {
 	AutomatableModel::unlinkModels(
-		m_models[id].m_model, other->m_models[id].m_model);
+		models()[id].m_model, other->models()[id].m_model);
 }
 
 
@@ -85,12 +85,12 @@ void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that,
 {
 	// if multiple lmgs, the first one must currently be the linking one
 	Q_ASSERT(this == lmg0 || lmg0->isLinking());
-	for (std::size_t idx = 0; idx < m_models.size(); ++idx)
+	for (std::size_t idx = 0; idx < models().size(); ++idx)
 	{
 		if (this == lmg0 || !lmg0->linkEnabledModel(idx)->value())
 		{
 			// try to load, if it fails, this will load a sane initial value
-			m_models[idx].m_model->saveSettings(doc, that, m_models[idx].m_name);
+			models()[idx].m_model->saveSettings(doc, that, models()[idx].m_name);
 		}
 		else
 		{
@@ -104,9 +104,9 @@ void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that,
 
 void LinkedModelGroup::saveLinksEnabled(QDomDocument &doc, QDomElement &that)
 {
-	for (std::size_t i = 0; i < m_linkEnabled.size(); ++i)
+	for (std::size_t i = 0; i < d.m_linkEnabled.size(); ++i)
 	{
-		m_linkEnabled[i]->saveSettings(doc, that, m_models[i].m_name);
+		d.m_linkEnabled[i]->saveSettings(doc, that, models()[i].m_name);
 	}
 }
 
@@ -116,12 +116,12 @@ void LinkedModelGroup::saveLinksEnabled(QDomDocument &doc, QDomElement &that)
 void LinkedModelGroup::loadValues(const QDomElement &that,
 	const LinkedModelGroup* lmg0)
 {
-	for (std::size_t idx = 0; idx < m_models.size(); ++idx)
+	for (std::size_t idx = 0; idx < models().size(); ++idx)
 	{
 		if (this == lmg0 || !lmg0->linkEnabledModel(idx)->value())
 		{
 			// try to load, if it fails, this will load a sane initial value
-			m_models[idx].m_model->loadSettings(that, m_models[idx].m_name);
+			models()[idx].m_model->loadSettings(that, models()[idx].m_name);
 		}
 		else
 		{
@@ -135,9 +135,9 @@ void LinkedModelGroup::loadValues(const QDomElement &that,
 
 void LinkedModelGroup::loadLinksEnabled(const QDomElement &that)
 {
-	for (std::size_t i = 0; i < m_linkEnabled.size(); ++i)
+	for (std::size_t i = 0; i < d.m_linkEnabled.size(); ++i)
 	{
-		m_linkEnabled[i]->loadSettings(that, m_models[i].m_name);
+		d.m_linkEnabled[i]->loadSettings(that, models()[i].m_name);
 	}
 }
 
@@ -146,7 +146,7 @@ void LinkedModelGroup::loadLinksEnabled(const QDomElement &that)
 
 void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 {
-	m_models.emplace_back(name, model);
+	models().emplace_back(name, model);
 }
 
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -74,7 +74,18 @@ void LinkedModelGroup::linkControls(LinkedModelGroup *other, std::size_t id)
 void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, std::size_t id)
 {
 	AutomatableModel::unlinkModels(
-		models()[id].m_model, other->models()[id].m_model);
+				models()[id].m_model, other->models()[id].m_model);
+}
+
+
+
+
+AutomatableModel *LinkedModelGroup::modelWithName(const QString &name) const
+{
+	auto itr = std::find_if(models().begin(), models().end(),
+		[&name](const ModelInfo& mi) -> bool
+	{ return mi.m_name == name; });
+	return itr == models().end() ? nullptr : itr->m_model;
 }
 
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -122,7 +122,6 @@ void LinkedModelGroup::saveLinksEnabled(QDomDocument &doc, QDomElement &that)
 		std::size_t count = 0;
 		for (BoolModel* bmo : m_linkEnabled)
 		{
-			//that.setAttribute(m_models[count++].m_name, bmo->value());
 			bmo->saveSettings(doc, that, m_models[count++].m_name);
 		}
 	}
@@ -268,8 +267,6 @@ void LinkedModelGroups::updateLinkStatesFromGlobal()
 		first->linkAllModels(false);
 	}
 
-	// if global channel link state has changed, always ignore link
-	// status of individual ports in the future
 	m_noLink = false;
 }
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -237,7 +237,10 @@ void LinkedModelGroups::saveSettings(QDomDocument& doc, QDomElement& that)
 {
 	if (getGroup(0))
 	{
-		m_multiChannelLinkModel->saveSettings(doc, that, "link");
+		if (m_multiChannelLinkModel)
+		{
+			m_multiChannelLinkModel->saveSettings(doc, that, "link");
+		}
 
 		{
 			QDomElement links = doc.createElement("links");
@@ -274,7 +277,10 @@ void LinkedModelGroups::loadSettings(const QDomElement& that)
 	QDomElement models = that.firstChildElement("models");
 	if (!models.isNull() && getGroup(0))
 	{
-		m_multiChannelLinkModel->loadSettings(that, "link");
+		if (m_multiChannelLinkModel)
+		{
+			m_multiChannelLinkModel->loadSettings(that, "link");
+		}
 
 		{
 			QDomElement links = that.firstChildElement("links");

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -83,6 +83,14 @@ void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 
 
 
+bool LinkedModelGroup::eraseModel(const QString& name)
+{
+	return m_models.erase(name.toStdString()) > 0;
+}
+
+
+
+
 void LinkedModelGroup::clearModels()
 {
 	m_models.clear();

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -1,5 +1,5 @@
 /*
- * LinkedModelGroups.cpp - base classes for groups of linkable models
+ * LinkedModelGroups.cpp - base classes for groups of linked models
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -42,8 +42,8 @@ void LinkedModelGroup::linkControls(LinkedModelGroup *other)
 {
 	foreach_model([&other](const std::string& id, ModelInfo& inf)
 	{
-		auto itr2 = other->models().find(id);
-		Q_ASSERT(itr2 != other->models().end());
+		auto itr2 = other->m_models.find(id);
+		Q_ASSERT(itr2 != other->m_models.end());
 		AutomatableModel::linkModels(inf.m_model, itr2->second.m_model);
 	});
 }
@@ -55,7 +55,7 @@ void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that)
 {
 	foreach_model([&doc, &that](const std::string& , ModelInfo& inf)
 	{
-		inf.m_model->saveSettings(doc, that, /*models()[idx].m_name*/ inf.m_name); /* TODO: m_name useful */
+		inf.m_model->saveSettings(doc, that, /*m_models[idx].m_name*/ inf.m_name); /* TODO: m_name useful */
 	});
 }
 
@@ -67,7 +67,7 @@ void LinkedModelGroup::loadValues(const QDomElement &that)
 	foreach_model([&that](const std::string& , ModelInfo& inf)
 	{
 		// try to load, if it fails, this will load a sane initial value
-		inf.m_model->loadSettings(that, /*models()[idx].m_name*/ inf.m_name); /* TODO: m_name useful */
+		inf.m_model->loadSettings(that, /*m_models()[idx].m_name*/ inf.m_name); /* TODO: m_name useful */
 	});
 }
 
@@ -77,7 +77,7 @@ void LinkedModelGroup::loadValues(const QDomElement &that)
 void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 {
 	model->setObjectName(name);
-	models().emplace(std::string(name.toUtf8().data()), ModelInfo(name, model));
+	m_models.emplace(std::string(name.toUtf8().data()), ModelInfo(name, model));
 }
 
 
@@ -85,9 +85,7 @@ void LinkedModelGroup::addModel(AutomatableModel *model, const QString &name)
 
 void LinkedModelGroup::clearModels()
 {
-	using datatype = decltype(d);
-	d.~datatype();
-	new (&d) datatype();
+	m_models.clear();
 }
 
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -61,7 +61,8 @@ void LinkedModelGroup::linkControls(LinkedModelGroup *other, int id)
 {
 	Q_ASSERT(id >= 0);
 	std::size_t id2 = static_cast<std::size_t>(id);
-	AutomatableModel::linkModels(m_models[id2], other->m_models[id2]);
+	AutomatableModel::linkModels(
+		m_models[id2].m_model, other->m_models[id2].m_model);
 }
 
 
@@ -72,7 +73,7 @@ void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, int id)
 	Q_ASSERT(id >= 0);
 	std::size_t id2 = static_cast<std::size_t>(id);
 	AutomatableModel::unlinkModels(
-		m_models[id2], other->m_models[id2]);
+		m_models[id2].m_model, other->m_models[id2].m_model);
 }
 
 
@@ -98,7 +99,7 @@ void LinkedModelGroup::linkStateChangedSlot()
 
 
 void LinkedModelGroup::addModel(AutomatableModel *model) {
-	m_models.push_back(model); }
+	m_models.emplace_back(model); }
 
 
 

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -84,7 +84,7 @@ void LinkedModelGroup::unlinkControls(LinkedModelGroup *other, int id)
 
 void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that)
 {
-	for(const ModelInfo& minf : m_models)
+	for (const ModelInfo& minf : m_models)
 	{
 		minf.m_model->saveSettings(doc, that, minf.m_name);
 	}
@@ -95,10 +95,10 @@ void LinkedModelGroup::saveValues(QDomDocument &doc, QDomElement &that)
 
 void LinkedModelGroup::saveLinksEnabled(QDomDocument &doc, QDomElement &that)
 {
-	if(m_linkEnabled.size())
+	if (m_linkEnabled.size())
 	{
 		std::size_t count = 0;
-		for(BoolModel* bmo : m_linkEnabled)
+		for (BoolModel* bmo : m_linkEnabled)
 		{
 			//that.setAttribute(m_models[count++].m_name, bmo->value());
 			bmo->saveSettings(doc, that, m_models[count++].m_name);
@@ -111,7 +111,7 @@ void LinkedModelGroup::saveLinksEnabled(QDomDocument &doc, QDomElement &that)
 
 void LinkedModelGroup::loadValues(const QDomElement &that)
 {
-	for(ModelInfo& minf : m_models)
+	for (ModelInfo& minf : m_models)
 	{
 		// try to load, if it fails, this will load a sane initial value
 		minf.m_model->loadSettings(that, minf.m_name);
@@ -123,10 +123,10 @@ void LinkedModelGroup::loadValues(const QDomElement &that)
 
 void LinkedModelGroup::loadLinksEnabled(const QDomElement &that)
 {
-	if(m_linkEnabled.size())
+	if (m_linkEnabled.size())
 	{
 		std::size_t count = 0;
-		for(BoolModel* bmo : m_linkEnabled)
+		for (BoolModel* bmo : m_linkEnabled)
 		{
 			bmo->loadSettings(that, m_models[count++].m_name);
 		}
@@ -175,7 +175,8 @@ LinkedModelGroups::~LinkedModelGroups() {}
 
 
 
-void LinkedModelGroups::createMultiChannelLinkModel() {
+void LinkedModelGroups::createMultiChannelLinkModel()
+{
 	m_multiChannelLinkModel.reset(new BoolModel(true, nullptr));
 }
 
@@ -234,7 +235,7 @@ void LinkedModelGroups::updateLinkStatesFromGlobal()
 
 void LinkedModelGroups::saveSettings(QDomDocument& doc, QDomElement& that)
 {
-	if(getGroup(0))
+	if (getGroup(0))
 	{
 		m_multiChannelLinkModel->saveSettings(doc, that, "link");
 
@@ -248,25 +249,21 @@ void LinkedModelGroups::saveSettings(QDomDocument& doc, QDomElement& that)
 		that.appendChild(models);
 
 		char chanName[] = "chan0";
-		for(char* chanPtr = chanName + 4; *chanPtr >= '0'; ++*chanPtr)
+		for (char* chanPtr = chanName + 4; *chanPtr >= '0'; ++*chanPtr)
 		{
 			LinkedModelGroup* lmg = getGroup(static_cast<std::size_t>(
 												*chanPtr - '0'));
-			if(lmg)
+			if (lmg)
 			{
 				QDomElement channel = doc.createElement(
 										QString::fromUtf8(chanName));
 				models.appendChild(channel);
 				lmg->saveValues(doc, channel);
 			}
-			else {
-				*chanPtr = 0;
-			}
+			else { *chanPtr = 0; }
 		}
 	}
-	else {
-		// don't even add a "models" node
-	}
+	else { /* don't even add a "models" node */ }
 }
 
 
@@ -275,7 +272,7 @@ void LinkedModelGroups::saveSettings(QDomDocument& doc, QDomElement& that)
 void LinkedModelGroups::loadSettings(const QDomElement& that)
 {
 	QDomElement models = that.firstChildElement("models");
-	if(!models.isNull() && getGroup(0))
+	if (!models.isNull() && getGroup(0))
 	{
 		m_multiChannelLinkModel->loadSettings(that, "link");
 
@@ -286,19 +283,17 @@ void LinkedModelGroups::loadSettings(const QDomElement& that)
 
 		QDomElement lastChan;
 		char chanName[] = "chan0";
-		for(char* chanPtr = chanName + 4; *chanPtr >= '0'; ++*chanPtr)
+		for (char* chanPtr = chanName + 4; *chanPtr >= '0'; ++*chanPtr)
 		{
 			LinkedModelGroup* lmg = getGroup(static_cast<std::size_t>(
 												*chanPtr - '0'));
-			if(lmg)
+			if (lmg)
 			{
 				QDomElement chan = models.firstChildElement(chanName);
-				if(!chan.isNull()) { lastChan = chan; }
+				if (!chan.isNull()) { lastChan = chan; }
 				lmg->loadValues(lastChan);
 			}
-			else {
-				*chanPtr = 0;
-			}
+			else { *chanPtr = 0; }
 		}
 	}
 }

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -187,7 +187,8 @@ LinkedModelGroups::~LinkedModelGroups() {}
 
 void LinkedModelGroups::createMultiChannelLinkModel()
 {
-	m_multiChannelLinkModel = make_unique<BoolModel>(true, nullptr);
+	m_multiChannelLinkModel =
+		make_unique<BoolModel, BoolModelDeleter>(true, nullptr);
 }
 
 
@@ -322,3 +323,9 @@ void LinkedModelGroups::loadSettings(const QDomElement& that)
 }
 
 
+
+
+void LinkedModelGroups::BoolModelDeleter::operator()(BoolModel *l)
+{
+	delete l;
+}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(LMMS_SRCS
 	gui/widgets/LcdSpinBox.cpp
 	gui/widgets/LcdWidget.cpp
 	gui/widgets/LedCheckbox.cpp
+	gui/widgets/LinkedModelGroupLayout.cpp
 	gui/widgets/LinkedModelGroupViews.cpp
 	gui/widgets/MeterDialog.cpp
 	gui/widgets/MidiPortMenu.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -49,6 +49,7 @@ SET(LMMS_SRCS
 	gui/widgets/ComboBox.cpp
 	gui/widgets/ControllerRackView.cpp
 	gui/widgets/ControllerView.cpp
+	gui/widgets/Controls.cpp
 	gui/widgets/CPULoadWidget.cpp
 	gui/widgets/EffectRackView.cpp
 	gui/widgets/EffectView.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,7 +68,7 @@ SET(LMMS_SRCS
 	gui/widgets/LcdSpinBox.cpp
 	gui/widgets/LcdWidget.cpp
 	gui/widgets/LedCheckbox.cpp
-	gui/widgets/LinkedModelGroupLayout.cpp
+	gui/widgets/ControlLayout.cpp
 	gui/widgets/LinkedModelGroupViews.cpp
 	gui/widgets/MeterDialog.cpp
 	gui/widgets/MidiPortMenu.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(LMMS_SRCS
 	gui/widgets/LcdSpinBox.cpp
 	gui/widgets/LcdWidget.cpp
 	gui/widgets/LedCheckbox.cpp
+	gui/widgets/LinkedModelGroupViews.cpp
 	gui/widgets/MeterDialog.cpp
 	gui/widgets/MidiPortMenu.cpp
 	gui/widgets/NStateButton.cpp

--- a/src/gui/widgets/ControlLayout.cpp
+++ b/src/gui/widgets/ControlLayout.cpp
@@ -87,6 +87,7 @@ ControlLayout::ControlLayout(QWidget *parent, int margin, int hSpacing, int vSpa
 {
 	setContentsMargins(margin, margin, margin, margin);
 	m_searchBar->setPlaceholderText("filter");
+	m_searchBar->setObjectName(s_searchBarName);
 	connect(m_searchBar, SIGNAL(textChanged(const QString&)),
 		this, SLOT(onTextChanged(const QString& )));
 	addWidget(m_searchBar);
@@ -140,9 +141,17 @@ QMap<QString, QLayoutItem*>::const_iterator
 ControlLayout::pairAt(int index) const
 {
 	if (index < 0) { return m_itemMap.cend(); }
+
+	auto skip = [&](QLayoutItem* item) -> bool
+	{
+		return item->widget()->objectName() == s_searchBarName;
+	};
+
 	QMap<QString, QLayoutItem*>::const_iterator itr = m_itemMap.cbegin();
-	++itr; // skip search bar
-	while (index-->0 && itr != m_itemMap.cend()) { ++itr; }
+	for (; itr != m_itemMap.cend() && (index > 0 || skip(itr.value())); ++itr)
+	{
+		if(!skip(itr.value())) { index--; }
+	}
 	return itr;
 }
 

--- a/src/gui/widgets/ControlLayout.cpp
+++ b/src/gui/widgets/ControlLayout.cpp
@@ -139,8 +139,7 @@ int ControlLayout::count() const
 QMap<QString, QLayoutItem*>::const_iterator
 ControlLayout::pairAt(int index) const
 {
-	if (index < 0)
-		return m_itemMap.cend();
+	if (index < 0) { return m_itemMap.cend(); }
 	QMap<QString, QLayoutItem*>::const_iterator itr = m_itemMap.cbegin();
 	++itr; // skip search bar
 	while (index-->0 && itr != m_itemMap.cend()) { ++itr; }
@@ -151,7 +150,7 @@ ControlLayout::pairAt(int index) const
 QLayoutItem *ControlLayout::itemAt(int index) const
 {
 	auto itr = pairAt(index);
-	return itr == m_itemMap.end() ? nullptr : itr.value();
+	return (itr == m_itemMap.end()) ? nullptr : itr.value();
 }
 
 QLayoutItem *ControlLayout::itemByString(const QString &key) const
@@ -231,12 +230,11 @@ int ControlLayout::doLayout(const QRect &rect, bool testOnly) const
 		itr.next();
 		QLayoutItem* item = itr.value();
 		QWidget *wid = item->widget();
-
-		if (first || // do not filter search bar
-			filterText.isEmpty() || // no filter - pass all
-			itr.key().contains(filterText, Qt::CaseInsensitive))
+		if (wid)
 		{
-			if (wid)
+			if (	first || // do not filter search bar
+				filterText.isEmpty() || // no filter - pass all
+				itr.key().contains(filterText, Qt::CaseInsensitive))
 			{
 				if (first)
 				{
@@ -277,10 +275,10 @@ int ControlLayout::doLayout(const QRect &rect, bool testOnly) const
 				lineHeight = qMax(lineHeight, item->sizeHint().height());
 				first = false;
 			}
-		}
-		else
-		{
-			if (wid) { wid->hide(); }
+			else
+			{
+				wid->hide();
+			}
 		}
 	}
 	return y + lineHeight - rect.y() + bottom;

--- a/src/gui/widgets/ControlLayout.cpp
+++ b/src/gui/widgets/ControlLayout.cpp
@@ -1,5 +1,5 @@
 /*
- * LinkedModelGroups.cpp - implementation for LinkedModelGroups.h
+ * ControlLayout.cpp - implementation for ControlLayout.h
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -71,7 +71,7 @@
 ****************************************************************************/
 
 
-#include "LinkedModelGroupLayout.h"
+#include "ControlLayout.h"
 
 #include <QWidget>
 #include <QLayoutItem>
@@ -79,11 +79,9 @@
 #include <QRect>
 #include <QString>
 
-// TODO: rename: ModelGroupLayout
+constexpr const int ControlLayout::m_minWidth;
 
-constexpr const int LinkedModelGroupLayout::m_minWidth;
-
-LinkedModelGroupLayout::LinkedModelGroupLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+ControlLayout::ControlLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
 	: QLayout(parent), m_hSpace(hSpacing), m_vSpace(vSpacing),
 	  m_searchBar(new QLineEdit(parent))
 {
@@ -95,19 +93,19 @@ LinkedModelGroupLayout::LinkedModelGroupLayout(QWidget *parent, int margin, int 
 	m_searchBar->setHidden(true); // nothing to filter yet
 }
 
-LinkedModelGroupLayout::~LinkedModelGroupLayout()
+ControlLayout::~ControlLayout()
 {
 	QLayoutItem *item;
 	while ((item = takeAt(0))) { delete item; }
 }
 
-void LinkedModelGroupLayout::onTextChanged(const QString&)
+void ControlLayout::onTextChanged(const QString&)
 {
 	invalidate();
 	update();
 }
 
-void LinkedModelGroupLayout::addItem(QLayoutItem *item)
+void ControlLayout::addItem(QLayoutItem *item)
 {
 	QWidget* widget = item->widget();
 	const QString str = widget ? widget->objectName() : QString("unnamed");
@@ -115,7 +113,7 @@ void LinkedModelGroupLayout::addItem(QLayoutItem *item)
 	invalidate();
 }
 
-int LinkedModelGroupLayout::horizontalSpacing() const
+int ControlLayout::horizontalSpacing() const
 {
 	if (m_hSpace >= 0) { return m_hSpace; }
 	else
@@ -124,7 +122,7 @@ int LinkedModelGroupLayout::horizontalSpacing() const
 	}
 }
 
-int LinkedModelGroupLayout::verticalSpacing() const
+int ControlLayout::verticalSpacing() const
 {
 	if (m_vSpace >= 0) { return m_vSpace; }
 	else
@@ -133,13 +131,13 @@ int LinkedModelGroupLayout::verticalSpacing() const
 	}
 }
 
-int LinkedModelGroupLayout::count() const
+int ControlLayout::count() const
 {
 	return m_itemMap.size() - 1;
 }
 
 QMap<QString, QLayoutItem*>::const_iterator
-LinkedModelGroupLayout::pairAt(int index) const
+ControlLayout::pairAt(int index) const
 {
 	if (index < 0)
 		return m_itemMap.cend();
@@ -150,53 +148,53 @@ LinkedModelGroupLayout::pairAt(int index) const
 }
 
 // linear time :-(
-QLayoutItem *LinkedModelGroupLayout::itemAt(int index) const
+QLayoutItem *ControlLayout::itemAt(int index) const
 {
 	auto itr = pairAt(index);
 	return itr == m_itemMap.end() ? nullptr : itr.value();
 }
 
-QLayoutItem *LinkedModelGroupLayout::itemByString(const QString &key) const
+QLayoutItem *ControlLayout::itemByString(const QString &key) const
 {
 	auto itr = m_itemMap.find(key);
 	return (itr == m_itemMap.end()) ? nullptr : *itr;
 }
 
 // linear time :-(
-QLayoutItem *LinkedModelGroupLayout::takeAt(int index)
+QLayoutItem *ControlLayout::takeAt(int index)
 {
 	auto itr = pairAt(index);
 	return (itr == m_itemMap.end()) ? nullptr : m_itemMap.take(itr.key());
 }
 
-Qt::Orientations LinkedModelGroupLayout::expandingDirections() const
+Qt::Orientations ControlLayout::expandingDirections() const
 {
 	return Qt::Orientations();
 }
 
-bool LinkedModelGroupLayout::hasHeightForWidth() const
+bool ControlLayout::hasHeightForWidth() const
 {
 	return true;
 }
 
-int LinkedModelGroupLayout::heightForWidth(int width) const
+int ControlLayout::heightForWidth(int width) const
 {
 	int height = doLayout(QRect(0, 0, width, 0), true);
 	return height;
 }
 
-void LinkedModelGroupLayout::setGeometry(const QRect &rect)
+void ControlLayout::setGeometry(const QRect &rect)
 {
 	QLayout::setGeometry(rect);
 	doLayout(rect, false);
 }
 
-QSize LinkedModelGroupLayout::sizeHint() const
+QSize ControlLayout::sizeHint() const
 {
 	return minimumSize();
 }
 
-QSize LinkedModelGroupLayout::minimumSize() const
+QSize ControlLayout::minimumSize() const
 {
 	// original formula from Qt's FlowLayout example:
 	// get maximum height and width for all children.
@@ -215,7 +213,7 @@ QSize LinkedModelGroupLayout::minimumSize() const
 	return size;
 }
 
-int LinkedModelGroupLayout::doLayout(const QRect &rect, bool testOnly) const
+int ControlLayout::doLayout(const QRect &rect, bool testOnly) const
 {
 	int left, top, right, bottom;
 	getContentsMargins(&left, &top, &right, &bottom);
@@ -288,7 +286,7 @@ int LinkedModelGroupLayout::doLayout(const QRect &rect, bool testOnly) const
 	return y + lineHeight - rect.y() + bottom;
 }
 
-int LinkedModelGroupLayout::smartSpacing(QStyle::PixelMetric pm) const
+int ControlLayout::smartSpacing(QStyle::PixelMetric pm) const
 {
 	QObject *parent = this->parent();
 	if (!parent) { return -1; }

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -1,0 +1,126 @@
+/*
+ * Controls.cpp - labeled control widgets
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "Controls.h"
+
+#include <QLabel>
+#include <QString>
+#include <QVBoxLayout>
+
+#include "ComboBox.h"
+#include "LcdSpinBox.h"
+#include "LedCheckbox.h"
+#include "Knob.h"
+
+
+
+
+ControlBase::~ControlBase() {}
+
+
+
+
+void KnobControl::setText(const QString &text) { m_knob->setLabel(text); }
+
+QWidget *KnobControl::topWidget() { return m_knob; }
+
+void KnobControl::setModel(AutomatableModel *model)
+{
+	m_knob->setModel(model->dcast<FloatModel>(true));
+}
+
+FloatModel *KnobControl::model() { return m_knob->model(); }
+
+KnobControl::KnobControl(QWidget *parent) :
+	m_knob(new Knob(parent)) {}
+
+KnobControl::~KnobControl() {}
+
+
+
+
+void ComboControl::setText(const QString &text) { m_label->setText(text); }
+
+void ComboControl::setModel(AutomatableModel *model) {
+	m_combo->setModel(model->dcast<ComboBoxModel>(true)); }
+
+ComboBoxModel *ComboControl::model() { return m_combo->model(); }
+
+ComboControl::ComboControl(QWidget *parent) :
+	m_widget(new QWidget(parent)),
+	m_combo(new ComboBox(nullptr)),
+	m_label(new QLabel(m_widget))
+{
+	m_combo->setFixedSize(64, 22);
+	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	vbox->addWidget(m_combo);
+	vbox->addWidget(m_label);
+	m_combo->repaint();
+}
+
+ComboControl::~ComboControl() {}
+
+
+
+
+void CheckControl::setText(const QString &text) { m_label->setText(text); }
+
+QWidget *CheckControl::topWidget() { return m_widget; }
+
+void CheckControl::setModel(AutomatableModel *model) {
+	m_checkBox->setModel(model->dcast<BoolModel>(true)); }
+
+BoolModel *CheckControl::model() { return m_checkBox->model(); }
+
+CheckControl::CheckControl(QWidget *parent) :
+	m_widget(new QWidget(parent)),
+	m_checkBox(new LedCheckBox(nullptr, QString(), LedCheckBox::Green)),
+	m_label(new QLabel(m_widget))
+{
+	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	vbox->addWidget(m_checkBox);
+	vbox->addWidget(m_label);
+}
+
+CheckControl::~CheckControl() {}
+
+
+
+
+void LcdControl::setText(const QString &text) { m_lcd->setLabel(text); }
+
+QWidget *LcdControl::topWidget() { return m_lcd; }
+
+void LcdControl::setModel(AutomatableModel *model) {
+	m_lcd->setModel(model->dcast<IntModel>(true)); }
+
+IntModel *LcdControl::model() { return m_lcd->model(); }
+
+LcdControl::LcdControl(int numDigits, QWidget *parent) :
+	m_lcd(new LcdSpinBox(numDigits, parent))
+{
+}
+
+LcdControl::~LcdControl() {}
+

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -62,8 +62,10 @@ KnobControl::~KnobControl() {}
 
 void ComboControl::setText(const QString &text) { m_label->setText(text); }
 
-void ComboControl::setModel(AutomatableModel *model) {
-	m_combo->setModel(model->dynamicCast<ComboBoxModel>(true)); }
+void ComboControl::setModel(AutomatableModel *model)
+{
+	m_combo->setModel(model->dynamicCast<ComboBoxModel>(true));
+}
 
 ComboBoxModel *ComboControl::model() { return m_combo->model(); }
 
@@ -88,8 +90,10 @@ void CheckControl::setText(const QString &text) { m_label->setText(text); }
 
 QWidget *CheckControl::topWidget() { return m_widget; }
 
-void CheckControl::setModel(AutomatableModel *model) {
-	m_checkBox->setModel(model->dynamicCast<BoolModel>(true)); }
+void CheckControl::setModel(AutomatableModel *model)
+{
+	m_checkBox->setModel(model->dynamicCast<BoolModel>(true));
+}
 
 BoolModel *CheckControl::model() { return m_checkBox->model(); }
 
@@ -112,8 +116,10 @@ void LcdControl::setText(const QString &text) { m_lcd->setLabel(text); }
 
 QWidget *LcdControl::topWidget() { return m_lcd; }
 
-void LcdControl::setModel(AutomatableModel *model) {
-	m_lcd->setModel(model->dynamicCast<IntModel>(true)); }
+void LcdControl::setModel(AutomatableModel *model)
+{
+	m_lcd->setModel(model->dynamicCast<IntModel>(true));
+}
 
 IntModel *LcdControl::model() { return m_lcd->model(); }
 

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -47,7 +47,7 @@ QWidget *KnobControl::topWidget() { return m_knob; }
 
 void KnobControl::setModel(AutomatableModel *model)
 {
-	m_knob->setModel(model->dcast<FloatModel>(true));
+	m_knob->setModel(model->dynamicCast<FloatModel>(true));
 }
 
 FloatModel *KnobControl::model() { return m_knob->model(); }
@@ -63,7 +63,7 @@ KnobControl::~KnobControl() {}
 void ComboControl::setText(const QString &text) { m_label->setText(text); }
 
 void ComboControl::setModel(AutomatableModel *model) {
-	m_combo->setModel(model->dcast<ComboBoxModel>(true)); }
+	m_combo->setModel(model->dynamicCast<ComboBoxModel>(true)); }
 
 ComboBoxModel *ComboControl::model() { return m_combo->model(); }
 
@@ -89,7 +89,7 @@ void CheckControl::setText(const QString &text) { m_label->setText(text); }
 QWidget *CheckControl::topWidget() { return m_widget; }
 
 void CheckControl::setModel(AutomatableModel *model) {
-	m_checkBox->setModel(model->dcast<BoolModel>(true)); }
+	m_checkBox->setModel(model->dynamicCast<BoolModel>(true)); }
 
 BoolModel *CheckControl::model() { return m_checkBox->model(); }
 
@@ -113,7 +113,7 @@ void LcdControl::setText(const QString &text) { m_lcd->setLabel(text); }
 QWidget *LcdControl::topWidget() { return m_lcd; }
 
 void LcdControl::setModel(AutomatableModel *model) {
-	m_lcd->setModel(model->dcast<IntModel>(true)); }
+	m_lcd->setModel(model->dynamicCast<IntModel>(true)); }
 
 IntModel *LcdControl::model() { return m_lcd->model(); }
 

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -52,6 +52,8 @@ void KnobControl::setModel(AutomatableModel *model)
 
 FloatModel *KnobControl::model() { return m_knob->model(); }
 
+AutomatableModelView* KnobControl::modelView() { return m_knob; }
+
 KnobControl::KnobControl(QWidget *parent) :
 	m_knob(new Knob(parent)) {}
 
@@ -68,6 +70,8 @@ void ComboControl::setModel(AutomatableModel *model)
 }
 
 ComboBoxModel *ComboControl::model() { return m_combo->model(); }
+
+AutomatableModelView* ComboControl::modelView() { return m_combo; }
 
 ComboControl::ComboControl(QWidget *parent) :
 	m_widget(new QWidget(parent)),
@@ -97,6 +101,8 @@ void CheckControl::setModel(AutomatableModel *model)
 
 BoolModel *CheckControl::model() { return m_checkBox->model(); }
 
+AutomatableModelView* CheckControl::modelView() { return m_checkBox; }
+
 CheckControl::CheckControl(QWidget *parent) :
 	m_widget(new QWidget(parent)),
 	m_checkBox(new LedCheckBox(nullptr, QString(), LedCheckBox::Green)),
@@ -122,6 +128,8 @@ void LcdControl::setModel(AutomatableModel *model)
 }
 
 IntModel *LcdControl::model() { return m_lcd->model(); }
+
+AutomatableModelView* LcdControl::modelView() { return m_lcd; }
 
 LcdControl::LcdControl(int numDigits, QWidget *parent) :
 	m_lcd(new LcdSpinBox(numDigits, parent))

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -36,7 +36,7 @@
 
 
 
-ControlBase::~ControlBase() {}
+Control::~Control() {}
 
 
 

--- a/src/gui/widgets/LinkedModelGroupLayout.cpp
+++ b/src/gui/widgets/LinkedModelGroupLayout.cpp
@@ -1,0 +1,305 @@
+/*
+ * LinkedModelGroups.cpp - implementation for LinkedModelGroups.h
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+/****************************************************************************
+**
+** Copyright (C) 2016 The Qt Company Ltd.
+** Contact: https://www.qt.io/licensing/
+**
+** $QT_BEGIN_LICENSE:BSD$
+** Commercial License Usage
+** Licensees holding valid commercial Qt licenses may use this file in
+** accordance with the commercial license agreement provided with the
+** Software or, alternatively, in accordance with the terms contained in
+** a written agreement between you and The Qt Company. For licensing terms
+** and conditions see https://www.qt.io/terms-conditions. For further
+** information use the contact form at https://www.qt.io/contact-us.
+**
+** BSD License Usage
+** Alternatively, you may use this file under the terms of the BSD license
+** as follows:
+**
+** "Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions are
+** met:
+**   * Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**   * Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in
+**     the documentation and/or other materials provided with the
+**     distribution.
+**   * Neither the name of The Qt Company Ltd nor the names of its
+**     contributors may be used to endorse or promote products derived
+**     from this software without specific prior written permission.
+**
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+** "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+** LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+** A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+** OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+**
+** $QT_END_LICENSE$
+**
+****************************************************************************/
+
+
+#include "LinkedModelGroupLayout.h"
+
+#include <QWidget>
+#include <QLayoutItem>
+#include <QLineEdit>
+#include <QRect>
+#include <QString>
+
+// TODO: rename: ModelGroupLayout
+
+constexpr const int LinkedModelGroupLayout::m_minWidth;
+
+LinkedModelGroupLayout::LinkedModelGroupLayout(QWidget *parent, int margin, int hSpacing, int vSpacing)
+	: QLayout(parent), m_hSpace(hSpacing), m_vSpace(vSpacing),
+	  m_searchBar(new QLineEdit(parent))
+{
+	setContentsMargins(margin, margin, margin, margin);
+	m_searchBar->setPlaceholderText("filter");
+	connect(m_searchBar, SIGNAL(textChanged(const QString&)),
+		this, SLOT(onTextChanged(const QString& )));
+	addWidget(m_searchBar);
+	m_searchBar->setHidden(true); // nothing to filter yet
+}
+
+LinkedModelGroupLayout::~LinkedModelGroupLayout()
+{
+	QLayoutItem *item;
+	while ((item = takeAt(0))) { delete item; }
+}
+
+void LinkedModelGroupLayout::onTextChanged(const QString&)
+{
+	invalidate();
+	update();
+}
+#include <QDebug>
+void LinkedModelGroupLayout::addItem(QLayoutItem *item)
+{
+	QWidget* widget = item->widget();
+	const QString str = widget ? widget->objectName() : QString("unnamed");
+	m_itemMap.insert(str, item);
+	// if there are at least two widget + search bar, show filter
+//	if(m_itemMap.size() > 2) { m_searchBar->setVisible(true); Q_ASSERT(false); qDebug() << "NO"; }
+	invalidate();
+}
+
+int LinkedModelGroupLayout::horizontalSpacing() const
+{
+	if (m_hSpace >= 0) { return m_hSpace; }
+	else
+	{
+		return smartSpacing(QStyle::PM_LayoutHorizontalSpacing);
+	}
+}
+
+int LinkedModelGroupLayout::verticalSpacing() const
+{
+	if (m_vSpace >= 0) { return m_vSpace; }
+	else
+	{
+		return smartSpacing(QStyle::PM_LayoutVerticalSpacing);
+	}
+}
+
+int LinkedModelGroupLayout::count() const
+{
+	return m_itemMap.size() - 1;
+}
+
+QMap<QString, QLayoutItem*>::const_iterator
+LinkedModelGroupLayout::pairAt(int index) const
+{
+	if(index < 0)
+		return m_itemMap.cend();
+	QMap<QString, QLayoutItem*>::const_iterator itr = m_itemMap.cbegin();
+	++itr; // skip search bar
+	while(index-->0 && itr != m_itemMap.cend()) { ++itr; }
+	return itr;
+}
+
+// linear time :-(
+QLayoutItem *LinkedModelGroupLayout::itemAt(int index) const
+{
+	auto itr = pairAt(index);
+	return itr == m_itemMap.end() ? nullptr : itr.value();
+}
+
+QLayoutItem *LinkedModelGroupLayout::itemByString(const QString &key) const
+{
+	auto itr = m_itemMap.find(key);
+	return (itr == m_itemMap.end()) ? nullptr : *itr;
+}
+
+// linear time :-(
+QLayoutItem *LinkedModelGroupLayout::takeAt(int index)
+{
+	auto itr = pairAt(index);
+	return (itr == m_itemMap.end()) ? nullptr : m_itemMap.take(itr.key());
+}
+
+Qt::Orientations LinkedModelGroupLayout::expandingDirections() const
+{
+	return Qt::Orientations();
+}
+
+bool LinkedModelGroupLayout::hasHeightForWidth() const
+{
+	return true;
+}
+
+int LinkedModelGroupLayout::heightForWidth(int width) const
+{
+	int height = doLayout(QRect(0, 0, width, 0), true);
+	return height;
+}
+
+void LinkedModelGroupLayout::setGeometry(const QRect &rect)
+{
+	QLayout::setGeometry(rect);
+	doLayout(rect, false);
+}
+
+QSize LinkedModelGroupLayout::sizeHint() const
+{
+	return minimumSize();
+}
+
+QSize LinkedModelGroupLayout::minimumSize() const
+{
+	// original formula from Qt's FlowLayout example:
+	// get maximum height and width for all children.
+	// as Qt will later call heightForWidth, only the width here really matters
+	QSize size;
+	for (const QLayoutItem *item : qAsConst(m_itemMap))
+	{
+		size = size.expandedTo(item->minimumSize());
+	}
+	const QMargins margins = contentsMargins();
+	size += QSize(margins.left() + margins.right(), margins.top() + margins.bottom());
+
+	// the original formula would leed to ~1 widget per row
+	// bash it at least to 400 so we have ~4 knobs per row
+	size.setWidth(qMax(size.width(), m_minWidth));
+	return size;
+}
+
+int LinkedModelGroupLayout::doLayout(const QRect &rect, bool testOnly) const
+{
+	int left, top, right, bottom;
+	getContentsMargins(&left, &top, &right, &bottom);
+	QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+	int x = effectiveRect.x();
+	int y = effectiveRect.y();
+	int lineHeight = 0;
+
+	const QString filterText = m_searchBar->text();
+	bool first = true;
+
+	QMapIterator<QString, QLayoutItem*> itr(m_itemMap);
+	while (itr.hasNext())
+	{
+		itr.next();
+		QLayoutItem* item = itr.value();
+		QWidget *wid = item->widget();
+
+		if (first || // do not filter search bar
+			filterText.isEmpty() || // no filter - pass all
+			itr.key().contains(filterText, Qt::CaseInsensitive))
+		{
+			if(wid)
+			{
+				if(first)
+				{
+					// for the search bar, only show it if there are at least
+					// two control widgets (i.e. at least 3 widgets)
+					if(m_itemMap.size() > 2) { wid->show(); }
+					else { wid->hide(); }
+				}
+				else { wid->show(); }
+
+				int spaceX = horizontalSpacing();
+				if (spaceX == -1)
+				{
+					spaceX = wid->style()->layoutSpacing(
+						QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Horizontal);
+				}
+				int spaceY = verticalSpacing();
+				if (spaceY == -1)
+				{
+					spaceY = wid->style()->layoutSpacing(
+						QSizePolicy::PushButton, QSizePolicy::PushButton, Qt::Vertical);
+				}
+				int nextX = x + item->sizeHint().width() + spaceX;
+				if (nextX - spaceX > effectiveRect.right() && lineHeight > 0)
+				{
+					x = effectiveRect.x();
+					y = y + lineHeight + spaceY;
+					nextX = x + item->sizeHint().width() + spaceX;
+					lineHeight = 0;
+				}
+
+				if (!testOnly)
+				{
+					item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+				}
+
+				x = nextX;
+				lineHeight = qMax(lineHeight, item->sizeHint().height());
+				first = false;
+			}
+		}
+		else
+		{
+			if(wid) { wid->hide(); }
+		}
+	}
+	return y + lineHeight - rect.y() + bottom;
+}
+
+int LinkedModelGroupLayout::smartSpacing(QStyle::PixelMetric pm) const
+{
+	QObject *parent = this->parent();
+	if (!parent) { return -1; }
+	else if (parent->isWidgetType())
+	{
+		QWidget *pw = static_cast<QWidget *>(parent);
+		return pw->style()->pixelMetric(pm, nullptr, pw);
+	}
+	else { return static_cast<QLayout *>(parent)->spacing(); }
+}
+
+

--- a/src/gui/widgets/LinkedModelGroupLayout.cpp
+++ b/src/gui/widgets/LinkedModelGroupLayout.cpp
@@ -106,14 +106,12 @@ void LinkedModelGroupLayout::onTextChanged(const QString&)
 	invalidate();
 	update();
 }
-#include <QDebug>
+
 void LinkedModelGroupLayout::addItem(QLayoutItem *item)
 {
 	QWidget* widget = item->widget();
 	const QString str = widget ? widget->objectName() : QString("unnamed");
 	m_itemMap.insert(str, item);
-	// if there are at least two widget + search bar, show filter
-//	if(m_itemMap.size() > 2) { m_searchBar->setVisible(true); Q_ASSERT(false); qDebug() << "NO"; }
 	invalidate();
 }
 
@@ -143,11 +141,11 @@ int LinkedModelGroupLayout::count() const
 QMap<QString, QLayoutItem*>::const_iterator
 LinkedModelGroupLayout::pairAt(int index) const
 {
-	if(index < 0)
+	if (index < 0)
 		return m_itemMap.cend();
 	QMap<QString, QLayoutItem*>::const_iterator itr = m_itemMap.cbegin();
 	++itr; // skip search bar
-	while(index-->0 && itr != m_itemMap.cend()) { ++itr; }
+	while (index-->0 && itr != m_itemMap.cend()) { ++itr; }
 	return itr;
 }
 
@@ -240,13 +238,13 @@ int LinkedModelGroupLayout::doLayout(const QRect &rect, bool testOnly) const
 			filterText.isEmpty() || // no filter - pass all
 			itr.key().contains(filterText, Qt::CaseInsensitive))
 		{
-			if(wid)
+			if (wid)
 			{
-				if(first)
+				if (first)
 				{
 					// for the search bar, only show it if there are at least
 					// two control widgets (i.e. at least 3 widgets)
-					if(m_itemMap.size() > 2) { wid->show(); }
+					if (m_itemMap.size() > 2) { wid->show(); }
 					else { wid->hide(); }
 				}
 				else { wid->show(); }
@@ -284,7 +282,7 @@ int LinkedModelGroupLayout::doLayout(const QRect &rect, bool testOnly) const
 		}
 		else
 		{
-			if(wid) { wid->hide(); }
+			if (wid) { wid->hide(); }
 		}
 	}
 	return y + lineHeight - rect.y() + bottom;

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -1,0 +1,189 @@
+/*
+ * LinkedModelGroupViews.h - views for groups of linkable models
+ *
+ * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "LinkedModelGroupViews.h"
+
+#include <QGridLayout>
+
+#include "Controls.h"
+#include "LedCheckbox.h"
+#include "LinkedModelGroups.h"
+
+
+/*
+	LinkedModelGroupViewBase
+*/
+
+
+LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
+	bool isLinking, int colNum, int curProc, int nProc, const QString& name) :
+	QGroupBox(parent),
+	m_colNum(colNum),
+	m_isLinking(isLinking),
+	m_grid(new QGridLayout(this))
+{
+	QString chanName;
+	if(name.isNull())
+	{
+		switch(nProc)
+		{
+			case 1: break; // don't display any channel name
+			case 2:
+				chanName = QObject::tr(curProc ? "Right" : "Left");
+				break;
+			default:
+				chanName = QObject::tr("Channel ") + QString::number(curProc + 1);
+				break;
+		}
+	}
+	else {
+		chanName = name;
+	}
+
+	if(!chanName.isNull()) { setTitle(chanName); }
+}
+
+
+
+
+LinkedModelGroupViewBase::~LinkedModelGroupViewBase() {}
+
+
+
+
+void LinkedModelGroupViewBase::modelChanged(LinkedModelGroup *group)
+{
+	// reconnect models
+	QVector<ControlBase*>::Iterator itr = m_controls.begin();
+	std::vector<AutomatableModel*> models = group->models();
+	Q_ASSERT(m_controls.size() == static_cast<int>(models.size()));
+
+	for(AutomatableModel* mdl : models)
+	{
+		(*itr++)->setModel(mdl);
+	}
+
+	std::size_t count = 0;
+	for (LedCheckBox* led : m_leds)
+	{
+		led->setModel(group->linkEnabledModel(count++));
+	}
+}
+
+
+
+
+void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
+{
+	int colNum2 = m_colNum * (1 + m_isLinking);
+	int wdgNum = m_controls.size() * (1 + m_isLinking);
+	if(ctrl)
+	{
+		int x = wdgNum%colNum2, y = wdgNum/colNum2;
+
+		// start in row one, add widgets cell by cell
+		if(m_isLinking) {
+			LedCheckBox* cb = new LedCheckBox(nullptr);
+			m_grid->addWidget(cb, y, x);
+			m_leds.push_back(cb);
+		}
+
+		m_controls.push_back(ctrl);
+		m_grid->addWidget(ctrl->topWidget(), y, x + 1, Qt::AlignCenter);
+		wdgNum += m_isLinking;
+		++wdgNum;
+	}
+
+	// matter of taste (takes a lot of space):
+	// makeAllGridCellsEqualSized();
+}
+
+
+
+
+void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
+{
+	int rowHeight = 0, colWidth = 0;
+	for(int row = 0; row < m_grid->rowCount(); ++row)
+	{
+		for(int col = 0; col < m_grid->columnCount(); ++col)
+		{
+			QLayoutItem* layout;
+			if((layout = m_grid->itemAtPosition(row, col)))
+			{
+				rowHeight = qMax(rowHeight, layout->geometry().height());
+				colWidth = qMax(colWidth, layout->geometry().width());
+			}
+		}
+	}
+
+	for(int row = 0; row < m_grid->rowCount(); ++row)
+	{
+		m_grid->setRowMinimumHeight(row, rowHeight);
+	}
+
+	for(int col = 0; col < m_grid->columnCount(); ++col)
+	{
+		m_grid->setColumnMinimumWidth(col, colWidth);
+	}
+}
+
+
+/*
+	LinkedModelGroupsViewBase
+*/
+
+
+LinkedModelGroupsViewBase::LinkedModelGroupsViewBase(
+	LinkedModelGroups *ctrlBase)
+{
+	if(ctrlBase->multiChannelLinkModel())
+	{
+		m_multiChannelLink = new LedCheckBox(QObject::tr("Link Channels"),
+												nullptr);
+	}
+}
+
+
+
+
+LinkedModelGroupsViewBase::~LinkedModelGroupsViewBase() {}
+
+
+
+
+void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
+{
+	if(groups->multiChannelLinkModel())
+	{
+		m_multiChannelLink->setModel(groups->multiChannelLinkModel());
+	}
+
+	for(std::size_t i = 0; getGroupView(i) && groups->getGroup(i); ++i)
+	{
+		getGroupView(i)->modelChanged(groups->getGroup(i));
+	}
+}
+
+

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -44,7 +44,7 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	m_isLinking(model->isLinking()),
 	m_grid(new QGridLayout(this))
 {
-	if (model->models().size())
+	if (model->modelNum())
 	{
 		std::size_t curProc = model->curProc();
 		QString chanName;
@@ -81,13 +81,11 @@ LinkedModelGroupView::~LinkedModelGroupView() {}
 void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 {
 	// reconnect models
-	using ModelInfo = LinkedModelGroup::ModelInfo;
-	std::vector<ModelInfo> models = group->models();
-	Q_ASSERT(m_controls.size() == models.size());
+	Q_ASSERT(m_controls.size() == group->modelNum());
 
-	for (std::size_t i = 0; i < models.size(); ++i)
+	for (std::size_t i = 0; i < group->modelNum(); ++i)
 	{
-		m_controls[i]->setModel(models[i].m_model);
+		m_controls[i]->setModel(group->model(i));
 	}
 
 	for (std::size_t i = 0; i < m_leds.size(); ++i)

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -1,5 +1,5 @@
 /*
- * LinkedModelGroupViews.h - views for groups of linkable models
+ * LinkedModelGroupViews.h - view for groups of linkable models
  *
  * Copyright (c) 2019-2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
  *
@@ -74,7 +74,7 @@ void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 		}
 		else
 		{
-			itr->second.m_ctrl->setModel(minf.m_model);
+			itr->second->setModel(minf.m_model);
 		}
 	});
 
@@ -93,10 +93,6 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 		QWidget* box = new QWidget(this);
 		QHBoxLayout* boxLayout = new QHBoxLayout(box);
 
-		// book-keeper of widget pointers
-		WidgetsPerModel widgets;
-
-		widgets.m_ctrl.reset(ctrl);
 		boxLayout->addWidget(ctrl->topWidget());
 
 		if (removable)
@@ -120,14 +116,11 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 		box->setObjectName(QString::fromStdString(display));
 		m_layout->addWidget(box);
 
-		m_widgets.emplace(id, std::move(widgets)); // TODO: use set?
+		m_widgets.emplace(id, ctrl); // TODO: use set?
 		++wdgNum;
 	}
 
-	if(isHidden()) { setHidden(false); }
-
-	// matter of taste (takes a lot of space):
-	// makeAllGridCellsEqualSized();
+	if(isHidden()) { setHidden(false); } // TODO: can be removed?
 }
 
 
@@ -152,38 +145,6 @@ void LinkedModelGroupView::removeControl(const QString& key)
 		// repaint immediately, so we don't have dangling model views
 		m_layout->update();
 	}
-}
-
-
-
-
-void LinkedModelGroupView::makeAllGridCellsEqualSized()
-{
-#if 0
-	int rowHeight = 0, colWidth = 0;
-	for (int row = 0; row < m_layout->rowCount(); ++row)
-	{
-		for (int col = 0; col < m_layout->columnCount(); ++col)
-		{
-			QLayoutItem* layout;
-			if ((layout = m_layout->itemAtPosition(row, col)))
-			{
-				rowHeight = qMax(rowHeight, layout->geometry().height());
-				colWidth = qMax(colWidth, layout->geometry().width());
-			}
-		}
-	}
-
-	for (int row = 0; row < m_layout->rowCount(); ++row)
-	{
-		m_layout->setRowMinimumHeight(row, rowHeight);
-	}
-
-	for (int col = 0; col < m_layout->columnCount(); ++col)
-	{
-		m_layout->setColumnMinimumWidth(col, colWidth);
-	}
-#endif
 }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -173,7 +173,7 @@ void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
 		m_multiChannelLink->setModel(groups->multiChannelLinkModel());
 	}
 
-	for (std::size_t i = 0; getGroupView(i) && groups->getGroup(i); ++i)
+	for (std::size_t i = 0; groups->getGroup(i) && getGroupView(i); ++i)
 	{
 		getGroupView(i)->modelChanged(groups->getGroup(i));
 	}

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -43,7 +43,6 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	QGroupBox(parent),
 	m_model(model),
 	m_colNum(colNum),
-	m_isLinking(model->isLinking()),
 	m_layout(new LinkedModelGroupLayout(this))
 {
 	// make viewable: if there are no knobs, the user should at least see
@@ -101,9 +100,6 @@ void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 		else
 		{
 			itr->second.m_ctrl->setModel(minf.m_model);
-			if(itr->second.m_led) {
-				itr->second.m_led->setModel(minf.m_linkEnabled);
-			}
 		}
 	});
 
@@ -228,26 +224,8 @@ void LinkedModelGroupView::makeAllGridCellsEqualSized()
 */
 
 
-LinkedModelGroupsView::LinkedModelGroupsView(
-	LinkedModelGroups *ctrlBase)
-{
-	if (ctrlBase->multiChannelLinkModel())
-	{
-		m_multiChannelLink = make_unique<LedCheckBox, MultiChannelLinkDeleter>
-								(QObject::tr("Link Channels"), nullptr);
-	}
-}
-
-
-
-
 void LinkedModelGroupsView::modelChanged(LinkedModelGroups *groups)
 {
-	if (groups->multiChannelLinkModel())
-	{
-		m_multiChannelLink->setModel(groups->multiChannelLinkModel());
-	}
-
 	LinkedModelGroupView* groupView;
 	LinkedModelGroup* group;
 	for (std::size_t i = 0;

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -78,11 +78,12 @@ LinkedModelGroupViewBase::~LinkedModelGroupViewBase() {}
 void LinkedModelGroupViewBase::modelChanged(LinkedModelGroup *group)
 {
 	// reconnect models
+	using ModelInfo = LinkedModelGroup::ModelInfo;
 	std::vector<std::unique_ptr<ControlBase>>::iterator itr = m_controls.begin();
-	std::vector<AutomatableModel*> models = group->models();
+	std::vector<ModelInfo> models = group->models();
 	Q_ASSERT(m_controls.size() == models.size());
 
-	for (AutomatableModel* mdl : models) { (*itr++)->setModel(mdl); }
+	for (const ModelInfo& mdl : models) { (*itr++)->setModel(mdl.m_model); }
 
 	std::size_t count = 0;
 	for (std::unique_ptr<LedCheckBox>& led : m_leds)

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -24,13 +24,10 @@
 
 #include "LinkedModelGroupViews.h"
 
-#include <QGridLayout>
-
+#include <QPushButton>
 #include "Controls.h"
-#include "LedCheckbox.h"
 #include "LinkedModelGroupLayout.h"
 #include "LinkedModelGroups.h"
-#include "stdshims.h"
 
 
 /*
@@ -67,7 +64,7 @@ void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 		auto itr = m_widgets.find(str);
 		// in case there are new or deleted widgets, the subclass has already
 		// modified m_widgets, so this will go into the else case
-		if(itr == m_widgets.end())
+		if (itr == m_widgets.end())
 		{
 			// no widget? this can happen when the whole view is being destroyed
 			// (for some strange reasons)
@@ -92,7 +89,6 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 	{
 		QWidget* box = new QWidget(this);
 		QHBoxLayout* boxLayout = new QHBoxLayout(box);
-
 		boxLayout->addWidget(ctrl->topWidget());
 
 		if (removable)
@@ -116,11 +112,11 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 		box->setObjectName(QString::fromStdString(display));
 		m_layout->addWidget(box);
 
-		m_widgets.emplace(id, ctrl); // TODO: use set?
+		m_widgets.emplace(id, ctrl);
 		++wdgNum;
 	}
 
-	if(isHidden()) { setHidden(false); } // TODO: can be removed?
+	if (isHidden()) { setHidden(false); }
 }
 
 
@@ -129,7 +125,7 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 void LinkedModelGroupView::removeControl(const QString& key)
 {
 	auto itr = m_widgets.find(key.toStdString());
-	if(itr != m_widgets.end())
+	if (itr != m_widgets.end())
 	{
 		QLayoutItem* item = m_layout->itemByString(key);
 		Q_ASSERT(!!item);
@@ -157,7 +153,7 @@ void LinkedModelGroupsView::modelChanged(LinkedModelGroups *groups)
 {
 	LinkedModelGroupView* groupView = getGroupView();
 	LinkedModelGroup* group0 = groups->getGroup(0);
-	if(group0 && groupView)
+	if (group0 && groupView)
 	{
 		groupView->modelChanged(group0);
 	}

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -42,9 +42,6 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	m_colNum(colNum),
 	m_layout(new LinkedModelGroupLayout(this))
 {
-	// make viewable: if there are no knobs, the user should at least see
-	// a rectangle to drop controls in
-	setMinimumSize(QSize(50, 50));
 }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -43,24 +43,28 @@ LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
 	m_isLinking(model->isLinking()),
 	m_grid(new QGridLayout(this))
 {
-	int curProc = model->curProc();
-	QString chanName;
-	if (name.isNull())
+	if(model->models().size())
 	{
-		switch(nProc)
+		int curProc = model->curProc();
+		QString chanName;
+		if (name.isNull())
 		{
-			case 1: break; // don't display any channel name
-			case 2:
-				chanName = QObject::tr(curProc ? "Right" : "Left");
-				break;
-			default:
-				chanName = QObject::tr("Channel ") + QString::number(curProc + 1);
-				break;
+			switch(nProc)
+			{
+				case 1: break; // don't display any channel name
+				case 2:
+					chanName = QObject::tr(curProc ? "Right" : "Left");
+					break;
+				default:
+					chanName = QObject::tr("Channel ") + QString::number(curProc + 1);
+					break;
+			}
 		}
-	}
-	else { chanName = name; }
+		else { chanName = name; }
 
-	if (!chanName.isNull()) { setTitle(chanName); }
+		if (!chanName.isNull()) { setTitle(chanName); }
+	}
+	else { setHidden(true); }
 }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -112,7 +112,7 @@ void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 	const std::string &display, bool removable)
 {
-	int wdgNum = static_cast<int>(m_widgets.size() * (1 + m_isLinking));
+	int wdgNum = static_cast<int>(m_widgets.size());
 	if (ctrl)
 	{
 		QWidget* box = new QWidget(this);
@@ -120,12 +120,6 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 
 		// book-keeper of widget pointers
 		WidgetsPerModel widgets;
-
-		if (m_isLinking)
-		{
-			widgets.m_led = new LedCheckBox(ctrl->topWidget()->parentWidget());
-			boxLayout->addWidget(widgets.m_led);
-		}
 
 		widgets.m_ctrl.reset(ctrl);
 		boxLayout->addWidget(ctrl->topWidget());
@@ -152,7 +146,6 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 		m_layout->addWidget(box);
 
 		m_widgets.emplace(id, std::move(widgets)); // TODO: use set?
-		wdgNum += m_isLinking;
 		++wdgNum;
 	}
 
@@ -235,13 +228,5 @@ void LinkedModelGroupsView::modelChanged(LinkedModelGroups *groups)
 		groupView->modelChanged(group);
 	}
 }
-
-
-
-
-// If you wonder why the default deleter can not be used:
-// https://stackoverflow.com/questions/9954518
-void LinkedModelGroupsView::MultiChannelLinkDeleter::
-	operator()(LedCheckBox *l) { delete l; }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -43,13 +43,13 @@ LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
 	m_isLinking(model->isLinking()),
 	m_grid(new QGridLayout(this))
 {
-	if(model->models().size())
+	if (model->models().size())
 	{
 		int curProc = model->curProc();
 		QString chanName;
 		if (name.isNull())
 		{
-			switch(nProc)
+			switch (nProc)
 			{
 				case 1: break; // don't display any channel name
 				case 2:

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -28,6 +28,7 @@
 
 #include "Controls.h"
 #include "LedCheckbox.h"
+#include "LinkedModelGroupLayout.h"
 #include "LinkedModelGroups.h"
 #include "stdshims.h"
 
@@ -40,10 +41,15 @@
 LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	LinkedModelGroup *model, std::size_t colNum, std::size_t nProc, const QString& name) :
 	QGroupBox(parent),
+	m_model(model),
 	m_colNum(colNum),
 	m_isLinking(model->isLinking()),
-	m_grid(new QGridLayout(this))
+	m_layout(new LinkedModelGroupLayout(this))
 {
+	// make viewable: if there are no knobs, the user should at least see
+	// a rectangle to drop controls in
+	setMinimumSize(QSize(50, 50));
+
 	if (model->modelNum())
 	{
 		std::size_t curProc = model->curProc();
@@ -67,7 +73,7 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 
 		if (!chanName.isNull()) { setTitle(chanName); }
 	}
-	else { setHidden(true); }
+	else { /*setHidden(true);*/ }
 }
 
 
@@ -81,44 +87,80 @@ LinkedModelGroupView::~LinkedModelGroupView() {}
 void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 {
 	// reconnect models
-	Q_ASSERT(m_controls.size() == group->modelNum());
-
-	for (std::size_t i = 0; i < group->modelNum(); ++i)
+	group->foreach_model([this](const std::string& str,
+		const LinkedModelGroup::ModelInfo& minf)
 	{
-		m_controls[i]->setModel(group->model(i));
-	}
+		auto itr = m_widgets.find(str);
+		// in case there are new or deleted widgets, the subclass has already
+		// modified m_widgets, so this will go into the else case
+		if(itr == m_widgets.end())
+		{
+			// no widget? this can happen when the whole view is being destroyed
+			// (for some strange reasons)
+		}
+		else
+		{
+			itr->second.m_ctrl->setModel(minf.m_model);
+			if(itr->second.m_led) {
+				itr->second.m_led->setModel(minf.m_linkEnabled);
+			}
+		}
+	});
 
-	for (std::size_t i = 0; i < m_leds.size(); ++i)
-	{
-		m_leds[i]->setModel(group->linkEnabledModel(i));
-	}
+	m_model = group;
 }
 
 
 
 
-void LinkedModelGroupView::addControl(Control* ctrl)
+void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
+	const std::string &display, bool removable)
 {
-	int colNum2 = static_cast<int>(m_colNum * (1 + m_isLinking));
-	int wdgNum = static_cast<int>(m_controls.size() * (1 + m_isLinking));
+	int wdgNum = static_cast<int>(m_widgets.size() * (1 + m_isLinking));
 	if (ctrl)
 	{
-		int x = wdgNum%colNum2, y = wdgNum/colNum2;
+		QWidget* box = new QWidget(this);
+		QHBoxLayout* boxLayout = new QHBoxLayout(box);
 
-		// start in row one, add widgets cell by cell
+		// book-keeper of widget pointers
+		WidgetsPerModel widgets;
+
 		if (m_isLinking)
 		{
-			LedCheckBox* cb = new LedCheckBox(
-				ctrl->topWidget()->parentWidget());
-			m_grid->addWidget(cb, y, x);
-			m_leds.push_back(std::unique_ptr<LedCheckBox>(cb));
+			widgets.m_led = new LedCheckBox(ctrl->topWidget()->parentWidget());
+			boxLayout->addWidget(widgets.m_led);
 		}
 
-		m_controls.push_back(std::unique_ptr<Control>(ctrl));
-		m_grid->addWidget(ctrl->topWidget(), y, x + 1, Qt::AlignCenter);
+		widgets.m_ctrl.reset(ctrl);
+		boxLayout->addWidget(ctrl->topWidget());
+
+		if (removable)
+		{
+			QPushButton* removeBtn = new QPushButton;
+			removeBtn->setIcon( embed::getIconPixmap( "discard" ) );
+			QObject::connect(removeBtn, &QPushButton::clicked,
+				this, [this,ctrl](bool){
+					AutomatableModel* controlModel = ctrl->model();
+					// remove control out of model group
+					// (will also remove it from the UI)
+					m_model->removeControl(controlModel);
+					// delete model (includes disconnecting all connections)
+					delete controlModel;
+				},
+				Qt::DirectConnection);
+			boxLayout->addWidget(removeBtn);
+		}
+
+		// required, so the Layout knows how to sort/filter widgets by string
+		box->setObjectName(QString::fromStdString(display));
+		m_layout->addWidget(box);
+
+		m_widgets.emplace(id, std::move(widgets)); // TODO: use set?
 		wdgNum += m_isLinking;
 		++wdgNum;
 	}
+
+	if(isHidden()) { setHidden(false); }
 
 	// matter of taste (takes a lot of space):
 	// makeAllGridCellsEqualSized();
@@ -127,15 +169,40 @@ void LinkedModelGroupView::addControl(Control* ctrl)
 
 
 
+void LinkedModelGroupView::removeControl(const QString& key)
+{
+	auto itr = m_widgets.find(key.toStdString());
+	if(itr != m_widgets.end())
+	{
+		QLayoutItem* item = m_layout->itemByString(key);
+		Q_ASSERT(!!item);
+		QWidget* wdg = item->widget();
+		Q_ASSERT(!!wdg);
+
+		// remove item from layout
+		m_layout->removeItem(item);
+		// the widget still exists and is visible - remove it now
+		delete wdg;
+		// erase widget pointer from dictionary
+		m_widgets.erase(itr);
+		// repaint immediately, so we don't have dangling model views
+		m_layout->update();
+	}
+}
+
+
+
+
 void LinkedModelGroupView::makeAllGridCellsEqualSized()
 {
+#if 0
 	int rowHeight = 0, colWidth = 0;
-	for (int row = 0; row < m_grid->rowCount(); ++row)
+	for (int row = 0; row < m_layout->rowCount(); ++row)
 	{
-		for (int col = 0; col < m_grid->columnCount(); ++col)
+		for (int col = 0; col < m_layout->columnCount(); ++col)
 		{
 			QLayoutItem* layout;
-			if ((layout = m_grid->itemAtPosition(row, col)))
+			if ((layout = m_layout->itemAtPosition(row, col)))
 			{
 				rowHeight = qMax(rowHeight, layout->geometry().height());
 				colWidth = qMax(colWidth, layout->geometry().width());
@@ -143,15 +210,16 @@ void LinkedModelGroupView::makeAllGridCellsEqualSized()
 		}
 	}
 
-	for (int row = 0; row < m_grid->rowCount(); ++row)
+	for (int row = 0; row < m_layout->rowCount(); ++row)
 	{
-		m_grid->setRowMinimumHeight(row, rowHeight);
+		m_layout->setRowMinimumHeight(row, rowHeight);
 	}
 
-	for (int col = 0; col < m_grid->columnCount(); ++col)
+	for (int col = 0; col < m_layout->columnCount(); ++col)
 	{
-		m_grid->setColumnMinimumWidth(col, colWidth);
+		m_layout->setColumnMinimumWidth(col, colWidth);
 	}
+#endif
 }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -46,7 +46,7 @@ LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
 	int nProc = model->nProc();
 	int curProc = model->curProc();
 	QString chanName;
-	if(name.isNull())
+	if (name.isNull())
 	{
 		switch(nProc)
 		{
@@ -59,11 +59,9 @@ LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
 				break;
 		}
 	}
-	else {
-		chanName = name;
-	}
+	else { chanName = name; }
 
-	if(!chanName.isNull()) { setTitle(chanName); }
+	if (!chanName.isNull()) { setTitle(chanName); }
 }
 
 
@@ -81,10 +79,7 @@ void LinkedModelGroupViewBase::modelChanged(LinkedModelGroup *group)
 	std::vector<AutomatableModel*> models = group->models();
 	Q_ASSERT(m_controls.size() == models.size());
 
-	for(AutomatableModel* mdl : models)
-	{
-		(*itr++)->setModel(mdl);
-	}
+	for (AutomatableModel* mdl : models) { (*itr++)->setModel(mdl); }
 
 	std::size_t count = 0;
 	for (std::unique_ptr<LedCheckBox>& led : m_leds)
@@ -100,12 +95,13 @@ void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
 {
 	int colNum2 = m_colNum * (1 + m_isLinking);
 	int wdgNum = static_cast<int>(m_controls.size() * (1 + m_isLinking));
-	if(ctrl)
+	if (ctrl)
 	{
 		int x = wdgNum%colNum2, y = wdgNum/colNum2;
 
 		// start in row one, add widgets cell by cell
-		if(m_isLinking) {
+		if (m_isLinking)
+		{
 			LedCheckBox* cb = new LedCheckBox(qobject_cast<QWidget*>(
 				ctrl->topWidget()->parent()));
 			m_grid->addWidget(cb, y, x);
@@ -128,12 +124,12 @@ void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
 void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
 {
 	int rowHeight = 0, colWidth = 0;
-	for(int row = 0; row < m_grid->rowCount(); ++row)
+	for (int row = 0; row < m_grid->rowCount(); ++row)
 	{
-		for(int col = 0; col < m_grid->columnCount(); ++col)
+		for (int col = 0; col < m_grid->columnCount(); ++col)
 		{
 			QLayoutItem* layout;
-			if((layout = m_grid->itemAtPosition(row, col)))
+			if ((layout = m_grid->itemAtPosition(row, col)))
 			{
 				rowHeight = qMax(rowHeight, layout->geometry().height());
 				colWidth = qMax(colWidth, layout->geometry().width());
@@ -141,12 +137,12 @@ void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
 		}
 	}
 
-	for(int row = 0; row < m_grid->rowCount(); ++row)
+	for (int row = 0; row < m_grid->rowCount(); ++row)
 	{
 		m_grid->setRowMinimumHeight(row, rowHeight);
 	}
 
-	for(int col = 0; col < m_grid->columnCount(); ++col)
+	for (int col = 0; col < m_grid->columnCount(); ++col)
 	{
 		m_grid->setColumnMinimumWidth(col, colWidth);
 	}
@@ -161,7 +157,7 @@ void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
 LinkedModelGroupsViewBase::LinkedModelGroupsViewBase(
 	LinkedModelGroups *ctrlBase)
 {
-	if(ctrlBase->multiChannelLinkModel())
+	if (ctrlBase->multiChannelLinkModel())
 	{
 		m_multiChannelLink.reset(new LedCheckBox(QObject::tr("Link Channels"),
 												nullptr));
@@ -173,12 +169,12 @@ LinkedModelGroupsViewBase::LinkedModelGroupsViewBase(
 
 void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
 {
-	if(groups->multiChannelLinkModel())
+	if (groups->multiChannelLinkModel())
 	{
 		m_multiChannelLink->setModel(groups->multiChannelLinkModel());
 	}
 
-	for(std::size_t i = 0; getGroupView(i) && groups->getGroup(i); ++i)
+	for (std::size_t i = 0; getGroupView(i) && groups->getGroup(i); ++i)
 	{
 		getGroupView(i)->modelChanged(groups->getGroup(i));
 	}
@@ -187,6 +183,7 @@ void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
 
 
 
-void LinkedModelGroupsViewBase::MultiChannelLinkDeleter::operator()(LedCheckBox *l) { delete l; }
+void LinkedModelGroupsViewBase::MultiChannelLinkDeleter::
+	operator()(LedCheckBox *l) { delete l; }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -37,13 +37,12 @@
 
 
 LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
-	LinkedModelGroup *model, int colNum, const QString& name) :
+	LinkedModelGroup *model, int colNum, int nProc, const QString& name) :
 	QGroupBox(parent),
 	m_colNum(colNum),
 	m_isLinking(model->isLinking()),
 	m_grid(new QGridLayout(this))
 {
-	int nProc = model->nProc();
 	int curProc = model->curProc();
 	QString chanName;
 	if (name.isNull())

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -26,7 +26,7 @@
 
 #include <QPushButton>
 #include "Controls.h"
-#include "LinkedModelGroupLayout.h"
+#include "ControlLayout.h"
 #include "LinkedModelGroups.h"
 
 
@@ -40,7 +40,7 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	QWidget(parent),
 	m_model(model),
 	m_colNum(colNum),
-	m_layout(new LinkedModelGroupLayout(this))
+	m_layout(new ControlLayout(this))
 {
 }
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -37,12 +37,14 @@
 
 
 LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
-	bool isLinking, int colNum, int curProc, int nProc, const QString& name) :
+	LinkedModelGroup *model, int colNum, const QString& name) :
 	QGroupBox(parent),
 	m_colNum(colNum),
-	m_isLinking(isLinking),
+	m_isLinking(model->isLinking()),
 	m_grid(new QGridLayout(this))
 {
+	int nProc = model->nProc();
+	int curProc = model->curProc();
 	QString chanName;
 	if(name.isNull())
 	{

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -39,8 +39,8 @@
 
 
 LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
-	LinkedModelGroup *model, std::size_t colNum, std::size_t nProc, const QString& name) :
-	QGroupBox(parent),
+	LinkedModelGroup *model, std::size_t colNum) :
+	QWidget(parent),
 	m_model(model),
 	m_colNum(colNum),
 	m_layout(new LinkedModelGroupLayout(this))
@@ -48,31 +48,6 @@ LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	// make viewable: if there are no knobs, the user should at least see
 	// a rectangle to drop controls in
 	setMinimumSize(QSize(50, 50));
-
-	if (model->modelNum())
-	{
-		std::size_t curProc = model->curProc();
-		QString chanName;
-		if (name.isNull())
-		{
-			switch (nProc)
-			{
-				case 1: break; // don't display any channel name
-				case 2:
-					chanName = curProc
-								? QObject::tr("Right")
-								: QObject::tr("Left");
-					break;
-				default:
-					chanName = QObject::tr("Channel %1").arg(curProc + 1);
-					break;
-			}
-		}
-		else { chanName = name; }
-
-		if (!chanName.isNull()) { setTitle(chanName); }
-	}
-	else { /*setHidden(true);*/ }
 }
 
 
@@ -219,13 +194,11 @@ void LinkedModelGroupView::makeAllGridCellsEqualSized()
 
 void LinkedModelGroupsView::modelChanged(LinkedModelGroups *groups)
 {
-	LinkedModelGroupView* groupView;
-	LinkedModelGroup* group;
-	for (std::size_t i = 0;
-		(group = groups->getGroup(i)) && (groupView = getGroupView(i));
-		++i)
+	LinkedModelGroupView* groupView = getGroupView();
+	LinkedModelGroup* group0 = groups->getGroup(0);
+	if(group0 && groupView)
 	{
-		groupView->modelChanged(group);
+		groupView->modelChanged(group0);
 	}
 }
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -36,7 +36,7 @@
 */
 
 
-LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
+LinkedModelGroupView::LinkedModelGroupView(QWidget* parent,
 	LinkedModelGroup *model, int colNum, int nProc, const QString& name) :
 	QGroupBox(parent),
 	m_colNum(colNum),
@@ -70,16 +70,16 @@ LinkedModelGroupViewBase::LinkedModelGroupViewBase(QWidget* parent,
 
 
 
-LinkedModelGroupViewBase::~LinkedModelGroupViewBase() {}
+LinkedModelGroupView::~LinkedModelGroupView() {}
 
 
 
 
-void LinkedModelGroupViewBase::modelChanged(LinkedModelGroup *group)
+void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 {
 	// reconnect models
 	using ModelInfo = LinkedModelGroup::ModelInfo;
-	std::vector<std::unique_ptr<ControlBase>>::iterator itr = m_controls.begin();
+	std::vector<std::unique_ptr<Control>>::iterator itr = m_controls.begin();
 	std::vector<ModelInfo> models = group->models();
 	Q_ASSERT(m_controls.size() == models.size());
 
@@ -95,7 +95,7 @@ void LinkedModelGroupViewBase::modelChanged(LinkedModelGroup *group)
 
 
 
-void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
+void LinkedModelGroupView::addControl(Control* ctrl)
 {
 	int colNum2 = m_colNum * (1 + m_isLinking);
 	int wdgNum = static_cast<int>(m_controls.size() * (1 + m_isLinking));
@@ -112,7 +112,7 @@ void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
 			m_leds.push_back(std::unique_ptr<LedCheckBox>(cb));
 		}
 
-		m_controls.push_back(std::unique_ptr<ControlBase>(ctrl));
+		m_controls.push_back(std::unique_ptr<Control>(ctrl));
 		m_grid->addWidget(ctrl->topWidget(), y, x + 1, Qt::AlignCenter);
 		wdgNum += m_isLinking;
 		++wdgNum;
@@ -125,7 +125,7 @@ void LinkedModelGroupViewBase::addControl(ControlBase* ctrl)
 
 
 
-void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
+void LinkedModelGroupView::makeAllGridCellsEqualSized()
 {
 	int rowHeight = 0, colWidth = 0;
 	for (int row = 0; row < m_grid->rowCount(); ++row)
@@ -158,7 +158,7 @@ void LinkedModelGroupViewBase::makeAllGridCellsEqualSized()
 */
 
 
-LinkedModelGroupsViewBase::LinkedModelGroupsViewBase(
+LinkedModelGroupsView::LinkedModelGroupsView(
 	LinkedModelGroups *ctrlBase)
 {
 	if (ctrlBase->multiChannelLinkModel())
@@ -171,7 +171,7 @@ LinkedModelGroupsViewBase::LinkedModelGroupsViewBase(
 
 
 
-void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
+void LinkedModelGroupsView::modelChanged(LinkedModelGroups *groups)
 {
 	if (groups->multiChannelLinkModel())
 	{
@@ -187,7 +187,7 @@ void LinkedModelGroupsViewBase::modelChanged(LinkedModelGroups *groups)
 
 
 
-void LinkedModelGroupsViewBase::MultiChannelLinkDeleter::
+void LinkedModelGroupsView::MultiChannelLinkDeleter::
 	operator()(LedCheckBox *l) { delete l; }
 
 

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -109,7 +109,8 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 		box->setObjectName(QString::fromStdString(display));
 		m_layout->addWidget(box);
 
-		m_widgets.emplace(id, ctrl);
+		// take ownership of control and add it
+		m_widgets.emplace(id, std::unique_ptr<Control>(ctrl));
 		++wdgNum;
 	}
 


### PR DESCRIPTION
The last sidebranch for the Lv2 core implementation #4899 .

This implements a container for multiple equal groups of linked models and
suiting views. Such groups are suited for representing mono effects where each
Model occurs twice. A group provides Models for one mono processor and is
visually represented with a group box.

![preview on branch lv2-review](https://i.imgur.com/A44OSFp.png)

The result is a dialogue like in LADSPA. You currently can't see this branches
changes unless you're on branch `lv2-review`. Loading and saving is also
missing yet because it's not part of the Lv2 core, and thus can not be tested.

There's known bug #4904 which however also occurs in LADSPA and is likely
related to `AutomatableModel`. It won't be fixed on this branch.

For the long term, I plan moving LADSPA (and SPA on its sidebranch) to use
the `LinkedModelGroups` classes, in order to refactor code.