### PR TITLE
playing/recording pianoRoll's chord notes (#4963)

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -266,6 +266,9 @@ private:
 	void testPlayNote( Note * n );
 	void testPlayKey( int _key, int _vol, int _pan );
 	void pauseTestNotes(bool pause = true );
+	void playChordNotes(int key, int velocity=-1);
+	void pauseChordNotes(int key);
+
 
 	QList<int> getAllOctavesForKey( int keyToMirror ) const;
 

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -577,13 +577,9 @@ NotePlayHandle * NotePlayHandleManager::acquire( InstrumentTrack* instrumentTrac
 				int midiEventChannel,
 				NotePlayHandle::Origin origin )
 {
-	if( s_availableIndex < 0 )
-	{
-		s_mutex.lockForWrite();
-		if( s_availableIndex < 0 ) extend( NPH_CACHE_INCREMENT );
-		s_mutex.unlock();
-	}
-	s_mutex.lockForRead();
+	// TODO: use some lockless data structures
+	s_mutex.lockForWrite();
+	if (s_availableIndex < 0) { extend(NPH_CACHE_INCREMENT); }
 	NotePlayHandle * nph = s_available[ s_availableIndex.fetchAndAddOrdered( -1 ) ];
 	s_mutex.unlock();
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -88,6 +88,7 @@ TimeLineWidget::TimeLineWidget( const int xoff, const int yoff, const float ppt,
 
 	m_xOffset -= s_posMarkerPixmap->width() / 2;
 
+	setMouseTracking(true);
 	m_pos.m_timeLine = this;
 
 	QTimer * updateTimer = new QTimer( this );
@@ -365,6 +366,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 
 void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 {
+	parentWidget()->update(); // essential for widgets that this timeline had taken their mouse move event from.
 	const MidiTime t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * MidiTime::ticksPerTact() / m_ppt );
 
 	switch( m_action )

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -430,8 +430,8 @@ void AutomationEditor::leaveEvent(QEvent * e )
 	{
 		QApplication::restoreOverrideCursor();
 	}
-
 	QWidget::leaveEvent( e );
+	update();
 }
 
 
@@ -1510,8 +1510,11 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		case SELECT: cursor = s_toolSelect; break;
 		case MOVE: cursor = s_toolMove; break;
 	}
-	p.drawPixmap( mapFromGlobal( QCursor::pos() ) + QPoint( 8, 8 ),
-								*cursor );
+	QPoint mousePosition = mapFromGlobal( QCursor::pos() );
+	if( cursor != NULL && mousePosition.y() > TOP_MARGIN + SCROLLBAR_SIZE)
+	{
+		p.drawPixmap( mousePosition + QPoint( 8, 8 ), *cursor );
+	}
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1894,7 +1894,7 @@ void PianoRoll::testPlayKey( int key, int velocity, int pan )
 	// turn off old key
 	pianoModel->handleKeyRelease( m_lastKey );
 	// if a chord was set, stop the chords notes as well
-	pauseChordNotes(key);
+	pauseChordNotes(m_lastKey);
 
 	// remember which one we're playing
 	m_lastKey = key;
@@ -2032,14 +2032,15 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 			{
 				m_pattern->instrumentTrack()->pianoModel()->
 						handleKeyRelease( note->key() );
-				note->setIsPlaying( false );
 				pauseChordNotes(note->key());
+				note->setIsPlaying( false );
 			}
 		}
 
 		// stop playing keys that we let go of
 		m_pattern->instrumentTrack()->pianoModel()->
 						handleKeyRelease( m_lastKey );
+		pauseChordNotes(m_lastKey);
 	}
 
 	m_currentNote = NULL;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1297,6 +1297,7 @@ void PianoRoll::leaveEvent(QEvent * e )
 
 	QWidget::leaveEvent( e );
 	s_textFloat->hide();
+	update(); // cleaning inner mouse-related graphics
 }
 
 
@@ -3167,10 +3168,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		case ModeSelect: cursor = s_toolSelect; break;
 		case ModeEditDetuning: cursor = s_toolOpen; break;
 	}
-	if( cursor != NULL )
+	QPoint mousePosition = mapFromGlobal( QCursor::pos() );
+	if( cursor != NULL && mousePosition.y() > keyAreaTop() && mousePosition.x() > noteEditLeft())
 	{
-		p.drawPixmap( mapFromGlobal( QCursor::pos() ) + QPoint( 8, 8 ),
-								*cursor );
+		p.drawPixmap( mousePosition + QPoint( 8, 8 ), *cursor );
 	}
 }
 


### PR DESCRIPTION
This change makes pianoRoll chord settings to generate notes accordingly, and record them (fixes #4963).  It can be triggered by mouse and keyboard, however it does not supported with an external MIDI controller (as current behavior). I'll work on another change that will enable the chord playing (and thus recording) of a base note that was generated by an external MIDI device in future (because it needs different approach, maybe MIDI messages manipulating). 