### PR TITLE
Ignore VS Code config files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.sw?
 .DS_Store
 *~
+.vscode
 /CMakeLists.txt.user
 /plugins/zynaddsubfx/zynaddsubfx/ExternalPrograms/Controller/Makefile
 /plugins/zynaddsubfx/zynaddsubfx/ExternalPrograms/Spliter/Makefile


### PR DESCRIPTION
Simple fix to prevent the .vscode folder from being committed.