### PR TITLE
SampleTrack: call requestChangesInModel before unref SampleBuffer

### DIFF
--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -110,7 +110,9 @@ SampleTCO::~SampleTCO()
 	{
 		sampletrack->updateTcos();
 	}
+	Engine::mixer()->requestChangeInModel();
 	sharedObject::unref( m_sampleBuffer );
+	Engine::mixer()->doneChangeInModel();
 }
 
 
@@ -133,7 +135,9 @@ const QString & SampleTCO::sampleFile() const
 
 void SampleTCO::setSampleBuffer( SampleBuffer* sb )
 {
+	Engine::mixer()->requestChangeInModel();
 	sharedObject::unref( m_sampleBuffer );
+	Engine::mixer()->doneChangeInModel();
 	m_sampleBuffer = sb;
 	updateLength();
 


### PR DESCRIPTION
To avoid a race condition between the gui thread which destroys the
samplebuffer and the mixer thread which increases the buffer's ref-
count, we'll make sure to touch the ref-count only when whe're synced
with the mixer.

Closes #4980.