### PR TITLE
SampleBuffer -> Samplerate - Fix two sample rate issues:

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -31,6 +31,7 @@
 
 
 #include "export.h"
+#include "lmms_basics.h"
 
 class BBTrackContainer;
 class DummyTrackContainer;
@@ -100,6 +101,9 @@ public:
 	{
 		return s_framesPerTick;
 	}
+
+	static float framesPerTick(sample_rate_t sample_rate);
+
 	static void updateFramesPerTick();
 
 	static inline LmmsCore * inst()

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -265,6 +265,8 @@ public slots:
 	void sampleRateChanged();
 
 private:
+	static sample_rate_t mixerSampleRate();
+
 	void update( bool _keep_settings = false );
 
 	void convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, int _channels);

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -103,6 +103,12 @@ void LmmsCore::destroy()
 	delete ConfigManager::inst();
 }
 
+float LmmsCore::framesPerTick(sample_rate_t sample_rate)
+{
+	return sample_rate * 60.0f * 4 /
+			DefaultTicksPerTact / s_song->getTempo();
+}
+
 
 
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -73,7 +73,7 @@ SampleBuffer::SampleBuffer( const QString & _audio_file,
 	m_amplification( 1.0f ),
 	m_reversed( false ),
 	m_frequency( BaseFreq ),
-	m_sampleRate( Engine::mixer()->baseSampleRate() )
+	m_sampleRate( mixerSampleRate () )
 {
 	if( _is_base64_data == true )
 	{
@@ -99,7 +99,7 @@ SampleBuffer::SampleBuffer( const sampleFrame * _data, const f_cnt_t _frames ) :
 	m_amplification( 1.0f ),
 	m_reversed( false ),
 	m_frequency( BaseFreq ),
-	m_sampleRate( Engine::mixer()->baseSampleRate() )
+	m_sampleRate( mixerSampleRate () )
 {
 	if( _frames > 0 )
 	{
@@ -127,7 +127,7 @@ SampleBuffer::SampleBuffer( const f_cnt_t _frames ) :
 	m_amplification( 1.0f ),
 	m_reversed( false ),
 	m_frequency( BaseFreq ),
-	m_sampleRate( Engine::mixer()->baseSampleRate() )
+	m_sampleRate( mixerSampleRate () )
 {
 	if( _frames > 0 )
 	{
@@ -153,6 +153,11 @@ SampleBuffer::~SampleBuffer()
 void SampleBuffer::sampleRateChanged()
 {
 	update( true );
+}
+
+sample_rate_t SampleBuffer::mixerSampleRate()
+{
+	return Engine::mixer()->processingSampleRate();
 }
 
 
@@ -190,7 +195,7 @@ void SampleBuffer::update( bool _keep_settings )
 		int_sample_t * buf = NULL;
 		sample_t * fbuf = NULL;
 		ch_cnt_t channels = DEFAULT_CHANNELS;
-		sample_rate_t samplerate = Engine::mixer()->baseSampleRate();
+		sample_rate_t samplerate = mixerSampleRate();
 		m_frames = 0;
 
 		const QFileInfo fileInfo( file );
@@ -379,10 +384,10 @@ void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 							bool _keep_settings )
 {
 	// do samplerate-conversion to our default-samplerate
-	if( _src_sr != Engine::mixer()->baseSampleRate() )
+	if( _src_sr != mixerSampleRate() )
 	{
 		SampleBuffer * resampled = resample( _src_sr,
-					Engine::mixer()->baseSampleRate() );
+					mixerSampleRate() );
 		MM_FREE( m_data );
 		m_frames = resampled->frames();
 		m_data = MM_ALLOC( sampleFrame, m_frames );

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -153,7 +153,7 @@ bool SamplePlayHandle::isFromTrack( const Track * _track ) const
 
 f_cnt_t SamplePlayHandle::totalFrames() const
 {
-	return ( m_sampleBuffer->endFrame() - m_sampleBuffer->startFrame() ) * ( Engine::mixer()->processingSampleRate() / Engine::mixer()->baseSampleRate() );
+	return ( m_sampleBuffer->endFrame() - m_sampleBuffer->startFrame() ) * ( Engine::mixer()->processingSampleRate() / m_sampleBuffer->sampleRate() );
 }
 
 

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -604,13 +604,16 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 		{
 			TrackContentObject * tco = getTCO( i );
 			SampleTCO * sTco = dynamic_cast<SampleTCO*>( tco );
-			float framesPerTick = Engine::framesPerTick();
+
 			if( _start >= sTco->startPosition() && _start < sTco->endPosition() )
 			{
 				if( sTco->isPlaying() == false )
 				{
-					f_cnt_t sampleStart = framesPerTick * ( _start - sTco->startPosition() );
-					f_cnt_t tcoFrameLength = framesPerTick * ( sTco->endPosition() - sTco->startPosition() );
+					auto bufferFramesPerTick = Engine::framesPerTick (sTco->sampleBuffer ()->sampleRate ());
+					f_cnt_t sampleStart = bufferFramesPerTick * ( _start - sTco->startPosition() );
+
+					f_cnt_t tcoFrameLength = bufferFramesPerTick * ( sTco->endPosition() - sTco->startPosition() );
+
 					f_cnt_t sampleBufferLength = sTco->sampleBuffer()->frames();
 					//if the Tco smaller than the sample length we play only until Tco end
 					//else we play the sample to the end but nothing more

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -245,6 +245,8 @@ void SampleTCO::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		QString s;
 		_this.setAttribute( "data", m_sampleBuffer->toBase64( s ) );
 	}
+
+	_this.setAttribute ("sample_rate", m_sampleBuffer->sampleRate());
 	// TODO: start- and end-frame
 }
 
@@ -264,6 +266,10 @@ void SampleTCO::loadSettings( const QDomElement & _this )
 	}
 	changeLength( _this.attribute( "len" ).toInt() );
 	setMuted( _this.attribute( "muted" ).toInt() );
+
+	if (_this.hasAttribute("sample_rate")) {
+		m_sampleBuffer->setSampleRate(_this.attribute("sample_rate").toInt());
+	}
 }
 
 


### PR DESCRIPTION
1. Resampling was the wrong (src_rate was invalid)
2. SampleBuffer was using baseSampleRate as the default samplerate
instead of the actual processingSampleRate.

Closes #4786