### PR TITLE
Removed unnecessary SF2 directory setting

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -161,11 +161,6 @@ public:
 		return m_gigDir;
 	}
 
-	const QString & sf2Dir() const
-	{
-		return m_sf2Dir;
-	}
-
 	const QString & vstDir() const
 	{
 		return m_vstDir;
@@ -266,7 +261,6 @@ private:
 	QString m_vstDir;
 	QString m_ladDir;
 	QString m_gigDir;
-	QString m_sf2Dir;
 	QString m_version;
 #ifdef LMMS_HAVE_STK
 	QString m_stkDir;

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -76,7 +76,6 @@ private slots:
 	void setWorkingDir( const QString & _wd );
 	void setVSTDir( const QString & _vd );
 	void setGIGDir( const QString & _gd );
-	void setSF2Dir( const QString & _sfd );
 	void setArtworkDir( const QString & _ad );
 	void setLADSPADir( const QString & _ld );
 	void setSTKDir( const QString & _sd );
@@ -108,7 +107,6 @@ private slots:
 	void openWorkingDir();
 	void openVSTDir();
 	void openGIGDir();
-	void openSF2Dir();
 	void openArtworkDir();
 	void openLADSPADir();
 	void openSTKDir();
@@ -156,7 +154,6 @@ private:
 	QLineEdit * m_adLineEdit;
 	QLineEdit * m_ladLineEdit;
 	QLineEdit * m_gigLineEdit;
-	QLineEdit * m_sf2LineEdit;
 #ifdef LMMS_HAVE_FLUIDSYNTH
 	QLineEdit * m_sfLineEdit;
 #endif
@@ -170,7 +167,6 @@ private:
 	QString m_artworkDir;
 	QString m_ladDir;
 	QString m_gigDir;
-	QString m_sf2Dir;
 #ifdef LMMS_HAVE_FLUIDSYNTH
 	QString m_defaultSoundfont;
 #endif

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -1119,10 +1119,6 @@ void sf2InstrumentView::showFileDialog()
 		ofd.setDirectory( QFileInfo( f ).absolutePath() );
 		ofd.selectFile( QFileInfo( f ).fileName() );
 	}
-	else
-	{
-		ofd.setDirectory( ConfigManager::inst()->sf2Dir() );
-	}
 
 	m_fileDialogButton->setEnabled( false );
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -64,7 +64,6 @@ ConfigManager::ConfigManager() :
 	m_artworkDir( defaultArtworkDir() ),
 	m_vstDir( m_workingDir + "vst/" ),
 	m_gigDir( m_workingDir + GIG_PATH ),
-	m_sf2Dir( m_workingDir + SF2_PATH ),
 	m_version( defaultVersion() )
 {
 	// Detect < 1.2.0 working directory as a courtesy
@@ -300,11 +299,6 @@ void ConfigManager::setGIGDir(const QString &gd)
 	m_gigDir = gd;
 }
 
-void ConfigManager::setSF2Dir(const QString &sfd)
-{
-	m_sf2Dir = sfd;
-}
-
 
 void ConfigManager::createWorkingDir()
 {
@@ -502,7 +496,6 @@ void ConfigManager::loadConfigFile( const QString & configFile )
 			setWorkingDir( value( "paths", "workingdir" ) );
 
 			setGIGDir( value( "paths", "gigdir" ) == "" ? gigDir() : value( "paths", "gigdir" ) );
-			setSF2Dir( value( "paths", "sf2dir" ) == "" ? sf2Dir() : value( "paths", "sf2dir" ) );
 			setVSTDir( value( "paths", "vstdir" ) );
 			setLADSPADir( value( "paths", "laddir" ) );
 		#ifdef LMMS_HAVE_STK
@@ -589,7 +582,6 @@ void ConfigManager::saveConfigFile()
 	setValue( "paths", "workingdir", m_workingDir );
 	setValue( "paths", "vstdir", m_vstDir );
 	setValue( "paths", "gigdir", m_gigDir );
-	setValue( "paths", "sf2dir", m_sf2Dir );
 	setValue( "paths", "laddir", m_ladDir );
 #ifdef LMMS_HAVE_STK
 	setValue( "paths", "stkdir", m_stkDir );

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -110,7 +110,6 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	m_artworkDir( QDir::toNativeSeparators( ConfigManager::inst()->artworkDir() ) ),
 	m_ladDir( QDir::toNativeSeparators( ConfigManager::inst()->ladspaDir() ) ),
 	m_gigDir( QDir::toNativeSeparators( ConfigManager::inst()->gigDir() ) ),
-	m_sf2Dir( QDir::toNativeSeparators( ConfigManager::inst()->sf2Dir() ) ),
 #ifdef LMMS_HAVE_FLUIDSYNTH
 	m_defaultSoundfont( QDir::toNativeSeparators( ConfigManager::inst()->defaultSoundfont() ) ),
 #endif
@@ -562,26 +561,6 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	connect( gigdir_select_btn, SIGNAL( clicked() ), this,
 						SLOT( openGIGDir() ) );
 
-	// sf2-dir
-	TabWidget * sf2_tw = new TabWidget( tr(
-					"SF2 directory" ).toUpper(),
-								pathSelectors );
-	sf2_tw->setFixedHeight( 48 );
-
-	m_sf2LineEdit = new QLineEdit( m_sf2Dir, sf2_tw );
-	m_sf2LineEdit->setGeometry( 10, 20, txtLength, 16 );
-	connect( m_sf2LineEdit, SIGNAL( textChanged( const QString & ) ), this,
-					SLOT( setSF2Dir( const QString & ) ) );
-
-	QPushButton * sf2dir_select_btn = new QPushButton(
-				embed::getIconPixmap( "project_open", 16, 16 ),
-								"", sf2_tw );
-	sf2dir_select_btn->setFixedSize( 24, 24 );
-	sf2dir_select_btn->move( btnStart, 16 );
-	connect( sf2dir_select_btn, SIGNAL( clicked() ), this,
-						SLOT( openSF2Dir() ) );
-
-
 
 	// LADSPA-dir
 	TabWidget * lad_tw = new TabWidget( tr(
@@ -649,8 +628,6 @@ SetupDialog::SetupDialog( ConfigTabs _tab_to_open ) :
 	pathSelectorLayout->addWidget( lmms_wd_tw );
 	pathSelectorLayout->addSpacing( 10 );
 	pathSelectorLayout->addWidget( gig_tw );
-	pathSelectorLayout->addSpacing( 10 );
-	pathSelectorLayout->addWidget( sf2_tw );
 	pathSelectorLayout->addSpacing( 10 );
 	pathSelectorLayout->addWidget( vst_tw );
 	pathSelectorLayout->addSpacing( 10 );
@@ -1115,7 +1092,6 @@ void SetupDialog::accept()
 	ConfigManager::inst()->setWorkingDir(QDir::fromNativeSeparators(m_workingDir));
 	ConfigManager::inst()->setVSTDir(QDir::fromNativeSeparators(m_vstDir));
 	ConfigManager::inst()->setGIGDir(QDir::fromNativeSeparators(m_gigDir));
-	ConfigManager::inst()->setSF2Dir(QDir::fromNativeSeparators(m_sf2Dir));
 	ConfigManager::inst()->setArtworkDir(QDir::fromNativeSeparators(m_artworkDir));
 	ConfigManager::inst()->setLADSPADir(QDir::fromNativeSeparators(m_ladDir));
 #ifdef LMMS_HAVE_FLUIDSYNTH
@@ -1376,17 +1352,6 @@ void SetupDialog::openGIGDir()
 	}
 }
 
-void SetupDialog::openSF2Dir()
-{
-	QString new_dir = FileDialog::getExistingDirectory( this,
-				tr( "Choose your SF2 directory" ),
-							m_sf2Dir );
-	if( new_dir != QString::null )
-	{
-		m_sf2LineEdit->setText( new_dir );
-	}
-}
-
 
 
 
@@ -1422,10 +1387,6 @@ void SetupDialog::setGIGDir(const QString &_gd)
 	m_gigDir = _gd;
 }
 
-void SetupDialog::setSF2Dir(const QString &_sfd)
-{
-	m_sf2Dir = _sfd;
-}
 
 
 


### PR DESCRIPTION
Closes #4180 

Removed every occurrence of SF2 directory in SetupDialog as well as ConfigManager. You might want to check my modification in the plugins/sf2_player/sf2_player.cpp though. I didn't understand what original code does; removed it anyway.