### PR TITLE
Add a save option to discard MIDI connections

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -65,6 +65,17 @@ public:
 		Mode_Count
 	} ;
 
+	struct SaveOptions {
+		/**
+		 * Should we discard MIDI ControllerConnections from project files?
+		 */
+		BoolModel discardMIDIConnections{false};
+
+		void setDefaultOptions() {
+			discardMIDIConnections.setValue(false);
+		}
+	};
+
 	void clearErrors();
 	void collectError( const QString error );
 	bool hasErrors();
@@ -322,6 +333,11 @@ public:
 	void exportProjectMidi(QString const & exportFileName) const;
 
 	inline void setLoadOnLauch(bool value) { m_loadOnLaunch = value; }
+	SaveOptions &getSaveOptions() {
+		return m_saveOptions;
+	}
+
+	bool isSavingProject() const;
 
 public slots:
 	void playSong();
@@ -419,8 +435,11 @@ private:
 	volatile bool m_playing;
 	volatile bool m_paused;
 
+	bool m_savingProject;
 	bool m_loadingProject;
 	bool m_isCancelled;
+
+	SaveOptions m_saveOptions;
 
 	QStringList m_errors;
 

--- a/include/VersionedSaveDialog.h
+++ b/include/VersionedSaveDialog.h
@@ -29,15 +29,25 @@
 #define VERSIONEDSAVEDIALOG_H
 
 #include "FileDialog.h"
+#include "Song.h"
 
 class QLineEdit;
+class LedCheckBox;
 
+class SaveOptionsWidget : public QWidget {
+public:
+	SaveOptionsWidget(Song::SaveOptions &saveOptions);
+
+private:
+	LedCheckBox *m_discardMIDIConnectionsCheckbox;
+};
 
 class VersionedSaveDialog : public FileDialog
 {
 	Q_OBJECT
 public:
 	explicit VersionedSaveDialog( QWidget *parent = 0,
+								  QWidget *saveOptionsWidget = nullptr,
 								  const QString &caption = QString(),
 								  const QString &directory = QString(),
 								  const QString &filter = QString() );

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -31,6 +31,7 @@
 #include "LocaleHelper.h"
 #include "Mixer.h"
 #include "ProjectJournal.h"
+#include "Song.h"
 
 long AutomatableModel::s_periodCounter = 0;
 
@@ -132,32 +133,37 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 	}
 
 	if( m_controllerConnection && m_controllerConnection->getController()->type()
-				!= Controller::DummyController )
-	{
-		QDomElement controllerElement;
+				!= Controller::DummyController) {
+		// Skip saving MIDI connections if we're saving project and
+		// the discardMIDIConnections option is true.
+		if (!Engine::getSong()->isSavingProject()
+			|| !Engine::getSong()->getSaveOptions().discardMIDIConnections.value()
+			|| m_controllerConnection->getController()->type() != Controller::MidiController) {
+			QDomElement controllerElement;
 
-		// get "connection" element (and create it if needed)
-		QDomNode node = element.namedItem( "connection" );
-		if( node.isElement() )
-		{
-			controllerElement = node.toElement();
-		}
-		else
-		{
-			controllerElement = doc.createElement( "connection" );
-			element.appendChild( controllerElement );
-		}
+			// get "connection" element (and create it if needed)
+			QDomNode node = element.namedItem( "connection" );
+			if (node.isElement())
+			{
+				controllerElement = node.toElement();
+			}
+			else
+			{
+				controllerElement = doc.createElement( "connection" );
+				element.appendChild( controllerElement );
+			}
 
-		bool mustQuote = mustQuoteName(name);
-		QString elementName = mustQuote ? "controllerconnection"
+			bool mustQuote = mustQuoteName( name );
+			QString elementName = mustQuote ? "controllerconnection"
 						: name;
 
-		QDomElement element = doc.createElement( elementName );
-		if(mustQuote)
-			element.setAttribute( "nodename", name );
-		m_controllerConnection->saveSettings( doc, element );
+			QDomElement element = doc.createElement( elementName );
+			if (mustQuote)
+				element.setAttribute( "nodename", name );
+			m_controllerConnection->saveSettings( doc, element );
 
-		controllerElement.appendChild( element );
+			controllerElement.appendChild( element );
+		}
 	}
 }
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -132,38 +132,34 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 		}
 	}
 
-	if( m_controllerConnection && m_controllerConnection->getController()->type()
-				!= Controller::DummyController) {
-		// Skip saving MIDI connections if we're saving project and
-		// the discardMIDIConnections option is true.
-		if (!Engine::getSong()->isSavingProject()
-			|| !Engine::getSong()->getSaveOptions().discardMIDIConnections.value()
-			|| m_controllerConnection->getController()->type() != Controller::MidiController) {
-			QDomElement controllerElement;
+	// Skip saving MIDI connections if we're saving project and
+	// the discardMIDIConnections option is true.
+	auto controllerType = m_controllerConnection->getController()->type();
+	bool skipMidiController = Engine::getSong()->isSavingProject()
+							  && Engine::getSong()->getSaveOptions().discardMIDIConnections.value();
+	if (m_controllerConnection && controllerType != Controller::DummyController
+		&& !(skipMidiController && controllerType == Controller::MidiController)) {
+		QDomElement controllerElement;
 
-			// get "connection" element (and create it if needed)
-			QDomNode node = element.namedItem( "connection" );
-			if (node.isElement())
-			{
-				controllerElement = node.toElement();
-			}
-			else
-			{
-				controllerElement = doc.createElement( "connection" );
-				element.appendChild( controllerElement );
-			}
-
-			bool mustQuote = mustQuoteName( name );
-			QString elementName = mustQuote ? "controllerconnection"
-						: name;
-
-			QDomElement element = doc.createElement( elementName );
-			if (mustQuote)
-				element.setAttribute( "nodename", name );
-			m_controllerConnection->saveSettings( doc, element );
-
-			controllerElement.appendChild( element );
+		// get "connection" element (and create it if needed)
+		QDomNode node = element.namedItem( "connection" );
+		if (node.isElement()) {
+			controllerElement = node.toElement();
+		} else {
+			controllerElement = doc.createElement( "connection" );
+			element.appendChild( controllerElement );
 		}
+
+		bool mustQuote = mustQuoteName( name );
+		QString elementName = mustQuote ? "controllerconnection"
+				: name;
+
+		QDomElement element = doc.createElement( elementName );
+		if (mustQuote)
+			element.setAttribute( "nodename", name );
+		m_controllerConnection->saveSettings( doc, element );
+
+		controllerElement.appendChild( element );
 	}
 }
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -144,7 +144,7 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 
 		// get "connection" element (and create it if needed)
 		QDomNode node = element.namedItem( "connection" );
-		if(node.isElement())
+		if( node.isElement() )
 		{
 			controllerElement = node.toElement();
 		}
@@ -155,7 +155,8 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 		}
 
 		bool mustQuote = mustQuoteName(name);
-		QString elementName = mustQuote ? "controllerconnection" : name;
+		QString elementName = mustQuote ? "controllerconnection"
+										: name;
 
 		QDomElement element = doc.createElement( elementName );
 		if(mustQuote)

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -134,7 +134,9 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 
 	// Skip saving MIDI connections if we're saving project and
 	// the discardMIDIConnections option is true.
-	auto controllerType = m_controllerConnection->getController()->type();
+	auto controllerType = m_controllerConnection
+			? m_controllerConnection->getController()->type()
+			: Controller::DummyController;
 	bool skipMidiController = Engine::getSong()->isSavingProject()
 							  && Engine::getSong()->getSaveOptions().discardMIDIConnections.value();
 	if (m_controllerConnection && controllerType != Controller::DummyController
@@ -156,7 +158,7 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 
 		bool mustQuote = mustQuoteName(name);
 		QString elementName = mustQuote ? "controllerconnection"
-										: name;
+						: name;
 
 		QDomElement element = doc.createElement( elementName );
 		if(mustQuote)

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -138,24 +138,27 @@ void AutomatableModel::saveSettings( QDomDocument& doc, QDomElement& element, co
 	bool skipMidiController = Engine::getSong()->isSavingProject()
 							  && Engine::getSong()->getSaveOptions().discardMIDIConnections.value();
 	if (m_controllerConnection && controllerType != Controller::DummyController
-		&& !(skipMidiController && controllerType == Controller::MidiController)) {
+		&& !(skipMidiController && controllerType == Controller::MidiController))
+	{
 		QDomElement controllerElement;
 
 		// get "connection" element (and create it if needed)
 		QDomNode node = element.namedItem( "connection" );
-		if (node.isElement()) {
+		if(node.isElement())
+		{
 			controllerElement = node.toElement();
-		} else {
+		}
+		else
+		{
 			controllerElement = doc.createElement( "connection" );
 			element.appendChild( controllerElement );
 		}
 
-		bool mustQuote = mustQuoteName( name );
-		QString elementName = mustQuote ? "controllerconnection"
-				: name;
+		bool mustQuote = mustQuoteName(name);
+		QString elementName = mustQuote ? "controllerconnection" : name;
 
 		QDomElement element = doc.createElement( elementName );
-		if (mustQuote)
+		if(mustQuote)
 			element.setAttribute( "nodename", name );
 		m_controllerConnection->saveSettings( doc, element );
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1272,7 +1272,7 @@ bool Song::guiSaveProjectAs( const QString & _file_name )
 	// After saving as, restore default save options.
 	m_saveOptions.setDefaultOptions();
 
-	if(saveResult)
+	if(!saveResult)
 	{
 		// Saving failed. Restore old filenames.
 		setProjectFileName(m_oldFileName);

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1212,6 +1212,7 @@ void Song::loadProject( const QString & fileName )
 bool Song::saveProjectFile( const QString & filename )
 {
 	DataFile dataFile( DataFile::SongProject );
+	m_savingProject = true;
 
 	m_tempoModel.saveSettings( dataFile, dataFile.head(), "bpm" );
 	m_timeSigModel.saveSettings( dataFile, dataFile.head(), "timesig" );
@@ -1232,6 +1233,8 @@ bool Song::saveProjectFile( const QString & filename )
 	}
 
 	saveControllerStates( dataFile, dataFile.content() );
+
+	m_savingProject = false;
 
 	return dataFile.writeFile( filename );
 }
@@ -1433,4 +1436,8 @@ QString Song::errorSummary()
 	errors.prepend( tr( "The following errors occured while loading: " ) );
 
 	return errors;
+}
+
+bool Song::isSavingProject() const {
+	return m_savingProject;
 }

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1268,7 +1268,11 @@ bool Song::guiSaveProjectAs( const QString & _file_name )
 	m_oldFileName = m_fileName;
 	setProjectFileName(_file_name);
 
-	if(!guiSaveProject())
+	bool saveResult = guiSaveProject();
+	// After saving as, restore default save options.
+	m_saveOptions.setDefaultOptions();
+
+	if(saveResult)
 	{
 		// Saving failed. Restore old filenames.
 		setProjectFileName(m_oldFileName);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -922,7 +922,8 @@ bool MainWindow::saveProject()
 
 bool MainWindow::saveProjectAs()
 {
-	VersionedSaveDialog sfd( this, tr( "Save Project" ), "",
+	auto optionsWidget = new SaveOptionsWidget(Engine::getSong()->getSaveOptions());
+	VersionedSaveDialog sfd( this, optionsWidget, tr( "Save Project" ), "",
 			tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
 				tr( "LMMS Project Template" ) + " (*.mpt)" );
 	QString f = Engine::getSong()->projectFileName();

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -66,14 +66,14 @@ VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 	layout->addLayout( hLayout, 2, 1 );
 
 	if (saveOptionsWidget) {
-		auto *groupBox = new QGroupBox(tr("Save Options"));
+		auto groupBox = new QGroupBox(tr("Save Options"));
 		auto optionsLayout = new QGridLayout;
 
 		optionsLayout->addWidget(saveOptionsWidget, 0, 0, Qt::AlignLeft);
 
 		groupBox->setLayout(optionsLayout);
 
-		layout->addWidget(groupBox, layout->rowCount()+1, 0, 1, -1);
+		layout->addWidget(groupBox, layout->rowCount() + 1, 0, 1, -1);
 	}
 
 	// Connect + and - buttons
@@ -177,10 +177,10 @@ bool VersionedSaveDialog::fileExistsQuery( QString FileName, QString WindowTitle
 SaveOptionsWidget::SaveOptionsWidget(Song::SaveOptions &saveOptions) {
 	auto *layout = new QVBoxLayout();
 
-	m_discardMIDIConnectionsCheckbox = new LedCheckBox( nullptr );
-	m_discardMIDIConnectionsCheckbox->setText(tr( "Discard MIDI connections"));
+	m_discardMIDIConnectionsCheckbox = new LedCheckBox(nullptr);
+	m_discardMIDIConnectionsCheckbox->setText(tr("Discard MIDI connections"));
 	m_discardMIDIConnectionsCheckbox->setModel(&saveOptions.discardMIDIConnections);
-	layout->addWidget( m_discardMIDIConnectionsCheckbox );
+	layout->addWidget(m_discardMIDIConnectionsCheckbox);
 
 	setLayout(layout);
 }

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -28,13 +28,15 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QGroupBox>
+#include <QLabel>
 
 #include "VersionedSaveDialog.h"
-
-
+#include "LedCheckbox.h"
 
 
 VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
+										  QWidget *saveOptionsWidget,
 										  const QString &caption,
 										  const QString &directory,
 										  const QString &filter ) :
@@ -62,6 +64,17 @@ VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 	hLayout->addWidget( plusButton );
 	hLayout->addWidget( minusButton );
 	layout->addLayout( hLayout, 2, 1 );
+
+	if (saveOptionsWidget) {
+		auto *groupBox = new QGroupBox(tr("Save Options"));
+		auto optionsLayout = new QGridLayout;
+
+		optionsLayout->addWidget(saveOptionsWidget, 0, 0, Qt::AlignLeft);
+
+		groupBox->setLayout(optionsLayout);
+
+		layout->addWidget(groupBox, layout->rowCount()+1, 0, 1, -1);
+	}
 
 	// Connect + and - buttons
 	connect( plusButton, SIGNAL( clicked() ), this, SLOT( incrementVersion() ));
@@ -159,4 +172,15 @@ bool VersionedSaveDialog::fileExistsQuery( QString FileName, QString WindowTitle
 		}
 	}
 	return fileExists;
+}
+
+SaveOptionsWidget::SaveOptionsWidget(Song::SaveOptions &saveOptions) {
+	auto *layout = new QVBoxLayout();
+
+	m_discardMIDIConnectionsCheckbox = new LedCheckBox( nullptr );
+	m_discardMIDIConnectionsCheckbox->setText(tr( "Discard MIDI connections"));
+	m_discardMIDIConnectionsCheckbox->setModel(&saveOptions.discardMIDIConnections);
+	layout->addWidget( m_discardMIDIConnectionsCheckbox );
+
+	setLayout(layout);
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -749,7 +749,12 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 	m_soundShaping.saveState( doc, thisElement );
 	m_noteStacking.saveState( doc, thisElement );
 	m_arpeggio.saveState( doc, thisElement );
-	m_midiPort.saveState( doc, thisElement );
+
+	// Don't save midi port info if the user chose to.
+	if (Engine::getSong()->isSavingProject()
+		&& !Engine::getSong()->getSaveOptions().discardMIDIConnections.value())
+		m_midiPort.saveState( doc, thisElement );
+
 	m_audioPort.effects()->saveState( doc, thisElement );
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -753,7 +753,9 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 	// Don't save midi port info if the user chose to.
 	if (Engine::getSong()->isSavingProject()
 		&& !Engine::getSong()->getSaveOptions().discardMIDIConnections.value())
+	{
 		m_midiPort.saveState( doc, thisElement );
+	}
 
 	m_audioPort.effects()->saveState( doc, thisElement );
 }


### PR DESCRIPTION
This is a rework of the general feature of #4883: allowing the user to ignore MIDI connections. 

This PR will add a checkbox in the "save as" dialog that will allow the user to discard MIDI connections both for controllers and instruments.  

The reason behind it is pretty simple: making save files portable and less setup-dependent. 