### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+tab_width = 4


### PR DESCRIPTION
This file tells the github online editor to use tabs of width 4 instead of 8 (as [discussed](https://github.com/LMMS/lmms/issues/4810)). Open [this](https://github.com/JohannesLorenz/github_test/blob/master/test.cpp) test file in your browser to see how it works (the width is 5 in the example).

Actually, it also tells many other editors...
