### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://lmms.io/get-involved/#donate


### PR DESCRIPTION
This adds the setting for a "sponsor" button on the repo. One repo's owner then need to activate it, see: https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository#displaying-a-sponsor-button-in-your-repository
