### PR TITLE
show BBEditor on clicking the TrackLabelButton

### DIFF
--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -664,5 +664,5 @@ bool BBTrackView::close()
 void BBTrackView::clickedTrackLabel()
 {
 	Engine::getBBTrackContainer()->setCurrentBB( m_bbTrack->index() );
-	gui->getBBEditor()->show();
+	gui->getBBEditor()->parentWidget()->show();
 }


### PR DESCRIPTION
In the LMMS.io forums a user reported the following:

> I have an issue in new stable release 1.2.0
>
> When you close the beat+bass line editor screen, and if you click to open it again, the beat+bass line editor screen don't open, you have to press the shortcut to open it again.
> 
> I have tried in another PC and it's the same.
> In LMMS 1.2.0 RC8 the behavior is normal and open and close as always.

The user means the TrackLabelButton. This PR fixes the issue.
