### PR TITLE
 Fixes #4984 - Remove maximize from Meter (Metro) menu 

### DIFF
--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -291,7 +291,11 @@ void TempoSyncKnob::showCustom()
 	if( m_custom == NULL )
 	{
 		m_custom = new MeterDialog( gui->mainWindow()->workspace() );
-		gui->mainWindow()->addWindowedWidget( m_custom );
+		QMdiSubWindow * subWindow = gui->mainWindow()->addWindowedWidget( m_custom );
+		Qt::WindowFlags flags = subWindow->windowFlags();
+		flags &= ~Qt::WindowMaximizeButtonHint;
+		subWindow->setWindowFlags( flags );
+		subWindow->setFixedSize( subWindow->size() );
 		m_custom->setWindowTitle( "Meter" );
 		m_custom->setModel( &model()->m_custom );
 	}


### PR DESCRIPTION
Tested locally that the Meter menu does not have a maximize button, and cannot be resized.

First time contributor, and new to Qt.. any feedback is welcome of course. 