### PR TITLE
Fixed renaming mixer channel from the context menu

### DIFF
--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -79,8 +79,6 @@ public:
 
 	static const int FxLineHeight;
 
-	void renameChannel();
-
 	bool eventFilter (QObject *dist, QEvent *event);
 
 private:
@@ -100,6 +98,9 @@ private:
 	bool m_inRename;
 	QLineEdit * m_renameLineEdit;
 	QGraphicsView * m_view;
+
+public slots:
+	void renameChannel();
 
 private slots:
 	void renameFinished();


### PR DESCRIPTION
`renameChannel()` wasn't a slot previously, so the menu couldn't access it. This PR fixes that.