### PR TITLE
Fix #5088: Numbers cut off at bottom of Spectrum Analyzer

### DIFF
--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -115,8 +115,11 @@ private:
 	float freqToXPixel(float frequency, unsigned int width);
 	float ampToYPixel(float amplitude, unsigned int height);
 
-	bool renderLogarithmicAmpTics() const;
+	bool isRenderLogarithmicAmpTics() const;
 	std::vector<std::pair<float, std::string>> const & getAmpTicsToRender() const;
+
+	bool isRenderLogarithmicFrequencyTics() const;
+	std::vector<std::pair<int, std::string>> const & getFrequencyTicsToRender() const;
 
 	// current boundaries for drawing
 	unsigned int m_displayTop;

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -115,12 +115,16 @@ private:
 	float freqToXPixel(float frequency, unsigned int width);
 	float ampToYPixel(float amplitude, unsigned int height);
 
+	bool renderLogarithmicAmpTics() const;
+	std::vector<std::pair<float, std::string>> const & getAmpTicsToRender() const;
+
 	// current boundaries for drawing
 	unsigned int m_displayTop;
 	unsigned int m_displayBottom;
 	unsigned int m_displayLeft;
 	unsigned int m_displayRight;
 	unsigned int m_displayWidth;
+	float m_margin;
 };
 #endif // SASPECTRUMVIEW_H
 


### PR DESCRIPTION
Fix for #5088. Fix the problem of numbers that are cut of at the bottom of the Spectrum Analyzer. The changes consist of the following:
* Measure the maximum height needed to render the frequency ticks and adjust the bottom of the rectangle where the spectrum is rendered accordingly.
* Measure the maximum width needed to render the amplitude ticks and adjust the left and right margin of the rectangle where the spectrum is rendered accordingly.
* Adjust the code that renders the cursor text to measure the text that will be rendered so that it can be positioned correctly.

Technical changes:
* Add the two helper methods `renderLogarithmicAmpTics` and `getAmpTicsToRender`.
* Make the bottom margin a member.