### PR TITLE
Fully hide song editor scrollbar when not needed

### DIFF
--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -227,8 +227,19 @@ void TrackContainerView::scrollToTrackView( TrackView * _tv )
 void TrackContainerView::realignTracks()
 {
 	QWidget * content = m_scrollArea->widget();
-	content->setFixedWidth( width()
-				- m_scrollArea->verticalScrollBar()->width() );
+
+	//Hide the vertical scrollbar *and* its scrollbar area when not needed
+	auto verticalScrollBar = m_scrollArea->verticalScrollBar();
+	if (verticalScrollBar->maximum() == verticalScrollBar->minimum())
+	{	//min == max implies the whole editor is visible without scrolling
+		m_scrollArea->verticalScrollBar()->setStyleSheet("QScrollBar {width:0px;}");
+		content->setFixedWidth( width() );
+	}
+	else
+	{	//Otherwise we need a scrollbar, so restore it's width
+		m_scrollArea->verticalScrollBar()->setStyleSheet("QScrollBar {}");
+		content->setFixedWidth( width() - m_scrollArea->verticalScrollBar()->width() );
+	}
 	content->setFixedHeight( content->minimumSizeHint().height() );
 
 	for( trackViewList::iterator it = m_trackViews.begin();

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -228,17 +228,17 @@ void TrackContainerView::realignTracks()
 {
 	QWidget * content = m_scrollArea->widget();
 
-	//Hide the vertical scrollbar *and* its scrollbar area when not needed
+	//Hide the scrollbar AND scrollbar area when it's not needed
 	auto verticalScrollBar = m_scrollArea->verticalScrollBar();
 	if (verticalScrollBar->maximum() == verticalScrollBar->minimum())
 	{	//min == max implies the whole editor is visible without scrolling
-		m_scrollArea->verticalScrollBar()->setStyleSheet("QScrollBar {width:0px;}");
+		verticalScrollBar->setStyleSheet("QScrollBar {width:0px;}");
 		content->setFixedWidth( width() );
 	}
 	else
 	{	//Otherwise we need a scrollbar, so restore it's width
-		m_scrollArea->verticalScrollBar()->setStyleSheet("QScrollBar {}");
-		content->setFixedWidth( width() - m_scrollArea->verticalScrollBar()->width() );
+		verticalScrollBar->setStyleSheet("QScrollBar {}");
+		content->setFixedWidth( width() - verticalScrollBar->width() );
 	}
 	content->setFixedHeight( content->minimumSizeHint().height() );
 

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -228,7 +228,7 @@ void TrackContainerView::realignTracks()
 {
 	QWidget * content = m_scrollArea->widget();
 
-	//Hide the scrollbar AND scrollbar area when it's not needed
+	//Hide the vertical scrollbar *and* its scrollbar area when not needed
 	auto verticalScrollBar = m_scrollArea->verticalScrollBar();
 	if (verticalScrollBar->maximum() == verticalScrollBar->minimum())
 	{	//min == max implies the whole editor is visible without scrolling


### PR DESCRIPTION
Previously, the scrollbar's background area would still be displayed.
To work around this, resize the scrollbar area to 0px when it's not needed.