### PR TITLE
Center vertical scroll position when opening the Automation Editor

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -209,6 +209,7 @@ private:
 	float m_bottomLevel;
 	float m_topLevel;
 
+	void centerTopBottomScroll();
 	void updateTopBottomLevels();
 
 	QScrollBar * m_leftRightScroll;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -323,7 +323,7 @@ void AutomationEditor::updateAfterPatternChange()
 	m_minLevel = m_pattern->firstObject()->minValue<float>();
 	m_maxLevel = m_pattern->firstObject()->maxValue<float>();
 	m_step = m_pattern->firstObject()->step<float>();
-	m_scrollLevel = ( m_minLevel + m_maxLevel ) / 2;
+	centerTopBottomScroll();
 
 	m_tensionModel->setValue( m_pattern->getTension() );
 
@@ -1587,12 +1587,36 @@ void AutomationEditor::drawLevelTick(QPainter & p, int tick, float value)
 
 		p.fillRect( x, y_start, rect_width, rect_height, currentColor );
 	}
-
+#ifdef LMMS_DEBUG
 	else
 	{
 		printf("not in range\n");
 	}
+#endif
+}
 
+
+
+
+// center the vertical scroll position on the first object's value
+void AutomationEditor::centerTopBottomScroll()
+{
+	// default to the m_scrollLevel position
+	int pos = (int) m_scrollLevel;
+	// If a pattern exists...
+	if (m_pattern) {
+		// get time map of current pattern
+		timeMap & time_map = m_pattern->getTimeMap();
+		// If time_map is not empty...
+		if ( !time_map.empty() ) {
+			// get the first object
+			timeMap::iterator it = time_map.begin();
+			// set the position to the inverted value ((max + min) - value)
+			// If we set just (max - value), we're off by m_pattern's minimum
+			pos = m_pattern->getMax() + m_pattern->getMin() - (int) it.value();
+		}
+	}
+	m_topBottomScroll->setValue( pos );
 }
 
 
@@ -1624,8 +1648,7 @@ void AutomationEditor::resizeEvent(QResizeEvent * re)
 		m_topBottomScroll->setRange( (int) m_scrollLevel,
 							(int) m_scrollLevel );
 	}
-
-	m_topBottomScroll->setValue( (int) m_scrollLevel );
+	centerTopBottomScroll();
 
 	if( Engine::getSong() )
 	{

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1602,21 +1602,21 @@ void AutomationEditor::drawLevelTick(QPainter & p, int tick, float value)
 void AutomationEditor::centerTopBottomScroll()
 {
 	// default to the m_scrollLevel position
-	int pos = (int) m_scrollLevel;
+	int pos = static_cast<int>(m_scrollLevel);
 	// If a pattern exists...
-	if (m_pattern) {
+	if (m_pattern)
+	{
 		// get time map of current pattern
 		timeMap & time_map = m_pattern->getTimeMap();
 		// If time_map is not empty...
-		if ( !time_map.empty() ) {
-			// get the first object
-			timeMap::iterator it = time_map.begin();
+		if (!time_map.empty())
+		{
 			// set the position to the inverted value ((max + min) - value)
 			// If we set just (max - value), we're off by m_pattern's minimum
-			pos = m_pattern->getMax() + m_pattern->getMin() - (int) it.value();
+			pos = m_pattern->getMax() + m_pattern->getMin() - static_cast<int>(time_map.begin().value());
 		}
 	}
-	m_topBottomScroll->setValue( pos );
+	m_topBottomScroll->setValue(pos);
 }
 
 


### PR DESCRIPTION
When you open the Automation Editor it centers at the exact center of the vertical scroll range. This can be very annoying when you have something that has a large range, such as the tempo (10-999).

This PR makes it so that the Automation Editor centers to the first node in the `timeMap`.

As a small extra, I noticed my console was getting flooded with `not in range` messages when the lines cannot be drawn visibly on the editor. This blocks it out with a preprocessor guard checking `LMMS_DEBUG`.