### PR TITLE
Fix validPattern to check if hasAutomation as well

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -70,7 +70,7 @@ public:
 
 	inline bool validPattern() const
 	{
-		return m_pattern != nullptr;
+		return m_pattern != nullptr && m_pattern->hasAutomation();
 	}
 
 	virtual void saveSettings(QDomDocument & doc, QDomElement & parent);


### PR DESCRIPTION
I've noticed in `stable-1.2` as well as `master` that when opening a new (unconnected) Automation Editor it thinks it has a valid pattern object with a min/max of 0/1 and allows adding nodes to the pattern (of which are present after connecting a new automation object).

Honestly, I'm not entirely sure of the core details of why this works, but it seems to have returned to desired behavior (follows the `else`s of `validPattern` checks and whatnot) when I added this extra check.