### PR TITLE
Extract TemplatesMenu class from MainWindow

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -32,7 +32,6 @@
 
 #include "ConfigManager.h"
 #include "SubWindow.h"
-#include "TemplatesMenu.h"
 
 class QAction;
 class QDomElement;
@@ -204,7 +203,6 @@ private:
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;
 
-	TemplatesMenu * m_templatesMenu;
 	QMenu * m_recentlyOpenedProjectsMenu;
 
 	struct keyModifiers

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -32,6 +32,7 @@
 
 #include "ConfigManager.h"
 #include "SubWindow.h"
+#include "TemplatesMenu.h"
 
 class QAction;
 class QDomElement;
@@ -148,7 +149,6 @@ public slots:
 
 	void emptySlot();
 	void createNewProject();
-	void createNewProjectFromTemplate( QAction * _idx );
 	void openProject();
 	bool saveProject();
 	bool saveProjectAs();
@@ -204,9 +204,8 @@ private:
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;
 
-	QMenu * m_templatesMenu;
+	TemplatesMenu * m_templatesMenu;
 	QMenu * m_recentlyOpenedProjectsMenu;
-	int m_custom_templates_count;
 
 	struct keyModifiers
 	{
@@ -240,7 +239,6 @@ private:
 
 private slots:
 	void browseHelp();
-	void fillTemplatesMenu();
 	void openRecentlyOpenedProject( QAction * _action );
 	void showTool( QAction * _idx );
 	void updateRecentlyOpenedProjectsMenu();

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -17,7 +17,7 @@ private slots:
 	int addTemplatesFromDir( QDir dir );
 
 private:
-	int m_custom_templates_count;
+	int m_customTemplatesCount;
 };
 
 #endif // TEMPLATESMENU_H

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -1,0 +1,21 @@
+#ifndef TEMPLATESMENU_H
+#define TEMPLATESMENU_H
+
+#include <QMenu>
+
+class TemplatesMenu : public QMenu
+{
+    Q_OBJECT
+public:
+    TemplatesMenu(QWidget *parent = nullptr);
+    virtual ~TemplatesMenu() = default;
+
+private slots:
+    void createNewProjectFromTemplate( QAction * _idx );
+    void fillTemplatesMenu();
+
+private:
+    int m_custom_templates_count;
+};
+
+#endif // TEMPLATESMENU_H

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -6,18 +6,18 @@
 
 class TemplatesMenu : public QMenu
 {
-    Q_OBJECT
+	Q_OBJECT
 public:
-    TemplatesMenu(QWidget *parent = nullptr);
-    virtual ~TemplatesMenu() = default;
+	TemplatesMenu(QWidget *parent = nullptr);
+	virtual ~TemplatesMenu() = default;
 
 private slots:
-    void createNewProjectFromTemplate( QAction * _idx );
-    void fillTemplatesMenu();
+	void createNewProjectFromTemplate( QAction * _idx );
+	void fillTemplatesMenu();
 	int addTemplatesFromDir( QDir dir );
 
 private:
-    int m_custom_templates_count;
+	int m_custom_templates_count;
 };
 
 #endif // TEMPLATESMENU_H

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -1,6 +1,7 @@
 #ifndef TEMPLATESMENU_H
 #define TEMPLATESMENU_H
 
+#include <QDir>
 #include <QMenu>
 
 class TemplatesMenu : public QMenu
@@ -13,6 +14,7 @@ public:
 private slots:
     void createNewProjectFromTemplate( QAction * _idx );
     void fillTemplatesMenu();
+	int addTemplatesFromDir( QDir dir );
 
 private:
     int m_custom_templates_count;

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -14,7 +14,7 @@ public:
 private slots:
 	void createNewProjectFromTemplate( QAction * _idx );
 	void fillTemplatesMenu();
-	int addTemplatesFromDir( QDir dir );
+	int addTemplatesFromDir( const QDir& dir );
 
 private:
 	int m_customTemplatesCount;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,6 +43,8 @@ SET(LMMS_SRCS
 	gui/editors/PianoRoll.cpp
 	gui/editors/SongEditor.cpp
 
+	gui/menus/TemplatesMenu.cpp
+
 	gui/widgets/AutomatableButton.cpp
 	gui/widgets/AutomatableSlider.cpp
 	gui/widgets/CaptionMenu.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -277,11 +277,7 @@ void MainWindow::finalize()
 					this, SLOT( createNewProject() ),
 					QKeySequence::New );
 
-	m_templatesMenu = new QMenu( tr("New from template"), this );
-	connect( m_templatesMenu, SIGNAL( aboutToShow() ), SLOT( fillTemplatesMenu() ) );
-	connect( m_templatesMenu, SIGNAL( triggered( QAction * ) ),
-		 SLOT( createNewProjectFromTemplate( QAction * ) ) );
-
+	m_templatesMenu = new TemplatesMenu( this );
 	project_menu->addMenu(m_templatesMenu);
 
 	project_menu->addAction( embed::getIconPixmap( "project_open" ),
@@ -803,24 +799,6 @@ void MainWindow::createNewProject()
 	if( mayChangeProject(true) )
 	{
 		Engine::getSong()->createNewProject();
-	}
-}
-
-
-
-
-void MainWindow::createNewProjectFromTemplate( QAction * _idx )
-{
-	if( m_templatesMenu && mayChangeProject(true) )
-	{
-		int indexOfTemplate = m_templatesMenu->actions().indexOf( _idx );
-		bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
-		QString dirBase =  isFactoryTemplate ?
-				ConfigManager::inst()->factoryTemplatesDir() :
-				ConfigManager::inst()->userTemplateDir();
-
-		const QString f = dirBase + _idx->text().replace("&&", "&") + ".mpt";
-		Engine::getSong()->createNewProjectFromTemplate(f);
 	}
 }
 
@@ -1445,40 +1423,6 @@ void MainWindow::timerEvent( QTimerEvent * _te)
 	emit periodicUpdate();
 }
 
-
-
-
-void MainWindow::fillTemplatesMenu()
-{
-	m_templatesMenu->clear();
-
-	auto addTemplatesFromDir = [this]( QDir dir ) {
-		QStringList templates = dir.entryList( QStringList( "*.mpt" ),
-							QDir::Files | QDir::Readable );
-
-		if ( templates.size() && ! m_templatesMenu->actions().isEmpty() )
-		{
-			m_templatesMenu->addSeparator();
-		}
-
-		for( QStringList::iterator it = templates.begin();
-							it != templates.end(); ++it )
-		{
-			m_templatesMenu->addAction(
-						embed::getIconPixmap( "project_file" ),
-						( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
-#ifdef LMMS_BUILD_APPLE
-			m_templatesMenu->actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
-			m_templatesMenu->actions().last()->setIconVisibleInMenu(true);
-#endif
-		}
-
-		return templates.size();
-	};
-
-	m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
-	addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
-}
 
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -61,6 +61,7 @@
 #include "SetupDialog.h"
 #include "SideBar.h"
 #include "SongEditor.h"
+#include "TemplatesMenu.h"
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
 #include "ToolButton.h"
@@ -88,7 +89,6 @@ void disableAutoKeyAccelerators(QWidget* mainWindow)
 
 MainWindow::MainWindow() :
 	m_workspace( NULL ),
-	m_templatesMenu( NULL ),
 	m_recentlyOpenedProjectsMenu( NULL ),
 	m_toolsMenu( NULL ),
 	m_autoSaveTimer( this ),
@@ -277,8 +277,8 @@ void MainWindow::finalize()
 					this, SLOT( createNewProject() ),
 					QKeySequence::New );
 
-	m_templatesMenu = new TemplatesMenu( this );
-	project_menu->addMenu(m_templatesMenu);
+	auto templates_menu = new TemplatesMenu( this );
+	project_menu->addMenu(templates_menu);
 
 	project_menu->addAction( embed::getIconPixmap( "project_open" ),
 					tr( "&Open..." ),
@@ -425,7 +425,7 @@ void MainWindow::finalize()
 				tr( "Create new project from template" ),
 					this, SLOT( emptySlot() ),
 							m_toolBar );
-	project_new_from_template->setMenu( m_templatesMenu );
+	project_new_from_template->setMenu( templates_menu );
 	project_new_from_template->setPopupMode( ToolButton::InstantPopup );
 
 	ToolButton * project_open = new ToolButton(

--- a/src/gui/menus/TemplatesMenu.cpp
+++ b/src/gui/menus/TemplatesMenu.cpp
@@ -48,7 +48,7 @@ void TemplatesMenu::fillTemplatesMenu()
 
 
 
-int TemplatesMenu::addTemplatesFromDir( QDir dir ) {
+int TemplatesMenu::addTemplatesFromDir( const QDir& dir ) {
 	QStringList templates = dir.entryList( QStringList( "*.mpt" ),
 		QDir::Files | QDir::Readable );
 

--- a/src/gui/menus/TemplatesMenu.cpp
+++ b/src/gui/menus/TemplatesMenu.cpp
@@ -1,0 +1,71 @@
+#include <QDir>
+
+#include "TemplatesMenu.h"
+#include "GuiApplication.h"
+#include "ConfigManager.h"
+#include "Engine.h"
+#include "embed.h"
+#include "MainWindow.h"
+#include "Song.h"
+
+TemplatesMenu::TemplatesMenu(QWidget *parent) :
+	QMenu(tr("New from template"), parent)
+{
+	connect( this, SIGNAL( aboutToShow() ), SLOT( fillTemplatesMenu() ) );
+	connect( this, SIGNAL( triggered( QAction * ) ),
+			 SLOT( createNewProjectFromTemplate( QAction * ) ) );
+}
+
+
+
+
+void TemplatesMenu::createNewProjectFromTemplate( QAction * _idx )
+{
+		if( gui->mainWindow()->mayChangeProject(true) )
+		{
+				int indexOfTemplate = actions().indexOf( _idx );
+				bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
+				QString dirBase =  isFactoryTemplate ?
+								ConfigManager::inst()->factoryTemplatesDir() :
+								ConfigManager::inst()->userTemplateDir();
+
+				const QString f = dirBase + _idx->text().replace("&&", "&") + ".mpt";
+				Engine::getSong()->createNewProjectFromTemplate(f);
+		}
+}
+
+
+
+
+
+void TemplatesMenu::fillTemplatesMenu()
+{
+		clear();
+
+		auto addTemplatesFromDir = [this]( QDir dir ) {
+				QStringList templates = dir.entryList( QStringList( "*.mpt" ),
+														QDir::Files | QDir::Readable );
+
+				if ( templates.size() && ! actions().isEmpty() )
+				{
+						addSeparator();
+				}
+
+				for( QStringList::iterator it = templates.begin();
+														it != templates.end(); ++it )
+				{
+						addAction(
+										embed::getIconPixmap( "project_file" ),
+										( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
+#ifdef LMMS_BUILD_APPLE
+						actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
+						actions().last()->setIconVisibleInMenu(true);
+#endif
+				}
+
+				return templates.size();
+		};
+
+		m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
+		addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
+}

--- a/src/gui/menus/TemplatesMenu.cpp
+++ b/src/gui/menus/TemplatesMenu.cpp
@@ -1,5 +1,3 @@
-#include <QDir>
-
 #include "TemplatesMenu.h"
 #include "GuiApplication.h"
 #include "ConfigManager.h"
@@ -42,30 +40,33 @@ void TemplatesMenu::fillTemplatesMenu()
 {
 		clear();
 
-		auto addTemplatesFromDir = [this]( QDir dir ) {
-				QStringList templates = dir.entryList( QStringList( "*.mpt" ),
-														QDir::Files | QDir::Readable );
-
-				if ( templates.size() && ! actions().isEmpty() )
-				{
-						addSeparator();
-				}
-
-				for( QStringList::iterator it = templates.begin();
-														it != templates.end(); ++it )
-				{
-						addAction(
-										embed::getIconPixmap( "project_file" ),
-										( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
-#ifdef LMMS_BUILD_APPLE
-						actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
-						actions().last()->setIconVisibleInMenu(true);
-#endif
-				}
-
-				return templates.size();
-		};
-
 		m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
 		addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
 }
+
+
+
+
+int TemplatesMenu::addTemplatesFromDir( QDir dir ) {
+	QStringList templates = dir.entryList( QStringList( "*.mpt" ),
+											QDir::Files | QDir::Readable );
+
+	if ( templates.size() && ! actions().isEmpty() )
+	{
+			addSeparator();
+	}
+
+	for( QStringList::iterator it = templates.begin();
+											it != templates.end(); ++it )
+	{
+			addAction(
+							embed::getIconPixmap( "project_file" ),
+							( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
+#ifdef LMMS_BUILD_APPLE
+			actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
+			actions().last()->setIconVisibleInMenu(true);
+#endif
+	}
+
+	return templates.size();
+};

--- a/src/gui/menus/TemplatesMenu.cpp
+++ b/src/gui/menus/TemplatesMenu.cpp
@@ -11,7 +11,7 @@ TemplatesMenu::TemplatesMenu(QWidget *parent) :
 {
 	connect( this, SIGNAL( aboutToShow() ), SLOT( fillTemplatesMenu() ) );
 	connect( this, SIGNAL( triggered( QAction * ) ),
-			 SLOT( createNewProjectFromTemplate( QAction * ) ) );
+		SLOT( createNewProjectFromTemplate( QAction * ) ) );
 }
 
 
@@ -19,17 +19,17 @@ TemplatesMenu::TemplatesMenu(QWidget *parent) :
 
 void TemplatesMenu::createNewProjectFromTemplate( QAction * _idx )
 {
-		if( gui->mainWindow()->mayChangeProject(true) )
-		{
-				int indexOfTemplate = actions().indexOf( _idx );
-				bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
-				QString dirBase =  isFactoryTemplate ?
-								ConfigManager::inst()->factoryTemplatesDir() :
-								ConfigManager::inst()->userTemplateDir();
+	if( gui->mainWindow()->mayChangeProject(true) )
+	{
+		int indexOfTemplate = actions().indexOf( _idx );
+		bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
+		QString dirBase =  isFactoryTemplate ?
+			ConfigManager::inst()->factoryTemplatesDir() :
+			ConfigManager::inst()->userTemplateDir();
 
-				const QString f = dirBase + _idx->text().replace("&&", "&") + ".mpt";
-				Engine::getSong()->createNewProjectFromTemplate(f);
-		}
+		const QString f = dirBase + _idx->text().replace("&&", "&") + ".mpt";
+		Engine::getSong()->createNewProjectFromTemplate(f);
+	}
 }
 
 
@@ -38,10 +38,10 @@ void TemplatesMenu::createNewProjectFromTemplate( QAction * _idx )
 
 void TemplatesMenu::fillTemplatesMenu()
 {
-		clear();
+	clear();
 
-		m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
-		addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
+	m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
+	addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
 }
 
 
@@ -49,24 +49,24 @@ void TemplatesMenu::fillTemplatesMenu()
 
 int TemplatesMenu::addTemplatesFromDir( QDir dir ) {
 	QStringList templates = dir.entryList( QStringList( "*.mpt" ),
-											QDir::Files | QDir::Readable );
+		QDir::Files | QDir::Readable );
 
 	if ( templates.size() && ! actions().isEmpty() )
 	{
-			addSeparator();
+		addSeparator();
 	}
 
 	for( QStringList::iterator it = templates.begin();
-											it != templates.end(); ++it )
+		it != templates.end(); ++it )
 	{
-			addAction(
-							embed::getIconPixmap( "project_file" ),
-							( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
+		addAction(
+			embed::getIconPixmap( "project_file" ),
+			( *it ).left( ( *it ).length() - 4 ).replace("&", "&&") );
 #ifdef LMMS_BUILD_APPLE
-			actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
-			actions().last()->setIconVisibleInMenu(true);
+		actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
+		actions().last()->setIconVisibleInMenu(true);
 #endif
 	}
 
 	return templates.size();
-};
+}

--- a/src/gui/menus/TemplatesMenu.cpp
+++ b/src/gui/menus/TemplatesMenu.cpp
@@ -7,7 +7,8 @@
 #include "Song.h"
 
 TemplatesMenu::TemplatesMenu(QWidget *parent) :
-	QMenu(tr("New from template"), parent)
+	QMenu(tr("New from template"), parent),
+	m_customTemplatesCount(0)
 {
 	connect( this, SIGNAL( aboutToShow() ), SLOT( fillTemplatesMenu() ) );
 	connect( this, SIGNAL( triggered( QAction * ) ),
@@ -22,7 +23,7 @@ void TemplatesMenu::createNewProjectFromTemplate( QAction * _idx )
 	if( gui->mainWindow()->mayChangeProject(true) )
 	{
 		int indexOfTemplate = actions().indexOf( _idx );
-		bool isFactoryTemplate = indexOfTemplate >= m_custom_templates_count;
+		bool isFactoryTemplate = indexOfTemplate >= m_customTemplatesCount;
 		QString dirBase =  isFactoryTemplate ?
 			ConfigManager::inst()->factoryTemplatesDir() :
 			ConfigManager::inst()->userTemplateDir();
@@ -40,7 +41,7 @@ void TemplatesMenu::fillTemplatesMenu()
 {
 	clear();
 
-	m_custom_templates_count = addTemplatesFromDir( ConfigManager::inst()->userTemplateDir() );
+	m_customTemplatesCount = addTemplatesFromDir(ConfigManager::inst()->userTemplateDir() );
 	addTemplatesFromDir( ConfigManager::inst()->factoryProjectsDir() + "templates" );
 }
 


### PR DESCRIPTION
Extracts the logic for the project template menu from MainWindow into a new class.

This does not change or add functionality. It's mainly intended to reduce the size of MainWindow and allow extracting the toolbar logic in the long term.