### PR TITLE
Fix stuck keys when dragging on piano view

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -199,7 +199,7 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 
 	lock();
 
-	if( m_totalFramesPlayed == 0 && !m_hasMidiNote
+	if( m_totalFramesPlayed == 0 && !m_hasMidiNote && !m_released
 		&& ( hasParent() || ! m_instrumentTrack->isArpeggioEnabled() ) )
 	{
 		m_hasMidiNote = true;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -199,7 +199,12 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 
 	lock();
 
-	if( m_totalFramesPlayed == 0 && !m_hasMidiNote && !m_released
+	/* It is possible for NotePlayHandle::noteOff to be called before NotePlayHandle::play,
+	 * which results in a note-on message being sent without a subsequent note-off message.
+	 * Therefore, we check here whether the note has already been released before sending
+	 * the note-on message. */
+	if( !m_released
+		&& m_totalFramesPlayed == 0 && !m_hasMidiNote
 		&& ( hasParent() || ! m_instrumentTrack->isArpeggioEnabled() ) )
 	{
 		m_hasMidiNote = true;


### PR DESCRIPTION
Fixes #5028.

It is possible for `NotePlayHandle::noteOff` to be called before `NotePlayHandle::play` is called for the first time, which results in a note-on message being sent without a subsequent note-off message. This PR checks whether the note has already been released before sending the note-on message.