### PR TITLE
Allow playing muted pattern in the piano roll

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -653,7 +653,9 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 	{
 		Pattern* p = dynamic_cast<Pattern*>( *it );
 		// everything which is not a pattern or muted won't be played
-		if( p == NULL || ( *it )->isMuted() )
+		if(p == NULL ||
+			(Engine::getSong()->playMode() == Song::Mode_PlaySong
+			&& (*it)->isMuted()))
 		{
 			continue;
 		}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -652,9 +652,10 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 	for( tcoVector::Iterator it = tcos.begin(); it != tcos.end(); ++it )
 	{
 		Pattern* p = dynamic_cast<Pattern*>( *it );
-		// everything which is not a pattern or muted won't be played
+		// everything which is not a pattern won't be played
+		// A pattern playing in the Piano Roll window will always play
 		if(p == NULL ||
-			(Engine::getSong()->playMode() == Song::Mode_PlaySong
+			(Engine::getSong()->playMode() != Song::Mode_PlayPattern
 			&& (*it)->isMuted()))
 		{
 			continue;


### PR DESCRIPTION
An annoyance to me so far has been wanting to listen to a pattern I just opened from the Song Editor, but I've muted it beforehand for whatever reason. I am then required to click back to the Song Editor to unmute the pattern (I don't know if there's a shortcut key to unmute the pattern from the Piano Roll window) and then I can go back to the Piano Roll to listen to it.

This should allow the Piano Roll (and I believe any other editor which uses `InstrumentTrack`) to play its pattern while being muted on the Song Editor.

My next step I want to be able to do is play while the entire track is muted, since this PR doesn't fix that instance.