### PR TITLE
Fix #4188 - Check for failed std::find

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -549,7 +549,10 @@ void PianoRoll::markSemiTone( int i )
 				for (int ix = 0; ix < aok.size(); ++ix)
 				{
 					i = std::find(m_markedSemiTones.begin(), m_markedSemiTones.end(), aok.at(ix));
-					m_markedSemiTones.erase(i);
+					if (i != m_markedSemiTones.end())
+					{
+						m_markedSemiTones.erase(i);
+					}
 				}
 			}
 			else


### PR DESCRIPTION
I noticed this crashed on `stable-1.2` and then in `master`.

Crash happens when trying to erase a note that doesn't exist in `m_markedSemiTones` when selecting "Mark/unmark all corresponding octave semitones", so the solution is just to check for a failed `std::find`.