### PR TITLE
Extract RecentProjectsMenu class from MainWindow

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -32,7 +32,6 @@
 
 #include "ConfigManager.h"
 #include "SubWindow.h"
-#include "RecentProjectsMenu.h"
 
 class QAction;
 class QDomElement;
@@ -203,8 +202,6 @@ private:
 
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;
-
-	RecentProjectsMenu * m_recentlyOpenedProjectsMenu;
 
 	struct keyModifiers
 	{

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -32,6 +32,7 @@
 
 #include "ConfigManager.h"
 #include "SubWindow.h"
+#include "RecentProjectsMenu.h"
 
 class QAction;
 class QDomElement;
@@ -203,7 +204,7 @@ private:
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;
 
-	QMenu * m_recentlyOpenedProjectsMenu;
+	RecentProjectsMenu * m_recentlyOpenedProjectsMenu;
 
 	struct keyModifiers
 	{

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -240,7 +240,6 @@ private slots:
 	void browseHelp();
 	void openRecentlyOpenedProject( QAction * _action );
 	void showTool( QAction * _idx );
-	void updateRecentlyOpenedProjectsMenu();
 	void updateViewMenu( void );
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -238,7 +238,6 @@ private:
 
 private slots:
 	void browseHelp();
-	void openRecentlyOpenedProject( QAction * _action );
 	void showTool( QAction * _idx );
 	void updateViewMenu( void );
 	void updateConfig( QAction * _who );

--- a/include/RecentProjectsMenu.h
+++ b/include/RecentProjectsMenu.h
@@ -1,0 +1,14 @@
+#ifndef RECENTPROJECTSMENU_H
+#define RECENTPROJECTSMENU_H
+
+#include <QMenu>
+
+class RecentProjectsMenu : public QMenu
+{
+	Q_OBJECT
+public:
+	RecentProjectsMenu(QWidget *parent = nullptr);
+
+};
+
+#endif // RECENTPROJECTSMENU_H

--- a/include/RecentProjectsMenu.h
+++ b/include/RecentProjectsMenu.h
@@ -9,6 +9,8 @@ class RecentProjectsMenu : public QMenu
 public:
 	RecentProjectsMenu(QWidget *parent = nullptr);
 
+private slots:
+	void updateRecentlyOpenedProjectsMenu();
 };
 
 #endif // RECENTPROJECTSMENU_H

--- a/include/RecentProjectsMenu.h
+++ b/include/RecentProjectsMenu.h
@@ -11,6 +11,7 @@ public:
 
 private slots:
 	void updateRecentlyOpenedProjectsMenu();
+	void openRecentlyOpenedProject( QAction * _action );
 };
 
 #endif // RECENTPROJECTSMENU_H

--- a/include/RecentProjectsMenu.h
+++ b/include/RecentProjectsMenu.h
@@ -10,8 +10,8 @@ public:
 	RecentProjectsMenu(QWidget *parent = nullptr);
 
 private slots:
-	void updateRecentlyOpenedProjectsMenu();
-	void openRecentlyOpenedProject( QAction * _action );
+	void fillMenu();
+	void openProject(QAction * _action );
 };
 
 #endif // RECENTPROJECTSMENU_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(LMMS_SRCS
 	gui/editors/PianoRoll.cpp
 	gui/editors/SongEditor.cpp
 
+	gui/menus/RecentProjectsMenu.cpp
 	gui/menus/TemplatesMenu.cpp
 
 	gui/widgets/AutomatableButton.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -57,6 +57,7 @@
 #include "ProjectJournal.h"
 #include "ProjectNotes.h"
 #include "ProjectRenderer.h"
+#include "RecentProjectsMenu.h"
 #include "RemotePlugin.h"
 #include "SetupDialog.h"
 #include "SideBar.h"
@@ -89,7 +90,6 @@ void disableAutoKeyAccelerators(QWidget* mainWindow)
 
 MainWindow::MainWindow() :
 	m_workspace( NULL ),
-	m_recentlyOpenedProjectsMenu( NULL ),
 	m_toolsMenu( NULL ),
 	m_autoSaveTimer( this ),
 	m_viewMenu( NULL ),
@@ -285,8 +285,7 @@ void MainWindow::finalize()
 					this, SLOT( openProject() ),
 					QKeySequence::Open );
 
-	m_recentlyOpenedProjectsMenu = new RecentProjectsMenu(this);
-	project_menu->addMenu(m_recentlyOpenedProjectsMenu);
+	project_menu->addMenu(new RecentProjectsMenu(this));
 
 	project_menu->addAction( embed::getIconPixmap( "project_save" ),
 					tr( "&Save" ),
@@ -434,7 +433,7 @@ void MainWindow::finalize()
 				embed::getIconPixmap( "project_open_recent" ),
 					tr( "Recently opened projects" ),
 					this, SLOT( emptySlot() ), m_toolBar );
-	project_open_recent->setMenu( m_recentlyOpenedProjectsMenu );
+	project_open_recent->setMenu( new RecentProjectsMenu(this) );
 	project_open_recent->setPopupMode( ToolButton::InstantPopup );
 
 	ToolButton * project_save = new ToolButton(

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -288,8 +288,6 @@ void MainWindow::finalize()
 	m_recentlyOpenedProjectsMenu = new RecentProjectsMenu(this);
 	project_menu->addMenu(m_recentlyOpenedProjectsMenu);
 
-	connect( m_recentlyOpenedProjectsMenu, SIGNAL( aboutToShow() ),
-			this, SLOT( updateRecentlyOpenedProjectsMenu() ) );
 	connect( m_recentlyOpenedProjectsMenu, SIGNAL( triggered( QAction * ) ),
 			this, SLOT( openRecentlyOpenedProject( QAction * ) ) );
 
@@ -826,42 +824,6 @@ void MainWindow::openProject()
 	}
 }
 
-
-
-
-void MainWindow::updateRecentlyOpenedProjectsMenu()
-{
-	m_recentlyOpenedProjectsMenu->clear();
-	QStringList rup = ConfigManager::inst()->recentlyOpenedProjects();
-
-//	The file history goes 50 deep but we only show the 15
-//	most recent ones that we can open and omit .mpt files.
-	int shownInMenu = 0;
-	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
-	{
-		QFileInfo recentFile( *it );
-		if ( recentFile.exists() &&
-				*it != ConfigManager::inst()->recoveryFile() )
-		{
-			if( recentFile.suffix().toLower() == "mpt" )
-			{
-				continue;
-			}
-
-			m_recentlyOpenedProjectsMenu->addAction(
-					embed::getIconPixmap( "project_file" ), it->replace("&", "&&") );
-#ifdef LMMS_BUILD_APPLE
-			m_recentlyOpenedProjectsMenu->actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
-			m_recentlyOpenedProjectsMenu->actions().last()->setIconVisibleInMenu(true);
-#endif
-			shownInMenu++;
-			if( shownInMenu >= 15 )
-			{
-				return;
-			}
-		}
-	}
-}
 
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -285,9 +285,9 @@ void MainWindow::finalize()
 					this, SLOT( openProject() ),
 					QKeySequence::Open );
 
-	m_recentlyOpenedProjectsMenu = project_menu->addMenu(
-				embed::getIconPixmap( "project_open_recent" ),
-					tr( "&Recently Opened Projects" ) );
+	m_recentlyOpenedProjectsMenu = new RecentProjectsMenu(this);
+	project_menu->addMenu(m_recentlyOpenedProjectsMenu);
+
 	connect( m_recentlyOpenedProjectsMenu, SIGNAL( aboutToShow() ),
 			this, SLOT( updateRecentlyOpenedProjectsMenu() ) );
 	connect( m_recentlyOpenedProjectsMenu, SIGNAL( triggered( QAction * ) ),

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -288,9 +288,6 @@ void MainWindow::finalize()
 	m_recentlyOpenedProjectsMenu = new RecentProjectsMenu(this);
 	project_menu->addMenu(m_recentlyOpenedProjectsMenu);
 
-	connect( m_recentlyOpenedProjectsMenu, SIGNAL( triggered( QAction * ) ),
-			this, SLOT( openRecentlyOpenedProject( QAction * ) ) );
-
 	project_menu->addAction( embed::getIconPixmap( "project_save" ),
 					tr( "&Save" ),
 					this, SLOT( saveProject() ),
@@ -821,20 +818,6 @@ void MainWindow::openProject()
 			song->loadProject( ofd.selectedFiles()[0] );
 			setCursor( Qt::ArrowCursor );
 		}
-	}
-}
-
-
-
-
-void MainWindow::openRecentlyOpenedProject( QAction * _action )
-{
-	if ( mayChangeProject(true) )
-	{
-		const QString f = _action->text().replace("&&", "&");
-		setCursor( Qt::WaitCursor );
-		Engine::getSong()->loadProject( f );
-		setCursor( Qt::ArrowCursor );
 	}
 }
 

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -1,0 +1,8 @@
+#include "RecentProjectsMenu.h"
+#include "embed.h"
+
+RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
+	QMenu(tr( "&Recently Opened Projects" ), parent)
+{
+	setIcon(embed::getIconPixmap( "project_open_recent" ));
+}

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -13,15 +13,15 @@ RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
 	setIcon(embed::getIconPixmap( "project_open_recent" ));
 
 	connect( this, SIGNAL( aboutToShow() ),
-			 this, SLOT( updateRecentlyOpenedProjectsMenu() ) );
+			 this, SLOT(fillMenu() ) );
 	connect( this, SIGNAL( triggered( QAction * ) ),
-			 this, SLOT( openRecentlyOpenedProject( QAction * ) ) );
+			 this, SLOT(openProject(QAction * ) ) );
 }
 
 
 
 
-void RecentProjectsMenu::updateRecentlyOpenedProjectsMenu()
+void RecentProjectsMenu::fillMenu()
 {
 	clear();
 	QStringList rup = ConfigManager::inst()->recentlyOpenedProjects();
@@ -62,7 +62,7 @@ void RecentProjectsMenu::updateRecentlyOpenedProjectsMenu()
 
 
 
-void RecentProjectsMenu::openRecentlyOpenedProject( QAction * _action )
+void RecentProjectsMenu::openProject(QAction * _action )
 {
 	if ( gui->mainWindow()->mayChangeProject(true) )
 	{

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -1,11 +1,14 @@
 #include "RecentProjectsMenu.h"
-#include "embed.h"
-#include "ConfigManager.h"
+
 #include <QFileInfo>
-#include "Song.h"
+
+#include "ConfigManager.h"
 #include "Engine.h"
-#include "MainWindow.h"
+#include "Song.h"
+
+#include "embed.h"
 #include "GuiApplication.h"
+#include "MainWindow.h"
 
 RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
 	QMenu(tr( "&Recently Opened Projects" ), parent)

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -1,8 +1,50 @@
 #include "RecentProjectsMenu.h"
 #include "embed.h"
+#include "ConfigManager.h"
+#include <QFileInfo>
 
 RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
 	QMenu(tr( "&Recently Opened Projects" ), parent)
 {
 	setIcon(embed::getIconPixmap( "project_open_recent" ));
+
+	connect( this, SIGNAL( aboutToShow() ),
+			 this, SLOT( updateRecentlyOpenedProjectsMenu() ) );
+}
+
+
+
+
+void RecentProjectsMenu::updateRecentlyOpenedProjectsMenu()
+{
+	clear();
+	QStringList rup = ConfigManager::inst()->recentlyOpenedProjects();
+
+	//	The file history goes 50 deep but we only show the 15
+	//	most recent ones that we can open and omit .mpt files.
+	int shownInMenu = 0;
+	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
+	{
+		QFileInfo recentFile( *it );
+		if ( recentFile.exists() &&
+			 *it != ConfigManager::inst()->recoveryFile() )
+		{
+			if( recentFile.suffix().toLower() == "mpt" )
+			{
+				continue;
+			}
+
+			addAction(
+				embed::getIconPixmap( "project_file" ), it->replace("&", "&&") );
+#ifdef LMMS_BUILD_APPLE
+			actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
+			actions().last()->setIconVisibleInMenu(true);
+#endif
+			shownInMenu++;
+			if( shownInMenu >= 15 )
+			{
+				return;
+			}
+		}
+	}
 }

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -26,31 +26,35 @@ void RecentProjectsMenu::updateRecentlyOpenedProjectsMenu()
 	clear();
 	QStringList rup = ConfigManager::inst()->recentlyOpenedProjects();
 
+	auto projectFileIcon = embed::getIconPixmap( "project_file" );
+
 	//	The file history goes 50 deep but we only show the 15
 	//	most recent ones that we can open and omit .mpt files.
 	int shownInMenu = 0;
-	for( QStringList::iterator it = rup.begin(); it != rup.end(); ++it )
+	for(QString& fileName : rup)
 	{
-		QFileInfo recentFile( *it );
-		if ( recentFile.exists() &&
-			 *it != ConfigManager::inst()->recoveryFile() )
+		QFileInfo recentFile(fileName);
+		if (!recentFile.exists() ||
+			fileName == ConfigManager::inst()->recoveryFile() )
 		{
-			if( recentFile.suffix().toLower() == "mpt" )
-			{
-				continue;
-			}
+			continue;
+		}
 
-			addAction(
-				embed::getIconPixmap( "project_file" ), it->replace("&", "&&") );
+		if( recentFile.suffix().toLower() == "mpt" )
+		{
+			continue;
+		}
+
+		addAction(projectFileIcon, fileName.replace("&", "&&") );
 #ifdef LMMS_BUILD_APPLE
-			actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
-			actions().last()->setIconVisibleInMenu(true);
+		actions().last()->setIconVisibleInMenu(false); // QTBUG-44565 workaround
+		actions().last()->setIconVisibleInMenu(true);
 #endif
-			shownInMenu++;
-			if( shownInMenu >= 15 )
-			{
-				return;
-			}
+
+		shownInMenu++;
+		if( shownInMenu >= 15 )
+		{
+			break;
 		}
 	}
 }

--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -2,6 +2,10 @@
 #include "embed.h"
 #include "ConfigManager.h"
 #include <QFileInfo>
+#include "Song.h"
+#include "Engine.h"
+#include "MainWindow.h"
+#include "GuiApplication.h"
 
 RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
 	QMenu(tr( "&Recently Opened Projects" ), parent)
@@ -10,6 +14,8 @@ RecentProjectsMenu::RecentProjectsMenu(QWidget *parent) :
 
 	connect( this, SIGNAL( aboutToShow() ),
 			 this, SLOT( updateRecentlyOpenedProjectsMenu() ) );
+	connect( this, SIGNAL( triggered( QAction * ) ),
+			 this, SLOT( openRecentlyOpenedProject( QAction * ) ) );
 }
 
 
@@ -46,5 +52,19 @@ void RecentProjectsMenu::updateRecentlyOpenedProjectsMenu()
 				return;
 			}
 		}
+	}
+}
+
+
+
+
+void RecentProjectsMenu::openRecentlyOpenedProject( QAction * _action )
+{
+	if ( gui->mainWindow()->mayChangeProject(true) )
+	{
+		const QString f = _action->text().replace("&&", "&");
+		setCursor( Qt::WaitCursor );
+		Engine::getSong()->loadProject( f );
+		setCursor( Qt::ArrowCursor );
 	}
 }


### PR DESCRIPTION
Extracts the logic for the recent projects menu from MainWindow into a new class.

This does not change or add functionality. It's mainly intended to reduce the size of MainWindow and allow extracting the toolbar logic in the long term.

This refactoring is similar to https://github.com/LMMS/lmms/pull/5125.