### PR TITLE
Fix loading state for recent projects menu

### DIFF
--- a/src/gui/menus/RecentProjectsMenu.cpp
+++ b/src/gui/menus/RecentProjectsMenu.cpp
@@ -67,11 +67,12 @@ void RecentProjectsMenu::fillMenu()
 
 void RecentProjectsMenu::openProject(QAction * _action )
 {
-	if ( gui->mainWindow()->mayChangeProject(true) )
+	auto mainWindow = gui->mainWindow();
+	if (mainWindow->mayChangeProject(true))
 	{
 		const QString f = _action->text().replace("&&", "&");
-		setCursor( Qt::WaitCursor );
+		mainWindow->setCursor( Qt::WaitCursor );
 		Engine::getSong()->loadProject( f );
-		setCursor( Qt::ArrowCursor );
+		mainWindow->setCursor( Qt::ArrowCursor );
 	}
 }


### PR DESCRIPTION
This fixes a small bug introduced by https://github.com/LMMS/lmms/pull/5148: When choosing a project from the recent projects menu, no loading indicator is shown because the `setCursor()` call happens on the menu instead of the MainWindow.

This can be reproduced by replacing `loadProject()` with something like `this->thread()->sleep(10);`