### PR TITLE
Set focus on Automation Editor editor instead of window.

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -297,6 +297,9 @@ public slots:
 signals:
 	void currentPatternChanged();
 
+protected:
+	virtual void focusInEvent(QFocusEvent * event);
+
 protected slots:
 	void play();
 	void stop();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -198,6 +198,8 @@ AutomationEditor::AutomationEditor() :
 	setCurrentPattern( NULL );
 
 	setMouseTracking( true );
+	setFocusPolicy( Qt::StrongFocus );
+	setFocus();
 }
 
 
@@ -2514,6 +2516,11 @@ void AutomationEditorWindow::clearCurrentPattern()
 {
 	m_editor->m_pattern = nullptr;
 	setCurrentPattern(nullptr);
+}
+
+void AutomationEditorWindow::focusInEvent(QFocusEvent * event)
+{
+	m_editor->setFocus( event->reason() );
 }
 
 void AutomationEditorWindow::play()


### PR DESCRIPTION
Set focus on Automation Editor editor instead of window so keyPressEvent's can be processed. This makes shortcuts work without manually have to click somewhere in the grey area of the editor itself.