### PR TITLE
Translation Fixes (Continuation of #4482)

### DIFF
--- a/data/locale/pl.ts
+++ b/data/locale/pl.ts
@@ -3002,7 +3002,7 @@ You can remove and move FX channels in the context menu, which is accessed by ri
     </message>
     <message>
         <source>VELOCITY</source>
-        <translation>PRĘDKOŚĆ UDERZENIA</translation>
+        <translation>PRĘDKOŚĆ</translation>
     </message>
     <message>
         <source>ENABLE MIDI OUTPUT</source>

--- a/data/locale/ru.ts
+++ b/data/locale/ru.ts
@@ -1664,7 +1664,7 @@ Oe Ai &lt;oeai/at/symbiants/dot/com&gt;</translation>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="66"/>
         <source>W/D</source>
-        <translation>НАСЫЩ</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="69"/>
@@ -1679,7 +1679,7 @@ Oe Ai &lt;oeai/at/symbiants/dot/com&gt;</translation>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="76"/>
         <source>DECAY</source>
-        <translation>ЗАТУХАНИЕ</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="79"/>

--- a/data/locale/sv.ts
+++ b/data/locale/sv.ts
@@ -1658,7 +1658,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="66"/>
         <source>W/D</source>
-        <translation>B/T</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="69"/>
@@ -1673,7 +1673,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="76"/>
         <source>DECAY</source>
-        <translation>FÖRFALL</translation>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="79"/>

--- a/data/locale/uk.ts
+++ b/data/locale/uk.ts
@@ -1678,7 +1678,7 @@ If you&apos;re interested in translating LMMS in another language or want to imp
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="76"/>
         <source>DECAY</source>
-        <translation>ЗГАСАННЯ</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../../src/gui/widgets/EffectView.cpp" line="79"/>


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/5032

Fixing some formatting issues in LMMS-1.2 caused by translations.
Continuation of https://github.com/LMMS/lmms/pull/4482

Problematic translation strings replaced with `<translation type="unfinished"/>` as mentioned [here](https://github.com/LMMS/lmms/issues/5032#issuecomment-531496557) except for the [polish translation](https://github.com/LMMS/lmms/compare/stable-1.2...zonkmachine:translationfixes2?expand=1#diff-f644f02e8f755b7cb39a896fa278355fR3005-L3005) where I removed one of the words. I don't speak polish. Not a bit.


