### PR TITLE
Implement fade in to prevent Triple Osc from clicking

### DIFF
--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -132,8 +132,8 @@ public:
 
 
 protected:
-    // fade in to prevent clicks
-    void applyFadeIn( sampleFrame * buf, const NotePlayHandle * _n );
+	// fade in to prevent clicks
+	void applyFadeIn( sampleFrame * buf, const NotePlayHandle * _n );
 
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -133,7 +133,7 @@ public:
 
 protected:
 	// fade in to prevent clicks
-	void applyFadeIn(sampleFrame * buf, const NotePlayHandle * _n);
+	void applyFadeIn(sampleFrame * buf, const NotePlayHandle * n);
 
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -133,7 +133,7 @@ public:
 
 protected:
 	// fade in to prevent clicks
-	void applyFadeIn( sampleFrame * buf, const NotePlayHandle * _n );
+	void applyFadeIn(sampleFrame * buf, const NotePlayHandle * _n);
 
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -133,7 +133,7 @@ public:
 
 protected:
 	// fade in to prevent clicks
-	void applyFadeIn(sampleFrame * buf, const NotePlayHandle * n);
+	void applyFadeIn(sampleFrame * buf, NotePlayHandle * n);
 
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -132,6 +132,9 @@ public:
 
 
 protected:
+    // fade in to prevent clicks
+    void applyFadeIn( sampleFrame * buf, const NotePlayHandle * _n );
+
 	// instruments may use this to apply a soft fade out at the end of
 	// notes - method does this only if really less or equal
 	// desiredReleaseFrames() frames are left

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -49,6 +49,9 @@ public:
 	void * m_pluginData;
 	std::unique_ptr<BasicFilters<>> m_filter;
 
+	// length of the declicking fade in
+	fpp_t m_fadeInLength;
+
 	// specifies origin of NotePlayHandle
 	enum Origins
 	{

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -364,6 +364,7 @@ void TripleOscillator::playNote( NotePlayHandle * _n,
 	osc_l->update( _working_buffer + offset, frames, 0 );
 	osc_r->update( _working_buffer + offset, frames, 1 );
 
+    applyFadeIn( _working_buffer, _n );
 	applyRelease( _working_buffer, _n );
 
 	instrumentTrack()->processAudioBuffer( _working_buffer, frames + offset, _n );

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -364,7 +364,7 @@ void TripleOscillator::playNote( NotePlayHandle * _n,
 	osc_l->update( _working_buffer + offset, frames, 0 );
 	osc_r->update( _working_buffer + offset, frames, 1 );
 
-    applyFadeIn( _working_buffer, _n );
+	applyFadeIn( _working_buffer, _n );
 	applyRelease( _working_buffer, _n );
 
 	instrumentTrack()->processAudioBuffer( _working_buffer, frames + offset, _n );

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -364,7 +364,7 @@ void TripleOscillator::playNote( NotePlayHandle * _n,
 	osc_l->update( _working_buffer + offset, frames, 0 );
 	osc_r->update( _working_buffer + offset, frames, 1 );
 
-	applyFadeIn( _working_buffer, _n );
+	applyFadeIn(_working_buffer, _n);
 	applyRelease( _working_buffer, _n );
 
 	instrumentTrack()->processAudioBuffer( _working_buffer, frames + offset, _n );

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -129,11 +129,12 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 	if (total == 0)
 	{
 		const fpp_t frames = n->framesLeftForCurrentPeriod();
+		const f_cnt_t offset = n->offset();
 
 		// We need to skip the first sample because it almost always
 		// produces a zero crossing; it's not helpful while
 		// determining the fade in length. Hence 1
-		int max_zc = count_zero_crossings(buf, 1, frames);
+		int max_zc = count_zero_crossings(buf, offset+1, offset+frames);
 
 		fpp_t length = getFadeInLength(MAX_FADE_IN_LENGTH,frames,max_zc);
 		n->m_fadeInLength = length;
@@ -144,7 +145,7 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 		{
 			for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-				buf[f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) f / (float)n->m_fadeInLength);
+				buf[offset+f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) f / (float)n->m_fadeInLength);
 			}
 		}
 	}

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -83,7 +83,7 @@ bool Instrument::isFromTrack( const Track * _track ) const
 }
 
 
-void Instrument::applyFadeIn(  sampleFrame * buf, const NotePlayHandle * n )
+void Instrument::applyFadeIn(sampleFrame * buf, const NotePlayHandle * n)
 {
 	// apply only if it's the start of the note
 	if (n->totalFramesPlayed() == 0)
@@ -96,15 +96,15 @@ void Instrument::applyFadeIn(  sampleFrame * buf, const NotePlayHandle * n )
 		int max_zc = 0;
 
 		// determine the zero point crossing counts
-		for ( fpp_t f = 0; f < frames; ++f )
+		for (fpp_t f = 0; f < frames; ++f)
 		{
-			for ( ch_cnt_t ch=0; ch < DEFAULT_CHANNELS; ++ch )
+			for (ch_cnt_t ch=0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-				if ( ( buf[f-1][ch] < 0.0 && buf[f][ch] > 0.0 ) ||
-						( buf[f-1][ch] > 0.0 && buf[f][ch] < 0.0 ) )
+				if ((buf[f-1][ch] < 0.0 && buf[f][ch] > 0.0) ||
+						(buf[f-1][ch] > 0.0 && buf[f][ch] < 0.0))
 				{
 					++zero_crossings[ch];
-					if ( zero_crossings[ch] > max_zc )
+					if (zero_crossings[ch] > max_zc)
 					{
 						max_zc = zero_crossings[ch];
 					}
@@ -114,13 +114,13 @@ void Instrument::applyFadeIn(  sampleFrame * buf, const NotePlayHandle * n )
 
 		// calculate the length of the fade in
 		fpp_t length = (fpp_t) (
-				( (float)frames - 1 )  /
-				( (float)max_zc / 2.0f + 1.0f ) / 3.0f );
+				((float)frames - 1)  /
+				((float)max_zc / 2.0f + 1.0f) / 3.0f);
 
 		// apply fade in
-		for ( fpp_t f = 0; f < length; ++f )
+		for (fpp_t f = 0; f < length; ++f)
 		{
-			for ( ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch )
+			for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 			{
 				buf[f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) f / (float) length);
 			}

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -100,8 +100,9 @@ void Instrument::applyFadeIn(sampleFrame * buf, const NotePlayHandle * n)
 		{
 			for (ch_cnt_t ch=0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-				if ((buf[f-1][ch] < 0.0 && buf[f][ch] > 0.0) ||
-						(buf[f-1][ch] > 0.0 && buf[f][ch] < 0.0))
+                // we don't want to count [-1, 0, 1] as two crossings
+				if ((buf[f-1][ch] <= 0.0 && buf[f][ch] > 0.0) ||
+						(buf[f-1][ch] >= 0.0 && buf[f][ch] < 0.0))
 				{
 					++zero_crossings[ch];
 					if (zero_crossings[ch] > max_zc)
@@ -113,6 +114,9 @@ void Instrument::applyFadeIn(sampleFrame * buf, const NotePlayHandle * n)
 		}
 
 		// calculate the length of the fade in
+		// Length is inversely proportional to the max of zero_crossings,
+		// because for low frequencies, we need a longer fade in to
+		// prevent clicking.
 		fpp_t length = (fpp_t) (
 				((float)frames - 1)  /
 				((float)max_zc / 2.0f + 1.0f) / 3.0f);

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -118,6 +118,9 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 	{
 		const fpp_t frames = n->framesLeftForCurrentPeriod();
 
+		// We need to skip the first sample because it almost always
+		// produces a zero crossing; it's not helpful while
+		// determining the fade in length. Hence 1
 		int max_zc = count_zero_crossings(buf, 1, frames);
 
 		// calculate the length of the fade in

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -100,7 +100,7 @@ void Instrument::applyFadeIn(sampleFrame * buf, const NotePlayHandle * n)
 		{
 			for (ch_cnt_t ch=0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-                // we don't want to count [-1, 0, 1] as two crossings
+				// we don't want to count [-1, 0, 1] as two crossings
 				if ((buf[f-1][ch] <= 0.0 && buf[f][ch] > 0.0) ||
 						(buf[f-1][ch] >= 0.0 && buf[f][ch] < 0.0))
 				{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -93,11 +93,11 @@ static int countZeroCrossings(sampleFrame *buf, fpp_t start, fpp_t frames)
 	// determine the zero point crossing counts
 	for (fpp_t f = start; f < frames; ++f)
 	{
-		for (ch_cnt_t ch=0; ch < DEFAULT_CHANNELS; ++ch)
+		for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 		{
 			// we don't want to count [-1, 0, 1] as two crossings
-			if ((buf[f-1][ch] <= 0.0 && buf[f][ch] > 0.0) ||
-					(buf[f-1][ch] >= 0.0 && buf[f][ch] < 0.0))
+			if ((buf[f - 1][ch] <= 0.0 && buf[f][ch] > 0.0) ||
+					(buf[f - 1][ch] >= 0.0 && buf[f][ch] < 0.0))
 			{
 				++zeroCrossings[ch];
 				if (zeroCrossings[ch] > maxZeroCrossings)
@@ -118,7 +118,7 @@ fpp_t getFadeInLength(float maxLength, fpp_t frames, int zeroCrossings)
 	// Length is inversely proportional to the max of zeroCrossings,
 	// because for low frequencies, we need a longer fade in to
 	// prevent clicking.
-	return (fpp_t) (maxLength  / ((float)zeroCrossings / ((float)frames/128.0f) + 1.0f));
+	return (fpp_t) (maxLength  / ((float) zeroCrossings / ((float) frames / 128.0f) + 1.0f));
 }
 
 
@@ -134,7 +134,7 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 		// We need to skip the first sample because it almost always
 		// produces a zero crossing; it's not helpful while
 		// determining the fade in length. Hence 1
-		int maxZeroCrossings = countZeroCrossings(buf, offset+1, offset+frames);
+		int maxZeroCrossings = countZeroCrossings(buf, offset + 1, offset + frames);
 
 		fpp_t length = getFadeInLength(MAX_FADE_IN_LENGTH, frames, maxZeroCrossings);
 		n->m_fadeInLength = length;
@@ -145,11 +145,11 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 		{
 			for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-				buf[offset+f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) f / (float)n->m_fadeInLength);
+				buf[offset + f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) f / (float) n->m_fadeInLength);
 			}
 		}
 	}
-	else if(total < n->m_fadeInLength)
+	else if (total < n->m_fadeInLength)
 	{
 		const fpp_t frames = n->framesLeftForCurrentPeriod();
 
@@ -160,9 +160,9 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 		{
 			for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 			{
-				float currentLength = n->m_fadeInLength*(1.0f-(float)f/frames) + new_length*((float)f/frames);
-				buf[f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) (total+f) / currentLength);
-				if(total+f >= currentLength)
+				float currentLength = n->m_fadeInLength * (1.0f - (float) f / frames) + new_length * ((float) f / frames);
+				buf[f][ch] *= 0.5 - 0.5 * cosf(F_PI * (float) (total + f) / currentLength);
+				if (total + f >= currentLength)
 				{
 					n->m_fadeInLength = currentLength;
 					return;


### PR DESCRIPTION
Fixes #5119

Before:
![image](https://user-images.githubusercontent.com/8028600/65271139-3d495600-db25-11e9-9ccb-868f87344d63.png)
After:
![image](https://user-images.githubusercontent.com/8028600/65271189-54884380-db25-11e9-8cfa-acf54106824a.png)

Algorithm is similar to [ZynAddSubFX's fade in function](https://github.com/zynaddsubfx/zynaddsubfx/blob/4e36e765f677dbc689461889e502d015c22966a5/src/Synth/ADnote.cpp#L1202-L1222) but not exactly the same.

Please review the code.