### PR TITLE
Set cursor local instead of global in PianoRoll.

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1404,7 +1404,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 			{
 				m_ctrlMode = m_editMode;
 				m_editMode = ModeSelect;
-				QApplication::changeOverrideCursor( Qt::ArrowCursor );
+				setCursor( Qt::ArrowCursor );
 				ke->accept();
 			}
 			break;
@@ -1458,11 +1458,6 @@ void PianoRoll::keyReleaseEvent(QKeyEvent* ke )
 
 void PianoRoll::leaveEvent(QEvent * e )
 {
-	while( QApplication::overrideCursor() != NULL )
-	{
-		QApplication::restoreOverrideCursor();
-	}
-
 	QWidget::leaveEvent( e );
 	s_textFloat->hide();
 	update(); // cleaning inner mouse-related graphics
@@ -1552,7 +1547,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 	{
 		m_ctrlMode = m_editMode;
 		m_editMode = ModeSelect;
-		QApplication::changeOverrideCursor( QCursor( Qt::ArrowCursor ) );
+		setCursor( Qt::ArrowCursor );
 		update();
 	}
 
@@ -1770,8 +1765,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					m_action = ActionResizeNote;
 
 					// set resize-cursor
-					QCursor c( Qt::SizeHorCursor );
-					QApplication::setOverrideCursor( c );
+					setCursor( Qt::SizeHorCursor );
 				}
 				else
 				{
@@ -1784,8 +1778,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					m_action = ActionMoveNote;
 
 					// set move-cursor
-					QCursor c( Qt::SizeAllCursor );
-					QApplication::setOverrideCursor( c );
+					setCursor( Qt::SizeAllCursor );
 
 					// if they're holding shift, copy all selected notes
 					if( ! is_new_note && me->modifiers() & Qt::ShiftModifier )
@@ -2213,7 +2206,7 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 
 	if( m_editMode == ModeDraw )
 	{
-		QApplication::restoreOverrideCursor();
+		setCursor( Qt::ArrowCursor );
 	}
 
 	if( mustRepaint )
@@ -2237,8 +2230,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	{
 		if( me->y() > keyAreaBottom() && me->y() < noteEditTop() )
 		{
-			QApplication::setOverrideCursor(
-					QCursor( Qt::SizeVerCursor ) );
+			setCursor( Qt::SizeVerCursor );
 			return;
 		}
 	}
@@ -2451,37 +2443,19 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				bool atTail = note->length() > 0 && x > noteRightX -
 							RESIZE_AREA_WIDTH;
 				Qt::CursorShape cursorShape = atTail ? Qt::SizeHorCursor :
-				                                       Qt::SizeAllCursor;
-				if( QApplication::overrideCursor() )
-				{
-					if( QApplication::overrideCursor()->shape() != cursorShape )
-					{
-						while( QApplication::overrideCursor() != NULL )
-						{
-							QApplication::restoreOverrideCursor();
-						}
-						QApplication::setOverrideCursor(QCursor(cursorShape));
-					}
-				}
-				else
-				{
-					QApplication::setOverrideCursor(QCursor(cursorShape));
-				}
+													Qt::SizeAllCursor;
+				setCursor( cursorShape );
 			}
 			else
 			{
 				// the cursor is over no note, so restore cursor
-				while( QApplication::overrideCursor() != NULL )
-				{
-					QApplication::restoreOverrideCursor();
-				}
+				setCursor( Qt::ArrowCursor );
 			}
 		}
 		else if( me->buttons() & Qt::LeftButton &&
 						m_editMode == ModeSelect &&
 						m_action == ActionSelectNotes )
 		{
-
 			// change size of selection
 
 			// get tick in which the cursor is posated
@@ -2552,6 +2526,13 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 					++it;
 				}
 			}
+		}
+		else if (me->buttons() == Qt::NoButton &&
+			( m_editMode == ModeErase ||
+			m_editMode == ModeSelect ||
+			m_editMode == ModeEditDetuning))
+		{
+			setCursor( Qt::ArrowCursor );
 		}
 	}
 	else
@@ -2631,7 +2612,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				--m_selectedKeys;
 			}
 		}
-		QApplication::restoreOverrideCursor();
+		setCursor( Qt::ArrowCursor );
 	}
 
 	m_lastMouseX = me->x();


### PR DESCRIPTION
Set cursor using `setCursor` instead of the global `QApplication::setOverrideCursor` in the PianoRoll.

Also added extra `if else` (https://github.com/LMMS/lmms/compare/master...CYBERDEViLNL:master_pianoroll_cursor#diff-ecf6965b3ecabc1b5c4cb7ded8c130bfR2530) so the cursor gets restored if in Erase, Select or in EditDetuning mode and did not trigger by something else. That fixes https://github.com/LMMS/lmms/issues/3306