### PR TITLE
CircleCI: Use xenial for linux.gcc builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
       - *save_cache
   linux.gcc:
     docker:
-      - image: lmmsci/linux.gcc:18.04
+      - image: lmmsci/linux.gcc:xenial
     environment:
       <<: *common_environment
     steps:

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -175,10 +175,9 @@ executables="${executables} -executable=${APPDIR}usr/lib/lmms/ladspa/pitch_scale
 # Bundle both qt and non-qt dependencies into appimage format
 echo -e "\nBundling and relinking system dependencies..."
 echo -e ">>>>> linuxdeployqt" > "$LOGFILE"
-# FIXME: -unsupported-allow-new-glibc may result in an AppImage which is unusable on old systems.
 
 # shellcheck disable=SC2086
-"$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -unsupported-allow-new-glibc -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP >> "$LOGFILE" 2>&1
+"$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP >> "$LOGFILE" 2>&1
 success "Bundled and relinked dependencies"
 
 # Link to original location so lmms can find them


### PR DESCRIPTION
AppImage will fail otherwise.

~Need to be merged after https://github.com/LMMS/lmms-ci-docker/pull/6.~ Should be able to merge now.