### PR TITLE
Fix regression introduced in #5170

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1484,7 +1484,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		m_leftRightScroll->setPageStep( l );
 	}
 
-	if( validPattern() && GuiApplication::instance()->automationEditor()->hasFocus() )
+	if(validPattern() && GuiApplication::instance()->automationEditor()->m_editor->hasFocus())
 	{
 
 		drawCross( p );


### PR DESCRIPTION
`drawCross` will never be called since the AutomationEditorWindow never has focus anymore.