### PR TITLE
Make SampleBuffer adjust its members when resampling. Fixes #5218 for stable-1.2

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -382,6 +382,7 @@ void SampleBuffer::directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _
 void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 							bool _keep_settings )
 {
+	const sample_rate_t old_rate = m_sampleRate;
 	// do samplerate-conversion to our default-samplerate
 	if( _src_sr != mixerSampleRate() )
 	{
@@ -403,12 +404,13 @@ void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 		m_loopStartFrame = m_startFrame = 0;
 		m_loopEndFrame = m_endFrame = m_frames;
 	}
-	else if( _src_sr != mixerSampleRate() )
+	else if( old_rate != mixerSampleRate() )
 	{
-		m_startFrame *= ((float)mixerSampleRate() / _src_sr);
-		m_endFrame *= ((float)mixerSampleRate() / _src_sr);
-		m_loopStartFrame *= ((float)mixerSampleRate() / _src_sr);
-		m_loopEndFrame *= ((float)mixerSampleRate() / _src_sr);
+		m_startFrame *= ((float)mixerSampleRate() / old_rate);
+		m_endFrame *= ((float)mixerSampleRate() / old_rate);
+		m_loopStartFrame *= ((float)mixerSampleRate() / old_rate);
+		m_loopEndFrame *= ((float)mixerSampleRate() / old_rate);
+		m_sampleRate = mixerSampleRate();
 	}
 }
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -387,6 +387,8 @@ void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 	{
 		SampleBuffer * resampled = resample( _src_sr,
 					mixerSampleRate() );
+
+		m_sampleRate = mixerSampleRate();
 		MM_FREE( m_data );
 		m_frames = resampled->frames();
 		m_data = MM_ALLOC( sampleFrame, m_frames );
@@ -400,6 +402,13 @@ void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 		// update frame-variables
 		m_loopStartFrame = m_startFrame = 0;
 		m_loopEndFrame = m_endFrame = m_frames;
+	}
+	else if( _src_sr != mixerSampleRate() )
+	{
+		m_startFrame *= ((float)mixerSampleRate() / _src_sr);
+		m_endFrame *= ((float)mixerSampleRate() / _src_sr);
+		m_loopStartFrame *= ((float)mixerSampleRate() / _src_sr);
+		m_loopEndFrame *= ((float)mixerSampleRate() / _src_sr);
 	}
 }
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -406,10 +406,12 @@ void SampleBuffer::normalizeSampleRate( const sample_rate_t _src_sr,
 	}
 	else if( old_rate != mixerSampleRate() )
 	{
-		m_startFrame *= ((float)mixerSampleRate() / old_rate);
-		m_endFrame *= ((float)mixerSampleRate() / old_rate);
-		m_loopStartFrame *= ((float)mixerSampleRate() / old_rate);
-		m_loopEndFrame *= ((float)mixerSampleRate() / old_rate);
+		auto old_rate_to_new_rate_ratio = static_cast<float>(mixerSampleRate()) / old_rate;
+
+		m_startFrame = qBound(0, f_cnt_t(m_startFrame*old_rate_to_new_rate_ratio), m_frames);
+		m_endFrame = qBound(m_startFrame, f_cnt_t(m_endFrame*old_rate_to_new_rate_ratio), m_frames);
+		m_loopStartFrame = qBound(0, f_cnt_t(m_loopStartFrame*old_rate_to_new_rate_ratio), m_frames);
+		m_loopEndFrame = qBound(m_loopStartFrame, f_cnt_t(m_loopEndFrame*old_rate_to_new_rate_ratio), m_frames);
 		m_sampleRate = mixerSampleRate();
 	}
 }


### PR DESCRIPTION
My proposition on how to make oversampling work again in the 1.2 line after the changes in #4991. Feel free to chime in if some use case of SampleBuffer remains broken (or gets a fresh bug) after this PR.