### PR TITLE
Remove GUI menu items for global automation

### DIFF
--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -89,9 +89,7 @@ public:
 public slots:
 	void execConnectionDialog();
 	void removeConnection();
-	void editSongGlobalAutomation();
 	void unlinkAllModels();
-	void removeSongGlobalAutomation();
 
 private slots:
 	/// Copy the model's value to the clipboard.

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -80,18 +80,6 @@ void AutomatableModelView::addDefaultActions( QMenu* menu )
 
 	menu->addSeparator();
 
-	menu->addAction( embed::getIconPixmap( "automation" ),
-						AutomatableModel::tr( "Edit song-global automation" ),
-							amvSlots,
-							SLOT( editSongGlobalAutomation() ) );
-
-	menu->addAction( QPixmap(),
-						AutomatableModel::tr( "Remove song-global automation" ),
-						amvSlots,
-						SLOT( removeSongGlobalAutomation() ) );
-
-	menu->addSeparator();
-
 	if( model->hasLinkedModels() )
 	{
 		menu->addAction( embed::getIconPixmap( "edit-delete" ),
@@ -218,21 +206,6 @@ void AutomatableModelViewSlots::removeConnection()
 }
 
 
-
-
-void AutomatableModelViewSlots::editSongGlobalAutomation()
-{
-	gui->automationEditor()->open(
-				AutomationPattern::globalAutomationPattern(m_amv->modelUntyped())
-	);
-}
-
-
-
-void AutomatableModelViewSlots::removeSongGlobalAutomation()
-{
-	delete AutomationPattern::globalAutomationPattern( m_amv->modelUntyped() );
-}
 
 
 void AutomatableModelViewSlots::unlinkAllModels()


### PR DESCRIPTION
Completes step 3 from #403 

This should be the only place where the GUI mentions and adds global automation menu items.