### PR TITLE
Fix Organic offset glitch

### DIFF
--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -307,7 +307,7 @@ void organicInstrument::playNote( NotePlayHandle * _n,
 	// fxKnob is [0;1]
 	float t =  m_fx1Model.value();
 	
-	for (int i=0 ; i < frames ; i++)
+	for (int i=0 ; i < frames + offset ; i++)
 	{
 		_working_buffer[i][0] = waveshape( _working_buffer[i][0], t ) *
 						m_volModel.value() / 100.0f;


### PR DESCRIPTION
First discussed in https://github.com/LMMS/lmms/issues/1499#issuecomment-188372716
Bug introduced in https://github.com/LMMS/lmms/commit/270af579b8572ebef22ecc3c10a36d019ca005fe

The FX section in Organic is not resolved during an offset part so if for instance the volume knob is set, during offset the modulation will instead be 1.


![](https://cloud.githubusercontent.com/assets/6368949/13294145/ffe31aa4-db22-11e5-9b25-cc80f2d30d9f.png)
