### PR TITLE
Refactor PianoRoll

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -138,6 +138,17 @@ PianoRoll {
 	qproperty-ghostNoteBorders: true;
 	qproperty-barColor: #4afd85;
 	qproperty-markedSemitoneColor: rgba( 0, 255, 200, 60 );
+	/* Piano keys */
+	qproperty-whiteKeyWidth: 64;
+	qproperty-whiteKeyActiveTextColor: #000;
+	qproperty-whiteKeyActiveTextShadow: rgb( 240, 240, 240 );
+	qproperty-whiteKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
+	qproperty-whiteKeyInactiveTextColor: rgb( 128, 128, 128);
+	qproperty-whiteKeyInactiveTextShadow: rgb( 240, 240, 240 );
+	qproperty-whiteKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #eeeeee, stop:1 #ffffff);
+	qproperty-blackKeyWidth: 64;
+	qproperty-blackKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
+	qproperty-blackKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #333, stop:1 #000);
 	/* Grid colors */
 	qproperty-lineColor: rgba( 128, 128, 128, 80 );
 	qproperty-beatLineColor: rgba( 128, 128, 128, 160 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -146,7 +146,7 @@ PianoRoll {
 	qproperty-whiteKeyInactiveTextColor: rgb( 128, 128, 128);
 	qproperty-whiteKeyInactiveTextShadow: rgb( 240, 240, 240 );
 	qproperty-whiteKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #eeeeee, stop:1 #ffffff);
-	qproperty-blackKeyWidth: 64;
+	qproperty-blackKeyWidth: 48;
 	qproperty-blackKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
 	qproperty-blackKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #333, stop:1 #000);
 	/* Grid colors */

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -118,7 +118,7 @@ QMenu::indicator:selected {
 	background-color: #747474;
 }
 
-positionLine {
+PositionLine {
 	qproperty-tailGradient: false;
 	qproperty-lineColor: rgb(255, 255, 255);
 }

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -178,7 +178,7 @@ PianoRoll {
 	qproperty-whiteKeyInactiveTextColor: #000;
 	qproperty-whiteKeyInactiveTextShadow: #fff;
 	qproperty-whiteKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #eeeeee, stop:1 #ffffff);
-	qproperty-blackKeyWidth: 64;
+	qproperty-blackKeyWidth: 48;
 	qproperty-blackKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
 	qproperty-blackKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #333, stop:1 #000);
 	/* Grid colors */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -170,6 +170,17 @@ PianoRoll {
 	qproperty-ghostNoteBorders: false;
 	qproperty-barColor: #078f3a;
 	qproperty-markedSemitoneColor: rgba(255, 255, 255, 30);
+	/* Piano keys */
+	qproperty-whiteKeyWidth: 64;
+	qproperty-whiteKeyActiveTextColor: #000;
+	qproperty-whiteKeyActiveTextShadow: #fff;
+	qproperty-whiteKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
+	qproperty-whiteKeyInactiveTextColor: #000;
+	qproperty-whiteKeyInactiveTextShadow: #fff;
+	qproperty-whiteKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #eeeeee, stop:1 #ffffff);
+	qproperty-blackKeyWidth: 64;
+	qproperty-blackKeyActiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #43e97b, stop:1 #3bcd6c);
+	qproperty-blackKeyInactiveBackground: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #333, stop:1 #000);
 	/* Grid colors */
 	qproperty-lineColor: #292929;
 	qproperty-beatLineColor: #2d6b45;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -150,7 +150,7 @@ QMenu::indicator:selected {
 	background-color: #101213;
 }
 
-positionLine {
+PositionLine {
 	qproperty-tailGradient: true;
 	qproperty-lineColor: rgb(255, 255, 255);
 }

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -306,6 +306,8 @@ private:
 	void playChordNotes(int key, int velocity=-1);
 	void pauseChordNotes(int key);
 
+	void updateScrollbars();
+
 	QList<int> getAllOctavesForKey( int keyToMirror ) const;
 
 	int noteEditTop() const;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -394,7 +394,6 @@ private:
 	int m_moveStartX;
 	int m_moveStartY;
 
-	int m_oldNotesEditHeight;
 	int m_notesEditHeight;
 	int m_ppb;  // pixels per bar
 	int m_totalKeysToScroll;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -297,12 +297,6 @@ private:
 	static const int cm_scrollAmtHoriz = 10;
 	static const int cm_scrollAmtVert = 1;
 
-	// static QPixmap * s_whiteKeyBigPm;
-	// static QPixmap * s_whiteKeyBigPressedPm;
-	// static QPixmap * s_whiteKeySmallPm;
-	// static QPixmap * s_whiteKeySmallPressedPm;
-	// static QPixmap * s_blackKeyPm;
-	// static QPixmap * s_blackKeyPressedPm;
 	static QPixmap * s_toolDraw;
 	static QPixmap * s_toolErase;
 	static QPixmap * s_toolSelect;
@@ -367,6 +361,7 @@ private:
 	int m_moveStartY;
 
 	int m_notesEditHeight;
+	int m_userSetNotesEditHeight;
 	int m_ppb;  // pixels per bar
 	int m_totalKeysToScroll;
 	int m_pianoKeysVisible;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -490,6 +490,7 @@ public:
 	}
 
 	QSize sizeHint() const override;
+	bool hasFocus() const;
 
 signals:
 	void currentPatternChanged();

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -56,25 +56,38 @@ class TimeLineWidget;
 class PianoRoll : public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY( QColor barLineColor READ barLineColor WRITE setBarLineColor )
-	Q_PROPERTY( QColor beatLineColor READ beatLineColor WRITE setBeatLineColor )
-	Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor )
-	Q_PROPERTY( QColor noteModeColor READ noteModeColor WRITE setNoteModeColor )
-	Q_PROPERTY( QColor noteColor READ noteColor WRITE setNoteColor )
-	Q_PROPERTY( QColor ghostNoteColor READ ghostNoteColor WRITE setGhostNoteColor )
-	Q_PROPERTY( QColor noteTextColor READ noteTextColor WRITE setNoteTextColor )
-	Q_PROPERTY( QColor ghostNoteTextColor READ ghostNoteTextColor WRITE setGhostNoteTextColor )
-	Q_PROPERTY( QColor barColor READ barColor WRITE setBarColor )
-	Q_PROPERTY( QColor selectedNoteColor READ selectedNoteColor WRITE setSelectedNoteColor )
-	Q_PROPERTY( QColor textColor READ textColor WRITE setTextColor )
-	Q_PROPERTY( QColor textColorLight READ textColorLight WRITE setTextColorLight )
-	Q_PROPERTY( QColor textShadow READ textShadow WRITE setTextShadow )
-	Q_PROPERTY( QColor markedSemitoneColor READ markedSemitoneColor WRITE setMarkedSemitoneColor )
-	Q_PROPERTY( int noteOpacity READ noteOpacity WRITE setNoteOpacity )
-	Q_PROPERTY( bool noteBorders READ noteBorders WRITE setNoteBorders )
-	Q_PROPERTY( int ghostNoteOpacity READ ghostNoteOpacity WRITE setGhostNoteOpacity )
-	Q_PROPERTY( bool ghostNoteBorders READ ghostNoteBorders WRITE setGhostNoteBorders )
-	Q_PROPERTY( QColor backgroundShade READ backgroundShade WRITE setBackgroundShade )
+	Q_PROPERTY(QColor barLineColor MEMBER m_barLineColor)
+	Q_PROPERTY(QColor beatLineColor MEMBER m_beatLineColor)
+	Q_PROPERTY(QColor lineColor MEMBER m_lineColor)
+	Q_PROPERTY(QColor noteModeColor MEMBER m_noteModeColor)
+	Q_PROPERTY(QColor noteColor MEMBER m_noteColor)
+	Q_PROPERTY(QColor ghostNoteColor MEMBER m_ghostNoteColor)
+	Q_PROPERTY(QColor noteTextColor MEMBER m_noteTextColor)
+	Q_PROPERTY(QColor ghostNoteTextColor MEMBER m_ghostNoteTextColor)
+	Q_PROPERTY(QColor barColor MEMBER m_barColor)
+	Q_PROPERTY(QColor selectedNoteColor MEMBER m_selectedNoteColor)
+	Q_PROPERTY(QColor textColor MEMBER m_textColor)
+	Q_PROPERTY(QColor textColorLight MEMBER m_textColorLight)
+	Q_PROPERTY(QColor textShadow MEMBER m_textShadow)
+	Q_PROPERTY(QColor markedSemitoneColor MEMBER m_markedSemitoneColor)
+	Q_PROPERTY(int noteOpacity MEMBER m_noteOpacity)
+	Q_PROPERTY(bool noteBorders MEMBER m_noteBorders)
+	Q_PROPERTY(int ghostNoteOpacity MEMBER m_ghostNoteOpacity)
+	Q_PROPERTY(bool ghostNoteBorders MEMBER m_ghostNoteBorders)
+	Q_PROPERTY(QColor backgroundShade MEMBER m_backgroundShade)
+
+	/* white key properties */
+	Q_PROPERTY(int whiteKeyWidth MEMBER m_whiteKeyWidth)
+	Q_PROPERTY(QColor whiteKeyInactiveTextColor MEMBER m_whiteKeyInactiveTextColor)
+	Q_PROPERTY(QColor whiteKeyInactiveTextShadow MEMBER m_whiteKeyInactiveTextShadow)
+	Q_PROPERTY(QBrush whiteKeyInactiveBackground MEMBER m_whiteKeyInactiveBackground)
+	Q_PROPERTY(QColor whiteKeyActiveTextColor MEMBER m_whiteKeyActiveTextColor)
+	Q_PROPERTY(QColor whiteKeyActiveTextShadow MEMBER m_whiteKeyActiveTextShadow)
+	Q_PROPERTY(QBrush whiteKeyActiveBackground MEMBER m_whiteKeyActiveBackground)
+	/* black key properties */
+	Q_PROPERTY(int blackKeyWidth MEMBER m_blackKeyWidth)
+	Q_PROPERTY(QBrush blackKeyInactiveBackground MEMBER m_blackKeyInactiveBackground)
+	Q_PROPERTY(QBrush blackKeyActiveBackground MEMBER m_blackKeyActiveBackground)
 public:
 	enum EditModes
 	{
@@ -125,47 +138,6 @@ public:
 	Song::PlayModes desiredPlayModeForAccompany() const;
 
 	int quantization() const;
-
-	// qproperty access functions
-	QColor barLineColor() const;
-	void setBarLineColor( const QColor & c );
-	QColor beatLineColor() const;
-	void setBeatLineColor( const QColor & c );
-	QColor lineColor() const;
-	void setLineColor( const QColor & c );
-	QColor noteModeColor() const;
-	void setNoteModeColor( const QColor & c );
-	QColor noteColor() const;
-	void setNoteColor( const QColor & c );
-	QColor noteTextColor() const;
-	void setNoteTextColor( const QColor & c );
-	QColor barColor() const;
-	void setBarColor( const QColor & c );
-	QColor selectedNoteColor() const;
-	void setSelectedNoteColor( const QColor & c );
-	QColor textColor() const;
-	void setTextColor( const QColor & c );
-	QColor textColorLight() const;
-	void setTextColorLight( const QColor & c );
-	QColor textShadow() const;
-	void setTextShadow( const QColor & c );
-	QColor markedSemitoneColor() const;
-	void setMarkedSemitoneColor( const QColor & c );
-	int noteOpacity() const;
-	void setNoteOpacity( const int i );
-	bool noteBorders() const;
-	void setNoteBorders( const bool b );
-	QColor ghostNoteColor() const;
-	void setGhostNoteColor( const QColor & c );
-	QColor ghostNoteTextColor() const;
-	void setGhostNoteTextColor( const QColor & c );
-	int ghostNoteOpacity() const;
-	void setGhostNoteOpacity( const int i );
-	bool ghostNoteBorders() const;
-	void setGhostNoteBorders( const bool b );
-	QColor backgroundShade() const;
-	void setBackgroundShade( const QColor & c );
-
 
 protected:
 	void keyPressEvent( QKeyEvent * ke ) override;
@@ -325,12 +297,12 @@ private:
 	static const int cm_scrollAmtHoriz = 10;
 	static const int cm_scrollAmtVert = 1;
 
-	static QPixmap * s_whiteKeyBigPm;
-	static QPixmap * s_whiteKeyBigPressedPm;
-	static QPixmap * s_whiteKeySmallPm;
-	static QPixmap * s_whiteKeySmallPressedPm;
-	static QPixmap * s_blackKeyPm;
-	static QPixmap * s_blackKeyPressedPm;
+	// static QPixmap * s_whiteKeyBigPm;
+	// static QPixmap * s_whiteKeyBigPressedPm;
+	// static QPixmap * s_whiteKeySmallPm;
+	// static QPixmap * s_whiteKeySmallPressedPm;
+	// static QPixmap * s_blackKeyPm;
+	// static QPixmap * s_blackKeyPressedPm;
 	static QPixmap * s_toolDraw;
 	static QPixmap * s_toolErase;
 	static QPixmap * s_toolSelect;
@@ -463,6 +435,18 @@ private:
 	bool m_noteBorders;
 	bool m_ghostNoteBorders;
 	QColor m_backgroundShade;
+	/* white key properties */
+	int m_whiteKeyWidth;
+	QColor m_whiteKeyActiveTextColor;
+	QColor m_whiteKeyActiveTextShadow;
+	QBrush m_whiteKeyActiveBackground;
+	QColor m_whiteKeyInactiveTextColor;
+	QColor m_whiteKeyInactiveTextShadow;
+	QBrush m_whiteKeyInactiveBackground;
+	/* black key properties */
+	int m_blackKeyWidth;
+	QBrush m_blackKeyActiveBackground;
+	QBrush m_blackKeyInactiveBackground;
 
 signals:
 	void positionChanged( const MidiTime & );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -40,6 +40,7 @@
 #include "ToolTip.h"
 #include "StepRecorder.h"
 #include "StepRecorderWidget.h"
+#include "PositionLine.h"
 
 class QPainter;
 class QPixmap;
@@ -188,7 +189,6 @@ protected:
 	void selectAll();
 	NoteVector getSelectedNotes() const;
 	void selectNotesOnKey();
-	int xCoordOfTick( int tick );
 
 	// for entering values with dblclick in the vol/pan bars
 	void enterValue( NoteVector* nv );
@@ -279,6 +279,8 @@ private:
 		PR_BLACK_KEY
 	};
 
+	PositionLine * m_positionLine;
+
 	QVector<QString> m_nemStr; // gui names of each edit mode
 	QMenu * m_noteEditMenu; // when you right click below the key area
 
@@ -307,6 +309,7 @@ private:
 	void pauseChordNotes(int key);
 
 	void updateScrollbars();
+	void updatePositionLineHeight();
 
 	QList<int> getAllOctavesForKey( int keyToMirror ) const;
 
@@ -395,6 +398,7 @@ private:
 	int m_notesEditHeight;
 	int m_ppb;  // pixels per bar
 	int m_totalKeysToScroll;
+	int m_pianoKeysVisible;
 
 	int m_keyLineHeight;
 	int m_octaveHeight;

--- a/include/PositionLine.h
+++ b/include/PositionLine.h
@@ -1,0 +1,49 @@
+/*
+ * PositionLine.h - declaration of class PositionLine, a simple widget that
+ *                  draws a line, mainly works with TimeLineWidget
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+ #ifndef POSITION_LINE_H
+ #define POSITION_LINE_H
+
+#include <QWidget>
+
+class PositionLine : public QWidget
+{
+	Q_OBJECT
+	Q_PROPERTY(bool tailGradient MEMBER m_hasTailGradient)
+	Q_PROPERTY(QColor lineColor MEMBER m_lineColor)
+public:
+	PositionLine(QWidget* parent);
+
+public slots:
+	void zoomChange(double zoom);
+
+private:
+	void paintEvent(QPaintEvent* pe) override;
+
+	bool m_hasTailGradient;
+	QColor m_lineColor;
+};
+
+ #endif

--- a/include/PositionLine.h
+++ b/include/PositionLine.h
@@ -23,8 +23,8 @@
  *
  */
 
- #ifndef POSITION_LINE_H
- #define POSITION_LINE_H
+#ifndef POSITION_LINE_H
+#define POSITION_LINE_H
 
 #include <QWidget>
 
@@ -46,4 +46,4 @@ private:
 	QColor m_lineColor;
 };
 
- #endif
+#endif

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -33,6 +33,7 @@
 #include "ActionGroup.h"
 #include "Editor.h"
 #include "TrackContainerView.h"
+#include "PositionLine.h"
 
 class QLabel;
 class QScrollBar;
@@ -45,31 +46,6 @@ class MeterDialog;
 class Song;
 class TextFloat;
 class TimeLineWidget;
-
-class positionLine : public QWidget
-{
-	Q_OBJECT
-	Q_PROPERTY ( bool tailGradient READ hasTailGradient WRITE setHasTailGradient )
-	Q_PROPERTY ( QColor lineColor READ lineColor WRITE setLineColor )
-public:
-	positionLine ( QWidget* parent );
-	
-	// qproperty access functions
-	bool hasTailGradient () const;
-	void setHasTailGradient ( const bool g );
-	QColor lineColor () const;
-	void setLineColor ( const QColor & c );
-
-public slots:
-	void zoomChange (double zoom);
-
-private:
-	void paintEvent( QPaintEvent* pe ) override;
-	
-	bool m_hasTailGradient;
-	QColor m_lineColor;
-
-};
 
 
 class SongEditor : public TrackContainerView
@@ -156,7 +132,7 @@ private:
 	TextFloat * m_mvsStatus;
 	TextFloat * m_mpsStatus;
 
-	positionLine * m_positionLine;
+	PositionLine * m_positionLine;
 
 	ComboBoxModel* m_zoomingModel;
 	ComboBoxModel* m_snappingModel;

--- a/include/StepRecorderWidget.h
+++ b/include/StepRecorderWidget.h
@@ -45,7 +45,9 @@ public:
 	//API used by PianoRoll
 	void setPixelsPerBar(int ppb);
 	void setCurrentPosition(MidiTime currentPosition);
+	void setMargins(const QMargins &qm);
 	void setBottomMargin(const int marginBottom);
+	QMargins margins();
 
 	//API used by StepRecorder
 	void setStepsLength(MidiTime stepsLength);

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -150,6 +150,8 @@ public:
 		update();
 	}
 
+	void setXOffset(const int x);
+
 	void addToolButtons(QToolBar* _tool_bar );
 
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -81,6 +81,7 @@ SET(LMMS_SRCS
 	gui/widgets/NStateButton.cpp
 	gui/widgets/Oscilloscope.cpp
 	gui/widgets/PixmapButton.cpp
+	gui/widgets/PositionLine.cpp
 	gui/widgets/ProjectNotes.cpp
 	gui/widgets/RenameDialog.cpp
 	gui/widgets/Rubberband.cpp

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -109,6 +109,14 @@ TimeLineWidget::~TimeLineWidget()
 
 
 
+void TimeLineWidget::setXOffset(const int x)
+{
+	m_xOffset = x;
+	if (s_posMarkerPixmap != nullptr) { m_xOffset -= s_posMarkerPixmap->width() / 2; }
+}
+
+
+
 
 void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 {

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2882,7 +2882,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		int grid_line_y = keyAreaTop() + m_keyLineHeight - 1;
 		static const int yTextCorrections[KeysPerOctave] = {
 		/*   C      D      E   F      G      A      B   */
-			-4, 0, -8, 0, -6, -4, 0, -8, 0, -8, 0, -6
+		    -4, 0, -8, 0, -6, -4, 0, -8, 0, -8, 0, -6
 		};
 		// lambda function for returning height of key
 		auto keyHeight = [&](

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4052,7 +4052,7 @@ void PianoRoll::updatePosition( const MidiTime & t )
 	if (pos >= m_currentPosition && pos <= m_currentPosition + width() - m_whiteKeyWidth)
 	{
 		m_positionLine->show();
-		m_positionLine->move(pos - m_currentPosition + m_whiteKeyWidth, keyAreaTop());
+		m_positionLine->move(pos - (m_positionLine->width() - 1) - m_currentPosition + m_whiteKeyWidth, keyAreaTop());
 	}
 	else
 	{
@@ -4107,6 +4107,7 @@ void PianoRoll::zoomingChanged()
 
 	m_timeLine->setPixelsPerBar( m_ppb );
 	m_stepRecorderWidget.setPixelsPerBar( m_ppb );
+	m_positionLine->zoomChange(m_zoomLevels[m_zoomingModel.value()]);
 
 	update();
 }

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3216,7 +3216,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	currentKeyCol.setAlpha( 64 );
 
 	// horizontal line for the key under the cursor
-	if( hasValidPattern() )
+	if(hasValidPattern() && gui->pianoRoll()->hasFocus())
 	{
 		int key_num = getKey( mapFromGlobal( QCursor::pos() ).y() );
 		p.fillRect( 10, keyAreaBottom() + 3 - m_keyLineHeight *
@@ -3228,32 +3228,35 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	p.fillRect( QRect( 0, keyAreaBottom(),
 					width()-PR_RIGHT_MARGIN, NOTE_EDIT_RESIZE_BAR ), editAreaCol );
 
-	const QPixmap * cursor = NULL;
-	// draw current edit-mode-icon below the cursor
-	switch( m_editMode )
+	if (gui->pianoRoll()->hasFocus())
 	{
-		case ModeDraw:
-			if( m_mouseDownRight )
-			{
-				cursor = s_toolErase;
-			}
-			else if( m_action == ActionMoveNote )
-			{
-				cursor = s_toolMove;
-			}
-			else
-			{
-				cursor = s_toolDraw;
-			}
-			break;
-		case ModeErase: cursor = s_toolErase; break;
-		case ModeSelect: cursor = s_toolSelect; break;
-		case ModeEditDetuning: cursor = s_toolOpen; break;
-	}
-	QPoint mousePosition = mapFromGlobal( QCursor::pos() );
-	if( cursor != NULL && mousePosition.y() > keyAreaTop() && mousePosition.x() > noteEditLeft())
-	{
-		p.drawPixmap( mousePosition + QPoint( 8, 8 ), *cursor );
+		const QPixmap * cursor = NULL;
+		// draw current edit-mode-icon below the cursor
+		switch( m_editMode )
+		{
+			case ModeDraw:
+				if( m_mouseDownRight )
+				{
+					cursor = s_toolErase;
+				}
+				else if( m_action == ActionMoveNote )
+				{
+					cursor = s_toolMove;
+				}
+				else
+				{
+					cursor = s_toolDraw;
+				}
+				break;
+			case ModeErase: cursor = s_toolErase; break;
+			case ModeSelect: cursor = s_toolSelect; break;
+			case ModeEditDetuning: cursor = s_toolOpen; break;
+		}
+		QPoint mousePosition = mapFromGlobal( QCursor::pos() );
+		if( cursor != NULL && mousePosition.y() > keyAreaTop() && mousePosition.x() > noteEditLeft())
+		{
+			p.drawPixmap( mousePosition + QPoint( 8, 8 ), *cursor );
+		}
 	}
 }
 
@@ -4591,6 +4594,13 @@ void PianoRollWindow::loadSettings( const QDomElement & de )
 QSize PianoRollWindow::sizeHint() const
 {
 	return { INITIAL_PIANOROLL_WIDTH, INITIAL_PIANOROLL_HEIGHT };
+}
+
+
+
+bool PianoRollWindow::hasFocus() const
+{
+	return m_editor->hasFocus();
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2222,7 +2222,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			return;
 		}
 		int newHeight = height() - me->y();
-		if (height() - newHeight < KEY_AREA_MIN_HEIGHT)
+		if (me->y() < KEY_AREA_MIN_HEIGHT)
 		{
 			newHeight = height() - KEY_AREA_MIN_HEIGHT -
 				PR_TOP_MARGIN - PR_BOTTOM_MARGIN; // - NOTE_EDIT_RESIZE_BAR

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2059,6 +2059,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	}
 	else if( m_action == ActionResizeNoteEditArea )
 	{
+		// Don't try to show more keys than the full keyboard, bail if trying to
 		if (m_pianoKeysVisible == NumKeys && me->y() > m_moveStartY)
 		{
 			return;
@@ -2679,10 +2680,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 	if (hasValidPattern())
 	{
-		int pianoArea, partialKeyVisible, topKey, topNote;
-		pianoArea = keyAreaBottom() - keyAreaTop();
-		m_pianoKeysVisible = pianoArea / m_keyLineHeight;
-		partialKeyVisible = pianoArea % m_keyLineHeight;
+		int pianoAreaHeight, partialKeyVisible, topKey, topNote;
+		pianoAreaHeight = keyAreaBottom() - keyAreaTop();
+		m_pianoKeysVisible = pianoAreaHeight / m_keyLineHeight;
+		partialKeyVisible = pianoAreaHeight % m_keyLineHeight;
 		// check if we're below the minimum key area size
 		if (m_pianoKeysVisible * m_keyLineHeight < KEY_AREA_MIN_HEIGHT)
 		{
@@ -2888,7 +2889,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				// draw next white key
 				drawKey(key - 1, grid_line_y + m_keyLineHeight);
 				drawHorizontalLine(key - 1, grid_line_y + m_keyLineHeight);
-				// draw black key over both
+				// draw black key over previous and next white key
 				drawKey(key, grid_line_y);
 				drawHorizontalLine(key, grid_line_y);
 				// drew two grid keys so skip ahead properly
@@ -3298,8 +3299,8 @@ void PianoRoll::updateScrollbars()
 		SCROLLBAR_SIZE,
 		height() - PR_TOP_MARGIN - SCROLLBAR_SIZE
 	);
-	int pianoArea = keyAreaBottom() - PR_TOP_MARGIN;
-	int numKeysVisible = pianoArea / m_keyLineHeight;
+	int pianoAreaHeight = keyAreaBottom() - PR_TOP_MARGIN;
+	int numKeysVisible = pianoAreaHeight / m_keyLineHeight;
 	m_totalKeysToScroll = qMax(0, NumKeys - numKeysVisible);
 	m_topBottomScroll->setRange(0, m_totalKeysToScroll);
 	if (m_startKey > m_totalKeysToScroll)

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -170,7 +170,6 @@ PianoRoll::PianoRoll() :
 	m_mouseDownTick( 0 ),
 	m_lastMouseX( 0 ),
 	m_lastMouseY( 0 ),
-	m_oldNotesEditHeight( 100 ),
 	m_notesEditHeight( 100 ),
 	m_ppb( DEFAULT_PR_PPB ),
 	m_keyLineHeight(DEFAULT_KEY_LINE_HEIGHT),
@@ -1552,7 +1551,6 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 	{
 		// resizing the note edit area
 		m_action = ActionResizeNoteEditArea;
-		m_oldNotesEditHeight = m_notesEditHeight;
 		return;
 	}
 
@@ -2148,11 +2146,6 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 			{
 				clearSelectedNotes();
 			}
-		}
-
-		if (m_action == ActionResizeNoteEditArea)
-		{
-			m_oldNotesEditHeight = m_notesEditHeight;
 		}
 	}
 
@@ -2837,11 +2830,6 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	if (hasValidPattern())
 	{
 		int pianoArea, partialKeyVisible, topKey, topNote;
-		// if resizing the note edit area, don't touch m_oldNotesEditHeight
-		if (m_action != ActionResizeNoteEditArea)
-		{
-			m_notesEditHeight = m_oldNotesEditHeight;
-		}
 		pianoArea = keyAreaBottom() - keyAreaTop();
 		m_pianoKeysVisible = pianoArea / m_keyLineHeight;
 		partialKeyVisible = pianoArea % m_keyLineHeight;
@@ -2855,10 +2843,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 		topKey = qBound(0, m_startKey + m_pianoKeysVisible - 1, NumKeys - 1);
 		topNote = topKey % KeysPerOctave;
-		// if resizing the note edit area, don't touch m_oldNotesEditHeight
+		// if resizing the note edit area
 		if (m_action != ActionResizeNoteEditArea && partialKeyVisible != 0)
 		{
-			m_oldNotesEditHeight = m_notesEditHeight;
 			// adding height always means we don't have to add keys
 			m_notesEditHeight += partialKeyVisible;
 		}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3014,7 +3014,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 
 		// don't draw over keys
-		p.setClipRect(WHITE_KEY_WIDTH, keyAreaTop(), width(), keyAreaBottom() - keyAreaTop());
+		p.setClipRect(WHITE_KEY_WIDTH, keyAreaTop(), width(), noteEditBottom() - keyAreaTop());
 
 		// draw alternating shading on bars
 		float timeSignature =

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2688,8 +2688,15 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		{
 			m_pianoKeysVisible = KEY_AREA_MIN_HEIGHT / m_keyLineHeight;
 			partialKeyVisible = KEY_AREA_MIN_HEIGHT % m_keyLineHeight;
+			// if we have a partial key, just show it
+			if (partialKeyVisible > 0)
+			{
+				m_pianoKeysVisible += 1;
+				partialKeyVisible = 0;
+			}
 			// have to modifiy the notes edit area height instead
-			m_notesEditHeight = height() - KEY_AREA_MIN_HEIGHT - PR_TOP_MARGIN - PR_BOTTOM_MARGIN;
+			m_notesEditHeight = height() - (m_pianoKeysVisible * m_keyLineHeight)
+				- PR_TOP_MARGIN - PR_BOTTOM_MARGIN;
 		}
 		// check if we're trying to show more keys than available
 		else if (m_pianoKeysVisible >= NumKeys)
@@ -3293,11 +3300,11 @@ void PianoRoll::updateScrollbars()
 	);
 	int pianoArea = keyAreaBottom() - PR_TOP_MARGIN;
 	int numKeysVisible = pianoArea / m_keyLineHeight;
-	m_totalKeysToScroll = NumKeys - numKeysVisible;
+	m_totalKeysToScroll = qMax(0, NumKeys - numKeysVisible);
 	m_topBottomScroll->setRange(0, m_totalKeysToScroll);
 	if (m_startKey > m_totalKeysToScroll)
 	{
-		m_startKey = m_totalKeysToScroll;
+		m_startKey = qMax(0, m_totalKeysToScroll);
 	}
 	m_topBottomScroll->setValue(m_totalKeysToScroll - m_startKey);
 }
@@ -3708,7 +3715,7 @@ void PianoRoll::horScrolled(int new_pos )
 void PianoRoll::verScrolled( int new_pos )
 {
 	// revert value
-	m_startKey = m_totalKeysToScroll - new_pos;
+	m_startKey = qMax(0, m_totalKeysToScroll - new_pos);
 
 	update();
 }
@@ -3862,13 +3869,13 @@ void PianoRoll::updateYScroll()
 	int total_pixels = m_octaveHeight * NumOctaves - (height() -
 					PR_TOP_MARGIN - PR_BOTTOM_MARGIN -
 							m_notesEditHeight);
-	m_totalKeysToScroll = total_pixels * KeysPerOctave / m_octaveHeight;
+	m_totalKeysToScroll = qMax(0, total_pixels * KeysPerOctave / m_octaveHeight);
 
 	m_topBottomScroll->setRange(0, m_totalKeysToScroll);
 
 	if(m_startKey > m_totalKeysToScroll)
 	{
-		m_startKey = m_totalKeysToScroll;
+		m_startKey = qMax(0, m_totalKeysToScroll);
 	}
 	m_topBottomScroll->setValue(m_totalKeysToScroll - m_startKey);
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -52,86 +52,6 @@
 #include "PianoRoll.h"
 #include "Track.h"
 
-positionLine::positionLine( QWidget* parent ) :
-	QWidget( parent ),
-	m_hasTailGradient ( false ),
-	m_lineColor (0, 0, 0, 0)
-{
-	resize( 8, height() );
-	
-	setAttribute( Qt::WA_NoSystemBackground, true );
-	setAttribute( Qt::WA_TransparentForMouseEvents );
-}
-
-void positionLine::paintEvent( QPaintEvent* pe )
-{
-	QPainter p( this );
-	
-	// If width is 1, we don't need a gradient
-	if (width() == 1)
-	{
-		p.fillRect( rect(),
-			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
-	}
-	
-	// If width > 1, we need the gradient
-	else
-	{
-		// Create the gradient trail behind the line
-		QLinearGradient gradient( rect().bottomLeft(), rect().bottomRight() );
-		
-		// If gradient is enabled, we're in focus and we're playing, enable gradient
-		if (Engine::getSong()->isPlaying() && m_hasTailGradient && 
-			Engine::getSong()->playMode() == Song::Mode_PlaySong)
-		{
-			gradient.setColorAt(( ( width() - 1.0 )/width() ),
-				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 60) );
-		}
-		else
-		{
-			gradient.setColorAt(( ( width() - 1.0 )/width() ),
-				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
-		}
-		
-		// Fill in the remaining parts
-		gradient.setColorAt(0,
-			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
-		gradient.setColorAt(1,
-			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
-		
-		// Fill line
-		p.fillRect( rect(), gradient );
-	}
-}
-
-// QProperty handles
-bool positionLine::hasTailGradient() const
-{ return m_hasTailGradient; }
-
-void positionLine::setHasTailGradient( const bool g )
-{ m_hasTailGradient = g; }
-
-QColor positionLine::lineColor() const
-{ return m_lineColor; }
-
-void positionLine::setLineColor( const QColor & c )
-{ m_lineColor = c; }
-
-// NOTE: the move() implementation fixes a bug where the position line would appear
-// in an unexpected location when positioned at the start of the track
-void positionLine::zoomChange( double zoom )
-{
-	int playHeadPos = x() + width() - 1;
-	
-	resize( 8.0 * zoom, height() );
-	move( playHeadPos - width() + 1, y() );
-	
-	update();
-}
-
-
-
-
 const QVector<double> SongEditor::m_zoomLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f };
 
@@ -172,7 +92,7 @@ SongEditor::SongEditor( Song * song ) :
 	connect( m_timeLine, SIGNAL( selectionFinished() ),
 			 this, SLOT( stopRubberBand() ) );
 
-	m_positionLine = new positionLine( this );
+	m_positionLine = new PositionLine(this);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );
 	
 	connect( m_song, SIGNAL( playbackStateChanged() ),

--- a/src/gui/widgets/PositionLine.cpp
+++ b/src/gui/widgets/PositionLine.cpp
@@ -52,24 +52,26 @@ void PositionLine::paintEvent(QPaintEvent* pe)
 		c.setAlpha(153);
 		p.fillRect(rect(), c);
 	}
-
 	// If width > 1, we need the gradient
 	else
 	{
 		// Create the gradient trail behind the line
 		QLinearGradient gradient(rect().bottomLeft(), rect().bottomRight());
+		qreal w = (width() - 1.0) / width();
 
 		// If gradient is enabled, we're in focus and we're playing, enable gradient
-		if (Engine::getSong()->isPlaying() && m_hasTailGradient && 
-			Engine::getSong()->playMode() == Song::Mode_PlaySong)
+		if (m_hasTailGradient &&
+			Engine::getSong()->isPlaying() &&
+			(Engine::getSong()->playMode() == Song::Mode_PlaySong ||
+			 Engine::getSong()->playMode() == Song::Mode_PlayPattern))
 		{
 			c.setAlpha(60);
-			gradient.setColorAt((width() - 1.0)/width(), c);
+			gradient.setColorAt(w, c);
 		}
 		else
 		{
 			c.setAlpha(0);
-			gradient.setColorAt((width() - 1.0 )/width(), c);
+			gradient.setColorAt(w, c);
 		}
 
 		// Fill in the remaining parts

--- a/src/gui/widgets/PositionLine.cpp
+++ b/src/gui/widgets/PositionLine.cpp
@@ -1,0 +1,96 @@
+/*
+ * PositionLine.cpp
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "PositionLine.h"
+
+#include <QPainter>
+
+#include "GuiApplication.h"
+#include "Song.h"
+
+
+PositionLine::PositionLine(QWidget* parent) :
+	QWidget(parent),
+	m_hasTailGradient(false),
+	m_lineColor(0, 0, 0, 0)
+{
+	resize(8, height());
+
+	setAttribute(Qt::WA_NoSystemBackground, true);
+	setAttribute(Qt::WA_TransparentForMouseEvents);
+}
+
+void PositionLine::paintEvent(QPaintEvent* pe)
+{
+	QPainter p(this);
+	QColor c = QColor(m_lineColor);
+
+	// If width is 1, we don't need a gradient
+	if (width() == 1)
+	{
+		c.setAlpha(153);
+		p.fillRect(rect(), c);
+	}
+
+	// If width > 1, we need the gradient
+	else
+	{
+		// Create the gradient trail behind the line
+		QLinearGradient gradient(rect().bottomLeft(), rect().bottomRight());
+
+		// If gradient is enabled, we're in focus and we're playing, enable gradient
+		if (Engine::getSong()->isPlaying() && m_hasTailGradient && 
+			Engine::getSong()->playMode() == Song::Mode_PlaySong)
+		{
+			c.setAlpha(60);
+			gradient.setColorAt((width() - 1.0)/width(), c);
+		}
+		else
+		{
+			c.setAlpha(0);
+			gradient.setColorAt((width() - 1.0 )/width(), c);
+		}
+
+		// Fill in the remaining parts
+		c.setAlpha(0);
+		gradient.setColorAt(0, c);
+		c.setAlpha(153);
+		gradient.setColorAt(1, c);
+
+		// Fill line
+		p.fillRect(rect(), gradient);
+	}
+}
+
+// NOTE: the move() implementation fixes a bug where the position line would appear
+// in an unexpected location when positioned at the start of the track
+void PositionLine::zoomChange(double zoom)
+{
+	int playHeadPos = x() + width() - 1;
+
+	resize(8.0 * zoom, height());
+	move(playHeadPos - width() + 1, y());
+
+	update();
+}

--- a/src/gui/widgets/StepRecorderWidget.cpp
+++ b/src/gui/widgets/StepRecorderWidget.cpp
@@ -58,6 +58,19 @@ void StepRecorderWidget::setCurrentPosition(MidiTime currentPosition)
 	m_currentPosition = currentPosition;
 }
 
+void StepRecorderWidget::setMargins(const QMargins &qm)
+{
+	m_left = qm.left();
+	m_right = qm.right();
+	m_top = qm.top();
+	m_bottom = qm.bottom();
+}
+
+QMargins StepRecorderWidget::margins()
+{
+	return QMargins(m_left, m_top, m_right, m_bottom);
+}
+
 void StepRecorderWidget::setBottomMargin(const int marginBottom)
 {
 	m_marginBottom = marginBottom;


### PR DESCRIPTION
Kind of a bigger PR, but fixes a few things: #4098, #5008 (partial, but easy to add to editors now).

In addition to those fixes, it reworks how the piano roll was painted before (and makes it somewhat easier to follow). Local tests of ~1000 `paintEvent` frames using the demo `Skiessi-C64.mmpz` put `master`'s `paintEvent` at ~6-6.1ms average time, this PR runs at ~4-4.1ms (improvement of ~33%) on `DEBUG` build.

General summary of updates:
* Split out SongEditor's `positionLine` class into an updated separate class file `PositionLine`
* No longer can the key area be resized larger than `NumKeys * KEY_LINE_HEIGHT` (108 * 12) pixels
* If window is sized larger than max key area size, note edit area is resized instead
* Key area snaps to `KEY_LINE_HEIGHT` to prevent partial key draws (except if top key is black key, the previous key is drawn in that case)
* Position marker added to timeline
* Simplifies some math, some if branches, and draw code (old code went through white keys then through black keys, now only one for loop)

EDIT: I've updated the title to be a little more general since I'm touching a little more than just `painteEvent` with this PR. It still focuses on `paintEvent`, but there's a lot more to it at this point.