### PR TITLE
Fix #3005

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1965,7 +1965,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 	}
 	else
 	{
-		mousePressEvent(me);
+		QWidget::mouseDoubleClickEvent(me);
 	}
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1963,6 +1963,10 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 			enterValue( &nv );
 		}
 	}
+	else
+	{
+		mousePressEvent(me);
+	}
 }
 
 


### PR DESCRIPTION
`mouseDoubleClickEvent` wasn't forwarding to `mousePressEvent` like the default implementation does. This adds that check.

I don't believe this should cause any problems double clicking elsewhere (I can't seem to find any problems with a basic test), but just in case we can restrict this to just the piano key area.