### PR TITLE
Piano Roll - Fix retrigger with vol/pan sliders

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2175,7 +2175,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 						m_pattern->instrumentTrack()->processInEvent( evt );
 					}
 				}
-				else if( n->isPlaying() )
+				else if( n->isPlaying() && !isSelection() )
 				{
 					// mouse not over this note, stop playing it.
 					m_pattern->instrumentTrack()->pianoModel()->handleKeyRelease( n->key() );


### PR DESCRIPTION
Fixes LMMS/lmms/#3637 where notes are retriggered when moving vol/pan sliders of a partially selected chord and it has an envelope.