### PR TITLE
Correct export of sampletracks at more than 44100 samplerate

### DIFF
--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -108,6 +108,7 @@ public:
 	// base64-data out of string
 	SampleBuffer( const QString & _audio_file, bool _is_base64_data = false );
 	SampleBuffer( const sampleFrame * _data, const f_cnt_t _frames );
+	SampleBuffer(const bool from_sample_track);
 	explicit SampleBuffer( const f_cnt_t _frames );
 
 	virtual ~SampleBuffer();
@@ -298,6 +299,7 @@ private:
 	bool m_reversed;
 	float m_frequency;
 	sample_rate_t m_sampleRate;
+	bool m_fromSampleTrack;
 
 	sampleFrame * getSampleFragment( f_cnt_t _index, f_cnt_t _frames,
 						LoopMode _loopmode,

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -73,7 +73,8 @@ SampleBuffer::SampleBuffer() :
 	m_amplification( 1.0f ),
 	m_reversed( false ),
 	m_frequency( BaseFreq ),
-	m_sampleRate( mixerSampleRate () )
+	m_sampleRate( mixerSampleRate () ),
+	m_fromSampleTrack (false)
 {
 
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
@@ -128,6 +129,11 @@ SampleBuffer::SampleBuffer( const f_cnt_t _frames )
 }
 
 
+SampleBuffer::SampleBuffer(const bool from_sample_track)
+	: SampleBuffer()
+{
+	m_fromSampleTrack = from_sample_track;
+}
 
 
 SampleBuffer::~SampleBuffer()
@@ -140,6 +146,10 @@ SampleBuffer::~SampleBuffer()
 
 void SampleBuffer::sampleRateChanged()
 {
+	if (m_fromSampleTrack)
+	{
+		setSampleRate(mixerSampleRate());
+	}
 	update( true );
 }
 

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -55,7 +55,7 @@
 
 SampleTCO::SampleTCO( Track * _track ) :
 	TrackContentObject( _track ),
-	m_sampleBuffer( new SampleBuffer ),
+	m_sampleBuffer( new SampleBuffer(true) ),
 	m_isPlaying( false )
 {
 	saveJournallingState( false );


### PR DESCRIPTION
I created a new constructor for `samplebuffer` that sets a flag (`m_fromSampleTrack`) for `samplebuffer` objects that belongs to sample tracks.
When the samplerate of the mixer is changed, those objects have their samplerate changed accordingly.
This fixes the bad rendering of sample tracks at more than 44100 samplerate and, as a side effect it fixes #2778.