### PR TITLE
Support NetBSD's OSS audio/midi implementation.

### DIFF
--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -59,7 +59,7 @@
 
 
 #ifndef _PATH_DEV_DSP
-#ifdef __OpenBSD__
+#if defined(__NetBSD__) || defined(__OpenBSD__)
 #define _PATH_DEV_DSP  "/dev/audio"
 #else
 #define _PATH_DEV_DSP  "/dev/dsp"

--- a/src/core/midi/MidiOss.cpp
+++ b/src/core/midi/MidiOss.cpp
@@ -71,7 +71,11 @@ QString MidiOss::probeDevice()
 		{
 			return getenv( "MIDIDEV" );
 		}
+#ifdef __NetBSD__
+		return "/dev/rmidi0";
+#else
 		return "/dev/midi";
+#endif
 	}
 	return dev;
 }


### PR DESCRIPTION
Just uses slightly different paths for the default devices.