### PR TITLE
Fix scrolling direction in SongEditor due to stuck Ctrl/Shift.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,7 +480,7 @@ ENDIF()
 
 # Due to a regression in gcc-4.8.X, we need to disable array-bounds check
 IF (CMAKE_COMPILER_IS_GNUCXX AND ((CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "4.8.0") OR (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.8.0") OR LMMS_BUILD_WIN32))
-   SET(WERROR_FLAGS "${WERROR_FLAGS} -Wno-array-bounds")
+   SET(WERROR_FLAGS "${WERROR_FLAGS} -Wno-array-bounds -Wno-attributes")
 ENDIF()
 
 IF(NOT CMAKE_BUILD_TYPE)

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -126,19 +126,10 @@ public:
 
 	void clearKeyModifiers();
 
-	bool isCtrlPressed()
-	{
-		return m_keyMods.m_ctrl;
-	}
-
+	[[deprecated]]  // TODO Remove this function, since m_shift can get stuck down.
 	bool isShiftPressed()
 	{
 		return m_keyMods.m_shift;
-	}
-
-	bool isAltPressed()
-	{
-		return m_keyMods.m_alt;
 	}
 
 	static void saveWidgetState( QWidget * _w, QDomElement & _de );
@@ -176,11 +167,11 @@ public slots:
 	void autoSave();
 
 protected:
-	virtual void closeEvent( QCloseEvent * _ce );
-	virtual void focusOutEvent( QFocusEvent * _fe );
-	virtual void keyPressEvent( QKeyEvent * _ke );
-	virtual void keyReleaseEvent( QKeyEvent * _ke );
-	virtual void timerEvent( QTimerEvent * _ev );
+	void closeEvent( QCloseEvent * _ce ) override;
+	void focusOutEvent( QFocusEvent * _fe ) override;
+	void keyPressEvent( QKeyEvent * _ke ) override;
+	void keyReleaseEvent( QKeyEvent * _ke ) override;
+	void timerEvent( QTimerEvent * _ev ) override;
 
 
 private:

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -694,7 +694,7 @@ void TrackContentObjectView::mousePressEvent( QMouseEvent * me )
 					dataFile.toString(), thumbnail, this );
 	}
 	else if( me->button() == Qt::LeftButton &&
-		/*	engine::mainWindow()->isShiftPressed() == false &&*/
+		/* (me->modifiers() & Qt::ShiftModifier) &&*/
 							fixedTCOs() == false )
 	{
 		m_tco->addJournalCheckPoint();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1423,6 +1423,7 @@ void MainWindow::sessionCleanup()
 
 void MainWindow::focusOutEvent( QFocusEvent * _fe )
 {
+	// TODO Remove this function, since it is apparently never actually called!
 	// when loosing focus we do not receive key-(release!)-events anymore,
 	// so we might miss release-events of one the modifiers we're watching!
 	clearKeyModifiers();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -415,14 +415,13 @@ void SongEditor::setEditModeSelect()
 
 void SongEditor::keyPressEvent( QKeyEvent * ke )
 {
-	if( /*_ke->modifiers() & Qt::ShiftModifier*/
-		gui->mainWindow()->isShiftPressed() == true &&
+	bool isShiftPressed = ke->modifiers() & Qt::ShiftModifier;
+	if( isShiftPressed &&
 						( ke->key() == Qt::Key_Insert || ke->key() == Qt::Key_Enter || ke->key() == Qt::Key_Return ) )
 	{
 		m_song->insertBar();
 	}
-	else if(/* _ke->modifiers() & Qt::ShiftModifier &&*/
-			gui->mainWindow()->isShiftPressed() == true &&
+	else if( isShiftPressed &&
 						( ke->key() == Qt::Key_Delete || ke->key() == Qt::Key_Backspace ) )
 	{
 		m_song->removeBar();
@@ -458,7 +457,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 void SongEditor::wheelEvent( QWheelEvent * we )
 {
-	if( gui->mainWindow()->isCtrlPressed() == true )
+	if( we->modifiers() & Qt::ControlModifier )
 	{
 		int z = m_zoomingModel->value();
 
@@ -480,7 +479,7 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 		// and make sure, all TCO's are resized and relocated
 		realignTracks();
 	}
-	else if( gui->mainWindow()->isShiftPressed() == true || we->orientation() == Qt::Horizontal )
+	else if( (we->modifiers() & Qt::ShiftModifier) || we->orientation() == Qt::Horizontal )
 	{
 		m_leftRightScroll->setValue( m_leftRightScroll->value() -
 							we->delta() / 30 );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -601,7 +601,7 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 		m_buttonPressed = true;
 	}
 	else if( _me->button() == Qt::LeftButton &&
-			gui->mainWindow()->isShiftPressed() == true )
+			(_me->modifiers() & Qt::ShiftModifier) )
 	{
 		new StringPairDrag( "float_value",
 					QString::number( model()->value() ),

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -122,7 +122,7 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 	if( m_mouseMoving )
 	{
 		int dy = event->globalY() - m_origMousePos.y();
-		if( gui->mainWindow()->isShiftPressed() )
+		if( event->modifiers() & Qt::ShiftModifier )
 			dy = qBound( -4, dy/4, 4 );
 		if( dy > 1 || dy < -1 )
 		{


### PR DESCRIPTION
As far as I can tell, MainWindow::focusOutEvent never gets called no matter what I do, so clearKeyModifiers fails to be called.