### PR TITLE
Automation Editor point fine tuning with wheel scroll

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -218,6 +218,8 @@ private:
 
 	Actions m_action;
 
+	float m_pointYLevel;
+
 	tick_t m_selectStartTick;
 	tick_t m_selectedTick;
 	float m_selectStartLevel;


### PR DESCRIPTION
Related to issue #5225 
And replaces old PR #5232 

Allows user to place cursor over an automation point in the Automation Editor, and use scroll wheel to adjust the y level for that point.  It also improves mouse cursor interaction with the point, and shows the point's Y level when mouse cursor is over a point.

https://cdn.discordapp.com/attachments/332258319228207114/629248936099708928/AutomationEditor2-2019-10-03_04.21.20.mp4 (example, not current)

This PR involves the creation of a variable, and the use of `mouseMoveEvent`, `drawCross`, and `wheelEvent`.

 - A variable, `m_pointYLevel` is created and used to hold a point's Y level position.
- The value of `m_pointYLevel` is set when the mouse moves over a point.
- The value of `m_pointYLevel` changes when the mouse wheel is scrolled, and over a point.
- The point's Y level changes when the mouse wheel is scrolled, and over a point.
- If the mouse moves away from a point, the value of `m_pointYLevel` returns to `0`.
- When the value of `m_pointYLevel` is `0`, the tool tip in `drawCross` displays the Y level position of the mouse.
- When the value of `m_pointYLevel` is greater than `0`, the tool tip in `drawCross` displays the point's Y level position. 