### PR TITLE
Automation Editor point fine tuning with double click

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -122,6 +122,7 @@ protected:
 	void paintEvent(QPaintEvent * pe) override;
 	void resizeEvent(QResizeEvent * re) override;
 	void wheelEvent(QWheelEvent * we) override;
+	void mouseDoubleClickEvent(QMouseEvent * mouseEvent) override;
 
 	float getLevel( int y );
 	int xCoordOfTick( int tick );
@@ -217,6 +218,8 @@ private:
 	MidiTime m_currentPosition;
 
 	Actions m_action;
+
+	float m_pointYLevel;
 
 	tick_t m_selectStartTick;
 	tick_t m_selectedTick;


### PR DESCRIPTION
Related to issue #5225 and old PR #5232 (closed)

Allows user to double click an automation point in the Automation Editor, and enter new number to adjust the y level for that point.  It also improves mouse cursor interaction with the point, and shows the point's Y level when mouse cursor is over a point.  

This PR involves the creation of `doubleClickEvent`, creation of variable `m_pointYLevel`, and the use of `mouseMoveEvent` and `drawCross`.

- A variable, `m_pointYLevel` is created and used to hold a point's Y level position.
- The value of `m_pointYLevel` is set when the mouse moves over a point.
- The value of `m_pointYLevel` is used when opening an input dialog box, for the current value.
- If the mouse moves away from a point, the value of `m_pointYLevel` returns to `0`.
- When the value of `m_pointYLevel` is `0`, the tool tip in `drawCross` displays the Y level position of the mouse.
- When the value of `m_pointYLevel` is greater than `0`, the tool tip in `drawCross` displays the point's Y level position.