### PR TITLE
Fix crash due to calling QWidget::move from a non-GUI thread while ex…

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -685,7 +685,7 @@ void Song::stop()
 				if( gui && gui->songEditor() &&
 						( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 				{
-					gui->songEditor()->m_editor->updatePosition(0);
+					QMetaObject::invokeMethod(gui->songEditor()->m_editor, "updatePosition", Qt::AutoConnection, Q_ARG(MidiTime, 0));
 				}
 				break;
 
@@ -699,7 +699,7 @@ void Song::stop()
 					if( gui && gui->songEditor() &&
 							( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 					{
-						gui->songEditor()->m_editor->updatePosition( MidiTime(tl->savedPos().getTicks() ) );
+						QMetaObject::invokeMethod(gui->songEditor()->m_editor, "updatePosition", Qt::AutoConnection, Q_ARG(MidiTime, tl->savedPos().getTicks()));
 					}
 					tl->savePos( -1 );
 				}


### PR DESCRIPTION
…porting tracks.

Using signals/slots instead should be thread safe.

Crash callstack:

QWidget::move
SongEditor::updatePosition
Song::stop
Song::stopExport
ProjectRenderer::run
QThreadPrivate::start