### PR TITLE
Build with Qt5 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ OPTION(WANT_TAP		"Include Tom's Audio Processing LADSPA plugins" ON)
 OPTION(WANT_VST		"Include VST support" ON)
 OPTION(WANT_VST_NOWINE	"Include partial VST support (without wine)" OFF)
 OPTION(WANT_WINMM	"Include WinMM MIDI support" OFF)
-OPTION(WANT_QT5		"Build with Qt5" OFF)
+OPTION(WANT_QT5		"Build with Qt5" ON)
 
 
 IF(LMMS_BUILD_APPLE)

--- a/cmake/build_mingw32.sh
+++ b/cmake/build_mingw32.sh
@@ -18,6 +18,8 @@ fi
 
 if [ $QT5 ]; then
 	CMAKE_OPTS="-DWANT_QT5=$QT5 -DCMAKE_PREFIX_PATH=$MINGW $CMAKE_OPTS"
+else
+	CMAKE_OPTS="-DWANT_QT5=OFF"
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/cmake/build_mingw64.sh
+++ b/cmake/build_mingw64.sh
@@ -16,6 +16,8 @@ fi
 
 if [ $QT5 ]; then
         CMAKE_OPTS="-DWANT_QT5=$QT5 -DCMAKE_PREFIX_PATH=$MINGW $CMAKE_OPTS"
+else
+		CMAKE_OPTS="-DWANT_QT5=OFF"
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/cmake/build_mingw64.sh
+++ b/cmake/build_mingw64.sh
@@ -17,7 +17,7 @@ fi
 if [ $QT5 ]; then
         CMAKE_OPTS="-DWANT_QT5=$QT5 -DCMAKE_PREFIX_PATH=$MINGW $CMAKE_OPTS"
 else
-		CMAKE_OPTS="-DWANT_QT5=OFF"
+        CMAKE_OPTS="-DWANT_QT5=OFF"
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
This makes `stable-1.2` build with Qt5 by default as suggested in https://github.com/LMMS/lmms/issues/5289#issuecomment-547836729.