### PR TITLE
Rename MidiTime to TimePos

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -30,7 +30,7 @@
 
 #include "JournallingObject.h"
 #include "Model.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "ValueBuffer.h"
 #include "MemoryManager.h"
 #include "ModelVisitor.h"
@@ -280,7 +280,7 @@ public:
 		return false;
 	}
 
-	float globalAutomationValueAt( const MidiTime& time );
+	float globalAutomationValueAt( const TimePos& time );
 
 	void setStrictStepSize( const bool b )
 	{

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -34,7 +34,7 @@
 
 #include "lmms_basics.h"
 #include "JournallingObject.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "AutomationPattern.h"
 #include "ComboBoxModel.h"
 #include "Knob.h"
@@ -153,7 +153,7 @@ protected slots:
 	void pasteValues();
 	void deleteSelectedValues();
 
-	void updatePosition( const MidiTime & t );
+	void updatePosition( const TimePos & t );
 
 	void zoomingXChanged();
 	void zoomingYChanged();
@@ -214,7 +214,7 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
-	MidiTime m_currentPosition;
+	TimePos m_currentPosition;
 
 	Actions m_action;
 
@@ -263,7 +263,7 @@ private:
 
 signals:
 	void currentPatternChanged();
-	void positionChanged( const MidiTime & );
+	void positionChanged( const TimePos & );
 } ;
 
 

--- a/include/AutomationPattern.h
+++ b/include/AutomationPattern.h
@@ -34,7 +34,7 @@
 
 
 class AutomationTrack;
-class MidiTime;
+class TimePos;
 
 
 
@@ -74,19 +74,19 @@ public:
 	}
 	void setTension( QString _new_tension );
 
-	MidiTime timeMapLength() const;
+	TimePos timeMapLength() const;
 	void updateLength();
 
-	MidiTime putValue( const MidiTime & time,
+	TimePos putValue( const TimePos & time,
 				const float value,
 				const bool quantPos = true,
 				const bool ignoreSurroundingPoints = true );
 
-	void removeValue( const MidiTime & time );
+	void removeValue( const TimePos & time );
 
-	void recordValue(MidiTime time, float value);
+	void recordValue(TimePos time, float value);
 
-	MidiTime setDragValue( const MidiTime & time,
+	TimePos setDragValue( const TimePos & time,
 				const float value,
 				const bool quantPos = true,
 				const bool controlKey = false );
@@ -134,8 +134,8 @@ public:
 		return m_timeMap.isEmpty() == false;
 	}
 
-	float valueAt( const MidiTime & _time ) const;
-	float *valuesAfter( const MidiTime & _time ) const;
+	float valueAt( const TimePos & _time ) const;
+	float *valuesAfter( const TimePos & _time ) const;
 
 	const QString name() const;
 

--- a/include/AutomationTrack.h
+++ b/include/AutomationTrack.h
@@ -37,7 +37,7 @@ public:
 	AutomationTrack( TrackContainer* tc, bool _hidden = false );
 	virtual ~AutomationTrack() = default;
 
-	virtual bool play( const MidiTime & _start, const fpp_t _frames,
+	virtual bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
 
 	virtual QString nodeName() const
@@ -46,7 +46,7 @@ public:
 	}
 
 	virtual TrackView * createView( TrackContainerView* );
-	virtual TrackContentObject * createTCO( const MidiTime & _pos );
+	virtual TrackContentObject * createTCO( const TimePos & _pos );
 
 	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent );

--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -132,10 +132,10 @@ public:
 	BBTrack( TrackContainer* tc );
 	virtual ~BBTrack();
 
-	virtual bool play( const MidiTime & _start, const fpp_t _frames,
+	virtual bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
 	virtual TrackView * createView( TrackContainerView* tcv );
-	virtual TrackContentObject * createTCO( const MidiTime & _pos );
+	virtual TrackContentObject * createTCO( const TimePos & _pos );
 
 	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent );

--- a/include/BBTrackContainer.h
+++ b/include/BBTrackContainer.h
@@ -38,7 +38,7 @@ public:
 	BBTrackContainer();
 	virtual ~BBTrackContainer();
 
-	virtual bool play( MidiTime _start, const fpp_t _frames,
+	virtual bool play( TimePos _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
 
 	virtual void updateAfterTrackAdd() override;
@@ -62,7 +62,7 @@ public:
 	void fixIncorrectPositions();
 	void createTCOsForBB( int _bb );
 
-	AutomatedValueMap automatedValuesAt(MidiTime time, int tcoNum) const override;
+	AutomatedValueMap automatedValuesAt(TimePos time, int tcoNum) const override;
 
 public slots:
 	void play();

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -30,7 +30,7 @@
 #include "lmms_export.h"
 #include "lmms_basics.h"
 #include "MemoryManager.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "Plugin.h"
 
 
@@ -105,7 +105,7 @@ public:
 
 	// sub-classes can re-implement this for receiving all incoming
 	// MIDI-events
-	inline virtual bool handleMidiEvent( const MidiEvent&, const MidiTime& = MidiTime(), f_cnt_t offset = 0 )
+	inline virtual bool handleMidiEvent( const MidiEvent&, const TimePos& = TimePos(), f_cnt_t offset = 0 )
 	{
 		return true;
 	}

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -80,8 +80,8 @@ public:
 
 	MidiEvent applyMasterKey( const MidiEvent& event );
 
-	virtual void processInEvent( const MidiEvent& event, const MidiTime& time = MidiTime(), f_cnt_t offset = 0 );
-	virtual void processOutEvent( const MidiEvent& event, const MidiTime& time = MidiTime(), f_cnt_t offset = 0 );
+	virtual void processInEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 );
+	virtual void processOutEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 );
 	// silence all running notes played by this track
 	void silenceAllNotes( bool removeIPH = false );
 
@@ -130,13 +130,13 @@ public:
 	}
 
 	// play everything in given frame-range - creates note-play-handles
-	virtual bool play( const MidiTime & _start, const fpp_t _frames,
+	virtual bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
 	// create new view for me
 	virtual TrackView * createView( TrackContainerView* tcv );
 
 	// create new track-content-object = pattern
-	virtual TrackContentObject * createTCO( const MidiTime & _pos );
+	virtual TrackContentObject * createTCO( const TimePos & _pos );
 
 
 	// called by track

--- a/include/MidiAlsaSeq.h
+++ b/include/MidiAlsaSeq.h
@@ -66,7 +66,7 @@ public:
 
 
 	virtual void processOutEvent( const MidiEvent & _me,
-						const MidiTime & _time,
+						const TimePos & _time,
 						const MidiPort * _port );
 
 	virtual void applyPortMode( MidiPort * _port );

--- a/include/MidiApple.h
+++ b/include/MidiApple.h
@@ -60,7 +60,7 @@ public:
 	}
 	
 	virtual void processOutEvent( const MidiEvent & _me,
-								const MidiTime & _time,
+								const TimePos & _time,
 								const MidiPort * _port );
 	
 	virtual void applyPortMode( MidiPort * _port );

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -46,7 +46,7 @@ public:
 
 	// to be implemented by sub-classes
 	virtual void processOutEvent( const MidiEvent & _me,
-						const MidiTime & _time,
+						const TimePos & _time,
 						const MidiPort * _port ) = 0;
 
 	// inheriting classes can re-implement this for being able to update
@@ -141,7 +141,7 @@ protected:
 private:
 	// this does MIDI-event-process
 	void processParsedEvent();
-	virtual void processOutEvent( const MidiEvent& event, const MidiTime& time, const MidiPort* port );
+	virtual void processOutEvent( const MidiEvent& event, const TimePos& time, const MidiPort* port );
 
 	// small helper function returning length of a certain event - this
 	// is necessary for parsing raw-MIDI-data

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -44,10 +44,10 @@ public:
 	virtual ~MidiController();
 
 	virtual void processInEvent( const MidiEvent & _me,
-					const MidiTime & _time, f_cnt_t offset = 0 );
+					const TimePos & _time, f_cnt_t offset = 0 );
 
 	virtual void processOutEvent( const MidiEvent& _me,
-					const MidiTime & _time, f_cnt_t offset = 0 )
+					const TimePos & _time, f_cnt_t offset = 0 )
 	{
 		// No output yet
 	}

--- a/include/MidiEventProcessor.h
+++ b/include/MidiEventProcessor.h
@@ -26,7 +26,7 @@
 #define MIDI_EVENT_PROCESSOR_H
 
 #include "MidiEvent.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "MemoryManager.h"
 
 // all classes being able to process MIDI-events should inherit from this
@@ -43,8 +43,8 @@ public:
 	}
 
 	// to be implemented by inheriting classes
-	virtual void processInEvent( const MidiEvent& event, const MidiTime& time = MidiTime(), f_cnt_t offset = 0 ) = 0;
-	virtual void processOutEvent( const MidiEvent& event, const MidiTime& time = MidiTime(), f_cnt_t offset = 0 ) = 0;
+	virtual void processInEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 ) = 0;
+	virtual void processOutEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 ) = 0;
 
 } ;
 

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -31,7 +31,7 @@
 #include <QtCore/QMap>
 
 #include "Midi.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "AutomatableModel.h"
 
 
@@ -99,8 +99,8 @@ public:
 		return outputChannel() - 1;
 	}
 
-	void processInEvent( const MidiEvent& event, const MidiTime& time = MidiTime() );
-	void processOutEvent( const MidiEvent& event, const MidiTime& time = MidiTime() );
+	void processInEvent( const MidiEvent& event, const TimePos& time = TimePos() );
+	void processOutEvent( const MidiEvent& event, const TimePos& time = TimePos() );
 
 
 	virtual void saveSettings( QDomDocument& doc, QDomElement& thisElement );

--- a/include/MidiWinMM.h
+++ b/include/MidiWinMM.h
@@ -64,7 +64,7 @@ public:
 
 
 	virtual void processOutEvent( const MidiEvent & _me,
-						const MidiTime & _time,
+						const TimePos & _time,
 						const MidiPort * _port );
 
 	virtual void applyPortMode( MidiPort * _port );

--- a/include/Note.h
+++ b/include/Note.h
@@ -30,7 +30,7 @@
 
 #include "volume.h"
 #include "panning.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "SerializingObject.h"
 
 class DetuningHelper;
@@ -81,8 +81,8 @@ const float MaxDetuning = 4 * 12.0f;
 class LMMS_EXPORT Note : public SerializingObject
 {
 public:
-	Note( const MidiTime & length = MidiTime( 0 ),
-		const MidiTime & pos = MidiTime( 0 ),
+	Note( const TimePos & length = TimePos( 0 ),
+		const TimePos & pos = TimePos( 0 ),
 		int key = DefaultKey,
 		volume_t volume = DefaultVolume,
 		panning_t panning = DefaultPanning,
@@ -93,9 +93,9 @@ public:
 	// used by GUI
 	inline void setSelected( const bool selected ) { m_selected = selected; }
 	inline void setOldKey( const int oldKey ) { m_oldKey = oldKey; }
-	inline void setOldPos( const MidiTime & oldPos ) { m_oldPos = oldPos; }
+	inline void setOldPos( const TimePos & oldPos ) { m_oldPos = oldPos; }
 
-	inline void setOldLength( const MidiTime & oldLength )
+	inline void setOldLength( const TimePos & oldLength )
 	{
 		m_oldLength = oldLength;
 	}
@@ -105,8 +105,8 @@ public:
 	}
 
 
-	void setLength( const MidiTime & length );
-	void setPos( const MidiTime & pos );
+	void setLength( const TimePos & length );
+	void setPos( const TimePos & pos );
 	void setKey( const int key );
 	virtual void setVolume( volume_t volume );
 	virtual void setPanning( panning_t panning );
@@ -138,12 +138,12 @@ public:
 		return m_oldKey;
 	}
 
-	inline MidiTime oldPos() const
+	inline TimePos oldPos() const
 	{
 		return m_oldPos;
 	}
 
-	inline MidiTime oldLength() const
+	inline TimePos oldLength() const
 	{
 		return m_oldLength;
 	}
@@ -153,23 +153,23 @@ public:
 		return m_isPlaying;
 	}
 
-	inline MidiTime endPos() const
+	inline TimePos endPos() const
 	{
 		const int l = length();
 		return pos() + l;
 	}
 
-	inline const MidiTime & length() const
+	inline const TimePos & length() const
 	{
 		return m_length;
 	}
 
-	inline const MidiTime & pos() const
+	inline const TimePos & pos() const
 	{
 		return m_pos;
 	}
 
-	inline MidiTime pos( MidiTime basePos ) const
+	inline TimePos pos( TimePos basePos ) const
 	{
 		const int bp = basePos;
 		return m_pos - bp;
@@ -205,7 +205,7 @@ public:
 		return classNodeName();
 	}
 
-	static MidiTime quantized( const MidiTime & m, const int qGrid );
+	static TimePos quantized( const TimePos & m, const int qGrid );
 
 	DetuningHelper * detuning() const
 	{
@@ -226,15 +226,15 @@ private:
 	// for piano roll editing
 	bool m_selected;
 	int m_oldKey;
-	MidiTime m_oldPos;
-	MidiTime m_oldLength;
+	TimePos m_oldPos;
+	TimePos m_oldLength;
 	bool m_isPlaying;
 
 	int m_key;
 	volume_t m_volume;
 	panning_t m_panning;
-	MidiTime m_length;
-	MidiTime m_pos;
+	TimePos m_length;
+	TimePos m_pos;
 	DetuningHelper * m_detuning;
 };
 

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -241,19 +241,19 @@ public:
 	}
 
 	/*! Process note detuning automation */
-	void processMidiTime( const MidiTime& time );
+	void processTimePos( const TimePos& time );
 
 	/*! Updates total length (m_frames) depending on a new tempo */
 	void resize( const bpm_t newTempo );
 
 	/*! Set song-global offset (relative to containing pattern) in order to properly perform the note detuning */
-	void setSongGlobalParentOffset( const MidiTime& offset )
+	void setSongGlobalParentOffset( const TimePos& offset )
 	{
 		m_songGlobalParentOffset = offset;
 	}
 
 	/*! Returns song-global offset */
-	const MidiTime& songGlobalParentOffset() const
+	const TimePos& songGlobalParentOffset() const
 	{
 		return m_songGlobalParentOffset;
 	}
@@ -320,7 +320,7 @@ private:
 	float m_unpitchedFrequency;
 
 	BaseDetuning* m_baseDetuning;
-	MidiTime m_songGlobalParentOffset;
+	TimePos m_songGlobalParentOffset;
 
 	int m_midiChannel;
 	Origin m_origin;

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -128,7 +128,7 @@ protected slots:
 
 
 private:
-	MidiTime beatPatternLength() const;
+	TimePos beatPatternLength() const;
 
 	void setType( PatternTypes _new_pattern_type );
 	void checkType();

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -212,9 +212,9 @@ protected slots:
 	void pasteNotes();
 	void deleteSelectedNotes();
 
-	void updatePosition(const MidiTime & t );
-	void updatePositionAccompany(const MidiTime & t );
-	void updatePositionStepRecording(const MidiTime & t );
+	void updatePosition(const TimePos & t );
+	void updatePositionAccompany(const TimePos & t );
+	void updatePositionStepRecording(const TimePos & t );
 
 	void zoomingChanged();
 	void quantizeChanged();
@@ -285,9 +285,9 @@ private:
 	PianoRoll( const PianoRoll & );
 	virtual ~PianoRoll();
 
-	void autoScroll(const MidiTime & t );
+	void autoScroll(const TimePos & t );
 
-	MidiTime newNoteLen() const;
+	TimePos newNoteLen() const;
 
 	void shiftPos(int amount);
 	void shiftSemiTone(int amount);
@@ -348,7 +348,7 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
-	MidiTime m_currentPosition;
+	TimePos m_currentPosition;
 	bool m_recording;
 	QList<Note> m_recordingNotes;
 
@@ -387,7 +387,7 @@ private:
 
 	// remember these values to use them
 	// for the next note that is set
-	MidiTime m_lenOfNewNotes;
+	TimePos m_lenOfNewNotes;
 	volume_t m_lastNoteVolume;
 	panning_t m_lastNotePanning;
 
@@ -442,7 +442,7 @@ private:
 	QColor m_backgroundShade;
 
 signals:
-	void positionChanged( const MidiTime & );
+	void positionChanged( const TimePos & );
 } ;
 
 

--- a/include/SampleRecordHandle.h
+++ b/include/SampleRecordHandle.h
@@ -29,7 +29,7 @@
 #include <QtCore/QList>
 #include <QtCore/QPair>
 
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "PlayHandle.h"
 
 class BBTrack;
@@ -60,7 +60,7 @@ private:
 	typedef QList<QPair<sampleFrame *, f_cnt_t> > bufferList;
 	bufferList m_buffers;
 	f_cnt_t m_framesRecorded;
-	MidiTime m_minLength;
+	TimePos m_minLength;
 
 	Track * m_track;
 	BBTrack * m_bbTrack;

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -49,7 +49,7 @@ public:
 	SampleTCO( Track * _track );
 	virtual ~SampleTCO();
 
-	virtual void changeLength( const MidiTime & _length );
+	virtual void changeLength( const TimePos & _length );
 	const QString & sampleFile() const;
 
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
@@ -64,7 +64,7 @@ public:
 		return m_sampleBuffer;
 	}
 
-	MidiTime sampleLength() const;
+	TimePos sampleLength() const;
 	void setSampleStartFrame( f_cnt_t startFrame );
 	void setSamplePlayLength( f_cnt_t length );
 	virtual TrackContentObjectView * createView( TrackView * _tv );
@@ -136,10 +136,10 @@ public:
 	SampleTrack( TrackContainer* tc );
 	virtual ~SampleTrack();
 
-	virtual bool play( const MidiTime & _start, const fpp_t _frames,
+	virtual bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _tco_num = -1 );
 	virtual TrackView * createView( TrackContainerView* tcv );
-	virtual TrackContentObject * createTCO(const MidiTime & pos);
+	virtual TrackContentObject * createTCO(const TimePos & pos);
 
 
 	virtual void saveTrackSpecificSettings( QDomDocument & _doc,

--- a/include/Song.h
+++ b/include/Song.h
@@ -81,11 +81,11 @@ public:
 	bool hasErrors();
 	QString errorSummary();
 
-	class PlayPos : public MidiTime
+	class PlayPos : public TimePos
 	{
 	public:
 		PlayPos( const int abs = 0 ) :
-			MidiTime( abs ),
+			TimePos( abs ),
 			m_timeLine( NULL ),
 			m_currentFrame( 0.0f )
 		{
@@ -131,27 +131,27 @@ public:
 		return m_elapsedMilliSeconds[playMode];
 	}
 
-	inline void setToTime(MidiTime const & midiTime)
+	inline void setToTime(TimePos const & time)
 	{
-		m_elapsedMilliSeconds[m_playMode] = midiTime.getTimeInMilliseconds(getTempo());
-		m_playPos[m_playMode].setTicks(midiTime.getTicks());
+		m_elapsedMilliSeconds[m_playMode] = time.getTimeInMilliseconds(getTempo());
+		m_playPos[m_playMode].setTicks(time.getTicks());
 	}
 
-	inline void setToTime(MidiTime const & midiTime, PlayModes playMode)
+	inline void setToTime(TimePos const & time, PlayModes playMode)
 	{
-		m_elapsedMilliSeconds[playMode] = midiTime.getTimeInMilliseconds(getTempo());
-		m_playPos[playMode].setTicks(midiTime.getTicks());
+		m_elapsedMilliSeconds[playMode] = time.getTimeInMilliseconds(getTempo());
+		m_playPos[playMode].setTicks(time.getTicks());
 	}
 
 	inline void setToTimeByTicks(tick_t ticks)
 	{
-		m_elapsedMilliSeconds[m_playMode] = MidiTime::ticksToMilliseconds(ticks, getTempo());
+		m_elapsedMilliSeconds[m_playMode] = TimePos::ticksToMilliseconds(ticks, getTempo());
 		m_playPos[m_playMode].setTicks(ticks);
 	}
 
 	inline void setToTimeByTicks(tick_t ticks, PlayModes playMode)
 	{
-		m_elapsedMilliSeconds[playMode] = MidiTime::ticksToMilliseconds(ticks, getTempo());
+		m_elapsedMilliSeconds[playMode] = TimePos::ticksToMilliseconds(ticks, getTempo());
 		m_playPos[playMode].setTicks(ticks);
 	}
 
@@ -162,7 +162,7 @@ public:
 
 	inline int ticksPerBar() const
 	{
-		return MidiTime::ticksPerBar(m_timeSigModel);
+		return TimePos::ticksPerBar(m_timeSigModel);
 	}
 
 	// Returns the beat position inside the bar, 0-based
@@ -269,7 +269,7 @@ public:
 	}
 
 	//TODO: Add Q_DECL_OVERRIDE when Qt4 is dropped
-	AutomatedValueMap automatedValuesAt(MidiTime time, int tcoNum = -1) const;
+	AutomatedValueMap automatedValuesAt(TimePos time, int tcoNum = -1) const;
 
 	// file management
 	void createNewProject();
@@ -405,7 +405,7 @@ private:
 
 	void removeAllControllers();
 
-	void processAutomations(const TrackList& tracks, MidiTime timeStart, fpp_t frames);
+	void processAutomations(const TrackList& tracks, TimePos timeStart, fpp_t frames);
 
 	void setModified(bool value);
 
@@ -458,11 +458,11 @@ private:
     
 	int m_loopRenderCount;
 	int m_loopRenderRemaining;
-	MidiTime m_exportSongBegin;
-	MidiTime m_exportLoopBegin;
-	MidiTime m_exportLoopEnd;
-	MidiTime m_exportSongEnd;
-	MidiTime m_exportEffectiveLength;
+	TimePos m_exportSongBegin;
+	TimePos m_exportLoopBegin;
+	TimePos m_exportLoopEnd;
+	TimePos m_exportSongEnd;
+	TimePos m_exportEffectiveLength;
 
 	friend class LmmsCore;
 	friend class SongEditor;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -88,7 +88,7 @@ public slots:
 	void setEditModeSelect();
 	void toggleProportionalSnap();
 
-	void updatePosition( const MidiTime & t );
+	void updatePosition( const TimePos & t );
 	void updatePositionLine();
 	void selectAllTcos( bool select );
 
@@ -158,7 +158,7 @@ private:
 	QPoint m_scrollPos;
 	QPoint m_mousePos;
 	int m_rubberBandStartTrackview;
-	MidiTime m_rubberbandStartMidipos;
+	TimePos m_rubberbandStartMidipos;
 	int m_currentZoomingValue;
 	int m_trackHeadWidth;
 	bool m_selectRegion;

--- a/include/StepRecorder.h
+++ b/include/StepRecorder.h
@@ -41,14 +41,14 @@ class StepRecorder : public QObject
 	StepRecorder(PianoRoll& pianoRoll, StepRecorderWidget& stepRecorderWidget);
 
 	void initialize();
-	void start(const MidiTime& currentPosition,const MidiTime& stepLength);
+	void start(const TimePos& currentPosition,const TimePos& stepLength);
 	void stop();
 	void notePressed(const Note & n);
 	void noteReleased(const Note & n);
 	bool keyPressEvent(QKeyEvent* ke);
 	bool mousePressEvent(QMouseEvent* ke);
 	void setCurrentPattern(Pattern* newPattern);
-	void setStepsLength(const MidiTime& newLength);
+	void setStepsLength(const TimePos& newLength);
 
 	QVector<Note*> getCurStepNotes();
 
@@ -73,7 +73,7 @@ class StepRecorder : public QObject
 	void dismissStep();
 	void prepareNewStep();
 
-	MidiTime getCurStepEndPos();
+	TimePos getCurStepEndPos();
 
 	void updateCurStepNotes();
 	void updateWidget();
@@ -84,11 +84,11 @@ class StepRecorder : public QObject
 	StepRecorderWidget& m_stepRecorderWidget;
 
 	bool m_isRecording = false;
-	MidiTime m_curStepStartPos = 0;
-	MidiTime m_curStepEndPos = 0;
+	TimePos m_curStepStartPos = 0;
+	TimePos m_curStepEndPos = 0;
 
-	MidiTime m_stepsLength;
-	MidiTime m_curStepLength; // current step length refers to the step currently recorded. it may defer from m_stepsLength
+	TimePos m_stepsLength;
+	TimePos m_curStepLength; // current step length refers to the step currently recorded. it may defer from m_stepsLength
 							  // since the user can make current step larger
 
 	QTimer m_updateReleasedTimer;

--- a/include/StepRecorderWidget.h
+++ b/include/StepRecorderWidget.h
@@ -44,13 +44,13 @@ public:
 
 	//API used by PianoRoll
 	void setPixelsPerBar(int ppb);
-	void setCurrentPosition(MidiTime currentPosition);
+	void setCurrentPosition(TimePos currentPosition);
 	void setBottomMargin(const int marginBottom);
 
 	//API used by StepRecorder
-	void setStepsLength(MidiTime stepsLength);
-	void setStartPosition(MidiTime pos);
-	void setEndPosition(MidiTime pos);
+	void setStepsLength(TimePos stepsLength);
+	void setStartPosition(TimePos pos);
+	void setEndPosition(TimePos pos);
 
 	void showHint();
 
@@ -60,16 +60,16 @@ private:
 	int xCoordOfTick(int tick);
 
 	void drawVerLine(QPainter* painter, int x, const QColor& color, int top, int bottom);
-	void drawVerLine(QPainter* painter, const MidiTime& pos, const QColor& color, int top, int bottom);
+	void drawVerLine(QPainter* painter, const TimePos& pos, const QColor& color, int top, int bottom);
 
 	void updateBoundaries();
 
-	MidiTime m_stepsLength;
-	MidiTime m_curStepStartPos;
-	MidiTime m_curStepEndPos;
+	TimePos m_stepsLength;
+	TimePos m_curStepStartPos;
+	TimePos m_curStepEndPos;
 
 	int m_ppb; // pixels per bar
-	MidiTime m_currentPosition; // current position showed by on PianoRoll
+	TimePos m_currentPosition; // current position showed by on PianoRoll
 
 	QColor m_colorLineStart;
 	QColor m_colorLineEnd;
@@ -86,7 +86,7 @@ private:
 	const int m_marginRight;
 
 signals:
-	void positionChanged(const MidiTime & t);
+	void positionChanged(const TimePos & t);
 } ;
 
 #endif //STEP_RECOREDER_WIDGET_H

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -73,7 +73,7 @@ public:
 
 
 	TimeLineWidget(int xoff, int yoff, float ppb, Song::PlayPos & pos,
-				const MidiTime & begin, Song::PlayModes mode, QWidget * parent);
+				const TimePos & begin, Song::PlayModes mode, QWidget * parent);
 	virtual ~TimeLineWidget();
 
 	inline QColor const & getBarLineColor() const { return m_barLineColor; }
@@ -123,23 +123,23 @@ public:
 		return m_loopPoints == LoopPointsEnabled;
 	}
 
-	inline const MidiTime & loopBegin() const
+	inline const TimePos & loopBegin() const
 	{
 		return ( m_loopPos[0] < m_loopPos[1] ) ?
 						m_loopPos[0] : m_loopPos[1];
 	}
 
-	inline const MidiTime & loopEnd() const
+	inline const TimePos & loopEnd() const
 	{
 		return ( m_loopPos[0] > m_loopPos[1] ) ?
 						m_loopPos[0] : m_loopPos[1];
 	}
 
-	inline void savePos( const MidiTime & pos )
+	inline void savePos( const TimePos & pos )
 	{
 		m_savedPos = pos;
 	}
-	inline const MidiTime & savedPos() const
+	inline const TimePos & savedPos() const
 	{
 		return m_savedPos;
 	}
@@ -160,10 +160,10 @@ public:
 		return "timeline";
 	}
 
-	inline int markerX( const MidiTime & _t ) const
+	inline int markerX( const TimePos & _t ) const
 	{
 		return m_xOffset + static_cast<int>( ( _t - m_begin ) *
-					m_ppb / MidiTime::ticksPerBar() );
+					m_ppb / TimePos::ticksPerBar() );
 	}
 
 signals:
@@ -173,10 +173,10 @@ signals:
 
 
 public slots:
-	void updatePosition( const MidiTime & );
+	void updatePosition( const TimePos & );
 	void updatePosition()
 	{
-		updatePosition( MidiTime() );
+		updatePosition( TimePos() );
 	}
 	void toggleAutoScroll( int _n );
 	void toggleLoopPoints( int _n );
@@ -216,11 +216,11 @@ private:
 	int m_posMarkerX;
 	float m_ppb;
 	Song::PlayPos & m_pos;
-	const MidiTime & m_begin;
+	const TimePos & m_begin;
 	const Song::PlayModes m_mode;
-	MidiTime m_loopPos[2];
+	TimePos m_loopPos[2];
 
-	MidiTime m_savedPos;
+	TimePos m_savedPos;
 
 
 	TextFloat * m_hint;
@@ -240,7 +240,7 @@ private:
 
 
 signals:
-	void positionChanged( const MidiTime & _t );
+	void positionChanged( const TimePos & _t );
 	void loopPointStateLoaded( int _n );
 	void positionMarkerMoved();
 

--- a/include/TimePos.h
+++ b/include/TimePos.h
@@ -1,5 +1,5 @@
 /*
- * MidiTime.h - declaration of class MidiTime which provides data type for
+ * TimePos.h - declaration of class TimePos which provides data type for
  *              position- and length-variables
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net
@@ -24,8 +24,8 @@
  */
 
 
-#ifndef MIDI_TIME_H
-#define MIDI_TIME_H
+#ifndef TIME_POS_H
+#define TIME_POS_H
 
 #include <QtGlobal>
 
@@ -57,17 +57,17 @@ private:
 };
 
 
-class LMMS_EXPORT MidiTime
+class LMMS_EXPORT TimePos
 {
 public:
-	MidiTime( const bar_t bar, const tick_t ticks );
-	MidiTime( const tick_t ticks = 0 );
+	TimePos( const bar_t bar, const tick_t ticks );
+	TimePos( const tick_t ticks = 0 );
 
-	MidiTime quantize(float) const;
-	MidiTime toAbsoluteBar() const;
+	TimePos quantize(float) const;
+	TimePos toAbsoluteBar() const;
 
-	MidiTime& operator+=( const MidiTime& time );
-	MidiTime& operator-=( const MidiTime& time );
+	TimePos& operator+=( const TimePos& time );
+	TimePos& operator-=( const TimePos& time );
 
 	// return the bar, rounded down and 0-based
 	bar_t getBar() const;
@@ -92,12 +92,12 @@ public:
 
 	double getTimeInMilliseconds( bpm_t beatsPerMinute ) const;
 
-	static MidiTime fromFrames( const f_cnt_t frames, const float framesPerTick );
+	static TimePos fromFrames( const f_cnt_t frames, const float framesPerTick );
 	static tick_t ticksPerBar();
 	static tick_t ticksPerBar( const TimeSig &sig );
 	static int stepsPerBar();
 	static void setTicksPerBar( tick_t tpt );
-	static MidiTime stepPosition( int step );
+	static TimePos stepPosition( int step );
 	static double ticksToMilliseconds( tick_t ticks, bpm_t beatsPerMinute );
 	static double ticksToMilliseconds( double ticks, bpm_t beatsPerMinute );
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -33,7 +33,7 @@
 #include <QMimeData>
 
 #include "lmms_basics.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "Rubberband.h"
 #include "JournallingObject.h"
 #include "AutomatableModel.h"
@@ -104,18 +104,18 @@ public:
 	}
 
 
-	inline const MidiTime & startPosition() const
+	inline const TimePos & startPosition() const
 	{
 		return m_startPosition;
 	}
 
-	inline MidiTime endPosition() const
+	inline TimePos endPosition() const
 	{
 		const int sp = m_startPosition;
 		return sp + m_length;
 	}
 
-	inline const MidiTime & length() const
+	inline const TimePos & length() const
 	{
 		return m_length;
 	}
@@ -130,8 +130,8 @@ public:
 		return m_autoResize;
 	}
 
-	virtual void movePosition( const MidiTime & pos );
-	virtual void changeLength( const MidiTime & length );
+	virtual void movePosition( const TimePos & pos );
+	virtual void changeLength( const TimePos & length );
 
 	virtual TrackContentObjectView * createView( TrackView * tv ) = 0;
 
@@ -148,8 +148,8 @@ public:
 	/// Returns true if and only if a->startPosition() < b->startPosition()
 	static bool comparePosition(const TrackContentObject* a, const TrackContentObject* b);
 
-	MidiTime startTimeOffset() const;
-	void setStartTimeOffset( const MidiTime &startTimeOffset );
+	TimePos startTimeOffset() const;
+	void setStartTimeOffset( const TimePos &startTimeOffset );
 
 public slots:
 	void copy();
@@ -174,9 +174,9 @@ private:
 	Track * m_track;
 	QString m_name;
 
-	MidiTime m_startPosition;
-	MidiTime m_length;
-	MidiTime m_startTimeOffset;
+	TimePos m_startPosition;
+	TimePos m_length;
+	TimePos m_startTimeOffset;
 
 	BoolModel m_mutedModel;
 	BoolModel m_soloModel;
@@ -298,9 +298,9 @@ private:
 	Actions m_action;
 	QPoint m_initialMousePos;
 	QPoint m_initialMouseGlobalPos;
-	MidiTime m_initialTCOPos;
-	MidiTime m_initialTCOEnd;
-	QVector<MidiTime> m_initialOffsets;
+	TimePos m_initialTCOPos;
+	TimePos m_initialTCOEnd;
+	QVector<TimePos> m_initialOffsets;
 
 	TextFloat * m_hint;
 
@@ -325,7 +325,7 @@ private:
 	void setInitialOffsets();
 
 	bool mouseMovedDistance( QMouseEvent * me, int distance );
-	MidiTime draggedTCOPos( QMouseEvent * me );
+	TimePos draggedTCOPos( QMouseEvent * me );
 } ;
 
 
@@ -359,10 +359,10 @@ public:
 		}
 	}
 
-	bool canPasteSelection( MidiTime tcoPos, const QDropEvent *de );
-	bool pasteSelection( MidiTime tcoPos, QDropEvent * de );
+	bool canPasteSelection( TimePos tcoPos, const QDropEvent *de );
+	bool pasteSelection( TimePos tcoPos, QDropEvent * de );
 
-	MidiTime endPosition( const MidiTime & posStart );
+	TimePos endPosition( const TimePos & posStart );
 
 	// qproperty access methods
 
@@ -378,7 +378,7 @@ public:
 
 public slots:
 	void update();
-	void changePosition( const MidiTime & newPos = MidiTime( -1 ) );
+	void changePosition( const TimePos & newPos = TimePos( -1 ) );
 
 protected:
 	virtual void dragEnterEvent( QDragEnterEvent * dee );
@@ -406,7 +406,7 @@ protected:
 
 private:
 	Track * getTrack();
-	MidiTime getPosition( int mouseX );
+	TimePos getPosition( int mouseX );
 
 	TrackView * m_trackView;
 
@@ -506,12 +506,12 @@ public:
 		return m_type;
 	}
 
-	virtual bool play( const MidiTime & start, const fpp_t frames,
+	virtual bool play( const TimePos & start, const fpp_t frames,
 						const f_cnt_t frameBase, int tcoNum = -1 ) = 0;
 
 
 	virtual TrackView * createView( TrackContainerView * view ) = 0;
-	virtual TrackContentObject * createTCO( const MidiTime & pos ) = 0;
+	virtual TrackContentObject * createTCO( const TimePos & pos ) = 0;
 
 	virtual void saveTrackSpecificSettings( QDomDocument & doc,
 						QDomElement & parent ) = 0;
@@ -540,15 +540,15 @@ public:
 	{
 		return m_trackContentObjects;
 	}
-	void getTCOsInRange( tcoVector & tcoV, const MidiTime & start,
-							const MidiTime & end );
+	void getTCOsInRange( tcoVector & tcoV, const TimePos & start,
+							const TimePos & end );
 	void swapPositionOfTCOs( int tcoNum1, int tcoNum2 );
 
 	void createTCOsForBB( int bb );
 
 
-	void insertBar( const MidiTime & pos );
-	void removeBar( const MidiTime & pos );
+	void insertBar( const TimePos & pos );
+	void removeBar( const TimePos & pos );
 
 	bar_t length() const;
 

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -93,13 +93,13 @@ public:
 		return m_TrackContainerType;
 	}
 
-	virtual AutomatedValueMap automatedValuesAt(MidiTime time, int tcoNum = -1) const;
+	virtual AutomatedValueMap automatedValuesAt(TimePos time, int tcoNum = -1) const;
 
 signals:
 	void trackAdded( Track * _track );
 
 protected:
-	static AutomatedValueMap automatedValuesFromTracks(const TrackList &tracks, MidiTime timeStart, int tcoNum = -1);
+	static AutomatedValueMap automatedValuesFromTracks(const TrackList &tracks, TimePos timeStart, int tcoNum = -1);
 
 	mutable QReadWriteLock m_tracksMutex;
 

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -57,7 +57,7 @@ public:
 		return m_scrollArea;
 	}
 
-	inline const MidiTime & currentPosition() const
+	inline const TimePos & currentPosition() const
 	{
 		return m_currentPosition;
 	}
@@ -144,7 +144,7 @@ protected:
 
 	virtual void resizeEvent( QResizeEvent * );
 
-	MidiTime m_currentPosition;
+	TimePos m_currentPosition;
 
 
 private:
@@ -183,7 +183,7 @@ private:
 
 
 signals:
-	void positionChanged( const MidiTime & _pos );
+	void positionChanged( const TimePos & _pos );
 
 
 } ;

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -42,7 +42,7 @@
 #include "Instrument.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "debug.h"
 #include "Song.h"
 
@@ -159,7 +159,7 @@ public:
 	
 	AutomationTrack * at;
 	AutomationPattern * ap;
-	MidiTime lastPos;
+	TimePos lastPos;
 	
 	smfMidiCC & create( TrackContainer* tc, QString tn )
 	{
@@ -186,11 +186,11 @@ public:
 	}
 
 
-	smfMidiCC & putValue( MidiTime time, AutomatableModel * objModel, float value )
+	smfMidiCC & putValue( TimePos time, AutomatableModel * objModel, float value )
 	{
 		if( !ap || time > lastPos + DefaultTicksPerBar )
 		{
-			MidiTime pPos = MidiTime( time.getBar(), 0 );
+			TimePos pPos = TimePos( time.getBar(), 0 );
 			ap = dynamic_cast<AutomationPattern*>(
 				at->createTCO(0) );
 			ap->movePosition( pPos );
@@ -200,7 +200,7 @@ public:
 		lastPos = time;
 		time = time - ap->startPosition();
 		ap->putValue( time, value, false );
-		ap->changeLength( MidiTime( time.getBar() + 1, 0 ) ); 
+		ap->changeLength( TimePos( time.getBar() + 1, 0 ) ); 
 
 		return *this;
 	}
@@ -226,7 +226,7 @@ public:
 	Instrument * it_inst;
 	bool isSF2; 
 	bool hasNotes;
-	MidiTime lastEnd;
+	TimePos lastEnd;
 	QString trackName;
 	
 	smfMidiChannel * create( TrackContainer* tc, QString tn )
@@ -269,7 +269,7 @@ public:
 	{
 		if( !p || n.pos() > lastEnd + DefaultTicksPerBar )
 		{
-			MidiTime pPos = MidiTime( n.pos().getBar(), 0 );
+			TimePos pPos = TimePos( n.pos().getBar(), 0 );
 			p = dynamic_cast<Pattern*>( it->createTCO( 0 ) );
 			p->movePosition( pPos );
 		}

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -293,7 +293,7 @@ int OpulenzInstrument::pushVoice(int v) {
 	return i;
 }
 
-bool OpulenzInstrument::handleMidiEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+bool OpulenzInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	emulatorMutex.lock();
 	int key, vel, voice, tmp_pb;

--- a/plugins/OpulenZ/OpulenZ.h
+++ b/plugins/OpulenZ/OpulenZ.h
@@ -56,7 +56,7 @@ public:
 		return IsSingleStreamed | IsMidiBased;
 	}
 
-	virtual bool handleMidiEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset = 0 );
+	virtual bool handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 );
 	virtual void play( sampleFrame * _working_buffer );
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this );

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -354,7 +354,7 @@ void CarlaInstrument::play(sampleFrame* workingBuffer)
     instrumentTrack()->processAudioBuffer(workingBuffer, bufsize, NULL);
 }
 
-bool CarlaInstrument::handleMidiEvent(const MidiEvent& event, const MidiTime&, f_cnt_t offset)
+bool CarlaInstrument::handleMidiEvent(const MidiEvent& event, const TimePos&, f_cnt_t offset)
 {
     const QMutexLocker ml(&fMutex);
 

--- a/plugins/carlabase/carla.h
+++ b/plugins/carlabase/carla.h
@@ -73,7 +73,7 @@ public:
     virtual void saveSettings(QDomDocument& doc, QDomElement& parent);
     virtual void loadSettings(const QDomElement& elem);
     virtual void play(sampleFrame* workingBuffer);
-    virtual bool handleMidiEvent(const MidiEvent& event, const MidiTime& time, f_cnt_t offset);
+    virtual bool handleMidiEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset);
     virtual PluginView* instantiateView(QWidget* parent);
 
 signals:

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -48,7 +48,7 @@ float frnd(float range)
 #include "ToolTip.h"
 #include "Song.h"
 #include "MidiEvent.h"
-#include "MidiTime.h"
+#include "TimePos.h"
 #include "Mixer.h"
 
 #include "embed.h"

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -394,7 +394,7 @@ void vestigeInstrument::play( sampleFrame * _buf )
 
 
 
-bool vestigeInstrument::handleMidiEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+bool vestigeInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	m_pluginMutex.lock();
 	if( m_plugin != NULL )

--- a/plugins/vestige/vestige.h
+++ b/plugins/vestige/vestige.h
@@ -67,7 +67,7 @@ public:
 		return IsSingleStreamed | IsMidiBased;
 	}
 
-	virtual bool handleMidiEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset = 0 );
+	virtual bool handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 );
 
 	virtual PluginView * instantiateView( QWidget * _parent );
 

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -350,7 +350,7 @@ void ZynAddSubFxInstrument::play( sampleFrame * _buf )
 
 
 
-bool ZynAddSubFxInstrument::handleMidiEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+bool ZynAddSubFxInstrument::handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	// do not forward external MIDI Control Change events if the according
 	// LED is not checked

--- a/plugins/zynaddsubfx/ZynAddSubFx.h
+++ b/plugins/zynaddsubfx/ZynAddSubFx.h
@@ -70,7 +70,7 @@ public:
 
 	virtual void play( sampleFrame * _working_buffer );
 
-	virtual bool handleMidiEvent( const MidiEvent& event, const MidiTime& time = MidiTime(), f_cnt_t offset = 0 );
+	virtual bool handleMidiEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 );
 
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
 	virtual void loadSettings( const QDomElement & _this );

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -693,7 +693,7 @@ void AutomatableModel::reset()
 
 
 
-float AutomatableModel::globalAutomationValueAt( const MidiTime& time )
+float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 {
 	// get patterns that connect to this model
 	QVector<AutomationPattern *> patterns = AutomationPattern::patternsForModel( this );
@@ -705,7 +705,7 @@ float AutomatableModel::globalAutomationValueAt( const MidiTime& time )
 	else
 	{
 		// of those patterns:
-		// find the patterns which overlap with the miditime position
+		// find the patterns which overlap with the time position
 		QVector<AutomationPattern *> patternsInRange;
 		for( QVector<AutomationPattern *>::ConstIterator it = patterns.begin(); it != patterns.end(); it++ )
 		{
@@ -723,7 +723,7 @@ float AutomatableModel::globalAutomationValueAt( const MidiTime& time )
 			latestPattern = patternsInRange[0];
 		}
 		else
-		// if we find no patterns at the exact miditime, we need to search for the last pattern before time and use that
+		// if we find no patterns at the exact timepos, we need to search for the last pattern before time and use that
 		{
 			int latestPosition = 0;
 

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -51,7 +51,7 @@ AutomationPattern::AutomationPattern( AutomationTrack * _auto_track ) :
 	m_isRecording( false ),
 	m_lastRecordedValue( 0 )
 {
-	changeLength( MidiTime( 1, 0 ) );
+	changeLength( TimePos( 1, 0 ) );
 	if( getTrack() )
 	{
 		switch( getTrack()->trackContainer()->type() )
@@ -110,7 +110,7 @@ bool AutomationPattern::addObject( AutomatableModel * _obj, bool _search_dup )
 	if( m_objects.isEmpty() && hasAutomation() == false )
 	{
 		// then initialize first value
-		putValue( MidiTime(0), _obj->inverseScaledValue( _obj->value<float>() ), false );
+		putValue( TimePos(0), _obj->inverseScaledValue( _obj->value<float>() ), false );
 	}
 
 	m_objects += _obj;
@@ -176,11 +176,11 @@ const AutomationPattern::objectVector& AutomationPattern::objects() const
 
 
 
-MidiTime AutomationPattern::timeMapLength() const
+TimePos AutomationPattern::timeMapLength() const
 {
 	if( m_timeMap.isEmpty() ) return 0;
 	timeMap::const_iterator it = m_timeMap.end();
-	return MidiTime( MidiTime( (it-1).key() ).nextFullBar(), 0 );
+	return TimePos( TimePos( (it-1).key() ).nextFullBar(), 0 );
 }
 
 
@@ -194,14 +194,14 @@ void AutomationPattern::updateLength()
 
 
 
-MidiTime AutomationPattern::putValue( const MidiTime & time,
+TimePos AutomationPattern::putValue( const TimePos & time,
 					const float value,
 					const bool quantPos,
 					const bool ignoreSurroundingPoints )
 {
 	cleanObjects();
 
-	MidiTime newTime = quantPos ?
+	TimePos newTime = quantPos ?
 				Note::quantized( time, quantization() ) :
 				time;
 
@@ -238,7 +238,7 @@ MidiTime AutomationPattern::putValue( const MidiTime & time,
 
 
 
-void AutomationPattern::removeValue( const MidiTime & time )
+void AutomationPattern::removeValue( const TimePos & time )
 {
 	cleanObjects();
 
@@ -261,7 +261,7 @@ void AutomationPattern::removeValue( const MidiTime & time )
 
 
 
-void AutomationPattern::recordValue(MidiTime time, float value)
+void AutomationPattern::recordValue(TimePos time, float value)
 {
 	if( value != m_lastRecordedValue )
 	{
@@ -286,14 +286,14 @@ void AutomationPattern::recordValue(MidiTime time, float value)
  * @param true to snip x position
  * @return
  */
-MidiTime AutomationPattern::setDragValue( const MidiTime & time,
+TimePos AutomationPattern::setDragValue( const TimePos & time,
 						const float value,
 						const bool quantPos,
 						const bool controlKey )
 {
 	if( m_dragging == false )
 	{
-		MidiTime newTime = quantPos  ?
+		TimePos newTime = quantPos  ?
 				Note::quantized( time, quantization() ) :
 							time;
 		this->removeValue( newTime );
@@ -327,7 +327,7 @@ void AutomationPattern::applyDragValue()
 
 
 
-float AutomationPattern::valueAt( const MidiTime & _time ) const
+float AutomationPattern::valueAt( const TimePos & _time ) const
 {
 	if( m_timeMap.isEmpty() )
 	{
@@ -395,7 +395,7 @@ float AutomationPattern::valueAt( timeMap::const_iterator v, int offset ) const
 
 
 
-float *AutomationPattern::valuesAfter( const MidiTime & _time ) const
+float *AutomationPattern::valuesAfter( const TimePos & _time ) const
 {
 	timeMap::ConstIterator v = m_timeMap.lowerBound( _time );
 	if( v == m_timeMap.end() || (v+1) == m_timeMap.end() )
@@ -436,12 +436,12 @@ void AutomationPattern::flipY( int min, int max )
 		if ( min < 0 )
 		{
 			tempValue = valueAt( ( iterate + i ).key() ) * -1;
-			putValue( MidiTime( (iterate + i).key() ) , tempValue, false);
+			putValue( TimePos( (iterate + i).key() ) , tempValue, false);
 		}
 		else
 		{
 			tempValue = max - valueAt( ( iterate + i ).key() );
-			putValue( MidiTime( (iterate + i).key() ) , tempValue, false);
+			putValue( TimePos( (iterate + i).key() ) , tempValue, false);
 		}
 	}
 
@@ -480,12 +480,12 @@ void AutomationPattern::flipX( int length )
 		if ( realLength < length )
 		{
 			tempValue = valueAt( ( iterate + numPoints ).key() );
-			putValue( MidiTime( length ) , tempValue, false);
+			putValue( TimePos( length ) , tempValue, false);
 			numPoints++;
 			for( int i = 0; i <= numPoints; i++ )
 			{
 				tempValue = valueAt( ( iterate + i ).key() );
-				MidiTime newTime = MidiTime( length - ( iterate + i ).key() );
+				TimePos newTime = TimePos( length - ( iterate + i ).key() );
 				tempMap[newTime] = tempValue;
 			}
 		}
@@ -494,15 +494,15 @@ void AutomationPattern::flipX( int length )
 			for( int i = 0; i <= numPoints; i++ )
 			{
 				tempValue = valueAt( ( iterate + i ).key() );
-				MidiTime newTime;
+				TimePos newTime;
 
 				if ( ( iterate + i ).key() <= length )
 				{
-					newTime = MidiTime( length - ( iterate + i ).key() );
+					newTime = TimePos( length - ( iterate + i ).key() );
 				}
 				else
 				{
-					newTime = MidiTime( ( iterate + i ).key() );
+					newTime = TimePos( ( iterate + i ).key() );
 				}
 				tempMap[newTime] = tempValue;
 			}
@@ -514,7 +514,7 @@ void AutomationPattern::flipX( int length )
 		{
 			tempValue = valueAt( ( iterate + i ).key() );
 			cleanObjects();
-			MidiTime newTime = MidiTime( realLength - ( iterate + i ).key() );
+			TimePos newTime = TimePos( realLength - ( iterate + i ).key() );
 			tempMap[newTime] = tempValue;
 		}
 	}

--- a/src/core/BBTrackContainer.cpp
+++ b/src/core/BBTrackContainer.cpp
@@ -53,7 +53,7 @@ BBTrackContainer::~BBTrackContainer()
 
 
 
-bool BBTrackContainer::play( MidiTime _start, fpp_t _frames,
+bool BBTrackContainer::play( TimePos _start, fpp_t _frames,
 								f_cnt_t _offset, int _tco_num )
 {
 	bool played_a_note = false;
@@ -62,7 +62,7 @@ bool BBTrackContainer::play( MidiTime _start, fpp_t _frames,
 		return false;
 	}
 
-	_start = _start % ( lengthOfBB( _tco_num ) * MidiTime::ticksPerBar() );
+	_start = _start % ( lengthOfBB( _tco_num ) * TimePos::ticksPerBar() );
 
 	TrackList tl = tracks();
 	for( TrackList::iterator it = tl.begin(); it != tl.end(); ++it )
@@ -92,7 +92,7 @@ void BBTrackContainer::updateAfterTrackAdd()
 
 bar_t BBTrackContainer::lengthOfBB( int _bb ) const
 {
-	MidiTime max_length = MidiTime::ticksPerBar();
+	TimePos max_length = TimePos::ticksPerBar();
 
 	const TrackList & tl = tracks();
 	for (Track* t : tl)
@@ -168,7 +168,7 @@ void BBTrackContainer::fixIncorrectPositions()
 	{
 		for( int i = 0; i < numOfBBs(); ++i )
 		{
-			( *it )->getTCO( i )->movePosition( MidiTime( i, 0 ) );
+			( *it )->getTCO( i )->movePosition( TimePos( i, 0 ) );
 		}
 	}
 }
@@ -242,18 +242,18 @@ void BBTrackContainer::createTCOsForBB( int _bb )
 	}
 }
 
-AutomatedValueMap BBTrackContainer::automatedValuesAt(MidiTime time, int tcoNum) const
+AutomatedValueMap BBTrackContainer::automatedValuesAt(TimePos time, int tcoNum) const
 {
 	Q_ASSERT(tcoNum >= 0);
 	Q_ASSERT(time.getTicks() >= 0);
 
 	auto length_bars = lengthOfBB(tcoNum);
-	auto length_ticks = length_bars * MidiTime::ticksPerBar();
+	auto length_ticks = length_bars * TimePos::ticksPerBar();
 	if (time > length_ticks)
 	{
 		time = length_ticks;
 	}
 
-	return TrackContainer::automatedValuesAt(time + (MidiTime::ticksPerBar() * tcoNum), tcoNum);
+	return TrackContainer::automatedValuesAt(time + (TimePos::ticksPerBar() * tcoNum), tcoNum);
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -64,6 +64,7 @@ set(LMMS_SRCS
 	core/SerializingObject.cpp
 	core/Song.cpp
 	core/TempoSyncKnobModel.cpp
+	core/TimePos.cpp
 	core/ToolPlugin.cpp
 	core/Track.cpp
 	core/TrackContainer.cpp
@@ -97,7 +98,6 @@ set(LMMS_SRCS
 	core/midi/MidiSndio.cpp
 	core/midi/MidiApple.cpp
 	core/midi/MidiPort.cpp
-	core/midi/MidiTime.cpp
 	core/midi/MidiWinMM.cpp
 
 	PARENT_SCOPE

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -505,7 +505,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 				NotePlayHandleManager::acquire( _n->instrumentTrack(),
 							frames_processed,
 							gated_frames,
-							Note( MidiTime( 0 ), MidiTime( 0 ), sub_note_key, _n->getVolume(),
+							Note( TimePos( 0 ), TimePos( 0 ), sub_note_key, _n->getVolume(),
 									_n->getPanning(), _n->detuning() ),
 							_n, -1, NotePlayHandle::OriginArpeggio )
 				);

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -361,7 +361,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 			// Stop crash with metronome if empty project
 				Engine::getSong()->countTracks() )
 	{
-		tick_t ticksPerBar = MidiTime::ticksPerBar();
+		tick_t ticksPerBar = TimePos::ticksPerBar();
 		if ( p.getTicks() % ( ticksPerBar / 1 ) == 0 )
 		{
 			addPlayHandle( new SamplePlayHandle( "misc/metronome02.ogg" ) );

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -31,7 +31,7 @@
 #include "DetuningHelper.h"
 
 
-Note::Note( const MidiTime & length, const MidiTime & pos,
+Note::Note( const TimePos & length, const TimePos & pos,
 		int key, volume_t volume, panning_t panning,
 						DetuningHelper * detuning ) :
 	m_selected( false ),
@@ -93,7 +93,7 @@ Note::~Note()
 
 
 
-void Note::setLength( const MidiTime & length )
+void Note::setLength( const TimePos & length )
 {
 	m_length = length;
 }
@@ -101,7 +101,7 @@ void Note::setLength( const MidiTime & length )
 
 
 
-void Note::setPos( const MidiTime & pos )
+void Note::setPos( const TimePos & pos )
 {
 	m_pos = pos;
 }
@@ -136,7 +136,7 @@ void Note::setPanning( panning_t panning )
 
 
 
-MidiTime Note::quantized( const MidiTime & m, const int qGrid )
+TimePos Note::quantized( const TimePos & m, const int qGrid )
 {
 	float p = ( (float) m / qGrid );
 	if( p - floorf( p ) < 0.5f )

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -211,7 +211,7 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 		// send MidiNoteOn event
 		m_instrumentTrack->processOutEvent(
 			MidiEvent( MidiNoteOn, midiChannel(), midiKey(), midiVelocity( baseVelocity ) ),
-			MidiTime::fromFrames( offset(), Engine::framesPerTick() ),
+			TimePos::fromFrames( offset(), Engine::framesPerTick() ),
 			offset() );
 	}
 
@@ -374,7 +374,7 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 		// send MidiNoteOff event
 		m_instrumentTrack->processOutEvent(
 				MidiEvent( MidiNoteOff, midiChannel(), midiKey(), 0 ),
-				MidiTime::fromFrames( _s, Engine::framesPerTick() ),
+				TimePos::fromFrames( _s, Engine::framesPerTick() ),
 				_s );
 	}
 
@@ -383,7 +383,7 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 	{
 		if( m_origin == OriginMidiInput )
 		{
-			setLength( MidiTime( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
+			setLength( TimePos( static_cast<f_cnt_t>( totalFramesPlayed() / Engine::framesPerTick() ) ) );
 			m_instrumentTrack->midiNoteOff( *this );
 		}
 	}
@@ -519,7 +519,7 @@ void NotePlayHandle::updateFrequency()
 
 
 
-void NotePlayHandle::processMidiTime( const MidiTime& time )
+void NotePlayHandle::processTimePos( const TimePos& time )
 {
 	if( detuning() && time >= songGlobalParentOffset()+pos() )
 	{

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -73,7 +73,7 @@ void SampleRecordHandle::play( sampleFrame * /*_working_buffer*/ )
 	writeBuffer( recbuf, frames );
 	m_framesRecorded += frames;
 
-	MidiTime len = (tick_t)( m_framesRecorded / Engine::framesPerTick() );
+	TimePos len = (tick_t)( m_framesRecorded / Engine::framesPerTick() );
 	if( len > m_minLength )
 	{
 //		m_tco->changeLength( len );

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -55,7 +55,7 @@
 #include "PeakController.h"
 
 
-tick_t MidiTime::s_ticksPerBar = DefaultTicksPerBar;
+tick_t TimePos::s_ticksPerBar = DefaultTicksPerBar;
 
 
 
@@ -162,7 +162,7 @@ void Song::setTempo()
 
 void Song::setTimeSignature()
 {
-	MidiTime::setTicksPerBar( ticksPerBar() );
+	TimePos::setTicksPerBar( ticksPerBar() );
 	emit timeSignatureChanged( m_oldTicksPerBar, ticksPerBar() );
 	emit dataChanged();
 	m_oldTicksPerBar = ticksPerBar();
@@ -287,7 +287,7 @@ void Song::processNextBuffer()
 				( int )( currentFrame / framesPerTick );
 
 			// did we play a whole bar?
-			if( ticks >= MidiTime::ticksPerBar() )
+			if( ticks >= TimePos::ticksPerBar() )
 			{
 				// per default we just continue playing even if
 				// there's no more stuff to play
@@ -317,7 +317,7 @@ void Song::processNextBuffer()
 				{
 					// then start from beginning and keep
 					// offset
-					ticks %= ( maxBar * MidiTime::ticksPerBar() );
+					ticks %= ( maxBar * TimePos::ticksPerBar() );
 
 					// wrap milli second counter
 					setToTimeByTicks(ticks);
@@ -406,14 +406,14 @@ void Song::processNextBuffer()
 		framesPlayed += framesToPlay;
 		m_playPos[m_playMode].setCurrentFrame( framesToPlay +
 								currentFrame );
-		m_elapsedMilliSeconds[m_playMode] += MidiTime::ticksToMilliseconds(framesToPlay / framesPerTick, getTempo());
+		m_elapsedMilliSeconds[m_playMode] += TimePos::ticksToMilliseconds(framesToPlay / framesPerTick, getTempo());
 		m_elapsedBars = m_playPos[Mode_PlaySong].getBar();
 		m_elapsedTicks = ( m_playPos[Mode_PlaySong].getTicks() % ticksPerBar() ) / 48;
 	}
 }
 
 
-void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fpp_t)
+void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp_t)
 {
 	AutomatedValueMap values;
 
@@ -455,7 +455,7 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 	for (TrackContentObject* tco : tcos)
 	{
 		auto p = dynamic_cast<AutomationPattern *>(tco);
-		MidiTime relTime = timeStart - p->startPosition();
+		TimePos relTime = timeStart - p->startPosition();
 		if (p->isRecording() && relTime >= 0 && relTime < p->length())
 		{
 			const AutomatableModel* recordedModel = p->firstObject();
@@ -491,7 +491,7 @@ bool Song::isExportDone() const
 
 int Song::getExportProgress() const
 {
-	MidiTime pos = m_playPos[m_playMode];
+	TimePos pos = m_playPos[m_playMode];
     
 	if (pos >= m_exportSongEnd)
 	{
@@ -637,7 +637,7 @@ void Song::setPlayPos( tick_t ticks, PlayModes playMode )
 {
 	tick_t ticksFromPlayMode = m_playPos[playMode].getTicks();
 	m_elapsedTicks += ticksFromPlayMode - ticks;
-	m_elapsedMilliSeconds[playMode] += MidiTime::ticksToMilliseconds( ticks - ticksFromPlayMode, getTempo() );
+	m_elapsedMilliSeconds[playMode] += TimePos::ticksToMilliseconds( ticks - ticksFromPlayMode, getTempo() );
 	m_playPos[playMode].setTicks( ticks );
 	m_playPos[playMode].setCurrentFrame( 0.0f );
 	m_playPos[playMode].setJumped( true );
@@ -751,7 +751,7 @@ void Song::startExport()
 	}
 	else
 	{
-		m_exportSongEnd = MidiTime(m_length, 0);
+		m_exportSongEnd = TimePos(m_length, 0);
         
 		// Handle potentially ridiculous loop points gracefully.
 		if (m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd) 
@@ -760,15 +760,15 @@ void Song::startExport()
 		}
 
 		if (!m_exportLoop) 
-			m_exportSongEnd += MidiTime(1,0);
+			m_exportSongEnd += TimePos(1,0);
         
-		m_exportSongBegin = MidiTime(0,0);
+		m_exportSongBegin = TimePos(0,0);
 		m_exportLoopBegin = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
 			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
-			m_playPos[Mode_PlaySong].m_timeLine->loopBegin() : MidiTime(0,0);
+			m_playPos[Mode_PlaySong].m_timeLine->loopBegin() : TimePos(0,0);
 		m_exportLoopEnd = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
 			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
-			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() : MidiTime(0,0);
+			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() : TimePos(0,0);
 
 		m_playPos[Mode_PlaySong].setTicks( 0 );
 	}
@@ -866,7 +866,7 @@ AutomationPattern * Song::tempoAutomationPattern()
 }
 
 
-AutomatedValueMap Song::automatedValuesAt(MidiTime time, int tcoNum) const
+AutomatedValueMap Song::automatedValuesAt(TimePos time, int tcoNum) const
 {
 	return TrackContainer::automatedValuesFromTracks(TrackList{m_globalAutomationTrack} << tracks(), time, tcoNum);
 }

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -42,7 +42,7 @@ void StepRecorder::initialize()
 	connect(&m_updateReleasedTimer, SIGNAL(timeout()), this, SLOT(removeNotesReleasedForTooLong()));
 }
 
-void StepRecorder::start(const MidiTime& currentPosition, const MidiTime& stepLength)
+void StepRecorder::start(const TimePos& currentPosition, const TimePos& stepLength)
 {
 	m_isRecording = true;
 
@@ -52,7 +52,7 @@ void StepRecorder::start(const MidiTime& currentPosition, const MidiTime& stepLe
 	const int q = m_pianoRoll.quantization();
 	const int curPosTicks = currentPosition.getTicks();
 	const int QuantizedPosTicks = (curPosTicks / q) * q;
-	const MidiTime& QuantizedPos = MidiTime(QuantizedPosTicks);
+	const TimePos& QuantizedPos = TimePos(QuantizedPosTicks);
 
 	m_curStepStartPos = QuantizedPos;
 	m_curStepLength = 0;
@@ -153,7 +153,7 @@ bool StepRecorder::keyPressEvent(QKeyEvent* ke)
 	return event_handled;
 }
 
-void StepRecorder::setStepsLength(const MidiTime& newLength)
+void StepRecorder::setStepsLength(const TimePos& newLength)
 {
 	if(m_isStepInProgress)
 	{
@@ -318,7 +318,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	}
 }
 
-MidiTime StepRecorder::getCurStepEndPos()
+TimePos StepRecorder::getCurStepEndPos()
 {
 	return m_curStepStartPos + m_curStepLength;
 }

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -1,5 +1,5 @@
 /*
- * MidiTime.cpp - Class that encapsulates the position of a note/event in terms of
+ * TimePos.cpp - Class that encapsulates the position of a note/event in terms of
  *   its bar, beat and tick.
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net
@@ -23,7 +23,7 @@
  *
  */
 
-#include "MidiTime.h"
+#include "TimePos.h"
 
 #include "MeterModel.h"
 
@@ -53,17 +53,17 @@ int TimeSig::denominator() const
 
 
 
-MidiTime::MidiTime( const bar_t bar, const tick_t ticks ) :
+TimePos::TimePos( const bar_t bar, const tick_t ticks ) :
 	m_ticks( bar * s_ticksPerBar + ticks )
 {
 }
 
-MidiTime::MidiTime( const tick_t ticks ) :
+TimePos::TimePos( const tick_t ticks ) :
 	m_ticks( ticks )
 {
 }
 
-MidiTime MidiTime::quantize(float bars) const
+TimePos TimePos::quantize(float bars) const
 {
 	//The intervals we should snap to, our new position should be a factor of this
 	int interval = s_ticksPerBar * bars;
@@ -78,80 +78,80 @@ MidiTime MidiTime::quantize(float bars) const
 }
 
 
-MidiTime MidiTime::toAbsoluteBar() const
+TimePos TimePos::toAbsoluteBar() const
 {
 	return getBar() * s_ticksPerBar;
 }
 
 
-MidiTime& MidiTime::operator+=( const MidiTime& time )
+TimePos& TimePos::operator+=( const TimePos& time )
 {
 	m_ticks += time.m_ticks;
 	return *this;
 }
 
 
-MidiTime& MidiTime::operator-=( const MidiTime& time )
+TimePos& TimePos::operator-=( const TimePos& time )
 {
 	m_ticks -= time.m_ticks;
 	return *this;
 }
 
 
-bar_t MidiTime::getBar() const
+bar_t TimePos::getBar() const
 {
 	return m_ticks / s_ticksPerBar;
 }
 
 
-bar_t MidiTime::nextFullBar() const
+bar_t TimePos::nextFullBar() const
 {
 	return ( m_ticks + ( s_ticksPerBar - 1 ) ) / s_ticksPerBar;
 }
 
 
-void MidiTime::setTicks( tick_t ticks )
+void TimePos::setTicks( tick_t ticks )
 {
 	m_ticks = ticks;
 }
 
 
-tick_t MidiTime::getTicks() const
+tick_t TimePos::getTicks() const
 {
 	return m_ticks;
 }
 
 
-MidiTime::operator int() const
+TimePos::operator int() const
 {
 	return m_ticks;
 }
 
 
-tick_t MidiTime::ticksPerBeat( const TimeSig &sig ) const
+tick_t TimePos::ticksPerBeat( const TimeSig &sig ) const
 {
 	// (number of ticks per bar) divided by (number of beats per bar)
 	return ticksPerBar(sig) / sig.numerator();
 }
 
 
-tick_t MidiTime::getTickWithinBar( const TimeSig &sig ) const
+tick_t TimePos::getTickWithinBar( const TimeSig &sig ) const
 {
 	return m_ticks % ticksPerBar( sig );
 }
 
-tick_t MidiTime::getBeatWithinBar( const TimeSig &sig ) const
+tick_t TimePos::getBeatWithinBar( const TimeSig &sig ) const
 {
 	return getTickWithinBar( sig ) / ticksPerBeat( sig );
 }
 
-tick_t MidiTime::getTickWithinBeat( const TimeSig &sig ) const
+tick_t TimePos::getTickWithinBeat( const TimeSig &sig ) const
 {
 	return getTickWithinBar( sig ) % ticksPerBeat( sig );
 }
 
 
-f_cnt_t MidiTime::frames( const float framesPerTick ) const
+f_cnt_t TimePos::frames( const float framesPerTick ) const
 {
 	if( m_ticks >= 0 )
 	{
@@ -160,53 +160,53 @@ f_cnt_t MidiTime::frames( const float framesPerTick ) const
 	return 0;
 }
 
-double MidiTime::getTimeInMilliseconds( bpm_t beatsPerMinute ) const
+double TimePos::getTimeInMilliseconds( bpm_t beatsPerMinute ) const
 {
 	return ticksToMilliseconds( getTicks(), beatsPerMinute );
 }
 
-MidiTime MidiTime::fromFrames( const f_cnt_t frames, const float framesPerTick )
+TimePos TimePos::fromFrames( const f_cnt_t frames, const float framesPerTick )
 {
-	return MidiTime( static_cast<int>( frames / framesPerTick ) );
+	return TimePos( static_cast<int>( frames / framesPerTick ) );
 }
 
 
-tick_t MidiTime::ticksPerBar()
+tick_t TimePos::ticksPerBar()
 {
 	return s_ticksPerBar;
 }
 
 
-tick_t MidiTime::ticksPerBar( const TimeSig &sig )
+tick_t TimePos::ticksPerBar( const TimeSig &sig )
 {
 	return DefaultTicksPerBar * sig.numerator() / sig.denominator();
 }
 
 
-int MidiTime::stepsPerBar()
+int TimePos::stepsPerBar()
 {
 	int steps = ticksPerBar() / DefaultBeatsPerBar;
 	return qMax( 1, steps );
 }
 
 
-void MidiTime::setTicksPerBar( tick_t tpb )
+void TimePos::setTicksPerBar( tick_t tpb )
 {
 	s_ticksPerBar = tpb;
 }
 
 
-MidiTime MidiTime::stepPosition( int step )
+TimePos TimePos::stepPosition( int step )
 {
 	return step * ticksPerBar() / stepsPerBar();
 }
 
-double MidiTime::ticksToMilliseconds( tick_t ticks, bpm_t beatsPerMinute )
+double TimePos::ticksToMilliseconds( tick_t ticks, bpm_t beatsPerMinute )
 {
-	return MidiTime::ticksToMilliseconds( static_cast<double>(ticks), beatsPerMinute );
+	return TimePos::ticksToMilliseconds( static_cast<double>(ticks), beatsPerMinute );
 }
 
-double MidiTime::ticksToMilliseconds(double ticks, bpm_t beatsPerMinute)
+double TimePos::ticksToMilliseconds(double ticks, bpm_t beatsPerMinute)
 {
 	// 60 * 1000 / 48 = 1250
 	return ( ticks * 1250 ) / beatsPerMinute;

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -248,13 +248,13 @@ bool TrackContainer::isEmpty() const
 
 
 
-AutomatedValueMap TrackContainer::automatedValuesAt(MidiTime time, int tcoNum) const
+AutomatedValueMap TrackContainer::automatedValuesAt(TimePos time, int tcoNum) const
 {
 	return automatedValuesFromTracks(tracks(), time, tcoNum);
 }
 
 
-AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tracks, MidiTime time, int tcoNum)
+AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tracks, TimePos time, int tcoNum)
 {
 	Track::tcoVector tcos;
 
@@ -295,7 +295,7 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 			if (! p->hasAutomation()) {
 				continue;
 			}
-			MidiTime relTime = time - p->startPosition();
+			TimePos relTime = time - p->startPosition();
 			if (! p->getAutoResize()) {
 				relTime = qMin(relTime, p->length());
 			}
@@ -311,9 +311,9 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 			auto bbIndex = dynamic_cast<class BBTrack*>(bb->getTrack())->index();
 			auto bbContainer = Engine::getBBTrackContainer();
 
-			MidiTime bbTime = time - tco->startPosition();
+			TimePos bbTime = time - tco->startPosition();
 			bbTime = std::min(bbTime, tco->length());
-			bbTime = bbTime % (bbContainer->lengthOfBB(bbIndex) * MidiTime::ticksPerBar());
+			bbTime = bbTime % (bbContainer->lengthOfBB(bbIndex) * TimePos::ticksPerBar());
 
 			auto bbValues = bbContainer->automatedValuesAt(bbTime, bbIndex);
 			for (auto it=bbValues.begin(); it != bbValues.end(); it++)

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -157,7 +157,7 @@ QString MidiAlsaSeq::probeDevice()
 
 
 
-void MidiAlsaSeq::processOutEvent( const MidiEvent& event, const MidiTime& time, const MidiPort* port )
+void MidiAlsaSeq::processOutEvent( const MidiEvent& event, const TimePos& time, const MidiPort* port )
 {
 	// HACK!!! - need a better solution which isn't that easy since we
 	// cannot store const-ptrs in our map because we need to call non-const
@@ -536,7 +536,7 @@ void MidiAlsaSeq::run()
 								ev->data.note.velocity,
 								source
 								),
-							MidiTime( ev->time.tick ) );
+							TimePos( ev->time.tick ) );
 					break;
 
 				case SND_SEQ_EVENT_NOTEOFF:
@@ -547,7 +547,7 @@ void MidiAlsaSeq::run()
 								ev->data.note.velocity,
 								source
 								),
-							MidiTime( ev->time.tick) );
+							TimePos( ev->time.tick) );
 					break;
 
 				case SND_SEQ_EVENT_KEYPRESS:
@@ -558,7 +558,7 @@ void MidiAlsaSeq::run()
 								KeysPerOctave,
 								ev->data.note.velocity,
 								source
-								), MidiTime() );
+								), TimePos() );
 					break;
 
 				case SND_SEQ_EVENT_CONTROLLER:
@@ -567,7 +567,7 @@ void MidiAlsaSeq::run()
 							ev->data.control.channel,
 							ev->data.control.param,
 							ev->data.control.value, source ),
-									MidiTime() );
+									TimePos() );
 					break;
 
 				case SND_SEQ_EVENT_PGMCHANGE:
@@ -576,7 +576,7 @@ void MidiAlsaSeq::run()
 							ev->data.control.channel,
 							ev->data.control.value,	0,
 							source ),
-								MidiTime() );
+								TimePos() );
 					break;
 
 				case SND_SEQ_EVENT_CHANPRESS:
@@ -585,14 +585,14 @@ void MidiAlsaSeq::run()
 							ev->data.control.channel,
 							ev->data.control.param,
 							ev->data.control.value, source ),
-									MidiTime() );
+									TimePos() );
 					break;
 
 				case SND_SEQ_EVENT_PITCHBEND:
 					dest->processInEvent( MidiEvent( MidiPitchBend,
 							ev->data.control.channel,
 							ev->data.control.value + 8192, 0, source ),
-									MidiTime() );
+									TimePos() );
 					break;
 
 				case SND_SEQ_EVENT_SENSING:

--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -57,7 +57,7 @@ MidiApple::~MidiApple()
 
 
 
-void MidiApple::processOutEvent( const MidiEvent& event, const MidiTime& time, const MidiPort* port )
+void MidiApple::processOutEvent( const MidiEvent& event, const TimePos& time, const MidiPort* port )
 {
 	qDebug("MidiApple:processOutEvent displayName:'%s'",port->displayName().toLatin1().constData());
 	

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -266,7 +266,7 @@ void MidiClientRaw::processParsedEvent()
 
 
 
-void MidiClientRaw::processOutEvent( const MidiEvent& event, const MidiTime & , const MidiPort* port )
+void MidiClientRaw::processOutEvent( const MidiEvent& event, const TimePos & , const MidiPort* port )
 {
 	// TODO: also evaluate _time and queue event if necessary
 	switch( event.type() )

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -80,7 +80,7 @@ void MidiController::updateName()
 
 
 
-void MidiController::processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+void MidiController::processInEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	unsigned char controllerNum;
 	switch( event.type() )

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -120,7 +120,7 @@ void MidiPort::setMode( Mode mode )
 
 
 
-void MidiPort::processInEvent( const MidiEvent& event, const MidiTime& time )
+void MidiPort::processInEvent( const MidiEvent& event, const TimePos& time )
 {
 	// mask event
 	if( isInputEnabled() &&
@@ -149,7 +149,7 @@ void MidiPort::processInEvent( const MidiEvent& event, const MidiTime& time )
 
 
 
-void MidiPort::processOutEvent( const MidiEvent& event, const MidiTime& time )
+void MidiPort::processOutEvent( const MidiEvent& event, const TimePos& time )
 {
 	// mask event
 	if( isOutputEnabled() && realOutputChannel() == event.channel() )

--- a/src/core/midi/MidiWinMM.cpp
+++ b/src/core/midi/MidiWinMM.cpp
@@ -49,7 +49,7 @@ MidiWinMM::~MidiWinMM()
 
 
 
-void MidiWinMM::processOutEvent( const MidiEvent& event, const MidiTime& time, const MidiPort* port )
+void MidiWinMM::processOutEvent( const MidiEvent& event, const TimePos& time, const MidiPort* port )
 {
 	const DWORD shortMsg = ( event.type() + event.channel() ) +
 				( ( event.param( 0 ) & 0xff ) << 8 ) +

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -290,7 +290,7 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 
 	const float y_scale = max - min;
 	const float h = ( height() - 2 * TCO_BORDER_WIDTH ) / y_scale;
-	const float ppTick  = ppb / MidiTime::ticksPerBar();
+	const float ppTick  = ppb / TimePos::ticksPerBar();
 
 	p.translate( 0.0f, max * height() / y_scale - TCO_BORDER_WIDTH );
 	p.scale( 1.0f, -h );

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -63,7 +63,7 @@ public:
 	}
 
 
-	virtual void processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset = 0 )
+	virtual void processInEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 )
 	{
 		if( event.type() == MidiControlChange &&
 			( m_midiPort.inputChannel() == 0 || m_midiPort.inputChannel() == event.channel() + 1 ) )

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1633,7 +1633,7 @@ void MainWindow::onSongStopped()
 				{
 					if(songEditor && ( tl->autoScroll() == TimeLineWidget::AutoScrollEnabled ) )
 					{
-						songEditor->m_editor->updatePosition( MidiTime(tl->savedPos().getTicks() ) );
+						songEditor->m_editor->updatePosition( TimePos(tl->savedPos().getTicks() ) );
 					}
 					tl->savePos( -1 );
 				}

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -43,7 +43,7 @@
 QPixmap * TimeLineWidget::s_posMarkerPixmap = NULL;
 
 TimeLineWidget::TimeLineWidget( const int xoff, const int yoff, const float ppb,
-			Song::PlayPos & pos, const MidiTime & begin, Song::PlayModes mode,
+			Song::PlayPos & pos, const TimePos & begin, Song::PlayModes mode,
 							QWidget * parent ) :
 	QWidget( parent ),
 	m_inactiveLoopColor( 52, 63, 53, 64 ),
@@ -172,7 +172,7 @@ void TimeLineWidget::loadSettings( const QDomElement & _this )
 
 
 
-void TimeLineWidget::updatePosition( const MidiTime & )
+void TimeLineWidget::updatePosition( const TimePos & )
 {
 	const int new_x = markerX( m_pos );
 
@@ -249,14 +249,14 @@ void TimeLineWidget::paintEvent( QPaintEvent * )
 
 	bar_t barNumber = m_begin.getBar();
 	int const x = m_xOffset + s_posMarkerPixmap->width() / 2 -
-			( ( static_cast<int>( m_begin * m_ppb ) / MidiTime::ticksPerBar() ) % static_cast<int>( m_ppb ) );
+			( ( static_cast<int>( m_begin * m_ppb ) / TimePos::ticksPerBar() ) % static_cast<int>( m_ppb ) );
 
 	for( int i = 0; x + i * m_ppb < width(); ++i )
 	{
 		++barNumber;
 		if( ( barNumber - 1 ) %
 			qMax( 1, qRound( 1.0f / 3.0f *
-				MidiTime::ticksPerBar() / m_ppb ) ) == 0 )
+				TimePos::ticksPerBar() / m_ppb ) ) == 0 )
 		{
 			const int cx = x + qRound( i * m_ppb );
 			p.setPen( barLineColor );
@@ -313,8 +313,8 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	else if( event->button() == Qt::RightButton )
 	{
 		m_moveXOff = s_posMarkerPixmap->width() / 2;
-		const MidiTime t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * MidiTime::ticksPerBar() / m_ppb );
-		const MidiTime loopMid = ( m_loopPos[0] + m_loopPos[1] ) / 2;
+		const TimePos t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * TimePos::ticksPerBar() / m_ppb );
+		const TimePos loopMid = ( m_loopPos[0] + m_loopPos[1] ) / 2;
 
 		if( t < loopMid )
 		{
@@ -349,7 +349,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 {
 	parentWidget()->update(); // essential for widgets that this timeline had taken their mouse move event from.
-	const MidiTime t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * MidiTime::ticksPerBar() / m_ppb );
+	const TimePos t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * TimePos::ticksPerBar() / m_ppb );
 
 	switch( m_action )
 	{
@@ -389,11 +389,11 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 				// marking instead of pushing it.
 				if( m_action == MoveLoopBegin ) 
         {
-					m_loopPos[0] -= MidiTime::ticksPerBar();
+					m_loopPos[0] -= TimePos::ticksPerBar();
         }
 				else
         {
-					m_loopPos[1] += MidiTime::ticksPerBar();
+					m_loopPos[1] += TimePos::ticksPerBar();
         }
 			}
 			update();

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -122,9 +122,9 @@ TrackView * TrackContainerView::addTrackView( TrackView * _tv )
 {
 	m_trackViews.push_back( _tv );
 	m_scrollLayout->addWidget( _tv );
-	connect( this, SIGNAL( positionChanged( const MidiTime & ) ),
+	connect( this, SIGNAL( positionChanged( const TimePos & ) ),
 				_tv->getTrackContentWidget(),
-				SLOT( changePosition( const MidiTime & ) ) );
+				SLOT( changePosition( const TimePos & ) ) );
 	realignTracks();
 	return( _tv );
 }

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -154,10 +154,10 @@ AutomationEditor::AutomationEditor() :
 					Song::Mode_PlayAutomationPattern ),
 					m_currentPosition,
 					Song::Mode_PlayAutomationPattern, this );
-	connect( this, SIGNAL( positionChanged( const MidiTime & ) ),
-		m_timeLine, SLOT( updatePosition( const MidiTime & ) ) );
-	connect( m_timeLine, SIGNAL( positionChanged( const MidiTime & ) ),
-			this, SLOT( updatePosition( const MidiTime & ) ) );
+	connect( this, SIGNAL( positionChanged( const TimePos & ) ),
+		m_timeLine, SLOT( updatePosition( const TimePos & ) ) );
+	connect( m_timeLine, SIGNAL( positionChanged( const TimePos & ) ),
+			this, SLOT( updatePosition( const TimePos & ) ) );
 
 	removeSelection();
 
@@ -486,8 +486,8 @@ void AutomationEditor::drawLine( int x0In, float y0, int x1In, float y1 )
 
 		x += xstep;
 		i += 1;
-		m_pattern->removeValue( MidiTime( x ) );
-		m_pattern->putValue( MidiTime( x ), y );
+		m_pattern->removeValue( TimePos( x ) );
+		m_pattern->putValue( TimePos( x ), y );
 	}
 }
 
@@ -514,7 +514,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 			x -= VALUES_WIDTH;
 
 			// get tick in which the user clicked
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 			// get time map of current pattern
@@ -531,7 +531,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 				if( pos_ticks >= it.key() &&
 					( it+1==time_map.end() ||
 						pos_ticks <= (it+1).key() ) &&
-		( pos_ticks<= it.key() + MidiTime::ticksPerBar() *4 / m_ppb ) &&
+		( pos_ticks<= it.key() + TimePos::ticksPerBar() *4 / m_ppb ) &&
 		( level == it.value() || mouseEvent->button() == Qt::RightButton ) )
 				{
 					break;
@@ -564,9 +564,9 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 				if( it == time_map.end() )
 				{
 					// then set new value
-					MidiTime value_pos( pos_ticks );
+					TimePos value_pos( pos_ticks );
 
-					MidiTime new_time =
+					TimePos new_time =
 						m_pattern->setDragValue( value_pos,
 									level, true,
 							mouseEvent->modifiers() &
@@ -583,7 +583,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 				int aligned_x = (int)( (float)( (
 						it.key() -
 						m_currentPosition ) *
-						m_ppb ) / MidiTime::ticksPerBar() );
+						m_ppb ) / TimePos::ticksPerBar() );
 				m_moveXOffset = x - aligned_x - 1;
 				// set move-cursor
 				QCursor c( Qt::SizeAllCursor );
@@ -711,7 +711,7 @@ void AutomationEditor::removePoints( int x0, int x1 )
 	int i = 0;
 	while( i <= deltax )
 	{
-		m_pattern->removeValue( MidiTime( x ) );
+		m_pattern->removeValue( TimePos( x ) );
 		x += xstep;
 		i += 1;
 	}
@@ -740,7 +740,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			x -= m_moveXOffset;
 		}
 
-		int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+		int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 		if( mouseEvent->buttons() & Qt::LeftButton && m_editMode == DRAW )
 		{
@@ -761,7 +761,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				// we moved the value so the value has to be
 				// moved properly according to new starting-
 				// time in the time map of pattern
-				m_pattern->setDragValue( MidiTime( pos_ticks ),
+				m_pattern->setDragValue( TimePos( pos_ticks ),
 								level, true,
 							mouseEvent->modifiers() &
 								Qt::ControlModifier );
@@ -872,7 +872,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			}
 
 			// get tick in which the cursor is posated
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 			m_selectedTick = pos_ticks - m_selectStartTick;
@@ -893,7 +893,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			// move selection + selected values
 
 			// do horizontal move-stuff
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 			int ticks_diff = pos_ticks -
 							m_moveStartTick;
@@ -918,8 +918,8 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			}
 			m_selectStartTick += ticks_diff;
 
-			int bar_diff = ticks_diff / MidiTime::ticksPerBar();
-			ticks_diff = ticks_diff % MidiTime::ticksPerBar();
+			int bar_diff = ticks_diff / TimePos::ticksPerBar();
+			ticks_diff = ticks_diff % TimePos::ticksPerBar();
 
 
 			// do vertical move-stuff
@@ -964,27 +964,27 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			for( timeMap::iterator it = m_selValuesForMove.begin();
 					it != m_selValuesForMove.end(); ++it )
 			{
-				MidiTime new_value_pos;
+				TimePos new_value_pos;
 				if( it.key() )
 				{
 					int value_bar =
 						( it.key() /
-							MidiTime::ticksPerBar() )
+							TimePos::ticksPerBar() )
 								+ bar_diff;
 					int value_ticks =
 						( it.key() %
-							MidiTime::ticksPerBar() )
+							TimePos::ticksPerBar() )
 								+ ticks_diff;
 					// ensure value_ticks range
-					if( value_ticks / MidiTime::ticksPerBar() )
+					if( value_ticks / TimePos::ticksPerBar() )
 					{
 						value_bar += value_ticks
-							/ MidiTime::ticksPerBar();
+							/ TimePos::ticksPerBar();
 						value_ticks %=
-							MidiTime::ticksPerBar();
+							TimePos::ticksPerBar();
 					}
 					m_pattern->removeValue( it.key() );
-					new_value_pos = MidiTime( value_bar,
+					new_value_pos = TimePos( value_bar,
 							value_ticks );
 				}
 				new_selValuesForMove[
@@ -1032,7 +1032,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 			}
 
 			// get tick in which the cursor is posated
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 			m_selectedTick = pos_ticks -
@@ -1288,7 +1288,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 				/ static_cast<float>( Engine::getSong()->getTimeSigModel().getDenominator() );
 		float zoomFactor = m_zoomXLevels[m_zoomingXModel.value()];
 		//the bars which disappears at the left side by scrolling
-		int leftBars = m_currentPosition * zoomFactor / MidiTime::ticksPerBar();
+		int leftBars = m_currentPosition * zoomFactor / TimePos::ticksPerBar();
 
 		//iterates the visible bars and draw the shading on uneven bars
 		for( int x = VALUES_WIDTH, barCount = leftBars; x < width() + m_currentPosition * zoomFactor / timeSignature; x += m_ppb, ++barCount )
@@ -1314,10 +1314,10 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		}
 
 		// and finally bars
-		for( tick = m_currentPosition - m_currentPosition % MidiTime::ticksPerBar(),
+		for( tick = m_currentPosition - m_currentPosition % TimePos::ticksPerBar(),
 				 x = xCoordOfTick( tick );
 			 x<=width();
-			 tick += MidiTime::ticksPerBar(), x = xCoordOfTick( tick ) )
+			 tick += TimePos::ticksPerBar(), x = xCoordOfTick( tick ) )
 		{
 			p.setPen( barLineColor() );
 			p.drawLine( x, grid_bottom, x, x_line_end );
@@ -1453,8 +1453,8 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 	// now draw selection-frame
 	int x = ( sel_pos_start - m_currentPosition ) * m_ppb /
-							MidiTime::ticksPerBar();
-	int w = ( sel_pos_end - sel_pos_start ) * m_ppb / MidiTime::ticksPerBar();
+							TimePos::ticksPerBar();
+	int w = ( sel_pos_end - sel_pos_start ) * m_ppb / TimePos::ticksPerBar();
 	int y, h;
 	if( m_y_auto )
 	{
@@ -1526,7 +1526,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 int AutomationEditor::xCoordOfTick(int tick )
 {
 	return VALUES_WIDTH + ( ( tick - m_currentPosition )
-		* m_ppb / MidiTime::ticksPerBar() );
+		* m_ppb / TimePos::ticksPerBar() );
 }
 
 
@@ -1687,7 +1687,7 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 		}
 		x = qBound( 0, x, m_zoomingXModel.size() - 1 );
 
-		int mouseX = (we->x() - VALUES_WIDTH)* MidiTime::ticksPerBar();
+		int mouseX = (we->x() - VALUES_WIDTH)* TimePos::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = mouseX / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -1958,7 +1958,7 @@ void AutomationEditor::getSelectedValues( timeMap & selected_values )
 									++it )
 	{
 		//TODO: Add constant
-		tick_t len_ticks = MidiTime::ticksPerBar() / 16;
+		tick_t len_ticks = TimePos::ticksPerBar() / 16;
 
 		float level = it.value();
 		tick_t pos_ticks = it.key();
@@ -2087,7 +2087,7 @@ void AutomationEditor::deleteSelectedValues()
 
 
 
-void AutomationEditor::updatePosition(const MidiTime & t )
+void AutomationEditor::updatePosition(const TimePos & t )
 {
 	if( ( Engine::getSong()->isPlaying() &&
 			Engine::getSong()->playMode() ==
@@ -2095,17 +2095,17 @@ void AutomationEditor::updatePosition(const MidiTime & t )
 							m_scrollBack == true )
 	{
 		const int w = width() - VALUES_WIDTH;
-		if( t > m_currentPosition + w * MidiTime::ticksPerBar() / m_ppb )
+		if( t > m_currentPosition + w * TimePos::ticksPerBar() / m_ppb )
 		{
 			m_leftRightScroll->setValue( t.getBar() *
-							MidiTime::ticksPerBar() );
+							TimePos::ticksPerBar() );
 		}
 		else if( t < m_currentPosition )
 		{
-			MidiTime t_ = qMax( t - w * MidiTime::ticksPerBar() *
-					MidiTime::ticksPerBar() / m_ppb, 0 );
+			TimePos t_ = qMax( t - w * TimePos::ticksPerBar() *
+					TimePos::ticksPerBar() / m_ppb, 0 );
 			m_leftRightScroll->setValue( t_.getBar() *
-							MidiTime::ticksPerBar() );
+							TimePos::ticksPerBar() );
 		}
 		m_scrollBack = false;
 	}

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -257,7 +257,7 @@ void BBTrackContainerView::dropEvent(QDropEvent* de)
 			hasValidBBTCOs = true;
 			for (int i = 0; i < t->getTCOs().size(); ++i)
 			{
-				if (t->getTCOs()[i]->startPosition() != MidiTime(i, 0))
+				if (t->getTCOs()[i]->startPosition() != TimePos(i, 0))
 				{
 					hasValidBBTCOs = false;
 					break;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -169,7 +169,7 @@ PianoRoll::PianoRoll() :
 	m_oldNotesEditHeight( 100 ),
 	m_notesEditHeight( 100 ),
 	m_ppb( DEFAULT_PR_PPB ),
-	m_lenOfNewNotes( MidiTime( 0, DefaultTicksPerBar/4 ) ),
+	m_lenOfNewNotes( TimePos( 0, DefaultTicksPerBar/4 ) ),
 	m_lastNoteVolume( DefaultVolume ),
 	m_lastNotePanning( DefaultPanning ),
 	m_startKey( INITIAL_START_KEY ),
@@ -307,25 +307,25 @@ PianoRoll::PianoRoll() :
 						Song::Mode_PlayPattern ),
 						m_currentPosition,
 						Song::Mode_PlayPattern, this );
-	connect( this, SIGNAL( positionChanged( const MidiTime & ) ),
-		m_timeLine, SLOT( updatePosition( const MidiTime & ) ) );
-	connect( m_timeLine, SIGNAL( positionChanged( const MidiTime & ) ),
-			this, SLOT( updatePosition( const MidiTime & ) ) );
+	connect( this, SIGNAL( positionChanged( const TimePos & ) ),
+		m_timeLine, SLOT( updatePosition( const TimePos & ) ) );
+	connect( m_timeLine, SIGNAL( positionChanged( const TimePos & ) ),
+			this, SLOT( updatePosition( const TimePos & ) ) );
 
 	//update timeline when in step-recording mode
-	connect( &m_stepRecorderWidget, SIGNAL( positionChanged( const MidiTime & ) ),
-			this, SLOT( updatePositionStepRecording( const MidiTime & ) ) );
+	connect( &m_stepRecorderWidget, SIGNAL( positionChanged( const TimePos & ) ),
+			this, SLOT( updatePositionStepRecording( const TimePos & ) ) );
 
 	// update timeline when in record-accompany mode
 	connect( Engine::getSong()->getPlayPos( Song::Mode_PlaySong ).m_timeLine,
-				SIGNAL( positionChanged( const MidiTime & ) ),
+				SIGNAL( positionChanged( const TimePos & ) ),
 			this,
-			SLOT( updatePositionAccompany( const MidiTime & ) ) );
+			SLOT( updatePositionAccompany( const TimePos & ) ) );
 	// TODO
 /*	connect( engine::getSong()->getPlayPos( Song::Mode_PlayBB ).m_timeLine,
-				SIGNAL( positionChanged( const MidiTime & ) ),
+				SIGNAL( positionChanged( const TimePos & ) ),
 			this,
-			SLOT( updatePositionAccompany( const MidiTime & ) ) );*/
+			SLOT( updatePositionAccompany( const TimePos & ) ) );*/
 
 	removeSelection();
 
@@ -759,7 +759,7 @@ void PianoRoll::selectRegionFromPixels( int xStart, int xEnd )
 	xEnd  -= WHITE_KEY_WIDTH;
 
 	// select an area of notes
-	int posTicks = xStart * MidiTime::ticksPerBar() / m_ppb +
+	int posTicks = xStart * TimePos::ticksPerBar() / m_ppb +
 					m_currentPosition;
 	int keyNum = 0;
 	m_selectStartTick = posTicks;
@@ -769,7 +769,7 @@ void PianoRoll::selectRegionFromPixels( int xStart, int xEnd )
 	// change size of selection
 
 	// get tick in which the cursor is posated
-	posTicks = xEnd  * MidiTime::ticksPerBar() / m_ppb +
+	posTicks = xEnd  * TimePos::ticksPerBar() / m_ppb +
 					m_currentPosition;
 	keyNum = 120;
 
@@ -1033,7 +1033,7 @@ void PianoRoll::drawDetuningInfo( QPainter & _p, const Note * _n, int _x,
 	for( timeMap::ConstIterator it = map.begin(); it != map.end(); ++it )
 	{
 		int pos_ticks = it.key();
-		int pos_x = _x + pos_ticks * m_ppb / MidiTime::ticksPerBar();
+		int pos_x = _x + pos_ticks * m_ppb / TimePos::ticksPerBar();
 
 		const float level = it.value();
 
@@ -1268,7 +1268,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 					// Move selected notes by one bar to the left
 					if (hasValidPattern())
 					{
-						shiftPos( direction * MidiTime::ticksPerBar() );
+						shiftPos( direction * TimePos::ticksPerBar() );
 					}
 				}
 				else if( ke->modifiers() & Qt::ShiftModifier && m_action == ActionNone)
@@ -1572,7 +1572,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			x -= WHITE_KEY_WIDTH;
 
 			// get tick in which the user clicked
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 
@@ -1586,7 +1586,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note *note = *it;
-				MidiTime len = note->length();
+				TimePos len = note->length();
 				if( len < 0 )
 				{
 					len = 4;
@@ -1602,7 +1602,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					||
 					( edit_note &&
 					pos_ticks <= note->pos() +
-						NOTE_EDIT_LINE_WIDTH * MidiTime::ticksPerBar() / m_ppb )
+						NOTE_EDIT_LINE_WIDTH * TimePos::ticksPerBar() / m_ppb )
 					)
 					)
 				{
@@ -1643,8 +1643,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// +32 to quanitize the note correctly when placing notes with
 					// the mouse.  We do this here instead of in note.quantized
 					// because live notes should still be quantized at the half.
-					MidiTime note_pos( pos_ticks - ( quantization() / 2 ) );
-					MidiTime note_len( newNoteLen() );
+					TimePos note_pos( pos_ticks - ( quantization() / 2 ) );
+					TimePos note_len( newNoteLen() );
 
 					Note new_note( note_len, note_pos, key_num );
 					new_note.setSelected( true );
@@ -1746,8 +1746,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 
 				// clicked at the "tail" of the note?
-				if( pos_ticks * m_ppb / MidiTime::ticksPerBar() >
-						m_currentNote->endPos() * m_ppb / MidiTime::ticksPerBar() - RESIZE_AREA_WIDTH
+				if( pos_ticks * m_ppb / TimePos::ticksPerBar() >
+						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - RESIZE_AREA_WIDTH
 					&& m_currentNote->length() > 0 )
 				{
 					m_pattern->addJournalCheckPoint();
@@ -1902,10 +1902,10 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 		int pixel_range = 4;
 		int x = me->x() - WHITE_KEY_WIDTH;
 		const int ticks_start = ( x-pixel_range/2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 		const int ticks_end = ( x+pixel_range/2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
-		const int ticks_middle = x * MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+		const int ticks_middle = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 		// go through notes to figure out which one we want to change
 		bool altPressed = me->modifiers() & Qt::AltModifier;
@@ -2300,9 +2300,9 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			// convert to ticks so that we can check which notes
 			// are in the range
 			int ticks_start = ( x-pixel_range/2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 			int ticks_end = ( x+pixel_range/2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 			// get note-vector of current pattern
 			const NoteVector & notes = m_pattern->notes();
@@ -2398,7 +2398,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			// set move- or resize-cursor
 
 			// get tick in which the cursor is posated
-			int pos_ticks = ( x * MidiTime::ticksPerBar() ) /
+			int pos_ticks = ( x * TimePos::ticksPerBar() ) /
 						m_ppb + m_currentPosition;
 
 			// get note-vector of current pattern
@@ -2431,7 +2431,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				Note *note = *it;
 				// x coordinate of the right edge of the note
 				int noteRightX = ( note->pos() + note->length() -
-					m_currentPosition) * m_ppb/MidiTime::ticksPerBar();
+					m_currentPosition) * m_ppb/TimePos::ticksPerBar();
 				// cursor at the "tail" of the note?
 				bool atTail = note->length() > 0 && x > noteRightX -
 							RESIZE_AREA_WIDTH;
@@ -2470,7 +2470,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			// change size of selection
 
 			// get tick in which the cursor is posated
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 			m_selectedTick = pos_ticks - m_selectStartTick;
@@ -2492,7 +2492,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			// any key if in erase mode
 
 			// get tick in which the user clicked
-			int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar() / m_ppb +
 							m_currentPosition;
 
 
@@ -2506,7 +2506,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			while( it != notes.end() )
 			{
 				Note *note = *it;
-				MidiTime len = note->length();
+				TimePos len = note->length();
 				if( len < 0 )
 				{
 					len = 4;
@@ -2523,7 +2523,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 					( edit_note &&
 					pos_ticks <= note->pos() +
 							NOTE_EDIT_LINE_WIDTH *
-						MidiTime::ticksPerBar() /
+						TimePos::ticksPerBar() /
 								m_ppb )
 					)
 					)
@@ -2573,7 +2573,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			}
 
 			// get tick in which the cursor is posated
-			int pos_ticks = x * MidiTime::ticksPerBar()/ m_ppb +
+			int pos_ticks = x * TimePos::ticksPerBar()/ m_ppb +
 							m_currentPosition;
 
 			m_selectedTick = pos_ticks -
@@ -2634,7 +2634,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 	// convert pixels to ticks and keys
 	int off_x = x - m_moveStartX;
-	int off_ticks = off_x * MidiTime::ticksPerBar() / m_ppb;
+	int off_ticks = off_x * TimePos::ticksPerBar() / m_ppb;
 	int off_key = getKey( y ) - getKey( m_moveStartY );
 
 	// handle scroll changes while dragging
@@ -2684,7 +2684,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 					{
 						ticks_new = 1;
 					}
-					note->setLength( MidiTime( ticks_new ) );
+					note->setLength( TimePos( ticks_new ) );
 					m_lenOfNewNotes = note->length();
 				}
 				else
@@ -2699,7 +2699,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 					key_num = qMax(0, key_num);
 					key_num = qMin(key_num, NumKeys);
 
-					note->setPos( MidiTime( pos_ticks ) );
+					note->setPos( TimePos( pos_ticks ) );
 					note->setKey( key_num );
 				}
 			}
@@ -2777,8 +2777,8 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 						posteriorDeltaThisFrame = (newStart+newLength) -
 							(note->pos().getTicks() + note->length().getTicks());
 					}
-					note->setLength( MidiTime(newLength) );
-					note->setPos( MidiTime(newStart) );
+					note->setLength( TimePos(newLength) );
+					note->setPos( TimePos(newStart) );
 
 					m_lenOfNewNotes = note->length();
 				}
@@ -2791,7 +2791,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 					if (!note->selected() && note->pos().getTicks() >= posteriorEndTick)
 					{
 						int newStart = note->pos().getTicks() + posteriorDeltaThisFrame;
-						note->setPos( MidiTime(newStart) );
+						note->setPos( TimePos(newStart) );
 					}
 				}
 			}
@@ -2805,7 +2805,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				{
 					int newLength = note->oldLength() + off_ticks;
 					newLength = qMax(1, newLength);
-					note->setLength( MidiTime(newLength) );
+					note->setLength( TimePos(newLength) );
 
 					m_lenOfNewNotes = note->length();
 				}
@@ -2821,7 +2821,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 int PianoRoll::xCoordOfTick( int tick )
 {
 	return WHITE_KEY_WIDTH + ( ( tick - m_currentPosition )
-		* m_ppb / MidiTime::ticksPerBar() );
+		* m_ppb / TimePos::ticksPerBar() );
 }
 
 void PianoRoll::paintEvent(QPaintEvent * pe )
@@ -3118,7 +3118,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				/ static_cast<float>( Engine::getSong()->getTimeSigModel().getDenominator() );
 		float zoomFactor = m_zoomLevels[m_zoomingModel.value()];
 		//the bars which disappears at the left side by scrolling
-		int leftBars = m_currentPosition * zoomFactor / MidiTime::ticksPerBar();
+		int leftBars = m_currentPosition * zoomFactor / TimePos::ticksPerBar();
 
 		//iterates the visible bars and draw the shading on uneven bars
 		for( int x = WHITE_KEY_WIDTH, barCount = leftBars; x < width() + m_currentPosition * zoomFactor / timeSignature; x += m_ppb, ++barCount )
@@ -3143,9 +3143,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 
 		// Draw the vertical bar lines
-		for( tick = m_currentPosition - m_currentPosition % MidiTime::ticksPerBar(),
+		for( tick = m_currentPosition - m_currentPosition % TimePos::ticksPerBar(),
 			x = xCoordOfTick( tick ); x <= width();
-			tick += MidiTime::ticksPerBar(), x = xCoordOfTick( tick ) )
+			tick += TimePos::ticksPerBar(), x = xCoordOfTick( tick ) )
 		{
 			p.setPen( barLineColor() );
 			p.drawLine( x, PR_TOP_MARGIN, x, height() - PR_BOTTOM_MARGIN );
@@ -3217,9 +3217,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 				int pos_ticks = note->pos();
 
-				int note_width = len_ticks * m_ppb / MidiTime::ticksPerBar();
+				int note_width = len_ticks * m_ppb / TimePos::ticksPerBar();
 				const int x = ( pos_ticks - m_currentPosition ) *
-						m_ppb / MidiTime::ticksPerBar();
+						m_ppb / TimePos::ticksPerBar();
 				// skip this note if not in visible area at all
 				if( !( x + note_width >= 0 && x <= width() - WHITE_KEY_WIDTH ) )
 				{
@@ -3259,9 +3259,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 			int pos_ticks = note->pos();
 
-			int note_width = len_ticks * m_ppb / MidiTime::ticksPerBar();
+			int note_width = len_ticks * m_ppb / TimePos::ticksPerBar();
 			const int x = ( pos_ticks - m_currentPosition ) *
-					m_ppb / MidiTime::ticksPerBar();
+					m_ppb / TimePos::ticksPerBar();
 			// skip this note if not in visible area at all
 			if( !( x + note_width >= 0 && x <= width() - WHITE_KEY_WIDTH ) )
 			{
@@ -3347,9 +3347,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 			int pos_ticks = note->pos();
 
-			int note_width = len_ticks * m_ppb / MidiTime::ticksPerBar();
+			int note_width = len_ticks * m_ppb / TimePos::ticksPerBar();
 			const int x = ( pos_ticks - m_currentPosition ) *
-					m_ppb / MidiTime::ticksPerBar();
+					m_ppb / TimePos::ticksPerBar();
 			// skip this note if not in visible area at all
 			if( !( x + note_width >= 0 && x <= width() - WHITE_KEY_WIDTH ) )
 			{
@@ -3390,9 +3390,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 	// now draw selection-frame
 	int x = ( ( sel_pos_start - m_currentPosition ) * m_ppb ) /
-						MidiTime::ticksPerBar();
+						TimePos::ticksPerBar();
 	int w = ( ( ( sel_pos_end - m_currentPosition ) * m_ppb ) /
-						MidiTime::ticksPerBar() ) - x;
+						TimePos::ticksPerBar() ) - x;
 	int y = (int) y_base - sel_key_start * KEY_LINE_HEIGHT;
 	int h = (int) y_base - sel_key_end * KEY_LINE_HEIGHT - y;
 	p.setPen( selectedNoteColor() );
@@ -3508,9 +3508,9 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		int pixel_range = 8;
 		int x = we->x() - WHITE_KEY_WIDTH;
 		int ticks_start = ( x - pixel_range / 2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 		int ticks_end = ( x + pixel_range / 2 ) *
-					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 		// When alt is pressed we only edit the note under the cursor
 		bool altPressed = we->modifiers() & Qt::AltModifier;
@@ -3611,7 +3611,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		}
 		z = qBound( 0, z, m_zoomingModel.size() - 1 );
 
-		int x = (we->x() - WHITE_KEY_WIDTH)* MidiTime::ticksPerBar();
+		int x = (we->x() - WHITE_KEY_WIDTH)* TimePos::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = x / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -3815,7 +3815,7 @@ void PianoRoll::startRecordNote(const Note & n )
 			(Engine::getSong()->playMode() == desiredPlayModeForAccompany() ||
 			Engine::getSong()->playMode() == Song::Mode_PlayPattern ))
 		{
-			MidiTime sub;
+			TimePos sub;
 			if( Engine::getSong()->playMode() == Song::Mode_PlaySong )
 			{
 				sub = m_pattern->startPosition();
@@ -4039,7 +4039,7 @@ void PianoRoll::copyToClipboard( const NoteVector & notes ) const
 	QDomElement note_list = dataFile.createElement( "note-list" );
 	dataFile.content().appendChild( note_list );
 
-	MidiTime start_pos( notes.front()->pos().getBar(), 0 );
+	TimePos start_pos( notes.front()->pos().getBar(), 0 );
 	for( const Note *note : notes )
 	{
 		Note clip_note( *note );
@@ -4197,18 +4197,18 @@ void PianoRoll::deleteSelectedNotes()
 
 
 
-void PianoRoll::autoScroll( const MidiTime & t )
+void PianoRoll::autoScroll( const TimePos & t )
 {
 	const int w = width() - WHITE_KEY_WIDTH;
-	if( t > m_currentPosition + w * MidiTime::ticksPerBar() / m_ppb )
+	if( t > m_currentPosition + w * TimePos::ticksPerBar() / m_ppb )
 	{
-		m_leftRightScroll->setValue( t.getBar() * MidiTime::ticksPerBar() );
+		m_leftRightScroll->setValue( t.getBar() * TimePos::ticksPerBar() );
 	}
 	else if( t < m_currentPosition )
 	{
-		MidiTime t2 = qMax( t - w * MidiTime::ticksPerBar() *
-					MidiTime::ticksPerBar() / m_ppb, (tick_t) 0 );
-		m_leftRightScroll->setValue( t2.getBar() * MidiTime::ticksPerBar() );
+		TimePos t2 = qMax( t - w * TimePos::ticksPerBar() *
+					TimePos::ticksPerBar() / m_ppb, (tick_t) 0 );
+		m_leftRightScroll->setValue( t2.getBar() * TimePos::ticksPerBar() );
 	}
 	m_scrollBack = false;
 }
@@ -4216,7 +4216,7 @@ void PianoRoll::autoScroll( const MidiTime & t )
 
 
 
-void PianoRoll::updatePosition( const MidiTime & t )
+void PianoRoll::updatePosition( const TimePos & t )
 {
 	if( ( Engine::getSong()->isPlaying()
 			&& Engine::getSong()->playMode() == Song::Mode_PlayPattern
@@ -4230,14 +4230,14 @@ void PianoRoll::updatePosition( const MidiTime & t )
 
 
 
-void PianoRoll::updatePositionAccompany( const MidiTime & t )
+void PianoRoll::updatePositionAccompany( const TimePos & t )
 {
 	Song * s = Engine::getSong();
 
 	if( m_recording && hasValidPattern() &&
 					s->playMode() != Song::Mode_PlayPattern )
 	{
-		MidiTime pos = t;
+		TimePos pos = t;
 		if( s->playMode() != Song::Mode_PlayBB )
 		{
 			pos -= m_pattern->startPosition();
@@ -4251,7 +4251,7 @@ void PianoRoll::updatePositionAccompany( const MidiTime & t )
 }
 
 
-void PianoRoll::updatePositionStepRecording( const MidiTime & t )
+void PianoRoll::updatePositionStepRecording( const TimePos & t )
 {
 	if( m_stepRecorder.isRecording() )
 	{
@@ -4327,7 +4327,7 @@ void PianoRoll::quantizeNotes()
 
 	for( Note* n : notes )
 	{
-		if( n->length() == MidiTime( 0 ) )
+		if( n->length() == TimePos( 0 ) )
 		{
 			continue;
 		}
@@ -4362,7 +4362,7 @@ void PianoRoll::updateSemiToneMarkerMenu()
 
 
 
-MidiTime PianoRoll::newNoteLen() const
+TimePos PianoRoll::newNoteLen() const
 {
 	if( m_noteLenModel.value() == 0 )
 	{
@@ -4398,7 +4398,7 @@ Note * PianoRoll::noteUnderMouse()
 
 	int key_num = getKey( pos.y() );
 	int pos_ticks = ( pos.x() - WHITE_KEY_WIDTH ) *
-			MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
+			TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 	// loop through whole note-vector...
 	for( Note* const& note : m_pattern->notes() )

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -99,11 +99,11 @@ SongEditor::SongEditor( Song * song ) :
 					m_song->m_playPos[Song::Mode_PlaySong],
 					m_currentPosition,
 					Song::Mode_PlaySong, this );
-	connect( this, SIGNAL( positionChanged( const MidiTime & ) ),
+	connect( this, SIGNAL( positionChanged( const TimePos & ) ),
 				m_song->m_playPos[Song::Mode_PlaySong].m_timeLine,
-			SLOT( updatePosition( const MidiTime & ) ) );
-	connect( m_timeLine, SIGNAL( positionChanged( const MidiTime & ) ),
-			this, SLOT( updatePosition( const MidiTime & ) ) );
+			SLOT( updatePosition( const TimePos & ) ) );
+	connect( m_timeLine, SIGNAL( positionChanged( const TimePos & ) ),
+			this, SLOT( updatePosition( const TimePos & ) ) );
 	connect( m_timeLine, SIGNAL( regionSelectedFromPixels( int, int ) ),
 			this, SLOT( selectRegionFromPixels( int, int ) ) );
 	connect( m_timeLine, SIGNAL( selectionFinished() ),
@@ -349,7 +349,7 @@ void SongEditor::setHighQuality( bool hq )
 void SongEditor::scrolled( int new_pos )
 {
 	update();
-	emit positionChanged( m_currentPosition = MidiTime( new_pos, 0 ) );
+	emit positionChanged( m_currentPosition = TimePos( new_pos, 0 ) );
 }
 
 
@@ -373,8 +373,8 @@ void SongEditor::selectRegionFromPixels(int xStart, int xEnd)
 		m_currentZoomingValue = zoomingModel()->value();
 
 		//calculate the song position where the mouse was clicked
-		m_rubberbandStartMidipos = MidiTime((xStart - m_trackHeadWidth)
-											/ pixelsPerBar() * MidiTime::ticksPerBar())
+		m_rubberbandStartMidipos = TimePos((xStart - m_trackHeadWidth)
+											/ pixelsPerBar() * TimePos::ticksPerBar())
 											+ m_currentPosition;
 		m_rubberBandStartTrackview = 0;
 	}
@@ -423,9 +423,9 @@ void SongEditor::updateRubberband()
 		//the index of the TrackView the mouse is hover
 		int rubberBandTrackview = trackIndexFromSelectionPoint(m_mousePos.y());
 
-		//the miditime the mouse is hover
-		MidiTime rubberbandMidipos = MidiTime((qMin(m_mousePos.x(), width()) - m_trackHeadWidth)
-											  / pixelsPerBar() * MidiTime::ticksPerBar())
+		//the timepos the mouse is hover
+		TimePos rubberbandMidipos = TimePos((qMin(m_mousePos.x(), width()) - m_trackHeadWidth)
+											  / pixelsPerBar() * TimePos::ticksPerBar())
 											  + m_currentPosition;
 
 		//are tcos in the rect of selection?
@@ -485,7 +485,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 	}
 	else if( ke->key() == Qt::Key_Left )
 	{
-		tick_t t = m_song->currentTick() - MidiTime::ticksPerBar();
+		tick_t t = m_song->currentTick() - TimePos::ticksPerBar();
 		if( t >= 0 )
 		{
 			m_song->setPlayPos( t, Song::Mode_PlaySong );
@@ -493,7 +493,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 	}
 	else if( ke->key() == Qt::Key_Right )
 	{
-		tick_t t = m_song->currentTick() + MidiTime::ticksPerBar();
+		tick_t t = m_song->currentTick() + TimePos::ticksPerBar();
 		if( t < MaxSongLength )
 		{
 			m_song->setPlayPos( t, Song::Mode_PlaySong );
@@ -611,10 +611,10 @@ void SongEditor::mousePressEvent(QMouseEvent *me)
 		rubberBand()->setGeometry(QRect(m_origin, QSize()));
 		rubberBand()->show();
 
-		//the trackView(index) and the miditime where the mouse was clicked
+		//the trackView(index) and the timepos where the mouse was clicked
 		m_rubberBandStartTrackview = trackIndexFromSelectionPoint(me->y());
-		m_rubberbandStartMidipos = MidiTime((me->x() - m_trackHeadWidth)
-											/ pixelsPerBar() * MidiTime::ticksPerBar())
+		m_rubberbandStartMidipos = TimePos((me->x() - m_trackHeadWidth)
+											/ pixelsPerBar() * TimePos::ticksPerBar())
 											+ m_currentPosition;
 	}
 	QWidget::mousePressEvent(me);
@@ -769,7 +769,7 @@ static inline void animateScroll( QScrollBar *scrollBar, int newVal, bool smooth
 
 
 
-void SongEditor::updatePosition( const MidiTime & t )
+void SongEditor::updatePosition( const TimePos & t )
 {
 	int widgetWidth, trackOpWidth;
 	if( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() )
@@ -791,7 +791,7 @@ void SongEditor::updatePosition( const MidiTime & t )
 		const int w = width() - widgetWidth
 							- trackOpWidth
 							- contentWidget()->verticalScrollBar()->width(); // width of right scrollbar
-		if( t > m_currentPosition + w * MidiTime::ticksPerBar() /
+		if( t > m_currentPosition + w * TimePos::ticksPerBar() /
 							pixelsPerBar() )
 		{
 			animateScroll( m_leftRightScroll, t.getBar(), m_smoothScroll );

--- a/src/gui/widgets/StepRecorderWidget.cpp
+++ b/src/gui/widgets/StepRecorderWidget.cpp
@@ -53,7 +53,7 @@ void StepRecorderWidget::setPixelsPerBar(int ppb)
 	m_ppb = ppb;
 }
 
-void StepRecorderWidget::setCurrentPosition(MidiTime currentPosition)
+void StepRecorderWidget::setCurrentPosition(TimePos currentPosition)
 {
 	m_currentPosition = currentPosition;
 }
@@ -63,12 +63,12 @@ void StepRecorderWidget::setBottomMargin(const int marginBottom)
 	m_marginBottom = marginBottom;
 }
 
-void StepRecorderWidget::setStartPosition(MidiTime pos)
+void StepRecorderWidget::setStartPosition(TimePos pos)
 {
 	m_curStepStartPos = pos;
 }
 
-void StepRecorderWidget::setEndPosition(MidiTime pos)
+void StepRecorderWidget::setEndPosition(TimePos pos)
 {
 	m_curStepEndPos = pos;
 	emit positionChanged(m_curStepEndPos);
@@ -80,7 +80,7 @@ void StepRecorderWidget::showHint()
 		embed::getIconPixmap("hint"));
 }
 
-void StepRecorderWidget::setStepsLength(MidiTime stepsLength)
+void StepRecorderWidget::setStepsLength(TimePos stepsLength)
 {
 	m_stepsLength = stepsLength;
 }
@@ -96,7 +96,7 @@ void StepRecorderWidget::paintEvent(QPaintEvent * pe)
 	//draw steps ruler
 	painter.setPen(m_colorLineEnd);
 
-	MidiTime curPos = m_curStepEndPos;
+	TimePos curPos = m_curStepEndPos;
 	int x = xCoordOfTick(curPos);
 	while(x <= m_right)
 	{
@@ -125,7 +125,7 @@ void StepRecorderWidget::paintEvent(QPaintEvent * pe)
 
 int StepRecorderWidget::xCoordOfTick(int tick)
 {
-	return m_marginLeft + ((tick - m_currentPosition) * m_ppb / MidiTime::ticksPerBar());
+	return m_marginLeft + ((tick - m_currentPosition) * m_ppb / TimePos::ticksPerBar());
 }
 
 
@@ -138,7 +138,7 @@ void StepRecorderWidget::drawVerLine(QPainter* painter, int x, const QColor& col
 	}
 }
 
-void StepRecorderWidget::drawVerLine(QPainter* painter, const MidiTime& pos, const QColor& color, int top, int bottom)
+void StepRecorderWidget::drawVerLine(QPainter* painter, const TimePos& pos, const QColor& color, int top, int bottom)
 {
 	drawVerLine(painter, xCoordOfTick(pos), color, top, bottom);
 }

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -40,7 +40,7 @@ AutomationTrack::AutomationTrack( TrackContainer* tc, bool _hidden ) :
 	setName( tr( "Automation track" ) );
 }
 
-bool AutomationTrack::play( const MidiTime & time_start, const fpp_t _frames,
+bool AutomationTrack::play( const TimePos & time_start, const fpp_t _frames,
 							const f_cnt_t _frame_base, int _tco_num )
 {
 	return false;
@@ -57,7 +57,7 @@ TrackView * AutomationTrack::createView( TrackContainerView* tcv )
 
 
 
-TrackContentObject * AutomationTrack::createTCO( const MidiTime & )
+TrackContentObject * AutomationTrack::createTCO( const TimePos & )
 {
 	return new AutomationPattern( this );
 }
@@ -117,11 +117,11 @@ void AutomationTrackView::dropEvent( QDropEvent * _de )
 					journallingObject( val.toInt() ) );
 		if( mod != NULL )
 		{
-			MidiTime pos = MidiTime( trackContainerView()->
+			TimePos pos = TimePos( trackContainerView()->
 							currentPosition() +
 				( _de->pos().x() -
 					getTrackContentWidget()->x() ) *
-						MidiTime::ticksPerBar() /
+						TimePos::ticksPerBar() /
 		static_cast<int>( trackContainerView()->pixelsPerBar() ) )
 				.toAbsoluteBar();
 

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -55,7 +55,7 @@ BBTCO::BBTCO( Track * _track ) :
 	if( t > 0 )
 	{
 		saveJournallingState( false );
-		changeLength( MidiTime( t, 0 ) );
+		changeLength( TimePos( t, 0 ) );
 		restoreJournallingState();
 	}
 	setAutoResize( false );
@@ -238,7 +238,7 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	p.setPen( c.darker( 200 ) );
 
 	bar_t t = Engine::getBBTrackContainer()->lengthOfBB( m_bbTCO->bbTrackIndex() );
-	if( m_bbTCO->length() > MidiTime::ticksPerBar() && t > 0 )
+	if( m_bbTCO->length() > TimePos::ticksPerBar() && t > 0 )
 	{
 		for( int x = static_cast<int>( t * pixelsPerBar() );
 								x < width() - 2;
@@ -423,7 +423,7 @@ BBTrack::~BBTrack()
 
 
 // play _frames frames of given TCO within starting with _start
-bool BBTrack::play( const MidiTime & _start, const fpp_t _frames,
+bool BBTrack::play( const TimePos & _start, const fpp_t _frames,
 					const f_cnt_t _offset, int _tco_num )
 {
 	if( isMuted() )
@@ -444,8 +444,8 @@ bool BBTrack::play( const MidiTime & _start, const fpp_t _frames,
 		return false;
 	}
 
-	MidiTime lastPosition;
-	MidiTime lastLen;
+	TimePos lastPosition;
+	TimePos lastLen;
 	for( tcoVector::iterator it = tcos.begin(); it != tcos.end(); ++it )
 	{
 		if( !( *it )->isMuted() &&
@@ -474,7 +474,7 @@ TrackView * BBTrack::createView( TrackContainerView* tcv )
 
 
 
-TrackContentObject * BBTrack::createTCO( const MidiTime & _pos )
+TrackContentObject * BBTrack::createTCO( const TimePos & _pos )
 {
 	BBTCO * bbtco = new BBTCO( this );
 	if( s_lastTCOColor )

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -241,7 +241,7 @@ MidiEvent InstrumentTrack::applyMasterKey( const MidiEvent& event )
 
 
 
-void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+void InstrumentTrack::processInEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	if( Engine::getSong()->isExporting() )
 	{
@@ -264,7 +264,7 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 						NotePlayHandleManager::acquire(
 								this, offset,
 								typeInfo<f_cnt_t>::max() / 2,
-								Note( MidiTime(), MidiTime(), event.key(), event.volume( midiPort()->baseVelocity() ) ),
+								Note( TimePos(), TimePos(), event.key(), event.volume( midiPort()->baseVelocity() ) ),
 								NULL, event.channel(),
 								NotePlayHandle::OriginMidiInput );
 					m_notes[event.key()] = nph;
@@ -329,7 +329,7 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 								nph->OriginMidiInput)
 							{
 								nph->setLength(
-									MidiTime( static_cast<f_cnt_t>(
+									TimePos( static_cast<f_cnt_t>(
 									nph->totalFramesPlayed() /
 									Engine::framesPerTick() ) ) );
 								midiNoteOff( *nph );
@@ -382,7 +382,7 @@ void InstrumentTrack::processInEvent( const MidiEvent& event, const MidiTime& ti
 
 
 
-void InstrumentTrack::processOutEvent( const MidiEvent& event, const MidiTime& time, f_cnt_t offset )
+void InstrumentTrack::processOutEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
 {
 	// do nothing if we do not have an instrument instance (e.g. when loading settings)
 	if( m_instrument == NULL )
@@ -608,7 +608,7 @@ void InstrumentTrack::removeMidiPortNode( DataFile & _dataFile )
 
 
 
-bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
+bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 							const f_cnt_t _offset, int _tco_num )
 {
 	if( ! m_instrument || ! tryLock() )
@@ -638,7 +638,7 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 	for( NotePlayHandleList::Iterator it = m_processHandles.begin();
 					it != m_processHandles.end(); ++it )
 	{
-		( *it )->processMidiTime( _start );
+		( *it )->processTimePos( _start );
 	}
 
 	if ( tcos.size() == 0 )
@@ -660,7 +660,7 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 		{
 			continue;
 		}
-		MidiTime cur_start = _start;
+		TimePos cur_start = _start;
 		if( _tco_num < 0 )
 		{
 			cur_start -= p->startPosition();
@@ -713,7 +713,7 @@ bool InstrumentTrack::play( const MidiTime & _start, const fpp_t _frames,
 
 
 
-TrackContentObject * InstrumentTrack::createTCO( const MidiTime & )
+TrackContentObject * InstrumentTrack::createTCO( const TimePos & )
 {
 	return new Pattern( this );
 }

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -56,7 +56,7 @@ Pattern::Pattern( InstrumentTrack * _instrument_track ) :
 	TrackContentObject( _instrument_track ),
 	m_instrumentTrack( _instrument_track ),
 	m_patternType( BeatPattern ),
-	m_steps( MidiTime::stepsPerBar() )
+	m_steps( TimePos::stepsPerBar() )
 {
 	setName( _instrument_track->name() );
 	if( _instrument_track->trackContainer()
@@ -161,7 +161,7 @@ void Pattern::updateLength()
 		return;
 	}
 
-	tick_t max_length = MidiTime::ticksPerBar();
+	tick_t max_length = TimePos::ticksPerBar();
 
 	for( NoteVector::ConstIterator it = m_notes.begin();
 						it != m_notes.end(); ++it )
@@ -172,17 +172,17 @@ void Pattern::updateLength()
 							( *it )->endPos() );
 		}
 	}
-	changeLength( MidiTime( max_length ).nextFullBar() *
-						MidiTime::ticksPerBar() );
+	changeLength( TimePos( max_length ).nextFullBar() *
+						TimePos::ticksPerBar() );
 	updateBBTrack();
 }
 
 
 
 
-MidiTime Pattern::beatPatternLength() const
+TimePos Pattern::beatPatternLength() const
 {
-	tick_t max_length = MidiTime::ticksPerBar();
+	tick_t max_length = TimePos::ticksPerBar();
 
 	for( NoteVector::ConstIterator it = m_notes.begin();
 						it != m_notes.end(); ++it )
@@ -194,13 +194,13 @@ MidiTime Pattern::beatPatternLength() const
 		}
 	}
 
-	if( m_steps != MidiTime::stepsPerBar() )
+	if( m_steps != TimePos::stepsPerBar() )
 	{
-		max_length = m_steps * MidiTime::ticksPerBar() /
-						MidiTime::stepsPerBar();
+		max_length = m_steps * TimePos::ticksPerBar() /
+						TimePos::stepsPerBar();
 	}
 
-	return MidiTime( max_length ).nextFullBar() * MidiTime::ticksPerBar();
+	return TimePos( max_length ).nextFullBar() * TimePos::ticksPerBar();
 }
 
 
@@ -259,7 +259,7 @@ Note * Pattern::noteAtStep( int _step )
 	for( NoteVector::Iterator it = m_notes.begin(); it != m_notes.end();
 									++it )
 	{
-		if( ( *it )->pos() == MidiTime::stepPosition( _step )
+		if( ( *it )->pos() == TimePos::stepPosition( _step )
 						&& ( *it )->length() < 0 )
 		{
 			return *it;
@@ -298,8 +298,8 @@ void Pattern::clearNotes()
 
 Note * Pattern::addStepNote( int step )
 {
-	return addNote( Note( MidiTime( -DefaultTicksPerBar ),
-				MidiTime::stepPosition( step ) ), false );
+	return addNote( Note( TimePos( -DefaultTicksPerBar ),
+				TimePos::stepPosition( step ) ), false );
 }
 
 
@@ -417,7 +417,7 @@ void Pattern::loadSettings( const QDomElement & _this )
 	m_steps = _this.attribute( "steps" ).toInt();
 	if( m_steps == 0 )
 	{
-		m_steps = MidiTime::stepsPerBar();
+		m_steps = TimePos::stepsPerBar();
 	}
 
 	checkType();
@@ -466,7 +466,7 @@ void Pattern::clear()
 
 void Pattern::addSteps()
 {
-	m_steps += MidiTime::stepsPerBar();
+	m_steps += TimePos::stepsPerBar();
 	updateLength();
 	emit dataChanged();
 }
@@ -497,7 +497,7 @@ void Pattern::cloneSteps()
 
 void Pattern::removeSteps()
 {
-	int n = MidiTime::stepsPerBar();
+	int n = TimePos::stepsPerBar();
 	if( n < m_steps )
 	{
 		for( int i = m_steps - n; i < m_steps; ++i )
@@ -555,19 +555,19 @@ bool Pattern::empty()
 
 void Pattern::changeTimeSignature()
 {
-	MidiTime last_pos = MidiTime::ticksPerBar() - 1;
+	TimePos last_pos = TimePos::ticksPerBar() - 1;
 	for( NoteVector::ConstIterator cit = m_notes.begin();
 						cit != m_notes.end(); ++cit )
 	{
 		if( ( *cit )->length() < 0 && ( *cit )->pos() > last_pos )
 		{
-			last_pos = ( *cit )->pos()+MidiTime::ticksPerBar() /
-						MidiTime::stepsPerBar();
+			last_pos = ( *cit )->pos()+TimePos::ticksPerBar() /
+						TimePos::stepsPerBar();
 		}
 	}
-	last_pos = last_pos.nextFullBar() * MidiTime::ticksPerBar();
-	m_steps = qMax<tick_t>( MidiTime::stepsPerBar(),
-				last_pos.getBar() * MidiTime::stepsPerBar() );
+	last_pos = last_pos.nextFullBar() * TimePos::ticksPerBar();
+	m_steps = qMax<tick_t>( TimePos::stepsPerBar(),
+				last_pos.getBar() * TimePos::stepsPerBar() );
 	updateLength();
 }
 
@@ -909,7 +909,7 @@ void PatternView::paintEvent( QPaintEvent * )
 
 	// Length of one bar/beat in the [0,1] x [0,1] coordinate system
 	const float barLength = 1. / m_pat->length().getBar();
-	const float tickLength = barLength / MidiTime::ticksPerBar();
+	const float tickLength = barLength / TimePos::ticksPerBar();
 
 	const int x_base = TCO_BORDER_WIDTH;
 

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -122,7 +122,7 @@ SampleTCO::~SampleTCO()
 
 
 
-void SampleTCO::changeLength( const MidiTime & _length )
+void SampleTCO::changeLength( const TimePos & _length )
 {
 	TrackContentObject::changeLength( qMax( static_cast<int>( _length ), 1 ) );
 }
@@ -230,7 +230,7 @@ void SampleTCO::updateLength()
 
 
 
-MidiTime SampleTCO::sampleLength() const
+TimePos SampleTCO::sampleLength() const
 {
 	return (int)( m_sampleBuffer->frames() / Engine::framesPerTick() );
 }
@@ -612,7 +612,7 @@ SampleTrack::~SampleTrack()
 
 
 
-bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
+bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 					const f_cnt_t _offset, int _tco_num )
 {
 	m_audioPort.effects()->startRunning();
@@ -710,7 +710,7 @@ TrackView * SampleTrack::createView( TrackContainerView* tcv )
 
 
 
-TrackContentObject * SampleTrack::createTCO(const MidiTime & pos)
+TrackContentObject * SampleTrack::createTCO(const TimePos & pos)
 {
 	SampleTCO * sTco = new SampleTCO(this);
 	sTco->movePosition(pos);
@@ -926,10 +926,10 @@ void SampleTrackView::dropEvent(QDropEvent *de)
 				? trackHeadWidth
 				: de->pos().x();
 
-		MidiTime tcoPos = trackContainerView()->fixedTCOs()
-				? MidiTime(0)
-				: MidiTime(((xPos - trackHeadWidth) / trackContainerView()->pixelsPerBar()
-							* MidiTime::ticksPerBar()) + trackContainerView()->currentPosition()
+		TimePos tcoPos = trackContainerView()->fixedTCOs()
+				? TimePos(0)
+				: TimePos(((xPos - trackHeadWidth) / trackContainerView()->pixelsPerBar()
+							* TimePos::ticksPerBar()) + trackContainerView()->currentPosition()
 						).quantize(1.0);
 
 		SampleTCO * sTco = static_cast<SampleTCO*>(getTrack()->createTCO(tcoPos));

--- a/tests/src/tracks/AutomationTrackTest.cpp
+++ b/tests/src/tracks/AutomationTrackTest.cpp
@@ -141,20 +141,20 @@ private slots:
 				dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, song));
 
 		Pattern* notePattern = dynamic_cast<Pattern*>(instrumentTrack->createTCO(0));
-		notePattern->changeLength(MidiTime(4, 0));
-		Note* note = notePattern->addNote(Note(MidiTime(4, 0)), false);
+		notePattern->changeLength(TimePos(4, 0));
+		Note* note = notePattern->addNote(Note(TimePos(4, 0)), false);
 		note->createDetuning();
 
 		DetuningHelper* dh = note->detuning();
 		auto pattern = dh->automationPattern();
 		pattern->setProgressionType( AutomationPattern::LinearProgression );
-		pattern->putValue(MidiTime(0, 0), 0.0);
-		pattern->putValue(MidiTime(4, 0), 1.0);
+		pattern->putValue(TimePos(0, 0), 0.0);
+		pattern->putValue(TimePos(4, 0), 1.0);
 
-		QCOMPARE(pattern->valueAt(MidiTime(0, 0)), 0.0f);
-		QCOMPARE(pattern->valueAt(MidiTime(1, 0)), 0.25f);
-		QCOMPARE(pattern->valueAt(MidiTime(2, 0)), 0.5f);
-		QCOMPARE(pattern->valueAt(MidiTime(4, 0)), 1.0f);
+		QCOMPARE(pattern->valueAt(TimePos(0, 0)), 0.0f);
+		QCOMPARE(pattern->valueAt(TimePos(1, 0)), 0.25f);
+		QCOMPARE(pattern->valueAt(TimePos(2, 0)), 0.5f);
+		QCOMPARE(pattern->valueAt(TimePos(4, 0)), 1.0f);
 	}
 
 	void testBBTrack()
@@ -186,12 +186,12 @@ private slots:
 		QVERIFY(! bbContainer->automatedValuesAt(5, bbTrack2.index()).size());
 
 		BBTCO tco(&bbTrack);
-		tco.changeLength(MidiTime::ticksPerBar() * 2);
+		tco.changeLength(TimePos::ticksPerBar() * 2);
 		tco.movePosition(0);
 
 		QCOMPARE(song->automatedValuesAt(0)[&model], 0.0f);
 		QCOMPARE(song->automatedValuesAt(5)[&model], 0.5f);
-		QCOMPARE(song->automatedValuesAt(MidiTime::ticksPerBar() + 5)[&model], 0.5f);
+		QCOMPARE(song->automatedValuesAt(TimePos::ticksPerBar() + 5)[&model], 0.5f);
 	}
 
 	void testGlobalAutomation()


### PR DESCRIPTION
I redid #4897 because of the conflicts after merging #4878. Also includes `TimePos.h`'s include guard, `NotePlayHandle::processMidiTime` and some parameter names.