### PR TITLE
Fix browser 'Factory files' delimiter position

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -827,7 +827,6 @@ bool Directory::addItems(const QString & path )
 			{
 				addChild( new Directory( cur_file, path,
 								m_filter ) );
-				m_dirCount++;
 			}
 
 			added_something = true;


### PR DESCRIPTION
Fixes an issue where the factory file delimiter in the browser tree is placed wrong where there are user added directories. Lingering issue from #1150. Earlier fixed in #2665 and #1505.

Fixes #3183
