### PR TITLE
CircleCI: Test merged pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,14 @@ shared:
         mkdir -p /tmp/artifacts
         # Workaround for failing submodule fetching
         git config --global --unset url."ssh://git@github.com".insteadOf || true
+        if [[ -n "${CIRCLE_PR_NUMBER}" ]]
+        then
+            echo "Fetching out merged pull request"
+            git fetch -u origin refs/pull/${CIRCLE_PR_NUMBER}/merge:pr/merge
+            git checkout pr/merge
+        else
+            echo "Not a pull request"
+        fi
 
   # Commmon environment variables
   common_environment: &common_environment


### PR DESCRIPTION
In contrast to Travis, CircleCI only tests a PR's branch without merging it first, see https://ideas.circleci.com/ideas/CCI-I-926. With CircleCI's default behaviour, we can't know if a PR breaks tests after merging. This PR adds an init step that checks out the merged PR.

Unfortunately, this only works with PRs from forks.