### PR TITLE
Fix invalid memory read on opening the ZynAddSubFx GUI

### DIFF
--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -101,14 +101,14 @@ RemotePlugin::RemotePlugin() :
 
 	m_socketFile = QDir::tempPath() + QDir::separator() +
 						QUuid::createUuid().toString();
-	const char * path = m_socketFile.toUtf8().constData();
-	size_t length = strlen( path );
+	auto path = m_socketFile.toUtf8();
+	size_t length = path.length();
 	if ( length >= sizeof sa.sun_path )
 	{
 		length = sizeof sa.sun_path - 1;
 		qWarning( "Socket path too long." );
 	}
-	memcpy( sa.sun_path, path, length );
+	memcpy(sa.sun_path, path.constData(), length );
 	sa.sun_path[length] = '\0';
 
 	m_server = socket( PF_LOCAL, SOCK_STREAM, 0 );
@@ -116,7 +116,7 @@ RemotePlugin::RemotePlugin() :
 	{
 		qWarning( "Unable to start the server." );
 	}
-	remove( path );
+	remove(path.constData());
 	int ret = bind( m_server, (struct sockaddr *) &sa, sizeof sa );
 	if ( ret == -1 || listen( m_server, 1 ) == -1 )
 	{


### PR DESCRIPTION
This fixes some undefined behaviour. I'd guess it probably doesn't fix the issue I was looking for, where when exporting tracks a ZynAddSubFx window suddenly pops up, disappears and pops up again, once per track, and the instrument settings for a random instrument mysteriously gets reset to a plain sine wave. It also doesn't fix a mutex deadlock where `ZynAddSubFxInstrument::saveSettings` calls itself recursively, when closing a ZynAddSubFx window with the X while running under valgrind.

```
Calling .toUtf8().constData() returns a pointer which is deleted at the end of the statement.

Invalid read of size 1
   at 0x4839A42: __strlen_sse2 (vg_replace_strmem.c:461)
   by 0x2884E7: RemotePlugin::RemotePlugin() (in /lmms/build/lmms)
   by 0x281DD3C1: ZynAddSubFxRemotePlugin::ZynAddSubFxRemotePlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281DEC50: ZynAddSubFxInstrument::initPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2DC9: ZynAddSubFxInstrument::reloadPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2EA3: ZynAddSubFxView::toggleUI() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x699E59D: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3803)
   by 0x4B2B5E1: QAbstractButton::toggled(bool) (moc_qabstractbutton.cpp:319)
   by 0x4B2B9F0: QAbstractButtonPrivate::emitToggled(bool) (qabstractbutton.cpp:456)
   by 0x4B2CFB8: QAbstractButton::setChecked(bool) (qabstractbutton.cpp:649)
   by 0x4B2CADC: QAbstractButtonPrivate::click() (qabstractbutton.cpp:397)
   by 0x4B2CD14: QAbstractButton::mouseReleaseEvent(QMouseEvent*) (qabstractbutton.cpp:1011)
 Address 0x22833e58 is 24 bytes inside a block of size 128 free'd
   at 0x4837900: free (vg_replace_malloc.c:538)
   by 0x2886F3: RemotePlugin::RemotePlugin() (in /lmms/build/lmms)
   by 0x281DD3C1: ZynAddSubFxRemotePlugin::ZynAddSubFxRemotePlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281DEC50: ZynAddSubFxInstrument::initPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2DC9: ZynAddSubFxInstrument::reloadPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2EA3: ZynAddSubFxView::toggleUI() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x699E59D: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3803)
   by 0x4B2B5E1: QAbstractButton::toggled(bool) (moc_qabstractbutton.cpp:319)
   by 0x4B2B9F0: QAbstractButtonPrivate::emitToggled(bool) (qabstractbutton.cpp:456)
   by 0x4B2CFB8: QAbstractButton::setChecked(bool) (qabstractbutton.cpp:649)
   by 0x4B2CADC: QAbstractButtonPrivate::click() (qabstractbutton.cpp:397)
   by 0x4B2CD14: QAbstractButton::mouseReleaseEvent(QMouseEvent*) (qabstractbutton.cpp:1011)
 Block was alloc'd at
   at 0x4838B99: realloc (vg_replace_malloc.c:834)
   by 0x67F2D0B: reallocateData (qarraydata.cpp:83)
   by 0x67F2D0B: QArrayData::reallocateUnaligned(QArrayData*, unsigned long, unsigned long, QFlags<QArrayData::AllocationOption>) (qarraydata.cpp:146)
   by 0x67F48B1: reallocateUnaligned (qarraydata.h:232)
   by 0x67F48B1: QByteArray::reallocData(unsigned int, QFlags<QArrayData::AllocationOption>) (qbytearray.cpp:1914)
   by 0x67F4A6F: QByteArray::resize(int) (qbytearray.cpp:1875)
   by 0x69CA143: QUtf8::convertFromUnicode(QChar const*, int) (qutfcodec.cpp:396)
   by 0x6861C27: qt_convert_to_utf8 (qstring.cpp:5423)
   by 0x6861C27: QString::toUtf8_helper(QString const&) (qstring.cpp:5415)
   by 0x2884A9: RemotePlugin::RemotePlugin() (in /lmms/build/lmms)
   by 0x281DD3C1: ZynAddSubFxRemotePlugin::ZynAddSubFxRemotePlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281DEC50: ZynAddSubFxInstrument::initPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2DC9: ZynAddSubFxInstrument::reloadPlugin() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x281E2EA3: ZynAddSubFxView::toggleUI() (in /lmms/build/plugins/libzynaddsubfx.so)
   by 0x699E59D: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3803)
```
**Edited** by PhysSong: wrapped the output in a code block.