### PR TITLE
Fix remote plugin crash reading parameters from Grooove plugin

### DIFF
--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1072,7 +1072,7 @@ void RemoteVstPlugin::getParameterDump()
 
 	for( int i = 0; i < m_plugin->numParams; ++i )
 	{
-		char paramName[32];
+		char paramName[65];
 		memset( paramName, 0, sizeof( paramName ) );
 		pluginDispatch( effGetParamName, i, 0, paramName );
 		paramName[sizeof(paramName)-1] = 0;

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1072,7 +1072,7 @@ void RemoteVstPlugin::getParameterDump()
 
 	for( int i = 0; i < m_plugin->numParams; ++i )
 	{
-		char paramName[65];
+		char paramName[256];
 		memset( paramName, 0, sizeof( paramName ) );
 		pluginDispatch( effGetParamName, i, 0, paramName );
 		paramName[sizeof(paramName)-1] = 0;


### PR DESCRIPTION
Reported by `@Pigroy#0913` on Discord. The crash occurs when performing an action that reads parameters from the plugin, such as loading a project, or opening the control window. [Grooove](https://bedroomproducersblog.com/2016/12/23/grooove-bpb/) writes a 65-byte string in response to `effGetParamName`, but we only provide a 32-byte buffer, resulting in stack corruption.