### PR TITLE
Sampletrack activity indicator

### DIFF
--- a/include/FadeButton.h
+++ b/include/FadeButton.h
@@ -47,6 +47,7 @@ public:
 public slots:
 	void activate();
 	void noteEnd();
+	void notPlaying();
 
 
 protected:

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -29,6 +29,7 @@
 #include <QLayout>
 
 #include "AudioPort.h"
+#include "FadeButton.h"
 #include "FxMixer.h"
 #include "FxLineLcdSpinBox.h"
 #include "Track.h"
@@ -161,6 +162,10 @@ public:
 		return "sampletrack";
 	}
 
+signals:
+	void playing();
+	void notPlaying();
+
 public slots:
 	void updateTcos();
 	void setPlayingTcos( bool isPlaying );
@@ -171,6 +176,7 @@ private:
 	FloatModel m_panningModel;
 	IntModel m_effectChannelModel;
 	AudioPort m_audioPort;
+	bool m_wasPlaying;
 
 
 
@@ -230,6 +236,7 @@ private:
 	SampleTrackWindow * m_window;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
+	FadeButton * m_activityIndicator;
 
 	TrackLabelButton * m_tlb;
 

--- a/src/gui/widgets/FadeButton.cpp
+++ b/src/gui/widgets/FadeButton.cpp
@@ -100,6 +100,16 @@ void FadeButton::noteEnd()
 
 
 
+void FadeButton::notPlaying()
+{
+	activeNotes = 0;
+	m_releaseTimer.restart();
+	signalUpdate();
+}
+
+
+
+
 void FadeButton::customEvent(QEvent *)
 {
 	update();

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -592,7 +592,8 @@ SampleTrack::SampleTrack( TrackContainer* tc ) :
 	m_panningModel( DefaultPanning, PanningLeft, PanningRight, 0.1f,
 					this, tr( "Panning" ) ),
 	m_effectChannelModel( 0, 0, 0, this, tr( "FX channel" ) ),
-	m_audioPort( tr( "Sample track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel )
+	m_audioPort( tr( "Sample track" ), true, &m_volumeModel, &m_panningModel, &m_mutedModel ),
+	m_wasPlaying(false)
 {
 	setName( tr( "Sample track" ) );
 	m_panningModel.setCenterValue( DefaultPanning );
@@ -617,11 +618,17 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 {
 	m_audioPort.effects()->startRunning();
 	bool played_a_note = false;	// will be return variable
+	bool is_playing = false;
 
 	tcoVector tcos;
 	::BBTrack * bb_track = NULL;
 	if( _tco_num >= 0 )
 	{
+		if (m_wasPlaying && _start > getTCO(_tco_num)->length())
+		{
+			m_wasPlaying = false;
+			emit notPlaying();
+		}
 		if( _start != 0 )
 		{
 			return false;
@@ -630,6 +637,8 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 		if (trackContainer() == (TrackContainer*)Engine::getBBTrackContainer())
 		{
 			bb_track = BBTrack::findBBTrack( _tco_num );
+			m_wasPlaying = true;
+			emit playing();
 		}
 	}
 	else
@@ -641,6 +650,10 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 
 			if( _start >= sTco->startPosition() && _start < sTco->endPosition() )
 			{
+				if (sTco->isPlaying())
+				{
+					is_playing = true;
+				}
 				if( sTco->isPlaying() == false && _start > sTco->startPosition() + sTco->startTimeOffset() )
 				{
 					auto bufferFramesPerTick = Engine::framesPerTick (sTco->sampleBuffer ()->sampleRate ());
@@ -657,6 +670,7 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 						sTco->setSamplePlayLength( samplePlayLength );
 						tcos.push_back( sTco );
 						sTco->setIsPlaying( true );
+						is_playing = true;
 					}
 				}
 			}
@@ -665,6 +679,18 @@ bool SampleTrack::play( const MidiTime & _start, const fpp_t _frames,
 				sTco->setIsPlaying( false );
 			}
 		}
+
+		if (is_playing && !m_wasPlaying)
+		{
+			m_wasPlaying = true;
+			emit playing();
+		}
+		else if (!is_playing && m_wasPlaying)
+		{
+			m_wasPlaying = false;
+			emit notPlaying();
+		}
+
 	}
 
 	for( tcoVector::Iterator it = tcos.begin(); it != tcos.end(); ++it )
@@ -825,6 +851,22 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_panningKnob->move( settingsWidgetWidth - 24, 2 );
 	m_panningKnob->setLabel( tr( "PAN" ) );
 	m_panningKnob->show();
+
+	m_activityIndicator = new FadeButton(QApplication::palette().color(QPalette::Active,
+							QPalette::Background),
+						QApplication::palette().color(QPalette::Active,
+							QPalette::BrightText),
+						QApplication::palette().color(QPalette::Active,
+							QPalette::BrightText).darker(),
+						getTrackSettingsWidget());
+	m_activityIndicator->setGeometry(settingsWidgetWidth-2*24-11, 2, 8, 28);
+	m_activityIndicator->show();
+	connect(_t, SIGNAL(playing()),
+			 m_activityIndicator, SLOT(activate()));
+	connect(_t, SIGNAL(notPlaying()),
+			m_activityIndicator, SLOT(notPlaying()));
+	connect(Engine::getSong(), SIGNAL(stopped()),
+			m_activityIndicator, SLOT(notPlaying()));
 
 	setModel( _t );
 


### PR DESCRIPTION
My proposed implementation for the Sample Track activity indicator led.
When a sample track is playing samples it emits the corresponding signal to `FadeButton` that activates the button animation.
When It ceases playing samples it does the same with the signal `notPlaying()`.
This is a work in progress, the behaviour is missing when the track is muted (maybe the same as `InstrumentTrack`, that is, the button fades in to another color), and the action when the led is pressed.
Suggestions for these?

