### PR TITLE
Automation Editor - Prevent dragging last point when drawing line

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -240,6 +240,7 @@ private:
 
 	EditModes m_editMode;
 
+	bool m_mouseDownLeft;
 	bool m_mouseDownRight; //true if right click is being held down
 
 	TimeLineWidget * m_timeLine;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -96,6 +96,7 @@ AutomationEditor::AutomationEditor() :
 	m_y_delta( DEFAULT_Y_DELTA ),
 	m_y_auto( true ),
 	m_editMode( DRAW ),
+	m_mouseDownLeft(false),
 	m_mouseDownRight( false ),
 	m_scrollBack( false ),
 	m_barLineColor( 0, 0, 0 ),
@@ -539,6 +540,10 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 				++it;
 			}
 
+			if (mouseEvent->button() == Qt::LeftButton)
+			{
+				m_mouseDownLeft = true;
+			}
 			if( mouseEvent->button() == Qt::RightButton )
 			{
 				m_mouseDownRight = true;
@@ -555,6 +560,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 					drawLine( m_drawLastTick,
 							m_drawLastLevel,
 							pos_ticks, level );
+					m_mouseDownLeft = false;
 				}
 				m_drawLastTick = pos_ticks;
 				m_drawLastLevel = level;
@@ -657,6 +663,11 @@ void AutomationEditor::mouseReleaseEvent(QMouseEvent * mouseEvent )
 {
 	bool mustRepaint = false;
 
+	if (mouseEvent->button() == Qt::LeftButton)
+	{
+		m_mouseDownLeft = false;
+		mustRepaint = true;
+	}
 	if ( mouseEvent->button() == Qt::RightButton )
 	{
 		m_mouseDownRight = false;
@@ -742,7 +753,8 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 
 		int pos_ticks = x * MidiTime::ticksPerBar() / m_ppb +
 							m_currentPosition;
-		if( mouseEvent->buttons() & Qt::LeftButton && m_editMode == DRAW )
+		// m_mouseDownLeft used to prevent drag when drawing line
+		if (m_mouseDownLeft && m_editMode == DRAW)
 		{
 			if( m_action == MOVE_VALUE )
 			{


### PR DESCRIPTION
Resolves #4040 

> When you draw a line the last automation point drawn is selected and ready to be dragged. This is a bit unintuitive and can lead to some unexpected results which is especially prone to happen if you work fast.
-zonkmachine 

After a line is drawn, when the user still has their finger on the left mouse button, and the mouse is moved, it is considered a drag, since the button is down when in edit mode.  Using `applyDragValue` and setting `m_action=NONE` after the `drawLine` command doesn't work, because as soon as the mouse is moved, the point is dragged.  Bypassing the drag with the shift key doesn't work, because it's set in `mousePressEvent` and as soon as the shift key is let go, a new line is drawn to the the cursor.

It seems that the main problem is the fact that the point gets dragged when the mouse button is down, so this fix disables the drag in `mouseMoveEvent` by replacing `mouseEvent->buttons() & Qt::LeftButton` with a variable called `m_mouseDownLeft`.  This way the variable can be set to `false` right after `drawLine` is called, and will return to `true` when the mouse button is clicked again.

-  create `m_mouseDownLeft`
-  set it to true in `mousePressEvent` when it's pressed
-   set it to false right under the `drawLine` call in `mousePressEvent`
-   set it to false again when released in `mouseReleaseEvent`
-   replace the first `mouseEvent->buttons() & Qt::LeftButton` with `m_mouseDownLeft` in `mouseMoveEvent` where it checks for condition of the left mouse button and `DRAW` mode (before the other `drawLine` call)
