### PR TITLE
Automation point drag cancel with right click

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -223,6 +223,8 @@ private:
 	float m_selectStartLevel;
 	float m_selectedLevels;
 
+	float m_dragStartLevel;
+	tick_t m_dragStartTick;
 	float m_moveStartLevel;
 	tick_t m_moveStartTick;
 	int m_moveXOffset;


### PR DESCRIPTION
Resolves #4671 

- The issue does not seem to affect other functions.
- A "deleting while dragging" feature does not seem worth redesigning other functions
- The buggy scenario can be resolved by this "cancel drag" feature

This feature uses two variables to record the location of the point at the start of the drag

- `float m_dragStartLevel`
- `tick_t m_dragStartTick`

They are assigned the point location in `mousePressEvent`

```
	if( mouseEvent->button() == Qt::LeftButton &&
					m_editMode == DRAW )
	{
		m_pattern->addJournalCheckPoint();
		m_dragStartLeve = level;
		m_dragStartTick = pos_ticks;
```

When right mouse button is clicked, and `m_action` is `MOVE_VALUE`, the stored point location is sent to `setDragValue` to move the point back to it's original position, then apply dragValue is called to stop dragging.

```
	if (m_action == MOVE_VALUE)
	{
		m_pattern->setDragValue(MidiTime(m_dragStartTick), m_dragStartLevel,
			true, false);
		m_pattern->applyDragValue();
	}
```

Now the cursor is over another point, and `m_action` is still `MOVE_VALUE`, and both mouse buttons are down, this condition allows dragging in `mouseMoveEvent`, so we want to prevent dragging in this case

```
	if (mouseEvent->buttons() & Qt::LeftButton
		// right button held when cancelling drag
		&& !(mouseEvent->buttons() & Qt::RightButton)
		&& m_editMode == DRAW )
	{
```

Now that we've prevented dragging, while both buttons are down, also in `mouseMoveEvent`, the condition to erase is met, so we don't want to erase a bunch of stuff on accident

```
	// drag erase
	else if ((mouseEvent->buttons() & Qt::RightButton
		// don't want to erase when cancelling drag with left held
		&& !(mouseEvent->buttons() & Qt::LeftButton)
		&& m_editMode == DRAW)
		|| (mouseEvent->buttons() & Qt::LeftButton
		&& m_editMode == ERASE))
	{
```

Finally, in `paintEvent`, where the cursor is changed, we're not erasing, so we want to switch back to the draw tool when the drag is cancelled.  That means the erase tool normally shows when the right mouse button is down, but we make an exception for when `m_action` is `MOVE_VALUE`, which is true until either button is released.

So, when we cancel a drag...
- if the right mouse button is released (left still down) cursor becomes draw tool
- if the left mouse button is released (right still down) cursor becomes erase tool

```
	if (m_mouseDownRight && m_action != MOVE_VALUE)
	{
		cursor = s_toolErase;
	}
	else if (m_action == MOVE_VALUE)
	{
		cursor = s_toolMove;
		if (m_mouseDownRight)
		{
			cursor = s_toolDraw;
		}
		else
		{
			cursor = s_toolMove;
		}
	}
```