### PR TITLE
Implement compress action for commandline use

### DIFF
--- a/doc/bash-completion/lmms
+++ b/doc/bash-completion/lmms
@@ -89,7 +89,7 @@ _lmms()
     pars_render=(--float --bitrate --format --interpolation)
     pars_render+=(--loop --mode --output --profile)
     pars_render+=(--samplerate --oversampling)
-    actions=(dump render rendertracks upgrade)
+    actions=(dump compress render rendertracks upgrade)
     actions_old=(-d --dump -r --render --rendertracks -u --upgrade)
     shortargs+=(-a -b -c -f -h -i -l -m -o -p -s -v -x)
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -161,7 +161,7 @@ void printHelp()
 		"Actions:\n"
 		"  <no action> [options...] [<project>]  Start LMMS in normal GUI mode\n"
 		"  dump <in>                             Dump XML of compressed file <in>\n"
-		"  compress <in>                         Compress file <n>\n"
+		"  compress <in>                         Compress file <in>\n"
 		"  render <project> [options...]         Render given project file\n"
 		"  rendertracks <project> [options...]   Render each track to a different file\n"
 		"  upgrade <in> [out]                    Upgrade file <in> and save as <out>\n"

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -161,6 +161,7 @@ void printHelp()
 		"Actions:\n"
 		"  <no action> [options...] [<project>]  Start LMMS in normal GUI mode\n"
 		"  dump <in>                             Dump XML of compressed file <in>\n"
+		"  compress <in>                         Compress file <n>\n"
 		"  render <project> [options...]         Render given project file\n"
 		"  rendertracks <project> [options...]   Render each track to a different file\n"
 		"  upgrade <in> [out]                    Upgrade file <in> and save as <out>\n"
@@ -424,6 +425,22 @@ int main( int argc, char * * argv )
 			f.open( QIODevice::ReadOnly );
 			QString d = qUncompress( f.readAll() );
 			printf( "%s\n", d.toUtf8().constData() );
+
+			return EXIT_SUCCESS;
+		}
+		else if( arg == "compress" || arg == "--compress")
+		{
+			++i;
+
+			if( i == argc )
+			{
+				return noInputFileError();
+			}
+			
+			QFile f( QString::fromLocal8Bit( argv[i] ) );
+			f.open( QIODevice::ReadOnly);
+			QByteArray d = qCompress( f.readAll() ) ;
+			fwrite( d.constData(), sizeof(char), d.size(), stdout );
 
 			return EXIT_SUCCESS;
 		}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -428,7 +428,7 @@ int main( int argc, char * * argv )
 
 			return EXIT_SUCCESS;
 		}
-		else if( arg == "compress" || arg == "--compress")
+		else if( arg == "compress" || arg == "--compress" )
 		{
 			++i;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -438,7 +438,7 @@ int main( int argc, char * * argv )
 			}
 			
 			QFile f( QString::fromLocal8Bit( argv[i] ) );
-			f.open( QIODevice::ReadOnly);
+			f.open( QIODevice::ReadOnly );
 			QByteArray d = qCompress( f.readAll() ) ;
 			fwrite( d.constData(), sizeof(char), d.size(), stdout );
 


### PR DESCRIPTION
Fixes the issue: #5290 
Added compress commandline action to allow conversion from mmp to mmpz
Usage: `lmms --compress infile.mmp > outfile.mmpz`