### PR TITLE
Make MIDI controller's buttons assignable

### DIFF
--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -78,8 +78,7 @@ protected slots:
 private:
 	// Midi
 	GroupBox * m_midiGroupBox;
-	LedCheckBox * m_midiEventIsCC;
-	LedCheckBox * m_midiEventIsKey;
+	ComboBox * m_midiEventType;
 	LcdSpinBox * m_midiChannelSpinBox;
 	LcdSpinBox * m_midiControllerSpinBox;
 	LedCheckBox * m_midiAutoDetectCheckBox;

--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -78,6 +78,8 @@ protected slots:
 private:
 	// Midi
 	GroupBox * m_midiGroupBox;
+	LedCheckBox * m_midiEventIsCC;
+	LedCheckBox * m_midiEventIsKey;
 	LcdSpinBox * m_midiChannelSpinBox;
 	LcdSpinBox * m_midiControllerSpinBox;
 	LedCheckBox * m_midiAutoDetectCheckBox;

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -33,13 +33,35 @@
 #include "Midi.h"
 #include "MidiTime.h"
 #include "AutomatableModel.h"
-
+#include "ComboBoxModel.h"
 
 class MidiClient;
 class MidiEvent;
 class MidiEventProcessor;
 class MidiPortMenu;
 
+class MidiPortEventModel : public ComboBoxModel
+{
+public:
+	enum Values
+	{
+		EventCC = 0,
+		EventKeyOnOnly,
+		EventKeyOnOffBinary,
+
+		EventLast
+	};
+	MidiPortEventModel(Model* parent = NULL,
+				Values defaultValue = EventCC,
+				const QString& displayName = QString()) :
+		ComboBoxModel(parent, displayName, true)
+	{
+		this->addItem(tr("Continuous Controller"));
+		this->addItem(tr("Note On (toggling)"));
+		this->addItem(tr("Note On and Off (binary)"));
+		this->setValue(defaultValue);
+	}
+};
 
 // class for abstraction of MIDI-port
 class MidiPort : public Model, public SerializingObject
@@ -47,8 +69,8 @@ class MidiPort : public Model, public SerializingObject
 	Q_OBJECT
 	mapPropertyFromModel(int,inputChannel,setInputChannel,m_inputChannelModel);
 	mapPropertyFromModel(int,outputChannel,setOutputChannel,m_outputChannelModel);
-	mapPropertyFromModel(bool,inputControllerIsKey,setInputControllerIsKey,m_inputControllerIsKeyModel);
-	mapPropertyFromModel(bool,inputControllerIsCC,setInputControllerIsCC,m_inputControllerIsCCModel);
+	mapPropertyFromModel(MidiPortEventModel::Values, inputControllerEventType,
+			     setInputControllerEventType,m_inputControllerEventTypeModel);
 	mapPropertyFromModel(int,inputController,setInputController,m_inputControllerModel);
 	mapPropertyFromModel(int,outputController,setOutputController,m_outputControllerModel);
 	mapPropertyFromModel(int,fixedInputVelocity,setFixedInputVelocity,m_fixedInputVelocityModel);
@@ -150,8 +172,7 @@ private:
 
 	IntModel m_inputChannelModel;
 	IntModel m_outputChannelModel;
-	BoolModel m_inputControllerIsKeyModel;
-	BoolModel m_inputControllerIsCCModel;
+	MidiPortEventModel m_inputControllerEventTypeModel;
 	IntModel m_inputControllerModel;
 	IntModel m_outputControllerModel;
 	IntModel m_fixedInputVelocityModel;

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -45,20 +45,20 @@ class MidiPortEventModel : public ComboBoxModel
 public:
 	enum Values
 	{
-		EventCC = 0,
-		EventKeyOnOnly,
-		EventKeyOnOffBinary,
+		EventControlChange = 0,
+		EventNoteOn,
+		EventNoteOnOff,
 
 		EventLast
 	};
 	MidiPortEventModel(Model* parent = NULL,
-				Values defaultValue = EventCC,
+				Values defaultValue = EventControlChange,
 				const QString& displayName = QString()) :
 		ComboBoxModel(parent, displayName, true)
 	{
-		this->addItem(tr("Continuous Controller"));
-		this->addItem(tr("Note On (toggling)"));
-		this->addItem(tr("Note On and Off (binary)"));
+		this->addItem(tr("Knob or slider position"));
+		this->addItem(tr("Key or button press"));
+		this->addItem(tr("Key or button press or release"));
 		this->setValue(defaultValue);
 	}
 };

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -47,6 +47,8 @@ class MidiPort : public Model, public SerializingObject
 	Q_OBJECT
 	mapPropertyFromModel(int,inputChannel,setInputChannel,m_inputChannelModel);
 	mapPropertyFromModel(int,outputChannel,setOutputChannel,m_outputChannelModel);
+	mapPropertyFromModel(bool,inputControllerIsKey,setInputControllerIsKey,m_inputControllerIsKeyModel);
+	mapPropertyFromModel(bool,inputControllerIsCC,setInputControllerIsCC,m_inputControllerIsCCModel);
 	mapPropertyFromModel(int,inputController,setInputController,m_inputControllerModel);
 	mapPropertyFromModel(int,outputController,setOutputController,m_outputControllerModel);
 	mapPropertyFromModel(int,fixedInputVelocity,setFixedInputVelocity,m_fixedInputVelocityModel);
@@ -148,6 +150,8 @@ private:
 
 	IntModel m_inputChannelModel;
 	IntModel m_outputChannelModel;
+	BoolModel m_inputControllerIsKeyModel;
+	BoolModel m_inputControllerIsCCModel;
 	IntModel m_inputControllerModel;
 	IntModel m_outputControllerModel;
 	IntModel m_fixedInputVelocityModel;

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -176,21 +176,21 @@ void MidiAlsaSeq::processOutEvent( const MidiEvent& event, const MidiTime& time,
 		case MidiNoteOn:
 			snd_seq_ev_set_noteon( &ev,
 						event.channel(),
-						event.key() + KeysPerOctave,
+						event.key(),
 						event.velocity() );
 			break;
 
 		case MidiNoteOff:
 			snd_seq_ev_set_noteoff( &ev,
 						event.channel(),
-						event.key() + KeysPerOctave,
+						event.key(),
 						event.velocity() );
 			break;
 
 		case MidiKeyPressure:
 			snd_seq_ev_set_keypress( &ev,
 						event.channel(),
-						event.key() + KeysPerOctave,
+						event.key(),
 						event.velocity() );
 			break;
 
@@ -531,8 +531,7 @@ void MidiAlsaSeq::run()
 				case SND_SEQ_EVENT_NOTEON:
 					dest->processInEvent( MidiEvent( MidiNoteOn,
 								ev->data.note.channel,
-								ev->data.note.note -
-								KeysPerOctave,
+								ev->data.note.note,
 								ev->data.note.velocity,
 								source
 								),
@@ -542,8 +541,7 @@ void MidiAlsaSeq::run()
 				case SND_SEQ_EVENT_NOTEOFF:
 					dest->processInEvent( MidiEvent( MidiNoteOff,
 								ev->data.note.channel,
-								ev->data.note.note -
-								KeysPerOctave,
+								ev->data.note.note,
 								ev->data.note.velocity,
 								source
 								),
@@ -554,8 +552,7 @@ void MidiAlsaSeq::run()
 					dest->processInEvent( MidiEvent(
 									MidiKeyPressure,
 								ev->data.note.channel,
-								ev->data.note.note -
-								KeysPerOctave,
+								ev->data.note.note,
 								ev->data.note.velocity,
 								source
 								), MidiTime() );

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -223,7 +223,7 @@ void MidiClientRaw::parseData( const unsigned char c )
 		case MidiNoteOn:
 		case MidiKeyPressure:
 		case MidiChannelPressure:
-			m_midiParseData.m_midiEvent.setKey( m_midiParseData.m_buffer[0] - KeysPerOctave );
+			m_midiParseData.m_midiEvent.setKey( m_midiParseData.m_buffer[0] );
 			m_midiParseData.m_midiEvent.setVelocity( m_midiParseData.m_buffer[1] );
 			break;
 

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -84,7 +84,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 {
 	unsigned char controllerNum;
 	int expectedChannel = m_midiPort.inputChannel();
-	MidiPortEventModel::Values linkEventType
+	MidiPortEventModel::Values portEvent
 			= m_midiPort.inputControllerEventType();
 	if (expectedChannel != event.channel() + 1  && expectedChannel != 0)
 	{
@@ -95,7 +95,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 		case MidiControlChange:
 			controllerNum = event.controllerNumber();
 
-			if(linkEventType == MidiPortEventModel::EventCC &&
+			if(portEvent == MidiPortEventModel::EventControlChange &&
 				m_midiPort.inputController() == controllerNum + 1)
 			{
 				unsigned char val = event.controllerValue();
@@ -111,7 +111,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 
 		case MidiNoteOn:
 			controllerNum = event.key();
-			if (linkEventType == MidiPortEventModel::EventKeyOnOnly &&
+			if (portEvent == MidiPortEventModel::EventNoteOn &&
 				m_midiPort.inputController() == controllerNum + 1)
 			{
 				m_previousValue = m_lastValue;
@@ -128,7 +128,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 					emit valueChanged();
 				}
 			}
-			if (linkEventType == MidiPortEventModel::EventKeyOnOffBinary &&
+			if (portEvent == MidiPortEventModel::EventNoteOnOff &&
 				m_midiPort.inputController() == controllerNum + 1)
 			{
 				m_previousValue = m_lastValue;
@@ -143,7 +143,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 
 		case MidiNoteOff:
 			controllerNum = event.key();
-			if (linkEventType == MidiPortEventModel::EventKeyOnOffBinary &&
+			if (portEvent == MidiPortEventModel::EventNoteOnOff &&
 				m_midiPort.inputController() == controllerNum + 1)
 			{
 				m_previousValue = m_lastValue;

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -174,6 +174,7 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 	m_inputChannelModel.saveSettings( doc, thisElement, "inputchannel" );
 	m_outputChannelModel.saveSettings( doc, thisElement, "outputchannel" );
 	m_inputControllerModel.saveSettings( doc, thisElement, "inputcontroller" );
+	m_inputControllerIsKeyModel.saveSettings( doc, thisElement, "inputcontrolleriskey" );
 	m_outputControllerModel.saveSettings( doc, thisElement, "outputcontroller" );
 	m_fixedInputVelocityModel.saveSettings( doc, thisElement, "fixedinputvelocity" );
 	m_fixedOutputVelocityModel.saveSettings( doc, thisElement, "fixedoutputvelocity" );
@@ -228,6 +229,7 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_inputChannelModel.loadSettings( thisElement, "inputchannel" );
 	m_outputChannelModel.loadSettings( thisElement, "outputchannel" );
 	m_inputControllerModel.loadSettings( thisElement, "inputcontroller" );
+	m_inputControllerIsKeyModel.loadSettings(thisElement, "inputcontrolleriskey");
 	m_outputControllerModel.loadSettings( thisElement, "outputcontroller" );
 	m_fixedInputVelocityModel.loadSettings( thisElement, "fixedinputvelocity" );
 	m_fixedOutputVelocityModel.loadSettings( thisElement, "fixedoutputvelocity" );

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -174,7 +174,7 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 	m_inputChannelModel.saveSettings( doc, thisElement, "inputchannel" );
 	m_outputChannelModel.saveSettings( doc, thisElement, "outputchannel" );
 	m_inputControllerModel.saveSettings( doc, thisElement, "inputcontroller" );
-	m_inputControllerIsKeyModel.saveSettings( doc, thisElement, "inputcontrolleriskey" );
+	m_inputControllerEventTypeModel.saveSettings( doc, thisElement, "inputctrleventtype" );
 	m_outputControllerModel.saveSettings( doc, thisElement, "outputcontroller" );
 	m_fixedInputVelocityModel.saveSettings( doc, thisElement, "fixedinputvelocity" );
 	m_fixedOutputVelocityModel.saveSettings( doc, thisElement, "fixedoutputvelocity" );
@@ -229,7 +229,7 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_inputChannelModel.loadSettings( thisElement, "inputchannel" );
 	m_outputChannelModel.loadSettings( thisElement, "outputchannel" );
 	m_inputControllerModel.loadSettings( thisElement, "inputcontroller" );
-	m_inputControllerIsKeyModel.loadSettings(thisElement, "inputcontrolleriskey");
+	m_inputControllerEventTypeModel.loadSettings( thisElement, "inputctrleventtype" );
 	m_outputControllerModel.loadSettings( thisElement, "outputcontroller" );
 	m_fixedInputVelocityModel.loadSettings( thisElement, "fixedinputvelocity" );
 	m_fixedOutputVelocityModel.loadSettings( thisElement, "fixedoutputvelocity" );

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -91,6 +91,7 @@ public:
 		c->m_midiPort.setInputChannel( m_midiPort.inputChannel() );
 		c->m_midiPort.setInputController( m_midiPort.inputController() );
 		c->m_midiPort.setInputControllerIsKey(m_midiPort.inputControllerIsKey());
+		c->m_midiPort.setInputControllerIsCC(m_midiPort.inputControllerIsCC());
 		c->subscribeReadablePorts( m_midiPort.readablePorts() );
 		c->updateName();
 

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -51,7 +51,7 @@ class AutoDetectMidiController : public MidiController
 public:
 	AutoDetectMidiController( Model* parent ) :
 		MidiController( parent ),
-		m_detectedMidiEvent(MidiPortEventModel::EventCC),
+		m_detectedMidiEvent(MidiPortEventModel::EventControlChange),
 		m_detectedMidiChannel(0),
 		m_detectedMidiController(0)
 	{
@@ -61,6 +61,19 @@ public:
 
 	virtual ~AutoDetectMidiController()
 	{
+	}
+
+	void setDetectedMidiEvent(MidiEventTypes eventType)
+	{
+		MidiPortEventModel::Values& detectedEvt = m_detectedMidiEvent;
+		if (eventType == MidiControlChange)
+		{
+			detectedEvt = MidiPortEventModel::EventControlChange;
+		}
+		else if (eventType == MidiNoteOn)
+		{
+			detectedEvt = MidiPortEventModel::EventNoteOn;
+		}
 	}
 
 
@@ -73,18 +86,7 @@ public:
 				event.type() == MidiNoteOn )
 			{
 				m_detectedMidiChannel = event.channel() + 1;
-
-				if (event.type() == MidiControlChange)
-				{
-					m_detectedMidiEvent = MidiPortEventModel::EventCC;
-				}
-				else if (event.type() == MidiNoteOn &&
-					m_detectedMidiEvent != MidiPortEventModel::EventKeyOnOnly &&
-					m_detectedMidiEvent != MidiPortEventModel::EventKeyOnOffBinary)
-				{
-					m_detectedMidiEvent = MidiPortEventModel::EventKeyOnOnly;
-				}
-
+				setDetectedMidiEvent(event.type());
 				m_detectedMidiController = event.controllerNumber() + 1;
 				m_detectedMidiPort = Engine::mixer()->midiClient()->sourcePortName( event );
 
@@ -101,7 +103,8 @@ public:
 		MidiController* c = new MidiController( parent );
 		c->m_midiPort.setInputChannel( m_midiPort.inputChannel() );
 		c->m_midiPort.setInputController( m_midiPort.inputController() );
-		c->m_midiPort.setInputControllerEventType(m_midiPort.inputControllerEventType());
+		c->m_midiPort.setInputControllerEventType(
+					m_midiPort.inputControllerEventType());
 		c->subscribeReadablePorts( m_midiPort.readablePorts() );
 		c->updateName();
 
@@ -128,7 +131,7 @@ public slots:
 	void reset()
 	{
 		m_midiPort.setInputControllerEventType(
-					MidiPortEventModel::EventCC);
+					MidiPortEventModel::EventControlChange);
 		m_midiPort.setInputChannel( 0 );
 		m_midiPort.setInputController( 0 );
 	}
@@ -165,8 +168,8 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	connect( m_midiGroupBox->model(), SIGNAL( dataChanged() ),
 			this, SLOT( midiToggled() ) );
 
-	m_midiEventType = new ComboBox(m_midiGroupBox, "Event type");
-	m_midiEventType->setGeometry(8, 24, 180, 22);
+	m_midiEventType = new ComboBox(m_midiGroupBox, tr("Event type"));
+	m_midiEventType->setGeometry(8, 24, 200, 22);
 
 	m_midiChannelSpinBox = new LcdSpinBox( 2, m_midiGroupBox,
 			tr( "Input channel" ) );


### PR DESCRIPTION
Adds a possibility to assign keys or buttons to automatable controls.

While some MIDI keyboards allow assigning push buttons to CCs, other MIDI devices such as AKAI Midimix trigger Note On and Note Off messages. In current implementation it is not possible to link those buttons with on-screen controls. One can use a slider or a knob instead, but a physical push button is much more relevant for on-off switches, especially when working with plugins such as OpulenZ that exposes 11 "LEDs".

The change proposed adds two modes of operation when dealing with Note On and Note Off messages:
 - each consecutive Note On message behaves as CC toggling between extreme values (0 and 127)
 - each Note On message behaves as CC set to value of 127, each Note Off acts as CC reset to 0

Change in scope of #1472 (proposed by me in a comment), it also addresses #1815.

Note: I had to remove the infamous octave-shifting code from MIDI clients, however I see that some proper solution is now being worked on in #5349. Maybe the aforementioned change needs to be merged first, then this PR should be rebased on top of it.