### PR TITLE
Custom note labels in Pianoroll editor

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -152,6 +152,20 @@ public:
 		return m_gigDir;
 	}
 
+	const QString & labels1Dir() const
+	{
+		return m_labels1Dir;
+	}
+	
+	const QString & labels2Dir() const
+	{
+		return m_labels2Dir;
+	}
+	
+	const QString & labels3Dir() const
+	{
+		return m_labels3Dir;
+	}
 
 	QString userVstDir() const
 	{
@@ -246,7 +260,10 @@ public:
 	void setGIGDir(const QString & gigDir);
 	void setThemeDir(const QString & themeDir);
 	void setBackgroundPicFile(const QString & backgroundPicFile);
-
+	void setLabels1Dir(const QString & labels1Dir);
+	void setLabels2Dir(const QString & labels2Dir);
+	void setLabels3Dir(const QString & labels3Dir);
+	
 	// Creates the working directory & subdirectories on disk.
 	void createWorkingDir();
 
@@ -276,6 +293,9 @@ private:
 	QString m_stkDir;
 #endif
 	QString m_gigDir;
+	QString m_labels1Dir;
+	QString m_labels2Dir;
+	QString m_labels3Dir;
 	QString m_themeDir;
 	QString m_backgroundPicFile;
 	QString m_lmmsRcFile;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -30,6 +30,8 @@
 #include <QVector>
 #include <QWidget>
 #include <QInputDialog>
+#include <QFile>
+#include <QTextStream>
 
 #include "Editor.h"
 #include "ComboBoxModel.h"
@@ -218,6 +220,7 @@ protected slots:
 
 	void zoomingChanged();
 	void quantizeChanged();
+	void labelsChanged();
 	void noteLengthChanged();
 	void quantizeNotes();
 
@@ -331,6 +334,7 @@ private:
 
 	ComboBoxModel m_zoomingModel;
 	ComboBoxModel m_quantizeModel;
+	ComboBoxModel m_labelsModel;
 	ComboBoxModel m_noteLenModel;
 	ComboBoxModel m_scaleModel;
 	ComboBoxModel m_chordModel;
@@ -414,7 +418,12 @@ private:
 
 	// did we start a mouseclick with shift pressed
 	bool m_startedWithShift;
-
+	
+	bool labelsPathCorrect( QString labelsPath );
+	bool labelsFile1Correct;
+	bool labelsFile2Correct;
+	bool labelsFile3Correct;
+	
 	friend class PianoRollWindow;
 
 	StepRecorderWidget m_stepRecorderWidget;
@@ -502,6 +511,7 @@ private:
 
 	ComboBox * m_zoomingComboBox;
 	ComboBox * m_quantizeComboBox;
+	ComboBox * m_labelsComboBox;
 	ComboBox * m_noteLenComboBox;
 	ComboBox * m_scaleComboBox;
 	ComboBox * m_chordComboBox;

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -117,6 +117,12 @@ private slots:
 	void setThemeDir(const QString & themeDir);
 	void openBackgroundPicFile();
 	void setBackgroundPicFile(const QString & backgroundPicFile);
+	void openLabels1Dir();
+	void setLabels1Dir(const QString & labels1Dir);
+	void openLabels2Dir();
+	void setLabels2Dir(const QString & labels2Dir);
+	void openLabels3Dir();
+	void setLabels3Dir(const QString & labels3Dir);
 
 	void showRestartWarning();
 
@@ -185,6 +191,9 @@ private:
 #endif
 	QString m_themeDir;
 	QString m_backgroundPicFile;
+	QString m_labels1Dir;
+	QString m_labels2Dir;
+	QString m_labels3Dir;
 
 	QLineEdit * m_workingDirLineEdit;
 	QLineEdit * m_vstDirLineEdit;
@@ -196,6 +205,9 @@ private:
 	QLineEdit * m_sf2FileLineEdit;
 #endif
 	QLineEdit * m_backgroundPicFileLineEdit;
+	QLineEdit * m_labels1DirLineEdit;
+	QLineEdit * m_labels2DirLineEdit;
+	QLineEdit * m_labels3DirLineEdit;
 
 	QLabel * restartWarningLbl;
 };

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -303,6 +303,30 @@ void ConfigManager::setBackgroundPicFile(const QString & backgroundPicFile)
 
 
 
+void ConfigManager::setLabels1Dir(const QString & labels1Dir)
+{
+	m_labels1Dir = labels1Dir;
+}
+
+
+
+
+void ConfigManager::setLabels2Dir(const QString & labels2Dir)
+{
+	m_labels2Dir = labels2Dir;
+}
+
+
+
+
+void ConfigManager::setLabels3Dir(const QString & labels3Dir)
+{
+	m_labels3Dir = labels3Dir;
+}
+
+
+
+
 void ConfigManager::createWorkingDir()
 {
 	QDir().mkpath(m_workingDir);
@@ -509,6 +533,9 @@ void ConfigManager::loadConfigFile(const QString & configFile)
 			setSF2File(value("paths", "defaultsf2"));
 		#endif
 			setBackgroundPicFile(value("paths", "backgroundtheme"));
+			setLabels1Dir(value("paths", "labels1Dir"));
+			setLabels2Dir(value("paths", "labels2Dir"));
+			setLabels3Dir(value("paths", "labels3Dir"));
 		}
 		else if(gui)
 		{
@@ -595,6 +622,9 @@ void ConfigManager::saveConfigFile()
 	setValue("paths", "defaultsf2", m_sf2File);
 #endif
 	setValue("paths", "backgroundtheme", m_backgroundPicFile);
+	setValue("paths", "labels1Dir", m_labels1Dir);
+	setValue("paths", "labels2Dir", m_labels2Dir);
+	setValue("paths", "labels3Dir", m_labels3Dir);
 
 	QDomDocument doc("lmms-config-file");
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -30,6 +30,8 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QScrollArea>
+#include <QTextStream>
+#include <QFile>
 
 #include "debug.h"
 #include "embed.h"
@@ -143,7 +145,10 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_sf2File(QDir::toNativeSeparators(ConfigManager::inst()->sf2File())),
 #endif
 	m_themeDir(QDir::toNativeSeparators(ConfigManager::inst()->themeDir())),
-	m_backgroundPicFile(QDir::toNativeSeparators(ConfigManager::inst()->backgroundPicFile()))
+	m_backgroundPicFile(QDir::toNativeSeparators(ConfigManager::inst()->backgroundPicFile())),
+	m_labels1Dir(QDir::toNativeSeparators(ConfigManager::inst()->labels1Dir())),
+	m_labels2Dir(QDir::toNativeSeparators(ConfigManager::inst()->labels2Dir())),
+	m_labels3Dir(QDir::toNativeSeparators(ConfigManager::inst()->labels3Dir()))
 {
 	setWindowIcon(embed::getIconPixmap("setup_general"));
 	setWindowTitle(tr("Settings"));
@@ -766,7 +771,18 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		SLOT(setBackgroundPicFile(const QString &)),
 		SLOT(openBackgroundPicFile()),
 		m_backgroundPicFileLineEdit);
-
+	addPathEntry("Piano roll custom labels 1", m_labels1Dir,
+		SLOT(setLabels1Dir(const QString &)),
+		SLOT(openLabels1Dir()),
+		m_labels1DirLineEdit);
+	addPathEntry("Piano roll custom labels 2", m_labels2Dir,
+		SLOT(setLabels2Dir(const QString &)),
+		SLOT(openLabels2Dir()),
+		m_labels2DirLineEdit);
+	addPathEntry("Piano roll custom labels 3", m_labels3Dir,
+		SLOT(setLabels3Dir(const QString &)),
+		SLOT(openLabels3Dir()),
+		m_labels3DirLineEdit);
 	pathSelectorsLayout->addStretch();
 
 	pathSelectors->setLayout(pathSelectorsLayout);
@@ -923,6 +939,11 @@ void SetupDialog::accept()
 	ConfigManager::inst()->setGIGDir(QDir::fromNativeSeparators(m_gigDir));
 	ConfigManager::inst()->setThemeDir(QDir::fromNativeSeparators(m_themeDir));
 	ConfigManager::inst()->setBackgroundPicFile(m_backgroundPicFile);
+	ConfigManager::inst()->setLabels1Dir(QDir::fromNativeSeparators(m_labels1Dir));
+	ConfigManager::inst()->setLabels2Dir(QDir::fromNativeSeparators(m_labels2Dir));
+	ConfigManager::inst()->setLabels3Dir(QDir::fromNativeSeparators(m_labels3Dir));
+
+
 
 	// Tell all audio-settings-widgets to save their settings.
 	for(AswMap::iterator it = m_audioIfaceSetupWidgets.begin();
@@ -1319,7 +1340,178 @@ void SetupDialog::setBackgroundPicFile(const QString & backgroundPicFile)
 }
 
 
+void SetupDialog::setLabels1Dir(const QString & labels1Dir)
+{
+	m_labels1Dir = labels1Dir;
+}
 
+void SetupDialog::openLabels1Dir()
+{
+	QString new_file = FileDialog::getOpenFileName(this,
+		tr("Choose your labels file"), m_labels1Dir, "Text files (*.txt)");
+
+	if (!new_file.isEmpty())
+	{
+		bool fileCorrect = 1;
+		QFile labelsFile(new_file);
+		labelsFile.open(QIODevice::ReadOnly);
+		if (!labelsFile.isOpen()) return ;
+		
+		QTextStream stream(&labelsFile);
+		QString line = stream.readLine();
+		QRegExp num("\\d*");
+		while (!line.isNull()) {
+			qDebug() << line;
+			if(line == ""){
+				break;
+			}
+			if(line.mid(0, 2) == "//"){
+				//Comment line
+			} else if (num.exactMatch(line.mid(0,1))){
+				if (num.exactMatch(line.mid(1,1))){
+					if (num.exactMatch(line.mid(2,1))){
+						int number = line.mid(0,3).toInt();
+						if (number > 127){
+							fileCorrect = 0;			
+							break;
+						} else if (line.mid(3,1) != " " || line.mid(3,2) == "  "){
+							fileCorrect = 0;
+							break;
+						}
+					} else if (line.mid(2,1) != " " || line.mid(2,2) == "  "){
+						fileCorrect = 0;
+						break;
+					}		
+				} else if (line.mid(1,1) != " " || line.mid(1,2) == "  ") {
+					fileCorrect = 0;
+					break;
+				}	
+			} else {
+				fileCorrect = 0;
+				break;
+			}
+			line = stream.readLine();
+		}	
+		if(fileCorrect){
+			m_labels1DirLineEdit->setText(new_file);
+		}	
+	}
+}
+
+void SetupDialog::setLabels2Dir(const QString & labels2Dir)
+{
+	m_labels2Dir = labels2Dir;
+}
+
+void SetupDialog::openLabels2Dir()
+{
+	QString new_file = FileDialog::getOpenFileName(this,
+		tr("Choose your labels file"), m_labels2Dir, "Text files (*.txt)");
+
+	if (!new_file.isEmpty())
+	{
+		bool fileCorrect = 1;
+		QFile labelsFile(new_file);
+		labelsFile.open(QIODevice::ReadOnly);
+		if (!labelsFile.isOpen()) return ;
+		
+		QTextStream stream(&labelsFile);
+		QString line = stream.readLine();
+		QRegExp num("\\d*");
+		while (!line.isNull()) {
+			qDebug() << line;
+			if(line == ""){
+				break;
+			}
+			if(line.mid(0, 2) == "//"){
+				//Comment line
+			} else if (num.exactMatch(line.mid(0,1))){
+				if (num.exactMatch(line.mid(1,1))){
+					if (num.exactMatch(line.mid(2,1))){
+						int number = line.mid(0,3).toInt();
+						if (number > 127){
+							fileCorrect = 0;			
+							break;
+						} else if (line.mid(3,1) != " " || line.mid(3,2) == "  "){
+							fileCorrect = 0;
+							break;
+						}
+					} else if (line.mid(2,1) != " " || line.mid(2,2) == "  "){
+						fileCorrect = 0;
+						break;
+					}		
+				} else if (line.mid(1,1) != " " || line.mid(1,2) == "  ") {
+					fileCorrect = 0;
+					break;
+				}	
+			} else {
+				fileCorrect = 0;
+				break;
+			}
+			line = stream.readLine();
+		}	
+		if(fileCorrect){
+			m_labels2DirLineEdit->setText(new_file);
+		}	
+	}
+}
+
+void SetupDialog::setLabels3Dir(const QString & labels3Dir)
+{
+	m_labels3Dir = labels3Dir;
+}
+
+void SetupDialog::openLabels3Dir()
+{
+	QString new_file = FileDialog::getOpenFileName(this,
+		tr("Choose your labels file"), m_labels3Dir, "Text files (*.txt)");
+
+	if (!new_file.isEmpty())
+	{
+		bool fileCorrect = 1;
+		QFile labelsFile(new_file);
+		labelsFile.open(QIODevice::ReadOnly);
+		if (!labelsFile.isOpen()) return ;
+		
+		QTextStream stream(&labelsFile);
+		QString line = stream.readLine();
+		QRegExp num("\\d*");
+		while (!line.isNull()) {
+			if(line == ""){
+				break;
+			}
+			if(line.mid(0, 2) == "//"){
+				//Comment line
+			} else if (num.exactMatch(line.mid(0,1))){
+				if (num.exactMatch(line.mid(1,1))){
+					if (num.exactMatch(line.mid(2,1))){
+						int number = line.mid(0,3).toInt();
+						if (number > 127){
+							fileCorrect = 0;			
+							break;
+						} else if (line.mid(3,1) != " " || line.mid(3,2) == "  "){
+							fileCorrect = 0;
+							break;
+						}
+					} else if (line.mid(2,1) != " " || line.mid(2,2) == "  "){
+						fileCorrect = 0;
+						break;
+					}		
+				} else if (line.mid(1,1) != " " || line.mid(1,2) == "  ") {
+					fileCorrect = 0;
+					break;
+				}	
+			} else {
+				fileCorrect = 0;
+				break;
+			}
+			line = stream.readLine();
+		}	
+		if(fileCorrect){
+			m_labels3DirLineEdit->setText(new_file);
+		}	
+	}
+}
 
 void SetupDialog::showRestartWarning()
 {

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -106,7 +106,6 @@ const int NUM_EVEN_LENGTHS = 6;
 const int NUM_TRIPLET_LENGTHS = 5;
 
 
-
 QPixmap * PianoRoll::s_whiteKeySmallPm = NULL;
 QPixmap * PianoRoll::s_whiteKeySmallPressedPm = NULL;
 QPixmap * PianoRoll::s_whiteKeyBigPm = NULL;
@@ -128,7 +127,9 @@ static QString getNoteString( int key )
 	return s_noteStrings[key % 12] + QString::number( static_cast<int>( key / KeysPerOctave ) );
 }
 
-
+bool labelsFile1Correct = 0;
+bool labelsFile2Correct = 0;
+bool labelsFile3Correct = 0;
 
 // used for drawing of piano
 PianoRoll::PianoRollKeyTypes PianoRoll::prKeyOrder[] =
@@ -151,6 +152,7 @@ PianoRoll::PianoRoll() :
 	m_semiToneMarkerMenu( NULL ),
 	m_zoomingModel(),
 	m_quantizeModel(),
+	m_labelsModel(),
 	m_noteLenModel(),
 	m_pattern( NULL ),
 	m_currentPosition(),
@@ -366,6 +368,32 @@ PianoRoll::PianoRoll() :
 	connect( &m_quantizeModel, SIGNAL( dataChanged() ),
 					this, SLOT( quantizeChanged() ) );
 
+	// Set up labels model
+	m_labelsModel.addItem( tr( "No labels" ) );
+	
+	QString labels1Path = ConfigManager::inst()->labels1Dir();
+	QString labels2Path = ConfigManager::inst()->labels2Dir();
+	QString labels3Path = ConfigManager::inst()->labels3Dir();
+	
+	if(labelsPathCorrect(labels1Path)){
+		labelsFile1Correct = 1;
+		m_labelsModel.addItem( tr( "Labels file 1" ) );
+	}
+	if(labelsPathCorrect(labels2Path)){
+		labelsFile2Correct = 1;
+		m_labelsModel.addItem( tr( "Labels file 2" ) );
+	}
+	if(labelsPathCorrect(labels3Path)){
+		labelsFile3Correct = 1;
+		m_labelsModel.addItem( tr( "Labels file 3" ) );
+	}
+		
+	m_labelsModel.setValue( 0 );
+
+	
+	connect( &m_labelsModel, SIGNAL( dataChanged() ),
+					this, SLOT( labelsChanged() ) );
+	
 	// Set up note length model
 	m_noteLenModel.addItem( tr( "Last note" ),
 					make_unique<PixmapLoader>( "edit_draw" ) );
@@ -2830,8 +2858,96 @@ int PianoRoll::xCoordOfTick( int tick )
 
 void PianoRoll::paintEvent(QPaintEvent * pe )
 {
+	QStringList labelsList;
+	QStringList numbersList;
 	bool drawNoteNames = ConfigManager::inst()->value( "ui", "printnotelabels").toInt();
-
+	int customLabelsFile;
+	bool drawCustomLabels = 0;
+	if (m_labelsModel.value() == 0){
+		drawCustomLabels = 0;
+	} else if (m_labelsModel.value() == 1) {
+		drawCustomLabels = 1;
+		if (labelsFile1Correct){
+			customLabelsFile = 1;
+		} else if (labelsFile2Correct) {
+			customLabelsFile = 2;
+		} else {
+			customLabelsFile = 3;
+		}
+	} else if (m_labelsModel.value() == 2) {
+		drawCustomLabels = 1;
+		if (labelsFile1Correct){
+			if (labelsFile2Correct) {
+				customLabelsFile = 2;
+			} else {
+				customLabelsFile = 3;
+			}
+		} else {
+			customLabelsFile = 3;
+		}
+	} else if (m_labelsModel.value() == 3) {
+		drawCustomLabels = 1;
+		customLabelsFile = 3;
+	}
+	
+	QString labels1Path = ConfigManager::inst()->labels1Dir();
+	QString labels2Path = ConfigManager::inst()->labels2Dir();
+	QString labels3Path = ConfigManager::inst()->labels3Dir();
+	
+	if (drawCustomLabels){
+		QString labelsPath;
+		if(customLabelsFile == 1) labelsPath = labels1Path; 
+		if(customLabelsFile == 2) labelsPath = labels2Path; 
+		if(customLabelsFile == 3) labelsPath = labels3Path; 
+				
+		QFile labelsFile(labelsPath);
+		labelsFile.open(QIODevice::ReadOnly);
+		QTextStream stream(&labelsFile);
+		QString line = stream.readLine();
+		QRegExp num("\\d*");
+		while (!line.isNull()) {
+			if (num.exactMatch(line.mid(0,1))){
+				if (num.exactMatch(line.mid(1,1))){
+					if (num.exactMatch(line.mid(2,1))){
+						int num = line.mid(0,3).toInt();
+						if (num > 107){		
+							break;
+						} else if (line.mid(3,1) != " " || line.mid(3,2) == "  "){
+							break;
+						} else {
+							//three digit number <= 107
+							int n = line.size();
+							QString labelText = line.mid(4, n-3);
+							labelsList << labelText;
+							numbersList << QString::number(num);
+						}
+					} else if (line.mid(2,1) != " " || line.mid(2,2) == "  "){
+						break;
+					} else {
+						//two digit number
+						int n = line.size();
+						QString labelText = line.mid(3, n-2);
+						int num = line.mid(0,2).toInt();	
+						labelsList << labelText;
+						numbersList << QString::number(num);
+					}
+				} else if (line.mid(1,1) != " " || line.mid(1,2) == "  ") {
+					break;
+				} else {
+					// one digit number
+					int n = line.size();
+					QString labelText = line.mid(2, n-1);
+					int num = line.mid(0,1).toInt();	
+					labelsList << labelText;
+					numbersList << QString::number(num);
+				}
+			}
+			line = stream.readLine();
+		}
+	}
+	
+	
+	
 	QStyleOption opt;
 	opt.initFrom( this );
 	QPainter p( this );
@@ -2975,6 +3091,10 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				p.drawText( textStart, noteString );
 			}
 		}
+		if (drawCustomLabels){
+			
+			
+		}
 		++key;
 	}
 
@@ -3114,6 +3234,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			}
 			p.drawLine( WHITE_KEY_WIDTH, y, width(), y );
 			++key;
+			
 		}
 
 
@@ -3459,6 +3580,24 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	if( cursor != NULL && mousePosition.y() > keyAreaTop() && mousePosition.x() > noteEditLeft())
 	{
 		p.drawPixmap( mousePosition + QPoint( 8, 8 ), *cursor );
+	}
+	if(drawCustomLabels){
+		key = m_startKey;
+		QFont labelFont = p.font();
+		labelFont.setBold( false );
+		p.setFont( pointSize<8>( labelFont ) );
+		for( int y = keyAreaBottom() - 1; y > PR_TOP_MARGIN;
+				y -= KEY_LINE_HEIGHT )
+		{
+			if(numbersList.contains(QString::number(key))) {
+				int index = numbersList.indexOf(QString::number(key));
+				p.setPen(QColor(190,190,190,255));
+				QString noteString = labelsList[index];
+				QPoint textStart( WHITE_KEY_WIDTH + 1, y-2);
+				p.drawText( textStart, noteString );
+			}
+			++key;	
+		}
 	}
 }
 
@@ -4284,6 +4423,11 @@ void PianoRoll::quantizeChanged()
 	update();
 }
 
+void PianoRoll::labelsChanged()
+{
+	update();
+}
+
 void PianoRoll::noteLengthChanged()
 {
 	m_stepRecorder.setStepsLength(newNoteLen());
@@ -4421,6 +4565,50 @@ Note * PianoRoll::noteUnderMouse()
 	return NULL;
 }
 
+bool PianoRoll::labelsPathCorrect( QString labelsPath ){
+	bool fileCorrect = 1;
+	QFile labelsFile(labelsPath);
+	if (!labelsFile.exists()){
+		return false;
+	}
+	labelsFile.open(QIODevice::ReadOnly);
+	if (!labelsFile.isOpen()) fileCorrect = 0 ;
+	QTextStream stream(&labelsFile);
+	QString line = stream.readLine();
+	QRegExp num("\\d*");
+	while (!line.isNull()) {
+		if(line == ""){
+			break;
+		}
+		if(line.mid(0, 2) == "//"){
+		//Comment line
+		} else if (num.exactMatch(line.mid(0,1))){
+			if (num.exactMatch(line.mid(1,1))){
+				if (num.exactMatch(line.mid(2,1))){
+					int number = line.mid(0,3).toInt();
+					if (number > 127){
+						fileCorrect = 0;			
+						break;
+					} else if (line.mid(3,1) != " " || line.mid(3,2) == "  "){
+						fileCorrect = 0;
+						break;
+					}
+				} else if (line.mid(2,1) != " " || line.mid(2,2) == "  "){
+					fileCorrect = 0;
+					break;
+				}		
+			} else if (line.mid(1,1) != " " || line.mid(1,2) == "  ") {
+				fileCorrect = 0;
+				break;
+			}	
+		} else {
+			fileCorrect = 0;
+			break;
+		}
+		line = stream.readLine();
+	}
+	return fileCorrect;	
+}
 
 
 
@@ -4515,6 +4703,15 @@ PianoRollWindow::PianoRollWindow() :
 	m_quantizeComboBox->setFixedSize( 64, 22 );
 	m_quantizeComboBox->setToolTip( tr( "Quantization") );
 
+	// setup labels-stuff
+	QLabel * labels_lbl = new QLabel( m_toolBar );
+	labels_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
+
+	m_labelsComboBox = new ComboBox( m_toolBar );
+	m_labelsComboBox->setModel( &m_editor->m_labelsModel );
+	m_labelsComboBox->setFixedSize( 100, 22 );
+	m_labelsComboBox->setToolTip( tr( "labels") );
+
 	// setup note-len-stuff
 	QLabel * note_len_lbl = new QLabel( m_toolBar );
 	note_len_lbl->setPixmap( embed::getIconPixmap( "note" ) );
@@ -4568,7 +4765,11 @@ PianoRollWindow::PianoRollWindow() :
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget( chord_lbl );
 	zoomAndNotesToolBar->addWidget( m_chordComboBox );
-
+	
+	zoomAndNotesToolBar->addSeparator();
+	zoomAndNotesToolBar->addWidget( labels_lbl );
+	zoomAndNotesToolBar->addWidget( m_labelsComboBox );
+	
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget( m_clearGhostButton );
 


### PR DESCRIPTION
I coded function for custom note labels for Pianoroll editor. Three labels files paths are stored in lmms config file. They can be set in settings -> paths. After setting paths lmms need restart. Then in Pianoroll editor you can select which file you want to use. Function reads labels from .txt files in pattern like attached one. File can't have any empty lines between labels/comments. Empty lines can be only after labels list. Between note number and label must be ONLY ONE space. 
In attached screenshots you can see how modifications looks like in Pianoroll and settings.

TODO:
Icon for labels file combo box in Pianoroll editor (currently using Quantize icon),
Only three files support, maybe add some kind of list,
May need some code clean-up and check,


![settings](https://user-images.githubusercontent.com/34841309/71548084-5d50a700-29a9-11ea-9fb1-9333306fb2c4.png)
![pianoroll](https://user-images.githubusercontent.com/34841309/71548085-5de93d80-29a9-11ea-9b51-bdddab3ff5bc.png)
[labels.txt](https://github.com/LMMS/lmms/files/4007313/labels.txt)