### PR TITLE
Fix #5194: Fix knobs moving too fast

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -174,8 +174,8 @@ private:
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;
 
-	QPoint m_mouseOffset;
-	QPoint m_origMousePos;
+	QPoint m_origMousePos; //!< position where user clicked to turn the knob
+	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
 	float m_leftOver;
 	bool m_buttonPressed;
 
@@ -196,6 +196,13 @@ private:
 
 	knobTypes m_knobNum;
 
+	enum class SetPosStatusType
+	{
+		NotChecked,
+		Works,
+		NoEffect
+	};
+	static SetPosStatusType s_setPosStatus;
 } ;
 
 #endif

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -174,7 +174,6 @@ private:
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;
 
-	QPoint m_origMousePos; //!< position where user clicked to turn the knob
 	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
 	float m_leftOver;
 	bool m_buttonPressed;

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -196,13 +196,6 @@ private:
 
 	knobTypes m_knobNum;
 
-	enum class SetPosStatusType
-	{
-		NotChecked,
-		Works,
-		NoEffect
-	};
-	static SetPosStatusType s_setPosStatus;
 } ;
 
 #endif

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -74,7 +74,7 @@ protected:
 
 private:
 	bool m_mouseMoving;
-	QPoint m_origMousePos;
+	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
 	int m_displayOffset;
 	void enterValue();
 

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -73,6 +73,7 @@ protected:
 	virtual void mouseDoubleClickEvent( QMouseEvent * _me );
 
 private:
+	float m_remainder; //!< floating offset of spinbox in [-0.5, 0.5]
 	bool m_mouseMoving;
 	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
 	int m_displayOffset;

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -499,8 +499,8 @@ float Knob::getValue( const QPoint & _p )
 {
 	float value;
 
-	// arcane mathemagicks for calculating knob movement
-	value = ( ( _p.y() + _p.y() * qMin( qAbs( _p.y() / 2.5f ), 6.0f ) ) ) / 12.0f;
+	// knob value increase is linear to mouse movement
+	value = .09f * _p.y();
 
 	// if shift pressed we want slower movement
 	if( gui->mainWindow()->isShiftPressed() )

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -498,7 +498,7 @@ float Knob::getValue( const QPoint & _p )
 	float value;
 
 	// knob value increase is linear to mouse movement
-	value = .09f * _p.y();
+	value = .4f * _p.y();
 
 	// if shift pressed we want slower movement
 	if( gui->mainWindow()->isShiftPressed() )

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -28,7 +28,6 @@
 #include <QInputDialog>
 #include <QMouseEvent>
 #include <QPainter>
-#include <QScreen>
 #include <QWhatsThis>
 
 #ifndef __USE_XOPEN
@@ -51,7 +50,6 @@
 #include "TextFloat.h"
 
 TextFloat * Knob::s_textFloat = NULL;
-Knob::SetPosStatusType Knob::s_setPosStatus = Knob::SetPosStatusType::NotChecked;
 
 
 
@@ -588,39 +586,12 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 			thisModel->saveJournallingState( false );
 		}
 
-		// on apple, we know that setPos will not work in many cases
-		// (and that the below check won't work either)
-		// to not confuse the user, we won't hide the cursor on apple,
-		// and we won't call setPos on apple either
-#ifdef LMMS_BUILD_APPLE
-		(void)s_setPosStatus;
-#else
-		if(s_setPosStatus == SetPosStatusType::NotChecked)
-		{
-			QPoint oldPos = QCursor::pos();
-			QCursor::setPos(oldPos - QPoint(1,1));
-			s_setPosStatus = (QCursor::pos() == oldPos)
-				? SetPosStatusType::NoEffect
-				: SetPosStatusType::Works;
-			QCursor::setPos(oldPos);
-		}
-#endif
-
 		const QPoint & p = _me->pos();
 		m_origMousePos = m_lastMousePos = p;
 		m_leftOver = 0.0f;
 
 		emit sliderPressed();
 
-#ifndef LMMS_BUILD_APPLE
-		if(s_setPosStatus == SetPosStatusType::Works)
-		{
-			// if overriding of cursor does not work, the user can
-			// be confused when a hidden cursor reappears somewhere
-			// outside of the knob
-			QApplication::setOverrideCursor( Qt::BlankCursor );
-		}
-#endif
 		s_textFloat->setText( displayValue() );
 		s_textFloat->moveGlobal( this,
 				QPoint( width() + 2, 0 ) );
@@ -650,50 +621,8 @@ void Knob::mouseMoveEvent( QMouseEvent * _me )
 		// knob position is changed depending on last mouse position
 		setPosition( _me->pos() - m_lastMousePos );
 		emit sliderMoved( model()->value() );
-
-		// the rest of the code updates the cursor and/or m_origMousePos
-
-		// get screen min/max values where a flip is not required yet
-		const QRect& rec =
-#if QT_VERSION >= 0x050A00
-			QApplication::screenAt(QCursor::pos())->geometry();
-#else
-			QApplication::desktop()->availableGeometry();
-#endif
-		int ymax = qMax(rec.height() - 2, 0), xmax = qMax(rec.width() - 2, 0);
-		int ymin = 1, xmin = 1;
-
-		// calculate new coordinates
-		int x = QCursor::pos().x(), y = QCursor::pos().y();
-		QPoint newPos(
-			(x<xmin) ? xmax : (x>xmax) ? xmin : x,
-			(y<ymin) ? ymax : (y>ymax) ? ymin : y);
-
-		auto setCursor = [&](const QPoint& p) -> bool
-		{
-#ifdef LMMS_BUILD_APPLE
-			(void)p;
-			return false;
-#else
-			QCursor::setPos(newPos);
-			return QCursor::pos() == newPos;
-#endif
-		};
-
-		// no flip, or calling QCursor::setPos() for flip has no effect?
-		// (the latter occurs on some systems without accessability)
-		if(newPos == QCursor::pos() || !setCursor(newPos))
-		{
-			// original position for next time is current position
-			m_lastMousePos = _me->pos();
-		}
-		else
-		{
-			// successful flip of cursor
-			// bash original position to current position
-			// to avoid the knob snapping back
-			m_lastMousePos = mapFromGlobal(QCursor::pos());
-		}
+		// original position for next time is current position
+		m_lastMousePos = _me->pos();
 	}
 	s_textFloat->setText( displayValue() );
 }
@@ -712,13 +641,7 @@ void Knob::mouseReleaseEvent( QMouseEvent* event )
 		}
 	}
 
-	if( m_buttonPressed )
-	{
-		m_buttonPressed = false;
-#ifndef LMMS_BUILD_APPLE
-		QCursor::setPos( mapToGlobal( m_origMousePos ) );
-#endif
-	}
+	m_buttonPressed = false;
 
 	emit sliderReleased();
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -587,7 +587,7 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 		}
 
 		const QPoint & p = _me->pos();
-		m_origMousePos = m_lastMousePos = p;
+		m_lastMousePos = p;
 		m_leftOver = 0.0f;
 
 		emit sliderPressed();

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -41,7 +41,7 @@ LcdSpinBox::LcdSpinBox( int numDigits, QWidget* parent, const QString& name ) :
 	LcdWidget( numDigits, parent, name ),
 	IntModelView( new IntModel( 0, 0, 0, NULL, name, true ), this ),
 	m_mouseMoving( false ),
-	m_origMousePos(),
+	m_lastMousePos(),
 	m_displayOffset( 0 )
 {
 }
@@ -53,7 +53,7 @@ LcdSpinBox::LcdSpinBox( int numDigits, const QString& style, QWidget* parent, co
 	LcdWidget( numDigits, parent, name ),
 	IntModelView( new IntModel( 0, 0, 0, NULL, name, true ), this ),
 	m_mouseMoving( false ),
-	m_origMousePos(),
+	m_lastMousePos(),
 	m_displayOffset( 0 )
 {
 }
@@ -98,8 +98,7 @@ void LcdSpinBox::mousePressEvent( QMouseEvent* event )
 						event->y() < cellHeight() + 2  )
 	{
 		m_mouseMoving = true;
-		m_origMousePos = event->globalPos();
-		QApplication::setOverrideCursor( Qt::BlankCursor );
+		m_lastMousePos = event->globalPos();
 
 		AutomatableModel *thisModel = model();
 		if( thisModel )
@@ -121,7 +120,7 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 {
 	if( m_mouseMoving )
 	{
-		int dy = event->globalY() - m_origMousePos.y();
+		int dy = 3 * (event->globalY() - m_lastMousePos.y());
 		if( event->modifiers() & Qt::ShiftModifier )
 			dy = qBound( -4, dy/4, 4 );
 		if( dy > 1 || dy < -1 )
@@ -129,8 +128,8 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 			model()->setInitValue( model()->value() -
 						dy / 2 * model()->step<int>() );
 			emit manualChange();
-			QCursor::setPos( m_origMousePos );
 		}
+		m_lastMousePos = event->globalPos();
 	}
 }
 
@@ -142,10 +141,7 @@ void LcdSpinBox::mouseReleaseEvent( QMouseEvent* )
 	if( m_mouseMoving )
 	{
 		model()->restoreJournallingState();
-
-		QCursor::setPos( m_origMousePos );
 		QApplication::restoreOverrideCursor();
-
 		m_mouseMoving = false;
 	}
 }

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -129,8 +129,8 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 			float fdy = static_cast<float>(dy);
 			if( event->modifiers() & Qt::ShiftModifier )
 				fdy = qBound( -4.f, fdy/4.f, 4.f );
-			float floatValNotRounded = model()->value() + m_remainder -
-										fdy / 2.f * model()->step<int>();
+			float floatValNotRounded =
+				model()->value() + m_remainder - fdy / 2.f * model()->step<int>();
 			float floatValRounded = roundf( floatValNotRounded );
 			m_remainder = floatValNotRounded - floatValRounded;
 			model()->setInitValue( floatValRounded );
@@ -189,6 +189,5 @@ void LcdSpinBox::enterValue()
 		model()->setValue( new_val );
 	}
 }
-
 
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <cmath>
 #include <QApplication>
 #include <QLabel>
 #include <QMouseEvent>
@@ -120,13 +121,14 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 {
 	if( m_mouseMoving )
 	{
-		int dy = 2 * (event->globalY() - m_lastMousePos.y());
+		float dy = static_cast<float>(event->globalY() - m_lastMousePos.y());
 		if( event->modifiers() & Qt::ShiftModifier )
-			dy = qBound( -4, dy/4, 4 );
-		if( dy > 1 || dy < -1 )
+			dy = qBound( -4.f, dy/4.f, 4.f );
+		if(dy > .5f || dy < -.5f) // that means "if dy != 0"
 		{
-			model()->setInitValue( model()->value() -
-						dy / 2 * model()->step<int>() );
+			float initValueNotRounded = model()->value() -
+						dy / 2 * model()->step<int>();
+			model()->setInitValue( roundf(initValueNotRounded) );
 			emit manualChange();
 		}
 		m_lastMousePos = event->globalPos();

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -127,8 +127,9 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 		if( dy )
 		{
 			float fdy = static_cast<float>(dy);
-			if( event->modifiers() & Qt::ShiftModifier )
+			if( event->modifiers() & Qt::ShiftModifier ) {
 				fdy = qBound( -4.f, fdy/4.f, 4.f );
+			}
 			float floatValNotRounded =
 				model()->value() + m_remainder - fdy / 2.f * model()->step<int>();
 			float floatValRounded = roundf( floatValNotRounded );
@@ -189,5 +190,4 @@ void LcdSpinBox::enterValue()
 		model()->setValue( new_val );
 	}
 }
-
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -120,7 +120,7 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 {
 	if( m_mouseMoving )
 	{
-		int dy = 3 * (event->globalY() - m_lastMousePos.y());
+		int dy = 2 * (event->globalY() - m_lastMousePos.y());
 		if( event->modifiers() & Qt::ShiftModifier )
 			dy = qBound( -4, dy/4, 4 );
 		if( dy > 1 || dy < -1 )


### PR DESCRIPTION
For systems where QCursor::setPos() has no effect, this fix adds a
workaround for the situation where a knob value is changed via mouse
click and move. The fix simulates that the cursor is moved back to the
original click position.