### PR TITLE
fix locking of the useless_lock in LocklessRingBuffer.h

### DIFF
--- a/include/LocklessRingBuffer.h
+++ b/include/LocklessRingBuffer.h
@@ -122,6 +122,7 @@ public:
 	void waitForData()
 	{
 		QMutex useless_lock;
+		useless_lock.lock();
 		m_notifier->wait(&useless_lock);
 		useless_lock.unlock();
 	}


### PR DESCRIPTION
Cherry-picked bugfix from #5328.