### PR TITLE
Fix stuck notes with Helm VSTi

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -540,6 +540,15 @@ void NotePlayHandle::processMidiTime( const MidiTime& time )
 
 void NotePlayHandle::resize( const bpm_t _new_tempo )
 {
+	if (origin() == OriginMidiInput ||
+		(origin() == OriginNoteStacking && m_parent->origin() == OriginMidiInput))
+	{
+		// Don't resize notes from MIDI input - they should continue to play
+		// until the key is released, and their large duration can cause
+		// overflows in this method.
+		return;
+	}
+
 	double completed = m_totalFramesPlayed / (double) m_frames;
 	double new_frames = m_origFrames * m_origTempo / (double) _new_tempo;
 	m_frames = (f_cnt_t)new_frames;


### PR DESCRIPTION
Fixes #3640.

As mentioned in that issue, resizing notes from MIDI input during tempo changes causes overflows, which result in incorrect MIDI messages sent to the plugin. This is avoided by not resizing these notes.