### PR TITLE
Fix Debian sid builds

### DIFF
--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -19,7 +19,7 @@ if(LMMS_HAVE_WEAKCARLA)
   )
   INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
   ADD_LIBRARY(carla_native-plugin MODULE DummyCarla.cpp)
-  INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}")
+  INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}/optional")
   SET(CARLA_LIBRARIES $<TARGET_FILE:carla_native-plugin>)
   SET(CARLA_LIBRARY_DIRS $<TARGET_FILE_DIR:carla_native-plugin>)
   # Set parent scope variables so carlarack and carlapatchbay can see them
@@ -32,12 +32,14 @@ if(LMMS_HAVE_CARLA OR LMMS_HAVE_WEAKCARLA)
         INCLUDE(BuildPlugin)
         INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
         LINK_DIRECTORIES(${CARLA_LIBRARY_DIRS})
+        LINK_LIBRARIES(${CARLA_LIBRARIES})
         BUILD_PLUGIN(carlabase carla.cpp carla.h MOCFILES carla.h EMBEDDED_RESOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.png" LINK SHARED)
         SET_TARGET_PROPERTIES(carlabase
                 PROPERTIES SKIP_BUILD_RPATH TRUE
                 BUILD_WITH_INSTALL_RPATH TRUE
                 INSTALL_RPATH_USE_LINK_PATH TRUE
                 INSTALL_RPATH "${CARLA_RPATH}")
-        TARGET_LINK_LIBRARIES(carlabase -lcarla_native-plugin)
-        ADD_DEPENDENCIES(carlabase carla_native-plugin)
+        IF(LMMS_HAVE_WEAKCARLA)
+                ADD_DEPENDENCIES(carlabase carla_native-plugin)
+        ENDIF()
 endif()

--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -18,7 +18,7 @@ if(LMMS_HAVE_WEAKCARLA)
     ${CMAKE_CURRENT_BINARY_DIR}
   )
   INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
-  ADD_LIBRARY(carla_native-plugin SHARED DummyCarla.cpp)
+  ADD_LIBRARY(carla_native-plugin MODULE DummyCarla.cpp)
   INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}")
   SET(CARLA_LIBRARIES $<TARGET_FILE:carla_native-plugin>)
   SET(CARLA_LIBRARY_DIRS $<TARGET_FILE_DIR:carla_native-plugin>)
@@ -32,11 +32,12 @@ if(LMMS_HAVE_CARLA OR LMMS_HAVE_WEAKCARLA)
         INCLUDE(BuildPlugin)
         INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
         LINK_DIRECTORIES(${CARLA_LIBRARY_DIRS})
-        LINK_LIBRARIES(${CARLA_LIBRARIES})
         BUILD_PLUGIN(carlabase carla.cpp carla.h MOCFILES carla.h EMBEDDED_RESOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.png" LINK SHARED)
         SET_TARGET_PROPERTIES(carlabase
                 PROPERTIES SKIP_BUILD_RPATH TRUE
                 BUILD_WITH_INSTALL_RPATH TRUE
                 INSTALL_RPATH_USE_LINK_PATH TRUE
                 INSTALL_RPATH "${CARLA_RPATH}")
+        TARGET_LINK_LIBRARIES(carlabase -lcarla_native-plugin)
+        ADD_DEPENDENCIES(carlabase carla_native-plugin)
 endif()

--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -19,7 +19,7 @@ if(LMMS_HAVE_WEAKCARLA)
   )
   INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
   ADD_LIBRARY(carla_native-plugin SHARED DummyCarla.cpp)
-  INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}/optional")
+  INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}")
   SET(CARLA_LIBRARIES $<TARGET_FILE:carla_native-plugin>)
   SET(CARLA_LIBRARY_DIRS $<TARGET_FILE_DIR:carla_native-plugin>)
   # Set parent scope variables so carlarack and carlapatchbay can see them

--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -18,7 +18,7 @@ if(LMMS_HAVE_WEAKCARLA)
     ${CMAKE_CURRENT_BINARY_DIR}
   )
   INCLUDE_DIRECTORIES(${CARLA_INCLUDE_DIRS})
-  ADD_LIBRARY(carla_native-plugin MODULE DummyCarla.cpp)
+  ADD_LIBRARY(carla_native-plugin SHARED DummyCarla.cpp)
   INSTALL(TARGETS carla_native-plugin LIBRARY DESTINATION "${PLUGIN_DIR}/optional")
   SET(CARLA_LIBRARIES $<TARGET_FILE:carla_native-plugin>)
   SET(CARLA_LIBRARY_DIRS $<TARGET_FILE_DIR:carla_native-plugin>)


### PR DESCRIPTION
In answer to https://github.com/LMMS/lmms/pull/4813#issuecomment-573220028, Debian sid builds may fail because sid may use newer versions of the build tools. This request fixes the builds in #4813.