### PR TITLE
Bias dropped clip position backwards

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1620,9 +1620,13 @@ bool TrackContentWidget::pasteSelection( MidiTime tcoPos, QDropEvent * de )
 	// TODO -- Need to draw the hovericon either way, or ghost the TCOs
 	// onto their final position.
 
+	float snapSize = gui->songEditor()->m_editor->getSnapSize();
 	// All patterns should be offset the same amount as the grabbed pattern
+	MidiTime offset = MidiTime(tcoPos - grabbedTCOPos);
+	// Users expect clips to "fall" backwards, so bias the offset
+	offset = offset - MidiTime::ticksPerBar() * snapSize / 2;
 	// The offset is quantized (rather than the positions) to preserve fine adjustments
-	int offset = MidiTime(tcoPos - grabbedTCOPos).quantize(gui->songEditor()->m_editor->getSnapSize());
+	offset = offset.quantize(snapSize);
 
 	for( int i = 0; i<tcoNodes.length(); i++ )
 	{


### PR DESCRIPTION
This matches the drop behavior from before #4973, as users expect clips to start on the bar they hover over, not on the bar whose start is closer to the cursor. Scales with snap size as well, so it drops onto the half-bar hovered over rather than the half-bar whose start is closer to the cursor, etc.
Closes #5393