### PR TITLE
Keyboard shortcuts to preview/add sounds from sidebar

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -99,6 +99,10 @@ public:
 	//! that are expanded in the tree.
 	QList<QString> expandedDirs( QTreeWidgetItem * item = nullptr ) const;
 
+	void tryAddSEInstrumentTrack(FileItem* file);
+	void tryAddBBInstrumentTrack(FileItem* file);
+	void previewFileItem(FileItem* file);
+
 
 protected:
 	void contextMenuEvent( QContextMenuEvent * e ) override;
@@ -108,6 +112,8 @@ protected:
 
 
 private:
+	void keyPressEvent( QKeyEvent * ke ) override;
+
 	void handleFile( FileItem * fi, InstrumentTrack * it );
 	void openInNewInstrumentTrack( TrackContainer* tc, FileItem* item );
 
@@ -118,8 +124,8 @@ private:
 	PlayHandle* m_previewPlayHandle;
 	QMutex m_pphMutex;
 
-	void populateSampleMenu(QMenu& contextMenu, FileItem* item);
-	void populatePluginMenu(QMenu& contextMenu, FileItem* item);
+	QList<QAction*> getContextActionsSE(FileItem* item);
+	QList<QAction*> getContextActionsBBE(FileItem* item);
 
 
 private slots:
@@ -234,6 +240,11 @@ public:
 	inline FileHandling handling( void ) const
 	{
 		return( m_handling );
+	}
+
+	inline bool isTrack( void ) const
+	{
+		return m_handling == LoadAsPreset || m_handling == LoadByPlugin;
 	}
 
 	QString extension( void );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -135,7 +135,7 @@ private:
 private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
 	void openInNewInstrumentTrack( FileItem* item, bool songEditor );
-	bool openInNewSampleTrack( FileItem* item, bool songEditor );
+	bool openInNewSampleTrack( FileItem* item );
 	void sendToActiveInstrumentTrack( FileItem* item );
 	void updateDirectory( QTreeWidgetItem * item );
 	void openContainingFolder( FileItem* item );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -115,6 +115,7 @@ private:
 
 	void keyPressEvent( QKeyEvent * ke ) override;
 	void keyReleaseEvent( QKeyEvent * ke ) override;
+	void hideEvent( QHideEvent * he ) override;
 
 	void handleFile( FileItem * fi, InstrumentTrack * it );
 	void openInNewInstrumentTrack( TrackContainer* tc, FileItem* item );
@@ -123,9 +124,9 @@ private:
 	bool m_mousePressed;
 	QPoint m_pressPos;
 
+	//! This should only be accessed or modified when m_pphMutex is held
 	PlayHandle* m_previewPlayHandle;
 	QMutex m_pphMutex;
-	FileItem* m_previewFileItem;
 
 	QList<QAction*> getContextActions(FileItem* item, bool songEditor);
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -113,7 +113,7 @@ protected:
 private:
 	//! Start a preview of a file item
 	void previewFileItem(FileItem* file);
-	//! If a preview is playing, stop it. Returns false if nothing was playing
+	//! If a preview is playing, stop it.
 	void stopPreview();
 
 	void handleFile( FileItem * fi, InstrumentTrack * it );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -105,6 +105,9 @@ protected:
 	void mousePressEvent( QMouseEvent * me ) override;
 	void mouseMoveEvent( QMouseEvent * me ) override;
 	void mouseReleaseEvent( QMouseEvent * me ) override;
+	void keyPressEvent( QKeyEvent * ke ) override;
+	void keyReleaseEvent( QKeyEvent * ke ) override;
+	void hideEvent( QHideEvent * he ) override;
 
 
 private:
@@ -112,10 +115,6 @@ private:
 	void previewFileItem(FileItem* file);
 	//! If a preview is playing, stop it. Returns false if nothing was playing
 	void stopPreview();
-
-	void keyPressEvent( QKeyEvent * ke ) override;
-	void keyReleaseEvent( QKeyEvent * ke ) override;
-	void hideEvent( QHideEvent * he ) override;
 
 	void handleFile( FileItem * fi, InstrumentTrack * it );
 	void openInNewInstrumentTrack( TrackContainer* tc, FileItem* item );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -101,7 +101,6 @@ public:
 
 	void tryAddSEInstrumentTrack(FileItem* file);
 	void tryAddBBInstrumentTrack(FileItem* file);
-	void previewFileItem(FileItem* file);
 
 
 protected:
@@ -112,7 +111,13 @@ protected:
 
 
 private:
+	//Preview a file
+	void previewFileItem(FileItem* file);
+	//If a preview is playing, stop it and return true. Otherwise return false
+	bool stopPreview();
+	
 	void keyPressEvent( QKeyEvent * ke ) override;
+	void keyReleaseEvent( QKeyEvent * ke ) override;
 
 	void handleFile( FileItem * fi, InstrumentTrack * it );
 	void openInNewInstrumentTrack( TrackContainer* tc, FileItem* item );
@@ -124,14 +129,12 @@ private:
 	PlayHandle* m_previewPlayHandle;
 	QMutex m_pphMutex;
 
-	QList<QAction*> getContextActionsSE(FileItem* item);
-	QList<QAction*> getContextActionsBBE(FileItem* item);
+	QList<QAction*> getContextActions(FileItem* item, bool songEditor);
 
 
 private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
-	void openInNewInstrumentTrackBBE( FileItem* item );
-	void openInNewInstrumentTrackSE( FileItem* item );
+	void openInNewInstrumentTrack( FileItem* item, bool songEditor );
 	void openInNewSampleTrack( FileItem* item );
 	void sendToActiveInstrumentTrack( FileItem* item );
 	void updateDirectory( QTreeWidgetItem * item );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -63,9 +63,9 @@ public:
 
 private slots:
 	void reloadTree( void );
-	void expandItems( QTreeWidgetItem * item=NULL, QList<QString> expandedDirs = QList<QString>() );
+	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );
 	// call with item=NULL to filter the entire tree
-	bool filterItems( const QString & filter, QTreeWidgetItem * item=NULL );
+	bool filterItems( const QString & filter, QTreeWidgetItem * item=nullptr );
 	void giveFocusToFilter();
 
 private:
@@ -112,7 +112,7 @@ private:
 	void previewFileItem(FileItem* file);
 	//! If a preview is playing, stop it. Returns false if nothing was playing
 	bool stopPreview();
-	
+
 	void keyPressEvent( QKeyEvent * ke ) override;
 	void keyReleaseEvent( QKeyEvent * ke ) override;
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -109,7 +109,7 @@ protected:
 
 private:
 	void handleFile( FileItem * fi, InstrumentTrack * it );
-	void openInNewInstrumentTrack( TrackContainer* tc );
+	void openInNewInstrumentTrack( TrackContainer* tc, FileItem* item );
 
 
 	bool m_mousePressed;
@@ -118,14 +118,16 @@ private:
 	PlayHandle* m_previewPlayHandle;
 	QMutex m_pphMutex;
 
-	FileItem * m_contextMenuItem;
+	void populateSampleMenu(QMenu& contextMenu, FileItem* item);
+	void populatePluginMenu(QMenu& contextMenu, FileItem* item);
 
 
 private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
-	void openInNewInstrumentTrackBBE( void );
-	void openInNewInstrumentTrackSE( void );
-	void sendToActiveInstrumentTrack( void );
+	void openInNewInstrumentTrackBBE( FileItem* item );
+	void openInNewInstrumentTrackSE( FileItem* item );
+	void openInNewSampleTrack( FileItem* item );
+	void sendToActiveInstrumentTrack( FileItem* item );
 	void updateDirectory( QTreeWidgetItem * item );
 	void openContainingFolder();
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -125,6 +125,7 @@ private:
 
 	PlayHandle* m_previewPlayHandle;
 	QMutex m_pphMutex;
+	FileItem* m_previewFileItem;
 
 	QList<QAction*> getContextActions(FileItem* item, bool songEditor);
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -111,7 +111,7 @@ private:
 	//! Start a preview of a file item
 	void previewFileItem(FileItem* file);
 	//! If a preview is playing, stop it. Returns false if nothing was playing
-	bool stopPreview();
+	void stopPreview();
 
 	void keyPressEvent( QKeyEvent * ke ) override;
 	void keyReleaseEvent( QKeyEvent * ke ) override;

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -99,9 +99,6 @@ public:
 	//! that are expanded in the tree.
 	QList<QString> expandedDirs( QTreeWidgetItem * item = nullptr ) const;
 
-	void tryAddSEInstrumentTrack(FileItem* file);
-	void tryAddBBInstrumentTrack(FileItem* file);
-
 
 protected:
 	void contextMenuEvent( QContextMenuEvent * e ) override;
@@ -111,9 +108,9 @@ protected:
 
 
 private:
-	//Preview a file
+	//! Start a preview of a file item
 	void previewFileItem(FileItem* file);
-	//If a preview is playing, stop it and return true. Otherwise return false
+	//! If a preview is playing, stop it. Returns false if nothing was playing
 	bool stopPreview();
 	
 	void keyPressEvent( QKeyEvent * ke ) override;

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -135,7 +135,7 @@ private slots:
 	void openInNewSampleTrack( FileItem* item );
 	void sendToActiveInstrumentTrack( FileItem* item );
 	void updateDirectory( QTreeWidgetItem * item );
-	void openContainingFolder();
+	void openContainingFolder( FileItem* item );
 
 } ;
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -135,7 +135,7 @@ private:
 private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
 	void openInNewInstrumentTrack( FileItem* item, bool songEditor );
-	void openInNewSampleTrack( FileItem* item );
+	bool openInNewSampleTrack( FileItem* item, bool songEditor );
 	void sendToActiveInstrumentTrack( FileItem* item );
 	void updateDirectory( QTreeWidgetItem * item );
 	void openContainingFolder( FileItem* item );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -476,12 +476,13 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 	QList<QAction*> result = QList<QAction*>();
 	const bool fileIsSample = file->type() == FileItem::SampleFile;
 
-	QString destination = fileIsSample ? "AFP Instance" : "Instrument Track";
-	QString shortcutMod = songEditor ? "" : "Ctrl +";
+	QString instrumentAction = fileIsSample ?
+		tr("Send to new AudioFileProcessor instance") :
+		tr("Send to new instrument track");
+	QString shortcutMod = songEditor ? "" : UI_CTRL_KEY + QString(" + ");
 
 	QAction* toInstrument = new QAction(
-		tr("Send to new %1 (%2 Enter)")
-		.arg(destination, shortcutMod),
+		instrumentAction + tr(" (%2Enter)").arg(shortcutMod),
 		nullptr
 	);
 	connect(toInstrument, &QAction::triggered,
@@ -490,7 +491,7 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 
 	if (songEditor && fileIsSample){
 		QAction* toSampleTrack = new QAction(
-			tr("Send to new Sample Track (Shift + Enter)"),
+			tr("Send to new sample track (Shift + Enter)"),
 			nullptr
 		);
 		connect(toSampleTrack, &QAction::triggered,
@@ -596,16 +597,14 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 
 
 
-bool FileBrowserTreeWidget::stopPreview()
+void FileBrowserTreeWidget::stopPreview()
 {
 	QMutexLocker previewLocker(&m_pphMutex);
 	if (m_previewPlayHandle != nullptr)
 	{
 		Engine::mixer()->removePlayHandle(m_previewPlayHandle);
 		m_previewPlayHandle = nullptr;
-		return true;
 	}
-	else { return false; }
 }
 
 
@@ -685,8 +684,8 @@ void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 			{
 				s->setDoneMayReturnTrue(true);
 			}
+			else { stopPreview(); }
 		}
-		else { stopPreview(); }
 	}
 }
 
@@ -802,7 +801,7 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 	if (item->type() != FileItem::SampleFile){ return false; }
 
 	// Create a new sample track for this sample
-	SampleTrack* sampleTrack = dynamic_cast<SampleTrack*>(
+	SampleTrack* sampleTrack = static_cast<SampleTrack*>(
 		Track::create(Track::SampleTrack, Engine::getSong()));
 
 	// Add the sample clip to the track

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -438,10 +438,13 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 		
 		contextMenu.addSeparator();
 
-		contextMenu.addAction(QIcon(embed::getIconPixmap("folder")),
-					tr("Open containing folder"),
-					this,
-					SLOT(openContainingFolder()));
+		QAction* openFolder = new QAction(
+			QIcon(embed::getIconPixmap("folder")),
+			tr("Open containing folder")
+		);
+		connect(openFolder, &QAction::triggered,
+			[=]{ openContainingFolder(file); });
+		contextMenu.addAction(openFolder);
 
 		//If all we have is the first action + two headers, the item isn't
 		//valid, so we shouldn't show the menu
@@ -792,19 +795,16 @@ void FileBrowserTreeWidget::openInNewInstrumentTrackSE( FileItem* item )
 
 
 
-void FileBrowserTreeWidget::openContainingFolder()
+void FileBrowserTreeWidget::openContainingFolder(FileItem* item)
 {
-	if (m_contextMenuItem)
-	{
-		// Delegate to QDesktopServices::openUrl with the directory of the selected file. Please note that
-		// this will only open the directory but not select the file as this is much more complicated due
-		// to different implementations that are needed for different platforms (Linux/Windows/MacOS).
+	// Delegate to QDesktopServices::openUrl with the directory of the selected file. Please note that
+	// this will only open the directory but not select the file as this is much more complicated due
+	// to different implementations that are needed for different platforms (Linux/Windows/MacOS).
 
-		// Using QDesktopServices::openUrl seems to be the most simple cross platform way which uses
-		// functionality that's already available in Qt.
-		QFileInfo fileInfo(m_contextMenuItem->fullName());
-		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.dir().path()));
-	}
+	// Using QDesktopServices::openUrl seems to be the most simple cross platform way which uses
+	// functionality that's already available in Qt.
+	QFileInfo fileInfo(item->fullName());
+	QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.dir().path()));
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -174,7 +174,7 @@ void FileBrowser::reloadTree( void )
 	{
 		addItems( *it );
 	}
-	expandItems(NULL, expandedDirs);
+	expandItems(nullptr, expandedDirs);
 	m_filterEdit->setText( text );
 	filterItems( text );
 }
@@ -241,7 +241,7 @@ void FileBrowser::addItems(const QString & path )
 			{
 				Directory * d = dynamic_cast<Directory *>(
 						m_fileBrowserTreeWidget->topLevelItem( i ) );
-				if( d == NULL || cur_file < d->text( 0 ) )
+				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done
 					Directory *dd = new Directory( cur_file, path,
@@ -321,7 +321,7 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 	QTreeWidget( parent ),
 	m_mousePressed( false ),
 	m_pressPos(),
-	m_previewPlayHandle( NULL ),
+	m_previewPlayHandle( nullptr ),
 	m_pphMutex( QMutex::Recursive )
 {
 	setColumnCount( 1 );
@@ -371,10 +371,10 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 {
 	// Shorter names for some commonly used properties of the event
 	const auto key = ke->key();
-	const bool vertical = key == Qt::Key_Up || key == Qt::Key_Down;
-	const bool horizontal = key == Qt::Key_Left || key == Qt::Key_Right;
-	const bool preview = key == Qt::Key_Space;
-	const bool insert = key == Qt::Key_Enter || key == Qt::Key_Return;
+	const bool vertical   = (key == Qt::Key_Up    || key == Qt::Key_Down);
+	const bool horizontal = (key == Qt::Key_Left  || key == Qt::Key_Right);
+	const bool insert     = (key == Qt::Key_Enter || key == Qt::Key_Return);
+	const bool preview    = (key == Qt::Key_Space);
 
 	// First of all, forward all keypresses
 	QTreeWidget::keyPressEvent(ke);
@@ -386,7 +386,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	// Try to get the currently selected item as a FileItem
 	FileItem * file = dynamic_cast<FileItem *>(currentItem());
 	// If it's null (folder, separator, etc.), there's nothing left for us to do
-	if (file == NULL){ return; }
+	if (file == nullptr){ return; }
 
 	// When moving to a new sound, preview it. Skip presets, they can play forever
 	if (vertical && file->type() == FileItem::SampleFile)
@@ -426,7 +426,7 @@ void FileBrowserTreeWidget::keyReleaseEvent(QKeyEvent * ke )
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
 	FileItem * file = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
-	if( file != NULL && file->isTrack() )
+	if( file != nullptr && file->isTrack() )
 	{
 		QMenu contextMenu( this );
 
@@ -517,7 +517,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 	}
 
 	FileItem * f = dynamic_cast<FileItem *>(i);
-	if(f != NULL){ previewFileItem(f); }
+	if(f != nullptr){ previewFileItem(f); }
 }
 
 
@@ -547,7 +547,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 		(file->extension() == "xiz" || file->extension() == "sf2" ||
 		 file->extension() == "sf3" || file->extension() == "gig" ||
 		 file ->extension() == "pat") &&
-		!pluginFactory->pluginSupportingExtension(file->extension()).info.isNull())
+		!pluginFactory->pluginSupportingExtension(file->extension()).isNull())
 	{
 		m_previewPlayHandle = new PresetPreviewPlayHandle(
 			file->fullName(), file->handling() == FileItem::LoadByPlugin);
@@ -568,11 +568,11 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			file->fullName(), file->handling() == FileItem::LoadByPlugin, &dataFile
 		);
 	}
-	if(m_previewPlayHandle != NULL)
+	if(m_previewPlayHandle != nullptr)
 	{
 		if(!Engine::mixer()->addPlayHandle(m_previewPlayHandle))
 		{
-			m_previewPlayHandle = NULL;
+			m_previewPlayHandle = nullptr;
 		}
 	}
 	m_pphMutex.unlock();
@@ -583,11 +583,11 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 
 bool FileBrowserTreeWidget::stopPreview()
 {
-	if (m_previewPlayHandle != NULL)
+	if (m_previewPlayHandle != nullptr)
 	{
 		m_pphMutex.lock();
 		Engine::mixer()->removePlayHandle(m_previewPlayHandle);
-		m_previewPlayHandle = NULL;
+		m_previewPlayHandle = nullptr;
 		m_pphMutex.unlock();
 		return true;
 	}
@@ -607,7 +607,7 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 		mouseReleaseEvent( NULL );
 
 		FileItem * f = dynamic_cast<FileItem *>( itemAt( m_pressPos ) );
-		if( f != NULL )
+		if( f != nullptr )
 		{
 			switch( f->type() )
 			{
@@ -658,7 +658,7 @@ void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 	m_mousePressed = false;
 
 	m_pphMutex.lock();
-	if(m_previewPlayHandle != NULL)
+	if(m_previewPlayHandle != nullptr)
 	{
 		// if there're samples shorter than 3 seconds, we don't
 		// stop them if the user releases mouse-button...
@@ -670,7 +670,7 @@ void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 						processingSampleRate() * 3))
 			{
 				s->setDoneMayReturnTrue(true);
-				m_previewPlayHandle = NULL;
+				m_previewPlayHandle = nullptr;
 				m_pphMutex.unlock();
 				return;
 			}
@@ -700,7 +700,7 @@ void FileBrowserTreeWidget::handleFile(FileItem * f, InstrumentTrack * it)
 		{
 			const QString e = f->extension();
 			Instrument * i = it->instrument();
-			if( i == NULL ||
+			if( i == nullptr ||
 				!i->descriptor()->supportsFileType( e ) )
 			{
 				PluginFactory::PluginInfoAndKey piakn =
@@ -740,7 +740,7 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 								int column )
 {
 	FileItem * f = dynamic_cast<FileItem *>( item );
-	if( f == NULL )
+	if( f == nullptr )
 	{
 		return;
 	}
@@ -748,7 +748,7 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 	if( f->handling() == FileItem::LoadAsProject ||
 		f->handling() == FileItem::ImportAsProject )
 	{
-		handleFile( f, NULL );
+		handleFile( f, nullptr );
 	}
 	else if( f->handling() != FileItem::NotSupported )
 	{
@@ -836,7 +836,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 		InstrumentTrackWindow * itw =
 			dynamic_cast<InstrumentTrackWindow *>(
 						w.previous()->widget() );
-		if( itw != NULL && itw->isHidden() == false )
+		if( itw != nullptr && itw->isHidden() == false )
 		{
 			handleFile( item, itw->model() );
 			break;
@@ -850,7 +850,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 {
 	Directory * dir = dynamic_cast<Directory *>( item );
-	if( dir != NULL )
+	if( dir != nullptr )
 	{
 		dir->update();
 	}
@@ -861,9 +861,9 @@ void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 
 
 
-QPixmap * Directory::s_folderPixmap = NULL;
-QPixmap * Directory::s_folderOpenedPixmap = NULL;
-QPixmap * Directory::s_folderLockedPixmap = NULL;
+QPixmap * Directory::s_folderPixmap = nullptr;
+QPixmap * Directory::s_folderOpenedPixmap = nullptr;
+QPixmap * Directory::s_folderLockedPixmap = nullptr;
 
 
 Directory::Directory(const QString & filename, const QString & path,
@@ -892,19 +892,19 @@ Directory::Directory(const QString & filename, const QString & path,
 
 void Directory::initPixmaps( void )
 {
-	if( s_folderPixmap == NULL )
+	if( s_folderPixmap == nullptr )
 	{
 		s_folderPixmap = new QPixmap(
 					embed::getIconPixmap( "folder" ) );
 	}
 
-	if( s_folderOpenedPixmap == NULL )
+	if( s_folderOpenedPixmap == nullptr )
 	{
 		s_folderOpenedPixmap = new QPixmap(
 				embed::getIconPixmap( "folder_opened" ) );
 	}
 
-	if( s_folderLockedPixmap == NULL )
+	if( s_folderLockedPixmap == nullptr )
 	{
 		s_folderLockedPixmap = new QPixmap(
 				embed::getIconPixmap( "folder_locked" ) );
@@ -982,7 +982,7 @@ bool Directory::addItems(const QString & path )
 			{
 				Directory * d = dynamic_cast<Directory *>(
 								child( i ) );
-				if( d == NULL || cur_file < d->text( 0 ) )
+				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done
 					insertChild( i, new Directory( cur_file,
@@ -1040,13 +1040,13 @@ bool Directory::addItems(const QString & path )
 
 
 
-QPixmap * FileItem::s_projectFilePixmap = NULL;
-QPixmap * FileItem::s_presetFilePixmap = NULL;
-QPixmap * FileItem::s_sampleFilePixmap = NULL;
-QPixmap * FileItem::s_soundfontFilePixmap = NULL;
-QPixmap * FileItem::s_vstPluginFilePixmap = NULL;
-QPixmap * FileItem::s_midiFilePixmap = NULL;
-QPixmap * FileItem::s_unknownFilePixmap = NULL;
+QPixmap * FileItem::s_projectFilePixmap = nullptr;
+QPixmap * FileItem::s_presetFilePixmap = nullptr;
+QPixmap * FileItem::s_sampleFilePixmap = nullptr;
+QPixmap * FileItem::s_soundfontFilePixmap = nullptr;
+QPixmap * FileItem::s_vstPluginFilePixmap = nullptr;
+QPixmap * FileItem::s_midiFilePixmap = nullptr;
+QPixmap * FileItem::s_unknownFilePixmap = nullptr;
 
 
 FileItem::FileItem(QTreeWidget * parent, const QString & name,
@@ -1074,43 +1074,43 @@ FileItem::FileItem(const QString & name, const QString & path ) :
 
 void FileItem::initPixmaps( void )
 {
-	if( s_projectFilePixmap == NULL )
+	if( s_projectFilePixmap == nullptr )
 	{
 		s_projectFilePixmap = new QPixmap( embed::getIconPixmap(
 						"project_file", 16, 16 ) );
 	}
 
-	if( s_presetFilePixmap == NULL )
+	if( s_presetFilePixmap == nullptr )
 	{
 		s_presetFilePixmap = new QPixmap( embed::getIconPixmap(
 						"preset_file", 16, 16 ) );
 	}
 
-	if( s_sampleFilePixmap == NULL )
+	if( s_sampleFilePixmap == nullptr )
 	{
 		s_sampleFilePixmap = new QPixmap( embed::getIconPixmap(
 						"sample_file", 16, 16 ) );
 	}
 
-	if ( s_soundfontFilePixmap == NULL )
+	if ( s_soundfontFilePixmap == nullptr )
 	{
 		s_soundfontFilePixmap = new QPixmap( embed::getIconPixmap(
 						"soundfont_file", 16, 16 ) );
 	}
 
-	if ( s_vstPluginFilePixmap == NULL )
+	if ( s_vstPluginFilePixmap == nullptr )
 	{
 		s_vstPluginFilePixmap = new QPixmap( embed::getIconPixmap(
 						"vst_plugin_file", 16, 16 ) );
 	}
 
-	if( s_midiFilePixmap == NULL )
+	if( s_midiFilePixmap == nullptr )
 	{
 		s_midiFilePixmap = new QPixmap( embed::getIconPixmap(
 							"midi_file", 16, 16 ) );
 	}
 
-	if( s_unknownFilePixmap == NULL )
+	if( s_unknownFilePixmap == nullptr )
 	{
 		s_unknownFilePixmap = new QPixmap( embed::getIconPixmap(
 							"unknown_file" ) );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -604,7 +604,7 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 					QApplication::startDragDistance() )
 	{
 		// make sure any playback is stopped
-		mouseReleaseEvent( NULL );
+		mouseReleaseEvent( nullptr );
 
 		FileItem * f = dynamic_cast<FileItem *>( itemAt( m_pressPos ) );
 		if( f != nullptr )

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -379,14 +379,14 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	// First of all, forward all keypresses
 	QTreeWidget::keyPressEvent(ke);
 	// Then, ignore all autorepeats (they would spam new tracks or previews)
-	if (ke->isAutoRepeat()){ return; }
+	if (ke->isAutoRepeat()) { return; }
 	// We should stop any running previews before we do anything new
-	else if (vertical || horizontal || preview || insert){ stopPreview(); }
+	else if (vertical || horizontal || preview || insert) { stopPreview(); }
 
 	// Try to get the currently selected item as a FileItem
 	FileItem * file = dynamic_cast<FileItem *>(currentItem());
 	// If it's null (folder, separator, etc.), there's nothing left for us to do
-	if (file == nullptr){ return; }
+	if (file == nullptr) { return; }
 
 	// When moving to a new sound, preview it. Skip presets, they can play forever
 	if (vertical && file->type() == FileItem::SampleFile)
@@ -408,7 +408,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	}
 
 	// When space is pressed, start a preview of the selected item
-	if (preview){ previewFileItem(file); }
+	if (preview) { previewFileItem(file); }
 }
 
 
@@ -417,7 +417,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 void FileBrowserTreeWidget::keyReleaseEvent(QKeyEvent* ke)
 {
 	// Cancel previews when the space key is released
-	if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()){ stopPreview(); }
+	if (ke->key() == Qt::Key_Space && !ke->isAutoRepeat()) { stopPreview(); }
 }
 
 
@@ -464,7 +464,7 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 		contextMenu.addActions( getContextActions(file, false) );
 
 		// We should only show the menu if it contains items
-		if (!contextMenu.isEmpty()){ contextMenu.exec( e->globalPos() ); }
+		if (!contextMenu.isEmpty()) { contextMenu.exec( e->globalPos() ); }
 	}
 }
 
@@ -489,7 +489,8 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 		[=]{ openInNewInstrumentTrack(file, songEditor); });
 	result.append(toInstrument);
 
-	if (songEditor && fileIsSample){
+	if (songEditor && fileIsSample)
+	{
 		QAction* toSampleTrack = new QAction(
 			tr("Send to new sample track (Shift + Enter)"),
 			nullptr
@@ -510,7 +511,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 	// Forward the event
 	QTreeWidget::mousePressEvent(me);
 	// QTreeWidget handles right clicks for us, so we only care about left clicks
-	if(me->button() != Qt::LeftButton){ return; }
+	if(me->button() != Qt::LeftButton) { return; }
 
 	QTreeWidgetItem * i = itemAt(me->pos());
 	if (i)
@@ -528,7 +529,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 	}
 
 	FileItem * f = dynamic_cast<FileItem *>(i);
-	if(f != nullptr){ previewFileItem(f); }
+	if(f != nullptr) { previewFileItem(f); }
 }
 
 
@@ -693,7 +694,6 @@ void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 
 
 
-
 void FileBrowserTreeWidget::handleFile(FileItem * f, InstrumentTrack * it)
 {
 	Engine::mixer()->requestChangeInModel();
@@ -789,7 +789,7 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(FileItem* item, bool songEd
 {
 	// Get the correct TrackContainer. Ternary doesn't compile here
 	TrackContainer* tc = Engine::getSong();
-	if (!songEditor){ tc = Engine::getBBTrackContainer(); }
+	if (!songEditor) { tc = Engine::getBBTrackContainer(); }
 	openInNewInstrumentTrack(tc, item);
 }
 
@@ -799,7 +799,7 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(FileItem* item, bool songEd
 bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 {
 	// Can't add non-samples to a sample track
-	if (item->type() != FileItem::SampleFile){ return false; }
+	if (item->type() != FileItem::SampleFile) { return false; }
 
 	// Create a new sample track for this sample
 	SampleTrack* sampleTrack = static_cast<SampleTrack*>(

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -390,11 +390,11 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 			}
 		case Qt::Key_Right:
 		{
-			if (!ke->isAutoRepeat()){
+			if (!ke->isAutoRepeat() && file != NULL){
 				if (!ke->modifiers())
-					{ tryAddSEInstrumentTrack(file); }
+					{ openInNewInstrumentTrackSE(file); }
 				else if (ke->modifiers() & Qt::ControlModifier)
-					{ tryAddBBInstrumentTrack(file); }
+					{ openInNewInstrumentTrackBBE(file); }
 			}
 			break;
 		}
@@ -416,8 +416,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
 	FileItem * file = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
-	if( file != NULL && (file->handling() == FileItem::LoadByPlugin ||
-	                    file->handling() == FileItem::LoadAsPreset) )
+	if( file != NULL && file->isTrack() )
 	{
 		QMenu contextMenu( this );
 
@@ -571,9 +570,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 		m_previewPlayHandle = new PresetPreviewPlayHandle(
 			file->fullName(), file->handling() == FileItem::LoadByPlugin );
 	}
-	else if( file->type() != FileItem::VstPluginFile &&
-			( file->handling() == FileItem::LoadAsPreset ||
-			file->handling() == FileItem::LoadByPlugin ) )
+	else if( file->type() != FileItem::VstPluginFile && file->isTrack() )
 	{
 		DataFile dataFile( file->fullName() );
 		if( !dataFile.validate( file->extension() ) )
@@ -769,8 +766,7 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 
 void FileBrowserTreeWidget::openInNewInstrumentTrack( TrackContainer* tc, FileItem* item )
 {
-	if( item->handling() == FileItem::LoadAsPreset ||
-		item->handling() == FileItem::LoadByPlugin )
+	if( item->isTrack() )
 	{
 		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
 				Track::create( Track::InstrumentTrack, tc ) );
@@ -810,22 +806,6 @@ void FileBrowserTreeWidget::openContainingFolder()
 		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.dir().path()));
 	}
 }
-
-
-
-void FileBrowserTreeWidget::tryAddSEInstrumentTrack(FileItem* file)
-{
-	if (file != NULL && file->isTrack()){ openInNewInstrumentTrackSE(file); }
-}
-
-
-
-
-void FileBrowserTreeWidget::tryAddBBInstrumentTrack(FileItem* file)
-{
-	if (file != NULL && file->isTrack()){ openInNewInstrumentTrackBBE(file); }
-}
-
 
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -55,7 +55,7 @@
 #include "StringPairDrag.h"
 #include "TextFloat.h"
 
-
+#include <QDebug>
 
 enum TreeWidgetItemTypes
 {
@@ -369,42 +369,49 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 
 void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 {
-	// Convenient things to check
+	// Shorter names for some commonly used properties of the event
 	const auto key = ke->key();
 	const bool vertical = key == Qt::Key_Up || key == Qt::Key_Down;
 	const bool horizontal = key == Qt::Key_Left || key == Qt::Key_Right;
-		
-	// We hijack left/right for preview/add, so don't let them navigate the tree
+
+	// First of all, forward all keypresses except left/right. Since we use them
+	// for preview & add, we have to ensure that they don't navigate in the tree
 	if (!horizontal){ QTreeWidget::keyPressEvent(ke); }
-	// We don't want to spam previews or track addition when a key is held
+	// Then, ignore all autorepeats (they would spam new tracks or previews)
 	if (ke->isAutoRepeat()){ return; }
-	// We should stop previews before we do anything new
-	if (vertical || horizontal){ stopPreview(); }
-	
-	// The currently selected file item
+
+	// Now add keys to expand/collapse folders, since we hijacked left/right
+	if (key == Qt::Key_Return || key == Qt::Key_Enter || key == Qt::Key_Space)
+	{ currentItem()->setExpanded(!currentItem()->isExpanded()); }
+	// We should stop any running previews before we do anything new
+	else if (vertical || horizontal){ stopPreview(); }
+
+	// Try to get the currently selected item as a FileItem
 	FileItem * file = dynamic_cast<FileItem *>(currentItem());
-	// If it's null, there's nothing for us to do
+	// If it's null (folder, separator, etc.), there's nothing left for us to do
 	if (file == NULL){ return; }
-	
-	// On navigation up/down, preview samples
-	// Don't automatically preview presets, because they can play forever
+
+	// When moving to a new sound, preview it. Skip presets, they can play forever
 	if (vertical && file->type() == FileItem::SampleFile)
 	{
 		previewFileItem(file);
 	}
-	
-	//On right arrow pressed, add the item
+
+	// When right arrow is pressed, add the selected item...
 	if (key == Qt::Key_Right)
 	{
+		// ...to the song editor by default, or to the BB editor if ctrl is held
 		bool songEditor = !(ke->modifiers() & Qt::ControlModifier);
+		// If shift is held, we send the item to a new sample track...
 		bool sampleTrack = ke->modifiers() & Qt::ShiftModifier;
-		//We can only send to sample tracks in the song editor
+		// ...but only in the song editor. So, ctrl+shift+right does nothing
 		if (sampleTrack && songEditor){ openInNewSampleTrack(file); }
+		// Otherwise we send the item as a new instrument track
 		else if (!sampleTrack){ openInNewInstrumentTrack(file, songEditor); }
 	}
 
-	//On left arrow pressed, start previewing the item
-	if (key == Qt::Key_Left) { previewFileItem(file); }
+	// When left arrow is pressed, start a preview of the selected item
+	if (key == Qt::Key_Left){ previewFileItem(file); }
 }
 
 
@@ -412,7 +419,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 
 void FileBrowserTreeWidget::keyReleaseEvent(QKeyEvent * ke )
 {
-	//Cancel previews when the left key is released
+	// Cancel previews when the left key is released
 	if (ke->key() == Qt::Key_Left && !ke->isAutoRepeat()){ stopPreview(); }
 }
 
@@ -426,36 +433,31 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 	{
 		QMenu contextMenu( this );
 
-		QAction* toActiveInstrument = new QAction(
-			tr( "Send to active instrument-track" ) );
-		connect(toActiveInstrument, &QAction::triggered,
-			[=]{ sendToActiveInstrumentTrack(file); });
-		contextMenu.addAction( toActiveInstrument );
-		
+		contextMenu.addAction(
+			tr( "Send to active instrument-track" ),
+			[=]{ sendToActiveInstrumentTrack(file); }
+		);
+
 		contextMenu.addSeparator();
 
-		QAction* openFolder = new QAction(
+		contextMenu.addAction(
 			QIcon(embed::getIconPixmap("folder")),
-			tr("Open containing folder")
+			tr("Open containing folder"),
+			[=]{ openContainingFolder(file); }
 		);
-		connect(openFolder, &QAction::triggered,
-			[=]{ openContainingFolder(file); });
-		contextMenu.addAction(openFolder);
 
-		QAction* songEditorHeader = new QAction( tr("Song Editor") );
+		QAction* songEditorHeader = new QAction( tr("Song Editor"), nullptr );
 		songEditorHeader->setDisabled(true);
 		contextMenu.addAction( songEditorHeader );
 		contextMenu.addActions( getContextActions(file, true) );
 
-		QAction* bbEditorHeader = new QAction( tr("BB Editor") );
+		QAction* bbEditorHeader = new QAction( tr("BB Editor"), nullptr );
 		bbEditorHeader->setDisabled(true);
 		contextMenu.addAction( bbEditorHeader );
 		contextMenu.addActions( getContextActions(file, false) );
 
-		//If all we have is the first action + two headers, the item isn't
-		//valid, so we shouldn't show the menu
-		if (!contextMenu.isEmpty())
-		{ contextMenu.exec( e->globalPos() ); }
+		// We should only show the menu if it contains items
+		if (!contextMenu.isEmpty()){ contextMenu.exec( e->globalPos() ); }
 	}
 }
 
@@ -466,24 +468,29 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 {
 	QList<QAction*> result = QList<QAction*>();
 	const bool fileIsSample = file->type() == FileItem::SampleFile;
-	
+
 	QString destination = fileIsSample ? "AFP Instance" : "Instrument Track";
 	QString shortcutMod = songEditor ? "" : "Ctrl + ";
-	
+
 	QAction* toInstrument = new QAction(
-		tr("Send to new %1 (%2Right Arrow)").arg(destination, shortcutMod));
+		tr("Send to new %1 (%2Right Arrow)")
+		.arg(destination, shortcutMod),
+		nullptr
+	);
 	connect(toInstrument, &QAction::triggered,
 		[=]{ openInNewInstrumentTrack(file, songEditor); });
 	result.append(toInstrument);
-	
-	if(songEditor && fileIsSample){
+
+	if (songEditor && fileIsSample){
 		QAction* toSampleTrack = new QAction(
-			tr("Send to new Sample Track (Shift + Right Arrow)"));
+			tr("Send to new Sample Track (Shift + Right Arrow)"),
+			nullptr
+		);
 		connect(toSampleTrack, &QAction::triggered,
-		[=]{ openInNewSampleTrack(file); });
+			[=]{ openInNewSampleTrack(file); });
 		result.append(toSampleTrack);
 	}
-	
+
 	return result;
 }
 
@@ -522,10 +529,10 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 {
 	m_pphMutex.lock();
-	//If something is already playing, stop it
+	// If something is already playing, stop it before we continue
 	stopPreview();
 
-	// in special case of sample-files we do not care about
+	// In special case of sample-files we do not care about
 	// handling() rather than directly creating a SamplePlayHandle
 	if(file->type() == FileItem::SampleFile)
 	{
@@ -773,7 +780,7 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(TrackContainer* tc, FileIte
 
 void FileBrowserTreeWidget::openInNewInstrumentTrack(FileItem* item, bool songEditor)
 {
-	//Get the correcy TrackContainer, ternary doesn't compile here so do it the long way
+	// Get the correct TrackContainer. Ternary doesn't compile here
 	TrackContainer* tc = Engine::getSong();
 	if (!songEditor){ tc = Engine::getBBTrackContainer(); }
 	openInNewInstrumentTrack(tc, item);
@@ -786,11 +793,11 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 {
 	// Can't add non-samples to a sample track
 	if (item->type() != FileItem::SampleFile){ return false; }
-	
+
 	// Create a new sample track for this sample
 	SampleTrack* sampleTrack = dynamic_cast<SampleTrack*>(
 		Track::create(Track::SampleTrack, Engine::getSong()));
-	
+
 	// Add the sample clip to the track
 	Engine::mixer()->requestChangeInModel();
 	SampleTCO* clip = dynamic_cast<SampleTCO*>(sampleTrack->createTCO(0));

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -688,6 +688,7 @@ void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 			}
 			else { stopPreview(); }
 		}
+		else { stopPreview(); }
 	}
 }
 
@@ -807,7 +808,7 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 
 	// Add the sample clip to the track
 	Engine::mixer()->requestChangeInModel();
-	SampleTCO* clip = dynamic_cast<SampleTCO*>(sampleTrack->createTCO(0));
+	SampleTCO* clip = static_cast<SampleTCO*>(sampleTrack->createTCO(0));
 	clip->setSampleFile(item->fullName());
 	Engine::mixer()->doneChangeInModel();
 	return true;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -372,6 +372,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	// Shorter names for some commonly used properties of the event
 	const auto key = ke->key();
 	const bool vertical = key == Qt::Key_Up || key == Qt::Key_Down;
+	const bool horizontal = key == Qt::Key_Left || key == Qt::Key_Right;
 	const bool preview = key == Qt::Key_Space;
 	const bool insert = key == Qt::Key_Enter || key == Qt::Key_Return;
 
@@ -380,7 +381,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	// Then, ignore all autorepeats (they would spam new tracks or previews)
 	if (ke->isAutoRepeat()){ return; }
 	// We should stop any running previews before we do anything new
-	else if (vertical || preview || insert){ stopPreview(); }
+	else if (vertical || horizontal || preview || insert){ stopPreview(); }
 
 	// Try to get the currently selected item as a FileItem
 	FileItem * file = dynamic_cast<FileItem *>(currentItem());

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -535,7 +535,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 
 
 void FileBrowserTreeWidget::previewFileItem(FileItem* file)
-{
+{	// TODO: We should do this work outside the event thread
 	// Lock the preview mutex
 	QMutexLocker previewLocker(&m_pphMutex);
 	// If something is already playing, stop it before we continue
@@ -553,6 +553,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			tr("Loading sample"),
 			tr("Please wait, loading sample for preview..."),
 			embed::getIconPixmap("sample_file", 24, 24), 0);
+		// TODO: this can be removed once we do this outside the event thread
 		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 		SamplePlayHandle* s = new SamplePlayHandle(fileName);
 		s->setDoneMayReturnTrue(false);


### PR DESCRIPTION
Now ready for testing and review

The file browser now behaves as follows:
- Pressing arrow keys, space, or enter/return will cancel any running previews
- Pressing up/down moves to the previous/next item
  - If the new item is a sample, it will automatically preview
  - If the key is held down and auto-repeats, previews are suppressed
- Holding space previews the current item. The preview ends when space is released.
- Enter/return sends the current item to the song editor as an instrument
  - Samples can be sent to a new sample track instead by holding shift
  - Holding control sends to the BB editor instead
  - Samples can't be sent as sample tracks to the BB editor (wontfix), so ctrl+shift does nothing
- RMB context menu gets fake headers, however legibility isn't ideal

![Preset Menu](https://user-images.githubusercontent.com/8918426/94586992-4285c880-0282-11eb-8f9e-e7d2761bf536.png)
![Sample Menu](https://user-images.githubusercontent.com/8918426/94587019-49acd680-0282-11eb-9827-1f58adc43365.png)

~Todo:~
- ~Sustained presets shouldn't play indefinitely. Only play presets while left arrow held?~ Done
- ~Shift + right arrow to add a sample to a new (empty) sample track in song editor~ Done
- ~Ctrl + shift + right arrow to add a sample to a new (empty) sample track in BB editor~ Not feasible, nor particularly useful.

~Code quality is iffy at best right now, among other things I did some questionable refactoring in the context menu code.~ The commit "DRY up code and ..." vastly improves this