### PR TITLE
Note selection: Editing values works in dialog

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1772,8 +1772,9 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 		{
 			const Note * closest = NULL;
 			int closest_dist = 9999999;
-			// if we caught multiple notes, find the closest...
-			if( nv.size() > 1 )
+			// if we caught multiple notes and we're not editing a
+			// selection, find the closest...
+			if( nv.size() > 1 && !isSelection() )
 			{
 				for ( const Note * i : nv )
 				{


### PR DESCRIPTION
Allow setting volume/pan for selected notes in pop up dialog.
I think this is safe for stable-1.2 but the PR works on master too.


Fixes https://github.com/LMMS/lmms/issues/5405