### PR TITLE
VST preset preview

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -214,6 +214,10 @@ public:
 
 	void setPreviewMode( const bool );
 
+	bool isPreviewMode() const
+	{
+		return m_previewMode;
+	}
 
 signals:
 	void instrumentChanged();

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -230,6 +230,8 @@ protected:
 		return "instrumenttrack";
 	}
 
+	QString getInstrumentName(const QDomElement & thisElement) const;
+
 
 protected slots:
 	void updateBaseNote();

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -234,7 +234,8 @@ protected:
 		return "instrumenttrack";
 	}
 
-	QString getInstrumentName(const QDomElement & thisElement) const;
+	// get the name of the instrument in the saved data
+	QString getSavedInstrumentName(const QDomElement & thisElement) const;
 
 
 protected slots:

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -198,9 +198,15 @@ void vestigeInstrument::loadSettings( const QDomElement & _this )
 	{
 		m_plugin->loadSettings( _this );
 
-		if ( _this.attribute( "guivisible" ).toInt() ) {
+		if (instrumentTrack() != NULL && instrumentTrack()->isPreviewMode())
+		{
+			m_plugin->hideUI();
+		}
+		else if (_this.attribute( "guivisible" ).toInt())
+		{
 			m_plugin->showUI();
-		} else {
+		} else
+		{
 			m_plugin->hideUI();
 		}
 
@@ -322,11 +328,16 @@ void vestigeInstrument::loadFile( const QString & _file )
 {
 	m_pluginMutex.lock();
 	const bool set_ch_name = ( m_plugin != NULL &&
-        	instrumentTrack()->name() == m_plugin->name() ) ||
-            	instrumentTrack()->name() == InstrumentTrack::tr( "Default preset" ) ||
-            	instrumentTrack()->name() == displayName();
+			instrumentTrack()->name() == m_plugin->name() ) ||
+			instrumentTrack()->name() == InstrumentTrack::tr( "Default preset" ) ||
+			instrumentTrack()->name() == displayName();
 
 	m_pluginMutex.unlock();
+
+	// if the same is loaded don't load again (for preview)
+	if (instrumentTrack() != NULL && instrumentTrack()->isPreviewMode() &&
+			m_pluginDLL == SampleBuffer::tryToMakeRelative( _file ))
+		return;
 
 	if ( m_plugin != NULL )
 	{
@@ -354,8 +365,11 @@ void vestigeInstrument::loadFile( const QString & _file )
 		return;
 	}
 
-	m_plugin->createUI(nullptr);
-	m_plugin->showUI();
+	if ( !(instrumentTrack() != NULL && instrumentTrack()->isPreviewMode()))
+	{
+		m_plugin->createUI(nullptr);
+		m_plugin->showUI();
+	}
 
 	if( set_ch_name )
 	{

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -156,19 +156,9 @@ PresetPreviewPlayHandle::PresetPreviewPlayHandle( const QString & _preset_file, 
 			dataFileCreated = true;
 		}
 
-		// vestige previews are bug prone; fallback on 3xosc with volume of 0
-		// without an instrument in preview track, it will segfault
-		if(dataFile->content().elementsByTagName( "vestige" ).length() == 0 )
-		{
-			s_previewTC->previewInstrumentTrack()->
-					loadTrackSpecificSettings(
-						dataFile->content().firstChild().toElement() );
-		}
-		else
-		{
-			s_previewTC->previewInstrumentTrack()->loadInstrument("tripleoscillator");
-			s_previewTC->previewInstrumentTrack()->setVolume( 0 );
-		}
+		s_previewTC->previewInstrumentTrack()->loadTrackSpecificSettings(
+					dataFile->content().firstChild().toElement());
+
 		if( dataFileCreated )
 		{
 			delete dataFile;

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -875,7 +875,7 @@ void InstrumentTrack::setPreviewMode( const bool value )
 
 QString InstrumentTrack::getSavedInstrumentName(const QDomElement &thisElement) const
 {
-	QDomNode elem = thisElement.firstChildElement("instrument");
+	QDomElement elem = thisElement.firstChildElement("instrument");
 	if (!elem.isNull())
 	{
 		return elem.attribute("name");

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -771,8 +771,7 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 
 void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement )
 {
-	silenceAllNotes(!(m_previewMode && m_instrument && m_instrument->nodeName() == "vestige"
-					&& getInstrumentName(thisElement) == "vestige"));
+	silenceAllNotes(!(m_previewMode && m_instrument && m_instrument->nodeName() == getInstrumentName(thisElement)));
 
 	lock();
 
@@ -821,14 +820,10 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 				typedef Plugin::Descriptor::SubPluginFeatures::Key PluginKey;
 				PluginKey key(node.toElement().elementsByTagName("key").item(0).toElement());
 
-				// don't delete vestige instrument in preview mode because loading vst
-				// can take long time, so better try change settings without recreating
-				// everything (this speeds up the loading of subsequent presets from one plugin)
-				if (m_previewMode && m_instrument && m_instrument->nodeName() == "vestige" &&
-						node.toElement().attribute("name") == "vestige")
+				// don't delete instrument in preview mode if it's the same
+				if (m_previewMode && m_instrument && m_instrument->nodeName() == node.toElement().attribute("name"))
 				{
 					m_instrument->restoreState(node.firstChildElement());
-					emit instrumentChanged();
 				}
 				else
 				{


### PR DESCRIPTION
Hello all.

Recently I started using LMMS, I like it very much. I started creating presets and it turned out that presets created in Vestige are not playing. In addition, when you click any VST preset, zynaddsubfx presets also stops playing. So I created a small patch that activates VST presets. To minimize the waiting time between preset switching, I changed the code to not delete the vestige instrument and plugin dll (when next preset uses the same plugin) every time preset is changed. Plugin UI is always hidden.

This is my first PR for LMMS so maybe I didn't understand something in the sources (spent only few hours). Maybe this patch will be helpful for someone who also wants to hear their presets. Tested on Linux.

Regards.