### PR TITLE
Piano roll vertical zoom

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -192,6 +192,8 @@ protected:
 	// for entering values with dblclick in the vol/pan bars
 	void enterValue( NoteVector* nv );
 
+	void updateYScroll();
+
 protected slots:
 	void play();
 	void record();
@@ -217,6 +219,7 @@ protected slots:
 	void updatePositionStepRecording(const MidiTime & t );
 
 	void zoomingChanged();
+	void zoomingYChanged();
 	void quantizeChanged();
 	void noteLengthChanged();
 	void quantizeNotes();
@@ -330,12 +333,14 @@ private:
 	static TextFloat * s_textFloat;
 
 	ComboBoxModel m_zoomingModel;
+	ComboBoxModel m_zoomingYModel;
 	ComboBoxModel m_quantizeModel;
 	ComboBoxModel m_noteLenModel;
 	ComboBoxModel m_scaleModel;
 	ComboBoxModel m_chordModel;
 
 	static const QVector<double> m_zoomLevels;
+	static const QVector<double> m_zoomYLevels;
 
 	Pattern* m_pattern;
 	NoteVector m_ghostNotes;
@@ -384,6 +389,12 @@ private:
 	int m_notesEditHeight;
 	int m_ppb;  // pixels per bar
 	int m_totalKeysToScroll;
+
+	static int s_keyLineHeight;
+	int m_octaveHeight;
+	int m_whiteKeySmallHeight;
+	int m_whiteKeyBigHeight;
+	int m_blackKeyHeight;
 
 	// remember these values to use them
 	// for the next note that is set
@@ -501,6 +512,7 @@ private:
 	PianoRoll* m_editor;
 
 	ComboBox * m_zoomingComboBox;
+	ComboBox * m_zoomingYComboBox;
 	ComboBox * m_quantizeComboBox;
 	ComboBox * m_noteLenComboBox;
 	ComboBox * m_scaleComboBox;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -180,7 +180,7 @@ protected:
 	void focusOutEvent( QFocusEvent * ) override;
 
 	int getKey( int y ) const;
-	static void drawNoteRect( QPainter & p, int x, int y,
+	void drawNoteRect( QPainter & p, int x, int y,
 					int  width, const Note * n, const QColor & noteCol, const QColor & noteTextColor,
 					const QColor & selCol, const int noteOpc, const bool borderless, bool drawNoteName );
 	void removeSelection();
@@ -390,7 +390,7 @@ private:
 	int m_ppb;  // pixels per bar
 	int m_totalKeysToScroll;
 
-	static int s_keyLineHeight;
+	int m_keyLineHeight;
 	int m_octaveHeight;
 	int m_whiteKeySmallHeight;
 	int m_whiteKeyBigHeight;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -78,11 +78,28 @@ const int SCROLLBAR_SIZE = 12;
 const int PIANO_X = 0;
 
 const int WHITE_KEY_WIDTH = 64;
-const int WHITE_KEY_SMALL_HEIGHT = 18;
+const int BLACK_KEY_WIDTH = 41;
+/*const int WHITE_KEY_SMALL_HEIGHT = 18;
 const int WHITE_KEY_BIG_HEIGHT = 24;
 const int BLACK_KEY_HEIGHT = 16;
 const int KEY_LINE_HEIGHT = 12;
-const int OCTAVE_HEIGHT = KEY_LINE_HEIGHT * KeysPerOctave;	// = 12 * 12;
+const int OCTAVE_HEIGHT = KEY_LINE_HEIGHT * KeysPerOctave;	// = 12 * 12;*/
+
+// double size
+/*const int WHITE_KEY_SMALL_HEIGHT = 27; //18*2; // key line * 1.5
+const int WHITE_KEY_BIG_HEIGHT = 36; //24*2; // key line * 2
+const int BLACK_KEY_HEIGHT = 24; //16*2; // keyline * 1.3333
+const int KEY_LINE_HEIGHT = 18; //12*2;
+const int OCTAVE_HEIGHT = KEY_LINE_HEIGHT * KeysPerOctave;	// = 12 * 12;*/
+
+const int KEY_LINE_HEIGHT = 24;
+const int DEFAULT_KEY_LINE_WIDTH = 12;
+const int OCTAVE_HEIGHT = KEY_LINE_HEIGHT * KeysPerOctave;
+const int WHITE_KEY_SMALL_HEIGHT = KEY_LINE_HEIGHT * 1.5;
+const int WHITE_KEY_BIG_HEIGHT = KEY_LINE_HEIGHT * 2;
+const int BLACK_KEY_HEIGHT = round(KEY_LINE_HEIGHT * 1.3333);
+
+
 
 const int NOTE_EDIT_RESIZE_BAR = 6;
 const int NOTE_EDIT_MIN_HEIGHT = 50;
@@ -139,7 +156,7 @@ PianoRoll::PianoRollKeyTypes PianoRoll::prKeyOrder[] =
 } ;
 
 
-const int DEFAULT_PR_PPB = KEY_LINE_HEIGHT * DefaultStepsPerBar;
+const int DEFAULT_PR_PPB = DEFAULT_KEY_LINE_WIDTH * DefaultStepsPerBar;
 
 const QVector<double> PianoRoll::m_zoomLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
@@ -2884,7 +2901,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 								PR_BLACK_KEY )
 		{
 			// draw it!
-			p.drawPixmap( PIANO_X, y - WHITE_KEY_SMALL_HEIGHT,
+			p.drawPixmap( PIANO_X, y - WHITE_KEY_SMALL_HEIGHT, WHITE_KEY_WIDTH, WHITE_KEY_SMALL_HEIGHT,
 							*s_whiteKeySmallPm );
 			// update y-pos
 			y -= WHITE_KEY_SMALL_HEIGHT / 2;
@@ -2901,11 +2918,13 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			// draw a small one while checking if it is pressed or not
 			if( hasValidPattern() && m_pattern->instrumentTrack()->pianoModel()->isKeyPressed( key ) )
 			{
-				p.drawPixmap( PIANO_X, y - WHITE_KEY_SMALL_HEIGHT, *s_whiteKeySmallPressedPm );
+				p.drawPixmap(PIANO_X, y - WHITE_KEY_SMALL_HEIGHT, WHITE_KEY_WIDTH, WHITE_KEY_SMALL_HEIGHT,
+							*s_whiteKeySmallPressedPm);
 			}
 			else
 			{
-				p.drawPixmap( PIANO_X, y - WHITE_KEY_SMALL_HEIGHT, *s_whiteKeySmallPm );
+				p.drawPixmap(PIANO_X, y - WHITE_KEY_SMALL_HEIGHT, WHITE_KEY_WIDTH, WHITE_KEY_SMALL_HEIGHT,
+							*s_whiteKeySmallPm);
 			}
 			// update y-pos
 			y -= WHITE_KEY_SMALL_HEIGHT;
@@ -2916,11 +2935,13 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			// draw a big one while checking if it is pressed or not
 			if( hasValidPattern() && m_pattern->instrumentTrack()->pianoModel()->isKeyPressed( key ) )
 			{
-				p.drawPixmap( PIANO_X, y - WHITE_KEY_BIG_HEIGHT, *s_whiteKeyBigPressedPm );
+				p.drawPixmap(PIANO_X, y - WHITE_KEY_BIG_HEIGHT, WHITE_KEY_WIDTH, WHITE_KEY_BIG_HEIGHT,
+							*s_whiteKeyBigPressedPm);
 			}
 			else
 			{
-				p.drawPixmap( PIANO_X, y-WHITE_KEY_BIG_HEIGHT, *s_whiteKeyBigPm );
+				p.drawPixmap(PIANO_X, y-WHITE_KEY_BIG_HEIGHT, WHITE_KEY_WIDTH, WHITE_KEY_BIG_HEIGHT,
+							*s_whiteKeyBigPm);
 			}
 			// if a big white key has been the first key,
 			// black keys needs to be lifted up
@@ -3000,7 +3021,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 								PR_BLACK_KEY )
 		{
 			// draw the black key!
-			p.drawPixmap( PIANO_X, y - BLACK_KEY_HEIGHT / 2,
+			p.drawPixmap( PIANO_X, y - BLACK_KEY_HEIGHT / 2, BLACK_KEY_WIDTH, BLACK_KEY_HEIGHT,
 								*s_blackKeyPm );
 			// is the one after the start-note a black key??
 			if( prKeyOrder[( key + 1 ) % KeysPerOctave] !=
@@ -3021,14 +3042,14 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				p.drawPixmap( PIANO_X, y - ( first_white_key_height -
 						WHITE_KEY_SMALL_HEIGHT ) -
 						WHITE_KEY_SMALL_HEIGHT/2 - 1 -
-						BLACK_KEY_HEIGHT, *s_blackKeyPressedPm );
+						BLACK_KEY_HEIGHT, BLACK_KEY_WIDTH, BLACK_KEY_HEIGHT, *s_blackKeyPressedPm );
 			}
 		    else
 			{
 				p.drawPixmap( PIANO_X, y - ( first_white_key_height -
 						WHITE_KEY_SMALL_HEIGHT ) -
 						WHITE_KEY_SMALL_HEIGHT/2 - 1 -
-						BLACK_KEY_HEIGHT, *s_blackKeyPm );
+						BLACK_KEY_HEIGHT, BLACK_KEY_WIDTH, BLACK_KEY_HEIGHT, *s_blackKeyPm );
 			}
 			// update y-pos
 			y -= WHITE_KEY_BIG_HEIGHT;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2869,7 +2869,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	p.setFont( pointSize<8>( p.font() ) );
 	QFontMetrics fontMetrics(p.font());
 	QRect const boundingRect = fontMetrics.boundingRect(QChar::fromLatin1('H'));
-	int const fontHeight = - boundingRect.top() - boundingRect.bottom();
+	// This is two times of the y coordinate of the center of the bounding rectangle
+	// (-(top+bottom)=-2(center)) but labelHeight is more intuitive/describing name
+	int const labelHeight = - boundingRect.top() - boundingRect.bottom();
 
 	// y_offset is used to align the piano-keys on the key-lines
 	int y_offset = 0;
@@ -2968,18 +2970,18 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		{
 		case 0: // C
 		case 5: // F
-			yCorrectionForNoteLabels = (m_whiteKeySmallHeight - fontHeight + 1) / -2;
+			yCorrectionForNoteLabels = (m_whiteKeySmallHeight - labelHeight + 1) / -2;
 			break;
 		case 2: // D
 		case 7: // G
 		case 9: // A
-			yCorrectionForNoteLabels = (m_whiteKeyBigHeight / 2 - fontHeight + 1) / -2;
+			yCorrectionForNoteLabels = (m_whiteKeyBigHeight / 2 - labelHeight + 1) / -2;
 			break;
 		case 4: // E
 		case 11: // B
 			// calculate center point of key and move half of text
 			yCorrectionForNoteLabels = -(((m_whiteKeySmallHeight - (m_whiteKeySmallHeight * 2 + 3) / 6) / 4)
-										 - fontHeight / 2);
+										 - labelHeight / 2);
 			break;
 		}
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -176,7 +176,7 @@ PianoRoll::PianoRoll() :
 	m_keyLineHeight(DEFAULT_KEY_LINE_HEIGHT),
 	m_octaveHeight(m_keyLineHeight * KeysPerOctave),
 	m_whiteKeySmallHeight(round(m_keyLineHeight * 1.5)),
-	m_whiteKeyBigHeight(round(m_keyLineHeight * 2)),
+	m_whiteKeyBigHeight(m_keyLineHeight * 2),
 	m_blackKeyHeight(round(m_keyLineHeight * 1.3333)),
 	m_lenOfNewNotes( MidiTime( 0, DefaultTicksPerBar/4 ) ),
 	m_lastNoteVolume( DefaultVolume ),
@@ -4310,7 +4310,7 @@ void PianoRoll::zoomingYChanged()
 	m_keyLineHeight = m_zoomYLevels[m_zoomingYModel.value()] * DEFAULT_KEY_LINE_HEIGHT;
 	m_octaveHeight = m_keyLineHeight * KeysPerOctave;
 	m_whiteKeySmallHeight = round(m_keyLineHeight * 1.5);
-	m_whiteKeyBigHeight = round(m_keyLineHeight * 2);
+	m_whiteKeyBigHeight = m_keyLineHeight * 2;
 	m_blackKeyHeight = round(m_keyLineHeight * 1.3333);
 
 	updateYScroll();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2867,6 +2867,8 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 	// set font-size to 8
 	p.setFont( pointSize<8>( p.font() ) );
+	QFontMetrics fontMetrics(p.font());
+	int const fontHeight = fontMetrics.boundingRect(QChar::fromLatin1('H')).height();
 
 	// y_offset is used to align the piano-keys on the key-lines
 	int y_offset = 0;
@@ -2961,20 +2963,22 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		int yCorrectionForNoteLabels = 0;
 
 		int keyCode = key % KeysPerOctave;
-		switch( keyCode )
+		switch (keyCode)
 		{
-		case 0:
-		case 5:
-			yCorrectionForNoteLabels = -4;
+		case 0: // C
+		case 5: // F
+			yCorrectionForNoteLabels = (m_whiteKeySmallHeight - fontHeight + 1) / -2;
 			break;
-		case 2:
-		case 7:
-		case 9:
-			yCorrectionForNoteLabels = -2;
+		case 2: // D
+		case 7: // G
+		case 9: // A
+			yCorrectionForNoteLabels = (m_whiteKeyBigHeight / 2 - fontHeight + 1) / -2;
 			break;
-		case 4:
-		case 11:
-			yCorrectionForNoteLabels = 2;
+		case 4: // E
+		case 11: // B
+			// calculate center point of key and move half of text
+			yCorrectionForNoteLabels = -(((m_whiteKeySmallHeight - (m_whiteKeySmallHeight * 2 + 3) / 6) / 4)
+										 - fontHeight / 2);
 			break;
 		}
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -121,8 +121,6 @@ QPixmap * PianoRoll::s_toolOpen = NULL;
 
 TextFloat * PianoRoll::s_textFloat = NULL;
 
-int PianoRoll::s_keyLineHeight = DEFAULT_KEY_LINE_HEIGHT;
-
 static QString s_noteStrings[12] = { "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
 
 static QString getNoteString( int key )
@@ -175,10 +173,11 @@ PianoRoll::PianoRoll() :
 	m_oldNotesEditHeight( 100 ),
 	m_notesEditHeight( 100 ),
 	m_ppb( DEFAULT_PR_PPB ),
-	m_octaveHeight(s_keyLineHeight * KeysPerOctave),
-	m_whiteKeySmallHeight(round(s_keyLineHeight * 1.5)),
-	m_whiteKeyBigHeight(round(s_keyLineHeight * 2)),
-	m_blackKeyHeight(round(s_keyLineHeight * 1.3333)),
+	m_keyLineHeight(DEFAULT_KEY_LINE_HEIGHT),
+	m_octaveHeight(m_keyLineHeight * KeysPerOctave),
+	m_whiteKeySmallHeight(round(m_keyLineHeight * 1.5)),
+	m_whiteKeyBigHeight(round(m_keyLineHeight * 2)),
+	m_blackKeyHeight(round(m_keyLineHeight * 1.3333)),
 	m_lenOfNewNotes( MidiTime( 0, DefaultTicksPerBar/4 ) ),
 	m_lastNoteVolume( DefaultVolume ),
 	m_lastNotePanning( DefaultPanning ),
@@ -968,7 +967,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 
 	const int borderWidth = borders ? 1 : 0;
 
-	const int noteHeight = s_keyLineHeight - 1 - borderWidth;
+	const int noteHeight = m_keyLineHeight - 1 - borderWidth;
 	int noteWidth = width + 1 - borderWidth;
 
 	// adjust note to make it a bit faded if it has a lower volume
@@ -1039,7 +1038,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 void PianoRoll::drawDetuningInfo( QPainter & _p, const Note * _n, int _x,
 								int _y ) const
 {
-	int middle_y = _y + s_keyLineHeight / 2;
+	int middle_y = _y + m_keyLineHeight / 2;
 	_p.setPen( noteColor() );
 	_p.setClipRect(WHITE_KEY_WIDTH, PR_TOP_MARGIN,
 		width() - WHITE_KEY_WIDTH,
@@ -1056,7 +1055,7 @@ void PianoRoll::drawDetuningInfo( QPainter & _p, const Note * _n, int _x,
 
 		const float level = it.value();
 
-		int pos_y = middle_y - level * s_keyLineHeight;
+		int pos_y = middle_y - level * m_keyLineHeight;
 
 		if( old_x != 0 && old_y != 0 )
 		{
@@ -2613,7 +2612,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			int visible_keys = ( height() - PR_TOP_MARGIN -
 						PR_BOTTOM_MARGIN -
 						m_notesEditHeight ) /
-							s_keyLineHeight + 2;
+							m_keyLineHeight + 2;
 			const int s_key = m_startKey - 1;
 
 			if( key_num <= s_key )
@@ -2870,13 +2869,13 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// calculate y_offset according to first key
 	switch( prKeyOrder[m_startKey % KeysPerOctave] )
 	{
-		case PR_BLACK_KEY: y_offset = s_keyLineHeight / 4; break;
-		case PR_WHITE_KEY_BIG: y_offset = s_keyLineHeight / 2; break;
+		case PR_BLACK_KEY: y_offset = m_keyLineHeight / 4; break;
+		case PR_WHITE_KEY_BIG: y_offset = m_keyLineHeight / 2; break;
 		case PR_WHITE_KEY_SMALL:
 			if( prKeyOrder[( ( m_startKey + 1 ) %
 					KeysPerOctave)] != PR_BLACK_KEY )
 			{
-				y_offset = s_keyLineHeight / 2;
+				y_offset = m_keyLineHeight / 2;
 			}
 			break;
 	}
@@ -2892,7 +2891,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 	// draw all white keys...
 	for( int y = key_line_y + 1 + y_offset; y > PR_TOP_MARGIN;
-			key_line_y -= s_keyLineHeight, ++keys_processed )
+			key_line_y -= m_keyLineHeight, ++keys_processed )
 	{
 		// check for white key that is only half visible on the
 		// bottom of piano-roll
@@ -2977,7 +2976,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		if( Piano::isWhiteKey( key ) )
 		{
 			// Draw note names if activated in the preferences, C notes are always drawn
-			if ( (key % 12 == 0 || drawNoteNames) && s_keyLineHeight > 10 )
+			if ( (key % 12 == 0 || drawNoteNames) && m_keyLineHeight > 10 )
 			{
 				QString noteString = getNoteString( key );
 
@@ -3028,7 +3027,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 								PR_BLACK_KEY )
 			{
 				// no, then move it up!
-				y -= s_keyLineHeight / 2;
+				y -= m_keyLineHeight / 2;
 			}
 		}
 		// current key black?
@@ -3124,7 +3123,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		// Draw horizontal lines
 		key = m_startKey;
 		for( int y = keyAreaBottom() - 1; y > PR_TOP_MARGIN;
-				y -= s_keyLineHeight )
+				y -= m_keyLineHeight )
 		{
 			if( static_cast<Keys>( key % KeysPerOctave ) == Key_C )
 			{
@@ -3183,14 +3182,14 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		{
 			const int key_num = m_markedSemiTones.at( i );
 			const int y = keyAreaBottom() + 5
-				- s_keyLineHeight * ( key_num - m_startKey + 1 );
+				- m_keyLineHeight * ( key_num - m_startKey + 1 );
 
 			if( y > keyAreaBottom() )
 			{
 				break;
 			}
 
-			p.fillRect( WHITE_KEY_WIDTH + 1, y - s_keyLineHeight / 2, width() - 10, s_keyLineHeight + 1,
+			p.fillRect( WHITE_KEY_WIDTH + 1, y - m_keyLineHeight / 2, width() - 10, m_keyLineHeight + 1,
 				    markedSemitoneColor() );
 		}
 	}
@@ -3221,7 +3220,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				height() - PR_TOP_MARGIN );
 
 		const int visible_keys = ( keyAreaBottom()-keyAreaTop() ) /
-							s_keyLineHeight + 2;
+							m_keyLineHeight + 2;
 
 		QPolygonF editHandles;
 
@@ -3260,7 +3259,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 					// we've done and checked all, let's draw the
 					// note
 					drawNoteRect( p, x + WHITE_KEY_WIDTH,
-							y_base - key * s_keyLineHeight,
+							y_base - key * m_keyLineHeight,
 									note_width, note, ghostNoteColor(), ghostNoteTextColor(), selectedNoteColor(),
 									ghostNoteOpacity(), ghostNoteBorders(), drawNoteNames );
 				}
@@ -3302,7 +3301,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				// we've done and checked all, let's draw the
 				// note
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
-						y_base - key * s_keyLineHeight,
+						y_base - key * m_keyLineHeight,
 								note_width, note, noteColor(), noteTextColor(), selectedNoteColor(),
 								noteOpacity(), noteBorders(), drawNoteNames );
 			}
@@ -3353,7 +3352,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			{
 				drawDetuningInfo( p, note,
 					x + WHITE_KEY_WIDTH,
-					y_base - key * s_keyLineHeight );
+					y_base - key * m_keyLineHeight );
 				p.setClipRect(WHITE_KEY_WIDTH, PR_TOP_MARGIN,
 					width() - WHITE_KEY_WIDTH,
 					height() - PR_TOP_MARGIN);
@@ -3389,7 +3388,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 				// we've done and checked all, let's draw the note
 				drawNoteRect( p, x + WHITE_KEY_WIDTH,
-						y_base - key * s_keyLineHeight,
+						y_base - key * m_keyLineHeight,
 								note_width, note, m_stepRecorder.curStepNoteColor(), noteTextColor(), selectedNoteColor(),
 								noteOpacity(), noteBorders(), drawNoteNames );
 			}
@@ -3420,8 +3419,8 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 						MidiTime::ticksPerBar();
 	int w = ( ( ( sel_pos_end - m_currentPosition ) * m_ppb ) /
 						MidiTime::ticksPerBar() ) - x;
-	int y = (int) y_base - sel_key_start * s_keyLineHeight;
-	int h = (int) y_base - sel_key_end * s_keyLineHeight - y;
+	int y = (int) y_base - sel_key_start * m_keyLineHeight;
+	int h = (int) y_base - sel_key_end * m_keyLineHeight - y;
 	p.setPen( selectedNoteColor() );
 	p.setBrush( Qt::NoBrush );
 	p.drawRect( x + WHITE_KEY_WIDTH, y, w, h );
@@ -3447,8 +3446,8 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	if( hasValidPattern() )
 	{
 		int key_num = getKey( mapFromGlobal( QCursor::pos() ).y() );
-		p.fillRect( 10, keyAreaBottom() + 3 - s_keyLineHeight *
-					( key_num - m_startKey + 1 ), width() - 10, s_keyLineHeight - 7, currentKeyCol );
+		p.fillRect( 10, keyAreaBottom() + 3 - m_keyLineHeight *
+					( key_num - m_startKey + 1 ), width() - 10, m_keyLineHeight - 7, currentKeyCol );
 	}
 
 	// bar to resize note edit area
@@ -3669,7 +3668,7 @@ int PianoRoll::getKey(int y ) const
 {
 	int key_line_y = keyAreaBottom() - 1;
 	// pressed key on piano
-	int key_num = ( key_line_y - y ) / s_keyLineHeight;
+	int key_num = ( key_line_y - y ) / m_keyLineHeight;
 	key_num += m_startKey;
 
 	// some range-checking-stuff
@@ -4308,11 +4307,11 @@ void PianoRoll::zoomingChanged()
 
 void PianoRoll::zoomingYChanged()
 {
-	s_keyLineHeight = m_zoomYLevels[m_zoomingYModel.value()] * DEFAULT_KEY_LINE_HEIGHT;
-	m_octaveHeight = s_keyLineHeight * KeysPerOctave;
-	m_whiteKeySmallHeight = round(s_keyLineHeight * 1.5);
-	m_whiteKeyBigHeight = round(s_keyLineHeight * 2);
-	m_blackKeyHeight = round(s_keyLineHeight * 1.3333);
+	m_keyLineHeight = m_zoomYLevels[m_zoomingYModel.value()] * DEFAULT_KEY_LINE_HEIGHT;
+	m_octaveHeight = m_keyLineHeight * KeysPerOctave;
+	m_whiteKeySmallHeight = round(m_keyLineHeight * 1.5);
+	m_whiteKeyBigHeight = round(m_keyLineHeight * 2);
+	m_blackKeyHeight = round(m_keyLineHeight * 1.3333);
 
 	updateYScroll();
 	update();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1009,7 +1009,12 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 
 			int const distanceToBorder = 2;
 			int const xOffset = borderWidth + distanceToBorder;
-			int const yOffset = ((noteHeight + fontMetrics.capHeight()) + 1) / 2;
+
+			// noteTextHeight, textSize are not suitable for determining vertical spacing, 
+			// capHeight() can be used for this, but requires Qt 5.8. 
+			// We use boundingRect() with QChar (the QString version returns wrong value).
+			QRect const boundingRect = fontMetrics.boundingRect(QChar::fromLatin1('H'));
+			int const yOffset = (noteHeight - boundingRect.top() - boundingRect.bottom()) / 2;
 
 			if (textSize.width() < noteWidth - xOffset)
 			{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1009,7 +1009,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 
 			int const distanceToBorder = 2;
 			int const xOffset = borderWidth + distanceToBorder;
-			int const yOffset = (noteHeight + noteTextHeight) / 2;
+			int const yOffset = ((noteHeight + fontMetrics.capHeight()) * 8 + 8) / 16;
 
 			if (textSize.width() < noteWidth - xOffset)
 			{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1009,7 +1009,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 
 			int const distanceToBorder = 2;
 			int const xOffset = borderWidth + distanceToBorder;
-			int const yOffset = ((noteHeight + fontMetrics.capHeight()) * 8 + 8) / 16;
+			int const yOffset = ((noteHeight + fontMetrics.capHeight()) + 1) / 2;
 
 			if (textSize.width() < noteWidth - xOffset)
 			{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2868,7 +2868,8 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// set font-size to 8
 	p.setFont( pointSize<8>( p.font() ) );
 	QFontMetrics fontMetrics(p.font());
-	int const fontHeight = fontMetrics.boundingRect(QChar::fromLatin1('H')).height();
+	QRect const boundingRect = fontMetrics.boundingRect(QChar::fromLatin1('H'));
+	int const fontHeight = - boundingRect.top() - boundingRect.bottom();
 
 	// y_offset is used to align the piano-keys on the key-lines
 	int y_offset = 0;


### PR DESCRIPTION
Hi,

After several hours of work / study at Piano Roll, I noticed that too small notes cause eye pain. So I implemented vertical zoom to relieve my eyes. This significantly improves the comfort of work.
This fixes https://github.com/LMMS/lmms/issues/2294 from https://github.com/LMMS/lmms/issues/4877.

### Screenshots
Default value is the same:
![pianoroll_100_100](https://user-images.githubusercontent.com/63190361/78698516-be6e0c00-7902-11ea-8d28-29b399fdacb1.png)

Personally, I prefer 150% in both directions, which is similar to FL Studio:
![pianoroll_150_150](https://user-images.githubusercontent.com/63190361/78698684-fd9c5d00-7902-11ea-8f03-fef2dc90e9ed.png)

Of course, the size can be specified in each direction separately:
![pianoroll_100_200](https://user-images.githubusercontent.com/63190361/78698811-2d4b6500-7903-11ea-8836-497fea236d26.png)

### Notes
I did not change the names of the variables related to horizontal zoom (like `zoomingChanged()`, `m_zoomingComboBox` etc.) to facilitate the code review.

Regards

