### PR TITLE
Audio/MidiJack: Fix invalid reads

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -58,6 +58,7 @@ public:
 	// the jack callback is handled here, we call the midi client so that it can read
 	// it's midi data during the callback
 	AudioJack * addMidiClient(MidiJack *midiClient);
+	void removeMidiClient(void) { m_midiClient = nullptr; }
 	jack_client_t * jackClient() {return m_client;};
 
 	inline static QString name()
@@ -109,7 +110,7 @@ private:
 	bool m_active;
 	std::atomic<bool> m_stopped;
 
-	MidiJack *m_midiClient;
+	std::atomic<MidiJack *> m_midiClient;
 	QVector<jack_port_t *> m_outputPorts;
 	jack_default_audio_sample_t * * m_tempOutBufs;
 	surroundSampleFrame * m_outBuf;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -34,6 +34,7 @@
 #include "AudioWeakJack.h"
 #endif
 
+#include <atomic>
 #include <QtCore/QVector>
 #include <QtCore/QList>
 #include <QtCore/QMap>
@@ -106,7 +107,7 @@ private:
 	jack_client_t * m_client;
 
 	bool m_active;
-	bool m_stopped;
+	std::atomic<bool> m_stopped;
 
 	MidiJack *m_midiClient;
 	QVector<jack_port_t *> m_outputPorts;

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -346,8 +346,8 @@ int AudioJack::processCallback( jack_nframes_t _nframes, void * _udata )
 	// add to the following sound processing
 	if( m_midiClient && _nframes > 0 )
 	{
-		m_midiClient->JackMidiRead(_nframes);
-		m_midiClient->JackMidiWrite(_nframes);
+		m_midiClient.load()->JackMidiRead(_nframes);
+		m_midiClient.load()->JackMidiWrite(_nframes);
 	}
 
 	for( int c = 0; c < channels(); ++c )

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -56,6 +56,8 @@ AudioJack::AudioJack( bool & _success_ful, Mixer*  _mixer ) :
 	m_framesDoneInCurBuf( 0 ),
 	m_framesToDoInCurBuf( 0 )
 {
+	m_stopped = true;
+
 	_success_ful = initJackClient();
 	if( _success_ful )
 	{
@@ -201,8 +203,6 @@ bool AudioJack::initJackClient()
 
 void AudioJack::startProcessing()
 {
-	m_stopped = false;
-
 	if( m_active || m_client == NULL )
 	{
 		return;
@@ -245,6 +245,7 @@ void AudioJack::startProcessing()
 		}
 	}
 
+	m_stopped = false;
 	free( ports );
 }
 

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -95,6 +95,8 @@ MidiJack::MidiJack() :
 		/* jack midi out not implemented
 		   JackMidiWrite and sendByte needs to be functional
 		   before enabling this
+		   If you enable this, also enable the
+		   corresponding jack_port_unregister line below
 		m_output_port = jack_port_register(
 				jackClient(), "MIDI out", JACK_DEFAULT_MIDI_TYPE,
 				JackPortIsOutput, 0);
@@ -123,9 +125,11 @@ MidiJack::~MidiJack()
 			printf("Failed to unregister jack midi input\n");
 		}
 
+		/* Unused yet, see the corresponding jack_port_register call
 		if( jack_port_unregister( jackClient(), m_output_port) != 0){
 			printf("Failed to unregister jack midi output\n");
 		}
+		*/
 
 		if(m_jackClient)
 		{

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -116,6 +116,9 @@ MidiJack::~MidiJack()
 {
 	if(jackClient())
 	{
+		// remove ourselves first (atomically), so we will not get called again
+		m_jackAudio->removeMidiClient();
+
 		if( jack_port_unregister( jackClient(), m_input_port) != 0){
 			printf("Failed to unregister jack midi input\n");
 		}

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -174,19 +174,22 @@ void MidiJack::JackMidiRead(jack_nframes_t nframes)
 	jack_nframes_t event_index = 0;
 	jack_nframes_t event_count = jack_midi_get_event_count(port_buf);
 
-	jack_midi_event_get(&in_event, port_buf, 0);
-	for(i=0; i<nframes; i++)
+	int rval = jack_midi_event_get(&in_event, port_buf, 0);
+	if (rval == 0 /* 0 = success */)
 	{
-		if((in_event.time == i) && (event_index < event_count))
+		for(i=0; i<nframes; i++)
 		{
-			// lmms is setup to parse bytes coming from a device
-			// parse it byte by byte as it expects
-			for(b=0;b<in_event.size;b++)
-				parseData( *(in_event.buffer + b) );
+			if((in_event.time == i) && (event_index < event_count))
+			{
+				// lmms is setup to parse bytes coming from a device
+				// parse it byte by byte as it expects
+				for(b=0;b<in_event.size;b++)
+					parseData( *(in_event.buffer + b) );
 
-			event_index++;
-			if(event_index < event_count)
-				jack_midi_event_get(&in_event, port_buf, event_index);
+				event_index++;
+				if(event_index < event_count)
+					jack_midi_event_get(&in_event, port_buf, event_index);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5408 

Info for testers:
* You need to have both JackAudio and JackMidi enabled in the settings to test this PR (restart required after changing settings).
* I already tested that the warnings from valgrind are gone now, but if someone who uses JackMidi can confirm that it still works as usual, that would be nice.