### PR TITLE
Add "Open containing folder" (#5453)

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -125,9 +125,9 @@ private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
 	void openInNewInstrumentTrackBBE( void );
 	void openInNewInstrumentTrackSE( void );
-	void openContainingFolder();
 	void sendToActiveInstrumentTrack( void );
 	void updateDirectory( QTreeWidgetItem * item );
+	void openContainingFolder();
 
 } ;
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -125,6 +125,7 @@ private slots:
 	void activateListItem( QTreeWidgetItem * item, int column );
 	void openInNewInstrumentTrackBBE( void );
 	void openInNewInstrumentTrackSE( void );
+	void openContainingFolder();
 	void sendToActiveInstrumentTrack( void );
 	void updateDirectory( QTreeWidgetItem * item );
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -364,30 +364,41 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
-	FileItem * f = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
-	if( f != NULL && ( f->handling() == FileItem::LoadAsPreset ||
-				 f->handling() == FileItem::LoadByPlugin ) )
+	FileItem * f = dynamic_cast<FileItem *>(itemAt(e->pos()));
+	if (f == nullptr)
 	{
+		return;
+	}
+
+	if (f->handling() == FileItem::LoadAsPreset || f->handling() == FileItem::LoadByPlugin)
+	{
+		// Set the member to the current FileItem so that it is available during the
+		// execution of the slots of the context menu we are about to create and execute.
 		m_contextMenuItem = f;
-		QMenu contextMenu( this );
-		contextMenu.addAction( tr( "Send to active instrument-track" ),
-						this,
-					SLOT( sendToActiveInstrumentTrack() ) );
-		contextMenu.addAction( tr( "Open in new instrument-track/"
-								"Song Editor" ),
-						this,
-					SLOT( openInNewInstrumentTrackSE() ) );
-		contextMenu.addAction( tr( "Open in new instrument-track/"
-								"B+B Editor" ),
-						this,
-					SLOT( openInNewInstrumentTrackBBE() ) );
-		contextMenu.addSeparator();
-		contextMenu.addAction( QIcon(embed::getIconPixmap( "folder" )),
-					tr( "Open containing folder" ),
+
+		QMenu contextMenu(this);
+
+		contextMenu.addAction(tr("Send to active instrument-track"),
 					this,
-					SLOT( openContainingFolder() ) );
-		contextMenu.exec( e->globalPos() );
-		m_contextMenuItem = NULL;
+					SLOT(sendToActiveInstrumentTrack()));
+		contextMenu.addAction(tr("Open in new instrument-track/Song Editor"),
+					this,
+					SLOT(openInNewInstrumentTrackSE()));
+		contextMenu.addAction(tr("Open in new instrument-track/B+B Editor"),
+					this,
+					SLOT(openInNewInstrumentTrackBBE()));
+
+		contextMenu.addSeparator();
+
+		contextMenu.addAction(QIcon(embed::getIconPixmap("folder")),
+					tr("Open containing folder"),
+					this,
+					SLOT(openContainingFolder()));
+
+		contextMenu.exec(e->globalPos());
+
+		// The context menu has been executed so we can reset this member back to nullptr.
+		m_contextMenuItem = nullptr;
 	}
 }
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -24,6 +24,7 @@
  */
 
 
+#include <QDesktopServices>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLineEdit>
@@ -380,6 +381,11 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 								"B+B Editor" ),
 						this,
 					SLOT( openInNewInstrumentTrackBBE() ) );
+		contextMenu.addSeparator();
+		contextMenu.addAction( QIcon(embed::getIconPixmap( "folder" )),
+					tr( "Open containing folder" ),
+					this,
+					SLOT( openContainingFolder() ) );
 		contextMenu.exec( e->globalPos() );
 		m_contextMenuItem = NULL;
 	}
@@ -669,6 +675,16 @@ void FileBrowserTreeWidget::openInNewInstrumentTrackSE( void )
 	openInNewInstrumentTrack( Engine::getSong() );
 }
 
+
+
+void FileBrowserTreeWidget::openContainingFolder()
+{
+	if (m_contextMenuItem)
+	{
+		QFileInfo fileInfo(m_contextMenuItem->fullName());
+		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.dir().path()));
+	}
+}
 
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -692,6 +692,12 @@ void FileBrowserTreeWidget::openContainingFolder()
 {
 	if (m_contextMenuItem)
 	{
+		// Delegate to QDesktopServices::openUrl with the directory of the selected file. Please note that
+		// this will only open the directory but not select the file as this is much more complicated due
+		// to different implementations that are needed for different platforms (Linux/Windows/MacOS).
+
+		// Using QDesktopServices::openUrl seems to be the most simple cross platform way which uses
+		// functionality that's already available in Qt.
 		QFileInfo fileInfo(m_contextMenuItem->fullName());
 		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.dir().path()));
 	}


### PR DESCRIPTION
Add functionality to open the containing folder of a file that's selected
in LMMS' file browser.

Technical details
------------------
Add a new private method openContainingFolder to FileBrowser. Add a new
action to the context menu of a selected file. This action in turn calls
the added method.

The current implementation of openContainingFolder delegates to
QDesktopServices::openUrl with the directory of the selected file. Please
note that this will only open the directory but not select the file as
this is much more complicated due to different implementations that are
needed for the different platforms (Linux/Windows/MacOS).

Using QDesktopServices::openUrl seems to be the most simple cross
platform way which uses functionality that's already available in Qt.