### PR TITLE
Add FX-Mixer channel color differentiation

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -594,6 +594,8 @@ FxLine {
 	background: #14161A;
 	color: #d1d8e4;
 	qproperty-backgroundActive: #3B424A;
+	qproperty-backgroundSendTo: #304040;
+	qproperty-backgroundReceiveFrom: #3C3237;
 	qproperty-strokeOuterActive: #262B30;
 	qproperty-strokeOuterInactive: #262B30;
 	qproperty-strokeInnerActive: #0C0D0F;

--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -44,6 +44,8 @@ class FxLine : public QWidget
 	Q_OBJECT
 public:
 	Q_PROPERTY( QBrush backgroundActive READ backgroundActive WRITE setBackgroundActive )
+	Q_PROPERTY(QBrush backgroundSendTo READ backgroundSendTo WRITE setBackgroundSendTo)
+	Q_PROPERTY(QBrush backgroundReceiveFrom READ backgroundReceiveFrom WRITE setBackgroundReceiveFrom)
 	Q_PROPERTY( QColor strokeOuterActive READ strokeOuterActive WRITE setStrokeOuterActive )
 	Q_PROPERTY( QColor strokeOuterInactive READ strokeOuterInactive WRITE setStrokeOuterInactive )
 	Q_PROPERTY( QColor strokeInnerActive READ strokeInnerActive WRITE setStrokeInnerActive )
@@ -64,16 +66,22 @@ public:
 
 	QBrush backgroundActive() const;
 	void setBackgroundActive( const QBrush & c );
-	
+
+	QBrush backgroundSendTo() const;
+	void setBackgroundSendTo(const QBrush &c);
+
+	QBrush backgroundReceiveFrom() const;
+	void setBackgroundReceiveFrom(const QBrush &c);
+
 	QColor strokeOuterActive() const;
 	void setStrokeOuterActive( const QColor & c );
-	
+
 	QColor strokeOuterInactive() const;
 	void setStrokeOuterInactive( const QColor & c );
-	
+
 	QColor strokeInnerActive() const;
 	void setStrokeInnerActive( const QColor & c );
-	
+
 	QColor strokeInnerInactive() const;
 	void setStrokeInnerInactive( const QColor & c );
 
@@ -89,6 +97,8 @@ private:
 	LcdWidget* m_lcd;
 	int m_channelIndex;
 	QBrush m_backgroundActive;
+	QBrush m_backgroundSendTo;
+	QBrush m_backgroundReceiveFrom;
 	QColor m_strokeOuterActive;
 	QColor m_strokeOuterInactive;
 	QColor m_strokeInnerActive;

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -61,6 +61,8 @@ FxLine::FxLine( QWidget * _parent, FxMixerView * _mv, int _channelIndex ) :
 	m_mv( _mv ),
 	m_channelIndex( _channelIndex ),
 	m_backgroundActive( Qt::SolidPattern ),
+	m_backgroundSendTo(Qt::SolidPattern),
+	m_backgroundReceiveFrom(Qt::SolidPattern),
 	m_strokeOuterActive( 0, 0, 0 ),
 	m_strokeOuterInactive( 0, 0, 0 ),
 	m_strokeInnerActive( 0, 0, 0 ),
@@ -157,7 +159,18 @@ void FxLine::drawFxLine( QPainter* p, const FxLine *fxLine, bool isActive, bool 
 	int width = fxLine->rect().width();
 	int height = fxLine->rect().height();
 
-	p->fillRect( fxLine->rect(), isActive ? fxLine->backgroundActive() : p->background() );
+	if (sendToThis)
+	{
+		p->fillRect(fxLine->rect(), fxLine->backgroundSendTo());
+	}
+	else if (receiveFromThis)
+	{
+		p->fillRect(fxLine->rect(), fxLine->backgroundReceiveFrom());
+	}
+	else
+	{
+		p->fillRect( fxLine->rect(), isActive ? fxLine->backgroundActive() : p->background() );
+	}
 	
 	// inner border
 	p->setPen( isActive ? fxLine->strokeInnerActive() : fxLine->strokeInnerInactive() );
@@ -330,6 +343,38 @@ QBrush FxLine::backgroundActive() const
 void FxLine::setBackgroundActive( const QBrush & c )
 {
 	m_backgroundActive = c;
+}
+
+
+
+
+QBrush FxLine::backgroundSendTo() const
+{
+	return m_backgroundSendTo;
+}
+
+
+
+
+void FxLine::setBackgroundSendTo(const QBrush &c)
+{
+	m_backgroundSendTo = c;
+}
+
+
+
+
+QBrush FxLine::backgroundReceiveFrom() const
+{
+	return m_backgroundReceiveFrom;
+}
+
+
+
+
+void FxLine::setBackgroundReceiveFrom(const QBrush &c)
+{
+	m_backgroundReceiveFrom = c;
 }
 
 


### PR DESCRIPTION
An idea that popped up in Discord's #production channel, wishing for a similar effect to FL Studio's "wires" that show connected channels.

![](https://www.image-line.com/support/flstudio_online_manual/html/img_shot/mixer_routingicons.png)

![lmms-mixer-colors](https://user-images.githubusercontent.com/2244945/80188092-509a3380-85d6-11ea-8fc8-be1f4a9dae33.PNG)

The active (selected) channel is still highlighted "white", but all channels that it sends to are highlighted different than the other channels (in this case a green tint). All channels that it receives from are highlighted different as well (in this case a red tint).

This does slightly change the default view for the master channel though:
![lmms-mixer-colors-master](https://user-images.githubusercontent.com/2244945/80188437-c69e9a80-85d6-11ea-9f08-5f54bb14735c.PNG)

When you're just sending to other channels:
![lmms-send-to-highlight](https://user-images.githubusercontent.com/2244945/80188469-d74f1080-85d6-11ea-8c49-ef4963400b54.PNG)

I leave it up to the color deciders to figure out the proper fitting colors to use for this. 😄