### PR TITLE
Set AutomationPattern length to 1 bar if the length is 0

### DIFF
--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -179,18 +179,15 @@ const AutomationPattern::objectVector& AutomationPattern::objects() const
 MidiTime AutomationPattern::timeMapLength() const
 {
 	MidiTime one_bar = MidiTime(1, 0);
-	if (m_timeMap.isEmpty())
-	{
-		return one_bar;
-	}
+	if (m_timeMap.isEmpty()) { return one_bar; }
+
 	timeMap::const_iterator it = m_timeMap.end();
 	tick_t last_tick = static_cast<tick_t>((it-1).key());
-	bar_t last_bar = qMax(0, MidiTime(last_tick).nextFullBar() - 1);
-	if (last_bar == 0 && last_tick == 0)
-	{
-		return one_bar;
-	}
-	return MidiTime(last_bar, last_tick);
+	// if last_tick is 0 (single item at tick 0)
+	// return length as a whole bar to prevent disappearing TCO
+	if (last_tick == 0) { return one_bar; }
+
+	return MidiTime(last_tick);
 }
 
 
@@ -198,7 +195,8 @@ MidiTime AutomationPattern::timeMapLength() const
 
 void AutomationPattern::updateLength()
 {
-	changeLength( timeMapLength() );
+	// Do not resize down in case user manually extended up
+	changeLength(qMax(length(), timeMapLength()));
 }
 
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -159,7 +159,7 @@ void TrackContentObject::movePosition( const MidiTime & pos )
 
 /*! \brief Change the length of this TrackContentObject
  *
- *  If the track content object's length has chaanged, update it.  We
+ *  If the track content object's length has changed, update it.  We
  *  also add a journal entry for undo and update the display.
  *
  * \param _length The new length of the track content object.


### PR DESCRIPTION
Fixes #5254 

~~AutomationPattern's length is now always updated (not only if it's a HiddenAutomationTrack which we're removing eventually). Just changing that though resulted in the length of the block in the SongEditor to be 0 (or a single pixel), so this also makes the minimum length of the block 1 bar.~~

~~Tested playing around with adding and removing blocks from BB tracks, Automation tracks, and Piano tracks, all seemed to still behave properly.~~

~~EDIT: I totally forgot that there were actually tests for the automation track length. I'm not sure how we want to change these.~~

If the last bar and last tick is 0, then set the length to 1 bar.