### PR TITLE
Allows instruments to keep the midi channel information when forwarding

### DIFF
--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -96,7 +96,10 @@ public:
 
 	int realOutputChannel() const
 	{
-		return outputChannel() - 1;
+		// There's a possibility of outputChannel being 0 ("--"), which is used to keep all
+		// midi channels when forwarding. In that case, realOutputChannel will return the
+		// default channel 1 (whose value is 0).
+		return outputChannel() ? outputChannel() - 1 : 0;
 	}
 
 	void processInEvent( const MidiEvent& event, const MidiTime& time = MidiTime() );

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -86,7 +86,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_outputChannelSpinBox = new LcdSpinBox( 2, m_midiOutputGroupBox );
 	m_outputChannelSpinBox->addTextForValue( 0, "--" );
 	m_outputChannelSpinBox->setLabel( tr( "CHANNEL" ) );
-	m_outputChannelSpinBox->setEnabled( false );
+	m_outputChannelSpinBox->setEnabled( true );
 	midiOutputLayout->addWidget( m_outputChannelSpinBox );
 
 	m_fixedOutputVelocitySpinBox = new LcdSpinBox( 3, m_midiOutputGroupBox );
@@ -109,8 +109,6 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	midiOutputLayout->addWidget( m_fixedOutputNoteSpinBox );
 	midiOutputLayout->addStretch();
 
-	connect( m_midiOutputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
-			m_outputChannelSpinBox, SLOT( setEnabled( bool ) ) );
 	connect( m_midiOutputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),
 		m_fixedOutputVelocitySpinBox, SLOT( setEnabled( bool ) ) );
 	connect( m_midiOutputGroupBox->ledButton(), SIGNAL( toggled( bool ) ),

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -86,7 +86,6 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_outputChannelSpinBox = new LcdSpinBox( 2, m_midiOutputGroupBox );
 	m_outputChannelSpinBox->addTextForValue( 0, "--" );
 	m_outputChannelSpinBox->setLabel( tr( "CHANNEL" ) );
-	m_outputChannelSpinBox->setEnabled( true );
 	midiOutputLayout->addWidget( m_outputChannelSpinBox );
 
 	m_fixedOutputVelocitySpinBox = new LcdSpinBox( 3, m_midiOutputGroupBox );

--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -84,6 +84,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	midiOutputLayout->setSpacing( 6 );
 
 	m_outputChannelSpinBox = new LcdSpinBox( 2, m_midiOutputGroupBox );
+	m_outputChannelSpinBox->addTextForValue( 0, "--" );
 	m_outputChannelSpinBox->setLabel( tr( "CHANNEL" ) );
 	m_outputChannelSpinBox->setEnabled( false );
 	midiOutputLayout->addWidget( m_outputChannelSpinBox );

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -395,11 +395,9 @@ void InstrumentTrack::processOutEvent( const MidiEvent& event, const MidiTime& t
 
 	// If we have a selected output midi channel between 1-16, we will use that channel to handle the midi event.
 	// But if our selected midi output channel is 0 ("--"), we will use the event channel instead.
-	auto handleEventOutputChannel = midiPort()->realOutputChannel();
-	if( midiPort()->outputChannel() == 0 )
-	{
-		handleEventOutputChannel = event.channel();
-	}
+	const auto handleEventOutputChannel = midiPort()->outputChannel() == 0
+		? event.channel()
+		: midiPort()->realOutputChannel();
 
 	switch( event.type() )
 	{


### PR DESCRIPTION
Implemented the feature discussed on issue #5462 .

### Without this PR, LMMS handles midi I/O the following way:

- Input can be enabled to allow an instrument to receive midi events. A channel can be selected (so only that channel is received) or none can be selected ("--", which allows all channels to be received).
- Output can be enabled to forward the midi events processed on the track to other channels. A channel from 1-16 can be selected, so only the events with that channel are forwarded.

There's another behavior related to the midi output channel that is less known:

- The midi events from the track itself (and all others received from other tracks) are sent to the instrument plugin using the midi output channel, being it enabled or not.

That behavior makes impossible to send midi events with different channels to an instrument plugin, since they will be all converted to have the selected output channel. An example of a situation where this could be an issue is if we decide to use a different channel to signal the instrument to use another preset. Another example: Suppose we make two tracks with different channels, where the first have the notes to be played and the second has notes that are going to be interpreted as automation values. We could forward those to a Carla-patchbay and automate parameters using the key values from the second track, differentiating each one using the channel. That would be a nice workaround for the lack of Carla automation we currently have (I managed to do it here with a build from my code and can share projects showing how to do it). Finally, some MIDI keyboards might support channel mapping and this feature could make use of that.

### With this PR the behavior is now the following:

- Midi input behavior stays the same
- We can now select a midi output channel from 1 to 16 (to filter the channels forwarded, exactly like before) or select no channel ("--"). If no channel is selected, all received midi events are forwarded keeping their original channels. The events generated by the instrument itself will be sent with the default channel (I've chosen 1). There will be no filtering, all events will be forwarded.
- Since the midi output channel is now relevant even when we have the midi output disabled (since the midi events will be sent to the instrument plugin and the channel used depends on it) the spin box widget that selects the midi output channel is enabled even when you have midi output disabled so you can change channels.

### Changes to the code:

- The `outputChannel()` from the class _MidiPort_ could only have values ranging from 1 to 16. Now it can have values from 0 to 16, 0 being a value representing "no channel".
- The `realOutputChannel()` will return `outputChannel() - 1` like before if the value of the channel is inside the old range, or it will return `1` if the value is 0. That would guarantee backward compatibility because the values will be inside the expected range and from my research `outputChannel()` is not used to retrieve the channel by any plugin, only `realOutputChannel()`.
- Created local variable `handleEventOutputChannel` in method `InstrumentTrack::processOutEvent` that will hold the channel used to handle midi events (channel sent to instrument plugins). Its value is decided based on the behavior described before (1-16 if output channel is selected, or `event.channel()` if not).
- Changed method `MidiPort::processOutEvent` to forward midi events from all channels when midi output channel "--" is selected.
- Changed code on the `InstrumentMidiIOView` widget to make the midi output channel spin box display "--" when the output channel value is 0 and to keep it to becoming disabled when midi output is disabled.