### PR TITLE
Fix crash on drawing line on the end of a graph

### DIFF
--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -235,8 +235,9 @@ void Graph::drawLineAt( int _x, int _y, int _lastx )
 		model()->drawSampleAt( sample_begin + i , val_begin + ((i ) * ystep));
 	}
 
-	
-	model()->samplesChanged( sample_begin, sample_end );
+	// We've changed [sample_end, sample_begin)
+	// However, samplesChanged expects two end points
+	model()->samplesChanged(sample_begin, sample_end - 1);
 }
 
 void Graph::changeSampleAt( int _x, int _y )


### PR DESCRIPTION
Fixes #4679 by emitting `sampleChanged()` with `sample_end - 1` instead of `sample_end`.