### PR TITLE
Fix #5461 and ensure consistent use of check gate

### DIFF
--- a/plugins/Amplifier/Amplifier.cpp
+++ b/plugins/Amplifier/Amplifier.cpp
@@ -83,7 +83,6 @@ bool AmplifierEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 	for( fpp_t f = 0; f < frames; ++f )
 	{
 //		qDebug( "offset %d, value %f", f, m_ampControls.m_volumeModel.value( f ) );
-		outSum += buf[f][0]*buf[f][0] + buf[f][1]*buf[f][1];
 	
 		sample_t s[2] = { buf[f][0], buf[f][1] };
 
@@ -123,6 +122,7 @@ bool AmplifierEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 		buf[f][0] = d * buf[f][0] + w * s[0];
 		buf[f][1] = d * buf[f][1] + w * s[1];
+		outSum += buf[f][0] * buf[f][0] + buf[f][1] * buf[f][1];
 	}
 
 	checkGate( outSum / frames );

--- a/plugins/BassBooster/BassBooster.cpp
+++ b/plugins/BassBooster/BassBooster.cpp
@@ -100,13 +100,13 @@ bool BassBoosterEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 		//float gain = gainBuffer ? gainBuffer[f] : gain;
 		m_bbFX.leftFX().setGain( gain );
 		m_bbFX.rightFX().setGain( gain);
-		outSum += buf[f][0]*buf[f][0] + buf[f][1]*buf[f][1];
 
 		sample_t s[2] = { buf[f][0], buf[f][1] };
 		m_bbFX.nextSample( s[0], s[1] );
 
 		buf[f][0] = d * buf[f][0] + w * s[0];
 		buf[f][1] = d * buf[f][1] + w * s[1];
+		outSum += buf[f][0] * buf[f][0] + buf[f][1] * buf[f][1];
 	}
 
 	checkGate( outSum / frames );

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -190,12 +190,12 @@ bool CrossoverEQEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 	double outSum = 0.0;
 	for( int f = 0; f < frames; ++f )
 	{
-		outSum = buf[f][0] * buf[f][0] + buf[f][1] * buf[f][1];
 		buf[f][0] = d * buf[f][0] + w * m_work[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_work[f][1];
+		outSum += buf[f][0] * buf[f][0] + buf[f][1] * buf[f][1];
 	}
 	
-	checkGate( outSum );
+	checkGate( outSum / frames );
 	
 	return isRunning();
 }

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -193,11 +193,11 @@ bool DualFilterEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames 
 			s[0] += ( s2[0] * mix2 );
 			s[1] += ( s2[1] * mix2 );
 		}
-		outSum += buf[f][0]*buf[f][0] + buf[f][1]*buf[f][1];
 
 		// do another mix with dry signal
 		buf[f][0] = d * buf[f][0] + w * s[0];
 		buf[f][1] = d * buf[f][1] + w * s[1];
+		outSum += buf[f][0] * buf[f][0] + buf[f][1] * buf[f][1];
 
 		//increment pointers
 		cut1Ptr += cut1Inc;

--- a/plugins/dynamics_processor/dynamics_processor.cpp
+++ b/plugins/dynamics_processor/dynamics_processor.cpp
@@ -214,10 +214,10 @@ bool dynProcEffect::processAudioBuffer( sampleFrame * _buf,
 		s[0] *= outputGain;
 		s[1] *= outputGain;
 
-		out_sum += _buf[f][0]*_buf[f][0] + _buf[f][1]*_buf[f][1];
 // mix wet/dry signals
 		_buf[f][0] = d * _buf[f][0] + w * s[0];
 		_buf[f][1] = d * _buf[f][1] + w * s[1];
+		out_sum += _buf[f][0] * _buf[f][0] + _buf[f][1] * _buf[f][1];
 	}
 
 	checkGate( out_sum / _frames );

--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -139,10 +139,10 @@ bool waveShaperEffect::processAudioBuffer( sampleFrame * _buf,
 		s[0] *= *outputPtr;
 		s[1] *= *outputPtr;
 
-		out_sum += _buf[f][0]*_buf[f][0] + _buf[f][1]*_buf[f][1];
 // mix wet/dry signals
 		_buf[f][0] = d * _buf[f][0] + w * s[0];
 		_buf[f][1] = d * _buf[f][1] + w * s[1];
+		out_sum += _buf[f][0] * _buf[f][0] + _buf[f][1] * _buf[f][1];
 
 		outputPtr += outputInc;
 		inputPtr += inputInc;


### PR DESCRIPTION
This PR addresses #5461 and ensures that `checkGate` is called on the processed buffer for several other builtin plugins. In the file "plugins/Eq/EqEffect.cpp", `checkGate` is also used incorrectly, however, fixing the problem is not as straightforward as for the other plugins and will be addressed in a separate PR.
