### PR TITLE
Select piano key from mouse position

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -250,6 +250,7 @@ private:
 
 	QList<int> m_markedSemiTones;
 	QMenu * m_semiToneMarkerMenu; // when you right click on the key area
+	int m_pianoKeySelected;
 
 	PianoRoll();
 	PianoRoll( const PianoRoll & );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -507,7 +507,7 @@ void PianoRoll::changeNoteEditMode( int i )
 
 void PianoRoll::markSemiTone( int i )
 {
-	const int key = getKey( mapFromGlobal( m_semiToneMarkerMenu->pos() ).y() );
+	const int key = m_pianoKeySelected;
 	const InstrumentFunctionNoteStacking::Chord * chord = nullptr;
 
 	switch( static_cast<SemiToneMarkerAction>( i ) )
@@ -1704,6 +1704,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			if( me->buttons() == Qt::RightButton )
 			{
 				// right click, tone marker contextual menu
+				m_pianoKeySelected = getKey( me->y() );
 				m_semiToneMarkerMenu->popup( mapToGlobal( QPoint( me->x(), me->y() ) ) );
 			}
 			else


### PR DESCRIPTION
When selecting a Piano Key to mark semi tones in the Piano Roll we
select key from the y position of the pop-up menu and not the mouse.
Incidentally these two are most often the same as the menu builds
from the mouse y positon and down. If there is room for it. If there
is no room downwords it will create the menu so the lower part of the
frame aligns with the mouse y position.

Fixed by creating a variable to hold the pressed key before creating
the menu.

![keySelect](https://user-images.githubusercontent.com/6368949/80755353-f139a780-8b30-11ea-8b18-32a9bac73a53.png)

In the case given above the pressed key will not be C4 but C#5

Bug replicated on lmms-1.0.3