### PR TITLE
Piano Roll - invert selection

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -296,6 +296,7 @@ private:
 	void shiftSemiTone(int amount);
 	bool isSelection() const;
 	int selectionCount() const;
+	void invertSelection() const;
 	void testPlayNote( Note * n );
 	void testPlayKey( int _key, int _vol, int _pan );
 	void pauseTestNotes(bool pause = true );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1212,6 +1212,21 @@ int PianoRoll::selectionCount() const // how many notes are selected?
 
 
 
+
+void PianoRoll::invertSelection() const
+{
+	if( m_pattern != NULL )
+	{
+		for( Note *note : m_pattern->notes() )
+		{
+			note->setSelected( ! note->selected() );
+		}
+	}
+}
+
+
+
+
 void PianoRoll::keyPressEvent(QKeyEvent* ke)
 {
 	if(m_stepRecorder.isRecording())
@@ -1354,6 +1369,19 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 					selectAll();
 				}
 				update();
+			}
+			break;
+
+		case Qt::Key_I:
+			if( ke->modifiers() & Qt::ControlModifier )
+			{
+				ke->accept();
+				if (ke->modifiers() & Qt::ShiftModifier)
+				{
+					// Ctrl + Shift + I = inverts selection
+					invertSelection();
+					update();
+				}
 			}
 			break;
 


### PR DESCRIPTION
Proof of concept (working).

In response to: https://github.com/LMMS/lmms/issues/4507 https://github.com/LMMS/lmms/issues/4602

With the key command `<Ctrl> + <Shift> + i` you invert the selection. If no notes are selected you select all notes.

Things to do:

* Need to study the code in [void PianoRoll::selectAll()](https://github.com/LMMS/lmms/blob/c755b56a52145a572247303a09d126e764238c11/src/gui/editors/PianoRoll.cpp#L3930). It's vastly different from this PR which is a bit worrying. This is a dumb first attempt but it's working,
* Better key combination? Just `<Ctrl> + i`?
* Should there be a gui knob to activate this?
  * Icon needed
* I think I have a redundant `update()` in there.
