### PR TITLE
Theming of disabled knobs

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -40,6 +40,11 @@ QMdiArea {
 	background-color: #111314;
 }
 
+Knob[enabled=false] {
+	qproperty-lineColor: rgb(120, 120, 120);
+	qproperty-arcColor: rgba(120, 120, 120, 70);
+}
+
 AutomationEditor {
 	color: #ffffff;
 	background-color: #141616;

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -70,7 +70,7 @@ class LMMS_EXPORT Knob : public QWidget, public FloatModelView
 	Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor)
 
 	void initUi( const QString & _name ); //!< to be called by ctors
-	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum 
+	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum
 
 public:
 	Knob( knobTypes _knob_num, QWidget * _parent = NULL, const QString & _name = QString() );

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -47,6 +47,8 @@ class LMMS_EXPORT Knob : public QWidget, public FloatModelView
 	Q_OBJECT
 	Q_ENUMS( knobTypes )
 
+	Q_PROPERTY(bool enabled READ isEnabled)
+
 	Q_PROPERTY(float innerRadius READ innerRadius WRITE setInnerRadius)
 	Q_PROPERTY(float outerRadius READ outerRadius WRITE setOuterRadius)
 
@@ -68,7 +70,7 @@ class LMMS_EXPORT Knob : public QWidget, public FloatModelView
 	Q_PROPERTY(QColor textColor READ textColor WRITE setTextColor)
 
 	void initUi( const QString & _name ); //!< to be called by ctors
-	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum
+	void onKnobNumUpdated(); //!< to be called when you updated @a m_knobNum 
 
 public:
 	Knob( knobTypes _knob_num, QWidget * _parent = NULL, const QString & _name = QString() );
@@ -134,6 +136,7 @@ protected:
 	void mouseDoubleClickEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _me ) override;
 	void wheelEvent( QWheelEvent * _me ) override;
+	void changeEvent( QEvent * _ev) override;
 
 	virtual float getValue( const QPoint & _p );
 
@@ -145,6 +148,7 @@ private slots:
 private:
 	QString displayValue() const;
 
+	void initLineColors();
 	void doConnections() override;
 
 	QLineF calculateLine( const QPointF & _mid, float _radius,
@@ -153,6 +157,9 @@ private:
 	void drawKnob( QPainter * _p );
 	void setPosition( const QPoint & _p );
 	bool updateAngle();
+	void resetPixmap();
+
+	void setEnabledTheme(bool); 
 
 	int angleFromValue( float value, float minValue, float maxValue, float totalAngle ) const
 	{

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -77,21 +77,8 @@ Knob::Knob( QWidget * _parent, const QString & _name ) :
 
 
 
-void Knob::initUi( const QString & _name )
+void initLineColors()
 {
-	if( s_textFloat == NULL )
-	{
-		s_textFloat = new TextFloat;
-	}
-
-	setWindowTitle( _name );
-
-	onKnobNumUpdated();
-	setTotalAngle( 270.0f );
-	setInnerRadius( 1.0f );
-	setOuterRadius( 10.0f );
-	setFocusPolicy( Qt::ClickFocus );
-
 	// This is a workaround to enable style sheets for knobs which are not styled knobs.
 	//
 	// It works as follows: the palette colors that are assigned as the line color previously
@@ -120,7 +107,27 @@ void Knob::initUi( const QString & _name )
 	default:
 		break;
 	}
+}
 
+
+
+
+void Knob::initUi( const QString & _name )
+{
+	if( s_textFloat == NULL )
+	{
+		s_textFloat = new TextFloat;
+	}
+
+	setWindowTitle( _name );
+
+	onKnobNumUpdated();
+	setTotalAngle( 270.0f );
+	setInnerRadius( 1.0f );
+	setOuterRadius( 10.0f );
+	setFocusPolicy( Qt::ClickFocus );
+
+	initLineColors();	
 	doConnections();
 }
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -134,7 +134,7 @@ void Knob::initUi( const QString & _name )
 
 
 
-void convertPixmapToGreyScale(QPixmap* pixmap)
+void convertPixmapToGrayScale(QPixmap* pixmap)
 {
 	QImage temp = pixmap->toImage().convertToFormat(QImage::Format_ARGB32);
 	for (int i = 0; i < temp.height(); ++i)
@@ -144,9 +144,9 @@ void convertPixmapToGreyScale(QPixmap* pixmap)
 			QColor pix;
 			pix = temp.pixelColor(i, j);
 			quint8 gscale = quint8( (11*pix.red() + 16*pix.green() + 5*pix.blue()) / 32);
-			QRgba64 pix_grey64;
-			pix_grey64 = QRgba64::fromRgba( gscale, gscale, gscale, quint8(pix.alpha()) );
-			temp.setPixelColor(i, j, pix_grey64);
+			QRgba64 pix_gray64;
+			pix_gray64 = QRgba64::fromRgba( gscale, gscale, gscale, quint8(pix.alpha()) );
+			temp.setPixelColor(i, j, pix_gray64);
 		}
 	} 
 	pixmap->convertFromImage(temp);	
@@ -195,7 +195,7 @@ void Knob::onKnobNumUpdated()
 
 		if ( !this->isEnabled() )
 		{
-			convertPixmapToGreyScale( m_knobPixmap );
+			convertPixmapToGrayScale( m_knobPixmap );
 		}
 
 		setFixedSize( m_knobPixmap->width(), m_knobPixmap->height() );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -167,12 +167,20 @@ void Knob::onKnobNumUpdated()
 
 
 
-Knob::~Knob()
+void Knob::resetPixMap()
 {
 	if( m_knobPixmap )
 	{
 		delete m_knobPixmap;
 	}
+}
+
+
+
+
+Knob::~Knob()
+{
+	resetPixMap();
 }
 
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -99,15 +99,23 @@ void Knob::initUi( const QString & _name )
 	// drawKnob method uses the line color to draw the lines. By assigning the palette colors
 	// as the line colors here the knob lines will be drawn in this color unless the stylesheet
 	// overrides that color.
+
+	QColor col;
 	switch (knobNum())
 	{
 	case knobSmall_17:
 	case knobBright_26:
 	case knobDark_28:
 		setlineColor(QApplication::palette().color( QPalette::Active, QPalette::WindowText ));
+		col = QColor(QApplication::palette().color( QPalette::Active, QPalette::WindowText)); 
+		col.setAlpha( 70 );
+		setarcColor( col );
 		break;
 	case knobVintage_32:
 		setlineColor(QApplication::palette().color( QPalette::Active, QPalette::Shadow ));
+		col = QColor(QApplication::palette().color( QPalette::Active, QPalette::Shadow));
+		col.setAlpha( 70 );
+		setarcColor( col );
 		break;
 	default:
 		break;
@@ -440,14 +448,9 @@ void Knob::drawKnob( QPainter * _p )
 	const int arcLineWidth = 2;
 	const int arcRectSize = m_knobPixmap->width() - arcLineWidth;
 
-	QColor col;
-	if( m_knobNum == knobVintage_32 )
-	{	col = QApplication::palette().color( QPalette::Active, QPalette::Shadow ); }
-	else
-	{	col = QApplication::palette().color( QPalette::Active, QPalette::WindowText ); }
-	col.setAlpha( 70 );
 
-	p.setPen( QPen( col, 2 ) );
+
+	p.setPen( QPen( arcColor(), 2 ) );
 	p.drawArc( mid.x() - arcRectSize/2, 1, arcRectSize, arcRectSize, 315*16, 16*m_totalAngle );
 
 	switch( m_knobNum )


### PR DESCRIPTION
This PR partly addresses #4749 and introduces the possibility to theme disabled knobs. 
I could not get it to work using the pseudo state ":disabled" in the style sheets, as suggested in #4749. As the knob icons are png Images, we somehow have to catch the `enabledChange` event and convert the image to grayscale. Moreover, the pseudo-states do not seem to work with a custom `QPROPERTY`, in contrast to the standard ones like `background-color` etc. . So redrawing the middle line and arc does not seem possible with pseudo-states.
