### PR TITLE
Fix #5483: sf2_player: No crash when file is no soundfont

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -358,18 +358,27 @@ void sf2Instrument::openFile( const QString & _sf2File, bool updateTrackName )
 	// Add to map, if doesn't exist.
 	else
 	{
-		m_fontId = fluid_synth_sfload( m_synth, sf2Ascii, true );
-
-		if( fluid_synth_sfcount( m_synth ) > 0 )
+		if( fluid_is_soundfont( sf2Ascii ) )
 		{
-			// Grab this sf from the top of the stack and add to list
-			m_font = new sf2Font( fluid_synth_get_sfont( m_synth, 0 ) );
-			s_fonts.insert( relativePath, m_font );
+			m_fontId = fluid_synth_sfload( m_synth, sf2Ascii, true );
+
+			if( fluid_synth_sfcount( m_synth ) > 0 )
+			{
+				// Grab this sf from the top of the stack and add to list
+				m_font = new sf2Font( fluid_synth_get_sfont( m_synth, 0 ) );
+				s_fonts.insert( relativePath, m_font );
+			}
+			else
+			{
+				collectErrorForUI( sf2Instrument::tr( "A soundfont %1 could not be loaded." ).
+					arg( QFileInfo( _sf2File ).baseName() ) );
+			}
 		}
 		else
 		{
-			collectErrorForUI( sf2Instrument::tr( "A soundfont %1 could not be loaded." ).arg( QFileInfo( _sf2File ).baseName() ) );
-			// TODO: Why is the filename missing when the file does not exist?
+			qDebug() << QFileInfo( _sf2File ).baseName() ;
+			collectErrorForUI( sf2Instrument::tr( "File %1 is not a soundfont." ).
+				arg( QFileInfo( _sf2File ).baseName() ) );
 		}
 	}
 

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -358,6 +358,7 @@ void sf2Instrument::openFile( const QString & _sf2File, bool updateTrackName )
 	// Add to map, if doesn't exist.
 	else
 	{
+		bool loaded = false;
 		if( fluid_is_soundfont( sf2Ascii ) )
 		{
 			m_fontId = fluid_synth_sfload( m_synth, sf2Ascii, true );
@@ -367,17 +368,13 @@ void sf2Instrument::openFile( const QString & _sf2File, bool updateTrackName )
 				// Grab this sf from the top of the stack and add to list
 				m_font = new sf2Font( fluid_synth_get_sfont( m_synth, 0 ) );
 				s_fonts.insert( relativePath, m_font );
-			}
-			else
-			{
-				collectErrorForUI( sf2Instrument::tr( "A soundfont %1 could not be loaded." ).
-					arg( QFileInfo( _sf2File ).baseName() ) );
+				loaded = true;
 			}
 		}
-		else
+
+		if(!loaded)
 		{
-			qDebug() << QFileInfo( _sf2File ).baseName() ;
-			collectErrorForUI( sf2Instrument::tr( "File %1 is not a soundfont." ).
+			collectErrorForUI( sf2Instrument::tr( "A soundfont %1 could not be loaded." ).
 				arg( QFileInfo( _sf2File ).baseName() ) );
 		}
 	}


### PR DESCRIPTION
Some hints for the review:

* I did not add a message box when the file is not a soundfont. This means you are only alerted when opening an LMMS project, but not when opening a soundfont in an open LMMS project. I didn't use a message box because this would show up additionally to the plugin warnings, and because the case that the soundfont could not be loaded is currently handled without message boxes, too.
* I removed that "TODO" line because I assume that whoever saw this warning with an empty filename just saw the space that PhysSong already described in #5483.

Testing is not required, this PR is simple enough. Code review would be nice.
