### PR TITLE
addStretch() before adding the oscilloscope

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -216,7 +216,7 @@ SongEditor::SongEditor( Song * song ) :
 	vcw_layout->setMargin( 0 );
 	vcw_layout->setSpacing( 0 );
 
-	//vcw_layout->addStretch();
+	vcw_layout->addStretch();
 	vcw_layout->addWidget( new Oscilloscope( vc_w ) );
 
 	vcw_layout->addWidget( new CPULoadWidget( vc_w ) );


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/25503477/81493235-ce17a200-926c-11ea-9fbc-a456819bc5a6.png)

After:
![after](https://user-images.githubusercontent.com/25503477/81493232-cbb54800-926c-11ea-8a43-dcd9308fa23e.png)

I think it looks better.