### PR TITLE
Fix #5194: Fix knobs moving too fast (alternative PR)

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -167,6 +167,7 @@ private:
 
 
 	static TextFloat * s_textFloat;
+	static QPoint s_desktopSize;
 
 	QString m_label;
 
@@ -174,8 +175,8 @@ private:
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;
 
-	QPoint m_mouseOffset;
-	QPoint m_origMousePos;
+	QPoint m_origMousePos; //!< position where user clicked to turn the knob
+	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
 	float m_leftOver;
 	bool m_buttonPressed;
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -511,7 +511,7 @@ float Knob::getValue( const QPoint & _p )
 
 	// knob value increase is linear to mouse movement
 	// for larger screens, change the knob slower
-	value = .09f * (_p.y()*(1080/s_desktopSize.y()));
+	value = .09f * (((float)_p.y())*(1080.f/(float)s_desktopSize.y()));
 
 	// if shift pressed we want slower movement
 	if( gui->mainWindow()->isShiftPressed() )

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -511,7 +511,7 @@ float Knob::getValue( const QPoint & _p )
 
 	// knob value increase is linear to mouse movement
 	// for larger screens, change the knob slower
-	value = .09f * (_p.y()/(1080/s_desktopSize.y()));
+	value = .09f * (_p.y()*(1080/s_desktopSize.y()));
 
 	// if shift pressed we want slower movement
 	if( gui->mainWindow()->isShiftPressed() )

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -24,10 +24,12 @@
 
 #include <QApplication>
 #include <QBitmap>
+#include <QDebug>
 #include <QFontMetrics>
 #include <QInputDialog>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QScreen>
 #include <QWhatsThis>
 
 #ifndef __USE_XOPEN
@@ -50,6 +52,7 @@
 #include "TextFloat.h"
 
 TextFloat * Knob::s_textFloat = NULL;
+QPoint Knob::s_desktopSize; // = (0, 0) (default CTOR)
 
 
 
@@ -83,6 +86,15 @@ void Knob::initUi( const QString & _name )
 	if( s_textFloat == NULL )
 	{
 		s_textFloat = new TextFloat;
+	}
+	if( s_desktopSize == QPoint() )
+	{
+		QRect screenGeom = QApplication::desktop()->availableGeometry();
+		Q_ASSERT(screenGeom != QRect());
+		qDebug() << "INFO: found screen dimensions: " << screenGeom;
+
+		s_desktopSize.setX(screenGeom.width());
+		s_desktopSize.setY(screenGeom.height());
 	}
 
 	setWindowTitle( _name );
@@ -497,8 +509,9 @@ float Knob::getValue( const QPoint & _p )
 {
 	float value;
 
-	// arcane mathemagicks for calculating knob movement
-	value = ( ( _p.y() + _p.y() * qMin( qAbs( _p.y() / 2.5f ), 6.0f ) ) ) / 12.0f;
+	// knob value increase is linear to mouse movement
+	// for larger screens, change the knob slower
+	value = .09f * (_p.y()/(1080/s_desktopSize.y()));
 
 	// if shift pressed we want slower movement
 	if( gui->mainWindow()->isShiftPressed() )
@@ -587,13 +600,11 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 		}
 
 		const QPoint & p = _me->pos();
-		m_origMousePos = p;
-		m_mouseOffset = QPoint(0, 0);
+		m_origMousePos = m_lastMousePos = p;
 		m_leftOver = 0.0f;
 
 		emit sliderPressed();
 
-		QApplication::setOverrideCursor( Qt::BlankCursor );
 		s_textFloat->setText( displayValue() );
 		s_textFloat->moveGlobal( this,
 				QPoint( width() + 2, 0 ) );
@@ -618,12 +629,13 @@ void Knob::mousePressEvent( QMouseEvent * _me )
 
 void Knob::mouseMoveEvent( QMouseEvent * _me )
 {
-	if( m_buttonPressed && _me->pos() != m_origMousePos )
+	if( m_buttonPressed && _me->pos() != m_lastMousePos )
 	{
-		m_mouseOffset = _me->pos() - m_origMousePos;
-		setPosition( m_mouseOffset );
+		// knob position is changed depending on last mouse position
+		setPosition( _me->pos() - m_lastMousePos );
 		emit sliderMoved( model()->value() );
-		QCursor::setPos( mapToGlobal( m_origMousePos ) );
+		// original position for next time is current position
+		m_lastMousePos = _me->pos();
 	}
 	s_textFloat->setText( displayValue() );
 }


### PR DESCRIPTION
This PR does

* Remove all `setPos()` from Knob.cpp on all OS
* Therefore use the previous position, not the original position to
  compute the cursor delta
* Use the cursor delta now linearly
* Use the cursor delta in relation to the screen height