### PR TITLE
Remove warning color from oscilloscope

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -163,7 +163,6 @@ Oscilloscope {
 	background: none;
 	border: none;
 	qproperty-normalColor: rgb(71, 253, 133);
-	qproperty-warningColor: rgb(255, 192, 64);
 	qproperty-clippingColor: rgb(255, 64, 64);
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -195,7 +195,6 @@ Oscilloscope {
 	background: none;
 	border: none;
 	qproperty-normalColor: rgb(71, 253, 133);
-	qproperty-warningColor: rgb(255, 192, 64);
 	qproperty-clippingColor: rgb(255, 64, 64);
 }
 

--- a/include/Oscilloscope.h
+++ b/include/Oscilloscope.h
@@ -37,7 +37,6 @@ class Oscilloscope : public QWidget
 	Q_OBJECT
 public:
 	Q_PROPERTY( QColor normalColor READ normalColor WRITE setNormalColor )
-	Q_PROPERTY( QColor warningColor READ warningColor WRITE setWarningColor )
 	Q_PROPERTY( QColor clippingColor READ clippingColor WRITE setClippingColor )
 
 	Oscilloscope( QWidget * _parent );
@@ -47,9 +46,6 @@ public:
 
 	QColor const & normalColor() const;
 	void setNormalColor(QColor const & normalColor);
-
-	QColor const & warningColor() const;
-	void setWarningColor(QColor const & warningColor);
 
 	QColor const & clippingColor() const;
 	void setClippingColor(QColor const & clippingColor);
@@ -74,7 +70,6 @@ private:
 	bool m_active;
 
 	QColor m_normalColor;
-	QColor m_warningColor;
 	QColor m_clippingColor;
 } ;
 

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -44,7 +44,6 @@ Oscilloscope::Oscilloscope( QWidget * _p ) :
 	m_points( new QPointF[Engine::mixer()->framesPerPeriod()] ),
 	m_active( false ),
 	m_normalColor(71, 253, 133),
-	m_warningColor(255, 192, 64),
 	m_clippingColor(255, 64, 64)
 {
 	setFixedSize( m_background.width(), m_background.height() );
@@ -121,16 +120,6 @@ void Oscilloscope::setNormalColor(QColor const & normalColor)
 	m_normalColor = normalColor;
 }
 
-QColor const & Oscilloscope::warningColor() const
-{
-	return m_warningColor;
-}
-
-void Oscilloscope::setWarningColor(QColor const & warningColor)
-{
-	m_warningColor = warningColor;
-}
-
 QColor const & Oscilloscope::clippingColor() const
 {
 	return m_clippingColor;
@@ -205,13 +194,9 @@ void Oscilloscope::mousePressEvent( QMouseEvent * _me )
 
 QColor const & Oscilloscope::determineLineColor(float level) const
 {
-	if( level < 0.9f )
+	if( level <= 1.0f )
 	{
 		return normalColor();
-	}
-	else if( level <= 1.0f )
-	{
-		return warningColor();
 	}
 	else
 	{


### PR DESCRIPTION
Because there is nothing to warn about when the audio level is in the arbitrary range of [90%, 100%].