### PR TITLE
Automatically assign a midi input device to the selected track

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -263,6 +263,7 @@ private:
 	bool m_previewMode;
 
 	bool m_hasAutoMidiDev;
+	static InstrumentTrack *s_autoAssignedTrack;
 
 	IntModel m_baseNoteModel;
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -219,6 +219,8 @@ public:
 		return m_previewMode;
 	}
 
+	void autoAssignMidiDevice( bool );
+
 signals:
 	void instrumentChanged();
 	void midiNoteOn( const Note& );
@@ -259,6 +261,8 @@ private:
 	bool m_silentBuffersProcessed;
 
 	bool m_previewMode;
+
+	bool m_hasAutoMidiDev;
 
 	IntModel m_baseNoteModel;
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -178,6 +178,7 @@ protected:
 	void resizeEvent( QResizeEvent * re ) override;
 	void wheelEvent( QWheelEvent * we ) override;
 	void focusOutEvent( QFocusEvent * ) override;
+	void focusInEvent( QFocusEvent * ) override;
 
 	int getKey( int y ) const;
 	void drawNoteRect( QPainter & p, int x, int y,

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -56,6 +56,7 @@ protected:
 	void mouseReleaseEvent( QMouseEvent * me ) override;
 	void mouseMoveEvent( QMouseEvent * me ) override;
 	void focusOutEvent( QFocusEvent * _fe ) override;
+	void focusInEvent( QFocusEvent * fe ) override;
 	void resizeEvent( QResizeEvent * _event ) override;
 
 

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -175,6 +175,7 @@ private:
 	QComboBox * m_midiInterfaces;
 	MswMap m_midiIfaceSetupWidgets;
 	trMap m_midiIfaceNames;
+	QComboBox * m_assignableMidiDevices;
 
 	// Paths settings widgets.
 	QString m_workingDir;

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -673,9 +673,18 @@ void PianoView::focusOutEvent( QFocusEvent * )
 		m_piano->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
 		m_piano->setKeyState( i, false );
 	}
+
+	// Deassign midi device
+	m_piano->instrumentTrack()->autoAssignMidiDevice(false);
+
 	update();
 }
 
+
+void PianoView::focusInEvent( QFocusEvent * )
+{
+	m_piano->instrumentTrack()->autoAssignMidiDevice(true);
+}
 
 
 

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -674,8 +674,6 @@ void PianoView::focusOutEvent( QFocusEvent * )
 		m_piano->setKeyState( i, false );
 	}
 
-	// Deassign midi device
-	m_piano->instrumentTrack()->autoAssignMidiDevice(false);
 
 	update();
 }

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -677,9 +677,25 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 			this, SLOT(midiInterfaceChanged(const QString &)));
 
 
+	// MIDI autoassign tab.
+	TabWidget * midiAutoAssign_tw = new TabWidget(
+			tr("Automatically assign MIDI controller to selected track"), midi_w);
+	midiAutoAssign_tw->setFixedHeight(56);
+
+	m_assignableMidiDevices = new QComboBox(midiAutoAssign_tw);
+	m_assignableMidiDevices->setGeometry(10, 20, 240, 28);
+	m_assignableMidiDevices->addItem("none");
+	m_assignableMidiDevices->addItems(Engine::mixer()->midiClient()->readablePorts());
+	int current = m_assignableMidiDevices->findText(ConfigManager::inst()->value("midi", "midiautoassign"));
+	if (current >= 0)
+	{
+		m_assignableMidiDevices->setCurrentIndex(current);
+	}
+
 	// MIDI layout ordering.
 	midi_layout->addWidget(midiiface_tw);
 	midi_layout->addWidget(ms_w);
+	midi_layout->addWidget(midiAutoAssign_tw);
 	midi_layout->addStretch();
 
 
@@ -917,6 +933,8 @@ void SetupDialog::accept()
 					QString::number(m_bufferSize));
 	ConfigManager::inst()->setValue("mixer", "mididev",
 					m_midiIfaceNames[m_midiInterfaces->currentText()]);
+	ConfigManager::inst()->setValue("midi", "midiautoassign",
+					m_assignableMidiDevices->currentText());
 
 
 	ConfigManager::inst()->setWorkingDir(QDir::fromNativeSeparators(m_workingDir));

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -691,7 +691,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	}
 	else
 	{
-		m_assignableMidiDevices->addItem("yes");
+		m_assignableMidiDevices->addItem("all");
 	}
 	int current = m_assignableMidiDevices->findText(ConfigManager::inst()->value("midi", "midiautoassign"));
 	if (current >= 0)

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -685,7 +685,14 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_assignableMidiDevices = new QComboBox(midiAutoAssign_tw);
 	m_assignableMidiDevices->setGeometry(10, 20, 240, 28);
 	m_assignableMidiDevices->addItem("none");
-	m_assignableMidiDevices->addItems(Engine::mixer()->midiClient()->readablePorts());
+	if ( !Engine::mixer()->midiClient()->isRaw() )
+	{
+		m_assignableMidiDevices->addItems(Engine::mixer()->midiClient()->readablePorts());
+	}
+	else
+	{
+		m_assignableMidiDevices->addItem("yes");
+	}
 	int current = m_assignableMidiDevices->findText(ConfigManager::inst()->value("midi", "midiautoassign"));
 	if (current >= 0)
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3656,11 +3656,22 @@ void PianoRoll::focusOutEvent( QFocusEvent * )
 			m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
 			m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
 		}
+
+		// De-assign midi device
+		m_pattern->instrumentTrack()->autoAssignMidiDevice(false);
 	}
 	m_editMode = m_ctrlMode;
 	update();
 }
 
+void PianoRoll::focusInEvent( QFocusEvent * )
+{
+	if ( hasValidPattern() )
+	{
+		// Assign midi device
+		m_pattern->instrumentTrack()->autoAssignMidiDevice(true);
+	}
+}
 
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3656,9 +3656,6 @@ void PianoRoll::focusOutEvent( QFocusEvent * )
 			m_pattern->instrumentTrack()->pianoModel()->midiEventProcessor()->processInEvent( MidiEvent( MidiNoteOff, -1, i, 0 ) );
 			m_pattern->instrumentTrack()->pianoModel()->setKeyState( i, false );
 		}
-
-		// De-assign midi device
-		m_pattern->instrumentTrack()->autoAssignMidiDevice(false);
 	}
 	m_editMode = m_ctrlMode;
 	update();

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -940,6 +940,12 @@ void InstrumentTrack::autoAssignMidiDevice(bool assign)
 	}
 
 	const QString &device = ConfigManager::inst()->value("midi", "midiautoassign");
+	if ( Engine::mixer()->midiClient()->isRaw() && device != "none" )
+	{
+		m_midiPort.setReadable( assign );
+		return;
+	}
+
 	// Check if the device exists
 	if ( Engine::mixer()->midiClient()->readablePorts().indexOf(device) >= 0 )
 	{

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -150,6 +150,13 @@ int InstrumentTrack::baseNote() const
 
 InstrumentTrack::~InstrumentTrack()
 {
+	// De-assign midi device
+	if (m_hasAutoMidiDev)
+	{
+		autoAssignMidiDevice(false);
+		s_autoAssignedTrack = NULL;
+	}
+	
 	// kill all running notes and the iph
 	silenceAllNotes( true );
 
@@ -915,12 +922,23 @@ Instrument * InstrumentTrack::loadInstrument(const QString & _plugin_name,
 
 
 
+InstrumentTrack *InstrumentTrack::s_autoAssignedTrack = NULL;
+
 /*! \brief Automatically assign a midi controller to this track, based on the midiautoassign setting
  *
  *  \param assign set to true to connect the midi device, set to false to disconnect
  */
 void InstrumentTrack::autoAssignMidiDevice(bool assign)
 {
+	if (assign)
+	{
+		if (s_autoAssignedTrack)
+		{
+			s_autoAssignedTrack->autoAssignMidiDevice(false);
+		}
+		s_autoAssignedTrack = this;
+	}
+
 	const QString &device = ConfigManager::inst()->value("midi", "midiautoassign");
 	// Check if the device exists
 	if ( Engine::mixer()->midiClient()->readablePorts().indexOf(device) >= 0 )


### PR DESCRIPTION
Hello everyone, this is my first pullrequest here!

This pullrequest implements "Faster access to MIDI assignment/auto-assignment" in meta-issue #1472 (as well as #3400 #1189 #1781 #1918 #1942 #3185)

With this pullrequest, it is now possible to automatically assign/connect a "master" midi input device (eg. a keyboard) to the currently selected instrument track and piano roll, this makes it behave similarly to the QWERTY keyboard for note input.
Whereas previously you needed to manually assign your MIDI keyboard via the menu every time you wanted to play a different instrument, now you can just select your main midi keyboard in the settings menu (MIDI Tab), and LMMS will automatically assign it. This speeds up the workflow for people who record using a MIDI device.

![2020-05-15_20-46-49](https://user-images.githubusercontent.com/17319302/82085466-5f639a00-96ed-11ea-830d-0200d65be81d.png)

The use of this feature is completely optional, if you leave the auto-assign setting at 'none', your workflow will not be impacted at all.