### PR TITLE
New logging mechanism

### DIFF
--- a/include/ConsoleLogSink.h
+++ b/include/ConsoleLogSink.h
@@ -1,0 +1,14 @@
+#ifndef CONSOLE_LOG_SINK_H
+#define CONSOLE_LOG_SINK_H
+
+#include "Logging.h"
+
+class ConsoleLogSink: public LogSink
+{
+public:
+	ConsoleLogSink(LogVerbosity maxVerbosity, LogManager& logManager);
+	void onLogLine(const LogLine& line) override;
+	~ConsoleLogSink() = default;
+};
+
+#endif // CONSOLE_LOG_SINK_H

--- a/include/Logging.h
+++ b/include/Logging.h
@@ -1,0 +1,93 @@
+#ifndef DEBUG_TRACE_H
+#define DEBUG_TRACE_H
+
+#include <string>
+#include <vector>
+
+class LogManager;
+
+enum class LogVerbosity
+{
+	Fatal = 0,
+	Error,
+	Warning,
+	Info,
+	Debug_Lo,
+	Debug_Hi,
+
+	Last
+};
+
+struct LogLine
+{
+	LogVerbosity verbosity;
+	unsigned int logLineNo;
+	unsigned long int timestamp;
+	std::string fileName;
+	unsigned int fileLineNo;
+	std::string content;
+
+	LogLine(LogVerbosity verbosity,
+		const char* fileName,
+		unsigned int fileLineNo,
+		const char* content);
+
+	std::string toString() const;
+};
+
+class LogSink
+{
+public:
+	LogSink(LogVerbosity maxVerbosity, LogManager& logManager);
+	virtual ~LogSink();
+
+	virtual void onLogLine(const LogLine& line) = 0;
+
+	LogVerbosity getMaxVerbosity()
+	{
+		return m_maxVerbosity;
+	}
+
+private:
+	LogVerbosity m_maxVerbosity;
+	LogManager& m_logManager;
+};
+
+class LogManager
+{
+public:
+	static LogManager& inst();
+	~LogManager();
+	void addSink(LogSink* sink);
+
+	void pauseFlush();
+	void resumeFlush();
+
+	void push(const LogLine& logLine);
+	void flush();
+
+private:
+	LogManager();
+
+	bool m_flushPaused;
+	LogVerbosity m_maxVerbosity;
+	std::vector<LogSink*> m_sinks;
+	std::vector<LogLine> m_pendingLogLines;
+};
+
+#define Log_Gen(verb,format,...)                                               \
+	do {                                                                   \
+		char _content[1024];                                           \
+		snprintf(_content, sizeof(_content), format, ##__VA_ARGS__);   \
+		LogLine _logLine(verb, __FILE__, __LINE__, _content);          \
+		LogManager::inst().push(std::move(_logLine));                  \
+	} while(0)
+
+#define Log_Fatal(format,...) Log_Gen(LogVerbosity::Fatal, format, ##__VA_ARGS__);
+#define Log_Err(format,...) Log_Gen(LogVerbosity::Error, format, ##__VA_ARGS__);
+#define Log_Wrn(format,...) Log_Gen(LogVerbosity::Warning, format, ##__VA_ARGS__);
+#define Log_Inf(format,...) Log_Gen(LogVerbosity::Info, format, ##__VA_ARGS__);
+#define Log_Dbg_Lo(format, ...) Log_Gen(LogVerbosity::Debug_Lo, format, ##__VA_ARGS__);
+#define Log_Dbg_Hi(format, ...) Log_Gen(LogVerbosity::Debug_Hi, format, ##__VA_ARGS__);
+
+#endif // DEBUG_TRACE_H

--- a/include/Logging.h
+++ b/include/Logging.h
@@ -2,6 +2,7 @@
 #define DEBUG_TRACE_H
 
 #include <string>
+#include <sstream>
 #include <vector>
 
 class LogManager;
@@ -28,9 +29,9 @@ struct LogLine
 	std::string content;
 
 	LogLine(LogVerbosity verbosity,
-		const char* fileName,
+		std::string fileName,
 		unsigned int fileLineNo,
-		const char* content);
+		std::string content);
 
 	std::string toString() const;
 };
@@ -75,6 +76,19 @@ private:
 	std::vector<LogLine> m_pendingLogLines;
 };
 
+class LogIostreamWrapper: public std::ostringstream
+{
+public:
+	LogIostreamWrapper(LogVerbosity verbosity,
+			std::string fileName,
+			unsigned int fileLineNo);
+
+	~LogIostreamWrapper() override;
+
+private:
+	LogLine m_line;
+};
+
 #define Log_Gen(verb,format,...)                                               \
 	do {                                                                   \
 		char _content[1024];                                           \
@@ -89,5 +103,13 @@ private:
 #define Log_Inf(format,...) Log_Gen(LogVerbosity::Info, format, ##__VA_ARGS__);
 #define Log_Dbg_Lo(format, ...) Log_Gen(LogVerbosity::Debug_Lo, format, ##__VA_ARGS__);
 #define Log_Dbg_Hi(format, ...) Log_Gen(LogVerbosity::Debug_Hi, format, ##__VA_ARGS__);
+
+#define Log_Str_Gen(verb) LogIostreamWrapper(verb, __FILE__, __LINE__)
+#define Log_Str_Fatal Log_Str_Gen(LogVerbosity::Fatal)
+#define Log_Str_Err Log_Str_Gen(LogVerbosity::Error)
+#define Log_Str_Wrn Log_Str_Gen(LogVerbosity::Warning)
+#define Log_Str_Inf Log_Str_Gen(LogVerbosity::Info)
+#define Log_Str_Dbg_Lo Log_Str_Gen(LogVerbosity::Debug_Lo)
+#define Log_Str_Dbg_Hi Log_Str_Gen(LogVerbosity::Debug_Hi)
 
 #endif // DEBUG_TRACE_H

--- a/include/Logging.h
+++ b/include/Logging.h
@@ -19,6 +19,8 @@ enum class LogVerbosity
 	Last
 };
 
+LogVerbosity stringToLogVerbosity(std::string s);
+
 struct LogLine
 {
 	LogVerbosity verbosity;
@@ -50,6 +52,8 @@ public:
 		return m_maxVerbosity;
 	}
 
+	void setMaxVerbosity(LogVerbosity verbosity);
+
 private:
 	LogVerbosity m_maxVerbosity;
 	LogManager& m_logManager;
@@ -73,6 +77,8 @@ public:
 		std::string content);
 
 	void flush();
+
+	void notifyVerbosityChanged();
 
 private:
 	LogManager();

--- a/include/LoggingThread.h
+++ b/include/LoggingThread.h
@@ -1,0 +1,28 @@
+#ifndef LOGGINGTHREAD_H
+#define LOGGINGTHREAD_H
+
+#include <QThread>
+
+class LoggingThread: public QThread
+{
+public:
+	static LoggingThread& inst();
+	~LoggingThread();
+	void run() override;
+	void setFlushInterval(unsigned int interval)
+	{
+		m_flushInterval = interval;
+	}
+
+	unsigned int flushInterval()
+	{
+		return m_flushInterval;
+	}
+
+private:
+	LoggingThread();
+	unsigned int m_flushInterval;
+	bool m_active;
+};
+
+#endif // LOGGINGTHREAD_H

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LMMS_SRCS
 	core/BufferManager.cpp
 	core/Clipboard.cpp
 	core/ComboBoxModel.cpp
+	core/ConsoleLogSink.cpp
 	core/ConfigManager.cpp
 	core/Controller.cpp
 	core/ControllerConnection.cpp
@@ -33,6 +34,7 @@ set(LMMS_SRCS
 	core/LfoController.cpp
 	core/LinkedModelGroups.cpp
 	core/LocklessAllocator.cpp
+	core/Logging.cpp
 	core/MemoryHelper.cpp
 	core/MemoryManager.cpp
 	core/MeterModel.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -35,6 +35,7 @@ set(LMMS_SRCS
 	core/LinkedModelGroups.cpp
 	core/LocklessAllocator.cpp
 	core/Logging.cpp
+	core/LoggingThread.cpp
 	core/MemoryHelper.cpp
 	core/MemoryManager.cpp
 	core/MeterModel.cpp

--- a/src/core/ConsoleLogSink.cpp
+++ b/src/core/ConsoleLogSink.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include "ConsoleLogSink.h"
+
+ConsoleLogSink::ConsoleLogSink(LogVerbosity maxVerbosity, LogManager& logManager)
+	: LogSink(maxVerbosity, logManager)
+{
+}
+
+void ConsoleLogSink::onLogLine(const LogLine& line)
+{
+	std::cout << line.toString() << std::endl;
+}

--- a/src/core/Logging.cpp
+++ b/src/core/Logging.cpp
@@ -1,0 +1,154 @@
+#include "Logging.h"
+#include <sstream>
+#include <iomanip>
+#include <sys/time.h>
+
+const int LOG_QUEUE_SIZE = 256;
+const unsigned int USEC_PER_SEC = 1000000;
+
+#if defined(WIN32) || defined(_WIN32)
+	#define PATH_SEPARATOR "\\"
+#else
+	#define PATH_SEPARATOR "/"
+#endif
+
+
+LogLine::LogLine(LogVerbosity verbosity,
+		const char* fileName,
+		unsigned int fileLineNo,
+		const char* content)
+{
+	static unsigned int logLineNo = 0;
+	static unsigned long int initialTimestamp = 0;
+	struct timeval tv;
+
+	this->verbosity = verbosity;
+	this->fileLineNo = fileLineNo;
+	this->fileName = fileName;
+	this->content = content;
+	this->logLineNo = logLineNo++;
+
+	/* Fill the timestamp information */
+	gettimeofday(&tv, nullptr);
+	this->timestamp = tv.tv_sec * USEC_PER_SEC + tv.tv_usec;
+
+	/* If the timestamp was not set yet, initialize it with the value
+	 * we have just obtained - this way the very first log line will
+	 * always have the timestamp of 0 */
+	if (initialTimestamp == 0)
+	{
+		initialTimestamp = this->timestamp;
+	}
+
+	this->timestamp -= initialTimestamp;
+
+	/* Check if the file name is a basename. If not, drop the directory
+	 * information */
+	if (this->fileName.find(PATH_SEPARATOR) != std::string::npos)
+	{
+		this->fileName = this->fileName.substr(
+					this->fileName.rfind(PATH_SEPARATOR)+1);
+	}
+
+}
+
+std::string LogLine::toString() const
+{
+	const char VERBOSITY_LETTERS[] = {'F', 'E', 'W', 'I', 'L', 'H'};
+	static_assert(sizeof(VERBOSITY_LETTERS) == (int)LogVerbosity::Last);
+
+	std::ostringstream os;
+	if (verbosity < LogVerbosity::Last)
+	{
+		os << VERBOSITY_LETTERS[(int)verbosity];
+	}
+	else
+	{
+		os << "X";
+	}
+
+	os << "-" << logLineNo;
+	os << "-" << (timestamp / USEC_PER_SEC);
+	os << "." << std::setw(6) << std::setfill('0') << (timestamp % USEC_PER_SEC);
+	os << "-" << fileName << ":" << fileLineNo;
+	os << ": " << content;
+
+	return os.str();
+}
+
+LogSink::LogSink(LogVerbosity maxVerbosity, LogManager& logManager)
+	: m_maxVerbosity(maxVerbosity), m_logManager(logManager)
+{
+}
+
+LogSink::~LogSink()
+{
+}
+
+
+LogManager& LogManager::inst()
+{
+	static LogManager instance;
+	return instance;
+}
+
+LogManager::LogManager()
+{
+	m_pendingLogLines.reserve(LOG_QUEUE_SIZE);
+	m_flushPaused = false;
+}
+
+LogManager::~LogManager()
+{
+	for (LogSink* pSink: m_sinks)
+	{
+		delete pSink;
+	}
+}
+
+void LogManager::addSink(LogSink* sink)
+{
+	m_sinks.push_back(sink);
+}
+
+void LogManager::pauseFlush()
+{
+	m_flushPaused = true;
+}
+
+void LogManager::resumeFlush()
+{
+	m_flushPaused = false;
+}
+
+void LogManager::push(const LogLine& logLine)
+{
+	if (m_maxVerbosity > logLine.verbosity) return;
+
+	if (m_pendingLogLines.size() < LOG_QUEUE_SIZE -1)
+	{
+		m_pendingLogLines.push_back(logLine);
+	}
+	else if (m_pendingLogLines.size() == LOG_QUEUE_SIZE - 1)
+	{
+		Log_Wrn("Log queue overflow, some lines might be dropped");
+	}
+
+	if (!m_flushPaused) flush();
+}
+
+void LogManager::flush()
+{
+	for (LogSink* pSink: m_sinks)
+	{
+		for (LogLine& logLine: m_pendingLogLines)
+		{
+			if (logLine.verbosity <= pSink->getMaxVerbosity())
+			{
+				pSink->onLogLine(logLine);
+			}
+		}
+	}
+	m_pendingLogLines.clear();
+}
+

--- a/src/core/Logging.cpp
+++ b/src/core/Logging.cpp
@@ -14,9 +14,9 @@ const unsigned int USEC_PER_SEC = 1000000;
 
 
 LogLine::LogLine(LogVerbosity verbosity,
-		const char* fileName,
+		std::string fileName,
 		unsigned int fileLineNo,
-		const char* content)
+		std::string content)
 {
 	static unsigned int logLineNo = 0;
 	static unsigned long int initialTimestamp = 0;
@@ -150,5 +150,18 @@ void LogManager::flush()
 		}
 	}
 	m_pendingLogLines.clear();
+}
+
+LogIostreamWrapper::LogIostreamWrapper(LogVerbosity verbosity,
+					std::string fileName,
+					unsigned int fileLineNo)
+	: m_line(verbosity, fileName, fileLineNo, "")
+{
+}
+
+LogIostreamWrapper::~LogIostreamWrapper()
+{
+	m_line.content = this->str();
+	LogManager::inst().push(m_line);
 }
 

--- a/src/core/Logging.cpp
+++ b/src/core/Logging.cpp
@@ -1,9 +1,10 @@
 #include "Logging.h"
+#include "LoggingThread.h"
 #include <sstream>
 #include <iomanip>
 #include <sys/time.h>
 
-const int LOG_QUEUE_SIZE = 256;
+const int LOG_BUFFER_SIZE = 256;
 const unsigned int USEC_PER_SEC = 1000000;
 
 #if defined(WIN32) || defined(_WIN32)
@@ -70,7 +71,16 @@ std::string LogLine::toString() const
 	os << "-" << logLineNo;
 	os << "-" << (timestamp / USEC_PER_SEC);
 	os << "." << std::setw(6) << std::setfill('0') << (timestamp % USEC_PER_SEC);
-	os << "-" << fileName << ":" << fileLineNo;
+
+	if (fileLineNo != 0)
+	{
+		os << "-" << fileName << ":" << fileLineNo;
+	}
+	else
+	{
+		os << "-?";
+	}
+
 	os << ": " << content;
 
 	return os.str();
@@ -85,6 +95,10 @@ LogSink::~LogSink()
 {
 }
 
+void LogSink::onTermination()
+{
+}
+
 
 LogManager& LogManager::inst()
 {
@@ -94,7 +108,7 @@ LogManager& LogManager::inst()
 
 LogManager::LogManager()
 {
-	m_pendingLogLines.reserve(LOG_QUEUE_SIZE);
+	m_pendingLogLines.reserve(LOG_BUFFER_SIZE);
 	m_flushPaused = false;
 }
 
@@ -102,6 +116,7 @@ LogManager::~LogManager()
 {
 	for (LogSink* pSink: m_sinks)
 	{
+		pSink->onTermination();
 		delete pSink;
 	}
 }
@@ -113,35 +128,88 @@ void LogManager::addSink(LogSink* sink)
 
 void LogManager::pauseFlush()
 {
+	m_flushPausedMutex.lock();
 	m_flushPaused = true;
+	m_flushPausedMutex.unlock();
 }
 
 void LogManager::resumeFlush()
 {
+	m_flushPausedMutex.lock();
 	m_flushPaused = false;
+	m_flushPausedMutex.unlock();
+
+	/* If the logging thread is not used, flush immediately the log lines
+	 * that were generated in performance-critical section. */
+	if (!LoggingThread::inst().isRunning())
+	{
+		flush();
+	}
 }
 
-void LogManager::push(const LogLine& logLine)
+bool LogManager::isFlushPaused() const
+{
+	bool result;
+
+	m_flushPausedMutex.lock();
+	result = m_flushPaused;
+	m_flushPausedMutex.unlock();
+
+	return result;
+}
+
+
+void LogManager::push(const LogLine logLine)
 {
 	if (m_maxVerbosity > logLine.verbosity) return;
 
-	if (m_pendingLogLines.size() < LOG_QUEUE_SIZE -1)
+	/* The logger thread might be now caching the log lines with the intent
+	 * of flushing them. It is better not to interfere */
+	m_pendingLogLinesMutex.lock();
+
+	if (m_pendingLogLines.size() < LOG_BUFFER_SIZE -1)
 	{
 		m_pendingLogLines.push_back(logLine);
 	}
-	else if (m_pendingLogLines.size() == LOG_QUEUE_SIZE - 1)
+	else if (m_pendingLogLines.size() == LOG_BUFFER_SIZE - 1)
 	{
 		Log_Wrn("Log queue overflow, some lines might be dropped");
 	}
 
-	if (!m_flushPaused) flush();
+	m_pendingLogLinesMutex.unlock();
+
+	/* If the logging thread is not used, make the log message appear
+	 * immediately unless we are in a performance-critical section */
+	if (!isFlushPaused() && !LoggingThread::inst().isRunning())
+	{
+		flush();
+	}
+}
+
+void LogManager::push(LogVerbosity verbosity,
+			std::string fileName,
+			unsigned int fileLineNo,
+			std::string content)
+{
+	LogLine logLine(verbosity, fileName, fileLineNo, content);
+	push(std::move(logLine));
 }
 
 void LogManager::flush()
 {
-	for (LogSink* pSink: m_sinks)
+	m_pendingLogLinesMutex.lock();
+	std::vector<LogLine> pendingLogLines(m_pendingLogLines);
+	m_pendingLogLines.clear();
+	m_pendingLogLinesMutex.unlock();
+
+	/* We have saved all the log lines and cleared the main buffer.
+	 * Other threads may now fill up the main buffer again, but they
+	 * will not be blocked by us writing down (potentially slowly)
+	 * the contents of the buffer. */
+
+	for (LogLine& logLine: pendingLogLines)
 	{
-		for (LogLine& logLine: m_pendingLogLines)
+		for (LogSink* pSink: m_sinks)
 		{
 			if (logLine.verbosity <= pSink->getMaxVerbosity())
 			{
@@ -149,7 +217,6 @@ void LogManager::flush()
 			}
 		}
 	}
-	m_pendingLogLines.clear();
 }
 
 LogIostreamWrapper::LogIostreamWrapper(LogVerbosity verbosity,
@@ -164,4 +231,5 @@ LogIostreamWrapper::~LogIostreamWrapper()
 	m_line.content = this->str();
 	LogManager::inst().push(m_line);
 }
+
 

--- a/src/core/LoggingThread.cpp
+++ b/src/core/LoggingThread.cpp
@@ -1,0 +1,42 @@
+#include "LoggingThread.h"
+#include "Logging.h"
+
+static const int DEFAULT_FLUSH_INTERVAL = 1000;
+
+LoggingThread::LoggingThread()
+	: m_flushInterval(DEFAULT_FLUSH_INTERVAL)
+	, m_active(true)
+{
+}
+
+LoggingThread::~LoggingThread()
+{
+	m_active = false;
+	if (!wait(m_flushInterval)) {
+		terminate();
+	}
+
+	/* Forcifully flush all the messages that still are present
+	 * in the buffer - don't care about the performance, as probably
+	 * we are shutting down right now.*/
+	LogManager::inst().flush();
+}
+
+LoggingThread& LoggingThread::inst()
+{
+	static LoggingThread instance;
+	return instance;
+}
+
+void LoggingThread::run()
+{
+	while (m_active)
+	{
+		if (!LogManager::inst().isFlushPaused())
+		{
+			LogManager::inst().flush();
+		}
+		msleep(DEFAULT_FLUSH_INTERVAL);
+	}
+	this->exit();
+}

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -26,6 +26,7 @@
 #include <QLabel>
 
 #include "AudioPulseAudio.h"
+#include "Logging.h"
 
 #ifdef LMMS_HAVE_PULSEAUDIO
 
@@ -134,12 +135,12 @@ static void stream_state_callback( pa_stream *s, void * userdata )
 			break;
 
 		case PA_STREAM_READY:
-			qDebug( "Stream successfully created\n" );
+			Log_Inf( "Stream successfully created" );
 			break;
 
 		case PA_STREAM_FAILED:
 		default:
-			qCritical( "Stream error: %s\n",
+			Log_Err( "Stream error: %s\n",
 					pa_strerror(pa_context_errno(
 						pa_stream_get_context( s ) ) ) );
 	}
@@ -160,7 +161,7 @@ static void context_state_callback(pa_context *c, void *userdata)
 
 		case PA_CONTEXT_READY:
 		{
-			qDebug( "Connection established.\n" );
+			Log_Inf("Connection established");
 			_this->m_s = pa_stream_new( c, "lmms", &_this->m_sampleSpec,  NULL);
 			pa_stream_set_state_callback( _this->m_s, stream_state_callback, _this );
 			pa_stream_set_write_callback( _this->m_s, stream_write_callback, _this );
@@ -195,7 +196,8 @@ static void context_state_callback(pa_context *c, void *userdata)
 
 		case PA_CONTEXT_FAILED:
 		default:
-			qCritical( "Connection failure: %s\n", pa_strerror( pa_context_errno( c ) ) );
+			Log_Err( "Connection failure: %s",
+				 pa_strerror( pa_context_errno( c ) ) );
 			_this->signalConnected( false );
 	}
 }

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -701,6 +701,7 @@ int main( int argc, char * * argv )
 					LogManager::inst()));
 
 	Log_Inf("Logging activated");
+	Log_Str_Inf << "C++ style too!";
 
 	ConfigManager::inst()->loadConfigFile(configFile);
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -39,6 +39,9 @@
 #include <QPushButton>
 #include <QTextStream>
 
+#include "Logging.h"
+#include "ConsoleLogSink.h"
+
 #ifdef LMMS_BUILD_WIN32
 #include <windows.h>
 #endif
@@ -693,6 +696,12 @@ int main( int argc, char * * argv )
 		fileCheck( fileToImport );
 	}
 
+	LogManager::inst().addSink(new ConsoleLogSink(
+					LogVerbosity::Debug_Lo,
+					LogManager::inst()));
+
+	Log_Inf("Logging activated");
+
 	ConfigManager::inst()->loadConfigFile(configFile);
 
 	// Hidden settings
@@ -729,7 +738,7 @@ int main( int argc, char * * argv )
 				sched_get_priority_min( SCHED_FIFO ) ) / 2;
 	if( sched_setscheduler( 0, SCHED_FIFO, &sparam ) == -1 )
 	{
-		printf( "Notice: could not set realtime priority.\n" );
+		Log_Wrn("Could not set realtime priority.");
 	}
 #endif
 #endif
@@ -738,7 +747,7 @@ int main( int argc, char * * argv )
 #ifdef LMMS_BUILD_WIN32
 	if( !SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS ) )
 	{
-		printf( "Notice: could not set high priority.\n" );
+		Log_Wrn("Could not set realtime priority.");
 	}
 #endif
 
@@ -765,14 +774,15 @@ int main( int argc, char * * argv )
 		Engine::init( true );
 		destroyEngine = true;
 
-		printf( "Loading project...\n" );
+		Log_Inf("Loading project...");
 		Engine::getSong()->loadProject( fileToLoad );
 		if( Engine::getSong()->isEmpty() )
 		{
-			printf("The project %s is empty, aborting!\n", fileToLoad.toUtf8().constData() );
+			Log_Wrn("The project %s is empty, aborting!",
+				fileToLoad.toUtf8().constData() );
 			exit( EXIT_FAILURE );
 		}
-		printf( "Done\n" );
+		Log_Inf("Done");
 
 		Engine::getSong()->setExportLoop( renderLoop );
 


### PR DESCRIPTION
Implementation of the log messages' mechanism for LMMS. Implements #5159, now in scope of #5468.

The new API is intended to be used universally in the application, including the performance-critical sections.

Basics:
- The central class is LogManager, which needs to be accessible from any place in the code. To achieve this, it was implemented as a singleton.
- The LogManager stores a list of LogSinks. Each LogSink represents a different kind of output for the log lines. Examples are: standard output, a log file, a debug messages' window inside an application, a remote endpoint...
- Each LogSink is assigned independently the highest level of verbosity of the messages. Currently there are six levels: Fatal, Error, Warning, Info, Debug Low, Debug High.
- Whenever the LogManager accepts a log line, it is broadcast to all the sinks, unless the verbosity level of the line is greater than the sink's verbosity level. For example, if we set the log file's verbosity level to Debug Low and console's verbosity to Warning, all Errors will appear in both places. On the other hand, Infos will be present only in the log file, Debug Highs will not appear anywhere.
- In order to shorten the code, the programmer is supposed to use a set of dedicated macros rather than calling LogManager's API directly. There are two sets of macros. Log_xxx macros accept the same syntax as printf function, while Log_Str_xxx macros are supposed to be used as C++ streams (or Qt's mechanism). Replace "xxx" by the verbosity level designator: Fatal, Err, Wrn, Inf, Dbg_Lo, Dbg_Hi.
- Each log line, besides the actual message, is accompanied by some metadata: verbosity information, sequential number of the log message, a timestamp and the location of the log (source file name and line number). The timestamps are relative to the execution of LMMS (more precisely: the "Logging activated" message is at t=0) and have a resolution of 1 µs.

Extra stuff:
- To reduce the overhead of logging in terms of thread's execution time, the log messages are cached inside LogManager and are distributed to LogSinks in the flushing process. Flushing is done periodically in a separate thread (LoggingThread). Thanks to this solution, the thread that generated a log line will not be paused by writing to a console and/or a file - it will continue running while the log line is processed in the background.
- LoggingThread can be disabled (in case it is really needed), under such condition the log messages will be flushed immediately after they are generated. This may however have negative impact on the performance.
- Flushing process can be temporarily paused. This allows to use the logging mechanism inside performance-critical code, ensuring that no console/file writes will compete for the CPU time. Until flushing is resumed, all the log lines remain cached inside LogManager. This remains valid even if the LoggingThread is disabled - in such situation the flush is invoked immediately at the resume.
- All the logs generated through Qt's mechanism are forwarded to the new mechanism, since Qt provides a way to define a custom logs' handler. The final goal, however, is to replace all these qDebugs, qWarnings, etc. with the new unified API, alongside with all the printfs.
- Access to the log messages cache is synchronized with a mutex. The flush pause flag is synchronized either with a separate mutex.

The pull request currently contains a preliminary implementation, being more a kind of proposal or PoC. A few things are yet to be done:

- implementation of sinks for log file and log window
- adding appropriate configuration options, accessible via GUI
- enhancing log messages with the information about the name of a thread that generated each line
- usage of smart pointers instead of C-style pointers to store the sinks
