### PR TITLE
#5339, #5340: Fix pasting notes from bb editor

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -108,6 +108,11 @@ public:
 		return m_instrument;
 	}
 
+	f_cnt_t envFrames()
+	{
+		return m_soundShaping.envFrames();
+	}
+
 	void deleteNotePluginData( NotePlayHandle * _n );
 
 	// name-stuff

--- a/include/Pattern.h
+++ b/include/Pattern.h
@@ -132,6 +132,7 @@ private:
 
 	void setType( PatternTypes _new_pattern_type );
 	void checkType();
+	void adjustSteps();
 
 	void resizeToFirstTrack();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4126,6 +4126,15 @@ void PianoRoll::pasteNotes()
 			cur_note.restoreState( list.item( i ).toElement() );
 			cur_note.setPos( cur_note.pos() + Note::quantized( m_timeLine->pos(), quantization() ) );
 
+			if ((cur_note.length().getTicks() == -DefaultTicksPerBar) && (m_pattern->type() != Pattern::BeatPattern)) 
+			{
+				// the length of copied notes is set to the length of the instruments envelope
+				f_cnt_t envFrames = m_pattern->instrumentTrack()->envFrames();
+				// if notes have zero length due to rounding set the length to a small value
+				tick_t noteLength = qMax(static_cast<float>(1), envFrames / Engine::framesPerTick());
+				cur_note.setLength(MidiTime(noteLength));
+			}
+
 			// select it
 			cur_note.setSelected( true );
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4131,7 +4131,7 @@ void PianoRoll::pasteNotes()
 				// the length of copied notes is set to the length of the instruments envelope
 				f_cnt_t envFrames = m_pattern->instrumentTrack()->envFrames();
 				// if notes have zero length due to rounding set the length to a small value
-				tick_t noteLength = qMax(static_cast<float>(1), envFrames / Engine::framesPerTick());
+				tick_t noteLength = static_cast<tick_t>(qMax(1.0f, ceil(envFrames / Engine::framesPerTick())));
 				cur_note.setLength(MidiTime(noteLength));
 			}
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -247,7 +247,6 @@ void Pattern::removeNote( Note * _note_to_del )
 	}
 	instrumentTrack()->unlock();
 	
-	adjustSteps();
 	checkType();
 	updateLength();
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -55,13 +55,14 @@ QPixmap * PatternView::s_stepBtnOffLight = NULL;
 Pattern::Pattern( InstrumentTrack * _instrument_track ) :
 	TrackContentObject( _instrument_track ),
 	m_instrumentTrack( _instrument_track ),
-	m_patternType( BeatPattern ),
+	m_patternType( MelodyPattern ),
 	m_steps( MidiTime::stepsPerBar() )
 {
 	setName( _instrument_track->name() );
 	if( _instrument_track->trackContainer()
 					== Engine::getBBTrackContainer() )
 	{
+		m_patternType = Pattern::BeatPattern;
 		resizeToFirstTrack();
 	}
 	init();
@@ -218,6 +219,7 @@ Note * Pattern::addNote( const Note & _new_note, const bool _quant_pos )
 	m_notes.insert(std::upper_bound(m_notes.begin(), m_notes.end(), new_note, Note::lessThan), new_note);
 	instrumentTrack()->unlock();
 
+	adjustSteps();
 	checkType();
 	updateLength();
 
@@ -244,11 +246,18 @@ void Pattern::removeNote( Note * _note_to_del )
 		++it;
 	}
 	instrumentTrack()->unlock();
-
+	
+	adjustSteps();
 	checkType();
 	updateLength();
 
 	emit dataChanged();
+}
+
+
+void Pattern::adjustSteps()
+{
+	m_steps = qMax(1, MidiTime(m_notes.last()->pos()).nextFullBar()) * MidiTime::stepsPerBar();
 }
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -55,14 +55,13 @@ QPixmap * PatternView::s_stepBtnOffLight = NULL;
 Pattern::Pattern( InstrumentTrack * _instrument_track ) :
 	TrackContentObject( _instrument_track ),
 	m_instrumentTrack( _instrument_track ),
-	m_patternType( MelodyPattern ),
+	m_patternType( BeatPattern ),
 	m_steps( MidiTime::stepsPerBar() )
 {
 	setName( _instrument_track->name() );
 	if( _instrument_track->trackContainer()
 					== Engine::getBBTrackContainer() )
 	{
-		m_patternType = Pattern::BeatPattern;
 		resizeToFirstTrack();
 	}
 	init();

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -246,7 +246,6 @@ void Pattern::removeNote( Note * _note_to_del )
 		++it;
 	}
 	instrumentTrack()->unlock();
-	
 	checkType();
 	updateLength();
 


### PR DESCRIPTION
Addresses #5339 and #5340: When pasting notes from the bb editor to the piano roll, the length of the notes copied is now set to the envelope length of the underlying instrument, dependent on the BPM and envelope settings at the moment of pasting. Previously, copying the notes led to unexpected behavior including them not being registered in the song editor or being ignored by the loop. Thanks @Veratil for the discussion on discord and the change requests.