### PR TITLE
Add "natural" scrolling support for trackpads

### DIFF
--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -332,13 +332,7 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 		}
 
 		Note * n = m_clip->noteAtStep( step );
-		int direction = we->angleDelta().y() > 0 ? 1 : -1;
-#if QT_VERSION >= 0x050700
-		if (we->inverted()) {
-			// Handle "natural" scrolling, which is common on trackpads and touch devices
-			direction = -direction;
-		}
-#endif
+		const int direction = (we->angleDelta().y() > 0 ? 1 : -1) * (we->inverted() ? -1 : 1);
 		if(!n && direction > 0)
 		{
 			n = m_clip->addStepNote( step );

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -332,7 +332,14 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 		}
 
 		Note * n = m_clip->noteAtStep( step );
-		if(!n && we->angleDelta().y() > 0)
+		int direction = we->angleDelta().y() > 0 ? 1 : -1;
+#if QT_VERSION >= 0x050700
+		if (we->inverted()) {
+			// Handle "natural" scrolling, which is common on trackpads and touch devices
+			direction = -direction;
+		}
+#endif
+		if(!n && direction > 0)
 		{
 			n = m_clip->addStepNote( step );
 			n->setVolume( 0 );
@@ -340,8 +347,7 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 		if( n != nullptr )
 		{
 			int vol = n->getVolume();
-
-			if(we->angleDelta().y() > 0)
+			if(direction > 0)
 			{
 				n->setVolume( qMin( 100, vol + 5 ) );
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3774,7 +3774,14 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		}
 		if( nv.size() > 0 )
 		{
-			const int step = we->angleDelta().y() > 0 ? 1 : -1;
+			int step = we->angleDelta().y() > 0 ? 1 : -1;
+#if QT_VERSION >= 0x050700
+			if (we->inverted()) {
+				// Handle "natural" scrolling, which is common on trackpads and touch devices
+				step = -step;
+			}
+#endif
+
 			if( m_noteEditMode == NoteEditMode::Volume )
 			{
 				for ( Note * n : nv )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3774,13 +3774,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		}
 		if( nv.size() > 0 )
 		{
-			int step = we->angleDelta().y() > 0 ? 1 : -1;
-#if QT_VERSION >= 0x050700
-			if (we->inverted()) {
-				// Handle "natural" scrolling, which is common on trackpads and touch devices
-				step = -step;
-			}
-#endif
+			const int step = (we->angleDelta().y() > 0 ? 1 : -1) * (we->inverted() ? -1 : 1);
 
 			if( m_noteEditMode == NoteEditMode::Volume )
 			{

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -220,13 +220,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		int direction = event->angleDelta().y() < 0 ? 1 : -1;
-#if QT_VERSION >= 0x050700
-		if (event->inverted()) {
-			// Handle "natural" scrolling, which is common on trackpads and touch devices
-			direction = -direction;
-		}
-#endif
+		const int direction = (event->angleDelta().y() < 0 ? 1 : -1) * (event->inverted() ? -1 : 1);
 		model()->setInitValue(model()->value() + direction);
 		update();
 		event->accept();

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -220,7 +220,14 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		model()->setInitValue(model()->value() + ((event->angleDelta().y() < 0) ? 1 : -1));
+		int direction = event->angleDelta().y() < 0 ? 1 : -1;
+#if QT_VERSION >= 0x050700
+		if (event->inverted()) {
+			// Handle "natural" scrolling, which is common on trackpads and touch devices
+			direction = -direction;
+		}
+#endif
+		model()->setInitValue(model()->value() + direction);
 		update();
 		event->accept();
 	}

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -193,15 +193,16 @@ void Fader::mouseReleaseEvent(QMouseEvent* mouseEvent)
 void Fader::wheelEvent (QWheelEvent* ev)
 {
 	ev->accept();
+	int direction = ev->angleDelta().y() > 0 ? 1 : -1;
 
-	if (ev->angleDelta().y() > 0)
-	{
-		model()->incValue(1);
+#if QT_VERSION >= 0x050700
+	if (ev->inverted()) {
+		// Handle "natural" scrolling, which is common on trackpads and touch devices
+		direction = -direction;
 	}
-	else
-	{
-		model()->incValue(-1);
-	}
+#endif
+
+	model()->incValue(direction);
 	updateTextFloat();
 	s_textFloat->setVisibilityTimeOut(1000);
 }

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -193,14 +193,7 @@ void Fader::mouseReleaseEvent(QMouseEvent* mouseEvent)
 void Fader::wheelEvent (QWheelEvent* ev)
 {
 	ev->accept();
-	int direction = ev->angleDelta().y() > 0 ? 1 : -1;
-
-#if QT_VERSION >= 0x050700
-	if (ev->inverted()) {
-		// Handle "natural" scrolling, which is common on trackpads and touch devices
-		direction = -direction;
-	}
-#endif
+	const int direction = (ev->angleDelta().y() > 0 ? 1 : -1) * (ev->inverted() ? -1 : 1);
 
 	model()->incValue(direction);
 	updateTextFloat();

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -326,6 +326,13 @@ void FloatModelEditorBase::wheelEvent(QWheelEvent * we)
 		}
 	}
 
+#if QT_VERSION >= 0x050700
+	// Handle "natural" scrolling, which is common on trackpads and touch devices
+	if (we->inverted()) {
+		direction = -direction;
+	}
+#endif
+
 	// Compute the number of steps but make sure that we always do at least one step
 	const float stepMult = std::max(range / numberOfStepsForFullSweep / step, 1.f);
 	const int inc = direction * stepMult;

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -326,12 +326,10 @@ void FloatModelEditorBase::wheelEvent(QWheelEvent * we)
 		}
 	}
 
-#if QT_VERSION >= 0x050700
 	// Handle "natural" scrolling, which is common on trackpads and touch devices
 	if (we->inverted()) {
 		direction = -direction;
 	}
-#endif
 
 	// Compute the number of steps but make sure that we always do at least one step
 	const float stepMult = std::max(range / numberOfStepsForFullSweep / step, 1.f);

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -141,7 +141,16 @@ void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
 	we->accept();
-	model()->setValue(model()->value() + ((we->angleDelta().y() > 0) ? 1 : -1) * model()->step<int>());
+	int direction = we->angleDelta().y() > 0 ? 1 : -1;
+
+#if QT_VERSION >= 0x050700
+	if (we->inverted()) {
+		// Handle "natural" scrolling, which is common on trackpads and touch devices
+		direction = -direction;
+	}
+#endif
+
+	model()->setValue(model()->value() + direction * model()->step<int>());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -141,14 +141,7 @@ void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
 	we->accept();
-	int direction = we->angleDelta().y() > 0 ? 1 : -1;
-
-#if QT_VERSION >= 0x050700
-	if (we->inverted()) {
-		// Handle "natural" scrolling, which is common on trackpads and touch devices
-		direction = -direction;
-	}
-#endif
+	const int direction = (we->angleDelta().y() > 0 ? 1 : -1) * (we->inverted() ? -1 : 1);
 
 	model()->setValue(model()->value() + direction * model()->step<int>());
 	emit manualChange();


### PR DESCRIPTION
Adds `QWheelEvent::inverted()` support to `LcdSpinbox`, `Knob`.

Closes #5507

~~If desired, may be a candidate for backport to 1.2.0 with a cherry-pick.~~

**Edit:** On second thought, let's let 1.2.x drift into the archives of time.  `master` master race. :D