### PR TITLE
Compensate beat note length when stretching

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1606,6 +1606,11 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// then resize the note
 					m_action = ActionResizeNote;
 
+					for (Note *note : getSelectedNotes())
+					{
+					    if (note->oldLength() <= 0) { note->setOldLength(4); }
+					}
+
 					// set resize-cursor
 					QCursor c( Qt::SizeHorCursor );
 					QApplication::setOverrideCursor( c );
@@ -2521,13 +2526,6 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 		if (shift)
 		{
-			for (Note *note : notes)
-			{
-				if (note->selected())
-				{
-					if (note->oldLength() <= 0){note->setOldLength(4);}
-				}
-			}
 			// Algorithm:
 			// Relative to the starting point of the left-most selected note,
 			//   all selected note start-points and *endpoints* (not length) should be scaled by a calculated factor.
@@ -2616,7 +2614,6 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			{
 				if (note->selected())
 				{
-					if (note->oldLength() <= 0){note->setOldLength(4);}
 					int newLength = note->oldLength() + off_ticks;
 					newLength = qMax(1, newLength);
 					note->setLength( MidiTime(newLength) );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2609,6 +2609,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			{
 				if (note->selected())
 				{
+					if (note->oldLength() <= 0){note->setOldLength(1);}
 					int newLength = note->oldLength() + off_ticks;
 					newLength = qMax(1, newLength);
 					note->setLength( MidiTime(newLength) );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2609,7 +2609,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			{
 				if (note->selected())
 				{
-					if (note->oldLength() <= 0){note->setOldLength(1);}
+					if (note->oldLength() <= 0){note->setOldLength(4);}
 					int newLength = note->oldLength() + off_ticks;
 					newLength = qMax(1, newLength);
 					note->setLength( MidiTime(newLength) );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2521,6 +2521,13 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 		if (shift)
 		{
+			for (Note *note : notes)
+			{
+				if (note->selected())
+				{
+					if (note->oldLength() <= 0){note->setOldLength(4);}
+				}
+			}
 			// Algorithm:
 			// Relative to the starting point of the left-most selected note,
 			//   all selected note start-points and *endpoints* (not length) should be scaled by a calculated factor.


### PR DESCRIPTION
We allow stretching beat notes to normal notes but the length starts from -192 so there is a lag for one whole note before any change is seen. Compensate by setting the oldNote value to 1 when stretching if the note is 0 or below in length. It's important to show the notes stretching because they are changing even though not visibly. They are converted to 1 tick notes behind the scenes while the other notes are stretching fine. 1 tick notes, as we all know, are a bit shit.

---

The issue is there on master, stable-1.2 and stable-1.1.3 . On 1.1.3 I believe you must select the notes with the select tool to demonstrate the issue. I think the inclusion in stretching of beat notes may have been unintentional. Any more advanced changes belongs on master.


Glitch example.

BBTrack opened in the Piano Roll with two beat notes and a quarter note added
```
<note vol="100" pos="0" pan="0" len="-192" key="57"/>
<note vol="100" pos="48" pan="0" len="-192" key="57"/>
<note vol="100" pos="72" pan="0" len="48" key="55"/>
```
Select all notes and start extending the notes by stretching the quarter note. The beat notes will not present you a tool for stretching. They will respond though but silently. If you stop and release the move before the beat notes have changed they are given the length 1 tick. The saved example below is after the quarter note has been stretched for a 16th note, the quantization level at the time. After stopping stretching I could now have grabbed any of the notes and they all would have stretched together fine.
```
<note vol="100" pos="0" pan="0" len="1" key="57"/>
<note vol="100" pos="48" pan="0" len="1" key="57"/>
<note vol="100" pos="72" pan="0" len="60" key="55"/>
```
Starting once more from two beat notes and a quarter note, after you have dragged for over 192 ticks so the beat notes are positive, the beat notes now are stretching but they are still 192 ticks behind.
```
<note vol="100" pos="0" pan="0" len="12" key="57"/>
<note vol="100" pos="48" pan="0" len="12" key="57"/>
<note vol="100" pos="72" pan="0" len="252" key="55"/>
```