### PR TITLE
Arpeggiator - Cut off trailing short notes

### DIFF
--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -389,8 +389,10 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	while( frames_processed < Engine::mixer()->framesPerPeriod() )
 	{
 		const f_cnt_t remaining_frames_for_cur_arp = arp_frames - ( cur_frame % arp_frames );
-		// does current arp-note fill whole audio-buffer?
-		if( remaining_frames_for_cur_arp > Engine::mixer()->framesPerPeriod() )
+		// does current arp-note fill whole audio-buffer or is the remaining time just
+		// a short bit that we can discard?
+		if( remaining_frames_for_cur_arp > Engine::mixer()->framesPerPeriod() ||
+			_n->frames() - _n->totalFramesPlayed() < arp_frames / 5 )
 		{
 			// then we don't have to do something!
 			break;


### PR DESCRIPTION
Prevent triggering of extra notes at the end by not counting trailing notes shorter than one fifth of the notes arp_frames. This value being arbitrarily found by trial and error.

Addresses one of the tickets (Extra notes) in https://github.com/LMMS/lmms/issues/3880
The picture in 3880 also demonstrates this fix in the lower stereo track where the duplicated notes (the bigger notes) are gone but the missing notes (another, separate issue) remains.

![arpagain](https://user-images.githubusercontent.com/6368949/83358825-71446e80-a376-11ea-80f8-b697b7624c9d.png)