### PR TITLE
Make better use of getSelectedNotes() in PianoRoll.cpp

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -185,7 +185,7 @@ protected:
 					const QColor & selCol, const int noteOpc, const bool borderless, bool drawNoteName );
 	void removeSelection();
 	void selectAll();
-	NoteVector getSelectedNotes();
+	NoteVector getSelectedNotes() const;
 	void selectNotesOnKey();
 	int xCoordOfTick( int tick );
 
@@ -212,7 +212,7 @@ protected slots:
 	void copySelectedNotes();
 	void cutSelectedNotes();
 	void pasteNotes();
-	void deleteSelectedNotes();
+	bool deleteSelectedNotes();
 
 	void updatePosition(const MidiTime & t );
 	void updatePositionAccompany(const MidiTime & t );
@@ -294,7 +294,9 @@ private:
 	MidiTime newNoteLen() const;
 
 	void shiftPos(int amount);
+	void shiftPos(NoteVector notes, int amount);
 	void shiftSemiTone(int amount);
+	void shiftSemiTone(NoteVector notes, int amount);
 	bool isSelection() const;
 	int selectionCount() const;
 	void testPlayNote( Note * n );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1711,15 +1711,10 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					note->setOldPos( note->pos() );
 					note->setOldLength( note->length() );
 
-					m_moveBoundaryLeft = qMin(
-										note->pos().getTicks(),
-										(tick_t) m_moveBoundaryLeft );
-					m_moveBoundaryRight = qMax( (int) note->endPos(),
-											m_moveBoundaryRight );
-					m_moveBoundaryBottom = qMin( note->key(),
-									   m_moveBoundaryBottom );
-					m_moveBoundaryTop = qMax( note->key(),
-												m_moveBoundaryTop );
+					m_moveBoundaryLeft = qMin(note->pos().getTicks(), (tick_t) m_moveBoundaryLeft);
+					m_moveBoundaryRight = qMax((int) note->endPos(), m_moveBoundaryRight);
+					m_moveBoundaryBottom = qMin(note->key(), m_moveBoundaryBottom);
+					m_moveBoundaryTop = qMax(note->key(), m_moveBoundaryTop);
 				}
 
 				// clicked at the "tail" of the note?
@@ -2668,6 +2663,8 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 		// If shift is pressed we resize and rearrange only the selected notes
 		// If shift + ctrl then we also rearrange all posterior notes (sticky)
 		// If shift is pressed but only one note is selected, apply sticky
+		
+		auto selectedNotes = getSelectedNotes();
 
 		if (shift)
 		{
@@ -2677,7 +2674,6 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			// This factor is such that the endpoint of the note whose handle is being dragged should lie under the cursor.
 			// first, determine the start-point of the left-most selected note:
 			int stretchStartTick = -1;
-			auto selectedNotes = getSelectedNotes();
 			for (const Note *note : selectedNotes)
 			{
 				if (stretchStartTick < 0 || note->oldPos().getTicks() < stretchStartTick)
@@ -2753,7 +2749,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 		else
 		{
 			// shift is not pressed; stretch length of selected notes but not their position
-			for (Note *note : getSelectedNotes())
+			for (Note *note : selectedNotes)
 			{
 				int newLength = note->oldLength() + off_ticks;
 				newLength = qMax(1, newLength);

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1755,7 +1755,6 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// if they're holding shift, copy all selected notes
 					if( ! is_new_note && me->modifiers() & Qt::ShiftModifier )
 					{
-						auto selectedNotes = getSelectedNotes();
 						for (Note* note: selectedNotes)
 						{
 							Note * newNote = m_pattern->addNote(*note, false);
@@ -2678,7 +2677,8 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			// This factor is such that the endpoint of the note whose handle is being dragged should lie under the cursor.
 			// first, determine the start-point of the left-most selected note:
 			int stretchStartTick = -1;
-			for (const Note *note : getSelectedNotes())
+			auto selectedNotes = getSelectedNotes();
+			for (const Note *note : selectedNotes)
 			{
 				if (stretchStartTick < 0 || note->oldPos().getTicks() < stretchStartTick)
 				{
@@ -2687,7 +2687,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 			}
 			// determine the ending tick of the right-most selected note
 			const Note *posteriorNote = nullptr;
-			for (const Note *note : getSelectedNotes())
+			for (const Note *note : selectedNotes)
 			{
 				if (posteriorNote == nullptr ||
 					note->oldPos().getTicks() + note->oldLength().getTicks() >
@@ -2705,7 +2705,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 
 			// process all selected notes & determine how much the endpoint of the right-most note was shifted
 			int posteriorDeltaThisFrame = 0;
-			for (Note *note : getSelectedNotes())
+			for (Note *note : selectedNotes)
 			{
 				// scale relative start and end positions by scaleFactor
 				int newStart = stretchStartTick + scaleFactor *

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1142,6 +1142,7 @@ void PianoRoll::shiftPos(int amount) //Shift notes pos by amount
 	if (!hasValidPattern()) { return; }
 
 	auto selectedNotes = getSelectedNotes();
+	//If no notes are selected, shift all of them, otherwise shift selection
 	if (selectedNotes.empty()) { return shiftPos(m_pattern->notes(), amount); }
 	else { return shiftPos(selectedNotes, amount); }
 }
@@ -1154,7 +1155,7 @@ void PianoRoll::shiftPos(NoteVector notes, int amount)
 	auto shiftAmount = (leftMostPos > -amount) ? amount : -leftMostPos;
 	if (shiftAmount == 0) { return; }
 
-	for( Note *note : notes ) { note->setPos( note->pos() + shiftAmount ); }
+	for (Note *note : notes) { note->setPos( note->pos() + shiftAmount ); }
 
 	m_pattern->rearrangeAllNotes();
 	m_pattern->updateLength();
@@ -1690,7 +1691,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				m_mouseDownTick = m_currentPosition;
 
 				//If clicked on an unselected note, remove selection and select that new note
-				if(!m_currentNote->selected())
+				if (!m_currentNote->selected())
 				{
 					clearSelectedNotes();
 					m_currentNote->setSelected( true );
@@ -1704,7 +1705,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				m_moveBoundaryTop = m_moveBoundaryBottom;
 
 				//Figure out the bounding box of all the selected notes
-				for (Note* note: selectedNotes)
+				for (Note *note: selectedNotes)
 				{
 					// remember note starting positions
 					note->setOldKey( note->key() );
@@ -1750,9 +1751,9 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// if they're holding shift, copy all selected notes
 					if( ! is_new_note && me->modifiers() & Qt::ShiftModifier )
 					{
-						for (Note* note: selectedNotes)
+						for (Note *note: selectedNotes)
 						{
-							Note * newNote = m_pattern->addNote(*note, false);
+							Note *newNote = m_pattern->addNote(*note, false);
 							newNote->setSelected(false);
 						}
 
@@ -2628,7 +2629,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 	{
 		for (Note *note : getSelectedNotes())
 		{
-			if( shift && ! m_startedWithShift )
+			if (shift && ! m_startedWithShift)
 			{
 				// quick resize, toggled by holding shift after starting a note move, but not before
 				int ticks_new = note->oldLength().getTicks() + off_ticks;
@@ -2709,7 +2710,7 @@ void PianoRoll::dragNotes( int x, int y, bool alt, bool shift, bool ctrl )
 				int newEnd = stretchStartTick + scaleFactor *
 					(note->oldPos().getTicks()+note->oldLength().getTicks() - stretchStartTick);
 				// if  not holding alt, quantize the offsets
-				if(!alt)
+				if (!alt)
 				{
 					// quantize start time
 					int oldStart = note->oldPos().getTicks();
@@ -4124,14 +4125,14 @@ void PianoRoll::pasteNotes()
 //Return false if no notes are deleted
 bool PianoRoll::deleteSelectedNotes()
 {
-	if(!hasValidPattern()) { return false; }
+	if (!hasValidPattern()) { return false; }
 
 	auto selectedNotes = getSelectedNotes();
 	if (selectedNotes.empty()) { return false; }
 
 	m_pattern->addJournalCheckPoint();
 
-	for(Note* note: selectedNotes) { m_pattern->removeNote( note ); }
+	for (Note* note: selectedNotes) { m_pattern->removeNote( note ); }
 
 	Engine::getSong()->setModified();
 	update();


### PR DESCRIPTION
Plus some other refactoring.

In terms of objective measures
- Reduces LOC
- Uses fewer levels of indentation in many places

Subjectively speaking
- Communicates the intent of code blocks more clearly. "For each selected note, do ..." rather than "For every note, check if it is selected. If it is, do ..."
- Easier to read in general

Could be slower in some cases, since we iterate once to get selected notes and once to use them, rather than one iteration with an if statement. However, should also be faster in other cases where we can do things like reuse the vector of selected notes or avoid repeated checks like ``if (first)`` (replaced by handling the first element of the vector once, before the loop).