### PR TITLE
Remove macros likely() and unlikely()

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -148,7 +148,7 @@ public:
 	template<class T>
 	inline T value( int frameOffset = 0 ) const
 	{
-		if( unlikely( hasLinkedModels() || m_controllerConnection != NULL ) )
+		if( Q_UNLIKELY( hasLinkedModels() || m_controllerConnection != NULL ) )
 		{
 			return castValue<T>( controllerValue( frameOffset ) );
 		}

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -148,7 +148,7 @@ public:
 	template<class T>
 	inline T value( int frameOffset = 0 ) const
 	{
-		if( Q_UNLIKELY( hasLinkedModels() || m_controllerConnection != NULL ) )
+		if( hasLinkedModels() || m_controllerConnection != NULL )
 		{
 			return castValue<T>( controllerValue( frameOffset ) );
 		}

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -55,9 +55,6 @@ typedef uint16_t fx_ch_t;			// FX-channel (0 to MAX_EFFECT_CHANNEL)
 
 typedef uint32_t jo_id_t;			// (unique) ID of a journalling object
 
-// use for improved branch prediction
-#define likely(x)	Q_LIKELY(x)
-#define unlikely(x)	Q_UNLIKELY(x)
 
 // windows headers define "min" and "max" macros, breaking the methods bwloe
 #undef min


### PR DESCRIPTION
Because they're merely aliases for the Qt macros `Q_LIKELY()` and `Q_UNLIKELY()`, and that's a bad idea.