### PR TITLE
Adding a trail (gradient) behind the position bar

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -118,6 +118,11 @@ QMenu::indicator:selected {
 	background-color: #747474;
 }
 
+positionLine {
+	qproperty-tailGradient: false;
+	qproperty-lineColor: rgba(255, 255, 255, 153);
+}
+
 PianoRoll {
 	background-color: rgb(0, 0, 0);
 	qproperty-backgroundShade: rgba( 255, 255, 255, 10 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -120,7 +120,7 @@ QMenu::indicator:selected {
 
 positionLine {
 	qproperty-tailGradient: false;
-	qproperty-lineColor: rgba(255, 255, 255, 153);
+	qproperty-lineColor: rgb(255, 255, 255);
 }
 
 PianoRoll {

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -150,6 +150,11 @@ QMenu::indicator:selected {
 	background-color: #101213;
 }
 
+positionLine {
+	qproperty-tailGradient: true;
+	qproperty-lineColor: rgb(255, 255, 255);
+}
+
 PianoRoll {
 	background-color: #141616;
 	qproperty-backgroundShade: rgba(255, 255, 255, 10);

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -52,7 +52,7 @@ class positionLine : public QWidget
 	Q_PROPERTY ( bool tailGradient READ hasTailGradient WRITE setHasTailGradient )
 	Q_PROPERTY ( QColor lineColor READ lineColor WRITE setLineColor )
 public:
-	positionLine ( QWidget* parent, ComboBoxModel* zoom );
+	positionLine ( QWidget* parent );
 	
 	// qproperty access functions
 	bool hasTailGradient () const;
@@ -60,15 +60,14 @@ public:
 	QColor lineColor () const;
 	void setLineColor ( const QColor & c );
 
+public slots:
+	void zoomChange (double zoom);
+
 private:
 	void paintEvent( QPaintEvent* pe ) override;
 	
 	bool m_hasTailGradient;
 	QColor m_lineColor;
-	
-	// to accomodate the change in size by zoom
-	ComboBoxModel* m_currentZoom;
-	static const QVector<double> s_zoomLevels;
 
 };
 
@@ -181,6 +180,9 @@ private:
 	bool m_selectRegion;
 
 	friend class SongEditorWindow;
+
+signals:
+	void zoomingValueChanged( double );
 } ;
 
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -51,21 +51,21 @@ Q_DECLARE_METATYPE(QLinearGradient)
 class positionLine : public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY( bool tailGradient READ tailGradient WRITE setTailGradient )
-	Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor )
+	Q_PROPERTY ( bool tailGradient READ tailGradient WRITE setTailGradient )
+	Q_PROPERTY ( QColor lineColor READ lineColor WRITE setLineColor )
 public:
-	positionLine( QWidget * parent, ComboBoxModel*, Song* );
+	positionLine ( QWidget * parent, ComboBoxModel * zoom, Song * song );
 	
 	int width ();
-	void go (int, int);
+	void go ( int x, int y );	// NOTE: Check SongEditor.cpp for usage
 	void zoomUpdate ();
 	void playStateChanged ();
 	
 	// qproperty access functions
-	bool tailGradient() const;
-	void setTailGradient( const bool & g );
-	QColor lineColor() const;
-	void setLineColor( const QColor & c );
+	bool tailGradient () const;
+	void setTailGradient ( const bool & g );
+	QColor lineColor () const;
+	void setLineColor ( const QColor & c );
 
 private:
 	void paintEvent( QPaintEvent * pe ) override;
@@ -77,13 +77,13 @@ private:
 	QColor m_lineColor;
 	
 	// to accomodate the change in size by zoom
-	ComboBoxModel* currentZoom;
+	ComboBoxModel * currentZoom;
 	static const QVector<double> m_zoomLevels;
 	
 	// to remove gradient when the line is not moving
-	Song * p_song;
+	Song * p_song;	// NOTE: p here stands for pointer
 
-} ;
+};
 
 
 class SongEditor : public TrackContainerView

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -54,7 +54,12 @@ class positionLine : public QWidget
 	Q_PROPERTY( bool tailGradient READ tailGradient WRITE setTailGradient )
 	Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor )
 public:
-	positionLine( QWidget * parent );
+	positionLine( QWidget * parent, ComboBoxModel*, Song* );
+	
+	int width ();
+	void go (int, int);
+	void zoomUpdate ();
+	void playStateChanged ();
 	
 	// qproperty access functions
 	bool tailGradient() const;
@@ -65,8 +70,18 @@ public:
 private:
 	void paintEvent( QPaintEvent * pe ) override;
 	
+	int m_width;
+	int m_x, m_y;	// NOTE: m_x is the playback position, not the position where the tail starts
+	
 	bool m_tailGradient;
 	QColor m_lineColor;
+	
+	// to accomodate the change in size by zoom
+	ComboBoxModel* currentZoom;
+	static const QVector<double> m_zoomLevels;
+	
+	// to remove gradient when the line is not moving
+	Song * p_song;
 
 } ;
 
@@ -129,6 +144,8 @@ private slots:
 	void updateScrollBar(int len);
 
 	void zoomingChanged();
+	
+	void playbackStateChanged();
 
 private:
 	void keyPressEvent( QKeyEvent * ke ) override;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -49,21 +49,21 @@ class TimeLineWidget;
 class positionLine : public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY ( bool tailGradient READ tailGradient WRITE setTailGradient )
+	Q_PROPERTY ( bool tailGradient READ hasTailGradient WRITE setHasTailGradient )
 	Q_PROPERTY ( QColor lineColor READ lineColor WRITE setLineColor )
 public:
 	positionLine ( QWidget* parent, ComboBoxModel* zoom );
 	
 	// qproperty access functions
-	bool tailGradient () const;
-	void setTailGradient ( const bool & g );
+	bool hasTailGradient () const;
+	void setHasTailGradient ( const bool g );
 	QColor lineColor () const;
 	void setLineColor ( const QColor & c );
 
 private:
 	void paintEvent( QPaintEvent* pe ) override;
 	
-	bool m_tailGradient;
+	bool m_hasTailGradient;
 	QColor m_lineColor;
 	
 	// to accomodate the change in size by zoom

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -46,20 +46,13 @@ class Song;
 class TextFloat;
 class TimeLineWidget;
 
-Q_DECLARE_METATYPE(QLinearGradient)
-
 class positionLine : public QWidget
 {
 	Q_OBJECT
 	Q_PROPERTY ( bool tailGradient READ tailGradient WRITE setTailGradient )
 	Q_PROPERTY ( QColor lineColor READ lineColor WRITE setLineColor )
 public:
-	positionLine ( QWidget * parent, ComboBoxModel * zoom, Song * song );
-	
-	int width ();
-	void go ( int x, int y );	// NOTE: Check SongEditor.cpp for usage
-	void zoomUpdate ();
-	void playStateChanged ();
+	positionLine ( QWidget* parent, ComboBoxModel* zoom );
 	
 	// qproperty access functions
 	bool tailGradient () const;
@@ -68,20 +61,14 @@ public:
 	void setLineColor ( const QColor & c );
 
 private:
-	void paintEvent( QPaintEvent * pe ) override;
-	
-	int m_width;
-	int m_x, m_y;	// NOTE: m_x is the playback position, not the position where the tail starts
+	void paintEvent( QPaintEvent* pe ) override;
 	
 	bool m_tailGradient;
 	QColor m_lineColor;
 	
 	// to accomodate the change in size by zoom
-	ComboBoxModel * currentZoom;
+	ComboBoxModel* m_currentZoom;
 	static const QVector<double> m_zoomLevels;
-	
-	// to remove gradient when the line is not moving
-	Song * p_song;	// NOTE: p here stands for pointer
 
 };
 
@@ -144,8 +131,6 @@ private slots:
 	void updateScrollBar(int len);
 
 	void zoomingChanged();
-	
-	void playbackStateChanged();
 
 private:
 	void keyPressEvent( QKeyEvent * ke ) override;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -28,6 +28,7 @@
 #define SONG_EDITOR_H
 
 #include <QVector>
+#include <QLinearGradient>
 
 #include "ActionGroup.h"
 #include "Editor.h"
@@ -45,13 +46,27 @@ class Song;
 class TextFloat;
 class TimeLineWidget;
 
+Q_DECLARE_METATYPE(QLinearGradient)
+
 class positionLine : public QWidget
 {
+	Q_OBJECT
+	Q_PROPERTY( bool tailGradient READ tailGradient WRITE setTailGradient )
+	Q_PROPERTY( QColor lineColor READ lineColor WRITE setLineColor )
 public:
 	positionLine( QWidget * parent );
+	
+	// qproperty access functions
+	bool tailGradient() const;
+	void setTailGradient( const bool & g );
+	QColor lineColor() const;
+	void setLineColor( const QColor & c );
 
 private:
 	void paintEvent( QPaintEvent * pe ) override;
+	
+	bool m_tailGradient;
+	QColor m_lineColor;
 
 } ;
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -68,7 +68,7 @@ private:
 	
 	// to accomodate the change in size by zoom
 	ComboBoxModel* m_currentZoom;
-	static const QVector<double> m_zoomLevels;
+	static const QVector<double> s_zoomLevels;
 
 };
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -57,7 +57,7 @@ const QVector<double> positionLine::s_zoomLevels =
 
 positionLine::positionLine( QWidget* parent, ComboBoxModel* zoom) :
 	QWidget( parent ),
-	m_tailGradient ( false ),
+	m_hasTailGradient ( false ),
 	m_lineColor (0, 0, 0, 0)
 {
 	m_currentZoom = zoom;
@@ -88,15 +88,15 @@ void positionLine::paintEvent( QPaintEvent* pe )
 		QLinearGradient gradient( rect().bottomLeft(), rect().bottomRight() );
 		
 		// If gradient is enabled, we're in focus and we're playing, enable gradient
-		if (Engine::getSong()->isPlaying() && m_tailGradient && 
+		if (Engine::getSong()->isPlaying() && m_hasTailGradient && 
 			Engine::getSong()->playMode() == Song::Mode_PlaySong)
 		{
-			gradient.setColorAt((double)( ( width() - 1.0f )/width() ),
+			gradient.setColorAt(( ( width() - 1.0f )/width() ),
 				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 60) );
 		}
 		else
 		{
-			gradient.setColorAt((double)( ( width() - 1.0f )/width() ),
+			gradient.setColorAt(( ( width() - 1.0f )/width() ),
 				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
 		}
 		
@@ -112,11 +112,11 @@ void positionLine::paintEvent( QPaintEvent* pe )
 }
 
 // QProperty handles
-bool positionLine::tailGradient() const
-{ return m_tailGradient; }
+bool positionLine::hasTailGradient() const
+{ return m_hasTailGradient; }
 
-void positionLine::setTailGradient( const bool & g )
-{ m_tailGradient = g; }
+void positionLine::setHasTailGradient( const bool g )
+{ m_hasTailGradient = g; }
 
 QColor positionLine::lineColor() const
 { return m_lineColor; }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -121,10 +121,10 @@ void positionLine::setLineColor( const QColor & c )
 // in an unexpected location when positioned at the start of the track
 void positionLine::zoomChange( double zoom )
 {
-	int X = x() + width() - 1;
+	int playHeadPos = x() + width() - 1;
 	
 	resize( 8.0 * zoom, height() );
-	move( X - width() + 1, y() );
+	move( playHeadPos - width() + 1, y() );
 	
 	update();
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -124,9 +124,10 @@ void positionLine::setLineColor( const QColor & c )
 // in an unexpected location when positioned at the start of the track
 void positionLine::zoomChange( double zoom )
 {
-	move( x() + width() - 1, y() );
+	int m_x = x() + width() - 1;
+	
 	resize( 8.0 * zoom, height() );
-	move( x() - width() + 1, y() );
+	move( m_x - width() + 1, y() );
 	
 	update();
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -59,6 +59,7 @@ positionLine::positionLine( QWidget * parent ) :
 {
 	setFixedWidth( 8 );
 	setAttribute( Qt::WA_NoSystemBackground, true );
+	setAttribute( Qt::WA_TransparentForMouseEvents );
 }
 
 void positionLine::paintEvent( QPaintEvent * pe )

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -55,7 +55,7 @@
 positionLine::positionLine( QWidget * parent ) :
 	QWidget( parent )
 {
-	setFixedWidth( 1 );
+	setFixedWidth( 8 );
 	setAttribute( Qt::WA_NoSystemBackground, true );
 }
 
@@ -65,7 +65,15 @@ positionLine::positionLine( QWidget * parent ) :
 void positionLine::paintEvent( QPaintEvent * pe )
 {
 	QPainter p( this );
-	p.fillRect( rect(), QColor( 255, 255, 255, 153 ) );
+	
+	// Create the gradient trail behind the line
+	QLinearGradient gradient(rect().bottomLeft(), rect().bottomRight());
+	gradient.setColorAt(0, QColor (255, 255, 255, 0) );
+	gradient.setColorAt(0.875, QColor (255, 255, 255, 60) );
+	gradient.setColorAt(1, QColor (255, 255, 255, 153) );
+	
+	// Fill line
+	p.fillRect( rect(), gradient );
 }
 
 const QVector<double> SongEditor::m_zoomLevels =
@@ -808,7 +816,7 @@ void SongEditor::updatePosition( const MidiTime & t )
 	if( x >= trackOpWidth + widgetWidth -1 )
 	{
 		m_positionLine->show();
-		m_positionLine->move( x, m_timeLine->height() );
+		m_positionLine->move( x-7, m_timeLine->height() );
 	}
 	else
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -124,10 +124,10 @@ void positionLine::setLineColor( const QColor & c )
 // in an unexpected location when positioned at the start of the track
 void positionLine::zoomChange( double zoom )
 {
-	int m_x = x() + width() - 1;
+	int X = x() + width() - 1;
 	
 	resize( 8.0 * zoom, height() );
-	move( m_x - width() + 1, y() );
+	move( X - width() + 1, y() );
 	
 	update();
 }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -53,14 +53,13 @@
 #include "Track.h"
 
 positionLine::positionLine( QWidget * parent ) :
-	QWidget( parent )
+	QWidget( parent ),
+	m_tailGradient ( false ),
+	m_lineColor (0, 0, 0, 0)
 {
 	setFixedWidth( 8 );
 	setAttribute( Qt::WA_NoSystemBackground, true );
 }
-
-
-
 
 void positionLine::paintEvent( QPaintEvent * pe )
 {
@@ -68,9 +67,22 @@ void positionLine::paintEvent( QPaintEvent * pe )
 	
 	// Create the gradient trail behind the line
 	QLinearGradient gradient(rect().bottomLeft(), rect().bottomRight());
-	gradient.setColorAt(0, QColor (255, 255, 255, 0) );
-	gradient.setColorAt(0.875, QColor (255, 255, 255, 60) );
-	gradient.setColorAt(1, QColor (255, 255, 255, 153) );
+	
+	gradient.setColorAt(0,
+		QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
+	gradient.setColorAt(1,
+		QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
+		
+	if (m_tailGradient) 
+	{ 
+		gradient.setColorAt(0.875, 
+			QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 60) );
+	}
+	else 
+	{ 
+		gradient.setColorAt(0.875, 
+			QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
+	}
 	
 	// Fill line
 	p.fillRect( rect(), gradient );
@@ -1139,3 +1151,15 @@ void SongEditorWindow::keyReleaseEvent( QKeyEvent *ke )
 		}
 	}
 }
+
+bool positionLine::tailGradient() const
+{ return m_tailGradient; }
+
+void positionLine::setTailGradient( const bool & g )
+{ m_tailGradient = g; }
+
+QColor positionLine::lineColor() const
+{ return m_lineColor; }
+
+void positionLine::setLineColor( const QColor & c )
+{ m_lineColor = c; }

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -52,7 +52,7 @@
 #include "PianoRoll.h"
 #include "Track.h"
 
-const QVector<double> positionLine::m_zoomLevels =
+const QVector<double> positionLine::s_zoomLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f };
 
 positionLine::positionLine( QWidget* parent, ComboBoxModel* zoom) :
@@ -72,7 +72,7 @@ void positionLine::paintEvent( QPaintEvent* pe )
 	QPainter p( this );
 	
 	// Resize based on the zoom value
-	resize( 8.0f * m_zoomLevels[ m_currentZoom->value() ], height() );
+	resize( 8.0f * s_zoomLevels[ m_currentZoom->value() ], height() );
 	
 	// If width is 1, we don't need a gradient
 	if (width() == 1)

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -67,9 +67,6 @@ void positionLine::paintEvent( QPaintEvent* pe )
 {
 	QPainter p( this );
 	
-	// Resize based on the zoom value
-	//resize( 8.0f * s_zoomLevels[ m_currentZoom->value() ], height() );
-	
 	// If width is 1, we don't need a gradient
 	if (width() == 1)
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -55,7 +55,7 @@
 const QVector<double> positionLine::m_zoomLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f };
 
-positionLine::positionLine( QWidget * parent, ComboBoxModel* zoom, Song* song ) :
+positionLine::positionLine( QWidget * parent, ComboBoxModel * zoom, Song * song ) :
 	QWidget( parent ),
 	m_tailGradient ( false ),
 	m_lineColor (0, 0, 0, 0)
@@ -82,37 +82,39 @@ void positionLine::paintEvent( QPaintEvent * pe )
 	// If width is 1, we don't need a gradient
 	if (m_width == 1)
 	{
-		p.fillRect ( rect(),
-			QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
+		p.fillRect( rect(),
+			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
 	}
 	
 	// If width > 1, we need the gradient
 	else
 	{
 		// Create the gradient trail behind the line
-		QLinearGradient gradient(rect().bottomLeft(), rect().bottomRight());
+		QLinearGradient gradient( rect().bottomLeft(), rect().bottomRight() );
 		
-		// If gradient is enabled and we're playing, enable gradient
-		if (p_song->isPlaying() && m_tailGradient)
+		// If gradient is enabled, we're in focus and we're playing, enable gradient
+		if (p_song->isPlaying() && m_tailGradient && 
+			p_song->playMode() == Song::Mode_PlaySong)
+		{
 			gradient.setColorAt((double)( ( width() - 1.0f )/width() ),
-				QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 60) );
+				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 60) );
+		}
 		else
+		{
 			gradient.setColorAt((double)( ( width() - 1.0f )/width() ),
-				QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
+				QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
+		}
 		
 		// Fill in the remaining parts
 		gradient.setColorAt(0,
-			QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
+			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 0) );
 		gradient.setColorAt(1,
-			QColor (m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
+			QColor( m_lineColor.red(), m_lineColor.green(), m_lineColor.blue(), 153) );
 		
 		// Fill line
 		p.fillRect( rect(), gradient );
 	}
 }
-
-const QVector<double> SongEditor::m_zoomLevels =
-		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f };
 
 int positionLine::width( void )
 {
@@ -120,17 +122,19 @@ int positionLine::width( void )
 	return m_width;
 }
 
+// synonymous to move(), but use this instead of move() so position line can log changes in its m_x & m_y
 void positionLine::go( int x, int y )
 {
-	move(x, y);
+	move( x, y );
 	m_x = x + width() - 1;
 	m_y = y;
 }
 
+// update width if zoom changes
 void positionLine::zoomUpdate()
 { move ( m_x - width() + 1, m_y ); }
 
-// Essentially causes a redraw so that gradient does not persist
+// Essentially repaints so that gradient does not persist when stopped (this is a bug fix)
 void positionLine::playStateChanged()
 { repaint(); }
 
@@ -147,6 +151,11 @@ QColor positionLine::lineColor() const
 void positionLine::setLineColor( const QColor & c )
 { m_lineColor = c; }
 
+
+
+
+const QVector<double> SongEditor::m_zoomLevels =
+		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f };
 
 SongEditor::SongEditor( Song * song ) :
 	TrackContainerView( song ),


### PR DESCRIPTION
Hey all, this is my first commit to LMMS.

This commit adds a little aesthetic feature similar to one in FL studio, where there's a little gradient right before the bar. It looks nice, and it makes the bar a little easier to see on large-res screens (without having to look at the triangle at the top).

Here's what it looks like:

![Screenshot from 2020-06-22 19-05-36](https://user-images.githubusercontent.com/26451259/85295844-1e199380-b4be-11ea-9728-56167d5c2c7a.png)

Currently there's a bug (or an intended feature) which doesn't allow selecting anything under the bar, and thus under the gradient too. I'm trying to figure out a fix, though guidance would really help as I'm new to contributing to LMMS and don't know its ins-and-outs quite well yet.

Thanks!