### PR TITLE
Fix garbage in exported audio caused by resampling

### DIFF
--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -115,7 +115,7 @@ protected:
 							const fpp_t _frames );
 
 	// resample given buffer from samplerate _src_sr to samplerate _dst_sr
-	void resample( const surroundSampleFrame * _src,
+	fpp_t resample( const surroundSampleFrame * _src,
 					const fpp_t _frames,
 					surroundSampleFrame * _dst,
 					const sample_rate_t _src_sr,

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -93,10 +93,8 @@ fpp_t AudioDevice::getNextBuffer( surroundSampleFrame * _ab )
 	// resample if necessary
 	if( mixer()->processingSampleRate() != m_sampleRate )
 	{
-		resample( b, frames, _ab, mixer()->processingSampleRate(),
-								m_sampleRate );
-		frames = frames * m_sampleRate /
-					mixer()->processingSampleRate();
+		frames = resample( b, frames, _ab, mixer()->processingSampleRate(),
+				    	   m_sampleRate );
 	}
 	else
 	{
@@ -184,7 +182,7 @@ void AudioDevice::renamePort( AudioPort * )
 
 
 
-void AudioDevice::resample( const surroundSampleFrame * _src,
+fpp_t AudioDevice::resample( const surroundSampleFrame * _src,
 						const fpp_t _frames,
 						surroundSampleFrame * _dst,
 						const sample_rate_t _src_sr,
@@ -192,7 +190,7 @@ void AudioDevice::resample( const surroundSampleFrame * _src,
 {
 	if( m_srcState == NULL )
 	{
-		return;
+		return _frames;
 	}
 	m_srcData.input_frames = _frames;
 	m_srcData.output_frames = _frames;
@@ -206,6 +204,7 @@ void AudioDevice::resample( const surroundSampleFrame * _src,
 		printf( "AudioDevice::resample(): error while resampling: %s\n",
 							src_strerror( error ) );
 	}
+	return static_cast<fpp_t>(m_srcData.output_frames_gen);
 }
 
 


### PR DESCRIPTION
This PR attempts to fix the problem of garbage in exported audio as reported by #5548. In the case of oversampling > 1, it is possible that libsamplerate returns fewer samples than assumed. This is exposed by libsamplerate via `output_frames_gen`.