### PR TITLE
Fix a bug on the "Remove unused channels" command inside the FX mixer

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -455,6 +455,15 @@ void FxMixerView::deleteUnusedChannels()
 					break;
 				}
 			}
+			else if( t->type() == Track::SampleTrack )
+			{
+				SampleTrack *strack = dynamic_cast<SampleTrack *>( t );
+				if( i == strack->effectChannelModel()->value(0) )
+				{
+					empty=false;
+					break;
+				}
+			}
 		}
 		FxChannel * ch = Engine::fxMixer()->effectChannel( i );
 		// delete channel if no references found


### PR DESCRIPTION
Inside the FX mixer, there's a command to remove the channels that are currently unused. The method that processes that command (`void FxMixerView::deleteUnusedChannels()`) only checked the channels for InstrumentTracks linked to them, but ignored SampleTracks. Because of that, if there was a channel where only SampleTracks are forwarded to and we clicked on "Remove unused channels", that channel was going to be removed.

This commit fixes that bug.