### PR TITLE
Implemented a portable mode to lmms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /build
 /target
-/.idea
-/cmake-build-debug
 .*.sw?
 .DS_Store
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build
 /target
+/.idea
+/cmake-build-debug
 .*.sw?
 .DS_Store
 *~

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -50,7 +50,7 @@ const QString LADSPA_PATH ="plugins/ladspa/";
 const QString DEFAULT_THEME_PATH = "themes/default/";
 const QString TRACK_ICON_PATH = "track_icons/";
 const QString LOCALE_PATH = "locale/";
-
+const QString PORTABLE_MODE_FILE = "/portable_mode.txt";
 
 class LMMS_EXPORT ConfigManager : public QObject
 {
@@ -70,6 +70,12 @@ public:
 	{
 		return m_workingDir;
 	}
+
+	void initPortableWorkingDir();
+
+	void initInstalledWorkingDir();
+
+	void initDevelopmentWorkingDir();
 
 	const QString & dataDir() const
 	{
@@ -216,7 +222,7 @@ public:
 	QString defaultVersion() const;
 
 
-	static QStringList availabeVstEmbedMethods();
+	static QStringList availableVstEmbedMethods();
 	QString vstEmbedMethod() const;
 
 	// Returns true if the working dir (e.g. ~/lmms) exists on disk.

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -66,8 +66,10 @@ ConfigManager::ConfigManager() : m_version(defaultVersion())
 	m_sf2Dir = m_workingDir + SF2_PATH;
 	m_gigDir = m_workingDir + GIG_PATH;
 	m_themeDir = defaultThemeDir();
-	if (! qgetenv("LMMS_DATA_DIR").isEmpty())
+	if (!qgetenv("LMMS_DATA_DIR").isEmpty())
+	{
 		QDir::addSearchPath("data", QString::fromLocal8Bit(qgetenv("LMMS_DATA_DIR")));
+	}
 	initDevelopmentWorkingDir();
 
 #ifdef LMMS_BUILD_WIN32

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -51,67 +51,30 @@ static inline QString ensureTrailingSlash(const QString & s )
 ConfigManager * ConfigManager::s_instanceOfMe = NULL;
 
 
-ConfigManager::ConfigManager() :
-	m_workingDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/lmms/"),
-	m_dataDir("data:/"),
-	m_vstDir(m_workingDir + "vst/"),
-	m_sf2Dir(m_workingDir + SF2_PATH),
-	m_gigDir(m_workingDir + GIG_PATH),
-	m_themeDir(defaultThemeDir()),
-	m_lmmsRcFile(QDir::home().absolutePath() +"/.lmmsrc.xml"),
-	m_version(defaultVersion())
+ConfigManager::ConfigManager() : m_version(defaultVersion())
 {
-	// Detect < 1.2.0 working directory as a courtesy
-	if ( QFileInfo( QDir::home().absolutePath() + "/lmms/projects/" ).exists() )
-                m_workingDir = QDir::home().absolutePath() + "/lmms/";
-
+	if (QFileInfo::exists(qApp->applicationDirPath() + PORTABLE_MODE_FILE))
+	{
+		initPortableWorkingDir();
+	}
+	else
+	{
+		initInstalledWorkingDir();
+	}
+	m_dataDir = "data:/";
+	m_vstDir = m_workingDir + "vst/";
+	m_sf2Dir = m_workingDir + SF2_PATH;
+	m_gigDir = m_workingDir + GIG_PATH;
+	m_themeDir = defaultThemeDir();
 	if (! qgetenv("LMMS_DATA_DIR").isEmpty())
 		QDir::addSearchPath("data", QString::fromLocal8Bit(qgetenv("LMMS_DATA_DIR")));
-
-	// If we're in development (lmms is not installed) let's get the source and
-	// binary directories by reading the CMake Cache
-	QDir appPath = qApp->applicationDirPath();
-	// If in tests, get parent directory
-	if (appPath.dirName() == "tests") {
-		appPath.cdUp();
-	}
-	QFile cmakeCache(appPath.absoluteFilePath("CMakeCache.txt"));
-	if (cmakeCache.exists()) {
-		cmakeCache.open(QFile::ReadOnly);
-		QTextStream stream(&cmakeCache);
-
-		// Find the lines containing something like lmms_SOURCE_DIR:static=<dir>
-		// and lmms_BINARY_DIR:static=<dir>
-		int done = 0;
-		while(! stream.atEnd())
-		{
-			QString line = stream.readLine();
-
-			if (line.startsWith("lmms_SOURCE_DIR:")) {
-				QString srcDir = line.section('=', -1).trimmed();
-				QDir::addSearchPath("data", srcDir + "/data/");
-				done++;
-			}
-			if (line.startsWith("lmms_BINARY_DIR:")) {
-				m_lmmsRcFile = line.section('=', -1).trimmed() +  QDir::separator() +
-											 ".lmmsrc.xml";
-				done++;
-			}
-			if (done == 2)
-			{
-				break;
-			}
-		}
-
-		cmakeCache.close();
-	}
+	initDevelopmentWorkingDir();
 
 #ifdef LMMS_BUILD_WIN32
 	QDir::addSearchPath("data", qApp->applicationDirPath() + "/data/");
 #else
 	QDir::addSearchPath("data", qApp->applicationDirPath().section('/', 0, -2) + "/share/lmms/");
 #endif
-
 
 }
 
@@ -193,7 +156,7 @@ QString ConfigManager::defaultVersion() const
 	return LMMS_VERSION;
 }
 
-QStringList ConfigManager::availabeVstEmbedMethods()
+QStringList ConfigManager::availableVstEmbedMethods()
 {
 	QStringList methods;
 	methods.append("none");
@@ -215,7 +178,7 @@ QStringList ConfigManager::availabeVstEmbedMethods()
 
 QString ConfigManager::vstEmbedMethod() const
 {
-	QStringList methods = availabeVstEmbedMethods();
+	QStringList methods = availableVstEmbedMethods();
 	QString defaultMethod = *(methods.end() - 1);
 	QString currentMethod = value( "ui", "vstembedmethod", defaultMethod );
 	return methods.contains(currentMethod) ? currentMethod : defaultMethod;
@@ -650,4 +613,61 @@ void ConfigManager::saveConfigFile()
 
 	outfile.write(xml.toUtf8());
 	outfile.close();
+}
+
+void ConfigManager::initPortableWorkingDir()
+{
+	QString applicationPath = qApp->applicationDirPath();
+	m_workingDir = applicationPath + "/lmms-workspace/";
+	m_lmmsRcFile = applicationPath + "/.lmmsrc.xml";
+}
+
+void ConfigManager::initInstalledWorkingDir()
+{
+	m_workingDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/lmms/";
+	m_lmmsRcFile = QDir::home().absolutePath() +"/.lmmsrc.xml";
+	// Detect < 1.2.0 working directory as a courtesy
+	if ( QFileInfo( QDir::home().absolutePath() + "/lmms/projects/" ).exists() )
+		m_workingDir = QDir::home().absolutePath() + "/lmms/";
+}
+
+void ConfigManager::initDevelopmentWorkingDir()
+{
+	// If we're in development (lmms is not installed) let's get the source and
+	// binary directories by reading the CMake Cache
+	QDir appPath = qApp->applicationDirPath();
+	// If in tests, get parent directory
+	if (appPath.dirName() == "tests") {
+		appPath.cdUp();
+	}
+	QFile cmakeCache(appPath.absoluteFilePath("CMakeCache.txt"));
+	if (cmakeCache.exists()) {
+		cmakeCache.open(QFile::ReadOnly);
+		QTextStream stream(&cmakeCache);
+
+		// Find the lines containing something like lmms_SOURCE_DIR:static=<dir>
+		// and lmms_BINARY_DIR:static=<dir>
+		int done = 0;
+		while(! stream.atEnd())
+		{
+			QString line = stream.readLine();
+
+			if (line.startsWith("lmms_SOURCE_DIR:")) {
+				QString srcDir = line.section('=', -1).trimmed();
+				QDir::addSearchPath("data", srcDir + "/data/");
+				done++;
+			}
+			if (line.startsWith("lmms_BINARY_DIR:")) {
+				m_lmmsRcFile = line.section('=', -1).trimmed() +  QDir::separator() +
+							   ".lmmsrc.xml";
+				done++;
+			}
+			if (done == 2)
+			{
+				break;
+			}
+		}
+
+		cmakeCache.close();
+	}
 }

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -389,7 +389,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_vstEmbedComboBox = new QComboBox(plugins_tw);
 	m_vstEmbedComboBox->move(XDelta, YDelta * ++counter);
 
-	QStringList embedMethods = ConfigManager::availabeVstEmbedMethods();
+	QStringList embedMethods = ConfigManager::availableVstEmbedMethods();
 	m_vstEmbedComboBox->addItem(tr("No embedding"), "none");
 	if(embedMethods.contains("qt"))
 	{


### PR DESCRIPTION
I've implemented this portable mode based on this issue https://github.com/LMMS/lmms/issues/5201

this is my first contribution to the project I tried to respect the programming style while refactoring a bit.

the overall modifications are : 
- I have added an environment variable PORTABLE_MODE, when LMMS is built with this environment variable, it will default its directory to the directory where it is executed (in portable mode, the lmms directory has been renamed to lmms-workspace in order to avoid name conflict on linux between the executable and the directory)

- I have fixed the typo from the function availabeVstEmbedMethods to availableVstEmbedMethods

- I have refactored the constructor of ConfigManager to be more readable

- I have added the CLion files autogenerated when opening a cmake project to the gitignore