### PR TITLE
Refactor deleteUnusedChannels in FxMixerView

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -439,7 +439,7 @@ void FxMixerView::deleteUnusedChannels()
 	tracks += Engine::getSong()->tracks();
 	tracks += Engine::getBBTrackContainer()->tracks();
 
-	bool inUse[m_fxChannelViews.size()] = {false};
+	std::vector<bool> inUse(m_fxChannelViews.size(), false);
 
 	for (Track* t: tracks)
 	{

--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -439,38 +439,28 @@ void FxMixerView::deleteUnusedChannels()
 	tracks += Engine::getSong()->tracks();
 	tracks += Engine::getBBTrackContainer()->tracks();
 
-	// go through all FX Channels
+	bool inUse[m_fxChannelViews.size()] = {false};
+
+	for (Track* t: tracks)
+	{
+		int channel = 0;
+		if (t->type() == Track::InstrumentTrack)
+		{
+			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>(t);
+			channel = inst->effectChannelModel()->value();
+		}
+		else if (t->type() == Track::SampleTrack)
+		{
+			SampleTrack *strack = dynamic_cast<SampleTrack *>(t);
+			channel = strack->effectChannelModel()->value();
+		}
+		inUse[channel] = true;
+	}
+
 	for(int i = m_fxChannelViews.size()-1; i > 0; --i)
 	{
-		// check if an instrument references to the current channel
-		bool empty=true;
-		for( Track* t : tracks )
-		{
-			if( t->type() == Track::InstrumentTrack )
-			{
-				InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
-				if( i == inst->effectChannelModel()->value(0) )
-				{
-					empty=false;
-					break;
-				}
-			}
-			else if( t->type() == Track::SampleTrack )
-			{
-				SampleTrack *strack = dynamic_cast<SampleTrack *>( t );
-				if( i == strack->effectChannelModel()->value(0) )
-				{
-					empty=false;
-					break;
-				}
-			}
-		}
-		FxChannel * ch = Engine::fxMixer()->effectChannel( i );
-		// delete channel if no references found
-		if( empty && ch->m_receives.isEmpty() )
-		{
-			deleteChannel( i );
-		}
+		if(!inUse[i] && Engine::fxMixer()->effectChannel(i)->m_receives.isEmpty())
+		{ deleteChannel(i); }
 	}
 }
 


### PR DESCRIPTION
**Old method**: Iterate over tracks once per channel. Short circuit when we find a track that sends to this channel, or delete it if none are found. (Assuming there are at least as many tracks as channels:) Worst case T * C iterations. Best case [C*(C+1)/2](https://en.wikipedia.org/wiki/Triangular_number). (If the first n tracks send to one channel each.)

**New method**: Iterate over tracks once, using an array of booleans to keep track of which mixer channels are in use. Iterate over channels once, deleting those that are unused. Always T + C iterations.

New method is shorter and IMO cleaner. I would have liked to add unit tests to ensure I didn't break anything, but couldn't figure out unit testing with GUI classes. A quick manual test indicates that it works. From a default template (empty mixer):
- Add a few tracks. Upon removal, all tracks are removed.
- Add a few tracks. Send to some of them, and rename these. Upon removal, only named tracks remain. Tested both sample and instrument tracks.
- Add 2 tracks, rename 1 to "Sender", 2 to "Receiver". Send 1 to 2. Upon removal, only "Receiver" remains (this matches current behavior).