### PR TITLE
Automation now responds when connected to a midi controller

### DIFF
--- a/include/Controller.h
+++ b/include/Controller.h
@@ -131,6 +131,13 @@ public:
 
 	bool hasModel( const Model * m ) const;
 
+	bool isValueChanged()
+	{
+		bool valch = m_valueChanged;
+		m_valueChanged = false;
+		return valch;
+	}
+
 public slots:
 	virtual ControllerDialog * createDialog( QWidget * _parent );
 
@@ -163,6 +170,8 @@ protected:
 	static ControllerVector s_controllers;
 
 	static long s_periods;
+
+	bool m_valueChanged;
 
 
 signals:

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -98,6 +98,10 @@ public:
 		return classNodeName();
 	}
 
+	bool isControllerMidi()
+	{
+		return m_controllerMidi;
+	}
 
 public slots:
 	void deleteConnection();
@@ -111,6 +115,8 @@ protected:
 	bool m_ownsController;
 
 	static ControllerConnectionVector s_connections;
+
+	bool m_controllerMidi;
 
 signals:
 	// The value changed while the mixer isn't running (i.e: MIDI CC)

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -59,7 +59,6 @@ public:
 	// Used by controllerConnectionDialog to copy
 	void subscribeReadablePorts( const MidiPort::Map & _map );
 
-
 public slots:
 	ControllerDialog * createDialog( QWidget * _parent ) override;
 	void updateName();

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -53,7 +53,9 @@ AutomatableModel::AutomatableModel(
 	m_controllerConnection( NULL ),
 	m_valueBuffer( static_cast<int>( Engine::mixer()->framesPerPeriod() ) ),
 	m_lastUpdatedPeriod( -1 ),
-	m_hasSampleExactData( false )
+	m_hasSampleExactData(false),
+	m_controllerOrValue (false),
+	m_mValueChanged(false)
 
 {
 	m_value = fittedValue( val );
@@ -311,6 +313,7 @@ void AutomatableModel::setValue( const float value )
 			}
 		}
 		m_valueChanged = true;
+		m_mValueChanged = true;
 		emit dataChanged();
 	}
 	else
@@ -392,6 +395,7 @@ void AutomatableModel::setAutomatedValue( const float value )
 			}
 		}
 		m_valueChanged = true;
+		m_mValueChanged = true;
 		emit dataChanged();
 	}
 	--m_setValueDepth;
@@ -550,6 +554,7 @@ void AutomatableModel::setControllerConnection( ControllerConnection* c )
 				this, SIGNAL( dataChanged() ), Qt::DirectConnection );
 		QObject::connect( m_controllerConnection, SIGNAL( destroyed() ), this, SLOT( unlinkControllerConnection() ) );
 		m_valueChanged = true;
+		m_mValueChanged = true;
 		emit dataChanged();
 	}
 }

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -50,7 +50,8 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 	m_valueBuffer( Engine::mixer()->framesPerPeriod() ),
 	m_bufferLastUpdated( -1 ),
 	m_connectionCount( 0 ),
-	m_type( _type )
+	m_type(_type),
+	m_valueChanged(false)
 {
 	if( _type != DummyController && _type != MidiController )
 	{

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -39,7 +39,8 @@ ControllerConnectionVector ControllerConnection::s_connections;
 ControllerConnection::ControllerConnection( Controller * _controller ) :
 	m_controller( NULL ),
 	m_controllerId( -1 ),
-	m_ownsController( false )
+	m_ownsController(false),
+	m_controllerMidi (false)
 {
 	if( _controller != NULL )
 	{
@@ -59,7 +60,8 @@ ControllerConnection::ControllerConnection( Controller * _controller ) :
 ControllerConnection::ControllerConnection( int _controllerId ) :
 	m_controller( Controller::create( Controller::DummyController, NULL ) ),
 	m_controllerId( _controllerId ),
-	m_ownsController( false )
+	m_ownsController( false ),
+	m_controllerMidi (false)
 {
 	s_connections.append( this );
 }
@@ -120,8 +122,16 @@ void ControllerConnection::setController( Controller * _controller )
 				this, SIGNAL( valueChanged() ), Qt::DirectConnection );
 	}
 
-	m_ownsController =
-			( _controller->type() == Controller::MidiController );
+	if (_controller->type() == Controller::MidiController)
+	{
+		m_ownsController = true;
+		m_controllerMidi = true;
+	}
+	else
+	{
+		m_ownsController = false;
+		m_controllerMidi = false;
+	}
 
 	// If we don't own the controller, allow deletion of controller
 	// to delete the connection

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -95,6 +95,7 @@ void MidiController::processInEvent( const MidiEvent& event, const MidiTime& tim
 				unsigned char val = event.controllerValue();
 				m_previousValue = m_lastValue;
 				m_lastValue = (float)( val ) / 127.0f;
+				m_valueChanged = true;
 				emit valueChanged();
 			}
 			break;


### PR DESCRIPTION
Fix for #4554.
I added a flag when the value of the midi controller changes and also when the automation value changes. So `AutomatableModel.h:value()` checks the one that last changed and remains returning this one until it changes to the other.