### PR TITLE
Fix crash on CLI rendering

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -767,12 +767,16 @@ void Song::startExport()
 			m_exportSongEnd += MidiTime(1,0);
         
 		m_exportSongBegin = MidiTime(0,0);
-		m_exportLoopBegin = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
-			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
-			m_playPos[Mode_PlaySong].m_timeLine->loopBegin() : MidiTime(0,0);
-		m_exportLoopEnd = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd && 
-			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
-			m_playPos[Mode_PlaySong].m_timeLine->loopEnd() : MidiTime(0,0);
+		// FIXME: remove this check once we load timeline in headless mode
+		if (m_playPos[Mode_PlaySong].m_timeLine)
+		{
+			m_exportLoopBegin = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd &&
+				m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
+				m_playPos[Mode_PlaySong].m_timeLine->loopBegin() : MidiTime(0,0);
+			m_exportLoopEnd = m_playPos[Mode_PlaySong].m_timeLine->loopBegin() < m_exportSongEnd &&
+				m_playPos[Mode_PlaySong].m_timeLine->loopEnd() <= m_exportSongEnd ?
+				m_playPos[Mode_PlaySong].m_timeLine->loopEnd() : MidiTime(0,0);
+		}
 
 		m_playPos[Mode_PlaySong].setTicks( 0 );
 	}


### PR DESCRIPTION
Fixes #5107.
This is a temporary workaround. To make all export options available in CLI, some properties of `TimeLineWidget` should be moved to a new core class.