### PR TITLE
Fixes small conflict on a new commit

### DIFF
--- a/src/gui/widgets/InstrumentMidiIOView.cpp
+++ b/src/gui/widgets/InstrumentMidiIOView.cpp
@@ -92,7 +92,6 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	/*: This string must be be short, its width must be less than
 	 *  width of LCD spin-box of two digits */
 	m_outputChannelSpinBox->setLabel( tr( "CHAN" ) );
-	m_outputChannelSpinBox->setEnabled( false );
 	midiOutputLayout->addWidget( m_outputChannelSpinBox );
 
 	m_fixedOutputVelocitySpinBox = new LcdSpinBox( 3, m_midiOutputGroupBox );


### PR DESCRIPTION
On the PR #5470 (_Allows intruments to keep the midi channel information when forwarding_), merged on Jun 1st 2020 `commit 97680e0`, there's a line removed on the _src/gui/widgets/InstrumentMidiIOView.cpp_ file ( `m_outputChannelSpinBox->setEnabled( false );` ), because since the output channel is now relevant even when MIDI forwarding is disabled, we need that spinbox always enabled. It was also disconnected from the LedButton to keep it from disabling/enabling it.

On the PR #5171 (_Removed the excessive margin in instruments' GUI (#5129)_), merged on Jul 9th 2020 `commit 9895472`, the line was reintroduced, possibly because it was an older PR that wasn't rebased to the latest changes. This broke the output channel spinbox because now it was disabled on the constructor, but it was still disconnected from the LedButton, as a result always disabled.

This hotfix removes the line again to fix the issue.