### PR TITLE
Avoid leaking the track grip QPixmap at each paintEvent

### DIFF
--- a/include/Track.h
+++ b/include/Track.h
@@ -459,8 +459,6 @@ private slots:
 	void clearTrack();
 
 private:
-	static QPixmap * s_grip;
-
 	TrackView * m_trackView;
 
 	QPushButton * m_trackOps;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1830,10 +1830,6 @@ void TrackContentWidget::setEmbossColor( const QBrush & c )
 // trackOperationsWidget
 // ===========================================================================
 
-
-QPixmap * TrackOperationsWidget::s_grip = NULL;     /*!< grip pixmap */
-
-
 /*! \brief Create a new trackOperationsWidget
  *
  * The trackOperationsWidget is the grip and the mute button of a track.
@@ -1960,17 +1956,11 @@ void TrackOperationsWidget::paintEvent( QPaintEvent * pe )
 
 	if( m_trackView->isMovingTrack() == false )
 	{
-		s_grip = new QPixmap( embed::getIconPixmap(
-							"track_op_grip" ) );
-
-		p.drawPixmap( 2, 2, *s_grip );
+		p.drawPixmap( 2, 2, embed::getIconPixmap("track_op_grip"));
 	}
 	else
 	{
-		s_grip = new QPixmap( embed::getIconPixmap(
-							"track_op_grip_c" ) );
-
-		p.drawPixmap( 2, 2, *s_grip );
+		p.drawPixmap( 2, 2, embed::getIconPixmap("track_op_grip_c"));
 	}
 }
 


### PR DESCRIPTION
Given that s_grip is not used anywhere else we remove it
and instead of allocating every paintEvent a new QPixmap on the heap,
which is constructed from the cached pixmap,
to then leak it, we just pass the cached pixmap directly.

ASAN report:
```
=================================================================
==222949==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8480 byte(s) in 265 object(s) allocated from:
    #0 0x7fcfe353ef41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55651cb436f2 in TrackOperationsWidget::paintEvent(QPaintEvent*) /home/smjert/Development/lmms/src/src/core/Track.cpp:1964

Direct leak of 2912 byte(s) in 91 object(s) allocated from:
    #0 0x7fcfe353ef41 in operator new(unsigned long) /build/gcc/src/gcc/libsanitizer/asan/asan_new_delete.cpp:99
    #1 0x55651cb43872 in TrackOperationsWidget::paintEvent(QPaintEvent*) /home/smjert/Development/lmms/src/src/core/Track.cpp:1971
```