### PR TITLE
Set default behaviour of playhead to << instead of |<<

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -209,8 +209,6 @@ private:
 	AutoScrollStates m_autoScroll;
 	LoopPointStates m_loopPoints;
 	BehaviourAtStopStates m_behaviourAtStop;
-	
-	NStateButton * behaviourAtStopButton;
 
 	bool m_changedPosition;
 
@@ -245,6 +243,7 @@ signals:
 	void positionChanged( const MidiTime & _t );
 	void loopPointStateLoaded( int _n );
 	void positionMarkerMoved();
+	void loadBehaviourAtStop( int _n );
 
 } ;
 

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -209,6 +209,8 @@ private:
 	AutoScrollStates m_autoScroll;
 	LoopPointStates m_loopPoints;
 	BehaviourAtStopStates m_behaviourAtStop;
+	
+	NStateButton * behaviourAtStopButton;
 
 	bool m_changedPosition;
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -142,7 +142,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 					SLOT( toggleBehaviourAtStop( int ) ) );
 	connect( this, SIGNAL( loadBehaviourAtStop( int ) ), behaviourAtStop,
 					SLOT( changeState( int ) ) );
-	behaviourAtStop->changeState( 1 );
+	behaviourAtStop->changeState( BackToStart );
 
 	_tool_bar->addWidget( autoScroll );
 	_tool_bar->addWidget( loopPoints );

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -130,7 +130,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 
 	NStateButton * behaviourAtStop = new NStateButton( _tool_bar );
 	behaviourAtStop->addState( embed::getIconPixmap( "back_to_zero" ),
-					tr( "After stopping go back to begin" )
+					tr( "After stopping go back to beginning" )
 									);
 	behaviourAtStop->addState( embed::getIconPixmap( "back_to_start" ),
 					tr( "After stopping go back to "
@@ -140,6 +140,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 					tr( "After stopping keep position" ) );
 	connect( behaviourAtStop, SIGNAL( changedState( int ) ), this,
 					SLOT( toggleBehaviourAtStop( int ) ) );
+	behaviourAtStop->changeState( 2 );
 
 	_tool_bar->addWidget( autoScroll );
 	_tool_bar->addWidget( loopPoints );

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -140,9 +140,9 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 					tr( "After stopping keep position" ) );
 	connect( behaviourAtStop, SIGNAL( changedState( int ) ), this,
 					SLOT( toggleBehaviourAtStop( int ) ) );
+	connect( this, SIGNAL( loadBehaviourAtStop( int ) ), behaviourAtStop,
+					SLOT( changeState( int ) ) );
 	behaviourAtStop->changeState( 1 );
-	
-	behaviourAtStopButton = behaviourAtStop;
 
 	_tool_bar->addWidget( autoScroll );
 	_tool_bar->addWidget( loopPoints );
@@ -157,7 +157,7 @@ void TimeLineWidget::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	_this.setAttribute( "lp0pos", (int) loopBegin() );
 	_this.setAttribute( "lp1pos", (int) loopEnd() );
 	_this.setAttribute( "lpstate", m_loopPoints );
-	_this.setAttribute( "stopbehaviour", behaviourAtStopButton->state() );
+	_this.setAttribute( "stopbehaviour", m_behaviourAtStop );
 }
 
 
@@ -174,7 +174,7 @@ void TimeLineWidget::loadSettings( const QDomElement & _this )
 	
 	if( _this.hasAttribute( "stopbehaviour" ) )
 	{
-		behaviourAtStopButton->changeState( _this.attribute( "stopbehaviour" ).toInt() );
+		emit loadBehaviourAtStop( _this.attribute( "stopbehaviour" ).toInt() );
 	}
 }
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -140,7 +140,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 					tr( "After stopping keep position" ) );
 	connect( behaviourAtStop, SIGNAL( changedState( int ) ), this,
 					SLOT( toggleBehaviourAtStop( int ) ) );
-	behaviourAtStop->changeState( 2 );
+	behaviourAtStop->changeState( 1 );
 
 	_tool_bar->addWidget( autoScroll );
 	_tool_bar->addWidget( loopPoints );

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -141,6 +141,8 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 	connect( behaviourAtStop, SIGNAL( changedState( int ) ), this,
 					SLOT( toggleBehaviourAtStop( int ) ) );
 	behaviourAtStop->changeState( 1 );
+	
+	behaviourAtStopButton = behaviourAtStop;
 
 	_tool_bar->addWidget( autoScroll );
 	_tool_bar->addWidget( loopPoints );
@@ -155,6 +157,7 @@ void TimeLineWidget::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	_this.setAttribute( "lp0pos", (int) loopBegin() );
 	_this.setAttribute( "lp1pos", (int) loopEnd() );
 	_this.setAttribute( "lpstate", m_loopPoints );
+	_this.setAttribute( "stopbehaviour", behaviourAtStopButton->state() );
 }
 
 
@@ -168,6 +171,11 @@ void TimeLineWidget::loadSettings( const QDomElement & _this )
 					_this.attribute( "lpstate" ).toInt() );
 	update();
 	emit loopPointStateLoaded( m_loopPoints );
+	
+	if( _this.hasAttribute( "stopbehaviour" ) )
+	{
+		behaviourAtStopButton->changeState( _this.attribute( "stopbehaviour" ).toInt() );
+	}
 }
 
 


### PR DESCRIPTION
Solves part of issue #3740. Title is self-explanatory, and I also fixed some wrong grammar in the tooltips. Minimal changes, and I did as decided in the issue related to this topic (although pause is now more convinient with a Shift+Pause hotkey).