### PR TITLE
Removes unused variable on SongEditor.cpp

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -575,7 +575,6 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 	}
 	else if( ke->key() == Qt::Key_Delete || ke->key() == Qt::Key_Backspace )
 	{
-		QVector<TrackContentObjectView *> tcoViews;
 		QVector<selectableObject *> so = selectedObjects();
 		for( QVector<selectableObject *>::iterator it = so.begin();
 				it != so.end(); ++it )


### PR DESCRIPTION
There was a variable declared but not used on the SongEditor.cpp file (method `SongEditor::keyPressEvent`), called `QVector<TrackContentObjectView *> tcoViews`. The variable was removed.