### PR TITLE
Remove excess parentheses from ternary operations

### DIFF
--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -58,7 +58,7 @@ public:
 
 	QString currentText() const
 	{
-		return ( size() > 0 && value() < size() ) ? m_items[value()].first : QString();
+		return size() > 0 && value() < size() ? m_items[value()].first : QString();
 	}
 
 	const PixmapLoader* currentData() const

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -73,7 +73,7 @@ public:
 
 	static inline float expKnobVal( float _val )
 	{
-		return ( ( _val < 0 ) ? -_val : _val ) * _val;
+		return ( _val < 0 ? -_val : _val ) * _val;
 	}
 
 	static LfoInstances * instances()

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -116,7 +116,7 @@ public:
 	AutomatableModel* getModel(const std::string& s)
 	{
 		auto itr = m_models.find(s);
-		return (itr == m_models.end()) ? nullptr : itr->second.m_model;
+		return itr == m_models.end() ? nullptr : itr->second.m_model;
 	}
 
 	//! Register a further model

--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -116,7 +116,7 @@ public:
 
 	static inline sample_t squareSample( const float _sample )
 	{
-		return ( fraction( _sample ) > 0.5f ) ? -1.0f : 1.0f;
+		return fraction( _sample ) > 0.5f ? -1.0f : 1.0f;
 	}
 
 	static inline sample_t moogSawSample( const float _sample )

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -125,13 +125,13 @@ public:
 
 	inline const MidiTime & loopBegin() const
 	{
-		return ( m_loopPos[0] < m_loopPos[1] ) ?
+		return m_loopPos[0] < m_loopPos[1] ?
 						m_loopPos[0] : m_loopPos[1];
 	}
 
 	inline const MidiTime & loopEnd() const
 	{
-		return ( m_loopPos[0] > m_loopPos[1] ) ?
+		return m_loopPos[0] > m_loopPos[1] ?
 						m_loopPos[0] : m_loopPos[1];
 	}
 

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -670,7 +670,7 @@ f_cnt_t GigInstrument::getPingPongIndex( f_cnt_t index, f_cnt_t startf, f_cnt_t 
 	const f_cnt_t looplen = endf - startf;
 	const f_cnt_t looppos = ( index - endf ) % ( looplen * 2 );
 
-	return ( looppos < looplen )
+	return looppos < looplen
 		? endf - looppos
 		: startf + ( looppos - looplen );
 }

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -1040,8 +1040,8 @@ void AudioFileProcessorWaveView::zoom( const bool _out )
 	const f_cnt_t d_to = m_to - end;
 
 	const f_cnt_t step = qMax( 1, qMax( d_from, d_to ) / 10 );
-	const f_cnt_t step_from = ( _out ? - step : step );
-	const f_cnt_t step_to = ( _out ? step : - step );
+	const f_cnt_t step_from = _out ? - step : step;
+	const f_cnt_t step_to = _out ? step : - step;
 
 	const double comp_ratio = double( qMin( d_from, d_to ) )
 								/ qMax( 1, qMax( d_from, d_to ) );

--- a/plugins/kicker/KickerOsc.h
+++ b/plugins/kicker/KickerOsc.h
@@ -65,7 +65,7 @@ public:
 	{
 		for( fpp_t frame = 0; frame < frames; ++frame )
 		{
-			const double gain = ( 1 - fastPow( ( m_counter < m_length ) ? m_counter / m_length : 1, m_env ) );
+			const double gain = ( 1 - fastPow( m_counter < m_length ? m_counter / m_length : 1, m_env ) );
 			const sample_t s = ( Oscillator::sinSample( m_phase ) * ( 1 - m_noise ) ) + ( Oscillator::noiseSample( 0 ) * gain * gain * m_noise );
 			buf[frame][0] = s * gain;
 			buf[frame][1] = s * gain;
@@ -81,7 +81,7 @@ public:
 			m_FX.nextSample( buf[frame][0], buf[frame][1] );
 			m_phase += m_freq / sampleRate;
 
-			const double change = ( m_counter < m_length ) ? ( ( m_startFreq - m_endFreq ) * ( 1 - fastPow( m_counter / m_length, m_slope ) ) ) : 0;
+			const double change = m_counter < m_length ? ( m_startFreq - m_endFreq ) * ( 1 - fastPow( m_counter / m_length, m_slope ) ) : 0;
 			m_freq = m_endFreq + change;
 			++m_counter;
 		}

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -199,7 +199,7 @@ void kickerInstrument::playNote( NotePlayHandle * _n,
 		const float desired = desiredReleaseFrames();
 		for( fpp_t f = 0; f < frames; ++f )
 		{
-			const float fac = ( done+f < desired ) ? ( 1.0f - ( ( done+f ) / desired ) ) : 0;
+			const float fac = done+f < desired ? 1.0f - ( ( done+f ) / desired ) : 0;
 			_working_buffer[f+offset][0] *= fac;
 			_working_buffer[f+offset][1] *= fac;
 		}

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -227,7 +227,7 @@ void lb302Filter3Pole::envRecalc()
 
 	// e0 is adjusted for Hz and doesn't need ENVINC
 	w = vcf_e0 + vcf_c0;
-	k = (fs->cutoff > 0.975)?0.975:fs->cutoff;
+	k = fs->cutoff > 0.975?0.975:fs->cutoff;
 	kfco = 50.f + (k)*((2300.f-1600.f*(fs->envmod))+(w) *
 	                   (700.f+1500.f*(k)+(1500.f+(k)*(Engine::mixer()->processingSampleRate()/2.f-6000.f)) *
 	                   (fs->envmod)) );
@@ -546,11 +546,11 @@ int lb302Synth::process(sampleFrame *outbuf, const int size)
 				break;
 
 			case SQUARE: // p0: slope of top
-				vco_k = (vco_c<0)?0.5:-0.5;
+				vco_k = vco_c<0?0.5:-0.5;
 				break;
 
 			case ROUND_SQUARE: // p0: width of round
-				vco_k = (vco_c<0)?(sqrtf(1-(vco_c*vco_c*4))-0.5):-0.5;
+				vco_k = vco_c<0?sqrtf(1-(vco_c*vco_c*4))-0.5:-0.5;
 				break;
 
 			case MOOG: // Maybe the fall should be exponential/sinsoidal instead of quadric.

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -390,8 +390,8 @@ void MonstroSynth::renderOutput( fpp_t _frames, sampleFrame * _buf  )
 		}
 
 		// pulse wave osc
-		sample_t O1L = ( absFraction( leftph ) < o1_pw ) ? 1.0f : -1.0f;
-		sample_t O1R = ( absFraction( rightph ) < o1_pw ) ? 1.0f : -1.0f;
+		sample_t O1L = absFraction( leftph ) < o1_pw ? 1.0f : -1.0f;
+		sample_t O1R = absFraction( rightph ) < o1_pw ? 1.0f : -1.0f;
 
 		// check for rise/fall, and sync if appropriate
 		// sync on rise

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -877,7 +877,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 
 	p.drawPixmap( 0, 0, *s_artwork );
 
-	QString plugin_name = ( m_vi->m_plugin != NULL ) ?
+	QString plugin_name = m_vi->m_plugin != NULL ?
 				m_vi->m_plugin->name()/* + QString::number(
 						m_plugin->version() )*/
 					:

--- a/plugins/vst_base/RemoteVstPlugin.cpp
+++ b/plugins/vst_base/RemoteVstPlugin.cpp
@@ -1161,7 +1161,7 @@ void RemoteVstPlugin::getParameterDump()
 void RemoteVstPlugin::setParameterDump( const message & _m )
 {
 	const int n = _m.getInt( 0 );
-	const int params = ( n > m_plugin->numParams ) ?
+	const int params = n > m_plugin->numParams ?
 					m_plugin->numParams : n;
 	int p = 0;
 	for( int i = 0; i < params; ++i )

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -852,7 +852,7 @@ void DataFile::upgrade_1_1_91()
 		// invert the mute LEDs
 		for( int j = 1; j <= 4; ++j ){
 			QString a = QString( "mute%1" ).arg( j );
-			el.setAttribute( a, ( el.attribute( a ) == "0" ) ? "1" : "0" );
+			el.setAttribute( a, el.attribute( a ) == "0" ? "1" : "0" );
 		}
 	}
 

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -165,7 +165,7 @@ float DrumSynth::waveform(float ph, int form)
              break;
      case 3: w = ph - TwoPi * (float)(int)(ph / TwoPi);                        //saw
              w = (0.3183098f * w) - 1.f;                                break;
-    default: w = (sin(fmod(ph,TwoPi))>0.0)? 1.f: -1.f;                  break; //square
+    default: w = sin(fmod(ph,TwoPi))>0.0? 1.f: -1.f;                  break; //square
   }
 
   return w;

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -319,7 +319,7 @@ void EnvelopeAndLfoParameters::fillLevel( float * _buf, f_cnt_t _frame,
 		else if( ( _frame - _release_begin ) < m_rFrames )
 		{
 			env_level = m_rEnv[_frame - _release_begin] *
-				( ( _release_begin < m_pahdFrames ) ?
+				( _release_begin < m_pahdFrames ?
 				m_pahdEnv[_release_begin] : m_sustainLevel );
 		}
 		else

--- a/src/core/FxMixer.cpp
+++ b/src/core/FxMixer.cpp
@@ -700,7 +700,7 @@ void FxMixer::clearChannel(fx_ch_t index)
 	ch->m_volumeModel.setValue( 1.0f );
 	ch->m_muteModel.setValue( false );
 	ch->m_soloModel.setValue( false );
-	ch->m_name = ( index == 0 ) ? tr( "Master" ) : tr( "FX %1" ).arg( index );
+	ch->m_name = index == 0 ? tr( "Master" ) : tr( "FX %1" ).arg( index );
 	ch->m_volumeModel.setDisplayName( ch->m_name + ">" + tr( "Volume" ) );
 	ch->m_muteModel.setDisplayName( ch->m_name + ">" + tr( "Mute" ) );
 	ch->m_soloModel.setDisplayName( ch->m_name + ">" + tr( "Solo" ) );

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -180,9 +180,9 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 	const f_cnt_t fl = _n->framesLeft();
 	if( fl <= desiredReleaseFrames()+fpp )
 	{
-		for( fpp_t f = (fpp_t)( ( fl > desiredReleaseFrames() ) ?
-				( qMax( fpp - desiredReleaseFrames(), 0 ) +
-					fl % fpp ) : 0 ); f < frames; ++f )
+		for( fpp_t f = (fpp_t)( fl > desiredReleaseFrames() ?
+				qMax( fpp - desiredReleaseFrames(), 0 ) +
+					fl % fpp : 0 ); f < frames; ++f )
 		{
 			const float fac = (float)( fl-f-1 ) /
 							desiredReleaseFrames();

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -380,11 +380,11 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	// used for calculating remaining frames for arp-note, we have to add
 	// arp_frames-1, otherwise the first arp-note will not be setup
 	// correctly... -> arp_frames frames silence at the start of every note!
-	int cur_frame = ( ( m_arpModeModel.value() != FreeMode ) ?
+	int cur_frame = ( m_arpModeModel.value() != FreeMode ?
 						cnphv.first()->totalFramesPlayed() :
 						_n->totalFramesPlayed() ) + arp_frames - 1;
 	// used for loop
-	f_cnt_t frames_processed = ( m_arpModeModel.value() != FreeMode ) ? cnphv.first()->noteOffset() : _n->noteOffset();
+	f_cnt_t frames_processed = m_arpModeModel.value() != FreeMode ? cnphv.first()->noteOffset() : _n->noteOffset();
 
 	while( frames_processed < Engine::mixer()->framesPerPeriod() )
 	{

--- a/src/core/LadspaControl.cpp
+++ b/src/core/LadspaControl.cpp
@@ -80,7 +80,7 @@ LadspaControl::LadspaControl( Model * _parent, port_desc_t * _port,
 				( m_port->max - m_port->min )
 				/ ( m_port->name.toUpper() == "GAIN"
 					&& m_port->max == 10.0f ? 4000.0f :
-								( m_port->suggests_logscale ? 8000000.0f : 800000.0f ) ) );
+								m_port->suggests_logscale ? 8000000.0f : 800000.0f ) );
 			m_knobModel.setInitValue( m_port->def );
 			connect( &m_knobModel, SIGNAL( dataChanged() ),
 						 this, SLOT( knobChanged() ) );

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -210,8 +210,8 @@ void addSanitizedMultipliedByBuffer( sampleFrame* dst, const sampleFrame* src, f
 
 	for( int f = 0; f < frames; ++f )
 	{
-		dst[f][0] += ( isinf( src[f][0] ) || isnan( src[f][0] ) ) ? 0.0f : src[f][0] * coeffSrc * coeffSrcBuf->values()[f];
-		dst[f][1] += ( isinf( src[f][1] ) || isnan( src[f][1] ) ) ? 0.0f : src[f][1] * coeffSrc * coeffSrcBuf->values()[f];
+		dst[f][0] += isinf( src[f][0] ) || isnan( src[f][0] ) ? 0.0f : src[f][0] * coeffSrc * coeffSrcBuf->values()[f];
+		dst[f][1] += isinf( src[f][1] ) || isnan( src[f][1] ) ? 0.0f : src[f][1] * coeffSrc * coeffSrcBuf->values()[f];
 	}
 }
 
@@ -226,10 +226,10 @@ void addSanitizedMultipliedByBuffers( sampleFrame* dst, const sampleFrame* src, 
 
 	for( int f = 0; f < frames; ++f )
 	{
-		dst[f][0] += ( isinf( src[f][0] ) || isnan( src[f][0] ) )
+		dst[f][0] += isinf( src[f][0] ) || isnan( src[f][0] )
 			? 0.0f
 			: src[f][0] * coeffSrcBuf1->values()[f] * coeffSrcBuf2->values()[f];
-		dst[f][1] += ( isinf( src[f][1] ) || isnan( src[f][1] ) )
+		dst[f][1] += isinf( src[f][1] ) || isnan( src[f][1] )
 			? 0.0f
 			: src[f][1] * coeffSrcBuf1->values()[f] * coeffSrcBuf2->values()[f];
 	}
@@ -243,8 +243,8 @@ struct AddSanitizedMultipliedOp
 
 	void operator()( sampleFrame& dst, const sampleFrame& src ) const
 	{
-		dst[0] += ( isinf( src[0] ) || isnan( src[0] ) ) ? 0.0f : src[0] * m_coeff;
-		dst[1] += ( isinf( src[1] ) || isnan( src[1] ) ) ? 0.0f : src[1] * m_coeff;
+		dst[0] += isinf( src[0] ) || isnan( src[0] ) ? 0.0f : src[0] * m_coeff;
+		dst[1] += isinf( src[1] ) || isnan( src[1] ) ? 0.0f : src[1] * m_coeff;
 	}
 
 	const float m_coeff;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -231,8 +231,8 @@ void NotePlayHandle::play( sampleFrame * _working_buffer )
 		m_totalFramesPlayed + framesThisPeriod > m_frames )
 	{
 		noteOff( m_totalFramesPlayed == 0
-			? ( m_frames + offset() ) // if we have noteon and noteoff during the same period, take offset in account for release frame
-			: ( m_frames - m_totalFramesPlayed ) ); // otherwise, the offset is already negated and can be ignored
+			? m_frames + offset() // if we have noteon and noteoff during the same period, take offset in account for release frame
+			: m_frames - m_totalFramesPlayed ); // otherwise, the offset is already negated and can be ignored
 	}
 
 	// under some circumstances we're called even if there's nothing to play

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -98,7 +98,7 @@ QString use_this_or(QString this_param, QString or_param)
 QString Plugin::displayName() const
 {
 	return Model::displayName().isEmpty() // currently always empty
-		? (m_descriptor->subPluginFeatures && m_key.isValid())
+		? m_descriptor->subPluginFeatures && m_key.isValid()
 			// get from sub plugin
 			? m_key.displayName()
 			// get from plugin
@@ -111,7 +111,7 @@ QString Plugin::displayName() const
 
 const PixmapLoader* Plugin::logo() const
 {
-	return (m_descriptor->subPluginFeatures && m_key.isValid())
+	return m_descriptor->subPluginFeatures && m_key.isValid()
 		? m_key.logo()
 		: m_descriptor->logo;
 }

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -300,7 +300,7 @@ void SampleBuffer::convertIntToFloat ( int_sample_t * & _ibuf, f_cnt_t _frames, 
 	// float-samples and does amplifying & reversing
 	const float fac = 1 / OUTPUT_SAMPLE_MULTIPLIER;
 	m_data = MM_ALLOC( sampleFrame, _frames );
-	const int ch = ( _channels > 1 ) ? 1 : 0;
+	const int ch = _channels > 1 ? 1 : 0;
 
 	// if reversing is on, we also reverse when
 	// scaling
@@ -335,7 +335,7 @@ void SampleBuffer::directFloatWrite ( sample_t * & _fbuf, f_cnt_t _frames, int _
 {
 
 	m_data = MM_ALLOC( sampleFrame, _frames );
-	const int ch = ( _channels > 1 ) ? 1 : 0;
+	const int ch = _channels > 1 ? 1 : 0;
 
 	// if reversing is on, we also reverse when
 	// scaling
@@ -927,7 +927,7 @@ f_cnt_t SampleBuffer::getPingPongIndex( f_cnt_t _index, f_cnt_t _startf, f_cnt_t
 	const f_cnt_t looplen = _endf - _startf;
 	const f_cnt_t looppos = ( _index - _endf ) % ( looplen*2 );
 
-	return ( looppos < looplen )
+	return looppos < looplen
 		? _endf - looppos
 		: _startf + ( looppos - looplen );
 }
@@ -1092,9 +1092,9 @@ FLAC__StreamEncoderWriteStatus flacStreamEncoderWriteCallback(
 	{
 		return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
 	}*/
-	return ( static_cast<QBuffer *>( _client_data )->write(
+	return static_cast<QBuffer *>( _client_data )->write(
 				(const char *) _buffer, _bytes ) ==
-								(int) _bytes ) ?
+								(int) _bytes ?
 				FLAC__STREAM_ENCODER_WRITE_STATUS_OK :
 				FLAC__STREAM_ENCODER_WRITE_STATUS_FATAL_ERROR;
 }

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -90,7 +90,7 @@ AudioAlsa::AudioAlsa( bool & _success_ful, Mixer*  _mixer ) :
 	snd_pcm_poll_descriptors( m_handle, ufds, count );
 	for( int i = 0; i < qMax( 3, count ); ++i )
 	{
-		const int fd = ( i >= count ) ? ufds[0].fd+i : ufds[i].fd;
+		const int fd = i >= count ? ufds[0].fd+i : ufds[i].fd;
 		int oldflags = fcntl( fd, F_GETFD, 0 );
 		if( oldflags < 0 )
 			continue;

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -107,9 +107,9 @@ bool AudioFileOgg::startEncoding()
 	vorbis_info_init( &m_vi );
 
 	if( vorbis_encode_setup_managed( &m_vi, m_channels, m_rate,
-			( maximumBitrate > 0 )? maximumBitrate * 1000 : -1,
+			maximumBitrate > 0 ? maximumBitrate * 1000 : -1,
 						nominalBitrate() * 1000, 
-			( minimalBitrate > 0 )? minimalBitrate * 1000 : -1 ) )
+			minimalBitrate > 0 ? minimalBitrate * 1000 : -1 ) )
 	{
 		printf( "Mode initialization failed: invalid parameters for "
 								"bitrate\n" );

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -181,7 +181,7 @@ bool AudioJack::initJackClient()
 	for( ch_cnt_t ch = 0; ch < channels(); ++ch )
 	{
 		QString name = QString( "master out " ) +
-				( ( ch % 2 ) ? "R" : "L" ) +
+				( ch % 2 ? "R" : "L" ) +
 				QString::number( ch / 2 + 1 );
 		m_outputPorts.push_back( jack_port_register( m_client,
 						name.toLatin1().constData(),

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -410,7 +410,7 @@ void AudioSoundIo::setupWidget::updateDevices()
 		SoundIoDevice *device = soundio_get_output_device(m_soundio, i);
 
 		QString raw_text = device->is_raw ? " (raw)" : "";
-		QString default_text = (i == m_defaultOutIndex) ? " (default)" : "";
+		QString default_text = i == m_defaultOutIndex ? " (default)" : "";
 
 		m_deviceModel.addItem(device->name + raw_text + default_text);
 		m_deviceList.append({device->id, device->is_raw});

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -93,7 +93,7 @@ Lv2ControlBase::~Lv2ControlBase() {}
 
 LinkedModelGroup *Lv2ControlBase::getGroup(std::size_t idx)
 {
-	return (m_procs.size() > idx) ? m_procs[idx].get() : nullptr;
+	return m_procs.size() > idx ? m_procs[idx].get() : nullptr;
 }
 
 
@@ -101,7 +101,7 @@ LinkedModelGroup *Lv2ControlBase::getGroup(std::size_t idx)
 
 const LinkedModelGroup *Lv2ControlBase::getGroup(std::size_t idx) const
 {
-	return (m_procs.size() > idx) ? m_procs[idx].get() : nullptr;
+	return m_procs.size() > idx ? m_procs[idx].get() : nullptr;
 }
 
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -88,9 +88,9 @@ Plugin::PluginTypes Lv2Proc::check(const LilvPlugin *plugin,
 		for (const PluginIssue& iss : issues) { qDebug() << "  - " << iss; }
 	}
 
-	return (audioChannels[inCount] > 2 || audioChannels[outCount] > 2)
+	return audioChannels[inCount] > 2 || audioChannels[outCount] > 2
 		? Plugin::Undefined
-		: (audioChannels[inCount] > 0)
+		: audioChannels[inCount] > 0
 			? Plugin::Effect
 			: Plugin::Instrument;
 }
@@ -307,7 +307,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 					float stepSize = (meta.m_max - meta.m_min) / 1000.0f;
 
 					// make multiples of 0.01 (or 0.1 for larger values)
-					float minStep = (stepSize >= 1.0f) ? 0.1f : 0.01f;
+					float minStep = stepSize >= 1.0f ? 0.1f : 0.01f;
 					stepSize -= fmodf(stepSize, minStep);
 					stepSize = std::max(stepSize, minStep);
 
@@ -456,7 +456,7 @@ struct ConnectPortVisitor : public Lv2Ports::Visitor
 	void visit(Lv2Ports::Control& ctrl) override { connectPort(&ctrl.m_val); }
 	void visit(Lv2Ports::Audio& audio) override
 	{
-		connectPort((audio.mustBeUsed()) ? audio.m_buffer.data() : nullptr);
+		connectPort(audio.mustBeUsed() ? audio.m_buffer.data() : nullptr);
 	}
 	void visit(Lv2Ports::Unknown&) override { connectPort(nullptr); }
 	~ConnectPortVisitor() override;

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -166,7 +166,7 @@ void MidiAlsaSeq::processOutEvent( const MidiEvent& event, const MidiTime& time,
 
 	snd_seq_event_t ev;
 	snd_seq_ev_clear( &ev );
-	snd_seq_ev_set_source( &ev, ( m_portIDs[p][1] != -1 ) ?
+	snd_seq_ev_set_source( &ev, m_portIDs[p][1] != -1 ?
 					m_portIDs[p][1] : m_portIDs[p][0] );
 	snd_seq_ev_set_subs( &ev );
 	snd_seq_ev_schedule_tick( &ev, m_queueID, 1, static_cast<int>( time ) );

--- a/src/gui/AutomationPatternView.cpp
+++ b/src/gui/AutomationPatternView.cpp
@@ -261,8 +261,8 @@ void AutomationPatternView::paintEvent( QPaintEvent * )
 	bool current = gui->automationEditor()->currentPattern() == m_pat;
 	
 	// state: selected, muted, normal
-	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
-		:	painter.background().color() );
+	c = isSelected() ? selectedColor() : muted ? mutedBackgroundColor() 
+		:	painter.background().color();
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -164,7 +164,7 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 			QStyleOptionTitleBar so( *titleBar );
 			so.palette = standardPalette();
 			so.palette.setColor( QPalette::HighlightedText,
-				( titleBar->titleBarState & State_Active ) ?
+				titleBar->titleBarState & State_Active ?
 					QColor( 255, 255, 255 ) :
 						QColor( 192, 192, 192 ) );
 			so.palette.setColor( QPalette::Text,

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -70,7 +70,7 @@ Lv2ViewProc::Lv2ViewProc(QWidget* parent, Lv2Proc* ctrlBase, int colNum) :
 						m_control = new KnobControl(m_par);
 						break;
 					case PortVis::Integer:
-						m_control = new LcdControl((port.m_max <= 9.0f) ? 1 : 2,
+						m_control = new LcdControl(port.m_max <= 9.0f ? 1 : 2,
 													m_par);
 						break;
 					case PortVis::Enumeration:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -599,7 +599,7 @@ void MainWindow::finalize()
 
 int MainWindow::addWidgetToToolBar( QWidget * _w, int _row, int _col )
 {
-	int col = ( _col == -1 ) ? m_toolBarLayout->columnCount() + 7 : _col;
+	int col = _col == -1 ? m_toolBarLayout->columnCount() + 7 : _col;
 	if( _w->height() > 32 || _row == -1 )
 	{
 		m_toolBarLayout->addWidget( _w, 0, col, 2, 1 );
@@ -780,11 +780,11 @@ void MainWindow::restoreWidgetState( QWidget * _w, const QDomElement & _de )
 		// set the window to its correct minimized/maximized/restored state
 		Qt::WindowStates flags = _w->windowState();
 		flags = _de.attribute( "minimized" ).toInt() ?
-				( flags | Qt::WindowMinimized ) :
-				( flags & ~Qt::WindowMinimized );
+				flags | Qt::WindowMinimized :
+				flags & ~Qt::WindowMinimized;
 		flags = _de.attribute( "maximized" ).toInt() ?
-				( flags | Qt::WindowMaximized ) :
-				( flags & ~Qt::WindowMaximized );
+				flags | Qt::WindowMaximized :
+				flags & ~Qt::WindowMaximized;
 		_w->setWindowState( flags );
 
 		_w->setVisible( _de.attribute( "visible" ).toInt() );

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -786,7 +786,7 @@ void PianoView::paintEvent( QPaintEvent * )
 
 	p.setPen( Qt::white );
 
-	const int base_key = ( m_piano != NULL ) ?
+	const int base_key = m_piano != NULL ?
 		m_piano->instrumentTrack()->baseNoteModel()->value() : 0;
 
 	QColor baseKeyColor = QApplication::palette().color( QPalette::Active,

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -1337,7 +1337,7 @@ void SetupDialog::openBackgroundPicFile()
 		}
 	}
 
-	QString dir = (m_backgroundPicFile.isEmpty()) ?
+	QString dir = m_backgroundPicFile.isEmpty() ?
 		m_themeDir :
 		m_backgroundPicFile;
 	QString new_file = FileDialog::getOpenFileName(this,

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -339,7 +339,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 			qSwap( m_loopPos[0], m_loopPos[1] );
 		}
 
-		m_loopPos[( m_action == MoveLoopBegin ) ? 0 : 1] = t;
+		m_loopPos[m_action == MoveLoopBegin ? 0 : 1] = t;
 	}
 
 	if( m_action == MoveLoopBegin || m_action == MoveLoopEnd )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -584,7 +584,7 @@ void PianoRoll::markSemiTone( int i )
 
 			const int first = chord->isScale() ? 0 : key;
 			const int last = chord->isScale() ? NumKeys : key + chord->last();
-			const int cap = ( chord->isScale() || chord->last() == 0 ) ? KeysPerOctave : chord->last();
+			const int cap = chord->isScale() || chord->last() == 0 ? KeysPerOctave : chord->last();
 
 			for( int i = first; i <= last; i++ )
 			{
@@ -1147,7 +1147,7 @@ void PianoRoll::shiftPos(NoteVector notes, int amount)
 	m_pattern->addJournalCheckPoint();
 	auto leftMostPos = notes.first()->pos();
 	//Limit leftwards shifts to prevent moving left of pattern start
-	auto shiftAmount = (leftMostPos > -amount) ? amount : -leftMostPos;
+	auto shiftAmount = leftMostPos > -amount ? amount : -leftMostPos;
 	if (shiftAmount == 0) { return; }
 
 	for (Note *note : notes) { note->setPos( note->pos() + shiftAmount ); }
@@ -3373,7 +3373,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	p.drawRect( x + WHITE_KEY_WIDTH, y, w, h );
 
 	// TODO: Get this out of paint event
-	int l = ( hasValidPattern() )? (int) m_pattern->length() : 0;
+	int l = hasValidPattern() ? (int) m_pattern->length() : 0;
 
 	// reset scroll-range
 	if( m_leftRightScroll->maximum() != l )

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -230,7 +230,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		model()->setInitValue( model()->value() + ( ( event->delta() < 0 ) ? 1 : -1 ) );
+		model()->setInitValue( model()->value() + ( event->delta() < 0 ? 1 : -1 ) );
 		update();
 		event->accept();
 	}

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -445,7 +445,7 @@ void Fader::paintLinearLevels(QPaintEvent * ev, QPainter & painter)
 
 	if( m_persistentPeak_L > 0.05 )
 	{
-		painter.fillRect( QRect( 2, persistentPeak_L, 7, 1 ), ( m_persistentPeak_L < 1.0 )
+		painter.fillRect( QRect( 2, persistentPeak_L, 7, 1 ), m_persistentPeak_L < 1.0
 			? peakGreen()
 			: peakRed() );
 	}
@@ -456,7 +456,7 @@ void Fader::paintLinearLevels(QPaintEvent * ev, QPainter & painter)
 
 	if( m_persistentPeak_R > 0.05 )
 	{
-		painter.fillRect( QRect( 14, persistentPeak_R, 7, 1 ), ( m_persistentPeak_R < 1.0 )
+		painter.fillRect( QRect( 14, persistentPeak_R, 7, 1 ), m_persistentPeak_R < 1.0
 			? peakGreen()
 			: peakRed() );
 	}

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -735,7 +735,7 @@ void graphModel::clearInvisible()
 void graphModel::drawSampleAt( int x, float val )
 {
 	//snap to the grid
-	val -= ( m_step != 0.0 ) ? fmod( val, m_step ) * m_step : 0;
+	val -= m_step != 0.0 ? fmod( val, m_step ) * m_step : 0;
 
 	// boundary crop
 	x = qMax( 0, qMin( length()-1, x ) );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -695,7 +695,7 @@ void Knob::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
 	const float stepMult = model()->range() / 2000 / model()->step<float>();
-	const int inc = ( ( _we->delta() > 0 ) ? 1 : -1 ) * ( ( stepMult < 1 ) ? 1 : stepMult );
+	const int inc = ( _we->delta() > 0 ? 1 : -1 ) * ( stepMult < 1 ? 1 : stepMult );
 	model()->incValue( inc );
 
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -153,7 +153,7 @@ void LcdSpinBox::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
 	model()->setInitValue( model()->value() +
-			( ( _we->delta() > 0 ) ? 1 : -1 ) * model()->step<int>() );
+			( _we->delta() > 0 ? 1 : -1 ) * model()->step<int>() );
 	emit manualChange();
 }
 

--- a/src/gui/widgets/MidiPortMenu.cpp
+++ b/src/gui/widgets/MidiPortMenu.cpp
@@ -86,7 +86,7 @@ void MidiPortMenu::activatedPort( QAction * _item )
 void MidiPortMenu::updateMenu()
 {
 	MidiPort * mp = castModel<MidiPort>();
-	const MidiPort::Map & map = ( m_mode == MidiPort::Input ) ?
+	const MidiPort::Map & map = m_mode == MidiPort::Input ?
 				mp->readablePorts() : mp->writablePorts();
 	clear();
 	for( MidiPort::Map::ConstIterator it = map.begin();

--- a/src/gui/widgets/NStateButton.cpp
+++ b/src/gui/widgets/NStateButton.cpp
@@ -72,7 +72,7 @@ void NStateButton::changeState( int _n )
 		m_curState = _n;
 
 		const QString & _tooltip =
-			( m_states[m_curState].second != "" ) ?
+			m_states[m_curState].second != "" ?
 				m_states[m_curState].second :
 					m_generalToolTip;
 		ToolTip::add( this, _tooltip );

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -50,7 +50,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		// then remove it
 		removeTab( _id );
 	}
-	QString caption = ( _text_is_tooltip ) ? QString( "" ) : _text;
+	QString caption = _text_is_tooltip ? QString( "" ) : _text;
 	// create tab-button
 	TabButton * b = new TabButton( caption, _id, this );
 	connect( b, SIGNAL( clicked( int ) ), this, SLOT( tabClicked( int ) ) );

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -125,7 +125,7 @@ int TabWidget::findTabAtPos( const QPoint *pos )
 
 	if( pos->y() > 1 && pos->y() < m_tabbarHeight - 1 )
 	{
-		int cx = ( ( m_caption == "" ) ? 4 : 14 ) + fontMetrics().width( m_caption );
+		int cx = ( m_caption == "" ? 4 : 14 ) + fontMetrics().width( m_caption );
 
 		for( widgetStack::iterator it = m_widgets.begin(); it != m_widgets.end(); ++it )
 		{
@@ -294,7 +294,7 @@ void TabWidget::wheelEvent( QWheelEvent * we )
 	}
 
 	we->accept();
-	int dir = ( we->delta() < 0 ) ? 1 : -1;
+	int dir = we->delta() < 0 ? 1 : -1;
 	int tab = m_activeTab;
 	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
 	{

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -214,9 +214,9 @@ void BBTCOView::paintEvent( QPaintEvent * )
 	bool muted = m_bbTCO->getTrack()->isMuted() || m_bbTCO->isMuted();
 	
 	// state: selected, muted, default, user selected
-	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor() 
-		: ( m_bbTCO->m_useStyleColor ? painter.background().color() 
-		: m_bbTCO->colorObj() ) );
+	c = isSelected() ? selectedColor() : muted ? mutedBackgroundColor() 
+		: m_bbTCO->m_useStyleColor ? painter.background().color() 
+		: m_bbTCO->colorObj();
 	
 	lingrad.setColorAt( 0, c.lighter( 130 ) );
 	lingrad.setColorAt( 1, c.lighter( 70 ) );

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1680,7 +1680,7 @@ void InstrumentTrackWindow::saveSettingsBtnClicked()
 
 void InstrumentTrackWindow::updateName()
 {
-	setWindowTitle( m_track->name().length() > 25 ? ( m_track->name().left(24)+"..." ) : m_track->name() );
+	setWindowTitle( m_track->name().length() > 25 ? m_track->name().left(24)+"..." : m_track->name() );
 
 	if( m_nameLineEdit->text() != m_track->name() )
 	{

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -864,9 +864,9 @@ void PatternView::paintEvent( QPaintEvent * )
 	bool beatPattern = m_pat->m_patternType == Pattern::BeatPattern;
 
 	// state: selected, normal, beat pattern, muted
-	QColor c = isSelected() ? selectedColor() : ( ( !muted && !beatPattern )
-		? painter.background().color() : ( beatPattern
-		? BBPatternBackground() : mutedBackgroundColor() ) );
+	QColor c = isSelected() ? selectedColor() : !muted && !beatPattern
+		? painter.background().color() : beatPattern
+		? BBPatternBackground() : mutedBackgroundColor();
 
 	// invert the gradient for the background in the B&B editor
 	QLinearGradient lingrad( 0, 0, 0, height() );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -333,7 +333,7 @@ void SampleTCOView::updateSample()
 	update();
 	// set tooltip to filename so that user can see what sample this
 	// sample-tco contains
-	ToolTip::add( this, ( m_tco->m_sampleBuffer->audioFile() != "" ) ?
+	ToolTip::add( this, m_tco->m_sampleBuffer->audioFile() != "" ?
 					PathUtil::toAbsolute(m_tco->m_sampleBuffer->audioFile()) :
 					tr( "Double-click to open sample" ) );
 }
@@ -501,8 +501,8 @@ void SampleTCOView::paintEvent( QPaintEvent * pe )
 	bool muted = m_tco->getTrack()->isMuted() || m_tco->isMuted();
 
 	// state: selected, muted, normal
-	c = isSelected() ? selectedColor() : ( muted ? mutedBackgroundColor()
-		: painter.background().color() );
+	c = isSelected() ? selectedColor() : muted ? mutedBackgroundColor()
+		: painter.background().color();
 
 	lingrad.setColorAt( 1, c.darker( 300 ) );
 	lingrad.setColorAt( 0, c );
@@ -1148,7 +1148,7 @@ void SampleTrackView::assignFxLine(int channelIndex)
 
 void SampleTrackWindow::updateName()
 {
-	setWindowTitle(m_track->name().length() > 25 ? (m_track->name().left(24) + "...") : m_track->name());
+	setWindowTitle(m_track->name().length() > 25 ? m_track->name().left(24) + "..." : m_track->name());
 
 	if(m_nameLineEdit->text() != m_track->name())
 	{


### PR DESCRIPTION
Thanks to the very low precedence of the ternary operator and its right-to-left associativity.