### PR TITLE
Fix metronome playing when song is paused.

### DIFF
--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -357,7 +357,7 @@ const surroundSampleFrame * Mixer::renderNextBuffer()
 					 currentPlayMode == Song::Mode_PlayBB;
 
 	if( playModeSupportsMetronome && m_metronomeActive && !song->isExporting() &&
-		p != last_metro_pos &&
+		!song->isPaused() && p != last_metro_pos &&
 			// Stop crash with metronome if empty project
 				Engine::getSong()->countTracks() )
 	{


### PR DESCRIPTION
Fixes #5610, which should be named "Metronome plays when dragging play head, even when song is ~~stopped~~ paused". 