### PR TITLE
LB302: Prevent cutoff frequency modification when the sampling rate changes.

### DIFF
--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -74,7 +74,7 @@
 
 
 //#define engine::mixer()->processingSampleRate() 44100.0f
-
+const float sampleRateCutoff = 44100.0f;
 
 extern "C"
 {
@@ -228,8 +228,11 @@ void lb302Filter3Pole::envRecalc()
 	// e0 is adjusted for Hz and doesn't need ENVINC
 	w = vcf_e0 + vcf_c0;
 	k = (fs->cutoff > 0.975)?0.975:fs->cutoff;
+    // sampleRateCutoff should not be changed to anything dynamic that is outside the
+    // scope of lb302 (like e.g. the mixers sample rate) as this changes the filters cutoff
+    // behavior without any modification to its controls.
 	kfco = 50.f + (k)*((2300.f-1600.f*(fs->envmod))+(w) *
-	                   (700.f+1500.f*(k)+(1500.f+(k)*(44100.f/2.f-6000.f)) *
+	                   (700.f+1500.f*(k)+(1500.f+(k)*(sampleRateCutoff/2.f-6000.f)) *
 	                   (fs->envmod)) );
 	//+iacc*(.3+.7*kfco*kenvmod)*kaccent*kaccurve*2000
 

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -229,7 +229,7 @@ void lb302Filter3Pole::envRecalc()
 	w = vcf_e0 + vcf_c0;
 	k = (fs->cutoff > 0.975)?0.975:fs->cutoff;
 	kfco = 50.f + (k)*((2300.f-1600.f*(fs->envmod))+(w) *
-	                   (700.f+1500.f*(k)+(1500.f+(k)*(Engine::mixer()->processingSampleRate()/2.f-6000.f)) *
+	                   (700.f+1500.f*(k)+(1500.f+(k)*(44100.f/2.f-6000.f)) *
 	                   (fs->envmod)) );
 	//+iacc*(.3+.7*kfco*kenvmod)*kaccent*kaccurve*2000
 


### PR DESCRIPTION
Fixes issue #5615. It turned out that the problem appears when the 24dB Filter is switched on and Env Mod > 0. 

Findings:
The term where I made the change gets normalized a few lines down by `1/(Engine::mixer()->processingSampleRate()/2)`, so the term is most likely the cutoff frequency and should therefore not depend on the sampling rate.
Yet, the calculation of the cutoff frequency involves a term with the current sampling rate times the value of the knob `k`: `(k)*(w)*(k)*(Engine::mixer()->processingSampleRate()/2.f)`. The `w` should be set proportional to `1/Engine::mixer()->processingSampleRate()` by the base class, but the author of the code explicitly set his own static values along with the comment "// do not call base class". When the sampling rate changes during the export, this term also changes and consequently the cutoff frequency.
A simple fix is to calculate the cutoff frequency with 44.1kHz fixed and maybe also check if the cutoff is above the nyquist frequency which might happen at a lower samplerate than 44.1kHz. Cutoffs up to 22.05kHz are sufficient in all cases.