### PR TITLE
Qt deprecation fix

### DIFF
--- a/include/DeprecationHelper.h
+++ b/include/DeprecationHelper.h
@@ -1,0 +1,63 @@
+/*
+ * DeprecationHelper.h - This file contains the declarations of helper functions
+ * which helps centralize the #ifdefs preprocessors regarding deprecation based on Qt versions.
+ * The functions are defined differently based on the callers' Qt versions.
+ *
+ * Copyright (c) 2020 Tien Dat Nguyen <ntd.bk.k56/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef DEPRECATIONHELPER_H
+#define DEPRECATIONHELPER_H
+
+#include <QFontMetrics>
+#include <QWheelEvent>
+
+/**
+ * @brief horizontalAdvance is a backwards-compatible adapter for
+ * QFontMetrics::horizontalAdvance and width functions.
+ * @param metrics
+ * @param text
+ * @return text's horizontal advance based on metrics.
+ */
+inline int horizontalAdvance(const QFontMetrics& metrics, const QString& text)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+	return metrics.horizontalAdvance(text);
+#else
+	return metrics.width(text);
+#endif
+}
+
+/**
+ * @brief position is a backwards-compatible adapter for
+ * QWheelEvent::position and pos functions.
+ * @param wheelEvent
+ * @return the position of wheelEvent
+ */
+inline QPoint position(QWheelEvent *wheelEvent)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+	return wheelEvent->position().toPoint();
+#else
+	return wheelEvent->pos();
+#endif
+}
+#endif // DEPRECATIONHELPER_H

--- a/include/FadeButton.h
+++ b/include/FadeButton.h
@@ -26,9 +26,9 @@
 #ifndef FADE_BUTTON_H
 #define FADE_BUTTON_H
 
-#include <QtCore/QTime>
 #include <QAbstractButton>
 #include <QColor>
+#include <QElapsedTimer>
 
 
 class FadeButton : public QAbstractButton
@@ -55,8 +55,8 @@ protected:
 
 
 private:
-	QTime m_stateTimer;
-	QTime m_releaseTimer;
+	QElapsedTimer m_stateTimer;
+	QElapsedTimer m_releaseTimer;
 
 	// the default color of the widget
 	QColor m_normalColor;
@@ -66,7 +66,7 @@ private:
 	QColor m_holdColor;
 	int activeNotes;
 
-	QColor fadeToColor(QColor, QColor, QTime, float);
+	QColor fadeToColor(QColor, QColor, QElapsedTimer, float);
 
 } ;
 

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -48,9 +48,10 @@
 #ifndef FADER_H
 #define FADER_H
 
-#include <QtCore/QTime>
-#include <QWidget>
+#include <QElapsedTimer>
 #include <QPixmap>
+#include <QWidget>
+
 
 #include "AutomatableModelView.h"
 
@@ -130,7 +131,7 @@ private:
 		return height() - ( ( height() - m_knob->height() ) * ( realVal / fRange ) );
 	}
 
-	void setPeak( float fPeak, float &targetPeak, float &persistentPeak, QTime &lastPeakTime );
+	void setPeak( float fPeak, float &targetPeak, float &persistentPeak, QElapsedTimer &lastPeakTimer );
 	int calculateDisplayPeak( float fPeak );
 
 	void updateTextFloat();
@@ -144,8 +145,8 @@ private:
 	float m_fMinPeak;
 	float m_fMaxPeak;
 
-	QTime m_lastPeakTime_L;
-	QTime m_lastPeakTime_R;
+	QElapsedTimer m_lastPeakTimer_L;
+	QElapsedTimer m_lastPeakTimer_R;
 
 	static QPixmap * s_back;
 	static QPixmap * s_leds;

--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -46,8 +46,7 @@ public:
 									const QString &caption = QString(),
 									const QString &directory = QString(),
 									const QString &filter = QString(),
-									QString *selectedFilter = 0,
-									QFileDialog::Options options = 0);
+									QString *selectedFilter = 0);
 	void clearSelection();
 };
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -61,7 +61,7 @@ public:
 	void addSpacingToToolBar( int _size );
 
 	// wrap the widget with a window decoration and add it to the workspace
-	LMMS_EXPORT SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags=0);
+	LMMS_EXPORT SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags = QFlag(0));
 
 
 	///

--- a/include/StepRecorder.h
+++ b/include/StepRecorder.h
@@ -21,7 +21,7 @@
 #ifndef STEP_RECORDER_H
 #define STEP_RECORDER_H
 
-#include <QTime>
+#include <QElapsedTimer>
 #include <QTimer>
 #include <QObject>
 #include <QKeyEvent>
@@ -130,7 +130,7 @@ class StepRecorder : public QObject
 
 		private:
 		bool m_pressed;
-		QTime releasedTimer;
+		QElapsedTimer releasedTimer;
 	} ;
 
 	QVector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the pattern)

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -55,7 +55,7 @@ class LMMS_EXPORT SubWindow : public QMdiSubWindow
 	Q_PROPERTY( QColor borderColor READ borderColor WRITE setBorderColor )
 
 public:
-	SubWindow( QWidget *parent = NULL, Qt::WindowFlags windowFlags = 0 );
+	SubWindow( QWidget *parent = NULL, Qt::WindowFlags windowFlags = QFlag(0) );
 	// same as QWidet::normalGeometry, but works properly under X11 (see https://bugreports.qt.io/browse/QTBUG-256)
 	QRect getTrueNormalGeometry() const;
 	QBrush activeColor() const;

--- a/plugins/GigPlayer/PatchesDialog.h
+++ b/plugins/GigPlayer/PatchesDialog.h
@@ -43,7 +43,7 @@ class PatchesDialog : public QDialog, private Ui::PatchesDialog
 public:
 
 	// Constructor.
-	PatchesDialog( QWidget * pParent = 0, Qt::WindowFlags wflags = 0 );
+	PatchesDialog(QWidget * pParent = 0, Qt::WindowFlags wflags = QFlag(0));
 
 	// Destructor.
 	virtual ~PatchesDialog();

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -867,7 +867,7 @@ void AudioFileProcessorWaveView::mouseMoveEvent( QMouseEvent * _me )
 
 void AudioFileProcessorWaveView::wheelEvent( QWheelEvent * _we )
 {
-	zoom( _we->delta() > 0 );
+	zoom( _we->angleDelta().y() > 0 );
 	update();
 }
 

--- a/plugins/ladspa_browser/ladspa_port_dialog.cpp
+++ b/plugins/ladspa_browser/ladspa_port_dialog.cpp
@@ -65,7 +65,7 @@ ladspaPortDialog::ladspaPortDialog( const ladspa_key_t & _key )
 		for( int col = 0; col < 7; ++col )
 		{
 			QTableWidgetItem * item = new QTableWidgetItem;
-			item->setFlags( 0 );
+			item->setFlags(QFlag(0));
 			settings->setItem( row, col, item );
 		}
 

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -433,8 +433,11 @@ QString lb302Synth::nodeName() const
 // OBSOLETE. Break apart once we get Q_OBJECT to work. >:[
 void lb302Synth::recalcFilter()
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	vcf.loadRelaxed()->recalc();
+#else
 	vcf.load()->recalc();
-
+#endif
 	// THIS IS OLD 3pole/24dB code, I may reintegrate it.  Don't need it
 	// right now.   Should be toggled by LB_24_RES_TRICK at the moment.
 
@@ -683,7 +686,11 @@ void lb302Synth::initNote( lb302Note *n)
 
 	if(n->dead ==0){
 		// Swap next two blocks??
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+		vcf.loadRelaxed()->playNote();
+#else
 		vcf.load()->playNote();
+#endif
 		// Ensure envelope is recalculated
 		vcf_envpos = ENVINC;
 

--- a/plugins/sf2_player/patches_dialog.h
+++ b/plugins/sf2_player/patches_dialog.h
@@ -43,7 +43,7 @@ class patchesDialog : public QDialog, private Ui::patchesDialog
 public:
 
 	// Constructor.
-	patchesDialog(QWidget *pParent = 0, Qt::WindowFlags wflags = 0);
+	patchesDialog(QWidget *pParent = 0, Qt::WindowFlags wflags = QFlag(0));
 
 	// Destructor.
 	virtual ~patchesDialog();

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -144,7 +144,12 @@ void PluginFactory::discoverPlugins()
 	QSet<QFileInfo> files;
 	for (const QString& searchPath : QDir::searchPaths("plugins"))
 	{
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+		auto discoveredPluginList = QDir(searchPath).entryInfoList(nameFilters);
+		files.unite(QSet<QFileInfo>(discoveredPluginList.begin(), discoveredPluginList.end()));
+#else
 		files.unite(QDir(searchPath).entryInfoList(nameFilters).toSet());
+#endif
 	}
 
 	// Cheap dependency handling: zynaddsubfx needs ZynAddSubFxCore. By loading

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1203,7 +1203,11 @@ void Song::loadProject( const QString & fileName )
 		}
 		else
 		{
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+			QTextStream(stderr) << Engine::getSong()->errorSummary() << Qt::endl;
+#else
 			QTextStream(stderr) << Engine::getSong()->errorSummary() << endl;
+#endif
 		}
 	}
 

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -30,7 +30,9 @@
 
 #ifdef LMMS_HAVE_OGGVORBIS
 
-
+#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
+#include <QRandomGenerator>
+#endif
 #include <string>
 #include <vorbis/vorbisenc.h>
 
@@ -136,8 +138,13 @@ bool AudioFileOgg::startEncoding()
 
 	// We give our ogg file a random serial number and avoid
 	// 0 and UINT32_MAX which can get you into trouble.
-	qsrand( time( 0 ) );
+#if (QT_VERSION >= QT_VERSION_CHECK(5,10,0))
+	QRandomGenerator::global()->seed(time(0));
+	m_serialNo = 0xD0000000 + QRandomGenerator::global()->generate() % 0x0FFFFFFF;
+#else
+	qsrand(time(0));
 	m_serialNo = 0xD0000000 + qrand() % 0x0FFFFFFF;
+#endif
 	ogg_stream_init( &m_os, m_serialNo );
 
 	// Now, build the three header packets and send through to the stream

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -1301,7 +1301,7 @@ void SetupDialog::openGIGDir()
 {
 	QString new_dir = FileDialog::getExistingDirectory(this,
 		tr("Choose your GIG directory"), m_gigDir);
-	if(new_dir != QString::null)
+	if(!new_dir.isEmpty())
 	{
 		m_gigDirLineEdit->setText(new_dir);
 	}
@@ -1318,7 +1318,7 @@ void SetupDialog::openThemeDir()
 {
 	QString new_dir = FileDialog::getExistingDirectory(this,
 		tr("Choose your theme directory"), m_themeDir);
-	if(new_dir != QString::null)
+	if(!new_dir.isEmpty())
 	{
 		m_themeDirLineEdit->setText(new_dir);
 	}
@@ -1353,7 +1353,7 @@ void SetupDialog::openBackgroundPicFile()
 	QString new_file = FileDialog::getOpenFileName(this,
 		tr("Choose your background picture"), dir, "Picture files (" + fileTypes + ")");
 
-	if(new_file != QString::null)
+	if(!new_file.isEmpty())
 	{
 		m_backgroundPicFileLineEdit->setText(new_file);
 	}

--- a/src/gui/dialogs/FileDialog.cpp
+++ b/src/gui/dialogs/FileDialog.cpp
@@ -84,11 +84,9 @@ QString FileDialog::getOpenFileName(QWidget *parent,
 									const QString &caption,
 									const QString &directory,
 									const QString &filter,
-									QString *selectedFilter,
-									QFileDialog::Options options)
+									QString *selectedFilter)
 {
 	FileDialog dialog(parent, caption, directory, filter);
-	dialog.setOptions(dialog.options() | options);
 	if (selectedFilter && !selectedFilter->isEmpty())
 		dialog.selectNameFilter(*selectedFilter);
 	if (dialog.exec() == QDialog::Accepted) {

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -31,6 +31,7 @@
 #include <QGroupBox>
 #include <QLabel>
 
+#include "DeprecationHelper.h"
 #include "VersionedSaveDialog.h"
 #include "LedCheckbox.h"
 
@@ -50,8 +51,8 @@ VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 	plusButton->setToolTip( tr( "Increment version number" ) );
 	QPushButton *minusButton( new QPushButton( "-", this ) );
 	minusButton->setToolTip( tr( "Decrement version number" ) );
-	plusButton->setFixedWidth( plusButton->fontMetrics().width( "+" ) + 30 );
-	minusButton->setFixedWidth( minusButton->fontMetrics().width( "+" ) + 30 );
+	plusButton->setFixedWidth(horizontalAdvance(plusButton->fontMetrics(), "+") + 30);
+	minusButton->setFixedWidth(horizontalAdvance(minusButton->fontMetrics(), "+") + 30);
 
 	// Add buttons to grid layout. For doing this, remove the lineEdit and
 	// replace it with a HBox containing lineEdit and the buttons.

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -45,21 +45,22 @@
 #endif
 
 #include "ActionGroup.h"
-#include "SongEditor.h"
-#include "MainWindow.h"
+#include "BBTrackContainer.h"
+#include "ComboBox.h"
+#include "debug.h"
+#include "DeprecationHelper.h"
 #include "GuiApplication.h"
+#include "MainWindow.h"
 #include "embed.h"
 #include "Engine.h"
 #include "gui_templates.h"
+#include "PianoRoll.h"
+#include "ProjectJournal.h"
+#include "SongEditor.h"
+#include "StringPairDrag.h"
+#include "TextFloat.h"
 #include "TimeLineWidget.h"
 #include "ToolTip.h"
-#include "TextFloat.h"
-#include "ComboBox.h"
-#include "BBTrackContainer.h"
-#include "PianoRoll.h"
-#include "debug.h"
-#include "StringPairDrag.h"
-#include "ProjectJournal.h"
 
 
 QPixmap * AutomationEditor::s_toolDraw = NULL;
@@ -1654,11 +1655,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::ShiftModifier )
 	{
 		int y = m_zoomingYModel.value();
-		if( we->angleDelta().y() > 0 )
+		if(we->angleDelta().y() > 0)
 		{
 			y++;
 		}
-		else if( we->angleDelta().y() < 0 )
+		else if(we->angleDelta().y() < 0)
 		{
 			y--;
 		}
@@ -1668,11 +1669,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::AltModifier )
 	{
 		int q = m_quantizeModel.value();
-		if( (we->angleDelta().x() + we->angleDelta().y()) > 0 ) // alt + scroll becomes horizontal scroll on KDE
+		if((we->angleDelta().x() + we->angleDelta().y()) > 0) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q--;
 		}
-		else if( (we->angleDelta().x() + we->angleDelta().y()) < 0 ) // alt + scroll becomes horizontal scroll on KDE
+		else if((we->angleDelta().x() + we->angleDelta().y()) < 0) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q++;
 		}
@@ -1683,17 +1684,17 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
 		int x = m_zoomingXModel.value();
-		if( we->angleDelta().y() > 0 )
+		if(we->angleDelta().y() > 0)
 		{
 			x++;
 		}
-		else if( we->angleDelta().y() < 0 )
+		else if(we->angleDelta().y() < 0)
 		{
 			x--;
 		}
 		x = qBound( 0, x, m_zoomingXModel.size() - 1 );
 
-		int mouseX = (we->position().x() - VALUES_WIDTH)* MidiTime::ticksPerBar();
+		int mouseX = (position( we ).x() - VALUES_WIDTH)* MidiTime::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = mouseX / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -1707,20 +1708,20 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
+	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().x() * 2 / 15);
 	}
-	else if( we->modifiers() & Qt::ShiftModifier )
+	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().y() * 2 / 15);
 	}
 	else
 	{
-		m_topBottomScroll->setValue( m_topBottomScroll->value() -
-							(we->angleDelta().x() + we->angleDelta().y()) / 30 );
+		m_topBottomScroll->setValue(m_topBottomScroll->value() -
+							(we->angleDelta().x() + we->angleDelta().y()) / 30);
 	}
 }
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1654,11 +1654,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::ShiftModifier )
 	{
 		int y = m_zoomingYModel.value();
-		if( we->delta() > 0 )
+		if( we->angleDelta().y() > 0 )
 		{
 			y++;
 		}
-		else if( we->delta() < 0 )
+		else if( we->angleDelta().y() < 0 )
 		{
 			y--;
 		}
@@ -1668,11 +1668,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::AltModifier )
 	{
 		int q = m_quantizeModel.value();
-		if( we->delta() > 0 )
+		if( (we->angleDelta().x() + we->angleDelta().y()) > 0 ) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q--;
 		}
-		else if( we->delta() < 0 )
+		else if( (we->angleDelta().x() + we->angleDelta().y()) < 0 ) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q++;
 		}
@@ -1683,17 +1683,17 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
 		int x = m_zoomingXModel.value();
-		if( we->delta() > 0 )
+		if( we->angleDelta().y() > 0 )
 		{
 			x++;
 		}
-		else if( we->delta() < 0 )
+		else if( we->angleDelta().y() < 0 )
 		{
 			x--;
 		}
 		x = qBound( 0, x, m_zoomingXModel.size() - 1 );
 
-		int mouseX = (we->x() - VALUES_WIDTH)* MidiTime::ticksPerBar();
+		int mouseX = (we->position().x() - VALUES_WIDTH)* MidiTime::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = mouseX / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -1705,16 +1705,22 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 
 		m_zoomingXModel.setValue( x );
 	}
-	else if( we->modifiers() & Qt::ShiftModifier
-			|| we->orientation() == Qt::Horizontal )
+
+	// FIXME: Reconsider if determining orientation is necessary in Qt6.
+	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->delta() * 2 / 15 );
+							we->angleDelta().x() * 2 / 15 );
+	}
+	else if( we->modifiers() & Qt::ShiftModifier )
+	{
+		m_leftRightScroll->setValue( m_leftRightScroll->value() -
+							we->angleDelta().y() * 2 / 15 );
 	}
 	else
 	{
 		m_topBottomScroll->setValue( m_topBottomScroll->value() -
-							we->delta() / 30 );
+							(we->angleDelta().x() + we->angleDelta().y()) / 30 );
 	}
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -47,11 +47,12 @@
 
 #include "AutomationEditor.h"
 #include "ActionGroup.h"
-#include "ConfigManager.h"
 #include "BBTrackContainer.h"
 #include "Clipboard.h"
 #include "ComboBox.h"
+#include "ConfigManager.h"
 #include "debug.h"
+#include "DeprecationHelper.h"
 #include "DetuningHelper.h"
 #include "embed.h"
 #include "GuiApplication.h"
@@ -61,9 +62,9 @@
 #include "Pattern.h"
 #include "SongEditor.h"
 #include "stdshims.h"
+#include "StepRecorderWidget.h"
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
-#include "StepRecorderWidget.h"
 
 
 using std::move;
@@ -3321,13 +3322,13 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 {
 	we->accept();
 	// handle wheel events for note edit area - for editing note vol/pan with mousewheel
-	if( we->position().x() > noteEditLeft() && we->position().x() < noteEditRight()
-	&& we->position().y() > noteEditTop() && we->position().y() < noteEditBottom() )
+	if(position(we).x() > noteEditLeft() && position(we).x() < noteEditRight()
+	&& position(we).y() > noteEditTop() && position(we).y() < noteEditBottom())
 	{
 		if (!hasValidPattern()) {return;}
 		// get values for going through notes
 		int pixel_range = 8;
-		int x = we->position().x() - m_whiteKeyWidth;
+		int x = position(we).x() - m_whiteKeyWidth;
 		int ticks_start = ( x - pixel_range / 2 ) *
 					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
 		int ticks_end = ( x + pixel_range / 2 ) *
@@ -3363,7 +3364,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 				{
 					// show the volume hover-text only if all notes have the
 					// same volume
-					showVolTextFloat( nv[0]->getVolume(), we->pos(), 1000 );
+					showVolTextFloat(nv[0]->getVolume(), position(we), 1000);
 				}
 			}
 			else if( m_noteEditMode == NoteEditPanning )
@@ -3382,7 +3383,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 				{
 					// show the pan hover-text only if all notes have the same
 					// panning
-					showPanTextFloat( nv[0]->getPanning(), we->pos(), 1000 );
+					showPanTextFloat( nv[0]->getPanning(), position( we ), 1000 );
 				}
 			}
 			update();
@@ -3394,11 +3395,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::AltModifier )
 	{
 		int q = m_quantizeModel.value();
-		if( (we->angleDelta().x() + we->angleDelta().y()) > 0 ) // alt + scroll becomes horizontal scroll on KDE
+		if((we->angleDelta().x() + we->angleDelta().y()) > 0) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q--;
 		}
-		else if( (we->angleDelta().x() + we->angleDelta().y()) < 0 ) // alt + scroll becomes horizontal scroll on KDE
+		else if((we->angleDelta().x() + we->angleDelta().y()) < 0) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q++;
 		}
@@ -3408,11 +3409,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::ShiftModifier )
 	{
 		int l = m_noteLenModel.value();
-		if( we->angleDelta().y() > 0 )
+		if(we->angleDelta().y() > 0)
 		{
 			l--;
 		}
-		else if( we->angleDelta().y() < 0 )
+		else if(we->angleDelta().y() < 0)
 		{
 			l++;
 		}
@@ -3422,17 +3423,17 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
 		int z = m_zoomingModel.value();
-		if( we->angleDelta().y() > 0 )
+		if(we->angleDelta().y() > 0)
 		{
 			z++;
 		}
-		else if( we->angleDelta().y() < 0 )
+		else if(we->angleDelta().y() < 0)
 		{
 			z--;
 		}
 		z = qBound( 0, z, m_zoomingModel.size() - 1 );
 
-		int x = (we->position().x() - m_whiteKeyWidth)* MidiTime::ticksPerBar();
+		int x = (position(we).x() - m_whiteKeyWidth) * MidiTime::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = x / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -3444,20 +3445,20 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
+	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().x() * 2 / 15);
 	}
-	else if( we->modifiers() & Qt::ShiftModifier )
+	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().y() * 2 / 15);
 	}
 	else
 	{
-		m_topBottomScroll->setValue( m_topBottomScroll->value() -
-							we->angleDelta().y() / 30 );
+		m_topBottomScroll->setValue(m_topBottomScroll->value() -
+							we->angleDelta().y() / 30);
 	}
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3321,13 +3321,13 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 {
 	we->accept();
 	// handle wheel events for note edit area - for editing note vol/pan with mousewheel
-	if( we->x() > noteEditLeft() && we->x() < noteEditRight()
-	&& we->y() > noteEditTop() && we->y() < noteEditBottom() )
+	if( we->position().x() > noteEditLeft() && we->position().x() < noteEditRight()
+	&& we->position().y() > noteEditTop() && we->position().y() < noteEditBottom() )
 	{
 		if (!hasValidPattern()) {return;}
 		// get values for going through notes
 		int pixel_range = 8;
-		int x = we->x() - m_whiteKeyWidth;
+		int x = we->position().x() - m_whiteKeyWidth;
 		int ticks_start = ( x - pixel_range / 2 ) *
 					MidiTime::ticksPerBar() / m_ppb + m_currentPosition;
 		int ticks_end = ( x + pixel_range / 2 ) *
@@ -3346,7 +3346,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		}
 		if( nv.size() > 0 )
 		{
-			const int step = we->delta() > 0 ? 1 : -1;
+			const int step = we->angleDelta().y() > 0 ? 1 : -1;
 			if( m_noteEditMode == NoteEditVolume )
 			{
 				for ( Note * n : nv )
@@ -3394,11 +3394,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::AltModifier )
 	{
 		int q = m_quantizeModel.value();
-		if( we->delta() > 0 )
+		if( (we->angleDelta().x() + we->angleDelta().y()) > 0 ) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q--;
 		}
-		else if( we->delta() < 0 )
+		else if( (we->angleDelta().x() + we->angleDelta().y()) < 0 ) // alt + scroll becomes horizontal scroll on KDE
 		{
 			q++;
 		}
@@ -3408,11 +3408,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::ShiftModifier )
 	{
 		int l = m_noteLenModel.value();
-		if( we->delta() > 0 )
+		if( we->angleDelta().y() > 0 )
 		{
 			l--;
 		}
-		else if( we->delta() < 0 )
+		else if( we->angleDelta().y() < 0 )
 		{
 			l++;
 		}
@@ -3422,17 +3422,17 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
 		int z = m_zoomingModel.value();
-		if( we->delta() > 0 )
+		if( we->angleDelta().y() > 0 )
 		{
 			z++;
 		}
-		else if( we->delta() < 0 )
+		else if( we->angleDelta().y() < 0 )
 		{
 			z--;
 		}
 		z = qBound( 0, z, m_zoomingModel.size() - 1 );
 
-		int x = (we->x() - m_whiteKeyWidth)* MidiTime::ticksPerBar();
+		int x = (we->position().x() - m_whiteKeyWidth)* MidiTime::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = x / m_ppb;
 		// what would be the ticks in the new zoom level on the very same mouse x
@@ -3442,16 +3442,22 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		// update combobox with zooming-factor
 		m_zoomingModel.setValue( z );
 	}
-	else if( we->modifiers() & Qt::ShiftModifier
-			 || we->orientation() == Qt::Horizontal )
+
+	// FIXME: Reconsider if determining orientation is necessary in Qt6.
+	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->delta() * 2 / 15 );
+							we->angleDelta().x() * 2 / 15 );
+	}
+	else if( we->modifiers() & Qt::ShiftModifier )
+	{
+		m_leftRightScroll->setValue( m_leftRightScroll->value() -
+							we->angleDelta().y() * 2 / 15 );
 	}
 	else
 	{
 		m_topBottomScroll->setValue( m_topBottomScroll->value() -
-							we->delta() / 30 );
+							we->angleDelta().y() / 30 );
 	}
 }
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -527,18 +527,18 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	{
 		int z = m_zoomingModel->value();
 
-		if( we->delta() > 0 )
+		if( we->angleDelta().y() > 0 )
 		{
 			z++;
 		}
-		else if( we->delta() < 0 )
+		else if( we->angleDelta().y() < 0 )
 		{
 			z--;
 		}
 		z = qBound( 0, z, m_zoomingModel->size() - 1 );
 
 
-		int x = we->x() - m_trackHeadWidth;
+		int x = we->position().x() - m_trackHeadWidth;
 		// bar based on the mouse x-position where the scroll wheel was used
 		int bar = x / pixelsPerBar();
 		// what would be the bar in the new zoom level on the very same mouse x
@@ -555,10 +555,17 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 		// and make sure, all TCO's are resized and relocated
 		realignTracks();
 	}
-	else if( we->modifiers() & Qt::ShiftModifier || we->orientation() == Qt::Horizontal )
+
+	// FIXME: Reconsider if determining orientation is necessary in Qt6.
+	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->delta() / 30 );
+							we->angleDelta().x() /30 );
+	}
+	else if( we->modifiers() & Qt::ShiftModifier )
+	{
+		m_leftRightScroll->setValue( m_leftRightScroll->value() -
+							we->angleDelta().y() / 30 );
 	}
 	else
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -24,7 +24,6 @@
 
 #include "SongEditor.h"
 
-#include <QTimeLine>
 #include <QAction>
 #include <QKeyEvent>
 #include <QLabel>
@@ -32,24 +31,26 @@
 #include <QMdiArea>
 #include <QMdiSubWindow>
 #include <QPainter>
+#include <QTimeLine>
 
+#include "AudioDevice.h"
 #include "AutomatableSlider.h"
 #include "ComboBox.h"
 #include "ConfigManager.h"
 #include "CPULoadWidget.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
 #include "GuiApplication.h"
 #include "LcdSpinBox.h"
 #include "MainWindow.h"
 #include "MeterDialog.h"
 #include "Mixer.h"
+#include "Oscilloscope.h"
+#include "PianoRoll.h"
 #include "TextFloat.h"
+#include "TimeDisplayWidget.h"
 #include "TimeLineWidget.h"
 #include "ToolTip.h"
-#include "Oscilloscope.h"
-#include "TimeDisplayWidget.h"
-#include "AudioDevice.h"
-#include "PianoRoll.h"
 #include "Track.h"
 
 const QVector<double> SongEditor::m_zoomLevels =
@@ -527,18 +528,18 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	{
 		int z = m_zoomingModel->value();
 
-		if( we->angleDelta().y() > 0 )
+		if(we->angleDelta().y() > 0)
 		{
 			z++;
 		}
-		else if( we->angleDelta().y() < 0 )
+		else if(we->angleDelta().y() < 0)
 		{
 			z--;
 		}
 		z = qBound( 0, z, m_zoomingModel->size() - 1 );
 
 
-		int x = we->position().x() - m_trackHeadWidth;
+		int x = position(we).x() - m_trackHeadWidth;
 		// bar based on the mouse x-position where the scroll wheel was used
 		int bar = x / pixelsPerBar();
 		// what would be the bar in the new zoom level on the very same mouse x
@@ -557,15 +558,15 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if( abs(we->angleDelta().x()) > abs(we->angleDelta().y()) ) // scrolling is horizontal
+	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().x() /30 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().x() /30);
 	}
-	else if( we->modifiers() & Qt::ShiftModifier )
+	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() -
-							we->angleDelta().y() / 30 );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							we->angleDelta().y() / 30);
 	}
 	else
 	{

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -192,7 +192,7 @@ void ComboBox::paintEvent( QPaintEvent * _pe )
 	// Border
 	QStyleOptionFrame opt;
 	opt.initFrom( this );
-	opt.state = 0;
+	opt.state = QStyle::StateFlag::State_None;
 
 	style()->drawPrimitive( QStyle::PE_Frame, &opt, &p, this );
 

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -230,7 +230,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		model()->setInitValue( model()->value() + ( ( event->angleDelta().y() < 0 ) ? 1 : -1 ) );
+		model()->setInitValue(model()->value() + ((event->angleDelta().y() < 0) ? 1 : -1));
 		update();
 		event->accept();
 	}

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -230,7 +230,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		model()->setInitValue( model()->value() + ( ( event->delta() < 0 ) ? 1 : -1 ) );
+		model()->setInitValue( model()->value() + ( ( event->angleDelta().y() < 0 ) ? 1 : -1 ) );
 		update();
 		event->accept();
 	}

--- a/src/gui/widgets/FadeButton.cpp
+++ b/src/gui/widgets/FadeButton.cpp
@@ -110,20 +110,20 @@ void FadeButton::paintEvent(QPaintEvent * _pe)
 {
 	QColor col = m_normalColor;
 
-	if(!m_stateTimer.isNull() && m_stateTimer.elapsed() < FadeDuration)
+	if(m_stateTimer.isValid() && m_stateTimer.elapsed() < FadeDuration)
 	{
 		// The first part of the fade, when a note is triggered.
 		col = fadeToColor(m_activatedColor, m_holdColor, m_stateTimer, FadeDuration);
 		QTimer::singleShot(20, this, SLOT(update()));
 	}
-	else if (!m_stateTimer.isNull()
+	else if (m_stateTimer.isValid()
 		&& m_stateTimer.elapsed() >= FadeDuration
 		&& activeNotes > 0)
 	{
 		// The fade is done, but at least one note is still held.
 		col = m_holdColor;
 	}
-	else if (!m_releaseTimer.isNull() && m_releaseTimer.elapsed() < FadeDuration)
+	else if (m_releaseTimer.isValid() && m_releaseTimer.elapsed() < FadeDuration)
 	{
 		// Last note just ended. Fade to default color.
 		col = fadeToColor(m_holdColor, m_normalColor, m_releaseTimer, FadeDuration);
@@ -149,7 +149,7 @@ void FadeButton::paintEvent(QPaintEvent * _pe)
 }
 
 
-QColor FadeButton::fadeToColor(QColor startCol, QColor endCol, QTime timer, float duration)
+QColor FadeButton::fadeToColor(QColor startCol, QColor endCol, QElapsedTimer timer, float duration)
 {
 	QColor col;
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -265,7 +265,7 @@ void Fader::wheelEvent ( QWheelEvent *ev )
 {
 	ev->accept();
 
-	if ( ev->angleDelta().y() > 0 )
+	if (ev->angleDelta().y() > 0)
 	{
 		model()->incValue( 1 );
 	}
@@ -282,7 +282,7 @@ void Fader::wheelEvent ( QWheelEvent *ev )
 ///
 /// Set peak value (0.0 .. 1.0)
 ///
-void Fader::setPeak( float fPeak, float &targetPeak, float &persistentPeak, QTime &lastPeakTime )
+void Fader::setPeak( float fPeak, float &targetPeak, float &persistentPeak, QElapsedTimer &lastPeakTimer )
 {
 	if( fPeak <  m_fMinPeak )
 	{
@@ -299,12 +299,12 @@ void Fader::setPeak( float fPeak, float &targetPeak, float &persistentPeak, QTim
 		if( targetPeak >= persistentPeak )
 		{
 			persistentPeak = targetPeak;
-			lastPeakTime.restart();
+			lastPeakTimer.restart();
 		}
 		update();
 	}
 
-	if( persistentPeak > 0 && lastPeakTime.elapsed() > 1500 )
+	if( persistentPeak > 0 && lastPeakTimer.elapsed() > 1500 )
 	{
 		persistentPeak = qMax<float>( 0, persistentPeak-0.05 );
 		update();
@@ -315,14 +315,14 @@ void Fader::setPeak( float fPeak, float &targetPeak, float &persistentPeak, QTim
 
 void Fader::setPeak_L( float fPeak )
 {
-	setPeak( fPeak, m_fPeakValue_L, m_persistentPeak_L, m_lastPeakTime_L );
+	setPeak( fPeak, m_fPeakValue_L, m_persistentPeak_L, m_lastPeakTimer_L );
 }
 
 
 
 void Fader::setPeak_R( float fPeak )
 {
-	setPeak( fPeak, m_fPeakValue_R, m_persistentPeak_R, m_lastPeakTime_R );
+	setPeak( fPeak, m_fPeakValue_R, m_persistentPeak_R, m_lastPeakTimer_R );
 }
 
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -265,7 +265,7 @@ void Fader::wheelEvent ( QWheelEvent *ev )
 {
 	ev->accept();
 
-	if ( ev->delta() > 0 )
+	if ( ev->angleDelta().y() > 0 )
 	{
 		model()->incValue( 1 );
 	}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -38,6 +38,7 @@
 #include "CaptionMenu.h"
 #include "ConfigManager.h"
 #include "ControllerConnection.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"
 #include "GuiApplication.h"
@@ -168,9 +169,9 @@ void Knob::setLabel( const QString & txt )
 	m_label = txt;
 	if( m_knobPixmap )
 	{
-		setFixedSize( qMax<int>( m_knobPixmap->width(),
-					QFontMetrics( pointSizeF( font(), 6.5) ).width( m_label ) ),
-						m_knobPixmap->height() + 10 );
+		setFixedSize(qMax<int>( m_knobPixmap->width(),
+					horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)),
+						m_knobPixmap->height() + 10);
 	}
 	update();
 }
@@ -682,20 +683,20 @@ void Knob::paintEvent( QPaintEvent * _me )
 			p.fontMetrics().width( m_label ) / 2 + 1,
 				height() - 1, m_label );*/
 		p.setPen( textColor() );
-		p.drawText( width() / 2 -
-				p.fontMetrics().width( m_label ) / 2,
-				height() - 2, m_label );
+		p.drawText(width() / 2 -
+				horizontalAdvance(p.fontMetrics(), m_label) / 2,
+				height() - 2, m_label);
 	}
 }
 
 
 
 
-void Knob::wheelEvent( QWheelEvent * _we )
+void Knob::wheelEvent(QWheelEvent * we)
 {
-	_we->accept();
+	we->accept();
 	const float stepMult = model()->range() / 2000 / model()->step<float>();
-	const int inc = ( ( _we->angleDelta().y() > 0 ) ? 1 : -1 ) * ( ( stepMult < 1 ) ? 1 : stepMult );
+	const int inc = ((we->angleDelta().y() > 0 ) ? 1 : -1) * ((stepMult < 1 ) ? 1 : stepMult);
 	model()->incValue( inc );
 
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -695,7 +695,7 @@ void Knob::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
 	const float stepMult = model()->range() / 2000 / model()->step<float>();
-	const int inc = ( ( _we->delta() > 0 ) ? 1 : -1 ) * ( ( stepMult < 1 ) ? 1 : stepMult );
+	const int inc = ( ( _we->angleDelta().y() > 0 ) ? 1 : -1 ) * ( ( stepMult < 1 ) ? 1 : stepMult );
 	model()->incValue( inc );
 
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -149,11 +149,10 @@ void LcdSpinBox::mouseReleaseEvent( QMouseEvent* )
 
 
 
-void LcdSpinBox::wheelEvent( QWheelEvent * _we )
+void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
-	_we->accept();
-	model()->setInitValue( model()->value() +
-			( ( _we->angleDelta().y() > 0 ) ? 1 : -1 ) * model()->step<int>() );
+	we->accept();
+	model()->setInitValue(model()->value() + ((we->angleDelta().y() > 0) ? 1 : -1) * model()->step<int>());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -153,7 +153,7 @@ void LcdSpinBox::wheelEvent( QWheelEvent * _we )
 {
 	_we->accept();
 	model()->setInitValue( model()->value() +
-			( ( _we->delta() > 0 ) ? 1 : -1 ) * model()->step<int>() );
+			( ( _we->angleDelta().y() > 0 ) ? 1 : -1 ) * model()->step<int>() );
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -32,6 +32,7 @@
 #include <QStyleOptionFrameV2>
 
 #include "LcdWidget.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
@@ -199,13 +200,13 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	{
 		p.setFont( pointSizeF( p.font(), 6.5 ) );
 		p.setPen( textShadowColor() );
-		p.drawText( width() / 2 -
-				p.fontMetrics().width( m_label ) / 2 + 1,
-						height(), m_label );
+		p.drawText(width() / 2 -
+				horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1,
+						height(), m_label);
 		p.setPen( textColor() );
-		p.drawText( width() / 2 -
-				p.fontMetrics().width( m_label ) / 2,
-						height() - 1, m_label );
+		p.drawText(width() / 2 -
+				horizontalAdvance(p.fontMetrics(), m_label) / 2,
+						height() - 1, m_label);
 	}
 
 }
@@ -240,10 +241,10 @@ void LcdWidget::updateSize()
 				m_cellHeight + (2*margin) );
 	}
 	else {
-		setFixedSize( qMax<int>(
+		setFixedSize(qMax<int>(
 				m_cellWidth * m_numDigits + 2*(margin+m_marginWidth),
-				QFontMetrics( pointSizeF( font(), 6.5 ) ).width( m_label ) ),
-				m_cellHeight + (2*margin) + 9 );
+				horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)),
+				m_cellHeight + (2*margin) + 9);
 	}
 
 	update();

--- a/src/gui/widgets/LedCheckbox.cpp
+++ b/src/gui/widgets/LedCheckbox.cpp
@@ -27,6 +27,7 @@
 #include <QPainter>
 
 #include "LedCheckbox.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"
 
@@ -120,7 +121,9 @@ void LedCheckBox::initUi( LedColors _color )
 
 void LedCheckBox::onTextUpdated()
 {
-	setFixedSize( m_ledOffPixmap->width() + 5 + QFontMetrics( font() ).width( text() ), m_ledOffPixmap->height() );
+	setFixedSize(m_ledOffPixmap->width() + 5 + horizontalAdvance(QFontMetrics(font()),
+				text()),
+				m_ledOffPixmap->height());
 }
 
 

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -288,13 +288,13 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 // Switch between tabs with mouse wheel
 void TabWidget::wheelEvent( QWheelEvent * we )
 {
-	if( we->y() > m_tabheight )
+	if( we->position().y() > m_tabheight )
 	{
 		return;
 	}
 
 	we->accept();
-	int dir = ( we->delta() < 0 ) ? 1 : -1;
+	int dir = ( we->angleDelta().y() < 0 ) ? 1 : -1;
 	int tab = m_activeTab;
 	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
 	{

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -31,8 +31,9 @@
 #include <QToolTip>
 #include <QWheelEvent>
 
-#include "gui_templates.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
+#include "gui_templates.h"
 
 TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 					 bool resizable) :
@@ -76,7 +77,7 @@ void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, i
 	}
 
 	// Tab's width when it is a text tab. This isn't correct for artwork tabs, but it's fixed later during the PaintEvent
-	int tab_width = fontMetrics().width( name ) + 10;
+	int tab_width = horizontalAdvance(fontMetrics(), name) + 10;
 
 	// Register new tab
 	widgetDesc d = { w, pixmap, name, tab_width };
@@ -125,7 +126,7 @@ int TabWidget::findTabAtPos( const QPoint *pos )
 
 	if( pos->y() > 1 && pos->y() < m_tabbarHeight - 1 )
 	{
-		int cx = ( ( m_caption == "" ) ? 4 : 14 ) + fontMetrics().width( m_caption );
+		int cx = ((m_caption == "") ? 4 : 14) + horizontalAdvance(fontMetrics(), m_caption);
 
 		for( widgetStack::iterator it = m_widgets.begin(); it != m_widgets.end(); ++it )
 		{
@@ -232,7 +233,7 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 	}
 
 	// Calculate the tabs' x (tabs are painted next to the caption)
-	int tab_x_offset = m_caption.isEmpty() ? 4 : 14 + fontMetrics().width( m_caption );
+	int tab_x_offset = m_caption.isEmpty() ? 4 : 14 + horizontalAdvance(fontMetrics(), m_caption);
 
 	// Compute tabs' width depending on the number of tabs (only applicable for artwork tabs)
 	widgetStack::iterator first = m_widgets.begin();
@@ -288,13 +289,13 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 // Switch between tabs with mouse wheel
 void TabWidget::wheelEvent( QWheelEvent * we )
 {
-	if( we->position().y() > m_tabheight )
+	if(position(we).y() > m_tabheight)
 	{
 		return;
 	}
 
 	we->accept();
-	int dir = ( we->angleDelta().y() < 0 ) ? 1 : -1;
+	int dir = (we->angleDelta().y() < 0) ? 1 : -1;
 	int tab = m_activeTab;
 	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
 	{

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -786,11 +786,11 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 {
 	if( m_pat->m_patternType == Pattern::BeatPattern &&
 				( fixedTCOs() || pixelsPerBar() >= 96 ) &&
-				_we->y() > height() - s_stepBtnOff->height() )
+				_we->position().y() > height() - s_stepBtnOff->height() )
 	{
 //	get the step number that was wheeled on and
 //	do calculations in floats to prevent rounding errors...
-		float tmp = ( ( float(_we->x()) - TCO_BORDER_WIDTH ) *
+		float tmp = ( ( float(_we->position().x()) - TCO_BORDER_WIDTH ) *
 				float( m_pat -> m_steps ) ) / float(width() - TCO_BORDER_WIDTH*2);
 
 		int step = int( tmp );
@@ -801,7 +801,7 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 		}
 
 		Note * n = m_pat->noteAtStep( step );
-		if( !n && _we->delta() > 0 )
+		if( !n && _we->angleDelta().y() > 0 )
 		{
 			n = m_pat->addStepNote( step );
 			n->setVolume( 0 );
@@ -810,7 +810,7 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 		{
 			int vol = n->getVolume();
 
-			if( _we->delta() > 0 )
+			if( _we->angleDelta().y() > 0 )
 			{
 				n->setVolume( qMin( 100, vol + 5 ) );
 			}

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -24,23 +24,21 @@
  */
 #include "Pattern.h"
 
+#include <QApplication>
 #include <QTimer>
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPushButton>
 
-#include "InstrumentTrack.h"
-#include "gui_templates.h"
-#include "embed.h"
-#include "GuiApplication.h"
-#include "PianoRoll.h"
-#include "RenameDialog.h"
-#include "SampleBuffer.h"
 #include "AudioSampleRecorder.h"
 #include "BBTrackContainer.h"
-#include "StringPairDrag.h"
-#include "MainWindow.h"
+#include "DeprecationHelper.h"
+#include "embed.h"
+#include "GuiApplication.h"
+#include "InstrumentTrack.h"
+#include "PianoRoll.h"
+#include "RenameDialog.h"
 
 #include <limits>
 
@@ -782,16 +780,16 @@ void PatternView::mouseDoubleClickEvent(QMouseEvent *_me)
 
 
 
-void PatternView::wheelEvent( QWheelEvent * _we )
+void PatternView::wheelEvent(QWheelEvent * we)
 {
-	if( m_pat->m_patternType == Pattern::BeatPattern &&
-				( fixedTCOs() || pixelsPerBar() >= 96 ) &&
-				_we->position().y() > height() - s_stepBtnOff->height() )
+	if(m_pat->m_patternType == Pattern::BeatPattern &&
+				(fixedTCOs() || pixelsPerBar() >= 96) &&
+				position(we).y() > height() - s_stepBtnOff->height())
 	{
 //	get the step number that was wheeled on and
 //	do calculations in floats to prevent rounding errors...
-		float tmp = ( ( float(_we->position().x()) - TCO_BORDER_WIDTH ) *
-				float( m_pat -> m_steps ) ) / float(width() - TCO_BORDER_WIDTH*2);
+		float tmp = ((float(position(we).x()) - TCO_BORDER_WIDTH) *
+				float(m_pat -> m_steps)) / float(width() - TCO_BORDER_WIDTH*2);
 
 		int step = int( tmp );
 
@@ -801,7 +799,7 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 		}
 
 		Note * n = m_pat->noteAtStep( step );
-		if( !n && _we->angleDelta().y() > 0 )
+		if(!n && we->angleDelta().y() > 0)
 		{
 			n = m_pat->addStepNote( step );
 			n->setVolume( 0 );
@@ -810,7 +808,7 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 		{
 			int vol = n->getVolume();
 
-			if( _we->angleDelta().y() > 0 )
+			if(we->angleDelta().y() > 0)
 			{
 				n->setVolume( qMin( 100, vol + 5 ) );
 			}
@@ -826,11 +824,11 @@ void PatternView::wheelEvent( QWheelEvent * _we )
 				gui->pianoRoll()->update();
 			}
 		}
-		_we->accept();
+		we->accept();
 	}
 	else
 	{
-		TrackContentObjectView::wheelEvent( _we );
+		TrackContentObjectView::wheelEvent(we);
 	}
 }
 


### PR DESCRIPTION
Fix Qt deprecation warnings

- Replace QWheelEvent::delta with angleDelta
- Replace QWheelEvent::orientation with comparison of angleDelta.x and y

- Remove Qt::WindowFlags parameters when adding SubWindows
- Remove QFileDialog::Options parameters when opening files
These parameters are currently not used anywhere.

- Use QFlag(0) when initializing items in ladspaPortDialog instead of 0
- Use explicit enum when specifying QStyle state in ComboBox's paintEvent

- Use QElapsedTimer instead of QTime where appropriate
- Use QAtomicPointer::loadRelaxed() instead of load()
- Use QSet<T>(list.begin(), list.end()) instead of list.toSet()
- Use Qt::endl in QTextStream
- Use QString::isEmpty() instead of comparing to QString::null
- Use QFontMetrics::horizontalAdvance instead of width
- Use QWheelEvent::position() instead of pos()