### PR TITLE
Fix for Icons and comboboxes mismatch in arpeggiator in Instrument Editor #5494

### DIFF
--- a/include/ComboBox.h
+++ b/include/ComboBox.h
@@ -49,7 +49,7 @@ public:
 		return castModel<ComboBoxModel>();
 	}
 
-	static const int DEFAULT_HEIGHT = 22;
+	static constexpr int DEFAULT_HEIGHT = 22;
 
 public slots:
 	void selectNext();

--- a/include/ComboBox.h
+++ b/include/ComboBox.h
@@ -32,8 +32,6 @@
 #include "ComboBoxModel.h"
 #include "AutomatableModelView.h"
 
-
-
 class LMMS_EXPORT ComboBox : public QWidget, public IntModelView
 {
 	Q_OBJECT
@@ -50,6 +48,8 @@ public:
 	{
 		return castModel<ComboBoxModel>();
 	}
+
+	static const int DEFAULT_HEIGHT = 22;
 
 public slots:
 	void selectNext();

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -75,12 +75,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	ToolTip::add( enabled2Toggle, tr( "Enable/disable filter 2" ) );
 
 	ComboBox * m_filter1ComboBox = new ComboBox( this );
-	m_filter1ComboBox->setGeometry( 19, 70, 137, 22 );
+	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	ComboBox * m_filter2ComboBox = new ComboBox( this );
-	m_filter2ComboBox->setGeometry( 217, 70, 137, 22 );
+	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -151,8 +151,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 	ComboBox *freqRangeCombo = new ComboBox(this, tr("Frequency range"));
 	freqRangeCombo->setToolTip(tr("Frequency range"));
-	freqRangeCombo->setMinimumSize(100, 22);
-	freqRangeCombo->setMaximumSize(200, 22);
+	freqRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
+	freqRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
 	freqRangeCombo->setModel(&controls->m_freqRangeModel);
 	config_layout->addWidget(freqRangeCombo, 0, 3, 2, 1);
 
@@ -171,8 +171,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 	ComboBox *ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
 	ampRangeCombo->setToolTip(tr("Amplitude range"));
-	ampRangeCombo->setMinimumSize(100, 22);
-	ampRangeCombo->setMaximumSize(200, 22);
+	ampRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
+	ampRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
 	ampRangeCombo->setModel(&controls->m_ampRangeModel);
 	config_layout->addWidget(ampRangeCombo, 2, 3, 2, 1);
 
@@ -201,8 +201,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 	ComboBox *windowCombo = new ComboBox(this, tr("FFT window type"));
 	windowCombo->setToolTip(tr("FFT window type"));
-	windowCombo->setMinimumSize(100, 22);
-	windowCombo->setMaximumSize(200, 22);
+	windowCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
+	windowCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
 	windowCombo->setModel(&controls->m_windowModel);
 	config_layout->addWidget(windowCombo, 2, 5, 2, 1);
 	processor->rebuildWindow();

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -541,7 +541,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 
 // interpolation selector
 	m_interpBox = new ComboBox( this );
-	m_interpBox->setGeometry( 142, 62, 82, 22 );
+	m_interpBox->setGeometry( 142, 62, 82, ComboBox::DEFAULT_HEIGHT );
 	m_interpBox->setFont( pointSize<8>( m_interpBox->font() ) );
 
 // wavegraph

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -1664,7 +1664,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_osc2VolKnob -> setVolumeKnob( true );
 
 	m_osc2WaveBox = new ComboBox( view );
-	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, 22 );
+	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_osc2WaveBox->setFont( pointSize<8>( m_osc2WaveBox->font() ) );
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
@@ -1679,18 +1679,18 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_osc3VolKnob -> setVolumeKnob( true );
 
 	m_osc3Wave1Box = new ComboBox( view );
-	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, 22 );
+	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_osc3Wave1Box->setFont( pointSize<8>( m_osc3Wave1Box->font() ) );
 
 	m_osc3Wave2Box = new ComboBox( view );
-	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, 22 );
+	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_osc3Wave2Box->setFont( pointSize<8>( m_osc3Wave2Box->font() ) );
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
-	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, 22 );
+	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo1WaveBox->setFont( pointSize<8>( m_lfo1WaveBox->font() ) );
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
@@ -1698,7 +1698,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	makeknob( m_lfo1PhsKnob, LFOCOL3, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
 
 	m_lfo2WaveBox = new ComboBox( view );
-	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, 22 );
+	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
 
 	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -403,7 +403,7 @@ malletsInstrumentView::malletsInstrumentView( malletsInstrument * _instrument,
 	changePreset(); // Show widget
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
-	m_presetsCombo->setGeometry( 140, 50, 99, 22 );
+	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
 	m_presetsCombo->setFont( pointSize<8>( m_presetsCombo->font() ) );
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -410,14 +410,14 @@ AudioPortAudio::setupWidget::setupWidget( QWidget * _parent ) :
 	AudioDeviceSetupWidget( AudioPortAudio::name(), _parent )
 {
 	m_backend = new ComboBox( this, "BACKEND" );
-	m_backend->setGeometry( 64, 15, 260, 20 );
+	m_backend->setGeometry( 64, 15, 260, ComboBox::DEFAULT_HEIGHT );
 
 	QLabel * backend_lbl = new QLabel( tr( "Backend" ), this );
 	backend_lbl->setFont( pointSize<7>( backend_lbl->font() ) );
 	backend_lbl->move( 8, 18 );
 
 	m_device = new ComboBox( this, "DEVICE" );
-	m_device->setGeometry( 64, 35, 260, 20 );
+	m_device->setGeometry( 64, 35, 260, ComboBox::DEFAULT_HEIGHT );
 
 	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -187,7 +187,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			this, SLOT( userToggled() ) );
 
 	m_userController = new ComboBox( m_userGroupBox, "Controller" );
-	m_userController->setGeometry( 10, 24, 200, 22 );
+	m_userController->setGeometry( 10, 24, 200, ComboBox::DEFAULT_HEIGHT );
 	for (Controller * c : Engine::getSong()->controllers())
 	{
 		m_userController->model()->addItem( c->name() );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2349,7 +2349,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	zoom_x_label->setPixmap( embed::getIconPixmap( "zoom_x" ) );
 
 	m_zoomingXComboBox = new ComboBox( zoomToolBar );
-	m_zoomingXComboBox->setFixedSize( 80, 22 );
+	m_zoomingXComboBox->setFixedSize( 80, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingXComboBox->setToolTip( tr( "Horizontal zooming" ) );
 
 	for( float const & zoomLevel : m_editor->m_zoomXLevels )
@@ -2368,7 +2368,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	zoom_y_label->setPixmap( embed::getIconPixmap( "zoom_y" ) );
 
 	m_zoomingYComboBox = new ComboBox( zoomToolBar );
-	m_zoomingYComboBox->setFixedSize( 80, 22 );
+	m_zoomingYComboBox->setFixedSize( 80, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingYComboBox->setToolTip( tr( "Vertical zooming" ) );
 
 	m_editor->m_zoomingYModel.addItem( "Auto" );
@@ -2398,7 +2398,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	quantize_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
 
 	m_quantizeComboBox = new ComboBox( m_toolBar );
-	m_quantizeComboBox->setFixedSize( 60, 22 );
+	m_quantizeComboBox->setFixedSize( 60, ComboBox::DEFAULT_HEIGHT );
 	m_quantizeComboBox->setToolTip( tr( "Quantization" ) );
 
 	m_quantizeComboBox->setModel( &m_editor->m_quantizeModel );

--- a/src/gui/editors/BBEditor.cpp
+++ b/src/gui/editors/BBEditor.cpp
@@ -75,7 +75,7 @@ BBEditor::BBEditor( BBTrackContainer* tc ) :
 	DropToolBar *beatSelectionToolBar = addDropToolBarToTop(tr("Beat selector"));
 
 	m_bbComboBox = new ComboBox( m_toolBar );
-	m_bbComboBox->setFixedSize( 200, 22 );
+	m_bbComboBox->setFixedSize( 200, ComboBox::DEFAULT_HEIGHT );
 	m_bbComboBox->setModel( &tc->m_bbComboBoxModel );
 
 	beatSelectionToolBar->addWidget( m_bbComboBox );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4344,7 +4344,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_zoomingComboBox = new ComboBox( m_toolBar );
 	m_zoomingComboBox->setModel( &m_editor->m_zoomingModel );
-	m_zoomingComboBox->setFixedSize( 64, 22 );
+	m_zoomingComboBox->setFixedSize( 64, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingComboBox->setToolTip( tr( "Horizontal zooming") );
 
 	QLabel * zoom_y_lbl = new QLabel(m_toolBar);
@@ -4352,7 +4352,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_zoomingYComboBox = new ComboBox(m_toolBar);
 	m_zoomingYComboBox->setModel(&m_editor->m_zoomingYModel);
-	m_zoomingYComboBox->setFixedSize(64, 22);
+	m_zoomingYComboBox->setFixedSize(64, ComboBox::DEFAULT_HEIGHT);
 	m_zoomingYComboBox->setToolTip(tr("Vertical zooming"));
 
 	// setup quantize-stuff
@@ -4361,7 +4361,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_quantizeComboBox = new ComboBox( m_toolBar );
 	m_quantizeComboBox->setModel( &m_editor->m_quantizeModel );
-	m_quantizeComboBox->setFixedSize( 64, 22 );
+	m_quantizeComboBox->setFixedSize( 64, ComboBox::DEFAULT_HEIGHT );
 	m_quantizeComboBox->setToolTip( tr( "Quantization") );
 
 	// setup note-len-stuff
@@ -4370,7 +4370,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_noteLenComboBox = new ComboBox( m_toolBar );
 	m_noteLenComboBox->setModel( &m_editor->m_noteLenModel );
-	m_noteLenComboBox->setFixedSize( 105, 22 );
+	m_noteLenComboBox->setFixedSize( 105, ComboBox::DEFAULT_HEIGHT );
 	m_noteLenComboBox->setToolTip( tr( "Note length") );
 
 	// setup scale-stuff
@@ -4379,7 +4379,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_scaleComboBox = new ComboBox( m_toolBar );
 	m_scaleComboBox->setModel( &m_editor->m_scaleModel );
-	m_scaleComboBox->setFixedSize( 105, 22 );
+	m_scaleComboBox->setFixedSize( 105, ComboBox::DEFAULT_HEIGHT );
 	m_scaleComboBox->setToolTip( tr( "Scale") );
 
 	// setup chord-stuff
@@ -4388,7 +4388,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	m_chordComboBox = new ComboBox( m_toolBar );
 	m_chordComboBox->setModel( &m_editor->m_chordModel );
-	m_chordComboBox->setFixedSize( 105, 22 );
+	m_chordComboBox->setFixedSize( 105, ComboBox::DEFAULT_HEIGHT );
 	m_chordComboBox->setToolTip( tr( "Chord" ) );
 
 	// -- Clear ghost pattern button

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -955,7 +955,7 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	//Set up zooming-stuff
 	m_zoomingComboBox = new ComboBox( m_toolBar );
-	m_zoomingComboBox->setFixedSize( 80, 22 );
+	m_zoomingComboBox->setFixedSize( 80, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingComboBox->move( 580, 4 );
 	m_zoomingComboBox->setModel(m_editor->m_zoomingModel);
 	m_zoomingComboBox->setToolTip(tr("Horizontal zooming"));
@@ -970,7 +970,7 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	//Set up quantization/snapping selector
 	m_snappingComboBox = new ComboBox( m_toolBar );
-	m_snappingComboBox->setFixedSize( 80, 22 );
+	m_snappingComboBox->setFixedSize( 80, ComboBox::DEFAULT_HEIGHT );
 	m_snappingComboBox->setModel(m_editor->m_snappingModel);
 	m_snappingComboBox->setToolTip(tr("Clip snapping size"));
 	connect(m_editor->snappingModel(), SIGNAL(dataChanged()), this, SLOT(updateSnapLabel()));

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -51,6 +51,8 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 	m_menu( this ),
 	m_pressed( false )
 {
+	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
+
 	if( s_background == NULL )
 	{
 		s_background = new QPixmap( embed::getIconPixmap( "combobox_bg" ) );

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -78,7 +78,7 @@ ComboControl::ComboControl(QWidget *parent) :
 	m_combo(new ComboBox(nullptr)),
 	m_label(new QLabel(m_widget))
 {
-	m_combo->setFixedSize(64, 22);
+	m_combo->setFixedSize(64, ComboBox::DEFAULT_HEIGHT);
 	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_combo);
 	vbox->addWidget(m_label);

--- a/src/gui/widgets/InstrumentSoundShapingView.cpp
+++ b/src/gui/widgets/InstrumentSoundShapingView.cpp
@@ -74,7 +74,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
-	m_filterComboBox->setGeometry( 14, 22, 120, 22 );
+	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
 	m_filterComboBox->setFont( pointSize<8>( m_filterComboBox->font() ) );
 
 


### PR DESCRIPTION

![ComboBox](https://user-images.githubusercontent.com/69391149/89940981-aa247d80-dc1a-11ea-9d07-b644ddad2513.PNG)
(https://github.com/LMMS/lmms/issues/5494)

Introduce a static const int variable for the default height of a ComboBox.
Set this height already in the constructor of the ComboBox object.
Update all modules setting the height of a ComboBox object to make use of the new constant.