### PR TITLE
Change the background color of the selected text in a text box.

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -35,6 +35,7 @@ QLineEdit {
 	border: 2px inset rgba(91,101,113,128);
 	background: #49515b;
 	color: #e0e0e0;
+	selection-background-color: #202020;
 }
 
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -62,6 +62,7 @@ QLineEdit {
 	border: 1px;
 	background: #101213;
 	color: #d1d8e4;
+	selection-background-color: #17793b;
 }
 
 QLineEdit:read-only {


### PR DESCRIPTION
The new background color matches the green background of selected items in a tree view.
![TextBoxSelection](https://user-images.githubusercontent.com/69391149/90070057-8c771700-dcf3-11ea-834c-c312738c03a7.png)

Fix for https://github.com/LMMS/lmms/issues/5484
The fix is not limited to track renaming, but to all texboxes that can be edited.