### PR TITLE
Fix use of translation functions

### DIFF
--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -71,7 +71,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget",
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget",
 			"ALSA (Advanced Linux Sound Architecture)" );
 	}
 

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -48,7 +48,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "Dummy (no sound output)" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "Dummy (no sound output)" );
 	}
 
 

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -63,7 +63,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget",
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget",
 			"JACK (JACK Audio Connection Kit)" );
 	}
 

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -48,7 +48,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "OSS (Open Sound System)" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "OSS (Open Sound System)" );
 	}
 
 	static QString probeDevice();

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -72,7 +72,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "PortAudio" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "PortAudio" );
 	}
 
 

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -50,7 +50,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "PulseAudio" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "PulseAudio" );
 	}
 
 	static QString probeDevice();

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -51,7 +51,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget",
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget",
 					"SDL (Simple DirectMedia Layer)" );
 	}
 

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -49,7 +49,7 @@ public:
 
 	inline static QString name( void )
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "sndio" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "sndio" );
 	}
 
 	class setupWidget : public AudioDeviceSetupWidget

--- a/include/AudioSoundIo.h
+++ b/include/AudioSoundIo.h
@@ -61,7 +61,7 @@ public:
 
 	inline static QString name()
 	{
-		return QT_TRANSLATE_NOOP( "setupWidget", "soundio" );
+		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "soundio" );
 	}
 
 	class setupWidget : public AudioDeviceSetupWidget

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -74,7 +74,7 @@ private:
 	FloatModel m_filterCutModel;
 	FloatModel m_filterResModel;
 
-	static const QString targetNames[InstrumentSoundShaping::NumTargets][3];
+	static const char *const targetNames[InstrumentSoundShaping::NumTargets][3];
 
 
 	friend class InstrumentSoundShapingView;

--- a/plugins/Amplifier/Amplifier.cpp
+++ b/plugins/Amplifier/Amplifier.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT amplifier_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Amplifier",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A native amplifier plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A native amplifier plugin" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/BassBooster/BassBooster.cpp
+++ b/plugins/BassBooster/BassBooster.cpp
@@ -34,7 +34,7 @@ Plugin::Descriptor PLUGIN_EXPORT bassbooster_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"BassBooster",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Boost your bass the fast and simple way" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Boost your bass the fast and simple way" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT bitcrush_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Bitcrush",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "An oversampling bitcrusher" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "An oversampling bitcrusher" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -36,7 +36,7 @@ Plugin::Descriptor PLUGIN_EXPORT crossovereq_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Crossover Equalizer",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A 4-band Crossover Equalizer" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A 4-band Crossover Equalizer" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT delay_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Delay",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A native delay plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A native delay plugin" ),
 	"Dave French <contact/dot/dave/dot/french3/at/googlemail/dot/com>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -36,7 +36,7 @@ Plugin::Descriptor PLUGIN_EXPORT dualfilter_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Dual Filter",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A Dual filter plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A Dual filter plugin" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -39,7 +39,7 @@ Plugin::Descriptor PLUGIN_EXPORT eq_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Equalizer",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A native eq plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A native eq plugin" ),
 	"Dave French <contact/dot/dave/dot/french3/at/googlemail/dot/com>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT flanger_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Flanger",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A native flanger plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A native flanger plugin" ),
 	"Dave French <contact/dot/dave/dot/french3/at/googlemail/dot/com>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -53,7 +53,7 @@ Plugin::Descriptor PLUGIN_EXPORT freeboy_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"FreeBoy",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Emulation of GameBoy (TM) APU" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Emulation of GameBoy (TM) APU" ),
 
 	"Attila Herman <attila589/at/gmail.com>"
 	"Csaba Hruska <csaba.hruska/at/gmail.com>",

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -63,7 +63,7 @@ Plugin::Descriptor PLUGIN_EXPORT gigplayer_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"GIG Player",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Player for GIG files" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Player for GIG files" ),
 	"Garrett Wilson <g/at/floft/dot/net>",
 	0x0100,
 	Plugin::Instrument,

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -29,7 +29,7 @@ Plugin::Descriptor PLUGIN_EXPORT hydrogenimport_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Hydrogen Import",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Filter for importing Hydrogen files into LMMS" ),
 	"frank mather",
 	0x0100,

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -53,7 +53,7 @@ Plugin::Descriptor PLUGIN_EXPORT ladspaeffect_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"LADSPA",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"plugin for using arbitrary LADSPA-effects "
 				"inside LMMS." ),
 	"Danny McRae <khjklujn/at/users.sourceforge.net>",

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -39,7 +39,7 @@ Plugin::Descriptor PLUGIN_EXPORT lv2effect_plugin_descriptor =
 {
 	STRINGIFY(PLUGIN_NAME),
 	"LV2",
-	QT_TRANSLATE_NOOP("pluginBrowser",
+	QT_TRANSLATE_NOOP("PluginBrowser",
 		"plugin for using arbitrary LV2-effects inside LMMS."),
 	"Johannes Lorenz <jlsf2013$$$users.sourceforge.net, $$$=@>",
 	0x0100,

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -44,7 +44,7 @@ Plugin::Descriptor PLUGIN_EXPORT lv2instrument_plugin_descriptor =
 {
 	STRINGIFY(PLUGIN_NAME),
 	"LV2",
-	QT_TRANSLATE_NOOP("pluginBrowser",
+	QT_TRANSLATE_NOOP("PluginBrowser",
 		"plugin for using arbitrary LV2 instruments inside LMMS."),
 	"Johannes Lorenz <jlsf2013$$$users.sourceforge.net, $$$=@>",
 	0x0100,

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -47,7 +47,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiexport_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"MIDI Export",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Filter for exporting MIDI-files from LMMS" ),
 	"Mohamed Abdel Maksoud <mohamed at amaksoud.com> and "
 	"Hyunjin Song <tteu.ingog/at/gmail.com>",

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -64,7 +64,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiimport_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"MIDI Import",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Filter for importing MIDI-files into LMMS" ),
 	"Tobias Doerffel <tobydox/at/users/dot/sf/dot/net>",
 	0x0100,

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -34,7 +34,7 @@ Plugin::Descriptor PLUGIN_EXPORT multitapecho_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Multitap Echo",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "A multitap echo delay plugin" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "A multitap echo delay plugin" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,
 	Plugin::Effect,

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -68,7 +68,7 @@ Plugin::Descriptor PLUGIN_EXPORT opulenz_plugin_descriptor =
 {
         STRINGIFY( PLUGIN_NAME ),
         "OpulenZ",
-        QT_TRANSLATE_NOOP( "pluginBrowser",
+        QT_TRANSLATE_NOOP( "PluginBrowser",
 			   "2-operator FM Synth" ),
         "Raine M. Ekman <raine/at/iki/fi>",
         0x0100,

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT reverbsc_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"ReverbSC",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Reverb algorithm by Sean Costello" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Reverb algorithm by Sean Costello" ),
 	"Paul Batchelor",
 	0x0123,
 	Plugin::Effect,

--- a/plugins/SpectrumAnalyzer/Analyzer.cpp
+++ b/plugins/SpectrumAnalyzer/Analyzer.cpp
@@ -42,7 +42,7 @@ extern "C" {
 	{
 		"spectrumanalyzer",
 		"Spectrum Analyzer",
-		QT_TRANSLATE_NOOP("pluginBrowser", "A graphical spectrum analyzer."),
+		QT_TRANSLATE_NOOP("PluginBrowser", "A graphical spectrum analyzer."),
 		"Martin Pavelek <he29/dot/HS/at/gmail/dot/com>",
 		0x0112,
 		Plugin::Effect,

--- a/plugins/Vectorscope/Vectorscope.cpp
+++ b/plugins/Vectorscope/Vectorscope.cpp
@@ -33,7 +33,7 @@ extern "C" {
 	{
 		STRINGIFY(PLUGIN_NAME),
 		"Vectorscope",
-		QT_TRANSLATE_NOOP("pluginBrowser", "A stereo field visualizer."),
+		QT_TRANSLATE_NOOP("PluginBrowser", "A stereo field visualizer."),
 		"Martin Pavelek <he29/dot/HS/at/gmail/dot/com>",
 		0x0100,
 		Plugin::Effect,

--- a/plugins/VstEffect/VstEffect.cpp
+++ b/plugins/VstEffect/VstEffect.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT vsteffect_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"VST",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"plugin for using arbitrary VST effects inside LMMS." ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0200,

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -374,7 +374,7 @@ manageVSTEffectView::manageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 		{
 			sprintf( paramStr, "%d", i);
 			m_vi->knobFModel[ i ] = new FloatModel( LocaleHelper::toFloat(s_dumpValues.at(2)),
-					0.0f, 1.0f, 0.01f, _eff, tr( paramStr ) );
+					0.0f, 1.0f, 0.01f, _eff, paramStr );
 		}
 
 		FloatModel * model = m_vi->knobFModel[i];

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -53,7 +53,7 @@
 extern "C" {
 
 Plugin::Descriptor PLUGIN_EXPORT xpressive_plugin_descriptor = { STRINGIFY(
-	PLUGIN_NAME), "Xpressive", QT_TRANSLATE_NOOP("pluginBrowser",
+	PLUGIN_NAME), "Xpressive", QT_TRANSLATE_NOOP("PluginBrowser",
 	"Mathematical expression parser"), "Orr Dvori", 0x0100,
 	Plugin::Instrument, new PluginPixmapLoader("logo"), NULL, NULL };
 

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -55,7 +55,7 @@ Plugin::Descriptor PLUGIN_EXPORT audiofileprocessor_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"AudioFileProcessor",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Simple sampler with various settings for "
 				"using samples (e.g. drums) in an "
 				"instrument-track" ),

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -51,7 +51,7 @@ Plugin::Descriptor PLUGIN_EXPORT bitinvader_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"BitInvader",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Customizable wavetable synthesizer" ),
 	"Andreas Brandmaier <andreas/at/brandmaier/dot/de>",
 	0x0100,

--- a/plugins/carlapatchbay/carlapatchbay.cpp
+++ b/plugins/carlapatchbay/carlapatchbay.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT carlapatchbay_plugin_descriptor =
 {
     STRINGIFY( PLUGIN_NAME ),
     "Carla Patchbay",
-    QT_TRANSLATE_NOOP( "pluginBrowser",
+    QT_TRANSLATE_NOOP( "PluginBrowser",
                        "Carla Patchbay Instrument" ),
     "falkTX <falktx/at/falktx.com>",
     CARLA_VERSION_HEX,

--- a/plugins/carlarack/carlarack.cpp
+++ b/plugins/carlarack/carlarack.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT carlarack_plugin_descriptor =
 {
     STRINGIFY( PLUGIN_NAME ),
     "Carla Rack",
-    QT_TRANSLATE_NOOP( "pluginBrowser",
+    QT_TRANSLATE_NOOP( "PluginBrowser",
                        "Carla Rack Instrument" ),
     "falkTX <falktx/at/falktx.com>",
     CARLA_VERSION_HEX,

--- a/plugins/dynamics_processor/dynamics_processor.cpp
+++ b/plugins/dynamics_processor/dynamics_processor.cpp
@@ -38,7 +38,7 @@ Plugin::Descriptor PLUGIN_EXPORT dynamicsprocessor_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Dynamics Processor",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"plugin for processing dynamics in a flexible way" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -45,7 +45,7 @@ Plugin::Descriptor PLUGIN_EXPORT kicker_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Kicker",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Versatile drum synthesizer" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,

--- a/plugins/ladspa_browser/ladspa_browser.cpp
+++ b/plugins/ladspa_browser/ladspa_browser.cpp
@@ -49,7 +49,7 @@ Plugin::Descriptor PLUGIN_EXPORT ladspabrowser_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"LADSPA Plugin Browser",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"List installed LADSPA plugins" ),
 	"Danny McRae <khjklujn/at/users.sourceforge.net>",
 	0x0100,

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -83,7 +83,7 @@ Plugin::Descriptor PLUGIN_EXPORT lb302_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"LB302",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 			"Incomplete monophonic imitation tb303" ),
 	"Paul Giblock <pgib/at/users.sf.net>",
 	0x0100,

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -45,7 +45,7 @@ Plugin::Descriptor PLUGIN_EXPORT monstro_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Monstro",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Monstrous 3-oscillator synth with modulation matrix" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,

--- a/plugins/nes/Nes.cpp
+++ b/plugins/nes/Nes.cpp
@@ -44,7 +44,7 @@ Plugin::Descriptor PLUGIN_EXPORT nes_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Nescaline",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"A NES-like synthesizer" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,

--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -51,7 +51,7 @@ Plugin::Descriptor PLUGIN_EXPORT organic_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Organic",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Additive Synthesizer for organ-like sounds" ),
 	"Andreas Brandmaier <andreas/at/brandmaier.de>",
 	0x0100,

--- a/plugins/patman/patman.cpp
+++ b/plugins/patman/patman.cpp
@@ -54,7 +54,7 @@ Plugin::Descriptor PLUGIN_EXPORT patman_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"PatMan",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"GUS-compatible patch instrument" ),
 	"Javier Serrano Polo <jasp00/at/users.sourceforge.net>",
 	0x0100,

--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT peakcontrollereffect_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Peak Controller",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 			"Plugin for controlling knobs with sound peaks" ),
 	"Paul Giblock <drfaygo/at/gmail.com>",
 	0x0100,

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -57,7 +57,7 @@ Plugin::Descriptor PLUGIN_EXPORT sf2player_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Sf2 Player",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Player for SoundFont files" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Player for SoundFont files" ),
 	"Paul Giblock <drfaygo/at/gmail/dot/com>",
 	0x0100,
 	Plugin::Instrument,

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -62,7 +62,7 @@ Plugin::Descriptor PLUGIN_EXPORT sfxr_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"sfxr",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"LMMS port of sfxr" ),
 	"Wong Cho Ching",
 	0x0100,

--- a/plugins/sid/sid_instrument.cpp
+++ b/plugins/sid/sid_instrument.cpp
@@ -75,7 +75,7 @@ Plugin::Descriptor PLUGIN_EXPORT sid_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"SID",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "Emulation of the MOS6581 and MOS8580 "
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Emulation of the MOS6581 and MOS8580 "
 					"SID.\nThis chip was used in the Commodore 64 computer." ),
 
 	"Csaba Hruska <csaba.hruska/at/gmail.com>"

--- a/plugins/stereo_enhancer/stereo_enhancer.cpp
+++ b/plugins/stereo_enhancer/stereo_enhancer.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT stereoenhancer_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"StereoEnhancer Effect",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Plugin for enhancing stereo separation of a stereo input file" ),
 	"Lou Herard <lherard/at/gmail.com>",
 	0x0100,

--- a/plugins/stereo_matrix/stereo_matrix.cpp
+++ b/plugins/stereo_matrix/stereo_matrix.cpp
@@ -35,7 +35,7 @@ Plugin::Descriptor PLUGIN_EXPORT stereomatrix_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Stereo Matrix",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Plugin for freely manipulating stereo output" ),
 	"Paul Giblock <drfaygo/at/gmail.com>",
 	0x0100,

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -50,7 +50,7 @@ Plugin::Descriptor PLUGIN_EXPORT malletsstk_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Mallets",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Tuneful things to bang on" ),
 	"Danny McRae <khjklujn/at/users.sf.net>",
 	0x0100,

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -49,7 +49,7 @@ Plugin::Descriptor PLUGIN_EXPORT tripleoscillator_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"TripleOscillator",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"Three powerful oscillators you can modulate "
 				"in several ways" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -71,7 +71,7 @@ Plugin::Descriptor Q_DECL_EXPORT  vestige_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"VeSTige",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 			"VST-host for using VST(i)-plugins within LMMS" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,
@@ -991,7 +991,7 @@ manageVestigeInstrumentView::manageVestigeInstrumentView( Instrument * _instrume
 		{
 			sprintf( paramStr, "%d", i);
 			m_vi->knobFModel[ i ] = new FloatModel( LocaleHelper::toFloat(s_dumpValues.at(2)),
-				0.0f, 1.0f, 0.01f, castModel<vestigeInstrument>(), tr( paramStr ) );
+				0.0f, 1.0f, 0.01f, castModel<vestigeInstrument>(), paramStr );
 		}
 
 		FloatModel * model = m_vi->knobFModel[i];

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -48,7 +48,7 @@ Plugin::Descriptor PLUGIN_EXPORT vibedstrings_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Vibed",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 					"Vibrating string modeler" ),
 	"Danny McRae <khjklujn/at/yahoo/com>",
 	0x0100,

--- a/plugins/vst_base/VstPlugin.cpp
+++ b/plugins/vst_base/VstPlugin.cpp
@@ -560,7 +560,7 @@ void VstPlugin::loadParameterDisplays()
 void VstPlugin::savePreset( )
 {
 	QString presName = currentProgramName().isEmpty() ? tr(": default") : currentProgramName();
-	presName.replace(tr("\""), tr("'")); // QFileDialog unable to handle double quotes properly
+	presName.replace("\"", "'"); // QFileDialog unable to handle double quotes properly
 
 	FileDialog sfd( NULL, tr( "Save Preset" ), presName.section(": ", 1, 1) + tr(".fxp"),
 		tr( "Vst Plugin Preset (*.fxp *.fxb)" ) );

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -44,7 +44,7 @@ Plugin::Descriptor PLUGIN_EXPORT watsyn_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Watsyn",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"4-oscillator modulatable wavetable synth" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,

--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -38,7 +38,7 @@ Plugin::Descriptor PLUGIN_EXPORT waveshaper_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"Waveshaper Effect",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 				"plugin for waveshaping" ),
 	"Vesa Kivimäki <contact/dot/diizy/at/nbl/dot/fi>",
 	0x0100,

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -58,7 +58,7 @@ Plugin::Descriptor PLUGIN_EXPORT zynaddsubfx_plugin_descriptor =
 {
 	STRINGIFY( PLUGIN_NAME ),
 	"ZynAddSubFX",
-	QT_TRANSLATE_NOOP( "pluginBrowser",
+	QT_TRANSLATE_NOOP( "PluginBrowser",
 			"Embedded ZynAddSubFX" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -43,16 +43,14 @@ const float RES_PRECISION = 1000.0f;
 
 // names for env- and lfo-targets - first is name being displayed to user
 // and second one is used internally, e.g. for saving/restoring settings
-const QString InstrumentSoundShaping::targetNames[InstrumentSoundShaping::NumTargets][3] =
+const char *const InstrumentSoundShaping::targetNames[InstrumentSoundShaping::NumTargets][3] =
 {
-	{ InstrumentSoundShaping::tr( "VOLUME" ), "vol",
-			InstrumentSoundShaping::tr( "Volume" ) },
-/*	InstrumentSoundShaping::tr( "Pan" ),
-	InstrumentSoundShaping::tr( "Pitch" ),*/
-	{ InstrumentSoundShaping::tr( "CUTOFF" ), "cut",
-			InstrumentSoundShaping::tr( "Cutoff frequency" ) },
-	{ InstrumentSoundShaping::tr( "RESO" ), "res",
-			InstrumentSoundShaping::tr( "Resonance" ) }
+	{ QT_TRANSLATE_NOOP("InstrumentSoundShaping", "VOLUME"), "vol",
+			QT_TRANSLATE_NOOP("InstrumentSoundShaping", "Volume") },
+	{ QT_TRANSLATE_NOOP("InstrumentSoundShaping", "CUTOFF"), "cut",
+			QT_TRANSLATE_NOOP("InstrumentSoundShaping", "Cutoff frequency") },
+	{ QT_TRANSLATE_NOOP("InstrumentSoundShaping", "RESO"), "res",
+			QT_TRANSLATE_NOOP("InstrumentSoundShaping", "Resonance") }
 } ;
  
 
@@ -77,7 +75,7 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 										value_for_zero_amount, 
 										this );
 		m_envLfoParameters[i]->setDisplayName(
-			tr( targetNames[i][2].toUtf8().constData() ) );
+			tr( targetNames[i][2] ) );
 	}
 
 	m_filterModel.addItem( tr( "Low-pass" ), make_unique<PixmapLoader>( "filter_lp" ) );

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -44,7 +44,7 @@ static Plugin::Descriptor dummyPluginDescriptor =
 {
 	"dummy",
 	"dummy",
-	QT_TRANSLATE_NOOP( "pluginBrowser", "no description" ),
+	QT_TRANSLATE_NOOP( "PluginBrowser", "no description" ),
 	"Tobias Doerffel <tobydox/at/users.sf.net>",
 	0x0100,
 	Plugin::Undefined,

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -1138,26 +1138,26 @@ void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * cme )
 	{
 		contextMenu.addAction(
 			embed::getIconPixmap( "cancel" ),
-			tr( individualTCO
-				? "Delete (middle mousebutton)"
-				: "Delete selection (middle mousebutton)" ),
+			individualTCO
+				? tr("Delete (middle mousebutton)")
+				: tr("Delete selection (middle mousebutton)"),
 			[this](){ contextMenuAction( Remove ); } );
 
 		contextMenu.addSeparator();
 
 		contextMenu.addAction(
 			embed::getIconPixmap( "edit_cut" ),
-			tr( individualTCO
-				? "Cut"
-				: "Cut selection" ),
+			individualTCO
+				? tr("Cut")
+				: tr("Cut selection"),
 			[this](){ contextMenuAction( Cut ); } );
 	}
 
 	contextMenu.addAction(
 		embed::getIconPixmap( "edit_copy" ),
-		tr( individualTCO
-			? "Copy"
-			: "Copy selection" ),
+		individualTCO
+			? tr("Copy")
+			: tr("Copy selection"),
 		[this](){ contextMenuAction( Copy ); } );
 
 	contextMenu.addAction(
@@ -1169,9 +1169,9 @@ void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * cme )
 
 	contextMenu.addAction(
 		embed::getIconPixmap( "muted" ),
-		tr( individualTCO
-			? "Mute/unmute (<%1> + middle click)"
-			: "Mute/unmute selection (<%1> + middle click)" ).arg(UI_CTRL_KEY),
+		(individualTCO
+			? tr("Mute/unmute (<%1> + middle click)")
+			: tr("Mute/unmute selection (<%1> + middle click)")).arg(UI_CTRL_KEY),
 		[this](){ contextMenuAction( Mute ); } );
 
 	constructContextMenu( &contextMenu );

--- a/src/gui/AudioDeviceSetupWidget.cpp
+++ b/src/gui/AudioDeviceSetupWidget.cpp
@@ -26,7 +26,7 @@
 
 
 AudioDeviceSetupWidget::AudioDeviceSetupWidget(const QString & caption, QWidget * parent) :
-	TabWidget(TabWidget::tr("Settings for %1").arg(TabWidget::tr(caption.toLatin1())), parent)
+	TabWidget(TabWidget::tr("Settings for %1").arg(tr(caption.toUtf8())), parent)
 {
 }
 

--- a/src/gui/EffectSelectDialog.cpp
+++ b/src/gui/EffectSelectDialog.cpp
@@ -234,7 +234,7 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 		{
 			QLabel *label = new QLabel(m_descriptionWidget);
 			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
-			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate( "pluginBrowser", descriptor.description ) + "</p>";
+			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate( "PluginBrowser", descriptor.description ) + "</p>";
 			labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author) + "</p>";
 
 			label->setText(labelText);

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -31,7 +31,7 @@
 
 MidiSetupWidget::MidiSetupWidget(const QString & caption, const QString & configSection,
 	const QString & devName, QWidget * parent) :
-	TabWidget(TabWidget::tr("Settings for %1").arg(tr(caption.toLatin1())), parent),
+	TabWidget(TabWidget::tr("Settings for %1").arg(tr(caption.toUtf8())), parent),
 	m_configSection(configSection),
 	m_device(nullptr)
 {

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -205,7 +205,9 @@ PluginDescWidget::PluginDescWidget(const PluginKey &_pk,
 	setFixedHeight( DEFAULT_HEIGHT );
 	setMouseTracking( true );
 	setCursor( Qt::PointingHandCursor );
-	setToolTip(_pk.description());
+	setToolTip(_pk.desc->subPluginFeatures
+		? _pk.description()
+		: tr(_pk.desc->description));
 }
 
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -31,12 +31,14 @@
 #include <QMessageBox>
 #include <QScrollArea>
 
+#include "AudioDeviceSetupWidget.h"
 #include "debug.h"
 #include "embed.h"
 #include "Engine.h"
 #include "FileDialog.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
+#include "MidiSetupWidget.h"
 #include "Mixer.h"
 #include "ProjectJournal.h"
 #include "SetupDialog.h"
@@ -195,14 +197,14 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	auto addLedCheckBox = [&XDelta, &YDelta, this](
-		const char* ledText,
+		const QString &ledText,
 		TabWidget* tw,
 		int& counter,
 		bool initialState,
 		const char* toggledSlot,
 		bool showRestartWarning
 	){
-		LedCheckBox * checkBox = new LedCheckBox(tr(ledText), tw);
+		LedCheckBox * checkBox = new LedCheckBox(ledText, tw);
 		counter++;
 		checkBox->move(XDelta, YDelta * counter);
 		checkBox->setChecked(initialState);
@@ -221,21 +223,21 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 			tr("Graphical user interface (GUI)"), general_w);
 
 
-	addLedCheckBox("Display volume as dBFS ", gui_tw, counter,
+	addLedCheckBox(tr("Display volume as dBFS "), gui_tw, counter,
 		m_displaydBFS, SLOT(toggleDisplaydBFS(bool)), true);
-	addLedCheckBox("Enable tooltips", gui_tw, counter,
+	addLedCheckBox(tr("Enable tooltips"), gui_tw, counter,
 		m_tooltips, SLOT(toggleTooltips(bool)), true);
-	addLedCheckBox("Enable master oscilloscope by default", gui_tw, counter,
+	addLedCheckBox(tr("Enable master oscilloscope by default"), gui_tw, counter,
 		m_displayWaveform, SLOT(toggleDisplayWaveform(bool)), true);
-	addLedCheckBox("Enable all note labels in piano roll", gui_tw, counter,
+	addLedCheckBox(tr("Enable all note labels in piano roll"), gui_tw, counter,
 		m_printNoteLabels, SLOT(toggleNoteLabels(bool)), false);
-	addLedCheckBox("Enable compact track buttons", gui_tw, counter,
+	addLedCheckBox(tr("Enable compact track buttons"), gui_tw, counter,
 		m_compactTrackButtons, SLOT(toggleCompactTrackButtons(bool)), true);
-	addLedCheckBox("Enable one instrument-track-window mode", gui_tw, counter,
+	addLedCheckBox(tr("Enable one instrument-track-window mode"), gui_tw, counter,
 		m_oneInstrumentTrackWindow, SLOT(toggleOneInstrumentTrackWindow(bool)), true);
-	addLedCheckBox("Show sidebar on the right-hand side", gui_tw, counter,
+	addLedCheckBox(tr("Show sidebar on the right-hand side"), gui_tw, counter,
 		m_sideBarOnRight, SLOT(toggleSideBarOnRight(bool)), true);
-	addLedCheckBox("Mute automation tracks during solo", gui_tw, counter,
+	addLedCheckBox(tr("Mute automation tracks during solo"), gui_tw, counter,
 		m_soloLegacyBehavior, SLOT(toggleSoloLegacyBehavior(bool)), false);
 
 	gui_tw->setFixedHeight(YDelta + YDelta * counter);
@@ -248,11 +250,11 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 			tr("Projects"), general_w);
 
 
-	addLedCheckBox("Compress project files by default", projects_tw, counter,
+	addLedCheckBox(tr("Compress project files by default"), projects_tw, counter,
 		m_MMPZ, SLOT(toggleMMPZ(bool)), true);
-	addLedCheckBox("Create a backup file when saving a project", projects_tw, counter,
+	addLedCheckBox(tr("Create a backup file when saving a project"), projects_tw, counter,
 		m_disableBackup, SLOT(toggleDisableBackup(bool)), false);
-	addLedCheckBox("Reopen last project on startup", projects_tw, counter,
+	addLedCheckBox(tr("Reopen last project on startup"), projects_tw, counter,
 		m_openLastProject, SLOT(toggleOpenLastProject(bool)), false);
 
 	projects_tw->setFixedHeight(YDelta + YDelta * counter);
@@ -372,9 +374,9 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	TabWidget * ui_fx_tw = new TabWidget(
 			tr("User interface (UI) effects vs. performance"), performance_w);
 
-	addLedCheckBox("Smooth scroll in song editor", ui_fx_tw, counter,
+	addLedCheckBox(tr("Smooth scroll in song editor"), ui_fx_tw, counter,
 		m_smoothScroll, SLOT(toggleSmoothScroll(bool)), false);
-	addLedCheckBox("Display playback cursor in AudioFileProcessor", ui_fx_tw, counter,
+	addLedCheckBox(tr("Display playback cursor in AudioFileProcessor"), ui_fx_tw, counter,
 		m_animateAFP, SLOT(toggleAnimateAFP(bool)), false);
 
 	ui_fx_tw->setFixedHeight(YDelta + YDelta * counter);
@@ -421,10 +423,10 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	connect(m_vstAlwaysOnTopCheckBox, SIGNAL(toggled(bool)),
 			this, SLOT(toggleVSTAlwaysOnTop(bool)));
 
-	addLedCheckBox("Sync VST plugins to host playback", plugins_tw, counter,
+	addLedCheckBox(tr("Sync VST plugins to host playback"), plugins_tw, counter,
 		m_syncVSTPlugins, SLOT(toggleSyncVSTPlugins(bool)), false);
 
-	addLedCheckBox("Keep effects running even without input", plugins_tw, counter,
+	addLedCheckBox(tr("Keep effects running even without input"), plugins_tw, counter,
 		m_disableAutoQuit, SLOT(toggleDisableAutoQuit(bool)), false);
 
 	plugins_tw->setFixedHeight(YDelta + YDelta * counter);
@@ -511,7 +513,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		it != m_audioIfaceSetupWidgets.end(); ++it)
 	{
 		m_audioIfaceNames[
-			tr(it.key().toLatin1())] = it.key();
+			AudioDeviceSetupWidget::tr(it.key().toUtf8())] = it.key();
 	}
 	for(trMap::iterator it = m_audioIfaceNames.begin();
 		it != m_audioIfaceNames.end(); ++it)
@@ -657,7 +659,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		it != m_midiIfaceSetupWidgets.end(); ++it)
 	{
 		m_midiIfaceNames[
-			tr(it.key().toLatin1())] = it.key();
+			MidiSetupWidget::tr(it.key().toUtf8())] = it.key();
 	}
 	for(trMap::iterator it = m_midiIfaceNames.begin();
 		it != m_midiIfaceNames.end(); ++it)
@@ -736,14 +738,14 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	QVBoxLayout * pathSelectorsLayout = new QVBoxLayout;
 	pathSelectorsLayout->setSpacing(10);
 
-	auto addPathEntry = [&](const char* caption,
+	auto addPathEntry = [&](const QString &caption,
 		const QString& content,
 		const char* setSlot,
 		const char* openSlot,
 		QLineEdit*& lineEdit,
 		const char* pixmap = "project_open")
 	{
-		TabWidget * newTw = new TabWidget(tr(caption),
+		TabWidget * newTw = new TabWidget(caption,
 					pathSelectors);
 		newTw->setFixedHeight(48);
 
@@ -763,37 +765,37 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		pathSelectorsLayout->addSpacing(10);
 	};
 
-	addPathEntry("LMMS working directory", m_workingDir,
+	addPathEntry(tr("LMMS working directory"), m_workingDir,
 		SLOT(setWorkingDir(const QString &)),
 		SLOT(openWorkingDir()),
 		m_workingDirLineEdit);
-	addPathEntry("VST plugins directory", m_vstDir,
+	addPathEntry(tr("VST plugins directory"), m_vstDir,
 		SLOT(setVSTDir(const QString &)),
 		SLOT(openVSTDir()),
 		m_vstDirLineEdit);
-	addPathEntry("LADSPA plugins directories", m_ladspaDir,
+	addPathEntry(tr("LADSPA plugins directories"), m_ladspaDir,
 		SLOT(setLADSPADir(const QString &)),
 		SLOT(openLADSPADir()),
 		m_ladspaDirLineEdit, "add_folder");
-	addPathEntry("SF2 directory", m_sf2Dir,
+	addPathEntry(tr("SF2 directory"), m_sf2Dir,
 		SLOT(setSF2Dir(const QString &)),
 		SLOT(openSF2Dir()),
 		m_sf2DirLineEdit);
 #ifdef LMMS_HAVE_FLUIDSYNTH
-	addPathEntry("Default SF2", m_sf2File,
+	addPathEntry(tr("Default SF2"), m_sf2File,
 		SLOT(setSF2File(const QString &)),
 		SLOT(openSF2File()),
 		m_sf2FileLineEdit);
 #endif
-	addPathEntry("GIG directory", m_gigDir,
+	addPathEntry(tr("GIG directory"), m_gigDir,
 		SLOT(setGIGDir(const QString &)),
 		SLOT(openGIGDir()),
 		m_gigDirLineEdit);
-	addPathEntry("Theme directory", m_themeDir,
+	addPathEntry(tr("Theme directory"), m_themeDir,
 		SLOT(setThemeDir(const QString &)),
 		SLOT(openThemeDir()),
 		m_themeDirLineEdit);
-	addPathEntry("Background artwork", m_backgroundPicFile,
+	addPathEntry(tr("Background artwork"), m_backgroundPicFile,
 		SLOT(setBackgroundPicFile(const QString &)),
 		SLOT(openBackgroundPicFile()),
 		m_backgroundPicFileLineEdit);

--- a/src/gui/widgets/InstrumentSoundShapingView.cpp
+++ b/src/gui/widgets/InstrumentSoundShapingView.cpp
@@ -62,7 +62,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 	{
 		m_envLfoViews[i] = new EnvelopeAndLfoView( m_targetsTabWidget );
 		m_targetsTabWidget->addTab( m_envLfoViews[i],
-						tr( InstrumentSoundShaping::targetNames[i][0].toUtf8().constData() ), 
+						tr( InstrumentSoundShaping::targetNames[i][0] ), 
                                                 NULL );
 	}
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -76,11 +76,6 @@
 #include "TrackLabelButton.h"
 
 
-const char * volume_help = QT_TRANSLATE_NOOP( "InstrumentTrack",
-						"With this knob you can set "
-						"the volume of the opened "
-						"channel.");
-
 const int INSTRUMENT_WIDTH	= 254;
 const int INSTRUMENT_HEIGHT	= INSTRUMENT_WIDTH;
 const int PIANO_HEIGHT		= 80;

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -358,26 +358,26 @@ void SampleTCOView::contextMenuEvent( QContextMenuEvent * _cme )
 	{
 		contextMenu.addAction(
 			embed::getIconPixmap( "cancel" ),
-			tr( individualTCO
-				? "Delete (middle mousebutton)"
-				: "Delete selection (middle mousebutton)" ),
+			individualTCO
+				? tr("Delete (middle mousebutton)")
+				: tr("Delete selection (middle mousebutton)"),
 			[this](){ contextMenuAction( Remove ); } );
 
 		contextMenu.addSeparator();
 
 		contextMenu.addAction(
 			embed::getIconPixmap( "edit_cut" ),
-			tr( individualTCO
-				? "Cut"
-				: "Cut selection" ),
+			individualTCO
+				? tr("Cut")
+				: tr("Cut selection"),
 			[this](){ contextMenuAction( Cut ); } );
 	}
 
 	contextMenu.addAction(
 		embed::getIconPixmap( "edit_copy" ),
-		tr( individualTCO
-			? "Copy"
-			: "Copy selection" ),
+		individualTCO
+			? tr("Copy")
+			: tr("Copy selection"),
 		[this](){ contextMenuAction( Copy ); } );
 
 	contextMenu.addAction(
@@ -389,9 +389,9 @@ void SampleTCOView::contextMenuEvent( QContextMenuEvent * _cme )
 
 	contextMenu.addAction(
 		embed::getIconPixmap( "muted" ),
-		tr( individualTCO
-			? "Mute/unmute (<%1> + middle click)"
-			: "Mute/unmute selection (<%1> + middle click)" ).arg(UI_CTRL_KEY),
+		(individualTCO
+			? tr("Mute/unmute (<%1> + middle click)")
+			: tr("Mute/unmute selection (<%1> + middle click)")).arg(UI_CTRL_KEY),
 		[this](){ contextMenuAction( Mute ); } );
 
 	/*contextMenu.addAction( embed::getIconPixmap( "record" ),


### PR DESCRIPTION
Fixes some outdated or incorrect usage of translation functions.
* The `pluginBrowser` class has since been renamed to `PluginBrowser`, so translations using that context have been updated to use the new name.
* The context for audio backend name translations has been changed from `setupWidget` to `AudioDeviceSetupWidget`. This is consistent with the use of `MidiSetupWidget` for MIDI backends.
* VeSTige and VstEffect no longer pass strings consisting of a single integer id through `tr`.
* The line `presName.replace(tr("\""), tr("'")); // QFileDialog unable to handle double quotes properly` from vst_base has been changed not to use `tr` - it doesn't make sense to allow translators to override this and break `QFileDialog`.
* Static strings in `InstrumentSoundShaping` now use `QT_TRANSLATE_NOOP` rather than `tr`; `tr` has no effect there since the translations have not been loaded yet at that point.
* Some places in `TrackContentObjectView`, `SetupDialog`, and `SampleTCOView` had calls to `tr` factored out of ternary expressions, or into lambdas. This breaks `lupdate`, which can't recognise anything but string literals within `tr` calls. Calls to `tr` have been moved to wrap the literals.
* In cases where it is necessary to pass the contents of a `QString` to `tr`, `toLatin1` has been changed to `toUtf8`, since this is the encoding Qt expects.
* `PluginBrowser` now translates descriptions in its tooltips for plugins that aren't subplugins.
* An unused static translation has been removed from `InstrumentTrack`.