### PR TITLE
Update portsmf + some MIDI loading updates

### DIFF
--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -31,6 +31,7 @@
 #include <QProgressDialog>
 
 #include <sstream>
+#include <unordered_map>
 
 #include "MidiImport.h"
 #include "TrackContainer.h"
@@ -305,7 +306,7 @@ public:
 
 bool MidiImport::readSMF( TrackContainer* tc )
 {
-
+	const int MIDI_CC_COUNT = 128 + 1; // 0-127 (128) + pitch bend
 	const int preTrackSteps = 2;
 	QProgressDialog pd( TrackContainer::tr( "Importing MIDI-file..." ),
 	TrackContainer::tr( "Cancel" ), 0, preTrackSteps, gui->mainWindow() );
@@ -315,10 +316,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 
 	pd.setValue( 0 );
 
-	std::stringstream stream;
-	QByteArray arr = readAllData();
-	stream.str(std::string(arr.constData(), arr.size()));
-
+	std::istringstream stream(readAllData().toStdString());
 	Alg_seq_ptr seq = new Alg_seq(stream, true);
 	seq->convert_to_beats();
 
@@ -326,8 +324,12 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	pd.setValue( 1 );
 	
 	// 128 CC + Pitch Bend
-	smfMidiCC ccs[129];
-	smfMidiChannel chs[256];
+	smfMidiCC ccs[MIDI_CC_COUNT];
+
+	// channels can be set out of 256 range
+	// using unordered_map should fix most invalid loads and crashes while loading
+	std::unordered_map<long, smfMidiChannel> chs;
+	// NOTE: unordered_map::operator[] creates a new element if none exists
 
 	MeterModel & timeSigMM = Engine::getSong()->getTimeSigModel();
 	AutomationTrack * nt = dynamic_cast<AutomationTrack*>(
@@ -407,7 +409,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 		Alg_track_ptr trk = seq->track( t );
 		pd.setValue( t + preTrackSteps );
 
-		for( int c = 0; c < 129; c++ )
+		for( int c = 0; c < MIDI_CC_COUNT; c++ )
 		{
 			ccs[c].clear();
 		}
@@ -423,7 +425,10 @@ bool MidiImport::readSMF( TrackContainer* tc )
                 if( evt->is_update() )
 				{
 					QString attr = evt->get_attribute();
-                    if( attr == "tracknames" && evt->get_update_type() == 's' ) {
+					// seqnames is a track0 identifier (see allegro code)
+					if (attr == (t == 0 ? "seqnames" : "tracknames")
+						&& evt->get_update_type() == 's')
+					{
 						trackName = evt->get_string_value();
 						handled = true;
 					}
@@ -444,7 +449,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
                     printf( "\n" );
 				}
 			}
-			else if( evt->is_note() && evt->chan < 256 )
+			else if (evt->is_note())
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
 				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
@@ -558,28 +563,26 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	delete seq;
 	
 	
-	for( int c=0; c < 256; ++c )
+	for( auto& c: chs )
 	{
-		if (chs[c].hasNotes)
+		if (c.second.hasNotes)
 		{
-			chs[c].splitPatterns();
+			c.second.splitPatterns();
 		}
-		else if (chs[c].it)
+		else if (c.second.it)
 		{
 			printf(" Should remove empty track\n");
 			// must delete trackView first - but where is it?
 			//tc->removeTrack( chs[c].it );
 			//it->deleteLater();
 		}
-	}
-
-	// Set channel 10 to drums as per General MIDI's orders
-	if( chs[9].hasNotes && chs[9].it_inst && chs[9].isSF2 )
-	{
-		// AFAIK, 128 should be the standard bank for drums in SF2.
-		// If not, this has to be made configurable.
-		chs[9].it_inst->childModel( "bank" )->setValue( 128 );
-		chs[9].it_inst->childModel( "patch" )->setValue( 0 );
+		// Set channel 10 to drums as per General MIDI's orders
+		if (c.first % 16l == 9 /* channel 10 */
+			&& c.second.hasNotes && c.second.it_inst && c.second.isSF2)
+		{
+			c.second.it_inst->childModel("bank")->setValue(128);
+			c.second.it_inst->childModel("patch")->setValue(0);
+		}
 	}
 
 	return true;

--- a/plugins/MidiImport/portsmf/algrd_internal.h
+++ b/plugins/MidiImport/portsmf/algrd_internal.h
@@ -1,4 +1,5 @@
 /* algread_internal.h -- interface between allegro.cpp and allegrord.cpp */
 
-Alg_error alg_read(std::istream &file, Alg_seq_ptr new_seq);
+Alg_error alg_read(std::istream &file, Alg_seq_ptr new_seq, 
+                   double *offset_ptr = NULL);
 

--- a/plugins/MidiImport/portsmf/allegro.cpp
+++ b/plugins/MidiImport/portsmf/allegro.cpp
@@ -9,7 +9,7 @@
 04 apr 03 -- fixed bug in add_track that caused infinite loop
 */
 
-#include "debug.h"
+#include "assert.h"
 #include "stdlib.h"
 #include "stdio.h"
 #include "string.h"
@@ -25,13 +25,15 @@ using namespace std;
 
 #define STREQL(x, y) (strcmp(x, y) == 0)
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
+#define ROUND(x) ((int) ((x) + 0.5))
 
 // 4311 is type cast ponter to long warning
 // 4996 is warning against strcpy
 // 4267 is size_t to long warning
-//#pragma warning(disable: 4311 4996 4267)
+#pragma warning(disable: 4311 4996 4267)
 Alg_atoms symbol_table;
-Serial_buffer Alg_track::ser_buf; // declare the static variable
+Serial_read_buffer Alg_track::ser_read_buf; // declare the static variables
+Serial_write_buffer Alg_track::ser_write_buf; 
 
 bool within(double d1, double d2, double epsilon)
 {
@@ -52,12 +54,10 @@ void Alg_atoms::expand()
 {
     maxlen = (maxlen + 5);   // extra growth for small sizes
     maxlen += (maxlen >> 2); // add 25%
-    char **new_atoms = new Alg_attribute[maxlen];
+    Alg_attribute *new_atoms = new Alg_attribute[maxlen];
     // now do copy
-    if (atoms) {
-        memcpy(new_atoms, atoms, len * sizeof(Alg_attribute));
-        delete[] atoms;
-    }
+    memcpy(new_atoms, atoms, len * sizeof(Alg_attribute));
+    if (atoms) delete[] atoms;
     atoms = new_atoms;
 }
 
@@ -81,6 +81,7 @@ Alg_attribute Alg_atoms::insert_new(const char *name, char attr_type)
 
 Alg_attribute Alg_atoms::insert_attribute(Alg_attribute attr)
 {
+    // should use hash algorithm
     for (int i = 0; i < len; i++) {
         if (STREQL(attr, atoms[i])) {
             return atoms[i];
@@ -123,7 +124,7 @@ void Alg_parameter::show()
         printf("%s:%s", attr_name(), s);
         break;
     case 'i':
-        printf("%s:%d", attr_name(), (int) i);
+        printf("%s:%ld", attr_name(), i);
         break;
     case 'l':
         printf("%s:%s", attr_name(), (l ? "t" : "f"));
@@ -143,7 +144,8 @@ Alg_parameter::~Alg_parameter()
 }
 
 
-void Alg_parameters::insert_real(Alg_parameters **list, char *name, double r)
+void Alg_parameters::insert_real(Alg_parameters **list, const char *name, 
+                                 double r)
 {
     Alg_parameters_ptr a = new Alg_parameters(*list);
     *list = a;
@@ -153,7 +155,8 @@ void Alg_parameters::insert_real(Alg_parameters **list, char *name, double r)
 }
 
 
-void Alg_parameters::insert_string(Alg_parameters **list, char *name, char *s)
+void Alg_parameters::insert_string(Alg_parameters **list, const char *name, 
+                                   const char *s)
 {
     Alg_parameters_ptr a = new Alg_parameters(*list);
     *list = a;
@@ -164,7 +167,8 @@ void Alg_parameters::insert_string(Alg_parameters **list, char *name, char *s)
 }
 
 
-void Alg_parameters::insert_integer(Alg_parameters **list, char *name, long i)
+void Alg_parameters::insert_integer(Alg_parameters **list, const char *name, 
+                                    long i)
 {
     Alg_parameters_ptr a = new Alg_parameters(*list);
     *list = a;
@@ -174,7 +178,8 @@ void Alg_parameters::insert_integer(Alg_parameters **list, char *name, long i)
 }
 
 
-void Alg_parameters::insert_logical(Alg_parameters **list, char *name, bool l)
+void Alg_parameters::insert_logical(Alg_parameters **list, const char *name, 
+                                    bool l)
 {
     Alg_parameters_ptr a = new Alg_parameters(*list);
     *list = a;
@@ -184,7 +189,8 @@ void Alg_parameters::insert_logical(Alg_parameters **list, char *name, bool l)
 }
 
 
-void Alg_parameters::insert_atom(Alg_parameters **list, char *name, char *s)
+void Alg_parameters::insert_atom(Alg_parameters **list, const char *name, 
+                                 const char *s)
 {
     Alg_parameters_ptr a = new Alg_parameters(*list);
     *list = a;
@@ -194,7 +200,8 @@ void Alg_parameters::insert_atom(Alg_parameters **list, char *name, char *s)
 }
 
 
-Alg_parameters *Alg_parameters::remove_key(Alg_parameters **list, const char *name)
+Alg_parameters *Alg_parameters::remove_key(Alg_parameters **list, 
+                                           const char *name)
 {
     while (*list) {
         if (STREQL((*list)->parm.attr_name(), name)) {
@@ -209,12 +216,12 @@ Alg_parameters *Alg_parameters::remove_key(Alg_parameters **list, const char *na
 }
 
 
-Alg_parameter_ptr Alg_parameters::find(Alg_attribute *attr)
+Alg_parameter_ptr Alg_parameters::find(Alg_attribute attr)
 {
     assert(attr);
     Alg_parameters_ptr temp = this;
     while (temp) {
-        if (temp->parm.attr == *attr) {
+        if (temp->parm.attr == attr) {
             return &(temp->parm);
         }
     }
@@ -226,9 +233,9 @@ int Alg_event::get_type_code()
 {
     if (!is_note()) {
         const char* attr = get_attribute();
-        if (STREQL(attr, "gate"))         // volume change
+        if (STREQL(attr, "gater"))         // volume change
             return ALG_GATE;
-        if (STREQL(attr, "bend"))         // pitch bend     
+        if (STREQL(attr, "bendr"))         // pitch bend     
             return ALG_BEND;
         if (strncmp(attr, "control", 7) == 0)      // control change
             // note that midi control changes have attributes of the form
@@ -237,15 +244,15 @@ int Alg_event::get_type_code()
             // We don't check for decimal numbers in the range 0-127, so any
             // attribute that begins with "control" is an ALG_CONTROL:
             return ALG_CONTROL;
-        if (STREQL(attr, "program"))      // program change
+        if (STREQL(attr, "programi"))      // program change
             return ALG_PROGRAM;
-        if (STREQL(attr, "pressure"))    // pressure change
+        if (STREQL(attr, "pressurer"))    // pressure change
             return ALG_PRESSURE;
-        if (STREQL(attr, "keysig"))       // key signature  
+        if (STREQL(attr, "keysigi"))       // key signature  
             return ALG_KEYSIG;
-        if (STREQL(attr, "timesig_num"))  // time signature numerator
+        if (STREQL(attr, "timesig_numi"))  // time signature numerator
             return ALG_TIMESIG_NUM;
-        if (STREQL(attr, "timesig_den"))  // time signature denominator
+        if (STREQL(attr, "timesig_deni"))  // time signature denominator
             return ALG_TIMESIG_DEN;
         return ALG_OTHER;
     }
@@ -258,7 +265,7 @@ void Alg_event::set_parameter(Alg_parameter_ptr new_parameter)
     Alg_parameter_ptr parm;
     if (is_note()) {
         Alg_note_ptr note = (Alg_note_ptr) this;
-        parm = note->parameters->find(&(new_parameter->attr));
+        parm = note->parameters->find(new_parameter->attr);
         if (!parm) {
             note->parameters = new Alg_parameters(note->parameters);
             parm = &(note->parameters->parm);
@@ -271,7 +278,7 @@ void Alg_event::set_parameter(Alg_parameter_ptr new_parameter)
 }
 
 
-void Alg_event::set_string_value(char *a, char *value)
+void Alg_event::set_string_value(const char *a, const char *value)
 {
     assert(a); // must be non-null
     Alg_attribute attr = symbol_table.insert_string(a);
@@ -284,7 +291,7 @@ void Alg_event::set_string_value(char *a, char *value)
 }
 
 
-void Alg_event::set_real_value(char *a, double value)
+void Alg_event::set_real_value(const char *a, double value)
 {
     assert(a); // must be non-null
     // attr is like a, but it has the type code prefixed for
@@ -300,7 +307,7 @@ void Alg_event::set_real_value(char *a, double value)
 }
 
 
-void Alg_event::set_logical_value(char *a, bool value)
+void Alg_event::set_logical_value(const char *a, bool value)
 {
     assert(a); // must be non-null
     Alg_attribute attr = symbol_table.insert_string(a);
@@ -313,7 +320,7 @@ void Alg_event::set_logical_value(char *a, bool value)
 }
 
 
-void Alg_event::set_integer_value(char *a, long value)
+void Alg_event::set_integer_value(const char *a, long value)
 {
     assert(a); // must be non-null
     Alg_attribute attr = symbol_table.insert_string(a);
@@ -326,7 +333,7 @@ void Alg_event::set_integer_value(char *a, long value)
 }
 
 
-void Alg_event::set_atom_value(char *a, char *value)
+void Alg_event::set_atom_value(const char *a, const char *value)
 {
     assert(a); // must be non-null
     Alg_attribute attr = symbol_table.insert_string(a);
@@ -402,18 +409,18 @@ void Alg_event::set_duration(double d)
 }
 
 
-bool Alg_event::has_attribute(char *a)
+bool Alg_event::has_attribute(const char *a)
 {
     assert(is_note());
     assert(a); // must be non-null
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     return parm != NULL;
 }
 
 
-char Alg_event::get_attribute_type(char *a)
+char Alg_event::get_attribute_type(const char *a)
 {
     assert(is_note());
     assert(a);
@@ -421,66 +428,66 @@ char Alg_event::get_attribute_type(char *a)
 }
 
 
-char *Alg_event::get_string_value(char *a, char *value)
+const char *Alg_event::get_string_value(const char *a, const char *value)
 {
     assert(is_note());
     assert(a); // must be non-null
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     assert(a[0] == 's'); // must be of type string
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     if (parm) return parm->s;
     return value;
 }
 
 
-double Alg_event::get_real_value(char *a, double value)
+double Alg_event::get_real_value(const char *a, double value)
 {	
     assert(is_note());
     assert(a);
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     assert(a[0] == 'r'); // must be of type real
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     if (parm) return parm->r;
     return value;
 }
 
 
-bool Alg_event::get_logical_value(char *a, bool value)
+bool Alg_event::get_logical_value(const char *a, bool value)
 {	
     assert(is_note());
     assert(a);
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     assert(a[0] == 'l'); // must be of type logical
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     if (parm) return parm->l;
     return value;
 }
 
 
-long Alg_event::get_integer_value(char *a, long value)
+long Alg_event::get_integer_value(const char *a, long value)
 {	
     assert(is_note());
     assert(a);
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     assert(a[0] == 'i'); // must be of type integer
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     if (parm) return parm->i;
     return value;
 }
 
 
-char *Alg_event::get_atom_value(char *a, char *value)
+const char *Alg_event::get_atom_value(const char *a, const char *value)
 {	
     assert(is_note());
     assert(a);
     Alg_note* note = (Alg_note *) this;
     Alg_attribute attr = symbol_table.insert_string(a);
     assert(a[0] == 'a'); // must be of type atom
-    Alg_parameter_ptr parm = note->parameters->find(&attr);
+    Alg_parameter_ptr parm = note->parameters->find(attr);
     if (parm) return parm->a;
     // if default is a string, convert to an atom (unique
     // string in symbol table) and return it
@@ -489,7 +496,7 @@ char *Alg_event::get_atom_value(char *a, char *value)
 }
 
 
-void Alg_event::delete_attribute(char *a)
+void Alg_event::delete_attribute(const char *a)
 {
     assert(is_note());
     Alg_note* note = (Alg_note *) this;
@@ -514,12 +521,12 @@ char Alg_event::get_update_type()
 }
 
 
-char *Alg_event::get_string_value()
+const char *Alg_event::get_string_value()
 {
     assert(is_update());
     Alg_update* update = (Alg_update *) this;
     assert(get_update_type() == 's');
-    return update->parameter.a;
+    return update->parameter.s;
 }
 
 
@@ -550,7 +557,7 @@ long Alg_event::get_integer_value()
 }
 
 
-char *Alg_event::get_atom_value()
+const char *Alg_event::get_atom_value()
 {
     assert(is_update());
     Alg_update* update = (Alg_update *) this;
@@ -566,7 +573,7 @@ bool Alg_event::overlap(double t, double len, bool all)
         return true;
     if (all && is_note()) {
         double dur = ((Alg_note_ptr) this)->dur;
-        // note ends within region
+        // note overlaps with region
         if (time < t && time + dur - ALG_EPS > t)
             return true;
     }
@@ -601,9 +608,9 @@ Alg_note::~Alg_note()
 
 void Alg_note::show()
 {
-    printf("Alg_note: time %g, chan %d, dur %g, key %d, "
+    printf("Alg_note: time %g, chan %ld, dur %g, key %ld, "
            "pitch %g, loud %g, attributes ",
-           time, (int) chan, dur, (int) key, pitch, loud);
+           time, chan, dur, key, pitch, loud);
     Alg_parameters_ptr parms = parameters;
     while (parms) {
         parms->parm.show();
@@ -670,6 +677,8 @@ Alg_event_ptr Alg_events::uninsert(long index)
 {
     assert(0 <= index && index < len);
     Alg_event_ptr event = events[index];
+    //printf("memmove: %x from %x (%d)\n", events + index, events + index + 1,
+    //        sizeof(Alg_event_ptr) * (len - index - 1));
     memmove(events + index, events + index + 1,
             sizeof(Alg_event_ptr) * (len - index - 1));
     len--;
@@ -695,6 +704,7 @@ void Alg_events::append(Alg_event_ptr event)
 
 Alg_events::~Alg_events()
 {
+    assert(!in_use);
     // individual events are not deleted, only the array
     if (events) {
         delete[] events;
@@ -729,8 +739,8 @@ void Alg_event_list::set_start_time(Alg_event *event, double t)
     // For Alg_track, change the time and move the event to the right place
     // For Alg_seq, find the track and do the update there
     
-	long index = 0, i;
-	Alg_track_ptr track_ptr = Alg_track_ptr();
+    long index, i;
+    Alg_track_ptr track_ptr;
     if (type == 'e') { // this is an Alg_event_list
         // make sure the owner has not changed its event set
         assert(events_owner && 
@@ -847,7 +857,12 @@ double Alg_time_map::beat_to_time(double beat)
         return beat;
     }
     int i = locate_beat(beat);
-    if (i == beats.len) {
+    // case 1: beat is between two time/beat pairs
+    if (0 < i && i < beats.len) {
+        mbi = &beats[i - 1];
+        mbi1 = &beats[i];
+    // case 2: beat is beyond last time/beat pair
+    } else if (i == beats.len) {
         if (last_tempo_flag) {
             return beats[i - 1].time + 
                    (beat - beats[i - 1].beat) / last_tempo;
@@ -858,11 +873,11 @@ double Alg_time_map::beat_to_time(double beat)
             mbi = &beats[i - 2];
             mbi1 = &beats[i - 1];
         }
-    } else {
-        mbi = &beats[i - 1];
-        mbi1 = &beats[i];
+    // case 3: beat is at time 0
+    } else /* if (i == 0) */ {
+        return beats[0].time;
     }
-    // whether w extrapolate or interpolate, the math is the same
+    // whether we extrapolate or interpolate, the math is the same
     double time_dif = mbi1->time - mbi->time;
     double beat_dif = mbi1->beat - mbi->beat;
     return mbi->time + (beat - mbi->beat) * time_dif / beat_dif;
@@ -945,12 +960,45 @@ bool Alg_time_map::insert_tempo(double tempo, double beat)
         // compute difference too
         diff = diff - old_diff;
         // apply new_diff to score and beats
+        i++;
         while (i < beats.len) {
             beats[i].time = beats[i].time + diff;
             i++;
         }
     }
     return true;
+}
+
+
+double Alg_time_map::get_tempo(double beat)
+{
+    Alg_beat_ptr mbi;
+    Alg_beat_ptr mbi1;
+    // if beat < 0, there is probably an error; return something nice anyway
+    if (beat < 0) return ALG_DEFAULT_BPM / 60.0;
+    long i = locate_beat(beat);
+    // this code is similar to beat_to_time() so far, but we want to get
+    // beyond beat if possible because we want the tempo FOLLOWING beat
+    // (Consider the case beat == 0.0)
+    if (i < beats.len && beat >= beats[i].beat) i++;
+    // case 1: beat is between two time/beat pairs
+    if (i < beats.len) {
+        mbi = &beats[i - 1];
+        mbi1 = &beats[i];
+    // case 2: beat is beyond last time/beat pair
+    } else /* if (i == beats.len) */ {
+        if (last_tempo_flag) {
+            return last_tempo;
+        } else if (i == 1) {
+            return ALG_DEFAULT_BPM / 60.0;
+        } else {
+            mbi = &beats[i - 2];
+            mbi1 = &beats[i - 1];
+        }
+    }
+    double time_dif = mbi1->time - mbi->time;
+    double beat_dif = mbi1->beat - mbi->beat;
+    return beat_dif / time_dif;
 }
 
 
@@ -972,6 +1020,34 @@ bool Alg_time_map::set_tempo(double tempo, double start_beat, double end_beat)
     }
     beats.len = start_x; // truncate the map to new length
     return insert_tempo(tempo, start_beat);
+}
+
+
+bool Alg_time_map::stretch_region(double b0, double b1, double dur)
+{
+    // find current duration
+    double t0 = beat_to_time(b0);
+    double t1 = beat_to_time(b1);
+    double old_dur = t1 - t0;
+    if (old_dur <= 0 || dur <= 0) return false;
+    double scale = dur / old_dur; // larger scale => slower
+    // insert a beat if necessary at b0 and b1
+    insert_beat(t0, b0);
+    insert_beat(t1, b1);
+    long start_x = locate_beat(b0);
+    long stop_x = locate_beat(b1);
+    double orig_time = beats[start_x].time;
+    double prev_time = orig_time;
+    for (int i = start_x + 1; i < beats.len; i++) {
+        double delta = beats[i].time - orig_time;
+        if (i <= stop_x) { // change tempo to next Alg_beat
+            delta *= scale;
+        }
+        orig_time = beats[i].time;
+        prev_time += delta;
+        beats[i].time = prev_time;
+    }
+    return true;
 }
 
 
@@ -1277,22 +1353,22 @@ void Alg_track::serialize(void **buffer, long *bytes)
     //
     // The format for a track is given within the Seq format above
     assert(get_type() == 't');
-    ser_buf.init_for_write();
+    ser_write_buf.init_for_write();
     serialize_track();
-    *buffer = ser_buf.to_heap(bytes); 
+    *buffer = ser_write_buf.to_heap(bytes); 
 }
 
 
 void Alg_seq::serialize(void **buffer, long *bytes)
 {	
     assert(get_type() == 's');
-    ser_buf.init_for_write();
+    ser_write_buf.init_for_write();
     serialize_seq();
-    *buffer = ser_buf.to_heap(bytes); 
+    *buffer = ser_write_buf.to_heap(bytes); 
 }
 
 
-void Serial_buffer::check_buffer(long needed)
+void Serial_write_buffer::check_buffer(long needed)
 {
     if (len < (ptr - buffer) + needed) { // do we need more space?
         long new_len = len * 2; // exponential growth is important
@@ -1301,9 +1377,11 @@ void Serial_buffer::check_buffer(long needed)
          // make sure new_len is as big as needed
         if (needed > new_len) new_len = needed;
         char *new_buffer = new char[new_len]; // allocate space
-        memcpy(new_buffer, buffer, len); // copy from old buffer
         ptr = new_buffer + (ptr - buffer); // relocate ptr to new buffer
-        delete buffer; // free old buffer
+        if (len > 0) { // we had a buffer already
+            memcpy(new_buffer, buffer, len); // copy from old buffer
+            delete buffer; // free old buffer
+        }
         buffer = new_buffer; // update buffer information
         len = new_len;
     }
@@ -1315,37 +1393,39 @@ void Alg_seq::serialize_seq()
     int i; // loop counters
     // we can easily compute how much buffer space we need until we
     // get to tracks, so expand at least that much
-    long needed = 48 + 16 * time_map->beats.len + 24 * time_sig.length();
-    ser_buf.check_buffer(needed);
-    ser_buf.set_char('A');
-    ser_buf.set_char('L');
-    ser_buf.set_char('G');
-    ser_buf.set_char('S');
-    long length_offset = ser_buf.get_posn();
-    ser_buf.set_int32(0); // leave room to come back and write length
-    ser_buf.set_int32(channel_offset_per_track);
-    ser_buf.set_int32(units_are_seconds);
-    ser_buf.set_double(time_map->last_tempo);
-    ser_buf.set_int32(time_map->last_tempo_flag);
-    ser_buf.set_int32(time_map->beats.len);
+    long needed = 64 + 16 * time_map->beats.len + 24 * time_sig.length();
+    ser_write_buf.check_buffer(needed);
+    ser_write_buf.set_char('A');
+    ser_write_buf.set_char('L');
+    ser_write_buf.set_char('G');
+    ser_write_buf.set_char('S');
+    long length_offset = ser_write_buf.get_posn();
+    ser_write_buf.set_int32(0); // leave room to come back and write length
+    ser_write_buf.set_int32(channel_offset_per_track);
+    ser_write_buf.set_int32(units_are_seconds);
+    ser_write_buf.set_double(beat_dur);
+    ser_write_buf.set_double(real_dur);
+    ser_write_buf.set_double(time_map->last_tempo);
+    ser_write_buf.set_int32(time_map->last_tempo_flag);
+    ser_write_buf.set_int32(time_map->beats.len);
     for (i = 0; i < time_map->beats.len; i++) {
-        ser_buf.set_double(time_map->beats[i].time);
-        ser_buf.set_double(time_map->beats[i].beat);
+        ser_write_buf.set_double(time_map->beats[i].time);
+        ser_write_buf.set_double(time_map->beats[i].beat);
     }
-    ser_buf.set_int32(time_sig.length());
-    ser_buf.pad();
+    ser_write_buf.set_int32(time_sig.length());
+    ser_write_buf.pad();
     for (i = 0; i < time_sig.length(); i++) {
-        ser_buf.set_double(time_sig[i].beat);
-        ser_buf.set_double(time_sig[i].num);
-        ser_buf.set_double(time_sig[i].den);
+        ser_write_buf.set_double(time_sig[i].beat);
+        ser_write_buf.set_double(time_sig[i].num);
+        ser_write_buf.set_double(time_sig[i].den);
     }
-    ser_buf.set_int32(tracks());
-    ser_buf.pad(); 
+    ser_write_buf.set_int32(tracks());
+    ser_write_buf.pad(); 
     for (i = 0; i < tracks(); i++) {
         track(i)->serialize_track();
     }
     // do not include ALGS, include padding at end
-    ser_buf.store_long(length_offset, ser_buf.get_posn() - length_offset);
+    ser_write_buf.store_long(length_offset, ser_write_buf.get_posn() - length_offset);
 }
 
 
@@ -1353,51 +1433,51 @@ void Alg_track::serialize_track()
 {
     // to simplify the code, copy from parameter addresses to locals
     int j;
-    ser_buf.check_buffer(32);
-    ser_buf.set_char('A');
-    ser_buf.set_char('L');
-    ser_buf.set_char('G');
-    ser_buf.set_char('T');
-    long length_offset = ser_buf.get_posn(); // save location for track length
-    ser_buf.set_int32(0); // room to write track length
-    ser_buf.set_int32(units_are_seconds);
-    ser_buf.set_double(beat_dur);
-    ser_buf.set_double(real_dur);
-    ser_buf.set_int32(len);
+    ser_write_buf.check_buffer(32);
+    ser_write_buf.set_char('A');
+    ser_write_buf.set_char('L');
+    ser_write_buf.set_char('G');
+    ser_write_buf.set_char('T');
+    long length_offset = ser_write_buf.get_posn(); // save location for track length
+    ser_write_buf.set_int32(0); // room to write track length
+    ser_write_buf.set_int32(units_are_seconds);
+    ser_write_buf.set_double(beat_dur);
+    ser_write_buf.set_double(real_dur);
+    ser_write_buf.set_int32(len);
     for (j = 0; j < len; j++) {
-        ser_buf.check_buffer(24);
+        ser_write_buf.check_buffer(24);
         Alg_event *event = (*this)[j];
-        ser_buf.set_int32(event->get_selected());
-        ser_buf.set_int32(event->get_type());
-        ser_buf.set_int32(event->get_identifier());
-        ser_buf.set_int32(event->chan);
-        ser_buf.set_double(event->time);
+        ser_write_buf.set_int32(event->get_selected());
+        ser_write_buf.set_int32(event->get_type());
+        ser_write_buf.set_int32(event->get_identifier());
+        ser_write_buf.set_int32(event->chan);
+        ser_write_buf.set_double(event->time);
         if (event->is_note()) {
-            ser_buf.check_buffer(20);
+            ser_write_buf.check_buffer(20);
             Alg_note *note = (Alg_note *) event;
-            ser_buf.set_float(note->pitch);
-            ser_buf.set_float(note->loud);
-            ser_buf.set_double(note->dur);
-            long parm_num_offset = ser_buf.get_posn();
+            ser_write_buf.set_float(note->pitch);
+            ser_write_buf.set_float(note->loud);
+            ser_write_buf.set_double(note->dur);
+            long parm_num_offset = ser_write_buf.get_posn();
             long parm_num = 0;
-            ser_buf.set_int32(0); // placeholder for no. parameters
+            ser_write_buf.set_int32(0); // placeholder for no. parameters
             Alg_parameters_ptr parms = note->parameters;
             while (parms) {
                 serialize_parameter(&(parms->parm));
                 parms = parms->next;
                 parm_num++;
             }
-            ser_buf.store_long(parm_num_offset, parm_num);
+            ser_write_buf.store_long(parm_num_offset, parm_num);
         } else {
             assert(event->is_update());
             Alg_update *update = (Alg_update *) event;
             serialize_parameter(&(update->parameter));
         }
-        ser_buf.check_buffer(7); // maximum padding possible
-        ser_buf.pad();
+        ser_write_buf.check_buffer(7); // maximum padding possible
+        ser_write_buf.pad();
     }
     // write length, not including ALGT, including padding at end
-    ser_buf.store_long(length_offset, ser_buf.get_posn() - length_offset);
+    ser_write_buf.store_long(length_offset, ser_write_buf.get_posn() - length_offset);
 }
 
 
@@ -1406,29 +1486,29 @@ void Alg_track::serialize_parameter(Alg_parameter *parm)
     // add eight to account for name + zero end-of-string and the
     // possibility of adding 7 padding bytes
     long len = strlen(parm->attr_name()) + 8;
-    ser_buf.check_buffer(len);
-    ser_buf.set_string(parm->attr_name());
-    ser_buf.pad();
+    ser_write_buf.check_buffer(len);
+    ser_write_buf.set_string(parm->attr_name());
+    ser_write_buf.pad();
     switch (parm->attr_type()) {
     case 'r':
-        ser_buf.check_buffer(8);
-        ser_buf.set_double(parm->r);
+        ser_write_buf.check_buffer(8);
+        ser_write_buf.set_double(parm->r);
         break;
     case 's':
-        ser_buf.check_buffer(strlen(parm->s) + 1);
-        ser_buf.set_string(parm->s);
+        ser_write_buf.check_buffer(strlen(parm->s) + 1);
+        ser_write_buf.set_string(parm->s);
         break;
     case 'i':
-        ser_buf.check_buffer(4);
-        ser_buf.set_int32(parm->i);
+        ser_write_buf.check_buffer(4);
+        ser_write_buf.set_int32(parm->i);
         break;
     case 'l':
-        ser_buf.check_buffer(4);
-        ser_buf.set_int32(parm->l);
+        ser_write_buf.check_buffer(4);
+        ser_write_buf.set_int32(parm->l);
         break;
     case 'a':
-        ser_buf.check_buffer(strlen(parm->a) + 1);
-        ser_buf.set_string(parm->a);
+        ser_write_buf.check_buffer(strlen(parm->a) + 1);
+        ser_write_buf.set_string(parm->a);
         break;
     }
 }
@@ -1438,55 +1518,69 @@ void Alg_track::serialize_parameter(Alg_parameter *parm)
 Alg_track *Alg_track::unserialize(void *buffer, long len)
 {
     assert(len > 8);
-    ser_buf.init_for_read(buffer, len);
-    bool alg = ser_buf.get_char() == 'A' &&
-               ser_buf.get_char() == 'L' &&
-               ser_buf.get_char() == 'G';
+    ser_read_buf.init_for_read(buffer, len);
+    bool alg = ser_read_buf.get_char() == 'A' &&
+               ser_read_buf.get_char() == 'L' &&
+               ser_read_buf.get_char() == 'G';
     assert(alg);
-    char c = ser_buf.get_char();
+    char c = ser_read_buf.get_char();
     if (c == 'S') {
         Alg_seq *seq = new Alg_seq;
+        ser_read_buf.unget_chars(4); // undo get_char() of A,L,G,S
         seq->unserialize_seq();
         return seq;
     } else {
         assert(c == 'T');
         Alg_track *track = new Alg_track;
+        ser_read_buf.unget_chars(4); // undo get_char() of A,L,G,T
         track->unserialize_track();
         return track;
     }
 }
 
 
+#pragma warning(disable: 4800) // long to bool performance warning
+
+/* Note: this Alg_seq must have a default initialized Alg_time_map.
+ * It will be filled in with data from the ser_read_buf buffer.
+ */
 void Alg_seq::unserialize_seq()
 {
-    ser_buf.check_input_buffer(28);
-    long len = ser_buf.get_int32();
-    assert(ser_buf.get_len() >= len);
-    channel_offset_per_track = ser_buf.get_int32();
-    units_are_seconds = (bool) ser_buf.get_int32();
-    time_map = new Alg_time_map();
-    time_map->last_tempo = ser_buf.get_double();
-    time_map->last_tempo_flag = (bool) ser_buf.get_int32();
-    long beats = ser_buf.get_int32();
-    ser_buf.check_input_buffer(beats * 16 + 4);
+    ser_read_buf.check_input_buffer(48);
+    bool algs = (ser_read_buf.get_char() == 'A') &&
+                (ser_read_buf.get_char() == 'L') &&
+                (ser_read_buf.get_char() == 'G') &&
+                (ser_read_buf.get_char() == 'S');
+    assert(algs);
+    long len = ser_read_buf.get_int32();
+    assert(ser_read_buf.get_len() >= len);
+    channel_offset_per_track = ser_read_buf.get_int32();
+    units_are_seconds = ser_read_buf.get_int32() != 0;
+    beat_dur = ser_read_buf.get_double();
+    real_dur = ser_read_buf.get_double();
+    // no need to allocate an Alg_time_map since it's done during initialization
+    time_map->last_tempo = ser_read_buf.get_double();
+    time_map->last_tempo_flag = ser_read_buf.get_int32() != 0;
+    long beats = ser_read_buf.get_int32();
+    ser_read_buf.check_input_buffer(beats * 16 + 4);
     int i;
     for (i = 0; i < beats; i++) {
-        double time = ser_buf.get_double();
-        double beat = ser_buf.get_double();
+        double time = ser_read_buf.get_double();
+        double beat = ser_read_buf.get_double();
         time_map->insert_beat(time, beat);
         // printf("time_map: %g, %g\n", time, beat);
     }
-    long time_sig_len = ser_buf.get_int32();
-    ser_buf.get_pad();
-    ser_buf.check_input_buffer(time_sig_len * 24 + 8);
+    long time_sig_len = ser_read_buf.get_int32();
+    ser_read_buf.get_pad();
+    ser_read_buf.check_input_buffer(time_sig_len * 24 + 8);
     for (i = 0; i < time_sig_len; i++) {
-        double beat = ser_buf.get_double();
-        double num = ser_buf.get_double();
-        double den = ser_buf.get_double();
+        double beat = ser_read_buf.get_double();
+        double num = ser_read_buf.get_double();
+        double den = ser_read_buf.get_double();
         time_sig.insert(beat, num, den);
     }
-    long tracks_num = ser_buf.get_int32();
-    ser_buf.get_pad();
+    long tracks_num = ser_read_buf.get_int32();
+    ser_read_buf.get_pad();
     add_track(tracks_num - 1); // create tracks_num tracks
     for (i = 0; i < tracks_num; i++) {
         track(i)->unserialize_track();
@@ -1494,40 +1588,41 @@ void Alg_seq::unserialize_seq()
     // assume seq started at beginning of buffer. len measures
     // bytes after 'ALGS' header, so add 4 bytes and compare to
     // current buffer position -- they should agree
-    assert(ser_buf.get_posn() == len + 4);
+    assert(ser_read_buf.get_posn() == len + 4);
 }
 
 
 void Alg_track::unserialize_track()
 {
-    ser_buf.check_input_buffer(32);
-    assert(ser_buf.get_char() == 'A');
-    assert(ser_buf.get_char() == 'L');
-    assert(ser_buf.get_char() == 'G');
-    assert(ser_buf.get_char() == 'T');
-    long offset = ser_buf.get_posn(); // stored length does not include 'ALGT'
-    long bytes = ser_buf.get_int32();
-    assert(bytes <= ser_buf.get_len() - offset);
-    units_are_seconds = (bool) ser_buf.get_int32();
-    beat_dur = ser_buf.get_double();
-    real_dur = ser_buf.get_double();
-    int event_count = ser_buf.get_int32();
+    ser_read_buf.check_input_buffer(32);
+    bool algt = (ser_read_buf.get_char() == 'A') &&
+                (ser_read_buf.get_char() == 'L') &&
+                (ser_read_buf.get_char() == 'G') &&
+                (ser_read_buf.get_char() == 'T');
+    assert(algt);
+    long offset = ser_read_buf.get_posn(); // stored length does not include 'ALGT'
+    long bytes = ser_read_buf.get_int32();
+    assert(bytes <= ser_read_buf.get_len() - offset);
+    units_are_seconds = (bool) ser_read_buf.get_int32();
+    beat_dur = ser_read_buf.get_double();
+    real_dur = ser_read_buf.get_double();
+    int event_count = ser_read_buf.get_int32();
     for (int i = 0; i < event_count; i++) {
-        ser_buf.check_input_buffer(24);
-        long selected = ser_buf.get_int32();
-        char type = (char) ser_buf.get_int32();
-        long key = ser_buf.get_int32();
-        long channel = ser_buf.get_int32();
-        double time = ser_buf.get_double();
+        ser_read_buf.check_input_buffer(24);
+        long selected = ser_read_buf.get_int32();
+        char type = (char) ser_read_buf.get_int32();
+        long key = ser_read_buf.get_int32();
+        long channel = ser_read_buf.get_int32();
+        double time = ser_read_buf.get_double();
         if (type == 'n') {
-            ser_buf.check_input_buffer(20);
-            float pitch = ser_buf.get_float();
-            float loud = ser_buf.get_float();
-            double dur = ser_buf.get_double();
+            ser_read_buf.check_input_buffer(20);
+            float pitch = ser_read_buf.get_float();
+            float loud = ser_read_buf.get_float();
+            double dur = ser_read_buf.get_double();
             Alg_note *note = 
                     create_note(time, channel, key, pitch, loud, dur);
-            note->set_selected(selected);
-            long param_num = ser_buf.get_int32();
+            note->set_selected(selected != 0);
+            long param_num = ser_read_buf.get_int32();
             int j;
             // this builds a list of parameters in the correct order
             // (although order shouldn't matter)
@@ -1541,42 +1636,43 @@ void Alg_track::unserialize_track()
         } else {
             assert(type == 'u');
             Alg_update *update = create_update(time, channel, key);
-            update->set_selected(selected);
+            update->set_selected(selected != 0);
             unserialize_parameter(&(update->parameter));
             append(update);
         }
-        ser_buf.get_pad();
+        ser_read_buf.get_pad();
     }
-    assert(offset + bytes == ser_buf.get_posn());
+    assert(offset + bytes == ser_read_buf.get_posn());
 }
 
 
 void Alg_track::unserialize_parameter(Alg_parameter_ptr parm_ptr)
 {
-    char *attr = ser_buf.get_string();
+    Alg_attribute attr = ser_read_buf.get_string();
     parm_ptr->attr = symbol_table.insert_string(attr);
     switch (parm_ptr->attr_type()) {
     case 'r':
-        ser_buf.check_input_buffer(8);
-        parm_ptr->r = ser_buf.get_double();
+        ser_read_buf.check_input_buffer(8);
+        parm_ptr->r = ser_read_buf.get_double();
         break;
     case 's':
-        parm_ptr->s = heapify(ser_buf.get_string());
+        parm_ptr->s = heapify(ser_read_buf.get_string());
         break;
     case 'i':
-        ser_buf.check_input_buffer(4);
-        parm_ptr->i = ser_buf.get_int32();
+        ser_read_buf.check_input_buffer(4);
+        parm_ptr->i = ser_read_buf.get_int32();
         break;
     case 'l':
-        ser_buf.check_input_buffer(4);
-        parm_ptr->l = (bool) ser_buf.get_int32();
+        ser_read_buf.check_input_buffer(4);
+        parm_ptr->l = ser_read_buf.get_int32() != 0;
         break;
     case 'a':
-        parm_ptr->a = symbol_table.insert_attribute(ser_buf.get_string());
+        parm_ptr->a = symbol_table.insert_attribute(ser_read_buf.get_string());
         break;
     }
 }
 
+#pragma warning(default: 4800)
 
 void Alg_track::set_time_map(Alg_time_map *map)
 {
@@ -1741,7 +1837,7 @@ void Alg_track::paste(double t, Alg_event_list *seq)
     assert(get_type() == 't');
     // seq can be an Alg_event_list, an Alg_track, or an Alg_seq
     // if it is an Alg_event_list, units_are_seconds must match
-    bool prev_units_are_seconds = false;
+    bool prev_units_are_seconds;
     if (seq->get_type() == 'e') {
         assert(seq->get_owner()->get_units_are_seconds() == units_are_seconds);
     } else { // make it match
@@ -1887,17 +1983,19 @@ Alg_event_list *Alg_track::find(double t, double len, bool all,
 
 void Alg_time_sigs::expand()
 {
+    assert(maxlen >= len);
     maxlen = (maxlen + 5);   // extra growth for small sizes
     maxlen += (maxlen >> 2); // add 25%
     Alg_time_sig_ptr new_time_sigs = new Alg_time_sig[maxlen];
     // now do copy
     memcpy(new_time_sigs, time_sigs, len * sizeof(Alg_time_sig));
-    if (time_sigs) delete[] time_sigs;
+    if (time_sigs)
+       delete[] time_sigs;
     time_sigs = new_time_sigs;
 }
 
 
-void Alg_time_sigs::insert(double beat, double num, double den)
+void Alg_time_sigs::insert(double beat, double num, double den, bool force)
 {
     // find insertion point:
     for (int i = 0; i < len; i++) {
@@ -1917,17 +2015,17 @@ void Alg_time_sigs::insert(double beat, double num, double den)
                 // check if redundant with implied initial 4/4 time sig:
                 (i == 0 && num == 4 && den == 4 &&
                  within(fmod(beat, 4), 0, ALG_EPS))) {
-                return; // redundant inserts are ignored here
+                if (!force) return; // redundant inserts can be ignored here
             }
             // make room for new event
             if (maxlen <= len) expand();
-            len++;
             // insert new event at i
             memmove(&time_sigs[i + 1], &time_sigs[i], 
                     sizeof(Alg_time_sig) * (len - i));
             time_sigs[i].beat = beat;
             time_sigs[i].num = num;
             time_sigs[i].den = den;
+            len++;
             return;
         }
     }
@@ -1959,55 +2057,225 @@ int Alg_time_sigs::find_beat(double beat)
 }
 
 
-void Alg_time_sigs::cut(double start, double end)
+double Alg_time_sigs::get_bar_len(double beat)
 {
-    // remove time_sig's from start to start+len -- these must be
-    //   in beats (not seconds)
-    // now rewrite time_sig[]: copy from i_in to i_out (more or less)
-    int i_in = 0;
-    int i_out = 0;
-    // first, figure out where to begin cut region
-    i_in = find_beat(start);
-    i_out = i_in;
-    // scan to end of cut region
-    while (i_in < len && time_sigs[i_in].beat < end) {
-        i_in = i_in + 1;
+    int i = find_beat(beat);
+    double num = 4.0;
+    double den = 4.0;
+    if (i != 0) {
+        num = time_sigs[i - 1].num;
+        den = time_sigs[i - 1].den;
     }
-    // change time_sig at start if necessary
-    //    there's a time_sig that was skipped if i_in > i_out. 
-    //    if that's true and the next time change is at end, we're
-    //    ok because it will be copied, but if the next time change
-    //    is after end, then maybe we should insert a time change
-    //    corresponding to what's in effect at end. We can skip this
-    //    insert if it corresponds to whatever is in effect at start
-    if (i_in > i_out && i_in < len && 
-        time_sigs[i_in].beat > end + ALG_EPS &&
-        (i_out == 0 || time_sigs[i_out - 1].num != time_sigs[i_in - 1].num ||
-         time_sigs[i_out - 1].den != time_sigs[i_in - 1].den)) {
-        time_sigs[i_out] = time_sigs[i_in - 1];
-        time_sigs[i_out].beat = start;
+    return 4 * num / den;
+}
+
+void Alg_time_sigs::cut(double start, double end, double dur)
+{
+    // remove time_sig's from start to end -- these must be
+    //   in beats (not seconds). 
+    // The duration of the whole sequence is dur (beats).
+
+    // If the first bar line after end comes before a time signature
+    // and does not fall on a bar line, insert a time signature at
+    // the time of the bar line to retain relative bar line positions
+
+    int i = find_beat(end);
+    // i is where you would insert a new time sig at beat, 
+    // Case 1: beat coincides with a time sig at i. Time signature
+    // at beat means that there is a barline at beat, so when beat
+    // is shifted to start, the relative barline positions are preserved
+    if (len > 0 &&
+        within(end, time_sigs[i].beat, ALG_EPS)) {
+        // beat coincides with time signature change, so end is on a barline
+        /* do nothing */ ;
+    // Case 2: there is no time signature before end
+    } else if (i == 0 && (len == 0 ||
+                          time_sigs[0].beat > end)) {
+        // If the next time signature does not fall on a barline,
+        // then end must not be on a barline, so there is a partial
+        // measure from end to the next barline. We need 
+        // a time signature there to preserve relative barline
+        // locations. It may be that the next bar after start is
+        // due to another time signature, in which case we do not
+        // need to insert anything.
+        double measures = end / 4.0;
+        double imeasures = ROUND(measures);
+        if (!within(measures, imeasures, ALG_EPS)) {
+            // start is not on a barline, maybe add one here:
+            double bar_loc = (int(measures) + 1) * 4.0;
+            if (bar_loc < dur - ALG_EPS &&
+                (len == 0 || time_sigs[0].beat > bar_loc + ALG_EPS)) {
+                insert(bar_loc, 4, 4, true); // forced insert
+            }
+        }
+    // This case should never be true because if i == 0, either there
+    // are no time signatures before beat (Case 2), 
+    // or there is one time signature at beat (Case 1)
+    } else if (i == 0) {
+        /* do nothing (might be good to assert(false)) */ ;
+    // Case 3: i-1 must be the effective time sig position
+    } else { 
+        // get the time signature in effect at end
+        Alg_time_sig &tsp = time_sigs[i - 1];
+        double beats_per_measure = (tsp.num * 4) / tsp.den;
+        double measures = (end - tsp.beat) / beats_per_measure;
+        int imeasures = ROUND(measures);
+        if (!within(measures, imeasures, ALG_EPS)) {
+            // end is not on a measure, so we need to insert a time sig
+            // to force a bar line at the first measure location after
+            // beat, if any
+            double bar_loc = tsp.beat + beats_per_measure * (int(measures) + 1);
+            // insert new time signature at bar_loc
+            // It will have the same time signature, but the position will
+            // force a barline to match the barline before the shift
+            // However, we should not insert a barline if there is a
+            // time signature earlier than the barline time
+            if (i < len /* time_sigs[i] is the last one */ &&
+                time_sigs[i].beat < bar_loc - ALG_EPS) {
+                /* do not insert because there's already a time signature */;
+            } else if (bar_loc < dur - ALG_EPS) {
+                insert(bar_loc, tsp.num, tsp.den, true); // forced insert
+            }
+        }
+        // else beat coincides with a barline, so no need for an extra
+        // time signature to force barline alignment
+    }
+
+    // Figure out if time signature at start matches
+    // the time signature at end. If not, we need to insert a
+    // time signature at end to force the correct time signature
+    // there. 
+    // Find time signature at start:
+    double start_num = 4.0; // default if no time signature specified
+    double start_den = 4.0;
+    i = find_beat(start);
+    // A time signature at start would go at index i, so the effective
+    // time signature prior to start is at i - 1. If i == 0, the default
+    // time signature is in effect prior to start.
+    if (i != 0) {
+        start_num = time_sigs[i - 1].num;
+        start_den = time_sigs[i - 1].den;
+    }
+    // Find the time signature at end:
+    double end_num = 4.0; // default if no time signature specified
+    double end_den = 4.0;
+    int j = find_beat(end);
+    if (j != 0) {
+        end_num = time_sigs[j - 1].num;
+        end_den = time_sigs[j - 1].den;
+    }
+    // compare: If meter changes and there is no time signature at end,
+    // insert a time signature at end
+    if (end < dur - ALG_EPS &&
+        (start_num != end_num || start_den != end_den) &&
+        (j >= len || !within(time_sigs[j].beat, end, ALG_EPS))) {
+        insert(end, end_num, end_den, true);
+    }
+
+    // Remove time signatures from start to end (not including one AT
+    // end, if there is one there. Be careful with ALG_EPS on that one.)
+
+    // since we may have inserted a time signature, find position again:
+    int i0 = find_beat(start);
+    int i1 = i0;
+    // scan to end of cut region
+    while (i1 < len && time_sigs[i1].beat < end - ALG_EPS) {
+        i1++;
     }
     // scan from end to len(time_sig)
-    while (i_in < length()) {
-        Alg_time_sig &ts = time_sigs[i_in];
-        ts.beat = ts.beat - (end - start);
-        time_sigs[i_out] = ts;
-        i_in = i_in + 1;
-        i_out = i_out + 1;
+    while (i1 < len) {
+        Alg_time_sig &ts = time_sigs[i1];
+        ts.beat -= (end - start);
+        time_sigs[i0] = ts;
+        i0++;
+        i1++;
     }
-    len = i_out;
+    len = i1;
 }
 
 
 void Alg_time_sigs::trim(double start, double end)
 {
-    // remove time_sig's not in [start, start+end)
+    // remove time_sig's not in [start, end), but retain
+    // barline positions relative to the notes. This means that
+    // if the meter (time signature) changes between start and
+    // end that we need to insert a time signature at start.
+    // Also, if trim() would cause barlines to move, we need to
+    // insert a time signature on a barline (timesignatures
+    // imply the beginning of a bar even if the previous bar
+    // does not have enough beats. Note that bars do not need
+    // to have an integer number of beats).
+    //
     // units must be in beats (not seconds)
-    // copy from i_in to i_out as we scan time_sig array
-    int i_in = 0;
-    int i_out = 0;
+    //
+    // Uses Alg_time_sigs::cut() to avoid writing a special case
+    double dur = end + 1000;
+    if (len > 0) {
+        dur = time_sigs[len - 1].beat + 1000;
+    }
+    cut(end, dur, dur);
+    cut(0, start, dur);
+
+#ifdef IGNORE_THIS_OLD_CODE
     // first, skip time signatures up to start
-    i_in = find_beat(start);
+    int i = find_beat(start);
+    // i is where you would insert a new time sig at beat, 
+    // Case 1: beat coincides with a time sig at i. Time signature
+    // at beat means that there is a barline at beat, so when beat
+    // is shifted to 0, the relative barline positions are preserved
+    if (len > 0 &&
+        within(start, time_sigs[i].beat, ALG_EPS)) {
+        // beat coincides with time signature change, so offset must
+        // be a multiple of beats
+        /* do nothing */ ;
+    // Case 2: there is no time signature before start
+    } else if (i == 0 && (len == 0 ||
+                             time_sigs[0].beat > start)) {
+        // If the next time signature does not fall on a barline,
+        // then start must not be on a barline, so there is a partial
+        // measure from start to the next barline. We need 
+        // a time signature there to preserve relative barline
+        // locations. It may be that the next bar after start is
+        // due to another time signature, in which case we do not
+        // need to insert anything.
+        double measures = start / 4.0;
+        double imeasures = ROUND(measures);
+        if (!within(measures, imeasures, ALG_EPS)) {
+            // start is not on a barline, maybe add one here:
+            double bar_loc = (int(measures) + 1) * 4.0;
+            if (len == 0 || time_sigs[1].beat > bar_loc + ALG_EPS) {
+                insert(bar_loc, 4, 4, true);
+            }
+        }
+    // This case should never be true because if i == 0, either there
+    // are no time signatures before beat (Case 2), 
+    // or there is one time signature at beat (Case 1)
+    } else if (i == 0) {
+        /* do nothing (might be good to assert(false)) */ ;
+    // Case 3: i-1 must be the effective time sig position
+    } else { 
+        i -= 1; // index the time signature in effect at start
+        Alg_time_sig &tsp = time_sigs[i];
+        double beats_per_measure = (tsp.num * 4) / tsp.den;
+        double measures = (start - tsp.beat) / beats_per_measure;
+        int imeasures = ROUND(measures);
+        if (!within(measures, imeasures, ALG_EPS)) {
+            // beat is not on a measure, so we need to insert a time sig
+            // to force a bar line at the first measure location after
+            // beat, if any
+            double bar_loc = tsp.beat + beats_per_measure * (int(measures) + 1);
+            // insert new time signature at bar_loc
+            // It will have the same time signature, but the position will
+            // force a barline to match the barline before the shift
+            insert(bar_loc, tsp.num, tsp.den, true);
+        } 
+        // else beat coincides with a barline, so no need for an extra
+        // time signature to force barline alignment
+    }
+    // since we may have inserted a time signature, find position again:
+    int i_in = find_beat(start);
+    int i_out = 0;
+       
     // put time_sig at start if necessary
     // if 0 < i_in < len, then the time sig at i_in is either
     // at start or after start. 
@@ -2034,7 +2302,7 @@ void Alg_time_sigs::trim(double start, double end)
         time_sigs[0].beat = 0.0;
         i_out = 1;
     }
-    // scan to end of cut region
+    // copy from i_in to i_out as we scan time_sig array to end of cut region
     while (i_in < len && time_sigs[i_in].beat < end - ALG_EPS) {
         Alg_time_sig &ts = time_sigs[i_in];
         ts.beat = ts.beat - start;
@@ -2043,6 +2311,7 @@ void Alg_time_sigs::trim(double start, double end)
         i_out++;
     }
     len = i_out;
+#endif
 }
 
 
@@ -2052,7 +2321,7 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     // show();
     Alg_time_sigs &from = seq->time_sig;
     // printf("time_sig::insert from\n");
-    from.show();
+    // from.show();
     // insert time signatures from seq into this time_sigs at start
     if (len == 0 && from.len == 0) {
         return; // default applies
@@ -2061,6 +2330,13 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     // remember the time signature at the splice point
     double num_after_splice = 4;
     double den_after_splice = 4; // default
+    double num_before_splice = 4;
+    double den_before_splice = 4; // default
+    // this is computed for use in aligning beats after the inserted 
+    // time signatures and duration. It is the position of time signature
+    // in effect immediately after start (the time signature will be 
+    // before start or at start)
+    double beat_after_splice = 0.0; 
     // three cases: 
     //  1) time sig at splice is at i-1
     //     for this, we must have len>0 & i>0
@@ -2073,13 +2349,23 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     if (len > 0 && i > 0 &&
         ((i < len && time_sigs[i].beat > start + ALG_EPS) ||
          (i == len))) {
+        // no time_signature at i
         num_after_splice = time_sigs[i-1].num;
         den_after_splice = time_sigs[i-1].den;
+        beat_after_splice = time_sigs[i - 1].beat;
+        num_before_splice = num_after_splice;
+        den_before_splice = den_after_splice;
     } else if (i < len && time_sigs[i].beat <= start + ALG_EPS) {
+        // time_signature at i is at "start" beats
         num_after_splice = time_sigs[i].num;
         den_after_splice = time_sigs[i].den;
+        beat_after_splice = start;
+        if (i > 0) { // time signature before start is at i - 1
+            num_before_splice = time_sigs[i-1].num;
+            den_before_splice = time_sigs[i-1].den;
+        }          
     }
-    // i is where insert will go, time_sig[i].beat > start
+    // i is where insert will go, time_sig[i].beat >= start
     // begin by adding duration to time_sig's at i and above
     // move time signatures forward by duration of seq
     double dur = seq->get_beat_dur();
@@ -2089,46 +2375,189 @@ void Alg_time_sigs::paste(double start, Alg_seq *seq)
     }
     //printf("time_sig::insert after making space\n");
     //show();
-    // now insert initial time_signature at start. This may create
+    // If time signature of "from" is not the effective time signature
+    // at start, insert a time_signature at start.  This may create
     // an extra measure if seq does not begin on a measure boundary
-    insert(start, 4, 4); // in case seq uses default starting signature
+    double num_of_insert = 4.0;
+    double den_of_insert = 4.0;
+    double beat_of_insert = 0.0;
+    int first_from_index = 0; // where to start copying from
+    if (from.length() > 0 && from[0].beat < ALG_EPS) {
+        // there is an initial time signature in "from"
+        num_of_insert = from[0].num;
+        den_of_insert = from[0].den;
+        // since we are handling the first time signature in from,
+        // we can start copying at index == 1:
+        first_from_index = 1;
+    }
+    // compare time signatures to see if we need a change at start:
+    if (num_before_splice != num_of_insert ||
+        den_before_splice != den_of_insert) {
+        // note that this will overwrite an existing time signature if
+        // it is within ALG_EPS of start -- this is correct because the
+        // existing time signature will already be recorded as
+        // num_after_splice and den_after_splice
+        insert(start, num_of_insert, den_of_insert);
+    }
     //printf("time_sig::insert after 4/4 at start\n");
     //show();
     // insert time signatures from seq offset by start
-    for (i = 0; i < from.length(); i++) {
-        insert(start + from[i].beat, from[i].num, from[i].den);
+    for (i = 0; i < from.length() && from[i].beat < dur - ALG_EPS; i++) {
+        num_of_insert = from[i].num; // keep latest time signature info
+        den_of_insert = from[i].den;
+        beat_of_insert = from[i].beat;
+        insert(start + beat_of_insert, num_of_insert, den_of_insert);
     }
     //printf("time_sig::insert after pasting in sigs\n");
     //show();
-    // now insert time signature at end of splice
-    insert(start + dur, num_after_splice, den_after_splice);
+    // now insert time signature at end of splice if necessary
+    // if the time signature changes, we need to insert a time signature
+    // immediately:
+    if (num_of_insert != num_after_splice &&
+        den_of_insert != den_after_splice) {
+        insert(start + dur, num_after_splice, den_after_splice);
+        num_of_insert = num_after_splice;
+        den_of_insert = den_after_splice;
+        beat_of_insert = start + dur;
+    }
+    // if the insert had a partial number of measures, we might need an
+    // additional time signature to realign the barlines after the insert
+    // To decide, we compare the beat of the first barline on or after
+    // start before the splice to the beat of the first barline on or
+    // after start + dur after the splice. In a sense, this is the "same"
+    // barline, so it should be shifted exactly by dur.
+    // First, compute the beat of the first barline on or after start:
+    double beats_per_measure = (num_after_splice * 4) / den_after_splice;
+    double measures = (start - beat_after_splice) / beats_per_measure;
+    // Measures might be slightly negative due to rounding. Use max()
+    // to eliminate any negative rounding error:
+    int imeasures = int(max(measures, 0.0));
+    double old_bar_loc = beat_after_splice + (imeasures * beats_per_measure);
+    if (old_bar_loc < start) old_bar_loc += beats_per_measure;
+    // now old_bar_loc is the original first bar position after start
+    // Do similar calculation for position after end after the insertion:
+    // beats_per_measure already calculated because signatures match
+    measures = (start + dur - beat_of_insert) / beats_per_measure;
+    imeasures = int(max(measures, 0.0));
+    double new_bar_loc = beat_of_insert + (imeasures * beats_per_measure);
+    if (new_bar_loc < start + dur) new_bar_loc += beats_per_measure;
+    // old_bar_loc should be shifted by dur:
+    old_bar_loc += dur;
+    // now the two bar locations should be equal, but due to rounding,
+    // they could be off by one measure
+    double diff = (new_bar_loc - old_bar_loc) + beats_per_measure;
+    double diff_in_measures = diff / beats_per_measure;
+    // if diff_in_measures is not (approximately) integer, we need to
+    // force a barline (time signature) after start + dur to maintain
+    // the relationship between barliness and notes
+    if (!within(diff_in_measures, ROUND(diff_in_measures), ALG_EPS)) {
+        // recall that old_bar_loc is shifted by dur
+        insert(old_bar_loc, num_after_splice, den_after_splice);
+    }
     //printf("time_sig::insert after sig at end of splice\n");
     //show();
 }
 
 
-void Alg_time_sigs::insert_beats(double beat, double len)
+void Alg_time_sigs::insert_beats(double start, double dur)
 {
-    int i;
-    // find the time_sig entry in effect at t
-    for (i = 0; i < len; i++) {
-        if (time_sigs[i].beat < beat + ALG_EPS) {
-            break;
+    int i = find_beat(start);
+
+    // time_sigs[i] is after beat and needs to shift
+    // Compute the time of the first bar at or after beat so that
+    // a bar can be placed at bar_loc + dur
+    double tsnum = 4.0;
+    double tsden = 4.0;
+    double tsbeat = 0.0; // defaults
+    
+    // three cases: 
+    //  1) time sig at splice is at i-1
+    //     for this, we must have len>0 & i>0
+    //     two sub-cases:
+    //       A) i < len && time_sig[i].beat > start
+    //       B) i == len
+    //  2) time_sig at splice is at i
+    //     for this, i < len && time_sig[i].beat ~= start
+    //  3) time_sig at splice is default 4/4
+    if (len > 0 && i > 0 &&
+        ((i < len && time_sigs[i].beat > start + ALG_EPS) ||
+         (i == len))) {
+        // no time_signature at i
+        tsnum = time_sigs[i-1].num;
+        tsden = time_sigs[i-1].den;
+        tsbeat = time_sigs[i-1].beat;
+    } else if (i < len && time_sigs[i].beat <= start + ALG_EPS) {
+        // time_signature at i is at "start" beats
+        tsnum = time_sigs[i].num;
+        tsden = time_sigs[i].den;
+        tsbeat = start;
+        i++; // we want i to be index of next time signature after start
+    }
+    // invariant: i is index of next time signature after start
+
+    // increase beat times from i to len - 1 by dur
+    for (int j = i; j < len; j++) {
+        time_sigs[j].beat += dur;
+    }
+
+    // insert a time signature to maintain bar positions if necessary
+    double beats_per_measure = (tsnum * 4) / tsden;
+    double measures = dur / beats_per_measure; // shift distance
+    int imeasures = ROUND(measures);
+    if (!within(measures, imeasures, ALG_EPS)) {
+        // shift is not a whole number of measures, so we may need to insert
+        // time signature after silence
+        // compute measures from time signature to next bar after time
+        measures = (start - tsbeat) / beats_per_measure;
+        // round up and add to tsbeat to get time of next bar
+        double bar_loc = tsbeat + beats_per_measure * (int(measures) + 1);
+        // translate bar_loc by len:
+        bar_loc += dur; // this is where we want a bar to be, but maybe
+        // there is a time signature change before bar, in which case we
+        // should not insert a new time signature
+        // The next time signature after start is at i if i < len
+        if (i < len && time_sigs[i].beat < bar_loc) {
+            /* do not insert */;
+        } else {
+            insert(bar_loc, tsnum, tsden);
         }
     }
-    // now, increase beat times by len
-    for (; i < len; i++) {
-        time_sigs[i].beat += len;
+}
+
+
+double Alg_time_sigs::nearest_beat(double beat)
+{
+    int i = find_beat(beat);
+    // i is where we would insert time signature at beat
+    // case 1: there is no time signature
+    if (i == 0 && len == 0) {
+        return ROUND(beat);
+    // case 2: beat falls approximately on time signature
+    } else if (i < len && within(time_sigs[i].beat, beat, ALG_EPS)) {
+        return time_sigs[i].beat;
+    // case 3: beat is after no time signature and before one
+    } else if (i == 0) {
+        double trial_beat = ROUND(beat);
+        // it is possible that we rounded up past a time signature
+        if (trial_beat > time_sigs[0].beat - ALG_EPS) {
+            return time_sigs[0].beat;
+        }
+        return trial_beat;
     }
+    // case 4: beat is after some time signature
+    double trial_beat = time_sigs[i - 1].beat + 
+                        ROUND(beat - time_sigs[i - 1].beat);
+    // rounding may advance trial_beat past next time signature:
+    if (i < len && trial_beat > time_sigs[i].beat - ALG_EPS) {
+        return time_sigs[i].beat;
+    }      
+    return trial_beat;
 }
 
 
 Alg_tracks::~Alg_tracks()
 {
-    // Alg_events objects (track data) are not deleted, only the array
-    if (tracks) {
-        delete[] tracks;
-    }
+    reset();
 }
 
 
@@ -2193,16 +2622,165 @@ void Alg_tracks::reset()
     // all track events are incorporated into the seq,
     // so all we need to delete are the arrays of pointers
     for (int i = 0; i < len; i++) {
+        // printf("deleting track at %d (%x, this %x) = %x\n", i, &(tracks[i]), 
+        //       this, tracks[i]);
         delete tracks[i];
     }
     if (tracks) delete [] tracks;
     tracks = NULL;
     len = 0;
-    maxlen = 0;               // Modified by Ning Hu Nov.19 2002
+    maxlen = 0;
 }
 
 
-Alg_seq::Alg_seq(const char *filename, bool smf)
+void Alg_tracks::set_in_use(bool flag)
+{
+    for (int i = 0; i < len; i++) {
+        tracks[i]->in_use = flag;
+    }
+}
+
+
+void Alg_iterator::expand_to(int new_max)
+{
+    maxlen = new_max;
+    Alg_pending_event_ptr new_pending_events = new Alg_pending_event[maxlen];
+    // now do copy
+    memcpy(new_pending_events, pending_events, 
+           len * sizeof(Alg_pending_event));
+    if (pending_events) {
+        delete[] pending_events;
+    }
+    pending_events = new_pending_events;
+}	
+
+
+void Alg_iterator::expand()
+{
+    maxlen = (maxlen + 5);   // extra growth for small sizes
+    maxlen += (maxlen >> 2); // add 25%
+    expand_to(maxlen);
+}
+
+
+Alg_iterator::~Alg_iterator()
+{
+    if (pending_events) {
+        delete[] pending_events;
+    }
+}
+
+
+/* in the heap, the children of N are (N+1)*2 and (N+1)*2-1, so
+ * the parent of N is (N+1)/2-1. This would be easier if arrays
+ * were 1-based instead of 0-based
+ */
+#define HEAP_PARENT(loc) ((((loc) + 1) / 2) - 1)
+#define FIRST_CHILD(loc) (((loc) * 2) + 1)
+
+void Alg_iterator::show()
+{
+    for (int i = 0; i < len; i++) {
+        Alg_pending_event_ptr p = &(pending_events[i]);
+        printf("    %d: %p[%ld]@%g on %d\n", i, p->events, p->index, 
+               p->offset, p->note_on);
+    }
+}
+
+
+bool Alg_iterator::earlier(int i, int j)
+// see if event i is earlier than event j
+{
+    // note-offs are scheduled ALG_EPS early so that if a note-off is
+    // followed immediately with the same timestamp by a note-on (common
+    // in MIDI files), the note-off will be scheduled first
+
+    double t_i = pending_events[i].time;
+    double t_j = pending_events[j].time;
+
+    if (t_i < t_j) return true;
+    // not sure if this case really exists or this is the best rule, but
+    // we want to give precedence to note-off events
+    else if (t_i == t_j && pending_events[j].note_on) return true;
+    return false;
+}
+
+
+void Alg_iterator::insert(Alg_events_ptr events, long index, 
+                          bool note_on, void *cookie, double offset)
+{
+    if (len == maxlen) expand();
+    pending_events[len].events = events;
+    pending_events[len].index = index;
+    pending_events[len].note_on = note_on;
+    pending_events[len].cookie = cookie;
+    pending_events[len].offset = offset;
+    Alg_event_ptr event = (*events)[index];
+    pending_events[len].time = (note_on ?  event->time : 
+                                event->get_end_time() - ALG_EPS) + offset;
+    /* BEGIN DEBUG *
+        printf("insert %p=%p[%d] @ %g\n", event, events, index, 
+               pending_events[len].time);
+        printf("    is_note %d note_on %d time %g dur %g end_time %g offset %g\n",
+               event->is_note(), note_on, event->time, event->get_duration(), 
+               event->get_end_time(), offset);
+    }
+     * END DEBUG */
+    int loc = len;
+    int loc_parent = HEAP_PARENT(loc);
+    len++;
+    // sift up:
+    while (loc > 0 &&
+           earlier(loc, loc_parent)) {
+        // swap loc with loc_parent
+        Alg_pending_event temp = pending_events[loc];
+        pending_events[loc] = pending_events[loc_parent];
+        pending_events[loc_parent] = temp;
+        loc = loc_parent;
+        loc_parent = HEAP_PARENT(loc);
+    }
+}
+
+
+bool Alg_iterator::remove_next(Alg_events_ptr &events, long &index, 
+                               bool &note_on, void *&cookie, 
+                               double &offset, double &time)
+{
+    if (len == 0) return false; // empty!
+    events = pending_events[0].events;
+    index = pending_events[0].index;
+    note_on = pending_events[0].note_on;
+    offset = pending_events[0].offset;
+    cookie = pending_events[0].cookie;
+    offset = pending_events[0].offset;
+    time = pending_events[0].time;
+    len--;
+    pending_events[0] = pending_events[len];
+    // sift down
+    long loc = 0;
+    long loc_child = FIRST_CHILD(loc);
+    while (loc_child < len) {
+        if (loc_child + 1 < len) {
+            if (earlier(loc_child + 1, loc_child)) {
+                loc_child++;
+            }
+        }
+        if (earlier(loc_child, loc)) {
+            Alg_pending_event temp = pending_events[loc];
+            pending_events[loc] = pending_events[loc_child];
+            pending_events[loc_child] = temp;
+            loc = loc_child;
+            loc_child = FIRST_CHILD(loc);
+        } else {
+            loc_child = len;
+        }
+    }
+    //    printf("After remove:"); show();
+    return true;
+}
+
+
+Alg_seq::Alg_seq(const char *filename, bool smf, double *offset_ptr)
 {
     basic_initialization();
     ifstream inf(filename, smf ? ios::binary | ios::in : ios::in);
@@ -2212,20 +2790,22 @@ Alg_seq::Alg_seq(const char *filename, bool smf)
     }
     if (smf) {
         error = alg_smf_read(inf, this);
+        if (offset_ptr) *offset_ptr = 0.0;
     } else {
-        error = alg_read(inf, this);
+        error = alg_read(inf, this, offset_ptr);
     }
     inf.close();
 }
 
 
-Alg_seq::Alg_seq(istream &file, bool smf)
+Alg_seq::Alg_seq(istream &file, bool smf, double *offset_ptr)
 {
     basic_initialization();
     if (smf) {
         error = alg_smf_read(file, this);
+        if (offset_ptr) *offset_ptr = 0.0;
     } else {
-        error = alg_read(file, this);
+        error = alg_read(file, this, offset_ptr);
     }
 }
 
@@ -2284,8 +2864,8 @@ Alg_track_ptr Alg_seq::track(int i)
     return &(track_list[i]);
 }
 
+#pragma warning(disable: 4715) // ok not to return a value here
 
-#pragma GCC diagnostic ignored "-Wreturn-type" // ok not to return a value here
 Alg_event_ptr &Alg_seq::operator[](int i) 
 {
     int ntracks = track_list.length();
@@ -2299,8 +2879,9 @@ Alg_event_ptr &Alg_seq::operator[](int i)
         }
         tr++;
     }
-	assert(false); // out of bounds
+    assert(false); // out of bounds
 }
+#pragma warning(default: 4715)
 
 
 void Alg_seq::convert_to_beats()
@@ -2369,11 +2950,12 @@ Alg_seq_ptr Alg_seq::cut(double start, double len, bool all)
     // return sequence from start to start+len and modify this
     // sequence by removing that time-span
 {
+    double dur = get_dur();
     // fix parameters to fall within existing sequence
-    if (start > get_dur()) return NULL; // nothing to cut
+    if (start > dur) return NULL; // nothing to cut
     if (start < 0) start = 0; // can't start before sequence starts
-    if (start + len > get_dur()) // can't cut after end:
-        len = get_dur() - start; 
+    if (start + len > dur) // can't cut after end:
+        len = dur - start; 
 
     Alg_seq_ptr result = new Alg_seq();
     Alg_time_map_ptr map = new Alg_time_map(get_time_map());
@@ -2399,11 +2981,13 @@ Alg_seq_ptr Alg_seq::cut(double start, double len, bool all)
     // we use len.
     double ts_start = start;
     double ts_end = start + len;
+    double ts_dur = dur;
     double ts_last_note_off = start + result->last_note_off;
     if (units_are_seconds) {
         ts_start = time_map->time_to_beat(ts_start);
         ts_end = time_map->time_to_beat(ts_end);
         ts_last_note_off = time_map->time_to_beat(ts_last_note_off);
+        ts_dur = time_map->time_to_beat(ts_dur);
     }
     // result is shifted from start to 0 and has length len, but
     // time_sig and time_map are copies from this. Adjust time_sig,
@@ -2425,9 +3009,9 @@ Alg_seq_ptr Alg_seq::cut(double start, double len, bool all)
     // we sliced out a portion of each track, so now we need to
     // slice out the corresponding sections of time_sig and time_map
     // as well as to adjust the duration.
-    time_sig.cut(ts_start, ts_end);
+    time_sig.cut(ts_start, ts_end, ts_dur);
     time_map->cut(start, len, units_are_seconds);
-    set_dur(get_dur() - len);
+    set_dur(dur - len);
 
     return result;
 }
@@ -2456,9 +3040,11 @@ void Alg_seq::insert_silence(double t, double len)
     } else {
         time_map->insert_beats(t_beats, len_beats);
     }
-    if (time_sig.length() > 0) {
-        time_sig.insert_beats(t_beats, len_beats);
-    }
+    time_sig.insert_beats(t_beats, len_beats);
+    // Final duration is defined to be t + len + whatever was
+    // in the sequence after t (if any). This translates to
+    // t + len + max(dur - t, 0)
+    set_dur(t + len + max(get_dur() - t, 0.0));
 }
 
 
@@ -2516,9 +3102,9 @@ Alg_seq *Alg_seq::copy(double start, double len, bool all)
 
 void Alg_seq::paste(double start, Alg_seq *seq)
 {
-    // insert seq at time; open up space for it
-    // to manipulate time map, we need units as beats
-    // save original form so we can convert back if necessary
+    // Insert seq at time, opening up space for it.
+    // To manipulate time map, we need units as beats.
+    // Save original form so we can convert back if necessary.
     bool units_should_be_seconds = units_are_seconds;
     bool seq_units_should_be_seconds = seq->get_units_are_seconds();
     if (units_are_seconds) {
@@ -2595,10 +3181,11 @@ void Alg_seq::clear_track(int track_num, double start, double len, bool all)
 void Alg_seq::clear(double start, double len, bool all)
 {
     // Fix parameters to fall within existing sequence
-    if (start > get_dur()) return; // nothing to cut
+    double dur = get_dur();
+    if (start > dur) return; // nothing to cut
     if (start < 0) start = 0; // can't start before sequence starts
-    if (start + len > get_dur()) // can't cut after end:
-        len = get_dur() - start;
+    if (start + len > dur) // can't cut after end:
+        len = dur - start;
 
     for (int i = 0; i < tracks(); i++)
         clear_track(i, start, len, all);
@@ -2606,17 +3193,19 @@ void Alg_seq::clear(double start, double len, bool all)
     // Put units in beats to match time_sig's.
     double ts_start = start;
     double ts_end = start + len;
+    double ts_dur = dur;
     if (units_are_seconds) {
         ts_start = time_map->time_to_beat(ts_start);
         ts_end = time_map->time_to_beat(ts_end);
+        ts_dur = time_map->time_to_beat(ts_dur);
     }
 
     // we sliced out a portion of each track, so now we need to
     // slice out the corresponding sections of time_sig and time_map
     // as well as to adjust the duration.
-    time_sig.cut(ts_start, ts_end);
+    time_sig.cut(ts_start, ts_end, ts_dur);
     time_map->cut(start, len, units_are_seconds);
-    set_dur(get_dur() - len);
+    set_dur(dur - len);
 }
 
 
@@ -2674,6 +3263,26 @@ bool Alg_seq::insert_beat(double time, double beat)
 }
 
 
+// input is time, return value is time
+double Alg_seq::nearest_beat_time(double time, double *beat)
+{
+    double b = time_map->time_to_beat(time);
+    b = time_sig.nearest_beat(b);
+    if (beat) *beat = b;
+    return time_map->beat_to_time(b);
+}
+
+
+bool Alg_seq::stretch_region(double b0, double b1, double dur)
+{
+    bool units_should_be_seconds = units_are_seconds;
+    convert_to_beats();
+    bool result = time_map->stretch_region(b0, b1, dur);
+    if (units_should_be_seconds) convert_to_seconds();
+    return result;
+}
+
+
 bool Alg_seq::insert_tempo(double bpm, double beat)
 {
     double bps = bpm / 60.0; // convert to beats per second
@@ -2724,6 +3333,12 @@ void Alg_seq::add_event(Alg_event_ptr event, int track_num)
 }
 
 
+double Alg_seq::get_tempo(double beat)
+{
+    return time_map->get_tempo(beat);
+}
+
+
 bool Alg_seq::set_tempo(double bpm, double start_beat, double end_beat)
 // set tempo from start_beat to end_beat
 {
@@ -2731,9 +3346,18 @@ bool Alg_seq::set_tempo(double bpm, double start_beat, double end_beat)
     if (start_beat >= end_beat) return false;
     bool units_should_be_seconds = units_are_seconds;
     convert_to_beats();
+    double dur = get_dur();
     bool result = time_map->set_tempo(bpm, start_beat, end_beat);
+    // preserve sequence duration in beats when tempo changes
+    set_dur(dur);
     if (units_should_be_seconds) convert_to_seconds();
     return result;
+}
+
+
+double Alg_seq::get_bar_len(double beat)
+{
+    return time_sig.get_bar_len(beat);
 }
 
 
@@ -2799,43 +3423,61 @@ void Alg_seq::set_events(Alg_event_ptr *events, long len, long max)
 */
 
 
-void Alg_seq::iteration_begin()
+void Alg_iterator::begin_seq(Alg_seq_ptr s, void *cookie, double offset)
 {
     // keep an array of indexes into tracks
-    current = new long[track_list.length()];
+    // printf("new pending\n");
     int i;
-    for (i = 0; i < track_list.length(); i++) {
-        current[i] = 0;
+    for (i = 0; i < s->track_list.length(); i++) {
+        if (s->track_list[i].length() > 0) {
+            insert(&(s->track_list[i]), 0, true, cookie, offset);
+        }
     }    
 }
 
 
-Alg_event_ptr Alg_seq::iteration_next()
+Alg_event_ptr Alg_iterator::next(bool *note_on, void **cookie_ptr, 
+                                 double *offset_ptr, double end_time)
     // return the next event in time from any track
 {
-    long cur;           // a track index
-    // find lowest next time of any track:
-    double next = 1000000.0;
-    int i, track = 0;
-    for (i = 0; i < track_list.length(); i++) {
-        Alg_track &tr = track_list[i];
-        cur = current[i];
-        if (cur < tr.length() && tr[cur]->time < next) {
-            next = tr[cur]->time;
-            track = i;
-        }
-    }
-    if (next < 1000000.0) {
-        return track_list[track][current[track]++];
-    } else {
+    bool on;
+    double when;
+    if (!remove_next(events_ptr, index, on, cookie, offset, when)) {
         return NULL;
     }
+    if (note_on) *note_on = on;
+    Alg_event_ptr event = (*events_ptr)[index];
+    if (on) {
+        if (note_off_flag && event->is_note() &&
+            (end_time == 0 ||
+             (*events_ptr)[index]->get_end_time() + offset < end_time)) {
+            // this was a note-on, so insert pending note-off
+            insert(events_ptr, index, false, cookie, offset);
+        }
+        // for both note-ons and updates, insert next event (at index + 1)
+        // DO NOT INCREMENT index: it must be preserved for request_note_off()
+        if (index + 1 < events_ptr->length() &&
+            (end_time == 0 || // zero means ignore end time
+             // stop iterating when end time is reached
+             (*events_ptr)[index + 1]->time + offset < end_time)) {
+            insert(events_ptr, index + 1, true, cookie, offset);
+        }
+    }
+    if (cookie_ptr) *cookie_ptr = cookie;
+    if (offset_ptr) *offset_ptr = offset;
+    return event;
 }
 
 
-void Alg_seq::iteration_end()
+void Alg_iterator::request_note_off()
 {
-    delete[] current;
+    assert(index >= 0 && index < events_ptr->length());
+    insert(events_ptr, index, false, cookie, offset);
+}
+
+
+void Alg_iterator::end()
+{
 }
 
 
@@ -2848,17 +3490,25 @@ void Alg_seq::merge_tracks()
     }
     // preallocate array for efficiency:
     Alg_event_ptr *notes = new Alg_event_ptr[sum];
-    iteration_begin();
+    Alg_iterator iterator(this, false);
+    iterator.begin();
     long notes_index = 0;
 
     Alg_event_ptr event;
-    while (( event = iteration_next() )) {
+    while ((event = iterator.next())) {
         notes[notes_index++] = event;
     }
     track_list.reset(); // don't need them any more
     add_track(0);
     track(0)->set_events(notes, sum, sum);
-    iteration_end();
+    iterator.end();
+}
+
+
+void Alg_seq::set_in_use(bool flag)
+{
+    Alg_track::set_in_use(flag);
+    track_list.set_in_use(flag);
 }
 
 

--- a/plugins/MidiImport/portsmf/allegrord.cpp
+++ b/plugins/MidiImport/portsmf/allegrord.cpp
@@ -40,6 +40,7 @@ public:
     int find_real_in(string &field, int n);
     double parse_real(string &field);
     void parse_error(string &field, long offset, char *message);
+    void parse_error(string &field, long offset, const char *message);
     double parse_dur(string &field, double base);
     double parse_after_dur(double dur, string &field, int n, double base);
     double parse_loud(string &field);
@@ -116,19 +117,19 @@ Alg_parameters_ptr Alg_reader::process_attributes(
     if (attributes) {
         Alg_parameters_ptr a;
         bool in_seconds = seq->get_units_are_seconds();
-        if (a = Alg_parameters::remove_key(&attributes, "tempor")) {
+        if ((a = Alg_parameters::remove_key(&attributes, "tempor"))) {
             double tempo = a->parm.r;
             seq->insert_tempo(tempo, seq->get_time_map()->time_to_beat(time));
         }
-        if (a = Alg_parameters::remove_key(&attributes, "beatr")) {
+        if ((a = Alg_parameters::remove_key(&attributes, "beatr"))) {
             double beat = a->parm.r;
             seq->insert_beat(time, beat);
         }
-        if (a = Alg_parameters::remove_key(&attributes, "timesig_numr")) {
+        if ((a = Alg_parameters::remove_key(&attributes, "timesig_numr"))) {
             tsnum = a->parm.r;
             ts_flag = true;
         }
-        if (a = Alg_parameters::remove_key(&attributes, "timesig_denr")) {
+        if ((a = Alg_parameters::remove_key(&attributes, "timesig_denr"))) {
             tsden = a->parm.r;
             ts_flag = true;
         }
@@ -158,7 +159,7 @@ bool Alg_reader::parse()
     while (line_parser_flag) {
         bool time_flag = false;
         bool next_flag = false;
-        double next;
+        double next = 0;
         bool voice_flag = false;
         bool loud_flag = false;
         bool dur_flag = false;
@@ -422,11 +423,11 @@ bool Alg_reader::parse()
 long Alg_reader::parse_chan(string &field)
 {
     const char *int_string = field.c_str() + 1;
-    char *msg = "Integer or - expected";
+    const char *msg = "Integer or - expected";
     const char *p = int_string;
     char c;
     // check that all chars in int_string are digits or '-':
-    while (c = *p++) {
+    while ((c = *p++)) {
         if (!isdigit(c) && c != '-') {
             parse_error(field, p - field.c_str() - 1, msg);
             return 0;
@@ -449,11 +450,11 @@ long Alg_reader::parse_chan(string &field)
 long Alg_reader::parse_int(string &field)
 {
     const char *int_string = field.c_str() + 1;
-    char *msg = "Integer expected";
+    const char *msg = "Integer expected";
     const char *p = int_string;
     char c;
     // check that all chars in int_string are digits:
-    while (c = *p++) {
+    while ((c = *p++)) {
         if (!isdigit(c)) {
             parse_error(field, p - field.c_str() - 1, msg);
             return 0;
@@ -491,7 +492,7 @@ int Alg_reader::find_real_in(string &field, int n)
 
 double Alg_reader::parse_real(string &field)
 {
-    char *msg = "Real expected";
+    const char *msg = "Real expected";
     int last = find_real_in(field, 1);
     string real_string = field.substr(1, last - 1);
     if (last <= 1 || last < (int) field.length()) {
@@ -514,15 +515,20 @@ void Alg_reader::parse_error(string &field, long offset, char *message)
     printf("    %s\n", message);
 }
 
+void Alg_reader::parse_error(string &field, long offset, const char *message)
+{
+    parse_error(field, offset, const_cast<char*>(message));
+}
+
 
 double duration_lookup[] = { 0.25, 0.5, 1.0, 2.0, 4.0 };
 
 
 double Alg_reader::parse_dur(string &field, double base)
 {
-    char *msg = "Duration expected";
-    char *durs = "SIQHW";
-    char *p;
+    const char *msg = "Duration expected";
+    const char *durs = "SIQHW";
+    const char *p;
     int last;
     double dur;
     if (field.length() < 2) {
@@ -535,7 +541,7 @@ double Alg_reader::parse_dur(string &field, double base)
         // convert dur from seconds to beats
         dur = seq->get_time_map()->time_to_beat(base + dur) - 
               seq->get_time_map()->time_to_beat(base);
-    } else if (p = strchr(durs, toupper(field[1]))) {
+    } else if ((p = strchr(durs, toupper(field[1])))) {
         dur = duration_lookup[p - durs];
         last = 2;
     } else {
@@ -578,7 +584,7 @@ double Alg_reader::parse_after_dur(double dur, string &field,
 }
 
 struct loud_lookup_struct {
-    char *str;
+    const char *str;
     int val;
 } loud_lookup[] = { {"FFF", 127}, {"FF", 120}, {"F", 110}, {"MF", 100}, 
                     {"MP", 90}, {"P", 80}, {"PP", 70}, {"PPP", 60}, 
@@ -587,7 +593,7 @@ struct loud_lookup_struct {
 
 double Alg_reader::parse_loud(string &field)
 {
-    char *msg = "Loudness expected";
+    const char *msg = "Loudness expected";
     if (isdigit(field[1])) {
         return parse_int(field);
     } else {
@@ -613,14 +619,14 @@ int key_lookup[] = {21, 23, 12, 14, 16, 17, 19};
 //
 long Alg_reader::parse_key(string &field)
 {
-    char *msg = "Pitch expected";
-    char *pitches = "ABCDEFG";
-    char *p;
+    const char *msg = "Pitch expected";
+    const char *pitches = "ABCDEFG";
+    const char *p;
     if (isdigit(field[1])) {
         // This routine would not have been called if field = "P<number>"
         // so it must be "K<number>" so <number> must be an integer.
         return parse_int(field);
-    } else if (p = strchr(pitches, toupper(field[1]))) {
+    } else if ((p = strchr(pitches, toupper(field[1])))) {
         long key = key_lookup[p - pitches];
         key = parse_after_key(key, field, 2);
         return key;
@@ -716,9 +722,9 @@ bool Alg_reader::parse_val(Alg_parameter_ptr param, string &s, int i)
     } else if (isdigit(s[i]) || s[i] == '-' || s[i] == '.') {
         int pos = i;
         bool period = false;
-        int sign = 1;
+        /* int sign = 1; LMMS unused variable */
         if (s[pos] == '-') {
-            sign = -1;
+            /* sign = -1; LMMS unused variable */
             pos++;
         }
         while (pos < len) {

--- a/plugins/MidiImport/portsmf/allegrosmfrd.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfrd.cpp
@@ -75,6 +75,7 @@ protected:
     void Mf_portprefix(int port);
     void Mf_eot();
     void Mf_error(char *);
+    void Mf_error(const char *);
     void Mf_header(int,int,int);
     void Mf_on(int,int,int);
     void Mf_off(int,int,int);
@@ -174,14 +175,19 @@ void Alg_midifile_reader::Mf_error(char *msg)
     fprintf(stdout, "Midifile reader error: %s\n", msg);
 }
 
+void Alg_midifile_reader::Mf_error(const char *msg)
+{
+    Mf_error(const_cast<char*>(msg));
+}
+
 
 void Alg_midifile_reader::Mf_header(int format, int ntrks, int division)
 {
     if (format > 1) {
         char msg[80];
-#pragma warning(disable: 4996) // msg is long enough
+//#pragma warning(disable: 4996) // msg is long enough
         sprintf(msg, "file format %d not implemented", format);
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
         Mf_error(msg);
     }
     divisions = division;
@@ -268,9 +274,9 @@ void Alg_midifile_reader::Mf_controller(int chan, int control, int val)
 {
     Alg_parameter parameter;
     char name[32];
-#pragma warning(disable: 4996) // name is long enough
+//#pragma warning(disable: 4996) // name is long enough
     sprintf(name, "control%dr", control);
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
     parameter.set_attr(symbol_table.insert_string(name));
     parameter.r = val / 127.0;
     update(chan, -1, &parameter);
@@ -314,9 +320,9 @@ void Alg_midifile_reader::binary_msg(int len, unsigned char *msg,
     Alg_parameter parameter;
     char *hexstr = new char[len * 2 + 1];
     for (int i = 0; i < len; i++) {
-#pragma warning(disable: 4996) // hexstr is long enough
+//#pragma warning(disable: 4996) // hexstr is long enough
         sprintf(hexstr + 2 * i, "%02x", (0xFF & msg[i]));
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
     }
     parameter.s = hexstr;
     parameter.set_attr(symbol_table.insert_string(attr_string));
@@ -340,9 +346,9 @@ void Alg_midifile_reader::Mf_arbitrary(int len, unsigned char *msg)
 void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
 {
     char text[128];
-#pragma warning(disable: 4996) // text is long enough
+//#pragma warning(disable: 4996) // text is long enough
     sprintf(text, "metamsic data, type 0x%x, ignored", type);
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
     Mf_error(text);
 }
 
@@ -353,7 +359,7 @@ void Alg_midifile_reader::Mf_seqnum(int n)
 }
 
 
-static char *fpsstr[4] = {"24", "25", "29.97", "30"};
+static const char *fpsstr[4] = {"24", "25", "29.97", "30"};
 
 void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
                                    int frames, int subframes)
@@ -363,10 +369,10 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
     char text[32];
     int fps = (hours >> 6) & 3;
     hours &= 0x1F;
-#pragma warning(disable: 4996) // text is long enough
+//#pragma warning(disable: 4996) // text is long enough
     sprintf(text, "%sfps:%02dh:%02dm:%02ds:%02d.%02df", 
             fpsstr[fps], hours, mins, secs, frames, subframes);
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
     Alg_parameter smpteoffset;
     smpteoffset.s = heapify(text);
     smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));

--- a/plugins/MidiImport/portsmf/allegrosmfrd.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfrd.cpp
@@ -3,7 +3,7 @@
 #include "stdlib.h"
 #include "stdio.h"
 #include "string.h"
-#include "debug.h"
+#include "assert.h"
 #include <string>
 #include <fstream>
 #include "allegro.h"
@@ -13,13 +13,13 @@
 
 using namespace std;
 
-typedef class Alg_pending {
+typedef class Alg_note_list {
 public:
     Alg_note_ptr note;
-    class Alg_pending *next;
-    Alg_pending(Alg_note_ptr n, class Alg_pending *list) { 
+    class Alg_note_list *next;
+    Alg_note_list(Alg_note_ptr n, class Alg_note_list *list) { 
         note = n; next = list; }
-} *Alg_pending_ptr;
+} *Alg_note_list_ptr;
 
 
 class Alg_midifile_reader: public Midifile_reader {
@@ -27,7 +27,7 @@ public:
     istream *file;
     Alg_seq_ptr seq;
     int divisions;
-    Alg_pending_ptr pending;
+    Alg_note_list_ptr note_list;
     Alg_track_ptr track;
     int track_number; // the number of the (current) track
     // chan is actual_channel + channel_offset_per_track * track_num +
@@ -41,7 +41,7 @@ public:
 
     Alg_midifile_reader(istream &f, Alg_seq_ptr new_seq) {
         file = &f;
-        pending = NULL;
+        note_list = NULL;
         seq = new_seq;
         channel_offset_per_track = 0;
         channel_offset_per_port = 16;
@@ -74,7 +74,7 @@ protected:
     void Mf_chanprefix(int chan);
     void Mf_portprefix(int port);
     void Mf_eot();
-    void Mf_error(const char *);
+    void Mf_error(char *);
     void Mf_header(int,int,int);
     void Mf_on(int,int,int);
     void Mf_off(int,int,int);
@@ -83,25 +83,25 @@ protected:
     void Mf_pitchbend(int,int,int);
     void Mf_program(int,int);
     void Mf_chanpressure(int,int);
-    void binary_msg(int len, char *msg, const char *attr_string);
-    void Mf_sysex(int,char*);
-    void Mf_arbitrary(int,char*);
-    void Mf_metamisc(int,int,char*);
+    void binary_msg(int len, unsigned char *msg, const char *attr_string);
+    void Mf_sysex(int,unsigned char*);
+    void Mf_arbitrary(int,unsigned char*);
+    void Mf_metamisc(int,int,unsigned char*);
     void Mf_seqnum(int);
     void Mf_smpte(int,int,int,int,int);
     void Mf_timesig(int,int,int,int);
     void Mf_tempo(int);
     void Mf_keysig(int,int);
-    void Mf_sqspecific(int,char*);
-    void Mf_text(int,int,char*);
+    void Mf_sqspecific(int,unsigned char*);
+    void Mf_text(int,int,unsigned char*);
 };
 
 
 Alg_midifile_reader::~Alg_midifile_reader()
 {
-    while (pending) {
-        Alg_pending_ptr to_be_freed = pending;
-        pending = pending->next;
+    while (note_list) {
+        Alg_note_list_ptr to_be_freed = note_list;
+        note_list = note_list->next;
         delete to_be_freed;
     }
     finalize(); // free Mf reader memory
@@ -169,7 +169,7 @@ void Alg_midifile_reader::Mf_eot()
 }
 
 
-void Alg_midifile_reader::Mf_error(const char *msg)
+void Alg_midifile_reader::Mf_error(char *msg)
 {
     fprintf(stdout, "Midifile reader error: %s\n", msg);
 }
@@ -179,7 +179,9 @@ void Alg_midifile_reader::Mf_header(int format, int ntrks, int division)
 {
     if (format > 1) {
         char msg[80];
+#pragma warning(disable: 4996) // msg is long enough
         sprintf(msg, "file format %d not implemented", format);
+#pragma warning(default: 4996)
         Mf_error(msg);
     }
     divisions = division;
@@ -201,7 +203,7 @@ void Alg_midifile_reader::Mf_on(int chan, int key, int vel)
         return;
     }
     Alg_note_ptr note = new Alg_note();
-    pending = new Alg_pending(note, pending);
+    note_list = new Alg_note_list(note, note_list);
     /*    trace("on: %d at %g\n", key, get_time()); */
     note->time = get_time();
     note->chan = chan + channel_offset + port * channel_offset_per_port;
@@ -217,14 +219,14 @@ void Alg_midifile_reader::Mf_on(int chan, int key, int vel)
 void Alg_midifile_reader::Mf_off(int chan, int key, int vel)
 {
     double time = get_time();
-    Alg_pending_ptr *p = &pending;
+    Alg_note_list_ptr *p = &note_list;
     while (*p) {
         if ((*p)->note->get_identifier() == key &&
             (*p)->note->chan == 
                     chan + channel_offset + port * channel_offset_per_port) {
             (*p)->note->dur = time - (*p)->note->time;
             // trace("updated %d dur %g\n", (*p)->note->key, (*p)->note->dur);
-            Alg_pending_ptr to_be_freed = *p;
+            Alg_note_list_ptr to_be_freed = *p;
             *p = to_be_freed->next;
             delete to_be_freed;
         } else {
@@ -266,7 +268,9 @@ void Alg_midifile_reader::Mf_controller(int chan, int control, int val)
 {
     Alg_parameter parameter;
     char name[32];
+#pragma warning(disable: 4996) // name is long enough
     sprintf(name, "control%dr", control);
+#pragma warning(default: 4996)
     parameter.set_attr(symbol_table.insert_string(name));
     parameter.r = val / 127.0;
     update(chan, -1, &parameter);
@@ -304,13 +308,15 @@ void Alg_midifile_reader::Mf_chanpressure(int chan, int val)
 }
 
 
-void Alg_midifile_reader::binary_msg(int len, char *msg, 
+void Alg_midifile_reader::binary_msg(int len, unsigned char *msg, 
                                      const char *attr_string)
 {
     Alg_parameter parameter;
     char *hexstr = new char[len * 2 + 1];
     for (int i = 0; i < len; i++) {
+#pragma warning(disable: 4996) // hexstr is long enough
         sprintf(hexstr + 2 * i, "%02x", (0xFF & msg[i]));
+#pragma warning(default: 4996)
     }
     parameter.s = hexstr;
     parameter.set_attr(symbol_table.insert_string(attr_string));
@@ -318,23 +324,25 @@ void Alg_midifile_reader::binary_msg(int len, char *msg,
 }
 
 
-void Alg_midifile_reader::Mf_sysex(int len, char *msg)
+void Alg_midifile_reader::Mf_sysex(int len, unsigned char *msg)
 {
     // sysex messages become updates with attribute sysexs and a hex string
     binary_msg(len, msg, "sysexs");
 }
 
 
-void Alg_midifile_reader::Mf_arbitrary(int len, char *msg)
+void Alg_midifile_reader::Mf_arbitrary(int len, unsigned char *msg)
 {
     Mf_error("arbitrary data ignored");
 }
 
 
-void Alg_midifile_reader::Mf_metamisc(int type, int len, char *msg)
+void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
 {
     char text[128];
+#pragma warning(disable: 4996) // text is long enough
     sprintf(text, "metamsic data, type 0x%x, ignored", type);
+#pragma warning(default: 4996)
     Mf_error(text);
 }
 
@@ -345,7 +353,7 @@ void Alg_midifile_reader::Mf_seqnum(int n)
 }
 
 
-static const char *fpsstr[4] = {"24", "25", "29.97", "30"};
+static char *fpsstr[4] = {"24", "25", "29.97", "30"};
 
 void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
                                    int frames, int subframes)
@@ -355,8 +363,10 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
     char text[32];
     int fps = (hours >> 6) & 3;
     hours &= 0x1F;
+#pragma warning(disable: 4996) // text is long enough
     sprintf(text, "%sfps:%02dh:%02dm:%02ds:%02d.%02df", 
             fpsstr[fps], hours, mins, secs, frames, subframes);
+#pragma warning(default: 4996)
     Alg_parameter smpteoffset;
     smpteoffset.s = heapify(text);
     smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));
@@ -367,7 +377,7 @@ void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
 
 void Alg_midifile_reader::Mf_timesig(int i1, int i2, int i3, int i4)
 {
-    seq->set_time_sig(get_currtime() / divisions, i1, 1 << i2);
+    seq->set_time_sig(double(get_currtime()) / divisions, i1, 1 << i2);
 }
 
 
@@ -398,7 +408,7 @@ void Alg_midifile_reader::Mf_keysig(int key, int mode)
 }
 
 
-void Alg_midifile_reader::Mf_sqspecific(int len, char *msg)
+void Alg_midifile_reader::Mf_sqspecific(int len, unsigned char *msg)
 {
     // sequencer specific messages become updates with attribute sqspecifics
     // and a hex string for the value
@@ -406,7 +416,7 @@ void Alg_midifile_reader::Mf_sqspecific(int len, char *msg)
 }
 
 
-char *heapify2(int len, char *s)
+char *heapify2(int len, unsigned char *s)
 {
     char *h = new char[len + 1];
     memcpy(h, s, len);
@@ -415,7 +425,7 @@ char *heapify2(int len, char *s)
 }
 
 
-void Alg_midifile_reader::Mf_text(int type, int len, char *msg)
+void Alg_midifile_reader::Mf_text(int type, int len, unsigned char *msg)
 {
     Alg_parameter text;
     text.s = heapify2(len, msg);

--- a/plugins/MidiImport/portsmf/allegrosmfwr.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfwr.cpp
@@ -353,7 +353,7 @@ void Alg_smf_write::write_update(Alg_update_ptr update)
         int len = strlen(s);
         char smpteoffset[5];
         if (len < 24) return; // not long enough, must be bad format
-        int fps;
+        int fps = 0;
         if (s[0] == '2') {
             if (s[1] == '4') fps = 0;
             else if (s[1] == '5') fps = 1;

--- a/plugins/MidiImport/portsmf/allegrosmfwr.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfwr.cpp
@@ -34,7 +34,7 @@ public:
     // chan is actual_channel + channels_per_track * track_number
     // default is 100, set this to 0 to merge all tracks to 16 channels
 
-    void write(ofstream &file /* , midiFileFormat = 1 */);
+    void write(ostream &file /* , midiFileFormat = 1 */);
 
 private:
     long previous_divs; // time in ticks of most recently written event
@@ -46,7 +46,7 @@ private:
     void write_note(Alg_note_ptr note, bool on);
     void write_update(Alg_update_ptr update);
     void write_text(Alg_update_ptr update, char type);
-    void write_binary(int type_byte, char *msg);
+    void write_binary(int type_byte, const char *msg);
     void write_midi_channel_prefix(Alg_update_ptr update);
     void write_smpteoffset(Alg_update_ptr update, char *s);
     void write_data(int data);
@@ -162,7 +162,7 @@ void Alg_smf_write::write_note(Alg_note_ptr note, bool on)
 
     //printf("deltaDivisions: %d, beats elapsed: %g, on? %c\n", deltaDivisions, note->time, on);
 
-    char chan = (note->chan & 15);
+    char chan = char(note->chan & 15);
     int pitch = int(note->pitch + 0.5);
     if (pitch < 0) {
           pitch = pitch % 12;
@@ -184,8 +184,8 @@ void Alg_smf_write::write_midi_channel_prefix(Alg_update_ptr update)
 {
    if (update->chan >= 0) { // write MIDI Channel Prefix
         write_delta(update->time);
-        out_file->put(0xFF); // Meta Event
-        out_file->put(0x20); // Type code for MIDI Channel Prefix
+        out_file->put('\xFF'); // Meta Event
+        out_file->put('\x20'); // Type code for MIDI Channel Prefix
         out_file->put(1); // length
         out_file->put(to_midi_channel(update->chan));
         // one thing odd about the Std MIDI File spec is that once
@@ -201,7 +201,7 @@ void Alg_smf_write::write_text(Alg_update_ptr update, char type)
 {
     write_midi_channel_prefix(update);
     write_delta(update->time);
-    out_file->put(0xFF);
+    out_file->put('\xFF');
     out_file->put(type);
     out_file->put((char) strlen(update->parameter.s));
     *out_file << update->parameter.s;
@@ -212,8 +212,8 @@ void Alg_smf_write::write_smpteoffset(Alg_update_ptr update, char *s)
 {
     write_midi_channel_prefix(update);
     write_delta(update->time);
-    out_file->put(0xFF); // meta event
-    out_file->put(0x54); // smpte offset type code
+    out_file->put('\xFF'); // meta event
+    out_file->put('\x54'); // smpte offset type code
     out_file->put(5); // length
     for (int i = 0; i < 5; i++) *out_file << s[i];
 }
@@ -255,13 +255,13 @@ static char hex_to_nibble(char c)
 }
 
 
-static char hex_to_char(char *s)
+static char hex_to_char(const char *s)
 {
     return (hex_to_nibble(s[0]) << 4) + hex_to_nibble(s[1]);
 }
 
 
-void Alg_smf_write::write_binary(int type_byte, char *msg)
+void Alg_smf_write::write_binary(int type_byte, const char *msg)
 {
     int len = strlen(msg) / 2;
     out_file->put(type_byte);
@@ -275,7 +275,7 @@ void Alg_smf_write::write_binary(int type_byte, char *msg)
 
 void Alg_smf_write::write_update(Alg_update_ptr update)
 {
-    char *name = update->parameter.attr_name();
+    const char *name = update->parameter.attr_name();
 
     /****Non-Meta Events****/
     if (!strcmp(name, "pressurer")) {
@@ -312,7 +312,7 @@ void Alg_smf_write::write_update(Alg_update_ptr update)
       write_data(val);
     } else if (!strcmp(name, "sysexs") &&
                update->parameter.attr_type() == 's') {
-        char *s = update->parameter.s;
+        const char *s = update->parameter.s;
         if (s[0] && s[1] && toupper(s[0]) == 'F' && s[1] == '0') {
             s += 2; // skip the initial "F0" byte in message: it is implied
         }
@@ -320,9 +320,9 @@ void Alg_smf_write::write_update(Alg_update_ptr update)
         write_binary(0xF0, s);
     } else if (!strcmp(name, "sqspecifics") &&
                update->parameter.attr_type() == 's') {
-        char *s = update->parameter.s;
+        const char *s = update->parameter.s;
         write_delta(update->time);
-        out_file->put(0xFF);
+        out_file->put('\xFF');
         write_binary(0x7F, s);
 
     /****Text Events****/
@@ -349,11 +349,11 @@ void Alg_smf_write::write_update(Alg_update_ptr update)
         // smpteoffset is specified as "24fps:00h:10m:00s:11.00f"
         // the following simple parser does not reject all badly
         // formatted strings, but it should parse good strings ok
-        char *s = update->parameter.s;
+        const char *s = update->parameter.s;
         int len = strlen(s);
         char smpteoffset[5];
         if (len < 24) return; // not long enough, must be bad format
-        int fps = 0;
+        int fps;
         if (s[0] == '2') {
             if (s[1] == '4') fps = 0;
             else if (s[1] == '5') fps = 1;
@@ -390,8 +390,8 @@ void Alg_smf_write::write_update(Alg_update_ptr update)
     }
     if (keysig != -99 && keysig_mode) { // write when both are defined
         write_delta(keysig_when);
-        out_file->put(0xFF);
-        out_file->put(0x59);
+        out_file->put('\xFF');
+        out_file->put('\x59');
         out_file->put(2);
         // mask off high bits so that this value appears to be positive
         // i.e. -1 -> 0xFF (otherwise, write_data will clip -1 to 0)
@@ -482,9 +482,9 @@ void Alg_smf_write::write_tempo(int divs, int tempo)
     //    printf("Inserting tempo %f after %f clocks.\n", tempo, delta);
     write_varinum(divs - previous_divs);
     previous_divs = divs;
-    out_file->put(0xFF);
-    out_file->put(0x51);
-    out_file->put(0x03);
+    out_file->put('\xFF');
+    out_file->put('\x51');
+    out_file->put('\x03');
     write_24bit((int)tempo);
 }
 
@@ -512,12 +512,11 @@ void Alg_smf_write::write_tempo_change(int i)
 void Alg_smf_write::write_time_signature(int i)
 {
     Alg_time_sigs &ts = seq->time_sig;
+    write_delta(ts[i].beat);
     // write the time signature
-    long divs = ROUND(ts[i].beat * division);
-    write_varinum(divs - previous_divs);
-    out_file->put(0xFF);
-    out_file->put(0x58);  // time signature
-    out_file->put(4);     // length of message
+    out_file->put('\xFF');
+    out_file->put('\x58');  // time signature
+    out_file->put('\x04');     // length of message
     out_file->put(ROUND(ts[i].num));
     int den = ROUND(ts[i].den);
     int den_byte = 0;
@@ -532,7 +531,7 @@ void Alg_smf_write::write_time_signature(int i)
 
 
 
-void Alg_smf_write::write(ofstream &file)
+void Alg_smf_write::write(ostream &file)
 {
     int track_len_offset;
     int track_end_offset;
@@ -564,9 +563,9 @@ void Alg_smf_write::write(ofstream &file)
 
         // End of track event
         write_varinum(0);           // delta time
-        out_file->put(0xFF);
-        out_file->put(0x2F);
-        out_file->put(0x00);
+        out_file->put('\xFF');
+        out_file->put('\x2F');
+        out_file->put('\x00');
 
         // Go back and write in the length of the track
         track_end_offset = out_file->tellp();
@@ -632,7 +631,7 @@ void Alg_smf_write::write_varinum(int value)
 }
 
 
-void Alg_seq::smf_write(ofstream &file)
+void Alg_seq::smf_write(ostream &file)
 {
     Alg_smf_write writer(this);
     writer.write(file);
@@ -646,4 +645,3 @@ bool Alg_seq::smf_write(const char *filename)
     outf.close();
     return true;
 }
-

--- a/plugins/MidiImport/portsmf/allegrowr.cpp
+++ b/plugins/MidiImport/portsmf/allegrowr.cpp
@@ -1,6 +1,6 @@
 // allegrowr.cpp -- write sequence to an Allegro file (text)
 
-#include "debug.h"
+#include "assert.h"
 #include "stdlib.h"
 #include <iostream>
 #include <fstream>
@@ -56,32 +56,34 @@ Alg_event_ptr Alg_seq::write_track_name(ostream &file, int n,
 // find a name and write it, return a pointer to it so the track
 // writer knows what update (if any) to skip
 {
-    Alg_event_ptr e = NULL;
+    Alg_event_ptr e = NULL; // e is the result, default is NULL
     file << "#track " << n;
     const char *attr = symbol_table.insert_string(
                                n == 0 ? "seqnames" : "tracknames");
     // search for name in events with timestamp of 0
     for (int i = 0; i < events.length(); i++) {
-        e = events[i];
-        if (e->time > 0) break;
-        if (e->is_update()) {
-            Alg_update_ptr u = (Alg_update_ptr) e;
+        Alg_event_ptr ue = events[i];
+        if (ue->time > 0) break;
+        if (ue->is_update()) {
+            Alg_update_ptr u = (Alg_update_ptr) ue;
             if (u->parameter.attr == attr) {
                 file << " " << u->parameter.s;
+                e = ue; // return the update event we found
                 break;
             }
         }
     }
-    file << endl;
-    return e;
+    file << endl; // end of line containing #track [<name>]
+    return e; // return parameter event with name if one was found
 }
 
 
-void Alg_seq::write(ostream &file, bool in_secs)
+void Alg_seq::write(ostream &file, bool in_secs, double offset)
 {
     int i, j;
     if (in_secs) convert_to_seconds();
     else convert_to_beats();
+    file << "#offset " << offset << endl;
     Alg_event_ptr update_to_skip = write_track_name(file, 0, track_list[0]);
     Alg_beats &beats = time_map->beats;
     for (i = 0; i < beats.len - 1; i++) {
@@ -171,11 +173,11 @@ void Alg_seq::write(ostream &file, bool in_secs)
     }
 }
 
-bool Alg_seq::write(const char *filename)
+bool Alg_seq::write(const char *filename, double offset)
 {
     ofstream file(filename);
     if (file.fail()) return false;
-     write(file, units_are_seconds);
-     file.close();
-     return true;
+    write(file, units_are_seconds, offset);
+    file.close();
+    return true;
 }

--- a/plugins/MidiImport/portsmf/mfmidi.cpp
+++ b/plugins/MidiImport/portsmf/mfmidi.cpp
@@ -35,7 +35,7 @@ void Midifile_reader::midifile()
     while (ntrks-- > 0 && !midifile_error) readtrack();
 }
 
-int Midifile_reader::readmt(char *s, int skip)
+int Midifile_reader::readmt(const char *s, int skip)
     /* read through the "MThd" or "MTrk" header string */
     /* if skip == 1, we attempt to skip initial garbage. */
 {
@@ -44,7 +44,7 @@ int Midifile_reader::readmt(char *s, int skip)
     char b[4];
     char buff[32];
     int c;
-    char *errmsg = "expecting ";
+    const char *errmsg = "expecting ";
 
     retry:
     while ( nread<4 ) {
@@ -68,10 +68,10 @@ int Midifile_reader::readmt(char *s, int skip)
         goto retry;
     }
     err:
-#pragma warning(disable: 4996) // strcpy is safe since strings have known lengths
+//#pragma warning(disable: 4996) // strcpy is safe since strings have known lengths
     (void) strcpy(buff,errmsg);
     (void) strcat(buff,s);
-#pragma warning(default: 4996) // turn it back on
+//#pragma warning(default: 4996) // turn it back on
     mferror(buff);
     return(0);
 }
@@ -257,9 +257,9 @@ void Midifile_reader::readtrack()
 void Midifile_reader::badbyte(int c)
 {
     char buff[32];
-#pragma warning(disable: 4996) // safe in this case
+//#pragma warning(disable: 4996) // safe in this case
     (void) sprintf(buff,"unexpected byte: 0x%02x",c);
-#pragma warning(default: 4996)
+//#pragma warning(default: 4996)
     mferror(buff);
 }
 
@@ -418,6 +418,11 @@ void Midifile_reader::mferror(char *s)
 {
     Mf_error(s);
     midifile_error = 1;
+}
+
+void Midifile_reader::mferror(const char *s)
+{
+    mferror(const_cast<char *>(s));
 }
 
 /* The code below allows collection of a system exclusive message of */

--- a/plugins/MidiImport/portsmf/mfmidi.cpp
+++ b/plugins/MidiImport/portsmf/mfmidi.cpp
@@ -13,6 +13,7 @@
 #include "stdio.h"
 #include "mfmidi.h"
 #include "string.h"
+#include "assert.h"
 
 #define MIDIFILE_ERROR -1
 
@@ -34,15 +35,16 @@ void Midifile_reader::midifile()
     while (ntrks-- > 0 && !midifile_error) readtrack();
 }
 
-int Midifile_reader::readmt(const char *s, int skip)
+int Midifile_reader::readmt(char *s, int skip)
     /* read through the "MThd" or "MTrk" header string */
     /* if skip == 1, we attempt to skip initial garbage. */
 {
+    assert(strlen(s) == 4); // must be "MThd" or "MTrk"
     int nread = 0;
     char b[4];
     char buff[32];
     int c;
-    const char *errmsg = "expecting ";
+    char *errmsg = "expecting ";
 
     retry:
     while ( nread<4 ) {
@@ -66,8 +68,10 @@ int Midifile_reader::readmt(const char *s, int skip)
         goto retry;
     }
     err:
+#pragma warning(disable: 4996) // strcpy is safe since strings have known lengths
     (void) strcpy(buff,errmsg);
     (void) strcat(buff,s);
+#pragma warning(default: 4996) // turn it back on
     mferror(buff);
     return(0);
 }
@@ -189,7 +193,7 @@ void Midifile_reader::readtrack()
             msginit();
 
             while ( Mf_toberead > lookfor ) {
-                char c = egetc();
+                unsigned char c = egetc();
                 if (midifile_error) return;
                 msgadd(c);
             }
@@ -253,15 +257,17 @@ void Midifile_reader::readtrack()
 void Midifile_reader::badbyte(int c)
 {
     char buff[32];
-
+#pragma warning(disable: 4996) // safe in this case
     (void) sprintf(buff,"unexpected byte: 0x%02x",c);
+#pragma warning(default: 4996)
     mferror(buff);
 }
 
 void Midifile_reader::metaevent(int type)
 {
     int leng = msgleng();
-    char *m = msg();
+    // made this unsigned to avoid sign extend
+    unsigned char *m = msg();
 
     switch ( type ) {
     case 0x00:
@@ -408,7 +414,7 @@ int Midifile_reader::read16bit()
     return to16bit(c1,c2);
 }
 
-void Midifile_reader::mferror(const char *s)
+void Midifile_reader::mferror(char *s)
 {
     Mf_error(s);
     midifile_error = 1;
@@ -444,7 +450,7 @@ void Midifile_reader::msginit()
     Msgindex = 0;
 }
 
-char *Midifile_reader::msg()
+unsigned char *Midifile_reader::msg()
 {
     return(Msgbuff);
 }
@@ -464,21 +470,16 @@ void Midifile_reader::msgadd(int c)
 
 void Midifile_reader::msgenlarge()
 {
-    char *newmess;
-    char *oldmess = Msgbuff;
+    unsigned char *newmess;
+    unsigned char *oldmess = Msgbuff;
     int oldleng = Msgsize;
 
     Msgsize += MSGINCREMENT;
-    newmess = (char *) Mf_malloc((sizeof(char) * Msgsize) );
+    newmess = (unsigned char *) Mf_malloc((sizeof(unsigned char) * Msgsize) );
 
     /* copy old message into larger new one */
     if ( oldmess != 0 ) {
-        register char *p = newmess;
-        register char *q = oldmess;
-        register char *endq = &oldmess[oldleng];
-
-        for ( ; q!=endq ; p++,q++ )
-            *p = *q;
+        memcpy(newmess, oldmess, oldleng);
         Mf_free(oldmess, oldleng);
     }
     Msgbuff = newmess;

--- a/plugins/MidiImport/portsmf/mfmidi.h
+++ b/plugins/MidiImport/portsmf/mfmidi.h
@@ -46,7 +46,7 @@ protected:
     virtual void Mf_chanprefix(int) = 0;
     virtual void Mf_portprefix(int) = 0;
     virtual void Mf_eot() = 0;
-    virtual void Mf_error(const char *) = 0;
+    virtual void Mf_error(char *) = 0;
     virtual void Mf_header(int,int,int) = 0;
     virtual void Mf_on(int,int,int) = 0;
     virtual void Mf_off(int,int,int) = 0;
@@ -55,16 +55,16 @@ protected:
     virtual void Mf_pitchbend(int,int,int) = 0;
     virtual void Mf_program(int,int) = 0;
     virtual void Mf_chanpressure(int,int) = 0;
-    virtual void Mf_sysex(int,char*) = 0;
-    virtual void Mf_arbitrary(int,char*) = 0;
-    virtual void Mf_metamisc(int,int,char*) = 0;
+    virtual void Mf_sysex(int,unsigned char*) = 0;
+    virtual void Mf_arbitrary(int,unsigned char*) = 0;
+    virtual void Mf_metamisc(int,int,unsigned char*) = 0;
     virtual void Mf_seqnum(int) = 0;
     virtual void Mf_smpte(int,int,int,int,int) = 0;
     virtual void Mf_timesig(int,int,int,int) = 0;
     virtual void Mf_tempo(int) = 0;
     virtual void Mf_keysig(int,int) = 0;
-    virtual void Mf_sqspecific(int,char*) = 0;
-    virtual void Mf_text(int,int,char*) = 0;
+    virtual void Mf_sqspecific(int,unsigned char*) = 0;
+    virtual void Mf_text(int,int,unsigned char*) = 0;
 
 private:
     long Mf_toberead;
@@ -73,7 +73,7 @@ private:
     long read32bit();
     int read16bit();
     void msgenlarge();
-    char *msg();
+    unsigned char *msg();
     int readheader();
     void readtrack();
     void sysex();
@@ -81,16 +81,16 @@ private:
     int egetc();
     int msgleng();
 
-    int readmt(const char *, int);
+    int readmt(char*,int);
     long to32bit(int,int,int,int);
     int to16bit(int,int);
-    void mferror(const char *);
+    void mferror(char *);
     void badbyte(int);
     void metaevent(int);
     void msgadd(int);
     void chanmessage(int,int,int);
 
-    char *Msgbuff;
+    unsigned char *Msgbuff;
     long Msgsize;
     long Msgindex;
 };

--- a/plugins/MidiImport/portsmf/mfmidi.h
+++ b/plugins/MidiImport/portsmf/mfmidi.h
@@ -81,10 +81,11 @@ private:
     int egetc();
     int msgleng();
 
-    int readmt(char*,int);
+    int readmt(const char*,int);
     long to32bit(int,int,int,int);
     int to16bit(int,int);
     void mferror(char *);
+    void mferror(const char *);
     void badbyte(int);
     void metaevent(int);
     void msgadd(int);

--- a/plugins/MidiImport/portsmf/strparse.cpp
+++ b/plugins/MidiImport/portsmf/strparse.cpp
@@ -1,5 +1,5 @@
-#include <cstring>
 #include <string>
+#include <cstring>
 // #include <iostream>  -- for debugging (cout)
 #include "ctype.h"
 using namespace std;
@@ -48,10 +48,10 @@ void String_parse::get_nonspace_quoted(string &field)
 }
 
 
-char *escape_chars[] = { (char *) "\\n", (char *)"\\t", (char *)"\\\\", (char *)"\\r", (char *) "\\\""};
+static const char *const escape_chars[] = {"\\n", "\\t", "\\\\", "\\r", "\\\""};
 
 
-void string_escape(string &result, char *str, const char *quote)
+void string_escape(string &result, const char *str, const char *quote)
 {
     int length = (int) strlen(str);
     if (quote[0]) {
@@ -59,8 +59,8 @@ void string_escape(string &result, char *str, const char *quote)
     }
     for (int i = 0; i < length; i++) {
         if (!isalnum((unsigned char) str[i])) {
-            char *chars = (char *)"\n\t\\\r\"";
-            char *special = strchr(chars, str[i]);
+            const char *const chars = "\n\t\\\r\"";
+            const char *const special = strchr(chars, str[i]);
             if (special) {
                 result.append(escape_chars[special - chars]);
             } else {
@@ -78,7 +78,7 @@ void String_parse::get_remainder(std::string &field)
     field.clear();
     skip_space();
     int len = str->length() - pos;
-    if ((*str)[len - 1] == '\n') { // if str ends in newline, 
+    if ((len > 0) && ((*str)[len - 1] == '\n')) { // if str ends in newline, 
         len--; // reduce length to ignore newline
     }
     field.insert(0, *str, pos, len);

--- a/plugins/MidiImport/portsmf/strparse.h
+++ b/plugins/MidiImport/portsmf/strparse.h
@@ -15,4 +15,4 @@ public:
     void get_remainder(std::string &field);
 };
 
-void string_escape(std::string &result, char *s, const char *quote);
+void string_escape(std::string &result, const char *s, const char *quote);

--- a/plugins/MidiImport/portsmf/trace.cpp
+++ b/plugins/MidiImport/portsmf/trace.cpp
@@ -15,7 +15,7 @@ void trace(char *format, ...)
     char msg[256];
     va_list args;
     va_start(args, format);
-    _vsnprintf(msg, 256, format, args);
+    _vsnprintf_s(msg, 256, _TRUNCATE, format, args);
     va_end(args);
 #ifdef _DEBUG
     _CrtDbgReport(_CRT_WARN, NULL, NULL, NULL, msg);


### PR DESCRIPTION
This updates portsmf to the latest commit from sourceforge, r234. I downloaded the snapshot and copied all the files we have over. A lot of changes here are function parameters adding `const`.

With the portsmf update brought an error when trying to use our `Alg_seq` constructor with `stringstream`. The constructor takes a `std::istream` which I tried to convert the `stringstream` to `stringistream`, but everything kept yelling that a constructor couldn't be found (during runtime). So I converted it to use `ifstream`, and everything calmed down and started working again. I've tested loading about 10 MIDIs I have saved for testing purposes, and all seemed to load without crashing or missing tracks (maybe) after the next change below.

I converted the static 256 count array of `smfMidiChannel` to an `unordered_map`. This is pretty much a drop in replacement as its `operator[]` will create a new element if none exists. This change has let me load previously unloadable MIDI files (found in Discord from others reporting it won't load). There are still some fixes to do, such as making sure all tracks are actually loaded. I find some MIDIs will load and have extra tracks created, but no data. I'm not certain if this is an error or a result of looping through a track that doesn't exist in the MIDI.

Finally, I added the `seqnames` attribute check since I've noticed before that track names won't load on some that use that attribute. This check is pretty much the same that's used in the allegro code.