### PR TITLE
Fix for Mixer volume percentage labels are off by a factor of 100 

### DIFF
--- a/include/Fader.h
+++ b/include/Fader.h
@@ -166,6 +166,14 @@ private:
 	QColor m_peakGreen;
 	QColor m_peakRed;
 	QColor m_peakYellow;
+
+	void patchDefaultActions( QMenu* contextMenu );
+	float floatFromClipboard(bool* ok);
+
+private slots:
+	void copyToClipboard();
+	void pasteFromClipboard();
+
 } ;
 
 


### PR DESCRIPTION
(#2340)

Patch the default context menu and take into account variable m_displayConversion to multiply/divide by 100.

Reset action: update the text with initValue multiplied by 100 if required.
Copy action: update the text with value multiplied by 100 if required. Replace the default copy slot by one
which also multiplies by 100 if required.
Paste action: Replace the default paste slot which divides by 100 if required.

Faders in FxMixer show now the correct context. Copying and pasting values between faders or even volume knobs
in tracks shows consistent behavior. Other faders (like in Eq) show the old behavior.