### PR TITLE
Play automation pattern when midi controller connected

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -151,7 +151,7 @@ public:
 	{
 		if (m_controllerConnection)
 		{
-			if (m_controllerConnection->isControllerMidi() && !m_useControllerValue)
+			if (!m_useControllerValue)
 			{
 				return castValue<T>(m_value);
 			}

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -151,7 +151,7 @@ public:
 	{
 		if (m_controllerConnection)
 		{
-			if (m_controllerConnection->isControllerMidi() && !m_controllerValue)
+			if (m_controllerConnection->isControllerMidi() && !m_useControllerValue)
 			{
 				return castValue<T>(m_value);
 			}
@@ -310,19 +310,15 @@ public:
 		s_periodCounter = 0;
 	}
 
-	bool isControllerValue()
+	bool useControllerValue()
 	{
-		return m_controllerValue;
-	}
-	void setControllerValue(bool b)
-	{
-		m_controllerValue = b;
+		return m_useControllerValue;
 	}
 
 public slots:
 	virtual void reset();
 	void unlinkControllerConnection();
-	void setAndEmitControllerValue();
+	void setUseControllerValue(bool b = true);
 
 
 protected:
@@ -417,7 +413,7 @@ private:
 	// prevent several threads from attempting to write the same vb at the same time
 	QMutex m_valueBufferMutex;
 
-	bool m_controllerValue;
+	bool m_useControllerValue;
 
 signals:
 	void initValueChanged( float val );

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -28,7 +28,6 @@
 #include <QtCore/QMap>
 #include <QtCore/QMutex>
 
-
 #include "JournallingObject.h"
 #include "Model.h"
 #include "MidiTime.h"

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -102,8 +102,6 @@ private slots:
 protected:
 	AutomatableModelView* m_amv;
 
-	void disconnectStopSignalMidi(AutomatableModel * autmod);
-
 } ;
 
 

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -102,6 +102,8 @@ private slots:
 protected:
 	AutomatableModelView* m_amv;
 
+	void disconnectStopSignalMidi(AutomatableModel * autmod);
+
 } ;
 
 

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -33,6 +33,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QVector>
 
+#include "AutomatableModel.h"
 #include "Controller.h"
 #include "JournallingObject.h"
 #include "ValueBuffer.h"
@@ -47,7 +48,7 @@ class LMMS_EXPORT ControllerConnection : public QObject, public JournallingObjec
 	Q_OBJECT
 public:
 
-	ControllerConnection( Controller * _controller );
+	ControllerConnection(Controller * _controller, AutomatableModel * contmod);
 	ControllerConnection( int _controllerId );
 
 	virtual ~ControllerConnection();
@@ -98,6 +99,10 @@ public:
 		return classNodeName();
 	}
 
+	bool isControllerMidi()
+	{
+		return m_controllerMidi;
+	}
 
 public slots:
 	void deleteConnection();
@@ -111,6 +116,9 @@ protected:
 	bool m_ownsController;
 
 	static ControllerConnectionVector s_connections;
+
+	bool m_controllerMidi;
+	AutomatableModel * m_controlledModel;
 
 signals:
 	// The value changed while the mixer isn't running (i.e: MIDI CC)

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -99,11 +99,6 @@ public:
 		return classNodeName();
 	}
 
-	bool isControllerMidi()
-	{
-		return m_controllerMidi;
-	}
-
 public slots:
 	void deleteConnection();
 
@@ -117,7 +112,6 @@ protected:
 
 	static ControllerConnectionVector s_connections;
 
-	bool m_controllerMidi;
 	AutomatableModel * m_controlledModel;
 
 signals:

--- a/include/Song.h
+++ b/include/Song.h
@@ -464,6 +464,8 @@ private:
 	MidiTime m_exportSongEnd;
 	MidiTime m_exportEffectiveLength;
 
+	AutomatedValueMap m_oldAutomatedValues;
+
 	friend class LmmsCore;
 	friend class SongEditor;
 	friend class mainWindow;

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -373,7 +373,7 @@ void AutomatableModel::roundAt( T& value, const T& where ) const
 void AutomatableModel::setAutomatedValue( const float value )
 {
 	setUseControllerValue(false);
-	
+
 	m_oldValue = m_value;
 	++m_setValueDepth;
 	const float oldValue = m_value;
@@ -781,12 +781,11 @@ void AutomatableModel::setUseControllerValue(bool b)
 		m_useControllerValue = true;
 		emit dataChanged();
 	}
-	else if (m_controllerConnection && m_useControllerValue && m_controllerConnection->isControllerMidi())
+	else if (m_controllerConnection && m_useControllerValue)
 	{
 		m_useControllerValue = false;
 		emit dataChanged();
 	}
-	
 }
 
 float FloatModel::getRoundedValue() const

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -121,21 +121,13 @@ void ControllerConnection::setController( Controller * _controller )
 				this, SIGNAL( valueChanged() ), Qt::DirectConnection );
 	}
 
-	if (_controller->type() == Controller::MidiController)
-	{
+	m_ownsController =
+		(_controller->type() == Controller::MidiController);
 
 		connect(Engine::getSong(), SIGNAL(stopped()),
 			m_controlledModel, SLOT(setUseControllerValue()),
 				Qt::UniqueConnection);
 
-		m_ownsController = true;
-		m_controllerMidi = true;
-	}
-	else
-	{
-		m_ownsController = false;
-		m_controllerMidi = false;
-	}
 	m_controlledModel->setUseControllerValue(true);
 
 	// If we don't own the controller, allow deletion of controller

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -124,9 +124,9 @@ void ControllerConnection::setController( Controller * _controller )
 	m_ownsController =
 		(_controller->type() == Controller::MidiController);
 
-		connect(Engine::getSong(), SIGNAL(stopped()),
-			m_controlledModel, SLOT(setUseControllerValue()),
-				Qt::UniqueConnection);
+	connect(Engine::getSong(), SIGNAL(stopped()),
+		m_controlledModel, SLOT(setUseControllerValue()),
+			Qt::UniqueConnection);
 
 	m_controlledModel->setUseControllerValue(true);
 

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -125,7 +125,7 @@ void ControllerConnection::setController( Controller * _controller )
 	{
 
 		connect(Engine::getSong(), SIGNAL(stopped()),
-			m_controlledModel, SLOT(setAndEmitControllerValue()),
+			m_controlledModel, SLOT(setUseControllerValue()),
 				Qt::UniqueConnection);
 
 		m_ownsController = true;
@@ -136,7 +136,7 @@ void ControllerConnection::setController( Controller * _controller )
 		m_ownsController = false;
 		m_controllerMidi = false;
 	}
-	m_controlledModel->setControllerValue(true);
+	m_controlledModel->setUseControllerValue(true);
 
 	// If we don't own the controller, allow deletion of controller
 	// to delete the connection

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -36,10 +36,11 @@ ControllerConnectionVector ControllerConnection::s_connections;
 
 
 
-ControllerConnection::ControllerConnection( Controller * _controller ) :
+ControllerConnection::ControllerConnection(Controller * _controller, AutomatableModel * contmod) :
 	m_controller( NULL ),
 	m_controllerId( -1 ),
-	m_ownsController( false )
+	m_ownsController(false),
+	m_controlledModel(contmod)
 {
 	if( _controller != NULL )
 	{
@@ -120,8 +121,22 @@ void ControllerConnection::setController( Controller * _controller )
 				this, SIGNAL( valueChanged() ), Qt::DirectConnection );
 	}
 
-	m_ownsController =
-			( _controller->type() == Controller::MidiController );
+	if (_controller->type() == Controller::MidiController)
+	{
+
+		connect(Engine::getSong(), SIGNAL(stopped()),
+			m_controlledModel, SLOT(setAndEmitControllerValue()),
+				Qt::UniqueConnection);
+
+		m_ownsController = true;
+		m_controllerMidi = true;
+	}
+	else
+	{
+		m_ownsController = false;
+		m_controllerMidi = false;
+	}
+	m_controlledModel->setControllerValue(true);
 
 	// If we don't own the controller, allow deletion of controller
 	// to delete the connection

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -473,9 +473,7 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
 		{
 			AutomatableModel * am = it.key();
-			if (am->controllerConnection() &&
-				am->controllerConnection()->isControllerMidi() &&
-				!values.contains(am))
+			if (am->controllerConnection() && !values.contains(am))
 			{
 				am->setUseControllerValue(true);
 			}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -477,7 +477,7 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 				am->controllerConnection()->isControllerMidi() &&
 				!values.contains(am))
 			{
-				am->setAndEmitControllerValue();
+				am->setUseControllerValue(true);
 			}
 		}
 	}
@@ -490,9 +490,9 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 		{
 			it.key()->setAutomatedValue(it.value());
 		}
-		else if (!it.key()->isControllerValue())
+		else if (!it.key()->useControllerValue())
 		{
-			it.key()->setAndEmitControllerValue();
+			it.key()->setUseControllerValue(true);
 		}
 	}
 }

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -468,6 +468,8 @@ void Song::processAutomations(const TrackList &tracklist, MidiTime timeStart, fp
 		}
 	}
 
+	// Checks if an automated model stopped being automated by automation patterns
+	// so we can move the control back to any connected controller again
 	if (!m_oldAutomatedValues.isEmpty())
 	{
 		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -186,11 +186,6 @@ void AutomatableModelViewSlots::execConnectionDialog()
 			// Update
 			if( m->controllerConnection() )
 			{
-				if (m->controllerConnection()->isControllerMidi() &&
-						!(d.chosenController()->type() == Controller::MidiController))
-				{
-					disconnectStopSignalMidi(m);
-				}
 				m->controllerConnection()->setController( d.chosenController() );
 			}
 			// New
@@ -218,10 +213,9 @@ void AutomatableModelViewSlots::removeConnection()
 
 	if( m->controllerConnection() )
 	{
-		if (m->controllerConnection()->isControllerMidi())
-		{
-			disconnectStopSignalMidi(m);
-		}
+		disconnect(Engine::getSong(), SIGNAL(stopped()),
+			   m, SLOT(setUseControllerValue()));
+
 		delete m->controllerConnection();
 		m->setControllerConnection( NULL );
 		emit m->dataChanged();
@@ -264,12 +258,6 @@ void AutomatableModelViewSlots::pasteFromClipboard()
 	if (isNumber) {
 		m_amv->modelUntyped()->setValue(number);
 	}
-}
-
-void AutomatableModelViewSlots::disconnectStopSignalMidi(AutomatableModel * autmod)
-{
-	disconnect(Engine::getSong(), SIGNAL(stopped()),
-		   autmod, SLOT(setUseControllerValue()));
 }
 
 /// Attempt to parse a float from the clipboard

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -269,7 +269,7 @@ void AutomatableModelViewSlots::pasteFromClipboard()
 void AutomatableModelViewSlots::disconnectStopSignalMidi(AutomatableModel * autmod)
 {
 	disconnect(Engine::getSong(), SIGNAL(stopped()),
-		   autmod, SLOT(setAndEmitControllerValue()));
+		   autmod, SLOT(setUseControllerValue()));
 }
 
 /// Attempt to parse a float from the clipboard


### PR DESCRIPTION
fix for #4554

When a button is connected to a midi controller it now plays the automation patterns.

I added a [flag](https://github.com/serdnab/lmms/blob/e65e12ac80d41de1fdafcc217c2b9561f942ff7c/include/AutomatableModel.h#L420) that when it is playing an automation pattern it does not look for `controllerValue()` but `m_value`.

Also I added:

- [`isControllerMidi()`](https://github.com/serdnab/lmms/blob/e65e12ac80d41de1fdafcc217c2b9561f942ff7c/include/ControllerConnection.h#L102) to `ControllerConnection.h` that is set when the controller is midi

- [this](https://github.com/serdnab/lmms/blob/e65e12ac80d41de1fdafcc217c2b9561f942ff7c/src/core/Song.cpp#L471-L483) code so that when an automatable model exits automation the midi controller takes back control

- a [signal connection](https://github.com/serdnab/lmms/blob/e65e12ac80d41de1fdafcc217c2b9561f942ff7c/src/core/ControllerConnection.cpp#L127-L129) so that when the song stops the midi controller takes back control

