### PR TITLE
CircleCI Deprecation Notice: Xcode 9.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
     environment:
       <<: *common_environment
     macos:
-      xcode: "9.3.1"
+      xcode: "9.4.1"
     steps:
       - checkout
       - *init


### PR DESCRIPTION
Hello! This is Adam from CircleCI 👋 

We are opening a PR to let you know that your project is using a version of Xcode that we are deprecating. This image is due for removal on 28 September 2020. After this date, jobs that request this image will begin to fail.

This PR updates your config file to Xcode 9.4.1, however we strongly suggest that you update to Xcode 10 or higher if you can.

For more information about this, please see our [announcement](https://discuss.circleci.com/t/deprecation-notice-xcode-9-0-1-and-xcode-9-3-1/37382)