### PR TITLE
Don't define NOMINMAX if it's already defined

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -40,7 +40,9 @@
 #include <QTextStream>
 
 #ifdef LMMS_BUILD_WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Co-authored-by: Dominic Clark <mrdomclark@gmail.com>