### PR TITLE
Remove unused stuff

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -35,7 +35,6 @@
 #include "lmms_basics.h"
 
 class BBTrackContainer;
-class DummyTrackContainer;
 class FxMixer;
 class ProjectJournal;
 class Mixer;
@@ -100,11 +99,6 @@ public:
 		return s_ladspaManager;
 	}
 
-	static DummyTrackContainer * dummyTrackContainer()
-	{
-		return s_dummyTC;
-	}
-
 	static float framesPerTick()
 	{
 		return s_framesPerTick;
@@ -149,7 +143,6 @@ private:
 	static Song * s_song;
 	static BBTrackContainer * s_bbTrackContainer;
 	static ProjectJournal * s_projectJournal;
-	static DummyTrackContainer * s_dummyTC;
 
 #ifdef LMMS_HAVE_LV2
 	static class Lv2Manager* s_lv2Manager;

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -173,8 +173,6 @@ public:
 
 	//! Set new audio device. Old device will be deleted,
 	//! unless it's stored using storeAudioDevice
-	void setAudioDevice( AudioDevice * _dev , bool startNow );
-	//! See overloaded function
 	void setAudioDevice( AudioDevice * _dev,
 				const struct qualitySettings & _qs,
 				bool _needs_fifo,

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -115,30 +115,4 @@ private:
 } ;
 
 
-class DummyTrackContainer : public TrackContainer
-{
-public:
-	DummyTrackContainer();
-
-	virtual ~DummyTrackContainer()
-	{
-	}
-
-	QString nodeName() const override
-	{
-		return "DummyTrackContainer";
-	}
-
-	InstrumentTrack * dummyInstrumentTrack()
-	{
-		return m_dummyInstrumentTrack;
-	}
-
-
-private:
-	InstrumentTrack * m_dummyInstrumentTrack;
-
-} ;
-
-
 #endif

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -47,7 +47,6 @@ Lv2Manager * LmmsCore::s_lv2Manager = nullptr;
 #endif
 Ladspa2LMMS * LmmsCore::s_ladspaManager = NULL;
 void* LmmsCore::s_dndPluginKey = nullptr;
-DummyTrackContainer * LmmsCore::s_dummyTC = NULL;
 
 
 
@@ -79,7 +78,6 @@ void LmmsCore::init( bool renderOnly )
 	s_mixer->initDevices();
 
 	PresetPreviewPlayHandle::init();
-	s_dummyTC = new DummyTrackContainer;
 
 	emit engine->initProgress(tr("Launching mixer threads"));
 	s_mixer->startProcessing();
@@ -98,7 +96,6 @@ void LmmsCore::destroy()
 	s_song->clearProject();
 
 	deleteHelper( &s_bbTrackContainer );
-	deleteHelper( &s_dummyTC );
 
 	deleteHelper( &s_fxMixer );
 	deleteHelper( &s_mixer );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -600,21 +600,6 @@ void Mixer::doSetAudioDevice( AudioDevice * _dev )
 
 
 
-void Mixer::setAudioDevice( AudioDevice * _dev,
-			    bool startNow )
-{
-	stopProcessing();
-
-	doSetAudioDevice( _dev );
-
-	emit sampleRateChanged();
-
-	if (startNow) {startProcessing();}
-}
-
-
-
-
 void Mixer::setAudioDevice(AudioDevice * _dev,
 				const struct qualitySettings & _qs,
 				bool _needs_fifo,

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -331,16 +331,3 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 	return valueMap;
 };
 
-
-
-DummyTrackContainer::DummyTrackContainer() :
-	TrackContainer(),
-	m_dummyInstrumentTrack( NULL )
-{
-	setJournalling( false );
-	m_dummyInstrumentTrack = dynamic_cast<InstrumentTrack *>(
-				Track::create( Track::InstrumentTrack,
-							this ) );
-	m_dummyInstrumentTrack->setJournalling( false );
-}
-

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1131,9 +1131,6 @@ void InstrumentTrackView::freeInstrumentTrackWindow()
 			model()->setHook( NULL );
 			m_window->setInstrumentTrackView( NULL );
 			m_window->parentWidget()->hide();
-			//m_window->setModel(
-			//	engine::dummyTrackContainer()->
-			//			dummyInstrumentTrack() );
 			m_window->updateInstrumentView();
 			s_windowCache << m_window;
 		}


### PR DESCRIPTION
This PR removes unused stuff: ```DummyTrackContainer``` and one of the overloaded methods in ```Mixer``` named ```setAudioDevice()```.