### PR TITLE
Fix background color of the selected text in the dialogs to enter a parameter, the project notes and editable combo boxes.

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -50,6 +50,11 @@ QLineEdit:focus {
 	border: 1px solid rgba(0,0,0, 128);
 }
 
+/* SpinBoxes used in QInputDialogs */
+
+QDoubleSpinBox, QSpinBox{
+	selection-background-color: #202020;
+}
 
 QToolTip {
 	border-radius: 4px;

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -51,7 +51,7 @@ QLineEdit:focus {
 /* Set color and selection background color for various inputs.
    SpinBoxes are used in QInputDialogs */
 
-QTextEdit, QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox {
+QTextEdit, QLineEdit:focus, QComboBox:focus, QSpinBox:focus, QDoubleSpinBox:focus {
 	color: #e0e0e0;
 	selection-background-color: #202020;
 }

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -34,8 +34,6 @@ QLineEdit {
 	border-radius: 4px;
 	border: 2px inset rgba(91,101,113,128);
 	background: #49515b;
-	color: #e0e0e0;
-	selection-background-color: #202020;
 }
 
 
@@ -50,9 +48,11 @@ QLineEdit:focus {
 	border: 1px solid rgba(0,0,0, 128);
 }
 
-/* SpinBoxes used in QInputDialogs */
+/* Set color and selection background color for various inputs.
+   SpinBoxes are used in QInputDialogs */
 
-QDoubleSpinBox, QSpinBox{
+QTextEdit, QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox {
+	color: #e0e0e0;
 	selection-background-color: #202020;
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -76,6 +76,11 @@ QLineEdit:focus {
 	border: 1px solid #0bd556;
 }
 
+/* SpinBoxes used in QInputDialogs */
+
+QDoubleSpinBox, QSpinBox{
+	selection-background-color: #17793b;
+}
 
 QToolTip {
 	border-radius: 4px;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -77,7 +77,7 @@ QLineEdit:focus {
 /* Set color and selection background color for various inputs.
    SpinBoxes are used in QInputDialogs */
 
-QTextEdit, QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox {
+QTextEdit, QLineEdit:focus, QComboBox:focus, QSpinBox:focus, QDoubleSpinBox:focus {
 	color: #d1d8e4;
 	selection-background-color: #17793b;
 }

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -61,8 +61,6 @@ QLineEdit {
 	border-radius: 4px;
 	border: 1px;
 	background: #101213;
-	color: #d1d8e4;
-	selection-background-color: #17793b;
 }
 
 QLineEdit:read-only {
@@ -76,9 +74,11 @@ QLineEdit:focus {
 	border: 1px solid #0bd556;
 }
 
-/* SpinBoxes used in QInputDialogs */
+/* Set color and selection background color for various inputs.
+   SpinBoxes are used in QInputDialogs */
 
-QDoubleSpinBox, QSpinBox{
+QTextEdit, QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox {
+	color: #d1d8e4;
 	selection-background-color: #17793b;
 }
 


### PR DESCRIPTION
Align the background color of the selected text in the spinboxes shown in the dialogs to enter a parameter with the background color of regular text inputs.
(related to the issue #5484 and PR #5628).

Before:
![before](https://user-images.githubusercontent.com/69391149/94349820-88574c80-0048-11eb-91e5-510681dea8a6.PNG)

After:
![after](https://user-images.githubusercontent.com/69391149/94349830-973dff00-0048-11eb-9e4f-3667b2408b00.PNG)

