### PR TITLE
Fix bug with baseQDir in PathUtils.cpp

### DIFF
--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -36,7 +36,11 @@ namespace PathUtil
 		return QDir::cleanPath(loc) + "/";
 	}
 
-	QDir baseQDir (const Base base) { return QDir(baseLocation(base)); }
+	QDir baseQDir (const Base base)
+	{
+		if (base == Base::Absolute){ return QDir::root(); }
+		return QDir(baseLocation(base));
+	}
 
 	QString basePrefix(const Base base)
 	{

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -38,7 +38,7 @@ namespace PathUtil
 
 	QDir baseQDir (const Base base)
 	{
-		if (base == Base::Absolute){ return QDir::root(); }
+		if (base == Base::Absolute) { return QDir::root(); }
 		return QDir(baseLocation(base));
 	}
 

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -125,8 +125,9 @@ namespace PathUtil
 
 	QString relativeOrAbsolute(const QString & input, const Base base)
 	{
-		if (input.isEmpty() || base == Base::Absolute) { return input; }
+		if (input.isEmpty()) { return input; }
 		QString absolutePath = toAbsolute(input);
+		if (base == Base::Absolute) { return absolutePath; }
 		QString relativePath = baseQDir(base).relativeFilePath(absolutePath);
 		return relativePath.startsWith("..") ? absolutePath : relativePath;
 	}

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -125,7 +125,7 @@ namespace PathUtil
 
 	QString relativeOrAbsolute(const QString & input, const Base base)
 	{
-		if (input.isEmpty()) { return input; }
+		if (input.isEmpty() || base == Base::Absolute) { return input; }
 		QString absolutePath = toAbsolute(input);
 		QString relativePath = baseQDir(base).relativeFilePath(absolutePath);
 		return relativePath.startsWith("..") ? absolutePath : relativePath;


### PR DESCRIPTION
_Originally posted by @PhysSong in https://github.com/LMMS/lmms/pull/5117#discussion_r495384656:_

If `base` is `Absolute`, `baseQDir(base)` will point to the working directory. It will result in undefined behaviors.

---

Opening for easier discussion, even this solution is flawed:

> Better than before, but that may result in getting foo/bar for /foo/bar which will be interpreted as old-style relative path.