### PR TITLE
Enable Lv2 Atom ports

### DIFF
--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -100,8 +100,12 @@ protected:
 	/*
 		utils for the run thread
 	*/
-	//! Copy values from all connected models into the respective ports
+	//! Copy values from the LMMS core (connected models, MIDI events, ...) into
+	//! the respective ports
 	void copyModelsFromLmms();
+	//! Bring values from all ports to the LMMS core
+	void copyModelsToLmms() const;
+
 	//! Copy buffer passed by LMMS into our ports
 	void copyBuffersFromLmms(const sampleFrame *buf, fpp_t frames);
 	//! Copy our ports into buffers passed by LMMS
@@ -123,6 +127,9 @@ protected:
 	*/
 	std::size_t controlCount() const;
 	QString nodeName() const { return "lv2controls"; }
+	bool hasNoteInput() const;
+	void handleMidiInputEvent(const class MidiEvent &event,
+		const class MidiTime &time, f_cnt_t offset);
 
 private:
 	//! Return the DataFile settings type

--- a/include/Lv2Evbuf.h
+++ b/include/Lv2Evbuf.h
@@ -1,0 +1,149 @@
+/*
+ * lv2_evbuf.h - Lv2 event buffer definitions
+ *
+ * Copyright (c) 2019-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * The original code was written by David Robillard <http://drobilla.net>
+ * Original version: 6f22ee0 from https://github.com/drobilla/jalv.git
+ * Minor changes have been done, but no functional changes.
+ * Considering this as an "external library", the identifiers do not need to
+ * match the LMMS coding conventions.
+ */
+
+#ifndef LV2_EVBUF_H
+#define LV2_EVBUF_H
+
+#include "lmmsconfig.h"
+
+#ifdef LMMS_HAVE_LV2
+
+#include <cstdint>
+
+/**
+   An abstract/opaque LV2 event buffer.
+*/
+typedef struct LV2_Evbuf_Impl LV2_Evbuf;
+
+/**
+   An iterator over an LV2_Evbuf.
+*/
+typedef struct {
+	LV2_Evbuf* evbuf;
+	uint32_t offset;
+} LV2_Evbuf_Iterator;
+
+/**
+   Allocate a new, empty event buffer.
+   URIDs for atom:Chunk and atom:Sequence must be passed for LV2_EVBUF_ATOM.
+*/
+LV2_Evbuf*
+lv2_evbuf_new(uint32_t capacity, uint32_t atom_Chunk, uint32_t atom_Sequence);
+
+/**
+   Free an event buffer allocated with lv2_evbuf_new.
+*/
+void
+lv2_evbuf_free(LV2_Evbuf* evbuf);
+
+/**
+   Clear and initialize an existing event buffer.
+   The contents of buf are ignored entirely and overwritten, except capacity
+   which is unmodified.
+   If input is false and this is an atom buffer, the buffer will be prepared
+   for writing by the plugin.  This MUST be called before every run cycle.
+*/
+void
+lv2_evbuf_reset(LV2_Evbuf* evbuf, bool input);
+
+/**
+   Return the total padded size of the events stored in the buffer.
+*/
+uint32_t
+lv2_evbuf_get_size(LV2_Evbuf* evbuf);
+
+/**
+   Return the actual buffer implementation.
+   The format of the buffer returned depends on the buffer type.
+*/
+void*
+lv2_evbuf_get_buffer(LV2_Evbuf* evbuf);
+
+/**
+   Return an iterator to the start of `evbuf`.
+*/
+LV2_Evbuf_Iterator
+lv2_evbuf_begin(LV2_Evbuf* evbuf);
+
+/**
+   Return an iterator to the end of `evbuf`.
+*/
+LV2_Evbuf_Iterator
+lv2_evbuf_end(LV2_Evbuf* evbuf);
+
+/**
+   Check if `iter` is valid.
+   @return True if `iter` is valid, otherwise false (past end of buffer)
+*/
+bool
+lv2_evbuf_is_valid(LV2_Evbuf_Iterator iter);
+
+/**
+   Advance `iter` forward one event.
+   `iter` must be valid.
+   @return True if `iter` is valid, otherwise false (reached end of buffer)
+*/
+LV2_Evbuf_Iterator
+lv2_evbuf_next(LV2_Evbuf_Iterator iter);
+
+/**
+   Dereference an event iterator (i.e. get the event currently pointed to).
+   `iter` must be valid.
+   `type` Set to the type of the event.
+   `size` Set to the size of the event.
+   `data` Set to the contents of the event.
+   @return True on success.
+*/
+bool
+lv2_evbuf_get(	LV2_Evbuf_Iterator iter,
+				uint32_t* frames,
+				uint32_t* type,
+				uint32_t* size,
+				uint8_t** data);
+
+/**
+   Write an event at `iter`.
+   The event (if any) pointed to by `iter` will be overwritten, and `iter`
+   incremented to point to the following event (i.e. several calls to this
+   function can be done in sequence without twiddling iter in-between).
+   @return True if event was written, otherwise false (buffer is full).
+*/
+bool
+lv2_evbuf_write(	LV2_Evbuf_Iterator* iter,
+					uint32_t frames,
+					uint32_t type,
+					uint32_t size,
+					const uint8_t* data);
+
+#endif // LMMS_HAVE_LV2
+
+#endif // LV2_EVBUF_H

--- a/include/Lv2Ports.h
+++ b/include/Lv2Ports.h
@@ -37,6 +37,7 @@
 #include "PluginIssue.h"
 
 struct ConnectPortVisitor;
+typedef struct LV2_Evbuf_Impl LV2_Evbuf;
 
 namespace Lv2Ports {
 
@@ -53,7 +54,7 @@ enum class Type {
 	Unknown,
 	Control,
 	Audio,
-	Event, //!< TODO: unused, describe
+	AtomSeq,
 	Cv //!< TODO: unused, describe
 };
 
@@ -74,6 +75,7 @@ struct ControlPortBase;
 struct Control;
 struct Audio;
 struct Cv;
+struct AtomSeq;
 struct Unknown;
 
 struct ConstVisitor
@@ -82,6 +84,7 @@ struct ConstVisitor
 	virtual void visit(const Lv2Ports::Control& ) {}
 	virtual void visit(const Lv2Ports::Audio& ) {}
 	virtual void visit(const Lv2Ports::Cv& ) {}
+	virtual void visit(const Lv2Ports::AtomSeq& ) {}
 	virtual void visit(const Lv2Ports::Unknown& ) {}
 
 	virtual ~ConstVisitor();
@@ -93,6 +96,7 @@ struct Visitor
 	virtual void visit(Lv2Ports::Control& ) {}
 	virtual void visit(Lv2Ports::Audio& ) {}
 	virtual void visit(Lv2Ports::Cv& ) {}
+	virtual void visit(Lv2Ports::AtomSeq& ) {}
 	virtual void visit(Lv2Ports::Unknown& ) {}
 
 	virtual ~Visitor();
@@ -190,6 +194,23 @@ private:
 
 	// the only case when data of m_buffer may be referenced:
 	friend struct ::ConnectPortVisitor;
+};
+
+struct AtomSeq : public VisitablePort<AtomSeq, PortBase>
+{
+	enum FlagType
+	{
+		None = 0,
+		Midi = 1
+	};
+	unsigned flags = FlagType::None;
+
+	struct Lv2EvbufDeleter
+	{
+		void operator()(LV2_Evbuf* n);
+	};
+	using AutoLv2Evbuf = std::unique_ptr<LV2_Evbuf, Lv2EvbufDeleter>;
+	AutoLv2Evbuf m_buf;
 };
 
 struct Unknown : public VisitablePort<Unknown, PortBase>

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -36,15 +36,18 @@
 #include "Lv2Basics.h"
 #include "Lv2Features.h"
 #include "LinkedModelGroups.h"
+#include "MidiEvent.h"
+#include "MidiTime.h"
 #include "Plugin.h"
 #include "PluginIssue.h"
-
+#include "../src/3rdparty/ringbuffer/include/ringbuffer/ringbuffer.h"
 
 // forward declare port structs/enums
 namespace Lv2Ports
 {
 	struct Audio;
 	struct PortBase;
+	struct AtomSeq;
 
 	enum class Type;
 	enum class Flow;
@@ -106,8 +109,11 @@ public:
 	/*
 		utils for the run thread
 	*/
-	//! Copy values from all connected models into the respective ports
+	//! Copy values from the LMMS core (connected models, MIDI events, ...) into
+	//! the respective ports
 	void copyModelsFromCore();
+	//! Bring values from all ports to the LMMS core
+	void copyModelsToCore();
 	/**
 	 * Copy buffer passed by the core into our ports
 	 * @param buf buffer of sample frames, each sample frame is something like
@@ -137,11 +143,15 @@ public:
 	//! Run the Lv2 plugin instance for @param frames frames
 	void run(fpp_t frames);
 
+	void handleMidiInputEvent(const class MidiEvent &event,
+		const MidiTime &time, f_cnt_t offset);
+
 	/*
 		misc
 	 */
 	class AutomatableModel *modelAtPort(const QString &uri); // unused currently
 	std::size_t controlCount() const { return LinkedModelGroup::modelNum(); }
+	bool hasNoteInput() const;
 
 protected:
 	/*
@@ -159,8 +169,25 @@ private:
 	LilvInstance* m_instance;
 	Lv2Features m_features;
 
+	// full list of ports
 	std::vector<std::unique_ptr<Lv2Ports::PortBase>> m_ports;
+	// quick reference to specific, unique ports
 	StereoPortRef m_inPorts, m_outPorts;
+	Lv2Ports::AtomSeq *m_midiIn = nullptr, *m_midiOut = nullptr;
+
+	// MIDI
+	// many things here may be moved into the `Instrument` class
+	constexpr const static std::size_t m_maxMidiInputEvents = 1024;
+	//! spinlock for the MIDI ringbuffer (for MIDI events going to the plugin)
+	std::atomic_flag m_ringLock = ATOMIC_FLAG_INIT;
+
+	//! MIDI ringbuffer (for MIDI events going to the plugin)
+	ringbuffer_t<struct MidiInputEvent> m_midiInputBuf;
+	//! MIDI ringbuffer reader
+	ringbuffer_reader_t<struct MidiInputEvent> m_midiInputReader;
+
+	// other
+	static std::size_t minimumEvbufSize() { return 1 << 15; /* ardour uses this*/ }
 
 	//! models for the controls, sorted by port symbols
 	std::map<std::string, AutomatableModel *> m_connectedModels;

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -37,7 +37,7 @@ class Lv2UridCache
 public:
 	enum class Id //!< ID for m_uridCache array
 	{
-		midi_MidiEvent, //!< just an example, unused yet
+		midi_MidiEvent,
 		size
 	};
 	//! Return URID for a cache ID

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -74,6 +74,7 @@ bool Lv2Effect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 	m_controls.run(frames);
 //	m_pluginMutex.unlock();
 
+	m_controls.copyModelsToLmms();
 	m_controls.copyBuffersToLmms(m_tmpOutputSmps.data(), frames);
 
 	double outSum = .0;

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -131,11 +131,9 @@ void Lv2Instrument::loadFile(const QString &file)
 bool Lv2Instrument::handleMidiEvent(
 	const MidiEvent &event, const MidiTime &time, f_cnt_t offset)
 {
-	// this function can be called from GUI threads while the plugin is running,
-	// so this requires caching, e.g. in ringbuffers
-	(void)time;
-	(void)offset;
-	(void)event;
+	// this function can be called from GUI threads while the plugin is running
+	// handleMidiInputEvent will use a thread-safe ringbuffer
+	handleMidiInputEvent(event, time, offset);
 	return true;
 }
 #endif
@@ -161,6 +159,7 @@ void Lv2Instrument::play(sampleFrame *buf)
 
 	run(fpp);
 
+	copyModelsToLmms();
 	copyBuffersToLmms(buf, fpp);
 
 	instrumentTrack()->processAudioBuffer(buf, fpp, nullptr);

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -63,7 +63,7 @@ public:
 	/*
 		realtime funcs
 	*/
-	bool hasNoteInput() const override { return false; /* not supported yet */ }
+	bool hasNoteInput() const override { return Lv2ControlBase::hasNoteInput(); }
 #ifdef LV2_INSTRUMENT_USE_MIDI
 	bool handleMidiEvent(const MidiEvent &event,
 		const MidiTime &time = MidiTime(), f_cnt_t offset = 0) override;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -93,6 +93,7 @@ set(LMMS_SRCS
 
 	core/lv2/Lv2Basics.cpp
 	core/lv2/Lv2ControlBase.cpp
+	core/lv2/Lv2Evbuf.cpp
 	core/lv2/Lv2Features.cpp
 	core/lv2/Lv2Ports.cpp
 	core/lv2/Lv2Proc.cpp

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -26,6 +26,7 @@
 
 #ifdef LMMS_HAVE_LV2
 
+#include <algorithm>
 #include <QtGlobal>
 
 #include "Engine.h"
@@ -113,6 +114,14 @@ void Lv2ControlBase::copyModelsFromLmms() {
 
 
 
+void Lv2ControlBase::copyModelsToLmms() const
+{
+	for (auto& c : m_procs) { c->copyModelsToCore(); }
+}
+
+
+
+
 void Lv2ControlBase::copyBuffersFromLmms(const sampleFrame *buf, fpp_t frames) {
 	unsigned firstChan = 0; // tell the procs which channels they shall read from
 	for (auto& c : m_procs) {
@@ -182,6 +191,24 @@ std::size_t Lv2ControlBase::controlCount() const {
 	std::size_t res = 0;
 	for (const auto& c : m_procs) { res += c->controlCount(); }
 	return res;
+}
+
+
+
+
+bool Lv2ControlBase::hasNoteInput() const
+{
+	return std::any_of(m_procs.begin(), m_procs.end(),
+		[](const auto& c) { return c->hasNoteInput(); });
+}
+
+
+
+
+void Lv2ControlBase::handleMidiInputEvent(const MidiEvent &event,
+	const MidiTime &time, f_cnt_t offset)
+{
+	for (auto& c : m_procs) { c->handleMidiInputEvent(event, time, offset); }
 }
 
 

--- a/src/core/lv2/Lv2Evbuf.cpp
+++ b/src/core/lv2/Lv2Evbuf.cpp
@@ -1,0 +1,193 @@
+/*
+ * lv2_evbuf.cpp - Lv2 event buffer implementation
+ *
+ * Copyright (c) 2019-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+/*
+ * The original code was written by David Robillard <http://drobilla.net>
+ */
+
+#include "Lv2Evbuf.h"
+
+#ifdef LMMS_HAVE_LV2
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+
+#include <lv2/lv2plug.in/ns/ext/atom/atom.h>
+
+struct LV2_Evbuf_Impl {
+	uint32_t capacity;
+	uint32_t atom_Chunk;
+	uint32_t atom_Sequence;
+	LV2_Atom_Sequence buf;
+};
+
+static inline uint32_t
+lv2_evbuf_pad_size(uint32_t size)
+{
+	return (size + 7) & (~7);
+}
+
+LV2_Evbuf*
+lv2_evbuf_new(uint32_t capacity, uint32_t atom_Chunk, uint32_t atom_Sequence)
+{
+	// FIXME: memory must be 64-bit aligned
+	LV2_Evbuf* evbuf = (LV2_Evbuf*)malloc(
+		sizeof(LV2_Evbuf) + sizeof(LV2_Atom_Sequence) + capacity);
+	evbuf->capacity = capacity;
+	evbuf->atom_Chunk = atom_Chunk;
+	evbuf->atom_Sequence = atom_Sequence;
+	lv2_evbuf_reset(evbuf, true);
+	return evbuf;
+}
+
+void
+lv2_evbuf_free(LV2_Evbuf* evbuf)
+{
+	free(evbuf);
+}
+
+void
+lv2_evbuf_reset(LV2_Evbuf* evbuf, bool input)
+{
+	if (input) {
+		evbuf->buf.atom.size = sizeof(LV2_Atom_Sequence_Body);
+		evbuf->buf.atom.type = evbuf->atom_Sequence;
+	} else {
+		evbuf->buf.atom.size = evbuf->capacity;
+		evbuf->buf.atom.type = evbuf->atom_Chunk;
+	}
+}
+
+uint32_t
+lv2_evbuf_get_size(LV2_Evbuf* evbuf)
+{
+	assert(evbuf->buf.atom.type != evbuf->atom_Sequence
+	|| evbuf->buf.atom.size >= sizeof(LV2_Atom_Sequence_Body));
+	return evbuf->buf.atom.type == evbuf->atom_Sequence
+		? evbuf->buf.atom.size - sizeof(LV2_Atom_Sequence_Body)
+		: 0;
+}
+
+void*
+lv2_evbuf_get_buffer(LV2_Evbuf* evbuf)
+{
+	return &evbuf->buf;
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_begin(LV2_Evbuf* evbuf)
+{
+	LV2_Evbuf_Iterator iter = { evbuf, 0 };
+	return iter;
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_end(LV2_Evbuf* evbuf)
+{
+	const uint32_t size = lv2_evbuf_get_size(evbuf);
+	const LV2_Evbuf_Iterator iter = { evbuf, lv2_evbuf_pad_size(size) };
+	return iter;
+}
+
+bool
+lv2_evbuf_is_valid(LV2_Evbuf_Iterator iter)
+{
+	return iter.offset < lv2_evbuf_get_size(iter.evbuf);
+}
+
+LV2_Evbuf_Iterator
+lv2_evbuf_next(LV2_Evbuf_Iterator iter)
+{
+	if (!lv2_evbuf_is_valid(iter)) {
+		return iter;
+	}
+
+	LV2_Evbuf* evbuf  = iter.evbuf;
+	uint32_t   offset = iter.offset;
+	uint32_t   size;
+	size = ((LV2_Atom_Event*)
+		((char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, &evbuf->buf.atom)
+		+ offset))->body.size;
+	offset += lv2_evbuf_pad_size(sizeof(LV2_Atom_Event) + size);
+
+	LV2_Evbuf_Iterator next = { evbuf, offset };
+	return next;
+}
+
+bool
+lv2_evbuf_get(LV2_Evbuf_Iterator iter,
+	uint32_t* frames,
+	uint32_t* type,
+	uint32_t* size,
+	uint8_t** data)
+{
+	*frames = *type = *size = 0;
+	*data = NULL;
+
+	if (!lv2_evbuf_is_valid(iter)) {
+		return false;
+	}
+
+	LV2_Atom_Sequence* aseq = &iter.evbuf->buf;
+	LV2_Atom_Event*    aev  = (LV2_Atom_Event*)(
+		(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter.offset);
+
+	*frames = aev->time.frames;
+	*type = aev->body.type;
+	*size = aev->body.size;
+	*data = (uint8_t*)LV2_ATOM_BODY(&aev->body);
+
+	return true;
+}
+
+bool
+lv2_evbuf_write(LV2_Evbuf_Iterator* iter,
+	uint32_t frames,
+	uint32_t type,
+	uint32_t size,
+	const uint8_t* data)
+{
+	LV2_Atom_Sequence* aseq = &iter->evbuf->buf;
+	if (iter->evbuf->capacity - sizeof(LV2_Atom) - aseq->atom.size <
+		sizeof(LV2_Atom_Event) + size) {
+		return false;
+	}
+
+	LV2_Atom_Event* aev = (LV2_Atom_Event*)(
+		(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter->offset);
+
+	aev->time.frames = frames;
+	aev->body.type = type;
+	aev->body.size = size;
+	memcpy(LV2_ATOM_BODY(&aev->body), data, size);
+
+	size = lv2_evbuf_pad_size(sizeof(LV2_Atom_Event) + size);
+	aseq->atom.size += size;
+	iter->offset += size;
+
+	return true;
+}
+
+#endif // LMMS_HAVE_LV2


### PR DESCRIPTION
This commit enables atom ports and feeds them with MIDI events, if the atom ports accepts them. This enables Lv2 instruments with piano roll, e.g. the MDA Piano.

Reviewer hints:
* ~~Please review~~

Tester hints:
* ~~Wait with final testing until review is done~~
* Set up a wide range of packages (my current list of packages at Arch Linux is: "calf lsp-plugins mda.lv2 noise-repellent surge x42-plugins", and from the AUR: "lv2-plugins-aur-meta")
* Any Lv2 instrument is worth testing
* New effects are also available: the x42-eq and x42-dpl
* This PR is actually just about passing piano roll key presses to Lv2 instruments (which it does via MIDI internally: when you press a key in piano roll or play it in the editor, LMMS passes MIDI to the plugin, and Lv2 now recognizes these MIDI events).
* Things to check can include
  - play notes using
    * piano roll
    * keyboard keys
    * the Instrument view's keyboard
  - playing tons of notes at the same or nearly the same time


