### PR TITLE
Don't reload sample from disk when reversing

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -24,6 +24,8 @@
 
 #include "SampleBuffer.h"
 
+#include <algorithm>
+
 #include <QBuffer>
 #include <QFile>
 #include <QFileInfo>
@@ -1412,7 +1414,12 @@ void SampleBuffer::setAmplification( float _a )
 void SampleBuffer::setReversed( bool _on )
 {
 	m_reversed = _on;
-	update( true );
+	Engine::mixer()->requestChangeInModel();
+	m_varLock.lockForWrite();
+	std::reverse(m_data, m_data + m_frames);
+	m_varLock.unlock();
+	Engine::mixer()->doneChangeInModel();
+	emit sampleUpdated();
 }
 
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -1413,10 +1413,10 @@ void SampleBuffer::setAmplification( float _a )
 
 void SampleBuffer::setReversed( bool _on )
 {
-	m_reversed = _on;
 	Engine::mixer()->requestChangeInModel();
 	m_varLock.lockForWrite();
-	std::reverse(m_data, m_data + m_frames);
+	if (m_reversed != _on) { std::reverse(m_data, m_data + m_frames); }
+	m_reversed = _on;
 	m_varLock.unlock();
 	Engine::mixer()->doneChangeInModel();
 	emit sampleUpdated();


### PR DESCRIPTION
Currently, when reversing a sample, `SampleBuffer` reloads it from disk. This is unnecessary and makes it impossible to do so in realtime code. This change still isn't realtime safe, since it locks a mutex, but a proper fix requires much wider changes, and it doesn't read from the disk any more at least.

Blocks #5695.