### PR TITLE
Add Carla support for Windows

### DIFF
--- a/plugins/carlabase/CMakeLists.txt
+++ b/plugins/carlabase/CMakeLists.txt
@@ -14,13 +14,22 @@ if(LMMS_HAVE_WEAKCARLA)
     ${CMAKE_CURRENT_SOURCE_DIR}/carla/source/utils
     ${CMAKE_CURRENT_SOURCE_DIR}/carla/source/backend
   )
-  ADD_LIBRARY(carla_native-plugin SHARED DummyCarla.cpp)
-  TARGET_INCLUDE_DIRECTORIES(carla_native-plugin PUBLIC ${CARLA_INCLUDE_DIRS})
-  INSTALL(TARGETS carla_native-plugin
+
+  IF(LMMS_BUILD_WIN32)
+      # use carla.dll
+      SET(CMAKE_SHARED_LIBRARY_PREFIX "")
+      SET(CARLA_NATIVE_LIB carla)
+  ELSE()
+      # use libcarla_native-plugin
+      SET(CARLA_NATIVE_LIB carla_native-plugin)
+  ENDIF()
+  ADD_LIBRARY(${CARLA_NATIVE_LIB} SHARED DummyCarla.cpp)
+  TARGET_INCLUDE_DIRECTORIES(${CARLA_NATIVE_LIB} PUBLIC ${CARLA_INCLUDE_DIRS})
+  INSTALL(TARGETS ${CARLA_NATIVE_LIB}
     LIBRARY DESTINATION "${PLUGIN_DIR}/optional"
     RUNTIME DESTINATION "${PLUGIN_DIR}/optional"
   )
-  SET(CARLA_LIBRARIES carla_native-plugin)
+  SET(CARLA_LIBRARIES ${CARLA_NATIVE_LIB})
   # Set parent scope variables so carlarack and carlapatchbay can see them
   SET(CARLA_LIBRARIES ${CARLA_LIBRARIES} PARENT_SCOPE)
 endif()
@@ -45,6 +54,6 @@ if(LMMS_HAVE_CARLA OR LMMS_HAVE_WEAKCARLA)
                 INSTALL_RPATH_USE_LINK_PATH TRUE
                 INSTALL_RPATH "${CARLA_RPATH}")
         IF(LMMS_HAVE_WEAKCARLA)
-                ADD_DEPENDENCIES(carlabase carla_native-plugin)
+                ADD_DEPENDENCIES(carlabase ${CARLA_NATIVE_LIB})
         ENDIF()
 endif()

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -149,12 +149,10 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     path.cdUp();
     path.cdUp();
     resourcesPath = path.absolutePath() + "/share/carla/resources";
-#elif defined(CARLA_OS_MAC)
+#elif defined(CARLA_OS_MAC) || defined(CARLA_OS_WIN32) || defined(CARLA_OS_WIN64)
     // parse prefix from dll filename
     QDir path = QFileInfo(dllName).dir();
     resourcesPath = path.absolutePath() + "/resources";
-#elif defined(CARLA_OS_WIN32) || defined(CARLA_OS_WIN64)
-    // not yet supported
 #endif
     fHost.resourceDir            = strdup(resourcesPath.toUtf8().constData());
     fHost.get_buffer_size        = host_get_buffer_size;

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -141,17 +141,15 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     fHost.uiParentId  = 0;
 
     // carla/resources contains PyQt scripts required for launch
-    QString dllName(carla_get_library_filename());
-    QString resourcesPath;
-    QDir path = QFileInfo(dllName).dir();
+    QDir path = QFileInfo(carla_get_library_folder()).absoluteDir();
 #if defined(CARLA_OS_LINUX)
     // parse prefix from dll filename
     path.cdUp();
     path.cdUp();
-    resourcesPath = path.absolutePath() + "/share/carla/resources";
+    QString resourcesPath = path.absolutePath() + "/share/carla/resources";
 #else
     // parse prefix from dll filename
-    resourcesPath = path.absolutePath() + "/resources";
+    QString resourcesPath = path.absolutePath() + "/resources";
 #endif
     fHost.resourceDir            = strdup(resourcesPath.toUtf8().constData());
     fHost.get_buffer_size        = host_get_buffer_size;
@@ -506,7 +504,7 @@ void CarlaInstrumentView::toggleUI(bool visible)
 #if defined(CARLA_OS_WIN32) || defined(CARLA_OS_WIN64)
         if (visible) {
             QString backupDir = QDir::currentPath();
-            QDir::setCurrent(QFileInfo(carla_get_library_filename()).dir().absolutePath());
+            QDir::setCurrent(carla_get_library_folder());
             fDescriptor->ui_show(fHandle, true);
             QDir::setCurrent(backupDir);
             return;

--- a/plugins/carlabase/carla.cpp
+++ b/plugins/carlabase/carla.cpp
@@ -141,9 +141,8 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     fHost.uiParentId  = 0;
 
     // carla/resources contains PyQt scripts required for launch
-    QDir path = QFileInfo(carla_get_library_folder()).absoluteDir();
+    QDir path(carla_get_library_folder());
 #if defined(CARLA_OS_LINUX)
-    // parse prefix from dll filename
     path.cdUp();
     path.cdUp();
     QString resourcesPath = path.absolutePath() + "/share/carla/resources";


### PR DESCRIPTION
Closes #4654 

This PR should be safe for backport to 1.2.x if needed.

What the PR does:
* Renames `libcarla_native-plugin.dll` to `carla.dll` to match that of the Windows release
* Fixes a `PATH` conflict preventing Carla from finding PyQt

Steps to use Carla with LMMS:
* Install a version of LMMS with Carla support (click [here](https://github.com/tresf/lmms/releases/download/experimental/lmms-1.2.3-729+gb64fe8e7c-mingw-win64.exe) if the download bot below doesn't have one)
* Download Carla for windows
* Extract Carla to a permanent location
* Add `Carla.lv2` to your `PATH` environment variable (e.g. `C:\Carla_2.2.0-win64\Carla.lv2`)
* Start LMMS

Known issues:
* Removing a Carla track may cause LMMS to segfault
* On slow machines, Carla may not load the first time and "Show GUI" may need to be clicked again

<img width="1440" alt="Screen Shot 2020-10-15 at 4 31 52 PM" src="https://user-images.githubusercontent.com/6345473/96182800-fa160e00-0f03-11eb-8853-78c88f16f1e8.png">
