### PR TITLE
[CI checking, ignore] Refactor writing MIDI events to buffers

### DIFF
--- a/include/MidiEventToByteSeq.h
+++ b/include/MidiEventToByteSeq.h
@@ -1,0 +1,47 @@
+/*
+ * MidiEventToByteSeq.h - writeToByteSeq declaration
+ *
+ * Copyright (c) 2020-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef MIDIEVENTTOBYTESEQ_H
+#define MIDIEVENTTOBYTESEQ_H
+
+#include <cstddef>
+#include <cstdint>
+
+#include "lmms_export.h"
+
+/**
+	Write MIDI event into byte sequence.
+
+	Conforming to http://lv2plug.in/ns/ext/midi#MidiEvent
+
+	@param data Pointer to the target buffer for the byte sequence. Must
+		point to existing memory with at least 3 bytes size.
+	@param bufsize Available size of the target buffer.
+	@return Used size of the target buffer, or 0 if the MidiEvent could not
+		be converted.
+*/
+std::size_t LMMS_EXPORT writeToByteSeq( const class MidiEvent& ev,
+										uint8_t* data, std::size_t bufsize );
+
+#endif // MIDIEVENTTOBYTESEQ_H

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -104,6 +104,7 @@ set(LMMS_SRCS
 	core/midi/MidiAlsaSeq.cpp
 	core/midi/MidiClient.cpp
 	core/midi/MidiController.cpp
+	core/midi/MidiEventToByteSeq.cpp
 	core/midi/MidiJack.cpp
 	core/midi/MidiOss.cpp
 	core/midi/MidiSndio.cpp

--- a/src/core/midi/MidiEventToByteSeq.cpp
+++ b/src/core/midi/MidiEventToByteSeq.cpp
@@ -1,0 +1,107 @@
+/*
+ * MidiEventToByteSeq.cpp - writeToByteSeq implementation
+ *
+ * Copyright (c) 2020-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "MidiEventToByteSeq.h"
+
+#include <QtGlobal>
+
+#include "MidiEvent.h"
+
+
+std::size_t writeToByteSeq(
+	const MidiEvent& ev, uint8_t *data, std::size_t bufsize)
+{
+	Q_ASSERT(bufsize >= 3);
+
+	std::size_t size = 0;
+	data[0] = ev.type() | (ev.channel() & 0x0F);
+
+	switch (ev.type())
+	{
+		case MidiNoteOn:
+			if (ev.velocity() > 0)
+			{
+				if (ev.key() < 0 || ev.key() > MidiMaxKey)
+					break;
+
+				data[1] = ev.key();
+				data[2] = ev.velocity();
+				size    = 3;
+				break;
+			}
+			else
+			{
+				// Lv2 MIDI specs:
+				// "Note On messages with velocity 0 are not allowed.
+				// These messages are equivalent to Note Off in standard
+				// MIDI streams, but here only proper Note Off messages
+				// are allowed."
+				data[0] = MidiNoteOff | (ev.channel() & 0x0F);
+				// nobreak
+			}
+
+		case MidiNoteOff:
+			if (ev.key() < 0 || ev.key() > MidiMaxKey)
+				break;
+			data[1] = ev.key();
+			data[2] = ev.velocity(); // release time
+			size    = 3;
+			break;
+
+		case MidiKeyPressure:
+			data[1] = ev.key();
+			data[2] = ev.velocity();
+			size    = 3;
+			break;
+
+		case MidiControlChange:
+			data[1] = ev.controllerNumber();
+			data[2] = ev.controllerValue();
+			size    = 3;
+			break;
+
+		case MidiProgramChange:
+			data[1] = ev.program();
+			size    = 2;
+			break;
+
+		case MidiChannelPressure:
+			data[1] = ev.channelPressure();
+			size    = 2;
+			break;
+
+		case MidiPitchBend:
+			data[1] = ev.pitchBend() & 0x7f;
+			data[2] = ev.pitchBend() >> 7;
+			size    = 3;
+			break;
+
+		default:
+			// unhandled
+			break;
+	}
+
+	return size;
+}
+


### PR DESCRIPTION
This moves out the code from the carla plugin into the core, because
this code will be re-used for Lv2 MIDI handling soon.

No reviews required (it's a split of #5691 which has been reviewed by Dom), I only wait for CI.