### PR TITLE
When deviceName or endPointName are null strlen crashed

### DIFF
--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -401,9 +401,9 @@ void MidiApple::midiInClose( MIDIEndpointRef reference )
 char *getName( MIDIObjectRef &object )
 {
 	// Returns the name of a given MIDIObjectRef as char *
-	CFStringRef name = nil;
+	CFStringRef name = nullptr;
 	if (noErr != MIDIObjectGetStringProperty(object, kMIDIPropertyName, &name))
-		return nil;
+		return nullptr;
 	int len = CFStringGetLength(name)+1;
 	char *value = (char *) malloc(len);
 	
@@ -615,8 +615,12 @@ char * MidiApple::getFullName(MIDIEndpointRef &endpoint_ref)
 	char * deviceName = getName(device);
 	char * endPointName = getName(endpoint_ref);
 	qDebug("device name='%s' endpoint name='%s'",deviceName,endPointName);
-	char * fullName = (char *)malloc(strlen(deviceName) + strlen(":") + strlen(endPointName)+1);
+	size_t deviceNameLen = deviceName == nullptr ? 0 : strlen(deviceName);
+	size_t endPointNameLen = endPointName == nullptr ? 0 : strlen(endPointName);
+	char * fullName = (char *)malloc(deviceNameLen + endPointNameLen + 2);
 	sprintf(fullName, "%s:%s", deviceName,endPointName);
+	if (deviceName != nullptr) { free(deviceName); }
+	if (endPointName != nullptr) { free(endPointName); }
 	return fullName;
 }
 


### PR DESCRIPTION
This fixes issue #5728.

The problem was that the deviceName was undefined when I tried to create a virtual midi device. That made `getName` return nil, which in turn crashed lmms when it tried to `strlen(nil)`.