### PR TITLE
Fixes bug with cloning Automation Tracks

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -2554,12 +2554,15 @@ Track * Track::create( const QDomElement & element, TrackContainer * tc )
 /*! \brief Clone a track from this track
  *
  */
-Track * Track::clone()
+Track* Track::clone()
 {
 	QDomDocument doc;
-	QDomElement parent = doc.createElement( "clone" );
-	saveState( doc, parent );
-	return create( parent.firstChild().toElement(), m_trackContainer );
+	QDomElement parent = doc.createElement("clone");
+	saveState(doc, parent);
+	Track* t = create(parent.firstChild().toElement(), m_trackContainer);
+
+	AutomationPattern::resolveAllIDs();
+	return t;
 }
 
 


### PR DESCRIPTION
Fixes bug from issue #5595. When cloning an automation track, the IDs from the recently created AutomationPatterns weren't being resolved, causing them to show as disconnected automations.

This PR fixes the issue by adding a call to `AutomationPattern::resolveAllIDs()` on the `Track::clone()` method. It also fixes the code style on that method.