### PR TITLE
Adds missing initializer to DataFile.cpp

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -146,7 +146,8 @@ DataFile::DataFile( const QString & _fileName ) :
 DataFile::DataFile( const QByteArray & _data ) :
 	QDomDocument(),
 	m_content(),
-	m_head()
+	m_head(),
+	m_fileVersion( UPGRADE_METHODS.size() )
 {
 	loadData( _data, "<internal data>" );
 }


### PR DESCRIPTION
The third constructor from DataFile was missing an initializer for the file version variable.