### PR TITLE
Attempt to fix DMGs

### DIFF
--- a/cmake/apple/CMakeLists.txt
+++ b/cmake/apple/CMakeLists.txt
@@ -9,6 +9,11 @@ SET(MACOSX_BUNDLE_MIMETYPE              "application/x-lmms-project")
 SET(MACOSX_BUNDLE_MIMETYPE_ICON         "project.icns")
 SET(MACOSX_BUNDLE_MIMETYPE_ID           "io.lmms")
 SET(MACOSX_BUNDLE_PROJECT_URL           "${PROJECT_URL}")
+SET(MACOSX_BUNDLE_DMG_TITLE             "${MACOSX_BUNDLE_BUNDLE_NAME} ${MACOSX_BUNDLE_LONG_VERSION_STRING}")
+
+# FIXME: appdmg won't allow volume names > 27 char
+# See also https://github.com/LinusU/node-appdmg/issues/48
+STRING(SUBSTRING "${MACOSX_BUNDLE_DMG_TITLE}" 0 27 MACOSX_BUNDLE_DMG_TITLE)
 
 CONFIGURE_FILE("lmms.plist.in"          "${CMAKE_BINARY_DIR}/Info.plist")
 CONFIGURE_FILE("install_apple.sh.in"    "${CMAKE_BINARY_DIR}/install_apple.sh" @ONLY)

--- a/cmake/apple/package_apple.json.in
+++ b/cmake/apple/package_apple.json.in
@@ -1,5 +1,5 @@
 {
- "title": "@MACOSX_BUNDLE_BUNDLE_NAME@ @MACOSX_BUNDLE_LONG_VERSION_STRING@",
+ "title": "@MACOSX_BUNDLE_DMG_TITLE@",
  "background": "@CMAKE_SOURCE_DIR@/cmake/apple/dmg_branding.png",
  "icon-size": 128,
  "contents": [


### PR DESCRIPTION
CircleCI's failing, the DMG name is too long.  I suspect this is caused by our new versioning logic.

There's an upstream bug report from 2015, doesn't seems like it will be fixed anytime soon, so patching it with CMake for now.

https://github.com/LinusU/node-appdmg/issues/48