### PR TITLE
Sidebar Improvements

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -149,7 +149,7 @@ MainWindow::MainWindow() :
 
 
 	QStringList root_paths;
-	QString title = tr( "Root directory" );
+	QString title = tr( "Root Directory" );
 	bool dirs_as_items = false;
 
 #ifdef LMMS_BUILD_APPLE

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -111,7 +111,7 @@ void SideBar::appendTab( SideBarWidget *widget )
 	SideBarButton *button = new SideBarButton( orientation(), this );
 	button->setText( " " + widget->title() );
 	button->setIcon( widget->icon() );
-	button->setLayoutDirection( Qt::RightToLeft );
+	button->setLayoutDirection( Qt::LeftToRight );
 	button->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 	button->setCheckable( true );
 	m_widgets[button] = widget;

--- a/src/gui/widgets/SideBar.cpp
+++ b/src/gui/widgets/SideBar.cpp
@@ -112,6 +112,7 @@ void SideBar::appendTab( SideBarWidget *widget )
 	button->setText( " " + widget->title() );
 	button->setIcon( widget->icon() );
 	button->setLayoutDirection( Qt::RightToLeft );
+	button->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 	button->setCheckable( true );
 	m_widgets[button] = widget;
 	m_btnGroup.addButton( button );
@@ -147,7 +148,6 @@ void SideBar::toggleButton( QAbstractButton * button )
 		else
 		{
 			curBtn->setChecked( false );
-			curBtn->setToolButtonStyle( Qt::ToolButtonIconOnly );
 		}
 
 		if( curWidget )
@@ -159,8 +159,6 @@ void SideBar::toggleButton( QAbstractButton * button )
 	if( toolButton && activeWidget )
 	{
 		activeWidget->setVisible( button->isChecked() );
-		toolButton->setToolButtonStyle( button->isChecked() ?
-				Qt::ToolButtonTextBesideIcon : Qt::ToolButtonIconOnly );
 	}
 }
 


### PR DESCRIPTION
This PR updates the sidebar to make it more modern and usable. The first change addresses #5703 by making the sidebar button labels visible permanently. This will be helpful for new users so that they will know what each button does immediately without needing to click on each button to discover what it does, and it will help longtime users so they won't have to remember what functions the icons represent.

The second change fixes an issue with the first change--the button labels are closer to the neighboring button's icon than their own button's icon. My solution to this was to move the position of the icon from the top of the buttons to the bottom.

As part of this PR, I have also taken the liberty of capitalizing the Root Directory button to match the other buttons.

Shown below is how this PR looks compared to the default.
![image](https://user-images.githubusercontent.com/1989498/97769190-c25bb880-1af6-11eb-936c-f6f2dfa7658f.png)

Before merging this PR, there are two additional changes I would like to make.

- [ ] Add an effect to the buttons to hint they are clickable when the mouse moves over them
- [ ] Keep the buttons visible when the window is too small to show them all

Some ideas for preventing this issue are renaming the tabs to remove "My", eliding the names if the window is too small, or making the sidebar scrollable with a hint at the bottom indicating there are additional items. As an example of eliding, here is the Kate text editor with the window resized.

![image](https://user-images.githubusercontent.com/1989498/97510557-fb5b2800-1952-11eb-9df9-7e5a0d0dd8a1.png)

Any feedback is appreciated! 👍