### PR TITLE
Implement Lv2 Options

### DIFF
--- a/include/Lv2Manager.h
+++ b/include/Lv2Manager.h
@@ -130,6 +130,8 @@ public:
 		return m_supportedFeatureURIs;
 	}
 	bool isFeatureSupported(const char* featName) const;
+	AutoLilvNodes findNodes(const LilvNode *subject,
+		const LilvNode *predicate, const LilvNode *object);
 
 	static const std::set<const char*, Lv2Manager::CmpStr>& getPluginBlacklist()
 	{

--- a/include/Lv2Options.h
+++ b/include/Lv2Options.h
@@ -29,6 +29,7 @@
 
 #ifdef LMMS_HAVE_LV2
 
+#include <cstdint>
 #include <lv2/lv2plug.in/ns/ext/options/options.h>
 #include <lv2/lv2plug.in/ns/ext/urid/urid.h>
 #include <map>
@@ -83,7 +84,7 @@ private:
 
 	struct VoidArrayDeleter
 	{
-		void operator()(void* n) { delete[] static_cast<char*>(n); }
+		void operator()(void* n) { delete[] static_cast<uint8_t*>(n); }
 	};
 	//! option value storage
 	std::map<LV2_URID, std::unique_ptr<void, VoidArrayDeleter>> m_optionValues;

--- a/include/Lv2Options.h
+++ b/include/Lv2Options.h
@@ -69,9 +69,8 @@ public:
 			LV2_Options_Context context = LV2_OPTIONS_INSTANCE,
 			std::uint32_t subject = 0)
 	{
-		using OptPtr = Opt*;
 		const Lv2UridCache& cache = Engine::getLv2Manager()->uridCache();
-		initOption(cache[key], sizeof(Opt), cache.uridForType(OptPtr()),
+		initOption(cache[key], sizeof(Opt), cache[Lv2UridCache::IdForType_v<Opt>],
 			std::make_shared<Opt>(std::forward<Arg>(value)), context, subject);
 	}
 	//! Fill m_options and m_optionPointers with all options

--- a/include/Lv2Options.h
+++ b/include/Lv2Options.h
@@ -70,7 +70,7 @@ public:
 			std::uint32_t subject = 0)
 	{
 		const Lv2UridCache& cache = Engine::getLv2Manager()->uridCache();
-		initOption(cache[key], sizeof(Opt), cache[Lv2UridCache::IdForType_v<Opt>],
+		initOption(cache[key], sizeof(Opt), cache[Lv2UridCache::IdForType<Opt>::value],
 			std::make_shared<Opt>(std::forward<Arg>(value)), context, subject);
 	}
 	//! Fill m_options and m_optionPointers with all options

--- a/include/Lv2Options.h
+++ b/include/Lv2Options.h
@@ -37,6 +37,8 @@
 #include <set>
 #include <vector>
 
+#include "Engine.h"
+#include "Lv2Manager.h"
 #include "Lv2UridCache.h"
 
 /**
@@ -63,11 +65,12 @@ public:
 
 	//! Initialize an option
 	template<typename Opt, typename Arg>
-	void initOption(const Lv2UridCache& cache, Lv2UridCache::Id key, Arg&& value,
+	void initOption(Lv2UridCache::Id key, Arg&& value,
 			LV2_Options_Context context = LV2_OPTIONS_INSTANCE,
 			std::uint32_t subject = 0)
 	{
 		using OptPtr = Opt*;
+		const Lv2UridCache& cache = Engine::getLv2Manager()->uridCache();
 		initOption(cache[key], sizeof(Opt), cache.uridForType(OptPtr()),
 			std::make_shared<Opt>(std::forward<Arg>(value)), context, subject);
 	}

--- a/include/Lv2Options.h
+++ b/include/Lv2Options.h
@@ -1,0 +1,97 @@
+/*
+ * Lv2Options.h - Lv2Options class
+ *
+ * Copyright (c) 2020-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LV2OPTIONS_H
+#define LV2OPTIONS_H
+
+#include "lmmsconfig.h"
+
+#ifdef LMMS_HAVE_LV2
+
+#include <lv2/lv2plug.in/ns/ext/options/options.h>
+#include <lv2/lv2plug.in/ns/ext/urid/urid.h>
+#include <map>
+#include <set>
+#include <vector>
+
+/**
+	Option container
+
+	References all available options for a plugin and maps them to their URIDs.
+	This class is used per Lv2 processor (justification in Lv2Proc::initMOptions())
+
+	The public member functions should be called in descending order:
+
+	1. supportOption: set all supported option URIDs
+	2. initOption: initialize options with values
+	3. createOptionVectors: create the option vectors required for
+		the feature
+	4. access the latter using feature()
+*/
+class Lv2Options
+{
+public:
+	//! Initialize an option
+	template<class T>
+	void initOption(LV2_URID key,
+		LV2_URID type,
+		const T* value,
+		LV2_Options_Context context = LV2_Options_Context::LV2_OPTIONS_INSTANCE,
+		uint32_t subject = 0)
+	{
+		initOption(key, sizeof(T), type, value, context, subject);
+	}
+	//! Fill m_options and m_optionPointers with all options
+	void createOptionVectors();
+	//! Return the feature
+	const LV2_Options_Option* feature() const
+	{
+		return m_options.data();
+	}
+
+
+	//! Return if a option is supported by LMMS
+	static bool isOptionSupported(LV2_URID key);
+	//! Mark option as supported
+	static void supportOption(LV2_URID key);
+
+private:
+	void initOption(LV2_URID key,
+		uint32_t size,
+		LV2_URID type,
+		const void* value,
+		LV2_Options_Context context,
+		uint32_t subject);
+
+	//! options that are supported by every processor
+	static std::set<LV2_URID> s_supportedOptions;
+	//! options + data, ordered by URID
+	std::map<LV2_URID, LV2_Options_Option> m_optionByUrid;
+	//! option storage
+	std::vector<LV2_Options_Option> m_options;
+};
+
+#endif // LMMS_HAVE_LV2
+
+#endif // LV2OPTIONS_H

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -35,6 +35,7 @@
 
 #include "Lv2Basics.h"
 #include "Lv2Features.h"
+#include "Lv2Options.h"
 #include "LinkedModelGroups.h"
 #include "MidiEvent.h"
 #include "Plugin.h"
@@ -168,6 +169,7 @@ private:
 	const LilvPlugin* m_plugin;
 	LilvInstance* m_instance;
 	Lv2Features m_features;
+	Lv2Options m_options;
 
 	// full list of ports
 	std::vector<std::unique_ptr<Lv2Ports::PortBase>> m_ports;
@@ -187,11 +189,12 @@ private:
 	ringbuffer_reader_t<struct MidiInputEvent> m_midiInputReader;
 
 	// other
-	static std::size_t minimumEvbufSize() { return 1 << 15; /* ardour uses this*/ }
+	static int32_t defaultEvbufSize() { return 1 << 15; /* ardour uses this*/ }
 
 	//! models for the controls, sorted by port symbols
 	std::map<std::string, AutomatableModel *> m_connectedModels;
 
+	void initMOptions(); //!< initialize m_options
 	void initPluginSpecificFeatures();
 
 	//! load a file in the plugin, but don't do anything in LMMS

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -37,7 +37,15 @@ class Lv2UridCache
 public:
 	enum class Id //!< ID for m_uridCache array
 	{
+		// keep it alphabetically
+		atom_Float,
+		atom_Int,
+		bufsz_minBlockLength,
+		bufsz_maxBlockLength,
+		bufsz_nominalBlockLength,
+		bufsz_sequenceSize,
 		midi_MidiEvent,
+		param_sampleRate,
 		size
 	};
 	//! Return URID for a cache ID

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -55,7 +55,7 @@ public:
 	struct IdForType;
 
 	template<typename T>
-	static constexpr Id IdForType_v = IdForType<T>::value;
+	static constexpr auto IdForType_v = IdForType<T>::value;
 
 	//! Return URID for a cache ID
 	uint32_t operator[](Id id) const;

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -50,18 +50,24 @@ public:
 		// exception to alphabetic ordering - keep at the end:
 		size
 	};
+
+	template<typename T>
+	struct IdForType;
+
+	template<typename T>
+	static constexpr auto IdForType_v = IdForType<T>::value;
+
 	//! Return URID for a cache ID
 	uint32_t operator[](Id id) const;
-
-	// get URID by type
-	uint32_t uridForType(const int32_t*) const { return operator[](Id::atom_Int); }
-	uint32_t uridForType(const float*) const { return operator[](Id::atom_Float); }
 
 	Lv2UridCache(class UridMap& mapper);
 
 private:
 	uint32_t m_cache[static_cast<int>(Id::size)];
 };
+
+template<> struct Lv2UridCache::IdForType<float> { static constexpr auto value = Id::atom_Float; };
+template<> struct Lv2UridCache::IdForType<std::int32_t> { static constexpr auto value = Id::atom_Int; };
 
 #endif // LMMS_HAVE_LV2
 #endif // LV2URIDCACHE_H

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -55,7 +55,7 @@ public:
 	struct IdForType;
 
 	template<typename T>
-	static constexpr auto IdForType_v = IdForType<T>::value;
+	static constexpr Id IdForType_v = IdForType<T>::value;
 
 	//! Return URID for a cache ID
 	uint32_t operator[](Id id) const;

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -37,7 +37,7 @@ class Lv2UridCache
 public:
 	enum class Id //!< ID for m_uridCache array
 	{
-		// keep it alphabetically
+		// keep it alphabetically (except "size" at the end)
 		atom_Float,
 		atom_Int,
 		bufsz_minBlockLength,
@@ -46,6 +46,7 @@ public:
 		bufsz_sequenceSize,
 		midi_MidiEvent,
 		param_sampleRate,
+		// exception to alphabetic ordering - keep at the end:
 		size
 	};
 	//! Return URID for a cache ID

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -29,6 +29,7 @@
 
 #ifdef LMMS_HAVE_LV2
 
+#include <QtGlobal>
 #include <cstdint>
 
 //! Cached URIDs for fast access (for use in real-time code)
@@ -52,7 +53,12 @@ public:
 	//! Return URID for a cache ID
 	uint32_t operator[](Id id) const;
 
+	// get URID by type
+	uint32_t uridForType(const int32_t*) const { return operator[](Id::atom_Int); }
+	uint32_t uridForType(const float*) const { return operator[](Id::atom_Float); }
+
 	Lv2UridCache(class UridMap& mapper);
+
 private:
 	uint32_t m_cache[static_cast<int>(Id::size)];
 };

--- a/include/Lv2UridCache.h
+++ b/include/Lv2UridCache.h
@@ -54,9 +54,6 @@ public:
 	template<typename T>
 	struct IdForType;
 
-	template<typename T>
-	static constexpr auto IdForType_v = IdForType<T>::value;
-
 	//! Return URID for a cache ID
 	uint32_t operator[](Id id) const;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -99,6 +99,7 @@ set(LMMS_SRCS
 	core/lv2/Lv2Ports.cpp
 	core/lv2/Lv2Proc.cpp
 	core/lv2/Lv2Manager.cpp
+	core/lv2/Lv2Options.cpp
 	core/lv2/Lv2SubPluginFeatures.cpp
 	core/lv2/Lv2UridCache.cpp
 	core/lv2/Lv2UridMap.cpp

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <lilv/lilv.h>
 #include <lv2.h>
+#include <lv2/lv2plug.in/ns/ext/options/options.h>
 #include <QDebug>
 #include <QDir>
 #include <QLibrary>
@@ -41,6 +42,7 @@
 #include "Plugin.h"
 #include "PluginFactory.h"
 #include "Lv2ControlBase.h"
+#include "Lv2Options.h"
 #include "PluginIssue.h"
 
 
@@ -67,6 +69,17 @@ Lv2Manager::Lv2Manager() :
 
 	m_supportedFeatureURIs.insert(LV2_URID__map);
 	m_supportedFeatureURIs.insert(LV2_URID__unmap);
+	m_supportedFeatureURIs.insert(LV2_OPTIONS__options);
+
+	auto supportOpt = [this](Lv2UridCache::Id id)
+	{
+		Lv2Options::supportOption(uridCache()[id]);
+	};
+	supportOpt(Lv2UridCache::Id::param_sampleRate);
+	supportOpt(Lv2UridCache::Id::bufsz_maxBlockLength);
+	supportOpt(Lv2UridCache::Id::bufsz_minBlockLength);
+	supportOpt(Lv2UridCache::Id::bufsz_nominalBlockLength);
+	supportOpt(Lv2UridCache::Id::bufsz_sequenceSize);
 }
 
 
@@ -200,6 +213,15 @@ bool Lv2Manager::CmpStr::operator()(const char *a, const char *b) const
 bool Lv2Manager::isFeatureSupported(const char *featName) const
 {
 	return m_supportedFeatureURIs.find(featName) != m_supportedFeatureURIs.end();
+}
+
+
+
+
+AutoLilvNodes Lv2Manager::findNodes(const LilvNode *subject,
+	const LilvNode *predicate, const LilvNode *object)
+{
+	return AutoLilvNodes(lilv_world_find_nodes (m_world, subject, predicate, object));
 }
 
 

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -83,8 +83,8 @@ void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
 	opt.type = type;
 
 	std::unique_ptr<void, VoidArrayDeleter> dataPtr;
-	dataPtr.reset(new char[size]);
-	std::copy((char*)value, (char*)value + size, (char*)dataPtr.get());
+	dataPtr.reset(new uint8_t[size]);
+	std::copy((uint8_t*)value, (uint8_t*)value + size, (uint8_t*)dataPtr.get());
 	opt.value = dataPtr.get();
 
 	Q_ASSERT(m_optionByUrid.find(key) == m_optionByUrid.end());

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -81,12 +81,16 @@ void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
 	opt.subject = subject;
 	opt.size = size;
 	opt.type = type;
-	opt.value = value;
 
-	auto itr = m_optionByUrid.find(key);
-	Q_ASSERT(itr == m_optionByUrid.end());
+	std::unique_ptr<void, VoidArrayDeleter> dataPtr;
+	dataPtr.reset(new char[size]);
+	std::copy((char*)value, (char*)value + size, (char*)dataPtr.get());
+	opt.value = dataPtr.get();
 
+	Q_ASSERT(m_optionByUrid.find(key) == m_optionByUrid.end());
+	Q_ASSERT(m_optionValues.find(key) == m_optionValues.end());
 	m_optionByUrid.emplace(key, opt);
+	m_optionValues.emplace(key, std::move(dataPtr));
 }
 
 

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -70,7 +70,7 @@ void Lv2Options::createOptionVectors()
 
 
 void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
-	const void *value,
+	std::shared_ptr<void> value,
 	LV2_Options_Context context, uint32_t subject)
 {
 	Q_ASSERT(isOptionSupported(key));
@@ -82,13 +82,8 @@ void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
 	opt.size = size;
 	opt.type = type;
 
-	std::unique_ptr<void, VoidArrayDeleter> dataPtr;
-	dataPtr.reset(new uint8_t[size]);
-	std::copy((uint8_t*)value, (uint8_t*)value + size, (uint8_t*)dataPtr.get());
-	opt.value = dataPtr.get();
-
 	const auto optResult = m_optionByUrid.emplace(key, opt);
-	const auto valResult = m_optionValues.emplace(key, std::move(dataPtr));
+	const auto valResult = m_optionValues.emplace(key, std::move(value));
 	Q_ASSERT(optResult.second);
 	Q_ASSERT(valResult.second);
 }

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -81,6 +81,7 @@ void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
 	opt.subject = subject;
 	opt.size = size;
 	opt.type = type;
+	opt.value = value.get();
 
 	const auto optResult = m_optionByUrid.emplace(key, opt);
 	const auto valResult = m_optionValues.emplace(key, std::move(value));

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -44,8 +44,8 @@ bool Lv2Options::isOptionSupported(LV2_URID key)
 
 void Lv2Options::supportOption(LV2_URID key)
 {
-	Q_ASSERT(s_supportedOptions.find(key) == s_supportedOptions.end());
-	s_supportedOptions.insert(key);
+	const auto result = s_supportedOptions.insert(key);
+	Q_ASSERT(result.second);
 }
 
 
@@ -87,12 +87,11 @@ void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
 	std::copy((uint8_t*)value, (uint8_t*)value + size, (uint8_t*)dataPtr.get());
 	opt.value = dataPtr.get();
 
-	Q_ASSERT(m_optionByUrid.find(key) == m_optionByUrid.end());
-	Q_ASSERT(m_optionValues.find(key) == m_optionValues.end());
-	m_optionByUrid.emplace(key, opt);
-	m_optionValues.emplace(key, std::move(dataPtr));
+	const auto optResult = m_optionByUrid.emplace(key, opt);
+	const auto valResult = m_optionValues.emplace(key, std::move(dataPtr));
+	Q_ASSERT(optResult.second);
+	Q_ASSERT(valResult.second);
 }
 
 
 #endif // LMMS_HAVE_LV2
-

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -1,0 +1,94 @@
+/*
+ * Lv2Options.cpp - Lv2Options implementation
+ *
+ * Copyright (c) 2020-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "Lv2Options.h"
+
+#ifdef LMMS_HAVE_LV2
+
+#include <QtGlobal>
+
+
+std::set<LV2_URID> Lv2Options::s_supportedOptions;
+
+
+
+
+bool Lv2Options::isOptionSupported(LV2_URID key)
+{
+	return s_supportedOptions.find(key) != s_supportedOptions.end();
+}
+
+
+
+
+void Lv2Options::supportOption(LV2_URID key)
+{
+	Q_ASSERT(s_supportedOptions.find(key) == s_supportedOptions.end());
+	s_supportedOptions.insert(key);
+}
+
+
+
+
+void Lv2Options::createOptionVectors()
+{
+	// create vector of options
+	for(LV2_URID urid : s_supportedOptions)
+	{
+		auto itr = m_optionByUrid.find(urid);
+		Q_ASSERT(itr != m_optionByUrid.end());
+		m_options.push_back(itr->second);
+	}
+	LV2_Options_Option nullOption;
+	nullOption.key = 0;
+	nullOption.value = nullptr;
+	m_options.push_back(nullOption);
+}
+
+
+
+
+void Lv2Options::initOption(LV2_URID key, uint32_t size, LV2_URID type,
+	const void *value,
+	LV2_Options_Context context, uint32_t subject)
+{
+	Q_ASSERT(isOptionSupported(key));
+
+	LV2_Options_Option opt;
+	opt.key = key;
+	opt.context = context;
+	opt.subject = subject;
+	opt.size = size;
+	opt.type = type;
+	opt.value = value;
+
+	auto itr = m_optionByUrid.find(key);
+	Q_ASSERT(itr == m_optionByUrid.end());
+
+	m_optionByUrid.emplace(key, opt);
+}
+
+
+#endif // LMMS_HAVE_LV2
+

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -461,15 +461,15 @@ void Lv2Proc::initMOptions()
 	int32_t sequenceSize = defaultEvbufSize();
 
 	m_options.initOption(cache[Lv2UridCache::Id::param_sampleRate],
-		atom_Float, &sampleRate);
+		sizeof(sampleRate), atom_Float, &sampleRate);
 	m_options.initOption(cache[Lv2UridCache::Id::bufsz_maxBlockLength],
-		atom_Int, &blockLength);
+		sizeof(blockLength), atom_Int, &blockLength);
 	m_options.initOption(cache[Lv2UridCache::Id::bufsz_minBlockLength],
-		atom_Int, &blockLength);
+		sizeof(blockLength), atom_Int, &blockLength);
 	m_options.initOption(cache[Lv2UridCache::Id::bufsz_nominalBlockLength],
-		atom_Int, &blockLength);
+		sizeof(blockLength), atom_Int, &blockLength);
 	m_options.initOption(cache[Lv2UridCache::Id::bufsz_sequenceSize],
-		atom_Int, &sequenceSize);
+		sizeof(sequenceSize), atom_Int, &sequenceSize);
 	m_options.createOptionVectors();
 }
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -441,8 +441,6 @@ bool Lv2Proc::hasNoteInput() const
 
 void Lv2Proc::initMOptions()
 {
-	const Lv2UridCache& cache = Engine::getLv2Manager()->uridCache();
-
 	/*
 		sampleRate:
 		LMMS can in theory inform plugins of a new sample rate.
@@ -457,16 +455,12 @@ void Lv2Proc::initMOptions()
 	int32_t blockLength = Engine::mixer()->framesPerPeriod();
 	int32_t sequenceSize = defaultEvbufSize();
 
-	m_options.initOption<float>(cache, Lv2UridCache::Id::param_sampleRate,
-		sampleRate);
-	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_maxBlockLength,
-		blockLength);
-	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_minBlockLength,
-		blockLength);
-	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_nominalBlockLength,
-		blockLength);
-	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_sequenceSize,
-		sequenceSize);
+	using Id = Lv2UridCache::Id;
+	m_options.initOption<float>(Id::param_sampleRate, sampleRate);
+	m_options.initOption<int32_t>(Id::bufsz_maxBlockLength, blockLength);
+	m_options.initOption<int32_t>(Id::bufsz_minBlockLength, blockLength);
+	m_options.initOption<int32_t>(Id::bufsz_nominalBlockLength, blockLength);
+	m_options.initOption<int32_t>(Id::bufsz_sequenceSize, sequenceSize);
 	m_options.createOptionVectors();
 }
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -443,9 +443,6 @@ void Lv2Proc::initMOptions()
 {
 	const Lv2UridCache& cache = Engine::getLv2Manager()->uridCache();
 
-	uint32_t atom_Float = cache[Lv2UridCache::Id::atom_Float];
-	uint32_t atom_Int = cache[Lv2UridCache::Id::atom_Int];
-
 	/*
 		sampleRate:
 		LMMS can in theory inform plugins of a new sample rate.
@@ -460,16 +457,16 @@ void Lv2Proc::initMOptions()
 	int32_t blockLength = Engine::mixer()->framesPerPeriod();
 	int32_t sequenceSize = defaultEvbufSize();
 
-	m_options.initOption(cache[Lv2UridCache::Id::param_sampleRate],
-		sizeof(sampleRate), atom_Float, &sampleRate);
-	m_options.initOption(cache[Lv2UridCache::Id::bufsz_maxBlockLength],
-		sizeof(blockLength), atom_Int, &blockLength);
-	m_options.initOption(cache[Lv2UridCache::Id::bufsz_minBlockLength],
-		sizeof(blockLength), atom_Int, &blockLength);
-	m_options.initOption(cache[Lv2UridCache::Id::bufsz_nominalBlockLength],
-		sizeof(blockLength), atom_Int, &blockLength);
-	m_options.initOption(cache[Lv2UridCache::Id::bufsz_sequenceSize],
-		sizeof(sequenceSize), atom_Int, &sequenceSize);
+	m_options.initOption<float>(cache, Lv2UridCache::Id::param_sampleRate,
+		sampleRate);
+	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_maxBlockLength,
+		blockLength);
+	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_minBlockLength,
+		blockLength);
+	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_nominalBlockLength,
+		blockLength);
+	m_options.initOption<int32_t>(cache, Lv2UridCache::Id::bufsz_sequenceSize,
+		sequenceSize);
 	m_options.createOptionVectors();
 }
 

--- a/src/core/lv2/Lv2UridCache.cpp
+++ b/src/core/lv2/Lv2UridCache.cpp
@@ -26,7 +26,10 @@
 
 #ifdef LMMS_HAVE_LV2
 
+#include <lv2/lv2plug.in/ns/ext/atom/atom.h>
+#include <lv2/lv2plug.in/ns/ext/buf-size/buf-size.h>
 #include <lv2/lv2plug.in/ns/ext/midi/midi.h>
+#include <lv2/lv2plug.in/ns/ext/parameters/parameters.h>
 #include <QtGlobal>
 
 #include "Lv2UridMap.h"
@@ -47,7 +50,14 @@ Lv2UridCache::Lv2UridCache(UridMap &mapper)
 		m_cache[static_cast<std::size_t>(id)] = mapper.map(uridStr);
 	};
 
+	init(Id::atom_Float, LV2_ATOM__Float);
+	init(Id::atom_Int, LV2_ATOM__Int);
+	init(Id::bufsz_minBlockLength, LV2_BUF_SIZE__minBlockLength);
+	init(Id::bufsz_maxBlockLength, LV2_BUF_SIZE__maxBlockLength);
+	init(Id::bufsz_nominalBlockLength, LV2_BUF_SIZE__nominalBlockLength);
+	init(Id::bufsz_sequenceSize, LV2_BUF_SIZE__sequenceSize);
 	init(Id::midi_MidiEvent, LV2_MIDI__MidiEvent);
+	init(Id::param_sampleRate, LV2_PARAMETERS__sampleRate);
 
 	for(uint32_t urid : m_cache) { Q_ASSERT(urid != noIdYet); }
 }

--- a/src/core/lv2/Lv2UridCache.cpp
+++ b/src/core/lv2/Lv2UridCache.cpp
@@ -34,6 +34,11 @@
 
 #include "Lv2UridMap.h"
 
+// support newer URIs on old systems
+#ifndef LV2_BUF_SIZE__nominalBlockLength
+#define LV2_BUF_SIZE__nominalBlockLength LV2_BUF_SIZE_PREFIX "nominalBlockLength"
+#endif
+
 uint32_t Lv2UridCache::operator[](Lv2UridCache::Id id) const
 {
 	Q_ASSERT(id != Id::size);


### PR DESCRIPTION
This includes buf-size properties. Basically this just gives sample rate and block size to the plugin (the former is currently not useful, but also not harming, see the code comments why).

Reviewer hints:

1. ~~Let's wait for CI before review.~~
2. The code currently assumes that the LMMS buffersize never changes, which is currently true in the LMMS code base. We could make this variable const, but it would make the initialization code of this variable a bit ugly to read. Or we could just comment this variable with `// if you change this variable, you'll have to change Lv2 code`. Any ideas?
3. I did not add any `LMMS_EXPORT` to the new `Lv2Options` class. The CI ran through, so I guess it's OK. 

Tester hints:

1. Wait with final testing until review is done
2. New plugins that could be worth testing see below.
3. Check our [Lv2 wiki page](https://github.com/LMMS/lmms/wiki/Lv2) for installation of Lv2 and of the plugins.
4. One thing to check is using a different buffersize in the LMMS options (and restarting LMMS). Do the plugins still sound the same? 



New plugins (a few of them could be picked for testing):
```
3 Band EQ
Bitrot Crush
Bitrot Repeat
Bitrot Reverser
Bitrot Tapestop
Cycle Shifter
Dragonfly
Early Reflections
Kars
MVerb
MaBitcrush
MaFreeverb
MaGigaverb
MaPitchshift
Nekobi
Ping Pong Pan
ProM
Soul Force
Wolf Spectrum
ZaMaximX2
ZaMultiCompX2
ZamAutoSat
ZamComp
ZamDelay
ZamDynamicEQ
ZamEQ2
ZamGEQ31
ZamGate
ZamGrains
ZamPhono
ZamTube
glBars
```