### PR TITLE
Blacklist SWH GLAME filters for Lv2

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -88,6 +88,8 @@ public:
 		return s_projectJournal;
 	}
 
+	static bool ignorePluginBlacklist();
+
 #ifdef LMMS_HAVE_LV2
 	static class Lv2Manager * getLv2Manager()
 	{

--- a/include/Lv2Manager.h
+++ b/include/Lv2Manager.h
@@ -131,6 +131,11 @@ public:
 	}
 	bool isFeatureSupported(const char* featName) const;
 
+	static const std::set<const char*, Lv2Manager::CmpStr>& getPluginBlacklist()
+	{
+		return pluginBlacklist;
+	}
+
 private:
 	// general data
 	bool m_debug; //!< if set, debug output will be printed
@@ -143,6 +148,9 @@ private:
 
 	// URID cache for fast URID access
 	Lv2UridCache m_uridCache;
+
+	// static
+	static const std::set<const char*, Lv2Manager::CmpStr> pluginBlacklist;
 
 	// functions
 	bool isSubclassOf(const LilvPluginClass *clvss, const char *uriStr);

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -44,6 +44,7 @@ enum PluginIssueType
 	portHasNoMax,
 	featureNotSupported, //!< plugin requires functionality LMMS can't offer
 	badPortType, //!< port type not supported
+	blacklisted,
 	noIssue
 };
 
@@ -60,6 +61,7 @@ public:
 		: m_issueType(it), m_info(msg)
 	{
 	}
+	PluginIssueType type() const { return m_issueType; }
 	friend QDebug operator<<(QDebug stream, const PluginIssue& iss);
 };
 

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -116,6 +116,18 @@ void LmmsCore::destroy()
 	delete ConfigManager::inst();
 }
 
+
+
+
+bool LmmsCore::ignorePluginBlacklist()
+{
+	const char* envVar = getenv("LMMS_IGNORE_BLACKLIST");
+	return (envVar && *envVar);
+}
+
+
+
+
 float LmmsCore::framesPerTick(sample_rate_t sampleRate)
 {
 	return sampleRate * 60.0f * 4 /

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -54,6 +54,8 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 			return "required feature not supported";
 		case badPortType:
 			return "unsupported port type";
+		case blacklisted:
+			return "blacklisted plugin";
 		case noIssue:
 			return nullptr;
 	}

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -48,6 +48,9 @@
 
 const std::set<const char*, Lv2Manager::CmpStr> Lv2Manager::pluginBlacklist =
 {
+	// github.com/calf-studio-gear/calf, #278
+	"http://calf.sourceforge.net/plugins/Analyzer",
+	"http://calf.sourceforge.net/plugins/BassEnhancer"
 };
 
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -26,6 +26,7 @@
 
 #ifdef LMMS_HAVE_LV2
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstring>
 #include <lilv/lilv.h>
@@ -36,10 +37,18 @@
 #include <QElapsedTimer>
 
 #include "ConfigManager.h"
+#include "Engine.h"
 #include "Plugin.h"
 #include "PluginFactory.h"
 #include "Lv2ControlBase.h"
 #include "PluginIssue.h"
+
+
+
+
+const std::set<const char*, Lv2Manager::CmpStr> Lv2Manager::pluginBlacklist =
+{
+};
 
 
 
@@ -100,6 +109,7 @@ void Lv2Manager::initPlugins()
 	QElapsedTimer timer;
 	timer.start();
 
+	unsigned blacklisted = 0;
 	LILV_FOREACH(plugins, itr, plugins)
 	{
 		const LilvPlugin* curPlug = lilv_plugins_get(plugins, itr);
@@ -111,6 +121,15 @@ void Lv2Manager::initPlugins()
 		m_lv2InfoMap[lilv_node_as_uri(lilv_plugin_get_uri(curPlug))]
 			= std::move(info);
 		if(issues.empty()) { ++pluginsLoaded; }
+		else
+		{
+			if(std::any_of(issues.begin(), issues.end(),
+				[](const PluginIssue& iss) {
+				return iss.type() == PluginIssueType::blacklisted; }))
+			{
+				++blacklisted;
+			}
+		}
 		++pluginCount;
 	}
 
@@ -132,6 +151,22 @@ void Lv2Manager::initPlugins()
 				"For details about not loaded plugins, please set\n"
 				"  environment variable \"LMMS_LV2_DEBUG\" to nonempty.";
 		}
+	}
+
+	// TODO: might be better in the LMMS core
+	if(Engine::ignorePluginBlacklist())
+	{
+		qWarning() <<
+			"WARNING! Plugin blacklist disabled! If you want to use the blacklist,\n"
+			"  please set environment variable \"LMMS_IGNORE_BLACKLIST\" to empty or\n"
+			"  do not set it.";
+	}
+	else if(blacklisted > 0)
+	{
+		qDebug() <<
+			"Lv2 Plugins blacklisted:" << blacklisted << "of" << pluginCount << "\n"
+			"  If you want to ignore the blacklist (dangerous!), please set\n"
+			"  environment variable \"LMMS_IGNORE_BLACKLIST\" to nonempty.";
 	}
 }
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -65,6 +65,19 @@ Plugin::PluginTypes Lv2Proc::check(const LilvPlugin *plugin,
 	unsigned audioChannels[maxCount] = { 0, 0 }; // audio input and output count
 	unsigned midiChannels[maxCount] = { 0, 0 }; // MIDI input and output count
 
+	const char* pluginUri = lilv_node_as_uri(lilv_plugin_get_uri(plugin));
+	//qDebug() << "Checking plugin" << pluginUri << "...";
+
+	// TODO: manage a global blacklist outside of the code
+	//       for now, this will help
+	//       this is only a fix for the meantime
+	const auto& pluginBlacklist = Lv2Manager::getPluginBlacklist();
+	if (!Engine::ignorePluginBlacklist() &&
+		pluginBlacklist.find(pluginUri) != pluginBlacklist.end())
+	{
+		issues.emplace_back(blacklisted);
+	}
+
 	for (unsigned portNum = 0; portNum < maxPorts; ++portNum)
 	{
 		Lv2Ports::Meta meta;


### PR DESCRIPTION
Hotfix for #5767. Implement a blacklist and add the SWH GLAME Lv2 filters to it.

This is just temporary, but I think it's important to take those filters out before more users hear that noise.

Reviewer hints:
1. The implementation may not be 100% perfect:
  a. it should be in the core, not restricted to Lv2
  b. a blacklist should be more general, as suggested in #5771 
2. ~~Wait for CI before review~~

Tester hints:
1. This PR does not require testing IMO, I tested the few bits myself. However, if you really want to test anything: Make sure you use "dummy audio output" in the LMMS settings and have restarted before. The audio produced by those effects is horrible.