### PR TITLE
Fix duplicate message in de.ts

### DIFF
--- a/data/locale/de.ts
+++ b/data/locale/de.ts
@@ -4137,10 +4137,6 @@ Bitte besuchen Sie http://lmms.sf.net/wiki für Dokumentationen über LMMS.</tra
 Please make sure you have write permission to the file and the directory containing the file and try again!</source>
         <translation type="unfinished"/>
     </message>
-    <message>
-        <source>Export &amp;MIDI...</source>
-        <translation type="unfinished"/>
-    </message>
 </context>
 <context>
     <name>MeterDialog</name>

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -349,6 +349,7 @@ public:
 					NotePlayHandle::Origin origin = NotePlayHandle::OriginPattern );
 	static void release( NotePlayHandle * nph );
 	static void extend( int i );
+	static void free();
 
 private:
 	static NotePlayHandle ** s_available;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -623,3 +623,8 @@ void NotePlayHandleManager::extend( int c )
 		++n;
 	}
 }
+
+void NotePlayHandleManager::free()
+{
+	MM_FREE(s_available);
+}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1009,5 +1009,8 @@ int main( int argc, char * * argv )
 	}
 #endif
 
+
+	NotePlayHandleManager::free();
+
 	return ret;
 }


### PR DESCRIPTION
Fixes a duplicate translation message in the German translation file. This addresses the (warranted but vague) error passed by Qt Creator.

![ts_error](https://user-images.githubusercontent.com/47124830/98536721-7a027000-2245-11eb-80a2-a3db4bfdc028.png)

The removed message is an unfinished translation while the message it is a duplicate of (on line 3984) is a finished translation.