### PR TITLE
Address the memory leak that the rpmalloc assert warns of on program exit

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -349,6 +349,7 @@ public:
 					NotePlayHandle::Origin origin = NotePlayHandle::OriginPattern );
 	static void release( NotePlayHandle * nph );
 	static void extend( int i );
+	static void free();
 
 private:
 	static NotePlayHandle ** s_available;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -623,3 +623,8 @@ void NotePlayHandleManager::extend( int c )
 		++n;
 	}
 }
+
+void NotePlayHandleManager::free()
+{
+	MM_FREE(s_available);
+}

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -1009,5 +1009,8 @@ int main( int argc, char * * argv )
 	}
 #endif
 
+
+	NotePlayHandleManager::free();
+
 	return ret;
 }


### PR DESCRIPTION
Hack to take care of the error dialogue sent by the rpmalloc memory manager (#5733 ). Creates a static "```free```" function for ```NotePlayHandleManager``` and then shoves it right before the program ends in ```main.cpp```.

![image](https://user-images.githubusercontent.com/47124830/98650411-15ebb480-22f6-11eb-9ee7-20ae2cc47beb.png) (The error dialogue)
