### PR TITLE
Fix for the font of truncated sidebar items (#5714).

### DIFF
--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -28,6 +28,7 @@
 #include <QtCore/QObject>
 
 #include "lmms_export.h"
+#include "lmmsconfig.h"
 
 class QLabel;
 
@@ -48,6 +49,9 @@ public:
 	~GuiApplication();
 
 	static GuiApplication* instance();
+#ifdef LMMS_BUILD_WIN32
+	static QFont getWin32SystemFont();
+#endif
 
 	MainWindow* mainWindow() { return m_mainWindow; }
 	FxMixerView* fxMixerView() { return m_fxMixerView; }

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -55,8 +55,6 @@
 #include "StringPairDrag.h"
 #include "TextFloat.h"
 
-
-
 enum TreeWidgetItemTypes
 {
 	TypeFileItem = QTreeWidgetItem::UserType,
@@ -335,6 +333,11 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 	connect( this, SIGNAL( itemExpanded( QTreeWidgetItem * ) ),
 				SLOT( updateDirectory( QTreeWidgetItem * ) ) );
 
+#ifdef LMMS_BUILD_WIN32
+	// Set the font for the QTreeWidget to the Windows System font to make sure that
+	// truncated (elided) items use the same font as non-truncated items.
+	setFont( GuiApplication::getWin32SystemFont() );
+#endif
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -333,7 +333,7 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 	connect( this, SIGNAL( itemExpanded( QTreeWidgetItem * ) ),
 				SLOT( updateDirectory( QTreeWidgetItem * ) ) );
 
-#ifdef LMMS_BUILD_WIN32
+#if QT_VERSION < QT_VERSION_CHECK(5, 12, 2) && defined LMMS_BUILD_WIN32
 	// Set the font for the QTreeWidget to the Windows System font to make sure that
 	// truncated (elided) items use the same font as non-truncated items.
 	// This is a workaround for this qt bug, fixed in 5.12.2: https://bugreports.qt.io/browse/QTBUG-29232

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -336,6 +336,8 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 #ifdef LMMS_BUILD_WIN32
 	// Set the font for the QTreeWidget to the Windows System font to make sure that
 	// truncated (elided) items use the same font as non-truncated items.
+	// This is a workaround for this qt bug, fixed in 5.12.2: https://bugreports.qt.io/browse/QTBUG-29232
+	// TODO: remove this when all builds use a recent enough version of qt.
 	setFont( GuiApplication::getWin32SystemFont() );
 #endif
 }

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -45,6 +45,10 @@
 #include <QMessageBox>
 #include <QSplashScreen>
 
+#ifdef LMMS_BUILD_WIN32
+#include <windows.h>
+#endif
+
 GuiApplication* GuiApplication::s_instance = nullptr;
 
 GuiApplication* GuiApplication::instance()
@@ -211,3 +215,24 @@ void GuiApplication::childDestroyed(QObject *obj)
 		m_controllerRackView = nullptr;
 	}
 }
+
+#ifdef LMMS_BUILD_WIN32
+/*!
+ * @brief Returns the Windows System font.
+ */
+QFont GuiApplication::getWin32SystemFont()
+{
+	NONCLIENTMETRICS metrics = { sizeof( NONCLIENTMETRICS ) };
+	SystemParametersInfo( SPI_GETNONCLIENTMETRICS, sizeof( NONCLIENTMETRICS ), &metrics, 0 );
+	int pointSize = metrics.lfMessageFont.lfHeight;
+	if ( pointSize < 0 )
+	{
+		// height is in pixels, convert to points
+		HDC hDC = GetDC( NULL );
+		pointSize = MulDiv( abs( pointSize ), 72, GetDeviceCaps( hDC, LOGPIXELSY ) );
+		ReleaseDC( NULL, hDC );
+	}
+
+	return QFont( QString::fromUtf8( metrics.lfMessageFont.lfFaceName ), pointSize );
+}
+#endif


### PR DESCRIPTION
For windows platforms, retrieve the system font and set it for the FileBrowserTreeWidget. This makes sure that truncated items will use the font as non-truncated items.
