### PR TITLE
Add option to continue sidebar previews when mouse released

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -75,6 +75,7 @@ private slots:
 	void toggleCompactTrackButtons(bool enabled);
 	void toggleOneInstrumentTrackWindow(bool enabled);
 	void toggleSideBarOnRight(bool enabled);
+	void toggleLetPreviewsFinish(bool enabled);
 	void toggleSoloLegacyBehavior(bool enabled);
 	void toggleMMPZ(bool enabled);
 	void toggleDisableBackup(bool enabled);
@@ -133,6 +134,7 @@ private:
 	bool m_compactTrackButtons;
 	bool m_oneInstrumentTrackWindow;
 	bool m_sideBarOnRight;
+	bool m_letPreviewsFinish;
 	bool m_soloLegacyBehavior;
 	bool m_MMPZ;
 	bool m_disableBackup;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -686,12 +686,17 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 {
 	m_mousePressed = false;
-	// Depending on the user's configuration, we may not want to stop previews
-	bool cont = ConfigManager::inst()->value("ui", "letpreviewsfinish").toInt();
-	if (cont) { return; }
 
+	// If a preview is running, we may need to stop it. Otherwise, we're done
 	QMutexLocker previewLocker(&m_pphMutex);
-	if (m_previewPlayHandle != nullptr) { stopPreview(); }
+	if (m_previewPlayHandle == nullptr) { return; }
+
+	// Only sample previews may continue after mouse up. Is this a sample preview?
+	bool isSample = m_previewPlayHandle->type() == PlayHandle::TypeSamplePlayHandle;
+	// Even sample previews should only continue if the user wants them to. Do they?
+	bool shouldContinue = ConfigManager::inst()->value("ui", "letpreviewsfinish").toInt();
+	// If both are true the preview may continue, otherwise we stop it
+	if (!(isSample && shouldContinue)) { stopPreview(); }
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -686,10 +686,11 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 void FileBrowserTreeWidget::mouseReleaseEvent(QMouseEvent * me )
 {
 	m_mousePressed = false;
+	// Depending on the user's configuration, we may not want to stop previews
+	bool cont = ConfigManager::inst()->value("ui", "letpreviewsfinish").toInt();
+	if (cont) { return; }
 
 	QMutexLocker previewLocker(&m_pphMutex);
-
-	//TODO: User setting to allow samples to play until completion instead
 	if (m_previewPlayHandle != nullptr) { stopPreview(); }
 }
 

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -104,6 +104,8 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 			"ui", "oneinstrumenttrackwindow").toInt()),
 	m_sideBarOnRight(ConfigManager::inst()->value(
 			"ui", "sidebaronright").toInt()),
+	m_letPreviewsFinish(ConfigManager::inst()->value(
+			"ui", "letpreviewsfinish").toInt()),
 	m_soloLegacyBehavior(ConfigManager::inst()->value(
 			"app", "sololegacybehavior", "0").toInt()),
 	m_MMPZ(!ConfigManager::inst()->value(
@@ -237,6 +239,8 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		m_oneInstrumentTrackWindow, SLOT(toggleOneInstrumentTrackWindow(bool)), true);
 	addLedCheckBox(tr("Show sidebar on the right-hand side"), gui_tw, counter,
 		m_sideBarOnRight, SLOT(toggleSideBarOnRight(bool)), true);
+	addLedCheckBox(tr("Let sample previews continue when mouse is released"), gui_tw, counter,
+		m_letPreviewsFinish, SLOT(toggleLetPreviewsFinish(bool)), false);
 	addLedCheckBox(tr("Mute automation tracks during solo"), gui_tw, counter,
 		m_soloLegacyBehavior, SLOT(toggleSoloLegacyBehavior(bool)), false);
 
@@ -466,7 +470,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	as_w_layout->setMargin(0);
 
 #ifdef LMMS_HAVE_JACK
-	m_audioIfaceSetupWidgets[AudioJack::name()] = 
+	m_audioIfaceSetupWidgets[AudioJack::name()] =
 			new AudioJack::setupWidget(as_w);
 #endif
 
@@ -911,6 +915,8 @@ void SetupDialog::accept()
 					QString::number(m_oneInstrumentTrackWindow));
 	ConfigManager::inst()->setValue("ui", "sidebaronright",
 					QString::number(m_sideBarOnRight));
+	ConfigManager::inst()->setValue("ui", "letpreviewsfinish",
+					QString::number(m_letPreviewsFinish));
 	ConfigManager::inst()->setValue("app", "sololegacybehavior",
 					QString::number(m_soloLegacyBehavior));
 	ConfigManager::inst()->setValue("app", "nommpz",
@@ -1022,6 +1028,12 @@ void SetupDialog::toggleOneInstrumentTrackWindow(bool enabled)
 void SetupDialog::toggleSideBarOnRight(bool enabled)
 {
 	m_sideBarOnRight = enabled;
+}
+
+
+void SetupDialog::toggleLetPreviewsFinish(bool enabled)
+{
+	m_letPreviewsFinish = enabled;
 }
 
 


### PR DESCRIPTION
Adds a new option to the (incredibly crowded) General>UI section of our preferences that allows clicked samples in the sidebar to play to completion/interruption. With this setting enabled, sample previews will not stop on mouse release, but will still stop when:
- Another sidebar item gains focus (another preview starts, cursor moves to folder)
- The sidebar loses focus (another area is clicked on)
- The sample finishes playing

Thanks to changes in #5764 (stopping previews on focus loss, specifically), this should no longer cause the crash described in #5736. Please test this! Somewhat related: #5427

Milestoning for 1.3 since 1.2 had this option... ish.