### PR TITLE
Lv2: Use port-property "logarithmic"

### DIFF
--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -70,7 +70,7 @@ class LMMS_EXPORT Lv2ControlBase : public LinkedModelGroups
 {
 public:
 	static Plugin::PluginTypes check(const LilvPlugin* m_plugin,
-		std::vector<PluginIssue> &issues, bool printIssues = false);
+		std::vector<PluginIssue> &issues);
 
 	const LilvPlugin* getPlugin() const { return m_plugin; }
 

--- a/include/Lv2Ports.h
+++ b/include/Lv2Ports.h
@@ -108,6 +108,8 @@ struct Meta
 	Flow m_flow = Flow::Unknown;
 	Vis m_vis = Vis::None;
 
+	bool m_logarithmic = false;
+
 	bool m_optional = false;
 	bool m_used = true;
 

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -61,7 +61,7 @@ class Lv2Proc : public LinkedModelGroup
 {
 public:
 	static Plugin::PluginTypes check(const LilvPlugin* plugin,
-		std::vector<PluginIssue> &issues, bool printIssues = false);
+		std::vector<PluginIssue> &issues);
 
 	/*
 		ctor/dtor

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -63,6 +63,8 @@ public:
 	{
 	}
 	PluginIssueType type() const { return m_issueType; }
+	bool operator==(const PluginIssue& other) const;
+	bool operator<(const PluginIssue& other) const;
 	friend QDebug operator<<(QDebug stream, const PluginIssue& iss);
 };
 

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -32,18 +32,27 @@
 //! LMMS Plugins should use this to indicate errors
 enum PluginIssueType
 {
+	// port flow & type
 	unknownPortFlow,
 	unknownPortType,
+	// channel count
 	tooManyInputChannels,
 	tooManyOutputChannels,
 	tooManyMidiInputChannels,
 	tooManyMidiOutputChannels,
 	noOutputChannel,
+	// port metadata
 	portHasNoDef,
 	portHasNoMin,
 	portHasNoMax,
+	minGreaterMax,
 	defaultValueNotInRange,
+	logScaleMinMissing,
+	logScaleMaxMissing,
+	logScaleMinMaxDifferentSigns,
+	// features
 	featureNotSupported, //!< plugin requires functionality LMMS can't offer
+	// misc
 	badPortType, //!< port type not supported
 	blacklisted,
 	noIssue

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -67,6 +67,24 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 
 
 
+bool PluginIssue::operator==(const PluginIssue &other) const
+{
+	return (m_issueType == other.m_issueType) && (m_info == other.m_info);
+}
+
+
+
+
+bool PluginIssue::operator<(const PluginIssue &other) const
+{
+	return (m_issueType != other.m_issueType)
+			? m_issueType < other.m_issueType
+			: m_info < other.m_info;
+}
+
+
+
+
 QDebug operator<<(QDebug stream, const PluginIssue &iss)
 {
 	stream << PluginIssue::msgFor(iss.m_issueType);

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -50,8 +50,16 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 			return "port is missing min value";
 		case portHasNoMax:
 			return "port is missing max value";
+		case minGreaterMax:
+			return "port minimum is greater than maximum";
 		case defaultValueNotInRange:
 			return "default value is not in range [min, max]";
+		case logScaleMinMissing:
+			return "logscale requires minimum value";
+		case logScaleMaxMissing:
+			return "logscale requires maximum value";
+		case logScaleMinMaxDifferentSigns:
+			return "logscale with min < 0 < max";
 		case featureNotSupported:
 			return "required feature not supported";
 		case badPortType:

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -37,10 +37,10 @@
 
 
 Plugin::PluginTypes Lv2ControlBase::check(const LilvPlugin *plugin,
-	std::vector<PluginIssue> &issues, bool printIssues)
+	std::vector<PluginIssue> &issues)
 {
 	// for some reason, all checks can be done by one processor...
-	return Lv2Proc::check(plugin, issues, printIssues);
+	return Lv2Proc::check(plugin, issues);
 }
 
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -118,7 +118,20 @@ void Lv2Manager::initPlugins()
 		const LilvPlugin* curPlug = lilv_plugins_get(plugins, itr);
 
 		std::vector<PluginIssue> issues;
-		Plugin::PluginTypes type = Lv2ControlBase::check(curPlug, issues, m_debug);
+		Plugin::PluginTypes type = Lv2ControlBase::check(curPlug, issues);
+		std::sort(issues.begin(), issues.end());
+		auto last = std::unique(issues.begin(), issues.end());
+		issues.erase(last, issues.end());
+		if (m_debug && issues.size())
+		{
+			qDebug() << "Lv2 plugin"
+				<< qStringFromPluginNode(curPlug, lilv_plugin_get_name)
+				<< "(URI:"
+				<< lilv_node_as_uri(lilv_plugin_get_uri(curPlug))
+				<< ") can not be loaded:";
+			for (const PluginIssue& iss : issues) { qDebug() << "  - " << iss; }
+		}
+
 		Lv2Info info(curPlug, type, issues.empty());
 
 		m_lv2InfoMap[lilv_node_as_uri(lilv_plugin_get_uri(curPlug))]

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -58,7 +58,7 @@ struct MidiInputEvent
 
 
 Plugin::PluginTypes Lv2Proc::check(const LilvPlugin *plugin,
-	std::vector<PluginIssue>& issues, bool printIssues)
+	std::vector<PluginIssue>& issues)
 {
 	unsigned maxPorts = lilv_plugin_get_num_ports(plugin);
 	enum { inCount, outCount, maxCount };
@@ -126,16 +126,6 @@ Plugin::PluginTypes Lv2Proc::check(const LilvPlugin *plugin,
 		{
 			issues.emplace_back(featureNotSupported, reqFeatName);
 		}
-	}
-
-	if (printIssues && issues.size())
-	{
-		qDebug() << "Lv2 plugin"
-			<< qStringFromPluginNode(plugin, lilv_plugin_get_name)
-			<< "(URI:"
-			<< lilv_node_as_uri(lilv_plugin_get_uri(plugin))
-			<< ") can not be loaded:";
-		for (const PluginIssue& iss : issues) { qDebug() << "  - " << iss; }
 	}
 
 	return (audioChannels[inCount] > 2 || audioChannels[outCount] > 2)

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -520,7 +520,12 @@ void Lv2Proc::createPort(std::size_t portNum)
 											nullptr, dispName));
 						break;
 				}
-			}
+				if(meta.m_logarithmic)
+				{
+					ctrl->m_connectedModel->setScaleLogarithmic();
+				}
+
+			} // if m_flow == Input
 			port = ctrl;
 			break;
 		}


### PR DESCRIPTION
My last PR (before refactoring), I promise :smile: 

Minimal PR to enable logarithmic ports (e.g. for frequency in GLAME butterworth filters).

There will be more useful [port properties](http://lv2plug.in/ns/ext/port-props) to implement (causesArtifacts, nonAutomatic, trigger), but this one was very easy and is very useful.

~Code review voluntarily. Testing voluntarily. Will be merged in 5 days.~