### PR TITLE
Fix missing icon of Stereo Matrix plugin

### DIFF
--- a/plugins/stereo_matrix/CMakeLists.txt
+++ b/plugins/stereo_matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
 INCLUDE(BuildPlugin)
 
-BUILD_PLUGIN(stereomatrix stereo_matrix.cpp stereomatrix_controls.cpp stereomatrix_control_dialog.cpp stereo_matrix.h stereomatrix_controls.h stereomatrix_control_dialog.h MOCFILES stereomatrix_controls.h stereomatrix_control_dialog.h EMBEDDED_RESOURCES artwork.png)
+BUILD_PLUGIN(stereomatrix stereo_matrix.cpp stereomatrix_controls.cpp stereomatrix_control_dialog.cpp stereo_matrix.h stereomatrix_controls.h stereomatrix_control_dialog.h MOCFILES stereomatrix_controls.h stereomatrix_control_dialog.h EMBEDDED_RESOURCES artwork.png logo.png)
 


### PR DESCRIPTION
Most probably intruduced by 9f905bc, the default lmms logo was replaced by a garbage-coloured pixel on the Stereo Matrix effect. The problem was caused by the image not being in the relevant CMakeLists.txt file.