### PR TITLE
Fixes bug on SampleBuffer::decodeSampleSF

### DIFF
--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -417,7 +417,7 @@ f_cnt_t SampleBuffer::decodeSampleSF(QString _f,
 	SF_INFO sf_info;
 	sf_info.format = 0;
 	f_cnt_t frames = 0;
-	bool sf_rr = false;
+	sf_count_t sfFramesRead;
 
 
 	// Use QFile to handle unicode file names on Windows
@@ -428,9 +428,9 @@ f_cnt_t SampleBuffer::decodeSampleSF(QString _f,
 		frames = sf_info.frames;
 
 		_buf = new sample_t[sf_info.channels * frames];
-		sf_rr = sf_read_float( snd_file, _buf, sf_info.channels * frames );
+		sfFramesRead = sf_read_float(snd_file, _buf, sf_info.channels * frames);
 
-		if( sf_rr < sf_info.channels * frames )
+		if (sfFramesRead < sf_info.channels * frames)
 		{
 #ifdef DEBUG_LMMS
 			qDebug( "SampleBuffer::decodeSampleSF(): could not read"


### PR DESCRIPTION
As requested, this PR extracts the bug fix from #5791. More details about the bug on the mentioned PR page, but basically the
variable `sf_rr` was declared with the wrong type causing the conditional that checks for errors on the loading to return true even when there were no errors (only noticeable with DEBUG builds).

This renames the variable and uses the correct type.