### PR TITLE
Support multiple instrument subplugin categories

### DIFF
--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -33,7 +33,6 @@
 
 class QLineEdit;
 class QTreeWidget;
-class QTreeWidgetItem;
 
 
 class PluginBrowser : public SideBarWidget
@@ -53,8 +52,6 @@ private:
 
 	QWidget * m_view;
 	QTreeWidget * m_descTree;
-	QTreeWidgetItem * m_lmmsRoot;
-	QTreeWidgetItem * m_lv2Root;
 };
 
 


### PR DESCRIPTION
Currently, the instrument sidebar only supports two categories: LMMS and LV2. This pull request supports a category for any instrument exposing subplugins. This is primarily in preparation for VST3, but should also be useful for other formats in the future.