### PR TITLE
FifoBuffer adjustments

### DIFF
--- a/include/FifoBuffer.h
+++ b/include/FifoBuffer.h
@@ -27,9 +27,8 @@
 
 #include <QtCore/QSemaphore>
 
-#include "lmms_basics.h"
 
-
+template<typename T>
 class FifoBuffer
 {
 public:
@@ -50,7 +49,7 @@ public:
 		m_readSem.release(m_size);
 	}
 
-	void write(surroundSampleFrame * element)
+	void write(T element)
 	{
 		m_writeSem.acquire();
 		m_buffer[m_writeIndex++] = element;
@@ -58,10 +57,10 @@ public:
 		m_readSem.release();
 	}
 
-	surroundSampleFrame * read()
+	T read()
 	{
 		m_readSem.acquire();
-		surroundSampleFrame * element = m_buffer[m_readIndex++];
+		T element = m_buffer[m_readIndex++];
 		m_readIndex %= m_size;
 		m_writeSem.release();
 		return element;
@@ -85,7 +84,7 @@ private:
 	int m_readIndex;
 	int m_writeIndex;
 	int m_size;
-	surroundSampleFrame ** m_buffer;
+	T * m_buffer;
 } ;
 
 

--- a/include/FifoBuffer.h
+++ b/include/FifoBuffer.h
@@ -39,7 +39,7 @@ public:
 		m_writeIndex(0),
 		m_size(size)
 	{
-		m_buffer = new surroundSampleFrame*[size];
+		m_buffer = new T[size];
 		m_readSem.acquire(size);
 	}
 

--- a/include/FifoBuffer.h
+++ b/include/FifoBuffer.h
@@ -1,5 +1,5 @@
 /*
- * fifo_buffer.h - FIFO fixed-size buffer
+ * FifoBuffer.h - FIFO fixed-size buffer
  *
  * Copyright (c) 2007 Javier Serrano Polo <jasp00/at/users.sourceforge.net>
  *
@@ -27,68 +27,66 @@
 
 #include <QtCore/QSemaphore>
 
+#include "lmms_basics.h"
 
-template<typename T>
-class fifoBuffer
+
+class FifoBuffer
 {
 public:
-	fifoBuffer( int _size ) :
-		m_reader_sem( _size ),
-		m_writer_sem( _size ),
-		m_reader_index( 0 ),
-		m_writer_index( 0 ),
-		m_size( _size )
+	FifoBuffer(int size) :
+		m_readSem(size),
+		m_writeSem(size),
+		m_readIndex(0),
+		m_writeIndex(0),
+		m_size(size)
 	{
-		m_buffer = new T[_size];
-		m_reader_sem.acquire( _size );
+		m_buffer = new surroundSampleFrame*[size];
+		m_readSem.acquire(size);
 	}
 
-	~fifoBuffer()
+	~FifoBuffer()
 	{
 		delete[] m_buffer;
-		m_reader_sem.release( m_size );
+		m_readSem.release(m_size);
 	}
 
-	void write( T _element )
+	void write(surroundSampleFrame * element)
 	{
-		m_writer_sem.acquire();
-		m_buffer[m_writer_index++] = _element;
-		m_writer_index %= m_size;
-		m_reader_sem.release();
+		m_writeSem.acquire();
+		m_buffer[m_writeIndex++] = element;
+		m_writeIndex %= m_size;
+		m_readSem.release();
 	}
 
-	T read()
+	surroundSampleFrame * read()
 	{
-		m_reader_sem.acquire();
-		T element = m_buffer[m_reader_index++];
-		m_reader_index %= m_size;
-		m_writer_sem.release();
-		return( element );
+		m_readSem.acquire();
+		surroundSampleFrame * element = m_buffer[m_readIndex++];
+		m_readIndex %= m_size;
+		m_writeSem.release();
+		return element;
 	}
 
 	void waitUntilRead()
 	{
-		m_writer_sem.acquire( m_size );
-		m_writer_sem.release( m_size );
+		m_writeSem.acquire(m_size);
+		m_writeSem.release(m_size);
 	}
 
 	bool available()
 	{
-		return( m_reader_sem.available() );
+		return m_readSem.available();
 	}
 
 
 private:
-	QSemaphore m_reader_sem;
-	QSemaphore m_writer_sem;
-	int m_reader_index;
-	int m_writer_index;
+	QSemaphore m_readSem;
+	QSemaphore m_writeSem;
+	int m_readIndex;
+	int m_writeIndex;
 	int m_size;
-	T * m_buffer;
-
+	surroundSampleFrame ** m_buffer;
 } ;
-
-
 
 
 #endif

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -328,17 +328,19 @@ signals:
 
 
 private:
+	typedef FifoBuffer<surroundSampleFrame *> Fifo;
+
 	class fifoWriter : public QThread
 	{
 	public:
-		fifoWriter( Mixer * mixer, FifoBuffer * fifo );
+		fifoWriter( Mixer * mixer, Fifo * fifo );
 
 		void finish();
 
 
 	private:
 		Mixer * m_mixer;
-		FifoBuffer * m_fifo;
+		Fifo * m_fifo;
 		volatile bool m_writing;
 
 		void run() override;
@@ -414,7 +416,7 @@ private:
 	QString m_midiClientName;
 
 	// FIFO stuff
-	FifoBuffer * m_fifo;
+	Fifo * m_fifo;
 	fifoWriter * m_fifoWriter;
 
 	MixerProfiler m_profiler;

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -35,7 +35,7 @@
 #include "lmms_basics.h"
 #include "LocklessList.h"
 #include "Note.h"
-#include "fifo_buffer.h"
+#include "FifoBuffer.h"
 #include "MixerProfiler.h"
 
 
@@ -328,19 +328,17 @@ signals:
 
 
 private:
-	typedef fifoBuffer<surroundSampleFrame *> fifo;
-
 	class fifoWriter : public QThread
 	{
 	public:
-		fifoWriter(Mixer * mixer, fifo * _fifo);
+		fifoWriter( Mixer * mixer, FifoBuffer * fifo );
 
 		void finish();
 
 
 	private:
 		Mixer * m_mixer;
-		fifo * m_fifo;
+		FifoBuffer * m_fifo;
 		volatile bool m_writing;
 
 		void run() override;
@@ -416,7 +414,7 @@ private:
 	QString m_midiClientName;
 
 	// FIFO stuff
-	fifo * m_fifo;
+	FifoBuffer * m_fifo;
 	fifoWriter * m_fifoWriter;
 
 	MixerProfiler m_profiler;

--- a/include/Song.h
+++ b/include/Song.h
@@ -338,7 +338,7 @@ public:
 
 	void exportProjectMidi(QString const & exportFileName) const;
 
-	inline void setLoadOnLauch(bool value) { m_loadOnLaunch = value; }
+	inline void setLoadOnLaunch(bool value) { m_loadOnLaunch = value; }
 	SaveOptions &getSaveOptions() {
 		return m_saveOptions;
 	}

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -131,7 +131,7 @@ Mixer::Mixer( bool renderOnly ) :
 	}
 
 	// allocte the FIFO from the determined size
-	m_fifo = new fifo( fifoSize );
+	m_fifo = new FifoBuffer( fifoSize );
 
 	// now that framesPerPeriod is fixed initialize global BufferManager
 	BufferManager::init( m_framesPerPeriod );
@@ -1222,7 +1222,7 @@ MidiClient * Mixer::tryMidiClients()
 
 
 
-Mixer::fifoWriter::fifoWriter( Mixer* mixer, fifo * _fifo ) :
+Mixer::fifoWriter::fifoWriter( Mixer* mixer, FifoBuffer * _fifo ) :
 	m_mixer( mixer ),
 	m_fifo( _fifo ),
 	m_writing( true )

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -131,7 +131,7 @@ Mixer::Mixer( bool renderOnly ) :
 	}
 
 	// allocte the FIFO from the determined size
-	m_fifo = new FifoBuffer( fifoSize );
+	m_fifo = new Fifo( fifoSize );
 
 	// now that framesPerPeriod is fixed initialize global BufferManager
 	BufferManager::init( m_framesPerPeriod );
@@ -1222,9 +1222,9 @@ MidiClient * Mixer::tryMidiClients()
 
 
 
-Mixer::fifoWriter::fifoWriter( Mixer* mixer, FifoBuffer * _fifo ) :
+Mixer::fifoWriter::fifoWriter( Mixer* mixer, Fifo * fifo ) :
 	m_mixer( mixer ),
-	m_fifo( _fifo ),
+	m_fifo( fifo ),
 	m_writing( true )
 {
 	setObjectName("Mixer::fifoWriter");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1646,7 +1646,7 @@ void MainWindow::onImportProject()
 			ImportFilter::import( ofd.selectedFiles()[0], song );
 		}
 
-		song->setLoadOnLauch(false);
+		song->setLoadOnLaunch(false);
 	}
 }
 


### PR DESCRIPTION
The template in ``fifoBuffer`` is unnecessary because only one type is used (``surroundSampleFrame *``). The PR also fixes the coding conventions for that header file.

Additionally, it fixes the typoed method name ``Song::setLoadOnLauch()``.