### PR TITLE
Bitinvader - Fix saving with automation and division by 0

### DIFF
--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -44,6 +44,8 @@
 
 #include "plugin_export.h"
 
+#define WAVETABLE_SIZE 200
+
 extern "C"
 {
 
@@ -72,8 +74,8 @@ bSynth::bSynth( float * _shape, NotePlayHandle * _nph, bool _interpolation,
 	sample_rate( _sample_rate ),
 	interpolation( _interpolation)
 {
-	sample_shape = new float[200];
-	for (int i=0; i < 200; ++i)
+	sample_shape = new float[WAVETABLE_SIZE];
+	for (int i=0; i < WAVETABLE_SIZE; ++i)
 	{
 		sample_shape[i] = _shape[i] * _factor;
 	}
@@ -138,8 +140,8 @@ sample_t bSynth::nextStringSample( float sample_length )
 
 bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
 	Instrument( _instrument_track, &bitinvader_plugin_descriptor ),
-	m_sampleLength( 128, 4, 200, 1, this, tr( "Sample length" ) ),
-	m_graph( -1.0f, 1.0f, 200, this ),
+	m_sampleLength( 128, 4, WAVETABLE_SIZE, 1, this, tr( "Sample length" ) ),
+	m_graph( -1.0f, 1.0f, WAVETABLE_SIZE, this ),
 	m_interpolation( false, this ),
 	m_normalize( false, this )
 {

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -197,10 +197,7 @@ void bitInvader::saveSettings( QDomDocument & _doc, QDomElement & _this )
 void bitInvader::loadSettings( const QDomElement & _this )
 {
 	// Clear wavetable before loading a new
-	for (int i = 0; i < WAVETABLE_SIZE; i++)
-	{
-		m_graph.setSampleAt(i, 0.f);
-	}
+	m_graph.clear();
 
 	// Load sample length
 	m_sampleLength.loadSettings( _this, "sampleLength" );

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -44,7 +44,7 @@
 
 #include "plugin_export.h"
 
-#define WAVETABLE_SIZE 200
+static const size_t wavetableSize = 200;
 
 extern "C"
 {
@@ -74,8 +74,8 @@ bSynth::bSynth( float * _shape, NotePlayHandle * _nph, bool _interpolation,
 	sample_rate( _sample_rate ),
 	interpolation( _interpolation)
 {
-	sample_shape = new float[WAVETABLE_SIZE];
-	for (int i=0; i < WAVETABLE_SIZE; ++i)
+	sample_shape = new float[wavetableSize];
+	for (int i=0; i < wavetableSize; ++i)
 	{
 		sample_shape[i] = _shape[i] * _factor;
 	}
@@ -140,8 +140,8 @@ sample_t bSynth::nextStringSample( float sample_length )
 
 bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
 	Instrument( _instrument_track, &bitinvader_plugin_descriptor ),
-	m_sampleLength(128, 4, WAVETABLE_SIZE, 1, this, tr("Sample length")),
-	m_graph(-1.0f, 1.0f, WAVETABLE_SIZE, this),
+	m_sampleLength(128, 4, wavetableSize, 1, this, tr("Sample length")),
+	m_graph(-1.0f, 1.0f, wavetableSize, this),
 	m_interpolation( false, this ),
 	m_normalize( false, this )
 {
@@ -180,7 +180,7 @@ void bitInvader::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	// Save sample shape base64-encoded
 	QString sampleString;
 	base64::encode((const char *)m_graph.samples(),
-		WAVETABLE_SIZE * sizeof(float), sampleString);
+		wavetableSize * sizeof(float), sampleString);
 	_this.setAttribute( "sampleShape", sampleString );
 	
 
@@ -245,7 +245,7 @@ void bitInvader::samplesChanged( int _begin, int _end )
 void bitInvader::normalize()
 {
 	// analyze
-	float max = 0.0001f;
+	float max = std::numeric_limits<float>::epsilon();
 	const float* samples = m_graph.samples();
 	for(int i=0; i < m_graph.length(); i++)
 	{

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -209,8 +209,9 @@ void bitInvader::loadSettings( const QDomElement & _this )
 	char * dst = 0;
 	base64::decode( _this.attribute( "sampleShape"), &dst, &size );
 
-	m_graph.setLength( sampleLength );
-	m_graph.setSamples( (float*) dst );
+	m_graph.setLength(size / sizeof(float));
+	m_graph.setSamples(reinterpret_cast<float*>(dst));
+	m_graph.setLength(sampleLength);
 	delete[] dst;
 
 	// Load LED normalize 

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -140,12 +140,12 @@ sample_t bSynth::nextStringSample( float sample_length )
 
 bitInvader::bitInvader( InstrumentTrack * _instrument_track ) :
 	Instrument( _instrument_track, &bitinvader_plugin_descriptor ),
-	m_sampleLength( 128, 4, WAVETABLE_SIZE, 1, this, tr( "Sample length" ) ),
-	m_graph( -1.0f, 1.0f, WAVETABLE_SIZE, this ),
+	m_sampleLength(128, 4, WAVETABLE_SIZE, 1, this, tr("Sample length")),
+	m_graph(-1.0f, 1.0f, WAVETABLE_SIZE, this),
 	m_interpolation( false, this ),
 	m_normalize( false, this )
 {
-		
+
 	lengthChanged();
 
 	m_graph.setWaveToSine();
@@ -179,8 +179,8 @@ void bitInvader::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 	// Save sample shape base64-encoded
 	QString sampleString;
-	base64::encode( (const char *)m_graph.samples(),
-		WAVETABLE_SIZE * sizeof(float), sampleString );
+	base64::encode((const char *)m_graph.samples(),
+		WAVETABLE_SIZE * sizeof(float), sampleString);
 	_this.setAttribute( "sampleShape", sampleString );
 	
 
@@ -196,6 +196,12 @@ void bitInvader::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 void bitInvader::loadSettings( const QDomElement & _this )
 {
+	// Clear wavetable before loading a new
+	for (int i = 0; i < WAVETABLE_SIZE; i++)
+	{
+		m_graph.setSampleAt(i, 0.f);
+	}
+
 	// Load sample length
 	m_sampleLength.loadSettings( _this, "sampleLength" );
 

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -240,7 +240,7 @@ void bitInvader::samplesChanged( int _begin, int _end )
 void bitInvader::normalize()
 {
 	// analyze
-	float max = 0;
+	float max = 0.0001f;
 	const float* samples = m_graph.samples();
 	for(int i=0; i < m_graph.length(); i++)
 	{

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -44,7 +44,7 @@
 
 #include "plugin_export.h"
 
-static const size_t wavetableSize = 200;
+static const int wavetableSize = 200;
 
 extern "C"
 {

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -180,7 +180,7 @@ void bitInvader::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	// Save sample shape base64-encoded
 	QString sampleString;
 	base64::encode( (const char *)m_graph.samples(),
-		m_graph.length() * sizeof(float), sampleString );
+		WAVETABLE_SIZE * sizeof(float), sampleString );
 	_this.setAttribute( "sampleShape", sampleString );
 	
 


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/5799 and division by 0 detected with fpe debug flags.

Save and Load complete wavetable or you will face issues when the project is automating the Length knob. Hard coded wavetable length is defined in bit_invader.cpp. Maybe it should be in bit_invader.h but this looks fine and other plugins did it similarly.

The normalize function may divide with zero so we solve this the same way as the normalize function in Graph.cpp by starting off with a small value for `max`. 

#### Testing
Use the steps to reproduce the issue from https://github.com/LMMS/lmms/issues/5799 and especially try saving the project with `Ctrl+s` while the Length knob is at it's smallest setting when it's being controlled with an LFO.
 * Add a Bit Invader and an LFO Controller.
 * Connect the `Length` knob to the controller.
 * Save and Reload multiple times and watch the graph of the Bit Invader get more and more destroyed in steps.