### PR TITLE
Lv2: Fix overflow and enum visualization

### DIFF
--- a/include/Lv2Ports.h
+++ b/include/Lv2Ports.h
@@ -61,10 +61,10 @@ enum class Type {
 //! Port visualization
 //! @note All Lv2 audio ports are float, this is only the visualisation
 enum class Vis {
-	None,
-	Integer,
-	Enumeration,
-	Toggled
+	Generic, //!< nothing specific, a generic knob or slider shall be used
+	Integer, //!< counter
+	Enumeration, //!< selection from enumerated values
+	Toggled //!< boolean widget
 };
 
 const char* toStr(Lv2Ports::Flow pf);
@@ -106,7 +106,7 @@ struct Meta
 {
 	Type m_type = Type::Unknown;
 	Flow m_flow = Flow::Unknown;
-	Vis m_vis = Vis::None;
+	Vis m_vis = Vis::Generic;
 
 	bool m_logarithmic = false;
 

--- a/src/core/lv2/Lv2Ports.cpp
+++ b/src/core/lv2/Lv2Ports.cpp
@@ -77,7 +77,7 @@ const char *toStr(Vis pv)
 		case Vis::Toggled: return "toggled";
 		case Vis::Enumeration: return "enumeration";
 		case Vis::Integer: return "integer";
-		case Vis::None: return "none";
+		case Vis::Generic: return "none";
 	}
 	return "";
 }
@@ -118,7 +118,7 @@ std::vector<PluginIssue> Meta::get(const LilvPlugin *plugin,
 		? Vis::Enumeration
 		: hasProperty(LV2_CORE__toggled)
 		? Vis::Toggled
-		: Vis::None;
+		: Vis::Generic;
 
 	if (isA(LV2_CORE__InputPort)) { m_flow = Flow::Input; }
 	else if (isA(LV2_CORE__OutputPort)) { m_flow = Flow::Output; }
@@ -218,11 +218,14 @@ std::vector<PluginIssue> Meta::get(const LilvPlugin *plugin,
 			}
 
 			// visualization
-			if (m_max - m_min > 15.0f)
+			if (!m_min_set() ||
+				!m_max_set() ||
+				// if we get here, min and max are set, so max-min should not overflow:
+				(m_vis == Vis::Integer && m_max - m_min > 15.0f))
 			{
 				// range too large for spinbox visualisation, use knobs
 				// e.g. 0...15 would be OK
-				m_vis = Vis::None;
+				m_vis = Vis::Generic;
 			}
 		}
 	}

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -471,7 +471,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 				}
 				switch (meta.m_vis)
 				{
-					case Lv2Ports::Vis::None:
+					case Lv2Ports::Vis::Generic:
 					{
 						// allow ~1000 steps
 						float stepSize = (meta.max(sr) - meta.min(sr)) / 1000.0f;

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -67,7 +67,7 @@ Lv2ViewProc::Lv2ViewProc(QWidget* parent, Lv2Proc* ctrlBase, int colNum) :
 
 				switch (port.m_vis)
 				{
-					case PortVis::None:
+					case PortVis::Generic:
 						m_control = new KnobControl(m_par);
 						break;
 					case PortVis::Integer:


### PR DESCRIPTION
Unfortunately, the developer who wrote #5788 forgot the testing phase for their PR :-1: . This fix does (citing the commit log):

* Fix arithmetic overflow in `Lv2Ports::Meta::get()` in case min and
  max are not set
* Fix combo boxes with >16 values being wrongly visualized as knobs
* Rename `Lv2Ports::Vis` enum value `None` to `Generic`

**First: Let's wait for CI.**
Code review: optional.
Testing: Please test the #5788 PR here again, with the instructions from there. Please also check that the arithmetic overflow is gone.