### PR TITLE
Fix export when rendering looped section multiple times

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -295,7 +295,7 @@ void Song::processNextBuffer()
 			}
 
 			// Handle loop points, and inform VST plugins of the loop status
-			if (loopEnabled || m_loopRenderRemaining > 1)
+			if (loopEnabled || (m_loopRenderRemaining > 1 && getPlayPos() >= timeline->loopBegin()))
 			{
 				m_vstSyncController.startCycle(
 					timeline->loopBegin().getTicks(), timeline->loopEnd().getTicks());


### PR DESCRIPTION
Apparently I don't understand how the "export looped section n times" feature is meant to work. Fortunately PhysSong does.

Applies PhysSong's fix from https://github.com/LMMS/lmms/pull/5723#discussion_r532386623. See https://github.com/LMMS/lmms/pull/5723#discussion_r532386747 for details.

Thanks to `@Rdrpenguin#0256` on Discord for reporting this bug.