### PR TITLE
rpmalloc - no asserts with fpe debug

### DIFF
--- a/src/3rdparty/rpmalloc/CMakeLists.txt
+++ b/src/3rdparty/rpmalloc/CMakeLists.txt
@@ -35,14 +35,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	else ()
 		set(ENABLE_VALIDATE_ARGS ON)
 	endif()
-	# The rpmalloc asserts are too noisy when debugging with option WANT_DEBUG_FPE.
-	if(WANT_DEBUG_FPE)
-		set(ENABLE_ASSERTS 0)
-	else()
-		set(ENABLE_ASSERTS 1)
-	endif()
 	target_compile_definitions(rpmalloc
-		PRIVATE -DENABLE_ASSERTS=${ENABLE_ASSERTS} -DENABLE_VALIDATE_ARGS=${ENABLE_VALIDATE_ARGS}
+		PRIVATE -DENABLE_ASSERTS=0 -DENABLE_VALIDATE_ARGS=${ENABLE_VALIDATE_ARGS}
 	)
 endif()
 

--- a/src/3rdparty/rpmalloc/CMakeLists.txt
+++ b/src/3rdparty/rpmalloc/CMakeLists.txt
@@ -35,8 +35,14 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	else ()
 		set(ENABLE_VALIDATE_ARGS ON)
 	endif()
+	# The rpmalloc asserts are too noisy when debugging with option WANT_DEBUG_FPE.
+	if(WANT_DEBUG_FPE)
+		SET(ENABLE_ASSERTS 0)
+	else()
+		set(ENABLE_ASSERTS 1)
+	endif()
 	target_compile_definitions(rpmalloc
-		PRIVATE -DENABLE_ASSERTS=1 -DENABLE_VALIDATE_ARGS=${ENABLE_VALIDATE_ARGS}
+		PRIVATE -DENABLE_ASSERTS=${ENABLE_ASSERTS} -DENABLE_VALIDATE_ARGS=${ENABLE_VALIDATE_ARGS}
 	)
 endif()
 

--- a/src/3rdparty/rpmalloc/CMakeLists.txt
+++ b/src/3rdparty/rpmalloc/CMakeLists.txt
@@ -37,7 +37,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 	endif()
 	# The rpmalloc asserts are too noisy when debugging with option WANT_DEBUG_FPE.
 	if(WANT_DEBUG_FPE)
-		SET(ENABLE_ASSERTS 0)
+		set(ENABLE_ASSERTS 0)
 	else()
 		set(ENABLE_ASSERTS 1)
 	endif()

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -251,10 +251,11 @@ int main( int argc, char * * argv )
 {
 #ifdef LMMS_DEBUG_FPE
 	// Enable exceptions for certain floating point results
+	// Commenting out FE_UNDERFLOW for now as it generates too much noise.
 	feenableexcept( FE_INVALID   |
 			FE_DIVBYZERO |
-			FE_OVERFLOW  |
-			FE_UNDERFLOW);
+			FE_OVERFLOW  /*|
+			FE_UNDERFLOW*/);
 
 	// Install the trap handler
 	// register signal SIGFPE and signal handler


### PR DESCRIPTION
The rpmalloc asserts are too noisy when using the floating point
exception debugging flags. Turning them off with fpe but they are
still on with normal debug builds.

Edit: You can't test this PR with the demo builds as it only concerns debug builds.