### PR TITLE
Change abs to std::abs

### DIFF
--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -168,7 +168,7 @@ void VectorView::paintEvent(QPaintEvent *event)
 				// To better preserve shapes, the log scale is applied to the distance from origin,
 				// not the individual channels.
 				const float distance = sqrt(inLeft * inLeft + inRight * inRight);
-				const float distanceLog = log10(1 + 9 * abs(distance));
+				const float distanceLog = log10(1 + 9 * std::abs(distance));
 				const float angleCos = inLeft / distance;
 				const float angleSin = inRight / distance;
 				left  = distanceLog * angleCos * (activeSize - 1) / 4;
@@ -222,7 +222,7 @@ void VectorView::paintEvent(QPaintEvent *event)
 			float inRight = inBuffer[frame][1] * m_zoom;
 			if (logScale) {
 				const float distance = sqrt(inLeft * inLeft + inRight * inRight);
-				const float distanceLog = log10(1 + 9 * abs(distance));
+				const float distanceLog = log10(1 + 9 * std::abs(distance));
 				const float angleCos = inLeft / distance;
 				const float angleSin = inRight / distance;
 				left  = distanceLog * angleCos * (activeSize - 1) / 4;


### PR DESCRIPTION
This prevents GCC 6 from raising an ambiguous call error.

Error reported in Discord: https://discord.com/channels/203559236729438208/207159523616489473/784937509267963904
On Debian 9.13 with GCC 6.3

@PhysSong 