### PR TITLE
Fixes bug with pasting of TCOs (#5840)

### DIFF
--- a/include/TimePos.h
+++ b/include/TimePos.h
@@ -68,9 +68,7 @@ public:
 	TimePos( const bar_t bar, const tick_t ticks );
 	TimePos( const tick_t ticks = 0 );
 
-	// Snap defines whether we should snap to the closest bar. If it's
-	// false we'll just stick to the lowest bar.
-	TimePos quantize(float bars, bool snap = true) const;
+	TimePos quantize(float) const;
 	TimePos toAbsoluteBar() const;
 
 	TimePos& operator+=( const TimePos& time );

--- a/include/TimePos.h
+++ b/include/TimePos.h
@@ -68,7 +68,9 @@ public:
 	TimePos( const bar_t bar, const tick_t ticks );
 	TimePos( const tick_t ticks = 0 );
 
-	TimePos quantize(float) const;
+	// Snap defines whether we should snap to the closest bar. If it's
+	// false we'll just stick to the lowest bar.
+	TimePos quantize(float bars, bool snap = true) const;
 	TimePos toAbsoluteBar() const;
 
 	TimePos& operator+=( const TimePos& time );

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -75,9 +75,9 @@ TimePos TimePos::quantize(float bars) const
 	// Ternary expression is making sure that the snap happens in the direction to
 	// the right even if m_ticks is negative and the offset is exactly half-way
 	// More details on issue #5840 and PR #5847
-	int snapUp = (offset == -(interval / 2))
+	int snapUp = ((2 * offset) == -interval)
 		? 0
-		: offset / (interval / 2);
+		: (2 * offset) / interval;
 
 	return (lowPos + snapUp) * interval;
 }

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -63,7 +63,7 @@ TimePos::TimePos( const tick_t ticks ) :
 {
 }
 
-TimePos TimePos::quantize(float bars, bool snap) const
+TimePos TimePos::quantize(float bars) const
 {
 	//The intervals we should snap to, our new position should be a factor of this
 	int interval = s_ticksPerBar * bars;
@@ -72,7 +72,12 @@ TimePos TimePos::quantize(float bars, bool snap) const
 	//Offset from the lower position
 	int offset = m_ticks % interval;
 	//1 if we should snap up, 0 if we shouldn't
-	int snapUp = snap ? offset / (interval / 2) : 0;
+	// Ternary expression is making sure that the snap happens in the direction to
+	// the right even if m_ticks is negative and the offset is exactly half-way
+	// More details on issue #5840 and PR #5847
+	int snapUp = (offset == -(interval / 2))
+		? 0
+		: offset / (interval / 2);
 
 	return (lowPos + snapUp) * interval;
 }

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -63,7 +63,7 @@ TimePos::TimePos( const tick_t ticks ) :
 {
 }
 
-TimePos TimePos::quantize(float bars) const
+TimePos TimePos::quantize(float bars, bool snap) const
 {
 	//The intervals we should snap to, our new position should be a factor of this
 	int interval = s_ticksPerBar * bars;
@@ -72,7 +72,7 @@ TimePos TimePos::quantize(float bars) const
 	//Offset from the lower position
 	int offset = m_ticks % interval;
 	//1 if we should snap up, 0 if we shouldn't
-	int snapUp = offset / (interval / 2);
+	int snapUp = snap ? offset / (interval / 2) : 0;
 
 	return (lowPos + snapUp) * interval;
 }

--- a/src/gui/widgets/TrackContentWidget.cpp
+++ b/src/gui/widgets/TrackContentWidget.cpp
@@ -474,20 +474,12 @@ bool TrackContentWidget::pasteSelection( TimePos tcoPos, const QMimeData * md, b
 	// onto their final position.
 
 	float snapSize = gui->songEditor()->m_editor->getSnapSize();
-	int snapTicks = static_cast<int>(snapSize * TimePos::ticksPerBar());
 	// All patterns should be offset the same amount as the grabbed pattern
 	TimePos offset = TimePos(tcoPos - grabbedTCOPos);
-	// If we need to quantize
-	if (offset % snapTicks)
-	{
-		// Since negative offsets will quantize up instead of down, we shift them back 1 snapSize
-		offset -= offset < 0 ? snapTicks : 0;
-
-		// The offset is quantized (rather than the positions) to preserve fine adjustments.
-		// We call quantize with snap set to false, so the TCO falls in the lowest bar, even
-		// if we clicked in the second half of it.
-		offset = offset.quantize(snapSize, false);
-	}
+	// Users expect clips to "fall" backwards, so bias the offset
+	offset -= TimePos::ticksPerBar() * snapSize / 2;
+	// The offset is quantized (rather than the positions) to preserve fine adjustments
+	offset = offset.quantize(snapSize);
 
 	// Get the leftmost TCO and fix the offset if it reaches below bar 0
 	TimePos leftmostPos = grabbedTCOPos;

--- a/src/gui/widgets/TrackContentWidget.cpp
+++ b/src/gui/widgets/TrackContentWidget.cpp
@@ -474,12 +474,20 @@ bool TrackContentWidget::pasteSelection( TimePos tcoPos, const QMimeData * md, b
 	// onto their final position.
 
 	float snapSize = gui->songEditor()->m_editor->getSnapSize();
+	int snapTicks = static_cast<int>(snapSize * TimePos::ticksPerBar());
 	// All patterns should be offset the same amount as the grabbed pattern
 	TimePos offset = TimePos(tcoPos - grabbedTCOPos);
-	// Users expect clips to "fall" backwards, so bias the offset
-	offset = offset - TimePos::ticksPerBar() * snapSize / 2;
-	// The offset is quantized (rather than the positions) to preserve fine adjustments
-	offset = offset.quantize(snapSize);
+	// If we need to quantize
+	if (offset % snapTicks)
+	{
+		// Since negative offsets will quantize up instead of down, we shift them back 1 snapSize
+		offset -= offset < 0 ? snapTicks : 0;
+
+		// The offset is quantized (rather than the positions) to preserve fine adjustments.
+		// We call quantize with snap set to false, so the TCO falls in the lowest bar, even
+		// if we clicked in the second half of it.
+		offset = offset.quantize(snapSize, false);
+	}
 
 	// Get the leftmost TCO and fix the offset if it reaches below bar 0
 	TimePos leftmostPos = grabbedTCOPos;


### PR DESCRIPTION
Fixes second issue of #5840 . I'd like feedback on the approach, I didn't want to create an exception on the behavior of `TimePos::quantize` since it's consistent, it just happens that we are working with negative values and expected them to be quantized the same way as positive ones. This makes a minor change to the `quantize` and moves most of the fix to the `pasteSelection` method.

`TimePos::quantize` works for negative values, but ends up snapping the TCO to the opposite direction. This is because the snapping down happens in the direction of the origin, which is left for positive values and right for negative values. The snapping up (when we are halfway through the interval) also happens in the opposite direction, away from the origin or right for positive values and left for negative ones:

![image](https://user-images.githubusercontent.com/22241596/101998924-67e97680-3cb6-11eb-99c4-1b592d494211.png)

That wasn't accounted for in the pasteSelection method and we ended up with wrong positions when pasting before the TCO(s) we copied. This PR attempts a fix by doing the following:

- Changing TimePos::quantize to have a boolean parameter that will define whether it snaps the position up if we are halfway through the interval or not (this removes the need to use that trick of subtracting `TimePos::ticksPerBar() * snapSize / 2` from the offset to try to "bias" it.
- Checking if we need quantizing at all by checking if the offset falls outsize the snap grid.
- If we do need quantizing and the offset is negative we subtract one snap, since the quantization will move the TCO to the opposite end (to the right). Then we call quantize.