### PR TITLE
Add `LcdFloatSpinBox` (extracted from microtonal PR)

### DIFF
--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -37,9 +37,8 @@ class LMMS_EXPORT LcdFloatSpinBox : public QWidget, public FloatModelView
 {
 	Q_OBJECT
 public:
-	LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent = nullptr, const QString& name = QString());
-	LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent = nullptr,
-		const QString& name = QString());
+	LcdFloatSpinBox(int numWhole, int numFrac, const QString& name = QString(), QWidget* parent = nullptr);
+	LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, const QString& name, QWidget* parent = nullptr);
 
 	void modelChanged() override
 	{

--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -92,6 +92,6 @@ signals:
 
 };
 
-typedef FloatModel LcdFloatSpinBoxModel;
+using LcdFloatSpinBoxModel = FloatModel;
 
 #endif

--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -1,0 +1,97 @@
+/*
+ * LcdFloatSpinBox.h - class LcdFloatSpinBox (LcdSpinBox for floats)
+ *
+ * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2020 Martin Pavelek <he29.HS/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef LCD_FLOATSPINBOX_H
+#define LCD_FLOATSPINBOX_H
+
+#include <QString>
+
+#include "LcdWidget.h"
+#include "AutomatableModelView.h"
+
+
+class LMMS_EXPORT LcdFloatSpinBox : public QWidget, public FloatModelView
+{
+	Q_OBJECT
+public:
+	LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent, const QString& name = QString());
+	LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent, const QString& name = QString());
+	virtual ~LcdFloatSpinBox() = default;
+
+	void modelChanged() override
+	{
+		ModelView::modelChanged();
+		update();
+	}
+
+	/*! Sets an offset which is always added to value of model so we can
+	    display values in a user-friendly way if they internally start at 0 */
+	void setDisplayOffset(int offset)
+	{
+		m_displayOffset = offset;
+	}
+
+	/*! \brief Returns internal offset for displaying values */
+	int displayOffset() const
+	{
+		return m_displayOffset;
+	}
+
+	void setLabel(const QString &label) {m_label = label;}
+
+public slots:
+	virtual void update();
+
+protected:
+	void contextMenuEvent(QContextMenuEvent *me) override;
+	void mousePressEvent(QMouseEvent *me) override;
+	void mouseMoveEvent(QMouseEvent *me) override;
+	void mouseReleaseEvent(QMouseEvent *me) override;
+	void wheelEvent(QWheelEvent *we) override;
+	void mouseDoubleClickEvent(QMouseEvent *me) override;
+	void paintEvent(QPaintEvent *pe) override;
+
+private:
+	void layoutSetup(const QString &style = QString("19green"));
+	void enterValue();
+	float getStep();
+
+	LcdWidget m_wholeDisplay;
+	LcdWidget m_fractionDisplay;
+	bool m_mouseMoving;
+	bool m_intStep;
+	QPoint m_origMousePos;
+	int m_displayOffset;
+	QString m_label;
+
+signals:
+	void manualChange();
+
+};
+
+typedef FloatModel LcdFloatSpinBoxModel;
+
+#endif

--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -37,27 +37,14 @@ class LMMS_EXPORT LcdFloatSpinBox : public QWidget, public FloatModelView
 {
 	Q_OBJECT
 public:
-	LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent, const QString& name = QString());
-	LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent, const QString& name = QString());
-	virtual ~LcdFloatSpinBox() = default;
+	LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent = nullptr, const QString& name = QString());
+	LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent = nullptr,
+		const QString& name = QString());
 
 	void modelChanged() override
 	{
 		ModelView::modelChanged();
 		update();
-	}
-
-	/*! Sets an offset which is always added to value of model so we can
-	    display values in a user-friendly way if they internally start at 0 */
-	void setDisplayOffset(int offset)
-	{
-		m_displayOffset = offset;
-	}
-
-	/*! \brief Returns internal offset for displaying values */
-	int displayOffset() const
-	{
-		return m_displayOffset;
 	}
 
 	void setLabel(const QString &label) { m_label = label; }
@@ -77,7 +64,7 @@ protected:
 private:
 	void layoutSetup(const QString &style = QString("19green"));
 	void enterValue();
-	float getStep();
+	float getStep() const;
 
 	LcdWidget m_wholeDisplay;
 	LcdWidget m_fractionDisplay;

--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -60,7 +60,7 @@ public:
 		return m_displayOffset;
 	}
 
-	void setLabel(const QString &label) {m_label = label;}
+	void setLabel(const QString &label) { m_label = label; }
 
 public slots:
 	virtual void update();

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -40,7 +40,7 @@ class LMMS_EXPORT LcdWidget : public QWidget
 	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
 	
 public:
-	LcdWidget(QWidget* parent, const QString& name = QString(), bool leadingZero = false);
+	explicit LcdWidget(QWidget* parent, const QString& name = QString(), bool leadingZero = false);
 	LcdWidget(int numDigits, QWidget* parent, const QString& name = QString(), bool leadingZero = false);
 	LcdWidget(int numDigits, const QString& style, QWidget* parent, const QString& name = QString(),
 		bool leadingZero = false);
@@ -104,8 +104,8 @@ private:
 	int m_cellHeight;
 	int m_numDigits;
 	int m_marginWidth;
-	int m_seamlessLeft;
-	int m_seamlessRight;
+	bool m_seamlessLeft;
+	bool m_seamlessRight;
 	bool m_leadingZero;
 
 	void initUi( const QString& name, const QString &style ); //!< to be called by ctors

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -40,9 +40,10 @@ class LMMS_EXPORT LcdWidget : public QWidget
 	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
 	
 public:
-	LcdWidget( QWidget* parent, const QString& name = QString() );
-	LcdWidget( int numDigits, QWidget* parent, const QString& name = QString() );
-	LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name = QString() );
+	LcdWidget( QWidget* parent, const QString& name = QString(), bool leadingZero = false );
+	LcdWidget( int numDigits, QWidget* parent, const QString& name = QString(), bool leadingZero = false );
+	LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name = QString(),
+		bool leadingZero = false );
 
 	virtual ~LcdWidget();
 
@@ -66,6 +67,10 @@ public:
 	QColor textShadowColor() const;
 	void setTextShadowColor( const QColor & c );
 
+	int cellHeight() const { return m_cellHeight; }
+
+	void setSeamless(bool left, bool right) {m_seamlessLeft = left; m_seamlessRight = right; updateSize();}
+
 public slots:
 	virtual void setMarginWidth( int width );
 
@@ -74,11 +79,6 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 
 	virtual void updateSize();
-
-	int cellHeight() const
-	{
-		return m_cellHeight;
-	}
 
 
 private:
@@ -99,9 +99,12 @@ private:
 	int m_cellHeight;
 	int m_numDigits;
 	int m_marginWidth;
+	int m_seamlessLeft;
+	int m_seamlessRight;
+	bool m_leadingZero;
 
 	void initUi( const QString& name, const QString &style ); //!< to be called by ctors
 
-} ;
+};
 
 #endif

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -40,10 +40,10 @@ class LMMS_EXPORT LcdWidget : public QWidget
 	Q_PROPERTY( QColor textShadowColor READ textShadowColor WRITE setTextShadowColor )
 	
 public:
-	LcdWidget( QWidget* parent, const QString& name = QString(), bool leadingZero = false );
-	LcdWidget( int numDigits, QWidget* parent, const QString& name = QString(), bool leadingZero = false );
-	LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name = QString(),
-		bool leadingZero = false );
+	LcdWidget(QWidget* parent, const QString& name = QString(), bool leadingZero = false);
+	LcdWidget(int numDigits, QWidget* parent, const QString& name = QString(), bool leadingZero = false);
+	LcdWidget(int numDigits, const QString& style, QWidget* parent, const QString& name = QString(),
+		bool leadingZero = false);
 
 	virtual ~LcdWidget();
 
@@ -69,7 +69,12 @@ public:
 
 	int cellHeight() const { return m_cellHeight; }
 
-	void setSeamless(bool left, bool right) {m_seamlessLeft = left; m_seamlessRight = right; updateSize();}
+	void setSeamless(bool left, bool right)
+	{
+		m_seamlessLeft = left;
+		m_seamlessRight = right;
+		updateSize();
+	}
 
 public slots:
 	virtual void setMarginWidth( int width );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(LMMS_SRCS
 	gui/widgets/LeftRightNav.cpp
 	gui/widgets/Knob.cpp
 	gui/widgets/LadspaControlView.cpp
+	gui/widgets/LcdFloatSpinBox.cpp
 	gui/widgets/LcdSpinBox.cpp
 	gui/widgets/LcdWidget.cpp
 	gui/widgets/LedCheckbox.cpp

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -78,7 +78,7 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 	m_wholeDisplay.setSeamless(false, true);
 	m_fractionDisplay.setSeamless(true, false);
 
-	lcdLayout->addWidget(&m_wholeDisplay);  
+	lcdLayout->addWidget(&m_wholeDisplay);
 
 	QLabel *dotLabel = new QLabel("", this);
 	QPixmap *dotPixmap = new QPixmap(embed::getIconPixmap(QString("lcd_" + style + "_dot").toUtf8().constData()));

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -27,6 +27,7 @@
 #include "LcdFloatSpinBox.h"
 
 #include <cmath>
+
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QInputDialog>
@@ -81,8 +82,8 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 	lcdLayout->addWidget(&m_wholeDisplay);
 
 	QLabel *dotLabel = new QLabel("", this);
-	QPixmap *dotPixmap = new QPixmap(embed::getIconPixmap(QString("lcd_" + style + "_dot").toUtf8().constData()));
-	dotLabel->setPixmap(dotPixmap->copy(0, 0, dotPixmap->size().width(), dotPixmap->size().height() / 2));
+	QPixmap dotPixmap(embed::getIconPixmap(QString("lcd_" + style + "_dot").toUtf8().constData()));
+	dotLabel->setPixmap(dotPixmap.copy(0, 0, dotPixmap.size().width(), dotPixmap.size().height() / 2));
 	lcdLayout->addWidget(dotLabel);
 
 	lcdLayout->addWidget(&m_fractionDisplay);
@@ -162,7 +163,7 @@ void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 		if (gui->mainWindow()->isShiftPressed()) { dy = qBound(-4, dy/4, 4); }
 		if (dy > 1 || dy < -1)
 		{
-			model()->setInitValue(model()->value() - dy / 2 * getStep());
+			model()->setValue(model()->value() - dy / 2 * getStep());
 			emit manualChange();
 			QCursor::setPos(m_origMousePos);
 		}
@@ -191,7 +192,7 @@ void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 	else { m_intStep = false; }
 
 	event->accept();
-	model()->setInitValue(model()->value() + ((event->delta() > 0) ? 1 : -1) * getStep());
+	model()->setValue(model()->value() + ((event->delta() > 0) ? 1 : -1) * getStep());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -103,7 +103,7 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 void LcdFloatSpinBox::update()
 {
 	const int whole = static_cast<int>(model()->value());
-	const float fraction = model()->value() - static_cast<int>(model()->value());
+	const float fraction = model()->value() - whole;
 	const int intFraction = fraction * std::pow(10.f, m_fractionDisplay.numDigits());
 	m_wholeDisplay.setValue(whole + m_displayOffset);
 	m_fractionDisplay.setValue(intFraction + m_displayOffset);
@@ -159,8 +159,7 @@ void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 	if (m_mouseMoving)
 	{
 		int dy = event->globalY() - m_origMousePos.y();
-		if (gui->mainWindow()->isShiftPressed())
-			dy = qBound(-4, dy/4, 4);
+		if (gui->mainWindow()->isShiftPressed()) { dy = qBound(-4, dy/4, 4); }
 		if (dy > 1 || dy < -1)
 		{
 			model()->setInitValue(model()->value() - dy / 2 * getStep());
@@ -211,8 +210,8 @@ void LcdFloatSpinBox::enterValue()
 	new_val = QInputDialog::getDouble(
 			this, tr("Set value"),
 			tr("Please enter a new value between %1 and %2:").
-			arg(model()->minValue()).
-			arg(model()->maxValue()),
+				arg(model()->minValue()).
+				arg(model()->maxValue()),
 			model()->value(),
 			model()->minValue(),
 			model()->maxValue(),

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -1,0 +1,255 @@
+/*
+ * LcdFloatSpinBox.cpp - class LcdFloatSpinBox (LcdSpinBox for floats)
+ *
+ * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2008 Paul Giblock <pgllama/at/gmail.com>
+ * Copyright (c) 2020 Martin Pavelek <he29.HS/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "LcdFloatSpinBox.h"
+
+#include <cmath>
+#include <QApplication>
+#include <QHBoxLayout>
+#include <QInputDialog>
+#include <QLabel>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPixmap>
+#include <QStyleOptionFrameV2>
+#include <QVBoxLayout>
+
+#include "CaptionMenu.h"
+#include "embed.h"
+#include "GuiApplication.h"
+#include "gui_templates.h"
+#include "MainWindow.h"
+
+
+LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent, const QString& name) :
+	FloatModelView(new FloatModel(0, 0, 0, 0, nullptr, name, true), this),
+	m_wholeDisplay(numWhole, parent, name, false),
+	m_fractionDisplay(numFrac, parent, name, true),
+	m_mouseMoving(false),
+	m_intStep(false),
+	m_origMousePos(),
+	m_displayOffset(0)
+{
+	layoutSetup();
+}
+
+
+LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent, const QString& name) :
+	FloatModelView(new FloatModel(0, 0, 0, 0, nullptr, name, true), this),
+	m_wholeDisplay(numWhole, style, parent, name, false),
+	m_fractionDisplay(numFrac, style, parent, name, true),
+	m_mouseMoving(false),
+	m_intStep(false),
+	m_origMousePos(),
+	m_displayOffset(0)
+{
+	layoutSetup(style);
+}
+
+
+void LcdFloatSpinBox::layoutSetup(const QString &style)
+{
+	// Assemble the LCD parts
+	QHBoxLayout *lcdLayout = new QHBoxLayout();
+
+	m_wholeDisplay.setSeamless(false, true);
+	m_fractionDisplay.setSeamless(true, false);
+
+	lcdLayout->addWidget(&m_wholeDisplay);  
+
+	QLabel *dotLabel = new QLabel("", this);
+	QPixmap *dotPixmap = new QPixmap(embed::getIconPixmap(QString("lcd_" + style + "_dot").toUtf8().constData()));
+	dotLabel->setPixmap(dotPixmap->copy(0, 0, dotPixmap->size().width(), dotPixmap->size().height() / 2));
+	lcdLayout->addWidget(dotLabel);
+
+	lcdLayout->addWidget(&m_fractionDisplay);
+
+	lcdLayout->setContentsMargins(0, 0, 0, 0);
+	lcdLayout->setSpacing(0);
+
+	// Add space for label
+	QVBoxLayout *outerLayout = new QVBoxLayout();
+	outerLayout->addLayout(lcdLayout);
+	outerLayout->addSpacing(9);
+	outerLayout->setContentsMargins(0, 0, 0, 0);
+	outerLayout->setSizeConstraint(QLayout::SetFixedSize);
+	this->setLayout(outerLayout);
+}
+
+
+void LcdFloatSpinBox::update()
+{
+	const int whole = static_cast<int>(model()->value());
+	const float fraction = model()->value() - static_cast<int>(model()->value());
+	const int intFraction = fraction * std::pow(10.f, m_fractionDisplay.numDigits());
+	m_wholeDisplay.setValue(whole + m_displayOffset);
+	m_fractionDisplay.setValue(intFraction + m_displayOffset);
+
+	QWidget::update();
+}
+
+
+void LcdFloatSpinBox::contextMenuEvent(QContextMenuEvent* event)
+{
+	// for the case, the user clicked right while pressing left mouse-
+	// button, the context-menu appears while mouse-cursor is still hidden
+	// and it isn't shown again until user does something which causes
+	// an QApplication::restoreOverrideCursor()-call...
+	mouseReleaseEvent(nullptr);
+
+	CaptionMenu contextMenu(model()->displayName());
+	addDefaultActions(&contextMenu);
+	contextMenu.exec(QCursor::pos());
+}
+
+
+void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton &&
+		!(event->modifiers() & Qt::ControlModifier) &&
+		event->y() < m_wholeDisplay.cellHeight() + 2)
+	{
+		m_mouseMoving = true;
+		m_origMousePos = event->globalPos();
+		QApplication::setOverrideCursor(Qt::BlankCursor);
+
+		AutomatableModel *thisModel = model();
+		if (thisModel)
+		{
+			thisModel->addJournalCheckPoint();
+			thisModel->saveJournallingState(false);
+		}
+	}
+	else
+	{
+		FloatModelView::mousePressEvent(event);
+	}
+}
+
+
+void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
+{
+	// switch between integer and fractional step based on cursor position
+	if (event->x() < m_wholeDisplay.width()) {m_intStep = true;}
+	else {m_intStep = false;}
+
+	if (m_mouseMoving)
+	{
+		int dy = event->globalY() - m_origMousePos.y();
+		if (gui->mainWindow()->isShiftPressed())
+			dy = qBound(-4, dy/4, 4);
+		if (dy > 1 || dy < -1)
+		{
+			model()->setInitValue(model()->value() - dy / 2 * getStep());
+			emit manualChange();
+			QCursor::setPos(m_origMousePos);
+		}
+	}
+}
+
+
+void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
+{
+	if (m_mouseMoving)
+	{
+		model()->restoreJournallingState();
+
+		QCursor::setPos(m_origMousePos);
+		QApplication::restoreOverrideCursor();
+
+		m_mouseMoving = false;
+	}
+}
+
+
+void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
+{
+	// switch between integer and fractional step based on cursor position
+	if (event->x() < m_wholeDisplay.width()) {m_intStep = true;}
+	else {m_intStep = false;}
+
+	event->accept();
+	model()->setInitValue(model()->value() + ((event->delta() > 0) ? 1 : -1) * getStep());
+	emit manualChange();
+}
+
+
+void LcdFloatSpinBox::mouseDoubleClickEvent(QMouseEvent *)
+{
+	enterValue();
+}
+
+
+void LcdFloatSpinBox::enterValue()
+{
+	bool ok;
+	float new_val;
+
+	new_val = QInputDialog::getDouble(
+			this, tr("Set value"),
+			tr("Please enter a new value between %1 and %2:").
+			arg(model()->minValue()).
+			arg(model()->maxValue()),
+			model()->value(),
+			model()->minValue(),
+			model()->maxValue(),
+			m_fractionDisplay.numDigits(), &ok);
+
+	if (ok)
+	{
+		model()->setValue(new_val);
+	}
+}
+
+
+float LcdFloatSpinBox::getStep()
+{
+	if (m_intStep) {return 1;}
+	else {return model()->step<float>();}
+}
+
+
+void LcdFloatSpinBox::paintEvent(QPaintEvent*)
+{
+	QPainter p(this);
+
+	// Border
+	QStyleOptionFrame opt;
+	opt.initFrom(this);
+	opt.state = QStyle::State_Sunken;
+	opt.rect = QRect(0, 0, width() - 1, m_wholeDisplay.height());
+	style()->drawPrimitive(QStyle::PE_Frame, &opt, &p, this);
+
+	// Label
+	if (!m_label.isEmpty())
+	{
+		p.setFont(pointSizeF(p.font(), 6.5));
+		p.setPen(m_wholeDisplay.textShadowColor());
+		p.drawText(width() / 2 - p.fontMetrics().width(m_label) / 2 + 1, height(), m_label);
+		p.setPen(m_wholeDisplay.textColor());
+		p.drawText(width() / 2 - p.fontMetrics().width(m_label) / 2, height() - 1, m_label);
+	}
+}

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -158,6 +158,7 @@ void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 		{
 			model()->setValue(model()->value() - dy / 2 * getStep());
 			emit manualChange();
+			m_origMousePos = event->globalPos();
 		}
 	}
 }
@@ -194,9 +195,9 @@ void LcdFloatSpinBox::mouseDoubleClickEvent(QMouseEvent *)
 void LcdFloatSpinBox::enterValue()
 {
 	bool ok;
-	float new_val;
+	float newVal;
 
-	new_val = QInputDialog::getDouble(
+	newVal = QInputDialog::getDouble(
 			this, tr("Set value"),
 			tr("Please enter a new value between %1 and %2:").
 				arg(model()->minValue()).
@@ -208,7 +209,7 @@ void LcdFloatSpinBox::enterValue()
 
 	if (ok)
 	{
-		model()->setValue(new_val);
+		model()->setValue(newVal);
 	}
 }
 

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -45,7 +45,7 @@
 #include "MainWindow.h"
 
 
-LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent, const QString& name) :
+LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& name, QWidget* parent) :
 	FloatModelView(new FloatModel(0, 0, 0, 0, nullptr, name, true), this),
 	m_wholeDisplay(numWhole, parent, name, false),
 	m_fractionDisplay(numFrac, parent, name, true),
@@ -58,7 +58,7 @@ LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, QWidget* parent, con
 }
 
 
-LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, QWidget* parent, const QString& name) :
+LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& style, const QString& name, QWidget* parent) :
 	FloatModelView(new FloatModel(0, 0, 0, 0, nullptr, name, true), this),
 	m_wholeDisplay(numWhole, style, parent, name, false),
 	m_fractionDisplay(numFrac, style, parent, name, true),
@@ -115,12 +115,6 @@ void LcdFloatSpinBox::update()
 
 void LcdFloatSpinBox::contextMenuEvent(QContextMenuEvent* event)
 {
-	// for the case, the user clicked right while pressing left mouse-
-	// button, the context-menu appears while mouse-cursor is still hidden
-	// and it isn't shown again until user does something which causes
-	// an QApplication::restoreOverrideCursor()-call...
-	mouseReleaseEvent(nullptr);
-
 	CaptionMenu contextMenu(model()->displayName());
 	addDefaultActions(&contextMenu);
 	contextMenu.exec(QCursor::pos());
@@ -135,7 +129,6 @@ void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
 	{
 		m_mouseMoving = true;
 		m_origMousePos = event->globalPos();
-		QApplication::setOverrideCursor(Qt::BlankCursor);
 
 		AutomatableModel *thisModel = model();
 		if (thisModel)
@@ -165,7 +158,6 @@ void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 		{
 			model()->setValue(model()->value() - dy / 2 * getStep());
 			emit manualChange();
-			QCursor::setPos(m_origMousePos);
 		}
 	}
 }
@@ -176,10 +168,6 @@ void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
 	if (m_mouseMoving)
 	{
 		model()->restoreJournallingState();
-
-		QCursor::setPos(m_origMousePos);
-		QApplication::restoreOverrideCursor();
-
 		m_mouseMoving = false;
 	}
 }

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -106,8 +106,8 @@ void LcdFloatSpinBox::update()
 	const int whole = static_cast<int>(model()->value());
 	const float fraction = model()->value() - whole;
 	const int intFraction = fraction * std::pow(10.f, m_fractionDisplay.numDigits());
-	m_wholeDisplay.setValue(whole + m_displayOffset);
-	m_fractionDisplay.setValue(intFraction + m_displayOffset);
+	m_wholeDisplay.setValue(whole);
+	m_fractionDisplay.setValue(intFraction);
 
 	QWidget::update();
 }
@@ -225,7 +225,7 @@ void LcdFloatSpinBox::enterValue()
 }
 
 
-float LcdFloatSpinBox::getStep()
+float LcdFloatSpinBox::getStep() const
 {
 	if (m_intStep) { return 1; }
 	else { return model()->step<float>(); }

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -153,8 +153,8 @@ void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
 void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 {
 	// switch between integer and fractional step based on cursor position
-	if (event->x() < m_wholeDisplay.width()) {m_intStep = true;}
-	else {m_intStep = false;}
+	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
+	else { m_intStep = false; }
 
 	if (m_mouseMoving)
 	{
@@ -187,8 +187,8 @@ void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
 void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 {
 	// switch between integer and fractional step based on cursor position
-	if (event->x() < m_wholeDisplay.width()) {m_intStep = true;}
-	else {m_intStep = false;}
+	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
+	else { m_intStep = false; }
 
 	event->accept();
 	model()->setInitValue(model()->value() + ((event->delta() > 0) ? 1 : -1) * getStep());
@@ -226,8 +226,8 @@ void LcdFloatSpinBox::enterValue()
 
 float LcdFloatSpinBox::getStep()
 {
-	if (m_intStep) {return 1;}
-	else {return model()->step<float>();}
+	if (m_intStep) { return 1; }
+	else { return model()->step<float>(); }
 }
 
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -70,17 +70,11 @@ void LcdSpinBox::update()
 
 
 
-void LcdSpinBox::contextMenuEvent( QContextMenuEvent* event )
+void LcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
 {
-	// for the case, the user clicked right while pressing left mouse-
-	// button, the context-menu appears while mouse-cursor is still hidden
-	// and it isn't shown again until user does something which causes
-	// an QApplication::restoreOverrideCursor()-call...
-	mouseReleaseEvent( NULL );
-
-	CaptionMenu contextMenu( model()->displayName() );
-	addDefaultActions( &contextMenu );
-	contextMenu.exec( QCursor::pos() );
+	CaptionMenu contextMenu(model()->displayName());
+	addDefaultActions(&contextMenu);
+	contextMenu.exec(QCursor::pos());
 }
 
 
@@ -136,12 +130,11 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 
 
 
-void LcdSpinBox::mouseReleaseEvent( QMouseEvent* )
+void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 {
-	if( m_mouseMoving )
+	if (m_mouseMoving)
 	{
 		model()->restoreJournallingState();
-		QApplication::restoreOverrideCursor();
 		m_mouseMoving = false;
 	}
 }

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -185,7 +185,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	}
 
 	// Right Margin
-	p.drawPixmap(QRect(0, 0, m_seamlessRight ? m_marginWidth : m_marginWidth - 1, m_cellHeight),
+	p.drawPixmap(QRect(0, 0, m_seamlessRight ? 0 : m_marginWidth - 1, m_cellHeight),
 		*m_lcdPixmap,
 		QRect(charsPerPixmap * m_cellWidth, isEnabled() ? 0 : m_cellHeight, m_cellWidth / 2, m_cellHeight));
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -152,7 +152,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 		p.drawPixmap(
 			cellRect,
 			*m_lcdPixmap,
-			QRect(QPoint(charsPerPixmap * m_cellWidth, isEnabled() ? 0 : m_cellHeight),	cellSize)
+			QRect(QPoint(charsPerPixmap * m_cellWidth, isEnabled() ? 0 : m_cellHeight), cellSize)
 		);
 
 		p.translate(m_marginWidth, 0);
@@ -291,5 +291,4 @@ void LcdWidget::initUi(const QString& name , const QString& style)
 
 	updateSize();
 }
-
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -40,28 +40,31 @@
 
 
 
-LcdWidget::LcdWidget( QWidget* parent, const QString& name ) :
-	LcdWidget( 1, parent, name )
+LcdWidget::LcdWidget( QWidget* parent, const QString& name, bool leadingZero ) :
+	LcdWidget( 1, parent, name, leadingZero )
 {
 }
 
 
 
 
-LcdWidget::LcdWidget( int numDigits, QWidget* parent, const QString& name ) :
-	LcdWidget( numDigits, QString("19green"), parent, name )
+LcdWidget::LcdWidget( int numDigits, QWidget* parent, const QString& name, bool leadingZero ) :
+	LcdWidget( numDigits, QString("19green"), parent, name, leadingZero )
 {
 }
 
 
 
 
-LcdWidget::LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name ) :
+LcdWidget::LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name, bool leadingZero ) :
 	QWidget( parent ),
 	m_label(),
 	m_textColor( 255, 255, 255 ),
 	m_textShadowColor( 64, 64, 64 ),
-	m_numDigits( numDigits )
+	m_numDigits( numDigits ),
+	m_seamlessLeft( false ),
+	m_seamlessRight( false ),
+	m_leadingZero( leadingZero )
 {
 	initUi( name, style );
 }
@@ -77,19 +80,15 @@ LcdWidget::~LcdWidget()
 
 
 
-void LcdWidget::setValue( int value )
+void LcdWidget::setValue(int value)
 {
 	QString s = m_textForValue[value];
-	if( s.isEmpty() )
+	if (s.isEmpty())
 	{
-		s = QString::number( value );
-		// TODO: if pad == true
-		/*
-		while( (int) s.length() < m_numDigits )
-		{
-			s = "0" + s;
+		s = QString::number(value);
+		if (m_leadingZero) {
+			s = s.rightJustified(m_numDigits, '0');
 		}
-		*/
 	}
 
 	m_display = s;
@@ -140,15 +139,23 @@ void LcdWidget::paintEvent( QPaintEvent* )
 //	p.translate( width() / 2 - lcdWidth / 2, 0 ); 
 	p.save();
 
-	p.translate( margin, margin );
+	// Don't skip any space and don't draw margin on the left side in seamless mode
+	if (m_seamlessLeft)
+	{
+		p.translate(0, margin);
+	}
+	else
+	{
+		p.translate(margin, margin);
+		// Left Margin
+		p.drawPixmap(
+			cellRect,
+			*m_lcdPixmap,
+			QRect(QPoint(charsPerPixmap * m_cellWidth, isEnabled() ? 0 : m_cellHeight),	cellSize)
+		);
 
-	// Left Margin
-	p.drawPixmap( cellRect, *m_lcdPixmap, 
-			QRect( QPoint( charsPerPixmap*m_cellWidth, 
-				isEnabled()?0:m_cellHeight ), 
-			cellSize ) );
-
-	p.translate( m_marginWidth, 0 );
+		p.translate(m_marginWidth, 0);
+	}
 
 	// Padding
 	for( int i=0; i < m_numDigits - m_display.length(); i++ ) 
@@ -177,21 +184,24 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	}
 
 	// Right Margin
-	p.drawPixmap( QRect( 0, 0, m_marginWidth-1, m_cellHeight ), *m_lcdPixmap, 
-			QRect( charsPerPixmap*m_cellWidth, isEnabled()?0:m_cellHeight,
-				m_cellWidth / 2, m_cellHeight ) );
+	p.drawPixmap(QRect(0, 0, m_seamlessRight ? m_marginWidth : m_marginWidth - 1, m_cellHeight),
+		*m_lcdPixmap,
+		QRect(charsPerPixmap * m_cellWidth, isEnabled() ? 0 : m_cellHeight, m_cellWidth / 2, m_cellHeight));
 
 
 	p.restore();
 
 	// Border
-	QStyleOptionFrame opt;
-	opt.initFrom( this );
-	opt.state = QStyle::State_Sunken;
-	opt.rect = QRect( 0, 0, m_cellWidth * m_numDigits + (margin+m_marginWidth)*2 - 1,
-			m_cellHeight + (margin*2) );
+	if (!m_seamlessLeft && !m_seamlessRight)
+	{
+		QStyleOptionFrame opt;
+		opt.initFrom(this);
+		opt.state = QStyle::State_Sunken;
+		opt.rect = QRect(0, 0, m_cellWidth * m_numDigits + (margin + m_marginWidth) * 2 - 1,
+			m_cellHeight + (margin * 2));
 
-	style()->drawPrimitive( QStyle::PE_Frame, &opt, &p, this );
+		style()->drawPrimitive(QStyle::PE_Frame, &opt, &p, this);
+	}
 
 	p.resetTransform();
 
@@ -235,16 +245,25 @@ void LcdWidget::setMarginWidth( int width )
 
 void LcdWidget::updateSize()
 {
-	int margin = 1;
-	if (m_label.isEmpty()) {
-		setFixedSize( m_cellWidth * m_numDigits + 2*(margin+m_marginWidth),
-				m_cellHeight + (2*margin) );
+	int margin_x1 = m_seamlessLeft ? 0 : 1 + m_marginWidth;
+	int margin_x2 = m_seamlessRight ? 0 : 1 + m_marginWidth;
+	int margin_y = 1;
+	if (m_label.isEmpty())
+	{
+		setFixedSize(
+			m_cellWidth * m_numDigits + margin_x1 + margin_x2,
+			m_cellHeight + (2 * margin_y)
+		);
 	}
-	else {
-		setFixedSize(qMax<int>(
-				m_cellWidth * m_numDigits + 2*(margin+m_marginWidth),
-				horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)),
-				m_cellHeight + (2*margin) + 9);
+	else
+	{
+		setFixedSize(
+			qMax<int>(
+				m_cellWidth * m_numDigits + margin_x1 + margin_x2,
+				horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)
+			),
+			m_cellHeight + (2 * margin_y) + 9
+		);
 	}
 
 	update();
@@ -271,8 +290,6 @@ void LcdWidget::initUi(const QString& name , const QString& style)
 
 	updateSize();
 }
-
-
 
 
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -193,6 +193,8 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	p.restore();
 
 	// Border
+	// When either the left or right edge is seamless, the border drawing must be done
+	// by the encapsulating class (usually LcdFloatSpinBox).
 	if (!m_seamlessLeft && !m_seamlessRight)
 	{
 		QStyleOptionFrame opt;

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -246,24 +246,24 @@ void LcdWidget::setMarginWidth( int width )
 
 void LcdWidget::updateSize()
 {
-	int margin_x1 = m_seamlessLeft ? 0 : 1 + m_marginWidth;
-	int margin_x2 = m_seamlessRight ? 0 : 1 + m_marginWidth;
-	int margin_y = 1;
+	const int marginX1 = m_seamlessLeft ? 0 : 1 + m_marginWidth;
+	const int marginX2 = m_seamlessRight ? 0 : 1 + m_marginWidth;
+	const int marginY = 1;
 	if (m_label.isEmpty())
 	{
 		setFixedSize(
-			m_cellWidth * m_numDigits + margin_x1 + margin_x2,
-			m_cellHeight + (2 * margin_y)
+			m_cellWidth * m_numDigits + marginX1 + marginX2,
+			m_cellHeight + (2 * marginY)
 		);
 	}
 	else
 	{
 		setFixedSize(
 			qMax<int>(
-				m_cellWidth * m_numDigits + margin_x1 + margin_x2,
+				m_cellWidth * m_numDigits + marginX1 + marginX2,
 				horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)
 			),
-			m_cellHeight + (2 * margin_y) + 9
+			m_cellHeight + (2 * marginY) + 9
 		);
 	}
 

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -40,31 +40,31 @@
 
 
 
-LcdWidget::LcdWidget( QWidget* parent, const QString& name, bool leadingZero ) :
-	LcdWidget( 1, parent, name, leadingZero )
+LcdWidget::LcdWidget(QWidget* parent, const QString& name, bool leadingZero) :
+	LcdWidget(1, parent, name, leadingZero)
 {
 }
 
 
 
 
-LcdWidget::LcdWidget( int numDigits, QWidget* parent, const QString& name, bool leadingZero ) :
-	LcdWidget( numDigits, QString("19green"), parent, name, leadingZero )
+LcdWidget::LcdWidget(int numDigits, QWidget* parent, const QString& name, bool leadingZero) :
+	LcdWidget(numDigits, QString("19green"), parent, name, leadingZero)
 {
 }
 
 
 
 
-LcdWidget::LcdWidget( int numDigits, const QString& style, QWidget* parent, const QString& name, bool leadingZero ) :
+LcdWidget::LcdWidget(int numDigits, const QString& style, QWidget* parent, const QString& name, bool leadingZero) :
 	QWidget( parent ),
 	m_label(),
 	m_textColor( 255, 255, 255 ),
 	m_textShadowColor( 64, 64, 64 ),
-	m_numDigits( numDigits ),
-	m_seamlessLeft( false ),
-	m_seamlessRight( false ),
-	m_leadingZero( leadingZero )
+	m_numDigits(numDigits),
+	m_seamlessLeft(false),
+	m_seamlessRight(false),
+	m_leadingZero(leadingZero)
 {
 	initUi( name, style );
 }
@@ -86,7 +86,8 @@ void LcdWidget::setValue(int value)
 	if (s.isEmpty())
 	{
 		s = QString::number(value);
-		if (m_leadingZero) {
+		if (m_leadingZero)
+		{
 			s = s.rightJustified(m_numDigits, '0');
 		}
 	}
@@ -290,6 +291,5 @@ void LcdWidget::initUi(const QString& name , const QString& style)
 
 	updateSize();
 }
-
 
 


### PR DESCRIPTION
This PR contains code for a new `LcdFloatSpinBox` widget, originally included in #5522.

As the name says, it is an LCD Spin Box that can be used for decimal numbers. It is a wrapper class, which instantiates two `LcdSpinBox`es, positions them next to each other and adds a decimal point in between. The whole and fractional part can be individually adjusted by a mouse, allowing easy coarse and fine adjustments.

The goal was to have only a "thin" wrapper and instantiate `LcdSpinBox`es to avoid redundancy and large changes to existing code, but in the end some parts had to be re-used in some form from the `LcdSpinBox` class. So there is a good chance it could be designed better, with even less redundancy, but it would likely require a substantial rewrite of the `LcdSpinBox` class.