### PR TITLE
Update BitcrushControlDialog.cpp

### DIFF
--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -75,7 +75,8 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	outClip->move( 138, 76 );
 	outClip->setModel( & controls->m_outClip );
 	outClip->setLabel( tr( "CLIP" ) );
-	outClip->setHintText( tr( "Output clip:" ) , "%" );
+    outClip->setHintText( tr( "Output clip:" ) , " dBFS");
+
 	
 	
 	// leds


### PR DESCRIPTION
Added the code outClip->setHintText( tr( "Output clip:" ) , " dBFS"); to fix the 

"Bitcrush plugins displays output clip level as % while it's dBFS #5856 " @PhysSong