### PR TITLE
Fix some problems with knob labels

### DIFF
--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -47,7 +47,7 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	Knob * freqKnob = new Knob( knobBright_26, this);
 	freqKnob->setModel( &controls->m_freqModel );
 	freqKnob->setLabel( tr( "FREQ" ) );
-	freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
+	freqKnob->setHintText( tr( "Frequency:" ) , " Hz" );
 
 	Knob * gainKnob = new Knob( knobBright_26, this );
 	gainKnob->setModel( &controls->m_gainModel );

--- a/plugins/CrossoverEQ/CrossoverEQControls.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControls.cpp
@@ -30,17 +30,17 @@
 CrossoverEQControls::CrossoverEQControls( CrossoverEQEffect * eff ) :
 	EffectControls( eff ),
 	m_effect( eff ),
-	m_xover12( 125.f, 50.f, 10000.f, 1.0f, this, "Band 1/2 Crossover" ),
-	m_xover23( 1250.f, 50.f, 20000.f, 1.0f, this, "Band 2/3 Crossover" ),
-	m_xover34( 5000.f, 50.f, 20000.f, 1.0f, this, "Band 3/4 Crossover" ),
-	m_gain1( 0.f, -60.f, 30.f, 0.1f, this, "Band 1 Gain" ),
-	m_gain2( 0.f, -60.f, 30.f, 0.1f, this, "Band 2 Gain" ),
-	m_gain3( 0.f, -60.f, 30.f, 0.1f, this, "Band 3 Gain" ),
-	m_gain4( 0.f, -60.f, 30.f, 0.1f, this, "Band 4 Gain" ),
-	m_mute1( true, this, "Mute Band 1" ),
-	m_mute2( true, this, "Mute Band 2" ),
-	m_mute3( true, this, "Mute Band 3" ),
-	m_mute4( true, this, "Mute Band 4" )
+	m_xover12( 125.f, 50.f, 10000.f, 1.0f, this, tr( "Band 1/2 Crossover" ) ),
+	m_xover23( 1250.f, 50.f, 20000.f, 1.0f, this, tr( "Band 2/3 Crossover" ) ),
+	m_xover34( 5000.f, 50.f, 20000.f, 1.0f, this, tr( "Band 3/4 Crossover" ) ),
+	m_gain1( 0.f, -60.f, 30.f, 0.1f, this, tr( "Band 1 Gain" ) ),
+	m_gain2( 0.f, -60.f, 30.f, 0.1f, this, tr( "Band 2 Gain" ) ),
+	m_gain3( 0.f, -60.f, 30.f, 0.1f, this, tr( "Band 3 Gain" ) ),
+	m_gain4( 0.f, -60.f, 30.f, 0.1f, this, tr( "Band 4 Gain" ) ),
+	m_mute1( true, this, tr( "Mute Band 1" ) ),
+	m_mute2( true, this, tr( "Mute Band 2" ) ),
+	m_mute3( true, this, tr( "Mute Band 3" ) ),
+	m_mute4( true, this, tr( "Mute Band 4" ) )
 {
 	connect( Engine::mixer(), SIGNAL( sampleRateChanged() ), this, SLOT( sampleRateChanged() ) );
 	connect( &m_xover12, SIGNAL( dataChanged() ), this, SLOT( xover12Changed() ) );

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -47,35 +47,35 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
 	sampleDelayKnob->setLabel( tr( "DELAY" ) );
-	sampleDelayKnob->setHintText( tr( "Delay time" ) + " ", " s" );
+	sampleDelayKnob->setHintText( tr( "Delay time:" ) + " ", " s" );
 
 	Knob * feedbackKnob = new Knob( knobBright_26, this );
 	feedbackKnob->move( 11, 58 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel);
 	feedbackKnob->setLabel( tr( "FDBK" ) );
-	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
+	feedbackKnob->setHintText( tr ( "Feedback amount:" ) + " " , "" );
 
 	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
-	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
+	lfoFreqKnob->setHintText( tr ( "LFO frequency:") + " ", " s" );
 
 	TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
 	lfoAmtKnob->setLabel( tr( "AMNT" ) );
-	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
+	lfoAmtKnob->setHintText( tr ( "LFO amount:" ) + " " , " s" );
 
 	EqFader * outFader = new EqFader( &controls->m_outGainModel,tr( "Out gain" ),
 									  this, &controls->m_outPeakL, &controls->m_outPeakR );
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 45 );
 	outFader->setDisplayConversion( false );
-	outFader->setHintText( tr( "Gain" ), "dBFS" );
+	outFader->setHintText( tr( "Gain:" ), "dBFS" );
 
 	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
 	pad->resize( 200, 200 );

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -75,7 +75,7 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 45 );
 	outFader->setDisplayConversion( false );
-	outFader->setHintText( tr( "Gain:" ), "dBFS" );
+	outFader->setHintText( tr( "Gain:" ), " dBFS" );
 
 	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
 	pad->resize( 200, 200 );

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -51,13 +51,13 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	setPalette( pal );
 	setFixedSize( 373, 109 );
 
-	makeknob( cut1Knob, 24, 26, m_cut1Model, tr( "FREQ" ), tr( "Cutoff frequency" ), "Hz" )
-	makeknob( res1Knob, 74, 26, m_res1Model, tr( "RESO" ), tr( "Resonance" ), "" )
-	makeknob( gain1Knob, 124, 26, m_gain1Model, tr( "GAIN" ), tr( "Gain" ), "%" )
-	makeknob( mixKnob, 173, 37, m_mixModel, tr( "MIX" ), tr( "Mix" ), "" )
-	makeknob( cut2Knob, 222, 26, m_cut2Model, tr( "FREQ" ), tr( "Cutoff frequency" ), "Hz" )
-	makeknob( res2Knob, 272, 26, m_res2Model, tr( "RESO" ), tr( "Resonance" ), "" )
-	makeknob( gain2Knob, 322, 26, m_gain2Model, tr( "GAIN" ), tr( "Gain" ), "%" )
+	makeknob( cut1Knob, 24, 26, m_cut1Model, tr( "FREQ" ), tr( "Cutoff frequency:" ), " Hz" )
+	makeknob( res1Knob, 74, 26, m_res1Model, tr( "RESO" ), tr( "Resonance:" ), "" )
+	makeknob( gain1Knob, 124, 26, m_gain1Model, tr( "GAIN" ), tr( "Gain:" ), "%" )
+	makeknob( mixKnob, 173, 37, m_mixModel, tr( "MIX" ), tr( "Mix:" ), "" )
+	makeknob( cut2Knob, 222, 26, m_cut2Model, tr( "FREQ" ), tr( "Cutoff frequency:" ), " Hz" )
+	makeknob( res2Knob, 272, 26, m_res2Model, tr( "RESO" ), tr( "Resonance:" ), "" )
+	makeknob( gain2Knob, 322, 26, m_gain2Model, tr( "GAIN" ), tr( "Gain:" ), "%" )
 
 	gain1Knob-> setVolumeKnob( true );
 	gain2Knob-> setVolumeKnob( true );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -80,24 +80,24 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	EqFader * GainFaderIn = new EqFader( &controls->m_inGainModel, tr( "Input gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_inPeakL, &controls->m_inPeakR );
 	GainFaderIn->move( 23, 295 );
 	GainFaderIn->setDisplayConversion( false );
-	GainFaderIn->setHintText( tr( "Gain" ), "dBv");
+	GainFaderIn->setHintText( tr( "Gain:" ), "dBv" );
 
 	EqFader * GainFaderOut = new EqFader( &controls->m_outGainModel, tr( "Output gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_outPeakL, &controls->m_outPeakR );
 	GainFaderOut->move( 453, 295);
 	GainFaderOut->setDisplayConversion( false );
-	GainFaderOut->setHintText( tr( "Gain" ), "dBv" );
+	GainFaderOut->setHintText( tr( "Gain:" ), "dBv" );
 
 	// Gain Fader for each Filter exepts the pass filter
 	int distance = 126;
 	for( int i = 1; i < m_parameterWidget->bandCount() - 1; i++ )
 	{
-		EqFader * gainFader = new EqFader( m_parameterWidget->getBandModels( i )->gain, tr( "" ), this, faderBg, faderLeds, faderKnob, m_parameterWidget->getBandModels( i )->peakL, m_parameterWidget->getBandModels( i )->peakR );
+		EqFader * gainFader = new EqFader( m_parameterWidget->getBandModels( i )->gain, "" , this, faderBg, faderLeds, faderKnob, m_parameterWidget->getBandModels( i )->peakL, m_parameterWidget->getBandModels( i )->peakR );
 		gainFader->move( distance, 295 );
 		distance += 44;
 		gainFader->setMinimumHeight(80);
 		gainFader->resize(gainFader->width() , 80);
 		gainFader->setDisplayConversion( false );
-		gainFader->setHintText( tr( "Gain") , "dB");
+		gainFader->setHintText( tr( "Gain:" ) , "dB" );
 	}
 
 	//Control Button and Knobs for each Band
@@ -108,8 +108,8 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		resKnob->move( distance, 440 );
 		resKnob->setVolumeKnob(false);
 		resKnob->setModel( m_parameterWidget->getBandModels( i )->res );
-		if(i > 1 && i < 6) { resKnob->setHintText( tr( "Bandwidth: " ) , tr( " Octave" ) ); }
-		else { resKnob->setHintText( tr( "Resonance : " ) , "" ); }
+		if(i > 1 && i < 6) { resKnob->setHintText( tr( "Bandwidth: " ) , tr( " octave(s)" ) ); }
+		else { resKnob->setHintText( tr( "Resonance: " ) , "" ); }
 
 		Knob * freqKnob = new Knob( knobBright_26, this );
 		freqKnob->move( distance, 396 );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -80,12 +80,12 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	EqFader * GainFaderIn = new EqFader( &controls->m_inGainModel, tr( "Input gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_inPeakL, &controls->m_inPeakR );
 	GainFaderIn->move( 23, 295 );
 	GainFaderIn->setDisplayConversion( false );
-	GainFaderIn->setHintText( tr( "Gain:" ), "dBv" );
+	GainFaderIn->setHintText( tr( "Gain:" ), " dB" );
 
 	EqFader * GainFaderOut = new EqFader( &controls->m_outGainModel, tr( "Output gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_outPeakL, &controls->m_outPeakR );
 	GainFaderOut->move( 453, 295);
 	GainFaderOut->setDisplayConversion( false );
-	GainFaderOut->setHintText( tr( "Gain:" ), "dBv" );
+	GainFaderOut->setHintText( tr( "Gain:" ), " dB" );
 
 	// Gain Fader for each Filter exepts the pass filter
 	int distance = 126;
@@ -97,7 +97,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		gainFader->setMinimumHeight(80);
 		gainFader->resize(gainFader->width() , 80);
 		gainFader->setDisplayConversion( false );
-		gainFader->setHintText( tr( "Gain:" ) , "dB" );
+		gainFader->setHintText( tr( "Gain:" ) , " dB" );
 	}
 
 	//Control Button and Knobs for each Band
@@ -115,7 +115,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		freqKnob->move( distance, 396 );
 		freqKnob->setVolumeKnob( false );
 		freqKnob->setModel( m_parameterWidget->getBandModels( i )->freq );
-		freqKnob->setHintText( tr( "Frequency:" ), "Hz" );
+		freqKnob->setHintText( tr( "Frequency:" ), " Hz" );
 
 		// adds the Number Active buttons
 		PixmapButton * activeButton = new PixmapButton( this, NULL );

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -45,7 +45,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	delayKnob->setVolumeKnob( false );
 	delayKnob->setModel( &controls->m_delayTimeModel );
 	delayKnob->setLabel( tr( "DELAY" ) );
-	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
+	delayKnob->setHintText( tr( "Delay time:" ) , " s" );
 
 	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoFreqKnob->move( 48,10 );

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -52,7 +52,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
-	lfoFreqKnob->setHintText( tr( "Period:" ) , " Sec" );
+	lfoFreqKnob->setHintText( tr( "Period:" ) , " s" );
 
 	Knob * lfoAmtKnob = new Knob( knobBright_26, this );
 	lfoAmtKnob->move( 85,10 );

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -711,18 +711,18 @@ OpulenzInstrumentView::OpulenzInstrumentView( Instrument * _instrument,
 
 
 	// OP1 knobs & buttons...
-	KNOB_GEN(op1_a_kn, "Attack", "", 6, 48);
-	KNOB_GEN(op1_d_kn, "Decay", "", 34, 48);
-	KNOB_GEN(op1_s_kn, "Sustain", "", 62, 48);
-	KNOB_GEN(op1_r_kn, "Release", "", 90, 48);
-	KNOB_GEN(op1_lvl_kn, "Level", "", 166, 48);
-	KNOB_GEN(op1_scale_kn, "Scale", "", 194, 48);
-	KNOB_GEN(op1_mul_kn, "Frequency multiplier", "", 222, 48);
+	KNOB_GEN(op1_a_kn, "Attack:", "", 6, 48);
+	KNOB_GEN(op1_d_kn, "Decay:", "", 34, 48);
+	KNOB_GEN(op1_s_kn, "Sustain:", "", 62, 48);
+	KNOB_GEN(op1_r_kn, "Release:", "", 90, 48);
+	KNOB_GEN(op1_lvl_kn, "Level:", "", 166, 48);
+	KNOB_GEN(op1_scale_kn, "Scale:", "", 194, 48);
+	KNOB_GEN(op1_mul_kn, "Frequency multiplier:", "", 222, 48);
 	BUTTON_GEN(op1_ksr_btn, "Keyboard scaling rate", 9, 87);
 	BUTTON_GEN(op1_perc_btn, "Percussive envelope", 36, 87);
 	BUTTON_GEN(op1_trem_btn, "Tremolo", 65, 87);
 	BUTTON_GEN(op1_vib_btn, "Vibrato", 93, 87);
-	KNOB_GEN(feedback_kn, "Feedback", "", 128, 48);
+	KNOB_GEN(feedback_kn, "Feedback:", "", 128, 48);
 
 	op1_waveform = new automatableButtonGroup( this );
 	WAVEBUTTON_GEN(op1_w0_btn,"Sine", 154, 86, "wave1_on", "wave1_off", op1_waveform);
@@ -732,13 +732,13 @@ OpulenzInstrumentView::OpulenzInstrumentView( Instrument * _instrument,
 
 
 	// And the same for OP2
-	KNOB_GEN(op2_a_kn, "Attack", "", 6, 138);
-	KNOB_GEN(op2_d_kn, "Decay", "", 34, 138);
-	KNOB_GEN(op2_s_kn, "Sustain", "", 62, 138);
-	KNOB_GEN(op2_r_kn, "Release", "", 90, 138);
-	KNOB_GEN(op2_lvl_kn, "Level", "", 166, 138);
-	KNOB_GEN(op2_scale_kn, "Scale", "", 194, 138);
-	KNOB_GEN(op2_mul_kn, "Frequency multiplier", "", 222, 138);
+	KNOB_GEN(op2_a_kn, "Attack:", "", 6, 138);
+	KNOB_GEN(op2_d_kn, "Decay:", "", 34, 138);
+	KNOB_GEN(op2_s_kn, "Sustain:", "", 62, 138);
+	KNOB_GEN(op2_r_kn, "Release:", "", 90, 138);
+	KNOB_GEN(op2_lvl_kn, "Level:", "", 166, 138);
+	KNOB_GEN(op2_scale_kn, "Scale:", "", 194, 138);
+	KNOB_GEN(op2_mul_kn, "Frequency multiplier:", "", 222, 138);
 	BUTTON_GEN(op2_ksr_btn, "Keyboard scaling rate", 9, 177);
 	BUTTON_GEN(op2_perc_btn, "Percussive envelope", 36, 177);
 	BUTTON_GEN(op2_trem_btn, "Tremolo", 65, 177);
@@ -800,21 +800,21 @@ void OpulenzInstrumentView::updateKnobHints()
 	OpulenzInstrument * m = castModel<OpulenzInstrument>();
 	
 
-	op1_a_kn->setHintText( tr( "Attack" ),
+	op1_a_kn->setHintText( tr( "Attack:" ),
 						   " (" + knobHintHelper(attack_times[(int)m->op1_a_mdl.value()]) + ")");
-	op2_a_kn->setHintText( tr( "Attack" ),
+	op2_a_kn->setHintText( tr( "Attack:" ),
 						   " (" + knobHintHelper(attack_times[(int)m->op2_a_mdl.value()]) + ")");
-	op1_d_kn->setHintText( tr( "Decay" ),
+	op1_d_kn->setHintText( tr( "Decay:" ),
 						   " (" + knobHintHelper(dr_times[(int)m->op1_d_mdl.value()]) + ")");
-	op2_d_kn->setHintText( tr( "Decay" ),
+	op2_d_kn->setHintText( tr( "Decay:" ),
 						   " (" + knobHintHelper(dr_times[(int)m->op2_d_mdl.value()]) + ")");
-	op1_r_kn->setHintText( tr( "Release" ),
+	op1_r_kn->setHintText( tr( "Release:" ),
 						   " (" + knobHintHelper(dr_times[(int)m->op1_r_mdl.value()]) + ")");
-	op2_r_kn->setHintText( tr( "Release" ),
+	op2_r_kn->setHintText( tr( "Release:" ),
 						   " (" + knobHintHelper(dr_times[(int)m->op2_r_mdl.value()]) + ")");
-	op1_mul_kn->setHintText( tr( "Frequency multiplier" ),
+	op1_mul_kn->setHintText( tr( "Frequency multiplier:" ),
 			       " (" + QString::number(fmultipliers[(int)m->op1_mul_mdl.value()]) + " semitones)");
-	op2_mul_kn->setHintText( tr( "Frequency multiplier" ),
+	op2_mul_kn->setHintText( tr( "Frequency multiplier:" ),
 			       " (" + QString::number(fmultipliers[(int)m->op2_mul_mdl.value()]) + " semitones)");
 }
 

--- a/plugins/ReverbSC/ReverbSCControlDialog.cpp
+++ b/plugins/ReverbSC/ReverbSCControlDialog.cpp
@@ -41,7 +41,7 @@ ReverbSCControlDialog::ReverbSCControlDialog( ReverbSCControls* controls ) :
 	inputGainKnob -> move( 16, 10 );
 	inputGainKnob->setModel( &controls->m_inputGainModel );
 	inputGainKnob->setLabel( tr( "Input" ) );
-	inputGainKnob->setHintText( tr( "Input gain:" ) , "dB" );
+	inputGainKnob->setHintText( tr( "Input gain:" ) , " dB" );
 
 	Knob * sizeKnob = new Knob( knobBright_26, this);
 	sizeKnob -> move( 57, 10 );
@@ -59,5 +59,5 @@ ReverbSCControlDialog::ReverbSCControlDialog( ReverbSCControls* controls ) :
 	outputGainKnob -> move( 139, 10 );
 	outputGainKnob->setModel( &controls->m_outputGainModel );
 	outputGainKnob->setLabel( tr( "Output" ) );
-	outputGainKnob->setHintText( tr( "Output gain:" ) , "dB" );
+	outputGainKnob->setHintText( tr( "Output gain:" ) , " dB" );
 }

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -82,7 +82,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	persistenceKnob->setModel(&controls->m_persistenceModel);
 	persistenceKnob->setLabel(tr("Persist."));
 	persistenceKnob->setToolTip(tr("Trace persistence: higher amount means the trace will stay bright for longer time."));
-	persistenceKnob->setHintText(tr("Trace persistence"), "");
+	persistenceKnob->setHintText(tr("Trace persistence:"), "");
 	config_layout->addWidget(persistenceKnob);
 }
 

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -99,7 +99,7 @@ Xpressive::Xpressive(InstrumentTrack* instrument_track) :
 	m_interpolateW3(false, this),
 	m_panning1( 1, -1.0f, 1.0f, 0.01f, this, tr("Panning 1")),
 	m_panning2(-1, -1.0f, 1.0f, 0.01f, this, tr("Panning 2")),
-	m_relTransition(50.0f, 0.0f, 500.0f, 1.0f, this, tr("Rel trans")),
+	m_relTransition(50.0f, 0.0f, 500.0f, 1.0f, this, tr("Release transition")),
 	m_W1(GRAPH_LENGTH),
 	m_W2(GRAPH_LENGTH),
 	m_W3(GRAPH_LENGTH),
@@ -450,7 +450,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 	m_panningKnob[1]->move(COL_KNOBS, ROW_KNOBSP2);
 
 	m_relKnob = new XpressiveKnob(this,"Release transition");
-	m_relKnob->setHintText(tr("Release transition:"), "ms");
+	m_relKnob->setHintText(tr("Release transition:"), " ms");
 	m_relKnob->move(COL_KNOBS, ROW_KNOBREL);
 
 
@@ -463,7 +463,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 	m_smoothKnob->setOuterRadius(9);
 	m_smoothKnob->setTotalAngle(280.0);
 	m_smoothKnob->setLineWidth(3);
-	m_smoothKnob->setHintText(tr("Smoothness"), "");
+	m_smoothKnob->setHintText(tr("Smoothness:"), "");
 	m_smoothKnob->move(66, EXPR_TEXT_Y + EXPR_TEXT_H + 4);
 
 	connect(m_generalPurposeKnob[0], SIGNAL(sliderMoved(float)), this,

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -343,7 +343,7 @@ bitInvaderView::bitInvaderView( Instrument * _instrument,
 	
 	m_sampleLengthKnob = new Knob( knobDark_28, this );
 	m_sampleLengthKnob->move( 6, 201 );
-	m_sampleLengthKnob->setHintText( tr( "Sample length" ), "" );
+	m_sampleLengthKnob->setHintText( tr( "Sample length:" ), "" );
 
 	m_graph = new Graph( this, Graph::NearestStyle, 204, 134 );
 	m_graph->move(23,59);	// 55,120 - 2px border

--- a/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
+++ b/plugins/dynamics_processor/dynamics_processor_control_dialog.cpp
@@ -77,13 +77,13 @@ dynProcControlDialog::dynProcControlDialog(
 	attackKnob -> move( 24, 268 );
 	attackKnob->setModel( &_controls->m_attackModel );
 	attackKnob->setLabel( tr( "ATTACK" ) );
-	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
+	attackKnob->setHintText( tr( "Peak attack time:" ) , " ms" );
 
 	Knob * releaseKnob = new Knob( knobBright_26, this );
 	releaseKnob -> move( 74, 268 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
 	releaseKnob->setLabel( tr( "RELEASE" ) );
-	releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );
+	releaseKnob->setHintText( tr( "Peak release time:" ) , " ms" );
 
 //wavegraph control buttons
 

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -281,11 +281,11 @@ kickerInstrumentView::kickerInstrumentView( Instrument * _instrument,
 	const int END_COL = COL1 + 48;
 	
 	m_startFreqKnob = new kickerLargeKnob( this );
-	m_startFreqKnob->setHintText( tr( "Start frequency:" ), "Hz" );
+	m_startFreqKnob->setHintText( tr( "Start frequency:" ), " Hz" );
 	m_startFreqKnob->move( COL1, ROW1 );
 
 	m_endFreqKnob = new kickerLargeKnob( this );
-	m_endFreqKnob->setHintText( tr( "End frequency:" ), "Hz" );
+	m_endFreqKnob->setHintText( tr( "End frequency:" ), " Hz" );
 	m_endFreqKnob->move( END_COL, ROW1 );
 
 	m_slopeKnob = new kickerKnob( this );
@@ -297,7 +297,7 @@ kickerInstrumentView::kickerInstrumentView( Instrument * _instrument,
 	m_gainKnob->move( COL1, ROW3 );
 
 	m_decayKnob = new kickerEnvKnob( this );
-	m_decayKnob->setHintText( tr( "Envelope length:" ), "ms" );
+	m_decayKnob->setHintText( tr( "Envelope length:" ), " ms" );
 	m_decayKnob->move( COL2, ROW3 );
 
 	m_envKnob = new kickerKnob( this );

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -859,7 +859,7 @@ lb302SynthView::lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 
 	m_distKnob = new Knob( knobBright_26, this );
 	m_distKnob->move( 210, 190 );
-	m_distKnob->setHintText( tr( "DIST:" ), "" );
+	m_distKnob->setHintText( tr( "Distortion:" ), "" );
 	m_distKnob->setLabel( tr( ""));
 
 

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -1641,25 +1641,25 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	QWidget * view = new QWidget( _parent );
 	view-> setFixedSize( 250, 250 );
 
-	makeknob( m_osc1VolKnob, KNOBCOL1, O1ROW, tr( "Volume" ), "%", "osc1Knob" )
-	makeknob( m_osc1PanKnob, KNOBCOL2, O1ROW, tr( "Panning" ), "", "osc1Knob" )
-	makeknob( m_osc1CrsKnob, KNOBCOL3, O1ROW, tr( "Coarse detune" ), tr( " semitones" ), "osc1Knob" )
-	makeknob( m_osc1FtlKnob, KNOBCOL4, O1ROW, tr( "Fine tune left" ), tr( " cents" ), "osc1Knob" )
-	makeknob( m_osc1FtrKnob, KNOBCOL5, O1ROW, tr( "Fine tune right" ), tr( " cents" ), "osc1Knob" )
-	makeknob( m_osc1SpoKnob, KNOBCOL6, O1ROW, tr( "Stereo phase offset" ), tr( " deg" ), "osc1Knob" )
-	makeknob( m_osc1PwKnob,  KNOBCOL7, O1ROW, tr( "Pulse width" ), "%", "osc1Knob" )
+	makeknob( m_osc1VolKnob, KNOBCOL1, O1ROW, tr( "Volume:" ), "%", "osc1Knob" )
+	makeknob( m_osc1PanKnob, KNOBCOL2, O1ROW, tr( "Panning:" ), "", "osc1Knob" )
+	makeknob( m_osc1CrsKnob, KNOBCOL3, O1ROW, tr( "Coarse detune:" ), tr( " semitones" ), "osc1Knob" )
+	makeknob( m_osc1FtlKnob, KNOBCOL4, O1ROW, tr( "Fine tune left:" ), tr( " cents" ), "osc1Knob" )
+	makeknob( m_osc1FtrKnob, KNOBCOL5, O1ROW, tr( "Fine tune right:" ), tr( " cents" ), "osc1Knob" )
+	makeknob( m_osc1SpoKnob, KNOBCOL6, O1ROW, tr( "Stereo phase offset:" ), tr( " deg" ), "osc1Knob" )
+	makeknob( m_osc1PwKnob,  KNOBCOL7, O1ROW, tr( "Pulse width:" ), "%", "osc1Knob" )
 
 	m_osc1VolKnob -> setVolumeKnob( true );
 
 	maketinyled( m_osc1SSRButton, 230, 34, tr( "Send sync on pulse rise" ) )
 	maketinyled( m_osc1SSFButton, 230, 44, tr( "Send sync on pulse fall" ) )
 
-	makeknob( m_osc2VolKnob, KNOBCOL1, O2ROW, tr( "Volume" ), "%", "osc2Knob" )
-	makeknob( m_osc2PanKnob, KNOBCOL2, O2ROW, tr( "Panning" ), "", "osc2Knob" )
-	makeknob( m_osc2CrsKnob, KNOBCOL3, O2ROW, tr( "Coarse detune" ), tr( " semitones" ), "osc2Knob" )
-	makeknob( m_osc2FtlKnob, KNOBCOL4, O2ROW, tr( "Fine tune left" ), tr( " cents" ), "osc2Knob" )
-	makeknob( m_osc2FtrKnob, KNOBCOL5, O2ROW, tr( "Fine tune right" ), tr( " cents" ), "osc2Knob" )
-	makeknob( m_osc2SpoKnob, KNOBCOL6, O2ROW, tr( "Stereo phase offset" ), tr( " deg" ), "osc2Knob" )
+	makeknob( m_osc2VolKnob, KNOBCOL1, O2ROW, tr( "Volume:" ), "%", "osc2Knob" )
+	makeknob( m_osc2PanKnob, KNOBCOL2, O2ROW, tr( "Panning:" ), "", "osc2Knob" )
+	makeknob( m_osc2CrsKnob, KNOBCOL3, O2ROW, tr( "Coarse detune:" ), tr( " semitones" ), "osc2Knob" )
+	makeknob( m_osc2FtlKnob, KNOBCOL4, O2ROW, tr( "Fine tune left:" ), tr( " cents" ), "osc2Knob" )
+	makeknob( m_osc2FtrKnob, KNOBCOL5, O2ROW, tr( "Fine tune right:" ), tr( " cents" ), "osc2Knob" )
+	makeknob( m_osc2SpoKnob, KNOBCOL6, O2ROW, tr( "Stereo phase offset:" ), tr( " deg" ), "osc2Knob" )
 
 	m_osc2VolKnob -> setVolumeKnob( true );
 
@@ -1670,11 +1670,11 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
 
-	makeknob( m_osc3VolKnob, KNOBCOL1, O3ROW, tr( "Volume" ), "%", "osc3Knob" )
-	makeknob( m_osc3PanKnob, KNOBCOL2, O3ROW, tr( "Panning" ), "", "osc3Knob" )
-	makeknob( m_osc3CrsKnob, KNOBCOL3, O3ROW, tr( "Coarse detune" ), tr( " semitones" ), "osc3Knob" )
-	makeknob( m_osc3SpoKnob, KNOBCOL4, O3ROW, tr( "Stereo phase offset" ), tr( " deg" ), "osc3Knob" )
-	makeknob( m_osc3SubKnob, KNOBCOL5, O3ROW, tr( "Sub-osc mix" ), "", "osc3Knob" )
+	makeknob( m_osc3VolKnob, KNOBCOL1, O3ROW, tr( "Volume:" ), "%", "osc3Knob" )
+	makeknob( m_osc3PanKnob, KNOBCOL2, O3ROW, tr( "Panning:" ), "", "osc3Knob" )
+	makeknob( m_osc3CrsKnob, KNOBCOL3, O3ROW, tr( "Coarse detune:" ), tr( " semitones" ), "osc3Knob" )
+	makeknob( m_osc3SpoKnob, KNOBCOL4, O3ROW, tr( "Stereo phase offset:" ), tr( " deg" ), "osc3Knob" )
+	makeknob( m_osc3SubKnob, KNOBCOL5, O3ROW, tr( "Sub-osc mix:" ), "", "osc3Knob" )
 
 	m_osc3VolKnob -> setVolumeKnob( true );
 
@@ -1693,33 +1693,33 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo1WaveBox->setFont( pointSize<8>( m_lfo1WaveBox->font() ) );
 
-	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
-	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
-	makeknob( m_lfo1PhsKnob, LFOCOL3, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
+	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack:" ), " ms", "lfoKnob" )
+	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate:" ), " ms", "lfoKnob" )
+	makeknob( m_lfo1PhsKnob, LFOCOL3, LFOROW, tr( "Phase:" ), tr( " deg" ), "lfoKnob" )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
 
-	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
-	maketsknob( m_lfo2RateKnob, LFOCOL5, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
-	makeknob( m_lfo2PhsKnob, LFOCOL6, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
+	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack:" ), " ms", "lfoKnob" )
+	maketsknob( m_lfo2RateKnob, LFOCOL5, LFOROW, tr( "Rate:" ), " ms", "lfoKnob" )
+	makeknob( m_lfo2PhsKnob, LFOCOL6, LFOROW, tr( "Phase:" ), tr( " deg" ), "lfoKnob" )
 
-	maketsknob( m_env1PreKnob, KNOBCOL1, E1ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env1AttKnob, KNOBCOL2, E1ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env1HoldKnob, KNOBCOL3, E1ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env1DecKnob, KNOBCOL4, E1ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env1SusKnob, KNOBCOL5, E1ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env1RelKnob, KNOBCOL6, E1ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env1SlopeKnob, KNOBCOL7, E1ROW, tr( "Slope" ), "", "envKnob" )
+	maketsknob( m_env1PreKnob, KNOBCOL1, E1ROW, tr( "Pre-delay:" ), " ms", "envKnob" )
+	maketsknob( m_env1AttKnob, KNOBCOL2, E1ROW, tr( "Attack:" ), " ms", "envKnob" )
+	maketsknob( m_env1HoldKnob, KNOBCOL3, E1ROW, tr( "Hold:" ), " ms", "envKnob" )
+	maketsknob( m_env1DecKnob, KNOBCOL4, E1ROW, tr( "Decay:" ), " ms", "envKnob" )
+	makeknob( m_env1SusKnob, KNOBCOL5, E1ROW, tr( "Sustain:" ), "", "envKnob" )
+	maketsknob( m_env1RelKnob, KNOBCOL6, E1ROW, tr( "Release:" ), " ms", "envKnob" )
+	makeknob( m_env1SlopeKnob, KNOBCOL7, E1ROW, tr( "Slope:" ), "", "envKnob" )
 
-	maketsknob( m_env2PreKnob, KNOBCOL1, E2ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env2AttKnob, KNOBCOL2, E2ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env2HoldKnob, KNOBCOL3, E2ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env2DecKnob, KNOBCOL4, E2ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env2SusKnob, KNOBCOL5, E2ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env2RelKnob, KNOBCOL6, E2ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env2SlopeKnob, KNOBCOL7, E2ROW, tr( "Slope" ), "", "envKnob" )
+	maketsknob( m_env2PreKnob, KNOBCOL1, E2ROW, tr( "Pre-delay:" ), " ms", "envKnob" )
+	maketsknob( m_env2AttKnob, KNOBCOL2, E2ROW, tr( "Attack:" ), " ms", "envKnob" )
+	maketsknob( m_env2HoldKnob, KNOBCOL3, E2ROW, tr( "Hold:" ), " ms", "envKnob" )
+	maketsknob( m_env2DecKnob, KNOBCOL4, E2ROW, tr( "Decay:" ), " ms", "envKnob" )
+	makeknob( m_env2SusKnob, KNOBCOL5, E2ROW, tr( "Sustain:" ), "", "envKnob" )
+	maketsknob( m_env2RelKnob, KNOBCOL6, E2ROW, tr( "Release:" ), " ms", "envKnob" )
+	makeknob( m_env2SlopeKnob, KNOBCOL7, E2ROW, tr( "Slope:" ), "", "envKnob" )
 
 	// mod selector
 	PixmapButton * m_mixButton = new PixmapButton( view, NULL );
@@ -1765,60 +1765,60 @@ QWidget * MonstroView::setupMatrixView( QWidget * _parent )
 	QWidget * view = new QWidget( _parent );
 	view-> setFixedSize( 250, 250 );
 
-	makeknob( m_vol1env1Knob, MATCOL1, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol1env2Knob, MATCOL2, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol1lfo1Knob, MATCOL3, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol1lfo2Knob, MATCOL4, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_vol1env1Knob, MATCOL1, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol1env2Knob, MATCOL2, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol1lfo1Knob, MATCOL3, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol1lfo2Knob, MATCOL4, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_vol2env1Knob, MATCOL1, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol2env2Knob, MATCOL2, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol2lfo1Knob, MATCOL3, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol2lfo2Knob, MATCOL4, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_vol2env1Knob, MATCOL1, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol2env2Knob, MATCOL2, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol2lfo1Knob, MATCOL3, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol2lfo2Knob, MATCOL4, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_vol3env1Knob, MATCOL1, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol3env2Knob, MATCOL2, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol3lfo1Knob, MATCOL3, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_vol3lfo2Knob, MATCOL4, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_vol3env1Knob, MATCOL1, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol3env2Knob, MATCOL2, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol3lfo1Knob, MATCOL3, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_vol3lfo2Knob, MATCOL4, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_phs1env1Knob, MATCOL1, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs1env2Knob, MATCOL2, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs1lfo1Knob, MATCOL3, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs1lfo2Knob, MATCOL4, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_phs1env1Knob, MATCOL1, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs1env2Knob, MATCOL2, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs1lfo1Knob, MATCOL3, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs1lfo2Knob, MATCOL4, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_phs2env1Knob, MATCOL1, MATROW4, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs2env2Knob, MATCOL2, MATROW4, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs2lfo1Knob, MATCOL3, MATROW4, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs2lfo2Knob, MATCOL4, MATROW4, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_phs2env1Knob, MATCOL1, MATROW4, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs2env2Knob, MATCOL2, MATROW4, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs2lfo1Knob, MATCOL3, MATROW4, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs2lfo2Knob, MATCOL4, MATROW4, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_phs3env1Knob, MATCOL1, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs3env2Knob, MATCOL2, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs3lfo1Knob, MATCOL3, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_phs3lfo2Knob, MATCOL4, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_phs3env1Knob, MATCOL1, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs3env2Knob, MATCOL2, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs3lfo1Knob, MATCOL3, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_phs3lfo2Knob, MATCOL4, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_pit1env1Knob, MATCOL5, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit1env2Knob, MATCOL6, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit1lfo1Knob, MATCOL7, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit1lfo2Knob, MATCOL8, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_pit1env1Knob, MATCOL5, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit1env2Knob, MATCOL6, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit1lfo1Knob, MATCOL7, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit1lfo2Knob, MATCOL8, MATROW1, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_pit2env1Knob, MATCOL5, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit2env2Knob, MATCOL6, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit2lfo1Knob, MATCOL7, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit2lfo2Knob, MATCOL8, MATROW3, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_pit2env1Knob, MATCOL5, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit2env2Knob, MATCOL6, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit2lfo1Knob, MATCOL7, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit2lfo2Knob, MATCOL8, MATROW3, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_pit3env1Knob, MATCOL5, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit3env2Knob, MATCOL6, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit3lfo1Knob, MATCOL7, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pit3lfo2Knob, MATCOL8, MATROW5, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_pit3env1Knob, MATCOL5, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit3env2Knob, MATCOL6, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit3lfo1Knob, MATCOL7, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pit3lfo2Knob, MATCOL8, MATROW5, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_pw1env1Knob, MATCOL5, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pw1env2Knob, MATCOL6, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pw1lfo1Knob, MATCOL7, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_pw1lfo2Knob, MATCOL8, MATROW2, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_pw1env1Knob, MATCOL5, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pw1env2Knob, MATCOL6, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pw1lfo1Knob, MATCOL7, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_pw1lfo2Knob, MATCOL8, MATROW2, tr( "Modulation amount:" ), "", "matrixKnob" )
 
-	makeknob( m_sub3env1Knob, MATCOL5, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_sub3env2Knob, MATCOL6, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_sub3lfo1Knob, MATCOL7, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
-	makeknob( m_sub3lfo2Knob, MATCOL8, MATROW6, tr( "Modulation amount" ), "", "matrixKnob" )
+	makeknob( m_sub3env1Knob, MATCOL5, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_sub3env2Knob, MATCOL6, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_sub3lfo1Knob, MATCOL7, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
+	makeknob( m_sub3lfo2Knob, MATCOL8, MATROW6, tr( "Modulation amount:" ), "", "matrixKnob" )
 
 	return( view );
 }

--- a/plugins/nes/Nes.cpp
+++ b/plugins/nes/Nes.cpp
@@ -759,17 +759,17 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 	
 	// channel 1
 	
-	makeknob( m_ch1VolumeKnob, KNOB_X1, KNOB_Y1, tr( "Volume" ), "", "" )
-	makeknob( m_ch1CrsKnob, KNOB_X2, KNOB_Y1, tr( "Coarse detune" ), "", "" )
-	makeknob( m_ch1EnvLenKnob, KNOB_X3, KNOB_Y1, tr( "Envelope length" ), "", "" )
+	makeknob( m_ch1VolumeKnob, KNOB_X1, KNOB_Y1, tr( "Volume:" ), "", "" )
+	makeknob( m_ch1CrsKnob, KNOB_X2, KNOB_Y1, tr( "Coarse detune:" ), "", "" )
+	makeknob( m_ch1EnvLenKnob, KNOB_X3, KNOB_Y1, tr( "Envelope length:" ), "", "" )
 	
 	makenesled( m_ch1EnabledBtn, KNOB_X1, KNOB_Y1 - 12, tr( "Enable channel 1" ) )
 	makenesled( m_ch1EnvEnabledBtn, KNOB_X3, KNOB_Y1 - 12, tr( "Enable envelope 1" ) )
 	makenesled( m_ch1EnvLoopedBtn, 129, KNOB_Y1 - 12, tr( "Enable envelope 1 loop" ) )
 
 	makenesled( m_ch1SweepEnabledBtn, KNOB_X6, KNOB_Y1 - 12, tr( "Enable sweep 1" ) )
-	makeknob( m_ch1SweepAmtKnob, KNOB_X6, KNOB_Y1, tr( "Sweep amount" ), "", "" )
-	makeknob( m_ch1SweepRateKnob, KNOB_X7, KNOB_Y1, tr( "Sweep rate" ), "", "" )
+	makeknob( m_ch1SweepAmtKnob, KNOB_X6, KNOB_Y1, tr( "Sweep amount:" ), "", "" )
+	makeknob( m_ch1SweepRateKnob, KNOB_X7, KNOB_Y1, tr( "Sweep rate:" ), "", "" )
 
 	int dcx = 117;
 	makedcled( ch1_dc1, dcx, 42, tr( "12.5% Duty cycle" ), "nesdc1_on" )
@@ -790,17 +790,17 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 	
 	// channel 2
 	
-	makeknob( m_ch2VolumeKnob, KNOB_X1, KNOB_Y2, tr( "Volume" ), "", "" )
-	makeknob( m_ch2CrsKnob, KNOB_X2, KNOB_Y2, tr( "Coarse detune" ), "", "" )
-	makeknob( m_ch2EnvLenKnob, KNOB_X3, KNOB_Y2, tr( "Envelope length" ), "", "" )
+	makeknob( m_ch2VolumeKnob, KNOB_X1, KNOB_Y2, tr( "Volume:" ), "", "" )
+	makeknob( m_ch2CrsKnob, KNOB_X2, KNOB_Y2, tr( "Coarse detune:" ), "", "" )
+	makeknob( m_ch2EnvLenKnob, KNOB_X3, KNOB_Y2, tr( "Envelope length:" ), "", "" )
 	
 	makenesled( m_ch2EnabledBtn, KNOB_X1, KNOB_Y2 - 12, tr( "Enable channel 2" ) )
 	makenesled( m_ch2EnvEnabledBtn, KNOB_X3, KNOB_Y2 - 12, tr( "Enable envelope 2" ) )
 	makenesled( m_ch2EnvLoopedBtn, 129, KNOB_Y2 - 12, tr( "Enable envelope 2 loop" ) )
 
 	makenesled( m_ch2SweepEnabledBtn, KNOB_X6, KNOB_Y2 - 12, tr( "Enable sweep 2" ) )
-	makeknob( m_ch2SweepAmtKnob, KNOB_X6, KNOB_Y2, tr( "Sweep amount" ), "", "" )
-	makeknob( m_ch2SweepRateKnob, KNOB_X7, KNOB_Y2, tr( "Sweep rate" ), "", "" )
+	makeknob( m_ch2SweepAmtKnob, KNOB_X6, KNOB_Y2, tr( "Sweep amount:" ), "", "" )
+	makeknob( m_ch2SweepRateKnob, KNOB_X7, KNOB_Y2, tr( "Sweep rate:" ), "", "" )
 
 	dcx = 117;
 	makedcled( ch2_dc1, dcx, 99, tr( "12.5% Duty cycle" ), "nesdc1_on" )
@@ -821,15 +821,15 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 	
 	//channel 3
 	makenesled( m_ch3EnabledBtn, KNOB_X1, KNOB_Y3 - 12, tr( "Enable channel 3" ) )
-	makeknob( m_ch3VolumeKnob, KNOB_X1, KNOB_Y3, tr( "Volume" ), "", "" )
-	makeknob( m_ch3CrsKnob, KNOB_X2, KNOB_Y3, tr( "Coarse detune" ), "", "" )
+	makeknob( m_ch3VolumeKnob, KNOB_X1, KNOB_Y3, tr( "Volume:" ), "", "" )
+	makeknob( m_ch3CrsKnob, KNOB_X2, KNOB_Y3, tr( "Coarse detune:" ), "", "" )
 	
 
 	//channel 4
-	makeknob( m_ch4VolumeKnob, KNOB_X1, KNOB_Y4, tr( "Volume" ), "", "" )
-	makeknob( m_ch4NoiseFreqKnob, KNOB_X2, KNOB_Y4, tr( "Noise Frequency" ), "", "" )
-	makeknob( m_ch4EnvLenKnob, KNOB_X3, KNOB_Y4, tr( "Envelope length" ), "", "" )
-	makeknob( m_ch4SweepKnob, KNOB_X4, KNOB_Y4, tr( "Frequency sweep" ), "", "" )
+	makeknob( m_ch4VolumeKnob, KNOB_X1, KNOB_Y4, tr( "Volume:" ), "", "" )
+	makeknob( m_ch4NoiseFreqKnob, KNOB_X2, KNOB_Y4, tr( "Noise Frequency:" ), "", "" )
+	makeknob( m_ch4EnvLenKnob, KNOB_X3, KNOB_Y4, tr( "Envelope length:" ), "", "" )
+	makeknob( m_ch4SweepKnob, KNOB_X4, KNOB_Y4, tr( "Frequency sweep:" ), "", "" )
 	
 	makenesled( m_ch4EnabledBtn, KNOB_X1, KNOB_Y4 - 12, tr( "Enable channel 4" ) )
 	makenesled( m_ch4EnvEnabledBtn, KNOB_X3, KNOB_Y4 - 12, tr( "Enable envelope 4" ) )
@@ -842,8 +842,8 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 
 	
 	//master
-	makeknob( m_masterVolKnob, KNOB_X4, KNOB_Y3, tr( "Master volume" ), "", "" )
-	makeknob( m_vibratoKnob, KNOB_X5, KNOB_Y3, tr( "Vibrato" ), "", "" )
+	makeknob( m_masterVolKnob, KNOB_X4, KNOB_Y3, tr( "Master volume:" ), "", "" )
+	makeknob( m_vibratoKnob, KNOB_X5, KNOB_Y3, tr( "Vibrato:" ), "", "" )
 
 }
 

--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -526,7 +526,7 @@ void organicInstrumentView::modelChanged()
 		// setup knob for fine-detuning
 		Knob * detuneKnob = new organicKnob( this );
 		detuneKnob->move( x + i * colWidth, y + rowHeight*3 );
-		detuneKnob->setHintText( tr( "Osc %1 stereo detuning" ).arg( i + 1 )
+		detuneKnob->setHintText( tr( "Osc %1 stereo detuning:" ).arg( i + 1 )
 							, " " +
 							tr( "cents" ) );
 

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -241,10 +241,10 @@ WatsynInstrument::WatsynInstrument( InstrumentTrack * _instrument_track ) :
 		b1_pan( 0.0f, -100.0f, 100.0f, 0.1f, this, tr( "Panning B1" ) ),
 		b2_pan( 0.0f, -100.0f, 100.0f, 0.1f, this, tr( "Panning B2" ) ),
 
-		a1_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Freq. multiplier A1" ) ),
-		a2_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Freq. multiplier A2" ) ),
-		b1_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Freq. multiplier B1" ) ),
-		b2_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Freq. multiplier B2" ) ),
+		a1_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Frequency multiplier A1" ) ),
+		a2_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Frequency multiplier A2" ) ),
+		b1_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Frequency multiplier B1" ) ),
+		b2_mult( 8.0f, 1.0, 24.0, 1.0, this, tr( "Frequency multiplier B2" ) ),
 
 		a1_ltune( 0.0f, -600.0f, 600.0f, 1.0f, this, tr( "Left detune A1" ) ),
 		a2_ltune( 0.0f, -600.0f, 600.0f, 1.0f, this, tr( "Left detune A2" ) ),
@@ -676,40 +676,40 @@ WatsynView::WatsynView( Instrument * _instrument,
 
 // knobs... lots of em
 
-	makeknob( a1_volKnob, 130, A1ROW, tr( "Volume" ), "%", "aKnob" )
-	makeknob( a2_volKnob, 130, A2ROW, tr( "Volume" ), "%", "aKnob" )
-	makeknob( b1_volKnob, 130, B1ROW, tr( "Volume" ), "%", "bKnob" )
-	makeknob( b2_volKnob, 130, B2ROW, tr( "Volume" ), "%", "bKnob"  )
+	makeknob( a1_volKnob, 130, A1ROW, tr( "Volume:" ), "%", "aKnob" )
+	makeknob( a2_volKnob, 130, A2ROW, tr( "Volume:" ), "%", "aKnob" )
+	makeknob( b1_volKnob, 130, B1ROW, tr( "Volume:" ), "%", "bKnob" )
+	makeknob( b2_volKnob, 130, B2ROW, tr( "Volume:" ), "%", "bKnob"  )
 
-	makeknob( a1_panKnob, 154, A1ROW, tr( "Panning" ), "", "aKnob" )
-	makeknob( a2_panKnob, 154, A2ROW, tr( "Panning" ), "", "aKnob" )
-	makeknob( b1_panKnob, 154, B1ROW, tr( "Panning" ), "", "bKnob"  )
-	makeknob( b2_panKnob, 154, B2ROW, tr( "Panning" ), "", "bKnob"  )
+	makeknob( a1_panKnob, 154, A1ROW, tr( "Panning:" ), "", "aKnob" )
+	makeknob( a2_panKnob, 154, A2ROW, tr( "Panning:" ), "", "aKnob" )
+	makeknob( b1_panKnob, 154, B1ROW, tr( "Panning:" ), "", "bKnob"  )
+	makeknob( b2_panKnob, 154, B2ROW, tr( "Panning:" ), "", "bKnob"  )
 
-	makeknob( a1_multKnob, 178, A1ROW, tr( "Freq. multiplier" ), "/8", "aKnob" )
-	makeknob( a2_multKnob, 178, A2ROW, tr( "Freq. multiplier" ), "/8", "aKnob" )
-	makeknob( b1_multKnob, 178, B1ROW, tr( "Freq. multiplier" ), "/8", "bKnob"  )
-	makeknob( b2_multKnob, 178, B2ROW, tr( "Freq. multiplier" ), "/8", "bKnob"  )
+	makeknob( a1_multKnob, 178, A1ROW, tr( "Frequency multiplier:" ), "/8", "aKnob" )
+	makeknob( a2_multKnob, 178, A2ROW, tr( "Frequency multiplier:" ), "/8", "aKnob" )
+	makeknob( b1_multKnob, 178, B1ROW, tr( "Frequency multiplier:" ), "/8", "bKnob"  )
+	makeknob( b2_multKnob, 178, B2ROW, tr( "Frequency multiplier:" ), "/8", "bKnob"  )
 
-	makeknob( a1_ltuneKnob, 202, A1ROW, tr( "Left detune" ), tr( " cents" ), "aKnob" )
-	makeknob( a2_ltuneKnob, 202, A2ROW, tr( "Left detune" ), tr( " cents" ), "aKnob" )
-	makeknob( b1_ltuneKnob, 202, B1ROW, tr( "Left detune" ), tr( " cents" ), "bKnob"  )
-	makeknob( b2_ltuneKnob, 202, B2ROW, tr( "Left detune" ), tr( " cents" ), "bKnob"  )
+	makeknob( a1_ltuneKnob, 202, A1ROW, tr( "Left detune:" ), tr( " cents" ), "aKnob" )
+	makeknob( a2_ltuneKnob, 202, A2ROW, tr( "Left detune:" ), tr( " cents" ), "aKnob" )
+	makeknob( b1_ltuneKnob, 202, B1ROW, tr( "Left detune:" ), tr( " cents" ), "bKnob"  )
+	makeknob( b2_ltuneKnob, 202, B2ROW, tr( "Left detune:" ), tr( " cents" ), "bKnob"  )
 
-	makeknob( a1_rtuneKnob, 226, A1ROW, tr( "Right detune" ), tr( " cents" ), "aKnob" )
-	makeknob( a2_rtuneKnob, 226, A2ROW, tr( "Right detune" ), tr( " cents" ), "aKnob" )
-	makeknob( b1_rtuneKnob, 226, B1ROW, tr( "Right detune" ), tr( " cents" ), "bKnob"  )
-	makeknob( b2_rtuneKnob, 226, B2ROW, tr( "Right detune" ), tr( " cents" ), "bKnob"  )
+	makeknob( a1_rtuneKnob, 226, A1ROW, tr( "Right detune:" ), tr( " cents" ), "aKnob" )
+	makeknob( a2_rtuneKnob, 226, A2ROW, tr( "Right detune:" ), tr( " cents" ), "aKnob" )
+	makeknob( b1_rtuneKnob, 226, B1ROW, tr( "Right detune:" ), tr( " cents" ), "bKnob"  )
+	makeknob( b2_rtuneKnob, 226, B2ROW, tr( "Right detune:" ), tr( " cents" ), "bKnob"  )
 
-	makeknob( m_abmixKnob, 4, 3, tr( "A-B Mix" ), "", "mixKnob" )
+	makeknob( m_abmixKnob, 4, 3, tr( "A-B Mix:" ), "", "mixKnob" )
 
-	makeknob( m_envAmtKnob, 88, 3, tr( "Mix envelope amount" ), "", "mixenvKnob" )
+	makeknob( m_envAmtKnob, 88, 3, tr( "Mix envelope amount:" ), "", "mixenvKnob" )
 
-	maketsknob( m_envAttKnob, 88, A1ROW, tr( "Mix envelope attack" ), " ms", "mixenvKnob" )
-	maketsknob( m_envHoldKnob, 88, A2ROW, tr( "Mix envelope hold" ), " ms", "mixenvKnob" )
-	maketsknob( m_envDecKnob, 88, B1ROW, tr( "Mix envelope decay" ), " ms", "mixenvKnob" )
+	maketsknob( m_envAttKnob, 88, A1ROW, tr( "Mix envelope attack:" ), " ms", "mixenvKnob" )
+	maketsknob( m_envHoldKnob, 88, A2ROW, tr( "Mix envelope hold:" ), " ms", "mixenvKnob" )
+	maketsknob( m_envDecKnob, 88, B1ROW, tr( "Mix envelope decay:" ), " ms", "mixenvKnob" )
 
-	makeknob( m_xtalkKnob, 88, B2ROW, tr( "Crosstalk" ), "", "xtalkKnob" )
+	makeknob( m_xtalkKnob, 88, B2ROW, tr( "Crosstalk:" ), "", "xtalkKnob" )
 
 // let's set volume knobs
 	a1_volKnob -> setVolumeKnob( true );

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -324,7 +324,7 @@ void Fader::updateTextFloat()
 	}
 	else
 	{
-		s_textFloat->setText( m_description + " " + QString("%1 ").arg( model()->value() * m_conversionFactor ) + " " + m_unit );
+		s_textFloat->setText( m_description + " " + QString("%1").arg( model()->value() * m_conversionFactor ) + m_unit );
 	}
 	s_textFloat->moveGlobal( this, QPoint( width() - ( *m_knob ).width() - 5, knobPosY() - 46 ) );
 }


### PR DESCRIPTION
This PR addresses some of the stuff in #5817, making tooltips a bit more consistent. Also made the Crossover Eq controls translatable.
It's just a quick aesthetic change which shouldn't conflict with the reorganization.