### PR TITLE
Fix MP3 stereo mode doesn't match to the selection in export dialog

### DIFF
--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -144,7 +144,7 @@ OutputSettings::StereoMode mapToStereoMode(int index)
 	case 0:
 		return OutputSettings::StereoMode_Mono;
 	case 1:
- 		return OutputSettings::StereoMode_Stereo;
+		return OutputSettings::StereoMode_Stereo;
 	case 2:
 		return OutputSettings::StereoMode_JointStereo;
 	default:

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -142,11 +142,11 @@ OutputSettings::StereoMode mapToStereoMode(int index)
 	switch (index)
 	{
 	case 0:
-		return OutputSettings::StereoMode_Stereo;
-	case 1:
-		return OutputSettings::StereoMode_JointStereo;
-	case 2:
 		return OutputSettings::StereoMode_Mono;
+	case 1:
+ 		return OutputSettings::StereoMode_Stereo;
+	case 2:
+		return OutputSettings::StereoMode_JointStereo;
 	default:
 		return OutputSettings::StereoMode_Stereo;
 	}


### PR DESCRIPTION
Fix for MP3 stereo mode doesn't match to the selection in export dialog #5876

Updated the code to match the #5876.