### PR TITLE
Feature: Pattern import/export

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -52,6 +52,7 @@ public:
 		ClipboardData,
 		JournalData,
 		EffectSettings,
+		NotePattern,
 		TypeCount
 	} ;
 	typedef Types Type;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -506,7 +506,6 @@ private:
 	void focusInEvent(QFocusEvent * event) override;
 	void stopStepRecording();
 	void updateStepRecordingIcon();
-	bool savePatternXML(QString filepath, bool compress = true);
 
 	PianoRoll* m_editor;
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -506,11 +506,11 @@ private:
 	void focusInEvent(QFocusEvent * event) override;
 	void stopStepRecording();
 	void updateStepRecordingIcon();
-	int savePatternXML(QString filepath, bool compress = true);
+	bool savePatternXML(QString filepath, bool compress = true);
 
 	PianoRoll* m_editor;
 
-	QToolButton * m_fileToolsButton;
+	QToolButton* m_fileToolsButton;
 	ComboBox * m_zoomingComboBox;
 	ComboBox * m_zoomingYComboBox;
 	ComboBox * m_quantizeComboBox;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -47,6 +47,7 @@ class QPixmap;
 class QScrollBar;
 class QString;
 class QMenu;
+class QToolButton;
 
 class ComboBox;
 class NotePlayHandle;
@@ -497,15 +498,19 @@ signals:
 private slots:
 	void updateAfterPatternChange();
 	void ghostPatternSet( bool state );
+	void exportPattern();
+	void importPattern();
 
 private:
 	void patternRenamed();
 	void focusInEvent(QFocusEvent * event) override;
 	void stopStepRecording();
 	void updateStepRecordingIcon();
+	int savePatternXML(QString filepath, bool compress = true);
 
 	PianoRoll* m_editor;
 
+	QToolButton * m_fileToolsButton;
 	ComboBox * m_zoomingComboBox;
 	ComboBox * m_zoomingYComboBox;
 	ComboBox * m_quantizeComboBox;

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -82,7 +82,8 @@ DataFile::typeDescStruct
 	{ DataFile::DragNDropData, "dnddata" },
 	{ DataFile::ClipboardData, "clipboard-data" },
 	{ DataFile::JournalData, "journaldata" },
-	{ DataFile::EffectSettings, "effectsettings" }
+	{ DataFile::EffectSettings, "effectsettings" },
+	{ DataFile::NotePattern, "pattern" }
 } ;
 
 
@@ -180,6 +181,12 @@ bool DataFile::validate( QString extension )
 		break;
 	case Type::InstrumentTrackSettings:
 		if ( extension == "xpf" || extension == "xml" )
+		{
+			return true;
+		}
+		break;
+	case Type::NotePattern:
+		if (extension == "xpt" || extension == "xptz")
 		{
 			return true;
 		}
@@ -285,7 +292,8 @@ bool DataFile::writeFile( const QString& filename )
 		return false;
 	}
 
-	if( fullName.section( '.', -1 ) == "mmpz" )
+	const QString extension = fullName.section('.', -1);
+	if (extension == "mmpz" || extension == "xptz")
 	{
 		QString xml;
 		QTextStream ts( &xml );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4408,7 +4408,7 @@ PianoRollWindow::PianoRollWindow() :
 	notesActionsToolBar->addAction( quantizeAction );
 
 	// -- File actions
-	DropToolBar *fileActionsToolBar = addDropToolBarToTop( tr( "File actions" ) );
+	DropToolBar* fileActionsToolBar = addDropToolBarToTop(tr("File actions"));
 
 	// -- File ToolButton
 	m_fileToolsButton = new QToolButton(m_toolBar);
@@ -4416,11 +4416,11 @@ PianoRollWindow::PianoRollWindow() :
 	m_fileToolsButton->setPopupMode(QToolButton::InstantPopup);
 
 	// Import / export
-	QAction * importAction = new QAction(embed::getIconPixmap("project_import"),
-				tr("Import pattern"), m_fileToolsButton);
+	QAction* importAction = new QAction(embed::getIconPixmap("project_import"),
+		tr("Import pattern"), m_fileToolsButton);
 
-	QAction * exportAction = new QAction(embed::getIconPixmap("project_export"),
-				tr("Export pattern"), m_fileToolsButton);
+	QAction* exportAction = new QAction(embed::getIconPixmap("project_export"),
+		tr("Export pattern"), m_fileToolsButton);
 
 	m_fileToolsButton->addAction(importAction);
 	m_fileToolsButton->addAction(exportAction);
@@ -4845,10 +4845,10 @@ void PianoRollWindow::exportPattern()
 		!exportDialog.selectedFiles().isEmpty() &&
 		!exportDialog.selectedFiles().first().isEmpty())
 	{
-		QString suffix = ConfigManager::inst()->value( "app",
-								"nommpz" ).toInt() == 0
-							? "xptz"
-							: "xpt" ;
+		QString suffix =
+			ConfigManager::inst()->value("app", "nommpz").toInt() == 0
+				? "xptz"
+				: "xpt";
 		exportDialog.setDefaultSuffix(suffix);
 
 		QString fullPath = exportDialog.selectedFiles()[0];
@@ -4856,7 +4856,7 @@ void PianoRollWindow::exportPattern()
 
 		bool compress = (chosenSuffix == "xpt") ? false : true;
 
-		if (savePatternXML(fullPath, compress) != 0)
+		if (!savePatternXML(fullPath, compress))
 		{
 			TextFloat::displayMessage(tr("Export pattern failed"),
 				tr("No permission to write to %1").arg(fullPath),
@@ -4875,26 +4875,28 @@ void PianoRollWindow::exportPattern()
 void PianoRollWindow::importPattern()
 {
 	// Overwrite confirmation.
-	if (!m_editor->m_pattern->empty() && QMessageBox::warning(NULL,
-				tr("Import pattern."),
-				tr("You are about to import a pattern, this will "
-					"overwrite your current pattern. Do you want to "
-					"continue?"),
-				QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)
-				!= QMessageBox::Yes)
+	if (!m_editor->m_pattern->empty() &&
+		QMessageBox::warning(
+			NULL,
+			tr("Import pattern."),
+			tr("You are about to import a pattern, this will "
+				"overwrite your current pattern. Do you want to "
+				"continue?"),
+			QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes
+		) != QMessageBox::Yes)
 	{
 		return;
 	}
 
 	FileDialog importDialog(this, tr("Open Pattern"), "",
-			tr("XML pattern file (*.xpt *.xptz)"));
+		tr("XML pattern file (*.xpt *.xptz)"));
 	importDialog.setFileMode(FileDialog::ExistingFiles);
 
-	if (importDialog.exec () == QDialog::Accepted &&
+	if (importDialog.exec() == QDialog::Accepted &&
 		!importDialog.selectedFiles().isEmpty())
 	{
 		QString fullPath = importDialog.selectedFiles()[0];
-		QString suffix = fullPath.section( '.', -1 );
+		QString suffix = fullPath.section('.', -1);
 		bool compression = (suffix == "xpt") ? false : true;
 
 		QDomDocument doc("xml");
@@ -4936,8 +4938,8 @@ void PianoRollWindow::importPattern()
 		m_editor->m_pattern->movePosition(pos);
 
 		TextFloat::displayMessage(tr("Import pattern success"),
-						tr("Imported pattern %1!").arg(fullPath),
-						embed::getIconPixmap("project_import"), 4000);
+			tr("Imported pattern %1!").arg(fullPath),
+			embed::getIconPixmap("project_import"), 4000);
 	}
 }
 
@@ -4974,11 +4976,11 @@ void PianoRollWindow::updateStepRecordingIcon()
 
 
 
-int PianoRollWindow::savePatternXML(QString filepath, bool compress)
+bool PianoRollWindow::savePatternXML(QString filepath, bool compress)
 {
 	QDomDocument doc("xml");
-	QDomElement rootElement = doc.createElement( "pattern" );
-	m_editor->m_pattern->saveSettings( doc, rootElement );
+	QDomElement rootElement = doc.createElement("pattern");
+	m_editor->m_pattern->saveSettings(doc, rootElement);
 
 	doc.appendChild(rootElement);
 
@@ -4987,7 +4989,7 @@ int PianoRollWindow::savePatternXML(QString filepath, bool compress)
 	if (!f.open(QFile::WriteOnly | QFile::Text))
 	{
 		f.close();
-		return 1;
+		return false;
 	}
 
 	if (compress)
@@ -5001,5 +5003,5 @@ int PianoRollWindow::savePatternXML(QString filepath, bool compress)
 	}
 	f.close();
 
-	return 0;
+	return true;
 }

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4834,8 +4834,8 @@ void PianoRollWindow::ghostPatternSet( bool state )
 
 void PianoRollWindow::exportPattern()
 {
-	QString extFilter("XML Pattern (*.xpt *.xptz)");
-	FileDialog exportDialog(this, tr("Export pattern"), "", extFilter);
+	FileDialog exportDialog(this, tr("Export pattern"), "",
+		tr("XML pattern file (*.xpt *.xptz)"));
 
 	exportDialog.setAcceptMode(FileDialog::AcceptSave);
 
@@ -4881,7 +4881,7 @@ void PianoRollWindow::importPattern()
 		return;
 	}
 
-	FileDialog importDialog(this, tr("Open Pattern"), "",
+	FileDialog importDialog(this, tr("Open pattern"), "",
 		tr("XML pattern file (*.xpt *.xptz)"));
 	importDialog.setFileMode(FileDialog::ExistingFile);
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4932,7 +4932,7 @@ void PianoRollWindow::importPattern()
 		}
 		f.close();
 
-		int pos = m_editor->m_pattern->startPosition(); // Backup position in timeline.
+		TimePos pos = m_editor->m_pattern->startPosition(); // Backup position in timeline.
 
 		m_editor->m_pattern->loadSettings(doc.documentElement());
 		m_editor->m_pattern->movePosition(pos);

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -39,8 +39,6 @@
 #include <QStyleOption>
 #include <QtMath>
 #include <QToolButton>
-#include <QTextStream>
-#include <QToolButton>
 
 #ifndef __USE_XOPEN
 #define __USE_XOPEN

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4890,7 +4890,7 @@ void PianoRollWindow::importPattern()
 
 	FileDialog importDialog(this, tr("Open Pattern"), "",
 		tr("XML pattern file (*.xpt *.xptz)"));
-	importDialog.setFileMode(FileDialog::ExistingFiles);
+	importDialog.setFileMode(FileDialog::ExistingFile);
 
 	if (importDialog.exec() == QDialog::Accepted &&
 		!importDialog.selectedFiles().isEmpty())


### PR DESCRIPTION
Continuation of https://github.com/LMMS/lmms/pull/5197

This makes it possible to export and import patterns. They will be saved to a XML document. Currently with the file-extension `.xpt` and `.xtpz` for compressed files.

Closes https://github.com/LMMS/lmms/issues/3393