### PR TITLE
Improves the PianoRoll detuning drawing

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -405,7 +405,7 @@ private:
 
 	void copyToClipboard(const NoteVector & notes ) const;
 
-	void drawDetuningInfo( QPainter & _p, const Note * _n, int _x, int _y ) const;
+	void drawDetuningInfo(QPainter & p, const Note * n, int x, int y) const;
 	bool mouseOverNote();
 	Note * noteUnderMouse();
 


### PR DESCRIPTION
This PR rewrites the detuning drawing method of the PianoRoll to behave similar to the AutomationEditor. It now draws Cubic Hermite progressions as well, and the detuning is displayed as a shape instead of a line.

The color of the detuning shape is the same as `m_noteColor`, except it's lighter and has some alpha.

![Detuning](https://user-images.githubusercontent.com/22241596/109690372-0920f400-7b65-11eb-9b7e-ad4f85de27bc.png)

There's one visual glitch left to fix, which is also present in `master`: Changes to the automation node's outValues don't immediately trigger a repaint on the PianoRoll, because they are done directly on the `AutomationNode` class which doesn't emit the `dataChanged()` signal on the Automation Pattern. This is an easy fix, once it's decided how to approach it. Waiting for some opinions on the Discord channel before working on the fix.