### PR TITLE
Added a null check before checking the flag of an instrument

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -106,7 +106,7 @@ NotePlayHandle::NotePlayHandle( InstrumentTrack* instrumentTrack,
 		m_instrumentTrack->midiNoteOn( *this );
 	}
 
-	if( m_instrumentTrack->instrument()->flags() & Instrument::IsSingleStreamed )
+	if(m_instrumentTrack->instrument() && m_instrumentTrack->instrument()->flags() & Instrument::IsSingleStreamed )
 	{
 		setUsesBuffer( false );
 	}


### PR DESCRIPTION
I added this check because else LMMS would crash if a track had no instrument, when we want to add midi notes, this is unlikely to happen for standard InstrumentTracks but is still important, as it caused crashes during my development of a new type of track for vocal instruments.