### PR TITLE
Fixes small bug on #5848

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -442,6 +442,7 @@ PianoRoll::PianoRoll() :
 	m_snapModel.addItem(tr("Nudge"));
 	m_snapModel.addItem(tr("Snap"));
 	m_snapModel.setValue(0);
+	changeSnapMode();
 	connect(&m_snapModel, SIGNAL(dataChanged()),
 		this, SLOT(changeSnapMode()));
 


### PR DESCRIPTION
`m_gridMode` was not being initialized on the PianoRoll constructor. For that reason the first note drag without changing the GridMode would result in m_gridMode being used unintialized and neither the Snap nor Nudge mode being used. Here, the result  of this was a note being moved unquantized.

This fixes it by calling changeSnapMode() after setting up the snapModel on the constructor.