### PR TITLE
Save Piano Roll's behavior at stop state

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -118,6 +118,11 @@ public:
 		return m_behaviourAtStop;
 	}
 
+	void setBehaviourAtStop (int state)
+	{
+		emit loadBehaviourAtStop (state);
+	}
+
 	bool loopPointsEnabled() const
 	{
 		return m_loopPoints == LoopPointsEnabled;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5085,6 +5085,8 @@ void PianoRollWindow::saveSettings( QDomDocument & doc, QDomElement & de )
 		de.appendChild(markedSemiTonesRoot);
 	}
 
+	de.setAttribute("stopbehaviour", m_editor->m_timeLine->behaviourAtStop());
+
 	MainWindow::saveWidgetState( this, de );
 }
 
@@ -5097,6 +5099,8 @@ void PianoRollWindow::loadSettings( const QDomElement & de )
 	m_editor->loadMarkedSemiTones(de.firstChildElement("markedSemiTones"));
 
 	MainWindow::restoreWidgetState( this, de );
+
+	m_editor->m_timeLine->setBehaviourAtStop(de.attribute("stopbehaviour").toInt());
 
 	// update margins here because we're later in the startup process
 	// We can't earlier because everything is still starting with the


### PR DESCRIPTION
Fixes #5938.

For some reason this seems to affect only the behavior at stop state, and not the loop points. My workaround was to save the state as an element in the piano roll, however suggestions are welcome.