### PR TITLE
Enhanced quantize in PianoRoll

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -484,7 +484,7 @@ QToolButton#stopButton {
 
 /* all tool buttons */
 
-QToolButton {
+QToolButton, QToolButton::menu-button {
 	padding: 1px 1px 1px 1px;
 	border-radius: 5px;
 	border: 1px solid rgba(63, 63, 63, 128);
@@ -508,6 +508,22 @@ QToolButton:checked  {
 	background: qradialgradient(cx:0.3, cy:0.3, radius:0.8, fx:0.3, fy:0.3, stop:0 #e0e0e0, stop:0.8 #c9c9c9, stop:1 #c0c0c0 );
 	padding: 2px 1px 0px 1px;
 	color: black;
+}
+
+/* buttons with combined menu */
+
+QToolButton[popupMode="1"] {
+	margin-right: 11px;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
+QToolButton::menu-button {
+	subcontrol-origin: margin;
+	width: 11px;
+	padding: 0;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 /* track label buttons - the part that contains the icon and track title */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -526,16 +526,16 @@ QToolButton:checked {
 
 QToolButton[popupMode="1"] {
 	margin-right: 13px;
-	border-top-right-radius: 0px;
-	border-bottom-right-radius: 0px;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 QToolButton::menu-button {
 	subcontrol-origin: margin;
 	width: 13px;
-	padding: 0px;
-	border-top-left-radius: 0px;
-	border-bottom-left-radius: 0px;
+	padding: 0;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 /* track label buttons - the part that contains the icon and track title */

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -490,7 +490,7 @@ QToolBar::separator {
 
 /* all tool buttons */
 
-QToolButton {
+QToolButton, QToolButton::menu-button {
 	margin: 1px;
 	padding: 2px 2px 2px 2px;
 	border-top: 1px solid #778394;
@@ -520,6 +520,22 @@ QToolButton:checked {
 	border-bottom: 1px solid #4a515e;
 	background: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #1b1f22, stop:1 #13161a);
 	background-image: url(resources:shadow_p.png);
+}
+
+/* buttons with combined menu */
+
+QToolButton[popupMode="1"] {
+	margin-right: 13px;
+	border-top-right-radius: 0px;
+	border-bottom-right-radius: 0px;
+}
+
+QToolButton::menu-button {
+	subcontrol-origin: margin;
+	width: 13px;
+	padding: 0px;
+	border-top-left-radius: 0px;
+	border-bottom-left-radius: 0px;
 }
 
 /* track label buttons - the part that contains the icon and track title */

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -142,6 +142,13 @@ public:
 	int quantization() const;
 
 protected:
+	enum QuantizeActions
+	{
+		QuantizeBoth,
+		QuantizePos,
+		QuantizeLength
+	};
+
 	void keyPressEvent( QKeyEvent * ke ) override;
 	void keyReleaseEvent( QKeyEvent * ke ) override;
 	void leaveEvent( QEvent * e ) override;
@@ -198,7 +205,7 @@ protected slots:
 	void quantizeChanged();
 	void noteLengthChanged();
 	void keyChanged();
-	void quantizeNotes();
+	void quantizeNotes(QuantizeActions mode = QuantizeBoth);
 
 	void updateSemiToneMarkerMenu();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4554,7 +4554,7 @@ int PianoRoll::quantization() const
 }
 
 
-void PianoRoll::quantizeNotes()
+void PianoRoll::quantizeNotes(QuantizeActions mode)
 {
 	if( ! hasValidPattern() )
 	{
@@ -4582,8 +4582,15 @@ void PianoRoll::quantizeNotes()
 
 		Note copy(*n);
 		m_pattern->removeNote( n );
-		copy.quantizePos( quantization() );
-		m_pattern->addNote( copy );
+		if (mode == QuantizeBoth || mode == QuantizePos)
+		{
+			copy.quantizePos(quantization());
+		}
+		if (mode == QuantizeBoth || mode == QuantizeLength)
+		{
+			copy.quantizeLength(quantization());
+		}
+		m_pattern->addNote(copy, false);
 	}
 
 	update();
@@ -4704,15 +4711,30 @@ PianoRollWindow::PianoRollWindow() :
 
 	connect( editModeGroup, SIGNAL( triggered( int ) ), m_editor, SLOT( setEditMode( int ) ) );
 
-	QAction* quantizeAction = new QAction(embed::getIconPixmap( "quantize" ), tr( "Quantize" ), this );
-	connect( quantizeAction, SIGNAL( triggered() ), m_editor, SLOT( quantizeNotes() ) );
+	// Quantize combo button
+	QToolButton *quantizeButton = new QToolButton(notesActionsToolBar);
+	QMenu *quantizeButtonMenu = new QMenu(quantizeButton);
+
+	QAction *quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
+	QAction *quantizePosAction = new QAction(tr("Quantize positions"), this);
+	QAction *quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
+
+	connect(quantizeAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(); });
+	connect(quantizePosAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(PianoRoll::QuantizePos); });
+	connect(quantizeLengthAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(PianoRoll::QuantizeLength); });
+
+	quantizeButton->setPopupMode(QToolButton::MenuButtonPopup);
+	quantizeButton->setDefaultAction(quantizeAction);
+	quantizeButton->setMenu(quantizeButtonMenu);
+	quantizeButtonMenu->addAction(quantizePosAction);
+	quantizeButtonMenu->addAction(quantizeLengthAction);
 
 	notesActionsToolBar->addAction( drawAction );
 	notesActionsToolBar->addAction( eraseAction );
 	notesActionsToolBar->addAction( selectAction );
 	notesActionsToolBar->addAction( pitchBendAction );
 	notesActionsToolBar->addSeparator();
-	notesActionsToolBar->addAction( quantizeAction );
+	notesActionsToolBar->addWidget(quantizeButton);
 
 	// Copy + paste actions
 	DropToolBar *copyPasteActionsToolBar =  addDropToolBarToTop( tr( "Copy paste controls" ) );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4712,12 +4712,12 @@ PianoRollWindow::PianoRollWindow() :
 	connect( editModeGroup, SIGNAL( triggered( int ) ), m_editor, SLOT( setEditMode( int ) ) );
 
 	// Quantize combo button
-	QToolButton *quantizeButton = new QToolButton(notesActionsToolBar);
-	QMenu *quantizeButtonMenu = new QMenu(quantizeButton);
+	QToolButton* quantizeButton = new QToolButton(notesActionsToolBar);
+	QMenu* quantizeButtonMenu = new QMenu(quantizeButton);
 
-	QAction *quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
-	QAction *quantizePosAction = new QAction(tr("Quantize positions"), this);
-	QAction *quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
+	QAction* quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
+	QAction* quantizePosAction = new QAction(tr("Quantize positions"), this);
+	QAction* quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
 
 	connect(quantizeAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(); });
 	connect(quantizePosAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(PianoRoll::QuantizePos); });


### PR DESCRIPTION
- Change Quantize button to alter _both_ positions and lengths of notes
- Put "Quantize positions" (the current functionality) in a dropdown menu
- Add "Quantize lengths" to the dropdown
- Style change for combinated button/dropdown menu

This is cherry picked from #5702.

![bild](https://user-images.githubusercontent.com/7693838/111029504-35f2c800-83fd-11eb-9691-60c523128209.png)

### Styling bug?

I can't get styling of combined button/dropdown to work as I want. Maybe it's impossible to get the way I want, since the arrow is a subcontrol if the button. Qt CSS experts will understand. This is how styling of buttons with a menu arrow behaves currently:

| Event | Style of button | Style of arrow |
|---|---|---|
|Hovering button|`hover`|`hover`|
|Clicking button|`pressed`|`pressed`|
|Hovering arrow|`hover`|`pressed` (!!!)|
|Clicking arrow|`pressed`|`pressed`|

My solution is to let the arrow have the same style, no matter hover or press. This way it stands of from the main button when hovering it, but the weird behavior is not displayed.