### PR TITLE
Allow assigning all tracks from a BBTrack to a FX channel

### DIFF
--- a/include/BBTrack.h
+++ b/include/BBTrack.h
@@ -168,10 +168,16 @@ public:
 		return( m_bbTrack );
 	}
 
+	// Create menu to assign all tracks from the BBTrack to a FX channel
+	QMenu* createFxMenu(QString title, QString newFxLabel) override;
 
 public slots:
 	void clickedTrackLabel();
 
+
+private slots:
+	void createFxLine();
+	void assignFxLine(int channelIndex);
 
 private:
 	BBTrack * m_bbTrack;

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -551,7 +551,7 @@ void BBTrackView::clickedTrackLabel()
 QMenu* BBTrackView::createFxMenu(QString title, QString newFxLabel)
 {
 	// We have a different title for BB Tracks
-	QMenu* fxMenu = new QMenu("Assign BBTrack to FX channel");
+	QMenu* fxMenu = new QMenu(tr("Assign all to FX channel"));
 
 	fxMenu->addAction(newFxLabel, this, SLOT(createFxLine()));
 	fxMenu->addSeparator();

--- a/src/tracks/BBTrack.cpp
+++ b/src/tracks/BBTrack.cpp
@@ -31,11 +31,15 @@
 #include "BBTrackContainer.h"
 #include "embed.h"
 #include "Engine.h"
+#include "FxMixer.h"
+#include "FxMixerView.h"
 #include "gui_templates.h"
 #include "GuiApplication.h"
+#include "InstrumentTrack.h"
 #include "MainWindow.h"
 #include "Mixer.h"
 #include "RenameDialog.h"
+#include "SampleTrack.h"
 #include "Song.h"
 #include "SongEditor.h"
 #include "ToolTip.h"
@@ -542,4 +546,64 @@ void BBTrackView::clickedTrackLabel()
 	Engine::getBBTrackContainer()->setCurrentBB( m_bbTrack->index() );
 	gui->getBBEditor()->parentWidget()->show();
 	gui->getBBEditor()->setFocus( Qt::ActiveWindowFocusReason );
+}
+
+QMenu* BBTrackView::createFxMenu(QString title, QString newFxLabel)
+{
+	// We have a different title for BB Tracks
+	QMenu* fxMenu = new QMenu("Assign BBTrack to FX channel");
+
+	fxMenu->addAction(newFxLabel, this, SLOT(createFxLine()));
+	fxMenu->addSeparator();
+
+	for (int i = 0; i < Engine::fxMixer()->numChannels(); ++i)
+	{
+		FxChannel* curFX = Engine::fxMixer()->effectChannel(i);
+
+		auto index = curFX->m_channelIndex;
+
+		QString label = tr("FX: %1: %2").arg(index).arg(curFX->m_name);
+
+		fxMenu->addAction(label, [this, index](){
+			assignFxLine(index);
+		});
+	}
+
+	return fxMenu;
+}
+
+void BBTrackView::createFxLine()
+{
+	int channelIndex = gui->fxMixerView()->addNewChannel();
+	auto channel = Engine::fxMixer()->effectChannel(channelIndex);
+
+	channel->m_name = getBBTrack()->name();
+	if (getTrack()->useColor()) { channel->setColor(getTrack()->color()); }
+
+	assignFxLine(channelIndex);
+}
+
+void BBTrackView::assignFxLine(int channelIndex)
+{
+	// Assign all tracks to channel:
+	TrackContainer::TrackList tl = Engine::getBBTrackContainer()->tracks();
+
+	for
+	(
+		TrackContainer::TrackList::iterator it = tl.begin();
+		it != tl.end();
+		++it
+	)
+	{
+		if((*it)->type() == Track::TrackTypes::InstrumentTrack)
+		{
+			InstrumentTrack* t = dynamic_cast<InstrumentTrack*>(*it);
+			if (t) { t->effectChannelModel()->setValue(channelIndex); }
+		}
+		else if ((*it)->type() == Track::TrackTypes::SampleTrack)
+		{
+			SampleTrack* t = dynamic_cast<SampleTrack*>(*it);
+			if (t) { t->effectChannelModel()->setValue(channelIndex); }
+		}
+	}
 }


### PR DESCRIPTION
I'm not sure people would actually find this useful, but at the beginning of production when I'm still working the drums inside the BBEditor I tend to change samples a lot and having them all grouped in a single FX channel (unless an individual sample needs some specific processing).

I wrote this so I could save some time assigning all the tracks from BBEditor to a particular FX channel. It works the same as the "Assign to FX channel" of regular tracks but it affects all tracks inside the BB. Opening a PR in case people find this would be a nice addition.