### PR TITLE
Use MEMBER, not WRITE for mouseHotspot Q_PROPERTYs

### DIFF
--- a/include/TrackContentObjectView.h
+++ b/include/TrackContentObjectView.h
@@ -57,8 +57,8 @@ class TrackContentObjectView : public selectableObject, public ModelView
 	Q_PROPERTY( bool gradient READ gradient WRITE setGradient )
 	// We have to use a QSize here because using QPoint isn't supported.
 	// width -> x, height -> y
-	Q_PROPERTY( QSize mouseHotspotHand WRITE setMouseHotspotHand )
-	Q_PROPERTY( QSize mouseHotspotKnife WRITE setMouseHotspotKnife )
+	Q_PROPERTY( QSize mouseHotspotHand MEMBER m_mouseHotspotHand )
+	Q_PROPERTY( QSize mouseHotspotKnife MEMBER m_mouseHotspotKnife )
 
 public:
 	TrackContentObjectView( TrackContentObject * tco, TrackView * tv );


### PR DESCRIPTION
Fixes warning in #5949