### PR TITLE
Drag and Drop exported note patterns into IntrumentTrack's.

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -220,6 +220,7 @@ public:
 		PatchFile,
 		MidiFile,
 		VstPluginFile,
+		PatternFile,
 		UnknownFile,
 		NumFileTypes
 	} ;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -719,6 +719,10 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 					new StringPairDrag( "projectfile", f->fullName(),
 							embed::getIconPixmap( "project_file" ), this );
 					break;
+				case FileItem::PatternFile:
+					new StringPairDrag("patternfile", f->fullName(),
+							embed::getIconPixmap("midi_file"), this);
+					break;
 
 				default:
 					break;
@@ -1207,6 +1211,9 @@ void FileItem::initPixmaps( void )
 		case MidiFile:
 			setIcon( 0, *s_midiFilePixmap );
 			break;
+		case PatternFile:
+			setIcon(0, *s_midiFilePixmap);
+			break;
 		case UnknownFile:
 		default:
 			setIcon( 0, *s_unknownFilePixmap );
@@ -1259,6 +1266,10 @@ void FileItem::determineFileType( void )
 	{
 		m_type = PresetFile;
 		m_handling = LoadByPlugin;
+	}
+	else if (ext == "xpt" || ext == "xptz")
+	{
+		m_type = PatternFile;
 	}
 	else
 	{


### PR DESCRIPTION
This makes it possible to drag exported note patterns (.xpt, .xptz) from the side-bar (file-browser) into a InstrumentTrack, it will be dropped as a new TCO. It works in both Song-Editor and BB-Editor.