### PR TITLE
Don't update m_positionLine in paintEvent

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3072,7 +3072,6 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			// otherwise we add height
 			else { m_notesEditHeight += partialKeyVisible; }
 		}
-		updatePositionLineHeight();
 		int x, q = quantization(), tick;
 
 		// draw vertical quantization lines


### PR DESCRIPTION
Fixes #5863 (for real this time)

This extra update in paintEvent was causing the misalignment in the piano keys (and actually anywhere the position line was in the window). There is still a very small glitch of the line height when resizing, but this is a small issue I can fix in another PR later.