### PR TITLE
Fix bug in the AutomationPattern copy-ctor

### DIFF
--- a/include/AutomationNode.h
+++ b/include/AutomationNode.h
@@ -130,6 +130,16 @@ public:
 		m_outTangent = tangent;
 	}
 
+	/**
+	 * @brief Sets the pattern this node belongs to
+	 * @param AutomationPattern* pattern that m_pattern will be
+	 * set to
+	 */
+	inline void setPattern(AutomationPattern* pat)
+	{
+		m_pattern = pat;
+	}
+
 private:
 	// Pattern that this node belongs to
 	AutomationPattern* m_pattern;

--- a/src/core/AutomationPattern.cpp
+++ b/src/core/AutomationPattern.cpp
@@ -91,6 +91,8 @@ AutomationPattern::AutomationPattern( const AutomationPattern & _pat_to_copy ) :
 	{
 		// Copies the automation node (in/out values and in/out tangents)
 		m_timeMap[POS(it)] = it.value();
+		// Sets the node's pattern to this one
+		m_timeMap[POS(it)].setPattern(this);
 	}
 	if (!getTrack()){ return; }
 	switch( getTrack()->trackContainer()->type() )


### PR DESCRIPTION
On the AutomationPattern copy constructor, the automation nodes were copied from the origin pattern but their "owner pattern" pointers weren't updated.

Thanks @DomClark for finding and reporting this bug.