### PR TITLE
Fix/improve includes/fwd decls

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -34,7 +34,6 @@
 #include "ValueBuffer.h"
 #include "MemoryManager.h"
 #include "ModelVisitor.h"
-#include "ControllerConnection.h"
 
 // simple way to map a property of a view to a model
 #define mapPropertyFromModelPtr(type,getfunc,setfunc,modelname)	\

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -28,6 +28,7 @@
 #include <QtCore/QMap>
 #include <QDomElement>
 
+class QMimeData;
 
 namespace Clipboard
 {

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -33,11 +33,11 @@
 #include <QtCore/QObject>
 #include <QtCore/QVector>
 
-#include "AutomatableModel.h"
 #include "Controller.h"
 #include "JournallingObject.h"
 #include "ValueBuffer.h"
 
+class AutomatableModel;
 class ControllerConnection;
 
 typedef QVector<ControllerConnection *> ControllerConnectionVector;

--- a/include/LocklessRingBuffer.h
+++ b/include/LocklessRingBuffer.h
@@ -28,6 +28,7 @@
 #include <QMutex>
 #include <QWaitCondition>
 
+#include "lmms_basics.h"
 #include "../src/3rdparty/ringbuffer/include/ringbuffer/ringbuffer.h"
 
 

--- a/include/MemoryHelper.h
+++ b/include/MemoryHelper.h
@@ -25,6 +25,8 @@
 #ifndef MEMORY_HELPER_H
 #define MEMORY_HELPER_H
 
+#include <cstddef>
+
 /**
  * Helper class to alocate aligned memory and free it.
  */

--- a/include/OutputSettings.h
+++ b/include/OutputSettings.h
@@ -26,6 +26,7 @@
 #ifndef OUTPUT_SETTINGS_H
 #define OUTPUT_SETTINGS_H
 
+#include "lmms_basics.h"
 
 class OutputSettings
 {

--- a/plugins/MidiImport/portsmf/algrd_internal.h
+++ b/plugins/MidiImport/portsmf/algrd_internal.h
@@ -1,5 +1,7 @@
 /* algread_internal.h -- interface between allegro.cpp and allegrord.cpp */
 
+#include "allegro.h"
+
 Alg_error alg_read(std::istream &file, Alg_seq_ptr new_seq, 
                    double *offset_ptr = NULL);
 

--- a/plugins/MidiImport/portsmf/algsmfrd_internal.h
+++ b/plugins/MidiImport/portsmf/algsmfrd_internal.h
@@ -1,3 +1,5 @@
 /* algsmfrd_internal.h -- interface from allegrosmfrd.cpp to allegro.cpp */
 
+#include "allegro.h"
+
 Alg_error alg_smf_read(std::istream &file, Alg_seq_ptr new_seq);

--- a/plugins/MidiImport/portsmf/allegro.h
+++ b/plugins/MidiImport/portsmf/allegro.h
@@ -49,6 +49,7 @@
 #ifndef ALLEGRO_H
 #define ALLEGRO_H
 #include <assert.h>
+#include <cstring>
 #include <istream>
 #include <ostream>
 

--- a/plugins/MidiImport/portsmf/mfmidi.h
+++ b/plugins/MidiImport/portsmf/mfmidi.h
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 #define NOTEOFF 0x80
 #define NOTEON 0x90
 #define PRESSURE 0xa0

--- a/plugins/peak_controller_effect/peak_controller_effect.h
+++ b/plugins/peak_controller_effect/peak_controller_effect.h
@@ -29,6 +29,8 @@
 #include "Effect.h"
 #include "peak_controller_effect_controls.h"
 
+class PeakController;
+
 class PeakControllerEffect : public Effect
 {
 public:

--- a/plugins/zynaddsubfx/RemoteZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/RemoteZynAddSubFx.cpp
@@ -29,7 +29,11 @@
 
 #include <queue>
 
+#include <FL/x.H>
+#undef CursorShape // is, by mistake, not undefed in FL
+
 #define BUILD_REMOTE_PLUGIN_CLIENT
+
 #include "Note.h"
 #include "RemotePlugin.h"
 #include "RemoteZynAddSubFx.h"
@@ -37,8 +41,6 @@
 
 #include "zynaddsubfx/src/Nio/Nio.h"
 #include "zynaddsubfx/src/UI/MasterUI.h"
-
-#include <FL/x.H>
 
 
 class RemoteZynAddSubFx : public RemotePluginClient, public LocalZynAddSubFx


### PR DESCRIPTION
Preparation for clang-format. It will shuffle the includes, and this
preparation will prevent errors from that step.

Review not required - no functional changes.