### PR TITLE
Fix bug introduced by #5657

### DIFF
--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -37,7 +37,6 @@
 #include "JournallingObject.h"
 #include "ValueBuffer.h"
 
-class AutomatableModel;
 class ControllerConnection;
 
 typedef QVector<ControllerConnection *> ControllerConnectionVector;
@@ -48,7 +47,7 @@ class LMMS_EXPORT ControllerConnection : public QObject, public JournallingObjec
 	Q_OBJECT
 public:
 
-	ControllerConnection(Controller * _controller, AutomatableModel * contmod);
+	ControllerConnection(Controller * _controller);
 	ControllerConnection( int _controllerId );
 
 	virtual ~ControllerConnection();
@@ -111,8 +110,6 @@ protected:
 	bool m_ownsController;
 
 	static ControllerConnectionVector s_connections;
-
-	AutomatableModel * m_controlledModel;
 
 signals:
 	// The value changed while the mixer isn't running (i.e: MIDI CC)

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -215,7 +215,7 @@ void AutomatableModel::loadSettings( const QDomElement& element, const QString& 
 		}
 		if( thisConnection.isElement() )
 		{
-			setControllerConnection(new ControllerConnection((Controller*)NULL, this));
+			setControllerConnection(new ControllerConnection(nullptr));
 			m_controllerConnection->loadSettings( thisConnection.toElement() );
 			//m_controllerConnection->setTargetName( displayName() );
 		}

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -36,11 +36,10 @@ ControllerConnectionVector ControllerConnection::s_connections;
 
 
 
-ControllerConnection::ControllerConnection(Controller * _controller, AutomatableModel * contmod) :
+ControllerConnection::ControllerConnection(Controller * _controller) :
 	m_controller( NULL ),
 	m_controllerId( -1 ),
-	m_ownsController(false),
-	m_controlledModel(contmod)
+	m_ownsController(false)
 {
 	if( _controller != NULL )
 	{
@@ -123,12 +122,6 @@ void ControllerConnection::setController( Controller * _controller )
 
 	m_ownsController =
 		(_controller->type() == Controller::MidiController);
-
-	connect(Engine::getSong(), SIGNAL(stopped()),
-		m_controlledModel, SLOT(setUseControllerValue()),
-			Qt::UniqueConnection);
-
-	m_controlledModel->setUseControllerValue(true);
 
 	// If we don't own the controller, allow deletion of controller
 	// to delete the connection

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -886,6 +886,9 @@ void Song::clearProject()
 	m_masterPitchModel.reset();
 	m_timeSigModel.reset();
 
+	// Clear the m_oldAutomatedValues AutomatedValueMap
+	m_oldAutomatedValues.clear();
+
 	AutomationPattern::globalAutomationPattern( &m_tempoModel )->clear();
 	AutomationPattern::globalAutomationPattern( &m_masterVolumeModel )->
 									clear();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -405,17 +405,15 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 		}
 	}
 
-	// Checks if an automated model stopped being automated by automation patterns
-	// so we can move the control back to any connected controller again
+	// Moves the control of the models that were processed earlier to their controllers.
+	// If they get processed again, setAutomatedValue() will move the control back
+	// to the automation.
 	if (!m_oldAutomatedValues.isEmpty())
 	{
 		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
 		{
 			AutomatableModel * am = it.key();
-			if (am->controllerConnection() && !values.contains(am))
-			{
-				am->setUseControllerValue(true);
-			}
+			am->setUseControllerValue(true);
 		}
 	}
 	m_oldAutomatedValues = values;
@@ -426,10 +424,6 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 		if (! recordedModels.contains(it.key()))
 		{
 			it.key()->setAutomatedValue(it.value());
-		}
-		else if (!it.key()->useControllerValue())
-		{
-			it.key()->setUseControllerValue(true);
 		}
 	}
 }
@@ -686,6 +680,18 @@ void Song::stop()
 
 	// remove all note-play-handles that are active
 	Engine::mixer()->clear();
+
+	// Moves the control of the models that were processed on the last frame
+	// back to their controllers.
+	if (!m_oldAutomatedValues.isEmpty())
+	{
+		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
+		{
+			AutomatableModel * am = it.key();
+			am->setUseControllerValue(true);
+		}
+	}
+	m_oldAutomatedValues.clear();
 
 	m_playMode = Mode_None;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -407,15 +407,12 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 
 	// Checks if an automated model stopped being automated by automation patterns
 	// so we can move the control back to any connected controller again
-	if (!m_oldAutomatedValues.isEmpty())
+	for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
 	{
-		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
+		AutomatableModel * am = it.key();
+		if (am->controllerConnection() && !values.contains(am))
 		{
-			AutomatableModel * am = it.key();
-			if (am->controllerConnection() && !values.contains(am))
-			{
-				am->setUseControllerValue(true);
-			}
+			am->setUseControllerValue(true);
 		}
 	}
 	m_oldAutomatedValues = values;
@@ -692,13 +689,10 @@ void Song::stop()
 
 	// Moves the control of the models that were processed on the last frame
 	// back to their controllers.
-	if (!m_oldAutomatedValues.isEmpty())
+	for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
 	{
-		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
-		{
-			AutomatableModel * am = it.key();
-			am->setUseControllerValue(true);
-		}
+		AutomatableModel * am = it.key();
+		am->setUseControllerValue(true);
 	}
 	m_oldAutomatedValues.clear();
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -639,6 +639,9 @@ void Song::stop()
 		return;
 	}
 
+	// To avoid race conditions with the processing threads
+	Engine::mixer()->requestChangeInModel();
+
 	TimeLineWidget * tl = m_playPos[m_playMode].m_timeLine;
 	m_paused = false;
 	m_recording = true;
@@ -691,17 +694,17 @@ void Song::stop()
 	// back to their controllers.
 	if (!m_oldAutomatedValues.isEmpty())
 	{
-		Engine::mixer()->requestChangeInModel();
 		for (auto it = m_oldAutomatedValues.begin(); it != m_oldAutomatedValues.end(); it++)
 		{
 			AutomatableModel * am = it.key();
 			am->setUseControllerValue(true);
 		}
-		Engine::mixer()->doneChangeInModel();
 	}
 	m_oldAutomatedValues.clear();
 
 	m_playMode = Mode_None;
+
+	Engine::mixer()->doneChangeInModel();
 
 	emit stopped();
 	emit playbackStateChanged();

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -33,7 +33,6 @@
 #include "embed.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
-#include "Song.h"
 #include "StringPairDrag.h"
 #include "Clipboard.h"
 
@@ -229,7 +228,7 @@ void AutomatableModelViewSlots::execConnectionDialog()
 			// New
 			else
 			{
-				ControllerConnection* cc = new ControllerConnection(d.chosenController(), m);
+				ControllerConnection* cc = new ControllerConnection(d.chosenController());
 				m->setControllerConnection( cc );
 				//cc->setTargetName( m->displayName() );
 			}
@@ -251,12 +250,8 @@ void AutomatableModelViewSlots::removeConnection()
 
 	if( m->controllerConnection() )
 	{
-		disconnect(Engine::getSong(), SIGNAL(stopped()),
-			   m, SLOT(setUseControllerValue()));
-
 		delete m->controllerConnection();
 		m->setControllerConnection( NULL );
-		emit m->dataChanged();
 	}
 }
 


### PR DESCRIPTION
There was a bug introduced by #5657 where reloading a project and playing it could cause a Segmentation Fault crash. After some debugging, @DomClark tracked the issue to be likely a use-after-free being caused by m_oldAutomatedValues not being cleared when the project was loaded again.

This commit adds a line to clear the `m_oldAutomatedValues` map on `Song::clearProject()`, which is called from `Song::loadProject()`.