### PR TITLE
Fix for issue #5978, VU meters in FX mixer stuck when channel is muted.

### DIFF
--- a/src/gui/FxMixerView.cpp
+++ b/src/gui/FxMixerView.cpp
@@ -598,29 +598,19 @@ void FxMixerView::updateFaders()
 
 	for( int i = 0; i < m_fxChannelViews.size(); ++i )
 	{
-		const float opl = m_fxChannelViews[i]->m_fader->getPeak_L();
-		const float opr = m_fxChannelViews[i]->m_fader->getPeak_R();
 		const float fallOff = 1.25;
-		if( m->effectChannel(i)->m_peakLeft >= opl/fallOff )
-		{
-			m_fxChannelViews[i]->m_fader->setPeak_L( m->effectChannel(i)->m_peakLeft );
-			// Set to -1 so later we'll know if this value has been refreshed yet.
-			m->effectChannel(i)->m_peakLeft = -1;
-		}
-		else if( m->effectChannel(i)->m_peakLeft != -1 )
-		{
-			m_fxChannelViews[i]->m_fader->setPeak_L( opl/fallOff );
-		}
+		
+		m_fxChannelViews[i]->m_fader->setPeak_L(
+			qMax( m->effectChannel(i)->m_peakLeft,
+			      m_fxChannelViews[i]->m_fader->getPeak_L()/fallOff)
+			);
 
-		if( m->effectChannel(i)->m_peakRight >= opr/fallOff )
-		{
-			m_fxChannelViews[i]->m_fader->setPeak_R( m->effectChannel(i)->m_peakRight );
-			// Set to -1 so later we'll know if this value has been refreshed yet.
-			m->effectChannel(i)->m_peakRight = -1;
-		}
-		else if( m->effectChannel(i)->m_peakRight != -1 )
-		{
-			m_fxChannelViews[i]->m_fader->setPeak_R( opr/fallOff );
-		}
+		m_fxChannelViews[i]->m_fader->setPeak_R(
+			qMax( m->effectChannel(i)->m_peakRight,
+			      m_fxChannelViews[i]->m_fader->getPeak_R()/fallOff)
+			);
+
+		m->effectChannel(i)->m_peakLeft  = 0;
+		m->effectChannel(i)->m_peakRight = 0; 
 	}
 }


### PR DESCRIPTION
Throwing this to the wolves now, eventhough I know it'll need rebasing after the Great Reorganising. 

Tried my code in one channel and the old in another, with slow falloff to see the difference and I'd say it was minimal. Also tried with a larger buffer size and a faster falloff and didn't see any ill effects. I'm undoing a bugfix here, but I'm not sure about the bug...