### PR TITLE
Fix JACK MIDI dropping events when two events have the same time stamp.

### DIFF
--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -188,7 +188,7 @@ void MidiJack::JackMidiRead(jack_nframes_t nframes)
 	{
 		for(i=0; i<nframes; i++)
 		{
-			if((in_event.time == i) && (event_index < event_count))
+			while((in_event.time == i) && (event_index < event_count))
 			{
 				// lmms is setup to parse bytes coming from a device
 				// parse it byte by byte as it expects


### PR DESCRIPTION
As reported and debugged on Discord: JACK MIDI input has a tendency to drop events. 
Explanation: 
- ```jack_midi_event_get``` is called to get a new event at the end of the for loop, if ```in_event_time == i``` 
- ```i``` gets incremented for the next iteration. 
- If the newly fetched event has the same ```time``` as the previous one, the comparison will be false and remain so for the rest of the buffer. Any further events will be ignored.

I suggest turning the ```if``` into a ```while``` to handle all events with the same ```time```value.