### PR TITLE
Improve spectrum analyzer performance by caching most used computations

### DIFF
--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -567,6 +567,9 @@ float SaProcessor::getFreqRangeMax() const
 
 
 // Map frequency to pixel x position on a display of given width.
+// NOTE: Results of this function may be cached by SaSpectrumView. If you use
+// a new function call or variable that can affect results of this function,
+// make sure to also add it as a trigger for cache update in SaSpectrumView.
 float SaProcessor::freqToXPixel(float freq, unsigned int width) const
 {
 	if (m_controls->m_logXModel.value())

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -225,12 +225,9 @@ void SaProcessor::analyze(LocklessRingBuffer<sampleFrame> &ring_buffer)
 							if (band_end - band_start > 1.0)
 							{
 								// band spans multiple pixels: draw all pixels it covers
-								for (target = (int)band_start; target < (int)band_end; target++)
+								for (target = std::max((int)band_start, 0); target < band_end && target < waterfallWidth(); target++)
 								{
-									if (target >= 0 && target < waterfallWidth())
-									{
-										pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);
-									}
+									pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);
 								}
 								// save remaining portion of the band for the following band / pixel
 								// (in case the next band uses sub-pixel drawing)
@@ -265,12 +262,9 @@ void SaProcessor::analyze(LocklessRingBuffer<sampleFrame> &ring_buffer)
 						else
 						{
 							// Linear: always draws one or more pixels per band
-							for (target = (int)band_start; target < band_end; target++)
+							for (target = std::max((int)band_start, 0); target < band_end && target < waterfallWidth(); target++)
 							{
-								if (target >= 0 && target < waterfallWidth())
-								{
-									pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);
-								}
+								pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);
 							}
 						}
 					}

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "SaSpectrumView.h"
-#include <iostream>
+
 #include <algorithm>
 #include <cmath>
 #include <QMouseEvent>

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -52,7 +52,8 @@ SaSpectrumView::SaSpectrumView(SaControls *controls, SaProcessor *processor, QWi
 	m_cachedRangeMax(-1),
 	m_cachedLogX(true),
 	m_cachedDisplayWidth(0),
-	m_cachedBinCount(0)
+	m_cachedBinCount(0),
+	m_cachedSampleRate(0)
 {
 	setMinimumSize(360, 170);
 	setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
@@ -362,13 +363,15 @@ QPainterPath SaSpectrumView::makePath(std::vector<float> &displayBuffer, float r
 	float rangeMin = m_processor->getFreqRangeMin(m_controls->m_logXModel.value());
 	float rangeMax = m_processor->getFreqRangeMax();
 	if (rangeMin != m_cachedRangeMin || rangeMax != m_cachedRangeMax || m_displayWidth != m_cachedDisplayWidth ||
-		m_controls->m_logXModel.value() != m_cachedLogX || m_processor->binCount() + 1 != m_cachedBinCount)
+		m_controls->m_logXModel.value() != m_cachedLogX || m_processor->binCount() + 1 != m_cachedBinCount ||
+		m_processor->getSampleRate() != m_cachedSampleRate)
 	{
 		m_cachedRangeMin = rangeMin;
 		m_cachedRangeMax = rangeMax;
 		m_cachedDisplayWidth = m_displayWidth;
 		m_cachedLogX = m_controls->m_logXModel.value();
 		m_cachedBinCount = m_processor->binCount() + 1;
+		m_cachedSampleRate = m_processor->getSampleRate();
 		for (unsigned int n = 0; n < m_cachedBinCount; n++)
 		{
 			m_cachedBinToX[n] = freqToXPixel(binToFreq(n), m_displayWidth);

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -25,7 +25,7 @@
  */
 
 #include "SaSpectrumView.h"
-
+#include <iostream>
 #include <algorithm>
 #include <cmath>
 #include <QMouseEvent>
@@ -50,6 +50,7 @@ SaSpectrumView::SaSpectrumView(SaControls *controls, SaProcessor *processor, QWi
 	m_frozen(false),
 	m_cachedRangeMin(-1),
 	m_cachedRangeMax(-1),
+	m_cachedLogX(true),
 	m_cachedDisplayWidth(0),
 	m_cachedBinCount(0)
 {
@@ -360,12 +361,13 @@ QPainterPath SaSpectrumView::makePath(std::vector<float> &displayBuffer, float r
 	// Update the cache only when range or display width are changed.
 	float rangeMin = m_processor->getFreqRangeMin(m_controls->m_logXModel.value());
 	float rangeMax = m_processor->getFreqRangeMax();
-	if (rangeMin != m_cachedRangeMin || rangeMax != m_cachedRangeMax ||
-		m_displayWidth != m_cachedDisplayWidth || m_processor->binCount() + 1 != m_cachedBinCount)
+	if (rangeMin != m_cachedRangeMin || rangeMax != m_cachedRangeMax || m_displayWidth != m_cachedDisplayWidth ||
+		m_controls->m_logXModel.value() != m_cachedLogX || m_processor->binCount() + 1 != m_cachedBinCount)
 	{
 		m_cachedRangeMin = rangeMin;
 		m_cachedRangeMax = rangeMax;
 		m_cachedDisplayWidth = m_displayWidth;
+		m_cachedLogX = m_controls->m_logXModel.value();
 		m_cachedBinCount = m_processor->binCount() + 1;
 		for (unsigned int n = 0; n < m_cachedBinCount; n++)
 		{

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -125,6 +125,7 @@ private:
 	std::vector<float> m_cachedBinToX;
 	float m_cachedRangeMin;
 	float m_cachedRangeMax;
+	bool m_cachedLogX;
 	unsigned int m_cachedDisplayWidth;
 	unsigned int m_cachedBinCount;
 

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 #include <QPainterPath>
 #include <QWidget>
 
@@ -119,6 +120,12 @@ private:
 	unsigned int m_displayLeft;
 	unsigned int m_displayRight;
 	unsigned int m_displayWidth;
+
+	// cached frequency bin → x position conversion for better performance
+	std::vector<float> m_cachedBinToX;
+	float m_cachedRangeMin;
+	float m_cachedRangeMax;
+	unsigned int m_cachedDisplayWidth;
 
 	#ifdef SA_DEBUG
 		float m_execution_avg;

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -128,6 +128,7 @@ private:
 	bool m_cachedLogX;
 	unsigned int m_cachedDisplayWidth;
 	unsigned int m_cachedBinCount;
+	unsigned int m_cachedSampleRate;
 
 	#ifdef SA_DEBUG
 		float m_execution_avg;

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -126,6 +126,7 @@ private:
 	float m_cachedRangeMin;
 	float m_cachedRangeMax;
 	unsigned int m_cachedDisplayWidth;
+	unsigned int m_cachedBinCount;
 
 	#ifdef SA_DEBUG
 		float m_execution_avg;


### PR DESCRIPTION
As previously discussed on Discord, my first attempt at improving the spectrum view improved the performance by around 4 % and needed 16 extra lines, while making the code less readable. So it did not seem worthwhile to merge that.

But. People say there is no such thing as a free lunch, but after thinking about it a bit more, I was able to bump that to 22 lines and a 100 % performance improvement. If that's not close to a free lunch, I don't know what is.

Compared to the first attempt, I now moved the caching closer to the point of use and extended it to a full LUT of complete results, instead of just pre-computed parts of a formula. Before the optimization, the `QPainter` path building took 9.5 ms out of 13.5 ms for the whole redraw (stereo and peak hold enabled, default TripleOsc tone playing, default analyzer window size on a 4K screen). After the update, path build takes only 1.8 ms and and the full redraw is 6.5 ms (there is also an extra 0.7 ms difference, not sure where that came from). That is, the maximum FPS limit increased from 74 to 154, leaving much more headroom for other plugins and GUI elements.