### PR TITLE
Use standard configuration directories

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -645,7 +645,20 @@ void ConfigManager::initPortableWorkingDir()
 void ConfigManager::initInstalledWorkingDir()
 {
 	m_workingDir = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation) + "/lmms/";
-	m_lmmsRcFile = QDir::home().absolutePath() +"/.lmmsrc.xml";
+
+	// Try the legacy RC file location first
+	m_lmmsRcFile = QDir::home().absolutePath() + "/.lmmsrc.xml";
+
+	// If the RC file is not found, try the new location
+	if (!QFileInfo(m_lmmsRcFile).exists())
+	{
+		QString cfgDir = QStandardPaths::standardLocations(QStandardPaths::AppConfigLocation).at(0);
+		QDir dir;
+
+		dir.mkpath(cfgDir);
+		m_lmmsRcFile = cfgDir + "/lmmsrc.xml";
+	}
+
 	// Detect < 1.2.0 working directory as a courtesy
 	if ( QFileInfo( QDir::home().absolutePath() + "/lmms/projects/" ).exists() )
 		m_workingDir = QDir::home().absolutePath() + "/lmms/";


### PR DESCRIPTION
With this PR, the "lmmsrc.xml" file is stored in the platform's standard directory for configuration files, but the file at the legacy location is checked first for backwards compatibility.

According to the documentation at https://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum, the location is ``~/.config/<APPNAME>`` for Linux, ``C:/Users/<USER>/AppData/Local/<APPNAME>`` for Windows, and ``~/Library/Preferences/<APPNAME>` for macOS.

Closes #5869.

**Note:** tested only on Linux.