### PR TITLE
Switch loop marker shortcuts, add context menu

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -194,6 +194,9 @@ protected:
 
 
 private:
+	TimePos getPositionFromX(const int x) const;
+	void setLoopPoint(bool end, int x, bool unquantized=false);
+
 	static QPixmap * s_posMarkerPixmap;
 
 	QColor m_inactiveLoopColor;
@@ -241,8 +244,6 @@ private:
 		DragLoop,
 		SelectSongTCO,
 	} m_action;
-
-	int m_moveXOff;
 
 
 signals:

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -190,6 +190,7 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void mouseMoveEvent( QMouseEvent * _me ) override;
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
+	void contextMenuEvent( QContextMenuEvent * _cme ) override;
 
 
 private:

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -194,6 +194,7 @@ protected:
 
 
 private:
+	void chooseMouseAction(QMouseEvent* event);
 	TimePos getPositionFromX(const int x) const;
 	void setLoopPoint(bool end, int x, bool unquantized=false);
 
@@ -237,12 +238,14 @@ private:
 	enum actions
 	{
 		NoAction,
+		Thresholded,
 		MovePositionMarker,
 		MoveLoopBegin,
 		MoveLoopEnd,
 		MoveLoopClosest,
 		DragLoop,
 		SelectSongTCO,
+		ShowContextMenu
 	} m_action;
 
 

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -236,6 +236,8 @@ private:
 		MovePositionMarker,
 		MoveLoopBegin,
 		MoveLoopEnd,
+		MoveLoopClosest,
+		DragLoop,
 		SelectSongTCO,
 	} m_action;
 

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -218,6 +218,7 @@ private:
 	int m_xOffset;
 	int m_posMarkerX;
 	float m_ppb;
+	float m_snapSize;
 	Song::PlayPos & m_pos;
 	const TimePos & m_begin;
 	const Song::PlayModes m_mode;

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -388,7 +388,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 		const bool quant = !(mods == (Qt::ControlModifier | Qt::ShiftModifier));
 		
 		m_loopPos[0] = quant ? t.quantize(m_snapSize) : t;
-		m_loopPos[1] = t + (quant ? TimePos::ticksPerBar() : 1);
+		m_loopPos[1] = m_loopPos[0] + (quant ? m_snapSize : 1);
 	}
 	
 	// Ensure that the loops beginning and end are stored in the right place
@@ -423,7 +423,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 	if (unquantized)
 	{
 		delete m_hint;
-		m_hint = NULL;
+		m_hint = nullptr;
 	}
 
 	switch (m_action)

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -312,6 +312,17 @@ void TimeLineWidget::paintEvent( QPaintEvent * )
 void TimeLineWidget::contextMenuEvent(QContextMenuEvent*)
 {
 	QMenu contextMenu(tr("Timeline"), this);
+
+	// TODO: Shortcut hints should be read from a config
+
+	QAction setStartPoint(tr("Loop start (shift + left click)"), this);
+	connect(&setStartPoint, &QAction::triggered, this, [this](){
+		setLoopPoint(0, m_initalXSelect);
+	});
+	QAction setEndPoint(tr("Loop end (shift + right click)"), this);
+	connect(&setEndPoint, &QAction::triggered, this, [this](){
+		setLoopPoint(1, m_initalXSelect);
+	});
 	QAction selectLoopPoints(tr("Select between loop points"), this);
 	connect(&selectLoopPoints, &QAction::triggered, this, [this](){
 		emit regionSelectedFromPixels(
@@ -320,6 +331,8 @@ void TimeLineWidget::contextMenuEvent(QContextMenuEvent*)
 		);
 		emit selectionFinished();
 	});
+	contextMenu.addAction(&setStartPoint);
+	contextMenu.addAction(&setEndPoint);
 	contextMenu.addAction(&selectLoopPoints);
 	contextMenu.exec(QCursor::pos());
 }
@@ -455,7 +468,7 @@ void TimeLineWidget::chooseMouseAction(QMouseEvent* event)
 
 	// TODO: Read these from a config
 	auto leftCtrlAction = SelectSongTCO;
-	auto rightCtrlAction = MoveLoopClosest;
+	auto rightCtrlAction = NoAction;
 	auto leftShiftAction = MoveLoopBegin;
 	auto rightShiftAction = MoveLoopEnd;
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -387,7 +387,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	{
 		const bool quant = !(mods == (Qt::ControlModifier | Qt::ShiftModifier));
 		
-		m_loopPos[0] = quant ? t.quantize(1.0) : t;
+		m_loopPos[0] = quant ? t.quantize(m_snapSize) : t;
 		m_loopPos[1] = t + (quant ? TimePos::ticksPerBar() : 1);
 	}
 	
@@ -447,7 +447,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 		{
 			const int i = m_action == MoveLoopBegin ? 0 : 1;
 			if (unquantized) { m_loopPos[i] = t; }
-			else { m_loopPos[i] = t.quantize(1.0); }
+			else { m_loopPos[i] = t.quantize(m_snapSize); }
 			// Catch begin == end
 			if (m_loopPos[0] == m_loopPos[1])
 			{
@@ -468,7 +468,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 		case DragLoop:
 		{
 			if (unquantized) { m_loopPos[1] = t; }
-			else { m_loopPos[1] = t.quantize(1.0); }
+			else { m_loopPos[1] = t.quantize(m_snapSize); }
 			update();
 			break;
 		}

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -466,6 +466,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 			if (unquantized) { m_loopPos[1] = t; }
 			else { m_loopPos[1] = t.quantize(1.0); }
 			update();
+			break;
 		}
 		case SelectSongTCO:
 			emit regionSelectedFromPixels(m_initalXSelect , event->x());

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -331,7 +331,7 @@ void TimeLineWidget::contextMenuEvent(QContextMenuEvent*)
 void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 {
 	// TODO: Read these from a config
-	auto leftCtrlAction = DragLoop;
+	auto leftCtrlAction = SelectSongTCO;
 	auto rightCtrlAction = MoveLoopClosest;
 	auto leftShiftAction = MoveLoopBegin;
 	auto rightShiftAction = MoveLoopEnd;

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -393,7 +393,6 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	if (m_action == SelectSongTCO || m_action == DragLoop)
 	{
 		m_initalXSelect = event->x();
-		if (m_action == DragLoop){  }
 	}
 
 	// Notify the user if they can disable quantization
@@ -470,7 +469,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 		}
 		case SelectSongTCO:
 			emit regionSelectedFromPixels(m_initalXSelect , event->x());
-		break;
+			break;
 
 		default:
 			break;


### PR DESCRIPTION
See #5505 and #6014

This PR now halfway-implements remappable loop marker controls, with limitations:
- Unmodified LMB and RMB are reserved (playhead, context menu)
- All combinations of Shift/Control and LMB/RMB can be assigned an action. For applicable actions (everything except selecting TCOs), this will be quantized
- Shift + Control + click is used for the unquantized version of Shift + Click actions

#### Future enhancements

- Bindings are currently assigned in code, but should be exposed via the UI. I'm not sure it's wise to add this to the current settings menu, so this might involve rewriting it or adding a new menu for keybindings.
- Allow the loop section to be shifted as a whole. Could be part of the drag loop mode.
- Populate the context menu, it currently only contains "select between loop markers".
  - Fit loop markers to selection
  - Zoom to loop/selection/song
  - Quantize loop marker length, start, end, start + end
  - Double/halve loop length

#### Proposed default shortcuts:
LMB: Move playhead
RMB: Open context menu

Ctrl + LMB: Group select
Ctrl + RMB: Mean select

Shift + LMB: Loop Start
Shift + RMB: Loop End

Holding both modifiers disables snapping. If both are held at the start of the action, the shift action is selected.