### PR TITLE
Fix CONTRIBUTORS and .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,4 +1,4 @@
-Alexandre Almeida <wilsalx@gmail.com> <meta.lx@hotmail.com>
+Alexandre Almeida <wilsalx@gmail.com>
 Tobias Junghans <tobias.doerffel@gmail.com>
 Dave French <dave.french3@googlemail.com>
 Paul Giblock <drfaygo@gmail.com> <pgib@users.sf.net>

--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -15,7 +15,7 @@ Michael Gregorius <michael.gregorius.git@arcor.de>
 grejppi <grejppi@gmail.com>
 Javier Serrano Polo <javier@jasp.net>
 Wong Cho Ching <chwong249664@yahoo.com>
-Alexandre Almeida <wilsalx@gmail.com>
+Alexandre Almeida (M374LX) <wilsalx@gmail.com>
 Daniel Winzen <d@winzen4.de>
 LMMS Service Account <lmms.service@gmail.com>
 Steffen Baranowsky <BaraMGB@freenet.de>
@@ -31,7 +31,6 @@ Andreas Brandmaier <andy@brandmaier.de>
 Fastigium <fastigiummusic@gmail.com>
 Amadeus Folego <amadeusfolego@gmail.com>
 Jonas Trappenberg <jonas@trappenberg.ch>
-M374LX <wilsalx@gmail.com>
 DomClark <mrdomclark@gmail.com>
 grindhold <grindhold@gmx.net>
 Mike Choi <rdavidian71@gmail.com>
@@ -58,7 +57,6 @@ mikobuntu <chrissy.mc.1@hotmail.co.uk>
 Andrés <andresbb@gmail.com>
 Matthew Krafczyk <krafczyk.matthew@gmail.com>
 mohamed <mohamed@amaksoud.com>
-Alexandre <wilson@wil-pc>
 RebeccaDeField <rebeccadefield@gmail.com>
 Yann Collette <ycollette.nospam@free.fr>
 Aya Morisawa <AyaMorisawa4869@gmail.com>


### PR DESCRIPTION
On CONTRIBUTORS, remove duplicates.

On .mailmap, remove an ancient address.