### PR TITLE
Default to FLAC compression level 5

### DIFF
--- a/include/OutputSettings.h
+++ b/include/OutputSettings.h
@@ -74,7 +74,7 @@ public:
 		m_bitRateSettings(bitRateSettings),
 		m_bitDepth(bitDepth),
 		m_stereoMode(stereoMode),
-		m_compressionLevel(0.5)
+		m_compressionLevel(0.625) // 5/8
 	{
 	}
 

--- a/src/gui/ExportProjectDialog.cpp
+++ b/src/gui/ExportProjectDialog.cpp
@@ -92,7 +92,7 @@ ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 			QVariant(i/static_cast<double>(MAX_LEVEL))
 		);
 	}
-	compLevelCB->setCurrentIndex(MAX_LEVEL/2);
+	compLevelCB->setCurrentIndex(5);
 #ifndef LMMS_HAVE_SF_COMPLEVEL
 	// Disable this widget; the setting would be ignored by the renderer.
 	compressionWidget->setVisible(false);


### PR DESCRIPTION
To be consistent with the default of the official encoder (flac), libsndfile, Audacity, FL Studio, and probably others too.

https://github.com/libsndfile/libsndfile/blob/62b7fb3b35ef8a0519af6af90d38981366d4665c/src/flac.c#L42
https://github.com/audacity/audacity/blob/8f41dd7a3854a66678911915b8e158712d21eb1f/src/export/ExportFLAC.cpp#L116

The extra level of compression might make some users happy. See #6049 for example.

The following `flac --help` output highlights the parameters of the current level and the proposed one.
![help](https://user-images.githubusercontent.com/25503477/121761024-a512b200-cafb-11eb-949a-20a358e54ca4.png)