### PR TITLE
WIP: Piano Roll mouse refactor + extras

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -41,6 +41,7 @@
 #include "StepRecorder.h"
 #include "StepRecorderWidget.h"
 #include "PositionLine.h"
+#include "InstrumentFunctions.h"
 
 class QPainter;
 class QPixmap;
@@ -243,7 +244,8 @@ private:
 		ActionSelectNotes,
 		ActionChangeNoteProperty,
 		ActionResizeNoteEditArea,
-		ActionKnife
+		ActionKnife,
+		ActionPlayKeys
 	};
 
 	enum NoteEditMode
@@ -311,6 +313,7 @@ private:
 	int selectionCount() const;
 	void testPlayNote( Note * n );
 	void testPlayKey( int _key, int _vol, int _pan );
+	void stopNotes();
 	void pauseTestNotes(bool pause = true );
 	void playChordNotes(int key, int velocity=-1);
 	void pauseChordNotes(int key);
@@ -356,6 +359,7 @@ private:
 	ComboBoxModel m_snapModel;
 
 	static QString m_lastChordName;
+	const InstrumentFunctionNoteStacking::Chord *m_lastChord;
 
 	static const QVector<float> m_zoomLevels;
 	static const QVector<float> m_zoomYLevels;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -239,6 +239,7 @@ private:
 	enum Actions
 	{
 		ActionNone,
+		ActionRemoveNote,
 		ActionMoveNote,
 		ActionResizeNote,
 		ActionSelectNotes,
@@ -434,8 +435,6 @@ private:
 	EditModes m_editMode;
 	EditModes m_ctrlMode; // mode they were in before they hit ctrl
 	EditModes m_knifeMode; // mode they where in before entering knife mode
-
-	bool m_mouseDownRight; //true if right click is being held down
 
 	TimeLineWidget * m_timeLine;
 	bool m_scrollBack;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -318,6 +318,7 @@ private:
 	void pauseTestNotes(bool pause = true );
 	void playChordNotes(int key, int velocity=-1);
 	void pauseChordNotes(int key);
+	void handleAftertouch(int key, int velocity);
 
 	void setKnifeAction();
 	void cancelKnifeAction();

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -277,6 +277,15 @@ private:
 	//	gridFree
 	};
 
+	enum PianoRollArea
+	{
+		Keys,
+		Notes,
+		NoteProperties,
+		EditMode,
+		EditAreaResize
+	};
+
 	PositionLine * m_positionLine;
 
 	QVector<QString> m_nemStr; // gui names of each edit mode
@@ -345,6 +354,8 @@ private:
 	ComboBoxModel m_scaleModel;
 	ComboBoxModel m_chordModel;
 	ComboBoxModel m_snapModel;
+
+	static QString m_lastChordName;
 
 	static const QVector<float> m_zoomLevels;
 	static const QVector<float> m_zoomYLevels;
@@ -434,6 +445,8 @@ private:
 	// turn a selection rectangle into selected notes
 	void computeSelectedNotes( bool shift );
 	void clearSelectedNotes();
+
+	PianoRollArea getPianoRollAreaIn(const int x, const int y);
 
 	// did we start a mouseclick with shift pressed
 	bool m_startedWithShift;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -333,6 +333,7 @@ private:
 	int keyAreaTop() const;
 	int noteEditRight() const;
 	int noteEditLeft() const;
+	int noteAreaWidth() const;
 
 	void dragNotes(int x, int y, bool alt, bool shift, bool ctrl);
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1647,7 +1647,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 		update();
 	}
 
-	const int key_num = getKey(mey);
+	const int keyNum = getKey(mey);
 
 
 	switch (pra)
@@ -1657,15 +1657,15 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 			// reference to last key needed for both
 			// right click (used for copy all keys on note)
 			// and for playing the key when left-clicked
-			//m_lastKey = key_num;
+			//m_lastKey = keyNum;
 
 			if (leftButton)
 			{
 				int v = static_cast<int>((static_cast<float>(mex) / m_whiteKeyWidth) * MidiDefaultVelocity);
-				testPlayKey(key_num, v, 0);
-				//m_pattern->instrumentTrack()->pianoModel()->handleKeyPress(key_num, v);
+				testPlayKey(keyNum, v, 0);
+				//m_pattern->instrumentTrack()->pianoModel()->handleKeyPress(keyNum, v);
 				// if a chord is set, play the chords notes as well:
-				//playChordNotes(key_num, v);
+				//playChordNotes(keyNum, v);
 				//mouseMoveEvent(me);
 				//update();
 			}
@@ -1681,7 +1681,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 		{
 			Note* n = noteUnderMouse(); // TODO: Rename to better name
 			// get tick in which the user clicked
-			const int pos_ticks = (mex - m_whiteKeyWidth) * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+			const int posTicks = (mex - m_whiteKeyWidth) * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 			switch (m_editMode)
 			{
@@ -1717,27 +1717,27 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 				{
 					if (leftButton)
 					{
-						bool is_new_note = false;
-						Note* created_new_note = nullptr;
+						bool isNewNote = false;
+						Note* createdNewNote = nullptr;
 						// did we click on a note or are we creating new?
 						if (n == nullptr) // create new note at mouse click position
 						{
-							is_new_note = true;
+							isNewNote = true;
 							m_pattern->addJournalCheckPoint();
 							// clear selection and select this new note
 							clearSelectedNotes();
 							// +32 to quanitize the note correctly when placing notes with
 							// the mouse.  We do this here instead of in note.quantized
 							// because live notes should still be quantized at the half.
-							TimePos note_pos(pos_ticks - (quantization() / 2));
-							TimePos note_len(newNoteLen());
+							TimePos notePos(posTicks - (quantization() / 2));
+							TimePos noteLen(newNoteLen());
 
 							// create new note and add to pattern
-							Note new_note(note_len, note_pos, key_num);
-							new_note.setSelected(true);
-							new_note.setPanning(m_lastNotePanning);
-							new_note.setVolume(m_lastNoteVolume);
-							created_new_note = m_pattern->addNote(new_note);
+							Note newNote(noteLen, notePos, keyNum);
+							newNote.setSelected(true);
+							newNote.setPanning(m_lastNotePanning);
+							newNote.setVolume(m_lastNoteVolume);
+							createdNewNote = m_pattern->addNote(newNote);
 
 							// check for chord draw
 							const InstrumentFunctionNoteStacking::Chord & chord =
@@ -1752,17 +1752,17 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 								{
 									if (m_startedWithShift) // arpeggio mode
 									{
-										note_pos += note_len;
+										notePos += noteLen;
 									}
-									Note new_note(note_len, note_pos, key_num + chord[i]);
-									new_note.setSelected(true);
-									new_note.setPanning(m_lastNotePanning);
-									new_note.setVolume(m_lastNoteVolume);
-									m_pattern->addNote(new_note);
+									Note newNote(noteLen, notePos, keyNum + chord[i]);
+									newNote.setSelected(true);
+									newNote.setPanning(m_lastNotePanning);
+									newNote.setVolume(m_lastNoteVolume);
+									m_pattern->addNote(newNote);
 								}
 							}
 
-							m_currentNote = created_new_note;
+							m_currentNote = createdNewNote;
 							m_lastNotePanning = m_currentNote->getPanning();
 							m_lastNoteVolume = m_currentNote->getVolume();
 							m_lenOfNewNotes = m_currentNote->length();
@@ -1773,7 +1773,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						m_mouseDownKey = m_startKey;
 						m_mouseDownTick = m_currentPosition;
 
-						// check if m_currentNote is still selected
+						// Check if m_currentNote is selected
+						// If user clicked in an unselected note it won't be
 						if (!m_currentNote->selected())
 						{
 							// clear notes and select this note
@@ -1781,7 +1782,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 							m_currentNote->setSelected(true);
 						}
 
-						// if we didn't click on a note or we did, get new bounding box
+						// Get new bounding box for the current selection
 						auto selectedNotes = getSelectedNotes();
 						m_moveBoundaryLeft = selectedNotes.first()->pos().getTicks();
 						m_moveBoundaryRight = selectedNotes.first()->endPos();
@@ -1800,7 +1801,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						}
 						printf("check tail\n");
 						// clicked at the "tail" of the note?
-						if( pos_ticks * m_ppb / TimePos::ticksPerBar() >
+						if( posTicks * m_ppb / TimePos::ticksPerBar() >
 								m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - RESIZE_AREA_WIDTH
 							&& m_currentNote->length() > 0 )
 						{
@@ -1836,7 +1837,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						}
 						else
 						{
-							if( ! created_new_note )
+							if( ! createdNewNote )
 							{
 								m_pattern->addJournalCheckPoint();
 							}
@@ -1848,7 +1849,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 							setCursor( Qt::SizeAllCursor );
 
 							// if they're holding shift, copy all selected notes
-							if( ! is_new_note && me->modifiers() & Qt::ShiftModifier )
+							if( ! isNewNote && me->modifiers() & Qt::ShiftModifier )
 							{
 								for (Note *note: selectedNotes)
 								{
@@ -1901,9 +1902,9 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 				{
 					if (leftButton) // select an area of notes
 					{
-						m_selectStartTick = pos_ticks;
+						m_selectStartTick = posTicks;
 						m_selectedTick = 0;
-						m_selectStartKey = key_num;
+						m_selectStartKey = keyNum;
 						m_selectedKeys = 1;
 						m_action = ActionSelectNotes;
 						printf("start ModeSelect\n");

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1933,11 +1933,31 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 					// we start a selection range with left click only
 					if (!leftButton) { break; }
 
-					m_selectStartTick = posTicks;
-					m_selectedTick = 0;
-					m_selectStartKey = keyNum;
-					m_selectedKeys = 1;
-					m_action = ActionSelectNotes;
+
+					// if we're over a note
+					if (mouseNote)
+					{
+						// we need to save previous values of selected notes to properly move notes
+						auto selectedNotes = getSelectedNotes();
+						for (Note* note : selectedNotes)
+						{
+							note->setOldKey(note->key());
+							note->setOldPos(note->pos());
+							note->setOldLength(note->length());
+						}
+						m_action = ActionMoveNote;
+						setCursor(Qt::SizeAllCursor);
+						testPlayNote(mouseNote);
+					}
+					else
+					{
+						m_selectStartTick = posTicks;
+						m_selectedTick = 0;
+						m_selectStartKey = keyNum;
+						m_selectedKeys = 1;
+
+						m_action = ActionSelectNotes;
+					}
 					// TODO: find a way to fix this glitch without calling mouseMoveEvent
 					// call mousemove to fix glitch where selection
 					// appears in wrong spot on mousedown

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2342,31 +2342,22 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent* me)
 			// Make sure vector is not empty
 			if (nv.size() > 0)
 			{
-				const Note* closest = nullptr;
-				int closestDist = 9999999;
+				Note* closest = nullptr;
+				// closestDist will be compared with all other note's distances to find
+				// the smallest, so we can set it to the first note's distance.
+				int closestDist = std::abs(nv.first()->pos().getTicks() - ticksMiddle);
 				// If we caught multiple notes and we're not editing a
 				// selection, find the closest...
 				if (nv.size() > 1 && !isSelection())
 				{
-					for (const Note* i : nv)
+					for (Note* i : nv)
 					{
-						const int dist = qAbs(i->pos().getTicks() - ticksMiddle);
-						if (dist < closestDist) { closest = i; closestDist = dist; }
+						const int dist = std::abs(i->pos().getTicks() - ticksMiddle);
+						if (dist <= closestDist) { closest = i; closestDist = dist; }
 					}
-					// ... then remove all notes from the vector that aren't on the same exact time
-					NoteVector::Iterator it = nv.begin();
-					while (it != nv.end())
-					{
-						const Note* note = *it;
-						if (note->pos().getTicks() != closest->pos().getTicks())
-						{
-							it = nv.erase(it);
-						}
-						else
-						{
-							it++;
-						}
-					}
+					// ... then we clear the vector and add just the closest note
+					nv.clear();
+					nv += closest;
 				}
 				enterValue(&nv);
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2306,7 +2306,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 
 
 
-void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
+void PianoRoll::mouseDoubleClickEvent(QMouseEvent* me)
 {
 	if (!hasValidPattern()) { return; }
 
@@ -2321,46 +2321,46 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 	{
 		case PianoRollArea::NoteProperties:
 		{
-			// get values for going through notes
-			int pixel_range = 4;
+			// Get values for going through notes
+			int pixelRange = 4;
 			int x = mex - m_whiteKeyWidth;
-			const int ticks_start = (x - pixel_range / 2) *
+			const int ticksStart = (x - pixelRange / 2) *
 						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-			const int ticks_end = (x + pixel_range / 2) *
+			const int ticksEnd = (x + pixelRange / 2) *
 						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-			const int ticks_middle = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+			const int ticksMiddle = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
-			// go through notes to figure out which one we want to change
+			// Go through notes to figure out which ones we want to change
 			NoteVector nv;
-			for ( Note * i : m_pattern->notes() )
+			for (Note* i : m_pattern->notes())
 			{
-				if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
+				if (i->withinRange(ticksStart, ticksEnd) || (i->selected() && !altPressed))
 				{
 					nv += i;
 				}
 			}
-			// make sure we're on a note
-			if( nv.size() > 0 )
+			// Make sure vector is not empty
+			if (nv.size() > 0)
 			{
-				const Note * closest = NULL;
-				int closest_dist = 9999999;
-				// if we caught multiple notes and we're not editing a
+				const Note* closest = nullptr;
+				int closestDist = 9999999;
+				// If we caught multiple notes and we're not editing a
 				// selection, find the closest...
-				if( nv.size() > 1 && !isSelection() )
+				if (nv.size() > 1 && !isSelection())
 				{
-					for ( const Note * i : nv )
+					for (const Note* i : nv)
 					{
-						const int dist = qAbs( i->pos().getTicks() - ticks_middle );
-						if( dist < closest_dist ) { closest = i; closest_dist = dist; }
+						const int dist = qAbs(i->pos().getTicks() - ticksMiddle);
+						if (dist < closestDist) { closest = i; closestDist = dist; }
 					}
 					// ... then remove all notes from the vector that aren't on the same exact time
 					NoteVector::Iterator it = nv.begin();
-					while( it != nv.end() )
+					while (it != nv.end())
 					{
-						const Note *note = *it;
-						if( note->pos().getTicks() != closest->pos().getTicks() )
+						const Note* note = *it;
+						if (note->pos().getTicks() != closest->pos().getTicks())
 						{
-							it = nv.erase( it );
+							it = nv.erase(it);
 						}
 						else
 						{
@@ -2368,7 +2368,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 						}
 					}
 				}
-				enterValue( &nv );
+				enterValue(&nv);
 			}
 			break;
 		}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2183,6 +2183,18 @@ void PianoRoll::testPlayKey( int key, int velocity, int pan )
 	playChordNotes(key, velocity);
 }
 
+void PianoRoll::handleAftertouch(int key, int velocity)
+{
+	if (m_lastChord && !m_lastChord->isEmpty())
+	{
+		for (int i = 0; i < m_lastChord->size(); ++i)
+		{
+			MidiEvent evt(MidiKeyPressure, -1, key + (*m_lastChord)[i], velocity);
+			m_pattern->instrumentTrack()->processInEvent(evt);
+		}
+	}
+}
+
 
 
 
@@ -2430,9 +2442,7 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 			}
 			else
 			{
-				MidiEvent evt(MidiKeyPressure, -1, yKey, v);
-				m_pattern->instrumentTrack()->processInEvent(evt);
-				// TODO: update chord notes
+				handleAftertouch(yKey, v);
 			}
 			break;
 		}


### PR DESCRIPTION
This is part of my continued effort to clean up the Piano Roll code to make it easier to maintain and read (and be faster), with help from @IanCaio. I wanted to open this now since most of the major work is done, and I'd like to start getting some testing and reviews. I'm certain there are some edge cases from the refactor that myself and Ian haven't found. Also if there are any suggestions for duplicated code that we can pull out into their own function would be helpful.

Quick summary of changes:
* organize code paths under switch statements depending on which duty or function is happening
* formatting code to new conventions
* pulling some code into their own functions
* adding fixes for #6020 #6028 #6058

My known issues:
* adjacent bug to #6020 - when zooming from a higher to lower value, auto-marked semitones have an off by one error (which fixes itself on the next paintEvent)