### PR TITLE
Remove 'using namespace std;' from LMMS headers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mjansson/rpmalloc.git
 [submodule "plugins/zynaddsubfx/zynaddsubfx"]
 	path = plugins/zynaddsubfx/zynaddsubfx
-	url = https://github.com/lmms/zynaddsubfx.git
+	url = https://github.com/irrenhaus3/zynaddsubfx.git
 [submodule "plugins/FreeBoy/game-music-emu"]
 	path = plugins/FreeBoy/game-music-emu
 	url = https://bitbucket.org/mpyne/game-music-emu.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mjansson/rpmalloc.git
 [submodule "plugins/zynaddsubfx/zynaddsubfx"]
 	path = plugins/zynaddsubfx/zynaddsubfx
-	url = https://github.com/irrenhaus3/zynaddsubfx.git
+	url = https://github.com/lmms/zynaddsubfx.git
 [submodule "plugins/FreeBoy/game-music-emu"]
 	path = plugins/FreeBoy/game-music-emu
 	url = https://bitbucket.org/mpyne/game-music-emu.git

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -32,7 +32,6 @@
 #include <QtCore/QtGlobal>
 
 #include <cmath>
-using namespace std;
 
 #ifndef exp10
 #define exp10(x) std::pow( 10.0, x )
@@ -220,10 +219,10 @@ static inline float logToLinearScale( float min, float max, float value )
 		const float mmax = qMax( qAbs( min ), qAbs( max ) );
 		const float val = value * ( max - min ) + min;
 		float result = signedPowf( val / mmax, F_E ) * mmax;
-		return isnan( result ) ? 0 : result;
+		return std::isnan( result ) ? 0 : result;
 	}
 	float result = powf( value, F_E ) * ( max - min ) + min;
-	return isnan( result ) ? 0 : result;
+	return std::isnan( result ) ? 0 : result;
 }
 
 
@@ -237,10 +236,10 @@ static inline float linearToLogScale( float min, float max, float value )
 	{
 		const float mmax = qMax( qAbs( min ), qAbs( max ) );
 		float result = signedPowf( valueLimited / mmax, EXP ) * mmax;
-		return isnan( result ) ? 0 : result;
+		return std::isnan( result ) ? 0 : result;
 	}
 	float result = powf( val, EXP ) * ( max - min ) + min;
-	return isnan( result ) ? 0 : result;
+	return std::isnan( result ) ? 0 : result;
 }
 
 
@@ -262,7 +261,7 @@ static inline float safeAmpToDbfs( float amp )
 //! @return Linear amplitude
 static inline float safeDbfsToAmp( float dbfs )
 {
-	return isinf( dbfs )
+	return std::isinf( dbfs )
 		? 0.0f
 		: exp10( dbfs * 0.05f );
 }

--- a/plugins/Compressor/Compressor.cpp
+++ b/plugins/Compressor/Compressor.cpp
@@ -328,7 +328,7 @@ bool CompressorEffect::processAudioBuffer(sampleFrame* buf, const fpp_t frames)
 			m_rmsVal[i] = m_rmsTimeConst * m_rmsVal[i] + ((1 - m_rmsTimeConst) * (inputValue * inputValue));
 
 			// Grab the peak or RMS value
-			inputValue = qMax(COMP_NOISE_FLOOR, peakmode ? abs(inputValue) : sqrt(m_rmsVal[i]));
+			inputValue = qMax(COMP_NOISE_FLOOR, peakmode ? std::abs(inputValue) : std::sqrt(m_rmsVal[i]));
 
 			// The following code uses math magic to semi-efficiently
 			// find the largest value in the lookahead buffer.

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -568,7 +568,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 		{
 			samplestoloopend = loopEnd - sample.sample->GetPos();
 			readsamples = sample.sample->Read( &buffer[totalreadsamples * sample.sample->FrameSize],
-					min( samplestoread, samplestoloopend ) );
+					std::min( samplestoread, samplestoloopend ) );
 			samplestoread -= readsamples;
 			totalreadsamples += readsamples;
 

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -137,7 +137,7 @@ public:
 		return m_pluginSubWindow.get();
 	}
 private:
-	unique_ptr<QMdiSubWindow> m_pluginSubWindow;
+	std::unique_ptr<QMdiSubWindow> m_pluginSubWindow;
 };
 
 

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -99,7 +99,7 @@ bool sanitize( sampleFrame * src, int frames )
 	{
 		for( int c = 0; c < 2; ++c )
 		{
-			if( isinf( src[f][c] ) || isnan( src[f][c] ) )
+			if( std::isinf( src[f][c] ) || std::isnan( src[f][c] ) )
 			{
 				#ifdef LMMS_DEBUG
 					printf("Bad data, clearing buffer. frame: ");
@@ -210,8 +210,8 @@ void addSanitizedMultipliedByBuffer( sampleFrame* dst, const sampleFrame* src, f
 
 	for( int f = 0; f < frames; ++f )
 	{
-		dst[f][0] += ( isinf( src[f][0] ) || isnan( src[f][0] ) ) ? 0.0f : src[f][0] * coeffSrc * coeffSrcBuf->values()[f];
-		dst[f][1] += ( isinf( src[f][1] ) || isnan( src[f][1] ) ) ? 0.0f : src[f][1] * coeffSrc * coeffSrcBuf->values()[f];
+		dst[f][0] += ( std::isinf( src[f][0] ) || std::isnan( src[f][0] ) ) ? 0.0f : src[f][0] * coeffSrc * coeffSrcBuf->values()[f];
+		dst[f][1] += ( std::isinf( src[f][1] ) || std::isnan( src[f][1] ) ) ? 0.0f : src[f][1] * coeffSrc * coeffSrcBuf->values()[f];
 	}
 }
 
@@ -226,10 +226,10 @@ void addSanitizedMultipliedByBuffers( sampleFrame* dst, const sampleFrame* src, 
 
 	for( int f = 0; f < frames; ++f )
 	{
-		dst[f][0] += ( isinf( src[f][0] ) || isnan( src[f][0] ) )
+		dst[f][0] += ( std::isinf( src[f][0] ) || std::isnan( src[f][0] ) )
 			? 0.0f
 			: src[f][0] * coeffSrcBuf1->values()[f] * coeffSrcBuf2->values()[f];
-		dst[f][1] += ( isinf( src[f][1] ) || isnan( src[f][1] ) )
+		dst[f][1] += ( std::isinf( src[f][1] ) || std::isnan( src[f][1] ) )
 			? 0.0f
 			: src[f][1] * coeffSrcBuf1->values()[f] * coeffSrcBuf2->values()[f];
 	}
@@ -243,8 +243,8 @@ struct AddSanitizedMultipliedOp
 
 	void operator()( sampleFrame& dst, const sampleFrame& src ) const
 	{
-		dst[0] += ( isinf( src[0] ) || isnan( src[0] ) ) ? 0.0f : src[0] * m_coeff;
-		dst[1] += ( isinf( src[1] ) || isnan( src[1] ) ) ? 0.0f : src[1] * m_coeff;
+		dst[0] += ( std::isinf( src[0] ) || std::isnan( src[0] ) ) ? 0.0f : src[0] * m_coeff;
+		dst[1] += ( std::isinf( src[1] ) || std::isnan( src[1] ) ) ? 0.0f : src[1] * m_coeff;
 	}
 
 	const float m_coeff;

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -153,7 +153,7 @@ void Knob::onKnobNumUpdated()
 		}
 
 		// If knobFilename is still empty here we should get the fallback pixmap of size 1x1
-		m_knobPixmap = make_unique<QPixmap>(QPixmap(embed::getIconPixmap(knobFilename.toUtf8().constData())));
+		m_knobPixmap = std::make_unique<QPixmap>(QPixmap(embed::getIconPixmap(knobFilename.toUtf8().constData())));
 		if (!this->isEnabled())
 		{
 			convertPixmapToGrayScale(*m_knobPixmap.get());


### PR DESCRIPTION
Removes "using namespace std" from global scope, which is a common source of symbol clashes. Adds std:: prefix to affected symbols in the header and some sources which included it transitively.