### PR TITLE
Fixes incorrect BB tracks being shown in the BB Editor (#6079)

### DIFF
--- a/src/gui/widgets/TrackContentWidget.cpp
+++ b/src/gui/widgets/TrackContentWidget.cpp
@@ -209,7 +209,7 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 						it != m_tcoViews.end(); ++it )
 		{
 		if( ( *it )->getTrackContentObject()->
-						startPosition().getBar() == curBB )
+						startPosition().getTicks() / DefaultTicksPerBar == curBB )
 			{
 				( *it )->move( 0, ( *it )->y() );
 				( *it )->raise();
@@ -225,7 +225,7 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 					it != m_tcoViews.end(); ++it )
 		{
 			if( ( *it )->getTrackContentObject()->
-						startPosition().getBar() != curBB )
+						startPosition().getTicks() / DefaultTicksPerBar != curBB )
 			{
 				( *it )->hide();
 			}


### PR DESCRIPTION
Fixes issue 6079, that is incorrect BB tracks being shown in the BB Editor.
The fix achieves this by not using getBar for calculating the number of the track (as that doesn't work with different signatures than n/n), and instead gets track number by dividing by DefaultTicksPerBar.