### PR TITLE
Fixes multiple bugs related to BBEditor and time signatures

### DIFF
--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -41,6 +41,7 @@
 #include "PatternTrack.h"
 #include "SampleTrack.h"
 #include "Song.h"
+#include "TimePos.h"
 
 
 namespace lmms
@@ -498,9 +499,9 @@ void Track::createClipsForPattern(int pattern)
 {
 	while( numOfClips() < pattern + 1 )
 	{
-		TimePos position = TimePos( numOfClips(), 0 );
+		auto position = TimePos(numOfClips() * DefaultTicksPerBar);
 		Clip * clip = createClip( position );
-		clip->changeLength( TimePos( 1, 0 ) );
+		clip->changeLength(TimePos(DefaultTicksPerBar));
 	}
 }
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -239,7 +239,7 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 		// first show clip for current pattern...
 		for (const auto& clipView : m_clipViews)
 		{
-			if (clipView->getClip()->startPosition().getBar() == curPattern)
+			if (clipView->getClip()->startPosition().getTicks() / DefaultTicksPerBar == curPattern)
 			{
 				clipView->move(0, clipView->y());
 				clipView->raise();
@@ -250,7 +250,7 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 		// ...then hide others to avoid flickering
 		for (const auto& clipView : m_clipViews)
 		{
-			if (clipView->getClip()->startPosition().getBar() != curPattern) { clipView->hide(); }
+			if (clipView->getClip()->startPosition().getTicks() / DefaultTicksPerBar != curPattern) { clipView->hide(); }
 		}
 		setUpdatesEnabled( true );
 		return;


### PR DESCRIPTION
This pull request fixes multiple bugs related to BBEditor and time signatures, stemming from incorrect or outdated usage of method getBar():

- Lines 212 and 228: Fix the issue of incorrect BB track being displayed when time signature is not n/n (#6079)
- ~~Line 575: Fixes the issue that if new BB subtrack is added when time signature isn't n/n, due to the way getBar() works the result wouldn't be the one the formula using it was hoping for, and, for example, subtrack added at time signature 8/4 would only appear on every other BB track (subtrack for track 1 would appear on track 2, for 2 on 4, etc.).~~