### PR TITLE
clang-format: Prepare plugin descriptor init'ers

### DIFF
--- a/plugins/Amplifier/Amplifier.cpp
+++ b/plugins/Amplifier/Amplifier.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT amplifier_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/BassBooster/BassBooster.cpp
+++ b/plugins/BassBooster/BassBooster.cpp
@@ -40,7 +40,7 @@ Plugin::Descriptor PLUGIN_EXPORT bassbooster_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -47,7 +47,7 @@ Plugin::Descriptor PLUGIN_EXPORT bitcrush_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 };
 
 }

--- a/plugins/Compressor/Compressor.cpp
+++ b/plugins/Compressor/Compressor.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT compressor_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT crossovereq_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 };
 
 }

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT delay_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT dualfilter_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -45,7 +45,7 @@ Plugin::Descriptor PLUGIN_EXPORT eq_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT flanger_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -60,7 +60,7 @@ Plugin::Descriptor PLUGIN_EXPORT freeboy_plugin_descriptor =
 	0x0100,
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -69,7 +69,7 @@ Plugin::Descriptor PLUGIN_EXPORT gigplayer_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	"gig",
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -36,7 +36,7 @@ Plugin::Descriptor PLUGIN_EXPORT hydrogenimport_plugin_descriptor =
 	Plugin::ImportFilter,
 	NULL,
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -56,7 +56,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiexport_plugin_descriptor =
 	Plugin::ExportFilter,
 	NULL,
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -72,7 +72,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiimport_plugin_descriptor =
 	Plugin::ImportFilter,
 	NULL,
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -40,7 +40,7 @@ Plugin::Descriptor PLUGIN_EXPORT multitapecho_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -75,7 +75,7 @@ Plugin::Descriptor PLUGIN_EXPORT opulenz_plugin_descriptor =
         Plugin::Instrument,
         new PluginPixmapLoader( "logo" ),
         "sbi",
-        NULL
+        NULL,
 };
 
 // necessary for getting instance out of shared lib

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -41,7 +41,7 @@ Plugin::Descriptor PLUGIN_EXPORT reverbsc_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -84,7 +84,7 @@ Plugin::Descriptor PLUGIN_EXPORT sid_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/SpectrumAnalyzer/Analyzer.cpp
+++ b/plugins/SpectrumAnalyzer/Analyzer.cpp
@@ -48,7 +48,7 @@ extern "C" {
 		Plugin::Effect,
 		new PluginPixmapLoader("logo"),
 		NULL,
-		NULL
+		NULL,
 	};
 }
 

--- a/plugins/Vectorscope/Vectorscope.cpp
+++ b/plugins/Vectorscope/Vectorscope.cpp
@@ -39,7 +39,7 @@ extern "C" {
 		Plugin::Effect,
 		new PluginPixmapLoader("logo"),
 		NULL,
-		NULL
+		NULL,
 	};
 }
 

--- a/plugins/audio_file_processor/audio_file_processor.cpp
+++ b/plugins/audio_file_processor/audio_file_processor.cpp
@@ -65,7 +65,7 @@ Plugin::Descriptor PLUGIN_EXPORT audiofileprocessor_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	"wav,ogg,ds,spx,au,voc,aif,aiff,flac,raw",
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -61,7 +61,7 @@ Plugin::Descriptor PLUGIN_EXPORT bitinvader_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/carlapatchbay/carlapatchbay.cpp
+++ b/plugins/carlapatchbay/carlapatchbay.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT carlapatchbay_plugin_descriptor =
     Plugin::Instrument,
     new PluginPixmapLoader( "logo" ),
     NULL,
-    NULL
+    NULL,
 } ;
 
 PLUGIN_EXPORT Plugin* lmms_plugin_main(Model* m, void*)

--- a/plugins/carlarack/carlarack.cpp
+++ b/plugins/carlarack/carlarack.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT carlarack_plugin_descriptor =
     Plugin::Instrument,
     new PluginPixmapLoader( "logo" ),
     NULL,
-    NULL
+    NULL,
 } ;
 
 PLUGIN_EXPORT Plugin* lmms_plugin_main(Model* m, void*)

--- a/plugins/dynamics_processor/dynamics_processor.cpp
+++ b/plugins/dynamics_processor/dynamics_processor.cpp
@@ -45,7 +45,7 @@ Plugin::Descriptor PLUGIN_EXPORT dynamicsprocessor_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -52,7 +52,7 @@ Plugin::Descriptor PLUGIN_EXPORT kicker_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/ladspa_browser/ladspa_browser.cpp
+++ b/plugins/ladspa_browser/ladspa_browser.cpp
@@ -56,7 +56,7 @@ Plugin::Descriptor PLUGIN_EXPORT ladspabrowser_plugin_descriptor =
 	Plugin::Tool,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -90,7 +90,7 @@ Plugin::Descriptor PLUGIN_EXPORT lb302_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 };
 
 }

--- a/plugins/monstro/Monstro.cpp
+++ b/plugins/monstro/Monstro.cpp
@@ -52,7 +52,7 @@ Plugin::Descriptor PLUGIN_EXPORT monstro_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/nes/Nes.cpp
+++ b/plugins/nes/Nes.cpp
@@ -51,7 +51,7 @@ Plugin::Descriptor PLUGIN_EXPORT nes_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/organic/organic.cpp
+++ b/plugins/organic/organic.cpp
@@ -58,7 +58,7 @@ Plugin::Descriptor PLUGIN_EXPORT organic_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/patman/patman.cpp
+++ b/plugins/patman/patman.cpp
@@ -62,7 +62,7 @@ Plugin::Descriptor PLUGIN_EXPORT patman_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	"pat",
-	NULL
+	NULL,
 } ;
 
 

--- a/plugins/peak_controller_effect/peak_controller_effect.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect.cpp
@@ -48,7 +48,7 @@ Plugin::Descriptor PLUGIN_EXPORT peakcontrollereffect_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -63,7 +63,7 @@ Plugin::Descriptor PLUGIN_EXPORT sf2player_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	"sf2,sf3",
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/sfxr/sfxr.cpp
+++ b/plugins/sfxr/sfxr.cpp
@@ -68,7 +68,7 @@ Plugin::Descriptor PLUGIN_EXPORT sfxr_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/stereo_enhancer/stereo_enhancer.cpp
+++ b/plugins/stereo_enhancer/stereo_enhancer.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT stereoenhancer_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/stereo_matrix/stereo_matrix.cpp
+++ b/plugins/stereo_matrix/stereo_matrix.cpp
@@ -42,7 +42,7 @@ Plugin::Descriptor PLUGIN_EXPORT stereomatrix_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/stk/mallets/mallets.cpp
+++ b/plugins/stk/mallets/mallets.cpp
@@ -57,7 +57,7 @@ Plugin::Descriptor PLUGIN_EXPORT malletsstk_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/triple_oscillator/TripleOscillator.cpp
+++ b/plugins/triple_oscillator/TripleOscillator.cpp
@@ -57,7 +57,7 @@ Plugin::Descriptor PLUGIN_EXPORT tripleoscillator_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -79,7 +79,7 @@ Plugin::Descriptor Q_DECL_EXPORT  vestige_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	"dll",
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -55,7 +55,7 @@ Plugin::Descriptor PLUGIN_EXPORT vibedstrings_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 };
 
 }

--- a/plugins/vst_base/vst_base.cpp
+++ b/plugins/vst_base/vst_base.cpp
@@ -40,7 +40,7 @@ Plugin::Descriptor VSTBASE_EXPORT vstbase_plugin_descriptor =
 	0x0100,
 	Plugin::Library,
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/watsyn/Watsyn.cpp
+++ b/plugins/watsyn/Watsyn.cpp
@@ -51,7 +51,7 @@ Plugin::Descriptor PLUGIN_EXPORT watsyn_plugin_descriptor =
 	Plugin::Instrument,
 	new PluginPixmapLoader( "logo" ),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }

--- a/plugins/waveshaper/waveshaper.cpp
+++ b/plugins/waveshaper/waveshaper.cpp
@@ -45,7 +45,7 @@ Plugin::Descriptor PLUGIN_EXPORT waveshaper_plugin_descriptor =
 	Plugin::Effect,
 	new PluginPixmapLoader("logo"),
 	NULL,
-	NULL
+	NULL,
 } ;
 
 }


### PR DESCRIPTION
Add a comma after the last element, this lets clang-format align them line by line.

As suggested in #5948, in https://github.com/LMMS/lmms/pull/5948#discussion_r680475664 : 