### PR TITLE
Update CPU to Pentium 4 for win32 builds

### DIFF
--- a/cmake/build_win32.sh
+++ b/cmake/build_win32.sh
@@ -31,7 +31,7 @@ fi
 export PATH=$MINGW/bin:$PATH
 export CXXFLAGS="$CFLAGS"
 if [ "$ARCH" == "32" ]; then
-	export CFLAGS="-march=pentium3 -mtune=generic -mpreferred-stack-boundary=5 -mfpmath=sse"
+	export CFLAGS="-march=pentium4 -mtune=generic -mpreferred-stack-boundary=5 -mfpmath=sse"
 fi
 
 CMAKE_OPTS="-DCMAKE_PREFIX_PATH=$MINGW $CMAKE_OPTS"


### PR DESCRIPTION
The CPU feature requirements for any currently supported 32-bit version of Windows (8.1 and 10) are PAE, NX and SSE2. That should mean a green light for bumping the CPU we build for to the minimum one with SSE2, and what better time for this than the release of 1.3?