### PR TITLE
Use vcpkg version 2021.05.12 for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
     - compiler: msvc
 install:
   - cd C:\Tools\vcpkg
-  - git pull
+  - git pull --quiet origin 2021.05.12
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install --triplet %PLATFORM%-windows --recurse fftw3 libsamplerate libsndfile lilv lv2 sdl2
@@ -28,4 +28,4 @@ artifacts:
   - path: 'build\lmms-*.exe'
     name: Installer
 cache:
-  - c:/tools/vcpkg/installed
+  - c:/tools/vcpkg/installed -> .appveyor.yml


### PR DESCRIPTION
The LV2 port is broken in the latest `master` version of vcpkg. I have submitted a pull request to fix this (microsoft/vcpkg#20102), but until that is merged, this PR should fix our MSVC builds by using an older version of vcpkg. I have chosen the most recently tagged version.

Changes:
* Pull `2021.05.12` tag instead of `master` branch for vcpkg on AppVeyor.
* Pass `--quiet` flag to `git pull` - currently it generates over 16000 lines of useless noise in our build logs.
* Add `.appveyor.yml` as a dependency for the vcpkg port cache. This is primarily to force a rebuild of the LV2 port with this PR, but may be useful for modifying ports in the future.

In the future, we may want to consider using a [manifest file](https://github.com/microsoft/vcpkg/blob/master/docs/users/manifests.md) for vcpkg, which would allow ports and their versions to be specified outside of the CI config script, and provide a consistent set of ports for both CI and local builds. Currently, however, manifest files are in beta and port versioning is still experimental and hidden behind a flag, so I am avoiding that for now.