### PR TITLE
Color submenu, undoable colors, renaming signals

### DIFF
--- a/include/FxLine.h
+++ b/include/FxLine.h
@@ -104,8 +104,8 @@ private:
 public slots:
 	void renameChannel();
 	void resetColor();
-	void changeColor();
-	void randomColor();
+	void selectColor();
+	void randomizeColor();
 
 private slots:
 	void renameFinished();

--- a/include/SampleTCOView.h
+++ b/include/SampleTCOView.h
@@ -45,7 +45,7 @@ public slots:
 
 
 protected:
-	void contextMenuEvent( QContextMenuEvent * _cme ) override;
+	void constructContextMenu(QMenu* cm) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;

--- a/include/Track.h
+++ b/include/Track.h
@@ -198,7 +198,7 @@ public slots:
 
 	void toggleSolo();
 
-	void changeColor( QColor & c );
+	void setColor(const QColor& c);
 	void resetColor();
 
 private:

--- a/include/Track.h
+++ b/include/Track.h
@@ -198,8 +198,8 @@ public slots:
 
 	void toggleSolo();
 
-	void trackColorChanged( QColor & c );
-	void trackColorReset();
+	void changeColor( QColor & c );
+	void resetColor();
 
 private:
 	TrackContainer* m_trackContainer;
@@ -229,6 +229,7 @@ signals:
 	void destroyedTrack();
 	void nameChanged();
 	void trackContentObjectAdded( TrackContentObject * );
+	void colorChanged();
 
 } ;
 

--- a/include/TrackContentObject.h
+++ b/include/TrackContentObject.h
@@ -135,8 +135,6 @@ public:
 	TimePos startTimeOffset() const;
 	void setStartTimeOffset( const TimePos &startTimeOffset );
 
-	void updateColor();
-
 	// Will copy the state of a TCO to another TCO
 	static void copyStateTo( TrackContentObject *src, TrackContentObject *dst );
 
@@ -149,7 +147,6 @@ signals:
 	void positionChanged();
 	void destroyedTCO();
 	void colorChanged();
-	void trackColorChanged();
 
 
 private:

--- a/include/TrackContentObject.h
+++ b/include/TrackContentObject.h
@@ -148,6 +148,7 @@ signals:
 	void lengthChanged();
 	void positionChanged();
 	void destroyedTCO();
+	void colorChanged();
 	void trackColorChanged();
 
 

--- a/include/TrackContentObjectView.h
+++ b/include/TrackContentObjectView.h
@@ -126,8 +126,10 @@ public slots:
 	void remove();
 	void update() override;
 
-	void changeClipColor();
-	void useTrackColor();
+	void selectColor();
+	void randomColor();
+	void resetColor();
+	void updateTrackColor();
 
 protected:
 	enum ContextMenuAction
@@ -231,6 +233,7 @@ private:
 	bool mouseMovedDistance( QMouseEvent * me, int distance );
 	TimePos draggedTCOPos( QMouseEvent * me );
 	int knifeMarkerPos( QMouseEvent * me );
+	void setColor(const QColor color);
 	//! Return true iff TCO could be split. Currently only implemented for samples
 	virtual bool splitTCO( const TimePos pos ){ return false; };
 	void updateCursor(QMouseEvent * me);

--- a/include/TrackContentObjectView.h
+++ b/include/TrackContentObjectView.h
@@ -127,7 +127,7 @@ public slots:
 	void update() override;
 
 	void selectColor();
-	void randomColor();
+	void randomizeColor();
 	void resetColor();
 
 protected:
@@ -232,7 +232,7 @@ private:
 	bool mouseMovedDistance( QMouseEvent * me, int distance );
 	TimePos draggedTCOPos( QMouseEvent * me );
 	int knifeMarkerPos( QMouseEvent * me );
-	void setColor(const QColor color);
+	void setColor(const QColor* color);
 	//! Return true iff TCO could be split. Currently only implemented for samples
 	virtual bool splitTCO( const TimePos pos ){ return false; };
 	void updateCursor(QMouseEvent * me);

--- a/include/TrackContentObjectView.h
+++ b/include/TrackContentObjectView.h
@@ -129,7 +129,6 @@ public slots:
 	void selectColor();
 	void randomColor();
 	void resetColor();
-	void updateTrackColor();
 
 protected:
 	enum ContextMenuAction

--- a/include/TrackOperationsWidget.h
+++ b/include/TrackOperationsWidget.h
@@ -53,7 +53,7 @@ private slots:
 	void changeTrackColor();
 	void randomTrackColor();
 	void resetTrackColor();
-	void useTrackColor();
+	void resetTCOColors();
 	void toggleRecording(bool on);
 	void recordingOn();
 	void recordingOff();
@@ -71,9 +71,6 @@ private:
 
 signals:
 	void trackRemovalScheduled( TrackView * t );
-	void colorChanged( QColor & c );
-	void colorParented();
-	void colorReset();
 
 } ;
 

--- a/include/TrackOperationsWidget.h
+++ b/include/TrackOperationsWidget.h
@@ -50,8 +50,8 @@ private slots:
 	void cloneTrack();
 	void removeTrack();
 	void updateMenu();
-	void changeTrackColor();
-	void randomTrackColor();
+	void selectTrackColor();
+	void randomizeTrackColor();
 	void resetTrackColor();
 	void resetTCOColors();
 	void toggleRecording(bool on);

--- a/src/core/BBTCO.cpp
+++ b/src/core/BBTCO.cpp
@@ -87,12 +87,15 @@ void BBTCO::loadSettings( const QDomElement & element )
 	}
 	
 	// for colors saved before 1.3
-	else
+	else if(element.hasAttribute("color"))
 	{
-		if( element.hasAttribute( "color" ) )
-		{ setColor( QColor( element.attribute( "color" ).toUInt() ) ); }
+		setColor(QColor(element.attribute("color").toUInt()));
 		
 		// usestyle attribute is no longer used
+	}
+	else
+	{
+		useCustomClipColor(false);
 	}
 }
 

--- a/src/core/SampleTCO.cpp
+++ b/src/core/SampleTCO.cpp
@@ -299,6 +299,10 @@ void SampleTCO::loadSettings( const QDomElement & _this )
 		useCustomClipColor( true );
 		setColor( _this.attribute( "color" ) );
 	}
+	else
+	{
+		useCustomClipColor(false);
+	}
 
 	if(_this.hasAttribute("reversed"))
 	{

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -270,8 +270,12 @@ void Track::loadSettings( const QDomElement & element )
 
 	if( element.hasAttribute( "color" ) )
 	{
-		m_color.setNamedColor( element.attribute( "color" ) );
-		m_hasColor = true;
+		QColor newColor = QColor(element.attribute("color"));
+		changeColor(newColor);
+	}
+	else
+	{
+		resetColor();
 	}
 
 	if( m_simpleSerializingMode )
@@ -647,23 +651,17 @@ void Track::toggleSolo()
 	}
 }
 
-void Track::trackColorChanged( QColor & c )
+void Track::changeColor( QColor & c )
 {
-	for (int i = 0; i < numOfTCOs(); i++)
-	{
-		m_trackContentObjects[i]->updateColor();
-	}
 	m_hasColor = true;
 	m_color = c;
+	emit colorChanged();
 }
 
-void Track::trackColorReset()
+void Track::resetColor()
 {
-	for (int i = 0; i < numOfTCOs(); i++)
-	{
-		m_trackContentObjects[i]->updateColor();
-	}
 	m_hasColor = false;
+	emit colorChanged();
 }
 
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -271,7 +271,7 @@ void Track::loadSettings( const QDomElement & element )
 	if( element.hasAttribute( "color" ) )
 	{
 		QColor newColor = QColor(element.attribute("color"));
-		changeColor(newColor);
+		setColor(newColor);
 	}
 	else
 	{
@@ -651,7 +651,7 @@ void Track::toggleSolo()
 	}
 }
 
-void Track::changeColor( QColor & c )
+void Track::setColor(const QColor& c)
 {
 	m_hasColor = true;
 	m_color = c;

--- a/src/core/TrackContentObject.cpp
+++ b/src/core/TrackContentObject.cpp
@@ -194,8 +194,9 @@ void TrackContentObject::updateColor()
 
 void TrackContentObject::useCustomClipColor( bool b )
 {
+	if (b == m_useCustomClipColor) { return; }
 	m_useCustomClipColor = b;
-	updateColor();
+	emit colorChanged();
 }
 
 

--- a/src/core/TrackContentObject.cpp
+++ b/src/core/TrackContentObject.cpp
@@ -182,14 +182,6 @@ void TrackContentObject::setStartTimeOffset( const TimePos &startTimeOffset )
 	m_startTimeOffset = startTimeOffset;
 }
 
-// Update TCO color if it follows the track color
-void TrackContentObject::updateColor()
-{
-	if( ! m_useCustomClipColor )
-	{
-		emit trackColorChanged();
-	}
-}
 
 
 void TrackContentObject::useCustomClipColor( bool b )

--- a/src/gui/SampleTCOView.cpp
+++ b/src/gui/SampleTCOView.cpp
@@ -63,80 +63,23 @@ void SampleTCOView::updateSample()
 
 
 
-void SampleTCOView::contextMenuEvent( QContextMenuEvent * _cme )
+void SampleTCOView::constructContextMenu(QMenu* cm)
 {
-	// Depending on whether we right-clicked a selection or an individual TCO we will have
-	// different labels for the actions.
-	bool individualTCO = getClickedTCOs().size() <= 1;
+	cm->addSeparator();
 
-	if( _cme->modifiers() )
-	{
-		return;
-	}
-
-	QMenu contextMenu( this );
-
-	if( fixedTCOs() == false )
-	{
-		contextMenu.addAction(
-			embed::getIconPixmap( "cancel" ),
-			individualTCO
-				? tr("Delete (middle mousebutton)")
-				: tr("Delete selection (middle mousebutton)"),
-			[this](){ contextMenuAction( Remove ); } );
-
-		contextMenu.addSeparator();
-
-		contextMenu.addAction(
-			embed::getIconPixmap( "edit_cut" ),
-			individualTCO
-				? tr("Cut")
-				: tr("Cut selection"),
-			[this](){ contextMenuAction( Cut ); } );
-	}
-
-	contextMenu.addAction(
-		embed::getIconPixmap( "edit_copy" ),
-		individualTCO
-			? tr("Copy")
-			: tr("Copy selection"),
-		[this](){ contextMenuAction( Copy ); } );
-
-	contextMenu.addAction(
-		embed::getIconPixmap( "edit_paste" ),
-		tr( "Paste" ),
-		[this](){ contextMenuAction( Paste ); } );
-
-	contextMenu.addSeparator();
-
-	contextMenu.addAction(
-		embed::getIconPixmap( "muted" ),
-		(individualTCO
-			? tr("Mute/unmute (<%1> + middle click)")
-			: tr("Mute/unmute selection (<%1> + middle click)")).arg(UI_CTRL_KEY),
-		[this](){ contextMenuAction( Mute ); } );
 
 	/*contextMenu.addAction( embed::getIconPixmap( "record" ),
 				tr( "Set/clear record" ),
 						m_tco, SLOT( toggleRecord() ) );*/
 
-	contextMenu.addAction(
+	cm->addAction(
 		embed::getIconPixmap("flip_x"),
 		tr("Reverse sample"),
 		this,
 		SLOT(reverseSample())
 	);
 
-	contextMenu.addSeparator();
 
-	contextMenu.addAction( embed::getIconPixmap( "colorize" ),
-			tr( "Set clip color" ), this, SLOT( changeClipColor() ) );
-	contextMenu.addAction( embed::getIconPixmap( "colorize" ),
-			tr( "Use track color" ), this, SLOT( useTrackColor() ) );
-
-	constructContextMenu( &contextMenu );
-
-	contextMenu.exec( QCursor::pos() );
 }
 
 

--- a/src/gui/TrackContentObjectView.cpp
+++ b/src/gui/TrackContentObjectView.cpp
@@ -125,8 +125,7 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	connect( m_tco, SIGNAL( destroyedTCO() ), this, SLOT( close() ) );
 	setModel( m_tco );
 	connect(m_tco, SIGNAL(colorChanged()), this, SLOT(update()));
-	connect( m_tco, SIGNAL( trackColorChanged() ), this, SLOT( update() ) );
-	connect( m_trackView->getTrackOperationsWidget(), SIGNAL( colorParented() ), this, SLOT( useTrackColor() ) );
+	connect(m_trackView->getTrack(), SIGNAL(colorChanged()), this, SLOT(updateTrackColor()));
 
 	m_trackView->getTrackContentWidget()->addTCOView( this );
 	updateLength();

--- a/src/gui/TrackContentObjectView.cpp
+++ b/src/gui/TrackContentObjectView.cpp
@@ -124,6 +124,7 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 			this, SLOT( updatePosition() ) );
 	connect( m_tco, SIGNAL( destroyedTCO() ), this, SLOT( close() ) );
 	setModel( m_tco );
+	connect(m_tco, SIGNAL(colorChanged()), this, SLOT(update()));
 	connect( m_tco, SIGNAL( trackColorChanged() ), this, SLOT( update() ) );
 	connect( m_trackView->getTrackOperationsWidget(), SIGNAL( colorParented() ), this, SLOT( useTrackColor() ) );
 
@@ -333,25 +334,82 @@ void TrackContentObjectView::updatePosition()
 
 
 
-void TrackContentObjectView::changeClipColor()
+void TrackContentObjectView::selectColor()
 {
 	// Get a color from the user
 	QColor new_color = ColorChooser( this ).withPalette( ColorChooser::Palette::Track )->getColor( m_tco->color() );
-	if( ! new_color.isValid() )
-	{ return; }
-
-	// Use that color
-	m_tco->setColor( new_color );
-	m_tco->useCustomClipColor( true );
-	update();
+	if (new_color.isValid()) { setColor(new_color); }
 }
 
 
 
-void TrackContentObjectView::useTrackColor()
+
+void TrackContentObjectView::randomColor()
 {
-	m_tco->useCustomClipColor( false );
-	update();
+	setColor(ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);
+}
+
+
+
+
+void TrackContentObjectView::resetColor()
+{
+	setColor(QColor());
+}
+
+
+
+void TrackContentObjectView::updateTrackColor()
+{
+	if (!m_tco->usesCustomClipColor())
+	{
+		update();
+	}
+}
+
+
+
+/*! \brief Change color of all selected TCOs
+ *
+ *  \param color The new QColor. Pass an invalid color to use the Track's color.
+ */
+void TrackContentObjectView::setColor(const QColor color)
+{
+	std::set<Track*> journaledTracks;
+
+	auto selectedTCOs = getClickedTCOs();
+	for (auto tcov: selectedTCOs)
+	{
+		auto tco = tcov->getTrackContentObject();
+		auto track = tco->getTrack();
+
+		// TODO journal whole Song or group of TCOs instead of one journal entry for each track
+
+		// If only one TCO changed, store that in the journal
+		if (selectedTCOs.length() == 1)
+		{
+			tco->addJournalCheckPoint();
+		}
+		// If multiple TCOs changed, store whole Track in the journal
+		// Check if track has been journaled already by trying to add it to the set
+		else if (journaledTracks.insert(track).second)
+		{
+			track->addJournalCheckPoint();
+		}
+
+		if (color.isValid())
+		{
+			tco->useCustomClipColor(true);
+			tco->setColor(color);
+		}
+		else
+		{
+			tco->useCustomClipColor(false);
+		}
+		tcov->update();
+	}
+
+	Engine::getSong()->setModified();
 }
 
 
@@ -1050,10 +1108,12 @@ void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * cme )
 
 	contextMenu.addSeparator();
 
-	contextMenu.addAction( embed::getIconPixmap( "colorize" ),
-			tr( "Set clip color" ), this, SLOT( changeClipColor() ) );
-	contextMenu.addAction( embed::getIconPixmap( "colorize" ),
-			tr( "Use track color" ), this, SLOT( useTrackColor() ) );
+	QMenu colorMenu (tr("Clip color"), this);
+	colorMenu.setIcon(embed::getIconPixmap("colorize"));
+	colorMenu.addAction(tr("Change"), this, SLOT(selectColor()));
+	colorMenu.addAction(tr("Reset"), this, SLOT(resetColor()));
+	colorMenu.addAction(tr("Pick random"), this, SLOT(randomColor()));
+	contextMenu.addMenu(&colorMenu);
 
 	constructContextMenu( &contextMenu );
 

--- a/src/gui/TrackContentObjectView.cpp
+++ b/src/gui/TrackContentObjectView.cpp
@@ -129,7 +129,7 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	connect(m_trackView->getTrack(), &Track::colorChanged, this, [this]
 	{
 		// redraw if TCO uses track color
-		if (m_tco && !m_tco->usesCustomClipColor()) { update(); }
+		if (!m_tco->usesCustomClipColor()) { update(); }
 	});
 
 	m_trackView->getTrackContentWidget()->addTCOView( this );
@@ -342,15 +342,15 @@ void TrackContentObjectView::selectColor()
 {
 	// Get a color from the user
 	QColor new_color = ColorChooser( this ).withPalette( ColorChooser::Palette::Track )->getColor( m_tco->color() );
-	if (new_color.isValid()) { setColor(new_color); }
+	if (new_color.isValid()) { setColor(&new_color); }
 }
 
 
 
 
-void TrackContentObjectView::randomColor()
+void TrackContentObjectView::randomizeColor()
 {
-	setColor(ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);
+	setColor(&ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);
 }
 
 
@@ -358,7 +358,7 @@ void TrackContentObjectView::randomColor()
 
 void TrackContentObjectView::resetColor()
 {
-	setColor(QColor());
+	setColor(nullptr);
 }
 
 
@@ -366,9 +366,9 @@ void TrackContentObjectView::resetColor()
 
 /*! \brief Change color of all selected TCOs
  *
- *  \param color The new QColor. Pass an invalid color to use the Track's color.
+ *  \param color The new QColor. Pass nullptr to use the Track's color.
  */
-void TrackContentObjectView::setColor(const QColor color)
+void TrackContentObjectView::setColor(const QColor* color)
 {
 	std::set<Track*> journaledTracks;
 
@@ -392,10 +392,10 @@ void TrackContentObjectView::setColor(const QColor color)
 			track->addJournalCheckPoint();
 		}
 
-		if (color.isValid())
+		if (color)
 		{
 			tco->useCustomClipColor(true);
-			tco->setColor(color);
+			tco->setColor(*color);
 		}
 		else
 		{
@@ -1107,7 +1107,7 @@ void TrackContentObjectView::contextMenuEvent( QContextMenuEvent * cme )
 	colorMenu.setIcon(embed::getIconPixmap("colorize"));
 	colorMenu.addAction(tr("Change"), this, SLOT(selectColor()));
 	colorMenu.addAction(tr("Reset"), this, SLOT(resetColor()));
-	colorMenu.addAction(tr("Pick random"), this, SLOT(randomColor()));
+	colorMenu.addAction(tr("Pick random"), this, SLOT(randomizeColor()));
 	contextMenu.addMenu(&colorMenu);
 
 	constructContextMenu( &contextMenu );

--- a/src/gui/TrackContentObjectView.cpp
+++ b/src/gui/TrackContentObjectView.cpp
@@ -125,7 +125,12 @@ TrackContentObjectView::TrackContentObjectView( TrackContentObject * tco,
 	connect( m_tco, SIGNAL( destroyedTCO() ), this, SLOT( close() ) );
 	setModel( m_tco );
 	connect(m_tco, SIGNAL(colorChanged()), this, SLOT(update()));
-	connect(m_trackView->getTrack(), SIGNAL(colorChanged()), this, SLOT(updateTrackColor()));
+
+	connect(m_trackView->getTrack(), &Track::colorChanged, this, [this]
+	{
+		// redraw if TCO uses track color
+		if (m_tco && !m_tco->usesCustomClipColor()) { update(); }
+	});
 
 	m_trackView->getTrackContentWidget()->addTCOView( this );
 	updateLength();
@@ -356,15 +361,6 @@ void TrackContentObjectView::resetColor()
 	setColor(QColor());
 }
 
-
-
-void TrackContentObjectView::updateTrackColor()
-{
-	if (!m_tco->usesCustomClipColor())
-	{
-		update();
-	}
-}
 
 
 

--- a/src/gui/TrackView.cpp
+++ b/src/gui/TrackView.cpp
@@ -102,12 +102,6 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	connect( &m_track->m_soloModel, SIGNAL( dataChanged() ),
 			m_track, SLOT( toggleSolo() ), Qt::DirectConnection );
 
-	connect( &m_trackOperationsWidget, SIGNAL( colorChanged( QColor & ) ),
-			m_track, SLOT( trackColorChanged( QColor & ) ) );
-
-	connect( &m_trackOperationsWidget, SIGNAL( colorReset() ),
-			m_track, SLOT( trackColorReset() ) );
-
 	// create views for already existing TCOs
 	for( Track::tcoVector::iterator it =
 					m_track->m_trackContentObjects.begin();

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -255,9 +255,9 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 
 	QMenu colorMenu(tr("Color"), this);
 	colorMenu.setIcon(embed::getIconPixmap("colorize"));
-	colorMenu.addAction(tr("Change"), this, SLOT(changeColor()));
+	colorMenu.addAction(tr("Change"), this, SLOT(selectColor()));
 	colorMenu.addAction(tr("Reset"), this, SLOT(resetColor()));
-	colorMenu.addAction(tr("Pick random" ), this, SLOT(randomColor()));
+	colorMenu.addAction(tr("Pick random"), this, SLOT(randomizeColor()));
 	contextMenu->addMenu(&colorMenu);
 
 	contextMenu->exec( QCursor::pos() );
@@ -420,7 +420,7 @@ void FxLine::setStrokeInnerInactive( const QColor & c )
 
 
 // Ask user for a color, and set it as the mixer line color
-void FxLine::changeColor()
+void FxLine::selectColor()
 {
 	auto channel = Engine::fxMixer()->effectChannel( m_channelIndex );
 	auto new_color = ColorChooser(this).withPalette(ColorChooser::Palette::Mixer)->getColor(channel->m_color);
@@ -441,7 +441,7 @@ void FxLine::resetColor()
 
 
 // Pick a random color from the mixer palette and set it as our color
-void FxLine::randomColor()
+void FxLine::randomizeColor()
 {
 	auto channel = Engine::fxMixer()->effectChannel( m_channelIndex );
 	channel->setColor (ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -426,6 +426,7 @@ void FxLine::changeColor()
 	auto new_color = ColorChooser(this).withPalette(ColorChooser::Palette::Mixer)->getColor(channel->m_color);
 	if(!new_color.isValid()) { return; }
 	channel->setColor (new_color);
+	Engine::getSong()->setModified();
 	update();
 }
 
@@ -434,6 +435,7 @@ void FxLine::changeColor()
 void FxLine::resetColor()
 {
 	Engine::fxMixer()->effectChannel( m_channelIndex )->m_hasColor = false;
+	Engine::getSong()->setModified();
 	update();
 }
 
@@ -443,5 +445,6 @@ void FxLine::randomColor()
 {
 	auto channel = Engine::fxMixer()->effectChannel( m_channelIndex );
 	channel->setColor (ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);
+	Engine::getSong()->setModified();
 	update();
 }

--- a/src/gui/widgets/FxLine.cpp
+++ b/src/gui/widgets/FxLine.cpp
@@ -252,9 +252,14 @@ void FxLine::contextMenuEvent( QContextMenuEvent * )
 	}
 	contextMenu->addAction( embed::getIconPixmap( "cancel" ), tr( "Remove &unused channels" ), this, SLOT( removeUnusedChannels() ) );
 	contextMenu->addSeparator();
-	contextMenu->addAction( embed::getIconPixmap( "colorize" ), tr( "Set channel color" ), this, SLOT( changeColor() ) );
-	contextMenu->addAction( embed::getIconPixmap( "colorize" ), tr( "Remove channel color" ), this, SLOT( resetColor() ) );
-	contextMenu->addAction( embed::getIconPixmap( "colorize" ), tr( "Pick random channel color" ), this, SLOT( randomColor() ) );
+
+	QMenu colorMenu(tr("Color"), this);
+	colorMenu.setIcon(embed::getIconPixmap("colorize"));
+	colorMenu.addAction(tr("Change"), this, SLOT(changeColor()));
+	colorMenu.addAction(tr("Reset"), this, SLOT(resetColor()));
+	colorMenu.addAction(tr("Pick random" ), this, SLOT(randomColor()));
+	contextMenu->addMenu(&colorMenu);
+
 	contextMenu->exec( QCursor::pos() );
 	delete contextMenu;
 }

--- a/src/gui/widgets/TrackOperationsWidget.cpp
+++ b/src/gui/widgets/TrackOperationsWidget.cpp
@@ -269,7 +269,7 @@ void TrackOperationsWidget::removeTrack()
 	}
 }
 
-void TrackOperationsWidget::changeTrackColor()
+void TrackOperationsWidget::selectTrackColor()
 {
 	QColor new_color = ColorChooser( this ).withPalette( ColorChooser::Palette::Track )-> \
 		getColor( m_trackView->getTrack()->color() );
@@ -279,7 +279,7 @@ void TrackOperationsWidget::changeTrackColor()
 
 	auto track = m_trackView->getTrack();
 	track->addJournalCheckPoint();
-	track->changeColor(new_color);
+	track->setColor(new_color);
 	Engine::getSong()->setModified();
 }
 
@@ -291,12 +291,12 @@ void TrackOperationsWidget::resetTrackColor()
 	Engine::getSong()->setModified();
 }
 
-void TrackOperationsWidget::randomTrackColor()
+void TrackOperationsWidget::randomizeTrackColor()
 {
 	QColor buffer = ColorChooser::getPalette( ColorChooser::Palette::Track )[ rand() % 48 ];
 	auto track = m_trackView->getTrack();
 	track->addJournalCheckPoint();
-	track->changeColor(buffer);
+	track->setColor(buffer);
 	Engine::getSong()->setModified();
 }
 
@@ -355,14 +355,13 @@ void TrackOperationsWidget::updateMenu()
 
 	toMenu->addSeparator();
 
-	QMenu* colorMenu = new QMenu(tr("Track color"), this);
+	QMenu* colorMenu = toMenu->addMenu(tr("Track color"));
 	colorMenu->setIcon(embed::getIconPixmap("colorize"));
-	colorMenu->addAction(tr("Change"), this, SLOT(changeTrackColor()));
+	colorMenu->addAction(tr("Change"), this, SLOT(selectTrackColor()));
 	colorMenu->addAction(tr("Reset"), this, SLOT(resetTrackColor()));
-	colorMenu->addAction(tr("Pick random"), this, SLOT(randomTrackColor()));
+	colorMenu->addAction(tr("Pick random"), this, SLOT(randomizeTrackColor()));
 	colorMenu->addSeparator();
 	colorMenu->addAction(tr("Reset clip colors"), this, SLOT(resetTCOColors()));
-	toMenu->addMenu(colorMenu);
 }
 
 

--- a/src/gui/widgets/TrackOperationsWidget.cpp
+++ b/src/gui/widgets/TrackOperationsWidget.cpp
@@ -308,6 +308,7 @@ void TrackOperationsWidget::resetTCOColors()
 	{
 		tco->useCustomClipColor(false);
 	}
+	Engine::getSong()->setModified();
 }
 
 

--- a/src/tracks/Pattern.cpp
+++ b/src/tracks/Pattern.cpp
@@ -422,6 +422,10 @@ void Pattern::loadSettings( const QDomElement & _this )
 		useCustomClipColor( true );
 		setColor( _this.attribute( "color" ) );
 	}
+	else
+	{
+		useCustomClipColor(false);
+	}
 	
 	if( _this.attribute( "pos" ).toInt() >= 0 )
 	{


### PR DESCRIPTION
### Visual changes

- Color actions in sub-menu (clips/tracks/channels)
- Consistent wording (clips/tracks/channels)
- Color change is undoable (clips/tracks)
- Random color action for clips
- [Edit]: Clip color applied to all selected clips

![image](https://user-images.githubusercontent.com/7693838/133843745-0accf027-129c-4c2b-91bf-7940d89b9eaa.png)

### Remove `SampleTCOView::contextMenuEvent`

This was just a copy-pasta of `TrackContentObject::contextMenuEvent`. Use `constructContextMenu` instead, like all other TCO sub-classes does, and let the parent class handle the rest.

### Rename some signals and slots

During my work on this PR I was extremely confused by the naming of some signals and slots related to setting colors. This is my motivation for renaming them.

- `Track::`
  - `trackColorChanged` renamed to `changeColor` (it's a SLOT)
  - `trackColorReset` renamed to `resetColor` (it's a SLOT)
- `TrackOperationsWidget::`
  - `useTrackColor` renamed to `resetTCOColors` to clarify the effect it has on TCOs and not on the Track (as this is the TrackOp widget)
- `TrackContentObjectView::`
  - `changeClipColor` (called to display color picker) renamed to `selectColor` to not be confused with....
  - `setColor(color)` a new function to handle color change and undo stuff
  - `useTrackColor` renamed to `resetColor` for sake of consitancy :confused: 
- `TrackContentObject::`
  - `trackColorChanged` SIGNAL renamed to `colorChanged` and emitted on *both* track and TCO color changes (see Communicating "Clear clip colors").

### Communicating a `Track` color change

This applies to `changeTrackColor`, `resetTrackColor` and `randomTrackColor`. The pseudo code illustrates the complicated way a track color change was communicated to a TCOView:

```py
# Slot triggered by menu action emits another signal
TrackOperationsWidget::resetTrackColor()
    emit colorReset()

# Signal proxied via TrackView
TrackView::TrackView()
    connect(trackOperationsWidget, SIGNAL(colorReset), track, SLOT(trackColorReset))

Track::trackColorReset()
    ... do stuff ...
    for (tco: tcos)
        tco->updateColor()

# Conditional check inside TCO, emits yet another signal if true
TrackContentObject::updateColor()
    if (usesTrackColor)
        emit trackColorChanged()

TrackContentObjectView::TrackContentObjectView()
    connect(tco, SIGNAL(trackColorChanged), this, SLOT(update))
```     

The new way:

```py
# Slot triggered by menu action calls Track directly
TrackOperationsWidget::resetTrackColor()
    trackView->track->resetColor()

Track::resetColor()
    ... do stuff ...
    emit colorChanged()

# Signal picked up by TCOView, conditional check inside lambda
TrackContentObjectView::TrackContentObjectView()
    connect(tco->track, Track::colorChanged, this, [this]{ if (tco->usesTrackColor) update() })
```

### Communicating "Clear clip colors"

The old way did not redraw the TCOView if the TCO got changed from anything else than the view, e.g. by `loadSettings`:

```py
# Slot triggered by menu action emits another signal
TrackOperationsWidget::useTrackColor()
    emit colorParented()

# Signal picked up by each TCOView
TrackContentObjectView::TrackContentObjectView()
    connect(trackOpWidget, SIGNAL(colorParented), this, SLOT(useTrackColor));

# update() called manually by TCOView
TrackContentObjectView::useTrackColor()
    tco->useCustomClipColor(false);
    update()

# This does not trigger an update
TrackContentObject::useCustomClipColor()
    ... do stuff ...
```

To make it work with undo/redo, this is the new way:

```py
# Slot triggered by menu action calls each TCO directly
TrackOperationsWidget::resetTCOColors()
    for (tco: trackView->track->tcos)
        tco->useCustomClipColor(false)

TrackContentObject::useCustomClipColor()
    ... do stuff ...
    emit colorChanged()

# update() called as a result of TCO change
TrackContentObjectView::TrackContentObjectView()
    connect(tco, SIGNAL(colorChanged), this, SLOT(update))
```