### PR TITLE
Extend denormal protection through DAZ flag to all capable CPUs.

### DIFF
--- a/include/denormals.h
+++ b/include/denormals.h
@@ -5,9 +5,8 @@
 #define DENORMALS_H
 
 #ifdef __SSE__
-#if defined(_MSC_VER)
 #include <immintrin.h>
-#elif defined(__GNUC__)
+#ifdef __GNUC__
 #include <x86intrin.h>
 #endif
 

--- a/include/denormals.h
+++ b/include/denormals.h
@@ -26,10 +26,7 @@ int inline can_we_daz() {
 #endif
 
 // Set denormal protection for this thread. 
-// To be on the safe side, don't set the DAZ flag for SSE2 builds, 
-// even if most SSE2 CPUs can handle it. 
 void inline disable_denormals() {
-
 #ifdef __SSE__
   /* Setting DAZ might freeze systems not supporting it */
   if(can_we_daz()) {

--- a/include/denormals.h
+++ b/include/denormals.h
@@ -5,20 +5,22 @@
 #define DENORMALS_H
 
 #ifdef __SSE__
+#if defined(_MSC_VER)
 #include <immintrin.h>
-#include <fxsrintrin.h>
+#elif defined(__GNUC__)
+#include <x86intrin.h>
+#endif
 
 // Intel® 64 and IA-32 Architectures Software Developer’s Manual,
 // Volume 1: Basic Architecture,
 // 11.6.3 Checking for the DAZ Flag in the MXCSR Register
 int inline can_we_daz() {
   alignas(16) unsigned char buffer[512] = {0};
-  #ifdef LMMS_HOST_X86
+#if defined(LMMS_HOST_X86)
   _fxsave(buffer);
-  #endif
-  #ifdef LMMS_HOST_X86_64
+#elif defined(LMMS_HOST_X86_64)
   _fxsave64(buffer);
-  #endif
+#endif
   // Bit 6 of the MXCSR_MASK, i.e. in the lowest byte,
   // tells if we can use the DAZ flag.
   return ((buffer[28] & (1 << 6)) != 0);

--- a/include/denormals.h
+++ b/include/denormals.h
@@ -4,15 +4,15 @@
 #ifndef DENORMALS_H
 #define DENORMALS_H
 
+#ifdef __SSE__
 #include <immintrin.h>
 #include <fxsrintrin.h>
 
-#ifdef __SSE__
 // Intel® 64 and IA-32 Architectures Software Developer’s Manual,
 // Volume 1: Basic Architecture,
 // 11.6.3 Checking for the DAZ Flag in the MXCSR Register
 int inline can_we_daz() {
-  unsigned char buffer[512] __attribute__ ((aligned(16))) = {0};
+  alignas(16) unsigned char buffer[512] = {0};
   #ifdef LMMS_HOST_X86
   _fxsave(buffer);
   #endif
@@ -21,7 +21,7 @@ int inline can_we_daz() {
   #endif
   // Bit 6 of the MXCSR_MASK, i.e. in the lowest byte,
   // tells if we can use the DAZ flag.
-  return( (buffer[28] & (1 << 6)) != 0);
+  return ((buffer[28] & (1 << 6)) != 0);
 }
 #endif
 
@@ -29,7 +29,7 @@ int inline can_we_daz() {
 void inline disable_denormals() {
 #ifdef __SSE__
   /* Setting DAZ might freeze systems not supporting it */
-  if(can_we_daz()) {
+  if (can_we_daz()) {
     _MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
   }
   /* FTZ flag */

--- a/include/denormals.h
+++ b/include/denormals.h
@@ -4,27 +4,39 @@
 #ifndef DENORMALS_H
 #define DENORMALS_H
 
+#include <immintrin.h>
+#include <fxsrintrin.h>
 
 #ifdef __SSE__
-#include <xmmintrin.h>
+// Intel® 64 and IA-32 Architectures Software Developer’s Manual,
+// Volume 1: Basic Architecture,
+// 11.6.3 Checking for the DAZ Flag in the MXCSR Register
+int inline can_we_daz() {
+  unsigned char buffer[512] __attribute__ ((aligned(16))) = {0};
+  #ifdef LMMS_HOST_X86
+  _fxsave(buffer);
+  #endif
+  #ifdef LMMS_HOST_X86_64
+  _fxsave64(buffer);
+  #endif
+  // Bit 6 of the MXCSR_MASK, i.e. in the lowest byte,
+  // tells if we can use the DAZ flag.
+  return( (buffer[28] & (1 << 6)) != 0);
+}
 #endif
-#ifdef __SSE3__
-#include <pmmintrin.h>
-#endif
-
 
 // Set denormal protection for this thread. 
 // To be on the safe side, don't set the DAZ flag for SSE2 builds, 
 // even if most SSE2 CPUs can handle it. 
 void inline disable_denormals() {
-#ifdef __SSE3__
-	/* DAZ flag */
-	_MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
-#endif
 
 #ifdef __SSE__
-	/* FTZ flag */
-	_MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
+  /* Setting DAZ might freeze systems not supporting it */
+  if(can_we_daz()) {
+    _MM_SET_DENORMALS_ZERO_MODE( _MM_DENORMALS_ZERO_ON );
+  }
+  /* FTZ flag */
+  _MM_SET_FLUSH_ZERO_MODE( _MM_FLUSH_ZERO_ON );
 #endif
 }
 


### PR DESCRIPTION
A long, long time ago denormal protection was added to LMMS, back then it was only fully enabled for builds at a level of SSE3 and higher, because some SSE2 systems could not handle the setting of the DAZ flag. 

A better way would be probing whether the CPU supports the DAZ flag, but back then nobody made the effort, on my part probably because it looked like it would involve a not too small bit of assembly.

This code corrects that and adds the probing, using the info in [Intel® 64 and IA-32 Architectures Software Developer’s Manual, Volume 1: Basic Architecture](https://www.intel.com/content/dam/support/us/en/documents/processors/pentium4/sb/25366521.pdf), chapter 11.6.3, page 325.
