### PR TITLE
Rename "mixer" to "audioengine" on lmmsrc.xml

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -274,6 +274,7 @@ private:
 
 	void upgrade_1_1_90();
 	void upgrade_1_1_91();
+	void upgrade_1_2_2();
 	void upgrade();
 
 	// List of all upgrade methods

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -109,15 +109,14 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	if( renderOnly == false )
 	{
 		m_framesPerPeriod = 
-			( fpp_t ) ConfigManager::inst()->
-				value( "mixer", "framesperaudiobuffer" ).toInt();
+			( fpp_t ) ConfigManager::inst()->value( "audioengine", "framesperaudiobuffer" ).toInt();
 
 		// if the value read from user configuration is not set or
 		// lower than the minimum allowed, use the default value and
 		// save it to the configuration
 		if( m_framesPerPeriod < MINIMUM_BUFFER_SIZE )
 		{
-			ConfigManager::inst()->setValue( "mixer",
+			ConfigManager::inst()->setValue( "audioengine",
 						"framesperaudiobuffer",
 						QString::number( DEFAULT_BUFFER_SIZE ) );
 
@@ -256,8 +255,7 @@ void AudioEngine::stopProcessing()
 
 sample_rate_t AudioEngine::baseSampleRate() const
 {
-	sample_rate_t sr =
-		ConfigManager::inst()->value( "mixer", "samplerate" ).toInt();
+	sample_rate_t sr = ConfigManager::inst()->value( "audioengine", "samplerate" ).toInt();
 	if( sr < 44100 )
 	{
 		sr = 44100;
@@ -956,7 +954,7 @@ AudioDevice * AudioEngine::tryAudioDevices()
 {
 	bool success_ful = false;
 	AudioDevice * dev = nullptr;
-	QString dev_name = ConfigManager::inst()->value( "mixer", "audiodev" );
+	QString dev_name = ConfigManager::inst()->value( "audioengine", "audiodev" );
 	if( !isAudioDevNameValid( dev_name ) )
 	{
 		dev_name = "";
@@ -1102,8 +1100,7 @@ AudioDevice * AudioEngine::tryAudioDevices()
 
 MidiClient * AudioEngine::tryMidiClients()
 {
-	QString client_name = ConfigManager::inst()->value( "mixer",
-								"mididev" );
+	QString client_name = ConfigManager::inst()->value( "audioengine", "mididev" );
 	if( !isMidiDevNameValid( client_name ) )
 	{
 		client_name = "";

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -40,9 +40,8 @@
 
 // Vector with all the upgrade methods
 const std::vector<ConfigManager::UpgradeMethod> ConfigManager::UPGRADE_METHODS = {
-	&ConfigManager::upgrade_1_1_90,
-	&ConfigManager::upgrade_1_1_91,
-	&ConfigManager::upgrade_1_2_2,
+	&ConfigManager::upgrade_1_1_90    ,    &ConfigManager::upgrade_1_1_91,
+	&ConfigManager::upgrade_1_2_2
 };
 
 static inline QString ensureTrailingSlash(const QString & s )

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -40,7 +40,9 @@
 
 // Vector with all the upgrade methods
 const std::vector<ConfigManager::UpgradeMethod> ConfigManager::UPGRADE_METHODS = {
-	&ConfigManager::upgrade_1_1_90    ,    &ConfigManager::upgrade_1_1_91
+	&ConfigManager::upgrade_1_1_90,
+	&ConfigManager::upgrade_1_1_91,
+	&ConfigManager::upgrade_1_2_2,
 };
 
 static inline QString ensureTrailingSlash(const QString & s )
@@ -119,16 +121,46 @@ void ConfigManager::upgrade_1_1_90()
 	}
 }
 
-	
 void ConfigManager::upgrade_1_1_91()
 {
 	// rename displaydbv to displaydbfs
-	if (!value("app", "displaydbv").isNull()) {
+	if (!value("app", "displaydbv").isNull())
+	{
 		setValue("app", "displaydbfs", value("app", "displaydbv"));
 		deleteValue("app", "displaydbv");
 	}
 }
 
+void ConfigManager::upgrade_1_2_2()
+{
+	// Rename mixer to audioengine
+	if (!value("mixer", "audiodev").isNull())
+	{
+		setValue("audioengine", "audiodev", value("mixer", "audiodev"));
+		deleteValue("mixer", "audiodev");
+	}
+	if (!value("mixer", "mididev").isNull())
+	{
+		setValue("audioengine", "mididev", value("mixer", "mididev"));
+		deleteValue("mixer", "mididev");
+	}
+	if (!value("mixer", "framesperaudiobuffer").isNull())
+	{
+		setValue("audioengine", "framesperaudiobuffer", value("mixer", "audiodev"));
+		deleteValue("mixer", "framesperaudiobuffer");
+	}
+	if (!value("mixer", "hqaudio").isNull())
+	{
+		setValue("audioengine", "hqaudio", value("mixer", "hqaudio"));
+		deleteValue("mixer", "hqaudio");
+	}
+	if (!value("mixer", "samplerate").isNull())
+	{
+		setValue("audioengine", "samplerate", value("mixer", "samplerate"));
+		deleteValue("mixer", "samplerate");
+	}
+	m_settings.remove("mixer");
+}
 
 void ConfigManager::upgrade()
 {

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -133,31 +133,19 @@ void ConfigManager::upgrade_1_1_91()
 void ConfigManager::upgrade_1_2_2()
 {
 	// Rename mixer to audioengine
-	if (!value("mixer", "audiodev").isNull())
+	std::vector<QString> attrs = {
+		"audiodev", "mididev", "framesperaudiobuffer", "hqaudio", "samplerate"
+	};
+
+	for (auto attr : attrs)
 	{
-		setValue("audioengine", "audiodev", value("mixer", "audiodev"));
-		deleteValue("mixer", "audiodev");
+		if (!value("mixer", attr).isNull())
+		{
+			setValue("audioengine", attr, value("mixer", attr));
+			deleteValue("mixer", attr);
+		}
 	}
-	if (!value("mixer", "mididev").isNull())
-	{
-		setValue("audioengine", "mididev", value("mixer", "mididev"));
-		deleteValue("mixer", "mididev");
-	}
-	if (!value("mixer", "framesperaudiobuffer").isNull())
-	{
-		setValue("audioengine", "framesperaudiobuffer", value("mixer", "audiodev"));
-		deleteValue("mixer", "framesperaudiobuffer");
-	}
-	if (!value("mixer", "hqaudio").isNull())
-	{
-		setValue("audioengine", "hqaudio", value("mixer", "hqaudio"));
-		deleteValue("mixer", "hqaudio");
-	}
-	if (!value("mixer", "samplerate").isNull())
-	{
-		setValue("audioengine", "samplerate", value("mixer", "samplerate"));
-		deleteValue("mixer", "samplerate");
-	}
+
 	m_settings.remove("mixer");
 }
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -132,7 +132,8 @@ void ConfigManager::upgrade_1_1_91()
 
 void ConfigManager::upgrade_1_2_2()
 {
-	// Rename mixer to audioengine
+	// Since mixer has been renamed to audioengine, we need to transfer the
+	// attributes from the old element to the new one
 	std::vector<QString> attrs = {
 		"audiodev", "mididev", "framesperaudiobuffer", "hqaudio", "samplerate"
 	};

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -263,7 +263,7 @@ void AudioDevice::clearS16Buffer( int_sample_t * _outbuf, const fpp_t _frames )
 
 bool AudioDevice::hqAudio() const
 {
-	return ConfigManager::inst()->value( "mixer", "hqaudio" ).toInt();
+	return ConfigManager::inst()->value( "audioengine", "hqaudio" ).toInt();
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -579,7 +579,7 @@ void MainWindow::finalize()
 	// user and is using AudioDummy as a fallback
 	// or the audio device is set to invalid one
 	else if( Engine::audioEngine()->audioDevStartFailed() || !AudioEngine::isAudioDevNameValid(
-		ConfigManager::inst()->value( "mixer", "audiodev" ) ) )
+		ConfigManager::inst()->value( "audioengine", "audiodev" ) ) )
 	{
 		// if so, offer the audio settings section of the setup dialog
 		SetupDialog sd( SetupDialog::AudioSettings );

--- a/src/gui/SetupDialog.cpp
+++ b/src/gui/SetupDialog.cpp
@@ -141,9 +141,9 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_NaNHandler(ConfigManager::inst()->value(
 			"app", "nanhandler", "1").toInt()),
 	m_hqAudioDev(ConfigManager::inst()->value(
-			"mixer", "hqaudio").toInt()),
+			"audioengine", "hqaudio").toInt()),
 	m_bufferSize(ConfigManager::inst()->value(
-			"mixer", "framesperaudiobuffer").toInt()),
+			"audioengine", "framesperaudiobuffer").toInt()),
 	m_workingDir(QDir::toNativeSeparators(ConfigManager::inst()->workingDir())),
 	m_vstDir(QDir::toNativeSeparators(ConfigManager::inst()->vstDir())),
 	m_ladspaDir(QDir::toNativeSeparators(ConfigManager::inst()->ladspaDir())),
@@ -533,11 +533,11 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	}
 
 	// If no preferred audio device is saved, save the current one.
-	QString audioDevName = ConfigManager::inst()->value("mixer", "audiodev");
+	QString audioDevName = ConfigManager::inst()->value("audioengine", "audiodev");
 	if (m_audioInterfaces->findText(audioDevName) < 0)
 	{
 		audioDevName = Engine::audioEngine()->audioDevName();
-		ConfigManager::inst()->setValue("mixer", "audiodev", audioDevName);
+		ConfigManager::inst()->setValue("audioengine", "audiodev", audioDevName);
 	}
 	m_audioInterfaces->
 		setCurrentIndex(m_audioInterfaces->findText(audioDevName));
@@ -678,11 +678,11 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		m_midiInterfaces->addItem(it.key());
 	}
 
-	QString midiDevName = ConfigManager::inst()->value("mixer", "mididev");
+	QString midiDevName = ConfigManager::inst()->value("audioengine", "mididev");
 	if (m_midiInterfaces->findText(midiDevName) < 0)
 	{
 		midiDevName = Engine::audioEngine()->midiClientName();
-		ConfigManager::inst()->setValue("mixer", "mididev", midiDevName);
+		ConfigManager::inst()->setValue("audioengine", "mididev", midiDevName);
 	}
 	m_midiInterfaces->setCurrentIndex(m_midiInterfaces->findText(midiDevName));
 	m_midiIfaceSetupWidgets[midiDevName]->show();
@@ -950,15 +950,15 @@ void SetupDialog::accept()
 					QString::number(m_syncVSTPlugins));
 	ConfigManager::inst()->setValue("ui", "disableautoquit",
 					QString::number(m_disableAutoQuit));
-	ConfigManager::inst()->setValue("mixer", "audiodev",
+	ConfigManager::inst()->setValue("audioengine", "audiodev",
 					m_audioIfaceNames[m_audioInterfaces->currentText()]);
 	ConfigManager::inst()->setValue("app", "nanhandler",
 					QString::number(m_NaNHandler));
-	ConfigManager::inst()->setValue("mixer", "hqaudio",
+	ConfigManager::inst()->setValue("audioengine", "hqaudio",
 					QString::number(m_hqAudioDev));
-	ConfigManager::inst()->setValue("mixer", "framesperaudiobuffer",
+	ConfigManager::inst()->setValue("audioengine", "framesperaudiobuffer",
 					QString::number(m_bufferSize));
-	ConfigManager::inst()->setValue("mixer", "mididev",
+	ConfigManager::inst()->setValue("audioengine", "mididev",
 					m_midiIfaceNames[m_midiInterfaces->currentText()]);
 	ConfigManager::inst()->setValue("midi", "midiautoassign",
 					m_assignableMidiDevices->currentText());


### PR DESCRIPTION
Although #6127 is now merged, the old name "mixer" persists in the lmmsrc.xml configuration file.