### PR TITLE
Double-click selection in piano roll

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -217,8 +217,6 @@ protected slots:
 
 	void hidePattern( Pattern* pattern );
 
-	void selectRegionFromPixels( int xStart, int xEnd );
-
 	void clearGhostPattern();
 	void glueNotes();
 	void fitNoteLengths(bool fill);
@@ -275,6 +273,14 @@ private:
 		gridNudge,
 		gridSnap
 	//	gridFree
+	};
+
+	enum SelectionMode
+	{
+		SelectionReplace,
+		SelectionAdd,
+		SelectionSubtract,
+		SelectionInvert
 	};
 
 	PositionLine * m_positionLine;
@@ -432,7 +438,7 @@ private:
 	Note * noteUnderMouse();
 
 	// turn a selection rectangle into selected notes
-	void computeSelectedNotes( bool shift );
+	void computeSelectedNotes(SelectionMode mode=SelectionReplace);
 	void clearSelectedNotes();
 
 	// did we start a mouseclick with shift pressed
@@ -482,6 +488,9 @@ private:
 	QBrush m_blackKeyActiveBackground;
 	QBrush m_blackKeyInactiveBackground;
 	QBrush m_blackKeyDisabledBackground;
+
+private slots:
+	void selectRegionFromPixels(int xStart, int xEnd, SelectionMode mode=SelectionReplace);
 
 signals:
 	void positionChanged( const TimePos & );


### PR DESCRIPTION
- Double click in selection mode to select all notes on that time position.
- Hold shift to toggle (not invert). Play video with sound to get an idea:

https://user-images.githubusercontent.com/7693838/136239354-89708470-7f86-4161-9abc-98311ee3e4f2.mp4

#### Q: Wait. How is this logical?
A: In a text editor you can double click to select the whole word.

#### Q: I just want to quickly select and resize a chord. Why do I need to hold ctrl?
1. Shift click without ctrl would create a copy of the note.
2. Double click may be useful for other things in other modes in the future (knife cutting all notes for example)

#### Q: Why the fancy toggle-logic? Just use `selectRegionFromPixels` as-is. It would be 4 lines of code.
1. I find this functionality more useful
2. Thinking of the text editor analogy, double click selects the whole word, even if some letters are selected.
3. Image editors often has a add/remove modifier to their select tool. If the user wants to invert the selection, there is often a [keyboard shortcut instead](https://github.com/zonkmachine/lmms/commit/1b08b987a34910cb54935d551558daa0584c806e).

#### Q: Nobody will every know about this feature except 3 people.
A: Yes, it would be nice with some kind of status-bar-ish-thing that gave a hint. But there is the online docs that nobody reads...

#### Q: *mumble mumble* `private slots` *muble* best practice *muble* motivation?
A: I don't know. Some seasoned dev, tell me if this makes sense.