### PR TITLE
High resolution scrolling

### DIFF
--- a/include/ScrollCounter.h
+++ b/include/ScrollCounter.h
@@ -28,8 +28,10 @@
 #include <QObject>
 #include <QPoint>
 
+#include "lmms_export.h"
 
-class ScrollCounter: public QObject
+
+class LMMS_EXPORT ScrollCounter: public QObject
 {
 public:
 	static int getStepsX(float stepSize = 120);

--- a/include/ScrollCounter.h
+++ b/include/ScrollCounter.h
@@ -1,0 +1,50 @@
+/*
+ * ScrollCounter.h - helper to handle smooth scroll on widgets
+ *
+ * Copyright (c) 2021 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SCROLL_COUNTER_H
+#define SCROLL_COUNTER_H
+
+#include <QObject>
+#include <QPoint>
+
+
+class ScrollCounter: public QObject
+{
+public:
+	static int getStepsX(float stepSize = 120);
+	static int getStepsY(float stepSize = 120);
+	static void registerWidget(QWidget* widget);
+
+	bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+	ScrollCounter();
+
+	static ScrollCounter* s_instance;
+
+	QPoint m_lastScroll;
+	QPoint m_remainder;
+};
+
+#endif

--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -35,6 +35,7 @@
 #include "gui_templates.h"
 #include "interpolation.h"
 #include "MainWindow.h"
+#include "ScrollCounter.h"
 #include "ToolTip.h"
 
 CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
@@ -303,6 +304,8 @@ CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
 	connect(&m_controls->m_stereoLinkModel, SIGNAL(dataChanged()), this, SLOT(stereoLinkChanged()));
 	connect(&m_controls->m_lookaheadModel, SIGNAL(dataChanged()), this, SLOT(lookaheadChanged()));
 	connect(&m_controls->m_limiterModel, SIGNAL(dataChanged()), this, SLOT(limiterChanged()));
+
+	ScrollCounter::registerWidget(this);
 
 	m_timeElapsed.start();
 
@@ -641,7 +644,7 @@ void CompressorControlDialog::resizeEvent(QResizeEvent *event)
 void CompressorControlDialog::wheelEvent(QWheelEvent * event)
 {
 	const float temp = m_dbRange;
-	const float dbRangeNew = m_dbRange - copysignf(COMP_GRID_SPACING, event->angleDelta().y());
+	const float dbRangeNew = m_dbRange - COMP_GRID_SPACING * ScrollCounter::getStepsY();
 	m_dbRange = round(qBound(COMP_GRID_SPACING, dbRangeNew, COMP_GRID_MAX) / COMP_GRID_SPACING) * COMP_GRID_SPACING;
 
 	// Only reset view if the scolling had an effect

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(LMMS_SRCS
 	gui/SampleTCOView.cpp
 	gui/SampleTrackView.cpp
 	gui/SampleTrackWindow.cpp
+	gui/ScrollCounter.cpp
 	gui/SetupDialog.cpp
 	gui/StringPairDrag.cpp
 	gui/SubWindow.cpp

--- a/src/gui/ScrollCounter.cpp
+++ b/src/gui/ScrollCounter.cpp
@@ -1,0 +1,118 @@
+/*
+ * ScrollCounter.cpp - helper to handle smooth scroll on widgets
+ *
+ * Copyright (c) 2021 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "ScrollCounter.h"
+
+#include <QWheelEvent>
+#include <QWidget>
+
+
+ScrollCounter* ScrollCounter::s_instance = nullptr;
+
+
+/*! \brief High-resolution scroll management
+ *
+ * First resister the widget you wish to manage with registerWidget().
+ *
+ * Use getStepsX or getStepsY from within QWidget::wheelEvent to pop a value from the scroll counter.
+ * If the counter is not checked (e.g. the widget choose to ignore the event) it will not be increased.
+ *
+ * Since the counter relies on an event filter, you cannot call QWidget::wheelEvent directly,
+ * as this would bypass the filter. Instead use QCoreApplication::sendEvent.
+ */
+ScrollCounter::ScrollCounter()
+{
+}
+
+
+
+
+//! Monitor scroll events of given widget
+void ScrollCounter::registerWidget(QWidget* widget)
+{
+	// Create global instance
+	if (s_instance == nullptr) { s_instance = new ScrollCounter(); }
+
+	widget->installEventFilter(s_instance);
+}
+
+
+
+//! Return number of horizontally scrolled steps of size stepSize (120 = 15°)
+int ScrollCounter::getStepsX(float stepSize)
+{
+	/* Only return a value if the last wheel event had this direction. Why? Imagine this scenario:
+	 *
+	 *   if (controlPressed)
+	 *		zoom(counter->getStepsY(120));
+	 *   else
+	 *		scrollWindow(counter->getStepsX(1), conter->getStepsY(1));
+	 *
+	 * In this example, the first statement has a higher stepSize (threshold if you will) than the second.
+	 *
+	 * If the user presses control and scrolls 100 units VERTICALLY, it will not be enough to hit the threshold,
+	 * and the value will be stored for later. If the user then releases control and scrolls HORIZONTALLY, the code
+	 * would return the previous 100 units due to the much lower threshold and thus ALSO scroll the window VERTICALLY.
+	 */
+
+	if (s_instance == nullptr || s_instance->m_lastScroll.x() == 0) { return 0; }
+
+	int sum = s_instance->m_lastScroll.x() + s_instance->m_remainder.x();
+	int quotient = sum / stepSize;
+	s_instance->m_remainder.setX(sum - quotient * stepSize);
+	return quotient;
+}
+
+
+
+//! Return number of vertically scrolled steps of size stepSize (120 = 15°)
+int ScrollCounter::getStepsY(float stepSize)
+{
+	if (s_instance == nullptr || s_instance->m_lastScroll.y() == 0) { return 0; }
+
+	int sum = s_instance->m_lastScroll.y() + s_instance->m_remainder.y();
+	int quotient = sum / stepSize;
+	s_instance->m_remainder.setY(sum - quotient * stepSize);
+	return quotient;
+}
+
+
+
+
+bool ScrollCounter::eventFilter(QObject *watchedObject, QEvent *event)
+{
+	if (event->type() == QEvent::Leave)
+	{
+		// Reset counter when mouse leaves the widget
+		m_remainder.setX(0);
+		m_remainder.setY(0);
+	}
+	else if (event->type() == QEvent::Wheel)
+	{
+		// Remember the last seen wheelEvent
+		// in case we get a call in a few secs
+		m_lastScroll = static_cast<QWheelEvent*>(event)->angleDelta();
+	}
+	return QObject::eventFilter(watchedObject, event);
+}

--- a/src/gui/TrackContainerView.cpp
+++ b/src/gui/TrackContainerView.cpp
@@ -474,10 +474,12 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 	// bb-editor etc.) because they might want to use it for zooming
 	// or scrolling left/right if a modifier-key is pressed, otherwise
 	// they do not accept it and we pass it up to QScrollArea
-	m_trackContainerView->wheelEvent( _we );
+	QApplication::sendEvent(m_trackContainerView, _we);
 	if( !_we->isAccepted() )
 	{
 		QScrollArea::wheelEvent( _we );
+		// Don't let it propagate up to MDI area
+		_we->accept();
 	}
 }
 

--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -29,6 +29,7 @@
 
 #include "CaptionMenu.h"
 #include "MainWindow.h"
+#include "ScrollCounter.h"
 
 
 
@@ -45,6 +46,8 @@ AutomatableSlider::AutomatableSlider( QWidget * _parent,
 					this, SLOT( changeValue( int ) ) );
 	connect( this, SIGNAL( sliderMoved( int ) ),
 					this, SLOT( moveSlider( int ) ) );
+
+	ScrollCounter::registerWidget(this);
 }
 
 
@@ -97,7 +100,7 @@ void AutomatableSlider::wheelEvent( QWheelEvent * _me )
 {
 	bool old_status = m_showStatus;
 	m_showStatus = true;
-	QSlider::wheelEvent( _me );
+	model()->incValue(ScrollCounter::getStepsY());
 	m_showStatus = old_status;
 }
 

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -36,6 +36,7 @@
 #include "embed.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
+#include "ScrollCounter.h"
 
 
 QPixmap * ComboBox::s_background = nullptr;
@@ -76,6 +77,8 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 
 	setWindowTitle( _name );
 	doConnections();
+
+	ScrollCounter::registerWidget(this);
 }
 
 
@@ -232,7 +235,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 {
 	if( model() )
 	{
-		model()->setInitValue(model()->value() + ((event->angleDelta().y() < 0) ? 1 : -1));
+		model()->setInitValue(model()->value() + ScrollCounter::getStepsY());
 		update();
 		event->accept();
 	}

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -43,6 +43,7 @@
 #include "GuiApplication.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
+#include "ScrollCounter.h"
 
 
 LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& name, QWidget* parent) :
@@ -181,7 +182,7 @@ void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 	else { m_intStep = false; }
 
 	event->accept();
-	model()->setValue(model()->value() + ((event->angleDelta().y() > 0) ? 1 : -1) * getStep());
+	model()->setValue(model()->value() + ScrollCounter::getStepsY() * getStep());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -35,6 +35,7 @@
 #include "CaptionMenu.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
+#include "ScrollCounter.h"
 
 
 
@@ -46,6 +47,7 @@ LcdSpinBox::LcdSpinBox( int numDigits, QWidget* parent, const QString& name ) :
 	m_lastMousePos(),
 	m_displayOffset( 0 )
 {
+	ScrollCounter::registerWidget(this);
 }
 
 
@@ -59,6 +61,7 @@ LcdSpinBox::LcdSpinBox( int numDigits, const QString& style, QWidget* parent, co
 	m_lastMousePos(),
 	m_displayOffset( 0 )
 {
+	ScrollCounter::registerWidget(this);
 }
 
 void LcdSpinBox::update()
@@ -145,7 +148,7 @@ void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
 	we->accept();
-	model()->setInitValue(model()->value() + ((we->angleDelta().y() > 0) ? 1 : -1) * model()->step<int>());
+	model()->setInitValue(model()->value() + ScrollCounter::getStepsY() * model()->step<int>());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -34,6 +34,7 @@
 #include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"
+#include "ScrollCounter.h"
 
 TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 					 bool resizable) :
@@ -48,7 +49,6 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 	m_tabBackground( 0, 0, 0 ),
 	m_tabBorder( 0, 0, 0 )
 {
-
 	// Create taller tabbar when it's to display artwork tabs
 	m_tabbarHeight = usePixmap ? GRAPHIC_TAB_HEIGHT : TEXT_TAB_HEIGHT;
 
@@ -62,6 +62,7 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 	pal.setColor( QPalette::Background, bg_color );
 	setPalette( pal );
 
+	ScrollCounter::registerWidget(this);
 }
 
 void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, int idx )
@@ -295,7 +296,7 @@ void TabWidget::wheelEvent( QWheelEvent * we )
 	}
 
 	we->accept();
-	int dir = (we->angleDelta().y() < 0) ? 1 : -1;
+	int dir = 0 - ScrollCounter::getStepsX() - ScrollCounter::getStepsY();
 	int tab = m_activeTab;
 	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
 	{


### PR DESCRIPTION
Handle really sensitive scroll wheels (or touch pads) gracefully.

### Problem

Most widgets only check if a scroll event is positive or negative, and scroll exactly one step. For mice like the MX master this may result in 7 steps per mouse wheel tick, because it has a wheel resolution of 2° (compared to standard 15°).

### Solution

This PR implements a concise way to calculate scrolled steps, while keeping the remainder value, [as suggested by the Qt docs](https://doc.qt.io/qt-5/qwheelevent.html#angleDelta). The remainder is discarded when the widget loses focus.

Widgets are updated to use this new counter logic. This means that editors, knobs and faders may be scrolled with a much finer precision using a hi-res mouse.

This also sets a new minimum scroll speed for knobs and faders (at most 200 steps form start to end). Scrolling really really fast on a standard mouse is also ~faster~ more accurate now.

### Excuses
I've tried to build the counter in a way that using it would require as little code as possible, and no need to remember increasing, decreasing or resetting it. In other words, make it so you can't get it wrong.

- Using `ScrollCounter` is cleaner than having an `int` member in each widget and doing the same calculation in 20 places.
- `ScrollCounter` is a [singleton](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Ri-singleton) because there is only one scroll wheel, so why would each widget have its own instance of it?
- If a widget doesn't check the counter during event handling, the counter won't be increased. This prevents it from silently growing when scroll events are being ignored or propagated to the parent.
- Also, thanks to the event filter, widgets never have to pass `QWheelEvent` to the counter.

As a side note, I've tried a way to intercept `QWheelEvent` and solve this problem higher up in the event chain. But this does not work due to how Qt does (undocumented) event propagation.

### Bugs fixed in this PR
- #3370 (not tested)
- #5511 (a matter of taste)
- Horizontal scroll on most automatable controls decrease their value
- Alt+scroll in piano roll note edit area only decreases the velocity
- Scrolling on empty pattern in song editor while zoomed in creates step notes even if they are invisible

### Other questionable changes
- Song editor's horizontal scroll step size is now based on zoom level
- Allow horizontal scroll in Piano roll's note edit area
- Scrolling inside Song editor never scrolls the MDI window
  - #3154