### PR TITLE
Fixed issue of build when fpermissive isn't enabled

### DIFF
--- a/plugins/MidiImport/portsmf/allegro.h
+++ b/plugins/MidiImport/portsmf/allegro.h
@@ -610,7 +610,7 @@ typedef class Serial_write_buffer: public Serial_buffer {
 #if defined(_WIN32)
 //#pragma warning(disable: 4311 4312)
 #endif
-        assert((char *)(((long) (ptr + 7)) & ~7) <= fence);
+        assert((char *)(((long long) (ptr + 7)) & ~7) <= fence);
 #if defined(_WIN32)
 //#pragma warning(default: 4311 4312)
 #endif


### PR DESCRIPTION
lmms wouldn't build on my windows x64 setup due to the fact char* pointers have a long long size rather than a long size so I fixed it by changing the cast to long long, it should still work on platforms where long is used as the container type has enough place to contain the value