### PR TITLE
Implement MIDI output note setting

### DIFF
--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -163,6 +163,12 @@ void MidiPort::processOutEvent( const MidiEvent& event, const TimePos& time )
 			outEvent.setVelocity( fixedOutputVelocity() );
 		}
 
+		if( fixedOutputNote() >= 0 &&
+			( event.type() == MidiNoteOn || event.type() == MidiNoteOff || event.type() == MidiKeyPressure ) )
+		{
+			outEvent.setKey( fixedOutputNote() );
+		}
+
 		m_midiClient->processOutEvent( outEvent, time, this );
 	}
 }
@@ -232,6 +238,7 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_outputControllerModel.loadSettings( thisElement, "outputcontroller" );
 	m_fixedInputVelocityModel.loadSettings( thisElement, "fixedinputvelocity" );
 	m_fixedOutputVelocityModel.loadSettings( thisElement, "fixedoutputvelocity" );
+	m_fixedOutputNoteModel.loadSettings( thisElement, "fixedoutputnote" );
 	m_outputProgramModel.loadSettings( thisElement, "outputprogram" );
 	m_baseVelocityModel.loadSettings( thisElement, "basevelocity" );
 	m_readableModel.loadSettings( thisElement, "readable" );


### PR DESCRIPTION
Now the fixed output note setting in the MIDI tab actually works and all notes output to the same key if specified.