### PR TITLE
Fix conditional crash when shifting notes in the Piano Roll

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1222,6 +1222,11 @@ void PianoRoll::shiftPos(int amount) //Shift notes pos by amount
 void PianoRoll::shiftPos(NoteVector notes, int amount)
 {
 	m_pattern->addJournalCheckPoint();
+
+	if (notes.isEmpty()) {
+		return;
+	}
+
 	auto leftMostPos = notes.first()->pos();
 	//Limit leftwards shifts to prevent moving left of pattern start
 	auto shiftAmount = (leftMostPos > -amount) ? amount : -leftMostPos;


### PR DESCRIPTION
Fixes #6039.

Crash was caused by trying to access the first object in an empty vector.
Added check for empty vector.