### PR TITLE
More LV2 buf-size features

### DIFF
--- a/src/core/lv2/Lv2Features.cpp
+++ b/src/core/lv2/Lv2Features.cpp
@@ -69,7 +69,15 @@ void Lv2Features::createFeatureVectors()
 	// create vector of features
 	for(std::pair<const char* const, void*>& pr : m_featureByUri)
 	{
-		Q_ASSERT(pr.second != nullptr);
+		/*
+			If pr.second is nullptr here, this means that the LV2_feature
+			has no "data". If this happens here, this means
+			* either that this feature is static
+			  (e.g. LV2_BUF_SIZE__boundedBlockLength)
+			* or that the programmer forgot to use operator[] before feature
+			  vector creation (This can be done in
+			  Lv2Proc::initPluginSpecificFeatures or in Lv2Features::initCommon)
+		*/
 		m_features.push_back(LV2_Feature { pr.first, pr.second });
 	}
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <lilv/lilv.h>
 #include <lv2.h>
+#include <lv2/lv2plug.in/ns/ext/buf-size/buf-size.h>
 #include <lv2/lv2plug.in/ns/ext/options/options.h>
 #include <QDebug>
 #include <QDir>
@@ -78,6 +79,10 @@ Lv2Manager::Lv2Manager() :
 	m_supportedFeatureURIs.insert(LV2_URID__map);
 	m_supportedFeatureURIs.insert(LV2_URID__unmap);
 	m_supportedFeatureURIs.insert(LV2_OPTIONS__options);
+	// min/max is always passed in the options
+	m_supportedFeatureURIs.insert(LV2_BUF_SIZE__boundedBlockLength);
+	// block length is only changed initially in AudioEngine CTOR
+	m_supportedFeatureURIs.insert(LV2_BUF_SIZE__fixedBlockLength);
 
 	auto supportOpt = [this](Lv2UridCache::Id id)
 	{


### PR DESCRIPTION
Implement `LV2_BUF_SIZE__boundedBlockLength` and `LV2_BUF_SIZE__fixedBlockLength`.

It was an oversight when we implemented buf-size to not implement these two. This PR implements them and will give access to a couple of plugins. Highlights:

* Helm
* Some new Guitarix effects

The full list:

```
ADLplug
Dexed
dRowAudio: Distortion
dRowAudio: Distortion Shaper
dRowAudio: Flanger
dRowAudio: Reverb
dRowAudio Tremolo
DrumSynth
EQinox
Gxjcm800pre
Gxjcm800preST
GxMetalAmp
GxMetalHead
GxRedeye Big Chump
GxRedeye Chump
GxRedeye Vibro Chump
Helm
HiReSam
JuceOPL
KlangFalter
LUFS Meter
Luftikus
Noize Mak3r
Obxd
OPNplug
PitchedDelay
ReFine
StereoSourceSeparation
Swanky Amp
Tal-Dub-3
Tal-Filter
Tal-Filter-2
Tal-Reverb
Tal-Reverb-II
Tal-Reverb-III
Tal-Vocoder-II
Temper
The Function
The Pilgrim
Vex
Vitalium
Wolpertinger
```

Reviews:

* Code-review would be nice. If no one has time for code-review, will be merged in 7 days without.
* Testing can be done: Check if some of those plugins must be blacklisted (at least, for me, "DrumSynth" causes high CPU and crashes when I open the instrument window).