### PR TITLE
added pianoview context menu for first/last/base, fixed small reset v…

### DIFF
--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -30,6 +30,7 @@
 
 #include "AutomatableModel.h"
 #include "ModelView.h"
+#include "ModelView.h"
 
 class Piano;
 
@@ -40,9 +41,9 @@ class PianoView : public QWidget, public ModelView
 public:
 	PianoView( QWidget * _parent );
 	virtual ~PianoView() = default;
-
 	static int getKeyFromKeyEvent( QKeyEvent * _ke );
-
+	static QString getNoteStringByKey(int key);
+	const static QString noteStrings[];
 
 public:
 	void keyPressEvent( QKeyEvent * ke ) override;
@@ -67,6 +68,7 @@ private:
 	int getKeyWidth(int key_num) const;
 	int getKeyHeight(int key_num) const;
 	IntModel *getNearestMarker(int key, QString* title = nullptr);
+	void setMarkerKeyValue(IntModel *noteModel, int key_num);
 
 	static QPixmap * s_whiteKeyPm;
 	static QPixmap * s_blackKeyPm;
@@ -81,11 +83,15 @@ private:
 	int m_startKey;					//!< first key when drawing
 	int m_lastKey;					//!< previously pressed key
 	IntModel *m_movedNoteModel;		//!< note marker which is being moved
-
+	int m_lastContextMenuKey;		//!< previous key selected by the context menu
 
 
 private slots:
 	void pianoScrolled( int _new_pos );
+	void setBaseNote();
+	void setFirstKey();
+	void setLastKey();
+	void setSingleKey();
 
 signals:
 	void keyPressed( int );

--- a/src/gui/PianoView.cpp
+++ b/src/gui/PianoView.cpp
@@ -152,6 +152,21 @@ PianoView::PianoView(QWidget *parent) :
 	connect(Engine::getSong(), SIGNAL(keymapListChanged(int)), this, SLOT(update()));
 }
 
+
+/*! \brief list of note strings
+ */
+const QString PianoView::noteStrings[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+
+
+/*! \brief return a note string (e.g. "C4") based on the key number
+ *  \param key The midi key number
+ */
+QString PianoView::getNoteStringByKey(int key)
+{
+	return noteStrings[key % 12] + QString::number(static_cast<int>(FirstOctave + key / KeysPerOctave));
+}
+
+
 /*! \brief Map a keyboard key being pressed to a note in our keyboard view
  *
  *  \param _k The keyboard scan code of the key being pressed.
@@ -402,33 +417,59 @@ void PianoView::pianoScrolled(int new_pos)
 }
 
 
-
-
-/*! \brief Handle a context menu selection on the piano display view
+/*! \brief Handle a context menu selection on the piano view
  *
  *  \param me the ContextMenuEvent to handle.
  *  \todo Is this right, or does this create the context menu?
  */
 void PianoView::contextMenuEvent(QContextMenuEvent *me)
 {
-	if (me->pos().y() > PIANO_BASE || m_piano == nullptr ||
+	if (m_piano == nullptr ||
 		m_piano->instrumentTrack()->keyRangeImport())
 	{
 		QWidget::contextMenuEvent(me);
 		return;
 	}
 
-	// check which control element is closest to the mouse and open the appropriate menu
 	QString title;
-	IntModel *noteModel = getNearestMarker(getKeyFromMouse(me->pos()), &title);
+	int key_num = getKeyFromMouse(me->pos());
 
-	CaptionMenu contextMenu(title);
-	AutomatableModelView amv(noteModel, &contextMenu);
-	amv.addDefaultActions(&contextMenu);
-	contextMenu.exec(QCursor::pos());
+	if (me->pos().y() > PIANO_BASE)
+	{
+		// context menu for the key area
+		m_lastContextMenuKey = key_num;
+
+		title = QString("Key %1 [%2]").arg(getNoteStringByKey(key_num)).arg(key_num);
+
+		CaptionMenu contextMenu(title);
+		QAction *actionBase = contextMenu.addAction(tr( "Set &base note" ),
+								this, SLOT( setBaseNote() ) );
+		contextMenu.addSeparator();
+
+		QAction *actionFirst = contextMenu.addAction(tr( "Set &first key" ),
+								this, SLOT( setFirstKey() ) );
+		QAction *actionLast = contextMenu.addAction(tr( "Set &last key" ),
+								this, SLOT( setLastKey() ) );
+		contextMenu.addAction(tr( "Set single key" ),
+								this, SLOT( setSingleKey() ) );
+
+		actionFirst->setEnabled(key_num != m_piano->instrumentTrack()->firstKeyModel()->value());
+		actionLast->setEnabled(key_num != m_piano->instrumentTrack()->lastKeyModel()->value());
+		actionBase->setEnabled(key_num != m_piano->instrumentTrack()->baseNoteModel()->value());
+
+		contextMenu.exec(QCursor::pos());
+	}
+	else
+	{
+		// context menu for the black stripe above the keys containing the first/last/base markers
+		IntModel *noteModel = getNearestMarker(key_num, &title);
+		CaptionMenu contextMenu(title);
+		AutomatableModelView amv(noteModel, &contextMenu);
+		amv.addDefaultActions(&contextMenu);
+
+		contextMenu.exec(QCursor::pos());
+	}
 }
-
-
 
 
 // handler for mouse-click-event
@@ -488,8 +529,7 @@ void PianoView::mousePressEvent(QMouseEvent *me)
 			}
 			else
 			{
-				m_movedNoteModel->setInitValue(static_cast<float>(key_num));
-				if (m_movedNoteModel == m_piano->instrumentTrack()->baseNoteModel()) { emit baseNoteChanged(); }	// TODO: not actually used by anything?
+				setMarkerKeyValue(m_movedNoteModel,key_num);
 			}
 		}
 		else
@@ -500,6 +540,39 @@ void PianoView::mousePressEvent(QMouseEvent *me)
 		// and let the user see that he pressed a key... :)
 		update();
 	}
+}
+
+
+void PianoView::setMarkerKeyValue(IntModel *noteModel, int key_num)
+{
+	noteModel->setValue(static_cast<float>(key_num));
+	if (noteModel == m_piano->instrumentTrack()->baseNoteModel()) { emit baseNoteChanged(); }	// TODO: not actually used by anything?
+}
+
+
+void PianoView::setBaseNote()
+{
+	setMarkerKeyValue(m_piano->instrumentTrack()->baseNoteModel(), m_lastContextMenuKey);
+	update();
+}
+
+void PianoView::setFirstKey()
+{
+	setMarkerKeyValue(m_piano->instrumentTrack()->firstKeyModel(), m_lastContextMenuKey);
+	update();
+}
+
+void PianoView::setLastKey()
+{
+	setMarkerKeyValue(m_piano->instrumentTrack()->lastKeyModel(), m_lastContextMenuKey);
+	update();
+}
+
+void PianoView::setSingleKey()
+{
+	setMarkerKeyValue(m_piano->instrumentTrack()->firstKeyModel(), m_lastContextMenuKey);
+	setMarkerKeyValue(m_piano->instrumentTrack()->lastKeyModel(), m_lastContextMenuKey);
+	update();
 }
 
 
@@ -596,7 +669,7 @@ void PianoView::mouseMoveEvent( QMouseEvent * _me )
 			else if (m_movedNoteModel != nullptr)
 			{
 				// upper section, move the base / first / last note marker
-				m_movedNoteModel->setInitValue(static_cast<float>(key_num));
+				setMarkerKeyValue(m_movedNoteModel,key_num);
 			}
 		}
 		// and let the user see that he pressed a key... :)
@@ -866,17 +939,25 @@ void PianoView::paintEvent( QPaintEvent * )
 		const int last_key = m_piano->instrumentTrack()->lastKeyModel()->value();
 		QColor marker_color = QApplication::palette().color(QPalette::Active, QPalette::BrightText);
 
-		// - prepare triangle shapes for start / end markers
+		// - prepare triangle shapes for start/end/base markers
+
+		// arrow pointing right
 		QPainterPath first_marker(QPoint(getKeyX(first_key) + 1, 1));
 		first_marker.lineTo(getKeyX(first_key) + 1, PIANO_BASE);
 		first_marker.lineTo(getKeyX(first_key) + PIANO_BASE / 2 + 1, PIANO_BASE / 2);
 
+		// arrow pointing left
 		QPainterPath last_marker(QPoint(getKeyX(last_key) + getKeyWidth(last_key), 1));
 		last_marker.lineTo(getKeyX(last_key) + getKeyWidth(last_key), PIANO_BASE);
 		last_marker.lineTo(getKeyX(last_key) + getKeyWidth(last_key) - PIANO_BASE / 2, PIANO_BASE / 2);
 
+		// arrow pointing down
+		QPainterPath base_marker(QPoint(getKeyX(base_key)+1, 1));
+		base_marker.lineTo(getKeyX(base_key) + getKeyWidth(base_key) + 1, 1);
+		base_marker.lineTo(getKeyX(base_key) + getKeyWidth(base_key) / 2 + 1, PIANO_BASE);
+
 		// - fill all markers
-		p.fillRect(QRect(getKeyX(base_key), 1, getKeyWidth(base_key) - 1, PIANO_BASE - 2), marker_color);
+		p.fillPath(base_marker, marker_color);
 		p.fillPath(first_marker, marker_color);
 		p.fillPath(last_marker, marker_color);
 	}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -123,13 +123,6 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 TextFloat * PianoRoll::s_textFloat = nullptr;
 
-static QString s_noteStrings[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-
-static QString getNoteString(int key)
-{
-	return s_noteStrings[key % 12] + QString::number(static_cast<int>(FirstOctave + key / KeysPerOctave));
-}
-
 // used for drawing of piano
 PianoRoll::PianoRollKeyTypes PianoRoll::prKeyOrder[] =
 {
@@ -387,7 +380,7 @@ PianoRoll::PianoRoll() :
 	// Set up key selection dropdown
 	m_keyModel.addItem(tr("No key"));
 	// Use piano roll note strings for key dropdown
-	for (int i = 0; i < 12; i++) { m_keyModel.addItem(s_noteStrings[i]); }
+	for (int i = 0; i < 12; i++) { m_keyModel.addItem(PianoView::noteStrings[i]); }
 	m_keyModel.setValue(0); // start with "No key"
 	connect(&m_keyModel, &ComboBoxModel::dataChanged, this, &PianoRoll::keyChanged);
 
@@ -1038,7 +1031,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 		int const noteTextHeight = static_cast<int>(noteHeight * 0.8);
 		if (noteTextHeight > 6)
 		{
-			QString noteKeyString = getNoteString(n->key());
+			QString noteKeyString = PianoView::getNoteStringByKey(n->key());
 
 			QFont noteFont(p.font());
 			noteFont.setPixelSize(noteTextHeight);
@@ -3211,7 +3204,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			{
 				// small font sizes have 1 pixel offset instead of 2
 				auto zoomOffset = m_zoomYLevels[m_zoomingYModel.value()] > 1.0f ? 2 : 1;
-				QString noteString = getNoteString(key);
+				QString noteString = PianoView::getNoteStringByKey(key);
 				QRect textRect(
 					m_whiteKeyWidth - boundingRect.width() - 2,
 					yb - m_keyLineHeight + zoomOffset,


### PR DESCRIPTION
This implements a context menu for the instrument piano view for setting the base note and the first/last key as discussed in the issue LMMS/lmms#6224. The context menu is only available in the key section of the PianoView. The automation context menu behavior in the black stripe above is not changed. 

![image](https://user-images.githubusercontent.com/93736385/148269245-61ec6fa2-1cf7-41a9-8a1d-4e1ce9d9453d.png)

"Set single key" sets the first and last key so just a single key is left:

![image](https://user-images.githubusercontent.com/93736385/148269312-f098a7ac-91be-47b9-b7a1-053826e20ac9.png)

The menu entries are disabled accordingly if the operation would just set the same value as already set.

Additionally the shape of the base note marker is changed from an rectangle to an arrow:

![image](https://user-images.githubusercontent.com/93736385/148269721-60ec1fed-7ae0-4539-8639-bb13cf4cc33c.png)

A small bugfix is also applied - the value of the base note an the first/last key was set by a setInitValue call instead of setValue (seems to be the same bug as described in LMMS/lmms#6213). So the reset value reflects now the correct initial value. 

![image](https://user-images.githubusercontent.com/93736385/148269936-8904698d-64c7-4963-bd0e-e06a6526975e.png)

The getNoteString method was moved to the PianoView an renamed to getNoteStringByKey to make it possible to use it from both the PianoRoll and the PianoView. 


