### PR TITLE
VeSTige Searches Original Path of Assigned VST Plugin in Former Syste…

### DIFF
--- a/plugins/vestige/vestige.cpp
+++ b/plugins/vestige/vestige.cpp
@@ -181,13 +181,13 @@ vestigeInstrument::~vestigeInstrument()
 
 void vestigeInstrument::loadSettings( const QDomElement & _this )
 {
-	QString plugin = _this.attribute( "plugin" );
+	QString plugin = QFileInfo( _this.attribute( "plugin" ) ).fileName();
 	if( plugin.isEmpty() )
 	{
 		return;
 	}
 
-	loadFile( plugin );
+	loadFile( ConfigManager::inst()->vstDir() + plugin );
 	m_pluginMutex.lock();
 	if( m_plugin != NULL )
 	{
@@ -263,7 +263,7 @@ void vestigeInstrument::reloadPlugin()
 
 void vestigeInstrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
-	_this.setAttribute( "plugin", m_pluginDLL );
+	_this.setAttribute( "plugin", QFileInfo( m_pluginDLL ).fileName() );
 	m_pluginMutex.lock();
 	if( m_plugin != NULL )
 	{


### PR DESCRIPTION
…m When Opening Project File #6271

A Patch to fix this issues minimally.

I think 1.3.0-a has good modification. However, we would also consider forward compatibility. In this patch, the path for VSTi will be rewritten to the path you configured. Besides, the path in the former system won't be saved in a project file. Running test is on Ubuntu 20.04.3 LTS.

Note that no change in vestigeInstrument::saveSettings makes forward compatibility between 1.2.2 and this patch. However, it should be changed if your community thinks a saved path causes a privacy breach.