### PR TITLE
midioss: Use unbuffered I/O to access the device node.

### DIFF
--- a/src/core/midi/MidiOss.cpp
+++ b/src/core/midi/MidiOss.cpp
@@ -40,9 +40,9 @@ MidiOss::MidiOss() :
 	// only start thread, if opening of MIDI-device is successful,
 	// otherwise isRunning()==false indicates error
 	if( m_midiDev.open( QIODevice::ReadWrite |
-		QIODevice::Unbuffered | QIODevice::ExistingOnly ) ||
+		QIODevice::Unbuffered ) ) ||
 		m_midiDev.open( QIODevice::ReadOnly |
-			QIODevice::Unbuffered | QIODevice::ExistingOnly ) )
+			QIODevice::Unbuffered ) )
 	{
 		start( QThread::LowPriority );
 	}

--- a/src/core/midi/MidiOss.cpp
+++ b/src/core/midi/MidiOss.cpp
@@ -39,8 +39,10 @@ MidiOss::MidiOss() :
 {
 	// only start thread, if opening of MIDI-device is successful,
 	// otherwise isRunning()==false indicates error
-	if( m_midiDev.open( QIODevice::ReadWrite ) ||
-					m_midiDev.open( QIODevice::ReadOnly ) )
+	if( m_midiDev.open( QIODevice::ReadWrite |
+		QIODevice::Unbuffered | QIODevice::ExistingOnly ) ||
+		m_midiDev.open( QIODevice::ReadOnly |
+			QIODevice::Unbuffered | QIODevice::ExistingOnly ) )
 	{
 		start( QThread::LowPriority );
 	}


### PR DESCRIPTION
This fixes problems reading from MIDI devices on NetBSD - the
input blocked until a certain number of notes have been read
rather than returning immediately when a single note is received.