### PR TITLE
Update PianoRoll.h

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -209,6 +209,7 @@ protected slots:
 	void noteLengthChanged();
 	void keyChanged();
 	void quantizeNotes(QuantizeActions mode = QuantizeBoth);
+	void strumNotesDn();
 
 	void updateSemiToneMarkerMenu();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4590,56 +4590,6 @@ int PianoRoll::quantization() const
 	return DefaultTicksPerBar / Quantizations[m_quantizeModel.value() - 1];
 }
 
-int returnStrum(int st)//input > read value from comboBox Q. Output size of strum
-{
-int strumSize = 0;
-	switch (st)
-	{   
-	//------sys-notes------------
-	case 1:
-        strumSize = 196;//Wholenote
-	break;
-        case 2:
-        strumSize = 98; //halfnote
-	break;
-        case 3:
-        strumSize = 48; //quoter
-	break;
-        case 4:
-        strumSize = 24; // 1/8
-	break;
-        case 5:
-        strumSize = 12; //1/16
-	break;
-        case 6:
-        strumSize = 6; //1/32
-	break;
-        case 7:
-        strumSize = 3; //1/64
-	break;
-	//---------triplets------------
-        case 8:
-        strumSize = 64; //1/2
-	break;
-        case 9:
-        strumSize = 32; //1/4
-	break;
-        case 10:
-        strumSize = 16; //1/8
-	break;
-        case 11:
-        strumSize = 8; //1/16
-	break;
-        case 12:
-        strumSize = 4; //1/32
-	break;
-        default:
-        strumSize = 1; //1/192 //smallest tick-value Availble if option 0 #notelock# is chosen
-	break;
-    }
-    return strumSize;
-}
-
 void PianoRoll::strumNotesDn() //down-top
 //Method for chord-strumming.
 //The strum-distance is the chosen Q-value
@@ -4656,7 +4606,7 @@ void PianoRoll::strumNotesDn() //down-top
   index = m_quantizeModel.value();	//uses UserSet Q-Value in combobox
   									//This value is position, so it need to be qualified
 									//to real piano/roll values
-  int strumSz = returnStrum(index); //size of note movement 
+  int strumSz = quantization(); //size of note movement	determined by users chosen Q-value in dropdown
   int strum = strumSz;//keep orr. value of selected strumming
   bool firstDone = false;//first note should not be moved
   for( Note* n : notes ) //for each selected

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4594,13 +4594,13 @@ void PianoRoll::strumNotesDn() //down-top
 //Method for chord-strumming.
 //The strum-distance is the chosen Q-value
 {
-  if( ! hasValidPattern() )
+  if(! hasValidMidiClip())
   {
      return;
   }
   int notesInChord = 0; //initializations
   int index = 0;
-  m_pattern->addJournalCheckPoint();
+  m_midiClip->addJournalCheckPoint();
   NoteVector notes = getSelectedNotes();//NoteVector of class QVector
   notesInChord = notes.count();//how many notes are in this chord
   index = m_quantizeModel.value();	//uses UserSet Q-Value in combobox
@@ -4609,19 +4609,19 @@ void PianoRoll::strumNotesDn() //down-top
   int strumSz = quantization(); //size of note movement	determined by users chosen Q-value in dropdown
   int strum = strumSz;//keep orr. value of selected strumming
   bool firstDone = false;//first note should not be moved
-  for( Note* n : notes ) //for each selected
+  for(Note* n : notes) //for each selected
   {
     n = notes.at(notesInChord-1);//Use QVector-method .at
     notesInChord-=1;
-    if( firstDone ){
+    if(firstDone){
         n->setPos( n->pos() + strumSz );
         strumSz += strum; }
     firstDone = true;
         if (notesInChord<=1) continue;      
   }    
-m_pattern->rearrangeAllNotes();
-m_pattern->updateLength();
-m_pattern->dataChanged();
+m_midiClip->rearrangeAllNotes();
+m_midiClip->updateLength();
+m_midiClip->dataChanged();
 update();//Project is changed. Update
 gui->songEditor()->update();
 Engine::getSong()->setModified();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4590,7 +4590,6 @@ int PianoRoll::quantization() const
 	return DefaultTicksPerBar / Quantizations[m_quantizeModel.value() - 1];
 }
 
-øøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøøø
 int returnStrum(int st)//input > read value from comboBox Q. Output size of strum
 {
 int strumSize = 0;


### PR DESCRIPTION
This addresses part of  #2380 
In pianoroll.h Added one prototype 
void strumNotesDn();
This done so new method can be added to pianoroll.cpp in next PR.
In pianoroll.cpp
Update PianoRoll.cpp
I have added one method
void PianoRoll::strumNotesDn()
This method will strum a stack of notes with the size of user-chosen value of Q
I have added one button for this action next to the Quantize button.
This button has tooltip, but it does not have an icon!
I hope our artists will create one in the style of current default theme. (if my patch is accepted.

