### PR TITLE
Fix Song Editor selection CPU hog

### DIFF
--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -45,9 +45,10 @@ public:
 	{
 	}
 
-	inline void setSelected( bool _selected )
+	inline void setSelected(bool selected)
 	{
-		m_selected = _selected;
+		if (m_selected == selected) { return; }
+		m_selected = selected;
 		update();
 	}
 


### PR DESCRIPTION
Add a long sample clip, hold control and move the mouse around. Computer: *suffocates\*

This is a simple fix.