### PR TITLE
Rename BB and TCO to clip and pattern in save files

### DIFF
--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -149,7 +149,7 @@ public:
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;
 
-	static const QString classNodeName() { return "automationpattern"; }
+	static const QString classNodeName() { return "automationclip"; }
 	QString nodeName() const override { return classNodeName(); }
 
 	ClipView * createView( TrackView * _tv ) override;

--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -123,6 +123,7 @@ private:
 	void upgrade_extendedNoteRange();
 	void upgrade_defaultTripleOscillatorHQ();
 	void upgrade_mixerRename();
+	void upgrade_bbTcoRename();
 
 	// List of all upgrade methods
 	static const std::vector<UpgradeMethod> UPGRADE_METHODS;

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -91,8 +91,7 @@ public:
 	void loadSettings( const QDomElement & _this ) override;
 	inline QString nodeName() const override
 	{
-		//TODO: rename to "midiClip"
-		return "pattern";
+		return "midiclip";
 	}
 
 	inline InstrumentTrack * instrumentTrack() const

--- a/include/PatternClip.h
+++ b/include/PatternClip.h
@@ -43,7 +43,7 @@ public:
 	void loadSettings( const QDomElement & _this ) override;
 	inline QString nodeName() const override
 	{
-		return( "bbtco" ); // TODO rename to patternclip
+		return "patternclip";
 	}
 
 	int patternIndex();

--- a/include/PatternStore.h
+++ b/include/PatternStore.h
@@ -69,7 +69,7 @@ public:
 
 	inline QString nodeName() const override
 	{
-		return "bbtrackcontainer"; // TODO rename to patternstore
+		return "patternstore";
 	}
 
 	bar_t lengthOfPattern(int pattern) const;

--- a/include/PatternTrack.h
+++ b/include/PatternTrack.h
@@ -77,7 +77,7 @@ public:
 protected:
 	inline QString nodeName() const override
 	{
-		return( "bbtrack" ); //TODO rename to patterntrack
+		return "patterntrack";
 	}
 
 

--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -48,7 +48,7 @@ public:
 	void loadSettings( const QDomElement & _this ) override;
 	inline QString nodeName() const override
 	{
-		return "sampletco";
+		return "sampleclip";
 	}
 
 	SampleBuffer* sampleBuffer()

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -138,7 +138,7 @@ bool MidiExport::tryExport(const TrackContainer::TrackList &tracks,
 					base_volume = LocaleHelper::toDouble(it.attribute("volume", "100"))/100.0;
 				}
 
-				if (n.nodeName() == "pattern") //TODO: rename to "midiClip"
+				if (n.nodeName() == "midiclip")
 				{
 					base_time = n.toElement().attribute("pos", "0").toInt();
 					writeMidiClip(midiClip, n, base_pitch, base_volume, base_time);
@@ -160,7 +160,7 @@ bool MidiExport::tryExport(const TrackContainer::TrackList &tracks,
 			for (QDomNode n = element.firstChild(); !n.isNull(); n = n.nextSibling())
 			{
 
-				if (n.nodeName() == "bbclip")  // TODO rename to patternclip
+				if (n.nodeName() == "patternclip")
 				{
 					QDomElement it = n.toElement();
 					int pos = it.attribute("pos", "0").toInt();
@@ -211,7 +211,7 @@ bool MidiExport::tryExport(const TrackContainer::TrackList &tracks,
 				base_volume = LocaleHelper::toDouble(it.attribute("volume", "100")) / 100.0;
 			}
 
-			if (n.nodeName() == "pattern") //TODO: rename to "midiClip"
+			if (n.nodeName() == "midiclip")
 			{
 				std::vector<std::pair<int,int>> &plist = *itr;
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -45,6 +45,7 @@
 #include "ProjectVersion.h"
 #include "SongEditor.h"
 #include "TextFloat.h"
+#include "Track.h"
 #include "PathUtil.h"
 
 #include "lmmsversion.h"
@@ -54,7 +55,7 @@ static void findIds(const QDomElement& elem, QList<jo_id_t>& idList);
 
 // QMap with the DOM elements that access file resources
 const DataFile::ResourcesMap DataFile::ELEMENTS_WITH_RESOURCES = {
-{ "sampletco", {"src"} },
+{ "sampleclip", {"src"} },
 { "audiofileprocessor", {"src"} },
 };
 
@@ -71,7 +72,7 @@ const std::vector<DataFile::UpgradeMethod> DataFile::UPGRADE_METHODS = {
 	&DataFile::upgrade_1_3_0            ,   &DataFile::upgrade_noHiddenClipNames,
 	&DataFile::upgrade_automationNodes  ,   &DataFile::upgrade_extendedNoteRange,
 	&DataFile::upgrade_defaultTripleOscillatorHQ,
-	&DataFile::upgrade_mixerRename
+	&DataFile::upgrade_mixerRename      ,   &DataFile::upgrade_bbTcoRename,
 };
 
 // Vector of all versions that have upgrade routines.
@@ -95,7 +96,7 @@ DataFile::typeDescStruct
 	{ DataFile::ClipboardData, "clipboard-data" },
 	{ DataFile::JournalData, "journaldata" },
 	{ DataFile::EffectSettings, "effectsettings" },
-	{ DataFile::MidiClip, "pattern" }
+	{ DataFile::MidiClip, "midiclip" }
 } ;
 
 
@@ -1785,6 +1786,40 @@ void DataFile::upgrade_mixerRename()
 		{
 			fxch.item(i).toElement().setAttribute("mixch", fxch.item(i).toElement().attribute("fxch"));
 			fxch.item(i).toElement().removeAttribute("fxch");
+		}
+	}
+}
+
+
+// Rename BB to pattern and TCO to clip
+void DataFile::upgrade_bbTcoRename()
+{
+	std::vector<std::pair<const char *, const char *>> names {
+		{"automationpattern", "automationclip"},
+		{"bbtco", "patternclip"},
+		{"pattern", "midiclip"},
+		{"sampletco", "sampleclip"},
+		{"bbtrack", "patterntrack"},
+		{"bbtrackcontainer", "patternstore"},
+	};
+	// Replace names of XML tags
+	for (auto name : names)
+	{
+		QDomNodeList elements = elementsByTagName(name.first);
+		for (int i = 0; !elements.item(i).isNull(); ++i)
+		{
+			elements.item(i).toElement().setTagName(name.second);
+		}
+	}
+	// Replace "Beat/Bassline" with "Pattern" in track names
+	QDomNodeList elements = elementsByTagName("track");
+	for (int i = 0; !elements.item(i).isNull(); ++i)
+	{
+		auto e = elements.item(i).toElement();
+		static_assert(Track::PatternTrack == 1, "Must be type=1 for backwards compatibility");
+		if (e.attribute("type").toInt() == Track::PatternTrack)
+		{
+			e.setAttribute("name", e.attribute("name").replace("Beat/Bassline", "Pattern"));
 		}
 	}
 }

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1112,7 +1112,7 @@ void Song::loadProject( const QString & fileName )
 				++m_nLoadingTrack;
 				if (nd.toElement().attribute("type").toInt() == Track::PatternTrack)
 				{
-					n += nd.toElement().elementsByTagName("bbtrack").at(0) // TODO rename to patterntrack
+					n += nd.toElement().elementsByTagName("patterntrack").at(0)
 						.toElement().firstChildElement().childNodes().count();
 				}
 				nd=nd.nextSibling();

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -161,8 +161,9 @@ Track * Track::create( const QDomElement & element, TrackContainer * tc )
  */
 Track* Track::clone()
 {
+	// Save track to temporary XML and load it to create a new identical track
 	QDomDocument doc;
-	QDomElement parent = doc.createElement("clone");
+	QDomElement parent = doc.createElement("clonedtrack");
 	saveState(doc, parent);
 	Track* t = create(parent.firstChild().toElement(), m_trackContainer);
 

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -149,14 +149,15 @@ void PatternTrack::saveTrackSpecificSettings(QDomDocument& doc, QDomElement& _th
 /*	_this.setAttribute( "current", s_infoMap[this] ==
 					engine::getPatternEditor()->currentPattern() );*/
 	if( s_infoMap[this] == 0 &&
-			_this.parentNode().parentNode().nodeName() != "clone" &&
+			_this.parentNode().parentNode().nodeName() != "clonedtrack" &&
 			_this.parentNode().parentNode().nodeName() != "journaldata" )
 	{
 		Engine::patternStore()->saveState(doc, _this);
 	}
-	if( _this.parentNode().parentNode().nodeName() == "clone" )
+	// If we are creating drag-n-drop data for Track::clone() only save pattern ID, not pattern content
+	if (_this.parentNode().parentNode().nodeName() == "clonedtrack")
 	{
-		_this.setAttribute( "clonebbt", s_infoMap[this] );  // TODO rename bb to pattern
+		_this.setAttribute("sourcepattern", s_infoMap[this]);
 	}
 }
 
@@ -170,9 +171,11 @@ void PatternTrack::loadTrackSpecificSettings(const QDomElement& _this)
 		m_trackLabel->setPixmapFile( _this.attribute( "icon" ) );
 	}*/
 
-	if( _this.hasAttribute( "clonebbt" ) )  // TODO rename bb to pattern
+	// If data was created by Track::clone(), do not add any tracks to the pattern(-editor)
+	// instead create a new copy of the clip on each track
+	if (_this.hasAttribute("sourcepattern"))
 	{
-		const int src = _this.attribute( "clonebbt" ).toInt(); // TODO rename bb to pattern
+		const int src = _this.attribute("sourcepattern").toInt();
 		const int dst = s_infoMap[this];
 		TrackContainer::TrackList tl =
 					Engine::patternStore()->tracks();


### PR DESCRIPTION
Upgrade method in `DataFile` + renamed some tags used internally to clone pattern tracks

**SAVING FILES WITH THIS WILL MAKE INCOMPATIBLE TO OLDER LMMS (BB tracks will be empty)!**

Things to test
- open old project, check automation, instruments, samples and patterns aka BBs
- **save project as new**, open and check again
- midi export
- cloning patterns aka BB tracks