### PR TITLE
Lv2: Don't show ports with prop `notOnGUI`

### DIFF
--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -32,6 +32,7 @@
 #include <QPushButton>
 #include <QHBoxLayout>
 #include <lilv/lilv.h>
+#include <lv2/port-props/port-props.h>
 
 #include "AudioEngine.h"
 #include "Controls.h"
@@ -102,18 +103,22 @@ Lv2ViewProc::Lv2ViewProc(QWidget* parent, Lv2Proc* ctrlBase, int colNum) :
 	ctrlBase->foreach_port(
 		[this, &commentUri](const Lv2Ports::PortBase* port)
 		{
-			SetupWidget setup;
-			setup.m_par = this;
-			setup.m_commentUri = commentUri.get();
-			port->accept(setup);
-
-			if (setup.m_control)
+			if(!lilv_port_has_property(port->m_plugin, port->m_port,
+										uri(LV2_PORT_PROPS__notOnGUI).get()))
 			{
-				addControl(setup.m_control,
-					lilv_node_as_string(lilv_port_get_symbol(
-						port->m_plugin, port->m_port)),
-					port->name().toUtf8().data(),
-					false);
+				SetupWidget setup;
+				setup.m_par = this;
+				setup.m_commentUri = commentUri.get();
+				port->accept(setup);
+
+				if (setup.m_control)
+				{
+					addControl(setup.m_control,
+						lilv_node_as_string(lilv_port_get_symbol(
+							port->m_plugin, port->m_port)),
+						port->name().toUtf8().data(),
+						false);
+				}
 			}
 		});
 }

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -32,7 +32,7 @@
 #include <QPushButton>
 #include <QHBoxLayout>
 #include <lilv/lilv.h>
-#include <lv2/port-props/port-props.h>
+#include <lv2/lv2plug.in/ns/ext/port-props/port-props.h>
 
 #include "AudioEngine.h"
 #include "Controls.h"

--- a/src/gui/widgets/LinkedModelGroupViews.cpp
+++ b/src/gui/widgets/LinkedModelGroupViews.cpp
@@ -86,7 +86,6 @@ void LinkedModelGroupView::modelChanged(LinkedModelGroup *group)
 void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 	const std::string &display, bool removable)
 {
-	int wdgNum = static_cast<int>(m_widgets.size());
 	if (ctrl)
 	{
 		QWidget* box = new QWidget(this);
@@ -116,7 +115,6 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 
 		// take ownership of control and add it
 		m_widgets.emplace(id, std::unique_ptr<Control>(ctrl));
-		++wdgNum;
 	}
 
 	if (isHidden()) { setHidden(false); }


### PR DESCRIPTION
Additionally, this commit removes an unused variable.

Original discussion: Comments in #6254 .