### PR TITLE
Make loop markers snap to same increments as clips

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -180,7 +180,7 @@ public slots:
 	{
 		updatePosition( TimePos() );
 	}
-	void updateSnapSize( const float snapSize )
+	void setSnapSize( const float snapSize )
 	{
 		m_snapSize = snapSize;
 	}

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -180,6 +180,10 @@ public slots:
 	{
 		updatePosition( TimePos() );
 	}
+	void updateSnapSize( const float snapSize )
+	{
+		m_snapSize = snapSize;
+	}
 	void toggleAutoScroll( int _n );
 	void toggleLoopPoints( int _n );
 	void toggleBehaviourAtStop( int _n );
@@ -217,6 +221,7 @@ private:
 	int m_xOffset;
 	int m_posMarkerX;
 	float m_ppb;
+	float m_snapSize;
 	Song::PlayPos & m_pos;
 	const TimePos & m_begin;
 	const Song::PlayModes m_mode;

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -413,11 +413,11 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 				// marking instead of pushing it.
 				if( m_action == MoveLoopBegin ) 
 				{
-					m_loopPos[0] -= TimePos::ticksPerBar();
+					m_loopPos[0] -= m_snapSize * TimePos::ticksPerBar();
 				}
 				else
 				{
-					m_loopPos[1] += TimePos::ticksPerBar();
+					m_loopPos[1] += m_snapSize * TimePos::ticksPerBar();
 				}
 			}
 			update();

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -344,7 +344,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 		{
 			m_action = MoveLoopBegin;
 		}
-		else if( t > loopMid )
+		else
 		{
 			m_action = MoveLoopEnd;
 		}

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -62,6 +62,7 @@ TimeLineWidget::TimeLineWidget( const int xoff, const int yoff, const float ppb,
 	m_xOffset( xoff ),
 	m_posMarkerX( 0 ),
 	m_ppb( ppb ),
+	m_snapSize( 1.0 ),
 	m_pos( pos ),
 	m_begin( begin ),
 	m_mode( mode ),
@@ -403,7 +404,7 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 			}
 			else
 			{
-				m_loopPos[i] = t.quantize(1.0);
+				m_loopPos[i] = t.quantize(m_snapSize);
 			}
 			// Catch begin == end
 			if( m_loopPos[0] == m_loopPos[1] )

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -341,7 +341,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 		const TimePos loopMid = ( m_loopPos[0] + m_loopPos[1] ) / 2;
 
 		m_action = t < loopMid ? MoveLoopBegin : MoveLoopEnd;
-		std::sort(m_loopPos, std::end(m_loopPos));
+		std::sort(std::begin(m_loopPos), std::end(m_loopPos));
 		m_loopPos[( m_action == MoveLoopBegin ) ? 0 : 1] = t;
 	}
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -395,7 +395,8 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 		case MoveLoopEnd:
 		{
 			const int i = m_action - MoveLoopBegin; // i == 0 || i == 1
-			if( event->modifiers() & Qt::ControlModifier )
+			const bool control = event->modifiers() & Qt::ControlModifier;
+			if (control)
 			{
 				// no ctrl-press-hint when having ctrl pressed
 				delete m_hint;
@@ -407,18 +408,13 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 				m_loopPos[i] = t.quantize(m_snapSize);
 			}
 			// Catch begin == end
-			if( m_loopPos[0] == m_loopPos[1] )
+			if (m_loopPos[0] == m_loopPos[1])
 			{
+				const int offset = control ? 1 : m_snapSize * TimePos::ticksPerBar();
 				// Note, swap 1 and 0 below and the behavior "skips" the other
 				// marking instead of pushing it.
-				if( m_action == MoveLoopBegin ) 
-				{
-					m_loopPos[0] -= m_snapSize * TimePos::ticksPerBar();
-				}
-				else
-				{
-					m_loopPos[1] += m_snapSize * TimePos::ticksPerBar();
-				}
+				if (m_action == MoveLoopBegin) { m_loopPos[0] -= offset; }
+				else { m_loopPos[1] += offset; }
 			}
 			update();
 			break;

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -340,20 +340,8 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 		const TimePos t = m_begin + static_cast<int>( qMax( event->x() - m_xOffset - m_moveXOff, 0 ) * TimePos::ticksPerBar() / m_ppb );
 		const TimePos loopMid = ( m_loopPos[0] + m_loopPos[1] ) / 2;
 
-		if( t < loopMid )
-		{
-			m_action = MoveLoopBegin;
-		}
-		else
-		{
-			m_action = MoveLoopEnd;
-		}
-
-		if( m_loopPos[0] > m_loopPos[1]  )
-		{
-			qSwap( m_loopPos[0], m_loopPos[1] );
-		}
-
+		m_action = t < loopMid ? MoveLoopBegin : MoveLoopEnd;
+		std::sort(m_loopPos, std::end(m_loopPos));
 		m_loopPos[( m_action == MoveLoopBegin ) ? 0 : 1] = t;
 	}
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -102,7 +102,8 @@ SongEditor::SongEditor( Song * song ) :
 	connect( this, SIGNAL( zoomingValueChanged( float ) ),
 			 m_positionLine, SLOT( zoomChange( float ) ) );
 			 
-	// ensure loop markers snap to correct size
+	// Ensure loop markers snap to same increments as clips. Zoom & proportional
+	// snap changes are handled in zoomingChanged() and toggleProportionalSnap()
 	connect(m_snappingModel, &ComboBoxModel::dataChanged,
 		[this]() { m_timeLine->setSnapSize(getSnapSize()); });
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -104,9 +104,7 @@ SongEditor::SongEditor( Song * song ) :
 			 
 	// ensure loop markers snap to correct size
 	connect(m_snappingModel, &ComboBoxModel::dataChanged,
-		[=]() { m_timeLine->updateSnapSize(getSnapSize()); });
-	connect(m_zoomingModel, &ComboBoxModel::dataChanged,
-		[=]() { m_timeLine->updateSnapSize(getSnapSize()); });
+		[this]() { m_timeLine->setSnapSize(getSnapSize()); });
 
 
 	// add some essential widgets to global tool-bar
@@ -468,6 +466,7 @@ void SongEditor::setEditModeSelect()
 void SongEditor::toggleProportionalSnap()
 {
 	m_proportionalSnap = !m_proportionalSnap;
+	m_timeLine->setSnapSize(getSnapSize());
 }
 
 
@@ -846,6 +845,7 @@ void SongEditor::zoomingChanged()
 					setPixelsPerBar( pixelsPerBar() );
 	realignTracks();
 	updateRubberband();
+	m_timeLine->setSnapSize(getSnapSize());
 	
 	emit zoomingValueChanged( m_zoomLevels[m_zoomingModel->value()] );
 }
@@ -1019,8 +1019,6 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_setProportionalSnapAction->setChecked(false);
 	connect(m_setProportionalSnapAction, SIGNAL(triggered()), m_editor, SLOT(toggleProportionalSnap()));
 	connect(m_setProportionalSnapAction, SIGNAL(triggered()), this, SLOT(updateSnapLabel()) );
-	connect(m_setProportionalSnapAction, &QAction::triggered,
-		[=]() { m_editor->m_timeLine->updateSnapSize(m_editor->getSnapSize()); });
 
 	snapToolBar->addWidget( snap_lbl );
 	snapToolBar->addWidget( m_snappingComboBox );

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -468,7 +468,6 @@ void SongEditor::setEditModeSelect()
 void SongEditor::toggleProportionalSnap()
 {
 	m_proportionalSnap = !m_proportionalSnap;
-	m_timeLine->updateSnapSize(getSnapSize());
 }
 
 
@@ -1020,6 +1019,8 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_setProportionalSnapAction->setChecked(false);
 	connect(m_setProportionalSnapAction, SIGNAL(triggered()), m_editor, SLOT(toggleProportionalSnap()));
 	connect(m_setProportionalSnapAction, SIGNAL(triggered()), this, SLOT(updateSnapLabel()) );
+	connect(m_setProportionalSnapAction, &QAction::triggered,
+		[=]() { m_editor->m_timeLine->updateSnapSize(m_editor->getSnapSize()); });
 
 	snapToolBar->addWidget( snap_lbl );
 	snapToolBar->addWidget( m_snappingComboBox );

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -101,6 +101,12 @@ SongEditor::SongEditor( Song * song ) :
 			 m_positionLine, SLOT( update() ) );
 	connect( this, SIGNAL( zoomingValueChanged( float ) ),
 			 m_positionLine, SLOT( zoomChange( float ) ) );
+			 
+	// ensure loop markers snap to correct size
+	connect(m_snappingModel, &ComboBoxModel::dataChanged,
+		[=]() { m_timeLine->updateSnapSize(getSnapSize()); });
+	connect(m_zoomingModel, &ComboBoxModel::dataChanged,
+		[=]() { m_timeLine->updateSnapSize(getSnapSize()); });
 
 
 	// add some essential widgets to global tool-bar
@@ -462,6 +468,7 @@ void SongEditor::setEditModeSelect()
 void SongEditor::toggleProportionalSnap()
 {
 	m_proportionalSnap = !m_proportionalSnap;
+	m_timeLine->updateSnapSize(getSnapSize());
 }
 
 


### PR DESCRIPTION
A bit of an oversight from the enhanced song editor snapping PR, now fixed. Tested and working on my end, unsure if there's a cleaner way to make sure that the snap size is updated when proportional snap is toggled.

Closes #6007