### PR TITLE
Apply clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,84 @@
+---
+# Language
+Language:        Cpp
+Standard:        Cpp11  # Cpp14 and Cpp17 are not supported by clang 11
+
+# Indentation
+TabWidth:        4
+UseTab:          Always
+IndentWidth:     4
+ColumnLimit:     120
+
+# Indentation detail
+AlignAfterOpenBracket: DontAlign
+ContinuationIndentWidth: 4
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerIndentWidth: 4
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+BinPackParameters: true
+BinPackArguments: true
+AlignOperands: false
+
+# Alignment
+AlignEscapedNewlines: DontAlign
+AccessModifierOffset: -4
+AllowShortBlocksOnASingleLine: Always
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+BreakBeforeBinaryOperators: All
+
+# Includes
+IncludeBlocks:   Regroup
+IncludeCategories:
+  # windows.h must go before everything else
+  # otherwise, you will get errors
+  - Regex:           '^<windows.h>$'
+    Priority:        -99
+  # the "main header" implicitly gets priority 0
+  # system headers
+  - Regex:           '^<[^>]+>$'
+    Priority:        1
+  # non-system headers
+  - Regex:           '.*'
+    Priority:        2
+SortIncludes:    true
+
+# Spaces
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+
+# Brace wrapping
+# Not directly mentioned in the coding conventions,
+# but required to avoid tons of auto reformatting
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+  BeforeWhile: false
+  BeforeLambdaBody: false
+
+# Do not break doxygen comments
+CommentPragmas:  '^[[:space:]]*\\.+'
+
+# Pointers
+# Use pointer close to type: `const char* const* function()`
+PointerAlignment: Left
+
+...
+

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,33 @@
+---
+Checks:          'bugprone-macro-parentheses,bugprone-macro-repeated-side-effects,modernize-use-override,readability-identifier-naming,readability-misleading-indentation,readability-simplify-boolean-expr,readability-braces-around-statements'
+WarningsAsErrors: ''
+HeaderFilterRegex: '' # don't show errors from headers
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            user
+CheckOptions:    
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.TypedefCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StructCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+# not yet working, as it currently applies both for static and object members
+# - key:             readability-identifier-naming.MemberPrefix
+#   value:           'm_'
+  # currently only working for local static variables:
+  - key:             readability-identifier-naming.StaticVariablePrefix
+    value:           's_'
+# not yet working
+# - key:             readability-identifier-naming.VariableCase
+#   value:           camelBack
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+...
+


### PR DESCRIPTION
This code here should be the same as in #5948 . Asking for final review.

A good "playground" might be src/gui/editors/PianoRoll.cpp (>5000 lines).

Note: The review can also end with "Let's better not take clang-format", that is also OK.