### PR TITLE
Fix track handles dissapearing

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -168,8 +168,6 @@ public slots:
 protected:
 	static const int DEFAULT_PIXELS_PER_BAR = 16;
 
-	void resizeEvent( QResizeEvent * ) override;
-
 	TimePos m_currentPosition;
 
 

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -89,11 +89,15 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	m_tc->setHook( this );
 	//keeps the direction of the widget, undepended on the locale
 	setLayoutDirection( Qt::LeftToRight );
+
+	// The main layout - by default it only contains the scroll area,
+	// but SongEditor uses the layout to add a TimeLineWidget on top
 	auto layout = new QVBoxLayout(this);
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing( 0 );
 	layout->addWidget( m_scrollArea );
 
+	// The widget that will contain all TrackViews
 	auto scrollContent = new QWidget;
 	m_scrollLayout = new QVBoxLayout( scrollContent );
 	m_scrollLayout->setContentsMargins(0, 0, 0, 0);
@@ -101,6 +105,7 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	m_scrollLayout->setSizeConstraint( QLayout::SetMinAndMaxSize );
 
 	m_scrollArea->setWidget( scrollContent );
+	m_scrollArea->setWidgetResizable(true);
 
 	m_scrollArea->show();
 	m_rubberBand->hide();
@@ -254,10 +259,6 @@ void TrackContainerView::scrollToTrackView( TrackView * _tv )
 
 void TrackContainerView::realignTracks()
 {
-	m_scrollArea->widget()->setFixedWidth(width());
-	m_scrollArea->widget()->setFixedHeight(
-				m_scrollArea->widget()->minimumSizeHint().height());
-
 	for (const auto& trackView : m_trackViews)
 	{
 		trackView->show();
@@ -442,15 +443,6 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		Track::create( dataFile.content().firstChild().toElement(), m_tc );
 		_de->accept();
 	}
-}
-
-
-
-
-void TrackContainerView::resizeEvent( QResizeEvent * _re )
-{
-	realignTracks();
-	QWidget::resizeEvent( _re );
 }
 
 


### PR DESCRIPTION
Fixes #6334, by letting Qt handle resizing of Song Editor's content.

I don't exactly understand what triggered the original bug, so testing is needed :smile:

Also this PR removes unnecessary **redrawing of ALL clips** when:

- Moving a track
- Adding or deleting a track
- Changing height of a track
- Changing height of Song Editor
- Opening/closing Song Editor