### PR TITLE
Rename LedCheckbox to LedCheckBox in filenames

### DIFF
--- a/include/LedCheckBox.h
+++ b/include/LedCheckBox.h
@@ -1,5 +1,5 @@
 /*
- * LedCheckbox.h - class LedCheckBox, an improved QCheckBox
+ * LedCheckBox.h - class LedCheckBox, an improved QCheckBox
  *
  * Copyright (c) 2005-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -31,7 +31,7 @@
 
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "lmmsconfig.h"
 #include "MidiClient.h"
 #include "MidiSetupWidget.h"

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -30,7 +30,7 @@
 #include "BitcrushControlDialog.h"
 #include "BitcrushControls.h"
 #include "ToolTip.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "Knob.h"
 
 BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -29,7 +29,7 @@
 #include "CrossoverEQControls.h"
 #include "embed.h"
 #include "ToolTip.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "Knob.h"
 #include "Fader.h"
 

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -27,7 +27,7 @@
 #include "DualFilterControlDialog.h"
 #include "DualFilterControls.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "ComboBox.h"
 #include "ToolTip.h"
 #include "gui_templates.h"

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -30,7 +30,7 @@
 #include "AutomatableButton.h"
 #include "embed.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "PixmapButton.h"
 
 #include "EqControls.h"

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -26,7 +26,7 @@
 
 #include "embed.h"
 #include "FlangerControls.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "TempoSyncKnob.h"
 
 

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -37,7 +37,7 @@
 #include "InstrumentView.h"
 #include "Knob.h"
 #include "LcdSpinBox.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "MemoryManager.h"
 #include "gig.h"
 

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -35,7 +35,7 @@
 #include "LadspaControls.h"
 #include "LadspaControlDialog.h"
 #include "LadspaControlView.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 
 
 

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -29,7 +29,7 @@
 #include "embed.h"
 #include "Graph.h"
 #include "ToolTip.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "Knob.h"
 #include "TempoSyncKnob.h"
 #include "LcdSpinBox.h"

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -33,7 +33,7 @@
 #include "ComboBox.h"
 #include "ComboBoxModel.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "PixmapButton.h"
 #include "SaControls.h"
 #include "SaProcessor.h"

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -29,7 +29,7 @@
 #include <QVBoxLayout>
 
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "VecControls.h"
 #include "Vectorscope.h"
 #include "VectorView.h"

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -33,7 +33,7 @@
 #include "GuiApplication.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "MainWindow.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"

--- a/plugins/bit_invader/bit_invader.cpp
+++ b/plugins/bit_invader/bit_invader.cpp
@@ -32,7 +32,7 @@
 #include "Graph.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"
 #include "ToolTip.h"

--- a/plugins/kicker/kicker.cpp
+++ b/plugins/kicker/kicker.cpp
@@ -32,7 +32,7 @@
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "NotePlayHandle.h"
 #include "KickerOsc.h"
 #include "TempoSyncKnob.h"

--- a/plugins/lb302/lb302.cpp
+++ b/plugins/lb302/lb302.cpp
@@ -38,7 +38,7 @@
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "NotePlayHandle.h"
 #include "Oscillator.h"
 #include "PixmapButton.h"

--- a/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
+++ b/plugins/peak_controller_effect/peak_controller_effect_control_dialog.cpp
@@ -32,7 +32,7 @@
 #include "peak_controller_effect_control_dialog.h"
 #include "peak_controller_effect_controls.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "embed.h"
 
 

--- a/plugins/stk/mallets/mallets.h
+++ b/plugins/stk/mallets/mallets.h
@@ -34,7 +34,7 @@
 #include "InstrumentView.h"
 #include "Knob.h"
 #include "NotePlayHandle.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 
 // As of Stk 4.4 all classes and types have been moved to the namespace "stk".
 // However in older versions this namespace does not exist, therefore declare it

--- a/plugins/vibed/vibed.cpp
+++ b/plugins/vibed/vibed.cpp
@@ -31,7 +31,7 @@
 #include "Graph.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "NotePlayHandle.h"
 #include "PixmapButton.h"
 #include "ToolTip.h"

--- a/plugins/waveshaper/waveshaper_control_dialog.cpp
+++ b/plugins/waveshaper/waveshaper_control_dialog.cpp
@@ -32,7 +32,7 @@
 #include "Knob.h"
 #include "PixmapButton.h"
 #include "ToolTip.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 
 
 waveShaperControlDialog::waveShaperControlDialog(

--- a/plugins/zynaddsubfx/ZynAddSubFx.cpp
+++ b/plugins/zynaddsubfx/ZynAddSubFx.cpp
@@ -36,7 +36,7 @@
 #include "ConfigManager.h"
 #include "Engine.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "DataFile.h"
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -88,7 +88,7 @@ SET(LMMS_SRCS
 	gui/widgets/LcdFloatSpinBox.cpp
 	gui/widgets/LcdSpinBox.cpp
 	gui/widgets/LcdWidget.cpp
-	gui/widgets/LedCheckbox.cpp
+	gui/widgets/LedCheckBox.cpp
 	gui/widgets/ControlLayout.cpp
 	gui/widgets/LinkedModelGroupViews.cpp
 	gui/widgets/MeterDialog.cpp

--- a/src/gui/ControllerConnectionDialog.cpp
+++ b/src/gui/ControllerConnectionDialog.cpp
@@ -35,7 +35,7 @@
 #include "MidiClient.h"
 #include "MidiPortMenu.h"
 #include "LcdSpinBox.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "ComboBox.h"
 #include "GroupBox.h"
 #include "Song.h"

--- a/src/gui/InstrumentTrackWindow.cpp
+++ b/src/gui/InstrumentTrackWindow.cpp
@@ -55,7 +55,7 @@
 #include "InstrumentTrackView.h"
 #include "Knob.h"
 #include "LcdSpinBox.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "LeftRightNav.h"
 #include "MainWindow.h"
 #include "PianoView.h"

--- a/src/gui/dialogs/VersionedSaveDialog.cpp
+++ b/src/gui/dialogs/VersionedSaveDialog.cpp
@@ -31,7 +31,7 @@
 
 #include "DeprecationHelper.h"
 #include "VersionedSaveDialog.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 
 
 VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,

--- a/src/gui/widgets/Controls.cpp
+++ b/src/gui/widgets/Controls.cpp
@@ -30,7 +30,7 @@
 
 #include "ComboBox.h"
 #include "LcdSpinBox.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "Knob.h"
 
 

--- a/src/gui/widgets/EffectView.cpp
+++ b/src/gui/widgets/EffectView.cpp
@@ -34,7 +34,7 @@
 #include "GuiApplication.h"
 #include "gui_templates.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "MainWindow.h"
 #include "SubWindow.h"
 #include "TempoSyncKnob.h"

--- a/src/gui/widgets/EnvelopeAndLfoView.cpp
+++ b/src/gui/widgets/EnvelopeAndLfoView.cpp
@@ -32,7 +32,7 @@
 #include "Engine.h"
 #include "gui_templates.h"
 #include "Knob.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "AudioEngine.h"
 #include "DataFile.h"
 #include "Oscillator.h"

--- a/src/gui/widgets/InstrumentMiscView.cpp
+++ b/src/gui/widgets/InstrumentMiscView.cpp
@@ -33,7 +33,7 @@
 #include "GroupBox.h"
 #include "gui_templates.h"
 #include "InstrumentTrack.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 
 
 InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :

--- a/src/gui/widgets/LadspaControlView.cpp
+++ b/src/gui/widgets/LadspaControlView.cpp
@@ -29,7 +29,7 @@
 #include "LadspaControl.h"
 #include "LadspaControlView.h"
 #include "LadspaBase.h"
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "TempoSyncKnob.h"
 #include "ToolTip.h"
 

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -1,5 +1,5 @@
 /*
- * LedCheckbox.cpp - class LedCheckBox, an improved QCheckBox
+ * LedCheckBox.cpp - class LedCheckBox, an improved QCheckBox
  *
  * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *
@@ -26,7 +26,7 @@
 #include <QFontMetrics>
 #include <QPainter>
 
-#include "LedCheckbox.h"
+#include "LedCheckBox.h"
 #include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"


### PR DESCRIPTION
Justification: The class is named `LedCheckBox`, and other files follow
the casing of the classes, too.