### PR TITLE
Fix SF2 Player segfault when releasing C-1 notes

### DIFF
--- a/plugins/sf2_player/sf2_player.cpp
+++ b/plugins/sf2_player/sf2_player.cpp
@@ -631,7 +631,7 @@ void sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		int midiNote = (int)floor( 12.0 * ( log2( _n->unpitchedFrequency() ) - LOG440 ) - 4.0 );
 
 		// out of range?
-		if( midiNote <= 0 || midiNote >= 128 )
+		if( midiNote < 0 || midiNote >= 128 )
 		{
 			return;
 		}


### PR DESCRIPTION
The SF2 Player had an off-by-one error when checking the range of MIDI note values. This caused an early return and missing initialization of `NotePlayHandle->m_pluginData` fields when playing C-1 notes, leading to a subsequent segmentation fault when releasing the note.