### PR TITLE
Sample caching

### DIFF
--- a/include/Engine.h
+++ b/include/Engine.h
@@ -33,6 +33,7 @@
 #include "lmmsconfig.h"
 #include "lmms_export.h"
 #include "lmms_basics.h"
+#include "SampleCache.h"
 
 class AudioEngine;
 class Mixer;
@@ -143,6 +144,7 @@ private:
 	static AudioEngine *s_audioEngine;
 	static Mixer * s_mixer;
 	static Song * s_song;
+	static SampleCache * s_sampleCache;
 	static PatternStore * s_patternStore;
 	static ProjectJournal * s_projectJournal;
 

--- a/include/SampleCache.h
+++ b/include/SampleCache.h
@@ -1,0 +1,37 @@
+/*
+ * SampleCache.h - A class for the sample cache
+ *
+ * Copyright (C) 2022 JGHFunRun <JGHFunRun@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SAMPLE_CACHE_H
+#define SAMPLE_CACHE_H
+
+#include <map>
+#include <string>
+
+#include "SampleBuffer.h"
+
+class SampleCache : public std::map<std::string,SampleBuffer> {
+	// TODO: stuff
+};
+
+#endif //SAMPLE_CACHE_H

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -33,6 +33,7 @@
 #include "Plugin.h"
 #include "PresetPreviewPlayHandle.h"
 #include "ProjectJournal.h"
+#include "SampleCache.h"
 #include "Song.h"
 #include "BandLimitedWave.h"
 #include "Oscillator.h"
@@ -41,6 +42,7 @@ float LmmsCore::s_framesPerTick;
 AudioEngine* LmmsCore::s_audioEngine = nullptr;
 Mixer * LmmsCore::s_mixer = nullptr;
 PatternStore * LmmsCore::s_patternStore = nullptr;
+SampleCache * LmmsCore::s_sampleCache = nullptr;
 Song * LmmsCore::s_song = nullptr;
 ProjectJournal * LmmsCore::s_projectJournal = nullptr;
 #ifdef LMMS_HAVE_LV2
@@ -65,6 +67,7 @@ void LmmsCore::init( bool renderOnly )
 	emit engine->initProgress(tr("Initializing data structures"));
 	s_projectJournal = new ProjectJournal;
 	s_audioEngine = new AudioEngine( renderOnly );
+	s_sampleCache = new SampleCache;
 	s_song = new Song;
 	s_mixer = new Mixer;
 	s_patternStore = new PatternStore;

--- a/src/core/SampleCache.cpp
+++ b/src/core/SampleCache.cpp
@@ -1,0 +1,27 @@
+/*
+ * SampleCache.h - A class for the sample cache
+ *
+ * Copyright (C) 2022 JGHFunRun <JGHFunRun@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "SampleCache.h"
+
+// TODO: stuff should go here


### PR DESCRIPTION
The code is very basic at the moment. For now I'm just getting this up so that it's visible and possibly someone can contribute code

TODOs:

- [ ] ~~Add a method to generate new audio file names. This is for recording and audio editing mainly, when they are incorporated. It's also why `SampleCache` is it's own class and not just a `typedef`~~
  - ~~My idea for this is to have a counter that counts the number of audio files made for the current project file and then have a user settable format string for it. The output format would also be selectable in settings. My idea for the default for this string is `{project_path}.dir/{n}.{format}`. Wanted feedback on how to do it before implementing it~~
  - I have been recommended by @DomClark to make this a separate thing and will be taking that advice
- [ ] Convert everything to using it
  - [ ] Sample tracks
  - [ ] AFP
  - [ ] 3xOsc's user wave
  - [ ] SF2Player
  - [ ] GIG Player
  - [ ] PatMan
  - [ ] TODO: find other plugins that should use the sample cache

It may be just best to get the ~~first bullet point,~~ AFP, and sample tracks done so that new plugins and features that need it can use it immediately instead of waiting to convert all of the plugins or need to be converted retroactively. ~~Possibly even to~~ Wait on the first bullet point since it's not needed until sample recording or destructive sample editing is implemented