### PR TITLE
Kill orphaned subprocesses on crash

### DIFF
--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -135,6 +135,7 @@ private:
 	fpp_t m_bufferSize;
 } ;
 
+#ifndef LMMS_BUILD_WIN32
 class PollParentThread
 {
 public:
@@ -171,6 +172,7 @@ private:
 	std::condition_variable m_cv;
 	std::thread m_thread;
 };
+#endif
 
 #ifdef SYNC_WITH_SHM_FIFO
 RemotePluginClient::RemotePluginClient( key_t _shm_in, key_t _shm_out ) :

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -32,7 +32,7 @@
 #	include <mutex>
 #	include <thread>
 
-#	include <sys/signal.h>
+#	include <signal.h>
 #	include <unistd.h>
 #endif
 

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -142,9 +142,11 @@ public:
 	PollParentThread() :
 		m_stop{false},
 		m_thread{
-			[this] {
+			[this]
+			{
+				using namespace std::literals::chrono_literals;
 				auto lock = std::unique_lock{m_mutex};
-				while (!m_cv.wait_for(lock, std::chrono::milliseconds(500), [this] { return m_stop; }))
+				while (!m_cv.wait_for(lock, 500ms, [this] { return m_stop; }))
 				{
 					if (getppid() == 1)
 					{

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2475,7 +2475,7 @@ int main( int _argc, char * * _argv )
 	}
 
 #ifndef LMMS_BUILD_WIN32
-	PollParentThread pollParentThread;
+	const auto pollParentThread = PollParentThread{};
 #endif
 
 #ifndef NATIVE_LINUX_VST

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2473,6 +2473,11 @@ int main( int _argc, char * * _argv )
 		fprintf( stderr, "not enough arguments\n" );
 		return -1;
 	}
+
+#ifndef LMMS_BUILD_WIN32
+	PollParentThread pollParentThread;
+#endif
+
 #ifndef NATIVE_LINUX_VST
 	OleInitialize(nullptr);
 #else

--- a/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
+++ b/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
@@ -35,9 +35,9 @@ add_executable(${EXE_NAME} WIN32
 	${LMMS_COMMON_SRCS}
 )
 if(IS_WIN)
-    target_link_libraries(${EXE_NAME} ole32)
+	target_link_libraries(${EXE_NAME} ole32)
 else()
-    target_link_libraries(${EXE_NAME} dl X11)
+	target_link_libraries(${EXE_NAME} dl X11)
 endif()
 if(NOT WIN32)
 	target_link_libraries(${EXE_NAME} pthread)

--- a/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
+++ b/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
@@ -37,8 +37,11 @@ add_executable(${EXE_NAME} WIN32
 if(IS_WIN)
     target_link_libraries(${EXE_NAME} ole32)
 else()
-    target_link_libraries(${EXE_NAME} pthread dl X11)
-ENDIF()
+    target_link_libraries(${EXE_NAME} dl X11)
+endif()
+if(NOT WIN32)
+	target_link_libraries(${EXE_NAME} pthread)
+endif()
 
 target_include_directories(${EXE_NAME}
 	PRIVATE 

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -267,6 +267,10 @@ int main( int _argc, char * * _argv )
 		return -1;
 	}
 
+#ifndef LMMS_BUILD_WIN32
+	PollParentThread pollParentThread;
+#endif
+
 #ifdef LMMS_BUILD_WIN32
 #ifndef __WINPTHREADS_VERSION
 	// (non-portable) initialization of statically linked pthread library

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -268,7 +268,7 @@ int main( int _argc, char * * _argv )
 	}
 
 #ifndef LMMS_BUILD_WIN32
-	PollParentThread pollParentThread;
+	const auto pollParentThread = PollParentThread{};
 #endif
 
 #ifdef LMMS_BUILD_WIN32

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -53,13 +53,17 @@ namespace {
 
 HANDLE getRemotePluginJob()
 {
-	static const auto job = [] {
+	static const auto job = []
+	{
 		const auto job = CreateJobObject(nullptr, nullptr);
+
 		auto limitInfo = JOBOBJECT_EXTENDED_LIMIT_INFORMATION{};
 		limitInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 		SetInformationJobObject(job, JobObjectExtendedLimitInformation, &limitInfo, sizeof(limitInfo));
+
 		return job;
 	}();
+
 	return job;
 }
 
@@ -96,7 +100,8 @@ void ProcessWatcher::run()
 			// the process itself, we can use QProcess::waitForFinished() with a
 			// zero timeout, but that too is insufficient as it fails if the
 			// process has already finished. Therefore, we check both.
-			if (!process.waitForFinished(0) && process.state() == QProcess::Running) {
+			if (!process.waitForFinished(0) && process.state() == QProcess::Running)
+			{
 				AssignProcessToJobObject(getRemotePluginJob(), processHandle);
 			}
 			CloseHandle(processHandle);

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -29,6 +29,10 @@
 #include <QDebug>
 #endif
 
+#ifdef LMMS_BUILD_WIN32
+#include <windows.h>
+#endif
+
 #include "BufferManager.h"
 #include "AudioEngine.h"
 #include "Engine.h"
@@ -43,6 +47,25 @@
 #include <sys/un.h>
 #endif
 
+#ifdef LMMS_BUILD_WIN32
+
+namespace {
+
+HANDLE getRemotePluginJob()
+{
+	static const auto job = [] {
+		const auto job = CreateJobObject(nullptr, nullptr);
+		auto limitInfo = JOBOBJECT_EXTENDED_LIMIT_INFORMATION{};
+		limitInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+		SetInformationJobObject(job, JobObjectExtendedLimitInformation, &limitInfo, sizeof(limitInfo));
+		return job;
+	}();
+	return job;
+}
+
+} // namespace
+
+#endif // LMMS_BUILD_WIN32
 
 // simple helper thread monitoring our RemotePlugin - if process terminates
 // unexpectedly invalidate plugin so LMMS doesn't lock up
@@ -56,18 +79,40 @@ ProcessWatcher::ProcessWatcher( RemotePlugin * _p ) :
 
 void ProcessWatcher::run()
 {
-	m_plugin->m_process.start( m_plugin->m_exec, m_plugin->m_args );
-	exec();
-	m_plugin->m_process.moveToThread( m_plugin->thread() );
-	while( !m_quit && m_plugin->messagesLeft() )
-	{
-		msleep( 200 );
-	}
-	if( !m_quit )
-	{
-		fprintf( stderr,
-				"remote plugin died! invalidating now.\n" );
+	auto& process = m_plugin->m_process;
+	process.start(m_plugin->m_exec, m_plugin->m_args);
 
+#ifdef LMMS_BUILD_WIN32
+	// Add the process to our job so it is killed if we crash
+	if (process.waitForStarted(-1))
+	{
+		if (const auto processHandle = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, false, process.processId()))
+		{
+			// Ensure the process is still running, otherwise the handle we
+			// obtained may be for a different process that happened to reuse
+			// the same process id.
+			// QProcess::state() alone is insufficient as it only returns a
+			// cached state variable that is updated asynchronously. To query
+			// the process itself, we can use QProcess::waitForFinished() with a
+			// zero timeout, but that too is insufficient as it fails if the
+			// process has already finished. Therefore, we check both.
+			if (!process.waitForFinished(0) && process.state() == QProcess::Running) {
+				AssignProcessToJobObject(getRemotePluginJob(), processHandle);
+			}
+			CloseHandle(processHandle);
+		}
+	}
+#endif // LMMS_BUILD_WIN32
+
+	exec();
+	process.moveToThread(m_plugin->thread());
+	while (!m_quit && m_plugin->messagesLeft())
+	{
+		msleep(200);
+	}
+	if (!m_quit)
+	{
+		fprintf(stderr, "remote plugin died! invalidating now.\n");
 		m_plugin->invalidate();
 	}
 }


### PR DESCRIPTION
Fixes #4408. Uses the techniques in the comments there, with a few tweaks:
* The Windows code no longer uses `QProcess::pid()`, since it is now deprecated. Replaced with `QProcess::processId()` and `OpenProcess()`.
* The compile guards for the POSIX code now check for "not Windows", rather than just "Apple or Linux", since LMMS is used on a number of other POSIX-compliant systems.
* The POSIX code now uses RAII to cleanly handle the multiple exit points from the remote plugins' `main()` methods.
* The POSIX code now uses a timed wait on a condition variable, so normal exit can happen immediately rather than waiting up to 500ms for each process.

I forgot to add Lukas-W as a co-author on the POSIX commit - will try to remember when I merge this.