### PR TITLE
Fix Qt Deprecations

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -26,6 +26,11 @@
 #define AUDIO_ENGINE_H
 
 #include <QMutex>
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	#include <QRecursiveMutex>
+#endif
+
 #include <QThread>
 #include <QVector>
 #include <QWaitCondition>
@@ -464,7 +469,11 @@ private:
 	bool m_changesSignal;
 	unsigned int m_changes;
 	QMutex m_changesMutex;
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	QRecursiveMutex m_doChangesMutex;
+#else
 	QMutex m_doChangesMutex;
+#endif
 	QMutex m_waitChangesMutex;
 	QWaitCondition m_changesAudioEngineCondition;
 	QWaitCondition m_changesRequestCondition;

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -29,6 +29,9 @@
 
 #include <QMap>
 #include <QPointer>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	#include <QRecursiveMutex>
+#endif
 
 #include "AutomationNode.h"
 #include "Clip.h"
@@ -189,7 +192,11 @@ private:
 
 	// Mutex to make methods involving automation clips thread safe
 	// Mutable so we can lock it from const objects
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	mutable QRecursiveMutex m_clipMutex;
+#else
 	mutable QMutex m_clipMutex;
+#endif
 
 	AutomationTrack * m_autoTrack;
 	QVector<jo_id_t> m_idsToResolve;

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -29,6 +29,9 @@
 #include <QCheckBox>
 #include <QDir>
 #include <QMutex>
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	#include <QRecursiveMutex>
+#endif
 #include <QTreeWidget>
 
 
@@ -140,7 +143,12 @@ private:
 
 	//! This should only be accessed or modified when m_pphMutex is held
 	PlayHandle* m_previewPlayHandle;
+	
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	QRecursiveMutex m_pphMutex;
+#else
 	QMutex m_pphMutex;
+#endif
 
 	QList<QAction*> getContextActions(FileItem* item, bool songEditor);
 

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -28,6 +28,10 @@
 #include "RemotePluginBase.h"
 #include "SharedMemory.h"
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	#include <QRecursiveMutex>
+#endif
+
 namespace lmms
 {
 
@@ -158,7 +162,11 @@ private:
 	QString m_exec;
 	QStringList m_args;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	QRecursiveMutex m_commMutex;
+#else
 	QMutex m_commMutex;
+#endif
 	bool m_splitChannels;
 
 	SharedMemory<float[]> m_audioBuffer;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -94,7 +94,9 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	m_clearSignal( false ),
 	m_changesSignal( false ),
 	m_changes( 0 ),
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	m_doChangesMutex( QMutex::Recursive ),
+#endif
 	m_waitingForWrite( false )
 {
 	for( int i = 0; i < 2; ++i )

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -47,7 +47,9 @@ const float AutomationClip::DEFAULT_MAX_VALUE = 1;
 
 AutomationClip::AutomationClip( AutomationTrack * _auto_track ) :
 	Clip( _auto_track ),
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	m_clipMutex(QMutex::Recursive),
+#endif
 	m_autoTrack( _auto_track ),
 	m_objects(),
 	m_tension( 1.0 ),
@@ -79,7 +81,9 @@ AutomationClip::AutomationClip( AutomationTrack * _auto_track ) :
 
 AutomationClip::AutomationClip( const AutomationClip & _clip_to_copy ) :
 	Clip( _clip_to_copy.m_autoTrack ),
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	m_clipMutex(QMutex::Recursive),
+#endif
 	m_autoTrack( _clip_to_copy.m_autoTrack ),
 	m_objects( _clip_to_copy.m_objects ),
 	m_tension( _clip_to_copy.m_tension ),

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -138,7 +138,9 @@ RemotePlugin::RemotePlugin() :
 #endif
 	m_failed( true ),
 	m_watcher( this ),
-	m_commMutex( QMutex::Recursive ),
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
+	m_commMutex(QMutex::Recursive),
+#endif
 	m_splitChannels( false ),
 	m_audioBufferSize( 0 ),
 	m_inputCount( DEFAULT_CHANNELS ),

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -372,8 +372,10 @@ FileBrowserTreeWidget::FileBrowserTreeWidget(QWidget * parent ) :
 	QTreeWidget( parent ),
 	m_mousePressed( false ),
 	m_pressPos(),
-	m_previewPlayHandle( nullptr ),
-	m_pphMutex( QMutex::Recursive )
+	m_previewPlayHandle( nullptr )
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
+	,m_pphMutex(QMutex::Recursive)
+#endif
 {
 	setColumnCount( 1 );
 	headerItem()->setHidden( true );

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -317,7 +317,11 @@ bool MicrotunerConfig::validateScaleForm()
 	if (name.contains('\n')) {fail(tr("Scale name cannot contain a new-line character")); return false;}
 
 	// check intervals
-	QStringList input = m_scaleTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+	#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+		QStringList input = m_scaleTextEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+	#else
+		QStringList input = m_scaleTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+	#endif
 	for (auto &line: input)
 	{
 		if (line.isEmpty()) {continue;}
@@ -361,7 +365,11 @@ bool MicrotunerConfig::validateKeymapForm()
 	if (name.contains('\n')) {fail(tr("Keymap name cannot contain a new-line character")); return false;}
 
 	// check key mappings
-	QStringList input = m_keymapTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+	#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+		QStringList input = m_keymapTextEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+	#else
+		QStringList input = m_keymapTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+	#endif
 	for (auto &line: input)
 	{
 		if (line.isEmpty()) {continue;}
@@ -391,7 +399,11 @@ bool MicrotunerConfig::applyScale()
 	std::vector<Interval> newIntervals;
 	newIntervals.push_back(Interval(1, 1));
 
-	QStringList input = m_scaleTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	QStringList input = m_keymapTextEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+#else
+	QStringList input = m_keymapTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+#endif
 	for (auto &line: input)
 	{
 		if (line.isEmpty()) {continue;}
@@ -433,7 +445,11 @@ bool MicrotunerConfig::applyKeymap()
 
 	std::vector<int> newMap;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+	QStringList input = m_keymapTextEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
+#else
 	QStringList input = m_keymapTextEdit->toPlainText().split('\n', QString::SkipEmptyParts);
+#endif
 	for (auto &line: input)
 	{
 		if (line.isEmpty()) {continue;}

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -755,7 +755,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 			}
 		}
 	}
-	else if( me->button() == Qt::MidButton )
+	else if( me->button() == Qt::MiddleButton )
 	{
 		if( me->modifiers() & Qt::ControlModifier )
 		{

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -145,7 +145,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 		this, SLOT(toggleMidiCCRack()));
 
 	m_activityIndicator = new FadeButton( QApplication::palette().color( QPalette::Active,
-							QPalette::Background),
+							QPalette::Window),
 						QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ),
 						QApplication::palette().color( QPalette::Active,

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -178,7 +178,7 @@ void TrackOperationsWidget::paintEvent( QPaintEvent * pe )
 {
 	QPainter p( this );
 
-	p.fillRect( rect(), palette().brush(QPalette::Background) );
+	p.fillRect(rect(), palette().brush(QPalette::Window));
 
 	if( m_trackView->getTrack()->useColor() && ! m_trackView->getTrack()->getMutedModel()->value() ) 
 	{


### PR DESCRIPTION
This PR fixes the following deprecations in src:
```
‘QMutex::QMutex(QMutex::RecursionMode)’ is deprecated: Use QRecursiveMutex instead of a recursive QMutex

‘QTextStream& QTextStreamFunctions::endl(QTextStream&)’ is deprecated: Use Qt::endl

‘Qt::MidButton’ is deprecated: MidButton is deprecated. Use MiddleButton instead

‘QPalette::Background’ is deprecated: Use QPalette::Window instead

‘QStringList QString::split(QChar, QString::SplitBehavior, Qt::CaseSensitivity) const’ is deprecated: Use 
Qt::SplitBehavior variant instead
```