### PR TITLE
Make AFP include the last sample frame

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -428,9 +428,9 @@ void AudioFileProcessor::loopPointChanged( void )
 
 void AudioFileProcessor::pointChanged( void )
 {
-	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	( m_sampleBuffer.frames() ) );
-	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * ( m_sampleBuffer.frames() ) );
-	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * ( m_sampleBuffer.frames() ) );
+	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	m_sampleBuffer.frames() );
+	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * m_sampleBuffer.frames() );
+	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * m_sampleBuffer.frames() );
 
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -428,9 +428,9 @@ void AudioFileProcessor::loopPointChanged( void )
 
 void AudioFileProcessor::pointChanged( void )
 {
-	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	( m_sampleBuffer.frames()-1 ) );
-	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * ( m_sampleBuffer.frames()-1 ) );
-	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * ( m_sampleBuffer.frames()-1 ) );
+	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	( m_sampleBuffer.frames() ) );
+	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * ( m_sampleBuffer.frames() ) );
+	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * ( m_sampleBuffer.frames() ) );
 
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;


### PR DESCRIPTION
Now AFP can graph and play the last sample frame.

I tested with the following [perfect loops](https://github.com/LMMS/lmms/files/8646530/perfectLoops.zip):

- 8frames.wav: now graphed with 8 points instead of 7, and there's no DC offset when looping it.
- 44100frames.wav: now labeled with a duration of 1000 ms instead of 999 ms, and there's no click when looping it.

This change could be problematic for existing projects that use AFP to loop tiny samples like 8frames.wav above.