### PR TITLE
Fix compilation with Carla 2.4.3

### DIFF
--- a/plugins/CarlaBase/Carla.h
+++ b/plugins/CarlaBase/Carla.h
@@ -36,6 +36,7 @@
 
 // carla/source/includes
 #include "carlabase_export.h"
+#include "CarlaDefines.h"
 #if CARLA_VERSION_HEX >= 0x010911
     #include "CarlaNativePlugin.h"
 #else


### PR DESCRIPTION
Replaces #6397.
Include `CarlaDefines.h` before using `CARLA_VERSION_HEX` to prevent hitting wrong preprocessor path.

Note that if we bump up Carla version requirement to [`1.9.11`=`2.0-RC1`](https://github.com/falkTX/Carla/releases/tag/v1.9.11), the `#else` part is not required.