### PR TITLE
Batch undo

### DIFF
--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -50,6 +50,8 @@ public:
 	bool canRedo() const;
 
 	void addJournalCheckPoint( JournallingObject *jo );
+	void beginCheckPointGroup();
+	void endCheckPointGroup();
 
 	bool isJournalling() const
 	{
@@ -107,13 +109,18 @@ private:
 		jo_id_t joID;
 		DataFile data;
 	} ;
-	typedef QStack<CheckPoint> CheckPointStack;
+	typedef std::vector<CheckPoint> CheckPointGroup;
+	typedef std::vector<CheckPointGroup> CheckPointStack;
+
+	void restoreCheckPoint(ProjectJournal::CheckPointStack& restore, ProjectJournal::CheckPointStack& backup);
 
 	JoIdMap m_joIDs;
 
 	CheckPointStack m_undoCheckPoints;
 	CheckPointStack m_redoCheckPoints;
 
+	//! Used to determine if checkpoints should be grouped
+	int m_groupCounter = 0;
 	bool m_journalling;
 
 } ;

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -835,6 +835,10 @@ void AutomationClip::loadSettings( const QDomElement & _this )
 		useCustomClipColor( true );
 		setColor( _this.attribute( "color" ) );
 	}
+	else
+	{
+		useCustomClipColor(false);
+	}
 
 	int len = _this.attribute( "len" ).toInt();
 	if( len <= 0 )

--- a/src/gui/ClipView.cpp
+++ b/src/gui/ClipView.cpp
@@ -43,6 +43,7 @@
 #include "MidiClip.h"
 #include "MidiClipView.h"
 #include "Note.h"
+#include "ProjectJournal.h"
 #include "SampleClip.h"
 #include "Song.h"
 #include "SongEditor.h"
@@ -372,25 +373,12 @@ void ClipView::setColor(const QColor* color)
 {
 	std::set<Track*> journaledTracks;
 
-	auto selectedClips = getClickedClips();
-	for (auto clipv: selectedClips)
+	Engine::projectJournal()->beginCheckPointGroup();
+
+	for (ClipView* clipv: getClickedClips())
 	{
 		auto clip = clipv->getClip();
-		auto track = clip->getTrack();
-
-		// TODO journal whole Song or group of clips instead of one journal entry for each track
-
-		// If only one clip changed, store that in the journal
-		if (selectedClips.length() == 1)
-		{
-			clip->addJournalCheckPoint();
-		}
-		// If multiple clips changed, store whole Track in the journal
-		// Check if track has been journaled already by trying to add it to the set
-		else if (journaledTracks.insert(track).second)
-		{
-			track->addJournalCheckPoint();
-		}
+		clip->addJournalCheckPoint();
 
 		if (color)
 		{
@@ -403,7 +391,7 @@ void ClipView::setColor(const QColor* color)
 		}
 		clipv->update();
 	}
-
+	Engine::projectJournal()->endCheckPointGroup();
 	Engine::getSong()->setModified();
 }
 


### PR DESCRIPTION
Allow multiple journal checkpoint to be grouped together, so they can all be restored with one click.

```cpp
Engine::projectJournal()->beginCheckPointGroup();
for (auto thing: allThings) { thing->addJournalCheckPoint(); }
Engine::projectJournal()->endCheckPointGroup();
```

Batch undo TODO:
- [x] Clip colors
- [ ] Clip delete
- [ ] Clip move
- [ ] Other actions that span multiple tracks?