### PR TITLE
Open .midi, .rmi files from sidebar

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1243,7 +1243,7 @@ void FileItem::determineFileType( void )
 	{
 		m_type = PatchFile;
 	}
-	else if( ext == "mid" )
+	else if( ext == "mid" || ext == "midi" || ext == "rmi" )
 	{
 		m_type = MidiFile;
 		m_handling = ImportAsProject;


### PR DESCRIPTION
Fixes #6400.
Simply extends to extension type for midi import to .midi and .rmi as well.

I have never done this before, and I didn't use git, since this doesn't appear to need it; fixed directly through github.
Seems to have been a quick fix. But just to be clear, I'm not entirely sure what I'm doing.