### PR TITLE
Fixes #6401: Reinit Lv2ControlBase on SR change

### DIFF
--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -133,6 +133,8 @@ public:
 
 private:
 	//! models for the controls
+	//! @note The AutomatableModels behind the ModelInfo are not owned,
+	//!   but referenced after `addModel` is being called.
 	std::map<std::string, ModelInfo> m_models;
 };
 

--- a/include/Lv2Basics.h
+++ b/include/Lv2Basics.h
@@ -1,7 +1,7 @@
 /*
  * Lv2Basics.h - basic Lv2 utils
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -142,11 +142,6 @@ protected:
 		const class TimePos &time, f_cnt_t offset);
 
 private:
-	//! Return the DataFile settings type
-	virtual DataFile::Types settingsType() = 0;
-	//! Inform the plugin about a file name change
-	virtual void setNameFromFile(const QString &fname) = 0;
-
 	//! Independent processors
 	//! If this is a mono effect, the vector will have size 2 in order to
 	//! fulfill LMMS' requirement of having stereo input and output

--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -77,6 +77,9 @@ public:
 	static Plugin::PluginTypes check(const LilvPlugin* m_plugin,
 		std::vector<PluginIssue> &issues);
 
+	void shutdown();
+	void init(Model* meAsModel);
+
 	const LilvPlugin* getPlugin() const { return m_plugin; }
 
 	Lv2Proc *control(std::size_t idx) { return m_procs[idx].get(); }
@@ -95,6 +98,7 @@ protected:
 	Lv2ControlBase(class Model *that, const QString& uri);
 	Lv2ControlBase(const Lv2ControlBase&) = delete;
 	~Lv2ControlBase() override;
+	void reload();
 
 	Lv2ControlBase& operator=(const Lv2ControlBase&) = delete;
 
@@ -129,8 +133,6 @@ protected:
 	void saveSettings(QDomDocument &doc, QDomElement &that);
 	void loadSettings(const QDomElement &that);
 	void loadFile(const QString &file);
-	//! TODO: not implemented
-	void reloadPlugin();
 
 	/*
 		more functions that must be called from virtuals

--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -1,7 +1,7 @@
 /*
  * Lv2ControlBase.h - Lv2 control base class
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/include/Lv2Features.h
+++ b/include/Lv2Features.h
@@ -69,6 +69,8 @@ public:
 	{
 		return m_featurePointers.data();
 	}
+	//! Clear everything
+	void clear();
 
 private:
 	//! feature storage

--- a/include/Lv2Manager.h
+++ b/include/Lv2Manager.h
@@ -1,7 +1,7 @@
 /*
  * Lv2Manager.h - Implementation of Lv2Manager class
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -59,8 +59,8 @@ namespace Lv2Ports
 }
 
 
-//! Class representing one Lv2 processor, i.e. one Lv2 handle
-//! For Mono effects, 1 Lv2ControlBase references 2 Lv2Proc
+//! Class representing one Lv2 processor, i.e. one Lv2 handle.
+//! For Mono effects, 1 Lv2ControlBase references 2 Lv2Proc.
 class Lv2Proc : public LinkedModelGroup
 {
 public:
@@ -197,6 +197,8 @@ private:
 	static int32_t defaultEvbufSize() { return 1 << 15; /* ardour uses this*/ }
 
 	//! models for the controls, sorted by port symbols
+	//! @note These are not owned, but rather link to the models in
+	//!   ControlPorts in `m_ports`
 	std::map<std::string, AutomatableModel *> m_connectedModels;
 
 	void initMOptions(); //!< initialize m_options

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -68,10 +68,12 @@ public:
 		std::vector<PluginIssue> &issues);
 
 	/*
-		ctor/dtor
+		ctor/dtor/reload
 	*/
 	Lv2Proc(const LilvPlugin* plugin, Model *parent);
 	~Lv2Proc() override;
+	void reload();
+	void onSampleRateChanged();
 	//! Must be checked after ctor or reload
 	bool isValid() const { return m_valid; }
 

--- a/include/Lv2SubPluginFeatures.h
+++ b/include/Lv2SubPluginFeatures.h
@@ -3,7 +3,7 @@
  *                          Plugin::Descriptor::SubPluginFeatures for
  *                          hosting LV2 plugins
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/include/Lv2ViewBase.h
+++ b/include/Lv2ViewBase.h
@@ -1,7 +1,7 @@
 /*
  * Lv2ViewBase.h - base class for Lv2 plugin views
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2Effect.cpp - implementation of LV2 effect
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2Effect.h
+++ b/plugins/Lv2Effect/Lv2Effect.h
@@ -1,7 +1,7 @@
 /*
  * Lv2Effect.h - implementation of LV2 effect
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2FxControlDialog.cpp
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.cpp
@@ -38,7 +38,7 @@ Lv2FxControlDialog::Lv2FxControlDialog(Lv2FxControls *controls) :
 {
 	if (m_reloadPluginButton) {
 		connect(m_reloadPluginButton, &QPushButton::clicked,
-				this, [this](){ lv2Controls()->reloadPlugin(); });
+				this, [this](){ lv2Controls()->reload(); });
 	}
 	if (m_toggleUIButton) {
 		connect(m_toggleUIButton, &QPushButton::toggled,
@@ -67,6 +67,8 @@ Lv2FxControls *Lv2FxControlDialog::lv2Controls()
 void Lv2FxControlDialog::modelChanged()
 {
 	Lv2ViewBase::modelChanged(lv2Controls());
+	connect(lv2Controls(), &Lv2FxControls::modelChanged,
+		this, [this](){ this->modelChanged();} );
 }
 
 

--- a/plugins/Lv2Effect/Lv2FxControlDialog.cpp
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2FxControlDialog.cpp - Lv2FxControlDialog implementation
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2FxControlDialog.h
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.h
@@ -45,7 +45,7 @@ public:
 
 private:
 	Lv2FxControls *lv2Controls();
-	void modelChanged() override;
+	void modelChanged() final;
 };
 
 

--- a/plugins/Lv2Effect/Lv2FxControlDialog.h
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.h
@@ -1,7 +1,7 @@
 /*
  * Lv2FxControlDialog.h - Lv2FxControlDialog implementation
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2FxControls.cpp
+++ b/plugins/Lv2Effect/Lv2FxControls.cpp
@@ -86,20 +86,4 @@ void Lv2FxControls::changeControl() // TODO: what is that?
 }
 
 
-
-
-DataFile::Types Lv2FxControls::settingsType()
-{
-	return DataFile::EffectSettings;
-}
-
-
-
-
-void Lv2FxControls::setNameFromFile(const QString &name)
-{
-	effect()->setDisplayName(name);
-}
-
-
 } // namespace lmms

--- a/plugins/Lv2Effect/Lv2FxControls.cpp
+++ b/plugins/Lv2Effect/Lv2FxControls.cpp
@@ -41,8 +41,28 @@ Lv2FxControls::Lv2FxControls(class Lv2Effect *effect, const QString& uri) :
 	if (isValid())
 	{
 		connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
-			this, [this](){Lv2ControlBase::reloadPlugin();});
+			this, [this](){onSampleRateChanged();});
 	}
+}
+
+
+
+
+void Lv2FxControls::reload()
+{
+	Lv2ControlBase::reload();
+	emit modelChanged();
+}
+
+
+
+
+void Lv2FxControls::onSampleRateChanged()
+{
+	// TODO: once lv2 options are implemented,
+	//       plugins that support it might allow changing their samplerate
+	//       through it instead of reloading
+	reload();
 }
 
 

--- a/plugins/Lv2Effect/Lv2FxControls.cpp
+++ b/plugins/Lv2Effect/Lv2FxControls.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2FxControls.cpp - Lv2FxControls implementation
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Effect/Lv2FxControls.h
+++ b/plugins/Lv2Effect/Lv2FxControls.h
@@ -60,9 +60,6 @@ private slots:
 	void changeControl();
 
 private:
-	DataFile::Types settingsType() override;
-	void setNameFromFile(const QString &name) override;
-
 	friend class gui::Lv2FxControlDialog;
 	friend class Lv2Effect;
 };

--- a/plugins/Lv2Effect/Lv2FxControls.h
+++ b/plugins/Lv2Effect/Lv2FxControls.h
@@ -43,8 +43,11 @@ class Lv2FxControlDialog;
 class Lv2FxControls : public EffectControls, public Lv2ControlBase
 {
 	Q_OBJECT
+signals:
+	void modelChanged();
 public:
 	Lv2FxControls(Lv2Effect *effect, const QString &uri);
+	void reload();
 
 	void saveSettings(QDomDocument &_doc, QDomElement &_parent) override;
 	void loadSettings(const QDomElement &that) override;
@@ -60,6 +63,8 @@ private slots:
 	void changeControl();
 
 private:
+	void onSampleRateChanged();
+
 	friend class gui::Lv2FxControlDialog;
 	friend class Lv2Effect;
 };

--- a/plugins/Lv2Effect/Lv2FxControls.h
+++ b/plugins/Lv2Effect/Lv2FxControls.h
@@ -1,7 +1,7 @@
 /*
  * Lv2FxControls.h - Lv2FxControls implementation
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -196,24 +196,8 @@ QString Lv2Instrument::nodeName() const
 
 
 
-DataFile::Types Lv2Instrument::settingsType()
-{
-	return DataFile::InstrumentTrackSettings;
-}
-
-
-
-
-void Lv2Instrument::setNameFromFile(const QString &name)
-{
-	instrumentTrack()->setName(name);
-}
-
-
-
 namespace gui
 {
-
 
 /*
 	Lv2InsView

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2Instrument.cpp - implementation of LV2 instrument
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -97,8 +97,6 @@ private slots:
 
 private:
 	QString nodeName() const override;
-	DataFile::Types settingsType() override;
-	void setNameFromFile(const QString &name) override;
 
 #ifdef LV2_INSTRUMENT_USE_MIDI
 	std::array<int, NumKeys> m_runningNotes = {};

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -50,6 +50,8 @@ class Lv2InsView;
 class Lv2Instrument : public Instrument, public Lv2ControlBase
 {
 	Q_OBJECT
+signals:
+	void modelChanged();
 public:
 	/*
 		initialization
@@ -57,6 +59,8 @@ public:
 	Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 		 Descriptor::SubPluginFeatures::Key* key);
 	~Lv2Instrument() override;
+	void reload();
+	void onSampleRateChanged();
 	//! Must be checked after ctor or reload
 	bool isValid() const;
 
@@ -101,6 +105,7 @@ private:
 #ifdef LV2_INSTRUMENT_USE_MIDI
 	std::array<int, NumKeys> m_runningNotes = {};
 #endif
+	void clearRunningNotes();
 
 	friend class gui::Lv2InsView;
 };

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -1,7 +1,7 @@
 /*
  * Lv2Instrument.h - implementation of LV2 instrument
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2ControlBase.cpp - Lv2 control base class
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/src/core/lv2/Lv2Features.cpp
+++ b/src/core/lv2/Lv2Features.cpp
@@ -105,6 +105,14 @@ void *&Lv2Features::operator[](const char *featName)
 }
 
 
+
+
+void Lv2Features::clear()
+{
+	m_featureByUri.clear();
+}
+
+
 } // namespace lmms
 
 #endif // LMMS_HAVE_LV2

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -60,6 +60,12 @@ const std::set<const char*, Lv2Manager::CmpStr> Lv2Manager::pluginBlacklist =
 	"http://calf.sourceforge.net/plugins/TransientDesigner",
 	"http://calf.sourceforge.net/plugins/Vinyl",
 
+	// https://gitlab.com/drobilla/blop-lv2/-/issues/3
+	"http://drobilla.net/plugins/blop/pulse",
+	"http://drobilla.net/plugins/blop/sawtooth",
+	"http://drobilla.net/plugins/blop/square",
+	"http://drobilla.net/plugins/blop/triangle",
+
 	// Visualization, meters, and scopes etc., won't work until we have gui support
 	"http://distrho.sf.net/plugins/ProM",
 	"http://distrho.sf.net/plugins/glBars",

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2Manager.cpp - Implementation of Lv2Manager class
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/src/core/lv2/Lv2SubPluginFeatures.cpp
+++ b/src/core/lv2/Lv2SubPluginFeatures.cpp
@@ -3,7 +3,7 @@
  *                            Plugin::Descriptor::SubPluginFeatures for
  *                            hosting LV2 plugins
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2ViewBase.cpp - base class for Lv2 plugin views
  *
- * Copyright (c) 2018-2020 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *


### PR DESCRIPTION
This implements the previous stub `Lv2ControlBase::reloadPlugin`, which
is required if the LMMS sample rate changes.

Additionally, this removes two unused pure virtual functions of
`Lv2ControlBase`, making the class non-abstract, so we can call its CTOR
after deleting it.