### PR TITLE
Correctly upgrade projects saved by LMMS forks

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1916,13 +1916,14 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 		if( !success ) qWarning("File Version conversion failure.");
 	}
 
+	// Perform upgrade routines
+	if (m_fileVersion < UPGRADE_METHODS.size()) { upgrade(); }
+
 	if (root.hasAttribute("creatorversion"))
 	{
 		// compareType defaults to All, so it doesn't have to be set here
 		ProjectVersion createdWith = root.attribute("creatorversion");
 		ProjectVersion openedWith = LMMS_VERSION;
-
-		if (createdWith < openedWith) { upgrade(); }
 
 		if (createdWith.setCompareType(ProjectVersion::Minor)
 		 !=  openedWith.setCompareType(ProjectVersion::Minor)

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1916,9 +1916,6 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 		if( !success ) qWarning("File Version conversion failure.");
 	}
 
-	// Perform upgrade routines
-	if (m_fileVersion < UPGRADE_METHODS.size()) { upgrade(); }
-
 	if (root.hasAttribute("creatorversion"))
 	{
 		// compareType defaults to All, so it doesn't have to be set here
@@ -1941,6 +1938,9 @@ void DataFile::loadData( const QByteArray & _data, const QString & _sourceFile )
 			);
 		}
 	}
+
+	// Perform upgrade routines
+	if (m_fileVersion < UPGRADE_METHODS.size()) { upgrade(); }
 
 	m_content = root.elementsByTagName(typeName(m_type)).item(0).toElement();
 }


### PR DESCRIPTION
Check `version` (of file format) instead of `creatorversion` (of LMMS) when deciding if a project file needs to be upgraded.

This fixes the [currently broken](https://github.com/LMMS/lmms/pull/6309#issuecomment-1146224632) `demos/DnB.mmpz`. It got saved by a fork `1.3.0-alpha.1.199` back in #6239. The current master is at `1.3.0-alpha.1.191` so - funny enough - it will be automatically un-broken in 9 commits.