### PR TITLE
MidiRawClient: Fix setting useless param

### DIFF
--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -225,7 +225,7 @@ void MidiClientRaw::parseData( const unsigned char c )
 			m_midiParseData.m_midiEvent.setVelocity(m_midiParseData.m_buffer[1]);
 		case MidiChannelPressure:
 		case MidiProgramChange:
-			// set key (or for ChannelPressure/ProgramChange: set param 1)
+			// set key (or for ChannelPressure/ProgramChange: set 1st param)
 			m_midiParseData.m_midiEvent.setKey(m_midiParseData.m_buffer[0]);
 			break;
 

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -221,12 +221,11 @@ void MidiClientRaw::parseData( const unsigned char c )
 		case MidiNoteOff:
 		case MidiNoteOn:
 		case MidiKeyPressure:
-			// set velocity of key
 			m_midiParseData.m_midiEvent.setVelocity(m_midiParseData.m_buffer[1]);
+			[[fallthrough]];
 		case MidiChannelPressure:
 		case MidiProgramChange:
-			// set key (or for ChannelPressure/ProgramChange: set 1st param)
-			m_midiParseData.m_midiEvent.setKey(m_midiParseData.m_buffer[0]);
+			m_midiParseData.m_midiEvent.setParam(0, m_midiParseData.m_buffer[0]);
 			break;
 
 		case MidiControlChange:

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -221,10 +221,12 @@ void MidiClientRaw::parseData( const unsigned char c )
 		case MidiNoteOff:
 		case MidiNoteOn:
 		case MidiKeyPressure:
+			// set velocity of key
+			m_midiParseData.m_midiEvent.setVelocity(m_midiParseData.m_buffer[1]);
 		case MidiChannelPressure:
 		case MidiProgramChange:
+			// set key (or for ChannelPressure/ProgramChange: set param 1)
 			m_midiParseData.m_midiEvent.setKey(m_midiParseData.m_buffer[0]);
-			m_midiParseData.m_midiEvent.setVelocity(m_midiParseData.m_buffer[1]);
 			break;
 
 		case MidiControlChange:

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -221,8 +221,10 @@ void MidiClientRaw::parseData( const unsigned char c )
 		case MidiNoteOff:
 		case MidiNoteOn:
 		case MidiKeyPressure:
+			m_midiParseData.m_midiEvent.setKey(m_midiParseData.m_buffer[0]);
 			m_midiParseData.m_midiEvent.setVelocity(m_midiParseData.m_buffer[1]);
-			[[fallthrough]];
+			break;
+
 		case MidiChannelPressure:
 		case MidiProgramChange:
 			m_midiParseData.m_midiEvent.setParam(0, m_midiParseData.m_buffer[0]);


### PR DESCRIPTION
MidiChannelPressure and MidiProgramChange have only one param, so only
set this one param for those.