### PR TITLE
Remove QVector from core

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -27,10 +27,10 @@
 
 #include <QMutex>
 #include <QThread>
-#include <QVector>
 #include <QWaitCondition>
 #include <samplerate.h>
 
+#include <vector>
 
 #include "lmms_basics.h"
 #include "LocklessList.h"
@@ -366,7 +366,7 @@ private:
 
 	bool m_renderOnly;
 
-	QVector<AudioPort *> m_audioPorts;
+	std::vector<AudioPort *> m_audioPorts;
 
 	fpp_t m_framesPerPeriod;
 
@@ -380,7 +380,7 @@ private:
 	surroundSampleFrame * m_outputBufferWrite;
 
 	// worker thread stuff
-	QVector<AudioEngineWorkerThread *> m_workers;
+	std::vector<AudioEngineWorkerThread *> m_workers;
 	int m_numWorkers;
 
 	// playhandle stuff

--- a/include/AudioEngineWorkerThread.h
+++ b/include/AudioEngineWorkerThread.h
@@ -96,7 +96,7 @@ public:
 							JobQueue::OperationMode _opMode = JobQueue::Static )
 	{
 		resetJobQueue( _opMode );
-		for( typename T::ConstIterator it = _vec.begin(); it != _vec.end(); ++it )
+		for (typename T::const_iterator it = _vec.begin(); it != _vec.end(); ++it)
 		{
 			addJob( *it );
 		}

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -30,6 +30,8 @@
 #include <QMap>
 #include <QPointer>
 
+#include <vector>
+
 #include "AutomationNode.h"
 #include "Clip.h"
 
@@ -51,7 +53,7 @@ public:
 	} ;
 
 	typedef QMap<int, AutomationNode> timeMap;
-	typedef QVector<QPointer<AutomatableModel>> objectVector;
+	typedef std::vector<QPointer<AutomatableModel>> objectVector;
 
 	using TimemapIterator = timeMap::const_iterator;
 
@@ -156,7 +158,7 @@ public:
 
 
 	static bool isAutomated( const AutomatableModel * _m );
-	static QVector<AutomationClip *> clipsForModel( const AutomatableModel * _m );
+	static std::vector<AutomationClip *> clipsForModel(const AutomatableModel * _m);
 	static AutomationClip * globalAutomationClip( AutomatableModel * _m );
 	static void resolveAllIDs();
 
@@ -184,7 +186,7 @@ private:
 	mutable QMutex m_clipMutex;
 
 	AutomationTrack * m_autoTrack;
-	QVector<jo_id_t> m_idsToResolve;
+	std::vector<jo_id_t> m_idsToResolve;
 	objectVector m_objects;
 	timeMap m_timeMap;	// actual values
 	timeMap m_oldTimeMap;	// old values for storing the values before setDragValue() is called.

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -27,6 +27,8 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
+#include <vector>
+
 #include "lmms_export.h"
 #include "Engine.h"
 #include "Model.h"
@@ -37,7 +39,7 @@ class ControllerDialog;
 class Controller;
 class ControllerConnection;
 
-typedef QVector<Controller *> ControllerVector;
+typedef std::vector<Controller *> ControllerVector;
 
 
 class LMMS_EXPORT Controller : public Model, public JournallingObject

--- a/include/StepRecorder.h
+++ b/include/StepRecorder.h
@@ -26,6 +26,8 @@
 #include <QTimer>
 #include <QObject>
 
+#include <vector>
+
 #include "Note.h"
 
 class MidiClip;
@@ -51,7 +53,7 @@ class StepRecorder : public QObject
 	void setCurrentMidiClip(MidiClip* newMidiClip);
 	void setStepsLength(const TimePos& newLength);
 
-	QVector<Note*> getCurStepNotes();
+	std::vector<Note*> getCurStepNotes();
 
 	bool isRecording() const
 	{
@@ -134,7 +136,7 @@ class StepRecorder : public QObject
 		QElapsedTimer releasedTimer;
 	} ;
 
-	QVector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
+	std::vector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
 
 	StepNote* findCurStepNote(const int key);
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -415,7 +415,7 @@ const surroundSampleFrame * AudioEngine::renderNextBuffer()
 	}
 
 	// STAGE 2: process effects of all instrument- and sampletracks
-	AudioEngineWorkerThread::fillJobQueue<QVector<AudioPort *> >( m_audioPorts );
+	AudioEngineWorkerThread::fillJobQueue<std::vector<AudioPort *> >(m_audioPorts);
 	AudioEngineWorkerThread::startAndWaitForJobs();
 
 
@@ -659,7 +659,7 @@ void AudioEngine::removeAudioPort(AudioPort * port)
 {
 	requestChangeInModel();
 
-	QVector<AudioPort *>::Iterator it = std::find(m_audioPorts.begin(), m_audioPorts.end(), port);
+	auto it = std::find(m_audioPorts.begin(), m_audioPorts.end(), port);
 	if (it != m_audioPorts.end())
 	{
 		m_audioPorts.erase(it);

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -719,8 +719,8 @@ void AutomatableModel::reset()
 float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 {
 	// get clips that connect to this model
-	QVector<AutomationClip *> clips = AutomationClip::clipsForModel( this );
-	if( clips.isEmpty() )
+	std::vector<AutomationClip *> clips = AutomationClip::clipsForModel(this);
+	if (clips.empty())
 	{
 		// if no such clips exist, return current value
 		return m_value;
@@ -729,17 +729,17 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 	{
 		// of those clips:
 		// find the clips which overlap with the time position
-		QVector<AutomationClip *> clipsInRange;
-		for( QVector<AutomationClip *>::ConstIterator it = clips.begin(); it != clips.end(); it++ )
+		std::vector<AutomationClip *> clipsInRange;
+		for (std::vector<AutomationClip *>::const_iterator it = clips.begin(); it != clips.end(); it++)
 		{
 			int s = ( *it )->startPosition();
 			int e = ( *it )->endPosition();
-			if( s <= time && e >= time ) { clipsInRange += ( *it ); }
+			if (s <= time && e >= time) { clipsInRange.push_back(*it); }
 		}
 
 		AutomationClip * latestClip = nullptr;
 
-		if( ! clipsInRange.isEmpty() )
+		if (!clipsInRange.empty())
 		{
 			// if there are more than one overlapping clips, just use the first one because
 			// multiple clip behaviour is undefined anyway
@@ -750,7 +750,7 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 		{
 			int latestPosition = 0;
 
-			for( QVector<AutomationClip *>::ConstIterator it = clips.begin(); it != clips.end(); it++ )
+			for (std::vector<AutomationClip *>::const_iterator it = clips.begin(); it != clips.end(); it++)
 			{
 				int e = ( *it )->endPosition();
 				if( e <= time && e > latestPosition )

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <QDomElement>
-#include <QVector>
 
 
 #include "AudioEngine.h"
@@ -37,7 +36,7 @@
 
 
 long Controller::s_periods = 0;
-QVector<Controller *> Controller::s_controllers;
+ControllerVector Controller::s_controllers;
 
 
 
@@ -52,7 +51,7 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 {
 	if( _type != DummyController && _type != MidiController )
 	{
-		s_controllers.append( this );
+		s_controllers.push_back(this);
 		// Determine which name to use
 		for ( uint i=s_controllers.size(); ; i++ )
 		{
@@ -83,10 +82,10 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 
 Controller::~Controller()
 {
-	int idx = s_controllers.indexOf( this );
-	if( idx >= 0 )
+	auto it = std::find(s_controllers.begin(), s_controllers.end(), this);
+	if (it != s_controllers.end())
 	{
-		s_controllers.remove( idx );
+		s_controllers.erase(it);
 	}
 
 	m_valueBuffer.clear();

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -183,10 +183,12 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 		}
 		else
 		{
-			int id = Engine::getSong()->controllers().indexOf( m_controller );
-			if( id >= 0 )
+			auto controllers = Engine::getSong()->controllers();
+			auto it = std::find(controllers.begin(), controllers.end(), m_controller);
+			if (it != controllers.end())
 			{
-				_this.setAttribute( "id", id );
+				int id = std::distance(controllers.begin(), it);
+				_this.setAttribute("id", id);
 			}
 		}
 	}

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1318,7 +1318,7 @@ void Song::restoreControllerStates( const QDomElement & element )
 		else
 		{
 			// Fix indices to ensure correct connections
-			m_controllers.append(Controller::create(
+			m_controllers.push_back(Controller::create(
 				Controller::DummyController, this));
 		}
 
@@ -1437,9 +1437,10 @@ void Song::setProjectFileName(QString const & projectFileName)
 
 void Song::addController( Controller * controller )
 {
-	if( controller && !m_controllers.contains( controller ) )
+	const auto cont = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	if (controller && cont == m_controllers.end())
 	{
-		m_controllers.append( controller );
+		m_controllers.push_back(controller);
 		emit controllerAdded( controller );
 
 		this->setModified();
@@ -1451,10 +1452,10 @@ void Song::addController( Controller * controller )
 
 void Song::removeController( Controller * controller )
 {
-	int index = m_controllers.indexOf( controller );
-	if( index != -1 )
+	auto it = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	if (it != m_controllers.end())
 	{
-		m_controllers.remove( index );
+		m_controllers.erase(it);
 
 		emit controllerRemoved( controller );
 		delete controller;

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -196,11 +196,11 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "flip_x" ),
 						tr( "Flip Horizontally (Visible)" ),
 						this, SLOT( flipX() ) );
-	if( !m_clip->m_objects.isEmpty() )
+	if (!m_clip->m_objects.empty())
 	{
 		_cm->addSeparator();
 		QMenu * m = new QMenu( tr( "%1 Connections" ).
-				arg( m_clip->m_objects.count() ), _cm );
+				arg(m_clip->m_objects.size()), _cm);
 		for( AutomationClip::objectVector::iterator it =
 						m_clip->m_objects.begin();
 					it != m_clip->m_objects.end(); ++it )

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -259,7 +259,8 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			}
 			else
 			{
-				int idx = Engine::getSong()->controllers().indexOf( cc->getController() );
+				auto controllers = Engine::getSong()->controllers();
+				int idx = std::distance(controllers.begin(), std::find(controllers.begin(), controllers.end(), cc->getController()));
 
 				if( idx >= 0 )
 				{


### PR DESCRIPTION
Removes [almost all] `QVector` from `src/core/`.

Only thing left is to change `InstrumentFunctionNoteStacking::ChordTable`. This will most likely require a bit more than changing `QVector` to `std::vector` since `ChordTable` inherits `QVector` and we don't want to inherit `std::vector`.


After changing a file I'd recompile lmms and open multiple demos and play them all to give a "working" test. No crashes. 👍