### PR TITLE
clang-tidy: Apply modernize-use-override everywhere

### DIFF
--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -69,7 +69,7 @@ public:
 
 public:
 	AudioAlsa( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioAlsa();
+	~AudioAlsa() override;
 
 	inline static QString name()
 	{

--- a/include/AudioAlsaSetupWidget.h
+++ b/include/AudioAlsaSetupWidget.h
@@ -47,7 +47,7 @@ class AudioAlsaSetupWidget : public AudioDeviceSetupWidget
 
 public:
 	AudioAlsaSetupWidget( QWidget * _parent );
-	virtual ~AudioAlsaSetupWidget();
+	~AudioAlsaSetupWidget() override;
 
 	void saveSettings() override;
 

--- a/include/AudioDeviceSetupWidget.h
+++ b/include/AudioDeviceSetupWidget.h
@@ -36,7 +36,7 @@ class AudioDeviceSetupWidget : public TabWidget
 public:
 	AudioDeviceSetupWidget( const QString & _caption, QWidget * _parent );
 
-	virtual ~AudioDeviceSetupWidget();
+	~AudioDeviceSetupWidget() override;
 
 	virtual void saveSettings() = 0;
 

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -43,7 +43,7 @@ public:
 		_success_ful = true;
 	}
 
-	virtual ~AudioDummy()
+	~AudioDummy() override
 	{
 		stopProcessing();
 	}
@@ -62,7 +62,7 @@ public:
 		{
 		}
 
-		virtual ~setupWidget()
+		~setupWidget() override
 		{
 		}
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -387,7 +387,7 @@ private:
 
 
 	AudioEngine( bool renderOnly );
-	virtual ~AudioEngine();
+	~AudioEngine() override;
 
 	void startProcessing(bool needsFifo = true);
 	void stopProcessing();

--- a/include/AudioEngineWorkerThread.h
+++ b/include/AudioEngineWorkerThread.h
@@ -78,7 +78,7 @@ public:
 
 
 	AudioEngineWorkerThread( AudioEngine* audioEngine );
-	virtual ~AudioEngineWorkerThread();
+	~AudioEngineWorkerThread() override;
 
 	virtual void quit();
 

--- a/include/AudioFileDevice.h
+++ b/include/AudioFileDevice.h
@@ -40,7 +40,7 @@ public:
 	AudioFileDevice(OutputSettings const & outputSettings,
 			const ch_cnt_t _channels, const QString & _file,
 			AudioEngine* audioEngine );
-	virtual ~AudioFileDevice();
+	~AudioFileDevice() override;
 
 	QString outputFile() const
 	{

--- a/include/AudioFileFlac.h
+++ b/include/AudioFileFlac.h
@@ -43,7 +43,7 @@ public:
 			AudioEngine* audioEngine
 	);
 
-	virtual ~AudioFileFlac();
+	~AudioFileFlac() override;
 
 	static AudioFileDevice* getInst(QString const& outputFilename,
 			OutputSettings const& outputSettings,
@@ -65,7 +65,7 @@ private:
 	SF_INFO  m_sfinfo;
 	SNDFILE* m_sf;
 
-	virtual void writeBuffer(surroundSampleFrame const* _ab,
+	void writeBuffer(surroundSampleFrame const* _ab,
 						fpp_t const frames,
 						float master_gain) override;
 

--- a/include/AudioFileMP3.h
+++ b/include/AudioFileMP3.h
@@ -45,7 +45,7 @@ public:
 			bool & successful,
 			const QString & _file,
 			AudioEngine* audioEngine );
-	virtual ~AudioFileMP3();
+	~AudioFileMP3() override;
 
 	static AudioFileDevice * getInst( const QString & outputFilename,
 					  OutputSettings const & outputSettings,
@@ -58,7 +58,7 @@ public:
 	}
 
 protected:
-	virtual void writeBuffer( const surroundSampleFrame * /* _buf*/,
+	void writeBuffer( const surroundSampleFrame * /* _buf*/,
 				  const fpp_t /*_frames*/,
 				  const float /*_master_gain*/ ) override;
 

--- a/include/AudioFileOgg.h
+++ b/include/AudioFileOgg.h
@@ -45,7 +45,7 @@ public:
 			bool & _success_ful,
 			const QString & _file,
 			AudioEngine* audioEngine );
-	virtual ~AudioFileOgg();
+	~AudioFileOgg() override;
 
 	static AudioFileDevice * getInst( const QString & outputFilename,
 					  OutputSettings const & outputSettings,
@@ -58,7 +58,7 @@ public:
 
 
 private:
-	virtual void writeBuffer( const surroundSampleFrame * _ab,
+	void writeBuffer( const surroundSampleFrame * _ab,
 						const fpp_t _frames,
 						const float _master_gain ) override;
 

--- a/include/AudioFileWave.h
+++ b/include/AudioFileWave.h
@@ -42,7 +42,7 @@ public:
 			bool & successful,
 			const QString & file,
 			AudioEngine* audioEngine );
-	virtual ~AudioFileWave();
+	~AudioFileWave() override;
 
 	static AudioFileDevice * getInst( const QString & outputFilename,
 					  OutputSettings const & outputSettings,
@@ -56,7 +56,7 @@ public:
 
 
 private:
-	virtual void writeBuffer( const surroundSampleFrame * _ab,
+	void writeBuffer( const surroundSampleFrame * _ab,
 						const fpp_t _frames,
 						float _master_gain ) override;
 

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -58,7 +58,7 @@ class AudioJack : public QObject, public AudioDevice
 	Q_OBJECT
 public:
 	AudioJack( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioJack();
+	~AudioJack() override;
 
 	// this is to allow the jack midi connection to use the same jack client connection
 	// the jack callback is handled here, we call the midi client so that it can read
@@ -78,9 +78,9 @@ class setupWidget : public gui::AudioDeviceSetupWidget
 	{
 	public:
 		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
+		~setupWidget() override;
 
-		virtual void saveSettings();
+		void saveSettings() override;
 
 	private:
 		QLineEdit * m_clientName;
@@ -96,13 +96,13 @@ private slots:
 private:
 	bool initJackClient();
 
-	virtual void startProcessing();
-	virtual void stopProcessing();
-	virtual void applyQualitySettings();
+	void startProcessing() override;
+	void stopProcessing() override;
+	void applyQualitySettings() override;
 
-	virtual void registerPort( AudioPort * _port );
-	virtual void unregisterPort( AudioPort * _port );
-	virtual void renamePort( AudioPort * _port );
+	void registerPort( AudioPort * _port ) override;
+	void unregisterPort( AudioPort * _port ) override;
+	void renamePort( AudioPort * _port ) override;
 
 	int processCallback( jack_nframes_t _nframes, void * _udata );
 

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -51,7 +51,7 @@ class AudioOss : public QThread, public AudioDevice
 	Q_OBJECT
 public:
 	AudioOss( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioOss();
+	~AudioOss() override;
 
 	inline static QString name()
 	{
@@ -65,7 +65,7 @@ class setupWidget : public gui::AudioDeviceSetupWidget
 	{
 	public:
 		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
+		~setupWidget() override;
 
 		void saveSettings() override;
 

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -77,7 +77,7 @@ class AudioPortAudio : public AudioDevice
 {
 public:
 	AudioPortAudio( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioPortAudio();
+	~AudioPortAudio() override;
 
 	inline static QString name()
 	{
@@ -94,10 +94,10 @@ public:
 	{
 	public:
 		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
+		~setupWidget() override;
 
-		virtual void saveSettings();
-		virtual void show();
+		void saveSettings() override;
+		void show() override;
 
 	private:
 		gui::ComboBox * m_backend;
@@ -107,9 +107,9 @@ public:
 	} ;
 
 private:
-	virtual void startProcessing();
-	virtual void stopProcessing();
-	virtual void applyQualitySettings();
+	void startProcessing() override;
+	void stopProcessing() override;
+	void applyQualitySettings() override;
 
 #ifdef PORTAUDIO_V19
 	static int _process_callback( const void *_inputBuffer, void * _outputBuffer,

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -52,7 +52,7 @@ class AudioPulseAudio : public QThread, public AudioDevice
 	Q_OBJECT
 public:
 	AudioPulseAudio( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioPulseAudio();
+	~AudioPulseAudio() override;
 
 	inline static QString name()
 	{
@@ -66,7 +66,7 @@ public:
 	{
 	public:
 		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
+		~setupWidget() override;
 
 		void saveSettings() override;
 

--- a/include/AudioSampleRecorder.h
+++ b/include/AudioSampleRecorder.h
@@ -41,14 +41,14 @@ class AudioSampleRecorder : public AudioDevice
 {
 public:
 	AudioSampleRecorder( const ch_cnt_t _channels, bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioSampleRecorder();
+	~AudioSampleRecorder() override;
 
 	f_cnt_t framesRecorded() const;
 	void createSampleBuffer( SampleBuffer** sampleBuffer );
 
 
 private:
-	virtual void writeBuffer( const surroundSampleFrame * _ab,
+	void writeBuffer( const surroundSampleFrame * _ab,
 						const fpp_t _frames,
 						const float _master_gain ) override;
 

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -48,7 +48,7 @@ class AudioSdl : public AudioDevice
 {
 public:
 	AudioSdl( bool & _success_ful, AudioEngine* audioEngine );
-	virtual ~AudioSdl();
+	~AudioSdl() override;
 
 	inline static QString name()
 	{

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -52,7 +52,7 @@ class AudioSndio : public QThread, public AudioDevice
 	Q_OBJECT
 public:
 	AudioSndio( bool & _success_ful, AudioEngine * _audioEngine );
-	virtual ~AudioSndio();
+	~AudioSndio() override;
 
 	inline static QString name( void )
 	{
@@ -63,7 +63,7 @@ public:
 	{
 	public:
 		setupWidget( QWidget * _parent );
-		virtual ~setupWidget();
+		~setupWidget() override;
 
 		void saveSettings( void ) override;
 

--- a/include/AutomatableButton.h
+++ b/include/AutomatableButton.h
@@ -42,7 +42,7 @@ class LMMS_EXPORT AutomatableButton : public QPushButton, public BoolModelView
 public:
 	AutomatableButton( QWidget * _parent, const QString & _name
 			= QString() );
-	virtual ~AutomatableButton();
+	~AutomatableButton() override;
 
 	inline void setCheckable( bool _on )
 	{
@@ -87,7 +87,7 @@ class LMMS_EXPORT automatableButtonGroup : public QWidget, public IntModelView
 public:
 	automatableButtonGroup( QWidget * _parent, const QString & _name
 			= QString() );
-	virtual ~automatableButtonGroup();
+	~automatableButtonGroup() override;
 
 	void addButton( AutomatableButton * _btn );
 	void removeButton( AutomatableButton * _btn );

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -89,7 +89,7 @@ public:
 	};
 
 
-	virtual ~AutomatableModel();
+	~AutomatableModel() override;
 
 	// Implement those by using the MODEL_IS_VISITABLE macro
 	virtual void accept(ModelVisitor& v) = 0;

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -39,7 +39,7 @@ class LMMS_EXPORT AutomatableModelView : public ModelView
 {
 public:
 	AutomatableModelView( Model* model, QWidget* _this );
-	virtual ~AutomatableModelView() = default;
+	~AutomatableModelView() override = default;
 
 	// some basic functions for convenience
 	AutomatableModel* modelUntyped()

--- a/include/AutomatableSlider.h
+++ b/include/AutomatableSlider.h
@@ -39,7 +39,7 @@ class AutomatableSlider : public QSlider, public IntModelView
 	Q_OBJECT
 public:
 	AutomatableSlider( QWidget * _parent, const QString & _name = QString() );
-	virtual ~AutomatableSlider();
+	~AutomatableSlider() override;
 
 	bool showStatus()
 	{

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -65,7 +65,7 @@ public:
 
 	AutomationClip( AutomationTrack * _auto_track );
 	AutomationClip( const AutomationClip & _clip_to_copy );
-	virtual ~AutomationClip() = default;
+	~AutomationClip() override = default;
 
 	bool addObject( AutomatableModel * _obj, bool _search_dup = true );
 

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -45,7 +45,7 @@ class AutomationClipView : public ClipView
 
 public:
 	AutomationClipView( AutomationClip * _clip, TrackView * _parent );
-	virtual ~AutomationClipView();
+	~AutomationClipView() override;
 
 public slots:
 	/// Opens this view's clip in the global automation editor

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -167,7 +167,7 @@ private:
 
 	AutomationEditor();
 	AutomationEditor( const AutomationEditor & );
-	virtual ~AutomationEditor();
+	~AutomationEditor() override;
 
 	static QPixmap * s_toolDraw;
 	static QPixmap * s_toolErase;
@@ -255,7 +255,7 @@ class AutomationEditorWindow : public Editor
 	static const int INITIAL_HEIGHT = 480;
 public:
 	AutomationEditorWindow();
-	~AutomationEditorWindow();
+	~AutomationEditorWindow() override;
 
 	void setCurrentClip(AutomationClip* clip);
 	const AutomationClip* currentClip();

--- a/include/AutomationTrack.h
+++ b/include/AutomationTrack.h
@@ -37,9 +37,9 @@ class AutomationTrack : public Track
 	Q_OBJECT
 public:
 	AutomationTrack( TrackContainer* tc, bool _hidden = false );
-	virtual ~AutomationTrack() = default;
+	~AutomationTrack() override = default;
 
-	virtual bool play( const TimePos & _start, const fpp_t _frames,
+	bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _clip_num = -1 ) override;
 
 	QString nodeName() const override
@@ -50,7 +50,7 @@ public:
 	gui::TrackView * createView( gui::TrackContainerView* ) override;
 	Clip* createClip(const TimePos & pos) override;
 
-	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
+	void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent ) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 

--- a/include/AutomationTrackView.h
+++ b/include/AutomationTrackView.h
@@ -41,7 +41,7 @@ class AutomationTrackView : public TrackView
 {
 public:
 	AutomationTrackView( AutomationTrack* at, TrackContainerView* tcv );
-	virtual ~AutomationTrackView() = default;
+	~AutomationTrackView() override = default;
 
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;

--- a/include/CPULoadWidget.h
+++ b/include/CPULoadWidget.h
@@ -43,7 +43,7 @@ class CPULoadWidget : public QWidget
 	Q_OBJECT
 public:
 	CPULoadWidget( QWidget * _parent );
-	virtual ~CPULoadWidget();
+	~CPULoadWidget() override;
 
 
 protected:

--- a/include/CaptionMenu.h
+++ b/include/CaptionMenu.h
@@ -41,7 +41,7 @@ class LMMS_EXPORT CaptionMenu : public QMenu
 	Q_OBJECT
 public:
 	CaptionMenu( const QString & _title, QWidget * _parent = 0 );
-	virtual ~CaptionMenu();
+	~CaptionMenu() override;
 } ;
 
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -53,7 +53,7 @@ class LMMS_EXPORT Clip : public Model, public JournallingObject
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
 	Clip( Track * track );
-	virtual ~Clip();
+	~Clip() override;
 
 	inline Track * getTrack() const
 	{

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -71,7 +71,7 @@ public:
 	const static int BORDER_WIDTH = 2;
 
 	ClipView( Clip * clip, TrackView * tv );
-	virtual ~ClipView();
+	~ClipView() override;
 
 	bool fixedClips();
 

--- a/include/ComboBox.h
+++ b/include/ComboBox.h
@@ -40,7 +40,7 @@ class LMMS_EXPORT ComboBox : public QWidget, public IntModelView
 	Q_OBJECT
 public:
 	ComboBox( QWidget* parent = nullptr, const QString& name = QString() );
-	virtual ~ComboBox();
+	~ComboBox() override;
 
 	ComboBoxModel* model()
 	{

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -47,7 +47,7 @@ public:
 	{
 	}
 
-	virtual ~ComboBoxModel()
+	~ComboBoxModel() override
 	{
 		clear();
 	}

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -274,7 +274,7 @@ private:
 
 	ConfigManager();
 	ConfigManager(const ConfigManager & _c);
-	~ConfigManager();
+	~ConfigManager() override;
 
 	void upgrade_1_1_90();
 	void upgrade_1_1_91();

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -70,7 +70,7 @@ public:
 	Controller( ControllerTypes _type, Model * _parent,
 						const QString & _display_name );
 
-	virtual ~Controller();
+	~Controller() override;
 
 	virtual float currentValue( int _offset );
 	// The per-controller get-value-in-buffers function

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -58,7 +58,7 @@ public:
 	ControllerConnection(Controller * _controller);
 	ControllerConnection( int _controllerId );
 
-	virtual ~ControllerConnection();
+	~ControllerConnection() override;
 
 	inline Controller * getController()
 	{

--- a/include/ControllerConnectionDialog.h
+++ b/include/ControllerConnectionDialog.h
@@ -61,7 +61,7 @@ class ControllerConnectionDialog : public QDialog
 public:
 	ControllerConnectionDialog( QWidget * _parent,
 			const AutomatableModel * _target_model );
-	virtual ~ControllerConnectionDialog();
+	~ControllerConnectionDialog() override;
 
 	Controller * chosenController()
 	{

--- a/include/ControllerDialog.h
+++ b/include/ControllerDialog.h
@@ -44,7 +44,7 @@ class ControllerDialog : public QWidget, public ModelView
 public:
 	ControllerDialog( Controller * _controller, QWidget * _parent );
 
-	virtual ~ControllerDialog();
+	~ControllerDialog() override;
 
 
 signals:

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -53,7 +53,7 @@ class ControllerRackView : public QWidget, public SerializingObject
 	Q_OBJECT
 public:
 	ControllerRackView();
-	virtual ~ControllerRackView();
+	~ControllerRackView() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/include/ControllerView.h
+++ b/include/ControllerView.h
@@ -48,7 +48,7 @@ class ControllerView : public QFrame, public ModelView
 	Q_OBJECT
 public:
 	ControllerView( Controller * _controller, QWidget * _parent );
-	virtual ~ControllerView();
+	~ControllerView() override;
 
 	inline Controller * getController()
 	{

--- a/include/CustomTextKnob.h
+++ b/include/CustomTextKnob.h
@@ -25,7 +25,7 @@ public:
 	}
 
 private:
-	virtual QString displayValue() const;
+	QString displayValue() const override;
 
 protected:
 	QString m_value_text;

--- a/include/DetuningHelper.h
+++ b/include/DetuningHelper.h
@@ -42,7 +42,7 @@ public:
 	{
 	}
 
-	virtual ~DetuningHelper()
+	~DetuningHelper() override
 	{
 	}
 

--- a/include/DummyEffect.h
+++ b/include/DummyEffect.h
@@ -60,7 +60,7 @@ public:
 	{
 	}
 
-	virtual ~DummyEffectControls()
+	~DummyEffectControls() override
 	{
 	}
 
@@ -102,7 +102,7 @@ public:
 		setName();
 	}
 
-	virtual ~DummyEffect()
+	~DummyEffect() override
 	{
 	}
 

--- a/include/DummyInstrument.h
+++ b/include/DummyInstrument.h
@@ -47,7 +47,7 @@ public:
 	{
 	}
 
-	virtual ~DummyInstrument()
+	~DummyInstrument() override
 	{
 	}
 

--- a/include/DummyPlugin.h
+++ b/include/DummyPlugin.h
@@ -41,7 +41,7 @@ public:
 	{
 	}
 
-	virtual ~DummyPlugin()
+	~DummyPlugin() override
 	{
 	}
 

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -81,7 +81,7 @@ protected:
 	/// \param	record	If set true, the editor's toolbar will contain record
 	///					buttons in addition to the play and stop buttons.
 	Editor(bool record = false, bool record_step = false);
-	virtual ~Editor();
+	~Editor() override;
 
 
 	DropToolBar* m_toolBar;

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -55,7 +55,7 @@ public:
 	Effect( const Plugin::Descriptor * _desc,
 			Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~Effect();
+	~Effect() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -48,7 +48,7 @@ class LMMS_EXPORT EffectChain : public Model, public SerializingObject
 	Q_OBJECT
 public:
 	EffectChain( Model * _parent );
-	virtual ~EffectChain();
+	~EffectChain() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/include/EffectControlDialog.h
+++ b/include/EffectControlDialog.h
@@ -44,7 +44,7 @@ class LMMS_EXPORT EffectControlDialog : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	EffectControlDialog( EffectControls * _controls );
-	virtual ~EffectControlDialog();
+	~EffectControlDialog() override;
 
 	virtual bool isResizable() const {return false;}
 

--- a/include/EffectControls.h
+++ b/include/EffectControls.h
@@ -51,7 +51,7 @@ public:
 	{
 	}
 
-	virtual ~EffectControls()
+	~EffectControls() override
 	{
 	}
 

--- a/include/EffectRackView.h
+++ b/include/EffectRackView.h
@@ -47,7 +47,7 @@ class EffectRackView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	EffectRackView( EffectChain* model, QWidget* parent = nullptr );
-	virtual ~EffectRackView();
+	~EffectRackView() override;
 
 	static constexpr int DEFAULT_WIDTH = 245;
 

--- a/include/EffectSelectDialog.h
+++ b/include/EffectSelectDialog.h
@@ -43,7 +43,7 @@ class EffectSelectDialog : public QDialog
 	Q_OBJECT
 public:
 	EffectSelectDialog( QWidget * _parent );
-	virtual ~EffectSelectDialog();
+	~EffectSelectDialog() override;
 
 	Effect * instantiateSelectedPlugin( EffectChain * _parent );
 

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -49,7 +49,7 @@ class EffectView : public PluginView
 	Q_OBJECT
 public:
 	EffectView( Effect * _model, QWidget * _parent );
-	virtual ~EffectView();
+	~EffectView() override;
 
 	inline Effect * effect()
 	{

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -78,7 +78,7 @@ public:
 
 	EnvelopeAndLfoParameters( float _value_for_zero_amount,
 							Model * _parent );
-	virtual ~EnvelopeAndLfoParameters();
+	~EnvelopeAndLfoParameters() override;
 
 	static inline float expKnobVal( float _val )
 	{

--- a/include/EnvelopeAndLfoView.h
+++ b/include/EnvelopeAndLfoView.h
@@ -54,7 +54,7 @@ class EnvelopeAndLfoView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	EnvelopeAndLfoView( QWidget * _parent );
-	virtual ~EnvelopeAndLfoView();
+	~EnvelopeAndLfoView() override;
 
 
 protected:

--- a/include/ExportFilter.h
+++ b/include/ExportFilter.h
@@ -40,7 +40,7 @@ class LMMS_EXPORT ExportFilter : public Plugin
 {
 public:
 	ExportFilter( const Descriptor * _descriptor ) : Plugin( _descriptor, nullptr ) {}
-	virtual ~ExportFilter() {}
+	~ExportFilter() override {}
 
 
 	virtual bool tryExport(const TrackContainer::TrackList &tracks,

--- a/include/FadeButton.h
+++ b/include/FadeButton.h
@@ -44,7 +44,7 @@ public:
 		const QColor & _hold_color,
 		QWidget * _parent );
 
-	virtual ~FadeButton();
+	~FadeButton() override;
 	void setActiveColor( const QColor & activated_color );
 
 

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -72,7 +72,7 @@ public:
 
 	Fader( FloatModel * _model, const QString & _name, QWidget * _parent );
 	Fader( FloatModel * _model, const QString & _name, QWidget * _parent, QPixmap * back, QPixmap * leds, QPixmap * knob );
-	virtual ~Fader() = default;
+	~Fader() override = default;
 
 	void init(FloatModel * model, QString const & name);
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -68,7 +68,7 @@ public:
 			const QString& userDir = "",
 			const QString& factoryDir = "");
 
-	virtual ~FileBrowser() = default;
+	~FileBrowser() override = default;
 
 private slots:
 	void reloadTree( void );
@@ -107,7 +107,7 @@ class FileBrowserTreeWidget : public QTreeWidget
 	Q_OBJECT
 public:
 	FileBrowserTreeWidget( QWidget * parent );
-	virtual ~FileBrowserTreeWidget() = default;
+	~FileBrowserTreeWidget() override = default;
 
 	//! This method returns a QList with paths (QString's) of all directories
 	//! that are expanded in the tree.

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -67,7 +67,7 @@ public:
 		int _width = 132,
 		int _height = 104
 	);
-	virtual ~Graph() = default;
+	~Graph() override = default;
 
 	void setForeground( const QPixmap & _pixmap );
 
@@ -151,7 +151,7 @@ public:
 			bool _default_constructed = false,
 			float _step = 0.0 );
 
-	virtual ~graphModel() = default;
+	~graphModel() override = default;
 
 	// TODO: saveSettings, loadSettings?
 

--- a/include/GroupBox.h
+++ b/include/GroupBox.h
@@ -42,7 +42,7 @@ class GroupBox : public QWidget, public BoolModelView
 	Q_OBJECT
 public:
 	GroupBox( const QString & _caption, QWidget * _parent = nullptr );
-	virtual ~GroupBox();
+	~GroupBox() override;
 
 	void modelChanged() override;
 

--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -50,7 +50,7 @@ class LMMS_EXPORT GuiApplication : public QObject
 	Q_OBJECT;
 public:
 	explicit GuiApplication();
-	~GuiApplication();
+	~GuiApplication() override;
 
 	static GuiApplication* instance();
 #ifdef LMMS_BUILD_WIN32

--- a/include/ImportFilter.h
+++ b/include/ImportFilter.h
@@ -42,7 +42,7 @@ class LMMS_EXPORT ImportFilter : public Plugin
 public:
 	ImportFilter( const QString & _file_name,
 					const Descriptor * _descriptor );
-	virtual ~ImportFilter();
+	~ImportFilter() override;
 
 
 	// tries to import given file to given track-container by having all

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -42,7 +42,7 @@ public:
 	{
 	}
 
-	virtual ~InlineAutomation()
+	~InlineAutomation() override
 	{
 		if( m_autoClip )
 		{

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -60,7 +60,7 @@ public:
 	Instrument(InstrumentTrack * _instrument_track,
 			const Descriptor * _descriptor,
 			const Descriptor::SubPluginFeatures::Key * key = nullptr);
-	virtual ~Instrument() = default;
+	~Instrument() override = default;
 
 	// --------------------------------------------------------------------
 	// functions that can/should be re-implemented:

--- a/include/InstrumentFunctionViews.h
+++ b/include/InstrumentFunctionViews.h
@@ -50,7 +50,7 @@ class InstrumentFunctionNoteStackingView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	InstrumentFunctionNoteStackingView( InstrumentFunctionNoteStacking* cc, QWidget* parent = nullptr );
-	virtual ~InstrumentFunctionNoteStackingView();
+	~InstrumentFunctionNoteStackingView() override;
 
 
 private:
@@ -73,7 +73,7 @@ class InstrumentFunctionArpeggioView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	InstrumentFunctionArpeggioView( InstrumentFunctionArpeggio* arp, QWidget* parent = nullptr );
-	virtual ~InstrumentFunctionArpeggioView();
+	~InstrumentFunctionArpeggioView() override;
 
 
 private:

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -58,7 +58,7 @@ private:
 
 public:
 	InstrumentFunctionNoteStacking( Model * _parent );
-	virtual ~InstrumentFunctionNoteStacking();
+	~InstrumentFunctionNoteStacking() override;
 
 	void processNote( NotePlayHandle* n );
 
@@ -180,7 +180,7 @@ public:
 	} ;
 
 	InstrumentFunctionArpeggio( Model * _parent );
-	virtual ~InstrumentFunctionArpeggio();
+	~InstrumentFunctionArpeggio() override;
 
 	void processNote( NotePlayHandle* n );
 

--- a/include/InstrumentMidiIOView.h
+++ b/include/InstrumentMidiIOView.h
@@ -50,7 +50,7 @@ class InstrumentMidiIOView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	InstrumentMidiIOView( QWidget* parent );
-	virtual ~InstrumentMidiIOView();
+	~InstrumentMidiIOView() override;
 
 
 private:

--- a/include/InstrumentPlayHandle.h
+++ b/include/InstrumentPlayHandle.h
@@ -38,7 +38,7 @@ class LMMS_EXPORT InstrumentPlayHandle : public PlayHandle
 public:
 	InstrumentPlayHandle( Instrument * instrument, InstrumentTrack* instrumentTrack );
 
-	virtual ~InstrumentPlayHandle()
+	~InstrumentPlayHandle() override
 	{
 	}
 

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -46,7 +46,7 @@ class InstrumentSoundShaping : public Model, public JournallingObject
 	Q_OBJECT
 public:
 	InstrumentSoundShaping( InstrumentTrack * _instrument_track );
-	virtual ~InstrumentSoundShaping();
+	~InstrumentSoundShaping() override;
 
 	void processAudioBuffer( sampleFrame * _ab, const fpp_t _frames,
 							NotePlayHandle * _n );

--- a/include/InstrumentSoundShapingView.h
+++ b/include/InstrumentSoundShapingView.h
@@ -47,7 +47,7 @@ class InstrumentSoundShapingView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	InstrumentSoundShapingView( QWidget * _parent );
-	virtual ~InstrumentSoundShapingView();
+	~InstrumentSoundShapingView() override;
 
 	void setFunctionsHidden( bool hidden );
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -64,7 +64,7 @@ class LMMS_EXPORT InstrumentTrack : public Track, public MidiEventProcessor
 	mapPropertyFromModel(int,getVolume,setVolume,m_volumeModel);
 public:
 	InstrumentTrack( TrackContainer* tc );
-	virtual ~InstrumentTrack();
+	~InstrumentTrack() override;
 
 	// used by instrument
 	void processAudioBuffer( sampleFrame * _buf, const fpp_t _frames,
@@ -122,7 +122,7 @@ public:
 	}
 
 	// play everything in given frame-range - creates note-play-handles
-	virtual bool play( const TimePos & _start, const fpp_t _frames,
+	bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _clip_num = -1 ) override;
 	// create new view for me
 	gui::TrackView* createView( gui::TrackContainerView* tcv ) override;
@@ -132,7 +132,7 @@ public:
 
 
 	// called by track
-	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
+	void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent ) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 

--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -46,7 +46,7 @@ class InstrumentTrackView : public TrackView
 	Q_OBJECT
 public:
 	InstrumentTrackView( InstrumentTrack * _it, TrackContainerView* tc );
-	virtual ~InstrumentTrackView();
+	~InstrumentTrackView() override;
 
 	InstrumentTrackWindow * getInstrumentTrackWindow();
 

--- a/include/InstrumentTrackWindow.h
+++ b/include/InstrumentTrackWindow.h
@@ -65,7 +65,7 @@ class InstrumentTrackWindow : public QWidget, public ModelView,
 	Q_OBJECT
 public:
 	InstrumentTrackWindow( InstrumentTrackView * _tv );
-	virtual ~InstrumentTrackWindow();
+	~InstrumentTrackWindow() override;
 
 	// parent for all internal tab-widgets
 	TabWidget * tabWidgetParent()

--- a/include/JournallingObject.h
+++ b/include/JournallingObject.h
@@ -37,7 +37,7 @@ class LMMS_EXPORT JournallingObject : public SerializingObject
 {
 public:
 	JournallingObject();
-	virtual ~JournallingObject();
+	~JournallingObject() override;
 
 	inline jo_id_t id() const
 	{
@@ -60,7 +60,7 @@ public:
 
 	void addJournalCheckPoint();
 
-	virtual QDomElement saveState( QDomDocument & _doc,
+	QDomElement saveState( QDomDocument & _doc,
 									QDomElement & _parent ) override;
 
 	void restoreState( const QDomElement & _this ) override;

--- a/include/Ladspa2LMMS.h
+++ b/include/Ladspa2LMMS.h
@@ -68,7 +68,7 @@ public:
 
 private:
 	Ladspa2LMMS();
-	virtual ~Ladspa2LMMS();
+	~Ladspa2LMMS() override;
 
 	l_sortable_plugin_t m_instruments;
 	l_sortable_plugin_t m_validEffects;

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -52,7 +52,7 @@ class LMMS_EXPORT LadspaControl : public Model, public JournallingObject
 public:
 	LadspaControl( Model * _parent, port_desc_t * _port,
 							bool _link = false );
-	~LadspaControl();
+	~LadspaControl() override;
 
 	LADSPA_Data value();
 	ValueBuffer * valueBuffer();

--- a/include/LadspaControlView.h
+++ b/include/LadspaControlView.h
@@ -43,7 +43,7 @@ class LMMS_EXPORT LadspaControlView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	LadspaControlView( QWidget * _parent, LadspaControl * _ctl );
-	virtual ~LadspaControlView();
+	~LadspaControlView() override;
 
 private:
 	LadspaControl * m_ctl;

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -40,7 +40,7 @@ public:
 
 	LcdSpinBox( int numDigits, const QString& style, QWidget* parent, const QString& name = QString() );
 
-	virtual ~LcdSpinBox() = default;
+	~LcdSpinBox() override = default;
 
 	void modelChanged() override
 	{

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -48,7 +48,7 @@ public:
 	LcdWidget(int numDigits, const QString& style, QWidget* parent, const QString& name = QString(),
 		bool leadingZero = false);
 
-	virtual ~LcdWidget();
+	~LcdWidget() override;
 
 	void setValue( int value );
 	void setLabel( const QString& label );

--- a/include/LedCheckBox.h
+++ b/include/LedCheckBox.h
@@ -54,7 +54,7 @@ public:
 				const QString & _name = QString(),
 						LedColors _color = Yellow );
 
-	virtual ~LedCheckBox();
+	~LedCheckBox() override;
 
 
 	inline const QString & text()

--- a/include/LfoController.h
+++ b/include/LfoController.h
@@ -57,7 +57,7 @@ class LfoController : public Controller
 public:
 	LfoController( Model * _parent );
 
-	virtual ~LfoController();
+	~LfoController() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
 	void loadSettings( const QDomElement & _this ) override;
@@ -105,7 +105,7 @@ class LfoControllerDialog : public ControllerDialog
 	Q_OBJECT
 public:
 	LfoControllerDialog( Controller * _controller, QWidget * _parent );
-	virtual ~LfoControllerDialog();
+	~LfoControllerDialog() override;
 
 
 protected:

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -70,7 +70,7 @@ public:
 	*/
 	LinkedModelGroupView(QWidget* parent, LinkedModelGroup* model,
 		std::size_t colNum);
-	~LinkedModelGroupView();
+	~LinkedModelGroupView() override;
 
 	//! Reconnect models if model changed
 	void modelChanged(LinkedModelGroup* linkedModelGroup);

--- a/include/LmmsPalette.h
+++ b/include/LmmsPalette.h
@@ -50,7 +50,7 @@ class LMMS_EXPORT LmmsPalette : public QWidget
 
 public:
 	LmmsPalette( QWidget * parent, QStyle * stylearg  ); 
-	virtual ~LmmsPalette();
+	~LmmsPalette() override;
 
 #define ACCESSMET( read, write ) \
 	QColor read () const; \

--- a/include/LmmsStyle.h
+++ b/include/LmmsStyle.h
@@ -66,23 +66,23 @@ public:
 	};
 
 	LmmsStyle();
-	virtual ~LmmsStyle()
+	~LmmsStyle() override
 	{
 	}
 
 	QPalette standardPalette( void ) const override;
 
-	virtual void drawComplexControl(
+	void drawComplexControl(
 				ComplexControl control,
 				const QStyleOptionComplex * option,
 					QPainter *painter,
 						const QWidget *widget ) const override;
-	virtual void drawPrimitive( PrimitiveElement element,
+	void drawPrimitive( PrimitiveElement element,
 					const QStyleOption *option,
 					QPainter *painter,
 					const QWidget *widget = 0 ) const override;
 
-	virtual int pixelMetric( PixelMetric metric,
+	int pixelMetric( PixelMetric metric,
 					const QStyleOption * option = 0,
 					const QWidget * widget = 0 ) const override;
 

--- a/include/LocklessAllocator.h
+++ b/include/LocklessAllocator.h
@@ -67,7 +67,7 @@ public:
 	{
 	}
 
-	virtual ~LocklessAllocatorT()
+	~LocklessAllocatorT() override
 	{
 	}
 

--- a/include/Lv2ViewBase.h
+++ b/include/Lv2ViewBase.h
@@ -58,7 +58,7 @@ class Lv2ViewProc : public LinkedModelGroupView
 public:
 	//! @param colNum numbers of columns for the controls
 	Lv2ViewProc(QWidget *parent, Lv2Proc *ctrlBase, int colNum);
-	~Lv2ViewProc();
+	~Lv2ViewProc() override;
 
 private:
 	static AutoLilvNode uri(const char *uriStr);

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -190,7 +190,7 @@ protected:
 private:
 	MainWindow();
 	MainWindow( const MainWindow & );
-	virtual ~MainWindow();
+	~MainWindow() override;
 
 	void finalize();
 

--- a/include/MeterDialog.h
+++ b/include/MeterDialog.h
@@ -41,7 +41,7 @@ class MeterDialog : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	MeterDialog( QWidget * _parent, bool _simple = false );
-	virtual ~MeterDialog();
+	~MeterDialog() override;
 
 	void modelChanged() override;
 

--- a/include/MeterModel.h
+++ b/include/MeterModel.h
@@ -38,7 +38,7 @@ class MeterModel : public Model
 	mapPropertyFromModel(int,getDenominator,setDenominator,m_denominatorModel);
 public:
 	MeterModel( Model * _parent );
-	~MeterModel();
+	~MeterModel() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this,
 						const QString & _name );

--- a/include/MidiAlsaRaw.h
+++ b/include/MidiAlsaRaw.h
@@ -48,7 +48,7 @@ class MidiAlsaRaw : public QThread, public MidiClientRaw
 	Q_OBJECT
 public:
 	MidiAlsaRaw();
-	virtual ~MidiAlsaRaw();
+	~MidiAlsaRaw() override;
 
 	static QString probeDevice();
 

--- a/include/MidiAlsaSeq.h
+++ b/include/MidiAlsaSeq.h
@@ -51,7 +51,7 @@ class MidiAlsaSeq : public QThread, public MidiClient
 	Q_OBJECT
 public:
 	MidiAlsaSeq();
-	virtual ~MidiAlsaSeq();
+	~MidiAlsaSeq() override;
 
 	static QString probeDevice();
 
@@ -70,7 +70,7 @@ public:
 
 
 
-	virtual void processOutEvent( const MidiEvent & _me,
+	void processOutEvent( const MidiEvent & _me,
 						const TimePos & _time,
 						const MidiPort * _port ) override;
 
@@ -95,20 +95,20 @@ public:
 	QString sourcePortName( const MidiEvent & ) const override;
 
 	// (un)subscribe given MidiPort to/from destination-port
-	virtual void subscribeReadablePort( MidiPort * _port,
+	void subscribeReadablePort( MidiPort * _port,
 						const QString & _dest,
 						bool _subscribe = true ) override;
-	virtual void subscribeWritablePort( MidiPort * _port,
+	void subscribeWritablePort( MidiPort * _port,
 						const QString & _dest,
 						bool _subscribe = true ) override;
-	virtual void connectRPChanged( QObject * _receiver,
+	void connectRPChanged( QObject * _receiver,
 							const char * _member ) override
 	{
 		connect( this, SIGNAL( readablePortsChanged() ),
 							_receiver, _member );
 	}
 
-	virtual void connectWPChanged( QObject * _receiver,
+	void connectWPChanged( QObject * _receiver,
 							const char * _member ) override
 	{
 		connect( this, SIGNAL( writablePortsChanged() ),

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -125,7 +125,7 @@ class MidiClientRaw : public MidiClient
 {
 public:
 	MidiClientRaw();
-	virtual ~MidiClientRaw();
+	~MidiClientRaw() override;
 
 	// we are raw-clients for sure!
 	bool isRaw() const override

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -55,7 +55,7 @@ public:
 
 	MidiClip( InstrumentTrack* instrumentTrack );
 	MidiClip( const MidiClip& other );
-	virtual ~MidiClip();
+	~MidiClip() override;
 
 	void init();
 

--- a/include/MidiClipView.h
+++ b/include/MidiClipView.h
@@ -43,7 +43,7 @@ class MidiClipView : public ClipView
 
 public:
 	MidiClipView( MidiClip* clip, TrackView* parent );
- 	virtual ~MidiClipView() = default;
+ 	~MidiClipView() override = default;
 
 	Q_PROPERTY(QColor noteFillColor READ getNoteFillColor WRITE setNoteFillColor)
 	Q_PROPERTY(QColor noteBorderColor READ getNoteBorderColor WRITE setNoteBorderColor)

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -49,12 +49,12 @@ class MidiController : public Controller, public MidiEventProcessor
 	Q_OBJECT
 public:
 	MidiController( Model * _parent );
-	virtual ~MidiController();
+	~MidiController() override;
 
-	virtual void processInEvent( const MidiEvent & _me,
+	void processInEvent( const MidiEvent & _me,
 					const TimePos & _time, f_cnt_t offset = 0 ) override;
 
-	virtual void processOutEvent( const MidiEvent& _me,
+	void processOutEvent( const MidiEvent& _me,
 					const TimePos & _time, f_cnt_t offset = 0 ) override
 	{
 		// No output yet

--- a/include/MidiDummy.h
+++ b/include/MidiDummy.h
@@ -38,7 +38,7 @@ public:
 	MidiDummy()
 	{
 	}
-	virtual ~MidiDummy()
+	~MidiDummy() override
 	{
 	}
 

--- a/include/MidiJack.h
+++ b/include/MidiJack.h
@@ -53,7 +53,7 @@ class MidiJack : public QThread, public MidiClientRaw
         Q_OBJECT
 public:
 	MidiJack();
-	virtual ~MidiJack();
+	~MidiJack() override;
 
 	jack_client_t* jackClient();
 
@@ -76,8 +76,8 @@ public:
 
 
 protected:
-	virtual void sendByte( const unsigned char c );
-	virtual void run();
+	void sendByte( const unsigned char c ) override;
+	void run() override;
 
 
 private:

--- a/include/MidiOss.h
+++ b/include/MidiOss.h
@@ -44,7 +44,7 @@ class MidiOss : public QThread, public MidiClientRaw
 	Q_OBJECT
 public:
 	MidiOss();
-	virtual ~MidiOss();
+	~MidiOss() override;
 
 	static QString probeDevice();
 

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -83,7 +83,7 @@ public:
 			MidiEventProcessor* eventProcessor,
 			Model* parent = nullptr,
 			Mode mode = Disabled );
-	virtual ~MidiPort();
+	~MidiPort() override;
 
 	void setName( const QString& name );
 

--- a/include/MidiPortMenu.h
+++ b/include/MidiPortMenu.h
@@ -41,7 +41,7 @@ class MidiPortMenu : public QMenu, public ModelView
 	Q_OBJECT
 public:
 	MidiPortMenu( MidiPort::Modes _mode );
-	virtual ~MidiPortMenu();
+	~MidiPortMenu() override;
 
 
 public slots:

--- a/include/MidiSndio.h
+++ b/include/MidiSndio.h
@@ -46,7 +46,7 @@ class MidiSndio : public QThread, public MidiClientRaw
 	Q_OBJECT
 public:
 	MidiSndio( void );
-	virtual ~MidiSndio();
+	~MidiSndio() override;
 
 	static QString probeDevice(void);
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -102,7 +102,7 @@ class MixerRoute : public QObject
 	Q_OBJECT
 	public:		
 		MixerRoute( MixerChannel * from, MixerChannel * to, float amount );
-		virtual ~MixerRoute();
+		~MixerRoute() override;
 		
 	mix_ch_t senderIndex() const
 	{
@@ -143,7 +143,7 @@ class LMMS_EXPORT Mixer : public Model, public JournallingObject
 	Q_OBJECT
 public:
 	Mixer();
-	virtual ~Mixer();
+	~Mixer() override;
 
 	void mixToChannel( const sampleFrame * _buf, mix_ch_t _ch );
 

--- a/include/MixerLine.h
+++ b/include/MixerLine.h
@@ -50,7 +50,7 @@ public:
 	Q_PROPERTY( QColor strokeInnerActive READ strokeInnerActive WRITE setStrokeInnerActive )
 	Q_PROPERTY( QColor strokeInnerInactive READ strokeInnerInactive WRITE setStrokeInnerInactive )
 	MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex);
-	~MixerLine();
+	~MixerLine() override;
 
 	void paintEvent( QPaintEvent * ) override;
 	void mousePressEvent( QMouseEvent * ) override;

--- a/include/MixerLineLcdSpinBox.h
+++ b/include/MixerLineLcdSpinBox.h
@@ -41,7 +41,7 @@ public:
 	MixerLineLcdSpinBox(int numDigits, QWidget * parent, const QString& name, TrackView * tv = nullptr) :
 		LcdSpinBox(numDigits, parent, name), m_tv(tv)
 	{}
-	virtual ~MixerLineLcdSpinBox() {}
+	~MixerLineLcdSpinBox() override {}
 
 	void setTrackView(TrackView * tv);
 

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -66,7 +66,7 @@ public:
 
 
 	MixerView();
-	virtual ~MixerView();
+	~MixerView() override;
 
 	void keyPressEvent(QKeyEvent * e) override;
 

--- a/include/Model.h
+++ b/include/Model.h
@@ -45,7 +45,7 @@ public:
 	{
 	}
 
-	virtual ~Model()
+	~Model() override
 	{
 	}
 

--- a/include/NStateButton.h
+++ b/include/NStateButton.h
@@ -41,7 +41,7 @@ class NStateButton : public ToolButton
 	Q_OBJECT
 public:
 	NStateButton( QWidget * _parent );
-	virtual ~NStateButton();
+	~NStateButton() override;
 	void addState( const QPixmap & _pixmap, const QString & _tooltip = "" );
 
 	inline void setGeneralToolTip( const QString & _tooltip )

--- a/include/Note.h
+++ b/include/Note.h
@@ -98,7 +98,7 @@ public:
 		panning_t panning = DefaultPanning,
 		DetuningHelper * detuning = nullptr );
 	Note( const Note & note );
-	virtual ~Note();
+	~Note() override;
 
 	// used by GUI
 	inline void setSelected( const bool selected ) { m_selected = selected; }

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -74,7 +74,7 @@ public:
 					NotePlayHandle* parent = nullptr,
 					int midiEventChannel = -1,
 					Origin origin = OriginMidiClip );
-	virtual ~NotePlayHandle();
+	~NotePlayHandle() override;
 
 	void * operator new ( size_t size, void * p )
 	{

--- a/include/Oscilloscope.h
+++ b/include/Oscilloscope.h
@@ -43,7 +43,7 @@ public:
 	Q_PROPERTY( QColor clippingColor READ clippingColor WRITE setClippingColor )
 
 	Oscilloscope( QWidget * _parent );
-	virtual ~Oscilloscope();
+	~Oscilloscope() override;
 
 	void setActive( bool _active );
 

--- a/include/PatternClip.h
+++ b/include/PatternClip.h
@@ -39,7 +39,7 @@ class PatternClip : public Clip
 {
 public:
 	PatternClip(Track* track);
-	virtual ~PatternClip() = default;
+	~PatternClip() override = default;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/include/PatternClipView.h
+++ b/include/PatternClipView.h
@@ -44,7 +44,7 @@ class PatternClipView : public ClipView
 	Q_OBJECT
 public:
 	PatternClipView(Clip* clip, TrackView* tv);
-	virtual ~PatternClipView() = default;
+	~PatternClipView() override = default;
 
 
 public slots:

--- a/include/PatternStore.h
+++ b/include/PatternStore.h
@@ -68,7 +68,7 @@ class LMMS_EXPORT PatternStore : public TrackContainer
 	mapPropertyFromModel(int, currentPattern, setCurrentPattern, m_patternComboBoxModel);
 public:
 	PatternStore();
-	virtual ~PatternStore();
+	~PatternStore() override;
 
 	virtual bool play(TimePos start, const fpp_t frames, const f_cnt_t frameBase, int clipNum = -1);
 

--- a/include/PatternTrack.h
+++ b/include/PatternTrack.h
@@ -51,15 +51,15 @@ class LMMS_EXPORT PatternTrack : public Track
 	Q_OBJECT
 public:
 	PatternTrack(TrackContainer* tc);
-	virtual ~PatternTrack();
+	~PatternTrack() override;
 
-	virtual bool play( const TimePos & _start, const fpp_t _frames,
+	bool play( const TimePos & _start, const fpp_t _frames,
 
 						const f_cnt_t _frame_base, int _clip_num = -1 ) override;
 	gui::TrackView * createView( gui::TrackContainerView* tcv ) override;
 	Clip* createClip(const TimePos & pos) override;
 
-	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
+	void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent ) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 

--- a/include/PatternTrackView.h
+++ b/include/PatternTrackView.h
@@ -45,7 +45,7 @@ class PatternTrackView : public TrackView
 	Q_OBJECT
 public:
 	PatternTrackView(PatternTrack* pt, TrackContainerView* tcv);
-	virtual ~PatternTrackView();
+	~PatternTrackView() override;
 
 	bool close() override;
 

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -47,7 +47,7 @@ public:
 		PeakControllerEffect *_peak_effect = nullptr );
 
 
-	virtual ~PeakController();
+	~PeakController() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
 	void loadSettings( const QDomElement & _this ) override;
@@ -92,7 +92,7 @@ class PeakControllerDialog : public ControllerDialog
 	Q_OBJECT
 public:
 	PeakControllerDialog( Controller * _controller, QWidget * _parent );
-	virtual ~PeakControllerDialog();
+	~PeakControllerDialog() override;
 
 protected:
 	void contextMenuEvent( QContextMenuEvent * _me ) override;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -298,7 +298,7 @@ private:
 
 	PianoRoll();
 	PianoRoll( const PianoRoll & );
-	virtual ~PianoRoll();
+	~PianoRoll() override;
 
 	void autoScroll(const TimePos & t );
 

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -44,7 +44,7 @@ class PianoView : public QWidget, public ModelView
 	Q_OBJECT
 public:
 	PianoView( QWidget * _parent );
-	virtual ~PianoView() = default;
+	~PianoView() override = default;
 
 	static int getKeyFromKeyEvent( QKeyEvent * _ke );
 

--- a/include/PixmapButton.h
+++ b/include/PixmapButton.h
@@ -40,7 +40,7 @@ class LMMS_EXPORT PixmapButton : public AutomatableButton
 public:
 	PixmapButton( QWidget * _parent,
 					const QString & _name = QString() );
-	virtual ~PixmapButton();
+	~PixmapButton() override;
 
 	void setActiveGraphic( const QPixmap & _pm );
 	void setInactiveGraphic( const QPixmap & _pm, bool _update = true );

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -244,7 +244,7 @@ public:
 	//!   See the key() function
 	Plugin(const Descriptor * descriptor, Model * parent,
 		const Descriptor::SubPluginFeatures::Key *key = nullptr);
-	virtual ~Plugin();
+	~Plugin() override;
 
 	//! Return display-name out of sub plugin or descriptor
 	QString displayName() const override;

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -41,7 +41,7 @@ class PluginBrowser : public SideBarWidget
 	Q_OBJECT
 public:
 	PluginBrowser( QWidget * _parent );
-	virtual ~PluginBrowser() = default;
+	~PluginBrowser() override = default;
 
 private slots:
 	void onFilterChanged( const QString & filter );

--- a/include/PresetPreviewPlayHandle.h
+++ b/include/PresetPreviewPlayHandle.h
@@ -40,7 +40,7 @@ class LMMS_EXPORT PresetPreviewPlayHandle : public PlayHandle
 {
 public:
 	PresetPreviewPlayHandle( const QString& presetFile, bool loadByPlugin = false, DataFile *dataFile = 0 );
-	virtual ~PresetPreviewPlayHandle();
+	~PresetPreviewPlayHandle() override;
 
 	inline bool affinityMatters() const override
 	{

--- a/include/ProjectNotes.h
+++ b/include/ProjectNotes.h
@@ -44,7 +44,7 @@ class LMMS_EXPORT ProjectNotes : public QMainWindow, public SerializingObject
 	Q_OBJECT
 public:
 	ProjectNotes();
-	virtual ~ProjectNotes();
+	~ProjectNotes() override;
 
 	void clear();
 	void setText( const QString & _text );

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -64,7 +64,7 @@ public:
 				const OutputSettings & _os,
 				ExportFileFormats _file_format,
 				const QString & _out_file );
-	virtual ~ProjectRenderer();
+	~ProjectRenderer() override;
 
 	bool isReady() const
 	{

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -39,7 +39,7 @@ class ProcessWatcher : public QThread
 	Q_OBJECT
 public:
 	ProcessWatcher( RemotePlugin * );
-	virtual ~ProcessWatcher() = default;
+	~ProcessWatcher() override = default;
 
 	void stop()
 	{
@@ -66,7 +66,7 @@ class LMMS_EXPORT RemotePlugin : public QObject, public RemotePluginBase
 	Q_OBJECT
 public:
 	RemotePlugin();
-	virtual ~RemotePlugin();
+	~RemotePlugin() override;
 
 	inline bool isRunning()
 	{

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -51,11 +51,11 @@ public:
 #else
 	RemotePluginClient( const char * socketPath );
 #endif
-	virtual ~RemotePluginClient();
+	~RemotePluginClient() override;
 
 	const VstSyncData* getVstSyncData();
 
-	virtual bool processMessage( const message & _m );
+	bool processMessage( const message & _m ) override;
 
 	virtual void process( const sampleFrame * _in_buf,
 					sampleFrame * _out_buf ) = 0;

--- a/include/RenameDialog.h
+++ b/include/RenameDialog.h
@@ -40,7 +40,7 @@ class RenameDialog : public QDialog
 	Q_OBJECT
 public:
 	RenameDialog( QString & _string );
-	~RenameDialog();
+	~RenameDialog() override;
 
 
 protected:

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -46,7 +46,7 @@ public:
 		ProjectRenderer::ExportFileFormats fmt,
 		QString outputPath);
 
-	virtual ~RenderManager();
+	~RenderManager() override;
 
 	/// Export all unmuted tracks into a single file
 	void renderProject();

--- a/include/RingBuffer.h
+++ b/include/RingBuffer.h
@@ -53,7 +53,7 @@ public:
  * 	\param size The size of the buffer in milliseconds. The actual size will be size + period size
  */
 	RingBuffer( float size );
-	virtual ~RingBuffer();
+	~RingBuffer() override;
 
 
 

--- a/include/RowTableView.h
+++ b/include/RowTableView.h
@@ -39,7 +39,7 @@ class RowTableView : public QTableView
 	Q_OBJECT
 public:
 	RowTableView( QWidget * parent = 0 );
-	virtual ~RowTableView();
+	~RowTableView() override;
 
 	void setModel( QAbstractItemModel * model ) override;
 

--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -44,7 +44,7 @@ public:
 	{
 	}
 
-	virtual ~selectableObject()
+	~selectableObject() override
 	{
 	}
 
@@ -80,7 +80,7 @@ class RubberBand : public QRubberBand
 {
 public:
 	RubberBand( QWidget * _parent );
-	virtual ~RubberBand();
+	~RubberBand() override;
 
 	QVector<selectableObject *> selectedObjects() const;
 	QVector<selectableObject *> selectableObjects() const;

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -119,7 +119,7 @@ public:
 	friend void swap(SampleBuffer & first, SampleBuffer & second) noexcept;
 	SampleBuffer& operator= (const SampleBuffer that);
 
-	virtual ~SampleBuffer();
+	~SampleBuffer() override;
 
 	bool play(
 		sampleFrame * ab,

--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -47,7 +47,7 @@ class SampleClip : public Clip
 public:
 	SampleClip( Track * _track );
 	SampleClip( const SampleClip& orig );
-	virtual ~SampleClip();
+	~SampleClip() override;
 
 	SampleClip& operator=( const SampleClip& that ) = delete;
 

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -44,7 +44,7 @@ class SampleClipView : public ClipView
 
 public:
 	SampleClipView( SampleClip * _clip, TrackView * _tv );
-	virtual ~SampleClipView() = default;
+	~SampleClipView() override = default;
 
 public slots:
 	void updateSample();

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -46,7 +46,7 @@ public:
 	SamplePlayHandle( SampleBuffer* sampleBuffer , bool ownAudioPort = true );
 	SamplePlayHandle( const QString& sampleFile );
 	SamplePlayHandle( SampleClip* clip );
-	virtual ~SamplePlayHandle();
+	~SamplePlayHandle() override;
 
 	inline bool affinityMatters() const override
 	{

--- a/include/SampleRecordHandle.h
+++ b/include/SampleRecordHandle.h
@@ -46,7 +46,7 @@ class SampleRecordHandle : public PlayHandle
 {
 public:
 	SampleRecordHandle( SampleClip* clip );
-	virtual ~SampleRecordHandle();
+	~SampleRecordHandle() override;
 
 	void play( sampleFrame * _working_buffer ) override;
 	bool isFinished() const override;

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -47,15 +47,15 @@ class SampleTrack : public Track
 	Q_OBJECT
 public:
 	SampleTrack( TrackContainer* tc );
-	virtual ~SampleTrack();
+	~SampleTrack() override;
 
-	virtual bool play( const TimePos & _start, const fpp_t _frames,
+	bool play( const TimePos & _start, const fpp_t _frames,
 						const f_cnt_t _frame_base, int _clip_num = -1 ) override;
 	gui::TrackView * createView( gui::TrackContainerView* tcv ) override;
 	Clip* createClip(const TimePos & pos) override;
 
 
-	virtual void saveTrackSpecificSettings( QDomDocument & _doc,
+	void saveTrackSpecificSettings( QDomDocument & _doc,
 							QDomElement & _parent ) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 

--- a/include/SampleTrackView.h
+++ b/include/SampleTrackView.h
@@ -47,7 +47,7 @@ class SampleTrackView : public TrackView
 	Q_OBJECT
 public:
 	SampleTrackView( SampleTrack* Track, TrackContainerView* tcv );
-	virtual ~SampleTrackView();
+	~SampleTrackView() override;
 
 	SampleTrackWindow * getSampleTrackWindow()
 	{

--- a/include/SampleTrackWindow.h
+++ b/include/SampleTrackWindow.h
@@ -50,7 +50,7 @@ class SampleTrackWindow : public QWidget, public ModelView, public SerializingOb
 	Q_OBJECT
 public:
 	SampleTrackWindow(SampleTrackView * tv);
-	virtual ~SampleTrackWindow();
+	~SampleTrackWindow() override;
 
 	SampleTrack * model()
 	{

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -64,7 +64,7 @@ public:
 	};
 
 	SetupDialog(ConfigTabs tab_to_open = GeneralSettings);
-	virtual ~SetupDialog();
+	~SetupDialog() override;
 
 
 protected slots:

--- a/include/SideBar.h
+++ b/include/SideBar.h
@@ -42,7 +42,7 @@ class SideBar : public QToolBar
 	Q_OBJECT
 public:
 	SideBar( Qt::Orientation _orientation, QWidget * _parent );
-	virtual ~SideBar();
+	~SideBar() override;
 
 	void appendTab( SideBarWidget * _sbw );
 

--- a/include/SideBarWidget.h
+++ b/include/SideBarWidget.h
@@ -41,7 +41,7 @@ class SideBarWidget : public QWidget
 public:
 	SideBarWidget( const QString & _title, const QPixmap & _icon,
 							QWidget * _parent );
-	virtual ~SideBarWidget();
+	~SideBarWidget() override;
 
 	inline const QPixmap & icon() const
 	{

--- a/include/Song.h
+++ b/include/Song.h
@@ -406,7 +406,7 @@ private slots:
 private:
 	Song();
 	Song( const Song & );
-	virtual ~Song();
+	~Song() override;
 
 
 	inline bar_t currentBar() const

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -66,7 +66,7 @@ public:
 	};
 
 	SongEditor( Song * song );
-	~SongEditor();
+	~SongEditor() override;
 
 	void saveSettings( QDomDocument& doc, QDomElement& element ) override;
 	void loadSettings( const QDomElement& element ) override;

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -44,7 +44,7 @@ class LMMS_EXPORT StringPairDrag : public QDrag
 public:
 	StringPairDrag( const QString & _key, const QString & _value,
 					const QPixmap & _icon, QWidget * _w );
-	~StringPairDrag();
+	~StringPairDrag() override;
 
 	static bool processDragEnterEvent( QDragEnterEvent * _dee,
 						const QString & _allowed_keys );

--- a/include/TabBar.h
+++ b/include/TabBar.h
@@ -46,7 +46,7 @@ class LMMS_EXPORT TabBar : public QWidget
 public:
 	TabBar( QWidget * _parent,
 			QBoxLayout::Direction _dir = QBoxLayout::LeftToRight );
-	virtual ~TabBar() = default;
+	~TabBar() override = default;
 
 	TabButton * addTab( QWidget * _w, const QString & _text,
 					int _id, bool _add_stretch = false,

--- a/include/TabButton.h
+++ b/include/TabButton.h
@@ -45,7 +45,7 @@ public:
 						SLOT( slotClicked() ) );
 	}
 
-	~TabButton()
+	~TabButton() override
 	{
 	}
 

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -43,7 +43,7 @@ public:
 	//!   If false, all child widget will be cut down to the TabWidget's size
 	TabWidget( const QString & _caption, QWidget * _parent,
 				bool usePixmap = false, bool resizable = false );
-	virtual ~TabWidget() = default;
+	~TabWidget() override = default;
 
 	void addTab( QWidget * w, const QString & name, const char *pixmap = nullptr, int idx = -1 );
 

--- a/include/TemplatesMenu.h
+++ b/include/TemplatesMenu.h
@@ -37,7 +37,7 @@ class TemplatesMenu : public QMenu
 	Q_OBJECT
 public:
 	TemplatesMenu(QWidget *parent = nullptr);
-	virtual ~TemplatesMenu() = default;
+	~TemplatesMenu() override = default;
 
 private slots:
 	static void createNewProjectFromTemplate(QAction * _action);

--- a/include/TempoSyncKnob.h
+++ b/include/TempoSyncKnob.h
@@ -42,7 +42,7 @@ class LMMS_EXPORT TempoSyncKnob : public Knob
 	Q_OBJECT
 public:
 	TempoSyncKnob( knobTypes knobNum, QWidget* parent = nullptr, const QString& name = QString() );
-	virtual ~TempoSyncKnob();
+	~TempoSyncKnob() override;
 
 	const QString & syncDescription();
 	void setSyncDescription( const QString & _new_description );

--- a/include/TextFloat.h
+++ b/include/TextFloat.h
@@ -39,7 +39,7 @@ class LMMS_EXPORT TextFloat : public QWidget
 	Q_OBJECT
 public:
 	TextFloat();
-	virtual ~TextFloat()
+	~TextFloat() override
 	{
 	}
 

--- a/include/TimeDisplayWidget.h
+++ b/include/TimeDisplayWidget.h
@@ -39,7 +39,7 @@ class TimeDisplayWidget : public QWidget
 	Q_OBJECT
 public:
 	TimeDisplayWidget();
-	virtual ~TimeDisplayWidget() = default;
+	~TimeDisplayWidget() override = default;
 
 
 protected:

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -78,7 +78,7 @@ public:
 
 	TimeLineWidget(int xoff, int yoff, float ppb, Song::PlayPos & pos,
 				const TimePos & begin, Song::PlayModes mode, QWidget * parent);
-	virtual ~TimeLineWidget();
+	~TimeLineWidget() override;
 
 	inline QColor const & getBarLineColor() const { return m_barLineColor; }
 	inline void setBarLineColor(QColor const & barLineColor) { m_barLineColor = barLineColor; }

--- a/include/ToolButton.h
+++ b/include/ToolButton.h
@@ -43,7 +43,7 @@ public:
 		QToolButton(_parent)
 	{ }
 
-	virtual ~ToolButton() = default;
+	~ToolButton() override = default;
 
 } ;
 

--- a/include/ToolPlugin.h
+++ b/include/ToolPlugin.h
@@ -38,7 +38,7 @@ class LMMS_EXPORT ToolPlugin : public Plugin
 {
 public:
 	ToolPlugin( const Descriptor * _descriptor, Model * _parent );
-	virtual ~ToolPlugin();
+	~ToolPlugin() override;
 
 	// instantiate tool-plugin with given name or return NULL
 	// on failure

--- a/include/Track.h
+++ b/include/Track.h
@@ -85,7 +85,7 @@ public:
 	} ;
 
 	Track( TrackTypes type, TrackContainer * tc );
-	virtual ~Track();
+	~Track() override;
 
 	static Track * create( TrackTypes tt, TrackContainer * tc );
 	static Track * create( const QDomElement & element,

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -57,7 +57,7 @@ public:
 	} ;
 
 	TrackContainer();
-	virtual ~TrackContainer();
+	~TrackContainer() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -73,7 +73,7 @@ class TrackContainerView : public QWidget, public ModelView,
 	Q_OBJECT
 public:
 	TrackContainerView( TrackContainer* tc );
-	virtual ~TrackContainerView();
+	~TrackContainerView() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
 	void loadSettings( const QDomElement & _this ) override;
@@ -184,7 +184,7 @@ private:
 	{
 	public:
 		scrollArea( TrackContainerView* parent );
-		virtual ~scrollArea();
+		~scrollArea() override;
 
 	protected:
 		void wheelEvent( QWheelEvent * _we ) override;

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -56,7 +56,7 @@ class TrackContentWidget : public QWidget, public JournallingObject
 
 public:
 	TrackContentWidget( TrackView * parent );
-	virtual ~TrackContentWidget();
+	~TrackContentWidget() override;
 
 	/*! \brief Updates the background tile pixmap. */
 	void updateBackground();

--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -41,7 +41,7 @@ class TrackLabelButton : public QToolButton
 	Q_OBJECT
 public:
 	TrackLabelButton( TrackView * _tv, QWidget * _parent );
-	virtual ~TrackLabelButton();
+	~TrackLabelButton() override;
 
 
 public slots:

--- a/include/TrackOperationsWidget.h
+++ b/include/TrackOperationsWidget.h
@@ -40,7 +40,7 @@ class TrackOperationsWidget : public QWidget
 	Q_OBJECT
 public:
 	TrackOperationsWidget( TrackView * parent );
-	~TrackOperationsWidget();
+	~TrackOperationsWidget() override;
 
 
 protected:

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -64,7 +64,7 @@ class TrackView : public QWidget, public ModelView, public JournallingObject
 	Q_OBJECT
 public:
 	TrackView( Track * _track, TrackContainerView* tcv );
-	virtual ~TrackView();
+	~TrackView() override;
 
 	inline const Track * getTrack() const
 	{

--- a/include/VstSyncController.h
+++ b/include/VstSyncController.h
@@ -40,7 +40,7 @@ class VstSyncController : public QObject
 	Q_OBJECT
 public:
 	VstSyncController();
-	~VstSyncController();
+	~VstSyncController() override;
 
 	void setAbsolutePosition( double ticks );
 

--- a/include/embed.h
+++ b/include/embed.h
@@ -120,7 +120,7 @@ public:
 	{
 	}
 
-	virtual QPixmap pixmap() const
+	QPixmap pixmap() const override
 	{
 		if( !m_name.isEmpty() )
 		{
@@ -130,7 +130,7 @@ public:
 		return( QPixmap() );
 	}
 
-	virtual QString pixmapName() const
+	QString pixmapName() const override
 	{
 		return QString( STRINGIFY(PLUGIN_NAME) ) + "::" + m_name;
 	}

--- a/plugins/Amplifier/Amplifier.h
+++ b/plugins/Amplifier/Amplifier.h
@@ -37,10 +37,10 @@ class AmplifierEffect : public Effect
 {
 public:
 	AmplifierEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~AmplifierEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~AmplifierEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_ampControls;
 	}

--- a/plugins/Amplifier/AmplifierControlDialog.h
+++ b/plugins/Amplifier/AmplifierControlDialog.h
@@ -42,7 +42,7 @@ class AmplifierControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	AmplifierControlDialog( AmplifierControls* controls );
-	virtual ~AmplifierControlDialog()
+	~AmplifierControlDialog() override
 	{
 	}
 

--- a/plugins/Amplifier/AmplifierControls.h
+++ b/plugins/Amplifier/AmplifierControls.h
@@ -45,23 +45,23 @@ class AmplifierControls : public EffectControls
 	Q_OBJECT
 public:
 	AmplifierControls( AmplifierEffect* effect );
-	virtual ~AmplifierControls()
+	~AmplifierControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "AmplifierControls";
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 4;
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::AmplifierControlDialog( this );
 	}

--- a/plugins/BassBooster/BassBooster.h
+++ b/plugins/BassBooster/BassBooster.h
@@ -37,10 +37,10 @@ class BassBoosterEffect : public Effect
 {
 public:
 	BassBoosterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~BassBoosterEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~BassBoosterEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_bbControls;
 	}

--- a/plugins/BassBooster/BassBoosterControlDialog.h
+++ b/plugins/BassBooster/BassBoosterControlDialog.h
@@ -40,7 +40,7 @@ class BassBoosterControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	BassBoosterControlDialog( BassBoosterControls* controls );
-	virtual ~BassBoosterControlDialog()
+	~BassBoosterControlDialog() override
 	{
 	}
 

--- a/plugins/BassBooster/BassBoosterControls.h
+++ b/plugins/BassBooster/BassBoosterControls.h
@@ -39,23 +39,23 @@ class BassBoosterControls : public EffectControls
 	Q_OBJECT
 public:
 	BassBoosterControls( BassBoosterEffect* effect );
-	virtual ~BassBoosterControls()
+	~BassBoosterControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "bassboostercontrols";
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 3;
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::BassBoosterControlDialog( this );
 	}

--- a/plugins/BitInvader/BitInvader.h
+++ b/plugins/BitInvader/BitInvader.h
@@ -74,25 +74,25 @@ class BitInvader : public Instrument
 	Q_OBJECT
 public:
 	BitInvader(InstrumentTrack * _instrument_track );
-	virtual ~BitInvader();
+	~BitInvader() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc,
-							QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc,
+							QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 64 );
 	}
 
-	virtual gui::PluginView * instantiateView( QWidget * _parent );
+	gui::PluginView * instantiateView( QWidget * _parent ) override;
 
 protected slots:
 	void lengthChanged();
@@ -124,7 +124,7 @@ public:
 	BitInvaderView( Instrument * _instrument,
 					QWidget * _parent );
 
-	virtual ~BitInvaderView() {};
+	~BitInvaderView() override {};
 
 protected slots:
 	//void sampleSizeChanged( float _new_sample_length );
@@ -142,7 +142,7 @@ protected slots:
 	void smoothClicked( void  );
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	Knob * m_sampleLengthKnob;
 	PixmapButton * m_sinWaveBtn;

--- a/plugins/Bitcrush/Bitcrush.h
+++ b/plugins/Bitcrush/Bitcrush.h
@@ -40,10 +40,10 @@ class BitcrushEffect : public Effect
 {
 public:
 	BitcrushEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~BitcrushEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~BitcrushEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_controls;
 	}

--- a/plugins/Bitcrush/BitcrushControlDialog.h
+++ b/plugins/Bitcrush/BitcrushControlDialog.h
@@ -43,7 +43,7 @@ class BitcrushControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	BitcrushControlDialog( BitcrushControls * controls );
-	virtual ~BitcrushControlDialog()
+	~BitcrushControlDialog() override
 	{
 	}
 };

--- a/plugins/Bitcrush/BitcrushControls.h
+++ b/plugins/Bitcrush/BitcrushControls.h
@@ -40,21 +40,21 @@ class BitcrushControls : public EffectControls
 	Q_OBJECT
 public:
 	BitcrushControls( BitcrushEffect * eff );
-	virtual ~BitcrushControls();
+	~BitcrushControls() override;
 
-	virtual void saveSettings( QDomDocument & doc, QDomElement & elem );
-	virtual void loadSettings( const QDomElement & elem );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & doc, QDomElement & elem ) override;
+	void loadSettings( const QDomElement & elem ) override;
+	inline QString nodeName() const override
 	{
 		return( "bitcrushcontrols" );
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 9 );
 	}
 
-	virtual gui::EffectControlDialog * createView()
+	gui::EffectControlDialog * createView() override
 	{
 		return( new gui::BitcrushControlDialog( this ) );
 	}

--- a/plugins/CarlaBase/Carla.h
+++ b/plugins/CarlaBase/Carla.h
@@ -93,7 +93,7 @@ public:
 		return !reg.exactMatch(name);
 	}
 
-	inline virtual void loadSettings(const QDomElement& element, const QString& name = QString("value")) override
+	inline void loadSettings(const QDomElement& element, const QString& name = QString("value")) override
 	{
 		AutomatableModel::loadSettings(element, name);
 		bool mustQuote = mustQuoteName(name);
@@ -104,7 +104,7 @@ public:
 		}
 	}
 
-	inline virtual void saveSettings(QDomDocument& doc, QDomElement& element,
+	inline void saveSettings(QDomDocument& doc, QDomElement& element,
 		const QString& name = QString( "value" )) override
 	{
 		if (m_isEnabled)
@@ -177,7 +177,7 @@ public:
     static const uint32_t kMaxMidiEvents = 512;
 
     CarlaInstrument(InstrumentTrack* const instrumentTrack, const Descriptor* const descriptor, const bool isPatchbay);
-    virtual ~CarlaInstrument();
+    ~CarlaInstrument() override;
 
     // Carla NativeHostDescriptor functions
     uint32_t handleGetBufferSize() const;
@@ -189,13 +189,13 @@ public:
     intptr_t handleDispatcher(const NativeHostDispatcherOpcode opcode, const int32_t index, const intptr_t value, void* const ptr, const float opt);
 
     // LMMS functions
-    virtual Flags flags() const;
-    virtual QString nodeName() const;
-    virtual void saveSettings(QDomDocument& doc, QDomElement& parent);
-    virtual void loadSettings(const QDomElement& elem);
-    virtual void play(sampleFrame* workingBuffer);
-    virtual bool handleMidiEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset);
-    virtual gui::PluginView* instantiateView(QWidget* parent);
+    Flags flags() const override;
+    QString nodeName() const override;
+    void saveSettings(QDomDocument& doc, QDomElement& parent) override;
+    void loadSettings(const QDomElement& elem) override;
+    void play(sampleFrame* workingBuffer) override;
+    bool handleMidiEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset) override;
+    gui::PluginView* instantiateView(QWidget* parent) override;
 
 signals:
     void uiClosed();
@@ -255,7 +255,7 @@ public:
 		setWindowFlags(windowFlags);
 	}
 
-	virtual void resizeEvent(QResizeEvent * event) override
+	void resizeEvent(QResizeEvent * event) override
 	{
 		if (mousePress) {
 			resizing = true;
@@ -263,13 +263,13 @@ public:
 		SubWindow::resizeEvent(event);
 	}
 
-	virtual void mousePressEvent(QMouseEvent * event) override
+	void mousePressEvent(QMouseEvent * event) override
 	{
 		mousePress = true;
 		SubWindow::mousePressEvent(event);
 	}
 
-	virtual void mouseReleaseEvent(QMouseEvent * event) override
+	void mouseReleaseEvent(QMouseEvent * event) override
 	{
 		if (resizing) {
 			resizing = false;
@@ -279,7 +279,7 @@ public:
 		SubWindow::mouseReleaseEvent(event);
 	}
 
-	virtual void closeEvent(QCloseEvent * event) override
+	void closeEvent(QCloseEvent * event) override
 	{
 		emit uiClosed();
 		event->accept();
@@ -298,7 +298,7 @@ class CarlaInstrumentView : public InstrumentViewFixedSize
 
 public:
     CarlaInstrumentView(CarlaInstrument* const instrument, QWidget* const parent);
-    virtual ~CarlaInstrumentView();
+    ~CarlaInstrumentView() override;
 
 private slots:
     void toggleUI(bool);
@@ -307,8 +307,8 @@ private slots:
     void paramsUiClosed();
 
 private:
-    virtual void modelChanged();
-    virtual void timerEvent(QTimerEvent*);
+    void modelChanged() override;
+    void timerEvent(QTimerEvent*) override;
 
     NativePluginHandle fHandle;
     const NativePluginDescriptor* fDescriptor;
@@ -333,7 +333,7 @@ class CarlaParamsView : public InstrumentView
 	Q_OBJECT
 public:
 	CarlaParamsView(CarlaInstrumentView* const instrumentView, QWidget* const parent);
-	virtual ~CarlaParamsView();
+	~CarlaParamsView() override;
 
 signals:
 	void uiClosed();

--- a/plugins/CrossoverEQ/CrossoverEQ.h
+++ b/plugins/CrossoverEQ/CrossoverEQ.h
@@ -39,10 +39,10 @@ class CrossoverEQEffect : public Effect
 {
 public:
 	CrossoverEQEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~CrossoverEQEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~CrossoverEQEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_controls;
 	}

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.h
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.h
@@ -45,7 +45,7 @@ class CrossoverEQControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	CrossoverEQControlDialog( CrossoverEQControls * controls );
-	virtual ~CrossoverEQControlDialog()
+	~CrossoverEQControlDialog() override
 	{
 	}
 	

--- a/plugins/CrossoverEQ/CrossoverEQControls.h
+++ b/plugins/CrossoverEQ/CrossoverEQControls.h
@@ -40,21 +40,21 @@ class CrossoverEQControls : public EffectControls
 	Q_OBJECT
 public:
 	CrossoverEQControls( CrossoverEQEffect * eff );
-	virtual ~CrossoverEQControls() {}
+	~CrossoverEQControls() override {}
 
-	virtual void saveSettings( QDomDocument & doc, QDomElement & elem );
-	virtual void loadSettings( const QDomElement & elem );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & doc, QDomElement & elem ) override;
+	void loadSettings( const QDomElement & elem ) override;
+	inline QString nodeName() const override
 	{
 		return( "crossoevereqcontrols" );
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 11 );
 	}
 
-	virtual gui::EffectControlDialog * createView()
+	gui::EffectControlDialog * createView() override
 	{
 		return( new gui::CrossoverEQControlDialog( this ) );
 	}

--- a/plugins/Delay/DelayControls.h
+++ b/plugins/Delay/DelayControls.h
@@ -40,19 +40,19 @@ class DelayControls : public EffectControls
 	Q_OBJECT
 public:
 	DelayControls( DelayEffect* effect );
-	virtual ~DelayControls()
+	~DelayControls() override
 	{
 	}
-	virtual void saveSettings( QDomDocument& doc, QDomElement& parent );
-	virtual void loadSettings( const QDomElement& _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument& doc, QDomElement& parent ) override;
+	void loadSettings( const QDomElement& _this ) override;
+	inline QString nodeName() const override
 	{
 		return "Delay";
 	}
-	virtual int controlCount(){
+	int controlCount() override{
 		return 5;
 	}
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::DelayControlsDialog( this );
 	}

--- a/plugins/Delay/DelayControlsDialog.h
+++ b/plugins/Delay/DelayControlsDialog.h
@@ -42,7 +42,7 @@ class DelayControlsDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	DelayControlsDialog( DelayControls* controls );
-	virtual ~DelayControlsDialog()
+	~DelayControlsDialog() override
 	{
 	}
 };
@@ -52,13 +52,13 @@ class XyPad : public QWidget
 	Q_OBJECT
 public:
 	XyPad( QWidget *parent = 0, FloatModel *xModel = 0, FloatModel *yModel = 0 );
-	~XyPad() {}
+	~XyPad() override {}
 
 protected:
-	virtual void paintEvent ( QPaintEvent * event );
-	virtual void mousePressEvent(QMouseEvent * event );
-	virtual void mouseReleaseEvent(QMouseEvent * event);
-	virtual void mouseMoveEvent(QMouseEvent * event);
+	void paintEvent ( QPaintEvent * event ) override;
+	void mousePressEvent(QMouseEvent * event ) override;
+	void mouseReleaseEvent(QMouseEvent * event) override;
+	void mouseMoveEvent(QMouseEvent * event) override;
 
 private:
 	FloatModel *m_xModel;

--- a/plugins/Delay/DelayEffect.h
+++ b/plugins/Delay/DelayEffect.h
@@ -38,9 +38,9 @@ class DelayEffect : public Effect
 {
 public:
 	DelayEffect(Model* parent , const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~DelayEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
-	virtual EffectControls* controls()
+	~DelayEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
+	EffectControls* controls() override
 	{
 		return &m_delayControls;
 	}

--- a/plugins/DualFilter/DualFilter.h
+++ b/plugins/DualFilter/DualFilter.h
@@ -39,10 +39,10 @@ class DualFilterEffect : public Effect
 {
 public:
 	DualFilterEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~DualFilterEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~DualFilterEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_dfControls;
 	}

--- a/plugins/DualFilter/DualFilterControlDialog.h
+++ b/plugins/DualFilter/DualFilterControlDialog.h
@@ -43,7 +43,7 @@ class DualFilterControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	DualFilterControlDialog( DualFilterControls* controls );
-	virtual ~DualFilterControlDialog()
+	~DualFilterControlDialog() override
 	{
 	}
 

--- a/plugins/DualFilter/DualFilterControls.h
+++ b/plugins/DualFilter/DualFilterControls.h
@@ -42,23 +42,23 @@ class DualFilterControls : public EffectControls
 	Q_OBJECT
 public:
 	DualFilterControls( DualFilterEffect* effect );
-	virtual ~DualFilterControls()
+	~DualFilterControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "DualFilterControls";
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 11;
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::DualFilterControlDialog( this );
 	}

--- a/plugins/DynamicsProcessor/DynamicsProcessor.h
+++ b/plugins/DynamicsProcessor/DynamicsProcessor.h
@@ -41,11 +41,11 @@ class DynProcEffect : public Effect
 public:
 	DynProcEffect( Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~DynProcEffect();
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-							const fpp_t _frames );
+	~DynProcEffect() override;
+	bool processAudioBuffer( sampleFrame * _buf,
+							const fpp_t _frames ) override;
 
-	virtual EffectControls * controls()
+	EffectControls * controls() override
 	{
 		return( &m_dpControls );
 	}

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.h
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.h
@@ -43,7 +43,7 @@ class DynProcControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	DynProcControlDialog( DynProcControls * _controls );
-	virtual ~DynProcControlDialog()
+	~DynProcControlDialog() override
 	{
 	}
 

--- a/plugins/DynamicsProcessor/DynamicsProcessorControls.h
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControls.h
@@ -49,25 +49,25 @@ public:
 		NumStereoModes
 	};
 	DynProcControls( DynProcEffect * _eff );
-	virtual ~DynProcControls()
+	~DynProcControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return( "dynamicsprocessor_controls" );
 	}
 
 	virtual void setDefaultShape();
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 6 );
 	}
 
-	virtual gui::EffectControlDialog * createView()
+	gui::EffectControlDialog * createView() override
 	{
 		return( new gui::DynProcControlDialog( this ) );
 	}

--- a/plugins/Eq/EqControls.h
+++ b/plugins/Eq/EqControls.h
@@ -44,25 +44,25 @@ class EqControls : public EffectControls
 	Q_OBJECT
 public:
 	explicit EqControls( EqEffect* effect );
-	virtual ~EqControls()
+	~EqControls() override
 	{
 	}
 
-	virtual void saveSettings ( QDomDocument& doc, QDomElement& parent );
+	void saveSettings ( QDomDocument& doc, QDomElement& parent ) override;
 
-	virtual void loadSettings ( const QDomElement &_this );
+	void loadSettings ( const QDomElement &_this ) override;
 
-	inline virtual QString nodeName() const
+	inline QString nodeName() const override
 	{
 		return "Eq";
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 42;
 	}
 
-	virtual gui::EffectControlDialog* createView();
+	gui::EffectControlDialog* createView() override;
 
 	float m_inPeakL;
 	float m_inPeakR;

--- a/plugins/Eq/EqControlsDialog.h
+++ b/plugins/Eq/EqControlsDialog.h
@@ -47,7 +47,7 @@ class EqControlsDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	EqControlsDialog( EqControls * controls );
-	virtual ~EqControlsDialog()
+	~EqControlsDialog() override
 	{
 	}
 
@@ -57,7 +57,7 @@ private:
 	EqControls * m_controls;
 	EqParameterWidget * m_parameterWidget;
 
-	virtual void mouseDoubleClickEvent(QMouseEvent *event);
+	void mouseDoubleClickEvent(QMouseEvent *event) override;
 
 	EqBand *setBand( int index, BoolModel *active, FloatModel *freq, FloatModel *res, FloatModel *gain, QColor color, QString name, float *peakL, float *peakR, BoolModel *hp12, BoolModel *hp24, BoolModel *hp48, BoolModel *lp12, BoolModel *lp24, BoolModel *lp48 );
 

--- a/plugins/Eq/EqCurve.h
+++ b/plugins/Eq/EqCurve.h
@@ -55,7 +55,7 @@ public:
 	static float gainToYPixel( float gain, int h, float pixelPerUnitHeight );
 	static float yPixelToGain( float y, int h, float pixelPerUnitHeight );
 
-	QRectF boundingRect() const;
+	QRectF boundingRect() const override;
 	QPainterPath getCurvePath();
 	float getPeakCurve( float x );
 	float getHighShelfCurve( float x );
@@ -83,13 +83,13 @@ signals:
 	void positionChanged();
 
 protected:
-	void mousePressEvent( QGraphicsSceneMouseEvent *event );
-	void mouseReleaseEvent( QGraphicsSceneMouseEvent *event );
-	void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget );
-	void wheelEvent( QGraphicsSceneWheelEvent *wevent );
-	void hoverEnterEvent( QGraphicsSceneHoverEvent *hevent );
-	void hoverLeaveEvent( QGraphicsSceneHoverEvent *hevent );
-	QVariant itemChange( GraphicsItemChange change, const QVariant &value );
+	void mousePressEvent( QGraphicsSceneMouseEvent *event ) override;
+	void mouseReleaseEvent( QGraphicsSceneMouseEvent *event ) override;
+	void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget ) override;
+	void wheelEvent( QGraphicsSceneWheelEvent *wevent ) override;
+	void hoverEnterEvent( QGraphicsSceneHoverEvent *hevent ) override;
+	void hoverLeaveEvent( QGraphicsSceneHoverEvent *hevent ) override;
+	QVariant itemChange( GraphicsItemChange change, const QVariant &value ) override;
 
 private:
 	double calculateGain( const double freq, const double a1, const double a2, const double b0, const double b1, const double b2 );
@@ -120,11 +120,11 @@ class EqCurve : public QGraphicsObject
 	Q_OBJECT
 public:
 	EqCurve( QList<EqHandle*> *handle, int x, int y );
-	QRectF boundingRect() const;
+	QRectF boundingRect() const override;
 	void setModelChanged(bool mc);
 
 protected:
-	void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget );
+	void paint( QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget ) override;
 
 private:
 	QList<EqHandle*> *m_handle;

--- a/plugins/Eq/EqEffect.h
+++ b/plugins/Eq/EqEffect.h
@@ -36,9 +36,9 @@ class EqEffect : public Effect
 {
 public:
 	EqEffect( Model * parent , const Descriptor::SubPluginFeatures::Key * key );
-	virtual ~EqEffect();
-	virtual bool processAudioBuffer( sampleFrame * buf, const fpp_t frames );
-	virtual EffectControls * controls()
+	~EqEffect() override;
+	bool processAudioBuffer( sampleFrame * buf, const fpp_t frames ) override;
+	EffectControls * controls() override
 	{
 		return &m_eqControls;
 	}

--- a/plugins/Eq/EqFader.h
+++ b/plugins/Eq/EqFader.h
@@ -72,7 +72,7 @@ public:
 
 
 
-	~EqFader()
+	~EqFader() override
 	{
 	}
 

--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -181,7 +181,7 @@ protected:
 class EqHp12Filter : public EqFilter
 {
 public :
-	virtual void calcCoefficents()
+	void calcCoefficents() override
 	{
 
 		// calc intermediate
@@ -226,7 +226,7 @@ public :
 class EqLp12Filter : public EqFilter
 {
 public :
-	virtual void calcCoefficents()
+	void calcCoefficents() override
 	{
 
 		// calc intermediate
@@ -270,7 +270,7 @@ class EqPeakFilter : public EqFilter
 public:
 
 
-	virtual void calcCoefficents()
+	void calcCoefficents() override
 	{
 		// calc intermediate
 		float w0 = F_2PI * m_freq / m_sampleRate;
@@ -300,7 +300,7 @@ public:
 		setCoeffs( a1, a2, b0, b1, b2 );
 	}
 
-	virtual inline void setParameters( float sampleRate, float freq, float bw, float gain )
+	inline void setParameters( float sampleRate, float freq, float bw, float gain ) override
 	{
 		bool hasChanged = false;
 		if( sampleRate != m_sampleRate )
@@ -334,7 +334,7 @@ public:
 class EqLowShelfFilter : public EqFilter
 {
 public :
-	virtual void calcCoefficents()
+	void calcCoefficents() override
 	{
 
 		// calc intermediate
@@ -373,7 +373,7 @@ public :
 class EqHighShelfFilter : public EqFilter
 {
 public :
-	virtual void calcCoefficents()
+	void calcCoefficents() override
 	{
 
 		// calc intermediate

--- a/plugins/Eq/EqParameterWidget.h
+++ b/plugins/Eq/EqParameterWidget.h
@@ -74,7 +74,7 @@ class EqParameterWidget : public QWidget
 	Q_OBJECT
 public:
 	explicit EqParameterWidget( QWidget *parent = 0, EqControls * controls = 0 );
-	~EqParameterWidget();
+	~EqParameterWidget() override;
 	QList<EqHandle*> *m_handleList;
 
 	const int bandCount()

--- a/plugins/Eq/EqSpectrumView.h
+++ b/plugins/Eq/EqSpectrumView.h
@@ -74,7 +74,7 @@ class EqSpectrumView : public QWidget
 	Q_OBJECT
 public:
 	explicit EqSpectrumView( EqAnalyser *b, QWidget *_parent = 0 );
-	virtual ~EqSpectrumView()
+	~EqSpectrumView() override
 	{
 	}
 
@@ -82,7 +82,7 @@ public:
 	void setColor( const QColor &value );
 
 protected:
-	virtual void paintEvent( QPaintEvent *event );
+	void paintEvent( QPaintEvent *event ) override;
 
 private slots:
 	void periodicalUpdate();

--- a/plugins/Flanger/FlangerControls.h
+++ b/plugins/Flanger/FlangerControls.h
@@ -39,20 +39,20 @@ class FlangerControls : public EffectControls
 	Q_OBJECT
 public:
 	FlangerControls( FlangerEffect* effect );
-	virtual ~FlangerControls()
+	~FlangerControls() override
 	{
 	}
-	virtual void saveSettings ( QDomDocument& doc, QDomElement& parent );
-	virtual void loadSettings ( const QDomElement &_this );
-	inline virtual QString nodeName() const
+	void saveSettings ( QDomDocument& doc, QDomElement& parent ) override;
+	void loadSettings ( const QDomElement &_this ) override;
+	inline QString nodeName() const override
 	{
 		return "Flanger";
 	}
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 7;
 	}
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::FlangerControlsDialog( this );
 	}

--- a/plugins/Flanger/FlangerControlsDialog.h
+++ b/plugins/Flanger/FlangerControlsDialog.h
@@ -42,7 +42,7 @@ class FlangerControlsDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	FlangerControlsDialog( FlangerControls* controls );
-	virtual ~FlangerControlsDialog()
+	~FlangerControlsDialog() override
 	{
 	}
 };

--- a/plugins/Flanger/FlangerEffect.h
+++ b/plugins/Flanger/FlangerEffect.h
@@ -44,9 +44,9 @@ class FlangerEffect : public Effect
 {
 public:
 	FlangerEffect( Model* parent , const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~FlangerEffect();
-	virtual bool processAudioBuffer( sampleFrame *buf, const fpp_t frames );
-	virtual EffectControls* controls()
+	~FlangerEffect() override;
+	bool processAudioBuffer( sampleFrame *buf, const fpp_t frames ) override;
+	EffectControls* controls() override
 	{
 		return &m_flangerControls;
 	}

--- a/plugins/FreeBoy/FreeBoy.h
+++ b/plugins/FreeBoy/FreeBoy.h
@@ -52,21 +52,21 @@ class FreeBoyInstrument : public Instrument
 public:
 
 	FreeBoyInstrument( InstrumentTrack * _instrument_track );
-	virtual ~FreeBoyInstrument();
+	~FreeBoyInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const;
+	f_cnt_t desiredReleaseFrames() const override;
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 /*public slots:
@@ -129,10 +129,10 @@ class FreeBoyInstrumentView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	FreeBoyInstrumentView( Instrument * _instrument, QWidget * _parent );
-	virtual ~FreeBoyInstrumentView();
+	~FreeBoyInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	Knob * m_ch1SweepTimeKnob;
 	PixmapButton * m_ch1SweepDirButton;

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -243,35 +243,35 @@ class GigInstrument : public Instrument
 
 public:
 	GigInstrument( InstrumentTrack * _instrument_track );
-	virtual ~GigInstrument();
+	~GigInstrument() override;
 
-	virtual void play( sampleFrame * _working_buffer );
+	void play( sampleFrame * _working_buffer ) override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual void loadFile( const QString & _file );
+	void loadFile( const QString & _file ) override;
 
-	virtual AutomatableModel * childModel( const QString & _modelName );
+	AutomatableModel * childModel( const QString & _modelName ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return 0;
 	}
 
-	virtual Flags flags() const
+	Flags flags() const override
 	{
 		return IsSingleStreamed|IsNotBendable;
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 	QString getCurrentPatchName();
 
@@ -352,10 +352,10 @@ class GigInstrumentView : public InstrumentViewFixedSize
 public:
 	GigInstrumentView( Instrument * _instrument,
 					QWidget * _parent );
-	virtual ~GigInstrumentView();
+	~GigInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	PixmapButton * m_fileDialogButton;
 	PixmapButton * m_patchDialogButton;

--- a/plugins/GigPlayer/PatchesDialog.cpp
+++ b/plugins/GigPlayer/PatchesDialog.cpp
@@ -42,7 +42,7 @@ public:
 		: QTreeWidgetItem( pListView, pItemAfter ) {}
 
 	// Sort/compare overriden method.
-	bool operator< ( const QTreeWidgetItem& other ) const
+	bool operator< ( const QTreeWidgetItem& other ) const override
 	{
 		int iColumn = QTreeWidgetItem::treeWidget()->sortColumn();
 		const QString& s1 = text( iColumn );

--- a/plugins/GigPlayer/PatchesDialog.h
+++ b/plugins/GigPlayer/PatchesDialog.h
@@ -50,7 +50,7 @@ public:
 	PatchesDialog(QWidget * pParent = 0, Qt::WindowFlags wflags = QFlag(0));
 
 	// Destructor.
-	virtual ~PatchesDialog();
+	~PatchesDialog() override;
 
 
 	void setup( GigInstance * pSynth, int iChan, const QString & chanName,
@@ -64,8 +64,8 @@ public slots:
 
 protected slots:
 
-	void accept();
-	void reject();
+	void accept() override;
+	void reject() override;
 
 protected:
 

--- a/plugins/HydrogenImport/HydrogenImport.h
+++ b/plugins/HydrogenImport/HydrogenImport.h
@@ -15,14 +15,14 @@ public:
 	HydrogenImport( const QString & _file );
         bool readSong();
 
-	virtual ~HydrogenImport();
+	~HydrogenImport() override;
 
-	virtual gui::PluginView* instantiateView( QWidget * )
+	gui::PluginView* instantiateView( QWidget * ) override
 	{
 		return( nullptr );
 	}
 private:
-	virtual bool tryImport( TrackContainer* tc );
+	bool tryImport( TrackContainer* tc ) override;
 };
 
 

--- a/plugins/Kicker/Kicker.h
+++ b/plugins/Kicker/Kicker.h
@@ -54,28 +54,28 @@ class KickerInstrument : public Instrument
 	Q_OBJECT
 public:
 	KickerInstrument( InstrumentTrack * _instrument_track );
-	virtual ~KickerInstrument();
+	~KickerInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual Flags flags() const
+	Flags flags() const override
 	{
 		return IsNotBendable;
 	}
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 512 );
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 private:
@@ -109,10 +109,10 @@ class KickerInstrumentView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	KickerInstrumentView( Instrument * _instrument, QWidget * _parent );
-	virtual ~KickerInstrumentView();
+	~KickerInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	Knob * m_startFreqKnob;
 	Knob * m_endFreqKnob;

--- a/plugins/LadspaBrowser/LadspaBrowser.h
+++ b/plugins/LadspaBrowser/LadspaBrowser.h
@@ -46,7 +46,7 @@ class LadspaBrowserView : public ToolPluginView
 	Q_OBJECT
 public:
 	LadspaBrowserView( ToolPlugin * _tool );
-	virtual ~LadspaBrowserView();
+	~LadspaBrowserView() override;
 
 
 public slots:
@@ -69,22 +69,22 @@ class LadspaBrowser : public ToolPlugin
 {
 public:
 	LadspaBrowser();
-	virtual ~LadspaBrowser();
+	~LadspaBrowser() override;
 
-	virtual gui::PluginView* instantiateView( QWidget * )
+	gui::PluginView* instantiateView( QWidget * ) override
 	{
 		return new gui::LadspaBrowserView( this );
 	}
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual void saveSettings( QDomDocument& doc, QDomElement& element )
+	void saveSettings( QDomDocument& doc, QDomElement& element ) override
 	{
 		Q_UNUSED(doc)
 		Q_UNUSED(element)
 	}
 
-	virtual void loadSettings( const QDomElement& element )
+	void loadSettings( const QDomElement& element ) override
 	{
 		Q_UNUSED(element)
 	}

--- a/plugins/LadspaBrowser/LadspaDescription.h
+++ b/plugins/LadspaBrowser/LadspaDescription.h
@@ -44,7 +44,7 @@ class LadspaDescription : public QWidget
 	Q_OBJECT
 public:
 	LadspaDescription( QWidget * _parent, LadspaPluginType _type );
-	virtual ~LadspaDescription();
+	~LadspaDescription() override;
 
 
 signals:

--- a/plugins/LadspaBrowser/LadspaPortDialog.h
+++ b/plugins/LadspaBrowser/LadspaPortDialog.h
@@ -40,7 +40,7 @@ class LadspaPortDialog : public QDialog
 	Q_OBJECT
 public:
 	LadspaPortDialog( const ladspa_key_t & _key );
-	virtual ~LadspaPortDialog();
+	~LadspaPortDialog() override;
 
 };
 

--- a/plugins/LadspaEffect/LadspaControlDialog.h
+++ b/plugins/LadspaEffect/LadspaControlDialog.h
@@ -50,7 +50,7 @@ class LadspaControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	LadspaControlDialog( LadspaControls * _ctl );
-	~LadspaControlDialog();
+	~LadspaControlDialog() override;
 
 
 private slots:

--- a/plugins/LadspaEffect/LadspaControls.h
+++ b/plugins/LadspaEffect/LadspaControls.h
@@ -43,21 +43,21 @@ class LadspaControls : public EffectControls
 	Q_OBJECT
 public:
 	LadspaControls( LadspaEffect * _eff );
-	virtual ~LadspaControls();
+	~LadspaControls() override;
 
-	inline int controlCount()
+	inline int controlCount() override
 	{
 		return m_controlCount;
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "ladspacontrols";
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::LadspaControlDialog( this );
 	}

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -46,14 +46,14 @@ class LadspaEffect : public Effect
 public:
 	LadspaEffect( Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~LadspaEffect();
+	~LadspaEffect() override;
 
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-							const fpp_t _frames );
+	bool processAudioBuffer( sampleFrame * _buf,
+							const fpp_t _frames ) override;
 	
 	void setControl( int _control, LADSPA_Data _data );
 
-	virtual EffectControls * controls()
+	EffectControls * controls() override
 	{
 		return m_controls;
 	}

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.h
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.h
@@ -44,7 +44,7 @@ public:
 	void fillDescriptionWidget( QWidget * _parent,
 												const Key * _key ) const override;
 
-	virtual void listSubPluginKeys( const Plugin::Descriptor * _desc,
+	void listSubPluginKeys( const Plugin::Descriptor * _desc,
 												KeyList & _kl ) const override;
 
 

--- a/plugins/Lb302/Lb302.h
+++ b/plugins/Lb302/Lb302.h
@@ -92,11 +92,11 @@ class Lb302FilterIIR2 : public Lb302Filter
 {
 	public:
 	Lb302FilterIIR2(Lb302FilterKnobState* p_fs);
-	virtual ~Lb302FilterIIR2();
+	~Lb302FilterIIR2() override;
 
-	virtual void recalc();
-	virtual void envRecalc();
-	virtual float process(const float& samp);
+	void recalc() override;
+	void envRecalc() override;
+	float process(const float& samp) override;
 
 	protected:
 	float vcf_d1,           //   d1 and d2 are added back into the sample with
@@ -118,9 +118,9 @@ class Lb302Filter3Pole : public Lb302Filter
 	Lb302Filter3Pole(Lb302FilterKnobState* p_fs);
 
 	//virtual void recalc();
-	virtual void envRecalc();
-	virtual void recalc();
-	virtual float process(const float& samp);
+	void envRecalc() override;
+	void recalc() override;
+	float process(const float& samp) override;
 
 	protected:
 	float kfcn,
@@ -150,30 +150,30 @@ class Lb302Synth : public Instrument
 	Q_OBJECT
 public:
 	Lb302Synth( InstrumentTrack * _instrument_track );
-	virtual ~Lb302Synth();
+	~Lb302Synth() override;
 
-	virtual void play( sampleFrame * _working_buffer );
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void play( sampleFrame * _working_buffer ) override;
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual Flags flags() const
+	Flags flags() const override
 	{
 		return IsSingleStreamed;
 	}
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return 0; //4048;
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 private:
 	void processNote( NotePlayHandle * n );
@@ -277,10 +277,10 @@ class Lb302SynthView : public InstrumentViewFixedSize
 public:
 	Lb302SynthView( Instrument * _instrument,
 	                QWidget * _parent );
-	virtual ~Lb302SynthView();
+	~Lb302SynthView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	Knob * m_vcfCutKnob;
 	Knob * m_vcfResKnob;

--- a/plugins/MidiExport/MidiExport.h
+++ b/plugins/MidiExport/MidiExport.h
@@ -63,16 +63,16 @@ class MidiExport: public ExportFilter
 // 	Q_OBJECT
 public:
 	MidiExport();
-	~MidiExport();
+	~MidiExport() override;
 
-	virtual gui::PluginView* instantiateView(QWidget *)
+	gui::PluginView* instantiateView(QWidget *) override
 	{
 		return nullptr;
 	}
 
-	virtual bool tryExport(const TrackContainer::TrackList &tracks,
+	bool tryExport(const TrackContainer::TrackList &tracks,
 				const TrackContainer::TrackList &patternTracks,
-				int tempo, int masterPitch, const QString &filename);
+				int tempo, int masterPitch, const QString &filename) override;
 	
 private:
 	void writeMidiClip(MidiNoteVector &midiClip, const QDomNode& n,

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -41,16 +41,16 @@ class MidiImport : public ImportFilter
 	Q_OBJECT
 public:
 	MidiImport( const QString & _file );
-	virtual ~MidiImport();
+	~MidiImport() override;
 
-	virtual gui::PluginView* instantiateView( QWidget * )
+	gui::PluginView* instantiateView( QWidget * ) override
 	{
 		return( nullptr );
 	}
 
 
 private:
-	virtual bool tryImport( TrackContainer* tc );
+	bool tryImport( TrackContainer* tc ) override;
 
 	bool readSMF( TrackContainer* tc );
 	bool readRIFF( TrackContainer* tc );

--- a/plugins/MidiImport/portsmf/allegro.h
+++ b/plugins/MidiImport/portsmf/allegro.h
@@ -293,26 +293,26 @@ public:
 
 typedef class Alg_note : public Alg_event {
 public:
-    virtual ~Alg_note();
+    ~Alg_note() override;
     Alg_note(Alg_note *); // copy constructor
     float pitch; // pitch in semitones (69 = A440)
     float loud;  // dynamic corresponding to MIDI velocity
     double dur;   // duration in seconds (normally to release point)
     Alg_parameters_ptr parameters; // attribute/value pair list
     Alg_note() { type = 'n'; parameters = nullptr; }
-    void show();
+    void show() override;
 } *Alg_note_ptr;
 
 
 typedef class Alg_update : public Alg_event {
 public:
-    virtual ~Alg_update() {};
+    ~Alg_update() override {};
     Alg_update(Alg_update *); // copy constructor
     Alg_parameter parameter; // an update contains one attr/value pair
 
 
     Alg_update() { type = 'u'; }
-    void show();
+    void show() override;
 } *Alg_update_ptr;
 
 
@@ -402,7 +402,7 @@ public:
 
     // The destructor does not free events because they are owned
     // by a track or seq structure.
-    virtual ~Alg_event_list();
+    ~Alg_event_list() override;
 
     // Returns the duration of the sequence in beats or seconds
     double get_beat_dur() { return beat_dur; }
@@ -548,7 +548,7 @@ public:
     // setting buffer, but it is not the Serial_read_buffer's responsibility
     // to delete the buffer (owner might want to reuse it), so the destructor
     // does nothing.
-    virtual ~Serial_read_buffer() {  }
+    ~Serial_read_buffer() override {  }
 #if defined(_WIN32)
 //#pragma warning(disable: 546) // cast to int is OK, we only want low 7 bits
 //#pragma warning(disable: 4311) // type cast pointer to long warning
@@ -588,7 +588,7 @@ typedef class Serial_write_buffer: public Serial_buffer {
     // This destructor will only run when the program exits, which will only
     // add overhead to the exit process, but it will eliminate an incorrect
     // report of memory leakage from automation that doesn't know better. -RBD
-    virtual ~Serial_write_buffer() {
+    ~Serial_write_buffer() override {
         if (buffer) delete [] buffer;
     }
     void init_for_write() { ptr = buffer; }
@@ -654,7 +654,7 @@ protected:
 public:
     void serialize_track();
     void unserialize_track();
-    virtual Alg_event_ptr const &operator[](int i) {
+    Alg_event_ptr const &operator[](int i) override {
         assert(i >= 0 && i < len);
         return events[i];
     }
@@ -669,7 +669,7 @@ public:
     // copy constructor: event_list is copied, map is installed and referenced
     Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, 
               bool units_are_seconds);
-    virtual ~Alg_track() { // note: do not call set_time_map(NULL)!
+    ~Alg_track() override { // note: do not call set_time_map(NULL)!
         if (time_map) time_map->dereference();
         time_map = nullptr; }
 
@@ -1030,11 +1030,11 @@ public:
     Alg_seq(std::istream &file, bool smf, double *offset_ptr = nullptr);
     // create from filename
     Alg_seq(const char *filename, bool smf, double *offset_ptr = nullptr);
-    virtual ~Alg_seq();
+    ~Alg_seq() override;
     int get_read_error() { return error; }
-    void serialize(void **buffer, long *bytes);
+    void serialize(void **buffer, long *bytes) override;
     void copy_time_sigs_to(Alg_seq *dest); // a utility function
-    void set_time_map(Alg_time_map *map);
+    void set_time_map(Alg_time_map *map) override;
 
     // encode sequence structure into contiguous, moveable memory block
     // address of newly allocated memory is assigned to *buffer, which must
@@ -1060,22 +1060,22 @@ public:
     // caller must not delete the result.
     Alg_track_ptr track(int);
 
-    virtual Alg_event_ptr const &operator[](int i);
+    Alg_event_ptr const &operator[](int i) override;
 
-    virtual void convert_to_seconds();
-    virtual void convert_to_beats();
+    void convert_to_seconds() override;
+    void convert_to_beats() override;
 
     Alg_track_ptr cut_from_track(int track_num, double start, double dur, 
                                  bool all);
-    Alg_seq *cut(double t, double len, bool all);
+    Alg_seq *cut(double t, double len, bool all) override;
     void insert_silence_in_track(int track_num, double t, double len);
-    void insert_silence(double t, double len);
+    void insert_silence(double t, double len) override;
     Alg_track_ptr copy_track(int track_num, double t, double len, bool all);
-    Alg_seq *copy(double start, double len, bool all);
+    Alg_seq *copy(double start, double len, bool all) override;
     void paste(double start, Alg_seq *seq);
-    virtual void clear(double t, double len, bool all);
-    virtual void merge(double t, Alg_event_list_ptr seq);
-    virtual void silence(double t, double len, bool all);
+    void clear(double t, double len, bool all) override;
+    void merge(double t, Alg_event_list_ptr seq) override;
+    void silence(double t, double len, bool all) override;
     void clear_track(int track_num, double start, double len, bool all);
     void silence_track(int track_num, double start, double len, bool all);
     Alg_event_list_ptr find_in_track(int track_num, double t, double len,
@@ -1100,7 +1100,7 @@ public:
     // add_event takes a pointer to an event on the heap. The event is not
     // copied, and this Alg_seq becomes the owner and freer of the event.
     void add_event(Alg_event_ptr event, int track_num);
-    void add(Alg_event_ptr event) { assert(false); } // call add_event instead
+    void add(Alg_event_ptr event) override { assert(false); } // call add_event instead
     // get the tempo starting at beat
     double get_tempo(double beat);
     bool set_tempo(double bpm, double start_beat, double end_beat);
@@ -1112,7 +1112,7 @@ public:
                          double *num, double *den);
     // void set_events(Alg_event_ptr *events, long len, long max);
     void merge_tracks();    // move all track data into one track
-    void set_in_use(bool flag); // set in_use flag on all tracks
+    void set_in_use(bool flag) override; // set in_use flag on all tracks
 } *Alg_seq_ptr, &Alg_seq_ref;
 
 

--- a/plugins/MidiImport/portsmf/allegrosmfrd.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfrd.cpp
@@ -65,36 +65,36 @@ protected:
 
     double get_time();
     void update(int chan, int key, Alg_parameter_ptr param);
-    void *Mf_malloc(size_t size) { return malloc(size); }
-    void Mf_free(void *obj, size_t size) { free(obj); }
+    void *Mf_malloc(size_t size) override { return malloc(size); }
+    void Mf_free(void *obj, size_t size) override { free(obj); }
     /* Methods to be called while processing the MIDI file. */
-    void Mf_starttrack();
-    void Mf_endtrack();
-    int Mf_getc();
-    void Mf_chanprefix(int chan);
-    void Mf_portprefix(int port);
-    void Mf_eot();
-    void Mf_error(char *);
+    void Mf_starttrack() override;
+    void Mf_endtrack() override;
+    int Mf_getc() override;
+    void Mf_chanprefix(int chan) override;
+    void Mf_portprefix(int port) override;
+    void Mf_eot() override;
+    void Mf_error(char *) override;
     void Mf_error(const char *);
-    void Mf_header(int,int,int);
-    void Mf_on(int,int,int);
-    void Mf_off(int,int,int);
-    void Mf_pressure(int,int,int);
-    void Mf_controller(int,int,int);
-    void Mf_pitchbend(int,int,int);
-    void Mf_program(int,int);
-    void Mf_chanpressure(int,int);
+    void Mf_header(int,int,int) override;
+    void Mf_on(int,int,int) override;
+    void Mf_off(int,int,int) override;
+    void Mf_pressure(int,int,int) override;
+    void Mf_controller(int,int,int) override;
+    void Mf_pitchbend(int,int,int) override;
+    void Mf_program(int,int) override;
+    void Mf_chanpressure(int,int) override;
     void binary_msg(int len, unsigned char *msg, const char *attr_string);
-    void Mf_sysex(int,unsigned char*);
-    void Mf_arbitrary(int,unsigned char*);
-    void Mf_metamisc(int,int,unsigned char*);
-    void Mf_seqnum(int);
-    void Mf_smpte(int,int,int,int,int);
-    void Mf_timesig(int,int,int,int);
-    void Mf_tempo(int);
-    void Mf_keysig(int,int);
-    void Mf_sqspecific(int,unsigned char*);
-    void Mf_text(int,int,unsigned char*);
+    void Mf_sysex(int,unsigned char*) override;
+    void Mf_arbitrary(int,unsigned char*) override;
+    void Mf_metamisc(int,int,unsigned char*) override;
+    void Mf_seqnum(int) override;
+    void Mf_smpte(int,int,int,int,int) override;
+    void Mf_timesig(int,int,int,int) override;
+    void Mf_tempo(int) override;
+    void Mf_keysig(int,int) override;
+    void Mf_sqspecific(int,unsigned char*) override;
+    void Mf_text(int,int,unsigned char*) override;
 };
 
 

--- a/plugins/Monstro/Monstro.h
+++ b/plugins/Monstro/Monstro.h
@@ -355,21 +355,21 @@ class MonstroInstrument : public Instrument
 
 public:
 	MonstroInstrument( InstrumentTrack * _instrument_track );
-	virtual ~MonstroInstrument();
+	~MonstroInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
-	virtual void saveSettings( QDomDocument & _doc,
-							QDomElement & _this );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc,
+							QDomElement & _this ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const;
+	f_cnt_t desiredReleaseFrames() const override;
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 public slots:
 	void updateVolume1();
@@ -593,13 +593,13 @@ class MonstroView : public InstrumentViewFixedSize
 public:
 	MonstroView( Instrument * _instrument,
 					QWidget * _parent );
-	virtual ~MonstroView();
+	~MonstroView() override;
 
 protected slots:
 	void updateLayout();
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	void setWidgetBackground( QWidget * _widget, const QString & _pic );
 	QWidget * setupOperatorsView( QWidget * _parent );

--- a/plugins/MultitapEcho/MultitapEcho.h
+++ b/plugins/MultitapEcho/MultitapEcho.h
@@ -39,10 +39,10 @@ class MultitapEchoEffect : public Effect
 {
 public:
 	MultitapEchoEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~MultitapEchoEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~MultitapEchoEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_controls;
 	}

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.h
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.h
@@ -44,7 +44,7 @@ class MultitapEchoControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	MultitapEchoControlDialog( MultitapEchoControls * controls );
-	virtual ~MultitapEchoControlDialog()
+	~MultitapEchoControlDialog() override
 	{
 	}
 };

--- a/plugins/MultitapEcho/MultitapEchoControls.h
+++ b/plugins/MultitapEcho/MultitapEchoControls.h
@@ -41,11 +41,11 @@ class MultitapEchoControls : public EffectControls
 	Q_OBJECT
 public:
 	MultitapEchoControls( MultitapEchoEffect * eff );
-	virtual ~MultitapEchoControls();
+	~MultitapEchoControls() override;
 
-	virtual void saveSettings( QDomDocument & doc, QDomElement & parent );
-	virtual void loadSettings( const QDomElement & elem );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & doc, QDomElement & parent ) override;
+	void loadSettings( const QDomElement & elem ) override;
+	inline QString nodeName() const override
 	{
 		return( "multitapechocontrols" );
 	}
@@ -53,12 +53,12 @@ public:
 	void setDefaultAmpShape();
 	void setDefaultLpShape();
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 5 );
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return( new gui::MultitapEchoControlDialog( this ) );
 	}

--- a/plugins/Nes/Nes.h
+++ b/plugins/Nes/Nes.h
@@ -211,25 +211,25 @@ class NesInstrument : public Instrument
 	Q_OBJECT
 public:
 	NesInstrument( InstrumentTrack * instrumentTrack );
-	virtual ~NesInstrument();
+	~NesInstrument() override;
 	
-	virtual void playNote( NotePlayHandle * n,
-						sampleFrame * workingBuffer );
-	virtual void deleteNotePluginData( NotePlayHandle * n );
+	void playNote( NotePlayHandle * n,
+						sampleFrame * workingBuffer ) override;
+	void deleteNotePluginData( NotePlayHandle * n ) override;
 
 
-	virtual void saveSettings( QDomDocument & doc,
-							QDomElement & element );
-	virtual void loadSettings( const QDomElement & element );
+	void saveSettings( QDomDocument & doc,
+							QDomElement & element ) override;
+	void loadSettings( const QDomElement & element ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 8 );
 	}
 	
-	virtual gui::PluginView* instantiateView( QWidget * parent );
+	gui::PluginView* instantiateView( QWidget * parent ) override;
 	
 public slots:
 	void updateFreq1();
@@ -313,10 +313,10 @@ class NesInstrumentView : public InstrumentViewFixedSize
 public:
 	NesInstrumentView( Instrument * instrument,
 					QWidget * parent );
-	virtual ~NesInstrumentView();	
+	~NesInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 	
 	// channel 1
 	PixmapButton * 	m_ch1EnabledBtn;

--- a/plugins/OpulenZ/OpulenZ.h
+++ b/plugins/OpulenZ/OpulenZ.h
@@ -59,24 +59,24 @@ class OpulenzInstrument : public Instrument
 	Q_OBJECT
 public:
 	OpulenzInstrument( InstrumentTrack * _instrument_track );
-	virtual ~OpulenzInstrument();
+	~OpulenzInstrument() override;
 
-	virtual QString nodeName() const;
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	QString nodeName() const override;
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
-	virtual Flags flags() const
+	Flags flags() const override
 	{
 		return IsSingleStreamed | IsMidiBased;
 	}
 
-	virtual bool handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 );
-	virtual void play( sampleFrame * _working_buffer );
+	bool handleMidiEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset = 0 ) override;
+	void play( sampleFrame * _working_buffer ) override;
 
-	void saveSettings( QDomDocument & _doc, QDomElement & _this );
-	void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
+	void loadSettings( const QDomElement & _this ) override;
 	void loadPatch(const unsigned char inst[14]);
 	void tuneEqual(int center, float Hz);
-	virtual void loadFile( const QString& file );
+	void loadFile( const QString& file ) override;
 
 	IntModel m_patchModel;
 
@@ -163,9 +163,9 @@ class OpulenzInstrumentView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	OpulenzInstrumentView( Instrument * _instrument, QWidget * _parent );
-	virtual ~OpulenzInstrumentView();
+	~OpulenzInstrumentView() override;
 	LcdSpinBox *m_patch;
-	void modelChanged();
+	void modelChanged() override;
 
 	Knob *op1_a_kn;
 	Knob *op1_d_kn;

--- a/plugins/Organic/Organic.h
+++ b/plugins/Organic/Organic.h
@@ -105,7 +105,7 @@ private:
 	float m_phaseOffsetRight;
 
 	OscillatorObject( Model * _parent, int _index );
-	virtual ~OscillatorObject();
+	~OscillatorObject() override;
 
 	friend class OrganicInstrument;
 	friend class gui::OrganicInstrumentView;
@@ -124,17 +124,17 @@ class OrganicInstrument : public Instrument
 	Q_OBJECT
 public:
 	OrganicInstrument( InstrumentTrack * _instrument_track );
-	virtual ~OrganicInstrument();
+	~OrganicInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
 	int intRand( int min, int max );
 
@@ -172,7 +172,7 @@ private:
 	FloatModel  m_fx1Model;
 	FloatModel  m_volModel;
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 private slots:
@@ -190,10 +190,10 @@ class OrganicInstrumentView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	OrganicInstrumentView( Instrument * _instrument, QWidget * _parent );
-	virtual ~OrganicInstrumentView();
+	~OrganicInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	struct OscillatorKnobs
 	{

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -57,26 +57,26 @@ class PatmanInstrument : public Instrument
 	Q_OBJECT
 public:
 	PatmanInstrument( InstrumentTrack * _track );
-	virtual ~PatmanInstrument();
+	~PatmanInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual void loadFile( const QString & _file );
+	void loadFile( const QString & _file ) override;
 
-	virtual QString nodeName( void ) const;
+	QString nodeName( void ) const override;
 
-	virtual f_cnt_t desiredReleaseFrames( void ) const
+	f_cnt_t desiredReleaseFrames( void ) const override
 	{
 		return( 128 );
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 public slots:
@@ -131,7 +131,7 @@ class PatmanView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	PatmanView( Instrument * _instrument, QWidget * _parent );
-	virtual ~PatmanView();
+	~PatmanView() override;
 
 
 public slots:
@@ -140,13 +140,13 @@ public slots:
 
 
 protected:
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
-	virtual void paintEvent( QPaintEvent * );
+	void dragEnterEvent( QDragEnterEvent * _dee ) override;
+	void dropEvent( QDropEvent * _de ) override;
+	void paintEvent( QPaintEvent * ) override;
 
 
 private:
-	virtual void modelChanged( void );
+	void modelChanged( void ) override;
 
 	PatmanInstrument * m_pi;
 	QString m_displayFilename;

--- a/plugins/PeakControllerEffect/PeakControllerEffect.h
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.h
@@ -40,8 +40,8 @@ class PeakControllerEffect : public Effect
 public:
 	PeakControllerEffect( Model * parent, 
 						const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~PeakControllerEffect();
-	virtual bool processAudioBuffer( sampleFrame * _buf,
+	~PeakControllerEffect() override;
+	bool processAudioBuffer( sampleFrame * _buf,
 									const fpp_t _frames ) override;
 
 	EffectControls * controls() override

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.h
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.h
@@ -45,7 +45,7 @@ class PeakControllerEffectControlDialog : public EffectControlDialog
 public:
 	PeakControllerEffectControlDialog(
 				PeakControllerEffectControls * _controls );
-	virtual ~PeakControllerEffectControlDialog()
+	~PeakControllerEffectControlDialog() override
 	{
 	}
 

--- a/plugins/PeakControllerEffect/PeakControllerEffectControls.h
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControls.h
@@ -41,7 +41,7 @@ class PeakControllerEffectControls : public EffectControls
 	Q_OBJECT
 public:
 	PeakControllerEffectControls( PeakControllerEffect * _eff );
-	virtual ~PeakControllerEffectControls()
+	~PeakControllerEffectControls() override
 	{
 	}
 

--- a/plugins/ReverbSC/ReverbSC.h
+++ b/plugins/ReverbSC/ReverbSC.h
@@ -44,10 +44,10 @@ class ReverbSCEffect : public Effect
 {
 public:
 	ReverbSCEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key );
-	virtual ~ReverbSCEffect();
-	virtual bool processAudioBuffer( sampleFrame* buf, const fpp_t frames );
+	~ReverbSCEffect() override;
+	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return &m_reverbSCControls;
 	}

--- a/plugins/ReverbSC/ReverbSCControlDialog.h
+++ b/plugins/ReverbSC/ReverbSCControlDialog.h
@@ -42,7 +42,7 @@ class ReverbSCControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	ReverbSCControlDialog( ReverbSCControls* controls );
-	virtual ~ReverbSCControlDialog()
+	~ReverbSCControlDialog() override
 	{
 	}
 

--- a/plugins/ReverbSC/ReverbSCControls.h
+++ b/plugins/ReverbSC/ReverbSCControls.h
@@ -40,23 +40,23 @@ class ReverbSCControls : public EffectControls
 	Q_OBJECT
 public:
 	ReverbSCControls( ReverbSCEffect* effect );
-	virtual ~ReverbSCControls()
+	~ReverbSCControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "ReverbSCControls";
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return 4;
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::ReverbSCControlDialog( this );
 	}

--- a/plugins/Sf2Player/PatchesDialog.cpp
+++ b/plugins/Sf2Player/PatchesDialog.cpp
@@ -47,7 +47,7 @@ public:
 		: QTreeWidgetItem( pListView, pItemAfter ) {}
 
 	// Sort/compare overriden method.
-	bool operator< ( const QTreeWidgetItem& other ) const
+	bool operator< ( const QTreeWidgetItem& other ) const override
 	{
 		int iColumn = QTreeWidgetItem::treeWidget()->sortColumn();
 		const QString& s1 = text( iColumn );

--- a/plugins/Sf2Player/PatchesDialog.h
+++ b/plugins/Sf2Player/PatchesDialog.h
@@ -50,7 +50,7 @@ public:
 	PatchesDialog(QWidget *pParent = 0, Qt::WindowFlags wflags = QFlag(0));
 
 	// Destructor.
-	virtual ~PatchesDialog();
+	~PatchesDialog() override;
 
 
 	void setup(fluid_synth_t *pSynth, int iChan, const QString & _chanName,
@@ -64,8 +64,8 @@ public slots:
 
 protected slots:
 
-	void accept();
-	void reject();
+	void accept() override;
+	void reject() override;
 
 protected:
 

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -63,35 +63,35 @@ class Sf2Instrument : public Instrument
 
 public:
 	Sf2Instrument( InstrumentTrack * _instrument_track );
-	virtual ~Sf2Instrument();
+	~Sf2Instrument() override;
 
-	virtual void play( sampleFrame * _working_buffer );
+	void play( sampleFrame * _working_buffer ) override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual void loadFile( const QString & _file );
+	void loadFile( const QString & _file ) override;
 
-	virtual AutomatableModel * childModel( const QString & _modelName );
+	AutomatableModel * childModel( const QString & _modelName ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return 0;
 	}
 
-	virtual Flags flags() const
+	Flags flags() const override
 	{
 		return IsSingleStreamed;
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 	
 	QString getCurrentPatchName();
 
@@ -203,10 +203,10 @@ class Sf2InstrumentView : public InstrumentViewFixedSize
 public:
 	Sf2InstrumentView( Instrument * _instrument,
 					QWidget * _parent );
-	virtual ~Sf2InstrumentView();
+	~Sf2InstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	PixmapButton * m_fileDialogButton;
 	PixmapButton * m_patchDialogButton;

--- a/plugins/Sfxr/Sfxr.h
+++ b/plugins/Sfxr/Sfxr.h
@@ -140,7 +140,7 @@ public:
 	{
 	}
 	/* purpose: prevent the initial value of the model from being changed */
-	virtual void loadSettings( const QDomElement& element, const QString& name = QString( "value" ) )
+	void loadSettings( const QDomElement& element, const QString& name = QString( "value" ) ) override
 	{
 		float oldInitValue = initValue();
 		FloatModel::loadSettings(element, name);
@@ -161,7 +161,7 @@ public:
 	{
 	}
 	/* purpose: prevent the initial value of the model from being changed */
-	virtual void loadSettings( const QDomElement& element, const QString& name = QString( "value" ) )
+	void loadSettings( const QDomElement& element, const QString& name = QString( "value" ) ) override
 	{
 		float oldInitValue = initValue();
 		FloatModel::loadSettings(element, name);
@@ -176,18 +176,18 @@ class SfxrInstrument : public Instrument
 	Q_OBJECT
 public:
 	SfxrInstrument(InstrumentTrack * _instrument_track );
-	virtual ~SfxrInstrument();
+	~SfxrInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n, sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n, sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
-	virtual void saveSettings( QDomDocument & _doc,
-							QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc,
+							QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 	void resetModels();
 
@@ -240,7 +240,7 @@ public:
 	SfxrInstrumentView( Instrument * _instrument,
 					QWidget * _parent );
 
-	virtual ~SfxrInstrumentView() {};
+	~SfxrInstrumentView() override {};
 
 protected slots:
 	void genPickup();
@@ -256,7 +256,7 @@ protected slots:
 	void previewSound();
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	Knob * m_attKnob; //Attack Time
 	Knob * m_holdKnob; //Sustain Time

--- a/plugins/Sid/SidInstrument.h
+++ b/plugins/Sid/SidInstrument.h
@@ -58,7 +58,7 @@ public:
 		NumWaveShapes
 	};
 	VoiceObject( Model * _parent, int _idx );
-	virtual ~VoiceObject();
+	~VoiceObject() override;
 
 
 private:
@@ -97,21 +97,21 @@ public:
 
 
 	SidInstrument( InstrumentTrack * _instrument_track );
-	virtual ~SidInstrument();
+	~SidInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const;
+	f_cnt_t desiredReleaseFrames() const override;
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 /*public slots:
@@ -147,10 +147,10 @@ class SidInstrumentView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	SidInstrumentView( Instrument * _instrument, QWidget * _parent );
-	virtual ~SidInstrumentView();
+	~SidInstrumentView() override;
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 	
 	automatableButtonGroup * m_passBtnGrp;
 	automatableButtonGroup * m_sidTypeBtnGrp;

--- a/plugins/SpectrumAnalyzer/Analyzer.h
+++ b/plugins/SpectrumAnalyzer/Analyzer.h
@@ -43,7 +43,7 @@ class Analyzer : public Effect
 {
 public:
 	Analyzer(Model *parent, const Descriptor::SubPluginFeatures::Key *key);
-	virtual ~Analyzer();
+	~Analyzer() override;
 
 	bool processAudioBuffer(sampleFrame *buffer, const fpp_t frame_count) override;
 	EffectControls *controls() override {return &m_controls;}

--- a/plugins/SpectrumAnalyzer/SaControls.h
+++ b/plugins/SpectrumAnalyzer/SaControls.h
@@ -49,7 +49,7 @@ class SaControls : public EffectControls
 	Q_OBJECT
 public:
 	explicit SaControls(Analyzer* effect);
-	virtual ~SaControls() {}
+	~SaControls() override {}
 
 	gui::EffectControlDialog* createView() override;
 

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.h
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.h
@@ -47,7 +47,7 @@ class SaControlsDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	explicit SaControlsDialog(SaControls *controls, SaProcessor *processor);
-	virtual ~SaControlsDialog() {}
+	~SaControlsDialog() override {}
 
 	bool isResizable() const override {return true;}
 	QSize sizeHint() const override;

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.h
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.h
@@ -54,7 +54,7 @@ class SaSpectrumView : public QWidget
 	Q_OBJECT
 public:
 	explicit SaSpectrumView(SaControls *controls, SaProcessor *processor, QWidget *_parent = 0);
-	virtual ~SaSpectrumView() {}
+	~SaSpectrumView() override {}
 
 	QSize sizeHint() const override {return QSize(400, 200);}
 

--- a/plugins/SpectrumAnalyzer/SaWaterfallView.h
+++ b/plugins/SpectrumAnalyzer/SaWaterfallView.h
@@ -49,7 +49,7 @@ class SaWaterfallView : public QWidget
 	Q_OBJECT
 public:
 	explicit SaWaterfallView(SaControls *controls, SaProcessor *processor, QWidget *_parent = 0);
-	virtual ~SaWaterfallView() {}
+	~SaWaterfallView() override {}
 
 	QSize sizeHint() const override {return QSize(400, 350);}
 

--- a/plugins/StereoEnhancer/StereoEnhancer.h
+++ b/plugins/StereoEnhancer/StereoEnhancer.h
@@ -39,11 +39,11 @@ class StereoEnhancerEffect : public Effect
 public:
 	StereoEnhancerEffect( Model * parent,
 	                      const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~StereoEnhancerEffect();
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-		                                          const fpp_t _frames );
+	~StereoEnhancerEffect() override;
+	bool processAudioBuffer( sampleFrame * _buf,
+		                                          const fpp_t _frames ) override;
 
-	virtual EffectControls * controls()
+	EffectControls * controls() override
 	{
 		return( &m_bbControls );
 	}

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.h
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.h
@@ -42,7 +42,7 @@ class StereoEnhancerControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	StereoEnhancerControlDialog( StereoEnhancerControls * _controls );
-	virtual ~StereoEnhancerControlDialog()
+	~StereoEnhancerControlDialog() override
 	{
 	}
 

--- a/plugins/StereoEnhancer/StereoEnhancerControls.h
+++ b/plugins/StereoEnhancer/StereoEnhancerControls.h
@@ -39,23 +39,23 @@ class StereoEnhancerControls : public EffectControls
 	Q_OBJECT
 public:
 	StereoEnhancerControls( StereoEnhancerEffect( * _eff ) ); 
-	virtual ~StereoEnhancerControls()
+	~StereoEnhancerControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return( "stereoenhancercontrols" );
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 1 );
 	}
 	
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::StereoEnhancerControlDialog( this );
 	}

--- a/plugins/StereoMatrix/StereoMatrix.h
+++ b/plugins/StereoMatrix/StereoMatrix.h
@@ -38,11 +38,11 @@ class StereoMatrixEffect : public Effect
 public:
 	StereoMatrixEffect( Model * parent, 
 	                      const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~StereoMatrixEffect();
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-		                                          const fpp_t _frames );
+	~StereoMatrixEffect() override;
+	bool processAudioBuffer( sampleFrame * _buf,
+		                                          const fpp_t _frames ) override;
 
-	virtual EffectControls* controls()
+	EffectControls* controls() override
 	{
 		return( &m_smControls );
 	}

--- a/plugins/StereoMatrix/StereoMatrixControlDialog.h
+++ b/plugins/StereoMatrix/StereoMatrixControlDialog.h
@@ -41,7 +41,7 @@ class StereoMatrixControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	StereoMatrixControlDialog( StereoMatrixControls * _controls );
-	virtual ~StereoMatrixControlDialog()
+	~StereoMatrixControlDialog() override
 	{
 	}
 

--- a/plugins/StereoMatrix/StereoMatrixControls.h
+++ b/plugins/StereoMatrix/StereoMatrixControls.h
@@ -39,23 +39,23 @@ class StereoMatrixControls : public EffectControls
 	Q_OBJECT
 public:
 	StereoMatrixControls( StereoMatrixEffect( * _eff ) ); 
-	virtual ~StereoMatrixControls()
+	~StereoMatrixControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return( "stereomatrixcontrols" );
 	}
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 1 );
 	}
 	
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return new gui::StereoMatrixControlDialog( this );
 	}

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -160,17 +160,17 @@ class MalletsInstrument : public Instrument
 	Q_OBJECT
 public:
 	MalletsInstrument( InstrumentTrack * _instrument_track );
-	virtual ~MalletsInstrument();
+	~MalletsInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
@@ -219,13 +219,13 @@ class MalletsInstrumentView: public InstrumentViewFixedSize
 public:
 	MalletsInstrumentView( MalletsInstrument * _instrument,
 				QWidget * _parent );
-	virtual ~MalletsInstrumentView();
+	~MalletsInstrumentView() override;
 
 public slots:
 	void changePreset();
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	void setWidgetBackground( QWidget * _widget, const QString & _pic );
 	QWidget * setupModalBarControls( QWidget * _parent );

--- a/plugins/TripleOscillator/TripleOscillator.h
+++ b/plugins/TripleOscillator/TripleOscillator.h
@@ -57,7 +57,7 @@ class OscillatorObject : public Model
 	Q_OBJECT
 public:
 	OscillatorObject( Model * _parent, int _idx );
-	virtual ~OscillatorObject();
+	~OscillatorObject() override;
 
 
 private:
@@ -108,24 +108,24 @@ class TripleOscillator : public Instrument
 	Q_OBJECT
 public:
 	TripleOscillator( InstrumentTrack * _track );
-	virtual ~TripleOscillator();
+	~TripleOscillator() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 128 );
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 
 protected slots:
@@ -157,11 +157,11 @@ class TripleOscillatorView : public InstrumentViewFixedSize
 	Q_OBJECT
 public:
 	TripleOscillatorView( Instrument * _instrument, QWidget * _parent );
-	virtual ~TripleOscillatorView();
+	~TripleOscillatorView() override;
 
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 	automatableButtonGroup * m_mod1BtnGrp;
 	automatableButtonGroup * m_mod2BtnGrp;

--- a/plugins/Vectorscope/VecControls.h
+++ b/plugins/Vectorscope/VecControls.h
@@ -47,7 +47,7 @@ class VecControls : public EffectControls
 	Q_OBJECT
 public:
 	explicit VecControls(Vectorscope *effect);
-	virtual ~VecControls() {}
+	~VecControls() override {}
 
 	gui::EffectControlDialog* createView() override;
 

--- a/plugins/Vectorscope/VecControlsDialog.h
+++ b/plugins/Vectorscope/VecControlsDialog.h
@@ -43,7 +43,7 @@ class VecControlsDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	explicit VecControlsDialog(VecControls *controls);
-	virtual ~VecControlsDialog() {}
+	~VecControlsDialog() override {}
 
 	bool isResizable() const override {return true;}
 	QSize sizeHint() const override;

--- a/plugins/Vectorscope/VectorView.h
+++ b/plugins/Vectorscope/VectorView.h
@@ -44,7 +44,7 @@ class VectorView : public QWidget
 	Q_OBJECT
 public:
 	explicit VectorView(VecControls *controls, LocklessRingBuffer<sampleFrame> *inputBuffer, unsigned short displaySize, QWidget *parent = 0);
-	virtual ~VectorView() {}
+	~VectorView() override {}
 
 	QSize sizeHint() const override {return QSize(300, 300);}
 

--- a/plugins/Vectorscope/Vectorscope.h
+++ b/plugins/Vectorscope/Vectorscope.h
@@ -37,7 +37,7 @@ class Vectorscope : public Effect
 {
 public:
 	Vectorscope(Model *parent, const Descriptor::SubPluginFeatures::Key *key);
-	virtual ~Vectorscope() {};
+	~Vectorscope() override {};
 
 	bool processAudioBuffer(sampleFrame *buffer, const fpp_t frame_count) override;
 	EffectControls *controls() override {return &m_controls;}

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -103,11 +103,11 @@ public:
 		setWindowFlags( Qt::WindowCloseButtonHint );
 	}
 
-	virtual ~vstSubWin()
+	~vstSubWin() override
 	{
 	}
 
-	virtual void closeEvent( QCloseEvent * e )
+	void closeEvent( QCloseEvent * e ) override
 	{
 		// ignore close-events - for some reason otherwise the VST GUI
 		// remains hidden when re-opening

--- a/plugins/Vibed/NineButtonSelector.h
+++ b/plugins/Vibed/NineButtonSelector.h
@@ -67,7 +67,7 @@ public:
 				int _default,
 				int _x, int _y,
 				QWidget * _parent);
-	virtual ~NineButtonSelector();
+	~NineButtonSelector() override;
 	
 //	inline int getSelected() { 
 //		return( castModel<NineButtonSelectorModel>()->value() );
@@ -86,13 +86,13 @@ public slots:
 	void button6Clicked();
 	void button7Clicked();
 	void button8Clicked();
-	void contextMenuEvent( QContextMenuEvent * );
+	void contextMenuEvent( QContextMenuEvent * ) override;
 	
 signals:
 	void NineButtonSelection( int );
 	
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 	void updateButton( int );
 
 	QList<PixmapButton *> m_buttons;

--- a/plugins/Vibed/Vibed.h
+++ b/plugins/Vibed/Vibed.h
@@ -97,11 +97,11 @@ class VibedView : public InstrumentViewFixedSize
 public:
 	VibedView( Instrument * _instrument,
 					QWidget * _parent );
-	virtual ~VibedView() {};
+	~VibedView() override {};
 
 public slots:
 	void showString( int _string );
-	void contextMenuEvent( QContextMenuEvent * );
+	void contextMenuEvent( QContextMenuEvent * ) override;
 
 protected slots:
 	void sinWaveClicked();
@@ -114,7 +114,7 @@ protected slots:
 	void normalizeClicked();
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 
 	// String-related

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -45,7 +45,7 @@ class VSTBASE_EXPORT VstPlugin : public RemotePlugin, public JournallingObject
 	Q_OBJECT
 public:
 	VstPlugin( const QString & _plugin );
-	virtual ~VstPlugin();
+	~VstPlugin() override;
 
 	void tryLoad( const QString &remoteVstPluginExecutable );
 
@@ -112,7 +112,7 @@ public:
 	void loadSettings( const QDomElement & _this ) override;
 	void saveSettings( QDomDocument & _doc, QDomElement & _this ) override;
 
-	virtual QString nodeName() const override
+	QString nodeName() const override
 	{
 		return "vstplugin";
 	}

--- a/plugins/VstEffect/VstEffect.h
+++ b/plugins/VstEffect/VstEffect.h
@@ -43,12 +43,12 @@ class VstEffect : public Effect
 public:
 	VstEffect( Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~VstEffect();
+	~VstEffect() override;
 
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-							const fpp_t _frames );
+	bool processAudioBuffer( sampleFrame * _buf,
+							const fpp_t _frames ) override;
 
-	virtual EffectControls * controls()
+	EffectControls * controls() override
 	{
 		return &m_vstControls;
 	}

--- a/plugins/VstEffect/VstEffectControlDialog.h
+++ b/plugins/VstEffect/VstEffectControlDialog.h
@@ -50,7 +50,7 @@ class VstEffectControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	VstEffectControlDialog( VstEffectControls * _controls );
-	virtual ~VstEffectControlDialog();
+	~VstEffectControlDialog() override;
 
 protected:
 	void paintEvent( QPaintEvent * _pe ) override;

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -55,18 +55,18 @@ class VstEffectControls : public EffectControls
 	Q_OBJECT
 public:
 	VstEffectControls( VstEffect * _eff );
-	virtual ~VstEffectControls();
+	~VstEffectControls() override;
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return "vsteffectcontrols";
 	}
 
-	virtual int controlCount();
+	int controlCount() override;
 
-	virtual gui::EffectControlDialog* createView();
+	gui::EffectControlDialog* createView() override;
 
 
 protected slots:
@@ -113,7 +113,7 @@ class ManageVSTEffectView : public QObject
 	Q_OBJECT
 public:
 	ManageVSTEffectView( VstEffect * _eff, VstEffectControls * m_vi );
-	virtual ~ManageVSTEffectView();
+	~ManageVSTEffectView() override;
 
 
 protected slots:

--- a/plugins/VstEffect/VstSubPluginFeatures.h
+++ b/plugins/VstEffect/VstSubPluginFeatures.h
@@ -40,11 +40,11 @@ class VstSubPluginFeatures : public Plugin::Descriptor::SubPluginFeatures
 public:
 	VstSubPluginFeatures( Plugin::PluginTypes _type );
 
-	virtual void fillDescriptionWidget( QWidget * _parent,
-											const Key * _key ) const;
+	void fillDescriptionWidget( QWidget * _parent,
+											const Key * _key ) const override;
 
-	virtual void listSubPluginKeys( const Plugin::Descriptor * _desc,
-											KeyList & _kl ) const;
+	void listSubPluginKeys( const Plugin::Descriptor * _desc,
+											KeyList & _kl ) const override;
 private:
 	void addPluginsFromDir(QStringList* filenames,  QString path) const;
 } ;

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -139,25 +139,25 @@ class WatsynInstrument : public Instrument
 	Q_OBJECT
 public:
 	WatsynInstrument( InstrumentTrack * _instrument_track );
-	virtual ~WatsynInstrument();
+	~WatsynInstrument() override;
 
-	virtual void playNote( NotePlayHandle * _n,
-						sampleFrame * _working_buffer );
-	virtual void deleteNotePluginData( NotePlayHandle * _n );
+	void playNote( NotePlayHandle * _n,
+						sampleFrame * _working_buffer ) override;
+	void deleteNotePluginData( NotePlayHandle * _n ) override;
 
 
-	virtual void saveSettings( QDomDocument & _doc,
-							QDomElement & _this );
-	virtual void loadSettings( const QDomElement & _this );
+	void saveSettings( QDomDocument & _doc,
+							QDomElement & _this ) override;
+	void loadSettings( const QDomElement & _this ) override;
 
-	virtual QString nodeName() const;
+	QString nodeName() const override;
 
-	virtual f_cnt_t desiredReleaseFrames() const
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 64 );
 	}
 
-	virtual gui::PluginView* instantiateView( QWidget * _parent );
+	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 public slots:
 	void updateVolumes();
@@ -310,7 +310,7 @@ class WatsynView : public InstrumentViewFixedSize
 public:
 	WatsynView( Instrument * _instrument,
 					QWidget * _parent );
-	virtual ~WatsynView();
+	~WatsynView() override;
 
 protected slots:
 	void updateLayout();
@@ -328,7 +328,7 @@ protected slots:
 	void loadClicked();
 
 private:
-	virtual void modelChanged();
+	void modelChanged() override;
 
 // knobs
 	Knob * a1_volKnob;

--- a/plugins/WaveShaper/WaveShaper.h
+++ b/plugins/WaveShaper/WaveShaper.h
@@ -39,11 +39,11 @@ class WaveShaperEffect : public Effect
 public:
 	WaveShaperEffect( Model * _parent,
 			const Descriptor::SubPluginFeatures::Key * _key );
-	virtual ~WaveShaperEffect();
-	virtual bool processAudioBuffer( sampleFrame * _buf,
-							const fpp_t _frames );
+	~WaveShaperEffect() override;
+	bool processAudioBuffer( sampleFrame * _buf,
+							const fpp_t _frames ) override;
 
-	virtual EffectControls * controls()
+	EffectControls * controls() override
 	{
 		return( &m_wsControls );
 	}

--- a/plugins/WaveShaper/WaveShaperControlDialog.h
+++ b/plugins/WaveShaper/WaveShaperControlDialog.h
@@ -42,7 +42,7 @@ class WaveShaperControlDialog : public EffectControlDialog
 	Q_OBJECT
 public:
 	WaveShaperControlDialog( WaveShaperControls * _controls );
-	virtual ~WaveShaperControlDialog()
+	~WaveShaperControlDialog() override
 	{
 	}
 

--- a/plugins/WaveShaper/WaveShaperControls.h
+++ b/plugins/WaveShaper/WaveShaperControls.h
@@ -42,25 +42,25 @@ class WaveShaperControls : public EffectControls
 	Q_OBJECT
 public:
 	WaveShaperControls( WaveShaperEffect * _eff );
-	virtual ~WaveShaperControls()
+	~WaveShaperControls() override
 	{
 	}
 
-	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
-	virtual void loadSettings( const QDomElement & _this );
-	inline virtual QString nodeName() const
+	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
+	void loadSettings( const QDomElement & _this ) override;
+	inline QString nodeName() const override
 	{
 		return( "waveshapercontrols" );
 	}
 
 	virtual void setDefaultShape();
 
-	virtual int controlCount()
+	int controlCount() override
 	{
 		return( 4 );
 	}
 
-	virtual gui::EffectControlDialog* createView()
+	gui::EffectControlDialog* createView() override
 	{
 		return( new gui::WaveShaperControlDialog( this ) );
 	}

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -56,7 +56,7 @@ struct freefunc0 : public exprtk::ifunction<T>
 	freefunc0() : exprtk::ifunction<T>(0) {
 		if (optimize) { exprtk::disable_has_side_effects(*this); }
 	}
-	inline T operator()()
+	inline T operator()() override
 	{ return Functor::process(); }
 };
 template <typename T,typename Functor,bool optimize>
@@ -67,7 +67,7 @@ struct freefunc1 : public exprtk::ifunction<T>
 	freefunc1() : exprtk::ifunction<T>(1) {
 		if (optimize) { exprtk::disable_has_side_effects(*this); }
 	}
-	inline T operator()(const T& x)
+	inline T operator()(const T& x) override
 	{ return Functor::process(x); }
 };
 
@@ -76,7 +76,7 @@ struct IntegrateFunction : public exprtk::ifunction<T>
 {
 
 	using exprtk::ifunction<T>::operator();
-	virtual ~IntegrateFunction()
+	~IntegrateFunction() override
 	{
 		delete [] m_counters;
 	}
@@ -94,7 +94,7 @@ struct IntegrateFunction : public exprtk::ifunction<T>
 		clearArray(m_counters,max_counters);
 	}
 
-	inline T operator()(const T& x)
+	inline T operator()(const T& x) override
 	{
 		if (*m_frame == 0)
 		{
@@ -131,7 +131,7 @@ struct LastSampleFunction : public exprtk::ifunction<T>
 {
 
 	using exprtk::ifunction<T>::operator();
-	virtual ~LastSampleFunction()
+	~LastSampleFunction() override
 	{
 		delete [] m_samples;
 	}
@@ -145,7 +145,7 @@ struct LastSampleFunction : public exprtk::ifunction<T>
 		clearArray(m_samples, history_size);
 	}
 
-	inline T operator()(const T& x)
+	inline T operator()(const T& x) override
 	{
 		if (!std::isnan(x) && !std::isinf(x))
 		{
@@ -187,7 +187,7 @@ struct WaveValueFunction : public exprtk::ifunction<T>
 	m_size(s)
 	{}
 
-	inline T operator()(const T& index)
+	inline T operator()(const T& index) override
 	{
 		return m_vec[(int) ( positiveFraction(index) * m_size )];
 	}
@@ -205,7 +205,7 @@ struct WaveValueFunctionInterpolate : public exprtk::ifunction<T>
 	m_size(s)
 	{}
 
-	inline T operator()(const T& index)
+	inline T operator()(const T& index) override
 	{
 		const T x = positiveFraction(index) * m_size;
 		const int ix = (int)x;
@@ -321,7 +321,7 @@ struct RandomVectorSeedFunction : public exprtk::ifunction<float>
 		return static_cast<int>(res) / (float)(1 << 31);
 	}
 
-	inline float operator()(const float& index,const float& seed)
+	inline float operator()(const float& index,const float& seed) override
 	{
 		int irseed;
 		if (seed < 0 || std::isnan(seed) || std::isinf(seed))
@@ -346,7 +346,7 @@ struct RandomVectorFunction : public exprtk::ifunction<float>
 	m_rseed(seed)
 	{ exprtk::disable_has_side_effects(*this); }
 
-	inline float operator()(const float& index)
+	inline float operator()(const float& index) override
 	{
 		return RandomVectorSeedFunction::randv(index,m_rseed);
 	}

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -64,17 +64,17 @@ public:
 		pthread_create( &m_messageThreadHandle, nullptr, messageLoop, this );
 	}
 
-	virtual ~RemoteZynAddSubFx()
+	~RemoteZynAddSubFx() override
 	{
 		Nio::stop();
 	}
 
-	virtual void updateSampleRate()
+	void updateSampleRate() override
 	{
 		LocalZynAddSubFx::setSampleRate( sampleRate() );
 	}
 
-	virtual void updateBufferSize()
+	void updateBufferSize() override
 	{
 		LocalZynAddSubFx::setBufferSize( bufferSize() );
 	}
@@ -91,7 +91,7 @@ public:
 		m_guiExit = true;
 	}
 
-	virtual bool processMessage( const message & _m )
+	bool processMessage( const message & _m ) override
 	{
 		switch( _m.id )
 		{
@@ -133,13 +133,13 @@ public:
 	}
 
 	// all functions are called while m_master->mutex is held
-	virtual void processMidiEvent( const MidiEvent& event, const f_cnt_t /* _offset */ )
+	void processMidiEvent( const MidiEvent& event, const f_cnt_t /* _offset */ ) override
 	{
 		LocalZynAddSubFx::processMidiEvent( event );
 	}
 
 
-	virtual void process( const sampleFrame * _in, sampleFrame * _out )
+	void process( const sampleFrame * _in, sampleFrame * _out ) override
 	{
 		LocalZynAddSubFx::processAudio( _out );
 	}

--- a/src/core/PresetPreviewPlayHandle.cpp
+++ b/src/core/PresetPreviewPlayHandle.cpp
@@ -53,7 +53,7 @@ public:
 		m_previewInstrumentTrack->setPreviewMode( true );
 	}
 
-	virtual ~PreviewTrackContainer()
+	~PreviewTrackContainer() override
 	{
 	}
 

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -113,7 +113,7 @@ MixerView::MixerView() :
 		public:
 			ChannelArea( QWidget * parent, MixerView * mv ) :
 				QScrollArea( parent ), m_mv( mv ) {}
-			~ChannelArea() {}
+			~ChannelArea() override {}
 			void keyPressEvent( QKeyEvent * e ) override
 			{
 				m_mv->keyPressEvent( e );

--- a/src/gui/RowTableView.cpp
+++ b/src/gui/RowTableView.cpp
@@ -41,13 +41,13 @@ public:
 		m_table( table )
 		{
 		}
-	virtual void paint( QPainter * painter,
+	void paint( QPainter * painter,
 					const QStyleOptionViewItem & option,
 					const QModelIndex & index ) const override;
 
 
 protected:
-	virtual void initStyleOption( QStyleOptionViewItem * option,
+	void initStyleOption( QStyleOptionViewItem * option,
 					const QModelIndex & index ) const override;
 
 

--- a/src/gui/SideBar.cpp
+++ b/src/gui/SideBar.cpp
@@ -44,7 +44,7 @@ public:
 	{
 	}
 
-	virtual ~SideBarButton() = default;
+	~SideBarButton() override = default;
 
 	Qt::Orientation orientation() const
 	{

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -60,7 +60,7 @@ public:
 	}
 
 
-	virtual ~AutoDetectMidiController()
+	~AutoDetectMidiController() override
 	{
 	}
 

--- a/tests/QTestSuite.h
+++ b/tests/QTestSuite.h
@@ -10,7 +10,7 @@ class QTestSuite : public QObject
 	Q_OBJECT
 public:
 	explicit QTestSuite(QObject *parent = 0);
-	~QTestSuite();
+	~QTestSuite() override;
 
 	static QList<QTestSuite*> suites();
 


### PR DESCRIPTION
This declares all virtual functions in base classes `virtual` and all overriding functions in derived classes `override` instead of `virtual`, following C++ Core Guideline C.128 https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override. This also affects destructors.