### PR TITLE
Don't send effEditIdle on CLI rendering

### DIFF
--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2165,7 +2165,7 @@ void RemoteVstPlugin::idle()
 		return;
 	}
 	setProcessing( true );
-	if (!HEADLESS)
+	if (!HEADLESS && m_window)
 	{
 		pluginDispatch( effEditIdle );
 	}

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2165,7 +2165,10 @@ void RemoteVstPlugin::idle()
 		return;
 	}
 	setProcessing( true );
-	pluginDispatch( effEditIdle );
+	if (!HEADLESS)
+	{
+		pluginDispatch( effEditIdle );
+	}
 	setShouldGiveIdle( false );
 	setProcessing( false );
 	// We might have received a message whilst idling

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2216,7 +2216,10 @@ void RemoteVstPlugin::processUIThreadMessages()
 #endif
 		if( shouldGiveIdle() )
 		{
-			pluginDispatch( effEditIdle );
+			if (!HEADLESS && m_window)
+			{
+				pluginDispatch( effEditIdle );
+			}
 			setShouldGiveIdle( false );
 		}
 #ifdef NATIVE_LINUX_VST


### PR DESCRIPTION
This fixes Plugin-Alliance plugins crashing on CLI rendering, at least on Windows.

Most plugins seem to handle the cases correctly where `effEditIdle` is called without editor instantiation(`effEditOpen`), but PA plugins doesn't.

This PR fixes the issue by sending `effEditIdle` only the editor is created.