### PR TITLE
Add ``pull_request`` to check-strings github workflow

### DIFF
--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -1,6 +1,6 @@
 name: check-strings
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Adds ``pull_request`` in the ``on`` section of the ``check-strings`` GitHub workflow. Intends to fix an issue with check-strings failing on PRs.