### PR TITLE
clang-tidy: Apply modernize-redundant-void-arg everywhere.

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -64,7 +64,7 @@ public:
 	// the jack callback is handled here, we call the midi client so that it can read
 	// it's midi data during the callback
 	AudioJack * addMidiClient(MidiJack *midiClient);
-	void removeMidiClient(void) { m_midiClient = nullptr; }
+	void removeMidiClient() { m_midiClient = nullptr; }
 	jack_client_t * jackClient() {return m_client;};
 
 	inline static QString name()

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -54,7 +54,7 @@ public:
 	AudioSndio( bool & _success_ful, AudioEngine * _audioEngine );
 	~AudioSndio() override;
 
-	inline static QString name( void )
+	inline static QString name( )
 	{
 		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "sndio" );
 	}
@@ -65,7 +65,7 @@ public:
 		setupWidget( QWidget * _parent );
 		~setupWidget() override;
 
-		void saveSettings( void ) override;
+		void saveSettings( ) override;
 
 	private:
 		QLineEdit * m_device;
@@ -73,10 +73,10 @@ public:
 	} ;
 
 private:
-	void startProcessing( void ) override;
-	void stopProcessing( void ) override;
-	void applyQualitySettings( void ) override;
-	void run( void ) override;
+	void startProcessing( ) override;
+	void stopProcessing( ) override;
+	void applyQualitySettings( ) override;
+	void run( ) override;
 
 	struct sio_hdl *m_hdl;
 	struct sio_par m_par;

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -54,7 +54,7 @@ public:
 	AudioSndio( bool & _success_ful, AudioEngine * _audioEngine );
 	~AudioSndio() override;
 
-	inline static QString name( )
+	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "sndio" );
 	}
@@ -65,7 +65,7 @@ public:
 		setupWidget( QWidget * _parent );
 		~setupWidget() override;
 
-		void saveSettings( ) override;
+		void saveSettings() override;
 
 	private:
 		QLineEdit * m_device;
@@ -73,10 +73,10 @@ public:
 	} ;
 
 private:
-	void startProcessing( ) override;
-	void stopProcessing( ) override;
-	void applyQualitySettings( ) override;
-	void run( ) override;
+	void startProcessing() override;
+	void stopProcessing() override;
+	void applyQualitySettings() override;
+	void run() override;
 
 	struct sio_hdl *m_hdl;
 	struct sio_par m_par;

--- a/include/DrumSynth.h
+++ b/include/DrumSynth.h
@@ -41,8 +41,8 @@ class DrumSynth {
         int GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs);
 
     private:
-        float LoudestEnv(void);
-        int   LongestEnv(void);
+        float LoudestEnv();
+        int   LongestEnv();
         void  UpdateEnv(int e, long t);
         void  GetEnv(int env, const char *sec, const char *key, QString ini);
 

--- a/include/ExportProjectDialog.h
+++ b/include/ExportProjectDialog.h
@@ -45,12 +45,12 @@ public:
 	ExportProjectDialog( const QString & _file_name, QWidget * _parent, bool multi_export );
 
 protected:
-	void reject( ) override;
+	void reject() override;
 	void closeEvent( QCloseEvent * _ce ) override;
 
 
 private slots:
-	void startBtnClicked( );
+	void startBtnClicked();
 	void updateTitleBar( int );
 	void accept() override;
 	void startExport();

--- a/include/ExportProjectDialog.h
+++ b/include/ExportProjectDialog.h
@@ -45,12 +45,12 @@ public:
 	ExportProjectDialog( const QString & _file_name, QWidget * _parent, bool multi_export );
 
 protected:
-	void reject( void ) override;
+	void reject( ) override;
 	void closeEvent( QCloseEvent * _ce ) override;
 
 
 private slots:
-	void startBtnClicked( void );
+	void startBtnClicked( );
 	void updateTitleBar( int );
 	void accept() override;
 	void startExport();

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -71,7 +71,7 @@ public:
 	~FileBrowser() override = default;
 
 private slots:
-	void reloadTree( void );
+	void reloadTree( );
 	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );
 	// call with item=NULL to filter the entire tree
 	bool filterItems( const QString & filter, QTreeWidgetItem * item=nullptr );
@@ -164,7 +164,7 @@ public:
 	Directory( const QString & filename, const QString & path,
 						const QString & filter );
 
-	void update( void );
+	void update( );
 
 	inline QString fullName( QString path = QString() )
 	{
@@ -187,7 +187,7 @@ public:
 
 
 private:
-	void initPixmaps( void );
+	void initPixmaps( );
 
 	bool addItems( const QString & path );
 
@@ -248,28 +248,28 @@ public:
 		return QFileInfo(m_path, text(0)).absoluteFilePath();
 	}
 
-	inline FileTypes type( void ) const
+	inline FileTypes type( ) const
 	{
 		return( m_type );
 	}
 
-	inline FileHandling handling( void ) const
+	inline FileHandling handling( ) const
 	{
 		return( m_handling );
 	}
 
-	inline bool isTrack( void ) const
+	inline bool isTrack( ) const
 	{
 		return m_handling == LoadAsPreset || m_handling == LoadByPlugin;
 	}
 
-	QString extension( void );
+	QString extension( );
 	static QString extension( const QString & file );
 
 
 private:
-	void initPixmaps( void );
-	void determineFileType( void );
+	void initPixmaps( );
+	void determineFileType( );
 
 	static QPixmap * s_projectFilePixmap;
 	static QPixmap * s_presetFilePixmap;

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -71,7 +71,7 @@ public:
 	~FileBrowser() override = default;
 
 private slots:
-	void reloadTree( );
+	void reloadTree();
 	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );
 	// call with item=NULL to filter the entire tree
 	bool filterItems( const QString & filter, QTreeWidgetItem * item=nullptr );
@@ -164,7 +164,7 @@ public:
 	Directory( const QString & filename, const QString & path,
 						const QString & filter );
 
-	void update( );
+	void update();
 
 	inline QString fullName( QString path = QString() )
 	{
@@ -187,7 +187,7 @@ public:
 
 
 private:
-	void initPixmaps( );
+	void initPixmaps();
 
 	bool addItems( const QString & path );
 
@@ -248,28 +248,28 @@ public:
 		return QFileInfo(m_path, text(0)).absoluteFilePath();
 	}
 
-	inline FileTypes type( ) const
+	inline FileTypes type() const
 	{
 		return( m_type );
 	}
 
-	inline FileHandling handling( ) const
+	inline FileHandling handling() const
 	{
 		return( m_handling );
 	}
 
-	inline bool isTrack( ) const
+	inline bool isTrack() const
 	{
 		return m_handling == LoadAsPreset || m_handling == LoadByPlugin;
 	}
 
-	QString extension( );
+	QString extension();
 	static QString extension( const QString & file );
 
 
 private:
-	void initPixmaps( );
-	void determineFileType( );
+	void initPixmaps();
+	void determineFileType();
 
 	static QPixmap * s_projectFilePixmap;
 	static QPixmap * s_presetFilePixmap;

--- a/include/Graph.h
+++ b/include/Graph.h
@@ -197,7 +197,7 @@ public slots:
 	void setWaveToSaw();
 	void setWaveToSquare();
 	void setWaveToNoise();
-	QString setWaveToUser( );
+	QString setWaveToUser();
 
 	void smooth();
 	void smoothNonCyclic();

--- a/include/LmmsStyle.h
+++ b/include/LmmsStyle.h
@@ -70,7 +70,7 @@ public:
 	{
 	}
 
-	QPalette standardPalette( void ) const override;
+	QPalette standardPalette( ) const override;
 
 	void drawComplexControl(
 				ComplexControl control,

--- a/include/LmmsStyle.h
+++ b/include/LmmsStyle.h
@@ -70,7 +70,7 @@ public:
 	{
 	}
 
-	QPalette standardPalette( ) const override;
+	QPalette standardPalette() const override;
 
 	void drawComplexControl(
 				ComplexControl control,

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -242,7 +242,7 @@ private:
 private slots:
 	void browseHelp();
 	void showTool( QAction * _idx );
-	void updateViewMenu( void );
+	void updateViewMenu( );
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
 	void onExportProject();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -242,7 +242,7 @@ private:
 private slots:
 	void browseHelp();
 	void showTool( QAction * _idx );
-	void updateViewMenu( );
+	void updateViewMenu();
 	void updateConfig( QAction * _who );
 	void onToggleMetronome();
 	void onExportProject();

--- a/include/MidiSndio.h
+++ b/include/MidiSndio.h
@@ -45,12 +45,12 @@ class MidiSndio : public QThread, public MidiClientRaw
 {
 	Q_OBJECT
 public:
-	MidiSndio( void );
+	MidiSndio( );
 	~MidiSndio() override;
 
-	static QString probeDevice(void);
+	static QString probeDevice();
 
-	inline static QString name(void)
+	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP("MidiSetupWidget", "sndio MIDI");
 	}
@@ -63,7 +63,7 @@ public:
 
 protected:
 	void sendByte(const unsigned char c) override;
-	void run(void) override;
+	void run() override;
 
 private:
 	mio_hdl *m_hdl;

--- a/include/MidiSndio.h
+++ b/include/MidiSndio.h
@@ -45,7 +45,7 @@ class MidiSndio : public QThread, public MidiClientRaw
 {
 	Q_OBJECT
 public:
-	MidiSndio( );
+	MidiSndio();
 	~MidiSndio() override;
 
 	static QString probeDevice();

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -61,7 +61,7 @@ public:
 
 public slots:
 	gui::ControllerDialog * createDialog( QWidget * _parent ) override;
-	void handleDestroyedEffect( );
+	void handleDestroyedEffect();
 	void updateCoeffs();
 
 protected:

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -253,7 +253,7 @@ public:
 	const PixmapLoader *logo() const;
 
 	//! Return plugin type
-	inline PluginTypes type( void ) const
+	inline PluginTypes type( ) const
 	{
 		return m_descriptor->type;
 	}

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -253,7 +253,7 @@ public:
 	const PixmapLoader *logo() const;
 
 	//! Return plugin type
-	inline PluginTypes type( ) const
+	inline PluginTypes type() const
 	{
 		return m_descriptor->type;
 	}

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -289,7 +289,7 @@ void AudioFileProcessor::loadFile( const QString & _file )
 
 
 
-QString AudioFileProcessor::nodeName( ) const
+QString AudioFileProcessor::nodeName() const
 {
 	return audiofileprocessor_plugin_descriptor.name;
 }
@@ -339,7 +339,7 @@ void AudioFileProcessor::setAudioFile( const QString & _audio_file,
 
 
 
-void AudioFileProcessor::reverseModelChanged( )
+void AudioFileProcessor::reverseModelChanged()
 {
 	m_sampleBuffer.setReversed( m_reverseModel.value() );
 	m_nextPlayStartPoint = m_sampleBuffer.startFrame();
@@ -349,7 +349,7 @@ void AudioFileProcessor::reverseModelChanged( )
 
 
 
-void AudioFileProcessor::ampModelChanged( )
+void AudioFileProcessor::ampModelChanged()
 {
 	m_sampleBuffer.setAmplification( m_ampModel.value() / 100.0f );
 }
@@ -362,7 +362,7 @@ void AudioFileProcessor::stutterModelChanged()
 }
 
 
-void AudioFileProcessor::startPointChanged( )
+void AudioFileProcessor::startPointChanged()
 {
 	// check if start is over end and swap values if so
 	if( m_startPointModel.value() > m_endPointModel.value() )
@@ -394,14 +394,14 @@ void AudioFileProcessor::startPointChanged( )
 
 }
 
-void AudioFileProcessor::endPointChanged( )
+void AudioFileProcessor::endPointChanged()
 {
 	// same as start, for now
 	startPointChanged();
 
 }
 
-void AudioFileProcessor::loopPointChanged( )
+void AudioFileProcessor::loopPointChanged()
 {
 
 	// check that loop point is between start-end points and not overlapping with endpoint
@@ -424,7 +424,7 @@ void AudioFileProcessor::loopPointChanged( )
 	pointChanged();
 }
 
-void AudioFileProcessor::pointChanged( )
+void AudioFileProcessor::pointChanged()
 {
 	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	( m_sampleBuffer.frames()-1 ) );
 	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * ( m_sampleBuffer.frames()-1 ) );
@@ -677,7 +677,7 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 
 
-void AudioFileProcessorView::sampleUpdated( )
+void AudioFileProcessorView::sampleUpdated()
 {
 	m_waveView->updateSampleRange();
 	m_waveView->update();
@@ -688,7 +688,7 @@ void AudioFileProcessorView::sampleUpdated( )
 
 
 
-void AudioFileProcessorView::openAudioFile( )
+void AudioFileProcessorView::openAudioFile()
 {
 	QString af = castModel<AudioFileProcessor>()->m_sampleBuffer.
 							openAudioFile();
@@ -703,7 +703,7 @@ void AudioFileProcessorView::openAudioFile( )
 
 
 
-void AudioFileProcessorView::modelChanged( )
+void AudioFileProcessorView::modelChanged()
 {
 	AudioFileProcessor * a = castModel<AudioFileProcessor>();
 	connect( &a->m_sampleBuffer, SIGNAL( sampleUpdated() ),

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -289,7 +289,7 @@ void AudioFileProcessor::loadFile( const QString & _file )
 
 
 
-QString AudioFileProcessor::nodeName( void ) const
+QString AudioFileProcessor::nodeName( ) const
 {
 	return audiofileprocessor_plugin_descriptor.name;
 }
@@ -339,7 +339,7 @@ void AudioFileProcessor::setAudioFile( const QString & _audio_file,
 
 
 
-void AudioFileProcessor::reverseModelChanged( void )
+void AudioFileProcessor::reverseModelChanged( )
 {
 	m_sampleBuffer.setReversed( m_reverseModel.value() );
 	m_nextPlayStartPoint = m_sampleBuffer.startFrame();
@@ -349,7 +349,7 @@ void AudioFileProcessor::reverseModelChanged( void )
 
 
 
-void AudioFileProcessor::ampModelChanged( void )
+void AudioFileProcessor::ampModelChanged( )
 {
 	m_sampleBuffer.setAmplification( m_ampModel.value() / 100.0f );
 }
@@ -362,7 +362,7 @@ void AudioFileProcessor::stutterModelChanged()
 }
 
 
-void AudioFileProcessor::startPointChanged( void )
+void AudioFileProcessor::startPointChanged( )
 {
 	// check if start is over end and swap values if so
 	if( m_startPointModel.value() > m_endPointModel.value() )
@@ -394,14 +394,14 @@ void AudioFileProcessor::startPointChanged( void )
 
 }
 
-void AudioFileProcessor::endPointChanged( void )
+void AudioFileProcessor::endPointChanged( )
 {
 	// same as start, for now
 	startPointChanged();
 
 }
 
-void AudioFileProcessor::loopPointChanged( void )
+void AudioFileProcessor::loopPointChanged( )
 {
 
 	// check that loop point is between start-end points and not overlapping with endpoint
@@ -424,7 +424,7 @@ void AudioFileProcessor::loopPointChanged( void )
 	pointChanged();
 }
 
-void AudioFileProcessor::pointChanged( void )
+void AudioFileProcessor::pointChanged( )
 {
 	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	( m_sampleBuffer.frames()-1 ) );
 	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * ( m_sampleBuffer.frames()-1 ) );
@@ -677,7 +677,7 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 
 
-void AudioFileProcessorView::sampleUpdated( void )
+void AudioFileProcessorView::sampleUpdated( )
 {
 	m_waveView->updateSampleRange();
 	m_waveView->update();
@@ -688,7 +688,7 @@ void AudioFileProcessorView::sampleUpdated( void )
 
 
 
-void AudioFileProcessorView::openAudioFile( void )
+void AudioFileProcessorView::openAudioFile( )
 {
 	QString af = castModel<AudioFileProcessor>()->m_sampleBuffer.
 							openAudioFile();
@@ -703,7 +703,7 @@ void AudioFileProcessorView::openAudioFile( void )
 
 
 
-void AudioFileProcessorView::modelChanged( void )
+void AudioFileProcessorView::modelChanged( )
 {
 	AudioFileProcessor * a = castModel<AudioFileProcessor>();
 	connect( &a->m_sampleBuffer, SIGNAL( sampleUpdated() ),

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -161,8 +161,8 @@ BitInvader::BitInvader( InstrumentTrack * _instrument_track ) :
 	m_graph.setWaveToSine();
 	lengthChanged();
 
-	connect( &m_sampleLength, SIGNAL( dataChanged( ) ),
-			this, SLOT( lengthChanged( ) ), Qt::DirectConnection );
+	connect( &m_sampleLength, SIGNAL( dataChanged() ),
+			this, SLOT( lengthChanged() ), Qt::DirectConnection );
 
 	connect( &m_graph, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( samplesChanged( int, int ) ) );

--- a/plugins/BitInvader/BitInvader.h
+++ b/plugins/BitInvader/BitInvader.h
@@ -139,7 +139,7 @@ protected slots:
 	void noiseWaveClicked();
 	void usrWaveClicked();
 	
-	void smoothClicked( void  );
+	void smoothClicked(  );
 
 private:
 	void modelChanged() override;

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -193,7 +193,7 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 	setAttribute( Qt::WA_TranslucentBackground, true );
 	m_skipBands = MAX_BANDS * 0.5;
 	float totalLength = log10( 20000 );
-	m_pixelsPerUnitWidth = width( ) / totalLength ;
+	m_pixelsPerUnitWidth = width() / totalLength ;
 	m_scale = 1.5;
 	m_color = QColor( 255, 255, 255, 255 );
 	for ( int i = 0 ; i < MAX_BANDS ; i++ )

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -293,26 +293,26 @@ Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
 	vca_mode(never_played)
 {
 
-	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged( ) ),
-	         this, SLOT ( filterChanged( ) ) );
+	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ),
+	         this, SLOT ( filterChanged() ) );
 
-	connect( &vcf_cut_knob, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( filterChanged( ) ) );
+	connect( &vcf_cut_knob, SIGNAL( dataChanged() ),
+	         this, SLOT ( filterChanged() ) );
 
-	connect( &vcf_res_knob, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( filterChanged( ) ) );
+	connect( &vcf_res_knob, SIGNAL( dataChanged() ),
+	         this, SLOT ( filterChanged() ) );
 
-	connect( &vcf_mod_knob, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( filterChanged( ) ) );
+	connect( &vcf_mod_knob, SIGNAL( dataChanged() ),
+	         this, SLOT ( filterChanged() ) );
 
-	connect( &vcf_dec_knob, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( filterChanged( ) ) );
+	connect( &vcf_dec_knob, SIGNAL( dataChanged() ),
+	         this, SLOT ( filterChanged() ) );
 
-	connect( &db24Toggle, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( db24Toggled( ) ) );
+	connect( &db24Toggle, SIGNAL( dataChanged() ),
+	         this, SLOT ( db24Toggled() ) );
 
-	connect( &dist_knob, SIGNAL( dataChanged( ) ),
-	         this, SLOT ( filterChanged( )));
+	connect( &dist_knob, SIGNAL( dataChanged() ),
+	         this, SLOT ( filterChanged()));
 
 
 	// SYNTH

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -251,7 +251,7 @@ void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 	// For mimeType() and MimeType enum class
 	using namespace Clipboard;
 
-	void (QDragEnterEvent::*reaction)(void) = &QDragEnterEvent::ignore;
+	void (QDragEnterEvent::*reaction)() = &QDragEnterEvent::ignore;
 
 	if (_dee->mimeData()->hasFormat( mimeType( MimeType::StringPair )))
 	{

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -56,7 +56,7 @@ private:
 	bool readRIFF( TrackContainer* tc );
 	bool readTrack( int _track_end, QString & _track_name );
 
-	void error( );
+	void error();
 
 
 	inline int readInt( int _bytes )

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -56,7 +56,7 @@ private:
 	bool readRIFF( TrackContainer* tc );
 	bool readTrack( int _track_end, QString & _track_name );
 
-	void error( void );
+	void error( );
 
 
 	inline int readInt( int _bytes )

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -125,7 +125,7 @@ void PatmanInstrument::loadFile( const QString & _file )
 
 
 
-QString PatmanInstrument::nodeName( void ) const
+QString PatmanInstrument::nodeName( ) const
 {
 	return( patman_plugin_descriptor.name );
 }
@@ -380,7 +380,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 
 
 
-void PatmanInstrument::unloadCurrentPatch( void )
+void PatmanInstrument::unloadCurrentPatch( )
 {
 	while( !m_patchSamples.empty() )
 	{
@@ -502,7 +502,7 @@ PatmanView::~PatmanView()
 
 
 
-void PatmanView::openFile( void )
+void PatmanView::openFile( )
 {
 	FileDialog ofd( nullptr, tr( "Open patch file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -554,7 +554,7 @@ void PatmanView::openFile( void )
 
 
 
-void PatmanView::updateFilename( void )
+void PatmanView::updateFilename( )
 {
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
@@ -638,7 +638,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 
 
 
-void PatmanView::modelChanged( void )
+void PatmanView::modelChanged( )
 {
 	m_pi = castModel<PatmanInstrument>();
 	m_loopButton->setModel( &m_pi->m_loopedModel );

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -125,7 +125,7 @@ void PatmanInstrument::loadFile( const QString & _file )
 
 
 
-QString PatmanInstrument::nodeName( ) const
+QString PatmanInstrument::nodeName() const
 {
 	return( patman_plugin_descriptor.name );
 }
@@ -380,7 +380,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 
 
 
-void PatmanInstrument::unloadCurrentPatch( )
+void PatmanInstrument::unloadCurrentPatch()
 {
 	while( !m_patchSamples.empty() )
 	{
@@ -502,7 +502,7 @@ PatmanView::~PatmanView()
 
 
 
-void PatmanView::openFile( )
+void PatmanView::openFile()
 {
 	FileDialog ofd( nullptr, tr( "Open patch file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -554,7 +554,7 @@ void PatmanView::openFile( )
 
 
 
-void PatmanView::updateFilename( )
+void PatmanView::updateFilename()
 {
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
@@ -638,7 +638,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 
 
 
-void PatmanView::modelChanged( )
+void PatmanView::modelChanged()
 {
 	m_pi = castModel<PatmanInstrument>();
 	m_loopButton->setModel( &m_pi->m_loopedModel );

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -69,9 +69,9 @@ public:
 
 	void loadFile( const QString & _file ) override;
 
-	QString nodeName( ) const override;
+	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames( ) const override
+	f_cnt_t desiredReleaseFrames() const override
 	{
 		return( 128 );
 	}
@@ -109,7 +109,7 @@ private:
 	} ;
 
 	LoadErrors loadPatch( const QString & _filename );
-	void unloadCurrentPatch( );
+	void unloadCurrentPatch();
 
 	void selectSample( NotePlayHandle * _n );
 
@@ -117,7 +117,7 @@ private:
 	friend class gui::PatmanView;
 
 signals:
-	void fileChanged( );
+	void fileChanged();
 
 } ;
 
@@ -135,8 +135,8 @@ public:
 
 
 public slots:
-	void openFile( );
-	void updateFilename( );
+	void openFile();
+	void updateFilename();
 
 
 protected:
@@ -146,7 +146,7 @@ protected:
 
 
 private:
-	void modelChanged( ) override;
+	void modelChanged() override;
 
 	PatmanInstrument * m_pi;
 	QString m_displayFilename;

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -69,9 +69,9 @@ public:
 
 	void loadFile( const QString & _file ) override;
 
-	QString nodeName( void ) const override;
+	QString nodeName( ) const override;
 
-	f_cnt_t desiredReleaseFrames( void ) const override
+	f_cnt_t desiredReleaseFrames( ) const override
 	{
 		return( 128 );
 	}
@@ -109,7 +109,7 @@ private:
 	} ;
 
 	LoadErrors loadPatch( const QString & _filename );
-	void unloadCurrentPatch( void );
+	void unloadCurrentPatch( );
 
 	void selectSample( NotePlayHandle * _n );
 
@@ -117,7 +117,7 @@ private:
 	friend class gui::PatmanView;
 
 signals:
-	void fileChanged( void );
+	void fileChanged( );
 
 } ;
 
@@ -135,8 +135,8 @@ public:
 
 
 public slots:
-	void openFile( void );
-	void updateFilename( void );
+	void openFile( );
+	void updateFilename( );
 
 
 protected:
@@ -146,7 +146,7 @@ protected:
 
 
 private:
-	void modelChanged( void ) override;
+	void modelChanged( ) override;
 
 	PatmanInstrument * m_pi;
 	QString m_displayFilename;

--- a/plugins/Sf2Player/PatchesDialog.cpp
+++ b/plugins/Sf2Player/PatchesDialog.cpp
@@ -264,7 +264,7 @@ void PatchesDialog::accept()
 
 
 // Reject settings (Cancel button slot).
-void PatchesDialog::reject (void)
+void PatchesDialog::reject ()
 {
 	// Reset selection to initial selection, if applicable...
 	if (m_dirty > 0)
@@ -306,7 +306,7 @@ QTreeWidgetItem *PatchesDialog::findProgItem ( int iProg )
 
 
 // Bank change slot.
-void PatchesDialog::bankChanged (void)
+void PatchesDialog::bankChanged ()
 {
 	if (m_pSynth == nullptr)
 		return;

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -741,7 +741,7 @@ void VestigeInstrumentView::openPreset()
 {
 
 	if ( m_vi->m_plugin != nullptr ) {
-		m_vi->m_plugin->openPreset( );
+		m_vi->m_plugin->openPreset();
     		bool converted;
     		QString str = m_vi->m_plugin->currentProgramName().section("/", 0, 0);
      		if (str != "")

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -759,7 +759,7 @@ void VestigeInstrumentView::savePreset()
 
 	if ( m_vi->m_plugin != nullptr )
 	{
-		m_vi->m_plugin->savePreset( );
+		m_vi->m_plugin->savePreset();
 /*    		bool converted;
     		QString str = m_vi->m_plugin->presetString().section("/", 0, 0);
      		if (str != "")

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -117,8 +117,8 @@ public:
 
 
 protected slots:
-	void syncPlugin( );
-	void displayAutomatedOnly( );
+	void syncPlugin();
+	void displayAutomatedOnly();
 	void setParameter( lmms::Model * action );
 	void syncParameterText();
 	void closeWindow();
@@ -154,16 +154,16 @@ public:
 
 
 protected slots:
-	void updateMenu( );
-	void openPlugin( );
-	void managePlugin( );
-	void openPreset( );
-	void savePreset( );
+	void updateMenu();
+	void openPlugin();
+	void managePlugin();
+	void openPreset();
+	void savePreset();
 	void nextProgram();
 	void previousProgram();
-	void selPreset( );
-	void toggleGUI( );
-	void noteOffAll( );
+	void selPreset();
+	void toggleGUI();
+	void noteOffAll();
 
 
 protected:
@@ -173,7 +173,7 @@ protected:
 
 
 private:
-	virtual void modelChanged( );
+	virtual void modelChanged();
 
 	static QPixmap * s_artwork;
 

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -66,7 +66,7 @@ public:
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
 	virtual void loadSettings( const QDomElement & _this );
 
-	virtual QString nodeName( void ) const;
+	virtual QString nodeName( ) const;
 
 	virtual void loadFile( const QString & _file );
 
@@ -85,7 +85,7 @@ protected slots:
 	void reloadPlugin();
 
 private:
-	void closePlugin( void );
+	void closePlugin( );
 
 
 	VstPlugin * m_plugin;
@@ -117,8 +117,8 @@ public:
 
 
 protected slots:
-	void syncPlugin( void );
-	void displayAutomatedOnly( void );
+	void syncPlugin( );
+	void displayAutomatedOnly( );
 	void setParameter( lmms::Model * action );
 	void syncParameterText();
 	void closeWindow();
@@ -154,16 +154,16 @@ public:
 
 
 protected slots:
-	void updateMenu( void );
-	void openPlugin( void );
-	void managePlugin( void );
-	void openPreset( void );
-	void savePreset( void );
+	void updateMenu( );
+	void openPlugin( );
+	void managePlugin( );
+	void openPreset( );
+	void savePreset( );
 	void nextProgram();
 	void previousProgram();
-	void selPreset( void );
-	void toggleGUI( void );
-	void noteOffAll( void );
+	void selPreset( );
+	void toggleGUI( );
+	void noteOffAll( );
 
 
 protected:
@@ -173,7 +173,7 @@ protected:
 
 
 private:
-	virtual void modelChanged( void );
+	virtual void modelChanged( );
 
 	static QPixmap * s_artwork;
 

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -66,7 +66,7 @@ public:
 	virtual void saveSettings( QDomDocument & _doc, QDomElement & _parent );
 	virtual void loadSettings( const QDomElement & _this );
 
-	virtual QString nodeName( ) const;
+	virtual QString nodeName() const;
 
 	virtual void loadFile( const QString & _file );
 
@@ -85,7 +85,7 @@ protected slots:
 	void reloadPlugin();
 
 private:
-	void closePlugin( );
+	void closePlugin();
 
 
 	VstPlugin * m_plugin;

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -492,7 +492,7 @@ VibedView::VibedView( Instrument * _instrument,
 	m_triangleWaveBtn->setToolTip(
 			tr( "Triangle wave" ) );
 	connect( m_triangleWaveBtn, SIGNAL ( clicked () ),
-			this, SLOT ( triangleWaveClicked( ) ) );
+			this, SLOT ( triangleWaveClicked() ) );
 
 	
 	m_sawWaveBtn = new PixmapButton( this, tr( "Saw wave" ) );

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -505,7 +505,7 @@ QWidget *VstPlugin::editor()
 }
 
 
-void VstPlugin::openPreset( )
+void VstPlugin::openPreset()
 {
 
 	gui::FileDialog ofd( nullptr, tr( "Open Preset" ), "",
@@ -583,7 +583,7 @@ void VstPlugin::loadParameterDisplays()
 
 
 
-void VstPlugin::savePreset( )
+void VstPlugin::savePreset()
 {
 	QString presName = currentProgramName().isEmpty() ? tr(": default") : currentProgramName();
 	presName.replace("\"", "'"); // QFileDialog unable to handle double quotes properly

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -126,13 +126,13 @@ public:
 public slots:
 	void setTempo( lmms::bpm_t _bpm );
 	void updateSampleRate();
-	void openPreset( );
+	void openPreset();
 	void setProgram( int index );
 	void rotateProgram( int offset );
 	void loadProgramNames();
 	void loadParameterLabels();
 	void loadParameterDisplays();
-	void savePreset( );
+	void savePreset();
 	void setParam( int i, float f );
 	void idleUpdate();
 

--- a/plugins/VstBase/VstPlugin.h
+++ b/plugins/VstBase/VstPlugin.h
@@ -126,13 +126,13 @@ public:
 public slots:
 	void setTempo( lmms::bpm_t _bpm );
 	void updateSampleRate();
-	void openPreset( void );
+	void openPreset( );
 	void setProgram( int index );
 	void rotateProgram( int offset );
 	void loadProgramNames();
 	void loadParameterLabels();
 	void loadParameterDisplays();
-	void savePreset( void );
+	void savePreset( );
 	void setParam( int i, float f );
 	void idleUpdate();
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -167,7 +167,7 @@ gui::EffectControlDialog* VstEffectControls::createView()
 
 
 
-void VstEffectControls::managePlugin( )
+void VstEffectControls::managePlugin()
 {
 	if ( m_effect->m_plugin != nullptr && m_subWindow == nullptr ) {
 		gui::ManageVSTEffectView * tt = new gui::ManageVSTEffectView( m_effect, this);
@@ -187,11 +187,11 @@ void VstEffectControls::managePlugin( )
 
 
 
-void VstEffectControls::savePreset( )
+void VstEffectControls::savePreset()
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
-		m_effect->m_plugin->savePreset( );
+		m_effect->m_plugin->savePreset();
 /*    		bool converted;
     		QString str = m_vi->m_plugin->currentProgramName().section("/", 0, 0);
      		if (str != "")
@@ -204,7 +204,7 @@ void VstEffectControls::savePreset( )
 
 
 
-void VstEffectControls::updateMenu( )
+void VstEffectControls::updateMenu()
 {
 
 	// get all presets -
@@ -239,11 +239,11 @@ void VstEffectControls::updateMenu( )
 
 
 
-void VstEffectControls::openPreset( )
+void VstEffectControls::openPreset()
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
-		m_effect->m_plugin->openPreset( );
+		m_effect->m_plugin->openPreset();
     		bool converted;
     		QString str = m_effect->m_plugin->currentProgramName().section("/", 0, 0);
      		if (str != "")
@@ -256,7 +256,7 @@ void VstEffectControls::openPreset( )
 
 
 
-void VstEffectControls::rollPreset( )
+void VstEffectControls::rollPreset()
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -272,7 +272,7 @@ void VstEffectControls::rollPreset( )
 
 
 
-void VstEffectControls::rolrPreset( )
+void VstEffectControls::rolrPreset()
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -288,7 +288,7 @@ void VstEffectControls::rolrPreset( )
 
 
 
-void VstEffectControls::selPreset( )
+void VstEffectControls::selPreset()
 {
 
      QAction *action = qobject_cast<QAction *>(sender());
@@ -438,7 +438,7 @@ void ManageVSTEffectView::closeWindow()
 
 
 
-void ManageVSTEffectView::syncPlugin( )
+void ManageVSTEffectView::syncPlugin()
 {
 	char paramStr[35];
 	QStringList s_dumpValues;
@@ -464,7 +464,7 @@ void ManageVSTEffectView::syncPlugin( )
 
 
 
-void ManageVSTEffectView::displayAutomatedOnly( )
+void ManageVSTEffectView::displayAutomatedOnly()
 {
 	bool isAuto = QString::compare( m_displayAutomatedOnly->text(), tr( "Automated" ) ) == 0;
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -167,7 +167,7 @@ gui::EffectControlDialog* VstEffectControls::createView()
 
 
 
-void VstEffectControls::managePlugin( void )
+void VstEffectControls::managePlugin( )
 {
 	if ( m_effect->m_plugin != nullptr && m_subWindow == nullptr ) {
 		gui::ManageVSTEffectView * tt = new gui::ManageVSTEffectView( m_effect, this);
@@ -187,7 +187,7 @@ void VstEffectControls::managePlugin( void )
 
 
 
-void VstEffectControls::savePreset( void )
+void VstEffectControls::savePreset( )
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -204,7 +204,7 @@ void VstEffectControls::savePreset( void )
 
 
 
-void VstEffectControls::updateMenu( void )
+void VstEffectControls::updateMenu( )
 {
 
 	// get all presets -
@@ -239,7 +239,7 @@ void VstEffectControls::updateMenu( void )
 
 
 
-void VstEffectControls::openPreset( void )
+void VstEffectControls::openPreset( )
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -256,7 +256,7 @@ void VstEffectControls::openPreset( void )
 
 
 
-void VstEffectControls::rollPreset( void )
+void VstEffectControls::rollPreset( )
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -272,7 +272,7 @@ void VstEffectControls::rollPreset( void )
 
 
 
-void VstEffectControls::rolrPreset( void )
+void VstEffectControls::rolrPreset( )
 {
 
 	if ( m_effect->m_plugin != nullptr ) {
@@ -288,7 +288,7 @@ void VstEffectControls::rolrPreset( void )
 
 
 
-void VstEffectControls::selPreset( void )
+void VstEffectControls::selPreset( )
 {
 
      QAction *action = qobject_cast<QAction *>(sender());
@@ -438,7 +438,7 @@ void ManageVSTEffectView::closeWindow()
 
 
 
-void ManageVSTEffectView::syncPlugin( void )
+void ManageVSTEffectView::syncPlugin( )
 {
 	char paramStr[35];
 	QStringList s_dumpValues;
@@ -464,7 +464,7 @@ void ManageVSTEffectView::syncPlugin( void )
 
 
 
-void ManageVSTEffectView::displayAutomatedOnly( void )
+void ManageVSTEffectView::displayAutomatedOnly( )
 {
 	bool isAuto = QString::compare( m_displayAutomatedOnly->text(), tr( "Automated" ) ) == 0;
 

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -70,13 +70,13 @@ public:
 
 
 protected slots:
-	void updateMenu( );
-	void managePlugin( );
-	void openPreset( );
-	void savePreset( );
-	void rollPreset( );
-	void rolrPreset( );
-	void selPreset( );
+	void updateMenu();
+	void managePlugin();
+	void openPreset();
+	void savePreset();
+	void rollPreset();
+	void rolrPreset();
+	void selPreset();
 	void setParameter( lmms::Model * action );
 
 protected:
@@ -117,8 +117,8 @@ public:
 
 
 protected slots:
-	void syncPlugin( );
-	void displayAutomatedOnly( );
+	void syncPlugin();
+	void displayAutomatedOnly();
 	void setParameter( lmms::Model * action );
 	void syncParameterText();
 	void closeWindow();

--- a/plugins/VstEffect/VstEffectControls.h
+++ b/plugins/VstEffect/VstEffectControls.h
@@ -70,13 +70,13 @@ public:
 
 
 protected slots:
-	void updateMenu( void );
-	void managePlugin( void );
-	void openPreset( void );
-	void savePreset( void );
-	void rollPreset( void );
-	void rolrPreset( void );
-	void selPreset( void );
+	void updateMenu( );
+	void managePlugin( );
+	void openPreset( );
+	void savePreset( );
+	void rollPreset( );
+	void rolrPreset( );
+	void selPreset( );
 	void setParameter( lmms::Model * action );
 
 protected:
@@ -117,8 +117,8 @@ public:
 
 
 protected slots:
-	void syncPlugin( void );
-	void displayAutomatedOnly( void );
+	void syncPlugin( );
+	void displayAutomatedOnly( );
 	void setParameter( lmms::Model * action );
 	void syncParameterText();
 	void closeWindow();

--- a/plugins/Xpressive/Xpressive.h
+++ b/plugins/Xpressive/Xpressive.h
@@ -171,9 +171,9 @@ protected slots:
 	void expWaveClicked();
 	void usrWaveClicked();
 	void helpClicked();
-	void expressionChanged( );
-	void smoothChanged( );
-	void graphDrawn( );
+	void expressionChanged();
+	void smoothChanged();
+	void graphDrawn();
 
 private:
 	void modelChanged() override;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -67,7 +67,7 @@ long  wavewords, wavemode=0;
 float mem_t=1.0f, mem_o=1.0f, mem_n=1.0f, mem_b=1.0f, mem_tune=1.0f, mem_time=1.0f;
 
 
-int DrumSynth::LongestEnv(void)
+int DrumSynth::LongestEnv()
 {
   long e, eon, p;
   float l=0.f;
@@ -86,7 +86,7 @@ int DrumSynth::LongestEnv(void)
 }
 
 
-float DrumSynth::LoudestEnv(void)
+float DrumSynth::LoudestEnv()
 {
   float loudest=0.f;
   int i=0;

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -53,8 +53,8 @@ PeakController::PeakController( Model * _parent,
 	setSampleExact( true );
 	if( m_peakEffect )
 	{
-		connect( m_peakEffect, SIGNAL( destroyed( ) ),
-			this, SLOT( handleDestroyedEffect( ) ) );
+		connect( m_peakEffect, SIGNAL( destroyed() ),
+			this, SLOT( handleDestroyedEffect() ) );
 	}
 	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ), this, SLOT( updateCoeffs() ) );
 	connect( m_peakEffect->attackModel(), SIGNAL( dataChanged() ),
@@ -127,7 +127,7 @@ void PeakController::updateCoeffs()
 }
 
 
-void PeakController::handleDestroyedEffect( )
+void PeakController::handleDestroyedEffect()
 {
 	// possible race condition...
 	//printf("disconnecting effect\n");

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -126,7 +126,7 @@ AudioSndio::~AudioSndio()
 }
 
 
-void AudioSndio::startProcessing( void )
+void AudioSndio::startProcessing( )
 {
 	if( !isRunning() )
 	{
@@ -135,13 +135,13 @@ void AudioSndio::startProcessing( void )
 }
 
 
-void AudioSndio::stopProcessing( void )
+void AudioSndio::stopProcessing( )
 {
 	stopProcessingThread( this );
 }
 
 
-void AudioSndio::applyQualitySettings( void )
+void AudioSndio::applyQualitySettings( )
 {
 	if( hqAudio() )
 	{
@@ -154,7 +154,7 @@ void AudioSndio::applyQualitySettings( void )
 }
 
 
-void AudioSndio::run( void )
+void AudioSndio::run( )
 {
 	surroundSampleFrame * temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
 	int_sample_t * outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
@@ -210,7 +210,7 @@ AudioSndio::setupWidget::~setupWidget()
 }
 
 
-void AudioSndio::setupWidget::saveSettings( void )
+void AudioSndio::setupWidget::saveSettings( )
 {
 	ConfigManager::inst()->setValue( "audiosndio", "device",
 	    m_device->text() );

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -126,7 +126,7 @@ AudioSndio::~AudioSndio()
 }
 
 
-void AudioSndio::startProcessing( )
+void AudioSndio::startProcessing()
 {
 	if( !isRunning() )
 	{
@@ -135,13 +135,13 @@ void AudioSndio::startProcessing( )
 }
 
 
-void AudioSndio::stopProcessing( )
+void AudioSndio::stopProcessing()
 {
 	stopProcessingThread( this );
 }
 
 
-void AudioSndio::applyQualitySettings( )
+void AudioSndio::applyQualitySettings()
 {
 	if( hqAudio() )
 	{
@@ -154,7 +154,7 @@ void AudioSndio::applyQualitySettings( )
 }
 
 
-void AudioSndio::run( )
+void AudioSndio::run()
 {
 	surroundSampleFrame * temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
 	int_sample_t * outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
@@ -210,7 +210,7 @@ AudioSndio::setupWidget::~setupWidget()
 }
 
 
-void AudioSndio::setupWidget::saveSettings( )
+void AudioSndio::setupWidget::saveSettings()
 {
 	ConfigManager::inst()->setValue( "audiosndio", "device",
 	    m_device->text() );

--- a/src/core/midi/MidiSndio.cpp
+++ b/src/core/midi/MidiSndio.cpp
@@ -38,7 +38,7 @@ namespace lmms
 {
 
 
-MidiSndio::MidiSndio( void ) :
+MidiSndio::MidiSndio( ) :
 	MidiClientRaw(),
 	m_quit( false )
 {
@@ -74,7 +74,7 @@ MidiSndio::~MidiSndio()
 }
 
 
-QString MidiSndio::probeDevice( void )
+QString MidiSndio::probeDevice( )
 {
 	QString dev = ConfigManager::inst()->value( "MidiSndio", "device" );
 
@@ -88,7 +88,7 @@ void MidiSndio::sendByte( const unsigned char c )
 }
 
 
-void MidiSndio::run( void )
+void MidiSndio::run( )
 {
 	struct pollfd pfd;
 	nfds_t nfds;

--- a/src/core/midi/MidiSndio.cpp
+++ b/src/core/midi/MidiSndio.cpp
@@ -38,7 +38,7 @@ namespace lmms
 {
 
 
-MidiSndio::MidiSndio( ) :
+MidiSndio::MidiSndio() :
 	MidiClientRaw(),
 	m_quit( false )
 {
@@ -74,7 +74,7 @@ MidiSndio::~MidiSndio()
 }
 
 
-QString MidiSndio::probeDevice( )
+QString MidiSndio::probeDevice()
 {
 	QString dev = ConfigManager::inst()->value( "MidiSndio", "device" );
 
@@ -88,7 +88,7 @@ void MidiSndio::sendByte( const unsigned char c )
 }
 
 
-void MidiSndio::run( )
+void MidiSndio::run()
 {
 	struct pollfd pfd;
 	nfds_t nfds;

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -42,7 +42,7 @@ namespace lmms::gui
 {
 
 
-ControllerRackView::ControllerRackView( ) :
+ControllerRackView::ControllerRackView() :
 	QWidget(),
 	m_nextIndex(0)
 {

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -201,7 +201,7 @@ bool FileBrowser::filterItems( const QString & filter, QTreeWidgetItem * item )
 }
 
 
-void FileBrowser::reloadTree( )
+void FileBrowser::reloadTree()
 {
 	QList<QString> expandedDirs = m_fileBrowserTreeWidget->expandedDirs();
 	const QString text = m_filterEdit->text();
@@ -957,7 +957,7 @@ Directory::Directory(const QString & filename, const QString & path,
 
 
 
-void Directory::initPixmaps( )
+void Directory::initPixmaps()
 {
 	if( s_folderPixmap == nullptr )
 	{
@@ -981,7 +981,7 @@ void Directory::initPixmaps( )
 
 
 
-void Directory::update( )
+void Directory::update()
 {
 	if( !isExpanded() )
 	{
@@ -1144,7 +1144,7 @@ FileItem::FileItem(const QString & name, const QString & path ) :
 
 
 
-void FileItem::initPixmaps( )
+void FileItem::initPixmaps()
 {
 	if( s_projectFilePixmap == nullptr )
 	{
@@ -1219,7 +1219,7 @@ void FileItem::initPixmaps( )
 
 
 
-void FileItem::determineFileType( )
+void FileItem::determineFileType()
 {
 	m_handling = NotSupported;
 
@@ -1287,7 +1287,7 @@ void FileItem::determineFileType( )
 
 
 
-QString FileItem::extension( )
+QString FileItem::extension()
 {
 	return extension( fullName() );
 }

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -201,7 +201,7 @@ bool FileBrowser::filterItems( const QString & filter, QTreeWidgetItem * item )
 }
 
 
-void FileBrowser::reloadTree( void )
+void FileBrowser::reloadTree( )
 {
 	QList<QString> expandedDirs = m_fileBrowserTreeWidget->expandedDirs();
 	const QString text = m_filterEdit->text();
@@ -957,7 +957,7 @@ Directory::Directory(const QString & filename, const QString & path,
 
 
 
-void Directory::initPixmaps( void )
+void Directory::initPixmaps( )
 {
 	if( s_folderPixmap == nullptr )
 	{
@@ -981,7 +981,7 @@ void Directory::initPixmaps( void )
 
 
 
-void Directory::update( void )
+void Directory::update( )
 {
 	if( !isExpanded() )
 	{
@@ -1144,7 +1144,7 @@ FileItem::FileItem(const QString & name, const QString & path ) :
 
 
 
-void FileItem::initPixmaps( void )
+void FileItem::initPixmaps( )
 {
 	if( s_projectFilePixmap == nullptr )
 	{
@@ -1219,7 +1219,7 @@ void FileItem::initPixmaps( void )
 
 
 
-void FileItem::determineFileType( void )
+void FileItem::determineFileType( )
 {
 	m_handling = NotSupported;
 
@@ -1287,7 +1287,7 @@ void FileItem::determineFileType( void )
 
 
 
-QString FileItem::extension( void )
+QString FileItem::extension( )
 {
 	return extension( fullName() );
 }

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -143,7 +143,7 @@ LmmsStyle::LmmsStyle() :
 
 
 
-QPalette LmmsStyle::standardPalette( ) const
+QPalette LmmsStyle::standardPalette() const
 {
 	if( s_palette != nullptr) { return * s_palette; }
 

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -143,7 +143,7 @@ LmmsStyle::LmmsStyle() :
 
 
 
-QPalette LmmsStyle::standardPalette( void ) const
+QPalette LmmsStyle::standardPalette( ) const
 {
 	if( s_palette != nullptr) { return * s_palette; }
 

--- a/src/gui/instrument/InstrumentView.cpp
+++ b/src/gui/instrument/InstrumentView.cpp
@@ -66,7 +66,7 @@ void InstrumentView::setModel( Model * _model, bool )
 
 
 
-InstrumentTrackWindow * InstrumentView::instrumentTrackWindow( void )
+InstrumentTrackWindow * InstrumentView::instrumentTrackWindow( )
 {
 	return( dynamic_cast<InstrumentTrackWindow *>(
 					parentWidget()->parentWidget() ) );

--- a/src/gui/instrument/InstrumentView.cpp
+++ b/src/gui/instrument/InstrumentView.cpp
@@ -66,7 +66,7 @@ void InstrumentView::setModel( Model * _model, bool )
 
 
 
-InstrumentTrackWindow * InstrumentView::instrumentTrackWindow( )
+InstrumentTrackWindow * InstrumentView::instrumentTrackWindow()
 {
 	return( dynamic_cast<InstrumentTrackWindow *>(
 					parentWidget()->parentWidget() ) );

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -55,8 +55,8 @@ Graph::Graph( QWidget * _parent, graphStyle _style, int _width,
 	QObject::connect( gModel, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( updateGraph( int, int ) ) );
 
-	QObject::connect( gModel, SIGNAL( lengthChanged( ) ),
-			this, SLOT( updateGraph( ) ) );
+	QObject::connect( gModel, SIGNAL( lengthChanged() ),
+			this, SLOT( updateGraph() ) );
 }
 
 void Graph::setForeground( const QPixmap &_pixmap )
@@ -438,8 +438,8 @@ void Graph::modelChanged()
 	QObject::connect( gModel, SIGNAL( samplesChanged( int, int ) ),
 			this, SLOT( updateGraph( int, int ) ) );
 
-	QObject::connect( gModel, SIGNAL( lengthChanged( ) ),
-			this, SLOT( updateGraph( ) ) );
+	QObject::connect( gModel, SIGNAL( lengthChanged() ),
+			this, SLOT( updateGraph() ) );
 }
 
 


### PR DESCRIPTION
This refactor transforms function declarations (and friends) of the form `T foo(void);` into `T foo();`. The `void` keyword is redundant there, since the declaration is equivalent to one with an empty argument list.