### PR TITLE
namespace-lmms: Add missing prefixes to types in AudioSoundIo.

### DIFF
--- a/include/AudioSoundIo.h
+++ b/include/AudioSoundIo.h
@@ -70,7 +70,7 @@ public:
 		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "soundio" );
 	}
 
-	class setupWidget : public AudioDeviceSetupWidget
+	class setupWidget : public gui::AudioDeviceSetupWidget
 	{
 	public:
 		setupWidget( QWidget * _parent );
@@ -84,8 +84,8 @@ public:
 	private:
 
 		AudioSoundIoSetupUtil m_setupUtil;
-		ComboBox * m_backend;
-		ComboBox * m_device;
+		gui::ComboBox * m_backend;
+		gui::ComboBox * m_device;
 
 		ComboBoxModel m_backendModel;
 		ComboBoxModel m_deviceModel;

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -455,14 +455,14 @@ AudioSoundIo::setupWidget::setupWidget( QWidget * _parent ) :
 {
 	m_setupUtil.m_setupWidget = this;
 
-	m_backend = new ComboBox( this, "BACKEND" );
+	m_backend = new gui::ComboBox( this, "BACKEND" );
 	m_backend->setGeometry( 64, 15, 260, 20 );
 
 	QLabel * backend_lbl = new QLabel( tr( "Backend" ), this );
 	backend_lbl->setFont( pointSize<7>( backend_lbl->font() ) );
 	backend_lbl->move( 8, 18 );
 
-	m_device = new ComboBox( this, "DEVICE" );
+	m_device = new gui::ComboBox( this, "DEVICE" );
 	m_device->setGeometry( 64, 35, 260, 20 );
 
 	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );


### PR DESCRIPTION
CI didn't catch this one, but @zonkmachine sure did! Now, 'tis fixed.