### PR TITLE
clang-tidy: Apply modernize-use-bool-literals and remove never-executed code

### DIFF
--- a/plugins/LadspaEffect/caps/Amp.cc
+++ b/plugins/LadspaEffect/caps/Amp.cc
@@ -388,9 +388,7 @@ AmpV::one_cycle (int frames)
 		v = v * v * .06 + .46;
 
 		a = filter[0].process (a + normal);
-		if (0)
-			a = filter[2].process (a);
-		
+
 		a = g * (a + supply * .001); 
 
 		a = v * tube.transfer_clip (up.upsample (a));
@@ -399,8 +397,7 @@ AmpV::one_cycle (int frames)
 		a = down.process (a);
 
 		a = filter[1].process (a - normal);
-		if (1)
-			a = filter[2].process (a + normal);
+		a = filter[2].process (a + normal);
 
 		{
 			for (int o = 1; o < OVERSAMPLE; ++o)

--- a/plugins/LadspaEffect/caps/dsp/Delay.h
+++ b/plugins/LadspaEffect/caps/dsp/Delay.h
@@ -154,9 +154,6 @@ class DelayTapA
 				int n;
 				fistp (f, n); /* read: n = (int) f; relies on FPTruncateMode */
 				f -= n;
-				if (0 && f < .5)
-					f += 1,
-					n -= 1;
 
 				sample_t x = d[n];
 				f = (1 - f) / (1 + f);

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -605,7 +605,7 @@ invalid_format:
 	}
 
 	// search for "data" chunk
-	while( 1 )
+	while( true )
 	{
 		const int id = readID();
 		const int len = read32LE();

--- a/plugins/ZynAddSubFx/LocalZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/LocalZynAddSubFx.cpp
@@ -86,7 +86,7 @@ LocalZynAddSubFx::LocalZynAddSubFx() :
 	m_ioEngine = new NulEngine;
 
 	m_master = new Master();
-	m_master->swaplr = 0;
+	m_master->swaplr = false;
 }
 
 

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -219,7 +219,7 @@ QString AudioOss::probeDevice()
 	if( QFileInfo( dev ).isWritable() == false )
 	{
 		int instance = -1;
-		while( 1 )
+		while( true )
 		{
 			dev = PATH_DEV_DSP + QString::number( ++instance );
 			if( !QFileInfo( dev ).exists() )


### PR DESCRIPTION
This runs `modernize-use-bool-literals` to replace statements like `bool b = 1` with `bool b = true`.    
It also removes an `if (true OR ...)` condition that was always true, leaving the guarded statement intact.    
It also removes two `if (false AND ...)` conditions that were always false, also deleting the statements they were guarding and which were never executed.