### PR TITLE
clang-tidy: Apply modernize-use-emplace everywhere

### DIFF
--- a/include/RemotePluginBase.h
+++ b/include/RemotePluginBase.h
@@ -412,7 +412,7 @@ public:
 		{
 			char buf[32];
 			sprintf( buf, "%d", _i );
-			data.push_back( std::string( buf ) );
+			data.emplace_back( buf );
 			return *this;
 		}
 
@@ -420,7 +420,7 @@ public:
 		{
 			char buf[32];
 			sprintf( buf, "%f", _f );
-			data.push_back( std::string( buf ) );
+			data.emplace_back( buf );
 			return *this;
 		}
 

--- a/plugins/MidiExport/MidiExport.cpp
+++ b/plugins/MidiExport/MidiExport.cpp
@@ -163,7 +163,7 @@ bool MidiExport::tryExport(const TrackContainer::TrackList &tracks,
 					QDomElement it = n.toElement();
 					int pos = it.attribute("pos", "0").toInt();
 					int len = it.attribute("len", "0").toInt();
-					plist.push_back(std::pair<int,int>(pos, pos+len));
+					plist.emplace_back(pos, pos+len);
 				}
 			}
 			std::sort(plist.begin(), plist.end());

--- a/src/core/Scale.cpp
+++ b/src/core/Scale.cpp
@@ -75,7 +75,7 @@ void Interval::loadSettings(const QDomElement &element)
 Scale::Scale() :
 	m_description(tr("empty"))
 {
-	m_intervals.push_back(Interval(1, 1));
+	m_intervals.emplace_back(1, 1);
 }
 
 Scale::Scale(QString description, std::vector<Interval> intervals) :

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -397,7 +397,7 @@ bool MicrotunerConfig::applyScale()
 	if (!validateScaleForm()) {return false;};
 
 	std::vector<Interval> newIntervals;
-	newIntervals.push_back(Interval(1, 1));
+	newIntervals.emplace_back(1, 1);
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 	QStringList input = m_keymapTextEdit->toPlainText().split('\n', Qt::SkipEmptyParts);
@@ -411,7 +411,7 @@ bool MicrotunerConfig::applyScale()
 		QString firstSection = line.section(QRegExp("\\s+|/"), 0, 0, QString::SectionSkipEmpty);
 		if (firstSection.contains('.'))		// cent mode
 		{
-			newIntervals.push_back(Interval(firstSection.toFloat()));
+			newIntervals.emplace_back(firstSection.toFloat());
 		}
 		else								// ratio mode
 		{
@@ -421,7 +421,7 @@ bool MicrotunerConfig::applyScale()
 			{
 				den = line.split('/').at(1).section(QRegExp("\\s+"), 0, 0, QString::SectionSkipEmpty).toInt();
 			}
-			newIntervals.push_back(Interval(num, den));
+			newIntervals.emplace_back(num, den);
 		}
 	}
 


### PR DESCRIPTION
For containers with an `emplace` method that constructs new objects directly in the container, this check identifies places where we call `push_back` etc. with a temporary object that's being copied in, and replaces them with calls to `emplace_back` etc.