### PR TITLE
clang-tidy: Apply modernize-use-using everywhere

### DIFF
--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -65,7 +65,7 @@ public:
 
 	};
 
-	typedef std::vector<DeviceInfo> DeviceInfoCollection;
+	using DeviceInfoCollection = std::vector<DeviceInfo>;
 
 public:
 	AudioAlsa( bool & _success_ful, AudioEngine* audioEngine );

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -370,7 +370,7 @@ signals:
 
 
 private:
-	typedef FifoBuffer<surroundSampleFrame *> Fifo;
+	using Fifo = FifoBuffer<surroundSampleFrame*>;
 
 	class fifoWriter : public QThread
 	{

--- a/include/AudioFileDevice.h
+++ b/include/AudioFileDevice.h
@@ -68,13 +68,8 @@ private:
 	OutputSettings m_outputSettings;
 } ;
 
-
-typedef AudioFileDevice * ( * AudioFileDeviceInstantiaton )
-					( const QString & outputFilename,
-					  OutputSettings const & outputSettings,
-					  const ch_cnt_t channels,
-					  AudioEngine* audioEngine,
-					  bool & successful );
+using AudioFileDeviceInstantiaton
+	= AudioFileDevice* (*)(const QString&, const OutputSettings&, const ch_cnt_t, AudioEngine*, bool&);
 
 } // namespace lmms
 

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -131,7 +131,7 @@ private:
 		jack_port_t * ports[2];
 	} ;
 
-	typedef QMap<AudioPort *, StereoPort> JackPortMap;
+	using JackPortMap = QMap<AudioPort *, StereoPort>;
 	JackPortMap m_portMap;
 #endif
 

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -131,10 +131,10 @@ private:
 		unsigned long _framesPerBuffer, PaTimestamp _outTime, void * _arg );
 
 
-	typedef double PaTime;
-	typedef PaDeviceID PaDeviceIndex;
+	using PaTime = double;
+	using PaDeviceIndex = PaDeviceID;
 
-	typedef struct PaStreamParameters
+	using PaStreamParameters = struct
 	{
 		PaDeviceIndex device;
 		int channelCount;

--- a/include/AudioSampleRecorder.h
+++ b/include/AudioSampleRecorder.h
@@ -52,7 +52,7 @@ private:
 						const fpp_t _frames,
 						const float _master_gain ) override;
 
-	typedef QList<QPair<sampleFrame *, fpp_t> > BufferList;
+	using BufferList = QList<QPair<sampleFrame*, fpp_t>>;
 	BufferList m_buffers;
 
 } ;

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -78,8 +78,7 @@ class LMMS_EXPORT AutomatableModel : public Model, public JournallingObject
 	Q_OBJECT
 	MM_OPERATORS
 public:
-
-	typedef QVector<AutomatableModel *> AutoModelVector;
+	using AutoModelVector = QVector<AutomatableModel*>;
 
 	enum ScaleType
 	{
@@ -504,8 +503,7 @@ public:
 	QString displayValue( const float val ) const override;
 } ;
 
-typedef QMap<AutomatableModel*, float> AutomatedValueMap;
-
+using AutomatedValueMap = QMap<AutomatableModel*, float>;
 
 } // namespace lmms
 

--- a/include/AutomatableSlider.h
+++ b/include/AutomatableSlider.h
@@ -73,7 +73,7 @@ private slots:
 } ;
 
 
-typedef IntModel sliderModel;
+using sliderModel = IntModel;
 
 } // namespace lmms::gui
 

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -61,8 +61,8 @@ public:
 		CubicHermiteProgression
 	} ;
 
-	typedef QMap<int, AutomationNode> timeMap;
-	typedef QVector<QPointer<AutomatableModel>> objectVector;
+	using timeMap = QMap<int, AutomationNode>;
+	using objectVector = QVector<QPointer<AutomatableModel>>;
 
 	using TimemapIterator = timeMap::const_iterator;
 

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -99,7 +99,7 @@ public slots:
 
 
 protected:
-	typedef AutomationClip::timeMap timeMap;
+	using timeMap = AutomationClip::timeMap;
 
 	void keyPressEvent(QKeyEvent * ke) override;
 	void leaveEvent(QEvent * e) override;

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -167,7 +167,7 @@ public:
 
 	static bool s_wavesGenerated;
 
-	static WaveMipMap s_waveforms [NumBLWaveforms];
+	static std::array<WaveMipMap, NumBLWaveforms> s_waveforms;
 
 	static QString s_wavetableDir;
 };

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -54,29 +54,30 @@ const int TLENS[MAXTBL+1] = { 2 << 0, 3 << 0, 2 << 1, 3 << 1,
 					2 << 8, 3 << 8, 2 << 9, 3 << 9,
 					2 << 10, 3 << 10, 2 << 11, 3 << 11 };
 
-typedef struct
+using WaveMipMap = struct
 {
 public:
-	inline sample_t sampleAt( int table, int ph )
+	inline sample_t sampleAt(int table, int ph)
 	{
-		if( table % 2 == 0 )
-		{	return m_data[ TLENS[ table ] + ph ]; }
+		if (table % 2 == 0) { return m_data[TLENS[table] + ph]; }
 		else
-		{	return m_data3[ TLENS[ table ] + ph ]; }
+		{
+			return m_data3[TLENS[table] + ph];
+		}
 	}
-	inline void setSampleAt( int table, int ph, sample_t sample )
+	inline void setSampleAt(int table, int ph, sample_t sample)
 	{
-		if( table % 2 == 0 )
-		{	m_data[ TLENS[ table ] + ph ] = sample; }
+		if (table % 2 == 0) { m_data[TLENS[table] + ph] = sample; }
 		else
-		{ 	m_data3[ TLENS[ table ] + ph ] = sample; }
+		{
+			m_data3[TLENS[table] + ph] = sample;
+		}
 	}
+
 private:
-	sample_t m_data [ MIPMAPSIZE ];
-	sample_t m_data3 [ MIPMAPSIZE3 ];
-
-} WaveMipMap;
-
+	sample_t m_data[MIPMAPSIZE];
+	sample_t m_data3[MIPMAPSIZE3];
+};
 
 QDataStream& operator<< ( QDataStream &out, WaveMipMap &waveMipMap );
 

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -54,7 +54,7 @@ const int TLENS[MAXTBL+1] = { 2 << 0, 3 << 0, 2 << 1, 3 << 1,
 					2 << 8, 3 << 8, 2 << 9, 3 << 9,
 					2 << 10, 3 << 10, 2 << 11, 3 << 11 };
 
-using WaveMipMap = struct
+using WaveMipMap = struct WaveMipMap
 {
 public:
 	inline sample_t sampleAt(int table, int ph)

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -54,7 +54,7 @@ const int TLENS[MAXTBL+1] = { 2 << 0, 3 << 0, 2 << 1, 3 << 1,
 					2 << 8, 3 << 8, 2 << 9, 3 << 9,
 					2 << 10, 3 << 10, 2 << 11, 3 << 11 };
 
-using WaveMipMap = struct WaveMipMap
+struct WaveMipMap
 {
 public:
 	inline sample_t sampleAt(int table, int ph)

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -141,7 +141,7 @@ private:
 	typedef double frame[CHANNELS];
 	frame m_z1, m_z2, m_z3, m_z4;
 };
-typedef LinkwitzRiley<2> StereoLinkwitzRiley;
+using StereoLinkwitzRiley = LinkwitzRiley<2>;
 
 template<ch_cnt_t CHANNELS>
 class BiQuad
@@ -184,7 +184,7 @@ private:
 	
 	friend class BasicFilters<CHANNELS>; // needed for subfilter stuff in BasicFilters
 };
-typedef BiQuad<2> StereoBiQuad;
+using StereoBiQuad = BiQuad<2>;
 
 template<ch_cnt_t CHANNELS>
 class OnePole
@@ -218,7 +218,7 @@ private:
 	float m_a0, m_b1; 
 	float m_z1 [CHANNELS];
 };
-typedef OnePole<2> StereoOnePole;
+using StereoOnePole = OnePole<2>;
 
 template<ch_cnt_t CHANNELS>
 class BasicFilters

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -138,7 +138,7 @@ private:
 	double m_a, m_a0, m_a1, m_a2;
 	double m_b1, m_b2, m_b3, m_b4;
 	
-	using frame = double[CHANNELS];
+	using frame = std::array<double, CHANNELS>;
 	frame m_z1, m_z2, m_z3, m_z4;
 };
 using StereoLinkwitzRiley = LinkwitzRiley<2>;
@@ -889,7 +889,7 @@ private:
 	// coeffs for Lowpass_SV (state-variant lowpass)
 	float m_svf1, m_svf2, m_svq;
 
-	using frame = sample_t[CHANNELS];
+	using frame = std::array<sample_t, CHANNELS>;
 
 	// in/out history for moog-filter
 	frame m_y1, m_y2, m_y3, m_y4, m_oldx, m_oldy1, m_oldy2, m_oldy3;

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -138,7 +138,7 @@ private:
 	double m_a, m_a0, m_a1, m_a2;
 	double m_b1, m_b2, m_b3, m_b4;
 	
-	typedef double frame[CHANNELS];
+	using frame = double[CHANNELS];
 	frame m_z1, m_z2, m_z3, m_z4;
 };
 using StereoLinkwitzRiley = LinkwitzRiley<2>;
@@ -889,7 +889,7 @@ private:
 	// coeffs for Lowpass_SV (state-variant lowpass)
 	float m_svf1, m_svf2, m_svq;
 
-	typedef sample_t frame[CHANNELS];
+	using frame = sample_t[CHANNELS];
 
 	// in/out history for moog-filter
 	frame m_y1, m_y2, m_y3, m_y4, m_oldx, m_oldy1, m_oldy2, m_oldy3;

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -87,7 +87,7 @@ public:
 
 
 private:
-	typedef std::pair<QString, std::unique_ptr<PixmapLoader> > Item;
+	using Item = std::pair<QString, std::unique_ptr<PixmapLoader>>;
 
 	std::vector<Item> m_items;
 

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -303,8 +303,8 @@ private:
 	unsigned int m_configVersion;
 	QStringList m_recentlyOpenedProjects;
 
-	typedef QVector<QPair<QString, QString> > stringPairVector;
-	typedef QMap<QString, stringPairVector> settingsMap;
+	using stringPairVector = QVector<QPair<QString, QString>>;
+	using settingsMap = QMap<QString, stringPairVector>;
 	settingsMap m_settings;
 
 

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -46,9 +46,7 @@ class ControllerDialog;
 
 } // namespace gui
 
-
-typedef QVector<Controller *> ControllerVector;
-
+using ControllerVector = QVector<Controller*>;
 
 class LMMS_EXPORT Controller : public Model, public JournallingObject
 {

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -47,8 +47,7 @@ namespace gui
 class ControllerConnectionDialog;
 }
 
-typedef QVector<ControllerConnection *> ControllerConnectionVector;
-
+using ControllerConnectionVector = QVector<ControllerConnection*>;
 
 class LMMS_EXPORT ControllerConnection : public QObject, public JournallingObject
 {

--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -61,7 +61,7 @@ public:
 		MidiClip,
 		TypeCount
 	} ;
-	typedef Types Type;
+	using Type = Types;
 
 	DataFile( const QString& fileName );
 	DataFile( const QByteArray& data );
@@ -136,7 +136,7 @@ private:
 	static const std::vector<ProjectVersion> UPGRADE_VERSIONS;
 
 	// Map with DOM elements that access resources (for making bundles)
-	typedef std::map<QString, std::vector<QString>> ResourcesMap;
+	using ResourcesMap = std::map<QString, std::vector<QString>>;
 	static const ResourcesMap ELEMENTS_WITH_RESOURCES;
 
 	void upgrade();

--- a/include/Delay.h
+++ b/include/Delay.h
@@ -66,7 +66,7 @@ template<ch_cnt_t CHANNELS>
 class CombFeedback
 {
 public:
-	using frame[CHANNELS] = double;
+	using frame = std::array<double, CHANNELS>;
 
 	CombFeedback( int maxDelay ) :
 		m_size( maxDelay ),
@@ -137,7 +137,7 @@ private:
 template<ch_cnt_t CHANNELS>
 class CombFeedfwd
 {
-	using frame[CHANNELS] = double;
+	using frame = std::array<double, CHANNELS>;
 
 	CombFeedfwd( int maxDelay ) :
 		m_size( maxDelay ),
@@ -208,7 +208,7 @@ private:
 template<ch_cnt_t CHANNELS>
 class CombFeedbackDualtap
 {
-	using frame[CHANNELS] = double;
+	using frame = std::array<double, CHANNELS>;
 
 	CombFeedbackDualtap( int maxDelay ) :
 		m_size( maxDelay ),
@@ -289,7 +289,7 @@ template<ch_cnt_t CHANNELS>
 class AllpassDelay
 {
 public:
-	using frame[CHANNELS] = double;
+	using frame = std::array<double, CHANNELS>;
 
 	AllpassDelay( int maxDelay ) :
 		m_size( maxDelay ),

--- a/include/Delay.h
+++ b/include/Delay.h
@@ -66,7 +66,7 @@ template<ch_cnt_t CHANNELS>
 class CombFeedback
 {
 public:
-	typedef double frame[CHANNELS];
+	using frame[CHANNELS] = double;
 
 	CombFeedback( int maxDelay ) :
 		m_size( maxDelay ),
@@ -137,7 +137,7 @@ private:
 template<ch_cnt_t CHANNELS>
 class CombFeedfwd
 {
-	typedef double frame[CHANNELS];
+	using frame[CHANNELS] = double;
 
 	CombFeedfwd( int maxDelay ) :
 		m_size( maxDelay ),
@@ -208,7 +208,7 @@ private:
 template<ch_cnt_t CHANNELS>
 class CombFeedbackDualtap
 {
-	typedef double frame[CHANNELS];
+	using frame[CHANNELS] = double;
 
 	CombFeedbackDualtap( int maxDelay ) :
 		m_size( maxDelay ),
@@ -289,7 +289,7 @@ template<ch_cnt_t CHANNELS>
 class AllpassDelay
 {
 public:
-	typedef double frame[CHANNELS];
+	using frame[CHANNELS] = double;
 
 	AllpassDelay( int maxDelay ) :
 		m_size( maxDelay ),
@@ -358,11 +358,10 @@ private:
 };
 
 // convenience typedefs for stereo effects
-typedef CombFeedback<2> StereoCombFeedback;
-typedef CombFeedfwd<2> StereoCombFeedfwd;
-typedef CombFeedbackDualtap<2> StereoCombFeedbackDualtap;
-typedef AllpassDelay<2> StereoAllpassDelay;
-
+using StereoCombFeedback = CombFeedback<2>;
+using StereoCombFeedfwd = CombFeedfwd<2>;
+using StereoCombFeedbackDualtap = CombFeedbackDualtap<2>;
+using StereoAllpassDelay = AllpassDelay<2>;
 
 } // namespace lmms
 

--- a/include/DspEffectLibrary.h
+++ b/include/DspEffectLibrary.h
@@ -38,7 +38,7 @@ namespace lmms::DspEffectLibrary
 	class MonoBase
 	{
 	public:
-		typedef class MonoBypass bypassType;
+		using bypassType = class MonoBypass;
 
 		static void process( sample_t * * _buf, const f_cnt_t _frames )
 		{
@@ -53,7 +53,7 @@ namespace lmms::DspEffectLibrary
 	class StereoBase
 	{
 	public:
-		typedef class StereoBypass bypassType;
+		using bypassType = class StereoBypass;
 
 		static void process( sample_t * * _buf, const f_cnt_t _frames )
 		{
@@ -164,7 +164,7 @@ namespace lmms::DspEffectLibrary
 	class Chain : public FX0::bypassType
 	{
 	public:
-		typedef typename FX0::sample_t sample_t;
+		using sample_t = typename FX0::sample_t;
 		Chain( const FX0& fx0, const FX1& fx1 = FX1() ) :
 			m_FX0( fx0 ),
 			m_FX1( fx1 )

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -236,10 +236,8 @@ private:
 
 } ;
 
-
-typedef Effect::Descriptor::SubPluginFeatures::Key EffectKey;
-typedef Effect::Descriptor::SubPluginFeatures::KeyList EffectKeyList;
-
+using EffectKey = Effect::Descriptor::SubPluginFeatures::Key;
+using EffectKeyList = Effect::Descriptor::SubPluginFeatures::KeyList;
 
 } // namespace lmms
 

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -69,7 +69,7 @@ public:
 
 
 private:
-	typedef QVector<Effect *> EffectList;
+	using EffectList = QVector<Effect*>;
 	EffectList m_effects;
 
 	BoolModel m_enabledModel;

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -67,7 +67,7 @@ public:
 
 	private:
 		QMutex m_lfoListMutex;
-		typedef QList<EnvelopeAndLfoParameters *> LfoList;
+		using LfoList = QList<EnvelopeAndLfoParameters*>;
 		LfoList m_lfos;
 
 	} ;

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -54,7 +54,7 @@ public:
 	static const int MAX_CHORD_POLYPHONY = 13;
 
 private:
-	using ChordSemiTones = int8_t[MAX_CHORD_POLYPHONY];
+	using ChordSemiTones = std::array<int8_t, MAX_CHORD_POLYPHONY>;
 
 public:
 	InstrumentFunctionNoteStacking( Model * _parent );

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -54,7 +54,7 @@ public:
 	static const int MAX_CHORD_POLYPHONY = 13;
 
 private:
-	typedef int8_t ChordSemiTones [MAX_CHORD_POLYPHONY];
+	using ChordSemiTones = int8_t[MAX_CHORD_POLYPHONY];
 
 public:
 	InstrumentFunctionNoteStacking( Model * _parent );

--- a/include/LadspaBase.h
+++ b/include/LadspaBase.h
@@ -35,7 +35,7 @@ namespace lmms
 
 class LadspaControl;
 
-using buffer_rate_t = enum BufferRates {
+enum buffer_rate_t {
 	CHANNEL_IN,
 	CHANNEL_OUT,
 	AUDIO_RATE_INPUT,
@@ -44,7 +44,7 @@ using buffer_rate_t = enum BufferRates {
 	CONTROL_RATE_OUTPUT
 };
 
-using buffer_data_t = enum BufferData { TOGGLED, ENUM, INTEGER, FLOATING, TIME, NONE };
+enum buffer_data_t { TOGGLED, ENUM, INTEGER, FLOATING, TIME, NONE };
 
 //! This struct is used to hold port descriptions internally
 //! which where received from the ladspa plugin

--- a/include/LadspaBase.h
+++ b/include/LadspaBase.h
@@ -35,30 +35,20 @@ namespace lmms
 
 class LadspaControl;
 
-
-typedef enum BufferRates
-{
+using buffer_rate_t = enum BufferRates {
 	CHANNEL_IN,
 	CHANNEL_OUT,
 	AUDIO_RATE_INPUT,
 	AUDIO_RATE_OUTPUT,
 	CONTROL_RATE_INPUT,
 	CONTROL_RATE_OUTPUT
-} buffer_rate_t;
+};
 
-typedef enum BufferData
-{
-	TOGGLED,
-	ENUM,
-	INTEGER,
-	FLOATING,
-	TIME,
-	NONE
-} buffer_data_t;
+using buffer_data_t = enum BufferData { TOGGLED, ENUM, INTEGER, FLOATING, TIME, NONE };
 
 //! This struct is used to hold port descriptions internally
 //! which where received from the ladspa plugin
-typedef struct PortDescription
+using port_desc_t = struct PortDescription
 {
 	QString name;
 	ch_cnt_t proc;
@@ -74,10 +64,9 @@ typedef struct PortDescription
 	//! This is true iff ladspa suggests logscale
 	//! Note however that the model can still decide to use a linear scale
 	bool suggests_logscale;
-	LADSPA_Data * buffer;
-	LadspaControl * control;
-} port_desc_t;
-
+	LADSPA_Data* buffer;
+	LadspaControl* control;
+};
 
 inline Plugin::Descriptor::SubPluginFeatures::Key ladspaKeyToSubPluginKey(
 						const Plugin::Descriptor * _desc,

--- a/include/LadspaBase.h
+++ b/include/LadspaBase.h
@@ -48,7 +48,7 @@ enum buffer_data_t { TOGGLED, ENUM, INTEGER, FLOATING, TIME, NONE };
 
 //! This struct is used to hold port descriptions internally
 //! which where received from the ladspa plugin
-using port_desc_t = struct PortDescription
+struct port_desc_t
 {
 	QString name;
 	ch_cnt_t proc;

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -29,13 +29,13 @@
 #include <ladspa.h>
 
 #include "AutomatableModel.h"
+#include "LadspaBase.h"
 #include "TempoSyncKnobModel.h"
 #include "ValueBuffer.h"
 
 namespace lmms
 {
 
-using port_desc_t = struct PortDescription;
 
 namespace gui
 {

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -29,13 +29,13 @@
 #include <ladspa.h>
 
 #include "AutomatableModel.h"
-#include "LadspaBase.h"
 #include "TempoSyncKnobModel.h"
 #include "ValueBuffer.h"
 
 namespace lmms
 {
 
+using port_desc_t = struct PortDescription;
 
 namespace gui
 {

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -35,7 +35,7 @@
 namespace lmms
 {
 
-using port_desc_t = struct PortDescription;
+struct port_desc_t;
 
 namespace gui
 {

--- a/include/LadspaControl.h
+++ b/include/LadspaControl.h
@@ -35,8 +35,7 @@
 namespace lmms
 {
 
-
-typedef struct PortDescription port_desc_t;
+using port_desc_t = struct PortDescription;
 
 namespace gui
 {

--- a/include/LadspaManager.h
+++ b/include/LadspaManager.h
@@ -73,7 +73,7 @@ enum LadspaPluginType
 	OTHER
 };
 
-using LadspaManagerDescription = struct LadspaManagerStorage
+struct LadspaManagerDescription
 {
 	LADSPA_Descriptor_Function descriptorFunction;
 	uint32_t index;

--- a/include/LadspaManager.h
+++ b/include/LadspaManager.h
@@ -45,10 +45,10 @@ namespace lmms
 
 const float NOHINT = -99342.2243f;
 
-typedef QPair<QString, QString> ladspa_key_t;
-typedef QPair<QString, ladspa_key_t> sortable_plugin_t;
-typedef QList<sortable_plugin_t> l_sortable_plugin_t;
-typedef QList<ladspa_key_t> l_ladspa_key_t;
+using ladspa_key_t = QPair<QString, QString>;
+using sortable_plugin_t = QPair<QString, ladspa_key_t>;
+using l_sortable_plugin_t = QList<sortable_plugin_t>;
+using l_ladspa_key_t = QList<ladspa_key_t>;
 
 /* LadspaManager provides a database of LADSPA plug-ins.  Upon instantiation,
 it loads all of the plug-ins found in the LADSPA_PATH environmental variable
@@ -73,15 +73,14 @@ enum LadspaPluginType
 	OTHER
 };
 
-typedef struct LadspaManagerStorage
+using LadspaManagerDescription = struct LadspaManagerStorage
 {
 	LADSPA_Descriptor_Function descriptorFunction;
 	uint32_t index;
 	LadspaPluginType type;
 	uint16_t inputChannels;
 	uint16_t outputChannels;
-} LadspaManagerDescription;
-
+};
 
 class LMMS_EXPORT LadspaManager
 {
@@ -342,8 +341,7 @@ private:
 	const LADSPA_PortRangeHint* getPortRangeHint( const ladspa_key_t& _plugin,
 													uint32_t _port );
 
-	typedef QMap<ladspa_key_t, LadspaManagerDescription *>
-						LadspaManagerMapType;
+	using LadspaManagerMapType = QMap<ladspa_key_t, LadspaManagerDescription*>;
 	LadspaManagerMapType m_ladspaManagerMap;
 	l_sortable_plugin_t m_sortedPlugins;
 

--- a/include/LcdSpinBox.h
+++ b/include/LcdSpinBox.h
@@ -86,7 +86,7 @@ signals:
 
 } ;
 
-typedef IntModel LcdSpinBoxModel;
+using LcdSpinBoxModel = IntModel;
 
 } // namespace lmms::gui
 

--- a/include/Lv2Evbuf.h
+++ b/include/Lv2Evbuf.h
@@ -52,7 +52,7 @@ using LV2_Evbuf = struct LV2_Evbuf_Impl;
 /**
    An iterator over an LV2_Evbuf.
 */
-using LV2_Evbuf_Iterator = struct LV2_Evbuf_Iterator
+struct LV2_Evbuf_Iterator
 {
 	LV2_Evbuf* evbuf;
 	uint32_t offset;

--- a/include/Lv2Evbuf.h
+++ b/include/Lv2Evbuf.h
@@ -52,7 +52,7 @@ using LV2_Evbuf = struct LV2_Evbuf_Impl;
 /**
    An iterator over an LV2_Evbuf.
 */
-using LV2_Evbuf_Iterator = struct
+using LV2_Evbuf_Iterator = struct LV2_Evbuf_Iterator
 {
 	LV2_Evbuf* evbuf;
 	uint32_t offset;

--- a/include/Lv2Evbuf.h
+++ b/include/Lv2Evbuf.h
@@ -47,15 +47,16 @@ namespace lmms
 /**
    An abstract/opaque LV2 event buffer.
 */
-typedef struct LV2_Evbuf_Impl LV2_Evbuf;
+using LV2_Evbuf = struct LV2_Evbuf_Impl;
 
 /**
    An iterator over an LV2_Evbuf.
 */
-typedef struct {
+using LV2_Evbuf_Iterator = struct
+{
 	LV2_Evbuf* evbuf;
 	uint32_t offset;
-} LV2_Evbuf_Iterator;
+};
 
 /**
    Allocate a new, empty event buffer.

--- a/include/Lv2Ports.h
+++ b/include/Lv2Ports.h
@@ -42,7 +42,7 @@ namespace lmms
 
 
 struct ConnectPortVisitor;
-typedef struct LV2_Evbuf_Impl LV2_Evbuf;
+using LV2_Evbuf = struct LV2_Evbuf_Impl;
 
 namespace Lv2Ports {
 

--- a/include/MemoryManager.h
+++ b/include/MemoryManager.h
@@ -52,8 +52,10 @@ public:
 template<typename T>
 struct MmAllocator
 {
-	typedef T value_type;
-	template<class U>  struct rebind { typedef MmAllocator<U> other; };
+	using value_type = T;
+	template<class U>  struct rebind {
+		using other = MmAllocator<U>;
+	};
 
 	T* allocate( std::size_t n )
 	{
@@ -65,7 +67,7 @@ struct MmAllocator
 		MemoryManager::free( p );
 	}
 
-	typedef std::vector<T, MmAllocator<T> > vector;
+	using vector = std::vector<T, MmAllocator<T>>;
 };
 
 

--- a/include/Midi.h
+++ b/include/Midi.h
@@ -81,8 +81,7 @@ enum MidiMetaEventTypes
 	MidiMetaCustom = 0x80,
 	MidiNotePanning
 } ;
-typedef MidiMetaEventTypes MidiMetaEventType;
-
+using MidiMetaEventType = MidiMetaEventTypes;
 
 enum MidiStandardControllers
 {

--- a/include/MidiApple.h
+++ b/include/MidiApple.h
@@ -140,7 +140,7 @@ private:
 	QMap<MIDIEndpointRef, MIDIPortRef> m_sourcePortRef;
 
 	// subscriptions
-	typedef QMap<QString, MidiPortList> SubMap;
+	using SubMap = QMap<QString, MidiPortList>;
 	SubMap m_inputSubs;
 	SubMap m_outputSubs;
 

--- a/include/MidiPort.h
+++ b/include/MidiPort.h
@@ -67,7 +67,7 @@ class MidiPort : public Model, public SerializingObject
 	mapPropertyFromModel(bool,isReadable,setReadable,m_readableModel);
 	mapPropertyFromModel(bool,isWritable,setWritable,m_writableModel);
 public:
-	typedef QMap<QString, bool> Map;
+	using Map = QMap<QString, bool>;
 
 	enum Modes
 	{
@@ -76,7 +76,7 @@ public:
 		Output,		// from MIDI-event-processor to MIDI-client
 		Duplex		// both directions
 	} ;
-	typedef Modes Mode;
+	using Mode = Modes;
 
 	MidiPort( const QString& name,
 			MidiClient* client,
@@ -186,8 +186,7 @@ signals:
 
 } ;
 
-
-typedef QList<MidiPort *> MidiPortList;
+using MidiPortList = QList<MidiPort*>;
 
 } // namespace lmms
 

--- a/include/MidiWinMM.h
+++ b/include/MidiWinMM.h
@@ -134,7 +134,7 @@ private:
 	QMap<HMIDIOUT, QString> m_outputDevices;
 
 	// subscriptions
-	typedef QMap<QString, MidiPortList> SubMap;
+	using SubMap = QMap<QString, MidiPortList>;
 	SubMap m_inputSubs;
 	SubMap m_outputSubs;
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -39,7 +39,7 @@ namespace lmms
 
 
 class MixerRoute;
-typedef QVector<MixerRoute *> MixerRouteVector;
+using MixerRouteVector = QVector<MixerRoute*>;
 
 class MixerChannel : public ThreadableJob
 {

--- a/include/Note.h
+++ b/include/Note.h
@@ -248,9 +248,7 @@ private:
 	DetuningHelper * m_detuning;
 };
 
-
-typedef QVector<Note *> NoteVector;
-
+using NoteVector = QVector<Note*>;
 
 } // namespace lmms
 

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -42,9 +42,8 @@ namespace lmms
 class InstrumentTrack;
 class NotePlayHandle;
 
-typedef QList<NotePlayHandle *> NotePlayHandleList;
-typedef QList<const NotePlayHandle *> ConstNotePlayHandleList;
-
+using NotePlayHandleList = QList<NotePlayHandle*>;
+using ConstNotePlayHandleList = QList<const NotePlayHandle*>;
 
 class LMMS_EXPORT NotePlayHandle : public PlayHandle, public Note
 {
@@ -65,7 +64,7 @@ public:
 		OriginArpeggio,		/*! created by arpeggio instrument function */
 		OriginCount
 	};
-	typedef Origins Origin;
+	using Origin = Origins;
 
 	NotePlayHandle( InstrumentTrack* instrumentTrack,
 					const f_cnt_t offset,

--- a/include/OscillatorConstants.h
+++ b/include/OscillatorConstants.h
@@ -50,9 +50,8 @@ namespace lmms::OscillatorConstants
 	//  - wave shape: abstract and precise definition of the graph associated with a given type of wave;
 	//  - waveform: digital representations the wave shape, a set of waves optimized for use at varying pitches;
 	//  - wavetable: a table containing one period of a wave, with frequency content optimized for a specific pitch.
-	typedef std::array<sample_t, WAVETABLE_LENGTH> wavetable_t;
-	typedef std::array<wavetable_t,	WAVE_TABLES_PER_WAVEFORM_COUNT> waveform_t;
-
+	using wavetable_t = std::array<sample_t, WAVETABLE_LENGTH>;
+	using waveform_t = std::array<wavetable_t, WAVE_TABLES_PER_WAVEFORM_COUNT>;
 
 } // namespace lmms::OscillatorConstants
 

--- a/include/PatternTrack.h
+++ b/include/PatternTrack.h
@@ -94,7 +94,7 @@ protected:
 private:
 	QList<Track *> m_disabledTracks;
 
-	typedef QMap<PatternTrack*, int> infoMap;
+	using infoMap = QMap<PatternTrack*, int>;
 	static infoMap s_infoMap;
 
 	friend class gui::PatternTrackView;

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -36,8 +36,7 @@ namespace lmms
 
 class PeakControllerEffect;
 
-typedef QVector<PeakControllerEffect *> PeakControllerEffectVector;
-
+using PeakControllerEffectVector = QVector<PeakControllerEffect*>;
 
 class LMMS_EXPORT PeakController : public Controller
 {

--- a/include/Pitch.h
+++ b/include/Pitch.h
@@ -30,8 +30,7 @@
 namespace lmms
 {
 
-
-typedef int16_t pitch_t;
+using pitch_t = int16_t;
 
 constexpr pitch_t CentsPerSemitone = 100;
 constexpr pitch_t MinPitchDefault = -CentsPerSemitone;

--- a/include/PlayHandle.h
+++ b/include/PlayHandle.h
@@ -52,7 +52,7 @@ public:
 		TypeSamplePlayHandle = 0x04,
 		TypePresetPreviewHandle = 0x08
 	} ;
-	typedef Types Type;
+	using Type = Types;
 
 	enum
 	{
@@ -161,9 +161,8 @@ private:
 	AudioPort * m_audioPort;
 } ;
 
-
-typedef QList<PlayHandle *> PlayHandleList;
-typedef QList<const PlayHandle *> ConstPlayHandleList;
+using PlayHandleList = QList<PlayHandle*>;
+using ConstPlayHandleList = QList<const PlayHandle*>;
 
 } // namespace lmms
 

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -136,7 +136,7 @@ public:
 			*/
 			struct Key
 			{
-				typedef QMap<QString, QString> AttributeMap;
+				using AttributeMap = QMap<QString, QString>;
 
 				inline Key( const Plugin::Descriptor * desc = nullptr,
 						const QString & name = QString(),
@@ -179,8 +179,7 @@ public:
 				const PixmapLoader* logo() const;
 			} ;
 
-			typedef QList<Key> KeyList;
-
+			using KeyList = QList<Key>;
 
 			SubPluginFeatures( Plugin::PluginTypes type ) :
 				m_type( type )
@@ -235,7 +234,7 @@ public:
 
 	} ;
 	// typedef a list so we can easily work with list of plugin descriptors
-	typedef QList<Descriptor*> DescriptorList;
+	using DescriptorList = QList<Descriptor*>;
 
 	//! Constructor of a plugin
 	//! @param key Sub plugins must pass a key here, optional otherwise.
@@ -307,8 +306,7 @@ private:
 	Descriptor::SubPluginFeatures::Key m_key;
 
 	// pointer to instantiation-function in plugin
-	typedef Plugin * ( * InstantiationHook )( Model * , void * );
-
+	using InstantiationHook = Plugin* (*)(Model*, void*);
 } ;
 
 

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -62,7 +62,7 @@ class PluginDescWidget : public QWidget
 {
 	Q_OBJECT
 public:
-	typedef Plugin::Descriptor::SubPluginFeatures::Key PluginKey;
+	using PluginKey = Plugin::Descriptor::SubPluginFeatures::Key;
 	PluginDescWidget( const PluginKey & _pk, QWidget * _parent );
 	QString name() const;
 

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -53,8 +53,8 @@ public:
 
 		bool isNull() const {return ! library;}
 	};
-	typedef QList<PluginInfo> PluginInfoList;
-	typedef QMultiMap<Plugin::PluginTypes, Plugin::Descriptor*> DescriptorMap;
+	using PluginInfoList = QList<PluginInfo>;
+	using DescriptorMap = QMultiMap<Plugin::PluginTypes, Plugin::Descriptor*>;
 
 	PluginFactory();
 	~PluginFactory() = default;

--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -100,7 +100,7 @@ public:
 
 
 private:
-	typedef QHash<jo_id_t, JournallingObject *> JoIdMap;
+	using JoIdMap = QHash<jo_id_t, JournallingObject*>;
 
 	struct CheckPoint
 	{
@@ -112,7 +112,7 @@ private:
 		jo_id_t joID;
 		DataFile data;
 	} ;
-	typedef QStack<CheckPoint> CheckPointStack;
+	using CheckPointStack = QStack<CheckPoint>;
 
 	JoIdMap m_joIDs;
 

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -206,7 +206,7 @@ RemotePluginClient::RemotePluginClient( const char * socketPath ) :
 	{
 		fprintf( stderr, "Could not connect to local server.\n" );
 	}
-	if ( ::connect( m_socket, (struct sockaddr *) &sa, sizeof sa ) == -1 )
+	if (QIODevice::connect(m_socket, (struct sockaddr*)&sa, sizeof sa) == -1)
 	{
 		fprintf( stderr, "Could not connect to local server.\n" );
 	}

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -206,7 +206,7 @@ RemotePluginClient::RemotePluginClient( const char * socketPath ) :
 	{
 		fprintf( stderr, "Could not connect to local server.\n" );
 	}
-	if (QIODevice::connect(m_socket, (struct sockaddr*)&sa, sizeof sa) == -1)
+	if ( ::connect( m_socket, (struct sockaddr *) &sa, sizeof sa ) == -1 )
 	{
 		fprintf( stderr, "Could not connect to local server.\n" );
 	}

--- a/include/SampleRecordHandle.h
+++ b/include/SampleRecordHandle.h
@@ -61,7 +61,7 @@ private:
 	virtual void writeBuffer( const sampleFrame * _ab,
 						const f_cnt_t _frames );
 
-	typedef QList<QPair<sampleFrame *, f_cnt_t> > bufferList;
+	using bufferList = QList<QPair<sampleFrame*, f_cnt_t>>;
 	bufferList m_buffers;
 	f_cnt_t m_framesRecorded;
 	TimePos m_minLength;

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -167,10 +167,9 @@ private:
 	bool m_syncVSTPlugins;
 	bool m_disableAutoQuit;
 
-
-	typedef QMap<QString, AudioDeviceSetupWidget *> AswMap;
-	typedef QMap<QString, MidiSetupWidget *> MswMap;
-	typedef QMap<QString, QString> trMap;
+	using AswMap = QMap<QString, AudioDeviceSetupWidget*>;
+	using MswMap = QMap<QString, MidiSetupWidget*>;
+	using trMap = QMap<QString, QString>;
 
 	// Audio settings widgets.
 	QComboBox * m_audioInterfaces;

--- a/include/SideBar.h
+++ b/include/SideBar.h
@@ -53,7 +53,7 @@ private slots:
 
 private:
 	QButtonGroup m_btnGroup;
-	typedef QMap<QToolButton *, QWidget *> ButtonMap;
+	using ButtonMap = QMap<QToolButton*, QWidget*>;
 	ButtonMap m_widgets;
 
 } ;

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -91,7 +91,7 @@ private:
 		QString name;        // name for widget
 		int nwidth;          // width of name when painting (only valid for text tab)
 	} ;
-	typedef QMap<int, widgetDesc> widgetStack;
+	using widgetStack = QMap<int, widgetDesc>;
 
 	widgetStack m_widgets;
 

--- a/include/TimeDisplayWidget.h
+++ b/include/TimeDisplayWidget.h
@@ -57,7 +57,7 @@ private:
 		BarsTicks,
 		DisplayModeCount
 	};
-	typedef DisplayModes DisplayMode;
+	using DisplayMode = DisplayModes;
 
 	void setDisplayMode( DisplayMode displayMode );
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -70,7 +70,7 @@ class LMMS_EXPORT Track : public Model, public JournallingObject
 	mapPropertyFromModel(bool,isMuted,setMuted,m_mutedModel);
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
-	typedef QVector<Clip *> clipVector;
+	using clipVector = QVector<Clip*>;
 
 	enum TrackTypes
 	{

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -49,7 +49,7 @@ class LMMS_EXPORT TrackContainer : public Model, public JournallingObject
 {
 	Q_OBJECT
 public:
-	typedef QVector<Track *> TrackList;
+	using TrackList = QVector<Track*>;
 	enum TrackContainerTypes
 	{
 		PatternContainer,

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -196,7 +196,7 @@ private:
 	friend class TrackContainerView::scrollArea;
 
 	TrackContainer* m_tc;
-	typedef QList<TrackView *> trackViewList;
+	using trackViewList = QList<TrackView*>;
 	trackViewList m_trackViews;
 
 	scrollArea * m_scrollArea;

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -132,7 +132,7 @@ private:
 
 	TrackView * m_trackView;
 
-	typedef QVector<ClipView *> clipViewVector;
+	using clipViewVector = QVector<ClipView*>;
 	clipViewVector m_clipViews;
 
 	QPixmap m_background;

--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -296,8 +296,6 @@ public:
 
 } ;
 
-
-
-typedef intptr_t (VST_CALL_CONV * audioMasterCallback)( AEffect * , int32_t, int32_t, intptr_t, void * , float );
+using audioMasterCallback = intptr_t (*)(AEffect*, int32_t, int32_t, intptr_t, void*, float);
 
 #endif

--- a/include/aeffectx.h
+++ b/include/aeffectx.h
@@ -296,6 +296,6 @@ public:
 
 } ;
 
-using audioMasterCallback = intptr_t (*)(AEffect*, int32_t, int32_t, intptr_t, void*, float);
+using audioMasterCallback = intptr_t (VST_CALL_CONV*)(AEffect*, int32_t, int32_t, intptr_t, void*, float);
 
 #endif

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -38,27 +38,23 @@
 namespace lmms
 {
 
+using bar_t = int32_t;
+using tick_t = int32_t;
+using volume_t = uint8_t;
+using panning_t = int8_t;
 
-typedef int32_t bar_t;
-typedef int32_t tick_t;
-typedef uint8_t volume_t;
-typedef int8_t panning_t;
+using sample_t = float;		  // standard sample-type
+using int_sample_t = int16_t; // 16-bit-int-sample
 
+using sample_rate_t = uint32_t; // sample-rate
+using fpp_t = int16_t;			// frames per period (0-16384)
+using f_cnt_t = int32_t;		// standard frame-count
+using ch_cnt_t = uint8_t;		// channel-count (0-SURROUND_CHANNELS)
+using bpm_t = uint16_t;			// tempo (MIN_BPM to MAX_BPM)
+using bitrate_t = uint16_t;		// bitrate in kbps
+using mix_ch_t = uint16_t;		// Mixer-channel (0 to MAX_CHANNEL)
 
-typedef float sample_t;			// standard sample-type
-typedef int16_t int_sample_t;		// 16-bit-int-sample
-
-
-typedef uint32_t sample_rate_t;		// sample-rate
-typedef int16_t fpp_t;			// frames per period (0-16384)
-typedef int32_t f_cnt_t;			// standard frame-count
-typedef uint8_t ch_cnt_t;			// channel-count (0-SURROUND_CHANNELS)
-typedef uint16_t bpm_t;			// tempo (MIN_BPM to MAX_BPM)
-typedef uint16_t bitrate_t;		// bitrate in kbps
-typedef uint16_t mix_ch_t;			// Mixer-channel (0 to MAX_CHANNEL)
-
-typedef uint32_t jo_id_t;			// (unique) ID of a journalling object
-
+using jo_id_t = uint32_t; // (unique) ID of a journalling object
 
 // windows headers define "min" and "max" macros, breaking the methods bwloe
 #undef min

--- a/include/volume.h
+++ b/include/volume.h
@@ -36,11 +36,10 @@ constexpr volume_t MinVolume = 0;
 constexpr volume_t MaxVolume = 200;
 constexpr volume_t DefaultVolume = 100;
 
-typedef struct
+using StereoVolumeVector = struct
 {
 	float vol[2];
-} StereoVolumeVector;
-
+};
 
 } // namespace lmms
 

--- a/include/volume.h
+++ b/include/volume.h
@@ -36,7 +36,7 @@ constexpr volume_t MinVolume = 0;
 constexpr volume_t MaxVolume = 200;
 constexpr volume_t DefaultVolume = 100;
 
-using StereoVolumeVector = struct
+struct StereoVolumeVector
 {
 	float vol[2];
 };

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -98,7 +98,7 @@ signals:
 
 
 private:
-	typedef SampleBuffer::handleState handleState;
+	using handleState = SampleBuffer::handleState;
 
 	SampleBuffer m_sampleBuffer;
 

--- a/plugins/FreeBoy/Gb_Apu_Buffer.h
+++ b/plugins/FreeBoy/Gb_Apu_Buffer.h
@@ -41,7 +41,7 @@ public:
 
 	blargg_err_t set_sample_rate(long sample_rate, long clock_rate);
 	long samples_avail() const;
-	typedef blip_sample_t sample_t;
+	using sample_t = blip_sample_t;
 	long read_samples(sample_t* out, long count);
 	void bass_freq(int freq);
 private:

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -154,11 +154,8 @@ QString KickerInstrument::nodeName() const
 	return kicker_plugin_descriptor.name;
 }
 
-
-
-typedef DspEffectLibrary::Distortion DistFX;
-typedef KickerOsc<DspEffectLibrary::MonoToStereoAdaptor<DistFX> > SweepOsc;
-
+using DistFX = DspEffectLibrary::Distortion;
+using SweepOsc = KickerOsc<DspEffectLibrary::MonoToStereoAdaptor<DistFX>>;
 
 void KickerInstrument::playNote( NotePlayHandle * _n,
 						sampleFrame * _working_buffer )

--- a/plugins/LadspaEffect/LadspaControls.h
+++ b/plugins/LadspaEffect/LadspaControls.h
@@ -33,7 +33,7 @@ namespace lmms
 
 
 class LadspaControl;
-typedef QVector<LadspaControl *> control_list_t;
+using control_list_t = QVector<LadspaControl*>;
 
 class LadspaEffect;
 

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -311,7 +311,7 @@ void LadspaEffect::pluginInstantiation()
 		multi_proc_t ports;
 		for( int port = 0; port < m_portCount; port++ )
 		{
-			port_desc_t * p = new PortDescription;
+			port_desc_t * p = new port_desc_t;
 
 			p->name = manager->getPortName( m_key, port );
 			p->proc = proc;

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -36,7 +36,7 @@
 namespace lmms
 {
 
-using PortDescription = struct port_desc_t;
+struct port_desc_t;
 using multi_proc_t = QVector<port_desc_t*>;
 
 class LadspaEffect : public Effect

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -30,13 +30,13 @@
 
 #include "Effect.h"
 #include "ladspa.h"
-#include "LadspaBase.h"
 #include "LadspaControls.h"
 #include "LadspaManager.h"
 
 namespace lmms
 {
 
+using port_desc_t = struct PortDescription;
 using multi_proc_t = QVector<port_desc_t*>;
 
 class LadspaEffect : public Effect

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -36,7 +36,7 @@
 namespace lmms
 {
 
-using port_desc_t = struct PortDescription;
+using PortDescription = struct port_desc_t;
 using multi_proc_t = QVector<port_desc_t*>;
 
 class LadspaEffect : public Effect

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -36,9 +36,8 @@
 namespace lmms
 {
 
-
-typedef struct PortDescription port_desc_t;
-typedef QVector<port_desc_t *> multi_proc_t;
+using port_desc_t = struct PortDescription;
+using multi_proc_t = QVector<port_desc_t*>;
 
 class LadspaEffect : public Effect
 {

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -30,13 +30,13 @@
 
 #include "Effect.h"
 #include "ladspa.h"
+#include "LadspaBase.h"
 #include "LadspaControls.h"
 #include "LadspaManager.h"
 
 namespace lmms
 {
 
-using port_desc_t = struct PortDescription;
 using multi_proc_t = QVector<port_desc_t*>;
 
 class LadspaEffect : public Effect

--- a/plugins/MidiExport/MidiExport.h
+++ b/plugins/MidiExport/MidiExport.h
@@ -38,7 +38,7 @@ namespace lmms
 
 
 const int BUFFER_SIZE = 50*1024;
-typedef MidiFile::MIDITrack<BUFFER_SIZE> MTrack;
+using MTrack = MidiFile::MIDITrack<BUFFER_SIZE>;
 
 struct MidiNote
 {
@@ -53,10 +53,8 @@ struct MidiNote
 	}
 } ;
 
-typedef std::vector<MidiNote> MidiNoteVector;
-typedef std::vector<MidiNote>::iterator MidiNoteIterator;
-
-
+using MidiNoteVector = std::vector<MidiNote>;
+using MidiNoteIterator = std::vector<MidiNote>::iterator;
 
 class MidiExport: public ExportFilter
 {

--- a/plugins/MidiImport/MidiImport.h
+++ b/plugins/MidiImport/MidiImport.h
@@ -120,8 +120,7 @@ private:
 		}
 	}
 
-
-	typedef QVector<QPair<int, MidiEvent> > EventVector;
+	using EventVector = QVector<QPair<int, MidiEvent>>;
 	EventVector m_events;
 	int m_timingDivision;
 

--- a/plugins/MidiImport/portsmf/allegro.h
+++ b/plugins/MidiImport/portsmf/allegro.h
@@ -68,7 +68,7 @@ char *heapify(const char *s); // put a string on the heap
 // the attribute 'tempor' (a real) is stored
 // as 'rtempor'. To get the string name, just
 // use attribute+1.
-typedef const char *Alg_attribute;
+using Alg_attribute = const char*;
 #define alg_attr_name(a) ((a) + 1)
 #define alg_attr_type(a) (*(a))
 
@@ -113,65 +113,45 @@ extern Alg_atoms symbol_table;
 // an attribute/value pair. Since Alg_attribute names imply type,
 // we try to keep attributes and values packaged together as
 // Alg_parameter class
-typedef class Alg_parameter {
-public:
-    // This constructor guarantees that an Alg_parameter can be
-    // deleted safely without further initialization. It does not
-    // do anything useful, so it is expected that the creator will
-    // set attr and store a value in the appropriate union field.
-    Alg_attribute attr;
-    union {
-        double r;// real
-        const char *s; // string
-        long i;  // integer
-        bool l;  // logical
-        const char *a; // symbol (atom)
-    }; // anonymous union
-
-    Alg_parameter() { attr = "i"; }
-    ~Alg_parameter();
-    void copy(Alg_parameter *); // copy from another parameter
-    const char attr_type() { return alg_attr_type(attr); }
-    const char *attr_name() { return alg_attr_name(attr); }
-    void set_attr(Alg_attribute a) { attr = a; }
-    void show();
-} *Alg_parameter_ptr;
-
+using Alg_parameter_ptr = union
+{
+	double r;	   // real
+	const char* s; // string
+	long i;		   // integer
+	bool l;		   // logical
+	const char* a; // symbol (atom)
+};
 
 // a list of attribute/value pairs
-typedef class Alg_parameters {
+using Alg_parameters_ptr = class Alg_parameters
+{
 public:
-    class Alg_parameters *next;
-    Alg_parameter parm;
+	class Alg_parameters* next;
+	Alg_parameter parm;
 
-    Alg_parameters(Alg_parameters *list) {
-        next = list;
-    }
+	Alg_parameters(Alg_parameters* list) { next = list; }
 
-    //~Alg_parameters() { }
+	//~Alg_parameters() { }
 
-    // each of these routines takes address of pointer to the list
-    // insertion is performed without checking whether or not a
-    // parameter already exists with this attribute. See find() and
-    // remove_key() to assist in checking for and removing existing 
-    // parameters.
-    // Note also that these insert_* methods convert name to an
-    // attribute. If you have already done the symbol table lookup/insert
-    // you can do these operations faster (in which case we should add
-    // another set of functions that take attributes as arguments.)
-    static void insert_real(Alg_parameters **list, const char *name, double r);
-    // insert string will copy string to heap
-    static void insert_string(Alg_parameters **list, const char *name, 
-                              const char *s);
-    static void insert_integer(Alg_parameters **list, const char *name, long i);
-    static void insert_logical(Alg_parameters **list, const char *name, bool l);
-    static void insert_atom(Alg_parameters **list, const char *name, 
-                            const char *s);
-    static Alg_parameters *remove_key(Alg_parameters **list, const char *name);
-    // find an attribute/value pair
-    Alg_parameter_ptr find(Alg_attribute attr);
-} *Alg_parameters_ptr;
-
+	// each of these routines takes address of pointer to the list
+	// insertion is performed without checking whether or not a
+	// parameter already exists with this attribute. See find() and
+	// remove_key() to assist in checking for and removing existing
+	// parameters.
+	// Note also that these insert_* methods convert name to an
+	// attribute. If you have already done the symbol table lookup/insert
+	// you can do these operations faster (in which case we should add
+	// another set of functions that take attributes as arguments.)
+	static void insert_real(Alg_parameters** list, const char* name, double r);
+	// insert string will copy string to heap
+	static void insert_string(Alg_parameters** list, const char* name, const char* s);
+	static void insert_integer(Alg_parameters** list, const char* name, long i);
+	static void insert_logical(Alg_parameters** list, const char* name, bool l);
+	static void insert_atom(Alg_parameters** list, const char* name, const char* s);
+	static Alg_parameters* remove_key(Alg_parameters** list, const char* name);
+	// find an attribute/value pair
+	Alg_parameter_ptr find(Alg_attribute attr);
+};
 
 // these are type codes associated with certain attributes
 // see Alg_track::find() where these are bit positions in event_type_mask
@@ -187,340 +167,367 @@ public:
 #define ALG_OTHER 9 // any other value
 
 // abstract superclass of Alg_note and Alg_update:
-typedef class Alg_event {
+using Alg_event_ptr = class Alg_event
+{
 protected:
-    bool selected;
-    char type; // 'e' event, 'n' note, 'u' update
-    long key; // note identifier
-    static const char* description; // static buffer for debugging (in Alg_event)
+	bool selected;
+	char type;						// 'e' event, 'n' note, 'u' update
+	long key;						// note identifier
+	static const char* description; // static buffer for debugging (in Alg_event)
 public:
-    double time;
-    long chan;
-    virtual void show() = 0;
-    // Note: there is no Alg_event() because Alg_event is an abstract class.
-    bool is_note() { return (type == 'n'); }   // tell whether an Alg_event is a note
-    bool is_update() { return (type == 'u'); } // tell whether an Alg_event is a parameter update
-    char get_type() { return type; }   // return 'n' for note, 'u' for update
-    int get_type_code();  // 1 = volume change,      2 = pitch bend,
-                          // 3 = control change,     4 = program change,
-                          // 5 = pressure change,    6 = key signature,
-                          // 7 = time sig numerator, 8 = time sig denominator
-    bool get_selected() { return selected; }         
-    void set_selected(bool b) { selected = b; }     
-    // Note: notes are identified by a (channel, identifier) pair. 
-    // For midi, the identifier is the key number (pitch). The identifier
-    // does not have to represent pitch; it's main purpose is to identify
-    // notes so that they can be named by subsequent update events.
-    long get_identifier() { return key; } // get MIDI key or note identifier of note or update
-    void set_identifier(long i) { key = i; } // set the identifier
-    // In all of these set_ methods, strings are owned by the caller and
-    // copied as necessary by the callee. For notes, an attribute/value
-    // pair is added to the parameters list. For updates, the single
-    // attribute/value parameter pair is overwritten. In all cases, the
-    // attribute (first argument) must agree in type with the second arg.
-    // The last letter of the attribute implies the type (see below).
-    void set_parameter(Alg_parameter_ptr new_parameter);
-    void set_string_value(const char *attr, const char *value);
-    void set_real_value(const char *attr, double value);
-    void set_logical_value(const char *attr, bool value);
-    void set_integer_value(const char *attr, long value);
-    void set_atom_value(const char *attr, const char *atom);
+	double time;
+	long chan;
+	virtual void show() = 0;
+	// Note: there is no Alg_event() because Alg_event is an abstract class.
+	bool is_note() { return (type == 'n'); }   // tell whether an Alg_event is a note
+	bool is_update() { return (type == 'u'); } // tell whether an Alg_event is a parameter update
+	char get_type() { return type; }		   // return 'n' for note, 'u' for update
+	int get_type_code();					   // 1 = volume change,      2 = pitch bend,
+											   // 3 = control change,     4 = program change,
+											   // 5 = pressure change,    6 = key signature,
+											   // 7 = time sig numerator, 8 = time sig denominator
+	bool get_selected() { return selected; }
+	void set_selected(bool b) { selected = b; }
+	// Note: notes are identified by a (channel, identifier) pair.
+	// For midi, the identifier is the key number (pitch). The identifier
+	// does not have to represent pitch; it's main purpose is to identify
+	// notes so that they can be named by subsequent update events.
+	long get_identifier() { return key; }	 // get MIDI key or note identifier of note or update
+	void set_identifier(long i) { key = i; } // set the identifier
+	// In all of these set_ methods, strings are owned by the caller and
+	// copied as necessary by the callee. For notes, an attribute/value
+	// pair is added to the parameters list. For updates, the single
+	// attribute/value parameter pair is overwritten. In all cases, the
+	// attribute (first argument) must agree in type with the second arg.
+	// The last letter of the attribute implies the type (see below).
+	void set_parameter(Alg_parameter_ptr new_parameter);
+	void set_string_value(const char* attr, const char* value);
+	void set_real_value(const char* attr, double value);
+	void set_logical_value(const char* attr, bool value);
+	void set_integer_value(const char* attr, long value);
+	void set_atom_value(const char* attr, const char* atom);
 
-    // Some note methods. These fail (via assert()) if this is not a note:
-    //
-    float get_pitch();// get pitch in steps -- use this even for MIDI
-    float get_loud(); // get loudness (MIDI velocity)
-    // times are in seconds or beats, depending upon the units_are_seconds 
-    // flag in the containing sequence
-    double get_start_time(); // get start time in seconds or beats
-    double get_end_time();   // get end time in seconds or beats
-    double get_duration();   // get duration in seconds or beats
-    void set_pitch(float);
-    void set_loud(float);
-    void set_duration(double);
+	// Some note methods. These fail (via assert()) if this is not a note:
+	//
+	float get_pitch(); // get pitch in steps -- use this even for MIDI
+	float get_loud();  // get loudness (MIDI velocity)
+	// times are in seconds or beats, depending upon the units_are_seconds
+	// flag in the containing sequence
+	double get_start_time(); // get start time in seconds or beats
+	double get_end_time();	 // get end time in seconds or beats
+	double get_duration();	 // get duration in seconds or beats
+	void set_pitch(float);
+	void set_loud(float);
+	void set_duration(double);
 
-    // Notes have lists of attribute values. Attributes are converted
-    // to/from strings in this API to avoid explicit use of Alg_attribute
-    // types. Attribute names end with a type designation: 's', 'r', 'l',
-    // 'i', or 'a'.
-    //
-    bool has_attribute(const char *attr);      // test if note has attribute/value pair
-    char get_attribute_type(const char *attr); // get the associated type: 
-        // 's' = string, 
-        // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
-        // 'a' = atom (char *), a unique string stored in Alg_seq
-    // get the string value
-    const char *get_string_value(const char *attr, const char *value = nullptr);
-    // get the real value
-    double get_real_value(const char *attr, double value = 0.0);
-    // get the logical value
-    bool get_logical_value(const char *attr, bool value = false);
-    // get the integer value
-    long get_integer_value(const char *attr, long value = 0);
-    // get the atom value
-    const char *get_atom_value(const char *attr, const char *value = nullptr);
-    void delete_attribute(const char *attr);   // delete an attribute/value pair
-        // (ignore if no matching attribute/value pair exists)
+	// Notes have lists of attribute values. Attributes are converted
+	// to/from strings in this API to avoid explicit use of Alg_attribute
+	// types. Attribute names end with a type designation: 's', 'r', 'l',
+	// 'i', or 'a'.
+	//
+	bool has_attribute(const char* attr);	   // test if note has attribute/value pair
+	char get_attribute_type(const char* attr); // get the associated type:
+											   // 's' = string,
+											   // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
+											   // 'a' = atom (char *), a unique string stored in Alg_seq
+	// get the string value
+	const char* get_string_value(const char* attr, const char* value = nullptr);
+	// get the real value
+	double get_real_value(const char* attr, double value = 0.0);
+	// get the logical value
+	bool get_logical_value(const char* attr, bool value = false);
+	// get the integer value
+	long get_integer_value(const char* attr, long value = 0);
+	// get the atom value
+	const char* get_atom_value(const char* attr, const char* value = nullptr);
+	void delete_attribute(const char* attr); // delete an attribute/value pair
+											 // (ignore if no matching attribute/value pair exists)
 
-    // Some attribute/value methods. These fail if this is not an update.
-    // Attributes are converted to/from strings to avoid explicit use
-    // of Alg_attribute types.
-    // 
-    const char *get_attribute();    // get the update's attribute (string)
-    char get_update_type();   // get the update's type: 's' = string, 
-        // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
-        // 'a' = atom (char *), a unique string stored in Alg_seq
-    const char *get_string_value(); // get the update's string value
-        // Notes: Caller does not own the return value. Do not modify.
-        // Do not use after underlying Alg_seq is modified.
-    double get_real_value();  // get the update's real value
-    bool get_logical_value(); // get the update's logical value
-    long get_integer_value(); // get the update's integer value
-    const char *get_atom_value();   // get the update's atom value
-        // Notes: Caller does not own the return value. Do not modify.
-        // The return value's lifetime is forever.
+	// Some attribute/value methods. These fail if this is not an update.
+	// Attributes are converted to/from strings to avoid explicit use
+	// of Alg_attribute types.
+	//
+	const char* get_attribute(); // get the update's attribute (string)
+	char get_update_type();		 // get the update's type: 's' = string,
+							// 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
+							// 'a' = atom (char *), a unique string stored in Alg_seq
+	const char* get_string_value(); // get the update's string value
+									// Notes: Caller does not own the return value. Do not modify.
+									// Do not use after underlying Alg_seq is modified.
+	double get_real_value();	  // get the update's real value
+	bool get_logical_value();	  // get the update's logical value
+	long get_integer_value();	  // get the update's integer value
+	const char* get_atom_value(); // get the update's atom value
+								  // Notes: Caller does not own the return value. Do not modify.
+								  // The return value's lifetime is forever.
 
-    // Auxiliary function to aid in editing tracks
-    // Returns true if the event overlaps the given region
-    bool overlap(double t, double len, bool all);
+	// Auxiliary function to aid in editing tracks
+	// Returns true if the event overlaps the given region
+	bool overlap(double t, double len, bool all);
 
-    const char *GetDescription(); // computes a text description of this event
-    // the result is in a static buffer, not thread-safe, just for debugging.
-    Alg_event() { selected = false; }
-    virtual ~Alg_event() = default;
-} *Alg_event_ptr;
+	const char* GetDescription(); // computes a text description of this event
+	// the result is in a static buffer, not thread-safe, just for debugging.
+	Alg_event() { selected = false; }
+	virtual ~Alg_event() = default;
+};
 
-
-typedef class Alg_note : public Alg_event {
+using Alg_note_ptr = class Alg_note : public Alg_event
+{
 public:
-    ~Alg_note() override;
-    Alg_note(Alg_note *); // copy constructor
-    float pitch; // pitch in semitones (69 = A440)
-    float loud;  // dynamic corresponding to MIDI velocity
-    double dur;   // duration in seconds (normally to release point)
-    Alg_parameters_ptr parameters; // attribute/value pair list
-    Alg_note() { type = 'n'; parameters = nullptr; }
-    void show() override;
-} *Alg_note_ptr;
+	~Alg_note() override;
+	Alg_note(Alg_note*);		   // copy constructor
+	float pitch;				   // pitch in semitones (69 = A440)
+	float loud;					   // dynamic corresponding to MIDI velocity
+	double dur;					   // duration in seconds (normally to release point)
+	Alg_parameters_ptr parameters; // attribute/value pair list
+	Alg_note()
+	{
+		type = 'n';
+		parameters = nullptr;
+	}
+	void show() override;
+};
 
-
-typedef class Alg_update : public Alg_event {
+using Alg_update_ptr = class Alg_update : public Alg_event
+{
 public:
-    ~Alg_update() override = default;
-    Alg_update(Alg_update *); // copy constructor
-    Alg_parameter parameter; // an update contains one attr/value pair
+	~Alg_update() override = default;
+	Alg_update(Alg_update*); // copy constructor
+	Alg_parameter parameter; // an update contains one attr/value pair
 
-
-    Alg_update() { type = 'u'; }
-    void show() override;
-} *Alg_update_ptr;
-
+	Alg_update() { type = 'u'; }
+	void show() override;
+};
 
 // a sequence of Alg_event objects
-typedef class Alg_events {
+using Alg_events_ptr = class Alg_events
+{
 private:
-    long maxlen;
-    void expand();
+	long maxlen;
+	void expand();
+
 protected:
-    long len;
-    Alg_event_ptr *events; // events is array of pointers
+	long len;
+	Alg_event_ptr* events; // events is array of pointers
 public:
-    // sometimes, it is nice to have the time of the last note-off.
-    // In the current implementation,
-    // this field is set by append to indicate the time of the 
-    // last note-off in the current unit, so it should be correct after 
-    // creating a new track and adding notes to it. It is *not*
-    // updated after uninsert(), so use it with care.
-    double last_note_off;
-    // initially false, in_use can be used to mark "do not delete". If an
-    // Alg_events instance is deleted while "in_use", an assertion will fail.
-    bool in_use;
-    virtual int length() { return len; }
-    Alg_event_ptr &operator[](int i) {
-        assert(i >= 0 && i < len);
-        return events[i];
-    }
-    Alg_events() {
-        maxlen = len = 0;
-        events = nullptr;
-        last_note_off = 0;
-        in_use = false;
-    }
-    // destructor deletes the events array, but not the
-    // events themselves
-    virtual ~Alg_events();
-    void set_events(Alg_event_ptr *e, long l, long m) {
-        if (events) delete [] events;
-        events = e; len = l; maxlen = m; }
-    // for use by Alg_track and Alg_seq
-    void insert(Alg_event_ptr event);
-    void append(Alg_event_ptr event);
-    Alg_event_ptr uninsert(long index);
-} *Alg_events_ptr;
+	// sometimes, it is nice to have the time of the last note-off.
+	// In the current implementation,
+	// this field is set by append to indicate the time of the
+	// last note-off in the current unit, so it should be correct after
+	// creating a new track and adding notes to it. It is *not*
+	// updated after uninsert(), so use it with care.
+	double last_note_off;
+	// initially false, in_use can be used to mark "do not delete". If an
+	// Alg_events instance is deleted while "in_use", an assertion will fail.
+	bool in_use;
+	virtual int length() { return len; }
+	Alg_event_ptr& operator[](int i)
+	{
+		assert(i >= 0 && i < len);
+		return events[i];
+	}
+	Alg_events()
+	{
+		maxlen = len = 0;
+		events = nullptr;
+		last_note_off = 0;
+		in_use = false;
+	}
+	// destructor deletes the events array, but not the
+	// events themselves
+	virtual ~Alg_events();
+	void set_events(Alg_event_ptr* e, long l, long m)
+	{
+		if (events) delete[] events;
+		events = e;
+		len = l;
+		maxlen = m;
+	}
+	// for use by Alg_track and Alg_seq
+	void insert(Alg_event_ptr event);
+	void append(Alg_event_ptr event);
+	Alg_event_ptr uninsert(long index);
+};
 
 class Alg_track;
 
-typedef class Alg_event_list : public Alg_events {
+using Alg_event_list_ptr = class Alg_event_list : public Alg_events
+{
 protected:
-    char type; // 'e' Alg_event_list, 't' Alg_track, 's' Alg_seq
-    static const char *last_error_message;
-    Alg_track *events_owner; // if this is an Alg_event_list,
-        // the events are owned by an Alg_track or an Alg_seq
-    static int sequences;  // to keep track of sequence numbers
-    int sequence_number;   // this sequence number is incremented
-        // whenever an edit is performed on an Alg_track or Alg_seq.
-        // When an Alg_event_list is created to contain pointers to
-        // a subset of an Alg_track or Alg_seq (the events_owner), 
-        // the Alg_event_list gets a copy of the events_owner's 
-        // sequence_number. If the events_owner is edited, the pointers
-        // in this Alg_event_list will become invalid. This is detected
-        // (for debugging) as differing sequence_numbers.
+	char type; // 'e' Alg_event_list, 't' Alg_track, 's' Alg_seq
+	static const char* last_error_message;
+	Alg_track* events_owner; // if this is an Alg_event_list,
+							 // the events are owned by an Alg_track or an Alg_seq
+	static int sequences; // to keep track of sequence numbers
+	int sequence_number;  // this sequence number is incremented
+						 // whenever an edit is performed on an Alg_track or Alg_seq.
+						 // When an Alg_event_list is created to contain pointers to
+						 // a subset of an Alg_track or Alg_seq (the events_owner),
+						 // the Alg_event_list gets a copy of the events_owner's
+						 // sequence_number. If the events_owner is edited, the pointers
+						 // in this Alg_event_list will become invalid. This is detected
+						 // (for debugging) as differing sequence_numbers.
 
-    // every event list, track, and seq has a duration.
-    // Usually the duration is set when the list is constructed, e.g.
-    // when you extract from 10 to 15 seconds, the duration is 5 secs.
-    // The duration does not tell you when is the last note-off.
-    // duration is recorded in both beats and seconds:
-    double beat_dur; 
-    double real_dur;
+	// every event list, track, and seq has a duration.
+	// Usually the duration is set when the list is constructed, e.g.
+	// when you extract from 10 to 15 seconds, the duration is 5 secs.
+	// The duration does not tell you when is the last note-off.
+	// duration is recorded in both beats and seconds:
+	double beat_dur;
+	double real_dur;
+
 public:
-    // the client should not create one of these, but these are
-    // returned from various track and seq operations. An
-    // Alg_event_list "knows" the Alg_track or Alg_seq that "owns"
-    // the events. All events in an Alg_event_list must belong
-    // to the same Alg_track or Alg_seq structure.
-    // When applied to an Alg_seq, events are enumerated track
-    // by track with increasing indices. This operation is not
-    // particularly fast on an Alg_seq.
-    virtual Alg_event_ptr const &operator[](int i);
-    Alg_event_list() { sequence_number = 0; 
-        beat_dur = 0.0; real_dur = 0.0; events_owner = nullptr; type = 'e'; }
-    Alg_event_list(Alg_track *owner);
+	// the client should not create one of these, but these are
+	// returned from various track and seq operations. An
+	// Alg_event_list "knows" the Alg_track or Alg_seq that "owns"
+	// the events. All events in an Alg_event_list must belong
+	// to the same Alg_track or Alg_seq structure.
+	// When applied to an Alg_seq, events are enumerated track
+	// by track with increasing indices. This operation is not
+	// particularly fast on an Alg_seq.
+	virtual Alg_event_ptr const& operator[](int i);
+	Alg_event_list()
+	{
+		sequence_number = 0;
+		beat_dur = 0.0;
+		real_dur = 0.0;
+		events_owner = nullptr;
+		type = 'e';
+	}
+	Alg_event_list(Alg_track* owner);
 
-    char get_type() { return type; }
-    Alg_track *get_owner() { return events_owner; }
+	char get_type() { return type; }
+	Alg_track* get_owner() { return events_owner; }
 
-    // The destructor does not free events because they are owned
-    // by a track or seq structure.
-    ~Alg_event_list() override;
+	// The destructor does not free events because they are owned
+	// by a track or seq structure.
+	~Alg_event_list() override;
 
-    // Returns the duration of the sequence in beats or seconds
-    double get_beat_dur() { return beat_dur; }
-    void set_beat_dur(double d) { beat_dur = d; }
-    double get_real_dur() { return real_dur; }
-    void set_real_dur(double d) { real_dur = d; }
+	// Returns the duration of the sequence in beats or seconds
+	double get_beat_dur() { return beat_dur; }
+	void set_beat_dur(double d) { beat_dur = d; }
+	double get_real_dur() { return real_dur; }
+	void set_real_dur(double d) { real_dur = d; }
 
-    // Events are stored in time order, so when you change the time of
-    // an event, you must adjust the position. When you call set_start_time
-    // on an Alg_event_list, the Alg_event_list is not modified, but the
-    // Alg_track that "owns" the event is modified. If the owner is an 
-    // Alg_seq, this may require searching the seq for the track containing
-    // the event. This will mean a logN search of every track in the seq
-    // (but if this turns out to be a problem, we can store each event's
-    // track owner in the Alg_event_list.)
-    virtual void set_start_time(Alg_event *event, double);
-    // get text description of run-time errors detected, clear error
-    const char *get_last_error_message() { return last_error_message; }
-    // Implementation hint: keep a sequence number on each Alg_track that is 
-    // incremented anytime there is a structural change. (This behavior is
-    // inherited by Alg_seq as well.) Copy the sequence number to any
-    // Alg_event_list object when it is created. Whenever you access an 
-    // Alg_event_list, using operator[], assert that the Alg_event_list sequence
-    // number matches the Alg_seq sequence number. This will guarantee that you
-    // do not try to retain pointers to events beyond the point where the events
-    // may no longer exist.
-} *Alg_event_list_ptr, &Alg_event_list_ref;
-
+	// Events are stored in time order, so when you change the time of
+	// an event, you must adjust the position. When you call set_start_time
+	// on an Alg_event_list, the Alg_event_list is not modified, but the
+	// Alg_track that "owns" the event is modified. If the owner is an
+	// Alg_seq, this may require searching the seq for the track containing
+	// the event. This will mean a logN search of every track in the seq
+	// (but if this turns out to be a problem, we can store each event's
+	// track owner in the Alg_event_list.)
+	virtual void set_start_time(Alg_event* event, double);
+	// get text description of run-time errors detected, clear error
+	const char* get_last_error_message() { return last_error_message; }
+	// Implementation hint: keep a sequence number on each Alg_track that is
+	// incremented anytime there is a structural change. (This behavior is
+	// inherited by Alg_seq as well.) Copy the sequence number to any
+	// Alg_event_list object when it is created. Whenever you access an
+	// Alg_event_list, using operator[], assert that the Alg_event_list sequence
+	// number matches the Alg_seq sequence number. This will guarantee that you
+	// do not try to retain pointers to events beyond the point where the events
+	// may no longer exist.
+};
+using Alg_event_list_ref = class Alg_event_list&;
 
 // Alg_beat is used to contruct a tempo map
-typedef class Alg_beat {
+using Alg_beat_ptr = class Alg_beat
+{
 public:
-    Alg_beat(double t, double b) {
-        time = t; beat = b; }
-    Alg_beat() = default;
-    double time;
-    double beat;
-} *Alg_beat_ptr;
-
+	Alg_beat(double t, double b)
+	{
+		time = t;
+		beat = b;
+	}
+	Alg_beat() = default;
+	double time;
+	double beat;
+};
 
 // Alg_beats is a list of Alg_beat objects used in Alg_seq
-typedef class Alg_beats {
+using Alg_beats_ptr = class Alg_beats
+{
 private:
-    long maxlen;
-    void expand();
+	long maxlen;
+	void expand();
+
 public:
-    long len;
-    Alg_beat_ptr beats;
-    Alg_beat &operator[](int i) {
-        assert(i >= 0 && i < len);
-        return beats[i];
-    }
-    Alg_beats() {
-        maxlen = len = 0;
-        beats = nullptr;
-        expand();
-        beats[0].time = 0;
-        beats[0].beat = 0;
-        len = 1;
-    }
-    ~Alg_beats() {
-        if (beats) delete[] beats;
-    }
-    void insert(long i, Alg_beat_ptr beat);
-} *Alg_beats_ptr;
+	long len;
+	Alg_beat_ptr beats;
+	Alg_beat& operator[](int i)
+	{
+		assert(i >= 0 && i < len);
+		return beats[i];
+	}
+	Alg_beats()
+	{
+		maxlen = len = 0;
+		beats = nullptr;
+		expand();
+		beats[0].time = 0;
+		beats[0].beat = 0;
+		len = 1;
+	}
+	~Alg_beats()
+	{
+		if (beats) delete[] beats;
+	}
+	void insert(long i, Alg_beat_ptr beat);
+};
 
-
-typedef class Alg_time_map {
+using Alg_time_map_ptr = class Alg_time_map
+{
 private:
-    int refcount;
-public:
-    Alg_beats beats; // array of Alg_beat
-    double last_tempo;
-    bool last_tempo_flag;
-    Alg_time_map() {
-        last_tempo = ALG_DEFAULT_BPM / 60.0; // note: this value ignored until
-                // last_tempo_flag is set; nevertheless, the default
-                // tempo is 100.
-        last_tempo_flag = true;
-        refcount = 0;
-    }
-    Alg_time_map(Alg_time_map *map); // copy constructor
-    long length() { return beats.len; }
-    void show();
-    long locate_time(double time);
-    long locate_beat(double beat);
-    double beat_to_time(double beat);
-    double time_to_beat(double time);
-    // Time map manipulations: it is prefered to call the corresponding
-    // methods in Alg_seq. If you manipulate an Alg_time_map directly,
-    // you should take care to convert all tracks that use the time map
-    // to beats or seconds as appropriate: Normally if you insert a beat
-    // you want tracks to be in time units and if you insert a tempo change
-    // you want tracks to be in beat units.
-    void insert_beat(double time, double beat);   // add a point to the map
-    bool insert_tempo(double tempo, double beat); // insert a tempo change
-    // get the tempo starting at beat
-    double get_tempo(double beat);
-    // set the tempo over a region
-    bool set_tempo(double tempo, double start_beat, double end_beat);
-    bool stretch_region(double b0, double b1, double dur);
-    void cut(double start, double len, bool units_are_seconds);
-    void trim(double start, double end, bool units_are_seconds);
-    void paste(double start, Alg_track *tr);
-    // insert a span of time. If start is at a tempo change, then
-    // the span of time runs at the changed tempo
-    void insert_time(double start, double len);
-    // insert a span of beats. If start is at a tempo change, the
-    // tempo change takes effect before the inserted beats
-    void insert_beats(double start, double len);
-    void dereference() {
-        if (--refcount <= 0) delete this;
-    }
-    void reference() {
-        refcount++;
-    }
-} *Alg_time_map_ptr;
+	int refcount;
 
+public:
+	Alg_beats beats; // array of Alg_beat
+	double last_tempo;
+	bool last_tempo_flag;
+	Alg_time_map()
+	{
+		last_tempo = ALG_DEFAULT_BPM / 60.0; // note: this value ignored until
+											 // last_tempo_flag is set; nevertheless, the default
+											 // tempo is 100.
+		last_tempo_flag = true;
+		refcount = 0;
+	}
+	Alg_time_map(Alg_time_map* map); // copy constructor
+	long length() { return beats.len; }
+	void show();
+	long locate_time(double time);
+	long locate_beat(double beat);
+	double beat_to_time(double beat);
+	double time_to_beat(double time);
+	// Time map manipulations: it is prefered to call the corresponding
+	// methods in Alg_seq. If you manipulate an Alg_time_map directly,
+	// you should take care to convert all tracks that use the time map
+	// to beats or seconds as appropriate: Normally if you insert a beat
+	// you want tracks to be in time units and if you insert a tempo change
+	// you want tracks to be in beat units.
+	void insert_beat(double time, double beat);	  // add a point to the map
+	bool insert_tempo(double tempo, double beat); // insert a tempo change
+	// get the tempo starting at beat
+	double get_tempo(double beat);
+	// set the tempo over a region
+	bool set_tempo(double tempo, double start_beat, double end_beat);
+	bool stretch_region(double b0, double b1, double dur);
+	void cut(double start, double len, bool units_are_seconds);
+	void trim(double start, double end, bool units_are_seconds);
+	void paste(double start, Alg_track* tr);
+	// insert a span of time. If start is at a tempo change, then
+	// the span of time runs at the changed tempo
+	void insert_time(double start, double len);
+	// insert a span of beats. If start is at a tempo change, the
+	// tempo change takes effect before the inserted beats
+	void insert_beats(double start, double len);
+	void dereference()
+	{
+		if (--refcount <= 0) delete this;
+	}
+	void reference() { refcount++; }
+};
 
 // Serial_buffer is an abstract class with common elements of
 //     Serial_read_buffer and Serial_write_buffer
@@ -541,302 +548,359 @@ class Serial_buffer {
     long get_len() { return len; }
 };
 
-
-typedef class Serial_read_buffer : public Serial_buffer {
+using Serial_read_buffer_ptr = class Serial_read_buffer : public Serial_buffer
+{
 public:
-    // note that a Serial_read_buffer is initialized for reading by
-    // setting buffer, but it is not the Serial_read_buffer's responsibility
-    // to delete the buffer (owner might want to reuse it), so the destructor
-    // does nothing.
-    ~Serial_read_buffer() override = default;
+	// note that a Serial_read_buffer is initialized for reading by
+	// setting buffer, but it is not the Serial_read_buffer's responsibility
+	// to delete the buffer (owner might want to reuse it), so the destructor
+	// does nothing.
+	~Serial_read_buffer() override = default;
 #if defined(_WIN32)
 //#pragma warning(disable: 546) // cast to int is OK, we only want low 7 bits
 //#pragma warning(disable: 4311) // type cast pointer to long warning
 #endif
-    void get_pad() { while ((intptr_t) ptr & 7) ptr++; }
+	void get_pad()
+	{
+		while ((intptr_t)ptr & 7)
+			ptr++;
+	}
 #if defined(_WIN32)
 //#pragma warning(default: 4311 546)
 #endif
-    // Prepare to read n bytes from buf. The caller must manage buf: it is
-    // valid until reading is finished, and it is caller's responsibility
-    // to free buf when it is no longer needed.
-    void init_for_read(void *buf, long n) {
-        buffer = (char *) buf;
-        ptr = (char *) buf;
-        len = n;
-    }
-    char get_char() { return *ptr++; }
-    void unget_chars(int n) { ptr -= n; } // undo n get_char() calls
-    long get_int32() { long i = *((long *) ptr); ptr += 4; return i; }
-    float get_float() { float f = *((float *) ptr); ptr += 4; return f; }
-    double get_double() { double d = *((double *) ptr); ptr += sizeof(double); 
-                          return d; }
-    const char *get_string() { char *s = ptr; char *fence = buffer + len;
-                         assert(ptr < fence); (void)fence; // unused variable
-                         while (*ptr++) assert(ptr < fence);
-                         get_pad();
-                         return s; }
-    void check_input_buffer(long needed) {
-        assert(get_posn() + needed <= len); }
-} *Serial_read_buffer_ptr;
+	// Prepare to read n bytes from buf. The caller must manage buf: it is
+	// valid until reading is finished, and it is caller's responsibility
+	// to free buf when it is no longer needed.
+	void init_for_read(void* buf, long n)
+	{
+		buffer = (char*)buf;
+		ptr = (char*)buf;
+		len = n;
+	}
+	char get_char() { return *ptr++; }
+	void unget_chars(int n) { ptr -= n; } // undo n get_char() calls
+	long get_int32()
+	{
+		long i = *((long*)ptr);
+		ptr += 4;
+		return i;
+	}
+	float get_float()
+	{
+		float f = *((float*)ptr);
+		ptr += 4;
+		return f;
+	}
+	double get_double()
+	{
+		double d = *((double*)ptr);
+		ptr += sizeof(double);
+		return d;
+	}
+	const char* get_string()
+	{
+		char* s = ptr;
+		char* fence = buffer + len;
+		assert(ptr < fence);
+		(void)fence; // unused variable
+		while (*ptr++)
+			assert(ptr < fence);
+		get_pad();
+		return s;
+	}
+	void check_input_buffer(long needed) { assert(get_posn() + needed <= len); }
+};
 
-
-typedef class Serial_write_buffer: public Serial_buffer {
-  public:
-    // Note: allegro.cpp declares one static instance of Serial_buffer to 
-    // reduce large memory (re)allocations when serializing tracks for UNDO.
-    // This destructor will only run when the program exits, which will only
-    // add overhead to the exit process, but it will eliminate an incorrect
-    // report of memory leakage from automation that doesn't know better. -RBD
-    ~Serial_write_buffer() override {
-        if (buffer) delete [] buffer;
-    }
-    void init_for_write() { ptr = buffer; }
-    // store_long writes a long at a given offset
-    void store_long(long offset, long value) {
-        assert(offset <= get_posn() - 4);
-        long *loc = (long *) (buffer + offset);
-        *loc = value;
-    }
-    void check_buffer(long needed);
-    void set_string(const char *s) { 
-        char *fence = buffer + len;
-        assert(ptr < fence); (void)fence; // unused variable
-        // two brackets surpress a g++ warning, because this is an
-        // assignment operator inside a test.
-        while ((*ptr++ = *s++)) assert(ptr < fence);
-        // 4311 is type cast pointer to long warning
-        // 4312 is type cast long to pointer warning
+using Serial_write_buffer_ptr = class Serial_write_buffer : public Serial_buffer
+{
+public:
+	// Note: allegro.cpp declares one static instance of Serial_buffer to
+	// reduce large memory (re)allocations when serializing tracks for UNDO.
+	// This destructor will only run when the program exits, which will only
+	// add overhead to the exit process, but it will eliminate an incorrect
+	// report of memory leakage from automation that doesn't know better. -RBD
+	~Serial_write_buffer() override
+	{
+		if (buffer) delete[] buffer;
+	}
+	void init_for_write() { ptr = buffer; }
+	// store_long writes a long at a given offset
+	void store_long(long offset, long value)
+	{
+		assert(offset <= get_posn() - 4);
+		long* loc = (long*)(buffer + offset);
+		*loc = value;
+	}
+	void check_buffer(long needed);
+	void set_string(const char* s)
+	{
+		char* fence = buffer + len;
+		assert(ptr < fence);
+		(void)fence; // unused variable
+		// two brackets surpress a g++ warning, because this is an
+		// assignment operator inside a test.
+		while ((*ptr++ = *s++))
+			assert(ptr < fence);
+			// 4311 is type cast pointer to long warning
+			// 4312 is type cast long to pointer warning
 #if defined(_WIN32)
 //#pragma warning(disable: 4311 4312)
 #endif
-        assert((char *)(((long long) (ptr + 7)) & ~7) <= fence);
+		assert((char*)(((long long)(ptr + 7)) & ~7) <= fence);
 #if defined(_WIN32)
 //#pragma warning(default: 4311 4312)
 #endif
-        pad(); }
-    void set_int32(long v) { *((long *) ptr) = v; ptr += 4; }
-    void set_double(double v) { *((double *) ptr) = v; ptr += 8; }
-    void set_float(float v) { *((float *) ptr) = v; ptr += 4; }
-    void set_char(char v) { *ptr++ = v; }
+		pad();
+	}
+	void set_int32(long v)
+	{
+		*((long*)ptr) = v;
+		ptr += 4;
+	}
+	void set_double(double v)
+	{
+		*((double*)ptr) = v;
+		ptr += 8;
+	}
+	void set_float(float v)
+	{
+		*((float*)ptr) = v;
+		ptr += 4;
+	}
+	void set_char(char v) { *ptr++ = v; }
 #if defined(_WIN32)
 //#pragma warning(disable: 546) // cast to int is OK, we only want low 7 bits
 //#pragma warning(disable: 4311) // type cast pointer to long warning
 #endif
-    void pad() { while ((intptr_t) ptr & 7) set_char(0); }
+	void pad()
+	{
+		while ((intptr_t)ptr & 7)
+			set_char(0);
+	}
 #if defined(_WIN32)
 //#pragma warning(default: 4311 546)
 #endif
-    void *to_heap(long *len) {
-        *len = get_posn();
-        char *newbuf = new char[*len];
-        memcpy(newbuf, buffer, *len);
-        return newbuf;
-    }
-} *Serial_write_buffer_ptr;
+	void* to_heap(long* len)
+	{
+		*len = get_posn();
+		char* newbuf = new char[*len];
+		memcpy(newbuf, buffer, *len);
+		return newbuf;
+	}
+};
 
-typedef class Alg_seq *Alg_seq_ptr;
+using Alg_seq_ptr = class Alg_seq;
 
-typedef class Alg_track : public Alg_event_list {
+using Alg_track_ptr = class Alg_track : public Alg_event_list
+{
 protected:
-    Alg_time_map *time_map;
-    bool units_are_seconds;
-    char *get_string(char **p, long *b);
-    long get_int32(char **p, long *b);
-    double get_double(char **p, long *b);
-    float get_float(char **p, long *b);
-    static Serial_read_buffer ser_read_buf;
-    static Serial_write_buffer ser_write_buf;
-    void serialize_parameter(Alg_parameter *parm);
-    // *buffer_ptr points to binary data, bytes_ptr points to how many
-    // bytes have been used so far, len is length of binary data
-    void unserialize_parameter(Alg_parameter_ptr parm_ptr);
+	Alg_time_map* time_map;
+	bool units_are_seconds;
+	char* get_string(char** p, long* b);
+	long get_int32(char** p, long* b);
+	double get_double(char** p, long* b);
+	float get_float(char** p, long* b);
+	static Serial_read_buffer ser_read_buf;
+	static Serial_write_buffer ser_write_buf;
+	void serialize_parameter(Alg_parameter* parm);
+	// *buffer_ptr points to binary data, bytes_ptr points to how many
+	// bytes have been used so far, len is length of binary data
+	void unserialize_parameter(Alg_parameter_ptr parm_ptr);
+
 public:
-    void serialize_track();
-    void unserialize_track();
-    Alg_event_ptr const &operator[](int i) override {
-        assert(i >= 0 && i < len);
-        return events[i];
-    }
-    Alg_track() { units_are_seconds = false; time_map = nullptr;
-                  set_time_map(nullptr); type = 't'; }
-    // initialize empty track with a time map
-    Alg_track(Alg_time_map *map, bool seconds); 
+	void serialize_track();
+	void unserialize_track();
+	Alg_event_ptr const& operator[](int i) override
+	{
+		assert(i >= 0 && i < len);
+		return events[i];
+	}
+	Alg_track()
+	{
+		units_are_seconds = false;
+		time_map = nullptr;
+		set_time_map(nullptr);
+		type = 't';
+	}
+	// initialize empty track with a time map
+	Alg_track(Alg_time_map* map, bool seconds);
 
-    Alg_event_ptr copy_event(Alg_event_ptr event); // make a complete copy
-    
-    Alg_track(Alg_track &track);  // copy constructor, does not copy time_map
-    // copy constructor: event_list is copied, map is installed and referenced
-    Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, 
-              bool units_are_seconds);
-    ~Alg_track() override { // note: do not call set_time_map(NULL)!
-        if (time_map) time_map->dereference();
-        time_map = nullptr; }
+	Alg_event_ptr copy_event(Alg_event_ptr event); // make a complete copy
 
-    // Returns a buffer containing a serialization of the
-    // file.  It will be an ASCII representation unless text is true.
-    // *buffer gets a newly allocated buffer pointer. The caller must free it.
-    // *len gets the length of the serialized track
-    virtual void serialize(void **buffer, long *bytes);
+	Alg_track(Alg_track& track); // copy constructor, does not copy time_map
+	// copy constructor: event_list is copied, map is installed and referenced
+	Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, bool units_are_seconds);
+	~Alg_track() override
+	{ // note: do not call set_time_map(NULL)!
+		if (time_map) time_map->dereference();
+		time_map = nullptr;
+	}
 
-    // Try to read from a memory buffer.  Automatically guess
-    // whether it's MIDI or text.
-    static Alg_track *unserialize(void *buffer, long len);
+	// Returns a buffer containing a serialization of the
+	// file.  It will be an ASCII representation unless text is true.
+	// *buffer gets a newly allocated buffer pointer. The caller must free it.
+	// *len gets the length of the serialized track
+	virtual void serialize(void** buffer, long* bytes);
 
-    // If the track is really an Alg_seq and you need to access an
-    // Alg_seq method, coerce to an Alg_seq with this function:
-    Alg_seq_ptr to_alg_seq() {
-        return (get_type() == 's' ? (Alg_seq_ptr) this : nullptr); }
+	// Try to read from a memory buffer.  Automatically guess
+	// whether it's MIDI or text.
+	static Alg_track* unserialize(void* buffer, long len);
 
-    // Are we using beats or seconds?
-    bool get_units_are_seconds() { return units_are_seconds; }
-    // Change units 
-    virtual void convert_to_beats();
-    virtual void convert_to_seconds();
-    void set_dur(double dur);
-    double get_dur() { return (units_are_seconds ? real_dur : beat_dur); }
+	// If the track is really an Alg_seq and you need to access an
+	// Alg_seq method, coerce to an Alg_seq with this function:
+	Alg_seq_ptr to_alg_seq() { return (get_type() == 's' ? (Alg_seq_ptr)this : nullptr); }
 
-    // Every Alg_track may have an associated time_map. If no map is
-    // specified, or if you set_time_map(NULL), then the behavior 
-    // should be as if there is a constant tempo of 100 beats/minute
-    // (this constant is determined by ALG_DEFAULT_BPM).
-    // Recommendation: create a static global tempo map object. When
-    // any operation that needs a tempo map gets NULL, use the global
-    // tempo map. (Exception: any operation that would modify the
-    // tempo map should raise an error -- you don't want to change the
-    // default tempo map.)
-    virtual void set_time_map(Alg_time_map *map);
-    Alg_time_map *get_time_map() { return time_map; }
+	// Are we using beats or seconds?
+	bool get_units_are_seconds() { return units_are_seconds; }
+	// Change units
+	virtual void convert_to_beats();
+	virtual void convert_to_seconds();
+	void set_dur(double dur);
+	double get_dur() { return (units_are_seconds ? real_dur : beat_dur); }
 
-    // Methods to create events. The returned event is owned by the caller.
-    // Use delete to get rid of it unless you call add() -- see below.
-    //
-    Alg_note *create_note(double time, int channel, int identifier, 
-                           float pitch, float loudness, double duration);
-    // Note: after create_update(), caller should use set_*_value() to
-    // initialize the attribute/value pair:
-    Alg_update *create_update(double time, int channel, int identifier);
-    // Adds a new event - it is automatically inserted into the
-    // correct order in the sequence based on its timestamp.
-    // The ownership passes from the caller to this Alg_seq. The
-    // event is not copied.
-    virtual void add(Alg_event *event) { insert(event); }
+	// Every Alg_track may have an associated time_map. If no map is
+	// specified, or if you set_time_map(NULL), then the behavior
+	// should be as if there is a constant tempo of 100 beats/minute
+	// (this constant is determined by ALG_DEFAULT_BPM).
+	// Recommendation: create a static global tempo map object. When
+	// any operation that needs a tempo map gets NULL, use the global
+	// tempo map. (Exception: any operation that would modify the
+	// tempo map should raise an error -- you don't want to change the
+	// default tempo map.)
+	virtual void set_time_map(Alg_time_map* map);
+	Alg_time_map* get_time_map() { return time_map; }
 
-    //
-    // Editing regions
-    //
+	// Methods to create events. The returned event is owned by the caller.
+	// Use delete to get rid of it unless you call add() -- see below.
+	//
+	Alg_note* create_note(double time, int channel, int identifier, float pitch, float loudness, double duration);
+	// Note: after create_update(), caller should use set_*_value() to
+	// initialize the attribute/value pair:
+	Alg_update* create_update(double time, int channel, int identifier);
+	// Adds a new event - it is automatically inserted into the
+	// correct order in the sequence based on its timestamp.
+	// The ownership passes from the caller to this Alg_seq. The
+	// event is not copied.
+	virtual void add(Alg_event* event) { insert(event); }
 
-    // Deletes the notes that start within the given region
-    // and returns them in a new sequence.  The start times
-    // of the notes in the returned sequence are shifted
-    // by -t.  The notes after the region get shifted over
-    // to fill the gap. In an Alg_seq, the tempo track is edited
-    // in a similar way
-    // and the cut tempo information is retained in the new seq.
-    // ONLY NOTES THAT START WITHIN THE REGION ARE CUT unless
-    // "all" is true in which case all notes that intersect
-    // the region are copied. CUT NOTES
-    // MAY EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
-    // The return type is the same as this (may be Alg_seq).
-    // All times including len are interpreted according to 
-    // units_are_seconds in the track.
-    virtual Alg_track *cut(double t, double len, bool all);
+	//
+	// Editing regions
+	//
 
-    // Like cut() but doesn't remove the notes from the original
-    // sequence. The Alg_events are copied, not shared. ONLY EVENTS
-    // THAT START WITHIN THE REGION ARE COPIED unless "all" is true
-    // in which case all notes that intersect the region are
-    // copied. COPIED NOTES MAY
-    // EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
-    // The return type is the same as this (may be Alg_seq).
-    virtual Alg_track *copy(double t, double len, bool all);
+	// Deletes the notes that start within the given region
+	// and returns them in a new sequence.  The start times
+	// of the notes in the returned sequence are shifted
+	// by -t.  The notes after the region get shifted over
+	// to fill the gap. In an Alg_seq, the tempo track is edited
+	// in a similar way
+	// and the cut tempo information is retained in the new seq.
+	// ONLY NOTES THAT START WITHIN THE REGION ARE CUT unless
+	// "all" is true in which case all notes that intersect
+	// the region are copied. CUT NOTES
+	// MAY EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
+	// The return type is the same as this (may be Alg_seq).
+	// All times including len are interpreted according to
+	// units_are_seconds in the track.
+	virtual Alg_track* cut(double t, double len, bool all);
 
-    // Inserts a sequence in the middle, shifting some notes
-    // over by the duration of the seq, which is first converted
-    // to the same units (seconds or beats) as this. (This makes
-    // a differece because the pasted data may change the tempo,
-    // and notes that overlap the borders will then experience
-    // a tempo change.)
-    // THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
-    // COPIED, NOT SHARED.
-    // The type of seq must be Alg_seq if seq is an Alg_seq, or
-    // Alg_track if seq is an Alg_track or an Alg_event_list.
-    virtual void paste(double t, Alg_event_list *seq); // Shifts notes
+	// Like cut() but doesn't remove the notes from the original
+	// sequence. The Alg_events are copied, not shared. ONLY EVENTS
+	// THAT START WITHIN THE REGION ARE COPIED unless "all" is true
+	// in which case all notes that intersect the region are
+	// copied. COPIED NOTES MAY
+	// EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
+	// The return type is the same as this (may be Alg_seq).
+	virtual Alg_track* copy(double t, double len, bool all);
 
-    // Merges two sequences with a certain offset. The offset is
-    // interpreted as either beats or seconds according to the 
-    // current units of this, and seq is converted to the same
-    // units as this. Except for a possible conversion to beats
-    // or seconds, the tempo track of seq (if any) is ignored. 
-    // (There is no way to merge tempo tracks.)
-    // THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
-    // COPIED, NOT SHARED.
-    // The type of seq must be Alg_seq if seq is an Alg_seq, or
-    // Alg_track if seq is an Alg_track or an Alg_event_list.
-    virtual void merge(double t, Alg_event_list_ptr seq);
+	// Inserts a sequence in the middle, shifting some notes
+	// over by the duration of the seq, which is first converted
+	// to the same units (seconds or beats) as this. (This makes
+	// a differece because the pasted data may change the tempo,
+	// and notes that overlap the borders will then experience
+	// a tempo change.)
+	// THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
+	// COPIED, NOT SHARED.
+	// The type of seq must be Alg_seq if seq is an Alg_seq, or
+	// Alg_track if seq is an Alg_track or an Alg_event_list.
+	virtual void paste(double t, Alg_event_list* seq); // Shifts notes
 
-    // Deletes and shifts notes to fill the gap. The tempo track
-    // is also modified accordingly. ONLY EVENTS THAT START WITHIN
-    // THE REGION ARE DELETED unless "all" is true, in which case
-    // all notes that intersect the region are cleared.
-    // NOTES THAT EXTEND FROM BEFORE THE
-    // REGION INTO THE REGION RETAIN THEIR DURATION IN EITHER
-    // BEATS OR SECONDS ACCORDING TO THE CURRENT UNITS OF this.
-    virtual void clear(double t, double len, bool all);
+	// Merges two sequences with a certain offset. The offset is
+	// interpreted as either beats or seconds according to the
+	// current units of this, and seq is converted to the same
+	// units as this. Except for a possible conversion to beats
+	// or seconds, the tempo track of seq (if any) is ignored.
+	// (There is no way to merge tempo tracks.)
+	// THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
+	// COPIED, NOT SHARED.
+	// The type of seq must be Alg_seq if seq is an Alg_seq, or
+	// Alg_track if seq is an Alg_track or an Alg_event_list.
+	virtual void merge(double t, Alg_event_list_ptr seq);
 
-    // Deletes notes but doesn't shift.  If the "all" argument
-    // is true, deletes all notes that intersect the range at all,
-    // not just those that start within it. The tempo track is 
-    // not affected.
-    virtual void silence(double t, double len, bool all);
+	// Deletes and shifts notes to fill the gap. The tempo track
+	// is also modified accordingly. ONLY EVENTS THAT START WITHIN
+	// THE REGION ARE DELETED unless "all" is true, in which case
+	// all notes that intersect the region are cleared.
+	// NOTES THAT EXTEND FROM BEFORE THE
+	// REGION INTO THE REGION RETAIN THEIR DURATION IN EITHER
+	// BEATS OR SECONDS ACCORDING TO THE CURRENT UNITS OF this.
+	virtual void clear(double t, double len, bool all);
 
-    // Simply shifts notes past time t over by len, which is given
-    // in either beats or seconds according to the units of this.
-    // The resulting interveal (t, t+len) may in fact contain notes
-    // that begin before t. The durations of notes are not changed.
-    // If this is an Alg_seq, the tempo track is expanded at t also.
-    virtual void insert_silence(double t, double len);
+	// Deletes notes but doesn't shift.  If the "all" argument
+	// is true, deletes all notes that intersect the range at all,
+	// not just those that start within it. The tempo track is
+	// not affected.
+	virtual void silence(double t, double len, bool all);
 
-    //
-    // Accessing for screen display
-    //
+	// Simply shifts notes past time t over by len, which is given
+	// in either beats or seconds according to the units of this.
+	// The resulting interveal (t, t+len) may in fact contain notes
+	// that begin before t. The durations of notes are not changed.
+	// If this is an Alg_seq, the tempo track is expanded at t also.
+	virtual void insert_silence(double t, double len);
 
-    // A useful generic function to retrieve only certain
-    // types of events.  The masks should be bit-masks defined
-    // somewhere else. Part of the mask allows us to search for 
-    // selected events. If this is an Alg_seq, search all tracks
-    // (otherwise, call track[i].find())
-    // If channel_mask == 0, accept ALL channels
-    virtual Alg_event_list *find(double t, double len, bool all,
-                                 long channel_mask, long event_type_mask);
+	//
+	// Accessing for screen display
+	//
 
-    virtual void set_in_use(bool flag) { in_use = flag; }
-    //
-    // MIDI playback
-    //
-    // See Alg_iterator
-} *Alg_track_ptr, &Alg_track_ref;
+	// A useful generic function to retrieve only certain
+	// types of events.  The masks should be bit-masks defined
+	// somewhere else. Part of the mask allows us to search for
+	// selected events. If this is an Alg_seq, search all tracks
+	// (otherwise, call track[i].find())
+	// If channel_mask == 0, accept ALL channels
+	virtual Alg_event_list* find(double t, double len, bool all, long channel_mask, long event_type_mask);
 
+	virtual void set_in_use(bool flag) { in_use = flag; }
+	//
+	// MIDI playback
+	//
+	// See Alg_iterator
+};
+using Alg_track_ref = class Alg_track&;
 
 // Alg_time_sig represents a single time signature;
 // although not recommended, time_signatures may have arbitrary
 // floating point values, e.g. 4.5 beats per measure
-typedef class Alg_time_sig {
+using Alg_time_sig_ptr = class Alg_time_sig
+{
 public:
-    double beat; // when does this take effect?
-    double num;  // what is the "numerator" (top number?)
-    double den;  // what is the "denominator" (bottom number?)
-    Alg_time_sig(double b, double n, double d) {
-        beat = b; num = n; den = d;
-    }
-    Alg_time_sig() {
-        beat = 0; num = 0; den = 0;
-    }
-    void beat_to_measure(double beat, double *measure, double *m_beat,
-                         double *num, double *den);
-
-} *Alg_time_sig_ptr;
-
+	double beat; // when does this take effect?
+	double num;	 // what is the "numerator" (top number?)
+	double den;	 // what is the "denominator" (bottom number?)
+	Alg_time_sig(double b, double n, double d)
+	{
+		beat = b;
+		num = n;
+		den = d;
+	}
+	Alg_time_sig()
+	{
+		beat = 0;
+		num = 0;
+		den = 0;
+	}
+	void beat_to_measure(double beat, double* measure, double* m_beat, double* num, double* den);
+};
 
 // Alg_time_sigs is a dynamic array of time signatures
 //
@@ -883,238 +947,236 @@ public:
 
 
 // a sequence of Alg_events objects
-typedef class Alg_tracks {
+using Alg_tracks_ptr = class Alg_tracks
+{
 private:
-    long maxlen;
-    void expand();
-    void expand_to(int new_max);
-    long len;
+	long maxlen;
+	void expand();
+	void expand_to(int new_max);
+	long len;
+
 public:
-    Alg_track_ptr *tracks; // tracks is array of pointers
-    Alg_track &operator[](int i) {
-        assert(i >= 0 && i < len);
-        return *tracks[i];
-    }
-    long length() { return len; }
-    Alg_tracks() {
-        maxlen = len = 0;
-        tracks = nullptr;
-    }
-    ~Alg_tracks();
-    // Append a track to tracks. This Alg_tracks becomes the owner of track.
-    void append(Alg_track_ptr track);
-    void add_track(int track_num, Alg_time_map_ptr time_map, bool seconds);
-    void reset();
-    void set_in_use(bool flag); // handy to set in_use flag on all tracks
-} *Alg_tracks_ptr;
+	Alg_track_ptr* tracks; // tracks is array of pointers
+	Alg_track& operator[](int i)
+	{
+		assert(i >= 0 && i < len);
+		return *tracks[i];
+	}
+	long length() { return len; }
+	Alg_tracks()
+	{
+		maxlen = len = 0;
+		tracks = nullptr;
+	}
+	~Alg_tracks();
+	// Append a track to tracks. This Alg_tracks becomes the owner of track.
+	void append(Alg_track_ptr track);
+	void add_track(int track_num, Alg_time_map_ptr time_map, bool seconds);
+	void reset();
+	void set_in_use(bool flag); // handy to set in_use flag on all tracks
+};
 
+using Alg_error = enum {
+	alg_no_error = 0,	   // no error reading Allegro or MIDI file
+	alg_error_open = -800, // could not open Allegro or MIDI file
+	alg_error_syntax	   // something found in the file that could not be parsed;
+	// generally you should ignore syntax errors or look at the printed error
+	// messages because there are some things in standard midi files that we do
+	// not handle; (maybe we should only set alg_error_syntax when there is a
+	// real problem with the file as opposed to when there is some warning
+	// message for the user)
+};
 
-typedef enum {
-    alg_no_error = 0,      // no error reading Allegro or MIDI file
-    alg_error_open = -800, // could not open Allegro or MIDI file
-    alg_error_syntax   // something found in the file that could not be parsed;
-    // generally you should ignore syntax errors or look at the printed error 
-    // messages because there are some things in standard midi files that we do
-    // not handle; (maybe we should only set alg_error_syntax when there is a
-    // real problem with the file as opposed to when there is some warning
-    // message for the user)
-} Alg_error;
+using Alg_pending_event_ptr = struct Alg_pending_event
+{
+	void* cookie;		// client-provided sequence identifier
+	Alg_events* events; // the array of events
+	long index;			// offset of this event
+	bool note_on;		// is this a note-on or a note-off (if applicable)?
+	double offset;		// time offset for events
+	double time;		// time for this event
+};
 
-
-typedef struct Alg_pending_event {
-    void *cookie; // client-provided sequence identifier
-    Alg_events *events; // the array of events
-    long index; // offset of this event
-    bool note_on; // is this a note-on or a note-off (if applicable)?
-    double offset; // time offset for events
-    double time; // time for this event
-} *Alg_pending_event_ptr;
-
-
-typedef class Alg_iterator {
+using Alg_iterator_ptr = class Alg_iterator
+{
 private:
-    long maxlen;
-    void expand();
-    void expand_to(int new_max);
-    long len;
-    Alg_seq_ptr seq;
-    Alg_pending_event *pending_events;
-    // the next four fields are mainly for request_note_off()
-    Alg_events_ptr events_ptr; // remembers events containing current event
-    long index; // remembers index of current event
-    void *cookie; // remembers the cookie associated with next event
-    double offset;
-    void show();
-    bool earlier(int i, int j);
-    void insert(Alg_events_ptr events, long index, bool note_on, 
-                void *cookie, double offset);
-    // returns the info on the next pending event in the priority queue
-    bool remove_next(Alg_events_ptr &events, long &index, bool &note_on,
-                     void *&cookie, double &offset, double &time);
-public:
-    bool note_off_flag; // remembers if we are iterating over note-off
-                        // events as well as note-on and update events
-    long length() { return len; }
-    Alg_iterator(Alg_seq_ptr s, bool note_off) {
-        seq = s;
-        note_off_flag = note_off;
-        maxlen = len = 0;
-        pending_events = nullptr;
-    }
-    // Normally, iteration is over the events in the one sequence used
-    // to instatiate the iterator (see above), but with this method, you
-    // can add more sequences to the iteration. Events are returned in
-    // time order, so effectively sequence events are merged.
-    // The optional offset is added to each event time of sequence s
-    // before merging/sorting. You should call begin_seq() for each
-    // sequence to be included in the iteration unless you call begin()
-    // (see below).
-    void begin_seq(Alg_seq_ptr s, void *cookie = nullptr, double offset = 0.0);
-    ~Alg_iterator();
-    // Prepare to enumerate events in order. If note_off_flag is true, then
-    // iteration_next will merge note-off events into the sequence. If you
-    // call begin(), you should not normally call begin_seq(). See above.
-    void begin(void *cookie = nullptr) { begin_seq(seq, cookie); }
-    // return next event (or NULL). If iteration_begin was called with
-    // note_off_flag = true, and if note_on is not NULL, then *note_on
-    // is set to true when the result value represents a note-on or update.
-    // (With note_off_flag, each Alg_note event is returned twice, once
-    // at the note-on time, with *note_on == true, and once at the note-off
-    // time, with *note_on == false. If a cookie_ptr is passed, then the
-    // cookie corresponding to the event is stored at that address
-    // If end_time is 0, iterate through the entire sequence, but if
-    // end_time is non_zero, stop iterating at the last event before end_time
-    Alg_event_ptr next(bool *note_on = nullptr, void **cookie_ptr = nullptr,
-                       double *offset_ptr = nullptr, double end_time = 0);
-    // Sometimes, the caller wants to receive note-off events for a subset
-    // of the notes, typically the notes that are played and need to be
-    // turned off. In this case, when a note is turned on, the client
-    // should call request_note_off(). This will insert a note-off into
-    // the queue for the most recent note returned by next(). 
-    void request_note_off();
-    void end();   // clean up after enumerating events
-} *Alg_iterator_ptr;
+	long maxlen;
+	void expand();
+	void expand_to(int new_max);
+	long len;
+	Alg_seq_ptr seq;
+	Alg_pending_event* pending_events;
+	// the next four fields are mainly for request_note_off()
+	Alg_events_ptr events_ptr; // remembers events containing current event
+	long index;				   // remembers index of current event
+	void* cookie;			   // remembers the cookie associated with next event
+	double offset;
+	void show();
+	bool earlier(int i, int j);
+	void insert(Alg_events_ptr events, long index, bool note_on, void* cookie, double offset);
+	// returns the info on the next pending event in the priority queue
+	bool remove_next(Alg_events_ptr& events, long& index, bool& note_on, void*& cookie, double& offset, double& time);
 
+public:
+	bool note_off_flag; // remembers if we are iterating over note-off
+						// events as well as note-on and update events
+	long length() { return len; }
+	Alg_iterator(Alg_seq_ptr s, bool note_off)
+	{
+		seq = s;
+		note_off_flag = note_off;
+		maxlen = len = 0;
+		pending_events = nullptr;
+	}
+	// Normally, iteration is over the events in the one sequence used
+	// to instatiate the iterator (see above), but with this method, you
+	// can add more sequences to the iteration. Events are returned in
+	// time order, so effectively sequence events are merged.
+	// The optional offset is added to each event time of sequence s
+	// before merging/sorting. You should call begin_seq() for each
+	// sequence to be included in the iteration unless you call begin()
+	// (see below).
+	void begin_seq(Alg_seq_ptr s, void* cookie = nullptr, double offset = 0.0);
+	~Alg_iterator();
+	// Prepare to enumerate events in order. If note_off_flag is true, then
+	// iteration_next will merge note-off events into the sequence. If you
+	// call begin(), you should not normally call begin_seq(). See above.
+	void begin(void* cookie = nullptr) { begin_seq(seq, cookie); }
+	// return next event (or NULL). If iteration_begin was called with
+	// note_off_flag = true, and if note_on is not NULL, then *note_on
+	// is set to true when the result value represents a note-on or update.
+	// (With note_off_flag, each Alg_note event is returned twice, once
+	// at the note-on time, with *note_on == true, and once at the note-off
+	// time, with *note_on == false. If a cookie_ptr is passed, then the
+	// cookie corresponding to the event is stored at that address
+	// If end_time is 0, iterate through the entire sequence, but if
+	// end_time is non_zero, stop iterating at the last event before end_time
+	Alg_event_ptr next(
+		bool* note_on = nullptr, void** cookie_ptr = nullptr, double* offset_ptr = nullptr, double end_time = 0);
+	// Sometimes, the caller wants to receive note-off events for a subset
+	// of the notes, typically the notes that are played and need to be
+	// turned off. In this case, when a note is turned on, the client
+	// should call request_note_off(). This will insert a note-off into
+	// the queue for the most recent note returned by next().
+	void request_note_off();
+	void end(); // clean up after enumerating events
+};
 
 // An Alg_seq is an array of Alg_events, each a sequence of Alg_event, 
 // with a tempo map and a sequence of time signatures
 //
-typedef class Alg_seq : public Alg_track {
+using Alg_seq_ptr = class Alg_seq : public Alg_track
+{
 protected:
-    Alg_iterator_ptr pending; // iterator used internally by Alg_seq methods
-    void serialize_seq();
-    Alg_error error; // error code set by file readers
-    // an internal function used for writing Allegro track names
-    Alg_event_ptr write_track_name(std::ostream &file, int n, 
-                                   Alg_events &events);
+	Alg_iterator_ptr pending; // iterator used internally by Alg_seq methods
+	void serialize_seq();
+	Alg_error error; // error code set by file readers
+	// an internal function used for writing Allegro track names
+	Alg_event_ptr write_track_name(std::ostream& file, int n, Alg_events& events);
+
 public:
-    int channel_offset_per_track; // used to encode track_num into channel
-    Alg_tracks track_list;       // array of Alg_events
-    Alg_time_sigs time_sig;
-    int beat_x;
-    void basic_initialization() {
-        error = alg_no_error;
-        units_are_seconds = true; type = 's';
-        channel_offset_per_track = 0;
-        add_track(0); // default is one empty track
-    }        
-    Alg_seq() {
-        basic_initialization();
-    }
-    // copy constructor -- if track is an Alg_seq, make a copy; if
-    //    track is just an Alg_track, the track becomes track 0
-    Alg_seq(Alg_track_ref track) { seq_from_track(track); }
-    Alg_seq(Alg_track_ptr track) { seq_from_track(*track); }
-    void seq_from_track(Alg_track_ref tr);
-    // create from file:
-    Alg_seq(std::istream &file, bool smf, double *offset_ptr = nullptr);
-    // create from filename
-    Alg_seq(const char *filename, bool smf, double *offset_ptr = nullptr);
-    ~Alg_seq() override;
-    int get_read_error() { return error; }
-    void serialize(void **buffer, long *bytes) override;
-    void copy_time_sigs_to(Alg_seq *dest); // a utility function
-    void set_time_map(Alg_time_map *map) override;
+	int channel_offset_per_track; // used to encode track_num into channel
+	Alg_tracks track_list;		  // array of Alg_events
+	Alg_time_sigs time_sig;
+	int beat_x;
+	void basic_initialization()
+	{
+		error = alg_no_error;
+		units_are_seconds = true;
+		type = 's';
+		channel_offset_per_track = 0;
+		add_track(0); // default is one empty track
+	}
+	Alg_seq() { basic_initialization(); }
+	// copy constructor -- if track is an Alg_seq, make a copy; if
+	//    track is just an Alg_track, the track becomes track 0
+	Alg_seq(Alg_track_ref track) { seq_from_track(track); }
+	Alg_seq(Alg_track_ptr track) { seq_from_track(*track); }
+	void seq_from_track(Alg_track_ref tr);
+	// create from file:
+	Alg_seq(std::istream& file, bool smf, double* offset_ptr = nullptr);
+	// create from filename
+	Alg_seq(const char* filename, bool smf, double* offset_ptr = nullptr);
+	~Alg_seq() override;
+	int get_read_error() { return error; }
+	void serialize(void** buffer, long* bytes) override;
+	void copy_time_sigs_to(Alg_seq* dest); // a utility function
+	void set_time_map(Alg_time_map* map) override;
 
-    // encode sequence structure into contiguous, moveable memory block
-    // address of newly allocated memory is assigned to *buffer, which must
-    // be freed by caller; the length of data is assigned to *len
-    void unserialize_seq();
+	// encode sequence structure into contiguous, moveable memory block
+	// address of newly allocated memory is assigned to *buffer, which must
+	// be freed by caller; the length of data is assigned to *len
+	void unserialize_seq();
 
-    // write an ascii representation to file
-    void write(std::ostream &file, bool in_secs, double offset = 0.0);
-    // returns true on success
-    bool write(const char *filename, double offset = 0.0);
-    void smf_write(std::ostream &file);
-    bool smf_write(const char *filename);
+	// write an ascii representation to file
+	void write(std::ostream& file, bool in_secs, double offset = 0.0);
+	// returns true on success
+	bool write(const char* filename, double offset = 0.0);
+	void smf_write(std::ostream& file);
+	bool smf_write(const char* filename);
 
-    // Returns the number of tracks
-    int tracks();
+	// Returns the number of tracks
+	int tracks();
 
-    // create a track
-    void add_track(int track_num) { 
-        track_list.add_track(track_num, get_time_map(), units_are_seconds); 
-    }
+	// create a track
+	void add_track(int track_num) { track_list.add_track(track_num, get_time_map(), units_are_seconds); }
 
-    // Return a particular track. This Alg_seq owns the track, so the
-    // caller must not delete the result.
-    Alg_track_ptr track(int);
+	// Return a particular track. This Alg_seq owns the track, so the
+	// caller must not delete the result.
+	Alg_track_ptr track(int);
 
-    Alg_event_ptr const &operator[](int i) override;
+	Alg_event_ptr const& operator[](int i) override;
 
-    void convert_to_seconds() override;
-    void convert_to_beats() override;
+	void convert_to_seconds() override;
+	void convert_to_beats() override;
 
-    Alg_track_ptr cut_from_track(int track_num, double start, double dur, 
-                                 bool all);
-    Alg_seq *cut(double t, double len, bool all) override;
-    void insert_silence_in_track(int track_num, double t, double len);
-    void insert_silence(double t, double len) override;
-    Alg_track_ptr copy_track(int track_num, double t, double len, bool all);
-    Alg_seq *copy(double start, double len, bool all) override;
-    void paste(double start, Alg_seq *seq);
-    void clear(double t, double len, bool all) override;
-    void merge(double t, Alg_event_list_ptr seq) override;
-    void silence(double t, double len, bool all) override;
-    void clear_track(int track_num, double start, double len, bool all);
-    void silence_track(int track_num, double start, double len, bool all);
-    Alg_event_list_ptr find_in_track(int track_num, double t, double len,
-                                     bool all, long channel_mask, 
-                                     long event_type_mask);
+	Alg_track_ptr cut_from_track(int track_num, double start, double dur, bool all);
+	Alg_seq* cut(double t, double len, bool all) override;
+	void insert_silence_in_track(int track_num, double t, double len);
+	void insert_silence(double t, double len) override;
+	Alg_track_ptr copy_track(int track_num, double t, double len, bool all);
+	Alg_seq* copy(double start, double len, bool all) override;
+	void paste(double start, Alg_seq* seq);
+	void clear(double t, double len, bool all) override;
+	void merge(double t, Alg_event_list_ptr seq) override;
+	void silence(double t, double len, bool all) override;
+	void clear_track(int track_num, double start, double len, bool all);
+	void silence_track(int track_num, double start, double len, bool all);
+	Alg_event_list_ptr find_in_track(
+		int track_num, double t, double len, bool all, long channel_mask, long event_type_mask);
 
-    // find index of first score event after time
-    long seek_time(double time, int track_num);
-    bool insert_beat(double time, double beat);
-    // return the time of the beat nearest to time, also returns beat
-    // number through beat. This will correspond to an integer number
-    // of beats from the nearest previous time signature or 0.0, but
-    // since time signatures need not be on integer beat boundaries
-    // the beat location may not be on an integer beat (beat locations
-    // are measured from the beginning which is beat 0.
-    double nearest_beat_time(double time, double *beat);
-    // warning: insert_tempo may change representation from seconds to beats
-    bool insert_tempo(double bpm, double beat);
-    // change the duration from b0 to b1 (beats) to dur (seconds) by
-    // scaling the intervening tempos
-    bool stretch_region(double b0, double b1, double dur);
-    // add_event takes a pointer to an event on the heap. The event is not
-    // copied, and this Alg_seq becomes the owner and freer of the event.
-    void add_event(Alg_event_ptr event, int track_num);
-    void add(Alg_event_ptr event) override { assert(false); } // call add_event instead
-    // get the tempo starting at beat
-    double get_tempo(double beat);
-    bool set_tempo(double bpm, double start_beat, double end_beat);
+	// find index of first score event after time
+	long seek_time(double time, int track_num);
+	bool insert_beat(double time, double beat);
+	// return the time of the beat nearest to time, also returns beat
+	// number through beat. This will correspond to an integer number
+	// of beats from the nearest previous time signature or 0.0, but
+	// since time signatures need not be on integer beat boundaries
+	// the beat location may not be on an integer beat (beat locations
+	// are measured from the beginning which is beat 0.
+	double nearest_beat_time(double time, double* beat);
+	// warning: insert_tempo may change representation from seconds to beats
+	bool insert_tempo(double bpm, double beat);
+	// change the duration from b0 to b1 (beats) to dur (seconds) by
+	// scaling the intervening tempos
+	bool stretch_region(double b0, double b1, double dur);
+	// add_event takes a pointer to an event on the heap. The event is not
+	// copied, and this Alg_seq becomes the owner and freer of the event.
+	void add_event(Alg_event_ptr event, int track_num);
+	void add(Alg_event_ptr event) override { assert(false); } // call add_event instead
+	// get the tempo starting at beat
+	double get_tempo(double beat);
+	bool set_tempo(double bpm, double start_beat, double end_beat);
 
-    // get the bar length in beats starting at beat
-    double get_bar_len(double beat);
-    void set_time_sig(double beat, double num, double den);
-    void beat_to_measure(double beat, long *measure, double *m_beat,
-                         double *num, double *den);
-    // void set_events(Alg_event_ptr *events, long len, long max);
-    void merge_tracks();    // move all track data into one track
-    void set_in_use(bool flag) override; // set in_use flag on all tracks
-} *Alg_seq_ptr, &Alg_seq_ref;
-
+	// get the bar length in beats starting at beat
+	double get_bar_len(double beat);
+	void set_time_sig(double beat, double num, double den);
+	void beat_to_measure(double beat, long* measure, double* m_beat, double* num, double* den);
+	// void set_events(Alg_event_ptr *events, long len, long max);
+	void merge_tracks();				 // move all track data into one track
+	void set_in_use(bool flag) override; // set in_use flag on all tracks
+};
+using Alg_seq_ref = class Alg_seq&;
 
 // see Alg_seq::Alg_seq() constructors that read from files
 // the following are for internal library implementation and are

--- a/plugins/MidiImport/portsmf/allegro.h
+++ b/plugins/MidiImport/portsmf/allegro.h
@@ -68,7 +68,7 @@ char *heapify(const char *s); // put a string on the heap
 // the attribute 'tempor' (a real) is stored
 // as 'rtempor'. To get the string name, just
 // use attribute+1.
-using Alg_attribute = const char*;
+typedef const char *Alg_attribute;
 #define alg_attr_name(a) ((a) + 1)
 #define alg_attr_type(a) (*(a))
 
@@ -113,45 +113,65 @@ extern Alg_atoms symbol_table;
 // an attribute/value pair. Since Alg_attribute names imply type,
 // we try to keep attributes and values packaged together as
 // Alg_parameter class
-using Alg_parameter_ptr = union
-{
-	double r;	   // real
-	const char* s; // string
-	long i;		   // integer
-	bool l;		   // logical
-	const char* a; // symbol (atom)
-};
+typedef class Alg_parameter {
+public:
+    // This constructor guarantees that an Alg_parameter can be
+    // deleted safely without further initialization. It does not
+    // do anything useful, so it is expected that the creator will
+    // set attr and store a value in the appropriate union field.
+    Alg_attribute attr;
+    union {
+        double r;// real
+        const char *s; // string
+        long i;  // integer
+        bool l;  // logical
+        const char *a; // symbol (atom)
+    }; // anonymous union
+
+    Alg_parameter() { attr = "i"; }
+    ~Alg_parameter();
+    void copy(Alg_parameter *); // copy from another parameter
+    const char attr_type() { return alg_attr_type(attr); }
+    const char *attr_name() { return alg_attr_name(attr); }
+    void set_attr(Alg_attribute a) { attr = a; }
+    void show();
+} *Alg_parameter_ptr;
+
 
 // a list of attribute/value pairs
-using Alg_parameters_ptr = class Alg_parameters
-{
+typedef class Alg_parameters {
 public:
-	class Alg_parameters* next;
-	Alg_parameter parm;
+    class Alg_parameters *next;
+    Alg_parameter parm;
 
-	Alg_parameters(Alg_parameters* list) { next = list; }
+    Alg_parameters(Alg_parameters *list) {
+        next = list;
+    }
 
-	//~Alg_parameters() { }
+    //~Alg_parameters() { }
 
-	// each of these routines takes address of pointer to the list
-	// insertion is performed without checking whether or not a
-	// parameter already exists with this attribute. See find() and
-	// remove_key() to assist in checking for and removing existing
-	// parameters.
-	// Note also that these insert_* methods convert name to an
-	// attribute. If you have already done the symbol table lookup/insert
-	// you can do these operations faster (in which case we should add
-	// another set of functions that take attributes as arguments.)
-	static void insert_real(Alg_parameters** list, const char* name, double r);
-	// insert string will copy string to heap
-	static void insert_string(Alg_parameters** list, const char* name, const char* s);
-	static void insert_integer(Alg_parameters** list, const char* name, long i);
-	static void insert_logical(Alg_parameters** list, const char* name, bool l);
-	static void insert_atom(Alg_parameters** list, const char* name, const char* s);
-	static Alg_parameters* remove_key(Alg_parameters** list, const char* name);
-	// find an attribute/value pair
-	Alg_parameter_ptr find(Alg_attribute attr);
-};
+    // each of these routines takes address of pointer to the list
+    // insertion is performed without checking whether or not a
+    // parameter already exists with this attribute. See find() and
+    // remove_key() to assist in checking for and removing existing 
+    // parameters.
+    // Note also that these insert_* methods convert name to an
+    // attribute. If you have already done the symbol table lookup/insert
+    // you can do these operations faster (in which case we should add
+    // another set of functions that take attributes as arguments.)
+    static void insert_real(Alg_parameters **list, const char *name, double r);
+    // insert string will copy string to heap
+    static void insert_string(Alg_parameters **list, const char *name, 
+                              const char *s);
+    static void insert_integer(Alg_parameters **list, const char *name, long i);
+    static void insert_logical(Alg_parameters **list, const char *name, bool l);
+    static void insert_atom(Alg_parameters **list, const char *name, 
+                            const char *s);
+    static Alg_parameters *remove_key(Alg_parameters **list, const char *name);
+    // find an attribute/value pair
+    Alg_parameter_ptr find(Alg_attribute attr);
+} *Alg_parameters_ptr;
+
 
 // these are type codes associated with certain attributes
 // see Alg_track::find() where these are bit positions in event_type_mask
@@ -167,367 +187,340 @@ public:
 #define ALG_OTHER 9 // any other value
 
 // abstract superclass of Alg_note and Alg_update:
-using Alg_event_ptr = class Alg_event
-{
+typedef class Alg_event {
 protected:
-	bool selected;
-	char type;						// 'e' event, 'n' note, 'u' update
-	long key;						// note identifier
-	static const char* description; // static buffer for debugging (in Alg_event)
+    bool selected;
+    char type; // 'e' event, 'n' note, 'u' update
+    long key; // note identifier
+    static const char* description; // static buffer for debugging (in Alg_event)
 public:
-	double time;
-	long chan;
-	virtual void show() = 0;
-	// Note: there is no Alg_event() because Alg_event is an abstract class.
-	bool is_note() { return (type == 'n'); }   // tell whether an Alg_event is a note
-	bool is_update() { return (type == 'u'); } // tell whether an Alg_event is a parameter update
-	char get_type() { return type; }		   // return 'n' for note, 'u' for update
-	int get_type_code();					   // 1 = volume change,      2 = pitch bend,
-											   // 3 = control change,     4 = program change,
-											   // 5 = pressure change,    6 = key signature,
-											   // 7 = time sig numerator, 8 = time sig denominator
-	bool get_selected() { return selected; }
-	void set_selected(bool b) { selected = b; }
-	// Note: notes are identified by a (channel, identifier) pair.
-	// For midi, the identifier is the key number (pitch). The identifier
-	// does not have to represent pitch; it's main purpose is to identify
-	// notes so that they can be named by subsequent update events.
-	long get_identifier() { return key; }	 // get MIDI key or note identifier of note or update
-	void set_identifier(long i) { key = i; } // set the identifier
-	// In all of these set_ methods, strings are owned by the caller and
-	// copied as necessary by the callee. For notes, an attribute/value
-	// pair is added to the parameters list. For updates, the single
-	// attribute/value parameter pair is overwritten. In all cases, the
-	// attribute (first argument) must agree in type with the second arg.
-	// The last letter of the attribute implies the type (see below).
-	void set_parameter(Alg_parameter_ptr new_parameter);
-	void set_string_value(const char* attr, const char* value);
-	void set_real_value(const char* attr, double value);
-	void set_logical_value(const char* attr, bool value);
-	void set_integer_value(const char* attr, long value);
-	void set_atom_value(const char* attr, const char* atom);
+    double time;
+    long chan;
+    virtual void show() = 0;
+    // Note: there is no Alg_event() because Alg_event is an abstract class.
+    bool is_note() { return (type == 'n'); }   // tell whether an Alg_event is a note
+    bool is_update() { return (type == 'u'); } // tell whether an Alg_event is a parameter update
+    char get_type() { return type; }   // return 'n' for note, 'u' for update
+    int get_type_code();  // 1 = volume change,      2 = pitch bend,
+                          // 3 = control change,     4 = program change,
+                          // 5 = pressure change,    6 = key signature,
+                          // 7 = time sig numerator, 8 = time sig denominator
+    bool get_selected() { return selected; }         
+    void set_selected(bool b) { selected = b; }     
+    // Note: notes are identified by a (channel, identifier) pair. 
+    // For midi, the identifier is the key number (pitch). The identifier
+    // does not have to represent pitch; it's main purpose is to identify
+    // notes so that they can be named by subsequent update events.
+    long get_identifier() { return key; } // get MIDI key or note identifier of note or update
+    void set_identifier(long i) { key = i; } // set the identifier
+    // In all of these set_ methods, strings are owned by the caller and
+    // copied as necessary by the callee. For notes, an attribute/value
+    // pair is added to the parameters list. For updates, the single
+    // attribute/value parameter pair is overwritten. In all cases, the
+    // attribute (first argument) must agree in type with the second arg.
+    // The last letter of the attribute implies the type (see below).
+    void set_parameter(Alg_parameter_ptr new_parameter);
+    void set_string_value(const char *attr, const char *value);
+    void set_real_value(const char *attr, double value);
+    void set_logical_value(const char *attr, bool value);
+    void set_integer_value(const char *attr, long value);
+    void set_atom_value(const char *attr, const char *atom);
 
-	// Some note methods. These fail (via assert()) if this is not a note:
-	//
-	float get_pitch(); // get pitch in steps -- use this even for MIDI
-	float get_loud();  // get loudness (MIDI velocity)
-	// times are in seconds or beats, depending upon the units_are_seconds
-	// flag in the containing sequence
-	double get_start_time(); // get start time in seconds or beats
-	double get_end_time();	 // get end time in seconds or beats
-	double get_duration();	 // get duration in seconds or beats
-	void set_pitch(float);
-	void set_loud(float);
-	void set_duration(double);
+    // Some note methods. These fail (via assert()) if this is not a note:
+    //
+    float get_pitch();// get pitch in steps -- use this even for MIDI
+    float get_loud(); // get loudness (MIDI velocity)
+    // times are in seconds or beats, depending upon the units_are_seconds 
+    // flag in the containing sequence
+    double get_start_time(); // get start time in seconds or beats
+    double get_end_time();   // get end time in seconds or beats
+    double get_duration();   // get duration in seconds or beats
+    void set_pitch(float);
+    void set_loud(float);
+    void set_duration(double);
 
-	// Notes have lists of attribute values. Attributes are converted
-	// to/from strings in this API to avoid explicit use of Alg_attribute
-	// types. Attribute names end with a type designation: 's', 'r', 'l',
-	// 'i', or 'a'.
-	//
-	bool has_attribute(const char* attr);	   // test if note has attribute/value pair
-	char get_attribute_type(const char* attr); // get the associated type:
-											   // 's' = string,
-											   // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
-											   // 'a' = atom (char *), a unique string stored in Alg_seq
-	// get the string value
-	const char* get_string_value(const char* attr, const char* value = nullptr);
-	// get the real value
-	double get_real_value(const char* attr, double value = 0.0);
-	// get the logical value
-	bool get_logical_value(const char* attr, bool value = false);
-	// get the integer value
-	long get_integer_value(const char* attr, long value = 0);
-	// get the atom value
-	const char* get_atom_value(const char* attr, const char* value = nullptr);
-	void delete_attribute(const char* attr); // delete an attribute/value pair
-											 // (ignore if no matching attribute/value pair exists)
+    // Notes have lists of attribute values. Attributes are converted
+    // to/from strings in this API to avoid explicit use of Alg_attribute
+    // types. Attribute names end with a type designation: 's', 'r', 'l',
+    // 'i', or 'a'.
+    //
+    bool has_attribute(const char *attr);      // test if note has attribute/value pair
+    char get_attribute_type(const char *attr); // get the associated type: 
+        // 's' = string, 
+        // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
+        // 'a' = atom (char *), a unique string stored in Alg_seq
+    // get the string value
+    const char *get_string_value(const char *attr, const char *value = nullptr);
+    // get the real value
+    double get_real_value(const char *attr, double value = 0.0);
+    // get the logical value
+    bool get_logical_value(const char *attr, bool value = false);
+    // get the integer value
+    long get_integer_value(const char *attr, long value = 0);
+    // get the atom value
+    const char *get_atom_value(const char *attr, const char *value = nullptr);
+    void delete_attribute(const char *attr);   // delete an attribute/value pair
+        // (ignore if no matching attribute/value pair exists)
 
-	// Some attribute/value methods. These fail if this is not an update.
-	// Attributes are converted to/from strings to avoid explicit use
-	// of Alg_attribute types.
-	//
-	const char* get_attribute(); // get the update's attribute (string)
-	char get_update_type();		 // get the update's type: 's' = string,
-							// 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
-							// 'a' = atom (char *), a unique string stored in Alg_seq
-	const char* get_string_value(); // get the update's string value
-									// Notes: Caller does not own the return value. Do not modify.
-									// Do not use after underlying Alg_seq is modified.
-	double get_real_value();	  // get the update's real value
-	bool get_logical_value();	  // get the update's logical value
-	long get_integer_value();	  // get the update's integer value
-	const char* get_atom_value(); // get the update's atom value
-								  // Notes: Caller does not own the return value. Do not modify.
-								  // The return value's lifetime is forever.
+    // Some attribute/value methods. These fail if this is not an update.
+    // Attributes are converted to/from strings to avoid explicit use
+    // of Alg_attribute types.
+    // 
+    const char *get_attribute();    // get the update's attribute (string)
+    char get_update_type();   // get the update's type: 's' = string, 
+        // 'r' = real (double), 'l' = logical (bool), 'i' = integer (long),
+        // 'a' = atom (char *), a unique string stored in Alg_seq
+    const char *get_string_value(); // get the update's string value
+        // Notes: Caller does not own the return value. Do not modify.
+        // Do not use after underlying Alg_seq is modified.
+    double get_real_value();  // get the update's real value
+    bool get_logical_value(); // get the update's logical value
+    long get_integer_value(); // get the update's integer value
+    const char *get_atom_value();   // get the update's atom value
+        // Notes: Caller does not own the return value. Do not modify.
+        // The return value's lifetime is forever.
 
-	// Auxiliary function to aid in editing tracks
-	// Returns true if the event overlaps the given region
-	bool overlap(double t, double len, bool all);
+    // Auxiliary function to aid in editing tracks
+    // Returns true if the event overlaps the given region
+    bool overlap(double t, double len, bool all);
 
-	const char* GetDescription(); // computes a text description of this event
-	// the result is in a static buffer, not thread-safe, just for debugging.
-	Alg_event() { selected = false; }
-	virtual ~Alg_event() = default;
-};
+    const char *GetDescription(); // computes a text description of this event
+    // the result is in a static buffer, not thread-safe, just for debugging.
+    Alg_event() { selected = false; }
+    virtual ~Alg_event() = default;
+} *Alg_event_ptr;
 
-using Alg_note_ptr = class Alg_note : public Alg_event
-{
+
+typedef class Alg_note : public Alg_event {
 public:
-	~Alg_note() override;
-	Alg_note(Alg_note*);		   // copy constructor
-	float pitch;				   // pitch in semitones (69 = A440)
-	float loud;					   // dynamic corresponding to MIDI velocity
-	double dur;					   // duration in seconds (normally to release point)
-	Alg_parameters_ptr parameters; // attribute/value pair list
-	Alg_note()
-	{
-		type = 'n';
-		parameters = nullptr;
-	}
-	void show() override;
-};
+    ~Alg_note() override;
+    Alg_note(Alg_note *); // copy constructor
+    float pitch; // pitch in semitones (69 = A440)
+    float loud;  // dynamic corresponding to MIDI velocity
+    double dur;   // duration in seconds (normally to release point)
+    Alg_parameters_ptr parameters; // attribute/value pair list
+    Alg_note() { type = 'n'; parameters = nullptr; }
+    void show() override;
+} *Alg_note_ptr;
 
-using Alg_update_ptr = class Alg_update : public Alg_event
-{
+
+typedef class Alg_update : public Alg_event {
 public:
-	~Alg_update() override = default;
-	Alg_update(Alg_update*); // copy constructor
-	Alg_parameter parameter; // an update contains one attr/value pair
+    ~Alg_update() override = default;
+    Alg_update(Alg_update *); // copy constructor
+    Alg_parameter parameter; // an update contains one attr/value pair
 
-	Alg_update() { type = 'u'; }
-	void show() override;
-};
+
+    Alg_update() { type = 'u'; }
+    void show() override;
+} *Alg_update_ptr;
+
 
 // a sequence of Alg_event objects
-using Alg_events_ptr = class Alg_events
-{
+typedef class Alg_events {
 private:
-	long maxlen;
-	void expand();
-
+    long maxlen;
+    void expand();
 protected:
-	long len;
-	Alg_event_ptr* events; // events is array of pointers
+    long len;
+    Alg_event_ptr *events; // events is array of pointers
 public:
-	// sometimes, it is nice to have the time of the last note-off.
-	// In the current implementation,
-	// this field is set by append to indicate the time of the
-	// last note-off in the current unit, so it should be correct after
-	// creating a new track and adding notes to it. It is *not*
-	// updated after uninsert(), so use it with care.
-	double last_note_off;
-	// initially false, in_use can be used to mark "do not delete". If an
-	// Alg_events instance is deleted while "in_use", an assertion will fail.
-	bool in_use;
-	virtual int length() { return len; }
-	Alg_event_ptr& operator[](int i)
-	{
-		assert(i >= 0 && i < len);
-		return events[i];
-	}
-	Alg_events()
-	{
-		maxlen = len = 0;
-		events = nullptr;
-		last_note_off = 0;
-		in_use = false;
-	}
-	// destructor deletes the events array, but not the
-	// events themselves
-	virtual ~Alg_events();
-	void set_events(Alg_event_ptr* e, long l, long m)
-	{
-		if (events) delete[] events;
-		events = e;
-		len = l;
-		maxlen = m;
-	}
-	// for use by Alg_track and Alg_seq
-	void insert(Alg_event_ptr event);
-	void append(Alg_event_ptr event);
-	Alg_event_ptr uninsert(long index);
-};
+    // sometimes, it is nice to have the time of the last note-off.
+    // In the current implementation,
+    // this field is set by append to indicate the time of the 
+    // last note-off in the current unit, so it should be correct after 
+    // creating a new track and adding notes to it. It is *not*
+    // updated after uninsert(), so use it with care.
+    double last_note_off;
+    // initially false, in_use can be used to mark "do not delete". If an
+    // Alg_events instance is deleted while "in_use", an assertion will fail.
+    bool in_use;
+    virtual int length() { return len; }
+    Alg_event_ptr &operator[](int i) {
+        assert(i >= 0 && i < len);
+        return events[i];
+    }
+    Alg_events() {
+        maxlen = len = 0;
+        events = nullptr;
+        last_note_off = 0;
+        in_use = false;
+    }
+    // destructor deletes the events array, but not the
+    // events themselves
+    virtual ~Alg_events();
+    void set_events(Alg_event_ptr *e, long l, long m) {
+        if (events) delete [] events;
+        events = e; len = l; maxlen = m; }
+    // for use by Alg_track and Alg_seq
+    void insert(Alg_event_ptr event);
+    void append(Alg_event_ptr event);
+    Alg_event_ptr uninsert(long index);
+} *Alg_events_ptr;
 
 class Alg_track;
 
-using Alg_event_list_ptr = class Alg_event_list : public Alg_events
-{
+typedef class Alg_event_list : public Alg_events {
 protected:
-	char type; // 'e' Alg_event_list, 't' Alg_track, 's' Alg_seq
-	static const char* last_error_message;
-	Alg_track* events_owner; // if this is an Alg_event_list,
-							 // the events are owned by an Alg_track or an Alg_seq
-	static int sequences; // to keep track of sequence numbers
-	int sequence_number;  // this sequence number is incremented
-						 // whenever an edit is performed on an Alg_track or Alg_seq.
-						 // When an Alg_event_list is created to contain pointers to
-						 // a subset of an Alg_track or Alg_seq (the events_owner),
-						 // the Alg_event_list gets a copy of the events_owner's
-						 // sequence_number. If the events_owner is edited, the pointers
-						 // in this Alg_event_list will become invalid. This is detected
-						 // (for debugging) as differing sequence_numbers.
+    char type; // 'e' Alg_event_list, 't' Alg_track, 's' Alg_seq
+    static const char *last_error_message;
+    Alg_track *events_owner; // if this is an Alg_event_list,
+        // the events are owned by an Alg_track or an Alg_seq
+    static int sequences;  // to keep track of sequence numbers
+    int sequence_number;   // this sequence number is incremented
+        // whenever an edit is performed on an Alg_track or Alg_seq.
+        // When an Alg_event_list is created to contain pointers to
+        // a subset of an Alg_track or Alg_seq (the events_owner), 
+        // the Alg_event_list gets a copy of the events_owner's 
+        // sequence_number. If the events_owner is edited, the pointers
+        // in this Alg_event_list will become invalid. This is detected
+        // (for debugging) as differing sequence_numbers.
 
-	// every event list, track, and seq has a duration.
-	// Usually the duration is set when the list is constructed, e.g.
-	// when you extract from 10 to 15 seconds, the duration is 5 secs.
-	// The duration does not tell you when is the last note-off.
-	// duration is recorded in both beats and seconds:
-	double beat_dur;
-	double real_dur;
-
+    // every event list, track, and seq has a duration.
+    // Usually the duration is set when the list is constructed, e.g.
+    // when you extract from 10 to 15 seconds, the duration is 5 secs.
+    // The duration does not tell you when is the last note-off.
+    // duration is recorded in both beats and seconds:
+    double beat_dur; 
+    double real_dur;
 public:
-	// the client should not create one of these, but these are
-	// returned from various track and seq operations. An
-	// Alg_event_list "knows" the Alg_track or Alg_seq that "owns"
-	// the events. All events in an Alg_event_list must belong
-	// to the same Alg_track or Alg_seq structure.
-	// When applied to an Alg_seq, events are enumerated track
-	// by track with increasing indices. This operation is not
-	// particularly fast on an Alg_seq.
-	virtual Alg_event_ptr const& operator[](int i);
-	Alg_event_list()
-	{
-		sequence_number = 0;
-		beat_dur = 0.0;
-		real_dur = 0.0;
-		events_owner = nullptr;
-		type = 'e';
-	}
-	Alg_event_list(Alg_track* owner);
+    // the client should not create one of these, but these are
+    // returned from various track and seq operations. An
+    // Alg_event_list "knows" the Alg_track or Alg_seq that "owns"
+    // the events. All events in an Alg_event_list must belong
+    // to the same Alg_track or Alg_seq structure.
+    // When applied to an Alg_seq, events are enumerated track
+    // by track with increasing indices. This operation is not
+    // particularly fast on an Alg_seq.
+    virtual Alg_event_ptr const &operator[](int i);
+    Alg_event_list() { sequence_number = 0; 
+        beat_dur = 0.0; real_dur = 0.0; events_owner = nullptr; type = 'e'; }
+    Alg_event_list(Alg_track *owner);
 
-	char get_type() { return type; }
-	Alg_track* get_owner() { return events_owner; }
+    char get_type() { return type; }
+    Alg_track *get_owner() { return events_owner; }
 
-	// The destructor does not free events because they are owned
-	// by a track or seq structure.
-	~Alg_event_list() override;
+    // The destructor does not free events because they are owned
+    // by a track or seq structure.
+    ~Alg_event_list() override;
 
-	// Returns the duration of the sequence in beats or seconds
-	double get_beat_dur() { return beat_dur; }
-	void set_beat_dur(double d) { beat_dur = d; }
-	double get_real_dur() { return real_dur; }
-	void set_real_dur(double d) { real_dur = d; }
+    // Returns the duration of the sequence in beats or seconds
+    double get_beat_dur() { return beat_dur; }
+    void set_beat_dur(double d) { beat_dur = d; }
+    double get_real_dur() { return real_dur; }
+    void set_real_dur(double d) { real_dur = d; }
 
-	// Events are stored in time order, so when you change the time of
-	// an event, you must adjust the position. When you call set_start_time
-	// on an Alg_event_list, the Alg_event_list is not modified, but the
-	// Alg_track that "owns" the event is modified. If the owner is an
-	// Alg_seq, this may require searching the seq for the track containing
-	// the event. This will mean a logN search of every track in the seq
-	// (but if this turns out to be a problem, we can store each event's
-	// track owner in the Alg_event_list.)
-	virtual void set_start_time(Alg_event* event, double);
-	// get text description of run-time errors detected, clear error
-	const char* get_last_error_message() { return last_error_message; }
-	// Implementation hint: keep a sequence number on each Alg_track that is
-	// incremented anytime there is a structural change. (This behavior is
-	// inherited by Alg_seq as well.) Copy the sequence number to any
-	// Alg_event_list object when it is created. Whenever you access an
-	// Alg_event_list, using operator[], assert that the Alg_event_list sequence
-	// number matches the Alg_seq sequence number. This will guarantee that you
-	// do not try to retain pointers to events beyond the point where the events
-	// may no longer exist.
-};
-using Alg_event_list_ref = class Alg_event_list&;
+    // Events are stored in time order, so when you change the time of
+    // an event, you must adjust the position. When you call set_start_time
+    // on an Alg_event_list, the Alg_event_list is not modified, but the
+    // Alg_track that "owns" the event is modified. If the owner is an 
+    // Alg_seq, this may require searching the seq for the track containing
+    // the event. This will mean a logN search of every track in the seq
+    // (but if this turns out to be a problem, we can store each event's
+    // track owner in the Alg_event_list.)
+    virtual void set_start_time(Alg_event *event, double);
+    // get text description of run-time errors detected, clear error
+    const char *get_last_error_message() { return last_error_message; }
+    // Implementation hint: keep a sequence number on each Alg_track that is 
+    // incremented anytime there is a structural change. (This behavior is
+    // inherited by Alg_seq as well.) Copy the sequence number to any
+    // Alg_event_list object when it is created. Whenever you access an 
+    // Alg_event_list, using operator[], assert that the Alg_event_list sequence
+    // number matches the Alg_seq sequence number. This will guarantee that you
+    // do not try to retain pointers to events beyond the point where the events
+    // may no longer exist.
+} *Alg_event_list_ptr, &Alg_event_list_ref;
+
 
 // Alg_beat is used to contruct a tempo map
-using Alg_beat_ptr = class Alg_beat
-{
+typedef class Alg_beat {
 public:
-	Alg_beat(double t, double b)
-	{
-		time = t;
-		beat = b;
-	}
-	Alg_beat() = default;
-	double time;
-	double beat;
-};
+    Alg_beat(double t, double b) {
+        time = t; beat = b; }
+    Alg_beat() = default;
+    double time;
+    double beat;
+} *Alg_beat_ptr;
+
 
 // Alg_beats is a list of Alg_beat objects used in Alg_seq
-using Alg_beats_ptr = class Alg_beats
-{
+typedef class Alg_beats {
 private:
-	long maxlen;
-	void expand();
-
+    long maxlen;
+    void expand();
 public:
-	long len;
-	Alg_beat_ptr beats;
-	Alg_beat& operator[](int i)
-	{
-		assert(i >= 0 && i < len);
-		return beats[i];
-	}
-	Alg_beats()
-	{
-		maxlen = len = 0;
-		beats = nullptr;
-		expand();
-		beats[0].time = 0;
-		beats[0].beat = 0;
-		len = 1;
-	}
-	~Alg_beats()
-	{
-		if (beats) delete[] beats;
-	}
-	void insert(long i, Alg_beat_ptr beat);
-};
+    long len;
+    Alg_beat_ptr beats;
+    Alg_beat &operator[](int i) {
+        assert(i >= 0 && i < len);
+        return beats[i];
+    }
+    Alg_beats() {
+        maxlen = len = 0;
+        beats = nullptr;
+        expand();
+        beats[0].time = 0;
+        beats[0].beat = 0;
+        len = 1;
+    }
+    ~Alg_beats() {
+        if (beats) delete[] beats;
+    }
+    void insert(long i, Alg_beat_ptr beat);
+} *Alg_beats_ptr;
 
-using Alg_time_map_ptr = class Alg_time_map
-{
+
+typedef class Alg_time_map {
 private:
-	int refcount;
-
+    int refcount;
 public:
-	Alg_beats beats; // array of Alg_beat
-	double last_tempo;
-	bool last_tempo_flag;
-	Alg_time_map()
-	{
-		last_tempo = ALG_DEFAULT_BPM / 60.0; // note: this value ignored until
-											 // last_tempo_flag is set; nevertheless, the default
-											 // tempo is 100.
-		last_tempo_flag = true;
-		refcount = 0;
-	}
-	Alg_time_map(Alg_time_map* map); // copy constructor
-	long length() { return beats.len; }
-	void show();
-	long locate_time(double time);
-	long locate_beat(double beat);
-	double beat_to_time(double beat);
-	double time_to_beat(double time);
-	// Time map manipulations: it is prefered to call the corresponding
-	// methods in Alg_seq. If you manipulate an Alg_time_map directly,
-	// you should take care to convert all tracks that use the time map
-	// to beats or seconds as appropriate: Normally if you insert a beat
-	// you want tracks to be in time units and if you insert a tempo change
-	// you want tracks to be in beat units.
-	void insert_beat(double time, double beat);	  // add a point to the map
-	bool insert_tempo(double tempo, double beat); // insert a tempo change
-	// get the tempo starting at beat
-	double get_tempo(double beat);
-	// set the tempo over a region
-	bool set_tempo(double tempo, double start_beat, double end_beat);
-	bool stretch_region(double b0, double b1, double dur);
-	void cut(double start, double len, bool units_are_seconds);
-	void trim(double start, double end, bool units_are_seconds);
-	void paste(double start, Alg_track* tr);
-	// insert a span of time. If start is at a tempo change, then
-	// the span of time runs at the changed tempo
-	void insert_time(double start, double len);
-	// insert a span of beats. If start is at a tempo change, the
-	// tempo change takes effect before the inserted beats
-	void insert_beats(double start, double len);
-	void dereference()
-	{
-		if (--refcount <= 0) delete this;
-	}
-	void reference() { refcount++; }
-};
+    Alg_beats beats; // array of Alg_beat
+    double last_tempo;
+    bool last_tempo_flag;
+    Alg_time_map() {
+        last_tempo = ALG_DEFAULT_BPM / 60.0; // note: this value ignored until
+                // last_tempo_flag is set; nevertheless, the default
+                // tempo is 100.
+        last_tempo_flag = true;
+        refcount = 0;
+    }
+    Alg_time_map(Alg_time_map *map); // copy constructor
+    long length() { return beats.len; }
+    void show();
+    long locate_time(double time);
+    long locate_beat(double beat);
+    double beat_to_time(double beat);
+    double time_to_beat(double time);
+    // Time map manipulations: it is prefered to call the corresponding
+    // methods in Alg_seq. If you manipulate an Alg_time_map directly,
+    // you should take care to convert all tracks that use the time map
+    // to beats or seconds as appropriate: Normally if you insert a beat
+    // you want tracks to be in time units and if you insert a tempo change
+    // you want tracks to be in beat units.
+    void insert_beat(double time, double beat);   // add a point to the map
+    bool insert_tempo(double tempo, double beat); // insert a tempo change
+    // get the tempo starting at beat
+    double get_tempo(double beat);
+    // set the tempo over a region
+    bool set_tempo(double tempo, double start_beat, double end_beat);
+    bool stretch_region(double b0, double b1, double dur);
+    void cut(double start, double len, bool units_are_seconds);
+    void trim(double start, double end, bool units_are_seconds);
+    void paste(double start, Alg_track *tr);
+    // insert a span of time. If start is at a tempo change, then
+    // the span of time runs at the changed tempo
+    void insert_time(double start, double len);
+    // insert a span of beats. If start is at a tempo change, the
+    // tempo change takes effect before the inserted beats
+    void insert_beats(double start, double len);
+    void dereference() {
+        if (--refcount <= 0) delete this;
+    }
+    void reference() {
+        refcount++;
+    }
+} *Alg_time_map_ptr;
+
 
 // Serial_buffer is an abstract class with common elements of
 //     Serial_read_buffer and Serial_write_buffer
@@ -548,359 +541,302 @@ class Serial_buffer {
     long get_len() { return len; }
 };
 
-using Serial_read_buffer_ptr = class Serial_read_buffer : public Serial_buffer
-{
+
+typedef class Serial_read_buffer : public Serial_buffer {
 public:
-	// note that a Serial_read_buffer is initialized for reading by
-	// setting buffer, but it is not the Serial_read_buffer's responsibility
-	// to delete the buffer (owner might want to reuse it), so the destructor
-	// does nothing.
-	~Serial_read_buffer() override = default;
+    // note that a Serial_read_buffer is initialized for reading by
+    // setting buffer, but it is not the Serial_read_buffer's responsibility
+    // to delete the buffer (owner might want to reuse it), so the destructor
+    // does nothing.
+    ~Serial_read_buffer() override = default;
 #if defined(_WIN32)
 //#pragma warning(disable: 546) // cast to int is OK, we only want low 7 bits
 //#pragma warning(disable: 4311) // type cast pointer to long warning
 #endif
-	void get_pad()
-	{
-		while ((intptr_t)ptr & 7)
-			ptr++;
-	}
+    void get_pad() { while ((intptr_t) ptr & 7) ptr++; }
 #if defined(_WIN32)
 //#pragma warning(default: 4311 546)
 #endif
-	// Prepare to read n bytes from buf. The caller must manage buf: it is
-	// valid until reading is finished, and it is caller's responsibility
-	// to free buf when it is no longer needed.
-	void init_for_read(void* buf, long n)
-	{
-		buffer = (char*)buf;
-		ptr = (char*)buf;
-		len = n;
-	}
-	char get_char() { return *ptr++; }
-	void unget_chars(int n) { ptr -= n; } // undo n get_char() calls
-	long get_int32()
-	{
-		long i = *((long*)ptr);
-		ptr += 4;
-		return i;
-	}
-	float get_float()
-	{
-		float f = *((float*)ptr);
-		ptr += 4;
-		return f;
-	}
-	double get_double()
-	{
-		double d = *((double*)ptr);
-		ptr += sizeof(double);
-		return d;
-	}
-	const char* get_string()
-	{
-		char* s = ptr;
-		char* fence = buffer + len;
-		assert(ptr < fence);
-		(void)fence; // unused variable
-		while (*ptr++)
-			assert(ptr < fence);
-		get_pad();
-		return s;
-	}
-	void check_input_buffer(long needed) { assert(get_posn() + needed <= len); }
-};
+    // Prepare to read n bytes from buf. The caller must manage buf: it is
+    // valid until reading is finished, and it is caller's responsibility
+    // to free buf when it is no longer needed.
+    void init_for_read(void *buf, long n) {
+        buffer = (char *) buf;
+        ptr = (char *) buf;
+        len = n;
+    }
+    char get_char() { return *ptr++; }
+    void unget_chars(int n) { ptr -= n; } // undo n get_char() calls
+    long get_int32() { long i = *((long *) ptr); ptr += 4; return i; }
+    float get_float() { float f = *((float *) ptr); ptr += 4; return f; }
+    double get_double() { double d = *((double *) ptr); ptr += sizeof(double); 
+                          return d; }
+    const char *get_string() { char *s = ptr; char *fence = buffer + len;
+                         assert(ptr < fence); (void)fence; // unused variable
+                         while (*ptr++) assert(ptr < fence);
+                         get_pad();
+                         return s; }
+    void check_input_buffer(long needed) {
+        assert(get_posn() + needed <= len); }
+} *Serial_read_buffer_ptr;
 
-using Serial_write_buffer_ptr = class Serial_write_buffer : public Serial_buffer
-{
-public:
-	// Note: allegro.cpp declares one static instance of Serial_buffer to
-	// reduce large memory (re)allocations when serializing tracks for UNDO.
-	// This destructor will only run when the program exits, which will only
-	// add overhead to the exit process, but it will eliminate an incorrect
-	// report of memory leakage from automation that doesn't know better. -RBD
-	~Serial_write_buffer() override
-	{
-		if (buffer) delete[] buffer;
-	}
-	void init_for_write() { ptr = buffer; }
-	// store_long writes a long at a given offset
-	void store_long(long offset, long value)
-	{
-		assert(offset <= get_posn() - 4);
-		long* loc = (long*)(buffer + offset);
-		*loc = value;
-	}
-	void check_buffer(long needed);
-	void set_string(const char* s)
-	{
-		char* fence = buffer + len;
-		assert(ptr < fence);
-		(void)fence; // unused variable
-		// two brackets surpress a g++ warning, because this is an
-		// assignment operator inside a test.
-		while ((*ptr++ = *s++))
-			assert(ptr < fence);
-			// 4311 is type cast pointer to long warning
-			// 4312 is type cast long to pointer warning
+
+typedef class Serial_write_buffer: public Serial_buffer {
+  public:
+    // Note: allegro.cpp declares one static instance of Serial_buffer to 
+    // reduce large memory (re)allocations when serializing tracks for UNDO.
+    // This destructor will only run when the program exits, which will only
+    // add overhead to the exit process, but it will eliminate an incorrect
+    // report of memory leakage from automation that doesn't know better. -RBD
+    ~Serial_write_buffer() override {
+        if (buffer) delete [] buffer;
+    }
+    void init_for_write() { ptr = buffer; }
+    // store_long writes a long at a given offset
+    void store_long(long offset, long value) {
+        assert(offset <= get_posn() - 4);
+        long *loc = (long *) (buffer + offset);
+        *loc = value;
+    }
+    void check_buffer(long needed);
+    void set_string(const char *s) { 
+        char *fence = buffer + len;
+        assert(ptr < fence); (void)fence; // unused variable
+        // two brackets surpress a g++ warning, because this is an
+        // assignment operator inside a test.
+        while ((*ptr++ = *s++)) assert(ptr < fence);
+        // 4311 is type cast pointer to long warning
+        // 4312 is type cast long to pointer warning
 #if defined(_WIN32)
 //#pragma warning(disable: 4311 4312)
 #endif
-		assert((char*)(((long long)(ptr + 7)) & ~7) <= fence);
+        assert((char *)(((long long) (ptr + 7)) & ~7) <= fence);
 #if defined(_WIN32)
 //#pragma warning(default: 4311 4312)
 #endif
-		pad();
-	}
-	void set_int32(long v)
-	{
-		*((long*)ptr) = v;
-		ptr += 4;
-	}
-	void set_double(double v)
-	{
-		*((double*)ptr) = v;
-		ptr += 8;
-	}
-	void set_float(float v)
-	{
-		*((float*)ptr) = v;
-		ptr += 4;
-	}
-	void set_char(char v) { *ptr++ = v; }
+        pad(); }
+    void set_int32(long v) { *((long *) ptr) = v; ptr += 4; }
+    void set_double(double v) { *((double *) ptr) = v; ptr += 8; }
+    void set_float(float v) { *((float *) ptr) = v; ptr += 4; }
+    void set_char(char v) { *ptr++ = v; }
 #if defined(_WIN32)
 //#pragma warning(disable: 546) // cast to int is OK, we only want low 7 bits
 //#pragma warning(disable: 4311) // type cast pointer to long warning
 #endif
-	void pad()
-	{
-		while ((intptr_t)ptr & 7)
-			set_char(0);
-	}
+    void pad() { while ((intptr_t) ptr & 7) set_char(0); }
 #if defined(_WIN32)
 //#pragma warning(default: 4311 546)
 #endif
-	void* to_heap(long* len)
-	{
-		*len = get_posn();
-		char* newbuf = new char[*len];
-		memcpy(newbuf, buffer, *len);
-		return newbuf;
-	}
-};
+    void *to_heap(long *len) {
+        *len = get_posn();
+        char *newbuf = new char[*len];
+        memcpy(newbuf, buffer, *len);
+        return newbuf;
+    }
+} *Serial_write_buffer_ptr;
 
-using Alg_seq_ptr = class Alg_seq;
+typedef class Alg_seq *Alg_seq_ptr;
 
-using Alg_track_ptr = class Alg_track : public Alg_event_list
-{
+typedef class Alg_track : public Alg_event_list {
 protected:
-	Alg_time_map* time_map;
-	bool units_are_seconds;
-	char* get_string(char** p, long* b);
-	long get_int32(char** p, long* b);
-	double get_double(char** p, long* b);
-	float get_float(char** p, long* b);
-	static Serial_read_buffer ser_read_buf;
-	static Serial_write_buffer ser_write_buf;
-	void serialize_parameter(Alg_parameter* parm);
-	// *buffer_ptr points to binary data, bytes_ptr points to how many
-	// bytes have been used so far, len is length of binary data
-	void unserialize_parameter(Alg_parameter_ptr parm_ptr);
-
+    Alg_time_map *time_map;
+    bool units_are_seconds;
+    char *get_string(char **p, long *b);
+    long get_int32(char **p, long *b);
+    double get_double(char **p, long *b);
+    float get_float(char **p, long *b);
+    static Serial_read_buffer ser_read_buf;
+    static Serial_write_buffer ser_write_buf;
+    void serialize_parameter(Alg_parameter *parm);
+    // *buffer_ptr points to binary data, bytes_ptr points to how many
+    // bytes have been used so far, len is length of binary data
+    void unserialize_parameter(Alg_parameter_ptr parm_ptr);
 public:
-	void serialize_track();
-	void unserialize_track();
-	Alg_event_ptr const& operator[](int i) override
-	{
-		assert(i >= 0 && i < len);
-		return events[i];
-	}
-	Alg_track()
-	{
-		units_are_seconds = false;
-		time_map = nullptr;
-		set_time_map(nullptr);
-		type = 't';
-	}
-	// initialize empty track with a time map
-	Alg_track(Alg_time_map* map, bool seconds);
+    void serialize_track();
+    void unserialize_track();
+    Alg_event_ptr const &operator[](int i) override {
+        assert(i >= 0 && i < len);
+        return events[i];
+    }
+    Alg_track() { units_are_seconds = false; time_map = nullptr;
+                  set_time_map(nullptr); type = 't'; }
+    // initialize empty track with a time map
+    Alg_track(Alg_time_map *map, bool seconds); 
 
-	Alg_event_ptr copy_event(Alg_event_ptr event); // make a complete copy
+    Alg_event_ptr copy_event(Alg_event_ptr event); // make a complete copy
+    
+    Alg_track(Alg_track &track);  // copy constructor, does not copy time_map
+    // copy constructor: event_list is copied, map is installed and referenced
+    Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, 
+              bool units_are_seconds);
+    ~Alg_track() override { // note: do not call set_time_map(NULL)!
+        if (time_map) time_map->dereference();
+        time_map = nullptr; }
 
-	Alg_track(Alg_track& track); // copy constructor, does not copy time_map
-	// copy constructor: event_list is copied, map is installed and referenced
-	Alg_track(Alg_event_list_ref event_list, Alg_time_map_ptr map, bool units_are_seconds);
-	~Alg_track() override
-	{ // note: do not call set_time_map(NULL)!
-		if (time_map) time_map->dereference();
-		time_map = nullptr;
-	}
+    // Returns a buffer containing a serialization of the
+    // file.  It will be an ASCII representation unless text is true.
+    // *buffer gets a newly allocated buffer pointer. The caller must free it.
+    // *len gets the length of the serialized track
+    virtual void serialize(void **buffer, long *bytes);
 
-	// Returns a buffer containing a serialization of the
-	// file.  It will be an ASCII representation unless text is true.
-	// *buffer gets a newly allocated buffer pointer. The caller must free it.
-	// *len gets the length of the serialized track
-	virtual void serialize(void** buffer, long* bytes);
+    // Try to read from a memory buffer.  Automatically guess
+    // whether it's MIDI or text.
+    static Alg_track *unserialize(void *buffer, long len);
 
-	// Try to read from a memory buffer.  Automatically guess
-	// whether it's MIDI or text.
-	static Alg_track* unserialize(void* buffer, long len);
+    // If the track is really an Alg_seq and you need to access an
+    // Alg_seq method, coerce to an Alg_seq with this function:
+    Alg_seq_ptr to_alg_seq() {
+        return (get_type() == 's' ? (Alg_seq_ptr) this : nullptr); }
 
-	// If the track is really an Alg_seq and you need to access an
-	// Alg_seq method, coerce to an Alg_seq with this function:
-	Alg_seq_ptr to_alg_seq() { return (get_type() == 's' ? (Alg_seq_ptr)this : nullptr); }
+    // Are we using beats or seconds?
+    bool get_units_are_seconds() { return units_are_seconds; }
+    // Change units 
+    virtual void convert_to_beats();
+    virtual void convert_to_seconds();
+    void set_dur(double dur);
+    double get_dur() { return (units_are_seconds ? real_dur : beat_dur); }
 
-	// Are we using beats or seconds?
-	bool get_units_are_seconds() { return units_are_seconds; }
-	// Change units
-	virtual void convert_to_beats();
-	virtual void convert_to_seconds();
-	void set_dur(double dur);
-	double get_dur() { return (units_are_seconds ? real_dur : beat_dur); }
+    // Every Alg_track may have an associated time_map. If no map is
+    // specified, or if you set_time_map(NULL), then the behavior 
+    // should be as if there is a constant tempo of 100 beats/minute
+    // (this constant is determined by ALG_DEFAULT_BPM).
+    // Recommendation: create a static global tempo map object. When
+    // any operation that needs a tempo map gets NULL, use the global
+    // tempo map. (Exception: any operation that would modify the
+    // tempo map should raise an error -- you don't want to change the
+    // default tempo map.)
+    virtual void set_time_map(Alg_time_map *map);
+    Alg_time_map *get_time_map() { return time_map; }
 
-	// Every Alg_track may have an associated time_map. If no map is
-	// specified, or if you set_time_map(NULL), then the behavior
-	// should be as if there is a constant tempo of 100 beats/minute
-	// (this constant is determined by ALG_DEFAULT_BPM).
-	// Recommendation: create a static global tempo map object. When
-	// any operation that needs a tempo map gets NULL, use the global
-	// tempo map. (Exception: any operation that would modify the
-	// tempo map should raise an error -- you don't want to change the
-	// default tempo map.)
-	virtual void set_time_map(Alg_time_map* map);
-	Alg_time_map* get_time_map() { return time_map; }
+    // Methods to create events. The returned event is owned by the caller.
+    // Use delete to get rid of it unless you call add() -- see below.
+    //
+    Alg_note *create_note(double time, int channel, int identifier, 
+                           float pitch, float loudness, double duration);
+    // Note: after create_update(), caller should use set_*_value() to
+    // initialize the attribute/value pair:
+    Alg_update *create_update(double time, int channel, int identifier);
+    // Adds a new event - it is automatically inserted into the
+    // correct order in the sequence based on its timestamp.
+    // The ownership passes from the caller to this Alg_seq. The
+    // event is not copied.
+    virtual void add(Alg_event *event) { insert(event); }
 
-	// Methods to create events. The returned event is owned by the caller.
-	// Use delete to get rid of it unless you call add() -- see below.
-	//
-	Alg_note* create_note(double time, int channel, int identifier, float pitch, float loudness, double duration);
-	// Note: after create_update(), caller should use set_*_value() to
-	// initialize the attribute/value pair:
-	Alg_update* create_update(double time, int channel, int identifier);
-	// Adds a new event - it is automatically inserted into the
-	// correct order in the sequence based on its timestamp.
-	// The ownership passes from the caller to this Alg_seq. The
-	// event is not copied.
-	virtual void add(Alg_event* event) { insert(event); }
+    //
+    // Editing regions
+    //
 
-	//
-	// Editing regions
-	//
+    // Deletes the notes that start within the given region
+    // and returns them in a new sequence.  The start times
+    // of the notes in the returned sequence are shifted
+    // by -t.  The notes after the region get shifted over
+    // to fill the gap. In an Alg_seq, the tempo track is edited
+    // in a similar way
+    // and the cut tempo information is retained in the new seq.
+    // ONLY NOTES THAT START WITHIN THE REGION ARE CUT unless
+    // "all" is true in which case all notes that intersect
+    // the region are copied. CUT NOTES
+    // MAY EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
+    // The return type is the same as this (may be Alg_seq).
+    // All times including len are interpreted according to 
+    // units_are_seconds in the track.
+    virtual Alg_track *cut(double t, double len, bool all);
 
-	// Deletes the notes that start within the given region
-	// and returns them in a new sequence.  The start times
-	// of the notes in the returned sequence are shifted
-	// by -t.  The notes after the region get shifted over
-	// to fill the gap. In an Alg_seq, the tempo track is edited
-	// in a similar way
-	// and the cut tempo information is retained in the new seq.
-	// ONLY NOTES THAT START WITHIN THE REGION ARE CUT unless
-	// "all" is true in which case all notes that intersect
-	// the region are copied. CUT NOTES
-	// MAY EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
-	// The return type is the same as this (may be Alg_seq).
-	// All times including len are interpreted according to
-	// units_are_seconds in the track.
-	virtual Alg_track* cut(double t, double len, bool all);
+    // Like cut() but doesn't remove the notes from the original
+    // sequence. The Alg_events are copied, not shared. ONLY EVENTS
+    // THAT START WITHIN THE REGION ARE COPIED unless "all" is true
+    // in which case all notes that intersect the region are
+    // copied. COPIED NOTES MAY
+    // EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
+    // The return type is the same as this (may be Alg_seq).
+    virtual Alg_track *copy(double t, double len, bool all);
 
-	// Like cut() but doesn't remove the notes from the original
-	// sequence. The Alg_events are copied, not shared. ONLY EVENTS
-	// THAT START WITHIN THE REGION ARE COPIED unless "all" is true
-	// in which case all notes that intersect the region are
-	// copied. COPIED NOTES MAY
-	// EXTEND BEYOND THE DURATION OF THE RESULTING SEQ.
-	// The return type is the same as this (may be Alg_seq).
-	virtual Alg_track* copy(double t, double len, bool all);
+    // Inserts a sequence in the middle, shifting some notes
+    // over by the duration of the seq, which is first converted
+    // to the same units (seconds or beats) as this. (This makes
+    // a differece because the pasted data may change the tempo,
+    // and notes that overlap the borders will then experience
+    // a tempo change.)
+    // THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
+    // COPIED, NOT SHARED.
+    // The type of seq must be Alg_seq if seq is an Alg_seq, or
+    // Alg_track if seq is an Alg_track or an Alg_event_list.
+    virtual void paste(double t, Alg_event_list *seq); // Shifts notes
 
-	// Inserts a sequence in the middle, shifting some notes
-	// over by the duration of the seq, which is first converted
-	// to the same units (seconds or beats) as this. (This makes
-	// a differece because the pasted data may change the tempo,
-	// and notes that overlap the borders will then experience
-	// a tempo change.)
-	// THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
-	// COPIED, NOT SHARED.
-	// The type of seq must be Alg_seq if seq is an Alg_seq, or
-	// Alg_track if seq is an Alg_track or an Alg_event_list.
-	virtual void paste(double t, Alg_event_list* seq); // Shifts notes
+    // Merges two sequences with a certain offset. The offset is
+    // interpreted as either beats or seconds according to the 
+    // current units of this, and seq is converted to the same
+    // units as this. Except for a possible conversion to beats
+    // or seconds, the tempo track of seq (if any) is ignored. 
+    // (There is no way to merge tempo tracks.)
+    // THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
+    // COPIED, NOT SHARED.
+    // The type of seq must be Alg_seq if seq is an Alg_seq, or
+    // Alg_track if seq is an Alg_track or an Alg_event_list.
+    virtual void merge(double t, Alg_event_list_ptr seq);
 
-	// Merges two sequences with a certain offset. The offset is
-	// interpreted as either beats or seconds according to the
-	// current units of this, and seq is converted to the same
-	// units as this. Except for a possible conversion to beats
-	// or seconds, the tempo track of seq (if any) is ignored.
-	// (There is no way to merge tempo tracks.)
-	// THE SEQ PARAMETER IS NOT MODIFIED, AND Alg_event's ARE
-	// COPIED, NOT SHARED.
-	// The type of seq must be Alg_seq if seq is an Alg_seq, or
-	// Alg_track if seq is an Alg_track or an Alg_event_list.
-	virtual void merge(double t, Alg_event_list_ptr seq);
+    // Deletes and shifts notes to fill the gap. The tempo track
+    // is also modified accordingly. ONLY EVENTS THAT START WITHIN
+    // THE REGION ARE DELETED unless "all" is true, in which case
+    // all notes that intersect the region are cleared.
+    // NOTES THAT EXTEND FROM BEFORE THE
+    // REGION INTO THE REGION RETAIN THEIR DURATION IN EITHER
+    // BEATS OR SECONDS ACCORDING TO THE CURRENT UNITS OF this.
+    virtual void clear(double t, double len, bool all);
 
-	// Deletes and shifts notes to fill the gap. The tempo track
-	// is also modified accordingly. ONLY EVENTS THAT START WITHIN
-	// THE REGION ARE DELETED unless "all" is true, in which case
-	// all notes that intersect the region are cleared.
-	// NOTES THAT EXTEND FROM BEFORE THE
-	// REGION INTO THE REGION RETAIN THEIR DURATION IN EITHER
-	// BEATS OR SECONDS ACCORDING TO THE CURRENT UNITS OF this.
-	virtual void clear(double t, double len, bool all);
+    // Deletes notes but doesn't shift.  If the "all" argument
+    // is true, deletes all notes that intersect the range at all,
+    // not just those that start within it. The tempo track is 
+    // not affected.
+    virtual void silence(double t, double len, bool all);
 
-	// Deletes notes but doesn't shift.  If the "all" argument
-	// is true, deletes all notes that intersect the range at all,
-	// not just those that start within it. The tempo track is
-	// not affected.
-	virtual void silence(double t, double len, bool all);
+    // Simply shifts notes past time t over by len, which is given
+    // in either beats or seconds according to the units of this.
+    // The resulting interveal (t, t+len) may in fact contain notes
+    // that begin before t. The durations of notes are not changed.
+    // If this is an Alg_seq, the tempo track is expanded at t also.
+    virtual void insert_silence(double t, double len);
 
-	// Simply shifts notes past time t over by len, which is given
-	// in either beats or seconds according to the units of this.
-	// The resulting interveal (t, t+len) may in fact contain notes
-	// that begin before t. The durations of notes are not changed.
-	// If this is an Alg_seq, the tempo track is expanded at t also.
-	virtual void insert_silence(double t, double len);
+    //
+    // Accessing for screen display
+    //
 
-	//
-	// Accessing for screen display
-	//
+    // A useful generic function to retrieve only certain
+    // types of events.  The masks should be bit-masks defined
+    // somewhere else. Part of the mask allows us to search for 
+    // selected events. If this is an Alg_seq, search all tracks
+    // (otherwise, call track[i].find())
+    // If channel_mask == 0, accept ALL channels
+    virtual Alg_event_list *find(double t, double len, bool all,
+                                 long channel_mask, long event_type_mask);
 
-	// A useful generic function to retrieve only certain
-	// types of events.  The masks should be bit-masks defined
-	// somewhere else. Part of the mask allows us to search for
-	// selected events. If this is an Alg_seq, search all tracks
-	// (otherwise, call track[i].find())
-	// If channel_mask == 0, accept ALL channels
-	virtual Alg_event_list* find(double t, double len, bool all, long channel_mask, long event_type_mask);
+    virtual void set_in_use(bool flag) { in_use = flag; }
+    //
+    // MIDI playback
+    //
+    // See Alg_iterator
+} *Alg_track_ptr, &Alg_track_ref;
 
-	virtual void set_in_use(bool flag) { in_use = flag; }
-	//
-	// MIDI playback
-	//
-	// See Alg_iterator
-};
-using Alg_track_ref = class Alg_track&;
 
 // Alg_time_sig represents a single time signature;
 // although not recommended, time_signatures may have arbitrary
 // floating point values, e.g. 4.5 beats per measure
-using Alg_time_sig_ptr = class Alg_time_sig
-{
+typedef class Alg_time_sig {
 public:
-	double beat; // when does this take effect?
-	double num;	 // what is the "numerator" (top number?)
-	double den;	 // what is the "denominator" (bottom number?)
-	Alg_time_sig(double b, double n, double d)
-	{
-		beat = b;
-		num = n;
-		den = d;
-	}
-	Alg_time_sig()
-	{
-		beat = 0;
-		num = 0;
-		den = 0;
-	}
-	void beat_to_measure(double beat, double* measure, double* m_beat, double* num, double* den);
-};
+    double beat; // when does this take effect?
+    double num;  // what is the "numerator" (top number?)
+    double den;  // what is the "denominator" (bottom number?)
+    Alg_time_sig(double b, double n, double d) {
+        beat = b; num = n; den = d;
+    }
+    Alg_time_sig() {
+        beat = 0; num = 0; den = 0;
+    }
+    void beat_to_measure(double beat, double *measure, double *m_beat,
+                         double *num, double *den);
+
+} *Alg_time_sig_ptr;
+
 
 // Alg_time_sigs is a dynamic array of time signatures
 //
@@ -947,236 +883,238 @@ public:
 
 
 // a sequence of Alg_events objects
-using Alg_tracks_ptr = class Alg_tracks
-{
+typedef class Alg_tracks {
 private:
-	long maxlen;
-	void expand();
-	void expand_to(int new_max);
-	long len;
-
+    long maxlen;
+    void expand();
+    void expand_to(int new_max);
+    long len;
 public:
-	Alg_track_ptr* tracks; // tracks is array of pointers
-	Alg_track& operator[](int i)
-	{
-		assert(i >= 0 && i < len);
-		return *tracks[i];
-	}
-	long length() { return len; }
-	Alg_tracks()
-	{
-		maxlen = len = 0;
-		tracks = nullptr;
-	}
-	~Alg_tracks();
-	// Append a track to tracks. This Alg_tracks becomes the owner of track.
-	void append(Alg_track_ptr track);
-	void add_track(int track_num, Alg_time_map_ptr time_map, bool seconds);
-	void reset();
-	void set_in_use(bool flag); // handy to set in_use flag on all tracks
-};
+    Alg_track_ptr *tracks; // tracks is array of pointers
+    Alg_track &operator[](int i) {
+        assert(i >= 0 && i < len);
+        return *tracks[i];
+    }
+    long length() { return len; }
+    Alg_tracks() {
+        maxlen = len = 0;
+        tracks = nullptr;
+    }
+    ~Alg_tracks();
+    // Append a track to tracks. This Alg_tracks becomes the owner of track.
+    void append(Alg_track_ptr track);
+    void add_track(int track_num, Alg_time_map_ptr time_map, bool seconds);
+    void reset();
+    void set_in_use(bool flag); // handy to set in_use flag on all tracks
+} *Alg_tracks_ptr;
 
-using Alg_error = enum {
-	alg_no_error = 0,	   // no error reading Allegro or MIDI file
-	alg_error_open = -800, // could not open Allegro or MIDI file
-	alg_error_syntax	   // something found in the file that could not be parsed;
-	// generally you should ignore syntax errors or look at the printed error
-	// messages because there are some things in standard midi files that we do
-	// not handle; (maybe we should only set alg_error_syntax when there is a
-	// real problem with the file as opposed to when there is some warning
-	// message for the user)
-};
 
-using Alg_pending_event_ptr = struct Alg_pending_event
-{
-	void* cookie;		// client-provided sequence identifier
-	Alg_events* events; // the array of events
-	long index;			// offset of this event
-	bool note_on;		// is this a note-on or a note-off (if applicable)?
-	double offset;		// time offset for events
-	double time;		// time for this event
-};
+typedef enum {
+    alg_no_error = 0,      // no error reading Allegro or MIDI file
+    alg_error_open = -800, // could not open Allegro or MIDI file
+    alg_error_syntax   // something found in the file that could not be parsed;
+    // generally you should ignore syntax errors or look at the printed error 
+    // messages because there are some things in standard midi files that we do
+    // not handle; (maybe we should only set alg_error_syntax when there is a
+    // real problem with the file as opposed to when there is some warning
+    // message for the user)
+} Alg_error;
 
-using Alg_iterator_ptr = class Alg_iterator
-{
+
+typedef struct Alg_pending_event {
+    void *cookie; // client-provided sequence identifier
+    Alg_events *events; // the array of events
+    long index; // offset of this event
+    bool note_on; // is this a note-on or a note-off (if applicable)?
+    double offset; // time offset for events
+    double time; // time for this event
+} *Alg_pending_event_ptr;
+
+
+typedef class Alg_iterator {
 private:
-	long maxlen;
-	void expand();
-	void expand_to(int new_max);
-	long len;
-	Alg_seq_ptr seq;
-	Alg_pending_event* pending_events;
-	// the next four fields are mainly for request_note_off()
-	Alg_events_ptr events_ptr; // remembers events containing current event
-	long index;				   // remembers index of current event
-	void* cookie;			   // remembers the cookie associated with next event
-	double offset;
-	void show();
-	bool earlier(int i, int j);
-	void insert(Alg_events_ptr events, long index, bool note_on, void* cookie, double offset);
-	// returns the info on the next pending event in the priority queue
-	bool remove_next(Alg_events_ptr& events, long& index, bool& note_on, void*& cookie, double& offset, double& time);
-
+    long maxlen;
+    void expand();
+    void expand_to(int new_max);
+    long len;
+    Alg_seq_ptr seq;
+    Alg_pending_event *pending_events;
+    // the next four fields are mainly for request_note_off()
+    Alg_events_ptr events_ptr; // remembers events containing current event
+    long index; // remembers index of current event
+    void *cookie; // remembers the cookie associated with next event
+    double offset;
+    void show();
+    bool earlier(int i, int j);
+    void insert(Alg_events_ptr events, long index, bool note_on, 
+                void *cookie, double offset);
+    // returns the info on the next pending event in the priority queue
+    bool remove_next(Alg_events_ptr &events, long &index, bool &note_on,
+                     void *&cookie, double &offset, double &time);
 public:
-	bool note_off_flag; // remembers if we are iterating over note-off
-						// events as well as note-on and update events
-	long length() { return len; }
-	Alg_iterator(Alg_seq_ptr s, bool note_off)
-	{
-		seq = s;
-		note_off_flag = note_off;
-		maxlen = len = 0;
-		pending_events = nullptr;
-	}
-	// Normally, iteration is over the events in the one sequence used
-	// to instatiate the iterator (see above), but with this method, you
-	// can add more sequences to the iteration. Events are returned in
-	// time order, so effectively sequence events are merged.
-	// The optional offset is added to each event time of sequence s
-	// before merging/sorting. You should call begin_seq() for each
-	// sequence to be included in the iteration unless you call begin()
-	// (see below).
-	void begin_seq(Alg_seq_ptr s, void* cookie = nullptr, double offset = 0.0);
-	~Alg_iterator();
-	// Prepare to enumerate events in order. If note_off_flag is true, then
-	// iteration_next will merge note-off events into the sequence. If you
-	// call begin(), you should not normally call begin_seq(). See above.
-	void begin(void* cookie = nullptr) { begin_seq(seq, cookie); }
-	// return next event (or NULL). If iteration_begin was called with
-	// note_off_flag = true, and if note_on is not NULL, then *note_on
-	// is set to true when the result value represents a note-on or update.
-	// (With note_off_flag, each Alg_note event is returned twice, once
-	// at the note-on time, with *note_on == true, and once at the note-off
-	// time, with *note_on == false. If a cookie_ptr is passed, then the
-	// cookie corresponding to the event is stored at that address
-	// If end_time is 0, iterate through the entire sequence, but if
-	// end_time is non_zero, stop iterating at the last event before end_time
-	Alg_event_ptr next(
-		bool* note_on = nullptr, void** cookie_ptr = nullptr, double* offset_ptr = nullptr, double end_time = 0);
-	// Sometimes, the caller wants to receive note-off events for a subset
-	// of the notes, typically the notes that are played and need to be
-	// turned off. In this case, when a note is turned on, the client
-	// should call request_note_off(). This will insert a note-off into
-	// the queue for the most recent note returned by next().
-	void request_note_off();
-	void end(); // clean up after enumerating events
-};
+    bool note_off_flag; // remembers if we are iterating over note-off
+                        // events as well as note-on and update events
+    long length() { return len; }
+    Alg_iterator(Alg_seq_ptr s, bool note_off) {
+        seq = s;
+        note_off_flag = note_off;
+        maxlen = len = 0;
+        pending_events = nullptr;
+    }
+    // Normally, iteration is over the events in the one sequence used
+    // to instatiate the iterator (see above), but with this method, you
+    // can add more sequences to the iteration. Events are returned in
+    // time order, so effectively sequence events are merged.
+    // The optional offset is added to each event time of sequence s
+    // before merging/sorting. You should call begin_seq() for each
+    // sequence to be included in the iteration unless you call begin()
+    // (see below).
+    void begin_seq(Alg_seq_ptr s, void *cookie = nullptr, double offset = 0.0);
+    ~Alg_iterator();
+    // Prepare to enumerate events in order. If note_off_flag is true, then
+    // iteration_next will merge note-off events into the sequence. If you
+    // call begin(), you should not normally call begin_seq(). See above.
+    void begin(void *cookie = nullptr) { begin_seq(seq, cookie); }
+    // return next event (or NULL). If iteration_begin was called with
+    // note_off_flag = true, and if note_on is not NULL, then *note_on
+    // is set to true when the result value represents a note-on or update.
+    // (With note_off_flag, each Alg_note event is returned twice, once
+    // at the note-on time, with *note_on == true, and once at the note-off
+    // time, with *note_on == false. If a cookie_ptr is passed, then the
+    // cookie corresponding to the event is stored at that address
+    // If end_time is 0, iterate through the entire sequence, but if
+    // end_time is non_zero, stop iterating at the last event before end_time
+    Alg_event_ptr next(bool *note_on = nullptr, void **cookie_ptr = nullptr,
+                       double *offset_ptr = nullptr, double end_time = 0);
+    // Sometimes, the caller wants to receive note-off events for a subset
+    // of the notes, typically the notes that are played and need to be
+    // turned off. In this case, when a note is turned on, the client
+    // should call request_note_off(). This will insert a note-off into
+    // the queue for the most recent note returned by next(). 
+    void request_note_off();
+    void end();   // clean up after enumerating events
+} *Alg_iterator_ptr;
+
 
 // An Alg_seq is an array of Alg_events, each a sequence of Alg_event, 
 // with a tempo map and a sequence of time signatures
 //
-using Alg_seq_ptr = class Alg_seq : public Alg_track
-{
+typedef class Alg_seq : public Alg_track {
 protected:
-	Alg_iterator_ptr pending; // iterator used internally by Alg_seq methods
-	void serialize_seq();
-	Alg_error error; // error code set by file readers
-	// an internal function used for writing Allegro track names
-	Alg_event_ptr write_track_name(std::ostream& file, int n, Alg_events& events);
-
+    Alg_iterator_ptr pending; // iterator used internally by Alg_seq methods
+    void serialize_seq();
+    Alg_error error; // error code set by file readers
+    // an internal function used for writing Allegro track names
+    Alg_event_ptr write_track_name(std::ostream &file, int n, 
+                                   Alg_events &events);
 public:
-	int channel_offset_per_track; // used to encode track_num into channel
-	Alg_tracks track_list;		  // array of Alg_events
-	Alg_time_sigs time_sig;
-	int beat_x;
-	void basic_initialization()
-	{
-		error = alg_no_error;
-		units_are_seconds = true;
-		type = 's';
-		channel_offset_per_track = 0;
-		add_track(0); // default is one empty track
-	}
-	Alg_seq() { basic_initialization(); }
-	// copy constructor -- if track is an Alg_seq, make a copy; if
-	//    track is just an Alg_track, the track becomes track 0
-	Alg_seq(Alg_track_ref track) { seq_from_track(track); }
-	Alg_seq(Alg_track_ptr track) { seq_from_track(*track); }
-	void seq_from_track(Alg_track_ref tr);
-	// create from file:
-	Alg_seq(std::istream& file, bool smf, double* offset_ptr = nullptr);
-	// create from filename
-	Alg_seq(const char* filename, bool smf, double* offset_ptr = nullptr);
-	~Alg_seq() override;
-	int get_read_error() { return error; }
-	void serialize(void** buffer, long* bytes) override;
-	void copy_time_sigs_to(Alg_seq* dest); // a utility function
-	void set_time_map(Alg_time_map* map) override;
+    int channel_offset_per_track; // used to encode track_num into channel
+    Alg_tracks track_list;       // array of Alg_events
+    Alg_time_sigs time_sig;
+    int beat_x;
+    void basic_initialization() {
+        error = alg_no_error;
+        units_are_seconds = true; type = 's';
+        channel_offset_per_track = 0;
+        add_track(0); // default is one empty track
+    }        
+    Alg_seq() {
+        basic_initialization();
+    }
+    // copy constructor -- if track is an Alg_seq, make a copy; if
+    //    track is just an Alg_track, the track becomes track 0
+    Alg_seq(Alg_track_ref track) { seq_from_track(track); }
+    Alg_seq(Alg_track_ptr track) { seq_from_track(*track); }
+    void seq_from_track(Alg_track_ref tr);
+    // create from file:
+    Alg_seq(std::istream &file, bool smf, double *offset_ptr = nullptr);
+    // create from filename
+    Alg_seq(const char *filename, bool smf, double *offset_ptr = nullptr);
+    ~Alg_seq() override;
+    int get_read_error() { return error; }
+    void serialize(void **buffer, long *bytes) override;
+    void copy_time_sigs_to(Alg_seq *dest); // a utility function
+    void set_time_map(Alg_time_map *map) override;
 
-	// encode sequence structure into contiguous, moveable memory block
-	// address of newly allocated memory is assigned to *buffer, which must
-	// be freed by caller; the length of data is assigned to *len
-	void unserialize_seq();
+    // encode sequence structure into contiguous, moveable memory block
+    // address of newly allocated memory is assigned to *buffer, which must
+    // be freed by caller; the length of data is assigned to *len
+    void unserialize_seq();
 
-	// write an ascii representation to file
-	void write(std::ostream& file, bool in_secs, double offset = 0.0);
-	// returns true on success
-	bool write(const char* filename, double offset = 0.0);
-	void smf_write(std::ostream& file);
-	bool smf_write(const char* filename);
+    // write an ascii representation to file
+    void write(std::ostream &file, bool in_secs, double offset = 0.0);
+    // returns true on success
+    bool write(const char *filename, double offset = 0.0);
+    void smf_write(std::ostream &file);
+    bool smf_write(const char *filename);
 
-	// Returns the number of tracks
-	int tracks();
+    // Returns the number of tracks
+    int tracks();
 
-	// create a track
-	void add_track(int track_num) { track_list.add_track(track_num, get_time_map(), units_are_seconds); }
+    // create a track
+    void add_track(int track_num) { 
+        track_list.add_track(track_num, get_time_map(), units_are_seconds); 
+    }
 
-	// Return a particular track. This Alg_seq owns the track, so the
-	// caller must not delete the result.
-	Alg_track_ptr track(int);
+    // Return a particular track. This Alg_seq owns the track, so the
+    // caller must not delete the result.
+    Alg_track_ptr track(int);
 
-	Alg_event_ptr const& operator[](int i) override;
+    Alg_event_ptr const &operator[](int i) override;
 
-	void convert_to_seconds() override;
-	void convert_to_beats() override;
+    void convert_to_seconds() override;
+    void convert_to_beats() override;
 
-	Alg_track_ptr cut_from_track(int track_num, double start, double dur, bool all);
-	Alg_seq* cut(double t, double len, bool all) override;
-	void insert_silence_in_track(int track_num, double t, double len);
-	void insert_silence(double t, double len) override;
-	Alg_track_ptr copy_track(int track_num, double t, double len, bool all);
-	Alg_seq* copy(double start, double len, bool all) override;
-	void paste(double start, Alg_seq* seq);
-	void clear(double t, double len, bool all) override;
-	void merge(double t, Alg_event_list_ptr seq) override;
-	void silence(double t, double len, bool all) override;
-	void clear_track(int track_num, double start, double len, bool all);
-	void silence_track(int track_num, double start, double len, bool all);
-	Alg_event_list_ptr find_in_track(
-		int track_num, double t, double len, bool all, long channel_mask, long event_type_mask);
+    Alg_track_ptr cut_from_track(int track_num, double start, double dur, 
+                                 bool all);
+    Alg_seq *cut(double t, double len, bool all) override;
+    void insert_silence_in_track(int track_num, double t, double len);
+    void insert_silence(double t, double len) override;
+    Alg_track_ptr copy_track(int track_num, double t, double len, bool all);
+    Alg_seq *copy(double start, double len, bool all) override;
+    void paste(double start, Alg_seq *seq);
+    void clear(double t, double len, bool all) override;
+    void merge(double t, Alg_event_list_ptr seq) override;
+    void silence(double t, double len, bool all) override;
+    void clear_track(int track_num, double start, double len, bool all);
+    void silence_track(int track_num, double start, double len, bool all);
+    Alg_event_list_ptr find_in_track(int track_num, double t, double len,
+                                     bool all, long channel_mask, 
+                                     long event_type_mask);
 
-	// find index of first score event after time
-	long seek_time(double time, int track_num);
-	bool insert_beat(double time, double beat);
-	// return the time of the beat nearest to time, also returns beat
-	// number through beat. This will correspond to an integer number
-	// of beats from the nearest previous time signature or 0.0, but
-	// since time signatures need not be on integer beat boundaries
-	// the beat location may not be on an integer beat (beat locations
-	// are measured from the beginning which is beat 0.
-	double nearest_beat_time(double time, double* beat);
-	// warning: insert_tempo may change representation from seconds to beats
-	bool insert_tempo(double bpm, double beat);
-	// change the duration from b0 to b1 (beats) to dur (seconds) by
-	// scaling the intervening tempos
-	bool stretch_region(double b0, double b1, double dur);
-	// add_event takes a pointer to an event on the heap. The event is not
-	// copied, and this Alg_seq becomes the owner and freer of the event.
-	void add_event(Alg_event_ptr event, int track_num);
-	void add(Alg_event_ptr event) override { assert(false); } // call add_event instead
-	// get the tempo starting at beat
-	double get_tempo(double beat);
-	bool set_tempo(double bpm, double start_beat, double end_beat);
+    // find index of first score event after time
+    long seek_time(double time, int track_num);
+    bool insert_beat(double time, double beat);
+    // return the time of the beat nearest to time, also returns beat
+    // number through beat. This will correspond to an integer number
+    // of beats from the nearest previous time signature or 0.0, but
+    // since time signatures need not be on integer beat boundaries
+    // the beat location may not be on an integer beat (beat locations
+    // are measured from the beginning which is beat 0.
+    double nearest_beat_time(double time, double *beat);
+    // warning: insert_tempo may change representation from seconds to beats
+    bool insert_tempo(double bpm, double beat);
+    // change the duration from b0 to b1 (beats) to dur (seconds) by
+    // scaling the intervening tempos
+    bool stretch_region(double b0, double b1, double dur);
+    // add_event takes a pointer to an event on the heap. The event is not
+    // copied, and this Alg_seq becomes the owner and freer of the event.
+    void add_event(Alg_event_ptr event, int track_num);
+    void add(Alg_event_ptr event) override { assert(false); } // call add_event instead
+    // get the tempo starting at beat
+    double get_tempo(double beat);
+    bool set_tempo(double bpm, double start_beat, double end_beat);
 
-	// get the bar length in beats starting at beat
-	double get_bar_len(double beat);
-	void set_time_sig(double beat, double num, double den);
-	void beat_to_measure(double beat, long* measure, double* m_beat, double* num, double* den);
-	// void set_events(Alg_event_ptr *events, long len, long max);
-	void merge_tracks();				 // move all track data into one track
-	void set_in_use(bool flag) override; // set in_use flag on all tracks
-};
-using Alg_seq_ref = class Alg_seq&;
+    // get the bar length in beats starting at beat
+    double get_bar_len(double beat);
+    void set_time_sig(double beat, double num, double den);
+    void beat_to_measure(double beat, long *measure, double *m_beat,
+                         double *num, double *den);
+    // void set_events(Alg_event_ptr *events, long len, long max);
+    void merge_tracks();    // move all track data into one track
+    void set_in_use(bool flag) override; // set in_use flag on all tracks
+} *Alg_seq_ptr, &Alg_seq_ref;
+
 
 // see Alg_seq::Alg_seq() constructors that read from files
 // the following are for internal library implementation and are

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -84,13 +84,13 @@ public slots:
 
 
 private:
-	typedef struct
+	using handle_data = struct
 	{
 		MM_OPERATORS
 		SampleBuffer::handleState* state;
 		bool tuned;
 		SampleBuffer* sample;
-	} handle_data;
+	};
 
 	QString m_patchFile;
 	QVector<SampleBuffer *> m_patchSamples;

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -84,7 +84,7 @@ public slots:
 
 
 private:
-	using handle_data = struct
+	struct handle_data
 	{
 		MM_OPERATORS
 		SampleBuffer::handleState* state;

--- a/plugins/ReverbSC/base.h
+++ b/plugins/ReverbSC/base.h
@@ -16,30 +16,27 @@
 
 #define SP_RANDMAX 2147483648
 
-using sp_frame = unsigned long;
+typedef unsigned long sp_frame;
 
-using sp_auxdata = struct sp_auxdata
-{
-	size_t size;
-	void* ptr;
-};
+typedef struct sp_auxdata {
+    size_t size;
+    void *ptr;
+} sp_auxdata;
 
-using sp_data = struct sp_data
-{
-	SPFLOAT* out;
-	uint32_t sr;
-	int nchan;
-	unsigned long len;
-	unsigned long pos;
-	char filename[200];
-	uint32_t rand;
-};
+typedef struct sp_data { 
+    SPFLOAT *out;
+    uint32_t sr;
+    int nchan;
+    unsigned long len;
+    unsigned long pos;
+    char filename[200];
+    uint32_t rand;
+} sp_data; 
 
-using sp_param = struct
-{
-	char state;
-	SPFLOAT val;
-};
+typedef struct {
+    char state;
+    SPFLOAT val;
+} sp_param;
 
 int sp_auxdata_alloc(sp_auxdata *aux, size_t size);
 int sp_auxdata_free(sp_auxdata *aux);
@@ -62,12 +59,12 @@ int sp_out(sp_data *sp, uint32_t chan, SPFLOAT val);
 uint32_t sp_rand(sp_data *sp);
 void sp_srand(sp_data *sp, uint32_t val);
 
-using sp_fft = struct
-{
-	SPFLOAT* utbl;
-	int16_t* BRLow;
-	int16_t* BRLowCpx;
-};
+
+typedef struct {
+    SPFLOAT *utbl;
+    int16_t *BRLow;
+    int16_t *BRLowCpx;
+} sp_fft;
 
 void sp_fft_create(sp_fft **fft);
 void sp_fft_init(sp_fft *fft, int M);
@@ -78,11 +75,10 @@ void sp_fft_destroy(sp_fft *fft);
 #ifndef kiss_fft_scalar
 #define kiss_fft_scalar SPFLOAT
 #endif
-using kiss_fft_cpx = struct
-{
-	kiss_fft_scalar r;
-	kiss_fft_scalar i;
-};
+typedef struct {
+    kiss_fft_scalar r;
+    kiss_fft_scalar i;
+}kiss_fft_cpx;
 
-using kiss_fft_cfg = struct kiss_fft_state;
-using kiss_fftr_cfg = struct kiss_fftr_state;
+typedef struct kiss_fft_state* kiss_fft_cfg;
+typedef struct kiss_fftr_state* kiss_fftr_cfg;

--- a/plugins/ReverbSC/base.h
+++ b/plugins/ReverbSC/base.h
@@ -16,27 +16,30 @@
 
 #define SP_RANDMAX 2147483648
 
-typedef unsigned long sp_frame;
+using sp_frame = unsigned long;
 
-typedef struct sp_auxdata {
-    size_t size;
-    void *ptr;
-} sp_auxdata;
+using sp_auxdata = struct sp_auxdata
+{
+	size_t size;
+	void* ptr;
+};
 
-typedef struct sp_data { 
-    SPFLOAT *out;
-    uint32_t sr;
-    int nchan;
-    unsigned long len;
-    unsigned long pos;
-    char filename[200];
-    uint32_t rand;
-} sp_data; 
+using sp_data = struct sp_data
+{
+	SPFLOAT* out;
+	uint32_t sr;
+	int nchan;
+	unsigned long len;
+	unsigned long pos;
+	char filename[200];
+	uint32_t rand;
+};
 
-typedef struct {
-    char state;
-    SPFLOAT val;
-} sp_param;
+using sp_param = struct
+{
+	char state;
+	SPFLOAT val;
+};
 
 int sp_auxdata_alloc(sp_auxdata *aux, size_t size);
 int sp_auxdata_free(sp_auxdata *aux);
@@ -59,12 +62,12 @@ int sp_out(sp_data *sp, uint32_t chan, SPFLOAT val);
 uint32_t sp_rand(sp_data *sp);
 void sp_srand(sp_data *sp, uint32_t val);
 
-
-typedef struct {
-    SPFLOAT *utbl;
-    int16_t *BRLow;
-    int16_t *BRLowCpx;
-} sp_fft;
+using sp_fft = struct
+{
+	SPFLOAT* utbl;
+	int16_t* BRLow;
+	int16_t* BRLowCpx;
+};
 
 void sp_fft_create(sp_fft **fft);
 void sp_fft_init(sp_fft *fft, int M);
@@ -75,10 +78,11 @@ void sp_fft_destroy(sp_fft *fft);
 #ifndef kiss_fft_scalar
 #define kiss_fft_scalar SPFLOAT
 #endif
-typedef struct {
-    kiss_fft_scalar r;
-    kiss_fft_scalar i;
-}kiss_fft_cpx;
+using kiss_fft_cpx = struct
+{
+	kiss_fft_scalar r;
+	kiss_fft_scalar i;
+};
 
-typedef struct kiss_fft_state* kiss_fft_cfg;
-typedef struct kiss_fftr_state* kiss_fftr_cfg;
+using kiss_fft_cfg = struct kiss_fft_state;
+using kiss_fftr_cfg = struct kiss_fftr_state;

--- a/plugins/ReverbSC/dcblock.h
+++ b/plugins/ReverbSC/dcblock.h
@@ -1,10 +1,9 @@
-using sp_dcblock = struct
-{
-	SPFLOAT gg;
-	SPFLOAT outputs;
-	SPFLOAT inputs;
-	SPFLOAT gain;
-};
+typedef struct {
+    SPFLOAT gg;
+    SPFLOAT outputs;
+    SPFLOAT inputs;
+    SPFLOAT gain;
+} sp_dcblock;
 
 int sp_dcblock_create(sp_dcblock **p);
 int sp_dcblock_destroy(sp_dcblock **p);

--- a/plugins/ReverbSC/dcblock.h
+++ b/plugins/ReverbSC/dcblock.h
@@ -1,9 +1,10 @@
-typedef struct {
-    SPFLOAT gg;
-    SPFLOAT outputs;
-    SPFLOAT inputs;
-    SPFLOAT gain;
-} sp_dcblock;
+using sp_dcblock = struct
+{
+	SPFLOAT gg;
+	SPFLOAT outputs;
+	SPFLOAT inputs;
+	SPFLOAT gain;
+};
 
 int sp_dcblock_create(sp_dcblock **p);
 int sp_dcblock_destroy(sp_dcblock **p);

--- a/plugins/ReverbSC/revsc.h
+++ b/plugins/ReverbSC/revsc.h
@@ -1,26 +1,28 @@
-typedef struct {
-    int writePos;
-    int bufferSize;
-    int readPos;
-    int readPosFrac;
-    int readPosFrac_inc;
-    int dummy;
-    int seedVal;
-    int randLine_cnt;
-    SPFLOAT filterState;
-    SPFLOAT *buf;
-} sp_revsc_dl;
+using sp_revsc_dl = struct
+{
+	int writePos;
+	int bufferSize;
+	int readPos;
+	int readPosFrac;
+	int readPosFrac_inc;
+	int dummy;
+	int seedVal;
+	int randLine_cnt;
+	SPFLOAT filterState;
+	SPFLOAT* buf;
+};
 
-typedef struct  {
-    SPFLOAT feedback, lpfreq;
-    SPFLOAT iSampleRate, iPitchMod, iSkipInit;
-    SPFLOAT sampleRate;
-    SPFLOAT dampFact;
-    SPFLOAT prv_LPFreq;
-    int initDone;
-    sp_revsc_dl delayLines[8];
-    sp_auxdata aux;
-} sp_revsc;
+using sp_revsc = struct
+{
+	SPFLOAT feedback, lpfreq;
+	SPFLOAT iSampleRate, iPitchMod, iSkipInit;
+	SPFLOAT sampleRate;
+	SPFLOAT dampFact;
+	SPFLOAT prv_LPFreq;
+	int initDone;
+	sp_revsc_dl delayLines[8];
+	sp_auxdata aux;
+};
 
 int sp_revsc_create(sp_revsc **p);
 int sp_revsc_destroy(sp_revsc **p);

--- a/plugins/ReverbSC/revsc.h
+++ b/plugins/ReverbSC/revsc.h
@@ -1,28 +1,26 @@
-using sp_revsc_dl = struct
-{
-	int writePos;
-	int bufferSize;
-	int readPos;
-	int readPosFrac;
-	int readPosFrac_inc;
-	int dummy;
-	int seedVal;
-	int randLine_cnt;
-	SPFLOAT filterState;
-	SPFLOAT* buf;
-};
+typedef struct {
+    int writePos;
+    int bufferSize;
+    int readPos;
+    int readPosFrac;
+    int readPosFrac_inc;
+    int dummy;
+    int seedVal;
+    int randLine_cnt;
+    SPFLOAT filterState;
+    SPFLOAT *buf;
+} sp_revsc_dl;
 
-using sp_revsc = struct
-{
-	SPFLOAT feedback, lpfreq;
-	SPFLOAT iSampleRate, iPitchMod, iSkipInit;
-	SPFLOAT sampleRate;
-	SPFLOAT dampFact;
-	SPFLOAT prv_LPFreq;
-	int initDone;
-	sp_revsc_dl delayLines[8];
-	sp_auxdata aux;
-};
+typedef struct  {
+    SPFLOAT feedback, lpfreq;
+    SPFLOAT iSampleRate, iPitchMod, iSkipInit;
+    SPFLOAT sampleRate;
+    SPFLOAT dampFact;
+    SPFLOAT prv_LPFreq;
+    int initDone;
+    sp_revsc_dl delayLines[8];
+    sp_auxdata aux;
+} sp_revsc;
 
 int sp_revsc_create(sp_revsc **p);
 int sp_revsc_destroy(sp_revsc **p);

--- a/plugins/Vibed/NineButtonSelector.h
+++ b/plugins/Vibed/NineButtonSelector.h
@@ -101,8 +101,7 @@ private:
 
 } ;
 
-typedef IntModel NineButtonSelectorModel;
-
+using NineButtonSelectorModel = IntModel;
 
 } // namespace lmms::gui
 

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -475,7 +475,7 @@ private:
 	std::mutex m_shmLock;
 	bool m_shmValid;
 
-	typedef std::vector<VstMidiEvent> VstMidiEventList;
+	using VstMidiEventList = int;
 	VstMidiEventList m_midiEvents;
 
 	bpm_t m_bpm;
@@ -997,8 +997,7 @@ bool RemoteVstPlugin::load( const std::string & _plugin_file )
 	}
 #endif
 
-	typedef AEffect * ( VST_CALL_CONV * mainEntryPointer )
-						( audioMasterCallback );
+	using mainEntryPointer = AEffect* (*)(audioMasterCallback);
 #ifndef NATIVE_LINUX_VST
 	mainEntryPointer mainEntry = (mainEntryPointer)
 				GetProcAddress( m_libInst, "VSTPluginMain" );

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -475,7 +475,7 @@ private:
 	std::mutex m_shmLock;
 	bool m_shmValid;
 
-	using VstMidiEventList = int;
+	typedef std::vector<VstMidiEvent> VstMidiEventList;
 	VstMidiEventList m_midiEvents;
 
 	bpm_t m_bpm;
@@ -997,7 +997,7 @@ bool RemoteVstPlugin::load( const std::string & _plugin_file )
 	}
 #endif
 
-	using mainEntryPointer = AEffect* (*)(audioMasterCallback);
+	using mainEntryPointer = AEffect* (VST_CALL_CONV*) (audioMasterCallback);
 #ifndef NATIVE_LINUX_VST
 	mainEntryPointer mainEntry = (mainEntryPointer)
 				GetProcAddress( m_libInst, "VSTPluginMain" );

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -475,7 +475,7 @@ private:
 	std::mutex m_shmLock;
 	bool m_shmValid;
 
-	typedef std::vector<VstMidiEvent> VstMidiEventList;
+	using VstMidiEventList = std::vector<VstMidiEvent>;
 	VstMidiEventList m_midiEvents;
 
 	bpm_t m_bpm;

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -43,10 +43,9 @@
 namespace lmms
 {
 
-
-typedef exprtk::symbol_table<float> symbol_table_t;
-typedef exprtk::expression<float> expression_t;
-typedef exprtk::parser<float> parser_t;
+using symbol_table_t = exprtk::symbol_table<float>;
+using expression_t = exprtk::expression<float>;
+using parser_t = exprtk::parser<float>;
 
 template <typename T,typename Functor,bool optimize>
 struct freefunc0 : public exprtk::ifunction<T>

--- a/plugins/Xpressive/ExprSynth.h
+++ b/plugins/Xpressive/ExprSynth.h
@@ -51,7 +51,7 @@ class PixmapButton;
 class ExprFront
 {
 public:
-	typedef float (*ff1data_functor)(void*, float);
+	using ff1data_functor = float (*)(void*, float);
 	ExprFront(const char* expr, int last_func_samples);
 	~ExprFront();
 	bool compile();

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -64,9 +64,7 @@
 namespace lmms
 {
 
-
-typedef LocklessList<PlayHandle *>::Element LocklessListElement;
-
+using LocklessListElement = LocklessList<PlayHandle*>::Element;
 
 static thread_local bool s_renderingThread;
 

--- a/src/core/BandLimitedWave.cpp
+++ b/src/core/BandLimitedWave.cpp
@@ -30,7 +30,7 @@
 namespace lmms
 {
 
-WaveMipMap BandLimitedWave::s_waveforms[4] = {  };
+std::array<WaveMipMap, BandLimitedWave::Waveforms::NumBLWaveforms> BandLimitedWave::s_waveforms = {  };
 bool BandLimitedWave::s_wavesGenerated = false;
 QString BandLimitedWave::s_wavetableDir = "";
 

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -234,7 +234,7 @@ void Oscillator::generateWaveTables()
 	// Generate tables for simple shaped (constructed by summing sine waves).
 	// Start from the table that contains the least number of bands, and re-use each table in the following
 	// iteration, adding more bands in each step and avoiding repeated computation of earlier bands.
-	typedef void (*generator_t)(int, sample_t*, int);
+	using generator_t = void (*)(int, sample_t*, int);
 	auto simpleGen = [](WaveShapes shape, generator_t generator)
 	{
 		const int shapeID = shape - FirstWaveShapeTable;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -538,7 +538,7 @@ DataFile ClipView::createClipDataFiles(
 	DataFile dataFile( DataFile::DragNDropData );
 	QDomElement clipParent = dataFile.createElement("clips");
 
-	typedef QVector<ClipView *> clipViewVector;
+	using clipViewVector = QVector<ClipView*>;
 	for( clipViewVector::const_iterator it = clipViews.begin();
 			it != clipViews.end(); ++it )
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -77,7 +77,7 @@ namespace lmms
 {
 
 
-typedef AutomationClip::timeMap timeMap;
+using timeMap = AutomationClip::timeMap;
 
 
 namespace gui

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -922,7 +922,7 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 			}
 			else if(node.nodeName() == "instrument")
 			{
-				typedef Plugin::Descriptor::SubPluginFeatures::Key PluginKey;
+				using PluginKey = Plugin::Descriptor::SubPluginFeatures::Key;
 				PluginKey key(node.toElement().elementsByTagName("key").item(0).toElement());
 
 				if (reuseInstrument)


### PR DESCRIPTION
This clang-tidy check converts ``typedef`` declarations into their ``using`` declaration equivalent. This PR in particular also updates C-style typedef arrays with ``std::array``. Do note that it may seem possible to replace some typedef function pointers with ``std::function`` at first. However, this created problems with the surrounding codebase, so those declarations are left as function pointers. 