### PR TITLE
Make `ControlLayout` more general

### DIFF
--- a/include/ControlLayout.h
+++ b/include/ControlLayout.h
@@ -73,14 +73,20 @@
 #ifndef CONTROLLAYOUT_H
 #define CONTROLLAYOUT_H
 
+#include <memory>
+#include <vector>
+
 #include <QLayout>
 #include <QMultiMap>
+#include <QString>
 #include <QStyle>
+#include <QWidget>
+
+#include "lmms_export.h"
 
 class QLayoutItem;
-class QRect;
-class QString;
 class QLineEdit;
+class QRect;
 
 
 namespace lmms::gui
@@ -91,17 +97,16 @@ namespace lmms::gui
 
 	Originally token from Qt's FlowLayout example. Modified.
 
-	Features a search bar, as well as looking up widgets with string keys
-	Keys have to be provided in the widgets' objectNames
+	Features widget filtering, as well as looking up widgets with string keys
+	Keys have to be provided in the widgets' property ControlLayout::KeyProperty
 */
-class ControlLayout : public QLayout
+class LMMS_EXPORT ControlLayout : public QLayout
 {
 	Q_OBJECT
 
 public:
 	explicit ControlLayout(QWidget *parent,
 		int margin = -1, int hSpacing = -1, int vSpacing = -1);
-	~ControlLayout() override;
 
 	void addItem(QLayoutItem *item) override;
 	int horizontalSpacing() const;
@@ -111,32 +116,43 @@ public:
 	int heightForWidth(int) const override;
 	int count() const override;
 	QLayoutItem *itemAt(int index) const override;
-	QLayoutItem *itemByString(const QString& key) const;
 	QSize minimumSize() const override;
 	void setGeometry(const QRect &rect) override;
 	QSize sizeHint() const override;
 	QLayoutItem *takeAt(int index) override;
-	//! remove focus from QLineEdit search bar
-	//! this may be useful if the mouse is outside the layout
-	void removeFocusFromSearchBar();
 
-private slots:
-	void onTextChanged(const QString&);
+	constexpr static auto KeyProperty = "lmms::gui::ControlLayout::keyProperty";
+
+public slots:
+	void setFilterString(const QString& filter);
 
 private:
 	int doLayout(const QRect &rect, bool testOnly) const;
 	int smartSpacing(QStyle::PixelMetric pm) const;
-	QMap<QString, QLayoutItem *>::const_iterator pairAt(int index) const;
 
-	QMultiMap<QString, QLayoutItem *> m_itemMap;
+	std::vector<std::unique_ptr<QLayoutItem>> m_items;
 	int m_hSpace;
 	int m_vSpace;
 	// relevant dimension is width, as later, heightForWidth() will be called
 	// 400 looks good and is ~4 knobs in a row
 	constexpr const static int m_minWidth = 400;
-	QLineEdit* m_searchBar;
-	//! name of search bar, must be ASCII sorted before any alpha numerics
-	static constexpr const char* s_searchBarName = "!!searchBar!!";
+	QString m_filterString;
+};
+
+/**
+ * Widget providing a filter field for ControlLayout
+ *
+ * Connect the filterChanged signal to the layout's setFilterString slot
+ */
+class LMMS_EXPORT ControlFilterWidget : public QWidget
+{
+	Q_OBJECT
+
+public:
+	ControlFilterWidget(QWidget* parent = nullptr);
+
+signals:
+	void filterChanged(const QString& filter);
 };
 
 } // namespace lmms::gui

--- a/include/LinkedModelGroupViews.h
+++ b/include/LinkedModelGroupViews.h
@@ -43,6 +43,7 @@ namespace gui
 {
 
 class Control;
+class ControlFilterWidget;
 
 /**
 	@file LinkedModelGroupViews.h
@@ -77,21 +78,17 @@ public:
 
 protected:
 	//! Add a control to this widget
-	//! @warning This widget will own this control, do not free it
-	void addControl(Control* ctrl, const std::string &id,
+	void addControl(std::unique_ptr<Control> ctrl, const std::string &id,
 					const std::string& display, bool removable);
-
-	void removeControl(const QString &key);
-
-	void removeFocusFromSearchBar();
 
 private:
 	class LinkedModelGroup* m_model;
 
 	//! column number in surrounding grid in LinkedModelGroupsView
 	std::size_t m_colNum;
+	ControlFilterWidget* m_filter;
 	class ControlLayout* m_layout;
-	std::map<std::string, std::unique_ptr<class Control>> m_widgets;
+	std::map<std::string, std::unique_ptr<Control>> m_widgets;
 };
 
 


### PR DESCRIPTION
There are a couple of things I want to do with this class: I want to be able to filter multiple layouts with a single search field (for VST3), and I want to be able to sort the control in various ways (e.g. most recently changed, for VST2). These are the changes in this PR:
* Split the search field into a separate widget, passing the search string via signals and slots. This means that one search field can be linked to multiple layouts. I chose to make a new widget, rather than use a raw `QLineEdit`, so we can add the sorting options to it in the future.
* Moved the widget filter keys from the object name to a custom property. If we add sorting, then we may want to reference multiple properties, and these can't all go in the object name, so we gain consistency like this. Also, it's probably a better place to put the keys anyway.
* Changed the layout's item storage from a map to a vector. This too reduces the special status of the filter keys, and makes some existing layout operations more efficient.
* Changed the layout's item storage to use `unique_ptr`s rather than raw pointers. The layout owns its layout items, and as they do not derive from `QObject` and so Qt's ownership model does not apply, this is the better choice.
* Removed the `removeFocusFromSearchBar` functions. They weren't used, and the problem they were intended to solve affects other text fields in the program, so a more general solution would be better.
* Removed `ControlLayout::itemByString` and `LinkedModelGroupView::removeControl`. This was broken, as controls were stored by filter key, but looked up by id. A correct implementation should go somewhere else, as it should not be the layout's responsibility to maintain a separate id-widget map for removing controls. It was also unused.
* Changed `LinkedModelGroupView::addControl` to take the control in a `unique_ptr`, since it assumes unique ownership of the control. (Not related to the rest of this PR, and I can revert if you want, but I had already made the change before realising it was unnecessary.)
* Exported the `ControlLayout` (and `ControlFilterWidget`) classes, so they can be used by plugins.

Screenshots of an LV2 control dialog before and after this change:
![Screenshot 2022-06-24 190243](https://user-images.githubusercontent.com/1873225/177040170-3ecc9467-c099-4a71-b28f-6980d9adc99c.png)
![Screenshot 2022-07-03 123403](https://user-images.githubusercontent.com/1873225/177040174-0987e039-c823-493c-829a-a56efb2696de.png)
(Yes, the filter box in the new dialog doesn't reach all the way across, but the widget that contains it has the same problem in the former dialog; it's just not visible as no control is wide enough to demonstrate the problem.)