### PR TITLE
Allow negative value for stereo difference in BitCrush

### DIFF
--- a/plugins/Bitcrush/BitcrushControls.cpp
+++ b/plugins/Bitcrush/BitcrushControls.cpp
@@ -42,7 +42,7 @@ BitcrushControls::BitcrushControls( BitcrushEffect * eff ) :
 	m_outGain( 0.0f, -20.0f, 20.0f, 0.1f, this, tr( "Output gain" ) ),
 	m_outClip( 0.0f, -20.0f, 20.0f, 0.1f, this, tr( "Output clip" ) ),
 	m_rate( 44100.f, 20.f, 44100.f, 1.0f, this, tr( "Sample rate" ) ),
-	m_stereoDiff( 0.f, 0.f, 50.f, 0.1f, this, tr( "Stereo difference" ) ),
+	m_stereoDiff( 0.f, -50.f, 50.f, 0.1f, this, tr( "Stereo difference" ) ),
 	m_levels( 256.f, 1.f, 256.f, 0.01f, this, tr( "Levels" ) ),
 	m_rateEnabled( true, this, tr( "Rate enabled" ) ),
 	m_depthEnabled( true, this, tr( "Depth enabled" ) )


### PR DESCRIPTION
Smallest PR ever. Now you can tune the left channel higher than the right one as well, which was only possible in one direction until now.