### PR TITLE
Core Refactor: Replace ``QVector`` with ``std::vector``

### DIFF
--- a/include/AudioEngineWorkerThread.h
+++ b/include/AudioEngineWorkerThread.h
@@ -100,7 +100,7 @@ public:
 							JobQueue::OperationMode _opMode = JobQueue::Static )
 	{
 		resetJobQueue( _opMode );
-		for (const auto job : _vec)
+		for (const auto& job : _vec)
 		{
 			addJob(job);
 		}

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -117,7 +117,7 @@ private:
 	std::atomic<bool> m_stopped;
 
 	std::atomic<MidiJack *> m_midiClient;
-	std::vector<jack_port_t*> m_outputPorts;
+	std::vector<jack_port_t *> m_outputPorts;
 	jack_default_audio_sample_t * * m_tempOutBufs;
 	surroundSampleFrame * m_outBuf;
 

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -189,12 +189,12 @@ private:
 	void generateTangents();
 	void generateTangents(timeMap::iterator it, int numToGenerate);
 	float valueAt( timeMap::const_iterator v, int offset ) const;
-	
+
 	/**
-	 * @brief 
+	 * @brief
 	 * This function combines the song tracks, pattern store tracks,
 	 * and the global automation track all in one vector.
-	 * 
+	 *
 	 * @return std::vector<Track*>
 	 */
 	static std::vector<Track*> combineAllTracks();

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -189,6 +189,15 @@ private:
 	void generateTangents();
 	void generateTangents(timeMap::iterator it, int numToGenerate);
 	float valueAt( timeMap::const_iterator v, int offset ) const;
+	
+	/**
+	 * @brief 
+	 * This function combines the song tracks, pattern store tracks,
+	 * and the global automation track all in one vector.
+	 * 
+	 * @return std::vector<Track*>
+	 */
+	static std::vector<Track*> combineAllTracks();
 
 	// Mutex to make methods involving automation clips thread safe
 	// Mutable so we can lock it from const objects

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -27,6 +27,7 @@
 #define LMMS_GUI_AUTOMATION_EDITOR_H
 
 #include <QWidget>
+#include <array>
 
 #include "Editor.h"
 
@@ -180,7 +181,7 @@ private:
 	ComboBoxModel m_zoomingYModel;
 	ComboBoxModel m_quantizeModel;
 
-	static const std::vector<float> m_zoomXLevels;
+	static const std::array<float, 7> m_zoomXLevels;
 
 	FloatModel * m_tensionModel;
 

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -2,7 +2,7 @@
  * ConfigManager.h - class ConfigManager, a class for managing LMMS-configuration
  *
  * Copyright (c) 2005-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- * 
+ *
  * This file is part of LMMS - https://lmms.io
  *
  * This program is free software; you can redistribute it and/or

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -33,6 +33,7 @@
 #include <QObject>
 
 #include <vector>
+#include <optional>
 #include "lmms_export.h"
 
 
@@ -239,11 +240,8 @@ public:
 
 	void addRecentlyOpenedProject(const QString & _file);
 
-	const QString value(const QString & cls, const QString & attribute) const;
-	
-	const QString & value(const QString & cls,
-					const QString & attribute,
-					const QString & defaultVal) const;
+	QString value(const QString& cls, const QString& attribute, const QString& defaultVal = "") const;
+
 	void setValue(const QString & cls, const QString & attribute,
 						const QString & value);
 	void deleteValue(const QString & cls, const QString & attribute);

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -33,7 +33,6 @@
 #include <QObject>
 
 #include <vector>
-#include <optional>
 #include "lmms_export.h"
 
 

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -2,7 +2,7 @@
  * ConfigManager.h - class ConfigManager, a class for managing LMMS-configuration
  *
  * Copyright (c) 2005-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
- *
+ * 
  * This file is part of LMMS - https://lmms.io
  *
  * This program is free software; you can redistribute it and/or

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -239,8 +239,8 @@ public:
 
 	void addRecentlyOpenedProject(const QString & _file);
 
-	const QString & value(const QString & cls,
-					const QString & attribute) const;
+	const QString value(const QString & cls, const QString & attribute) const;
+	
 	const QString & value(const QString & cls,
 					const QString & attribute,
 					const QString & defaultVal) const;

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -72,7 +72,7 @@ public:
 	{
 		return m_controller->currentValue( _offset );
 	}
-	
+
 	ValueBuffer * valueBuffer()
 	{
 		return m_controller->valueBuffer();
@@ -113,7 +113,7 @@ protected:
 	Controller * m_controller;
 	QString m_targetName;
 	int m_controllerId;
-	
+
 	bool m_ownsController;
 
 	static ControllerConnectionVector s_connections;

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -72,7 +72,7 @@ public:
 	{
 		return m_controller->currentValue( _offset );
 	}
-
+	
 	ValueBuffer * valueBuffer()
 	{
 		return m_controller->valueBuffer();
@@ -113,7 +113,7 @@ protected:
 	Controller * m_controller;
 	QString m_targetName;
 	int m_controllerId;
-
+	
 	bool m_ownsController;
 
 	static ControllerConnectionVector s_connections;

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -119,7 +119,7 @@ public:
 	};
 
 
-	struct ChordTable : public QVector<Chord>
+	struct ChordTable
 	{
 	private:
 		ChordTable();
@@ -131,6 +131,7 @@ public:
 		};
 
 		static std::array<Init, NUM_CHORD_TABLES> s_initTable;
+		std::vector<Chord> m_chords;
 
 	public:
 		static const ChordTable & getInstance()
@@ -149,6 +150,11 @@ public:
 		const Chord & getChordByName( const QString & name ) const
 		{
 			return getByName( name, false );
+		}
+
+		const std::vector<Chord>& chords() const
+		{
+			return m_chords;
 		}
 	};
 

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -26,7 +26,7 @@
 #define LMMS_MIDI_CLIENT_H
 
 #include <QStringList>
-#include <QVector>
+#include <vector>
 
 
 #include "MidiEvent.h"
@@ -111,7 +111,7 @@ public:
 	static MidiClient * openMidiClient();
 
 protected:
-	QVector<MidiPort *> m_midiPorts;
+	std::vector<MidiPort *> m_midiPorts;
 
 } ;
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -39,7 +39,7 @@ namespace lmms
 
 
 class MixerRoute;
-using MixerRouteVector = QVector<MixerRoute*>;
+using MixerRouteVector = std::vector<MixerRoute*>;
 
 class MixerChannel : public ThreadableJob
 {
@@ -219,7 +219,7 @@ public:
 
 private:
 	// the mixer channels in the mixer. index 0 is always master.
-	QVector<MixerChannel *> m_mixerChannels;
+	std::vector<MixerChannel*> m_mixerChannels;
 
 	// make sure we have at least num channels
 	void allocateChannelsTo(int num);

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -87,11 +87,11 @@ class MixerChannel : public ThreadableJob
 		QColor m_color;
 		bool m_hasColor;
 
-
+	
 		std::atomic_int m_dependenciesMet;
 		void incrementDeps();
 		void processed();
-
+		
 	private:
 		void doProcessing() override;
 };

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -87,11 +87,11 @@ class MixerChannel : public ThreadableJob
 		QColor m_color;
 		bool m_hasColor;
 
-	
+
 		std::atomic_int m_dependenciesMet;
 		void incrementDeps();
 		void processed();
-		
+
 	private:
 		void doProcessing() override;
 };
@@ -100,9 +100,9 @@ class MixerChannel : public ThreadableJob
 class MixerRoute : public QObject
 {
 	Q_OBJECT
-public:
-	MixerRoute( MixerChannel * from, MixerChannel * to, float amount );
-	~MixerRoute() override = default;
+	public:
+		MixerRoute( MixerChannel * from, MixerChannel * to, float amount );
+		~MixerRoute() override = default;
 
 	mix_ch_t senderIndex() const
 	{

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -100,9 +100,9 @@ class MixerChannel : public ThreadableJob
 class MixerRoute : public QObject
 {
 	Q_OBJECT
-	public:
-		MixerRoute( MixerChannel * from, MixerChannel * to, float amount );
-		~MixerRoute() override = default;
+public:
+	MixerRoute( MixerChannel * from, MixerChannel * to, float amount );
+	~MixerRoute() override = default;
 
 	mix_ch_t senderIndex() const
 	{

--- a/include/Note.h
+++ b/include/Note.h
@@ -27,7 +27,7 @@
 #define LMMS_NOTE_H
 
 #include <optional>
-#include <QVector>
+#include <vector>
 
 #include "volume.h"
 #include "panning.h"
@@ -249,7 +249,7 @@ private:
 	DetuningHelper * m_detuning;
 };
 
-using NoteVector = QVector<Note*>;
+using NoteVector = std::vector<Note*>;
 
 struct NoteBounds
 {

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -36,7 +36,7 @@ namespace lmms
 
 class PeakControllerEffect;
 
-using PeakControllerEffectVector = QVector<PeakControllerEffect*>;
+using PeakControllerEffectVector = std::vector<PeakControllerEffect*>;
 
 class LMMS_EXPORT PeakController : public Controller
 {

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -2,7 +2,7 @@
  * PeakController.h - peak-controller class
  *
  * Copyright (c) 2008-2009 Paul Giblock <drfaygo/at/gmail.com>
- * 
+ *
  * This file is part of LMMS - https://lmms.io
  *
  * This program is free software; you can redistribute it and/or
@@ -77,7 +77,7 @@ private:
 	static int m_getCount;
 	static int m_loadCount;
 	static bool m_buggedFile;
-	
+
 	float m_attackCoeff;
 	float m_decayCoeff;
 	bool m_coeffNeedsUpdate;

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -2,7 +2,7 @@
  * PeakController.h - peak-controller class
  *
  * Copyright (c) 2008-2009 Paul Giblock <drfaygo/at/gmail.com>
- *
+ * 
  * This file is part of LMMS - https://lmms.io
  *
  * This program is free software; you can redistribute it and/or
@@ -77,7 +77,7 @@ private:
 	static int m_getCount;
 	static int m_loadCount;
 	static bool m_buggedFile;
-
+	
 	float m_attackCoeff;
 	float m_decayCoeff;
 	bool m_coeffNeedsUpdate;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -27,8 +27,9 @@
 #ifndef LMMS_GUI_PIANO_ROLL_H
 #define LMMS_GUI_PIANO_ROLL_H
 
-#include <QVector>
 #include <QWidget>
+
+#include <vector>
 
 #include "Editor.h"
 #include "ComboBoxModel.h"
@@ -291,7 +292,7 @@ private:
 
 	PositionLine * m_positionLine;
 
-	QVector<QString> m_nemStr; // gui names of each edit mode
+	std::vector<QString> m_nemStr; // gui names of each edit mode
 	QMenu * m_noteEditMenu; // when you right click below the key area
 
 	QList<int> m_markedSemiTones;
@@ -358,8 +359,8 @@ private:
 	ComboBoxModel m_chordModel;
 	ComboBoxModel m_snapModel;
 
-	static const QVector<float> m_zoomLevels;
-	static const QVector<float> m_zoomYLevels;
+	static const std::vector<float> m_zoomLevels;
+	static const std::vector<float> m_zoomYLevels;
 
 	MidiClip* m_midiClip;
 	NoteVector m_ghostNotes;

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -27,12 +27,12 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <QFileInfo>
 #include <QHash>
 #include <QList>
 #include <QString>
-#include <QVector>
 
 #include "lmms_export.h"
 #include "Plugin.h"
@@ -99,7 +99,7 @@ private:
 	PluginInfoList m_pluginInfos;
 
 	QMap<QString, PluginInfoAndKey> m_pluginByExt;
-	QVector<std::string> m_garbage; //!< cleaned up at destruction
+	std::vector<std::string> m_garbage; //!< cleaned up at destruction
 
 	QHash<QString, QString> m_errors;
 

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -78,8 +78,8 @@ private:
 
 	std::unique_ptr<ProjectRenderer> m_activeRenderer;
 
-	QVector<Track*> m_tracksToRender;
-	QVector<Track*> m_unmuted;
+	std::vector<Track*> m_tracksToRender;
+	std::vector<Track*> m_unmuted;
 } ;
 
 

--- a/include/StepRecorder.h
+++ b/include/StepRecorder.h
@@ -59,7 +59,7 @@ class StepRecorder : public QObject
 	void setCurrentMidiClip(MidiClip* newMidiClip);
 	void setStepsLength(const TimePos& newLength);
 
-	QVector<Note*> getCurStepNotes();
+	std::vector<Note*> getCurStepNotes();
 
 	bool isRecording() const
 	{
@@ -142,7 +142,7 @@ class StepRecorder : public QObject
 		QElapsedTimer releasedTimer;
 	} ;
 
-	QVector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
+	std::vector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
 
 	StepNote* findCurStepNote(const int key);
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -188,7 +188,7 @@ public:
 	{
 		return m_processingLock.tryLock();
 	}
-
+	
 	QColor color()
 	{
 		return m_color;
@@ -202,7 +202,7 @@ public:
 	{
 		return m_mutedBeforeSolo;
 	}
-
+	
 	BoolModel* getMutedModel();
 
 public slots:
@@ -240,7 +240,7 @@ private:
 	clipVector m_clips;
 
 	QMutex m_processingLock;
-
+	
 	QColor m_color;
 	bool m_hasColor;
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -22,10 +22,11 @@
  *
  */
 
-#ifndef LMMS_TRACK_H
-#define LMMS_TRACK_H
+#ifndef TRACK_H
+#define TRACK_H
 
-#include <QVector>
+#include <vector>
+
 #include <QColor>
 
 #include "AutomatableModel.h"
@@ -69,7 +70,7 @@ class LMMS_EXPORT Track : public Model, public JournallingObject
 	mapPropertyFromModel(bool,isMuted,setMuted,m_mutedModel);
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
-	using clipVector = QVector<Clip*>;
+	using clipVector = std::vector<Clip*>;
 
 	enum TrackTypes
 	{

--- a/include/Track.h
+++ b/include/Track.h
@@ -22,8 +22,8 @@
  *
  */
 
-#ifndef TRACK_H
-#define TRACK_H
+#ifndef LMMS_TRACK_H
+#define LMMS_TRACK_H
 
 #include <vector>
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -188,7 +188,7 @@ public:
 	{
 		return m_processingLock.tryLock();
 	}
-	
+
 	QColor color()
 	{
 		return m_color;
@@ -202,7 +202,7 @@ public:
 	{
 		return m_mutedBeforeSolo;
 	}
-	
+
 	BoolModel* getMutedModel();
 
 public slots:
@@ -240,7 +240,7 @@ private:
 	clipVector m_clips;
 
 	QMutex m_processingLock;
-	
+
 	QColor m_color;
 	bool m_hasColor;
 

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -49,7 +49,7 @@ class LMMS_EXPORT TrackContainer : public Model, public JournallingObject
 {
 	Q_OBJECT
 public:
-	using TrackList = QVector<Track*>;
+	using TrackList = std::vector<Track*>;
 	enum TrackContainerTypes
 	{
 		PatternContainer,

--- a/include/panning.h
+++ b/include/panning.h
@@ -31,6 +31,8 @@
 #include "Midi.h"
 #include "volume.h"
 
+#include <cmath>
+
 namespace lmms
 {
 
@@ -40,7 +42,7 @@ inline StereoVolumeVector panningToVolumeVector( panning_t _p,
 {
 	StereoVolumeVector v = { { _scale, _scale } };
 	const float pf = _p / 100.0f;
-	v.vol[_p >= PanningCenter ? 0 : 1] *= 1.0f - qAbs<float>( pf );
+	v.vol[_p >= PanningCenter ? 0 : 1] *= 1.0f - std::abs(pf);
 	return v;
 }
 

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -76,7 +76,7 @@ PeakControllerEffect::PeakControllerEffect(
 	{
 		Engine::getSong()->addController( m_autoController );
 	}
-	PeakController::s_effects.append( this );
+	PeakController::s_effects.push_back(this);
 }
 
 
@@ -84,11 +84,11 @@ PeakControllerEffect::PeakControllerEffect(
 
 PeakControllerEffect::~PeakControllerEffect()
 {
-	int idx = PeakController::s_effects.indexOf( this );
-	if( idx >= 0 )
+	auto it = std::find(PeakController::s_effects.begin(), PeakController::s_effects.end(), this);
+	if (it != PeakController::s_effects.end())
 	{
-		PeakController::s_effects.remove( idx );
-		Engine::getSong()->removeController( m_autoController );
+		PeakController::s_effects.erase(it);
+		Engine::getSong()->removeController(m_autoController);
 	}
 }
 

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -99,7 +99,7 @@ bool PeakControllerEffect::processAudioBuffer( sampleFrame * _buf,
 	PeakControllerEffectControls & c = m_peakControls;
 
 	// This appears to be used for determining whether or not to continue processing
-	// audio with this effect	
+	// audio with this effect
 	if( !isEnabled() || !isRunning() )
 	{
 		return false;

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -99,7 +99,7 @@ bool PeakControllerEffect::processAudioBuffer( sampleFrame * _buf,
 	PeakControllerEffectControls & c = m_peakControls;
 
 	// This appears to be used for determining whether or not to continue processing
-	// audio with this effect
+	// audio with this effect	
 	if( !isEnabled() || !isRunning() )
 	{
 		return false;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -112,7 +112,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	// size from user configuration
 	if( renderOnly == false )
 	{
-		m_framesPerPeriod = 
+		m_framesPerPeriod =
 			( fpp_t ) ConfigManager::inst()->value( "audioengine", "framesperaudiobuffer" ).toInt();
 
 		// if the value read from user configuration is not set or

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -419,7 +419,7 @@ const surroundSampleFrame * AudioEngine::renderNextBuffer()
 	}
 
 	// STAGE 2: process effects of all instrument- and sampletracks
-	AudioEngineWorkerThread::fillJobQueue<std::vector<AudioPort*>>(m_audioPorts);
+	AudioEngineWorkerThread::fillJobQueue(m_audioPorts);
 	AudioEngineWorkerThread::startAndWaitForJobs();
 
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -112,7 +112,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	// size from user configuration
 	if( renderOnly == false )
 	{
-		m_framesPerPeriod =
+		m_framesPerPeriod = 
 			( fpp_t ) ConfigManager::inst()->value( "audioengine", "framesperaudiobuffer" ).toInt();
 
 		// if the value read from user configuration is not set or

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -473,7 +473,7 @@ float AutomatableModel::fittedValue( float value ) const
 
 void AutomatableModel::linkModel( AutomatableModel* model )
 {
-	bool containsModel = std::find(m_linkedModels.begin(), m_linkedModels.end(), model) != m_linkedModels.end();
+	auto containsModel = std::find(m_linkedModels.begin(), m_linkedModels.end(), model) != m_linkedModels.end();
 	if (!containsModel && model != this)
 	{
 		m_linkedModels.push_back( model );
@@ -505,8 +505,8 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 
 void AutomatableModel::linkModels( AutomatableModel* model1, AutomatableModel* model2 )
 {
-	bool containsModel2 = std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) != model1->m_linkedModels.end();
-	if (!containsModel2 && model1 != model2)
+	auto model1ContainsModel2 = std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) != model1->m_linkedModels.end();
+	if (!model1ContainsModel2 && model1 != model2)
 	{
 		// copy data
 		model1->m_value = model2->m_value;
@@ -723,7 +723,7 @@ void AutomatableModel::reset()
 float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 {
 	// get clips that connect to this model
-	auto clips = AutomationClip::clipsForModel( this );
+	auto clips = AutomationClip::clipsForModel(this);
 	if (clips.empty())
 	{
 		// if no such clips exist, return current value
@@ -734,12 +734,11 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 		// of those clips:
 		// find the clips which overlap with the time position
 		std::vector<AutomationClip*> clipsInRange;
-
-		for (const auto clip : clipsInRange)
+		for (const auto& clip : clips)
 		{
-			int start = clip->startPosition();
-			int end = clip->endPosition();
-			if (start <= time && end >= time) { clipsInRange.push_back(clip); }
+			int s = clip->startPosition();
+			int e = clip->endPosition();
+			if (s <= time && e >= time) { clipsInRange.push_back(clip); }
 		}
 
 		AutomationClip * latestClip = nullptr;
@@ -754,18 +753,19 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 		// if we find no clips at the exact time, we need to search for the last clip before time and use that
 		{
 			int latestPosition = 0;
-			for (const auto clip : clips)
+
+			for (const auto& clip : clips)
 			{
-				int end = clip->endPosition();
-				if (end <= time && end > latestPosition)
+				int e = clip->endPosition();
+				if (e <= time && e > latestPosition)
 				{
-					latestPosition = end;
+					latestPosition = e;
 					latestClip = clip;
 				}
 			}
 		}
 
-		if (latestClip)
+		if( latestClip )
 		{
 			// scale/fit the value appropriately and return it
 			const float value = latestClip->valueAt( time - latestClip->startPosition() );

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -71,7 +71,7 @@ AutomatableModel::~AutomatableModel()
 {
 	while( m_linkedModels.empty() == false )
 	{
-		m_linkedModels.last()->unlinkModel( this );
+		m_linkedModels.back()->unlinkModel(this);
 		m_linkedModels.erase( m_linkedModels.end() - 1 );
 	}
 
@@ -473,7 +473,8 @@ float AutomatableModel::fittedValue( float value ) const
 
 void AutomatableModel::linkModel( AutomatableModel* model )
 {
-	if( !m_linkedModels.contains( model ) && model != this )
+	bool containsModel = std::find(m_linkedModels.begin(), m_linkedModels.end(), model) != m_linkedModels.end();
+	if (!containsModel && model != this)
 	{
 		m_linkedModels.push_back( model );
 
@@ -490,7 +491,7 @@ void AutomatableModel::linkModel( AutomatableModel* model )
 
 void AutomatableModel::unlinkModel( AutomatableModel* model )
 {
-	AutoModelVector::Iterator it = std::find( m_linkedModels.begin(), m_linkedModels.end(), model );
+	auto it = std::find(m_linkedModels.begin(), m_linkedModels.end(), model);
 	if( it != m_linkedModels.end() )
 	{
 		m_linkedModels.erase( it );
@@ -504,7 +505,8 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 
 void AutomatableModel::linkModels( AutomatableModel* model1, AutomatableModel* model2 )
 {
-	if (!model1->m_linkedModels.contains( model2 ) && model1 != model2)
+	bool containsModel2 = std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) != model1->m_linkedModels.end();
+	if (!containsModel2 && model1 != model2)
 	{
 		// copy data
 		model1->m_value = model2->m_value;
@@ -588,7 +590,7 @@ float AutomatableModel::controllerValue( int frameOffset ) const
 		return v;
 	}
 
-	AutomatableModel* lm = m_linkedModels.first();
+	AutomatableModel* lm = m_linkedModels.front();
 	if (lm->controllerConnection() && lm->useControllerValue())
 	{
 		return fittedValue( lm->controllerValue( frameOffset ) );
@@ -649,7 +651,7 @@ ValueBuffer * AutomatableModel::valueBuffer()
 		AutomatableModel* lm = nullptr;
 		if (hasLinkedModels())
 		{
-			lm = m_linkedModels.first();
+			lm = m_linkedModels.front();
 		}
 		if (lm && lm->controllerConnection() && lm->useControllerValue() &&
 				lm->controllerConnection()->getController()->isSampleExact())

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -888,12 +888,8 @@ gui::ClipView * AutomationClip::createView( gui::TrackView * _tv )
 
 bool AutomationClip::isAutomated( const AutomatableModel * _m )
 {
-	TrackContainer::TrackList l;
-
-	auto& songTracks = Engine::getSong()->tracks();
-	l.insert(l.end(), songTracks.begin(), songTracks.end());
-
-	for (const auto& track : l)
+	auto l = combineAllTracks();
+	for (const auto track : l)
 	{
 		if (track->type() == Track::AutomationTrack || track->type() == Track::HiddenAutomationTrack)
 		{
@@ -924,15 +920,7 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
 std::vector<AutomationClip *> AutomationClip::clipsForModel(const AutomatableModel* _m)
 {
 	std::vector<AutomationClip *> clips;
-	TrackContainer::TrackList l;
-
-	auto& songTracks = Engine::getSong()->tracks();
-	l.insert(l.end(), songTracks.begin(), songTracks.end());
-
-	auto& patternStoreTracks = Engine::patternStore()->tracks();
-	l.insert(l.end(), patternStoreTracks.begin(), patternStoreTracks.end());
-
-	l.push_back(Engine::getSong()->globalAutomationTrack());
+	auto l = combineAllTracks();
 
 	// go through all tracks...
 	for (const auto track : l)
@@ -994,15 +982,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 
 void AutomationClip::resolveAllIDs()
 {
-	TrackContainer::TrackList l;
-
-	auto& tracks = Engine::getSong()->tracks();
-	l.insert(l.end(), tracks.begin(), tracks.end());
-
-	auto& patternStoreTracks = Engine::patternStore()->tracks();
-	l.insert(l.end(), patternStoreTracks.begin(), patternStoreTracks.end());
-
-	l.push_back(Engine::getSong()->globalAutomationTrack());
+	auto l = combineAllTracks();
 	for (const auto& track : l)
 	{
 		if (track->type() == Track::AutomationTrack || track->type() == Track::HiddenAutomationTrack)
@@ -1181,6 +1161,20 @@ void AutomationClip::generateTangents(timeMap::iterator it, int numToGenerate)
 		}
 		it++;
 	}
+}
+
+std::vector<Track*> AutomationClip::combineAllTracks()
+{
+	std::vector<Track*> combinedTrackList;
+
+	auto& songTracks = Engine::getSong()->tracks();
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+
+	combinedTrackList.insert(combinedTrackList.end(), songTracks.begin(), songTracks.end());
+	combinedTrackList.insert(combinedTrackList.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+	combinedTrackList.push_back(Engine::getSong()->globalAutomationTrack());
+
+	return combinedTrackList;
 }
 
 } // namespace lmms

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -770,7 +770,7 @@ void AutomationClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	_this.setAttribute( "prog", QString::number( progressionType() ) );
 	_this.setAttribute( "tens", QString::number( getTension() ) );
 	_this.setAttribute( "mute", QString::number( isMuted() ) );
-
+	
 	if( usesCustomClipColor() )
 	{
 		_this.setAttribute( "color", color().name() );
@@ -831,10 +831,10 @@ void AutomationClip::loadSettings( const QDomElement & _this )
 		}
 		else if( element.tagName() == "object" )
 		{
-			m_idsToResolve.push_back(element.attribute( "id" ).toInt());
+			m_idsToResolve.push_back(element.attribute("id").toInt());
 		}
 	}
-
+	
 	if( _this.hasAttribute( "color" ) )
 	{
 		useCustomClipColor( true );
@@ -1055,11 +1055,11 @@ void AutomationClip::objectDestroyed( jo_id_t _id )
 
 	for (auto objIt = m_objects.begin(); objIt != m_objects.end(); objIt++)
 	{
-		Q_ASSERT(!(*objIt).isNull());
-		if((*objIt)->id() == _id)
+		Q_ASSERT( !(*objIt).isNull() );
+		if( (*objIt)->id() == _id )
 		{
 			//Assign to objIt so that this loop work even break; is removed.
-			objIt = m_objects.erase(objIt);
+			objIt = m_objects.erase( objIt );
 			break;
 		}
 	}

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -997,8 +997,10 @@ void AutomationClip::resolveAllIDs()
 	TrackContainer::TrackList l;
 
 	auto& tracks = Engine::getSong()->tracks();
+	l.insert(l.end(), tracks.begin(), tracks.end());
+
 	auto& patternStoreTracks = Engine::patternStore()->tracks();
-	l.insert(tracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+	l.insert(l.end(), patternStoreTracks.begin(), patternStoreTracks.end());
 
 	l.push_back(Engine::getSong()->globalAutomationTrack());
 	for (const auto& track : l)

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -334,10 +334,10 @@ void ConfigManager::addRecentlyOpenedProject(const QString & file)
 
 
 
-const QString ConfigManager::value(const QString & cls,
-					const QString & attribute) const
+QString ConfigManager::value(const QString& cls, const QString& attribute, const QString& defaultVal) const
 {
-	if (m_settings.contains(cls))
+	std::optional<QString> val;
+	if (m_settings.find(cls) != m_settings.end())
 	{
 		for (const auto& setting : m_settings[cls])
 		{
@@ -347,16 +347,8 @@ const QString ConfigManager::value(const QString & cls,
 			}
 		}
 	}
-	return "";
-}
 
-
-const QString & ConfigManager::value(const QString & cls,
-				      const QString & attribute,
-				      const QString & defaultVal) const
-{
-	const QString & val = value(cls, attribute);
-	return val.isEmpty() ? defaultVal : val;
+	return val.value_or(defaultVal);
 }
 
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -346,7 +346,6 @@ QString ConfigManager::value(const QString& cls, const QString& attribute, const
 			}
 		}
 	}
-	
 	return defaultVal;
 }
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -169,9 +169,9 @@ void ConfigManager::upgrade()
 			(this->*um)();
 		}
 	);
-	
+
 	ProjectVersion createdWith = m_version;
-	
+
 	// Don't use old themes as they break the UI (i.e. 0.4 != 1.0, etc)
 	if (createdWith.setCompareType(ProjectVersion::Minor) != LMMS_VERSION)
 	{
@@ -334,10 +334,10 @@ void ConfigManager::addRecentlyOpenedProject(const QString & file)
 
 
 
-const QString & ConfigManager::value(const QString & cls,
+const QString ConfigManager::value(const QString & cls,
 					const QString & attribute) const
 {
-	if(m_settings.contains(cls))
+	if (m_settings.contains(cls))
 	{
 		for (const auto& setting : m_settings[cls])
 		{
@@ -347,10 +347,8 @@ const QString & ConfigManager::value(const QString & cls,
 			}
 		}
 	}
-	static QString empty;
-	return empty;
+	return "";
 }
-
 
 
 const QString & ConfigManager::value(const QString & cls,

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -169,9 +169,9 @@ void ConfigManager::upgrade()
 			(this->*um)();
 		}
 	);
-
+	
 	ProjectVersion createdWith = m_version;
-
+	
 	// Don't use old themes as they break the UI (i.e. 0.4 != 1.0, etc)
 	if (createdWith.setCompareType(ProjectVersion::Minor) != LMMS_VERSION)
 	{

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -336,7 +336,6 @@ void ConfigManager::addRecentlyOpenedProject(const QString & file)
 
 QString ConfigManager::value(const QString& cls, const QString& attribute, const QString& defaultVal) const
 {
-	std::optional<QString> val;
 	if (m_settings.find(cls) != m_settings.end())
 	{
 		for (const auto& setting : m_settings[cls])
@@ -347,8 +346,8 @@ QString ConfigManager::value(const QString& cls, const QString& attribute, const
 			}
 		}
 	}
-
-	return val.value_or(defaultVal);
+	
+	return defaultVal;
 }
 
 

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -87,7 +87,7 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 Controller::~Controller()
 {
 	auto it = std::find(s_controllers.begin(), s_controllers.end(), this);
-	if (it != s_controllers.end()) 
+	if (it != s_controllers.end())
 	{
 		s_controllers.erase(it);
 	}
@@ -105,7 +105,7 @@ float Controller::currentValue( int _offset )
 	{
 		m_currentValue = fittedValue( value( _offset ) );
 	}
-	
+
 	return m_currentValue;
 }
 
@@ -119,7 +119,7 @@ float Controller::value( int offset )
 	}
 	return m_valueBuffer.values()[ offset ];
 }
-	
+
 
 ValueBuffer * Controller::valueBuffer()
 {
@@ -209,7 +209,7 @@ Controller * Controller::create( ControllerTypes _ct, Model * _parent )
 			c = new class MidiController( _parent );
 			break;
 
-		default: 
+		default:
 			break;
 	}
 

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -105,7 +105,7 @@ float Controller::currentValue( int _offset )
 	{
 		m_currentValue = fittedValue( value( _offset ) );
 	}
-
+	
 	return m_currentValue;
 }
 
@@ -119,7 +119,7 @@ float Controller::value( int offset )
 	}
 	return m_valueBuffer.values()[ offset ];
 }
-
+	
 
 ValueBuffer * Controller::valueBuffer()
 {
@@ -209,7 +209,7 @@ Controller * Controller::create( ControllerTypes _ct, Model * _parent )
 			c = new class MidiController( _parent );
 			break;
 
-		default:
+		default: 
 			break;
 	}
 

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -189,14 +189,10 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 		}
 		else
 		{
-			auto& controllers = Engine::getSong()->controllers();
-			auto it = std::find(controllers.begin(), controllers.end(), m_controller);
-			int id = std::distance(controllers.begin(), it);
-
-			if (id >= 0)
-			{
-				_this.setAttribute( "id", id );
-			}
+			const auto& controllers = Engine::getSong()->controllers();
+			const auto it = std::find(controllers.begin(), controllers.end(), m_controller);
+			const int id = it != controllers.end() ? std::distance(controllers.begin(), it) : -1;
+			_this.setAttribute("id", id);
 		}
 	}
 }

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -53,7 +53,7 @@ ControllerConnection::ControllerConnection(Controller * _controller) :
 		m_controller = Controller::create( Controller::DummyController,
 									nullptr );
 	}
-	s_connections.append( this );
+	s_connections.push_back(this);
 }
 
 
@@ -64,7 +64,7 @@ ControllerConnection::ControllerConnection( int _controllerId ) :
 	m_controllerId( _controllerId ),
 	m_ownsController( false )
 {
-	s_connections.append( this );
+	s_connections.push_back(this);
 }
 
 
@@ -76,7 +76,10 @@ ControllerConnection::~ControllerConnection()
 	{
 		m_controller->removeConnection( this );
 	}
-	s_connections.remove( s_connections.indexOf( this ) );
+
+	auto it = std::find(s_connections.begin(), s_connections.end(), this);
+	if (it != s_connections.end()) { s_connections.erase(it); };
+
 	if( m_ownsController )
 	{
 		delete m_controller;

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -191,8 +191,11 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 		{
 			const auto& controllers = Engine::getSong()->controllers();
 			const auto it = std::find(controllers.begin(), controllers.end(), m_controller);
-			const int id = it != controllers.end() ? std::distance(controllers.begin(), it) : -1;
-			_this.setAttribute("id", id);
+			if (it != controllers.end())
+			{
+						const int id = std::distance(controllers.begin(), it);
+						_this.setAttribute("id", id);
+			}
 		}
 	}
 }

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -193,8 +193,8 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 			const auto it = std::find(controllers.begin(), controllers.end(), m_controller);
 			if (it != controllers.end())
 			{
-						const int id = std::distance(controllers.begin(), it);
-						_this.setAttribute("id", id);
+				const int id = std::distance(controllers.begin(), it);
+				_this.setAttribute("id", id);
 			}
 		}
 	}

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -56,7 +56,7 @@ EffectChain::~EffectChain()
 void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	m_enabledModel.saveSettings( _doc, _this, "enabled" );
-	_this.setAttribute( "numofeffects", m_effects.count() );
+	_this.setAttribute("numofeffects", static_cast<int>(m_effects.size()));
 
 	for( Effect* effect : m_effects)
 	{
@@ -121,7 +121,7 @@ void EffectChain::loadSettings( const QDomElement & _this )
 void EffectChain::appendEffect( Effect * _effect )
 {
 	Engine::audioEngine()->requestChangeInModel();
-	m_effects.append( _effect );
+	m_effects.push_back(_effect);
 	Engine::audioEngine()->doneChangeInModel();
 
 	m_enabledModel.setValue( true );
@@ -136,7 +136,7 @@ void EffectChain::removeEffect( Effect * _effect )
 {
 	Engine::audioEngine()->requestChangeInModel();
 
-	Effect ** found = std::find( m_effects.begin(), m_effects.end(), _effect );
+	auto found = std::find(m_effects.begin(), m_effects.end(), _effect);
 	if( found == m_effects.end() )
 	{
 		Engine::audioEngine()->doneChangeInModel();
@@ -146,7 +146,7 @@ void EffectChain::removeEffect( Effect * _effect )
 
 	Engine::audioEngine()->doneChangeInModel();
 
-	if( m_effects.isEmpty() )
+	if (m_effects.empty())
 	{
 		m_enabledModel.setValue( false );
 	}
@@ -159,10 +159,10 @@ void EffectChain::removeEffect( Effect * _effect )
 
 void EffectChain::moveDown( Effect * _effect )
 {
-	if( _effect != m_effects.last() )
+	if (_effect != m_effects.back())
 	{
-		int i = m_effects.indexOf(_effect);
-		std::swap(m_effects[i + 1], m_effects[i]);
+		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
+		std::swap(*(it++), *it);
 	}
 }
 
@@ -171,10 +171,10 @@ void EffectChain::moveDown( Effect * _effect )
 
 void EffectChain::moveUp( Effect * _effect )
 {
-	if( _effect != m_effects.first() )
+	if (_effect != m_effects.front())
 	{
-		int i = m_effects.indexOf(_effect);
-		std::swap(m_effects[i - 1], m_effects[i]);
+		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
+		std::swap(*(it--), *it);
 	}
 }
 
@@ -228,9 +228,9 @@ void EffectChain::clear()
 
 	Engine::audioEngine()->requestChangeInModel();
 
-	while( m_effects.count() )
+	while (m_effects.size())
 	{
-		Effect * e = m_effects[m_effects.count() - 1];
+		Effect * e = m_effects[m_effects.size() - 1];
 		m_effects.pop_back();
 		delete e;
 	}

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -162,7 +162,7 @@ void EffectChain::moveDown( Effect * _effect )
 	if (_effect != m_effects.back())
 	{
 		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
-		std::swap(*(it++), *it);
+		std::swap(*std::next(it), *it);
 	}
 }
 
@@ -174,7 +174,7 @@ void EffectChain::moveUp( Effect * _effect )
 	if (_effect != m_effects.front())
 	{
 		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
-		std::swap(*(it--), *it);
+		std::swap(*std::prev(it), *it);
 	}
 }
 

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -230,7 +230,7 @@ void EffectChain::clear()
 
 	while (m_effects.size())
 	{
-		Effect * e = m_effects[m_effects.size() - 1];
+		auto e = m_effects[m_effects.size() - 1];
 		m_effects.pop_back();
 		delete e;
 	}

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -190,7 +190,7 @@ InstrumentFunctionNoteStacking::ChordTable::ChordTable()
 
 const InstrumentFunctionNoteStacking::Chord & InstrumentFunctionNoteStacking::ChordTable::getByName( const QString & name, bool is_scale ) const
 {
-	for (const auto chord : m_chords)
+	for (const auto& chord : m_chords)
 	{
 		if (chord.getName() == name && is_scale == chord.isScale())
 		{

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -177,12 +177,11 @@ bool InstrumentFunctionNoteStacking::Chord::hasSemiTone( int8_t semi_tone ) cons
 
 
 
-InstrumentFunctionNoteStacking::ChordTable::ChordTable() :
-	QVector<Chord>()
+InstrumentFunctionNoteStacking::ChordTable::ChordTable()
 {
 	for (const auto& chord : s_initTable)
 	{
-		push_back(Chord(chord.m_name, chord.m_semiTones));
+		m_chords.emplace_back(chord.m_name, chord.m_semiTones);
 	}
 }
 
@@ -191,10 +190,12 @@ InstrumentFunctionNoteStacking::ChordTable::ChordTable() :
 
 const InstrumentFunctionNoteStacking::Chord & InstrumentFunctionNoteStacking::ChordTable::getByName( const QString & name, bool is_scale ) const
 {
-	for( int i = 0; i < size(); i++ )
+	for (const auto chord : m_chords)
 	{
-		if( at( i ).getName() == name && is_scale == at( i ).isScale() )
-			return at( i );
+		if (chord.getName() == name && is_scale == chord.isScale())
+		{
+			return chord;
+		}
 	}
 
 	static Chord empty;
@@ -211,9 +212,10 @@ InstrumentFunctionNoteStacking::InstrumentFunctionNoteStacking( Model * _parent 
 	m_chordRangeModel( 1.0f, 1.0f, 9.0f, 1.0f, this, tr( "Chord range" ) )
 {
 	const ChordTable & chord_table = ChordTable::getInstance();
-	for( int i = 0; i < chord_table.size(); ++i )
+
+	for (const auto& chord : chord_table.chords())
 	{
-		m_chordsModel.addItem( chord_table[i].getName() );
+		m_chordsModel.addItem(chord.getName());
 	}
 }
 
@@ -244,10 +246,10 @@ void InstrumentFunctionNoteStacking::processNote( NotePlayHandle * _n )
 			const int sub_note_key_base = base_note_key + octave_cnt * KeysPerOctave;
 
 			// process all notes in the chord
-			for( int i = 0; i < chord_table[selected_chord].size(); ++i )
+			for( int i = 0; i < chord_table.chords()[selected_chord].size(); ++i )
 			{
 				// add interval to sub-note-key
-				const int sub_note_key = sub_note_key_base + (int) chord_table[selected_chord][i];
+				const int sub_note_key = sub_note_key_base + (int) chord_table.chords()[selected_chord][i];
 				// maybe we're out of range -> let's get outta
 				// here!
 				if( sub_note_key > NumKeys )
@@ -309,9 +311,9 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	m_arpModeModel( this, tr( "Arpeggio mode" ) )
 {
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
-	for( int i = 0; i < chord_table.size(); ++i )
+	for (auto& chord : chord_table.chords())
 	{
-		m_arpModel.addItem( chord_table[i].getName() );
+		m_arpModel.addItem(chord.getName());
 	}
 
 	m_arpDirectionModel.addItem( tr( "Up" ), std::make_unique<PixmapLoader>( "arp_up" ) );
@@ -362,7 +364,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	}
 
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
-	const int cur_chord_size = chord_table[selected_arp].size();
+	const int cur_chord_size = chord_table.chords()[selected_arp].size();
 	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * m_arpRepeatsModel.value());
 	const int total_range = range * cnphv.size();
 
@@ -485,7 +487,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		// now calculate final key for our arp-note
 		const int sub_note_key = base_note_key + (cur_arp_idx / cur_chord_size ) *
-							KeysPerOctave + chord_table[selected_arp][cur_arp_idx % cur_chord_size];
+							KeysPerOctave + chord_table.chords()[selected_arp][cur_arp_idx % cur_chord_size];
 
 		// range-checking
 		if( sub_note_key >= NumKeys ||

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -848,15 +848,18 @@ void Mixer::validateChannelName( int index, int oldIndex )
 bool Mixer::isChannelInUse(int index)
 {
 	// check if the index mixer channel receives audio from any other channel
-	if (!m_mixerChannels[index]->m_receives.isEmpty())
+	if (!m_mixerChannels[index]->m_receives.empty())
 	{
 		return true;
 	}
 
 	// check if the destination mixer channel on any instrument or sample track is the index mixer channel
 	TrackContainer::TrackList tracks;
-	tracks += Engine::getSong()->tracks();
-	tracks += Engine::patternStore()->tracks();
+
+	auto& songTracks = Engine::getSong()->tracks();
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+	tracks.insert(tracks.end(), songTracks.begin(), songTracks.end());
+	tracks.insert(patternStoreTracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
 
 	for (const auto t : tracks)
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -297,7 +297,7 @@ void Mixer::deleteChannel( int index )
 	auto& songTracks = Engine::getSong()->tracks();
 	auto& patternStoreTracks = Engine::patternStore()->tracks();
 	tracks.insert(tracks.end(), songTracks.begin(), songTracks.end());
-	tracks.insert(patternStoreTracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+	tracks.insert(tracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
 
 	for( Track* t : tracks )
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -859,7 +859,7 @@ bool Mixer::isChannelInUse(int index)
 	auto& songTracks = Engine::getSong()->tracks();
 	auto& patternStoreTracks = Engine::patternStore()->tracks();
 	tracks.insert(tracks.end(), songTracks.begin(), songTracks.end());
-	tracks.insert(patternStoreTracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+	tracks.insert(tracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
 
 	for (const auto t : tracks)
 	{

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -201,9 +201,9 @@ Mixer::Mixer() :
 
 Mixer::~Mixer()
 {
-	while( ! m_mixerRoutes.isEmpty() )
+	while (!m_mixerRoutes.empty())
 	{
-		deleteChannelSend( m_mixerRoutes.first() );
+		deleteChannelSend(m_mixerRoutes.front());
 	}
 	while( m_mixerChannels.size() )
 	{
@@ -293,8 +293,11 @@ void Mixer::deleteChannel( int index )
 
 	// go through every instrument and adjust for the channel index change
 	TrackContainer::TrackList tracks;
-	tracks += Engine::getSong()->tracks();
-	tracks += Engine::patternStore()->tracks();
+
+	auto& songTracks = Engine::getSong()->tracks();
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+	tracks.insert(tracks.end(), songTracks.begin(), songTracks.end());
+	tracks.insert(patternStoreTracks.end(), patternStoreTracks.begin(), patternStoreTracks.end());
 
 	for( Track* t : tracks )
 	{
@@ -335,13 +338,13 @@ void Mixer::deleteChannel( int index )
 	MixerChannel * ch = m_mixerChannels[index];
 
 	// delete all of this channel's sends and receives
-	while( ! ch->m_sends.isEmpty() )
+	while (!ch->m_sends.empty())
 	{
-		deleteChannelSend( ch->m_sends.first() );
+		deleteChannelSend( ch->m_sends.front() );
 	}
-	while( ! ch->m_receives.isEmpty() )
+	while (!ch->m_receives.empty())
 	{
-		deleteChannelSend( ch->m_receives.first() );
+		deleteChannelSend( ch->m_receives.front() );
 	}
 
 	// if m_lastSoloed was our index, reset it
@@ -350,7 +353,7 @@ void Mixer::deleteChannel( int index )
 	else if (m_lastSoloed > index) { --m_lastSoloed; }
 
 	// actually delete the channel
-	m_mixerChannels.remove(index);
+	m_mixerChannels.erase(m_mixerChannels.begin() + index);
 	delete ch;
 
 	for( int i = index; i < m_mixerChannels.size(); ++i )
@@ -477,13 +480,13 @@ MixerRoute * Mixer::createRoute( MixerChannel * from, MixerChannel * to, float a
 	auto route = new MixerRoute(from, to, amount);
 
 	// add us to from's sends
-	from->m_sends.append( route );
+	from->m_sends.push_back(route);
 
 	// add us to to's receives
-	to->m_receives.append( route );
+	to->m_receives.push_back(route);
 
 	// add us to mixer's list
-	Engine::mixer()->m_mixerRoutes.append( route );
+	Engine::mixer()->m_mixerRoutes.push_back(route);
 	Engine::audioEngine()->doneChangeInModel();
 
 	return route;
@@ -512,12 +515,22 @@ void Mixer::deleteChannelSend( mix_ch_t fromChannel, mix_ch_t toChannel )
 void Mixer::deleteChannelSend( MixerRoute * route )
 {
 	Engine::audioEngine()->requestChangeInModel();
+
+	auto removeFromMixerRoute = [route](MixerRouteVector& routeVec) 
+	{
+		auto it = std::find(routeVec.begin(), routeVec.end(), route);
+		if (it != routeVec.end()) { routeVec.erase(it); }
+	};
+
 	// remove us from from's sends
-	route->sender()->m_sends.remove( route->sender()->m_sends.indexOf( route ) );
+	removeFromMixerRoute(route->sender()->m_sends);
+
 	// remove us from to's receives
-	route->receiver()->m_receives.remove( route->receiver()->m_receives.indexOf( route ) );
+	removeFromMixerRoute(route->receiver()->m_receives);
+
 	// remove us from mixer's list
-	Engine::mixer()->m_mixerRoutes.remove( Engine::mixer()->m_mixerRoutes.indexOf( route ) );
+	removeFromMixerRoute(Engine::mixer()->m_mixerRoutes);
+
 	delete route;
 	Engine::audioEngine()->doneChangeInModel();
 }
@@ -714,9 +727,9 @@ void Mixer::clearChannel(mix_ch_t index)
 	if( index > 0)
 	{
 		// delete existing sends
-		while( ! ch->m_sends.isEmpty() )
+		while (!ch->m_sends.empty())
 		{
-			deleteChannelSend( ch->m_sends.first() );
+			deleteChannelSend(ch->m_sends.front());
 		}
 
 		// add send to master
@@ -724,9 +737,9 @@ void Mixer::clearChannel(mix_ch_t index)
 	}
 
 	// delete receives
-	while( ! ch->m_receives.isEmpty() )
+	while (!ch->m_receives.empty())
 	{
-		deleteChannelSend( ch->m_receives.first() );
+		deleteChannelSend(ch->m_receives.front());
 	}
 }
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -340,11 +340,11 @@ void Mixer::deleteChannel( int index )
 	// delete all of this channel's sends and receives
 	while (!ch->m_sends.empty())
 	{
-		deleteChannelSend( ch->m_sends.front() );
+		deleteChannelSend(ch->m_sends.front());
 	}
 	while (!ch->m_receives.empty())
 	{
-		deleteChannelSend( ch->m_receives.front() );
+		deleteChannelSend(ch->m_receives.front());
 	}
 
 	// if m_lastSoloed was our index, reset it

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -516,7 +516,7 @@ void Mixer::deleteChannelSend( MixerRoute * route )
 {
 	Engine::audioEngine()->requestChangeInModel();
 
-	auto removeFromMixerRoute = [route](MixerRouteVector& routeVec) 
+	auto removeFromMixerRoute = [route](MixerRouteVector& routeVec)
 	{
 		auto it = std::find(routeVec.begin(), routeVec.end(), route);
 		if (it != routeVec.end()) { routeVec.erase(it); }

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -161,12 +161,11 @@ void PeakController::loadSettings( const QDomElement & _this )
 		effectId = m_loadCount++;
 	}
 
-	PeakControllerEffectVector::Iterator i;
-	for( i = s_effects.begin(); i != s_effects.end(); ++i )
+	for (const auto& effect : s_effects) 
 	{
-		if( (*i)->m_effectId == effectId )
+		if (effect->m_effectId == effectId) 
 		{
-			m_peakEffect = *i;
+			m_peakEffect = effect;
 			return;
 		}
 	}
@@ -190,16 +189,14 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 {
 	int effectId = _this.attribute( "effectId" ).toInt();
 
-	PeakControllerEffectVector::Iterator i;
-
 	//Backward compatibility for bug in <= 0.4.15 . For >= 1.0.0 ,
 	//foundCount should always be 1 because m_effectId is initialized with rand()
 	int foundCount = 0;
 	if( m_buggedFile == false )
 	{
-		for( i = s_effects.begin(); i != s_effects.end(); ++i )
+		for (const auto& effect : s_effects) 
 		{
-			if( (*i)->m_effectId == effectId )
+			if (effect->m_effectId == effectId )
 			{
 				foundCount++;
 			}
@@ -208,9 +205,9 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 		{
 			m_buggedFile = true;
 			int newEffectId = 0;
-			for( i = s_effects.begin(); i != s_effects.end(); ++i )
+			for (const auto& effect : s_effects)
 			{
-				(*i)->m_effectId = newEffectId++;
+				effect->m_effectId = newEffectId++;
 			}
 			QMessageBox msgBox;
 			msgBox.setIcon( QMessageBox::Information );
@@ -231,11 +228,11 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 	}
 	m_getCount++; //NB: m_getCount should be increased even m_buggedFile is false
 
-	for( i = s_effects.begin(); i != s_effects.end(); ++i )
+	for (const auto& effect : s_effects)
 	{
-		if( (*i)->m_effectId == effectId )
+		if (effect->m_effectId == effectId)
 		{
-			return (*i)->controller();
+			return effect->controller();
 		}
 	}
 

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -161,9 +161,9 @@ void PeakController::loadSettings( const QDomElement & _this )
 		effectId = m_loadCount++;
 	}
 
-	for (const auto& effect : s_effects) 
+	for (const auto& effect : s_effects)
 	{
-		if (effect->m_effectId == effectId) 
+		if (effect->m_effectId == effectId)
 		{
 			m_peakEffect = effect;
 			return;
@@ -194,7 +194,7 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 	int foundCount = 0;
 	if( m_buggedFile == false )
 	{
-		for (const auto& effect : s_effects) 
+		for (const auto& effect : s_effects)
 		{
 			if (effect->m_effectId == effectId )
 			{

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -196,7 +196,7 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 	{
 		for (const auto& effect : s_effects)
 		{
-			if (effect->m_effectId == effectId )
+			if (effect->m_effectId == effectId)
 			{
 				foundCount++;
 			}

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -69,7 +69,7 @@ void RenderManager::renderNextTrack()
 {
 	m_activeRenderer.reset();
 
-	if( m_tracksToRender.isEmpty() )
+	if (m_tracksToRender.empty())
 	{
 		// nothing left to render
 		restoreMutedState();
@@ -169,7 +169,7 @@ void RenderManager::render(QString outputPath)
 // Unmute all tracks that were muted while rendering tracks
 void RenderManager::restoreMutedState()
 {
-	while( !m_unmuted.isEmpty() )
+	while (!m_unmuted.empty())
 	{
 		Track* restoreTrack = m_unmuted.back();
 		m_unmuted.pop_back();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -840,7 +840,9 @@ bpm_t Song::getTempo()
 
 AutomatedValueMap Song::automatedValuesAt(TimePos time, int clipNum) const
 {
-	return TrackContainer::automatedValuesFromTracks(TrackList{m_globalAutomationTrack} << tracks(), time, clipNum);
+	auto globalAutomationTracks = TrackList{m_globalAutomationTrack};
+	globalAutomationTracks.insert(globalAutomationTracks.end(), tracks().begin(), tracks().end());
+	return TrackContainer::automatedValuesFromTracks(globalAutomationTracks, time, clipNum);
 }
 
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1326,8 +1326,7 @@ void Song::restoreControllerStates( const QDomElement & element )
 		else
 		{
 			// Fix indices to ensure correct connections
-			m_controllers.append(Controller::create(
-				Controller::DummyController, this));
+			m_controllers.push_back(Controller::create(Controller::DummyController, this));
 		}
 
 		node = node.nextSibling();
@@ -1445,9 +1444,10 @@ void Song::setProjectFileName(QString const & projectFileName)
 
 void Song::addController( Controller * controller )
 {
-	if( controller && !m_controllers.contains( controller ) )
+	bool containsController = std::find(m_controllers.begin(), m_controllers.end(), controller) != m_controllers.end();
+	if (controller && !containsController)
 	{
-		m_controllers.append( controller );
+		m_controllers.push_back(controller);
 		emit controllerAdded( controller );
 
 		this->setModified();
@@ -1459,10 +1459,10 @@ void Song::addController( Controller * controller )
 
 void Song::removeController( Controller * controller )
 {
-	int index = m_controllers.indexOf( controller );
-	if( index != -1 )
+	auto it = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	if (it != m_controllers.end())
 	{
-		m_controllers.remove( index );
+		m_controllers.erase(it);
 
 		emit controllerRemoved( controller );
 		delete controller;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -450,7 +450,7 @@ bool Song::isExportDone() const
 int Song::getExportProgress() const
 {
 	TimePos pos = m_playPos[m_playMode];
-    
+
 	if (pos >= m_exportSongEnd)
 	{
 		return 100;
@@ -729,16 +729,16 @@ void Song::startExport()
 	else
 	{
 		m_exportSongEnd = TimePos(m_length, 0);
-        
+
 		// Handle potentially ridiculous loop points gracefully.
-		if (m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd) 
+		if (m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd)
 		{
 			m_exportSongEnd = m_playPos[Mode_PlaySong].m_timeLine->loopEnd();
 		}
 
-		if (!m_exportLoop) 
+		if (!m_exportLoop)
 			m_exportSongEnd += TimePos(1,0);
-        
+
 		m_exportSongBegin = TimePos(0,0);
 		// FIXME: remove this check once we load timeline in headless mode
 		if (m_playPos[Mode_PlaySong].m_timeLine)
@@ -754,7 +754,7 @@ void Song::startExport()
 		m_playPos[Mode_PlaySong].setTicks( 0 );
 	}
 
-	m_exportEffectiveLength = (m_exportLoopBegin - m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin) 
+	m_exportEffectiveLength = (m_exportLoopBegin - m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin)
 		* m_loopRenderCount + (m_exportSongEnd - m_exportLoopEnd);
 	m_loopRenderRemaining = m_loopRenderCount;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -450,7 +450,7 @@ bool Song::isExportDone() const
 int Song::getExportProgress() const
 {
 	TimePos pos = m_playPos[m_playMode];
-
+    
 	if (pos >= m_exportSongEnd)
 	{
 		return 100;
@@ -729,16 +729,16 @@ void Song::startExport()
 	else
 	{
 		m_exportSongEnd = TimePos(m_length, 0);
-
+        
 		// Handle potentially ridiculous loop points gracefully.
-		if (m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd)
+		if (m_loopRenderCount > 1 && m_playPos[Mode_PlaySong].m_timeLine->loopEnd() > m_exportSongEnd) 
 		{
 			m_exportSongEnd = m_playPos[Mode_PlaySong].m_timeLine->loopEnd();
 		}
 
-		if (!m_exportLoop)
+		if (!m_exportLoop) 
 			m_exportSongEnd += TimePos(1,0);
-
+        
 		m_exportSongBegin = TimePos(0,0);
 		// FIXME: remove this check once we load timeline in headless mode
 		if (m_playPos[Mode_PlaySong].m_timeLine)
@@ -754,7 +754,7 @@ void Song::startExport()
 		m_playPos[Mode_PlaySong].setTicks( 0 );
 	}
 
-	m_exportEffectiveLength = (m_exportLoopBegin - m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin)
+	m_exportEffectiveLength = (m_exportLoopBegin - m_exportSongBegin) + (m_exportLoopEnd - m_exportLoopBegin) 
 		* m_loopRenderCount + (m_exportSongEnd - m_exportLoopEnd);
 	m_loopRenderRemaining = m_loopRenderCount;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -840,9 +840,9 @@ bpm_t Song::getTempo()
 
 AutomatedValueMap Song::automatedValuesAt(TimePos time, int clipNum) const
 {
-	auto globalAutomationTracks = TrackList{m_globalAutomationTrack};
-	globalAutomationTracks.insert(globalAutomationTracks.end(), tracks().begin(), tracks().end());
-	return TrackContainer::automatedValuesFromTracks(globalAutomationTracks, time, clipNum);
+	auto trackList = TrackList{m_globalAutomationTrack};
+	trackList.insert(trackList.end(), tracks().begin(), tracks().end());
+	return TrackContainer::automatedValuesFromTracks(trackList, time, clipNum);
 }
 
 

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -301,7 +301,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 				delete stepNote;
 				notesRemoved = true;
 			}
-			else 
+			else
 			{
 				nextTimout = min(nextTimout, REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS - timeSinceReleased);
 			}

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -297,17 +297,17 @@ void StepRecorder::removeNotesReleasedForTooLong()
 			{
 				notesRemoved = true;
 			}
-			else 
+			else
 			{
 				nextTimout = min(nextTimout, REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS - timeSinceReleased);
 			}
 		}
 	}
 
-	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [](auto stepNote) 
+	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [](auto stepNote)
 	{
 		bool shouldRemove = stepNote->isReleased() && stepNote->timeSinceReleased() >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS;
-		if (shouldRemove) 
+		if (shouldRemove)
 		{
 			delete stepNote;
 		}

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -292,7 +292,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	{
 		if (stepNote->isReleased())
 		{
-			const int timeSinceReleased = stepNote->timeSinceReleased();
+			const int timeSinceReleased = stepNote->timeSinceReleased(); // capture value to avoid wraparound when calculting nextTimout
 			if (timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS)
 			{
 				notesRemoved = true;

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -175,15 +175,15 @@ void StepRecorder::setStepsLength(const TimePos& newLength)
 	updateWidget();
 }
 
-QVector<Note*> StepRecorder::getCurStepNotes()
+std::vector<Note*> StepRecorder::getCurStepNotes()
 {
-	QVector<Note*> notes;
+	std::vector<Note*> notes;
 
 	if(m_isStepInProgress)
 	{
-		for(StepNote* stepNote: m_curStepNotes)
+		for (StepNote* stepNote: m_curStepNotes)
 		{
-			notes.append(&stepNote->m_note);
+			notes.push_back(&stepNote->m_note);
 		}
 	}
 

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -288,26 +288,27 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	int nextTimout = std::numeric_limits<int>::max();
 	bool notesRemoved = false;
 
-	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [&](StepNote* stepNote) 
+	for (const auto& stepNote : m_curStepNotes) 
 	{
-		bool shouldRemove = false;
 		if (stepNote->isReleased()) 
 		{
 			const int timeSinceReleased = stepNote->timeSinceReleased();
-			shouldRemove = timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS;
-
-			if (shouldRemove) 
+			if (timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS) 
 			{
 				delete stepNote;
 				notesRemoved = true;
 			}
-			else
+			else 
 			{
 				nextTimout = min(nextTimout, REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS - timeSinceReleased);
 			}
 		}
-		return stepNote->isReleased() && shouldRemove;
-	}), m_curStepNotes.end());
+	}
+
+	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [](auto stepNote) 
+	{ 
+		return stepNote->timeSinceReleased() >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS; 
+	}));
 
 	if(notesRemoved)
 	{

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -288,28 +288,30 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	int nextTimout = std::numeric_limits<int>::max();
 	bool notesRemoved = false;
 
-	for (const auto& stepNote : m_curStepNotes) 
+	auto it = m_curStepNotes.begin();
+	while (it != m_curStepNotes.end()) 
 	{
+		StepNote* stepNote = *it;
+
 		if (stepNote->isReleased()) 
 		{
 			const int timeSinceReleased = stepNote->timeSinceReleased();
-			if (timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS) 
+			if (timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS)
 			{
 				delete stepNote;
+				it = m_curStepNotes.erase(it);
 				notesRemoved = true;
+				continue;
 			}
 			else 
 			{
 				nextTimout = min(nextTimout, REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS - timeSinceReleased);
 			}
 		}
+
+		++it;
 	}
-
-	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [](auto stepNote) 
-	{ 
-		return stepNote->timeSinceReleased() >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS; 
-	}));
-
+	
 	if(notesRemoved)
 	{
 		m_pianoRoll.update();

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -84,9 +84,9 @@ Track::~Track()
 	lock();
 	emit destroyedTrack();
 
-	while( !m_clips.isEmpty() )
+	while (!m_clips.empty())
 	{
-		delete m_clips.last();
+		delete m_clips.back();
 	}
 
 	m_trackContainer->removeTrack( this );
@@ -365,9 +365,9 @@ void Track::removeClip( Clip * clip )
 /*! \brief Remove all Clips from this track */
 void Track::deleteClips()
 {
-	while( ! m_clips.isEmpty() )
+	while (!m_clips.empty())
 	{
-		delete m_clips.first();
+		delete m_clips.front();
 	}
 }
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -208,12 +208,12 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	{
 		element.setAttribute( "trackheight", m_height );
 	}
-	
+
 	if( m_hasColor )
 	{
 		element.setAttribute( "color", m_color.name() );
 	}
-	
+
 	QDomElement tsDe = doc.createElement( nodeName() );
 	// let actual track (InstrumentTrack, PatternTrack, SampleTrack etc.) save its settings
 	element.appendChild( tsDe );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -208,12 +208,12 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	{
 		element.setAttribute( "trackheight", m_height );
 	}
-
+	
 	if( m_hasColor )
 	{
 		element.setAttribute( "color", m_color.name() );
 	}
-
+	
 	QDomElement tsDe = doc.createElement( nodeName() );
 	// let actual track (InstrumentTrack, PatternTrack, SampleTrack etc.) save its settings
 	element.appendChild( tsDe );

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -196,14 +196,14 @@ void TrackContainer::removeTrack( Track * _track )
 	//   After checking that index != -1, we need to upgrade the lock to a write locker before changing m_tracks.
 	//   But since Qt offers no function to promote a read lock to a write lock, we must start with the write locker.
 	QWriteLocker lockTracksAccess(&m_tracksMutex);
-	int index = m_tracks.indexOf( _track );
-	if( index != -1 )
+	auto it = std::find(m_tracks.begin(), m_tracks.end(), _track);
+	if (it != m_tracks.end())
 	{
 		// If the track is solo, all other tracks are muted. Change this before removing the solo track:
 		if (_track->isSolo()) {
 			_track->setSolo(false);
 		}
-		m_tracks.remove( index );
+		m_tracks.erase(it);
 		lockTracksAccess.unlock();
 
 		if( Engine::getSong() )
@@ -226,9 +226,9 @@ void TrackContainer::updateAfterTrackAdd()
 void TrackContainer::clearAllTracks()
 {
 	//m_tracksMutex.lockForWrite();
-	while( !m_tracks.isEmpty() )
+	while (!m_tracks.empty())
 	{
-		delete m_tracks.first();
+		delete m_tracks.front();
 	}
 	//m_tracksMutex.unlock();
 }
@@ -240,7 +240,7 @@ bool TrackContainer::isEmpty() const
 {
 	for (const auto& track : m_tracks)
 	{
-		if (!track->getClips().isEmpty())
+		if (!track->getClips().empty())
 		{
 			return false;
 		}
@@ -275,7 +275,7 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 				track->getClipsInRange(clips, 0, time);
 			} else {
 				Q_ASSERT(track->numOfClips() > clipNum);
-				clips << track->getClip(clipNum);
+				clips.push_back(track->getClip(clipNum));
 			}
 		default:
 			break;

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -71,8 +71,7 @@ void MidiClient::removePort( MidiPort* port )
 		return;
 	}
 
-	QVector<MidiPort *>::Iterator it =
-		std::find( m_midiPorts.begin(), m_midiPorts.end(), port );
+	auto it = std::find( m_midiPorts.begin(), m_midiPorts.end(), port );
 	if( it != m_midiPorts.end() )
 	{
 		m_midiPorts.erase( it );

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -71,7 +71,7 @@ void MidiClient::removePort( MidiPort* port )
 		return;
 	}
 
-	auto it = std::find( m_midiPorts.begin(), m_midiPorts.end(), port );
+	auto it = std::find(m_midiPorts.begin(), m_midiPorts.end(), port);
 	if( it != m_midiPorts.end() )
 	{
 		m_midiPorts.erase( it );

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -103,7 +103,7 @@ void EffectRackView::moveUp( EffectView* view )
 	if( view != m_effectViews.first() )
 	{
 		int i = 0;
-		for( QVector<EffectView *>::Iterator it = m_effectViews.begin(); 
+		for( QVector<EffectView *>::Iterator it = m_effectViews.begin();
 					it != m_effectViews.end(); it++, i++ )
 		{
 			if( *it == view )
@@ -196,7 +196,7 @@ void EffectRackView::update()
 	const int EffectViewMargin = 3;
 	m_lastY = EffectViewMargin;
 
-	for( QVector<EffectView *>::Iterator it = m_effectViews.begin(); 
+	for( QVector<EffectView *>::Iterator it = m_effectViews.begin();
 					it != m_effectViews.end(); i++ )
 	{
 		if( i < view_map.size() && view_map[i] == false )

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -103,7 +103,7 @@ void EffectRackView::moveUp( EffectView* view )
 	if( view != m_effectViews.first() )
 	{
 		int i = 0;
-		for( QVector<EffectView *>::Iterator it = m_effectViews.begin();
+		for( QVector<EffectView *>::Iterator it = m_effectViews.begin(); 
 					it != m_effectViews.end(); it++, i++ )
 		{
 			if( *it == view )
@@ -196,7 +196,7 @@ void EffectRackView::update()
 	const int EffectViewMargin = 3;
 	m_lastY = EffectViewMargin;
 
-	for( QVector<EffectView *>::Iterator it = m_effectViews.begin();
+	for( QVector<EffectView *>::Iterator it = m_effectViews.begin(); 
 					it != m_effectViews.end(); i++ )
 	{
 		if( i < view_map.size() && view_map[i] == false )

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -478,12 +478,10 @@ void MixerView::deleteUnusedChannels()
 {
 	Mixer* mix = Engine::mixer();
 
-	const auto mixer = Engine::mixer();
-
 	// Check all channels except master, delete those with no incoming sends
 	for (int i = m_mixerChannelViews.size() - 1; i > 0; --i)
 	{
-		if (!mixer->isChannelInUse(i) && mixer->mixerChannel(i)->m_receives.empty())
+		if (!mix->isChannelInUse(i))
 		{
 			deleteChannel(i);
 		}

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -478,10 +478,12 @@ void MixerView::deleteUnusedChannels()
 {
 	Mixer* mix = Engine::mixer();
 
+	const auto mixer = Engine::mixer();
+
 	// Check all channels except master, delete those with no incoming sends
 	for (int i = m_mixerChannelViews.size() - 1; i > 0; --i)
 	{
-		if (!mix->isChannelInUse(i))
+		if (!mixer->isChannelInUse(i) && mixer->mixerChannel(i)->m_receives.empty())
 		{
 			deleteChannel(i);
 		}

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -191,10 +191,10 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "flip_x" ),
 						tr( "Flip Horizontally (Visible)" ),
 						this, SLOT(flipX()));
-	if( !m_clip->m_objects.isEmpty() )
+	if (!m_clip->m_objects.empty())
 	{
 		_cm->addSeparator();
-		auto m = new QMenu(tr("%1 Connections").arg(m_clip->m_objects.count()), _cm);
+		auto m = new QMenu(tr("%1 Connections").arg(m_clip->m_objects.size()), _cm);
 		for (const auto& object : m_clip->m_objects)
 		{
 			if (object)

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -559,13 +559,13 @@ DataFile ClipView::createClipDataFiles(
 	// Add extra metadata needed for calculations later
 
 	const auto initialTrackIt = std::find(tc->tracks().begin(), tc->tracks().end(), t);
-	const int initialTrackIndex = initialTrackIt != tc->tracks().end() ? std::distance(tc->tracks().begin(), initialTrackIt) : -1;
-
-	if (initialTrackIndex < 0)
+	if (initialTrackIt != tc->tracks().end())
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");
 		return dataFile;
 	}
+
+	const int initialTrackIndex = std::distance(tc->tracks().begin(), initialTrackIt);
 	QDomElement metadata = dataFile.createElement( "copyMetadata" );
 	// initialTrackIndex is the index of the track that was touched
 	metadata.setAttribute( "initialTrackIndex", initialTrackIndex );

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -558,7 +558,9 @@ DataFile ClipView::createClipDataFiles(
 
 	// Add extra metadata needed for calculations later
 
-	int initialTrackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), t));
+	const auto initialTrackIt = std::find(tc->tracks().begin(), tc->tracks().end(), t);
+	const int initialTrackIndex = initialTrackIt != tc->tracks().end() ? std::distance(tc->tracks().begin(), initialTrackIt) : -1;
+
 	if (initialTrackIndex < 0)
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -545,7 +545,7 @@ DataFile ClipView::createClipDataFiles(
 	{
 		// Insert into the dom under the "clips" element
 		Track* clipTrack = clipView->m_trackView->getTrack();
-		int trackIndex = tc->tracks().indexOf( clipTrack );
+		int trackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), clipTrack));
 		QDomElement clipElement = dataFile.createElement("clip");
 		clipElement.setAttribute( "trackIndex", trackIndex );
 		clipElement.setAttribute( "trackType", clipTrack->type() );
@@ -557,8 +557,9 @@ DataFile ClipView::createClipDataFiles(
 	dataFile.content().appendChild( clipParent );
 
 	// Add extra metadata needed for calculations later
-	int initialTrackIndex = tc->tracks().indexOf( t );
-	if( initialTrackIndex < 0 )
+
+	int initialTrackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), t));
+	if (initialTrackIndex < 0)
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");
 		return dataFile;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -72,7 +72,7 @@ QPixmap * AutomationEditor::s_toolMove = nullptr;
 QPixmap * AutomationEditor::s_toolYFlip = nullptr;
 QPixmap * AutomationEditor::s_toolXFlip = nullptr;
 
-const QVector<float> AutomationEditor::m_zoomXLevels =
+const std::vector<float> AutomationEditor::m_zoomXLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
 
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -72,7 +72,7 @@ QPixmap * AutomationEditor::s_toolMove = nullptr;
 QPixmap * AutomationEditor::s_toolYFlip = nullptr;
 QPixmap * AutomationEditor::s_toolXFlip = nullptr;
 
-const std::vector<float> AutomationEditor::m_zoomXLevels =
+const std::array<float, 7> AutomationEditor::m_zoomXLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -148,15 +148,15 @@ std::array<PianoRoll::PianoRollKeyTypes, 12> PianoRoll::prKeyOrder
 
 const int DEFAULT_PR_PPB = DEFAULT_CELL_WIDTH * DefaultStepsPerBar;
 
-const QVector<float> PianoRoll::m_zoomLevels =
+const std::vector<float> PianoRoll::m_zoomLevels =
 		{0.125f, 0.25f, 0.5f, 1.0f, 1.5f, 2.0f, 4.0f, 8.0f};
 
-const QVector<float> PianoRoll::m_zoomYLevels =
+const std::vector<float> PianoRoll::m_zoomYLevels =
 		{0.25f, 0.5f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f, 4.0f};
 
 
 PianoRoll::PianoRoll() :
-	m_nemStr( QVector<QString>() ),
+	m_nemStr(),
 	m_noteEditMenu( nullptr ),
 	m_semiToneMarkerMenu( nullptr ),
 	m_zoomingModel(),
@@ -406,7 +406,7 @@ PianoRoll::PianoRoll() :
 			InstrumentFunctionNoteStacking::ChordTable::getInstance();
 
 	m_scaleModel.addItem( tr("No scale") );
-	for( const InstrumentFunctionNoteStacking::Chord& chord : chord_table )
+	for (const InstrumentFunctionNoteStacking::Chord& chord : chord_table.chords())
 	{
 		if( chord.isScale() )
 		{
@@ -423,7 +423,7 @@ PianoRoll::PianoRoll() :
 
 	// Set up chord model
 	m_chordModel.addItem( tr("No chord") );
-	for( const InstrumentFunctionNoteStacking::Chord& chord : chord_table )
+	for (const InstrumentFunctionNoteStacking::Chord& chord : chord_table.chords())
 	{
 		if( ! chord.isScale() )
 		{
@@ -775,7 +775,7 @@ void PianoRoll::fitNoteLengths(bool fill)
 		{
 			if (!fill) { break; }
 			// Last notes stretch to end of last bar
-			length = notes.last()->endPos().nextFullBar() * TimePos::ticksPerBar() - note->pos();
+			length = notes.back()->endPos().nextFullBar() * TimePos::ticksPerBar() - note->pos();
 		}
 		else
 		{
@@ -1241,11 +1241,11 @@ void PianoRoll::shiftPos(NoteVector notes, int amount)
 {
 	m_midiClip->addJournalCheckPoint();
 
-	if (notes.isEmpty()) {
+	if (notes.empty()) {
 		return;
 	}
 
-	auto leftMostPos = notes.first()->pos();
+	auto leftMostPos = notes.front()->pos();
 	//Limit leftwards shifts to prevent moving left of clip start
 	auto shiftAmount = (leftMostPos > -amount) ? amount : -leftMostPos;
 	if (shiftAmount == 0) { return; }
@@ -1645,7 +1645,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 		if (note)
 		{
-			n.append(note);
+			n.push_back(note);
 
 			updateKnifePos(me);
 
@@ -1723,7 +1723,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -1846,9 +1846,9 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 				auto selectedNotes = getSelectedNotes();
 
-				m_moveBoundaryLeft = selectedNotes.first()->pos().getTicks();
-				m_moveBoundaryRight = selectedNotes.first()->endPos();
-				m_moveBoundaryBottom = selectedNotes.first()->key();
+				m_moveBoundaryLeft = selectedNotes.front()->pos().getTicks();
+				m_moveBoundaryRight = selectedNotes.front()->endPos();
+				m_moveBoundaryBottom = selectedNotes.front()->key();
 				m_moveBoundaryTop = m_moveBoundaryBottom;
 
 				//Figure out the bounding box of all the selected notes
@@ -2036,7 +2036,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 		{
 			if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
 			{
-				nv += i;
+				nv.push_back(i);
 			}
 		}
 		// make sure we're on a note
@@ -2054,8 +2054,8 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 					if( dist < closest_dist ) { closest = i; closest_dist = dist; }
 				}
 				// ... then remove all notes from the vector that aren't on the same exact time
-				NoteVector::Iterator it = nv.begin();
-				while( it != nv.end() )
+				auto it = nv.begin();
+				while (it != nv.end())
 				{
 					const Note *note = *it;
 					if( note->pos().getTicks() != closest->pos().getTicks() )
@@ -2517,7 +2517,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			bool altPressed = me->modifiers() & Qt::AltModifier;
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note* n = *it;
@@ -2579,7 +2579,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -2656,7 +2656,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin();
+			auto it = notes.begin();
 
 			// loop through whole note-vector...
 			while( it != notes.end() )
@@ -3789,7 +3789,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		{
 			if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
 			{
-				nv += i;
+				nv.push_back(i);
 			}
 		}
 		if( nv.size() > 0 )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -156,7 +156,6 @@ const std::vector<float> PianoRoll::m_zoomYLevels =
 
 
 PianoRoll::PianoRoll() :
-	m_nemStr(),
 	m_noteEditMenu( nullptr ),
 	m_semiToneMarkerMenu( nullptr ),
 	m_zoomingModel(),

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -199,8 +199,8 @@ void TrackContainerView::moveTrackView( TrackView * trackView, int indexTo )
 
 	Track * track = m_tc->m_tracks[indexFrom];
 
-	m_tc->m_tracks.remove( indexFrom );
-	m_tc->m_tracks.insert( indexTo, track );
+	m_tc->m_tracks.erase(m_tc->m_tracks.begin() + indexFrom);
+	m_tc->m_tracks.insert(m_tc->m_tracks.begin() + indexTo, track);
 	m_trackViews.move( indexFrom, indexTo );
 
 	realignTracks();

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -258,10 +258,12 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			}
 			else
 			{
-				int idx = Engine::getSong()->controllers().indexOf( cc->getController() );
-
-				if( idx >= 0 )
+				auto& controllers = Engine::getSong()->controllers();
+				auto it = std::find(controllers.begin(), controllers.end(), cc->getController());
+				
+				if (it != controllers.end())
 				{
+					int idx = std::distance(it, controllers.begin());
 					m_userGroupBox->model()->setValue( true );
 					m_userController->model()->setValue( idx );
 				}

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -125,7 +125,7 @@ private:
 namespace gui
 {
 
-ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
+ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent, 
 		const AutomatableModel * _target_model ) :
 	QDialog( _parent ),
 	m_readablePorts( nullptr ),
@@ -143,7 +143,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	m_midiGroupBox->setGeometry( 8, 10, 240, 80 );
 	connect( m_midiGroupBox->model(), SIGNAL(dataChanged()),
 			this, SLOT(midiToggled()));
-
+	
 	m_midiChannelSpinBox = new LcdSpinBox( 2, m_midiGroupBox,
 			tr( "Input channel" ) );
 	m_midiChannelSpinBox->addTextForValue( 0, "--" );
@@ -155,7 +155,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	m_midiControllerSpinBox->addTextForValue( 0, "---" );
 	m_midiControllerSpinBox->setLabel( tr( "CONTROLLER" ) );
 	m_midiControllerSpinBox->move( 68, 24 );
-
+	
 
 	m_midiAutoDetectCheckBox =
 			new LedCheckBox( tr("Auto Detect"),
@@ -218,7 +218,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	btn_layout->setContentsMargins(0, 0, 0, 0);
 
 	auto select_btn = new QPushButton(embed::getIconPixmap("add"), tr("OK"), buttons);
-	connect( select_btn, SIGNAL(clicked()),
+	connect( select_btn, SIGNAL(clicked()), 
 				this, SLOT(selectController()));
 
 	auto cancel_btn = new QPushButton(embed::getIconPixmap("cancel"), tr("Cancel"), buttons);
@@ -235,7 +235,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	setFixedSize( 256, 280 );
 
 	// Crazy MIDI View stuff
-
+	
 	// TODO, handle by making this a model for the Dialog "view"
 	ControllerConnection * cc = nullptr;
 	if( m_targetModel )
@@ -301,9 +301,9 @@ void ControllerConnectionDialog::selectController()
 		{
 			MidiController * mc;
 			mc = m_midiController->copyToMidiController( Engine::getSong() );
-
+	
 			/*
-			if( m_targetModel->getTrack() &&
+			if( m_targetModel->getTrack() && 
 					!m_targetModel->getTrack()->displayName().isEmpty() )
 			{
 				mc->m_midiPort.setName( QString( "%1 (%2)" ).
@@ -320,12 +320,12 @@ void ControllerConnectionDialog::selectController()
 		}
 	}
 	// User
-	else
+	else 
 	{
-		if( m_userGroupBox->model()->value() > 0 &&
+		if( m_userGroupBox->model()->value() > 0 && 
 				Engine::getSong()->controllers().size() )
 		{
-			m_controller = Engine::getSong()->controllers().at(
+			m_controller = Engine::getSong()->controllers().at( 
 					m_userController->model()->value() );
 		}
 
@@ -334,7 +334,7 @@ void ControllerConnectionDialog::selectController()
 			QMessageBox::warning(this, tr("LMMS"), tr("Cycle Detected."));
 			return;
 		}
-
+	
 	}
 
 	accept();

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -125,7 +125,7 @@ private:
 namespace gui
 {
 
-ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent, 
+ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 		const AutomatableModel * _target_model ) :
 	QDialog( _parent ),
 	m_readablePorts( nullptr ),
@@ -143,7 +143,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	m_midiGroupBox->setGeometry( 8, 10, 240, 80 );
 	connect( m_midiGroupBox->model(), SIGNAL(dataChanged()),
 			this, SLOT(midiToggled()));
-	
+
 	m_midiChannelSpinBox = new LcdSpinBox( 2, m_midiGroupBox,
 			tr( "Input channel" ) );
 	m_midiChannelSpinBox->addTextForValue( 0, "--" );
@@ -155,7 +155,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	m_midiControllerSpinBox->addTextForValue( 0, "---" );
 	m_midiControllerSpinBox->setLabel( tr( "CONTROLLER" ) );
 	m_midiControllerSpinBox->move( 68, 24 );
-	
+
 
 	m_midiAutoDetectCheckBox =
 			new LedCheckBox( tr("Auto Detect"),
@@ -218,7 +218,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	btn_layout->setContentsMargins(0, 0, 0, 0);
 
 	auto select_btn = new QPushButton(embed::getIconPixmap("add"), tr("OK"), buttons);
-	connect( select_btn, SIGNAL(clicked()), 
+	connect( select_btn, SIGNAL(clicked()),
 				this, SLOT(selectController()));
 
 	auto cancel_btn = new QPushButton(embed::getIconPixmap("cancel"), tr("Cancel"), buttons);
@@ -235,7 +235,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 	setFixedSize( 256, 280 );
 
 	// Crazy MIDI View stuff
-	
+
 	// TODO, handle by making this a model for the Dialog "view"
 	ControllerConnection * cc = nullptr;
 	if( m_targetModel )
@@ -260,7 +260,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			{
 				auto& controllers = Engine::getSong()->controllers();
 				auto it = std::find(controllers.begin(), controllers.end(), cc->getController());
-				
+
 				if (it != controllers.end())
 				{
 					int idx = std::distance(it, controllers.begin());
@@ -301,9 +301,9 @@ void ControllerConnectionDialog::selectController()
 		{
 			MidiController * mc;
 			mc = m_midiController->copyToMidiController( Engine::getSong() );
-	
+
 			/*
-			if( m_targetModel->getTrack() && 
+			if( m_targetModel->getTrack() &&
 					!m_targetModel->getTrack()->displayName().isEmpty() )
 			{
 				mc->m_midiPort.setName( QString( "%1 (%2)" ).
@@ -320,12 +320,12 @@ void ControllerConnectionDialog::selectController()
 		}
 	}
 	// User
-	else 
+	else
 	{
-		if( m_userGroupBox->model()->value() > 0 && 
+		if( m_userGroupBox->model()->value() > 0 &&
 				Engine::getSong()->controllers().size() )
 		{
-			m_controller = Engine::getSong()->controllers().at( 
+			m_controller = Engine::getSong()->controllers().at(
 					m_userController->model()->value() );
 		}
 
@@ -334,7 +334,7 @@ void ControllerConnectionDialog::selectController()
 			QMessageBox::warning(this, tr("LMMS"), tr("Cycle Detected."));
 			return;
 		}
-	
+
 	}
 
 	accept();

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -346,7 +346,8 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	// Get the current track's index
 	const TrackContainer::TrackList tracks = t->trackContainer()->tracks();
-	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), t));
+	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
+	const int currentTrackIndex = currentTrackIt != tracks.end() ? std::distance(tracks.begin(), currentTrackIt) : -1;
 
 	// Don't paste if we're on the same bar and allowSameBar is false
 	auto sourceTrackContainerId = metadata.attributeNode( "trackContainerId" ).value().toUInt();
@@ -436,8 +437,9 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	// Snap the mouse position to the beginning of the dropped bar, in ticks
 	const TrackContainer::TrackList tracks = getTrack()->trackContainer()->tracks();
-	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), getTrack()));
-	
+	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
+	const int currentTrackIndex = currentTrackIt != tracks.end() ? std::distance(tracks.begin(), currentTrackIt) : -1;
+
 	bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
 
 	// Unselect the old group

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -346,7 +346,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	// Get the current track's index
 	const TrackContainer::TrackList tracks = t->trackContainer()->tracks();
-	const int currentTrackIndex = tracks.indexOf( t );
+	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), t));
 
 	// Don't paste if we're on the same bar and allowSameBar is false
 	auto sourceTrackContainerId = metadata.attributeNode( "trackContainerId" ).value().toUInt();
@@ -436,8 +436,8 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	// Snap the mouse position to the beginning of the dropped bar, in ticks
 	const TrackContainer::TrackList tracks = getTrack()->trackContainer()->tracks();
-	const int currentTrackIndex = tracks.indexOf( getTrack() );
-
+	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), getTrack()));
+	
 	bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
 
 	// Unselect the old group

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -748,7 +748,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 		if( cur_start > 0 )
 		{
 			// skip notes which are posated before start-bar
-			while (nit != notes.end() && (*nit)->pos() < cur_start)
+			while( nit != notes.end() && ( *nit )->pos() < cur_start )
 			{
 				++nit;
 			}
@@ -986,18 +986,18 @@ void InstrumentTrack::replaceInstrument(DataFile dataFile)
 
 	InstrumentTrack::removeMidiPortNode(dataFile);
 	setSimpleSerializing();
-
+	
 	//Replacing an instrument shouldn't change the solo/mute state.
 	bool oldMute = isMuted();
 	bool oldSolo = isSolo();
 	bool oldMutedBeforeSolo = isMutedBeforeSolo();
 
 	loadSettings(dataFile.content().toElement());
-
+	
 	setMuted(oldMute);
 	setSolo(oldSolo);
 	setMutedBeforeSolo(oldMutedBeforeSolo);
-
+	
 	m_mixerChannelModel.setValue(mixerChannel);
 	Engine::getSong()->setModified();
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -739,7 +739,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 		// get all notes from the given clip...
 		const NoteVector & notes = c->notes();
 		// ...and set our index to zero
-		NoteVector::ConstIterator nit = notes.begin();
+		auto nit = notes.begin();
 
 		// very effective algorithm for playing notes that are
 		// posated within the current sample-frame
@@ -748,7 +748,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 		if( cur_start > 0 )
 		{
 			// skip notes which are posated before start-bar
-			while( nit != notes.end() && ( *nit )->pos() < cur_start )
+			while (nit != notes.end() && (*nit)->pos() < cur_start)
 			{
 				++nit;
 			}
@@ -986,18 +986,18 @@ void InstrumentTrack::replaceInstrument(DataFile dataFile)
 
 	InstrumentTrack::removeMidiPortNode(dataFile);
 	setSimpleSerializing();
-	
+
 	//Replacing an instrument shouldn't change the solo/mute state.
 	bool oldMute = isMuted();
 	bool oldSolo = isSolo();
 	bool oldMutedBeforeSolo = isMutedBeforeSolo();
 
 	loadSettings(dataFile.content().toElement());
-	
+
 	setMuted(oldMute);
 	setSolo(oldSolo);
 	setMutedBeforeSolo(oldMutedBeforeSolo);
-	
+
 	m_mixerChannelModel.setValue(mixerChannel);
 	Engine::getSong()->setModified();
 }

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -481,7 +481,8 @@ MidiClip * MidiClip::adjacentMidiClipByOffset(int offset) const
 {
 	std::vector<Clip *> clips = m_instrumentTrack->getClips();
 	int clipNum = m_instrumentTrack->getClipNum(this);
-	return (clipNum < 0 || clipNum > clips.size() - 1) ? nullptr : dynamic_cast<MidiClip*>(clips[clipNum + offset]);
+	if (clipNum < 0 || clipNum > clips.size() - 1) { return nullptr; }
+	return dynamic_cast<MidiClip*>(clips[clipNum + offset]);
 }
 
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -115,11 +115,16 @@ void MidiClip::resizeToFirstTrack()
 		{
 			if (track != m_instrumentTrack)
 			{
-				unsigned int currentClip = std::distance(m_instrumentTrack->getClips().begin(),
-					std::find(m_instrumentTrack->getClips().begin(), m_instrumentTrack->getClips().end(), this));
-				m_steps = static_cast<MidiClip *>
-					(track->getClip(currentClip))
-					->m_steps;
+				const auto& instrumentTrackClips = m_instrumentTrack->getClips();
+				const auto currentClipIt = std::find(instrumentTrackClips.begin(), instrumentTrackClips.end(), this);
+				unsigned int currentClip = currentClipIt != instrumentTrackClips.end() ?
+					std::distance(instrumentTrackClips.begin(), currentClipIt) : -1;
+
+				if (currentClip >= 0)
+				{
+					m_steps = static_cast<MidiClip*>(track->getClip(currentClip))->m_steps;
+				}
+
 			}
 			break;
 		}

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -119,12 +119,7 @@ void MidiClip::resizeToFirstTrack()
 				const auto currentClipIt = std::find(instrumentTrackClips.begin(), instrumentTrackClips.end(), this);
 				unsigned int currentClip = currentClipIt != instrumentTrackClips.end() ?
 					std::distance(instrumentTrackClips.begin(), currentClipIt) : -1;
-
-				if (currentClip >= 0)
-				{
-					m_steps = static_cast<MidiClip*>(track->getClip(currentClip))->m_steps;
-				}
-
+				m_steps = static_cast<MidiClip*>(track->getClip(currentClip))->m_steps;
 			}
 			break;
 		}

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -226,7 +226,7 @@ void MidiClip::removeNote( Note * _note_to_del )
 
 	m_notes.erase(std::remove_if(m_notes.begin(), m_notes.end(), [&](Note* note)
 	{
-		bool shouldRemove = note == _note_to_del;
+		auto shouldRemove = note == _note_to_del;
 		if (shouldRemove) { delete note; }
 		return shouldRemove;
 	}), m_notes.end());
@@ -271,7 +271,6 @@ void MidiClip::clearNotes()
 	{
 		delete note;
 	}
-
 	m_notes.clear();
 	instrumentTrack()->unlock();
 
@@ -365,7 +364,6 @@ void MidiClip::checkType()
 			return;
 		}
 	}
-
 	setType( BeatClip );
 }
 
@@ -376,7 +374,7 @@ void MidiClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	_this.setAttribute( "type", m_clipType );
 	_this.setAttribute( "name", name() );
-
+	
 	if( usesCustomClipColor() )
 	{
 		_this.setAttribute( "color", color().name() );
@@ -411,7 +409,7 @@ void MidiClip::loadSettings( const QDomElement & _this )
 	m_clipType = static_cast<MidiClipTypes>( _this.attribute( "type"
 								).toInt() );
 	setName( _this.attribute( "name" ) );
-
+	
 	if( _this.hasAttribute( "color" ) )
 	{
 		useCustomClipColor( true );
@@ -421,7 +419,7 @@ void MidiClip::loadSettings( const QDomElement & _this )
 	{
 		useCustomClipColor(false);
 	}
-
+	
 	if( _this.attribute( "pos" ).toInt() >= 0 )
 	{
 		movePosition( _this.attribute( "pos" ).toInt() );
@@ -581,7 +579,6 @@ bool MidiClip::empty()
 			return false;
 		}
 	}
-
 	return true;
 }
 
@@ -591,7 +588,6 @@ bool MidiClip::empty()
 void MidiClip::changeTimeSignature()
 {
 	TimePos last_pos = TimePos::ticksPerBar() - 1;
-
 	for (const auto& note : m_notes)
 	{
 		if (note->length() < 0 && note->pos() > last_pos)
@@ -599,7 +595,6 @@ void MidiClip::changeTimeSignature()
 			last_pos = note->pos() + TimePos::ticksPerBar() / TimePos::stepsPerBar();
 		}
 	}
-
 	last_pos = last_pos.nextFullBar() * TimePos::ticksPerBar();
 	m_steps = qMax<tick_t>( TimePos::stepsPerBar(),
 				last_pos.getBar() * TimePos::stepsPerBar() );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -22,7 +22,7 @@
  * Boston, MA 02110-1301 USA.
  *
  */
-
+ 
 #include "SampleTrack.h"
 
 #include <QDomElement>

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -22,7 +22,7 @@
  * Boston, MA 02110-1301 USA.
  *
  */
- 
+
 #include "SampleTrack.h"
 
 #include <QDomElement>


### PR DESCRIPTION
Essentially what was done in Veratil's Qt removal PR, only this time with more modernization (particularly with iterators) and testing. Changes on the GUI side were made as necessary to make the code compile. The remaining ``QVector``'s, if any, in the codebase should be in the GUI, but it is likely that I may have missed something.

The "Phase 2" is mainly because there were changes that needed to be made in order to make the code compile that I had missed on the first run.

Edit: I've decided that I will also remove the remaining ``QVector``'s in the UI part of the codebase, but as a follow-up PR to this one.