### PR TITLE
Arpeggiator - Random distribution

### DIFF
--- a/include/InstrumentFunctionViews.h
+++ b/include/InstrumentFunctionViews.h
@@ -85,12 +85,14 @@ private:
 	Knob * m_arpRangeKnob;
 	Knob * m_arpRepeatsKnob;
 	Knob * m_arpCycleKnob;
+	Knob * m_arpRandShapeKnob;
 	Knob * m_arpSkipKnob;
 	Knob * m_arpMissKnob;
 	TempoSyncKnob * m_arpTimeKnob;
 	Knob * m_arpGateKnob;
 
 	ComboBox * m_arpDirectionComboBox;
+	ComboBox * m_arpRandomComboBox;
 	ComboBox * m_arpModeComboBox;
 
 } ;

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -207,6 +207,9 @@ enum ArpRandomDistributions
 		return "arpeggiator";
 	}
 
+protected slots:
+
+	void updateNoteRange();
 
 private:
 	enum class ArpMode

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -185,6 +185,14 @@ public:
 		Random
 	} ;
 
+enum ArpRandomDistributions
+	{
+		ArpRandomExp,
+		ArpRandomNormal,
+		ArpRandomChase,
+		NumArpRandomDistributions
+	} ;
+
 	InstrumentFunctionArpeggio( Model * _parent );
 	~InstrumentFunctionArpeggio() override = default;
 
@@ -213,13 +221,15 @@ private:
 	FloatModel m_arpRangeModel;
 	FloatModel m_arpRepeatsModel;
 	FloatModel m_arpCycleModel;
+	FloatModel m_arpRandShapeModel;
 	FloatModel m_arpSkipModel;
 	FloatModel m_arpMissModel;
 	TempoSyncKnobModel m_arpTimeModel;
 	FloatModel m_arpGateModel;
 	ComboBoxModel m_arpDirectionModel;
+	ComboBoxModel m_arpRandomModel;
 	ComboBoxModel m_arpModeModel;
-
+	int m_lastRandomNote;
 
 	friend class InstrumentTrack;
 	friend class gui::InstrumentFunctionArpeggioView;

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -187,6 +187,7 @@ public:
 
 enum ArpRandomDistributions
 	{
+		ArpRandomBase,
 		ArpRandomExp,
 		ArpRandomNormal,
 		ArpRandomChase,

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -358,7 +358,7 @@ void InstrumentFunctionArpeggio::updateNoteRange()
 	const int cur_chord_size = chord_table.chords()[m_arpModel.value()].size();
 	float noteRange = m_arpRangeModel.value() * cur_chord_size;
 
-	m_arpCycleModel.setRange( 0.0f, noteRange );
+	m_arpCycleModel.setRange( 0.0f, noteRange - 1 );
 
 	if( sticky )
 	{

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -401,7 +401,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
 	const int cur_chord_size = chord_table.chords()[selected_arp].size();
 	const int repeats = m_arpRepeatsModel.value();
-	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * repeats) + 1;
+	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * repeats) + repeats;
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played
@@ -484,23 +484,23 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			// once down -> makes 2 * range possible notes...
 			// because we don't play the lower and upper notes
 			// twice, we have to subtract 2
-			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 );
+			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 * repeats );
 			// if greater than range, we have to play down...
 			// looks like the code for arp_dir==DOWN... :)
 			if( cur_arp_idx >= range )
 			{
-				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - 1;
+				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - repeats;
 			}
 		}
 		else if( dir == ArpDirection::DownAndUp && range > 1 )
 		{
 			// copied from ArpDirection::UpAndDown above
-			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 );
+			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 * repeats);
 			// if greater than range, we have to play down...
 			// looks like the code for arp_dir==DOWN... :)
 			if( cur_arp_idx >= range )
 			{
-				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - 1;
+				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - repeats;
 			}
 			// inverts direction
 			cur_arp_idx = range - cur_arp_idx - 1;

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -512,7 +512,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 				randNumber = fastRandf(1.0f);
 				float shape2 = fabs(m_arpRandShapeModel.value());
 				int change = static_cast<int>(shape2 - std::round(2 * shape2 * randNumber));
-
+				change *= m_arpRepeatsModel.value();
 				cur_arp_idx = m_lastRandomNote + change;
 				if (!isNeg)
 				{

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -329,8 +329,8 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 
 	m_arpRandomModel.addItem(tr("Base"), std::make_unique<PixmapLoader>("arp_random"));
 	m_arpRandomModel.addItem(tr("Exponential"), std::make_unique<PixmapLoader>("arp_random"));
-	m_arpRandomModel.addItem(tr("Normal"), std::make_unique<PixmapLoader>("arp_random"));
-	m_arpRandomModel.addItem(tr("Chase"), std::make_unique<PixmapLoader>("arp_random"));
+	m_arpRandomModel.addItem(tr("Normal"), std::make_unique<PixmapLoader>("filter_bp"));
+	m_arpRandomModel.addItem(tr("Chase"), std::make_unique<PixmapLoader>("white_noise_wave_active"));
 
 	m_arpModeModel.addItem( tr( "Free" ), std::make_unique<PixmapLoader>( "arp_free" ) );
 	m_arpModeModel.addItem( tr( "Sort" ), std::make_unique<PixmapLoader>( "arp_sort" ) );

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -402,7 +402,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
 	const int cur_chord_size = chord_table.chords()[selected_arp].size();
 	const int repeats = m_arpRepeatsModel.value();
-	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * repeats) + repeats;
+	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * repeats);
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -301,7 +301,7 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	Model( _parent, tr( "Arpeggio" ) ),
 	m_arpEnabledModel( false ),
 	m_arpModel( this, tr( "Arpeggio type" ) ),
-	m_arpRangeModel( 0.0f, 0.0f, 9.0f, 1.0f, this, tr( "Arpeggio range" ) ),
+	m_arpRangeModel( 1.0f, 0.0f, 9.0f, 1.0f, this, tr( "Arpeggio range" ) ),
 	m_arpRepeatsModel( 1.0f, 1.0f, 8.0f, 1.0f, this, tr( "Note repeats" ) ),
 	m_arpCycleModel( 0.0f, 0.0f, 6.0f, 1.0f, this, tr( "Cycle steps" ) ),
 	m_arpRandShapeModel( 0.0f, -10.0f, 10.0f, 1.0f, this, tr( "Rand shape" ) ),
@@ -334,9 +334,36 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	m_arpModeModel.addItem( tr( "Free" ), std::make_unique<PixmapLoader>( "arp_free" ) );
 	m_arpModeModel.addItem( tr( "Sort" ), std::make_unique<PixmapLoader>( "arp_sort" ) );
 	m_arpModeModel.addItem( tr( "Sync" ), std::make_unique<PixmapLoader>( "arp_sync" ) );
+
+	connect( &m_arpModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateNoteRange() ), Qt::DirectConnection );
+	connect( &m_arpRangeModel, SIGNAL( dataChanged() ),
+			this, SLOT( updateNoteRange() ), Qt::DirectConnection );
 }
 
 
+
+
+void InstrumentFunctionArpeggio::updateNoteRange()
+{
+	bool sticky = false;
+	if( m_arpCycleModel.value() && m_arpCycleModel.value() ==  m_arpCycleModel.maxValue() )
+	{
+		sticky = true;
+	}
+
+	const InstrumentFunctionNoteStacking::ChordTable & chord_table =
+				InstrumentFunctionNoteStacking::ChordTable::getInstance();
+	const int cur_chord_size = chord_table.chords()[m_arpModel.value()].size();
+	float noteRange = m_arpRangeModel.value() * cur_chord_size;
+
+	m_arpCycleModel.setRange( 0.0f, noteRange );
+
+	if( sticky )
+	{
+		m_arpCycleModel.setValue( m_arpCycleModel.maxValue() );
+	}
+}
 
 
 

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -301,7 +301,7 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	Model( _parent, tr( "Arpeggio" ) ),
 	m_arpEnabledModel( false ),
 	m_arpModel( this, tr( "Arpeggio type" ) ),
-	m_arpRangeModel( 1.0f, 0.0f, 9.0f, 1.0f, this, tr( "Arpeggio range" ) ),
+	m_arpRangeModel( 1.0f, 1.0f, 9.0f, 1.0f, this, tr( "Arpeggio range" ) ),
 	m_arpRepeatsModel( 1.0f, 1.0f, 8.0f, 1.0f, this, tr( "Note repeats" ) ),
 	m_arpCycleModel( 0.0f, 0.0f, 6.0f, 1.0f, this, tr( "Cycle steps" ) ),
 	m_arpRandShapeModel( 0.0f, -10.0f, 10.0f, 1.0f, this, tr( "Rand shape" ) ),
@@ -400,10 +400,8 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
 	const int cur_chord_size = chord_table.chords()[selected_arp].size();
-	int rangecompute = m_arpRangeModel.value();
-	int rangeModifier = rangecompute > 0 ? 1 : 0;
-	rangecompute = rangecompute > 0 ? rangecompute : 1;
-	const int range = static_cast<int>(cur_chord_size * rangecompute * m_arpRepeatsModel.value()) + rangeModifier;
+	const int repeats = m_arpRepeatsModel.value();
+	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * repeats) + 1;
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played
@@ -539,7 +537,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 				randNumber = fastRandf(1.0f);
 				float shape2 = fabs(m_arpRandShapeModel.value());
 				int change = static_cast<int>(shape2 - std::round(2 * shape2 * randNumber));
-				change *= m_arpRepeatsModel.value();
+				change *= repeats;
 				cur_arp_idx = m_lastRandomNote + change;
 				if (!isNeg)
 				{
@@ -557,13 +555,13 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		}
 
 		// Divide cur_arp_idx with wanted repeats. The repeat feature will not affect random notes.
-		cur_arp_idx = static_cast<int>(cur_arp_idx / m_arpRepeatsModel.value());
+		cur_arp_idx = static_cast<int>(cur_arp_idx / repeats);
 
 		// Cycle notes
 		if( m_arpCycleModel.value() && dir != ArpDirection::Random )
 		{
 			cur_arp_idx *= m_arpCycleModel.value() + 1;
-			cur_arp_idx %= static_cast<int>( range / m_arpRepeatsModel.value() );
+			cur_arp_idx %= static_cast<int>( range / repeats );
 		}
 
 		// now calculate final key for our arp-note

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -101,11 +101,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpRangeKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpRepeatsKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpCycleKnob( new Knob( KnobType::Bright26 ) ),
+	m_arpRandShapeKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpSkipKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpMissKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpTimeKnob( new TempoSyncKnob( KnobType::Bright26 ) ),
 	m_arpGateKnob( new Knob( KnobType::Bright26 ) ),
 	m_arpDirectionComboBox( new ComboBox() ),
+	m_arpRandomComboBox( new ComboBox() ),
 	m_arpModeComboBox( new ComboBox() )
 {
 	auto topLayout = new QHBoxLayout(this);
@@ -128,6 +130,10 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 
 	m_arpCycleKnob->setLabel( tr( "CYCLE" ) );
 	m_arpCycleKnob->setHintText( tr( "Cycle notes:" ) + " ", " " + tr( "note(s)" ) );
+
+
+	m_arpRandShapeKnob->setLabel(tr("RAND"));
+	m_arpRandShapeKnob->setHintText(tr("Rand shape:"), "");
 
 
 	m_arpSkipKnob->setLabel( tr( "SKIP" ) );
@@ -154,16 +160,22 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	auto arpModeLabel = new QLabel(tr("Mode:"));
 	arpModeLabel->setFont( pointSize<8>( arpModeLabel->font() ) );
 
+	QLabel* arpRandomLabel = new QLabel(tr("Distribution:"));
+	arpRandomLabel->setFont(pointSize<8>(arpRandomLabel->font()));
+
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );
-	mainLayout->addWidget( arpDirectionLabel, 3, 0 );
-	mainLayout->addWidget( m_arpDirectionComboBox, 4, 0 );
+	mainLayout->addWidget( arpDirectionLabel, 2, 0 );
+	mainLayout->addWidget( m_arpDirectionComboBox, 3, 0 );
+	mainLayout->addWidget( arpRandomLabel, 4, 0 );
+	mainLayout->addWidget( m_arpRandomComboBox, 5, 0 );
 	mainLayout->addWidget( arpModeLabel, 6, 0 );
 	mainLayout->addWidget( m_arpModeComboBox, 7, 0 );
 
 	mainLayout->addWidget( m_arpRangeKnob, 0, 1, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpRepeatsKnob, 0, 2, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpCycleKnob, 0, 3, 2, 1, Qt::AlignHCenter );
+	mainLayout->addWidget( m_arpRandShapeKnob, 3, 1, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpSkipKnob, 3, 2, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpMissKnob, 3, 3, 2, 1, Qt::AlignHCenter );
 	mainLayout->addWidget( m_arpGateKnob, 6, 2, 2, 1, Qt::AlignHCenter );
@@ -192,11 +204,13 @@ void InstrumentFunctionArpeggioView::modelChanged()
 	m_arpRangeKnob->setModel( &m_a->m_arpRangeModel );
 	m_arpRepeatsKnob->setModel( &m_a->m_arpRepeatsModel );
 	m_arpCycleKnob->setModel( &m_a->m_arpCycleModel );
+	m_arpRandShapeKnob->setModel( &m_a->m_arpRandShapeModel );
 	m_arpSkipKnob->setModel( &m_a->m_arpSkipModel );
 	m_arpMissKnob->setModel( &m_a->m_arpMissModel );
 	m_arpTimeKnob->setModel( &m_a->m_arpTimeModel );
 	m_arpGateKnob->setModel( &m_a->m_arpGateModel );
 	m_arpDirectionComboBox->setModel( &m_a->m_arpDirectionModel );
+	m_arpRandomComboBox->setModel( &m_a->m_arpRandomModel );
 	m_arpModeComboBox->setModel( &m_a->m_arpModeModel );
 }
 

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -157,11 +157,11 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
 	arpDirectionLabel->setFont( pointSize<8>( arpDirectionLabel->font() ) );
 
+	auto arpRandomLabel = new QLabel(tr("Distribution:"));
+	arpRandomLabel->setFont(pointSize<8>(arpRandomLabel->font()));
+
 	auto arpModeLabel = new QLabel(tr("Mode:"));
 	arpModeLabel->setFont( pointSize<8>( arpModeLabel->font() ) );
-
-	QLabel* arpRandomLabel = new QLabel(tr("Distribution:"));
-	arpRandomLabel->setFont(pointSize<8>(arpRandomLabel->font()));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );


### PR DESCRIPTION
 Implements different random sources in the arpeggiator, selectable from a new combobox, and adds a knob to control the behaviour.

 Exponential (default) - A negative value make the base note more likely and the top note less likely to be selected. The opposite
 is true for a positive value. Center (0) is equivalent to the old random behavior with equal representation.

 Normal - Normal distribution, a bell curve. A positive value will put the weight on the center note(s) and a negative value will put
 the weight on the base/top notes. Center (0) is equivalent to equal representation.

 Chase - Brownian motion for the keys. Nudges the last note with a random value whose extreme value is set by the knob. On a positive value the base/top notes are stop points and on a negative value the note is allowed to warp around between base/note.

---

I've also made some changes to 'range' that is intended for testing purposes only. For this reason the PR is a draft for now. The range of the arpeggio doesn't go the whole way to the full octave. If you play a scale on an instrument you usually complete a full octave and this is not the case on the lmms arpeggiator. I've tested other arpeggiators and we're not unique in this regard. 
I think the discussion here touches on the matter: https://github.com/LMMS/lmms/issues/1836#issuecomment-77753824
The 'Chase' function won't mind but the other additions is more at home in a full octave context.

https://www.youtube.com/watch?v=wegC5eXN6TU