### PR TITLE
clang-tidy: Apply modernize-use-auto everywhere

### DIFF
--- a/plugins/Amplifier/AmplifierControlDialog.cpp
+++ b/plugins/Amplifier/AmplifierControlDialog.cpp
@@ -43,27 +43,27 @@ AmplifierControlDialog::AmplifierControlDialog( AmplifierControls* controls ) :
 	setPalette( pal );
 	setFixedSize( 100, 110 );
 
-	Knob * volumeKnob = new Knob( knobBright_26, this);
+	auto volumeKnob = new Knob(knobBright_26, this);
 	volumeKnob -> move( 16, 10 );
 	volumeKnob -> setVolumeKnob( true );
 	volumeKnob->setModel( &controls->m_volumeModel );
 	volumeKnob->setLabel( tr( "VOL" ) );
 	volumeKnob->setHintText( tr( "Volume:" ) , "%" );
 
-	Knob * panKnob = new Knob( knobBright_26, this);
+	auto panKnob = new Knob(knobBright_26, this);
 	panKnob -> move( 57, 10 );
 	panKnob->setModel( &controls->m_panModel );
 	panKnob->setLabel( tr( "PAN" ) );
 	panKnob->setHintText( tr( "Panning:" ) , "" );
 
-	Knob * leftKnob = new Knob( knobBright_26, this);
+	auto leftKnob = new Knob(knobBright_26, this);
 	leftKnob -> move( 16, 65 );
 	leftKnob -> setVolumeKnob( true );
 	leftKnob->setModel( &controls->m_leftModel );
 	leftKnob->setLabel( tr( "LEFT" ) );
 	leftKnob->setHintText( tr( "Left gain:" ) , "%" );
 
-	Knob * rightKnob = new Knob( knobBright_26, this);
+	auto rightKnob = new Knob(knobBright_26, this);
 	rightKnob -> move( 57, 65 );
 	rightKnob -> setVolumeKnob( true );
 	rightKnob->setModel( &controls->m_rightModel );

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -426,9 +426,9 @@ void AudioFileProcessor::loopPointChanged()
 
 void AudioFileProcessor::pointChanged()
 {
-	const auto f_start = static_cast<f_cnt_t>(m_startPointModel.value() * m_sampleBuffer.frames());
-	const auto f_end = static_cast<f_cnt_t>(m_endPointModel.value() * m_sampleBuffer.frames());
-	const auto f_loop = static_cast<f_cnt_t>(m_loopPointModel.value() * m_sampleBuffer.frames());
+	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	m_sampleBuffer.frames() );
+	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * m_sampleBuffer.frames() );
+	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * m_sampleBuffer.frames() );
 
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;
@@ -479,7 +479,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 
 // loop button group
 
-	auto* m_loopOffButton = new PixmapButton(this);
+	PixmapButton * m_loopOffButton = new PixmapButton( this );
 	m_loopOffButton->setCheckable( true );
 	m_loopOffButton->move( 190, 105 );
 	m_loopOffButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -488,7 +488,8 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_off_off" ) );
 	m_loopOffButton->setToolTip(tr("Disable loop"));
 
-	auto* m_loopOnButton = new PixmapButton(this);
+
+	PixmapButton * m_loopOnButton = new PixmapButton( this );
 	m_loopOnButton->setCheckable( true );
 	m_loopOnButton->move( 190, 124 );
 	m_loopOnButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -497,7 +498,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_on_off" ) );
 	m_loopOnButton->setToolTip(tr("Enable loop"));
 
-	auto* m_loopPingPongButton = new PixmapButton(this);
+	PixmapButton * m_loopPingPongButton = new PixmapButton( this );
 	m_loopPingPongButton->setCheckable( true );
 	m_loopPingPongButton->move( 216, 124 );
 	m_loopPingPongButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -644,9 +645,9 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 	p.drawPixmap( 0, 0, *s_artwork );
 
-	auto* a = castModel<AudioFileProcessor>();
+	AudioFileProcessor * a = castModel<AudioFileProcessor>();
 
-	QString file_name = "";
+ 	QString file_name = "";
 	int idx = a->m_sampleBuffer.audioFile().length();
 
 	p.setFont( pointSize<8>( font() ) );
@@ -701,7 +702,7 @@ void AudioFileProcessorView::openAudioFile()
 
 void AudioFileProcessorView::modelChanged()
 {
-	auto* a = castModel<AudioFileProcessor>();
+	AudioFileProcessor * a = castModel<AudioFileProcessor>();
 	connect( &a->m_sampleBuffer, SIGNAL( sampleUpdated() ),
 					this, SLOT( sampleUpdated() ) );
 	m_ampKnob->setModel( &a->m_ampModel );

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -426,9 +426,9 @@ void AudioFileProcessor::loopPointChanged()
 
 void AudioFileProcessor::pointChanged()
 {
-	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	m_sampleBuffer.frames() );
-	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * m_sampleBuffer.frames() );
-	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * m_sampleBuffer.frames() );
+	const auto f_start = static_cast<f_cnt_t>(m_startPointModel.value() * m_sampleBuffer.frames());
+	const auto f_end = static_cast<f_cnt_t>(m_endPointModel.value() * m_sampleBuffer.frames());
+	const auto f_loop = static_cast<f_cnt_t>(m_loopPointModel.value() * m_sampleBuffer.frames());
 
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;
@@ -479,7 +479,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 
 // loop button group
 
-	PixmapButton * m_loopOffButton = new PixmapButton( this );
+	auto m_loopOffButton = new PixmapButton(this);
 	m_loopOffButton->setCheckable( true );
 	m_loopOffButton->move( 190, 105 );
 	m_loopOffButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -488,8 +488,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_off_off" ) );
 	m_loopOffButton->setToolTip(tr("Disable loop"));
 
-
-	PixmapButton * m_loopOnButton = new PixmapButton( this );
+	auto m_loopOnButton = new PixmapButton(this);
 	m_loopOnButton->setCheckable( true );
 	m_loopOnButton->move( 190, 124 );
 	m_loopOnButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -498,7 +497,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_on_off" ) );
 	m_loopOnButton->setToolTip(tr("Enable loop"));
 
-	PixmapButton * m_loopPingPongButton = new PixmapButton( this );
+	auto m_loopPingPongButton = new PixmapButton(this);
 	m_loopPingPongButton->setCheckable( true );
 	m_loopPingPongButton->move( 216, 124 );
 	m_loopPingPongButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -645,9 +644,9 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 	p.drawPixmap( 0, 0, *s_artwork );
 
-	AudioFileProcessor * a = castModel<AudioFileProcessor>();
+	auto a = castModel<AudioFileProcessor>();
 
- 	QString file_name = "";
+	QString file_name = "";
 	int idx = a->m_sampleBuffer.audioFile().length();
 
 	p.setFont( pointSize<8>( font() ) );
@@ -702,7 +701,7 @@ void AudioFileProcessorView::openAudioFile()
 
 void AudioFileProcessorView::modelChanged()
 {
-	AudioFileProcessor * a = castModel<AudioFileProcessor>();
+	auto a = castModel<AudioFileProcessor>();
 	connect( &a->m_sampleBuffer, SIGNAL( sampleUpdated() ),
 					this, SLOT( sampleUpdated() ) );
 	m_ampKnob->setModel( &a->m_ampModel );

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -426,9 +426,9 @@ void AudioFileProcessor::loopPointChanged()
 
 void AudioFileProcessor::pointChanged()
 {
-	const f_cnt_t f_start = static_cast<f_cnt_t>( m_startPointModel.value() *	m_sampleBuffer.frames() );
-	const f_cnt_t f_end = static_cast<f_cnt_t>( m_endPointModel.value() * m_sampleBuffer.frames() );
-	const f_cnt_t f_loop = static_cast<f_cnt_t>( m_loopPointModel.value() * m_sampleBuffer.frames() );
+	const auto f_start = static_cast<f_cnt_t>(m_startPointModel.value() * m_sampleBuffer.frames());
+	const auto f_end = static_cast<f_cnt_t>(m_endPointModel.value() * m_sampleBuffer.frames());
+	const auto f_loop = static_cast<f_cnt_t>(m_loopPointModel.value() * m_sampleBuffer.frames());
 
 	m_nextPlayStartPoint = f_start;
 	m_nextPlayBackwards = false;
@@ -479,7 +479,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 
 // loop button group
 
-	PixmapButton * m_loopOffButton = new PixmapButton( this );
+	auto* m_loopOffButton = new PixmapButton(this);
 	m_loopOffButton->setCheckable( true );
 	m_loopOffButton->move( 190, 105 );
 	m_loopOffButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -488,8 +488,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_off_off" ) );
 	m_loopOffButton->setToolTip(tr("Disable loop"));
 
-
-	PixmapButton * m_loopOnButton = new PixmapButton( this );
+	auto* m_loopOnButton = new PixmapButton(this);
 	m_loopOnButton->setCheckable( true );
 	m_loopOnButton->move( 190, 124 );
 	m_loopOnButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -498,7 +497,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 							"loop_on_off" ) );
 	m_loopOnButton->setToolTip(tr("Enable loop"));
 
-	PixmapButton * m_loopPingPongButton = new PixmapButton( this );
+	auto* m_loopPingPongButton = new PixmapButton(this);
 	m_loopPingPongButton->setCheckable( true );
 	m_loopPingPongButton->move( 216, 124 );
 	m_loopPingPongButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
@@ -645,9 +644,9 @@ void AudioFileProcessorView::paintEvent( QPaintEvent * )
 
 	p.drawPixmap( 0, 0, *s_artwork );
 
-	AudioFileProcessor * a = castModel<AudioFileProcessor>();
+	auto* a = castModel<AudioFileProcessor>();
 
- 	QString file_name = "";
+	QString file_name = "";
 	int idx = a->m_sampleBuffer.audioFile().length();
 
 	p.setFont( pointSize<8>( font() ) );
@@ -702,7 +701,7 @@ void AudioFileProcessorView::openAudioFile()
 
 void AudioFileProcessorView::modelChanged()
 {
-	AudioFileProcessor * a = castModel<AudioFileProcessor>();
+	auto* a = castModel<AudioFileProcessor>();
 	connect( &a->m_sampleBuffer, SIGNAL( sampleUpdated() ),
 					this, SLOT( sampleUpdated() ) );
 	m_ampKnob->setModel( &a->m_ampModel );

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -45,10 +45,10 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	setPalette( pal );
 	setFixedSize( 120, 60 );
 
-	auto* tl = new QVBoxLayout(this);
+	QVBoxLayout * tl = new QVBoxLayout( this );
 	tl->addSpacing( 4 );
 
-	auto* l = new QHBoxLayout;
+	QHBoxLayout * l = new QHBoxLayout;
 
 	Knob * freqKnob = new Knob( knobBright_26, this);
 	freqKnob->setModel( &controls->m_freqModel );

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -45,10 +45,10 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	setPalette( pal );
 	setFixedSize( 120, 60 );
 
-	QVBoxLayout * tl = new QVBoxLayout( this );
+	auto* tl = new QVBoxLayout(this);
 	tl->addSpacing( 4 );
 
-	QHBoxLayout * l = new QHBoxLayout;
+	auto* l = new QHBoxLayout;
 
 	Knob * freqKnob = new Knob( knobBright_26, this);
 	freqKnob->setModel( &controls->m_freqModel );

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -45,22 +45,22 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	setPalette( pal );
 	setFixedSize( 120, 60 );
 
-	QVBoxLayout * tl = new QVBoxLayout( this );
+	auto tl = new QVBoxLayout(this);
 	tl->addSpacing( 4 );
 
-	QHBoxLayout * l = new QHBoxLayout;
+	auto l = new QHBoxLayout;
 
-	Knob * freqKnob = new Knob( knobBright_26, this);
+	auto freqKnob = new Knob(knobBright_26, this);
 	freqKnob->setModel( &controls->m_freqModel );
 	freqKnob->setLabel( tr( "FREQ" ) );
 	freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
 
-	Knob * gainKnob = new Knob( knobBright_26, this );
+	auto gainKnob = new Knob(knobBright_26, this);
 	gainKnob->setModel( &controls->m_gainModel );
 	gainKnob->setLabel( tr( "GAIN" ) );
 	gainKnob->setHintText( tr( "Gain:" ) , "" );
 
-	Knob * ratioKnob = new Knob( knobBright_26, this );
+	auto ratioKnob = new Knob(knobBright_26, this);
 	ratioKnob->setModel( &controls->m_ratioModel );
 	ratioKnob->setLabel( tr( "RATIO" ) );
 	ratioKnob->setHintText( tr( "Ratio:" ) , "" );

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -103,10 +103,8 @@ BSynth::~BSynth()
 
 sample_t BSynth::nextStringSample( float sample_length )
 {
-	float sample_step = 
-		static_cast<float>( sample_length / ( sample_rate / nph->frequency() ) );
+	auto sample_step = static_cast<float>(sample_length / (sample_rate / nph->frequency()));
 
-	
 	// check overflow
 	while (sample_realindex >= sample_length) {
 		sample_realindex -= sample_length;
@@ -299,7 +297,7 @@ void BitInvader::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	BSynth * ps = static_cast<BSynth *>( _n->m_pluginData );
+	auto* ps = static_cast<BSynth*>(_n->m_pluginData);
 	for( fpp_t frame = offset; frame < frames + offset; ++frame )
 	{
 		const sample_t cur = ps->nextStringSample( m_graph.length() );
@@ -472,7 +470,7 @@ BitInvaderView::BitInvaderView( Instrument * _instrument,
 
 void BitInvaderView::modelChanged()
 {
-	BitInvader * b = castModel<BitInvader>();
+	auto* b = castModel<BitInvader>();
 
 	m_graph->setModel( &b->m_graph );
 	m_sampleLengthKnob->setModel( &b->m_sampleLength );

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -103,10 +103,8 @@ BSynth::~BSynth()
 
 sample_t BSynth::nextStringSample( float sample_length )
 {
-	float sample_step = 
-		static_cast<float>( sample_length / ( sample_rate / nph->frequency() ) );
+	auto sample_step = static_cast<float>(sample_length / (sample_rate / nph->frequency()));
 
-	
 	// check overflow
 	while (sample_realindex >= sample_length) {
 		sample_realindex -= sample_length;
@@ -299,7 +297,7 @@ void BitInvader::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	BSynth * ps = static_cast<BSynth *>( _n->m_pluginData );
+	auto ps = static_cast<BSynth*>(_n->m_pluginData);
 	for( fpp_t frame = offset; frame < frames + offset; ++frame )
 	{
 		const sample_t cur = ps->nextStringSample( m_graph.length() );
@@ -472,7 +470,7 @@ BitInvaderView::BitInvaderView( Instrument * _instrument,
 
 void BitInvaderView::modelChanged()
 {
-	BitInvader * b = castModel<BitInvader>();
+	auto b = castModel<BitInvader>();
 
 	m_graph->setModel( &b->m_graph );
 	m_sampleLengthKnob->setModel( &b->m_sampleLength );

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -103,8 +103,10 @@ BSynth::~BSynth()
 
 sample_t BSynth::nextStringSample( float sample_length )
 {
-	auto sample_step = static_cast<float>(sample_length / (sample_rate / nph->frequency()));
+	float sample_step = 
+		static_cast<float>( sample_length / ( sample_rate / nph->frequency() ) );
 
+	
 	// check overflow
 	while (sample_realindex >= sample_length) {
 		sample_realindex -= sample_length;
@@ -297,7 +299,7 @@ void BitInvader::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	auto* ps = static_cast<BSynth*>(_n->m_pluginData);
+	BSynth * ps = static_cast<BSynth *>( _n->m_pluginData );
 	for( fpp_t frame = offset; frame < frames + offset; ++frame )
 	{
 		const sample_t cur = ps->nextStringSample( m_graph.length() );
@@ -470,7 +472,7 @@ BitInvaderView::BitInvaderView( Instrument * _instrument,
 
 void BitInvaderView::modelChanged()
 {
-	auto* b = castModel<BitInvader>();
+	BitInvader * b = castModel<BitInvader>();
 
 	m_graph->setModel( &b->m_graph );
 	m_sampleLengthKnob->setModel( &b->m_sampleLength );

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -46,10 +46,10 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	setFixedSize( 181, 128 );
 	
 	// labels
-	auto* inLabel = new QLabel(tr("IN"), this);
+	QLabel * inLabel = new QLabel( tr( "IN" ), this );
 	inLabel->move( 24, 15 );
-
-	auto* outLabel = new QLabel(tr("OUT"), this);
+	
+	QLabel * outLabel = new QLabel( tr( "OUT" ), this );
 	outLabel->move( 139, 15 );
 	
 	// input knobs
@@ -82,12 +82,12 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// leds
-	auto* rateEnabled = new LedCheckBox("", this, tr("Rate enabled"), LedCheckBox::Green);
+	LedCheckBox * rateEnabled = new LedCheckBox( "", this, tr( "Rate enabled" ), LedCheckBox::Green );
 	rateEnabled->move( 64, 14 );
 	rateEnabled->setModel( & controls->m_rateEnabled );
 	rateEnabled->setToolTip(tr("Enable sample-rate crushing"));
-
-	auto* depthEnabled = new LedCheckBox("", this, tr("Depth enabled"), LedCheckBox::Green);
+	
+	LedCheckBox * depthEnabled = new LedCheckBox( "", this, tr( "Depth enabled" ), LedCheckBox::Green );
 	depthEnabled->move( 101, 14 );
 	depthEnabled->setModel( & controls->m_depthEnabled );
 	depthEnabled->setToolTip(tr("Enable bit-depth crushing"));

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -46,10 +46,10 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	setFixedSize( 181, 128 );
 	
 	// labels
-	QLabel * inLabel = new QLabel( tr( "IN" ), this );
+	auto* inLabel = new QLabel(tr("IN"), this);
 	inLabel->move( 24, 15 );
-	
-	QLabel * outLabel = new QLabel( tr( "OUT" ), this );
+
+	auto* outLabel = new QLabel(tr("OUT"), this);
 	outLabel->move( 139, 15 );
 	
 	// input knobs
@@ -82,12 +82,12 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// leds
-	LedCheckBox * rateEnabled = new LedCheckBox( "", this, tr( "Rate enabled" ), LedCheckBox::Green );
+	auto* rateEnabled = new LedCheckBox("", this, tr("Rate enabled"), LedCheckBox::Green);
 	rateEnabled->move( 64, 14 );
 	rateEnabled->setModel( & controls->m_rateEnabled );
 	rateEnabled->setToolTip(tr("Enable sample-rate crushing"));
-	
-	LedCheckBox * depthEnabled = new LedCheckBox( "", this, tr( "Depth enabled" ), LedCheckBox::Green );
+
+	auto* depthEnabled = new LedCheckBox("", this, tr("Depth enabled"), LedCheckBox::Green);
 	depthEnabled->move( 101, 14 );
 	depthEnabled->setModel( & controls->m_depthEnabled );
 	depthEnabled->setToolTip(tr("Enable bit-depth crushing"));

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -46,20 +46,20 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	setFixedSize( 181, 128 );
 	
 	// labels
-	QLabel * inLabel = new QLabel( tr( "IN" ), this );
+	auto inLabel = new QLabel(tr("IN"), this);
 	inLabel->move( 24, 15 );
-	
-	QLabel * outLabel = new QLabel( tr( "OUT" ), this );
+
+	auto outLabel = new QLabel(tr("OUT"), this);
 	outLabel->move( 139, 15 );
 	
 	// input knobs
-	Knob * inGain = new Knob( knobBright_26, this );
+	auto inGain = new Knob(knobBright_26, this);
 	inGain->move( 16, 32 );
 	inGain->setModel( & controls->m_inGain );
 	inGain->setLabel( tr( "GAIN" ) );
 	inGain->setHintText( tr( "Input gain:" ) , " dBFS" );
-	
-	Knob * inNoise = new Knob( knobBright_26, this );
+
+	auto inNoise = new Knob(knobBright_26, this);
 	inNoise->move( 14, 76 );
 	inNoise->setModel( & controls->m_inNoise );
 	inNoise->setLabel( tr( "NOISE" ) );
@@ -67,13 +67,13 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// output knobs
-	Knob * outGain = new Knob( knobBright_26, this );
+	auto outGain = new Knob(knobBright_26, this);
 	outGain->move( 138, 32 );
 	outGain->setModel( & controls->m_outGain );
 	outGain->setLabel( tr( "GAIN" ) );
 	outGain->setHintText( tr( "Output gain:" ) , " dBFS" );
-	
-	Knob * outClip = new Knob( knobBright_26, this );
+
+	auto outClip = new Knob(knobBright_26, this);
 	outClip->move( 138, 76 );
 	outClip->setModel( & controls->m_outClip );
 	outClip->setLabel( tr( "CLIP" ) );
@@ -82,25 +82,25 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// leds
-	LedCheckBox * rateEnabled = new LedCheckBox( "", this, tr( "Rate enabled" ), LedCheckBox::Green );
+	auto rateEnabled = new LedCheckBox("", this, tr("Rate enabled"), LedCheckBox::Green);
 	rateEnabled->move( 64, 14 );
 	rateEnabled->setModel( & controls->m_rateEnabled );
 	rateEnabled->setToolTip(tr("Enable sample-rate crushing"));
-	
-	LedCheckBox * depthEnabled = new LedCheckBox( "", this, tr( "Depth enabled" ), LedCheckBox::Green );
+
+	auto depthEnabled = new LedCheckBox("", this, tr("Depth enabled"), LedCheckBox::Green);
 	depthEnabled->move( 101, 14 );
 	depthEnabled->setModel( & controls->m_depthEnabled );
 	depthEnabled->setToolTip(tr("Enable bit-depth crushing"));
 	
 	
 	// rate crushing knobs
-	Knob * rate = new Knob( knobBright_26, this );
+	auto rate = new Knob(knobBright_26, this);
 	rate->move( 59, 32 );
 	rate->setModel( & controls->m_rate );
 	rate->setLabel( tr( "FREQ" ) );
 	rate->setHintText( tr( "Sample rate:" ) , " Hz" );
-	
-	Knob * stereoDiff = new Knob( knobBright_26, this );
+
+	auto stereoDiff = new Knob(knobBright_26, this);
 	stereoDiff->move( 72, 76 );
 	stereoDiff->setModel( & controls->m_stereoDiff );
 	stereoDiff->setLabel( tr( "STEREO" ) );
@@ -108,7 +108,7 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// depth crushing knob
-	Knob * levels = new Knob( knobBright_26, this );
+	auto levels = new Knob(knobBright_26, this);
 	levels->move( 92, 32 );
 	levels->setModel( & controls->m_levels );
 	levels->setLabel( tr( "QUANT" ) );

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -194,8 +194,8 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
         fDescriptor->activate(fHandle);
 
     // we need a play-handle which cares for calling play()
-    InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, instrumentTrack );
-    Engine::audioEngine()->addPlayHandle( iph );
+	auto iph = new InstrumentPlayHandle(this, instrumentTrack);
+	Engine::audioEngine()->addPlayHandle( iph );
 
 #if CARLA_VERSION_HEX >= CARLA_MIN_PARAM_VERSION
     // text filter completion
@@ -625,8 +625,8 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     pal.setBrush(backgroundRole(), instrument->kIsPatchbay ? PLUGIN_NAME::getIconPixmap("artwork-patchbay") : PLUGIN_NAME::getIconPixmap("artwork-rack"));
     setPalette(pal);
 
-    QHBoxLayout* l = new QHBoxLayout(this);
-    l->setContentsMargins( 20, 180, 10, 10 );
+	auto l = new QHBoxLayout(this);
+	l->setContentsMargins( 20, 180, 10, 10 );
     l->setSpacing(3);
     l->setAlignment(Qt::AlignTop);
 
@@ -750,8 +750,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_curOutColumn(0),
 	m_curOutRow(0)
 {
-	QWidget* centralWidget = new QWidget(this);
-	QVBoxLayout* verticalLayout = new QVBoxLayout(centralWidget);
+	auto centralWidget = new QWidget(this);
+	auto verticalLayout = new QVBoxLayout(centralWidget);
 
 	// -- Toolbar
 	m_toolBarLayout = new QHBoxLayout();
@@ -794,9 +794,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_toolBarLayout->addWidget(m_groupFilterCombo);
 
 	// -- Input params
-	QFrame* inputFrame = new QFrame(this);
-	QVBoxLayout* inputLayout = new QVBoxLayout(inputFrame);
-	QLabel* inputLabel = new QLabel("Input parameters", inputFrame);
+	auto inputFrame = new QFrame(this);
+	auto inputLayout = new QVBoxLayout(inputFrame);
+	auto inputLabel = new QLabel("Input parameters", inputFrame);
 
 	m_inputScrollArea = new QScrollArea(inputFrame);
 	m_inputScrollAreaWidgetContent = new QWidget();
@@ -820,9 +820,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	inputLayout->addWidget(m_inputScrollArea);
 
 	// -- Output params
-	QFrame* outputFrame = new QFrame(this);
-	QVBoxLayout* outputLayout = new QVBoxLayout(outputFrame);
-	QLabel* outputLabel = new QLabel("Output parameters", outputFrame);
+	auto outputFrame = new QFrame(this);
+	auto outputLayout = new QVBoxLayout(outputFrame);
+	auto outputLabel = new QLabel("Output parameters", outputFrame);
 
 	m_outputScrollArea = new QScrollArea(outputFrame);
 	m_outputScrollAreaWidgetContent = new QWidget();
@@ -846,7 +846,7 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	outputLayout->addWidget(m_outputScrollArea);
 
 	// -- QSplitter
-	QSplitter* splitter = new QSplitter(Qt::Vertical, this);
+	auto splitter = new QSplitter(Qt::Vertical, this);
 
 	// -- Add layout and widgets.
 	verticalLayout->addLayout(m_toolBarLayout);
@@ -866,8 +866,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 #endif
 
 	// -- Sub window
-	CarlaParamsSubWindow* win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(), Qt::SubWindow |
-		Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
+	auto win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(),
+		Qt::SubWindow | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 	m_carlaInstrumentView->m_paramsSubWindow = getGUI()->mainWindow()->workspace()->addSubWindow(win);
 	m_carlaInstrumentView->m_paramsSubWindow->setSizePolicy(
 		QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -976,7 +976,7 @@ void CarlaParamsView::filterKnobs()
 	}
 
 	// Add spacer so all knobs go to top
-	QSpacerItem* verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
+	auto verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
 	m_inputScrollAreaLayout->addItem(verticalSpacer, m_curRow+1, 0, 1, 1);
 }
 

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -194,8 +194,8 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
         fDescriptor->activate(fHandle);
 
     // we need a play-handle which cares for calling play()
-	auto* iph = new InstrumentPlayHandle(this, instrumentTrack);
-	Engine::audioEngine()->addPlayHandle( iph );
+    InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, instrumentTrack );
+    Engine::audioEngine()->addPlayHandle( iph );
 
 #if CARLA_VERSION_HEX >= CARLA_MIN_PARAM_VERSION
     // text filter completion
@@ -625,8 +625,8 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     pal.setBrush(backgroundRole(), instrument->kIsPatchbay ? PLUGIN_NAME::getIconPixmap("artwork-patchbay") : PLUGIN_NAME::getIconPixmap("artwork-rack"));
     setPalette(pal);
 
-	auto* l = new QHBoxLayout(this);
-	l->setContentsMargins( 20, 180, 10, 10 );
+    QHBoxLayout* l = new QHBoxLayout(this);
+    l->setContentsMargins( 20, 180, 10, 10 );
     l->setSpacing(3);
     l->setAlignment(Qt::AlignTop);
 
@@ -750,8 +750,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_curOutColumn(0),
 	m_curOutRow(0)
 {
-	auto* centralWidget = new QWidget(this);
-	auto* verticalLayout = new QVBoxLayout(centralWidget);
+	QWidget* centralWidget = new QWidget(this);
+	QVBoxLayout* verticalLayout = new QVBoxLayout(centralWidget);
 
 	// -- Toolbar
 	m_toolBarLayout = new QHBoxLayout();
@@ -794,9 +794,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_toolBarLayout->addWidget(m_groupFilterCombo);
 
 	// -- Input params
-	auto* inputFrame = new QFrame(this);
-	auto* inputLayout = new QVBoxLayout(inputFrame);
-	auto* inputLabel = new QLabel("Input parameters", inputFrame);
+	QFrame* inputFrame = new QFrame(this);
+	QVBoxLayout* inputLayout = new QVBoxLayout(inputFrame);
+	QLabel* inputLabel = new QLabel("Input parameters", inputFrame);
 
 	m_inputScrollArea = new QScrollArea(inputFrame);
 	m_inputScrollAreaWidgetContent = new QWidget();
@@ -820,9 +820,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	inputLayout->addWidget(m_inputScrollArea);
 
 	// -- Output params
-	auto* outputFrame = new QFrame(this);
-	auto* outputLayout = new QVBoxLayout(outputFrame);
-	auto* outputLabel = new QLabel("Output parameters", outputFrame);
+	QFrame* outputFrame = new QFrame(this);
+	QVBoxLayout* outputLayout = new QVBoxLayout(outputFrame);
+	QLabel* outputLabel = new QLabel("Output parameters", outputFrame);
 
 	m_outputScrollArea = new QScrollArea(outputFrame);
 	m_outputScrollAreaWidgetContent = new QWidget();
@@ -846,7 +846,7 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	outputLayout->addWidget(m_outputScrollArea);
 
 	// -- QSplitter
-	auto* splitter = new QSplitter(Qt::Vertical, this);
+	QSplitter* splitter = new QSplitter(Qt::Vertical, this);
 
 	// -- Add layout and widgets.
 	verticalLayout->addLayout(m_toolBarLayout);
@@ -866,8 +866,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 #endif
 
 	// -- Sub window
-	auto* win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(),
-		Qt::SubWindow | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
+	CarlaParamsSubWindow* win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(), Qt::SubWindow |
+		Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 	m_carlaInstrumentView->m_paramsSubWindow = getGUI()->mainWindow()->workspace()->addSubWindow(win);
 	m_carlaInstrumentView->m_paramsSubWindow->setSizePolicy(
 		QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -976,7 +976,7 @@ void CarlaParamsView::filterKnobs()
 	}
 
 	// Add spacer so all knobs go to top
-	auto* verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
+	QSpacerItem* verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
 	m_inputScrollAreaLayout->addItem(verticalSpacer, m_curRow+1, 0, 1, 1);
 }
 

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -194,8 +194,8 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
         fDescriptor->activate(fHandle);
 
     // we need a play-handle which cares for calling play()
-    InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, instrumentTrack );
-    Engine::audioEngine()->addPlayHandle( iph );
+	auto* iph = new InstrumentPlayHandle(this, instrumentTrack);
+	Engine::audioEngine()->addPlayHandle( iph );
 
 #if CARLA_VERSION_HEX >= CARLA_MIN_PARAM_VERSION
     // text filter completion
@@ -625,8 +625,8 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     pal.setBrush(backgroundRole(), instrument->kIsPatchbay ? PLUGIN_NAME::getIconPixmap("artwork-patchbay") : PLUGIN_NAME::getIconPixmap("artwork-rack"));
     setPalette(pal);
 
-    QHBoxLayout* l = new QHBoxLayout(this);
-    l->setContentsMargins( 20, 180, 10, 10 );
+	auto* l = new QHBoxLayout(this);
+	l->setContentsMargins( 20, 180, 10, 10 );
     l->setSpacing(3);
     l->setAlignment(Qt::AlignTop);
 
@@ -750,8 +750,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_curOutColumn(0),
 	m_curOutRow(0)
 {
-	QWidget* centralWidget = new QWidget(this);
-	QVBoxLayout* verticalLayout = new QVBoxLayout(centralWidget);
+	auto* centralWidget = new QWidget(this);
+	auto* verticalLayout = new QVBoxLayout(centralWidget);
 
 	// -- Toolbar
 	m_toolBarLayout = new QHBoxLayout();
@@ -794,9 +794,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	m_toolBarLayout->addWidget(m_groupFilterCombo);
 
 	// -- Input params
-	QFrame* inputFrame = new QFrame(this);
-	QVBoxLayout* inputLayout = new QVBoxLayout(inputFrame);
-	QLabel* inputLabel = new QLabel("Input parameters", inputFrame);
+	auto* inputFrame = new QFrame(this);
+	auto* inputLayout = new QVBoxLayout(inputFrame);
+	auto* inputLabel = new QLabel("Input parameters", inputFrame);
 
 	m_inputScrollArea = new QScrollArea(inputFrame);
 	m_inputScrollAreaWidgetContent = new QWidget();
@@ -820,9 +820,9 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	inputLayout->addWidget(m_inputScrollArea);
 
 	// -- Output params
-	QFrame* outputFrame = new QFrame(this);
-	QVBoxLayout* outputLayout = new QVBoxLayout(outputFrame);
-	QLabel* outputLabel = new QLabel("Output parameters", outputFrame);
+	auto* outputFrame = new QFrame(this);
+	auto* outputLayout = new QVBoxLayout(outputFrame);
+	auto* outputLabel = new QLabel("Output parameters", outputFrame);
 
 	m_outputScrollArea = new QScrollArea(outputFrame);
 	m_outputScrollAreaWidgetContent = new QWidget();
@@ -846,7 +846,7 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 	outputLayout->addWidget(m_outputScrollArea);
 
 	// -- QSplitter
-	QSplitter* splitter = new QSplitter(Qt::Vertical, this);
+	auto* splitter = new QSplitter(Qt::Vertical, this);
 
 	// -- Add layout and widgets.
 	verticalLayout->addLayout(m_toolBarLayout);
@@ -866,8 +866,8 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 #endif
 
 	// -- Sub window
-	CarlaParamsSubWindow* win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(), Qt::SubWindow |
-		Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
+	auto* win = new CarlaParamsSubWindow(getGUI()->mainWindow()->workspace()->viewport(),
+		Qt::SubWindow | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
 	m_carlaInstrumentView->m_paramsSubWindow = getGUI()->mainWindow()->workspace()->addSubWindow(win);
 	m_carlaInstrumentView->m_paramsSubWindow->setSizePolicy(
 		QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -976,7 +976,7 @@ void CarlaParamsView::filterKnobs()
 	}
 
 	// Add spacer so all knobs go to top
-	QSpacerItem* verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
+	auto* verticalSpacer = new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding);
 	m_inputScrollAreaLayout->addItem(verticalSpacer, m_curRow+1, 0, 1, 1);
 }
 

--- a/plugins/CarlaBase/DummyCarla.cpp
+++ b/plugins/CarlaBase/DummyCarla.cpp
@@ -4,11 +4,7 @@
 
 CARLA_EXPORT const char* carla_get_library_filename() { return nullptr; }
 CARLA_EXPORT const char* carla_get_library_folder() { return nullptr; }
-CARLA_EXPORT const NativePluginDescriptor;
-*carla_get_native_rack_plugin()
-{
-	return nullptr;
-}
+CARLA_EXPORT const NativePluginDescriptor* carla_get_native_rack_plugin() { return nullptr; }
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay_plugin() { return nullptr; }
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay16_plugin() { return nullptr; }
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay32_plugin() { return nullptr; }

--- a/plugins/CarlaBase/DummyCarla.cpp
+++ b/plugins/CarlaBase/DummyCarla.cpp
@@ -4,7 +4,11 @@
 
 CARLA_EXPORT const char* carla_get_library_filename() { return nullptr; }
 CARLA_EXPORT const char* carla_get_library_folder() { return nullptr; }
-CARLA_EXPORT const NativePluginDescriptor* carla_get_native_rack_plugin() { return nullptr; }
+CARLA_EXPORT const NativePluginDescriptor;
+*carla_get_native_rack_plugin()
+{
+	return nullptr;
+}
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay_plugin() { return nullptr; }
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay16_plugin() { return nullptr; }
 CARLA_EXPORT const NativePluginDescriptor* carla_get_native_patchbay32_plugin() { return nullptr; }

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -69,47 +69,43 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	m_fader_knob = QPixmap( PLUGIN_NAME::getIconPixmap( "fader_knob2" ) );
 	
 	// faders
-	Fader * gain1 = new Fader( &controls->m_gain1, tr( "Band 1 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+	auto* gain1 = new Fader(&controls->m_gain1, tr("Band 1 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain1->move( 7, 56 );
 	gain1->setDisplayConversion( false );
 	gain1->setHintText( tr( "Band 1 gain:" ), " dBFS" );
-	
-	Fader * gain2 = new Fader( &controls->m_gain2, tr( "Band 2 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto* gain2 = new Fader(&controls->m_gain2, tr("Band 2 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain2->move( 47, 56 );
 	gain2->setDisplayConversion( false );
 	gain2->setHintText( tr( "Band 2 gain:" ), " dBFS" );
-	
-	Fader * gain3 = new Fader( &controls->m_gain3, tr( "Band 3 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto* gain3 = new Fader(&controls->m_gain3, tr("Band 3 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain3->move( 87, 56 );
 	gain3->setDisplayConversion( false );
 	gain3->setHintText( tr( "Band 3 gain:" ), " dBFS" );
-	
-	Fader * gain4 = new Fader( &controls->m_gain4, tr( "Band 4 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto* gain4 = new Fader(&controls->m_gain4, tr("Band 4 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain4->move( 127, 56 );
 	gain4->setDisplayConversion( false );
 	gain4->setHintText( tr( "Band 4 gain:" ), " dBFS" );
 	
 	// leds
-	LedCheckBox * mute1 = new LedCheckBox( "", this, tr( "Band 1 mute" ), LedCheckBox::Green );
+	auto* mute1 = new LedCheckBox("", this, tr("Band 1 mute"), LedCheckBox::Green);
 	mute1->move( 15, 154 );
 	mute1->setModel( & controls->m_mute1 );
 	mute1->setToolTip(tr("Mute band 1"));
-	
-	LedCheckBox * mute2 = new LedCheckBox( "", this, tr( "Band 2 mute" ), LedCheckBox::Green );
+
+	auto* mute2 = new LedCheckBox("", this, tr("Band 2 mute"), LedCheckBox::Green);
 	mute2->move( 55, 154 );
 	mute2->setModel( & controls->m_mute2 );
 	mute2->setToolTip(tr("Mute band 2"));
-	
-	LedCheckBox * mute3 = new LedCheckBox( "", this, tr( "Band 3 mute" ), LedCheckBox::Green );
+
+	auto* mute3 = new LedCheckBox("", this, tr("Band 3 mute"), LedCheckBox::Green);
 	mute3->move( 95, 154 );
 	mute3->setModel( & controls->m_mute3 );
 	mute3->setToolTip(tr("Mute band 3"));
-	
-	LedCheckBox * mute4 = new LedCheckBox( "", this, tr( "Band 4 mute" ), LedCheckBox::Green );
+
+	auto* mute4 = new LedCheckBox("", this, tr("Band 4 mute"), LedCheckBox::Green);
 	mute4->move( 135, 154 );
 	mute4->setModel( & controls->m_mute4 );
 	mute4->setToolTip(tr("Mute band 4"));

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -46,19 +46,19 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	setFixedSize( 167, 178 );
 	
 	// knobs
-	Knob * xover12 = new Knob( knobBright_26, this );
+	auto xover12 = new Knob(knobBright_26, this);
 	xover12->move( 29, 11 );
 	xover12->setModel( & controls->m_xover12 );
 	xover12->setLabel( "1/2" );
 	xover12->setHintText( tr( "Band 1/2 crossover:" ), " Hz" );
-	
-	Knob * xover23 = new Knob( knobBright_26, this );
+
+	auto xover23 = new Knob(knobBright_26, this);
 	xover23->move( 69, 11 );
 	xover23->setModel( & controls->m_xover23 );
 	xover23->setLabel( "2/3" );
 	xover23->setHintText( tr( "Band 2/3 crossover:" ), " Hz" );
-	
-	Knob * xover34 = new Knob( knobBright_26, this );
+
+	auto xover34 = new Knob(knobBright_26, this);
 	xover34->move( 109, 11 );
 	xover34->setModel( & controls->m_xover34 );
 	xover34->setLabel( "3/4" );
@@ -69,47 +69,43 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	m_fader_knob = QPixmap( PLUGIN_NAME::getIconPixmap( "fader_knob2" ) );
 	
 	// faders
-	Fader * gain1 = new Fader( &controls->m_gain1, tr( "Band 1 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+	auto gain1 = new Fader(&controls->m_gain1, tr("Band 1 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain1->move( 7, 56 );
 	gain1->setDisplayConversion( false );
 	gain1->setHintText( tr( "Band 1 gain:" ), " dBFS" );
-	
-	Fader * gain2 = new Fader( &controls->m_gain2, tr( "Band 2 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto gain2 = new Fader(&controls->m_gain2, tr("Band 2 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain2->move( 47, 56 );
 	gain2->setDisplayConversion( false );
 	gain2->setHintText( tr( "Band 2 gain:" ), " dBFS" );
-	
-	Fader * gain3 = new Fader( &controls->m_gain3, tr( "Band 3 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto gain3 = new Fader(&controls->m_gain3, tr("Band 3 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain3->move( 87, 56 );
 	gain3->setDisplayConversion( false );
 	gain3->setHintText( tr( "Band 3 gain:" ), " dBFS" );
-	
-	Fader * gain4 = new Fader( &controls->m_gain4, tr( "Band 4 gain" ), this,
-		&m_fader_bg, &m_fader_empty, &m_fader_knob );
+
+	auto gain4 = new Fader(&controls->m_gain4, tr("Band 4 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
 	gain4->move( 127, 56 );
 	gain4->setDisplayConversion( false );
 	gain4->setHintText( tr( "Band 4 gain:" ), " dBFS" );
 	
 	// leds
-	LedCheckBox * mute1 = new LedCheckBox( "", this, tr( "Band 1 mute" ), LedCheckBox::Green );
+	auto mute1 = new LedCheckBox("", this, tr("Band 1 mute"), LedCheckBox::Green);
 	mute1->move( 15, 154 );
 	mute1->setModel( & controls->m_mute1 );
 	mute1->setToolTip(tr("Mute band 1"));
-	
-	LedCheckBox * mute2 = new LedCheckBox( "", this, tr( "Band 2 mute" ), LedCheckBox::Green );
+
+	auto mute2 = new LedCheckBox("", this, tr("Band 2 mute"), LedCheckBox::Green);
 	mute2->move( 55, 154 );
 	mute2->setModel( & controls->m_mute2 );
 	mute2->setToolTip(tr("Mute band 2"));
-	
-	LedCheckBox * mute3 = new LedCheckBox( "", this, tr( "Band 3 mute" ), LedCheckBox::Green );
+
+	auto mute3 = new LedCheckBox("", this, tr("Band 3 mute"), LedCheckBox::Green);
 	mute3->move( 95, 154 );
 	mute3->setModel( & controls->m_mute3 );
 	mute3->setToolTip(tr("Mute band 3"));
-	
-	LedCheckBox * mute4 = new LedCheckBox( "", this, tr( "Band 4 mute" ), LedCheckBox::Green );
+
+	auto mute4 = new LedCheckBox("", this, tr("Band 4 mute"), LedCheckBox::Green);
 	mute4->move( 135, 154 );
 	mute4->setModel( & controls->m_mute4 );
 	mute4->setToolTip(tr("Mute band 4"));

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -69,43 +69,47 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	m_fader_knob = QPixmap( PLUGIN_NAME::getIconPixmap( "fader_knob2" ) );
 	
 	// faders
-	auto* gain1 = new Fader(&controls->m_gain1, tr("Band 1 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
+	Fader * gain1 = new Fader( &controls->m_gain1, tr( "Band 1 gain" ), this,
+		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain1->move( 7, 56 );
 	gain1->setDisplayConversion( false );
 	gain1->setHintText( tr( "Band 1 gain:" ), " dBFS" );
-
-	auto* gain2 = new Fader(&controls->m_gain2, tr("Band 2 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
+	
+	Fader * gain2 = new Fader( &controls->m_gain2, tr( "Band 2 gain" ), this,
+		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain2->move( 47, 56 );
 	gain2->setDisplayConversion( false );
 	gain2->setHintText( tr( "Band 2 gain:" ), " dBFS" );
-
-	auto* gain3 = new Fader(&controls->m_gain3, tr("Band 3 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
+	
+	Fader * gain3 = new Fader( &controls->m_gain3, tr( "Band 3 gain" ), this,
+		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain3->move( 87, 56 );
 	gain3->setDisplayConversion( false );
 	gain3->setHintText( tr( "Band 3 gain:" ), " dBFS" );
-
-	auto* gain4 = new Fader(&controls->m_gain4, tr("Band 4 gain"), this, &m_fader_bg, &m_fader_empty, &m_fader_knob);
+	
+	Fader * gain4 = new Fader( &controls->m_gain4, tr( "Band 4 gain" ), this,
+		&m_fader_bg, &m_fader_empty, &m_fader_knob );
 	gain4->move( 127, 56 );
 	gain4->setDisplayConversion( false );
 	gain4->setHintText( tr( "Band 4 gain:" ), " dBFS" );
 	
 	// leds
-	auto* mute1 = new LedCheckBox("", this, tr("Band 1 mute"), LedCheckBox::Green);
+	LedCheckBox * mute1 = new LedCheckBox( "", this, tr( "Band 1 mute" ), LedCheckBox::Green );
 	mute1->move( 15, 154 );
 	mute1->setModel( & controls->m_mute1 );
 	mute1->setToolTip(tr("Mute band 1"));
-
-	auto* mute2 = new LedCheckBox("", this, tr("Band 2 mute"), LedCheckBox::Green);
+	
+	LedCheckBox * mute2 = new LedCheckBox( "", this, tr( "Band 2 mute" ), LedCheckBox::Green );
 	mute2->move( 55, 154 );
 	mute2->setModel( & controls->m_mute2 );
 	mute2->setToolTip(tr("Mute band 2"));
-
-	auto* mute3 = new LedCheckBox("", this, tr("Band 3 mute"), LedCheckBox::Green);
+	
+	LedCheckBox * mute3 = new LedCheckBox( "", this, tr( "Band 3 mute" ), LedCheckBox::Green );
 	mute3->move( 95, 154 );
 	mute3->setModel( & controls->m_mute3 );
 	mute3->setToolTip(tr("Mute band 3"));
-
-	auto* mute4 = new LedCheckBox("", this, tr("Band 4 mute"), LedCheckBox::Green);
+	
+	LedCheckBox * mute4 = new LedCheckBox( "", this, tr( "Band 4 mute" ), LedCheckBox::Green );
 	mute4->move( 135, 154 );
 	mute4->setModel( & controls->m_mute4 );
 	mute4->setToolTip(tr("Mute band 4"));

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -44,42 +44,42 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 300, 208 );
 
-	TempoSyncKnob* sampleDelayKnob = new TempoSyncKnob( knobBright_26, this );
+	auto sampleDelayKnob = new TempoSyncKnob(knobBright_26, this);
 	sampleDelayKnob->move( 10,14 );
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
 	sampleDelayKnob->setLabel( tr( "DELAY" ) );
 	sampleDelayKnob->setHintText( tr( "Delay time" ) + " ", " s" );
 
-	Knob * feedbackKnob = new Knob( knobBright_26, this );
+	auto feedbackKnob = new Knob(knobBright_26, this);
 	feedbackKnob->move( 11, 58 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel);
 	feedbackKnob->setLabel( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
 
-	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	auto lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
 
-	TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
+	auto lfoAmtKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
 	lfoAmtKnob->setLabel( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
 
-	EqFader * outFader = new EqFader( &controls->m_outGainModel,tr( "Out gain" ),
-									  this, &controls->m_outPeakL, &controls->m_outPeakR );
+	auto outFader
+		= new EqFader(&controls->m_outGainModel, tr("Out gain"), this, &controls->m_outPeakL, &controls->m_outPeakR);
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 45 );
 	outFader->setDisplayConversion( false );
 	outFader->setHintText( tr( "Gain" ), "dBFS" );
 
-	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
+	auto pad = new XyPad(this, &controls->m_feedbackModel, &controls->m_delayTimeModel);
 	pad->resize( 200, 200 );
 	pad->move( 50, 5 );
 }

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -44,7 +44,7 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 300, 208 );
 
-	auto* sampleDelayKnob = new TempoSyncKnob(knobBright_26, this);
+	TempoSyncKnob* sampleDelayKnob = new TempoSyncKnob( knobBright_26, this );
 	sampleDelayKnob->move( 10,14 );
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
@@ -58,28 +58,28 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	feedbackKnob->setLabel( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
 
-	auto* lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
+	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
 
-	auto* lfoAmtKnob = new TempoSyncKnob(knobBright_26, this);
+	TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
 	lfoAmtKnob->setLabel( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
 
-	auto* outFader
-		= new EqFader(&controls->m_outGainModel, tr("Out gain"), this, &controls->m_outPeakL, &controls->m_outPeakR);
+	EqFader * outFader = new EqFader( &controls->m_outGainModel,tr( "Out gain" ),
+									  this, &controls->m_outPeakL, &controls->m_outPeakR );
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 45 );
 	outFader->setDisplayConversion( false );
 	outFader->setHintText( tr( "Gain" ), "dBFS" );
 
-	auto* pad = new XyPad(this, &controls->m_feedbackModel, &controls->m_delayTimeModel);
+	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
 	pad->resize( 200, 200 );
 	pad->move( 50, 5 );
 }

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -44,7 +44,7 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 300, 208 );
 
-	TempoSyncKnob* sampleDelayKnob = new TempoSyncKnob( knobBright_26, this );
+	auto* sampleDelayKnob = new TempoSyncKnob(knobBright_26, this);
 	sampleDelayKnob->move( 10,14 );
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
@@ -58,28 +58,28 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	feedbackKnob->setLabel( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
 
-	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	auto* lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
 
-	TempoSyncKnob * lfoAmtKnob = new TempoSyncKnob( knobBright_26, this );
+	auto* lfoAmtKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
 	lfoAmtKnob->setLabel( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
 
-	EqFader * outFader = new EqFader( &controls->m_outGainModel,tr( "Out gain" ),
-									  this, &controls->m_outPeakL, &controls->m_outPeakR );
+	auto* outFader
+		= new EqFader(&controls->m_outGainModel, tr("Out gain"), this, &controls->m_outPeakL, &controls->m_outPeakR);
 	outFader->setMaximumHeight( 196 );
 	outFader->move( 263, 45 );
 	outFader->setDisplayConversion( false );
 	outFader->setHintText( tr( "Gain" ), "dBFS" );
 
-	XyPad * pad = new XyPad( this, &controls->m_feedbackModel, &controls->m_delayTimeModel );
+	auto* pad = new XyPad(this, &controls->m_feedbackModel, &controls->m_delayTimeModel);
 	pad->resize( 200, 200 );
 	pad->move( 50, 5 );
 }

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -64,10 +64,8 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	gain1Knob-> setVolumeKnob( true );
 	gain2Knob-> setVolumeKnob( true );
 
-	LedCheckBox * enabled1Toggle = new LedCheckBox( "", this,
-				tr( "Filter 1 enabled" ), LedCheckBox::Green );
-	LedCheckBox * enabled2Toggle = new LedCheckBox( "", this,
-				tr( "Filter 2 enabled" ), LedCheckBox::Green );
+	auto enabled1Toggle = new LedCheckBox("", this, tr("Filter 1 enabled"), LedCheckBox::Green);
+	auto enabled2Toggle = new LedCheckBox("", this, tr("Filter 2 enabled"), LedCheckBox::Green);
 
 	enabled1Toggle -> move( 12, 11 );
 	enabled1Toggle -> setModel( &controls -> m_enabled1Model );
@@ -76,12 +74,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	enabled2Toggle -> setModel( &controls -> m_enabled2Model );
 	enabled2Toggle->setToolTip(tr("Enable/disable filter 2"));
 
-	ComboBox * m_filter1ComboBox = new ComboBox( this );
+	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
-	ComboBox * m_filter2ComboBox = new ComboBox( this );
+	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -64,8 +64,10 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	gain1Knob-> setVolumeKnob( true );
 	gain2Knob-> setVolumeKnob( true );
 
-	auto* enabled1Toggle = new LedCheckBox("", this, tr("Filter 1 enabled"), LedCheckBox::Green);
-	auto* enabled2Toggle = new LedCheckBox("", this, tr("Filter 2 enabled"), LedCheckBox::Green);
+	LedCheckBox * enabled1Toggle = new LedCheckBox( "", this,
+				tr( "Filter 1 enabled" ), LedCheckBox::Green );
+	LedCheckBox * enabled2Toggle = new LedCheckBox( "", this,
+				tr( "Filter 2 enabled" ), LedCheckBox::Green );
 
 	enabled1Toggle -> move( 12, 11 );
 	enabled1Toggle -> setModel( &controls -> m_enabled1Model );
@@ -74,12 +76,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	enabled2Toggle -> setModel( &controls -> m_enabled2Model );
 	enabled2Toggle->setToolTip(tr("Enable/disable filter 2"));
 
-	auto* m_filter1ComboBox = new ComboBox(this);
+	ComboBox * m_filter1ComboBox = new ComboBox( this );
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
-	auto* m_filter2ComboBox = new ComboBox(this);
+	ComboBox * m_filter2ComboBox = new ComboBox( this );
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -64,10 +64,8 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	gain1Knob-> setVolumeKnob( true );
 	gain2Knob-> setVolumeKnob( true );
 
-	LedCheckBox * enabled1Toggle = new LedCheckBox( "", this,
-				tr( "Filter 1 enabled" ), LedCheckBox::Green );
-	LedCheckBox * enabled2Toggle = new LedCheckBox( "", this,
-				tr( "Filter 2 enabled" ), LedCheckBox::Green );
+	auto* enabled1Toggle = new LedCheckBox("", this, tr("Filter 1 enabled"), LedCheckBox::Green);
+	auto* enabled2Toggle = new LedCheckBox("", this, tr("Filter 2 enabled"), LedCheckBox::Green);
 
 	enabled1Toggle -> move( 12, 11 );
 	enabled1Toggle -> setModel( &controls -> m_enabled1Model );
@@ -76,12 +74,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 	enabled2Toggle -> setModel( &controls -> m_enabled2Model );
 	enabled2Toggle->setToolTip(tr("Enable/disable filter 2"));
 
-	ComboBox * m_filter1ComboBox = new ComboBox( this );
+	auto* m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
-	ComboBox * m_filter2ComboBox = new ComboBox( this );
+	auto* m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
 	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -47,7 +47,7 @@ DynProcControlDialog::DynProcControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 319 );
 
-	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
+	auto waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -58,7 +58,7 @@ DynProcControlDialog::DynProcControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	Knob * inputKnob = new Knob( knobBright_26, this);
+	auto inputKnob = new Knob(knobBright_26, this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 223 );
@@ -66,21 +66,21 @@ DynProcControlDialog::DynProcControlDialog(
 	inputKnob->setLabel( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	Knob * outputKnob = new Knob( knobBright_26, this );
+	auto outputKnob = new Knob(knobBright_26, this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 223 );
 	outputKnob->setModel( &_controls->m_outputModel );
 	outputKnob->setLabel( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ) , "" );
-	
-	Knob * attackKnob = new Knob( knobBright_26, this);
+
+	auto attackKnob = new Knob(knobBright_26, this);
 	attackKnob -> move( 24, 268 );
 	attackKnob->setModel( &_controls->m_attackModel );
 	attackKnob->setLabel( tr( "ATTACK" ) );
 	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
 
-	Knob * releaseKnob = new Knob( knobBright_26, this );
+	auto releaseKnob = new Knob(knobBright_26, this);
 	releaseKnob -> move( 74, 268 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
 	releaseKnob->setLabel( tr( "RELEASE" ) );
@@ -88,28 +88,28 @@ DynProcControlDialog::DynProcControlDialog(
 
 //wavegraph control buttons
 
-	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
+	auto resetButton = new PixmapButton(this, tr("Reset wavegraph"));
 	resetButton -> move( 162, 223 );
 	resetButton -> resize( 13, 48 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
+	auto smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
 	smoothButton -> move( 162, 239 );
 	smoothButton -> resize( 13, 48 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
+	auto addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
 	addOneButton -> move( 131, 223 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
+	auto subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
 	subOneButton -> move( 131, 239 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
@@ -117,28 +117,28 @@ DynProcControlDialog::DynProcControlDialog(
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
 //stereomode switches
-	PixmapButton * smMaxButton = new PixmapButton( this, tr( "Stereo mode: maximum" ) );
+	auto smMaxButton = new PixmapButton(this, tr("Stereo mode: maximum"));
 	smMaxButton -> move( 131, 257 );
 	smMaxButton -> resize( 78, 17 );
 	smMaxButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "max_active" ) );
 	smMaxButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "max_inactive" ) );
 	smMaxButton->setToolTip(tr("Process based on the maximum of both stereo channels"));
-	
-	PixmapButton * smAvgButton = new PixmapButton( this, tr( "Stereo mode: average" ) );
+
+	auto smAvgButton = new PixmapButton(this, tr("Stereo mode: average"));
 	smAvgButton -> move( 131, 274 );
 	smAvgButton -> resize( 78, 16 );
 	smAvgButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_active" ) );
 	smAvgButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_inactive" ) );
 	smAvgButton->setToolTip(tr("Process based on the average of both stereo channels"));
 
-	PixmapButton * smUnlButton = new PixmapButton( this, tr( "Stereo mode: unlinked" ) );
+	auto smUnlButton = new PixmapButton(this, tr("Stereo mode: unlinked"));
 	smUnlButton -> move( 131, 290 );
 	smUnlButton -> resize( 78, 17 );
 	smUnlButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_active" ) );
 	smUnlButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_inactive" ) );
 	smUnlButton->setToolTip(tr("Process each stereo channel independently"));
-	
-	automatableButtonGroup * smGroup = new automatableButtonGroup( this );
+
+	auto smGroup = new automatableButtonGroup(this);
 	smGroup -> addButton( smMaxButton );
 	smGroup -> addButton( smAvgButton );
 	smGroup -> addButton( smUnlButton );

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -47,7 +47,7 @@ DynProcControlDialog::DynProcControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 319 );
 
-	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
+	auto* waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -88,28 +88,28 @@ DynProcControlDialog::DynProcControlDialog(
 
 //wavegraph control buttons
 
-	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
+	auto* resetButton = new PixmapButton(this, tr("Reset wavegraph"));
 	resetButton -> move( 162, 223 );
 	resetButton -> resize( 13, 48 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
+	auto* smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
 	smoothButton -> move( 162, 239 );
 	smoothButton -> resize( 13, 48 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
+	auto* addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
 	addOneButton -> move( 131, 223 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
+	auto* subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
 	subOneButton -> move( 131, 239 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
@@ -117,28 +117,28 @@ DynProcControlDialog::DynProcControlDialog(
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
 //stereomode switches
-	PixmapButton * smMaxButton = new PixmapButton( this, tr( "Stereo mode: maximum" ) );
+	auto* smMaxButton = new PixmapButton(this, tr("Stereo mode: maximum"));
 	smMaxButton -> move( 131, 257 );
 	smMaxButton -> resize( 78, 17 );
 	smMaxButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "max_active" ) );
 	smMaxButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "max_inactive" ) );
 	smMaxButton->setToolTip(tr("Process based on the maximum of both stereo channels"));
-	
-	PixmapButton * smAvgButton = new PixmapButton( this, tr( "Stereo mode: average" ) );
+
+	auto* smAvgButton = new PixmapButton(this, tr("Stereo mode: average"));
 	smAvgButton -> move( 131, 274 );
 	smAvgButton -> resize( 78, 16 );
 	smAvgButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_active" ) );
 	smAvgButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_inactive" ) );
 	smAvgButton->setToolTip(tr("Process based on the average of both stereo channels"));
 
-	PixmapButton * smUnlButton = new PixmapButton( this, tr( "Stereo mode: unlinked" ) );
+	auto* smUnlButton = new PixmapButton(this, tr("Stereo mode: unlinked"));
 	smUnlButton -> move( 131, 290 );
 	smUnlButton -> resize( 78, 17 );
 	smUnlButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_active" ) );
 	smUnlButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_inactive" ) );
 	smUnlButton->setToolTip(tr("Process each stereo channel independently"));
-	
-	automatableButtonGroup * smGroup = new automatableButtonGroup( this );
+
+	auto* smGroup = new automatableButtonGroup(this);
 	smGroup -> addButton( smMaxButton );
 	smGroup -> addButton( smAvgButton );
 	smGroup -> addButton( smUnlButton );

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -47,7 +47,7 @@ DynProcControlDialog::DynProcControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 319 );
 
-	auto* waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
+	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -88,28 +88,28 @@ DynProcControlDialog::DynProcControlDialog(
 
 //wavegraph control buttons
 
-	auto* resetButton = new PixmapButton(this, tr("Reset wavegraph"));
+	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
 	resetButton -> move( 162, 223 );
 	resetButton -> resize( 13, 48 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	auto* smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
+	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
 	smoothButton -> move( 162, 239 );
 	smoothButton -> resize( 13, 48 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	auto* addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
+	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
 	addOneButton -> move( 131, 223 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	auto* subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
+	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
 	subOneButton -> move( 131, 239 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
@@ -117,28 +117,28 @@ DynProcControlDialog::DynProcControlDialog(
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
 //stereomode switches
-	auto* smMaxButton = new PixmapButton(this, tr("Stereo mode: maximum"));
+	PixmapButton * smMaxButton = new PixmapButton( this, tr( "Stereo mode: maximum" ) );
 	smMaxButton -> move( 131, 257 );
 	smMaxButton -> resize( 78, 17 );
 	smMaxButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "max_active" ) );
 	smMaxButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "max_inactive" ) );
 	smMaxButton->setToolTip(tr("Process based on the maximum of both stereo channels"));
-
-	auto* smAvgButton = new PixmapButton(this, tr("Stereo mode: average"));
+	
+	PixmapButton * smAvgButton = new PixmapButton( this, tr( "Stereo mode: average" ) );
 	smAvgButton -> move( 131, 274 );
 	smAvgButton -> resize( 78, 16 );
 	smAvgButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_active" ) );
 	smAvgButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "avg_inactive" ) );
 	smAvgButton->setToolTip(tr("Process based on the average of both stereo channels"));
 
-	auto* smUnlButton = new PixmapButton(this, tr("Stereo mode: unlinked"));
+	PixmapButton * smUnlButton = new PixmapButton( this, tr( "Stereo mode: unlinked" ) );
 	smUnlButton -> move( 131, 290 );
 	smUnlButton -> resize( 78, 17 );
 	smUnlButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_active" ) );
 	smUnlButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "unl_inactive" ) );
 	smUnlButton->setToolTip(tr("Process each stereo channel independently"));
-
-	auto* smGroup = new automatableButtonGroup(this);
+	
+	automatableButtonGroup * smGroup = new automatableButtonGroup( this );
 	smGroup -> addButton( smMaxButton );
 	smGroup -> addButton( smAvgButton );
 	smGroup -> addButton( smUnlButton );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -52,11 +52,11 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 500, 500 );
 
-	EqSpectrumView * inSpec = new EqSpectrumView( &controls->m_inFftBands, this );
+	auto inSpec = new EqSpectrumView(&controls->m_inFftBands, this);
 	inSpec->move( 26, 17 );
 	inSpec->setColor( QColor( 77, 101, 242, 150 ) );
 
-	EqSpectrumView * outSpec = new EqSpectrumView( &controls->m_outFftBands, this );
+	auto outSpec = new EqSpectrumView(&controls->m_outFftBands, this);
 	outSpec->setColor( QColor( 0, 255, 239, 150 ) );
 	outSpec->move( 26, 17 );
 
@@ -72,16 +72,18 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setBand( 6, &controls->m_highShelfActiveModel, &controls->m_highShelfFreqModel, &controls->m_highShelfResModel, &controls->m_highShelfGainModel, QColor(255 ,255, 255), tr( "High-shelf" ), &controls->m_highShelfPeakL, &controls->m_highShelfPeakR,0,0,0,0,0,0 );
 	setBand( 7, &controls->m_lpActiveModel, &controls->m_lpFreqModel, &controls->m_lpResModel, 0, QColor(255 ,255, 255), tr( "LP" ) ,0,0,0,0,0, &controls->m_lp12Model, &controls->m_lp24Model, &controls->m_lp48Model);
 
-	QPixmap * faderBg = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderback" ) );
-	QPixmap * faderLeds = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderleds" ) );
-	QPixmap * faderKnob = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderknob" ) );
+	auto faderBg = new QPixmap(PLUGIN_NAME::getIconPixmap("faderback"));
+	auto faderLeds = new QPixmap(PLUGIN_NAME::getIconPixmap("faderleds"));
+	auto faderKnob = new QPixmap(PLUGIN_NAME::getIconPixmap("faderknob"));
 
-	EqFader * GainFaderIn = new EqFader( &controls->m_inGainModel, tr( "Input gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_inPeakL, &controls->m_inPeakR );
+	auto GainFaderIn = new EqFader(&controls->m_inGainModel, tr("Input gain"), this, faderBg, faderLeds, faderKnob,
+		&controls->m_inPeakL, &controls->m_inPeakR);
 	GainFaderIn->move( 23, 295 );
 	GainFaderIn->setDisplayConversion( false );
 	GainFaderIn->setHintText( tr( "Gain" ), "dBv");
 
-	EqFader * GainFaderOut = new EqFader( &controls->m_outGainModel, tr( "Output gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_outPeakL, &controls->m_outPeakR );
+	auto GainFaderOut = new EqFader(&controls->m_outGainModel, tr("Output gain"), this, faderBg, faderLeds, faderKnob,
+		&controls->m_outPeakL, &controls->m_outPeakR);
 	GainFaderOut->move( 453, 295);
 	GainFaderOut->setDisplayConversion( false );
 	GainFaderOut->setHintText( tr( "Gain" ), "dBv" );
@@ -90,7 +92,8 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	int distance = 126;
 	for( int i = 1; i < m_parameterWidget->bandCount() - 1; i++ )
 	{
-		EqFader * gainFader = new EqFader( m_parameterWidget->getBandModels( i )->gain, tr( "" ), this, faderBg, faderLeds, faderKnob, m_parameterWidget->getBandModels( i )->peakL, m_parameterWidget->getBandModels( i )->peakR );
+		auto gainFader = new EqFader(m_parameterWidget->getBandModels(i)->gain, tr(""), this, faderBg, faderLeds,
+			faderKnob, m_parameterWidget->getBandModels(i)->peakL, m_parameterWidget->getBandModels(i)->peakR);
 		gainFader->move( distance, 295 );
 		distance += 44;
 		gainFader->setMinimumHeight(80);
@@ -103,21 +106,21 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	distance = 81;
 	for( int i = 0; i < m_parameterWidget->bandCount() ; i++ )
 	{
-		Knob * resKnob = new Knob( knobBright_26, this );
+		auto resKnob = new Knob(knobBright_26, this);
 		resKnob->move( distance, 440 );
 		resKnob->setVolumeKnob(false);
 		resKnob->setModel( m_parameterWidget->getBandModels( i )->res );
 		if(i > 1 && i < 6) { resKnob->setHintText( tr( "Bandwidth: " ) , tr( " Octave" ) ); }
 		else { resKnob->setHintText( tr( "Resonance : " ) , "" ); }
 
-		Knob * freqKnob = new Knob( knobBright_26, this );
+		auto freqKnob = new Knob(knobBright_26, this);
 		freqKnob->move( distance, 396 );
 		freqKnob->setVolumeKnob( false );
 		freqKnob->setModel( m_parameterWidget->getBandModels( i )->freq );
 		freqKnob->setHintText( tr( "Frequency:" ), "Hz" );
 
 		// adds the Number Active buttons
-		PixmapButton * activeButton = new PixmapButton( this, nullptr );
+		auto activeButton = new PixmapButton(this, nullptr);
 		activeButton->setCheckable(true);
 		activeButton->setModel( m_parameterWidget->getBandModels( i )->active );
 
@@ -140,48 +143,48 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 
 
 	// adds the buttons for Spectrum analyser on/off
-	LedCheckBox * inSpecButton = new LedCheckBox( this );
+	auto inSpecButton = new LedCheckBox(this);
 	inSpecButton->setCheckable(true);
 	inSpecButton->setModel( &controls->m_analyseInModel );
 	inSpecButton->move( 172, 240 );
-	LedCheckBox * outSpecButton = new LedCheckBox( this );
+	auto outSpecButton = new LedCheckBox(this);
 	outSpecButton->setCheckable(true);
 	outSpecButton->setModel( &controls->m_analyseOutModel );
 	outSpecButton->move( 302, 240 );
 
 	//hp filter type
-	PixmapButton * hp12Button = new PixmapButton( this , nullptr );
+	auto hp12Button = new PixmapButton(this, nullptr);
 	hp12Button->setModel( m_parameterWidget->getBandModels( 0 )->hp12 );
 	hp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	hp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 	hp12Button->move( 79, 298 );
-	PixmapButton * hp24Button = new PixmapButton( this , nullptr );
+	auto hp24Button = new PixmapButton(this, nullptr);
 	hp24Button->setModel(m_parameterWidget->getBandModels( 0 )->hp24 );
 	hp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	hp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	hp24Button->move( 79 , 328 );
-	PixmapButton * hp48Button = new PixmapButton( this , nullptr );
+	auto hp48Button = new PixmapButton(this, nullptr);
 	hp48Button->setModel( m_parameterWidget->getBandModels(0)->hp48 );
 	hp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	hp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
 
 	hp48Button->move( 79, 358 );
 	//LP filter type
-	PixmapButton * lp12Button = new PixmapButton( this , nullptr );
+	auto lp12Button = new PixmapButton(this, nullptr);
 	lp12Button->setModel( m_parameterWidget->getBandModels( 7 )->lp12 );
 	lp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	lp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 
 	lp12Button->move( 387, 298 );
-	PixmapButton * lp24Button = new PixmapButton( this , nullptr );
+	auto lp24Button = new PixmapButton(this, nullptr);
 	lp24Button->setModel( m_parameterWidget->getBandModels( 7 )->lp24 );
 	lp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	lp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	lp24Button->move( 387, 328 );
 
-	PixmapButton * lp48Button = new PixmapButton( this , nullptr );
+	auto lp48Button = new PixmapButton(this, nullptr);
 	lp48Button->setModel( m_parameterWidget->getBandModels( 7 )->lp48 );
 	lp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	lp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
@@ -196,13 +199,13 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp24 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp48 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 
-	automatableButtonGroup *lpBtnGrp = new automatableButtonGroup( this, tr( "LP group" ) );
+	auto lpBtnGrp = new automatableButtonGroup(this, tr("LP group"));
 	lpBtnGrp->addButton( lp12Button );
 	lpBtnGrp->addButton( lp24Button );
 	lpBtnGrp->addButton( lp48Button );
 	lpBtnGrp->setModel(&m_controls->m_lpTypeModel);
 
-	automatableButtonGroup *hpBtnGrp = new automatableButtonGroup( this, tr( "HP group" ) );
+	auto hpBtnGrp = new automatableButtonGroup(this, tr("HP group"));
 	hpBtnGrp->addButton( hp12Button );
 	hpBtnGrp->addButton( hp24Button );
 	hpBtnGrp->addButton( hp48Button );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -52,11 +52,11 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 500, 500 );
 
-	auto* inSpec = new EqSpectrumView(&controls->m_inFftBands, this);
+	EqSpectrumView * inSpec = new EqSpectrumView( &controls->m_inFftBands, this );
 	inSpec->move( 26, 17 );
 	inSpec->setColor( QColor( 77, 101, 242, 150 ) );
 
-	auto* outSpec = new EqSpectrumView(&controls->m_outFftBands, this);
+	EqSpectrumView * outSpec = new EqSpectrumView( &controls->m_outFftBands, this );
 	outSpec->setColor( QColor( 0, 255, 239, 150 ) );
 	outSpec->move( 26, 17 );
 
@@ -72,18 +72,16 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setBand( 6, &controls->m_highShelfActiveModel, &controls->m_highShelfFreqModel, &controls->m_highShelfResModel, &controls->m_highShelfGainModel, QColor(255 ,255, 255), tr( "High-shelf" ), &controls->m_highShelfPeakL, &controls->m_highShelfPeakR,0,0,0,0,0,0 );
 	setBand( 7, &controls->m_lpActiveModel, &controls->m_lpFreqModel, &controls->m_lpResModel, 0, QColor(255 ,255, 255), tr( "LP" ) ,0,0,0,0,0, &controls->m_lp12Model, &controls->m_lp24Model, &controls->m_lp48Model);
 
-	auto* faderBg = new QPixmap(PLUGIN_NAME::getIconPixmap("faderback"));
-	auto* faderLeds = new QPixmap(PLUGIN_NAME::getIconPixmap("faderleds"));
-	auto* faderKnob = new QPixmap(PLUGIN_NAME::getIconPixmap("faderknob"));
+	QPixmap * faderBg = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderback" ) );
+	QPixmap * faderLeds = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderleds" ) );
+	QPixmap * faderKnob = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderknob" ) );
 
-	auto* GainFaderIn = new EqFader(&controls->m_inGainModel, tr("Input gain"), this, faderBg, faderLeds, faderKnob,
-		&controls->m_inPeakL, &controls->m_inPeakR);
+	EqFader * GainFaderIn = new EqFader( &controls->m_inGainModel, tr( "Input gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_inPeakL, &controls->m_inPeakR );
 	GainFaderIn->move( 23, 295 );
 	GainFaderIn->setDisplayConversion( false );
 	GainFaderIn->setHintText( tr( "Gain" ), "dBv");
 
-	auto* GainFaderOut = new EqFader(&controls->m_outGainModel, tr("Output gain"), this, faderBg, faderLeds, faderKnob,
-		&controls->m_outPeakL, &controls->m_outPeakR);
+	EqFader * GainFaderOut = new EqFader( &controls->m_outGainModel, tr( "Output gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_outPeakL, &controls->m_outPeakR );
 	GainFaderOut->move( 453, 295);
 	GainFaderOut->setDisplayConversion( false );
 	GainFaderOut->setHintText( tr( "Gain" ), "dBv" );
@@ -92,8 +90,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	int distance = 126;
 	for( int i = 1; i < m_parameterWidget->bandCount() - 1; i++ )
 	{
-		auto* gainFader = new EqFader(m_parameterWidget->getBandModels(i)->gain, tr(""), this, faderBg, faderLeds,
-			faderKnob, m_parameterWidget->getBandModels(i)->peakL, m_parameterWidget->getBandModels(i)->peakR);
+		EqFader * gainFader = new EqFader( m_parameterWidget->getBandModels( i )->gain, tr( "" ), this, faderBg, faderLeds, faderKnob, m_parameterWidget->getBandModels( i )->peakL, m_parameterWidget->getBandModels( i )->peakR );
 		gainFader->move( distance, 295 );
 		distance += 44;
 		gainFader->setMinimumHeight(80);
@@ -120,7 +117,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		freqKnob->setHintText( tr( "Frequency:" ), "Hz" );
 
 		// adds the Number Active buttons
-		auto* activeButton = new PixmapButton(this, nullptr);
+		PixmapButton * activeButton = new PixmapButton( this, nullptr );
 		activeButton->setCheckable(true);
 		activeButton->setModel( m_parameterWidget->getBandModels( i )->active );
 
@@ -143,48 +140,48 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 
 
 	// adds the buttons for Spectrum analyser on/off
-	auto* inSpecButton = new LedCheckBox(this);
+	LedCheckBox * inSpecButton = new LedCheckBox( this );
 	inSpecButton->setCheckable(true);
 	inSpecButton->setModel( &controls->m_analyseInModel );
 	inSpecButton->move( 172, 240 );
-	auto* outSpecButton = new LedCheckBox(this);
+	LedCheckBox * outSpecButton = new LedCheckBox( this );
 	outSpecButton->setCheckable(true);
 	outSpecButton->setModel( &controls->m_analyseOutModel );
 	outSpecButton->move( 302, 240 );
 
 	//hp filter type
-	auto* hp12Button = new PixmapButton(this, nullptr);
+	PixmapButton * hp12Button = new PixmapButton( this , nullptr );
 	hp12Button->setModel( m_parameterWidget->getBandModels( 0 )->hp12 );
 	hp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	hp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 	hp12Button->move( 79, 298 );
-	auto* hp24Button = new PixmapButton(this, nullptr);
+	PixmapButton * hp24Button = new PixmapButton( this , nullptr );
 	hp24Button->setModel(m_parameterWidget->getBandModels( 0 )->hp24 );
 	hp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	hp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	hp24Button->move( 79 , 328 );
-	auto* hp48Button = new PixmapButton(this, nullptr);
+	PixmapButton * hp48Button = new PixmapButton( this , nullptr );
 	hp48Button->setModel( m_parameterWidget->getBandModels(0)->hp48 );
 	hp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	hp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
 
 	hp48Button->move( 79, 358 );
 	//LP filter type
-	auto* lp12Button = new PixmapButton(this, nullptr);
+	PixmapButton * lp12Button = new PixmapButton( this , nullptr );
 	lp12Button->setModel( m_parameterWidget->getBandModels( 7 )->lp12 );
 	lp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	lp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 
 	lp12Button->move( 387, 298 );
-	auto* lp24Button = new PixmapButton(this, nullptr);
+	PixmapButton * lp24Button = new PixmapButton( this , nullptr );
 	lp24Button->setModel( m_parameterWidget->getBandModels( 7 )->lp24 );
 	lp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	lp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	lp24Button->move( 387, 328 );
 
-	auto* lp48Button = new PixmapButton(this, nullptr);
+	PixmapButton * lp48Button = new PixmapButton( this , nullptr );
 	lp48Button->setModel( m_parameterWidget->getBandModels( 7 )->lp48 );
 	lp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	lp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
@@ -199,13 +196,13 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp24 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp48 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 
-	auto* lpBtnGrp = new automatableButtonGroup(this, tr("LP group"));
+	automatableButtonGroup *lpBtnGrp = new automatableButtonGroup( this, tr( "LP group" ) );
 	lpBtnGrp->addButton( lp12Button );
 	lpBtnGrp->addButton( lp24Button );
 	lpBtnGrp->addButton( lp48Button );
 	lpBtnGrp->setModel(&m_controls->m_lpTypeModel);
 
-	auto* hpBtnGrp = new automatableButtonGroup(this, tr("HP group"));
+	automatableButtonGroup *hpBtnGrp = new automatableButtonGroup( this, tr( "HP group" ) );
 	hpBtnGrp->addButton( hp12Button );
 	hpBtnGrp->addButton( hp24Button );
 	hpBtnGrp->addButton( hp48Button );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -52,11 +52,11 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 500, 500 );
 
-	EqSpectrumView * inSpec = new EqSpectrumView( &controls->m_inFftBands, this );
+	auto* inSpec = new EqSpectrumView(&controls->m_inFftBands, this);
 	inSpec->move( 26, 17 );
 	inSpec->setColor( QColor( 77, 101, 242, 150 ) );
 
-	EqSpectrumView * outSpec = new EqSpectrumView( &controls->m_outFftBands, this );
+	auto* outSpec = new EqSpectrumView(&controls->m_outFftBands, this);
 	outSpec->setColor( QColor( 0, 255, 239, 150 ) );
 	outSpec->move( 26, 17 );
 
@@ -72,16 +72,18 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	setBand( 6, &controls->m_highShelfActiveModel, &controls->m_highShelfFreqModel, &controls->m_highShelfResModel, &controls->m_highShelfGainModel, QColor(255 ,255, 255), tr( "High-shelf" ), &controls->m_highShelfPeakL, &controls->m_highShelfPeakR,0,0,0,0,0,0 );
 	setBand( 7, &controls->m_lpActiveModel, &controls->m_lpFreqModel, &controls->m_lpResModel, 0, QColor(255 ,255, 255), tr( "LP" ) ,0,0,0,0,0, &controls->m_lp12Model, &controls->m_lp24Model, &controls->m_lp48Model);
 
-	QPixmap * faderBg = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderback" ) );
-	QPixmap * faderLeds = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderleds" ) );
-	QPixmap * faderKnob = new QPixmap( PLUGIN_NAME::getIconPixmap( "faderknob" ) );
+	auto* faderBg = new QPixmap(PLUGIN_NAME::getIconPixmap("faderback"));
+	auto* faderLeds = new QPixmap(PLUGIN_NAME::getIconPixmap("faderleds"));
+	auto* faderKnob = new QPixmap(PLUGIN_NAME::getIconPixmap("faderknob"));
 
-	EqFader * GainFaderIn = new EqFader( &controls->m_inGainModel, tr( "Input gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_inPeakL, &controls->m_inPeakR );
+	auto* GainFaderIn = new EqFader(&controls->m_inGainModel, tr("Input gain"), this, faderBg, faderLeds, faderKnob,
+		&controls->m_inPeakL, &controls->m_inPeakR);
 	GainFaderIn->move( 23, 295 );
 	GainFaderIn->setDisplayConversion( false );
 	GainFaderIn->setHintText( tr( "Gain" ), "dBv");
 
-	EqFader * GainFaderOut = new EqFader( &controls->m_outGainModel, tr( "Output gain" ), this, faderBg, faderLeds, faderKnob, &controls->m_outPeakL, &controls->m_outPeakR );
+	auto* GainFaderOut = new EqFader(&controls->m_outGainModel, tr("Output gain"), this, faderBg, faderLeds, faderKnob,
+		&controls->m_outPeakL, &controls->m_outPeakR);
 	GainFaderOut->move( 453, 295);
 	GainFaderOut->setDisplayConversion( false );
 	GainFaderOut->setHintText( tr( "Gain" ), "dBv" );
@@ -90,7 +92,8 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	int distance = 126;
 	for( int i = 1; i < m_parameterWidget->bandCount() - 1; i++ )
 	{
-		EqFader * gainFader = new EqFader( m_parameterWidget->getBandModels( i )->gain, tr( "" ), this, faderBg, faderLeds, faderKnob, m_parameterWidget->getBandModels( i )->peakL, m_parameterWidget->getBandModels( i )->peakR );
+		auto* gainFader = new EqFader(m_parameterWidget->getBandModels(i)->gain, tr(""), this, faderBg, faderLeds,
+			faderKnob, m_parameterWidget->getBandModels(i)->peakL, m_parameterWidget->getBandModels(i)->peakR);
 		gainFader->move( distance, 295 );
 		distance += 44;
 		gainFader->setMinimumHeight(80);
@@ -117,7 +120,7 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		freqKnob->setHintText( tr( "Frequency:" ), "Hz" );
 
 		// adds the Number Active buttons
-		PixmapButton * activeButton = new PixmapButton( this, nullptr );
+		auto* activeButton = new PixmapButton(this, nullptr);
 		activeButton->setCheckable(true);
 		activeButton->setModel( m_parameterWidget->getBandModels( i )->active );
 
@@ -140,48 +143,48 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 
 
 	// adds the buttons for Spectrum analyser on/off
-	LedCheckBox * inSpecButton = new LedCheckBox( this );
+	auto* inSpecButton = new LedCheckBox(this);
 	inSpecButton->setCheckable(true);
 	inSpecButton->setModel( &controls->m_analyseInModel );
 	inSpecButton->move( 172, 240 );
-	LedCheckBox * outSpecButton = new LedCheckBox( this );
+	auto* outSpecButton = new LedCheckBox(this);
 	outSpecButton->setCheckable(true);
 	outSpecButton->setModel( &controls->m_analyseOutModel );
 	outSpecButton->move( 302, 240 );
 
 	//hp filter type
-	PixmapButton * hp12Button = new PixmapButton( this , nullptr );
+	auto* hp12Button = new PixmapButton(this, nullptr);
 	hp12Button->setModel( m_parameterWidget->getBandModels( 0 )->hp12 );
 	hp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	hp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 	hp12Button->move( 79, 298 );
-	PixmapButton * hp24Button = new PixmapButton( this , nullptr );
+	auto* hp24Button = new PixmapButton(this, nullptr);
 	hp24Button->setModel(m_parameterWidget->getBandModels( 0 )->hp24 );
 	hp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	hp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	hp24Button->move( 79 , 328 );
-	PixmapButton * hp48Button = new PixmapButton( this , nullptr );
+	auto* hp48Button = new PixmapButton(this, nullptr);
 	hp48Button->setModel( m_parameterWidget->getBandModels(0)->hp48 );
 	hp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	hp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
 
 	hp48Button->move( 79, 358 );
 	//LP filter type
-	PixmapButton * lp12Button = new PixmapButton( this , nullptr );
+	auto* lp12Button = new PixmapButton(this, nullptr);
 	lp12Button->setModel( m_parameterWidget->getBandModels( 7 )->lp12 );
 	lp12Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "12dB" ) );
 	lp12Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "12dBoff" ) );
 
 	lp12Button->move( 387, 298 );
-	PixmapButton * lp24Button = new PixmapButton( this , nullptr );
+	auto* lp24Button = new PixmapButton(this, nullptr);
 	lp24Button->setModel( m_parameterWidget->getBandModels( 7 )->lp24 );
 	lp24Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "24dB" ) );
 	lp24Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "24dBoff" ) );
 
 	lp24Button->move( 387, 328 );
 
-	PixmapButton * lp48Button = new PixmapButton( this , nullptr );
+	auto* lp48Button = new PixmapButton(this, nullptr);
 	lp48Button->setModel( m_parameterWidget->getBandModels( 7 )->lp48 );
 	lp48Button->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "48dB" ) );
 	lp48Button->setInactiveGraphic(  PLUGIN_NAME::getIconPixmap( "48dBoff" ) );
@@ -196,13 +199,13 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp24 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 	QObject::connect( m_parameterWidget->getBandModels( 7 )->lp48 , SIGNAL ( dataChanged() ), m_parameterWidget, SLOT( updateHandle()));
 
-	automatableButtonGroup *lpBtnGrp = new automatableButtonGroup( this, tr( "LP group" ) );
+	auto* lpBtnGrp = new automatableButtonGroup(this, tr("LP group"));
 	lpBtnGrp->addButton( lp12Button );
 	lpBtnGrp->addButton( lp24Button );
 	lpBtnGrp->addButton( lp48Button );
 	lpBtnGrp->setModel(&m_controls->m_lpTypeModel);
 
-	automatableButtonGroup *hpBtnGrp = new automatableButtonGroup( this, tr( "HP group" ) );
+	auto* hpBtnGrp = new automatableButtonGroup(this, tr("HP group"));
 	hpBtnGrp->addButton( hp12Button );
 	hpBtnGrp->addButton( hp24Button );
 	hpBtnGrp->addButton( hp48Button );

--- a/plugins/Eq/EqParameterWidget.cpp
+++ b/plugins/Eq/EqParameterWidget.cpp
@@ -56,9 +56,9 @@ EqParameterWidget::EqParameterWidget( QWidget *parent, EqControls * controls ) :
 	m_pixelsPerOctave = EqHandle::freqToXPixel( 10000, m_displayWidth ) - EqHandle::freqToXPixel( 5000, m_displayWidth );
 
 	//GraphicsScene and GraphicsView stuff
-	QGraphicsScene *scene = new QGraphicsScene();
+	auto scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, m_displayWidth, m_displayHeigth );
-	QGraphicsView *view = new QGraphicsView( this );
+	auto view = new QGraphicsView(this);
 	view->setStyleSheet( "border-style: none; background: transparent;" );
 	view->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	view->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );

--- a/plugins/Eq/EqParameterWidget.cpp
+++ b/plugins/Eq/EqParameterWidget.cpp
@@ -56,9 +56,9 @@ EqParameterWidget::EqParameterWidget( QWidget *parent, EqControls * controls ) :
 	m_pixelsPerOctave = EqHandle::freqToXPixel( 10000, m_displayWidth ) - EqHandle::freqToXPixel( 5000, m_displayWidth );
 
 	//GraphicsScene and GraphicsView stuff
-	QGraphicsScene *scene = new QGraphicsScene();
+	auto* scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, m_displayWidth, m_displayHeigth );
-	QGraphicsView *view = new QGraphicsView( this );
+	auto* view = new QGraphicsView(this);
 	view->setStyleSheet( "border-style: none; background: transparent;" );
 	view->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	view->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );

--- a/plugins/Eq/EqParameterWidget.cpp
+++ b/plugins/Eq/EqParameterWidget.cpp
@@ -56,9 +56,9 @@ EqParameterWidget::EqParameterWidget( QWidget *parent, EqControls * controls ) :
 	m_pixelsPerOctave = EqHandle::freqToXPixel( 10000, m_displayWidth ) - EqHandle::freqToXPixel( 5000, m_displayWidth );
 
 	//GraphicsScene and GraphicsView stuff
-	auto* scene = new QGraphicsScene();
+	QGraphicsScene *scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, m_displayWidth, m_displayHeigth );
-	auto* view = new QGraphicsView(this);
+	QGraphicsView *view = new QGraphicsView( this );
 	view->setStyleSheet( "border-style: none; background: transparent;" );
 	view->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 	view->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -49,7 +49,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	delayKnob->setLabel( tr( "DELAY" ) );
 	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
 
-	auto* lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
+	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
 	lfoFreqKnob->move( 48,10 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
@@ -84,7 +84,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	whiteNoiseKnob->setLabel( tr( "NOISE" ) );
 	whiteNoiseKnob->setHintText( tr( "White noise amount:" ) , "" );
 
-	auto* invertCb = new LedCheckBox(tr("Invert"), this);
+	LedCheckBox * invertCb = new LedCheckBox( tr( "Invert" ), this );
 	invertCb->move( 10,53 );
 
 

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -42,49 +42,49 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 233, 75 );
 
-	Knob* delayKnob = new Knob( knobBright_26, this );
+	auto delayKnob = new Knob(knobBright_26, this);
 	delayKnob->move( 10,10 );
 	delayKnob->setVolumeKnob( false );
 	delayKnob->setModel( &controls->m_delayTimeModel );
 	delayKnob->setLabel( tr( "DELAY" ) );
 	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
 
-	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	auto lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoFreqKnob->move( 48,10 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
 	lfoFreqKnob->setLabel( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr( "Period:" ) , " Sec" );
 
-	Knob * lfoAmtKnob = new Knob( knobBright_26, this );
+	auto lfoAmtKnob = new Knob(knobBright_26, this);
 	lfoAmtKnob->move( 85,10 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
 	lfoAmtKnob->setLabel( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr( "Amount:" ) , "" );
 
-	Knob * lfoPhaseKnob = new Knob( knobBright_26, this );
+	auto lfoPhaseKnob = new Knob(knobBright_26, this);
 	lfoPhaseKnob->move( 123,10 );
 	lfoPhaseKnob->setVolumeKnob( false );
 	lfoPhaseKnob->setModel( &controls->m_lfoPhaseModel );
 	lfoPhaseKnob->setLabel( tr( "PHASE" ) );
 	lfoPhaseKnob->setHintText( tr( "Phase:" ) , " degrees" );
 
-	Knob * feedbackKnob = new Knob( knobBright_26, this );
+	auto feedbackKnob = new Knob(knobBright_26, this);
 	feedbackKnob->move( 160,10 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel );
 	feedbackKnob->setLabel( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr( "Feedback amount:" ) , "" );
 
-	Knob * whiteNoiseKnob = new Knob( knobBright_26, this );
+	auto whiteNoiseKnob = new Knob(knobBright_26, this);
 	whiteNoiseKnob->move( 196,10 );
 	whiteNoiseKnob->setVolumeKnob( true) ;
 	whiteNoiseKnob->setModel( &controls->m_whiteNoiseAmountModel );
 	whiteNoiseKnob->setLabel( tr( "NOISE" ) );
 	whiteNoiseKnob->setHintText( tr( "White noise amount:" ) , "" );
 
-	LedCheckBox * invertCb = new LedCheckBox( tr( "Invert" ), this );
+	auto invertCb = new LedCheckBox(tr("Invert"), this);
 	invertCb->move( 10,53 );
 
 

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -49,7 +49,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	delayKnob->setLabel( tr( "DELAY" ) );
 	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
 
-	TempoSyncKnob * lfoFreqKnob = new TempoSyncKnob( knobBright_26, this );
+	auto* lfoFreqKnob = new TempoSyncKnob(knobBright_26, this);
 	lfoFreqKnob->move( 48,10 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
@@ -84,7 +84,7 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	whiteNoiseKnob->setLabel( tr( "NOISE" ) );
 	whiteNoiseKnob->setHintText( tr( "White noise amount:" ) , "" );
 
-	LedCheckBox * invertCb = new LedCheckBox( tr( "Invert" ), this );
+	auto* invertCb = new LedCheckBox(tr("Invert"), this);
 	invertCb->move( 10,53 );
 
 

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -251,7 +251,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 
 	if ( tfp == 0 )
 	{
-		Gb_Apu_Buffer *papu = new Gb_Apu_Buffer();
+		auto* papu = new Gb_Apu_Buffer();
 		papu->set_sample_rate( samplerate, CLOCK_RATE );
 
 		// Master sound circuitry power control
@@ -282,7 +282,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = papu;
 	}
 
-	Gb_Apu_Buffer *papu = static_cast<Gb_Apu_Buffer *>( _n->m_pluginData );
+	auto* papu = static_cast<Gb_Apu_Buffer*>(_n->m_pluginData);
 
 	papu->treble_eq( m_trebleModel.value() );
 	papu->bass_freq( m_bassModel.value() );
@@ -681,7 +681,7 @@ FreeBoyInstrumentView::FreeBoyInstrumentView( Instrument * _instrument,
 
 void FreeBoyInstrumentView::modelChanged()
 {
-	FreeBoyInstrument * p = castModel<FreeBoyInstrument>();
+	auto* p = castModel<FreeBoyInstrument>();
 
 	m_ch1SweepTimeKnob->setModel( &p->m_ch1SweepTimeModel );
 	m_ch1SweepDirButton->setModel( &p->m_ch1SweepDirModel );

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -251,7 +251,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 
 	if ( tfp == 0 )
 	{
-		auto* papu = new Gb_Apu_Buffer();
+		Gb_Apu_Buffer *papu = new Gb_Apu_Buffer();
 		papu->set_sample_rate( samplerate, CLOCK_RATE );
 
 		// Master sound circuitry power control
@@ -282,7 +282,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = papu;
 	}
 
-	auto* papu = static_cast<Gb_Apu_Buffer*>(_n->m_pluginData);
+	Gb_Apu_Buffer *papu = static_cast<Gb_Apu_Buffer *>( _n->m_pluginData );
 
 	papu->treble_eq( m_trebleModel.value() );
 	papu->bass_freq( m_bassModel.value() );
@@ -681,7 +681,7 @@ FreeBoyInstrumentView::FreeBoyInstrumentView( Instrument * _instrument,
 
 void FreeBoyInstrumentView::modelChanged()
 {
-	auto* p = castModel<FreeBoyInstrument>();
+	FreeBoyInstrument * p = castModel<FreeBoyInstrument>();
 
 	m_ch1SweepTimeKnob->setModel( &p->m_ch1SweepTimeModel );
 	m_ch1SweepDirButton->setModel( &p->m_ch1SweepDirModel );

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -251,7 +251,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 
 	if ( tfp == 0 )
 	{
-		Gb_Apu_Buffer *papu = new Gb_Apu_Buffer();
+		auto papu = new Gb_Apu_Buffer();
 		papu->set_sample_rate( samplerate, CLOCK_RATE );
 
 		// Master sound circuitry power control
@@ -282,7 +282,7 @@ void FreeBoyInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = papu;
 	}
 
-	Gb_Apu_Buffer *papu = static_cast<Gb_Apu_Buffer *>( _n->m_pluginData );
+	auto papu = static_cast<Gb_Apu_Buffer*>(_n->m_pluginData);
 
 	papu->treble_eq( m_trebleModel.value() );
 	papu->bass_freq( m_bassModel.value() );
@@ -681,7 +681,7 @@ FreeBoyInstrumentView::FreeBoyInstrumentView( Instrument * _instrument,
 
 void FreeBoyInstrumentView::modelChanged()
 {
-	FreeBoyInstrument * p = castModel<FreeBoyInstrument>();
+	auto p = castModel<FreeBoyInstrument>();
 
 	m_ch1SweepTimeKnob->setModel( &p->m_ch1SweepTimeModel );
 	m_ch1SweepDirButton->setModel( &p->m_ch1SweepDirModel );

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -92,7 +92,7 @@ GigInstrument::GigInstrument( InstrumentTrack * _instrument_track ) :
 	m_RandomSeed( 0 ),
 	m_currentKeyDimension( 0 )
 {
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	updateSampleRate();
@@ -305,7 +305,7 @@ void GigInstrument::playNote( NotePlayHandle * _n, sampleFrame * )
 
 	if( tfp == 0 )
 	{
-		GIGPluginData * pluginData = new GIGPluginData;
+		auto pluginData = new GIGPluginData;
 		pluginData->midiNote = midiNote;
 		_n->m_pluginData = pluginData;
 
@@ -593,7 +593,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	// Convert from 16 or 24 bit into 32-bit float
 	if( sample.sample->BitDepth == 24 ) // 24 bit
 	{
-		uint8_t * pInt = reinterpret_cast<uint8_t*>( &buffer );
+		auto pInt = reinterpret_cast<uint8_t*>(&buffer);
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -625,7 +625,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	}
 	else // 16 bit
 	{
-		int16_t * pInt = reinterpret_cast<int16_t*>( &buffer );
+		auto pInt = reinterpret_cast<int16_t*>(&buffer);
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -684,7 +684,7 @@ f_cnt_t GigInstrument::getPingPongIndex( f_cnt_t index, f_cnt_t startf, f_cnt_t 
 // A key has been released
 void GigInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	GIGPluginData * pluginData = static_cast<GIGPluginData *>( _n->m_pluginData );
+	auto pluginData = static_cast<GIGPluginData*>(_n->m_pluginData);
 	QMutexLocker locker( &m_notesMutex );
 
 	// Mark the note as being released, but only if it was playing or was just
@@ -931,7 +931,7 @@ public:
 GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _parent ) :
         InstrumentViewFixedSize( _instrument, _parent )
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto k = castModel<GigInstrument>();
 
 	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
 	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
@@ -990,7 +990,7 @@ GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _paren
 
 void GigInstrumentView::modelChanged()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto k = castModel<GigInstrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1007,7 +1007,7 @@ void GigInstrumentView::modelChanged()
 
 void GigInstrumentView::updateFilename()
 {
-	GigInstrument * i = castModel<GigInstrument>();
+	auto i = castModel<GigInstrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".gig", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1025,7 +1025,7 @@ void GigInstrumentView::updateFilename()
 
 void GigInstrumentView::updatePatchName()
 {
-	GigInstrument * i = castModel<GigInstrument>();
+	auto i = castModel<GigInstrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1046,7 +1046,7 @@ void GigInstrumentView::invalidateFile()
 
 void GigInstrumentView::showFileDialog()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto k = castModel<GigInstrument>();
 
 	FileDialog ofd( nullptr, tr( "Open GIG file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1087,7 +1087,7 @@ void GigInstrumentView::showFileDialog()
 
 void GigInstrumentView::showPatchDialog()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto k = castModel<GigInstrument>();
 	PatchesDialog pd( this );
 	pd.setup( k->m_instance, 1, k->instrumentTrack()->name(), &k->m_bankNum, &k->m_patchNum, m_patchLabel );
 	pd.exec();

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -92,7 +92,7 @@ GigInstrument::GigInstrument( InstrumentTrack * _instrument_track ) :
 	m_RandomSeed( 0 ),
 	m_currentKeyDimension( 0 )
 {
-	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	updateSampleRate();
@@ -305,7 +305,7 @@ void GigInstrument::playNote( NotePlayHandle * _n, sampleFrame * )
 
 	if( tfp == 0 )
 	{
-		auto* pluginData = new GIGPluginData;
+		GIGPluginData * pluginData = new GIGPluginData;
 		pluginData->midiNote = midiNote;
 		_n->m_pluginData = pluginData;
 
@@ -593,7 +593,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	// Convert from 16 or 24 bit into 32-bit float
 	if( sample.sample->BitDepth == 24 ) // 24 bit
 	{
-		auto* pInt = reinterpret_cast<uint8_t*>(&buffer);
+		uint8_t * pInt = reinterpret_cast<uint8_t*>( &buffer );
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -625,7 +625,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	}
 	else // 16 bit
 	{
-		auto* pInt = reinterpret_cast<int16_t*>(&buffer);
+		int16_t * pInt = reinterpret_cast<int16_t*>( &buffer );
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -684,7 +684,7 @@ f_cnt_t GigInstrument::getPingPongIndex( f_cnt_t index, f_cnt_t startf, f_cnt_t 
 // A key has been released
 void GigInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	auto* pluginData = static_cast<GIGPluginData*>(_n->m_pluginData);
+	GIGPluginData * pluginData = static_cast<GIGPluginData *>( _n->m_pluginData );
 	QMutexLocker locker( &m_notesMutex );
 
 	// Mark the note as being released, but only if it was playing or was just
@@ -931,7 +931,7 @@ public:
 GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _parent ) :
         InstrumentViewFixedSize( _instrument, _parent )
 {
-	auto* k = castModel<GigInstrument>();
+	GigInstrument * k = castModel<GigInstrument>();
 
 	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
 	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
@@ -990,7 +990,7 @@ GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _paren
 
 void GigInstrumentView::modelChanged()
 {
-	auto* k = castModel<GigInstrument>();
+	GigInstrument * k = castModel<GigInstrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1007,7 +1007,7 @@ void GigInstrumentView::modelChanged()
 
 void GigInstrumentView::updateFilename()
 {
-	auto* i = castModel<GigInstrument>();
+	GigInstrument * i = castModel<GigInstrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".gig", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1025,7 +1025,7 @@ void GigInstrumentView::updateFilename()
 
 void GigInstrumentView::updatePatchName()
 {
-	auto* i = castModel<GigInstrument>();
+	GigInstrument * i = castModel<GigInstrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1046,7 +1046,7 @@ void GigInstrumentView::invalidateFile()
 
 void GigInstrumentView::showFileDialog()
 {
-	auto* k = castModel<GigInstrument>();
+	GigInstrument * k = castModel<GigInstrument>();
 
 	FileDialog ofd( nullptr, tr( "Open GIG file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1087,7 +1087,7 @@ void GigInstrumentView::showFileDialog()
 
 void GigInstrumentView::showPatchDialog()
 {
-	auto* k = castModel<GigInstrument>();
+	GigInstrument * k = castModel<GigInstrument>();
 	PatchesDialog pd( this );
 	pd.setup( k->m_instance, 1, k->instrumentTrack()->name(), &k->m_bankNum, &k->m_patchNum, m_patchLabel );
 	pd.exec();

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -92,7 +92,7 @@ GigInstrument::GigInstrument( InstrumentTrack * _instrument_track ) :
 	m_RandomSeed( 0 ),
 	m_currentKeyDimension( 0 )
 {
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	updateSampleRate();
@@ -305,7 +305,7 @@ void GigInstrument::playNote( NotePlayHandle * _n, sampleFrame * )
 
 	if( tfp == 0 )
 	{
-		GIGPluginData * pluginData = new GIGPluginData;
+		auto* pluginData = new GIGPluginData;
 		pluginData->midiNote = midiNote;
 		_n->m_pluginData = pluginData;
 
@@ -593,7 +593,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	// Convert from 16 or 24 bit into 32-bit float
 	if( sample.sample->BitDepth == 24 ) // 24 bit
 	{
-		uint8_t * pInt = reinterpret_cast<uint8_t*>( &buffer );
+		auto* pInt = reinterpret_cast<uint8_t*>(&buffer);
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -625,7 +625,7 @@ void GigInstrument::loadSample( GigSample& sample, sampleFrame* sampleData, f_cn
 	}
 	else // 16 bit
 	{
-		int16_t * pInt = reinterpret_cast<int16_t*>( &buffer );
+		auto* pInt = reinterpret_cast<int16_t*>(&buffer);
 
 		for( f_cnt_t i = 0; i < samples; ++i )
 		{
@@ -684,7 +684,7 @@ f_cnt_t GigInstrument::getPingPongIndex( f_cnt_t index, f_cnt_t startf, f_cnt_t 
 // A key has been released
 void GigInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	GIGPluginData * pluginData = static_cast<GIGPluginData *>( _n->m_pluginData );
+	auto* pluginData = static_cast<GIGPluginData*>(_n->m_pluginData);
 	QMutexLocker locker( &m_notesMutex );
 
 	// Mark the note as being released, but only if it was playing or was just
@@ -931,7 +931,7 @@ public:
 GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _parent ) :
         InstrumentViewFixedSize( _instrument, _parent )
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto* k = castModel<GigInstrument>();
 
 	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
 	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
@@ -990,7 +990,7 @@ GigInstrumentView::GigInstrumentView( Instrument * _instrument, QWidget * _paren
 
 void GigInstrumentView::modelChanged()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto* k = castModel<GigInstrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1007,7 +1007,7 @@ void GigInstrumentView::modelChanged()
 
 void GigInstrumentView::updateFilename()
 {
-	GigInstrument * i = castModel<GigInstrument>();
+	auto* i = castModel<GigInstrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".gig", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1025,7 +1025,7 @@ void GigInstrumentView::updateFilename()
 
 void GigInstrumentView::updatePatchName()
 {
-	GigInstrument * i = castModel<GigInstrument>();
+	auto* i = castModel<GigInstrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1046,7 +1046,7 @@ void GigInstrumentView::invalidateFile()
 
 void GigInstrumentView::showFileDialog()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto* k = castModel<GigInstrument>();
 
 	FileDialog ofd( nullptr, tr( "Open GIG file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1087,7 +1087,7 @@ void GigInstrumentView::showFileDialog()
 
 void GigInstrumentView::showPatchDialog()
 {
-	GigInstrument * k = castModel<GigInstrument>();
+	auto* k = castModel<GigInstrument>();
 	PatchesDialog pd( this );
 	pd.setup( k->m_instance, 1, k->instrumentTrack()->name(), &k->m_bankNum, &k->m_patchNum, m_patchLabel );
 	pd.exec();

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -276,7 +276,7 @@ bool HydrogenImport::readSong()
 				QString instrId = LocalFileMng::readXmlString( noteNode, "instrument", 0,false, false );
 				int i = pattern_count - 1 + existing_patterns;
 				pattern_id[sName] = pattern_count - 1;
-				auto* p = dynamic_cast<MidiClip*>(drum_track[instrId]->getClip(i));
+				MidiClip*p = dynamic_cast<MidiClip*>( drum_track[instrId]->getClip( i ) );
 				Note n; 
 				n.setPos( nPosition );
 				if ( (nPosition + 48) <= nSize ) 

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -276,7 +276,7 @@ bool HydrogenImport::readSong()
 				QString instrId = LocalFileMng::readXmlString( noteNode, "instrument", 0,false, false );
 				int i = pattern_count - 1 + existing_patterns;
 				pattern_id[sName] = pattern_count - 1;
-				MidiClip*p = dynamic_cast<MidiClip*>( drum_track[instrId]->getClip( i ) );
+				auto* p = dynamic_cast<MidiClip*>(drum_track[instrId]->getClip(i));
 				Note n; 
 				n.setPos( nPosition );
 				if ( (nPosition + 48) <= nSize ) 

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -276,7 +276,7 @@ bool HydrogenImport::readSong()
 				QString instrId = LocalFileMng::readXmlString( noteNode, "instrument", 0,false, false );
 				int i = pattern_count - 1 + existing_patterns;
 				pattern_id[sName] = pattern_count - 1;
-				MidiClip*p = dynamic_cast<MidiClip*>( drum_track[instrId]->getClip( i ) );
+				auto p = dynamic_cast<MidiClip*>(drum_track[instrId]->getClip(i));
 				Note n; 
 				n.setPos( nPosition );
 				if ( (nPosition + 48) <= nSize ) 

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -185,7 +185,7 @@ void KickerInstrument::playNote( NotePlayHandle * _n,
 		_n->noteOff();
 	}
 
-	auto* so = static_cast<SweepOsc*>(_n->m_pluginData);
+	SweepOsc * so = static_cast<SweepOsc *>( _n->m_pluginData );
 	so->update( _working_buffer + offset, frames, Engine::audioEngine()->processingSampleRate() );
 
 	if( _n->isReleased() )
@@ -334,7 +334,7 @@ KickerInstrumentView::KickerInstrumentView( Instrument * _instrument,
 
 void KickerInstrumentView::modelChanged()
 {
-	auto* k = castModel<KickerInstrument>();
+	KickerInstrument * k = castModel<KickerInstrument>();
 	m_startFreqKnob->setModel( &k->m_startFreqModel );
 	m_endFreqKnob->setModel( &k->m_endFreqModel );
 	m_decayKnob->setModel( &k->m_decayModel );

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -185,7 +185,7 @@ void KickerInstrument::playNote( NotePlayHandle * _n,
 		_n->noteOff();
 	}
 
-	SweepOsc * so = static_cast<SweepOsc *>( _n->m_pluginData );
+	auto* so = static_cast<SweepOsc*>(_n->m_pluginData);
 	so->update( _working_buffer + offset, frames, Engine::audioEngine()->processingSampleRate() );
 
 	if( _n->isReleased() )
@@ -334,7 +334,7 @@ KickerInstrumentView::KickerInstrumentView( Instrument * _instrument,
 
 void KickerInstrumentView::modelChanged()
 {
-	KickerInstrument * k = castModel<KickerInstrument>();
+	auto* k = castModel<KickerInstrument>();
 	m_startFreqKnob->setModel( &k->m_startFreqModel );
 	m_endFreqKnob->setModel( &k->m_endFreqModel );
 	m_decayKnob->setModel( &k->m_decayModel );

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -185,7 +185,7 @@ void KickerInstrument::playNote( NotePlayHandle * _n,
 		_n->noteOff();
 	}
 
-	SweepOsc * so = static_cast<SweepOsc *>( _n->m_pluginData );
+	auto so = static_cast<SweepOsc*>(_n->m_pluginData);
 	so->update( _working_buffer + offset, frames, Engine::audioEngine()->processingSampleRate() );
 
 	if( _n->isReleased() )
@@ -334,7 +334,7 @@ KickerInstrumentView::KickerInstrumentView( Instrument * _instrument,
 
 void KickerInstrumentView::modelChanged()
 {
-	KickerInstrument * k = castModel<KickerInstrument>();
+	auto k = castModel<KickerInstrument>();
 	m_startFreqKnob->setModel( &k->m_startFreqModel );
 	m_endFreqKnob->setModel( &k->m_endFreqModel );
 	m_decayKnob->setModel( &k->m_decayModel );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -96,7 +96,7 @@ namespace gui
 LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	ToolPluginView( _tool  )
 {
-	auto* hlayout = new QHBoxLayout(this);
+	QHBoxLayout * hlayout = new QHBoxLayout( this );
 	hlayout->setSpacing( 0 );
 	hlayout->setMargin( 0 );
 
@@ -104,7 +104,7 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	m_tabBar->setExclusive( true );
 	m_tabBar->setFixedWidth( 72 );
 
-	auto* ws = new QWidget(this);
+	QWidget * ws = new QWidget( this );
 	ws->setFixedSize( 500, 480 );
 
 	QWidget * available = createTab( ws, tr( "Available Effects" ), VALID );
@@ -162,14 +162,14 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 							LadspaPluginType _type )
 {
-	auto* tab = new QWidget(_parent);
+	QWidget * tab = new QWidget( _parent );
 	tab->setFixedSize( 500, 400 );
-	auto* layout = new QVBoxLayout(tab);
+	QVBoxLayout * layout = new QVBoxLayout( tab );
 	layout->setSpacing( 0 );
 	layout->setMargin( 0 );
 
 	const QString type = "<b>" + tr( "Type:" ) + "</b> ";
-	auto* title = new QLabel(type + _txt, tab);
+	QLabel * title = new QLabel( type + _txt, tab );
 	QFont f = title->font();
 	f.setBold( true );
 	title->setFont( pointSize<12>( f ) );
@@ -178,7 +178,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	layout->addWidget( title );
 	layout->addSpacing( 10 );
 
-	auto* description = new LadspaDescription(tab, _type);
+	LadspaDescription * description = new LadspaDescription( tab, _type );
 	connect( description, SIGNAL( doubleClicked( const ::lmms::ladspa_key_t & ) ),
 				SLOT( showPorts( const ::lmms::ladspa_key_t & ) ) );
 	layout->addWidget( description, 1 );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -96,7 +96,7 @@ namespace gui
 LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	ToolPluginView( _tool  )
 {
-	QHBoxLayout * hlayout = new QHBoxLayout( this );
+	auto hlayout = new QHBoxLayout(this);
 	hlayout->setSpacing( 0 );
 	hlayout->setMargin( 0 );
 
@@ -104,7 +104,7 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	m_tabBar->setExclusive( true );
 	m_tabBar->setFixedWidth( 72 );
 
-	QWidget * ws = new QWidget( this );
+	auto ws = new QWidget(this);
 	ws->setFixedSize( 500, 480 );
 
 	QWidget * available = createTab( ws, tr( "Available Effects" ), VALID );
@@ -162,14 +162,14 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 							LadspaPluginType _type )
 {
-	QWidget * tab = new QWidget( _parent );
+	auto tab = new QWidget(_parent);
 	tab->setFixedSize( 500, 400 );
-	QVBoxLayout * layout = new QVBoxLayout( tab );
+	auto layout = new QVBoxLayout(tab);
 	layout->setSpacing( 0 );
 	layout->setMargin( 0 );
 
 	const QString type = "<b>" + tr( "Type:" ) + "</b> ";
-	QLabel * title = new QLabel( type + _txt, tab );
+	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
 	title->setFont( pointSize<12>( f ) );
@@ -178,7 +178,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	layout->addWidget( title );
 	layout->addSpacing( 10 );
 
-	LadspaDescription * description = new LadspaDescription( tab, _type );
+	auto description = new LadspaDescription(tab, _type);
 	connect( description, SIGNAL( doubleClicked( const ::lmms::ladspa_key_t & ) ),
 				SLOT( showPorts( const ::lmms::ladspa_key_t & ) ) );
 	layout->addWidget( description, 1 );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -96,7 +96,7 @@ namespace gui
 LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	ToolPluginView( _tool  )
 {
-	QHBoxLayout * hlayout = new QHBoxLayout( this );
+	auto* hlayout = new QHBoxLayout(this);
 	hlayout->setSpacing( 0 );
 	hlayout->setMargin( 0 );
 
@@ -104,7 +104,7 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	m_tabBar->setExclusive( true );
 	m_tabBar->setFixedWidth( 72 );
 
-	QWidget * ws = new QWidget( this );
+	auto* ws = new QWidget(this);
 	ws->setFixedSize( 500, 480 );
 
 	QWidget * available = createTab( ws, tr( "Available Effects" ), VALID );
@@ -162,14 +162,14 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 							LadspaPluginType _type )
 {
-	QWidget * tab = new QWidget( _parent );
+	auto* tab = new QWidget(_parent);
 	tab->setFixedSize( 500, 400 );
-	QVBoxLayout * layout = new QVBoxLayout( tab );
+	auto* layout = new QVBoxLayout(tab);
 	layout->setSpacing( 0 );
 	layout->setMargin( 0 );
 
 	const QString type = "<b>" + tr( "Type:" ) + "</b> ";
-	QLabel * title = new QLabel( type + _txt, tab );
+	auto* title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
 	title->setFont( pointSize<12>( f ) );
@@ -178,7 +178,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	layout->addWidget( title );
 	layout->addSpacing( 10 );
 
-	LadspaDescription * description = new LadspaDescription( tab, _type );
+	auto* description = new LadspaDescription(tab, _type);
 	connect( description, SIGNAL( doubleClicked( const ::lmms::ladspa_key_t & ) ),
 				SLOT( showPorts( const ::lmms::ladspa_key_t & ) ) );
 	layout->addWidget( description, 1 );

--- a/plugins/LadspaBrowser/LadspaDescription.cpp
+++ b/plugins/LadspaBrowser/LadspaDescription.cpp
@@ -84,8 +84,8 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 		}
 	}
 
-	QGroupBox * pluginsBox = new QGroupBox( tr( "Plugins" ), this );
-	QListWidget * pluginList = new QListWidget( pluginsBox );
+	auto pluginsBox = new QGroupBox(tr("Plugins"), this);
+	auto pluginList = new QListWidget(pluginsBox);
 	pluginList->addItems( pluginNames );
 	connect( pluginList, SIGNAL( currentRowChanged( int ) ),
 						SLOT( rowChanged( int ) ) );
@@ -93,15 +93,15 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 				SLOT( onDoubleClicked( QListWidgetItem * ) ) );
 	( new QVBoxLayout( pluginsBox ) )->addWidget( pluginList );
 
-	QGroupBox * descriptionBox = new QGroupBox( tr( "Description" ), this );
-	QVBoxLayout * descriptionLayout = new QVBoxLayout( descriptionBox );
+	auto descriptionBox = new QGroupBox(tr("Description"), this);
+	auto descriptionLayout = new QVBoxLayout(descriptionBox);
 	descriptionLayout->setSpacing( 0 );
 	descriptionLayout->setMargin( 0 );
 
 	m_scrollArea = new QScrollArea( descriptionBox );
 	descriptionLayout->addWidget( m_scrollArea );
 
-	QVBoxLayout * layout = new QVBoxLayout( this );
+	auto layout = new QVBoxLayout(this);
 	layout->addWidget( pluginsBox );
 	layout->addWidget( descriptionBox );
 
@@ -118,76 +118,76 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 
 void LadspaDescription::update( const ladspa_key_t & _key )
 {
-	QWidget * description = new QWidget;
+	auto description = new QWidget;
 	m_scrollArea->setWidget( description );
 
-	QVBoxLayout * layout = new QVBoxLayout( description );
+	auto layout = new QVBoxLayout(description);
 	layout->setSizeConstraint( QLayout::SetFixedSize );
 
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 
-	QLabel * name = new QLabel( description );
+	auto name = new QLabel(description);
 	name->setText( QWidget::tr( "Name: " ) + manager->getName( _key ) );
 	layout->addWidget( name );
 
-	QWidget * maker = new QWidget( description );
-	QHBoxLayout * makerLayout = new QHBoxLayout( maker );
+	auto maker = new QWidget(description);
+	auto makerLayout = new QHBoxLayout(maker);
 	makerLayout->setMargin( 0 );
 	makerLayout->setSpacing( 0 );
 	layout->addWidget( maker );
 
-	QLabel * maker_label = new QLabel( maker );
+	auto maker_label = new QLabel(maker);
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	QLabel * maker_content = new QLabel( maker );
+	auto maker_content = new QLabel(maker);
 	maker_content->setText( manager->getMaker( _key ) );
 	maker_content->setWordWrap( true );
 	makerLayout->addWidget( maker_label );
 	makerLayout->addWidget( maker_content, 1 );
 
-	QWidget * copyright = new QWidget( description );
-	QHBoxLayout * copyrightLayout = new QHBoxLayout( copyright );
+	auto copyright = new QWidget(description);
+	auto copyrightLayout = new QHBoxLayout(copyright);
 	copyrightLayout->setMargin( 0 );
 	copyrightLayout->setSpacing( 0 );
 	layout->addWidget( copyright );
 
-	QLabel * copyright_label = new QLabel( copyright );
+	auto copyright_label = new QLabel(copyright);
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	QLabel * copyright_content = new QLabel( copyright );
+	auto copyright_content = new QLabel(copyright);
 	copyright_content->setText( manager->getCopyright( _key ) );
 	copyright_content->setWordWrap( true );
 	copyrightLayout->addWidget( copyright_label );
 	copyrightLayout->addWidget( copyright_content, 1 );
 
-	QLabel * requiresRealTime = new QLabel( description );
+	auto requiresRealTime = new QLabel(description);
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 				( manager->hasRealTimeDependency( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( requiresRealTime );
 
-	QLabel * realTimeCapable = new QLabel( description );
+	auto realTimeCapable = new QLabel(description);
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( manager->isRealTimeCapable( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( realTimeCapable );
 
-	QLabel * inplaceBroken = new QLabel( description );
+	auto inplaceBroken = new QLabel(description);
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( manager->isInplaceBroken( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( inplaceBroken );
 
-	QLabel * channelsIn = new QLabel( description );
+	auto channelsIn = new QLabel(description);
 	channelsIn->setText( QWidget::tr( "Channels In: " ) + QString::number(
 			manager->getDescription( _key )->inputChannels ) );
 	layout->addWidget( channelsIn );
 
-	QLabel * channelsOut = new QLabel( description );
+	auto channelsOut = new QLabel(description);
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) + QString::number(
 			manager->getDescription( _key )->outputChannels ) );
 	layout->addWidget( channelsOut );

--- a/plugins/LadspaBrowser/LadspaDescription.cpp
+++ b/plugins/LadspaBrowser/LadspaDescription.cpp
@@ -84,8 +84,8 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 		}
 	}
 
-	QGroupBox * pluginsBox = new QGroupBox( tr( "Plugins" ), this );
-	QListWidget * pluginList = new QListWidget( pluginsBox );
+	auto* pluginsBox = new QGroupBox(tr("Plugins"), this);
+	auto* pluginList = new QListWidget(pluginsBox);
 	pluginList->addItems( pluginNames );
 	connect( pluginList, SIGNAL( currentRowChanged( int ) ),
 						SLOT( rowChanged( int ) ) );
@@ -93,15 +93,15 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 				SLOT( onDoubleClicked( QListWidgetItem * ) ) );
 	( new QVBoxLayout( pluginsBox ) )->addWidget( pluginList );
 
-	QGroupBox * descriptionBox = new QGroupBox( tr( "Description" ), this );
-	QVBoxLayout * descriptionLayout = new QVBoxLayout( descriptionBox );
+	auto* descriptionBox = new QGroupBox(tr("Description"), this);
+	auto* descriptionLayout = new QVBoxLayout(descriptionBox);
 	descriptionLayout->setSpacing( 0 );
 	descriptionLayout->setMargin( 0 );
 
 	m_scrollArea = new QScrollArea( descriptionBox );
 	descriptionLayout->addWidget( m_scrollArea );
 
-	QVBoxLayout * layout = new QVBoxLayout( this );
+	auto* layout = new QVBoxLayout(this);
 	layout->addWidget( pluginsBox );
 	layout->addWidget( descriptionBox );
 
@@ -118,76 +118,76 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 
 void LadspaDescription::update( const ladspa_key_t & _key )
 {
-	QWidget * description = new QWidget;
+	auto* description = new QWidget;
 	m_scrollArea->setWidget( description );
 
-	QVBoxLayout * layout = new QVBoxLayout( description );
+	auto* layout = new QVBoxLayout(description);
 	layout->setSizeConstraint( QLayout::SetFixedSize );
 
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 
-	QLabel * name = new QLabel( description );
+	auto* name = new QLabel(description);
 	name->setText( QWidget::tr( "Name: " ) + manager->getName( _key ) );
 	layout->addWidget( name );
 
-	QWidget * maker = new QWidget( description );
-	QHBoxLayout * makerLayout = new QHBoxLayout( maker );
+	auto* maker = new QWidget(description);
+	auto* makerLayout = new QHBoxLayout(maker);
 	makerLayout->setMargin( 0 );
 	makerLayout->setSpacing( 0 );
 	layout->addWidget( maker );
 
-	QLabel * maker_label = new QLabel( maker );
+	auto* maker_label = new QLabel(maker);
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	QLabel * maker_content = new QLabel( maker );
+	auto* maker_content = new QLabel(maker);
 	maker_content->setText( manager->getMaker( _key ) );
 	maker_content->setWordWrap( true );
 	makerLayout->addWidget( maker_label );
 	makerLayout->addWidget( maker_content, 1 );
 
-	QWidget * copyright = new QWidget( description );
-	QHBoxLayout * copyrightLayout = new QHBoxLayout( copyright );
+	auto* copyright = new QWidget(description);
+	auto* copyrightLayout = new QHBoxLayout(copyright);
 	copyrightLayout->setMargin( 0 );
 	copyrightLayout->setSpacing( 0 );
 	layout->addWidget( copyright );
 
-	QLabel * copyright_label = new QLabel( copyright );
+	auto* copyright_label = new QLabel(copyright);
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	QLabel * copyright_content = new QLabel( copyright );
+	auto* copyright_content = new QLabel(copyright);
 	copyright_content->setText( manager->getCopyright( _key ) );
 	copyright_content->setWordWrap( true );
 	copyrightLayout->addWidget( copyright_label );
 	copyrightLayout->addWidget( copyright_content, 1 );
 
-	QLabel * requiresRealTime = new QLabel( description );
+	auto* requiresRealTime = new QLabel(description);
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 				( manager->hasRealTimeDependency( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( requiresRealTime );
 
-	QLabel * realTimeCapable = new QLabel( description );
+	auto* realTimeCapable = new QLabel(description);
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( manager->isRealTimeCapable( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( realTimeCapable );
 
-	QLabel * inplaceBroken = new QLabel( description );
+	auto* inplaceBroken = new QLabel(description);
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( manager->isInplaceBroken( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( inplaceBroken );
 
-	QLabel * channelsIn = new QLabel( description );
+	auto* channelsIn = new QLabel(description);
 	channelsIn->setText( QWidget::tr( "Channels In: " ) + QString::number(
 			manager->getDescription( _key )->inputChannels ) );
 	layout->addWidget( channelsIn );
 
-	QLabel * channelsOut = new QLabel( description );
+	auto* channelsOut = new QLabel(description);
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) + QString::number(
 			manager->getDescription( _key )->outputChannels ) );
 	layout->addWidget( channelsOut );

--- a/plugins/LadspaBrowser/LadspaDescription.cpp
+++ b/plugins/LadspaBrowser/LadspaDescription.cpp
@@ -84,8 +84,8 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 		}
 	}
 
-	auto* pluginsBox = new QGroupBox(tr("Plugins"), this);
-	auto* pluginList = new QListWidget(pluginsBox);
+	QGroupBox * pluginsBox = new QGroupBox( tr( "Plugins" ), this );
+	QListWidget * pluginList = new QListWidget( pluginsBox );
 	pluginList->addItems( pluginNames );
 	connect( pluginList, SIGNAL( currentRowChanged( int ) ),
 						SLOT( rowChanged( int ) ) );
@@ -93,15 +93,15 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 				SLOT( onDoubleClicked( QListWidgetItem * ) ) );
 	( new QVBoxLayout( pluginsBox ) )->addWidget( pluginList );
 
-	auto* descriptionBox = new QGroupBox(tr("Description"), this);
-	auto* descriptionLayout = new QVBoxLayout(descriptionBox);
+	QGroupBox * descriptionBox = new QGroupBox( tr( "Description" ), this );
+	QVBoxLayout * descriptionLayout = new QVBoxLayout( descriptionBox );
 	descriptionLayout->setSpacing( 0 );
 	descriptionLayout->setMargin( 0 );
 
 	m_scrollArea = new QScrollArea( descriptionBox );
 	descriptionLayout->addWidget( m_scrollArea );
 
-	auto* layout = new QVBoxLayout(this);
+	QVBoxLayout * layout = new QVBoxLayout( this );
 	layout->addWidget( pluginsBox );
 	layout->addWidget( descriptionBox );
 
@@ -118,76 +118,76 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 
 void LadspaDescription::update( const ladspa_key_t & _key )
 {
-	auto* description = new QWidget;
+	QWidget * description = new QWidget;
 	m_scrollArea->setWidget( description );
 
-	auto* layout = new QVBoxLayout(description);
+	QVBoxLayout * layout = new QVBoxLayout( description );
 	layout->setSizeConstraint( QLayout::SetFixedSize );
 
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 
-	auto* name = new QLabel(description);
+	QLabel * name = new QLabel( description );
 	name->setText( QWidget::tr( "Name: " ) + manager->getName( _key ) );
 	layout->addWidget( name );
 
-	auto* maker = new QWidget(description);
-	auto* makerLayout = new QHBoxLayout(maker);
+	QWidget * maker = new QWidget( description );
+	QHBoxLayout * makerLayout = new QHBoxLayout( maker );
 	makerLayout->setMargin( 0 );
 	makerLayout->setSpacing( 0 );
 	layout->addWidget( maker );
 
-	auto* maker_label = new QLabel(maker);
+	QLabel * maker_label = new QLabel( maker );
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	auto* maker_content = new QLabel(maker);
+	QLabel * maker_content = new QLabel( maker );
 	maker_content->setText( manager->getMaker( _key ) );
 	maker_content->setWordWrap( true );
 	makerLayout->addWidget( maker_label );
 	makerLayout->addWidget( maker_content, 1 );
 
-	auto* copyright = new QWidget(description);
-	auto* copyrightLayout = new QHBoxLayout(copyright);
+	QWidget * copyright = new QWidget( description );
+	QHBoxLayout * copyrightLayout = new QHBoxLayout( copyright );
 	copyrightLayout->setMargin( 0 );
 	copyrightLayout->setSpacing( 0 );
 	layout->addWidget( copyright );
 
-	auto* copyright_label = new QLabel(copyright);
+	QLabel * copyright_label = new QLabel( copyright );
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	auto* copyright_content = new QLabel(copyright);
+	QLabel * copyright_content = new QLabel( copyright );
 	copyright_content->setText( manager->getCopyright( _key ) );
 	copyright_content->setWordWrap( true );
 	copyrightLayout->addWidget( copyright_label );
 	copyrightLayout->addWidget( copyright_content, 1 );
 
-	auto* requiresRealTime = new QLabel(description);
+	QLabel * requiresRealTime = new QLabel( description );
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 				( manager->hasRealTimeDependency( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( requiresRealTime );
 
-	auto* realTimeCapable = new QLabel(description);
+	QLabel * realTimeCapable = new QLabel( description );
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( manager->isRealTimeCapable( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( realTimeCapable );
 
-	auto* inplaceBroken = new QLabel(description);
+	QLabel * inplaceBroken = new QLabel( description );
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( manager->isInplaceBroken( _key ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 	layout->addWidget( inplaceBroken );
 
-	auto* channelsIn = new QLabel(description);
+	QLabel * channelsIn = new QLabel( description );
 	channelsIn->setText( QWidget::tr( "Channels In: " ) + QString::number(
 			manager->getDescription( _key )->inputChannels ) );
 	layout->addWidget( channelsIn );
 
-	auto* channelsOut = new QLabel(description);
+	QLabel * channelsOut = new QLabel( description );
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) + QString::number(
 			manager->getDescription( _key )->outputChannels ) );
 	layout->addWidget( channelsOut );

--- a/plugins/LadspaBrowser/LadspaPortDialog.cpp
+++ b/plugins/LadspaBrowser/LadspaPortDialog.cpp
@@ -45,13 +45,13 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	setWindowTitle( tr( "Ports" ) );
 	setModal( true );
 
-	QVBoxLayout * vlayout = new QVBoxLayout( this );
+	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing( 0 );
 	vlayout->setMargin( 0 );
 
 	int pc = manager->getPortCount( _key );
 
-	QTableWidget * settings = new QTableWidget( pc, 7, this );
+	auto settings = new QTableWidget(pc, 7, this);
 
 	QStringList ports;
 	ports.append( tr( "Name" ) );
@@ -67,7 +67,7 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	{
 		for( int col = 0; col < 7; ++col )
 		{
-			QTableWidgetItem * item = new QTableWidgetItem;
+			auto item = new QTableWidgetItem;
 			item->setFlags(QFlag(0));
 			settings->setItem( row, col, item );
 		}

--- a/plugins/LadspaBrowser/LadspaPortDialog.cpp
+++ b/plugins/LadspaBrowser/LadspaPortDialog.cpp
@@ -45,13 +45,13 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	setWindowTitle( tr( "Ports" ) );
 	setModal( true );
 
-	QVBoxLayout * vlayout = new QVBoxLayout( this );
+	auto* vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing( 0 );
 	vlayout->setMargin( 0 );
 
 	int pc = manager->getPortCount( _key );
 
-	QTableWidget * settings = new QTableWidget( pc, 7, this );
+	auto* settings = new QTableWidget(pc, 7, this);
 
 	QStringList ports;
 	ports.append( tr( "Name" ) );
@@ -67,7 +67,7 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	{
 		for( int col = 0; col < 7; ++col )
 		{
-			QTableWidgetItem * item = new QTableWidgetItem;
+			auto* item = new QTableWidgetItem;
 			item->setFlags(QFlag(0));
 			settings->setItem( row, col, item );
 		}

--- a/plugins/LadspaBrowser/LadspaPortDialog.cpp
+++ b/plugins/LadspaBrowser/LadspaPortDialog.cpp
@@ -45,13 +45,13 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	setWindowTitle( tr( "Ports" ) );
 	setModal( true );
 
-	auto* vlayout = new QVBoxLayout(this);
+	QVBoxLayout * vlayout = new QVBoxLayout( this );
 	vlayout->setSpacing( 0 );
 	vlayout->setMargin( 0 );
 
 	int pc = manager->getPortCount( _key );
 
-	auto* settings = new QTableWidget(pc, 7, this);
+	QTableWidget * settings = new QTableWidget( pc, 7, this );
 
 	QStringList ports;
 	ports.append( tr( "Name" ) );
@@ -67,7 +67,7 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 	{
 		for( int col = 0; col < 7; ++col )
 		{
-			auto* item = new QTableWidgetItem;
+			QTableWidgetItem * item = new QTableWidgetItem;
 			item->setFlags(QFlag(0));
 			settings->setItem( row, col, item );
 		}

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -46,7 +46,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	m_effectLayout( nullptr ),
 	m_stereoLink( nullptr )
 {
-	QVBoxLayout * mainLay = new QVBoxLayout( this );
+	auto mainLay = new QVBoxLayout(this);
 
 	m_effectLayout = new QHBoxLayout();
 	mainLay->addLayout( m_effectLayout );
@@ -56,7 +56,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	if( _ctl->m_processors > 1 )
 	{
 		mainLay->addSpacing( 3 );
-		QHBoxLayout * center = new QHBoxLayout();
+		auto center = new QHBoxLayout();
 		mainLay->addLayout( center );
 		m_stereoLink = new LedCheckBox( tr( "Link Channels" ), this );
 		m_stereoLink->setModel( &_ctl->m_stereoLinkModel );
@@ -101,7 +101,7 @@ void LadspaControlDialog::updateEffectView( LadspaControls * _ctl )
 			grouper = new QGroupBox( this );
 		}
 
-		QGridLayout * gl = new QGridLayout( grouper );
+		auto gl = new QGridLayout(grouper);
 		grouper->setLayout( gl );
 		grouper->setAlignment( Qt::Vertical );
 

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -46,7 +46,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	m_effectLayout( nullptr ),
 	m_stereoLink( nullptr )
 {
-	QVBoxLayout * mainLay = new QVBoxLayout( this );
+	auto* mainLay = new QVBoxLayout(this);
 
 	m_effectLayout = new QHBoxLayout();
 	mainLay->addLayout( m_effectLayout );
@@ -56,7 +56,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	if( _ctl->m_processors > 1 )
 	{
 		mainLay->addSpacing( 3 );
-		QHBoxLayout * center = new QHBoxLayout();
+		auto* center = new QHBoxLayout();
 		mainLay->addLayout( center );
 		m_stereoLink = new LedCheckBox( tr( "Link Channels" ), this );
 		m_stereoLink->setModel( &_ctl->m_stereoLinkModel );
@@ -101,7 +101,7 @@ void LadspaControlDialog::updateEffectView( LadspaControls * _ctl )
 			grouper = new QGroupBox( this );
 		}
 
-		QGridLayout * gl = new QGridLayout( grouper );
+		auto* gl = new QGridLayout(grouper);
 		grouper->setLayout( gl );
 		grouper->setAlignment( Qt::Vertical );
 

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -46,7 +46,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	m_effectLayout( nullptr ),
 	m_stereoLink( nullptr )
 {
-	auto* mainLay = new QVBoxLayout(this);
+	QVBoxLayout * mainLay = new QVBoxLayout( this );
 
 	m_effectLayout = new QHBoxLayout();
 	mainLay->addLayout( m_effectLayout );
@@ -56,7 +56,7 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	if( _ctl->m_processors > 1 )
 	{
 		mainLay->addSpacing( 3 );
-		auto* center = new QHBoxLayout();
+		QHBoxLayout * center = new QHBoxLayout();
 		mainLay->addLayout( center );
 		m_stereoLink = new LedCheckBox( tr( "Link Channels" ), this );
 		m_stereoLink->setModel( &_ctl->m_stereoLinkModel );
@@ -101,7 +101,7 @@ void LadspaControlDialog::updateEffectView( LadspaControls * _ctl )
 			grouper = new QGroupBox( this );
 		}
 
-		auto* gl = new QGridLayout(grouper);
+		QGridLayout * gl = new QGridLayout( grouper );
 		grouper->setLayout( gl );
 		grouper->setAlignment( Qt::Vertical );
 

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -311,7 +311,7 @@ void LadspaEffect::pluginInstantiation()
 		multi_proc_t ports;
 		for( int port = 0; port < m_portCount; port++ )
 		{
-			auto* p = new port_desc_t;
+			port_desc_t * p = new port_desc_t;
 
 			p->name = manager->getPortName( m_key, port );
 			p->proc = proc;

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -311,7 +311,7 @@ void LadspaEffect::pluginInstantiation()
 		multi_proc_t ports;
 		for( int port = 0; port < m_portCount; port++ )
 		{
-			port_desc_t * p = new port_desc_t;
+			auto* p = new port_desc_t;
 
 			p->name = manager->getPortName( m_key, port );
 			p->proc = proc;

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -311,7 +311,7 @@ void LadspaEffect::pluginInstantiation()
 		multi_proc_t ports;
 		for( int port = 0; port < m_portCount; port++ )
 		{
-			port_desc_t * p = new port_desc_t;
+			auto p = new port_desc_t;
 
 			p->name = manager->getPortName( m_key, port );
 			p->proc = proc;

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -63,65 +63,65 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	const ladspa_key_t & lkey = subPluginKeyToLadspaKey( _key );
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
 
-	auto* label = new QLabel(_parent);
+	QLabel * label = new QLabel( _parent );
 	label->setText( QWidget::tr( "Name: " ) + lm->getName( lkey ) );
 
-	auto* fileInfo = new QLabel(_parent);
+	QLabel* fileInfo = new QLabel( _parent );
 	fileInfo->setText( QWidget::tr( "File: %1" ).arg( lkey.first ) );
 
-	auto* maker = new QWidget(_parent);
-	auto* l = new QHBoxLayout(maker);
+	QWidget * maker = new QWidget( _parent );
+	QHBoxLayout * l = new QHBoxLayout( maker );
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
-	auto* maker_label = new QLabel(maker);
+	QLabel * maker_label = new QLabel( maker );
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	auto* maker_content = new QLabel(maker);
+	QLabel * maker_content = new QLabel( maker );
 	maker_content->setText( lm->getMaker( lkey ) );
 	maker_content->setWordWrap( true );
 	l->addWidget( maker_label );
 	l->addWidget( maker_content, 1 );
 
-	auto* copyright = new QWidget(_parent);
+	QWidget * copyright = new QWidget( _parent );
 	l = new QHBoxLayout( copyright );
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
 	copyright->setMinimumWidth( _parent->minimumWidth() );
-	auto* copyright_label = new QLabel(copyright);
+	QLabel * copyright_label = new QLabel( copyright );
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	auto* copyright_content = new QLabel(copyright);
+	QLabel * copyright_content = new QLabel( copyright );
 	copyright_content->setText( lm->getCopyright( lkey ) );
 	copyright_content->setWordWrap( true );
 	l->addWidget( copyright_label );
 	l->addWidget( copyright_content, 1 );
 
-	auto* requiresRealTime = new QLabel(_parent);
+	QLabel * requiresRealTime = new QLabel( _parent );
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 					( lm->hasRealTimeDependency( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	auto* realTimeCapable = new QLabel(_parent);
+	QLabel * realTimeCapable = new QLabel( _parent );
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( lm->isRealTimeCapable( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	auto* inplaceBroken = new QLabel(_parent);
+	QLabel * inplaceBroken = new QLabel( _parent );
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( lm->isInplaceBroken( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
-
-	auto* channelsIn = new QLabel(_parent);
+	
+	QLabel * channelsIn = new QLabel( _parent );
 	channelsIn->setText( QWidget::tr( "Channels In: " ) +
 		QString::number( lm->getDescription( lkey )->inputChannels ) );
 
-	auto* channelsOut = new QLabel(_parent);
+	QLabel * channelsOut = new QLabel( _parent );
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) +
 		QString::number( lm->getDescription( lkey )->outputChannels ) );	
 }

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -63,65 +63,65 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	const ladspa_key_t & lkey = subPluginKeyToLadspaKey( _key );
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
 
-	QLabel * label = new QLabel( _parent );
+	auto label = new QLabel(_parent);
 	label->setText( QWidget::tr( "Name: " ) + lm->getName( lkey ) );
 
-	QLabel* fileInfo = new QLabel( _parent );
+	auto fileInfo = new QLabel(_parent);
 	fileInfo->setText( QWidget::tr( "File: %1" ).arg( lkey.first ) );
 
-	QWidget * maker = new QWidget( _parent );
-	QHBoxLayout * l = new QHBoxLayout( maker );
+	auto maker = new QWidget(_parent);
+	auto l = new QHBoxLayout(maker);
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
-	QLabel * maker_label = new QLabel( maker );
+	auto maker_label = new QLabel(maker);
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	QLabel * maker_content = new QLabel( maker );
+	auto maker_content = new QLabel(maker);
 	maker_content->setText( lm->getMaker( lkey ) );
 	maker_content->setWordWrap( true );
 	l->addWidget( maker_label );
 	l->addWidget( maker_content, 1 );
 
-	QWidget * copyright = new QWidget( _parent );
+	auto copyright = new QWidget(_parent);
 	l = new QHBoxLayout( copyright );
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
 	copyright->setMinimumWidth( _parent->minimumWidth() );
-	QLabel * copyright_label = new QLabel( copyright );
+	auto copyright_label = new QLabel(copyright);
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	QLabel * copyright_content = new QLabel( copyright );
+	auto copyright_content = new QLabel(copyright);
 	copyright_content->setText( lm->getCopyright( lkey ) );
 	copyright_content->setWordWrap( true );
 	l->addWidget( copyright_label );
 	l->addWidget( copyright_content, 1 );
 
-	QLabel * requiresRealTime = new QLabel( _parent );
+	auto requiresRealTime = new QLabel(_parent);
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 					( lm->hasRealTimeDependency( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	QLabel * realTimeCapable = new QLabel( _parent );
+	auto realTimeCapable = new QLabel(_parent);
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( lm->isRealTimeCapable( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	QLabel * inplaceBroken = new QLabel( _parent );
+	auto inplaceBroken = new QLabel(_parent);
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( lm->isInplaceBroken( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
-	
-	QLabel * channelsIn = new QLabel( _parent );
+
+	auto channelsIn = new QLabel(_parent);
 	channelsIn->setText( QWidget::tr( "Channels In: " ) +
 		QString::number( lm->getDescription( lkey )->inputChannels ) );
 
-	QLabel * channelsOut = new QLabel( _parent );
+	auto channelsOut = new QLabel(_parent);
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) +
 		QString::number( lm->getDescription( lkey )->outputChannels ) );	
 }

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -63,65 +63,65 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	const ladspa_key_t & lkey = subPluginKeyToLadspaKey( _key );
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
 
-	QLabel * label = new QLabel( _parent );
+	auto* label = new QLabel(_parent);
 	label->setText( QWidget::tr( "Name: " ) + lm->getName( lkey ) );
 
-	QLabel* fileInfo = new QLabel( _parent );
+	auto* fileInfo = new QLabel(_parent);
 	fileInfo->setText( QWidget::tr( "File: %1" ).arg( lkey.first ) );
 
-	QWidget * maker = new QWidget( _parent );
-	QHBoxLayout * l = new QHBoxLayout( maker );
+	auto* maker = new QWidget(_parent);
+	auto* l = new QHBoxLayout(maker);
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
-	QLabel * maker_label = new QLabel( maker );
+	auto* maker_label = new QLabel(maker);
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
-	QLabel * maker_content = new QLabel( maker );
+	auto* maker_content = new QLabel(maker);
 	maker_content->setText( lm->getMaker( lkey ) );
 	maker_content->setWordWrap( true );
 	l->addWidget( maker_label );
 	l->addWidget( maker_content, 1 );
 
-	QWidget * copyright = new QWidget( _parent );
+	auto* copyright = new QWidget(_parent);
 	l = new QHBoxLayout( copyright );
 	l->setMargin( 0 );
 	l->setSpacing( 0 );
 
 	copyright->setMinimumWidth( _parent->minimumWidth() );
-	QLabel * copyright_label = new QLabel( copyright );
+	auto* copyright_label = new QLabel(copyright);
 	copyright_label->setText( QWidget::tr( "Copyright: " ) );
 	copyright_label->setAlignment( Qt::AlignTop );
 
-	QLabel * copyright_content = new QLabel( copyright );
+	auto* copyright_content = new QLabel(copyright);
 	copyright_content->setText( lm->getCopyright( lkey ) );
 	copyright_content->setWordWrap( true );
 	l->addWidget( copyright_label );
 	l->addWidget( copyright_content, 1 );
 
-	QLabel * requiresRealTime = new QLabel( _parent );
+	auto* requiresRealTime = new QLabel(_parent);
 	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
 					( lm->hasRealTimeDependency( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	QLabel * realTimeCapable = new QLabel( _parent );
+	auto* realTimeCapable = new QLabel(_parent);
 	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
 					( lm->isRealTimeCapable( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
 
-	QLabel * inplaceBroken = new QLabel( _parent );
+	auto* inplaceBroken = new QLabel(_parent);
 	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
 					( lm->isInplaceBroken( lkey ) ?
 							QWidget::tr( "Yes" ) :
 							QWidget::tr( "No" ) ) );
-	
-	QLabel * channelsIn = new QLabel( _parent );
+
+	auto* channelsIn = new QLabel(_parent);
 	channelsIn->setText( QWidget::tr( "Channels In: " ) +
 		QString::number( lm->getDescription( lkey )->inputChannels ) );
 
-	QLabel * channelsOut = new QLabel( _parent );
+	auto* channelsOut = new QLabel(_parent);
 	channelsOut->setText( QWidget::tr( "Channels Out: " ) +
 		QString::number( lm->getDescription( lkey )->outputChannels ) );	
 }

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -349,7 +349,7 @@ Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
 
 	filterChanged();
 
-	auto* iph = new InstrumentPlayHandle(this, _instrumentTrack);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -869,7 +869,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	// move to 120,75
 	const int waveBtnX = 10;
 	const int waveBtnY = 96;
-	auto* sawWaveBtn = new PixmapButton(this, tr("Saw wave"));
+	PixmapButton * sawWaveBtn = new PixmapButton( this, tr( "Saw wave" ) );
 	sawWaveBtn->move( waveBtnX, waveBtnY );
 	sawWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -878,7 +878,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sawWaveBtn->setToolTip(
 			tr( "Click here for a saw-wave." ) );
 
-	auto* triangleWaveBtn = new PixmapButton(this, tr("Triangle wave"));
+	PixmapButton * triangleWaveBtn =
+		new PixmapButton( this, tr( "Triangle wave" ) );
 	triangleWaveBtn->move( waveBtnX+(16*1), waveBtnY );
 	triangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -887,7 +888,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	triangleWaveBtn->setToolTip(
 			tr( "Click here for a triangle-wave." ) );
 
-	auto* sqrWaveBtn = new PixmapButton(this, tr("Square wave"));
+	PixmapButton * sqrWaveBtn = new PixmapButton( this, tr( "Square wave" ) );
 	sqrWaveBtn->move( waveBtnX+(16*2), waveBtnY );
 	sqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -896,7 +897,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave." ) );
 
-	auto* roundSqrWaveBtn = new PixmapButton(this, tr("Rounded square wave"));
+	PixmapButton * roundSqrWaveBtn =
+		new PixmapButton( this, tr( "Rounded square wave" ) );
 	roundSqrWaveBtn->move( waveBtnX+(16*3), waveBtnY );
 	roundSqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"round_square_wave_active" ) );
@@ -905,7 +907,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	roundSqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave with a rounded end." ) );
 
-	auto* moogWaveBtn = new PixmapButton(this, tr("Moog wave"));
+	PixmapButton * moogWaveBtn =
+		new PixmapButton( this, tr( "Moog wave" ) );
 	moogWaveBtn->move( waveBtnX+(16*4), waveBtnY );
 	moogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -914,7 +917,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	moogWaveBtn->setToolTip(
 			tr( "Click here for a moog-like wave." ) );
 
-	auto* sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
+	PixmapButton * sinWaveBtn = new PixmapButton( this, tr( "Sine wave" ) );
 	sinWaveBtn->move( waveBtnX+(16*5), waveBtnY );
 	sinWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -923,7 +926,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sinWaveBtn->setToolTip(
 			tr( "Click for a sine-wave." ) );
 
-	auto* exponentialWaveBtn = new PixmapButton(this, tr("White noise wave"));
+	PixmapButton * exponentialWaveBtn =
+		new PixmapButton( this, tr( "White noise wave" ) );
 	exponentialWaveBtn->move( waveBtnX+(16*6), waveBtnY );
 	exponentialWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "exp_wave_active" ) );
@@ -932,7 +936,9 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	exponentialWaveBtn->setToolTip(
 			tr( "Click here for an exponential wave." ) );
 
-	auto* whiteNoiseWaveBtn = new PixmapButton(this, tr("White noise wave"));
+
+	PixmapButton * whiteNoiseWaveBtn =
+		new PixmapButton( this, tr( "White noise wave" ) );
 	whiteNoiseWaveBtn->move( waveBtnX+(16*7), waveBtnY );
 	whiteNoiseWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -941,7 +947,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	whiteNoiseWaveBtn->setToolTip(
 			tr( "Click here for white-noise." ) );
 
-	auto* blSawWaveBtn = new PixmapButton(this, tr("Bandlimited saw wave"));
+	PixmapButton * blSawWaveBtn =
+		new PixmapButton( this, tr( "Bandlimited saw wave" ) );
 	blSawWaveBtn->move( waveBtnX+(16*9)-8, waveBtnY );
 	blSawWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "saw_wave_active" ) );
@@ -950,7 +957,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSawWaveBtn->setToolTip(
 			tr( "Click here for bandlimited saw wave." ) );
 
-	auto* blSquareWaveBtn = new PixmapButton(this, tr("Bandlimited square wave"));
+	PixmapButton * blSquareWaveBtn =
+		new PixmapButton( this, tr( "Bandlimited square wave" ) );
 	blSquareWaveBtn->move( waveBtnX+(16*10)-8, waveBtnY );
 	blSquareWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "square_wave_active" ) );
@@ -959,7 +967,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSquareWaveBtn->setToolTip(
 			tr( "Click here for bandlimited square wave." ) );
 
-	auto* blTriangleWaveBtn = new PixmapButton(this, tr("Bandlimited triangle wave"));
+	PixmapButton * blTriangleWaveBtn =
+		new PixmapButton( this, tr( "Bandlimited triangle wave" ) );
 	blTriangleWaveBtn->move( waveBtnX+(16*11)-8, waveBtnY );
 	blTriangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -968,7 +977,8 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blTriangleWaveBtn->setToolTip(
 			tr( "Click here for bandlimited triangle wave." ) );
 
-	auto* blMoogWaveBtn = new PixmapButton(this, tr("Bandlimited moog saw wave"));
+	PixmapButton * blMoogWaveBtn =
+		new PixmapButton( this, tr( "Bandlimited moog saw wave" ) );
 	blMoogWaveBtn->move( waveBtnX+(16*12)-8, waveBtnY );
 	blMoogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -1002,7 +1012,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 
 void Lb302SynthView::modelChanged()
 {
-	auto* syn = castModel<Lb302Synth>();
+	Lb302Synth * syn = castModel<Lb302Synth>();
 
 	m_vcfCutKnob->setModel( &syn->vcf_cut_knob );
 	m_vcfResKnob->setModel( &syn->vcf_res_knob );

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -349,7 +349,7 @@ Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
 
 	filterChanged();
 
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
+	auto iph = new InstrumentPlayHandle(this, _instrumentTrack);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -869,7 +869,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	// move to 120,75
 	const int waveBtnX = 10;
 	const int waveBtnY = 96;
-	PixmapButton * sawWaveBtn = new PixmapButton( this, tr( "Saw wave" ) );
+	auto sawWaveBtn = new PixmapButton(this, tr("Saw wave"));
 	sawWaveBtn->move( waveBtnX, waveBtnY );
 	sawWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -878,8 +878,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sawWaveBtn->setToolTip(
 			tr( "Click here for a saw-wave." ) );
 
-	PixmapButton * triangleWaveBtn =
-		new PixmapButton( this, tr( "Triangle wave" ) );
+	auto triangleWaveBtn = new PixmapButton(this, tr("Triangle wave"));
 	triangleWaveBtn->move( waveBtnX+(16*1), waveBtnY );
 	triangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -888,7 +887,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	triangleWaveBtn->setToolTip(
 			tr( "Click here for a triangle-wave." ) );
 
-	PixmapButton * sqrWaveBtn = new PixmapButton( this, tr( "Square wave" ) );
+	auto sqrWaveBtn = new PixmapButton(this, tr("Square wave"));
 	sqrWaveBtn->move( waveBtnX+(16*2), waveBtnY );
 	sqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -897,8 +896,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave." ) );
 
-	PixmapButton * roundSqrWaveBtn =
-		new PixmapButton( this, tr( "Rounded square wave" ) );
+	auto roundSqrWaveBtn = new PixmapButton(this, tr("Rounded square wave"));
 	roundSqrWaveBtn->move( waveBtnX+(16*3), waveBtnY );
 	roundSqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"round_square_wave_active" ) );
@@ -907,8 +905,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	roundSqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave with a rounded end." ) );
 
-	PixmapButton * moogWaveBtn =
-		new PixmapButton( this, tr( "Moog wave" ) );
+	auto moogWaveBtn = new PixmapButton(this, tr("Moog wave"));
 	moogWaveBtn->move( waveBtnX+(16*4), waveBtnY );
 	moogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -917,7 +914,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	moogWaveBtn->setToolTip(
 			tr( "Click here for a moog-like wave." ) );
 
-	PixmapButton * sinWaveBtn = new PixmapButton( this, tr( "Sine wave" ) );
+	auto sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
 	sinWaveBtn->move( waveBtnX+(16*5), waveBtnY );
 	sinWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -926,8 +923,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sinWaveBtn->setToolTip(
 			tr( "Click for a sine-wave." ) );
 
-	PixmapButton * exponentialWaveBtn =
-		new PixmapButton( this, tr( "White noise wave" ) );
+	auto exponentialWaveBtn = new PixmapButton(this, tr("White noise wave"));
 	exponentialWaveBtn->move( waveBtnX+(16*6), waveBtnY );
 	exponentialWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "exp_wave_active" ) );
@@ -936,9 +932,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	exponentialWaveBtn->setToolTip(
 			tr( "Click here for an exponential wave." ) );
 
-
-	PixmapButton * whiteNoiseWaveBtn =
-		new PixmapButton( this, tr( "White noise wave" ) );
+	auto whiteNoiseWaveBtn = new PixmapButton(this, tr("White noise wave"));
 	whiteNoiseWaveBtn->move( waveBtnX+(16*7), waveBtnY );
 	whiteNoiseWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -947,8 +941,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	whiteNoiseWaveBtn->setToolTip(
 			tr( "Click here for white-noise." ) );
 
-	PixmapButton * blSawWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited saw wave" ) );
+	auto blSawWaveBtn = new PixmapButton(this, tr("Bandlimited saw wave"));
 	blSawWaveBtn->move( waveBtnX+(16*9)-8, waveBtnY );
 	blSawWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "saw_wave_active" ) );
@@ -957,8 +950,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSawWaveBtn->setToolTip(
 			tr( "Click here for bandlimited saw wave." ) );
 
-	PixmapButton * blSquareWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited square wave" ) );
+	auto blSquareWaveBtn = new PixmapButton(this, tr("Bandlimited square wave"));
 	blSquareWaveBtn->move( waveBtnX+(16*10)-8, waveBtnY );
 	blSquareWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "square_wave_active" ) );
@@ -967,8 +959,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSquareWaveBtn->setToolTip(
 			tr( "Click here for bandlimited square wave." ) );
 
-	PixmapButton * blTriangleWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited triangle wave" ) );
+	auto blTriangleWaveBtn = new PixmapButton(this, tr("Bandlimited triangle wave"));
 	blTriangleWaveBtn->move( waveBtnX+(16*11)-8, waveBtnY );
 	blTriangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -977,8 +968,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blTriangleWaveBtn->setToolTip(
 			tr( "Click here for bandlimited triangle wave." ) );
 
-	PixmapButton * blMoogWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited moog saw wave" ) );
+	auto blMoogWaveBtn = new PixmapButton(this, tr("Bandlimited moog saw wave"));
 	blMoogWaveBtn->move( waveBtnX+(16*12)-8, waveBtnY );
 	blMoogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -1012,7 +1002,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 
 void Lb302SynthView::modelChanged()
 {
-	Lb302Synth * syn = castModel<Lb302Synth>();
+	auto syn = castModel<Lb302Synth>();
 
 	m_vcfCutKnob->setModel( &syn->vcf_cut_knob );
 	m_vcfResKnob->setModel( &syn->vcf_res_knob );

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -349,7 +349,7 @@ Lb302Synth::Lb302Synth( InstrumentTrack * _instrumentTrack ) :
 
 	filterChanged();
 
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
+	auto* iph = new InstrumentPlayHandle(this, _instrumentTrack);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -869,7 +869,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	// move to 120,75
 	const int waveBtnX = 10;
 	const int waveBtnY = 96;
-	PixmapButton * sawWaveBtn = new PixmapButton( this, tr( "Saw wave" ) );
+	auto* sawWaveBtn = new PixmapButton(this, tr("Saw wave"));
 	sawWaveBtn->move( waveBtnX, waveBtnY );
 	sawWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -878,8 +878,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sawWaveBtn->setToolTip(
 			tr( "Click here for a saw-wave." ) );
 
-	PixmapButton * triangleWaveBtn =
-		new PixmapButton( this, tr( "Triangle wave" ) );
+	auto* triangleWaveBtn = new PixmapButton(this, tr("Triangle wave"));
 	triangleWaveBtn->move( waveBtnX+(16*1), waveBtnY );
 	triangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -888,7 +887,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	triangleWaveBtn->setToolTip(
 			tr( "Click here for a triangle-wave." ) );
 
-	PixmapButton * sqrWaveBtn = new PixmapButton( this, tr( "Square wave" ) );
+	auto* sqrWaveBtn = new PixmapButton(this, tr("Square wave"));
 	sqrWaveBtn->move( waveBtnX+(16*2), waveBtnY );
 	sqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -897,8 +896,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave." ) );
 
-	PixmapButton * roundSqrWaveBtn =
-		new PixmapButton( this, tr( "Rounded square wave" ) );
+	auto* roundSqrWaveBtn = new PixmapButton(this, tr("Rounded square wave"));
 	roundSqrWaveBtn->move( waveBtnX+(16*3), waveBtnY );
 	roundSqrWaveBtn->setActiveGraphic( embed::getIconPixmap(
 					"round_square_wave_active" ) );
@@ -907,8 +905,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	roundSqrWaveBtn->setToolTip(
 			tr( "Click here for a square-wave with a rounded end." ) );
 
-	PixmapButton * moogWaveBtn =
-		new PixmapButton( this, tr( "Moog wave" ) );
+	auto* moogWaveBtn = new PixmapButton(this, tr("Moog wave"));
 	moogWaveBtn->move( waveBtnX+(16*4), waveBtnY );
 	moogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -917,7 +914,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	moogWaveBtn->setToolTip(
 			tr( "Click here for a moog-like wave." ) );
 
-	PixmapButton * sinWaveBtn = new PixmapButton( this, tr( "Sine wave" ) );
+	auto* sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
 	sinWaveBtn->move( waveBtnX+(16*5), waveBtnY );
 	sinWaveBtn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -926,8 +923,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	sinWaveBtn->setToolTip(
 			tr( "Click for a sine-wave." ) );
 
-	PixmapButton * exponentialWaveBtn =
-		new PixmapButton( this, tr( "White noise wave" ) );
+	auto* exponentialWaveBtn = new PixmapButton(this, tr("White noise wave"));
 	exponentialWaveBtn->move( waveBtnX+(16*6), waveBtnY );
 	exponentialWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "exp_wave_active" ) );
@@ -936,9 +932,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	exponentialWaveBtn->setToolTip(
 			tr( "Click here for an exponential wave." ) );
 
-
-	PixmapButton * whiteNoiseWaveBtn =
-		new PixmapButton( this, tr( "White noise wave" ) );
+	auto* whiteNoiseWaveBtn = new PixmapButton(this, tr("White noise wave"));
 	whiteNoiseWaveBtn->move( waveBtnX+(16*7), waveBtnY );
 	whiteNoiseWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -947,8 +941,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	whiteNoiseWaveBtn->setToolTip(
 			tr( "Click here for white-noise." ) );
 
-	PixmapButton * blSawWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited saw wave" ) );
+	auto* blSawWaveBtn = new PixmapButton(this, tr("Bandlimited saw wave"));
 	blSawWaveBtn->move( waveBtnX+(16*9)-8, waveBtnY );
 	blSawWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "saw_wave_active" ) );
@@ -957,8 +950,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSawWaveBtn->setToolTip(
 			tr( "Click here for bandlimited saw wave." ) );
 
-	PixmapButton * blSquareWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited square wave" ) );
+	auto* blSquareWaveBtn = new PixmapButton(this, tr("Bandlimited square wave"));
 	blSquareWaveBtn->move( waveBtnX+(16*10)-8, waveBtnY );
 	blSquareWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "square_wave_active" ) );
@@ -967,8 +959,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blSquareWaveBtn->setToolTip(
 			tr( "Click here for bandlimited square wave." ) );
 
-	PixmapButton * blTriangleWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited triangle wave" ) );
+	auto* blTriangleWaveBtn = new PixmapButton(this, tr("Bandlimited triangle wave"));
 	blTriangleWaveBtn->move( waveBtnX+(16*11)-8, waveBtnY );
 	blTriangleWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -977,8 +968,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	blTriangleWaveBtn->setToolTip(
 			tr( "Click here for bandlimited triangle wave." ) );
 
-	PixmapButton * blMoogWaveBtn =
-		new PixmapButton( this, tr( "Bandlimited moog saw wave" ) );
+	auto* blMoogWaveBtn = new PixmapButton(this, tr("Bandlimited moog saw wave"));
 	blMoogWaveBtn->move( waveBtnX+(16*12)-8, waveBtnY );
 	blMoogWaveBtn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -1012,7 +1002,7 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 
 void Lb302SynthView::modelChanged()
 {
-	Lb302Synth * syn = castModel<Lb302Synth>();
+	auto* syn = castModel<Lb302Synth>();
 
 	m_vcfCutKnob->setModel( &syn->vcf_cut_knob );
 	m_vcfResKnob->setModel( &syn->vcf_res_knob );

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -90,8 +90,8 @@ bool Lv2Effect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 	{
 		buf[f][0] = d * buf[f][0] + w * m_tmpOutputSmps[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_tmpOutputSmps[f][1];
-		double l = static_cast<double>(buf[f][0]);
-		double r = static_cast<double>(buf[f][1]);
+		auto l = static_cast<double>(buf[f][0]);
+		auto r = static_cast<double>(buf[f][1]);
 		outSum += l*l + r*r;
 	}
 	checkGate(outSum / frames);
@@ -109,7 +109,7 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Effect* eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
+	auto eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
 	if (!eff->isValid()) { delete eff; eff = nullptr; }
 	return eff;
 }

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -90,8 +90,8 @@ bool Lv2Effect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 	{
 		buf[f][0] = d * buf[f][0] + w * m_tmpOutputSmps[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_tmpOutputSmps[f][1];
-		auto l = static_cast<double>(buf[f][0]);
-		auto r = static_cast<double>(buf[f][1]);
+		double l = static_cast<double>(buf[f][0]);
+		double r = static_cast<double>(buf[f][1]);
 		outSum += l*l + r*r;
 	}
 	checkGate(outSum / frames);
@@ -109,7 +109,7 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	auto* eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
+	Lv2Effect* eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
 	if (!eff->isValid()) { delete eff; eff = nullptr; }
 	return eff;
 }

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -90,8 +90,8 @@ bool Lv2Effect::processAudioBuffer(sampleFrame *buf, const fpp_t frames)
 	{
 		buf[f][0] = d * buf[f][0] + w * m_tmpOutputSmps[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_tmpOutputSmps[f][1];
-		double l = static_cast<double>(buf[f][0]);
-		double r = static_cast<double>(buf[f][1]);
+		auto l = static_cast<double>(buf[f][0]);
+		auto r = static_cast<double>(buf[f][1]);
 		outSum += l*l + r*r;
 	}
 	checkGate(outSum / frames);
@@ -109,7 +109,7 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Effect* eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
+	auto* eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
 	if (!eff->isValid()) { delete eff; eff = nullptr; }
 	return eff;
 }

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -87,8 +87,7 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 			this, [this](){Lv2ControlBase::reloadPlugin();});
 
 		// now we need a play-handle which cares for calling play()
-		InstrumentPlayHandle *iph =
-			new InstrumentPlayHandle(this, instrumentTrackArg);
+		auto* iph = new InstrumentPlayHandle(this, instrumentTrackArg);
 		Engine::audioEngine()->addPlayHandle(iph);
 	}
 }
@@ -299,9 +298,7 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Instrument* ins = new Lv2Instrument(
-							static_cast<InstrumentTrack*>(_parent),
-							static_cast<KeyType*>(_data ));
+	auto* ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
 	if (!ins->isValid()) { delete ins; ins = nullptr; }
 	return ins;
 }

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -87,7 +87,8 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 			this, [this](){Lv2ControlBase::reloadPlugin();});
 
 		// now we need a play-handle which cares for calling play()
-		auto* iph = new InstrumentPlayHandle(this, instrumentTrackArg);
+		InstrumentPlayHandle *iph =
+			new InstrumentPlayHandle(this, instrumentTrackArg);
 		Engine::audioEngine()->addPlayHandle(iph);
 	}
 }
@@ -298,7 +299,9 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	auto* ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
+	Lv2Instrument* ins = new Lv2Instrument(
+							static_cast<InstrumentTrack*>(_parent),
+							static_cast<KeyType*>(_data ));
 	if (!ins->isValid()) { delete ins; ins = nullptr; }
 	return ins;
 }

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -87,8 +87,7 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 			this, [this](){Lv2ControlBase::reloadPlugin();});
 
 		// now we need a play-handle which cares for calling play()
-		InstrumentPlayHandle *iph =
-			new InstrumentPlayHandle(this, instrumentTrackArg);
+		auto iph = new InstrumentPlayHandle(this, instrumentTrackArg);
 		Engine::audioEngine()->addPlayHandle(iph);
 	}
 }
@@ -299,9 +298,7 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Instrument* ins = new Lv2Instrument(
-							static_cast<InstrumentTrack*>(_parent),
-							static_cast<KeyType*>(_data ));
+	auto ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
 	if (!ins->isValid()) { delete ins; ins = nullptr; }
 	return ins;
 }

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -310,7 +310,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	pd.setValue( 0 );
 
 	std::istringstream stream(readAllData().toStdString());
-	Alg_seq_ptr seq = new Alg_seq(stream, true);
+	auto seq = new Alg_seq(stream, true);
 	seq->convert_to_beats();
 
 	pd.setMaximum( seq->tracks()  + preTrackSteps );
@@ -328,18 +328,14 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	// NOTE: unordered_map::operator[] creates a new element if none exists
 
 	MeterModel & timeSigMM = Engine::getSong()->getTimeSigModel();
-	AutomationTrack * nt = dynamic_cast<AutomationTrack*>(
-		Track::create(Track::AutomationTrack, Engine::getSong()));
+	auto* nt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
 	nt->setName(tr("MIDI Time Signature Numerator"));
-	AutomationTrack * dt = dynamic_cast<AutomationTrack*>(
-		Track::create(Track::AutomationTrack, Engine::getSong()));
+	auto* dt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
 	dt->setName(tr("MIDI Time Signature Denominator"));
-	AutomationClip * timeSigNumeratorPat =
-		new AutomationClip(nt);
+	auto* timeSigNumeratorPat = new AutomationClip(nt);
 	timeSigNumeratorPat->setDisplayName(tr("Numerator"));
 	timeSigNumeratorPat->addObject(&timeSigMM.numeratorModel());
-	AutomationClip * timeSigDenominatorPat =
-		new AutomationClip(dt);
+	auto* timeSigDenominatorPat = new AutomationClip(dt);
 	timeSigDenominatorPat->setDisplayName(tr("Denominator"));
 	timeSigDenominatorPat->addObject(&timeSigMM.denominatorModel());
 	
@@ -448,7 +444,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			else if (evt->is_note())
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
-				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
+				auto noteEvt = dynamic_cast<Alg_note_ptr>(evt);
 				int ticks = noteEvt->get_duration() * ticksPerBeat;
 				Note n( (ticks < 1 ? 1 : ticks ),
 						noteEvt->get_start_time() * ticksPerBeat,

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -310,7 +310,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	pd.setValue( 0 );
 
 	std::istringstream stream(readAllData().toStdString());
-	auto seq = new Alg_seq(stream, true);
+	Alg_seq_ptr seq = new Alg_seq(stream, true);
 	seq->convert_to_beats();
 
 	pd.setMaximum( seq->tracks()  + preTrackSteps );
@@ -328,14 +328,18 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	// NOTE: unordered_map::operator[] creates a new element if none exists
 
 	MeterModel & timeSigMM = Engine::getSong()->getTimeSigModel();
-	auto* nt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
+	AutomationTrack * nt = dynamic_cast<AutomationTrack*>(
+		Track::create(Track::AutomationTrack, Engine::getSong()));
 	nt->setName(tr("MIDI Time Signature Numerator"));
-	auto* dt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
+	AutomationTrack * dt = dynamic_cast<AutomationTrack*>(
+		Track::create(Track::AutomationTrack, Engine::getSong()));
 	dt->setName(tr("MIDI Time Signature Denominator"));
-	auto* timeSigNumeratorPat = new AutomationClip(nt);
+	AutomationClip * timeSigNumeratorPat =
+		new AutomationClip(nt);
 	timeSigNumeratorPat->setDisplayName(tr("Numerator"));
 	timeSigNumeratorPat->addObject(&timeSigMM.numeratorModel());
-	auto* timeSigDenominatorPat = new AutomationClip(dt);
+	AutomationClip * timeSigDenominatorPat =
+		new AutomationClip(dt);
 	timeSigDenominatorPat->setDisplayName(tr("Denominator"));
 	timeSigDenominatorPat->addObject(&timeSigMM.denominatorModel());
 	
@@ -444,7 +448,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			else if (evt->is_note())
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
-				auto noteEvt = dynamic_cast<Alg_note_ptr>(evt);
+				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
 				int ticks = noteEvt->get_duration() * ticksPerBeat;
 				Note n( (ticks < 1 ? 1 : ticks ),
 						noteEvt->get_start_time() * ticksPerBeat,

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -310,7 +310,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	pd.setValue( 0 );
 
 	std::istringstream stream(readAllData().toStdString());
-	Alg_seq_ptr seq = new Alg_seq(stream, true);
+	auto seq = new Alg_seq(stream, true);
 	seq->convert_to_beats();
 
 	pd.setMaximum( seq->tracks()  + preTrackSteps );
@@ -328,18 +328,14 @@ bool MidiImport::readSMF( TrackContainer* tc )
 	// NOTE: unordered_map::operator[] creates a new element if none exists
 
 	MeterModel & timeSigMM = Engine::getSong()->getTimeSigModel();
-	AutomationTrack * nt = dynamic_cast<AutomationTrack*>(
-		Track::create(Track::AutomationTrack, Engine::getSong()));
+	auto nt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
 	nt->setName(tr("MIDI Time Signature Numerator"));
-	AutomationTrack * dt = dynamic_cast<AutomationTrack*>(
-		Track::create(Track::AutomationTrack, Engine::getSong()));
+	auto dt = dynamic_cast<AutomationTrack*>(Track::create(Track::AutomationTrack, Engine::getSong()));
 	dt->setName(tr("MIDI Time Signature Denominator"));
-	AutomationClip * timeSigNumeratorPat =
-		new AutomationClip(nt);
+	auto timeSigNumeratorPat = new AutomationClip(nt);
 	timeSigNumeratorPat->setDisplayName(tr("Numerator"));
 	timeSigNumeratorPat->addObject(&timeSigMM.numeratorModel());
-	AutomationClip * timeSigDenominatorPat =
-		new AutomationClip(dt);
+	auto timeSigDenominatorPat = new AutomationClip(dt);
 	timeSigDenominatorPat->setDisplayName(tr("Denominator"));
 	timeSigDenominatorPat->addObject(&timeSigMM.denominatorModel());
 	
@@ -448,7 +444,7 @@ bool MidiImport::readSMF( TrackContainer* tc )
 			else if (evt->is_note())
 			{
 				smfMidiChannel * ch = chs[evt->chan].create( tc, trackName );
-				Alg_note_ptr noteEvt = dynamic_cast<Alg_note_ptr>( evt );
+				auto noteEvt = dynamic_cast<Alg_note_ptr>(evt);
 				int ticks = noteEvt->get_duration() * ticksPerBeat;
 				Note n( (ticks < 1 ? 1 : ticks ),
 						noteEvt->get_start_time() * ticksPerBeat,

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -87,7 +87,7 @@ MonstroSynth::MonstroSynth( MonstroInstrument * _i, NotePlayHandle * _nph ) :
 
 	m_lfo_next[0] = Oscillator::noiseSample( 0.0f );
 	m_lfo_next[1] = Oscillator::noiseSample( 0.0f );
-	
+
 	m_osc1l_last = 0.0f;
 	m_osc1r_last = 0.0f;
 
@@ -652,14 +652,14 @@ inline void MonstroSynth::updateModulators( float * env1, float * env2, float * 
 {
 	// frames played before
 	const f_cnt_t tfp = m_nph->totalFramesPlayed();
-	
+
 	float * lfo [2];
 	float * env [2];
 	lfo[0] = lfo1;
 	lfo[1] = lfo2;
 	env[0] = env1;
 	env[1] = env2;
-	
+
 	for( int i = 0; i < 2; ++i )
 	{
 		switch( m_lfovalue[i] )
@@ -740,7 +740,7 @@ inline void MonstroSynth::updateModulators( float * env1, float * env2, float * 
 				{
 					const f_cnt_t tm = ( tfp + f ) % static_cast<int>( m_lfo_rate[i] );
 					if( tm == 0 )
-					{ 
+					{
 						m_lfo_last[i] = m_lfo_next[i];
 						m_lfo_next[i] = Oscillator::noiseSample( 0.0f );
 					}
@@ -755,9 +755,9 @@ inline void MonstroSynth::updateModulators( float * env1, float * env2, float * 
 		{
 			if( tfp + f < m_lfoatt[i] ) lfo[i][f] *= ( static_cast<sample_t>( tfp ) / m_lfoatt[i] );
 		}
-		
-		
-		
+
+
+
 	/////////////////////////////////////////////
 	//                                         //
 	//                                         //
@@ -765,7 +765,7 @@ inline void MonstroSynth::updateModulators( float * env1, float * env2, float * 
 	//                                         //
 	//                                         //
 	/////////////////////////////////////////////
-		
+
 		for( f_cnt_t f = 0; f < frames; ++f )
 		{
 			if( m_env_phase[i] < 4.0f && m_nph->isReleased() && f >= m_nph->framesBeforeRelease() )
@@ -1035,7 +1035,7 @@ void MonstroInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = new MonstroSynth( this, _n );
 	}
 
-	MonstroSynth * ms = static_cast<MonstroSynth *>( _n->m_pluginData );
+	auto ms = static_cast<MonstroSynth*>(_n->m_pluginData);
 
 	ms->renderOutput( frames, _working_buffer + offset );
 
@@ -1414,7 +1414,7 @@ void MonstroInstrument::updateLFOAtts()
 void MonstroInstrument::updateSamplerate()
 {
 	m_samplerate = Engine::audioEngine()->processingSampleRate();
-	
+
 	m_integrator = 0.5f - ( 0.5f - INTEGRATOR ) * 44100.0f / m_samplerate;
 	m_fmCorrection = 44100.f / m_samplerate * FM_AMOUNT;
 	m_counterMax = ( m_samplerate * 5 ) / 44100;
@@ -1459,13 +1459,13 @@ MonstroView::MonstroView( Instrument * _instrument,
 
 // "tab buttons"
 
-	PixmapButton * m_opViewButton = new PixmapButton( this, nullptr );
+	auto m_opViewButton = new PixmapButton(this, nullptr);
 	m_opViewButton -> move( 0,0 );
 	m_opViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_active" ) );
 	m_opViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_inactive" ) );
 	m_opViewButton->setToolTip(tr("Operators view"));
 
-	PixmapButton * m_matViewButton = new PixmapButton( this, nullptr );
+	auto m_matViewButton = new PixmapButton(this, nullptr);
 	m_matViewButton -> move( 125,0 );
 	m_matViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_active" ) );
 	m_matViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_inactive" ) );
@@ -1498,7 +1498,7 @@ void MonstroView::updateLayout()
 
 void MonstroView::modelChanged()
 {
-	MonstroInstrument * m = castModel<MonstroInstrument>();
+	auto m = castModel<MonstroInstrument>();
 
 	m_osc1VolKnob-> setModel( &m-> m_osc1Vol );
 	m_osc1PanKnob-> setModel( &m-> m_osc1Pan );
@@ -1631,7 +1631,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 {
 	// operators view
 
-	QWidget * view = new QWidget( _parent );
+	auto view = new QWidget(_parent);
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_osc1VolKnob, KNOBCOL1, O1ROW, tr( "Volume" ), "%", "osc1Knob" )
@@ -1694,46 +1694,47 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
 
-	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
-	maketsknob( m_lfo2RateKnob, LFOCOL5, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
-	makeknob( m_lfo2PhsKnob, LFOCOL6, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
+	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob") 
+	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob") 
+	makeknob(m_lfo2PhsKnob, LFOCOL6, LFOROW, tr("Phase"), tr(" deg"), "lfoKnob")
 
-	maketsknob( m_env1PreKnob, KNOBCOL1, E1ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env1AttKnob, KNOBCOL2, E1ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env1HoldKnob, KNOBCOL3, E1ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env1DecKnob, KNOBCOL4, E1ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env1SusKnob, KNOBCOL5, E1ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env1RelKnob, KNOBCOL6, E1ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env1SlopeKnob, KNOBCOL7, E1ROW, tr( "Slope" ), "", "envKnob" )
+	maketsknob(m_env1PreKnob, KNOBCOL1, E1ROW, tr("Pre-delay"), " ms", "envKnob")
+	maketsknob(m_env1AttKnob, KNOBCOL2, E1ROW, tr("Attack"), " ms", "envKnob")
+	maketsknob(m_env1HoldKnob, KNOBCOL3, E1ROW, tr("Hold"), " ms", "envKnob")
+	maketsknob(m_env1DecKnob, KNOBCOL4, E1ROW, tr("Decay"), " ms", "envKnob")
 
-	maketsknob( m_env2PreKnob, KNOBCOL1, E2ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env2AttKnob, KNOBCOL2, E2ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env2HoldKnob, KNOBCOL3, E2ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env2DecKnob, KNOBCOL4, E2ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env2SusKnob, KNOBCOL5, E2ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env2RelKnob, KNOBCOL6, E2ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env2SlopeKnob, KNOBCOL7, E2ROW, tr( "Slope" ), "", "envKnob" )
+	makeknob(m_env1SusKnob, KNOBCOL5, E1ROW, tr("Sustain"), "", "envKnob")
+	maketsknob(m_env1RelKnob, KNOBCOL6, E1ROW, tr("Release"), " ms", "envKnob")
+	makeknob(m_env1SlopeKnob, KNOBCOL7, E1ROW, tr("Slope"), "", "envKnob")
+
+	maketsknob(m_env2PreKnob, KNOBCOL1, E2ROW, tr("Pre-delay"), " ms", "envKnob")
+	maketsknob(m_env2AttKnob, KNOBCOL2, E2ROW, tr("Attack"), " ms", "envKnob")
+	maketsknob(m_env2HoldKnob, KNOBCOL3, E2ROW, tr("Hold"), " ms", "envKnob")
+	maketsknob(m_env2DecKnob, KNOBCOL4, E2ROW, tr("Decay"), " ms", "envKnob")
+	makeknob(m_env2SusKnob, KNOBCOL5, E2ROW, tr("Sustain"), "", "envKnob")
+	maketsknob(m_env2RelKnob, KNOBCOL6, E2ROW, tr("Release"), " ms", "envKnob")
+	makeknob(m_env2SlopeKnob, KNOBCOL7, E2ROW, tr("Slope"), "", "envKnob")
 
 	// mod selector
-	PixmapButton * m_mixButton = new PixmapButton( view, nullptr );
+	auto m_mixButton = new PixmapButton(view, nullptr);
 	m_mixButton -> move( 225, 185 );
 	m_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_active" ) );
 	m_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_inactive" ) );
 	m_mixButton->setToolTip(tr("Mix osc 2 with osc 3"));
 
-	PixmapButton * m_amButton = new PixmapButton( view, nullptr );
+	auto m_amButton = new PixmapButton(view, nullptr);
 	m_amButton -> move( 225, 185 + 15 );
 	m_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "am_active" ) );
 	m_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "am_inactive" ) );
 	m_amButton->setToolTip(tr("Modulate amplitude of osc 3 by osc 2"));
 
-	PixmapButton * m_fmButton = new PixmapButton( view, nullptr );
+	auto m_fmButton = new PixmapButton(view, nullptr);
 	m_fmButton -> move( 225, 185 + 15*2 );
 	m_fmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_active" ) );
 	m_fmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_inactive" ) );
 	m_fmButton->setToolTip(tr("Modulate frequency of osc 3 by osc 2"));
 
-	PixmapButton * m_pmButton = new PixmapButton( view, nullptr );
+	auto m_pmButton = new PixmapButton(view, nullptr);
 	m_pmButton -> move( 225, 185 + 15*3 );
 	m_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_active" ) );
 	m_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_inactive" ) );
@@ -1755,7 +1756,7 @@ QWidget * MonstroView::setupMatrixView( QWidget * _parent )
 {
 	// matrix view
 
-	QWidget * view = new QWidget( _parent );
+	auto view = new QWidget(_parent);
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_vol1env1Knob, MATCOL1, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1035,7 +1035,7 @@ void MonstroInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = new MonstroSynth( this, _n );
 	}
 
-	auto* ms = static_cast<MonstroSynth*>(_n->m_pluginData);
+	MonstroSynth * ms = static_cast<MonstroSynth *>( _n->m_pluginData );
 
 	ms->renderOutput( frames, _working_buffer + offset );
 
@@ -1459,13 +1459,13 @@ MonstroView::MonstroView( Instrument * _instrument,
 
 // "tab buttons"
 
-	auto* m_opViewButton = new PixmapButton(this, nullptr);
+	PixmapButton * m_opViewButton = new PixmapButton( this, nullptr );
 	m_opViewButton -> move( 0,0 );
 	m_opViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_active" ) );
 	m_opViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_inactive" ) );
 	m_opViewButton->setToolTip(tr("Operators view"));
 
-	auto* m_matViewButton = new PixmapButton(this, nullptr);
+	PixmapButton * m_matViewButton = new PixmapButton( this, nullptr );
 	m_matViewButton -> move( 125,0 );
 	m_matViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_active" ) );
 	m_matViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_inactive" ) );
@@ -1498,7 +1498,7 @@ void MonstroView::updateLayout()
 
 void MonstroView::modelChanged()
 {
-	auto* m = castModel<MonstroInstrument>();
+	MonstroInstrument * m = castModel<MonstroInstrument>();
 
 	m_osc1VolKnob-> setModel( &m-> m_osc1Vol );
 	m_osc1PanKnob-> setModel( &m-> m_osc1Pan );
@@ -1631,7 +1631,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 {
 	// operators view
 
-	auto* view = new QWidget(_parent);
+	QWidget * view = new QWidget( _parent );
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_osc1VolKnob, KNOBCOL1, O1ROW, tr( "Volume" ), "%", "osc1Knob" )
@@ -1694,46 +1694,46 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
 
-	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob") maketsknob(m_lfo2RateKnob, LFOCOL5,
-		LFOROW, tr("Rate"), " ms",
-		"lfoKnob") makeknob(m_lfo2PhsKnob, LFOCOL6, LFOROW, tr("Phase"), tr(" deg"), "lfoKnob")
+	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
+	maketsknob( m_lfo2RateKnob, LFOCOL5, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
+	makeknob( m_lfo2PhsKnob, LFOCOL6, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
 
-		maketsknob(m_env1PreKnob, KNOBCOL1, E1ROW, tr("Pre-delay"), " ms", "envKnob") maketsknob(
-			m_env1AttKnob, KNOBCOL2, E1ROW, tr("Attack"), " ms", "envKnob") maketsknob(m_env1HoldKnob, KNOBCOL3, E1ROW,
-			tr("Hold"), " ms", "envKnob") maketsknob(m_env1DecKnob, KNOBCOL4, E1ROW, tr("Decay"), " ms", "envKnob")
-			makeknob(m_env1SusKnob, KNOBCOL5, E1ROW, tr("Sustain"), "", "envKnob")
-				maketsknob(m_env1RelKnob, KNOBCOL6, E1ROW, tr("Release"), " ms", "envKnob")
-					makeknob(m_env1SlopeKnob, KNOBCOL7, E1ROW, tr("Slope"), "", "envKnob")
+	maketsknob( m_env1PreKnob, KNOBCOL1, E1ROW, tr( "Pre-delay" ), " ms", "envKnob" )
+	maketsknob( m_env1AttKnob, KNOBCOL2, E1ROW, tr( "Attack" ), " ms", "envKnob" )
+	maketsknob( m_env1HoldKnob, KNOBCOL3, E1ROW, tr( "Hold" ), " ms", "envKnob" )
+	maketsknob( m_env1DecKnob, KNOBCOL4, E1ROW, tr( "Decay" ), " ms", "envKnob" )
+	makeknob( m_env1SusKnob, KNOBCOL5, E1ROW, tr( "Sustain" ), "", "envKnob" )
+	maketsknob( m_env1RelKnob, KNOBCOL6, E1ROW, tr( "Release" ), " ms", "envKnob" )
+	makeknob( m_env1SlopeKnob, KNOBCOL7, E1ROW, tr( "Slope" ), "", "envKnob" )
 
-						maketsknob(m_env2PreKnob, KNOBCOL1, E2ROW, tr("Pre-delay"), " ms", "envKnob")
-							maketsknob(m_env2AttKnob, KNOBCOL2, E2ROW, tr("Attack"), " ms", "envKnob")
-								maketsknob(m_env2HoldKnob, KNOBCOL3, E2ROW, tr("Hold"), " ms", "envKnob")
-									maketsknob(m_env2DecKnob, KNOBCOL4, E2ROW, tr("Decay"), " ms", "envKnob")
-										makeknob(m_env2SusKnob, KNOBCOL5, E2ROW, tr("Sustain"), "", "envKnob")
-											maketsknob(m_env2RelKnob, KNOBCOL6, E2ROW, tr("Release"), " ms", "envKnob")
-												makeknob(m_env2SlopeKnob, KNOBCOL7, E2ROW, tr("Slope"), "", "envKnob")
+	maketsknob( m_env2PreKnob, KNOBCOL1, E2ROW, tr( "Pre-delay" ), " ms", "envKnob" )
+	maketsknob( m_env2AttKnob, KNOBCOL2, E2ROW, tr( "Attack" ), " ms", "envKnob" )
+	maketsknob( m_env2HoldKnob, KNOBCOL3, E2ROW, tr( "Hold" ), " ms", "envKnob" )
+	maketsknob( m_env2DecKnob, KNOBCOL4, E2ROW, tr( "Decay" ), " ms", "envKnob" )
+	makeknob( m_env2SusKnob, KNOBCOL5, E2ROW, tr( "Sustain" ), "", "envKnob" )
+	maketsknob( m_env2RelKnob, KNOBCOL6, E2ROW, tr( "Release" ), " ms", "envKnob" )
+	makeknob( m_env2SlopeKnob, KNOBCOL7, E2ROW, tr( "Slope" ), "", "envKnob" )
 
-		// mod selector
-		auto* m_mixButton
-		= new PixmapButton(view, nullptr);
+	// mod selector
+	PixmapButton * m_mixButton = new PixmapButton( view, nullptr );
 	m_mixButton -> move( 225, 185 );
 	m_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_active" ) );
 	m_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_inactive" ) );
 	m_mixButton->setToolTip(tr("Mix osc 2 with osc 3"));
 
-	auto* m_amButton = new PixmapButton(view, nullptr);
+	PixmapButton * m_amButton = new PixmapButton( view, nullptr );
 	m_amButton -> move( 225, 185 + 15 );
 	m_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "am_active" ) );
 	m_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "am_inactive" ) );
 	m_amButton->setToolTip(tr("Modulate amplitude of osc 3 by osc 2"));
 
-	auto* m_fmButton = new PixmapButton(view, nullptr);
+	PixmapButton * m_fmButton = new PixmapButton( view, nullptr );
 	m_fmButton -> move( 225, 185 + 15*2 );
 	m_fmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_active" ) );
 	m_fmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_inactive" ) );
 	m_fmButton->setToolTip(tr("Modulate frequency of osc 3 by osc 2"));
 
-	auto* m_pmButton = new PixmapButton(view, nullptr);
+	PixmapButton * m_pmButton = new PixmapButton( view, nullptr );
 	m_pmButton -> move( 225, 185 + 15*3 );
 	m_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_active" ) );
 	m_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_inactive" ) );
@@ -1755,7 +1755,7 @@ QWidget * MonstroView::setupMatrixView( QWidget * _parent )
 {
 	// matrix view
 
-	auto* view = new QWidget(_parent);
+	QWidget * view = new QWidget( _parent );
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_vol1env1Knob, MATCOL1, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1035,7 +1035,7 @@ void MonstroInstrument::playNote( NotePlayHandle * _n,
 		_n->m_pluginData = new MonstroSynth( this, _n );
 	}
 
-	MonstroSynth * ms = static_cast<MonstroSynth *>( _n->m_pluginData );
+	auto* ms = static_cast<MonstroSynth*>(_n->m_pluginData);
 
 	ms->renderOutput( frames, _working_buffer + offset );
 
@@ -1459,13 +1459,13 @@ MonstroView::MonstroView( Instrument * _instrument,
 
 // "tab buttons"
 
-	PixmapButton * m_opViewButton = new PixmapButton( this, nullptr );
+	auto* m_opViewButton = new PixmapButton(this, nullptr);
 	m_opViewButton -> move( 0,0 );
 	m_opViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_active" ) );
 	m_opViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "opview_inactive" ) );
 	m_opViewButton->setToolTip(tr("Operators view"));
 
-	PixmapButton * m_matViewButton = new PixmapButton( this, nullptr );
+	auto* m_matViewButton = new PixmapButton(this, nullptr);
 	m_matViewButton -> move( 125,0 );
 	m_matViewButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_active" ) );
 	m_matViewButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "matview_inactive" ) );
@@ -1498,7 +1498,7 @@ void MonstroView::updateLayout()
 
 void MonstroView::modelChanged()
 {
-	MonstroInstrument * m = castModel<MonstroInstrument>();
+	auto* m = castModel<MonstroInstrument>();
 
 	m_osc1VolKnob-> setModel( &m-> m_osc1Vol );
 	m_osc1PanKnob-> setModel( &m-> m_osc1Pan );
@@ -1631,7 +1631,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 {
 	// operators view
 
-	QWidget * view = new QWidget( _parent );
+	auto* view = new QWidget(_parent);
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_osc1VolKnob, KNOBCOL1, O1ROW, tr( "Volume" ), "%", "osc1Knob" )
@@ -1694,46 +1694,46 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
 	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
 
-	maketsknob( m_lfo2AttKnob, LFOCOL4, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
-	maketsknob( m_lfo2RateKnob, LFOCOL5, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
-	makeknob( m_lfo2PhsKnob, LFOCOL6, LFOROW, tr( "Phase" ), tr( " deg" ), "lfoKnob" )
+	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob") maketsknob(m_lfo2RateKnob, LFOCOL5,
+		LFOROW, tr("Rate"), " ms",
+		"lfoKnob") makeknob(m_lfo2PhsKnob, LFOCOL6, LFOROW, tr("Phase"), tr(" deg"), "lfoKnob")
 
-	maketsknob( m_env1PreKnob, KNOBCOL1, E1ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env1AttKnob, KNOBCOL2, E1ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env1HoldKnob, KNOBCOL3, E1ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env1DecKnob, KNOBCOL4, E1ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env1SusKnob, KNOBCOL5, E1ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env1RelKnob, KNOBCOL6, E1ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env1SlopeKnob, KNOBCOL7, E1ROW, tr( "Slope" ), "", "envKnob" )
+		maketsknob(m_env1PreKnob, KNOBCOL1, E1ROW, tr("Pre-delay"), " ms", "envKnob") maketsknob(
+			m_env1AttKnob, KNOBCOL2, E1ROW, tr("Attack"), " ms", "envKnob") maketsknob(m_env1HoldKnob, KNOBCOL3, E1ROW,
+			tr("Hold"), " ms", "envKnob") maketsknob(m_env1DecKnob, KNOBCOL4, E1ROW, tr("Decay"), " ms", "envKnob")
+			makeknob(m_env1SusKnob, KNOBCOL5, E1ROW, tr("Sustain"), "", "envKnob")
+				maketsknob(m_env1RelKnob, KNOBCOL6, E1ROW, tr("Release"), " ms", "envKnob")
+					makeknob(m_env1SlopeKnob, KNOBCOL7, E1ROW, tr("Slope"), "", "envKnob")
 
-	maketsknob( m_env2PreKnob, KNOBCOL1, E2ROW, tr( "Pre-delay" ), " ms", "envKnob" )
-	maketsknob( m_env2AttKnob, KNOBCOL2, E2ROW, tr( "Attack" ), " ms", "envKnob" )
-	maketsknob( m_env2HoldKnob, KNOBCOL3, E2ROW, tr( "Hold" ), " ms", "envKnob" )
-	maketsknob( m_env2DecKnob, KNOBCOL4, E2ROW, tr( "Decay" ), " ms", "envKnob" )
-	makeknob( m_env2SusKnob, KNOBCOL5, E2ROW, tr( "Sustain" ), "", "envKnob" )
-	maketsknob( m_env2RelKnob, KNOBCOL6, E2ROW, tr( "Release" ), " ms", "envKnob" )
-	makeknob( m_env2SlopeKnob, KNOBCOL7, E2ROW, tr( "Slope" ), "", "envKnob" )
+						maketsknob(m_env2PreKnob, KNOBCOL1, E2ROW, tr("Pre-delay"), " ms", "envKnob")
+							maketsknob(m_env2AttKnob, KNOBCOL2, E2ROW, tr("Attack"), " ms", "envKnob")
+								maketsknob(m_env2HoldKnob, KNOBCOL3, E2ROW, tr("Hold"), " ms", "envKnob")
+									maketsknob(m_env2DecKnob, KNOBCOL4, E2ROW, tr("Decay"), " ms", "envKnob")
+										makeknob(m_env2SusKnob, KNOBCOL5, E2ROW, tr("Sustain"), "", "envKnob")
+											maketsknob(m_env2RelKnob, KNOBCOL6, E2ROW, tr("Release"), " ms", "envKnob")
+												makeknob(m_env2SlopeKnob, KNOBCOL7, E2ROW, tr("Slope"), "", "envKnob")
 
-	// mod selector
-	PixmapButton * m_mixButton = new PixmapButton( view, nullptr );
+		// mod selector
+		auto* m_mixButton
+		= new PixmapButton(view, nullptr);
 	m_mixButton -> move( 225, 185 );
 	m_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_active" ) );
 	m_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "mix_inactive" ) );
 	m_mixButton->setToolTip(tr("Mix osc 2 with osc 3"));
 
-	PixmapButton * m_amButton = new PixmapButton( view, nullptr );
+	auto* m_amButton = new PixmapButton(view, nullptr);
 	m_amButton -> move( 225, 185 + 15 );
 	m_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "am_active" ) );
 	m_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "am_inactive" ) );
 	m_amButton->setToolTip(tr("Modulate amplitude of osc 3 by osc 2"));
 
-	PixmapButton * m_fmButton = new PixmapButton( view, nullptr );
+	auto* m_fmButton = new PixmapButton(view, nullptr);
 	m_fmButton -> move( 225, 185 + 15*2 );
 	m_fmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_active" ) );
 	m_fmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fm_inactive" ) );
 	m_fmButton->setToolTip(tr("Modulate frequency of osc 3 by osc 2"));
 
-	PixmapButton * m_pmButton = new PixmapButton( view, nullptr );
+	auto* m_pmButton = new PixmapButton(view, nullptr);
 	m_pmButton -> move( 225, 185 + 15*3 );
 	m_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_active" ) );
 	m_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "pm_inactive" ) );
@@ -1755,7 +1755,7 @@ QWidget * MonstroView::setupMatrixView( QWidget * _parent )
 {
 	// matrix view
 
-	QWidget * view = new QWidget( _parent );
+	auto* view = new QWidget(_parent);
 	view-> setFixedSize( 250, 250 );
 
 	makeknob( m_vol1env1Knob, MATCOL1, MATROW1, tr( "Modulation amount" ), "", "matrixKnob" )

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -47,10 +47,10 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	setFixedSize( 245, 300 );
 	
 	// graph widgets
-	
-	Graph * ampGraph = new Graph( this, Graph::BarStyle, 204, 105 );
-	Graph * lpGraph = new Graph( this, Graph::BarStyle, 204, 105 );
-	
+
+	auto ampGraph = new Graph(this, Graph::BarStyle, 204, 105);
+	auto lpGraph = new Graph(this, Graph::BarStyle, 204, 105);
+
 	ampGraph->move( 30, 10 );
 	lpGraph->move( 30, 125 );
 	
@@ -71,33 +71,33 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	lpGraph -> setMaximumSize( 204, 105 );
 	
 	// steps spinbox
-	
-	LcdSpinBox * steps = new LcdSpinBox( 2, this, "Steps" );
+
+	auto steps = new LcdSpinBox(2, this, "Steps");
 	steps->move( 20, 245 );
 	steps->setModel( & controls->m_steps );
 	
 	// knobs
 
-	TempoSyncKnob * stepLength = new TempoSyncKnob( knobBright_26, this );
+	auto stepLength = new TempoSyncKnob(knobBright_26, this);
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
 	stepLength->setLabel( tr( "Length" ) );
 	stepLength->setHintText( tr( "Step length:" ) , " ms" );
-	
-	Knob * dryGain = new Knob( knobBright_26, this );
+
+	auto dryGain = new Knob(knobBright_26, this);
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
 	dryGain->setLabel( tr( "Dry" ) );
 	dryGain->setHintText( tr( "Dry gain:" ) , " dBFS" );
 
-	Knob * stages = new Knob( knobBright_26, this );
+	auto stages = new Knob(knobBright_26, this);
 	stages->move( 200, 245 );
 	stages->setModel( & controls->m_stages );
 	stages->setLabel( tr( "Stages" ) );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );
 	// switch led
-	
-	LedCheckBox * swapInputs = new LedCheckBox( "Swap inputs", this, tr( "Swap inputs" ), LedCheckBox::Green );
+
+	auto swapInputs = new LedCheckBox("Swap inputs", this, tr("Swap inputs"), LedCheckBox::Green);
 	swapInputs->move( 20, 275 );
 	swapInputs->setModel( & controls->m_swapInputs );
 	swapInputs->setToolTip(tr("Swap left and right input channels for reflections"));

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -47,10 +47,10 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	setFixedSize( 245, 300 );
 	
 	// graph widgets
-
-	auto* ampGraph = new Graph(this, Graph::BarStyle, 204, 105);
-	auto* lpGraph = new Graph(this, Graph::BarStyle, 204, 105);
-
+	
+	Graph * ampGraph = new Graph( this, Graph::BarStyle, 204, 105 );
+	Graph * lpGraph = new Graph( this, Graph::BarStyle, 204, 105 );
+	
 	ampGraph->move( 30, 10 );
 	lpGraph->move( 30, 125 );
 	
@@ -71,14 +71,14 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	lpGraph -> setMaximumSize( 204, 105 );
 	
 	// steps spinbox
-
-	auto* steps = new LcdSpinBox(2, this, "Steps");
+	
+	LcdSpinBox * steps = new LcdSpinBox( 2, this, "Steps" );
 	steps->move( 20, 245 );
 	steps->setModel( & controls->m_steps );
 	
 	// knobs
 
-	auto* stepLength = new TempoSyncKnob(knobBright_26, this);
+	TempoSyncKnob * stepLength = new TempoSyncKnob( knobBright_26, this );
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
 	stepLength->setLabel( tr( "Length" ) );
@@ -96,8 +96,8 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	stages->setLabel( tr( "Stages" ) );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );
 	// switch led
-
-	auto* swapInputs = new LedCheckBox("Swap inputs", this, tr("Swap inputs"), LedCheckBox::Green);
+	
+	LedCheckBox * swapInputs = new LedCheckBox( "Swap inputs", this, tr( "Swap inputs" ), LedCheckBox::Green );
 	swapInputs->move( 20, 275 );
 	swapInputs->setModel( & controls->m_swapInputs );
 	swapInputs->setToolTip(tr("Swap left and right input channels for reflections"));

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -47,10 +47,10 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	setFixedSize( 245, 300 );
 	
 	// graph widgets
-	
-	Graph * ampGraph = new Graph( this, Graph::BarStyle, 204, 105 );
-	Graph * lpGraph = new Graph( this, Graph::BarStyle, 204, 105 );
-	
+
+	auto* ampGraph = new Graph(this, Graph::BarStyle, 204, 105);
+	auto* lpGraph = new Graph(this, Graph::BarStyle, 204, 105);
+
 	ampGraph->move( 30, 10 );
 	lpGraph->move( 30, 125 );
 	
@@ -71,14 +71,14 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	lpGraph -> setMaximumSize( 204, 105 );
 	
 	// steps spinbox
-	
-	LcdSpinBox * steps = new LcdSpinBox( 2, this, "Steps" );
+
+	auto* steps = new LcdSpinBox(2, this, "Steps");
 	steps->move( 20, 245 );
 	steps->setModel( & controls->m_steps );
 	
 	// knobs
 
-	TempoSyncKnob * stepLength = new TempoSyncKnob( knobBright_26, this );
+	auto* stepLength = new TempoSyncKnob(knobBright_26, this);
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
 	stepLength->setLabel( tr( "Length" ) );
@@ -96,8 +96,8 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	stages->setLabel( tr( "Stages" ) );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );
 	// switch led
-	
-	LedCheckBox * swapInputs = new LedCheckBox( "Swap inputs", this, tr( "Swap inputs" ), LedCheckBox::Green );
+
+	auto* swapInputs = new LedCheckBox("Swap inputs", this, tr("Swap inputs"), LedCheckBox::Green);
 	swapInputs->move( 20, 275 );
 	swapInputs->setModel( & controls->m_swapInputs );
 	swapInputs->setToolTip(tr("Swap left and right input channels for reflections"));

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -385,9 +385,9 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		//	                          //
 		//  final stage - mixing      //
 		//                            //
-		////////////////////////////////			
-		
-		float pin1 = static_cast<float>( ch1 + ch2 ); 
+		////////////////////////////////
+
+		auto pin1 = static_cast<float>(ch1 + ch2);
 		// add dithering noise
 		pin1 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin1 = pin1 / 30.0f;
@@ -405,8 +405,7 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		
 		pin1 *= NES_MIXING_12;
 
-		
-		float pin2 = static_cast<float>( ch3 + ch4 ); 
+		auto pin2 = static_cast<float>(ch3 + ch4);
 		// add dithering noise
 		pin2 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin2 = pin2 / 30.0f;
@@ -552,13 +551,13 @@ void NesInstrument::playNote( NotePlayHandle * n, sampleFrame * workingBuffer )
 	const f_cnt_t offset = n->noteOffset();
 	
 	if ( n->totalFramesPlayed() == 0 || n->m_pluginData == nullptr )
-	{	
-		NesObject * nes = new NesObject( this, Engine::audioEngine()->processingSampleRate(), n );
+	{
+		auto* nes = new NesObject(this, Engine::audioEngine()->processingSampleRate(), n);
 		n->m_pluginData = nes;
 	}
-	
-	NesObject * nes = static_cast<NesObject *>( n->m_pluginData );
-	
+
+	auto* nes = static_cast<NesObject*>(n->m_pluginData);
+
 	nes->renderOutput( workingBuffer + offset, frames );
 	
 	applyRelease( workingBuffer, n );
@@ -846,7 +845,7 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 
 void NesInstrumentView::modelChanged()
 {
-	NesInstrument * nes = castModel<NesInstrument>();	
+	auto* nes = castModel<NesInstrument>();
 
 	m_ch1EnabledBtn->setModel( &nes->m_ch1Enabled );
 	m_ch1CrsKnob->setModel( &nes->m_ch1Crs );

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -385,9 +385,9 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		//	                          //
 		//  final stage - mixing      //
 		//                            //
-		////////////////////////////////			
-		
-		float pin1 = static_cast<float>( ch1 + ch2 ); 
+		////////////////////////////////
+
+		auto pin1 = static_cast<float>(ch1 + ch2);
 		// add dithering noise
 		pin1 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin1 = pin1 / 30.0f;
@@ -405,8 +405,7 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		
 		pin1 *= NES_MIXING_12;
 
-		
-		float pin2 = static_cast<float>( ch3 + ch4 ); 
+		auto pin2 = static_cast<float>(ch3 + ch4);
 		// add dithering noise
 		pin2 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin2 = pin2 / 30.0f;
@@ -552,13 +551,13 @@ void NesInstrument::playNote( NotePlayHandle * n, sampleFrame * workingBuffer )
 	const f_cnt_t offset = n->noteOffset();
 	
 	if ( n->totalFramesPlayed() == 0 || n->m_pluginData == nullptr )
-	{	
-		NesObject * nes = new NesObject( this, Engine::audioEngine()->processingSampleRate(), n );
+	{
+		auto nes = new NesObject(this, Engine::audioEngine()->processingSampleRate(), n);
 		n->m_pluginData = nes;
 	}
-	
-	NesObject * nes = static_cast<NesObject *>( n->m_pluginData );
-	
+
+	auto nes = static_cast<NesObject*>(n->m_pluginData);
+
 	nes->renderOutput( workingBuffer + offset, frames );
 	
 	applyRelease( workingBuffer, n );
@@ -846,7 +845,7 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 
 void NesInstrumentView::modelChanged()
 {
-	NesInstrument * nes = castModel<NesInstrument>();	
+	auto nes = castModel<NesInstrument>();
 
 	m_ch1EnabledBtn->setModel( &nes->m_ch1Enabled );
 	m_ch1CrsKnob->setModel( &nes->m_ch1Crs );

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -385,9 +385,9 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		//	                          //
 		//  final stage - mixing      //
 		//                            //
-		////////////////////////////////
-
-		auto pin1 = static_cast<float>(ch1 + ch2);
+		////////////////////////////////			
+		
+		float pin1 = static_cast<float>( ch1 + ch2 ); 
 		// add dithering noise
 		pin1 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin1 = pin1 / 30.0f;
@@ -405,7 +405,8 @@ void NesObject::renderOutput( sampleFrame * buf, fpp_t frames )
 		
 		pin1 *= NES_MIXING_12;
 
-		auto pin2 = static_cast<float>(ch3 + ch4);
+		
+		float pin2 = static_cast<float>( ch3 + ch4 ); 
 		// add dithering noise
 		pin2 *= 1.0 + ( Oscillator::noiseSample( 0.0f ) * DITHER_AMP );		
 		pin2 = pin2 / 30.0f;
@@ -551,13 +552,13 @@ void NesInstrument::playNote( NotePlayHandle * n, sampleFrame * workingBuffer )
 	const f_cnt_t offset = n->noteOffset();
 	
 	if ( n->totalFramesPlayed() == 0 || n->m_pluginData == nullptr )
-	{
-		auto* nes = new NesObject(this, Engine::audioEngine()->processingSampleRate(), n);
+	{	
+		NesObject * nes = new NesObject( this, Engine::audioEngine()->processingSampleRate(), n );
 		n->m_pluginData = nes;
 	}
-
-	auto* nes = static_cast<NesObject*>(n->m_pluginData);
-
+	
+	NesObject * nes = static_cast<NesObject *>( n->m_pluginData );
+	
 	nes->renderOutput( workingBuffer + offset, frames );
 	
 	applyRelease( workingBuffer, n );
@@ -845,7 +846,7 @@ NesInstrumentView::NesInstrumentView( Instrument * instrument,	QWidget * parent 
 
 void NesInstrumentView::modelChanged()
 {
-	auto* nes = castModel<NesInstrument>();
+	NesInstrument * nes = castModel<NesInstrument>();	
 
 	m_ch1EnabledBtn->setModel( &nes->m_ch1Enabled );
 	m_ch1CrsKnob->setModel( &nes->m_ch1Crs );

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -215,7 +215,7 @@ OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
 	MOD_CON( trem_depth_mdl );
 
 	// Connect the plugin to the audio engine...
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -798,8 +798,7 @@ void OpulenzInstrumentView::updateKnobHints()
 		-12, 0, 12, 19, 24, 28, 31, 34, 36, 38, 40, 40, 43, 43, 47, 47  
 	};
 
-	OpulenzInstrument * m = castModel<OpulenzInstrument>();
-	
+	auto* m = castModel<OpulenzInstrument>();
 
 	op1_a_kn->setHintText( tr( "Attack" ),
 						   " (" + knobHintHelper(attack_times[(int)m->op1_a_mdl.value()]) + ")");
@@ -821,7 +820,7 @@ void OpulenzInstrumentView::updateKnobHints()
 
 void OpulenzInstrumentView::modelChanged()
 {
-	OpulenzInstrument * m = castModel<OpulenzInstrument>();
+	auto* m = castModel<OpulenzInstrument>();
 	// m_patch->setModel( &m->m_patchModel );
 
 	op1_a_kn->setModel( &m->op1_a_mdl );

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -215,7 +215,7 @@ OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
 	MOD_CON( trem_depth_mdl );
 
 	// Connect the plugin to the audio engine...
-	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -798,7 +798,8 @@ void OpulenzInstrumentView::updateKnobHints()
 		-12, 0, 12, 19, 24, 28, 31, 34, 36, 38, 40, 40, 43, 43, 47, 47  
 	};
 
-	auto* m = castModel<OpulenzInstrument>();
+	OpulenzInstrument * m = castModel<OpulenzInstrument>();
+	
 
 	op1_a_kn->setHintText( tr( "Attack" ),
 						   " (" + knobHintHelper(attack_times[(int)m->op1_a_mdl.value()]) + ")");
@@ -820,7 +821,7 @@ void OpulenzInstrumentView::updateKnobHints()
 
 void OpulenzInstrumentView::modelChanged()
 {
-	auto* m = castModel<OpulenzInstrument>();
+	OpulenzInstrument * m = castModel<OpulenzInstrument>();
 	// m_patch->setModel( &m->m_patchModel );
 
 	op1_a_kn->setModel( &m->op1_a_mdl );

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -215,7 +215,7 @@ OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
 	MOD_CON( trem_depth_mdl );
 
 	// Connect the plugin to the audio engine...
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -798,8 +798,7 @@ void OpulenzInstrumentView::updateKnobHints()
 		-12, 0, 12, 19, 24, 28, 31, 34, 36, 38, 40, 40, 43, 43, 47, 47  
 	};
 
-	OpulenzInstrument * m = castModel<OpulenzInstrument>();
-	
+	auto m = castModel<OpulenzInstrument>();
 
 	op1_a_kn->setHintText( tr( "Attack" ),
 						   " (" + knobHintHelper(attack_times[(int)m->op1_a_mdl.value()]) + ")");
@@ -821,7 +820,7 @@ void OpulenzInstrumentView::updateKnobHints()
 
 void OpulenzInstrumentView::modelChanged()
 {
-	OpulenzInstrument * m = castModel<OpulenzInstrument>();
+	auto m = castModel<OpulenzInstrument>();
 	// m_patch->setModel( &m->m_patchModel );
 
 	op1_a_kn->setModel( &m->op1_a_mdl );

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -422,7 +422,7 @@ OrganicInstrumentView::OrganicInstrumentView( Instrument * _instrument,
 	InstrumentViewFixedSize( _instrument, _parent ),
 	m_oscKnobs( nullptr )
 {
-	auto* oi = castModel<OrganicInstrument>();
+	OrganicInstrument * oi = castModel<OrganicInstrument>();
 
 	setAutoFillBackground( true );
 	QPalette pal;
@@ -474,8 +474,8 @@ OrganicInstrumentView::~OrganicInstrumentView()
 
 void OrganicInstrumentView::modelChanged()
 {
-	auto* oi = castModel<OrganicInstrument>();
-
+	OrganicInstrument * oi = castModel<OrganicInstrument>();
+	
 	const float y=91.0f;
 	const float rowHeight = 26.0f;
 	const float x=53.0f;
@@ -547,7 +547,7 @@ void OrganicInstrumentView::modelChanged()
 
 void OrganicInstrumentView::updateKnobHint()
 {
-	auto* oi = castModel<OrganicInstrument>();
+	OrganicInstrument * oi = castModel<OrganicInstrument>();
 	for( int i = 0; i < m_numOscillators; ++i )
 	{
 		const float harm = oi->m_osc[i]->m_harmModel.value();

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -422,7 +422,7 @@ OrganicInstrumentView::OrganicInstrumentView( Instrument * _instrument,
 	InstrumentViewFixedSize( _instrument, _parent ),
 	m_oscKnobs( nullptr )
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
+	auto oi = castModel<OrganicInstrument>();
 
 	setAutoFillBackground( true );
 	QPalette pal;
@@ -474,8 +474,8 @@ OrganicInstrumentView::~OrganicInstrumentView()
 
 void OrganicInstrumentView::modelChanged()
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
-	
+	auto oi = castModel<OrganicInstrument>();
+
 	const float y=91.0f;
 	const float rowHeight = 26.0f;
 	const float x=53.0f;
@@ -512,7 +512,7 @@ void OrganicInstrumentView::modelChanged()
 		oscKnob->setHintText( tr( "Osc %1 waveform:" ).arg( i + 1 ), QString() );
 										
 		// setup volume-knob
-		Knob * volKnob = new Knob( knobStyled, this );
+		auto volKnob = new Knob(knobStyled, this);
 		volKnob->setVolumeKnob( true );
 		volKnob->move( x + i * colWidth, y + rowHeight*1 );
 		volKnob->setFixedSize( 21, 21 );
@@ -547,7 +547,7 @@ void OrganicInstrumentView::modelChanged()
 
 void OrganicInstrumentView::updateKnobHint()
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
+	auto oi = castModel<OrganicInstrument>();
 	for( int i = 0; i < m_numOscillators; ++i )
 	{
 		const float harm = oi->m_osc[i]->m_harmModel.value();

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -422,7 +422,7 @@ OrganicInstrumentView::OrganicInstrumentView( Instrument * _instrument,
 	InstrumentViewFixedSize( _instrument, _parent ),
 	m_oscKnobs( nullptr )
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
+	auto* oi = castModel<OrganicInstrument>();
 
 	setAutoFillBackground( true );
 	QPalette pal;
@@ -474,8 +474,8 @@ OrganicInstrumentView::~OrganicInstrumentView()
 
 void OrganicInstrumentView::modelChanged()
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
-	
+	auto* oi = castModel<OrganicInstrument>();
+
 	const float y=91.0f;
 	const float rowHeight = 26.0f;
 	const float x=53.0f;
@@ -547,7 +547,7 @@ void OrganicInstrumentView::modelChanged()
 
 void OrganicInstrumentView::updateKnobHint()
 {
-	OrganicInstrument * oi = castModel<OrganicInstrument>();
+	auto* oi = castModel<OrganicInstrument>();
 	for( int i = 0; i < m_numOscillators; ++i )
 	{
 		const float harm = oi->m_osc[i]->m_harmModel.value();

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -148,7 +148,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 	{
 		selectSample( _n );
 	}
-	handle_data * hdata = (handle_data *)_n->m_pluginData;
+	auto hdata = (handle_data*)_n->m_pluginData;
 
 	float play_freq = hdata->tuned ? _n->frequency() :
 						hdata->sample->frequency();
@@ -171,7 +171,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 
 void PatmanInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	handle_data * hdata = (handle_data *)_n->m_pluginData;
+	auto hdata = (handle_data*)_n->m_pluginData;
 	sharedObject::unref( hdata->sample );
 	delete hdata->state;
 	delete hdata;
@@ -347,7 +347,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		sampleFrame * data = new sampleFrame[frames];
+		auto data = new sampleFrame[frames];
 
 		for( f_cnt_t frame = 0; frame < frames; ++frame )
 		{
@@ -358,7 +358,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		SampleBuffer* psample = new SampleBuffer( data, frames );
+		auto psample = new SampleBuffer(data, frames);
 		psample->setFrequency( root_freq / 1000.0f );
 		psample->setSampleRate( sample_rate );
 
@@ -412,7 +412,7 @@ void PatmanInstrument::selectSample( NotePlayHandle * _n )
 		}
 	}
 
-	handle_data * hdata = new handle_data;
+	auto hdata = new handle_data;
 	hdata->tuned = m_tunedModel.value();
 	if( sample )
 	{

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -148,7 +148,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 	{
 		selectSample( _n );
 	}
-	handle_data * hdata = (handle_data *)_n->m_pluginData;
+	auto* hdata = (handle_data*)_n->m_pluginData;
 
 	float play_freq = hdata->tuned ? _n->frequency() :
 						hdata->sample->frequency();
@@ -171,7 +171,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 
 void PatmanInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	handle_data * hdata = (handle_data *)_n->m_pluginData;
+	auto* hdata = (handle_data*)_n->m_pluginData;
 	sharedObject::unref( hdata->sample );
 	delete hdata->state;
 	delete hdata;
@@ -347,7 +347,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		sampleFrame * data = new sampleFrame[frames];
+		auto* data = new sampleFrame[frames];
 
 		for( f_cnt_t frame = 0; frame < frames; ++frame )
 		{
@@ -358,7 +358,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		SampleBuffer* psample = new SampleBuffer( data, frames );
+		auto* psample = new SampleBuffer(data, frames);
 		psample->setFrequency( root_freq / 1000.0f );
 		psample->setSampleRate( sample_rate );
 
@@ -412,7 +412,7 @@ void PatmanInstrument::selectSample( NotePlayHandle * _n )
 		}
 	}
 
-	handle_data * hdata = new handle_data;
+	auto* hdata = new handle_data;
 	hdata->tuned = m_tunedModel.value();
 	if( sample )
 	{

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -148,7 +148,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 	{
 		selectSample( _n );
 	}
-	auto* hdata = (handle_data*)_n->m_pluginData;
+	handle_data * hdata = (handle_data *)_n->m_pluginData;
 
 	float play_freq = hdata->tuned ? _n->frequency() :
 						hdata->sample->frequency();
@@ -171,7 +171,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 
 void PatmanInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	auto* hdata = (handle_data*)_n->m_pluginData;
+	handle_data * hdata = (handle_data *)_n->m_pluginData;
 	sharedObject::unref( hdata->sample );
 	delete hdata->state;
 	delete hdata;
@@ -347,7 +347,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		auto* data = new sampleFrame[frames];
+		sampleFrame * data = new sampleFrame[frames];
 
 		for( f_cnt_t frame = 0; frame < frames; ++frame )
 		{
@@ -358,7 +358,7 @@ PatmanInstrument::LoadErrors PatmanInstrument::loadPatch(
 			}
 		}
 
-		auto* psample = new SampleBuffer(data, frames);
+		SampleBuffer* psample = new SampleBuffer( data, frames );
 		psample->setFrequency( root_freq / 1000.0f );
 		psample->setSampleRate( sample_rate );
 
@@ -412,7 +412,7 @@ void PatmanInstrument::selectSample( NotePlayHandle * _n )
 		}
 	}
 
-	auto* hdata = new handle_data;
+	handle_data * hdata = new handle_data;
 	hdata->tuned = m_tunedModel.value();
 	if( sample )
 	{

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
@@ -85,9 +85,9 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	m_absLed = new LedCheckBox( tr( "Absolute value" ), this );
 	m_absLed->setModel( &_controls->m_absModel );
 
-	QVBoxLayout * mainLayout = new QVBoxLayout();
-	QHBoxLayout * knobLayout = new QHBoxLayout();
-	QHBoxLayout * ledLayout = new QHBoxLayout();
+	auto mainLayout = new QVBoxLayout();
+	auto knobLayout = new QHBoxLayout();
+	auto ledLayout = new QHBoxLayout();
 
 	knobLayout->addWidget( m_baseKnob );
 	knobLayout->addWidget( m_amountKnob );

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
@@ -85,9 +85,9 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	m_absLed = new LedCheckBox( tr( "Absolute value" ), this );
 	m_absLed->setModel( &_controls->m_absModel );
 
-	auto* mainLayout = new QVBoxLayout();
-	auto* knobLayout = new QHBoxLayout();
-	auto* ledLayout = new QHBoxLayout();
+	QVBoxLayout * mainLayout = new QVBoxLayout();
+	QHBoxLayout * knobLayout = new QHBoxLayout();
+	QHBoxLayout * ledLayout = new QHBoxLayout();
 
 	knobLayout->addWidget( m_baseKnob );
 	knobLayout->addWidget( m_amountKnob );

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
@@ -85,9 +85,9 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	m_absLed = new LedCheckBox( tr( "Absolute value" ), this );
 	m_absLed->setModel( &_controls->m_absModel );
 
-	QVBoxLayout * mainLayout = new QVBoxLayout();
-	QHBoxLayout * knobLayout = new QHBoxLayout();
-	QHBoxLayout * ledLayout = new QHBoxLayout();
+	auto* mainLayout = new QVBoxLayout();
+	auto* knobLayout = new QHBoxLayout();
+	auto* ledLayout = new QHBoxLayout();
 
 	knobLayout->addWidget( m_baseKnob );
 	knobLayout->addWidget( m_amountKnob );

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -98,12 +98,10 @@ bool ReverbSCEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 	{
 		sample_t s[2] = { buf[f][0], buf[f][1] };
 
-		const SPFLOAT inGain = (SPFLOAT)DB2LIN((inGainBuf ? 
-			inGainBuf->values()[f] 
-			: m_reverbSCControls.m_inputGainModel.value()));
-		const SPFLOAT outGain = (SPFLOAT)DB2LIN((outGainBuf ? 
-			outGainBuf->values()[f] 
-			: m_reverbSCControls.m_outputGainModel.value()));
+		const auto inGain
+			= (SPFLOAT)DB2LIN((inGainBuf ? inGainBuf->values()[f] : m_reverbSCControls.m_inputGainModel.value()));
+		const auto outGain
+			= (SPFLOAT)DB2LIN((outGainBuf ? outGainBuf->values()[f] : m_reverbSCControls.m_outputGainModel.value()));
 
 		s[0] *= inGain;
 		s[1] *= inGain;

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -98,10 +98,12 @@ bool ReverbSCEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 	{
 		sample_t s[2] = { buf[f][0], buf[f][1] };
 
-		const auto inGain
-			= (SPFLOAT)DB2LIN((inGainBuf ? inGainBuf->values()[f] : m_reverbSCControls.m_inputGainModel.value()));
-		const auto outGain
-			= (SPFLOAT)DB2LIN((outGainBuf ? outGainBuf->values()[f] : m_reverbSCControls.m_outputGainModel.value()));
+		const SPFLOAT inGain = (SPFLOAT)DB2LIN((inGainBuf ? 
+			inGainBuf->values()[f] 
+			: m_reverbSCControls.m_inputGainModel.value()));
+		const SPFLOAT outGain = (SPFLOAT)DB2LIN((outGainBuf ? 
+			outGainBuf->values()[f] 
+			: m_reverbSCControls.m_outputGainModel.value()));
 
 		s[0] *= inGain;
 		s[1] *= inGain;

--- a/plugins/ReverbSC/ReverbSCControlDialog.cpp
+++ b/plugins/ReverbSC/ReverbSCControlDialog.cpp
@@ -41,26 +41,26 @@ ReverbSCControlDialog::ReverbSCControlDialog( ReverbSCControls* controls ) :
 	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
 	setFixedSize( 185, 55 );
-	
-	Knob * inputGainKnob = new Knob( knobBright_26, this);
+
+	auto inputGainKnob = new Knob(knobBright_26, this);
 	inputGainKnob -> move( 16, 10 );
 	inputGainKnob->setModel( &controls->m_inputGainModel );
 	inputGainKnob->setLabel( tr( "Input" ) );
 	inputGainKnob->setHintText( tr( "Input gain:" ) , "dB" );
 
-	Knob * sizeKnob = new Knob( knobBright_26, this);
+	auto sizeKnob = new Knob(knobBright_26, this);
 	sizeKnob -> move( 57, 10 );
 	sizeKnob->setModel( &controls->m_sizeModel );
 	sizeKnob->setLabel( tr( "Size" ) );
 	sizeKnob->setHintText( tr( "Size:" ) , "" );
 
-	Knob * colorKnob = new Knob( knobBright_26, this);
+	auto colorKnob = new Knob(knobBright_26, this);
 	colorKnob -> move( 98, 10 );
 	colorKnob->setModel( &controls->m_colorModel );
 	colorKnob->setLabel( tr( "Color" ) );
 	colorKnob->setHintText( tr( "Color:" ) , "" );
 
-	Knob * outputGainKnob = new Knob( knobBright_26, this);
+	auto outputGainKnob = new Knob(knobBright_26, this);
 	outputGainKnob -> move( 139, 10 );
 	outputGainKnob->setModel( &controls->m_outputGainModel );
 	outputGainKnob->setLabel( tr( "Output" ) );

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -186,7 +186,7 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusSpeed, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -640,7 +640,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		}
 		const int baseVelocity = instrumentTrack()->midiPort()->baseVelocity();
 
-		Sf2PluginData * pluginData = new Sf2PluginData;
+		auto pluginData = new Sf2PluginData;
 		pluginData->midiNote = midiNote;
 		pluginData->lastPanning = 0;
 		pluginData->lastVelocity = _n->midiVelocity( baseVelocity );
@@ -658,7 +658,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	}
 	else if( _n->isReleased() && ! _n->instrumentTrack()->isSustainPedalPressed() ) // note is released during this period
 	{
-		Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
+		auto pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
 		pluginData->offset = _n->framesBeforeRelease();
 		pluginData->isNew = false;
 
@@ -766,8 +766,8 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 		NotePlayHandle * currentNote = m_playingNotes[0];
 		for( int i = 1; i < m_playingNotes.size(); ++i )
 		{
-			Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
-			Sf2PluginData * iData = static_cast<Sf2PluginData *>( m_playingNotes[i]->m_pluginData );
+			auto currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
+			auto iData = static_cast<Sf2PluginData*>(m_playingNotes[i]->m_pluginData);
 			if( currentData->offset > iData->offset )
 			{
 				currentNote = m_playingNotes[i];
@@ -776,7 +776,7 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 
 		// process the current note:
 		// first see if we're synced in frame count
-		Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
+		auto currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
 		if( currentData->offset > currentFrame )
 		{
 			renderFrames( currentData->offset - currentFrame, _working_buffer + currentFrame );
@@ -860,7 +860,7 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, sampleFrame * buf )
 
 void Sf2Instrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
+	auto pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
 	if( ! pluginData->noteOffSent ) // if we for some reason haven't noteoffed the note before it gets deleted,
 									// do it here
 	{
@@ -908,37 +908,36 @@ Sf2InstrumentView::Sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 //	QVBoxLayout * vl = new QVBoxLayout( this );
 //	QHBoxLayout * hl = new QHBoxLayout();
 
-	Sf2Instrument* k = castModel<Sf2Instrument>();
+	auto k = castModel<Sf2Instrument>();
 
-	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
-	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
+	connect(&k->m_bankNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
+	connect(&k->m_patchNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
 
 	// File Button
-	m_fileDialogButton = new PixmapButton( this );
-	m_fileDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
-	m_fileDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_on" ) );
-	m_fileDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_off" ) );
-	m_fileDialogButton->move( 217, 107 );
+	m_fileDialogButton = new PixmapButton(this);
+	m_fileDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
+	m_fileDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_on"));
+	m_fileDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_off"));
+	m_fileDialogButton->move(217, 107);
 
-	connect( m_fileDialogButton, SIGNAL( clicked() ), this, SLOT( showFileDialog() ) );
+	connect(m_fileDialogButton, SIGNAL(clicked()), this, SLOT(showFileDialog()));
 
 	m_fileDialogButton->setToolTip(tr("Open SoundFont file"));
 
 	// Patch Button
-	m_patchDialogButton = new PixmapButton( this );
-	m_patchDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
-	m_patchDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_on" ) );
-	m_patchDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_off" ) );
-	m_patchDialogButton->setEnabled( false );
-	m_patchDialogButton->move( 217, 125 );
+	m_patchDialogButton = new PixmapButton(this);
+	m_patchDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
+	m_patchDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("patches_on"));
+	m_patchDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("patches_off"));
+	m_patchDialogButton->setEnabled(false);
+	m_patchDialogButton->move(217, 125);
 
-	connect( m_patchDialogButton, SIGNAL( clicked() ), this, SLOT( showPatchDialog() ) );
+	connect(m_patchDialogButton, SIGNAL(clicked()), this, SLOT(showPatchDialog()));
 
 	m_patchDialogButton->setToolTip(tr("Choose patch"));
 
-
 	// LCDs
-	m_bankNumLcd = new LcdSpinBox( 3, "21pink", this );
+	m_bankNumLcd = new LcdSpinBox(3, "21pink", this);
 	m_bankNumLcd->move(131, 62);
 //	m_bankNumLcd->addTextForValue( -1, "---" );
 //	m_bankNumLcd->setEnabled( false );
@@ -1057,7 +1056,7 @@ Sf2InstrumentView::Sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 
 void Sf2InstrumentView::modelChanged()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto k = castModel<Sf2Instrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1088,7 +1087,7 @@ void Sf2InstrumentView::modelChanged()
 
 void Sf2InstrumentView::updateFilename()
 {
-	Sf2Instrument * i = castModel<Sf2Instrument>();
+	auto i = castModel<Sf2Instrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".sf2", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1108,7 +1107,7 @@ void Sf2InstrumentView::updateFilename()
 
 void Sf2InstrumentView::updatePatchName()
 {
-	Sf2Instrument * i = castModel<Sf2Instrument>();
+	auto i = castModel<Sf2Instrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1130,7 +1129,7 @@ void Sf2InstrumentView::invalidateFile()
 
 void Sf2InstrumentView::showFileDialog()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto k = castModel<Sf2Instrument>();
 
 	FileDialog ofd( nullptr, tr( "Open SoundFont file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1170,7 +1169,7 @@ void Sf2InstrumentView::showFileDialog()
 
 void Sf2InstrumentView::showPatchDialog()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto k = castModel<Sf2Instrument>();
 
 	PatchesDialog pd( this );
 

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -186,7 +186,7 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusSpeed, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -640,7 +640,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		}
 		const int baseVelocity = instrumentTrack()->midiPort()->baseVelocity();
 
-		Sf2PluginData * pluginData = new Sf2PluginData;
+		auto* pluginData = new Sf2PluginData;
 		pluginData->midiNote = midiNote;
 		pluginData->lastPanning = 0;
 		pluginData->lastVelocity = _n->midiVelocity( baseVelocity );
@@ -658,7 +658,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	}
 	else if( _n->isReleased() && ! _n->instrumentTrack()->isSustainPedalPressed() ) // note is released during this period
 	{
-		Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
+		auto* pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
 		pluginData->offset = _n->framesBeforeRelease();
 		pluginData->isNew = false;
 
@@ -766,8 +766,8 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 		NotePlayHandle * currentNote = m_playingNotes[0];
 		for( int i = 1; i < m_playingNotes.size(); ++i )
 		{
-			Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
-			Sf2PluginData * iData = static_cast<Sf2PluginData *>( m_playingNotes[i]->m_pluginData );
+			auto* currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
+			auto* iData = static_cast<Sf2PluginData*>(m_playingNotes[i]->m_pluginData);
 			if( currentData->offset > iData->offset )
 			{
 				currentNote = m_playingNotes[i];
@@ -776,7 +776,7 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 
 		// process the current note:
 		// first see if we're synced in frame count
-		Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
+		auto* currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
 		if( currentData->offset > currentFrame )
 		{
 			renderFrames( currentData->offset - currentFrame, _working_buffer + currentFrame );
@@ -860,7 +860,7 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, sampleFrame * buf )
 
 void Sf2Instrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
+	auto* pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
 	if( ! pluginData->noteOffSent ) // if we for some reason haven't noteoffed the note before it gets deleted,
 									// do it here
 	{
@@ -908,38 +908,37 @@ Sf2InstrumentView::Sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 //	QVBoxLayout * vl = new QVBoxLayout( this );
 //	QHBoxLayout * hl = new QHBoxLayout();
 
-	Sf2Instrument* k = castModel<Sf2Instrument>();
+auto* k = castModel<Sf2Instrument>();
 
-	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
-	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
+connect(&k->m_bankNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
+connect(&k->m_patchNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
 
-	// File Button
-	m_fileDialogButton = new PixmapButton( this );
-	m_fileDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
-	m_fileDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_on" ) );
-	m_fileDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_off" ) );
-	m_fileDialogButton->move( 217, 107 );
+// File Button
+m_fileDialogButton = new PixmapButton(this);
+m_fileDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
+m_fileDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_on"));
+m_fileDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_off"));
+m_fileDialogButton->move(217, 107);
 
-	connect( m_fileDialogButton, SIGNAL( clicked() ), this, SLOT( showFileDialog() ) );
+connect(m_fileDialogButton, SIGNAL(clicked()), this, SLOT(showFileDialog()));
 
-	m_fileDialogButton->setToolTip(tr("Open SoundFont file"));
+m_fileDialogButton->setToolTip(tr("Open SoundFont file"));
 
-	// Patch Button
-	m_patchDialogButton = new PixmapButton( this );
-	m_patchDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
-	m_patchDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_on" ) );
-	m_patchDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_off" ) );
-	m_patchDialogButton->setEnabled( false );
-	m_patchDialogButton->move( 217, 125 );
+// Patch Button
+m_patchDialogButton = new PixmapButton(this);
+m_patchDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
+m_patchDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("patches_on"));
+m_patchDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("patches_off"));
+m_patchDialogButton->setEnabled(false);
+m_patchDialogButton->move(217, 125);
 
-	connect( m_patchDialogButton, SIGNAL( clicked() ), this, SLOT( showPatchDialog() ) );
+connect(m_patchDialogButton, SIGNAL(clicked()), this, SLOT(showPatchDialog()));
 
-	m_patchDialogButton->setToolTip(tr("Choose patch"));
+m_patchDialogButton->setToolTip(tr("Choose patch"));
 
-
-	// LCDs
-	m_bankNumLcd = new LcdSpinBox( 3, "21pink", this );
-	m_bankNumLcd->move(131, 62);
+// LCDs
+m_bankNumLcd = new LcdSpinBox(3, "21pink", this);
+m_bankNumLcd->move(131, 62);
 //	m_bankNumLcd->addTextForValue( -1, "---" );
 //	m_bankNumLcd->setEnabled( false );
 
@@ -1057,7 +1056,7 @@ Sf2InstrumentView::Sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 
 void Sf2InstrumentView::modelChanged()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto* k = castModel<Sf2Instrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1088,7 +1087,7 @@ void Sf2InstrumentView::modelChanged()
 
 void Sf2InstrumentView::updateFilename()
 {
-	Sf2Instrument * i = castModel<Sf2Instrument>();
+	auto* i = castModel<Sf2Instrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".sf2", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1108,7 +1107,7 @@ void Sf2InstrumentView::updateFilename()
 
 void Sf2InstrumentView::updatePatchName()
 {
-	Sf2Instrument * i = castModel<Sf2Instrument>();
+	auto* i = castModel<Sf2Instrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1130,7 +1129,7 @@ void Sf2InstrumentView::invalidateFile()
 
 void Sf2InstrumentView::showFileDialog()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto* k = castModel<Sf2Instrument>();
 
 	FileDialog ofd( nullptr, tr( "Open SoundFont file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1170,7 +1169,7 @@ void Sf2InstrumentView::showFileDialog()
 
 void Sf2InstrumentView::showPatchDialog()
 {
-	Sf2Instrument * k = castModel<Sf2Instrument>();
+	auto* k = castModel<Sf2Instrument>();
 
 	PatchesDialog pd( this );
 

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -186,7 +186,7 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusSpeed, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 
-	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
 	Engine::audioEngine()->addPlayHandle( iph );
 }
 
@@ -640,7 +640,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 		}
 		const int baseVelocity = instrumentTrack()->midiPort()->baseVelocity();
 
-		auto* pluginData = new Sf2PluginData;
+		Sf2PluginData * pluginData = new Sf2PluginData;
 		pluginData->midiNote = midiNote;
 		pluginData->lastPanning = 0;
 		pluginData->lastVelocity = _n->midiVelocity( baseVelocity );
@@ -658,7 +658,7 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	}
 	else if( _n->isReleased() && ! _n->instrumentTrack()->isSustainPedalPressed() ) // note is released during this period
 	{
-		auto* pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
+		Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
 		pluginData->offset = _n->framesBeforeRelease();
 		pluginData->isNew = false;
 
@@ -766,8 +766,8 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 		NotePlayHandle * currentNote = m_playingNotes[0];
 		for( int i = 1; i < m_playingNotes.size(); ++i )
 		{
-			auto* currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
-			auto* iData = static_cast<Sf2PluginData*>(m_playingNotes[i]->m_pluginData);
+			Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
+			Sf2PluginData * iData = static_cast<Sf2PluginData *>( m_playingNotes[i]->m_pluginData );
 			if( currentData->offset > iData->offset )
 			{
 				currentNote = m_playingNotes[i];
@@ -776,7 +776,7 @@ void Sf2Instrument::play( sampleFrame * _working_buffer )
 
 		// process the current note:
 		// first see if we're synced in frame count
-		auto* currentData = static_cast<Sf2PluginData*>(currentNote->m_pluginData);
+		Sf2PluginData * currentData = static_cast<Sf2PluginData *>( currentNote->m_pluginData );
 		if( currentData->offset > currentFrame )
 		{
 			renderFrames( currentData->offset - currentFrame, _working_buffer + currentFrame );
@@ -860,7 +860,7 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, sampleFrame * buf )
 
 void Sf2Instrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	auto* pluginData = static_cast<Sf2PluginData*>(_n->m_pluginData);
+	Sf2PluginData * pluginData = static_cast<Sf2PluginData *>( _n->m_pluginData );
 	if( ! pluginData->noteOffSent ) // if we for some reason haven't noteoffed the note before it gets deleted,
 									// do it here
 	{
@@ -908,37 +908,38 @@ Sf2InstrumentView::Sf2InstrumentView( Instrument * _instrument, QWidget * _paren
 //	QVBoxLayout * vl = new QVBoxLayout( this );
 //	QHBoxLayout * hl = new QHBoxLayout();
 
-auto* k = castModel<Sf2Instrument>();
+	Sf2Instrument* k = castModel<Sf2Instrument>();
 
-connect(&k->m_bankNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
-connect(&k->m_patchNum, SIGNAL(dataChanged()), this, SLOT(updatePatchName()));
+	connect( &k->m_bankNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
+	connect( &k->m_patchNum, SIGNAL( dataChanged() ), this, SLOT( updatePatchName() ) );
 
-// File Button
-m_fileDialogButton = new PixmapButton(this);
-m_fileDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
-m_fileDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_on"));
-m_fileDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("fileselect_off"));
-m_fileDialogButton->move(217, 107);
+	// File Button
+	m_fileDialogButton = new PixmapButton( this );
+	m_fileDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
+	m_fileDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_on" ) );
+	m_fileDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "fileselect_off" ) );
+	m_fileDialogButton->move( 217, 107 );
 
-connect(m_fileDialogButton, SIGNAL(clicked()), this, SLOT(showFileDialog()));
+	connect( m_fileDialogButton, SIGNAL( clicked() ), this, SLOT( showFileDialog() ) );
 
-m_fileDialogButton->setToolTip(tr("Open SoundFont file"));
+	m_fileDialogButton->setToolTip(tr("Open SoundFont file"));
 
-// Patch Button
-m_patchDialogButton = new PixmapButton(this);
-m_patchDialogButton->setCursor(QCursor(Qt::PointingHandCursor));
-m_patchDialogButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("patches_on"));
-m_patchDialogButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("patches_off"));
-m_patchDialogButton->setEnabled(false);
-m_patchDialogButton->move(217, 125);
+	// Patch Button
+	m_patchDialogButton = new PixmapButton( this );
+	m_patchDialogButton->setCursor( QCursor( Qt::PointingHandCursor ) );
+	m_patchDialogButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_on" ) );
+	m_patchDialogButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "patches_off" ) );
+	m_patchDialogButton->setEnabled( false );
+	m_patchDialogButton->move( 217, 125 );
 
-connect(m_patchDialogButton, SIGNAL(clicked()), this, SLOT(showPatchDialog()));
+	connect( m_patchDialogButton, SIGNAL( clicked() ), this, SLOT( showPatchDialog() ) );
 
-m_patchDialogButton->setToolTip(tr("Choose patch"));
+	m_patchDialogButton->setToolTip(tr("Choose patch"));
 
-// LCDs
-m_bankNumLcd = new LcdSpinBox(3, "21pink", this);
-m_bankNumLcd->move(131, 62);
+
+	// LCDs
+	m_bankNumLcd = new LcdSpinBox( 3, "21pink", this );
+	m_bankNumLcd->move(131, 62);
 //	m_bankNumLcd->addTextForValue( -1, "---" );
 //	m_bankNumLcd->setEnabled( false );
 
@@ -1056,7 +1057,7 @@ m_bankNumLcd->move(131, 62);
 
 void Sf2InstrumentView::modelChanged()
 {
-	auto* k = castModel<Sf2Instrument>();
+	Sf2Instrument * k = castModel<Sf2Instrument>();
 	m_bankNumLcd->setModel( &k->m_bankNum );
 	m_patchNumLcd->setModel( &k->m_patchNum );
 
@@ -1087,7 +1088,7 @@ void Sf2InstrumentView::modelChanged()
 
 void Sf2InstrumentView::updateFilename()
 {
-	auto* i = castModel<Sf2Instrument>();
+	Sf2Instrument * i = castModel<Sf2Instrument>();
 	QFontMetrics fm( m_filenameLabel->font() );
 	QString file = i->m_filename.endsWith( ".sf2", Qt::CaseInsensitive ) ?
 			i->m_filename.left( i->m_filename.length() - 4 ) :
@@ -1107,7 +1108,7 @@ void Sf2InstrumentView::updateFilename()
 
 void Sf2InstrumentView::updatePatchName()
 {
-	auto* i = castModel<Sf2Instrument>();
+	Sf2Instrument * i = castModel<Sf2Instrument>();
 	QFontMetrics fm( font() );
 	QString patch = i->getCurrentPatchName();
 	m_patchLabel->setText( fm.elidedText( patch, Qt::ElideLeft, m_patchLabel->width() ) );
@@ -1129,7 +1130,7 @@ void Sf2InstrumentView::invalidateFile()
 
 void Sf2InstrumentView::showFileDialog()
 {
-	auto* k = castModel<Sf2Instrument>();
+	Sf2Instrument * k = castModel<Sf2Instrument>();
 
 	FileDialog ofd( nullptr, tr( "Open SoundFont file" ) );
 	ofd.setFileMode( FileDialog::ExistingFiles );
@@ -1169,7 +1170,7 @@ void Sf2InstrumentView::showFileDialog()
 
 void Sf2InstrumentView::showPatchDialog()
 {
-	auto* k = castModel<Sf2Instrument>();
+	Sf2Instrument * k = castModel<Sf2Instrument>();
 
 	PatchesDialog pd( this );
 

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -464,7 +464,7 @@ void SfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffe
 // debug code
 //	qDebug( "pFN %d", pitchedFrameNum );
 
-	auto* pitchedBuffer = new sampleFrame[pitchedFrameNum];
+	sampleFrame * pitchedBuffer = new sampleFrame[pitchedFrameNum];
 	static_cast<SfxrSynth*>(_n->m_pluginData)->update( pitchedBuffer, pitchedFrameNum );
 	for( fpp_t i=0; i<frameNum; i++ )
 	{
@@ -709,7 +709,7 @@ SfxrInstrumentView::SfxrInstrumentView( Instrument * _instrument,
 
 void SfxrInstrumentView::modelChanged()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 
 	m_attKnob->setModel( &s->m_attModel );
 	m_holdKnob->setModel( &s->m_holdModel );
@@ -748,7 +748,7 @@ void SfxrInstrumentView::modelChanged()
 
 void SfxrInstrumentView::genPickup()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 	s->m_startFreqModel.setValue( 0.4f+frnd(0.5f) );
 	s->m_attModel.setValue( 0.0f );
@@ -768,7 +768,7 @@ void SfxrInstrumentView::genPickup()
 
 void SfxrInstrumentView::genLaser()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -827,7 +827,7 @@ void SfxrInstrumentView::genLaser()
 
 void SfxrInstrumentView::genExplosion()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 3 );
@@ -882,7 +882,7 @@ void SfxrInstrumentView::genExplosion()
 
 void SfxrInstrumentView::genPowerup()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	if(rnd(1))
@@ -916,7 +916,7 @@ void SfxrInstrumentView::genPowerup()
 
 void SfxrInstrumentView::genHit()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -946,7 +946,7 @@ void SfxrInstrumentView::genHit()
 
 void SfxrInstrumentView::genJump()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 0 );
@@ -976,7 +976,7 @@ void SfxrInstrumentView::genJump()
 
 void SfxrInstrumentView::genBlip()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(1) );
@@ -998,7 +998,7 @@ void SfxrInstrumentView::genBlip()
 
 void SfxrInstrumentView::randomize()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 
 	s->m_startFreqModel.setValue( pow(frnd(2.0f)-1.0f, 2.0f) );
 	if(rnd(1))
@@ -1059,7 +1059,7 @@ void SfxrInstrumentView::randomize()
 
 void SfxrInstrumentView::mutate()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument * s = castModel<SfxrInstrument>();
 
 	if(rnd(1)) s->m_startFreqModel.setValue( s->m_startFreqModel.value()+frnd(0.1f)-0.05f );
 	//		if(rnd(1)) s->m_minFreqModel.setValue( s->m_minFreqModel.value()+frnd(0.1f)-0.05f );
@@ -1099,7 +1099,7 @@ void SfxrInstrumentView::mutate()
 
 void SfxrInstrumentView::previewSound()
 {
-	auto* s = castModel<SfxrInstrument>();
+	SfxrInstrument* s = castModel<SfxrInstrument>();
 	InstrumentTrack* it = s->instrumentTrack();
 	it->silenceAllNotes();
 	it->processInEvent( MidiEvent( MidiNoteOn, 0, it->baseNoteModel()->value(), MidiDefaultVelocity ) );

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -464,7 +464,7 @@ void SfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffe
 // debug code
 //	qDebug( "pFN %d", pitchedFrameNum );
 
-	sampleFrame * pitchedBuffer = new sampleFrame[pitchedFrameNum];
+	auto* pitchedBuffer = new sampleFrame[pitchedFrameNum];
 	static_cast<SfxrSynth*>(_n->m_pluginData)->update( pitchedBuffer, pitchedFrameNum );
 	for( fpp_t i=0; i<frameNum; i++ )
 	{
@@ -709,7 +709,7 @@ SfxrInstrumentView::SfxrInstrumentView( Instrument * _instrument,
 
 void SfxrInstrumentView::modelChanged()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 
 	m_attKnob->setModel( &s->m_attModel );
 	m_holdKnob->setModel( &s->m_holdModel );
@@ -748,7 +748,7 @@ void SfxrInstrumentView::modelChanged()
 
 void SfxrInstrumentView::genPickup()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 	s->m_startFreqModel.setValue( 0.4f+frnd(0.5f) );
 	s->m_attModel.setValue( 0.0f );
@@ -768,7 +768,7 @@ void SfxrInstrumentView::genPickup()
 
 void SfxrInstrumentView::genLaser()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -827,7 +827,7 @@ void SfxrInstrumentView::genLaser()
 
 void SfxrInstrumentView::genExplosion()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 3 );
@@ -882,7 +882,7 @@ void SfxrInstrumentView::genExplosion()
 
 void SfxrInstrumentView::genPowerup()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	if(rnd(1))
@@ -916,7 +916,7 @@ void SfxrInstrumentView::genPowerup()
 
 void SfxrInstrumentView::genHit()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -946,7 +946,7 @@ void SfxrInstrumentView::genHit()
 
 void SfxrInstrumentView::genJump()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 0 );
@@ -976,7 +976,7 @@ void SfxrInstrumentView::genJump()
 
 void SfxrInstrumentView::genBlip()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(1) );
@@ -998,7 +998,7 @@ void SfxrInstrumentView::genBlip()
 
 void SfxrInstrumentView::randomize()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 
 	s->m_startFreqModel.setValue( pow(frnd(2.0f)-1.0f, 2.0f) );
 	if(rnd(1))
@@ -1059,7 +1059,7 @@ void SfxrInstrumentView::randomize()
 
 void SfxrInstrumentView::mutate()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 
 	if(rnd(1)) s->m_startFreqModel.setValue( s->m_startFreqModel.value()+frnd(0.1f)-0.05f );
 	//		if(rnd(1)) s->m_minFreqModel.setValue( s->m_minFreqModel.value()+frnd(0.1f)-0.05f );
@@ -1099,7 +1099,7 @@ void SfxrInstrumentView::mutate()
 
 void SfxrInstrumentView::previewSound()
 {
-	SfxrInstrument* s = castModel<SfxrInstrument>();
+	auto* s = castModel<SfxrInstrument>();
 	InstrumentTrack* it = s->instrumentTrack();
 	it->silenceAllNotes();
 	it->processInEvent( MidiEvent( MidiNoteOn, 0, it->baseNoteModel()->value(), MidiDefaultVelocity ) );

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -464,7 +464,7 @@ void SfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffe
 // debug code
 //	qDebug( "pFN %d", pitchedFrameNum );
 
-	sampleFrame * pitchedBuffer = new sampleFrame[pitchedFrameNum];
+	auto pitchedBuffer = new sampleFrame[pitchedFrameNum];
 	static_cast<SfxrSynth*>(_n->m_pluginData)->update( pitchedBuffer, pitchedFrameNum );
 	for( fpp_t i=0; i<frameNum; i++ )
 	{
@@ -709,7 +709,7 @@ SfxrInstrumentView::SfxrInstrumentView( Instrument * _instrument,
 
 void SfxrInstrumentView::modelChanged()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 
 	m_attKnob->setModel( &s->m_attModel );
 	m_holdKnob->setModel( &s->m_holdModel );
@@ -748,7 +748,7 @@ void SfxrInstrumentView::modelChanged()
 
 void SfxrInstrumentView::genPickup()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 	s->m_startFreqModel.setValue( 0.4f+frnd(0.5f) );
 	s->m_attModel.setValue( 0.0f );
@@ -768,7 +768,7 @@ void SfxrInstrumentView::genPickup()
 
 void SfxrInstrumentView::genLaser()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -827,7 +827,7 @@ void SfxrInstrumentView::genLaser()
 
 void SfxrInstrumentView::genExplosion()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 3 );
@@ -882,7 +882,7 @@ void SfxrInstrumentView::genExplosion()
 
 void SfxrInstrumentView::genPowerup()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	if(rnd(1))
@@ -916,7 +916,7 @@ void SfxrInstrumentView::genPowerup()
 
 void SfxrInstrumentView::genHit()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(2) );
@@ -946,7 +946,7 @@ void SfxrInstrumentView::genHit()
 
 void SfxrInstrumentView::genJump()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( 0 );
@@ -976,7 +976,7 @@ void SfxrInstrumentView::genJump()
 
 void SfxrInstrumentView::genBlip()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	s->resetModels();
 
 	s->m_waveFormModel.setValue( rnd(1) );
@@ -998,7 +998,7 @@ void SfxrInstrumentView::genBlip()
 
 void SfxrInstrumentView::randomize()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 
 	s->m_startFreqModel.setValue( pow(frnd(2.0f)-1.0f, 2.0f) );
 	if(rnd(1))
@@ -1059,7 +1059,7 @@ void SfxrInstrumentView::randomize()
 
 void SfxrInstrumentView::mutate()
 {
-	SfxrInstrument * s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 
 	if(rnd(1)) s->m_startFreqModel.setValue( s->m_startFreqModel.value()+frnd(0.1f)-0.05f );
 	//		if(rnd(1)) s->m_minFreqModel.setValue( s->m_minFreqModel.value()+frnd(0.1f)-0.05f );
@@ -1099,7 +1099,7 @@ void SfxrInstrumentView::mutate()
 
 void SfxrInstrumentView::previewSound()
 {
-	SfxrInstrument* s = castModel<SfxrInstrument>();
+	auto s = castModel<SfxrInstrument>();
 	InstrumentTrack* it = s->instrumentTrack();
 	it->silenceAllNotes();
 	it->processInEvent( MidiEvent( MidiNoteOn, 0, it->baseNoteModel()->value(), MidiDefaultVelocity ) );

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -317,7 +317,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 	SID *sid = static_cast<SID *>( _n->m_pluginData );
 	int delta_t = clockrate * frames / samplerate + 4;
 	// avoid variable length array for msvc compat
-	short* buf = reinterpret_cast<short*>(_working_buffer + offset);
+	auto buf = reinterpret_cast<short*>(_working_buffer + offset);
 	unsigned char sidreg[NUMSIDREGS];
 
 	for (int c = 0; c < NUMSIDREGS; c++)
@@ -498,19 +498,19 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_cutKnob->setHintText( tr( "Cutoff frequency:" ), " Hz" );
 	m_cutKnob->move( 7 + 2*28, 64 );
 
-	PixmapButton * hp_btn = new PixmapButton( this, nullptr );
+	auto hp_btn = new PixmapButton(this, nullptr);
 	hp_btn->move( 140, 77 );
 	hp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "hpred" ) );
 	hp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "hp" ) );
 	hp_btn->setToolTip(tr("High-pass filter "));
 
-	PixmapButton * bp_btn = new PixmapButton( this, nullptr );
+	auto bp_btn = new PixmapButton(this, nullptr);
 	bp_btn->move( 164, 77 );
 	bp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpred" ) );
 	bp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bp" ) );
 	bp_btn->setToolTip(tr("Band-pass filter "));
 
-	PixmapButton * lp_btn = new PixmapButton( this, nullptr );
+	auto lp_btn = new PixmapButton(this, nullptr);
 	lp_btn->move( 185, 77 );
 	lp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "lpred" ) );
 	lp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "lp" ) );
@@ -528,13 +528,13 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_offButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "3off" ) );
 	m_offButton->setToolTip(tr("Voice 3 off "));
 
-	PixmapButton * mos6581_btn = new PixmapButton( this, nullptr );
+	auto mos6581_btn = new PixmapButton(this, nullptr);
 	mos6581_btn->move( 170, 59 );
 	mos6581_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "6581red" ) );
 	mos6581_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "6581" ) );
 	mos6581_btn->setToolTip(tr("MOS6581 SID "));
 
-	PixmapButton * mos8580_btn = new PixmapButton( this, nullptr );
+	auto mos8580_btn = new PixmapButton(this, nullptr);
 	mos8580_btn->move( 207, 59 );
 	mos8580_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "8580red" ) );
 	mos8580_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "8580" ) );
@@ -570,7 +570,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 		crsk->setHintText( tr("Coarse:"), " semitones" );
 		crsk->move( 147, 114 + i*50 );
 
-		PixmapButton * pulse_btn = new PixmapButton( this, nullptr );
+		auto pulse_btn = new PixmapButton(this, nullptr);
 		pulse_btn->move( 187, 101 + i*50 );
 		pulse_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "pulsered" ) );
@@ -578,7 +578,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "pulse" ) );
 		pulse_btn->setToolTip(tr("Pulse wave"));
 
-		PixmapButton * triangle_btn = new PixmapButton( this, nullptr );
+		auto triangle_btn = new PixmapButton(this, nullptr);
 		triangle_btn->move( 168, 101 + i*50 );
 		triangle_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "trianglered" ) );
@@ -586,7 +586,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "triangle" ) );
 		triangle_btn->setToolTip(tr("Triangle wave"));
 
-		PixmapButton * saw_btn = new PixmapButton( this, nullptr );
+		auto saw_btn = new PixmapButton(this, nullptr);
 		saw_btn->move( 207, 101 + i*50 );
 		saw_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "sawred" ) );
@@ -594,7 +594,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "saw" ) );
 		saw_btn->setToolTip(tr("Saw wave"));
 
-		PixmapButton * noise_btn = new PixmapButton( this, nullptr );
+		auto noise_btn = new PixmapButton(this, nullptr);
 		noise_btn->move( 226, 101 + i*50 );
 		noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "noisered" ) );
@@ -602,15 +602,14 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "noise" ) );
 		noise_btn->setToolTip(tr("Noise"));
 
-		automatableButtonGroup * wfbg =
-			new automatableButtonGroup( this );
+		auto wfbg = new automatableButtonGroup(this);
 
 		wfbg->addButton( pulse_btn );
 		wfbg->addButton( triangle_btn );
 		wfbg->addButton( saw_btn );
 		wfbg->addButton( noise_btn );
 
-		PixmapButton * sync_btn = new PixmapButton( this, nullptr );
+		auto sync_btn = new PixmapButton(this, nullptr);
 		sync_btn->setCheckable( true );
 		sync_btn->move( 207, 134 + i*50 );
 		sync_btn->setActiveGraphic(
@@ -619,7 +618,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "sync" ) );
 		sync_btn->setToolTip(tr("Sync"));
 
-		PixmapButton * ringMod_btn = new PixmapButton( this, nullptr );
+		auto ringMod_btn = new PixmapButton(this, nullptr);
 		ringMod_btn->setCheckable( true );
 		ringMod_btn->move( 170, 116 + i*50 );
 		ringMod_btn->setActiveGraphic(
@@ -628,7 +627,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "ring" ) );
 		ringMod_btn->setToolTip(tr("Ring modulation"));
 
-		PixmapButton * filter_btn = new PixmapButton( this, nullptr );
+		auto filter_btn = new PixmapButton(this, nullptr);
 		filter_btn->setCheckable( true );
 		filter_btn->move( 207, 116 + i*50 );
 		filter_btn->setActiveGraphic(
@@ -637,7 +636,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "filter" ) );
 		filter_btn->setToolTip(tr("Filtered"));
 
-		PixmapButton * test_btn = new PixmapButton( this, nullptr );
+		auto test_btn = new PixmapButton(this, nullptr);
 		test_btn->setCheckable( true );
 		test_btn->move( 170, 134 + i*50 );
 		test_btn->setActiveGraphic(
@@ -654,7 +653,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 
 void SidInstrumentView::updateKnobHint()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto k = castModel<SidInstrument>();
 
 	for( int i = 0; i < 3; ++i )
 	{
@@ -695,7 +694,7 @@ void SidInstrumentView::updateKnobHint()
 
 void SidInstrumentView::updateKnobToolTip()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto k = castModel<SidInstrument>();
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voiceKnobs[i].m_sustKnob->setToolTip(
@@ -715,7 +714,7 @@ void SidInstrumentView::updateKnobToolTip()
 
 void SidInstrumentView::modelChanged()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto k = castModel<SidInstrument>();
 
 	m_volKnob->setModel( &k->m_volumeModel );
 	m_resKnob->setModel( &k->m_filterResonanceModel );

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -317,7 +317,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 	SID *sid = static_cast<SID *>( _n->m_pluginData );
 	int delta_t = clockrate * frames / samplerate + 4;
 	// avoid variable length array for msvc compat
-	auto* buf = reinterpret_cast<short*>(_working_buffer + offset);
+	short* buf = reinterpret_cast<short*>(_working_buffer + offset);
 	unsigned char sidreg[NUMSIDREGS];
 
 	for (int c = 0; c < NUMSIDREGS; c++)
@@ -498,19 +498,19 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_cutKnob->setHintText( tr( "Cutoff frequency:" ), " Hz" );
 	m_cutKnob->move( 7 + 2*28, 64 );
 
-	auto* hp_btn = new PixmapButton(this, nullptr);
+	PixmapButton * hp_btn = new PixmapButton( this, nullptr );
 	hp_btn->move( 140, 77 );
 	hp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "hpred" ) );
 	hp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "hp" ) );
 	hp_btn->setToolTip(tr("High-pass filter "));
 
-	auto* bp_btn = new PixmapButton(this, nullptr);
+	PixmapButton * bp_btn = new PixmapButton( this, nullptr );
 	bp_btn->move( 164, 77 );
 	bp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpred" ) );
 	bp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bp" ) );
 	bp_btn->setToolTip(tr("Band-pass filter "));
 
-	auto* lp_btn = new PixmapButton(this, nullptr);
+	PixmapButton * lp_btn = new PixmapButton( this, nullptr );
 	lp_btn->move( 185, 77 );
 	lp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "lpred" ) );
 	lp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "lp" ) );
@@ -528,13 +528,13 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_offButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "3off" ) );
 	m_offButton->setToolTip(tr("Voice 3 off "));
 
-	auto* mos6581_btn = new PixmapButton(this, nullptr);
+	PixmapButton * mos6581_btn = new PixmapButton( this, nullptr );
 	mos6581_btn->move( 170, 59 );
 	mos6581_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "6581red" ) );
 	mos6581_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "6581" ) );
 	mos6581_btn->setToolTip(tr("MOS6581 SID "));
 
-	auto* mos8580_btn = new PixmapButton(this, nullptr);
+	PixmapButton * mos8580_btn = new PixmapButton( this, nullptr );
 	mos8580_btn->move( 207, 59 );
 	mos8580_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "8580red" ) );
 	mos8580_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "8580" ) );
@@ -570,7 +570,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 		crsk->setHintText( tr("Coarse:"), " semitones" );
 		crsk->move( 147, 114 + i*50 );
 
-		auto* pulse_btn = new PixmapButton(this, nullptr);
+		PixmapButton * pulse_btn = new PixmapButton( this, nullptr );
 		pulse_btn->move( 187, 101 + i*50 );
 		pulse_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "pulsered" ) );
@@ -578,7 +578,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "pulse" ) );
 		pulse_btn->setToolTip(tr("Pulse wave"));
 
-		auto* triangle_btn = new PixmapButton(this, nullptr);
+		PixmapButton * triangle_btn = new PixmapButton( this, nullptr );
 		triangle_btn->move( 168, 101 + i*50 );
 		triangle_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "trianglered" ) );
@@ -586,7 +586,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "triangle" ) );
 		triangle_btn->setToolTip(tr("Triangle wave"));
 
-		auto* saw_btn = new PixmapButton(this, nullptr);
+		PixmapButton * saw_btn = new PixmapButton( this, nullptr );
 		saw_btn->move( 207, 101 + i*50 );
 		saw_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "sawred" ) );
@@ -594,7 +594,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "saw" ) );
 		saw_btn->setToolTip(tr("Saw wave"));
 
-		auto* noise_btn = new PixmapButton(this, nullptr);
+		PixmapButton * noise_btn = new PixmapButton( this, nullptr );
 		noise_btn->move( 226, 101 + i*50 );
 		noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "noisered" ) );
@@ -602,14 +602,15 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "noise" ) );
 		noise_btn->setToolTip(tr("Noise"));
 
-		auto* wfbg = new automatableButtonGroup(this);
+		automatableButtonGroup * wfbg =
+			new automatableButtonGroup( this );
 
 		wfbg->addButton( pulse_btn );
 		wfbg->addButton( triangle_btn );
 		wfbg->addButton( saw_btn );
 		wfbg->addButton( noise_btn );
 
-		auto* sync_btn = new PixmapButton(this, nullptr);
+		PixmapButton * sync_btn = new PixmapButton( this, nullptr );
 		sync_btn->setCheckable( true );
 		sync_btn->move( 207, 134 + i*50 );
 		sync_btn->setActiveGraphic(
@@ -618,7 +619,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "sync" ) );
 		sync_btn->setToolTip(tr("Sync"));
 
-		auto* ringMod_btn = new PixmapButton(this, nullptr);
+		PixmapButton * ringMod_btn = new PixmapButton( this, nullptr );
 		ringMod_btn->setCheckable( true );
 		ringMod_btn->move( 170, 116 + i*50 );
 		ringMod_btn->setActiveGraphic(
@@ -627,7 +628,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "ring" ) );
 		ringMod_btn->setToolTip(tr("Ring modulation"));
 
-		auto* filter_btn = new PixmapButton(this, nullptr);
+		PixmapButton * filter_btn = new PixmapButton( this, nullptr );
 		filter_btn->setCheckable( true );
 		filter_btn->move( 207, 116 + i*50 );
 		filter_btn->setActiveGraphic(
@@ -636,7 +637,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "filter" ) );
 		filter_btn->setToolTip(tr("Filtered"));
 
-		auto* test_btn = new PixmapButton(this, nullptr);
+		PixmapButton * test_btn = new PixmapButton( this, nullptr );
 		test_btn->setCheckable( true );
 		test_btn->move( 170, 134 + i*50 );
 		test_btn->setActiveGraphic(
@@ -653,7 +654,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 
 void SidInstrumentView::updateKnobHint()
 {
-	auto* k = castModel<SidInstrument>();
+	SidInstrument * k = castModel<SidInstrument>();
 
 	for( int i = 0; i < 3; ++i )
 	{
@@ -694,7 +695,7 @@ void SidInstrumentView::updateKnobHint()
 
 void SidInstrumentView::updateKnobToolTip()
 {
-	auto* k = castModel<SidInstrument>();
+	SidInstrument * k = castModel<SidInstrument>();
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voiceKnobs[i].m_sustKnob->setToolTip(
@@ -714,7 +715,7 @@ void SidInstrumentView::updateKnobToolTip()
 
 void SidInstrumentView::modelChanged()
 {
-	auto* k = castModel<SidInstrument>();
+	SidInstrument * k = castModel<SidInstrument>();
 
 	m_volKnob->setModel( &k->m_volumeModel );
 	m_resKnob->setModel( &k->m_filterResonanceModel );

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -317,7 +317,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 	SID *sid = static_cast<SID *>( _n->m_pluginData );
 	int delta_t = clockrate * frames / samplerate + 4;
 	// avoid variable length array for msvc compat
-	short* buf = reinterpret_cast<short*>(_working_buffer + offset);
+	auto* buf = reinterpret_cast<short*>(_working_buffer + offset);
 	unsigned char sidreg[NUMSIDREGS];
 
 	for (int c = 0; c < NUMSIDREGS; c++)
@@ -498,19 +498,19 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_cutKnob->setHintText( tr( "Cutoff frequency:" ), " Hz" );
 	m_cutKnob->move( 7 + 2*28, 64 );
 
-	PixmapButton * hp_btn = new PixmapButton( this, nullptr );
+	auto* hp_btn = new PixmapButton(this, nullptr);
 	hp_btn->move( 140, 77 );
 	hp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "hpred" ) );
 	hp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "hp" ) );
 	hp_btn->setToolTip(tr("High-pass filter "));
 
-	PixmapButton * bp_btn = new PixmapButton( this, nullptr );
+	auto* bp_btn = new PixmapButton(this, nullptr);
 	bp_btn->move( 164, 77 );
 	bp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpred" ) );
 	bp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bp" ) );
 	bp_btn->setToolTip(tr("Band-pass filter "));
 
-	PixmapButton * lp_btn = new PixmapButton( this, nullptr );
+	auto* lp_btn = new PixmapButton(this, nullptr);
 	lp_btn->move( 185, 77 );
 	lp_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "lpred" ) );
 	lp_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "lp" ) );
@@ -528,13 +528,13 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 	m_offButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "3off" ) );
 	m_offButton->setToolTip(tr("Voice 3 off "));
 
-	PixmapButton * mos6581_btn = new PixmapButton( this, nullptr );
+	auto* mos6581_btn = new PixmapButton(this, nullptr);
 	mos6581_btn->move( 170, 59 );
 	mos6581_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "6581red" ) );
 	mos6581_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "6581" ) );
 	mos6581_btn->setToolTip(tr("MOS6581 SID "));
 
-	PixmapButton * mos8580_btn = new PixmapButton( this, nullptr );
+	auto* mos8580_btn = new PixmapButton(this, nullptr);
 	mos8580_btn->move( 207, 59 );
 	mos8580_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap( "8580red" ) );
 	mos8580_btn->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "8580" ) );
@@ -570,7 +570,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 		crsk->setHintText( tr("Coarse:"), " semitones" );
 		crsk->move( 147, 114 + i*50 );
 
-		PixmapButton * pulse_btn = new PixmapButton( this, nullptr );
+		auto* pulse_btn = new PixmapButton(this, nullptr);
 		pulse_btn->move( 187, 101 + i*50 );
 		pulse_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "pulsered" ) );
@@ -578,7 +578,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "pulse" ) );
 		pulse_btn->setToolTip(tr("Pulse wave"));
 
-		PixmapButton * triangle_btn = new PixmapButton( this, nullptr );
+		auto* triangle_btn = new PixmapButton(this, nullptr);
 		triangle_btn->move( 168, 101 + i*50 );
 		triangle_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "trianglered" ) );
@@ -586,7 +586,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "triangle" ) );
 		triangle_btn->setToolTip(tr("Triangle wave"));
 
-		PixmapButton * saw_btn = new PixmapButton( this, nullptr );
+		auto* saw_btn = new PixmapButton(this, nullptr);
 		saw_btn->move( 207, 101 + i*50 );
 		saw_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "sawred" ) );
@@ -594,7 +594,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "saw" ) );
 		saw_btn->setToolTip(tr("Saw wave"));
 
-		PixmapButton * noise_btn = new PixmapButton( this, nullptr );
+		auto* noise_btn = new PixmapButton(this, nullptr);
 		noise_btn->move( 226, 101 + i*50 );
 		noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "noisered" ) );
@@ -602,15 +602,14 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "noise" ) );
 		noise_btn->setToolTip(tr("Noise"));
 
-		automatableButtonGroup * wfbg =
-			new automatableButtonGroup( this );
+		auto* wfbg = new automatableButtonGroup(this);
 
 		wfbg->addButton( pulse_btn );
 		wfbg->addButton( triangle_btn );
 		wfbg->addButton( saw_btn );
 		wfbg->addButton( noise_btn );
 
-		PixmapButton * sync_btn = new PixmapButton( this, nullptr );
+		auto* sync_btn = new PixmapButton(this, nullptr);
 		sync_btn->setCheckable( true );
 		sync_btn->move( 207, 134 + i*50 );
 		sync_btn->setActiveGraphic(
@@ -619,7 +618,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "sync" ) );
 		sync_btn->setToolTip(tr("Sync"));
 
-		PixmapButton * ringMod_btn = new PixmapButton( this, nullptr );
+		auto* ringMod_btn = new PixmapButton(this, nullptr);
 		ringMod_btn->setCheckable( true );
 		ringMod_btn->move( 170, 116 + i*50 );
 		ringMod_btn->setActiveGraphic(
@@ -628,7 +627,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "ring" ) );
 		ringMod_btn->setToolTip(tr("Ring modulation"));
 
-		PixmapButton * filter_btn = new PixmapButton( this, nullptr );
+		auto* filter_btn = new PixmapButton(this, nullptr);
 		filter_btn->setCheckable( true );
 		filter_btn->move( 207, 116 + i*50 );
 		filter_btn->setActiveGraphic(
@@ -637,7 +636,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 			PLUGIN_NAME::getIconPixmap( "filter" ) );
 		filter_btn->setToolTip(tr("Filtered"));
 
-		PixmapButton * test_btn = new PixmapButton( this, nullptr );
+		auto* test_btn = new PixmapButton(this, nullptr);
 		test_btn->setCheckable( true );
 		test_btn->move( 170, 134 + i*50 );
 		test_btn->setActiveGraphic(
@@ -654,7 +653,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 
 void SidInstrumentView::updateKnobHint()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto* k = castModel<SidInstrument>();
 
 	for( int i = 0; i < 3; ++i )
 	{
@@ -695,7 +694,7 @@ void SidInstrumentView::updateKnobHint()
 
 void SidInstrumentView::updateKnobToolTip()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto* k = castModel<SidInstrument>();
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voiceKnobs[i].m_sustKnob->setToolTip(
@@ -715,7 +714,7 @@ void SidInstrumentView::updateKnobToolTip()
 
 void SidInstrumentView::modelChanged()
 {
-	SidInstrument * k = castModel<SidInstrument>();
+	auto* k = castModel<SidInstrument>();
 
 	m_volKnob->setModel( &k->m_volumeModel );
 	m_resKnob->setModel( &k->m_filterResonanceModel );

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -52,15 +52,15 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	m_processor(processor)
 {
 	// Top level placement of sections is handled by QSplitter widget.
-	auto* master_layout = new QHBoxLayout;
-	auto* display_splitter = new QSplitter(Qt::Vertical);
+	QHBoxLayout *master_layout = new QHBoxLayout;
+	QSplitter *display_splitter = new QSplitter(Qt::Vertical);
 	master_layout->addWidget(display_splitter);
 	master_layout->setContentsMargins(2, 6, 2, 8);
 	setLayout(master_layout);
 
 	// Display splitter top: controls section
-	auto* controls_widget = new QWidget;
-	auto* controls_layout = new QHBoxLayout;
+	QWidget *controls_widget = new QWidget;
+	QHBoxLayout *controls_layout = new QHBoxLayout;
 	controls_layout->setContentsMargins(0, 0, 0, 0);
 	controls_widget->setLayout(controls_layout);
 	controls_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
@@ -69,8 +69,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Basic configuration
-	auto* config_widget = new QWidget;
-	auto* config_layout = new QGridLayout;
+	QWidget *config_widget = new QWidget;
+	QGridLayout *config_layout = new QGridLayout;
 	config_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	config_widget->setMaximumHeight(m_configHeight);
 	config_widget->setLayout(config_layout);
@@ -87,12 +87,10 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// pause and freeze buttons
-	auto* pauseButton = new PixmapButton(this, tr("Pause"));
+	PixmapButton *pauseButton = new PixmapButton(this, tr("Pause"));
 	pauseButton->setToolTip(tr("Pause data acquisition"));
-	auto* pauseOnPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	auto* pauseOffPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *pauseOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *pauseOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	pauseOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseButton->setActiveGraphic(*pauseOnPixmap);
@@ -101,12 +99,10 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	pauseButton->setModel(&controls->m_pauseModel);
 	config_layout->addWidget(pauseButton, 0, 0, 2, 1, Qt::AlignHCenter);
 
-	auto* refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
+	PixmapButton *refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
 	refFreezeButton->setToolTip(tr("Freeze current input as a reference / disable falloff in peak-hold mode."));
-	auto* freezeOnPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	auto* freezeOffPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *freezeOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *freezeOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	freezeOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	freezeOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	refFreezeButton->setActiveGraphic(*freezeOnPixmap);
@@ -116,28 +112,28 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(refFreezeButton, 2, 0, 2, 1, Qt::AlignHCenter);
 
 	// misc configuration switches
-	auto* waterfallButton = new LedCheckBox(tr("Waterfall"), this);
+	LedCheckBox *waterfallButton = new LedCheckBox(tr("Waterfall"), this);
 	waterfallButton->setToolTip(tr("Display real-time spectrogram"));
 	waterfallButton->setCheckable(true);
 	waterfallButton->setMinimumSize(70, 12);
 	waterfallButton->setModel(&controls->m_waterfallModel);
 	config_layout->addWidget(waterfallButton, 0, 1);
 
-	auto* smoothButton = new LedCheckBox(tr("Averaging"), this);
+	LedCheckBox *smoothButton = new LedCheckBox(tr("Averaging"), this);
 	smoothButton->setToolTip(tr("Enable exponential moving average"));
 	smoothButton->setCheckable(true);
 	smoothButton->setMinimumSize(70, 12);
 	smoothButton->setModel(&controls->m_smoothModel);
 	config_layout->addWidget(smoothButton, 1, 1);
 
-	auto* stereoButton = new LedCheckBox(tr("Stereo"), this);
+	LedCheckBox *stereoButton = new LedCheckBox(tr("Stereo"), this);
 	stereoButton->setToolTip(tr("Display stereo channels separately"));
 	stereoButton->setCheckable(true);
 	stereoButton->setMinimumSize(70, 12);
 	stereoButton->setModel(&controls->m_stereoModel);
 	config_layout->addWidget(stereoButton, 2, 1);
 
-	auto* peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
+	LedCheckBox *peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
 	peakHoldButton->setToolTip(tr("Display envelope of peak values"));
 	peakHoldButton->setCheckable(true);
 	peakHoldButton->setMinimumSize(70, 12);
@@ -145,12 +141,10 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(peakHoldButton, 3, 1);
 
 	// frequency: linear / log. switch and range selector
-	auto* logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
+	PixmapButton *logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
 	logXButton->setToolTip(tr("Switch between logarithmic and linear frequency scale"));
-	auto* logXOnPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	auto* logXOffPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *logXOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *logXOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logXOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXButton->setActiveGraphic(*logXOnPixmap);
@@ -159,7 +153,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logXButton->setModel(&controls->m_logXModel);
 	config_layout->addWidget(logXButton, 0, 2, 2, 1, Qt::AlignRight);
 
-	auto* freqRangeCombo = new ComboBox(this, tr("Frequency range"));
+	ComboBox *freqRangeCombo = new ComboBox(this, tr("Frequency range"));
 	freqRangeCombo->setToolTip(tr("Frequency range"));
 	freqRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	freqRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -167,12 +161,10 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(freqRangeCombo, 0, 3, 2, 1);
 
 	// amplitude: linear / log switch and range selector
-	auto* logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
+	PixmapButton *logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
 	logYButton->setToolTip(tr("Switch between logarithmic and linear amplitude scale"));
-	auto* logYOnPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	auto* logYOffPixmap = new QPixmap(
-		PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *logYOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *logYOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logYOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYButton->setActiveGraphic(*logYOnPixmap);
@@ -181,7 +173,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logYButton->setModel(&controls->m_logYModel);
 	config_layout->addWidget(logYButton, 2, 2, 2, 1, Qt::AlignRight);
 
-	auto* ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
+	ComboBox *ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
 	ampRangeCombo->setToolTip(tr("Amplitude range"));
 	ampRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	ampRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -189,13 +181,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(ampRangeCombo, 2, 3, 2, 1);
 
 	// FFT: block size: icon and selector
-	auto* blockSizeLabel = new QLabel("", this);
-	auto* blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
+	QLabel *blockSizeLabel = new QLabel("", this);
+	QPixmap *blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
 	blockSizeIcon->setDevicePixelRatio(devicePixelRatio());
 	blockSizeLabel->setPixmap(blockSizeIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(blockSizeLabel, 0, 4, 2, 1, Qt::AlignRight);
 
-	auto* blockSizeCombo = new ComboBox(this, tr("FFT block size"));
+	ComboBox *blockSizeCombo = new ComboBox(this, tr("FFT block size"));
 	blockSizeCombo->setToolTip(tr("FFT block size"));
 	blockSizeCombo->setMinimumSize(100, 22);
 	blockSizeCombo->setMaximumSize(200, 22);
@@ -205,13 +197,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_blockSizeModel, &ComboBoxModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// FFT: window type: icon and selector
-	auto* windowLabel = new QLabel("", this);
-	auto* windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
+	QLabel *windowLabel = new QLabel("", this);
+	QPixmap *windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
 	windowIcon->setDevicePixelRatio(devicePixelRatio());
 	windowLabel->setPixmap(windowIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(windowLabel, 2, 4, 2, 1, Qt::AlignRight);
 
-	auto* windowCombo = new ComboBox(this, tr("FFT window type"));
+	ComboBox *windowCombo = new ComboBox(this, tr("FFT window type"));
 	windowCombo->setToolTip(tr("FFT window type"));
 	windowCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	windowCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -226,8 +218,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced configuration
-	auto* advanced_widget = new QWidget;
-	auto* advanced_layout = new QGridLayout;
+	QWidget *advanced_widget = new QWidget;
+	QGridLayout *advanced_layout = new QGridLayout;
 	advanced_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	advanced_widget->setMaximumHeight(m_configHeight);
 	advanced_widget->setLayout(advanced_layout);
@@ -305,12 +297,10 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced settings button
-	auto* advancedButton = new PixmapButton(this, tr("Advanced settings"));
+	PixmapButton *advancedButton = new PixmapButton(this, tr("Advanced settings"));
 	advancedButton->setToolTip(tr("Access advanced settings"));
-	auto* advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on")
-											 .scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	auto* advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off")
-											  .scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	QPixmap *advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	advancedOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedButton->setActiveGraphic(*advancedOnPixmap);

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -52,15 +52,15 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	m_processor(processor)
 {
 	// Top level placement of sections is handled by QSplitter widget.
-	QHBoxLayout *master_layout = new QHBoxLayout;
-	QSplitter *display_splitter = new QSplitter(Qt::Vertical);
+	auto* master_layout = new QHBoxLayout;
+	auto* display_splitter = new QSplitter(Qt::Vertical);
 	master_layout->addWidget(display_splitter);
 	master_layout->setContentsMargins(2, 6, 2, 8);
 	setLayout(master_layout);
 
 	// Display splitter top: controls section
-	QWidget *controls_widget = new QWidget;
-	QHBoxLayout *controls_layout = new QHBoxLayout;
+	auto* controls_widget = new QWidget;
+	auto* controls_layout = new QHBoxLayout;
 	controls_layout->setContentsMargins(0, 0, 0, 0);
 	controls_widget->setLayout(controls_layout);
 	controls_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
@@ -69,8 +69,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Basic configuration
-	QWidget *config_widget = new QWidget;
-	QGridLayout *config_layout = new QGridLayout;
+	auto* config_widget = new QWidget;
+	auto* config_layout = new QGridLayout;
 	config_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	config_widget->setMaximumHeight(m_configHeight);
 	config_widget->setLayout(config_layout);
@@ -87,10 +87,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// pause and freeze buttons
-	PixmapButton *pauseButton = new PixmapButton(this, tr("Pause"));
+	auto* pauseButton = new PixmapButton(this, tr("Pause"));
 	pauseButton->setToolTip(tr("Pause data acquisition"));
-	QPixmap *pauseOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *pauseOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* pauseOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* pauseOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	pauseOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseButton->setActiveGraphic(*pauseOnPixmap);
@@ -99,10 +101,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	pauseButton->setModel(&controls->m_pauseModel);
 	config_layout->addWidget(pauseButton, 0, 0, 2, 1, Qt::AlignHCenter);
 
-	PixmapButton *refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
+	auto* refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
 	refFreezeButton->setToolTip(tr("Freeze current input as a reference / disable falloff in peak-hold mode."));
-	QPixmap *freezeOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *freezeOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* freezeOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* freezeOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	freezeOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	freezeOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	refFreezeButton->setActiveGraphic(*freezeOnPixmap);
@@ -112,28 +116,28 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(refFreezeButton, 2, 0, 2, 1, Qt::AlignHCenter);
 
 	// misc configuration switches
-	LedCheckBox *waterfallButton = new LedCheckBox(tr("Waterfall"), this);
+	auto* waterfallButton = new LedCheckBox(tr("Waterfall"), this);
 	waterfallButton->setToolTip(tr("Display real-time spectrogram"));
 	waterfallButton->setCheckable(true);
 	waterfallButton->setMinimumSize(70, 12);
 	waterfallButton->setModel(&controls->m_waterfallModel);
 	config_layout->addWidget(waterfallButton, 0, 1);
 
-	LedCheckBox *smoothButton = new LedCheckBox(tr("Averaging"), this);
+	auto* smoothButton = new LedCheckBox(tr("Averaging"), this);
 	smoothButton->setToolTip(tr("Enable exponential moving average"));
 	smoothButton->setCheckable(true);
 	smoothButton->setMinimumSize(70, 12);
 	smoothButton->setModel(&controls->m_smoothModel);
 	config_layout->addWidget(smoothButton, 1, 1);
 
-	LedCheckBox *stereoButton = new LedCheckBox(tr("Stereo"), this);
+	auto* stereoButton = new LedCheckBox(tr("Stereo"), this);
 	stereoButton->setToolTip(tr("Display stereo channels separately"));
 	stereoButton->setCheckable(true);
 	stereoButton->setMinimumSize(70, 12);
 	stereoButton->setModel(&controls->m_stereoModel);
 	config_layout->addWidget(stereoButton, 2, 1);
 
-	LedCheckBox *peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
+	auto* peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
 	peakHoldButton->setToolTip(tr("Display envelope of peak values"));
 	peakHoldButton->setCheckable(true);
 	peakHoldButton->setMinimumSize(70, 12);
@@ -141,10 +145,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(peakHoldButton, 3, 1);
 
 	// frequency: linear / log. switch and range selector
-	PixmapButton *logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
+	auto* logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
 	logXButton->setToolTip(tr("Switch between logarithmic and linear frequency scale"));
-	QPixmap *logXOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *logXOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* logXOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* logXOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logXOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXButton->setActiveGraphic(*logXOnPixmap);
@@ -153,7 +159,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logXButton->setModel(&controls->m_logXModel);
 	config_layout->addWidget(logXButton, 0, 2, 2, 1, Qt::AlignRight);
 
-	ComboBox *freqRangeCombo = new ComboBox(this, tr("Frequency range"));
+	auto* freqRangeCombo = new ComboBox(this, tr("Frequency range"));
 	freqRangeCombo->setToolTip(tr("Frequency range"));
 	freqRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	freqRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -161,10 +167,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(freqRangeCombo, 0, 3, 2, 1);
 
 	// amplitude: linear / log switch and range selector
-	PixmapButton *logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
+	auto* logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
 	logYButton->setToolTip(tr("Switch between logarithmic and linear amplitude scale"));
-	QPixmap *logYOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *logYOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* logYOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* logYOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logYOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYButton->setActiveGraphic(*logYOnPixmap);
@@ -173,7 +181,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logYButton->setModel(&controls->m_logYModel);
 	config_layout->addWidget(logYButton, 2, 2, 2, 1, Qt::AlignRight);
 
-	ComboBox *ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
+	auto* ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
 	ampRangeCombo->setToolTip(tr("Amplitude range"));
 	ampRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	ampRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -181,13 +189,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(ampRangeCombo, 2, 3, 2, 1);
 
 	// FFT: block size: icon and selector
-	QLabel *blockSizeLabel = new QLabel("", this);
-	QPixmap *blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
+	auto* blockSizeLabel = new QLabel("", this);
+	auto* blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
 	blockSizeIcon->setDevicePixelRatio(devicePixelRatio());
 	blockSizeLabel->setPixmap(blockSizeIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(blockSizeLabel, 0, 4, 2, 1, Qt::AlignRight);
 
-	ComboBox *blockSizeCombo = new ComboBox(this, tr("FFT block size"));
+	auto* blockSizeCombo = new ComboBox(this, tr("FFT block size"));
 	blockSizeCombo->setToolTip(tr("FFT block size"));
 	blockSizeCombo->setMinimumSize(100, 22);
 	blockSizeCombo->setMaximumSize(200, 22);
@@ -197,13 +205,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_blockSizeModel, &ComboBoxModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// FFT: window type: icon and selector
-	QLabel *windowLabel = new QLabel("", this);
-	QPixmap *windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
+	auto* windowLabel = new QLabel("", this);
+	auto* windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
 	windowIcon->setDevicePixelRatio(devicePixelRatio());
 	windowLabel->setPixmap(windowIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(windowLabel, 2, 4, 2, 1, Qt::AlignRight);
 
-	ComboBox *windowCombo = new ComboBox(this, tr("FFT window type"));
+	auto* windowCombo = new ComboBox(this, tr("FFT window type"));
 	windowCombo->setToolTip(tr("FFT window type"));
 	windowCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	windowCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -218,8 +226,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced configuration
-	QWidget *advanced_widget = new QWidget;
-	QGridLayout *advanced_layout = new QGridLayout;
+	auto* advanced_widget = new QWidget;
+	auto* advanced_layout = new QGridLayout;
 	advanced_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	advanced_widget->setMaximumHeight(m_configHeight);
 	advanced_widget->setLayout(advanced_layout);
@@ -297,10 +305,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced settings button
-	PixmapButton *advancedButton = new PixmapButton(this, tr("Advanced settings"));
+	auto* advancedButton = new PixmapButton(this, tr("Advanced settings"));
 	advancedButton->setToolTip(tr("Access advanced settings"));
-	QPixmap *advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on")
+											 .scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto* advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off")
+											  .scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	advancedOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedButton->setActiveGraphic(*advancedOnPixmap);

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -52,15 +52,15 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	m_processor(processor)
 {
 	// Top level placement of sections is handled by QSplitter widget.
-	QHBoxLayout *master_layout = new QHBoxLayout;
-	QSplitter *display_splitter = new QSplitter(Qt::Vertical);
+	auto master_layout = new QHBoxLayout;
+	auto display_splitter = new QSplitter(Qt::Vertical);
 	master_layout->addWidget(display_splitter);
 	master_layout->setContentsMargins(2, 6, 2, 8);
 	setLayout(master_layout);
 
 	// Display splitter top: controls section
-	QWidget *controls_widget = new QWidget;
-	QHBoxLayout *controls_layout = new QHBoxLayout;
+	auto controls_widget = new QWidget;
+	auto controls_layout = new QHBoxLayout;
 	controls_layout->setContentsMargins(0, 0, 0, 0);
 	controls_widget->setLayout(controls_layout);
 	controls_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
@@ -69,8 +69,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Basic configuration
-	QWidget *config_widget = new QWidget;
-	QGridLayout *config_layout = new QGridLayout;
+	auto config_widget = new QWidget;
+	auto config_layout = new QGridLayout;
 	config_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	config_widget->setMaximumHeight(m_configHeight);
 	config_widget->setLayout(config_layout);
@@ -87,10 +87,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// pause and freeze buttons
-	PixmapButton *pauseButton = new PixmapButton(this, tr("Pause"));
+	auto pauseButton = new PixmapButton(this, tr("Pause"));
 	pauseButton->setToolTip(tr("Pause data acquisition"));
-	QPixmap *pauseOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *pauseOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto pauseOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("play").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto pauseOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("pause").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	pauseOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	pauseButton->setActiveGraphic(*pauseOnPixmap);
@@ -99,10 +101,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	pauseButton->setModel(&controls->m_pauseModel);
 	config_layout->addWidget(pauseButton, 0, 0, 2, 1, Qt::AlignHCenter);
 
-	PixmapButton *refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
+	auto refFreezeButton = new PixmapButton(this, tr("Reference freeze"));
 	refFreezeButton->setToolTip(tr("Freeze current input as a reference / disable falloff in peak-hold mode."));
-	QPixmap *freezeOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *freezeOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto freezeOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("freeze").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto freezeOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("freeze_off").scaled(buttonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	freezeOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	freezeOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	refFreezeButton->setActiveGraphic(*freezeOnPixmap);
@@ -112,28 +116,28 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(refFreezeButton, 2, 0, 2, 1, Qt::AlignHCenter);
 
 	// misc configuration switches
-	LedCheckBox *waterfallButton = new LedCheckBox(tr("Waterfall"), this);
+	auto waterfallButton = new LedCheckBox(tr("Waterfall"), this);
 	waterfallButton->setToolTip(tr("Display real-time spectrogram"));
 	waterfallButton->setCheckable(true);
 	waterfallButton->setMinimumSize(70, 12);
 	waterfallButton->setModel(&controls->m_waterfallModel);
 	config_layout->addWidget(waterfallButton, 0, 1);
 
-	LedCheckBox *smoothButton = new LedCheckBox(tr("Averaging"), this);
+	auto smoothButton = new LedCheckBox(tr("Averaging"), this);
 	smoothButton->setToolTip(tr("Enable exponential moving average"));
 	smoothButton->setCheckable(true);
 	smoothButton->setMinimumSize(70, 12);
 	smoothButton->setModel(&controls->m_smoothModel);
 	config_layout->addWidget(smoothButton, 1, 1);
 
-	LedCheckBox *stereoButton = new LedCheckBox(tr("Stereo"), this);
+	auto stereoButton = new LedCheckBox(tr("Stereo"), this);
 	stereoButton->setToolTip(tr("Display stereo channels separately"));
 	stereoButton->setCheckable(true);
 	stereoButton->setMinimumSize(70, 12);
 	stereoButton->setModel(&controls->m_stereoModel);
 	config_layout->addWidget(stereoButton, 2, 1);
 
-	LedCheckBox *peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
+	auto peakHoldButton = new LedCheckBox(tr("Peak hold"), this);
 	peakHoldButton->setToolTip(tr("Display envelope of peak values"));
 	peakHoldButton->setCheckable(true);
 	peakHoldButton->setMinimumSize(70, 12);
@@ -141,10 +145,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(peakHoldButton, 3, 1);
 
 	// frequency: linear / log. switch and range selector
-	PixmapButton *logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
+	auto logXButton = new PixmapButton(this, tr("Logarithmic frequency"));
 	logXButton->setToolTip(tr("Switch between logarithmic and linear frequency scale"));
-	QPixmap *logXOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *logXOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto logXOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("x_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto logXOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("x_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logXOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logXButton->setActiveGraphic(*logXOnPixmap);
@@ -153,7 +159,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logXButton->setModel(&controls->m_logXModel);
 	config_layout->addWidget(logXButton, 0, 2, 2, 1, Qt::AlignRight);
 
-	ComboBox *freqRangeCombo = new ComboBox(this, tr("Frequency range"));
+	auto freqRangeCombo = new ComboBox(this, tr("Frequency range"));
 	freqRangeCombo->setToolTip(tr("Frequency range"));
 	freqRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	freqRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -161,10 +167,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(freqRangeCombo, 0, 3, 2, 1);
 
 	// amplitude: linear / log switch and range selector
-	PixmapButton *logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
+	auto logYButton = new PixmapButton(this, tr("Logarithmic amplitude"));
 	logYButton->setToolTip(tr("Switch between logarithmic and linear amplitude scale"));
-	QPixmap *logYOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *logYOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto logYOnPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("y_log").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto logYOffPixmap = new QPixmap(
+		PLUGIN_NAME::getIconPixmap("y_linear").scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	logYOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	logYButton->setActiveGraphic(*logYOnPixmap);
@@ -173,7 +181,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	logYButton->setModel(&controls->m_logYModel);
 	config_layout->addWidget(logYButton, 2, 2, 2, 1, Qt::AlignRight);
 
-	ComboBox *ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
+	auto ampRangeCombo = new ComboBox(this, tr("Amplitude range"));
 	ampRangeCombo->setToolTip(tr("Amplitude range"));
 	ampRangeCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	ampRangeCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -181,13 +189,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	config_layout->addWidget(ampRangeCombo, 2, 3, 2, 1);
 
 	// FFT: block size: icon and selector
-	QLabel *blockSizeLabel = new QLabel("", this);
-	QPixmap *blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
+	auto blockSizeLabel = new QLabel("", this);
+	auto blockSizeIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("block_size"));
 	blockSizeIcon->setDevicePixelRatio(devicePixelRatio());
 	blockSizeLabel->setPixmap(blockSizeIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(blockSizeLabel, 0, 4, 2, 1, Qt::AlignRight);
 
-	ComboBox *blockSizeCombo = new ComboBox(this, tr("FFT block size"));
+	auto blockSizeCombo = new ComboBox(this, tr("FFT block size"));
 	blockSizeCombo->setToolTip(tr("FFT block size"));
 	blockSizeCombo->setMinimumSize(100, 22);
 	blockSizeCombo->setMaximumSize(200, 22);
@@ -197,13 +205,13 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_blockSizeModel, &ComboBoxModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// FFT: window type: icon and selector
-	QLabel *windowLabel = new QLabel("", this);
-	QPixmap *windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
+	auto windowLabel = new QLabel("", this);
+	auto windowIcon = new QPixmap(PLUGIN_NAME::getIconPixmap("window"));
 	windowIcon->setDevicePixelRatio(devicePixelRatio());
 	windowLabel->setPixmap(windowIcon->scaled(iconSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	config_layout->addWidget(windowLabel, 2, 4, 2, 1, Qt::AlignRight);
 
-	ComboBox *windowCombo = new ComboBox(this, tr("FFT window type"));
+	auto windowCombo = new ComboBox(this, tr("FFT window type"));
 	windowCombo->setToolTip(tr("FFT window type"));
 	windowCombo->setMinimumSize(100, ComboBox::DEFAULT_HEIGHT);
 	windowCombo->setMaximumSize(200, ComboBox::DEFAULT_HEIGHT);
@@ -218,8 +226,8 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced configuration
-	QWidget *advanced_widget = new QWidget;
-	QGridLayout *advanced_layout = new QGridLayout;
+	auto advanced_widget = new QWidget;
+	auto advanced_layout = new QGridLayout;
 	advanced_widget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 	advanced_widget->setMaximumHeight(m_configHeight);
 	advanced_widget->setLayout(advanced_layout);
@@ -228,7 +236,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	controls_layout->setStretchFactor(advanced_widget, 10);
 
 	// Peak envelope resolution
-	Knob *envelopeResolutionKnob = new Knob(knobSmall_17, this);
+	auto envelopeResolutionKnob = new Knob(knobSmall_17, this);
 	envelopeResolutionKnob->setModel(&controls->m_envelopeResolutionModel);
 	envelopeResolutionKnob->setLabel(tr("Envelope res."));
 	envelopeResolutionKnob->setToolTip(tr("Increase envelope resolution for better details, decrease for better GUI performance."));
@@ -236,7 +244,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(envelopeResolutionKnob, 0, 0, 1, 1, Qt::AlignCenter);
 
 	// Spectrum graph resolution
-	Knob *spectrumResolutionKnob = new Knob(knobSmall_17, this);
+	auto spectrumResolutionKnob = new Knob(knobSmall_17, this);
 	spectrumResolutionKnob->setModel(&controls->m_spectrumResolutionModel);
 	spectrumResolutionKnob->setLabel(tr("Spectrum res."));
 	spectrumResolutionKnob->setToolTip(tr("Increase spectrum resolution for better details, decrease for better GUI performance."));
@@ -244,7 +252,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(spectrumResolutionKnob, 1, 0, 1, 1, Qt::AlignCenter);
 
 	// Peak falloff speed
-	Knob *peakDecayFactorKnob = new Knob(knobSmall_17, this);
+	auto peakDecayFactorKnob = new Knob(knobSmall_17, this);
 	peakDecayFactorKnob->setModel(&controls->m_peakDecayFactorModel);
 	peakDecayFactorKnob->setLabel(tr("Falloff factor"));
 	peakDecayFactorKnob->setToolTip(tr("Decrease to make peaks fall faster."));
@@ -252,7 +260,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(peakDecayFactorKnob, 0, 1, 1, 1, Qt::AlignCenter);
 
 	// Averaging weight
-	Knob *averagingWeightKnob = new Knob(knobSmall_17, this);
+	auto averagingWeightKnob = new Knob(knobSmall_17, this);
 	averagingWeightKnob->setModel(&controls->m_averagingWeightModel);
 	averagingWeightKnob->setLabel(tr("Averaging weight"));
 	averagingWeightKnob->setToolTip(tr("Decrease to make averaging slower and smoother."));
@@ -260,7 +268,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(averagingWeightKnob, 1, 1, 1, 1, Qt::AlignCenter);
 
 	// Waterfall history size
-	Knob *waterfallHeightKnob = new Knob(knobSmall_17, this);
+	auto waterfallHeightKnob = new Knob(knobSmall_17, this);
 	waterfallHeightKnob->setModel(&controls->m_waterfallHeightModel);
 	waterfallHeightKnob->setLabel(tr("Waterfall height"));
 	waterfallHeightKnob->setToolTip(tr("Increase to get slower scrolling, decrease to see fast transitions better. Warning: medium CPU usage."));
@@ -270,7 +278,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_waterfallHeightModel, &FloatModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// Waterfall gamma correction
-	Knob *waterfallGammaKnob = new Knob(knobSmall_17, this);
+	auto waterfallGammaKnob = new Knob(knobSmall_17, this);
 	waterfallGammaKnob->setModel(&controls->m_waterfallGammaModel);
 	waterfallGammaKnob->setLabel(tr("Waterfall gamma"));
 	waterfallGammaKnob->setToolTip(tr("Decrease to see very weak signals, increase to get better contrast."));
@@ -278,7 +286,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(waterfallGammaKnob, 1, 2, 1, 1, Qt::AlignCenter);
 
 	// FFT window overlap
-	Knob *windowOverlapKnob = new Knob(knobSmall_17, this);
+	auto windowOverlapKnob = new Knob(knobSmall_17, this);
 	windowOverlapKnob->setModel(&controls->m_windowOverlapModel);
 	windowOverlapKnob->setLabel(tr("Window overlap"));
 	windowOverlapKnob->setToolTip(tr("Increase to prevent missing fast transitions arriving near FFT window edges. Warning: high CPU usage."));
@@ -286,7 +294,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	advanced_layout->addWidget(windowOverlapKnob, 0, 3, 1, 1, Qt::AlignCenter);
 
 	// FFT zero padding
-	Knob *zeroPaddingKnob = new Knob(knobSmall_17, this);
+	auto zeroPaddingKnob = new Knob(knobSmall_17, this);
 	zeroPaddingKnob->setModel(&controls->m_zeroPaddingModel);
 	zeroPaddingKnob->setLabel(tr("Zero padding"));
 	zeroPaddingKnob->setToolTip(tr("Increase to get smoother-looking spectrum. Warning: high CPU usage."));
@@ -297,10 +305,12 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 
 
 	// Advanced settings button
-	PixmapButton *advancedButton = new PixmapButton(this, tr("Advanced settings"));
+	auto advancedButton = new PixmapButton(this, tr("Advanced settings"));
 	advancedButton->setToolTip(tr("Access advanced settings"));
-	QPixmap *advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-	QPixmap *advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off").scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto advancedOnPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_on")
+											.scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+	auto advancedOffPixmap = new QPixmap(PLUGIN_NAME::getIconPixmap("advanced_off")
+											 .scaled(advButtonSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
 	advancedOnPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedOffPixmap->setDevicePixelRatio(devicePixelRatio());
 	advancedButton->setActiveGraphic(*advancedOnPixmap);

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -199,7 +199,7 @@ void SaProcessor::analyze(LocklessRingBuffer<sampleFrame> &ring_buffer)
 				if (m_waterfallActive && m_waterfallNotEmpty)
 				{
 					// move waterfall history one line down and clear the top line
-					QRgb *pixel = (QRgb *)m_history_work.data();
+					auto pixel = (QRgb*)m_history_work.data();
 					std::copy(pixel,
 							  pixel + waterfallWidth() * m_waterfallHeight - waterfallWidth(),
 							  pixel + waterfallWidth());

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
@@ -38,9 +38,9 @@ StereoEnhancerControlDialog::StereoEnhancerControlDialog(
 	StereoEnhancerControls * _controls ) :
 	EffectControlDialog( _controls )
 {
-	QHBoxLayout * l = new QHBoxLayout( this );
+	auto l = new QHBoxLayout(this);
 
-	Knob * widthKnob = new Knob( knobBright_26, this );
+	auto widthKnob = new Knob(knobBright_26, this);
 	widthKnob->setModel( &_controls->m_widthModel );
 	widthKnob->setLabel( tr( "WIDTH" ) );
 	widthKnob->setHintText( tr( "Width:" ) , " samples" );

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
@@ -38,7 +38,7 @@ StereoEnhancerControlDialog::StereoEnhancerControlDialog(
 	StereoEnhancerControls * _controls ) :
 	EffectControlDialog( _controls )
 {
-	QHBoxLayout * l = new QHBoxLayout( this );
+	auto* l = new QHBoxLayout(this);
 
 	Knob * widthKnob = new Knob( knobBright_26, this );
 	widthKnob->setModel( &_controls->m_widthModel );

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
@@ -38,7 +38,7 @@ StereoEnhancerControlDialog::StereoEnhancerControlDialog(
 	StereoEnhancerControls * _controls ) :
 	EffectControlDialog( _controls )
 {
-	auto* l = new QHBoxLayout(this);
+	QHBoxLayout * l = new QHBoxLayout( this );
 
 	Knob * widthKnob = new Knob( knobBright_26, this );
 	widthKnob->setModel( &_controls->m_widthModel );

--- a/plugins/StereoMatrix/StereoMatrixControlDialog.cpp
+++ b/plugins/StereoMatrix/StereoMatrixControlDialog.cpp
@@ -48,23 +48,22 @@ StereoMatrixControlDialog::StereoMatrixControlDialog(
 				PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
 
-
-	Knob * llKnob = new Knob( knobBright_26, this );
+	auto llKnob = new Knob(knobBright_26, this);
 	llKnob->setModel( &_controls->m_llModel );
 	llKnob->setHintText( tr( "Left to Left Vol:" ) , "" );
 	llKnob->move( 10, 79 );
 
-	Knob * lrKnob = new Knob( knobBright_26, this );
+	auto lrKnob = new Knob(knobBright_26, this);
 	lrKnob->setModel( &_controls->m_lrModel );
 	lrKnob->setHintText( tr( "Left to Right Vol:" ) , "" );
 	lrKnob->move( 48, 79 );
 
-	Knob * rlKnob = new Knob( knobBright_26, this );
+	auto rlKnob = new Knob(knobBright_26, this);
 	rlKnob->setModel( &_controls->m_rlModel );
 	rlKnob->setHintText( tr( "Right to Left Vol:" ) , "" );
 	rlKnob->move( 85, 79 );
 
-	Knob * rrKnob = new Knob( knobBright_26, this );
+	auto rrKnob = new Knob(knobBright_26, this);
 	rrKnob->setModel( &_controls->m_rrModel );
 	rrKnob->setHintText( tr( "Right to Right Vol:" ) , "" );
 	rrKnob->move( 123, 79 );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -342,7 +342,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	MalletsSynth * ps = static_cast<MalletsSynth *>( _n->m_pluginData );
+	auto ps = static_cast<MalletsSynth*>(_n->m_pluginData);
 	ps->setFrequency( freq );
 	p = ps->presetIndex();
 
@@ -442,7 +442,7 @@ void MalletsInstrumentView::setWidgetBackground( QWidget * _widget, const QStrin
 
 QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 {
-	QWidget * widget = new QWidget( _parent );
+	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 		
 	m_hardnessKnob = new Knob( knobVintage_32, widget );
@@ -478,7 +478,7 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 
 QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 {
-	QWidget * widget = new QWidget( _parent );
+	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
 	m_modulatorKnob = new Knob( knobVintage_32, widget );
@@ -515,7 +515,7 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 {
 	// BandedWG
-	QWidget * widget = new QWidget( _parent );
+	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
 /*	m_strikeLED = new LedCheckBox( tr( "Bowed" ), widget );
@@ -549,7 +549,7 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 
 void MalletsInstrumentView::modelChanged()
 {
-	MalletsInstrument * inst = castModel<MalletsInstrument>();
+	auto inst = castModel<MalletsInstrument>();
 	m_hardnessKnob->setModel( &inst->m_hardnessModel );
 	m_positionKnob->setModel( &inst->m_positionModel );
 	m_vibratoGainKnob->setModel( &inst->m_vibratoGainModel );
@@ -574,7 +574,7 @@ void MalletsInstrumentView::modelChanged()
 
 void MalletsInstrumentView::changePreset()
 {
-	MalletsInstrument * inst = castModel<MalletsInstrument>();
+	auto inst = castModel<MalletsInstrument>();
 	int _preset = inst->m_presetsModel.value();
 
 	if( _preset < 9 )

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -342,7 +342,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	auto* ps = static_cast<MalletsSynth*>(_n->m_pluginData);
+	MalletsSynth * ps = static_cast<MalletsSynth *>( _n->m_pluginData );
 	ps->setFrequency( freq );
 	p = ps->presetIndex();
 
@@ -442,7 +442,7 @@ void MalletsInstrumentView::setWidgetBackground( QWidget * _widget, const QStrin
 
 QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 {
-	auto* widget = new QWidget(_parent);
+	QWidget * widget = new QWidget( _parent );
 	widget->setFixedSize( 250, 250 );
 		
 	m_hardnessKnob = new Knob( knobVintage_32, widget );
@@ -478,7 +478,7 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 
 QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 {
-	auto* widget = new QWidget(_parent);
+	QWidget * widget = new QWidget( _parent );
 	widget->setFixedSize( 250, 250 );
 	
 	m_modulatorKnob = new Knob( knobVintage_32, widget );
@@ -515,7 +515,7 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 {
 	// BandedWG
-	auto* widget = new QWidget(_parent);
+	QWidget * widget = new QWidget( _parent );
 	widget->setFixedSize( 250, 250 );
 	
 /*	m_strikeLED = new LedCheckBox( tr( "Bowed" ), widget );
@@ -549,7 +549,7 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 
 void MalletsInstrumentView::modelChanged()
 {
-	auto* inst = castModel<MalletsInstrument>();
+	MalletsInstrument * inst = castModel<MalletsInstrument>();
 	m_hardnessKnob->setModel( &inst->m_hardnessModel );
 	m_positionKnob->setModel( &inst->m_positionModel );
 	m_vibratoGainKnob->setModel( &inst->m_vibratoGainModel );
@@ -574,7 +574,7 @@ void MalletsInstrumentView::modelChanged()
 
 void MalletsInstrumentView::changePreset()
 {
-	auto* inst = castModel<MalletsInstrument>();
+	MalletsInstrument * inst = castModel<MalletsInstrument>();
 	int _preset = inst->m_presetsModel.value();
 
 	if( _preset < 9 )

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -342,7 +342,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
 
-	MalletsSynth * ps = static_cast<MalletsSynth *>( _n->m_pluginData );
+	auto* ps = static_cast<MalletsSynth*>(_n->m_pluginData);
 	ps->setFrequency( freq );
 	p = ps->presetIndex();
 
@@ -442,7 +442,7 @@ void MalletsInstrumentView::setWidgetBackground( QWidget * _widget, const QStrin
 
 QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 {
-	QWidget * widget = new QWidget( _parent );
+	auto* widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 		
 	m_hardnessKnob = new Knob( knobVintage_32, widget );
@@ -478,7 +478,7 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 
 QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 {
-	QWidget * widget = new QWidget( _parent );
+	auto* widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
 	m_modulatorKnob = new Knob( knobVintage_32, widget );
@@ -515,7 +515,7 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 {
 	// BandedWG
-	QWidget * widget = new QWidget( _parent );
+	auto* widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
 /*	m_strikeLED = new LedCheckBox( tr( "Bowed" ), widget );
@@ -549,7 +549,7 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 
 void MalletsInstrumentView::modelChanged()
 {
-	MalletsInstrument * inst = castModel<MalletsInstrument>();
+	auto* inst = castModel<MalletsInstrument>();
 	m_hardnessKnob->setModel( &inst->m_hardnessModel );
 	m_positionKnob->setModel( &inst->m_positionModel );
 	m_vibratoGainKnob->setModel( &inst->m_vibratoGainModel );
@@ -574,7 +574,7 @@ void MalletsInstrumentView::modelChanged()
 
 void MalletsInstrumentView::changePreset()
 {
-	MalletsInstrument * inst = castModel<MalletsInstrument>();
+	auto* inst = castModel<MalletsInstrument>();
 	int _preset = inst->m_presetsModel.value();
 
 	if( _preset < 9 )

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -452,7 +452,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	const int osc_h = 52;
 
 	// TODO: clean rewrite using layouts and all that...
-	PixmapButton * pm_osc1_btn = new PixmapButton( this, nullptr );
+	auto pm_osc1_btn = new PixmapButton(this, nullptr);
 	pm_osc1_btn->move( mod_x, mod1_y );
 	pm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -460,7 +460,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc1_btn->setToolTip(tr("Modulate phase of oscillator 1 by oscillator 2"));
 
-	PixmapButton * am_osc1_btn = new PixmapButton( this, nullptr );
+	auto am_osc1_btn = new PixmapButton(this, nullptr);
 	am_osc1_btn->move( mod_x + 35, mod1_y );
 	am_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -468,7 +468,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc1_btn->setToolTip(tr("Modulate amplitude of oscillator 1 by oscillator 2"));
 
-	PixmapButton * mix_osc1_btn = new PixmapButton( this, nullptr );
+	auto mix_osc1_btn = new PixmapButton(this, nullptr);
 	mix_osc1_btn->move( mod_x + 70, mod1_y );
 	mix_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -476,7 +476,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc1_btn->setToolTip(tr("Mix output of oscillators 1 & 2"));
 
-	PixmapButton * sync_osc1_btn = new PixmapButton( this, nullptr );
+	auto sync_osc1_btn = new PixmapButton(this, nullptr);
 	sync_osc1_btn->move( mod_x + 105, mod1_y );
 	sync_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -485,7 +485,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	sync_osc1_btn->setToolTip(tr("Synchronize oscillator 1 with "
 							"oscillator 2" ) );
 
-	PixmapButton * fm_osc1_btn = new PixmapButton( this, nullptr );
+	auto fm_osc1_btn = new PixmapButton(this, nullptr);
 	fm_osc1_btn->move( mod_x + 140, mod1_y );
 	fm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -500,9 +500,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	m_mod1BtnGrp->addButton( sync_osc1_btn );
 	m_mod1BtnGrp->addButton( fm_osc1_btn );
 
-
-
-	PixmapButton * pm_osc2_btn = new PixmapButton( this, nullptr );
+	auto pm_osc2_btn = new PixmapButton(this, nullptr);
 	pm_osc2_btn->move( mod_x, mod2_y );
 	pm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -510,7 +508,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc2_btn->setToolTip(tr("Modulate phase of oscillator 2 by oscillator 3"));
 
-	PixmapButton * am_osc2_btn = new PixmapButton( this, nullptr );
+	auto am_osc2_btn = new PixmapButton(this, nullptr);
 	am_osc2_btn->move( mod_x + 35, mod2_y );
 	am_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -518,7 +516,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc2_btn->setToolTip(tr("Modulate amplitude of oscillator 2 by oscillator 3"));
 
-	PixmapButton * mix_osc2_btn = new PixmapButton( this, nullptr );
+	auto mix_osc2_btn = new PixmapButton(this, nullptr);
 	mix_osc2_btn->move( mod_x + 70, mod2_y );
 	mix_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -526,7 +524,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc2_btn->setToolTip(tr("Mix output of oscillators 2 & 3"));
 
-	PixmapButton * sync_osc2_btn = new PixmapButton( this, nullptr );
+	auto sync_osc2_btn = new PixmapButton(this, nullptr);
 	sync_osc2_btn->move( mod_x + 105, mod2_y );
 	sync_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -534,7 +532,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"sync_inactive" ) );
 	sync_osc2_btn->setToolTip(tr("Synchronize oscillator 2 with oscillator 3"));
 
-	PixmapButton * fm_osc2_btn = new PixmapButton( this, nullptr );
+	auto fm_osc2_btn = new PixmapButton(this, nullptr);
 	fm_osc2_btn->move( mod_x + 140, mod2_y );
 	fm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -556,7 +554,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		int knob_y = osc_y + i * osc_h;
 
 		// setup volume-knob
-		Knob * vk = new Knob( knobStyled, this );
+		auto vk = new Knob(knobStyled, this);
 		vk->setVolumeKnob( true );
 		vk->setFixedSize( 28, 35 );
 		vk->move( 6, knob_y );
@@ -604,7 +602,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 		int btn_y = 96 + i * osc_h;
 
-		PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
+		auto sin_wave_btn = new PixmapButton(this, nullptr);
 		sin_wave_btn->move( 128, btn_y );
 		sin_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sin_shape_active" ) );
@@ -613,8 +611,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sin_wave_btn->setToolTip(
 				tr( "Sine wave" ) );
 
-		PixmapButton * triangle_wave_btn =
-						new PixmapButton( this, nullptr );
+		auto triangle_wave_btn = new PixmapButton(this, nullptr);
 		triangle_wave_btn->move( 143, btn_y );
 		triangle_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "triangle_shape_active" ) );
@@ -623,7 +620,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		triangle_wave_btn->setToolTip(
 				tr( "Triangle wave") );
 
-		PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
+		auto saw_wave_btn = new PixmapButton(this, nullptr);
 		saw_wave_btn->move( 158, btn_y );
 		saw_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"saw_shape_active" ) );
@@ -632,7 +629,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		saw_wave_btn->setToolTip(
 				tr( "Saw wave" ) );
 
-		PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
+		auto sqr_wave_btn = new PixmapButton(this, nullptr);
 		sqr_wave_btn->move( 173, btn_y );
 		sqr_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 						"square_shape_active" ) );
@@ -641,8 +638,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sqr_wave_btn->setToolTip(
 				tr( "Square wave" ) );
 
-		PixmapButton * moog_saw_wave_btn =
-						new PixmapButton( this, nullptr );
+		auto moog_saw_wave_btn = new PixmapButton(this, nullptr);
 		moog_saw_wave_btn->move( 188, btn_y );
 		moog_saw_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "moog_saw_shape_active" ) );
@@ -651,7 +647,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		moog_saw_wave_btn->setToolTip(
 				tr( "Moog-like saw wave" ) );
 
-		PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
+		auto exp_wave_btn = new PixmapButton(this, nullptr);
 		exp_wave_btn->move( 203, btn_y );
 		exp_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"exp_shape_active" ) );
@@ -660,7 +656,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		exp_wave_btn->setToolTip(
 				tr( "Exponential wave" ) );
 
-		PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
+		auto white_noise_btn = new PixmapButton(this, nullptr);
 		white_noise_btn->move( 218, btn_y );
 		white_noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "white_noise_shape_active" ) );
@@ -669,7 +665,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		white_noise_btn->setToolTip(
 				tr( "White noise" ) );
 
-		PixmapButton * uwb = new PixmapButton( this, nullptr );
+		auto uwb = new PixmapButton(this, nullptr);
 		uwb->move( 233, btn_y );
 		uwb->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"usr_shape_active" ) );
@@ -677,7 +673,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"usr_shape_inactive" ) );
 		uwb->setToolTip(tr("User-defined wave"));
 
-		PixmapButton * uwt = new PixmapButton( this, nullptr );
+		auto uwt = new PixmapButton(this, nullptr);
 		uwt->move( 110, btn_y );
 		uwt->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"wavetable_active" ) );
@@ -686,8 +682,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		uwt->setCheckable(true);
 		uwt->setToolTip(tr("Use alias-free wavetable oscillators."));
 
-		automatableButtonGroup * wsbg =
-			new automatableButtonGroup( this );
+		auto wsbg = new automatableButtonGroup(this);
 
 		wsbg->addButton( sin_wave_btn );
 		wsbg->addButton( triangle_wave_btn );
@@ -709,7 +704,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 void TripleOscillatorView::modelChanged()
 {
-	TripleOscillator * t = castModel<TripleOscillator>();
+	auto t = castModel<TripleOscillator>();
 	m_mod1BtnGrp->setModel( &t->m_osc[0]->m_modulationAlgoModel );
 	m_mod2BtnGrp->setModel( &t->m_osc[1]->m_modulationAlgoModel );
 

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -452,7 +452,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	const int osc_h = 52;
 
 	// TODO: clean rewrite using layouts and all that...
-	auto* pm_osc1_btn = new PixmapButton(this, nullptr);
+	PixmapButton * pm_osc1_btn = new PixmapButton( this, nullptr );
 	pm_osc1_btn->move( mod_x, mod1_y );
 	pm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -460,7 +460,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc1_btn->setToolTip(tr("Modulate phase of oscillator 1 by oscillator 2"));
 
-	auto* am_osc1_btn = new PixmapButton(this, nullptr);
+	PixmapButton * am_osc1_btn = new PixmapButton( this, nullptr );
 	am_osc1_btn->move( mod_x + 35, mod1_y );
 	am_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -468,7 +468,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc1_btn->setToolTip(tr("Modulate amplitude of oscillator 1 by oscillator 2"));
 
-	auto* mix_osc1_btn = new PixmapButton(this, nullptr);
+	PixmapButton * mix_osc1_btn = new PixmapButton( this, nullptr );
 	mix_osc1_btn->move( mod_x + 70, mod1_y );
 	mix_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -476,7 +476,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc1_btn->setToolTip(tr("Mix output of oscillators 1 & 2"));
 
-	auto* sync_osc1_btn = new PixmapButton(this, nullptr);
+	PixmapButton * sync_osc1_btn = new PixmapButton( this, nullptr );
 	sync_osc1_btn->move( mod_x + 105, mod1_y );
 	sync_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -485,7 +485,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	sync_osc1_btn->setToolTip(tr("Synchronize oscillator 1 with "
 							"oscillator 2" ) );
 
-	auto* fm_osc1_btn = new PixmapButton(this, nullptr);
+	PixmapButton * fm_osc1_btn = new PixmapButton( this, nullptr );
 	fm_osc1_btn->move( mod_x + 140, mod1_y );
 	fm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -500,7 +500,9 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	m_mod1BtnGrp->addButton( sync_osc1_btn );
 	m_mod1BtnGrp->addButton( fm_osc1_btn );
 
-	auto* pm_osc2_btn = new PixmapButton(this, nullptr);
+
+
+	PixmapButton * pm_osc2_btn = new PixmapButton( this, nullptr );
 	pm_osc2_btn->move( mod_x, mod2_y );
 	pm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -508,7 +510,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc2_btn->setToolTip(tr("Modulate phase of oscillator 2 by oscillator 3"));
 
-	auto* am_osc2_btn = new PixmapButton(this, nullptr);
+	PixmapButton * am_osc2_btn = new PixmapButton( this, nullptr );
 	am_osc2_btn->move( mod_x + 35, mod2_y );
 	am_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -516,7 +518,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc2_btn->setToolTip(tr("Modulate amplitude of oscillator 2 by oscillator 3"));
 
-	auto* mix_osc2_btn = new PixmapButton(this, nullptr);
+	PixmapButton * mix_osc2_btn = new PixmapButton( this, nullptr );
 	mix_osc2_btn->move( mod_x + 70, mod2_y );
 	mix_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -524,7 +526,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc2_btn->setToolTip(tr("Mix output of oscillators 2 & 3"));
 
-	auto* sync_osc2_btn = new PixmapButton(this, nullptr);
+	PixmapButton * sync_osc2_btn = new PixmapButton( this, nullptr );
 	sync_osc2_btn->move( mod_x + 105, mod2_y );
 	sync_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -532,7 +534,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"sync_inactive" ) );
 	sync_osc2_btn->setToolTip(tr("Synchronize oscillator 2 with oscillator 3"));
 
-	auto* fm_osc2_btn = new PixmapButton(this, nullptr);
+	PixmapButton * fm_osc2_btn = new PixmapButton( this, nullptr );
 	fm_osc2_btn->move( mod_x + 140, mod2_y );
 	fm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -602,7 +604,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 		int btn_y = 96 + i * osc_h;
 
-		auto* sin_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
 		sin_wave_btn->move( 128, btn_y );
 		sin_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sin_shape_active" ) );
@@ -611,7 +613,8 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sin_wave_btn->setToolTip(
 				tr( "Sine wave" ) );
 
-		auto* triangle_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * triangle_wave_btn =
+						new PixmapButton( this, nullptr );
 		triangle_wave_btn->move( 143, btn_y );
 		triangle_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "triangle_shape_active" ) );
@@ -620,7 +623,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		triangle_wave_btn->setToolTip(
 				tr( "Triangle wave") );
 
-		auto* saw_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
 		saw_wave_btn->move( 158, btn_y );
 		saw_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"saw_shape_active" ) );
@@ -629,7 +632,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		saw_wave_btn->setToolTip(
 				tr( "Saw wave" ) );
 
-		auto* sqr_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
 		sqr_wave_btn->move( 173, btn_y );
 		sqr_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 						"square_shape_active" ) );
@@ -638,7 +641,8 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sqr_wave_btn->setToolTip(
 				tr( "Square wave" ) );
 
-		auto* moog_saw_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * moog_saw_wave_btn =
+						new PixmapButton( this, nullptr );
 		moog_saw_wave_btn->move( 188, btn_y );
 		moog_saw_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "moog_saw_shape_active" ) );
@@ -647,7 +651,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		moog_saw_wave_btn->setToolTip(
 				tr( "Moog-like saw wave" ) );
 
-		auto* exp_wave_btn = new PixmapButton(this, nullptr);
+		PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
 		exp_wave_btn->move( 203, btn_y );
 		exp_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"exp_shape_active" ) );
@@ -656,7 +660,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		exp_wave_btn->setToolTip(
 				tr( "Exponential wave" ) );
 
-		auto* white_noise_btn = new PixmapButton(this, nullptr);
+		PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
 		white_noise_btn->move( 218, btn_y );
 		white_noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "white_noise_shape_active" ) );
@@ -665,7 +669,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		white_noise_btn->setToolTip(
 				tr( "White noise" ) );
 
-		auto* uwb = new PixmapButton(this, nullptr);
+		PixmapButton * uwb = new PixmapButton( this, nullptr );
 		uwb->move( 233, btn_y );
 		uwb->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"usr_shape_active" ) );
@@ -673,7 +677,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"usr_shape_inactive" ) );
 		uwb->setToolTip(tr("User-defined wave"));
 
-		auto* uwt = new PixmapButton(this, nullptr);
+		PixmapButton * uwt = new PixmapButton( this, nullptr );
 		uwt->move( 110, btn_y );
 		uwt->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"wavetable_active" ) );
@@ -682,7 +686,8 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		uwt->setCheckable(true);
 		uwt->setToolTip(tr("Use alias-free wavetable oscillators."));
 
-		auto* wsbg = new automatableButtonGroup(this);
+		automatableButtonGroup * wsbg =
+			new automatableButtonGroup( this );
 
 		wsbg->addButton( sin_wave_btn );
 		wsbg->addButton( triangle_wave_btn );
@@ -704,7 +709,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 void TripleOscillatorView::modelChanged()
 {
-	auto* t = castModel<TripleOscillator>();
+	TripleOscillator * t = castModel<TripleOscillator>();
 	m_mod1BtnGrp->setModel( &t->m_osc[0]->m_modulationAlgoModel );
 	m_mod2BtnGrp->setModel( &t->m_osc[1]->m_modulationAlgoModel );
 

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -452,7 +452,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	const int osc_h = 52;
 
 	// TODO: clean rewrite using layouts and all that...
-	PixmapButton * pm_osc1_btn = new PixmapButton( this, nullptr );
+	auto* pm_osc1_btn = new PixmapButton(this, nullptr);
 	pm_osc1_btn->move( mod_x, mod1_y );
 	pm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -460,7 +460,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc1_btn->setToolTip(tr("Modulate phase of oscillator 1 by oscillator 2"));
 
-	PixmapButton * am_osc1_btn = new PixmapButton( this, nullptr );
+	auto* am_osc1_btn = new PixmapButton(this, nullptr);
 	am_osc1_btn->move( mod_x + 35, mod1_y );
 	am_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -468,7 +468,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc1_btn->setToolTip(tr("Modulate amplitude of oscillator 1 by oscillator 2"));
 
-	PixmapButton * mix_osc1_btn = new PixmapButton( this, nullptr );
+	auto* mix_osc1_btn = new PixmapButton(this, nullptr);
 	mix_osc1_btn->move( mod_x + 70, mod1_y );
 	mix_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -476,7 +476,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc1_btn->setToolTip(tr("Mix output of oscillators 1 & 2"));
 
-	PixmapButton * sync_osc1_btn = new PixmapButton( this, nullptr );
+	auto* sync_osc1_btn = new PixmapButton(this, nullptr);
 	sync_osc1_btn->move( mod_x + 105, mod1_y );
 	sync_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -485,7 +485,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	sync_osc1_btn->setToolTip(tr("Synchronize oscillator 1 with "
 							"oscillator 2" ) );
 
-	PixmapButton * fm_osc1_btn = new PixmapButton( this, nullptr );
+	auto* fm_osc1_btn = new PixmapButton(this, nullptr);
 	fm_osc1_btn->move( mod_x + 140, mod1_y );
 	fm_osc1_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -500,9 +500,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 	m_mod1BtnGrp->addButton( sync_osc1_btn );
 	m_mod1BtnGrp->addButton( fm_osc1_btn );
 
-
-
-	PixmapButton * pm_osc2_btn = new PixmapButton( this, nullptr );
+	auto* pm_osc2_btn = new PixmapButton(this, nullptr);
 	pm_osc2_btn->move( mod_x, mod2_y );
 	pm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"pm_active" ) );
@@ -510,7 +508,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"pm_inactive" ) );
 	pm_osc2_btn->setToolTip(tr("Modulate phase of oscillator 2 by oscillator 3"));
 
-	PixmapButton * am_osc2_btn = new PixmapButton( this, nullptr );
+	auto* am_osc2_btn = new PixmapButton(this, nullptr);
 	am_osc2_btn->move( mod_x + 35, mod2_y );
 	am_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"am_active" ) );
@@ -518,7 +516,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"am_inactive" ) );
 	am_osc2_btn->setToolTip(tr("Modulate amplitude of oscillator 2 by oscillator 3"));
 
-	PixmapButton * mix_osc2_btn = new PixmapButton( this, nullptr );
+	auto* mix_osc2_btn = new PixmapButton(this, nullptr);
 	mix_osc2_btn->move( mod_x + 70, mod2_y );
 	mix_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"mix_active" ) );
@@ -526,7 +524,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"mix_inactive" ) );
 	mix_osc2_btn->setToolTip(tr("Mix output of oscillators 2 & 3"));
 
-	PixmapButton * sync_osc2_btn = new PixmapButton( this, nullptr );
+	auto* sync_osc2_btn = new PixmapButton(this, nullptr);
 	sync_osc2_btn->move( mod_x + 105, mod2_y );
 	sync_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sync_active" ) );
@@ -534,7 +532,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"sync_inactive" ) );
 	sync_osc2_btn->setToolTip(tr("Synchronize oscillator 2 with oscillator 3"));
 
-	PixmapButton * fm_osc2_btn = new PixmapButton( this, nullptr );
+	auto* fm_osc2_btn = new PixmapButton(this, nullptr);
 	fm_osc2_btn->move( mod_x + 140, mod2_y );
 	fm_osc2_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 								"fm_active" ) );
@@ -604,7 +602,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 		int btn_y = 96 + i * osc_h;
 
-		PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
+		auto* sin_wave_btn = new PixmapButton(this, nullptr);
 		sin_wave_btn->move( 128, btn_y );
 		sin_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"sin_shape_active" ) );
@@ -613,8 +611,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sin_wave_btn->setToolTip(
 				tr( "Sine wave" ) );
 
-		PixmapButton * triangle_wave_btn =
-						new PixmapButton( this, nullptr );
+		auto* triangle_wave_btn = new PixmapButton(this, nullptr);
 		triangle_wave_btn->move( 143, btn_y );
 		triangle_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "triangle_shape_active" ) );
@@ -623,7 +620,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		triangle_wave_btn->setToolTip(
 				tr( "Triangle wave") );
 
-		PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
+		auto* saw_wave_btn = new PixmapButton(this, nullptr);
 		saw_wave_btn->move( 158, btn_y );
 		saw_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"saw_shape_active" ) );
@@ -632,7 +629,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		saw_wave_btn->setToolTip(
 				tr( "Saw wave" ) );
 
-		PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
+		auto* sqr_wave_btn = new PixmapButton(this, nullptr);
 		sqr_wave_btn->move( 173, btn_y );
 		sqr_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 						"square_shape_active" ) );
@@ -641,8 +638,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		sqr_wave_btn->setToolTip(
 				tr( "Square wave" ) );
 
-		PixmapButton * moog_saw_wave_btn =
-						new PixmapButton( this, nullptr );
+		auto* moog_saw_wave_btn = new PixmapButton(this, nullptr);
 		moog_saw_wave_btn->move( 188, btn_y );
 		moog_saw_wave_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "moog_saw_shape_active" ) );
@@ -651,7 +647,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		moog_saw_wave_btn->setToolTip(
 				tr( "Moog-like saw wave" ) );
 
-		PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
+		auto* exp_wave_btn = new PixmapButton(this, nullptr);
 		exp_wave_btn->move( 203, btn_y );
 		exp_wave_btn->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"exp_shape_active" ) );
@@ -660,7 +656,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		exp_wave_btn->setToolTip(
 				tr( "Exponential wave" ) );
 
-		PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
+		auto* white_noise_btn = new PixmapButton(this, nullptr);
 		white_noise_btn->move( 218, btn_y );
 		white_noise_btn->setActiveGraphic(
 			PLUGIN_NAME::getIconPixmap( "white_noise_shape_active" ) );
@@ -669,7 +665,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		white_noise_btn->setToolTip(
 				tr( "White noise" ) );
 
-		PixmapButton * uwb = new PixmapButton( this, nullptr );
+		auto* uwb = new PixmapButton(this, nullptr);
 		uwb->move( 233, btn_y );
 		uwb->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"usr_shape_active" ) );
@@ -677,7 +673,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 							"usr_shape_inactive" ) );
 		uwb->setToolTip(tr("User-defined wave"));
 
-		PixmapButton * uwt = new PixmapButton( this, nullptr );
+		auto* uwt = new PixmapButton(this, nullptr);
 		uwt->move( 110, btn_y );
 		uwt->setActiveGraphic( PLUGIN_NAME::getIconPixmap(
 							"wavetable_active" ) );
@@ -686,8 +682,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 		uwt->setCheckable(true);
 		uwt->setToolTip(tr("Use alias-free wavetable oscillators."));
 
-		automatableButtonGroup * wsbg =
-			new automatableButtonGroup( this );
+		auto* wsbg = new automatableButtonGroup(this);
 
 		wsbg->addButton( sin_wave_btn );
 		wsbg->addButton( triangle_wave_btn );
@@ -709,7 +704,7 @@ TripleOscillatorView::TripleOscillatorView( Instrument * _instrument,
 
 void TripleOscillatorView::modelChanged()
 {
-	TripleOscillator * t = castModel<TripleOscillator>();
+	auto* t = castModel<TripleOscillator>();
 	m_mod1BtnGrp->setModel( &t->m_osc[0]->m_modulationAlgoModel );
 	m_mod2BtnGrp->setModel( &t->m_osc[1]->m_modulationAlgoModel );
 

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -43,25 +43,25 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	EffectControlDialog(controls),
 	m_controls(controls)
 {
-	QVBoxLayout *master_layout = new QVBoxLayout;
+	auto master_layout = new QVBoxLayout;
 	master_layout->setContentsMargins(0, 2, 0, 0);
 	setLayout(master_layout);
 
 	// Visualizer widget
 	// The size of 768 pixels seems to offer a good balance of speed, accuracy and trace thickness.
-	VectorView *display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
+	auto display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
 	master_layout->addWidget(display);
 
 	// Config area located inside visualizer
-	QVBoxLayout *internal_layout = new QVBoxLayout(display);
-	QHBoxLayout *config_layout = new QHBoxLayout();
-	QVBoxLayout *switch_layout = new QVBoxLayout();
+	auto internal_layout = new QVBoxLayout(display);
+	auto config_layout = new QHBoxLayout();
+	auto switch_layout = new QVBoxLayout();
 	internal_layout->addStretch();
 	internal_layout->addLayout(config_layout);
 	config_layout->addLayout(switch_layout);
 
 	// High-quality switch
-	LedCheckBox *highQualityButton = new LedCheckBox(tr("HQ"), this);
+	auto highQualityButton = new LedCheckBox(tr("HQ"), this);
 	highQualityButton->setToolTip(tr("Double the resolution and simulate continuous analog-like trace."));
 	highQualityButton->setCheckable(true);
 	highQualityButton->setMinimumSize(70, 12);
@@ -69,7 +69,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	switch_layout->addWidget(highQualityButton);
 
 	// Log. scale switch
-	LedCheckBox *logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
+	auto logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
 	logarithmicButton->setToolTip(tr("Display amplitude on logarithmic scale to better see small values."));
 	logarithmicButton->setCheckable(true);
 	logarithmicButton->setMinimumSize(70, 12);
@@ -79,7 +79,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	config_layout->addStretch();
 
 	// Persistence knob
-	Knob *persistenceKnob = new Knob(knobSmall_17, this);
+	auto persistenceKnob = new Knob(knobSmall_17, this);
 	persistenceKnob->setModel(&controls->m_persistenceModel);
 	persistenceKnob->setLabel(tr("Persist."));
 	persistenceKnob->setToolTip(tr("Trace persistence: higher amount means the trace will stay bright for longer time."));

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -43,25 +43,25 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	EffectControlDialog(controls),
 	m_controls(controls)
 {
-	auto* master_layout = new QVBoxLayout;
+	QVBoxLayout *master_layout = new QVBoxLayout;
 	master_layout->setContentsMargins(0, 2, 0, 0);
 	setLayout(master_layout);
 
 	// Visualizer widget
 	// The size of 768 pixels seems to offer a good balance of speed, accuracy and trace thickness.
-	auto* display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
+	VectorView *display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
 	master_layout->addWidget(display);
 
 	// Config area located inside visualizer
-	auto* internal_layout = new QVBoxLayout(display);
-	auto* config_layout = new QHBoxLayout();
-	auto* switch_layout = new QVBoxLayout();
+	QVBoxLayout *internal_layout = new QVBoxLayout(display);
+	QHBoxLayout *config_layout = new QHBoxLayout();
+	QVBoxLayout *switch_layout = new QVBoxLayout();
 	internal_layout->addStretch();
 	internal_layout->addLayout(config_layout);
 	config_layout->addLayout(switch_layout);
 
 	// High-quality switch
-	auto* highQualityButton = new LedCheckBox(tr("HQ"), this);
+	LedCheckBox *highQualityButton = new LedCheckBox(tr("HQ"), this);
 	highQualityButton->setToolTip(tr("Double the resolution and simulate continuous analog-like trace."));
 	highQualityButton->setCheckable(true);
 	highQualityButton->setMinimumSize(70, 12);
@@ -69,7 +69,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	switch_layout->addWidget(highQualityButton);
 
 	// Log. scale switch
-	auto* logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
+	LedCheckBox *logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
 	logarithmicButton->setToolTip(tr("Display amplitude on logarithmic scale to better see small values."));
 	logarithmicButton->setCheckable(true);
 	logarithmicButton->setMinimumSize(70, 12);

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -43,25 +43,25 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	EffectControlDialog(controls),
 	m_controls(controls)
 {
-	QVBoxLayout *master_layout = new QVBoxLayout;
+	auto* master_layout = new QVBoxLayout;
 	master_layout->setContentsMargins(0, 2, 0, 0);
 	setLayout(master_layout);
 
 	// Visualizer widget
 	// The size of 768 pixels seems to offer a good balance of speed, accuracy and trace thickness.
-	VectorView *display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
+	auto* display = new VectorView(controls, m_controls->m_effect->getBuffer(), 768, this);
 	master_layout->addWidget(display);
 
 	// Config area located inside visualizer
-	QVBoxLayout *internal_layout = new QVBoxLayout(display);
-	QHBoxLayout *config_layout = new QHBoxLayout();
-	QVBoxLayout *switch_layout = new QVBoxLayout();
+	auto* internal_layout = new QVBoxLayout(display);
+	auto* config_layout = new QHBoxLayout();
+	auto* switch_layout = new QVBoxLayout();
 	internal_layout->addStretch();
 	internal_layout->addLayout(config_layout);
 	config_layout->addLayout(switch_layout);
 
 	// High-quality switch
-	LedCheckBox *highQualityButton = new LedCheckBox(tr("HQ"), this);
+	auto* highQualityButton = new LedCheckBox(tr("HQ"), this);
 	highQualityButton->setToolTip(tr("Double the resolution and simulate continuous analog-like trace."));
 	highQualityButton->setCheckable(true);
 	highQualityButton->setMinimumSize(70, 12);
@@ -69,7 +69,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	switch_layout->addWidget(highQualityButton);
 
 	// Log. scale switch
-	LedCheckBox *logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
+	auto* logarithmicButton = new LedCheckBox(tr("Log. scale"), this);
 	logarithmicButton->setToolTip(tr("Display amplitude on logarithmic scale to better see small values."));
 	logarithmicButton->setCheckable(true);
 	logarithmicButton->setMinimumSize(70, 12);

--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -307,7 +307,7 @@ void VectorView::periodicUpdate()
 // More of an Easter egg, to avoid cluttering the interface with non-essential functionality.
 void VectorView::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	auto* colorDialog = new ColorChooser(m_controls->m_colorFG, this);
+	ColorChooser *colorDialog = new ColorChooser(m_controls->m_colorFG, this);
 	if (colorDialog->exec())
 	{
 		m_controls->m_colorFG = colorDialog->currentColor();

--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -307,7 +307,7 @@ void VectorView::periodicUpdate()
 // More of an Easter egg, to avoid cluttering the interface with non-essential functionality.
 void VectorView::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	ColorChooser *colorDialog = new ColorChooser(m_controls->m_colorFG, this);
+	auto* colorDialog = new ColorChooser(m_controls->m_colorFG, this);
 	if (colorDialog->exec())
 	{
 		m_controls->m_colorFG = colorDialog->currentColor();

--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -307,7 +307,7 @@ void VectorView::periodicUpdate()
 // More of an Easter egg, to avoid cluttering the interface with non-essential functionality.
 void VectorView::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	ColorChooser *colorDialog = new ColorChooser(m_controls->m_colorFG, this);
+	auto colorDialog = new ColorChooser(m_controls->m_colorFG, this);
 	if (colorDialog->exec())
 	{
 		m_controls->m_colorFG = colorDialog->currentColor();

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -161,7 +161,7 @@ VestigeInstrument::VestigeInstrument( InstrumentTrack * _instrument_track ) :
 	p_subWindow( nullptr )
 {
 	// now we need a play-handle which cares for calling play()
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( ConfigManager::inst(), SIGNAL( valueChanged(QString,QString,QString) ),
@@ -588,7 +588,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_selPresetButton = new QPushButton( tr( "" ), this );
 	m_selPresetButton->setGeometry( 228, 201, 16, 16 );
 
-	QMenu *menu = new QMenu;
+	auto* menu = new QMenu;
 
 	connect( menu, SIGNAL( aboutToShow() ), this, SLOT( updateMenu() ) );
 
@@ -605,8 +605,9 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
-	QPushButton * note_off_all_btn = new QPushButton( tr( "Turn off all "
-							"notes" ), this );
+	auto* note_off_all_btn = new QPushButton(tr("Turn off all "
+												"notes"),
+		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
 	note_off_all_btn->setFont( pointSize<8>( note_off_all_btn->font() ) );
@@ -798,13 +799,14 @@ void VestigeInstrumentView::previousProgram()
 void VestigeInstrumentView::selPreset( void )
 {
 
-     QAction *action = qobject_cast<QAction *>(sender());
-     if (action)
-         if ( m_vi->m_plugin != nullptr ) {
-		lastPosInMenu = action->data().toInt();
-		m_vi->m_plugin->setProgram( action->data().toInt() );
-		QWidget::update();
-	 }
+	auto* action = qobject_cast<QAction*>(sender());
+	if (action)
+		if (m_vi->m_plugin != nullptr)
+		{
+			lastPosInMenu = action->data().toInt();
+			m_vi->m_plugin->setProgram(action->data().toInt());
+			QWidget::update();
+		}
 }
 
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -161,7 +161,7 @@ VestigeInstrument::VestigeInstrument( InstrumentTrack * _instrument_track ) :
 	p_subWindow( nullptr )
 {
 	// now we need a play-handle which cares for calling play()
-	auto* iph = new InstrumentPlayHandle(this, _instrument_track);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( ConfigManager::inst(), SIGNAL( valueChanged(QString,QString,QString) ),
@@ -588,7 +588,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_selPresetButton = new QPushButton( tr( "" ), this );
 	m_selPresetButton->setGeometry( 228, 201, 16, 16 );
 
-	auto* menu = new QMenu;
+	QMenu *menu = new QMenu;
 
 	connect( menu, SIGNAL( aboutToShow() ), this, SLOT( updateMenu() ) );
 
@@ -605,9 +605,8 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
-	auto* note_off_all_btn = new QPushButton(tr("Turn off all "
-												"notes"),
-		this);
+	QPushButton * note_off_all_btn = new QPushButton( tr( "Turn off all "
+							"notes" ), this );
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
 	note_off_all_btn->setFont( pointSize<8>( note_off_all_btn->font() ) );
@@ -799,14 +798,13 @@ void VestigeInstrumentView::previousProgram()
 void VestigeInstrumentView::selPreset( void )
 {
 
-	auto* action = qobject_cast<QAction*>(sender());
-	if (action)
-		if (m_vi->m_plugin != nullptr)
-		{
-			lastPosInMenu = action->data().toInt();
-			m_vi->m_plugin->setProgram(action->data().toInt());
-			QWidget::update();
-		}
+     QAction *action = qobject_cast<QAction *>(sender());
+     if (action)
+         if ( m_vi->m_plugin != nullptr ) {
+		lastPosInMenu = action->data().toInt();
+		m_vi->m_plugin->setProgram( action->data().toInt() );
+		QWidget::update();
+	 }
 }
 
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -161,7 +161,7 @@ VestigeInstrument::VestigeInstrument( InstrumentTrack * _instrument_track ) :
 	p_subWindow( nullptr )
 {
 	// now we need a play-handle which cares for calling play()
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrument_track );
+	auto iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( ConfigManager::inst(), SIGNAL( valueChanged(QString,QString,QString) ),
@@ -588,7 +588,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_selPresetButton = new QPushButton( tr( "" ), this );
 	m_selPresetButton->setGeometry( 228, 201, 16, 16 );
 
-	QMenu *menu = new QMenu;
+	auto menu = new QMenu;
 
 	connect( menu, SIGNAL( aboutToShow() ), this, SLOT( updateMenu() ) );
 
@@ -605,8 +605,9 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
-	QPushButton * note_off_all_btn = new QPushButton( tr( "Turn off all "
-							"notes" ), this );
+	auto note_off_all_btn = new QPushButton(tr("Turn off all "
+											   "notes"),
+		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
 	note_off_all_btn->setFont( pointSize<8>( note_off_all_btn->font() ) );
@@ -797,14 +798,13 @@ void VestigeInstrumentView::previousProgram()
 
 void VestigeInstrumentView::selPreset( void )
 {
-
-     QAction *action = qobject_cast<QAction *>(sender());
-     if (action)
-         if ( m_vi->m_plugin != nullptr ) {
+	auto action = qobject_cast<QAction*>(sender());
+	if (action && m_vi->m_plugin != nullptr)
+	{
 		lastPosInMenu = action->data().toInt();
-		m_vi->m_plugin->setProgram( action->data().toInt() );
+		m_vi->m_plugin->setProgram(action->data().toInt());
 		QWidget::update();
-	 }
+	}
 }
 
 

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -301,8 +301,7 @@ void Vibed::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
-	StringContainer * ps = static_cast<StringContainer *>(
-							_n->m_pluginData );
+	auto* ps = static_cast<StringContainer*>(_n->m_pluginData);
 
 	for( fpp_t i = offset; i < frames + offset; ++i )
 	{
@@ -583,8 +582,8 @@ void VibedView::modelChanged()
 
 void VibedView::showString( int _string )
 {
-	Vibed * v = castModel<Vibed>();
-	
+	auto* v = castModel<Vibed>();
+
 	m_pickKnob->setModel( v->m_pickKnobs[_string] );
 	m_pickupKnob->setModel( v->m_pickupKnobs[_string] );
 	m_stiffnessKnob->setModel( v->m_stiffnessKnobs[_string] );

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -301,8 +301,7 @@ void Vibed::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
-	StringContainer * ps = static_cast<StringContainer *>(
-							_n->m_pluginData );
+	auto ps = static_cast<StringContainer*>(_n->m_pluginData);
 
 	for( fpp_t i = offset; i < frames + offset; ++i )
 	{
@@ -583,8 +582,8 @@ void VibedView::modelChanged()
 
 void VibedView::showString( int _string )
 {
-	Vibed * v = castModel<Vibed>();
-	
+	auto v = castModel<Vibed>();
+
 	m_pickKnob->setModel( v->m_pickKnobs[_string] );
 	m_pickupKnob->setModel( v->m_pickupKnobs[_string] );
 	m_stiffnessKnob->setModel( v->m_stiffnessKnobs[_string] );

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -301,7 +301,8 @@ void Vibed::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
-	auto* ps = static_cast<StringContainer*>(_n->m_pluginData);
+	StringContainer * ps = static_cast<StringContainer *>(
+							_n->m_pluginData );
 
 	for( fpp_t i = offset; i < frames + offset; ++i )
 	{
@@ -582,8 +583,8 @@ void VibedView::modelChanged()
 
 void VibedView::showString( int _string )
 {
-	auto* v = castModel<Vibed>();
-
+	Vibed * v = castModel<Vibed>();
+	
 	m_pickKnob->setModel( v->m_pickKnobs[_string] );
 	m_pickupKnob->setModel( v->m_pickupKnobs[_string] );
 	m_stiffnessKnob->setModel( v->m_stiffnessKnobs[_string] );

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -95,7 +95,7 @@ VibratingString::VibratingString(	float _pitch,
 VibratingString::delayLine * VibratingString::initDelayLine( int _len,
 								int _pick )
 {
-	delayLine * dl = new VibratingString::delayLine[_len];
+	auto dl = new VibratingString::delayLine[_len];
 	dl->length = _len;
 	if( _len > 0 )
 	{

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -95,7 +95,7 @@ VibratingString::VibratingString(	float _pitch,
 VibratingString::delayLine * VibratingString::initDelayLine( int _len,
 								int _pick )
 {
-	delayLine * dl = new VibratingString::delayLine[_len];
+	auto* dl = new VibratingString::delayLine[_len];
 	dl->length = _len;
 	if( _len > 0 )
 	{

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -95,7 +95,7 @@ VibratingString::VibratingString(	float _pitch,
 VibratingString::delayLine * VibratingString::initDelayLine( int _len,
 								int _pick )
 {
-	auto* dl = new VibratingString::delayLine[_len];
+	delayLine * dl = new VibratingString::delayLine[_len];
 	dl->length = _len;
 	if( _len > 0 )
 	{

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -1048,7 +1048,7 @@ void RemoteVstPlugin::process( const sampleFrame * _in, sampleFrame * _out )
 					return a.deltaFrames < b.deltaFrames;
 				} );
 
-		VstEvents* events = (VstEvents *) eventsBuffer;
+		auto events = (VstEvents*)eventsBuffer;
 		events->reserved = 0;
 		events->numEvents = m_midiEvents.size();
 
@@ -1425,7 +1425,7 @@ struct sBank
 void RemoteVstPlugin::savePreset( const std::string & _file )
 {
 	unsigned int chunk_size = 0;
-	sBank * pBank = ( sBank* ) new char[ sizeof( sBank ) ];
+	auto pBank = (sBank*)new char[sizeof(sBank)];
 	char progName[ 128 ] = { 0 };
 	char* data = nullptr;
 	const bool chunky = ( m_plugin->flags & ( 1 << 5 ) ) != 0;
@@ -1444,11 +1444,11 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 		if (isPreset) {
 			chunk_size = m_plugin->numParams * sizeof( float );
 			data = new char[ chunk_size ];
-			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( data );
+			auto toUIntArray = reinterpret_cast<unsigned int*>(data);
 			for ( int i = 0; i < m_plugin->numParams; i++ )
 			{
 				float value = m_plugin->getParameter( m_plugin, i );
-				unsigned int * pValue = ( unsigned int * ) &value;
+				auto pValue = (unsigned int*)&value;
 				toUIntArray[ i ] = endian_swap( *pValue );
 			}
 		} else chunk_size = (((m_plugin->numParams * sizeof( float )) + 56)*m_plugin->numPrograms);
@@ -1463,7 +1463,7 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 	if (!isPreset &&!chunky) pBank->fxMagic = 0x6B427846;
 
 	pBank->version = 0x01000000;
-	unsigned int uIntToFile = (unsigned int) m_plugin->uniqueID;
+	auto uIntToFile = (unsigned int)m_plugin->uniqueID;
 	pBank->fxID = endian_swap( uIntToFile );
 	uIntToFile = (unsigned int) pluginVersion();
 	pBank->fxVersion = endian_swap( uIntToFile );
@@ -1526,9 +1526,9 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 {
 	void * chunk = nullptr;
-	unsigned int * pLen = new unsigned int[ 1 ];
+	auto pLen = new unsigned int[1];
 	unsigned int len = 0;
-	sBank * pBank = (sBank*) new char[ sizeof( sBank ) ];
+	auto pBank = (sBank*)new char[sizeof(sBank)];
 	FILE * stream = F_OPEN_UTF8( _file, "rb" );
 	if (!stream)
 	{
@@ -1580,7 +1580,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 			pluginDispatch( 24, 1, len, chunk );
 		else
 		{
-			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( chunk );
+			auto toUIntArray = reinterpret_cast<unsigned int*>(chunk);
 			for (int i = 0; i < pBank->numPrograms; i++ )
 			{
 				toUInt = endian_swap( toUIntArray[ i ] );
@@ -1634,7 +1634,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 
 void RemoteVstPlugin::loadChunkFromFile( const std::string & _file, int _len )
 {
-	char * chunk = new char[_len];
+	auto chunk = new char[_len];
 
 	FILE* fp = F_OPEN_UTF8( _file, "rb" );
 	if (!fp)

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -1048,7 +1048,7 @@ void RemoteVstPlugin::process( const sampleFrame * _in, sampleFrame * _out )
 					return a.deltaFrames < b.deltaFrames;
 				} );
 
-		VstEvents* events = (VstEvents *) eventsBuffer;
+		auto* events = (VstEvents*)eventsBuffer;
 		events->reserved = 0;
 		events->numEvents = m_midiEvents.size();
 
@@ -1425,7 +1425,7 @@ struct sBank
 void RemoteVstPlugin::savePreset( const std::string & _file )
 {
 	unsigned int chunk_size = 0;
-	sBank * pBank = ( sBank* ) new char[ sizeof( sBank ) ];
+	auto* pBank = (sBank*)new char[sizeof(sBank)];
 	char progName[ 128 ] = { 0 };
 	char* data = nullptr;
 	const bool chunky = ( m_plugin->flags & ( 1 << 5 ) ) != 0;
@@ -1444,11 +1444,11 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 		if (isPreset) {
 			chunk_size = m_plugin->numParams * sizeof( float );
 			data = new char[ chunk_size ];
-			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( data );
+			auto* toUIntArray = reinterpret_cast<unsigned int*>(data);
 			for ( int i = 0; i < m_plugin->numParams; i++ )
 			{
 				float value = m_plugin->getParameter( m_plugin, i );
-				unsigned int * pValue = ( unsigned int * ) &value;
+				auto* pValue = (unsigned int*)&value;
 				toUIntArray[ i ] = endian_swap( *pValue );
 			}
 		} else chunk_size = (((m_plugin->numParams * sizeof( float )) + 56)*m_plugin->numPrograms);
@@ -1463,7 +1463,7 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 	if (!isPreset &&!chunky) pBank->fxMagic = 0x6B427846;
 
 	pBank->version = 0x01000000;
-	unsigned int uIntToFile = (unsigned int) m_plugin->uniqueID;
+	auto uIntToFile = (unsigned int)m_plugin->uniqueID;
 	pBank->fxID = endian_swap( uIntToFile );
 	uIntToFile = (unsigned int) pluginVersion();
 	pBank->fxVersion = endian_swap( uIntToFile );
@@ -1526,9 +1526,9 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 {
 	void * chunk = nullptr;
-	unsigned int * pLen = new unsigned int[ 1 ];
+	auto* pLen = new unsigned int[1];
 	unsigned int len = 0;
-	sBank * pBank = (sBank*) new char[ sizeof( sBank ) ];
+	auto* pBank = (sBank*)new char[sizeof(sBank)];
 	FILE * stream = F_OPEN_UTF8( _file, "rb" );
 	if (!stream)
 	{
@@ -1580,7 +1580,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 			pluginDispatch( 24, 1, len, chunk );
 		else
 		{
-			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( chunk );
+			auto* toUIntArray = reinterpret_cast<unsigned int*>(chunk);
 			for (int i = 0; i < pBank->numPrograms; i++ )
 			{
 				toUInt = endian_swap( toUIntArray[ i ] );

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -1048,7 +1048,7 @@ void RemoteVstPlugin::process( const sampleFrame * _in, sampleFrame * _out )
 					return a.deltaFrames < b.deltaFrames;
 				} );
 
-		auto* events = (VstEvents*)eventsBuffer;
+		VstEvents* events = (VstEvents *) eventsBuffer;
 		events->reserved = 0;
 		events->numEvents = m_midiEvents.size();
 
@@ -1425,7 +1425,7 @@ struct sBank
 void RemoteVstPlugin::savePreset( const std::string & _file )
 {
 	unsigned int chunk_size = 0;
-	auto* pBank = (sBank*)new char[sizeof(sBank)];
+	sBank * pBank = ( sBank* ) new char[ sizeof( sBank ) ];
 	char progName[ 128 ] = { 0 };
 	char* data = nullptr;
 	const bool chunky = ( m_plugin->flags & ( 1 << 5 ) ) != 0;
@@ -1444,11 +1444,11 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 		if (isPreset) {
 			chunk_size = m_plugin->numParams * sizeof( float );
 			data = new char[ chunk_size ];
-			auto* toUIntArray = reinterpret_cast<unsigned int*>(data);
+			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( data );
 			for ( int i = 0; i < m_plugin->numParams; i++ )
 			{
 				float value = m_plugin->getParameter( m_plugin, i );
-				auto* pValue = (unsigned int*)&value;
+				unsigned int * pValue = ( unsigned int * ) &value;
 				toUIntArray[ i ] = endian_swap( *pValue );
 			}
 		} else chunk_size = (((m_plugin->numParams * sizeof( float )) + 56)*m_plugin->numPrograms);
@@ -1463,7 +1463,7 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 	if (!isPreset &&!chunky) pBank->fxMagic = 0x6B427846;
 
 	pBank->version = 0x01000000;
-	auto uIntToFile = (unsigned int)m_plugin->uniqueID;
+	unsigned int uIntToFile = (unsigned int) m_plugin->uniqueID;
 	pBank->fxID = endian_swap( uIntToFile );
 	uIntToFile = (unsigned int) pluginVersion();
 	pBank->fxVersion = endian_swap( uIntToFile );
@@ -1526,9 +1526,9 @@ void RemoteVstPlugin::savePreset( const std::string & _file )
 void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 {
 	void * chunk = nullptr;
-	auto* pLen = new unsigned int[1];
+	unsigned int * pLen = new unsigned int[ 1 ];
 	unsigned int len = 0;
-	auto* pBank = (sBank*)new char[sizeof(sBank)];
+	sBank * pBank = (sBank*) new char[ sizeof( sBank ) ];
 	FILE * stream = F_OPEN_UTF8( _file, "rb" );
 	if (!stream)
 	{
@@ -1580,7 +1580,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 			pluginDispatch( 24, 1, len, chunk );
 		else
 		{
-			auto* toUIntArray = reinterpret_cast<unsigned int*>(chunk);
+			unsigned int* toUIntArray = reinterpret_cast<unsigned int*>( chunk );
 			for (int i = 0; i < pBank->numPrograms; i++ )
 			{
 				toUInt = endian_swap( toUIntArray[ i ] );

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -791,7 +791,7 @@ void VstPlugin::createUI( QWidget * parent )
 		{
 			parent->setAttribute(Qt::WA_NativeWindow);
 		}
-		QX11EmbedContainer * embedContainer = new QX11EmbedContainer( parent );
+		auto embedContainer = new QX11EmbedContainer(parent);
 		connect(embedContainer, SIGNAL(clientIsEmbedded()), this, SLOT(handleClientEmbed()));
 		embedContainer->embedClient( m_pluginWindowID );
 		container = embedContainer;

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -791,7 +791,7 @@ void VstPlugin::createUI( QWidget * parent )
 		{
 			parent->setAttribute(Qt::WA_NativeWindow);
 		}
-		auto* embedContainer = new QX11EmbedContainer(parent);
+		QX11EmbedContainer * embedContainer = new QX11EmbedContainer( parent );
 		connect(embedContainer, SIGNAL(clientIsEmbedded()), this, SLOT(handleClientEmbed()));
 		embedContainer->embedClient( m_pluginWindowID );
 		container = embedContainer;

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -791,7 +791,7 @@ void VstPlugin::createUI( QWidget * parent )
 		{
 			parent->setAttribute(Qt::WA_NativeWindow);
 		}
-		QX11EmbedContainer * embedContainer = new QX11EmbedContainer( parent );
+		auto* embedContainer = new QX11EmbedContainer(parent);
 		connect(embedContainer, SIGNAL(clientIsEmbedded()), this, SLOT(handleClientEmbed()));
 		embedContainer->embedClient( m_pluginWindowID );
 		container = embedContainer;

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -48,7 +48,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	m_plugin( nullptr ),
 	tbLabel( nullptr )
 {
-	QGridLayout * l = new QGridLayout( this );
+	auto l = new QGridLayout(this);
 	l->setContentsMargins( 10, 10, 10, 10 );
 	l->setVerticalSpacing( 2 );
 	l->setHorizontalSpacing( 2 );
@@ -73,7 +73,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	{
 		setWindowTitle( m_plugin->name() );
 
-		QPushButton * btn = new QPushButton( tr( "Show/hide" ));
+		auto btn = new QPushButton(tr("Show/hide"));
 
 		if (embed_vst) {
 			btn->setCheckable( true );
@@ -173,7 +173,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		_ctl->m_selPresetButton->setCursor( Qt::PointingHandCursor );
 		_ctl->m_selPresetButton->setIcon( embed::getIconPixmap( "stepper-down" ) );
 
-		QMenu * menu = new QMenu;
+		auto menu = new QMenu;
 		connect( menu, SIGNAL( aboutToShow() ), _ctl, SLOT( updateMenu() ) );
 
  		_ctl->m_selPresetButton->setMenu(menu);
@@ -206,11 +206,11 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		}
 		newSize = std::max(newSize, 250);
 
-		QWidget* resize = new QWidget(this);
+		auto resize = new QWidget(this);
 		resize->resize( newSize, 10 );
-		QWidget* space0 = new QWidget(this);
+		auto space0 = new QWidget(this);
 		space0->resize(8, 10);
-		QWidget* space1 = new QWidget(this);
+		auto space1 = new QWidget(this);
 		space1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		QFont f( "Arial", 10 );
 
@@ -223,7 +223,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		l->setRowStretch( 5, 1 );
 		l->setColumnStretch( 1, 1 );
 
-		QToolBar * tb = new QToolBar( this );
+		auto tb = new QToolBar(this);
 		tb->resize( newSize , 32 );
 		tb->addWidget(space0);
 		tb->addWidget( m_rolLPresetButton );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -48,7 +48,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	m_plugin( nullptr ),
 	tbLabel( nullptr )
 {
-	QGridLayout * l = new QGridLayout( this );
+	auto* l = new QGridLayout(this);
 	l->setContentsMargins( 10, 10, 10, 10 );
 	l->setVerticalSpacing( 2 );
 	l->setHorizontalSpacing( 2 );
@@ -73,7 +73,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	{
 		setWindowTitle( m_plugin->name() );
 
-		QPushButton * btn = new QPushButton( tr( "Show/hide" ));
+		auto* btn = new QPushButton(tr("Show/hide"));
 
 		if (embed_vst) {
 			btn->setCheckable( true );
@@ -173,7 +173,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		_ctl->m_selPresetButton->setCursor( Qt::PointingHandCursor );
 		_ctl->m_selPresetButton->setIcon( embed::getIconPixmap( "stepper-down" ) );
 
-		QMenu * menu = new QMenu;
+		auto* menu = new QMenu;
 		connect( menu, SIGNAL( aboutToShow() ), _ctl, SLOT( updateMenu() ) );
 
  		_ctl->m_selPresetButton->setMenu(menu);
@@ -206,11 +206,11 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		}
 		newSize = std::max(newSize, 250);
 
-		QWidget* resize = new QWidget(this);
+		auto* resize = new QWidget(this);
 		resize->resize( newSize, 10 );
-		QWidget* space0 = new QWidget(this);
+		auto* space0 = new QWidget(this);
 		space0->resize(8, 10);
-		QWidget* space1 = new QWidget(this);
+		auto* space1 = new QWidget(this);
 		space1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		QFont f( "Arial", 10 );
 
@@ -223,7 +223,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		l->setRowStretch( 5, 1 );
 		l->setColumnStretch( 1, 1 );
 
-		QToolBar * tb = new QToolBar( this );
+		auto* tb = new QToolBar(this);
 		tb->resize( newSize , 32 );
 		tb->addWidget(space0);
 		tb->addWidget( m_rolLPresetButton );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -48,7 +48,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	m_plugin( nullptr ),
 	tbLabel( nullptr )
 {
-	auto* l = new QGridLayout(this);
+	QGridLayout * l = new QGridLayout( this );
 	l->setContentsMargins( 10, 10, 10, 10 );
 	l->setVerticalSpacing( 2 );
 	l->setHorizontalSpacing( 2 );
@@ -73,7 +73,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 	{
 		setWindowTitle( m_plugin->name() );
 
-		auto* btn = new QPushButton(tr("Show/hide"));
+		QPushButton * btn = new QPushButton( tr( "Show/hide" ));
 
 		if (embed_vst) {
 			btn->setCheckable( true );
@@ -173,7 +173,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		_ctl->m_selPresetButton->setCursor( Qt::PointingHandCursor );
 		_ctl->m_selPresetButton->setIcon( embed::getIconPixmap( "stepper-down" ) );
 
-		auto* menu = new QMenu;
+		QMenu * menu = new QMenu;
 		connect( menu, SIGNAL( aboutToShow() ), _ctl, SLOT( updateMenu() ) );
 
  		_ctl->m_selPresetButton->setMenu(menu);
@@ -206,11 +206,11 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		}
 		newSize = std::max(newSize, 250);
 
-		auto* resize = new QWidget(this);
+		QWidget* resize = new QWidget(this);
 		resize->resize( newSize, 10 );
-		auto* space0 = new QWidget(this);
+		QWidget* space0 = new QWidget(this);
 		space0->resize(8, 10);
-		auto* space1 = new QWidget(this);
+		QWidget* space1 = new QWidget(this);
 		space1->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		QFont f( "Arial", 10 );
 
@@ -223,7 +223,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		l->setRowStretch( 5, 1 );
 		l->setColumnStretch( 1, 1 );
 
-		auto* tb = new QToolBar(this);
+		QToolBar * tb = new QToolBar( this );
 		tb->resize( newSize , 32 );
 		tb->addWidget(space0);
 		tb->addWidget( m_rolLPresetButton );

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -170,7 +170,7 @@ gui::EffectControlDialog* VstEffectControls::createView()
 void VstEffectControls::managePlugin()
 {
 	if ( m_effect->m_plugin != nullptr && m_subWindow == nullptr ) {
-		gui::ManageVSTEffectView * tt = new gui::ManageVSTEffectView( m_effect, this);
+		auto* tt = new gui::ManageVSTEffectView(m_effect, this);
 		ctrHandle = (QObject *)tt;
 	} else if (m_subWindow != nullptr) {
 		if (m_subWindow->widget()->isVisible() == false ) { 
@@ -221,8 +221,8 @@ void VstEffectControls::updateMenu()
     		to_menu->clear();
 
      		for (int i = 0; i < list1.size(); i++) {
-			QAction* presetAction = new QAction(this);
-			connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
+				auto* presetAction = new QAction(this);
+				connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
 
         		presetAction->setText(QString("%1. %2").arg(QString::number(i+1), list1.at(i)));
         		presetAction->setData(i);
@@ -291,13 +291,14 @@ void VstEffectControls::rolrPreset()
 void VstEffectControls::selPreset()
 {
 
-     QAction *action = qobject_cast<QAction *>(sender());
-     if (action)
-         if ( m_effect->m_plugin != nullptr ) {
-		lastPosInMenu = action->data().toInt();
-		m_effect->m_plugin->setProgram( lastPosInMenu );
-		//QWidget::update();
-	 }
+	auto* action = qobject_cast<QAction*>(sender());
+	if (action)
+		if (m_effect->m_plugin != nullptr)
+		{
+			lastPosInMenu = action->data().toInt();
+			m_effect->m_plugin->setProgram(lastPosInMenu);
+			// QWidget::update();
+		}
 }
 
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -170,7 +170,7 @@ gui::EffectControlDialog* VstEffectControls::createView()
 void VstEffectControls::managePlugin()
 {
 	if ( m_effect->m_plugin != nullptr && m_subWindow == nullptr ) {
-		gui::ManageVSTEffectView * tt = new gui::ManageVSTEffectView( m_effect, this);
+		auto tt = new gui::ManageVSTEffectView(m_effect, this);
 		ctrHandle = (QObject *)tt;
 	} else if (m_subWindow != nullptr) {
 		if (m_subWindow->widget()->isVisible() == false ) { 
@@ -221,8 +221,8 @@ void VstEffectControls::updateMenu()
     		to_menu->clear();
 
      		for (int i = 0; i < list1.size(); i++) {
-			QAction* presetAction = new QAction(this);
-			connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
+				auto presetAction = new QAction(this);
+				connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
 
         		presetAction->setText(QString("%1. %2").arg(QString::number(i+1), list1.at(i)));
         		presetAction->setData(i);
@@ -290,14 +290,13 @@ void VstEffectControls::rolrPreset()
 
 void VstEffectControls::selPreset()
 {
-
-     QAction *action = qobject_cast<QAction *>(sender());
-     if (action)
-         if ( m_effect->m_plugin != nullptr ) {
+	auto action = qobject_cast<QAction*>(sender());
+	if (action && m_effect->m_plugin != nullptr)
+	{
 		lastPosInMenu = action->data().toInt();
-		m_effect->m_plugin->setProgram( lastPosInMenu );
-		//QWidget::update();
-	 }
+		m_effect->m_plugin->setProgram(lastPosInMenu);
+		// QWidget::update();
+	}
 }
 
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -170,7 +170,7 @@ gui::EffectControlDialog* VstEffectControls::createView()
 void VstEffectControls::managePlugin()
 {
 	if ( m_effect->m_plugin != nullptr && m_subWindow == nullptr ) {
-		auto* tt = new gui::ManageVSTEffectView(m_effect, this);
+		gui::ManageVSTEffectView * tt = new gui::ManageVSTEffectView( m_effect, this);
 		ctrHandle = (QObject *)tt;
 	} else if (m_subWindow != nullptr) {
 		if (m_subWindow->widget()->isVisible() == false ) { 
@@ -221,8 +221,8 @@ void VstEffectControls::updateMenu()
     		to_menu->clear();
 
      		for (int i = 0; i < list1.size(); i++) {
-				auto* presetAction = new QAction(this);
-				connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
+			QAction* presetAction = new QAction(this);
+			connect(presetAction, SIGNAL(triggered()), this, SLOT(selPreset()));
 
         		presetAction->setText(QString("%1. %2").arg(QString::number(i+1), list1.at(i)));
         		presetAction->setData(i);
@@ -291,14 +291,13 @@ void VstEffectControls::rolrPreset()
 void VstEffectControls::selPreset()
 {
 
-	auto* action = qobject_cast<QAction*>(sender());
-	if (action)
-		if (m_effect->m_plugin != nullptr)
-		{
-			lastPosInMenu = action->data().toInt();
-			m_effect->m_plugin->setProgram(lastPosInMenu);
-			// QWidget::update();
-		}
+     QAction *action = qobject_cast<QAction *>(sender());
+     if (action)
+         if ( m_effect->m_plugin != nullptr ) {
+		lastPosInMenu = action->data().toInt();
+		m_effect->m_plugin->setProgram( lastPosInMenu );
+		//QWidget::update();
+	 }
 }
 
 

--- a/plugins/VstEffect/VstSubPluginFeatures.cpp
+++ b/plugins/VstEffect/VstSubPluginFeatures.cpp
@@ -55,7 +55,7 @@ void VstSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 void VstSubPluginFeatures::listSubPluginKeys( const Plugin::Descriptor * _desc,
 														KeyList & _kl ) const
 {
-	QStringList *dlls = new QStringList();
+	auto* dlls = new QStringList();
 	const QString path = QString("");
 	addPluginsFromDir(dlls, path );
 	// TODO: eval m_type

--- a/plugins/VstEffect/VstSubPluginFeatures.cpp
+++ b/plugins/VstEffect/VstSubPluginFeatures.cpp
@@ -55,7 +55,7 @@ void VstSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 void VstSubPluginFeatures::listSubPluginKeys( const Plugin::Descriptor * _desc,
 														KeyList & _kl ) const
 {
-	QStringList *dlls = new QStringList();
+	auto dlls = new QStringList();
 	const QString path = QString("");
 	addPluginsFromDir(dlls, path );
 	// TODO: eval m_type

--- a/plugins/VstEffect/VstSubPluginFeatures.cpp
+++ b/plugins/VstEffect/VstSubPluginFeatures.cpp
@@ -55,7 +55,7 @@ void VstSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 void VstSubPluginFeatures::listSubPluginKeys( const Plugin::Descriptor * _desc,
 														KeyList & _kl ) const
 {
-	auto* dlls = new QStringList();
+	QStringList *dlls = new QStringList();
 	const QString path = QString("");
 	addPluginsFromDir(dlls, path );
 	// TODO: eval m_type

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -331,14 +331,8 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 {
 	if ( _n->totalFramesPlayed() == 0 || _n->m_pluginData == nullptr )
 	{
-		WatsynObject * w = new WatsynObject(
-				&A1_wave[0],
-				&A2_wave[0],
-				&B1_wave[0],
-				&B2_wave[0],
-				m_amod.value(), m_bmod.value(),
-				Engine::audioEngine()->processingSampleRate(), _n,
-				Engine::audioEngine()->framesPerPeriod(), this );
+		auto w = new WatsynObject(&A1_wave[0], &A2_wave[0], &B1_wave[0], &B2_wave[0], m_amod.value(), m_bmod.value(),
+			Engine::audioEngine()->processingSampleRate(), _n, Engine::audioEngine()->framesPerPeriod(), this);
 
 		_n->m_pluginData = w;
 	}
@@ -347,7 +341,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const f_cnt_t offset = _n->noteOffset();
 	sampleFrame * buffer = _working_buffer + offset;
 
-	WatsynObject * w = static_cast<WatsynObject *>( _n->m_pluginData );
+	auto w = static_cast<WatsynObject*>(_n->m_pluginData);
 
 	sampleFrame * abuf = w->abuf();
 	sampleFrame * bbuf = w->bbuf();
@@ -360,7 +354,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const float envHold = ( m_envHold.value() * w->samplerate() ) / 1000.0f;
 	const float envDec = ( m_envDec.value() * w->samplerate() ) / 1000.0f;
 	const float envLen = envAtt + envDec + envHold;
-	const float tfp_ = static_cast<float>( _n->totalFramesPlayed() );
+	const auto tfp_ = static_cast<float>(_n->totalFramesPlayed());
 
 	// if sample-exact is enabled, use sample-exact calculations...
 	// disabled pending proper implementation of sample-exactness
@@ -723,25 +717,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 
 // button groups next.
 // graph select buttons
-	PixmapButton * a1_selectButton = new PixmapButton( this, nullptr );
+	auto a1_selectButton = new PixmapButton(this, nullptr);
 	a1_selectButton -> move( 4, 121 );
 	a1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_active" ) );
 	a1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_inactive" ) );
 	a1_selectButton->setToolTip(tr("Select oscillator A1"));
 
-	PixmapButton * a2_selectButton = new PixmapButton( this, nullptr );
+	auto a2_selectButton = new PixmapButton(this, nullptr);
 	a2_selectButton -> move( 44, 121 );
 	a2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_active" ) );
 	a2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_inactive" ) );
 	a2_selectButton->setToolTip(tr("Select oscillator A2"));
 
-	PixmapButton * b1_selectButton = new PixmapButton( this, nullptr );
+	auto b1_selectButton = new PixmapButton(this, nullptr);
 	b1_selectButton -> move( 84, 121 );
 	b1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_active" ) );
 	b1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_inactive" ) );
 	b1_selectButton->setToolTip(tr("Select oscillator B1"));
 
-	PixmapButton * b2_selectButton = new PixmapButton( this, nullptr );
+	auto b2_selectButton = new PixmapButton(this, nullptr);
 	b2_selectButton -> move( 124, 121 );
 	b2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_active" ) );
 	b2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_inactive" ) );
@@ -752,29 +746,29 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_selectedGraphGroup -> addButton( a2_selectButton );
 	m_selectedGraphGroup -> addButton( b1_selectButton );
 	m_selectedGraphGroup -> addButton( b2_selectButton );
-	WatsynInstrument * w = castModel<WatsynInstrument>();
+	auto w = castModel<WatsynInstrument>();
 	m_selectedGraphGroup -> setModel( &w -> m_selectedGraph);
 
 // A-modulation button group
-	PixmapButton * amod_mixButton = new PixmapButton( this, nullptr );
+	auto amod_mixButton = new PixmapButton(this, nullptr);
 	amod_mixButton -> move( 4, 50 );
 	amod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_active" ) );
 	amod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_inactive" ) );
 	amod_mixButton->setToolTip(tr("Mix output of A2 to A1"));
 
-	PixmapButton * amod_amButton = new PixmapButton( this, nullptr );
+	auto amod_amButton = new PixmapButton(this, nullptr);
 	amod_amButton -> move( 4, 66 );
 	amod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_active" ) );
 	amod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_inactive" ) );
 	amod_amButton->setToolTip(tr("Modulate amplitude of A1 by output of A2"));
 
-	PixmapButton * amod_rmButton = new PixmapButton( this, nullptr );
+	auto amod_rmButton = new PixmapButton(this, nullptr);
 	amod_rmButton -> move( 4, 82 );
 	amod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_active" ) );
 	amod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_inactive" ) );
 	amod_rmButton->setToolTip(tr("Ring modulate A1 and A2"));
 
-	PixmapButton * amod_pmButton = new PixmapButton( this, nullptr );
+	auto amod_pmButton = new PixmapButton(this, nullptr);
 	amod_pmButton -> move( 4, 98 );
 	amod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_active" ) );
 	amod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_inactive" ) );
@@ -787,25 +781,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_aModGroup -> addButton( amod_pmButton );
 
 // B-modulation button group
-	PixmapButton * bmod_mixButton = new PixmapButton( this, nullptr );
+	auto bmod_mixButton = new PixmapButton(this, nullptr);
 	bmod_mixButton -> move( 44, 50 );
 	bmod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_active" ) );
 	bmod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_inactive" ) );
 	bmod_mixButton->setToolTip(tr("Mix output of B2 to B1"));
 
-	PixmapButton * bmod_amButton = new PixmapButton( this, nullptr );
+	auto bmod_amButton = new PixmapButton(this, nullptr);
 	bmod_amButton -> move( 44, 66 );
 	bmod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_active" ) );
 	bmod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_inactive" ) );
 	bmod_amButton->setToolTip(tr("Modulate amplitude of B1 by output of B2"));
 
-	PixmapButton * bmod_rmButton = new PixmapButton( this, nullptr );
+	auto bmod_rmButton = new PixmapButton(this, nullptr);
 	bmod_rmButton -> move( 44, 82 );
 	bmod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_active" ) );
 	bmod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_inactive" ) );
 	bmod_rmButton->setToolTip(tr("Ring modulate B1 and B2"));
 
-	PixmapButton * bmod_pmButton = new PixmapButton( this, nullptr );
+	auto bmod_pmButton = new PixmapButton(this, nullptr);
 	bmod_pmButton -> move( 44, 98 );
 	bmod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_active" ) );
 	bmod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_inactive" ) );
@@ -1218,7 +1212,7 @@ void WatsynView::loadClicked()
 
 void WatsynView::modelChanged()
 {
-	WatsynInstrument * w = castModel<WatsynInstrument>();
+	auto w = castModel<WatsynInstrument>();
 
 	a1_volKnob -> setModel( &w -> a1_vol );
 	a2_volKnob -> setModel( &w -> a2_vol );

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -331,8 +331,14 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 {
 	if ( _n->totalFramesPlayed() == 0 || _n->m_pluginData == nullptr )
 	{
-		auto* w = new WatsynObject(&A1_wave[0], &A2_wave[0], &B1_wave[0], &B2_wave[0], m_amod.value(), m_bmod.value(),
-			Engine::audioEngine()->processingSampleRate(), _n, Engine::audioEngine()->framesPerPeriod(), this);
+		WatsynObject * w = new WatsynObject(
+				&A1_wave[0],
+				&A2_wave[0],
+				&B1_wave[0],
+				&B2_wave[0],
+				m_amod.value(), m_bmod.value(),
+				Engine::audioEngine()->processingSampleRate(), _n,
+				Engine::audioEngine()->framesPerPeriod(), this );
 
 		_n->m_pluginData = w;
 	}
@@ -341,7 +347,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const f_cnt_t offset = _n->noteOffset();
 	sampleFrame * buffer = _working_buffer + offset;
 
-	auto* w = static_cast<WatsynObject*>(_n->m_pluginData);
+	WatsynObject * w = static_cast<WatsynObject *>( _n->m_pluginData );
 
 	sampleFrame * abuf = w->abuf();
 	sampleFrame * bbuf = w->bbuf();
@@ -354,7 +360,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const float envHold = ( m_envHold.value() * w->samplerate() ) / 1000.0f;
 	const float envDec = ( m_envDec.value() * w->samplerate() ) / 1000.0f;
 	const float envLen = envAtt + envDec + envHold;
-	const auto tfp_ = static_cast<float>(_n->totalFramesPlayed());
+	const float tfp_ = static_cast<float>( _n->totalFramesPlayed() );
 
 	// if sample-exact is enabled, use sample-exact calculations...
 	// disabled pending proper implementation of sample-exactness
@@ -717,25 +723,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 
 // button groups next.
 // graph select buttons
-	auto* a1_selectButton = new PixmapButton(this, nullptr);
+	PixmapButton * a1_selectButton = new PixmapButton( this, nullptr );
 	a1_selectButton -> move( 4, 121 );
 	a1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_active" ) );
 	a1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_inactive" ) );
 	a1_selectButton->setToolTip(tr("Select oscillator A1"));
 
-	auto* a2_selectButton = new PixmapButton(this, nullptr);
+	PixmapButton * a2_selectButton = new PixmapButton( this, nullptr );
 	a2_selectButton -> move( 44, 121 );
 	a2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_active" ) );
 	a2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_inactive" ) );
 	a2_selectButton->setToolTip(tr("Select oscillator A2"));
 
-	auto* b1_selectButton = new PixmapButton(this, nullptr);
+	PixmapButton * b1_selectButton = new PixmapButton( this, nullptr );
 	b1_selectButton -> move( 84, 121 );
 	b1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_active" ) );
 	b1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_inactive" ) );
 	b1_selectButton->setToolTip(tr("Select oscillator B1"));
 
-	auto* b2_selectButton = new PixmapButton(this, nullptr);
+	PixmapButton * b2_selectButton = new PixmapButton( this, nullptr );
 	b2_selectButton -> move( 124, 121 );
 	b2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_active" ) );
 	b2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_inactive" ) );
@@ -746,29 +752,29 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_selectedGraphGroup -> addButton( a2_selectButton );
 	m_selectedGraphGroup -> addButton( b1_selectButton );
 	m_selectedGraphGroup -> addButton( b2_selectButton );
-	auto* w = castModel<WatsynInstrument>();
+	WatsynInstrument * w = castModel<WatsynInstrument>();
 	m_selectedGraphGroup -> setModel( &w -> m_selectedGraph);
 
 // A-modulation button group
-	auto* amod_mixButton = new PixmapButton(this, nullptr);
+	PixmapButton * amod_mixButton = new PixmapButton( this, nullptr );
 	amod_mixButton -> move( 4, 50 );
 	amod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_active" ) );
 	amod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_inactive" ) );
 	amod_mixButton->setToolTip(tr("Mix output of A2 to A1"));
 
-	auto* amod_amButton = new PixmapButton(this, nullptr);
+	PixmapButton * amod_amButton = new PixmapButton( this, nullptr );
 	amod_amButton -> move( 4, 66 );
 	amod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_active" ) );
 	amod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_inactive" ) );
 	amod_amButton->setToolTip(tr("Modulate amplitude of A1 by output of A2"));
 
-	auto* amod_rmButton = new PixmapButton(this, nullptr);
+	PixmapButton * amod_rmButton = new PixmapButton( this, nullptr );
 	amod_rmButton -> move( 4, 82 );
 	amod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_active" ) );
 	amod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_inactive" ) );
 	amod_rmButton->setToolTip(tr("Ring modulate A1 and A2"));
 
-	auto* amod_pmButton = new PixmapButton(this, nullptr);
+	PixmapButton * amod_pmButton = new PixmapButton( this, nullptr );
 	amod_pmButton -> move( 4, 98 );
 	amod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_active" ) );
 	amod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_inactive" ) );
@@ -781,25 +787,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_aModGroup -> addButton( amod_pmButton );
 
 // B-modulation button group
-	auto* bmod_mixButton = new PixmapButton(this, nullptr);
+	PixmapButton * bmod_mixButton = new PixmapButton( this, nullptr );
 	bmod_mixButton -> move( 44, 50 );
 	bmod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_active" ) );
 	bmod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_inactive" ) );
 	bmod_mixButton->setToolTip(tr("Mix output of B2 to B1"));
 
-	auto* bmod_amButton = new PixmapButton(this, nullptr);
+	PixmapButton * bmod_amButton = new PixmapButton( this, nullptr );
 	bmod_amButton -> move( 44, 66 );
 	bmod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_active" ) );
 	bmod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_inactive" ) );
 	bmod_amButton->setToolTip(tr("Modulate amplitude of B1 by output of B2"));
 
-	auto* bmod_rmButton = new PixmapButton(this, nullptr);
+	PixmapButton * bmod_rmButton = new PixmapButton( this, nullptr );
 	bmod_rmButton -> move( 44, 82 );
 	bmod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_active" ) );
 	bmod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_inactive" ) );
 	bmod_rmButton->setToolTip(tr("Ring modulate B1 and B2"));
 
-	auto* bmod_pmButton = new PixmapButton(this, nullptr);
+	PixmapButton * bmod_pmButton = new PixmapButton( this, nullptr );
 	bmod_pmButton -> move( 44, 98 );
 	bmod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_active" ) );
 	bmod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_inactive" ) );
@@ -1212,7 +1218,7 @@ void WatsynView::loadClicked()
 
 void WatsynView::modelChanged()
 {
-	auto* w = castModel<WatsynInstrument>();
+	WatsynInstrument * w = castModel<WatsynInstrument>();
 
 	a1_volKnob -> setModel( &w -> a1_vol );
 	a2_volKnob -> setModel( &w -> a2_vol );

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -331,14 +331,8 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 {
 	if ( _n->totalFramesPlayed() == 0 || _n->m_pluginData == nullptr )
 	{
-		WatsynObject * w = new WatsynObject(
-				&A1_wave[0],
-				&A2_wave[0],
-				&B1_wave[0],
-				&B2_wave[0],
-				m_amod.value(), m_bmod.value(),
-				Engine::audioEngine()->processingSampleRate(), _n,
-				Engine::audioEngine()->framesPerPeriod(), this );
+		auto* w = new WatsynObject(&A1_wave[0], &A2_wave[0], &B1_wave[0], &B2_wave[0], m_amod.value(), m_bmod.value(),
+			Engine::audioEngine()->processingSampleRate(), _n, Engine::audioEngine()->framesPerPeriod(), this);
 
 		_n->m_pluginData = w;
 	}
@@ -347,7 +341,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const f_cnt_t offset = _n->noteOffset();
 	sampleFrame * buffer = _working_buffer + offset;
 
-	WatsynObject * w = static_cast<WatsynObject *>( _n->m_pluginData );
+	auto* w = static_cast<WatsynObject*>(_n->m_pluginData);
 
 	sampleFrame * abuf = w->abuf();
 	sampleFrame * bbuf = w->bbuf();
@@ -360,7 +354,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	const float envHold = ( m_envHold.value() * w->samplerate() ) / 1000.0f;
 	const float envDec = ( m_envDec.value() * w->samplerate() ) / 1000.0f;
 	const float envLen = envAtt + envDec + envHold;
-	const float tfp_ = static_cast<float>( _n->totalFramesPlayed() );
+	const auto tfp_ = static_cast<float>(_n->totalFramesPlayed());
 
 	// if sample-exact is enabled, use sample-exact calculations...
 	// disabled pending proper implementation of sample-exactness
@@ -723,25 +717,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 
 // button groups next.
 // graph select buttons
-	PixmapButton * a1_selectButton = new PixmapButton( this, nullptr );
+	auto* a1_selectButton = new PixmapButton(this, nullptr);
 	a1_selectButton -> move( 4, 121 );
 	a1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_active" ) );
 	a1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a1_inactive" ) );
 	a1_selectButton->setToolTip(tr("Select oscillator A1"));
 
-	PixmapButton * a2_selectButton = new PixmapButton( this, nullptr );
+	auto* a2_selectButton = new PixmapButton(this, nullptr);
 	a2_selectButton -> move( 44, 121 );
 	a2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_active" ) );
 	a2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "a2_inactive" ) );
 	a2_selectButton->setToolTip(tr("Select oscillator A2"));
 
-	PixmapButton * b1_selectButton = new PixmapButton( this, nullptr );
+	auto* b1_selectButton = new PixmapButton(this, nullptr);
 	b1_selectButton -> move( 84, 121 );
 	b1_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_active" ) );
 	b1_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b1_inactive" ) );
 	b1_selectButton->setToolTip(tr("Select oscillator B1"));
 
-	PixmapButton * b2_selectButton = new PixmapButton( this, nullptr );
+	auto* b2_selectButton = new PixmapButton(this, nullptr);
 	b2_selectButton -> move( 124, 121 );
 	b2_selectButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_active" ) );
 	b2_selectButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "b2_inactive" ) );
@@ -752,29 +746,29 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_selectedGraphGroup -> addButton( a2_selectButton );
 	m_selectedGraphGroup -> addButton( b1_selectButton );
 	m_selectedGraphGroup -> addButton( b2_selectButton );
-	WatsynInstrument * w = castModel<WatsynInstrument>();
+	auto* w = castModel<WatsynInstrument>();
 	m_selectedGraphGroup -> setModel( &w -> m_selectedGraph);
 
 // A-modulation button group
-	PixmapButton * amod_mixButton = new PixmapButton( this, nullptr );
+	auto* amod_mixButton = new PixmapButton(this, nullptr);
 	amod_mixButton -> move( 4, 50 );
 	amod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_active" ) );
 	amod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "amix_inactive" ) );
 	amod_mixButton->setToolTip(tr("Mix output of A2 to A1"));
 
-	PixmapButton * amod_amButton = new PixmapButton( this, nullptr );
+	auto* amod_amButton = new PixmapButton(this, nullptr);
 	amod_amButton -> move( 4, 66 );
 	amod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_active" ) );
 	amod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "aam_inactive" ) );
 	amod_amButton->setToolTip(tr("Modulate amplitude of A1 by output of A2"));
 
-	PixmapButton * amod_rmButton = new PixmapButton( this, nullptr );
+	auto* amod_rmButton = new PixmapButton(this, nullptr);
 	amod_rmButton -> move( 4, 82 );
 	amod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_active" ) );
 	amod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "arm_inactive" ) );
 	amod_rmButton->setToolTip(tr("Ring modulate A1 and A2"));
 
-	PixmapButton * amod_pmButton = new PixmapButton( this, nullptr );
+	auto* amod_pmButton = new PixmapButton(this, nullptr);
 	amod_pmButton -> move( 4, 98 );
 	amod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_active" ) );
 	amod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "apm_inactive" ) );
@@ -787,25 +781,25 @@ WatsynView::WatsynView( Instrument * _instrument,
 	m_aModGroup -> addButton( amod_pmButton );
 
 // B-modulation button group
-	PixmapButton * bmod_mixButton = new PixmapButton( this, nullptr );
+	auto* bmod_mixButton = new PixmapButton(this, nullptr);
 	bmod_mixButton -> move( 44, 50 );
 	bmod_mixButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_active" ) );
 	bmod_mixButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bmix_inactive" ) );
 	bmod_mixButton->setToolTip(tr("Mix output of B2 to B1"));
 
-	PixmapButton * bmod_amButton = new PixmapButton( this, nullptr );
+	auto* bmod_amButton = new PixmapButton(this, nullptr);
 	bmod_amButton -> move( 44, 66 );
 	bmod_amButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_active" ) );
 	bmod_amButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bam_inactive" ) );
 	bmod_amButton->setToolTip(tr("Modulate amplitude of B1 by output of B2"));
 
-	PixmapButton * bmod_rmButton = new PixmapButton( this, nullptr );
+	auto* bmod_rmButton = new PixmapButton(this, nullptr);
 	bmod_rmButton -> move( 44, 82 );
 	bmod_rmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_active" ) );
 	bmod_rmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "brm_inactive" ) );
 	bmod_rmButton->setToolTip(tr("Ring modulate B1 and B2"));
 
-	PixmapButton * bmod_pmButton = new PixmapButton( this, nullptr );
+	auto* bmod_pmButton = new PixmapButton(this, nullptr);
 	bmod_pmButton -> move( 44, 98 );
 	bmod_pmButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_active" ) );
 	bmod_pmButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "bpm_inactive" ) );
@@ -1218,7 +1212,7 @@ void WatsynView::loadClicked()
 
 void WatsynView::modelChanged()
 {
-	WatsynInstrument * w = castModel<WatsynInstrument>();
+	auto* w = castModel<WatsynInstrument>();
 
 	a1_volKnob -> setModel( &w -> a1_vol );
 	a2_volKnob -> setModel( &w -> a2_vol );

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -48,7 +48,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 274 );
 
-	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
+	auto* waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -75,36 +75,35 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	outputKnob->setLabel( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
-	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
+	auto* resetButton = new PixmapButton(this, tr("Reset wavegraph"));
 	resetButton -> move( 162, 221 );
 	resetButton -> resize( 13, 46 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
+	auto* smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
 	smoothButton -> move( 162, 237 );
 	smoothButton -> resize( 13, 46 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
+	auto* addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
 	addOneButton -> move( 131, 221 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
+	auto* subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
 	subOneButton -> move( 131, 237 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
 	subOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_inactive" ) );
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
-	LedCheckBox * clipInputToggle = new LedCheckBox( "Clip input", this,
-							tr( "Clip input" ), LedCheckBox::Green );
+	auto* clipInputToggle = new LedCheckBox("Clip input", this, tr("Clip input"), LedCheckBox::Green);
 	clipInputToggle -> move( 131, 252 );
 	clipInputToggle -> setModel( &_controls -> m_clipModel );
 	clipInputToggle->setToolTip(tr("Clip input signal to 0 dB"));

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -48,7 +48,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 274 );
 
-	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
+	auto waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -59,7 +59,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	Knob * inputKnob = new Knob( knobBright_26, this);
+	auto inputKnob = new Knob(knobBright_26, this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 225 );
@@ -67,7 +67,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	inputKnob->setLabel( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	Knob * outputKnob = new Knob( knobBright_26, this );
+	auto outputKnob = new Knob(knobBright_26, this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 225 );
@@ -75,36 +75,35 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	outputKnob->setLabel( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
-	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
+	auto resetButton = new PixmapButton(this, tr("Reset wavegraph"));
 	resetButton -> move( 162, 221 );
 	resetButton -> resize( 13, 46 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
+	auto smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
 	smoothButton -> move( 162, 237 );
 	smoothButton -> resize( 13, 46 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
+	auto addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
 	addOneButton -> move( 131, 221 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
+	auto subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
 	subOneButton -> move( 131, 237 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
 	subOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_inactive" ) );
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
-	LedCheckBox * clipInputToggle = new LedCheckBox( "Clip input", this,
-							tr( "Clip input" ), LedCheckBox::Green );
+	auto clipInputToggle = new LedCheckBox("Clip input", this, tr("Clip input"), LedCheckBox::Green);
 	clipInputToggle -> move( 131, 252 );
 	clipInputToggle -> setModel( &_controls -> m_clipModel );
 	clipInputToggle->setToolTip(tr("Clip input signal to 0 dB"));

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -48,7 +48,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	setPalette( pal );
 	setFixedSize( 224, 274 );
 
-	auto* waveGraph = new Graph(this, Graph::LinearNonCyclicStyle, 204, 205);
+	Graph * waveGraph = new Graph( this, Graph::LinearNonCyclicStyle, 204, 205 );
 	waveGraph -> move( 10, 6 );
 	waveGraph -> setModel( &_controls -> m_wavegraphModel );
 	waveGraph -> setAutoFillBackground( true );
@@ -75,35 +75,36 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	outputKnob->setLabel( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
-	auto* resetButton = new PixmapButton(this, tr("Reset wavegraph"));
+	PixmapButton * resetButton = new PixmapButton( this, tr("Reset wavegraph") );
 	resetButton -> move( 162, 221 );
 	resetButton -> resize( 13, 46 );
 	resetButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_active" ) );
 	resetButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "reset_inactive" ) );
 	resetButton->setToolTip(tr("Reset wavegraph"));
 
-	auto* smoothButton = new PixmapButton(this, tr("Smooth wavegraph"));
+	PixmapButton * smoothButton = new PixmapButton( this, tr("Smooth wavegraph") );
 	smoothButton -> move( 162, 237 );
 	smoothButton -> resize( 13, 46 );
 	smoothButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_active" ) );
 	smoothButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "smooth_inactive" ) );
 	smoothButton->setToolTip(tr("Smooth wavegraph"));
 
-	auto* addOneButton = new PixmapButton(this, tr("Increase wavegraph amplitude by 1 dB"));
+	PixmapButton * addOneButton = new PixmapButton( this, tr("Increase wavegraph amplitude by 1 dB") );
 	addOneButton -> move( 131, 221 );
 	addOneButton -> resize( 13, 29 );
 	addOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_active" ) );
 	addOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "add1_inactive" ) );
 	addOneButton->setToolTip(tr("Increase wavegraph amplitude by 1 dB"));
 
-	auto* subOneButton = new PixmapButton(this, tr("Decrease wavegraph amplitude by 1 dB"));
+	PixmapButton * subOneButton = new PixmapButton( this, tr("Decrease wavegraph amplitude by 1 dB") );
 	subOneButton -> move( 131, 237 );
 	subOneButton -> resize( 13, 29 );
 	subOneButton -> setActiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_active" ) );
 	subOneButton -> setInactiveGraphic( PLUGIN_NAME::getIconPixmap( "sub1_inactive" ) );
 	subOneButton->setToolTip(tr("Decrease wavegraph amplitude by 1 dB"));
 
-	auto* clipInputToggle = new LedCheckBox("Clip input", this, tr("Clip input"), LedCheckBox::Green);
+	LedCheckBox * clipInputToggle = new LedCheckBox( "Clip input", this,
+							tr( "Clip input" ), LedCheckBox::Green );
 	clipInputToggle -> move( 131, 252 );
 	clipInputToggle -> setModel( &_controls -> m_clipModel );
 	clipInputToggle->setToolTip(tr("Clip input signal to 0 dB"));

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -312,7 +312,7 @@ struct RandomVectorSeedFunction : public exprtk::ifunction<float>
 		{
 			return 0;
 		}
-		const unsigned int xi = (unsigned int)index;
+		const auto xi = (unsigned int)index;
 		const unsigned int si = irseed % data_size;
 		const unsigned int sa = irseed / data_size;
 		unsigned int res=rotateLeft(random_data[(xi + 23 * si + 1) % data_size] ^ random_data[(xi / data_size + sa) % data_size],sa % 31 + 1);
@@ -634,13 +634,13 @@ bool ExprFront::add_cyclic_vector(const char* name, const float* data, size_t le
 	{
 		if (interp)
 		{
-			WaveValueFunctionInterpolate<float> *wvf = new WaveValueFunctionInterpolate<float>(data, length);
+			auto wvf = new WaveValueFunctionInterpolate<float>(data, length);
 			m_data->m_cyclics_interp.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}
 		else
 		{
-			WaveValueFunction<float> *wvf = new WaveValueFunction<float>(data, length);
+			auto wvf = new WaveValueFunction<float>(data, length);
 			m_data->m_cyclics.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -312,7 +312,7 @@ struct RandomVectorSeedFunction : public exprtk::ifunction<float>
 		{
 			return 0;
 		}
-		const unsigned int xi = (unsigned int)index;
+		const auto xi = (unsigned int)index;
 		const unsigned int si = irseed % data_size;
 		const unsigned int sa = irseed / data_size;
 		unsigned int res=rotateLeft(random_data[(xi + 23 * si + 1) % data_size] ^ random_data[(xi / data_size + sa) % data_size],sa % 31 + 1);
@@ -634,13 +634,13 @@ bool ExprFront::add_cyclic_vector(const char* name, const float* data, size_t le
 	{
 		if (interp)
 		{
-			WaveValueFunctionInterpolate<float> *wvf = new WaveValueFunctionInterpolate<float>(data, length);
+			auto* wvf = new WaveValueFunctionInterpolate<float>(data, length);
 			m_data->m_cyclics_interp.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}
 		else
 		{
-			WaveValueFunction<float> *wvf = new WaveValueFunction<float>(data, length);
+			auto* wvf = new WaveValueFunction<float>(data, length);
 			m_data->m_cyclics.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -312,7 +312,7 @@ struct RandomVectorSeedFunction : public exprtk::ifunction<float>
 		{
 			return 0;
 		}
-		const auto xi = (unsigned int)index;
+		const unsigned int xi = (unsigned int)index;
 		const unsigned int si = irseed % data_size;
 		const unsigned int sa = irseed / data_size;
 		unsigned int res=rotateLeft(random_data[(xi + 23 * si + 1) % data_size] ^ random_data[(xi / data_size + sa) % data_size],sa % 31 + 1);
@@ -634,13 +634,13 @@ bool ExprFront::add_cyclic_vector(const char* name, const float* data, size_t le
 	{
 		if (interp)
 		{
-			auto* wvf = new WaveValueFunctionInterpolate<float>(data, length);
+			WaveValueFunctionInterpolate<float> *wvf = new WaveValueFunctionInterpolate<float>(data, length);
 			m_data->m_cyclics_interp.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}
 		else
 		{
-			auto* wvf = new WaveValueFunction<float>(data, length);
+			WaveValueFunction<float> *wvf = new WaveValueFunction<float>(data, length);
 			m_data->m_cyclics.push_back(wvf);
 			return m_data->m_symbol_table.add_function(name, *wvf);
 		}

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -203,9 +203,8 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 
 	if (nph->totalFramesPlayed() == 0 || nph->m_pluginData == nullptr) {
 
-		auto* exprO1 = new ExprFront(m_outputExpression[0].constData(),
-			Engine::audioEngine()->processingSampleRate()); // give the "last" function a whole second
-		auto* exprO2 = new ExprFront(m_outputExpression[1].constData(), Engine::audioEngine()->processingSampleRate());
+		ExprFront *exprO1 = new ExprFront(m_outputExpression[0].constData(),Engine::audioEngine()->processingSampleRate());//give the "last" function a whole second
+		ExprFront *exprO2 = new ExprFront(m_outputExpression[1].constData(),Engine::audioEngine()->processingSampleRate());
 
 		auto init_expression_step1 = [this, nph](ExprFront* e) { //lambda function to init exprO1 and exprO2
 			//add the constants and the variables to the expression.
@@ -228,7 +227,10 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 				Engine::audioEngine()->processingSampleRate(), &m_panning1, &m_panning2, m_relTransition.value());
 	}
 
-	auto* ps = static_cast<ExprSynth*>(nph->m_pluginData);
+
+
+
+	ExprSynth *ps = static_cast<ExprSynth*>(nph->m_pluginData);
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();
 
@@ -255,7 +257,7 @@ void Xpressive::smooth(float smoothness,const graphModel * in,graphModel * out)
 		const int guass_center = guass_size/2;
 		const float delta = smoothness;
 		const float a= 1.0f / (sqrtf(2.0f * F_PI) * delta);
-		auto* const guassian = new float[guass_size];
+		float * const guassian = new float [guass_size];
 		float sum = 0.0f;
 		float temp = 0.0f;
 		int i;
@@ -388,7 +390,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 	m_selectedGraphGroup->addButton(m_o1Btn);
 	m_selectedGraphGroup->addButton(m_o2Btn);
 
-	auto* e = castModel<Xpressive>();
+	Xpressive *e = castModel<Xpressive>();
 	m_selectedGraphGroup->setModel(&e->selectedGraph());
 
 	m_sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
@@ -534,7 +536,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 
 
 void XpressiveView::expressionChanged() {
-	auto* e = castModel<Xpressive>();
+	Xpressive * e = castModel<Xpressive>();
 	QByteArray text = m_expressionEditor->toPlainText().toLatin1();
 
 	switch (m_selectedGraphGroup->model()->value()) {
@@ -590,7 +592,7 @@ void XpressiveView::expressionChanged() {
 		if (parse_ok) {
 			e->exprValid().setValue(0);
 			const int length = m_raw_graph->length();
-			auto* const samples = new float[length];
+			float * const samples = new float[length];
 			for (i = 0; i < length; i++) {
 				t = i / (float) length;
 				samples[i] = expr.evaluate();
@@ -625,8 +627,8 @@ void XpressiveView::expressionChanged() {
 
 void XpressiveView::smoothChanged()
 {
-
-	auto* e = castModel<Xpressive>();
+	
+	Xpressive * e = castModel<Xpressive>();
 	float smoothness=0;
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
@@ -658,7 +660,7 @@ void XpressiveView::smoothChanged()
 void XpressiveView::graphDrawn()
 {
 	m_raw_graph->setSamples(m_graph->model()->samples());
-	auto* e = castModel<Xpressive>();
+	Xpressive * e = castModel<Xpressive>();
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
 		e->W1().copyFrom(m_graph->model());
@@ -674,7 +676,7 @@ void XpressiveView::graphDrawn()
 }
 
 void XpressiveView::modelChanged() {
-	auto* b = castModel<Xpressive>();
+	Xpressive * b = castModel<Xpressive>();
 
 	m_expressionValidToggle->setModel( &b->exprValid() );
 	m_generalPurposeKnob[0]->setModel( &b->parameterA1() );
@@ -690,7 +692,7 @@ void XpressiveView::modelChanged() {
 }
 
 void XpressiveView::updateLayout() {
-	auto* e = castModel<Xpressive>();
+	Xpressive * e = castModel<Xpressive>();
 	m_output_expr=false;
 	m_wave_expr=false;
 	switch (m_selectedGraphGroup->model()->value()) {

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -203,8 +203,9 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 
 	if (nph->totalFramesPlayed() == 0 || nph->m_pluginData == nullptr) {
 
-		ExprFront *exprO1 = new ExprFront(m_outputExpression[0].constData(),Engine::audioEngine()->processingSampleRate());//give the "last" function a whole second
-		ExprFront *exprO2 = new ExprFront(m_outputExpression[1].constData(),Engine::audioEngine()->processingSampleRate());
+		auto exprO1 = new ExprFront(m_outputExpression[0].constData(),
+			Engine::audioEngine()->processingSampleRate()); // give the "last" function a whole second
+		auto exprO2 = new ExprFront(m_outputExpression[1].constData(), Engine::audioEngine()->processingSampleRate());
 
 		auto init_expression_step1 = [this, nph](ExprFront* e) { //lambda function to init exprO1 and exprO2
 			//add the constants and the variables to the expression.
@@ -227,10 +228,7 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 				Engine::audioEngine()->processingSampleRate(), &m_panning1, &m_panning2, m_relTransition.value());
 	}
 
-
-
-
-	ExprSynth *ps = static_cast<ExprSynth*>(nph->m_pluginData);
+	auto ps = static_cast<ExprSynth*>(nph->m_pluginData);
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();
 
@@ -257,7 +255,7 @@ void Xpressive::smooth(float smoothness,const graphModel * in,graphModel * out)
 		const int guass_center = guass_size/2;
 		const float delta = smoothness;
 		const float a= 1.0f / (sqrtf(2.0f * F_PI) * delta);
-		float * const guassian = new float [guass_size];
+		auto const guassian = new float[guass_size];
 		float sum = 0.0f;
 		float temp = 0.0f;
 		int i;
@@ -390,7 +388,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 	m_selectedGraphGroup->addButton(m_o1Btn);
 	m_selectedGraphGroup->addButton(m_o2Btn);
 
-	Xpressive *e = castModel<Xpressive>();
+	auto e = castModel<Xpressive>();
 	m_selectedGraphGroup->setModel(&e->selectedGraph());
 
 	m_sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
@@ -536,7 +534,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 
 
 void XpressiveView::expressionChanged() {
-	Xpressive * e = castModel<Xpressive>();
+	auto e = castModel<Xpressive>();
 	QByteArray text = m_expressionEditor->toPlainText().toLatin1();
 
 	switch (m_selectedGraphGroup->model()->value()) {
@@ -592,7 +590,7 @@ void XpressiveView::expressionChanged() {
 		if (parse_ok) {
 			e->exprValid().setValue(0);
 			const int length = m_raw_graph->length();
-			float * const samples = new float[length];
+			auto const samples = new float[length];
 			for (i = 0; i < length; i++) {
 				t = i / (float) length;
 				samples[i] = expr.evaluate();
@@ -627,8 +625,8 @@ void XpressiveView::expressionChanged() {
 
 void XpressiveView::smoothChanged()
 {
-	
-	Xpressive * e = castModel<Xpressive>();
+
+	auto e = castModel<Xpressive>();
 	float smoothness=0;
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
@@ -660,7 +658,7 @@ void XpressiveView::smoothChanged()
 void XpressiveView::graphDrawn()
 {
 	m_raw_graph->setSamples(m_graph->model()->samples());
-	Xpressive * e = castModel<Xpressive>();
+	auto e = castModel<Xpressive>();
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
 		e->W1().copyFrom(m_graph->model());
@@ -676,7 +674,7 @@ void XpressiveView::graphDrawn()
 }
 
 void XpressiveView::modelChanged() {
-	Xpressive * b = castModel<Xpressive>();
+	auto b = castModel<Xpressive>();
 
 	m_expressionValidToggle->setModel( &b->exprValid() );
 	m_generalPurposeKnob[0]->setModel( &b->parameterA1() );
@@ -692,7 +690,7 @@ void XpressiveView::modelChanged() {
 }
 
 void XpressiveView::updateLayout() {
-	Xpressive * e = castModel<Xpressive>();
+	auto e = castModel<Xpressive>();
 	m_output_expr=false;
 	m_wave_expr=false;
 	switch (m_selectedGraphGroup->model()->value()) {

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -203,8 +203,9 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 
 	if (nph->totalFramesPlayed() == 0 || nph->m_pluginData == nullptr) {
 
-		ExprFront *exprO1 = new ExprFront(m_outputExpression[0].constData(),Engine::audioEngine()->processingSampleRate());//give the "last" function a whole second
-		ExprFront *exprO2 = new ExprFront(m_outputExpression[1].constData(),Engine::audioEngine()->processingSampleRate());
+		auto* exprO1 = new ExprFront(m_outputExpression[0].constData(),
+			Engine::audioEngine()->processingSampleRate()); // give the "last" function a whole second
+		auto* exprO2 = new ExprFront(m_outputExpression[1].constData(), Engine::audioEngine()->processingSampleRate());
 
 		auto init_expression_step1 = [this, nph](ExprFront* e) { //lambda function to init exprO1 and exprO2
 			//add the constants and the variables to the expression.
@@ -227,10 +228,7 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 				Engine::audioEngine()->processingSampleRate(), &m_panning1, &m_panning2, m_relTransition.value());
 	}
 
-
-
-
-	ExprSynth *ps = static_cast<ExprSynth*>(nph->m_pluginData);
+	auto* ps = static_cast<ExprSynth*>(nph->m_pluginData);
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();
 
@@ -257,7 +255,7 @@ void Xpressive::smooth(float smoothness,const graphModel * in,graphModel * out)
 		const int guass_center = guass_size/2;
 		const float delta = smoothness;
 		const float a= 1.0f / (sqrtf(2.0f * F_PI) * delta);
-		float * const guassian = new float [guass_size];
+		auto* const guassian = new float[guass_size];
 		float sum = 0.0f;
 		float temp = 0.0f;
 		int i;
@@ -390,7 +388,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 	m_selectedGraphGroup->addButton(m_o1Btn);
 	m_selectedGraphGroup->addButton(m_o2Btn);
 
-	Xpressive *e = castModel<Xpressive>();
+	auto* e = castModel<Xpressive>();
 	m_selectedGraphGroup->setModel(&e->selectedGraph());
 
 	m_sinWaveBtn = new PixmapButton(this, tr("Sine wave"));
@@ -536,7 +534,7 @@ XpressiveView::XpressiveView(Instrument * _instrument, QWidget * _parent) :
 
 
 void XpressiveView::expressionChanged() {
-	Xpressive * e = castModel<Xpressive>();
+	auto* e = castModel<Xpressive>();
 	QByteArray text = m_expressionEditor->toPlainText().toLatin1();
 
 	switch (m_selectedGraphGroup->model()->value()) {
@@ -592,7 +590,7 @@ void XpressiveView::expressionChanged() {
 		if (parse_ok) {
 			e->exprValid().setValue(0);
 			const int length = m_raw_graph->length();
-			float * const samples = new float[length];
+			auto* const samples = new float[length];
 			for (i = 0; i < length; i++) {
 				t = i / (float) length;
 				samples[i] = expr.evaluate();
@@ -627,8 +625,8 @@ void XpressiveView::expressionChanged() {
 
 void XpressiveView::smoothChanged()
 {
-	
-	Xpressive * e = castModel<Xpressive>();
+
+	auto* e = castModel<Xpressive>();
 	float smoothness=0;
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
@@ -660,7 +658,7 @@ void XpressiveView::smoothChanged()
 void XpressiveView::graphDrawn()
 {
 	m_raw_graph->setSamples(m_graph->model()->samples());
-	Xpressive * e = castModel<Xpressive>();
+	auto* e = castModel<Xpressive>();
 	switch (m_selectedGraphGroup->model()->value()) {
 	case W1_EXPR:
 		e->W1().copyFrom(m_graph->model());
@@ -676,7 +674,7 @@ void XpressiveView::graphDrawn()
 }
 
 void XpressiveView::modelChanged() {
-	Xpressive * b = castModel<Xpressive>();
+	auto* b = castModel<Xpressive>();
 
 	m_expressionValidToggle->setModel( &b->exprValid() );
 	m_generalPurposeKnob[0]->setModel( &b->parameterA1() );
@@ -692,7 +690,7 @@ void XpressiveView::modelChanged() {
 }
 
 void XpressiveView::updateLayout() {
-	Xpressive * e = castModel<Xpressive>();
+	auto* e = castModel<Xpressive>();
 	m_output_expr=false;
 	m_wave_expr=false;
 	switch (m_selectedGraphGroup->model()->value()) {

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -146,8 +146,7 @@ public:
 
 	static void * messageLoop( void * _arg )
 	{
-		RemoteZynAddSubFx * _this =
-					static_cast<RemoteZynAddSubFx *>( _arg );
+		auto _this = static_cast<RemoteZynAddSubFx*>(_arg);
 
 		_this->messageLoop();
 
@@ -285,7 +284,7 @@ int main( int _argc, char * * _argv )
 	RemoteZynAddSubFx * remoteZASF =
 		new RemoteZynAddSubFx( _argv[1], _argv[2] );
 #else
-	RemoteZynAddSubFx * remoteZASF = new RemoteZynAddSubFx( _argv[1] );
+	auto remoteZASF = new RemoteZynAddSubFx(_argv[1]);
 #endif
 
 	remoteZASF->guiLoop();

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -146,7 +146,8 @@ public:
 
 	static void * messageLoop( void * _arg )
 	{
-		auto* _this = static_cast<RemoteZynAddSubFx*>(_arg);
+		RemoteZynAddSubFx * _this =
+					static_cast<RemoteZynAddSubFx *>( _arg );
 
 		_this->messageLoop();
 
@@ -284,7 +285,7 @@ int main( int _argc, char * * _argv )
 	RemoteZynAddSubFx * remoteZASF =
 		new RemoteZynAddSubFx( _argv[1], _argv[2] );
 #else
-	auto* remoteZASF = new RemoteZynAddSubFx(_argv[1]);
+	RemoteZynAddSubFx * remoteZASF = new RemoteZynAddSubFx( _argv[1] );
 #endif
 
 	remoteZASF->guiLoop();

--- a/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/RemoteZynAddSubFx.cpp
@@ -146,8 +146,7 @@ public:
 
 	static void * messageLoop( void * _arg )
 	{
-		RemoteZynAddSubFx * _this =
-					static_cast<RemoteZynAddSubFx *>( _arg );
+		auto* _this = static_cast<RemoteZynAddSubFx*>(_arg);
 
 		_this->messageLoop();
 
@@ -285,7 +284,7 @@ int main( int _argc, char * * _argv )
 	RemoteZynAddSubFx * remoteZASF =
 		new RemoteZynAddSubFx( _argv[1], _argv[2] );
 #else
-	RemoteZynAddSubFx * remoteZASF = new RemoteZynAddSubFx( _argv[1] );
+	auto* remoteZASF = new RemoteZynAddSubFx(_argv[1]);
 #endif
 
 	remoteZASF->guiLoop();

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -135,7 +135,7 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 			this, SLOT( updateResBandwidth() ), Qt::DirectConnection );
 
 	// now we need a play-handle which cares for calling play()
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
+	auto* iph = new InstrumentPlayHandle(this, _instrumentTrack);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ),
@@ -503,7 +503,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 								"artwork" ) );
 	setPalette( pal );
 
-	QGridLayout * l = new QGridLayout( this );
+	auto* l = new QGridLayout(this);
 	l->setContentsMargins( 20, 80, 10, 10 );
 	l->setVerticalSpacing( 16 );
 	l->setHorizontalSpacing( 10 );
@@ -611,7 +611,7 @@ void ZynAddSubFxView::dropEvent( QDropEvent * _de )
 
 void ZynAddSubFxView::modelChanged()
 {
-	ZynAddSubFxInstrument * m = castModel<ZynAddSubFxInstrument>();
+	auto* m = castModel<ZynAddSubFxInstrument>();
 
 	// set models for controller knobs
 	m_portamento->setModel( &m->m_portamentoModel );
@@ -632,7 +632,7 @@ void ZynAddSubFxView::modelChanged()
 
 void ZynAddSubFxView::toggleUI()
 {
-	ZynAddSubFxInstrument * model = castModel<ZynAddSubFxInstrument>();
+	auto* model = castModel<ZynAddSubFxInstrument>();
 	if( model->m_hasGUI != m_toggleUIButton->isChecked() )
 	{
 		model->m_hasGUI = m_toggleUIButton->isChecked();

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -135,7 +135,7 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 			this, SLOT( updateResBandwidth() ), Qt::DirectConnection );
 
 	// now we need a play-handle which cares for calling play()
-	auto* iph = new InstrumentPlayHandle(this, _instrumentTrack);
+	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ),
@@ -503,7 +503,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 								"artwork" ) );
 	setPalette( pal );
 
-	auto* l = new QGridLayout(this);
+	QGridLayout * l = new QGridLayout( this );
 	l->setContentsMargins( 20, 80, 10, 10 );
 	l->setVerticalSpacing( 16 );
 	l->setHorizontalSpacing( 10 );
@@ -611,7 +611,7 @@ void ZynAddSubFxView::dropEvent( QDropEvent * _de )
 
 void ZynAddSubFxView::modelChanged()
 {
-	auto* m = castModel<ZynAddSubFxInstrument>();
+	ZynAddSubFxInstrument * m = castModel<ZynAddSubFxInstrument>();
 
 	// set models for controller knobs
 	m_portamento->setModel( &m->m_portamentoModel );
@@ -632,7 +632,7 @@ void ZynAddSubFxView::modelChanged()
 
 void ZynAddSubFxView::toggleUI()
 {
-	auto* model = castModel<ZynAddSubFxInstrument>();
+	ZynAddSubFxInstrument * model = castModel<ZynAddSubFxInstrument>();
 	if( model->m_hasGUI != m_toggleUIButton->isChecked() )
 	{
 		model->m_hasGUI = m_toggleUIButton->isChecked();

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -135,7 +135,7 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 			this, SLOT( updateResBandwidth() ), Qt::DirectConnection );
 
 	// now we need a play-handle which cares for calling play()
-	InstrumentPlayHandle * iph = new InstrumentPlayHandle( this, _instrumentTrack );
+	auto iph = new InstrumentPlayHandle(this, _instrumentTrack);
 	Engine::audioEngine()->addPlayHandle( iph );
 
 	connect( Engine::audioEngine(), SIGNAL( sampleRateChanged() ),
@@ -503,7 +503,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 								"artwork" ) );
 	setPalette( pal );
 
-	QGridLayout * l = new QGridLayout( this );
+	auto l = new QGridLayout(this);
 	l->setContentsMargins( 20, 80, 10, 10 );
 	l->setVerticalSpacing( 16 );
 	l->setHorizontalSpacing( 10 );
@@ -611,7 +611,7 @@ void ZynAddSubFxView::dropEvent( QDropEvent * _de )
 
 void ZynAddSubFxView::modelChanged()
 {
-	ZynAddSubFxInstrument * m = castModel<ZynAddSubFxInstrument>();
+	auto m = castModel<ZynAddSubFxInstrument>();
 
 	// set models for controller knobs
 	m_portamento->setModel( &m->m_portamentoModel );
@@ -632,7 +632,7 @@ void ZynAddSubFxView::modelChanged()
 
 void ZynAddSubFxView::toggleUI()
 {
-	ZynAddSubFxInstrument * model = castModel<ZynAddSubFxInstrument>();
+	auto model = castModel<ZynAddSubFxInstrument>();
 	if( model->m_hasGUI != m_toggleUIButton->isChecked() )
 	{
 		model->m_hasGUI = m_toggleUIButton->isChecked();

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -148,7 +148,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 	for( int i = 0; i < m_numWorkers+1; ++i )
 	{
-		AudioEngineWorkerThread * wt = new AudioEngineWorkerThread( this );
+		auto* wt = new AudioEngineWorkerThread(this);
 		if( i < m_numWorkers )
 		{
 			wt->start( QThread::TimeCriticalPriority );
@@ -315,7 +315,7 @@ void AudioEngine::pushInputFrames( sampleFrame * _ab, const f_cnt_t _frames )
 	if( frames + _frames > size )
 	{
 		size = qMax( size * 2, frames + _frames );
-		sampleFrame * ab = new sampleFrame[ size ];
+		auto* ab = new sampleFrame[size];
 		memcpy( ab, buf, frames * sizeof( sampleFrame ) );
 		delete [] buf;
 
@@ -1113,7 +1113,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_ALSA
 	if( client_name == MidiAlsaSeq::name() || client_name == "" )
 	{
-		MidiAlsaSeq * malsas = new MidiAlsaSeq;
+		auto* malsas = new MidiAlsaSeq;
 		if( malsas->isRunning() )
 		{
 			m_midiClientName = MidiAlsaSeq::name();
@@ -1124,7 +1124,7 @@ MidiClient * AudioEngine::tryMidiClients()
 
 	if( client_name == MidiAlsaRaw::name() || client_name == "" )
 	{
-		MidiAlsaRaw * malsar = new MidiAlsaRaw;
+		auto* malsar = new MidiAlsaRaw;
 		if( malsar->isRunning() )
 		{
 			m_midiClientName = MidiAlsaRaw::name();
@@ -1137,7 +1137,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_JACK
 	if( client_name == MidiJack::name() || client_name == "" )
 	{
-		MidiJack * mjack = new MidiJack;
+		auto* mjack = new MidiJack;
 		if( mjack->isRunning() )
 		{
 			m_midiClientName = MidiJack::name();
@@ -1150,7 +1150,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_OSS
 	if( client_name == MidiOss::name() || client_name == "" )
 	{
-		MidiOss * moss = new MidiOss;
+		auto* moss = new MidiOss;
 		if( moss->isRunning() )
 		{
 			m_midiClientName = MidiOss::name();
@@ -1261,7 +1261,7 @@ void AudioEngine::fifoWriter::run()
 	const fpp_t frames = m_audioEngine->framesPerPeriod();
 	while( m_writing )
 	{
-		surroundSampleFrame * buffer = new surroundSampleFrame[frames];
+		auto* buffer = new surroundSampleFrame[frames];
 		const surroundSampleFrame * b = m_audioEngine->renderNextBuffer();
 		memcpy( buffer, b, frames * sizeof( surroundSampleFrame ) );
 		write( buffer );

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -148,7 +148,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 	for( int i = 0; i < m_numWorkers+1; ++i )
 	{
-		auto* wt = new AudioEngineWorkerThread(this);
+		AudioEngineWorkerThread * wt = new AudioEngineWorkerThread( this );
 		if( i < m_numWorkers )
 		{
 			wt->start( QThread::TimeCriticalPriority );
@@ -315,7 +315,7 @@ void AudioEngine::pushInputFrames( sampleFrame * _ab, const f_cnt_t _frames )
 	if( frames + _frames > size )
 	{
 		size = qMax( size * 2, frames + _frames );
-		auto* ab = new sampleFrame[size];
+		sampleFrame * ab = new sampleFrame[ size ];
 		memcpy( ab, buf, frames * sizeof( sampleFrame ) );
 		delete [] buf;
 
@@ -1113,7 +1113,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_ALSA
 	if( client_name == MidiAlsaSeq::name() || client_name == "" )
 	{
-		auto* malsas = new MidiAlsaSeq;
+		MidiAlsaSeq * malsas = new MidiAlsaSeq;
 		if( malsas->isRunning() )
 		{
 			m_midiClientName = MidiAlsaSeq::name();
@@ -1124,7 +1124,7 @@ MidiClient * AudioEngine::tryMidiClients()
 
 	if( client_name == MidiAlsaRaw::name() || client_name == "" )
 	{
-		auto* malsar = new MidiAlsaRaw;
+		MidiAlsaRaw * malsar = new MidiAlsaRaw;
 		if( malsar->isRunning() )
 		{
 			m_midiClientName = MidiAlsaRaw::name();
@@ -1137,7 +1137,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_JACK
 	if( client_name == MidiJack::name() || client_name == "" )
 	{
-		auto* mjack = new MidiJack;
+		MidiJack * mjack = new MidiJack;
 		if( mjack->isRunning() )
 		{
 			m_midiClientName = MidiJack::name();
@@ -1150,7 +1150,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_OSS
 	if( client_name == MidiOss::name() || client_name == "" )
 	{
-		auto* moss = new MidiOss;
+		MidiOss * moss = new MidiOss;
 		if( moss->isRunning() )
 		{
 			m_midiClientName = MidiOss::name();
@@ -1261,7 +1261,7 @@ void AudioEngine::fifoWriter::run()
 	const fpp_t frames = m_audioEngine->framesPerPeriod();
 	while( m_writing )
 	{
-		auto* buffer = new surroundSampleFrame[frames];
+		surroundSampleFrame * buffer = new surroundSampleFrame[frames];
 		const surroundSampleFrame * b = m_audioEngine->renderNextBuffer();
 		memcpy( buffer, b, frames * sizeof( surroundSampleFrame ) );
 		write( buffer );

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -148,7 +148,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 	for( int i = 0; i < m_numWorkers+1; ++i )
 	{
-		AudioEngineWorkerThread * wt = new AudioEngineWorkerThread( this );
+		auto wt = new AudioEngineWorkerThread(this);
 		if( i < m_numWorkers )
 		{
 			wt->start( QThread::TimeCriticalPriority );
@@ -315,7 +315,7 @@ void AudioEngine::pushInputFrames( sampleFrame * _ab, const f_cnt_t _frames )
 	if( frames + _frames > size )
 	{
 		size = qMax( size * 2, frames + _frames );
-		sampleFrame * ab = new sampleFrame[ size ];
+		auto ab = new sampleFrame[size];
 		memcpy( ab, buf, frames * sizeof( sampleFrame ) );
 		delete [] buf;
 
@@ -1113,7 +1113,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_ALSA
 	if( client_name == MidiAlsaSeq::name() || client_name == "" )
 	{
-		MidiAlsaSeq * malsas = new MidiAlsaSeq;
+		auto malsas = new MidiAlsaSeq;
 		if( malsas->isRunning() )
 		{
 			m_midiClientName = MidiAlsaSeq::name();
@@ -1124,7 +1124,7 @@ MidiClient * AudioEngine::tryMidiClients()
 
 	if( client_name == MidiAlsaRaw::name() || client_name == "" )
 	{
-		MidiAlsaRaw * malsar = new MidiAlsaRaw;
+		auto malsar = new MidiAlsaRaw;
 		if( malsar->isRunning() )
 		{
 			m_midiClientName = MidiAlsaRaw::name();
@@ -1137,7 +1137,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_JACK
 	if( client_name == MidiJack::name() || client_name == "" )
 	{
-		MidiJack * mjack = new MidiJack;
+		auto mjack = new MidiJack;
 		if( mjack->isRunning() )
 		{
 			m_midiClientName = MidiJack::name();
@@ -1150,7 +1150,7 @@ MidiClient * AudioEngine::tryMidiClients()
 #ifdef LMMS_HAVE_OSS
 	if( client_name == MidiOss::name() || client_name == "" )
 	{
-		MidiOss * moss = new MidiOss;
+		auto moss = new MidiOss;
 		if( moss->isRunning() )
 		{
 			m_midiClientName = MidiOss::name();
@@ -1261,7 +1261,7 @@ void AudioEngine::fifoWriter::run()
 	const fpp_t frames = m_audioEngine->framesPerPeriod();
 	while( m_writing )
 	{
-		surroundSampleFrame * buffer = new surroundSampleFrame[frames];
+		auto buffer = new surroundSampleFrame[frames];
 		const surroundSampleFrame * b = m_audioEngine->renderNextBuffer();
 		memcpy( buffer, b, frames * sizeof( surroundSampleFrame ) );
 		write( buffer );

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -801,7 +801,7 @@ float FloatModel::getRoundedValue() const
 
 int FloatModel::getDigitCount() const
 {
-	auto steptemp = step<float>();
+	float steptemp = step<float>();
 	int digits = 0;
 	while ( steptemp < 1 )
 	{

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -801,7 +801,7 @@ float FloatModel::getRoundedValue() const
 
 int FloatModel::getDigitCount() const
 {
-	float steptemp = step<float>();
+	auto steptemp = step<float>();
 	int digits = 0;
 	while ( steptemp < 1 )
 	{

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -211,7 +211,7 @@ TimePos AutomationClip::timeMapLength() const
 	if (m_timeMap.isEmpty()) { return one_bar; }
 
 	timeMap::const_iterator it = m_timeMap.end();
-	tick_t last_tick = static_cast<tick_t>(POS(it - 1));
+	auto last_tick = static_cast<tick_t>(POS(it - 1));
 	// if last_tick is 0 (single item at tick 0)
 	// return length as a whole bar to prevent disappearing Clip
 	if (last_tick == 0) { return one_bar; }
@@ -374,8 +374,8 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	TimePos start = TimePos(qMin(tick0, tick1));
-	TimePos end = TimePos(qMax(tick0, tick1));
+	auto start = TimePos(qMin(tick0, tick1));
+	auto end = TimePos(qMax(tick0, tick1));
 
 	// Make a list of TimePos with nodes to be removed
 	// because we can't simply remove the nodes from
@@ -410,8 +410,8 @@ void AutomationClip::resetNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	TimePos start = TimePos(qMin(tick0, tick1));
-	TimePos end = TimePos(qMax(tick0, tick1));
+	auto start = TimePos(qMin(tick0, tick1));
+	auto end = TimePos(qMax(tick0, tick1));
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)
 	{
@@ -610,7 +610,7 @@ float *AutomationClip::valuesAfter( const TimePos & _time ) const
 	}
 
 	int numValues = POS(v + 1) - POS(v);
-	float *ret = new float[numValues];
+	auto* ret = new float[numValues];
 
 	for( int i = 0; i < numValues; i++ )
 	{
@@ -698,7 +698,7 @@ void AutomationClip::flipX(int length)
 				// We swap the inValue and outValue when flipping horizontally
 				tempValue = OUTVAL(it);
 				tempOutValue = INVAL(it);
-				TimePos newTime = TimePos(length - POS(it));
+				auto newTime = TimePos(length - POS(it));
 
 				tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
@@ -740,7 +740,7 @@ void AutomationClip::flipX(int length)
 			tempValue = OUTVAL(it);
 			tempOutValue = INVAL(it);
 
-			TimePos newTime = TimePos(realLength - POS(it));
+			auto newTime = TimePos(realLength - POS(it));
 			tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
 			++it;
@@ -903,7 +903,7 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
 			const Track::clipVector & v = ( *it )->getClips();
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				const AutomationClip * a = dynamic_cast<const AutomationClip *>( *j );
+				const auto* a = dynamic_cast<const AutomationClip*>(*j);
 				if( a && a->hasAutomation() )
 				{
 					for( objectVector::const_iterator k = a->m_objects.begin(); k != a->m_objects.end(); ++k )
@@ -945,7 +945,7 @@ QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel 
 			// go through all the clips...
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+				auto* a = dynamic_cast<AutomationClip*>(*j);
 				// check that the clip has automation
 				if( a && a->hasAutomation() )
 				{
@@ -977,7 +977,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 	Track::clipVector v = t->getClips();
 	for( Track::clipVector::const_iterator j = v.begin(); j != v.end(); ++j )
 	{
-		AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+		auto* a = dynamic_cast<AutomationClip*>(*j);
 		if( a )
 		{
 			for( objectVector::const_iterator k = a->m_objects.begin();
@@ -991,7 +991,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 		}
 	}
 
-	AutomationClip * a = new AutomationClip( t );
+	auto* a = new AutomationClip(t);
 	a->addObject( _m, false );
 	return a;
 }
@@ -1014,7 +1014,7 @@ void AutomationClip::resolveAllIDs()
 			for( Track::clipVector::iterator j = v.begin();
 							j != v.end(); ++j )
 			{
-				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+				auto* a = dynamic_cast<AutomationClip*>(*j);
 				if( a )
 				{
 					for( QVector<jo_id_t>::Iterator k = a->m_idsToResolve.begin();

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -211,7 +211,7 @@ TimePos AutomationClip::timeMapLength() const
 	if (m_timeMap.isEmpty()) { return one_bar; }
 
 	timeMap::const_iterator it = m_timeMap.end();
-	tick_t last_tick = static_cast<tick_t>(POS(it - 1));
+	auto last_tick = static_cast<tick_t>(POS(it - 1));
 	// if last_tick is 0 (single item at tick 0)
 	// return length as a whole bar to prevent disappearing Clip
 	if (last_tick == 0) { return one_bar; }
@@ -374,8 +374,8 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	TimePos start = TimePos(qMin(tick0, tick1));
-	TimePos end = TimePos(qMax(tick0, tick1));
+	auto start = TimePos(qMin(tick0, tick1));
+	auto end = TimePos(qMax(tick0, tick1));
 
 	// Make a list of TimePos with nodes to be removed
 	// because we can't simply remove the nodes from
@@ -410,8 +410,8 @@ void AutomationClip::resetNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	TimePos start = TimePos(qMin(tick0, tick1));
-	TimePos end = TimePos(qMax(tick0, tick1));
+	auto start = TimePos(qMin(tick0, tick1));
+	auto end = TimePos(qMax(tick0, tick1));
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)
 	{
@@ -610,7 +610,7 @@ float *AutomationClip::valuesAfter( const TimePos & _time ) const
 	}
 
 	int numValues = POS(v + 1) - POS(v);
-	float *ret = new float[numValues];
+	auto ret = new float[numValues];
 
 	for( int i = 0; i < numValues; i++ )
 	{
@@ -698,7 +698,7 @@ void AutomationClip::flipX(int length)
 				// We swap the inValue and outValue when flipping horizontally
 				tempValue = OUTVAL(it);
 				tempOutValue = INVAL(it);
-				TimePos newTime = TimePos(length - POS(it));
+				auto newTime = TimePos(length - POS(it));
 
 				tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
@@ -740,7 +740,7 @@ void AutomationClip::flipX(int length)
 			tempValue = OUTVAL(it);
 			tempOutValue = INVAL(it);
 
-			TimePos newTime = TimePos(realLength - POS(it));
+			auto newTime = TimePos(realLength - POS(it));
 			tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
 			++it;
@@ -903,7 +903,7 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
 			const Track::clipVector & v = ( *it )->getClips();
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				const AutomationClip * a = dynamic_cast<const AutomationClip *>( *j );
+				const auto a = dynamic_cast<const AutomationClip*>(*j);
 				if( a && a->hasAutomation() )
 				{
 					for( objectVector::const_iterator k = a->m_objects.begin(); k != a->m_objects.end(); ++k )
@@ -945,7 +945,7 @@ QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel 
 			// go through all the clips...
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+				auto a = dynamic_cast<AutomationClip*>(*j);
 				// check that the clip has automation
 				if( a && a->hasAutomation() )
 				{
@@ -977,7 +977,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 	Track::clipVector v = t->getClips();
 	for( Track::clipVector::const_iterator j = v.begin(); j != v.end(); ++j )
 	{
-		AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+		auto a = dynamic_cast<AutomationClip*>(*j);
 		if( a )
 		{
 			for( objectVector::const_iterator k = a->m_objects.begin();
@@ -991,7 +991,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 		}
 	}
 
-	AutomationClip * a = new AutomationClip( t );
+	auto a = new AutomationClip(t);
 	a->addObject( _m, false );
 	return a;
 }
@@ -1014,7 +1014,7 @@ void AutomationClip::resolveAllIDs()
 			for( Track::clipVector::iterator j = v.begin();
 							j != v.end(); ++j )
 			{
-				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
+				auto a = dynamic_cast<AutomationClip*>(*j);
 				if( a )
 				{
 					for( QVector<jo_id_t>::Iterator k = a->m_idsToResolve.begin();

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -211,7 +211,7 @@ TimePos AutomationClip::timeMapLength() const
 	if (m_timeMap.isEmpty()) { return one_bar; }
 
 	timeMap::const_iterator it = m_timeMap.end();
-	auto last_tick = static_cast<tick_t>(POS(it - 1));
+	tick_t last_tick = static_cast<tick_t>(POS(it - 1));
 	// if last_tick is 0 (single item at tick 0)
 	// return length as a whole bar to prevent disappearing Clip
 	if (last_tick == 0) { return one_bar; }
@@ -374,8 +374,8 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	auto start = TimePos(qMin(tick0, tick1));
-	auto end = TimePos(qMax(tick0, tick1));
+	TimePos start = TimePos(qMin(tick0, tick1));
+	TimePos end = TimePos(qMax(tick0, tick1));
 
 	// Make a list of TimePos with nodes to be removed
 	// because we can't simply remove the nodes from
@@ -410,8 +410,8 @@ void AutomationClip::resetNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	auto start = TimePos(qMin(tick0, tick1));
-	auto end = TimePos(qMax(tick0, tick1));
+	TimePos start = TimePos(qMin(tick0, tick1));
+	TimePos end = TimePos(qMax(tick0, tick1));
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)
 	{
@@ -610,7 +610,7 @@ float *AutomationClip::valuesAfter( const TimePos & _time ) const
 	}
 
 	int numValues = POS(v + 1) - POS(v);
-	auto* ret = new float[numValues];
+	float *ret = new float[numValues];
 
 	for( int i = 0; i < numValues; i++ )
 	{
@@ -698,7 +698,7 @@ void AutomationClip::flipX(int length)
 				// We swap the inValue and outValue when flipping horizontally
 				tempValue = OUTVAL(it);
 				tempOutValue = INVAL(it);
-				auto newTime = TimePos(length - POS(it));
+				TimePos newTime = TimePos(length - POS(it));
 
 				tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
@@ -740,7 +740,7 @@ void AutomationClip::flipX(int length)
 			tempValue = OUTVAL(it);
 			tempOutValue = INVAL(it);
 
-			auto newTime = TimePos(realLength - POS(it));
+			TimePos newTime = TimePos(realLength - POS(it));
 			tempMap[newTime] = AutomationNode(this, tempValue, tempOutValue, newTime);
 
 			++it;
@@ -903,7 +903,7 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
 			const Track::clipVector & v = ( *it )->getClips();
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				const auto* a = dynamic_cast<const AutomationClip*>(*j);
+				const AutomationClip * a = dynamic_cast<const AutomationClip *>( *j );
 				if( a && a->hasAutomation() )
 				{
 					for( objectVector::const_iterator k = a->m_objects.begin(); k != a->m_objects.end(); ++k )
@@ -945,7 +945,7 @@ QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel 
 			// go through all the clips...
 			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
 			{
-				auto* a = dynamic_cast<AutomationClip*>(*j);
+				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
 				// check that the clip has automation
 				if( a && a->hasAutomation() )
 				{
@@ -977,7 +977,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 	Track::clipVector v = t->getClips();
 	for( Track::clipVector::const_iterator j = v.begin(); j != v.end(); ++j )
 	{
-		auto* a = dynamic_cast<AutomationClip*>(*j);
+		AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
 		if( a )
 		{
 			for( objectVector::const_iterator k = a->m_objects.begin();
@@ -991,7 +991,7 @@ AutomationClip * AutomationClip::globalAutomationClip(
 		}
 	}
 
-	auto* a = new AutomationClip(t);
+	AutomationClip * a = new AutomationClip( t );
 	a->addObject( _m, false );
 	return a;
 }
@@ -1014,7 +1014,7 @@ void AutomationClip::resolveAllIDs()
 			for( Track::clipVector::iterator j = v.begin();
 							j != v.end(); ++j )
 			{
-				auto* a = dynamic_cast<AutomationClip*>(*j);
+				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
 				if( a )
 				{
 					for( QVector<jo_id_t>::Iterator k = a->m_idsToResolve.begin();

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -50,7 +50,7 @@ namespace lmms::Clipboard
 
 	void copyString( const QString & str, MimeType mT )
 	{
-		auto* content = new QMimeData;
+		QMimeData *content = new QMimeData;
 
 		content->setData( mimeType( mT ), str.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
@@ -71,7 +71,7 @@ namespace lmms::Clipboard
 	{
 		QString finalString = key + ":" + value;
 
-		auto* content = new QMimeData;
+		QMimeData *content = new QMimeData;
 		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
 	}

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -50,7 +50,7 @@ namespace lmms::Clipboard
 
 	void copyString( const QString & str, MimeType mT )
 	{
-		QMimeData *content = new QMimeData;
+		auto* content = new QMimeData;
 
 		content->setData( mimeType( mT ), str.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
@@ -71,7 +71,7 @@ namespace lmms::Clipboard
 	{
 		QString finalString = key + ":" + value;
 
-		QMimeData *content = new QMimeData;
+		auto* content = new QMimeData;
 		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
 	}

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -50,7 +50,7 @@ namespace lmms::Clipboard
 
 	void copyString( const QString & str, MimeType mT )
 	{
-		QMimeData *content = new QMimeData;
+		auto content = new QMimeData;
 
 		content->setData( mimeType( mT ), str.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
@@ -71,7 +71,7 @@ namespace lmms::Clipboard
 	{
 		QString finalString = key + ":" + value;
 
-		QMimeData *content = new QMimeData;
+		auto content = new QMimeData;
 		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );
 		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
 	}

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -246,7 +246,7 @@ bool Controller::hasModel( const Model * m ) const
 {
 	for (QObject * c : children())
 	{
-		AutomatableModel * am = qobject_cast<AutomatableModel*>(c);
+		auto* am = qobject_cast<AutomatableModel*>(c);
 		if( am != nullptr )
 		{
 			if( am == m )
@@ -296,7 +296,7 @@ QString Controller::nodeName() const
 
 gui::ControllerDialog * Controller::createDialog( QWidget * _parent )
 {
-	gui::ControllerDialog * d = new gui::ControllerDialog( this, _parent );
+	auto* d = new gui::ControllerDialog(this, _parent);
 
 	return d;
 }

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -246,7 +246,7 @@ bool Controller::hasModel( const Model * m ) const
 {
 	for (QObject * c : children())
 	{
-		auto* am = qobject_cast<AutomatableModel*>(c);
+		AutomatableModel * am = qobject_cast<AutomatableModel*>(c);
 		if( am != nullptr )
 		{
 			if( am == m )
@@ -296,7 +296,7 @@ QString Controller::nodeName() const
 
 gui::ControllerDialog * Controller::createDialog( QWidget * _parent )
 {
-	auto* d = new gui::ControllerDialog(this, _parent);
+	gui::ControllerDialog * d = new gui::ControllerDialog( this, _parent );
 
 	return d;
 }

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -246,7 +246,7 @@ bool Controller::hasModel( const Model * m ) const
 {
 	for (QObject * c : children())
 	{
-		AutomatableModel * am = qobject_cast<AutomatableModel*>(c);
+		auto am = qobject_cast<AutomatableModel*>(c);
 		if( am != nullptr )
 		{
 			if( am == m )
@@ -296,7 +296,7 @@ QString Controller::nodeName() const
 
 gui::ControllerDialog * Controller::createDialog( QWidget * _parent )
 {
-	gui::ControllerDialog * d = new gui::ControllerDialog( this, _parent );
+	auto d = new gui::ControllerDialog(this, _parent);
 
 	return d;
 }

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -427,7 +427,7 @@ bool DataFile::copyResources(const QString& resourcesDir)
 	// repeating filenames
 	std::list<QString> namesList;
 
-	auto it = ELEMENTS_WITH_RESOURCES.begin();
+	ResourcesMap::const_iterator it = ELEMENTS_WITH_RESOURCES.begin();
 
 	// Copy resources and manipulate the DataFile to have local paths to them
 	while (it != ELEMENTS_WITH_RESOURCES.end())
@@ -439,7 +439,7 @@ bool DataFile::copyResources(const QString& resourcesDir)
 		{
 			QDomElement el = list.item(i).toElement();
 
-			auto res = it->second.begin();
+			std::vector<QString>::const_iterator res = it->second.begin();
 
 			// Search for attributes that point to resources
 			while (res != it->second.end())
@@ -533,7 +533,12 @@ bool DataFile::hasLocalPlugins(QDomElement parent /* = QDomElement()*/, bool fir
 		bool skipNode = false;
 		// Skip the nodes allowed to have "local:" attributes, but
 		// still check its children
-		for (auto it = ELEMENTS_WITH_RESOURCES.begin(); it != ELEMENTS_WITH_RESOURCES.end(); ++it)
+		for
+		(
+			ResourcesMap::const_iterator it = ELEMENTS_WITH_RESOURCES.begin();
+			it != ELEMENTS_WITH_RESOURCES.end();
+			++it
+		)
 		{
 			if (childElement.tagName() == it->first)
 			{

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -427,7 +427,7 @@ bool DataFile::copyResources(const QString& resourcesDir)
 	// repeating filenames
 	std::list<QString> namesList;
 
-	ResourcesMap::const_iterator it = ELEMENTS_WITH_RESOURCES.begin();
+	auto it = ELEMENTS_WITH_RESOURCES.begin();
 
 	// Copy resources and manipulate the DataFile to have local paths to them
 	while (it != ELEMENTS_WITH_RESOURCES.end())
@@ -439,7 +439,7 @@ bool DataFile::copyResources(const QString& resourcesDir)
 		{
 			QDomElement el = list.item(i).toElement();
 
-			std::vector<QString>::const_iterator res = it->second.begin();
+			auto res = it->second.begin();
 
 			// Search for attributes that point to resources
 			while (res != it->second.end())
@@ -533,12 +533,7 @@ bool DataFile::hasLocalPlugins(QDomElement parent /* = QDomElement()*/, bool fir
 		bool skipNode = false;
 		// Skip the nodes allowed to have "local:" attributes, but
 		// still check its children
-		for
-		(
-			ResourcesMap::const_iterator it = ELEMENTS_WITH_RESOURCES.begin();
-			it != ELEMENTS_WITH_RESOURCES.end();
-			++it
-		)
+		for (auto it = ELEMENTS_WITH_RESOURCES.begin(); it != ELEMENTS_WITH_RESOURCES.end(); ++it)
 		{
 			if (childElement.tagName() == it->first)
 			{

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -124,7 +124,7 @@ Effect * Effect::instantiate( const QString& pluginName,
 	if( dynamic_cast<Effect *>( p ) != nullptr )
 	{
 		// everything ok, so return pointer
-		Effect * effect = dynamic_cast<Effect *>( p );
+		auto* effect = dynamic_cast<Effect*>(p);
 		effect->m_parent = dynamic_cast<EffectChain *>(_parent);
 		return effect;
 	}

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -124,7 +124,7 @@ Effect * Effect::instantiate( const QString& pluginName,
 	if( dynamic_cast<Effect *>( p ) != nullptr )
 	{
 		// everything ok, so return pointer
-		auto* effect = dynamic_cast<Effect*>(p);
+		Effect * effect = dynamic_cast<Effect *>( p );
 		effect->m_parent = dynamic_cast<EffectChain *>(_parent);
 		return effect;
 	}

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -124,7 +124,7 @@ Effect * Effect::instantiate( const QString& pluginName,
 	if( dynamic_cast<Effect *>( p ) != nullptr )
 	{
 		// everything ok, so return pointer
-		Effect * effect = dynamic_cast<Effect *>( p );
+		auto effect = dynamic_cast<Effect*>(p);
 		effect->m_parent = dynamic_cast<EffectChain *>(_parent);
 		return effect;
 	}

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -60,10 +60,7 @@ void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 	for( Effect* effect : m_effects)
 	{
-		if( DummyEffect* dummy = dynamic_cast<DummyEffect*>(effect) )
-		{
-			_this.appendChild( dummy->originalPluginData() );
-		}
+		if (auto dummy = dynamic_cast<DummyEffect*>(effect)) { _this.appendChild(dummy->originalPluginData()); }
 		else
 		{
 			QDomElement ef = effect->saveState( _doc, _this );

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -60,10 +60,7 @@ void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 	for( Effect* effect : m_effects)
 	{
-		if( DummyEffect* dummy = dynamic_cast<DummyEffect*>(effect) )
-		{
-			_this.appendChild( dummy->originalPluginData() );
-		}
+		if (auto* dummy = dynamic_cast<DummyEffect*>(effect)) { _this.appendChild(dummy->originalPluginData()); }
 		else
 		{
 			QDomElement ef = effect->saveState( _doc, _this );

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -60,7 +60,10 @@ void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 	for( Effect* effect : m_effects)
 	{
-		if (auto* dummy = dynamic_cast<DummyEffect*>(effect)) { _this.appendChild(dummy->originalPluginData()); }
+		if( DummyEffect* dummy = dynamic_cast<DummyEffect*>(effect) )
+		{
+			_this.appendChild( dummy->originalPluginData() );
+		}
 		else
 		{
 			QDomElement ef = effect->saveState( _doc, _this );

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -404,13 +404,16 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 				Engine::audioEngine()->processingSampleRate();
 
 	// TODO: Remove the expKnobVals, time should be linear
-	const auto predelay_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_predelayModel.value()));
+	const f_cnt_t predelay_frames = static_cast<f_cnt_t>(
+							frames_per_env_seg *
+					expKnobVal( m_predelayModel.value() ) );
 
 	const f_cnt_t attack_frames = qMax( minimumFrames,
 					static_cast<f_cnt_t>( frames_per_env_seg *
 					expKnobVal( m_attackModel.value() ) ) );
 
-	const auto hold_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_holdModel.value()));
+	const f_cnt_t hold_frames = static_cast<f_cnt_t>( frames_per_env_seg *
+					expKnobVal( m_holdModel.value() ) );
 
 	const f_cnt_t decay_frames = qMax( minimumFrames,
 					static_cast<f_cnt_t>( frames_per_env_seg *

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -404,16 +404,13 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 				Engine::audioEngine()->processingSampleRate();
 
 	// TODO: Remove the expKnobVals, time should be linear
-	const f_cnt_t predelay_frames = static_cast<f_cnt_t>(
-							frames_per_env_seg *
-					expKnobVal( m_predelayModel.value() ) );
+	const auto predelay_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_predelayModel.value()));
 
 	const f_cnt_t attack_frames = qMax( minimumFrames,
 					static_cast<f_cnt_t>( frames_per_env_seg *
 					expKnobVal( m_attackModel.value() ) ) );
 
-	const f_cnt_t hold_frames = static_cast<f_cnt_t>( frames_per_env_seg *
-					expKnobVal( m_holdModel.value() ) );
+	const auto hold_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_holdModel.value()));
 
 	const f_cnt_t decay_frames = qMax( minimumFrames,
 					static_cast<f_cnt_t>( frames_per_env_seg *

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -368,8 +368,8 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played
-	const auto arp_frames = (f_cnt_t)(m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->processingSampleRate());
-	const auto gated_frames = (f_cnt_t)(m_arpGateModel.value() * arp_frames / 100.0f);
+	const f_cnt_t arp_frames = (f_cnt_t)( m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->processingSampleRate() );
+	const f_cnt_t gated_frames = (f_cnt_t)( m_arpGateModel.value() * arp_frames / 100.0f );
 
 	// used for calculating remaining frames for arp-note, we have to add
 	// arp_frames-1, otherwise the first arp-note will not be setup

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -368,8 +368,8 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played
-	const f_cnt_t arp_frames = (f_cnt_t)( m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->processingSampleRate() );
-	const f_cnt_t gated_frames = (f_cnt_t)( m_arpGateModel.value() * arp_frames / 100.0f );
+	const auto arp_frames = (f_cnt_t)(m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->processingSampleRate());
+	const auto gated_frames = (f_cnt_t)(m_arpGateModel.value() * arp_frames / 100.0f);
 
 	// used for calculating remaining frames for arp-note, we have to add
 	// arp_frames-1, otherwise the first arp-note will not be setup

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -86,9 +86,7 @@ LadspaManager::LadspaManager()
 
 			if( plugin_lib.load() == true )
 			{
-				LADSPA_Descriptor_Function descriptorFunction =
-			( LADSPA_Descriptor_Function ) plugin_lib.resolve(
-							"ladspa_descriptor" );
+				auto descriptorFunction = (LADSPA_Descriptor_Function)plugin_lib.resolve("ladspa_descriptor");
 				if( descriptorFunction != nullptr )
 				{
 					addPlugins( descriptorFunction,
@@ -158,8 +156,7 @@ void LadspaManager::addPlugins(
 			continue;
 		}
 
-		LadspaManagerDescription * plugIn = 
-				new LadspaManagerDescription;
+		auto plugIn = new LadspaManagerDescription;
 		plugIn->descriptorFunction = _descriptor_func;
 		plugIn->index = pluginIndex;
 		plugIn->inputChannels = getPluginInputs( descriptor );

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -86,9 +86,7 @@ LadspaManager::LadspaManager()
 
 			if( plugin_lib.load() == true )
 			{
-				LADSPA_Descriptor_Function descriptorFunction =
-			( LADSPA_Descriptor_Function ) plugin_lib.resolve(
-							"ladspa_descriptor" );
+				auto descriptorFunction = (LADSPA_Descriptor_Function)plugin_lib.resolve("ladspa_descriptor");
 				if( descriptorFunction != nullptr )
 				{
 					addPlugins( descriptorFunction,
@@ -158,8 +156,7 @@ void LadspaManager::addPlugins(
 			continue;
 		}
 
-		LadspaManagerDescription * plugIn = 
-				new LadspaManagerDescription;
+		auto* plugIn = new LadspaManagerDescription;
 		plugIn->descriptorFunction = _descriptor_func;
 		plugIn->index = pluginIndex;
 		plugIn->inputChannels = getPluginInputs( descriptor );

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -86,7 +86,9 @@ LadspaManager::LadspaManager()
 
 			if( plugin_lib.load() == true )
 			{
-				auto descriptorFunction = (LADSPA_Descriptor_Function)plugin_lib.resolve("ladspa_descriptor");
+				LADSPA_Descriptor_Function descriptorFunction =
+			( LADSPA_Descriptor_Function ) plugin_lib.resolve(
+							"ladspa_descriptor" );
 				if( descriptorFunction != nullptr )
 				{
 					addPlugins( descriptorFunction,
@@ -156,7 +158,8 @@ void LadspaManager::addPlugins(
 			continue;
 		}
 
-		auto* plugIn = new LadspaManagerDescription;
+		LadspaManagerDescription * plugIn = 
+				new LadspaManagerDescription;
 		plugIn->descriptorFunction = _descriptor_func;
 		plugIn->index = pluginIndex;
 		plugIn->inputChannels = getPluginInputs( descriptor );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -293,7 +293,7 @@ void Mixer::deleteChannel( int index )
 	{
 		if( t->type() == Track::InstrumentTrack )
 		{
-			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
+			auto* inst = dynamic_cast<InstrumentTrack*>(t);
 			int val = inst->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -309,7 +309,7 @@ void Mixer::deleteChannel( int index )
 		}
 		else if( t->type() == Track::SampleTrack )
 		{
-			SampleTrack* strk = dynamic_cast<SampleTrack *>( t );
+			auto* strk = dynamic_cast<SampleTrack*>(t);
 			int val = strk->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -395,7 +395,7 @@ void Mixer::moveChannelLeft( int index )
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
+				auto* inst = (InstrumentTrack*)trackList[i];
 				int val = inst->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -408,7 +408,7 @@ void Mixer::moveChannelLeft( int index )
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				SampleTrack * strk = (SampleTrack *) trackList[i];
+				auto* strk = (SampleTrack*)trackList[i];
 				int val = strk->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -469,7 +469,7 @@ MixerRoute * Mixer::createRoute( MixerChannel * from, MixerChannel * to, float a
 		return nullptr;
 	}
 	Engine::audioEngine()->requestChangeInModel();
-	MixerRoute * route = new MixerRoute( from, to, amount );
+	auto* route = new MixerRoute(from, to, amount);
 
 	// add us to from's sends
 	from->m_sends.append( route );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -293,7 +293,7 @@ void Mixer::deleteChannel( int index )
 	{
 		if( t->type() == Track::InstrumentTrack )
 		{
-			auto* inst = dynamic_cast<InstrumentTrack*>(t);
+			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
 			int val = inst->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -309,7 +309,7 @@ void Mixer::deleteChannel( int index )
 		}
 		else if( t->type() == Track::SampleTrack )
 		{
-			auto* strk = dynamic_cast<SampleTrack*>(t);
+			SampleTrack* strk = dynamic_cast<SampleTrack *>( t );
 			int val = strk->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -395,7 +395,7 @@ void Mixer::moveChannelLeft( int index )
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				auto* inst = (InstrumentTrack*)trackList[i];
+				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
 				int val = inst->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -408,7 +408,7 @@ void Mixer::moveChannelLeft( int index )
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				auto* strk = (SampleTrack*)trackList[i];
+				SampleTrack * strk = (SampleTrack *) trackList[i];
 				int val = strk->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -469,7 +469,7 @@ MixerRoute * Mixer::createRoute( MixerChannel * from, MixerChannel * to, float a
 		return nullptr;
 	}
 	Engine::audioEngine()->requestChangeInModel();
-	auto* route = new MixerRoute(from, to, amount);
+	MixerRoute * route = new MixerRoute( from, to, amount );
 
 	// add us to from's sends
 	from->m_sends.append( route );

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -293,7 +293,7 @@ void Mixer::deleteChannel( int index )
 	{
 		if( t->type() == Track::InstrumentTrack )
 		{
-			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>( t );
+			auto inst = dynamic_cast<InstrumentTrack*>(t);
 			int val = inst->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -309,7 +309,7 @@ void Mixer::deleteChannel( int index )
 		}
 		else if( t->type() == Track::SampleTrack )
 		{
-			SampleTrack* strk = dynamic_cast<SampleTrack *>( t );
+			auto strk = dynamic_cast<SampleTrack*>(t);
 			int val = strk->mixerChannelModel()->value(0);
 			if( val == index )
 			{
@@ -395,7 +395,7 @@ void Mixer::moveChannelLeft( int index )
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
+				auto inst = (InstrumentTrack*)trackList[i];
 				int val = inst->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -408,7 +408,7 @@ void Mixer::moveChannelLeft( int index )
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				SampleTrack * strk = (SampleTrack *) trackList[i];
+				auto strk = (SampleTrack*)trackList[i];
 				int val = strk->mixerChannelModel()->value(0);
 				if( val == a )
 				{
@@ -469,7 +469,7 @@ MixerRoute * Mixer::createRoute( MixerChannel * from, MixerChannel * to, float a
 		return nullptr;
 	}
 	Engine::audioEngine()->requestChangeInModel();
-	MixerRoute * route = new MixerRoute( from, to, amount );
+	auto route = new MixerRoute(from, to, amount);
 
 	// add us to from's sends
 	from->m_sends.append( route );

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -459,7 +459,7 @@ int NotePlayHandle::index() const
 	int idx = 0;
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const auto* nph = dynamic_cast<const NotePlayHandle*>(*it);
+		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
 		if( nph == nullptr || nph->m_instrumentTrack != m_instrumentTrack || nph->isReleased() || nph->hasParent() )
 		{
 			continue;
@@ -483,7 +483,7 @@ ConstNotePlayHandleList NotePlayHandle::nphsOfInstrumentTrack( const InstrumentT
 
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const auto* nph = dynamic_cast<const NotePlayHandle*>(*it);
+		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
 		if( nph != nullptr && nph->m_instrumentTrack == _it && ( ( nph->isReleased() == false && nph->hasParent() == false ) || _all_ph == true ) )
 		{
 			cnphv.push_back( nph );
@@ -606,7 +606,7 @@ void NotePlayHandleManager::init()
 {
 	s_available = MM_ALLOC<NotePlayHandle*>( INITIAL_NPH_CACHE );
 
-	auto* n = MM_ALLOC<NotePlayHandle>(INITIAL_NPH_CACHE);
+	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( INITIAL_NPH_CACHE );
 
 	for( int i=0; i < INITIAL_NPH_CACHE; ++i )
 	{
@@ -649,11 +649,11 @@ void NotePlayHandleManager::release( NotePlayHandle * nph )
 void NotePlayHandleManager::extend( int c )
 {
 	s_size += c;
-	auto** tmp = MM_ALLOC<NotePlayHandle*>(s_size);
+	NotePlayHandle ** tmp = MM_ALLOC<NotePlayHandle*>( s_size );
 	MM_FREE( s_available );
 	s_available = tmp;
 
-	auto* n = MM_ALLOC<NotePlayHandle>(c);
+	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( c );
 
 	for( int i=0; i < c; ++i )
 	{

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -459,7 +459,7 @@ int NotePlayHandle::index() const
 	int idx = 0;
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
+		const auto nph = dynamic_cast<const NotePlayHandle*>(*it);
 		if( nph == nullptr || nph->m_instrumentTrack != m_instrumentTrack || nph->isReleased() || nph->hasParent() )
 		{
 			continue;
@@ -483,7 +483,7 @@ ConstNotePlayHandleList NotePlayHandle::nphsOfInstrumentTrack( const InstrumentT
 
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
+		const auto nph = dynamic_cast<const NotePlayHandle*>(*it);
 		if( nph != nullptr && nph->m_instrumentTrack == _it && ( ( nph->isReleased() == false && nph->hasParent() == false ) || _all_ph == true ) )
 		{
 			cnphv.push_back( nph );
@@ -606,7 +606,7 @@ void NotePlayHandleManager::init()
 {
 	s_available = MM_ALLOC<NotePlayHandle*>( INITIAL_NPH_CACHE );
 
-	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( INITIAL_NPH_CACHE );
+	auto n = MM_ALLOC<NotePlayHandle>(INITIAL_NPH_CACHE);
 
 	for( int i=0; i < INITIAL_NPH_CACHE; ++i )
 	{
@@ -649,11 +649,11 @@ void NotePlayHandleManager::release( NotePlayHandle * nph )
 void NotePlayHandleManager::extend( int c )
 {
 	s_size += c;
-	NotePlayHandle ** tmp = MM_ALLOC<NotePlayHandle*>( s_size );
+	auto tmp = MM_ALLOC<NotePlayHandle*>(s_size);
 	MM_FREE( s_available );
 	s_available = tmp;
 
-	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( c );
+	auto n = MM_ALLOC<NotePlayHandle>(c);
 
 	for( int i=0; i < c; ++i )
 	{

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -459,7 +459,7 @@ int NotePlayHandle::index() const
 	int idx = 0;
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
+		const auto* nph = dynamic_cast<const NotePlayHandle*>(*it);
 		if( nph == nullptr || nph->m_instrumentTrack != m_instrumentTrack || nph->isReleased() || nph->hasParent() )
 		{
 			continue;
@@ -483,7 +483,7 @@ ConstNotePlayHandleList NotePlayHandle::nphsOfInstrumentTrack( const InstrumentT
 
 	for( PlayHandleList::ConstIterator it = playHandles.begin(); it != playHandles.end(); ++it )
 	{
-		const NotePlayHandle * nph = dynamic_cast<const NotePlayHandle *>( *it );
+		const auto* nph = dynamic_cast<const NotePlayHandle*>(*it);
 		if( nph != nullptr && nph->m_instrumentTrack == _it && ( ( nph->isReleased() == false && nph->hasParent() == false ) || _all_ph == true ) )
 		{
 			cnphv.push_back( nph );
@@ -606,7 +606,7 @@ void NotePlayHandleManager::init()
 {
 	s_available = MM_ALLOC<NotePlayHandle*>( INITIAL_NPH_CACHE );
 
-	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( INITIAL_NPH_CACHE );
+	auto* n = MM_ALLOC<NotePlayHandle>(INITIAL_NPH_CACHE);
 
 	for( int i=0; i < INITIAL_NPH_CACHE; ++i )
 	{
@@ -649,11 +649,11 @@ void NotePlayHandleManager::release( NotePlayHandle * nph )
 void NotePlayHandleManager::extend( int c )
 {
 	s_size += c;
-	NotePlayHandle ** tmp = MM_ALLOC<NotePlayHandle*>( s_size );
+	auto** tmp = MM_ALLOC<NotePlayHandle*>(s_size);
 	MM_FREE( s_available );
 	s_available = tmp;
 
-	NotePlayHandle * n = MM_ALLOC<NotePlayHandle>( c );
+	auto* n = MM_ALLOC<NotePlayHandle>(c);
 
 	for( int i=0; i < c; ++i )
 	{

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -233,7 +233,7 @@ void ProjectRenderer::updateConsoleProgress()
 	}
 	prog[cols] = 0;
 
-	const char * activity = (const char *) "|/-\\";
+	const auto activity = (const char*)"|/-\\";
 	memset( buf, 0, sizeof( buf ) );
 	sprintf( buf, "\r|%s|    %3d%%   %c  ", prog, m_progress,
 							activity[rot] );

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -380,7 +380,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 		}
 		else
 		{
-			sampleFrame * o = (sampleFrame *) m_audioBuffer.get();
+			auto* o = (sampleFrame*)m_audioBuffer.get();
 			for( ch_cnt_t ch = 0; ch < inputs; ++ch )
 			{
 				for( fpp_t frame = 0; frame < frames; ++frame )
@@ -423,8 +423,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 	}
 	else
 	{
-		sampleFrame * o = (sampleFrame *) ( m_audioBuffer.get() +
-							m_inputCount*frames );
+		auto* o = (sampleFrame*)(m_audioBuffer.get() + m_inputCount * frames);
 		// clear buffer, if plugin didn't fill up both channels
 		BufferManager::clear( _out_buf, frames );
 

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -380,7 +380,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 		}
 		else
 		{
-			sampleFrame * o = (sampleFrame *) m_audioBuffer.get();
+			auto o = (sampleFrame*)m_audioBuffer.get();
 			for( ch_cnt_t ch = 0; ch < inputs; ++ch )
 			{
 				for( fpp_t frame = 0; frame < frames; ++frame )
@@ -423,8 +423,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 	}
 	else
 	{
-		sampleFrame * o = (sampleFrame *) ( m_audioBuffer.get() +
-							m_inputCount*frames );
+		auto o = (sampleFrame*)(m_audioBuffer.get() + m_inputCount * frames);
 		// clear buffer, if plugin didn't fill up both channels
 		BufferManager::clear( _out_buf, frames );
 

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -380,7 +380,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 		}
 		else
 		{
-			auto* o = (sampleFrame*)m_audioBuffer.get();
+			sampleFrame * o = (sampleFrame *) m_audioBuffer.get();
 			for( ch_cnt_t ch = 0; ch < inputs; ++ch )
 			{
 				for( fpp_t frame = 0; frame < frames; ++frame )
@@ -423,7 +423,8 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 	}
 	else
 	{
-		auto* o = (sampleFrame*)(m_audioBuffer.get() + m_inputCount * frames);
+		sampleFrame * o = (sampleFrame *) ( m_audioBuffer.get() +
+							m_inputCount*frames );
 		// clear buffer, if plugin didn't fill up both channels
 		BufferManager::clear( _out_buf, frames );
 

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -538,7 +538,7 @@ size_t qfileReadCallback(void * ptr, size_t size, size_t n, void * udata )
 
 int qfileSeekCallback(void * udata, ogg_int64_t offset, int whence)
 {
-	QFile * f = static_cast<QFile *>(udata);
+	auto f = static_cast<QFile*>(udata);
 
 	if (whence == SEEK_CUR)
 	{
@@ -594,7 +594,7 @@ f_cnt_t SampleBuffer::decodeSampleOGGVorbis(
 
 	f_cnt_t frames = 0;
 
-	QFile * f = new QFile(fileName);
+	auto f = new QFile(fileName);
 	if (f->open(QFile::ReadOnly) == false)
 	{
 		delete f;
@@ -727,9 +727,7 @@ bool SampleBuffer::play(
 		m_sampleRate / Engine::audioEngine()->processingSampleRate();
 
 	// calculate how many frames we have in requested pitch
-	const f_cnt_t totalFramesForCurrentPitch = static_cast<f_cnt_t>(
-		(endFrame - startFrame) / freqFactor
-	);
+	const auto totalFramesForCurrentPitch = static_cast<f_cnt_t>((endFrame - startFrame) / freqFactor);
 
 	if (totalFramesForCurrentPitch == 0)
 	{
@@ -1331,8 +1329,8 @@ SampleBuffer * SampleBuffer::resample(const sample_rate_t srcSR, const sample_ra
 {
 	sampleFrame * data = m_data;
 	const f_cnt_t frames = m_frames;
-	const f_cnt_t dstFrames = static_cast<f_cnt_t>((frames / (float) srcSR) * (float) dstSR);
-	SampleBuffer * dstSB = new SampleBuffer(dstFrames);
+	const auto dstFrames = static_cast<f_cnt_t>((frames / (float)srcSR) * (float)dstSR);
+	auto dstSB = new SampleBuffer(dstFrames);
 	sampleFrame * dstBuf = dstSB->m_origData;
 
 	// yeah, libsamplerate, let's rock with sinc-interpolation!

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -538,7 +538,7 @@ size_t qfileReadCallback(void * ptr, size_t size, size_t n, void * udata )
 
 int qfileSeekCallback(void * udata, ogg_int64_t offset, int whence)
 {
-	QFile * f = static_cast<QFile *>(udata);
+	auto* f = static_cast<QFile*>(udata);
 
 	if (whence == SEEK_CUR)
 	{
@@ -594,7 +594,7 @@ f_cnt_t SampleBuffer::decodeSampleOGGVorbis(
 
 	f_cnt_t frames = 0;
 
-	QFile * f = new QFile(fileName);
+	auto* f = new QFile(fileName);
 	if (f->open(QFile::ReadOnly) == false)
 	{
 		delete f;
@@ -727,9 +727,7 @@ bool SampleBuffer::play(
 		m_sampleRate / Engine::audioEngine()->processingSampleRate();
 
 	// calculate how many frames we have in requested pitch
-	const f_cnt_t totalFramesForCurrentPitch = static_cast<f_cnt_t>(
-		(endFrame - startFrame) / freqFactor
-	);
+	const auto totalFramesForCurrentPitch = static_cast<f_cnt_t>((endFrame - startFrame) / freqFactor);
 
 	if (totalFramesForCurrentPitch == 0)
 	{
@@ -1331,8 +1329,8 @@ SampleBuffer * SampleBuffer::resample(const sample_rate_t srcSR, const sample_ra
 {
 	sampleFrame * data = m_data;
 	const f_cnt_t frames = m_frames;
-	const f_cnt_t dstFrames = static_cast<f_cnt_t>((frames / (float) srcSR) * (float) dstSR);
-	SampleBuffer * dstSB = new SampleBuffer(dstFrames);
+	const auto dstFrames = static_cast<f_cnt_t>((frames / (float)srcSR) * (float)dstSR);
+	auto* dstSB = new SampleBuffer(dstFrames);
 	sampleFrame * dstBuf = dstSB->m_origData;
 
 	// yeah, libsamplerate, let's rock with sinc-interpolation!

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -538,7 +538,7 @@ size_t qfileReadCallback(void * ptr, size_t size, size_t n, void * udata )
 
 int qfileSeekCallback(void * udata, ogg_int64_t offset, int whence)
 {
-	auto* f = static_cast<QFile*>(udata);
+	QFile * f = static_cast<QFile *>(udata);
 
 	if (whence == SEEK_CUR)
 	{
@@ -594,7 +594,7 @@ f_cnt_t SampleBuffer::decodeSampleOGGVorbis(
 
 	f_cnt_t frames = 0;
 
-	auto* f = new QFile(fileName);
+	QFile * f = new QFile(fileName);
 	if (f->open(QFile::ReadOnly) == false)
 	{
 		delete f;
@@ -727,7 +727,9 @@ bool SampleBuffer::play(
 		m_sampleRate / Engine::audioEngine()->processingSampleRate();
 
 	// calculate how many frames we have in requested pitch
-	const auto totalFramesForCurrentPitch = static_cast<f_cnt_t>((endFrame - startFrame) / freqFactor);
+	const f_cnt_t totalFramesForCurrentPitch = static_cast<f_cnt_t>(
+		(endFrame - startFrame) / freqFactor
+	);
 
 	if (totalFramesForCurrentPitch == 0)
 	{
@@ -1329,8 +1331,8 @@ SampleBuffer * SampleBuffer::resample(const sample_rate_t srcSR, const sample_ra
 {
 	sampleFrame * data = m_data;
 	const f_cnt_t frames = m_frames;
-	const auto dstFrames = static_cast<f_cnt_t>((frames / (float)srcSR) * (float)dstSR);
-	auto* dstSB = new SampleBuffer(dstFrames);
+	const f_cnt_t dstFrames = static_cast<f_cnt_t>((frames / (float) srcSR) * (float) dstSR);
+	SampleBuffer * dstSB = new SampleBuffer(dstFrames);
 	sampleFrame * dstBuf = dstSB->m_origData;
 
 	// yeah, libsamplerate, let's rock with sinc-interpolation!

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -102,7 +102,7 @@ SampleClip::SampleClip(const SampleClip& orig) :
 
 SampleClip::~SampleClip()
 {
-	auto* sampletrack = dynamic_cast<SampleTrack*>(getTrack());
+	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
 	if ( sampletrack )
 	{
 		sampletrack->updateClips();
@@ -180,7 +180,7 @@ void SampleClip::toggleRecord()
 void SampleClip::playbackPositionChanged()
 {
 	Engine::audioEngine()->removePlayHandlesOfTypes( getTrack(), PlayHandle::TypeSamplePlayHandle );
-	auto* st = dynamic_cast<SampleTrack*>(getTrack());
+	SampleTrack * st = dynamic_cast<SampleTrack*>( getTrack() );
 	st->setPlayingClips( false );
 }
 
@@ -189,7 +189,7 @@ void SampleClip::playbackPositionChanged()
 
 void SampleClip::updateTrackClips()
 {
-	auto* sampletrack = dynamic_cast<SampleTrack*>(getTrack());
+	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
 	if( sampletrack)
 	{
 		sampletrack->updateClips();

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -102,7 +102,7 @@ SampleClip::SampleClip(const SampleClip& orig) :
 
 SampleClip::~SampleClip()
 {
-	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
+	auto sampletrack = dynamic_cast<SampleTrack*>(getTrack());
 	if ( sampletrack )
 	{
 		sampletrack->updateClips();
@@ -180,7 +180,7 @@ void SampleClip::toggleRecord()
 void SampleClip::playbackPositionChanged()
 {
 	Engine::audioEngine()->removePlayHandlesOfTypes( getTrack(), PlayHandle::TypeSamplePlayHandle );
-	SampleTrack * st = dynamic_cast<SampleTrack*>( getTrack() );
+	auto st = dynamic_cast<SampleTrack*>(getTrack());
 	st->setPlayingClips( false );
 }
 
@@ -189,7 +189,7 @@ void SampleClip::playbackPositionChanged()
 
 void SampleClip::updateTrackClips()
 {
-	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
+	auto sampletrack = dynamic_cast<SampleTrack*>(getTrack());
 	if( sampletrack)
 	{
 		sampletrack->updateClips();

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -102,7 +102,7 @@ SampleClip::SampleClip(const SampleClip& orig) :
 
 SampleClip::~SampleClip()
 {
-	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
+	auto* sampletrack = dynamic_cast<SampleTrack*>(getTrack());
 	if ( sampletrack )
 	{
 		sampletrack->updateClips();
@@ -180,7 +180,7 @@ void SampleClip::toggleRecord()
 void SampleClip::playbackPositionChanged()
 {
 	Engine::audioEngine()->removePlayHandlesOfTypes( getTrack(), PlayHandle::TypeSamplePlayHandle );
-	SampleTrack * st = dynamic_cast<SampleTrack*>( getTrack() );
+	auto* st = dynamic_cast<SampleTrack*>(getTrack());
 	st->setPlayingClips( false );
 }
 
@@ -189,7 +189,7 @@ void SampleClip::playbackPositionChanged()
 
 void SampleClip::updateTrackClips()
 {
-	SampleTrack * sampletrack = dynamic_cast<SampleTrack*>( getTrack() );
+	auto* sampletrack = dynamic_cast<SampleTrack*>(getTrack());
 	if( sampletrack)
 	{
 		sampletrack->updateClips();

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -115,7 +115,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 {
 	const f_cnt_t frames = framesRecorded();
 	// create buffer to store all recorded buffers in
-	sampleFrame * data = new sampleFrame[frames];
+	auto* data = new sampleFrame[frames];
 	// make sure buffer is cleaned up properly at the end...
 	sampleFrame * data_ptr = data;
 
@@ -140,7 +140,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 
 void SampleRecordHandle::writeBuffer( const sampleFrame * _ab, const f_cnt_t _frames )
 {
-	sampleFrame * buf = new sampleFrame[_frames];
+	auto* buf = new sampleFrame[_frames];
 	for( f_cnt_t frame = 0; frame < _frames; ++frame )
 	{
 		for( ch_cnt_t chnl = 0; chnl < DEFAULT_CHANNELS; ++chnl )

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -115,7 +115,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 {
 	const f_cnt_t frames = framesRecorded();
 	// create buffer to store all recorded buffers in
-	sampleFrame * data = new sampleFrame[frames];
+	auto data = new sampleFrame[frames];
 	// make sure buffer is cleaned up properly at the end...
 	sampleFrame * data_ptr = data;
 
@@ -140,7 +140,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 
 void SampleRecordHandle::writeBuffer( const sampleFrame * _ab, const f_cnt_t _frames )
 {
-	sampleFrame * buf = new sampleFrame[_frames];
+	auto buf = new sampleFrame[_frames];
 	for( f_cnt_t frame = 0; frame < _frames; ++frame )
 	{
 		for( ch_cnt_t chnl = 0; chnl < DEFAULT_CHANNELS; ++chnl )

--- a/src/core/SampleRecordHandle.cpp
+++ b/src/core/SampleRecordHandle.cpp
@@ -115,7 +115,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 {
 	const f_cnt_t frames = framesRecorded();
 	// create buffer to store all recorded buffers in
-	auto* data = new sampleFrame[frames];
+	sampleFrame * data = new sampleFrame[frames];
 	// make sure buffer is cleaned up properly at the end...
 	sampleFrame * data_ptr = data;
 
@@ -140,7 +140,7 @@ void SampleRecordHandle::createSampleBuffer( SampleBuffer** sampleBuf )
 
 void SampleRecordHandle::writeBuffer( const sampleFrame * _ab, const f_cnt_t _frames )
 {
-	auto* buf = new sampleFrame[_frames];
+	sampleFrame * buf = new sampleFrame[_frames];
 	for( f_cnt_t frame = 0; frame < _frames; ++frame )
 	{
 		for( ch_cnt_t chnl = 0; chnl < DEFAULT_CHANNELS; ++chnl )

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -146,12 +146,12 @@ void Song::masterVolumeChanged()
 void Song::setTempo()
 {
 	Engine::audioEngine()->requestChangeInModel();
-	const auto tempo = (bpm_t)m_tempoModel.value();
+	const bpm_t tempo = ( bpm_t ) m_tempoModel.value();
 	PlayHandleList & playHandles = Engine::audioEngine()->playHandles();
 	for( PlayHandleList::Iterator it = playHandles.begin();
 						it != playHandles.end(); ++it )
 	{
-		auto* nph = dynamic_cast<NotePlayHandle*>(*it);
+		NotePlayHandle * nph = dynamic_cast<NotePlayHandle *>( *it );
 		if( nph && !nph->isReleased() )
 		{
 			nph->lock();
@@ -321,7 +321,7 @@ void Song::processNextBuffer()
 		}
 
 		const f_cnt_t framesUntilNextPeriod = framesPerPeriod - frameOffsetInPeriod;
-		const auto framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
+		const f_cnt_t framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
 
 		// We want to proceed to the next buffer or tick, whichever is closer
 		const auto framesToPlay = std::min(framesUntilNextPeriod, framesUntilNextTick);

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -146,12 +146,12 @@ void Song::masterVolumeChanged()
 void Song::setTempo()
 {
 	Engine::audioEngine()->requestChangeInModel();
-	const bpm_t tempo = ( bpm_t ) m_tempoModel.value();
+	const auto tempo = (bpm_t)m_tempoModel.value();
 	PlayHandleList & playHandles = Engine::audioEngine()->playHandles();
 	for( PlayHandleList::Iterator it = playHandles.begin();
 						it != playHandles.end(); ++it )
 	{
-		NotePlayHandle * nph = dynamic_cast<NotePlayHandle *>( *it );
+		auto nph = dynamic_cast<NotePlayHandle*>(*it);
 		if( nph && !nph->isReleased() )
 		{
 			nph->lock();
@@ -321,7 +321,7 @@ void Song::processNextBuffer()
 		}
 
 		const f_cnt_t framesUntilNextPeriod = framesPerPeriod - frameOffsetInPeriod;
-		const f_cnt_t framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
+		const auto framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
 
 		// We want to proceed to the next buffer or tick, whichever is closer
 		const auto framesToPlay = std::min(framesUntilNextPeriod, framesUntilNextTick);

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -146,12 +146,12 @@ void Song::masterVolumeChanged()
 void Song::setTempo()
 {
 	Engine::audioEngine()->requestChangeInModel();
-	const bpm_t tempo = ( bpm_t ) m_tempoModel.value();
+	const auto tempo = (bpm_t)m_tempoModel.value();
 	PlayHandleList & playHandles = Engine::audioEngine()->playHandles();
 	for( PlayHandleList::Iterator it = playHandles.begin();
 						it != playHandles.end(); ++it )
 	{
-		NotePlayHandle * nph = dynamic_cast<NotePlayHandle *>( *it );
+		auto* nph = dynamic_cast<NotePlayHandle*>(*it);
 		if( nph && !nph->isReleased() )
 		{
 			nph->lock();
@@ -321,7 +321,7 @@ void Song::processNextBuffer()
 		}
 
 		const f_cnt_t framesUntilNextPeriod = framesPerPeriod - frameOffsetInPeriod;
-		const f_cnt_t framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
+		const auto framesUntilNextTick = static_cast<f_cnt_t>(std::ceil(framesPerTick - frameOffsetInTick));
 
 		// We want to proceed to the next buffer or tick, whichever is closer
 		const auto framesToPlay = std::min(framesUntilNextPeriod, framesUntilNextTick);

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -295,9 +295,9 @@ void AudioAlsa::applyQualitySettings()
 
 void AudioAlsa::run()
 {
-	surroundSampleFrame * temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
-	int_sample_t * outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
-	int_sample_t * pcmbuf = new int_sample_t[m_periodSize * channels()];
+	auto temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
+	auto outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
+	auto pcmbuf = new int_sample_t[m_periodSize * channels()];
 
 	int outbuf_size = audioEngine()->framesPerPeriod() * channels();
 	int outbuf_pos = 0;

--- a/src/core/audio/AudioFileWave.cpp
+++ b/src/core/audio/AudioFileWave.cpp
@@ -104,7 +104,7 @@ void AudioFileWave::writeBuffer( const surroundSampleFrame * _ab,
 
 	if( bitDepth == OutputSettings::Depth_32Bit || bitDepth == OutputSettings::Depth_24Bit )
 	{
-		float *  buf = new float[_frames*channels()];
+		auto buf = new float[_frames * channels()];
 		for( fpp_t frame = 0; frame < _frames; ++frame )
 		{
 			for( ch_cnt_t chnl = 0; chnl < channels(); ++chnl )
@@ -118,7 +118,7 @@ void AudioFileWave::writeBuffer( const surroundSampleFrame * _ab,
 	}
 	else
 	{
-		int_sample_t * buf = new int_sample_t[_frames * channels()];
+		auto buf = new int_sample_t[_frames * channels()];
 		convertToS16( _ab, _frames, _master_gain, buf,
 							!isLittleEndian() );
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -442,7 +442,7 @@ int AudioJack::staticProcessCallback( jack_nframes_t _nframes, void * _udata )
 
 void AudioJack::shutdownCallback( void * _udata )
 {
-	AudioJack * _this = static_cast<AudioJack *>( _udata );
+	auto _this = static_cast<AudioJack*>(_udata);
 	_this->m_client = nullptr;
 	_this->zombified();
 }
@@ -462,11 +462,11 @@ AudioJack::setupWidget::setupWidget( QWidget * _parent ) :
 	m_clientName = new QLineEdit( cn, this );
 	m_clientName->setGeometry( 10, 20, 160, 20 );
 
-	QLabel * cn_lbl = new QLabel( tr( "Client name" ), this );
+	auto cn_lbl = new QLabel(tr("Client name"), this);
 	cn_lbl->setFont( pointSize<7>( cn_lbl->font() ) );
 	cn_lbl->setGeometry( 10, 40, 160, 10 );
 
-	gui::LcdSpinBoxModel * m = new gui::LcdSpinBoxModel( /* this */ );
+	auto m = new gui::LcdSpinBoxModel(/* this */);
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audiojack",

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -292,8 +292,8 @@ void AudioOss::applyQualitySettings()
 
 void AudioOss::run()
 {
-	surroundSampleFrame * temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
-	int_sample_t * outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
+	auto temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];
+	auto outbuf = new int_sample_t[audioEngine()->framesPerPeriod() * channels()];
 
 	while( true )
 	{
@@ -323,11 +323,11 @@ AudioOss::setupWidget::setupWidget( QWidget * _parent ) :
 	m_device = new QLineEdit( probeDevice(), this );
 	m_device->setGeometry( 10, 20, 160, 20 );
 
-	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );
+	auto dev_lbl = new QLabel(tr("Device"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 
-	gui::LcdSpinBoxModel * m = new gui::LcdSpinBoxModel( /* this */ );
+	auto m = new gui::LcdSpinBoxModel(/* this */);
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audiooss",

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -332,7 +332,7 @@ int AudioPortAudio::_process_callback(
 	Q_UNUSED(_timeInfo);
 	Q_UNUSED(_statusFlags);
 
-	AudioPortAudio * _this  = static_cast<AudioPortAudio *> (_arg);
+	auto _this = static_cast<AudioPortAudio*>(_arg);
 	return _this->process_callback( (const float*)_inputBuffer,
 		(float*)_outputBuffer, _framesPerBuffer );
 }
@@ -422,14 +422,14 @@ AudioPortAudio::setupWidget::setupWidget( QWidget * _parent ) :
 	m_backend = new ComboBox( this, "BACKEND" );
 	m_backend->setGeometry( 64, 15, 260, ComboBox::DEFAULT_HEIGHT );
 
-	QLabel * backend_lbl = new QLabel( tr( "Backend" ), this );
+	auto backend_lbl = new QLabel(tr("Backend"), this);
 	backend_lbl->setFont( pointSize<7>( backend_lbl->font() ) );
 	backend_lbl->move( 8, 18 );
 
 	m_device = new ComboBox( this, "DEVICE" );
 	m_device->setGeometry( 64, 35, 260, ComboBox::DEFAULT_HEIGHT );
 
-	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );
+	auto dev_lbl = new QLabel(tr("Device"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->move( 8, 38 );
 	

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -152,7 +152,7 @@ static void stream_state_callback( pa_stream *s, void * userdata )
 /* This is called whenever the context status changes */
 static void context_state_callback(pa_context *c, void *userdata)
 {
-	AudioPulseAudio * _this = static_cast<AudioPulseAudio *>( userdata );
+	auto _this = static_cast<AudioPulseAudio*>(userdata);
 	switch( pa_context_get_state( c ) )
 	{
 		case PA_CONTEXT_CONNECTING:
@@ -247,7 +247,7 @@ void AudioPulseAudio::run()
 	else
 	{
 		const fpp_t fpp = audioEngine()->framesPerPeriod();
-		surroundSampleFrame * temp = new surroundSampleFrame[fpp];
+		auto temp = new surroundSampleFrame[fpp];
 		while( getNextBuffer( temp ) )
 		{
 		}
@@ -266,8 +266,8 @@ void AudioPulseAudio::run()
 void AudioPulseAudio::streamWriteCallback( pa_stream *s, size_t length )
 {
 	const fpp_t fpp = audioEngine()->framesPerPeriod();
-	surroundSampleFrame * temp = new surroundSampleFrame[fpp];
-	int_sample_t* pcmbuf = (int_sample_t *)pa_xmalloc( fpp * channels() * sizeof(int_sample_t) );
+	auto temp = new surroundSampleFrame[fpp];
+	auto pcmbuf = (int_sample_t*)pa_xmalloc(fpp * channels() * sizeof(int_sample_t));
 
 	size_t fd = 0;
 	while( fd < length/4 && m_quit == false )
@@ -315,11 +315,11 @@ AudioPulseAudio::setupWidget::setupWidget( QWidget * _parent ) :
 	m_device = new QLineEdit( AudioPulseAudio::probeDevice(), this );
 	m_device->setGeometry( 10, 20, 160, 20 );
 
-	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );
+	auto dev_lbl = new QLabel(tr("Device"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 
-	gui::LcdSpinBoxModel * m = new gui::LcdSpinBoxModel( /* this */ );
+	auto m = new gui::LcdSpinBoxModel(/* this */);
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audiopa",

--- a/src/core/audio/AudioSampleRecorder.cpp
+++ b/src/core/audio/AudioSampleRecorder.cpp
@@ -75,7 +75,7 @@ void AudioSampleRecorder::createSampleBuffer( SampleBuffer** sampleBuf )
 {
 	const f_cnt_t frames = framesRecorded();
 	// create buffer to store all recorded buffers in
-	sampleFrame * data = new sampleFrame[frames];
+	auto data = new sampleFrame[frames];
 	// make sure buffer is cleaned up properly at the end...
 	sampleFrame * data_ptr = data;
 
@@ -102,7 +102,7 @@ void AudioSampleRecorder::createSampleBuffer( SampleBuffer** sampleBuf )
 void AudioSampleRecorder::writeBuffer( const surroundSampleFrame * _ab,
 					const fpp_t _frames, const float )
 {
-	sampleFrame * buf = new sampleFrame[_frames];
+	auto buf = new sampleFrame[_frames];
 	for( fpp_t frame = 0; frame < _frames; ++frame )
 	{
 		for( ch_cnt_t chnl = 0; chnl < DEFAULT_CHANNELS; ++chnl )

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -225,7 +225,7 @@ void AudioSdl::applyQualitySettings()
 
 void AudioSdl::sdlAudioCallback( void * _udata, Uint8 * _buf, int _len )
 {
-	AudioSdl * _this = static_cast<AudioSdl *>( _udata );
+	auto _this = static_cast<AudioSdl*>(_udata);
 
 	_this->sdlAudioCallback( _buf, _len );
 }
@@ -310,13 +310,13 @@ void AudioSdl::sdlAudioCallback( Uint8 * _buf, int _len )
 #ifdef LMMS_HAVE_SDL2
 
 void AudioSdl::sdlInputAudioCallback(void *_udata, Uint8 *_buf, int _len) {
-	AudioSdl * _this = static_cast<AudioSdl *>( _udata );
+	auto _this = static_cast<AudioSdl*>(_udata);
 
 	_this->sdlInputAudioCallback( _buf, _len );
 }
 
 void AudioSdl::sdlInputAudioCallback(Uint8 *_buf, int _len) {
-	sampleFrame *samples_buffer = (sampleFrame *) _buf;
+	auto samples_buffer = (sampleFrame*)_buf;
 	fpp_t frames = _len / sizeof ( sampleFrame );
 
 	audioEngine()->pushInputFrames (samples_buffer, frames);
@@ -331,7 +331,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	m_device = new QLineEdit( dev, this );
 	m_device->setGeometry( 10, 20, 160, 20 );
 
-	QLabel * dev_lbl = new QLabel( tr( "Device" ), this );
+	auto dev_lbl = new QLabel(tr("Device"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 

--- a/src/core/lv2/Lv2Evbuf.cpp
+++ b/src/core/lv2/Lv2Evbuf.cpp
@@ -57,8 +57,7 @@ LV2_Evbuf*
 lv2_evbuf_new(uint32_t capacity, uint32_t atom_Chunk, uint32_t atom_Sequence)
 {
 	// FIXME: memory must be 64-bit aligned
-	LV2_Evbuf* evbuf = (LV2_Evbuf*)malloc(
-		sizeof(LV2_Evbuf) + sizeof(LV2_Atom_Sequence) + capacity);
+	auto evbuf = (LV2_Evbuf*)malloc(sizeof(LV2_Evbuf) + sizeof(LV2_Atom_Sequence) + capacity);
 	evbuf->capacity = capacity;
 	evbuf->atom_Chunk = atom_Chunk;
 	evbuf->atom_Sequence = atom_Sequence;
@@ -155,8 +154,7 @@ lv2_evbuf_get(LV2_Evbuf_Iterator iter,
 	}
 
 	LV2_Atom_Sequence* aseq = &iter.evbuf->buf;
-	LV2_Atom_Event*    aev  = (LV2_Atom_Event*)(
-		(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter.offset);
+	auto aev = (LV2_Atom_Event*)((char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter.offset);
 
 	*frames = aev->time.frames;
 	*type = aev->body.type;
@@ -179,8 +177,7 @@ lv2_evbuf_write(LV2_Evbuf_Iterator* iter,
 		return false;
 	}
 
-	LV2_Atom_Event* aev = (LV2_Atom_Event*)(
-		(char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter->offset);
+	auto aev = (LV2_Atom_Event*)((char*)LV2_ATOM_CONTENTS(LV2_Atom_Sequence, aseq) + iter->offset);
 
 	aev->time.frames = frames;
 	aev->body.type = type;

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -500,7 +500,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 	{
 		case Lv2Ports::Type::Control:
 		{
-			Lv2Ports::Control* ctrl = new Lv2Ports::Control;
+			auto ctrl = new Lv2Ports::Control;
 			if (meta.m_flow == Lv2Ports::Flow::Input)
 			{
 				AutoLilvNode node(lilv_port_get_name(m_plugin, lilvPort));
@@ -542,9 +542,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 						break;
 					case Lv2Ports::Vis::Enumeration:
 					{
-						ComboBoxModel* comboModel
-							= new ComboBoxModel(
-								nullptr, dispName);
+						auto comboModel = new ComboBoxModel(nullptr, dispName);
 						LilvScalePoints* sps =
 							lilv_port_get_scale_points(m_plugin, lilvPort);
 						LILV_FOREACH(scale_points, i, sps)
@@ -578,18 +576,14 @@ void Lv2Proc::createPort(std::size_t portNum)
 		}
 		case Lv2Ports::Type::Audio:
 		{
-			Lv2Ports::Audio* audio =
-				new Lv2Ports::Audio(
-						static_cast<std::size_t>(
-							Engine::audioEngine()->framesPerPeriod()),
-						portIsSideChain(m_plugin, lilvPort)
-					);
+			auto audio = new Lv2Ports::Audio(static_cast<std::size_t>(Engine::audioEngine()->framesPerPeriod()),
+				portIsSideChain(m_plugin, lilvPort));
 			port = audio;
 			break;
 		}
 		case Lv2Ports::Type::AtomSeq:
 		{
-			Lv2Ports::AtomSeq* atomPort = new Lv2Ports::AtomSeq;
+			auto atomPort = new Lv2Ports::AtomSeq;
 
 			{
 				AutoLilvNode uriAtomSupports(Engine::getLv2Manager()->uri(LV2_ATOM__supports));

--- a/src/core/lv2/Lv2SubPluginFeatures.cpp
+++ b/src/core/lv2/Lv2SubPluginFeatures.cpp
@@ -72,23 +72,23 @@ void Lv2SubPluginFeatures::fillDescriptionWidget(QWidget *parent,
 {
 	const LilvPlugin *plug = getPlugin(*k);
 
-	QLabel *label = new QLabel(parent);
+	auto label = new QLabel(parent);
 	label->setText(QWidget::tr("Name: ") + pluginName(plug));
 
-	QLabel *label2 = new QLabel(parent);
+	auto label2 = new QLabel(parent);
 	label2->setText(QWidget::tr("URI: ") +
 		lilv_node_as_uri(lilv_plugin_get_uri(plug)));
 
-	QWidget *maker = new QWidget(parent);
-	QHBoxLayout *l = new QHBoxLayout(maker);
+	auto maker = new QWidget(parent);
+	auto l = new QHBoxLayout(maker);
 	l->setMargin(0);
 	l->setSpacing(0);
 
-	QLabel *maker_label = new QLabel(maker);
+	auto maker_label = new QLabel(maker);
 	maker_label->setText(QWidget::tr("Maker: "));
 	maker_label->setAlignment(Qt::AlignTop);
 
-	QLabel *maker_content = new QLabel(maker);
+	auto maker_content = new QLabel(maker);
 	maker_content->setText(
 		qStringFromPluginNode(plug, lilv_plugin_get_author_name));
 	maker_content->setWordWrap(true);
@@ -96,17 +96,17 @@ void Lv2SubPluginFeatures::fillDescriptionWidget(QWidget *parent,
 	l->addWidget(maker_label);
 	l->addWidget(maker_content, 1);
 
-	QWidget *copyright = new QWidget(parent);
+	auto copyright = new QWidget(parent);
 	l = new QHBoxLayout(copyright);
 	l->setMargin(0);
 	l->setSpacing(0);
 	copyright->setMinimumWidth(parent->minimumWidth());
 
-	QLabel *copyright_label = new QLabel(copyright);
+	auto copyright_label = new QLabel(copyright);
 	copyright_label->setText(QWidget::tr("Copyright: "));
 	copyright_label->setAlignment(Qt::AlignTop);
 
-	QLabel *copyright_content = new QLabel(copyright);
+	auto copyright_content = new QLabel(copyright);
 	copyright_content->setText("<unknown>");
 	copyright_content->setWordWrap(true);
 	l->addWidget(copyright_label);

--- a/src/core/lv2/Lv2UridMap.cpp
+++ b/src/core/lv2/Lv2UridMap.cpp
@@ -33,13 +33,13 @@ namespace lmms
 
 static LV2_URID staticMap(LV2_URID_Map_Handle handle, const char* uri)
 {
-	UridMap* map = static_cast<UridMap*>(handle);
+	auto map = static_cast<UridMap*>(handle);
 	return map->map(uri);
 }
 
 static const char* staticUnmap(LV2_URID_Unmap_Handle handle, LV2_URID urid)
 {
-	UridMap* map = static_cast<UridMap*>(handle);
+	auto map = static_cast<UridMap*>(handle);
 	return map->unmap(urid);
 }
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -126,7 +126,7 @@ void consoleMessageHandler(QtMsgType type,
 inline void loadTranslation( const QString & tname,
 	const QString & dir = lmms::ConfigManager::inst()->localeDir() )
 {
-	QTranslator * t = new QTranslator( QCoreApplication::instance() );
+	auto t = new QTranslator(QCoreApplication::instance());
 	QString name = tname + ".qm";
 
 	if (t->load(name, dir))
@@ -829,12 +829,12 @@ int main( int argc, char * * argv )
 		}
 
 		// create renderer
-		RenderManager * r = new RenderManager( qs, os, eff, renderOut );
+		auto r = new RenderManager(qs, os, eff, renderOut);
 		QCoreApplication::instance()->connect( r,
 				SIGNAL(finished()), SLOT(quit()));
 
 		// timer for progress-updates
-		QTimer * t = new QTimer( r );
+		auto t = new QTimer(r);
 		r->connect( t, SIGNAL(timeout()),
 				SLOT(updateConsoleProgress()));
 		t->start( 200 );

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -126,7 +126,7 @@ void consoleMessageHandler(QtMsgType type,
 inline void loadTranslation( const QString & tname,
 	const QString & dir = lmms::ConfigManager::inst()->localeDir() )
 {
-	auto* t = new QTranslator(QCoreApplication::instance());
+	QTranslator * t = new QTranslator( QCoreApplication::instance() );
 	QString name = tname + ".qm";
 
 	if (t->load(name, dir))
@@ -829,12 +829,12 @@ int main( int argc, char * * argv )
 		}
 
 		// create renderer
-		auto* r = new RenderManager(qs, os, eff, renderOut);
+		RenderManager * r = new RenderManager( qs, os, eff, renderOut );
 		QCoreApplication::instance()->connect( r,
 				SIGNAL(finished()), SLOT(quit()));
 
 		// timer for progress-updates
-		auto* t = new QTimer(r);
+		QTimer * t = new QTimer( r );
 		r->connect( t, SIGNAL(timeout()),
 				SLOT(updateConsoleProgress()));
 		t->start( 200 );

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -126,7 +126,7 @@ void consoleMessageHandler(QtMsgType type,
 inline void loadTranslation( const QString & tname,
 	const QString & dir = lmms::ConfigManager::inst()->localeDir() )
 {
-	QTranslator * t = new QTranslator( QCoreApplication::instance() );
+	auto* t = new QTranslator(QCoreApplication::instance());
 	QString name = tname + ".qm";
 
 	if (t->load(name, dir))
@@ -829,12 +829,12 @@ int main( int argc, char * * argv )
 		}
 
 		// create renderer
-		RenderManager * r = new RenderManager( qs, os, eff, renderOut );
+		auto* r = new RenderManager(qs, os, eff, renderOut);
 		QCoreApplication::instance()->connect( r,
 				SIGNAL(finished()), SLOT(quit()));
 
 		// timer for progress-updates
-		QTimer * t = new QTimer( r );
+		auto* t = new QTimer(r);
 		r->connect( t, SIGNAL(timeout()),
 				SLOT(updateConsoleProgress()));
 		t->start( 200 );

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -164,7 +164,7 @@ void MidiAlsaSeq::processOutEvent( const MidiEvent& event, const TimePos& time, 
 	// HACK!!! - need a better solution which isn't that easy since we
 	// cannot store const-ptrs in our map because we need to call non-const
 	// methods of MIDI-port - it's a mess...
-	MidiPort* p = const_cast<MidiPort *>( port );
+	auto p = const_cast<MidiPort*>(port);
 
 	snd_seq_event_t ev;
 	snd_seq_ev_clear( &ev );
@@ -353,8 +353,7 @@ QString MidiAlsaSeq::sourcePortName( const MidiEvent & _event ) const
 {
 	if( _event.sourcePort() )
 	{
-		const snd_seq_addr_t * addr =
-			static_cast<const snd_seq_addr_t *>( _event.sourcePort() );
+		const auto addr = static_cast<const snd_seq_addr_t*>(_event.sourcePort());
 		return portName( m_seqHandle, addr );
 	}
 	return MidiClient::sourcePortName( _event );
@@ -462,7 +461,7 @@ void MidiAlsaSeq::run()
 	// watch the pipe and sequencer input events
 	int pollfd_count = snd_seq_poll_descriptors_count( m_seqHandle,
 								POLLIN );
-	struct pollfd * pollfd_set = new struct pollfd[pollfd_count + 1];
+	auto pollfd_set = new struct pollfd[pollfd_count + 1];
 	snd_seq_poll_descriptors( m_seqHandle, pollfd_set + 1, pollfd_count,
 								POLLIN );
 	pollfd_set[0].fd = m_pipe[0];

--- a/src/core/midi/MidiJack.cpp
+++ b/src/core/midi/MidiJack.cpp
@@ -41,7 +41,7 @@ namespace lmms
 /* callback functions for jack */
 static int JackMidiProcessCallback(jack_nframes_t nframes, void *arg)
 {
-	MidiJack *jmd = (MidiJack *)arg;
+	auto jmd = (MidiJack*)arg;
 
 	if (nframes <= 0)
 		return (0);

--- a/src/gui/AudioAlsaSetupWidget.cpp
+++ b/src/gui/AudioAlsaSetupWidget.cpp
@@ -67,11 +67,11 @@ AudioAlsaSetupWidget::AudioAlsaSetupWidget( QWidget * _parent ) :
 			SIGNAL(currentIndexChanged(int)),
 			SLOT(onCurrentIndexChanged(int)));
 
-	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
+	auto* dev_lbl = new QLabel(tr("DEVICE"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 
-	LcdSpinBoxModel * m = new LcdSpinBoxModel( /* this */ );
+	auto* m = new LcdSpinBoxModel(/* this */);
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audioalsa",

--- a/src/gui/AudioAlsaSetupWidget.cpp
+++ b/src/gui/AudioAlsaSetupWidget.cpp
@@ -67,11 +67,11 @@ AudioAlsaSetupWidget::AudioAlsaSetupWidget( QWidget * _parent ) :
 			SIGNAL(currentIndexChanged(int)),
 			SLOT(onCurrentIndexChanged(int)));
 
-	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
+	auto dev_lbl = new QLabel(tr("DEVICE"), this);
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 
-	LcdSpinBoxModel * m = new LcdSpinBoxModel( /* this */ );
+	auto m = new LcdSpinBoxModel(/* this */);
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audioalsa",

--- a/src/gui/AudioAlsaSetupWidget.cpp
+++ b/src/gui/AudioAlsaSetupWidget.cpp
@@ -67,11 +67,11 @@ AudioAlsaSetupWidget::AudioAlsaSetupWidget( QWidget * _parent ) :
 			SIGNAL(currentIndexChanged(int)),
 			SLOT(onCurrentIndexChanged(int)));
 
-	auto* dev_lbl = new QLabel(tr("DEVICE"), this);
+	QLabel * dev_lbl = new QLabel( tr( "DEVICE" ), this );
 	dev_lbl->setFont( pointSize<7>( dev_lbl->font() ) );
 	dev_lbl->setGeometry( 10, 40, 160, 10 );
 
-	auto* m = new LcdSpinBoxModel(/* this */);
+	LcdSpinBoxModel * m = new LcdSpinBoxModel( /* this */ );
 	m->setRange( DEFAULT_CHANNELS, SURROUND_CHANNELS );
 	m->setStep( 2 );
 	m->setValue( ConfigManager::inst()->value( "audioalsa",

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -55,7 +55,7 @@ void AutomatableModelView::addDefaultActions( QMenu* menu )
 {
 	AutomatableModel* model = modelUntyped();
 
-	auto* amvSlots = new AutomatableModelViewSlots(this, menu);
+	AutomatableModelViewSlots* amvSlots = new AutomatableModelViewSlots( this, menu );
 
 	menu->addAction( embed::getIconPixmap( "reload" ),
 						AutomatableModel::tr( "&Reset (%1%2)" ).
@@ -230,7 +230,7 @@ void AutomatableModelViewSlots::execConnectionDialog()
 			// New
 			else
 			{
-				auto* cc = new ControllerConnection(d.chosenController());
+				ControllerConnection* cc = new ControllerConnection(d.chosenController());
 				m->setControllerConnection( cc );
 				//cc->setTargetName( m->displayName() );
 			}

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -55,7 +55,7 @@ void AutomatableModelView::addDefaultActions( QMenu* menu )
 {
 	AutomatableModel* model = modelUntyped();
 
-	AutomatableModelViewSlots* amvSlots = new AutomatableModelViewSlots( this, menu );
+	auto amvSlots = new AutomatableModelViewSlots(this, menu);
 
 	menu->addAction( embed::getIconPixmap( "reload" ),
 						AutomatableModel::tr( "&Reset (%1%2)" ).
@@ -230,7 +230,7 @@ void AutomatableModelViewSlots::execConnectionDialog()
 			// New
 			else
 			{
-				ControllerConnection* cc = new ControllerConnection(d.chosenController());
+				auto cc = new ControllerConnection(d.chosenController());
 				m->setControllerConnection( cc );
 				//cc->setTargetName( m->displayName() );
 			}

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -55,7 +55,7 @@ void AutomatableModelView::addDefaultActions( QMenu* menu )
 {
 	AutomatableModel* model = modelUntyped();
 
-	AutomatableModelViewSlots* amvSlots = new AutomatableModelViewSlots( this, menu );
+	auto* amvSlots = new AutomatableModelViewSlots(this, menu);
 
 	menu->addAction( embed::getIconPixmap( "reload" ),
 						AutomatableModel::tr( "&Reset (%1%2)" ).
@@ -230,7 +230,7 @@ void AutomatableModelViewSlots::execConnectionDialog()
 			// New
 			else
 			{
-				ControllerConnection* cc = new ControllerConnection(d.chosenController());
+				auto* cc = new ControllerConnection(d.chosenController());
 				m->setControllerConnection( cc );
 				//cc->setTargetName( m->displayName() );
 			}

--- a/src/gui/ControlLayout.cpp
+++ b/src/gui/ControlLayout.cpp
@@ -309,7 +309,7 @@ int ControlLayout::smartSpacing(QStyle::PixelMetric pm) const
 	if (!parent) { return -1; }
 	else if (parent->isWidgetType())
 	{
-		QWidget *pw = static_cast<QWidget *>(parent);
+		auto* pw = static_cast<QWidget*>(parent);
 		return pw->style()->pixelMetric(pm, nullptr, pw);
 	}
 	else { return static_cast<QLayout *>(parent)->spacing(); }

--- a/src/gui/ControlLayout.cpp
+++ b/src/gui/ControlLayout.cpp
@@ -309,7 +309,7 @@ int ControlLayout::smartSpacing(QStyle::PixelMetric pm) const
 	if (!parent) { return -1; }
 	else if (parent->isWidgetType())
 	{
-		auto* pw = static_cast<QWidget*>(parent);
+		QWidget *pw = static_cast<QWidget *>(parent);
 		return pw->style()->pixelMetric(pm, nullptr, pw);
 	}
 	else { return static_cast<QLayout *>(parent)->spacing(); }

--- a/src/gui/ControlLayout.cpp
+++ b/src/gui/ControlLayout.cpp
@@ -309,7 +309,7 @@ int ControlLayout::smartSpacing(QStyle::PixelMetric pm) const
 	if (!parent) { return -1; }
 	else if (parent->isWidgetType())
 	{
-		QWidget *pw = static_cast<QWidget *>(parent);
+		auto pw = static_cast<QWidget*>(parent);
 		return pw->style()->pixelMetric(pm, nullptr, pw);
 	}
 	else { return static_cast<QLayout *>(parent)->spacing(); }

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -53,7 +53,7 @@ ControllerRackView::ControllerRackView() :
 	m_scrollArea->setPalette( QApplication::palette( m_scrollArea ) );
 	m_scrollArea->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 
-	auto* scrollAreaWidget = new QWidget(m_scrollArea);
+	QWidget * scrollAreaWidget = new QWidget( m_scrollArea );
 	m_scrollAreaLayout = new QVBoxLayout( scrollAreaWidget );
 	m_scrollAreaLayout->addStretch();
 	scrollAreaWidget->setLayout( m_scrollAreaLayout );
@@ -71,7 +71,7 @@ ControllerRackView::ControllerRackView() :
 	connect( song, SIGNAL(controllerAdded(lmms::Controller*)), SLOT(onControllerAdded(lmms::Controller*)));
 	connect( song, SIGNAL(controllerRemoved(lmms::Controller*)), SLOT(onControllerRemoved(lmms::Controller*)));
 
-	auto* layout = new QVBoxLayout();
+	QVBoxLayout * layout = new QVBoxLayout();
 	layout->addWidget( m_scrollArea );
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
@@ -139,7 +139,7 @@ void ControllerRackView::onControllerAdded( Controller * controller )
 {
 	QWidget * scrollAreaWidget = m_scrollArea->widget();
 
-	auto* controllerView = new ControllerView(controller, scrollAreaWidget);
+	ControllerView * controllerView = new ControllerView( controller, scrollAreaWidget );
 
 	connect( controllerView, SIGNAL(deleteController(lmms::gui::ControllerView*)),
 		 this, SLOT(deleteController(lmms::gui::ControllerView*)), Qt::QueuedConnection );

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -53,7 +53,7 @@ ControllerRackView::ControllerRackView() :
 	m_scrollArea->setPalette( QApplication::palette( m_scrollArea ) );
 	m_scrollArea->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 
-	QWidget * scrollAreaWidget = new QWidget( m_scrollArea );
+	auto scrollAreaWidget = new QWidget(m_scrollArea);
 	m_scrollAreaLayout = new QVBoxLayout( scrollAreaWidget );
 	m_scrollAreaLayout->addStretch();
 	scrollAreaWidget->setLayout( m_scrollAreaLayout );
@@ -71,7 +71,7 @@ ControllerRackView::ControllerRackView() :
 	connect( song, SIGNAL(controllerAdded(lmms::Controller*)), SLOT(onControllerAdded(lmms::Controller*)));
 	connect( song, SIGNAL(controllerRemoved(lmms::Controller*)), SLOT(onControllerRemoved(lmms::Controller*)));
 
-	QVBoxLayout * layout = new QVBoxLayout();
+	auto layout = new QVBoxLayout();
 	layout->addWidget( m_scrollArea );
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
@@ -139,7 +139,7 @@ void ControllerRackView::onControllerAdded( Controller * controller )
 {
 	QWidget * scrollAreaWidget = m_scrollArea->widget();
 
-	ControllerView * controllerView = new ControllerView( controller, scrollAreaWidget );
+	auto controllerView = new ControllerView(controller, scrollAreaWidget);
 
 	connect( controllerView, SIGNAL(deleteController(lmms::gui::ControllerView*)),
 		 this, SLOT(deleteController(lmms::gui::ControllerView*)), Qt::QueuedConnection );

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -53,7 +53,7 @@ ControllerRackView::ControllerRackView() :
 	m_scrollArea->setPalette( QApplication::palette( m_scrollArea ) );
 	m_scrollArea->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
 
-	QWidget * scrollAreaWidget = new QWidget( m_scrollArea );
+	auto* scrollAreaWidget = new QWidget(m_scrollArea);
 	m_scrollAreaLayout = new QVBoxLayout( scrollAreaWidget );
 	m_scrollAreaLayout->addStretch();
 	scrollAreaWidget->setLayout( m_scrollAreaLayout );
@@ -71,7 +71,7 @@ ControllerRackView::ControllerRackView() :
 	connect( song, SIGNAL(controllerAdded(lmms::Controller*)), SLOT(onControllerAdded(lmms::Controller*)));
 	connect( song, SIGNAL(controllerRemoved(lmms::Controller*)), SLOT(onControllerRemoved(lmms::Controller*)));
 
-	QVBoxLayout * layout = new QVBoxLayout();
+	auto* layout = new QVBoxLayout();
 	layout->addWidget( m_scrollArea );
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
@@ -139,7 +139,7 @@ void ControllerRackView::onControllerAdded( Controller * controller )
 {
 	QWidget * scrollAreaWidget = m_scrollArea->widget();
 
-	ControllerView * controllerView = new ControllerView( controller, scrollAreaWidget );
+	auto* controllerView = new ControllerView(controller, scrollAreaWidget);
 
 	connect( controllerView, SIGNAL(deleteController(lmms::gui::ControllerView*)),
 		 this, SLOT(deleteController(lmms::gui::ControllerView*)), Qt::QueuedConnection );

--- a/src/gui/ControllerView.cpp
+++ b/src/gui/ControllerView.cpp
@@ -54,19 +54,19 @@ ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 	this->setFrameStyle( QFrame::StyledPanel );
 	this->setFrameShadow( QFrame::Raised );
 
-	QVBoxLayout *vBoxLayout = new QVBoxLayout(this);
+	auto* vBoxLayout = new QVBoxLayout(this);
 
-	QHBoxLayout *hBox = new QHBoxLayout();
+	auto* hBox = new QHBoxLayout();
 	vBoxLayout->addLayout(hBox);
 
-	QLabel *label = new QLabel( "<b>" + _model->displayName() + "</b>", this);
+	auto* label = new QLabel("<b>" + _model->displayName() + "</b>", this);
 	QSizePolicy sizePolicy = label->sizePolicy();
 	sizePolicy.setHorizontalStretch(1);
 	label->setSizePolicy(sizePolicy);
 
 	hBox->addWidget(label);
 
-	QPushButton * controlsButton = new QPushButton( tr( "Controls" ), this );
+	auto* controlsButton = new QPushButton(tr("Controls"), this);
 	connect( controlsButton, SIGNAL(clicked()), SLOT(editControls()));
 
 	hBox->addWidget(controlsButton);
@@ -141,7 +141,7 @@ void ControllerView::deleteController()
 void ControllerView::renameController()
 {
 	bool ok;
-	Controller * c = castModel<Controller>();
+	auto* c = castModel<Controller>();
 	QString new_name = QInputDialog::getText( this,
 			tr( "Rename controller" ),
 			tr( "Enter the new name for this controller" ),

--- a/src/gui/ControllerView.cpp
+++ b/src/gui/ControllerView.cpp
@@ -54,19 +54,19 @@ ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 	this->setFrameStyle( QFrame::StyledPanel );
 	this->setFrameShadow( QFrame::Raised );
 
-	auto* vBoxLayout = new QVBoxLayout(this);
+	QVBoxLayout *vBoxLayout = new QVBoxLayout(this);
 
-	auto* hBox = new QHBoxLayout();
+	QHBoxLayout *hBox = new QHBoxLayout();
 	vBoxLayout->addLayout(hBox);
 
-	auto* label = new QLabel("<b>" + _model->displayName() + "</b>", this);
+	QLabel *label = new QLabel( "<b>" + _model->displayName() + "</b>", this);
 	QSizePolicy sizePolicy = label->sizePolicy();
 	sizePolicy.setHorizontalStretch(1);
 	label->setSizePolicy(sizePolicy);
 
 	hBox->addWidget(label);
 
-	auto* controlsButton = new QPushButton(tr("Controls"), this);
+	QPushButton * controlsButton = new QPushButton( tr( "Controls" ), this );
 	connect( controlsButton, SIGNAL(clicked()), SLOT(editControls()));
 
 	hBox->addWidget(controlsButton);
@@ -141,7 +141,7 @@ void ControllerView::deleteController()
 void ControllerView::renameController()
 {
 	bool ok;
-	auto* c = castModel<Controller>();
+	Controller * c = castModel<Controller>();
 	QString new_name = QInputDialog::getText( this,
 			tr( "Rename controller" ),
 			tr( "Enter the new name for this controller" ),

--- a/src/gui/ControllerView.cpp
+++ b/src/gui/ControllerView.cpp
@@ -54,19 +54,19 @@ ControllerView::ControllerView( Controller * _model, QWidget * _parent ) :
 	this->setFrameStyle( QFrame::StyledPanel );
 	this->setFrameShadow( QFrame::Raised );
 
-	QVBoxLayout *vBoxLayout = new QVBoxLayout(this);
+	auto vBoxLayout = new QVBoxLayout(this);
 
-	QHBoxLayout *hBox = new QHBoxLayout();
+	auto hBox = new QHBoxLayout();
 	vBoxLayout->addLayout(hBox);
 
-	QLabel *label = new QLabel( "<b>" + _model->displayName() + "</b>", this);
+	auto label = new QLabel("<b>" + _model->displayName() + "</b>", this);
 	QSizePolicy sizePolicy = label->sizePolicy();
 	sizePolicy.setHorizontalStretch(1);
 	label->setSizePolicy(sizePolicy);
 
 	hBox->addWidget(label);
 
-	QPushButton * controlsButton = new QPushButton( tr( "Controls" ), this );
+	auto controlsButton = new QPushButton(tr("Controls"), this);
 	connect( controlsButton, SIGNAL(clicked()), SLOT(editControls()));
 
 	hBox->addWidget(controlsButton);
@@ -141,7 +141,7 @@ void ControllerView::deleteController()
 void ControllerView::renameController()
 {
 	bool ok;
-	Controller * c = castModel<Controller>();
+	auto c = castModel<Controller>();
 	QString new_name = QInputDialog::getText( this,
 			tr( "Rename controller" ),
 			tr( "Enter the new name for this controller" ),

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -72,7 +72,7 @@ ComboControl::ComboControl(QWidget *parent) :
 	m_label(new QLabel(m_widget))
 {
 	m_combo->setFixedSize(64, ComboBox::DEFAULT_HEIGHT);
-	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	auto* vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_combo);
 	vbox->addWidget(m_label);
 	m_combo->repaint();
@@ -98,7 +98,7 @@ CheckControl::CheckControl(QWidget *parent) :
 	m_checkBox(new LedCheckBox(nullptr, QString(), LedCheckBox::Green)),
 	m_label(new QLabel(m_widget))
 {
-	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	auto* vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_checkBox);
 	vbox->addWidget(m_label);
 }

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -72,7 +72,7 @@ ComboControl::ComboControl(QWidget *parent) :
 	m_label(new QLabel(m_widget))
 {
 	m_combo->setFixedSize(64, ComboBox::DEFAULT_HEIGHT);
-	auto* vbox = new QVBoxLayout(m_widget);
+	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_combo);
 	vbox->addWidget(m_label);
 	m_combo->repaint();
@@ -98,7 +98,7 @@ CheckControl::CheckControl(QWidget *parent) :
 	m_checkBox(new LedCheckBox(nullptr, QString(), LedCheckBox::Green)),
 	m_label(new QLabel(m_widget))
 {
-	auto* vbox = new QVBoxLayout(m_widget);
+	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_checkBox);
 	vbox->addWidget(m_label);
 }

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -72,7 +72,7 @@ ComboControl::ComboControl(QWidget *parent) :
 	m_label(new QLabel(m_widget))
 {
 	m_combo->setFixedSize(64, ComboBox::DEFAULT_HEIGHT);
-	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	auto vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_combo);
 	vbox->addWidget(m_label);
 	m_combo->repaint();
@@ -98,7 +98,7 @@ CheckControl::CheckControl(QWidget *parent) :
 	m_checkBox(new LedCheckBox(nullptr, QString(), LedCheckBox::Green)),
 	m_label(new QLabel(m_widget))
 {
-	QVBoxLayout* vbox = new QVBoxLayout(m_widget);
+	auto vbox = new QVBoxLayout(m_widget);
 	vbox->addWidget(m_checkBox);
 	vbox->addWidget(m_label);
 }

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -41,13 +41,13 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( nullptr, this )
 {
-	QVBoxLayout* mainLayout = new QVBoxLayout( this );
+	auto* mainLayout = new QVBoxLayout(this);
 	mainLayout->setMargin( 5 );
 
 	m_effectsGroupBox = new GroupBox( tr( "EFFECTS CHAIN" ) );
 	mainLayout->addWidget( m_effectsGroupBox );
 
-	QVBoxLayout* effectsLayout = new QVBoxLayout( m_effectsGroupBox );
+	auto* effectsLayout = new QVBoxLayout(m_effectsGroupBox);
 	effectsLayout->setSpacing( 0 );
 	effectsLayout->setContentsMargins( 2, m_effectsGroupBox->titleBarHeight() + 2, 2, 2 );
 
@@ -60,7 +60,7 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 
 	effectsLayout->addWidget( m_scrollArea );
 
-	QPushButton* addButton = new QPushButton;
+	auto* addButton = new QPushButton;
 	addButton->setText( tr( "Add effect" ) );
 
 	effectsLayout->addWidget( addButton );
@@ -170,7 +170,7 @@ void EffectRackView::update()
 		}
 		if( i >= m_effectViews.size() )
 		{
-			EffectView * view = new EffectView( *it, w );
+			auto* view = new EffectView(*it, w);
 			connect( view, SIGNAL(moveUp(lmms::gui::EffectView*)),
 					this, SLOT(moveUp(lmms::gui::EffectView*)));
 			connect( view, SIGNAL(moveDown(lmms::gui::EffectView*)),

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -41,13 +41,13 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( nullptr, this )
 {
-	QVBoxLayout* mainLayout = new QVBoxLayout( this );
+	auto mainLayout = new QVBoxLayout(this);
 	mainLayout->setMargin( 5 );
 
 	m_effectsGroupBox = new GroupBox( tr( "EFFECTS CHAIN" ) );
 	mainLayout->addWidget( m_effectsGroupBox );
 
-	QVBoxLayout* effectsLayout = new QVBoxLayout( m_effectsGroupBox );
+	auto effectsLayout = new QVBoxLayout(m_effectsGroupBox);
 	effectsLayout->setSpacing( 0 );
 	effectsLayout->setContentsMargins( 2, m_effectsGroupBox->titleBarHeight() + 2, 2, 2 );
 
@@ -60,7 +60,7 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 
 	effectsLayout->addWidget( m_scrollArea );
 
-	QPushButton* addButton = new QPushButton;
+	auto addButton = new QPushButton;
 	addButton->setText( tr( "Add effect" ) );
 
 	effectsLayout->addWidget( addButton );
@@ -170,7 +170,7 @@ void EffectRackView::update()
 		}
 		if( i >= m_effectViews.size() )
 		{
-			EffectView * view = new EffectView( *it, w );
+			auto view = new EffectView(*it, w);
 			connect( view, SIGNAL(moveUp(lmms::gui::EffectView*)),
 					this, SLOT(moveUp(lmms::gui::EffectView*)));
 			connect( view, SIGNAL(moveDown(lmms::gui::EffectView*)),

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -41,13 +41,13 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	QWidget( parent ),
 	ModelView( nullptr, this )
 {
-	auto* mainLayout = new QVBoxLayout(this);
+	QVBoxLayout* mainLayout = new QVBoxLayout( this );
 	mainLayout->setMargin( 5 );
 
 	m_effectsGroupBox = new GroupBox( tr( "EFFECTS CHAIN" ) );
 	mainLayout->addWidget( m_effectsGroupBox );
 
-	auto* effectsLayout = new QVBoxLayout(m_effectsGroupBox);
+	QVBoxLayout* effectsLayout = new QVBoxLayout( m_effectsGroupBox );
 	effectsLayout->setSpacing( 0 );
 	effectsLayout->setContentsMargins( 2, m_effectsGroupBox->titleBarHeight() + 2, 2, 2 );
 
@@ -60,7 +60,7 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 
 	effectsLayout->addWidget( m_scrollArea );
 
-	auto* addButton = new QPushButton;
+	QPushButton* addButton = new QPushButton;
 	addButton->setText( tr( "Add effect" ) );
 
 	effectsLayout->addWidget( addButton );
@@ -170,7 +170,7 @@ void EffectRackView::update()
 		}
 		if( i >= m_effectViews.size() )
 		{
-			auto* view = new EffectView(*it, w);
+			EffectView * view = new EffectView( *it, w );
 			connect( view, SIGNAL(moveUp(lmms::gui::EffectView*)),
 					this, SLOT(moveUp(lmms::gui::EffectView*)));
 			connect( view, SIGNAL(moveDown(lmms::gui::EffectView*)),

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -85,8 +85,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 	if( effect()->controls()->controlCount() > 0 )
 	{
-		QPushButton * ctls_btn = new QPushButton( tr( "Controls" ),
-									this );
+		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
 		ctls_btn->setFont( pointSize<8>( f ) );
 		ctls_btn->setGeometry( 150, 14, 50, 20 );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -85,8 +85,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 	if( effect()->controls()->controlCount() > 0 )
 	{
-		QPushButton * ctls_btn = new QPushButton( tr( "Controls" ),
-									this );
+		auto* ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
 		ctls_btn->setFont( pointSize<8>( f ) );
 		ctls_btn->setGeometry( 150, 14, 50, 20 );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -85,7 +85,8 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 	if( effect()->controls()->controlCount() > 0 )
 	{
-		auto* ctls_btn = new QPushButton(tr("Controls"), this);
+		QPushButton * ctls_btn = new QPushButton( tr( "Controls" ),
+									this );
 		QFont f = ctls_btn->font();
 		ctls_btn->setFont( pointSize<8>( f ) );
 		ctls_btn->setGeometry( 150, 14, 50, 20 );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -115,10 +115,10 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 		addContentCheckBox();
 	}
 
-	QWidget * searchWidget = new QWidget( contentParent() );
+	auto searchWidget = new QWidget(contentParent());
 	searchWidget->setFixedHeight( 24 );
 
-	QHBoxLayout * searchWidgetLayout = new QHBoxLayout( searchWidget );
+	auto searchWidgetLayout = new QHBoxLayout(searchWidget);
 	searchWidgetLayout->setMargin( 0 );
 	searchWidgetLayout->setSpacing( 0 );
 
@@ -128,9 +128,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	connect( m_filterEdit, SIGNAL( textEdited( const QString& ) ),
 			this, SLOT( filterItems( const QString& ) ) );
 
-	QPushButton * reload_btn = new QPushButton(
-				embed::getIconPixmap( "reload" ),
-						QString(), searchWidget );
+	auto reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
 	reload_btn->setToolTip( tr( "Refresh list" ) );
 	connect( reload_btn, SIGNAL(clicked()), this, SLOT(reloadTree()));
 
@@ -144,7 +142,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	addContentWidget( m_fileBrowserTreeWidget );
 
 	// Whenever the FileBrowser has focus, Ctrl+F should direct focus to its filter box.
-	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( QKeySequence::Find ), this, SLOT(giveFocusToFilter()));
+	auto filterFocusShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this, SLOT(giveFocusToFilter()));
 	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
 	reloadTree();
@@ -241,7 +239,7 @@ void FileBrowser::expandItems( QTreeWidgetItem * item, QList<QString> expandedDi
 		{
 			it->setExpanded( true );
 		}
-		Directory *d = dynamic_cast<Directory *> ( it );
+		auto d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
 			d->update();
@@ -290,13 +288,11 @@ void FileBrowser::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < m_fileBrowserTreeWidget->topLevelItemCount(); ++i )
 			{
-				Directory * d = dynamic_cast<Directory *>(
-						m_fileBrowserTreeWidget->topLevelItem( i ) );
+				auto d = dynamic_cast<Directory*>(m_fileBrowserTreeWidget->topLevelItem(i));
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done
-					Directory *dd = new Directory( cur_file, path,
-												   m_filter );
+					auto dd = new Directory(cur_file, path, m_filter);
 					m_fileBrowserTreeWidget->insertTopLevelItem( i,dd );
 					dd->update(); // add files to the directory
 					orphan = false;
@@ -319,8 +315,7 @@ void FileBrowser::addItems(const QString & path )
 			{
 				// it has not yet been added yet, so it's (lexically)
 				// larger than all other dirs => append it at the bottom
-				Directory *d = new Directory( cur_file,
-											  path, m_filter );
+				auto d = new Directory(cur_file, path, m_filter);
 				d->update();
 				m_fileBrowserTreeWidget->addTopLevelItem( d );
 			}
@@ -411,7 +406,7 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 		// Add expanded top level directories.
 		if (it->isExpanded() && (it->type() == TypeDirectoryItem))
 		{
-			Directory *d = static_cast<Directory *> ( it );
+			auto d = static_cast<Directory*>(it);
 			dirs.append( d->fullName() );
 		}
 
@@ -444,7 +439,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	else if (vertical || horizontal || preview || insert) { stopPreview(); }
 
 	// Try to get the currently selected item as a FileItem
-	FileItem * file = dynamic_cast<FileItem *>(currentItem());
+	auto file = dynamic_cast<FileItem*>(currentItem());
 	// If it's null (folder, separator, etc.), there's nothing left for us to do
 	if (file == nullptr) { return; }
 
@@ -505,7 +500,7 @@ void FileBrowserTreeWidget::focusOutEvent(QFocusEvent* fe)
 
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
-	FileItem * file = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
+	auto file = dynamic_cast<FileItem*>(itemAt(e->pos()));
 	if( file != nullptr && file->isTrack() )
 	{
 		QMenu contextMenu( this );
@@ -523,12 +518,12 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 			[=]{ openContainingFolder(file); }
 		);
 
-		QAction* songEditorHeader = new QAction( tr("Song Editor"), nullptr );
+		auto songEditorHeader = new QAction(tr("Song Editor"), nullptr);
 		songEditorHeader->setDisabled(true);
 		contextMenu.addAction( songEditorHeader );
 		contextMenu.addActions( getContextActions(file, true) );
 
-		QAction* patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
+		auto patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
 		patternEditorHeader->setDisabled(true);
 		contextMenu.addAction(patternEditorHeader);
 		contextMenu.addActions( getContextActions(file, false) );
@@ -551,20 +546,14 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 		tr("Send to new instrument track");
 	QString shortcutMod = songEditor ? "" : UI_CTRL_KEY + QString(" + ");
 
-	QAction* toInstrument = new QAction(
-		instrumentAction + tr(" (%2Enter)").arg(shortcutMod),
-		nullptr
-	);
+	auto toInstrument = new QAction(instrumentAction + tr(" (%2Enter)").arg(shortcutMod), nullptr);
 	connect(toInstrument, &QAction::triggered,
 		[=]{ openInNewInstrumentTrack(file, songEditor); });
 	result.append(toInstrument);
 
 	if (songEditor && fileIsSample)
 	{
-		QAction* toSampleTrack = new QAction(
-			tr("Send to new sample track (Shift + Enter)"),
-			nullptr
-		);
+		auto toSampleTrack = new QAction(tr("Send to new sample track (Shift + Enter)"), nullptr);
 		connect(toSampleTrack, &QAction::triggered,
 			[=]{ openInNewSampleTrack(file); });
 		result.append(toSampleTrack);
@@ -598,7 +587,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 //		}
 	}
 
-	FileItem * f = dynamic_cast<FileItem *>(i);
+	auto f = dynamic_cast<FileItem*>(i);
 	if(f != nullptr) { previewFileItem(f); }
 }
 
@@ -626,7 +615,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			embed::getIconPixmap("sample_file", 24, 24), 0);
 		// TODO: this can be removed once we do this outside the event thread
 		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-		SamplePlayHandle* s = new SamplePlayHandle(fileName);
+		auto s = new SamplePlayHandle(fileName);
 		s->setDoneMayReturnTrue(false);
 		newPPH = s;
 		delete tf;
@@ -691,7 +680,7 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 		// make sure any playback is stopped
 		mouseReleaseEvent( nullptr );
 
-		FileItem * f = dynamic_cast<FileItem *>( itemAt( m_pressPos ) );
+		auto f = dynamic_cast<FileItem*>(itemAt(m_pressPos));
 		if( f != nullptr )
 		{
 			switch( f->type() )
@@ -808,7 +797,7 @@ void FileBrowserTreeWidget::handleFile(FileItem * f, InstrumentTrack * it)
 void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 								int column )
 {
-	FileItem * f = dynamic_cast<FileItem *>( item );
+	auto f = dynamic_cast<FileItem*>(item);
 	if( f == nullptr )
 	{
 		return;
@@ -821,9 +810,7 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 	}
 	else if( f->handling() != FileItem::NotSupported )
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-			Track::create(Track::InstrumentTrack, Engine::patternStore())
-		);
+		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, Engine::patternStore()));
 		handleFile( f, it );
 	}
 }
@@ -835,8 +822,7 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(TrackContainer* tc, FileIte
 {
 	if(item->isTrack())
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-				Track::create(Track::InstrumentTrack, tc));
+		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, tc));
 		handleFile(item, it);
 	}
 }
@@ -861,8 +847,7 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 	if (item->type() != FileItem::SampleFile) { return false; }
 
 	// Create a new sample track for this sample
-	SampleTrack* sampleTrack = static_cast<SampleTrack*>(
-		Track::create(Track::SampleTrack, Engine::getSong()));
+	auto sampleTrack = static_cast<SampleTrack*>(Track::create(Track::SampleTrack, Engine::getSong()));
 
 	// Add the sample clip to the track
 	Engine::audioEngine()->requestChangeInModel();
@@ -902,9 +887,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 	// instrument-track
 	while( w.hasPrevious() )
 	{
-		InstrumentTrackWindow * itw =
-			dynamic_cast<InstrumentTrackWindow *>(
-						w.previous()->widget() );
+		auto itw = dynamic_cast<InstrumentTrackWindow*>(w.previous()->widget());
 		if( itw != nullptr && itw->isHidden() == false )
 		{
 			handleFile( item, itw->model() );
@@ -918,7 +901,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 
 void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 {
-	Directory * dir = dynamic_cast<Directory *>( item );
+	auto dir = dynamic_cast<Directory*>(item);
 	if( dir != nullptr )
 	{
 		dir->update();
@@ -1009,7 +992,7 @@ void Directory::update()
 				int filesNow = childCount() - m_dirCount;
 				if(filesNow > filesBeforeAdd) // any file appended?
 				{
-					QTreeWidgetItem * sep = new QTreeWidgetItem;
+					auto sep = new QTreeWidgetItem;
 					sep->setText( 0,
 						FileBrowserTreeWidget::tr(
 							"--- Factory files ---" ) );
@@ -1049,8 +1032,7 @@ bool Directory::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < childCount(); ++i )
 			{
-				Directory * d = dynamic_cast<Directory *>(
-								child( i ) );
+				auto d = dynamic_cast<Directory*>(child(i));
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -115,10 +115,10 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 		addContentCheckBox();
 	}
 
-	auto* searchWidget = new QWidget(contentParent());
+	QWidget * searchWidget = new QWidget( contentParent() );
 	searchWidget->setFixedHeight( 24 );
 
-	auto* searchWidgetLayout = new QHBoxLayout(searchWidget);
+	QHBoxLayout * searchWidgetLayout = new QHBoxLayout( searchWidget );
 	searchWidgetLayout->setMargin( 0 );
 	searchWidgetLayout->setSpacing( 0 );
 
@@ -128,7 +128,9 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	connect( m_filterEdit, SIGNAL( textEdited( const QString& ) ),
 			this, SLOT( filterItems( const QString& ) ) );
 
-	auto* reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
+	QPushButton * reload_btn = new QPushButton(
+				embed::getIconPixmap( "reload" ),
+						QString(), searchWidget );
 	reload_btn->setToolTip( tr( "Refresh list" ) );
 	connect( reload_btn, SIGNAL(clicked()), this, SLOT(reloadTree()));
 
@@ -142,7 +144,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	addContentWidget( m_fileBrowserTreeWidget );
 
 	// Whenever the FileBrowser has focus, Ctrl+F should direct focus to its filter box.
-	auto* filterFocusShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this, SLOT(giveFocusToFilter()));
+	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( QKeySequence::Find ), this, SLOT(giveFocusToFilter()));
 	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
 	reloadTree();
@@ -239,7 +241,7 @@ void FileBrowser::expandItems( QTreeWidgetItem * item, QList<QString> expandedDi
 		{
 			it->setExpanded( true );
 		}
-		auto* d = dynamic_cast<Directory*>(it);
+		Directory *d = dynamic_cast<Directory *> ( it );
 		if (d)
 		{
 			d->update();
@@ -288,11 +290,13 @@ void FileBrowser::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < m_fileBrowserTreeWidget->topLevelItemCount(); ++i )
 			{
-				auto* d = dynamic_cast<Directory*>(m_fileBrowserTreeWidget->topLevelItem(i));
+				Directory * d = dynamic_cast<Directory *>(
+						m_fileBrowserTreeWidget->topLevelItem( i ) );
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done
-					auto* dd = new Directory(cur_file, path, m_filter);
+					Directory *dd = new Directory( cur_file, path,
+												   m_filter );
 					m_fileBrowserTreeWidget->insertTopLevelItem( i,dd );
 					dd->update(); // add files to the directory
 					orphan = false;
@@ -315,7 +319,8 @@ void FileBrowser::addItems(const QString & path )
 			{
 				// it has not yet been added yet, so it's (lexically)
 				// larger than all other dirs => append it at the bottom
-				auto* d = new Directory(cur_file, path, m_filter);
+				Directory *d = new Directory( cur_file,
+											  path, m_filter );
 				d->update();
 				m_fileBrowserTreeWidget->addTopLevelItem( d );
 			}
@@ -406,7 +411,7 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 		// Add expanded top level directories.
 		if (it->isExpanded() && (it->type() == TypeDirectoryItem))
 		{
-			auto* d = static_cast<Directory*>(it);
+			Directory *d = static_cast<Directory *> ( it );
 			dirs.append( d->fullName() );
 		}
 
@@ -439,7 +444,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	else if (vertical || horizontal || preview || insert) { stopPreview(); }
 
 	// Try to get the currently selected item as a FileItem
-	auto* file = dynamic_cast<FileItem*>(currentItem());
+	FileItem * file = dynamic_cast<FileItem *>(currentItem());
 	// If it's null (folder, separator, etc.), there's nothing left for us to do
 	if (file == nullptr) { return; }
 
@@ -500,7 +505,7 @@ void FileBrowserTreeWidget::focusOutEvent(QFocusEvent* fe)
 
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
-	auto* file = dynamic_cast<FileItem*>(itemAt(e->pos()));
+	FileItem * file = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
 	if( file != nullptr && file->isTrack() )
 	{
 		QMenu contextMenu( this );
@@ -518,12 +523,12 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 			[=]{ openContainingFolder(file); }
 		);
 
-		auto* songEditorHeader = new QAction(tr("Song Editor"), nullptr);
+		QAction* songEditorHeader = new QAction( tr("Song Editor"), nullptr );
 		songEditorHeader->setDisabled(true);
 		contextMenu.addAction( songEditorHeader );
 		contextMenu.addActions( getContextActions(file, true) );
 
-		auto* patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
+		QAction* patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
 		patternEditorHeader->setDisabled(true);
 		contextMenu.addAction(patternEditorHeader);
 		contextMenu.addActions( getContextActions(file, false) );
@@ -546,14 +551,20 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 		tr("Send to new instrument track");
 	QString shortcutMod = songEditor ? "" : UI_CTRL_KEY + QString(" + ");
 
-	auto* toInstrument = new QAction(instrumentAction + tr(" (%2Enter)").arg(shortcutMod), nullptr);
+	QAction* toInstrument = new QAction(
+		instrumentAction + tr(" (%2Enter)").arg(shortcutMod),
+		nullptr
+	);
 	connect(toInstrument, &QAction::triggered,
 		[=]{ openInNewInstrumentTrack(file, songEditor); });
 	result.append(toInstrument);
 
 	if (songEditor && fileIsSample)
 	{
-		auto* toSampleTrack = new QAction(tr("Send to new sample track (Shift + Enter)"), nullptr);
+		QAction* toSampleTrack = new QAction(
+			tr("Send to new sample track (Shift + Enter)"),
+			nullptr
+		);
 		connect(toSampleTrack, &QAction::triggered,
 			[=]{ openInNewSampleTrack(file); });
 		result.append(toSampleTrack);
@@ -587,7 +598,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 //		}
 	}
 
-	auto* f = dynamic_cast<FileItem*>(i);
+	FileItem * f = dynamic_cast<FileItem *>(i);
 	if(f != nullptr) { previewFileItem(f); }
 }
 
@@ -615,7 +626,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			embed::getIconPixmap("sample_file", 24, 24), 0);
 		// TODO: this can be removed once we do this outside the event thread
 		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-		auto* s = new SamplePlayHandle(fileName);
+		SamplePlayHandle* s = new SamplePlayHandle(fileName);
 		s->setDoneMayReturnTrue(false);
 		newPPH = s;
 		delete tf;
@@ -680,7 +691,7 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 		// make sure any playback is stopped
 		mouseReleaseEvent( nullptr );
 
-		auto* f = dynamic_cast<FileItem*>(itemAt(m_pressPos));
+		FileItem * f = dynamic_cast<FileItem *>( itemAt( m_pressPos ) );
 		if( f != nullptr )
 		{
 			switch( f->type() )
@@ -797,7 +808,7 @@ void FileBrowserTreeWidget::handleFile(FileItem * f, InstrumentTrack * it)
 void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 								int column )
 {
-	auto* f = dynamic_cast<FileItem*>(item);
+	FileItem * f = dynamic_cast<FileItem *>( item );
 	if( f == nullptr )
 	{
 		return;
@@ -810,7 +821,9 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 	}
 	else if( f->handling() != FileItem::NotSupported )
 	{
-		auto* it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, Engine::patternStore()));
+		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
+			Track::create(Track::InstrumentTrack, Engine::patternStore())
+		);
 		handleFile( f, it );
 	}
 }
@@ -822,7 +835,8 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(TrackContainer* tc, FileIte
 {
 	if(item->isTrack())
 	{
-		auto* it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, tc));
+		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
+				Track::create(Track::InstrumentTrack, tc));
 		handleFile(item, it);
 	}
 }
@@ -847,7 +861,8 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 	if (item->type() != FileItem::SampleFile) { return false; }
 
 	// Create a new sample track for this sample
-	auto* sampleTrack = static_cast<SampleTrack*>(Track::create(Track::SampleTrack, Engine::getSong()));
+	SampleTrack* sampleTrack = static_cast<SampleTrack*>(
+		Track::create(Track::SampleTrack, Engine::getSong()));
 
 	// Add the sample clip to the track
 	Engine::audioEngine()->requestChangeInModel();
@@ -887,7 +902,9 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 	// instrument-track
 	while( w.hasPrevious() )
 	{
-		auto* itw = dynamic_cast<InstrumentTrackWindow*>(w.previous()->widget());
+		InstrumentTrackWindow * itw =
+			dynamic_cast<InstrumentTrackWindow *>(
+						w.previous()->widget() );
 		if( itw != nullptr && itw->isHidden() == false )
 		{
 			handleFile( item, itw->model() );
@@ -901,7 +918,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 
 void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 {
-	auto* dir = dynamic_cast<Directory*>(item);
+	Directory * dir = dynamic_cast<Directory *>( item );
 	if( dir != nullptr )
 	{
 		dir->update();
@@ -992,7 +1009,7 @@ void Directory::update()
 				int filesNow = childCount() - m_dirCount;
 				if(filesNow > filesBeforeAdd) // any file appended?
 				{
-					auto* sep = new QTreeWidgetItem;
+					QTreeWidgetItem * sep = new QTreeWidgetItem;
 					sep->setText( 0,
 						FileBrowserTreeWidget::tr(
 							"--- Factory files ---" ) );
@@ -1032,7 +1049,8 @@ bool Directory::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < childCount(); ++i )
 			{
-				auto* d = dynamic_cast<Directory*>(child(i));
+				Directory * d = dynamic_cast<Directory *>(
+								child( i ) );
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -115,10 +115,10 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 		addContentCheckBox();
 	}
 
-	QWidget * searchWidget = new QWidget( contentParent() );
+	auto* searchWidget = new QWidget(contentParent());
 	searchWidget->setFixedHeight( 24 );
 
-	QHBoxLayout * searchWidgetLayout = new QHBoxLayout( searchWidget );
+	auto* searchWidgetLayout = new QHBoxLayout(searchWidget);
 	searchWidgetLayout->setMargin( 0 );
 	searchWidgetLayout->setSpacing( 0 );
 
@@ -128,9 +128,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	connect( m_filterEdit, SIGNAL( textEdited( const QString& ) ),
 			this, SLOT( filterItems( const QString& ) ) );
 
-	QPushButton * reload_btn = new QPushButton(
-				embed::getIconPixmap( "reload" ),
-						QString(), searchWidget );
+	auto* reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
 	reload_btn->setToolTip( tr( "Refresh list" ) );
 	connect( reload_btn, SIGNAL(clicked()), this, SLOT(reloadTree()));
 
@@ -144,7 +142,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	addContentWidget( m_fileBrowserTreeWidget );
 
 	// Whenever the FileBrowser has focus, Ctrl+F should direct focus to its filter box.
-	QShortcut *filterFocusShortcut = new QShortcut( QKeySequence( QKeySequence::Find ), this, SLOT(giveFocusToFilter()));
+	auto* filterFocusShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this, SLOT(giveFocusToFilter()));
 	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
 	reloadTree();
@@ -241,7 +239,7 @@ void FileBrowser::expandItems( QTreeWidgetItem * item, QList<QString> expandedDi
 		{
 			it->setExpanded( true );
 		}
-		Directory *d = dynamic_cast<Directory *> ( it );
+		auto* d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
 			d->update();
@@ -290,13 +288,11 @@ void FileBrowser::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < m_fileBrowserTreeWidget->topLevelItemCount(); ++i )
 			{
-				Directory * d = dynamic_cast<Directory *>(
-						m_fileBrowserTreeWidget->topLevelItem( i ) );
+				auto* d = dynamic_cast<Directory*>(m_fileBrowserTreeWidget->topLevelItem(i));
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done
-					Directory *dd = new Directory( cur_file, path,
-												   m_filter );
+					auto* dd = new Directory(cur_file, path, m_filter);
 					m_fileBrowserTreeWidget->insertTopLevelItem( i,dd );
 					dd->update(); // add files to the directory
 					orphan = false;
@@ -319,8 +315,7 @@ void FileBrowser::addItems(const QString & path )
 			{
 				// it has not yet been added yet, so it's (lexically)
 				// larger than all other dirs => append it at the bottom
-				Directory *d = new Directory( cur_file,
-											  path, m_filter );
+				auto* d = new Directory(cur_file, path, m_filter);
 				d->update();
 				m_fileBrowserTreeWidget->addTopLevelItem( d );
 			}
@@ -411,7 +406,7 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 		// Add expanded top level directories.
 		if (it->isExpanded() && (it->type() == TypeDirectoryItem))
 		{
-			Directory *d = static_cast<Directory *> ( it );
+			auto* d = static_cast<Directory*>(it);
 			dirs.append( d->fullName() );
 		}
 
@@ -444,7 +439,7 @@ void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 	else if (vertical || horizontal || preview || insert) { stopPreview(); }
 
 	// Try to get the currently selected item as a FileItem
-	FileItem * file = dynamic_cast<FileItem *>(currentItem());
+	auto* file = dynamic_cast<FileItem*>(currentItem());
 	// If it's null (folder, separator, etc.), there's nothing left for us to do
 	if (file == nullptr) { return; }
 
@@ -505,7 +500,7 @@ void FileBrowserTreeWidget::focusOutEvent(QFocusEvent* fe)
 
 void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 {
-	FileItem * file = dynamic_cast<FileItem *>( itemAt( e->pos() ) );
+	auto* file = dynamic_cast<FileItem*>(itemAt(e->pos()));
 	if( file != nullptr && file->isTrack() )
 	{
 		QMenu contextMenu( this );
@@ -523,12 +518,12 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent * e )
 			[=]{ openContainingFolder(file); }
 		);
 
-		QAction* songEditorHeader = new QAction( tr("Song Editor"), nullptr );
+		auto* songEditorHeader = new QAction(tr("Song Editor"), nullptr);
 		songEditorHeader->setDisabled(true);
 		contextMenu.addAction( songEditorHeader );
 		contextMenu.addActions( getContextActions(file, true) );
 
-		QAction* patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
+		auto* patternEditorHeader = new QAction(tr("Pattern Editor"), nullptr);
 		patternEditorHeader->setDisabled(true);
 		contextMenu.addAction(patternEditorHeader);
 		contextMenu.addActions( getContextActions(file, false) );
@@ -551,20 +546,14 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 		tr("Send to new instrument track");
 	QString shortcutMod = songEditor ? "" : UI_CTRL_KEY + QString(" + ");
 
-	QAction* toInstrument = new QAction(
-		instrumentAction + tr(" (%2Enter)").arg(shortcutMod),
-		nullptr
-	);
+	auto* toInstrument = new QAction(instrumentAction + tr(" (%2Enter)").arg(shortcutMod), nullptr);
 	connect(toInstrument, &QAction::triggered,
 		[=]{ openInNewInstrumentTrack(file, songEditor); });
 	result.append(toInstrument);
 
 	if (songEditor && fileIsSample)
 	{
-		QAction* toSampleTrack = new QAction(
-			tr("Send to new sample track (Shift + Enter)"),
-			nullptr
-		);
+		auto* toSampleTrack = new QAction(tr("Send to new sample track (Shift + Enter)"), nullptr);
 		connect(toSampleTrack, &QAction::triggered,
 			[=]{ openInNewSampleTrack(file); });
 		result.append(toSampleTrack);
@@ -598,7 +587,7 @@ void FileBrowserTreeWidget::mousePressEvent(QMouseEvent * me )
 //		}
 	}
 
-	FileItem * f = dynamic_cast<FileItem *>(i);
+	auto* f = dynamic_cast<FileItem*>(i);
 	if(f != nullptr) { previewFileItem(f); }
 }
 
@@ -626,7 +615,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			embed::getIconPixmap("sample_file", 24, 24), 0);
 		// TODO: this can be removed once we do this outside the event thread
 		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-		SamplePlayHandle* s = new SamplePlayHandle(fileName);
+		auto* s = new SamplePlayHandle(fileName);
 		s->setDoneMayReturnTrue(false);
 		newPPH = s;
 		delete tf;
@@ -691,7 +680,7 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 		// make sure any playback is stopped
 		mouseReleaseEvent( nullptr );
 
-		FileItem * f = dynamic_cast<FileItem *>( itemAt( m_pressPos ) );
+		auto* f = dynamic_cast<FileItem*>(itemAt(m_pressPos));
 		if( f != nullptr )
 		{
 			switch( f->type() )
@@ -808,7 +797,7 @@ void FileBrowserTreeWidget::handleFile(FileItem * f, InstrumentTrack * it)
 void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 								int column )
 {
-	FileItem * f = dynamic_cast<FileItem *>( item );
+	auto* f = dynamic_cast<FileItem*>(item);
 	if( f == nullptr )
 	{
 		return;
@@ -821,9 +810,7 @@ void FileBrowserTreeWidget::activateListItem(QTreeWidgetItem * item,
 	}
 	else if( f->handling() != FileItem::NotSupported )
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-			Track::create(Track::InstrumentTrack, Engine::patternStore())
-		);
+		auto* it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, Engine::patternStore()));
 		handleFile( f, it );
 	}
 }
@@ -835,8 +822,7 @@ void FileBrowserTreeWidget::openInNewInstrumentTrack(TrackContainer* tc, FileIte
 {
 	if(item->isTrack())
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-				Track::create(Track::InstrumentTrack, tc));
+		auto* it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, tc));
 		handleFile(item, it);
 	}
 }
@@ -861,8 +847,7 @@ bool FileBrowserTreeWidget::openInNewSampleTrack(FileItem* item)
 	if (item->type() != FileItem::SampleFile) { return false; }
 
 	// Create a new sample track for this sample
-	SampleTrack* sampleTrack = static_cast<SampleTrack*>(
-		Track::create(Track::SampleTrack, Engine::getSong()));
+	auto* sampleTrack = static_cast<SampleTrack*>(Track::create(Track::SampleTrack, Engine::getSong()));
 
 	// Add the sample clip to the track
 	Engine::audioEngine()->requestChangeInModel();
@@ -902,9 +887,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 	// instrument-track
 	while( w.hasPrevious() )
 	{
-		InstrumentTrackWindow * itw =
-			dynamic_cast<InstrumentTrackWindow *>(
-						w.previous()->widget() );
+		auto* itw = dynamic_cast<InstrumentTrackWindow*>(w.previous()->widget());
 		if( itw != nullptr && itw->isHidden() == false )
 		{
 			handleFile( item, itw->model() );
@@ -918,7 +901,7 @@ void FileBrowserTreeWidget::sendToActiveInstrumentTrack( FileItem* item )
 
 void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 {
-	Directory * dir = dynamic_cast<Directory *>( item );
+	auto* dir = dynamic_cast<Directory*>(item);
 	if( dir != nullptr )
 	{
 		dir->update();
@@ -1009,7 +992,7 @@ void Directory::update()
 				int filesNow = childCount() - m_dirCount;
 				if(filesNow > filesBeforeAdd) // any file appended?
 				{
-					QTreeWidgetItem * sep = new QTreeWidgetItem;
+					auto* sep = new QTreeWidgetItem;
 					sep->setText( 0,
 						FileBrowserTreeWidget::tr(
 							"--- Factory files ---" ) );
@@ -1049,8 +1032,7 @@ bool Directory::addItems(const QString & path )
 			bool orphan = true;
 			for( int i = 0; i < childCount(); ++i )
 			{
-				Directory * d = dynamic_cast<Directory *>(
-								child( i ) );
+				auto* d = dynamic_cast<Directory*>(child(i));
 				if( d == nullptr || cur_file < d->text( 0 ) )
 				{
 					// insert before item, we're done

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -91,11 +91,11 @@ GuiApplication::GuiApplication()
 	QDir::addSearchPath("artwork", ConfigManager::inst()->defaultThemeDir());
 	QDir::addSearchPath("artwork", ":/artwork");
 
-	auto* lmmsstyle = new LmmsStyle();
+	LmmsStyle* lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);
 
-	auto* lmmspal = new LmmsPalette(nullptr, lmmsstyle);
-	auto* lpal = new QPalette(lmmspal->palette());
+	LmmsPalette* lmmspal = new LmmsPalette(nullptr, lmmsstyle);
+	QPalette* lpal = new QPalette(lmmspal->palette());
 
 	QApplication::setPalette( *lpal );
 	LmmsStyle::s_palette = lpal;

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -91,11 +91,11 @@ GuiApplication::GuiApplication()
 	QDir::addSearchPath("artwork", ConfigManager::inst()->defaultThemeDir());
 	QDir::addSearchPath("artwork", ":/artwork");
 
-	LmmsStyle* lmmsstyle = new LmmsStyle();
+	auto* lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);
 
-	LmmsPalette* lmmspal = new LmmsPalette(nullptr, lmmsstyle);
-	QPalette* lpal = new QPalette(lmmspal->palette());
+	auto* lmmspal = new LmmsPalette(nullptr, lmmsstyle);
+	auto* lpal = new QPalette(lmmspal->palette());
 
 	QApplication::setPalette( *lpal );
 	LmmsStyle::s_palette = lpal;

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -91,11 +91,11 @@ GuiApplication::GuiApplication()
 	QDir::addSearchPath("artwork", ConfigManager::inst()->defaultThemeDir());
 	QDir::addSearchPath("artwork", ":/artwork");
 
-	LmmsStyle* lmmsstyle = new LmmsStyle();
+	auto lmmsstyle = new LmmsStyle();
 	QApplication::setStyle(lmmsstyle);
 
-	LmmsPalette* lmmspal = new LmmsPalette(nullptr, lmmsstyle);
-	QPalette* lpal = new QPalette(lmmspal->palette());
+	auto lmmspal = new LmmsPalette(nullptr, lmmsstyle);
+	auto lpal = new QPalette(lmmspal->palette());
 
 	QApplication::setPalette( *lpal );
 	LmmsStyle::s_palette = lpal;

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -42,7 +42,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	ModelView( _ctl, this ),
 	m_ctl( _ctl )
 {
-	QHBoxLayout * layout = new QHBoxLayout( this );
+	auto* layout = new QHBoxLayout(this);
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );
 
@@ -62,8 +62,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	{
 		case TOGGLED:
 		{
-			LedCheckBox * toggle = new LedCheckBox(
-				m_ctl->port()->name, this, QString(), LedCheckBox::Green );
+			auto* toggle = new LedCheckBox(m_ctl->port()->name, this, QString(), LedCheckBox::Green);
 			toggle->setModel( m_ctl->toggledModel() );
 			layout->addWidget( toggle );
 			if( link != nullptr )

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -42,7 +42,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	ModelView( _ctl, this ),
 	m_ctl( _ctl )
 {
-	QHBoxLayout * layout = new QHBoxLayout( this );
+	auto layout = new QHBoxLayout(this);
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );
 
@@ -62,8 +62,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	{
 		case TOGGLED:
 		{
-			LedCheckBox * toggle = new LedCheckBox(
-				m_ctl->port()->name, this, QString(), LedCheckBox::Green );
+			auto toggle = new LedCheckBox(m_ctl->port()->name, this, QString(), LedCheckBox::Green);
 			toggle->setModel( m_ctl->toggledModel() );
 			layout->addWidget( toggle );
 			if( link != nullptr )

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -42,7 +42,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	ModelView( _ctl, this ),
 	m_ctl( _ctl )
 {
-	auto* layout = new QHBoxLayout(this);
+	QHBoxLayout * layout = new QHBoxLayout( this );
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );
 
@@ -62,7 +62,8 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	{
 		case TOGGLED:
 		{
-			auto* toggle = new LedCheckBox(m_ctl->port()->name, this, QString(), LedCheckBox::Green);
+			LedCheckBox * toggle = new LedCheckBox(
+				m_ctl->port()->name, this, QString(), LedCheckBox::Green );
 			toggle->setModel( m_ctl->toggledModel() );
 			layout->addWidget( toggle );
 			if( link != nullptr )

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -81,7 +81,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 
-	PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
+	auto sin_wave_btn = new PixmapButton(this, nullptr);
 	sin_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y );
 	sin_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -90,8 +90,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sin_wave_btn->setToolTip(
 			tr( "Sine wave" ) );
 
-	PixmapButton * triangle_wave_btn =
-					new PixmapButton( this, nullptr );
+	auto triangle_wave_btn = new PixmapButton(this, nullptr);
 	triangle_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y );
 	triangle_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -100,7 +99,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	triangle_wave_btn->setToolTip(
 			tr( "Triangle wave" ) );
 
-	PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
+	auto saw_wave_btn = new PixmapButton(this, nullptr);
 	saw_wave_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y );
 	saw_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -109,7 +108,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	saw_wave_btn->setToolTip(
 			tr( "Saw wave" ) );
 
-	PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
+	auto sqr_wave_btn = new PixmapButton(this, nullptr);
 	sqr_wave_btn->move( CD_LFO_SHAPES_X + 45, CD_LFO_SHAPES_Y );
 	sqr_wave_btn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -118,8 +117,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sqr_wave_btn->setToolTip(
 			tr( "Square wave" ) );
 
-	PixmapButton * moog_saw_wave_btn =
-					new PixmapButton( this, nullptr );
+	auto moog_saw_wave_btn = new PixmapButton(this, nullptr);
 	moog_saw_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y + 15 );
 	moog_saw_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -128,7 +126,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	moog_saw_wave_btn->setToolTip(
 			tr( "Moog saw wave" ) );
 
-	PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
+	auto exp_wave_btn = new PixmapButton(this, nullptr);
 	exp_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y + 15 );
 	exp_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"exp_wave_active" ) );
@@ -137,7 +135,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	exp_wave_btn->setToolTip(
 			tr( "Exponential wave" ) );
 
-	PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
+	auto white_noise_btn = new PixmapButton(this, nullptr);
 	white_noise_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y + 15 );
 	white_noise_btn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -168,8 +166,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_waveBtnGrp->addButton( white_noise_btn );
 	m_waveBtnGrp->addButton( m_userWaveBtn );
 
-
-	PixmapButton * x1 = new PixmapButton( this, nullptr );
+	auto x1 = new PixmapButton(this, nullptr);
 	x1->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y +7);
 	x1->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x1_active" ) );
@@ -178,7 +175,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x1->setToolTip(
 				tr( "Mutliply modulation frequency by 1" ));
 
-	PixmapButton * x100 = new PixmapButton( this, nullptr );
+	auto x100 = new PixmapButton(this, nullptr);
 	x100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y - 8 );
 	x100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x100_active" ) );
@@ -187,7 +184,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x100->setToolTip(
 				tr( "Mutliply modulation frequency by 100" ));
 
-	PixmapButton * d100 = new PixmapButton( this, nullptr );
+	auto d100 = new PixmapButton(this, nullptr);
 	d100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y + 22 );
 	d100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_d100_active" ) );

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -81,7 +81,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 
-	auto* sin_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
 	sin_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y );
 	sin_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -90,7 +90,8 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sin_wave_btn->setToolTip(
 			tr( "Sine wave" ) );
 
-	auto* triangle_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * triangle_wave_btn =
+					new PixmapButton( this, nullptr );
 	triangle_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y );
 	triangle_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -99,7 +100,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	triangle_wave_btn->setToolTip(
 			tr( "Triangle wave" ) );
 
-	auto* saw_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
 	saw_wave_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y );
 	saw_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -108,7 +109,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	saw_wave_btn->setToolTip(
 			tr( "Saw wave" ) );
 
-	auto* sqr_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
 	sqr_wave_btn->move( CD_LFO_SHAPES_X + 45, CD_LFO_SHAPES_Y );
 	sqr_wave_btn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -117,7 +118,8 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sqr_wave_btn->setToolTip(
 			tr( "Square wave" ) );
 
-	auto* moog_saw_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * moog_saw_wave_btn =
+					new PixmapButton( this, nullptr );
 	moog_saw_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y + 15 );
 	moog_saw_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -126,7 +128,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	moog_saw_wave_btn->setToolTip(
 			tr( "Moog saw wave" ) );
 
-	auto* exp_wave_btn = new PixmapButton(this, nullptr);
+	PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
 	exp_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y + 15 );
 	exp_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"exp_wave_active" ) );
@@ -135,7 +137,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	exp_wave_btn->setToolTip(
 			tr( "Exponential wave" ) );
 
-	auto* white_noise_btn = new PixmapButton(this, nullptr);
+	PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
 	white_noise_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y + 15 );
 	white_noise_btn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -166,7 +168,8 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_waveBtnGrp->addButton( white_noise_btn );
 	m_waveBtnGrp->addButton( m_userWaveBtn );
 
-	auto* x1 = new PixmapButton(this, nullptr);
+
+	PixmapButton * x1 = new PixmapButton( this, nullptr );
 	x1->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y +7);
 	x1->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x1_active" ) );
@@ -175,7 +178,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x1->setToolTip(
 				tr( "Mutliply modulation frequency by 1" ));
 
-	auto* x100 = new PixmapButton(this, nullptr);
+	PixmapButton * x100 = new PixmapButton( this, nullptr );
 	x100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y - 8 );
 	x100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x100_active" ) );
@@ -184,7 +187,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x100->setToolTip(
 				tr( "Mutliply modulation frequency by 100" ));
 
-	auto* d100 = new PixmapButton(this, nullptr);
+	PixmapButton * d100 = new PixmapButton( this, nullptr );
 	d100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y + 22 );
 	d100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_d100_active" ) );

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -81,7 +81,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 
-	PixmapButton * sin_wave_btn = new PixmapButton( this, nullptr );
+	auto* sin_wave_btn = new PixmapButton(this, nullptr);
 	sin_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y );
 	sin_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"sin_wave_active" ) );
@@ -90,8 +90,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sin_wave_btn->setToolTip(
 			tr( "Sine wave" ) );
 
-	PixmapButton * triangle_wave_btn =
-					new PixmapButton( this, nullptr );
+	auto* triangle_wave_btn = new PixmapButton(this, nullptr);
 	triangle_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y );
 	triangle_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "triangle_wave_active" ) );
@@ -100,7 +99,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	triangle_wave_btn->setToolTip(
 			tr( "Triangle wave" ) );
 
-	PixmapButton * saw_wave_btn = new PixmapButton( this, nullptr );
+	auto* saw_wave_btn = new PixmapButton(this, nullptr);
 	saw_wave_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y );
 	saw_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"saw_wave_active" ) );
@@ -109,7 +108,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	saw_wave_btn->setToolTip(
 			tr( "Saw wave" ) );
 
-	PixmapButton * sqr_wave_btn = new PixmapButton( this, nullptr );
+	auto* sqr_wave_btn = new PixmapButton(this, nullptr);
 	sqr_wave_btn->move( CD_LFO_SHAPES_X + 45, CD_LFO_SHAPES_Y );
 	sqr_wave_btn->setActiveGraphic( embed::getIconPixmap(
 					"square_wave_active" ) );
@@ -118,8 +117,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	sqr_wave_btn->setToolTip(
 			tr( "Square wave" ) );
 
-	PixmapButton * moog_saw_wave_btn =
-					new PixmapButton( this, nullptr );
+	auto* moog_saw_wave_btn = new PixmapButton(this, nullptr);
 	moog_saw_wave_btn->move( CD_LFO_SHAPES_X, CD_LFO_SHAPES_Y + 15 );
 	moog_saw_wave_btn->setActiveGraphic(
 		embed::getIconPixmap( "moog_saw_wave_active" ) );
@@ -128,7 +126,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	moog_saw_wave_btn->setToolTip(
 			tr( "Moog saw wave" ) );
 
-	PixmapButton * exp_wave_btn = new PixmapButton( this, nullptr );
+	auto* exp_wave_btn = new PixmapButton(this, nullptr);
 	exp_wave_btn->move( CD_LFO_SHAPES_X + 15, CD_LFO_SHAPES_Y + 15 );
 	exp_wave_btn->setActiveGraphic( embed::getIconPixmap(
 						"exp_wave_active" ) );
@@ -137,7 +135,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	exp_wave_btn->setToolTip(
 			tr( "Exponential wave" ) );
 
-	PixmapButton * white_noise_btn = new PixmapButton( this, nullptr );
+	auto* white_noise_btn = new PixmapButton(this, nullptr);
 	white_noise_btn->move( CD_LFO_SHAPES_X + 30, CD_LFO_SHAPES_Y + 15 );
 	white_noise_btn->setActiveGraphic(
 		embed::getIconPixmap( "white_noise_wave_active" ) );
@@ -168,8 +166,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	m_waveBtnGrp->addButton( white_noise_btn );
 	m_waveBtnGrp->addButton( m_userWaveBtn );
 
-
-	PixmapButton * x1 = new PixmapButton( this, nullptr );
+	auto* x1 = new PixmapButton(this, nullptr);
 	x1->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y +7);
 	x1->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x1_active" ) );
@@ -178,7 +175,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x1->setToolTip(
 				tr( "Mutliply modulation frequency by 1" ));
 
-	PixmapButton * x100 = new PixmapButton( this, nullptr );
+	auto* x100 = new PixmapButton(this, nullptr);
 	x100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y - 8 );
 	x100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_x100_active" ) );
@@ -187,7 +184,7 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	x100->setToolTip(
 				tr( "Mutliply modulation frequency by 100" ));
 
-	PixmapButton * d100 = new PixmapButton( this, nullptr );
+	auto* d100 = new PixmapButton(this, nullptr);
 	d100->move( CD_LFO_MULTIPLIER_X, CD_LFO_SHAPES_Y + 22 );
 	d100->setActiveGraphic( embed::getIconPixmap(
 						"lfo_d100_active" ) );

--- a/src/gui/LinkedModelGroupViews.cpp
+++ b/src/gui/LinkedModelGroupViews.cpp
@@ -86,13 +86,13 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 {
 	if (ctrl)
 	{
-		QWidget* box = new QWidget(this);
-		QHBoxLayout* boxLayout = new QHBoxLayout(box);
+		auto box = new QWidget(this);
+		auto boxLayout = new QHBoxLayout(box);
 		boxLayout->addWidget(ctrl->topWidget());
 
 		if (removable)
 		{
-			QPushButton* removeBtn = new QPushButton;
+			auto removeBtn = new QPushButton;
 			removeBtn->setIcon( embed::getIconPixmap( "discard" ) );
 			QObject::connect(removeBtn, &QPushButton::clicked,
 				this, [this,ctrl](bool){

--- a/src/gui/LinkedModelGroupViews.cpp
+++ b/src/gui/LinkedModelGroupViews.cpp
@@ -86,13 +86,13 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 {
 	if (ctrl)
 	{
-		QWidget* box = new QWidget(this);
-		QHBoxLayout* boxLayout = new QHBoxLayout(box);
+		auto* box = new QWidget(this);
+		auto* boxLayout = new QHBoxLayout(box);
 		boxLayout->addWidget(ctrl->topWidget());
 
 		if (removable)
 		{
-			QPushButton* removeBtn = new QPushButton;
+			auto* removeBtn = new QPushButton;
 			removeBtn->setIcon( embed::getIconPixmap( "discard" ) );
 			QObject::connect(removeBtn, &QPushButton::clicked,
 				this, [this,ctrl](bool){

--- a/src/gui/LinkedModelGroupViews.cpp
+++ b/src/gui/LinkedModelGroupViews.cpp
@@ -86,13 +86,13 @@ void LinkedModelGroupView::addControl(Control* ctrl, const std::string& id,
 {
 	if (ctrl)
 	{
-		auto* box = new QWidget(this);
-		auto* boxLayout = new QHBoxLayout(box);
+		QWidget* box = new QWidget(this);
+		QHBoxLayout* boxLayout = new QHBoxLayout(box);
 		boxLayout->addWidget(ctrl->topWidget());
 
 		if (removable)
 		{
-			auto* removeBtn = new QPushButton;
+			QPushButton* removeBtn = new QPushButton;
 			removeBtn->setIcon( embed::getIconPixmap( "discard" ) );
 			QObject::connect(removeBtn, &QPushButton::clicked,
 				this, [this,ctrl](bool){

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -161,7 +161,8 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 	// fix broken titlebar styling on win32
 	if( control == CC_TitleBar )
 	{
-		const auto* titleBar = qstyleoption_cast<const QStyleOptionTitleBar*>(option);
+		const QStyleOptionTitleBar * titleBar =
+			qstyleoption_cast<const QStyleOptionTitleBar *>(option );
 		if( titleBar )
 		{
 			QStyleOptionTitleBar so( *titleBar );

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -161,8 +161,7 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 	// fix broken titlebar styling on win32
 	if( control == CC_TitleBar )
 	{
-		const QStyleOptionTitleBar * titleBar =
-			qstyleoption_cast<const QStyleOptionTitleBar *>(option );
+		const auto titleBar = qstyleoption_cast<const QStyleOptionTitleBar*>(option);
 		if( titleBar )
 		{
 			QStyleOptionTitleBar so( *titleBar );

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -161,8 +161,7 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 	// fix broken titlebar styling on win32
 	if( control == CC_TitleBar )
 	{
-		const QStyleOptionTitleBar * titleBar =
-			qstyleoption_cast<const QStyleOptionTitleBar *>(option );
+		const auto* titleBar = qstyleoption_cast<const QStyleOptionTitleBar*>(option);
 		if( titleBar )
 		{
 			QStyleOptionTitleBar so( *titleBar );

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -136,9 +136,9 @@ AutoLilvNode Lv2ViewProc::uri(const char *uriStr)
 
 Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 {
-	QGridLayout* grid = new QGridLayout(meAsWidget);
+	auto* grid = new QGridLayout(meAsWidget);
 
-	QHBoxLayout* btnBox = new QHBoxLayout();
+	auto* btnBox = new QHBoxLayout();
 	if (/* DISABLES CODE */ (false))
 	{
 		m_reloadPluginButton = new QPushButton(QObject::tr("Reload Plugin"),
@@ -169,7 +169,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 	LILV_FOREACH(nodes, itr, props.get())
 	{
 		const LilvNode* node = lilv_nodes_get(props.get(), itr);
-		QLabel* infoLabel = new QLabel(lilv_node_as_string(node));
+		auto* infoLabel = new QLabel(lilv_node_as_string(node));
 		infoLabel->setWordWrap(true);
 		infoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -136,9 +136,9 @@ AutoLilvNode Lv2ViewProc::uri(const char *uriStr)
 
 Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 {
-	QGridLayout* grid = new QGridLayout(meAsWidget);
+	auto grid = new QGridLayout(meAsWidget);
 
-	QHBoxLayout* btnBox = new QHBoxLayout();
+	auto btnBox = new QHBoxLayout();
 	if (/* DISABLES CODE */ (false))
 	{
 		m_reloadPluginButton = new QPushButton(QObject::tr("Reload Plugin"),
@@ -169,7 +169,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 	LILV_FOREACH(nodes, itr, props.get())
 	{
 		const LilvNode* node = lilv_nodes_get(props.get(), itr);
-		QLabel* infoLabel = new QLabel(lilv_node_as_string(node));
+		auto infoLabel = new QLabel(lilv_node_as_string(node));
 		infoLabel->setWordWrap(true);
 		infoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -136,9 +136,9 @@ AutoLilvNode Lv2ViewProc::uri(const char *uriStr)
 
 Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 {
-	auto* grid = new QGridLayout(meAsWidget);
+	QGridLayout* grid = new QGridLayout(meAsWidget);
 
-	auto* btnBox = new QHBoxLayout();
+	QHBoxLayout* btnBox = new QHBoxLayout();
 	if (/* DISABLES CODE */ (false))
 	{
 		m_reloadPluginButton = new QPushButton(QObject::tr("Reload Plugin"),
@@ -169,7 +169,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 	LILV_FOREACH(nodes, itr, props.get())
 	{
 		const LilvNode* node = lilv_nodes_get(props.get(), itr);
-		auto* infoLabel = new QLabel(lilv_node_as_string(node));
+		QLabel* infoLabel = new QLabel(lilv_node_as_string(node));
 		infoLabel->setWordWrap(true);
 		infoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -50,7 +50,7 @@ bool MainApplication::event(QEvent* event)
 	{
 		case QEvent::FileOpen:
 		{
-			QFileOpenEvent * fileEvent = static_cast<QFileOpenEvent *>(event);
+			auto fileEvent = static_cast<QFileOpenEvent*>(event);
 			// Handle the project file
 			m_queuedFile = fileEvent->file();
 			if(Engine::getSong())

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -50,7 +50,7 @@ bool MainApplication::event(QEvent* event)
 	{
 		case QEvent::FileOpen:
 		{
-			QFileOpenEvent * fileEvent = static_cast<QFileOpenEvent *>(event);
+			auto* fileEvent = static_cast<QFileOpenEvent*>(event);
 			// Handle the project file
 			m_queuedFile = fileEvent->file();
 			if(Engine::getSong())

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -50,7 +50,7 @@ bool MainApplication::event(QEvent* event)
 	{
 		case QEvent::FileOpen:
 		{
-			auto* fileEvent = static_cast<QFileOpenEvent*>(event);
+			QFileOpenEvent * fileEvent = static_cast<QFileOpenEvent *>(event);
 			// Handle the project file
 			m_queuedFile = fileEvent->file();
 			if(Engine::getSong())

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -84,8 +84,8 @@ void disableAutoKeyAccelerators(QWidget* mainWindow)
 {
 	using DisablerFunc = void(*)(QWidget*);
 	QLibrary kf5WidgetsAddon("KF5WidgetsAddons", 5);
-	DisablerFunc setNoAccelerators =
-			reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
+	auto setNoAccelerators
+		= reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
 	if(setNoAccelerators)
 	{
 		setNoAccelerators(mainWindow);
@@ -108,19 +108,19 @@ MainWindow::MainWindow() :
 #endif
 	setAttribute( Qt::WA_DeleteOnClose );
 
-	QWidget * main_widget = new QWidget( this );
-	QVBoxLayout * vbox = new QVBoxLayout( main_widget );
+	auto main_widget = new QWidget(this);
+	auto vbox = new QVBoxLayout(main_widget);
 	vbox->setSpacing( 0 );
 	vbox->setMargin( 0 );
 
-	QWidget * w = new QWidget( main_widget );
-	QHBoxLayout * hbox = new QHBoxLayout( w );
+	auto w = new QWidget(main_widget);
+	auto hbox = new QHBoxLayout(w);
 	hbox->setSpacing( 0 );
 	hbox->setMargin( 0 );
 
-	SideBar * sideBar = new SideBar( Qt::Vertical, w );
+	auto sideBar = new SideBar(Qt::Vertical, w);
 
-	QSplitter * splitter = new QSplitter( Qt::Horizontal, w );
+	auto splitter = new QSplitter(Qt::Horizontal, w);
 	splitter->setChildrenCollapsible( false );
 
 	ConfigManager* confMgr = ConfigManager::inst();
@@ -298,7 +298,7 @@ void MainWindow::finalize()
 
 
 	// project-popup-menu
-	QMenu * project_menu = new QMenu( this );
+	auto project_menu = new QMenu(this);
 	menuBar()->addMenu( project_menu )->setText( tr( "&File" ) );
 	project_menu->addAction( embed::getIconPixmap( "project_new" ),
 					tr( "&New" ),
@@ -362,8 +362,7 @@ void MainWindow::finalize()
 					qApp, SLOT(closeAllWindows()),
 					Qt::CTRL + Qt::Key_Q );
 
-
-	QMenu * edit_menu = new QMenu( this );
+	auto edit_menu = new QMenu(this);
 	menuBar()->addMenu( edit_menu )->setText( tr( "&Edit" ) );
 	m_undoAction = edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
 					tr( "Undo" ),
@@ -413,7 +412,7 @@ void MainWindow::finalize()
 
 
 	// help-popup-menu
-	QMenu * help_menu = new QMenu( this );
+	auto help_menu = new QMenu(this);
 	menuBar()->addMenu( help_menu )->setText( tr( "&Help" ) );
 	// May use offline help
 	if( true )
@@ -437,47 +436,27 @@ void MainWindow::finalize()
 				  this, SLOT(aboutLMMS()));
 
 	// create tool-buttons
-	ToolButton * project_new = new ToolButton(
-					embed::getIconPixmap( "project_new" ),
-					tr( "Create new project" ),
-					this, SLOT(createNewProject()),
-							m_toolBar );
+	auto project_new = new ToolButton(
+		embed::getIconPixmap("project_new"), tr("Create new project"), this, SLOT(createNewProject()), m_toolBar);
 
-	ToolButton * project_new_from_template = new ToolButton(
-			embed::getIconPixmap( "project_new_from_template" ),
-				tr( "Create new project from template" ),
-					this, SLOT(emptySlot()),
-							m_toolBar );
+	auto project_new_from_template = new ToolButton(embed::getIconPixmap("project_new_from_template"),
+		tr("Create new project from template"), this, SLOT(emptySlot()), m_toolBar);
 	project_new_from_template->setMenu( templates_menu );
 	project_new_from_template->setPopupMode( ToolButton::InstantPopup );
 
-	ToolButton * project_open = new ToolButton(
-					embed::getIconPixmap( "project_open" ),
-					tr( "Open existing project" ),
-					this, SLOT(openProject()),
-								m_toolBar );
+	auto project_open = new ToolButton(
+		embed::getIconPixmap("project_open"), tr("Open existing project"), this, SLOT(openProject()), m_toolBar);
 
-
-	ToolButton * project_open_recent = new ToolButton(
-				embed::getIconPixmap( "project_open_recent" ),
-					tr( "Recently opened projects" ),
-					this, SLOT(emptySlot()), m_toolBar );
+	auto project_open_recent = new ToolButton(embed::getIconPixmap("project_open_recent"),
+		tr("Recently opened projects"), this, SLOT(emptySlot()), m_toolBar);
 	project_open_recent->setMenu( new RecentProjectsMenu(this) );
 	project_open_recent->setPopupMode( ToolButton::InstantPopup );
 
-	ToolButton * project_save = new ToolButton(
-					embed::getIconPixmap( "project_save" ),
-					tr( "Save current project" ),
-					this, SLOT(saveProject()),
-								m_toolBar );
+	auto project_save = new ToolButton(
+		embed::getIconPixmap("project_save"), tr("Save current project"), this, SLOT(saveProject()), m_toolBar);
 
-
-	ToolButton * project_export = new ToolButton(
-				embed::getIconPixmap( "project_export" ),
-					tr( "Export current project" ),
-					this,
-							SLOT(onExportProject()),
-								m_toolBar );
+	auto project_export = new ToolButton(
+		embed::getIconPixmap("project_export"), tr("Export current project"), this, SLOT(onExportProject()), m_toolBar);
 
 	m_metronomeToggle = new ToolButton(
 				embed::getIconPixmap( "metronome" ),
@@ -498,68 +477,36 @@ void MainWindow::finalize()
 
 
 	// window-toolbar
-	ToolButton * song_editor_window = new ToolButton(
-					embed::getIconPixmap( "songeditor" ),
-					tr( "Song Editor" ) + " (Ctrl+1)",
-					this, SLOT(toggleSongEditorWin()),
-								m_toolBar );
+	auto song_editor_window = new ToolButton(embed::getIconPixmap("songeditor"), tr("Song Editor") + " (Ctrl+1)", this,
+		SLOT(toggleSongEditorWin()), m_toolBar);
 	song_editor_window->setShortcut( Qt::CTRL + Qt::Key_1 );
 
-
-	ToolButton* pattern_editor_window = new ToolButton(
-					embed::getIconPixmap("pattern_track_btn"),
-					tr("Pattern Editor") + " (Ctrl+2)",
-					this, SLOT(togglePatternEditorWin()),
-					m_toolBar);
+	auto pattern_editor_window = new ToolButton(embed::getIconPixmap("pattern_track_btn"),
+		tr("Pattern Editor") + " (Ctrl+2)", this, SLOT(togglePatternEditorWin()), m_toolBar);
 	pattern_editor_window->setShortcut(Qt::CTRL + Qt::Key_2);
 
-
-	ToolButton * piano_roll_window = new ToolButton(
-						embed::getIconPixmap( "piano" ),
-						tr( "Piano Roll" ) +
-									" (Ctrl+3)",
-					this, SLOT(togglePianoRollWin()),
-								m_toolBar );
+	auto piano_roll_window = new ToolButton(
+		embed::getIconPixmap("piano"), tr("Piano Roll") + " (Ctrl+3)", this, SLOT(togglePianoRollWin()), m_toolBar);
 	piano_roll_window->setShortcut( Qt::CTRL + Qt::Key_3 );
 
-	ToolButton * automation_editor_window = new ToolButton(
-					embed::getIconPixmap( "automation" ),
-					tr( "Automation Editor" ) +
-									" (Ctrl+4)",
-					this,
-					SLOT(toggleAutomationEditorWin()),
-					m_toolBar );
+	auto automation_editor_window = new ToolButton(embed::getIconPixmap("automation"),
+		tr("Automation Editor") + " (Ctrl+4)", this, SLOT(toggleAutomationEditorWin()), m_toolBar);
 	automation_editor_window->setShortcut( Qt::CTRL + Qt::Key_4 );
 
-	ToolButton * mixer_window = new ToolButton(
-					embed::getIconPixmap( "mixer" ),
-					tr( "Mixer" ) + " (Ctrl+5)",
-					this, SLOT(toggleMixerWin()),
-					m_toolBar );
+	auto mixer_window = new ToolButton(
+		embed::getIconPixmap("mixer"), tr("Mixer") + " (Ctrl+5)", this, SLOT(toggleMixerWin()), m_toolBar);
 	mixer_window->setShortcut( Qt::CTRL + Qt::Key_5 );
 
-	ToolButton * controllers_window = new ToolButton(
-					embed::getIconPixmap( "controller" ),
-					tr( "Show/hide controller rack" ) +
-								" (Ctrl+6)",
-					this, SLOT(toggleControllerRack()),
-								m_toolBar );
+	auto controllers_window = new ToolButton(embed::getIconPixmap("controller"),
+		tr("Show/hide controller rack") + " (Ctrl+6)", this, SLOT(toggleControllerRack()), m_toolBar);
 	controllers_window->setShortcut( Qt::CTRL + Qt::Key_6 );
 
-	ToolButton * project_notes_window = new ToolButton(
-					embed::getIconPixmap( "project_notes" ),
-					tr( "Show/hide project notes" ) +
-								" (Ctrl+7)",
-					this, SLOT(toggleProjectNotesWin()),
-								m_toolBar );
+	auto project_notes_window = new ToolButton(embed::getIconPixmap("project_notes"),
+		tr("Show/hide project notes") + " (Ctrl+7)", this, SLOT(toggleProjectNotesWin()), m_toolBar);
 	project_notes_window->setShortcut( Qt::CTRL + Qt::Key_7 );
 
-	ToolButton * microtuner_window = new ToolButton(
-					embed::getIconPixmap( "microtuner" ),
-					tr( "Microtuner configuration" ) +
-								" (Ctrl+8)",
-					this, SLOT(toggleMicrotunerWin()),
-								m_toolBar );
+	auto microtuner_window = new ToolButton(embed::getIconPixmap("microtuner"),
+		tr("Microtuner configuration") + " (Ctrl+8)", this, SLOT(toggleMicrotunerWin()), m_toolBar);
 	microtuner_window->setShortcut( Qt::CTRL + Qt::Key_8 );
 
 	m_toolBarLayout->addWidget( song_editor_window, 1, 1 );
@@ -649,7 +596,7 @@ void MainWindow::addSpacingToToolBar( int _size )
 SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags)
 {
 	// wrap the widget in our own *custom* window that patches some errors in QMdiSubWindow
-	SubWindow *win = new SubWindow(m_workspace->viewport(), windowFlags);
+	auto win = new SubWindow(m_workspace->viewport(), windowFlags);
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
 	if (w && w->sizeHint().isValid()) {win->resize(w->sizeHint());}
@@ -760,7 +707,7 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 
 	// If the widget is a SubWindow, then we can make use of the getTrueNormalGeometry() method that
 	// performs the same as normalGeometry, but isn't broken on X11 ( see https://bugreports.qt.io/browse/QTBUG-256 )
-	SubWindow *asSubWindow = qobject_cast<SubWindow*>(_w);
+	auto asSubWindow = qobject_cast<SubWindow*>(_w);
 	QRect normalGeom = asSubWindow != nullptr ? asSubWindow->getTrueNormalGeometry() : _w->normalGeometry();
 
 	bool visible = _w->isVisible();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -84,8 +84,8 @@ void disableAutoKeyAccelerators(QWidget* mainWindow)
 {
 	using DisablerFunc = void(*)(QWidget*);
 	QLibrary kf5WidgetsAddon("KF5WidgetsAddons", 5);
-	DisablerFunc setNoAccelerators =
-			reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
+	auto setNoAccelerators
+		= reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
 	if(setNoAccelerators)
 	{
 		setNoAccelerators(mainWindow);
@@ -108,19 +108,19 @@ MainWindow::MainWindow() :
 #endif
 	setAttribute( Qt::WA_DeleteOnClose );
 
-	QWidget * main_widget = new QWidget( this );
-	QVBoxLayout * vbox = new QVBoxLayout( main_widget );
+	auto* main_widget = new QWidget(this);
+	auto* vbox = new QVBoxLayout(main_widget);
 	vbox->setSpacing( 0 );
 	vbox->setMargin( 0 );
 
-	QWidget * w = new QWidget( main_widget );
-	QHBoxLayout * hbox = new QHBoxLayout( w );
+	auto* w = new QWidget(main_widget);
+	auto* hbox = new QHBoxLayout(w);
 	hbox->setSpacing( 0 );
 	hbox->setMargin( 0 );
 
-	SideBar * sideBar = new SideBar( Qt::Vertical, w );
+	auto* sideBar = new SideBar(Qt::Vertical, w);
 
-	QSplitter * splitter = new QSplitter( Qt::Horizontal, w );
+	auto* splitter = new QSplitter(Qt::Horizontal, w);
 	splitter->setChildrenCollapsible( false );
 
 	ConfigManager* confMgr = ConfigManager::inst();
@@ -298,7 +298,7 @@ void MainWindow::finalize()
 
 
 	// project-popup-menu
-	QMenu * project_menu = new QMenu( this );
+	auto* project_menu = new QMenu(this);
 	menuBar()->addMenu( project_menu )->setText( tr( "&File" ) );
 	project_menu->addAction( embed::getIconPixmap( "project_new" ),
 					tr( "&New" ),
@@ -362,8 +362,7 @@ void MainWindow::finalize()
 					qApp, SLOT(closeAllWindows()),
 					Qt::CTRL + Qt::Key_Q );
 
-
-	QMenu * edit_menu = new QMenu( this );
+	auto* edit_menu = new QMenu(this);
 	menuBar()->addMenu( edit_menu )->setText( tr( "&Edit" ) );
 	m_undoAction = edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
 					tr( "Undo" ),
@@ -413,7 +412,7 @@ void MainWindow::finalize()
 
 
 	// help-popup-menu
-	QMenu * help_menu = new QMenu( this );
+	auto* help_menu = new QMenu(this);
 	menuBar()->addMenu( help_menu )->setText( tr( "&Help" ) );
 	// May use offline help
 	if( true )
@@ -437,47 +436,27 @@ void MainWindow::finalize()
 				  this, SLOT(aboutLMMS()));
 
 	// create tool-buttons
-	ToolButton * project_new = new ToolButton(
-					embed::getIconPixmap( "project_new" ),
-					tr( "Create new project" ),
-					this, SLOT(createNewProject()),
-							m_toolBar );
+	auto* project_new = new ToolButton(
+		embed::getIconPixmap("project_new"), tr("Create new project"), this, SLOT(createNewProject()), m_toolBar);
 
-	ToolButton * project_new_from_template = new ToolButton(
-			embed::getIconPixmap( "project_new_from_template" ),
-				tr( "Create new project from template" ),
-					this, SLOT(emptySlot()),
-							m_toolBar );
+	auto* project_new_from_template = new ToolButton(embed::getIconPixmap("project_new_from_template"),
+		tr("Create new project from template"), this, SLOT(emptySlot()), m_toolBar);
 	project_new_from_template->setMenu( templates_menu );
 	project_new_from_template->setPopupMode( ToolButton::InstantPopup );
 
-	ToolButton * project_open = new ToolButton(
-					embed::getIconPixmap( "project_open" ),
-					tr( "Open existing project" ),
-					this, SLOT(openProject()),
-								m_toolBar );
+	auto* project_open = new ToolButton(
+		embed::getIconPixmap("project_open"), tr("Open existing project"), this, SLOT(openProject()), m_toolBar);
 
-
-	ToolButton * project_open_recent = new ToolButton(
-				embed::getIconPixmap( "project_open_recent" ),
-					tr( "Recently opened projects" ),
-					this, SLOT(emptySlot()), m_toolBar );
+	auto* project_open_recent = new ToolButton(embed::getIconPixmap("project_open_recent"),
+		tr("Recently opened projects"), this, SLOT(emptySlot()), m_toolBar);
 	project_open_recent->setMenu( new RecentProjectsMenu(this) );
 	project_open_recent->setPopupMode( ToolButton::InstantPopup );
 
-	ToolButton * project_save = new ToolButton(
-					embed::getIconPixmap( "project_save" ),
-					tr( "Save current project" ),
-					this, SLOT(saveProject()),
-								m_toolBar );
+	auto* project_save = new ToolButton(
+		embed::getIconPixmap("project_save"), tr("Save current project"), this, SLOT(saveProject()), m_toolBar);
 
-
-	ToolButton * project_export = new ToolButton(
-				embed::getIconPixmap( "project_export" ),
-					tr( "Export current project" ),
-					this,
-							SLOT(onExportProject()),
-								m_toolBar );
+	auto* project_export = new ToolButton(
+		embed::getIconPixmap("project_export"), tr("Export current project"), this, SLOT(onExportProject()), m_toolBar);
 
 	m_metronomeToggle = new ToolButton(
 				embed::getIconPixmap( "metronome" ),
@@ -498,68 +477,36 @@ void MainWindow::finalize()
 
 
 	// window-toolbar
-	ToolButton * song_editor_window = new ToolButton(
-					embed::getIconPixmap( "songeditor" ),
-					tr( "Song Editor" ) + " (Ctrl+1)",
-					this, SLOT(toggleSongEditorWin()),
-								m_toolBar );
+	auto* song_editor_window = new ToolButton(embed::getIconPixmap("songeditor"), tr("Song Editor") + " (Ctrl+1)", this,
+		SLOT(toggleSongEditorWin()), m_toolBar);
 	song_editor_window->setShortcut( Qt::CTRL + Qt::Key_1 );
 
-
-	ToolButton* pattern_editor_window = new ToolButton(
-					embed::getIconPixmap("pattern_track_btn"),
-					tr("Pattern Editor") + " (Ctrl+2)",
-					this, SLOT(togglePatternEditorWin()),
-					m_toolBar);
+	auto* pattern_editor_window = new ToolButton(embed::getIconPixmap("pattern_track_btn"),
+		tr("Pattern Editor") + " (Ctrl+2)", this, SLOT(togglePatternEditorWin()), m_toolBar);
 	pattern_editor_window->setShortcut(Qt::CTRL + Qt::Key_2);
 
-
-	ToolButton * piano_roll_window = new ToolButton(
-						embed::getIconPixmap( "piano" ),
-						tr( "Piano Roll" ) +
-									" (Ctrl+3)",
-					this, SLOT(togglePianoRollWin()),
-								m_toolBar );
+	auto* piano_roll_window = new ToolButton(
+		embed::getIconPixmap("piano"), tr("Piano Roll") + " (Ctrl+3)", this, SLOT(togglePianoRollWin()), m_toolBar);
 	piano_roll_window->setShortcut( Qt::CTRL + Qt::Key_3 );
 
-	ToolButton * automation_editor_window = new ToolButton(
-					embed::getIconPixmap( "automation" ),
-					tr( "Automation Editor" ) +
-									" (Ctrl+4)",
-					this,
-					SLOT(toggleAutomationEditorWin()),
-					m_toolBar );
+	auto* automation_editor_window = new ToolButton(embed::getIconPixmap("automation"),
+		tr("Automation Editor") + " (Ctrl+4)", this, SLOT(toggleAutomationEditorWin()), m_toolBar);
 	automation_editor_window->setShortcut( Qt::CTRL + Qt::Key_4 );
 
-	ToolButton * mixer_window = new ToolButton(
-					embed::getIconPixmap( "mixer" ),
-					tr( "Mixer" ) + " (Ctrl+5)",
-					this, SLOT(toggleMixerWin()),
-					m_toolBar );
+	auto* mixer_window = new ToolButton(
+		embed::getIconPixmap("mixer"), tr("Mixer") + " (Ctrl+5)", this, SLOT(toggleMixerWin()), m_toolBar);
 	mixer_window->setShortcut( Qt::CTRL + Qt::Key_5 );
 
-	ToolButton * controllers_window = new ToolButton(
-					embed::getIconPixmap( "controller" ),
-					tr( "Show/hide controller rack" ) +
-								" (Ctrl+6)",
-					this, SLOT(toggleControllerRack()),
-								m_toolBar );
+	auto* controllers_window = new ToolButton(embed::getIconPixmap("controller"),
+		tr("Show/hide controller rack") + " (Ctrl+6)", this, SLOT(toggleControllerRack()), m_toolBar);
 	controllers_window->setShortcut( Qt::CTRL + Qt::Key_6 );
 
-	ToolButton * project_notes_window = new ToolButton(
-					embed::getIconPixmap( "project_notes" ),
-					tr( "Show/hide project notes" ) +
-								" (Ctrl+7)",
-					this, SLOT(toggleProjectNotesWin()),
-								m_toolBar );
+	auto* project_notes_window = new ToolButton(embed::getIconPixmap("project_notes"),
+		tr("Show/hide project notes") + " (Ctrl+7)", this, SLOT(toggleProjectNotesWin()), m_toolBar);
 	project_notes_window->setShortcut( Qt::CTRL + Qt::Key_7 );
 
-	ToolButton * microtuner_window = new ToolButton(
-					embed::getIconPixmap( "microtuner" ),
-					tr( "Microtuner configuration" ) +
-								" (Ctrl+8)",
-					this, SLOT(toggleMicrotunerWin()),
-								m_toolBar );
+	auto* microtuner_window = new ToolButton(embed::getIconPixmap("microtuner"),
+		tr("Microtuner configuration") + " (Ctrl+8)", this, SLOT(toggleMicrotunerWin()), m_toolBar);
 	microtuner_window->setShortcut( Qt::CTRL + Qt::Key_8 );
 
 	m_toolBarLayout->addWidget( song_editor_window, 1, 1 );
@@ -649,7 +596,7 @@ void MainWindow::addSpacingToToolBar( int _size )
 SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags)
 {
 	// wrap the widget in our own *custom* window that patches some errors in QMdiSubWindow
-	SubWindow *win = new SubWindow(m_workspace->viewport(), windowFlags);
+	auto* win = new SubWindow(m_workspace->viewport(), windowFlags);
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
 	if (w && w->sizeHint().isValid()) {win->resize(w->sizeHint());}
@@ -760,7 +707,7 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 
 	// If the widget is a SubWindow, then we can make use of the getTrueNormalGeometry() method that
 	// performs the same as normalGeometry, but isn't broken on X11 ( see https://bugreports.qt.io/browse/QTBUG-256 )
-	SubWindow *asSubWindow = qobject_cast<SubWindow*>(_w);
+	auto* asSubWindow = qobject_cast<SubWindow*>(_w);
 	QRect normalGeom = asSubWindow != nullptr ? asSubWindow->getTrueNormalGeometry() : _w->normalGeometry();
 
 	bool visible = _w->isVisible();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -84,8 +84,8 @@ void disableAutoKeyAccelerators(QWidget* mainWindow)
 {
 	using DisablerFunc = void(*)(QWidget*);
 	QLibrary kf5WidgetsAddon("KF5WidgetsAddons", 5);
-	auto setNoAccelerators
-		= reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
+	DisablerFunc setNoAccelerators =
+			reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
 	if(setNoAccelerators)
 	{
 		setNoAccelerators(mainWindow);
@@ -108,19 +108,19 @@ MainWindow::MainWindow() :
 #endif
 	setAttribute( Qt::WA_DeleteOnClose );
 
-	auto* main_widget = new QWidget(this);
-	auto* vbox = new QVBoxLayout(main_widget);
+	QWidget * main_widget = new QWidget( this );
+	QVBoxLayout * vbox = new QVBoxLayout( main_widget );
 	vbox->setSpacing( 0 );
 	vbox->setMargin( 0 );
 
-	auto* w = new QWidget(main_widget);
-	auto* hbox = new QHBoxLayout(w);
+	QWidget * w = new QWidget( main_widget );
+	QHBoxLayout * hbox = new QHBoxLayout( w );
 	hbox->setSpacing( 0 );
 	hbox->setMargin( 0 );
 
-	auto* sideBar = new SideBar(Qt::Vertical, w);
+	SideBar * sideBar = new SideBar( Qt::Vertical, w );
 
-	auto* splitter = new QSplitter(Qt::Horizontal, w);
+	QSplitter * splitter = new QSplitter( Qt::Horizontal, w );
 	splitter->setChildrenCollapsible( false );
 
 	ConfigManager* confMgr = ConfigManager::inst();
@@ -298,7 +298,7 @@ void MainWindow::finalize()
 
 
 	// project-popup-menu
-	auto* project_menu = new QMenu(this);
+	QMenu * project_menu = new QMenu( this );
 	menuBar()->addMenu( project_menu )->setText( tr( "&File" ) );
 	project_menu->addAction( embed::getIconPixmap( "project_new" ),
 					tr( "&New" ),
@@ -362,7 +362,8 @@ void MainWindow::finalize()
 					qApp, SLOT(closeAllWindows()),
 					Qt::CTRL + Qt::Key_Q );
 
-	auto* edit_menu = new QMenu(this);
+
+	QMenu * edit_menu = new QMenu( this );
 	menuBar()->addMenu( edit_menu )->setText( tr( "&Edit" ) );
 	m_undoAction = edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
 					tr( "Undo" ),
@@ -412,7 +413,7 @@ void MainWindow::finalize()
 
 
 	// help-popup-menu
-	auto* help_menu = new QMenu(this);
+	QMenu * help_menu = new QMenu( this );
 	menuBar()->addMenu( help_menu )->setText( tr( "&Help" ) );
 	// May use offline help
 	if( true )
@@ -436,27 +437,47 @@ void MainWindow::finalize()
 				  this, SLOT(aboutLMMS()));
 
 	// create tool-buttons
-	auto* project_new = new ToolButton(
-		embed::getIconPixmap("project_new"), tr("Create new project"), this, SLOT(createNewProject()), m_toolBar);
+	ToolButton * project_new = new ToolButton(
+					embed::getIconPixmap( "project_new" ),
+					tr( "Create new project" ),
+					this, SLOT(createNewProject()),
+							m_toolBar );
 
-	auto* project_new_from_template = new ToolButton(embed::getIconPixmap("project_new_from_template"),
-		tr("Create new project from template"), this, SLOT(emptySlot()), m_toolBar);
+	ToolButton * project_new_from_template = new ToolButton(
+			embed::getIconPixmap( "project_new_from_template" ),
+				tr( "Create new project from template" ),
+					this, SLOT(emptySlot()),
+							m_toolBar );
 	project_new_from_template->setMenu( templates_menu );
 	project_new_from_template->setPopupMode( ToolButton::InstantPopup );
 
-	auto* project_open = new ToolButton(
-		embed::getIconPixmap("project_open"), tr("Open existing project"), this, SLOT(openProject()), m_toolBar);
+	ToolButton * project_open = new ToolButton(
+					embed::getIconPixmap( "project_open" ),
+					tr( "Open existing project" ),
+					this, SLOT(openProject()),
+								m_toolBar );
 
-	auto* project_open_recent = new ToolButton(embed::getIconPixmap("project_open_recent"),
-		tr("Recently opened projects"), this, SLOT(emptySlot()), m_toolBar);
+
+	ToolButton * project_open_recent = new ToolButton(
+				embed::getIconPixmap( "project_open_recent" ),
+					tr( "Recently opened projects" ),
+					this, SLOT(emptySlot()), m_toolBar );
 	project_open_recent->setMenu( new RecentProjectsMenu(this) );
 	project_open_recent->setPopupMode( ToolButton::InstantPopup );
 
-	auto* project_save = new ToolButton(
-		embed::getIconPixmap("project_save"), tr("Save current project"), this, SLOT(saveProject()), m_toolBar);
+	ToolButton * project_save = new ToolButton(
+					embed::getIconPixmap( "project_save" ),
+					tr( "Save current project" ),
+					this, SLOT(saveProject()),
+								m_toolBar );
 
-	auto* project_export = new ToolButton(
-		embed::getIconPixmap("project_export"), tr("Export current project"), this, SLOT(onExportProject()), m_toolBar);
+
+	ToolButton * project_export = new ToolButton(
+				embed::getIconPixmap( "project_export" ),
+					tr( "Export current project" ),
+					this,
+							SLOT(onExportProject()),
+								m_toolBar );
 
 	m_metronomeToggle = new ToolButton(
 				embed::getIconPixmap( "metronome" ),
@@ -477,36 +498,68 @@ void MainWindow::finalize()
 
 
 	// window-toolbar
-	auto* song_editor_window = new ToolButton(embed::getIconPixmap("songeditor"), tr("Song Editor") + " (Ctrl+1)", this,
-		SLOT(toggleSongEditorWin()), m_toolBar);
+	ToolButton * song_editor_window = new ToolButton(
+					embed::getIconPixmap( "songeditor" ),
+					tr( "Song Editor" ) + " (Ctrl+1)",
+					this, SLOT(toggleSongEditorWin()),
+								m_toolBar );
 	song_editor_window->setShortcut( Qt::CTRL + Qt::Key_1 );
 
-	auto* pattern_editor_window = new ToolButton(embed::getIconPixmap("pattern_track_btn"),
-		tr("Pattern Editor") + " (Ctrl+2)", this, SLOT(togglePatternEditorWin()), m_toolBar);
+
+	ToolButton* pattern_editor_window = new ToolButton(
+					embed::getIconPixmap("pattern_track_btn"),
+					tr("Pattern Editor") + " (Ctrl+2)",
+					this, SLOT(togglePatternEditorWin()),
+					m_toolBar);
 	pattern_editor_window->setShortcut(Qt::CTRL + Qt::Key_2);
 
-	auto* piano_roll_window = new ToolButton(
-		embed::getIconPixmap("piano"), tr("Piano Roll") + " (Ctrl+3)", this, SLOT(togglePianoRollWin()), m_toolBar);
+
+	ToolButton * piano_roll_window = new ToolButton(
+						embed::getIconPixmap( "piano" ),
+						tr( "Piano Roll" ) +
+									" (Ctrl+3)",
+					this, SLOT(togglePianoRollWin()),
+								m_toolBar );
 	piano_roll_window->setShortcut( Qt::CTRL + Qt::Key_3 );
 
-	auto* automation_editor_window = new ToolButton(embed::getIconPixmap("automation"),
-		tr("Automation Editor") + " (Ctrl+4)", this, SLOT(toggleAutomationEditorWin()), m_toolBar);
+	ToolButton * automation_editor_window = new ToolButton(
+					embed::getIconPixmap( "automation" ),
+					tr( "Automation Editor" ) +
+									" (Ctrl+4)",
+					this,
+					SLOT(toggleAutomationEditorWin()),
+					m_toolBar );
 	automation_editor_window->setShortcut( Qt::CTRL + Qt::Key_4 );
 
-	auto* mixer_window = new ToolButton(
-		embed::getIconPixmap("mixer"), tr("Mixer") + " (Ctrl+5)", this, SLOT(toggleMixerWin()), m_toolBar);
+	ToolButton * mixer_window = new ToolButton(
+					embed::getIconPixmap( "mixer" ),
+					tr( "Mixer" ) + " (Ctrl+5)",
+					this, SLOT(toggleMixerWin()),
+					m_toolBar );
 	mixer_window->setShortcut( Qt::CTRL + Qt::Key_5 );
 
-	auto* controllers_window = new ToolButton(embed::getIconPixmap("controller"),
-		tr("Show/hide controller rack") + " (Ctrl+6)", this, SLOT(toggleControllerRack()), m_toolBar);
+	ToolButton * controllers_window = new ToolButton(
+					embed::getIconPixmap( "controller" ),
+					tr( "Show/hide controller rack" ) +
+								" (Ctrl+6)",
+					this, SLOT(toggleControllerRack()),
+								m_toolBar );
 	controllers_window->setShortcut( Qt::CTRL + Qt::Key_6 );
 
-	auto* project_notes_window = new ToolButton(embed::getIconPixmap("project_notes"),
-		tr("Show/hide project notes") + " (Ctrl+7)", this, SLOT(toggleProjectNotesWin()), m_toolBar);
+	ToolButton * project_notes_window = new ToolButton(
+					embed::getIconPixmap( "project_notes" ),
+					tr( "Show/hide project notes" ) +
+								" (Ctrl+7)",
+					this, SLOT(toggleProjectNotesWin()),
+								m_toolBar );
 	project_notes_window->setShortcut( Qt::CTRL + Qt::Key_7 );
 
-	auto* microtuner_window = new ToolButton(embed::getIconPixmap("microtuner"),
-		tr("Microtuner configuration") + " (Ctrl+8)", this, SLOT(toggleMicrotunerWin()), m_toolBar);
+	ToolButton * microtuner_window = new ToolButton(
+					embed::getIconPixmap( "microtuner" ),
+					tr( "Microtuner configuration" ) +
+								" (Ctrl+8)",
+					this, SLOT(toggleMicrotunerWin()),
+								m_toolBar );
 	microtuner_window->setShortcut( Qt::CTRL + Qt::Key_8 );
 
 	m_toolBarLayout->addWidget( song_editor_window, 1, 1 );
@@ -596,7 +649,7 @@ void MainWindow::addSpacingToToolBar( int _size )
 SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags)
 {
 	// wrap the widget in our own *custom* window that patches some errors in QMdiSubWindow
-	auto* win = new SubWindow(m_workspace->viewport(), windowFlags);
+	SubWindow *win = new SubWindow(m_workspace->viewport(), windowFlags);
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
 	if (w && w->sizeHint().isValid()) {win->resize(w->sizeHint());}
@@ -707,7 +760,7 @@ void MainWindow::saveWidgetState( QWidget * _w, QDomElement & _de )
 
 	// If the widget is a SubWindow, then we can make use of the getTrueNormalGeometry() method that
 	// performs the same as normalGeometry, but isn't broken on X11 ( see https://bugreports.qt.io/browse/QTBUG-256 )
-	auto* asSubWindow = qobject_cast<SubWindow*>(_w);
+	SubWindow *asSubWindow = qobject_cast<SubWindow*>(_w);
 	QRect normalGeom = asSubWindow != nullptr ? asSubWindow->getTrueNormalGeometry() : _w->normalGeometry();
 
 	bool visible = _w->isVisible();

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -68,20 +68,20 @@ MicrotunerConfig::MicrotunerConfig() :
 	setWindowTitle(tr("Microtuner"));
 
 	// Organize into 2 main columns: scales and keymaps
-	QGridLayout *microtunerLayout = new QGridLayout();
+	auto microtunerLayout = new QGridLayout();
 	microtunerLayout->setSpacing(2);
 
 	// ----------------------------------
 	// Scale sub-column
 	//
-	QLabel *scaleLabel = new QLabel(tr("Scale:"));
+	auto scaleLabel = new QLabel(tr("Scale:"));
 	microtunerLayout->addWidget(scaleLabel, 0, 0, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxScaleCount; i++)
 	{
 		m_scaleComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getScale(i)->getDescription());
 	}
-	ComboBox *scaleCombo = new ComboBox();
+	auto scaleCombo = new ComboBox();
 	scaleCombo->setModel(&m_scaleComboModel);
 	microtunerLayout->addWidget(scaleCombo, 1, 0, 1, 2);
 	connect(&m_scaleComboModel, &ComboBoxModel::dataChanged, [=] {updateScaleForm();});
@@ -90,8 +90,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleNameEdit->setToolTip(tr("Scale description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_scaleNameEdit, 2, 0, 1, 2);
 
-	QPushButton *loadScaleButton = new QPushButton(tr("Load"));
-	QPushButton *saveScaleButton = new QPushButton(tr("Save"));
+	auto loadScaleButton = new QPushButton(tr("Load"));
+	auto saveScaleButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadScaleButton, 3, 0, 1, 1);
 	microtunerLayout->addWidget(saveScaleButton, 3, 1, 1, 1);
 	connect(loadScaleButton, &QPushButton::clicked, [=] {loadScaleFromFile();});
@@ -102,21 +102,21 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleTextEdit->setToolTip(tr("Enter intervals on separate lines. Numbers containing a decimal point are treated as cents.\nOther inputs are treated as integer ratios and must be in the form of \'a/b\' or \'a\'.\nUnity (0.0 cents or ratio 1/1) is always present as a hidden first value; do not enter it manually."));
 	microtunerLayout->addWidget(m_scaleTextEdit, 4, 0, 2, 2);
 
-	QPushButton *applyScaleButton = new QPushButton(tr("Apply scale"));
+	auto applyScaleButton = new QPushButton(tr("Apply scale"));
 	microtunerLayout->addWidget(applyScaleButton, 6, 0, 1, 2);
 	connect(applyScaleButton, &QPushButton::clicked, [=] {applyScale();});
 
 	// ----------------------------------
 	// Mapping sub-column
 	//
-	QLabel *keymapLabel = new QLabel(tr("Keymap:"));
+	auto keymapLabel = new QLabel(tr("Keymap:"));
 	microtunerLayout->addWidget(keymapLabel, 0, 2, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxKeymapCount; i++)
 	{
 		m_keymapComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getKeymap(i)->getDescription());
 	}
-	ComboBox *keymapCombo = new ComboBox();
+	auto keymapCombo = new ComboBox();
 	keymapCombo->setModel(&m_keymapComboModel);
 	microtunerLayout->addWidget(keymapCombo, 1, 2, 1, 2);
 	connect(&m_keymapComboModel, &ComboBoxModel::dataChanged, [=] {updateKeymapForm();});
@@ -125,8 +125,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_keymapNameEdit->setToolTip(tr("Keymap description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_keymapNameEdit, 2, 2, 1, 2);
 
-	QPushButton *loadKeymapButton = new QPushButton(tr("Load"));
-	QPushButton *saveKeymapButton = new QPushButton(tr("Save"));
+	auto loadKeymapButton = new QPushButton(tr("Load"));
+	auto saveKeymapButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadKeymapButton, 3, 2, 1, 1);
 	microtunerLayout->addWidget(saveKeymapButton, 3, 3, 1, 1);
 	connect(loadKeymapButton, &QPushButton::clicked, [=] {loadKeymapFromFile();});
@@ -138,40 +138,40 @@ MicrotunerConfig::MicrotunerConfig() :
 	microtunerLayout->addWidget(m_keymapTextEdit, 4, 2, 1, 2);
 
 	// Mapping ranges
-	QGridLayout *keymapRangeLayout = new QGridLayout();
+	auto keymapRangeLayout = new QGridLayout();
 	microtunerLayout->addLayout(keymapRangeLayout, 5, 2, 1, 2, Qt::AlignCenter | Qt::AlignTop);
 
-	LcdSpinBox *firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
+	auto firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
 	firstKeySpin->setLabel(tr("FIRST"));
 	firstKeySpin->setToolTip(tr("First MIDI key that will be mapped"));
 	firstKeySpin->setModel(&m_firstKeyModel);
 	keymapRangeLayout->addWidget(firstKeySpin, 0, 0);
 
-	LcdSpinBox *lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
+	auto lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
 	lastKeySpin->setLabel(tr("LAST"));
 	lastKeySpin->setToolTip(tr("Last MIDI key that will be mapped"));
 	lastKeySpin->setModel(&m_lastKeyModel);
 	keymapRangeLayout->addWidget(lastKeySpin, 0, 1);
 
-	LcdSpinBox *middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
+	auto middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
 	middleKeySpin->setLabel(tr("MIDDLE"));
 	middleKeySpin->setToolTip(tr("First line in the keymap refers to this MIDI key"));
 	middleKeySpin->setModel(&m_middleKeyModel);
 	keymapRangeLayout->addWidget(middleKeySpin, 0, 2);
 
-	LcdSpinBox *baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
+	auto baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
 	baseKeySpin->setLabel(tr("BASE N."));
 	baseKeySpin->setToolTip(tr("Base note frequency will be assigned to this MIDI key"));
 	baseKeySpin->setModel(&m_baseKeyModel);
 	keymapRangeLayout->addWidget(baseKeySpin, 1, 0);
 
-	LcdFloatSpinBox *baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
+	auto baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
 	baseFreqSpin->setLabel(tr("BASE NOTE FREQ"));
 	baseFreqSpin->setModel(&m_baseFreqModel);
 	baseFreqSpin->setToolTip(tr("Base note frequency"));
 	keymapRangeLayout->addWidget(baseFreqSpin, 1, 1, 1, 2);
 
-	QPushButton *applyKeymapButton = new QPushButton(tr("Apply keymap"));
+	auto applyKeymapButton = new QPushButton(tr("Apply keymap"));
 	microtunerLayout->addWidget(applyKeymapButton, 6, 2, 1, 2);
 	connect(applyKeymapButton, &QPushButton::clicked, [=] {applyKeymap();});
 

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -68,20 +68,20 @@ MicrotunerConfig::MicrotunerConfig() :
 	setWindowTitle(tr("Microtuner"));
 
 	// Organize into 2 main columns: scales and keymaps
-	auto* microtunerLayout = new QGridLayout();
+	QGridLayout *microtunerLayout = new QGridLayout();
 	microtunerLayout->setSpacing(2);
 
 	// ----------------------------------
 	// Scale sub-column
 	//
-	auto* scaleLabel = new QLabel(tr("Scale:"));
+	QLabel *scaleLabel = new QLabel(tr("Scale:"));
 	microtunerLayout->addWidget(scaleLabel, 0, 0, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxScaleCount; i++)
 	{
 		m_scaleComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getScale(i)->getDescription());
 	}
-	auto* scaleCombo = new ComboBox();
+	ComboBox *scaleCombo = new ComboBox();
 	scaleCombo->setModel(&m_scaleComboModel);
 	microtunerLayout->addWidget(scaleCombo, 1, 0, 1, 2);
 	connect(&m_scaleComboModel, &ComboBoxModel::dataChanged, [=] {updateScaleForm();});
@@ -90,8 +90,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleNameEdit->setToolTip(tr("Scale description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_scaleNameEdit, 2, 0, 1, 2);
 
-	auto* loadScaleButton = new QPushButton(tr("Load"));
-	auto* saveScaleButton = new QPushButton(tr("Save"));
+	QPushButton *loadScaleButton = new QPushButton(tr("Load"));
+	QPushButton *saveScaleButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadScaleButton, 3, 0, 1, 1);
 	microtunerLayout->addWidget(saveScaleButton, 3, 1, 1, 1);
 	connect(loadScaleButton, &QPushButton::clicked, [=] {loadScaleFromFile();});
@@ -102,21 +102,21 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleTextEdit->setToolTip(tr("Enter intervals on separate lines. Numbers containing a decimal point are treated as cents.\nOther inputs are treated as integer ratios and must be in the form of \'a/b\' or \'a\'.\nUnity (0.0 cents or ratio 1/1) is always present as a hidden first value; do not enter it manually."));
 	microtunerLayout->addWidget(m_scaleTextEdit, 4, 0, 2, 2);
 
-	auto* applyScaleButton = new QPushButton(tr("Apply scale"));
+	QPushButton *applyScaleButton = new QPushButton(tr("Apply scale"));
 	microtunerLayout->addWidget(applyScaleButton, 6, 0, 1, 2);
 	connect(applyScaleButton, &QPushButton::clicked, [=] {applyScale();});
 
 	// ----------------------------------
 	// Mapping sub-column
 	//
-	auto* keymapLabel = new QLabel(tr("Keymap:"));
+	QLabel *keymapLabel = new QLabel(tr("Keymap:"));
 	microtunerLayout->addWidget(keymapLabel, 0, 2, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxKeymapCount; i++)
 	{
 		m_keymapComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getKeymap(i)->getDescription());
 	}
-	auto* keymapCombo = new ComboBox();
+	ComboBox *keymapCombo = new ComboBox();
 	keymapCombo->setModel(&m_keymapComboModel);
 	microtunerLayout->addWidget(keymapCombo, 1, 2, 1, 2);
 	connect(&m_keymapComboModel, &ComboBoxModel::dataChanged, [=] {updateKeymapForm();});
@@ -125,8 +125,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_keymapNameEdit->setToolTip(tr("Keymap description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_keymapNameEdit, 2, 2, 1, 2);
 
-	auto* loadKeymapButton = new QPushButton(tr("Load"));
-	auto* saveKeymapButton = new QPushButton(tr("Save"));
+	QPushButton *loadKeymapButton = new QPushButton(tr("Load"));
+	QPushButton *saveKeymapButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadKeymapButton, 3, 2, 1, 1);
 	microtunerLayout->addWidget(saveKeymapButton, 3, 3, 1, 1);
 	connect(loadKeymapButton, &QPushButton::clicked, [=] {loadKeymapFromFile();});
@@ -138,40 +138,40 @@ MicrotunerConfig::MicrotunerConfig() :
 	microtunerLayout->addWidget(m_keymapTextEdit, 4, 2, 1, 2);
 
 	// Mapping ranges
-	auto* keymapRangeLayout = new QGridLayout();
+	QGridLayout *keymapRangeLayout = new QGridLayout();
 	microtunerLayout->addLayout(keymapRangeLayout, 5, 2, 1, 2, Qt::AlignCenter | Qt::AlignTop);
 
-	auto* firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
+	LcdSpinBox *firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
 	firstKeySpin->setLabel(tr("FIRST"));
 	firstKeySpin->setToolTip(tr("First MIDI key that will be mapped"));
 	firstKeySpin->setModel(&m_firstKeyModel);
 	keymapRangeLayout->addWidget(firstKeySpin, 0, 0);
 
-	auto* lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
+	LcdSpinBox *lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
 	lastKeySpin->setLabel(tr("LAST"));
 	lastKeySpin->setToolTip(tr("Last MIDI key that will be mapped"));
 	lastKeySpin->setModel(&m_lastKeyModel);
 	keymapRangeLayout->addWidget(lastKeySpin, 0, 1);
 
-	auto* middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
+	LcdSpinBox *middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
 	middleKeySpin->setLabel(tr("MIDDLE"));
 	middleKeySpin->setToolTip(tr("First line in the keymap refers to this MIDI key"));
 	middleKeySpin->setModel(&m_middleKeyModel);
 	keymapRangeLayout->addWidget(middleKeySpin, 0, 2);
 
-	auto* baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
+	LcdSpinBox *baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
 	baseKeySpin->setLabel(tr("BASE N."));
 	baseKeySpin->setToolTip(tr("Base note frequency will be assigned to this MIDI key"));
 	baseKeySpin->setModel(&m_baseKeyModel);
 	keymapRangeLayout->addWidget(baseKeySpin, 1, 0);
 
-	auto* baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
+	LcdFloatSpinBox *baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
 	baseFreqSpin->setLabel(tr("BASE NOTE FREQ"));
 	baseFreqSpin->setModel(&m_baseFreqModel);
 	baseFreqSpin->setToolTip(tr("Base note frequency"));
 	keymapRangeLayout->addWidget(baseFreqSpin, 1, 1, 1, 2);
 
-	auto* applyKeymapButton = new QPushButton(tr("Apply keymap"));
+	QPushButton *applyKeymapButton = new QPushButton(tr("Apply keymap"));
 	microtunerLayout->addWidget(applyKeymapButton, 6, 2, 1, 2);
 	connect(applyKeymapButton, &QPushButton::clicked, [=] {applyKeymap();});
 

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -68,20 +68,20 @@ MicrotunerConfig::MicrotunerConfig() :
 	setWindowTitle(tr("Microtuner"));
 
 	// Organize into 2 main columns: scales and keymaps
-	QGridLayout *microtunerLayout = new QGridLayout();
+	auto* microtunerLayout = new QGridLayout();
 	microtunerLayout->setSpacing(2);
 
 	// ----------------------------------
 	// Scale sub-column
 	//
-	QLabel *scaleLabel = new QLabel(tr("Scale:"));
+	auto* scaleLabel = new QLabel(tr("Scale:"));
 	microtunerLayout->addWidget(scaleLabel, 0, 0, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxScaleCount; i++)
 	{
 		m_scaleComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getScale(i)->getDescription());
 	}
-	ComboBox *scaleCombo = new ComboBox();
+	auto* scaleCombo = new ComboBox();
 	scaleCombo->setModel(&m_scaleComboModel);
 	microtunerLayout->addWidget(scaleCombo, 1, 0, 1, 2);
 	connect(&m_scaleComboModel, &ComboBoxModel::dataChanged, [=] {updateScaleForm();});
@@ -90,8 +90,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleNameEdit->setToolTip(tr("Scale description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_scaleNameEdit, 2, 0, 1, 2);
 
-	QPushButton *loadScaleButton = new QPushButton(tr("Load"));
-	QPushButton *saveScaleButton = new QPushButton(tr("Save"));
+	auto* loadScaleButton = new QPushButton(tr("Load"));
+	auto* saveScaleButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadScaleButton, 3, 0, 1, 1);
 	microtunerLayout->addWidget(saveScaleButton, 3, 1, 1, 1);
 	connect(loadScaleButton, &QPushButton::clicked, [=] {loadScaleFromFile();});
@@ -102,21 +102,21 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_scaleTextEdit->setToolTip(tr("Enter intervals on separate lines. Numbers containing a decimal point are treated as cents.\nOther inputs are treated as integer ratios and must be in the form of \'a/b\' or \'a\'.\nUnity (0.0 cents or ratio 1/1) is always present as a hidden first value; do not enter it manually."));
 	microtunerLayout->addWidget(m_scaleTextEdit, 4, 0, 2, 2);
 
-	QPushButton *applyScaleButton = new QPushButton(tr("Apply scale"));
+	auto* applyScaleButton = new QPushButton(tr("Apply scale"));
 	microtunerLayout->addWidget(applyScaleButton, 6, 0, 1, 2);
 	connect(applyScaleButton, &QPushButton::clicked, [=] {applyScale();});
 
 	// ----------------------------------
 	// Mapping sub-column
 	//
-	QLabel *keymapLabel = new QLabel(tr("Keymap:"));
+	auto* keymapLabel = new QLabel(tr("Keymap:"));
 	microtunerLayout->addWidget(keymapLabel, 0, 2, 1, 2, Qt::AlignBottom);
 
 	for (unsigned int i = 0; i < MaxKeymapCount; i++)
 	{
 		m_keymapComboModel.addItem(QString::number(i) + ": " + Engine::getSong()->getKeymap(i)->getDescription());
 	}
-	ComboBox *keymapCombo = new ComboBox();
+	auto* keymapCombo = new ComboBox();
 	keymapCombo->setModel(&m_keymapComboModel);
 	microtunerLayout->addWidget(keymapCombo, 1, 2, 1, 2);
 	connect(&m_keymapComboModel, &ComboBoxModel::dataChanged, [=] {updateKeymapForm();});
@@ -125,8 +125,8 @@ MicrotunerConfig::MicrotunerConfig() :
 	m_keymapNameEdit->setToolTip(tr("Keymap description. Cannot start with \"!\" and cannot contain a newline character."));
 	microtunerLayout->addWidget(m_keymapNameEdit, 2, 2, 1, 2);
 
-	QPushButton *loadKeymapButton = new QPushButton(tr("Load"));
-	QPushButton *saveKeymapButton = new QPushButton(tr("Save"));
+	auto* loadKeymapButton = new QPushButton(tr("Load"));
+	auto* saveKeymapButton = new QPushButton(tr("Save"));
 	microtunerLayout->addWidget(loadKeymapButton, 3, 2, 1, 1);
 	microtunerLayout->addWidget(saveKeymapButton, 3, 3, 1, 1);
 	connect(loadKeymapButton, &QPushButton::clicked, [=] {loadKeymapFromFile();});
@@ -138,40 +138,40 @@ MicrotunerConfig::MicrotunerConfig() :
 	microtunerLayout->addWidget(m_keymapTextEdit, 4, 2, 1, 2);
 
 	// Mapping ranges
-	QGridLayout *keymapRangeLayout = new QGridLayout();
+	auto* keymapRangeLayout = new QGridLayout();
 	microtunerLayout->addLayout(keymapRangeLayout, 5, 2, 1, 2, Qt::AlignCenter | Qt::AlignTop);
 
-	LcdSpinBox *firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
+	auto* firstKeySpin = new LcdSpinBox(3, nullptr, tr("First key"));
 	firstKeySpin->setLabel(tr("FIRST"));
 	firstKeySpin->setToolTip(tr("First MIDI key that will be mapped"));
 	firstKeySpin->setModel(&m_firstKeyModel);
 	keymapRangeLayout->addWidget(firstKeySpin, 0, 0);
 
-	LcdSpinBox *lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
+	auto* lastKeySpin = new LcdSpinBox(3, nullptr, tr("Last key"));
 	lastKeySpin->setLabel(tr("LAST"));
 	lastKeySpin->setToolTip(tr("Last MIDI key that will be mapped"));
 	lastKeySpin->setModel(&m_lastKeyModel);
 	keymapRangeLayout->addWidget(lastKeySpin, 0, 1);
 
-	LcdSpinBox *middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
+	auto* middleKeySpin = new LcdSpinBox(3, nullptr, tr("Middle key"));
 	middleKeySpin->setLabel(tr("MIDDLE"));
 	middleKeySpin->setToolTip(tr("First line in the keymap refers to this MIDI key"));
 	middleKeySpin->setModel(&m_middleKeyModel);
 	keymapRangeLayout->addWidget(middleKeySpin, 0, 2);
 
-	LcdSpinBox *baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
+	auto* baseKeySpin = new LcdSpinBox(3, nullptr, tr("Base key"));
 	baseKeySpin->setLabel(tr("BASE N."));
 	baseKeySpin->setToolTip(tr("Base note frequency will be assigned to this MIDI key"));
 	baseKeySpin->setModel(&m_baseKeyModel);
 	keymapRangeLayout->addWidget(baseKeySpin, 1, 0);
 
-	LcdFloatSpinBox *baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
+	auto* baseFreqSpin = new LcdFloatSpinBox(4, 3, tr("Base note frequency"));
 	baseFreqSpin->setLabel(tr("BASE NOTE FREQ"));
 	baseFreqSpin->setModel(&m_baseFreqModel);
 	baseFreqSpin->setToolTip(tr("Base note frequency"));
 	keymapRangeLayout->addWidget(baseFreqSpin, 1, 1, 1, 2);
 
-	QPushButton *applyKeymapButton = new QPushButton(tr("Apply keymap"));
+	auto* applyKeymapButton = new QPushButton(tr("Apply keymap"));
 	microtunerLayout->addWidget(applyKeymapButton, 6, 2, 1, 2);
 	connect(applyKeymapButton, &QPushButton::clicked, [=] {applyKeymap();});
 

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -64,21 +64,21 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	subWin->hide();
 
 	// Main window layout
-	QVBoxLayout *mainLayout = new QVBoxLayout(this);
+	auto mainLayout = new QVBoxLayout(this);
 
 	// Knobs GroupBox - Here we have the MIDI CC controller knobs for the selected track
 	m_midiCCGroupBox = new GroupBox(tr("MIDI CC Knobs:"));
 
 	// Layout to keep scrollable area under the GroupBox header
-	QVBoxLayout *knobsGroupBoxLayout = new QVBoxLayout();
+	auto knobsGroupBoxLayout = new QVBoxLayout();
 	knobsGroupBoxLayout->setContentsMargins(5, 16, 5, 5);
 
 	m_midiCCGroupBox->setLayout(knobsGroupBoxLayout);
 
 	// Scrollable area + widget + its layout that will have all the knobs
-	QScrollArea *knobsScrollArea = new QScrollArea();
-	QWidget *knobsArea = new QWidget();
-	QGridLayout *knobsAreaLayout = new QGridLayout();
+	auto knobsScrollArea = new QScrollArea();
+	auto knobsArea = new QWidget();
+	auto knobsAreaLayout = new QGridLayout();
 
 	knobsArea->setLayout(knobsAreaLayout);
 	knobsScrollArea->setWidget(knobsArea);

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -64,21 +64,21 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	subWin->hide();
 
 	// Main window layout
-	auto* mainLayout = new QVBoxLayout(this);
+	QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
 	// Knobs GroupBox - Here we have the MIDI CC controller knobs for the selected track
 	m_midiCCGroupBox = new GroupBox(tr("MIDI CC Knobs:"));
 
 	// Layout to keep scrollable area under the GroupBox header
-	auto* knobsGroupBoxLayout = new QVBoxLayout();
+	QVBoxLayout *knobsGroupBoxLayout = new QVBoxLayout();
 	knobsGroupBoxLayout->setContentsMargins(5, 16, 5, 5);
 
 	m_midiCCGroupBox->setLayout(knobsGroupBoxLayout);
 
 	// Scrollable area + widget + its layout that will have all the knobs
-	auto* knobsScrollArea = new QScrollArea();
-	auto* knobsArea = new QWidget();
-	auto* knobsAreaLayout = new QGridLayout();
+	QScrollArea *knobsScrollArea = new QScrollArea();
+	QWidget *knobsArea = new QWidget();
+	QGridLayout *knobsAreaLayout = new QGridLayout();
 
 	knobsArea->setLayout(knobsAreaLayout);
 	knobsScrollArea->setWidget(knobsArea);

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -64,21 +64,21 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	subWin->hide();
 
 	// Main window layout
-	QVBoxLayout *mainLayout = new QVBoxLayout(this);
+	auto* mainLayout = new QVBoxLayout(this);
 
 	// Knobs GroupBox - Here we have the MIDI CC controller knobs for the selected track
 	m_midiCCGroupBox = new GroupBox(tr("MIDI CC Knobs:"));
 
 	// Layout to keep scrollable area under the GroupBox header
-	QVBoxLayout *knobsGroupBoxLayout = new QVBoxLayout();
+	auto* knobsGroupBoxLayout = new QVBoxLayout();
 	knobsGroupBoxLayout->setContentsMargins(5, 16, 5, 5);
 
 	m_midiCCGroupBox->setLayout(knobsGroupBoxLayout);
 
 	// Scrollable area + widget + its layout that will have all the knobs
-	QScrollArea *knobsScrollArea = new QScrollArea();
-	QWidget *knobsArea = new QWidget();
-	QGridLayout *knobsAreaLayout = new QGridLayout();
+	auto* knobsScrollArea = new QScrollArea();
+	auto* knobsArea = new QWidget();
+	auto* knobsAreaLayout = new QGridLayout();
 
 	knobsArea->setLayout(knobsAreaLayout);
 	knobsScrollArea->setWidget(knobsArea);

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -48,7 +48,7 @@ MidiSetupWidget::MidiSetupWidget(const QString & caption, const QString & config
 		m_device = new QLineEdit(devName, this);
 		m_device->setGeometry(10, 20, 160, 20);
 
-		QLabel * dev_lbl = new QLabel(tr("Device"), this);
+		auto dev_lbl = new QLabel(tr("Device"), this);
 		dev_lbl->setFont(pointSize<7>(dev_lbl->font()));
 		dev_lbl->setGeometry(10, 40, 160, 10);
 	}

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -48,7 +48,7 @@ MidiSetupWidget::MidiSetupWidget(const QString & caption, const QString & config
 		m_device = new QLineEdit(devName, this);
 		m_device->setGeometry(10, 20, 160, 20);
 
-		QLabel * dev_lbl = new QLabel(tr("Device"), this);
+		auto* dev_lbl = new QLabel(tr("Device"), this);
 		dev_lbl->setFont(pointSize<7>(dev_lbl->font()));
 		dev_lbl->setGeometry(10, 40, 160, 10);
 	}

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -48,7 +48,7 @@ MidiSetupWidget::MidiSetupWidget(const QString & caption, const QString & config
 		m_device = new QLineEdit(devName, this);
 		m_device->setGeometry(10, 20, 160, 20);
 
-		auto* dev_lbl = new QLabel(tr("Device"), this);
+		QLabel * dev_lbl = new QLabel(tr("Device"), this);
 		dev_lbl->setFont(pointSize<7>(dev_lbl->font()));
 		dev_lbl->setGeometry(10, 40, 160, 10);
 	}

--- a/src/gui/MixerLine.cpp
+++ b/src/gui/MixerLine.cpp
@@ -53,7 +53,7 @@ bool MixerLine::eventFilter( QObject *dist, QEvent *event )
 	// If we are in a rename, capture the enter/return events and handle them
 	if ( event->type() == QEvent::KeyPress )
 	{
-		QKeyEvent * keyEvent = static_cast<QKeyEvent*>(event);
+		auto* keyEvent = static_cast<QKeyEvent*>(event);
 		if( keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return )
 		{
 			if( m_inRename )
@@ -120,7 +120,7 @@ MixerLine::MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	m_renameLineEdit->setReadOnly( true );
 	m_renameLineEdit->installEventFilter( this );
 
-	QGraphicsScene * scene = new QGraphicsScene();
+	auto* scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, 33, MixerLineHeight );
 
 	m_view = new QGraphicsView( this );

--- a/src/gui/MixerLine.cpp
+++ b/src/gui/MixerLine.cpp
@@ -53,7 +53,7 @@ bool MixerLine::eventFilter( QObject *dist, QEvent *event )
 	// If we are in a rename, capture the enter/return events and handle them
 	if ( event->type() == QEvent::KeyPress )
 	{
-		auto* keyEvent = static_cast<QKeyEvent*>(event);
+		QKeyEvent * keyEvent = static_cast<QKeyEvent*>(event);
 		if( keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return )
 		{
 			if( m_inRename )
@@ -120,7 +120,7 @@ MixerLine::MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	m_renameLineEdit->setReadOnly( true );
 	m_renameLineEdit->installEventFilter( this );
 
-	auto* scene = new QGraphicsScene();
+	QGraphicsScene * scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, 33, MixerLineHeight );
 
 	m_view = new QGraphicsView( this );

--- a/src/gui/MixerLine.cpp
+++ b/src/gui/MixerLine.cpp
@@ -53,7 +53,7 @@ bool MixerLine::eventFilter( QObject *dist, QEvent *event )
 	// If we are in a rename, capture the enter/return events and handle them
 	if ( event->type() == QEvent::KeyPress )
 	{
-		QKeyEvent * keyEvent = static_cast<QKeyEvent*>(event);
+		auto keyEvent = static_cast<QKeyEvent*>(event);
 		if( keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return )
 		{
 			if( m_inRename )
@@ -120,7 +120,7 @@ MixerLine::MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	m_renameLineEdit->setReadOnly( true );
 	m_renameLineEdit->installEventFilter( this );
 
-	QGraphicsScene * scene = new QGraphicsScene();
+	auto scene = new QGraphicsScene();
 	scene->setSceneRect( 0, 0, 33, MixerLineHeight );
 
 	m_view = new QGraphicsView( this );

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -69,7 +69,7 @@ MixerView::MixerView() :
 	setWindowIcon( embed::getIconPixmap( "mixer" ) );
 
 	// main-layout
-	QHBoxLayout * ml = new QHBoxLayout;
+	auto ml = new QHBoxLayout;
 
 	// Set margins
 	ml->setContentsMargins( 0, 4, 0, 0 );
@@ -131,7 +131,7 @@ MixerView::MixerView() :
 	ml->addWidget( channelArea, 1, Qt::AlignTop );
 
 	// show the add new mixer channel button
-	QPushButton * newChannelBtn = new QPushButton( embed::getIconPixmap( "new_channel" ), QString(), this );
+	auto newChannelBtn = new QPushButton(embed::getIconPixmap("new_channel"), QString(), this);
 	newChannelBtn->setObjectName( "newChannelBtn" );
 	newChannelBtn->setFixedSize( mixerLineSize );
 	connect( newChannelBtn, SIGNAL(clicked()), this, SLOT(addNewChannel()));
@@ -247,13 +247,13 @@ void MixerView::updateMaxChannelSelector()
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
+				auto inst = (InstrumentTrack*)trackList[i];
 				inst->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				SampleTrack * strk = (SampleTrack *) trackList[i];
+				auto strk = (SampleTrack*)trackList[i];
 				strk->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
@@ -445,12 +445,12 @@ void MixerView::deleteUnusedChannels()
 		int channel = 0;
 		if (t->type() == Track::InstrumentTrack)
 		{
-			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>(t);
+			auto inst = dynamic_cast<InstrumentTrack*>(t);
 			channel = inst->mixerChannelModel()->value();
 		}
 		else if (t->type() == Track::SampleTrack)
 		{
-			SampleTrack *strack = dynamic_cast<SampleTrack *>(t);
+			auto strack = dynamic_cast<SampleTrack*>(t);
 			channel = strack->mixerChannelModel()->value();
 		}
 		inUse[channel] = true;

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -69,7 +69,7 @@ MixerView::MixerView() :
 	setWindowIcon( embed::getIconPixmap( "mixer" ) );
 
 	// main-layout
-	auto* ml = new QHBoxLayout;
+	QHBoxLayout * ml = new QHBoxLayout;
 
 	// Set margins
 	ml->setContentsMargins( 0, 4, 0, 0 );
@@ -131,7 +131,7 @@ MixerView::MixerView() :
 	ml->addWidget( channelArea, 1, Qt::AlignTop );
 
 	// show the add new mixer channel button
-	auto* newChannelBtn = new QPushButton(embed::getIconPixmap("new_channel"), QString(), this);
+	QPushButton * newChannelBtn = new QPushButton( embed::getIconPixmap( "new_channel" ), QString(), this );
 	newChannelBtn->setObjectName( "newChannelBtn" );
 	newChannelBtn->setFixedSize( mixerLineSize );
 	connect( newChannelBtn, SIGNAL(clicked()), this, SLOT(addNewChannel()));
@@ -247,13 +247,13 @@ void MixerView::updateMaxChannelSelector()
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				auto* inst = (InstrumentTrack*)trackList[i];
+				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
 				inst->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				auto* strk = (SampleTrack*)trackList[i];
+				SampleTrack * strk = (SampleTrack *) trackList[i];
 				strk->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
@@ -445,12 +445,12 @@ void MixerView::deleteUnusedChannels()
 		int channel = 0;
 		if (t->type() == Track::InstrumentTrack)
 		{
-			auto* inst = dynamic_cast<InstrumentTrack*>(t);
+			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>(t);
 			channel = inst->mixerChannelModel()->value();
 		}
 		else if (t->type() == Track::SampleTrack)
 		{
-			auto* strack = dynamic_cast<SampleTrack*>(t);
+			SampleTrack *strack = dynamic_cast<SampleTrack *>(t);
 			channel = strack->mixerChannelModel()->value();
 		}
 		inUse[channel] = true;

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -69,7 +69,7 @@ MixerView::MixerView() :
 	setWindowIcon( embed::getIconPixmap( "mixer" ) );
 
 	// main-layout
-	QHBoxLayout * ml = new QHBoxLayout;
+	auto* ml = new QHBoxLayout;
 
 	// Set margins
 	ml->setContentsMargins( 0, 4, 0, 0 );
@@ -131,7 +131,7 @@ MixerView::MixerView() :
 	ml->addWidget( channelArea, 1, Qt::AlignTop );
 
 	// show the add new mixer channel button
-	QPushButton * newChannelBtn = new QPushButton( embed::getIconPixmap( "new_channel" ), QString(), this );
+	auto* newChannelBtn = new QPushButton(embed::getIconPixmap("new_channel"), QString(), this);
 	newChannelBtn->setObjectName( "newChannelBtn" );
 	newChannelBtn->setFixedSize( mixerLineSize );
 	connect( newChannelBtn, SIGNAL(clicked()), this, SLOT(addNewChannel()));
@@ -247,13 +247,13 @@ void MixerView::updateMaxChannelSelector()
 		{
 			if( trackList[i]->type() == Track::InstrumentTrack )
 			{
-				InstrumentTrack * inst = (InstrumentTrack *) trackList[i];
+				auto* inst = (InstrumentTrack*)trackList[i];
 				inst->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
 			else if( trackList[i]->type() == Track::SampleTrack )
 			{
-				SampleTrack * strk = (SampleTrack *) trackList[i];
+				auto* strk = (SampleTrack*)trackList[i];
 				strk->mixerChannelModel()->setRange(0,
 					m_mixerChannelViews.size()-1,1);
 			}
@@ -445,12 +445,12 @@ void MixerView::deleteUnusedChannels()
 		int channel = 0;
 		if (t->type() == Track::InstrumentTrack)
 		{
-			InstrumentTrack* inst = dynamic_cast<InstrumentTrack *>(t);
+			auto* inst = dynamic_cast<InstrumentTrack*>(t);
 			channel = inst->mixerChannelModel()->value();
 		}
 		else if (t->type() == Track::SampleTrack)
 		{
-			SampleTrack *strack = dynamic_cast<SampleTrack *>(t);
+			auto* strack = dynamic_cast<SampleTrack*>(t);
 			channel = strack->mixerChannelModel()->value();
 		}
 		inUse[channel] = true;

--- a/src/gui/PeakControllerDialog.cpp
+++ b/src/gui/PeakControllerDialog.cpp
@@ -45,7 +45,7 @@ PeakControllerDialog::PeakControllerDialog( Controller * _model, QWidget * _pare
 	
 	setToolTip(tr("LFO Controller"));
 
-	QLabel * l = new QLabel( this );
+	auto l = new QLabel(this);
 	l->setText( "Use FX's controls" );
 	l->move(10, 10);
 

--- a/src/gui/PeakControllerDialog.cpp
+++ b/src/gui/PeakControllerDialog.cpp
@@ -45,7 +45,7 @@ PeakControllerDialog::PeakControllerDialog( Controller * _model, QWidget * _pare
 	
 	setToolTip(tr("LFO Controller"));
 
-	auto* l = new QLabel(this);
+	QLabel * l = new QLabel( this );
 	l->setText( "Use FX's controls" );
 	l->move(10, 10);
 

--- a/src/gui/PeakControllerDialog.cpp
+++ b/src/gui/PeakControllerDialog.cpp
@@ -45,7 +45,7 @@ PeakControllerDialog::PeakControllerDialog( Controller * _model, QWidget * _pare
 	
 	setToolTip(tr("LFO Controller"));
 
-	QLabel * l = new QLabel( this );
+	auto* l = new QLabel(this);
 	l->setText( "Use FX's controls" );
 	l->move(10, 10);
 

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -51,7 +51,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 
 	addContentWidget( m_view );
 
-	auto* view_layout = new QVBoxLayout(m_view);
+	QVBoxLayout * view_layout = new QVBoxLayout( m_view );
 	view_layout->setMargin( 5 );
 	view_layout->setSpacing( 5 );
 
@@ -63,7 +63,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 								m_view );
 	hint->setWordWrap( true );
 
-	auto* searchBar = new QLineEdit(m_view);
+	QLineEdit * searchBar = new QLineEdit( m_view );
 	searchBar->setPlaceholderText( "Search" );
 	searchBar->setMaxLength( 64 );
 	searchBar->setClearButtonEnabled( true );
@@ -120,7 +120,8 @@ void PluginBrowser::onFilterChanged( const QString & filter )
 		for (int itemIndex = 0; itemIndex < itemCount; ++itemIndex)
 		{
 			QTreeWidgetItem * item = root->child( itemIndex );
-			auto* descWidget = static_cast<PluginDescWidget*>(m_descTree->itemWidget(item, 0));
+			PluginDescWidget * descWidget = static_cast<PluginDescWidget *>
+							(m_descTree->itemWidget( item, 0));
 			if (descWidget->name().contains(filter, Qt::CaseInsensitive))
 			{
 				item->setHidden( false );

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -51,7 +51,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 
 	addContentWidget( m_view );
 
-	QVBoxLayout * view_layout = new QVBoxLayout( m_view );
+	auto* view_layout = new QVBoxLayout(m_view);
 	view_layout->setMargin( 5 );
 	view_layout->setSpacing( 5 );
 
@@ -63,7 +63,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 								m_view );
 	hint->setWordWrap( true );
 
-	QLineEdit * searchBar = new QLineEdit( m_view );
+	auto* searchBar = new QLineEdit(m_view);
 	searchBar->setPlaceholderText( "Search" );
 	searchBar->setMaxLength( 64 );
 	searchBar->setClearButtonEnabled( true );
@@ -120,8 +120,7 @@ void PluginBrowser::onFilterChanged( const QString & filter )
 		for (int itemIndex = 0; itemIndex < itemCount; ++itemIndex)
 		{
 			QTreeWidgetItem * item = root->child( itemIndex );
-			PluginDescWidget * descWidget = static_cast<PluginDescWidget *>
-							(m_descTree->itemWidget( item, 0));
+			auto* descWidget = static_cast<PluginDescWidget*>(m_descTree->itemWidget(item, 0));
 			if (descWidget->name().contains(filter, Qt::CaseInsensitive))
 			{
 				item->setHidden( false );

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -51,7 +51,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 
 	addContentWidget( m_view );
 
-	QVBoxLayout * view_layout = new QVBoxLayout( m_view );
+	auto view_layout = new QVBoxLayout(m_view);
 	view_layout->setMargin( 5 );
 	view_layout->setSpacing( 5 );
 
@@ -63,7 +63,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 								m_view );
 	hint->setWordWrap( true );
 
-	QLineEdit * searchBar = new QLineEdit( m_view );
+	auto searchBar = new QLineEdit(m_view);
 	searchBar->setPlaceholderText( "Search" );
 	searchBar->setMaxLength( 64 );
 	searchBar->setClearButtonEnabled( true );
@@ -120,8 +120,7 @@ void PluginBrowser::onFilterChanged( const QString & filter )
 		for (int itemIndex = 0; itemIndex < itemCount; ++itemIndex)
 		{
 			QTreeWidgetItem * item = root->child( itemIndex );
-			PluginDescWidget * descWidget = static_cast<PluginDescWidget *>
-							(m_descTree->itemWidget( item, 0));
+			auto descWidget = static_cast<PluginDescWidget*>(m_descTree->itemWidget(item, 0));
 			if (descWidget->name().contains(filter, Qt::CaseInsensitive))
 			{
 				item->setHidden( false );

--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -186,7 +186,8 @@ void ProjectNotes::setupActions()
 	connect( m_actionTextUnderline, SIGNAL(triggered()), this,
 						SLOT(textUnderline()));
 
-	auto* grp = new QActionGroup(tb);
+
+	QActionGroup * grp = new QActionGroup( tb );
 	connect( grp, SIGNAL(triggered(QAction*)), this,
 					SLOT(textAlign(QAction*)));
 

--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -186,8 +186,7 @@ void ProjectNotes::setupActions()
 	connect( m_actionTextUnderline, SIGNAL(triggered()), this,
 						SLOT(textUnderline()));
 
-
-	QActionGroup * grp = new QActionGroup( tb );
+	auto* grp = new QActionGroup(tb);
 	connect( grp, SIGNAL(triggered(QAction*)), this,
 					SLOT(textAlign(QAction*)));
 

--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -186,8 +186,7 @@ void ProjectNotes::setupActions()
 	connect( m_actionTextUnderline, SIGNAL(triggered()), this,
 						SLOT(textUnderline()));
 
-
-	QActionGroup * grp = new QActionGroup( tb );
+	auto grp = new QActionGroup(tb);
 	connect( grp, SIGNAL(triggered(QAction*)), this,
 					SLOT(textAlign(QAction*)));
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -56,19 +56,19 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 {
 	// init own layout + widgets
 	setFocusPolicy(Qt::StrongFocus);
-	QVBoxLayout * vlayout = new QVBoxLayout(this);
+	auto vlayout = new QVBoxLayout(this);
 	vlayout->setMargin(0);
 	vlayout->setSpacing(0);
 
-	TabWidget* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
+	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
 
-	QVBoxLayout* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
+	auto generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
 
 	generalSettingsLayout->setContentsMargins(8, 18, 8, 8);
 	generalSettingsLayout->setSpacing(6);
 
-	QWidget* nameWidget = new QWidget(generalSettingsWidget);
-	QHBoxLayout* nameLayout = new QHBoxLayout(nameWidget);
+	auto nameWidget = new QWidget(generalSettingsWidget);
+	auto nameLayout = new QHBoxLayout(nameWidget);
 	nameLayout->setContentsMargins(0, 0, 0, 0);
 	nameLayout->setSpacing(2);
 
@@ -84,8 +84,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 
 	generalSettingsLayout->addWidget(nameWidget);
 
-
-	QGridLayout* basicControlsLayout = new QGridLayout;
+	auto basicControlsLayout = new QGridLayout;
 	basicControlsLayout->setHorizontalSpacing(3);
 	basicControlsLayout->setVerticalSpacing(0);
 	basicControlsLayout->setContentsMargins(0, 0, 0, 0);
@@ -102,7 +101,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	basicControlsLayout->addWidget(m_volumeKnob, 0, 0);
 	basicControlsLayout->setAlignment(m_volumeKnob, widgetAlignment);
 
-	QLabel *label = new QLabel(tr("VOL"), this);
+	auto label = new QLabel(tr("VOL"), this);
 	label->setStyleSheet(labelStyleSheet);
 	basicControlsLayout->addWidget(label, 1, 0);
 	basicControlsLayout->setAlignment(label, labelAlignment);

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -56,19 +56,19 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 {
 	// init own layout + widgets
 	setFocusPolicy(Qt::StrongFocus);
-	QVBoxLayout * vlayout = new QVBoxLayout(this);
+	auto* vlayout = new QVBoxLayout(this);
 	vlayout->setMargin(0);
 	vlayout->setSpacing(0);
 
-	TabWidget* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
+	auto* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
 
-	QVBoxLayout* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
+	auto* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
 
 	generalSettingsLayout->setContentsMargins(8, 18, 8, 8);
 	generalSettingsLayout->setSpacing(6);
 
-	QWidget* nameWidget = new QWidget(generalSettingsWidget);
-	QHBoxLayout* nameLayout = new QHBoxLayout(nameWidget);
+	auto* nameWidget = new QWidget(generalSettingsWidget);
+	auto* nameLayout = new QHBoxLayout(nameWidget);
 	nameLayout->setContentsMargins(0, 0, 0, 0);
 	nameLayout->setSpacing(2);
 
@@ -84,8 +84,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 
 	generalSettingsLayout->addWidget(nameWidget);
 
-
-	QGridLayout* basicControlsLayout = new QGridLayout;
+	auto* basicControlsLayout = new QGridLayout;
 	basicControlsLayout->setHorizontalSpacing(3);
 	basicControlsLayout->setVerticalSpacing(0);
 	basicControlsLayout->setContentsMargins(0, 0, 0, 0);
@@ -102,7 +101,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	basicControlsLayout->addWidget(m_volumeKnob, 0, 0);
 	basicControlsLayout->setAlignment(m_volumeKnob, widgetAlignment);
 
-	QLabel *label = new QLabel(tr("VOL"), this);
+	auto* label = new QLabel(tr("VOL"), this);
 	label->setStyleSheet(labelStyleSheet);
 	basicControlsLayout->addWidget(label, 1, 0);
 	basicControlsLayout->setAlignment(label, labelAlignment);

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -56,19 +56,19 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 {
 	// init own layout + widgets
 	setFocusPolicy(Qt::StrongFocus);
-	auto* vlayout = new QVBoxLayout(this);
+	QVBoxLayout * vlayout = new QVBoxLayout(this);
 	vlayout->setMargin(0);
 	vlayout->setSpacing(0);
 
-	auto* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
+	TabWidget* generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
 
-	auto* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
+	QVBoxLayout* generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
 
 	generalSettingsLayout->setContentsMargins(8, 18, 8, 8);
 	generalSettingsLayout->setSpacing(6);
 
-	auto* nameWidget = new QWidget(generalSettingsWidget);
-	auto* nameLayout = new QHBoxLayout(nameWidget);
+	QWidget* nameWidget = new QWidget(generalSettingsWidget);
+	QHBoxLayout* nameLayout = new QHBoxLayout(nameWidget);
 	nameLayout->setContentsMargins(0, 0, 0, 0);
 	nameLayout->setSpacing(2);
 
@@ -84,7 +84,8 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 
 	generalSettingsLayout->addWidget(nameWidget);
 
-	auto* basicControlsLayout = new QGridLayout;
+
+	QGridLayout* basicControlsLayout = new QGridLayout;
 	basicControlsLayout->setHorizontalSpacing(3);
 	basicControlsLayout->setVerticalSpacing(0);
 	basicControlsLayout->setContentsMargins(0, 0, 0, 0);
@@ -101,7 +102,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	basicControlsLayout->addWidget(m_volumeKnob, 0, 0);
 	basicControlsLayout->setAlignment(m_volumeKnob, widgetAlignment);
 
-	auto* label = new QLabel(tr("VOL"), this);
+	QLabel *label = new QLabel(tr("VOL"), this);
 	label->setStyleSheet(labelStyleSheet);
 	basicControlsLayout->addWidget(label, 1, 0);
 	basicControlsLayout->setAlignment(label, labelAlignment);

--- a/src/gui/SideBar.cpp
+++ b/src/gui/SideBar.cpp
@@ -103,7 +103,7 @@ SideBar::SideBar( Qt::Orientation _orientation, QWidget * _parent ) :
 
 void SideBar::appendTab( SideBarWidget *widget )
 {
-	SideBarButton *button = new SideBarButton( orientation(), this );
+	auto* button = new SideBarButton(orientation(), this);
 	button->setText( " " + widget->title() );
 	button->setIcon( widget->icon() );
 	button->setLayoutDirection( Qt::RightToLeft );

--- a/src/gui/SideBar.cpp
+++ b/src/gui/SideBar.cpp
@@ -103,7 +103,7 @@ SideBar::SideBar( Qt::Orientation _orientation, QWidget * _parent ) :
 
 void SideBar::appendTab( SideBarWidget *widget )
 {
-	SideBarButton *button = new SideBarButton( orientation(), this );
+	auto button = new SideBarButton(orientation(), this);
 	button->setText( " " + widget->title() );
 	button->setIcon( widget->icon() );
 	button->setLayoutDirection( Qt::RightToLeft );

--- a/src/gui/SideBar.cpp
+++ b/src/gui/SideBar.cpp
@@ -103,7 +103,7 @@ SideBar::SideBar( Qt::Orientation _orientation, QWidget * _parent ) :
 
 void SideBar::appendTab( SideBarWidget *widget )
 {
-	auto* button = new SideBarButton(orientation(), this);
+	SideBarButton *button = new SideBarButton( orientation(), this );
 	button->setText( " " + widget->title() );
 	button->setIcon( widget->icon() );
 	button->setLayoutDirection( Qt::RightToLeft );

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -58,7 +58,7 @@ StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
 		setPixmap( _icon );
 	}
 	QString txt = _key + ":" + _value;
-	auto* m = new QMimeData();
+	QMimeData * m = new QMimeData();
 	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
 	setMimeData( m );
 	exec( Qt::LinkAction, Qt::LinkAction );

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -58,7 +58,7 @@ StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
 		setPixmap( _icon );
 	}
 	QString txt = _key + ":" + _value;
-	QMimeData * m = new QMimeData();
+	auto m = new QMimeData();
 	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
 	setMimeData( m );
 	exec( Qt::LinkAction, Qt::LinkAction );

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -58,7 +58,7 @@ StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
 		setPixmap( _icon );
 	}
 	QString txt = _key + ":" + _value;
-	QMimeData * m = new QMimeData();
+	auto* m = new QMimeData();
 	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
 	setMimeData( m );
 	exec( Qt::LinkAction, Qt::LinkAction );

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -166,8 +166,7 @@ void AutomationClipView::flipX()
 
 void AutomationClipView::constructContextMenu( QMenu * _cm )
 {
-	QAction * a = new QAction( embed::getIconPixmap( "automation" ),
-				tr( "Open in Automation editor" ), _cm );
+	auto a = new QAction(embed::getIconPixmap("automation"), tr("Open in Automation editor"), _cm);
 	_cm->insertAction( _cm->actions()[0], a );
 	connect(a, SIGNAL(triggered()), this, SLOT(openInAutomationEditor()));
 	_cm->insertSeparator( _cm->actions()[1] );
@@ -195,8 +194,7 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	if( !m_clip->m_objects.isEmpty() )
 	{
 		_cm->addSeparator();
-		QMenu * m = new QMenu( tr( "%1 Connections" ).
-				arg( m_clip->m_objects.count() ), _cm );
+		auto m = new QMenu(tr("%1 Connections").arg(m_clip->m_objects.count()), _cm);
 		for( AutomationClip::objectVector::iterator it =
 						m_clip->m_objects.begin();
 					it != m_clip->m_objects.end(); ++it )
@@ -276,8 +274,8 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 				/ (float) m_clip->timeMapLength().getBar() :
 								pixelsPerBar();
 
-	const float min = m_clip->firstObject()->minValue<float>();
-	const float max = m_clip->firstObject()->maxValue<float>();
+	const auto min = m_clip->firstObject()->minValue<float>();
+	const auto max = m_clip->firstObject()->maxValue<float>();
 
 	const float y_scale = max - min;
 	const float h = ( height() - 2 * BORDER_WIDTH ) / y_scale;
@@ -303,7 +301,7 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 		if( it+1 == m_clip->getTimeMap().end() )
 		{
 			const float x1 = POS(it) * ppTick;
-			const float x2 = (float)( width() - BORDER_WIDTH );
+			const auto x2 = (float)(width() - BORDER_WIDTH);
 			if( x1 > ( width() - BORDER_WIDTH ) ) break;
 			// We are drawing the space after the last node, so we use the outValue
 			if( gradient() )
@@ -434,9 +432,7 @@ void AutomationClipView::dropEvent( QDropEvent * _de )
 	QString val = StringPairDrag::decodeValue( _de );
 	if( type == "automatable_model" )
 	{
-		AutomatableModel * mod = dynamic_cast<AutomatableModel *>(
-				Engine::projectJournal()->
-					journallingObject( val.toInt() ) );
+		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )
 		{
 			bool added = m_clip->addObject( mod );

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -425,7 +425,7 @@ void ClipView::setColor(const QColor* color)
 void ClipView::dragEnterEvent( QDragEnterEvent * dee )
 {
 	TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
-	TimePos clipPos = TimePos( m_clip->startPosition() );
+	auto clipPos = TimePos(m_clip->startPosition());
 
 	if( tcw->canPasteSelection( clipPos, dee ) == false )
 	{
@@ -465,7 +465,7 @@ void ClipView::dropEvent( QDropEvent * de )
 	if( m_trackView->trackContainerView()->allowRubberband() == true )
 	{
 		TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
-		TimePos clipPos = TimePos( m_clip->startPosition() );
+		auto clipPos = TimePos(m_clip->startPosition());
 
 		if( tcw->pasteSelection( clipPos, de ) == true )
 		{
@@ -501,7 +501,7 @@ void ClipView::dropEvent( QDropEvent * de )
  */
 void ClipView::updateCursor(QMouseEvent * me)
 {
-	SampleClip * sClip = dynamic_cast<SampleClip*>(m_clip);
+	auto sClip = dynamic_cast<SampleClip*>(m_clip);
 
 	// If we are at the edges, use the resize cursor
 	if ((me->x() > width() - RESIZE_GRIP_WIDTH && !me->buttons() && !m_clip->getAutoResize())
@@ -634,7 +634,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 	setInitialOffsets();
 	if( !fixedClips() && me->button() == Qt::LeftButton )
 	{
-		SampleClip * sClip = dynamic_cast<SampleClip*>( m_clip );
+		auto sClip = dynamic_cast<SampleClip*>(m_clip);
 		const bool knifeMode = m_trackView->trackContainerView()->knifeMode();
 
 		if ( me->modifiers() & Qt::ControlModifier && !(sClip && knifeMode) )
@@ -747,7 +747,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 		if (m_action == Split)
 		{
 			m_action = NoAction;
-			SampleClip * sClip = dynamic_cast<SampleClip*>( m_clip );
+			auto sClip = dynamic_cast<SampleClip*>(m_clip);
 			if (sClip)
 			{
 				setMarkerEnabled( false );
@@ -798,8 +798,7 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 					m_trackView->trackContainerView()->selectedObjects();
 				for( auto it = so.begin(); it != so.end(); ++it )
 				{
-					ClipView * clipv =
-						dynamic_cast<ClipView *>( *it );
+					auto clipv = dynamic_cast<ClipView*>(*it);
 					if( clipv != nullptr )
 					{
 						clipViews.push_back( clipv );
@@ -863,8 +862,7 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 		for( QVector<selectableObject *>::iterator it = so.begin();
 							it != so.end(); ++it )
 		{
-			ClipView* clipv =
-				dynamic_cast<ClipView *>( *it );
+			auto clipv = dynamic_cast<ClipView*>(*it);
 			if( clipv == nullptr ) { continue; }
 			clips.push_back( clipv->m_clip );
 			int index = std::distance( so.begin(), it );
@@ -912,14 +910,14 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				TimePos initialLength = m_initialClipEnd - m_initialClipPos;
 				TimePos offset = TimePos( l - initialLength ).quantize( snapSize );
 				// Don't resize to less than 1 tick
-				TimePos min = TimePos( initialLength % snapLength );
+				auto min = TimePos(initialLength % snapLength);
 				if (min < 1) min += snapLength;
 				m_clip->changeLength( qMax<int>( min, initialLength + offset) );
 			}
 		}
 		else
 		{
-			SampleClip * sClip = dynamic_cast<SampleClip*>( m_clip );
+			auto sClip = dynamic_cast<SampleClip*>(m_clip);
 			if( sClip )
 			{
 				const int x = mapToParent( me->pos() ).x() - m_initialMousePos.x();
@@ -946,7 +944,7 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				{	// Otherwise, resize in fixed increments
 					// Don't resize to less than 1 tick
 					TimePos initialLength = m_initialClipEnd - m_initialClipPos;
-					TimePos minLength = TimePos( initialLength % snapLength );
+					auto minLength = TimePos(initialLength % snapLength);
 					if (minLength < 1) minLength += snapLength;
 					TimePos offset = TimePos(t - m_initialClipPos).quantize( snapSize );
 					t = qMin<int>( m_initialClipEnd - minLength, m_initialClipPos + offset );
@@ -975,7 +973,7 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 	}
 	else if( m_action == Split )
 	{
-		SampleClip * sClip = dynamic_cast<SampleClip*>( m_clip );
+		auto sClip = dynamic_cast<SampleClip*>(m_clip);
 		if (sClip) {
 			setCursor( m_cursorKnife );
 			setMarkerPos( knifeMarkerPos( me ) );
@@ -1157,7 +1155,7 @@ QVector<ClipView *> ClipView::getClickedClips()
 	selection.reserve( sos.size() );
 	for( auto so: sos )
 	{
-		ClipView *clipv = dynamic_cast<ClipView *> ( so );
+		auto clipv = dynamic_cast<ClipView*>(so);
 		if( clipv != nullptr )
 		{
 			selection.append( clipv );
@@ -1207,7 +1205,7 @@ void ClipView::paste()
 	using namespace Clipboard;
 
 	// If possible, paste the selection on the TimePos of the selected Track and remove it
-	TimePos clipPos = TimePos( m_clip->startPosition() );
+	auto clipPos = TimePos(m_clip->startPosition());
 
 	TrackContentWidget *tcw = getTrackView()->getTrackContentWidget();
 
@@ -1246,8 +1244,7 @@ bool ClipView::canMergeSelection(QVector<ClipView*> clipvs)
 void ClipView::mergeClips(QVector<ClipView*> clipvs)
 {
 	// Get the track that we are merging Clips in
-	InstrumentTrack* track =
-		dynamic_cast<InstrumentTrack*>(clipvs.at(0)->getTrackView()->getTrack());
+	auto track = dynamic_cast<InstrumentTrack*>(clipvs.at(0)->getTrackView()->getTrack());
 
 	if (!track)
 	{
@@ -1271,7 +1268,7 @@ void ClipView::mergeClips(QVector<ClipView*> clipvs)
 	const TimePos earliestPos = (*earliestClipV)->getClip()->startPosition();
 
 	// Create a clip where all notes will be added
-	MidiClip* newMidiClip = dynamic_cast<MidiClip*>(track->createClip(earliestPos));
+	auto newMidiClip = dynamic_cast<MidiClip*>(track->createClip(earliestPos));
 	if (!newMidiClip)
 	{
 		qWarning("Warning: Failed to convert Clip to MidiClip on mergeClips");
@@ -1284,7 +1281,7 @@ void ClipView::mergeClips(QVector<ClipView*> clipvs)
 	for (auto clipv: clipvs)
 	{
 		// Convert ClipV to MidiClipView
-		MidiClipView* mcView = dynamic_cast<MidiClipView*>(clipv);
+		auto mcView = dynamic_cast<MidiClipView*>(clipv);
 
 		if (!mcView)
 		{
@@ -1342,8 +1339,7 @@ void ClipView::setInitialOffsets()
 	for( QVector<selectableObject *>::iterator it = so.begin();
 						it != so.end(); ++it )
 	{
-		ClipView * clipv =
-			dynamic_cast<ClipView *>( *it );
+		auto clipv = dynamic_cast<ClipView*>(*it);
 		if( clipv == nullptr )
 		{
 			continue;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -425,7 +425,7 @@ void ClipView::setColor(const QColor* color)
 void ClipView::dragEnterEvent( QDragEnterEvent * dee )
 {
 	TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
-	auto clipPos = TimePos(m_clip->startPosition());
+	TimePos clipPos{m_clip->startPosition()};
 
 	if( tcw->canPasteSelection( clipPos, dee ) == false )
 	{
@@ -465,7 +465,7 @@ void ClipView::dropEvent( QDropEvent * de )
 	if( m_trackView->trackContainerView()->allowRubberband() == true )
 	{
 		TrackContentWidget * tcw = getTrackView()->getTrackContentWidget();
-		auto clipPos = TimePos(m_clip->startPosition());
+		TimePos clipPos{m_clip->startPosition()};
 
 		if( tcw->pasteSelection( clipPos, de ) == true )
 		{
@@ -1205,7 +1205,7 @@ void ClipView::paste()
 	using namespace Clipboard;
 
 	// If possible, paste the selection on the TimePos of the selected Track and remove it
-	auto clipPos = TimePos(m_clip->startPosition());
+	TimePos clipPos{m_clip->startPosition()};
 
 	TrackContentWidget *tcw = getTrackView()->getTrackContentWidget();
 

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -206,14 +206,12 @@ void MidiClipView::constructContextMenu( QMenu * _cm )
 {
 	bool isBeat = m_clip->type() == MidiClip::BeatClip;
 
-	QAction * a = new QAction( embed::getIconPixmap( "piano" ),
-					tr( "Open in piano-roll" ), _cm );
+	auto a = new QAction(embed::getIconPixmap("piano"), tr("Open in piano-roll"), _cm);
 	_cm->insertAction( _cm->actions()[0], a );
 	connect( a, SIGNAL(triggered(bool)),
 					this, SLOT(openInPianoRoll()));
 
-	QAction * b = new QAction( embed::getIconPixmap( "ghost_note" ),
-						tr( "Set as ghost in piano-roll" ), _cm );
+	auto b = new QAction(embed::getIconPixmap("ghost_note"), tr("Set as ghost in piano-roll"), _cm);
 	if( m_clip->empty() ) { b->setEnabled( false ); }
 	_cm->insertAction( _cm->actions()[1], b );
 	connect( b, SIGNAL(triggered(bool)),

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -52,9 +52,7 @@ PatternClipView::PatternClipView(Clip* _clip, TrackView* _tv) :
 
 void PatternClipView::constructContextMenu(QMenu* _cm)
 {
-	QAction* a = new QAction(embed::getIconPixmap("pattern_track"),
-					tr("Open in Pattern Editor"),
-					_cm );
+	auto a = new QAction(embed::getIconPixmap("pattern_track"), tr("Open in Pattern Editor"), _cm);
 	_cm->insertAction( _cm->actions()[0], a );
 	connect( a, SIGNAL(triggered(bool)),
 			this, SLOT(openInPatternEditor()));

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -140,7 +140,7 @@ void SampleClipView::mousePressEvent( QMouseEvent * _me )
 	{
 		if( _me->button() == Qt::MiddleButton && _me->modifiers() == Qt::ControlModifier )
 		{
-			SampleClip * sClip = dynamic_cast<SampleClip*>( getClip() );
+			auto sClip = dynamic_cast<SampleClip*>(getClip());
 			if( sClip )
 			{
 				sClip->updateTrackClips();
@@ -157,7 +157,7 @@ void SampleClipView::mouseReleaseEvent(QMouseEvent *_me)
 {
 	if( _me->button() == Qt::MiddleButton && !_me->modifiers() )
 	{
-		SampleClip * sClip = dynamic_cast<SampleClip*>( getClip() );
+		auto sClip = dynamic_cast<SampleClip*>(getClip());
 		if( sClip )
 		{
 			sClip->playbackPositionChanged();
@@ -342,7 +342,7 @@ bool SampleClipView::splitClip( const TimePos pos )
 		m_clip->getTrack()->addJournalCheckPoint();
 		m_clip->getTrack()->saveJournallingState( false );
 
-		SampleClip * rightClip = new SampleClip ( *m_clip );
+		auto rightClip = new SampleClip(*m_clip);
 
 		m_clip->changeLength( splitPos - m_initialClipPos );
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -348,7 +348,7 @@ void AutomationEditor::drawLine( int x0In, float y0, int x1In, float y1 )
 	int x0 = Note::quantized( x0In, AutomationClip::quantization() );
 	int x1 = Note::quantized( x1In, AutomationClip::quantization() );
 	int deltax = qAbs( x1 - x0 );
-	float deltay = qAbs<float>( y1 - y0 );
+	auto deltay = qAbs<float>(y1 - y0);
 	int x = x0;
 	float y = y0;
 	int xstep;
@@ -962,8 +962,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 	// print value numbers
 	int font_height = p.fontMetrics().height();
-	Qt::Alignment text_flags =
-		(Qt::Alignment)( Qt::AlignRight | Qt::AlignVCenter );
+	auto text_flags = (Qt::Alignment)(Qt::AlignRight | Qt::AlignVCenter);
 
 	if( validClip() )
 	{
@@ -1839,7 +1838,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	// Edit mode buttons
 	DropToolBar *editActionsToolBar = addDropToolBarToTop(tr("Edit actions"));
 
-	ActionGroup* editModeGroup = new ActionGroup(this);
+	auto editModeGroup = new ActionGroup(this);
 	QAction* drawAction = editModeGroup->addAction(embed::getIconPixmap("edit_draw"), tr("Draw mode (Shift+D)"));
 	drawAction->setShortcut(Qt::SHIFT | Qt::Key_D);
 	drawAction->setChecked(true);
@@ -1864,7 +1863,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	// Interpolation actions
 	DropToolBar *interpolationActionsToolBar = addDropToolBarToTop(tr("Interpolation controls"));
 
-	ActionGroup* progression_type_group = new ActionGroup(this);
+	auto progression_type_group = new ActionGroup(this);
 
 	m_discreteAction = progression_type_group->addAction(
 				embed::getIconPixmap("progression_discrete"), tr("Discrete progression"));
@@ -1899,7 +1898,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	// Zoom controls
 	DropToolBar *zoomToolBar = addDropToolBarToTop(tr("Zoom controls"));
 
-	QLabel * zoom_x_label = new QLabel( zoomToolBar );
+	auto zoom_x_label = new QLabel(zoomToolBar);
 	zoom_x_label->setPixmap( embed::getIconPixmap( "zoom_x" ) );
 
 	m_zoomingXComboBox = new ComboBox( zoomToolBar );
@@ -1917,8 +1916,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	connect( &m_editor->m_zoomingXModel, SIGNAL(dataChanged()),
 			m_editor, SLOT(zoomingXChanged()));
 
-
-	QLabel * zoom_y_label = new QLabel( zoomToolBar );
+	auto zoom_y_label = new QLabel(zoomToolBar);
 	zoom_y_label->setPixmap( embed::getIconPixmap( "zoom_y" ) );
 
 	m_zoomingYComboBox = new ComboBox( zoomToolBar );
@@ -1946,7 +1944,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	// Quantization controls
 	DropToolBar *quantizationActionsToolBar = addDropToolBarToTop(tr("Quantization controls"));
 
-	QLabel * quantize_lbl = new QLabel( m_toolBar );
+	auto quantize_lbl = new QLabel(m_toolBar);
 	quantize_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
 
 	m_quantizeComboBox = new ComboBox( m_toolBar );
@@ -2031,9 +2029,7 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 	QString val = StringPairDrag::decodeValue( _de );
 	if( type == "automatable_model" )
 	{
-		AutomatableModel * mod = dynamic_cast<AutomatableModel *>(
-				Engine::projectJournal()->
-					journallingObject( val.toInt() ) );
+		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if (mod != nullptr)
 		{
 			bool added = m_editor->m_clip->addObject( mod );

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -58,7 +58,7 @@ DropToolBar * Editor::addDropToolBar(Qt::ToolBarArea whereToAdd, QString const &
 
 DropToolBar * Editor::addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle)
 {
-	DropToolBar *toolBar = new DropToolBar(parent);
+	auto toolBar = new DropToolBar(parent);
 	addToolBar(whereToAdd, toolBar);
 	toolBar->setMovable(false);
 	toolBar->setFloatable(false);

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -76,7 +76,7 @@ void PatternEditor::removeSteps()
 	{
 		if( ( *it )->type() == Track::InstrumentTrack )
 		{
-			MidiClip* p = static_cast<MidiClip*>((*it)->getClip(m_ps->currentPattern()));
+			auto p = static_cast<MidiClip*>((*it)->getClip(m_ps->currentPattern()));
 			p->removeSteps();
 		}
 	}
@@ -184,7 +184,7 @@ void PatternEditor::makeSteps( bool clone )
 	{
 		if( ( *it )->type() == Track::InstrumentTrack )
 		{
-			MidiClip* p = static_cast<MidiClip*>((*it)->getClip(m_ps->currentPattern()));
+			auto p = static_cast<MidiClip*>((*it)->getClip(m_ps->currentPattern()));
 			if( clone )
 			{
 				p->cloneSteps();
@@ -201,7 +201,7 @@ void PatternEditor::makeSteps( bool clone )
 void PatternEditor::cloneClip()
 {
 	// Get the current PatternTrack id
-	PatternStore* ps = static_cast<PatternStore*>(model());
+	auto ps = static_cast<PatternStore*>(model());
 	const int currentPattern = ps->currentPattern();
 
 	PatternTrack* pt = PatternTrack::findPatternTrack(currentPattern);
@@ -272,7 +272,7 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_automation"), tr("Add automation-track"),
 						m_editor, SLOT(addAutomationTrack()));
 
-	QWidget* stretch = new QWidget(m_toolBar);
+	auto stretch = new QWidget(m_toolBar);
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	trackAndStepActionsToolBar->addWidget(stretch);
 
@@ -288,13 +288,12 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	connect(&ps->m_patternComboBoxModel, SIGNAL(dataChanged()),
 			m_editor, SLOT(updatePosition()));
 
-
-	QAction* viewNext = new QAction(this);
+	auto viewNext = new QAction(this);
 	connect(viewNext, SIGNAL(triggered()), m_patternComboBox, SLOT(selectNext()));
 	viewNext->setShortcut(Qt::Key_Plus);
 	addAction(viewNext);
 
-	QAction* viewPrevious = new QAction(this);
+	auto viewPrevious = new QAction(this);
 	connect(viewPrevious, SIGNAL(triggered()), m_patternComboBox, SLOT(selectPrevious()));
 	viewPrevious->setShortcut(Qt::Key_Minus);
 	addAction(viewPrevious);

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1001,7 +1001,7 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	float leftPercent = qMin<float>( 1.0f, leftPanSpan / panningRange * 2.0f );
 	float rightPercent = qMin<float>( 1.0f, rightPanSpan / panningRange * 2.0f );
 
-	auto col = QColor(noteCol);
+	QColor col{noteCol};
 	QPen pen;
 
 	if( n->selected() )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -227,19 +227,19 @@ PianoRoll::PianoRoll() :
 	m_noteEditMenu->clear();
 	for( int i = 0; i < m_nemStr.size(); ++i )
 	{
-		QAction * act = new QAction( m_nemStr.at(i), this );
+		auto act = new QAction(m_nemStr.at(i), this);
 		connect( act, &QAction::triggered, [this, i](){ changeNoteEditMode(i); } );
 		m_noteEditMenu->addAction( act );
 	}
 
 	m_semiToneMarkerMenu = new QMenu( this );
 
-	QAction* markSemitoneAction = new QAction( tr("Mark/unmark current semitone"), this );
-	QAction* markAllOctaveSemitonesAction = new QAction( tr("Mark/unmark all corresponding octave semitones"), this );
-	QAction* markScaleAction = new QAction( tr("Mark current scale"), this );
-	QAction* markChordAction = new QAction( tr("Mark current chord"), this );
-	QAction* unmarkAllAction = new QAction( tr("Unmark all"), this );
-	QAction* copyAllNotesAction = new QAction( tr("Select all notes on this key"), this);
+	auto markSemitoneAction = new QAction(tr("Mark/unmark current semitone"), this);
+	auto markAllOctaveSemitonesAction = new QAction(tr("Mark/unmark all corresponding octave semitones"), this);
+	auto markScaleAction = new QAction(tr("Mark current scale"), this);
+	auto markChordAction = new QAction(tr("Mark current chord"), this);
+	auto unmarkAllAction = new QAction(tr("Unmark all"), this);
+	auto copyAllNotesAction = new QAction(tr("Select all notes on this key"), this);
 
 	connect( markSemitoneAction, &QAction::triggered, [this](){ markSemiTone(stmaMarkCurrentSemiTone); });
 	connect( markAllOctaveSemitonesAction, &QAction::triggered, [this](){ markSemiTone(stmaMarkAllOctaveSemiTones); });
@@ -633,7 +633,7 @@ void PianoRoll::setGhostMidiClip( MidiClip* newMidiClip )
 	{
 		for( Note *note : newMidiClip->notes() )
 		{
-			Note * new_note = new Note( note->length(), note->pos(), note->key() );
+			auto new_note = new Note(note->length(), note->pos(), note->key());
 			m_ghostNotes.push_back( new_note );
 		}
 		emit ghostClipSet( true );
@@ -649,7 +649,7 @@ void PianoRoll::loadGhostNotes( const QDomElement & de )
 		QDomNode node = de.firstChild();
 		while( !node.isNull() )
 		{
-			Note * n = new Note;
+			auto n = new Note;
 			n->restoreState( node.toElement() );
 			n->setVolume(DefaultVolume);
 			m_ghostNotes.push_back( n );
@@ -988,20 +988,20 @@ void PianoRoll::drawNoteRect( QPainter & p, int x, int y,
 	}
 
 	// Volume
-	float const volumeRange = static_cast<float>(MaxVolume - MinVolume);
-	float const volumeSpan = static_cast<float>(n->getVolume() - MinVolume);
+	auto const volumeRange = static_cast<float>(MaxVolume - MinVolume);
+	auto const volumeSpan = static_cast<float>(n->getVolume() - MinVolume);
 	float const volumeRatio = volumeSpan / volumeRange;
 	int volVal = qMin( 255, 100 + static_cast<int>( volumeRatio * 155.0f) );
 
 	// Panning
-	float const panningRange = static_cast<float>(PanningRight - PanningLeft);
-	float const leftPanSpan = static_cast<float>(PanningRight - n->getPanning());
-	float const rightPanSpan = static_cast<float>(n->getPanning() - PanningLeft);
+	auto const panningRange = static_cast<float>(PanningRight - PanningLeft);
+	auto const leftPanSpan = static_cast<float>(PanningRight - n->getPanning());
+	auto const rightPanSpan = static_cast<float>(n->getPanning() - PanningLeft);
 
 	float leftPercent = qMin<float>( 1.0f, leftPanSpan / panningRange * 2.0f );
 	float rightPercent = qMin<float>( 1.0f, rightPanSpan / panningRange * 2.0f );
 
-	QColor col = QColor( noteCol );
+	auto col = QColor(noteCol);
 	QPen pen;
 
 	if( n->selected() )
@@ -3651,8 +3651,8 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	}
 
 	// set line colors
-	QColor editAreaCol = QColor(m_lineColor);
-	QColor currentKeyCol = QColor(m_beatLineColor);
+	auto editAreaCol = QColor(m_lineColor);
+	auto currentKeyCol = QColor(m_beatLineColor);
 
 	editAreaCol.setAlpha( 64 );
 	currentKeyCol.setAlpha( 64 );
@@ -4738,7 +4738,7 @@ PianoRollWindow::PianoRollWindow() :
 	DropToolBar *notesActionsToolBar = addDropToolBarToTop( tr( "Edit actions" ) );
 
 	// init edit-buttons at the top
-	ActionGroup* editModeGroup = new ActionGroup( this );
+	auto editModeGroup = new ActionGroup(this);
 	QAction* drawAction = editModeGroup->addAction( embed::getIconPixmap( "edit_draw" ), tr( "Draw mode (Shift+D)" ) );
 	QAction* eraseAction = editModeGroup->addAction( embed::getIconPixmap( "edit_erase" ), tr("Erase mode (Shift+E)" ) );
 	QAction* selectAction = editModeGroup->addAction( embed::getIconPixmap( "edit_select" ), tr( "Select mode (Shift+S)" ) );
@@ -4754,12 +4754,12 @@ PianoRollWindow::PianoRollWindow() :
 	connect( editModeGroup, SIGNAL(triggered(int)), m_editor, SLOT(setEditMode(int)));
 
 	// Quantize combo button
-	QToolButton* quantizeButton = new QToolButton(notesActionsToolBar);
-	QMenu* quantizeButtonMenu = new QMenu(quantizeButton);
+	auto quantizeButton = new QToolButton(notesActionsToolBar);
+	auto quantizeButtonMenu = new QMenu(quantizeButton);
 
-	QAction* quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
-	QAction* quantizePosAction = new QAction(tr("Quantize positions"), this);
-	QAction* quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
+	auto quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
+	auto quantizePosAction = new QAction(tr("Quantize positions"), this);
+	auto quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
 
 	connect(quantizeAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(); });
 	connect(quantizePosAction, &QAction::triggered, [this](){ m_editor->quantizeNotes(PianoRoll::QuantizePos); });
@@ -4787,11 +4787,9 @@ PianoRollWindow::PianoRollWindow() :
 	m_fileToolsButton->setPopupMode(QToolButton::InstantPopup);
 
 	// Import / export
-	QAction* importAction = new QAction(embed::getIconPixmap("project_import"),
-		tr("Import clip"), m_fileToolsButton);
+	auto importAction = new QAction(embed::getIconPixmap("project_import"), tr("Import clip"), m_fileToolsButton);
 
-	QAction* exportAction = new QAction(embed::getIconPixmap("project_export"),
-		tr("Export clip"), m_fileToolsButton);
+	auto exportAction = new QAction(embed::getIconPixmap("project_export"), tr("Export clip"), m_fileToolsButton);
 
 	m_fileToolsButton->addAction(importAction);
 	m_fileToolsButton->addAction(exportAction);
@@ -4804,14 +4802,11 @@ PianoRollWindow::PianoRollWindow() :
 	// Copy + paste actions
 	DropToolBar *copyPasteActionsToolBar =  addDropToolBarToTop( tr( "Copy paste controls" ) );
 
-	QAction* cutAction = new QAction(embed::getIconPixmap( "edit_cut" ),
-								tr( "Cut (%1+X)" ).arg(UI_CTRL_KEY), this );
+	auto cutAction = new QAction(embed::getIconPixmap("edit_cut"), tr("Cut (%1+X)").arg(UI_CTRL_KEY), this);
 
-	QAction* copyAction = new QAction(embed::getIconPixmap( "edit_copy" ),
-								 tr( "Copy (%1+C)" ).arg(UI_CTRL_KEY), this );
+	auto copyAction = new QAction(embed::getIconPixmap("edit_copy"), tr("Copy (%1+C)").arg(UI_CTRL_KEY), this);
 
-	QAction* pasteAction = new QAction(embed::getIconPixmap( "edit_paste" ),
-					tr( "Paste (%1+V)" ).arg(UI_CTRL_KEY), this );
+	auto pasteAction = new QAction(embed::getIconPixmap("edit_paste"), tr("Paste (%1+V)").arg(UI_CTRL_KEY), this);
 
 	cutAction->setShortcut( Qt::CTRL | Qt::Key_X );
 	copyAction->setShortcut( Qt::CTRL | Qt::Key_C );
@@ -4830,32 +4825,30 @@ PianoRollWindow::PianoRollWindow() :
 	m_editor->m_timeLine->addToolButtons( timeLineToolBar );
 
 	// -- Note modifier tools
-	QToolButton * noteToolsButton = new QToolButton(m_toolBar);
+	auto noteToolsButton = new QToolButton(m_toolBar);
 	noteToolsButton->setIcon(embed::getIconPixmap("tool"));
 	noteToolsButton->setPopupMode(QToolButton::InstantPopup);
 
-	QAction * glueAction = new QAction(embed::getIconPixmap("glue"),
-				tr("Glue"), noteToolsButton);
+	auto glueAction = new QAction(embed::getIconPixmap("glue"), tr("Glue"), noteToolsButton);
 	connect(glueAction, SIGNAL(triggered()), m_editor, SLOT(glueNotes()));
 	glueAction->setShortcut( Qt::SHIFT | Qt::Key_G );
 
-	QAction * knifeAction = new QAction(embed::getIconPixmap("edit_knife"),
-				tr("Knife"), noteToolsButton);
+	auto knifeAction = new QAction(embed::getIconPixmap("edit_knife"), tr("Knife"), noteToolsButton);
 	connect(knifeAction, &QAction::triggered, m_editor, &PianoRoll::setKnifeAction);
 	knifeAction->setShortcut( Qt::SHIFT | Qt::Key_K );
-        
-	QAction* fillAction = new QAction(embed::getIconPixmap("fill"), tr("Fill"), noteToolsButton);
+
+	auto fillAction = new QAction(embed::getIconPixmap("fill"), tr("Fill"), noteToolsButton);
 	connect(fillAction, &QAction::triggered, [this](){ m_editor->fitNoteLengths(true); });
 	fillAction->setShortcut(Qt::SHIFT | Qt::Key_F);
 
-	QAction* cutOverlapsAction = new QAction(embed::getIconPixmap("cut_overlaps"), tr("Cut overlaps"), noteToolsButton);
+	auto cutOverlapsAction = new QAction(embed::getIconPixmap("cut_overlaps"), tr("Cut overlaps"), noteToolsButton);
 	connect(cutOverlapsAction, &QAction::triggered, [this](){ m_editor->fitNoteLengths(false); });
 	cutOverlapsAction->setShortcut(Qt::SHIFT | Qt::Key_C);
 
-	QAction* minLengthAction = new QAction(embed::getIconPixmap("min_length"), tr("Min length as last"), noteToolsButton);
+	auto minLengthAction = new QAction(embed::getIconPixmap("min_length"), tr("Min length as last"), noteToolsButton);
 	connect(minLengthAction, &QAction::triggered, [this](){ m_editor->constrainNoteLengths(false); });
 
-	QAction* maxLengthAction = new QAction(embed::getIconPixmap("max_length"), tr("Max length as last"), noteToolsButton);
+	auto maxLengthAction = new QAction(embed::getIconPixmap("max_length"), tr("Max length as last"), noteToolsButton);
 	connect(maxLengthAction, &QAction::triggered, [this](){ m_editor->constrainNoteLengths(true); });
 
 	noteToolsButton->addAction(glueAction);
@@ -4872,7 +4865,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	DropToolBar *zoomAndNotesToolBar = addDropToolBarToTop( tr( "Zoom and note controls" ) );
 
-	QLabel * zoom_lbl = new QLabel( m_toolBar );
+	auto zoom_lbl = new QLabel(m_toolBar);
 	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom_x" ) );
 
 	m_zoomingComboBox = new ComboBox( m_toolBar );
@@ -4880,7 +4873,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_zoomingComboBox->setFixedSize( 64, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingComboBox->setToolTip( tr( "Horizontal zooming") );
 
-	QLabel * zoom_y_lbl = new QLabel(m_toolBar);
+	auto zoom_y_lbl = new QLabel(m_toolBar);
 	zoom_y_lbl->setPixmap(embed::getIconPixmap("zoom_y"));
 
 	m_zoomingYComboBox = new ComboBox(m_toolBar);
@@ -4889,7 +4882,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_zoomingYComboBox->setToolTip(tr("Vertical zooming"));
 
 	// setup quantize-stuff
-	QLabel * quantize_lbl = new QLabel( m_toolBar );
+	auto quantize_lbl = new QLabel(m_toolBar);
 	quantize_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
 
 	m_quantizeComboBox = new ComboBox( m_toolBar );
@@ -4898,7 +4891,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_quantizeComboBox->setToolTip( tr( "Quantization") );
 
 	// setup note-len-stuff
-	QLabel * note_len_lbl = new QLabel( m_toolBar );
+	auto note_len_lbl = new QLabel(m_toolBar);
 	note_len_lbl->setPixmap( embed::getIconPixmap( "note" ) );
 
 	m_noteLenComboBox = new ComboBox( m_toolBar );
@@ -4913,7 +4906,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_keyComboBox->setToolTip(tr("Key"));
 
 	// setup scale-stuff
-	QLabel * scale_lbl = new QLabel( m_toolBar );
+	auto scale_lbl = new QLabel(m_toolBar);
 	scale_lbl->setPixmap( embed::getIconPixmap( "scale" ) );
 
 	m_scaleComboBox = new ComboBox( m_toolBar );
@@ -4922,7 +4915,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_scaleComboBox->setToolTip( tr( "Scale") );
 
 	// setup chord-stuff
-	QLabel * chord_lbl = new QLabel( m_toolBar );
+	auto chord_lbl = new QLabel(m_toolBar);
 	chord_lbl->setPixmap( embed::getIconPixmap( "chord" ) );
 
 	m_chordComboBox = new ComboBox( m_toolBar );
@@ -4931,7 +4924,7 @@ PianoRollWindow::PianoRollWindow() :
 	m_chordComboBox->setToolTip( tr( "Chord" ) );
 
 	// setup snap-stuff
-	QLabel* snapLbl = new QLabel(m_toolBar);
+	auto snapLbl = new QLabel(m_toolBar);
 	snapLbl->setPixmap(embed::getIconPixmap("gridmode"));
 
 	m_snapComboBox = new ComboBox(m_toolBar);
@@ -4949,24 +4942,24 @@ PianoRollWindow::PianoRollWindow() :
 
 	// Wrap label icons and comboboxes in a single widget so when
 	// the window is resized smaller in width it hides both
-	QWidget * zoom_widget = new QWidget();
-	QHBoxLayout * zoom_hbox = new QHBoxLayout();
+	auto zoom_widget = new QWidget();
+	auto zoom_hbox = new QHBoxLayout();
 	zoom_hbox->setContentsMargins(0, 0, 0, 0);
 	zoom_hbox->addWidget(zoom_lbl);
 	zoom_hbox->addWidget(m_zoomingComboBox);
 	zoom_widget->setLayout(zoom_hbox);
 	zoomAndNotesToolBar->addWidget(zoom_widget);
 
-	QWidget * zoomY_widget = new QWidget();
-	QHBoxLayout * zoomY_hbox = new QHBoxLayout();
+	auto zoomY_widget = new QWidget();
+	auto zoomY_hbox = new QHBoxLayout();
 	zoomY_hbox->setContentsMargins(0, 0, 0, 0);
 	zoomY_hbox->addWidget(zoom_y_lbl);
 	zoomY_hbox->addWidget(m_zoomingYComboBox);
 	zoomY_widget->setLayout(zoomY_hbox);
 	zoomAndNotesToolBar->addWidget(zoomY_widget);
 
-	QWidget * quantize_widget = new QWidget();
-	QHBoxLayout * quantize_hbox = new QHBoxLayout();
+	auto quantize_widget = new QWidget();
+	auto quantize_hbox = new QHBoxLayout();
 	quantize_hbox->setContentsMargins(0, 0, 0, 0);
 	quantize_hbox->addWidget(quantize_lbl);
 	quantize_hbox->addWidget(m_quantizeComboBox);
@@ -4974,8 +4967,8 @@ PianoRollWindow::PianoRollWindow() :
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget(quantize_widget);
 
-	QWidget * note_widget = new QWidget();
-	QHBoxLayout * note_hbox = new QHBoxLayout();
+	auto note_widget = new QWidget();
+	auto note_hbox = new QHBoxLayout();
 	note_hbox->setContentsMargins(0, 0, 0, 0);
 	note_hbox->addWidget(note_len_lbl);
 	note_hbox->addWidget(m_noteLenComboBox);
@@ -4983,8 +4976,8 @@ PianoRollWindow::PianoRollWindow() :
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget(note_widget);
 
-	QWidget * scale_widget = new QWidget();
-	QHBoxLayout * scale_hbox = new QHBoxLayout();
+	auto scale_widget = new QWidget();
+	auto scale_hbox = new QHBoxLayout();
 	scale_hbox->setContentsMargins(0, 0, 0, 0);
 	scale_hbox->addWidget(scale_lbl);
 	// Add the key selection between scale label and key
@@ -4994,8 +4987,8 @@ PianoRollWindow::PianoRollWindow() :
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget(scale_widget);
 
-	QWidget * chord_widget = new QWidget();
-	QHBoxLayout * chord_hbox = new QHBoxLayout();
+	auto chord_widget = new QWidget();
+	auto chord_hbox = new QHBoxLayout();
 	chord_hbox->setContentsMargins(0, 0, 0, 0);
 	chord_hbox->addWidget(chord_lbl);
 	chord_hbox->addWidget(m_chordComboBox);
@@ -5006,8 +4999,8 @@ PianoRollWindow::PianoRollWindow() :
 	zoomAndNotesToolBar->addSeparator();
 	zoomAndNotesToolBar->addWidget( m_clearGhostButton );
 
-	QWidget* snapWidget = new QWidget();
-	QHBoxLayout* snapHbox = new QHBoxLayout();
+	auto snapWidget = new QWidget();
+	auto snapHbox = new QHBoxLayout();
 	snapHbox->setContentsMargins(0, 0, 0, 0);
 	snapHbox->addWidget(snapLbl);
 	snapHbox->addWidget(m_snapComboBox);

--- a/src/gui/editors/PositionLine.cpp
+++ b/src/gui/editors/PositionLine.cpp
@@ -46,7 +46,7 @@ PositionLine::PositionLine(QWidget* parent) :
 void PositionLine::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	QColor c = QColor(m_lineColor);
+	auto c = QColor(m_lineColor);
 
 	// If width is 1, we don't need a gradient
 	if (width() == 1)

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -145,8 +145,7 @@ SongEditor::SongEditor( Song * song ) :
 
 	getGUI()->mainWindow()->addSpacingToToolBar( 10 );
 
-
-	QLabel * master_vol_lbl = new QLabel( tb );
+	auto master_vol_lbl = new QLabel(tb);
 	master_vol_lbl->setPixmap( embed::getIconPixmap( "master_volume" ) );
 
 	m_masterVolumeSlider = new AutomatableSlider( tb,
@@ -178,8 +177,7 @@ SongEditor::SongEditor( Song * song ) :
 
 	getGUI()->mainWindow()->addSpacingToToolBar( 10 );
 
-
-	QLabel * master_pitch_lbl = new QLabel( tb );
+	auto master_pitch_lbl = new QLabel(tb);
 	master_pitch_lbl->setPixmap( embed::getIconPixmap( "master_pitch" ) );
 	master_pitch_lbl->setFixedHeight( 64 );
 
@@ -210,8 +208,8 @@ SongEditor::SongEditor( Song * song ) :
 	getGUI()->mainWindow()->addSpacingToToolBar( 10 );
 
 	// create widget for oscilloscope- and cpu-load-widget
-	QWidget * vc_w = new QWidget( tb );
-	QVBoxLayout * vcw_layout = new QVBoxLayout( vc_w );
+	auto vc_w = new QWidget(tb);
+	auto vcw_layout = new QVBoxLayout(vc_w);
 	vcw_layout->setMargin( 0 );
 	vcw_layout->setSpacing( 0 );
 
@@ -427,7 +425,7 @@ void SongEditor::updateRubberband()
 		//are clips in the rect of selection?
 		for (auto &it : findChildren<selectableObject *>())
 		{
-			ClipView * clip = dynamic_cast<ClipView*>(it);
+			auto clip = dynamic_cast<ClipView*>(it);
 			if (clip)
 			{
 				auto indexOfTrackView = trackViews().indexOf(clip->getTrackView());
@@ -512,8 +510,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 		for( QVector<selectableObject *>::iterator it = so.begin();
 				it != so.end(); ++it )
 		{
-			ClipView * clipv =
-				dynamic_cast<ClipView *>( *it );
+			auto clipv = dynamic_cast<ClipView*>(*it);
 			clipv->remove();
 		}
 	}
@@ -756,7 +753,7 @@ static inline void animateScroll( QScrollBar *scrollBar, int newVal, bool smooth
 	else
 	{
 		// do smooth scroll animation using QTimeLine
-		QTimeLine *t = scrollBar->findChild<QTimeLine *>();
+		auto t = scrollBar->findChild<QTimeLine*>();
 		if( t == nullptr )
 		{
 			t = new QTimeLine( 600, scrollBar );
@@ -989,7 +986,7 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	DropToolBar *zoomToolBar = addDropToolBarToTop(tr("Zoom controls"));
 
-	QLabel * zoom_lbl = new QLabel( m_toolBar );
+	auto zoom_lbl = new QLabel(m_toolBar);
 	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
 
 	//Set up zooming-stuff
@@ -1004,7 +1001,7 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	zoomToolBar->addWidget( m_zoomingComboBox );
 
 	DropToolBar *snapToolBar = addDropToolBarToTop(tr("Snap controls"));
-	QLabel * snap_lbl = new QLabel( m_toolBar );
+	auto snap_lbl = new QLabel(m_toolBar);
 	snap_lbl->setPixmap( embed::getIconPixmap( "quantize" ) );
 
 	//Set up quantization/snapping selector

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -88,7 +88,7 @@ TimeLineWidget::TimeLineWidget( const int xoff, const int yoff, const float ppb,
 	setMouseTracking(true);
 	m_pos.m_timeLine = this;
 
-	QTimer * updateTimer = new QTimer( this );
+	auto updateTimer = new QTimer(this);
 	connect( updateTimer, SIGNAL(timeout()),
 					this, SLOT(updatePosition()));
 	updateTimer->start( 1000 / 60 );  // 60 fps
@@ -121,14 +121,14 @@ void TimeLineWidget::setXOffset(const int x)
 
 void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 {
-	NStateButton * autoScroll = new NStateButton( _tool_bar );
+	auto autoScroll = new NStateButton(_tool_bar);
 	autoScroll->setGeneralToolTip( tr( "Auto scrolling" ) );
 	autoScroll->addState( embed::getIconPixmap( "autoscroll_on" ) );
 	autoScroll->addState( embed::getIconPixmap( "autoscroll_off" ) );
 	connect( autoScroll, SIGNAL(changedState(int)), this,
 					SLOT(toggleAutoScroll(int)));
 
-	NStateButton * loopPoints = new NStateButton( _tool_bar );
+	auto loopPoints = new NStateButton(_tool_bar);
 	loopPoints->setGeneralToolTip( tr( "Loop points" ) );
 	loopPoints->addState( embed::getIconPixmap( "loop_points_off" ) );
 	loopPoints->addState( embed::getIconPixmap( "loop_points_on" ) );
@@ -137,7 +137,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 	connect( this, SIGNAL(loopPointStateLoaded(int)), loopPoints,
 					SLOT(changeState(int)));
 
-	NStateButton * behaviourAtStop = new NStateButton( _tool_bar );
+	auto behaviourAtStop = new NStateButton(_tool_bar);
 	behaviourAtStop->addState( embed::getIconPixmap( "back_to_zero" ),
 					tr( "After stopping go back to beginning" )
 									);

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -89,12 +89,12 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	m_tc->setHook( this );
 	//keeps the direction of the widget, undepended on the locale
 	setLayoutDirection( Qt::LeftToRight );
-	QVBoxLayout * layout = new QVBoxLayout( this );
+	auto layout = new QVBoxLayout(this);
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );
 	layout->addWidget( m_scrollArea );
 
-	QWidget * scrollContent = new QWidget;
+	auto scrollContent = new QWidget;
 	m_scrollLayout = new QVBoxLayout( scrollContent );
 	m_scrollLayout->setMargin( 0 );
 	m_scrollLayout->setSpacing( 0 );
@@ -399,11 +399,8 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 	QString value = StringPairDrag::decodeValue( _de );
 	if( type == "instrument" )
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-				Track::create( Track::InstrumentTrack,
-								m_tc ) );
-		InstrumentLoaderThread *ilt = new InstrumentLoaderThread(
-					this, it, value );
+		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, m_tc));
+		auto ilt = new InstrumentLoaderThread(this, it, value);
 		ilt->start();
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
@@ -412,9 +409,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		|| type == "soundfontfile" || type == "vstpluginfile"
 		|| type == "patchfile" )
 	{
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-				Track::create( Track::InstrumentTrack,
-								m_tc ) );
+		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, m_tc));
 		PluginFactory::PluginInfoAndKey piakn =
 			getPluginFactory()->pluginSupportingExtension(FileItem::extension(value));
 		Instrument * i = it->loadInstrument(piakn.info.name(), &piakn.key);
@@ -425,9 +420,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 	else if( type == "presetfile" )
 	{
 		DataFile dataFile( value );
-		InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-				Track::create( Track::InstrumentTrack,
-								m_tc ) );
+		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, m_tc));
 		it->setSimpleSerializing();
 		it->loadSettings( dataFile.content().toElement() );
 		//it->toggledInstrumentTrackButton( true );

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -166,29 +166,28 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoAmountKnob->move( LFO_AMOUNT_KNOB_X, LFO_KNOB_Y );
 	m_lfoAmountKnob->setHintText( tr( "Modulation amount:" ), "" );
 
-
-	PixmapButton * sin_lfo_btn = new PixmapButton( this, nullptr );
+	auto sin_lfo_btn = new PixmapButton(this, nullptr);
 	sin_lfo_btn->move( LFO_SHAPES_X, LFO_SHAPES_Y );
 	sin_lfo_btn->setActiveGraphic( embed::getIconPixmap(
 							"sin_wave_active" ) );
 	sin_lfo_btn->setInactiveGraphic( embed::getIconPixmap(
 							"sin_wave_inactive" ) );
 
-	PixmapButton * triangle_lfo_btn = new PixmapButton( this, nullptr );
+	auto triangle_lfo_btn = new PixmapButton(this, nullptr);
 	triangle_lfo_btn->move( LFO_SHAPES_X+15, LFO_SHAPES_Y );
 	triangle_lfo_btn->setActiveGraphic( embed::getIconPixmap(
 						"triangle_wave_active" ) );
 	triangle_lfo_btn->setInactiveGraphic( embed::getIconPixmap(
 						"triangle_wave_inactive" ) );
 
-	PixmapButton * saw_lfo_btn = new PixmapButton( this, nullptr );
+	auto saw_lfo_btn = new PixmapButton(this, nullptr);
 	saw_lfo_btn->move( LFO_SHAPES_X+30, LFO_SHAPES_Y );
 	saw_lfo_btn->setActiveGraphic( embed::getIconPixmap(
 							"saw_wave_active" ) );
 	saw_lfo_btn->setInactiveGraphic( embed::getIconPixmap(
 							"saw_wave_inactive" ) );
 
-	PixmapButton * sqr_lfo_btn = new PixmapButton( this, nullptr );
+	auto sqr_lfo_btn = new PixmapButton(this, nullptr);
 	sqr_lfo_btn->move( LFO_SHAPES_X+45, LFO_SHAPES_Y );
 	sqr_lfo_btn->setActiveGraphic( embed::getIconPixmap(
 						"square_wave_active" ) );
@@ -205,7 +204,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	connect( m_userLfoBtn, SIGNAL(toggled(bool)),
 				this, SLOT(lfoUserWaveChanged()));
 
-	PixmapButton * random_lfo_btn = new PixmapButton( this, nullptr );
+	auto random_lfo_btn = new PixmapButton(this, nullptr);
 	random_lfo_btn->move( LFO_SHAPES_X+60, LFO_SHAPES_Y );
 	random_lfo_btn->setActiveGraphic( embed::getIconPixmap(
 						"random_wave_active" ) );

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -46,17 +46,17 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	m_chordsComboBox( new ComboBox() ),
 	m_chordRangeKnob( new Knob( knobBright_26 ) )
 {
-	QHBoxLayout* topLayout = new QHBoxLayout( this );
+	auto topLayout = new QHBoxLayout(this);
 	topLayout->setMargin( 0 );
 	topLayout->addWidget( m_chordsGroupBox );
 
-	QGridLayout* mainLayout = new QGridLayout( m_chordsGroupBox );
+	auto mainLayout = new QGridLayout(m_chordsGroupBox);
 	mainLayout->setContentsMargins( 8, 18, 8, 8 );
 	mainLayout->setColumnStretch( 0, 1 );
 	mainLayout->setHorizontalSpacing( 20 );
 	mainLayout->setVerticalSpacing( 1 );
 
-	QLabel* chordLabel = new QLabel( tr( "Chord:" ) );
+	auto chordLabel = new QLabel(tr("Chord:"));
 	chordLabel->setFont( pointSize<8>( chordLabel->font() ) );
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
@@ -108,11 +108,11 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpDirectionComboBox( new ComboBox() ),
 	m_arpModeComboBox( new ComboBox() )
 {
-	QHBoxLayout* topLayout = new QHBoxLayout( this );
+	auto topLayout = new QHBoxLayout(this);
 	topLayout->setMargin( 0 );
 	topLayout->addWidget( m_arpGroupBox );
 
-	QGridLayout* mainLayout = new QGridLayout( m_arpGroupBox );
+	auto mainLayout = new QGridLayout(m_arpGroupBox);
 	mainLayout->setContentsMargins( 8, 18, 8, 8 );
 	mainLayout->setColumnStretch( 0, 1 );
 	mainLayout->setHorizontalSpacing( 20 );
@@ -145,14 +145,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setLabel( tr( "GATE" ) );
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
-
-	QLabel* arpChordLabel = new QLabel( tr( "Chord:" ) );
+	auto arpChordLabel = new QLabel(tr("Chord:"));
 	arpChordLabel->setFont( pointSize<8>( arpChordLabel->font() ) );
 
-	QLabel* arpDirectionLabel = new QLabel( tr( "Direction:" ) );
+	auto arpDirectionLabel = new QLabel(tr("Direction:"));
 	arpDirectionLabel->setFont( pointSize<8>( arpDirectionLabel->font() ) );
 
-	QLabel* arpModeLabel = new QLabel( tr( "Mode:" ) );
+	auto arpModeLabel = new QLabel(tr("Mode:"));
 	arpModeLabel->setFont( pointSize<8>( arpModeLabel->font() ) );
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -47,12 +47,12 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_rpBtn( nullptr ),
 	m_wpBtn( nullptr )
 {
-	QVBoxLayout* layout = new QVBoxLayout( this );
+	auto layout = new QVBoxLayout(this);
 	layout->setMargin( 5 );
 	m_midiInputGroupBox = new GroupBox( tr( "ENABLE MIDI INPUT" ) );
 	layout->addWidget( m_midiInputGroupBox );
 
-	QHBoxLayout* midiInputLayout = new QHBoxLayout( m_midiInputGroupBox );
+	auto midiInputLayout = new QHBoxLayout(m_midiInputGroupBox);
 	midiInputLayout->setContentsMargins( 8, 18, 8, 8 );
 	midiInputLayout->setSpacing( 4 );
 
@@ -83,7 +83,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_midiOutputGroupBox = new GroupBox( tr( "ENABLE MIDI OUTPUT" ) );
 	layout->addWidget( m_midiOutputGroupBox );
 
-	QHBoxLayout* midiOutputLayout = new QHBoxLayout( m_midiOutputGroupBox );
+	auto midiOutputLayout = new QHBoxLayout(m_midiOutputGroupBox);
 	midiOutputLayout->setContentsMargins( 8, 18, 8, 8 );
 	midiOutputLayout->setSpacing( 4 );
 
@@ -144,14 +144,15 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 		midiOutputLayout->insertWidget( 0, m_wpBtn );
 	}
 
-	GroupBox* baseVelocityGroupBox = new GroupBox( tr( "CUSTOM BASE VELOCITY" ) );
+	auto baseVelocityGroupBox = new GroupBox(tr("CUSTOM BASE VELOCITY"));
 	layout->addWidget( baseVelocityGroupBox );
 
-	QVBoxLayout* baseVelocityLayout = new QVBoxLayout( baseVelocityGroupBox );
+	auto baseVelocityLayout = new QVBoxLayout(baseVelocityGroupBox);
 	baseVelocityLayout->setContentsMargins( 8, 18, 8, 8 );
 	baseVelocityLayout->setSpacing( 6 );
 
-	QLabel* baseVelocityHelp = new QLabel( tr( "Specify the velocity normalization base for MIDI-based instruments at 100% note velocity." ) );
+	auto baseVelocityHelp
+		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
     baseVelocityHelp->setFont( pointSize<8>( baseVelocityHelp->font() ) );
 
@@ -174,7 +175,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 
 void InstrumentMidiIOView::modelChanged()
 {
-	MidiPort * mp = castModel<MidiPort>();
+	auto mp = castModel<MidiPort>();
 
 	m_midiInputGroupBox->setModel( &mp->m_readableModel );
 	m_inputChannelSpinBox->setModel( &mp->m_inputChannelModel );

--- a/src/gui/instrument/InstrumentMiscView.cpp
+++ b/src/gui/instrument/InstrumentMiscView.cpp
@@ -43,7 +43,7 @@ namespace lmms::gui
 InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	QWidget(parent)
 {
-	QVBoxLayout *layout = new QVBoxLayout(this);
+	auto layout = new QVBoxLayout(this);
 	layout->setMargin(5);
 
 	// Master pitch toggle
@@ -51,10 +51,10 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	m_pitchGroupBox->setModel(&it->m_useMasterPitchModel);
 	layout->addWidget(m_pitchGroupBox);
 
-	QHBoxLayout *masterPitchLayout = new QHBoxLayout(m_pitchGroupBox);
+	auto masterPitchLayout = new QHBoxLayout(m_pitchGroupBox);
 	masterPitchLayout->setContentsMargins(8, 18, 8, 8);
 
-	QLabel *tlabel = new QLabel(tr("Enables the use of master pitch"));
+	auto tlabel = new QLabel(tr("Enables the use of master pitch"));
 	tlabel->setFont(pointSize<8>(tlabel->font()));
 	masterPitchLayout->addWidget(tlabel);
 
@@ -63,17 +63,17 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	m_microtunerGroupBox->setModel(it->m_microtuner.enabledModel());
 	layout->addWidget(m_microtunerGroupBox);
 
-	QVBoxLayout *microtunerLayout = new QVBoxLayout(m_microtunerGroupBox);
+	auto microtunerLayout = new QVBoxLayout(m_microtunerGroupBox);
 	microtunerLayout->setContentsMargins(8, 18, 8, 8);
 
-	QLabel *scaleLabel = new QLabel(tr("Active scale:"));
+	auto scaleLabel = new QLabel(tr("Active scale:"));
 	microtunerLayout->addWidget(scaleLabel);
 
 	m_scaleCombo = new ComboBox();
 	m_scaleCombo->setModel(it->m_microtuner.scaleModel());
 	microtunerLayout->addWidget(m_scaleCombo);
 
-	QLabel *keymapLabel = new QLabel(tr("Active keymap:"));
+	auto keymapLabel = new QLabel(tr("Active keymap:"));
 	microtunerLayout->addWidget(keymapLabel);
 
 	m_keymapCombo = new ComboBox();

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -89,19 +89,19 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// init own layout + widgets
 	setFocusPolicy( Qt::StrongFocus );
-	QVBoxLayout * vlayout = new QVBoxLayout( this );
+	auto vlayout = new QVBoxLayout(this);
 	vlayout->setMargin( 0 );
 	vlayout->setSpacing( 0 );
 
-	TabWidget* generalSettingsWidget = new TabWidget( tr( "GENERAL SETTINGS" ), this );
+	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
 
-	QVBoxLayout* generalSettingsLayout = new QVBoxLayout( generalSettingsWidget );
+	auto generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
 
 	generalSettingsLayout->setContentsMargins( 8, 18, 8, 8 );
 	generalSettingsLayout->setSpacing( 6 );
 
-	QWidget* nameAndChangeTrackWidget = new QWidget( generalSettingsWidget );
-	QHBoxLayout* nameAndChangeTrackLayout = new QHBoxLayout( nameAndChangeTrackWidget );
+	auto nameAndChangeTrackWidget = new QWidget(generalSettingsWidget);
+	auto nameAndChangeTrackLayout = new QHBoxLayout(nameAndChangeTrackWidget);
 	nameAndChangeTrackLayout->setContentsMargins( 0, 0, 0, 0 );
 	nameAndChangeTrackLayout->setSpacing( 2 );
 
@@ -127,9 +127,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	generalSettingsLayout->addWidget( nameAndChangeTrackWidget );
 
-
-
-	QGridLayout* basicControlsLayout = new QGridLayout;
+	auto basicControlsLayout = new QGridLayout;
 	basicControlsLayout->setHorizontalSpacing(3);
 	basicControlsLayout->setVerticalSpacing(0);
 	basicControlsLayout->setContentsMargins(0, 0, 0, 0);
@@ -157,7 +155,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	basicControlsLayout->addWidget( m_volumeKnob, 0, 0 );
 	basicControlsLayout->setAlignment( m_volumeKnob, widgetAlignment );
 
-	QLabel *label = new QLabel( tr( "VOL" ), this );
+	auto label = new QLabel(tr("VOL"), this);
 	label->setStyleSheet( labelStyleSheet );
 	basicControlsLayout->addWidget( label, 1, 0);
 	basicControlsLayout->setAlignment( label, labelAlignment );
@@ -218,7 +216,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	basicControlsLayout->addWidget( label, 1, 6);
 	basicControlsLayout->setAlignment( label, labelAlignment );
 
-	QPushButton* saveSettingsBtn = new QPushButton( embed::getIconPixmap( "project_save" ), QString() );
+	auto saveSettingsBtn = new QPushButton(embed::getIconPixmap("project_save"), QString());
 	saveSettingsBtn->setMinimumSize( 32, 32 );
 
 	connect( saveSettingsBtn, SIGNAL(clicked()), this, SLOT(saveSettingsBtnClicked()));
@@ -246,8 +244,8 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	m_ssView = new InstrumentSoundShapingView( m_tabWidget );
 
 	// FUNC tab
-	QWidget* instrumentFunctions = new QWidget( m_tabWidget );
-	QVBoxLayout* instrumentFunctionsLayout = new QVBoxLayout( instrumentFunctions );
+	auto instrumentFunctions = new QWidget(m_tabWidget);
+	auto instrumentFunctionsLayout = new QVBoxLayout(instrumentFunctions);
 	instrumentFunctionsLayout->setMargin( 5 );
 	m_noteStackingView = new InstrumentFunctionNoteStackingView( &m_track->m_noteStacking );
 	m_arpeggioView = new InstrumentFunctionArpeggioView( &m_track->m_arpeggio );

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -145,7 +145,7 @@ PianoView::PianoView(QWidget *parent) :
 			this, SLOT(pianoScrolled(int)));
 
 	// create a layout for ourselves
-	QVBoxLayout * layout = new QVBoxLayout( this );
+	auto layout = new QVBoxLayout(this);
 	layout->setSpacing( 0 );
 	layout->setMargin( 0 );
 	layout->addSpacing( PIANO_BASE+PW_WHITE_KEY_HEIGHT );

--- a/src/gui/menus/MidiPortMenu.cpp
+++ b/src/gui/menus/MidiPortMenu.cpp
@@ -45,7 +45,7 @@ MidiPortMenu::MidiPortMenu( MidiPort::Modes _mode ) :
 
 void MidiPortMenu::modelChanged()
 {
-	MidiPort * mp = castModel<MidiPort>();
+	auto mp = castModel<MidiPort>();
 	if( m_mode == MidiPort::Input )
 	{
 		connect( mp, SIGNAL(readablePortsChanged()),
@@ -81,7 +81,7 @@ void MidiPortMenu::activatedPort( QAction * _item )
 
 void MidiPortMenu::updateMenu()
 {
-	MidiPort * mp = castModel<MidiPort>();
+	auto mp = castModel<MidiPort>();
 	const MidiPort::Map & map = ( m_mode == MidiPort::Input ) ?
 				mp->readablePorts() : mp->writablePorts();
 	clear();

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -81,7 +81,7 @@ public:
 	// model has none.
 	MidiController* copyToMidiController( Model* parent )
 	{
-		MidiController* c = new MidiController( parent );
+		auto c = new MidiController(parent);
 		c->m_midiPort.setInputChannel( m_midiPort.inputChannel() );
 		c->m_midiPort.setInputController( m_midiPort.inputController() );
 		c->subscribeReadablePorts( m_midiPort.readablePorts() );
@@ -172,7 +172,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 		m_readablePorts = new MidiPortMenu( MidiPort::Input );
 		connect( m_readablePorts, SIGNAL(triggered(QAction*)),
 				this, SLOT(enableAutoDetect(QAction*)));
-		ToolButton * rp_btn = new ToolButton( m_midiGroupBox );
+		auto rp_btn = new ToolButton(m_midiGroupBox);
 		rp_btn->setText( tr( "MIDI-devices to receive "
 						"MIDI-events from" ) );
 		rp_btn->setIcon( embed::getIconPixmap( "piano" ) );
@@ -210,22 +210,18 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 
 
 	// Buttons
-	QWidget * buttons = new QWidget( this );
+	auto buttons = new QWidget(this);
 	buttons->setGeometry( 8, 240, 240, 32 );
 
-	QHBoxLayout * btn_layout = new QHBoxLayout( buttons );
+	auto btn_layout = new QHBoxLayout(buttons);
 	btn_layout->setSpacing( 0 );
 	btn_layout->setMargin( 0 );
-	
-	QPushButton * select_btn = new QPushButton( 
-					embed::getIconPixmap( "add" ),
-					tr( "OK" ), buttons );
+
+	auto select_btn = new QPushButton(embed::getIconPixmap("add"), tr("OK"), buttons);
 	connect( select_btn, SIGNAL(clicked()), 
 				this, SLOT(selectController()));
-	
-	QPushButton * cancel_btn = new QPushButton( 
-					embed::getIconPixmap( "cancel" ),
-					tr( "Cancel" ), buttons );
+
+	auto cancel_btn = new QPushButton(embed::getIconPixmap("cancel"), tr("Cancel"), buttons);
 	connect( cancel_btn, SIGNAL(clicked()),
 				this, SLOT(reject()));
 
@@ -253,8 +249,8 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 				m_midiGroupBox->model()->setValue( true );
 				// ensure controller is created
 				midiToggled();
-			
-				MidiController * cont = (MidiController*)( cc->getController() );
+
+				auto cont = (MidiController*)(cc->getController());
 				m_midiChannelSpinBox->model()->setValue( cont->m_midiPort.inputChannel() );
 				m_midiControllerSpinBox->model()->setValue( cont->m_midiPort.inputController() );
 

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -108,7 +108,7 @@ EffectSelectDialog::EffectSelectDialog( QWidget * _parent ) :
 	ui->pluginList->setModel( &m_model );
 
 	// setup selection model
-	QItemSelectionModel * selectionModel = new QItemSelectionModel( &m_model );
+	auto selectionModel = new QItemSelectionModel(&m_model);
 	ui->pluginList->setSelectionModel( selectionModel );
 	connect( selectionModel, SIGNAL( currentRowChanged( const QModelIndex&,
 														const QModelIndex & ) ),
@@ -193,14 +193,14 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 	{
 		m_descriptionWidget = new QWidget;
 
-		QHBoxLayout *hbox = new QHBoxLayout( m_descriptionWidget );
+		auto hbox = new QHBoxLayout(m_descriptionWidget);
 
 		Plugin::Descriptor const & descriptor = *( m_currentSelection.desc );
 
 		const PixmapLoader* pixLoa = m_currentSelection.logo();
 		if (pixLoa)
 		{
-			QLabel *logoLabel = new QLabel( m_descriptionWidget );
+			auto logoLabel = new QLabel(m_descriptionWidget);
 			logoLabel->setPixmap(pixLoa->pixmap());
 			logoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
@@ -208,18 +208,18 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 			hbox->setAlignment( logoLabel, Qt::AlignTop);
 		}
 
-		QWidget *textualInfoWidget = new QWidget( m_descriptionWidget );
+		auto textualInfoWidget = new QWidget(m_descriptionWidget);
 
 		hbox->addWidget(textualInfoWidget);
 
-		QVBoxLayout * textWidgetLayout = new QVBoxLayout( textualInfoWidget);
+		auto textWidgetLayout = new QVBoxLayout(textualInfoWidget);
 		textWidgetLayout->setMargin( 4 );
 		textWidgetLayout->setSpacing( 0 );
 
 		if ( m_currentSelection.desc->subPluginFeatures )
 		{
-			QWidget *subWidget = new QWidget(textualInfoWidget);
-			QVBoxLayout * subLayout = new QVBoxLayout( subWidget );
+			auto subWidget = new QWidget(textualInfoWidget);
+			auto subLayout = new QVBoxLayout(subWidget);
 			subLayout->setMargin( 4 );
 			subLayout->setSpacing( 0 );
 			m_currentSelection.desc->subPluginFeatures->
@@ -236,7 +236,7 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 		}
 		else
 		{
-			QLabel *label = new QLabel(m_descriptionWidget);
+			auto label = new QLabel(m_descriptionWidget);
 			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
 			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate( "PluginBrowser", descriptor.description ) + "</p>";
 			labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author) + "</p>";

--- a/src/gui/modals/FileDialog.cpp
+++ b/src/gui/modals/FileDialog.cpp
@@ -104,7 +104,7 @@ QString FileDialog::getOpenFileName(QWidget *parent,
 
 void FileDialog::clearSelection()
 {
-    QListView *view = findChild<QListView*>();
+	auto view = findChild<QListView*>();
 	Q_ASSERT( view );
 	view->clearSelection();
 }

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -76,7 +76,7 @@ constexpr int BUFFERSIZE_RESOLUTION = 32;
 
 inline void labelWidget(QWidget * w, const QString & txt)
 {
-	QLabel * title = new QLabel(txt, w);
+	auto title = new QLabel(txt, w);
 	QFont f = title->font();
 	f.setBold(true);
 	title->setFont(pointSize<12>(f));
@@ -170,16 +170,15 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	const int YDelta = 18;
 
 	// Main widget.
-	QWidget * main_w = new QWidget(this);
-
+	auto main_w = new QWidget(this);
 
 	// Vertical layout.
-	QVBoxLayout * vlayout = new QVBoxLayout(this);
+	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing(0);
 	vlayout->setMargin(0);
 
 	// Horizontal layout.
-	QHBoxLayout * hlayout = new QHBoxLayout(main_w);
+	auto hlayout = new QHBoxLayout(main_w);
 	hlayout->setSpacing(0);
 	hlayout->setMargin(0);
 
@@ -189,26 +188,19 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_tabBar->setFixedWidth(72);
 
 	// Settings widget.
-	QWidget * settings_w = new QWidget(main_w);
+	auto settings_w = new QWidget(main_w);
 	settings_w->setFixedSize(360, 360);
 
 	// General widget.
-	QWidget * general_w = new QWidget(settings_w);
-	QVBoxLayout * general_layout = new QVBoxLayout(general_w);
+	auto general_w = new QWidget(settings_w);
+	auto general_layout = new QVBoxLayout(general_w);
 	general_layout->setSpacing(10);
 	general_layout->setMargin(0);
 	labelWidget(general_w, tr("General"));
 
-
-	auto addLedCheckBox = [&XDelta, &YDelta, this](
-		const QString &ledText,
-		TabWidget* tw,
-		int& counter,
-		bool initialState,
-		const char* toggledSlot,
-		bool showRestartWarning
-	){
-		LedCheckBox * checkBox = new LedCheckBox(ledText, tw);
+	auto addLedCheckBox = [&XDelta, &YDelta, this](const QString& ledText, TabWidget* tw, int& counter,
+							  bool initialState, const char* toggledSlot, bool showRestartWarning) {
+		auto checkBox = new LedCheckBox(ledText, tw);
 		counter++;
 		checkBox->move(XDelta, YDelta * counter);
 		checkBox->setChecked(initialState);
@@ -219,13 +211,10 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		}
 	};
 
-
 	int counter = 0;
 
 	// GUI tab.
-	TabWidget * gui_tw = new TabWidget(
-			tr("Graphical user interface (GUI)"), general_w);
-
+	auto gui_tw = new TabWidget(tr("Graphical user interface (GUI)"), general_w);
 
 	addLedCheckBox(tr("Display volume as dBFS "), gui_tw, counter,
 		m_displaydBFS, SLOT(toggleDisplaydBFS(bool)), true);
@@ -254,9 +243,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	counter = 0;
 
 	// Projects tab.
-	TabWidget * projects_tw = new TabWidget(
-			tr("Projects"), general_w);
-
+	auto projects_tw = new TabWidget(tr("Projects"), general_w);
 
 	addLedCheckBox(tr("Compress project files by default"), projects_tw, counter,
 		m_MMPZ, SLOT(toggleMMPZ(bool)), true);
@@ -268,10 +255,9 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	projects_tw->setFixedHeight(YDelta + YDelta * counter);
 
 	// Language tab.
-	TabWidget * lang_tw = new TabWidget(
-			tr("Language"), general_w);
+	auto lang_tw = new TabWidget(tr("Language"), general_w);
 	lang_tw->setFixedHeight(48);
-	QComboBox * changeLang = new QComboBox(lang_tw);
+	auto changeLang = new QComboBox(lang_tw);
 	changeLang->move(XDelta, 20);
 
 	QDir dir(ConfigManager::inst()->localeDir());
@@ -324,8 +310,8 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Performance widget.
-	QWidget * performance_w = new QWidget(settings_w);
-	QVBoxLayout * performance_layout = new QVBoxLayout(performance_w);
+	auto performance_w = new QWidget(settings_w);
+	auto performance_layout = new QVBoxLayout(performance_w);
 	performance_layout->setSpacing(10);
 	performance_layout->setMargin(0);
 	labelWidget(performance_w,
@@ -333,8 +319,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Autosave tab.
-	TabWidget * auto_save_tw = new TabWidget(
-			tr("Autosave"), performance_w);
+	auto auto_save_tw = new TabWidget(tr("Autosave"), performance_w);
 	auto_save_tw->setFixedHeight(106);
 
 	m_saveIntervalSlider = new QSlider(Qt::Horizontal, auto_save_tw);
@@ -366,8 +351,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	connect(m_runningAutoSave, SIGNAL(toggled(bool)),
 			this, SLOT(toggleRunningAutoSave(bool)));
 
-	QPushButton * autoSaveResetBtn = new QPushButton(
-			embed::getIconPixmap("reload"), "", auto_save_tw);
+	auto autoSaveResetBtn = new QPushButton(embed::getIconPixmap("reload"), "", auto_save_tw);
 	autoSaveResetBtn->setGeometry(320, 70, 28, 28);
 	connect(autoSaveResetBtn, SIGNAL(clicked()),
 			this, SLOT(resetAutoSave()));
@@ -379,8 +363,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	counter = 0;
 
 	// UI effect vs. performance tab.
-	TabWidget * ui_fx_tw = new TabWidget(
-			tr("User interface (UI) effects vs. performance"), performance_w);
+	auto ui_fx_tw = new TabWidget(tr("User interface (UI) effects vs. performance"), performance_w);
 
 	addLedCheckBox(tr("Smooth scroll in song editor"), ui_fx_tw, counter,
 		m_smoothScroll, SLOT(toggleSmoothScroll(bool)), false);
@@ -393,8 +376,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	counter = 0;
 
 	// Plugins tab.
-	TabWidget * plugins_tw = new TabWidget(
-			tr("Plugins"), performance_w);
+	auto plugins_tw = new TabWidget(tr("Plugins"), performance_w);
 
 	m_vstEmbedLbl = new QLabel(plugins_tw);
 	m_vstEmbedLbl->move(XDelta, YDelta * ++counter);
@@ -446,16 +428,15 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Audio widget.
-	QWidget * audio_w = new QWidget(settings_w);
-	QVBoxLayout * audio_layout = new QVBoxLayout(audio_w);
+	auto audio_w = new QWidget(settings_w);
+	auto audio_layout = new QVBoxLayout(audio_w);
 	audio_layout->setSpacing(10);
 	audio_layout->setMargin(0);
 	labelWidget(audio_w,
 			tr("Audio"));
 
 	// Audio interface tab.
-	TabWidget * audioiface_tw = new TabWidget(
-			tr("Audio interface"), audio_w);
+	auto audioiface_tw = new TabWidget(tr("Audio interface"), audio_w);
 	audioiface_tw->setFixedHeight(56);
 
 	m_audioInterfaces = new QComboBox(audioiface_tw);
@@ -463,10 +444,10 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Ifaces-settings-widget.
-	QWidget * as_w = new QWidget(audio_w);
+	auto as_w = new QWidget(audio_w);
 	as_w->setFixedHeight(60);
 
-	QHBoxLayout * as_w_layout = new QHBoxLayout(as_w);
+	auto as_w_layout = new QHBoxLayout(as_w);
 	as_w_layout->setSpacing(0);
 	as_w_layout->setMargin(0);
 
@@ -546,14 +527,12 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	// Advanced setting, hidden for now
 	if(false)
 	{
-		LedCheckBox * useNaNHandler = new LedCheckBox(
-			tr("Use built-in NaN handler"), audio_w);
+		auto useNaNHandler = new LedCheckBox(tr("Use built-in NaN handler"), audio_w);
 		useNaNHandler->setChecked(m_NaNHandler);
 	}
 
 	// HQ mode LED.
-	LedCheckBox * hqaudio = new LedCheckBox(
-			tr("HQ mode for output audio device"), audio_w);
+	auto hqaudio = new LedCheckBox(tr("HQ mode for output audio device"), audio_w);
 	hqaudio->move(10, 0);
 	hqaudio->setChecked(m_hqAudioDev);
 	connect(hqaudio, SIGNAL(toggled(bool)),
@@ -561,8 +540,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Buffer size tab.
-	TabWidget * bufferSize_tw = new TabWidget(
-			tr("Buffer size"), audio_w);
+	auto bufferSize_tw = new TabWidget(tr("Buffer size"), audio_w);
 	bufferSize_tw->setFixedHeight(76);
 
 	m_bufferSizeSlider = new QSlider(Qt::Horizontal, bufferSize_tw);
@@ -582,8 +560,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	m_bufferSizeLbl->setGeometry(10, 40, 200, 24);
 	setBufferSize(m_bufferSizeSlider->value());
 
-	QPushButton * bufferSize_reset_btn = new QPushButton(
-			embed::getIconPixmap("reload"), "", bufferSize_tw);
+	auto bufferSize_reset_btn = new QPushButton(embed::getIconPixmap("reload"), "", bufferSize_tw);
 	bufferSize_reset_btn->setGeometry(320, 40, 28, 28);
 	connect(bufferSize_reset_btn, SIGNAL(clicked()),
 			this, SLOT(resetBufferSize()));
@@ -601,26 +578,25 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// MIDI widget.
-	QWidget * midi_w = new QWidget(settings_w);
-	QVBoxLayout * midi_layout = new QVBoxLayout(midi_w);
+	auto midi_w = new QWidget(settings_w);
+	auto midi_layout = new QVBoxLayout(midi_w);
 	midi_layout->setSpacing(10);
 	midi_layout->setMargin(0);
 	labelWidget(midi_w,
 			tr("MIDI"));
 
 	// MIDI interface tab.
-	TabWidget * midiiface_tw = new TabWidget(
-			tr("MIDI interface"), midi_w);
+	auto midiiface_tw = new TabWidget(tr("MIDI interface"), midi_w);
 	midiiface_tw->setFixedHeight(56);
 
 	m_midiInterfaces = new QComboBox(midiiface_tw);
 	m_midiInterfaces->setGeometry(10, 20, 240, 28);
 
 	// Ifaces-settings-widget.
-	QWidget * ms_w = new QWidget(midi_w);
+	auto ms_w = new QWidget(midi_w);
 	ms_w->setFixedHeight(60);
 
-	QHBoxLayout * ms_w_layout = new QHBoxLayout(ms_w);
+	auto ms_w_layout = new QHBoxLayout(ms_w);
 	ms_w_layout->setSpacing(0);
 	ms_w_layout->setMargin(0);
 
@@ -689,8 +665,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// MIDI autoassign tab.
-	TabWidget * midiAutoAssign_tw = new TabWidget(
-			tr("Automatically assign MIDI controller to selected track"), midi_w);
+	auto midiAutoAssign_tw = new TabWidget(tr("Automatically assign MIDI controller to selected track"), midi_w);
 	midiAutoAssign_tw->setFixedHeight(56);
 
 	m_assignableMidiDevices = new QComboBox(midiAutoAssign_tw);
@@ -719,9 +694,9 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Paths widget.
-	QWidget * paths_w = new QWidget(settings_w);
+	auto paths_w = new QWidget(settings_w);
 
-	QVBoxLayout * paths_layout = new QVBoxLayout(paths_w);
+	auto paths_layout = new QVBoxLayout(paths_w);
 	paths_layout->setSpacing(10);
 	paths_layout->setMargin(0);
 
@@ -729,29 +704,23 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 
 	// Paths scroll area.
-	QScrollArea * pathsScroll = new QScrollArea(paths_w);
+	auto pathsScroll = new QScrollArea(paths_w);
 	pathsScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 	pathsScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
 	// Path selectors widget.
-	QWidget * pathSelectors = new QWidget(paths_w);
+	auto pathSelectors = new QWidget(paths_w);
 
 	const int txtLength = 284;
 	const int btnStart = 300;
 
 	// Path selectors layout.
-	QVBoxLayout * pathSelectorsLayout = new QVBoxLayout;
+	auto pathSelectorsLayout = new QVBoxLayout;
 	pathSelectorsLayout->setSpacing(10);
 
-	auto addPathEntry = [&](const QString &caption,
-		const QString& content,
-		const char* setSlot,
-		const char* openSlot,
-		QLineEdit*& lineEdit,
-		const char* pixmap = "project_open")
-	{
-		TabWidget * newTw = new TabWidget(caption,
-					pathSelectors);
+	auto addPathEntry = [&](const QString& caption, const QString& content, const char* setSlot, const char* openSlot,
+							QLineEdit*& lineEdit, const char* pixmap = "project_open") {
+		auto newTw = new TabWidget(caption, pathSelectors);
 		newTw->setFixedHeight(48);
 
 		lineEdit = new QLineEdit(content, newTw);
@@ -759,9 +728,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		connect(lineEdit, SIGNAL(textChanged(const QString&)),
 			this, setSlot);
 
-		QPushButton * selectBtn = new QPushButton(
-			embed::getIconPixmap(pixmap, 16, 16),
-			"", newTw);
+		auto selectBtn = new QPushButton(embed::getIconPixmap(pixmap, 16, 16), "", newTw);
 		selectBtn->setFixedSize(24, 24);
 		selectBtn->move(btnStart, 16);
 		connect(selectBtn, SIGNAL(clicked()), this, openSlot);
@@ -842,8 +809,8 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	hlayout->addSpacing(10);
 
 	// Extras widget and layout.
-	QWidget * extras_w = new QWidget(this);
-	QHBoxLayout * extras_layout = new QHBoxLayout(extras_w);
+	auto extras_w = new QWidget(this);
+	auto extras_layout = new QHBoxLayout(extras_w);
 	extras_layout->setSpacing(0);
 	extras_layout->setMargin(0);
 
@@ -853,16 +820,12 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	restartWarningLbl->hide();
 
 	// OK button.
-	QPushButton * ok_btn = new QPushButton(
-			embed::getIconPixmap("apply"),
-			tr("OK"), extras_w);
+	auto ok_btn = new QPushButton(embed::getIconPixmap("apply"), tr("OK"), extras_w);
 	connect(ok_btn, SIGNAL(clicked()),
 			this, SLOT(accept()));
 
 	// Cancel button.
-	QPushButton * cancel_btn = new QPushButton(
-			embed::getIconPixmap("cancel"),
-			tr("Cancel"), extras_w);
+	auto cancel_btn = new QPushButton(embed::getIconPixmap("cancel"), tr("Cancel"), extras_w);
 	connect(cancel_btn, SIGNAL(clicked()),
 			this, SLOT(reject()));
 

--- a/src/gui/modals/VersionedSaveDialog.cpp
+++ b/src/gui/modals/VersionedSaveDialog.cpp
@@ -49,20 +49,20 @@ VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 	setFileMode( QFileDialog::AnyFile );
 
 	// Create + and - buttons
-	QPushButton *plusButton( new QPushButton( "+", this) );
+	auto plusButton(new QPushButton("+", this));
 	plusButton->setToolTip( tr( "Increment version number" ) );
-	QPushButton *minusButton( new QPushButton( "-", this ) );
+	auto minusButton(new QPushButton("-", this));
 	minusButton->setToolTip( tr( "Decrement version number" ) );
 	plusButton->setFixedWidth(horizontalAdvance(plusButton->fontMetrics(), "+") + 30);
 	minusButton->setFixedWidth(horizontalAdvance(minusButton->fontMetrics(), "+") + 30);
 
 	// Add buttons to grid layout. For doing this, remove the lineEdit and
 	// replace it with a HBox containing lineEdit and the buttons.
-	QGridLayout *layout = dynamic_cast<QGridLayout*>( this->layout() );
+	auto layout = dynamic_cast<QGridLayout*>(this->layout());
 	QWidget *lineEdit = findChild<QLineEdit*>();
 	layout->removeWidget( lineEdit );
 
-	QHBoxLayout* hLayout( new QHBoxLayout() );
+	auto hLayout(new QHBoxLayout());
 	hLayout->addWidget( lineEdit );
 	hLayout->addWidget( plusButton );
 	hLayout->addWidget( minusButton );

--- a/src/gui/tracks/AutomationTrackView.cpp
+++ b/src/gui/tracks/AutomationTrackView.cpp
@@ -40,12 +40,11 @@ AutomationTrackView::AutomationTrackView( AutomationTrack * _at, TrackContainerV
 	TrackView( _at, tcv )
 {
         setFixedHeight( 32 );
-	TrackLabelButton * tlb = new TrackLabelButton( this,
-						getTrackSettingsWidget() );
-	tlb->setIcon( embed::getIconPixmap( "automation_track" ) );
-	tlb->move( 3, 1 );
-	tlb->show();
-	setModel( _at );
+		auto tlb = new TrackLabelButton(this, getTrackSettingsWidget());
+		tlb->setIcon(embed::getIconPixmap("automation_track"));
+		tlb->move(3, 1);
+		tlb->show();
+		setModel(_at);
 }
 
 void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
@@ -62,9 +61,7 @@ void AutomationTrackView::dropEvent( QDropEvent * _de )
 	QString val = StringPairDrag::decodeValue( _de );
 	if( type == "automatable_model" )
 	{
-		AutomatableModel * mod = dynamic_cast<AutomatableModel *>(
-				Engine::projectJournal()->
-					journallingObject( val.toInt() ) );
+		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )
 		{
 			TimePos pos = TimePos( trackContainerView()->
@@ -81,7 +78,7 @@ void AutomationTrackView::dropEvent( QDropEvent * _de )
 			}
 
 			Clip * clip = getTrack()->createClip( pos );
-			AutomationClip * autoClip = dynamic_cast<AutomationClip *>( clip );
+			auto autoClip = dynamic_cast<AutomationClip*>(clip);
 			autoClip->addObject( mod );
 		}
 	}

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -366,7 +366,7 @@ QMenu * InstrumentTrackView::createMixerMenu(QString title, QString newMixerLabe
 		title = title.arg( channelIndex ).arg( mixerChannel->m_name );
 	}
 
-	QMenu *mixerMenu = new QMenu( title );
+	auto mixerMenu = new QMenu(title);
 
 	mixerMenu->addAction( newMixerLabel, this, SLOT(createMixerLine()));
 	mixerMenu->addSeparator();

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -134,7 +134,7 @@ QMenu * SampleTrackView::createMixerMenu(QString title, QString newMixerLabel)
 		title = title.arg(channelIndex).arg(mixerChannel->m_name);
 	}
 
-	QMenu *mixerMenu = new QMenu(title);
+	auto mixerMenu = new QMenu(title);
 
 	mixerMenu->addAction(newMixerLabel, this, SLOT(createMixerLine()));
 	mixerMenu->addSeparator();
@@ -168,7 +168,7 @@ void SampleTrackView::showEffects()
 
 void SampleTrackView::modelChanged()
 {
-	SampleTrack * st = castModel<SampleTrack>();
+	auto st = castModel<SampleTrack>();
 	m_volumeKnob->setModel(&st->m_volumeModel);
 
 	TrackView::modelChanged();
@@ -206,7 +206,7 @@ void SampleTrackView::dropEvent(QDropEvent *de)
 							* TimePos::ticksPerBar()) + trackContainerView()->currentPosition()
 						).quantize(1.0);
 
-		SampleClip * sClip = static_cast<SampleClip*>(getTrack()->createClip(clipPos));
+		auto sClip = static_cast<SampleClip*>(getTrack()->createClip(clipPos));
 		if (sClip) { sClip->setSampleFile(value); }
 	}
 }

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -468,7 +468,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
 	// All clips should be offset the same amount as the grabbed clip
-	TimePos offset = TimePos(clipPos - grabbedClipPos);
+	auto offset = TimePos(clipPos - grabbedClipPos);
 	// Users expect clips to "fall" backwards, so bias the offset
 	offset -= TimePos::ticksPerBar() * snapSize / 2;
 	// The offset is quantized (rather than the positions) to preserve fine adjustments

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -188,8 +188,7 @@ void TrackLabelButton::paintEvent( QPaintEvent * _pe )
 {
 	if( m_trackView->getTrack()->type() == Track::InstrumentTrack )
 	{
-		InstrumentTrack * it =
-			dynamic_cast<InstrumentTrack *>( m_trackView->getTrack() );
+		auto it = dynamic_cast<InstrumentTrack*>(m_trackView->getTrack());
 		const PixmapLoader * pl;
 		auto get_logo = [](InstrumentTrack* it) -> const PixmapLoader*
 		{

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -63,7 +63,7 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 	setToolTip(tr("Press <%1> while clicking on move-grip "
 				"to begin a new drag'n'drop action." ).arg(UI_CTRL_KEY) );
 
-	QMenu * toMenu = new QMenu( this );
+	auto toMenu = new QMenu(this);
 	toMenu->setFont( pointSize<9>( toMenu->font() ) );
 	connect( toMenu, SIGNAL(aboutToShow()), this, SLOT(updateMenu()));
 
@@ -195,7 +195,7 @@ bool TrackOperationsWidget::confirmRemoval()
 					.arg(m_trackView->getTrack()->name());
 	QString messageTitleRemoveTrack = tr("Confirm removal");
 	QString askAgainText = tr("Don't ask again");
-	QCheckBox* askAgainCheckBox = new QCheckBox(askAgainText, nullptr);
+	auto askAgainCheckBox = new QCheckBox(askAgainText, nullptr);
 	connect(askAgainCheckBox, &QCheckBox::stateChanged, [this](int state){
 		// Invert button state, if it's checked we *shouldn't* ask again
 		ConfigManager::inst()->setValue("ui", "trackdeletionwarning", state ? "0" : "1");
@@ -337,7 +337,7 @@ void TrackOperationsWidget::updateMenu()
 		toMenu->addMenu(mixerMenu);
 	}
 
-	if (InstrumentTrackView * trackView = dynamic_cast<InstrumentTrackView *>(m_trackView))
+	if (auto trackView = dynamic_cast<InstrumentTrackView*>(m_trackView))
 	{
 		toMenu->addSeparator();
 		toMenu->addMenu(trackView->midiMenu());
@@ -362,12 +362,12 @@ void TrackOperationsWidget::updateMenu()
 
 void TrackOperationsWidget::toggleRecording( bool on )
 {
-	AutomationTrackView * atv = dynamic_cast<AutomationTrackView *>( m_trackView );
+	auto atv = dynamic_cast<AutomationTrackView*>(m_trackView);
 	if( atv )
 	{
 		for( Clip * clip : atv->getTrack()->getClips() )
 		{
-			AutomationClip * ap = dynamic_cast<AutomationClip *>( clip );
+			auto ap = dynamic_cast<AutomationClip*>(clip);
 			if( ap ) { ap->setRecording( on ); }
 		}
 		atv->update();

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -74,7 +74,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 
 	m_trackSettingsWidget.setAutoFillBackground( true );
 
-	QHBoxLayout * layout = new QHBoxLayout( this );
+	auto layout = new QHBoxLayout(this);
 	layout->setMargin( 0 );
 	layout->setSpacing( 0 );
 	layout->addWidget( &m_trackOperationsWidget );

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -126,7 +126,7 @@ void AutomatableButton::mousePressEvent( QMouseEvent * _me )
 		if( m_group )
 		{
 			// A group, we must get process it instead
-			AutomatableModelView* groupView = (AutomatableModelView*)m_group;
+			auto groupView = (AutomatableModelView*)m_group;
 			new StringPairDrag( "automatable_model",
 					QString::number( groupView->modelUntyped()->id() ),
 					QPixmap(), widget() );

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -168,7 +168,7 @@ void Fader::mouseMoveEvent( QMouseEvent *mouseEvent )
 
 		float delta = dy * ( model()->maxValue() - model()->minValue() ) / (float) ( height() - ( *m_knob ).height() );
 
-		const float step = model()->step<float>();
+		const auto step = model()->step<float>();
 		float newValue = static_cast<float>( static_cast<int>( ( m_startValue + delta ) / step + 0.5 ) ) * step;
 		model()->setValue( newValue );
 

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -50,7 +50,7 @@ Graph::Graph( QWidget * _parent, graphStyle _style, int _width,
 	setAcceptDrops( true );
 	setCursor( Qt::CrossCursor );
 
-	graphModel * gModel = castModel<graphModel>();
+	auto gModel = castModel<graphModel>();
 
 	QObject::connect( gModel, SIGNAL(samplesChanged(int,int)),
 			this, SLOT(updateGraph(int,int)));
@@ -433,7 +433,7 @@ void Graph::dragEnterEvent( QDragEnterEvent * _dee )
 
 void Graph::modelChanged()
 {
-	graphModel * gModel = castModel<graphModel>();
+	auto gModel = castModel<graphModel>();
 
 	QObject::connect( gModel, SIGNAL(samplesChanged(int,int)),
 			this, SLOT(updateGraph(int,int)));
@@ -588,7 +588,7 @@ void graphModel::setWaveToNoise()
 
 QString graphModel::setWaveToUser()
 {
-	SampleBuffer * sampleBuffer = new SampleBuffer;
+	auto sampleBuffer = new SampleBuffer;
 	QString fileName = sampleBuffer->openAndSetWaveformFile();
 	if( fileName.isEmpty() == false )
 	{

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -549,9 +549,7 @@ void Knob::dropEvent( QDropEvent * _de )
 	}
 	else if( type == "automatable_model" )
 	{
-		AutomatableModel * mod = dynamic_cast<AutomatableModel *>(
-				Engine::projectJournal()->
-					journallingObject( val.toInt() ) );
+		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )
 		{
 			AutomatableModel::linkModels( model(), mod );
@@ -709,7 +707,7 @@ void Knob::wheelEvent(QWheelEvent * we)
 void Knob::setPosition( const QPoint & _p )
 {
 	const float value = getValue( _p ) + m_leftOver;
-	const float step = model()->step<float>();
+	const auto step = model()->step<float>();
 	const float oldValue = model()->value();
 
 

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -76,14 +76,14 @@ LcdFloatSpinBox::LcdFloatSpinBox(int numWhole, int numFrac, const QString& style
 void LcdFloatSpinBox::layoutSetup(const QString &style)
 {
 	// Assemble the LCD parts
-	QHBoxLayout *lcdLayout = new QHBoxLayout();
+	auto lcdLayout = new QHBoxLayout();
 
 	m_wholeDisplay.setSeamless(false, true);
 	m_fractionDisplay.setSeamless(true, false);
 
 	lcdLayout->addWidget(&m_wholeDisplay);
 
-	QLabel *dotLabel = new QLabel("", this);
+	auto dotLabel = new QLabel("", this);
 	QPixmap dotPixmap(embed::getIconPixmap(QString("lcd_" + style + "_dot").toUtf8().constData()));
 	dotLabel->setPixmap(dotPixmap.copy(0, 0, dotPixmap.size().width(), dotPixmap.size().height() / 2));
 	lcdLayout->addWidget(dotLabel);
@@ -94,7 +94,7 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 	lcdLayout->setSpacing(0);
 
 	// Add space for label
-	QVBoxLayout *outerLayout = new QVBoxLayout();
+	auto outerLayout = new QVBoxLayout();
 	outerLayout->addLayout(lcdLayout);
 	outerLayout->addSpacing(9);
 	outerLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -108,7 +108,7 @@ void LcdSpinBox::mouseMoveEvent( QMouseEvent* event )
 		int dy = event->globalY() - m_lastMousePos.y();
 		if( dy )
 		{
-			float fdy = static_cast<float>(dy);
+			auto fdy = static_cast<float>(dy);
 			if( event->modifiers() & Qt::ShiftModifier ) {
 				fdy = qBound( -4.f, fdy/4.f, 4.f );
 			}

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -41,12 +41,12 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	QWidget( _parent ),
 	ModelView( nullptr, this )
 {
-	QVBoxLayout * vlayout = new QVBoxLayout( this );
+	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing( 0 );
 	vlayout->setMargin( 0 );
 
-	QWidget * num = new QWidget( this );
-	QHBoxLayout * num_layout = new QHBoxLayout( num );
+	auto num = new QWidget(this);
+	auto num_layout = new QHBoxLayout(num);
 	num_layout->setSpacing( 0 );
 	num_layout->setMargin( 0 );
 
@@ -58,7 +58,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 
 	if( !_simple )
 	{
-		QLabel * num_label = new QLabel( tr( "Meter Numerator" ), num );
+		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
 		num_label->setFont( pointSize<7>( f ) );
 		num_layout->addSpacing( 5 );
@@ -66,9 +66,8 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	}
 	num_layout->addStretch();
 
-
-	QWidget * den = new QWidget( this );
-	QHBoxLayout * den_layout = new QHBoxLayout( den );
+	auto den = new QWidget(this);
+	auto den_layout = new QHBoxLayout(den);
 	den_layout->setSpacing( 0 );
 	den_layout->setMargin( 0 );
 
@@ -83,8 +82,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 
 	if( !_simple )
 	{
-		QLabel * den_label = new QLabel( tr( "Meter Denominator" ),
-									den );
+		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
 		den_label->setFont( pointSize<7>( f ) );
 		den_layout->addSpacing( 5 );
@@ -108,7 +106,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 
 void MeterDialog::modelChanged()
 {
-	MeterModel * mm = castModel<MeterModel>();
+	auto mm = castModel<MeterModel>();
 	m_numerator->setModel( &mm->numeratorModel() );
 	m_denominator->setModel( &mm->denominatorModel() );
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -54,7 +54,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 	}
 	QString caption = ( _text_is_tooltip ) ? QString( "" ) : _text;
 	// create tab-button
-	TabButton * b = new TabButton( caption, _id, this );
+	auto b = new TabButton(caption, _id, this);
 	connect( b, SIGNAL(clicked(int)), this, SLOT(tabClicked(int)));
 	b->setIconSize( QSize( 48, 48 ) );
 	b->setFixedSize( 64, 64 );

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -152,7 +152,7 @@ bool TabWidget::event(QEvent *event)
 
 	if ( event->type() == QEvent::ToolTip )
 	{
-		QHelpEvent *helpEvent = static_cast<QHelpEvent *>(event);
+		auto helpEvent = static_cast<QHelpEvent*>(event);
 
 		int idx = findTabAtPos( & helpEvent->pos() );
 

--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -92,7 +92,7 @@ TextFloat * TextFloat::displayMessage( const QString & _msg, int _timeout,
 					QWidget * _parent, int _add_y_margin )
 {
 	QWidget * mw = getGUI()->mainWindow();
-	TextFloat * tf = new TextFloat;
+	auto tf = new TextFloat;
 	if( _parent != nullptr )
 	{
 		tf->moveGlobal( _parent, QPoint( _parent->width() + 2, 0 ) );

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -58,7 +58,7 @@ gui::TrackView* AutomationTrack::createView( gui::TrackContainerView* tcv )
 
 Clip* AutomationTrack::createClip(const TimePos & pos)
 {
-	AutomationClip* p = new AutomationClip(this);
+	auto p = new AutomationClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -58,7 +58,7 @@ gui::TrackView* AutomationTrack::createView( gui::TrackContainerView* tcv )
 
 Clip* AutomationTrack::createClip(const TimePos & pos)
 {
-	auto* p = new AutomationClip(this);
+	AutomationClip* p = new AutomationClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -58,7 +58,7 @@ gui::TrackView* AutomationTrack::createView( gui::TrackContainerView* tcv )
 
 Clip* AutomationTrack::createClip(const TimePos & pos)
 {
-	AutomationClip* p = new AutomationClip(this);
+	auto* p = new AutomationClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -304,9 +304,9 @@ void InstrumentTrack::processCCEvent(int controller)
 	// Does nothing if the LED is disabled
 	if (!m_midiCCEnable->value()) { return; }
 
-	uint8_t channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
-	uint16_t cc = static_cast<uint16_t>(controller);
-	uint16_t value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
+	auto channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
+	auto cc = static_cast<uint16_t>(controller);
+	auto value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
 
 	// Process the MIDI CC event as an input event but with source set to Internal
 	// so we can know LMMS generated the event, not a controller, and can process it during
@@ -727,7 +727,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		MidiClip* c = dynamic_cast<MidiClip*>( *it );
+		auto* c = dynamic_cast<MidiClip*>(*it);
 		// everything which is not a MIDI clip won't be played
 		// A MIDI clip playing in the Piano Roll window will always play
 		if(c == nullptr ||
@@ -791,7 +791,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 Clip* InstrumentTrack::createClip(const TimePos & pos)
 {
-	MidiClip* p = new MidiClip(this);
+	auto* p = new MidiClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -304,9 +304,9 @@ void InstrumentTrack::processCCEvent(int controller)
 	// Does nothing if the LED is disabled
 	if (!m_midiCCEnable->value()) { return; }
 
-	auto channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
-	auto cc = static_cast<uint16_t>(controller);
-	auto value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
+	uint8_t channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
+	uint16_t cc = static_cast<uint16_t>(controller);
+	uint16_t value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
 
 	// Process the MIDI CC event as an input event but with source set to Internal
 	// so we can know LMMS generated the event, not a controller, and can process it during
@@ -727,7 +727,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		auto* c = dynamic_cast<MidiClip*>(*it);
+		MidiClip* c = dynamic_cast<MidiClip*>( *it );
 		// everything which is not a MIDI clip won't be played
 		// A MIDI clip playing in the Piano Roll window will always play
 		if(c == nullptr ||
@@ -791,7 +791,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 Clip* InstrumentTrack::createClip(const TimePos & pos)
 {
-	auto* p = new MidiClip(this);
+	MidiClip* p = new MidiClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -304,9 +304,9 @@ void InstrumentTrack::processCCEvent(int controller)
 	// Does nothing if the LED is disabled
 	if (!m_midiCCEnable->value()) { return; }
 
-	uint8_t channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
-	uint16_t cc = static_cast<uint16_t>(controller);
-	uint16_t value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
+	auto channel = static_cast<uint8_t>(midiPort()->realOutputChannel());
+	auto cc = static_cast<uint16_t>(controller);
+	auto value = static_cast<uint16_t>(m_midiCCModel[controller]->value());
 
 	// Process the MIDI CC event as an input event but with source set to Internal
 	// so we can know LMMS generated the event, not a controller, and can process it during
@@ -727,7 +727,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		MidiClip* c = dynamic_cast<MidiClip*>( *it );
+		auto c = dynamic_cast<MidiClip*>(*it);
 		// everything which is not a MIDI clip won't be played
 		// A MIDI clip playing in the Piano Roll window will always play
 		if(c == nullptr ||
@@ -791,7 +791,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 Clip* InstrumentTrack::createClip(const TimePos & pos)
 {
-	MidiClip* p = new MidiClip(this);
+	auto p = new MidiClip(this);
 	p->movePosition(pos);
 	return p;
 }

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -199,7 +199,7 @@ TimePos MidiClip::beatClipLength() const
 
 Note * MidiClip::addNote( const Note & _new_note, const bool _quant_pos )
 {
-	Note * new_note = new Note( _new_note );
+	auto new_note = new Note(_new_note);
 	if (_quant_pos && gui::getGUI()->pianoRoll())
 	{
 		new_note->quantizePos(gui::getGUI()->pianoRoll()->quantization());
@@ -448,7 +448,7 @@ void MidiClip::loadSettings( const QDomElement & _this )
 		if( node.isElement() &&
 			!node.toElement().attribute( "metadata" ).toInt() )
 		{
-			Note * n = new Note;
+			auto n = new Note;
 			n->restoreState( node.toElement() );
 			m_notes.push_back( n );
 		}

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -139,7 +139,7 @@ gui::TrackView* PatternTrack::createView(gui::TrackContainerView* tcv)
 
 Clip* PatternTrack::createClip(const TimePos & pos)
 {
-	PatternClip* pc = new PatternClip(this);
+	auto pc = new PatternClip(this);
 	pc->movePosition(pos);
 	return pc;
 }
@@ -234,8 +234,8 @@ PatternTrack* PatternTrack::findPatternTrack(int pattern_num)
 
 void PatternTrack::swapPatternTracks(Track* track1, Track* track2)
 {
-	PatternTrack* t1 = dynamic_cast<PatternTrack*>(track1);
-	PatternTrack* t2 = dynamic_cast<PatternTrack*>(track2);
+	auto t1 = dynamic_cast<PatternTrack*>(track1);
+	auto t2 = dynamic_cast<PatternTrack*>(track2);
 	if( t1 != nullptr && t2 != nullptr )
 	{
 		qSwap( s_infoMap[t1], s_infoMap[t2] );

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -139,7 +139,7 @@ gui::TrackView* PatternTrack::createView(gui::TrackContainerView* tcv)
 
 Clip* PatternTrack::createClip(const TimePos & pos)
 {
-	auto* pc = new PatternClip(this);
+	PatternClip* pc = new PatternClip(this);
 	pc->movePosition(pos);
 	return pc;
 }
@@ -234,8 +234,8 @@ PatternTrack* PatternTrack::findPatternTrack(int pattern_num)
 
 void PatternTrack::swapPatternTracks(Track* track1, Track* track2)
 {
-	auto* t1 = dynamic_cast<PatternTrack*>(track1);
-	auto* t2 = dynamic_cast<PatternTrack*>(track2);
+	PatternTrack* t1 = dynamic_cast<PatternTrack*>(track1);
+	PatternTrack* t2 = dynamic_cast<PatternTrack*>(track2);
 	if( t1 != nullptr && t2 != nullptr )
 	{
 		qSwap( s_infoMap[t1], s_infoMap[t2] );

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -139,7 +139,7 @@ gui::TrackView* PatternTrack::createView(gui::TrackContainerView* tcv)
 
 Clip* PatternTrack::createClip(const TimePos & pos)
 {
-	PatternClip* pc = new PatternClip(this);
+	auto* pc = new PatternClip(this);
 	pc->movePosition(pos);
 	return pc;
 }
@@ -234,8 +234,8 @@ PatternTrack* PatternTrack::findPatternTrack(int pattern_num)
 
 void PatternTrack::swapPatternTracks(Track* track1, Track* track2)
 {
-	PatternTrack* t1 = dynamic_cast<PatternTrack*>(track1);
-	PatternTrack* t2 = dynamic_cast<PatternTrack*>(track2);
+	auto* t1 = dynamic_cast<PatternTrack*>(track1);
+	auto* t2 = dynamic_cast<PatternTrack*>(track2);
 	if( t1 != nullptr && t2 != nullptr )
 	{
 		qSwap( s_infoMap[t1], s_infoMap[t2] );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -102,7 +102,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 		for( int i = 0; i < numOfClips(); ++i )
 		{
 			Clip * clip = getClip( i );
-			SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
+			auto* sClip = dynamic_cast<SampleClip*>(clip);
 
 			if( _start >= sClip->startPosition() && _start < sClip->endPosition() )
 			{
@@ -137,7 +137,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		SampleClip * st = dynamic_cast<SampleClip *>( *it );
+		auto* st = dynamic_cast<SampleClip*>(*it);
 		if( !st->isMuted() )
 		{
 			PlayHandle* handle;
@@ -147,12 +147,12 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 				{
 					return played_a_note;
 				}
-				SampleRecordHandle* smpHandle = new SampleRecordHandle( st );
+				auto* smpHandle = new SampleRecordHandle(st);
 				handle = smpHandle;
 			}
 			else
 			{
-				SamplePlayHandle* smpHandle = new SamplePlayHandle( st );
+				auto* smpHandle = new SamplePlayHandle(st);
 				smpHandle->setVolumeModel( &m_volumeModel );
 				smpHandle->setPatternTrack(pattern_track);
 				handle = smpHandle;
@@ -180,7 +180,7 @@ gui::TrackView * SampleTrack::createView( gui::TrackContainerView* tcv )
 
 Clip * SampleTrack::createClip(const TimePos & pos)
 {
-	SampleClip * sClip = new SampleClip(this);
+	auto* sClip = new SampleClip(this);
 	sClip->movePosition(pos);
 	return sClip;
 }
@@ -241,7 +241,7 @@ void SampleTrack::setPlayingClips( bool isPlaying )
 	for( int i = 0; i < numOfClips(); ++i )
 	{
 		Clip * clip = getClip( i );
-		SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
+		auto* sClip = dynamic_cast<SampleClip*>(clip);
 		sClip->setIsPlaying( isPlaying );
 	}
 }

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -102,7 +102,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 		for( int i = 0; i < numOfClips(); ++i )
 		{
 			Clip * clip = getClip( i );
-			SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
+			auto sClip = dynamic_cast<SampleClip*>(clip);
 
 			if( _start >= sClip->startPosition() && _start < sClip->endPosition() )
 			{
@@ -137,7 +137,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		SampleClip * st = dynamic_cast<SampleClip *>( *it );
+		auto st = dynamic_cast<SampleClip*>(*it);
 		if( !st->isMuted() )
 		{
 			PlayHandle* handle;
@@ -147,12 +147,12 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 				{
 					return played_a_note;
 				}
-				SampleRecordHandle* smpHandle = new SampleRecordHandle( st );
+				auto smpHandle = new SampleRecordHandle(st);
 				handle = smpHandle;
 			}
 			else
 			{
-				SamplePlayHandle* smpHandle = new SamplePlayHandle( st );
+				auto smpHandle = new SamplePlayHandle(st);
 				smpHandle->setVolumeModel( &m_volumeModel );
 				smpHandle->setPatternTrack(pattern_track);
 				handle = smpHandle;
@@ -180,7 +180,7 @@ gui::TrackView * SampleTrack::createView( gui::TrackContainerView* tcv )
 
 Clip * SampleTrack::createClip(const TimePos & pos)
 {
-	SampleClip * sClip = new SampleClip(this);
+	auto sClip = new SampleClip(this);
 	sClip->movePosition(pos);
 	return sClip;
 }
@@ -241,7 +241,7 @@ void SampleTrack::setPlayingClips( bool isPlaying )
 	for( int i = 0; i < numOfClips(); ++i )
 	{
 		Clip * clip = getClip( i );
-		SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
+		auto sClip = dynamic_cast<SampleClip*>(clip);
 		sClip->setIsPlaying( isPlaying );
 	}
 }

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -102,7 +102,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 		for( int i = 0; i < numOfClips(); ++i )
 		{
 			Clip * clip = getClip( i );
-			auto* sClip = dynamic_cast<SampleClip*>(clip);
+			SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
 
 			if( _start >= sClip->startPosition() && _start < sClip->endPosition() )
 			{
@@ -137,7 +137,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
 	{
-		auto* st = dynamic_cast<SampleClip*>(*it);
+		SampleClip * st = dynamic_cast<SampleClip *>( *it );
 		if( !st->isMuted() )
 		{
 			PlayHandle* handle;
@@ -147,12 +147,12 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 				{
 					return played_a_note;
 				}
-				auto* smpHandle = new SampleRecordHandle(st);
+				SampleRecordHandle* smpHandle = new SampleRecordHandle( st );
 				handle = smpHandle;
 			}
 			else
 			{
-				auto* smpHandle = new SamplePlayHandle(st);
+				SamplePlayHandle* smpHandle = new SamplePlayHandle( st );
 				smpHandle->setVolumeModel( &m_volumeModel );
 				smpHandle->setPatternTrack(pattern_track);
 				handle = smpHandle;
@@ -180,7 +180,7 @@ gui::TrackView * SampleTrack::createView( gui::TrackContainerView* tcv )
 
 Clip * SampleTrack::createClip(const TimePos & pos)
 {
-	auto* sClip = new SampleClip(this);
+	SampleClip * sClip = new SampleClip(this);
 	sClip->movePosition(pos);
 	return sClip;
 }
@@ -241,7 +241,7 @@ void SampleTrack::setPlayingClips( bool isPlaying )
 	for( int i = 0; i < numOfClips(); ++i )
 	{
 		Clip * clip = getClip( i );
-		auto* sClip = dynamic_cast<SampleClip*>(clip);
+		SampleClip * sClip = dynamic_cast<SampleClip*>( clip );
 		sClip->setIsPlaying( isPlaying );
 	}
 }


### PR DESCRIPTION
This clang-tidy check uses ``auto`` in place of types in variable declarations where applicable. It does this with the goal of improving readability and maintainability, i.e. only used in places that yield a reasonable benefit.