### PR TITLE
PianoRoll: New edit mode "PitchShift" micro-tunes notes with single mouse clicks.

### DIFF
--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -177,6 +177,8 @@ public:
 	static int quantization() { return s_quantization; }
 	static void setQuantization(int q) { s_quantization = q; }
 
+	void shift(float amt);
+
 public slots:
 	void clear();
 	void objectDestroyed( lmms::jo_id_t );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -34,6 +34,7 @@
 #include "ComboBoxModel.h"
 #include "SerializingObject.h"
 #include "Note.h"
+#include "LcdSpinBox.h"
 #include "lmms_basics.h"
 #include "Song.h"
 #include "StepRecorder.h"
@@ -109,6 +110,7 @@ public:
 		ModeErase,
 		ModeSelect,
 		ModeEditDetuning,
+		ModeEditDetuningShift,
 		ModeEditKnife
 	};
 
@@ -356,6 +358,8 @@ private:
 	ComboBoxModel m_chordModel;
 	ComboBoxModel m_snapModel;
 
+	IntModel m_detuningShiftModel;
+
 	static const QVector<float> m_zoomLevels;
 	static const QVector<float> m_zoomYLevels;
 
@@ -555,6 +559,7 @@ private:
 
 	PianoRoll* m_editor;
 
+	LcdSpinBox *m_shiftSpinBox;
 	QToolButton* m_fileToolsButton;
 	ComboBox * m_zoomingComboBox;
 	ComboBox * m_zoomingYComboBox;

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -40,6 +40,8 @@ namespace lmms
 
 using bar_t = int32_t;
 using tick_t = int32_t;
+const auto TICK_MAX = INT32_MAX;
+const auto TICK_MIN = INT32_MIN;
 using volume_t = uint8_t;
 using panning_t = int8_t;
 

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -1058,6 +1058,21 @@ void AutomationClip::resolveAllIDs()
 
 
 
+/**
+ * @brief Adds the specified value to all inValues and outValues.
+ */
+void AutomationClip::shift(float amt) {
+	QMutexLocker clipMutexLocker(&m_clipMutex);
+	QList<tick_t> positions = m_timeMap.keys();
+	for (tick_t position : positions) {
+		m_timeMap[position] += amt;
+	}
+	emit dataChanged();
+}
+
+
+
+
 void AutomationClip::clear()
 {
 	QMutexLocker m(&m_clipMutex);


### PR DESCRIPTION
This would make a great addition to the current microtuning capabilities of LMMS (i.e., Microtuner). This also enables users to experiment with microtonal intervals without the hassle of the automation editor. It was tested to work correctly with different setups of preexisting detuning data.