### PR TITLE
Limit height of while position line to height of all tracks

### DIFF
--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -148,8 +148,7 @@ public:
 		return "trackcontainerview";
 	}
 
-	int calcTotalHeightOfTracks();
-
+	int totalHeightOfTracks();
 
 	RubberBand *rubberBand() const;
 

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -206,7 +206,15 @@ private:
 
 	RubberBand * m_rubberBand;
 
+public:
+    // public helpers
 
+    /**
+     * @brief sums up the heights of all of the tracks
+     * @param trackViews: a QList of track views
+     * @return the summed height as an int
+     */
+    static int calcTotalHeightOfTracks(const trackViewList& trackViews);
 
 signals:
 	void positionChanged( const lmms::TimePos & _pos );

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -148,7 +148,7 @@ public:
 		return "trackcontainerview";
 	}
 
-	int totalHeightOfTracks();
+	unsigned int totalHeightOfTracks() const;
 
 	RubberBand *rubberBand() const;
 

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -148,7 +148,7 @@ public:
 		return "trackcontainerview";
 	}
 
-    int calcTotalHeightOfTracks();
+	int calcTotalHeightOfTracks();
 
 
 	RubberBand *rubberBand() const;
@@ -210,7 +210,7 @@ private:
 
 signals:
 	void positionChanged( const lmms::TimePos & _pos );
-    void tracksRealigned();
+	void tracksRealigned();
 
 
 } ;

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -148,6 +148,8 @@ public:
 		return "trackcontainerview";
 	}
 
+    int calcTotalHeightOfTracks();
+
 
 	RubberBand *rubberBand() const;
 
@@ -206,18 +208,9 @@ private:
 
 	RubberBand * m_rubberBand;
 
-public:
-    // public helpers
-
-    /**
-     * @brief sums up the heights of all of the tracks
-     * @param trackViews: a QList of track views
-     * @return the summed height as an int
-     */
-    static int calcTotalHeightOfTracks(const trackViewList& trackViews);
-
 signals:
 	void positionChanged( const lmms::TimePos & _pos );
+    void tracksRealigned();
 
 
 } ;

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -100,6 +100,10 @@ SongEditor::SongEditor( Song * song ) :
 	connect( m_timeLine, SIGNAL(selectionFinished()),
 			 this, SLOT(stopRubberBand()));
 
+    // when tracks realign, adjust height of position line
+    connect( this, SIGNAL(tracksRealigned()),
+             this, SLOT(updatePositionLine()) );
+
 	m_positionLine = new PositionLine(this);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );
 	
@@ -826,7 +830,7 @@ void SongEditor::updatePosition( const TimePos & t )
 		m_positionLine->hide();
 	}
 
-    m_positionLine->setFixedHeight( TrackContainerView::calcTotalHeightOfTracks(this->trackViews()) );
+    m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
 
 }
 
@@ -835,7 +839,7 @@ void SongEditor::updatePosition( const TimePos & t )
 
 void SongEditor::updatePositionLine()
 {
-    m_positionLine->setFixedHeight( TrackContainerView::calcTotalHeightOfTracks(this->trackViews()) );
+    m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
 }
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -54,8 +54,6 @@
 #include "TimeLineWidget.h"
 #include "TrackView.h"
 
-#include <iostream>
-
 namespace lmms::gui
 {
 
@@ -100,9 +98,9 @@ SongEditor::SongEditor( Song * song ) :
 	connect( m_timeLine, SIGNAL(selectionFinished()),
 			 this, SLOT(stopRubberBand()));
 
-    // when tracks realign, adjust height of position line
-    connect( this, SIGNAL(tracksRealigned()),
-             this, SLOT(updatePositionLine()) );
+	// when tracks realign, adjust height of position line
+	connect( this, SIGNAL(tracksRealigned()),
+			 this, SLOT(updatePositionLine()) );
 
 	m_positionLine = new PositionLine(this);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );
@@ -830,7 +828,7 @@ void SongEditor::updatePosition( const TimePos & t )
 		m_positionLine->hide();
 	}
 
-    m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
+	m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
 
 }
 
@@ -839,7 +837,7 @@ void SongEditor::updatePosition( const TimePos & t )
 
 void SongEditor::updatePositionLine()
 {
-    m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
+	m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
 }
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -54,6 +54,8 @@
 #include "TimeLineWidget.h"
 #include "TrackView.h"
 
+#include <iostream>
+
 namespace lmms::gui
 {
 
@@ -824,7 +826,8 @@ void SongEditor::updatePosition( const TimePos & t )
 		m_positionLine->hide();
 	}
 
-	m_positionLine->setFixedHeight( height() );
+    m_positionLine->setFixedHeight( TrackContainerView::calcTotalHeightOfTracks(this->trackViews()) );
+
 }
 
 
@@ -832,7 +835,7 @@ void SongEditor::updatePosition( const TimePos & t )
 
 void SongEditor::updatePositionLine()
 {
-	m_positionLine->setFixedHeight( height() );
+    m_positionLine->setFixedHeight( TrackContainerView::calcTotalHeightOfTracks(this->trackViews()) );
 }
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -99,8 +99,7 @@ SongEditor::SongEditor( Song * song ) :
 			 this, SLOT(stopRubberBand()));
 
 	// when tracks realign, adjust height of position line
-	connect( this, SIGNAL(tracksRealigned()),
-			 this, SLOT(updatePositionLine()) );
+	connect(this, &TrackContainerView::tracksRealigned, this, &SongEditor::updatePositionLine);
 
 	m_positionLine = new PositionLine(this);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );
@@ -828,8 +827,7 @@ void SongEditor::updatePosition( const TimePos & t )
 		m_positionLine->hide();
 	}
 
-	m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
-
+	updatePositionLine();
 }
 
 
@@ -837,7 +835,7 @@ void SongEditor::updatePosition( const TimePos & t )
 
 void SongEditor::updatePositionLine()
 {
-	m_positionLine->setFixedHeight( calcTotalHeightOfTracks() );
+	m_positionLine->setFixedHeight(totalHeightOfTracks());
 }
 
 

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -265,7 +265,7 @@ void TrackContainerView::realignTracks()
 		( *it )->update();
 	}
 
-    emit tracksRealigned();
+	emit tracksRealigned();
 }
 
 
@@ -504,12 +504,12 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 
 int TrackContainerView::calcTotalHeightOfTracks()
 {
-    unsigned int heightSum = 0;
-    for(auto & trackView : m_trackViews)
-    {
-        heightSum += trackView->getTrack()->getHeight();
-    }
-    return heightSum;
+	unsigned int heightSum = 0;
+	for (auto & trackView : m_trackViews)
+	{
+		heightSum += trackView->getTrack()->getHeight();
+	}
+	return heightSum;
 }
 
 } // namespace gui

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -500,6 +500,15 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 	}
 }
 
+int TrackContainerView::calcTotalHeightOfTracks(const trackViewList& trackViews)
+{
+    unsigned int heightSum = 0;
+    for(auto & trackView : trackViews)
+    {
+        heightSum += trackView->getTrack()->getHeight();
+    }
+    return heightSum;
+}
 
 } // namespace gui
 

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -502,7 +502,10 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 	}
 }
 
-int TrackContainerView::totalHeightOfTracks()
+
+
+
+unsigned int TrackContainerView::totalHeightOfTracks() const
 {
 	unsigned int heightSum = 0;
 	for (auto & trackView : m_trackViews)

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -264,6 +264,8 @@ void TrackContainerView::realignTracks()
 		( *it )->show();
 		( *it )->update();
 	}
+
+    emit tracksRealigned();
 }
 
 
@@ -500,10 +502,10 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 	}
 }
 
-int TrackContainerView::calcTotalHeightOfTracks(const trackViewList& trackViews)
+int TrackContainerView::calcTotalHeightOfTracks()
 {
     unsigned int heightSum = 0;
-    for(auto & trackView : trackViews)
+    for(auto & trackView : m_trackViews)
     {
         heightSum += trackView->getTrack()->getHeight();
     }

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -502,7 +502,7 @@ void TrackContainerView::scrollArea::wheelEvent( QWheelEvent * _we )
 	}
 }
 
-int TrackContainerView::calcTotalHeightOfTracks()
+int TrackContainerView::totalHeightOfTracks()
 {
 	unsigned int heightSum = 0;
 	for (auto & trackView : m_trackViews)


### PR DESCRIPTION
Release notes:
- The height of the position line in the song editor window matches the total height of all of the tracks at all times.

Closes #6159 