### PR TITLE
Support building AppImage on non-ubuntu systems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,7 @@ jobs:
       - name: Package
         run: |
           cmake --build build --target install
-          cmake --build build --target appimage \
-            || (cat build/appimage.log && false)
+          cmake --build build --target appimage
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -87,7 +87,7 @@ if [[ -z $LINUXDEPLOYQT || -z $APPIMAGETOOL ]]; then
 	# Also, we need to set LD_LIBRARY_PATH, but linuxdepoyqt's AppRun unsets it
 	# See https://github.com/probonopd/linuxdeployqt/pull/370/
 	chmod +x "$filename"
-	"$filename" --appimage-extract > /dev/null 2>&1
+	./"$filename" --appimage-extract >/dev/null
 	success "Extracted $filename"
 
 	# We set PATH earlier to include the extracted ./squashfs-root

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -6,11 +6,10 @@
 # Notes:    Will attempt to fetch linuxdeployqt automatically (x86_64 only)
 #           See Also: https://github.com/probonopd/linuxdeployqt/blob/master/BUILDING.md
 
-set -e
+trap "error 'Failed to generate AppImage'; exit 1" ERR
 
 LINUXDEPLOYQT="@CMAKE_BINARY_DIR@/linuxdeployqt"
 VERBOSITY=2 # 3=debug
-LOGFILE="@CMAKE_BINARY_DIR@/appimage.log"
 APPDIR="@CMAKE_BINARY_DIR@/@PROJECT_NAME_UCASE@.AppDir/"
 DESKTOPFILE="${APPDIR}usr/share/applications/lmms.desktop"
 STRIP=""
@@ -40,6 +39,13 @@ function skipped {
 	echo -e "   ${PLAIN}[${YELLOW}skipped${PLAIN}] ${1}"
 }
 
+# Run a command silently, but print output if it fails
+function try_quiet {
+    output="$("$@" 2>&1)" && return
+    printf '%s\n' "$output"
+    return 1
+}
+
 # Blindly assume system arch is appimage arch
 ARCH=$(uname -m)
 export ARCH
@@ -49,8 +55,6 @@ INSTALL=$(echo "@CMAKE_INSTALL_PREFIX@" | sed 's/\/*$//g')
 if [ "$INSTALL" == "/usr/local" ] || [ "$INSTALL" == "/usr" ] ; then
 	error "Incompatible CMAKE_INSTALL_PREFIX for creating AppImage: @CMAKE_INSTALL_PREFIX@"
 fi
-
-echo -e "\nWriting verbose output to \"${LOGFILE}\""
 
 # Ensure linuxdeployqt uses the same qmake version as cmake
 PATH="$(pwd -P)/squashfs-root/usr/bin:$(dirname "@QT_QMAKE_EXECUTABLE@")":$PATH
@@ -65,11 +69,17 @@ else
 	filename="linuxdeployqt-continuous-$ARCH.AppImage"
 	url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/$filename"
 	down_file="$(pwd)/$filename"
-	if [ ! -f "$LINUXDEPLOYQT" ]; then
+	if [ ! -L "$LINUXDEPLOYQT" ]; then
 		ln -s "$down_file" "$LINUXDEPLOYQT"
 	fi
-	echo "   [.......] Downloading ($(uname -p)): ${url}"
-	wget -N -q "$url" || (rm "$filename" && false)
+	echo "   [.......] Downloading: ${url}"
+	wget -N -q "$url" || errorcode=$?
+	if [ "$errorcode" == 8 ]; then
+		# Server issued an error response
+		error "No package available for architecture: $ARCH"
+	elif [ "$errorcode" ]; then
+		error "Download failed"
+	fi
 	chmod +x "$LINUXDEPLOYQT"
 	success "Downloaded $LINUXDEPLOYQT"
 	# Extract AppImage and replace LINUXDEPLOYQT variable with extracted binary
@@ -151,10 +161,9 @@ executables="${executables} -executable=${APPDIR}usr/lib/lmms/ladspa/pitch_scale
 
 # Bundle both qt and non-qt dependencies into appimage format
 echo -e "\nBundling and relinking system dependencies..."
-echo -e ">>>>> linuxdeployqt" > "$LOGFILE"
 
 # shellcheck disable=SC2086
-"$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP >> "$LOGFILE" 2>&1
+try_quiet "$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP
 success "Bundled and relinked dependencies"
 
 # Link to original location so lmms can find them
@@ -187,8 +196,7 @@ ln -sr "${APPDIR}/usr/bin/lmms" "${APPDIR}/AppRun"
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."
-echo -e "\n\n>>>>> appimagetool" >> "$LOGFILE"
-"$APPIMAGETOOL" "${APPDIR}" "@APPIMAGE_FILE@" >> "$LOGFILE" 2>&1
+try_quiet "$APPIMAGETOOL" "${APPDIR}" "@APPIMAGE_FILE@"
 success "Created @APPIMAGE_FILE@"
 
 echo -e "\nFinished"

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -6,10 +6,8 @@
 # Notes:    Will attempt to fetch linuxdeployqt automatically (x86_64 only)
 #           See Also: https://github.com/probonopd/linuxdeployqt/blob/master/BUILDING.md
 
-trap "error 'Failed to generate AppImage'; exit 1" ERR
-
-LINUXDEPLOYQT="@CMAKE_BINARY_DIR@/linuxdeployqt"
 VERBOSITY=2 # 3=debug
+LOGFILE="@CMAKE_BINARY_DIR@/appimage.log"
 APPDIR="@CMAKE_BINARY_DIR@/@PROJECT_NAME_UCASE@.AppDir/"
 DESKTOPFILE="${APPDIR}usr/share/applications/lmms.desktop"
 STRIP=""
@@ -39,11 +37,17 @@ function skipped {
 	echo -e "   ${PLAIN}[${YELLOW}skipped${PLAIN}] ${1}"
 }
 
+# Exit with error message if any command fails
+trap "error 'Failed to generate AppImage'; exit 1" ERR
+
 # Run a command silently, but print output if it fails
-function try_quiet {
-    output="$("$@" 2>&1)" && return
-    echo "$output"
-    return 1
+function run_and_log {
+	echo -e "\n\n>>>>> $1" >> "$LOGFILE"
+	output="$("$@" 2>&1)"
+	status=$?
+	echo "$output" >> "$LOGFILE"
+	[[ $status != 0 ]] && echo "$output"
+	return $status
 }
 
 # Blindly assume system arch is appimage arch
@@ -56,39 +60,39 @@ if [ "$INSTALL" == "/usr/local" ] || [ "$INSTALL" == "/usr" ] ; then
 	error "Incompatible CMAKE_INSTALL_PREFIX for creating AppImage: @CMAKE_INSTALL_PREFIX@"
 fi
 
+# Include content of linuxdeployqt's extracted AppImage in PATH
 # Ensure linuxdeployqt uses the same qmake version as cmake
 PATH="$(pwd -P)/squashfs-root/usr/bin:$(dirname "@QT_QMAKE_EXECUTABLE@")":$PATH
 export PATH
 
+# Use linuxdeployqt from env or in PATH
+[[ $LINUXDEPLOYQT ]] || LINUXDEPLOYQT="$(which linuxdeployqt 2>/dev/null)" || true
+[[ $APPIMAGETOOL ]] || APPIMAGETOOL="$(which appimagetool 2>/dev/null)" || true
+
 # Fetch portable linuxdeployqt if not in PATH
-APPIMAGETOOL="squashfs-root/usr/bin/appimagetool"
-echo -e "\nDownloading linuxdeployqt to ${LINUXDEPLOYQT}..."
-if env -i which linuxdeployqt > /dev/null 2>&1; then
-	skipped "System already provides this utility"
-else
+if [[ -z $LINUXDEPLOYQT || -z $APPIMAGETOOL ]]; then
 	filename="linuxdeployqt-continuous-$ARCH.AppImage"
 	url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/$filename"
-	down_file="$(pwd)/$filename"
-	if [ ! -L "$LINUXDEPLOYQT" ]; then
-		ln -s "$down_file" "$LINUXDEPLOYQT"
-	fi
 	echo "   [.......] Downloading: ${url}"
-	wget -N -q "$url" || errorcode=$?
-	if [ "$errorcode" == 8 ]; then
-		# Server issued an error response
-		error "No package available for architecture: $ARCH"
-	elif [ "$errorcode" ]; then
-		error "Download failed"
-	fi
-	chmod +x "$LINUXDEPLOYQT"
-	success "Downloaded $LINUXDEPLOYQT"
+	wget -N -q "$url" && err=0 || err=$?
+	case "$err" in
+		0) success "Downloaded $PWD/$filename" ;;
+		# 8 == server issued 4xx error
+		8) error "Download failed (perhaps no package available for $ARCH)" ;;
+		*) error "Download failed" ;;
+	esac
+
 	# Extract AppImage and replace LINUXDEPLOYQT variable with extracted binary
 	# to support systems without fuse
 	# Also, we need to set LD_LIBRARY_PATH, but linuxdepoyqt's AppRun unsets it
 	# See https://github.com/probonopd/linuxdeployqt/pull/370/
-	"$LINUXDEPLOYQT" --appimage-extract > /dev/null 2>&1
-	LINUXDEPLOYQT="squashfs-root/usr/bin/linuxdeployqt"
-	success "Extracted $APPIMAGETOOL"
+	chmod +x "$filename"
+	"$filename" --appimage-extract > /dev/null 2>&1
+	success "Extracted $filename"
+
+	# We set PATH earlier to include the extracted ./squashfs-root
+	[[ $LINUXDEPLOYQT ]] || LINUXDEPLOYQT="$(which linuxdeployqt)"
+	[[ $APPIMAGETOOL ]] || APPIMAGETOOL="$(which appimagetool)"
 fi
 
 # Make skeleton AppDir
@@ -159,11 +163,14 @@ executables="${executables} -executable=${APPDIR}usr/lib/lmms/ladspa/imbeq_1197.
 executables="${executables} -executable=${APPDIR}usr/lib/lmms/ladspa/pitch_scale_1193.so"
 executables="${executables} -executable=${APPDIR}usr/lib/lmms/ladspa/pitch_scale_1194.so"
 
+echo -e "\nWriting verbose output to \"${LOGFILE}\""
+echo -n > "$LOGFILE"
+
 # Bundle both qt and non-qt dependencies into appimage format
 echo -e "\nBundling and relinking system dependencies..."
 
 # shellcheck disable=SC2086
-try_quiet "$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP
+run_and_log "$LINUXDEPLOYQT" "$DESKTOPFILE" $executables -bundle-non-qt-libs -verbose=$VERBOSITY $STRIP
 success "Bundled and relinked dependencies"
 
 # Link to original location so lmms can find them
@@ -196,7 +203,7 @@ ln -sr "${APPDIR}/usr/bin/lmms" "${APPDIR}/AppRun"
 
 # Create AppImage
 echo -e "\nFinishing the AppImage..."
-try_quiet "$APPIMAGETOOL" "${APPDIR}" "@APPIMAGE_FILE@"
+run_and_log "$APPIMAGETOOL" "${APPDIR}" "@APPIMAGE_FILE@"
 success "Created @APPIMAGE_FILE@"
 
 echo -e "\nFinished"

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -42,7 +42,7 @@ function skipped {
 # Run a command silently, but print output if it fails
 function try_quiet {
     output="$("$@" 2>&1)" && return
-    printf '%s\n' "$output"
+    echo "$output"
     return 1
 }
 

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -41,7 +41,7 @@ function skipped {
 }
 
 # Blindly assume system arch is appimage arch
-ARCH=$(arch)
+ARCH=$(uname -m)
 export ARCH
 
 # Check for problematic install locations
@@ -62,7 +62,7 @@ echo -e "\nDownloading linuxdeployqt to ${LINUXDEPLOYQT}..."
 if env -i which linuxdeployqt > /dev/null 2>&1; then
 	skipped "System already provides this utility"
 else
-	filename="linuxdeployqt-continuous-$(uname -p).AppImage"
+	filename="linuxdeployqt-continuous-$ARCH.AppImage"
 	url="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/$filename"
 	down_file="$(pwd)/$filename"
 	if [ ! -f "$LINUXDEPLOYQT" ]; then

--- a/cmake/linux/package_linux.sh.in
+++ b/cmake/linux/package_linux.sh.in
@@ -60,9 +60,8 @@ if [ "$INSTALL" == "/usr/local" ] || [ "$INSTALL" == "/usr" ] ; then
 	error "Incompatible CMAKE_INSTALL_PREFIX for creating AppImage: @CMAKE_INSTALL_PREFIX@"
 fi
 
-# Include content of linuxdeployqt's extracted AppImage in PATH
 # Ensure linuxdeployqt uses the same qmake version as cmake
-PATH="$(pwd -P)/squashfs-root/usr/bin:$(dirname "@QT_QMAKE_EXECUTABLE@")":$PATH
+PATH="$(dirname "@QT_QMAKE_EXECUTABLE@"):$PATH"
 export PATH
 
 # Use linuxdeployqt from env or in PATH
@@ -90,7 +89,8 @@ if [[ -z $LINUXDEPLOYQT || -z $APPIMAGETOOL ]]; then
 	./"$filename" --appimage-extract >/dev/null
 	success "Extracted $filename"
 
-	# We set PATH earlier to include the extracted ./squashfs-root
+	# Use the extracted linuxdeployqt and appimagetool
+	PATH="$(pwd -P)/squashfs-root/usr/bin:$PATH"
 	[[ $LINUXDEPLOYQT ]] || LINUXDEPLOYQT="$(which linuxdeployqt)"
 	[[ $APPIMAGETOOL ]] || APPIMAGETOOL="$(which appimagetool)"
 fi


### PR DESCRIPTION
Currently building AppImages on other systems than Ubuntu 18.04 x86_64 fails for a number of reasons, and resulting errors are misleading (see #6503)

- `uname -p` [only works on Ubuntu](https://unix.stackexchange.com/questions/307955/uname-p-i-are-unknown) and a few other distros.
- `/usr/bin/arch` is an [non-standard addition by Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=516050).

This PR also adds some more error messages, and verbose output is shown if build commands fail. Previously this verbose output was only printed in the CI action if it failed. Now it is printed during the build, for the user to see.

Build will still fail on systems newer than Ubuntu 18.04 due to [an arbitrary limitation in linuxdeployqt](https://github.com/probonopd/linuxdeployqt/blob/5fa79fa1df0788b45ed04963d7478d4e68fda2f8/tools/linuxdeployqt/main.cpp#L203). This can be circumvented using `-unsupported-allow-new-glibc`, but I'm not doing that here.