### PR TITLE
Fix bug that shows only one effect in the effect chain

### DIFF
--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -165,6 +165,7 @@ void EffectRackView::update()
 				view_map[i] = true;
 				break;
 			}
+			++i;
 		}
 		if( i >= m_effectViews.size() )
 		{


### PR DESCRIPTION
#6481  Introduced a bug where only one effect would show up in the effect chain, even though you could audibly tell that the effect was still added. This PR fixes this bug.