### PR TITLE
Fix master pitch behavior to transpose instead of detune

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -527,7 +527,7 @@ void NotePlayHandle::updateFrequency()
 	if (m_instrumentTrack->m_microtuner.enabled())
 	{
 		// custom key mapping and scale: get frequency from the microtuner
-		const int transposedKey = key() + masterPitch;
+		const auto transposedKey = key() + masterPitch;
 
 		if (m_instrumentTrack->isKeyMapped(transposedKey))
 		{

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -527,13 +527,13 @@ void NotePlayHandle::updateFrequency()
 	if (m_instrumentTrack->m_microtuner.enabled())
 	{
 		// custom key mapping and scale: get frequency from the microtuner
-		const float detuneMaster = detune + masterPitch;
+		const int transposedKey = key() + masterPitch;
 
-		if (m_instrumentTrack->isKeyMapped(key()))
+		if (m_instrumentTrack->isKeyMapped(transposedKey))
 		{
-			const auto frequency = m_instrumentTrack->m_microtuner.keyToFreq(key(), baseNote);
-			m_frequency = frequency * powf(2.f, (detuneMaster + instrumentPitch / 100) / 12.f);
-			m_unpitchedFrequency = frequency * powf(2.f, detuneMaster / 12.f);
+			const auto frequency = m_instrumentTrack->m_microtuner.keyToFreq(transposedKey, baseNote);
+			m_frequency = frequency * powf(2.f, (detune + instrumentPitch / 100) / 12.f);
+			m_unpitchedFrequency = frequency * powf(2.f, detune / 12.f);
 		}
 		else
 		{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -184,14 +184,14 @@ SongEditor::SongEditor( Song * song ) :
 	master_pitch_lbl->setPixmap( embed::getIconPixmap( "master_pitch" ) );
 	master_pitch_lbl->setFixedHeight( 64 );
 
-	m_masterPitchSlider = new AutomatableSlider( tb, tr( "Master pitch" ) );
+	m_masterPitchSlider = new AutomatableSlider( tb, tr( "Global transposition" ) );
 	m_masterPitchSlider->setModel( &m_song->m_masterPitchModel );
 	m_masterPitchSlider->setOrientation( Qt::Vertical );
 	m_masterPitchSlider->setPageStep( 1 );
 	m_masterPitchSlider->setTickPosition( QSlider::TicksLeft );
 	m_masterPitchSlider->setFixedSize( 26, 60 );
 	m_masterPitchSlider->setTickInterval( 12 );
-	m_masterPitchSlider->setToolTip(tr("Master pitch"));
+	m_masterPitchSlider->setToolTip(tr("Global transposition"));
 	connect( m_masterPitchSlider, SIGNAL(logicValueChanged(int)), this,
 			SLOT(setMasterPitch(int)));
 	connect( m_masterPitchSlider, SIGNAL(sliderPressed()), this,
@@ -202,7 +202,7 @@ SongEditor::SongEditor( Song * song ) :
 			SLOT(hideMasterPitchFloat()));
 
 	m_mpsStatus = new TextFloat;
-	m_mpsStatus->setTitle( tr( "Master pitch" ) );
+	m_mpsStatus->setTitle( tr( "Global transposition" ) );
 	m_mpsStatus->setPixmap( embed::getIconPixmap( "master_pitch" ) );
 
 	getGUI()->mainWindow()->addWidgetToToolBar( master_pitch_lbl );
@@ -723,7 +723,7 @@ void SongEditor::showMasterPitchFloat( void )
 
 void SongEditor::updateMasterPitchFloat( int new_val )
 {
-	m_mpsStatus->setText( tr( "Value: %1 semitones").arg( new_val ) );
+	m_mpsStatus->setText( tr( "Value: %1 notes").arg( new_val ) );
 
 }
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -723,7 +723,7 @@ void SongEditor::showMasterPitchFloat( void )
 
 void SongEditor::updateMasterPitchFloat( int new_val )
 {
-	m_mpsStatus->setText( tr( "Value: %1 notes").arg( new_val ) );
+	m_mpsStatus->setText( tr( "Value: %1 keys").arg( new_val ) );
 
 }
 

--- a/src/gui/instrument/InstrumentMiscView.cpp
+++ b/src/gui/instrument/InstrumentMiscView.cpp
@@ -55,6 +55,7 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	masterPitchLayout->setContentsMargins(8, 18, 8, 8);
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
+	tlabel->setWordWrap(true);
 	tlabel->setFont(pointSize<8>(tlabel->font()));
 	masterPitchLayout->addWidget(tlabel);
 

--- a/src/gui/instrument/InstrumentMiscView.cpp
+++ b/src/gui/instrument/InstrumentMiscView.cpp
@@ -47,14 +47,14 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	layout->setMargin(5);
 
 	// Master pitch toggle
-	m_pitchGroupBox = new GroupBox(tr("MASTER PITCH"));
+	m_pitchGroupBox = new GroupBox(tr("GLOBAL TRANSPOSITION"));
 	m_pitchGroupBox->setModel(&it->m_useMasterPitchModel);
 	layout->addWidget(m_pitchGroupBox);
 
 	auto masterPitchLayout = new QHBoxLayout(m_pitchGroupBox);
 	masterPitchLayout->setContentsMargins(8, 18, 8, 8);
 
-	auto tlabel = new QLabel(tr("Enables the use of master pitch"));
+	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setFont(pointSize<8>(tlabel->font()));
 	masterPitchLayout->addWidget(tlabel);
 


### PR DESCRIPTION
Title says it all.  This is the expected behavior for a master pitch slider (and already how it works for VSTs and ZynAddSubFX), and also makes the usage of that slider compatible with microtuning.