### PR TITLE
Fix rpmalloc assert for NotePlayHandle

### DIFF
--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -353,6 +353,7 @@ public:
 	static void release( NotePlayHandle * nph );
 	static void extend( int i );
 	static void free();
+	static void freeAvailable();
 
 private:
 	static NotePlayHandle ** s_available;

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -650,7 +650,7 @@ void NotePlayHandleManager::extend( int c )
 {
 	s_size += c;
 	auto tmp = MM_ALLOC<NotePlayHandle*>(s_size);
-	MM_FREE( s_available );
+	freeAvailable();
 	s_available = tmp;
 
 	auto n = MM_ALLOC<NotePlayHandle>(c);
@@ -662,9 +662,17 @@ void NotePlayHandleManager::extend( int c )
 	}
 }
 
+void NotePlayHandleManager::freeAvailable()
+{
+	// rpmalloc catches this as a non-free'd alloc
+	NotePlayHandle * n = s_available[0];
+	MM_FREE(n);
+	MM_FREE(s_available);
+}
+
 void NotePlayHandleManager::free()
 {
-	MM_FREE(s_available);
+	freeAvailable();
 }
 
 


### PR DESCRIPTION
Did some digging on a common rpmalloc assert raised for me and found this instance of an `MM_FREE` not being called.

For the quick fix I just added the `NotePlayHandle::freeAvailable` function, since I didn't go through and see if anything else called `NotePlayHandle::free`.