### PR TITLE
Fix pattern clip colors from pre-1.3 versions

### DIFF
--- a/src/core/PatternClip.cpp
+++ b/src/core/PatternClip.cpp
@@ -83,19 +83,20 @@ void PatternClip::loadSettings(const QDomElement& element)
 		toggleMute();
 	}
 	
-	// for colors saved in 1.3-onwards
-	if( element.hasAttribute( "color" ) && !element.hasAttribute( "usestyle" ) )
+	if (element.hasAttribute("color"))
 	{
-		useCustomClipColor( true );
-		setColor( element.attribute( "color" ) );
-	}
-	
-	// for colors saved before 1.3
-	else if(element.hasAttribute("color"))
-	{
-		setColor(QColor(element.attribute("color").toUInt()));
-		
-		// usestyle attribute is no longer used
+		if (!element.hasAttribute("usestyle"))
+		{
+			// for colors saved in 1.3-onwards
+			setColor(element.attribute("color"));
+			useCustomClipColor(true);
+		}
+		else
+		{
+			// for colors saved before 1.3
+			setColor(QColor(element.attribute("color").toUInt()));
+			useCustomClipColor(element.attribute("usestyle").toUInt() == 0);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Fixes a bug which prevented pattern clip colors from pre-1.3 versions from being used

Closes #6555