### PR TITLE
Microtonality for SF2Player

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ ENDIF()
 
 # check for Fluidsynth
 IF(WANT_SF2)
-	find_package(FluidSynth 1.0.7)
+	find_package(FluidSynth 1.1.0)
 	if(FluidSynth_FOUND)
 		SET(LMMS_HAVE_FLUIDSYNTH TRUE)
 		SET(STATUS_FLUIDSYNTH "OK")

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -223,6 +223,11 @@ public:
 	{
 		return &m_mixerChannelModel;
 	}
+	
+	BoolModel * useMasterPitchModel()
+    {
+        return &m_useMasterPitchModel;
+    }
 
 	void setPreviewMode( const bool );
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -223,11 +223,11 @@ public:
 	{
 		return &m_mixerChannelModel;
 	}
-	
-	BoolModel * useMasterPitchModel()
-    {
-        return &m_useMasterPitchModel;
-    }
+
+	BoolModel* useMasterPitchModel()
+	{
+		return &m_useMasterPitchModel;
+	}
 
 	void setPreviewMode( const bool );
 

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -549,7 +549,6 @@ void Sf2Instrument::updateTuning()
 {
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
-		int baseNote = instrumentTrack()->baseNoteModel()->value();
 		double * centArray = new double[128];
 		double lowestHz = powf(2.f, -69.f / 12.f) * 440.f;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -644,6 +644,7 @@ void Sf2Instrument::reloadSynth()
 	updateReverbOn();
 	updateChorusOn();
 	updateGain();
+	updateTuning();
 
 	// Reset last MIDI pitch properties, which will be set to the correct values
 	// upon playing the next note

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -183,12 +183,13 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	
 	// Microtuning
-	connect(Engine::getSong(), SIGNAL(scaleListChanged(int)), this, SLOT(updateTuning()));
-	connect(Engine::getSong(), SIGNAL(keymapListChanged(int)), this, SLOT(updateTuning()));
-	connect(instrumentTrack()->microtuner()->enabledModel(), SIGNAL(dataChanged()), this, SLOT(updateTuning()), Qt::DirectConnection);
-	connect(instrumentTrack()->microtuner()->scaleModel(), SIGNAL(dataChanged()), this, SLOT(updateTuning()), Qt::DirectConnection);
-	connect(instrumentTrack()->microtuner()->keymapModel(), SIGNAL(dataChanged()), this, SLOT(updateTuning()), Qt::DirectConnection);
-	connect(instrumentTrack()->baseNoteModel(), SIGNAL(dataChanged()), this, SLOT(updateTuning()), Qt::DirectConnection);
+	connect(Engine::getSong(), &Song::scaleListChanged, this, &Sf2Instrument::updateTuning);
+	connect(Engine::getSong(), &Song::keymapListChanged, this, &Sf2Instrument::updateTuning);
+	connect(instrumentTrack()->microtuner()->enabledModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
+	connect(instrumentTrack()->microtuner()->scaleModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
+	connect(instrumentTrack()->microtuner()->keymapModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
+	connect(instrumentTrack()->microtuner()->keyRangeImportModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
+	connect(instrumentTrack()->baseNoteModel(), &Model::dataChanged, this, &Sf2Instrument::updateTuning, Qt::DirectConnection);
 
 	auto iph = new InstrumentPlayHandle(this, _instrument_track);
 	Engine::audioEngine()->addPlayHandle( iph );
@@ -556,9 +557,9 @@ void Sf2Instrument::updateTuning()
 			// Get desired Hz of note
 			double noteHz = instrumentTrack()->microtuner()->keyToFreq(i, DefaultBaseKey);
 			// Convert Hz to cents
-			centArray[i] = 1200. * log2(noteHz / lowestHz);
+			centArray[i] = noteHz == 0. ? 0. : 1200. * log2(noteHz / lowestHz);
 		}
-		
+
 		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", centArray.data(), true);
 		for (int chan = 0; chan < 16; chan++)
 		{

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -551,25 +551,27 @@ void Sf2Instrument::updateTuning()
 	{
 		int baseNote = instrumentTrack()->baseNoteModel()->value();
 		double * centArray = new double[128];
-		double lowestHz = pow(2, -69.f / 12.f) * 440.f;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
+		double lowestHz = powf(2.f, -69.f / 12.f) * 440.f;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
+			// Get desired Hz of note
 			centArray[i] = instrumentTrack()->microtuner()->keyToFreq(i, DefaultBaseKey);
-			
 			// Convert Hz to cents
 			centArray[i] = 1200.f * log2(centArray[i] / lowestHz);
 		}
+		
 		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", centArray, true);
-		for (int chan = 0 ; chan<16 ; chan++) {
+		for (int chan = 0; chan < 16; chan++)
+		{
 		    fluid_synth_activate_tuning(m_synth, chan, 0, 0, true);
 		}
-
 		delete[] centArray;
 	}
 	else
 	{
 		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", NULL, true);
-		for (int chan = 0 ; chan<16 ; chan++) {
+		for (int chan = 0; chan < 16; chan++)
+		{
 		    fluid_synth_activate_tuning(m_synth, chan, 0, 0, true);
 		}
 	}

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -663,18 +663,19 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	}
 
 	const f_cnt_t tfp = _n->totalFramesPlayed();
+	
+	int masterPitch = instrumentTrack()->useMasterPitchModel()->value() ? Engine::getSong()->masterPitch() : 0;
+	int baseNote = instrumentTrack()->baseNoteModel()->value();
+	int midiNote = _n->midiKey() - baseNote + DefaultBaseKey + masterPitch;
+
+	// out of range?
+	if( midiNote <= 0 || midiNote >= 128 )
+	{
+		return;
+	}
 
 	if( tfp == 0 )
 	{
-		int masterPitch = instrumentTrack()->useMasterPitchModel()->value() ? Engine::getSong()->masterPitch() : 0;
-		int baseNote = instrumentTrack()->baseNoteModel()->value();
-		int midiNote = _n->midiKey() - baseNote + DefaultBaseKey + masterPitch;
-
-		// out of range?
-		if( midiNote <= 0 || midiNote >= 128 )
-		{
-			return;
-		}
 		const int baseVelocity = instrumentTrack()->midiPort()->baseVelocity();
 
 		auto pluginData = new Sf2PluginData;

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -549,7 +549,7 @@ void Sf2Instrument::updateTuning()
 {
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
-		double * centArray = new double[128];
+		auto centArray = std::array<double, 128>{};
 		double lowestHz = powf(2.f, -69.f / 12.f) * 440.f;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
@@ -559,12 +559,11 @@ void Sf2Instrument::updateTuning()
 			centArray[i] = 1200.f * log2(centArray[i] / lowestHz);
 		}
 		
-		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", centArray, true);
+		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", centArray.data(), true);
 		for (int chan = 0; chan < 16; chan++)
 		{
 		    fluid_synth_activate_tuning(m_synth, chan, 0, 0, true);
 		}
-		delete[] centArray;
 	}
 	else
 	{

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -567,7 +567,7 @@ void Sf2Instrument::updateTuning()
 	}
 	else
 	{
-		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", NULL, true);
+		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", nullptr, true);
 		for (int chan = 0; chan < 16; chan++)
 		{
 		    fluid_synth_activate_tuning(m_synth, chan, 0, 0, true);

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -550,13 +550,13 @@ void Sf2Instrument::updateTuning()
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
 		auto centArray = std::array<double, 128>{};
-		double lowestHz = powf(2.f, -69.f / 12.f) * 440.f;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
+		double lowestHz = pow(2., -69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
 			// Get desired Hz of note
-			centArray[i] = instrumentTrack()->microtuner()->keyToFreq(i, DefaultBaseKey);
+			double noteHz = instrumentTrack()->microtuner()->keyToFreq(i, DefaultBaseKey);
 			// Convert Hz to cents
-			centArray[i] = 1200.f * log2(centArray[i] / lowestHz);
+			centArray[i] = 1200. * log2(noteHz / lowestHz);
 		}
 		
 		fluid_synth_activate_key_tuning(m_synth, 0, 0, "", centArray.data(), true);
@@ -669,12 +669,12 @@ void Sf2Instrument::playNote( NotePlayHandle * _n, sampleFrame * )
 	int midiNote = _n->midiKey() - baseNote + DefaultBaseKey + masterPitch;
 
 	// out of range?
-	if( midiNote <= 0 || midiNote >= 128 )
+	if (midiNote < 0 || midiNote >= 128)
 	{
 		return;
 	}
 
-	if( tfp == 0 )
+	if (tfp == 0)
 	{
 		const int baseVelocity = instrumentTrack()->midiPort()->baseVelocity();
 

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -111,7 +111,7 @@ public slots:
 	void updateChorusOn();
 	void updateChorus();
 	void updateGain();
-
+	void updateTuning();
 
 private:
 	static QMutex s_fontsMutex;


### PR DESCRIPTION
SF2Player in its current state rounds microtuned notes to the closest 12EDO note, which obviously isn't desired behavior.  This PR makes use of `fluid_synth_activate_key_tuning` in order to adjust the number of cents each note is from MIDI note 0, to match the Hz of every note to the desired value.