### PR TITLE
Fix unwanted scrolling when changing track name

### DIFF
--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -105,6 +105,7 @@ void TrackLabelButton::renameFinished()
 {
 	if( !( ConfigManager::inst()->value( "ui", "compacttrackbuttons" ).toInt() ) )
 	{
+		m_renameLineEdit->clearFocus();
 		m_renameLineEdit->hide();
 		if( m_renameLineEdit->text() != "" )
 		{


### PR DESCRIPTION
When changing the track name in the Song Editor, ``m_renameLineEdit`` gains focus and subsequently hides without losing focus after the track has been renamed. This causes the scroll area in the Song Editor to unnecessarily jump to the track that was renamed. To prevent this, ``m_renameLineEdit`` should lose focus before hiding.

Fixes #6343.