### PR TITLE
PatternClips now use startTimeOffset, too, and can be resized on their start

### DIFF
--- a/src/core/PatternClip.cpp
+++ b/src/core/PatternClip.cpp
@@ -60,6 +60,7 @@ void PatternClip::saveSettings(QDomDocument& doc, QDomElement& element)
 		element.setAttribute( "pos", startPosition() );
 	}
 	element.setAttribute( "len", length() );
+	element.setAttribute("off", startTimeOffset());
 	element.setAttribute( "muted", isMuted() );
 	if( usesCustomClipColor() )
 	{
@@ -78,6 +79,7 @@ void PatternClip::loadSettings(const QDomElement& element)
 		movePosition( element.attribute( "pos" ).toInt() );
 	}
 	changeLength( element.attribute( "len" ).toInt() );
+	setStartTimeOffset(element.attribute("off").toInt());
 	if( element.attribute( "muted" ).toInt() != isMuted() )
 	{
 		toggleMute();

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -115,14 +115,18 @@ void PatternClipView::paintEvent(QPaintEvent*)
 	
 	// bar lines
 	const int lineSize = 3;
+	int pixelsPerPattern = Engine::patternStore()->lengthOfPattern(m_patternClip->patternIndex()) * pixelsPerBar();
+	int offset = static_cast<int>(m_patternClip->startTimeOffset() * (pixelsPerBar() / TimePos::ticksPerBar()))
+			% pixelsPerPattern;
+	if (offset < 2) {
+		offset += pixelsPerPattern;
+	}
+
 	p.setPen( c.darker( 200 ) );
 
-	bar_t t = Engine::patternStore()->lengthOfPattern(m_patternClip->patternIndex());
-	if (m_patternClip->length() > TimePos::ticksPerBar() && t > 0)
+	if (pixelsPerPattern > 0)
 	{
-		for( int x = static_cast<int>( t * pixelsPerBar() );
-								x < width() - 2;
-			x += static_cast<int>( t * pixelsPerBar() ) )
+		for (int x = offset; x < width() - 2; x += pixelsPerPattern)
 		{
 			p.drawLine( x, BORDER_WIDTH, x, BORDER_WIDTH + lineSize );
 			p.drawLine( x, rect().bottom() - ( BORDER_WIDTH + lineSize ),

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -108,19 +108,27 @@ bool PatternTrack::play( const TimePos & _start, const fpp_t _frames,
 	}
 
 	TimePos lastPosition;
-	TimePos lastLen;
+	TimePos lastLength;
+	tick_t lastOffset = 0;
 	for (const auto& clip : clips)
 	{
 		if (!clip->isMuted() && clip->startPosition() >= lastPosition)
 		{
 			lastPosition = clip->startPosition();
-			lastLen = clip->length();
+			lastLength = clip->length();
+			tick_t patternLength = Engine::patternStore()->lengthOfPattern(static_cast<PatternClip*>(clip)->patternIndex())
+					* TimePos::ticksPerBar();
+			lastOffset = patternLength - (clip->startTimeOffset() % patternLength);
+			if (lastOffset == patternLength)
+			{
+				lastOffset = 0;
+			}
 		}
 	}
 
-	if( _start - lastPosition < lastLen )
+	if( _start - lastPosition < lastLength )
 	{
-		return Engine::patternStore()->play(_start - lastPosition, _frames, _offset, s_infoMap[this]);
+		return Engine::patternStore()->play(_start - lastPosition + lastOffset, _frames, _offset, s_infoMap[this]);
 	}
 	return false;
 }


### PR DESCRIPTION
I checked the gui part, playback, export, copying and storing.
When dropping a pattern clip with startTimeOffset into another pattern clip, the startTimeOffset is currently not copied. If this is no wanted behaviour, please tell me, so I can try to fix it.
Also the behaviour of resizing the start is faulty sometimes when colliding with the start of the song editor (clip may grow or there is a padding sometimes). As this also happens on the sample track, it seems to be a general deal with ResizeLeft action.
This commit is for issue #6346.