### PR TITLE
Add mixer dB markers

### DIFF
--- a/include/MixerDbMarkers.h
+++ b/include/MixerDbMarkers.h
@@ -1,0 +1,47 @@
+/*
+ * MixerDbMarkers.h - dB markers for mixer channels
+ *
+ * Copyright (c) 2022 saker <sakertooth@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef MIXER_DB_MARKERS
+#define MIXER_DB_MARKERS
+
+#include <QWidget>
+
+namespace lmms::gui 
+{
+    class MixerDbMarkers : public QWidget 
+    {
+        Q_OBJECT
+    public:
+        MixerDbMarkers(QWidget* parent = nullptr);
+        void setMinDb(int minDb);
+        void setMaxDb(int maxDb);
+        void paintEvent(QPaintEvent* event) override;
+    private:
+        int m_minDb = 0;
+        int m_maxDb = 0;
+    };
+} // namespace lmms::gui
+
+#endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -108,6 +108,7 @@ SET(LMMS_SRCS
 	gui/widgets/LedCheckBox.cpp
 	gui/widgets/LeftRightNav.cpp
 	gui/widgets/MeterDialog.cpp
+	gui/widgets/MixerDbMarkers.cpp
 	gui/widgets/MixerLineLcdSpinBox.cpp
 	gui/widgets/NStateButton.cpp
 	gui/widgets/Oscilloscope.cpp

--- a/src/gui/MixerLine.cpp
+++ b/src/gui/MixerLine.cpp
@@ -91,7 +91,7 @@ MixerLine::MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 		s_receiveBgArrow = new QPixmap( embed::getIconPixmap( "receive_bg_arrow", 29, 56 ) );
 	}
 
-	setFixedSize( 33, MixerLineHeight );
+	setFixedSize(53, MixerLineHeight);
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 
@@ -121,7 +121,7 @@ MixerLine::MixerLine( QWidget * _parent, MixerView * _mv, int _channelIndex ) :
 	m_renameLineEdit->installEventFilter( this );
 
 	auto scene = new QGraphicsScene();
-	scene->setSceneRect( 0, 0, 33, MixerLineHeight );
+	scene->setSceneRect(0, 0, 53, MixerLineHeight);
 
 	m_view = new QGraphicsView( this );
 	m_view->setStyleSheet( "border-style: none; background: transparent;" );

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -32,6 +32,7 @@
 #include "lmms_math.h"
 
 #include "MixerView.h"
+#include "MixerDbMarkers.h"
 #include "Knob.h"
 #include "MixerLine.h"
 #include "Mixer.h"
@@ -312,6 +313,12 @@ MixerView::MixerChannelView::MixerChannelView(QWidget * _parent, MixerView * _mv
 	connect(&mixerChannel->m_soloModel, SIGNAL(dataChanged()),
 			_mv, SLOT ( toggledSolo() ), Qt::DirectConnection );
 	m_soloBtn->setToolTip(tr("Solo this channel"));
+
+	auto mixerDbMarkers = new MixerDbMarkers{m_mixerLine};
+	mixerDbMarkers->setMinDb(static_cast<int>(ampToDbfs(m_fader->getMinPeak())));
+	mixerDbMarkers->setMaxDb(static_cast<int>(ampToDbfs(m_fader->getMaxPeak())));
+	mixerDbMarkers->setFixedSize(20, m_fader->height());
+	mixerDbMarkers->move(m_fader->x() + m_fader->width() + 2, m_fader->y() + 5);
 
 	// Create EffectRack for the channel
 	m_rackView = new EffectRackView( &mixerChannel->m_fxChain, _mv->m_racksWidget );

--- a/src/gui/widgets/MixerDbMarkers.cpp
+++ b/src/gui/widgets/MixerDbMarkers.cpp
@@ -72,8 +72,7 @@ namespace lmms::gui
             }
 
             markerDb -= 3;
-        }
-        
+        }        
     }
 
 } // namespace lmms::gui

--- a/src/gui/widgets/MixerDbMarkers.cpp
+++ b/src/gui/widgets/MixerDbMarkers.cpp
@@ -1,0 +1,79 @@
+/*
+ * MixerDbMarkers.cpp - dB markers for mixer channels
+ *
+ * Copyright (c) 2022 saker <sakertooth@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "MixerDbMarkers.h"
+#include <QWidget>
+#include <QPainter>
+
+namespace lmms::gui 
+{
+    MixerDbMarkers::MixerDbMarkers(QWidget* parent) : QWidget(parent)
+    {
+        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
+    }
+
+    void MixerDbMarkers::setMinDb(int minDb) 
+    {
+        m_minDb = minDb;
+    }
+
+    void MixerDbMarkers::setMaxDb(int maxDb) 
+    {
+        m_maxDb = maxDb;
+    }
+
+    void MixerDbMarkers::paintEvent(QPaintEvent* event) 
+    {
+        const auto dbRange = m_maxDb - m_minDb;
+        if (dbRange <= 0 || dbRange % 3 != 0) { return; }
+
+        const auto numMarkers = dbRange / 3;
+        const auto markerSpacing = rect().height() / numMarkers;
+        auto markerDb = m_maxDb;
+
+        QPainter painter{this};
+        painter.setPen(Qt::white);
+        
+        auto font = painter.font();
+        font.setPointSize(7);
+        painter.setFont(font);
+
+        for (int i = 0; i <= numMarkers; ++i)
+        {
+            const auto markerPoint = QPoint{rect().x(), rect().y() + i * markerSpacing};
+            const auto markerWidth = rect().width() / (i % 2 == 0 ? 6 : 4);
+
+            painter.drawLine(markerPoint, QPoint{markerPoint.x() + markerWidth, markerPoint.y()});
+            if (i % 2 != 0) 
+            {
+                const auto markerRect = QRect{markerPoint.x() + 5, markerPoint.y() - markerSpacing, rect().width() - markerWidth, rect().height()};
+                painter.drawText(markerRect, Qt::AlignRight, QString::number(std::abs(markerDb)));
+            }
+
+            markerDb -= 3;
+        }
+        
+    }
+
+} // namespace lmms::gui


### PR DESCRIPTION
This PR adds dB markers for mixer channels. This is especially useful when leveling mixes, and is generally useful when you want to simply estimate at what dB a fader is peaking at.

**Screenshot**
![image](https://user-images.githubusercontent.com/20197645/207437105-cebbfc76-35d6-47dc-b188-927d9eb67feb.png)
