### PR TITLE
Fix recording not possible with MIDI keyboard in PianoRoll

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -116,7 +116,7 @@ Song::Song() :
 /*	connect( &m_masterPitchModel, SIGNAL(dataChanged()),
 			this, SLOT(masterPitchChanged()));*/
 
-	qRegisterMetaType<Note>( "Note" );
+	qRegisterMetaType<lmms::Note>( "lmms::Note" );
 	setType( SongContainer );
 
 	for (auto& scale : m_scales) {scale = std::make_shared<Scale>();}


### PR DESCRIPTION
closes #6592
Just Added missing namespace for `Note` .
Now Recording works as before.