### PR TITLE
Resample SampleBuffer only once when loading from SampleClip

### DIFF
--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -292,6 +292,10 @@ void SampleClip::loadSettings( const QDomElement & _this )
 	if( sampleFile().isEmpty() && _this.hasAttribute( "data" ) )
 	{
 		m_sampleBuffer->loadFromBase64( _this.attribute( "data" ) );
+		if (_this.hasAttribute("sample_rate"))
+		{
+			m_sampleBuffer->setSampleRate(_this.attribute("sample_rate").toInt());
+		}
 	}
 	changeLength( _this.attribute( "len" ).toInt() );
 	setMuted( _this.attribute( "muted" ).toInt() );

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -297,10 +297,6 @@ void SampleClip::loadSettings( const QDomElement & _this )
 	setMuted( _this.attribute( "muted" ).toInt() );
 	setStartTimeOffset( _this.attribute( "off" ).toInt() );
 
-	if ( _this.hasAttribute( "sample_rate" ) ) {
-		m_sampleBuffer->setSampleRate( _this.attribute( "sample_rate" ).toInt() );
-	}
-
 	if( _this.hasAttribute( "color" ) )
 	{
 		useCustomClipColor( true );


### PR DESCRIPTION
The ``SampleBuffer``'s sample rate in ``SampleClip`` was altered twice during ``SampleClip::loadSettings``: first when ``setSampleFile`` was called, which set the sample rate of the ``SampleBuffer`` to the ``AudioEngine``'s sample rate (good), and a second time when calling ``setSampleRate``, which set it to the sample rate specified within the project file (bad). This led to the sample rate of the buffer being different than that of the project, resulting in it being pitched incorrectly on playback.

I believe more improvement can be done here (I am questioning the need of setting the sample rate of a ``SampleBuffer`` as it should match the sample rate of the project), but for the sake of keeping it simple, I have only implemented the fix for now.

Fixes #6574.