### PR TITLE
Fix deprecated QString.sprintf with QString.arg

### DIFF
--- a/include/Scale.h
+++ b/include/Scale.h
@@ -47,7 +47,7 @@ public:
 	QString getString() const
 	{
 		if (m_denominator) {return QString::number(m_numerator) + "/" + QString::number(m_denominator);}
-		else {return QString().sprintf("%.4f", m_cents);}
+		else {return QString("%1").arg(m_cents, 0, 'f', 4);}
 	}
 
 	void saveSettings(QDomDocument &doc, QDomElement &element) override;


### PR DESCRIPTION
Was mentioned by @PhysSong in #5522 but never fixed.