### PR TITLE
Fix orphan class declarations in Flanger

### DIFF
--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -24,6 +24,9 @@
 
 #include "FlangerEffect.h"
 #include "Engine.h"
+#include "MonoDelay.h"
+#include "Noise.h"
+#include "QuadratureLfo.h"
 
 #include "embed.h"
 #include "plugin_export.h"

--- a/plugins/Flanger/FlangerEffect.h
+++ b/plugins/Flanger/FlangerEffect.h
@@ -28,16 +28,13 @@
 
 #include "Effect.h"
 #include "FlangerControls.h"
-#include "MonoDelay.h"
-#include "Noise.h"
-#include "QuadratureLfo.h"
+
+namespace lmms
+{
 
 class MonoDelay;
 class Noise;
 class QuadratureLfo;
-
-namespace lmms
-{
 
 
 class FlangerEffect : public Effect


### PR DESCRIPTION
Three dummy classes are declared outside the `lmms` namespace. Just something I stumbled upon.