### PR TITLE
Fix broken "Display playback cursor in AudioFileProcessor"

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -550,7 +550,7 @@ AudioFileProcessorView::AudioFileProcessorView( Instrument * _instrument,
 	connect( castModel<AudioFileProcessor>(), SIGNAL( isPlaying( lmms::f_cnt_t ) ),
 			m_waveView, SLOT( isPlaying( lmms::f_cnt_t ) ) );
 
-	qRegisterMetaType<f_cnt_t>( "f_cnt_t" );
+	qRegisterMetaType<lmms::f_cnt_t>( "lmms::f_cnt_t" );
 
 	setAcceptDrops( true );
 }


### PR DESCRIPTION
Adds missing `lmms` namespace for `f_cnt_t` to qRegisterMetaType.

Related: #6592, #6174