### PR TITLE
Improve readability of text floats

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -70,7 +70,7 @@ QToolTip {
 	color: #4afd85;
 }
 
-lmms--gui--TextFloat {
+lmms--gui--TextFloat, lmms--gui--SimpleTextFloat {
 	border-radius: 4px;
 	background: qlineargradient(spread:reflect, x1:0.5, y1:0.5, x2:0.5, y2:0, stop:0 rgba(0, 0, 0, 255), stop:1 rgba(50, 50, 50, 220));
 	opacity: 175;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -100,7 +100,7 @@ QToolTip {
 	color: #d1d8e4;
 }
 
-lmms--gui--TextFloat {
+lmms--gui--TextFloat, lmms--gui--SimpleTextFloat {
 	background: #040506;
 	color: #d1d8e4;
 }

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -55,10 +55,11 @@
 
 #include "AutomatableModelView.h"
 
+
 namespace lmms::gui
 {
 
-class TextFloat;
+class SimpleTextFloat;
 
 
 class LMMS_EXPORT Fader : public QWidget, public FloatModelView
@@ -164,7 +165,7 @@ private:
 	int m_moveStartPoint;
 	float m_startValue;
 
-	static TextFloat * s_textFloat;
+	static SimpleTextFloat * s_textFloat;
 
 	QColor m_peakGreen;
 	QColor m_peakRed;

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -41,7 +41,7 @@ namespace lmms::gui
 {
 
 
-class TextFloat;
+class SimpleTextFloat;
 
 enum knobTypes
 {
@@ -175,7 +175,7 @@ private:
 	}
 
 
-	static TextFloat * s_textFloat;
+	static SimpleTextFloat * s_textFloat;
 
 	QString m_label;
 	bool m_isHtmlLabel;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -60,7 +60,7 @@ namespace gui
 
 class ComboBox;
 class PositionLine;
-class TextFloat;
+class SimpleTextFloat;
 class TimeLineWidget;
 
 
@@ -345,7 +345,7 @@ private:
 
 	static std::array<PianoRollKeyTypes, 12> prKeyOrder;
 
-	static TextFloat * s_textFloat;
+	static SimpleTextFloat * s_textFloat;
 
 	ComboBoxModel m_zoomingModel;
 	ComboBoxModel m_zoomingYModel;

--- a/include/SimpleTextFloat.h
+++ b/include/SimpleTextFloat.h
@@ -2,8 +2,8 @@
  * TextFloat.h - class textFloat, a floating text-label
  *
  * Copyright (c) 2023 LMMS team
- * 
- * This file is part of LMMS - https://lmms.io
+*
+* This file is part of LMMS - https://lmms.io
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public
@@ -20,7 +20,7 @@
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA 02110-1301 USA.
  *
- */
+*/
 
 
 #ifndef SIMPLE_TEXT_FLOAT_H
@@ -42,13 +42,13 @@ public:
 	SimpleTextFloat();
 	~SimpleTextFloat() override = default;
 
-	void setText( const QString & _text );
+	void setText(const QString & text);
 
-	void setVisibilityTimeOut( int _msecs );
+	void setVisibilityTimeOut(int msecs);
 
-	void moveGlobal( QWidget * _w, const QPoint & _offset )
+	void moveGlobal(QWidget * w, const QPoint & offset)
 	{
-		move( _w->mapToGlobal( QPoint( 0, 0 ) ) + _offset );
+		move(w->mapToGlobal(QPoint(0, 0)) + offset);
 	}
 
 private:

--- a/include/SimpleTextFloat.h
+++ b/include/SimpleTextFloat.h
@@ -1,0 +1,61 @@
+/*
+ * TextFloat.h - class textFloat, a floating text-label
+ *
+ * Copyright (c) 2023 LMMS team
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef SIMPLE_TEXT_FLOAT_H
+#define SIMPLE_TEXT_FLOAT_H
+
+#include <QWidget>
+
+#include "lmms_export.h"
+
+class QLabel;
+
+namespace lmms::gui
+{
+
+class LMMS_EXPORT SimpleTextFloat : public QWidget
+{
+	Q_OBJECT
+public:
+	SimpleTextFloat();
+	~SimpleTextFloat() override = default;
+
+	void setText( const QString & _text );
+
+	void setVisibilityTimeOut( int _msecs );
+
+	void moveGlobal( QWidget * _w, const QPoint & _offset )
+	{
+		move( _w->mapToGlobal( QPoint( 0, 0 ) ) + _offset );
+	}
+
+private:
+	QLabel * m_textLabel;
+};
+
+
+} // namespace lmms::gui
+
+#endif

--- a/include/TextFloat.h
+++ b/include/TextFloat.h
@@ -42,31 +42,30 @@ public:
 	TextFloat();
 	~TextFloat() override = default;
 
-	void setTitle( const QString & _title );
-	void setText( const QString & _text );
-	void setPixmap( const QPixmap & _pixmap );
+	void setTitle(const QString & title);
+	void setText(const QString & text);
+	void setPixmap(const QPixmap & pixmap);
 
-	void setVisibilityTimeOut( int _msecs );
+	void setVisibilityTimeOut(int msecs);
 
-	static TextFloat * displayMessage( const QString & _title,
-						const QString & _msg,
-						const QPixmap & _pixmap =
-								QPixmap(),
-						int _timeout = 2000,
-						QWidget * _parent = nullptr );
+	static TextFloat * displayMessage(const QString & title,
+						const QString & msg,
+						const QPixmap & pixmap = QPixmap(),
+						int timeout = 2000,
+						QWidget * parent = nullptr);
 
-	void moveGlobal( QWidget * _w, const QPoint & _offset )
+	void moveGlobal(QWidget * w, const QPoint & offset)
 	{
-		move( _w->mapToGlobal( QPoint( 0, 0 ) )+_offset );
+		move(w->mapToGlobal(QPoint(0, 0)) + offset);
 	}
 
 
 protected:
-	void mousePressEvent( QMouseEvent * _me ) override;
+	void mousePressEvent(QMouseEvent * me) override;
 
 
 private:
-	TextFloat(const QString & _title, const QString & _text, const QPixmap & _pixmap);
+	TextFloat(const QString & title, const QString & text, const QPixmap & pixmap);
 
 	QLabel * m_pixmapLabel;
 	QLabel * m_titleLabel;

--- a/include/TextFloat.h
+++ b/include/TextFloat.h
@@ -27,9 +27,10 @@
 #define TEXT_FLOAT_H
 
 #include <QWidget>
-#include <QPixmap>
 
 #include "lmms_export.h"
+
+class QLabel;
 
 namespace lmms::gui
 {
@@ -47,11 +48,6 @@ public:
 
 	void setVisibilityTimeOut( int _msecs );
 
-
-	static TextFloat * displayMessage( const QString & _msg,
-						int _timeout = 2000,
-						QWidget * _parent = nullptr,
-						int _add_y_margin = 0 );
 	static TextFloat * displayMessage( const QString & _title,
 						const QString & _msg,
 						const QPixmap & _pixmap =
@@ -66,16 +62,15 @@ public:
 
 
 protected:
-	void paintEvent( QPaintEvent * _me ) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
 
 
 private:
-	void updateSize();
+	TextFloat(const QString & _title, const QString & _text, const QPixmap & _pixmap);
 
-	QString m_title;
-	QString m_text;
-	QPixmap m_pixmap;
+	QLabel * m_pixmapLabel;
+	QLabel * m_titleLabel;
+	QLabel * m_textLabel;
 
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -112,6 +112,7 @@ SET(LMMS_SRCS
 	gui/widgets/NStateButton.cpp
 	gui/widgets/Oscilloscope.cpp
 	gui/widgets/PixmapButton.cpp
+	gui/widgets/SimpleTextFloat.cpp
 	gui/widgets/TabBar.cpp
 	gui/widgets/TabWidget.cpp
 	gui/widgets/TempoSyncKnob.cpp

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -66,6 +66,7 @@
 #include "PatternStore.h"
 #include "PianoView.h"
 #include "PositionLine.h"
+#include "SimpleTextFloat.h"
 #include "SongEditor.h"
 #include "StepRecorderWidget.h"
 #include "TextFloat.h"
@@ -127,7 +128,7 @@ QPixmap * PianoRoll::s_toolMove = nullptr;
 QPixmap * PianoRoll::s_toolOpen = nullptr;
 QPixmap* PianoRoll::s_toolKnife = nullptr;
 
-TextFloat * PianoRoll::s_textFloat = nullptr;
+SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
 static std::array<QString, 12> s_noteStrings {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
 
@@ -290,7 +291,7 @@ PianoRoll::PianoRoll() :
 	// init text-float
 	if( s_textFloat == nullptr )
 	{
-		s_textFloat = new TextFloat;
+		s_textFloat = new SimpleTextFloat;
 	}
 
 	setAttribute( Qt::WA_OpaquePaintEvent, true );

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -54,13 +54,13 @@
 #include "embed.h"
 #include "CaptionMenu.h"
 #include "ConfigManager.h"
-#include "TextFloat.h"
+#include "SimpleTextFloat.h"
 
 namespace lmms::gui
 {
 
 
-TextFloat * Fader::s_textFloat = nullptr;
+SimpleTextFloat * Fader::s_textFloat = nullptr;
 QPixmap * Fader::s_back = nullptr;
 QPixmap * Fader::s_leds = nullptr;
 QPixmap * Fader::s_knob = nullptr;
@@ -83,7 +83,7 @@ Fader::Fader( FloatModel * _model, const QString & _name, QWidget * _parent ) :
 {
 	if( s_textFloat == nullptr )
 	{
-		s_textFloat = new TextFloat;
+		s_textFloat = new SimpleTextFloat;
 	}
 	if( ! s_back )
 	{
@@ -125,7 +125,7 @@ Fader::Fader( FloatModel * model, const QString & name, QWidget * parent, QPixma
 {
 	if( s_textFloat == nullptr )
 	{
-		s_textFloat = new TextFloat;
+		s_textFloat = new SimpleTextFloat;
 	}
 
 	m_back = back;

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -328,7 +328,8 @@ void Fader::updateTextFloat()
 	{
 		s_textFloat->setText( m_description + " " + QString("%1 ").arg( model()->value() * m_conversionFactor ) + " " + m_unit );
 	}
-	s_textFloat->moveGlobal( this, QPoint( width() - ( *m_knob ).width() - 5, knobPosY() - 46 ) );
+
+	s_textFloat->moveGlobal( this, QPoint( width() + 2, knobPosY() - s_textFloat->height() / 2 ) );
 }
 
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -329,7 +329,7 @@ void Fader::updateTextFloat()
 		s_textFloat->setText( m_description + " " + QString("%1 ").arg( model()->value() * m_conversionFactor ) + " " + m_unit );
 	}
 
-	s_textFloat->moveGlobal( this, QPoint( width() + 2, knobPosY() - s_textFloat->height() / 2 ) );
+	s_textFloat->moveGlobal(this, QPoint(width() + 2, knobPosY() - s_textFloat->height() / 2));
 }
 
 

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -45,14 +45,14 @@
 #include "LocaleHelper.h"
 #include "MainWindow.h"
 #include "ProjectJournal.h"
+#include "SimpleTextFloat.h"
 #include "StringPairDrag.h"
-#include "TextFloat.h"
 
 
 namespace lmms::gui
 {
 
-TextFloat * Knob::s_textFloat = nullptr;
+SimpleTextFloat * Knob::s_textFloat = nullptr;
 
 
 
@@ -86,7 +86,7 @@ void Knob::initUi( const QString & _name )
 {
 	if( s_textFloat == nullptr )
 	{
-		s_textFloat = new TextFloat;
+		s_textFloat = new SimpleTextFloat;
 	}
 
 	setWindowTitle( _name );

--- a/src/gui/widgets/SimpleTextFloat.cpp
+++ b/src/gui/widgets/SimpleTextFloat.cpp
@@ -1,0 +1,62 @@
+/*
+ * TextFloat.cpp - class textFloat, a floating text-label
+ *
+ * Copyright (c) LMMS team
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "SimpleTextFloat.h"
+
+#include <QTimer>
+#include <QStyleOption>
+#include <QHBoxLayout>
+#include <QLabel>
+
+#include "GuiApplication.h"
+#include "MainWindow.h"
+
+namespace lmms::gui
+{
+
+
+SimpleTextFloat::SimpleTextFloat() :
+	QWidget(getGUI()->mainWindow(), Qt::ToolTip)
+{
+	QHBoxLayout * layout = new QHBoxLayout(this);
+	layout->setMargin(3);
+	setLayout(layout);
+
+	m_textLabel = new QLabel(this);
+	layout->addWidget(m_textLabel);
+}
+
+void SimpleTextFloat::setText( const QString & _text )
+{
+	m_textLabel->setText(_text);
+}
+
+
+void SimpleTextFloat::setVisibilityTimeOut( int _msecs )
+{
+	QTimer::singleShot( _msecs, this, SLOT(hide()));
+	show();
+}
+
+} // namespace lmms::gui

--- a/src/gui/widgets/SimpleTextFloat.cpp
+++ b/src/gui/widgets/SimpleTextFloat.cpp
@@ -47,15 +47,15 @@ SimpleTextFloat::SimpleTextFloat() :
 	layout->addWidget(m_textLabel);
 }
 
-void SimpleTextFloat::setText( const QString & _text )
+void SimpleTextFloat::setText(const QString & text)
 {
-	m_textLabel->setText(_text);
+	m_textLabel->setText(text);
 }
 
 
-void SimpleTextFloat::setVisibilityTimeOut( int _msecs )
+void SimpleTextFloat::setVisibilityTimeOut(int msecs)
 {
-	QTimer::singleShot( _msecs, this, SLOT(hide()));
+	QTimer::singleShot(msecs, this, SLOT(hide()));
 	show();
 }
 

--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -43,8 +43,8 @@ TextFloat::TextFloat() :
 {
 }
 
-TextFloat::TextFloat(const QString & _title, const QString & _text, const QPixmap & _pixmap) :
-	QWidget( getGUI()->mainWindow(), Qt::ToolTip )
+TextFloat::TextFloat(const QString & title, const QString & text, const QPixmap & pixmap) :
+	QWidget(getGUI()->mainWindow(), Qt::ToolTip)
 {
 	QHBoxLayout * mainLayout = new QHBoxLayout();
 	setLayout(mainLayout);
@@ -68,66 +68,66 @@ TextFloat::TextFloat(const QString & _title, const QString & _text, const QPixma
 	mainLayout->addWidget(titleAndTextWidget);
 
 	// Call the setters so that the hidden state is updated
-	setTitle(_title);
-	setText(_text);
-	setPixmap(_pixmap);
+	setTitle(title);
+	setText(text);
+	setPixmap(pixmap);
 }
 
-void TextFloat::setTitle( const QString & _title )
+void TextFloat::setTitle(const QString & title)
 {
-	m_titleLabel->setText(_title);
-	m_titleLabel->setHidden(_title.isEmpty());
+	m_titleLabel->setText(title);
+	m_titleLabel->setHidden(title.isEmpty());
 }
 
-void TextFloat::setText( const QString & _text )
+void TextFloat::setText(const QString & text)
 {
-	m_textLabel->setText(_text);
-	m_textLabel->setHidden(_text.isEmpty());
+	m_textLabel->setText(text);
+	m_textLabel->setHidden(text.isEmpty());
 }
 
-void TextFloat::setPixmap( const QPixmap & _pixmap )
+void TextFloat::setPixmap(const QPixmap & pixmap)
 {
-	m_pixmapLabel->setPixmap(_pixmap);
-	m_pixmapLabel->setHidden(_pixmap.isNull());
+	m_pixmapLabel->setPixmap(pixmap);
+	m_pixmapLabel->setHidden(pixmap.isNull());
 }
 
-void TextFloat::setVisibilityTimeOut( int _msecs )
+void TextFloat::setVisibilityTimeOut(int msecs)
 {
-	QTimer::singleShot( _msecs, this, SLOT(hide()));
+	QTimer::singleShot(msecs, this, SLOT(hide()));
 	show();
 }
 
-TextFloat * TextFloat::displayMessage( const QString & _title,
-					const QString & _msg,
-					const QPixmap & _pixmap,
-					int _timeout, QWidget * _parent )
+TextFloat * TextFloat::displayMessage(const QString & title,
+					const QString & msg,
+					const QPixmap & pixmap,
+					int timeout, QWidget * parent)
 {
-	auto tf = new TextFloat(_title, _msg, _pixmap);
+	auto tf = new TextFloat(title, msg, pixmap);
 
 	// Show the widget so that the correct height is calculated in the code that follows
 	tf->show();
 
-	if( _parent != nullptr )
+	if(parent != nullptr)
 	{
-		tf->moveGlobal( _parent, QPoint( _parent->width() + 2, 0 ) );
+		tf->moveGlobal(parent, QPoint(parent->width() + 2, 0));
 	}
 	else
 	{
 		// If no parent is given move the window to the lower left area of the main window
 		QWidget * mw = getGUI()->mainWindow();
-		tf->moveGlobal( mw, QPoint( 32, mw->height() - tf->height() - 8 ) );
+		tf->moveGlobal(mw, QPoint(32, mw->height() - tf->height() - 8));
 	}
 
-	if( _timeout > 0 )
+	if (timeout > 0)
 	{
-		tf->setAttribute( Qt::WA_DeleteOnClose, true );
-		QTimer::singleShot( _timeout, tf, SLOT(close()));
+		tf->setAttribute(Qt::WA_DeleteOnClose, true);
+		QTimer::singleShot(timeout, tf, SLOT(close()));
 	}
 
 	return tf;
 }
 
-void TextFloat::mousePressEvent( QMouseEvent * )
+void TextFloat::mousePressEvent(QMouseEvent *)
 {
 	close();
 }


### PR DESCRIPTION
Improve the readability of text floats by removing the hard coded pixel font size. The widget is now composed of three `QLabels` which are used to display the title, text and pixmap. A small step to improve the problems described in #2510.

The adjusted version looks as follows. Please use the main menu as a reference for a "normal" text size:

https://user-images.githubusercontent.com/9293269/211168411-7fa46aa4-0701-4df5-ad7c-97215fa84699.mp4

## Technical details
Remove the methods `paintEvent` and `updateSize` because the widget is now updated automatically whenever the QLabels change state.

Merge both versions of `TextFloat::displayMessage` because one of them was only called by the other.

The default constructor of `TextFloat` now delegates to the "full" constructor. The latter is private because it is only used from within `displayMessage`.

The methods `setTitle`, `setText` and `setPixmap` show/hide their corresponding labels depending on whether there is text or a pixmap to show.

Adjust the class `Fader` so that the text float is shown to the right of the fader. Otherwise the new implementation would have covered the fader while it is being moved.

## Old version
For comparison, here's how the current implementation looks. The text is very small and hard to read.

https://user-images.githubusercontent.com/9293269/211168527-bd4e00ab-3c07-43ca-a19a-762d20af3ca6.mp4

