### PR TITLE
Fix recent files menu on old KDE in a different way

### DIFF
--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -39,6 +39,19 @@ MainApplication::MainApplication(int& argc, char** argv) :
 	QApplication(argc, argv),
 	m_queuedFile()
 {
+#if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_APPLE) && !defined(LMMS_BUILD_HAIKU)
+	// Work around a bug of KXmlGui < 5.55
+	// which breaks the recent files menu
+	// https://bugs.kde.org/show_bug.cgi?id=337491
+	for (auto child : children())
+	{
+		if (child->inherits("KCheckAcceleratorsInitializer"))
+		{
+			delete child;
+		}
+	}
+#endif
+
 #if defined(LMMS_BUILD_WIN32)
 	installNativeEventFilter(this);
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -33,7 +33,6 @@
 #include <QMenuBar>
 #include <QMessageBox>
 #include <QShortcut>
-#include <QLibrary>
 #include <QSplitter>
 
 #include "AboutDialog.h"
@@ -78,22 +77,6 @@
 namespace lmms::gui
 {
 
-#if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_APPLE) && !defined(LMMS_BUILD_HAIKU)
-//Work around an issue on KDE5 as per https://bugs.kde.org/show_bug.cgi?id=337491#c21
-void disableAutoKeyAccelerators(QWidget* mainWindow)
-{
-	using DisablerFunc = void(*)(QWidget*);
-	QLibrary kf5WidgetsAddon("KF5WidgetsAddons", 5);
-	auto setNoAccelerators
-		= reinterpret_cast<DisablerFunc>(kf5WidgetsAddon.resolve("_ZN19KAcceleratorManager10setNoAccelEP7QWidget"));
-	if(setNoAccelerators)
-	{
-		setNoAccelerators(mainWindow);
-	}
-	kf5WidgetsAddon.unload();
-}
-#endif
-
 
 MainWindow::MainWindow() :
 	m_workspace( nullptr ),
@@ -103,9 +86,6 @@ MainWindow::MainWindow() :
 	m_metronomeToggle( 0 ),
 	m_session( Normal )
 {
-#if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_APPLE) && !defined(LMMS_BUILD_HAIKU)
-	disableAutoKeyAccelerators(this);
-#endif
 	setAttribute( Qt::WA_DeleteOnClose );
 
 	auto main_widget = new QWidget(this);


### PR DESCRIPTION
Fixes #6587.
This PR reverts #3872 and applies an alternative fix for #3741. In the previous approach, `KAcceleratorManager::setNoAccel` was called with the `MainWindow` instance. This, however, leads to a crash in certain cases as reported by #6587.
KXmlGui library registers a startup function for `QCoreApplication` which may install a `KCheckAccelerators` global event filter, using `KCheckAcceleratorsInitializer`. The event filter is supposed to be installed only if the application directly links to KXmlGui, but it was always installed prior to KXmlGui 5.55.0.

The new approach has two advantages:
- For buggy versions of KXmlGui, it removes the root cause of the issue completely
- For newer KXmlGui versions, it's effectively doing nothing.

As far as know, CentOS 7, Ubuntu 18.04 and Debian 10 ships with buggy versions of the library. Once all of them gets unsupported, we may entirely remove the workaround.