### PR TITLE
Fix more Qt deprecation warnings

### DIFF
--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -29,6 +29,7 @@
 #include <string>
 
 #include <QFileInfo>
+#include <QHash>
 #include <QList>
 #include <QString>
 #include <QVector>

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -98,7 +98,7 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 {
 	auto hlayout = new QHBoxLayout(this);
 	hlayout->setSpacing( 0 );
-	hlayout->setMargin( 0 );
+	hlayout->setContentsMargins(0, 0, 0, 0);
 
 	m_tabBar = new TabBar( this, QBoxLayout::TopToBottom );
 	m_tabBar->setExclusive( true );
@@ -166,7 +166,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	tab->setFixedSize( 500, 400 );
 	auto layout = new QVBoxLayout(tab);
 	layout->setSpacing( 0 );
-	layout->setMargin( 0 );
+	layout->setContentsMargins(0, 0, 0, 0);
 
 	const QString type = "<b>" + tr( "Type:" ) + "</b> ";
 	auto title = new QLabel(type + _txt, tab);

--- a/plugins/LadspaBrowser/LadspaDescription.cpp
+++ b/plugins/LadspaBrowser/LadspaDescription.cpp
@@ -94,7 +94,7 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 	auto descriptionBox = new QGroupBox(tr("Description"), this);
 	auto descriptionLayout = new QVBoxLayout(descriptionBox);
 	descriptionLayout->setSpacing( 0 );
-	descriptionLayout->setMargin( 0 );
+	descriptionLayout->setContentsMargins(0, 0, 0, 0);
 
 	m_scrollArea = new QScrollArea( descriptionBox );
 	descriptionLayout->addWidget( m_scrollArea );
@@ -130,7 +130,7 @@ void LadspaDescription::update( const ladspa_key_t & _key )
 
 	auto maker = new QWidget(description);
 	auto makerLayout = new QHBoxLayout(maker);
-	makerLayout->setMargin( 0 );
+	makerLayout->setContentsMargins(0, 0, 0, 0);
 	makerLayout->setSpacing( 0 );
 	layout->addWidget( maker );
 
@@ -145,7 +145,7 @@ void LadspaDescription::update( const ladspa_key_t & _key )
 
 	auto copyright = new QWidget(description);
 	auto copyrightLayout = new QHBoxLayout(copyright);
-	copyrightLayout->setMargin( 0 );
+	copyrightLayout->setContentsMargins(0, 0, 0, 0);
 	copyrightLayout->setSpacing( 0 );
 	layout->addWidget( copyright );
 

--- a/plugins/LadspaBrowser/LadspaPortDialog.cpp
+++ b/plugins/LadspaBrowser/LadspaPortDialog.cpp
@@ -47,7 +47,7 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 
 	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing( 0 );
-	vlayout->setMargin( 0 );
+	vlayout->setContentsMargins(0, 0, 0, 0);
 
 	int pc = manager->getPortCount( _key );
 

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -71,7 +71,7 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 
 	auto maker = new QWidget(_parent);
 	auto l = new QHBoxLayout(maker);
-	l->setMargin( 0 );
+	l->setContentsMargins(0, 0, 0, 0);
 	l->setSpacing( 0 );
 
 	auto maker_label = new QLabel(maker);
@@ -85,7 +85,7 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 
 	auto copyright = new QWidget(_parent);
 	l = new QHBoxLayout( copyright );
-	l->setMargin( 0 );
+	l->setContentsMargins(0, 0, 0, 0);
 	l->setSpacing( 0 );
 
 	copyright->setMinimumWidth( _parent->minimumWidth() );

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -751,7 +751,7 @@ void VstPlugin::createUI( QWidget * parent )
 		QHBoxLayout * l = new QHBoxLayout( helper );
 		QWidget * target = new QWidget( helper );
 		l->setSpacing( 0 );
-		l->setMargin( 0 );
+		l->setContentsMargins(0, 0, 0, 0);
 		l->addWidget( target );
 
 		// we've to call that for making sure, Qt created the windows

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1043,7 +1043,12 @@ void Song::loadProject( const QString & fileName )
 			else
 			{
 				QTextStream(stderr) << tr("Can't load project: "
-					"Project file contains local paths to plugins.") << endl;
+					"Project file contains local paths to plugins.")
+#if (QT_VERSION >= QT_VERSION_CHECK(5,15,0))
+					<< Qt::endl;
+#else
+					<< endl;
+#endif
 			}
 		}
 	}

--- a/src/core/lv2/Lv2SubPluginFeatures.cpp
+++ b/src/core/lv2/Lv2SubPluginFeatures.cpp
@@ -81,7 +81,7 @@ void Lv2SubPluginFeatures::fillDescriptionWidget(QWidget *parent,
 
 	auto maker = new QWidget(parent);
 	auto l = new QHBoxLayout(maker);
-	l->setMargin(0);
+	l->setContentsMargins(0, 0, 0, 0);
 	l->setSpacing(0);
 
 	auto maker_label = new QLabel(maker);
@@ -98,7 +98,7 @@ void Lv2SubPluginFeatures::fillDescriptionWidget(QWidget *parent,
 
 	auto copyright = new QWidget(parent);
 	l = new QHBoxLayout(copyright);
-	l->setMargin(0);
+	l->setContentsMargins(0, 0, 0, 0);
 	l->setSpacing(0);
 	copyright->setMinimumWidth(parent->minimumWidth());
 

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -176,7 +176,7 @@ void AutomatableModelView::mousePressEvent( QMouseEvent* event )
 		new gui::StringPairDrag( "automatable_model", QString::number( modelUntyped()->id() ), QPixmap(), widget() );
 		event->accept();
 	}
-	else if( event->button() == Qt::MidButton )
+	else if( event->button() == Qt::MiddleButton )
 	{
 		modelUntyped()->reset();
 	}

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -42,7 +42,7 @@ EffectRackView::EffectRackView( EffectChain* model, QWidget* parent ) :
 	ModelView( nullptr, this )
 {
 	auto mainLayout = new QVBoxLayout(this);
-	mainLayout->setMargin( 5 );
+	mainLayout->setContentsMargins(5, 5, 5, 5);
 
 	m_effectsGroupBox = new GroupBox( tr( "EFFECTS CHAIN" ) );
 	mainLayout->addWidget( m_effectsGroupBox );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -76,7 +76,7 @@ void FileBrowser::addContentCheckBox()
 	auto filterWidget = new QWidget(contentParent());
 	filterWidget->setFixedHeight(15);
 	auto filterWidgetLayout = new QHBoxLayout(filterWidget);
-	filterWidgetLayout->setMargin(0);
+	filterWidgetLayout->setContentsMargins(0, 0, 0, 0);
 	filterWidgetLayout->setSpacing(0);
 
 	auto configCheckBox = [this, &filterWidgetLayout](QCheckBox* box)
@@ -119,7 +119,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	searchWidget->setFixedHeight( 24 );
 
 	auto searchWidgetLayout = new QHBoxLayout(searchWidget);
-	searchWidgetLayout->setMargin( 0 );
+	searchWidgetLayout->setContentsMargins(0, 0, 0, 0);
 	searchWidgetLayout->setSpacing( 0 );
 
 	m_filterEdit = new QLineEdit( searchWidget );

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -43,7 +43,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 	m_ctl( _ctl )
 {
 	auto layout = new QHBoxLayout(this);
-	layout->setMargin( 0 );
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing( 0 );
 
 	LedCheckBox * link = nullptr;

--- a/src/gui/LmmsPalette.cpp
+++ b/src/gui/LmmsPalette.cpp
@@ -75,7 +75,7 @@ QPalette LmmsPalette::palette() const
 {
 	QPalette pal = QApplication::style()->standardPalette();
 	
-	pal.setColor( QPalette::Background, 		background() );	
+	pal.setColor( QPalette::Window, 			background() );
 	pal.setColor( QPalette::WindowText, 		windowText() );	
 	pal.setColor( QPalette::Base, 				base() );	
 	pal.setColor( QPalette::ButtonText, 		buttonText() );	

--- a/src/gui/LmmsStyle.cpp
+++ b/src/gui/LmmsStyle.cpp
@@ -189,7 +189,7 @@ void LmmsStyle::drawComplexControl( ComplexControl control,
 /*	else if( control == CC_ScrollBar )
 	{
 		painter->fillRect( option->rect, QApplication::palette().color( QPalette::Active,
-							QPalette::Background ) );
+							QPalette::Window ) );
 
 	}*/
 	QProxyStyle::drawComplexControl( control, option, painter, widget );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -91,12 +91,12 @@ MainWindow::MainWindow() :
 	auto main_widget = new QWidget(this);
 	auto vbox = new QVBoxLayout(main_widget);
 	vbox->setSpacing( 0 );
-	vbox->setMargin( 0 );
+	vbox->setContentsMargins(0, 0, 0, 0);
 
 	auto w = new QWidget(main_widget);
 	auto hbox = new QHBoxLayout(w);
 	hbox->setSpacing( 0 );
-	hbox->setMargin( 0 );
+	hbox->setContentsMargins(0, 0, 0, 0);
 
 	auto sideBar = new SideBar(Qt::Vertical, w);
 
@@ -206,7 +206,7 @@ MainWindow::MainWindow() :
 
 	// add layout for organizing quite complex toolbar-layouting
 	m_toolBarLayout = new QGridLayout( m_toolBar/*, 2, 1*/ );
-	m_toolBarLayout->setMargin( 0 );
+	m_toolBarLayout->setContentsMargins(0, 0, 0, 0);
 	m_toolBarLayout->setSpacing( 0 );
 
 	vbox->addWidget( m_toolBar );

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -59,7 +59,7 @@ MixerView::MixerView() :
 	m->setHook( this );
 
 	//QPalette pal = palette();
-	//pal.setColor( QPalette::Background, QColor( 72, 76, 88 ) );
+	//pal.setColor( QPalette::Window, QColor( 72, 76, 88 ) );
 	//setPalette( pal );
 
 	setAutoFillBackground( true );

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -79,7 +79,7 @@ MixerView::MixerView() :
 	chLayout = new QHBoxLayout( m_channelAreaWidget );
 	chLayout->setSizeConstraint( QLayout::SetMinimumSize );
 	chLayout->setSpacing( 0 );
-	chLayout->setMargin( 0 );
+	chLayout->setContentsMargins(0, 0, 0, 0);
 	m_channelAreaWidget->setLayout(chLayout);
 
 	// create rack layout before creating the first channel

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -52,7 +52,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 	addContentWidget( m_view );
 
 	auto view_layout = new QVBoxLayout(m_view);
-	view_layout->setMargin( 5 );
+	view_layout->setContentsMargins(5, 5, 5, 5);
 	view_layout->setSpacing( 5 );
 
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -57,7 +57,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	// init own layout + widgets
 	setFocusPolicy(Qt::StrongFocus);
 	auto vlayout = new QVBoxLayout(this);
-	vlayout->setMargin(0);
+	vlayout->setContentsMargins(0, 0, 0, 0);
 	vlayout->setSpacing(0);
 
 	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);

--- a/src/gui/SideBarWidget.cpp
+++ b/src/gui/SideBarWidget.cpp
@@ -44,7 +44,7 @@ SideBarWidget::SideBarWidget( const QString & _title, const QPixmap & _icon,
 	m_contents = new QWidget( this );
 	m_layout = new QVBoxLayout( m_contents );
 	m_layout->setSpacing( 5 );
-	m_layout->setMargin( 0 );
+	m_layout->setContentsMargins(0, 0, 0, 0);
 	m_closeBtn = new QPushButton(embed::getIconPixmap("close"), QString(), this);
 	m_closeBtn->resize(m_buttonSize);
 	m_closeBtn->setToolTip(tr("Close"));

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -213,7 +213,7 @@ SongEditor::SongEditor( Song * song ) :
 	// create widget for oscilloscope- and cpu-load-widget
 	auto vc_w = new QWidget(tb);
 	auto vcw_layout = new QVBoxLayout(vc_w);
-	vcw_layout->setMargin( 0 );
+	vcw_layout->setContentsMargins(0, 0, 0, 0);
 	vcw_layout->setSpacing( 0 );
 
 	vcw_layout->addStretch();

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -90,13 +90,13 @@ TrackContainerView::TrackContainerView( TrackContainer * _tc ) :
 	//keeps the direction of the widget, undepended on the locale
 	setLayoutDirection( Qt::LeftToRight );
 	auto layout = new QVBoxLayout(this);
-	layout->setMargin( 0 );
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing( 0 );
 	layout->addWidget( m_scrollArea );
 
 	auto scrollContent = new QWidget;
 	m_scrollLayout = new QVBoxLayout( scrollContent );
-	m_scrollLayout->setMargin( 0 );
+	m_scrollLayout->setContentsMargins(0, 0, 0, 0);
 	m_scrollLayout->setSpacing( 0 );
 	m_scrollLayout->setSizeConstraint( QLayout::SetMinAndMaxSize );
 

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -47,7 +47,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	m_chordRangeKnob( new Knob( knobBright_26 ) )
 {
 	auto topLayout = new QHBoxLayout(this);
-	topLayout->setMargin( 0 );
+	topLayout->setContentsMargins(0, 0, 0, 0);
 	topLayout->addWidget( m_chordsGroupBox );
 
 	auto mainLayout = new QGridLayout(m_chordsGroupBox);
@@ -109,7 +109,7 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpModeComboBox( new ComboBox() )
 {
 	auto topLayout = new QHBoxLayout(this);
-	topLayout->setMargin( 0 );
+	topLayout->setContentsMargins(0, 0, 0, 0);
 	topLayout->addWidget( m_arpGroupBox );
 
 	auto mainLayout = new QGridLayout(m_arpGroupBox);

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -48,7 +48,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	m_wpBtn( nullptr )
 {
 	auto layout = new QVBoxLayout(this);
-	layout->setMargin( 5 );
+	layout->setContentsMargins(5, 5, 5, 5);
 	m_midiInputGroupBox = new GroupBox( tr( "ENABLE MIDI INPUT" ) );
 	layout->addWidget( m_midiInputGroupBox );
 

--- a/src/gui/instrument/InstrumentMiscView.cpp
+++ b/src/gui/instrument/InstrumentMiscView.cpp
@@ -44,7 +44,7 @@ InstrumentMiscView::InstrumentMiscView(InstrumentTrack *it, QWidget *parent) :
 	QWidget(parent)
 {
 	auto layout = new QVBoxLayout(this);
-	layout->setMargin(5);
+	layout->setContentsMargins(5, 5, 5, 5);
 
 	// Master pitch toggle
 	m_pitchGroupBox = new GroupBox(tr("GLOBAL TRANSPOSITION"));

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -90,7 +90,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// init own layout + widgets
 	setFocusPolicy( Qt::StrongFocus );
 	auto vlayout = new QVBoxLayout(this);
-	vlayout->setMargin( 0 );
+	vlayout->setContentsMargins(0, 0, 0, 0);
 	vlayout->setSpacing( 0 );
 
 	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
@@ -246,7 +246,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// FUNC tab
 	auto instrumentFunctions = new QWidget(m_tabWidget);
 	auto instrumentFunctionsLayout = new QVBoxLayout(instrumentFunctions);
-	instrumentFunctionsLayout->setMargin( 5 );
+	instrumentFunctionsLayout->setContentsMargins(5, 5, 5, 5);
 	m_noteStackingView = new InstrumentFunctionNoteStackingView( &m_track->m_noteStacking );
 	m_arpeggioView = new InstrumentFunctionArpeggioView( &m_track->m_arpeggio );
 

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -147,7 +147,7 @@ PianoView::PianoView(QWidget *parent) :
 	// create a layout for ourselves
 	auto layout = new QVBoxLayout(this);
 	layout->setSpacing( 0 );
-	layout->setMargin( 0 );
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addSpacing( PIANO_BASE+PW_WHITE_KEY_HEIGHT );
 	layout->addWidget( m_pianoScroll );
 

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -215,7 +215,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 
 	auto btn_layout = new QHBoxLayout(buttons);
 	btn_layout->setSpacing( 0 );
-	btn_layout->setMargin( 0 );
+	btn_layout->setContentsMargins(0, 0, 0, 0);
 
 	auto select_btn = new QPushButton(embed::getIconPixmap("add"), tr("OK"), buttons);
 	connect( select_btn, SIGNAL(clicked()), 

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -213,14 +213,14 @@ void EffectSelectDialog::rowChanged( const QModelIndex & _idx,
 		hbox->addWidget(textualInfoWidget);
 
 		auto textWidgetLayout = new QVBoxLayout(textualInfoWidget);
-		textWidgetLayout->setMargin( 4 );
+		textWidgetLayout->setContentsMargins(4, 4, 4, 4);
 		textWidgetLayout->setSpacing( 0 );
 
 		if ( m_currentSelection.desc->subPluginFeatures )
 		{
 			auto subWidget = new QWidget(textualInfoWidget);
 			auto subLayout = new QVBoxLayout(subWidget);
-			subLayout->setMargin( 4 );
+			subLayout->setContentsMargins(4, 4, 4, 4);
 			subLayout->setSpacing( 0 );
 			m_currentSelection.desc->subPluginFeatures->
 			fillDescriptionWidget( subWidget, &m_currentSelection );

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -175,12 +175,12 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	// Vertical layout.
 	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing(0);
-	vlayout->setMargin(0);
+	vlayout->setContentsMargins(0, 0, 0, 0);
 
 	// Horizontal layout.
 	auto hlayout = new QHBoxLayout(main_w);
 	hlayout->setSpacing(0);
-	hlayout->setMargin(0);
+	hlayout->setContentsMargins(0, 0, 0, 0);
 
 	// Tab bar for the main tabs.
 	m_tabBar = new TabBar(main_w, QBoxLayout::TopToBottom);
@@ -195,7 +195,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	auto general_w = new QWidget(settings_w);
 	auto general_layout = new QVBoxLayout(general_w);
 	general_layout->setSpacing(10);
-	general_layout->setMargin(0);
+	general_layout->setContentsMargins(0, 0, 0, 0);
 	labelWidget(general_w, tr("General"));
 
 	auto addLedCheckBox = [&XDelta, &YDelta, this](const QString& ledText, TabWidget* tw, int& counter,
@@ -324,7 +324,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	auto performance_w = new QWidget(settings_w);
 	auto performance_layout = new QVBoxLayout(performance_w);
 	performance_layout->setSpacing(10);
-	performance_layout->setMargin(0);
+	performance_layout->setContentsMargins(0, 0, 0, 0);
 	labelWidget(performance_w,
 			tr("Performance"));
 
@@ -442,7 +442,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	auto audio_w = new QWidget(settings_w);
 	auto audio_layout = new QVBoxLayout(audio_w);
 	audio_layout->setSpacing(10);
-	audio_layout->setMargin(0);
+	audio_layout->setContentsMargins(0, 0, 0, 0);
 	labelWidget(audio_w,
 			tr("Audio"));
 
@@ -460,7 +460,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 	auto as_w_layout = new QHBoxLayout(as_w);
 	as_w_layout->setSpacing(0);
-	as_w_layout->setMargin(0);
+	as_w_layout->setContentsMargins(0, 0, 0, 0);
 
 #ifdef LMMS_HAVE_JACK
 	m_audioIfaceSetupWidgets[AudioJack::name()] =
@@ -592,7 +592,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	auto midi_w = new QWidget(settings_w);
 	auto midi_layout = new QVBoxLayout(midi_w);
 	midi_layout->setSpacing(10);
-	midi_layout->setMargin(0);
+	midi_layout->setContentsMargins(0, 0, 0, 0);
 	labelWidget(midi_w,
 			tr("MIDI"));
 
@@ -609,7 +609,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 	auto ms_w_layout = new QHBoxLayout(ms_w);
 	ms_w_layout->setSpacing(0);
-	ms_w_layout->setMargin(0);
+	ms_w_layout->setContentsMargins(0, 0, 0, 0);
 
 #ifdef LMMS_HAVE_ALSA
 	m_midiIfaceSetupWidgets[MidiAlsaSeq::name()] =
@@ -709,7 +709,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 	auto paths_layout = new QVBoxLayout(paths_w);
 	paths_layout->setSpacing(10);
-	paths_layout->setMargin(0);
+	paths_layout->setContentsMargins(0, 0, 0, 0);
 
 	labelWidget(paths_w, tr("Paths"));
 
@@ -823,7 +823,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	auto extras_w = new QWidget(this);
 	auto extras_layout = new QHBoxLayout(extras_w);
 	extras_layout->setSpacing(0);
-	extras_layout->setMargin(0);
+	extras_layout->setContentsMargins(0, 0, 0, 0);
 
 	// Restart warning label.
 	restartWarningLbl = new QLabel(

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -82,7 +82,7 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_panningKnob->show();
 
 	m_activityIndicator = new FadeButton(
-		QApplication::palette().color(QPalette::Active, QPalette::Background),
+		QApplication::palette().color(QPalette::Active, QPalette::Window),
 		QApplication::palette().color(QPalette::Active, QPalette::BrightText),
 		QApplication::palette().color(QPalette::Active, QPalette::BrightText).darker(),
 		getTrackSettingsWidget()

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -75,7 +75,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	m_trackSettingsWidget.setAutoFillBackground( true );
 
 	auto layout = new QHBoxLayout(this);
-	layout->setMargin( 0 );
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing( 0 );
 	layout->addWidget( &m_trackOperationsWidget );
 	layout->addWidget( &m_trackSettingsWidget );

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -38,6 +38,7 @@
 #include <QVBoxLayout>
 
 #include "CaptionMenu.h"
+#include "DeprecationHelper.h"
 #include "embed.h"
 #include "GuiApplication.h"
 #include "gui_templates.h"
@@ -179,7 +180,7 @@ void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
 void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 {
 	// switch between integer and fractional step based on cursor position
-	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
+	if (position(event).x() < m_wholeDisplay.width()) { m_intStep = true; }
 	else { m_intStep = false; }
 
 	event->accept();
@@ -239,9 +240,9 @@ void LcdFloatSpinBox::paintEvent(QPaintEvent*)
 	{
 		p.setFont(pointSizeF(p.font(), 6.5));
 		p.setPen(m_wholeDisplay.textShadowColor());
-		p.drawText(width() / 2 - p.fontMetrics().width(m_label) / 2 + 1, height(), m_label);
+		p.drawText(width() / 2 - horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1, height(), m_label);
 		p.setPen(m_wholeDisplay.textColor());
-		p.drawText(width() / 2 - p.fontMetrics().width(m_label) / 2, height() - 1, m_label);
+		p.drawText(width() / 2 - horizontalAdvance(p.fontMetrics(), m_label) / 2, height() - 1, m_label);
 	}
 }
 

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -43,12 +43,12 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 {
 	auto vlayout = new QVBoxLayout(this);
 	vlayout->setSpacing( 0 );
-	vlayout->setMargin( 0 );
+	vlayout->setContentsMargins(0, 0, 0, 0);
 
 	auto num = new QWidget(this);
 	auto num_layout = new QHBoxLayout(num);
 	num_layout->setSpacing( 0 );
-	num_layout->setMargin( 0 );
+	num_layout->setContentsMargins(0, 0, 0, 0);
 
 
 	m_numerator = new LcdSpinBox( 2, num, tr( "Meter Numerator" ) );
@@ -69,7 +69,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	auto den = new QWidget(this);
 	auto den_layout = new QHBoxLayout(den);
 	den_layout->setSpacing( 0 );
-	den_layout->setMargin( 0 );
+	den_layout->setContentsMargins(0, 0, 0, 0);
 
 	m_denominator = new LcdSpinBox( 2, den, tr( "Meter Denominator" ) );
 	m_denominator->setToolTip(tr("Meter denominator"));

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -37,7 +37,7 @@ TabBar::TabBar( QWidget * _parent, QBoxLayout::Direction _dir ) :
 	m_layout( new QBoxLayout( _dir, this ) ),
 	m_exclusive( false )
 {
-	m_layout->setMargin( 8 );
+	m_layout->setContentsMargins(8, 8, 8, 8);
 	m_layout->setSpacing( 0 );
 
 	setLayout( m_layout );

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -60,9 +60,9 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 	setFont( pointSize<8>( font() ) );
 
 	setAutoFillBackground( true );
-	QColor bg_color = QApplication::palette().color( QPalette::Active, QPalette::Background ). darker( 132 );
+	QColor bg_color = QApplication::palette().color( QPalette::Active, QPalette::Window ). darker( 132 );
 	QPalette pal = palette();
-	pal.setColor( QPalette::Background, bg_color );
+	pal.setColor( QPalette::Window, bg_color );
 	setPalette( pal );
 
 }

--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -43,7 +43,7 @@ TimeDisplayWidget::TimeDisplayWidget() :
 	m_milliSecondsLCD( 3, this )
 {
 	m_spinBoxesLayout.setSpacing( 0 );
-	m_spinBoxesLayout.setMargin( 0 );
+	m_spinBoxesLayout.setContentsMargins(0, 0, 0, 0);
 	m_spinBoxesLayout.addWidget( &m_majorLCD );
 	m_spinBoxesLayout.addWidget( &m_minorLCD );
 	m_spinBoxesLayout.addWidget( &m_milliSecondsLCD );


### PR DESCRIPTION
The first part of #6614. I fixed all build errors with Qt 5.15 + `-DQT_DISABLE_DEPRECATED_BEFORE=0x060000`, except the one in `qt5-x11embed`.
Note that this isn't sufficient to make LMMS build with Qt 6 yet.