### PR TITLE
Add control+click selection in Piano Roll editor

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2225,7 +2225,7 @@ void PianoRoll::computeSelectedNotes(bool shift)
 	{
 		for( Note *note : m_midiClip->notes() )
 		{
-			// make a new selection unless they're holding shift
+			// make a new selection unless they're holding shift (or control)
 			if( ! shift )
 			{
 				note->setSelected( false );
@@ -2252,7 +2252,7 @@ void PianoRoll::computeSelectedNotes(bool shift)
 				pos_ticks + len_ticks > sel_pos_start &&
 				pos_ticks < sel_pos_end )
 			{
-				// remove from selection when holding shift
+				// remove from selection when holding shift (or control)
 				bool selected = shift && note->selected();
 				note->setSelected( ! selected);
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2287,7 +2287,7 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 			// select the notes within the selection rectangle and
 			// then destroy the selection rectangle
 			computeSelectedNotes(
-					me->modifiers() & Qt::ShiftModifier );
+					me->modifiers() & (Qt::ShiftModifier | Qt::ControlModifier));
 		}
 		else if( m_action == ActionMoveNote )
 		{


### PR DESCRIPTION
This makes Control+Click select work the same as Shift+Click in the Piano Roll editor.

This is part of #4602, namely: 

> Piano Roll --> Multiple selection of midi notes by pressing "Ctrl" inside the piano roll.