### PR TITLE
[ci skip] Update .clang-format

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,18 +2,22 @@
 Checks: >
   bugprone-macro-parentheses,
   bugprone-macro-repeated-side-effects,
+  modernize-avoid-c-arrays,
+  modernize-loop-convert,
   modernize-redundant-void-arg,
+  modernize-use-auto,
   modernize-use-bool-literals,
   modernize-use-emplace,
   modernize-use-equals-default,
   modernize-use-equals-delete,
   modernize-use-override,
+  modernize-use-using,
   performance-trivially-destructible,
+  readability-braces-around-statements,
   readability-const-return-type,
   readability-identifier-naming,
   readability-misleading-indentation,
-  readability-simplify-boolean-expr,
-  readability-braces-around-statements
+  readability-simplify-boolean-expr
 WarningsAsErrors: ''
 HeaderFilterRegex: '' # don't show errors from headers
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
This adds previously applied checks to the `.clang-format` file and also reorders the checks alphabetically.