### PR TITLE
Make song length only update periodically

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -276,6 +276,7 @@ public:
 	}
 
 	void updateLength();
+	void recalcLength();
 	bar_t length() const
 	{
 		return m_length;
@@ -390,6 +391,8 @@ public slots:
 	void clearProject();
 
 	void addPatternTrack();
+	
+	void checkUpdateLength();
 
 
 private slots:
@@ -485,6 +488,7 @@ private:
 	PlayModes m_playMode;
 	PlayPos m_playPos[Mode_Count];
 	bar_t m_length;
+	bool m_shouldUpdateLength;
 
 	const MidiClip* m_midiClipToPlay;
 	bool m_loopMidiClip;


### PR DESCRIPTION
Currently, when an LMMS project has a large number of clips, moving them around or copy+pasting them causes quite a massive amount of lag.  This lag multiplies when moving/pasting multiple clips, sometimes even causing LMMS to completely freeze for a full minute or more!

The reason for this is a tad embarrassing.  Every time a clip is moved or created, the song length is updated.  When the song length is updated, LMMS checks the length of every single track individually.  When a track's length is checked, it checks the length and location of every single clip it contains.

So, as an example, if your song has 1000 clips in it, and you want to move the song over to the right by 1 measure, LMMS will loop through _one million clips_, solely to calculate the length of the song.  This is obviously ridiculous.

This PR aims to fix this issue by changing as little of the code base as possible.  The `updateLength` function has been changed to simply set a boolean to true to let LMMS know that the song length should be checked again.  Then, approximately once per frame, LMMS checks the state of this boolean, and then updates the song length accordingly.  In the very rare cases where the song length needs to be updated immediately (e.g. upon project export), the new `recalcLength` function is used instead.

- [ ] TODO: Use MainWindow's `periodicUpdate` instead of a separate QTimer