### PR TITLE
Draggable effects

### DIFF
--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -61,6 +61,11 @@ public:
 	}
 
 	static constexpr int DEFAULT_WIDTH = 215;
+	static constexpr int DEFAULT_HEIGHT = 60;
+	
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void mousePressEvent(QMouseEvent* event) override;
+	void mouseReleaseEvent(QMouseEvent* event) override;
 
 public slots:
 	void editControls();
@@ -90,6 +95,8 @@ private:
 	Knob * m_gate;
 	QMdiSubWindow * m_subWindow;
 	EffectControlDialog * m_controlView;
+	
+	bool m_dragging;
 
 } ;
 

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -98,7 +98,7 @@ private:
 	EffectControlDialog * m_controlView;
 	
 	bool m_dragging;
-	QGraphicsOpacityEffect * m_opacityEffect;
+	QGraphicsOpacityEffect* m_opacityEffect;
 
 } ;
 

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -30,6 +30,7 @@
 #include "PluginView.h"
 #include "Effect.h"
 
+class QGraphicsOpacityEffect;
 class QGroupBox;
 class QLabel;
 class QPushButton;
@@ -97,6 +98,7 @@ private:
 	EffectControlDialog * m_controlView;
 	
 	bool m_dragging;
+	QGraphicsOpacityEffect * m_opacityEffect;
 
 } ;
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -239,16 +239,14 @@ void EffectView::mouseReleaseEvent(QMouseEvent* event)
 
 void EffectView::mouseMoveEvent(QMouseEvent* event)
 {
-	if (m_dragging)
+	if (!m_dragging) {return;}
+	if (event->pos().y() < 0)
 	{
-		if (event->pos().y() < 0)
-		{
-			moveUp();
-		}
-		else if (event->pos().y() > EffectView::DEFAULT_HEIGHT)
-		{
-			moveDown();
-		}
+		moveUp();
+	}
+	else if (event->pos().y() > EffectView::DEFAULT_HEIGHT)
+	{
+		moveDown();
 	}
 }
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -48,10 +48,10 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	PluginView( _model, _parent ),
 	m_bg( embed::getIconPixmap( "effect_plugin" ) ),
 	m_subWindow( nullptr ),
-	m_controlView( nullptr ),
-	m_dragging( false )
+	m_controlView(nullptr),
+	m_dragging(false)
 {
-	setFixedSize( EffectView::DEFAULT_WIDTH, EffectView::DEFAULT_HEIGHT );
+	setFixedSize(EffectView::DEFAULT_WIDTH, EffectView::DEFAULT_HEIGHT);
 
 	// Disable effects that are of type "DummyEffect"
 	bool isEnabled = !dynamic_cast<DummyEffect *>( effect() );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -25,9 +25,9 @@
 
 #include <QGraphicsOpacityEffect>
 #include <QLayout>
+#include <QMouseEvent>
 #include <QPushButton>
 #include <QPainter>
-#include <QMouseEvent>
 
 #include "EffectView.h"
 #include "DummyEffect.h"

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <QGraphicsOpacityEffect>
 #include <QLayout>
 #include <QPushButton>
 #include <QPainter>
@@ -118,7 +119,10 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 			m_subWindow->hide();
 		}
 	}
-
+	
+	m_opacityEffect = new QGraphicsOpacityEffect(this);
+	m_opacityEffect->setOpacity(1);
+	setGraphicsEffect(m_opacityEffect);
 
 	//move above vst effect view creation
 	//setModel( _model );
@@ -215,6 +219,7 @@ void EffectView::mousePressEvent(QMouseEvent* event)
 	if (event->button() == Qt::LeftButton)
 	{
 		m_dragging = true;
+		m_opacityEffect->setOpacity(0.3);
 		update();
 	}
 }
@@ -224,20 +229,24 @@ void EffectView::mouseReleaseEvent(QMouseEvent* event)
 	if (event->button() == Qt::LeftButton)
 	{
 		m_dragging = false;
+		m_opacityEffect->setOpacity(1);
 		update();
 	}
 }
 
 void EffectView::mouseMoveEvent(QMouseEvent* event)
 {
-    if (event->pos().y() < 0)
-    {
-		moveUp();
-    }
-    else if (event->pos().y() > EffectView::DEFAULT_HEIGHT)
-    {
-		moveDown();
-    }
+	if (m_dragging)
+	{
+		if (event->pos().y() < 0)
+		{
+			moveUp();
+		}
+		else if (event->pos().y() > EffectView::DEFAULT_HEIGHT)
+		{
+			moveDown();
+		}
+	}
 }
 
 
@@ -245,7 +254,6 @@ void EffectView::mouseMoveEvent(QMouseEvent* event)
 void EffectView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
-	if (m_dragging) {p.setOpacity(0.5);}
 	p.drawPixmap( 0, 0, m_bg );
 
 	QFont f = pointSizeF( font(), 7.5f );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -220,8 +220,8 @@ void EffectView::mousePressEvent(QMouseEvent* event)
 	{
 		m_dragging = true;
 		m_opacityEffect->setOpacity(0.3);
-		QCursor c( Qt::SizeVerCursor );
-		QApplication::setOverrideCursor( c );
+		QCursor c(Qt::SizeVerCursor);
+		QApplication::setOverrideCursor(c);
 		update();
 	}
 }
@@ -239,7 +239,7 @@ void EffectView::mouseReleaseEvent(QMouseEvent* event)
 
 void EffectView::mouseMoveEvent(QMouseEvent* event)
 {
-	if (!m_dragging) {return;}
+	if (!m_dragging) { return; }
 	if (event->pos().y() < 0)
 	{
 		moveUp();

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -23,9 +23,10 @@
  *
  */
 
+#include <QLayout>
 #include <QPushButton>
 #include <QPainter>
-#include <QLayout>
+#include <QMouseEvent>
 
 #include "EffectView.h"
 #include "DummyEffect.h"
@@ -47,9 +48,10 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	PluginView( _model, _parent ),
 	m_bg( embed::getIconPixmap( "effect_plugin" ) ),
 	m_subWindow( nullptr ),
-	m_controlView( nullptr )
+	m_controlView( nullptr ),
+	m_dragging( false )
 {
-	setFixedSize( EffectView::DEFAULT_WIDTH, 60 );
+	setFixedSize( EffectView::DEFAULT_WIDTH, EffectView::DEFAULT_HEIGHT );
 
 	// Disable effects that are of type "DummyEffect"
 	bool isEnabled = !dynamic_cast<DummyEffect *>( effect() );
@@ -208,10 +210,42 @@ void EffectView::contextMenuEvent( QContextMenuEvent * )
 
 
 
+void EffectView::mousePressEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		m_dragging = true;
+		update();
+	}
+}
+
+void EffectView::mouseReleaseEvent(QMouseEvent* event)
+{
+	if (event->button() == Qt::LeftButton)
+	{
+		m_dragging = false;
+		update();
+	}
+}
+
+void EffectView::mouseMoveEvent(QMouseEvent* event)
+{
+    if (event->pos().y() < 0)
+    {
+		moveUp();
+    }
+    else if (event->pos().y() > EffectView::DEFAULT_HEIGHT)
+    {
+		moveDown();
+    }
+}
+
+
 
 void EffectView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
+	if (m_dragging) {p.setOpacity(0.5);}
 	p.drawPixmap( 0, 0, m_bg );
 
 	QFont f = pointSizeF( font(), 7.5f );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -220,6 +220,8 @@ void EffectView::mousePressEvent(QMouseEvent* event)
 	{
 		m_dragging = true;
 		m_opacityEffect->setOpacity(0.3);
+		QCursor c( Qt::SizeVerCursor );
+		QApplication::setOverrideCursor( c );
 		update();
 	}
 }
@@ -230,6 +232,7 @@ void EffectView::mouseReleaseEvent(QMouseEvent* event)
 	{
 		m_dragging = false;
 		m_opacityEffect->setOpacity(1);
+		QApplication::restoreOverrideCursor();
 		update();
 	}
 }


### PR DESCRIPTION
This PR allows users to rearrange effects in the mixer by dragging them up or down, instead of needing to go into the context menu over and over and over again.  The effect's opacity is decreased while it is being dragged as a visual indication of which effect is currently being dragged.