### PR TITLE
Fix EQ effect warnings

### DIFF
--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -742,17 +742,17 @@ void EqCurve::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, 
 		}
 		//compute a QPainterPath
 		m_curve = QPainterPath();
-		//only draw the EQ curve if there are activeHandles
+		//only draw the EQ curve if there are any activeHandles
 		if (activeHandles != 0)
 		{
-			for ( int x = 0; x < m_width ; x++ )
+			for (int x = 0; x < m_width; x++)
 			{
-				mainCurve[x] = ( ( mainCurve[x] / activeHandles ) ) - ( m_heigth/2 );
-				if ( x==0 )
+				mainCurve[x] = ((mainCurve[x] / activeHandles)) - (m_heigth / 2);
+				if (x == 0)
 				{
-					m_curve.moveTo( x, mainCurve[x] );
+					m_curve.moveTo(x, mainCurve[x]);
 				}
-				m_curve.lineTo( x, mainCurve[x] );
+				m_curve.lineTo(x, mainCurve[x]);
 			}
 		}
 		//we cache the curve painting in a pixmap for saving cpu

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -65,7 +65,7 @@ QRectF EqHandle::boundingRect() const
 
 float EqHandle::freqToXPixel( float freq , int w )
 {
-	if (freq == 0) { return 0.0f; }
+	if (typeInfo<float>::isEqual(freq, 0.0f)) { return 0.0f; }
 	float min = log10f( 20 );
 	float max = log10f( 20000 );
 	float range = max - min;

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -741,14 +741,18 @@ void EqCurve::paint( QPainter *painter, const QStyleOptionGraphicsItem *option, 
 		}
 		//compute a QPainterPath
 		m_curve = QPainterPath();
-		for ( int x = 0; x < m_width ; x++ )
+		//only draw the EQ curve if there are activeHandles
+		if (activeHandles != 0)
 		{
-			mainCurve[x] = ( ( mainCurve[x] / activeHandles ) ) - ( m_heigth/2 );
-			if ( x==0 )
+			for ( int x = 0; x < m_width ; x++ )
 			{
-				m_curve.moveTo( x, mainCurve[x] );
+				mainCurve[x] = ( ( mainCurve[x] / activeHandles ) ) - ( m_heigth/2 );
+				if ( x==0 )
+				{
+					m_curve.moveTo( x, mainCurve[x] );
+				}
+				m_curve.lineTo( x, mainCurve[x] );
 			}
-			m_curve.lineTo( x, mainCurve[x] );
 		}
 		//we cache the curve painting in a pixmap for saving cpu
 		QPixmap cacheMap( boundingRect().size().toSize() );

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -65,6 +65,7 @@ QRectF EqHandle::boundingRect() const
 
 float EqHandle::freqToXPixel( float freq , int w )
 {
+	if (freq == 0) { return 0.0f; }
 	float min = log10f( 20 );
 	float max = log10f( 20000 );
 	float range = max - min;


### PR DESCRIPTION
Basically corrects two (math) errors that cause a lot of "QPainterPath::lineTo Invalid coordinates" warnings on the console.

- [ ] the first one is related to when there are no EQ bands active causing a div by 0 and generating the warnings when loading the EQ or changing some parameters.

- [ ] the second one is related to log10f(0) which cause a pole error, returning and invalid x pixel position (the function is called every time audio buffer is processed)

I don't know why git tracks so many changes in the code with the first commit. Just added an if around some existing code.

