### PR TITLE
Make note octave highlight in piano roll obey microtonality

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -149,6 +149,8 @@ public:
 	{
 		return m_midiClip != nullptr;
 	}
+	
+	int trackOctaveSize() const;
 
 	Song::PlayModes desiredPlayModeForAccompany() const;
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -600,7 +600,7 @@ void PianoRoll::markSemiTone(int i, bool fromMenu)
 
 			const int first = chord->isScale() ? 0 : key;
 			const int last = chord->isScale() ? NumKeys : key + chord->last();
-			const int cap = ( chord->isScale() || chord->last() == 0 ) ? KeysPerOctave : chord->last();
+			const int cap = ( chord->isScale() || chord->last() == 0 ) ? trackOctaveSize() : chord->last();
 
 			for( int i = first; i <= last; i++ )
 			{
@@ -936,6 +936,13 @@ void PianoRoll::hideMidiClip( MidiClip* clip )
 		setCurrentMidiClip( nullptr );
 	}
 }
+
+
+int PianoRoll::trackOctaveSize() const
+{
+	return m_midiClip->instrumentTrack()->microtuner()->octaveSize();
+}
+
 
 void PianoRoll::selectRegionFromPixels( int xStart, int xEnd )
 {
@@ -3950,7 +3957,8 @@ QList<int> PianoRoll::getAllOctavesForKey( int keyToMirror ) const
 {
 	QList<int> keys;
 
-	for (int i=keyToMirror % KeysPerOctave; i < NumKeys; i += KeysPerOctave)
+	int trackKeysPerOctave = trackOctaveSize();
+	for (int i=keyToMirror % trackKeysPerOctave; i < NumKeys; i += trackKeysPerOctave)
 	{
 		keys.append(i);
 	}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -600,7 +600,7 @@ void PianoRoll::markSemiTone(int i, bool fromMenu)
 
 			const int first = chord->isScale() ? 0 : key;
 			const int last = chord->isScale() ? NumKeys : key + chord->last();
-			const int cap = ( chord->isScale() || chord->last() == 0 ) ? trackOctaveSize() : chord->last();
+			const int cap = (chord->isScale() || chord->last() == 0) ? trackOctaveSize() : chord->last();
 
 			for( int i = first; i <= last; i++ )
 			{
@@ -3958,7 +3958,7 @@ QList<int> PianoRoll::getAllOctavesForKey( int keyToMirror ) const
 	QList<int> keys;
 
 	int trackKeysPerOctave = trackOctaveSize();
-	for (int i=keyToMirror % trackKeysPerOctave; i < NumKeys; i += trackKeysPerOctave)
+	for (int i = keyToMirror % trackKeysPerOctave; i < NumKeys; i += trackKeysPerOctave)
 	{
 		keys.append(i);
 	}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -940,7 +940,8 @@ void PianoRoll::hideMidiClip( MidiClip* clip )
 
 int PianoRoll::trackOctaveSize() const
 {
-	return m_midiClip->instrumentTrack()->microtuner()->enabled() ? m_midiClip->instrumentTrack()->microtuner()->octaveSize() : KeysPerOctave;
+	auto ut = m_midiClip->instrumentTrack()->microtuner();
+	return ut->enabled() ? ut->octaveSize() : KeysPerOctave;
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -940,7 +940,7 @@ void PianoRoll::hideMidiClip( MidiClip* clip )
 
 int PianoRoll::trackOctaveSize() const
 {
-	return m_midiClip->instrumentTrack()->microtuner()->octaveSize();
+	return m_midiClip->instrumentTrack()->microtuner()->enabled() ? m_midiClip->instrumentTrack()->microtuner()->octaveSize() : KeysPerOctave;
 }
 
 


### PR DESCRIPTION
Highlighting all corresponding note octaves currently highlights every 12 notes.  This PR makes LMMS appropriately highlight the proper note octaves within the current track.