### PR TITLE
Add references to namespaces in `inherits` function call

### DIFF
--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -211,7 +211,7 @@ InstrumentTrackWindow * InstrumentTrackView::topLevelInstrumentTrackWindow()
 				getGUI()->mainWindow()->workspace()->subWindowList(
 											QMdiArea::ActivationHistoryOrder ) )
 	{
-		if( sw->isVisible() && sw->widget()->inherits( "InstrumentTrackWindow" ) )
+		if( sw->isVisible() && sw->widget()->inherits( "lmms::gui::InstrumentTrackWindow" ) )
 		{
 			w = qobject_cast<InstrumentTrackWindow *>( sw->widget() );
 		}


### PR DESCRIPTION
I think that `topLevelInstrumentTrackWindow` function doesn't work properly without this edit.

To test you can try adding TripleOscillator, putting Amplifier effect on it and twisting Volume knob (in Amplifier window) while playing notes with the keyboard. Without the edit notes will not play and with the edit notes will play.

Seems that the bug occured after this was merged: #6174 