### PR TITLE
Add confirm removal on mixer channels

### DIFF
--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -202,6 +202,10 @@ public:
 	// rename channels when moving etc. if they still have their original name
 	void validateChannelName( int index, int oldIndex );
 
+	// check if the index channel receives audio from any other channel
+	// or from any instrument or sample track
+	bool isChannelInUse(int index);
+
 	void toggledSolo();
 	void activateSolo();
 	void deactivateSolo();

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -95,6 +95,7 @@ public:
 
 	// notify the view that a mixer channel was deleted
 	void deleteChannel(int index);
+	bool confirmRemoval(int index);
 
 	// delete all unused channels
 	void deleteUnusedChannels();

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -82,6 +82,7 @@ private slots:
 	void toggleLetPreviewsFinish(bool enabled);
 	void toggleSoloLegacyBehavior(bool enabled);
 	void toggleTrackDeletionWarning(bool enabled);
+	void toggleMixerChannelDeletionWarning(bool enabled);
 	void toggleMMPZ(bool enabled);
 	void toggleDisableBackup(bool enabled);
 	void toggleOpenLastProject(bool enabled);
@@ -141,6 +142,7 @@ private:
 	bool m_letPreviewsFinish;
 	bool m_soloLegacyBehavior;
 	bool m_trackDeletionWarning;
+	bool m_mixerChannelDeletionWarning;
 	bool m_MMPZ;
 	bool m_disableBackup;
 	bool m_openLastProject;

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -828,39 +828,37 @@ void Mixer::validateChannelName( int index, int oldIndex )
 bool Mixer::isChannelInUse(int index)
 {
 	// check if the index mixer channel receives audio from any other channel
-	if (!m_mixerChannels[index]->m_receives.isEmpty()) 
-	{ 
-		return true; 
-	}
-	else
+	if (!m_mixerChannels[index]->m_receives.isEmpty())
 	{
-		TrackContainer::TrackList tracks;
-		tracks += Engine::getSong()->tracks();
-		tracks += Engine::patternStore()->tracks();
+		return true;
+	}
 
-		// check if the destination mixer channel on any track is index mixer channel
-		for (Track* t : tracks)
+	// check if the destination mixer channel on any instrument or sample track is the index mixer channel
+	TrackContainer::TrackList tracks;
+	tracks += Engine::getSong()->tracks();
+	tracks += Engine::patternStore()->tracks();
+
+	for (Track* t : tracks)
+	{
+		if (t->type() == Track::InstrumentTrack)
 		{
-			if (t->type() == Track::InstrumentTrack)
+			auto inst = dynamic_cast<InstrumentTrack*>(t);
+			if (inst->mixerChannelModel()->value() == index)
 			{
-				auto inst = dynamic_cast<InstrumentTrack*>(t);
-				if (inst->mixerChannelModel()->value() == index) 
-				{ 
-					return true; 
-				}
-			}
-			else if (t->type() == Track::SampleTrack)
-			{
-				auto strack = dynamic_cast<SampleTrack*>(t);
-				if (strack->mixerChannelModel()->value() == index) 
-				{ 
-					return true; 
-				}
+				return true;
 			}
 		}
-
-		return false;
+		else if (t->type() == Track::SampleTrack)
+		{
+			auto strack = dynamic_cast<SampleTrack*>(t);
+			if (strack->mixerChannelModel()->value() == index)
+			{
+				return true;
+			}
+		}
 	}
+
+	return false;
 }
 
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -825,5 +825,43 @@ void Mixer::validateChannelName( int index, int oldIndex )
 	}
 }
 
+bool Mixer::isChannelInUse(int index)
+{
+	// check if the index mixer channel receives audio from any other channel
+	if (!m_mixerChannels[index]->m_receives.isEmpty()) 
+	{ 
+		return true; 
+	}
+	else
+	{
+		TrackContainer::TrackList tracks;
+		tracks += Engine::getSong()->tracks();
+		tracks += Engine::patternStore()->tracks();
+
+		// check if the destination mixer channel on any track is index mixer channel
+		for (Track* t : tracks)
+		{
+			if (t->type() == Track::InstrumentTrack)
+			{
+				auto inst = dynamic_cast<InstrumentTrack*>(t);
+				if (inst->mixerChannelModel()->value() == index) 
+				{ 
+					return true; 
+				}
+			}
+			else if (t->type() == Track::SampleTrack)
+			{
+				auto strack = dynamic_cast<SampleTrack*>(t);
+				if (strack->mixerChannelModel()->value() == index) 
+				{ 
+					return true; 
+				}
+			}
+		}
+
+		return false;
+	}
+}
+
 
 } // namespace lmms

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -838,7 +838,7 @@ bool Mixer::isChannelInUse(int index)
 	tracks += Engine::getSong()->tracks();
 	tracks += Engine::patternStore()->tracks();
 
-	for (Track* t : tracks)
+	for (const auto t : tracks)
 	{
 		if (t->type() == Track::InstrumentTrack)
 		{

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -387,7 +387,7 @@ void MixerView::deleteChannel(int index)
 	// can't delete master
 	if( index == 0 ) return;
 
-	// if there is user no confirmation, do nothing
+	// if there is no user confirmation, do nothing
 	if (!confirmRemoval(index))
 	{
 		return;

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -389,7 +389,7 @@ void MixerView::deleteChannel(int index)
 
 	// if there is user no confirmation, do nothing
 	if (!confirmRemoval(index))
-	{ 
+	{
 		return;
 	}
 
@@ -424,9 +424,9 @@ void MixerView::deleteChannel(int index)
 	m_mixerChannelViews.remove(index);
 
 	// select the next channel
-	if (selLine >= m_mixerChannelViews.size()) 
-	{ 
-		selLine = m_mixerChannelViews.size() - 1; 
+	if (selLine >= m_mixerChannelViews.size())
+	{
+		selLine = m_mixerChannelViews.size() - 1;
 	}
 	setCurrentMixerLine(selLine);
 
@@ -440,17 +440,17 @@ bool MixerView::confirmRemoval(int index)
 	if (!needConfirm) { return true; }
 
 	Mixer* mix = Engine::mixer();
-	
+
 	if (!mix->isChannelInUse(index))
-	{ 
+	{
 		// is the channel is not in use, there is no need for user confirmation
 		return true;
 	}
 
 	QString messageRemoveTrack = tr("This Mixer Channel is being used.\n"
-									"Are you sure you want to remove this channel?\n\n" 
+									"Are you sure you want to remove this channel?\n\n"
 									"Warning: This operation can not be undone.");
-										
+
 	QString messageTitleRemoveTrack = tr("Confirm removal");
 	QString askAgainText = tr("Don't ask again");
 	auto askAgainCheckBox = new QCheckBox(askAgainText, nullptr);
@@ -458,7 +458,7 @@ bool MixerView::confirmRemoval(int index)
 		// Invert button state, if it's checked we *shouldn't* ask again
 		ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning", state ? "0" : "1");
 	});
-		
+
 	QMessageBox mb(this);
 	mb.setText(messageRemoveTrack);
 	mb.setWindowTitle(messageTitleRemoveTrack);
@@ -470,8 +470,7 @@ bool MixerView::confirmRemoval(int index)
 
 	int answer = mb.exec();
 
-	if (answer == QMessageBox::Ok) { return true; }
-	return false;
+	return answer == QMessageBox::Ok;
 }
 
 
@@ -484,7 +483,7 @@ void MixerView::deleteUnusedChannels()
 	{
 		if (!mix->isChannelInUse(i))
 		{
-			deleteChannel(i); 
+			deleteChannel(i);
 		}
 	}
 }

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -112,6 +112,8 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 			"app", "sololegacybehavior", "0").toInt()),
 	m_trackDeletionWarning(ConfigManager::inst()->value(
 			"ui", "trackdeletionwarning", "1").toInt()),
+	m_mixerChannelDeletionWarning(ConfigManager::inst()->value(
+			"ui", "mixerchanneldeletionwarning", "1").toInt()),
 	m_MMPZ(!ConfigManager::inst()->value(
 			"app", "nommpz").toInt()),
 	m_disableBackup(!ConfigManager::inst()->value(
@@ -198,6 +200,18 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	general_layout->setContentsMargins(0, 0, 0, 0);
 	labelWidget(general_w, tr("General"));
 
+	// General scroll area.
+	auto generalScroll = new QScrollArea(general_w);
+	generalScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+	generalScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+	// General controls widget.
+	auto generalControls = new QWidget(general_w);
+
+	// Path selectors layout.
+	auto generalControlsLayout = new QVBoxLayout;
+	generalControlsLayout->setSpacing(10);
+
 	auto addLedCheckBox = [&XDelta, &YDelta, this](const QString& ledText, TabWidget* tw, int& counter,
 							  bool initialState, const char* toggledSlot, bool showRestartWarning) {
 		auto checkBox = new LedCheckBox(ledText, tw);
@@ -214,7 +228,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	int counter = 0;
 
 	// GUI tab.
-	auto gui_tw = new TabWidget(tr("Graphical user interface (GUI)"), general_w);
+	auto gui_tw = new TabWidget(tr("Graphical user interface (GUI)"), generalControls);
 
 	addLedCheckBox(tr("Display volume as dBFS "), gui_tw, counter,
 		m_displaydBFS, SLOT(toggleDisplaydBFS(bool)), true);
@@ -236,14 +250,19 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		m_soloLegacyBehavior, SLOT(toggleSoloLegacyBehavior(bool)), false);
 	addLedCheckBox(tr("Show warning when deleting tracks"), gui_tw, counter,
 		m_trackDeletionWarning, SLOT(toggleTrackDeletionWarning(bool)), false);
+	addLedCheckBox(tr("Show warning when deleting a mixer channel that is in use"), gui_tw, counter, 
+		m_mixerChannelDeletionWarning,	SLOT(toggleMixerChannelDeletionWarning(bool)), false);
 
 	gui_tw->setFixedHeight(YDelta + YDelta * counter);
+
+	generalControlsLayout->addWidget(gui_tw);
+	generalControlsLayout->addSpacing(10);
 
 
 	counter = 0;
 
 	// Projects tab.
-	auto projects_tw = new TabWidget(tr("Projects"), general_w);
+	auto projects_tw = new TabWidget(tr("Projects"), generalControls);
 
 	addLedCheckBox(tr("Compress project files by default"), projects_tw, counter,
 		m_MMPZ, SLOT(toggleMMPZ(bool)), true);
@@ -254,8 +273,12 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 
 	projects_tw->setFixedHeight(YDelta + YDelta * counter);
 
+	generalControlsLayout->addWidget(projects_tw);
+	generalControlsLayout->addSpacing(10);
+
+
 	// Language tab.
-	auto lang_tw = new TabWidget(tr("Language"), general_w);
+	auto lang_tw = new TabWidget(tr("Language"), generalControls);
 	lang_tw->setFixedHeight(48);
 	auto changeLang = new QComboBox(lang_tw);
 	changeLang->move(XDelta, 20);
@@ -310,11 +333,15 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 	connect(changeLang, SIGNAL(currentIndexChanged(int)),
 			this, SLOT(showRestartWarning()));
 
+	generalControlsLayout->addWidget(lang_tw);
+	generalControlsLayout->addSpacing(10);
 
 	// General layout ordering.
-	general_layout->addWidget(gui_tw);
-	general_layout->addWidget(projects_tw);
-	general_layout->addWidget(lang_tw);
+	generalControlsLayout->addStretch();
+	generalControls->setLayout(generalControlsLayout);
+	generalScroll->setWidget(generalControls);
+	generalScroll->setWidgetResizable(true);
+	general_layout->addWidget(generalScroll);
 	general_layout->addStretch();
 
 
@@ -896,6 +923,8 @@ void SetupDialog::accept()
 					QString::number(m_soloLegacyBehavior));
 	ConfigManager::inst()->setValue("ui", "trackdeletionwarning",
 					QString::number(m_trackDeletionWarning));
+	ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning", 
+					QString::number(m_mixerChannelDeletionWarning));
 	ConfigManager::inst()->setValue("app", "nommpz",
 					QString::number(!m_MMPZ));
 	ConfigManager::inst()->setValue("app", "disablebackup",
@@ -1015,6 +1044,11 @@ void SetupDialog::toggleLetPreviewsFinish(bool enabled)
 void SetupDialog::toggleTrackDeletionWarning(bool enabled)
 {
 	m_trackDeletionWarning = enabled;
+}
+
+void SetupDialog::toggleMixerChannelDeletionWarning(bool enabled)
+{
+	m_mixerChannelDeletionWarning = enabled;
 }
 
 

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -923,7 +923,7 @@ void SetupDialog::accept()
 					QString::number(m_soloLegacyBehavior));
 	ConfigManager::inst()->setValue("ui", "trackdeletionwarning",
 					QString::number(m_trackDeletionWarning));
-	ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning", 
+	ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning",
 					QString::number(m_mixerChannelDeletionWarning));
 	ConfigManager::inst()->setValue("app", "nommpz",
 					QString::number(!m_MMPZ));

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -250,7 +250,7 @@ SetupDialog::SetupDialog(ConfigTabs tab_to_open) :
 		m_soloLegacyBehavior, SLOT(toggleSoloLegacyBehavior(bool)), false);
 	addLedCheckBox(tr("Show warning when deleting tracks"), gui_tw, counter,
 		m_trackDeletionWarning, SLOT(toggleTrackDeletionWarning(bool)), false);
-	addLedCheckBox(tr("Show warning when deleting a mixer channel that is in use"), gui_tw, counter, 
+	addLedCheckBox(tr("Show warning when deleting a mixer channel that is in use"), gui_tw, counter,
 		m_mixerChannelDeletionWarning,	SLOT(toggleMixerChannelDeletionWarning(bool)), false);
 
 	gui_tw->setFixedHeight(YDelta + YDelta * counter);


### PR DESCRIPTION
Add confirm removal popup when the user calls the action "remove channel" on a mixer channel that is in use (receives audio from other channel or track).
Set a config variable to keep track if the user don't want to be asked again (similar to remove track)
Adding a scroll on settings-general tab because there weren't enough space on the area.