### PR TITLE
Add instrument plugins to Song Editor via right click

### DIFF
--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -63,13 +63,14 @@ public:
 	using PluginKey = Plugin::Descriptor::SubPluginFeatures::Key;
 	PluginDescWidget( const PluginKey & _pk, QWidget * _parent );
 	QString name() const;
-
+	void openInNewInstrumentTrack(QString value);
 
 protected:
 	void enterEvent( QEvent * _e ) override;
 	void leaveEvent( QEvent * _e ) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
+	void contextMenuEvent(QContextMenuEvent * e ) override;
 
 private:
 	constexpr static int DEFAULT_HEIGHT{24};

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -70,7 +70,7 @@ protected:
 	void leaveEvent( QEvent * _e ) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
-	void contextMenuEvent(QContextMenuEvent * e) override;
+	void contextMenuEvent(QContextMenuEvent* e) override;
 
 private:
 	constexpr static int DEFAULT_HEIGHT{24};

--- a/include/PluginBrowser.h
+++ b/include/PluginBrowser.h
@@ -70,7 +70,7 @@ protected:
 	void leaveEvent( QEvent * _e ) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
-	void contextMenuEvent(QContextMenuEvent * e ) override;
+	void contextMenuEvent(QContextMenuEvent * e) override;
 
 private:
 	constexpr static int DEFAULT_HEIGHT{24};

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -291,7 +291,7 @@ void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 }
 
 
-void PluginDescWidget::contextMenuEvent(QContextMenuEvent * e)
+void PluginDescWidget::contextMenuEvent(QContextMenuEvent* e)
 {
 	QMenu contextMenu(this);
 
@@ -308,10 +308,10 @@ void PluginDescWidget::openInNewInstrumentTrack(QString value)
 {
 	TrackContainer* tc = Engine::getSong();
 	
-	InstrumentTrack * it = dynamic_cast<InstrumentTrack*>(
+	auto it = dynamic_cast<InstrumentTrack*>(
 			Track::create(Track::InstrumentTrack,
 							tc));
-	InstrumentLoaderThread *ilt = new InstrumentLoaderThread(
+	auto ilt = new InstrumentLoaderThread(
 				this, it, value);
 	ilt->start();
 }

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -308,11 +308,8 @@ void PluginDescWidget::openInNewInstrumentTrack(QString value)
 {
 	TrackContainer* tc = Engine::getSong();
 	
-	auto it = dynamic_cast<InstrumentTrack*>(
-			Track::create(Track::InstrumentTrack,
-							tc));
-	auto ilt = new InstrumentLoaderThread(
-				this, it, value);
+	auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, tc));
+	auto ilt = new InstrumentLoaderThread(this, it, value);
 	ilt->start();
 }
 

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -27,6 +27,7 @@
 #include <QHeaderView>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QStyleOption>
@@ -34,7 +35,10 @@
 
 #include "embed.h"
 #include "Engine.h"
+#include "InstrumentTrack.h"
+#include "Song.h"
 #include "StringPairDrag.h"
+#include "TrackContainerView.h"
 #include "PluginFactory.h"
 
 namespace lmms::gui
@@ -284,6 +288,32 @@ void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 			QString::fromUtf8(m_pluginKey.desc->name), m_logo, this);
 		leaveEvent( _me );
 	}
+}
+
+
+void PluginDescWidget::contextMenuEvent(QContextMenuEvent * e)
+{
+	QMenu contextMenu(this);
+
+	contextMenu.addAction(
+		tr("Send to new instrument track"),
+		[=]{ openInNewInstrumentTrack(m_pluginKey.desc->name); }
+	);
+	
+	contextMenu.exec(e->globalPos());
+}
+
+
+void PluginDescWidget::openInNewInstrumentTrack(QString value)
+{
+	TrackContainer* tc = Engine::getSong();
+	
+	InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
+			Track::create( Track::InstrumentTrack,
+							tc));
+	InstrumentLoaderThread *ilt = new InstrumentLoaderThread(
+				this, it, value);
+	ilt->start();
 }
 
 

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -308,8 +308,8 @@ void PluginDescWidget::openInNewInstrumentTrack(QString value)
 {
 	TrackContainer* tc = Engine::getSong();
 	
-	InstrumentTrack * it = dynamic_cast<InstrumentTrack *>(
-			Track::create( Track::InstrumentTrack,
+	InstrumentTrack * it = dynamic_cast<InstrumentTrack*>(
+			Track::create(Track::InstrumentTrack,
 							tc));
 	InstrumentLoaderThread *ilt = new InstrumentLoaderThread(
 				this, it, value);

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -294,12 +294,10 @@ void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 void PluginDescWidget::contextMenuEvent(QContextMenuEvent* e)
 {
 	QMenu contextMenu(this);
-
 	contextMenu.addAction(
 		tr("Send to new instrument track"),
 		[=]{ openInNewInstrumentTrack(m_pluginKey.desc->name); }
 	);
-	
 	contextMenu.exec(e->globalPos());
 }
 
@@ -307,7 +305,6 @@ void PluginDescWidget::contextMenuEvent(QContextMenuEvent* e)
 void PluginDescWidget::openInNewInstrumentTrack(QString value)
 {
 	TrackContainer* tc = Engine::getSong();
-	
 	auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::InstrumentTrack, tc));
 	auto ilt = new InstrumentLoaderThread(this, it, value);
 	ilt->start();


### PR DESCRIPTION
There seems to be a recurring trend of drag-and-drop completely breaking within LMMS.  It's been broken in Wayland for years, and it just recently broke for XOrg with GNOME as well in the new Fedora 38.

Being able to add instrument plugins via right click instead of drag-and-drop will allow people with this bug to still be able to make use of LMMS (though automation will still unfortunately be unusable...).
![image](https://user-images.githubusercontent.com/34612565/234387384-0ddbad80-4ce0-4f5c-b272-721f7859e3be.png)
