### PR TITLE
Natural, smooth and zoom-relative scrolling

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -180,8 +180,6 @@ private:
 	ComboBoxModel m_zoomingYModel;
 	ComboBoxModel m_quantizeModel;
 
-	static const QVector<float> m_zoomXLevels;
-
 	FloatModel * m_tensionModel;
 
 	AutomationClip * m_clip;

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -64,6 +64,7 @@ protected:
 	void focusOutEvent( QFocusEvent * _fe ) override;
 	void focusInEvent( QFocusEvent * fe ) override;
 	void resizeEvent( QResizeEvent * _event ) override;
+	void wheelEvent(QWheelEvent* we) override;
 
 
 private:

--- a/include/ScrollHelpers.h
+++ b/include/ScrollHelpers.h
@@ -1,0 +1,81 @@
+/*
+ * ScrollHelpers.h - helper functions for wheel events
+ *
+ * Copyright (c) 2023 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SCROLL_HELPERS_H
+#define SCROLL_HELPERS_H
+
+#include <Qt>
+
+#include "lmms_export.h"
+
+class QWheelEvent;
+
+
+namespace lmms {
+
+
+/*! \brief Mark event as ignored and return true if it matches the orientation
+ *
+ *  Convenience function that may be used for early return in wheelEvent.
+ *  Events that doesn't match the orientation are marked accepted.
+ */
+bool LMMS_EXPORT ignoreScroll(const Qt::Orientation orientation, QWheelEvent* event);
+
+
+
+/*! \brief Return number scrolled steps
+ *
+ *  By default it counts standard scroll wheel steps of 15°.
+ *
+ *  If you intend to round or divide WheelEvent::angleDelta() this function should ALWAYS be used to get proper
+ *  support for mice and trackpads that report scroll in very small values.
+ *
+ *  Only call this function ONCE per event and orientation. Never call it if the event will be ignored.
+ *
+ *  \param event - QWheelEvent to get delta value from.
+ *  \param orientation - Vertical or horizontal.
+ *  \param factor - Scroll speed/precision. If factor=2 it returns 2 for a complete step and 1 for a halfstep.
+ *  \param allowNatural - Whether macOS-style natural scroll should be allowed or inverted to regular scroll.
+ */
+int LMMS_EXPORT getScroll(const QWheelEvent* event, const Qt::Orientation orientation, const float factor,
+	const bool allowNatural);
+
+
+/*! \brief Overload of getScroll
+ *
+ * Returns a positive value if the top of the wheel is moved to the left
+ */
+int LMMS_EXPORT horizontalScroll(const QWheelEvent* event, const float factor = 1, const bool allowNatural = true);
+
+
+/*! \brief Overload of getScroll
+ *
+ *  Returns a positive value if the top of the wheel is rotating away from the hand operating it
+ */
+int LMMS_EXPORT verticalScroll(const QWheelEvent* event, const float factor = 1, const bool allowNatural = true);
+
+
+} // namespace lmms
+
+#endif

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -37,6 +37,7 @@ class QLabel;
 class QMoveEvent;
 class QPushButton;
 class QResizeEvent;
+class QWheelEvent;
 class QWidget;
 
 namespace lmms::gui
@@ -75,6 +76,7 @@ protected:
 	void resizeEvent( QResizeEvent * event ) override;
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
+	void wheelEvent(QWheelEvent* event) override;
 
 signals:
 	void focusLost();

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -40,6 +40,7 @@
 #include "NotePlayHandle.h"
 #include "PathUtil.h"
 #include "PixmapButton.h"
+#include "ScrollHelpers.h"
 #include "Song.h"
 #include "StringPairDrag.h"
 #include "Clipboard.h"
@@ -864,9 +865,14 @@ void AudioFileProcessorWaveView::mouseMoveEvent( QMouseEvent * _me )
 
 
 
-void AudioFileProcessorWaveView::wheelEvent( QWheelEvent * _we )
+void AudioFileProcessorWaveView::wheelEvent(QWheelEvent* we)
 {
-	zoom( _we->angleDelta().y() > 0 );
+	if (ignoreScroll(Qt::Horizontal, we)) { return; }
+
+	int steps = verticalScroll(we);
+	if (steps == 0) { return; }
+
+	zoom(steps < 0);
 	update();
 }
 

--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -38,6 +38,7 @@
 #include "Knob.h"
 #include "MainWindow.h"
 #include "PixmapButton.h"
+#include "ScrollHelpers.h"
 
 namespace lmms::gui
 {
@@ -646,8 +647,10 @@ void CompressorControlDialog::resizeEvent(QResizeEvent *event)
 
 void CompressorControlDialog::wheelEvent(QWheelEvent * event)
 {
+	if (ignoreScroll(Qt::Horizontal, event)) { return; }
+
 	const float temp = m_dbRange;
-	const float dbRangeNew = m_dbRange - copysignf(COMP_GRID_SPACING, event->angleDelta().y());
+	const float dbRangeNew = m_dbRange - COMP_GRID_SPACING * verticalScroll(event);
 	m_dbRange = round(qBound(COMP_GRID_SPACING, dbRangeNew, COMP_GRID_MAX) / COMP_GRID_SPACING) * COMP_GRID_SPACING;
 
 	// Only reset view if the scolling had an effect

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -570,43 +570,19 @@ void EqHandle::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
 
 void EqHandle::wheelEvent( QGraphicsSceneWheelEvent *wevent )
 {
-	float highestBandwich;
-	if( m_type != para )
-	{
-		highestBandwich = 10;
-	}
-	else
-	{
-		highestBandwich = 4;
-	}
+	wevent->setAccepted(wevent->orientation() == Qt::Vertical);
+	if (!wevent->isAccepted()) { return; }
 
-	int numDegrees = wevent->delta() / 120;
-	float numSteps = 0;
-	if( wevent->modifiers() == Qt::ControlModifier )
-	{
-		numSteps = numDegrees * 0.01;
-	}
-	else
-	{
-		 numSteps = numDegrees * 0.15;
-	}
+	float highestBandwidth = m_type != para ? 10 : 4;
 
-	if( wevent->orientation() == Qt::Vertical )
-	{
-		m_resonance = m_resonance + ( numSteps );
+	// TODO check inverted() for natural scrolling when made available
 
-		if( m_resonance < 0.1 )
-		{
-			m_resonance = 0.1;
-		}
+	float wheelStepDelta = 120; // Qt unit
+	float changePerStep = wevent->modifiers() & Qt::ControlModifier ? 0.01f : 0.15f;
+	float change = wevent->delta() / wheelStepDelta * changePerStep;
 
-		if( m_resonance > highestBandwich )
-		{
-			m_resonance = highestBandwich;
-		}
-		emit positionChanged();
-	}
-	wevent->accept();
+	m_resonance = std::clamp(m_resonance + change, 0.1f, highestBandwidth);
+	emit positionChanged();
 }
 
 

--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -31,6 +31,7 @@
 #include "ColorChooser.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
+#include "ScrollHelpers.h"
 #include "VecControls.h"
 
 namespace lmms::gui
@@ -318,10 +319,12 @@ void VectorView::mouseDoubleClickEvent(QMouseEvent *event)
 // Change zoom level using the mouse wheel
 void VectorView::wheelEvent(QWheelEvent *event)
 {
+	if (ignoreScroll(Qt::Horizontal, event)) { return; }
+
 	// Go through integers to avoid accumulating errors
 	const unsigned short old_zoom = round(100 * m_zoom);
 	// Min-max bounds are 20 and 1000 %, step for 15°-increment mouse wheel is 20 %
-	const unsigned short new_zoom = qBound(20, old_zoom + event->angleDelta().y() / 6, 1000);
+	const unsigned short new_zoom = qBound(20, old_zoom + verticalScroll(event, 20), 1000);
 	m_zoom = new_zoom / 100.f;
 	event->accept();
 	m_zoomTimestamp = std::chrono::duration_cast<std::chrono::milliseconds>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(LMMS_SRCS
 	gui/ProjectNotes.cpp
 	gui/RowTableView.cpp
 	gui/SampleTrackWindow.cpp
+	gui/ScrollHelpers.cpp
 	gui/SendButtonIndicator.cpp
 	gui/SideBar.cpp
 	gui/SideBarWidget.cpp

--- a/src/gui/ScrollHelpers.cpp
+++ b/src/gui/ScrollHelpers.cpp
@@ -1,0 +1,90 @@
+/*
+ * ScrollHelpers.cpp - helper functions for wheel events
+ *
+ * Copyright (c) 2023 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "ScrollHelpers.h"
+
+#include <QWheelEvent>
+
+
+namespace lmms {
+
+
+bool ignoreScroll(const Qt::Orientation orientation, QWheelEvent* event)
+{
+	bool hasOtherOrientation = orientation == Qt::Horizontal ? event->angleDelta().y() : event->angleDelta().x();
+	event->setAccepted(hasOtherOrientation);
+	return !hasOtherOrientation;
+}
+
+
+
+
+// TODO: is there a good way to prevent calling this method multiple times with the same event?
+int getScroll(const QWheelEvent* event, const Qt::Orientation orientation, const float factor, const bool allowNatural)
+{
+	static int xRemainder;
+	static int yRemainder;
+
+	int& remainder = orientation == Qt::Horizontal ? xRemainder : yRemainder;
+
+	int delta = orientation == Qt::Horizontal ? event->angleDelta().x() : event->angleDelta().y();
+	if (event->inverted() and !allowNatural)
+	{
+		delta = -delta;
+	}
+
+	// If the wheel changed direction forget the accumulated value
+	if (delta * remainder < 0) { remainder = 0; }
+
+	// A normal scroll wheel click is 15° and Qt counts angle delta in 1/8 of a degree
+	const float deltaPerWheelTick = 120;
+	// Angle delta needed to scroll one step (never more than 15°)
+	const float deltaPerStep = deltaPerWheelTick / std::max(1.0f, factor);
+
+	// Summarize, return whole steps and keep what's left
+	remainder += delta;
+	int steps = remainder / deltaPerStep;
+	remainder -= steps * deltaPerStep;
+
+	return steps;
+}
+
+
+
+
+int horizontalScroll(const QWheelEvent* event, const float factor, const bool allowNatural)
+{
+	return getScroll(event, Qt::Horizontal, factor, allowNatural);
+}
+
+
+
+
+int verticalScroll(const QWheelEvent* event, const float factor, const bool allowNatural)
+{
+	return getScroll(event, Qt::Vertical, factor, allowNatural);
+}
+
+
+} // namespace lmms

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -382,4 +382,18 @@ void SubWindow::resizeEvent( QResizeEvent * event )
 }
 
 
+
+
+/**
+ * @brief SubWindow::wheelEvent
+ *
+ *  Capture all WheelEvents that we receive directly or from our subwidgets.
+ *  Don't let them propagate up further to the MDI area.
+ */
+void SubWindow::wheelEvent(QWheelEvent* event)
+{
+	event->accept();
+}
+
+
 } // namespace lmms::gui

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -48,6 +48,7 @@
 #include "Oscilloscope.h"
 #include "PianoRoll.h"
 #include "PositionLine.h"
+#include "ScrollHelpers.h"
 #include "SubWindow.h"
 #include "TextFloat.h"
 #include "TimeDisplayWidget.h"
@@ -535,31 +536,17 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 void SongEditor::wheelEvent( QWheelEvent * we )
 {
-	if( we->modifiers() & Qt::ControlModifier )
+	if (we->modifiers() & Qt::ControlModifier && we->angleDelta().y())
 	{
-		int z = m_zoomingModel->value();
-
-		if(we->angleDelta().y() > 0)
-		{
-			z++;
-		}
-		else if(we->angleDelta().y() < 0)
-		{
-			z--;
-		}
-		z = qBound( 0, z, m_zoomingModel->size() - 1 );
-
-
 		int x = position(we).x() - m_trackHeadWidth;
 		// bar based on the mouse x-position where the scroll wheel was used
 		int bar = x / pixelsPerBar();
-		// what would be the bar in the new zoom level on the very same mouse x
-		int newBar = x / DEFAULT_PIXELS_PER_BAR / m_zoomLevels[z];
+		// update combobox with zooming-factor
+		m_zoomingModel->setValue(m_zoomingModel->value() + verticalScroll(we));
+		// the bar in the new zoom level on the very same mouse x
+		int newBar = x / pixelsPerBar();
 		// scroll so the bar "selected" by the mouse x doesn't move on the screen
 		m_leftRightScroll->setValue(m_leftRightScroll->value() + bar - newBar);
-
-		// update combobox with zooming-factor
-		m_zoomingModel->setValue( z );
 
 		// update timeline
 		m_song->m_playPos[Song::Mode_PlaySong].m_timeLine->
@@ -567,17 +554,11 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 		// and make sure, all Clip's are resized and relocated
 		realignTracks();
 	}
-
-	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
+	else if (we->angleDelta().x())
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() /30);
-	}
-	else if(we->modifiers() & Qt::ShiftModifier)
-	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() / 30);
+		// Move 2 bars per wheel step at 100% zoom, and more when we zoom out
+		float barsPerStep = 2.0f * DEFAULT_PIXELS_PER_BAR / pixelsPerBar();
+		m_leftRightScroll->setValue(m_leftRightScroll->value() - horizontalScroll(we, barsPerStep, true));
 	}
 	else
 	{

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -738,6 +738,12 @@ void PianoView::resizeEvent(QResizeEvent* event)
 
 
 
+void PianoView::wheelEvent(QWheelEvent* we)
+{
+	QApplication::sendEvent(m_pianoScroll, we);
+}
+
+
 
 /*! \brief Convert a key number to an X coordinate in the piano display view
  *

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -35,6 +35,7 @@
 #include "CaptionMenu.h"
 #include "embed.h"
 #include "gui_templates.h"
+#include "ScrollHelpers.h"
 
 namespace lmms::gui
 {
@@ -227,12 +228,12 @@ void ComboBox::paintEvent( QPaintEvent * _pe )
 
 void ComboBox::wheelEvent( QWheelEvent* event )
 {
-	if( model() )
-	{
-		model()->setInitValue(model()->value() + ((event->angleDelta().y() < 0) ? 1 : -1));
-		update();
-		event->accept();
-	}
+	if (ignoreScroll(Qt::Horizontal, event)) { return; }
+
+	if (!model()) { return; }
+
+	model()->setValue(model()->value() + verticalScroll(event));
+	update();
 }
 
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -54,6 +54,7 @@
 #include "embed.h"
 #include "CaptionMenu.h"
 #include "ConfigManager.h"
+#include "ScrollHelpers.h"
 #include "SimpleTextFloat.h"
 
 namespace lmms::gui
@@ -252,16 +253,17 @@ void Fader::mouseReleaseEvent( QMouseEvent * mouseEvent )
 
 void Fader::wheelEvent ( QWheelEvent *ev )
 {
-	ev->accept();
+	if (ignoreScroll(Qt::Horizontal, ev)) { return; }
 
-	if (ev->angleDelta().y() > 0)
-	{
-		model()->incValue( 1 );
-	}
-	else
-	{
-		model()->incValue( -1 );
-	}
+	if (!model()) { return; }
+
+	// Number of steps in the model
+	const float modelSteps = model()->range() / model()->step<float>();
+	// Scrolling 200 physical steps should take us from start to end
+	const float scrollFactor = modelSteps / 200;
+
+	model()->incValue(verticalScroll(ev, scrollFactor));
+
 	updateTextFloat();
 	s_textFloat->setVisibilityTimeOut( 1000 );
 }

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -45,6 +45,7 @@
 #include "LocaleHelper.h"
 #include "MainWindow.h"
 #include "ProjectJournal.h"
+#include "ScrollHelpers.h"
 #include "SimpleTextFloat.h"
 #include "StringPairDrag.h"
 
@@ -689,10 +690,15 @@ void Knob::paintEvent( QPaintEvent * _me )
 void Knob::wheelEvent(QWheelEvent * we)
 {
 	we->accept();
-	const float stepMult = model()->range() / 2000 / model()->step<float>();
-	const int inc = ((we->angleDelta().y() > 0 ) ? 1 : -1) * ((stepMult < 1 ) ? 1 : stepMult);
-	model()->incValue( inc );
 
+	if (!model()) { return; }
+
+	// Number of steps in the model
+	const float modelSteps = model()->range() / model()->step<float>();
+		// Scrolling 200 physical steps should take us from start to end
+	const float scrollFactor = modelSteps / 200;
+
+	model()->incValue(verticalScroll(we, scrollFactor) - horizontalScroll(we, scrollFactor));
 
 	s_textFloat->setText( displayValue() );
 	s_textFloat->moveGlobal( this, QPoint( width() + 2, 0 ) );

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -43,6 +43,7 @@
 #include "GuiApplication.h"
 #include "gui_templates.h"
 #include "MainWindow.h"
+#include "ScrollHelpers.h"
 
 namespace lmms::gui
 {
@@ -179,12 +180,13 @@ void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
 
 void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 {
+	if (ignoreScroll(Qt::Horizontal, event)) { return; }
+
 	// switch between integer and fractional step based on cursor position
 	if (position(event).x() < m_wholeDisplay.width()) { m_intStep = true; }
 	else { m_intStep = false; }
 
-	event->accept();
-	model()->setValue(model()->value() + ((event->angleDelta().y() > 0) ? 1 : -1) * getStep());
+	model()->setValue(model()->value() + verticalScroll(event) * getStep());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -29,7 +29,7 @@
 
 #include "LcdSpinBox.h"
 #include "CaptionMenu.h"
-
+#include "ScrollHelpers.h"
 
 namespace lmms::gui
 {
@@ -140,8 +140,9 @@ void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 
 void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
-	we->accept();
-	model()->setValue(model()->value() + ((we->angleDelta().y() > 0) ? 1 : -1) * model()->step<int>());
+	if (ignoreScroll(Qt::Horizontal, we)) { return; }
+
+	model()->setValue(model()->value() + verticalScroll(we) * model()->step<int>());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -34,6 +34,7 @@
 #include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"
+#include "ScrollHelpers.h"
 
 namespace lmms::gui
 {
@@ -293,11 +294,14 @@ void TabWidget::wheelEvent( QWheelEvent * we )
 {
 	if(position(we).y() > m_tabheight)
 	{
+		we->ignore();
 		return;
 	}
 
 	we->accept();
-	int dir = (we->angleDelta().y() < 0) ? 1 : -1;
+
+	int steps = 0 - horizontalScroll(we) - verticalScroll(we);
+	int dir = std::clamp(steps, -1, 1);
 	int tab = m_activeTab;
 	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
 	{


### PR DESCRIPTION
### Scrolling overhaul - a.k.a please make zooming usable for me :crying_cat_face:

- Handle smooth scrolling trackpads and mice gracefully (supersedes [#6220](https://github.com/LMMS/lmms/issues/6220))
- Only allow macOS natural scrolling in places where it makes sense
- Scrolling in editors is relative to zoom level
- Minimum scroll speed of Knob and Fader is at least 1% per wheel step
- Only scroll MDI area on empty space or scrollbars
- Discard horizontal scroll in places where it shouldn't be
- Fix bug when scrolling on empty MidiClip
- Remove shift+scroll in favor of Qt's built-in alt+scroll :scream: (see [#5169](https://github.com/LMMS/lmms/issues/5169))

Much of the above is done through the use of a single helper function, inspired by [Qt's docs](https://doc.qt.io/qt-5/qwheelevent.html#angleDelta) and [internal code](https://github.com/qt/qtbase/blob/959800f6de137f6a77c7d5a2741a5bae0638cbd9/src/widgets/widgets/qabstractslider.cpp#L690).

```cpp
knob->incValue(verticalScroll(event, 10));  // scrolling increases knob by 10
```

## Fixes maybe?
- Fixes #3154
- #5511
- #3370 
- #6413
- #5507
  - Doesn't work for me under Gnome/X11, hope it works for macOS

## Things to test

- Scrolling in editors + modifier keys
- Scroll speed of editors at different zoom levels
- Scrolling on widgets like combo box
- Scroll speed of knob and fader
- Natural scrolling on Mac
- Touch pad scrolling





