### PR TITLE
Adding new FX channel while in solo 

### DIFF
--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -192,9 +192,9 @@ Mixer::Mixer() :
 	JournallingObject(),
 	m_mixerChannels()
 {
+	m_lastSoloed = -1;
 	// create master channel
 	createChannel();
-	m_lastSoloed = -1;
 }
 
 
@@ -223,6 +223,13 @@ int Mixer::createChannel()
 
 	// reset channel state
 	clearChannel( index );
+
+	// if there is a soloed channel, mute the new track
+	if (m_lastSoloed != -1 && m_mixerChannels[m_lastSoloed]->m_soloModel.value())
+	{
+		m_mixerChannels[index]->m_muteBeforeSolo = m_mixerChannels[index]->m_muteModel.value();
+		m_mixerChannels[index]->m_muteModel.setValue(true);
+	}
 
 	return index;
 }

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -190,9 +190,9 @@ void MixerChannel::doProcessing()
 Mixer::Mixer() :
 	Model( nullptr ),
 	JournallingObject(),
-	m_mixerChannels()
+	m_mixerChannels(),
+	m_lastSoloed(-1)
 {
-	m_lastSoloed = -1;
 	// create master channel
 	createChannel();
 }


### PR DESCRIPTION
Fixes #6311

When adding a new FX channel (A) and there is a solo'ed FX channel (B), that one (A) is muted. 
So when (B) is un-soloed (A) is un-muted.
