### PR TITLE
Add setAutoQuitDisabled function

### DIFF
--- a/include/Effect.h
+++ b/include/Effect.h
@@ -161,6 +161,10 @@ public:
 	inline void setAutoQuitDisabled(bool state)
 	{
 		m_autoQuitDisabled = state;
+		if (m_autoQuitDisabled && !m_running)
+		{
+			startRunning();
+		}
 	}
 
 	EffectChain * effectChain() const

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -157,6 +157,11 @@ public:
 	{
 		m_noRun = _state;
 	}
+	
+	inline void setAutoQuitDisabled(bool state)
+	{
+		m_autoQuitDisabled = state;
+	}
 
 	EffectChain * effectChain() const
 	{


### PR DESCRIPTION
Sometimes LMMS effects need to run permanently, regardless of the user's "Keep effects running even without input" setting.  This is possible by directly setting the `m_autoQuitDisabled` variable, but a function is required for that to fit the code style guidelines.

An effect can simply run `setAutoQuitDisabled(true);` in its constructor to disable autoquitting.  This function also starts running the effect if it isn't already running, so the user doesn't have to feed it audio input before it turns on (which is necessary for effects that can generate an output without any input).