### PR TITLE
Fix LMMS startup lag with FileBrowser's expandItems

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -235,10 +235,6 @@ void FileBrowser::expandItems( QTreeWidgetItem * item, QList<QString> expandedDi
 	for (int i = 0; i < numChildren; ++i)
 	{
 		QTreeWidgetItem * it = item ? item->child( i ) : m_fileBrowserTreeWidget->topLevelItem(i);
-		if ( m_recurse )
-		{
-			it->setExpanded( true );
-		}
 		auto d = dynamic_cast<Directory*>(it);
 		if (d)
 		{


### PR DESCRIPTION
When an LMMS user's user directory contains a large number of files and directories, LMMS startup can take anywhere from several seconds to a few minutes.  This lag is caused by `it->setExpanded(true);` being run on every item individually (even non-directories).  Removing that part causes files and directories to only be loaded in when needed, which completely removes pretty much all of the lag it generates during startup.

Here's an example of the difference in load times.
https://www.youtube.com/watch?v=HknooMT5rK4