### PR TITLE
Fix uninitialized variable "pCurPreset"

### DIFF
--- a/plugins/Sf2Player/PatchesDialog.cpp
+++ b/plugins/Sf2Player/PatchesDialog.cpp
@@ -154,7 +154,7 @@ void PatchesDialog::setup ( fluid_synth_t * pSynth, int iChan,
 			fluid_preset_t preset;
 			fluid_preset_t *pCurPreset = &preset;
 #else
-			fluid_preset_t *pCurPreset;
+			fluid_preset_t *pCurPreset = nullptr;
 #endif
 			while ((pCurPreset = fluid_sfont_iteration_next_wrapper(pSoundFont, pCurPreset))) {
 				int iBank = fluid_preset_get_banknum(pCurPreset);


### PR DESCRIPTION
Fix the uninitialized variable `pCurPreset` by setting it to `nullptr`

Please note that it looks as if the `nullptr` is now being passed to the `function fluid_sfont_iteration_next_wrapper`. However, the function does not use the parameter anyway and then the variable is set to the result of that function.

Resolves #6639