### PR TITLE
Look for libcarla_native-plugin.dll on Windows

### DIFF
--- a/plugins/CarlaBase/CMakeLists.txt
+++ b/plugins/CarlaBase/CMakeLists.txt
@@ -15,14 +15,13 @@ if(LMMS_HAVE_WEAKCARLA)
     ${CMAKE_CURRENT_SOURCE_DIR}/carla/source/backend
   )
 
+  # force "lib" prefix
   IF(LMMS_BUILD_WIN32)
-      # use carla.dll
-      SET(CMAKE_SHARED_LIBRARY_PREFIX "")
-      SET(CARLA_NATIVE_LIB carla)
-  ELSE()
-      # use libcarla_native-plugin
-      SET(CARLA_NATIVE_LIB carla_native-plugin)
+      SET(CMAKE_SHARED_LIBRARY_PREFIX "lib")
   ENDIF()
+
+  SET(CARLA_NATIVE_LIB carla_native-plugin)
+
   ADD_LIBRARY(${CARLA_NATIVE_LIB} SHARED DummyCarla.cpp)
   TARGET_INCLUDE_DIRECTORIES(${CARLA_NATIVE_LIB} PUBLIC ${CARLA_INCLUDE_DIRS})
   INSTALL(TARGETS ${CARLA_NATIVE_LIB}


### PR DESCRIPTION
Previously, we looked for a file called [`carla.dll`](https://github.com/LMMS/lmms/pull/5713), but this has [changed upstream](https://github.com/LMMS/lmms/issues/5984#issuecomment-1577283226) to `libcarla_native-plugin.dll` to match other OSs.

Closes #5984