### PR TITLE
Extend TabWidget's style sheet options (#6730)

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -187,6 +187,7 @@ lmms--gui--TabWidget {
 	qproperty-tabText: rgba(255, 255, 255, 180);
 	qproperty-tabTitleText: #fff;
 	qproperty-tabSelected: #61666b;
+	qproperty-tabTextSelected: rgba(255, 255, 255, 180);
 	qproperty-tabBackground: #3c434b;
 	qproperty-tabBorder: #3c434b;
 }

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -218,7 +218,8 @@ lmms--gui--TabWidget {
 	background-color: #262b30;
 	qproperty-tabText: rgba(255, 255, 255, 180);
 	qproperty-tabTitleText: #fff;
-	qproperty-tabSelected: #323940;
+	qproperty-tabSelected: #1c4933;
+	qproperty-tabTextSelected: rgba(255, 255, 255, 255);
 	qproperty-tabBackground: #181b1f;
 	qproperty-tabBorder: #181b1f;
 }

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -59,6 +59,7 @@ public:
 	Q_PROPERTY( QColor tabText READ tabText WRITE setTabText)
 	Q_PROPERTY( QColor tabTitleText READ tabTitleText WRITE setTabTitleText)
 	Q_PROPERTY( QColor tabSelected READ tabSelected WRITE setTabSelected)
+	Q_PROPERTY( QColor tabTextSelected READ tabTextSelected WRITE setTabTextSelected)
 	Q_PROPERTY( QColor tabBackground READ tabBackground WRITE setTabBackground)
 	Q_PROPERTY( QColor tabBorder READ tabBorder WRITE setTabBorder)
 
@@ -68,6 +69,8 @@ public:
 	void setTabTitleText( const QColor & c );
 	QColor tabSelected() const;
 	void setTabSelected( const QColor & c );
+	QColor tabTextSelected() const;
+	void setTabTextSelected( const QColor & c );
 	QColor tabBackground() const;
 	void setTabBackground( const QColor & c );
 	QColor tabBorder() const;
@@ -104,6 +107,7 @@ private:
 	QColor m_tabText;       // The color of the tabs' text.
 	QColor m_tabTitleText;  // The color of the TabWidget's title text.
 	QColor m_tabSelected;   // The highlighting color for the selected tab.
+	QColor m_tabTextSelected;// The text color for the selected tab.
 	QColor m_tabBackground; // The TabWidget's background color.
 	QColor m_tabBorder;     // The TabWidget's borders color.
 } ;

--- a/include/TabWidget.h
+++ b/include/TabWidget.h
@@ -40,56 +40,56 @@ class TabWidget : public QWidget
 public:
 	//! @param resizable If true, the widget resizes to fit the size of all tabs
 	//!   If false, all child widget will be cut down to the TabWidget's size
-	TabWidget( const QString & _caption, QWidget * _parent,
-				bool usePixmap = false, bool resizable = false );
+	TabWidget(const QString& caption, QWidget* parent,
+				bool usePixmap = false, bool resizable = false);
 	~TabWidget() override = default;
 
-	void addTab( QWidget * w, const QString & name, const char *pixmap = nullptr, int idx = -1 );
+	void addTab(QWidget* w, const QString& name, const char* pixmap = nullptr, int idx = -1);
 
-	void setActiveTab( int idx );
+	void setActiveTab(int idx);
 
-	int findTabAtPos( const QPoint *pos );
+	int findTabAtPos(const QPoint* pos);
 
 	inline int activeTab() const
 	{
-		return( m_activeTab );
+		return(m_activeTab);
 	}
 
 	// Themeability
-	Q_PROPERTY( QColor tabText READ tabText WRITE setTabText)
-	Q_PROPERTY( QColor tabTitleText READ tabTitleText WRITE setTabTitleText)
-	Q_PROPERTY( QColor tabSelected READ tabSelected WRITE setTabSelected)
-	Q_PROPERTY( QColor tabTextSelected READ tabTextSelected WRITE setTabTextSelected)
-	Q_PROPERTY( QColor tabBackground READ tabBackground WRITE setTabBackground)
-	Q_PROPERTY( QColor tabBorder READ tabBorder WRITE setTabBorder)
+	Q_PROPERTY(QColor tabText READ tabText WRITE setTabText)
+	Q_PROPERTY(QColor tabTitleText READ tabTitleText WRITE setTabTitleText)
+	Q_PROPERTY(QColor tabSelected READ tabSelected WRITE setTabSelected)
+	Q_PROPERTY(QColor tabTextSelected READ tabTextSelected WRITE setTabTextSelected)
+	Q_PROPERTY(QColor tabBackground READ tabBackground WRITE setTabBackground)
+	Q_PROPERTY(QColor tabBorder READ tabBorder WRITE setTabBorder)
 
 	QColor tabText() const;
-	void setTabText( const QColor & c );
+	void setTabText(const QColor & c);
 	QColor tabTitleText() const;
-	void setTabTitleText( const QColor & c );
+	void setTabTitleText(const QColor & c);
 	QColor tabSelected() const;
-	void setTabSelected( const QColor & c );
+	void setTabSelected(const QColor & c);
 	QColor tabTextSelected() const;
-	void setTabTextSelected( const QColor & c );
+	void setTabTextSelected(const QColor & c);
 	QColor tabBackground() const;
-	void setTabBackground( const QColor & c );
+	void setTabBackground(const QColor & c);
 	QColor tabBorder() const;
-	void setTabBorder( const QColor & c );
+	void setTabBorder(const QColor & c);
 
 protected:
-	bool event( QEvent * event ) override;
-	void mousePressEvent( QMouseEvent * _me ) override;
-	void paintEvent( QPaintEvent * _pe ) override;
-	void resizeEvent( QResizeEvent * _re ) override;
-	void wheelEvent( QWheelEvent * _we ) override;
+	bool event(QEvent* event) override;
+	void mousePressEvent(QMouseEvent* me) override;
+	void paintEvent(QPaintEvent* pe) override;
+	void resizeEvent(QResizeEvent* re) override;
+	void wheelEvent(QWheelEvent* we) override;
 	QSize minimumSizeHint() const override;
 	QSize sizeHint() const override;
 
 private:
 	struct widgetDesc
 	{
-		QWidget * w;         // ptr to widget
-		const char * pixmap; // artwork for the widget
+		QWidget* w;         // ptr to widget
+		const char* pixmap; // artwork for the widget
 		QString name;        // name for widget
 		int nwidth;          // width of name when painting (only valid for text tab)
 	} ;

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -48,6 +48,7 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 	m_tabText( 0, 0, 0 ),
 	m_tabTitleText( 0, 0, 0 ),
 	m_tabSelected( 0, 0, 0 ),
+	m_tabTextSelected( 0, 0, 0 ),
 	m_tabBackground( 0, 0, 0 ),
 	m_tabBorder( 0, 0, 0 )
 {
@@ -274,10 +275,15 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 			if( it.key() == m_activeTab )
 			{
 				p.fillRect( tab_x_offset, 2, ( *it ).nwidth - 6, m_tabbarHeight - 4, tabSelected() );
+				p.setPen(tabTextSelected());
+				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
 			}
-
-			// Draw text
-			p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+			else
+			{
+				// Draw text
+				p.setPen( tabText() );
+				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+			}
 		}
 
 		// Next tab's horizontal position
@@ -390,6 +396,18 @@ QColor TabWidget::tabSelected() const
 void TabWidget::setTabSelected( const QColor & c )
 {
 	m_tabSelected = c;
+}
+
+// Return the text color of the selected tab
+QColor TabWidget::tabTextSelected() const
+{
+	return m_tabTextSelected;
+}
+
+// Set the text color of the selected tab
+void TabWidget::setTabTextSelected( const QColor & c )
+{
+	m_tabTextSelected = c;
 }
 
 // Return the color to be used for the TabWidget's background

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -38,19 +38,19 @@
 namespace lmms::gui
 {
 
-TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
+TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 					 bool resizable) :
-	QWidget( parent ),
-	m_resizable( resizable ),
-	m_activeTab( 0 ),
-	m_caption( caption ),
-	m_usePixmap( usePixmap ),
-	m_tabText( 0, 0, 0 ),
-	m_tabTitleText( 0, 0, 0 ),
-	m_tabSelected( 0, 0, 0 ),
-	m_tabTextSelected( 0, 0, 0 ),
-	m_tabBackground( 0, 0, 0 ),
-	m_tabBorder( 0, 0, 0 )
+	QWidget(parent),
+	m_resizable(resizable),
+	m_activeTab(0),
+	m_caption(caption),
+	m_usePixmap(usePixmap),
+	m_tabText(0, 0, 0),
+	m_tabTitleText(0, 0, 0),
+	m_tabSelected(0, 0, 0),
+	m_tabTextSelected(0, 0, 0),
+	m_tabBackground(0, 0, 0),
+	m_tabBorder(0, 0, 0)
 {
 
 	// Create taller tabbar when it's to display artwork tabs
@@ -58,24 +58,24 @@ TabWidget::TabWidget(const QString & caption, QWidget * parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont( pointSize<8>( font() ) );
+	setFont(pointSize<8>(font()));
 
-	setAutoFillBackground( true );
-	QColor bg_color = QApplication::palette().color( QPalette::Active, QPalette::Window ). darker( 132 );
+	setAutoFillBackground(true);
+	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);
 	QPalette pal = palette();
-	pal.setColor( QPalette::Window, bg_color );
-	setPalette( pal );
+	pal.setColor(QPalette::Window, bg_color);
+	setPalette(pal);
 
 }
 
-void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, int idx )
+void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont( pointSize<8>( font() ) );
+	setFont(pointSize<8>(font()));
 
 	// Append tab when position is not given
-	if( idx < 0/* || m_widgets.contains( idx ) == true*/ )
+	if (idx < 0/* || m_widgets.contains(idx) == true*/)
 	{
-		while( m_widgets.contains( ++idx ) == true )
+		while(m_widgets.contains(++idx) == true)
 		{
 		}
 	}
@@ -84,19 +84,19 @@ void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, i
 	int tab_width = horizontalAdvance(fontMetrics(), name) + 10;
 
 	// Register new tab
-	widgetDesc d = { w, pixmap, name, tab_width };
+	widgetDesc d = {w, pixmap, name, tab_width};
 	m_widgets[idx] = d;
 
 	// Position tab's window
 	if (!m_resizable)
 	{
-		w->setFixedSize( width() - 4, height() - m_tabbarHeight );
+		w->setFixedSize(width() - 4, height() - m_tabbarHeight);
 	}
-	w->move( 2, m_tabbarHeight - 1 );
+	w->move(2, m_tabbarHeight - 1);
 	w->hide();
 
 	// Show tab's window if it's active
-	if( m_widgets.contains( m_activeTab ) )
+	if (m_widgets.contains(m_activeTab))
 	{
 		// make sure new tab doesn't overlap current widget
 		m_widgets[m_activeTab].w->show();
@@ -107,15 +107,15 @@ void TabWidget::addTab( QWidget * w, const QString & name, const char *pixmap, i
 
 
 
-void TabWidget::setActiveTab( int idx )
+void TabWidget::setActiveTab(int idx)
 {
-	if( m_widgets.contains( idx ) )
+	if (m_widgets.contains(idx))
 	{
 		int old_active = m_activeTab;
 		m_activeTab = idx;
 		m_widgets[m_activeTab].w->raise();
 		m_widgets[m_activeTab].w->show();
-		if( old_active != idx && m_widgets.contains( old_active ) )
+		if (old_active != idx && m_widgets.contains(old_active))
 		{
 			m_widgets[old_active].w->hide();
 		}
@@ -125,42 +125,42 @@ void TabWidget::setActiveTab( int idx )
 
 
 // Return the index of the tab at position "pos"
-int TabWidget::findTabAtPos( const QPoint *pos )
+int TabWidget::findTabAtPos(const QPoint* pos)
 {
 
-	if( pos->y() > 1 && pos->y() < m_tabbarHeight - 1 )
+	if (pos->y() > 1 && pos->y() < m_tabbarHeight - 1)
 	{
 		int cx = ((m_caption == "") ? 4 : 14) + horizontalAdvance(fontMetrics(), m_caption);
 
-		for( widgetStack::iterator it = m_widgets.begin(); it != m_widgets.end(); ++it )
+		for (widgetStack::iterator it = m_widgets.begin(); it != m_widgets.end(); ++it)
 		{
-			if( pos->x() >= cx && pos->x() <= cx + ( *it ).nwidth )
+			if (pos->x() >= cx && pos->x() <= cx + (*it).nwidth)
 			{
-				return( it.key() );
+				return(it.key());
 			}
-			cx += ( *it ).nwidth;
+			cx += (*it).nwidth;
 		}
 	}
 
 	// Haven't found any tab at position "pos"
-	return( -1 );
+	return(-1);
 }
 
 
 // Overload the QWidget::event handler to display tooltips (from https://doc.qt.io/qt-4.8/qt-widgets-tooltips-example.html)
-bool TabWidget::event(QEvent *event)
+bool TabWidget::event(QEvent* event)
 {
 
-	if ( event->type() == QEvent::ToolTip )
+	if (event->type() == QEvent::ToolTip)
 	{
 		auto helpEvent = static_cast<QHelpEvent*>(event);
 
-		int idx = findTabAtPos( & helpEvent->pos() );
+		int idx = findTabAtPos(& helpEvent->pos());
 
-		if ( idx != -1 )
+		if (idx != -1)
 		{
 			// Display tab's tooltip
-			QToolTip::showText( helpEvent->globalPos(), m_widgets[idx].name );
+			QToolTip::showText(helpEvent->globalPos(), m_widgets[idx].name);
 		}
 		else
 		{
@@ -178,17 +178,17 @@ bool TabWidget::event(QEvent *event)
 
 
 // Activate tab when clicked
-void TabWidget::mousePressEvent( QMouseEvent * me )
+void TabWidget::mousePressEvent(QMouseEvent* me)
 {
 
 	// Find index of tab that has been clicked
 	QPoint pos = me->pos();
-	int idx = findTabAtPos( &pos );
+	int idx = findTabAtPos(&pos);
 
 	// When found, activate tab that has been clicked
-	if ( idx != -1 )
+	if (idx != -1)
 	{
-		setActiveTab( idx );
+		setActiveTab(idx);
 		update();
 		return;
 	}
@@ -197,7 +197,7 @@ void TabWidget::mousePressEvent( QMouseEvent * me )
 
 
 
-void TabWidget::resizeEvent( QResizeEvent * )
+void TabWidget::resizeEvent(QResizeEvent*)
 {
 	if (!m_resizable)
 	{
@@ -211,28 +211,28 @@ void TabWidget::resizeEvent( QResizeEvent * )
 
 
 
-void TabWidget::paintEvent( QPaintEvent * pe )
+void TabWidget::paintEvent(QPaintEvent* pe)
 {
-	QPainter p( this );
-	p.setFont( pointSize<7>( font() ) );
+	QPainter p(this);
+	p.setFont(pointSize<7>(font()));
 
 	// Draw background
 	QBrush bg_color = p.background();
-	p.fillRect( 0, 0, width() - 1, height() - 1, bg_color );
+	p.fillRect(0, 0, width() - 1, height() - 1, bg_color);
 
 	// Draw external borders
-	p.setPen( tabBorder() );
-	p.drawRect( 0, 0, width() - 1, height() - 1 );
+	p.setPen(tabBorder());
+	p.drawRect(0, 0, width() - 1, height() - 1);
 
 	// Draw tabs' bar background
-	p.fillRect( 1, 1, width() - 2, m_tabheight + 2, tabBackground() );
+	p.fillRect(1, 1, width() - 2, m_tabheight + 2, tabBackground());
 
 	// Draw title, if any
-	if( ! m_caption.isEmpty() )
+	if (!m_caption.isEmpty())
 	{
-		p.setFont( pointSize<8>( p.font() ) );
-		p.setPen( tabTitleText() );
-		p.drawText( 5, 11, m_caption );
+		p.setFont(pointSize<8>(p.font()));
+		p.setPen(tabTitleText());
+		p.drawText(5, 11, m_caption);
 	}
 
 	// Calculate the tabs' x (tabs are painted next to the caption)
@@ -242,52 +242,52 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 	widgetStack::iterator first = m_widgets.begin();
 	widgetStack::iterator last = m_widgets.end();
 	int tab_width = width();
-	if ( first != last )
+	if (first != last)
 	{
-		tab_width = ( width() - tab_x_offset ) / std::distance( first, last );
+		tab_width = (width() - tab_x_offset) / std::distance(first, last);
 	}
 
 	// Draw all tabs
-	p.setPen( tabText() );
-	for( widgetStack::iterator it = first ; it != last ; ++it )
+	p.setPen(tabText());
+	for (widgetStack::iterator it = first ; it != last ; ++it)
 	{
 		// Draw a text tab or a artwork tab.
-		if( m_usePixmap )
+		if (m_usePixmap)
 		{
 			// Fixes tab's width, because original size is only correct for text tabs
-			( *it ).nwidth = tab_width;
+			(*it).nwidth = tab_width;
 
 			// Get artwork
-			QPixmap artwork( embed::getIconPixmap( ( *it ).pixmap ) );
+			QPixmap artwork(embed::getIconPixmap((*it).pixmap));
 
 			// Highlight active tab
-			if( it.key() == m_activeTab )
+			if (it.key() == m_activeTab)
 			{
-				p.fillRect( tab_x_offset, 0, ( *it ).nwidth, m_tabbarHeight - 1, tabSelected() );
+				p.fillRect(tab_x_offset, 0, (*it).nwidth, m_tabbarHeight - 1, tabSelected());
 			}
 
 			// Draw artwork
-			p.drawPixmap(tab_x_offset + ( ( *it ).nwidth - artwork.width() ) / 2, 1, artwork );
+			p.drawPixmap(tab_x_offset + ((*it).nwidth - artwork.width()) / 2, 1, artwork);
 		}
 		else
 		{
 			// Highlight tab when active
-			if( it.key() == m_activeTab )
+			if (it.key() == m_activeTab)
 			{
-				p.fillRect( tab_x_offset, 2, ( *it ).nwidth - 6, m_tabbarHeight - 4, tabSelected() );
+				p.fillRect(tab_x_offset, 2, (*it).nwidth - 6, m_tabbarHeight - 4, tabSelected());
 				p.setPen(tabTextSelected());
-				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+				p.drawText(tab_x_offset + 3, m_tabheight + 1, (*it).name);
 			}
 			else
 			{
 				// Draw text
-				p.setPen( tabText() );
-				p.drawText( tab_x_offset + 3, m_tabheight + 1, ( *it ).name );
+				p.setPen(tabText());
+				p.drawText(tab_x_offset + 3, m_tabheight + 1, (*it).name);
 			}
 		}
 
 		// Next tab's horizontal position
-		tab_x_offset += ( *it ).nwidth;
+		tab_x_offset += (*it).nwidth;
 	}
 }
 
@@ -295,9 +295,9 @@ void TabWidget::paintEvent( QPaintEvent * pe )
 
 
 // Switch between tabs with mouse wheel
-void TabWidget::wheelEvent( QWheelEvent * we )
+void TabWidget::wheelEvent(QWheelEvent* we)
 {
-	if(position(we).y() > m_tabheight)
+	if (position(we).y() > m_tabheight)
 	{
 		return;
 	}
@@ -305,15 +305,15 @@ void TabWidget::wheelEvent( QWheelEvent * we )
 	we->accept();
 	int dir = (we->angleDelta().y() < 0) ? 1 : -1;
 	int tab = m_activeTab;
-	while( tab > -1 && static_cast<int>( tab ) < m_widgets.count() )
+	while(tab > -1 && static_cast<int>(tab) < m_widgets.count())
 	{
 		tab += dir;
-		if( m_widgets.contains( tab ) )
+		if (m_widgets.contains(tab))
 		{
 			break;
 		}
 	}
-	setActiveTab( tab );
+	setActiveTab(tab);
 }
 
 
@@ -369,7 +369,7 @@ QColor TabWidget::tabTitleText() const
 }
 
 // Set the color to be used to draw a TabWidget's title text (if any)
-void TabWidget::setTabTitleText( const QColor & c )
+void TabWidget::setTabTitleText(const QColor& c)
 {
 	m_tabTitleText = c;
 }
@@ -381,7 +381,7 @@ QColor TabWidget::tabText() const
 }
 
 // Set the color to be used to draw a TabWidget's text (if any)
-void TabWidget::setTabText( const QColor & c )
+void TabWidget::setTabText(const QColor& c)
 {
 	m_tabText = c;
 }
@@ -393,7 +393,7 @@ QColor TabWidget::tabSelected() const
 }
 
 // Set the color to be used to highlight a TabWidget'selected tab (if any)
-void TabWidget::setTabSelected( const QColor & c )
+void TabWidget::setTabSelected(const QColor& c)
 {
 	m_tabSelected = c;
 }
@@ -405,7 +405,7 @@ QColor TabWidget::tabTextSelected() const
 }
 
 // Set the text color of the selected tab
-void TabWidget::setTabTextSelected( const QColor & c )
+void TabWidget::setTabTextSelected(const QColor& c)
 {
 	m_tabTextSelected = c;
 }
@@ -417,7 +417,7 @@ QColor TabWidget::tabBackground() const
 }
 
 // Set the color to be used for the TabWidget's background
-void TabWidget::setTabBackground( const QColor & c )
+void TabWidget::setTabBackground(const QColor& c)
 {
 	m_tabBackground = c;
 }
@@ -429,7 +429,7 @@ QColor TabWidget::tabBorder() const
 }
 
 // Set the color to be used for the TabWidget's borders
-void TabWidget::setTabBorder( const QColor & c )
+void TabWidget::setTabBorder(const QColor& c)
 {
 	m_tabBorder = c;
 }

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -134,11 +134,13 @@ int TabWidget::findTabAtPos(const QPoint* pos)
 
 		for (widgetStack::iterator it = m_widgets.begin(); it != m_widgets.end(); ++it)
 		{
-			if (pos->x() >= cx && pos->x() <= cx + (*it).nwidth)
+			int const currentWidgetWidth = it->nwidth;
+
+			if (pos->x() >= cx && pos->x() <= cx + currentWidgetWidth)
 			{
 				return(it.key());
 			}
-			cx += (*it).nwidth;
+			cx += currentWidgetWidth;
 		}
 	}
 
@@ -251,43 +253,45 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	p.setPen(tabText());
 	for (widgetStack::iterator it = first ; it != last ; ++it)
 	{
+		auto & currentWidgetDesc = *it;
+
 		// Draw a text tab or a artwork tab.
 		if (m_usePixmap)
 		{
 			// Fixes tab's width, because original size is only correct for text tabs
-			(*it).nwidth = tab_width;
+			currentWidgetDesc.nwidth = tab_width;
 
 			// Get artwork
-			QPixmap artwork(embed::getIconPixmap((*it).pixmap));
+			QPixmap artwork(embed::getIconPixmap(currentWidgetDesc.pixmap));
 
 			// Highlight active tab
 			if (it.key() == m_activeTab)
 			{
-				p.fillRect(tab_x_offset, 0, (*it).nwidth, m_tabbarHeight - 1, tabSelected());
+				p.fillRect(tab_x_offset, 0, currentWidgetDesc.nwidth, m_tabbarHeight - 1, tabSelected());
 			}
 
 			// Draw artwork
-			p.drawPixmap(tab_x_offset + ((*it).nwidth - artwork.width()) / 2, 1, artwork);
+			p.drawPixmap(tab_x_offset + (currentWidgetDesc.nwidth - artwork.width()) / 2, 1, artwork);
 		}
 		else
 		{
 			// Highlight tab when active
 			if (it.key() == m_activeTab)
 			{
-				p.fillRect(tab_x_offset, 2, (*it).nwidth - 6, m_tabbarHeight - 4, tabSelected());
+				p.fillRect(tab_x_offset, 2, currentWidgetDesc.nwidth - 6, m_tabbarHeight - 4, tabSelected());
 				p.setPen(tabTextSelected());
-				p.drawText(tab_x_offset + 3, m_tabheight + 1, (*it).name);
+				p.drawText(tab_x_offset + 3, m_tabheight + 1, currentWidgetDesc.name);
 			}
 			else
 			{
 				// Draw text
 				p.setPen(tabText());
-				p.drawText(tab_x_offset + 3, m_tabheight + 1, (*it).name);
+				p.drawText(tab_x_offset + 3, m_tabheight + 1, currentWidgetDesc.name);
 			}
 		}
 
 		// Next tab's horizontal position
-		tab_x_offset += (*it).nwidth;
+		tab_x_offset += currentWidgetDesc.nwidth;
 	}
 }
 


### PR DESCRIPTION
Extend the `TabWidget` class so that the text color of the selected tab can be set in the style sheet. Adjust the paint method to make use of the new property.

Adjust the default style sheet as follows:
* Background color of the selected tab is the green of the knobs
* Text color of the selected tab is full on white

Adjust the classic style sheet in such a way that nothing changes, i.e. the text colors of the selected tab and the other ones are the same.

Fixes https://github.com/LMMS/lmms/issues/6730