### PR TITLE
Partially revert #6721, improve performance of Directory::addItems

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -235,7 +235,7 @@ void FileBrowser::expandItems(QTreeWidgetItem * item, QList<QString> expandedDir
 	for (int i = 0; i < numChildren; ++i)
 	{
 		QTreeWidgetItem * it = item ? item->child(i) : m_fileBrowserTreeWidget->topLevelItem(i);
-		Directory *d = dynamic_cast<Directory *>(it);
+		Directory *d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
 			if (m_recurse)

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1008,39 +1008,27 @@ bool Directory::addItems(const QString& path)
 
     treeWidget()->setUpdatesEnabled(false);
 
-    QStringList directories;
-    QStringList files;
-
-    QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
+    QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware | QDir::DirsFirst | QDir::Name);
     for (auto& entry : entries)
     {
         QString fileName = entry.fileName();
         if (entry.isDir())
         {
-            directories.append(fileName);
+            auto dir = new Directory(fileName, path, m_filter);
+            addChild(dir);
+            m_dirCount++;
         }
         else if (entry.isFile() && thisDir.match(m_filter, fileName.toLower()))
         {
-            files.append(fileName);
+            auto fileItem = new FileItem(fileName, path);
+            addChild(fileItem);
         }
     }
-
-    for (auto& dirName : directories)
-    {
-        auto dir = new Directory(dirName, path, m_filter);
-        addChild(dir);
-        m_dirCount++;
-    }
-
-    for (auto& fileName : files)
-    {
-        auto fileItem = new FileItem(fileName, path);
-        addChild(fileItem);
-    }
-
+    
     treeWidget()->setUpdatesEnabled(true);
-
-    return !(directories.isEmpty() && files.isEmpty());
+    
+    // return true if we added any child items
+    return childCount() > 0;
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1033,7 +1033,6 @@ bool Directory::addItems(const QString& path)
     }
 
     directories.sort(Qt::CaseInsensitive);
-
     for (const QString& dirName : directories)
     {
         Directory* dir = new Directory(dirName, path, m_filter);

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -234,16 +234,12 @@ void FileBrowser::expandItems(QTreeWidgetItem * item, QList<QString> expandedDir
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
 	for (int i = 0; i < numChildren; ++i)
 	{
-		QTreeWidgetItem * it = item ? item->child(i) : m_fileBrowserTreeWidget->topLevelItem(i);
-		Directory *d = dynamic_cast<Directory*>(it);
+		auto it = item ? item->child(i) : m_fileBrowserTreeWidget->topLevelItem(i);
+		auto d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
-			if (m_recurse)
-			{
-				d->setExpanded(true);
-			}
-			bool expand = expandedDirs.contains(d->fullName());
-			d->setExpanded(expand);
+			if (m_recurse) { d->setExpanded(true); }
+			d->setExpanded(expandedDirs.contains(d->fullName()));
 			if (m_recurse && it->childCount())
 			{
 				expandItems(it, expandedDirs);
@@ -1008,10 +1004,7 @@ void Directory::update()
 bool Directory::addItems(const QString& path)
 {
     QDir thisDir(path);
-    if (!thisDir.isReadable())
-    {
-        return false;
-    }
+    if (!thisDir.isReadable()) { return false; }
 
     treeWidget()->setUpdatesEnabled(false);
 
@@ -1019,37 +1012,35 @@ bool Directory::addItems(const QString& path)
     QStringList files;
 
     QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot);
-    for (const QFileInfo& entry : entries)
+    for (auto& entry : entries)
     {
         QString fileName = entry.fileName();
-        if (entry.isDir() && fileName[0] != '.')
+        if (entry.isDir())
         {
             directories.append(fileName);
         }
-        else if (entry.isFile() && fileName[0] != '.' && thisDir.match(m_filter, fileName.toLower()))
+        else if (entry.isFile() && thisDir.match(m_filter, fileName.toLower()))
         {
             files.append(fileName);
         }
     }
 
-    directories.sort(Qt::CaseInsensitive);
     for (const QString& dirName : directories)
     {
-        Directory* dir = new Directory(dirName, path, m_filter);
+        auto dir = new Directory(dirName, path, m_filter);
         addChild(dir);
         m_dirCount++;
     }
 
-    files.sort(Qt::CaseInsensitive);
     for (const QString& fileName : files)
     {
-        FileItem* fileItem = new FileItem(fileName, path);
+        auto fileItem = new FileItem(fileName, path);
         addChild(fileItem);
     }
 
     treeWidget()->setUpdatesEnabled(true);
 
-    return !directories.isEmpty() || !files.isEmpty();
+    return !(directories.isEmpty() && files.isEmpty());
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1025,14 +1025,14 @@ bool Directory::addItems(const QString& path)
         }
     }
 
-    for (const QString& dirName : directories)
+    for (auto& dirName : directories)
     {
         auto dir = new Directory(dirName, path, m_filter);
         addChild(dir);
         m_dirCount++;
     }
 
-    for (const QString& fileName : files)
+    for (auto& fileName : files)
     {
         auto fileItem = new FileItem(fileName, path);
         addChild(fileItem);

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -238,6 +238,7 @@ void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs
 		auto d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
+			// Expanding is required when recursive to load in its contents, even if it's collapsed right afterward
 			if (m_recurse) { d->setExpanded(true); }
 			d->setExpanded(expandedDirs.contains(d->fullName()));
 			if (m_recurse && it->childCount())
@@ -1003,32 +1004,32 @@ void Directory::update()
 
 bool Directory::addItems(const QString& path)
 {
-    QDir thisDir(path);
-    if (!thisDir.isReadable()) { return false; }
+	QDir thisDir(path);
+	if (!thisDir.isReadable()) { return false; }
 
-    treeWidget()->setUpdatesEnabled(false);
+	treeWidget()->setUpdatesEnabled(false);
 
-    QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware | QDir::DirsFirst | QDir::Name);
-    for (auto& entry : entries)
-    {
-        QString fileName = entry.fileName();
-        if (entry.isDir())
-        {
-            auto dir = new Directory(fileName, path, m_filter);
-            addChild(dir);
-            m_dirCount++;
-        }
-        else if (entry.isFile() && thisDir.match(m_filter, fileName.toLower()))
-        {
-            auto fileItem = new FileItem(fileName, path);
-            addChild(fileItem);
-        }
-    }
-    
-    treeWidget()->setUpdatesEnabled(true);
-    
-    // return true if we added any child items
-    return childCount() > 0;
+	QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware | QDir::DirsFirst | QDir::Name);
+	for (auto& entry : entries)
+	{
+		QString fileName = entry.fileName();
+		if (entry.isDir())
+		{
+			auto dir = new Directory(fileName, path, m_filter);
+			addChild(dir);
+			m_dirCount++;
+		}
+		else if (entry.isFile() && thisDir.match(m_filter, fileName.toLower()))
+		{
+			auto fileItem = new FileItem(fileName, path);
+			addChild(fileItem);
+		}
+	}
+	
+	treeWidget()->setUpdatesEnabled(true);
+	
+	// return true if we added any child items
+	return childCount() > 0;
 }
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -229,13 +229,13 @@ void FileBrowser::reloadTree()
 
 
 
-void FileBrowser::expandItems( QTreeWidgetItem * item, QList<QString> expandedDirs )
+void FileBrowser::expandItems(QTreeWidgetItem * item, QList<QString> expandedDirs)
 {
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
 	for (int i = 0; i < numChildren; ++i)
 	{
-		QTreeWidgetItem * it = item ? item->child( i ) : m_fileBrowserTreeWidget->topLevelItem(i);
-		Directory *d = dynamic_cast<Directory *> ( it );
+		QTreeWidgetItem * it = item ? item->child(i) : m_fileBrowserTreeWidget->topLevelItem(i);
+		Directory *d = dynamic_cast<Directory *>(it);
 		if (d)
 		{
 			if (m_recurse)

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -229,7 +229,7 @@ void FileBrowser::reloadTree()
 
 
 
-void FileBrowser::expandItems(QTreeWidgetItem * item, QList<QString> expandedDirs)
+void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs)
 {
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
 	for (int i = 0; i < numChildren; ++i)


### PR DESCRIPTION
#6721 was merged quite a bit faster than I expected, and unfortunately its incompatibility with the search bar wasn't noticed by anybody until I was messing with things the day after.  As an apology, I spent far too many hours on figuring out how I can optimize FileBrowser performance without lazy loading breaking the search bar.

This PR fixes that issue, and includes a full rewrite of Directory::addItems to massively increase its performance.  On my system, LMMS can load in over 10,000 directories with one file each in 16 seconds with the old (pre-#6721) behavior, and 4 seconds with this PR applied, so you can expect it to run around 4x as fast on average.  This will improve both FileBrowser reload times and LMMS opening times.

Fixes #6734.