### PR TITLE
Remove redundant nameChanged signal from InstrumentTrack

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -244,7 +244,6 @@ signals:
 	void instrumentChanged();
 	void midiNoteOn( const lmms::Note& );
 	void midiNoteOff( const lmms::Note& );
-	void nameChanged();
 	void newNote();
 	void endNote();
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -609,8 +609,6 @@ void InstrumentTrack::setName( const QString & _new_name )
 	Track::setName( _new_name );
 	m_midiPort.setName( name() );
 	m_audioPort.setName( name() );
-
-	emit nameChanged();
 }
 
 


### PR DESCRIPTION
Noticed a bunch of these messages:
```
QMetaObject::indexOfSignal: signal nameChanged() from lmms::Track redefined in lmms::InstrumentTrack
```

This removes the signal from `InstrumentTrack` since it gets it from inheritance (`InstrumentTrack : public Track` and `nameChanged` is in public scope).

Also, since `Track::setName` emits `nameChanged` this removes a second emit of the same signal.