### PR TITLE
Detect hiir fetch

### DIFF
--- a/cmake/modules/CheckSubmodules.cmake
+++ b/cmake/modules/CheckSubmodules.cmake
@@ -18,7 +18,7 @@
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
 # Files which confirm a successful clone
-SET(VALID_CRUMBS "CMakeLists.txt;Makefile;Makefile.in;Makefile.am;configure.ac;configure.py;autogen.sh;.gitignore;LICENSE;Home.md")
+SET(VALID_CRUMBS "CMakeLists.txt;Makefile;Makefile.in;Makefile.am;configure.ac;configure.py;autogen.sh;.gitignore;LICENSE;Home.md;license.txt")
 
 OPTION(NO_SHALLOW_CLONE "Disable shallow cloning of submodules" OFF)
 


### PR DESCRIPTION
Add a crumb for detecting that `hiir` is already present

This helps nixpkgs packaging: Failing to detect that hiir is already present triggers git-submodule fetching, which fails when building from a git-archive rather than a git checkout, and wouldn't have been able to reach the internet from inside the nix build sandbox anyway.