### PR TITLE
Fix occasional crash when clicking the key ComboBox in Piano Roll with no clip

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -941,6 +941,7 @@ void PianoRoll::hideMidiClip( MidiClip* clip )
 
 int PianoRoll::trackOctaveSize() const
 {
+	if (!m_midiClip) { return KeysPerOctave; }
 	auto ut = m_midiClip->instrumentTrack()->microtuner();
 	return ut->enabled() ? ut->octaveSize() : KeysPerOctave;
 }


### PR DESCRIPTION
If I open the Piano Roll without a clip, sometimes I can cause a crash when I click the key ComboBox.

The crash occurs when `PianoRoll::trackOctaveSize()` tries to dereference the pointer `m_midiClip` without first checking if it is null.
This PR simply adds a null pointer check to fix the crash.

#### gdb backtrace
<details>
  <summary>Click to expand</summary>
<pre>
Thread 1 "lmms" received signal SIGSEGV, Segmentation fault.
0x00005555559623b0 in lmms::MidiClip::instrumentTrack (this=0x0) at /home/dalton/Documents/lmms_testing/clip-improvement-dev/include/MidiClip.h:105
105                     return m_instrumentTrack;
(gdb) bt
#0  0x00005555559623b0 in lmms::MidiClip::instrumentTrack() const (this=0x0) at /home/dalton/Documents/lmms_testing/clip-improvement-dev/include/MidiClip.h:105
#1  0x000055555594596d in lmms::gui::PianoRoll::trackOctaveSize() const (this=0x555557511a00)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/gui/editors/PianoRoll.cpp:946
#2  0x0000555555943da5 in lmms::gui::PianoRoll::markSemiTone(int, bool) (this=0x555557511a00, i=3, fromMenu=false)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/gui/editors/PianoRoll.cpp:606
#3  0x0000555555955170 in lmms::gui::PianoRoll::keyChanged() (this=0x555557511a00) at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/gui/editors/PianoRoll.cpp:4605
#4  0x0000555555967b02 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (lmms::gui::PianoRoll::*)()>::call(void (lmms::gui::PianoRoll::*)(), lmms::gui::PianoRoll*, void**) (f=(void (lmms::gui::PianoRoll::*)(lmms::gui::PianoRoll * const)) 0x55555595514a <lmms::gui::PianoRoll::keyChanged()>, o=0x555557511a00, arg=0x7fffffffc9e0)
    at /home/dalton/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:152
#5  0x0000555555966f55 in QtPrivate::FunctionPointer<void (lmms::gui::PianoRoll::*)()>::call<QtPrivate::List<>, void>(void (lmms::gui::PianoRoll::*)(), lmms::gui::PianoRoll*, void**)
    (f=(void (lmms::gui::PianoRoll::*)(lmms::gui::PianoRoll * const)) 0x55555595514a <lmms::gui::PianoRoll::keyChanged()>, o=0x555557511a00, arg=0x7fffffffc9e0)
    at /home/dalton/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:185
#6  0x0000555555965975 in QtPrivate::QSlotObject<void (lmms::gui::PianoRoll::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*)
    (which=1, this_=0x555557524410, r=0x555557511a00, a=0x7fffffffc9e0, ret=0x0) at /home/dalton/Qt/5.15.2/gcc_64/include/QtCore/qobjectdefs_impl.h:418
#7  0x00007ffff5cd5f30 in QtPrivate::QSlotObjectBase::call(QObject*, void**) (a=0x7fffffffc9e0, r=0x555557511a00, this=<optimized out>)
--Type <RET> for more, q to quit, c to continue without paging--
    at ../../include/QtCore/../../src/corelib/kernel/qobjectdefs_impl.h:398
#8  doActivate<false>(QObject*, int, void**) (sender=0x555557511e70, signal_index=3, argv=0x7fffffffc9e0) at kernel/qobject.cpp:3886
#9  0x000055555578c38b in lmms::Model::dataChanged() (this=0x555557511e70)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/build/src/lmmsobjs_autogen/DGKZTCOIDE/moc_Model.cpp:154
#10 0x00005555557b2cee in lmms::AutomatableModel::setValue(float) (this=0x555557511e70, value=1)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/core/AutomatableModel.cpp:318
#11 0x00005555557b3ebe in lmms::AutomatableModel::setInitValue(float) (this=0x555557511e70, value=1)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/core/AutomatableModel.cpp:704
#12 0x00005555559c22da in lmms::gui::ComboBox::selectNext() (this=0x55555755c6e0) at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/gui/widgets/ComboBox.cpp:89
#13 0x00005555559c27df in lmms::gui::ComboBox::mousePressEvent(QMouseEvent*) (this=0x55555755c6e0, event=0x7fffffffcfb0)
    at /home/dalton/Documents/lmms_testing/clip-improvement-dev/src/gui/widgets/ComboBox.cpp:154
</pre>
</details>
