### PR TITLE
Fix scale highlighting with vertical zooming

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3355,11 +3355,11 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		for(x = 0; x < m_markedSemiTones.size(); ++x)
 		{
 			const int key_num = m_markedSemiTones.at(x);
-			const int y = keyAreaBottom() + 5 - m_keyLineHeight *
+			const int y = keyAreaBottom() - 1 - m_keyLineHeight *
 				(key_num - m_startKey + 1);
 			if(y > keyAreaBottom()) { break; }
 			p.fillRect(m_whiteKeyWidth + 1,
-				y - m_keyLineHeight / 2,
+				y,
 				width() - 10,
 				m_keyLineHeight + 1,
 				m_markedSemitoneColor);


### PR DESCRIPTION
Vertically zooming the piano roll caused highlighted semitones to drift from the actual note positions. This 2-line fix ensures the marked semitones are aligned with the grid lines and notes at all available vertical zoom levels.

![02-07-23-scale-fix](https://github.com/LMMS/lmms/assets/53168336/eb161d6c-ec97-4f0d-8ff3-ade9c8cb13e5)

Although this works on my low-resolution linux device, I am unable to test if display scaling (e.g. for 4k screens), OS differences (or other factors I have not considered) play well with this patch. 

This might conflict with other pull requests that affect the piano roll like #6700 