### PR TITLE
Add missing keyboard shortcuts

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -924,6 +924,9 @@ int main( int argc, char * * argv )
 			// set icons
 			recover->setIcon( embed::getIconPixmap( "recover" ) );
 			discard->setIcon( embed::getIconPixmap( "discard" ) );
+			
+			// add shortcut to discard
+			discard->setShortcut(Qt::CTRL + Qt::Key_D);
 
 			mb.setDefaultButton( recover );
 			mb.setEscapeButton( exit );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -316,7 +316,8 @@ void MainWindow::finalize()
 	project_menu->addAction( embed::getIconPixmap( "project_import" ),
 					tr( "Import..." ),
 					this,
-					SLOT(onImportProject()));
+					SLOT(onImportProject()),
+					Qt::CTRL + Qt::Key_I );
 	project_menu->addAction( embed::getIconPixmap( "project_export" ),
 					tr( "E&xport..." ),
 					this,

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -635,15 +635,16 @@ bool MainWindow::mayChangeProject(bool stopPlayback)
 					"last saving. Do you want to save it "
 								"now?" );
 
-	QMessageBox mb( ( getSession() == Recover ?
-				messageTitleRecovered : messageTitleUnsaved ),
-			( getSession() == Recover ?
-					messageRecovered : messageUnsaved ),
-				QMessageBox::Question,
-				QMessageBox::Save,
-				QMessageBox::Discard,
-				QMessageBox::Cancel,
-				this );
+	QMessageBox mb;
+	mb.setWindowTitle( getSession() == Recover ? messageTitleRecovered : messageTitleUnsaved );
+	mb.setText( getSession() == Recover ? messageRecovered : messageUnsaved );
+	mb.setIcon( QMessageBox::Question );
+
+	mb.addButton(QMessageBox::Save);
+	QAbstractButton * discardButton = mb.addButton(QMessageBox::Discard);
+	discardButton->setShortcut(Qt::CTRL + Qt::Key_D);
+	mb.addButton(QMessageBox::Cancel);
+
 	int answer = mb.exec();
 
 	if( answer == QMessageBox::Save )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4779,7 +4779,7 @@ PianoRollWindow::PianoRollWindow() :
 	auto quantizeButton = new QToolButton(notesActionsToolBar);
 	auto quantizeButtonMenu = new QMenu(quantizeButton);
 
-	auto quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize"), this);
+	auto quantizeAction = new QAction(embed::getIconPixmap("quantize"), tr("Quantize (Shift+Q)"), this);
 	auto quantizePosAction = new QAction(tr("Quantize positions"), this);
 	auto quantizeLengthAction = new QAction(tr("Quantize lengths"), this);
 
@@ -4792,6 +4792,8 @@ PianoRollWindow::PianoRollWindow() :
 	quantizeButton->setMenu(quantizeButtonMenu);
 	quantizeButtonMenu->addAction(quantizePosAction);
 	quantizeButtonMenu->addAction(quantizeLengthAction);
+
+	quantizeAction->setShortcut( Qt::SHIFT | Qt::Key_Q );
 
 	notesActionsToolBar->addAction( drawAction );
 	notesActionsToolBar->addAction( eraseAction );

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -53,6 +53,7 @@
 #include "TimeDisplayWidget.h"
 #include "TimeLineWidget.h"
 #include "TrackView.h"
+#include "qnamespace.h"
 
 namespace lmms::gui
 {
@@ -983,6 +984,8 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_removeBarAction = new QAction(embed::getIconPixmap("remove_bar"), tr("Remove bar"), this);
 	insertActionsToolBar->addAction( m_insertBarAction );
 	insertActionsToolBar->addAction( m_removeBarAction );
+	m_insertBarAction->setShortcut(Qt::CTRL + Qt::Key_B);
+	m_removeBarAction->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_B);
 	connect(m_insertBarAction, SIGNAL(triggered()), song, SLOT(insertBar()));
 	connect(m_removeBarAction, SIGNAL(triggered()), song, SLOT(removeBar()));
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -980,8 +980,8 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 	m_editor->m_timeLine->addToolButtons(timeLineToolBar);
 
 	DropToolBar *insertActionsToolBar = addDropToolBarToTop(tr("Bar insert controls"));
-	m_insertBarAction = new QAction(embed::getIconPixmap("insert_bar"), tr("Insert bar"), this);
-	m_removeBarAction = new QAction(embed::getIconPixmap("remove_bar"), tr("Remove bar"), this);
+	m_insertBarAction = new QAction(embed::getIconPixmap("insert_bar"), tr("Insert bar (Ctrl+B)"), this);
+	m_removeBarAction = new QAction(embed::getIconPixmap("remove_bar"), tr("Remove bar (Ctrl+Shift+B)"), this);
 	insertActionsToolBar->addAction( m_insertBarAction );
 	insertActionsToolBar->addAction( m_removeBarAction );
 	m_insertBarAction->setShortcut(Qt::CTRL + Qt::Key_B);


### PR DESCRIPTION
This PR aims to improve ease of usability throughout the DAW, adding useful keyboard shortcuts.

- **Ctrl+D** will discard changes when prompted to save changes (borrowed from GIMP)
- **Ctrl + B**/**Ctrl + Shift + B** to add/remove bars in song editor
- **Shift+Q** to quantize notes in piano roll

I felt like these actions were missing shortcuts and I have personally found these very helpful. I have added relevant tooltips where appropriate, however I'm not sure the best way to signpost the Ctrl+D shortcut.
As this is my first pull request, any criticism is greatly appreciated. Thank you!