### PR TITLE
Modifier keys for mouse wheel adjustments

### DIFF
--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -696,22 +696,26 @@ void Knob::wheelEvent(QWheelEvent * we)
 	float const step = m->step<float>();
 	float const range = m->range();
 
+	// This is the default number of steps or mouse wheel events that it takes to sweep
+	// from the lowest value to the highest value.
+	// It might be modified if the user presses modifier keys. See below.
 	float numberOfStepsForFullSweep = 100.;
 
 	auto const modKeys = we->modifiers();
 	if (modKeys == Qt::ShiftModifier)
 	{
-		// With shift we want to be able to go through the values in 10 steps
+		// The shift is intended to go through the values in very coarse steps as in:
+		// "Shift into overdrive"
 		numberOfStepsForFullSweep = 10;
 	}
 	else if (modKeys == Qt::ControlModifier)
 	{
-		// With control we want to be able to go through the values in 100 steps
+		// The control key gives more control, i.e. it enables more fine-grained adjustments
 		numberOfStepsForFullSweep = 1000;
 	}
 	else if (modKeys == Qt::AltModifier)
 	{
-		// With alt we want to be able to go through the values in 1000 steps
+		// The alt key enables even finer adjustments
 		numberOfStepsForFullSweep = 2000;
 
 		// It seems that on some systems pressing Alt with mess with the directions,

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -734,7 +734,7 @@ void Knob::wheelEvent(QWheelEvent * we)
 	// Compute the number of steps but make sure that we always do at least one step
 	const float stepMult = std::max(range / numberOfStepsForFullSweep / step, 1.f);
 	const int inc = direction * stepMult;
-	model()->incValue( inc );
+	model()->incValue(inc);
 
 	s_textFloat->setText( displayValue() );
 	s_textFloat->moveGlobal( this, QPoint( width() + 2, 0 ) );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -714,9 +714,9 @@ void Knob::wheelEvent(QWheelEvent * we)
 		// With alt we want to be able to go through the values in 1000 steps
 		numberOfStepsForFullSweep = 2000;
 
-			   // It seems that on some systems pressing Alt with mess with the directions,
-			   // i.e. scrolling the mouse wheel is interpreted as pressing the mouse wheel
-			   // left and right. Account for this quirk.
+		// It seems that on some systems pressing Alt with mess with the directions,
+		// i.e. scrolling the mouse wheel is interpreted as pressing the mouse wheel
+		// left and right. Account for this quirk.
 		if (deltaY == 0)
 		{
 			int const deltaX = we->angleDelta().x();
@@ -727,7 +727,7 @@ void Knob::wheelEvent(QWheelEvent * we)
 		}
 	}
 
-		   // Compute the number of steps but make sure that we always do at least one step
+	// Compute the number of steps but make sure that we always do at least one step
 	const float stepMult = std::max(range / numberOfStepsForFullSweep / step, 1.f);
 	const int inc = direction * stepMult;
 	model()->incValue( inc );


### PR DESCRIPTION
Give the users the option to use modifier keys (Shift, Ctrl, Alt) to switch between different scales of adjustment when changing knob values using the mouse wheel.

The commit implements the following behaviour:

* Using the mouse wheel without any modifier keys makes coarser adjustments than the current default, i.e. the range of the parameter can be swept with 100 mouse wheel events instead of 2000.
* Pressing the "Shift" key while using the mouse wheel allows making coarser adjustments than the default. The range can be swept with 10 mouse wheel events.
* Pressing the "Ctrl" key allows making finer adjustments than the default. The range is swept with 1000 events.
* Pressing the "Alt" key allows even finer adjustments. The range is swept with 2000 events (the current default).

Most of these scales are organized in magnitudes (10, 100, 1000) which should give a very natural feeling to "zone in" on a value.

Closes #6769