### PR TITLE
Updated MIDI CC handling not to count from 1

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -127,6 +127,7 @@ private:
 	void upgrade_mixerRename();
 	void upgrade_bbTcoRename();
 	void upgrade_sampleAndHold();
+	void upgrade_midiCCIndexing();
 
 	// List of all upgrade methods
 	static const std::vector<UpgradeMethod> UPGRADE_METHODS;

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -48,7 +48,7 @@ class MidiController : public Controller, public MidiEventProcessor
 {
 	Q_OBJECT
 public:
-	static const int NONE = -1;
+	static constexpr int NONE = -1;
 	MidiController( Model * _parent );
 	~MidiController() override = default;
 

--- a/include/MidiController.h
+++ b/include/MidiController.h
@@ -48,6 +48,7 @@ class MidiController : public Controller, public MidiEventProcessor
 {
 	Q_OBJECT
 public:
+	static const int NONE = -1;
 	MidiController( Model * _parent );
 	~MidiController() override = default;
 

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -35,7 +35,6 @@
 #include <QFileInfo>
 #include <QDir>
 #include <QMessageBox>
-#include <string>
 
 #include "base64.h"
 #include "ConfigManager.h"
@@ -1814,17 +1813,18 @@ void DataFile::upgrade_sampleAndHold()
 //! count the CCs from 1.
 void DataFile::upgrade_midiCCIndexing()
 {
-	std::vector<const char*> attributesToUpdate = {"inputcontroller", "outputcontroller"};
+	static constexpr std::array attributesToUpdate{"inputcontroller", "outputcontroller"};
 
 	QDomNodeList elements = elementsByTagName("Midicontroller");
-	for(int i = 0; !elements.item(i).isNull(); ++i)
+	for(int i = 0; i < elements.length(); i++)
 	{
+		if (elements.item(i).isNull()) { continue; }
 		auto element = elements.item(i).toElement();
 		for (const char* attrName : attributesToUpdate)
 		{
-			if(element.hasAttribute(attrName))
+			if (element.hasAttribute(attrName))
 			{
-				int cc = std::stoi(element.attribute(attrName).toStdString());
+				int cc = element.attribute(attrName).toInt();
 				element.setAttribute(attrName, cc - 1);
 			}
 		}

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -80,7 +80,7 @@ void MidiController::processInEvent( const MidiEvent& event, const TimePos& time
 		case MidiControlChange:
 			controllerNum = event.controllerNumber();
 
-			if( m_midiPort.inputController() == controllerNum + 1 &&
+			if( m_midiPort.inputController() == controllerNum &&
 					( m_midiPort.inputChannel() == event.channel() + 1 ||
 					  m_midiPort.inputChannel() == 0 ) )
 			{

--- a/src/core/midi/MidiController.cpp
+++ b/src/core/midi/MidiController.cpp
@@ -72,21 +72,20 @@ void MidiController::updateName()
 
 
 
-void MidiController::processInEvent( const MidiEvent& event, const TimePos& time, f_cnt_t offset )
+void MidiController::processInEvent(const MidiEvent& event, const TimePos& time, f_cnt_t offset)
 {
 	unsigned char controllerNum;
-	switch( event.type() )
+	switch(event.type())
 	{
 		case MidiControlChange:
 			controllerNum = event.controllerNumber();
 
-			if( m_midiPort.inputController() == controllerNum &&
-					( m_midiPort.inputChannel() == event.channel() + 1 ||
-					  m_midiPort.inputChannel() == 0 ) )
+			if (m_midiPort.inputController() == controllerNum &&
+				(m_midiPort.inputChannel() == event.channel() + 1 || m_midiPort.inputChannel() == 0))
 			{
 				unsigned char val = event.controllerValue();
 				m_previousValue = m_lastValue;
-				m_lastValue = (float)( val ) / 127.0f;
+				m_lastValue = static_cast<float>(val) / 127.0f;
 				emit valueChanged();
 			}
 			break;

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -31,6 +31,7 @@
 #include "MidiEventProcessor.h"
 #include "Note.h"
 #include "Song.h"
+#include "MidiController.h"
 
 
 namespace lmms
@@ -54,8 +55,8 @@ MidiPort::MidiPort( const QString& name,
 	m_mode( mode ),
 	m_inputChannelModel( 0, 0, MidiChannelCount, this, tr( "Input channel" ) ),
 	m_outputChannelModel( 1, 0, MidiChannelCount, this, tr( "Output channel" ) ),
-	m_inputControllerModel( 0, 0, MidiControllerCount, this, tr( "Input controller" ) ),
-	m_outputControllerModel( 0, 0, MidiControllerCount, this, tr( "Output controller" ) ),
+	m_inputControllerModel(MidiController::NONE, MidiController::NONE, MidiControllerCount - 1, this, tr( "Input controller" )),
+	m_outputControllerModel(MidiController::NONE, MidiController::NONE, MidiControllerCount - 1, this, tr( "Output controller" )),
 	m_fixedInputVelocityModel( -1, -1, MidiMaxVelocity, this, tr( "Fixed input velocity" ) ),
 	m_fixedOutputVelocityModel( -1, -1, MidiMaxVelocity, this, tr( "Fixed output velocity" ) ),
 	m_fixedOutputNoteModel( -1, -1, MidiMaxKey, this, tr( "Fixed output note" ) ),

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -197,11 +197,6 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 	m_readableModel.saveSettings( doc, thisElement, "readable" );
 	m_writableModel.saveSettings( doc, thisElement, "writable" );
 
-	/* New versions of LMMS count the controllers from 0, older ones count from 1. We need to mark that the new
-	 * indexing convention is used. When loading the project LMMS will know if the values should be translated or not */
-	BoolModel controllerZeroBaseModel(true, this);
-	controllerZeroBaseModel.saveSettings(doc, thisElement, "controller0base");
-
 	if( isInputEnabled() )
 	{
 		QString rp;
@@ -241,6 +236,7 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 
 
 
+
 void MidiPort::loadSettings( const QDomElement& thisElement )
 {
 	m_inputChannelModel.loadSettings( thisElement, "inputchannel" );
@@ -254,16 +250,6 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_baseVelocityModel.loadSettings( thisElement, "basevelocity" );
 	m_readableModel.loadSettings( thisElement, "readable" );
 	m_writableModel.loadSettings( thisElement, "writable" );
-
-	BoolModel controllerZeroBaseModel;
-	controllerZeroBaseModel.loadSettings(thisElement, "controller0base");
-
-	if (controllerZeroBaseModel.value() == false) {
-		/* We have a project created with older version of LMMS. We need to translate the controller indexes
-		 * to the new convention */
-		m_inputControllerModel.setValue(m_inputControllerModel.value() - 1);
-		m_outputControllerModel.setValue(m_outputControllerModel.value() - 1);
-	}
 
 	// restore connections
 

--- a/src/core/midi/MidiPort.cpp
+++ b/src/core/midi/MidiPort.cpp
@@ -197,6 +197,11 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 	m_readableModel.saveSettings( doc, thisElement, "readable" );
 	m_writableModel.saveSettings( doc, thisElement, "writable" );
 
+	/* New versions of LMMS count the controllers from 0, older ones count from 1. We need to mark that the new
+	 * indexing convention is used. When loading the project LMMS will know if the values should be translated or not */
+	BoolModel controllerZeroBaseModel(true, this);
+	controllerZeroBaseModel.saveSettings(doc, thisElement, "controller0base");
+
 	if( isInputEnabled() )
 	{
 		QString rp;
@@ -236,7 +241,6 @@ void MidiPort::saveSettings( QDomDocument& doc, QDomElement& thisElement )
 
 
 
-
 void MidiPort::loadSettings( const QDomElement& thisElement )
 {
 	m_inputChannelModel.loadSettings( thisElement, "inputchannel" );
@@ -250,6 +254,16 @@ void MidiPort::loadSettings( const QDomElement& thisElement )
 	m_baseVelocityModel.loadSettings( thisElement, "basevelocity" );
 	m_readableModel.loadSettings( thisElement, "readable" );
 	m_writableModel.loadSettings( thisElement, "writable" );
+
+	BoolModel controllerZeroBaseModel;
+	controllerZeroBaseModel.loadSettings(thisElement, "controller0base");
+
+	if (controllerZeroBaseModel.value() == false) {
+		/* We have a project created with older version of LMMS. We need to translate the controller indexes
+		 * to the new convention */
+		m_inputControllerModel.setValue(m_inputControllerModel.value() - 1);
+		m_outputControllerModel.setValue(m_outputControllerModel.value() - 1);
+	}
 
 	// restore connections
 

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -54,7 +54,7 @@ public:
 	AutoDetectMidiController( Model* parent ) :
 		MidiController( parent ),
 		m_detectedMidiChannel( 0 ),
-		m_detectedMidiController( 0 )
+		m_detectedMidiController(NONE)
 	{
 		updateName();
 	}
@@ -69,7 +69,7 @@ public:
 			( m_midiPort.inputChannel() == 0 || m_midiPort.inputChannel() == event.channel() + 1 ) )
 		{
 			m_detectedMidiChannel = event.channel() + 1;
-			m_detectedMidiController = event.controllerNumber() + 1;
+			m_detectedMidiController = event.controllerNumber();
 			m_detectedMidiPort = Engine::audioEngine()->midiClient()->sourcePortName( event );
 
 			emit valueChanged();
@@ -152,7 +152,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 
 	m_midiControllerSpinBox = new LcdSpinBox( 3, m_midiGroupBox,
 			tr( "Input controller" ) );
-	m_midiControllerSpinBox->addTextForValue( 0, "---" );
+	m_midiControllerSpinBox->addTextForValue(MidiController::NONE, "---" );
 	m_midiControllerSpinBox->setLabel( tr( "CONTROLLER" ) );
 	m_midiControllerSpinBox->move( 68, 24 );
 	


### PR DESCRIPTION
Fixes #6722

The MIDI controller numbers are now displayed without alterations - for example, CC 40 is presented in the application as 40 instead of 41. This has been done to provide consistency with the MIDI specs and with the behavior of MIDI devices.