### PR TITLE
Consolidate and simplify CMAKE_POLICY entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ SET(LMMS_BINARY_DIR ${CMAKE_BINARY_DIR})
 SET(LMMS_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
 # CMAKE_POLICY Section
-CMAKE_POLICY(SET CMP0057 NEW) # Support new if() IN_LIST operator.
 
 # Import of windows.h breaks min()/max()
 ADD_DEFINITIONS(-DNOMINMAX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(LMMS_BINARY_DIR ${CMAKE_BINARY_DIR})
 SET(LMMS_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
 # CMAKE_POLICY Section
+CMAKE_POLICY(SET CMP0057 NEW) # Support new if() IN_LIST operator.
 
 # Import of windows.h breaks min()/max()
 ADD_DEFINITIONS(-DNOMINMAX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,13 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 SET(LMMS_BINARY_DIR ${CMAKE_BINARY_DIR})
 SET(LMMS_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
-IF(COMMAND CMAKE_POLICY)
-	CMAKE_POLICY(SET CMP0005 NEW)
-	CMAKE_POLICY(SET CMP0003 NEW)
-	IF (CMAKE_MAJOR_VERSION GREATER 2)
-		CMAKE_POLICY(SET CMP0026 NEW)
-		CMAKE_POLICY(SET CMP0045 NEW)
-		CMAKE_POLICY(SET CMP0050 OLD)
-	ENDIF()
-	CMAKE_POLICY(SET CMP0020 NEW)
-	CMAKE_POLICY(SET CMP0057 NEW)
-ENDIF(COMMAND CMAKE_POLICY)
+CMAKE_POLICY(SET CMP0005 NEW)	# Preprocessor definition values are now escaped automatically
+CMAKE_POLICY(SET CMP0003 NEW)   # Libraries linked via full path no longer produce linker search paths.
+CMAKE_POLICY(SET CMP0026 NEW)	# Disallow use of the LOCATION property for build targets.
+CMAKE_POLICY(SET CMP0045 NEW)   # Error on non-existent target in get_target_property.
+CMAKE_POLICY(SET CMP0050 OLD)   # Disallow add_custom_command SOURCE signatures.
+CMAKE_POLICY(SET CMP0020 NEW)	# Automatically link Qt executables to qtmain target on Windows.
+CMAKE_POLICY(SET CMP0057 NEW)	# Support new if() IN_LIST operator.
 
 
 # Import of windows.h breaks min()/max()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,14 +6,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 SET(LMMS_BINARY_DIR ${CMAKE_BINARY_DIR})
 SET(LMMS_SOURCE_DIR ${CMAKE_SOURCE_DIR})
 
-CMAKE_POLICY(SET CMP0005 NEW)	# Preprocessor definition values are now escaped automatically
-CMAKE_POLICY(SET CMP0003 NEW)   # Libraries linked via full path no longer produce linker search paths.
-CMAKE_POLICY(SET CMP0026 NEW)	# Disallow use of the LOCATION property for build targets.
-CMAKE_POLICY(SET CMP0045 NEW)   # Error on non-existent target in get_target_property.
-CMAKE_POLICY(SET CMP0050 OLD)   # Disallow add_custom_command SOURCE signatures.
-CMAKE_POLICY(SET CMP0020 NEW)	# Automatically link Qt executables to qtmain target on Windows.
-CMAKE_POLICY(SET CMP0057 NEW)	# Support new if() IN_LIST operator.
-
+# CMAKE_POLICY Section
 
 # Import of windows.h breaks min()/max()
 ADD_DEFINITIONS(-DNOMINMAX)

--- a/cmake/modules/DefineInstallVar.cmake
+++ b/cmake/modules/DefineInstallVar.cmake
@@ -24,7 +24,7 @@ function(DEFINE_INSTALL_VAR)
         endif()
     else()
         if(VAR_GENERATOR_EXPRESSION)
-            cmake_policy(SET CMP0087 NEW)
+            cmake_policy(SET CMP0087 NEW) # install(CODE) and install(SCRIPT) support generator expressions.
         endif()
         install(CODE "set(\"${VAR_NAME}\" \"${VAR_CONTENT}\")")
     endif()

--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -1,9 +1,6 @@
 include(GetPrerequisites)
 include(CMakeParseArguments)
 
-CMAKE_POLICY(SET CMP0011 NEW)
-CMAKE_POLICY(SET CMP0057 NEW)
-
 function(make_absolute var)
 	get_filename_component(abs "${${var}}" ABSOLUTE BASE_DIR "${CMAKE_INSTALL_PREFIX}")
 	set(${var} ${abs} PARENT_SCOPE)

--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -1,6 +1,8 @@
 include(GetPrerequisites)
 include(CMakeParseArguments)
 
+CMAKE_POLICY(SET CMP0057 NEW) # Support new if() IN_LIST operator.
+
 function(make_absolute var)
 	get_filename_component(abs "${${var}}" ABSOLUTE BASE_DIR "${CMAKE_INSTALL_PREFIX}")
 	set(${var} ${abs} PARENT_SCOPE)

--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -1,7 +1,8 @@
 include(GetPrerequisites)
 include(CMakeParseArguments)
 
-cmake_minimum_required(${CMAKE_MINIMUM_REQUIRED_VERSION})
+# Project's cmake_minimum_required doesn't always propagate
+cmake_policy(SET CMP0057 NEW)
 
 function(make_absolute var)
 	get_filename_component(abs "${${var}}" ABSOLUTE BASE_DIR "${CMAKE_INSTALL_PREFIX}")

--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -2,7 +2,7 @@ include(GetPrerequisites)
 include(CMakeParseArguments)
 
 # Project's cmake_minimum_required doesn't always propagate
-cmake_policy(SET CMP0057 NEW)
+cmake_policy(SET CMP0057 NEW) # Support new if() IN_LIST operator.
 
 function(make_absolute var)
 	get_filename_component(abs "${${var}}" ABSOLUTE BASE_DIR "${CMAKE_INSTALL_PREFIX}")

--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -1,7 +1,7 @@
 include(GetPrerequisites)
 include(CMakeParseArguments)
 
-CMAKE_POLICY(SET CMP0057 NEW) # Support new if() IN_LIST operator.
+cmake_minimum_required(${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 function(make_absolute var)
 	get_filename_component(abs "${${var}}" ABSOLUTE BASE_DIR "${CMAKE_INSTALL_PREFIX}")

--- a/plugins/CarlaBase/CMakeLists.txt
+++ b/plugins/CarlaBase/CMakeLists.txt
@@ -1,11 +1,3 @@
-# For MacOS, use "OLD" RPATH install_name behavior
-# This can be changed to "NEW" safely if install_apple.sh.in
-# is updated to relink libcarlabase.dylib.  MacOS 10.8 uses
-# cmake 3.9.6, so this can be done at any time.
-IF(NOT CMAKE_VERSION VERSION_LESS 3.9)
-  CMAKE_POLICY(SET CMP0068 OLD) # RPATH settings on macOS do not affect install_name.
-ENDIF()
-
 # If Carla was not provided by the system, make a dummy library instead
 if(LMMS_HAVE_WEAKCARLA)
   SET(CARLA_INCLUDE_DIRS

--- a/plugins/CarlaBase/CMakeLists.txt
+++ b/plugins/CarlaBase/CMakeLists.txt
@@ -3,7 +3,7 @@
 # is updated to relink libcarlabase.dylib.  MacOS 10.8 uses
 # cmake 3.9.6, so this can be done at any time.
 IF(NOT CMAKE_VERSION VERSION_LESS 3.9)
-  CMAKE_POLICY(SET CMP0068 OLD)
+  CMAKE_POLICY(SET CMP0068 OLD) # RPATH settings on macOS do not affect install_name.
 ENDIF()
 
 # If Carla was not provided by the system, make a dummy library instead


### PR DESCRIPTION
Inspired by: https://github.com/LMMS/lmms/pull/6758#discussion_r1271346366

Supersedes: #6778

Quoting @DomClark:

> We require a minimum of CMake 3.9 now, which means all of these policies will use the new behaviour by default (since CMake 3.9 includes the policies up to and including CMP0069). Thus the only line that still has an effect is the one that sets CMP0050 to OLD. Furthermore, I don't think we require that old behaviour any more: the policy value was introduced in #3583 because the old behaviour was used in the RemoteVstPlugin build scripts, but that use was since removed in ea154694f905087db28119ea1901861cac92a2e2. I can't find any other uses of the old behaviour, and LMMS configures and builds correctly without it (at least on my machine, using MSVC).
> 
> There are a couple of other `cmake_policy` commands elsewhere in the project. There are two in `cmake/modules/InstallDependencies.cmake`, which are also obsolete. Another is in `plugins/CarlaBase/CMakeLists.txt`, which already has a decent comment above it. Finally, there's one in `cmake/modules/DefineInstallVar.cmake`, which is still required, and lacks a comment.