### PR TITLE
HiDPI fixes for elements based on QTreeView

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -132,7 +132,7 @@ QMenu::indicator:selected {
 
 lmms--gui--FileBrowser QCheckBox
 {
-	font-size: 10px;
+	font-size: 8pt;
 	color: white;
 }
 

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -9,7 +9,6 @@ QLabel, QTreeWidget, QListWidget, QGroupBox, QMenuBar {
 
 QTreeView {
 	outline: none;
-	font-size: 12px;
 }
 
 QTreeWidget::item {
@@ -42,7 +41,7 @@ QMdiArea {
 
 lmms--gui--FileBrowser QCheckBox
 {
-	font-size: 10px;
+	font-size: 8pt;
 	color: white;
 }
 


### PR DESCRIPTION
Fix the HiDPI problems for elements that are based on QTreeView by removing the fixed point based font size from the style sheet. This affects:
* The file browser
* The headings of the plugin browser
* The patch selection dialogs for GigPlayer and SoundFont player

Also make the text size of the check boxes for user content and factory content based on a point size instead of a pixel size.

## Preview
File browser:
![2510-QTreeViewFixes-FileBrowser](https://github.com/LMMS/lmms/assets/9293269/612c81fa-9918-4d99-8482-0d4b7a4f18f7)

Patch selections:
![2510-QTreeViewFixes-GigPatches](https://github.com/LMMS/lmms/assets/9293269/ac60222b-0cba-44c8-bea7-e8b62501ab4b)
![2510-QTreeViewFixes-SoundfontPatches](https://github.com/LMMS/lmms/assets/9293269/83973465-9cdf-4078-9255-49cf1bebf3b3)
