### PR TITLE
MidiApple.cpp: fix getName to allow build with GCC

### DIFF
--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -403,7 +403,7 @@ void MidiApple::midiInClose( MIDIEndpointRef reference )
 
 
 
-char *getName( MIDIObjectRef &object )
+char *getName( const MIDIObjectRef &object )
 {
 	// Returns the name of a given MIDIObjectRef as char *
 	CFStringRef name = nullptr;


### PR DESCRIPTION
@tresf Here is our fix for GCC build.

(Edit by @tresf):
Closes #6785 