### PR TITLE
versioninfo.h: improve recognition of compiler and platforms

### DIFF
--- a/include/versioninfo.h
+++ b/include/versioninfo.h
@@ -3,15 +3,17 @@
 
 #include "lmms_basics.h"
 
-#ifdef __GNUC__
+#if defined(__GNUC__)
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "GCC " __VERSION__;
+#elif defined(__clang__)
+constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "Clang " __clang_version__;
 #elif defined(_MSC_VER)
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "MSVC " LMMS_STRINGIFY(_MSC_FULL_VER);
 #else
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "unknown compiler";
 #endif
 
-#ifdef LMMS_HOST_X86
+#if defined(LMMS_HOST_X86)
 constexpr const char* LMMS_BUILDCONF_MACHINE = "i386";
 #elif defined(LMMS_HOST_X86_64)
 constexpr const char* LMMS_BUILDCONF_MACHINE = "x86_64";
@@ -23,32 +25,28 @@ constexpr const char* LMMS_BUILDCONF_MACHINE = "arm64";
 constexpr const char* LMMS_BUILDCONF_MACHINE = "riscv32";
 #elif defined(LMMS_HOST_RISCV64)
 constexpr const char* LMMS_BUILDCONF_MACHINE = "riscv64";
+#elif defined(LMMS_HOST_PPC32)
+constexpr const char* LMMS_BUILDCONF_MACHINE = "ppc";
+#elif defined(LMMS_HOST_PPC64)
+constexpr const char* LMMS_BUILDCONF_MACHINE = "ppc64";
 #else
 constexpr const char* LMMS_BUILDCONF_MACHINE = "unknown processor";
 #endif
 
-#ifdef LMMS_BUILD_LINUX
+#if defined(LMMS_BUILD_LINUX)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "Linux";
-#endif
-
-#ifdef LMMS_BUILD_APPLE
+#elif defined(LMMS_BUILD_APPLE)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "OS X";
-#endif
-
-#ifdef LMMS_BUILD_OPENBSD
+#elif defined(LMMS_BUILD_OPENBSD)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "OpenBSD";
-#endif
-
-#ifdef LMMS_BUILD_FREEBSD
+#elif defined(LMMS_BUILD_FREEBSD)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "FreeBSD";
-#endif
-
-#ifdef LMMS_BUILD_WIN32
+#elif defined(LMMS_BUILD_WIN32)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "win32";
-#endif
-
-#ifdef LMMS_BUILD_HAIKU
+#elif defined(LMMS_BUILD_HAIKU)
 constexpr const char* LMMS_BUILDCONF_PLATFORM = "Haiku";
+#else
+constexpr const char* LMMS_BUILDCONF_PLATFORM = "unknown platform";
 #endif
 
 #endif // LMMS_VERSION_INFO_H


### PR DESCRIPTION
@tresf Forward-porting the fix :) 

P. S. For the record, while the logic appears coherent and simple, this is untested, as my environment does not support building from the master.

**Edit: @tresf:**

This is a forward-port of #6794 