### PR TITLE
Lv2: Improve control visualization

### DIFF
--- a/src/core/lv2/Lv2Ports.cpp
+++ b/src/core/lv2/Lv2Ports.cpp
@@ -114,12 +114,12 @@ std::vector<PluginIssue> Meta::get(const LilvPlugin *plugin,
 
 	m_optional = hasProperty(LV2_CORE__connectionOptional);
 
-	m_vis = hasProperty(LV2_CORE__integer)
-		? Vis::Integer // WARNING: this may still be changed below
+	m_vis = hasProperty(LV2_CORE__toggled)
+		? Vis::Toggled
 		: hasProperty(LV2_CORE__enumeration)
 		? Vis::Enumeration
-		: hasProperty(LV2_CORE__toggled)
-		? Vis::Toggled
+		: hasProperty(LV2_CORE__integer)
+		? Vis::Integer // WARNING: this may still be changed below
 		: Vis::Generic;
 
 	if (isA(LV2_CORE__InputPort)) { m_flow = Flow::Input; }

--- a/src/gui/ControlLayout.cpp
+++ b/src/gui/ControlLayout.cpp
@@ -258,8 +258,8 @@ int ControlLayout::doLayout(const QRect &rect, bool testOnly) const
 				if (first)
 				{
 					// for the search bar, only show it if there are at least
-					// two control widgets (i.e. at least 3 widgets)
-					if (m_itemMap.size() > 2) { wid->show(); }
+					// two control widgets (i.e. at least 6 widgets)
+					if (m_itemMap.size() > 5) { wid->show(); }
 					else { wid->hide(); }
 				}
 				else { wid->show(); }

--- a/src/gui/ControlLayout.cpp
+++ b/src/gui/ControlLayout.cpp
@@ -258,7 +258,7 @@ int ControlLayout::doLayout(const QRect &rect, bool testOnly) const
 				if (first)
 				{
 					// for the search bar, only show it if there are at least
-					// two control widgets (i.e. at least 6 widgets)
+					// five control widgets (i.e. at least 6 widgets)
 					if (m_itemMap.size() > 5) { wid->show(); }
 					else { wid->hide(); }
 				}


### PR DESCRIPTION
Previously, the Lv2 controls were checked for control types in this order:

  integer?
  enum?
  toggle?
  generic?

This is bad because it goes from generic (integer) to specific (toggle), and then defaults to most generic. The order should be specific (toggle) to generic (integer, generic), which is fixed by this PR.

This solves that controls which are marked "toggle" and "integer" were being displayed as a spinbox.

Additional improvement: Only show search bar for more than 5 controls, previously more than 2.