### PR TITLE
Fix note copy/paste in the Pattern Editor

### DIFF
--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -325,7 +325,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 	QString value = decodeValue( md );
 
 	// We can only paste into tracks of the same type
-	if( type != ( "clip_" + QString::number( t->type() ) ) )
+	if (type != ("clip_" + QString::number(t->type())))
 	{
 		return false;
 	}
@@ -361,8 +361,8 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	// If we are pasting into the PatternEditor, only a single Clip is allowed to be pasted
 	// so we don't have the unexpected behavior of pasting on different PatternTracks
-	if( m_trackView->trackContainerView()->fixedClips() == true &&
-			clipNodes.length() > 1 )
+	if (m_trackView->trackContainerView()->fixedClips() == true &&
+			clipNodes.length() > 1)
 	{
 		return false;
 	}

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -325,8 +325,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 	QString value = decodeValue( md );
 
 	// We can only paste into tracks of the same type
-	if( type != ( "clip_" + QString::number( t->type() ) ) ||
-		m_trackView->trackContainerView()->fixedClips() == true )
+	if( type != ( "clip_" + QString::number( t->type() ) ) )
 	{
 		return false;
 	}
@@ -359,6 +358,14 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 	// Extract the clip data
 	QDomElement clipParent = dataFile.content().firstChildElement("clips");
 	QDomNodeList clipNodes = clipParent.childNodes();
+
+	// If we are pasting into the PatternEditor, only a single Clip is allowed to be pasted
+	// so we don't have the unexpected behavior of pasting on different PatternTracks
+	if( m_trackView->trackContainerView()->fixedClips() == true &&
+			clipNodes.length() > 1 )
+	{
+		return false;
+	}
 
 	// Determine if all the Clips will land on a valid track
 	for( int i = 0; i < clipNodes.length(); i++ )


### PR DESCRIPTION
Since the refactoring of the Copy/Paste features, it was not possible to paste inside the BBEditor (now Pattern Editor), as reported on issue #6002. The reason for that is better explained in the issue discussion.

This PR fixes this by allowing pasting inside the Pattern Editor when the clipboard has a single Clip, which is what was allowed on the previous workflow, while at the same time avoiding the unexpected behavior of pasting multiple Clips that might invade the positions reserved for different Pattern Tracks.

Fixes #6002