### PR TITLE
Fix segfault when clicking "Auto Detect" in Connection Settings window

### DIFF
--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -406,7 +406,7 @@ void ControllerConnectionDialog::userSelected()
 
 void ControllerConnectionDialog::autoDetectToggled()
 {
-	if( m_midiAutoDetect.value() )
+	if (m_midiAutoDetect.value() && m_midiController)
 	{
 		m_midiController->reset();
 	}


### PR DESCRIPTION
Just a simple null pointer check.

Fixes #6810 
