### PR TITLE
fix #6807: Marked notes bleed into note velocity

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3357,7 +3357,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			const int key_num = m_markedSemiTones.at(x);
 			const int y = keyAreaBottom() - 1 - m_keyLineHeight *
 				(key_num - m_startKey + 1);
-			if(y > keyAreaBottom()) { break; }
+			if(y >= keyAreaBottom() - 1) { break; }
 			p.fillRect(m_whiteKeyWidth + 1,
 				y,
 				width() - 10,


### PR DESCRIPTION
Issue was caused by an obiwan (off-by-one)
The 'if (y > limit)' test was broken by an incorrect inequality,
 should be >=, and a graphical adjustment made previously in the
 'y = ...' statement. I perserved the graphical adjustment and
 fixed the test to be 'if (y >= limit - 1) { break; }'
 
 Fixes #6807