### PR TITLE
Piano Roll scroll bar improvement

### DIFF
--- a/include/MidiClipView.h
+++ b/include/MidiClipView.h
@@ -68,7 +68,7 @@ public slots:
 
 
 protected slots:
-	void openInPianoRoll();
+	void openInPianoRoll(double scrollX = -1.0);
 	void setGhostInPianoRoll();
 
 	void resetName();

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -238,6 +238,7 @@ protected slots:
 
 	void changeSnapMode();
 
+	void updateScrollbarRange();
 
 signals:
 	void currentMidiClipChanged();

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -540,6 +540,8 @@ public:
 	QSize sizeHint() const override;
 	bool hasFocus() const;
 
+	void setScrollbarPos(double posX); //!< posX is in range [0, 1)
+
 signals:
 	void currentMidiClipChanged();
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -189,6 +189,7 @@ protected:
 	// for entering values with dblclick in the vol/pan bars
 	void enterValue( NoteVector* nv );
 
+	void updateXScroll();
 	void updateYScroll();
 
 protected slots:
@@ -237,8 +238,6 @@ protected slots:
 	void constrainNoteLengths(bool constrainMax);
 
 	void changeSnapMode();
-
-	void updateScrollbarRange();
 
 signals:
 	void currentMidiClipChanged();

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -107,9 +107,13 @@ void MidiClipView::update()
 
 
 
-void MidiClipView::openInPianoRoll()
+void MidiClipView::openInPianoRoll(double scrollX)
 {
-	getGUI()->pianoRoll()->setCurrentMidiClip( m_clip );
+	getGUI()->pianoRoll()->setCurrentMidiClip(m_clip);
+	if (scrollX >= 0.0)
+	{
+		getGUI()->pianoRoll()->setScrollbarPos(scrollX);
+	}
 	getGUI()->pianoRoll()->parentWidget()->show();
 	getGUI()->pianoRoll()->show();
 	getGUI()->pianoRoll()->setFocus();
@@ -313,7 +317,9 @@ void MidiClipView::mouseDoubleClickEvent(QMouseEvent *_me)
 	}
 	if( m_clip->m_clipType == MidiClip::MelodyClip || !fixedClips() )
 	{
-		openInPianoRoll();
+		// Local X position of mouse over clip, normalized to range of [0, 1)
+		auto scrollX = _me->localPos().x() / width();
+		openInPianoRoll(scrollX);
 	}
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -924,6 +924,8 @@ void PianoRoll::setCurrentMidiClip( MidiClip* newMidiClip )
 	connect(m_midiClip->instrumentTrack()->microtuner()->keyRangeImportModel(), SIGNAL(dataChanged()),
 		this, SLOT(update()));
 
+	connect(m_midiClip, &MidiClip::lengthChanged, this, &PianoRoll::updateScrollbarRange);
+
 	update();
 	emit currentMidiClipChanged();
 }
@@ -3661,16 +3663,6 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	p.setBrush( Qt::NoBrush );
 	p.drawRect(x + m_whiteKeyWidth, y, w, h);
 
-	// TODO: Get this out of paint event
-	int l = ( hasValidMidiClip() )? (int) m_midiClip->length() : 0;
-
-	// reset scroll-range
-	if( m_leftRightScroll->maximum() != l )
-	{
-		m_leftRightScroll->setRange( 0, l );
-		m_leftRightScroll->setPageStep( l );
-	}
-
 	// set line colors
 	auto editAreaCol = QColor(m_lineColor);
 	auto currentKeyCol = QColor(m_beatLineColor);
@@ -3750,6 +3742,16 @@ void PianoRoll::updateScrollbars()
 		m_startKey = qMax(0, m_totalKeysToScroll);
 	}
 	m_topBottomScroll->setValue(m_totalKeysToScroll - m_startKey);
+}
+
+void PianoRoll::updateScrollbarRange()
+{
+	const int length = hasValidMidiClip() ? static_cast<int>(m_midiClip->length()) : 0;
+	if (m_leftRightScroll->maximum() != length)
+	{
+		m_leftRightScroll->setRange(0, length);
+		m_leftRightScroll->setPageStep(length);
+	}
 }
 
 // responsible for moving/resizing scrollbars after window-resizing

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5234,6 +5234,16 @@ bool PianoRollWindow::hasFocus() const
 }
 
 
+void PianoRollWindow::setScrollbarPos(double posX)
+{
+	auto sbX = m_editor->m_leftRightScroll;
+	const auto halfEditorWidth = (sbX->width() - m_editor->m_topBottomScroll->width()) / 2.0;
+
+	auto absolutePosX = static_cast<int>(posX * (sbX->maximum() - sbX->minimum()) - halfEditorWidth);
+
+	sbX->setValue(std::max(absolutePosX, 0));
+}
+
 
 void PianoRollWindow::updateAfterMidiClipChange()
 {

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5243,7 +5243,7 @@ void PianoRollWindow::setScrollbarPos(double posX)
 	const auto zoomFactor = m_editor->m_zoomLevels[m_editor->m_zoomingModel.value()];
 	const auto zoomOffset = halfEditorWidth * (-1.0 / zoomFactor);
 
-	const auto scrollPosX = static_cast<int>(posX * (sbX->maximum() - sbX->minimum()) + zoomOffset);
+	const auto scrollPosX = static_cast<int>(posX * (sbX->maximum() - sbX->minimum()) + zoomOffset + (sbY->width() / 2));
 
 	sbX->setValue(std::max(scrollPosX, 0));
 }

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5236,12 +5236,16 @@ bool PianoRollWindow::hasFocus() const
 
 void PianoRollWindow::setScrollbarPos(double posX)
 {
-	auto sbX = m_editor->m_leftRightScroll;
-	const auto halfEditorWidth = (sbX->width() - m_editor->m_topBottomScroll->width()) / 2.0;
+	const auto sbX = m_editor->m_leftRightScroll;
+	const auto sbY = m_editor->m_topBottomScroll;
 
-	auto absolutePosX = static_cast<int>(posX * (sbX->maximum() - sbX->minimum()) - halfEditorWidth);
+	const auto halfEditorWidth = (sbX->width() - sbY->width()) / 2.0;
+	const auto zoomFactor = m_editor->m_zoomLevels[m_editor->m_zoomingModel.value()];
+	const auto zoomOffset = halfEditorWidth * (-1.0 / zoomFactor);
 
-	sbX->setValue(std::max(absolutePosX, 0));
+	const auto scrollPosX = static_cast<int>(posX * (sbX->maximum() - sbX->minimum()) + zoomOffset);
+
+	sbX->setValue(std::max(scrollPosX, 0));
 }
 
 


### PR DESCRIPTION
This is a simple quality-of-life improvement for the Piano Roll.

When working with large midi clips in the Piano Roll, it can be tiring to switch between clips because the Piano Roll's horizontal scroll bar always snaps back to the beginning of the clip, forcing the user to scroll over to the position where they want to work every time.

With this PR, double clicking a midi clip in the Song Editor will open that clip in the Piano Roll not to the beginning of the clip but to wherever on the Song Editor midi clip the user double clicked.

Demonstration:
https://github.com/LMMS/lmms/assets/33463986/e95b8b5b-50ab-46e4-af80-4800d99e7665

I also did some minor refactoring.