### PR TITLE
Core: Replace global Qt declarations with standard equivalents

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -27,6 +27,7 @@
 
 #include <QMap>
 #include <QMutex>
+#include <cmath>
 
 #include "JournallingObject.h"
 #include "Model.h"
@@ -144,7 +145,7 @@ public:
 	template<bool>
 	static bool castValue( const float v )
 	{
-		return ( qRound( v ) != 0 );
+		return (std::round(v) != 0);
 	}
 
 

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -209,7 +209,7 @@ public:
 	
 	inline float update( float s, ch_cnt_t ch )
 	{
-		if( qAbs( s ) < 1.0e-10f && qAbs( m_z1[ch] ) < 1.0e-10f ) return 0.0f;
+		if (std::abs(s) < 1.0e-10f && std::abs(m_z1[ch]) < 1.0e-10f) return 0.0f;
 		return m_z1[ch] = s * m_a0 + m_z1[ch] * m_b1;
 	}
 	
@@ -597,7 +597,7 @@ public:
 			case Formantfilter:
 			case FastFormant:
 			{
-				if( qAbs( _in0 ) < 1.0e-10f && qAbs( m_vflast[0][_chnl] ) < 1.0e-10f ) { return 0.0f; } // performance hack - skip processing when the numbers get too small
+				if (std::abs(_in0) < 1.0e-10f && std::abs(m_vflast[0][_chnl]) < 1.0e-10f) { return 0.0f; } // performance hack - skip processing when the numbers get too small
 				sample_t hp, bp, in;
 
 				out = 0;

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -702,7 +702,7 @@ public:
 	inline void calcFilterCoeffs( float _freq, float _q )
 	{
 		// temp coef vars
-		_q = qMax( _q, minQ() );
+		_q = std::max(_q, minQ());
 
 		if( m_type == Lowpass_RC12  ||
 			m_type == Bandpass_RC12 ||
@@ -796,10 +796,10 @@ public:
 			m_type == Highpass_SV ||
 			m_type == Notch_SV )
 		{
-			const float f = sinf( qMax( minFreq(), _freq ) * m_sampleRatio * F_PI );
+			const float f = sinf(std::max(minFreq(), _freq) * m_sampleRatio * F_PI);
 			m_svf1 = qMin( f, 0.825f );
 			m_svf2 = qMin( f * 2.0f, 0.825f );
-			m_svq = qMax( 0.0001f, 2.0f - ( _q * 0.1995f ) );
+			m_svq = std::max(0.0001f, 2.0f - (_q * 0.1995f));
 			return;
 		}
 

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -340,22 +340,18 @@ public:
 
 				// four cascaded onepole filters
 				// (bilinear transform)
-				m_y1[_chnl] = qBound( -10.0f,
-						( x + m_oldx[_chnl] ) * m_p
-							- m_k * m_y1[_chnl],
+				m_y1[_chnl] = std::clamp((x + m_oldx[_chnl]) * m_p
+							- m_k * m_y1[_chnl], -10.0f,
+								10.0f);
+				m_y2[_chnl] = std::clamp((m_y1[_chnl] + m_oldy1[_chnl]) * m_p
+							- m_k * m_y2[_chnl], -10.0f,
+								10.0f);
+				m_y3[_chnl] = std::clamp((m_y2[_chnl] + m_oldy2[_chnl]) * m_p
+							- m_k * m_y3[_chnl], -10.0f,
 								10.0f );
-				m_y2[_chnl] = qBound( -10.0f,
-					( m_y1[_chnl] + m_oldy1[_chnl] ) * m_p
-							- m_k * m_y2[_chnl],
-								10.0f );
-				m_y3[_chnl] = qBound( -10.0f,
-					( m_y2[_chnl] + m_oldy2[_chnl] ) * m_p
-							- m_k * m_y3[_chnl],
-								10.0f );
-				m_y4[_chnl] = qBound( -10.0f,
-					( m_y3[_chnl] + m_oldy3[_chnl] ) * m_p
-							- m_k * m_y4[_chnl],
-								10.0f );
+				m_y4[_chnl] = std::clamp((m_y3[_chnl] + m_oldy3[_chnl]) * m_p
+							- m_k * m_y4[_chnl], -10.0f,
+								10.0f);
 
 				m_oldx[_chnl] = x;
 				m_oldy1[_chnl] = m_y1[_chnl];
@@ -377,18 +373,15 @@ public:
 					ip += 0.25f;
 					sample_t x = linearInterpolate( m_last[_chnl], _in0, ip ) - m_r * m_y3[_chnl];
 					
-					m_y1[_chnl] = qBound( -10.0f,
-						( x + m_oldx[_chnl] ) * m_p
-							- m_k * m_y1[_chnl],
-								10.0f );
-					m_y2[_chnl] = qBound( -10.0f,
-						( m_y1[_chnl] + m_oldy1[_chnl] ) * m_p
-								- m_k * m_y2[_chnl],
-									10.0f );
-					m_y3[_chnl] = qBound( -10.0f,
-						( m_y2[_chnl] + m_oldy2[_chnl] ) * m_p
-								- m_k * m_y3[_chnl],
-									10.0f );
+					m_y1[_chnl] = std::clamp((x + m_oldx[_chnl]) * m_p
+							- m_k * m_y1[_chnl], -10.0f,
+								10.0f);
+					m_y2[_chnl] = std::clamp((m_y1[_chnl] + m_oldy1[_chnl]) * m_p
+								- m_k * m_y2[_chnl], -10.0f,
+									10.0f);
+					m_y3[_chnl] = std::clamp((m_y2[_chnl] + m_oldy2[_chnl]) * m_p
+								- m_k * m_y3[_chnl], -10.0f,
+									10.0f);
 					m_oldx[_chnl] = x;
 					m_oldy1[_chnl] = m_y1[_chnl];
 					m_oldy2[_chnl] = m_y2[_chnl];
@@ -471,16 +464,16 @@ public:
 				for( int n = 4; n != 0; --n )
 				{
 					in = _in0 + m_rcbp0[_chnl] * m_rcq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					lp = in * m_rcb + m_rclp0[_chnl] * m_rca;
-					lp = qBound( -1.0f, lp, 1.0f );
+					lp = std::clamp(lp, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp0[_chnl] + in - m_rclast0[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp0[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast0[_chnl] = in;
 					m_rclp0[_chnl] = lp;
@@ -496,13 +489,13 @@ public:
 				for( int n = 4; n != 0; --n )
 				{
 					in = _in0 + m_rcbp0[_chnl] * m_rcq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp0[_chnl] + in - m_rclast0[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp0[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast0[_chnl] = in;
 					m_rchp0[_chnl] = hp;
@@ -518,16 +511,16 @@ public:
 				{
 					// first stage is as for the 12dB case...
 					in = _in0 + m_rcbp0[_chnl] * m_rcq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					lp = in * m_rcb + m_rclp0[_chnl] * m_rca;
-					lp = qBound( -1.0f, lp, 1.0f );
+					lp = std::clamp(lp, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp0[_chnl] + in - m_rclast0[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp0[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast0[_chnl] = in;
 					m_rclp0[_chnl] = lp;
@@ -536,16 +529,16 @@ public:
 
 					// second stage gets the output of the first stage as input...
 					in = lp + m_rcbp1[_chnl] * m_rcq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f );
 
 					lp = in * m_rcb + m_rclp1[_chnl] * m_rca;
-					lp = qBound( -1.0f, lp, 1.0f );
+					lp = std::clamp(lp, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp1[_chnl] + in - m_rclast1[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp1[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast1[_chnl] = in;
 					m_rclp1[_chnl] = lp;
@@ -562,13 +555,13 @@ public:
 				{
 					// first stage is as for the 12dB case...
 					in = _in0 + m_rcbp0[_chnl] * m_rcq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp0[_chnl] + in - m_rclast0[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp0[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast0[_chnl] = in;
 					m_rchp0[_chnl] = hp;
@@ -579,13 +572,13 @@ public:
 						? hp + m_rcbp1[_chnl] * m_rcq
 						: bp + m_rcbp1[_chnl] * m_rcq;
 
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_rcc * ( m_rchp1[_chnl] + in - m_rclast1[_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_rcb + m_rcbp1[_chnl] * m_rca;
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_rclast1[_chnl] = in;
 					m_rchp1[_chnl] = hp;
@@ -606,39 +599,39 @@ public:
 				{
 					// first formant
 					in = _in0 + m_vfbp[0][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[0] * ( m_vfhp[0][_chnl] + in - m_vflast[0][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[0] + m_vfbp[0][_chnl] * m_vfa[0];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[0][_chnl] = in;
 					m_vfhp[0][_chnl] = hp;
 					m_vfbp[0][_chnl] = bp;
 
 					in = bp + m_vfbp[2][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[0] * ( m_vfhp[2][_chnl] + in - m_vflast[2][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[0] + m_vfbp[2][_chnl] * m_vfa[0];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[2][_chnl] = in;
 					m_vfhp[2][_chnl] = hp;
 					m_vfbp[2][_chnl] = bp;
 
 					in = bp + m_vfbp[4][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[0] * ( m_vfhp[4][_chnl] + in - m_vflast[4][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[0] + m_vfbp[4][_chnl] * m_vfa[0];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[4][_chnl] = in;
 					m_vfhp[4][_chnl] = hp;
@@ -648,39 +641,39 @@ public:
 
 					// second formant
 					in = _in0 + m_vfbp[0][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[1] * ( m_vfhp[1][_chnl] + in - m_vflast[1][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[1] + m_vfbp[1][_chnl] * m_vfa[1];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[1][_chnl] = in;
 					m_vfhp[1][_chnl] = hp;
 					m_vfbp[1][_chnl] = bp;
 
 					in = bp + m_vfbp[3][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[1] * ( m_vfhp[3][_chnl] + in - m_vflast[3][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[1] + m_vfbp[3][_chnl] * m_vfa[1];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[3][_chnl] = in;
 					m_vfhp[3][_chnl] = hp;
 					m_vfbp[3][_chnl] = bp;
 
 					in = bp + m_vfbp[5][_chnl] * m_vfq;
-					in = qBound( -1.0f, in, 1.0f );
+					in = std::clamp(in, -1.0f, 1.0f);
 
 					hp = m_vfc[1] * ( m_vfhp[5][_chnl] + in - m_vflast[5][_chnl] );
-					hp = qBound( -1.0f, hp, 1.0f );
+					hp = std::clamp(hp, -1.0f, 1.0f);
 
 					bp = hp * m_vfb[1] + m_vfbp[5][_chnl] * m_vfa[1];
-					bp = qBound( -1.0f, bp, 1.0f );
+					bp = std::clamp(bp, -1.0f, 1.0f);
 
 					m_vflast[5][_chnl] = in;
 					m_vfhp[5][_chnl] = hp;
@@ -718,7 +711,7 @@ public:
 			m_type == Bandpass_RC24 ||
 			m_type == Highpass_RC24 )
 		{
-			_freq = qBound( 50.0f, _freq, 20000.0f );
+			_freq = std::clamp(_freq, 50.0f, 20000.0f);
 			const float sr = m_sampleRatio * 0.25f;
 			const float f = 1.0f / ( _freq * F_2PI );
 			
@@ -734,7 +727,7 @@ public:
 		if( m_type == Formantfilter ||
 			m_type == FastFormant )
 		{
-			_freq = qBound( minFreq(), _freq, 20000.0f ); // limit freq and q for not getting bad noise out of the filter...
+			_freq = std::clamp(_freq, minFreq(), 20000.0f); // limit freq and q for not getting bad noise out of the filter...
 
 			// formats for a, e, i, o, u, a
 			static const float _f[6][2] = { { 1000, 1400 }, { 500, 2300 },
@@ -772,7 +765,7 @@ public:
 			m_type == DoubleMoog )
 		{
 			// [ 0 - 0.5 ]
-			const float f = qBound( minFreq(), _freq, 20000.0f ) * m_sampleRatio;
+			const float f = std::clamp(_freq, minFreq(), 20000.0f) * m_sampleRatio;
 			// (Empirical tunning)
 			m_p = ( 3.6f - 3.2f * f ) * f;
 			m_k = 2.0f * m_p - 1;
@@ -789,7 +782,7 @@ public:
 		
 		if( m_type == Tripole )
 		{
-			const float f = qBound( 20.0f, _freq, 20000.0f ) * m_sampleRatio * 0.25f;
+			const float f = std::clamp(_freq, 20.0f, 20000.0f) * m_sampleRatio * 0.25f;
 			
 			m_p = ( 3.6f - 3.2f * f ) * f;
 			m_k = 2.0f * m_p - 1.0f;
@@ -811,7 +804,7 @@ public:
 		}
 
 		// other filters
-		_freq = qBound( minFreq(), _freq, 20000.0f );
+		_freq = std::clamp(_freq, minFreq(), 20000.0f);
 		const float omega = F_2PI * _freq * m_sampleRatio;
 		const float tsin = sinf( omega ) * 0.5f;
 		const float tcos = cosf( omega );

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -797,8 +797,8 @@ public:
 			m_type == Notch_SV )
 		{
 			const float f = sinf(std::max(minFreq(), _freq) * m_sampleRatio * F_PI);
-			m_svf1 = qMin( f, 0.825f );
-			m_svf2 = qMin( f * 2.0f, 0.825f );
+			m_svf1 = std::min(f, 0.825f);
+			m_svf2 = std::min(f * 2.0f, 0.825f);
 			m_svq = std::max(0.0001f, 2.0f - (_q * 0.1995f));
 			return;
 		}

--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -72,12 +72,12 @@ public:
 
 	const QString & itemText( int i ) const
 	{
-		return m_items[qBound<int>( minValue(), i,  maxValue() )].first;
+		return m_items[std::clamp(i, minValue(), maxValue())].first;
 	}
 
 	const PixmapLoader* itemPixmap( int i ) const
 	{
-		return m_items[qBound<int>( minValue(), i, maxValue() )].second.get();
+		return m_items[std::clamp(i, minValue(), maxValue())].second.get();
 	}
 
 	int size() const

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -118,7 +118,7 @@ public:
 
 	inline static float fittedValue( float _val )
 	{
-		return qBound<float>( 0.0f, _val, 1.0f );
+		return std::clamp(_val, 0.0f, 1.0f);
 	}
 
 	static long runningPeriods()

--- a/include/DspEffectLibrary.h
+++ b/include/DspEffectLibrary.h
@@ -187,7 +187,7 @@ namespace lmms::DspEffectLibrary
 	template<typename sample_t>
 	inline sample_t saturate( sample_t x )
 	{
-		return qMin<sample_t>( qMax<sample_t>( -1.0f, x ), 1.0f );
+		return qMin<sample_t>(std::max<sample_t>(-1.0f, x), 1.0f);
 	}
 
 
@@ -198,7 +198,7 @@ namespace lmms::DspEffectLibrary
 				const sample_t _gain,
 				const sample_t _ratio,
 				const FastBassBoost & _orig = FastBassBoost() ) :
-			m_frequency( qMax<sample_t>( _frequency, 10.0 ) ),
+			m_frequency(std::max<sample_t>(_frequency, 10.0)),
 			m_gain1( 1.0 / ( m_frequency + 1.0 ) ),
 			m_gain2( _gain ),
 			m_ratio( _ratio ),

--- a/include/DspEffectLibrary.h
+++ b/include/DspEffectLibrary.h
@@ -187,7 +187,7 @@ namespace lmms::DspEffectLibrary
 	template<typename sample_t>
 	inline sample_t saturate( sample_t x )
 	{
-		return qMin<sample_t>(std::max<sample_t>(-1.0f, x), 1.0f);
+		return std::min<sample_t>(std::max<sample_t>(-1.0f, x), 1.0f);
 	}
 
 

--- a/include/Note.h
+++ b/include/Note.h
@@ -198,7 +198,7 @@ public:
 
 	int midiVelocity( int midiBaseVelocity ) const
 	{
-		return qMin( MidiMaxVelocity, getVolume() * midiBaseVelocity / DefaultVolume );
+		return std::min(MidiMaxVelocity, getVolume() * midiBaseVelocity / DefaultVolume);
 	}
 
 	inline panning_t getPanning() const

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -228,7 +228,7 @@ static inline float logToLinearScale( float min, float max, float value )
 static inline float linearToLogScale( float min, float max, float value )
 {
 	static const float EXP = 1.0f / F_E;
-	const float valueLimited = qBound( min, value, max);
+	const float valueLimited = std::clamp(value, min, max);
 	const float val = ( valueLimited - min ) / ( max - min );
 	if( min < 0 )
 	{

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -214,7 +214,7 @@ static inline float logToLinearScale( float min, float max, float value )
 {
 	if( min < 0 )
 	{
-		const float mmax = qMax( qAbs( min ), qAbs( max ) );
+		const float mmax = qMax(std::abs(min), std::abs(max));
 		const float val = value * ( max - min ) + min;
 		float result = signedPowf( val / mmax, F_E ) * mmax;
 		return std::isnan( result ) ? 0 : result;
@@ -232,7 +232,7 @@ static inline float linearToLogScale( float min, float max, float value )
 	const float val = ( valueLimited - min ) / ( max - min );
 	if( min < 0 )
 	{
-		const float mmax = qMax( qAbs( min ), qAbs( max ) );
+		const float mmax = qMax(std::abs(min), std::abs(max));
 		float result = signedPowf( valueLimited / mmax, EXP ) * mmax;
 		return std::isnan( result ) ? 0 : result;
 	}
@@ -315,14 +315,14 @@ static inline float fastSqrt( float n )
 template<class T>
 static inline T absMax( T a, T b )
 {
-	return qAbs<T>(a) > qAbs<T>(b) ? a : b;
+	return std::abs(a) > std::abs(b) ? a : b;
 }
 
 //! returns value nearest to zero
 template<class T>
 static inline T absMin( T a, T b )
 {
-	return qAbs<T>(a) < qAbs<T>(b) ? a : b;
+	return std::abs(a) < std::abs(b) ? a : b;
 }
 
 

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -214,7 +214,7 @@ static inline float logToLinearScale( float min, float max, float value )
 {
 	if( min < 0 )
 	{
-		const float mmax = qMax(std::abs(min), std::abs(max));
+		const float mmax = std::max(std::abs(min), std::abs(max));
 		const float val = value * ( max - min ) + min;
 		float result = signedPowf( val / mmax, F_E ) * mmax;
 		return std::isnan( result ) ? 0 : result;
@@ -232,7 +232,7 @@ static inline float linearToLogScale( float min, float max, float value )
 	const float val = ( valueLimited - min ) / ( max - min );
 	if( min < 0 )
 	{
-		const float mmax = qMax(std::abs(min), std::abs(max));
+		const float mmax = std::max(std::abs(min), std::abs(max));
 		float result = signedPowf( valueLimited / mmax, EXP ) * mmax;
 		return std::isnan( result ) ? 0 : result;
 	}

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -314,7 +314,7 @@ void AudioEngine::pushInputFrames( sampleFrame * _ab, const f_cnt_t _frames )
 
 	if( frames + _frames > size )
 	{
-		size = qMax( size * 2, frames + _frames );
+		size = std::max(size * 2, frames + _frames);
 		auto ab = new sampleFrame[size];
 		memcpy( ab, buf, frames * sizeof( sampleFrame ) );
 		delete [] buf;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -551,8 +551,8 @@ AudioEngine::StereoSample AudioEngine::getPeakValues(sampleFrame * ab, const f_c
 
 	for (f_cnt_t f = 0; f < frames; ++f)
 	{
-		float const absLeft = qAbs(ab[f][0]);
-		float const absRight = qAbs(ab[f][1]);
+		float const absLeft = std::abs(ab[f][0]);
+		float const absRight = std::abs(ab[f][1]);
 		if (absLeft > peakLeft)
 		{
 			peakLeft = absLeft;

--- a/src/core/AudioEngineProfiler.cpp
+++ b/src/core/AudioEngineProfiler.cpp
@@ -41,7 +41,7 @@ void AudioEngineProfiler::finishPeriod( sample_rate_t sampleRate, fpp_t framesPe
 	int periodElapsed = m_periodTimer.elapsed();
 
 	const float newCpuLoad = periodElapsed / 10000.0f * sampleRate / framesPerPeriod;
-    m_cpuLoad = qBound<int>( 0, ( newCpuLoad * 0.1f + m_cpuLoad * 0.9f ), 100 );
+    m_cpuLoad = std::clamp<int>((newCpuLoad * 0.1f + m_cpuLoad * 0.9f), 0, 100);
 
 	if( m_outputFile.isOpen() )
 	{

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -444,7 +444,7 @@ void AutomatableModel::setStep( const float step )
 
 float AutomatableModel::fittedValue( float value ) const
 {
-	value = qBound<float>( m_minValue, value, m_maxValue );
+	value = std::clamp(value, m_minValue, m_maxValue);
 
 	if( m_step != 0 && m_hasStrictStepSize )
 	{

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -585,7 +585,7 @@ float AutomatableModel::controllerValue( int frameOffset ) const
 		}
 		if( typeInfo<float>::isEqual( m_step, 1 ) && m_hasStrictStepSize )
 		{
-			return qRound( v );
+			return std::round(v);
 		}
 		return v;
 	}
@@ -794,7 +794,7 @@ void AutomatableModel::setUseControllerValue(bool b)
 
 float FloatModel::getRoundedValue() const
 {
-	return qRound( value() / step<float>() ) * step<float>();
+	return std::round(value() / step<float>()) * step<float>();
 }
 
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -354,8 +354,8 @@ float AutomatableModel::inverseScaledValue( float value ) const
 template<class T>
 void roundAt( T& value, const T& where, const T& step_size )
 {
-	if( qAbs<float>( value - where )
-		< typeInfo<float>::minEps() * qAbs<float>( step_size ) )
+	if (std::abs(value - where)
+		< typeInfo<float>::minEps() * std::abs(step_size))
 	{
 		value = where;
 	}

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -225,7 +225,7 @@ TimePos AutomationClip::timeMapLength() const
 void AutomationClip::updateLength()
 {
 	// Do not resize down in case user manually extended up
-	changeLength(qMax(length(), timeMapLength()));
+	changeLength(std::max(length(), timeMapLength()));
 }
 
 
@@ -375,7 +375,7 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 	}
 
 	auto start = TimePos(qMin(tick0, tick1));
-	auto end = TimePos(qMax(tick0, tick1));
+	auto end = TimePos(std::max(tick0, tick1));
 
 	// Make a list of TimePos with nodes to be removed
 	// because we can't simply remove the nodes from
@@ -411,7 +411,7 @@ void AutomationClip::resetNodes(const int tick0, const int tick1)
 	}
 
 	auto start = TimePos(qMin(tick0, tick1));
-	auto end = TimePos(qMax(tick0, tick1));
+	auto end = TimePos(std::max(tick0, tick1));
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)
 	{

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -374,7 +374,7 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	auto start = TimePos(qMin(tick0, tick1));
+	auto start = TimePos(std::min(tick0, tick1));
 	auto end = TimePos(std::max(tick0, tick1));
 
 	// Make a list of TimePos with nodes to be removed
@@ -410,7 +410,7 @@ void AutomationClip::resetNodes(const int tick0, const int tick1)
 		return;
 	}
 
-	auto start = TimePos(qMin(tick0, tick1));
+	auto start = TimePos(std::min(tick0, tick1));
 	auto end = TimePos(std::max(tick0, tick1));
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)

--- a/src/core/BandLimitedWave.cpp
+++ b/src/core/BandLimitedWave.cpp
@@ -109,7 +109,7 @@ void BandLimitedWave::generateWaves()
 					harm++;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLSaw ].setSampleAt( i, ph, s );
-				max = qMax(max, std::abs(s));
+				max = std::max(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )
@@ -151,7 +151,7 @@ void BandLimitedWave::generateWaves()
 					harm += 2;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLSquare ].setSampleAt( i, ph, s );
-				max = qMax(max, std::abs(s));
+				max = std::max(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )
@@ -193,7 +193,7 @@ void BandLimitedWave::generateWaves()
 					harm += 2;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLTriangle ].setSampleAt( i, ph, s );
-				max = qMax(max, std::abs(s));
+				max = std::max(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )

--- a/src/core/BandLimitedWave.cpp
+++ b/src/core/BandLimitedWave.cpp
@@ -109,7 +109,7 @@ void BandLimitedWave::generateWaves()
 					harm++;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLSaw ].setSampleAt( i, ph, s );
-				max = qMax( max, qAbs( s ) );
+				max = qMax(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )
@@ -151,7 +151,7 @@ void BandLimitedWave::generateWaves()
 					harm += 2;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLSquare ].setSampleAt( i, ph, s );
-				max = qMax( max, qAbs( s ) );
+				max = qMax(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )
@@ -193,7 +193,7 @@ void BandLimitedWave::generateWaves()
 					harm += 2;
 				} while( hlen > 2.0 );
 				s_waveforms[ BandLimitedWave::BLTriangle ].setSampleAt( i, ph, s );
-				max = qMax( max, qAbs( s ) );
+				max = qMax(max, std::abs(s));
 			}
 			// normalize
 			for( int ph = 0; ph < len; ph++ )

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -92,7 +92,7 @@ Clip::~Clip()
  */
 void Clip::movePosition( const TimePos & pos )
 {
-	TimePos newPos = qMax(0, pos.getTicks());
+	TimePos newPos = std::max(0, pos.getTicks());
 	if (m_startPosition != newPos)
 	{
 		Engine::audioEngine()->requestChangeInModel();

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -77,9 +77,9 @@ ConfigManager::ConfigManager() :
 	m_sf2Dir = m_workingDir + SF2_PATH;
 	m_gigDir = m_workingDir + GIG_PATH;
 	m_themeDir = defaultThemeDir();
-	if (!qgetenv("LMMS_DATA_DIR").isEmpty())
+	if (std::getenv("LMMS_DATA_DIR"))
 	{
-		QDir::addSearchPath("data", QString::fromLocal8Bit(qgetenv("LMMS_DATA_DIR")));
+		QDir::addSearchPath("data", QString::fromLocal8Bit(std::getenv("LMMS_DATA_DIR")));
 	}
 	initDevelopmentWorkingDir();
 
@@ -557,8 +557,8 @@ void ConfigManager::loadConfigFile(const QString & configFile)
 	upgrade();
 
 	QStringList searchPaths;
-	if(! qgetenv("LMMS_THEME_PATH").isNull())
-		searchPaths << qgetenv("LMMS_THEME_PATH");
+	if (std::getenv("LMMS_THEME_PATH"))
+		searchPaths << std::getenv("LMMS_THEME_PATH");
 	searchPaths << themeDir() << defaultThemeDir();
 	QDir::setSearchPaths("resources", searchPaths);
 

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -274,7 +274,7 @@ inline void EnvelopeAndLfoParameters::fillLfoLevel( float * _buf,
 	}
 
 	fpp_t offset = 0;
-	const float lafI = 1.0f / qMax( minimumFrames, m_lfoAttackFrames );
+	const float lafI = 1.0f / std::max(minimumFrames, m_lfoAttackFrames);
 	for( ; offset < _frames && _frame < m_lfoAttackFrames; ++offset,
 								++_frame )
 	{
@@ -404,16 +404,16 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 	// TODO: Remove the expKnobVals, time should be linear
 	const auto predelay_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_predelayModel.value()));
 
-	const f_cnt_t attack_frames = qMax( minimumFrames,
-					static_cast<f_cnt_t>( frames_per_env_seg *
-					expKnobVal( m_attackModel.value() ) ) );
+	const f_cnt_t attack_frames = std::max(minimumFrames,
+					static_cast<f_cnt_t>(frames_per_env_seg *
+					expKnobVal(m_attackModel.value())));
 
 	const auto hold_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_holdModel.value()));
 
-	const f_cnt_t decay_frames = qMax( minimumFrames,
-					static_cast<f_cnt_t>( frames_per_env_seg *
-					expKnobVal( m_decayModel.value() *
-					( 1 - m_sustainModel.value() ) ) ) );
+	const f_cnt_t decay_frames = std::max(minimumFrames,
+					static_cast<f_cnt_t>(frames_per_env_seg *
+					expKnobVal(m_decayModel.value() *
+					(1 - m_sustainModel.value()))));
 
 	m_sustainLevel = m_sustainModel.value();
 	m_amount = m_amountModel.value();
@@ -430,7 +430,7 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 								decay_frames;
 	m_rFrames = static_cast<f_cnt_t>( frames_per_env_seg *
 					expKnobVal( m_releaseModel.value() ) );
-	m_rFrames = qMax( minimumFrames, m_rFrames );
+	m_rFrames = std::max(minimumFrames, m_rFrames);
 
 	if( static_cast<int>( floorf( m_amount * 1000.0f ) ) == 0 )
 	{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -185,8 +185,8 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 	if( fl <= desiredReleaseFrames()+fpp )
 	{
 		for( fpp_t f = (fpp_t)( ( fl > desiredReleaseFrames() ) ?
-				( qMax( fpp - desiredReleaseFrames(), 0 ) +
-					fl % fpp ) : 0 ); f < frames; ++f )
+				(std::max(fpp - desiredReleaseFrames(), 0) +
+					fl % fpp) : 0); f < frames; ++f)
 		{
 			const float fac = (float)( fl-f-1 ) /
 							desiredReleaseFrames();

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -317,7 +317,7 @@ f_cnt_t InstrumentSoundShaping::releaseFrames() const
 	{
 		if( m_envLfoParameters[i]->isUsed() )
 		{
-			ret_val = qMax( ret_val, m_envLfoParameters[i]->releaseFrames() );
+			ret_val = std::max(ret_val, m_envLfoParameters[i]->releaseFrames());
 		}
 	}
 	return ret_val;

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -109,7 +109,7 @@ void LfoController::updateValueBuffer()
 			? m_sampleFunction( phase )
 			: m_userDefSampleBuffer->userWaveSample( phase );
 
-		f = qBound( 0.0f, m_baseModel.value() + ( *amountPtr * currentSample / 2.0f ), 1.0f );
+		f = std::clamp(m_baseModel.value() + (*amountPtr * currentSample / 2.0f), 0.0f, 1.0f);
 
 		phase += 1.0 / m_duration;
 		amountPtr += amountInc;

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -121,7 +121,7 @@ bool sanitize( sampleFrame * src, int frames )
 			}
 			else
 			{
-				src[f][c] = qBound( -1000.0f, src[f][c], 1000.0f );
+				src[f][c] = std::clamp(src[f][c], -1000.0f, 1000.0f);
 			}
 		}
 	}

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -173,8 +173,8 @@ void MixerChannel::doProcessing()
 		m_stillRunning = m_fxChain.processAudioBuffer( m_buffer, fpp, m_hasInput );
 
 		AudioEngine::StereoSample peakSamples = Engine::audioEngine()->getPeakValues(m_buffer, fpp);
-		m_peakLeft = qMax( m_peakLeft, peakSamples.left * v );
-		m_peakRight = qMax( m_peakRight, peakSamples.right * v );
+		m_peakLeft = std::max(m_peakLeft, peakSamples.left * v);
+		m_peakRight = std::max(m_peakRight, peakSamples.right * v);
 	}
 	else
 	{

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -38,13 +38,13 @@ Note::Note( const TimePos & length, const TimePos & pos,
 		int key, volume_t volume, panning_t panning,
 						DetuningHelper * detuning ) :
 	m_selected( false ),
-	m_oldKey( qBound( 0, key, NumKeys ) ),
+	m_oldKey(std::clamp(key, 0, NumKeys)),
 	m_oldPos( pos ),
 	m_oldLength( length ),
 	m_isPlaying( false ),
-	m_key( qBound( 0, key, NumKeys ) ),
-	m_volume( qBound( MinVolume, volume, MaxVolume ) ),
-	m_panning( qBound( PanningLeft, panning, PanningRight ) ),
+	m_key(std::clamp(key, 0, NumKeys)),
+	m_volume(std::clamp(volume, MinVolume, MaxVolume)),
+	m_panning(std::clamp(panning, PanningLeft, PanningRight)),
 	m_length( length ),
 	m_pos( pos ),
 	m_detuning( nullptr )
@@ -114,7 +114,7 @@ void Note::setPos( const TimePos & pos )
 
 void Note::setKey( const int key )
 {
-	const int k = qBound( 0, key, NumKeys - 1 );
+	const int k = std::clamp(key, 0, NumKeys - 1);
 	m_key = k;
 }
 
@@ -123,7 +123,7 @@ void Note::setKey( const int key )
 
 void Note::setVolume( volume_t volume )
 {
-	const volume_t v = qBound( MinVolume, volume, MaxVolume );
+	const volume_t v = std::clamp(volume, MinVolume, MaxVolume);
 	m_volume = v;
 }
 
@@ -132,7 +132,7 @@ void Note::setVolume( volume_t volume )
 
 void Note::setPanning( panning_t panning )
 {
-	const panning_t p = qBound( PanningLeft, panning, PanningRight );
+	const panning_t p = std::clamp(panning, PanningLeft, PanningRight);
 	m_panning = p;
 }
 

--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -192,7 +192,7 @@ void Note::saveSettings( QDomDocument & doc, QDomElement & parent )
 void Note::loadSettings( const QDomElement & _this )
 {
 	const int oldKey = _this.attribute( "tone" ).toInt() + _this.attribute( "oct" ).toInt() * KeysPerOctave;
-	m_key = qMax( oldKey, _this.attribute( "key" ).toInt() );
+	m_key = std::max(oldKey, _this.attribute("key").toInt());
 	m_volume = _this.attribute( "vol" ).toInt();
 	m_panning = _this.attribute( "pan" ).toInt();
 	m_length = _this.attribute( "len" ).toInt();

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -384,7 +384,7 @@ void NotePlayHandle::noteOff( const f_cnt_t _s )
 
 	// then set some variables indicating release-state
 	m_framesBeforeRelease = _s;
-	m_releaseFramesToDo = qMax<f_cnt_t>( 0, actualReleaseFramesToDo() );
+	m_releaseFramesToDo = std::max<f_cnt_t>(0, actualReleaseFramesToDo());
 
 	if( m_hasMidiNote )
 	{

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -350,9 +350,9 @@ fpp_t NotePlayHandle::framesLeftForCurrentPeriod() const
 {
 	if( m_totalFramesPlayed == 0 )
 	{
-		return (fpp_t) qMin<f_cnt_t>( framesLeft(), Engine::audioEngine()->framesPerPeriod() - offset() );
+		return static_cast<fpp_t>(std::min<f_cnt_t>(framesLeft(), Engine::audioEngine()->framesPerPeriod() - offset()));
 	}
-	return (fpp_t) qMin<f_cnt_t>( framesLeft(), Engine::audioEngine()->framesPerPeriod() );
+	return static_cast<fpp_t>(std::min<f_cnt_t>(framesLeft(), Engine::audioEngine()->framesPerPeriod()));
 }
 
 

--- a/src/core/PatternStore.cpp
+++ b/src/core/PatternStore.cpp
@@ -97,7 +97,7 @@ bar_t PatternStore::lengthOfPattern(int pattern) const
 		// Don't create Clips here if they don't exist
 		if (pattern < t->numOfClips())
 		{
-			maxLength = qMax(maxLength, t->getClip(pattern)->length());
+			maxLength = std::max(maxLength, t->getClip(pattern)->length());
 		}
 	}
 
@@ -125,7 +125,7 @@ void PatternStore::removePattern(int pattern)
 	}
 	if (pattern <= currentPattern())
 	{
-		setCurrentPattern(qMax(currentPattern() - 1, 0));
+		setCurrentPattern(std::max(currentPattern() - 1, 0));
 	}
 }
 

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -85,7 +85,6 @@ void PluginFactory::setupSearchPaths()
 	addRelativeIfExists(PLUGIN_DIR);
 #endif
 	// Or via an environment variable:
-	QString env_path;
 	if (const char* env_path = std::getenv("LMMS_PLUGIN_DIR"))
 		QDir::addSearchPath("plugins", env_path);
 

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -86,7 +86,7 @@ void PluginFactory::setupSearchPaths()
 #endif
 	// Or via an environment variable:
 	QString env_path;
-	if (!(env_path = qgetenv("LMMS_PLUGIN_DIR")).isEmpty())
+	if (const char* env_path = std::getenv("LMMS_PLUGIN_DIR"))
 		QDir::addSearchPath("plugins", env_path);
 
 	QDir::addSearchPath("plugins", ConfigManager::inst()->workingDir() + "plugins");

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -95,7 +95,7 @@ int ProjectVersion::compare(const ProjectVersion & a, const ProjectVersion & b, 
 	if(aPat != bPat){ return aPat - bPat; }
 
 	// Decide how many optional identifiers we care about
-	const int maxLabels = qMax(0, limit - 3);
+	const int maxLabels = std::max(0, limit - 3);
 	const auto aLabels = a.getLabels().mid(0, maxLabels);
 	const auto bLabels = b.getLabels().mid(0, maxLabels);
 

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -100,7 +100,7 @@ int ProjectVersion::compare(const ProjectVersion & a, const ProjectVersion & b, 
 	const auto bLabels = b.getLabels().mid(0, maxLabels);
 
 	// We can only compare identifiers if both versions have them
-	const int commonLabels = qMin(aLabels.size(), bLabels.size());
+	const int commonLabels = std::min(aLabels.size(), bLabels.size());
 	// If one version has optional labels and the other doesn't,
 	// the one without them is bigger
 	if (commonLabels == 0){ return bLabels.size() - aLabels.size(); }

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -359,7 +359,7 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 
 	memset( m_audioBuffer.get(), 0, m_audioBufferSize );
 
-	ch_cnt_t inputs = qMin<ch_cnt_t>( m_inputCount, DEFAULT_CHANNELS );
+	ch_cnt_t inputs = std::min<ch_cnt_t>(m_inputCount, DEFAULT_CHANNELS);
 
 	if( _in_buf != nullptr && inputs > 0 )
 	{
@@ -403,8 +403,8 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 	waitForMessage( IdProcessingDone );
 	unlock();
 
-	const ch_cnt_t outputs = qMin<ch_cnt_t>( m_outputCount,
-							DEFAULT_CHANNELS );
+	const ch_cnt_t outputs = std::min<ch_cnt_t>(m_outputCount,
+							DEFAULT_CHANNELS);
 	if( m_splitChannels )
 	{
 		for( ch_cnt_t ch = 0; ch < outputs; ++ch )
@@ -427,8 +427,8 @@ bool RemotePlugin::process( const sampleFrame * _in_buf, sampleFrame * _out_buf 
 		// clear buffer, if plugin didn't fill up both channels
 		BufferManager::clear( _out_buf, frames );
 
-		for( ch_cnt_t ch = 0; ch <
-				qMin<int>( DEFAULT_CHANNELS, outputs ); ++ch )
+		for (ch_cnt_t ch = 0; ch <
+				std::min<int>(DEFAULT_CHANNELS, outputs); ++ch)
 		{
 			for( fpp_t frame = 0; frame < frames; ++frame )
 			{

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -456,10 +456,10 @@ void SampleBuffer::normalizeSampleRate(const sample_rate_t srcSR, bool keepSetti
 	{
 		auto oldRateToNewRateRatio = static_cast<float>(audioEngineSampleRate()) / oldRate;
 
-		m_startFrame = qBound(0, f_cnt_t(m_startFrame * oldRateToNewRateRatio), m_frames);
-		m_endFrame = qBound(m_startFrame, f_cnt_t(m_endFrame * oldRateToNewRateRatio), m_frames);
-		m_loopStartFrame = qBound(0, f_cnt_t(m_loopStartFrame * oldRateToNewRateRatio), m_frames);
-		m_loopEndFrame = qBound(m_loopStartFrame, f_cnt_t(m_loopEndFrame * oldRateToNewRateRatio), m_frames);
+		m_startFrame = std::clamp(f_cnt_t(m_startFrame * oldRateToNewRateRatio), 0, m_frames);
+		m_endFrame = std::clamp(f_cnt_t(m_endFrame * oldRateToNewRateRatio), m_startFrame, m_frames);
+		m_loopStartFrame = std::clamp(f_cnt_t(m_loopStartFrame * oldRateToNewRateRatio), 0, m_frames);
+		m_loopEndFrame = std::clamp(f_cnt_t(m_loopEndFrame * oldRateToNewRateRatio), m_loopStartFrame, m_frames);
 		m_sampleRate = audioEngineSampleRate();
 	}
 }
@@ -1085,8 +1085,8 @@ void SampleBuffer::visualize(
 
 		const float trueRmsData = (rmsData[0] + rmsData[1]) / 2 / fpp;
 		const float sqrtRmsData = sqrt(trueRmsData);
-		const float maxRmsData = qBound(minData, sqrtRmsData, maxData);
-		const float minRmsData = qBound(minData, -sqrtRmsData, maxData);
+		const float maxRmsData = std::clamp(sqrtRmsData, minData, maxData);
+		const float minRmsData = std::clamp(-sqrtRmsData, minData, maxData);
 
 		// If nbFrames >= w, we can use curPixel to calculate X
 		// but if nbFrames < w, we need to calculate it proportionally

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -915,12 +915,12 @@ sampleFrame * SampleBuffer::getSampleFragment(
 	}
 	else if (loopMode == LoopOn)
 	{
-		f_cnt_t copied = qMin(frames, loopEnd - index);
+		f_cnt_t copied = std::min(frames, loopEnd - index);
 		memcpy(*tmp, m_data + index, copied * BYTES_PER_FRAME);
 		f_cnt_t loopFrames = loopEnd - loopStart;
 		while (copied < frames)
 		{
-			f_cnt_t todo = qMin(frames - copied, loopFrames);
+			f_cnt_t todo = std::min(frames - copied, loopFrames);
 			memcpy(*tmp + copied, m_data + loopStart, todo * BYTES_PER_FRAME);
 			copied += todo;
 		}
@@ -936,7 +936,7 @@ sampleFrame * SampleBuffer::getSampleFragment(
 
 		if (currentBackwards)
 		{
-			copied = qMin(frames, pos - loopStart);
+			copied = std::min(frames, pos - loopStart);
 			for (int i = 0; i < copied; i++)
 			{
 				(*tmp)[i][0] = m_data[pos - i][0];
@@ -947,7 +947,7 @@ sampleFrame * SampleBuffer::getSampleFragment(
 		}
 		else
 		{
-			copied = qMin(frames, loopEnd - pos);
+			copied = std::min(frames, loopEnd - pos);
 			memcpy(*tmp, m_data + pos, copied * BYTES_PER_FRAME);
 			pos += copied;
 			if (pos == loopEnd) { currentBackwards = true; }
@@ -957,7 +957,7 @@ sampleFrame * SampleBuffer::getSampleFragment(
 		{
 			if (currentBackwards)
 			{
-				f_cnt_t todo = qMin(frames - copied, pos - loopStart);
+				f_cnt_t todo = std::min(frames - copied, pos - loopStart);
 				for (int i = 0; i < todo; i++)
 				{
 					(*tmp)[copied + i][0] = m_data[pos - i][0];
@@ -969,7 +969,7 @@ sampleFrame * SampleBuffer::getSampleFragment(
 			}
 			else
 			{
-				f_cnt_t todo = qMin(frames - copied, loopEnd - pos);
+				f_cnt_t todo = std::min(frames - copied, loopEnd - pos);
 				memcpy(*tmp + copied, m_data + pos, todo * BYTES_PER_FRAME);
 				pos += todo;
 				copied += todo;
@@ -1291,7 +1291,7 @@ QString & SampleBuffer::toBase64(QString & dst) const
 
 	while (frameCnt < m_frames)
 	{
-		f_cnt_t remaining = qMin<f_cnt_t>(FRAMES_PER_BUF, m_frames - frameCnt);
+		f_cnt_t remaining = std::min<f_cnt_t>(FRAMES_PER_BUF, m_frames - frameCnt);
 		FLAC__int32 buf[FRAMES_PER_BUF * DEFAULT_CHANNELS];
 		for (f_cnt_t f = 0; f < remaining; ++f)
 		{

--- a/src/core/SampleBuffer.cpp
+++ b/src/core/SampleBuffer.cpp
@@ -736,7 +736,7 @@ bool SampleBuffer::play(
 
 
 	// this holds the index of the first frame to play
-	f_cnt_t playFrame = qMax(state->m_frameIndex, startFrame);
+	f_cnt_t playFrame = std::max(state->m_frameIndex, startFrame);
 
 	if (loopMode == LoopOff)
 	{

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -117,7 +117,7 @@ SampleClip::~SampleClip()
 
 void SampleClip::changeLength( const TimePos & _length )
 {
-	Clip::changeLength( qMax( static_cast<int>( _length ), 1 ) );
+	Clip::changeLength(std::max(static_cast<int>(_length), 1));
 }
 
 

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -194,7 +194,7 @@ tick_t TimePos::ticksPerBar( const TimeSig &sig )
 int TimePos::stepsPerBar()
 {
 	int steps = ticksPerBar() / DefaultBeatsPerBar;
-	return qMax( 1, steps );
+	return std::max(1, steps);
 }
 
 

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -299,7 +299,7 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 			}
 			TimePos relTime = time - p->startPosition();
 			if (! p->getAutoResize()) {
-				relTime = qMin(relTime, p->length());
+				relTime = std::min(relTime, p->length());
 			}
 			float value = p->valueAt(relTime);
 

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -328,7 +328,7 @@ void AudioAlsa::run()
 						outbuf,
 						m_convertEndian );
 			}
-			int min_len = qMin( len, outbuf_size - outbuf_pos );
+			int min_len = std::min(len, outbuf_size - outbuf_pos);
 			memcpy( ptr, outbuf + outbuf_pos,
 					min_len * sizeof( int_sample_t ) );
 			ptr += min_len;

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -87,7 +87,7 @@ AudioAlsa::AudioAlsa( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	int count = snd_pcm_poll_descriptors_count( m_handle );
 	ufds = new pollfd[count];
 	snd_pcm_poll_descriptors( m_handle, ufds, count );
-	for( int i = 0; i < qMax( 3, count ); ++i )
+	for (int i = 0; i < std::max(3, count); ++i)
 	{
 		const int fd = ( i >= count ) ? ufds[0].fd+i : ufds[i].fd;
 		int oldflags = fcntl( fd, F_GETFD, 0 );

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -36,10 +36,10 @@ namespace lmms
 {
 
 AudioAlsa::AudioAlsa( bool & _success_ful, AudioEngine*  _audioEngine ) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audioalsa", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audioalsa", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_handle( nullptr ),
 	m_hwParams( nullptr ),
 	m_swParams( nullptr ),

--- a/src/core/audio/AudioFileFlac.cpp
+++ b/src/core/audio/AudioFileFlac.cpp
@@ -104,7 +104,7 @@ void AudioFileFlac::writeBuffer(surroundSampleFrame const* _ab, fpp_t const fram
 				// Clip the negative side to just above -1.0 in order to prevent it from changing sign
 				// Upstream issue: https://github.com/erikd/libsndfile/issues/309
 				// When this commit is reverted libsndfile-1.0.29 must be made a requirement for FLAC
-				buf[frame*channels() + channel] = qMax( clipvalue, _ab[frame][channel] * master_gain );
+				buf[frame*channels() + channel] = std::max(clipvalue, _ab[frame][channel] * master_gain);
 			}
 		}
 		sf_writef_float(m_sf, static_cast<float*>(buf.data()), frames);

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -44,10 +44,10 @@ namespace lmms
 {
 
 AudioJack::AudioJack( bool & _success_ful, AudioEngine*  _audioEngine ) :
-	AudioDevice( qBound<int>(
+	AudioDevice(std::clamp<int>(
+		ConfigManager::inst()->value("audiojack", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audiojack", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_client( nullptr ),
 	m_active( false ),
 	m_midiClient( nullptr ),

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -364,7 +364,7 @@ int AudioJack::processCallback( jack_nframes_t _nframes, void * _udata )
 	}
 
 #ifdef AUDIO_PORT_SUPPORT
-	const int frames = qMin<int>( _nframes, audioEngine()->framesPerPeriod() );
+	const int frames = std::min<int>(_nframes, audioEngine()->framesPerPeriod());
 	for( JackPortMap::iterator it = m_portMap.begin();
 						it != m_portMap.end(); ++it )
 	{
@@ -389,10 +389,10 @@ int AudioJack::processCallback( jack_nframes_t _nframes, void * _udata )
 	jack_nframes_t done = 0;
 	while( done < _nframes && m_stopped == false )
 	{
-		jack_nframes_t todo = qMin<jack_nframes_t>(
+		jack_nframes_t todo = std::min<jack_nframes_t>(
 						_nframes,
 						m_framesToDoInCurBuf -
-							m_framesDoneInCurBuf );
+							m_framesDoneInCurBuf);
 		const float gain = audioEngine()->masterGain();
 		for( int c = 0; c < channels(); ++c )
 		{

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -70,10 +70,10 @@ static const QString PATH_DEV_DSP =
 
 
 AudioOss::AudioOss( bool & _success_ful, AudioEngine*  _audioEngine ) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audiooss", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audiooss", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_convertEndian( false )
 {
 	_success_ful = false;

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -62,10 +62,10 @@ namespace lmms
 
 
 AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine ) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audioportaudio", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audioportaudio", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_paStream( nullptr ),
 	m_wasPAInitError( false ),
 	m_outBuf( new surroundSampleFrame[audioEngine()->framesPerPeriod()] ),

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -496,12 +496,12 @@ void AudioPortAudio::setupWidget::show()
 		const QString& device = ConfigManager::inst()->value(
 			"audioportaudio", "device" );
 		
-		int i = qMax( 0, m_setupUtil.m_backendModel.findText( backend ) );
+		int i = std::max(0, m_setupUtil.m_backendModel.findText(backend));
 		m_setupUtil.m_backendModel.setValue( i );
 		
 		m_setupUtil.updateDevices();
 		
-		i = qMax( 0, m_setupUtil.m_deviceModel.findText( device ) );
+		i = std::max(0, m_setupUtil.m_deviceModel.findText(device));
 		m_setupUtil.m_deviceModel.setValue( i );
 	}
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -295,8 +295,8 @@ int AudioPortAudio::process_callback(
 			}
 			m_outBufSize = frames;
 		}
-		const int min_len = qMin( (int)_framesPerBuffer,
-			m_outBufSize - m_outBufPos );
+		const int min_len = std::min(static_cast<int>(_framesPerBuffer),
+			m_outBufSize - m_outBufPos);
 
 		float master_gain = audioEngine()->masterGain();
 

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -47,10 +47,10 @@ static void stream_write_callback(pa_stream *s, size_t length, void *userdata)
 
 
 AudioPulseAudio::AudioPulseAudio( bool & _success_ful, AudioEngine*  _audioEngine ) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audiopa", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audiopa", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_s( nullptr ),
 	m_quit( false ),
 	m_convertEndian( false )

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -257,9 +257,9 @@ void AudioSdl::sdlAudioCallback( Uint8 * _buf, int _len )
 			m_currentBufferFramesCount = frames;
 
 		}
-		const uint min_frames_count = qMin( _len/sizeof(sampleFrame),
+		const uint min_frames_count = std::min(_len/sizeof(sampleFrame),
 										  m_currentBufferFramesCount
-										- m_currentBufferFramePos );
+										- m_currentBufferFramePos);
 
 		const float gain = audioEngine()->masterGain();
 		for (uint f = 0; f < min_frames_count; f++)
@@ -296,8 +296,8 @@ void AudioSdl::sdlAudioCallback( Uint8 * _buf, int _len )
 						(int_sample_t *)m_convertedBuf,
 						m_outConvertEndian );
 		}
-		const int min_len = qMin( _len, m_convertedBufSize
-							- m_convertedBufPos );
+		const int min_len = std::min(_len, m_convertedBufSize
+							- m_convertedBufPos);
 		memcpy( _buf, m_convertedBuf + m_convertedBufPos, min_len );
 		_buf += min_len;
 		_len -= min_len;

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -70,7 +70,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 						// to convert the buffers
 #endif
 	m_audioHandle.channels = channels();
-	m_audioHandle.samples = qMax( 1024, audioEngine()->framesPerPeriod()*2 );
+	m_audioHandle.samples = std::max(1024, audioEngine()->framesPerPeriod() * 2);
 
 	m_audioHandle.callback = sdlAudioCallback;
 	m_audioHandle.userdata = this;

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -44,10 +44,10 @@ namespace lmms
 {
 
 AudioSndio::AudioSndio(bool & _success_ful, AudioEngine * _audioEngine) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audiosndio", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audiosndio", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine ),
+		SURROUND_CHANNELS), _audioEngine),
 	m_convertEndian ( false )
 {
 	_success_ful = false;

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -40,10 +40,10 @@ namespace lmms
 {
 
 AudioSoundIo::AudioSoundIo( bool & outSuccessful, AudioEngine * _audioEngine ) :
-	AudioDevice( qBound<ch_cnt_t>(
+	AudioDevice(std::clamp<ch_cnt_t>(
+		ConfigManager::inst()->value("audiosoundio", "channels").toInt(),
 		DEFAULT_CHANNELS,
-		ConfigManager::inst()->value( "audiosoundio", "channels" ).toInt(),
-		SURROUND_CHANNELS ), _audioEngine )
+		SURROUND_CHANNELS), _audioEngine)
 {
 	outSuccessful = false;
 	m_soundio = nullptr;

--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -259,7 +259,7 @@ void MidiApple::HandleReadCallback( const MIDIPacketList *pktlist, void *srcConn
 		nBytes = packet->length;
 		// Check if this is the end of a continued SysEx message
 		if (continueSysEx) {
-			unsigned int lengthToCopy = qMin(nBytes, SYSEX_LENGTH - sysExLength);
+			unsigned int lengthToCopy = std::min(nBytes, SYSEX_LENGTH - sysExLength);
 			// Copy the message into our SysEx message buffer,
 			// making sure not to overrun the buffer
 			memcpy(sysExMessage + sysExLength, packet->data, lengthToCopy);
@@ -298,7 +298,7 @@ void MidiApple::HandleReadCallback( const MIDIPacketList *pktlist, void *srcConn
 				{
 					// MIDI SysEx then we copy the rest of the message into the SysEx message buffer
 					unsigned int lengthLeftInMessage = nBytes - iByte;
-					unsigned int lengthToCopy = qMin(lengthLeftInMessage, SYSEX_LENGTH);
+					unsigned int lengthToCopy = std::min(lengthLeftInMessage, SYSEX_LENGTH);
 					
 					memcpy(sysExMessage + sysExLength, packet->data, lengthToCopy);
 					sysExLength += lengthToCopy;

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -265,7 +265,7 @@ void InstrumentTrack::processAudioBuffer( sampleFrame* buf, const fpp_t frames, 
 		const f_cnt_t offset = n->noteOffset();
 		m_soundShaping.processAudioBuffer( buf + offset, frames - offset, n );
 		const float vol = ( (float) n->getVolume() * DefaultVolumeRatio );
-		const panning_t pan = qBound( PanningLeft, n->getPanning(), PanningRight );
+		const panning_t pan = std::clamp(n->getPanning(), PanningLeft, PanningRight);
 		StereoVolumeVector vv = panningToVolumeVector( pan, vol );
 		for( f_cnt_t f = offset; f < frames; ++f )
 		{
@@ -666,7 +666,7 @@ int InstrumentTrack::masterKey( int _midi_key ) const
 {
 
 	int key = baseNote();
-	return qBound<int>( 0, _midi_key - ( key - DefaultKey ), NumKeys );
+	return std::clamp(_midi_key - (key - DefaultKey), 0, NumKeys);
 }
 
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -157,7 +157,7 @@ void MidiClip::updateLength()
 	{
 		if (note->length() > 0)
 		{
-			max_length = qMax<tick_t>(max_length, note->endPos());
+			max_length = std::max<tick_t>(max_length, note->endPos());
 		}
 	}
 	changeLength( TimePos( max_length ).nextFullBar() *
@@ -176,7 +176,7 @@ TimePos MidiClip::beatClipLength() const
 	{
 		if (note->length() < 0)
 		{
-			max_length = qMax<tick_t>(max_length, note->pos() + 1);
+			max_length = std::max<tick_t>(max_length, note->pos() + 1);
 		}
 	}
 
@@ -591,8 +591,8 @@ void MidiClip::changeTimeSignature()
 		}
 	}
 	last_pos = last_pos.nextFullBar() * TimePos::ticksPerBar();
-	m_steps = qMax<tick_t>( TimePos::stepsPerBar(),
-				last_pos.getBar() * TimePos::stepsPerBar() );
+	m_steps = std::max<tick_t>(TimePos::stepsPerBar(),
+				last_pos.getBar() * TimePos::stepsPerBar());
 	updateLength();
 }
 


### PR DESCRIPTION
Replaces the functions ``qBound``, ``qMax``, ``qMin``, ``qRound``, and ``qgetenv`` with ``std::clamp``, ``std::max``, ``std::min``, ``std::round``, and ``std::getenv`` respectively. These were the only functions used within the core that were provided by Qt's global declarations.