### PR TITLE
Fix regressions in #6477

### DIFF
--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -559,7 +559,7 @@ DataFile ClipView::createClipDataFiles(
 	// Add extra metadata needed for calculations later
 
 	const auto initialTrackIt = std::find(tc->tracks().begin(), tc->tracks().end(), t);
-	if (initialTrackIt != tc->tracks().end())
+	if (initialTrackIt == tc->tracks().end())
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");
 		return dataFile;

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -263,7 +263,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 
 				if (it != controllers.end())
 				{
-					int idx = std::distance(it, controllers.begin());
+					int idx = std::distance(controllers.begin(), it);
 					m_userGroupBox->model()->setValue( true );
 					m_userController->model()->setValue( idx );
 				}


### PR DESCRIPTION
Fixes two regressions in #6477. One being an incorrect if statement, and the other a mismatch in the parameter order for ``std::distance``.

Fixes #6824
Fixes #6825