### PR TITLE
fixes #6759: Tempo Sync Knob - Context menu string don't update on custom tempo

### DIFF
--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -117,8 +117,7 @@ void TempoSyncKnobModel::calculateTempoSyncTime( bpm_t _bpm )
 		emit syncModeChanged( m_tempoSyncMode );
 		m_tempoLastSyncMode = m_tempoSyncMode;
 	}
-
-	if ( m_tempoSyncMode == SyncMode::Custom )
+	else if ( m_tempoSyncMode == SyncMode::Custom )
 	{
 		emit syncModeChanged( m_tempoSyncMode );
 	}

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -117,6 +117,11 @@ void TempoSyncKnobModel::calculateTempoSyncTime( bpm_t _bpm )
 		emit syncModeChanged( m_tempoSyncMode );
 		m_tempoLastSyncMode = m_tempoSyncMode;
 	}
+
+	if ( m_tempoSyncMode == SyncMode::Custom )
+	{
+		emit syncModeChanged( m_tempoSyncMode );
+	}
 }
 
 

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -119,7 +119,7 @@ void TempoSyncKnobModel::calculateTempoSyncTime( bpm_t _bpm )
 	}
 	else if (m_tempoSyncMode == SyncMode::Custom)
 	{
-		emit syncModeChanged( m_tempoSyncMode );
+		emit syncModeChanged(m_tempoSyncMode);
 	}
 }
 

--- a/src/core/TempoSyncKnobModel.cpp
+++ b/src/core/TempoSyncKnobModel.cpp
@@ -117,7 +117,7 @@ void TempoSyncKnobModel::calculateTempoSyncTime( bpm_t _bpm )
 		emit syncModeChanged( m_tempoSyncMode );
 		m_tempoLastSyncMode = m_tempoSyncMode;
 	}
-	else if ( m_tempoSyncMode == SyncMode::Custom )
+	else if (m_tempoSyncMode == SyncMode::Custom)
 	{
 		emit syncModeChanged( m_tempoSyncMode );
 	}

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -76,7 +76,8 @@ void TempoSyncKnob::modelChanged()
 		m_custom->setModel( &model()->m_custom );
 	}
 	connect(model(), &TempoSyncKnobModel::syncModeChanged, this, &TempoSyncKnob::updateDescAndIcon);
-	connect(this, &TempoSyncKnob::sliderMoved, model(), &TempoSyncKnobModel::disableSync);
+	connect( this, SIGNAL(sliderMoved(float)),
+			model(), SLOT(disableSync()));
 	updateDescAndIcon();
 }
 

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -75,7 +75,7 @@ void TempoSyncKnob::modelChanged()
 	{
 		m_custom->setModel( &model()->m_custom );
 	}
-	connect( model(), SIGNAL(syncModeChanged(lmms::TempoSyncKnobModel::TempoSyncMode)),
+	connect( model(), SIGNAL(syncModeChanged(lmms::TempoSyncKnobModel::SyncMode)),
 			this, SLOT(updateDescAndIcon()));
 	connect( this, SIGNAL(sliderMoved(float)),
 			model(), SLOT(disableSync()));

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -76,7 +76,7 @@ void TempoSyncKnob::modelChanged()
 		m_custom->setModel( &model()->m_custom );
 	}
 	connect(model(), &TempoSyncKnobModel::syncModeChanged, this, &TempoSyncKnob::updateDescAndIcon);
-	connect(this, &TempoSyncKnob::sliderMoved(), model(), &TempoSyncKnobModel::disableSync());
+	connect(this, &TempoSyncKnob::sliderMoved, model(), &TempoSyncKnobModel::disableSync);
 	updateDescAndIcon();
 }
 

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -75,10 +75,8 @@ void TempoSyncKnob::modelChanged()
 	{
 		m_custom->setModel( &model()->m_custom );
 	}
-	connect( model(), SIGNAL(syncModeChanged(lmms::TempoSyncKnobModel::SyncMode)),
-			this, SLOT(updateDescAndIcon()));
-	connect( this, SIGNAL(sliderMoved(float)),
-			model(), SLOT(disableSync()));
+	connect(model(), &TempoSyncKnobModel::syncModeChanged, this, &TempoSyncKnob::updateDescAndIcon);
+	connect(this, &TempoSyncKnob::sliderMoved(), model(), &TempoSyncKnobModel::disableSync());
 	updateDescAndIcon();
 }
 


### PR DESCRIPTION
fixes #6759 
The TempoSyncKnobModel didn't emit any signal when a SyncMode::Custom was recalculated after it had been changed in the gui window.
Also it looks like someone broke the TempoSyncKnobModel because SyncMode had been renamed to TempoSyncMode and the build was screaming.