### PR TITLE
Add mixer LCD channels for Instrument & Sample tracks

### DIFF
--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -25,6 +25,7 @@
 #ifndef LMMS_GUI_INSTRUMENT_TRACK_VIEW_H
 #define LMMS_GUI_INSTRUMENT_TRACK_VIEW_H
 
+#include "MixerLineLcdSpinBox.h"
 #include "TrackView.h"
 
 #include "InstrumentTrack.h"
@@ -72,6 +73,7 @@ public:
 
 
 protected:
+	void modelChanged() override;
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
 
@@ -97,6 +99,7 @@ private:
 
 	// widgets in track-settings-widget
 	TrackLabelButton * m_tlb;
+	MixerLineLcdSpinBox* m_mixerChannelNumber;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
 	FadeButton * m_activityIndicator;

--- a/include/SampleTrackView.h
+++ b/include/SampleTrackView.h
@@ -26,6 +26,7 @@
 #define LMMS_GUI_SAMPLE_TRACK_VIEW_H
 
 
+#include "MixerLineLcdSpinBox.h"
 #include "TrackView.h"
 
 namespace lmms
@@ -90,6 +91,7 @@ private slots:
 
 private:
 	SampleTrackWindow * m_window;
+	MixerLineLcdSpinBox* m_mixerChannelNumber;
 	Knob * m_volumeKnob;
 	Knob * m_panningKnob;
 	FadeButton * m_activityIndicator;

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -48,12 +48,12 @@ class FadeButton;
 class TrackContainerView;
 
 
-const int DEFAULT_SETTINGS_WIDGET_WIDTH = 224;
-const int TRACK_OP_WIDTH = 78;
+const int DEFAULT_SETTINGS_WIDGET_WIDTH = 256;
+const int TRACK_OP_WIDTH = 90;
 // This shaves 150-ish pixels off track buttons,
 // ruled from config: ui.compacttrackbuttons
-const int DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT = 96;
-const int TRACK_OP_WIDTH_COMPACT = 62;
+const int DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT = 128;
+const int TRACK_OP_WIDTH_COMPACT = 82;
 
 
 class TrackView : public QWidget, public ModelView, public JournallingObject

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -49,11 +49,11 @@ class TrackContainerView;
 
 
 const int DEFAULT_SETTINGS_WIDGET_WIDTH = 256;
-const int TRACK_OP_WIDTH = 90;
+const int TRACK_OP_WIDTH = 78;
 // This shaves 150-ish pixels off track buttons,
 // ruled from config: ui.compacttrackbuttons
 const int DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT = 128;
-const int TRACK_OP_WIDTH_COMPACT = 82;
+const int TRACK_OP_WIDTH_COMPACT = 62;
 
 
 class TrackView : public QWidget, public ModelView, public JournallingObject

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -145,8 +145,8 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	auto layout = new QHBoxLayout(getTrackSettingsWidget());
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(0);
-	layout->addWidget(m_mixerChannelNumber);
 	layout->addWidget(m_tlb);
+	layout->addWidget(m_mixerChannelNumber);
 	layout->addWidget(m_activityIndicator);
 	layout->addWidget(m_volumeKnob);
 	layout->addWidget(m_panningKnob);

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -63,7 +63,6 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_tlb = new TrackLabelButton( this, getTrackSettingsWidget() );
 	m_tlb->setCheckable( true );
 	m_tlb->setIcon( embed::getIconPixmap( "instrument_track" ) );
-	m_tlb->move( 3, 1 );
 	m_tlb->show();
 
 	connect( m_tlb, SIGNAL(toggled(bool)),
@@ -75,24 +74,14 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	connect(ConfigManager::inst(), SIGNAL(valueChanged(QString,QString,QString)),
 			this, SLOT(handleConfigChange(QString,QString,QString)));
 
-	// creation of widgets for track-settings-widget
-	int widgetWidth;
-	if( ConfigManager::inst()->value( "ui",
-					  "compacttrackbuttons" ).toInt() )
-	{
-		widgetWidth = DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT;
-	}
-	else
-	{
-		widgetWidth = DEFAULT_SETTINGS_WIDGET_WIDTH;
-	}
+	m_mixerChannelNumber = new MixerLineLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
+	m_mixerChannelNumber->show();
 
 	m_volumeKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
 							tr( "Volume" ) );
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_it->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
-	m_volumeKnob->move( widgetWidth-2*24, 2 );
 	m_volumeKnob->setLabel( tr( "VOL" ) );
 	m_volumeKnob->show();
 
@@ -100,7 +89,6 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 							tr( "Panning" ) );
 	m_panningKnob->setModel( &_it->m_panningModel );
 	m_panningKnob->setHintText(tr("Panning:"), "%");
-	m_panningKnob->move( widgetWidth-24, 2 );
 	m_panningKnob->setLabel( tr( "PAN" ) );
 	m_panningKnob->show();
 
@@ -151,9 +139,18 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 						QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText).darker(),
 						getTrackSettingsWidget() );
-	m_activityIndicator->setGeometry(
-					 widgetWidth-2*24-11, 2, 8, 28 );
+	m_activityIndicator->setFixedSize(8, 28);
 	m_activityIndicator->show();
+
+	auto layout = new QHBoxLayout(getTrackSettingsWidget());
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setSpacing(0);
+	layout->addWidget(m_mixerChannelNumber);
+	layout->addWidget(m_tlb);
+	layout->addWidget(m_activityIndicator);
+	layout->addWidget(m_volumeKnob);
+	layout->addWidget(m_panningKnob);
+
 	connect( m_activityIndicator, SIGNAL(pressed()),
 				this, SLOT(activityIndicatorPressed()));
 	connect( m_activityIndicator, SIGNAL(released()),
@@ -266,6 +263,13 @@ void InstrumentTrackView::handleConfigChange(QString cls, QString attr, QString 
 	{
 		m_tlb->setChecked(m_window && m_window == topLevelInstrumentTrackWindow());
 	}
+}
+
+void InstrumentTrackView::modelChanged()
+{
+	TrackView::modelChanged();
+	auto st = castModel<InstrumentTrack>();
+	m_mixerChannelNumber->setModel(&st->m_mixerChannelModel);
 }
 
 void InstrumentTrackView::dragEnterEvent( QDragEnterEvent * _dee )

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -56,7 +56,6 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	connect(m_tlb, SIGNAL(clicked(bool)),
 			this, SLOT(showEffects()));
 	m_tlb->setIcon(embed::getIconPixmap("sample_track"));
-	m_tlb->move(3, 1);
 	m_tlb->show();
 
 	m_mixerChannelNumber = new MixerLineLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
@@ -68,11 +67,6 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_volumeKnob->setModel( &_t->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
 
-	int settingsWidgetWidth = ConfigManager::inst()->
-					value( "ui", "compacttrackbuttons" ).toInt()
-				? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT
-				: DEFAULT_SETTINGS_WIDGET_WIDTH;
-	m_volumeKnob->move( settingsWidgetWidth - 2 * 24, 2 );
 	m_volumeKnob->setLabel( tr( "VOL" ) );
 	m_volumeKnob->show();
 
@@ -80,7 +74,6 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 							tr( "Panning" ) );
 	m_panningKnob->setModel( &_t->m_panningModel );
 	m_panningKnob->setHintText( tr( "Panning:" ), "%" );
-	m_panningKnob->move( settingsWidgetWidth - 24, 2 );
 	m_panningKnob->setLabel( tr( "PAN" ) );
 	m_panningKnob->show();
 
@@ -90,8 +83,19 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 		QApplication::palette().color(QPalette::Active, QPalette::BrightText).darker(),
 		getTrackSettingsWidget()
 	);
-	m_activityIndicator->setGeometry(settingsWidgetWidth - 2 * 24 - 11, 2, 8, 28);
+	m_activityIndicator->setFixedSize(8, 28);
 	m_activityIndicator->show();
+
+	auto layout = new QHBoxLayout(getTrackSettingsWidget());
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setSpacing(0);
+
+	layout->addWidget(m_mixerChannelNumber);
+	layout->addWidget(m_tlb);
+	layout->addWidget(m_activityIndicator);
+	layout->addWidget(m_volumeKnob);
+	layout->addWidget(m_panningKnob);
+
 	connect(_t, SIGNAL(playingChanged()), this, SLOT(updateIndicator()));
 
 	setModel( _t );

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -89,9 +89,8 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	auto layout = new QHBoxLayout(getTrackSettingsWidget());
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(0);
-
-	layout->addWidget(m_mixerChannelNumber);
 	layout->addWidget(m_tlb);
+	layout->addWidget(m_mixerChannelNumber);
 	layout->addWidget(m_activityIndicator);
 	layout->addWidget(m_volumeKnob);
 	layout->addWidget(m_panningKnob);

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -59,6 +59,9 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_tlb->move(3, 1);
 	m_tlb->show();
 
+	m_mixerChannelNumber = new MixerLineLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
+	m_mixerChannelNumber->show();
+
 	m_volumeKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
 						    tr( "Track volume" ) );
 	m_volumeKnob->setVolumeKnob( true );
@@ -170,6 +173,7 @@ void SampleTrackView::modelChanged()
 {
 	auto st = castModel<SampleTrack>();
 	m_volumeKnob->setModel(&st->m_volumeModel);
+	m_mixerChannelNumber->setModel(&st->m_mixerChannelModel);
 
 	TrackView::modelChanged();
 }


### PR DESCRIPTION
This PR adds mixer LCD channels directly on the instrument & sample tracks. This should make it more convenient to change assigned mixer channels for instrument & sample tracks, and also help you to know what mixer channel it is assigned to quicker, compared to having to open a window. 

#### Preview
![image](https://github.com/LMMS/lmms/assets/20197645/fcb44032-6566-4d98-9635-641f4cc532cc)