### PR TITLE
Fix the base note automation fix

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1671,6 +1671,8 @@ void DataFile::upgrade_extendedNoteRange()
 {
 	auto root = documentElement();
 	UpgradeExtendedNoteRange upgradeExtendedNoteRange(root);
+
+	upgradeExtendedNoteRange.upgrade();
 }
 
 

--- a/src/core/UpgradeExtendedNoteRange.cpp
+++ b/src/core/UpgradeExtendedNoteRange.cpp
@@ -193,6 +193,7 @@ static void fixTrack(QDomElement & track, std::set<unsigned int> & automatedBase
 		for (int i = 0; i < subTracks.size(); ++i)
 		{
 			QDomElement subTrack = subTracks.item(i).toElement();
+			assert (static_cast<Track::Type>(subTrack.attribute("type").toInt()) != Track::Type::Pattern);
 			fixTrack(subTrack, automatedBaseNoteIds);
 		}
 	}


### PR DESCRIPTION
Towards the end of the development for the fix of #6548 (via #6725) the upgrade code was refactored into its own class. While doing so it was forgotten to actually call the `upgrade` method on the `UpgradeExtendedNoteRange` instance. As a result almost all files should currently open in a wrong state with many instruments transposed. This commit fixes this.

Also explicitly check the assertion that BB tracks do not contain other BB tracks.

Fixes #6828