### PR TITLE
Change the title for SideBarWidgets to be vertically centered related…

### DIFF
--- a/src/gui/SideBarWidget.cpp
+++ b/src/gui/SideBarWidget.cpp
@@ -62,7 +62,7 @@ void SideBarWidget::paintEvent( QPaintEvent * )
 
 	QFont f = p.font();
 	f.setBold( true );
-	f.setUnderline( false );
+	f.setUnderline(false);
 	f.setPointSize( f.pointSize() + 2 );
 	p.setFont( f );
 

--- a/src/gui/SideBarWidget.cpp
+++ b/src/gui/SideBarWidget.cpp
@@ -62,16 +62,16 @@ void SideBarWidget::paintEvent( QPaintEvent * )
 
 	QFont f = p.font();
 	f.setBold( true );
-	f.setUnderline( true );
+	f.setUnderline( false );
 	f.setPointSize( f.pointSize() + 2 );
 	p.setFont( f );
 
 	p.setPen( palette().highlightedText().color() );
 
-	const int tx = m_icon.width()+4;
+	const int tx = m_icon.width() + 8;
 
 	QFontMetrics metrics( f );
-	const int ty = metrics.ascent();
+	const int ty = (metrics.ascent() + m_icon.height()) / 2;
 	p.drawText( tx, ty, m_title );
 
 	p.drawPixmap( 2, 2, m_icon.transformed( QTransform().rotate( -90 ) ) );


### PR DESCRIPTION
… to icon and with no underlining

Old version to the left, new to the right.
![defaultold](https://github.com/LMMS/lmms/assets/6368949/4f469999-b60b-4e95-bc67-8a4ba093fb77)

Fixes #6660
