### PR TITLE
Fix a few memory issues found with ASan

### DIFF
--- a/plugins/LadspaEffect/caps/Descriptor.h
+++ b/plugins/LadspaEffect/caps/Descriptor.h
@@ -53,7 +53,7 @@ class DescriptorStub
 				PortCount = 0;
 			}
 
-		~DescriptorStub()
+		virtual ~DescriptorStub()
 			{
 				if (PortCount)
 				{
@@ -87,6 +87,7 @@ class Descriptor
 
 	public:
 		Descriptor() { setup(); }
+		~Descriptor() override = default;
 		void setup();
 
 		void autogen() 

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -347,9 +347,9 @@ void AutomationClip::removeNode(const TimePos & time)
 
 	m_timeMap.remove(time);
 
-	if (!m_timeMap.isEmpty())
+	auto it = m_timeMap.lowerBound(time);
+	if (it != m_timeMap.end())
 	{
-		auto it = m_timeMap.lowerBound(time);
 		if (it != m_timeMap.begin())
 		{
 			--it;
@@ -483,8 +483,7 @@ TimePos AutomationClip::setDragValue(
 			}
 		}
 
-		removeNode(newTime);
-
+		this->removeNode(newTime);
 		m_oldTimeMap = m_timeMap;
 		m_dragging = true;
 	}

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -345,13 +345,17 @@ void AutomationClip::removeNode(const TimePos & time)
 
 	cleanObjects();
 
-	m_timeMap.remove( time );
-	timeMap::iterator it = m_timeMap.lowerBound(time);
-	if( it != m_timeMap.begin() )
+	m_timeMap.remove(time);
+
+	if (!m_timeMap.isEmpty())
 	{
-		--it;
+		auto it = m_timeMap.lowerBound(time);
+		if (it != m_timeMap.begin())
+		{
+			--it;
+		}
+		generateTangents(it, 3);
 	}
-	generateTangents(it, 3);
 
 	updateLength();
 
@@ -479,7 +483,8 @@ TimePos AutomationClip::setDragValue(
 			}
 		}
 
-		this->removeNode(newTime);
+		removeNode(newTime);
+
 		m_oldTimeMap = m_timeMap;
 		m_dragging = true;
 	}

--- a/src/gui/widgets/SimpleTextFloat.cpp
+++ b/src/gui/widgets/SimpleTextFloat.cpp
@@ -46,11 +46,11 @@ SimpleTextFloat::SimpleTextFloat() :
 	m_textLabel = new QLabel(this);
 	layout->addWidget(m_textLabel);
 
-	m_showTimer = new QTimer();
+	m_showTimer = new QTimer(this);
 	m_showTimer->setSingleShot(true);
 	QObject::connect(m_showTimer, &QTimer::timeout, this, &SimpleTextFloat::show);
 
-	m_hideTimer = new QTimer();
+	m_hideTimer = new QTimer(this);
 	m_hideTimer->setSingleShot(true);
 	QObject::connect(m_hideTimer, &QTimer::timeout, this, &SimpleTextFloat::hide);
 }


### PR DESCRIPTION
I used an AddressSanitizer build to find and fix some memory issues:
- Memory leak in LADSPA effects
- Memory leak in SimpleTextFloat
- Invalid iterator in AutomationClip
    - Occurred when adding and removing nodes in the Automation Editor
    - Likely the cause of Automation Editor crashes that I've experienced before
- Buffer overflow in PianoView
    - I didn't understand the logic of the code I wanted to fix, so I rewrote it. It works in a more straightforward and understandable way now, and the buffer overflow problem is fixed.
    - Fixes #6608
    
I'm sure there are more memory-related errors I could find and fix with ASan, but this is enough for now.