### PR TITLE
Make files visible when searching in ``FileBrowser`` 

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -75,14 +75,16 @@ public:
 private slots:
 	void reloadTree();
 	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );
-	// call with item=NULL to filter the entire tree
-	bool filterItems( const QString & filter, QTreeWidgetItem * item=nullptr );
+	bool filterAndExpandItems(const QString & filter, QTreeWidgetItem * item = nullptr);
 	void giveFocusToFilter();
 
 private:
 	void keyPressEvent( QKeyEvent * ke ) override;
 
 	void addItems( const QString & path );
+
+	void saveDirectoriesStates();
+	void restoreDirectoriesStates();
 
 	FileBrowserTreeWidget * m_fileBrowserTreeWidget;
 
@@ -99,6 +101,8 @@ private:
 	QCheckBox* m_showFactoryContent = nullptr;
 	QString m_userDir;
 	QString m_factoryDir;
+	QList<QString> m_savedExpandedDirs;
+	QString m_previousFilterValue;
 } ;
 
 
@@ -114,7 +118,6 @@ public:
 	//! This method returns a QList with paths (QString's) of all directories
 	//! that are expanded in the tree.
 	QList<QString> expandedDirs( QTreeWidgetItem * item = nullptr ) const;
-
 
 protected:
 	void contextMenuEvent( QContextMenuEvent * e ) override;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -190,7 +190,7 @@ bool FileBrowser::filterAndExpandItems(const QString & filter, QTreeWidgetItem *
 	bool anyMatched = false;
 
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
-	for (int i = 0; i < numChildren; i++)
+	for (int i = 0; i < numChildren; ++i)
 	{
 		QTreeWidgetItem * it = item ? item->child( i ) : m_fileBrowserTreeWidget->topLevelItem(i);
 
@@ -278,17 +278,14 @@ void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs
 			// Expanding is required when recursive to load in its contents, even if it's collapsed right afterward
 			if (m_recurse) { d->setExpanded(true); }
 			d->setExpanded(expandedDirs.contains(d->fullName()));
-			d->setHidden(false);
 
 			if (m_recurse && it->childCount())
 			{
 				expandItems(it, expandedDirs);
 			}
 		}
-		else
-		{
-			it->setHidden(false);
-		}
+		
+		it->setHidden(false);		
 	}
 }
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -126,7 +126,7 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	m_filterEdit->setPlaceholderText( tr("Search") );
 	m_filterEdit->setClearButtonEnabled( true );
 	connect( m_filterEdit, SIGNAL( textEdited( const QString& ) ),
-			this, SLOT( filterItems( const QString& ) ) );
+			this, SLOT( filterAndExpandItems( const QString& ) ) );
 
 	auto reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
 	reload_btn->setToolTip( tr( "Refresh list" ) );
@@ -145,52 +145,84 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	auto filterFocusShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this, SLOT(giveFocusToFilter()));
 	filterFocusShortcut->setContext(Qt::WidgetWithChildrenShortcut);
 
+	m_previousFilterValue = "";
+
 	reloadTree();
 	show();
 }
 
-bool FileBrowser::filterItems( const QString & filter, QTreeWidgetItem * item )
+void FileBrowser::saveDirectoriesStates()
 {
-	// call with item=NULL to filter the entire tree
+	m_savedExpandedDirs = m_fileBrowserTreeWidget->expandedDirs();
+}
+	
+void FileBrowser::restoreDirectoriesStates()
+{
+	expandItems(nullptr, m_savedExpandedDirs);
+}
+
+bool FileBrowser::filterAndExpandItems(const QString & filter, QTreeWidgetItem * item)
+{
+	// Call with item = nullptr to filter the entire tree
+
+	if (item == nullptr)
+	{
+		// First search character so need to save current expanded directories
+		if (m_previousFilterValue.isEmpty())
+		{
+			saveDirectoriesStates();
+		}
+
+		m_previousFilterValue = filter;
+	}
+
+	if (filter.isEmpty())
+	{
+		// Restore previous expanded directories
+		if (item == nullptr) 
+		{
+			restoreDirectoriesStates();
+		}
+
+		return false;
+	}
+	
 	bool anyMatched = false;
 
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
-	for( int i = 0; i < numChildren; ++i )
+	for (int i = 0; i < numChildren; i++)
 	{
 		QTreeWidgetItem * it = item ? item->child( i ) : m_fileBrowserTreeWidget->topLevelItem(i);
 
-		// is directory?
-		if( it->childCount() )
+		// Directory
+		if (it->childCount())
 		{
-			// matches filter?
-			if( it->text( 0 ).
-				contains( filter, Qt::CaseInsensitive ) )
+			if (it->text(0).contains(filter, Qt::CaseInsensitive))
 			{
-				// yes, then show everything below
-				it->setHidden( false );
-				filterItems( QString(), it );
+				it->setHidden(false);
+				it->setExpanded(true);
+				filterAndExpandItems(QString(), it);
 				anyMatched = true;
 			}
 			else
 			{
-				// only show if item below matches filter
-				bool didMatch = filterItems( filter, it );
-				it->setHidden( !didMatch );
+				bool didMatch = filterAndExpandItems(filter, it);
+				it->setHidden(!didMatch);
+				it->setExpanded(didMatch);
 				anyMatched = anyMatched || didMatch;
 			}
 		}
-		// a standard item (i.e. no file or directory item?)
-		else if( it->type() == QTreeWidgetItem::Type )
+		// A standard item (i.e. no file or directory item?)
+		else if (it->type() == QTreeWidgetItem::Type)
 		{
-			// hide if there's any filter
-			it->setHidden( !filter.isEmpty() );
+			// Hide if there's any filter
+			it->setHidden(!filter.isEmpty());
 		}
 		else
 		{
-			// file matches filter?
-			bool didMatch = it->text( 0 ).
-				contains( filter, Qt::CaseInsensitive );
-			it->setHidden( !didMatch );
+			// File
+			bool didMatch = it->text(0).contains(filter, Qt::CaseInsensitive);
+			it->setHidden(!didMatch);
 			anyMatched = anyMatched || didMatch;
 		}
 	}
@@ -201,15 +233,14 @@ bool FileBrowser::filterItems( const QString & filter, QTreeWidgetItem * item )
 
 void FileBrowser::reloadTree()
 {
-	QList<QString> expandedDirs = m_fileBrowserTreeWidget->expandedDirs();
-	const QString text = m_filterEdit->text();
-	m_filterEdit->clear();
 	m_fileBrowserTreeWidget->clear();
 	QStringList paths = m_directories.split('*');
+
 	if (m_showUserContent && !m_showUserContent->isChecked())
 	{
 		paths.removeAll(m_userDir);
 	}
+
 	if (m_showFactoryContent && !m_showFactoryContent->isChecked())
 	{
 		paths.removeAll(m_factoryDir);
@@ -222,9 +253,15 @@ void FileBrowser::reloadTree()
 			addItems(path);
 		}
 	}
-	expandItems(nullptr, expandedDirs);
-	m_filterEdit->setText( text );
-	filterItems( text );
+
+	if (m_filterEdit->text().isEmpty())
+	{
+		restoreDirectoriesStates();
+	}
+	else
+	{
+		filterAndExpandItems(m_filterEdit->text());
+	}
 }
 
 
@@ -241,10 +278,16 @@ void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs
 			// Expanding is required when recursive to load in its contents, even if it's collapsed right afterward
 			if (m_recurse) { d->setExpanded(true); }
 			d->setExpanded(expandedDirs.contains(d->fullName()));
+			d->setHidden(false);
+
 			if (m_recurse && it->childCount())
 			{
 				expandItems(it, expandedDirs);
 			}
+		}
+		else
+		{
+			it->setHidden(false);
 		}
 	}
 }
@@ -414,8 +457,6 @@ QList<QString> FileBrowserTreeWidget::expandedDirs( QTreeWidgetItem * item ) con
 	}
 	return dirs;
 }
-
-
 
 
 void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )


### PR DESCRIPTION
Try to make files visible when searching in FileBrowser and restore the previous state if search is cancelled

Fixes #4214