### PR TITLE
fixes #6354: Sample and Hold for LFO Controller

### DIFF
--- a/include/LfoController.h
+++ b/include/LfoController.h
@@ -86,6 +86,7 @@ protected:
 	sample_t (*m_sampleFunction)( const float );
 
 private:
+	float m_heldSample;
 	SampleBuffer * m_userDefSampleBuffer;
 
 protected slots:

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -88,6 +88,7 @@ void LfoController::updateValueBuffer()
 {
 	m_phaseOffset = m_phaseModel.value() / 360.0;
 	float phase = m_currentPhase + m_phaseOffset;
+	float phasePrev = 0.0f;
 
 	// roll phase up until we're in sync with period counter
 	m_bufferLastUpdated++;
@@ -102,15 +103,35 @@ void LfoController::updateValueBuffer()
 	ValueBuffer *amountBuffer = m_amountModel.valueBuffer();
 	int amountInc = amountBuffer ? 1 : 0;
 	float *amountPtr = amountBuffer ? &(amountBuffer->values()[ 0 ] ) : &amount;
+	Oscillator::WaveShape waveshape = 
+			static_cast<Oscillator::WaveShape>(m_waveModel.value());
 
 	for( float& f : m_valueBuffer )
 	{
-		const float currentSample = m_sampleFunction != nullptr
-			? m_sampleFunction( phase )
-			: m_userDefSampleBuffer->userWaveSample( phase );
+		float currentSample = 0;
+		switch (waveshape)
+		{
+			case Oscillator::WaveShape::WhiteNoise:
+				if (absFraction(phase) < absFraction(phasePrev))
+				{
+					// Resample when phase period has completed
+					m_heldSample = m_sampleFunction( phase );
+				}
+				currentSample = m_heldSample;
+				break;
+			case Oscillator::WaveShape::UserDefined:
+				currentSample = m_userDefSampleBuffer->userWaveSample( phase );
+				break;
+			default:
+				if (m_sampleFunction != nullptr)
+				{
+					currentSample = m_sampleFunction( phase );
+				}
+		}
 
 		f = std::clamp(m_baseModel.value() + (*amountPtr * currentSample / 2.0f), 0.0f, 1.0f);
 
+		phasePrev = phase;
 		phase += 1.0 / m_duration;
 		amountPtr += amountInc;
 	}


### PR DESCRIPTION
LFO controller's "white noise" wave shape didn't respect the frequency knob at all, so Sample-and-Hold was added to extend the functionality of the LFO Controller with the "white noise" wave shape.
The original functionality can still be accessed by setting the FREQ knob to minimum (0.01), so this is purely a feature extension.