### PR TITLE
fixes #6736: Sample tracks lose FX Channel

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1727,7 +1727,7 @@ void DataFile::upgrade_mixerRename()
 
 	// Change the attribute fxch of element <instrumenttrack> to mixch
 	QDomNodeList fxch = elementsByTagName("instrumenttrack");
-	for(int i = 0; i < fxch.length(); ++i)
+	for (int i = 0; i < fxch.length(); ++i)
 	{
 		auto item = fxch.item(i).toElement();
 		if (item.isNull())

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1703,26 +1703,41 @@ void DataFile::upgrade_mixerRename()
 {
 	// Change nodename <fxmixer> to <mixer>
 	QDomNodeList fxmixer = elementsByTagName("fxmixer");
-	for (int i = 0; !fxmixer.item(i).isNull(); ++i)
+	for (int i = 0; fxmixer.length(); ++i)
 	{
-		fxmixer.item(i).toElement().setTagName("mixer");
+		auto item = fxmixer.item(i).toElement();
+		if (item.isNull())
+		{
+			continue;
+		}
+		item.setTagName("mixer");
 	}
 
 	// Change nodename <fxchannel> to <mixerchannel>
 	QDomNodeList fxchannel = elementsByTagName("fxchannel");
-	for (int i = 0; !fxchannel.item(i).isNull(); ++i)
+	for (int i = 0; fxchannel.length(); ++i)
 	{
-		fxchannel.item(i).toElement().setTagName("mixerchannel");
+		auto item = fxchannel.item(i).toElement();
+		if (item.isNull())
+		{
+			continue;
+		}
+		item.setTagName("mixerchannel");
 	}
 
 	// Change the attribute fxch of element <instrumenttrack> to mixch
 	QDomNodeList fxch = elementsByTagName("instrumenttrack");
-	for(int i = 0; !fxch.item(i).isNull(); ++i)
+	for(int i = 0; fxch.length(); ++i)
 	{
-		if(fxch.item(i).toElement().hasAttribute("fxch"))
+		auto item = fxch.item(i).toElement();
+		if (item.isNull())
 		{
-			fxch.item(i).toElement().setAttribute("mixch", fxch.item(i).toElement().attribute("fxch"));
-			fxch.item(i).toElement().removeAttribute("fxch");
+			continue;
+		}
+		if (item.hasAttribute("fxch"))
+		{
+			item.setAttribute("mixch", item.attribute("fxch"));
+			item.removeAttribute("fxch");
 		}
 	}
 	// Change the attribute fxch of element <sampletrack> to mixch
@@ -1730,6 +1745,10 @@ void DataFile::upgrade_mixerRename()
 	for (int i = 0; fxch.length(); ++i)
 	{
 		auto item = fxch.item(i).toElement();
+		if (item.isNull())
+		{
+			continue;
+		}
 		if (item.hasAttribute("fxch"))
 		{
 			item.setAttribute("mixch", item.attribute("fxch"));

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1727,12 +1727,13 @@ void DataFile::upgrade_mixerRename()
 	}
 	// Change the attribute fxch of element <sampletrack> to mixch
 	fxch = elementsByTagName("sampletrack");
-	for(int i = 0; !fxch.item(i).isNull(); ++i)
+	for (int i = 0; fxch.length(); ++i)
 	{
-		if(fxch.item(i).toElement().hasAttribute("fxch"))
+		auto item = fxch.item(i).toElement();
+		if (item.hasAttribute("fxch"))
 		{
-			fxch.item(i).toElement().setAttribute("mixch", fxch.item(i).toElement().attribute("fxch"));
-			fxch.item(i).toElement().removeAttribute("fxch");
+			item.setAttribute("mixch", item.attribute("fxch"));
+			item.removeAttribute("fxch");
 		}
 	}
 }

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1703,7 +1703,7 @@ void DataFile::upgrade_mixerRename()
 {
 	// Change nodename <fxmixer> to <mixer>
 	QDomNodeList fxmixer = elementsByTagName("fxmixer");
-	for (int i = 0; fxmixer.length(); ++i)
+	for (int i = 0; i < fxmixer.length(); ++i)
 	{
 		auto item = fxmixer.item(i).toElement();
 		if (item.isNull())
@@ -1715,7 +1715,7 @@ void DataFile::upgrade_mixerRename()
 
 	// Change nodename <fxchannel> to <mixerchannel>
 	QDomNodeList fxchannel = elementsByTagName("fxchannel");
-	for (int i = 0; fxchannel.length(); ++i)
+	for (int i = 0; i < fxchannel.length(); ++i)
 	{
 		auto item = fxchannel.item(i).toElement();
 		if (item.isNull())
@@ -1727,7 +1727,7 @@ void DataFile::upgrade_mixerRename()
 
 	// Change the attribute fxch of element <instrumenttrack> to mixch
 	QDomNodeList fxch = elementsByTagName("instrumenttrack");
-	for(int i = 0; fxch.length(); ++i)
+	for(int i = 0; i < fxch.length(); ++i)
 	{
 		auto item = fxch.item(i).toElement();
 		if (item.isNull())
@@ -1742,7 +1742,7 @@ void DataFile::upgrade_mixerRename()
 	}
 	// Change the attribute fxch of element <sampletrack> to mixch
 	fxch = elementsByTagName("sampletrack");
-	for (int i = 0; fxch.length(); ++i)
+	for (int i = 0; i < fxch.length(); ++i)
 	{
 		auto item = fxch.item(i).toElement();
 		if (item.isNull())

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1725,6 +1725,16 @@ void DataFile::upgrade_mixerRename()
 			fxch.item(i).toElement().removeAttribute("fxch");
 		}
 	}
+	// Change the attribute fxch of element <sampletrack> to mixch
+	fxch = elementsByTagName("sampletrack");
+	for(int i = 0; !fxch.item(i).isNull(); ++i)
+	{
+		if(fxch.item(i).toElement().hasAttribute("fxch"))
+		{
+			fxch.item(i).toElement().setAttribute("mixch", fxch.item(i).toElement().attribute("fxch"));
+			fxch.item(i).toElement().removeAttribute("fxch");
+		}
+	}
 }
 
 


### PR DESCRIPTION
Fixes #6736 : **Sample Tracks in projects from latest alpha version lose their assigned FX Channel when loaded in Nightly**

It was just like @PhysSong said, just needed someone to do the work.