### PR TITLE
fixes #4049: Off-grid nodes not draggable

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -531,7 +531,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 								: POS(clickedNode)
 							),
 							level,
-							true,
+							clickedNode == tm.end(),
 							mouseEvent->modifiers() & Qt::ControlModifier
 						);
 


### PR DESCRIPTION
fixes #4049 
The quantPos arg of AutomationClip::setDragValue causes the node time to be quantized before its looked up in the timeMap iterator. This results in the node not being found and a new one being created inside the setDragValue function even though we had found one.

Simply setting it to true causes this bug, simply setting it to false causes a new node to be created off grid/not snapped until the user moves the mouse while dragging in which case it snaps normally.

So the fix is to quantize the position for the lookup only if we haven't found an existing node under the cursor.