### PR TITLE
Activate volume envelope by default (#6121)

### DIFF
--- a/data/projects/templates/default.mpt
+++ b/data/projects/templates/default.mpt
@@ -34,9 +34,9 @@
                   <kicker decay_numerator="4" decay_denominator="4" distend="0.8" click="0.4" endnote="0" version="1" decay_syncmode="0" decay="440" noise="0" slope="0.06" dist="0.8" env="0.163" startnote="1" startfreq="150" endfreq="40" gain="1"/>
                 </instrument>
                 <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
-                  <elvol lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="1" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-                  <elcut lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-                  <elres lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
                 </eldata>
                 <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
                 <arpeggiator arptime="100" arprange="1" arpskip="0" arptime_denominator="4" arptime_syncmode="0" arpmode="0" arpcycle="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpmiss="0" arpgate="100"/>

--- a/data/projects/templates/default.mpt
+++ b/data/projects/templates/default.mpt
@@ -10,9 +10,9 @@
             <tripleoscillator phoffset2="0" userwavefile0="" finer0="0" userwavefile1="" finer1="0" userwavefile2="" finer2="0" coarse0="0" coarse1="-12" coarse2="-24" finel0="0" finel1="0" modalgo1="2" modalgo2="2" finel2="0" pan0="0" modalgo3="2" pan1="0" stphdetun0="0" pan2="0" stphdetun1="0" wavetype0="0" stphdetun2="0" wavetype1="0" wavetype2="0" vol0="33" vol1="33" phoffset0="0" phoffset1="0" vol2="33" useWaveTable1="1" useWaveTable2="1" useWaveTable3="1"/>
           </instrument>
           <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
-            <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-            <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-            <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+            <elvol lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="1" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+            <elcut lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+            <elres lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
           </eldata>
           <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
           <arpeggiator arptime="100" arprange="1" arpskip="0" arptime_denominator="4" arptime_syncmode="0" arpmode="0" arpcycle="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpmiss="0" arpgate="100"/>
@@ -34,9 +34,9 @@
                   <kicker decay_numerator="4" decay_denominator="4" distend="0.8" click="0.4" endnote="0" version="1" decay_syncmode="0" decay="440" noise="0" slope="0.06" dist="0.8" env="0.163" startnote="1" startfreq="150" endfreq="40" gain="1"/>
                 </instrument>
                 <eldata fres="0.5" ftype="0" fcut="14000" fwet="0">
-                  <elvol lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-                  <elcut lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
-                  <elres lspd_denominator="4" sustain="0.5" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.5" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elvol lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="1" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elcut lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
+                  <elres lspd_denominator="4" sustain="1.0" pdel="0" userwavefile="" dec="0.5" lamt="0" latt="0" rel="0.1" amt="0" x100="0" att="0" lpdel="0" hold="0.0" lspd_syncmode="0" lshp="0" lspd="0.1" ctlenvamt="0" lspd_numerator="4"/>
                 </eldata>
                 <chordcreator chord="0" chordrange="1" chord-enabled="0"/>
                 <arpeggiator arptime="100" arprange="1" arpskip="0" arptime_denominator="4" arptime_syncmode="0" arpmode="0" arpcycle="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpmiss="0" arpgate="100"/>

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -72,8 +72,8 @@ public:
 
 	} ;
 
-	EnvelopeAndLfoParameters( float _value_for_zero_amount,
-							Model * _parent );
+	EnvelopeAndLfoParameters(float _value_for_zero_amount,
+		float defaultAmount, Model * _parent );
 	~EnvelopeAndLfoParameters() override;
 
 	static inline float expKnobVal( float _val )

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -113,6 +113,9 @@ public:
 		return m_rFrames;
 	}
 
+	void setPAHDSR(float predelay, float attack, float hold, float decay, float sustain, float release);
+	void setAmount(float amount);
+
 
 public slots:
 	void updateSampleVars();

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -134,6 +134,7 @@ public:
 		return m_instrumentTrack;
 	}
 
+	void resetToLegacyVolumeEnvelope();
 
 protected:
 	// fade in to prevent clicks

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -73,6 +73,8 @@ public:
 		return "eldata";
 	}
 
+	void resetToLegacyVolumeEnvelope();
+
 
 private:
 	EnvelopeAndLfoParameters * m_envLfoParameters[NumTargets];

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -240,6 +240,8 @@ public:
 
 	void autoAssignMidiDevice( bool );
 
+	void resetToLegacyVolumeEnvelope();
+
 signals:
 	void instrumentChanged();
 	void midiNoteOn( const lmms::Note& );

--- a/include/TrackContainerView.h
+++ b/include/TrackContainerView.h
@@ -50,7 +50,7 @@ class InstrumentLoaderThread : public QThread
 Q_OBJECT
 public:
 	InstrumentLoaderThread( QObject *parent = 0, InstrumentTrack *it = 0,
-		QString name = "" );
+		QString name = "", bool resetToLegacyVolumeEnvelope = false );
 
 	void run() override;
 
@@ -58,6 +58,7 @@ private:
 	InstrumentTrack *m_it;
 	QString m_name;
 	QThread *m_containerThread;
+	bool m_resetToLegacyVolumeEnvelope;
 };
 
 namespace gui
@@ -169,6 +170,8 @@ protected:
 	static const int DEFAULT_PIXELS_PER_BAR = 16;
 
 	void resizeEvent( QResizeEvent * ) override;
+
+	void handleDropEvent(QDropEvent * de, bool resetToLegacyVolumeEnvelope);
 
 	TimePos m_currentPosition;
 

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -90,16 +90,17 @@ void EnvelopeAndLfoParameters::LfoInstances::remove( EnvelopeAndLfoParameters * 
 
 EnvelopeAndLfoParameters::EnvelopeAndLfoParameters(
 					float _value_for_zero_amount,
-							Model * _parent ) :
+					float defaultAmount,
+					Model * _parent ) :
 	Model( _parent ),
 	m_used( false ),
 	m_predelayModel( 0.0, 0.0, 2.0, 0.001, this, tr( "Env pre-delay" ) ),
 	m_attackModel( 0.0, 0.0, 2.0, 0.001, this, tr( "Env attack" ) ),
-	m_holdModel( 0.5, 0.0, 2.0, 0.001, this, tr( "Env hold" ) ),
+	m_holdModel( 0.0, 0.0, 2.0, 0.001, this, tr( "Env hold" ) ),
 	m_decayModel( 0.5, 0.0, 2.0, 0.001, this, tr( "Env decay" ) ),
-	m_sustainModel( 0.5, 0.0, 1.0, 0.001, this, tr( "Env sustain" ) ),
+	m_sustainModel( 1.0, 0.0, 1.0, 0.001, this, tr( "Env sustain" ) ),
 	m_releaseModel( 0.1, 0.0, 2.0, 0.001, this, tr( "Env release" ) ),
-	m_amountModel( 0.0, -1.0, 1.0, 0.005, this, tr( "Env mod amount" ) ),
+	m_amountModel( defaultAmount, -1.0, 1.0, 0.005, this, tr( "Env mod amount" ) ),
 	m_valueForZeroAmount( _value_for_zero_amount ),
 	m_pahdFrames( 0 ),
 	m_rFrames( 0 ),

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -393,6 +393,21 @@ void EnvelopeAndLfoParameters::loadSettings( const QDomElement & _this )
 }
 
 
+void EnvelopeAndLfoParameters::setPAHDSR(float predelay, float attack, float hold, float decay, float sustain, float release)
+{
+	m_predelayModel.setValue(predelay);
+	m_attackModel.setValue(attack);
+	m_holdModel.setValue(hold);
+	m_decayModel.setValue(decay);
+	m_sustainModel.setValue(sustain);
+	m_releaseModel.setValue(release);
+}
+
+void EnvelopeAndLfoParameters::setAmount(float amount)
+{
+	m_amountModel.setValue(amount);
+}
+
 
 
 void EnvelopeAndLfoParameters::updateSampleVars()
@@ -532,11 +547,5 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 	emit dataChanged();
 
 }
-
-
-
-
-
-
 
 } // namespace lmms

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -86,6 +86,14 @@ bool Instrument::isFromTrack( const Track * _track ) const
 	return( m_instrumentTrack == _track );
 }
 
+
+void Instrument::resetToLegacyVolumeEnvelope()
+{
+	// For some funny reasons the track has the envelopes
+	instrumentTrack()->resetToLegacyVolumeEnvelope();
+}
+
+
 // helper function for Instrument::applyFadeIn
 static int countZeroCrossings(sampleFrame *buf, fpp_t start, fpp_t frames)
 {

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -370,6 +370,13 @@ void InstrumentSoundShaping::loadSettings( const QDomElement & _this )
 }
 
 
+void InstrumentSoundShaping::resetToLegacyVolumeEnvelope()
+{
+	EnvelopeAndLfoParameters * volumeParameters = m_envLfoParameters[static_cast<std::size_t>(Target::Volume)];
+
+	volumeParameters->setPAHDSR(0., 0., 0.5, 0.5, 0.5, 0.1);
+	volumeParameters->setAmount(0);
+}
 
 
 

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -66,18 +66,16 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 	m_filterCutModel( 14000.0, 1.0, 14000.0, 1.0, this, tr( "Cutoff frequency" ) ),
 	m_filterResModel( 0.5, BasicFilters<>::minQ(), 10.0, 0.01, this, tr( "Q/Resonance" ) )
 {
-	for( int i = 0; i < NumTargets; ++i )
+	for(int i = 0; i < NumTargets; ++i)
 	{
-		float value_for_zero_amount = 0.0;
-		if( static_cast<Target>(i) == Target::Volume )
-		{
-			value_for_zero_amount = 1.0;
-		}
+		bool const isVolumeTarget = static_cast<Target>(i) == Target::Volume;
+		
 		m_envLfoParameters[i] = new EnvelopeAndLfoParameters(
-										value_for_zero_amount, 
-										this );
-		m_envLfoParameters[i]->setDisplayName(
-			tr( targetNames[i][2] ) );
+			isVolumeTarget ? 1.0 : 0.0, // Value for zero amount
+			isVolumeTarget ? 1.0 : 0.0, // Default amount
+			this);
+
+		m_envLfoParameters[i]->setDisplayName(tr(targetNames[i][2]));
 	}
 
 	m_filterModel.addItem( tr( "Low-pass" ), std::make_unique<PixmapLoader>( "filter_lp" ) );

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -306,7 +306,11 @@ void PluginDescWidget::openInNewInstrumentTrack(QString value)
 {
 	TrackContainer* tc = Engine::getSong();
 	auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, tc));
-	auto ilt = new InstrumentLoaderThread(this, it, value);
+
+	// This is the case where an instrument is pulled into the song editor.
+	// Hence we don't want to disable the volume envelope.
+	auto ilt = new InstrumentLoaderThread(this, it, value, false);
+
 	ilt->start();
 }
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -158,7 +158,7 @@ void PatternEditor::dropEvent(QDropEvent* de)
 	}
 	else
 	{
-		TrackContainerView::dropEvent( de );
+		handleDropEvent(de, true);
 	}
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1076,5 +1076,10 @@ void InstrumentTrack::autoAssignMidiDevice(bool assign)
 	}
 }
 
+void InstrumentTrack::resetToLegacyVolumeEnvelope()
+{
+	m_soundShaping.resetToLegacyVolumeEnvelope();
+}
+
 
 } // namespace lmms


### PR DESCRIPTION
The deactivated volume envelope leads to clicky sounds. This is fixed by activating it by default for instruments that are added to the project as well as in the default project.

The following changes are made to the envelopes:
* The amount of the volume envelope is set to 1, i.e. it is activated by default.
* The amounts of the cutoff and resonance envelopes are kept at 0 so that users have to opt-in to them. This might also potentially save resources.
* The amount for sustain is changed from 0.5 to 1. This way users start with a full sustained sound.
* The amount for hold is set to 0.

The reasoning for the changes is to enable users to quickly dial in some well known envelopes, especially if they only know ADSR envelopes and don't known how an AHDSR envelope works. A user that wants to dial in some pluck envelope might try to turn the sustain down to 0. However, if the "hold" parameter was set to 0.5 by default it would get in the way and users had to learn that they have to turn the "hold" down to 0. With the new set of default values they can discover the "hold" feature without it getting into the way with simpler approaches.

## Technical details
The constructor of `EnvelopeAndLfoParameters` was extended with the new parameter `defaultAmount` so that we are able to quickly set amounts of 1 or 0 for the volume, cutoff and resonance envelopes. See the changes in `InstrumentSoundShaping`.

Adjust `default.mpt` according to the code changes so that not only newly added instruments have the better defaults.