### PR TITLE
Display flats in Piano Roll's keys dropdown

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,7 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+static std::array<QString, 12> s_noteStrings {"C", "C#/D\u266D", "D", "D#/E\u266D", "E", "F", "F#/G\u266D", "G", "G#/A\u266D", "A", "A#/B\u266D", "B"};
 
 static QString getNoteString(int key)
 {
@@ -1687,7 +1687,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 		m_moveStartY = me->y();
 	}
 
-	if(me->button() == Qt::LeftButton &&
+	if( me->button() == Qt::LeftButton &&
 		me->y() > keyAreaBottom() && me->y() < noteEditTop())
 	{
 		// resizing the note edit area

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,7 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C#/D\u266D", "D", "D#/E\u266D", "E", "F", "F#/G\u266D", "G", "G#/A\u266D", "A", "A#/B\u266D", "B"};
+static std::array<QString, 12> s_noteStrings {"C", "C# / D\u266D", "D", "D# / E\u266D", "E", "F", "F# / G\u266D", "G", "G# / A\u266D", "A", "A# / B\u266D", "B"};
 
 static QString getNoteString(int key)
 {
@@ -1687,7 +1687,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 		m_moveStartY = me->y();
 	}
 
-	if( me->button() == Qt::LeftButton &&
+	if(me->button() == Qt::LeftButton &&
 		me->y() > keyAreaBottom() && me->y() < noteEditTop())
 	{
 		// resizing the note edit area


### PR DESCRIPTION
This was an attempt to fix this issue #6862 where the user noted that there aren't any flats listed in the list of keys in the piano roll. I wasn't really sure how to address their concerns without changing a big chunk of the code, so what I did was add the flats alongside the sharps in the array. Here is what the dropdown menu for the keys looks like now.

<img width="153" alt="Screenshot 2023-09-13 at 3 05 42 PM" src="https://github.com/LMMS/lmms/assets/100326501/4672faf0-c261-4416-ac3d-fd544f9e0d01">

~~I also made a very tiny change where I added a space to an if statement to make it more consistent with the rest of the if statements in the file.~~ Reverted this as it wasn't relevant to this issue.

UPDATE: Added space in between sharps and flats to make dropdown menu look a little nicer.