### PR TITLE
Fix invalid use of iterators in piano roll

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2513,7 +2513,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			bool altPressed = me->modifiers() & Qt::AltModifier;
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
-			auto it = notes.rend();
+			auto it = notes.rbegin();
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note* n = *it;
@@ -2556,7 +2556,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				}
 
 
-				--it;
+				++it;
 			}
 
 			// Emit MIDI clip has changed

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1719,7 +1719,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.begin();
+			auto it = notes.rend();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -1747,7 +1747,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				{
 					break;
 				}
-				it++;
+				--it;
 			}
 
 			// first check whether the user clicked in note-edit-
@@ -1769,7 +1769,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				Note * created_new_note = nullptr;
 				// did it reach end of vector because
 				// there's no note??
-				if (it == notes.end())
+				if (it == notes.rbegin())
 				{
 					is_new_note = true;
 					m_midiClip->addJournalCheckPoint();
@@ -1816,8 +1816,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// reset it so that it can be used for
 					// ops (move, resize) after this
 					// code-block
-					it = notes.begin();
-					while( it != notes.end() && *it != created_new_note )
+					it = notes.rbegin();
+					while( it != notes.rend() && *it != created_new_note )
 					{
 						++it;
 					}
@@ -1933,7 +1933,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			{
 				// erase single note
 				m_mouseDownRight = true;
-				if (it != notes.end())
+				if (it != notes.rbegin())
 				{
 					m_midiClip->addJournalCheckPoint();
 					m_midiClip->removeNote( *it );
@@ -2513,7 +2513,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			bool altPressed = me->modifiers() & Qt::AltModifier;
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
-			auto it = notes.begin();
+			auto it = notes.rend();
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note* n = *it;
@@ -2556,7 +2556,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				}
 
 
-				it++;
+				--it;
 			}
 
 			// Emit MIDI clip has changed
@@ -2575,7 +2575,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.begin();
+			auto it = notes.rend();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -2591,12 +2591,12 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				{
 					break;
 				}
-				it++;
+				--it;
 			}
 
 			// did it reach end of vector because there's
 			// no note??
-			if (it != notes.end())
+			if (it != notes.rbegin())
 			{
 				Note *note = *it;
 				// x coordinate of the right edge of the note
@@ -2686,7 +2686,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				}
 				else
 				{
-					it++;
+					++it;
 				}
 			}
 		}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1722,7 +1722,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			auto it = notes.rbegin();
 
 			// loop through whole note-vector...
-			for( int i = 0; i < notes.size(); ++i )
+			while (it != notes.rend())
 			{
 				Note *note = *it;
 				TimePos len = note->length();
@@ -1747,7 +1747,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				{
 					break;
 				}
-				--it;
+				++it;
 			}
 
 			// first check whether the user clicked in note-edit-

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1720,7 +1720,6 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 			// will be our iterator in the following loop
 			auto it = notes.end();
-			if (!notes.empty()){ auto it = notes.begin() + notes.size() - 1; }
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1769,7 +1769,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				Note * created_new_note = nullptr;
 				// did it reach end of vector because
 				// there's no note??
-				if(it == notes.end())
+				if (it == notes.end())
 				{
 					is_new_note = true;
 					m_midiClip->addJournalCheckPoint();
@@ -1933,7 +1933,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			{
 				// erase single note
 				m_mouseDownRight = true;
-				if(it != notes.end())
+				if (it != notes.end())
 				{
 					m_midiClip->addJournalCheckPoint();
 					m_midiClip->removeNote( *it );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2600,7 +2600,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 
 			// did it reach end of vector because there's
 			// no note??
-			if( it != notes.begin()-1 )
+			if (it != notes.begin())
 			{
 				Note *note = *it;
 				// x coordinate of the right edge of the note

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2578,7 +2578,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			auto it = notes.rbegin();
 
 			// loop through whole note-vector...
-			for( int i = 0; i < notes.size(); ++i )
+			while (it != notes.rend())
 			{
 				Note *note = *it;
 				// and check whether the cursor is over an
@@ -2591,7 +2591,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				{
 					break;
 				}
-				--it;
+				++it;
 			}
 
 			// did it reach end of vector because there's

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1719,7 +1719,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.end();
+			auto it = notes.begin();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -1747,7 +1747,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				{
 					break;
 				}
-				--it;
+				it++;
 			}
 
 			// first check whether the user clicked in note-edit-
@@ -1769,7 +1769,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				Note * created_new_note = nullptr;
 				// did it reach end of vector because
 				// there's no note??
-				if( it == notes.begin()-1 )
+				if(it == notes.end())
 				{
 					is_new_note = true;
 					m_midiClip->addJournalCheckPoint();
@@ -1933,7 +1933,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			{
 				// erase single note
 				m_mouseDownRight = true;
-				if( it != notes.begin()-1 )
+				if(it != notes.end())
 				{
 					m_midiClip->addJournalCheckPoint();
 					m_midiClip->removeNote( *it );
@@ -2513,7 +2513,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			bool altPressed = me->modifiers() & Qt::AltModifier;
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
-			auto it = notes.begin() + notes.size() - 1;
+			auto it = notes.begin();
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note* n = *it;
@@ -2556,7 +2556,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				}
 
 
-				--it;
+				it++;
 			}
 
 			// Emit MIDI clip has changed
@@ -2575,11 +2575,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.end();
-			if (!notes.empty()) {
-				
-				auto it = notes.begin() + notes.size() - 1;
-			} 
+			auto it = notes.begin();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -2595,12 +2591,12 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				{
 					break;
 				}
-				--it;
+				it++;
 			}
 
 			// did it reach end of vector because there's
 			// no note??
-			if (it != notes.begin())
+			if (it != notes.end())
 			{
 				Note *note = *it;
 				// x coordinate of the right edge of the note
@@ -2690,7 +2686,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				}
 				else
 				{
-					++it;
+					it++;
 				}
 			}
 		}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1719,7 +1719,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.begin() + notes.size() - 1;
+			auto it = notes.end();
+			if (!notes.empty()){ auto it = notes.begin() + notes.size() - 1; }
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1719,7 +1719,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.rend();
+			auto it = notes.rbegin();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -1769,7 +1769,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				Note * created_new_note = nullptr;
 				// did it reach end of vector because
 				// there's no note??
-				if (it == notes.rbegin())
+				if (it == notes.rend())
 				{
 					is_new_note = true;
 					m_midiClip->addJournalCheckPoint();
@@ -1816,8 +1816,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// reset it so that it can be used for
 					// ops (move, resize) after this
 					// code-block
-					it = notes.rbegin();
-					while( it != notes.rend() && *it != created_new_note )
+					it = notes.rend();
+					while (it != notes.rbegin() && *it != created_new_note)
 					{
 						++it;
 					}
@@ -1933,7 +1933,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			{
 				// erase single note
 				m_mouseDownRight = true;
-				if (it != notes.rbegin())
+				if (it != notes.rend())
 				{
 					m_midiClip->addJournalCheckPoint();
 					m_midiClip->removeNote( *it );
@@ -2575,7 +2575,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.rend();
+			auto it = notes.rbegin();
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -2596,7 +2596,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 
 			// did it reach end of vector because there's
 			// no note??
-			if (it != notes.rbegin())
+			if (it != notes.rend())
 			{
 				Note *note = *it;
 				// x coordinate of the right edge of the note

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2575,13 +2575,11 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
+			auto it = notes.end();
 			if (!notes.empty()) {
+				
 				auto it = notes.begin() + notes.size() - 1;
 			} 
-			else {
-				// on MSVC, trying to access empty notes leads to error
-				auto it = notes.end();
-			}
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1816,8 +1816,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// reset it so that it can be used for
 					// ops (move, resize) after this
 					// code-block
-					it = notes.rend();
-					while (it != notes.rbegin()+1 && *it != created_new_note)
+					it = notes.rbegin();
+					while (it != notes.rend() && *it != created_new_note)
 					{
 						++it;
 					}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1816,8 +1816,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// reset it so that it can be used for
 					// ops (move, resize) after this
 					// code-block
-					it = notes.rend();
-					while (it != notes.rbegin() && *it != created_new_note)
+					it = notes.rend()+1;
+					while (it != notes.rbegin()+1 && *it != created_new_note)
 					{
 						++it;
 					}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2575,7 +2575,13 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			auto it = notes.begin() + notes.size() - 1;
+			if (!notes.empty()) {
+				auto it = notes.begin() + notes.size() - 1;
+			} 
+			else {
+				// on MSVC, trying to access empty notes leads to error
+				auto it = notes.end();
+			}
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1816,7 +1816,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					// reset it so that it can be used for
 					// ops (move, resize) after this
 					// code-block
-					it = notes.rend()+1;
+					it = notes.rend();
 					while (it != notes.rbegin()+1 && *it != created_new_note)
 					{
 						++it;


### PR DESCRIPTION
I found a crash on the MSVC build. The bug seems to have been exposed post #6477. It required some adjustments. 

Affected versions : MSVC build of latest master.
To reproduce : try to draw on an empty midi clip. It crashes with a debug assertion failed message.