### PR TITLE
Update display file name when opening ``PatmanView``

### DIFF
--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -446,7 +446,7 @@ namespace gui
 
 PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 	InstrumentViewFixedSize( _instrument, _parent ),
-	m_pi( nullptr )
+	m_pi(dynamic_cast<PatmanInstrument*>(_instrument))
 {
 	setAutoFillBackground( true );
 	QPalette pal;
@@ -490,6 +490,8 @@ PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 	m_displayFilename = tr( "No file selected" );
 
 	setAcceptDrops( true );
+	updateFilename();
+	connect(m_pi, &PatmanInstrument::fileChanged, this, &PatmanView::updateFilename);
 }
 
 
@@ -636,8 +638,6 @@ void PatmanView::modelChanged()
 	m_pi = castModel<PatmanInstrument>();
 	m_loopButton->setModel( &m_pi->m_loopedModel );
 	m_tuneButton->setModel( &m_pi->m_tunedModel );
-	connect( m_pi, SIGNAL( fileChanged() ),
-			this, SLOT( updateFilename() ) );
 }
 
 

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -446,7 +446,7 @@ namespace gui
 
 PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 	InstrumentViewFixedSize( _instrument, _parent ),
-	m_pi(dynamic_cast<PatmanInstrument*>(_instrument))
+	m_pi(castModel<PatmanInstrument>())
 {
 	setAutoFillBackground( true );
 	QPalette pal;
@@ -487,11 +487,17 @@ PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 								"tune_off" ) );
 	m_tuneButton->setToolTip(tr("Tune mode"));
 
-	m_displayFilename = tr( "No file selected" );
+
+	if (m_pi->m_patchFile.isEmpty())
+	{
+		m_displayFilename = tr("No file selected");
+	}
+	else
+	{
+		updateFilename();
+	}
 
 	setAcceptDrops( true );
-	updateFilename();
-	connect(m_pi, &PatmanInstrument::fileChanged, this, &PatmanView::updateFilename);
 }
 
 
@@ -638,6 +644,8 @@ void PatmanView::modelChanged()
 	m_pi = castModel<PatmanInstrument>();
 	m_loopButton->setModel( &m_pi->m_loopedModel );
 	m_tuneButton->setModel( &m_pi->m_tunedModel );
+	connect( m_pi, SIGNAL( fileChanged() ),
+			this, SLOT( updateFilename() ) );
 }
 
 


### PR DESCRIPTION
When loading a project file with the Patman instrument and opening its GUI, it will display the file name as "No file selected" even though there is a file loaded in and can be played. This PR makes sure the function ``updateFileName`` is called within the ``PatmanView`` constructor if a patch file is already loaded.