### PR TITLE
Use remaining sample duration for AFP beat length

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -292,15 +292,24 @@ QString AudioFileProcessor::nodeName() const
 
 
 
-int AudioFileProcessor::getBeatLen( NotePlayHandle * _n ) const
+auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 {
+	// If we can play indefinitely, use the default beat note duration
+	if (static_cast<SampleBuffer::LoopMode>(m_loopModel.value()) != SampleBuffer::LoopMode::Off) { return 0; }
+
+	// Otherwise, use the remaining sample duration
 	const auto baseFreq = instrumentTrack()->baseFreq();
-	const float freq_factor = baseFreq / _n->frequency() *
-			Engine::audioEngine()->processingSampleRate() / Engine::audioEngine()->baseSampleRate();
+	const auto freqFactor = baseFreq / note->frequency()
+		* Engine::audioEngine()->processingSampleRate()
+		/ Engine::audioEngine()->baseSampleRate();
 
-	return static_cast<int>( floorf( ( m_sampleBuffer.endFrame() - m_sampleBuffer.startFrame() ) * freq_factor ) );
+	const auto startFrame = m_nextPlayStartPoint >= m_sampleBuffer.endFrame()
+		? m_sampleBuffer.startFrame()
+		: m_nextPlayStartPoint;
+	const auto duration = m_sampleBuffer.endFrame() - startFrame;
+
+	return static_cast<int>(floorf(duration * freqFactor));
 }
-
 
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -24,6 +24,8 @@
 
 #include "AudioFileProcessor.h"
 
+#include <cmath>
+
 #include <QPainter>
 #include <QFileInfo>
 #include <QDropEvent>
@@ -308,7 +310,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 		: m_nextPlayStartPoint;
 	const auto duration = m_sampleBuffer.endFrame() - startFrame;
 
-	return static_cast<int>(std::floorf(duration * freqFactor));
+	return static_cast<int>(std::floor(duration * freqFactor));
 }
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -308,7 +308,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 		: m_nextPlayStartPoint;
 	const auto duration = m_sampleBuffer.endFrame() - startFrame;
 
-	return static_cast<int>(floorf(duration * freqFactor));
+	return static_cast<int>(std::floorf(duration * freqFactor));
 }
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -67,7 +67,7 @@ public:
 
 	QString nodeName() const override;
 
-	virtual int getBeatLen( NotePlayHandle * _n ) const;
+	auto beatLen(NotePlayHandle* note) const -> int override;
 
 	f_cnt_t desiredReleaseFrames() const override
 	{


### PR DESCRIPTION
Fixes #2074.

The problem, as mentioned in that issue, is that the overriding `beatLen` method was incorrectly named in AudioFileProcessor. As well as renaming it, I have also changed that method to handle looping and continuous cross-note playback modes appropriately.

For loop modes that can continue indefinitely (i.e. loop and ping-pong, but not off), using the sample length for the beat doesn't make much sense. (If you want this, why enable the loop?) As such, these modes fall back to the default duration, which is still the envelope length, even if it's disabled. This is perhaps not a good default, but improvements to it are out of scope here.

I haven't written an upgrade routine as I can't think of an approach that would be guaranteed not to break anything else. The obvious option would be to enable the volume envelope for all AFPs in the pattern editor, with an appropriate length and shape to match the old behaviour. But this won't work properly if the envelope is automated, or if there are non-beat notes mixed in amongst the beat notes. I'm inclined to leave it, and think further if we get complaints.