### PR TITLE
Changed sharps to music sharps unicode

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,10 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C\u266F / D\u266D", "D", "D\u266F / E\u266D", "E", "F", "F\u266F / G\u266D", "G", "G\u266F / A\u266D", "A", "A\u266F / B\u266D", "B"};
+static std::array<QString, 12> s_noteStrings {
+	"C", "C\u266F / D\u266D", "D", "D\u266F / E\u266D", "E", "F", "F\u266F / G\u266D", 
+	"G", "G\u266F / A\u266D", "A", "A\u266F / B\u266D", "B"
+};
 
 static QString getNoteString(int key)
 {

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,7 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C# / D\u266D", "D", "D# / E\u266D", "E", "F", "F# / G\u266D", "G", "G# / A\u266D", "A", "A# / B\u266D", "B"};
+static std::array<QString, 12> s_noteStrings {"C", "C\u266F / D\u266D", "D", "D\u266F / E\u266D", "E", "F", "F\u266F / G\u266D", "G", "G\u266F / A\u266D", "A", "A\u266F / B\u266D", "B"};
 
 static QString getNoteString(int key)
 {

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,7 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+static std::array<QString, 12> s_noteStrings {"C", "C#/D\u266D", "D", "D#/E\u266D", "E", "F", "F#/G\u266D", "G", "G#/A\u266D", "A", "A#/B\u266D", "B"};
 
 static QString getNoteString(int key)
 {
@@ -1687,7 +1687,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 		m_moveStartY = me->y();
 	}
 
-	if(me->button() == Qt::LeftButton &&
+	if( me->button() == Qt::LeftButton &&
 		me->y() > keyAreaBottom() && me->y() < noteEditTop())
 	{
 		// resizing the note edit area

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -130,7 +130,7 @@ QPixmap* PianoRoll::s_toolKnife = nullptr;
 
 SimpleTextFloat * PianoRoll::s_textFloat = nullptr;
 
-static std::array<QString, 12> s_noteStrings {"C", "C#/D\u266D", "D", "D#/E\u266D", "E", "F", "F#/G\u266D", "G", "G#/A\u266D", "A", "A#/B\u266D", "B"};
+static std::array<QString, 12> s_noteStrings {"C", "C# / D\u266D", "D", "D# / E\u266D", "E", "F", "F# / G\u266D", "G", "G# / A\u266D", "A", "A# / B\u266D", "B"};
 
 static QString getNoteString(int key)
 {
@@ -1687,7 +1687,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 		m_moveStartY = me->y();
 	}
 
-	if( me->button() == Qt::LeftButton &&
+	if(me->button() == Qt::LeftButton &&
 		me->y() > keyAreaBottom() && me->y() < noteEditTop())
 	{
 		// resizing the note edit area


### PR DESCRIPTION
Took a suggestion from a comment on my last pull request #6865 that suggested the sharps signs be turned into the unicode versions of the music sharp signs rather than using # . Here is what it looks like now.

<img width="104" alt="Screenshot 2023-09-17 at 6 34 09 PM" src="https://github.com/LMMS/lmms/assets/100326501/12fb86ac-dc47-459b-a0e7-f5647a7bc90e">
