### PR TITLE
Use UTF-8 for MSVC source and execution charset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,6 +651,9 @@ IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	ELSE(WIN32)
 		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DPIC")
 	ENDIF(WIN32)
+elseif(MSVC)
+	# Use UTF-8 as the source and execution character set
+	add_compile_options("/utf-8")
 ENDIF()
 
 # add enabled sanitizers


### PR DESCRIPTION
Fixes the sharp and flat symbol display issues in MSVC builds mentioned in https://github.com/LMMS/lmms/pull/6873#issuecomment-1723293154. Sets the source character set (the encoding used for the input file) and the execution character set (the encoding used for strings in the compiled binary) to UTF-8 for MSVC. See the [Microsoft documentation for the flag](https://learn.microsoft.com/en-gb/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170).