### PR TITLE
Push policy stack in InstallDependencies module

### DIFF
--- a/cmake/modules/InstallDependencies.cmake
+++ b/cmake/modules/InstallDependencies.cmake
@@ -1,7 +1,8 @@
 include(GetPrerequisites)
 include(CMakeParseArguments)
 
-# Project's cmake_minimum_required doesn't always propagate
+# Project's cmake_minimum_required doesn't propagate to install scripts
+cmake_policy(PUSH)
 cmake_policy(SET CMP0057 NEW) # Support new if() IN_LIST operator.
 
 function(make_absolute var)
@@ -182,3 +183,5 @@ function(FIND_PREREQUISITES target RESULT_VAR exclude_system recurse
 
 	set(${RESULT_VAR} ${RESULTS} PARENT_SCOPE)
 endfunction()
+
+cmake_policy(POP)


### PR DESCRIPTION
Since #6780, we get this warning when running the install script:
```
CMake Warning (dev) in D:/a/lmms/lmms/cmake/modules/InstallDependencies.cmake:
  Policy CMP0011 is not set: Included scripts do automatic cmake_policy PUSH
  and POP.  Run "cmake --help-policy CMP0011" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  The included script

    D:/a/lmms/lmms/cmake/modules/InstallDependencies.cmake

  affects policy settings.  CMake is implying the NO_POLICY_SCOPE option for
  compatibility, so the effects are applied to the including context.
Call Stack (most recent call first):
  D:/a/lmms/lmms/build/cmake/install/cmake_install.cmake:45 (INCLUDE)
  D:/a/lmms/lmms/build/cmake_install.cmake:112 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
That module previously set CMP0011, presumably to silence this error, but as I mentioned in https://github.com/LMMS/lmms/pull/6780#issuecomment-1652559462, this fix is incorrect. It only silences the warning, doing nothing to create the intended policy scope. (This is a deliberate choice by CMake - it silences the warning to support the use case where a helper module is included in order to set policies.) To create a policy scope for a file that has already been included without one, the `cmake_policy(PUSH)` and `cmake_policy(POP)` commands can be used.

(Apologies to @tresf - I should have thought of this when reviewing that PR.)