### PR TITLE
Revamp synchronization with the audio engine

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -25,14 +25,13 @@
 #ifndef LMMS_AUDIO_ENGINE_H
 #define LMMS_AUDIO_ENGINE_H
 
-#include <QMutex>
-
-#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
-	#include <QRecursiveMutex>
+#ifdef __MINGW32__
+#include <mingw.mutex.h>
+#else
+#include <mutex>
 #endif
 
 #include <QThread>
-#include <QWaitCondition>
 #include <samplerate.h>
 
 #include <vector>
@@ -476,17 +475,7 @@ private:
 
 	bool m_clearSignal;
 
-	bool m_changesSignal;
-	unsigned int m_changes;
-	QMutex m_changesMutex;
-#if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
-	QRecursiveMutex m_doChangesMutex;
-#else
-	QMutex m_doChangesMutex;
-#endif
-	QMutex m_waitChangesMutex;
-	QWaitCondition m_changesAudioEngineCondition;
-	QWaitCondition m_changesRequestCondition;
+	std::mutex m_changeMutex;
 
 	bool m_waitingForWrite;
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -448,8 +448,6 @@ private:
 	struct qualitySettings m_qualitySettings;
 	float m_masterGain;
 
-	bool m_isProcessing;
-
 	// audio device stuff
 	void doSetAudioDevice( AudioDevice *_dev );
 	AudioDevice * m_audioDev;

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -477,8 +477,6 @@ private:
 
 	std::mutex m_changeMutex;
 
-	bool m_waitingForWrite;
-
 	friend class Engine;
 	friend class AudioEngineWorkerThread;
 	friend class ProjectRenderer;

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -419,10 +419,6 @@ private:
 
 	void clearInternal();
 
-	//! Called by the audio thread to give control to other threads,
-	//! such that they can do changes in the model (like e.g. removing effects)
-	void runChangesInModel();
-
 	bool m_renderOnly;
 
 	std::vector<AudioPort *> m_audioPorts;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -84,7 +84,6 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	m_newPlayHandles( PlayHandle::MaxNumber ),
 	m_qualitySettings( qualitySettings::Mode::Draft ),
 	m_masterGain( 1.0f ),
-	m_isProcessing( false ),
 	m_audioDev( nullptr ),
 	m_oldAudioDev( nullptr ),
 	m_audioDevStartFailed( false ),
@@ -225,8 +224,6 @@ void AudioEngine::startProcessing(bool needsFifo)
 	}
 
 	m_audioDev->startProcessing();
-
-	m_isProcessing = true;
 }
 
 
@@ -234,8 +231,6 @@ void AudioEngine::startProcessing(bool needsFifo)
 
 void AudioEngine::stopProcessing()
 {
-	m_isProcessing = false;
-
 	if( m_fifoWriter != nullptr )
 	{
 		m_fifoWriter->finish();

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -800,15 +800,15 @@ void AudioEngine::removePlayHandlesOfTypes(Track * track, PlayHandle::Types type
 void AudioEngine::requestChangeInModel()
 {
 	if (s_renderingThread || s_runningChange) { return; }
-	s_runningChange = true;
 	m_changeMutex.lock();
+	s_runningChange = true;
 }
 
 void AudioEngine::doneChangeInModel()
 {
 	if (s_renderingThread || !s_runningChange) { return; }
-	s_runningChange = false;
 	m_changeMutex.unlock();
+	s_runningChange = false;
 }
 
 bool AudioEngine::isAudioDevNameValid(QString name)


### PR DESCRIPTION
Revamps synchronization of the audio engine. I'm not too sure why the current implementation of ``requestChangesInModel``/``doneChangeInModel`` did not make the master audio thread wait as expected, but I presume it had something to do with the boolean variables being used, making certain calls to ``requestChangesInModel`` only apply once. All in all, this PR intends to:

* Actually make the other threads wait when changes are running.
* Bring code that is easier to follow.
* Not cause data races within the synchronization mechanism itself (TSan reported 0 data races involving these functions with these changes applied).
* Bring use of STL's ``std::mutex`` and ~~``std::condition_variable``~~ ``std::shared_mutex`` over equivalent Qt types.

The revamp consists of one lock. Both calls to ``requestChangeInModel`` and ``renderNextBuffer`` will try and acquire the lock. Waiting on the lock on the thread requesting the change is either because there is already another change that has locked the mutex, or the audio thread has locked it for rendering. Waiting on the lock on the audio thread is because a change is currently running.  

It is also important to mention that we can also be passing in certain changes to be executed on the master audio thread without using locks, under the condition that we do not create Qt objects (or call most Qt functions) on those threads, as such operations should be done on the main thread. Because of this, maybe it will be beneficial to add this functionality alongside ``requestChangesInModel``/``doneChangesInModel`` for non-Qt related operations that need to synchronize with the master audio thread in the future.