### PR TITLE
Updated some old file filtering code.

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -328,68 +328,62 @@ void FileBrowser::addItems(const QString & path )
 	}
 
 	// try to add all directories from file system alphabetically into the tree
-	QDir cdir( path );
-	QStringList files = cdir.entryList( QDir::Dirs, QDir::Name );
-	files.sort(Qt::CaseInsensitive);
-	for( QStringList::const_iterator it = files.constBegin();
-						it != files.constEnd(); ++it )
+	QDir cdir(path);
+	if (!cdir.isReadable()) { return; }
+	cdir.setNameFilters(m_filter.split(' '));
+	QFileInfoList entries = cdir.entryInfoList(
+			QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot,
+			QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
+	for (auto& entry : entries)
 	{
-		QString cur_file = *it;
-		if( cur_file[0] != '.' )
+		QString fileName = entry.fileName();
+		if (entry.isDir())
 		{
+			// Merge dir's together
 			bool orphan = true;
-			for( int i = 0; i < m_fileBrowserTreeWidget->topLevelItemCount(); ++i )
+			for (int i = 0; i < m_fileBrowserTreeWidget->topLevelItemCount(); ++i)
 			{
 				auto d = dynamic_cast<Directory*>(m_fileBrowserTreeWidget->topLevelItem(i));
-				if( d == nullptr || cur_file < d->text( 0 ) )
+				if (d == nullptr || fileName < d->text(0))
 				{
 					// insert before item, we're done
-					auto dd = new Directory(cur_file, path, m_filter);
-					m_fileBrowserTreeWidget->insertTopLevelItem( i,dd );
+					auto dd = new Directory(fileName, path, m_filter);
+					m_fileBrowserTreeWidget->insertTopLevelItem(i,dd);
 					dd->update(); // add files to the directory
 					orphan = false;
 					break;
 				}
-				else if( cur_file == d->text( 0 ) )
+				else if (fileName == d->text(0))
 				{
 					// imagine we have subdirs named "TripleOscillator/xyz" in
 					// two directories from m_directories
 					// then only add one tree widget for both
 					// so we don't add a new Directory - we just
 					// add the path to the current directory
-					d->addDirectory( path );
+					d->addDirectory(path);
 					d->update();
 					orphan = false;
 					break;
 				}
 			}
-			if( orphan )
+			if (orphan)
 			{
 				// it has not yet been added yet, so it's (lexically)
 				// larger than all other dirs => append it at the bottom
-				auto d = new Directory(cur_file, path, m_filter);
+				auto d = new Directory(fileName, path, m_filter);
 				d->update();
-				m_fileBrowserTreeWidget->addTopLevelItem( d );
+				m_fileBrowserTreeWidget->addTopLevelItem(d);
 			}
-		}
-	}
-
-	files = cdir.entryList( QDir::Files, QDir::Name );
-	for( QStringList::const_iterator it = files.constBegin();
-						it != files.constEnd(); ++it )
-	{
-		QString cur_file = *it;
-		if( cur_file[0] != '.' )
-		{
+		} else if (entry.isFile()) {
 			// TODO: don't insert instead of removing, order changed
 			// remove existing file-items
 			QList<QTreeWidgetItem *> existing = m_fileBrowserTreeWidget->findItems(
-					cur_file, Qt::MatchFixedString );
-			if( !existing.empty() )
+					fileName, Qt::MatchFixedString );
+			if (!existing.empty())
 			{
 				delete existing.front();
 			}
-			(void) new FileItem( m_fileBrowserTreeWidget, cur_file, path );
+			(void) new FileItem(m_fileBrowserTreeWidget, fileName, path);
 		}
 	}
 }
@@ -1063,7 +1057,10 @@ bool Directory::addItems(const QString& path)
 
 	treeWidget()->setUpdatesEnabled(false);
 
-	QFileInfoList entries = thisDir.entryInfoList(QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot, QDir::LocaleAware | QDir::DirsFirst | QDir::Name);
+	thisDir.setNameFilters(m_filter.split(' '));
+	QFileInfoList entries = thisDir.entryInfoList(
+			QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot,
+			QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
 	for (auto& entry : entries)
 	{
 		QString fileName = entry.fileName();
@@ -1073,7 +1070,7 @@ bool Directory::addItems(const QString& path)
 			addChild(dir);
 			m_dirCount++;
 		}
-		else if (entry.isFile() && thisDir.match(m_filter, fileName.toLower()))
+		else if (entry.isFile())
 		{
 			auto fileItem = new FileItem(fileName, path);
 			addChild(fileItem);

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -330,11 +330,11 @@ void FileBrowser::addItems(const QString & path )
 	// try to add all directories from file system alphabetically into the tree
 	QDir cdir(path);
 	if (!cdir.isReadable()) { return; }
-	cdir.setNameFilters(m_filter.split(' '));
 	QFileInfoList entries = cdir.entryInfoList(
+			m_filter.split(' '),
 			QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot,
 			QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
-	for (auto& entry : entries)
+	for (const auto& entry : entries)
 	{
 		QString fileName = entry.fileName();
 		if (entry.isDir())
@@ -1057,11 +1057,11 @@ bool Directory::addItems(const QString& path)
 
 	treeWidget()->setUpdatesEnabled(false);
 
-	thisDir.setNameFilters(m_filter.split(' '));
 	QFileInfoList entries = thisDir.entryInfoList(
+			m_filter.split(' '),
 			QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot,
 			QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
-	for (auto& entry : entries)
+	for (const auto& entry : entries)
 	{
 		QString fileName = entry.fileName();
 		if (entry.isDir())

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -379,8 +379,7 @@ void FileBrowser::addItems(const QString & path )
 		{
 			// TODO: don't insert instead of removing, order changed
 			// remove existing file-items
-			QList<QTreeWidgetItem *> existing = m_fileBrowserTreeWidget->findItems(
-					fileName, Qt::MatchFixedString );
+			QList<QTreeWidgetItem *> existing = m_fileBrowserTreeWidget->findItems(fileName, Qt::MatchFixedString);
 			if (!existing.empty())
 			{
 				delete existing.front();

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -374,7 +374,9 @@ void FileBrowser::addItems(const QString & path )
 				d->update();
 				m_fileBrowserTreeWidget->addTopLevelItem(d);
 			}
-		} else if (entry.isFile()) {
+		}
+		else if (entry.isFile())
+		{
 			// TODO: don't insert instead of removing, order changed
 			// remove existing file-items
 			QList<QTreeWidgetItem *> existing = m_fileBrowserTreeWidget->findItems(

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -112,7 +112,7 @@ MainWindow::MainWindow() :
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userProjectsDir() + "*" +
 				confMgr->factoryProjectsDir(),
-					"*.mmp *.mmpz *.xml *.mid",
+					"*.mmp *.mmpz *.xml *.mid *.mpt",
 							tr( "My Projects" ),
 					embed::getIconPixmap( "project_file" ).transformed( QTransform().rotate( 90 ) ),
 							splitter, false, true,


### PR DESCRIPTION
**Summary**
This is a bug fix for an unnoticed issue "File Browser filters do nothing" The built-in file extension filers are ignored on the top level leading to a messy projects directory.

Before, the File Browser would show any and all files in the projects directory, despite an existing filter in MainWindow.cpp "*.mmp *.mmpz *.xml *.mid" which FileBrowser was ignoring at the top level, but passed down to Directory, which used it correctly and in a modern way.

**Background**
I was trying to add a way to show/hide the .bak and other files with some filter buttons when I noticed the code in Directory::addItems was a modernized copy pasta of the older style (not using good Qt 5 conventions) FileBrowser::addItems.

In addition, only, FileBrowser::addItems was not respecting the filter's at all. I brought both of them into line with Qt 5 practices which now respects the m_filter list of extensions for both FileBrowser and Directory. In Directory::addItems I only needed to change where the match was being done, FileBrowser::addItems didn't try to filter/match at all.

**Conflict**
After doing all this I noticed that #6339 has been working on something similar (dare I say better!) to what I was going to do before I discovered this bug.

I would like to help out or take over that work so we can all have nice file browser filter buttons like Blender :)
@allejok96 hit me up!

I have checked out the current state of #6339 and it segfaults unfortunately; things have moved on a bunch (209 commits behind, woof!)

I am also willing to integrate #5772 and #6189 into this work if need be as these are all sore spots for me when using LMMS daily.