### PR TITLE
Fix warnings in Clang build

### DIFF
--- a/include/Flags.h
+++ b/include/Flags.h
@@ -48,8 +48,8 @@ public:
 		m_value{value}
 	{}
 
-	constexpr auto testAll(Flags flags) const -> bool { return *this & flags == flags; }
-	constexpr auto testAny(Flags flags) const -> bool { return *this & flags != Flags{}; }
+	constexpr auto testAll(Flags flags) const -> bool { return (*this & flags) == flags; }
+	constexpr auto testAny(Flags flags) const -> bool { return (*this & flags) != Flags{}; }
 	constexpr auto testFlag(EnumType flag) const -> bool { return static_cast<bool>(*this & flag); }
 
 	constexpr auto operator~() const -> Flags { return Flags{~m_value}; }

--- a/include/Lv2UridMap.h
+++ b/include/Lv2UridMap.h
@@ -55,7 +55,7 @@ class UridMap
 	LV2_URID_Map m_mapFeature;
 	LV2_URID_Unmap m_unmapFeature;
 
-	LV2_URID m_lastUrid = 0;
+	[[maybe_unused]] LV2_URID m_lastUrid = 0;
 
 public:
 	//! constructor; will set up the features

--- a/include/Lv2UridMap.h
+++ b/include/Lv2UridMap.h
@@ -55,8 +55,6 @@ class UridMap
 	LV2_URID_Map m_mapFeature;
 	LV2_URID_Unmap m_unmapFeature;
 
-	[[maybe_unused]] LV2_URID m_lastUrid = 0;
-
 public:
 	//! constructor; will set up the features
 	UridMap();

--- a/include/MidiEvent.h
+++ b/include/MidiEvent.h
@@ -212,7 +212,7 @@ private:
 		int32_t m_sysExDataLen;	// len of m_sysExData
 	} m_data;
 
-	const char* m_sysExData;
+	[[maybe_unused]] const char* m_sysExData;
 	const void* m_sourcePort;
 
 	// Stores the source of the MidiEvent: Internal or External (hardware controllers).

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -302,7 +302,7 @@ void DataFile::write( QTextStream & _strm )
 bool DataFile::writeFile(const QString& filename, bool withResources)
 {
 	// Small lambda function for displaying errors
-	auto showError = [this](QString title, QString body){
+	auto showError = [](QString title, QString body){
 		if (gui::getGUI() != nullptr)
 		{
 			QMessageBox mb;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -273,7 +273,9 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   //generation
   long  Length, tpos=0, tplus, totmp, t, i, j;
   float x[3] = {0.f, 0.f, 0.f};
-  float MasterTune, randmax, randmax2;
+  float MasterTune;
+  constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
+  constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
   int   MainFilter, HighPass;
 
   long  NON, NT, TON, DiON, TDroop=0, DStep;
@@ -454,7 +456,6 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   }
 
   //prepare envelopes
-  randmax = 1.f / RAND_MAX; randmax2 = 2.f * randmax;
   for (i=1;i<8;i++) { envData[i][NEXTT]=0; envData[i][PNT]=0; }
   Length = LongestEnv();
 

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -409,7 +409,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		// Skip notes randomly
 		if( m_arpSkipModel.value() )
 		{
-			if( 100 * ( (float) rand() / (float)( RAND_MAX + 1.0f ) ) < m_arpSkipModel.value() )
+			if( 100 * ( (float) rand() / (static_cast<float>(RAND_MAX) + 1.0f)) < m_arpSkipModel.value() )
 			{
 				// update counters
 				frames_processed += arp_frames;
@@ -425,7 +425,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		if( m_arpMissModel.value() )
 		{
-			if( 100 * ( (float) rand() / (float)( RAND_MAX + 1.0f ) ) < m_arpMissModel.value() )
+			if( 100 * ( (float) rand() / (static_cast<float>(RAND_MAX) + 1.0f)) < m_arpMissModel.value() )
 			{
 				dir = ArpDirection::Random;
 			}

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -409,7 +409,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		// Skip notes randomly
 		if( m_arpSkipModel.value() )
 		{
-			if( 100 * ( (float) rand() / (static_cast<float>(RAND_MAX) + 1.0f)) < m_arpSkipModel.value() )
+			if (100 * static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) + 1.0f) < m_arpSkipModel.value())
 			{
 				// update counters
 				frames_processed += arp_frames;
@@ -425,7 +425,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		if( m_arpMissModel.value() )
 		{
-			if( 100 * ( (float) rand() / (static_cast<float>(RAND_MAX) + 1.0f)) < m_arpMissModel.value() )
+			if (100 * static_cast<float>(rand()) / (static_cast<float>(RAND_MAX) + 1.0f) < m_arpMissModel.value())
 			{
 				dir = ArpDirection::Random;
 			}

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -464,7 +464,7 @@ bool MixerView::confirmRemoval(int index)
 	QString messageTitleRemoveTrack = tr("Confirm removal");
 	QString askAgainText = tr("Don't ask again");
 	auto askAgainCheckBox = new QCheckBox(askAgainText, nullptr);
-	connect(askAgainCheckBox, &QCheckBox::stateChanged, [this](int state) {
+	connect(askAgainCheckBox, &QCheckBox::stateChanged, [](int state) {
 		// Invert button state, if it's checked we *shouldn't* ask again
 		ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning", state ? "0" : "1");
 	});

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -212,7 +212,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	auto generalControlsLayout = new QVBoxLayout;
 	generalControlsLayout->setSpacing(10);
 
-	auto addLedCheckBox = [this](const QString& ledText, TabWidget* tw, int& counter,
+	auto addLedCheckBox = [&](const QString& ledText, TabWidget* tw, int& counter,
 							  bool initialState, const char* toggledSlot, bool showRestartWarning) {
 		auto checkBox = new LedCheckBox(ledText, tw);
 		counter++;

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -168,8 +168,8 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 
 
 	// Constants for positioning LED check boxes.
-	const int XDelta = 10;
-	const int YDelta = 18;
+	constexpr int XDelta = 10;
+	constexpr int YDelta = 18;
 
 	// Main widget.
 	auto main_w = new QWidget(this);
@@ -212,7 +212,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	auto generalControlsLayout = new QVBoxLayout;
 	generalControlsLayout->setSpacing(10);
 
-	auto addLedCheckBox = [&XDelta, &YDelta, this](const QString& ledText, TabWidget* tw, int& counter,
+	auto addLedCheckBox = [this](const QString& ledText, TabWidget* tw, int& counter,
 							  bool initialState, const char* toggledSlot, bool showRestartWarning) {
 		auto checkBox = new LedCheckBox(ledText, tw);
 		counter++;

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -195,7 +195,7 @@ bool TrackOperationsWidget::confirmRemoval()
 	QString messageTitleRemoveTrack = tr("Confirm removal");
 	QString askAgainText = tr("Don't ask again");
 	auto askAgainCheckBox = new QCheckBox(askAgainText, nullptr);
-	connect(askAgainCheckBox, &QCheckBox::stateChanged, [this](int state){
+	connect(askAgainCheckBox, &QCheckBox::stateChanged, [](int state){
 		// Invert button state, if it's checked we *shouldn't* ask again
 		ConfigManager::inst()->setValue("ui", "trackdeletionwarning", state ? "0" : "1");
 	});


### PR DESCRIPTION
This PR fixes all the warnings generated by Clang/AppleClang when building the Core and GUI.
For now, I've refrained from fixing any warnings generated from plugins or 3rd party libraries, since that would likely require a lot more work.

Changes include:
- Fixed unused variable warnings
- Fixed implicit conversion warnings
- Fixed unused lambda capture warnings
- Fixed an operator precedence bug from #6760
  - The bitwise AND operator (`&`) counterintuitively has [lower precedence](https://en.cppreference.com/w/cpp/language/operator_precedence) than `==`
