### PR TITLE
SetupDialog - message on buffer size larger than 256

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -126,6 +126,9 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 			m_framesPerPeriod = DEFAULT_BUFFER_SIZE;
 		}
+		// lmms works with chunks of size DEFAULT_BUFFER_SIZE (256) and only the final mix will use the actual
+		// buffer size. Plugins don't see a larger buffer size than 256. If m_framesPerPeriod is larger than
+		// DEFAULT_BUFFER_SIZE, it's set to DEFAULT_BUFFER_SIZE and the rest is handled by an increased fifoSize.
 		else if( m_framesPerPeriod > DEFAULT_BUFFER_SIZE )
 		{
 			fifoSize = m_framesPerPeriod / DEFAULT_BUFFER_SIZE;

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -1182,7 +1182,11 @@ void SetupDialog::audioInterfaceChanged(const QString & iface)
 void SetupDialog::updateBufferSizeWarning(int value)
 {
 	QString text = "<ul>";
-	if((value & (value - 1)) != 0)  // <=> value is not a power of 2 (for value > 0)
+	// 'value' is not a power of 2 (for value > 0) and under 256. On buffer sizes larger than 256
+	// lmms works with chunks of size 256 and only the final mix will use the actual buffer size.
+	// Plugins don't see a larger buffer size than 256 so anything larger than this is functionally
+	// a 'power of 2' value.
+	if(((value & (value - 1)) != 0) && value < 256)
 	{
 		text += "<li>" + tr("The currently selected value is not a power of 2 "
 					"(32, 64, 128, 256, 512, 1024, ...). Some plugins may not be available.") + "</li>";

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -1189,7 +1189,7 @@ void SetupDialog::updateBufferSizeWarning(int value)
 	if(((value & (value - 1)) != 0) && value < 256)
 	{
 		text += "<li>" + tr("The currently selected value is not a power of 2 "
-					"(32, 64, 128, 256, 512, 1024, ...). Some plugins may not be available.") + "</li>";
+					"(32, 64, 128, 256). Some plugins may not be available.") + "</li>";
 	}
 	if(value <= 32)
 	{


### PR DESCRIPTION
In the Lv2-worker PR we also got support for plugins in want of a buffer size that is a power of 2. (issue https://github.com/LMMS/lmms/issues/6492).
Wile testing the Lv2-worker I noticed that plugins that only shouyld work with a power of 2 buffer size wouldn't crash if I forced it to an odd value as long as this value was higher than 256. https://github.com/LMMS/lmms/pull/6484#issuecomment-1288293177
A legend to the rescue. Jasp00 remarked that the larger buffer sizes are really convenient [chunks of size 256](https://github.com/LMMS/lmms/pull/6484#issuecomment-1322503624) and upon testing the Lv2 plugins further it turns out that they don't see anything higher than 256. So anything higher is a power of 2 value. We only need to tweak the user message in Settings.