### PR TITLE
Fix instrument release fade-out

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -394,6 +394,17 @@ void AudioEngine::renderStageInstruments()
 
 	AudioEngineWorkerThread::fillJobQueue(m_playHandles);
 	AudioEngineWorkerThread::startAndWaitForJobs();
+}
+
+
+
+void AudioEngine::renderStageEffects()
+{
+	AudioEngineProfiler::Probe profilerProbe(m_profiler, AudioEngineProfiler::DetailType::Effects);
+
+	// STAGE 2: process effects of all instrument- and sampletracks
+	AudioEngineWorkerThread::fillJobQueue(m_audioPorts);
+	AudioEngineWorkerThread::startAndWaitForJobs();
 
 	// removed all play handles which are done
 	for( PlayHandleList::Iterator it = m_playHandles.begin();
@@ -420,17 +431,6 @@ void AudioEngine::renderStageInstruments()
 			++it;
 		}
 	}
-}
-
-
-
-void AudioEngine::renderStageEffects()
-{
-	AudioEngineProfiler::Probe profilerProbe(m_profiler, AudioEngineProfiler::DetailType::Effects);
-
-	// STAGE 2: process effects of all instrument- and sampletracks
-	AudioEngineWorkerThread::fillJobQueue(m_audioPorts);
-	AudioEngineWorkerThread::startAndWaitForJobs();
 }
 
 

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -179,21 +179,18 @@ void Instrument::applyFadeIn(sampleFrame * buf, NotePlayHandle * n)
 
 void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 {
-	const fpp_t frames = _n->framesLeftForCurrentPeriod();
-	const fpp_t fpp = Engine::audioEngine()->framesPerPeriod();
-	const f_cnt_t fl = _n->framesLeft();
-	if( fl < desiredReleaseFrames()+fpp )
+	const auto fpp = Engine::audioEngine()->framesPerPeriod();
+	const auto releaseFrames = desiredReleaseFrames();
+
+	const auto endFrame = _n->framesLeft();
+	const auto startFrame = std::max(0, endFrame - releaseFrames);
+
+	for (auto f = startFrame; f < endFrame && f < fpp; f++)
 	{
-		for( fpp_t f = (fpp_t)( ( fl > desiredReleaseFrames() ) ?
-				(std::max(fpp - desiredReleaseFrames(), 0) +
-					fl) % fpp : 0); f < frames; ++f)
+		const float fac = (float)(endFrame - f) / (float)releaseFrames;
+		for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ch++)
 		{
-			const float fac = (float)( fl-f ) /
-							desiredReleaseFrames();
-			for( ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch )
-			{
-				buf[f][ch] *= fac;
-			}
+			buf[f][ch] *= fac;
 		}
 	}
 }

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -188,7 +188,7 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 				(std::max(fpp - desiredReleaseFrames(), 0) +
 					fl) % fpp : 0); f < frames; ++f)
 		{
-			const float fac = (float)( fl-f-1 ) /
+			const float fac = (float)( fl-f ) /
 							desiredReleaseFrames();
 			for( ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch )
 			{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -186,7 +186,7 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 	{
 		for( fpp_t f = (fpp_t)( ( fl > desiredReleaseFrames() ) ?
 				(std::max(fpp - desiredReleaseFrames(), 0) +
-					fl % fpp) : 0); f < frames; ++f)
+					fl) % fpp : 0); f < frames; ++f)
 		{
 			const float fac = (float)( fl-f-1 ) /
 							desiredReleaseFrames();

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -182,7 +182,7 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const fpp_t fpp = Engine::audioEngine()->framesPerPeriod();
 	const f_cnt_t fl = _n->framesLeft();
-	if( fl <= desiredReleaseFrames()+fpp )
+	if( fl < desiredReleaseFrames()+fpp )
 	{
 		for( fpp_t f = (fpp_t)( ( fl > desiredReleaseFrames() ) ?
 				(std::max(fpp - desiredReleaseFrames(), 0) +


### PR DESCRIPTION
This fixes #3086 by addressing two bugs leading to clicks on instrument note-off in most instruments.

The first bug was introduced as part of a refactoring done by Vesa via 857de8d2c829dc688745f41ba8eddbe148a63a20 and caused each note play handle's last buffer being dropped because the play handles were deleted before being processed in AudioPort as discovered by @lleroy in https://github.com/LMMS/lmms/issues/3086#issuecomment-519087089.

The second bug looks like a typo that has always been there since the fade-out was introduced in 02433380c629457ad021a1f9c91b8148769c33dc and was a misplaced parenthesis in Instrument::applyRelease breaking the calculation of the note-off envelope's start frame, sometimes putting it outside of the buffer. I'd love a second set of eyes on this one because I'm not sure I really understand the calculation. I think it could just be replaced by `_n->framesBeforeRelease()` and in my tests `f` is always equal to that at the start of the loop, but maybe I'm missing some edge case here.

Before/after examples copied from https://github.com/LMMS/lmms/issues/3086#issuecomment-1741553796:

* Triple Oscillator
  ![image](https://github.com/LMMS/lmms/assets/2879917/49d3986c-82f4-4f23-b327-23aac4686fec)
* BitInvader
  ![image](https://github.com/LMMS/lmms/assets/2879917/67990549-690c-4ba9-83e3-77eb5291aef9)
