### PR TITLE
Mallets - Some small fixes

### DIFF
--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -380,13 +380,19 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 
 	auto ps = static_cast<MalletsSynth*>(_n->m_pluginData);
 	ps->setFrequency(freq);
-	if (p==9) // Tubular Bells
+
+	p = ps->presetIndex();
+	if (p < 9) // ModalBar updates
+	{
+		ps->setVibratoGain(m_vibratoGainModel.value());
+		ps->setVibratoFreq(m_vibratoFreqModel.value());
+	}
+	else if (p == 9) // Tubular Bells updates
 	{
 		ps->setADSR(m_adsrModel.value());
 		ps->setLFODepth(m_lfoDepthModel.value());
 		ps->setLFOSpeed(m_lfoSpeedModel.value());
 	}
-	p = ps->presetIndex();
 
 	sample_t add_scale = 0.0f;
 	if( p == 10 && m_isOldVersionModel.value() == true )

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -301,6 +301,8 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 		float position = m_positionModel.value();
 		float modulator = m_modulatorModel.value();
 		float crossfade = m_crossfadeModel.value();
+		float pressure = m_pressureModel.value();
+		float speed = m_velocityModel.value();
 
 		if (p < 9)
 		{
@@ -317,6 +319,14 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 
 			crossfade += random * (static_cast<float>(fast_rand() % 128) - 64.0);
 			crossfade = std::clamp(crossfade, 0.0f, 128.0f);
+		}
+		else
+		{
+			pressure += random * (static_cast<float>(fast_rand() % 128) - 64.0);
+			pressure = std::clamp(pressure, 0.0f, 128.0f);
+
+			speed += random * (static_cast<float>(fast_rand() % 128) - 64.0);
+			speed = std::clamp(speed, 0.0f, 128.0f);
 		}
 
 		// critical section as STK is not thread-safe
@@ -352,12 +362,12 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 		{
 			_n->m_pluginData = new MalletsSynth( freq,
 						vel,
-						m_pressureModel.value(),
+						pressure,
 						m_motionModel.value(),
 						m_vibratoModel.value(),
 						p - 10,
 						m_strikeModel.value() * 128.0,
-						m_velocityModel.value(),
+						speed,
 						(uint8_t) m_spreadModel.value(),
 				Engine::audioEngine()->processingSampleRate() );
 		}

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -380,6 +380,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 
 	auto ps = static_cast<MalletsSynth*>(_n->m_pluginData);
 	ps->setFrequency( freq );
+	if (p==9) { ps->setADSR( m_adsrModel.value() ); }
 	p = ps->presetIndex();
 
 	sample_t add_scale = 0.0f;

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -304,18 +304,18 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 
 		if (p < 9)
 		{
-			hardness += random * static_cast<float>(fast_rand() % 128) - 64.0;
+			hardness += random * (static_cast<float>(fast_rand() % 128) - 64.0);
 			hardness = std::clamp(hardness, 0.0f, 128.0f);
 
-			position += random * static_cast<float>(fast_rand() % 64) - 32.0;
+			position += random * (static_cast<float>(fast_rand() % 64) - 32.0);
 			position = std::clamp(position, 0.0f, 64.0f);
 		}
 		else if (p == 9)
 		{
-			modulator += random * static_cast<float>(fast_rand() % 128) - 64.0;
+			modulator += random * (static_cast<float>(fast_rand() % 128) - 64.0);
 			modulator = std::clamp(modulator, 0.0f, 128.0f);
 
-			crossfade += random * static_cast<float>(fast_rand() % 128) - 64.0;
+			crossfade += random * (static_cast<float>(fast_rand() % 128) - 64.0);
 			crossfade = std::clamp(crossfade, 0.0f, 128.0f);
 		}
 

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -380,7 +380,12 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 
 	auto ps = static_cast<MalletsSynth*>(_n->m_pluginData);
 	ps->setFrequency( freq );
-	if (p==9) { ps->setADSR( m_adsrModel.value() ); }
+	if (p==9) // Tubular Bells
+	{
+		ps->setADSR( m_adsrModel.value() );
+		ps->setLFODepth( m_lfoDepthModel.value() );
+		ps->setLFOSpeed( m_lfoSpeedModel.value() );
+	}
 	p = ps->presetIndex();
 
 	sample_t add_scale = 0.0f;

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -379,12 +379,12 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 	const f_cnt_t offset = _n->noteOffset();
 
 	auto ps = static_cast<MalletsSynth*>(_n->m_pluginData);
-	ps->setFrequency( freq );
+	ps->setFrequency(freq);
 	if (p==9) // Tubular Bells
 	{
-		ps->setADSR( m_adsrModel.value() );
-		ps->setLFODepth( m_lfoDepthModel.value() );
-		ps->setLFOSpeed( m_lfoSpeedModel.value() );
+		ps->setADSR(m_adsrModel.value());
+		ps->setLFODepth(m_lfoDepthModel.value());
+		ps->setLFOSpeed(m_lfoSpeedModel.value());
 	}
 	p = ps->presetIndex();
 

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -124,12 +124,14 @@ public:
 		return( s );
 	}
 
-	inline void setFrequency( const StkFloat _pitch )
+	inline void setFrequency(const StkFloat _pitch)
 	{
-		if( m_voice )
-		{
-			m_voice->setFrequency( _pitch );
-		}
+		if ( m_voice ) { m_voice->setFrequency( _pitch ); }
+	}
+
+	inline void setADSR( const StkFloat _control128 )
+	{
+		if( m_voice ) { m_voice->controlChange( 128, _control128 ); }
 	}
 
 	inline int presetIndex()

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -131,7 +131,17 @@ public:
 
 	inline void setADSR( const StkFloat _control128 )
 	{
-		if( m_voice ) { m_voice->controlChange( 128, _control128 ); }
+		if ( m_voice ) { m_voice->controlChange( 128, _control128 ); }
+	}
+
+	inline void setLFODepth( const StkFloat _control1 )
+	{
+		if ( m_voice ) { m_voice->controlChange( 1, _control1 ); }
+	}
+
+	inline void setLFOSpeed( const StkFloat _control11 )
+	{
+		if ( m_voice ) { m_voice->controlChange( 11, _control11 ); }
 	}
 
 	inline int presetIndex()

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -126,22 +126,22 @@ public:
 
 	inline void setFrequency(const StkFloat _pitch)
 	{
-		if ( m_voice ) { m_voice->setFrequency( _pitch ); }
+		if (m_voice) { m_voice->setFrequency(_pitch); }
 	}
 
-	inline void setADSR( const StkFloat _control128 )
+	inline void setADSR(const StkFloat _control128)
 	{
-		if ( m_voice ) { m_voice->controlChange( 128, _control128 ); }
+		if (m_voice) { m_voice->controlChange(128, _control128); }
 	}
 
-	inline void setLFODepth( const StkFloat _control1 )
+	inline void setLFODepth(const StkFloat _control1)
 	{
-		if ( m_voice ) { m_voice->controlChange( 1, _control1 ); }
+		if (m_voice) { m_voice->controlChange(1, _control1); }
 	}
 
-	inline void setLFOSpeed( const StkFloat _control11 )
+	inline void setLFOSpeed(const StkFloat _control11)
 	{
-		if ( m_voice ) { m_voice->controlChange( 11, _control11 ); }
+		if (m_voice) { m_voice->controlChange(11, _control11); }
 	}
 
 	inline int presetIndex()

--- a/plugins/Stk/Mallets/Mallets.h
+++ b/plugins/Stk/Mallets/Mallets.h
@@ -129,6 +129,20 @@ public:
 		if (m_voice) { m_voice->setFrequency(_pitch); }
 	}
 
+	// ModalBar updates
+	inline void setVibratoGain(const StkFloat _control8)
+	{
+		// bug in stk, Control Number 8 and 1 swapped in ModalBar
+		// we send the control number for stick direct mix instead
+		if (m_voice) { m_voice->controlChange(8, _control8); }
+	}
+
+	inline void setVibratoFreq(const StkFloat _control11)
+	{
+		if (m_voice) { m_voice->controlChange(11, _control11); }
+	}
+
+	// Tubular Bells updates
 	inline void setADSR(const StkFloat _control128)
 	{
 		if (m_voice) { m_voice->controlChange(128, _control128); }


### PR DESCRIPTION
Found an oddity caused by the Random function. Fixed up some older oddities and glitches at the same time.

* Fix an issue with the Random algorithm where the randomized variables ended up half as big as they should be.
* Tubular Bells
  * Implement the ADSR knob which had no action. The value needed updating.
  * LFO - update values while playing.
* BandedWG (Uniform Bar, Tuned Bar, etc.) - Randomize values of Pressure and Speed.
* ModalBar (Marimba, Vibraphone, etc.) - Update values of Vibrato (Gain, Frequency) while playing.

The change on the Vibrato is how you expect the knobs to work. On a long note you should hear the vibrato change when you turn the knobs but it was only updated on every new note. There is no way to create an upgrade routine for this but the effect should be subtle and not cause any problems. Same with the ADSR. The knob didn't have an effect previously but if it was turned, with no perceived effect, the new value was still saved with the project correctly so in this case older projects may not upgrade properly. This will also be subtle changes where the ADSR knob modulates the action of the Modulator and Crossfade knobs. You could probably dig into the STK code here but I don't think it's going to be worth the effort. Been there, done that.

The ModalBar Vibrato and stick mix control messages in stk seem to have been mixed up. Reported upstream.
https://github.com/thestk/stk/issues/143