### PR TITLE
Add zoom actions with hotkeys

### DIFF
--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -64,6 +64,13 @@ public:
 		Select
 	};
 
+	enum class ZoomAction
+	{
+		Loop,
+		Selection,
+		FullSong
+	};
+
 	SongEditor( Song * song );
 	~SongEditor() override = default;
 
@@ -125,6 +132,9 @@ private:
 
 	int trackIndexFromSelectionPoint(int yPos);
 	int indexOfTrackView(const TrackView* tv);
+
+	void zoomToAction(enum ZoomAction);
+	TextFloat* m_zoomInfo;
 
 	Song * m_song;
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -92,7 +92,8 @@ SongEditor::SongEditor( Song * song ) :
 	m_trackHeadWidth(ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt()==1
 					 ? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT
 					 : DEFAULT_SETTINGS_WIDGET_WIDTH + TRACK_OP_WIDTH),
-	m_selectRegion(false)
+	m_selectRegion(false),
+	m_zoomInfo(nullptr)
 {
 	m_zoomingModel->setParent(this);
 	m_snappingModel->setParent(this);
@@ -532,7 +533,18 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 	{
 		m_zoomingModel->reset();
 	}
-	else
+	else if (ke->key() == Qt::Key_L && ke->modifiers() & Qt::ControlModifier)
+	{
+		zoomToAction(ZoomAction::Loop);
+	}
+	else if (ke->key() == Qt::Key_T && ke->modifiers() & Qt::ControlModifier)
+	{
+		zoomToAction(ZoomAction::Selection);
+	}
+	else if ((ke->key() == Qt::Key_F && ke->modifiers() & Qt::ControlModifier))
+	{
+		zoomToAction(ZoomAction::FullSong);
+	}
 	{
 		QWidget::keyPressEvent(ke);
 	}
@@ -924,6 +936,89 @@ int SongEditor::indexOfTrackView(const TrackView *tv)
 {
 	return static_cast<int>(std::distance(trackViews().begin(),
 										  std::find(trackViews().begin(), trackViews().end(), tv)));
+}
+
+
+
+
+void SongEditor::zoomToAction(ZoomAction zAction)
+{
+	int beatZoomBegin;
+	int beatZoomEnd;
+	std::string sAction;
+
+	// get beatBegin and beatEnd and show warnings
+	switch (zAction)
+	{
+		case ZoomAction::Loop: {
+			sAction = "Loop";
+			beatZoomBegin = std::floor(static_cast<float>(m_timeLine->loopBegin()) / TimePos::ticksPerBar());
+			beatZoomEnd = std::ceil(static_cast<float>(m_timeLine->loopEnd()) / TimePos::ticksPerBar());
+			break;
+		}
+		case ZoomAction::Selection:	{
+			sAction = "Selection";
+			QVector<selectableObject*> so = selectedObjects();
+
+			if (so.isEmpty())
+			{
+				m_zoomInfo = TextFloat::displayMessage(tr("Info"),
+													  tr("There is no selection active. \n"
+														  "Please, select some clips to apply zoom to selection."),
+													  embed::getIconPixmap("whatsthis"), 4000);
+				return;
+			}
+			else
+			{
+				TimePos posSelBegin = std::numeric_limits<int32_t>::max();
+				TimePos posSelEnd = 0;
+
+				for (const auto& selectedClip : so)
+				{
+					auto clipv = dynamic_cast<ClipView*>(selectedClip);
+					posSelBegin = std::min(posSelBegin, clipv->getClip()->startPosition());
+					posSelEnd = std::max(posSelEnd, clipv->getClip()->endPosition());
+				}
+				beatZoomBegin = posSelBegin.getBar();
+				beatZoomEnd = posSelEnd.nextFullBar();
+			}
+			break;
+		}
+		case ZoomAction::FullSong: {
+			sAction = "Full song";
+			beatZoomBegin = 0;
+			beatZoomEnd = m_song->length();
+			break;
+		}
+		default:
+			return;
+	}
+
+	// calculate the area for beats in SongEditor
+	float w = width() - m_trackHeadWidth;
+	// substract width of vertical scrollbar, if visible
+	if (contentWidget()->verticalScrollBar()->isVisible())
+	{
+		w -= contentWidget()->verticalScrollBar()->width();
+	}
+
+	int newPPB = static_cast<int>((w / (beatZoomEnd - beatZoomBegin)));
+
+	if (newPPB < MIN_PIXELS_PER_BAR)
+	{
+		m_zoomInfo = TextFloat::displayMessage(tr("Warning"),
+											   tr("%1 is bigger than visible Song-Editor area. \n"
+												  "You may need to increse the size of Song-Editor window.").arg(QString::fromStdString(sAction)),
+											   embed::getIconPixmap("whatsthis"), 4000);
+	}
+
+	newPPB = std::clamp(newPPB, MIN_PIXELS_PER_BAR, MAX_PIXELS_PER_BAR);
+	int newZoom = std::clamp(calculateZoomSliderValue(newPPB) - 1, 0, ZOOM_STEPS);
+	m_zoomingModel->setValue(newZoom);
+
+	// scroll to first beat of selection
+	scrolled(beatZoomBegin);
+	m_leftRightScroll->setValue(beatZoomBegin);
 }
 
 


### PR DESCRIPTION
Taking advantage of the new "continuous" zooming, add zoom actions with hotkeys for quick zooming options:

- Ctrl + L --> zoom to Loop: adjust the zoom value so the loop area "fills" all of the song-editor.
- Ctrl + T --> zoom to Selection: adjust the zoom value so the selection area "fills" all the song-editor. If there is no selection, an information message is shown to the user.
- Ctrl + F --> zoom to FullSong: adjust the zoom value to "fit" the full song in the song-editor.

Observations. 
- Because we have a maximum zoom value, sometimes it cannot be possible to fit all the loop/selection/full-song in the song-editor area. In that case an information message is shown to the user.
- In fact, we don't have "continuous" zooming values (but pixel related zooming), so "fill" or "fit" doesn't means "use all the space available" but using a zoom value that gets closer to use all the space available.
- Please, review the information messages to make them English native.