### PR TITLE
Fix LcdFloatSpinBox mouse behavior and negative values

### DIFF
--- a/include/LcdFloatSpinBox.h
+++ b/include/LcdFloatSpinBox.h
@@ -49,6 +49,12 @@ public:
 	}
 
 	void setLabel(const QString &label) { m_label = label; }
+	
+	void setSeamless(bool left, bool right)
+	{
+		m_wholeDisplay.setSeamless(left, true);
+		m_fractionDisplay.setSeamless(true, right);
+	}
 
 public slots:
 	virtual void update();

--- a/include/LcdWidget.h
+++ b/include/LcdWidget.h
@@ -49,8 +49,9 @@ public:
 
 	~LcdWidget() override;
 
-	void setValue( int value );
-	void setLabel( const QString& label );
+	void setValue(int value);
+	void setValue(float value);
+	void setLabel(const QString& label);
 
 	void addTextForValue( int value, const QString& text )
 	{

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -114,7 +114,7 @@ void LcdFloatSpinBox::update()
 	int fraction = std::abs(std::round((value - static_cast<int>(value)) * digitValue));
 	if (fraction == digitValue)
 	{
-		value += copysign(1, value);
+		value += std::copysign(1, value);
 		fraction = 0;
 	}
 	m_wholeDisplay.setValue(value);

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -109,12 +109,16 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 
 void LcdFloatSpinBox::update()
 {
-	const int whole = static_cast<int>(model()->value());
-	float fraction = std::abs(model()->value() - whole);
-	fraction += model()->step<float>() * 0.9f;// Fix roundoff errors
-	const int intFraction = fraction * std::pow(10.f, m_fractionDisplay.numDigits());
-	m_wholeDisplay.setValue(model()->value());
-	m_fractionDisplay.setValue(intFraction);
+	const int digitValue = std::pow(10.f, m_fractionDisplay.numDigits());
+	float value = model()->value();
+	int fraction = std::abs(std::round((value - static_cast<int>(value)) * digitValue));
+	if (fraction == digitValue)
+	{
+		value += copysign(1, value);
+		fraction = 0;
+	}
+	m_wholeDisplay.setValue(value);
+	m_fractionDisplay.setValue(fraction);
 
 	QWidget::update();
 }

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -110,9 +110,10 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 void LcdFloatSpinBox::update()
 {
 	const int whole = static_cast<int>(model()->value());
-	const float fraction = model()->value() - whole;
+	float fraction = std::abs(model()->value() - whole);
+	fraction += model()->step<float>() * 0.9f;// Fix roundoff errors
 	const int intFraction = fraction * std::pow(10.f, m_fractionDisplay.numDigits());
-	m_wholeDisplay.setValue(whole);
+	m_wholeDisplay.setValue(model()->value());
 	m_fractionDisplay.setValue(intFraction);
 
 	QWidget::update();
@@ -129,6 +130,10 @@ void LcdFloatSpinBox::contextMenuEvent(QContextMenuEvent* event)
 
 void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
 {
+	// switch between integer and fractional step based on cursor position
+	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
+	else { m_intStep = false; }
+
 	if (event->button() == Qt::LeftButton &&
 		!(event->modifiers() & Qt::ControlModifier) &&
 		event->y() < m_wholeDisplay.cellHeight() + 2)
@@ -152,10 +157,6 @@ void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
 
 void LcdFloatSpinBox::mouseMoveEvent(QMouseEvent* event)
 {
-	// switch between integer and fractional step based on cursor position
-	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
-	else { m_intStep = false; }
-
 	if (m_mouseMoving)
 	{
 		int dy = event->globalY() - m_origMousePos.y();

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -135,8 +135,7 @@ void LcdFloatSpinBox::contextMenuEvent(QContextMenuEvent* event)
 void LcdFloatSpinBox::mousePressEvent(QMouseEvent* event)
 {
 	// switch between integer and fractional step based on cursor position
-	if (event->x() < m_wholeDisplay.width()) { m_intStep = true; }
-	else { m_intStep = false; }
+	m_intStep = event->x() < m_wholeDisplay.width();
 
 	if (event->button() == Qt::LeftButton &&
 		!(event->modifiers() & Qt::ControlModifier) &&

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -94,6 +94,22 @@ void LcdWidget::setValue(int value)
 	update();
 }
 
+void LcdWidget::setValue(float value)
+{
+	if (value < 0 && value > -1)
+	{
+		QString s = QString::number(static_cast<int>(value));
+		s.prepend('-');
+		
+		m_display = s;
+		update();
+	}
+	else
+	{
+		setValue(static_cast<int>(value));
+	}
+}
+
 
 
 


### PR DESCRIPTION
This PR makes it so the whole and fractional parts are updated depending on which you click instead of the current position of your mouse.  It also fixes negative values, which don't work properly with the LcdFloatSpinBox without this PR.

Edit:  Forgot to mention it also makes `setSeamless` work properly as well.