### PR TITLE
Only add sound shaping tab for non-single streamed instruments

### DIFF
--- a/include/InstrumentSoundShapingView.h
+++ b/include/InstrumentSoundShapingView.h
@@ -30,7 +30,6 @@
 #include "InstrumentSoundShaping.h"
 #include "ModelView.h"
 
-class QLabel;
 
 namespace lmms::gui
 {
@@ -49,8 +48,6 @@ public:
 	InstrumentSoundShapingView( QWidget * _parent );
 	~InstrumentSoundShapingView() override;
 
-	void setFunctionsHidden( bool hidden );
-
 
 private:
 	void modelChanged() override;
@@ -65,10 +62,7 @@ private:
 	ComboBox * m_filterComboBox;
 	Knob * m_filterCutKnob;
 	Knob * m_filterResKnob;
-
-	QLabel* m_singleStreamInfoLabel;
-
-} ;
+};
 
 
 } // namespace lmms::gui

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -22,8 +22,6 @@
  *
  */
 
-#include <QLabel>
-
 #include "InstrumentSoundShapingView.h"
 #include "EnvelopeAndLfoParameters.h"
 #include "EnvelopeAndLfoView.h"
@@ -90,16 +88,6 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 	m_filterResKnob->setLabel( tr( "Q/RESO" ) );
 	m_filterResKnob->move( 196, 18 );
 	m_filterResKnob->setHintText( tr( "Q/Resonance:" ), "" );
-
-
-	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
-	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont( pointSize<8>( m_singleStreamInfoLabel->font() ) );
-
-	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
-						TARGETS_TABWIDGET_Y,
-						TARGETS_TABWIDGET_WIDTH,
-						TARGETS_TABWIDGET_HEIGTH );
 }
 
 
@@ -108,15 +96,6 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 InstrumentSoundShapingView::~InstrumentSoundShapingView()
 {
 	delete m_targetsTabWidget;
-}
-
-
-
-void InstrumentSoundShapingView::setFunctionsHidden( bool hidden )
-{
-	m_targetsTabWidget->setHidden( hidden );
-	m_filterGroupBox->setHidden( hidden );
-	m_singleStreamInfoLabel->setHidden( !hidden );
 }
 
 


### PR DESCRIPTION
Only add the sound shaping tab for instruments that are not single streamed. This removes the "Nothing to see here" message and makes the GUI more concise. Examples for single streamed instruments are VeSTige, OpulenZ and LB302.

![Screenshot_20231008_200939](https://github.com/LMMS/lmms/assets/9293269/c80a46a8-9117-4525-b754-0f56e6c1aaab)


Technical details
------------------
Remove all code related to showing the message "Envelopes, LFOs and filters are not supported by the current instrument." from `InstrumentSoundShapingView`.

Initialize `m_ssView` in `InstrumentTrackWindow` to `nullptr`. Only initialize it for instruments that are not single streamed. Add `nullptr` checks to all references. Use a variable to increment the index for calls to `addTab` because the addition of `m_ssView` now becomes conditional.