### PR TITLE
fixed invalid iterators in piano roll (again)

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2517,7 +2517,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
 			auto it = notes.rbegin();
-			for( int i = 0; i < notes.size(); ++i )
+			while (it != notes.rend())
 			{
 				Note* n = *it;
 


### PR DESCRIPTION
The crash which was supposed to be fixed by #6869 did not get fixed properly. It was fixed, till @DomClark left [this comment](https://github.com/LMMS/lmms/pull/6869#pullrequestreview-1630103174). He was right to use increment in that line, but neither he nor i thought of fixing the loop accordingly. This pr does that.

@superpaik wanna look?