### PR TITLE
Fix conditional jump on an uninitialized value

### DIFF
--- a/include/CPULoadWidget.h
+++ b/include/CPULoadWidget.h
@@ -68,7 +68,7 @@ private:
 
 	QTimer m_updateTimer;
 
-	int m_stepSize;
+	int m_stepSize = 1;
 
 } ;
 


### PR DESCRIPTION
Introduced in #5970 , `CPULoadWidget::m_stepSize` is uninitialized, leading to valgrind warnings:

```
==9429== Conditional jump or move depends on uninitialised value(s)
==9429==    at 0x3715A9: int const& std::max<int>(int const&, int const&) (stl_algobase.h:262)
==9429==    by 0x59E3BB: lmms::gui::CPULoadWidget::stepSize() const (CPULoadWidget.h:59)
==9429==    by 0x59DA2E: lmms::gui::CPULoadWidget::paintEvent(QPaintEvent*) (CPULoadWidget.cpp:78)
```

Even though `grep` shows:

```
data/themes/classic/style.css:  qproperty-stepSize: 4;
data/themes/default/style.css:  qproperty-stepSize: 1;
```

It seems like the issue is caused by paint events occurring even before the style sheet has been applied. In order to fix this, and to be future proof with style sheets which do not set it, we initialize `CPULoadWidget::m_stepSize` to `1`.