### PR TITLE
Lv2Proc: Delay setting worker iface (Fixes #6946)

### DIFF
--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -47,9 +47,10 @@ class Lv2Worker
 {
 public:
 	// CTOR/DTOR/feature access
-	Lv2Worker(const LV2_Worker_Interface* iface, Semaphore* common_work_lock, bool threaded);
+	Lv2Worker(Semaphore* common_work_lock, bool threaded);
 	~Lv2Worker();
-	void setHandle(LV2_Handle handle) { m_handle = handle; }
+	void setHandle(LV2_Handle handle);
+	void setIface(const LV2_Worker_Interface* iface);
 	LV2_Worker_Schedule* feature() { return &m_scheduleFeature; }
 
 	// public API

--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -50,7 +50,7 @@ public:
 	Lv2Worker(Semaphore* commonWorkLock, bool threaded);
 	~Lv2Worker();
 	void setHandle(LV2_Handle handle);
-	void setInterface(const LV2_Worker_Interface* new_interface);
+	void setInterface(const LV2_Worker_Interface* newInterface);
 	LV2_Worker_Schedule* feature() { return &m_scheduleFeature; }
 
 	// public API

--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -47,17 +47,17 @@ class Lv2Worker
 {
 public:
 	// CTOR/DTOR/feature access
-	Lv2Worker(Semaphore* common_work_lock, bool threaded);
+	Lv2Worker(Semaphore* commonWorkLock, bool threaded);
 	~Lv2Worker();
 	void setHandle(LV2_Handle handle);
-	void setInterface(const LV2_Worker_Interface* iface);
+	void setInterface(const LV2_Worker_Interface* interface);
 	LV2_Worker_Schedule* feature() { return &m_scheduleFeature; }
 
 	// public API
 	void emitResponses();
 	void notifyPluginThatRunFinished()
 	{
-		if(m_iface->end_run) { m_iface->end_run(m_scheduleFeature.handle); }
+		if(m_interface->end_run) { m_interface->end_run(m_scheduleFeature.handle); }
 	}
 
 	// to be called only by static functions
@@ -70,7 +70,7 @@ private:
 	std::size_t bufferSize() const;  //!< size of internal buffers
 
 	// parameters
-	const LV2_Worker_Interface* m_iface;
+	const LV2_Worker_Interface* m_interface;
 	bool m_threaded;
 	LV2_Handle m_handle;
 	LV2_Worker_Schedule m_scheduleFeature;

--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -50,7 +50,7 @@ public:
 	Lv2Worker(Semaphore* commonWorkLock, bool threaded);
 	~Lv2Worker();
 	void setHandle(LV2_Handle handle);
-	void setInterface(const LV2_Worker_Interface* interface);
+	void setInterface(const LV2_Worker_Interface* new_interface);
 	LV2_Worker_Schedule* feature() { return &m_scheduleFeature; }
 
 	// public API

--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -70,9 +70,9 @@ private:
 	std::size_t bufferSize() const;  //!< size of internal buffers
 
 	// parameters
-	const LV2_Worker_Interface* m_interface;
-	bool m_threaded;
-	LV2_Handle m_handle;
+	const bool m_threaded;
+	const LV2_Worker_Interface* m_interface = nullptr;
+	LV2_Handle m_handle = nullptr;
 	LV2_Worker_Schedule m_scheduleFeature;
 
 	// threading/synchronization

--- a/include/Lv2Worker.h
+++ b/include/Lv2Worker.h
@@ -50,7 +50,7 @@ public:
 	Lv2Worker(Semaphore* common_work_lock, bool threaded);
 	~Lv2Worker();
 	void setHandle(LV2_Handle handle);
-	void setIface(const LV2_Worker_Interface* iface);
+	void setInterface(const LV2_Worker_Interface* iface);
 	LV2_Worker_Schedule* feature() { return &m_scheduleFeature; }
 
 	// public API

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -444,7 +444,7 @@ void Lv2Proc::initPlugin()
 	{
 		const auto iface = static_cast<const LV2_Worker_Interface*>(
 			lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
-		if(iface) {
+		if (iface) {
 			m_worker->setHandle(lilv_instance_get_handle(m_instance));
 			m_worker->setInterface(iface);
 		}

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -536,8 +536,7 @@ void Lv2Proc::initPluginSpecificFeatures()
 		bool threaded = !Engine::audioEngine()->renderOnly();
 		m_worker.emplace(&m_workLock, threaded);
 		m_features[LV2_WORKER__schedule] = m_worker->feature();
-		// note: the worker interface can not be instantiated yet - it requires m_instance
-		//       see initPlugin()
+		// note: the worker interface can not be instantiated yet - it requires m_instance. see initPlugin()
 	}
 }
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -442,11 +442,16 @@ void Lv2Proc::initPlugin()
 
 	if (m_instance)
 	{
-		if(m_worker) {
+		const auto iface = static_cast<const LV2_Worker_Interface*>(
+			lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
+		if(iface) {
 			m_worker->setHandle(lilv_instance_get_handle(m_instance));
+			m_worker->setIface(iface);
 		}
 		for (std::size_t portNum = 0; portNum < m_ports.size(); ++portNum)
+		{
 			connectPort(portNum);
+		}
 		lilv_instance_activate(m_instance);
 	}
 	else
@@ -528,12 +533,11 @@ void Lv2Proc::initPluginSpecificFeatures()
 	// worker (if plugin has worker extension)
 	Lv2Manager* mgr = Engine::getLv2Manager();
 	if (lilv_plugin_has_extension_data(m_plugin, mgr->uri(LV2_WORKER__interface).get())) {
-		const auto iface = static_cast<const LV2_Worker_Interface*>(
-			lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
 		bool threaded = !Engine::audioEngine()->renderOnly();
-		m_worker.emplace(iface, &m_workLock, threaded);
+		m_worker.emplace(&m_workLock, threaded);
 		m_features[LV2_WORKER__schedule] = m_worker->feature();
-		// Note: m_worker::setHandle will still need to be called later
+		// note: the worker interface can not be instantiated yet - it requires m_instance
+		//       see initPlugin()
 	}
 }
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -446,7 +446,7 @@ void Lv2Proc::initPlugin()
 			lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
 		if(iface) {
 			m_worker->setHandle(lilv_instance_get_handle(m_instance));
-			m_worker->setIface(iface);
+			m_worker->setInterface(iface);
 		}
 		for (std::size_t portNum = 0; portNum < m_ports.size(); ++portNum)
 		{

--- a/src/core/lv2/Lv2Worker.cpp
+++ b/src/core/lv2/Lv2Worker.cpp
@@ -60,10 +60,8 @@ std::size_t Lv2Worker::bufferSize() const
 
 
 
-Lv2Worker::Lv2Worker(const LV2_Worker_Interface* iface,
-	Semaphore* common_work_lock,
+Lv2Worker::Lv2Worker(Semaphore* common_work_lock,
 	bool threaded) :
-	m_iface(iface),
 	m_threaded(threaded),
 	m_response(bufferSize()),
 	m_requests(bufferSize()),
@@ -73,7 +71,6 @@ Lv2Worker::Lv2Worker(const LV2_Worker_Interface* iface,
 	m_sem(0),
 	m_workLock(common_work_lock)
 {
-	assert(iface);
 	m_scheduleFeature.handle = static_cast<LV2_Worker_Schedule_Handle>(this);
 	m_scheduleFeature.schedule_work = [](LV2_Worker_Schedule_Handle handle,
 		uint32_t size, const void* data) -> LV2_Worker_Status
@@ -86,6 +83,20 @@ Lv2Worker::Lv2Worker(const LV2_Worker_Interface* iface,
 
 	m_requests.mlock();
 	m_responses.mlock();
+}
+
+
+
+
+void Lv2Worker::setHandle(LV2_Handle handle) { m_handle = handle; }
+
+
+
+
+void Lv2Worker::setIface(const LV2_Worker_Interface* iface)
+{
+	assert (iface);
+	m_iface = iface;
 }
 
 

--- a/src/core/lv2/Lv2Worker.cpp
+++ b/src/core/lv2/Lv2Worker.cpp
@@ -92,10 +92,10 @@ void Lv2Worker::setHandle(LV2_Handle handle) { m_handle = handle; }
 
 
 
-void Lv2Worker::setInterface(const LV2_Worker_Interface* new_interface)
+void Lv2Worker::setInterface(const LV2_Worker_Interface* newInterface)
 {
-	assert(new_interface);
-	m_interface = new_interface;
+	assert(newInterface);
+	m_interface = newInterface;
 }
 
 

--- a/src/core/lv2/Lv2Worker.cpp
+++ b/src/core/lv2/Lv2Worker.cpp
@@ -92,10 +92,10 @@ void Lv2Worker::setHandle(LV2_Handle handle) { m_handle = handle; }
 
 
 
-void Lv2Worker::setInterface(const LV2_Worker_Interface* interface)
+void Lv2Worker::setInterface(const LV2_Worker_Interface* new_interface)
 {
-	assert(interface);
-	m_interface = interface;
+	assert(new_interface);
+	m_interface = new_interface;
 }
 
 

--- a/src/core/lv2/Lv2Worker.cpp
+++ b/src/core/lv2/Lv2Worker.cpp
@@ -93,7 +93,7 @@ void Lv2Worker::setHandle(LV2_Handle handle) { m_handle = handle; }
 
 
 
-void Lv2Worker::setIface(const LV2_Worker_Interface* iface)
+void Lv2Worker::setInterface(const LV2_Worker_Interface* iface)
 {
 	assert(iface);
 	m_iface = iface;

--- a/src/core/lv2/Lv2Worker.cpp
+++ b/src/core/lv2/Lv2Worker.cpp
@@ -95,7 +95,7 @@ void Lv2Worker::setHandle(LV2_Handle handle) { m_handle = handle; }
 
 void Lv2Worker::setIface(const LV2_Worker_Interface* iface)
 {
-	assert (iface);
+	assert(iface);
 	m_iface = iface;
 }
 


### PR DESCRIPTION
This delays passing the `LV2_Worker_Interface` to the `Lv2Worker` class,
because prior to the patch, the instance, which provides the interface,
has not been initialized yet, which resulted in a segfault.