### PR TITLE
Fixes #6626: Throw if Lv2 object CTORs fail

### DIFF
--- a/include/Lv2ControlBase.h
+++ b/include/Lv2ControlBase.h
@@ -102,9 +102,6 @@ protected:
 
 	Lv2ControlBase& operator=(const Lv2ControlBase&) = delete;
 
-	//! Must be checked after ctor or reload
-	bool isValid() const { return m_valid; }
-
 	/*
 		overrides
 	*/
@@ -149,7 +146,6 @@ private:
 	//! fulfill LMMS' requirement of having stereo input and output
 	std::vector<std::unique_ptr<Lv2Proc>> m_procs;
 
-	bool m_valid = true;
 	bool m_hasGUI = false;
 	unsigned m_channelsPerProc;
 

--- a/include/Lv2Proc.h
+++ b/include/Lv2Proc.h
@@ -78,8 +78,6 @@ public:
 	~Lv2Proc() override;
 	void reload();
 	void onSampleRateChanged();
-	//! Must be checked after ctor or reload
-	bool isValid() const { return m_valid; }
 
 	/*
 		port access
@@ -173,8 +171,6 @@ protected:
 	void shutdownPlugin();
 
 private:
-	bool m_valid = true;
-
 	const LilvPlugin* m_plugin;
 	LilvInstance* m_instance = nullptr;
 	Lv2Features m_features;

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -110,14 +110,12 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Effect* eff;
 	try {
-		eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
+		return new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
 	} catch (const std::runtime_error& e) {
 		qCritical() << e.what();
-		eff = nullptr;
+		return nullptr;
 	}
-	return eff;
 }
 
 }

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -22,9 +22,9 @@
  *
  */
 
-#include <QDebug>
 #include "Lv2Effect.h"
 
+#include <QDebug>
 
 #include "Lv2SubPluginFeatures.h"
 

--- a/plugins/Lv2Effect/Lv2Effect.cpp
+++ b/plugins/Lv2Effect/Lv2Effect.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <QDebug>
 #include "Lv2Effect.h"
 
 
@@ -109,8 +110,13 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	auto eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
-	if (!eff->isValid()) { delete eff; eff = nullptr; }
+	Lv2Effect* eff;
+	try {
+		eff = new Lv2Effect(_parent, static_cast<const KeyType*>(_data));
+	} catch (const std::runtime_error& e) {
+		qCritical() << e.what();
+		eff = nullptr;
+	}
 	return eff;
 }
 

--- a/plugins/Lv2Effect/Lv2Effect.h
+++ b/plugins/Lv2Effect/Lv2Effect.h
@@ -41,8 +41,6 @@ public:
 		initialization
 	*/
 	Lv2Effect(Model* parent, const Descriptor::SubPluginFeatures::Key* _key);
-	//! Must be checked after ctor or reload
-	bool isValid() const { return m_controls.isValid(); }
 
 	bool processAudioBuffer( sampleFrame* buf, const fpp_t frames ) override;
 	EffectControls* controls() override { return &m_controls; }

--- a/plugins/Lv2Effect/Lv2FxControls.cpp
+++ b/plugins/Lv2Effect/Lv2FxControls.cpp
@@ -39,7 +39,7 @@ Lv2FxControls::Lv2FxControls(class Lv2Effect *effect, const QString& uri) :
 	Lv2ControlBase(this, uri)
 {
 	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
-		this, [this](){onSampleRateChanged();});
+		this, &Lv2FxControls::onSampleRateChanged);
 }
 
 

--- a/plugins/Lv2Effect/Lv2FxControls.cpp
+++ b/plugins/Lv2Effect/Lv2FxControls.cpp
@@ -38,11 +38,8 @@ Lv2FxControls::Lv2FxControls(class Lv2Effect *effect, const QString& uri) :
 	EffectControls(effect),
 	Lv2ControlBase(this, uri)
 {
-	if (isValid())
-	{
-		connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
-			this, [this](){onSampleRateChanged();});
-	}
+	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
+		this, [this](){onSampleRateChanged();});
 }
 
 

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -76,19 +76,16 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 	Instrument(instrumentTrackArg, &lv2instrument_plugin_descriptor, key),
 	Lv2ControlBase(this, key->attributes["uri"])
 {
-	if (Lv2ControlBase::isValid())
-	{
-		clearRunningNotes();
+	clearRunningNotes();
 
-		connect(instrumentTrack()->pitchRangeModel(), SIGNAL(dataChanged()),
-			this, SLOT(updatePitchRange()), Qt::DirectConnection);
-		connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
-			this, [this](){onSampleRateChanged();});
+	connect(instrumentTrack()->pitchRangeModel(), SIGNAL(dataChanged()),
+		this, SLOT(updatePitchRange()), Qt::DirectConnection);
+	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
+		this, [this](){onSampleRateChanged();});
 
-		// now we need a play-handle which cares for calling play()
-		auto iph = new InstrumentPlayHandle(this, instrumentTrackArg);
-		Engine::audioEngine()->addPlayHandle(iph);
-	}
+	// now we need a play-handle which cares for calling play()
+	auto iph = new InstrumentPlayHandle(this, instrumentTrackArg);
+	Engine::audioEngine()->addPlayHandle(iph);
 }
 
 
@@ -130,11 +127,6 @@ void Lv2Instrument::onSampleRateChanged()
 	//       through it instead of reloading
 	reload();
 }
-
-
-
-
-bool Lv2Instrument::isValid() const { return Lv2ControlBase::isValid(); }
 
 
 
@@ -321,8 +313,13 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	auto ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
-	if (!ins->isValid()) { delete ins; ins = nullptr; }
+	Lv2Instrument *ins;
+	try {
+		ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
+	} catch (const std::runtime_error& e) {
+		qCritical() << e.what();
+		ins = nullptr;
+	}
 	return ins;
 }
 

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -81,7 +81,7 @@ Lv2Instrument::Lv2Instrument(InstrumentTrack *instrumentTrackArg,
 	connect(instrumentTrack()->pitchRangeModel(), SIGNAL(dataChanged()),
 		this, SLOT(updatePitchRange()), Qt::DirectConnection);
 	connect(Engine::audioEngine(), &AudioEngine::sampleRateChanged,
-		this, [this](){onSampleRateChanged();});
+		this, &Lv2Instrument::onSampleRateChanged);
 
 	// now we need a play-handle which cares for calling play()
 	auto iph = new InstrumentPlayHandle(this, instrumentTrackArg);

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -313,14 +313,12 @@ extern "C"
 PLUGIN_EXPORT Plugin *lmms_plugin_main(Model *_parent, void *_data)
 {
 	using KeyType = Plugin::Descriptor::SubPluginFeatures::Key;
-	Lv2Instrument *ins;
 	try {
-		ins = new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
+		return new Lv2Instrument(static_cast<InstrumentTrack*>(_parent), static_cast<KeyType*>(_data));
 	} catch (const std::runtime_error& e) {
 		qCritical() << e.what();
-		ins = nullptr;
+		return nullptr;
 	}
-	return ins;
 }
 
 }

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -61,8 +61,6 @@ public:
 	~Lv2Instrument() override;
 	void reload();
 	void onSampleRateChanged();
-	//! Must be checked after ctor or reload
-	bool isValid() const;
 
 	/*
 		load/save

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -59,7 +59,7 @@ Lv2ControlBase::Lv2ControlBase(Model* that, const QString &uri) :
 	else
 	{
 		qCritical() << "No Lv2 plugin found for URI" << uri;
-		m_valid = false;
+		throw std::runtime_error("No Lv2 plugin found for given URI");
 	}
 }
 
@@ -77,26 +77,14 @@ void Lv2ControlBase::init(Model* meAsModel)
 	while (channelsLeft > 0)
 	{
 		std::unique_ptr<Lv2Proc> newOne = std::make_unique<Lv2Proc>(m_plugin, meAsModel);
-		if (newOne->isValid())
-		{
-			channelsLeft -= std::max(
-				1 + static_cast<bool>(newOne->inPorts().m_right),
-				1 + static_cast<bool>(newOne->outPorts().m_right));
-			Q_ASSERT(channelsLeft >= 0);
-			m_procs.push_back(std::move(newOne));
-		}
-		else
-		{
-			qCritical() << "Failed instantiating LV2 processor";
-			m_valid = false;
-			channelsLeft = 0;
-		}
+		channelsLeft -= std::max(
+			1 + static_cast<bool>(newOne->inPorts().m_right),
+			1 + static_cast<bool>(newOne->outPorts().m_right));
+		Q_ASSERT(channelsLeft >= 0);
+		m_procs.push_back(std::move(newOne));
 	}
-	if (m_valid)
-	{
-		m_channelsPerProc = DEFAULT_CHANNELS / m_procs.size();
-		linkAllModels();
-	}
+	m_channelsPerProc = DEFAULT_CHANNELS / m_procs.size();
+	linkAllModels();
 }
 
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -481,7 +481,7 @@ void Lv2Proc::shutdownPlugin()
 	m_instance = nullptr;
 
 	m_features.clear();
-		m_options.clear();
+	m_options.clear();
 }
 
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -467,7 +467,7 @@ void Lv2Proc::initPlugin()
 			<< "(URI:"
 			<< lilv_node_as_uri(lilv_plugin_get_uri(m_plugin))
 			<< ")";
-		m_valid = false;
+		throw std::runtime_error("Failed to create Lv2 processor");
 	}
 }
 
@@ -476,16 +476,12 @@ void Lv2Proc::initPlugin()
 
 void Lv2Proc::shutdownPlugin()
 {
-	if (m_valid)
-	{
-		lilv_instance_deactivate(m_instance);
-		lilv_instance_free(m_instance);
-		m_instance = nullptr;
+	lilv_instance_deactivate(m_instance);
+	lilv_instance_free(m_instance);
+	m_instance = nullptr;
 
-		m_features.clear();
+	m_features.clear();
 		m_options.clear();
-	}
-	m_valid = true;
 }
 
 


### PR DESCRIPTION
I still have open questions here, as written on discord:

1. Which types of exceptions do we really want to catch? E.g. should an `std::logic_error` be ignored and cause LMMS to terminate? Should we create a new `lmms::plugin_error` class to decide what exactly we want to catch? Or should we just catch everything? I would rather say the last, because users will want to avoid LMMS crashes, no matter what kind of plugin error?
2. Many people argue to not use std::string when throwing. Should we follow this? If yes, should a throw be accompanied by a `qCritical()` (or similar) if a verbose message is needed? (it is needed in a lot of cases). Or should we create a class which contains multiple arguments (`void*` or template parameters), that we concatenate when catching that class?

In this PR I solved it like this:

1. Simply catch all kinds of exception. No exception from any plugin code is worth crashing LMMS.
2. I avoided creating `std::string`, but this leads to redundant `qCritical()` calls. It might be a cleaner approach to throw an exception which keeps its arguments in an `std::tuple`, which we pass to `qCritical()` at `catch` time.

Feel free to suggest changes.

Fixes #6626