### PR TITLE
Fix CLI render crash

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -727,7 +727,8 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 	// Handle automation: detuning
 	for (const auto& processHandle : m_processHandles)
 	{
-		processHandle->processTimePos(_start, m_pitchModel.value(), gui::GuiApplication::instance()->pianoRoll()->isRecording());
+		processHandle->processTimePos(
+			_start, m_pitchModel.value(), gui::getGUI() && gui::getGUI()->pianoRoll()->isRecording());
 	}
 
 	if ( clips.size() == 0 )


### PR DESCRIPTION
Fixes an unchecked access to GUI leading to a segfault when rendering using the CLI as reported in  #6942, a regression from 005ee47d439f0ccf023de4c73f552f8c5119ec63 / #6297.
