### PR TITLE
SubWindow: Increase to respect child's sizeHint

### DIFF
--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -68,6 +68,8 @@ public:
 	void setActiveColor( const QBrush & b );
 	void setTextShadowColor( const QColor &c );
 	void setBorderColor( const QColor &c );
+	int titleBarHeight() const;
+	int frameWidth() const;
 
 protected:
 	// hook the QWidget move/resize events to update the tracked geometry

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -580,8 +580,8 @@ SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
 	if (w && w->sizeHint().isValid()) {
-		std::size_t titleBarHeight = win->titleBarHeight();
-		std::size_t frameWidth = win->frameWidth();
+		int titleBarHeight = win->titleBarHeight();
+		int frameWidth = win->frameWidth();
 		QSize delta(2* frameWidth, titleBarHeight + frameWidth);
 		win->resize(delta + w->sizeHint());
 	}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -570,13 +570,21 @@ void MainWindow::addSpacingToToolBar( int _size )
 								7, _size );
 }
 
+
+
+
 SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags)
 {
 	// wrap the widget in our own *custom* window that patches some errors in QMdiSubWindow
 	auto win = new SubWindow(m_workspace->viewport(), windowFlags);
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
-	if (w && w->sizeHint().isValid()) {win->resize(w->sizeHint());}
+	if (w && w->sizeHint().isValid()) {
+		std::size_t titleBarHeight = win->titleBarHeight();
+		std::size_t frameWidth = win->frameWidth();
+		QSize delta(2* frameWidth, titleBarHeight + frameWidth);
+		win->resize(delta + w->sizeHint());
+	}
 	m_workspace->addSubWindow(win);
 	return win;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -580,8 +580,8 @@ SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags
 	win->setAttribute(Qt::WA_DeleteOnClose);
 	win->setWidget(w);
 	if (w && w->sizeHint().isValid()) {
-		int titleBarHeight = win->titleBarHeight();
-		int frameWidth = win->frameWidth();
+		auto titleBarHeight = win->titleBarHeight();
+		auto frameWidth = win->frameWidth();
 		QSize delta(2* frameWidth, titleBarHeight + frameWidth);
 		win->resize(delta + w->sizeHint());
 	}

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -34,6 +34,7 @@
 #include <QMoveEvent>
 #include <QPainter>
 #include <QPushButton>
+#include <QStyleOption>
 
 #include "embed.h"
 
@@ -41,11 +42,11 @@ namespace lmms::gui
 {
 
 
-SubWindow::SubWindow( QWidget *parent, Qt::WindowFlags windowFlags ) :
-	QMdiSubWindow( parent, windowFlags ),
-	m_buttonSize( 17, 17 ),
-	m_titleBarHeight( 24 ),
-	m_hasFocus( false )
+SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
+	QMdiSubWindow(parent, windowFlags),
+	m_buttonSize(17, 17),
+	m_titleBarHeight(titleBarHeight()),
+	m_hasFocus(false)
 {
 	// initialize the tracked geometry to whatever Qt thinks the normal geometry currently is.
 	// this should always work, since QMdiSubWindows will not start as maximized
@@ -237,6 +238,27 @@ void SubWindow::setBorderColor( const QColor &c )
 {
 	m_borderColor = c;
 }
+
+
+
+
+int SubWindow::titleBarHeight() const
+{
+	QStyleOptionTitleBar so;
+	so.titleBarState = Qt::WindowActive; // kThemeStateActiv
+	so.titleBarFlags = Qt::Window;
+	return style()->pixelMetric(QStyle::PM_TitleBarHeight, &so, this);
+}
+
+
+
+
+int SubWindow::frameWidth() const
+{
+	QStyleOptionFrame so;
+	return style()->pixelMetric(QStyle::PM_MdiSubWindowFrameWidth, &so, this);
+}
+
 
 
 


### PR DESCRIPTION
Before this commit, on creation, `SubWindow` gets resized to exactly the children's `sizeHint`. This makes the child too small, since the `SubWindow` already contains a title bar and borders.

With this commit, the `SubWindow` is calculated such that after rendering, the child window gets exactly the `size` that its `sizeHint` has previously suggested.

Most of LMMS widgets are not resizable, but the Lv2 help window is a good example to test this out. The help windows now in most cases contain enough space to fit the help text. In some cases, it still does not fit, though debug prints show that the `size` matches the `sizeHint`.