### PR TITLE
Fix Lv2 help window related issues (#6753)

### DIFF
--- a/include/Lv2ViewBase.h
+++ b/include/Lv2ViewBase.h
@@ -95,6 +95,7 @@ protected:
 
 	void toggleUI();
 	void toggleHelp(bool visible);
+	void closeHelpWindow();
 
 	// to be called by child virtuals
 	//! Reconnect models if model changed

--- a/include/Lv2ViewBase.h
+++ b/include/Lv2ViewBase.h
@@ -71,7 +71,7 @@ class HelpWindowEventFilter : public QObject
 	Q_OBJECT
 	class Lv2ViewBase* const m_viewBase;
 protected:
-	bool eventFilter(QObject *obj, QEvent *event) override;
+	bool eventFilter(QObject* obj, QEvent* event) override;
 public:
 	HelpWindowEventFilter(class Lv2ViewBase* viewBase);
 };

--- a/include/Lv2ViewBase.h
+++ b/include/Lv2ViewBase.h
@@ -37,7 +37,7 @@
 
 class QPushButton;
 class QMdiSubWindow;
-
+class QLabel;
 namespace lmms
 {
 
@@ -64,9 +64,25 @@ private:
 };
 
 
+
+
+class HelpWindowEventFilter : public QObject
+{
+	Q_OBJECT
+	class Lv2ViewBase* const m_viewBase;
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+public:
+	HelpWindowEventFilter(class Lv2ViewBase* viewBase);
+};
+
+
+
+
 //! Base class for view for one Lv2 plugin
 class LMMS_EXPORT Lv2ViewBase : public LinkedModelGroupsView
 {
+	friend class HelpWindowEventFilter;
 protected:
 	//! @param pluginWidget A child class which inherits QWidget
 	Lv2ViewBase(class QWidget *pluginWidget, Lv2ControlBase *ctrlBase);
@@ -94,12 +110,14 @@ private:
 
 	static AutoLilvNode uri(const char *uriStr);
 	LinkedModelGroupView* getGroupView() override { return m_procView; }
+	void onHelpWindowClosed();
 
 	Lv2ViewProc* m_procView;
 
 	//! Numbers of controls per row; must be multiple of 2 for mono effects
 	const int m_colNum = 6;
 	QMdiSubWindow* m_helpWindow = nullptr;
+	HelpWindowEventFilter m_helpWindowEventFilter;
 };
 
 

--- a/plugins/Lv2Effect/Lv2FxControlDialog.cpp
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.cpp
@@ -72,4 +72,13 @@ void Lv2FxControlDialog::modelChanged()
 }
 
 
+
+
+void Lv2FxControlDialog::hideEvent(QHideEvent *event)
+{
+	closeHelpWindow();
+	QWidget::hideEvent(event);
+}
+
+
 } // namespace lmms::gui

--- a/plugins/Lv2Effect/Lv2FxControlDialog.h
+++ b/plugins/Lv2Effect/Lv2FxControlDialog.h
@@ -46,6 +46,7 @@ public:
 private:
 	Lv2FxControls *lv2Controls();
 	void modelChanged() final;
+	void hideEvent(QHideEvent *event) override;
 };
 
 

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -295,6 +295,15 @@ void Lv2InsView::dropEvent(QDropEvent *_de)
 
 
 
+void Lv2InsView::hideEvent(QHideEvent *event)
+{
+	closeHelpWindow();
+	QWidget::hideEvent(event);
+}
+
+
+
+
 void Lv2InsView::modelChanged()
 {
 	Lv2ViewBase::modelChanged(castModel<Lv2Instrument>());

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -124,6 +124,7 @@ public:
 protected:
 	void dragEnterEvent(QDragEnterEvent *_dee) override;
 	void dropEvent(QDropEvent *_de) override;
+	void hideEvent(QHideEvent* event) override;
 
 private:
 	void modelChanged() override;

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -137,7 +137,8 @@ AutoLilvNode Lv2ViewProc::uri(const char *uriStr)
 
 
 
-Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
+Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
+	m_helpWindowEventFilter(this)
 {
 	auto grid = new QGridLayout(meAsWidget);
 
@@ -181,8 +182,9 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 		btnBox->addWidget(m_helpButton);
 
 		m_helpWindow = getGUI()->mainWindow()->addWindowedWidget(infoLabel);
-		m_helpWindow->setSizePolicy(QSizePolicy::Minimum,
+		m_helpWindow->setSizePolicy(QSizePolicy::Expanding,
 									QSizePolicy::Expanding);
+		m_helpWindow->installEventFilter(&m_helpWindowEventFilter);
 		m_helpWindow->setAttribute(Qt::WA_DeleteOnClose, false);
 		m_helpWindow->hide();
 
@@ -203,6 +205,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase)
 
 
 Lv2ViewBase::~Lv2ViewBase() {
+	m_helpWindow->close();
 	// TODO: hide UI if required
 }
 
@@ -245,6 +248,32 @@ void Lv2ViewBase::modelChanged(Lv2ControlBase *ctrlBase)
 AutoLilvNode Lv2ViewBase::uri(const char *uriStr)
 {
 	return Engine::getLv2Manager()->uri(uriStr);
+}
+
+
+
+
+void Lv2ViewBase::onHelpWindowClosed()
+{
+	m_helpButton->setChecked(true);
+}
+
+
+
+
+HelpWindowEventFilter::HelpWindowEventFilter(Lv2ViewBase* viewBase) :
+	m_viewBase(viewBase) {}
+
+
+
+
+bool HelpWindowEventFilter::eventFilter(QObject *obj, QEvent *event)
+{
+	if (event->type() == QEvent::Close) {
+		m_viewBase->m_helpButton->setChecked(false);
+		return true;
+	}
+	return false;
 }
 
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -205,7 +205,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 
 
 Lv2ViewBase::~Lv2ViewBase() {
-	m_helpWindow->close();
+	if(m_helpWindow) { m_helpWindow->close(); }
 	// TODO: hide UI if required
 }
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -267,7 +267,7 @@ HelpWindowEventFilter::HelpWindowEventFilter(Lv2ViewBase* viewBase) :
 
 
 
-bool HelpWindowEventFilter::eventFilter(QObject *obj, QEvent *event)
+bool HelpWindowEventFilter::eventFilter(QObject* , QEvent* event)
 {
 	if (event->type() == QEvent::Close) {
 		m_viewBase->m_helpButton->setChecked(false);

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -173,7 +173,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 	LILV_FOREACH(nodes, itr, props.get())
 	{
 		const LilvNode* node = lilv_nodes_get(props.get(), itr);
-		auto infoLabel = new QLabel(lilv_node_as_string(node));
+		auto infoLabel = new QLabel(QString(lilv_node_as_string(node)).trimmed());
 		infoLabel->setWordWrap(true);
 		infoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -205,7 +205,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 
 
 Lv2ViewBase::~Lv2ViewBase() {
-	if(m_helpWindow) { m_helpWindow->close(); }
+	closeHelpWindow();
 	// TODO: hide UI if required
 }
 
@@ -226,6 +226,14 @@ void Lv2ViewBase::toggleHelp(bool visible)
 		if (visible) { m_helpWindow->show(); m_helpWindow->raise(); }
 		else { m_helpWindow->hide(); }
 	}
+}
+
+
+
+
+void Lv2ViewBase::closeHelpWindow()
+{
+	if (m_helpWindow) { m_helpWindow->close(); }
 }
 
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -173,7 +173,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 	LILV_FOREACH(nodes, itr, props.get())
 	{
 		const LilvNode* node = lilv_nodes_get(props.get(), itr);
-		auto infoLabel = new QLabel(QString(lilv_node_as_string(node)).trimmed());
+		auto infoLabel = new QLabel(QString(lilv_node_as_string(node)).trimmed() + "\n");
 		infoLabel->setWordWrap(true);
 		infoLabel->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
 


### PR DESCRIPTION
This fixes at least 3 issues:

* Help window is not synched with window manager's `X`-button
* Help window is not being closed on track destruction or on closing the plugin window
* Trims help window strings and force-adds a newline, because `QLabel::sizeHint` sometimes computes too small values. Now, together with #6956, all help windows fit their strings. Some help windows are too large by one line, but I think this is better than forcing the user to resize them if they are too small by one line.

Fixes #6753