### PR TITLE
fixed AudioFileProcessor reverse bug

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -1164,33 +1164,15 @@ void AudioFileProcessorWaveView::slideSampleByFrames( f_cnt_t _frames )
 	// to avoid them clamping each other
 	if (v < 0)
 	{
-		if (m_startKnob)
-		{
-			m_startKnob->slideBy(v, false);
-		}
-		if (m_loopKnob)
-		{
-			m_loopKnob->slideBy(v, false);
-		}
-		if (m_endKnob)
-		{
-			m_endKnob->slideBy(v, false);
-		}
+		m_startKnob->slideBy(v, false);
+		m_loopKnob->slideBy(v, false);
+		m_endKnob->slideBy(v, false);
 	}
 	else
 	{
-		if (m_endKnob)
-		{
-			m_endKnob->slideBy(v, false);
-		}
-		if (m_loopKnob)
-		{
-			m_loopKnob->slideBy(v, false);
-		}
-		if (m_startKnob)
-		{
-			m_startKnob->slideBy(v, false);
-		}
+		m_endKnob->slideBy(v, false);
+		m_loopKnob->slideBy(v, false);
+		m_startKnob->slideBy(v, false);
 	}
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -1160,8 +1160,8 @@ void AudioFileProcessorWaveView::slideSampleByFrames( f_cnt_t _frames )
 		return;
 	}
 	const double v = static_cast<double>( _frames ) / m_sampleBuffer.frames();
-	//update knobs in the right order
-	//to avoid them clamping each other
+	// update knobs in the right order
+	// to avoid them clamping each other
 	if (v < 0)
 	{
 		if (m_startKnob)

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -1160,14 +1160,25 @@ void AudioFileProcessorWaveView::slideSampleByFrames( f_cnt_t _frames )
 		return;
 	}
 	const double v = static_cast<double>( _frames ) / m_sampleBuffer.frames();
+	//update knobs in the right order
+	//to avoid them clamping each other
+	bool updateBefore = false;
+	if (m_loopKnob && m_startKnob && m_endKnob &&
+			(m_loopKnob->model()->value() < m_startKnob->model()->value() + v ||
+			m_loopKnob->model()->value() > m_endKnob->model()->value() + v))
+	{
+		updateBefore = true;
+		m_loopKnob->slideBy(v, false);
+	}
 	if( m_startKnob ) {
 		m_startKnob->slideBy( v, false );
 	}
 	if( m_endKnob ) {
 		m_endKnob->slideBy( v, false );
 	}
-	if( m_loopKnob ) {
-		m_loopKnob->slideBy( v, false );
+	if (m_loopKnob && updateBefore==false)
+	{
+		m_loopKnob->slideBy(v, false);
 	}
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -1162,23 +1162,35 @@ void AudioFileProcessorWaveView::slideSampleByFrames( f_cnt_t _frames )
 	const double v = static_cast<double>( _frames ) / m_sampleBuffer.frames();
 	//update knobs in the right order
 	//to avoid them clamping each other
-	bool updateBefore = false;
-	if (m_loopKnob && m_startKnob && m_endKnob &&
-			(m_loopKnob->model()->value() < m_startKnob->model()->value() + v ||
-			m_loopKnob->model()->value() > m_endKnob->model()->value() + v))
+	if (v < 0)
 	{
-		updateBefore = true;
-		m_loopKnob->slideBy(v, false);
+		if (m_startKnob)
+		{
+			m_startKnob->slideBy(v, false);
+		}
+		if (m_loopKnob)
+		{
+			m_loopKnob->slideBy(v, false);
+		}
+		if (m_endKnob)
+		{
+			m_endKnob->slideBy(v, false);
+		}
 	}
-	if( m_startKnob ) {
-		m_startKnob->slideBy( v, false );
-	}
-	if( m_endKnob ) {
-		m_endKnob->slideBy( v, false );
-	}
-	if (m_loopKnob && updateBefore==false)
+	else
 	{
-		m_loopKnob->slideBy(v, false);
+		if (m_endKnob)
+		{
+			m_endKnob->slideBy(v, false);
+		}
+		if (m_loopKnob)
+		{
+			m_loopKnob->slideBy(v, false);
+		}
+		if (m_startKnob)
+		{
+			m_startKnob->slideBy(v, false);
+		}
 	}
 }
 


### PR DESCRIPTION
#6708 fixed

The loop knob will not move randomly when the sample is reversed even when the loop knob is at the end.
The problem was caused by the start knob clamping the loop knob's value because it was moved earlier.