### PR TITLE
Use macOS 12 for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,8 @@ jobs:
         run: |
           brew bundle install --verbose
           # Update npm's built-in node-gyp to work with preinstalled Python 3.12
-          # TODO: Remove this once runner's npm version is at least 10.2.2
-          npm explore npm/node_modules/@npmcli/run-script -g -- \
+          # TODO: Remove this line once runner's npm version is at least 10.2.2
+          sudo npm explore npm/node_modules/@npmcli/run-script -g -- \
             npm_config_global=false npm install node-gyp@latest
           npm install --location=global appdmg
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           CCACHE_MAXSIZE: 500M
   macos:
     name: macos
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
@@ -78,7 +78,7 @@ jobs:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j3
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,10 @@ jobs:
       - name: Install dependencies
         run: |
           brew bundle install --verbose
+          # Update npm's built-in node-gyp to work with preinstalled Python 3.12
+          # TODO: Remove this once runner's npm version is at least 10.2.2
+          npm explore npm/node_modules/@npmcli/run-script -g -- \
+            npm_config_global=false npm install node-gyp@latest
           npm install --location=global appdmg
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,9 +106,11 @@ jobs:
         run: |
           brew bundle install --verbose
           # Update npm's built-in node-gyp to work with preinstalled Python 3.12
-          # TODO: Remove this line once runner's npm version is at least 10.2.2
+          # TODO: Remove this once runner's npm version is at least 10.2.2
           sudo npm explore npm/node_modules/@npmcli/run-script -g -- \
             npm_config_global=false npm install node-gyp@latest
+          # Fix npm cache ownership after running previous command as root
+          sudo chown -R 501:20 "/Users/runner/.npm"
           npm install --location=global appdmg
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
See title. Homebrew has dropped bottle support for macOS 11, and we really don't want to build dependencies, especially Qt, ourselves.