### PR TITLE
Run CI build on macOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j3
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
     steps:
       - name: Check out
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           CCACHE_MAXSIZE: 500M
   macos:
     name: macos
-    runs-on: macos-11
+    runs-on: macos-12
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
@@ -78,7 +78,6 @@ jobs:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j3
-      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
     steps:
       - name: Check out
         uses: actions/checkout@v3
@@ -105,6 +104,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew bundle install --verbose
+          npm update -g npm
           npm install --location=global appdmg
         env:
           HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Update the build workflow to use macOS 12 to fix slow CI times because Homebrew doesn't provide bottles for macOS 11 anymore. Sorry @DomClark, I only saw your PR #6959 after doing these changes myself. Not sure why yours is failing, but this patch worked in [my test](https://github.com/lukas-w/lmms/actions/runs/6755756967/job/18364498590) and just upgrading `npm` is a simpler workaround I guess.
