### PR TITLE
Improve search performance in `FileBrowser`

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -274,6 +274,7 @@ public:
 
 	QString extension();
 	static QString extension( const QString & file );
+	static QString defaultFilters();
 
 
 private:

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -28,7 +28,6 @@
 #include <QCheckBox>
 #include <QDir>
 #include <QMutex>
-#include <queue>
 
 #ifdef __MINGW32__
 #include <mingw.condition_variable.h>

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -203,6 +203,8 @@ public:
 	void search(SearchTask task);
 	void cancel();
 
+	bool inHiddenDirectory(const QString& path);
+
 	static FileBrowserSearcher* instance();
 
 signals:

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -84,6 +84,8 @@ public:
 
 	~FileBrowser() override = default;
 
+	static QDir::Filters dirFilters();
+
 private slots:
 	void reloadTree();
 	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -221,7 +221,7 @@ private:
 	std::atomic<bool> m_cancel = false;
 	bool m_stopped = false;
 	bool m_run = false;
-	static std::unique_ptr<FileBrowserSearcher> s_instance;
+	inline static std::unique_ptr<FileBrowserSearcher> s_instance = nullptr;
 };
 
 

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -28,6 +28,18 @@
 #include <QCheckBox>
 #include <QDir>
 #include <QMutex>
+#include <queue>
+
+#ifdef __MINGW32__
+#include <mingw.condition_variable.h>
+#include <mingw.mutex.h>
+#include <mingw.thread.h>
+#else
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#endif
+
 #if (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 	#include <QRecursiveMutex>
 #endif
@@ -86,7 +98,12 @@ private:
 	void saveDirectoriesStates();
 	void restoreDirectoriesStates();
 
+	void buildSearchTree(QStringList matches, QString id);
+	void onSearch(const QString& filter);
+	void toggleSearch(bool on);
+
 	FileBrowserTreeWidget * m_fileBrowserTreeWidget;
+	FileBrowserTreeWidget * m_searchTreeWidget;
 
 	QLineEdit * m_filterEdit;
 
@@ -164,6 +181,44 @@ private slots:
 	void openContainingFolder( lmms::gui::FileItem* item );
 
 } ;
+
+class FileBrowserSearcher : public QObject
+{
+	Q_OBJECT
+public:
+	struct SearchTask
+	{
+		QString directories;
+		QString userFilter;
+		QDir::Filters dirFilters;
+		QStringList nameFilters;
+		QString id;
+	};
+
+	FileBrowserSearcher();
+	~FileBrowserSearcher() noexcept override;
+
+	void search(SearchTask task);
+	void cancel();
+
+	static FileBrowserSearcher* instance();
+
+signals:
+	void searchComplete(QStringList matches, QString id);
+
+private:
+	void run();
+	void filter();
+	SearchTask m_currentTask;
+	std::thread m_worker;
+	std::mutex m_runMutex;
+	std::mutex m_cancelMutex;
+	std::condition_variable m_runCond;
+	std::atomic<bool> m_cancel = false;
+	bool m_stopped = false;
+	bool m_run = false;
+	static std::unique_ptr<FileBrowserSearcher> s_instance;
+};
 
 
 

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1109,7 +1109,7 @@ void FileBrowserSearcher::filter()
 			it.next();
 			const auto name = it.fileName();
 			const auto path = it.filePath();
-			if (name.contains(userFilter, Qt::CaseInsensitive)) { matches.push_back(path); }
+			if (!inHiddenDirectory(path) && name.contains(userFilter, Qt::CaseInsensitive)) { matches.push_back(path); }
 			if (m_cancel) { return; }
 		}
 	}
@@ -1123,7 +1123,17 @@ FileBrowserSearcher* FileBrowserSearcher::instance()
 	return s_instance.get();
 }
 
-
+bool FileBrowserSearcher::inHiddenDirectory(const QString& path)
+{
+	auto dir = QDir{path};
+	while (!dir.isRoot())
+	{
+		auto info = QFileInfo{dir.path()};
+		if (info.isHidden()) { return true; }
+		dir.cdUp();
+	}
+	return false;
+}
 
 
 QPixmap * Directory::s_folderPixmap = nullptr;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -158,6 +158,11 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	show();
 }
 
+QDir::Filters FileBrowser::dirFilters()
+{
+	return QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot;
+}
+
 void FileBrowser::saveDirectoriesStates()
 {	
 	m_savedExpandedDirs = m_fileBrowserTreeWidget->expandedDirs();
@@ -231,8 +236,7 @@ void FileBrowser::onSearch(const QString& filter)
 		instance->cancel();
 		return;
 	}
-	instance->search(
-		{m_directories, filter, QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot, m_filter.split(' '), title()});
+	instance->search({m_directories, filter, dirFilters(), m_filter.split(' '), title()});
 }
 
 void FileBrowser::toggleSearch(bool on)
@@ -419,9 +423,7 @@ void FileBrowser::addItems(const QString & path )
 	QDir cdir(path);
 	if (!cdir.isReadable()) { return; }
 	QFileInfoList entries = cdir.entryInfoList(
-			m_filter.split(' '),
-			QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot,
-			QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
+		m_filter.split(' '), dirFilters(), QDir::LocaleAware | QDir::DirsFirst | QDir::Name | QDir::IgnoreCase);
 	for (const auto& entry : entries)
 	{
 		QString fileName = entry.fileName();

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1275,5 +1275,18 @@ QString FileItem::extension(const QString & file )
 	return QFileInfo( file ).suffix().toLower();
 }
 
+QString FileItem::defaultFilters()
+{
+	// TODO: Supported extensions should be in a centralized location
+	auto simpleExtensions
+		= QString{"*.mmp *.mpt *.mmpz *.xpf *.xml *.xiz *.sf2 *.sf3 *.pat *.mid *.midi *.rmi *.dll *.lv2"};
+#ifdef LMMS_BUILD_LINUX
+	simpleExtensions += " *.so";
+#endif
+	auto audioExtensions = QString{"*.wav *.ogg *.ds *.flac *.spx *.voc *.aif *.aiff *.au *.raw *.wav *.ogg *.ds "
+								   "*.flac *.spx *.voc *.aif *.aiff *.au *.raw"};
+	return simpleExtensions + " " + audioExtensions;
+}
+
 
 } // namespace lmms::gui

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1048,8 +1048,6 @@ void FileBrowserTreeWidget::updateDirectory(QTreeWidgetItem * item )
 
 
 
-std::unique_ptr<FileBrowserSearcher> FileBrowserSearcher::s_instance = nullptr;
-
 FileBrowserSearcher::FileBrowserSearcher()
 	: m_worker([this] { run(); })
 {

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -206,20 +206,19 @@ void FileBrowser::buildSearchTree(QStringList matches, QString id)
 			if (relativeParentPath == ".")
 			{
 				m_searchTreeWidget->addTopLevelItem(childWidget);
+				if (matchInfo.isDir()) { m_searchTreeWidget->expandItem(childWidget); }
 				continue;
 			}
 
 			auto parentItems = m_searchTreeWidget->findItems(relativeParentPath, Qt::MatchExactly);
 			auto parentItem = parentItems.isEmpty() ? new Directory(relativeParentPath, matchParentPath, m_filter) : parentItems[0];
-
 			auto parentDirItem = dynamic_cast<Directory*>(parentItem);
 			if (!parentDirItem) { continue; }
 
 			parentDirItem->addChild(childWidget);
-			parentDirItem->setExpanded(true);
-			if (parentItems.isEmpty()) { parentDirItem->update(); }
-
+			parentDirItem->update();
 			m_searchTreeWidget->addTopLevelItem(parentDirItem);
+			m_searchTreeWidget->expandItem(parentDirItem);
 		}
 	}
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -118,14 +118,10 @@ MainWindow::MainWindow() :
 							splitter, false, true,
 				confMgr->userProjectsDir(),
 				confMgr->factoryProjectsDir()));
-	sideBar->appendTab( new FileBrowser(
-				confMgr->userSamplesDir() + "*" +
-				confMgr->factorySamplesDir(),
-					"*", tr( "My Samples" ),
-					embed::getIconPixmap( "sample_file" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, false, true,
-					confMgr->userSamplesDir(),
-					confMgr->factorySamplesDir()));
+	sideBar->appendTab(
+		new FileBrowser(confMgr->userSamplesDir() + "*" + confMgr->factorySamplesDir(), FileItem::defaultFilters(),
+			tr("My Samples"), embed::getIconPixmap("sample_file").transformed(QTransform().rotate(90)), splitter, false,
+			true, confMgr->userSamplesDir(), confMgr->factorySamplesDir()));
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userPresetsDir() + "*" +
 				confMgr->factoryPresetsDir(),

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -135,11 +135,8 @@ MainWindow::MainWindow() :
 							splitter , false, true,
 				confMgr->userPresetsDir(),
 				confMgr->factoryPresetsDir()));
-	sideBar->appendTab( new FileBrowser( QDir::homePath(), "*",
-							tr( "My Home" ),
-					embed::getIconPixmap( "home" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, false, false ) );
-
+	sideBar->appendTab(new FileBrowser(QDir::homePath(), FileItem::defaultFilters(), tr("My Home"),
+		embed::getIconPixmap("home").transformed(QTransform().rotate(90)), splitter, false, false));
 
 	QStringList root_paths;
 	QString title = tr( "Root directory" );
@@ -161,9 +158,8 @@ MainWindow::MainWindow() :
 	}
 #endif
 
-	sideBar->appendTab( new FileBrowser( root_paths.join( "*" ), "*", title,
-					embed::getIconPixmap( "computer" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, dirs_as_items) );
+	sideBar->appendTab(new FileBrowser(root_paths.join("*"), FileItem::defaultFilters(), title,
+		embed::getIconPixmap("computer").transformed(QTransform().rotate(90)), splitter, dirs_as_items));
 
 	m_workspace = new QMdiArea(splitter);
 


### PR DESCRIPTION
Improves the search performance of the file browser by delegating the search to a worker thread. The main thread then builds the tree and displays it to the user.

Fixes #6874.