### PR TITLE
More prominent search (#6966)

### DIFF
--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -121,11 +121,12 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	searchWidgetLayout->setContentsMargins(0, 0, 0, 0);
 	searchWidgetLayout->setSpacing( 0 );
 
-	m_filterEdit = new QLineEdit( searchWidget );
-	m_filterEdit->setPlaceholderText( tr("Search") );
-	m_filterEdit->setClearButtonEnabled( true );
-	connect( m_filterEdit, SIGNAL( textEdited( const QString& ) ),
-			this, SLOT( filterAndExpandItems( const QString& ) ) );
+	m_filterEdit = new QLineEdit(searchWidget);
+	m_filterEdit->setPlaceholderText(tr("Search"));
+	m_filterEdit->setClearButtonEnabled(true);
+	m_filterEdit->addAction(embed::getIconPixmap("zoom"), QLineEdit::LeadingPosition);
+	connect(m_filterEdit, SIGNAL(textEdited(const QString&)),
+			this, SLOT(filterAndExpandItems(const QString&)));
 
 	auto reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
 	reload_btn->setToolTip( tr( "Refresh list" ) );

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -125,8 +125,8 @@ FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 	m_filterEdit->setPlaceholderText(tr("Search"));
 	m_filterEdit->setClearButtonEnabled(true);
 	m_filterEdit->addAction(embed::getIconPixmap("zoom"), QLineEdit::LeadingPosition);
-	connect(m_filterEdit, SIGNAL(textEdited(const QString&)),
-			this, SLOT(filterAndExpandItems(const QString&)));
+
+	connect(m_filterEdit, &QLineEdit::textEdited, [this](const QString & filter) { filterAndExpandItems(filter); });
 
 	auto reload_btn = new QPushButton(embed::getIconPixmap("reload"), QString(), searchWidget);
 	reload_btn->setToolTip( tr( "Refresh list" ) );

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -68,9 +68,10 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 	hint->setWordWrap( true );
 
 	auto searchBar = new QLineEdit(m_view);
-	searchBar->setPlaceholderText( "Search" );
-	searchBar->setMaxLength( 64 );
-	searchBar->setClearButtonEnabled( true );
+	searchBar->setPlaceholderText(tr("Search"));
+	searchBar->setMaxLength(64);
+	searchBar->setClearButtonEnabled(true);
+	searchBar->addAction(embed::getIconPixmap("zoom"), QLineEdit::LeadingPosition);
 
 	m_descTree = new QTreeWidget( m_view );
 	m_descTree->setColumnCount( 1 );

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -98,12 +98,14 @@ EffectSelectDialog::EffectSelectDialog( QWidget * _parent ) :
 	m_model.setSourceModel( &m_sourceModel );
 	m_model.setFilterCaseSensitivity( Qt::CaseInsensitive );
 
-	connect( ui->filterEdit, SIGNAL( textChanged( const QString& ) ),
-				&m_model, SLOT( setFilterFixedString( const QString& ) ) );
-	connect( ui->filterEdit, SIGNAL( textChanged( const QString& ) ),
-					this, SLOT(updateSelection()));
-	connect( ui->filterEdit, SIGNAL( textChanged( const QString& ) ),
-							SLOT(sortAgain()));
+	ui->filterEdit->setPlaceholderText(tr("Search"));
+	ui->filterEdit->setClearButtonEnabled(true);
+	ui->filterEdit->addAction(embed::getIconPixmap("zoom"), QLineEdit::LeadingPosition);
+
+	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)),
+				&m_model, SLOT(setFilterFixedString(const QString&)));
+	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)), SLOT(updateSelection()));
+	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)), SLOT(sortAgain()));
 
 	ui->pluginList->setModel( &m_model );
 

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -102,10 +102,9 @@ EffectSelectDialog::EffectSelectDialog( QWidget * _parent ) :
 	ui->filterEdit->setClearButtonEnabled(true);
 	ui->filterEdit->addAction(embed::getIconPixmap("zoom"), QLineEdit::LeadingPosition);
 
-	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)),
-				&m_model, SLOT(setFilterFixedString(const QString&)));
-	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)), SLOT(updateSelection()));
-	connect(ui->filterEdit, SIGNAL(textChanged(const QString&)), SLOT(sortAgain()));
+	connect(ui->filterEdit, &QLineEdit::textChanged, &m_model, &QSortFilterProxyModel::setFilterFixedString);
+	connect(ui->filterEdit, &QLineEdit::textChanged, this, &EffectSelectDialog::updateSelection);
+	connect(ui->filterEdit, &QLineEdit::textChanged, this, &EffectSelectDialog::sortAgain);
 
 	ui->pluginList->setModel( &m_model );
 


### PR DESCRIPTION
Make the search features more prominent by adding an icon with a magnifying glass to the line edits. Because there is no specific icon for "search" the same icon as for "zoom" is used.

![Screenshot_20231106_114347](https://github.com/LMMS/lmms/assets/9293269/7ef17cfd-b9e5-4c47-b9b6-050f1d9f0d5d)

Make the "Search" text translatable in `PluginBrowser.cpp` and add a search icon.

Make the search in the effects selection dialog more similar to the other ones by adding a search icon and a placeholder text and by enabling the clear button.

![Screenshot_20231106_114459](https://github.com/LMMS/lmms/assets/9293269/bda715ee-935e-434e-a243-9b46dce33366)

Make some whitespace adjustments in the vicinity of the other adjustments.

It could be considered to create the search line edits in a factory although this would not work for the effects select dialog because its line edit is created in the UI file. In that case we'd have to add an additional method like `embellishLineEditForSearch(QLineEdit*)` or something similar to the factory.