### PR TITLE
Fix LV2 instrument instantiation crash

### DIFF
--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -281,9 +281,9 @@ void PluginDescWidget::leaveEvent( QEvent * _e )
 
 void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 {
+	Engine::setDndPluginKey(&m_pluginKey);
 	if ( _me->button() == Qt::LeftButton )
 	{
-		Engine::setDndPluginKey(&m_pluginKey);
 		new StringPairDrag("instrument",
 			QString::fromUtf8(m_pluginKey.desc->name), m_logo, this);
 		leaveEvent( _me );


### PR DESCRIPTION
Fixes LV2 instrument instantiation crash that occurs when right-clicking an LV2 instrument in plugin browser and then clicking "Send to new instrument track".