### PR TITLE
Fix memleaks in help/version, including CI tests

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+---
 custom: https://lmms.io/get-involved/#donate

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,5 @@
+---
 contact_links:
-- name: Get help on Discord
-  url: https://lmms.io/chat/
-  about: Need help? Have a question? Reach out to other LMMS users on our Discord server!
+  - name: Get help on Discord
+    url: https://lmms.io/chat/
+    about: Need help? Have a question? Reach out to other LMMS users on our Discord server!

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,2 +1,3 @@
+---
 # Label requiring a response
 responseRequiredLabel: "response required"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,12 +271,14 @@ jobs:
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
+          # yamllint disable rule:line-length
           key: "ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
             ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}-
             ccache-${{ github.job }}-${{ matrix.config.arch }}-
           path: ~\AppData\Local\ccache
+          # yamllint enable rule:line-length
       - name: Install tools
         run: choco install ccache
       - name: Install 64-bit Qt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,11 @@ jobs:
         run: |
           cmake --build build --target install
           cmake --build build --target appimage
+      - name: Display help
+        run: >
+          build/install/bin/lmms --help | grep "Usage: lmms"
+      - name: Display version
+        run: build/install/bin/lmms --version | grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -131,6 +136,11 @@ jobs:
         run: |
           cmake --build build --target install
           cmake --build build --target dmg
+      - name: Display help
+        run: >
+          build/LMMS.app/Contents/MacOS/lmms --help | grep "Usage: lmms"
+      - name: Display version
+        run: build/LMMS.app/Contents/MacOS/lmms --version | grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -171,7 +181,10 @@ jobs:
         run: |
           add-apt-repository ppa:git-core/ppa
           apt-get update
-          apt-get --yes install git
+          apt-get --yes install git wine-stable p7zip-full
+          dpkg --add-architecture i386  # add i386 arch for wine32
+          apt-get --yes update
+          apt-get --yes install wine32
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check out
         uses: actions/checkout@v3
@@ -198,6 +211,20 @@ jobs:
         run: cmake --build build --target tests
       - name: Package
         run: cmake --build build --target package
+      - name: Unpack
+        run: |
+          mkdir build/install
+          7z x -obuild/install build/lmms-*.exe
+      - name: Display help
+        run: >
+          WINEPREFIX=/tmp/lmms-wineprefix
+          wine "build/install/lmms.exe" --help |
+          grep "Usage: lmms"
+      - name: Display version
+        run: >
+          WINEPREFIX=/tmp/lmms-wineprefix
+          wine "build/install/lmms.exe" --version |
+          grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -216,8 +243,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['x86', 'x64']
-    name: msvc-${{ matrix.arch }}
+        config:
+          - arch: 'x86'
+            programfiles-suffix: '(x86)'
+          - arch: 'x64'
+            programfiles-suffix: ''
+    name: msvc-${{ matrix.config.arch }}
     runs-on: windows-2019
     env:
       qt-version: '5.15.2'
@@ -233,23 +264,23 @@ jobs:
         id: cache-deps
         uses: actions/cache@v3
         with:
-          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ matrix.config.arch }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ matrix.arch }}-
+            vcpkg-${{ matrix.config.arch }}-
           path: build\vcpkg_installed
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
-          key: "ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}\
+          key: "ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}-
-            ccache-${{ github.job }}-${{ matrix.arch }}-
+            ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}-
+            ccache-${{ github.job }}-${{ matrix.config.arch }}-
           path: ~\AppData\Local\ccache
       - name: Install tools
         run: choco install ccache
       - name: Install 64-bit Qt
-        if: matrix.arch == 'x64'
+        if: matrix.config.arch == 'x64'
         uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           version: ${{ env.qt-version }}
@@ -263,11 +294,11 @@ jobs:
           arch: win32_msvc2019
           archives: qtbase qtsvg qttools
           cache: true
-          set-env: ${{ matrix.arch == 'x86' }}
+          set-env: ${{ matrix.config.arch == 'x86' }}
       - name: Set up build environment
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
         with:
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.config.arch }}
       - name: Configure
         run: |
           ccache --zero-stats
@@ -278,8 +309,8 @@ jobs:
             --toolchain C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DUSE_COMPILE_CACHE=ON `
-            -DVCPKG_TARGET_TRIPLET="${{ matrix.arch }}-windows" `
-            -DVCPKG_HOST_TRIPLET="${{ matrix.arch }}-windows" `
+            -DVCPKG_TARGET_TRIPLET="${{ matrix.config.arch }}-windows" `
+            -DVCPKG_HOST_TRIPLET="${{ matrix.config.arch }}-windows" `
             -DVCPKG_MANIFEST_INSTALL="${{ env.should_install_manifest }}"
         env:
           should_install_manifest:
@@ -290,10 +321,24 @@ jobs:
         run: cmake --build build --target tests
       - name: Package
         run: cmake --build build --target package
+      - name: Unpack
+        run: Start-Process @(gci build/lmms-*.exe)[0] -ArgumentList /S -Wait
+        # yamllint disable rule:line-length
+      - name: Display help
+        run: >
+            $result = & "${env:ProgramFiles${{ matrix.config.programfiles-suffix }}}/LMMS/lmms.exe" "--help" |
+            Select-String "Usage: lmms";
+            if($result.Matches.Count -eq 0) { exit 1 }
+      - name: Display version
+        run: >
+            $result = & "${env:ProgramFiles${{ matrix.config.programfiles-suffix }}}/LMMS/lmms.exe" "--version" |
+            Select-String -Pattern "Copyright \(c\) .* LMMS Developers";
+            if($result.Matches.Count -eq 0) { exit 1 }
+        # yamllint enable rule:line-length
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: msvc-${{ matrix.arch }}
+          name: msvc-${{ matrix.config.arch }}
           path: build\lmms-*.exe
       - name: Trim ccache and print statistics
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,3 +31,10 @@ jobs:
             $(find "./cmake/" -type f -name '*.sh' -o -name "*.sh.in") \
             doc/bash-completion/lmms \
             buildtools/update_locales
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+      - name: Run yamllint
+        run: for i in $(git ls-files '*.yml'); do yamllint $i; done

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,3 @@
+rules:
+  line-length:
+    max: 120  # be conforming to LMMS coding rules

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -254,7 +254,58 @@ int main( int argc, char * * argv )
 {
 	using namespace lmms;
 
-#ifdef LMMS_DEBUG_FPE
+	bool coreOnly = false;
+	bool fullscreen = true;
+	bool exitAfterImport = false;
+	bool allowRoot = false;
+	bool renderLoop = false;
+	bool renderTracks = false;
+	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
+
+	// first of two command-line parsing stages
+	for (int i = 1; i < argc; ++i)
+	{
+		QString arg = argv[i];
+
+		if (arg == "--help" || arg == "-h")
+		{
+			printHelp();
+			return EXIT_SUCCESS;
+		}
+		else if (arg == "--version" || arg == "-v")
+		{
+			printVersion(argv[0]);
+			return EXIT_SUCCESS;
+		}
+		else if (arg == "render" || arg == "--render" || arg == "-r" )
+		{
+			coreOnly = true;
+		}
+		else if (arg == "rendertracks" || arg == "--rendertracks")
+		{
+			coreOnly = true;
+			renderTracks = true;
+		}
+		else if (arg == "--allowroot")
+		{
+			allowRoot = true;
+		}
+		else if (arg == "--geometry" || arg == "-geometry")
+		{
+			if (arg == "--geometry")
+			{
+				// Delete the first "-" so Qt recognize the option
+				strcpy(argv[i], "-geometry");
+			}
+			// option -geometry is filtered by Qt later,
+			// so we need to check its presence now to
+			// determine, if the application should run in
+			// fullscreen mode (default, no -geometry given).
+			fullscreen = false;
+		}
+	}
+
+	#ifdef LMMS_DEBUG_FPE
 	// Enable exceptions for certain floating point results
 	// FE_UNDERFLOW is disabled for the time being
 	feenableexcept( FE_INVALID   |
@@ -302,49 +353,6 @@ int main( int argc, char * * argv )
 
 	disable_denormals();
 
-	bool coreOnly = false;
-	bool fullscreen = true;
-	bool exitAfterImport = false;
-	bool allowRoot = false;
-	bool renderLoop = false;
-	bool renderTracks = false;
-	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
-
-	// first of two command-line parsing stages
-	for( int i = 1; i < argc; ++i )
-	{
-		QString arg = argv[i];
-
-		if( arg == "--help"    || arg == "-h" ||
-		    arg == "--version" || arg == "-v" ||
-		    arg == "render" || arg == "--render" || arg == "-r" )
-		{
-			coreOnly = true;
-		}
-		else if( arg == "rendertracks" || arg == "--rendertracks" )
-		{
-			coreOnly = true;
-			renderTracks = true;
-		}
-		else if( arg == "--allowroot" )
-		{
-			allowRoot = true;
-		}
-		else if( arg == "--geometry" || arg == "-geometry")
-		{
-			if( arg == "--geometry" )
-			{
-				// Delete the first "-" so Qt recognize the option
-				strcpy(argv[i], "-geometry");
-			}
-			// option -geometry is filtered by Qt later,
-			// so we need to check its presence now to
-			// determine, if the application should run in
-			// fullscreen mode (default, no -geometry given).
-			fullscreen = false;
-		}
-	}
-
 #if !defined(LMMS_BUILD_WIN32) && !defined(LMMS_BUILD_HAIKU)
 	if ( ( getuid() == 0 || geteuid() == 0 ) && !allowRoot )
 	{
@@ -372,17 +380,7 @@ int main( int argc, char * * argv )
 	{
 		QString arg = argv[i];
 
-		if( arg == "--version" || arg == "-v" )
-		{
-			printVersion( argv[0] );
-			return EXIT_SUCCESS;
-		}
-		else if( arg == "--help" || arg  == "-h" )
-		{
-			printHelp();
-			return EXIT_SUCCESS;
-		}
-		else if( arg == "upgrade" || arg == "--upgrade" || arg  == "-u")
+		if (arg == "upgrade" || arg == "--upgrade" || arg  == "-u")
 		{
 			++i;
 


### PR DESCRIPTION
Finally ready to review. Thanks to the almost not countable devs who helped.

For discussion:

* **Time spent** Most systems are equally fast, however, MinGW takes ~ 1 minute more (master average time is 9 minutes), because I added dpkg --add-architecture i386 && apt-get --yes update. I also had to add a second apt-get install, which however just takes ~ 15 seconds. I hope that is all acceptable.
* **Kinds of tests** Currently, the mentioned PR only runs --help and --version and checks the output. However, I would like to let it export a song to wav, too, since that can be done with the command line. The question is just which song we take. If it is a simple, minimal song, we may have a reproducible output (the WAV is always the same), but we do not test many instruments. Larger songs may cover more instruments, but might have random somewhere, so they might not be deterministic.