### PR TITLE
Disable Compressor background autofill

### DIFF
--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -58,7 +58,10 @@ CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
 	m_graphColor(209, 216, 228, 50),
 	m_resetColor(200, 100, 15, 200)
 {
-	setAutoFillBackground(true);
+	setAutoFillBackground(false);
+	setAttribute(Qt::WA_OpaquePaintEvent, true);
+	setAttribute(Qt::WA_NoSystemBackground, true);
+	
 	QPalette pal;
 	pal.setBrush(backgroundRole(), PLUGIN_NAME::getIconPixmap("artwork"));
 	setPalette(pal);


### PR DESCRIPTION
Compressor's display is hilariously slow since Qt renders everything via the CPU instead of the GPU, but it turns out disabling the unnecessary background autofill speeds things up by quite a surprising amount.