### PR TITLE
SlicerT reversed slices and bug fixes

### DIFF
--- a/plugins/SlicerT/SlicerT.h
+++ b/plugins/SlicerT/SlicerT.h
@@ -96,6 +96,8 @@ private:
 	BoolModel m_enableSync;
 
 	SampleBuffer m_originalSample;
+	std::vector<sampleFrame> m_sampleData;
+	std::vector<sampleFrame> m_reversedSampleData;
 
 	std::vector<float> m_slicePoints;
 


### PR DESCRIPTION
Fixes the bugs mentioned by @zonkmachine in #6857 and adds reversed slices below the base note. Backwards compatibility should be preserved.

Here is an example, the selected notes get played in reverse:

![image](https://github.com/LMMS/lmms/assets/47889291/f4cdbab2-d9d9-423a-b5d1-0dabf49536bb)
