### PR TITLE
Enforce lazy loading for `FileBrowser`

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -69,7 +69,7 @@ public:
 	*/
 	FileBrowser( const QString & directories, const QString & filter,
 			const QString & title, const QPixmap & pm,
-			QWidget * parent, bool dirs_as_items = false, bool recurse = false,
+			QWidget * parent, bool dirs_as_items = false,
 			const QString& userDir = "",
 			const QString& factoryDir = "");
 
@@ -93,7 +93,7 @@ public:
 
 private slots:
 	void reloadTree();
-	void expandItems( QTreeWidgetItem * item=nullptr, QList<QString> expandedDirs = QList<QString>() );
+	void expandItems(const QList<QString>& expandedDirs, QTreeWidgetItem* item = nullptr);
 	void giveFocusToFilter();
 
 private:
@@ -120,7 +120,6 @@ private:
 	QString m_filter; //!< Filter as used in QDir::match()
 
 	bool m_dirsAsItems;
-	bool m_recurse;
 
 	void addContentCheckBox();
 	QCheckBox* m_showUserContent = nullptr;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -102,14 +102,13 @@ void FileBrowser::addContentCheckBox()
 
 FileBrowser::FileBrowser(const QString & directories, const QString & filter,
 			const QString & title, const QPixmap & pm,
-			QWidget * parent, bool dirs_as_items, bool recurse,
+			QWidget * parent, bool dirs_as_items,
 			const QString& userDir,
 			const QString& factoryDir):
 	SideBarWidget( title, pm, parent ),
 	m_directories( directories ),
 	m_filter( filter ),
 	m_dirsAsItems( dirs_as_items ),
-	m_recurse( recurse ),
 	m_userDir(userDir),
 	m_factoryDir(factoryDir)
 {
@@ -177,7 +176,7 @@ void FileBrowser::saveDirectoriesStates()
 	
 void FileBrowser::restoreDirectoriesStates()
 {
-	expandItems(nullptr, m_savedExpandedDirs);
+	expandItems(m_savedExpandedDirs);
 }
 
 void FileBrowser::buildSearchTree()
@@ -337,8 +336,10 @@ void FileBrowser::reloadTree()
 
 
 
-void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs)
+void FileBrowser::expandItems(const QList<QString>& expandedDirs, QTreeWidgetItem* item)
 {
+	if (expandedDirs.isEmpty()) { return; }
+
 	int numChildren = item ? item->childCount() : m_fileBrowserTreeWidget->topLevelItemCount();
 	for (int i = 0; i < numChildren; ++i)
 	{
@@ -346,14 +347,10 @@ void FileBrowser::expandItems(QTreeWidgetItem* item, QList<QString> expandedDirs
 		auto d = dynamic_cast<Directory*>(it);
 		if (d)
 		{
-			// Expanding is required when recursive to load in its contents, even if it's collapsed right afterward
-			if (m_recurse) { d->setExpanded(true); }
-
 			d->setExpanded(expandedDirs.contains(d->fullName()));
-
-			if (m_recurse && it->childCount())
+			if (it->childCount() > 0)
 			{
-				expandItems(it, expandedDirs);
+				expandItems(expandedDirs, it);
 			}
 		}
 		

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -115,24 +115,24 @@ MainWindow::MainWindow() :
 					"*.mmp *.mmpz *.xml *.mid *.mpt",
 							tr( "My Projects" ),
 					embed::getIconPixmap( "project_file" ).transformed( QTransform().rotate( 90 ) ),
-							splitter, false, true,
+							splitter, false,
 				confMgr->userProjectsDir(),
 				confMgr->factoryProjectsDir()));
 	sideBar->appendTab(
 		new FileBrowser(confMgr->userSamplesDir() + "*" + confMgr->factorySamplesDir(), FileItem::defaultFilters(),
 			tr("My Samples"), embed::getIconPixmap("sample_file").transformed(QTransform().rotate(90)), splitter, false,
-			true, confMgr->userSamplesDir(), confMgr->factorySamplesDir()));
+			confMgr->userSamplesDir(), confMgr->factorySamplesDir()));
 	sideBar->appendTab( new FileBrowser(
 				confMgr->userPresetsDir() + "*" +
 				confMgr->factoryPresetsDir(),
 					"*.xpf *.cs.xml *.xiz *.lv2",
 					tr( "My Presets" ),
 					embed::getIconPixmap( "preset_file" ).transformed( QTransform().rotate( 90 ) ),
-							splitter , false, true,
+							splitter , false,
 				confMgr->userPresetsDir(),
 				confMgr->factoryPresetsDir()));
 	sideBar->appendTab(new FileBrowser(QDir::homePath(), FileItem::defaultFilters(), tr("My Home"),
-		embed::getIconPixmap("home").transformed(QTransform().rotate(90)), splitter, false, false));
+		embed::getIconPixmap("home").transformed(QTransform().rotate(90)), splitter, false));
 
 	QStringList root_paths;
 	QString title = tr( "Root directory" );


### PR DESCRIPTION
When reloading the file browser, LMMS first stores the directories the user has expanded so that it can clear and populate the browser while keeping those directories expanded after it is finished populating it. This however, also happens when the user first starts LMMS, and given that no directories were expanded, LMMS will attempt to expand absolutely nothing but still try because it wants to load all of the entries in otherwise (i.e., it loads entries by expanding directories).

All of the entries do not need to be loaded at once, but can be loaded as the user gradually expands more and more directories. This was already being done, but for some reason, this all-in-one loading of every single entry was needlessly done as well.