### PR TITLE
Feature/bounce

### DIFF
--- a/include/BounceManager.h
+++ b/include/BounceManager.h
@@ -1,0 +1,78 @@
+/*
+ * RenderManager.h - No questions asked bouncing of clips  to wav loops
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_BOUNCE_MANAGER_H
+#define LMMS_BOUNCE_MANAGER_H
+
+#include <memory>
+
+#include "ProjectRenderer.h"
+#include "OutputSettings.h"
+#include "TimePos.h"
+
+
+namespace lmms
+{
+
+
+class BounceManager : public QObject
+{
+	Q_OBJECT
+public:
+	BounceManager();
+
+	~BounceManager() override;
+
+	/// Export all unmuted tracks into a single file
+	void renderProject();
+
+	void abortProcessing();
+
+signals:
+	void finished();
+
+private slots:
+
+private:
+	QString pathForTrack( const Track *track, int num );
+	void setLoopPoints( );
+	void setOutputDefaults( );
+	void muteUnsuedTracks( );
+	void render( );
+	void restoreMutedState( );
+
+	const AudioEngine::qualitySettings * m_qualitySettings;
+	const AudioEngine::qualitySettings m_oldQualitySettings;
+	const OutputSettings * m_outputSettings;
+	ProjectRenderer::ExportFileFormat m_format;
+	QString m_outputPath;
+	ProjectRenderer * m_renderer;
+
+	std::vector<Track*> m_muted;
+	TimePos m_start;
+	TimePos m_end;
+} ;
+
+
+} // namespace lmms
+
+#endif // LMMS_BOUNCE_MANAGER_H

--- a/include/BounceManager.h
+++ b/include/BounceManager.h
@@ -42,8 +42,10 @@ public:
 
 	~BounceManager() override;
 
+	bool setExportPoints( );
+
 	/// Export all unmuted tracks into a single file
-	void renderProject();
+	void render();
 
 	void abortProcessing();
 
@@ -54,10 +56,8 @@ private slots:
 
 private:
 	QString pathForTrack( const Track *track, int num );
-	void setLoopPoints( );
 	void setOutputDefaults( );
-	void muteUnsuedTracks( );
-	void render( );
+	void muteUnusedTracks( );
 	void restoreMutedState( );
 
 	const AudioEngine::qualitySettings * m_qualitySettings;

--- a/include/BounceManager.h
+++ b/include/BounceManager.h
@@ -39,25 +39,16 @@ class BounceManager : public QObject
 	Q_OBJECT
 public:
 	BounceManager();
-
 	~BounceManager() override;
 
-	bool setExportPoints( );
-
-	/// Export all unmuted tracks into a single file
 	void render();
 
-	void abortProcessing();
-
-signals:
+public slots:
 	void finished();
 
-private slots:
-
 private:
-	QString pathForTrack( const Track *track, int num );
-	void setOutputDefaults( );
-	void muteUnusedTracks( );
+	bool setExportPoints( );
+	bool setOutputDefaults( );
 	void restoreMutedState( );
 
 	const AudioEngine::qualitySettings * m_qualitySettings;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -31,6 +31,7 @@
 #include <QMainWindow>
 
 #include "ConfigManager.h"
+#include "BounceManager.h"
 
 class QAction;
 class QDomElement;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -178,6 +178,7 @@ public slots:
 
 private slots:
 	void onExportProjectMidi();
+	void onBounceSelectedClip();
 
 protected:
 	void closeEvent( QCloseEvent * _ce ) override;
@@ -198,6 +199,7 @@ private:
 	void refocus();
 
 	void exportProject(bool multiExport = false);
+	void bounceSelectedClip();
 	void handleSaveResult(QString const & filename, bool songSavedSuccessfully);
 	bool guiSaveProject();
 	bool guiSaveProjectAs( const QString & filename );

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -178,7 +178,7 @@ public slots:
 
 private slots:
 	void onExportProjectMidi();
-	void onBounceSelectedClip();
+	void onBounceSelectedClips();
 
 protected:
 	void closeEvent( QCloseEvent * _ce ) override;
@@ -199,7 +199,7 @@ private:
 	void refocus();
 
 	void exportProject(bool multiExport = false);
-	void bounceSelectedClip();
+	void bounceSelectedClips();
 	void handleSaveResult(QString const & filename, bool songSavedSuccessfully);
 	bool guiSaveProject();
 	bool guiSaveProjectAs( const QString & filename );

--- a/include/Song.h
+++ b/include/Song.h
@@ -238,7 +238,7 @@ public:
 			m_loopRenderCount = count;
 		m_loopRenderRemaining = m_loopRenderCount;
 	}
-    
+
 	inline int getLoopRenderCount() const
 	{
 		return m_loopRenderCount;
@@ -250,6 +250,21 @@ public:
 	inline void setRenderBetweenMarkers( bool renderBetweenMarkers )
 	{
 		m_renderBetweenMarkers = renderBetweenMarkers;
+		m_renderClips = false;
+	}
+
+	inline void setRenderClips( TimePos exportLoopBegin, TimePos exportLoopEnd )
+	{
+		m_renderClips = true;
+		m_exportLoop =  true;
+		m_exportLoopBegin = exportLoopBegin;
+		m_exportLoopEnd = exportLoopEnd;
+		m_loopRenderCount = 1;
+	}
+
+	inline void unsetRenderClips()
+	{
+		m_renderClips = false;
 	}
 
 	inline PlayMode playMode() const
@@ -470,6 +485,7 @@ private:
 	volatile bool m_exporting;
 	volatile bool m_exportLoop;
 	volatile bool m_renderBetweenMarkers;
+	volatile bool m_renderClips;
 	volatile bool m_playing;
 	volatile bool m_paused;
 

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -70,6 +70,10 @@ public:
 			removeClipView( m_clipViews[clipNum] );
 		}
 	}
+	QVector<ClipView*> getClipViews()
+	{
+		return m_clipViews;
+	}
 
 	bool canPasteSelection( TimePos clipPos, const QDropEvent *de );
 	bool canPasteSelection( TimePos clipPos, const QMimeData *md, bool allowSameBar = false );

--- a/src/core/BounceManager.cpp
+++ b/src/core/BounceManager.cpp
@@ -1,0 +1,172 @@
+/*
+ * BounceManager - bouncing clips to wavs/loops for play with audio file processor.
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <QDir>
+
+#include "BounceManager.h"
+
+#include "FileDialog.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
+#include "PatternStore.h"
+#include "Song.h"
+
+using namespace lmms::gui;
+
+namespace lmms
+{
+
+
+BounceManager::BounceManager() :
+	m_qualitySettings(),
+	m_oldQualitySettings( Engine::audioEngine()->currentQualitySettings() ),
+	m_outputSettings(),
+	m_format(),
+	m_outputPath()
+{
+	Engine::audioEngine()->storeAudioDevice();
+}
+
+BounceManager::~BounceManager()
+{
+	Engine::audioEngine()->restoreAudioDevice();  // Also deletes audio dev.
+	Engine::audioEngine()->changeQuality( m_oldQualitySettings );
+	if ( m_qualitySettings )
+	{
+		delete m_qualitySettings;
+	}
+	if ( m_outputSettings )
+	{
+		delete m_outputSettings;
+	}
+}
+
+// set the file tou output and the file format settings based on defaults
+void BounceManager::setOutputDefaults()
+{
+	// TODO defaults from settings
+	QString defaultDir = QFileInfo( Engine::getSong()->projectFileName() ).absolutePath();
+	QString suffix = "wav";
+
+	FileDialog bfd( getGUI()->mainWindow() );
+	bfd.setFileMode( FileDialog::AnyFile );
+	bfd.setDirectory( defaultDir );
+	bfd.setDefaultSuffix( suffix );
+	bfd.setAcceptMode( FileDialog::AcceptSave );
+	if( bfd.exec() == QDialog::Accepted && !bfd.selectedFiles().isEmpty() &&
+					 !bfd.selectedFiles()[0].isEmpty() )
+	{
+		m_outputPath = bfd.selectedFiles()[0];
+	}
+	else {
+		return;
+	}
+
+	// TODO merge output prefs and allow users to configure
+	int bitrate = 256;
+	int bitdepth = 16;
+	OutputSettings::StereoMode stereomode = OutputSettings::StereoMode::Stereo;
+	int samplerate = 44100;
+	int interpolation = 3;
+	int oversampling = 1;
+
+
+	// TODO memory leak if called twice
+	m_qualitySettings =
+			new AudioEngine::qualitySettings(
+					static_cast<AudioEngine::qualitySettings::Interpolation>(interpolation),
+					static_cast<AudioEngine::qualitySettings::Oversampling>(oversampling));
+
+	OutputSettings::BitRateSettings bitRateSettings(bitrate , false);
+	m_outputSettings = new OutputSettings(
+			samplerate,
+			bitRateSettings,
+			static_cast<OutputSettings::BitDepth>( bitdepth ),
+			stereomode );
+
+}
+
+// set the part of the timeline to export based on selected clips
+void BounceManager::setLoopPoints()
+{
+	Song * song = Engine::getSong();
+	int startTick = 0;
+
+	song->getPlayPos().setTicks(startTick);
+}
+
+// mute all tracks except those selected
+void BounceManager::muteUnsuedTracks()
+{
+
+}
+
+void BounceManager::abortProcessing()
+{
+	if ( m_renderer ) {
+		m_renderer->abortProcessing();
+	}
+	restoreMutedState();
+}
+
+
+// Bounce the clips into a .wav
+void BounceManager::renderProject()
+{
+	Song * song = Engine::getSong();
+	song->setExportLoop( true );
+	song->setRenderBetweenMarkers( true );
+	song->setLoopRenderCount( 1 );
+	render( );
+}
+
+void BounceManager::render()
+{
+	m_renderer = new ProjectRenderer(
+			*m_qualitySettings,
+			*m_outputSettings,
+			m_format,
+			m_outputPath);
+
+	if ( m_renderer->isReady() )
+	{
+		m_renderer->startProcessing();
+	}
+	else
+	{
+		qDebug( "Renderer failed to acquire a file device!" );
+	}
+}
+
+// Unmute all tracks that were muted while rendering clips
+void BounceManager::restoreMutedState()
+{
+	while ( !m_muted.empty() )
+	{
+		Track* restoreTrack = m_muted.back();
+		m_muted.pop_back();
+		restoreTrack->setMuted( false );
+	}
+}
+
+
+} // namespace lmms

--- a/src/core/BounceManager.cpp
+++ b/src/core/BounceManager.cpp
@@ -134,9 +134,6 @@ bool BounceManager::setExportPoints()
 			auto clip = clipv->getClip();
 			begin = clip->startPosition() < begin ? clip->startPosition() : begin;
 			end = clip->endPosition() > end ? clip->endPosition() : end;
-			qWarning("selected clip: %s: %i to %i",
-					 clip->getTrack()->name().toStdString().c_str(),
-					 clip->startPosition().getTicks(), clip->endPosition().getTicks());
 			tracks << clip->getTrack();
 		}
 		so->setSelected(false);
@@ -196,6 +193,8 @@ void BounceManager::finished()
 		so->setSelected(false);
 	}
 	restoreMutedState();
+	// this works provided RenderManager does nothing after emit finished()
+	delete this;
 }
 
 // Unmute all tracks that were muted while rendering clips

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LMMS_SRCS
 	core/AutomationNode.cpp
 	core/BandLimitedWave.cpp
 	core/base64.cpp
+	core/BounceManager.cpp
 	core/BufferManager.cpp
 	core/Clipboard.cpp
 	core/ComboBoxModel.cpp

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -74,6 +74,7 @@ void RenderManager::renderNextTrack()
 		// nothing left to render
 		restoreMutedState();
 		emit finished();
+		// must not do anything more after finished() see BounceManager::finished()
 	}
 	else
 	{

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -731,6 +731,7 @@ void Song::startExport()
 	{
 		m_exportSongBegin = m_exportLoopBegin;
 		m_exportSongEnd = m_exportLoopEnd;
+		getPlayPos(PlayMode::Song).setTicks( m_exportSongBegin );
 	}
 	else
 	{

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -84,6 +84,7 @@ Song::Song() :
 	m_exporting( false ),
 	m_exportLoop( false ),
 	m_renderBetweenMarkers( false ),
+	m_renderClips( false ),
 	m_playing( false ),
 	m_paused( false ),
 	m_savingProject( false ),
@@ -726,19 +727,26 @@ void Song::startExport()
 
 		getPlayPos(PlayMode::Song).setTicks( getPlayPos(PlayMode::Song).m_timeLine->loopBegin().getTicks() );
 	}
+	else if (m_renderClips)
+	{
+		m_exportSongBegin = m_exportLoopBegin;
+		m_exportSongEnd = m_exportLoopEnd;
+	}
 	else
 	{
 		m_exportSongEnd = TimePos(m_length, 0);
-        
+
 		// Handle potentially ridiculous loop points gracefully.
 		if (m_loopRenderCount > 1 && getPlayPos(PlayMode::Song).m_timeLine->loopEnd() > m_exportSongEnd) 
 		{
 			m_exportSongEnd = getPlayPos(PlayMode::Song).m_timeLine->loopEnd();
 		}
 
-		if (!m_exportLoop) 
+		if (!m_exportLoop)
+		{
 			m_exportSongEnd += TimePos(1,0);
-        
+		}
+
 		m_exportSongBegin = TimePos(0,0);
 		// FIXME: remove this check once we load timeline in headless mode
 		if (getPlayPos(PlayMode::Song).m_timeLine)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -332,9 +332,9 @@ void MainWindow::finalize()
 					Qt::CTRL + Qt::SHIFT + Qt::Key_E );
 
 	project_menu->addAction( embed::getIconPixmap( "project_export" ),
-					tr( "Bounce selected clip" ),
+					tr( "Bounce selected clips" ),
 					this,
-					SLOT(onBounceSelectedClip()),
+					SLOT(onBounceSelectedClips()),
 					Qt::CTRL + Qt::Key_B );
 
 
@@ -1547,13 +1547,10 @@ void MainWindow::exportProject(bool multiExport)
 	}
 }
 
-void MainWindow::bounceSelectedClip()
+void MainWindow::bounceSelectedClips()
 {
-	BounceManager bm = BounceManager();
-	if ( bm.setExportPoints() )
-	{
-		bm.render();
-	}
+	BounceManager * bm = new BounceManager();
+	bm->render();
 }
 
 void MainWindow::handleSaveResult(QString const & filename, bool songSavedSuccessfully)
@@ -1600,9 +1597,9 @@ void MainWindow::onExportProjectTracks()
 	this->exportProject(true);
 }
 
-void MainWindow::onBounceSelectedClip()
+void MainWindow::onBounceSelectedClips()
 {
-	this->bounceSelectedClip();
+	this->bounceSelectedClips();
 }
 
 void MainWindow::onImportProject()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -37,7 +37,9 @@
 
 #include "AboutDialog.h"
 #include "AutomationEditor.h"
+#include "BounceManager.h"
 #include "ControllerRackView.h"
+#include "ClipView.h"
 #include "embed.h"
 #include "Engine.h"
 #include "ExportProjectDialog.h"
@@ -50,6 +52,7 @@
 #include "InstrumentTrackWindow.h"
 #include "MicrotunerConfig.h"
 #include "PatternEditor.h"
+#include "PatternStore.h"
 #include "PianoRoll.h"
 #include "PianoView.h"
 #include "PluginBrowser.h"
@@ -327,6 +330,13 @@ void MainWindow::finalize()
 					this,
 					SLOT(onExportProjectTracks()),
 					Qt::CTRL + Qt::SHIFT + Qt::Key_E );
+
+	project_menu->addAction( embed::getIconPixmap( "project_export" ),
+					tr( "Bounce selected clip" ),
+					this,
+					SLOT(onBounceSelectedClip()),
+					Qt::CTRL + Qt::Key_B );
+
 
 	project_menu->addAction( embed::getIconPixmap( "midi_file" ),
 					tr( "Export &MIDI..." ),
@@ -1537,6 +1547,15 @@ void MainWindow::exportProject(bool multiExport)
 	}
 }
 
+void MainWindow::bounceSelectedClip()
+{
+	BounceManager bm = BounceManager();
+	if ( bm.setExportPoints() )
+	{
+		bm.render();
+	}
+}
+
 void MainWindow::handleSaveResult(QString const & filename, bool songSavedSuccessfully)
 {
 	if (songSavedSuccessfully)
@@ -1579,6 +1598,11 @@ void MainWindow::onExportProject()
 void MainWindow::onExportProjectTracks()
 {
 	this->exportProject(true);
+}
+
+void MainWindow::onBounceSelectedClip()
+{
+	this->bounceSelectedClip();
 }
 
 void MainWindow::onImportProject()


### PR DESCRIPTION
Adds Ctrl + B to bounce clips to .wav.  I believe other DAWs have Ctl+B as the short cut too.

Enables selecting some clips in the song window, and exporting those clips muting the other tracks without the popup windows.

Makes sense if output prefs and bounce directory are configured in advance because then select Ctrl + B can save with no questions asked, that would require a merge of feature/outputprefs as well
