### PR TITLE
Fix memory leaks within tests

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -19,5 +19,6 @@ int main(int argc, char* argv[])
 		if (QTest::qExec(suite, argc, argv) != 0) { ++failed; }
 	}
 	qDebug() << "<<" << failed << "out of"<<numsuites<<"test suites failed.";
+	lmms::Engine::destroy();
 	return failed;
 }

--- a/tests/src/tracks/AutomationTrackTest.cpp
+++ b/tests/src/tracks/AutomationTrackTest.cpp
@@ -148,12 +148,11 @@ private slots:
 
 		auto song = Engine::getSong();
 
-		InstrumentTrack* instrumentTrack =
-				dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, song));
+		InstrumentTrack instrumentTrack(song);
 
-		MidiClip* midiClip = dynamic_cast<MidiClip*>(instrumentTrack->createClip(0));
-		midiClip->changeLength(TimePos(4, 0));
-		Note* note = midiClip->addNote(Note(TimePos(4, 0)), false);
+		MidiClip midiClip(&instrumentTrack);
+		midiClip.changeLength(TimePos(4, 0));
+		Note* note = midiClip.addNote(Note(TimePos(4, 0)), false);
 		note->createDetuning();
 
 		DetuningHelper* dh = note->detuning();
@@ -175,10 +174,11 @@ private slots:
 		auto song = Engine::getSong();
 		auto patternStore = Engine::patternStore();
 		PatternTrack patternTrack(song);
-		Track* automationTrack = Track::create(Track::Type::Automation, patternStore);
+		AutomationTrack automationTrack(patternStore);
+		automationTrack.createClipsForPattern(patternStore->numOfPatterns() - 1);
 
-		QVERIFY(automationTrack->numOfClips());
-		AutomationClip* c1 = dynamic_cast<AutomationClip*>(automationTrack->getClip(0));
+		QVERIFY(automationTrack.numOfClips());
+		auto c1 = dynamic_cast<AutomationClip*>(automationTrack.getClip(0));
 		QVERIFY(c1);
 
 		FloatModel model;


### PR DESCRIPTION
See title and commit. Caused by not calling `Engine::destroy` at the end of running the tests, as well as some track/clip creation on the heap that was not freed.