### PR TITLE
Refactor ArpDirection::Down and ArpDirection::DownAndUp

### DIFF
--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -433,16 +433,11 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		int cur_arp_idx = 0;
 		// process according to arpeggio-direction...
-		if( dir == ArpDirection::Up )
+		if (dir == ArpDirection::Up || dir == ArpDirection::Down)
 		{
 			cur_arp_idx = ( cur_frame / arp_frames ) % range;
 		}
-		else if( dir == ArpDirection::Down )
-		{
-			cur_arp_idx = range - ( cur_frame / arp_frames ) %
-								range - 1;
-		}
-		else if( dir == ArpDirection::UpAndDown && range > 1 )
+		else if ((dir == ArpDirection::UpAndDown || dir == ArpDirection::DownAndUp) && range > 1)
 		{
 			// imagine, we had to play the arp once up and then
 			// once down -> makes 2 * range possible notes...
@@ -455,19 +450,6 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			{
 				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - 1;
 			}
-		}
-		else if( dir == ArpDirection::DownAndUp && range > 1 )
-		{
-			// copied from ArpDirection::UpAndDown above
-			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 );
-			// if greater than range, we have to play down...
-			// looks like the code for arp_dir==DOWN... :)
-			if( cur_arp_idx >= range )
-			{
-				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - 1;
-			}
-			// inverts direction
-			cur_arp_idx = range - cur_arp_idx - 1;
 		}
 		else if( dir == ArpDirection::Random )
 		{
@@ -483,6 +465,12 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		{
 			cur_arp_idx *= m_arpCycleModel.value() + 1;
 			cur_arp_idx %= static_cast<int>( range / m_arpRepeatsModel.value() );
+		}
+
+		// If ArpDirection::Down or ArpDirection::DownAndUp, invert the final range.
+		if (dir == ArpDirection::Down || dir == ArpDirection::DownAndUp)
+		{
+			cur_arp_idx = static_cast<int>(range) - cur_arp_idx - 1;
 		}
 
 		// now calculate final key for our arp-note

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -470,7 +470,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 		// If ArpDirection::Down or ArpDirection::DownAndUp, invert the final range.
 		if (dir == ArpDirection::Down || dir == ArpDirection::DownAndUp)
 		{
-			cur_arp_idx = static_cast<int>(range) - cur_arp_idx - 1;
+			cur_arp_idx = static_cast<int>(range / m_arpRepeatsModel.value()) - cur_arp_idx - 1;
 		}
 
 		// now calculate final key for our arp-note

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -443,12 +443,12 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			// once down -> makes 2 * range possible notes...
 			// because we don't play the lower and upper notes
 			// twice, we have to subtract 2
-			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - (2 * static_cast<int>(m_arpRepeatsModel.value())) );
+			cur_arp_idx = (cur_frame / arp_frames) % (range * 2 - (2 * static_cast<int>(m_arpRepeatsModel.value())));
 			// if greater than range, we have to play down...
 			// looks like the code for arp_dir==DOWN... :)
-			if( cur_arp_idx >= range )
+			if (cur_arp_idx >= range)
 			{
-				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - static_cast<int>(m_arpRepeatsModel.value());
+				cur_arp_idx = range - cur_arp_idx % (range - 1) - static_cast<int>(m_arpRepeatsModel.value());
 			}
 		}
 		else if( dir == ArpDirection::Random )

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -443,12 +443,12 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 			// once down -> makes 2 * range possible notes...
 			// because we don't play the lower and upper notes
 			// twice, we have to subtract 2
-			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - 2 );
+			cur_arp_idx = ( cur_frame / arp_frames ) % ( range * 2 - (2 * static_cast<int>(m_arpRepeatsModel.value())) );
 			// if greater than range, we have to play down...
 			// looks like the code for arp_dir==DOWN... :)
 			if( cur_arp_idx >= range )
 			{
-				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - 1;
+				cur_arp_idx = range - cur_arp_idx % ( range - 1 ) - static_cast<int>(m_arpRepeatsModel.value());
 			}
 		}
 		else if( dir == ArpDirection::Random )


### PR DESCRIPTION
Fix issue with wrong pattern when going down and cycle is over 0.

Working on https://github.com/LMMS/lmms/pull/6478 I spotted an issue with the arpeggio pattern when using cycle. This issue was present on the initial implementation of the cycle function. In order to produce similar results, up and down they are now treated the same and later inverted if they are `ArpDirection::Down` or `ArpDirection::DownAndUp`.

