### PR TITLE
Compressor plugin hideable controls

### DIFF
--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -310,8 +310,6 @@ CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
 	connect(&m_controls->m_lookaheadModel, SIGNAL(dataChanged()), this, SLOT(lookaheadChanged()));
 	connect(&m_controls->m_limiterModel, SIGNAL(dataChanged()), this, SLOT(limiterChanged()));
 
-	guiVisibility = true;
-
 	m_timeElapsed.start();
 
 	peakmodeChanged();
@@ -692,13 +690,13 @@ void CompressorControlDialog::drawGraph()
 }
 
 
-void CompressorControlDialog::mouseDoubleClickEvent(QMouseEvent * event)
+void CompressorControlDialog::mouseDoubleClickEvent(QMouseEvent* event)
 {
-	setAllGuiVisible(!getGuiVisibility());
+	setGuiVisibility(!m_guiVisibility);
 }
 
 
-void CompressorControlDialog::setAllGuiVisible(bool isVisible)
+void CompressorControlDialog::setGuiVisibility(bool isVisible)
 {
 	m_controlsBoxLabel->setVisible(isVisible);
 	m_rmsEnabledLabel->setVisible(isVisible);
@@ -741,7 +739,7 @@ void CompressorControlDialog::setAllGuiVisible(bool isVisible)
 	auditionButton->setVisible(isVisible);
 	feedbackButton->setVisible(isVisible);
 	lookaheadButton->setVisible(isVisible);
-	guiVisibility = isVisible;
+	m_guiVisibility = isVisible;
 }
 
 

--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -698,24 +698,44 @@ void CompressorControlDialog::mouseDoubleClickEvent(QMouseEvent* event)
 
 void CompressorControlDialog::setGuiVisibility(bool isVisible)
 {
+	if (!isVisible)
+	{
+		m_rmsKnob->setVisible(isVisible);
+		m_rmsEnabledLabel->setVisible(isVisible);
+
+		m_lookaheadLengthKnob->setVisible(isVisible);
+		m_lookaheadEnabledLabel->setVisible(isVisible);
+
+		m_blendKnob->setVisible(isVisible);
+		m_blendEnabledLabel->setVisible(isVisible);
+
+		m_ratioKnob->setVisible(isVisible);
+		m_ratioEnabledLabel->setVisible(isVisible);
+	}
+	else
+	{
+		m_rmsKnob->setVisible(!m_controls->m_peakmodeModel.value());
+		m_rmsEnabledLabel->setVisible(!m_controls->m_peakmodeModel.value());
+
+		m_blendKnob->setVisible(m_controls->m_stereoLinkModel.value() == 4);
+		m_blendEnabledLabel->setVisible(m_controls->m_stereoLinkModel.value() == 4);
+
+		m_lookaheadLengthKnob->setVisible(m_controls->m_lookaheadModel.value());
+		m_lookaheadEnabledLabel->setVisible(m_controls->m_lookaheadModel.value());
+
+		m_ratioKnob->setVisible(!m_controls->m_limiterModel.value());
+		m_ratioEnabledLabel->setVisible(!m_controls->m_limiterModel.value());
+	}
 	m_controlsBoxLabel->setVisible(isVisible);
-	m_rmsEnabledLabel->setVisible(isVisible);
-	m_blendEnabledLabel->setVisible(isVisible);
-	m_lookaheadEnabledLabel->setVisible(isVisible);
-	m_ratioEnabledLabel->setVisible(isVisible);
 	m_thresholdKnob->setVisible(isVisible);
-	m_ratioKnob->setVisible(isVisible);
 	m_attackKnob->setVisible(isVisible);
 	m_releaseKnob->setVisible(isVisible);
 	m_kneeKnob->setVisible(isVisible);
 	m_rangeKnob->setVisible(isVisible);
-	m_lookaheadLengthKnob->setVisible(isVisible);
 	m_holdKnob->setVisible(isVisible);
-	m_rmsKnob->setVisible(isVisible);
 	m_inBalanceKnob->setVisible(isVisible);
 	m_outBalanceKnob->setVisible(isVisible);
 	m_stereoBalanceKnob->setVisible(isVisible);
-	m_blendKnob->setVisible(isVisible);
 	m_tiltKnob->setVisible(isVisible);
 	m_tiltFreqKnob->setVisible(isVisible);
 	m_mixKnob->setVisible(isVisible);

--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -310,6 +310,8 @@ CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
 	connect(&m_controls->m_lookaheadModel, SIGNAL(dataChanged()), this, SLOT(lookaheadChanged()));
 	connect(&m_controls->m_limiterModel, SIGNAL(dataChanged()), this, SLOT(limiterChanged()));
 
+	guiVisibility = true;
+
 	m_timeElapsed.start();
 
 	peakmodeChanged();
@@ -687,6 +689,59 @@ void CompressorControlDialog::drawGraph()
 	}
 
 	m_p.end();
+}
+
+
+void CompressorControlDialog::mouseDoubleClickEvent(QMouseEvent * event)
+{
+	setAllGuiVisible(!getGuiVisibility());
+}
+
+
+void CompressorControlDialog::setAllGuiVisible(bool isVisible)
+{
+	m_controlsBoxLabel->setVisible(isVisible);
+	m_rmsEnabledLabel->setVisible(isVisible);
+	m_blendEnabledLabel->setVisible(isVisible);
+	m_lookaheadEnabledLabel->setVisible(isVisible);
+	m_ratioEnabledLabel->setVisible(isVisible);
+	m_thresholdKnob->setVisible(isVisible);
+	m_ratioKnob->setVisible(isVisible);
+	m_attackKnob->setVisible(isVisible);
+	m_releaseKnob->setVisible(isVisible);
+	m_kneeKnob->setVisible(isVisible);
+	m_rangeKnob->setVisible(isVisible);
+	m_lookaheadLengthKnob->setVisible(isVisible);
+	m_holdKnob->setVisible(isVisible);
+	m_rmsKnob->setVisible(isVisible);
+	m_inBalanceKnob->setVisible(isVisible);
+	m_outBalanceKnob->setVisible(isVisible);
+	m_stereoBalanceKnob->setVisible(isVisible);
+	m_blendKnob->setVisible(isVisible);
+	m_tiltKnob->setVisible(isVisible);
+	m_tiltFreqKnob->setVisible(isVisible);
+	m_mixKnob->setVisible(isVisible);
+	m_autoAttackKnob->setVisible(isVisible);
+	m_autoReleaseKnob->setVisible(isVisible);
+	m_outFader->setVisible(isVisible);
+	m_inFader->setVisible(isVisible);
+	rmsButton->setVisible(isVisible);
+	peakButton->setVisible(isVisible);
+	rmsPeakGroup->setVisible(isVisible);
+	leftRightButton->setVisible(isVisible);
+	midSideButton->setVisible(isVisible);
+	compressButton->setVisible(isVisible);
+	limitButton->setVisible(isVisible);
+	unlinkedButton->setVisible(isVisible);
+	maximumButton->setVisible(isVisible);
+	averageButton->setVisible(isVisible);
+	minimumButton->setVisible(isVisible);
+	blendButton->setVisible(isVisible);
+	autoMakeupButton->setVisible(isVisible);
+	auditionButton->setVisible(isVisible);
+	feedbackButton->setVisible(isVisible);
+	lookaheadButton->setVisible(isVisible);
+	guiVisibility = isVisible;
 }
 
 

--- a/plugins/Compressor/CompressorControlDialog.h
+++ b/plugins/Compressor/CompressorControlDialog.h
@@ -108,6 +108,12 @@ private:
 	void drawKneePixmap2();
 	void drawMiscPixmap();
 	void drawGraph();
+	void mouseDoubleClickEvent(QMouseEvent *event) override;
+	inline bool getGuiVisibility()
+	{
+		return guiVisibility;
+	}
+	void setAllGuiVisible(bool isVisible);
 
 	QPainter m_p;
 
@@ -213,6 +219,8 @@ private:
 	PixmapButton * auditionButton;
 	PixmapButton * feedbackButton;
 	PixmapButton * lookaheadButton;
+
+	bool guiVisibility;
 
 	QElapsedTimer m_timeElapsed;
 	int m_timeSinceLastUpdate = 0;

--- a/plugins/Compressor/CompressorControlDialog.h
+++ b/plugins/Compressor/CompressorControlDialog.h
@@ -108,12 +108,8 @@ private:
 	void drawKneePixmap2();
 	void drawMiscPixmap();
 	void drawGraph();
-	void mouseDoubleClickEvent(QMouseEvent *event) override;
-	inline bool getGuiVisibility()
-	{
-		return guiVisibility;
-	}
-	void setAllGuiVisible(bool isVisible);
+	void mouseDoubleClickEvent(QMouseEvent* event) override;
+	void setGuiVisibility(bool isVisible);
 
 	QPainter m_p;
 
@@ -220,7 +216,7 @@ private:
 	PixmapButton * feedbackButton;
 	PixmapButton * lookaheadButton;
 
-	bool guiVisibility;
+	bool m_guiVisibility = true;
 
 	QElapsedTimer m_timeElapsed;
 	int m_timeSinceLastUpdate = 0;


### PR DESCRIPTION
Closes #6830

With this change, if you double click in the compressor plugin/effect then the controls will be hidden similarly to the Equalizer.