### PR TITLE
Update Linux CI to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,7 @@ concurrency:
 jobs:
   linux:
     name: linux
-    runs-on: ubuntu-latest
-    container: lmmsci/linux.gcc:20.04
+    runs-on: ubuntu-20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
@@ -18,12 +17,6 @@ jobs:
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j2
     steps:
-      - name: Update and configure Git
-        run: |
-          add-apt-repository ppa:git-core/ppa
-          apt-get update
-          apt-get --yes install git
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check out
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,72 +24,72 @@ jobs:
           submodules: recursive
       - name: Install dependencies - part 1
         run: |
-          apt-get update && apt-get install -y    \
-          --no-install-recommends                 \
-          ca-certificates                         \
-          software-properties-common              \
-          make                                    \
-          libc6-dev                               \
-          cmake                                   \
-          git                                     \
-          ssh-client                              \
-          ccache                                  \
-          perl                                    \
-          libxml2-utils                           \
-          libxml-perl                             \
-          liblist-moreutils-perl                  \
-          && rm -rf /var/lib/apt/lists/*
+          sudo apt-get update && sudo apt-get install -y \
+              --no-install-recommends                    \
+              ca-certificates                            \
+              software-properties-common                 \
+              make                                       \
+              libc6-dev                                  \
+              cmake                                      \
+              git                                        \
+              ssh-client                                 \
+              ccache                                     \
+              perl                                       \
+              libxml2-utils                              \
+              libxml-perl                                \
+              liblist-moreutils-perl                     \
+          && sudo rm -rf /var/lib/apt/lists/*
       - name: Install dependencies - part 2
         run: |
-          apt-get update && apt-get install -y    \
-          qt5-default qttools5-dev-tools          \
-          && rm -rf /var/lib/apt/lists/*
+          sudo apt-get update && sudo apt-get install -y \
+              qt5-default qttools5-dev-tools             \
+          && sudo rm -rf /var/lib/apt/lists/*
       - name: Install dependencies - part 3
         run: |
-          dpkg --add-architecture i386
-          apt-get update -qq &&       \
-          apt-get install -y          \
-          --no-install-recommends     \
-              ccache                  \
-              fluid                   \
-              libasound2-dev          \
-              libc6-dev-i386          \
-              libfftw3-dev            \
-              libfltk1.3-dev          \
-              libfluidsynth-dev       \
-              libgig-dev              \
-              libjack-jackd2-dev      \
-              libmp3lame-dev          \
-              liblilv-dev             \
-              libogg-dev              \
-              libsamplerate0-dev      \
-              libsdl-dev              \
-              libsndfile1-dev         \
-              libstk0-dev             \
-              libvorbis-dev           \
-              libxft-dev              \
-              libxinerama-dev         \
-              lv2-dev                 \
-              portaudio19-dev         \
-              gcc-multilib            \
-              g++-multilib            \
-              qt5-default             \
-              qtbase5-dev             \
-              libqt5x11extras5-dev    \
-              libxcb-keysyms1-dev     \
-              libxcb-util0-dev        \
-              qtbase5-private-dev     \
-              && rm -rf /var/lib/apt/lists/*
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq &&     \
+          sudo apt-get install -y        \
+              --no-install-recommends    \
+              ccache                     \
+              fluid                      \
+              libasound2-dev             \
+              libc6-dev-i386             \
+              libfftw3-dev               \
+              libfltk1.3-dev             \
+              libfluidsynth-dev          \
+              libgig-dev                 \
+              libjack-jackd2-dev         \
+              libmp3lame-dev             \
+              liblilv-dev                \
+              libogg-dev                 \
+              libsamplerate0-dev         \
+              libsdl-dev                 \
+              libsndfile1-dev            \
+              libstk0-dev                \
+              libvorbis-dev              \
+              libxft-dev                 \
+              libxinerama-dev            \
+              lv2-dev                    \
+              portaudio19-dev            \
+              gcc-multilib               \
+              g++-multilib               \
+              qt5-default                \
+              qtbase5-dev                \
+              libqt5x11extras5-dev       \
+              libxcb-keysyms1-dev        \
+              libxcb-util0-dev           \
+              qtbase5-private-dev        \
+          && sudo rm -rf /var/lib/apt/lists/*
       - name: Install dependencies - part 4
         run: |
-          apt-get update && apt-get install -y    \
-          stk                                     \
-          wget                                    \
-          file                                    \
-          libwine-dev                             \
-          libwine-dev:i386                        \
-          wine64-tools                            \
-          && rm -rf /var/lib/apt/lists/*
+          sudo apt-get update && sudo apt-get install -y \
+              stk                                        \
+              wget                                       \
+              file                                       \
+              libwine-dev                                \
+              libwine-dev:i386                           \
+              wine64-tools                               \
+          && sudo rm -rf /var/lib/apt/lists/*
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,74 +22,54 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install dependencies - part 1
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-              --no-install-recommends                    \
-              ca-certificates                            \
-              software-properties-common                 \
-              make                                       \
-              libc6-dev                                  \
-              cmake                                      \
-              git                                        \
-              ssh-client                                 \
-              ccache                                     \
-              perl                                       \
-              libxml2-utils                              \
-              libxml-perl                                \
-              liblist-moreutils-perl                     \
-          && sudo rm -rf /var/lib/apt/lists/*
-      - name: Install dependencies - part 2
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-              qt5-default qttools5-dev-tools             \
-          && sudo rm -rf /var/lib/apt/lists/*
-      - name: Install dependencies - part 3
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update -qq &&     \
-          sudo apt-get install -y        \
-              --no-install-recommends    \
-              ccache                     \
-              fluid                      \
-              libasound2-dev             \
-              libc6-dev-i386             \
-              libfftw3-dev               \
-              libfltk1.3-dev             \
-              libfluidsynth-dev          \
-              libgig-dev                 \
-              libjack-jackd2-dev         \
-              libmp3lame-dev             \
-              liblilv-dev                \
-              libogg-dev                 \
-              libsamplerate0-dev         \
-              libsdl-dev                 \
-              libsndfile1-dev            \
-              libstk0-dev                \
-              libvorbis-dev              \
-              libxft-dev                 \
-              libxinerama-dev            \
-              lv2-dev                    \
-              portaudio19-dev            \
-              gcc-multilib               \
-              g++-multilib               \
-              qt5-default                \
-              qtbase5-dev                \
-              libqt5x11extras5-dev       \
-              libxcb-keysyms1-dev        \
-              libxcb-util0-dev           \
-              qtbase5-private-dev        \
-              libx11-xcb-dev             \
-          && sudo rm -rf /var/lib/apt/lists/*
-      - name: Install dependencies - part 4
-        run: |
-          sudo apt-get update && sudo apt-get install -y \
-              stk                                        \
-              wget                                       \
-              file                                       \
-              libwine-dev                                \
-              wine64-tools                               \
-          && sudo rm -rf /var/lib/apt/lists/*
+      - name: Set up dpkg architecture
+        run: sudo dpkg --add-architecture i386
+      - name: Install dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: >
+            ca-certificates
+            software-properties-common
+            libc6-dev
+            ccache
+            libxml2-utils
+            libxml-perl
+            liblist-moreutils-perl
+            qt5-default
+            qttools5-dev-tools
+            fluid
+            libasound2-dev
+            libc6-dev-i386
+            libfftw3-dev
+            libfltk1.3-dev
+            libfluidsynth-dev
+            libgig-dev
+            libjack-jackd2-dev
+            libmp3lame-dev
+            liblilv-dev
+            libogg-dev
+            libsamplerate0-dev
+            libsdl-dev
+            libsndfile1-dev
+            libstk0-dev
+            libvorbis-dev
+            libxft-dev
+            libxinerama-dev
+            lv2-dev
+            portaudio19-dev
+            gcc-multilib
+            g++-multilib
+            qt5-default
+            qtbase5-dev
+            libqt5x11extras5-dev
+            libxcb-keysyms1-dev
+            libxcb-util0-dev
+            qtbase5-private-dev
+            libx11-xcb-dev
+            stk
+            libwine-dev
+            wine64-tools
+          version: 1.0
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           echo "[ccache config]"
           ccache --show-config
           echo "[ccache stats]"
-          ccache --show-stats --verbose
+          ccache --show-stats
         env:
           CCACHE_MAXSIZE: 500M
   macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,9 @@ jobs:
         run: |
           ccache --cleanup
           echo "[ccache config]"
-          ccache --print-config
+          ccache --show-config
           echo "[ccache stats]"
-          ccache --show-stats
+          ccache --show-stats --verbose
         env:
           CCACHE_MAXSIZE: 500M
   macos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,74 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Install dependencies - part 1
+        run: |
+          apt-get update && apt-get install -y    \
+          --no-install-recommends                 \
+          ca-certificates                         \
+          software-properties-common              \
+          make                                    \
+          libc6-dev                               \
+          cmake                                   \
+          git                                     \
+          ssh-client                              \
+          ccache                                  \
+          perl                                    \
+          libxml2-utils                           \
+          libxml-perl                             \
+          liblist-moreutils-perl                  \
+          && rm -rf /var/lib/apt/lists/*
+      - name: Install dependencies - part 2
+        run: |
+          apt-get update && apt-get install -y    \
+          qt5-default qttools5-dev-tools          \
+          && rm -rf /var/lib/apt/lists/*
+      - name: Install dependencies - part 3
+        run: |
+          dpkg --add-architecture i386
+          apt-get update -qq &&       \
+          apt-get install -y          \
+          --no-install-recommends     \
+              ccache                  \
+              fluid                   \
+              libasound2-dev          \
+              libc6-dev-i386          \
+              libfftw3-dev            \
+              libfltk1.3-dev          \
+              libfluidsynth-dev       \
+              libgig-dev              \
+              libjack-jackd2-dev      \
+              libmp3lame-dev          \
+              liblilv-dev             \
+              libogg-dev              \
+              libsamplerate0-dev      \
+              libsdl-dev              \
+              libsndfile1-dev         \
+              libstk0-dev             \
+              libvorbis-dev           \
+              libxft-dev              \
+              libxinerama-dev         \
+              lv2-dev                 \
+              portaudio19-dev         \
+              gcc-multilib            \
+              g++-multilib            \
+              qt5-default             \
+              qtbase5-dev             \
+              libqt5x11extras5-dev    \
+              libxcb-keysyms1-dev     \
+              libxcb-util0-dev        \
+              qtbase5-private-dev     \
+              && rm -rf /var/lib/apt/lists/*
+      - name: Install dependencies - part 4
+      - run: |
+          apt-get update && apt-get install -y    \
+          stk                                     \
+          wget                                    \
+          file									                  \
+          libwine-dev                             \
+          libwine-dev:i386                        \
+          wine64-tools                            \
+          && rm -rf /var/lib/apt/lists/*
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
   linux:
     name: linux
     runs-on: ubuntu-latest
-    container: lmmsci/linux.gcc:18.04
+    container: lmmsci/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,6 @@ jobs:
               wget                                       \
               file                                       \
               libwine-dev                                \
-              libwine-dev:i386                           \
               wine64-tools                               \
           && sudo rm -rf /var/lib/apt/lists/*
       - name: Cache ccache data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,11 +81,11 @@ jobs:
               qtbase5-private-dev     \
               && rm -rf /var/lib/apt/lists/*
       - name: Install dependencies - part 4
-      - run: |
+        run: |
           apt-get update && apt-get install -y    \
           stk                                     \
           wget                                    \
-          file									                  \
+          file                                    \
           libwine-dev                             \
           libwine-dev:i386                        \
           wine64-tools                            \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
               libxcb-keysyms1-dev        \
               libxcb-util0-dev           \
               qtbase5-private-dev        \
+              libx11-xcb-dev             \
           && sudo rm -rf /var/lib/apt/lists/*
       - name: Install dependencies - part 4
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,11 @@ jobs:
   linux:
     name: linux
     runs-on: ubuntu-latest
-    container: ghcr.io/lmms/linux.gcc:20.04
+    container:
+      image: ghcr.io/lmms/linux.gcc:20.04
+      credentials:
+       username: ${{ github.actor }}
+       password: ${{ secrets.github_token }}
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ concurrency:
 jobs:
   linux:
     name: linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: ghcr.io/lmms/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
@@ -23,90 +24,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Print versions
-        run: |
-          apt-get --version
-          dpkg --version
-      - name: Print all packages
-        run: dpkg -l
-      - name: Checksum
-        run: |
-          sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get clean
-          apt-get download libwine-dev:i386
-          md5sum libwine-dev_*_i386.deb
-          apt-get download libwine-dev:amd64
-          md5sum libwine-dev_*_amd64.deb
-      - name: diff
-        run: |
-          dpkg-deb -R libwine-dev_*amd64.deb tmp_amd64/
-          dpkg-deb -R libwine-dev_*i386.deb tmp_i386/
-          diff -r tmp_amd64/ tmp_i386/ >&2
-      - name: Install wine - part 1
-        run: >
-          sudo dpkg --add-architecture i386 &&
-          sudo apt-get update &&
-          sudo apt-get install aptitude --yes &&
-          sudo aptitude install --safe-resolver -y
-          libwine-dev:amd64
-          libwine-dev:i386
-      - name: Print info - 1
-        run: |
-          lsb_release -a
-          dpkg -l | grep wine
-          dpkg-query -s libwine-dev:amd64
-          dpkg-query -s libwine-dev:i386
-      - name: Install wine - part 2
-        run: >
-          sudo aptitude install --safe-resolver -y
-          g++-multilib
-          gcc-multilib
-          libc6-dev
-          libc6-dev-i386
-          wine64-tools
-      - name: Print info - 2
-        run: |
-          dpkg -l | grep wine
-          dpkg-query -s libwine-dev:amd64
-          dpkg-query -s libwine-dev:i386
-      - name: Install dependencies
-        run: >
-          sudo apt-get install --yes
-          ccache
-          libasound2-dev
-          libfftw3-dev
-          libfltk1.3-dev
-          libfluidsynth-dev
-          libgig-dev
-          libjack-jackd2-dev
-          liblilv-dev
-          liblist-moreutils-perl
-          libmp3lame-dev
-          libogg-dev
-          libqt5x11extras5-dev
-          libsamplerate0-dev
-          libsdl2-dev
-          libsndfile1-dev
-          libstk0-dev
-          libvorbis-dev
-          libwine-dev
-          libwine-dev:i386
-          libx11-xcb-dev
-          libxcb-keysyms1-dev
-          libxcb-util0-dev
-          libxft-dev
-          libxinerama-dev
-          libxml-perl
-          libxml2-utils
-          lv2-dev
-          portaudio19-dev
-          qt5-qmake
-          qtbase5-dev
-          qtbase5-dev-tools
-          qtbase5-private-dev
-          qttools5-dev-tools
-          stk
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,60 +16,97 @@ jobs:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j2
+      DEBIAN_FRONTEND: noninteractive
     steps:
       - name: Check out
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Set up dpkg architecture
-        run: sudo dpkg --add-architecture i386
+      - name: Print versions
+        run: |
+          apt-get --version
+          dpkg --version
+      - name: Print all packages
+        run: dpkg -l
+      - name: Checksum
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get clean
+          apt-get download libwine-dev:i386
+          md5sum libwine-dev_*_i386.deb
+          apt-get download libwine-dev:amd64
+          md5sum libwine-dev_*_amd64.deb
+      - name: diff
+        run: |
+          dpkg-deb -R libwine-dev_*amd64.deb tmp_amd64/
+          dpkg-deb -R libwine-dev_*i386.deb tmp_i386/
+          diff -r tmp_amd64/ tmp_i386/ >&2
+      - name: Install wine - part 1
+        run: >
+          sudo dpkg --add-architecture i386 &&
+          sudo apt-get update &&
+          sudo apt-get install aptitude --yes &&
+          sudo aptitude install --safe-resolver -y
+          libwine-dev:amd64
+          libwine-dev:i386
+      - name: Print info - 1
+        run: |
+          lsb_release -a
+          dpkg -l | grep wine
+          dpkg-query -s libwine-dev:amd64
+          dpkg-query -s libwine-dev:i386
+      - name: Install wine - part 2
+        run: >
+          sudo aptitude install --safe-resolver -y
+          g++-multilib
+          gcc-multilib
+          libc6-dev
+          libc6-dev-i386
+          wine64-tools
+      - name: Print info - 2
+        run: |
+          dpkg -l | grep wine
+          dpkg-query -s libwine-dev:amd64
+          dpkg-query -s libwine-dev:i386
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: >
-            ca-certificates
-            software-properties-common
-            libc6-dev
-            ccache
-            libxml2-utils
-            libxml-perl
-            liblist-moreutils-perl
-            qt5-default
-            qttools5-dev-tools
-            fluid
-            libasound2-dev
-            libc6-dev-i386
-            libfftw3-dev
-            libfltk1.3-dev
-            libfluidsynth-dev
-            libgig-dev
-            libjack-jackd2-dev
-            libmp3lame-dev
-            liblilv-dev
-            libogg-dev
-            libsamplerate0-dev
-            libsdl-dev
-            libsndfile1-dev
-            libstk0-dev
-            libvorbis-dev
-            libxft-dev
-            libxinerama-dev
-            lv2-dev
-            portaudio19-dev
-            gcc-multilib
-            g++-multilib
-            qt5-default
-            qtbase5-dev
-            libqt5x11extras5-dev
-            libxcb-keysyms1-dev
-            libxcb-util0-dev
-            qtbase5-private-dev
-            libx11-xcb-dev
-            stk
-            libwine-dev
-            wine64-tools
-          version: 1.0
+        run: >
+          sudo apt-get install --yes
+          ccache
+          libasound2-dev
+          libfftw3-dev
+          libfltk1.3-dev
+          libfluidsynth-dev
+          libgig-dev
+          libjack-jackd2-dev
+          liblilv-dev
+          liblist-moreutils-perl
+          libmp3lame-dev
+          libogg-dev
+          libqt5x11extras5-dev
+          libsamplerate0-dev
+          libsdl2-dev
+          libsndfile1-dev
+          libstk0-dev
+          libvorbis-dev
+          libwine-dev
+          libwine-dev:i386
+          libx11-xcb-dev
+          libxcb-keysyms1-dev
+          libxcb-util0-dev
+          libxft-dev
+          libxinerama-dev
+          libxml-perl
+          libxml2-utils
+          lv2-dev
+          portaudio19-dev
+          qt5-qmake
+          qtbase5-dev
+          qtbase5-dev-tools
+          qtbase5-private-dev
+          qttools5-dev-tools
+          stk
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,7 @@ jobs:
   linux:
     name: linux
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/lmms/linux.gcc:20.04
-      credentials:
-       username: ${{ github.actor }}
-       password: ${{ secrets.github_token }}
+    container: ghcr.io/lmms/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,7 @@ jobs:
   linux:
     name: linux
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/lmms/linux.gcc:20.04
-      credentials:
-       username: ${{ github.actor }}
-       password: ${{ secrets.github_token }}
+    container: ghcr.io/lmms/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
@@ -21,8 +17,9 @@ jobs:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j2
-      DEBIAN_FRONTEND: noninteractive
     steps:
+      - name: Configure git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check out
         uses: actions/checkout@v3
         with:

--- a/plugins/LadspaEffect/calf/CMakeLists.txt
+++ b/plugins/LadspaEffect/calf/CMakeLists.txt
@@ -35,10 +35,12 @@ SET_TARGET_PROPERTIES(veal PROPERTIES PREFIX "")
 TARGET_COMPILE_DEFINITIONS(veal PRIVATE DISABLE_OSC=1)
 
 SET(INLINE_FLAGS "")
+SET(OTHER_FLAGS "")
 IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	SET(INLINE_FLAGS -finline-functions-called-once -finline-limit=80)
+	SET(OTHER_FLAGS -Wno-format-overflow)
 ENDIF()
-target_compile_options(veal PRIVATE -fexceptions -O2 -finline-functions ${INLINE_FLAGS})
+target_compile_options(veal PRIVATE -fexceptions -O2 -finline-functions ${INLINE_FLAGS} ${OTHER_FLAGS})
 
 if(LMMS_BUILD_WIN32)
 	add_custom_command(

--- a/plugins/ZynAddSubFx/CMakeLists.txt
+++ b/plugins/ZynAddSubFx/CMakeLists.txt
@@ -29,7 +29,7 @@ if(NOT MSVC)
 endif()
 
 IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "6.0.0")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-misleading-indentation")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-misleading-indentation -Wno-format-truncation")
 ENDIF()
 
 IF(MINGW_PREFIX)


### PR DESCRIPTION
This PR updates the Linux CI builds to use Ubuntu 20.04 (focal) instead of Ubuntu 18.04 (bionic).

A few changes were needed for a successful build:
- Created an Ubuntu 20.04 Docker image `ghcr.io/lmms/linux.gcc:20.04`
  - Linux packages have migrated from Docker Hub to https://github.com/orgs/lmms/packages
  - Built using the Dockerfiles from https://github.com/LMMS/lmms-ci-docker/pull/15
- Updated the `veal` submodule to the latest commit on the default `ladspa` branch
  - Fixed [an error](https://github.com/messmerd/lmms/actions/runs/7094168856/job/19308965870) when catching a polymorphic type with GCC 9. See: https://github.com/LMMS/veal/commit/0ae9287dd75a86bbcdce7d1692f0687ef03720e2  
- Added GCC flag `-Wno-format-truncation` for ZynAddSubFx build.
  - See the [build failure](https://github.com/messmerd/lmms/actions/runs/7094584994/job/19310101751) which prompted this.
- Added GCC flag `-Wno-format-overflow` for calf/veal build.
  - See the [build failure](https://github.com/messmerd/lmms/actions/runs/7094308136/job/19309349759) which prompted this.

Benefits:
- Updates GCC from 7.4 to 9.3, which enables support for `std::filesystem` in all LMMS CI build runners except for MinGW, taking us one step closer to permitting its use in LMMS code. Once MSVC builds fully replace MinGW, or if the MinGW builds are updated to Ubuntu 20.04, `std::filesystem` will be usable.
- Updates Qt from 5.9.5 to 5.12.8.
- Updates SDL from SDL 1.2.15 to SDL 2.0.10.
- Updates fluidsynth from 1.1.9 to 2.1.1, enabling per-note panning for SF2.
- Can now use short-style LV2 header paths in #6990
- ...

Closes #6993
