### PR TITLE
Fix floating point exception in Spectrum Analyzer

### DIFF
--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -41,6 +41,9 @@
 #include "LocklessRingBuffer.h"
 #include "SaControls.h"
 
+#include <cassert>
+#include <limits>
+
 namespace lmms
 {
 
@@ -650,7 +653,8 @@ float SaProcessor::ampToYPixel(float amplitude, unsigned int height) const
 	if (m_controls->m_logYModel.value())
 	{
 		// logarithmic scale: convert linear amplitude to dB (relative to 1.0)
-		float amplitude_dB = 10 * log10(amplitude);
+		assert (amplitude >= 0);
+		float amplitude_dB = 10 * log10(amplitude == 0 ? std::numeric_limits<float>::min() : amplitude);
 		if (amplitude_dB < getAmpRangeMin())
 		{
 			return height;

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -654,8 +654,7 @@ float SaProcessor::ampToYPixel(float amplitude, unsigned int height) const
 	{
 		// logarithmic scale: convert linear amplitude to dB (relative to 1.0)
 		assert (amplitude >= 0);
-		const float minNonZeroAmplitude = std::numeric_limits<float>::min();
-		float amplitude_dB = 10 * std::log10(std::max(amplitude, minNonZeroAmplitude));
+		float amplitude_dB = 10 * std::log10(std::max(amplitude, std::numeric_limits<float>::min()));
 		if (amplitude_dB < getAmpRangeMin())
 		{
 			return height;

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -654,7 +654,8 @@ float SaProcessor::ampToYPixel(float amplitude, unsigned int height) const
 	{
 		// logarithmic scale: convert linear amplitude to dB (relative to 1.0)
 		assert (amplitude >= 0);
-		float amplitude_dB = 10 * log10(amplitude == 0 ? std::numeric_limits<float>::min() : amplitude);
+		const float minNonZeroAmplitude = std::numeric_limits<float>::min();
+		float amplitude_dB = 10 * std::log10(std::max(amplitude, minNonZeroAmplitude));
 		if (amplitude_dB < getAmpRangeMin())
 		{
 			return height;


### PR DESCRIPTION
Fix a floating point exception in the Spectrum Analyzer which occurs if the amplitude is 0. The amplitude is used in the calculation of a logarithm which is not defined for values smaller or equal to 0.

The fix is to replace a value of 0 with the minimum positive float value. Negative values are not handled because it seems that only values greater or equal to 0 are fed into the method. This assumption is asserted in case this ever changes.

This issue is somewhat related to #7014.