### PR TITLE
Fix minimum size of LADSPA dialogs (#6982)

### DIFF
--- a/plugins/LadspaEffect/LadspaMatrixControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaMatrixControlDialog.cpp
@@ -41,9 +41,6 @@
 #include "LadspaControlView.h"
 #include "LedCheckBox.h"
 
-#include "GuiApplication.h"
-#include "MainWindow.h"
-
 
 namespace lmms::gui
 {
@@ -205,20 +202,6 @@ void LadspaMatrixControlDialog::updateEffectView(LadspaControls * ladspaControls
 	// Make sure that the horizontal scroll bar does not show
 	// From: https://forum.qt.io/topic/13374/solved-qscrollarea-vertical-scroll-only/4
 	m_scrollArea->setMinimumWidth(matrixWidget->minimumSizeHint().width() + m_scrollArea->verticalScrollBar()->width());
-
-
-	// Make sure that the widget is shown without a scrollbar whenever possible
-	// If the widget fits on the workspace we use the height of the widget as the minimum size of the scroll area.
-	// This will ensure that the scrollbar is not shown initially (and never will be).
-	// If the widget is larger than the workspace then we want it to mostly cover the workspace.
-	//
-	// This is somewhat ugly but I have no idea how to control the initial size of the scroll area otherwise
-	auto const workspaceSize = getGUI()->mainWindow()->workspace()->viewport()->size();
-	// Make sure that we always account a minumum height for the workspace, i.e. that we never compute
-	// something close to 0 if the LMMS window is very small
-	int workspaceHeight = qMax(200, static_cast<int>(workspaceSize.height() * 0.9));
-	int minOfWidgetAndWorkspace = qMin(matrixWidget->minimumSizeHint().height(), workspaceHeight);
-	m_scrollArea->setMinimumHeight(minOfWidgetAndWorkspace);
 
 	if (getChannelCount() > 1 && m_stereoLink != nullptr)
 	{


### PR DESCRIPTION
Remove the code which computes a minimum height for the LADSPA dialogs. It was intended to make sure that no scrollbar is shown in most cases. However, doing so came at the cost that the computed height was the minimum height as well. Therefore the dialogs took a lot of space on low-res displays and could not be made smaller.

After the removal the behavior is still sane. Small dialogs are shown in full and dialogs which are larger, e.g. "Calf Equalizer 12 Band LADSPA", seem to be sized around half the height of the workspace and show scrollbars.