### PR TITLE
MSVC - Remove the unnecessary terminal instance on launch.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,15 @@ GENERATE_EXPORT_HEADER(lmmsobjs
 	BASE_NAME lmms
 )
 
-ADD_EXECUTABLE(lmms
+IF(MSVC)
+	# Win32 flag needed to remove the unnecessary terminal
+	# instance popping up on msvc builds
+	SET(WIN32_FLAG "WIN32")
+ELSE()
+	SET(WIN32_FLAG "")
+ENDIF()
+
+ADD_EXECUTABLE(lmms ${WIN32_FLAG}
 	core/main.cpp
 	$<TARGET_OBJECTS:lmmsobjs>
 	"${WINRC}"


### PR DESCRIPTION
There was a missing flag to be included in msvc builds. I set it up so that the terminal opening gets suppressed.