### PR TITLE
Fix LOMM crossovers

### DIFF
--- a/plugins/LOMM/LOMM.h
+++ b/plugins/LOMM/LOMM.h
@@ -73,6 +73,8 @@ private:
 	StereoLinkwitzRiley m_hp1;
 	StereoLinkwitzRiley m_hp2;
 	
+	BasicFilters<2> m_ap;
+	
 	bool m_needsUpdate;
 	float m_coeffPrecalc;
 	


### PR DESCRIPTION
LOMM's crossover filters were added as placeholders at the very beginning of development and I completely forgot to readdress them later on.  The current implementation results in a notch in the frequency spectrum that becomes more audible when the crossover frequencies are closer to each other.  Luckily LOMM's default crossover values are quite far apart, so while this PR absolutely is not backwards-compatible in the slightest, the audible difference should be _relatively_ small in most cases.

Regardless, the current crossover behavior should be considered a major bug, and this PR fixes it.  With these changes, the frequency spectrum is guaranteed to be perfectly flat regardless of the filter crossover frequencies.