### PR TITLE
Fix Editor windows keeping focus after close

### DIFF
--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -148,7 +148,7 @@ void Editor::closeEvent( QCloseEvent * _ce )
 	{
 		hide();
 	}
-	_ce->ignore();
+	_ce->accept();
  }
 
 DropToolBar::DropToolBar(QWidget* parent) : QToolBar(parent)


### PR DESCRIPTION
With the Piano Roll, there's a fairly major bug where pressing space after closing the window quantizes all of the notes that were in it.  Turns out this is because Qt's QCloseEvent is ignored for Editors, causing some of the widgets within them to retain focus even after the window they're in is closed.  This PR accepts QCloseEvents within Editors to fix this.