### PR TITLE
Resizable mixer window

### DIFF
--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -75,7 +75,6 @@ MixerView::MixerView() :
 	//setPalette(pal);
 
 	setAutoFillBackground(true);
-	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
 	setWindowTitle(tr("Mixer"));
 	setWindowIcon(embed::getIconPixmap("mixer"));
@@ -153,7 +152,6 @@ MixerView::MixerView() :
 
 
 	// add the stacked layout for the effect racks of mixer channels
-	m_racksWidget->setFixedHeight(mixerChannelSize.height());
 	ml->addWidget(m_racksWidget);
 
 	setCurrentMixerChannel(m_mixerChannelViews[0]);


### PR DESCRIPTION
Make the mixer window resizable and allow the effects rack to grow. This enables the users a better overview of the effects used.

In practice it looks as follows:

https://github.com/LMMS/lmms/assets/9293269/f1760667-3781-4d7e-9ad4-017956d4a814

Next step would be to allow the mixer strips to resize.