### PR TITLE
Add setSampleRate to BasicFilters and update LOMM allpass sample rate

### DIFF
--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -328,6 +328,12 @@ public:
 		}
 	}
 
+	inline void setSampleRate(float sampleRate)
+	{
+		m_sampleRate = sampleRate;
+		m_sampleRatio = 1.f / m_sampleRate;
+	}
+
 	inline sample_t update( sample_t _in0, ch_cnt_t _chnl )
 	{
 		sample_t out;

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -328,7 +328,7 @@ public:
 		}
 	}
 
-	inline void setSampleRate(float sampleRate)
+	inline void setSampleRate(const sample_rate_t sampleRate)
 	{
 		m_sampleRate = sampleRate;
 		m_sampleRatio = 1.f / m_sampleRate;

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -332,6 +332,10 @@ public:
 	{
 		m_sampleRate = sampleRate;
 		m_sampleRatio = 1.f / m_sampleRate;
+		if (m_subFilter != nullptr)
+		{
+			m_subFilter->setSampleRate(m_sampleRate);
+		}
 	}
 
 	inline sample_t update( sample_t _in0, ch_cnt_t _chnl )

--- a/plugins/LOMM/LOMM.cpp
+++ b/plugins/LOMM/LOMM.cpp
@@ -81,6 +81,7 @@ void LOMMEffect::changeSampleRate()
 	m_lp2.setSampleRate(m_sampleRate);
 	m_hp1.setSampleRate(m_sampleRate);
 	m_hp2.setSampleRate(m_sampleRate);
+	m_ap.setSampleRate(m_sampleRate);
 	
 	m_coeffPrecalc = -2.2f / (m_sampleRate * 0.001f);
 	m_needsUpdate = true;
@@ -97,16 +98,6 @@ void LOMMEffect::changeSampleRate()
 		}
 	}
 }
-
-void LOMMEffect::clearFilterHistories()
-{
-	m_lp1.clearHistory();
-	m_lp2.clearHistory();
-	m_hp1.clearHistory();
-	m_hp2.clearHistory();
-}
-
-
 
 
 bool LOMMEffect::processAudioBuffer(sampleFrame* buf, const fpp_t frames)

--- a/plugins/LOMM/LOMM.h
+++ b/plugins/LOMM/LOMM.h
@@ -52,8 +52,6 @@ public:
 		return &m_lommControls;
 	}
 	
-	void clearFilterHistories();
-	
 	inline float msToCoeff(float ms)
 	{
 		return (ms == 0) ? 0 : exp(m_coeffPrecalc / ms);


### PR DESCRIPTION
Gives LMMS's BasicFilter class the ability to change its sample rate at any time rather than only at startup, and does so with LOMM's allpass.  Also removed an unused function in the plugin while I was at it.