### PR TITLE
Fix crash on subsequent song loads

### DIFF
--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -206,8 +206,11 @@ void MixerView::refreshDisplay()
 	// delete all views and re-add them
 	for (int i = 1; i<m_mixerChannelViews.size(); ++i)
 	{
-		chLayout->removeWidget(m_mixerChannelViews[i]);
-		m_racksLayout->removeWidget(m_mixerChannelViews[i]->m_effectRackView);
+		auto * mixerChannelView = m_mixerChannelViews[i];
+		chLayout->removeWidget(mixerChannelView);
+		m_racksLayout->removeWidget(mixerChannelView->m_effectRackView);
+
+		delete mixerChannelView;
 	}
 	m_channelAreaWidget->adjustSize();
 


### PR DESCRIPTION
Fix a crash that occurs when songs are loaded after each other. The crash only occurs if the "participating" songs have at least one other channel besides the master channel.

The crash occurred because the `MixerChannelViews` were not really deleted in `MixerView::refreshDisplay`. As a consequence the parent child relationship was still given between the `MixerView` and the `MixerChannelView`. When a song was loaded the event queue was evaluated which in turn resulted in the method `Fader::knobPosY` being called on a `Fader` which did not have a model anymore.

Fixes #7046.