### PR TITLE
Fix scaling of PixmapButton in layouts

### DIFF
--- a/include/PixmapButton.h
+++ b/include/PixmapButton.h
@@ -56,6 +56,8 @@ protected:
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
 	void mouseDoubleClickEvent( QMouseEvent * _me ) override;
 
+private:
+	bool isActive() const;
 
 private:
 	QPixmap m_activePixmap;

--- a/src/gui/widgets/PixmapButton.cpp
+++ b/src/gui/widgets/PixmapButton.cpp
@@ -131,11 +131,11 @@ QSize PixmapButton::sizeHint() const
 {
 	if( ( model() != nullptr && model()->value() ) || m_pressed )
 	{
-		return m_activePixmap.size() / devicePixelRatio();
+		return m_activePixmap.size();
 	}
 	else 
 	{
-		return m_inactivePixmap.size() / devicePixelRatio();
+		return m_inactivePixmap.size();
 	}
 }
 

--- a/src/gui/widgets/PixmapButton.cpp
+++ b/src/gui/widgets/PixmapButton.cpp
@@ -50,20 +50,15 @@ PixmapButton::PixmapButton( QWidget * _parent, const QString & _name ) :
 
 
 
-void PixmapButton::paintEvent( QPaintEvent * )
+void PixmapButton::paintEvent(QPaintEvent*)
 {
-	QPainter p( this );
+	QPainter p(this);
 
-	if( ( model() != nullptr && model()->value() ) || m_pressed )
+	QPixmap* pixmapToDraw = isActive() ? &m_activePixmap : &m_inactivePixmap;
+
+	if (!pixmapToDraw->isNull())
 	{
-		if( !m_activePixmap.isNull() )
-		{
-			p.drawPixmap( 0, 0, m_activePixmap );
-		}
-	}
-	else if( !m_inactivePixmap.isNull() )
-	{
-		p.drawPixmap( 0, 0, m_inactivePixmap );
+		p.drawPixmap(0, 0, *pixmapToDraw);
 	}
 }
 
@@ -129,7 +124,7 @@ void PixmapButton::setInactiveGraphic( const QPixmap & _pm, bool _update )
 
 QSize PixmapButton::sizeHint() const
 {
-	if( ( model() != nullptr && model()->value() ) || m_pressed )
+	if (isActive())
 	{
 		return m_activePixmap.size();
 	}
@@ -139,5 +134,10 @@ QSize PixmapButton::sizeHint() const
 	}
 }
 
+
+bool PixmapButton::isActive() const
+{
+	return (model() != nullptr && model()->value()) || m_pressed;
+}
 
 } // namespace lmms::gui


### PR DESCRIPTION
Fix the scaling of `PixmapButton` when used in layouts. In this case `PixmapButton::sizeHint` is queried which used `devicePixelRatio` to divide the size of the active pixmap. As a result the size is always the same in pixels regardless of the scaling factor of the application. This is fixed by removing the calls.

Example: If the scaling factor is 2 then the pixmap will also report twice the size in pixels and hence request more space in layouts, etc. However, if we divide by the device/pixel ratio then the original size of the image/pixmap will be reported and therefore it will be too small in layouts.

The calls to `devicePixelRatio` have been introduced with pull request #4950 (via commit c3b4d51) which replaced the old Spectrum Analyzer. The pixmaps of the Spectrum Analyzer still look good with this change.

Can be tested on any system by building LMMS and then starting it with:
```
QT_SCALE_FACTOR=2 ./lmms
```

Fixes #7052.