### PR TITLE
Fix mixer channel updates on solo/mute

### DIFF
--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -97,7 +97,6 @@ namespace lmms::gui
         void removeUnusedChannels();
         void moveChannelLeft();
         void moveChannelRight();
-	    void toggledMute();
 
     private:
         QString elideName(const QString& name);

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -97,6 +97,7 @@ namespace lmms::gui
         void removeUnusedChannels();
         void moveChannelLeft();
         void moveChannelRight();
+	    void toggledMute();
 
     private:
         QString elideName(const QString& name);

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -111,6 +111,8 @@ private slots:
 private:
 	Mixer* getMixer() const;
 	void updateAllMixerChannels();
+	void connectToSoloAndMute(int channelIndex);
+	void disconnectFromSoloAndMute(int channelIndex);
 
 private:
 	QVector<MixerChannelView*> m_mixerChannelViews;

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -98,7 +98,6 @@ protected:
 private slots:
 	void updateFaders();
 	void toggledSolo();
-	void toggledMute();
 
 private:
 	void updateAllMixerChannels();

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -98,6 +98,7 @@ protected:
 private slots:
 	void updateFaders();
 	void toggledSolo();
+	void toggledMute();
 
 private:
 	void updateAllMixerChannels();

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -98,6 +98,10 @@ protected:
 private slots:
 	void updateFaders();
 	void toggledSolo();
+	void toggledMute();
+
+private:
+	void updateAllMixerChannels();
 
 private:
 	QVector<MixerChannelView*> m_mixerChannelViews;

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -50,7 +50,7 @@ class LMMS_EXPORT MixerView : public QWidget, public ModelView,
 {
 	Q_OBJECT
 public:
-	MixerView();
+	MixerView(Mixer* mixer);
 	void keyPressEvent(QKeyEvent* e) override;
 
 	void saveSettings(QDomDocument& doc, QDomElement& domElement) override;
@@ -124,6 +124,7 @@ private:
 	QWidget* m_channelAreaWidget;
 	QStackedLayout* m_racksLayout;
 	QWidget* m_racksWidget;
+	Mixer* m_mixer;
 
 	void updateMaxChannelSelector();
 

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -97,6 +97,9 @@ protected:
 
 private slots:
 	void updateFaders();
+	// TODO This should be improved. Currently the solo and mute models are connected via
+	// the MixerChannelView's constructor with the MixerView. It would already be an improvement
+	// if the MixerView connected itself to each new MixerChannel that it creates/handles.
 	void toggledSolo();
 	void toggledMute();
 

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -38,6 +38,11 @@
 #include "embed.h"
 #include "EffectRackView.h"
 
+namespace lmms
+{
+	class Mixer;
+}
+
 namespace lmms::gui
 {
 class LMMS_EXPORT MixerView : public QWidget, public ModelView,
@@ -104,6 +109,7 @@ private slots:
 	void toggledMute();
 
 private:
+	Mixer* getMixer() const;
 	void updateAllMixerChannels();
 
 private:

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -148,7 +148,7 @@ GuiApplication::GuiApplication()
 	connect(m_songEditor, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing mixer"));
-	m_mixerView = new MixerView;
+	m_mixerView = new MixerView(Engine::mixer());
 	connect(m_mixerView, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
 
 	displayInitProgress(tr("Preparing controller rack"));

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -104,6 +104,7 @@ namespace lmms::gui
         m_muteButton->setInactiveGraphic(embed::getIconPixmap("led_green"));
         m_muteButton->setCheckable(true);
         m_muteButton->setToolTip(tr("Mute this channel"));
+        connect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, mixerView, &MixerView::toggledMute, Qt::DirectConnection);
 
         m_soloButton = new PixmapButton(this, tr("Solo"));
         m_soloButton->setModel(&mixerChannel->m_soloModel);

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -104,7 +104,7 @@ namespace lmms::gui
         m_muteButton->setInactiveGraphic(embed::getIconPixmap("led_green"));
         m_muteButton->setCheckable(true);
         m_muteButton->setToolTip(tr("Mute this channel"));
-        connect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, this, &MixerChannelView::toggledMute, Qt::DirectConnection);
+        connect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, mixerView, &MixerView::toggledMute, Qt::DirectConnection);
 
         m_soloButton = new PixmapButton(this, tr("Solo"));
         m_soloButton->setModel(&mixerChannel->m_soloModel);
@@ -274,24 +274,11 @@ namespace lmms::gui
 
     void MixerChannelView::setChannelIndex(int index)
     {
-        // First disconnect the signals of the previous mixer channel
-        auto * currentMixerChannel = Engine::mixer()->mixerChannel(m_channelIndex);
-        disconnect(&currentMixerChannel->m_muteModel, &BoolModel::dataChanged, this, &MixerChannelView::toggledMute);
-        disconnect(&currentMixerChannel->m_soloModel, &BoolModel::dataChanged, m_mixerView, &MixerView::toggledSolo);
-
         MixerChannel* mixerChannel = Engine::mixer()->mixerChannel(index);
         m_fader->setModel(&mixerChannel->m_volumeModel);
-
-        auto * muteModel = &mixerChannel->m_muteModel;
-        m_muteButton->setModel(muteModel);
-        connect(muteModel, &BoolModel::dataChanged, this, &MixerChannelView::toggledMute, Qt::DirectConnection);
-
-        auto * soloModel = &mixerChannel->m_soloModel;
-        m_soloButton->setModel(soloModel);
-        connect(soloModel, &BoolModel::dataChanged, m_mixerView, &MixerView::toggledSolo, Qt::DirectConnection);
-
+        m_muteButton->setModel(&mixerChannel->m_muteModel);
+        m_soloButton->setModel(&mixerChannel->m_soloModel);
         m_effectRackView->setModel(&mixerChannel->m_fxChain);
-
         m_channelIndex = index;
     }
 
@@ -448,11 +435,6 @@ namespace lmms::gui
     {
         auto mix = getGUI()->mixerView();
         mix->moveChannelRight(m_channelIndex);
-    }
-
-    void MixerChannelView::toggledMute()
-    {
-        update();
     }
 
     QString MixerChannelView::elideName(const QString& name)

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -104,15 +104,13 @@ namespace lmms::gui
         m_muteButton->setInactiveGraphic(embed::getIconPixmap("led_green"));
         m_muteButton->setCheckable(true);
         m_muteButton->setToolTip(tr("Mute this channel"));
-        connect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, mixerView, &MixerView::toggledMute, Qt::DirectConnection);
 
         m_soloButton = new PixmapButton(this, tr("Solo"));
         m_soloButton->setModel(&mixerChannel->m_soloModel);
         m_soloButton->setActiveGraphic(embed::getIconPixmap("led_red"));
         m_soloButton->setInactiveGraphic(embed::getIconPixmap("led_off"));
         m_soloButton->setCheckable(true);
-        m_soloButton->setToolTip(tr("Solo this channel"));
-        connect(&mixerChannel->m_soloModel, &BoolModel::dataChanged, mixerView, &MixerView::toggledSolo, Qt::DirectConnection);
+        m_soloButton->setToolTip(tr("Solo this channel"));        
 
         QVBoxLayout* soloMuteLayout = new QVBoxLayout();
         soloMuteLayout->setContentsMargins(0, 0, 0, 0);

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -288,6 +288,11 @@ void MixerView::toggledSolo()
 }
 
 
+void MixerView::toggledMute()
+{
+	updateAllMixerChannels();
+}
+
 void MixerView::updateAllMixerChannels()
 {
 	for (int i = 0; i < m_mixerChannelViews.size(); ++i)

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -102,12 +102,12 @@ MixerView::MixerView() :
 
 	// add master channel
 	m_mixerChannelViews.resize(m->numChannels());
-	m_mixerChannelViews[0] = new MixerChannelView(this, this, 0);
+	MixerChannelView * masterView = new MixerChannelView(this, this, 0);
 	connectToSoloAndMute(0);
+	m_mixerChannelViews[0] = masterView;
 
 	m_racksLayout->addWidget(m_mixerChannelViews[0]->m_effectRackView);
 
-	MixerChannelView * masterView = m_mixerChannelViews[0];
 	ml->addWidget(masterView, 0, Qt::AlignTop);
 
 	auto mixerChannelSize = masterView->sizeHint();

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -288,11 +288,6 @@ void MixerView::toggledSolo()
 }
 
 
-void MixerView::toggledMute()
-{
-	updateAllMixerChannels();
-}
-
 void MixerView::updateAllMixerChannels()
 {
 	for (int i = 0; i < m_mixerChannelViews.size(); ++i)

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -52,10 +52,11 @@ namespace lmms::gui
 {
 
 
-MixerView::MixerView() :
+MixerView::MixerView(Mixer* mixer) :
 	QWidget(),
 	ModelView(nullptr, this),
-	SerializingObjectHook()
+	SerializingObjectHook(),
+	m_mixer(mixer)
 {
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
@@ -67,8 +68,7 @@ MixerView::MixerView() :
 	using ::operator|;
 #endif
 
-	Mixer * m = getMixer();
-	m->setHook(this);
+	mixer->setHook(this);
 
 	//QPalette pal = palette();
 	//pal.setColor(QPalette::Window, QColor(72, 76, 88));
@@ -101,7 +101,7 @@ MixerView::MixerView() :
 	m_racksWidget->setLayout(m_racksLayout);
 
 	// add master channel
-	m_mixerChannelViews.resize(m->numChannels());
+	m_mixerChannelViews.resize(mixer->numChannels());
 	MixerChannelView * masterView = new MixerChannelView(this, this, 0);
 	connectToSoloAndMute(0);
 	m_mixerChannelViews[0] = masterView;
@@ -179,7 +179,7 @@ MixerView::MixerView() :
 	parentWidget()->move(5, 310);
 
 	// we want to receive dataChanged-signals in order to update
-	setModel(m);
+	setModel(mixer);
 }
 
 
@@ -302,7 +302,7 @@ void MixerView::toggledMute()
 
 Mixer* MixerView::getMixer() const
 {
-	return Engine::mixer();
+	return m_mixer;
 }
 
 void MixerView::updateAllMixerChannels()

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -209,14 +209,14 @@ void MixerView::refreshDisplay()
 	// delete all views and re-add them
 	for (int i = 1; i<m_mixerChannelViews.size(); ++i)
 	{
+		// First disconnect from the solo/mute models.
+		disconnectFromSoloAndMute(i);
+
 		auto * mixerChannelView = m_mixerChannelViews[i];
 		chLayout->removeWidget(mixerChannelView);
 		m_racksLayout->removeWidget(mixerChannelView->m_effectRackView);
 
 		delete mixerChannelView;
-
-		// We are only deleting the views but not the actual mixer channels.
-		// Therefore we do not have to disconnect from the solo/mute models.
 	}
 	m_channelAreaWidget->adjustSize();
 
@@ -225,7 +225,8 @@ void MixerView::refreshDisplay()
 	for (int i = 1; i < m_mixerChannelViews.size(); ++i)
 	{
 		m_mixerChannelViews[i] = new MixerChannelView(m_channelAreaWidget, this, i);
-		// We are readding the views for existing channels so we do not have to connect to solo/mute here
+		connectToSoloAndMute(i);
+
 		chLayout->addWidget(m_mixerChannelViews[i]);
 		m_racksLayout->addWidget(m_mixerChannelViews[i]->m_effectRackView);
 	}

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -283,6 +283,22 @@ void MixerView::loadSettings(const QDomElement& domElement)
 void MixerView::toggledSolo()
 {
 	Engine::mixer()->toggledSolo();
+
+	updateAllMixerChannels();
+}
+
+
+void MixerView::toggledMute()
+{
+	updateAllMixerChannels();
+}
+
+void MixerView::updateAllMixerChannels()
+{
+	for (int i = 0; i < m_mixerChannelViews.size(); ++i)
+	{
+		m_mixerChannelViews[i]->update();
+	}
 }
 
 


### PR DESCRIPTION
Fix the update of the mixer channels whenever a channel is soloed or muted.

The solution is rather "brutal" as it updates all mixer channel views when one of the models changes.

Introduce private helper method `MixerView::updateAllMixerChannels`. It calls the `update` method on each `MixerChannelView` so that they can get repainted.

Call `updateAllMixerChannels` at the end of the existing method `toggledSolo`.

Introduce a new method `MixerView::toggledMute` which is called whenever the mute model of a channel changes. It also updates all mixer channels.

Fixes #7054.