### PR TITLE
Fix sliding of waveform when drawing sample in reverse

### DIFF
--- a/include/Sample.h
+++ b/include/Sample.h
@@ -96,7 +96,7 @@ public:
 	auto sampleDuration() const -> std::chrono::milliseconds;
 	auto sampleFile() const -> const QString& { return m_buffer->audioFile(); }
 	auto sampleRate() const -> int { return m_buffer->sampleRate(); }
-	auto sampleSize() const -> int { return m_buffer->size(); }
+	auto sampleSize() const -> size_t { return m_buffer->size(); }
 
 	auto toBase64() const -> QString { return m_buffer->toBase64(); }
 

--- a/include/SampleWaveform.h
+++ b/include/SampleWaveform.h
@@ -34,7 +34,15 @@ namespace lmms::gui {
 class LMMS_EXPORT SampleWaveform
 {
 public:
-	static void visualize(const Sample& sample, QPainter& p, const QRect& dr, int fromFrame = 0, int toFrame = 0);
+	struct Parameters
+	{
+		const sampleFrame* buffer;
+		size_t size;
+		float amplification;
+		bool reversed;
+	};
+
+	static void visualize(Parameters parameters, QPainter& painter, const QRect& rect);
 };
 } // namespace lmms::gui
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -719,7 +719,7 @@ void AudioFileProcessorWaveView::updateSampleRange()
 	{
 		const f_cnt_t marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
 		m_from = qMax(0, m_sample->startFrame() - marging);
-		m_to = qMin(m_sample->endFrame() + marging, m_sample->sampleSize());
+		m_to = qMin<size_t>(m_sample->endFrame() + marging, m_sample->sampleSize());
 	}
 }
 
@@ -1014,7 +1014,11 @@ void AudioFileProcessorWaveView::updateGraph()
 	m_graph.fill( Qt::transparent );
 	QPainter p( &m_graph );
 	p.setPen( QColor( 255, 255, 255 ) );
-	SampleWaveform::visualize(*m_sample, p, QRect(0, 0, m_graph.width(), m_graph.height()), m_from, m_to);
+
+	const auto rect = QRect{0, 0, m_graph.width(), m_graph.height()};
+	const auto waveform = SampleWaveform::Parameters{
+		m_sample->data() + m_from, static_cast<size_t>(m_to - m_from), m_sample->amplification(), m_sample->reversed()};
+	SampleWaveform::visualize(waveform, p, rect);
 }
 
 
@@ -1076,8 +1080,8 @@ void AudioFileProcessorWaveView::slide( int _px )
 		step = -step;
 	}
 
-	f_cnt_t step_from = qBound(0, m_from + step, m_sample->sampleSize()) - m_from;
-	f_cnt_t step_to = qBound(m_from + 1, m_to + step, m_sample->sampleSize()) - m_to;
+	f_cnt_t step_from = qBound<size_t>(0, m_from + step, m_sample->sampleSize()) - m_from;
+	f_cnt_t step_to = qBound<size_t>(m_from + 1, m_to + step, m_sample->sampleSize()) - m_to;
 
 	step = qAbs( step_from ) < qAbs( step_to ) ? step_from : step_to;
 

--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -147,7 +147,7 @@ void SlicerTWaveform::drawEditorWaveform()
 	float zoomOffset = (m_editorHeight - m_zoomLevel * m_editorHeight) / 2;
 
 	const auto& sample = m_slicerTParent->m_originalSample;
-	const auto waveform = SampleWaveform::Parameters{sample.data() + startFrame, endFrame, sample.amplification(), sample.reversed()};
+	const auto waveform = SampleWaveform::Parameters{sample.data() + startFrame, endFrame - startFrame, sample.amplification(), sample.reversed()};
 	const auto rect = QRect(0, zoomOffset, m_editorWidth, m_zoomLevel * m_editorHeight);
 	SampleWaveform::visualize(waveform, brush, rect);
 

--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -89,9 +89,10 @@ void SlicerTWaveform::drawSeekerWaveform()
 	QPainter brush(&m_seekerWaveform);
 	brush.setPen(s_waveformColor);
 
-	SampleWaveform::visualize(m_slicerTParent->m_originalSample, brush,
-		QRect(0, 0, m_seekerWaveform.width(), m_seekerWaveform.height()), 0,
-		m_slicerTParent->m_originalSample.sampleSize());
+	const auto& sample = m_slicerTParent->m_originalSample;
+	const auto waveform = SampleWaveform::Parameters{sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
+	const auto rect = QRect(0, 0, m_seekerWaveform.width(), m_seekerWaveform.height());
+	SampleWaveform::visualize(waveform, brush, rect);
 
 	// increase brightness in inner color
 	QBitmap innerMask = m_seekerWaveform.createMaskFromColor(s_waveformMaskColor, Qt::MaskMode::MaskOutColor);
@@ -139,14 +140,16 @@ void SlicerTWaveform::drawEditorWaveform()
 	if (m_slicerTParent->m_originalSample.sampleSize() <= 1) { return; }
 
 	QPainter brush(&m_editorWaveform);
-	float startFrame = m_seekerStart * m_slicerTParent->m_originalSample.sampleSize();
-	float endFrame = m_seekerEnd * m_slicerTParent->m_originalSample.sampleSize();
+	size_t startFrame = m_seekerStart * m_slicerTParent->m_originalSample.sampleSize();
+	size_t endFrame = m_seekerEnd * m_slicerTParent->m_originalSample.sampleSize();
 
 	brush.setPen(s_waveformColor);
 	float zoomOffset = (m_editorHeight - m_zoomLevel * m_editorHeight) / 2;
 
-	SampleWaveform::visualize(m_slicerTParent->m_originalSample, brush,
-		QRect(0, zoomOffset, m_editorWidth, m_zoomLevel * m_editorHeight), startFrame, endFrame);
+	const auto& sample = m_slicerTParent->m_originalSample;
+	const auto waveform = SampleWaveform::Parameters{sample.data() + startFrame, endFrame, sample.amplification(), sample.reversed()};
+	const auto rect = QRect(0, zoomOffset, m_editorWidth, m_zoomLevel * m_editorHeight);
+	SampleWaveform::visualize(waveform, brush, rect);
 
 	// increase brightness in inner color
 	QBitmap innerMask = m_editorWaveform.createMaskFromColor(s_waveformMaskColor, Qt::MaskMode::MaskOutColor);

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -269,7 +269,10 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	float offset =  m_clip->startTimeOffset() / ticksPerBar * pixelsPerBar();
 	QRect r = QRect( offset, spacing,
 			qMax( static_cast<int>( m_clip->sampleLength() * ppb / ticksPerBar ), 1 ), rect().bottom() - 2 * spacing );
-	SampleWaveform::visualize(m_clip->m_sample, p, r);
+
+	const auto& sample = m_clip->m_sample;
+	const auto waveform = SampleWaveform::Parameters{sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
+	SampleWaveform::visualize(waveform, p, r);
 
 	QString name = PathUtil::cleanName(m_clip->m_sample.sampleFile());
 	paintTextLabel(name, p);

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1248,7 +1248,12 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 			int yOffset = (editorHeight - sampleHeight) / 2.0f + TOP_MARGIN;
 
 			p.setPen(m_ghostSampleColor);
-			SampleWaveform::visualize(m_ghostSample->sample(), p, QRect(startPos, yOffset, sampleWidth, sampleHeight), 0, sampleFrames);
+			
+			const auto& sample = m_ghostSample->sample();
+			const auto waveform = SampleWaveform::Parameters{
+				sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
+			const auto rect = QRect(startPos, yOffset, sampleWidth, sampleHeight);
+			SampleWaveform::visualize(waveform, p, rect);
 		}
 
 		// draw ghost notes


### PR DESCRIPTION
The issue is resolved by choosing the frames to draw based on frame indicies, and not on pixel indicies. Fixes #7061.