### PR TITLE
Hide the LED button for "Custom Base Velocity"

### DIFF
--- a/include/GroupBox.h
+++ b/include/GroupBox.h
@@ -50,6 +50,21 @@ public:
 		return m_led;
 	}
 
+	/**
+	 * @brief Returns whether the LED button is shown or not
+	 * 
+	 * @return true LED button is shown
+	 * @return false LED button is hidden
+	 */
+	bool ledButtonShown() const;
+
+	/**
+	 * @brief Sets if the LED check box is shown or not
+	 * 
+	 * @param value Set to true to show the LED check box or to false to hide it.
+	 */
+	void setLedButtonShown(bool value) const;
+
 	int titleBarHeight() const
 	{
 		return m_titleBarHeight;

--- a/include/GroupBox.h
+++ b/include/GroupBox.h
@@ -63,7 +63,7 @@ public:
 	 * 
 	 * @param value Set to true to show the LED check box or to false to hide it.
 	 */
-	void setLedButtonShown(bool value) const;
+	void setLedButtonShown(bool value);
 
 	int titleBarHeight() const
 	{

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -145,6 +145,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	}
 
 	auto baseVelocityGroupBox = new GroupBox(tr("CUSTOM BASE VELOCITY"));
+	baseVelocityGroupBox->setLedButtonShown(false);
 	layout->addWidget( baseVelocityGroupBox );
 
 	auto baseVelocityLayout = new QVBoxLayout(baseVelocityGroupBox);
@@ -160,11 +161,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 
 	m_baseVelocitySpinBox = new LcdSpinBox( 3, baseVelocityGroupBox );
 	m_baseVelocitySpinBox->setLabel( tr( "BASE VELOCITY" ) );
-	m_baseVelocitySpinBox->setEnabled( false );
 	baseVelocityLayout->addWidget( m_baseVelocitySpinBox );
-
-	connect( baseVelocityGroupBox->ledButton(), SIGNAL(toggled(bool)),
-			m_baseVelocitySpinBox, SLOT(setEnabled(bool)));
 
 	layout->addStretch();
 }

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -72,13 +72,23 @@ void GroupBox::modelChanged()
 }
 
 
+bool GroupBox::ledButtonShown() const
+{
+	return m_led->isVisible();
+}
+
+
+void GroupBox::setLedButtonShown(bool value) const
+{
+	m_led->setVisible(value);
+}
 
 
 void GroupBox::mousePressEvent( QMouseEvent * _me )
 {
-	if( _me->y() > 1 && _me->y() < 13 && _me->button() == Qt::LeftButton )
+	if (ledButtonShown() && _me->y() > 1 && _me->y() < 13 && _me->button() == Qt::LeftButton)
 	{
-		model()->setValue( !model()->value() );
+		model()->setValue(!model()->value());
 	}
 }
 
@@ -102,7 +112,9 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
 	p.setFont( pointSize<8>( font() ) );
-	p.drawText( 22, m_titleBarHeight, m_caption );
+
+	int const captionX = ledButtonShown() ? 22 : 6;
+	p.drawText(captionX, m_titleBarHeight, m_caption);
 }
 
 

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -78,7 +78,7 @@ bool GroupBox::ledButtonShown() const
 }
 
 
-void GroupBox::setLedButtonShown(bool value) const
+void GroupBox::setLedButtonShown(bool value)
 {
 	m_led->setVisible(value);
 }


### PR DESCRIPTION
Hide the LED button for "Custom Base Velocity" as it did not have any other effect besides disabling the spinbox in the GUI. It did not affect any model which could be evaluated elsewhere.

Here's how it looks:

![CustomBaseVelocity](https://github.com/LMMS/lmms/assets/9293269/3343eeaf-fe76-48cf-8fd7-30e087d26074)

## Technical details
Add functionality to show/hide the LED button to `GroupBox`. There's also a corresponding getter called `ledButtonShown`. The latter is evaluated in the following situations:
* Mouse clicks: if the LED button is hidden then the model is not toggled.
* Paining: The X position of the caption changes depending on whether the LED button is shown or not.

At a certain point the class `GroupBox` should be replaced by something that's implemented with layouts and which is used wherever it's possible.

Should fix the remaining issues of #5706.