### PR TITLE
Center effects W/D knob at 0

### DIFF
--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -52,7 +52,7 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
-	m_wetDryModel.setCenterValue(0);
+	m_wetDryModel.setCenterValue( 0 );
 
 	m_srcState[0] = m_srcState[1] = nullptr;
 	reinitSRC();

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -52,7 +52,7 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
-	m_wetDryModel.setCenterValue( 0 );
+	m_wetDryModel.setCenterValue(0);
 
 	m_srcState[0] = m_srcState[1] = nullptr;
 	reinitSRC();

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -52,9 +52,11 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
+	m_wetDryModel.setCenterValue( 0 );
+
 	m_srcState[0] = m_srcState[1] = nullptr;
 	reinitSRC();
-	
+
 	if( ConfigManager::inst()->value( "ui", "disableautoquit").toInt() )
 	{
 		m_autoQuitDisabled = true;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,10 +5,6 @@
 			"name": "fftw3",
 			"default-features": false,
 			"features": [
-				"sse",
-				"sse2",
-				"avx",
-				"avx2"
 			]
 		},
 		{

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,10 @@
 			"name": "fftw3",
 			"default-features": false,
 			"features": [
+				"sse",
+				"sse2",
+				"avx",
+				"avx2"
 			]
 		},
 		{


### PR DESCRIPTION
Implements #7076 
Set the centre value of the W/D knob as 0 in display so active arc is drawn wrt 0 instead of -1
![image](https://github.com/LMMS/lmms/assets/76674645/85018a5a-8c07-49d7-94b5-0f87fd874f63)
![image](https://github.com/LMMS/lmms/assets/76674645/9f9f7581-2050-4212-be66-d17ed42e9421)
Displays as expected in instrument fx chains and mixer.

For reference, existing behaviour of W/D knob:
![image](https://github.com/LMMS/lmms/assets/76674645/80b58256-c7e1-400c-bcff-1536bef19db7)

v. simple change. just needed to understand
