### PR TITLE
Fix invalidated iterator when removing notes in Piano Roll

### DIFF
--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -63,7 +63,7 @@ public:
 	// note management
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
 
-	void removeNote( Note * _note_to_del );
+	NoteVecotr::const_iterator removeNote(Note* note_to_del);
 
 	Note * noteAtStep( int _step );
 

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -63,7 +63,7 @@ public:
 	// note management
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
 
-	NoteVecotr::const_iterator removeNote(Note* note_to_del);
+	NoteVector::const_iterator removeNote(Note* note_to_del);
 
 	Note * noteAtStep( int _step );
 

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -64,7 +64,7 @@ public:
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
 
 	NoteVector::const_iterator removeNote(NoteVector::const_iterator note);
-	NoteVector::const_iterator removeNote(Note* note_to_del);
+	NoteVector::const_iterator removeNote(Note* note);
 
 	Note * noteAtStep( int _step );
 

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -63,6 +63,7 @@ public:
 	// note management
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
 
+	NoteVector::const_iterator removeNote(NoteVector::const_iterator note);
 	NoteVector::const_iterator removeNote(Note* note_to_del);
 
 	Note * noteAtStep( int _step );

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -63,7 +63,7 @@ public:
 	// note management
 	Note * addNote( const Note & _new_note, const bool _quant_pos = true );
 
-	NoteVector::const_iterator removeNote(NoteVector::const_iterator note);
+	NoteVector::const_iterator removeNote(NoteVector::const_iterator it);
 	NoteVector::const_iterator removeNote(Note* note);
 
 	Note * noteAtStep( int _step );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2646,7 +2646,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 					)
 				{
 					// delete this note
-					it = m_midiClip->removeNote(note);
+					it = m_midiClip->removeNote(it);
 					Engine::getSong()->setModified();
 				}
 				else

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2646,7 +2646,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 					)
 				{
 					// delete this note
-					m_midiClip->removeNote( note );
+					it = m_midiClip->removeNote(note);
 					Engine::getSong()->setModified();
 				}
 				else

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -208,13 +208,13 @@ Note * MidiClip::addNote( const Note & _new_note, const bool _quant_pos )
 
 
 
-void MidiClip::removeNote( Note * _note_to_del )
+NoteVector::const_iterator MidiClip::removeNote(Note* note_to_del)
 {
 	instrumentTrack()->lock();
 
-	m_notes.erase(std::remove_if(m_notes.begin(), m_notes.end(), [&](Note* note)
+	auto it = m_notes.erase(std::remove_if(m_notes.begin(), m_notes.end(), [&](Note* note)
 	{
-		auto shouldRemove = note == _note_to_del;
+		auto shouldRemove = note == note_to_del;
 		if (shouldRemove) { delete note; }
 		return shouldRemove;
 	}), m_notes.end());
@@ -225,6 +225,7 @@ void MidiClip::removeNote( Note * _note_to_del )
 	updateLength();
 
 	emit dataChanged();
+	return it;
 }
 
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -208,11 +208,11 @@ Note * MidiClip::addNote( const Note & _new_note, const bool _quant_pos )
 
 
 
-NoteVector::const_iterator MidiClip::removeNote(NoteVector::const_iterator note)
+NoteVector::const_iterator MidiClip::removeNote(NoteVector::const_iterator it)
 {
 	instrumentTrack()->lock();
-	delete *note;
-	auto new_it = m_notes.erase(note);
+	delete *it;
+	auto new_it = m_notes.erase(it);
 	instrumentTrack()->unlock();
 
 	checkType();

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -222,11 +222,11 @@ NoteVector::const_iterator MidiClip::removeNote(NoteVector::const_iterator note)
 	return new_it;
 }
 
-NoteVector::const_iterator MidiClip::removeNote(Note* note_to_del )
+NoteVector::const_iterator MidiClip::removeNote(Note* note)
 {
 	instrumentTrack()->lock();
 
-	auto it = std::find(m_notes.begin(), m_notes.end(), note_to_del);
+	auto it = std::find(m_notes.begin(), m_notes.end(), note);
 	if (it != m_notes.end())
 	{
 		delete *it;

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -208,16 +208,30 @@ Note * MidiClip::addNote( const Note & _new_note, const bool _quant_pos )
 
 
 
-NoteVector::const_iterator MidiClip::removeNote(Note* note_to_del)
+NoteVector::const_iterator MidiClip::removeNote(NoteVector::const_iterator note)
+{
+	instrumentTrack()->lock();
+	delete *note;
+	auto new_it = m_notes.erase(note);
+	instrumentTrack()->unlock();
+
+	checkType();
+	updateLength();
+
+	emit dataChanged();
+	return new_it;
+}
+
+NoteVector::const_iterator MidiClip::removeNote(Note* note_to_del )
 {
 	instrumentTrack()->lock();
 
-	auto it = m_notes.erase(std::remove_if(m_notes.begin(), m_notes.end(), [&](Note* note)
+	auto it = std::find(m_notes.begin(), m_notes.end(), note_to_del);
+	if (it != m_notes.end())
 	{
-		auto shouldRemove = note == note_to_del;
-		if (shouldRemove) { delete note; }
-		return shouldRemove;
-	}), m_notes.end());
+		delete *it;
+		it = m_notes.erase(it);
+	}
 
 	instrumentTrack()->unlock();
 


### PR DESCRIPTION
According to [`erase` documentation](https://en.cppreference.com/w/cpp/container/vector/erase) the return value is the new (valid) iterator after removing the given iterator. Currently we just remove the note and throw away the iterator returned, this can cause an invalidated iterator when removing notes in the Piano Roll.
> Iterators (including the end() iterator) and references to the elements at or after the point of the erase are invalidated. 

From what I can tell I believe this is the only place where we continue to use the iterator, so all other places using `remoteNote` should be okay.