### PR TITLE
Fix deletion of mixer channels when calling MixerView::clear

### DIFF
--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -590,7 +590,7 @@ void MixerView::setCurrentMixerChannel(int channel)
 
 void MixerView::clear()
 {
-	getMixer()->clear();
+	while (m_mixerChannelViews.size() > 1) { deleteChannel(1); }
 
 	refreshDisplay();
 }

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -590,7 +590,8 @@ void MixerView::setCurrentMixerChannel(int channel)
 
 void MixerView::clear()
 {
-	while (m_mixerChannelViews.size() > 1) { deleteChannel(1); }
+	for (auto i = m_mixerChannelViews.size() - 1; i > 0; --i) { deleteChannel(i); }
+	getMixer()->clearChannel(0);
 
 	refreshDisplay();
 }


### PR DESCRIPTION
Currently calling `getMixer()->clear()` only deletes the mixer channels, but doesn't do any disconnections or other necessary destruction calls. Instead of just deleting the channels, we use MixerView's deleteChannel to properly destroy the view and underlying channel.