### PR TITLE
Sf2Player missing nullptr initialization

### DIFF
--- a/plugins/Sf2Player/PatchesDialog.cpp
+++ b/plugins/Sf2Player/PatchesDialog.cpp
@@ -328,7 +328,7 @@ void PatchesDialog::bankChanged ()
 			fluid_preset_t preset;
 			fluid_preset_t *pCurPreset = &preset;
 #else
-			fluid_preset_t *pCurPreset;
+			fluid_preset_t *pCurPreset = nullptr;
 #endif
 			while ((pCurPreset = fluid_sfont_iteration_next_wrapper(pSoundFont, pCurPreset))) {
 				int iBank = fluid_preset_get_banknum(pCurPreset);


### PR DESCRIPTION
My MSVC debug build kept asserting at this, so fixing a missing nullptr initialization.