### PR TITLE
Update URL of tap-plugins submodule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,8 @@ jobs:
         run: |
           add-apt-repository ppa:git-core/ppa
           apt-get update
-          apt-get --yes install git
+          apt-get --yes install apt-transport-https ca-certificates git
+          update-ca-certificates
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check out
         uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	url = https://github.com/swh/ladspa
 [submodule "plugins/LadspaEffect/tap/tap-plugins"]
 	path = plugins/LadspaEffect/tap/tap-plugins
-	url = https://github.com/tomszilagyi/tap-plugins
+	url = https://git.hq.sig7.se/tap-plugins.git
 [submodule "src/3rdparty/weakjack/weakjack"]
 	path = src/3rdparty/weakjack/weakjack
 	url = https://github.com/x42/weakjack.git


### PR DESCRIPTION
The TAP LADSPA plugins have moved off GitHub, and the history has been deleted from the GitHub repository. As such, attempting to initialise that submodule currently fails with the following error:
```
fatal: Fetched in submodule path 'plugins/LadspaEffect/tap/tap-plugins', but it did not contain 85640223047d49a305e90ba1b92303eb066ba474. Direct fetching of that commit failed.
```
This PR updates the submodule to refer to the new repository. See also https://github.com/tomscii/tap-plugins.