### PR TITLE
Fix vcpkg dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,14 +1,13 @@
 {
 	"$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+	"name": "lmms",
 	"dependencies": [
 		{
 			"name": "fftw3",
 			"default-features": false,
 			"features": [
 				"sse",
-				"sse2",
-				"avx",
-				"avx2"
+				"sse2"
 			]
 		},
 		{
@@ -64,10 +63,7 @@
 		},
 		{
 			"name": "sdl2",
-			"default-features": false,
-			"features": [
-				"base"
-			]
+			"default-features": false
 		},
 		{
 			"name": "zlib",


### PR DESCRIPTION
* SDL2 no longer has a "base" feature; the library functions as required with no features enabled. (The features it has only support Linux.)
* FFTW3 doesn't seem to support detecting CPU features at runtime on Windows, unlike on Unix (or perhaps it isn't working properly). A user on Discord reported experiencing illegal instruction exceptions when running their local build, which were fixed by disabling the SIMD features. I have removed the AVX features from the list; SSE2 should be safe to keep since it is required by all versions of Windows still in support.
* Specifying the project name makes error messages a bit nicer. (I thought `error: sdl2@2.28.5#1 does not have required feature base needed by` had been cut off, but it turns out vcpkg simply didn't have a name to put at the end.)

We should perhaps consider pinning dependencies to a particular version so we don't experience breakages like with SDL2 here, but I will leave that for now.