### PR TITLE
Remove message location check from check-strings test

### DIFF
--- a/tests/scripted/check-strings
+++ b/tests/scripted/check-strings
@@ -112,14 +112,14 @@ for theme in sorted([d for d in Path('data/themes').iterdir() if d.is_dir()]):
                         if str(c.value).startswith(GUI_NAMESPACE_PREFIX):
                             classes_in_sheet.add(unscope_classname(stylesheet, c.value))
                         else:
-                            error(str(stylesheet), f"Namespace prefix missing from class {c.value}")
+                            error(stylesheet.as_posix(), f"Namespace prefix missing from class {c.value}")
                     class_found = True
                 # After whitespace or comma comes a new class
                 elif c.type == 'whitespace' or (c.type == 'literal' and c.value == ','):
                     class_found = False
     missing_classes = classes_in_sheet - classes
     for class_in_sheet in sorted(missing_classes):
-        error(str(stylesheet), f'Class does not exist in source code: {class_in_sheet}')
+        error(stylesheet.as_posix(), f'Class does not exist in source code: {class_in_sheet}')
 
 
 caption('patches (checks only plugins/)')
@@ -138,7 +138,7 @@ for cur_file in sorted(Path('.').glob('*/patches/*.patch')):
             if mpath.parent == Path('plugins/LadspaEffect/swh/ladspa/'):
                 mpath = mpath.with_suffix('.xml')
             if not mpath.is_file():
-                error(str(cur_file), f'Source file does not exist: {str(mpath)}')
+                error(cur_file.as_posix(), f'Source file does not exist: {mpath.as_posix()}')
 
 
 caption('debian docs (only one string)')

--- a/tests/scripted/check-strings
+++ b/tests/scripted/check-strings
@@ -71,19 +71,12 @@ for p in re.findall(r'\[submodule "([^"]+)"\]\s*$', Path('.gitmodules').read_tex
 
 caption('locale')
 
-filenames = set()
 classes_found = set()
 for cur_file in Path('data/locale').glob('*.ts'):
     tree = ElementTree.parse(str(cur_file))
     root = tree.getroot()
-    for location in root.findall('./context/message/location'):
-        filenames.add(location.attrib['filename'])
     for location in root.findall('./context/name'):
         classes_found.add(location.text)
-for f in sorted(filenames):
-    # The files sometimes are relative to data/local and sometimes to the git tree's root...
-    if not Path(f).is_file() and not Path(f'data/locale/{f}').is_file():
-        error('data/locale', f'Source file does not exist: {f}')
 for c in sorted(classes_found):
     if is_our_class(c) and '::' not in c and c not in classes:
         error('data/locale', f'Class does not exist in source code: {c}')

--- a/tests/scripted/verify
+++ b/tests/scripted/verify
@@ -106,22 +106,6 @@ with tempfile.TemporaryDirectory() as tmpdir:
 		create_file('data/locale/fr.ts',
 					'<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">\n'
 					'    <context>\n'
-					'    <name>TestClass</name>\n'
-					'     <message>\n'
-					'        <location filename="../../src/core/non-existent.cpp" line="20"/>\n'
-					'        <source>About LMMS</source>\n'
-					'        <translation>À propos de LMMS</translation>\n'
-					'    </message>\n'
-					'</context>\n'
-					'</TS>\n')
-		test.run()
-		test.expect('Error: data/locale: Source file does not exist: ../../src/core/non-existent.cpp')
-		test.expect('1 errors')
-
-	with ScriptTest(check_strings) as test:
-		create_file('data/locale/fr.ts',
-					'<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">\n'
-					'    <context>\n'
 					'    <name>NonExistentClass</name>\n'
 					'     <message>\n'
 					'        <location filename="../../src/core/classes.cpp" line="20"/>\n'

--- a/tests/scripted/verify
+++ b/tests/scripted/verify
@@ -4,6 +4,7 @@ import subprocess
 from pathlib import Path
 import tempfile
 import os
+import sys
 
 
 def set_git_config():
@@ -17,7 +18,7 @@ def set_git_config():
 def create_file(filename: str, file_content: str):
 	"""Create a file in the current directory and adds it to git"""
 	Path(filename).parent.mkdir(parents=True, exist_ok=True)
-	with open(filename, "w") as textfile:
+	with open(filename, "w", encoding='utf-8') as textfile:
 		print(file_content, file=textfile)
 	subprocess.run(['git', 'add', filename], check=True)
 
@@ -64,7 +65,10 @@ class ScriptTest():
 
 	def run(self, expected_returncode: int = 1):  # default: something goes wrong ("to the safe side")
 		"""Run the script, check the exit code and store the result"""
-		self.result = subprocess.run([str(self.scriptpath)], capture_output=True, text=True)
+		command = [str(self.scriptpath)]
+		if os.name == 'nt':
+			command.insert(0, sys.executable)
+		self.result = subprocess.run(command, capture_output=True, text=True)
 		print('--->8--- Script output BEGIN --->8---')
 		print(self.result.stdout)
 		print('--->8--- Script output END   --->8---')


### PR DESCRIPTION
The message locations in locale files include both a file name and a line number, so we invalidate them almost every time we modify a file containing localised strings. It doesn't make sense to me to check whether the files exist, but allow the line numbers to be nonsense. We could require developers to regenerate the locale files after every change, but this feels unnecessary, and will clutter reviews. Instead, I think we should just accept that the message locations will be wrong most of the time. What really matters is whether the class containing the message exists, as this is what Qt's translation function actually uses. We do check this, and this PR doesn't change that.

This PR also adds support for running `tests/scripted/verify` on Windows, since I had to make those changes anyway while testing.