### PR TITLE
Prevent out of bounds read in `Sample::playRaw`

### DIFF
--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -178,7 +178,7 @@ void Sample::playRaw(sampleFrame* dst, size_t numFrames, const PlaybackState* st
 		switch (loopMode)
 		{
 		case Loop::Off:
-			if (index < 0 || index > m_endFrame) { return; }
+			if (index < 0 || index >= m_endFrame) { return; }
 			break;
 		case Loop::On:
 			if (index < m_loopStartFrame && backwards) { index = m_loopEndFrame - 1; }


### PR DESCRIPTION
Fixes a typo that was causing an out of bounds read and consequently, audible clicks when playing samples in AudioFileProcessor.