### PR TITLE
Reenable song editor zooming

### DIFF
--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -393,17 +393,18 @@ void TrackView::mouseReleaseEvent( QMouseEvent * me )
 
 void TrackView::wheelEvent(QWheelEvent* we)
 {
-	we->accept();
-	
-	const int deltaY = we->angleDelta().y();
+	// Note: we add the values because one of them will be 0. If the alt modifier
+	// is pressed x is non-zero and otherwise y.
+	const int deltaY = we->angleDelta().x() + we->angleDelta().y();
 	int const direction = deltaY < 0 ? -1 : 1;
 
 	auto const modKeys = we->modifiers();
-	int stepSize = modKeys == Qt::ControlModifier ? 1 : modKeys == Qt::ShiftModifier ? 5 : 0;
+	int stepSize = modKeys == (Qt::ControlModifier | Qt::AltModifier) ? 1 : modKeys == (Qt::ShiftModifier | Qt::AltModifier) ? 5 : 0;
 
 	if (stepSize != 0)
 	{
 		resizeToHeight(height() + stepSize * direction);
+		we->accept();
 	}
 }
 


### PR DESCRIPTION
Reenable zooming in the song editor by
* only resizing the track if the alt modifier is pressed and
* only accepting the wheel event if we in fact resize the track.

By doing so all other wheel events bubble up so that zooming and scrolling of the song editor can be handled by parent components.

The code that handles the retrieval of the delta value had to be adjusted as well. The reason is that pressing the alt key messes with the way that deltas are reported in the wheel event. The wheel event is interpreted as a horizontal scroll when alt is pressed.

Fixes #7117.