### PR TITLE
Enable link-time optimizations by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ option(WANT_DEBUG_TSAN	"Enable ThreadSanitizer" OFF)
 option(WANT_DEBUG_MSAN	"Enable MemorySanitizer" OFF)
 option(WANT_DEBUG_UBSAN	"Enable UndefinedBehaviorSanitizer" OFF)
 OPTION(BUNDLE_QT_TRANSLATIONS	"Install Qt translation files for LMMS" OFF)
+OPTION(ENABLE_LTO	"Enable LTO (link-time optimizations)" ON)
 
 
 IF(LMMS_BUILD_APPLE)
@@ -733,6 +734,11 @@ add_sanitizer(undefined "GNU|Clang" WANT_DEBUG_UBSAN STATUS_DEBUG_UBSAN -fno-san
 
 # use ccache
 include(CompileCache)
+
+# enable LTO (link-time optimizations)
+IF(ENABLE_LTO)
+	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+ENDIF()
 
 # make sub-directories
 ADD_SUBDIRECTORY(cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,8 +736,12 @@ add_sanitizer(undefined "GNU|Clang" WANT_DEBUG_UBSAN STATUS_DEBUG_UBSAN -fno-san
 include(CompileCache)
 
 # enable LTO (link-time optimizations)
-IF(ENABLE_LTO)
-	set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT result)
+IF(result)
+	IF(ENABLE_LTO)
+		set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+	ENDIF()
 ENDIF()
 
 # make sub-directories


### PR DESCRIPTION
In most cases, LTO can slightly increase performance and significantly decrease binary size without impacting stability. The only caveat is that it does have an impact on build times, albeit a relatively minor one.

For only the LMMS executable itself, these were my local improvements building for Linux debug with clang compiler and mold linker:
Size before: 29.8 MiB
Size after: 26.1 MiB
(About a 13% improvement)
I expect plugins and libraries will show similar improvements.