### PR TITLE
Fix crash in Audio File Processor

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -184,12 +184,12 @@ void AudioFileProcessorView::newWaveView()
 		delete m_waveView;
 		m_waveView = 0;
 	}
-	m_waveView = new AudioFileProcessorWaveView(this, 245, 75, &castModel<AudioFileProcessor>()->sample());
-	m_waveView->move(2, 172);
-	m_waveView->setKnobs(
+	m_waveView = new AudioFileProcessorWaveView(this, 245, 75, &castModel<AudioFileProcessor>()->sample(),
 		dynamic_cast<AudioFileProcessorWaveView::knob*>(m_startKnob),
 		dynamic_cast<AudioFileProcessorWaveView::knob*>(m_endKnob),
 		dynamic_cast<AudioFileProcessorWaveView::knob*>(m_loopKnob));
+	m_waveView->move(2, 172);
+	
 	m_waveView->show();
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -65,7 +65,8 @@ f_cnt_t AudioFileProcessorWaveView::range() const
 	return m_to - m_from;
 }
 
-AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget * parent, int w, int h, Sample const * buf) :
+AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget * parent, int w, int h, Sample const * buf,
+	knob * start, knob * end, knob * loop) :
 	QWidget(parent),
 	m_sample(buf),
 	m_graph(QPixmap(w - 2 * s_padding, h - 2 * s_padding)),
@@ -74,9 +75,9 @@ AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget * parent, int w, 
 	m_last_from(0),
 	m_last_to(0),
 	m_last_amp(0),
-	m_startKnob(0),
-	m_endKnob(0),
-	m_loopKnob(0),
+	m_startKnob(start),
+	m_endKnob(end),
+	m_loopKnob(loop),
 	m_isDragging(false),
 	m_reversed(false),
 	m_framesPlayed(0),
@@ -84,6 +85,8 @@ AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget * parent, int w, 
 {
 	setFixedSize(w, h);
 	setMouseTracking(true);
+
+	configureKnobRelationsAndWaveViews();
 
 	updateSampleRange();
 
@@ -399,21 +402,6 @@ void AudioFileProcessorWaveView::slide(int px)
 	slideSampleByFrames(step);
 }
 
-void AudioFileProcessorWaveView::setKnobs(knob * start, knob * end, knob * loop)
-{
-	m_startKnob = start;
-	m_endKnob = end;
-	m_loopKnob = loop;
-
-	m_startKnob->setWaveView(this);
-	m_startKnob->setRelatedKnob(m_endKnob);
-
-	m_endKnob->setWaveView(this);
-	m_endKnob->setRelatedKnob(m_startKnob);
-
-	m_loopKnob->setWaveView(this);
-}
-
 void AudioFileProcessorWaveView::slideSamplePointByPx(Point point, int px)
 {
 	slideSamplePointByFrames(
@@ -509,6 +497,17 @@ void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
 		setCursor(Qt::ClosedHandCursor);
 	else
 		setCursor(Qt::OpenHandCursor);
+}
+
+void AudioFileProcessorWaveView::configureKnobRelationsAndWaveViews()
+{
+	m_startKnob->setWaveView(this);
+	m_startKnob->setRelatedKnob(m_endKnob);
+
+	m_endKnob->setWaveView(this);
+	m_endKnob->setRelatedKnob(m_startKnob);
+
+	m_loopKnob->setWaveView(this);
 }
 
 void AudioFileProcessorWaveView::knob::slideTo(double v, bool check_bound)

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -65,8 +65,8 @@ f_cnt_t AudioFileProcessorWaveView::range() const
 	return m_to - m_from;
 }
 
-AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget * parent, int w, int h, Sample const * buf,
-	knob * start, knob * end, knob * loop) :
+AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget* parent, int w, int h, Sample const* buf,
+	knob* start, knob* end, knob* loop) :
 	QWidget(parent),
 	m_sample(buf),
 	m_graph(QPixmap(w - 2 * s_padding, h - 2 * s_padding)),

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -146,8 +146,8 @@ private:
 	friend class AudioFileProcessorView;
 
 public:
-	AudioFileProcessorWaveView(QWidget* parent, int w, int h, Sample const* buf);
-	void setKnobs(knob* start, knob* end, knob* loop);
+	AudioFileProcessorWaveView(QWidget* parent, int w, int h, Sample const* buf,
+		knob * start, knob * end, knob * loop);
 
 
 	void updateSampleRange();
@@ -169,6 +169,8 @@ private:
 	void updateGraph();
 	void reverse();
 	void updateCursor(QMouseEvent* me = nullptr);
+
+	void configureKnobRelationsAndWaveViews();
 
 	static bool isCloseTo(int a, int b)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -147,7 +147,7 @@ private:
 
 public:
 	AudioFileProcessorWaveView(QWidget* parent, int w, int h, Sample const* buf,
-		knob * start, knob * end, knob * loop);
+		knob* start, knob* end, knob* loop);
 
 
 	void updateSampleRange();


### PR DESCRIPTION
Fix a crash in the Audio File Processor that occurs when an Audio File Processor with a reversed sample is loaded from a save file and then the plugin window is opened.

The problem was caused by a call to `AudioFileProcessorWaveView::slideSampleByFrames` during the execution of constructor of `AudioFileProcessorWaveView`. In that situation the three `knob` members were all `nullptr` because for some reason there was an explicit setter for them which was only called after construction. This is fixed by passing and setting the knobs in the constructor.

Another question is if it's not a problem in the first place that the knobs are given to the `AudioFileProcessorWaveView` instead of their underlying models.

Fixes #7123.