### PR TITLE
Fix missing icons for some instruments

### DIFF
--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -71,6 +71,8 @@ public:
 	// Create a menu for assigning/creating channels for this track
 	QMenu * createMixerMenu( QString title, QString newMixerLabel ) override;
 
+	QPixmap determinePixmap();
+
 
 protected:
 	void modelChanged() override;

--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -55,6 +55,7 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void mouseDoubleClickEvent( QMouseEvent * _me ) override;
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
+	void paintEvent(QPaintEvent* pe) override;
 	void resizeEvent( QResizeEvent * _re ) override;
 
 private:

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -397,6 +397,11 @@ QMenu * InstrumentTrackView::createMixerMenu(QString title, QString newMixerLabe
 	return mixerMenu;
 }
 
+QPixmap InstrumentTrackView::determinePixmap()
+{
+	return determinePixmap(dynamic_cast<InstrumentTrack*>(getTrack()));
+}
+
 
 QPixmap InstrumentTrackView::determinePixmap(InstrumentTrack* instrumentTrack)
 {

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -30,6 +30,7 @@
 
 #include "ConfigManager.h"
 #include "embed.h"
+#include "InstrumentTrackView.h"
 #include "RenameDialog.h"
 #include "TrackRenameLineEdit.h"
 #include "TrackView.h"
@@ -178,6 +179,16 @@ void TrackLabelButton::mouseReleaseEvent( QMouseEvent *_me )
 }
 
 
+void TrackLabelButton::paintEvent(QPaintEvent* pe)
+{
+	InstrumentTrackView* instrumentTrackView = dynamic_cast<InstrumentTrackView*>(m_trackView);
+	if (instrumentTrackView)
+	{
+		setIcon(instrumentTrackView->determinePixmap());
+	}
+
+	QToolButton::paintEvent(pe);
+}
 
 
 void TrackLabelButton::resizeEvent(QResizeEvent *_re)


### PR DESCRIPTION
Revert some of the changes made in commit 88e0e94dcdb. The underlying idea was that the `InstrumentTrackView` should be responsible for assigning the icon that's shown by its `TrackLabelButton`. However, this does not work because in some cases the `InstrumentTrack` that's passed into `InstrumentTrackView::determinePixmap` does not have an `Instrument` assigned. This in turn seems to be caused due to initalizations that are running in parallel in different threads.

Here are the steps to reproduce the threading problem (line numbers refer to commit 360254f):
1. Set a break point in line 1054 of `InstrumentTrack`, i.e. the line in `InstrumentTrack::loadInstrument` where `m_instrument` is being assigned to.
2. Set a break point in `InstrumentTrackView::determinePixmap`, e.g. inside of the first if statement.
3. Drop an instance of "Sf2 Player" onto the Song Editor.
4. The first break point in `InstrumentTrack` is hit in a thread called "lmms::Instrumen" (shown like that in my debugger). Try to step over it.
5. The second break point in `InstrumentTrackView` now gets hit before the code is stepped over. This time we are in the thread called "lmms". I guess this is the GUI main thread.
6. Continue execution.

If you now switch to the application then the icon is shown. I guess the debugger is halted long enough in the main thread so that the InstrumentTrack gets an instrument assigned in another thread.

If you delete/disable the break point in `InstrumentTrack::determinePixmap` and follow the coarse steps above then the icon is not shown because the track has no instrument.

The current fix still delegates to the `InstrumentTrackView` to determine the pixmap in hopes that one day there will be a better solution where the parent component can be fully responsible for its child component.

Fixes #7116.