### PR TITLE
Fix a NaN in EqSpectrumView

### DIFF
--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -186,6 +186,7 @@ namespace gui
 EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 	QWidget( _parent ),
 	m_analyser( b ),
+	m_peakSum(0.),
 	m_periodicalUpdate( false )
 {
 	setFixedSize( 450, 200 );


### PR DESCRIPTION
Fix a `NaN` in `EqSpectrumView` that's caused by `m_peakSum` not being initialzed.