### PR TITLE
Fix NaNs in basic filters and Equalizer

### DIFF
--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -144,7 +144,12 @@ template<ch_cnt_t CHANNELS>
 class BiQuad
 {
 public:
-	BiQuad() 
+	BiQuad() :
+		m_a1(0.),
+		m_a2(0.),
+		m_b0(0.),
+		m_b1(0.),
+		m_b2(0.)
 	{
 		clearHistory();
 	}

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -290,10 +290,7 @@ bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 float EqEffect::peakBand( float minF, float maxF, EqAnalyser *fft, int sr )
 {
 	auto const fftEnergy = fft->getEnergy();
-	if (fftEnergy == 0.)
-	{
-		return 0.;
-	}
+	if (fftEnergy == 0.) { return 0.; }
 
 	float peak = -60;
 	float *b = fft->m_bands;
@@ -302,7 +299,7 @@ float EqEffect::peakBand( float minF, float maxF, EqAnalyser *fft, int sr )
 	{
 		if( bandToFreq( x ,sr) >= minF && bandToFreq( x,sr ) <= maxF )
 		{
-			h = 20. * ( log10( *b / fftEnergy ) );
+			h = 20. * log10(*b / fftEnergy);
 			peak = h > peak ? h : peak;
 		}
 	}

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -289,6 +289,12 @@ bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 
 float EqEffect::peakBand( float minF, float maxF, EqAnalyser *fft, int sr )
 {
+	auto const fftEnergy = fft->getEnergy();
+	if (fftEnergy == 0.)
+	{
+		return 0.;
+	}
+
 	float peak = -60;
 	float *b = fft->m_bands;
 	float h = 0;
@@ -296,7 +302,7 @@ float EqEffect::peakBand( float minF, float maxF, EqAnalyser *fft, int sr )
 	{
 		if( bandToFreq( x ,sr) >= minF && bandToFreq( x,sr ) <= maxF )
 		{
-			h = 20 * ( log10( *b / fft->getEnergy() ) );
+			h = 20 * ( log10( *b / fftEnergy ) );
 			peak = h > peak ? h : peak;
 		}
 	}

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -302,7 +302,7 @@ float EqEffect::peakBand( float minF, float maxF, EqAnalyser *fft, int sr )
 	{
 		if( bandToFreq( x ,sr) >= minF && bandToFreq( x,sr ) <= maxF )
 		{
-			h = 20 * ( log10( *b / fftEnergy ) );
+			h = 20. * ( log10( *b / fftEnergy ) );
 			peak = h > peak ? h : peak;
 		}
 	}

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -209,7 +209,7 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 void EqSpectrumView::paintEvent(QPaintEvent *event)
 {
 	const float energy = m_analyser->getEnergy();
-	if (energy <= 0)
+	if (energy <= 0.)
 	{		
 		// If there is no energy in the signal we don't need to draw anything
 		return;
@@ -238,7 +238,7 @@ void EqSpectrumView::paintEvent(QPaintEvent *event)
 	const float fallOff = 1.07;
 	for( int x = 0; x < MAX_BANDS; ++x, ++bands )
 	{
-		peak = *bands != 0 ? ( fh * 2.0 / 3.0 * ( 20 * ( log10( *bands / energy ) ) - LOWER_Y ) / ( - LOWER_Y ) ) : 0.;
+		peak = *bands != 0. ? ( fh * 2.0 / 3.0 * ( 20. * ( log10( *bands / energy ) ) - LOWER_Y ) / ( - LOWER_Y ) ) : 0.;
 		if( peak < 0 )
 		{
 			peak = 0;

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -238,7 +238,8 @@ void EqSpectrumView::paintEvent(QPaintEvent *event)
 	const float fallOff = 1.07;
 	for( int x = 0; x < MAX_BANDS; ++x, ++bands )
 	{
-		peak = *bands != 0. ? ( fh * 2.0 / 3.0 * ( 20. * ( log10( *bands / energy ) ) - LOWER_Y ) / ( - LOWER_Y ) ) : 0.;
+		peak = *bands != 0. ? (fh * 2.0 / 3.0 * (20. * log10(*bands / energy) - LOWER_Y) / (-LOWER_Y)) : 0.;
+
 		if( peak < 0 )
 		{
 			peak = 0;

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -208,10 +208,10 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 
 void EqSpectrumView::paintEvent(QPaintEvent *event)
 {
-	const float energy =  m_analyser->getEnergy();
-	if( energy <= 0 && m_peakSum <= 0 )
+	const float energy = m_analyser->getEnergy();
+	if (energy <= 0)
 	{		
-		//dont draw anything
+		// If there is no energy in the signal we don't need to draw anything
 		return;
 	}
 
@@ -238,7 +238,7 @@ void EqSpectrumView::paintEvent(QPaintEvent *event)
 	const float fallOff = 1.07;
 	for( int x = 0; x < MAX_BANDS; ++x, ++bands )
 	{
-		peak = ( fh * 2.0 / 3.0 * ( 20 * ( log10( *bands / energy ) ) - LOWER_Y ) / ( - LOWER_Y ) );
+		peak = *bands != 0 ? ( fh * 2.0 / 3.0 * ( 20 * ( log10( *bands / energy ) ) - LOWER_Y ) / ( - LOWER_Y ) ) : 0.;
 		if( peak < 0 )
 		{
 			peak = 0;


### PR DESCRIPTION
Fix several NaNs in the context of the basic filters and the Equalizer.

The coefficients of the `BiQuad` were not initialized which seems to have led to NaNs down the line.

Fix a division by zero in `EqEffect::peakBand` and `EqSpectrumView::paintEvent` if the energy is zero.

The condition `m_peakSum <= 0` was removed from `EqSpectrumView::paintEvent` because the value is initialized to 0 down the line and later only potentially positive values are added.

Seems to fix #7131.