### PR TITLE
Fix NaNs for some dbFS value displays (-∞ dbFS)

### DIFF
--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -303,8 +303,17 @@ void Fader::updateTextFloat()
 {
 	if( ConfigManager::inst()->value( "app", "displaydbfs" ).toInt() && m_conversionFactor == 100.0 )
 	{
-		s_textFloat->setText( QString("Volume: %1 dBFS").
-				arg( ampToDbfs( model()->value() ), 3, 'f', 2 ) );
+		QString label(tr("Volume: %1 dBFS"));
+
+		auto const modelValue = model()->value();
+		if (modelValue <= 0.)
+		{
+			s_textFloat->setText(label.arg("-∞"));
+		}
+		else
+		{
+			s_textFloat->setText(label.arg(ampToDbfs(modelValue), 3, 'f', 2));
+		}
 	}
 	else
 	{

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -388,12 +388,15 @@ void FloatModelEditorBase::enterValue()
 	if (isVolumeKnob() &&
 		ConfigManager::inst()->value("app", "displaydbfs").toInt())
 	{
+		auto const initalValue = model()->getRoundedValue() / 100.0;
+		auto const initialDbValue = initalValue > 0. ? ampToDbfs(initalValue) : -96;
+
 		new_val = QInputDialog::getDouble(
 			this, tr("Set value"),
 			tr("Please enter a new value between "
 					"-96.0 dBFS and 6.0 dBFS:"),
-				ampToDbfs(model()->getRoundedValue() / 100.0),
-							-96.0, 6.0, model()->getDigitCount(), &ok);
+				initialDbValue, -96.0, 6.0, model()->getDigitCount(), &ok);
+
 		if (new_val <= -96.0)
 		{
 			new_val = 0.0f;
@@ -439,9 +442,16 @@ QString FloatModelEditorBase::displayValue() const
 	if (isVolumeKnob() &&
 		ConfigManager::inst()->value("app", "displaydbfs").toInt())
 	{
-		return m_description.trimmed() + QString(" %1 dBFS").
-				arg(ampToDbfs(model()->getRoundedValue() / volumeRatio()),
-								3, 'f', 2);
+		auto const valueToVolumeRatio = model()->getRoundedValue() / volumeRatio();
+		if (valueToVolumeRatio == 0.)
+		{
+			return m_description.trimmed() + QString(" -∞ dBFS");
+		}
+		else
+		{
+			return m_description.trimmed() + QString(" %1 dBFS").
+				arg(ampToDbfs(valueToVolumeRatio), 3, 'f', 2);
+		}
 	}
 
 	return m_description.trimmed() + QString(" %1").


### PR DESCRIPTION
Fix some NaNs in the context of the display of dbFS values. They occur during the display of the current value when a mixer fader or the volume knob of an instrument is pulled down completely.

The fix is to detect these cases and to display "-∞ dbFS".

Also fix a problem with the editor where dbFS values can be entered for volume knobs. When the knob is turned completely to the left and the amplification is 0 then the initially displayed value is set to -96 dBFS, i.e. the lower limit that is shown in the dialog. This is done because the dialog likely cannot handle displaying or entering "-∞".