### PR TITLE
Update game-music-emu submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/lmms/zynaddsubfx.git
 [submodule "plugins/FreeBoy/game-music-emu"]
 	path = plugins/FreeBoy/game-music-emu
-	url = https://bitbucket.org/mpyne/game-music-emu.git
+	url = https://github.com/libgme/game-music-emu.git
 [submodule "plugins/OpulenZ/adplug"]
 	path = plugins/OpulenZ/adplug
 	url = https://github.com/adplug/adplug.git


### PR DESCRIPTION
The `game-music-emu` submodule used by FreeBoy has migrated from Bitbucket (https://bitbucket.org/mpyne/game-music-emu) to GitHub (https://github.com/libgme/game-music-emu).

This PR modifies our submodule to point to its new GitHub URL and also updates to the latest commit on `game-music-emu`'s master branch. This lets LMMS incorporate several of the upstream bug fixes for the Game Boy APU emulator that have been made over the years. I do not know yet whether this will resolve any of LMMS's open FreeBoy issues.

EDIT: The gme upgrade didn't seem to fix any of the open FreeBoy issues.