### PR TITLE
Check if `m_peakSum` is less than or equal to 0 again

### DIFF
--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -209,11 +209,7 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 void EqSpectrumView::paintEvent(QPaintEvent *event)
 {
 	const float energy = m_analyser->getEnergy();
-	if (energy <= 0.)
-	{		
-		// If there is no energy in the signal we don't need to draw anything
-		return;
-	}
+	if (energy <= 0. && m_peakSum <= 0) { return; }
 
 	const int fh = height();
 	const int LOWER_Y = -36;	// dB


### PR DESCRIPTION
The conditional check for if `m_peakSum <= 0` in `EqSpectrumView` was removed in #7141. I think the reason for removing it was not warranted at all, and actually caused a bug where the EQ display simply flickers, rather than doing a fade out when the signal drops in volume.