### PR TITLE
Refactor `gui_templates.h`

### DIFF
--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -48,10 +48,10 @@ inline QFont pointSize(QFont _f, float SIZE)
 {
 	// to calculate DPI of a screen to make it HiDPI ready
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-    qreal scaleFactor = devicePixelRatio > 1.0 ? devicePixelRatio : 1.0; // Ensure scaleFactor is at least 1.0
+    qreal scaleFactor = std::max(devicePixelRatio, 1.0); // Ensure scaleFactor is at least 1.0
 
 	_f.setPointSizeF(SIZE * scaleFactor);
-	return( _f );
+	return (_f);
 }
 
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -43,14 +43,14 @@ namespace lmms
 
 // return DPI-independent font-size - font with returned font-size has always
 // the same size in pixels
-inline QFont pointSize(QFont _f, float SIZE)
+inline QFont pointSize(QFont fontPointer, float fontSize)
 {
 	// to calculate DPI of a screen to make it HiDPI ready
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
     qreal scaleFactor = std::max(devicePixelRatio, 1.0); // Ensure scaleFactor is at least 1.0
 
-	_f.setPointSizeF(SIZE * scaleFactor);
-	return (_f);
+	fontPointer.setPointSizeF(fontSize * scaleFactor);
+	return fontPointer;
 }
 
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -44,18 +44,14 @@ namespace lmms
 
 // return DPI-independent font-size - font with returned font-size has always
 // the same size in pixels
-inline QFont pointSize(QFont _f, int SIZE)
+template<typename T>
+inline QFont pointSize(QFont _f, T SIZE)
 {
-	_f.setPointSizeF((int)(((float)SIZE + 0.5f) * 96 / 
-		QGuiApplication::primaryScreen()->logicalDotsPerInchY()));
-	return( _f );
-}
+	// to calculate DPI of a screen to make it HiDPI ready
+	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
+    qreal scaleFactor = devicePixelRatio > 1.0 ? devicePixelRatio : 1.0; // Ensure scaleFactor is at least 1.0
 
-
-inline QFont pointSizeF( QFont _f, float SIZE )
-{
-	_f.setPointSizeF((SIZE+0.5f) * 96 /
-			QGuiApplication::primaryScreen()->logicalDotsPerInchY());
+	_f.setPointSizeF((float)SIZE * scaleFactor);
 	return( _f );
 }
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -31,37 +31,31 @@
 #include <QFont>
 #include <QDesktopWidget>
 
+// TODO: cleanup for qt6
+#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
+	#include <QScreen>
+#else
+	#include <QGuiApplication>
+#endif
+
 namespace lmms
 {
 
 
 // return DPI-independent font-size - font with returned font-size has always
 // the same size in pixels
-template<int SIZE>
-inline QFont pointSize( QFont _f )
+inline QFont pointSize(QFont _f, int SIZE)
 {
-	static const float DPI = 96;
-#ifdef LMMS_BUILD_WIN32
-	_f.setPointSizeF( ((float) SIZE+0.5f) * DPI /
-			QApplication::desktop()->logicalDpiY() );
-#else
-	_f.setPointSizeF( (float) SIZE * DPI /
-			QApplication::desktop()->logicalDpiY() );
-#endif
+	_f.setPointSizeF((int)(((float)SIZE + 0.5f) * 96 / 
+		QGuiApplication::primaryScreen()->logicalDotsPerInchY()));
 	return( _f );
 }
 
 
 inline QFont pointSizeF( QFont _f, float SIZE )
 {
-	static const float DPI = 96;
-#ifdef LMMS_BUILD_WIN32
-	_f.setPointSizeF( (SIZE+0.5f) * DPI /
-			QApplication::desktop()->logicalDpiY() );
-#else
-	_f.setPointSizeF( SIZE * DPI /
-			QApplication::desktop()->logicalDpiY() );
-#endif
+	_f.setPointSizeF((SIZE+0.5f) * 96 /
+			QGuiApplication::primaryScreen()->logicalDotsPerInchY());
 	return( _f );
 }
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -44,14 +44,13 @@ namespace lmms
 
 // return DPI-independent font-size - font with returned font-size has always
 // the same size in pixels
-template<typename T>
-inline QFont pointSize(QFont _f, T SIZE)
+inline QFont pointSize(QFont _f, float SIZE)
 {
 	// to calculate DPI of a screen to make it HiDPI ready
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
     qreal scaleFactor = devicePixelRatio > 1.0 ? devicePixelRatio : 1.0; // Ensure scaleFactor is at least 1.0
 
-	_f.setPointSizeF((float)SIZE * scaleFactor);
+	_f.setPointSizeF(SIZE * scaleFactor);
 	return( _f );
 }
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -27,14 +27,14 @@
 
 #include "lmmsconfig.h"
 
+#include <algorithm>
 #include <QApplication>
 #include <QFont>
+#include <QGuiApplication>
 
-// TODO: cleanup for qt6
+// TODO: remove once qt5 support is dropped
 #if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
 	#include <QScreen>
-#else
-	#include <QGuiApplication>
 #endif
 
 namespace lmms

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -29,7 +29,6 @@
 
 #include <QApplication>
 #include <QFont>
-#include <QDesktopWidget>
 
 // TODO: cleanup for qt6
 #if (QT_VERSION < QT_VERSION_CHECK(6,0,0))

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -37,7 +37,7 @@
 	#include <QScreen>
 #endif
 
-namespace lmms
+namespace lmms::gui
 {
 
 
@@ -54,6 +54,6 @@ inline QFont pointSize(QFont fontPointer, float fontSize)
 }
 
 
-} // namespace lmms
+} // namespace lmms::gui
 
 #endif // LMMS_GUI_TEMPLATES_H

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -134,7 +134,7 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 // interpolation selector
 	m_interpBox = new ComboBox(this);
 	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-	m_interpBox->setFont(pointSize<8>(m_interpBox->font()));
+	m_interpBox->setFont(pointSize(m_interpBox->font(), 8));
 
 // wavegraph
 	m_waveView = 0;
@@ -228,7 +228,7 @@ void AudioFileProcessorView::paintEvent(QPaintEvent*)
 
 	int idx = a->sample().sampleFile().length();
 
-	p.setFont(pointSize<8>(font()));
+	p.setFont(pointSize(font(), 8));
 
 	QFontMetrics fm(p.font());
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -134,7 +134,7 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 // interpolation selector
 	m_interpBox = new ComboBox(this);
 	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-	m_interpBox->setFont(pointSize<int>(m_interpBox->font(), 8));
+	m_interpBox->setFont(pointSize(m_interpBox->font(), 8));
 
 // wavegraph
 	m_waveView = 0;
@@ -228,7 +228,7 @@ void AudioFileProcessorView::paintEvent(QPaintEvent*)
 
 	int idx = a->sample().sampleFile().length();
 
-	p.setFont(pointSize<int>(font(), 8));
+	p.setFont(pointSize(font(), 8));
 
 	QFontMetrics fm(p.font());
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -134,7 +134,7 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 // interpolation selector
 	m_interpBox = new ComboBox(this);
 	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-	m_interpBox->setFont(pointSize(m_interpBox->font(), 8));
+	m_interpBox->setFont(pointSize<int>(m_interpBox->font(), 8));
 
 // wavegraph
 	m_waveView = 0;
@@ -228,7 +228,7 @@ void AudioFileProcessorView::paintEvent(QPaintEvent*)
 
 	int idx = a->sample().sampleFile().length();
 
-	p.setFont(pointSize(font(), 8));
+	p.setFont(pointSize<int>(font(), 8));
 
 	QFontMetrics fm(p.font());
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -273,7 +273,7 @@ void AudioFileProcessorWaveView::paintEvent(QPaintEvent * pe)
 	p.fillRect(s_padding, s_padding, m_graph.width(), 14, g);
 
 	p.setPen(QColor(255, 255, 255));
-	p.setFont(pointSize<8>(font()));
+	p.setFont(pointSize(font(), 8));
 
 	QString length_text;
 	const int length = m_sample->sampleDuration().count();

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -273,7 +273,7 @@ void AudioFileProcessorWaveView::paintEvent(QPaintEvent * pe)
 	p.fillRect(s_padding, s_padding, m_graph.width(), 14, g);
 
 	p.setPen(QColor(255, 255, 255));
-	p.setFont(pointSize(font(), 8));
+	p.setFont(pointSize<int>(font(), 8));
 
 	QString length_text;
 	const int length = m_sample->sampleDuration().count();

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -273,7 +273,7 @@ void AudioFileProcessorWaveView::paintEvent(QPaintEvent * pe)
 	p.fillRect(s_padding, s_padding, m_graph.width(), 14, g);
 
 	p.setPen(QColor(255, 255, 255));
-	p.setFont(pointSize<int>(font(), 8));
+	p.setFont(pointSize(font(), 8));
 
 	QString length_text;
 	const int length = m_sample->sampleDuration().count();

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -632,7 +632,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleUIButton->setCheckable( true );
     m_toggleUIButton->setChecked( false );
     m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-    m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+    m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
     connect( m_toggleUIButton, SIGNAL( clicked(bool) ), this, SLOT( toggleUI( bool ) ) );
 
     m_toggleUIButton->setToolTip(

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -632,7 +632,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleUIButton->setCheckable( true );
     m_toggleUIButton->setChecked( false );
     m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-    m_toggleUIButton->setFont( pointSize<8>( m_toggleUIButton->font() ) );
+    m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
     connect( m_toggleUIButton, SIGNAL( clicked(bool) ), this, SLOT( toggleUI( bool ) ) );
 
     m_toggleUIButton->setToolTip(
@@ -642,7 +642,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleParamsWindowButton = new QPushButton(tr("Params"), this);
     m_toggleParamsWindowButton->setIcon(embed::getIconPixmap("controller"));
     m_toggleParamsWindowButton->setCheckable(true);
-    m_toggleParamsWindowButton->setFont(pointSize<8>(m_toggleParamsWindowButton->font()));
+    m_toggleParamsWindowButton->setFont(pointSize(m_toggleParamsWindowButton->font(), 8));
 #if CARLA_VERSION_HEX < CARLA_MIN_PARAM_VERSION
     m_toggleParamsWindowButton->setEnabled(false);
     m_toggleParamsWindowButton->setToolTip(tr("Available from Carla version 2.1 and up."));

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -632,7 +632,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleUIButton->setCheckable( true );
     m_toggleUIButton->setChecked( false );
     m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-    m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
+    m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
     connect( m_toggleUIButton, SIGNAL( clicked(bool) ), this, SLOT( toggleUI( bool ) ) );
 
     m_toggleUIButton->setToolTip(
@@ -642,7 +642,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleParamsWindowButton = new QPushButton(tr("Params"), this);
     m_toggleParamsWindowButton->setIcon(embed::getIconPixmap("controller"));
     m_toggleParamsWindowButton->setCheckable(true);
-    m_toggleParamsWindowButton->setFont(pointSize<int>(m_toggleParamsWindowButton->font(), 8));
+    m_toggleParamsWindowButton->setFont(pointSize(m_toggleParamsWindowButton->font(), 8));
 #if CARLA_VERSION_HEX < CARLA_MIN_PARAM_VERSION
     m_toggleParamsWindowButton->setEnabled(false);
     m_toggleParamsWindowButton->setToolTip(tr("Available from Carla version 2.1 and up."));

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -642,7 +642,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleParamsWindowButton = new QPushButton(tr("Params"), this);
     m_toggleParamsWindowButton->setIcon(embed::getIconPixmap("controller"));
     m_toggleParamsWindowButton->setCheckable(true);
-    m_toggleParamsWindowButton->setFont(pointSize(m_toggleParamsWindowButton->font(), 8));
+    m_toggleParamsWindowButton->setFont(pointSize<int>(m_toggleParamsWindowButton->font(), 8));
 #if CARLA_VERSION_HEX < CARLA_MIN_PARAM_VERSION
     m_toggleParamsWindowButton->setEnabled(false);
     m_toggleParamsWindowButton->setToolTip(tr("Available from Carla version 2.1 and up."));

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -76,12 +76,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 
 	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter1ComboBox->setFont( pointSize<8>( m_filter1ComboBox->font() ) );
+	m_filter1ComboBox->setFont(pointSize(m_filter1ComboBox->font(), 8));
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter2ComboBox->setFont( pointSize<8>( m_filter2ComboBox->font() ) );
+	m_filter2ComboBox->setFont(pointSize(m_filter2ComboBox->font(), 8));
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }
 

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -76,12 +76,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 
 	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter1ComboBox->setFont(pointSize(m_filter1ComboBox->font(), 8));
+	m_filter1ComboBox->setFont(pointSize<int>(m_filter1ComboBox->font(), 8));
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter2ComboBox->setFont(pointSize(m_filter2ComboBox->font(), 8));
+	m_filter2ComboBox->setFont(pointSize<int>(m_filter2ComboBox->font(), 8));
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }
 

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -76,12 +76,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 
 	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter1ComboBox->setFont(pointSize<int>(m_filter1ComboBox->font(), 8));
+	m_filter1ComboBox->setFont(pointSize(m_filter1ComboBox->font(), 8));
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter2ComboBox->setFont(pointSize<int>(m_filter2ComboBox->font(), 8));
+	m_filter2ComboBox->setFont(pointSize(m_filter2ComboBox->font(), 8));
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }
 

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -172,7 +172,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
-	title->setFont( pointSize<12>( f ) );
+	title->setFont(pointSize(f, 12));
 
 	layout->addSpacing( 5 );
 	layout->addWidget( title );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -172,7 +172,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
-	title->setFont(pointSize(f, 12));
+	title->setFont(pointSize<int>(f, 12));
 
 	layout->addSpacing( 5 );
 	layout->addWidget( title );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -172,7 +172,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
-	title->setFont(pointSize<int>(f, 12));
+	title->setFont(pointSize(f, 12));
 
 	layout->addSpacing( 5 );
 	layout->addWidget( title );

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1694,7 +1694,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc2WaveBox = new ComboBox( view );
 	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc2WaveBox->setFont( pointSize<8>( m_osc2WaveBox->font() ) );
+	m_osc2WaveBox->setFont(pointSize(m_osc2WaveBox->font(), 8));
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
@@ -1709,18 +1709,18 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc3Wave1Box = new ComboBox( view );
 	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave1Box->setFont( pointSize<8>( m_osc3Wave1Box->font() ) );
+	m_osc3Wave1Box->setFont(pointSize(m_osc3Wave1Box->font(), 8));
 
 	m_osc3Wave2Box = new ComboBox( view );
 	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave2Box->setFont( pointSize<8>( m_osc3Wave2Box->font() ) );
+	m_osc3Wave2Box->setFont(pointSize(m_osc3Wave2Box->font(), 8));
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo1WaveBox->setFont( pointSize<8>( m_lfo1WaveBox->font() ) );
+	m_lfo1WaveBox->setFont(pointSize(m_lfo1WaveBox->font(), 8));
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
 	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
@@ -1728,7 +1728,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo2WaveBox->setFont( pointSize<8>( m_lfo2WaveBox->font() ) );
+	m_lfo2WaveBox->setFont(pointSize(m_lfo2WaveBox->font(), 8));
 
 	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob")
 	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob")

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1694,7 +1694,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc2WaveBox = new ComboBox( view );
 	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc2WaveBox->setFont(pointSize<int>(m_osc2WaveBox->font(), 8));
+	m_osc2WaveBox->setFont(pointSize(m_osc2WaveBox->font(), 8));
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
@@ -1709,18 +1709,18 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc3Wave1Box = new ComboBox( view );
 	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave1Box->setFont(pointSize<int>(m_osc3Wave1Box->font(), 8));
+	m_osc3Wave1Box->setFont(pointSize(m_osc3Wave1Box->font(), 8));
 
 	m_osc3Wave2Box = new ComboBox( view );
 	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave2Box->setFont(pointSize<int>(m_osc3Wave2Box->font(), 8));
+	m_osc3Wave2Box->setFont(pointSize(m_osc3Wave2Box->font(), 8));
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo1WaveBox->setFont(pointSize<int>(m_lfo1WaveBox->font(), 8));
+	m_lfo1WaveBox->setFont(pointSize(m_lfo1WaveBox->font(), 8));
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
 	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
@@ -1728,7 +1728,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo2WaveBox->setFont(pointSize<int>(m_lfo2WaveBox->font(), 8));
+	m_lfo2WaveBox->setFont(pointSize(m_lfo2WaveBox->font(), 8));
 
 	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob")
 	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob")

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1694,7 +1694,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc2WaveBox = new ComboBox( view );
 	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc2WaveBox->setFont(pointSize(m_osc2WaveBox->font(), 8));
+	m_osc2WaveBox->setFont(pointSize<int>(m_osc2WaveBox->font(), 8));
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
@@ -1709,18 +1709,18 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc3Wave1Box = new ComboBox( view );
 	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave1Box->setFont(pointSize(m_osc3Wave1Box->font(), 8));
+	m_osc3Wave1Box->setFont(pointSize<int>(m_osc3Wave1Box->font(), 8));
 
 	m_osc3Wave2Box = new ComboBox( view );
 	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave2Box->setFont(pointSize(m_osc3Wave2Box->font(), 8));
+	m_osc3Wave2Box->setFont(pointSize<int>(m_osc3Wave2Box->font(), 8));
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo1WaveBox->setFont(pointSize(m_lfo1WaveBox->font(), 8));
+	m_lfo1WaveBox->setFont(pointSize<int>(m_lfo1WaveBox->font(), 8));
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
 	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
@@ -1728,7 +1728,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo2WaveBox->setFont(pointSize(m_lfo2WaveBox->font(), 8));
+	m_lfo2WaveBox->setFont(pointSize<int>(m_lfo2WaveBox->font(), 8));
 
 	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob")
 	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob")

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -548,7 +548,7 @@ void PatmanView::updateFilename()
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
 
-	QFontMetrics fm(pointSize(font(), 8));
+	QFontMetrics fm(pointSize<int>(font(), 8));
 
 	// simple algorithm for creating a text from the filename that
 	// matches in the white rectangle
@@ -618,7 +618,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	p.setFont(pointSize(font() ,8));
+	p.setFont(pointSize<int>(font() ,8));
 	p.drawText( 8, 116, 235, 16,
 			Qt::AlignLeft | Qt::TextSingleLine | Qt::AlignVCenter,
 			m_displayFilename );

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -548,7 +548,7 @@ void PatmanView::updateFilename()
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
 
-	QFontMetrics fm( pointSize<8>( font() ) );
+	QFontMetrics fm(pointSize(font(), 8));
 
 	// simple algorithm for creating a text from the filename that
 	// matches in the white rectangle
@@ -618,7 +618,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	p.setFont( pointSize<8>( font() ) );
+	p.setFont(pointSize(font() ,8));
 	p.drawText( 8, 116, 235, 16,
 			Qt::AlignLeft | Qt::TextSingleLine | Qt::AlignVCenter,
 			m_displayFilename );

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -548,7 +548,7 @@ void PatmanView::updateFilename()
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
 
-	QFontMetrics fm(pointSize<int>(font(), 8));
+	QFontMetrics fm(pointSize(font(), 8));
 
 	// simple algorithm for creating a text from the filename that
 	// matches in the white rectangle
@@ -618,7 +618,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	p.setFont(pointSize<int>(font() ,8));
+	p.setFont(pointSize(font() ,8));
 	p.drawText( 8, 116, 235, 16,
 			Qt::AlignLeft | Qt::TextSingleLine | Qt::AlignVCenter,
 			m_displayFilename );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -450,7 +450,7 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
 	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
-	m_presetsCombo->setFont( pointSize<8>( m_presetsCombo->font() ) );
+	m_presetsCombo->setFont(pointSize(m_presetsCombo->font(), 8));
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -450,7 +450,7 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
 	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
-	m_presetsCombo->setFont(pointSize(m_presetsCombo->font(), 8));
+	m_presetsCombo->setFont(pointSize<int>(m_presetsCombo->font(), 8));
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -450,7 +450,7 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
 	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
-	m_presetsCombo->setFont(pointSize<int>(m_presetsCombo->font(), 8));
+	m_presetsCombo->setFont(pointSize(m_presetsCombo->font(), 8));
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -587,7 +587,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_toggleGUIButton = new QPushButton( tr( "Show/hide GUI" ), this );
 	m_toggleGUIButton->setGeometry( 20, 130, 200, 24 );
 	m_toggleGUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleGUIButton->setFont(pointSize(m_toggleGUIButton->font(), 8));
+	m_toggleGUIButton->setFont(pointSize<int>(m_toggleGUIButton->font(), 8));
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
@@ -596,7 +596,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
-	note_off_all_btn->setFont(pointSize(note_off_all_btn->font(), 8));
+	note_off_all_btn->setFont(pointSize<int>(note_off_all_btn->font(), 8));
 	connect( note_off_all_btn, SIGNAL( clicked() ), this,
 							SLOT( noteOffAll() ) );
 
@@ -881,7 +881,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 				tr( "No VST plugin loaded" );
 	QFont f = p.font();
 	f.setBold( true );
-	p.setFont(pointSize(f, 10));
+	p.setFont(pointSize<int>(f, 10));
 	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( 10, 100, plugin_name );
 
@@ -893,7 +893,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 	{
 		p.setPen( QColor( 0, 0, 0 ) );
 		f.setBold( false );
-		p.setFont(pointSize(f, 8));
+		p.setFont(pointSize<int>(f, 8));
 		p.drawText( 10, 114, tr( "by " ) +
 					m_vi->m_plugin->vendorString() );
 		p.setPen( QColor( 255, 255, 255 ) );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -587,7 +587,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_toggleGUIButton = new QPushButton( tr( "Show/hide GUI" ), this );
 	m_toggleGUIButton->setGeometry( 20, 130, 200, 24 );
 	m_toggleGUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleGUIButton->setFont(pointSize<int>(m_toggleGUIButton->font(), 8));
+	m_toggleGUIButton->setFont(pointSize(m_toggleGUIButton->font(), 8));
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
@@ -596,7 +596,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
-	note_off_all_btn->setFont(pointSize<int>(note_off_all_btn->font(), 8));
+	note_off_all_btn->setFont(pointSize(note_off_all_btn->font(), 8));
 	connect( note_off_all_btn, SIGNAL( clicked() ), this,
 							SLOT( noteOffAll() ) );
 
@@ -881,7 +881,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 				tr( "No VST plugin loaded" );
 	QFont f = p.font();
 	f.setBold( true );
-	p.setFont(pointSize<int>(f, 10));
+	p.setFont(pointSize(f, 10));
 	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( 10, 100, plugin_name );
 
@@ -893,7 +893,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 	{
 		p.setPen( QColor( 0, 0, 0 ) );
 		f.setBold( false );
-		p.setFont(pointSize<int>(f, 8));
+		p.setFont(pointSize(f, 8));
 		p.drawText( 10, 114, tr( "by " ) +
 					m_vi->m_plugin->vendorString() );
 		p.setPen( QColor( 255, 255, 255 ) );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -587,7 +587,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_toggleGUIButton = new QPushButton( tr( "Show/hide GUI" ), this );
 	m_toggleGUIButton->setGeometry( 20, 130, 200, 24 );
 	m_toggleGUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleGUIButton->setFont( pointSize<8>( m_toggleGUIButton->font() ) );
+	m_toggleGUIButton->setFont(pointSize(m_toggleGUIButton->font(), 8));
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
@@ -596,7 +596,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
-	note_off_all_btn->setFont( pointSize<8>( note_off_all_btn->font() ) );
+	note_off_all_btn->setFont(pointSize(note_off_all_btn->font(), 8));
 	connect( note_off_all_btn, SIGNAL( clicked() ), this,
 							SLOT( noteOffAll() ) );
 
@@ -881,7 +881,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 				tr( "No VST plugin loaded" );
 	QFont f = p.font();
 	f.setBold( true );
-	p.setFont( pointSize<10>( f ) );
+	p.setFont(pointSize(f, 10));
 	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( 10, 100, plugin_name );
 
@@ -893,7 +893,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 	{
 		p.setPen( QColor( 0, 0, 0 ) );
 		f.setBold( false );
-		p.setFont( pointSize<8>( f ) );
+		p.setFont(pointSize(f, 8));
 		p.drawText( 10, 114, tr( "by " ) +
 					m_vi->m_plugin->vendorString() );
 		p.setPen( QColor( 255, 255, 255 ) );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -246,7 +246,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		tb->addWidget(space1);
 
 		tbLabel = new QLabel( tr( "Effect by: " ), this );
-		tbLabel->setFont( pointSize<7>( f ) );
+		tbLabel->setFont(pointSize(f, 7));
 		tbLabel->setTextFormat(Qt::RichText);
 		tbLabel->setAlignment( Qt::AlignTop | Qt::AlignLeft );
 		tb->addWidget( tbLabel );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -246,7 +246,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		tb->addWidget(space1);
 
 		tbLabel = new QLabel( tr( "Effect by: " ), this );
-		tbLabel->setFont(pointSize(f, 7));
+		tbLabel->setFont(pointSize<int>(f, 7));
 		tbLabel->setTextFormat(Qt::RichText);
 		tbLabel->setAlignment( Qt::AlignTop | Qt::AlignLeft );
 		tb->addWidget( tbLabel );

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -246,7 +246,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		tb->addWidget(space1);
 
 		tbLabel = new QLabel( tr( "Effect by: " ), this );
-		tbLabel->setFont(pointSize<int>(f, 7));
+		tbLabel->setFont(pointSize(f, 7));
 		tbLabel->setTextFormat(Qt::RichText);
 		tbLabel->setAlignment( Qt::AlignTop | Qt::AlignLeft );
 		tb->addWidget( tbLabel );

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -541,7 +541,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	m_toggleUIButton->setCheckable( true );
 	m_toggleUIButton->setChecked( false );
 	m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleUIButton->setFont( pointSize<8>( m_toggleUIButton->font() ) );
+	m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
 	connect( m_toggleUIButton, SIGNAL( toggled( bool ) ), this,
 							SLOT( toggleUI() ) );
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -541,7 +541,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	m_toggleUIButton->setCheckable( true );
 	m_toggleUIButton->setChecked( false );
 	m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
+	m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
 	connect( m_toggleUIButton, SIGNAL( toggled( bool ) ), this,
 							SLOT( toggleUI() ) );
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -541,7 +541,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	m_toggleUIButton->setCheckable( true );
 	m_toggleUIButton->setChecked( false );
 	m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+	m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
 	connect( m_toggleUIButton, SIGNAL( toggled( bool ) ), this,
 							SLOT( toggleUI() ) );
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -37,7 +37,6 @@
 #include "LcdSpinBox.h"
 #include "MainWindow.h"
 #include "MidiJack.h"
-#include "gui_templates.h"
 
 namespace lmms
 {

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -34,7 +34,6 @@
 #include "LcdSpinBox.h"
 #include "AudioEngine.h"
 #include "Engine.h"
-#include "gui_templates.h"
 
 #ifdef LMMS_HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -53,7 +53,6 @@ void AudioPortAudioSetupUtil::updateChannels()
 
 #include "Engine.h"
 #include "ConfigManager.h"
-#include "gui_templates.h"
 #include "ComboBox.h"
 #include "AudioEngine.h"
 

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -32,7 +32,6 @@
 #include "ConfigManager.h"
 #include "LcdSpinBox.h"
 #include "AudioEngine.h"
-#include "gui_templates.h"
 #include "Engine.h"
 
 namespace lmms

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -32,7 +32,6 @@
 
 #include "AudioEngine.h"
 #include "ConfigManager.h"
-#include "gui_templates.h"
 
 namespace lmms
 {

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -35,7 +35,6 @@
 #include "LcdSpinBox.h"
 #include "AudioEngine.h"
 #include "Engine.h"
-#include "gui_templates.h"
 
 #include "ConfigManager.h"
 

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -32,7 +32,6 @@
 #include "Engine.h"
 #include "debug.h"
 #include "ConfigManager.h"
-#include "gui_templates.h"
 #include "ComboBox.h"
 #include "AudioEngine.h"
 

--- a/src/gui/AudioAlsaSetupWidget.cpp
+++ b/src/gui/AudioAlsaSetupWidget.cpp
@@ -31,7 +31,6 @@
 
 #include "ConfigManager.h"
 #include "LcdSpinBox.h"
-#include "gui_templates.h"
 
 namespace lmms::gui
 {

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -90,7 +90,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	{
 		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
-		ctls_btn->setFont(pointSize(f, 8));
+		ctls_btn->setFont(pointSize<int>(f, 8));
 		ctls_btn->setGeometry( 150, 14, 50, 20 );
 		connect( ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));
@@ -257,7 +257,7 @@ void EffectView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	p.drawPixmap( 0, 0, m_bg );
 
-	QFont f = pointSizeF( font(), 7.5f );
+	QFont f = pointSize<float>(font(), 7.5f);
 	f.setBold( true );
 	p.setFont( f );
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -90,7 +90,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	{
 		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
-		ctls_btn->setFont( pointSize<8>( f ) );
+		ctls_btn->setFont(pointSize(f, 8));
 		ctls_btn->setGeometry( 150, 14, 50, 20 );
 		connect( ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -90,7 +90,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	{
 		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
-		ctls_btn->setFont(pointSize<int>(f, 8));
+		ctls_btn->setFont(pointSize(f, 8));
 		ctls_btn->setGeometry( 150, 14, 50, 20 );
 		connect( ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));
@@ -257,7 +257,7 @@ void EffectView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	p.drawPixmap( 0, 0, m_bg );
 
-	QFont f = pointSize<float>(font(), 7.5f);
+	QFont f = pointSize(font(), 7.5f);
 	f.setBold( true );
 	p.setFont( f );
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -157,8 +157,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 		m_toggleUIButton->setCheckable(true);
 		m_toggleUIButton->setChecked(false);
 		m_toggleUIButton->setIcon(embed::getIconPixmap("zoom"));
-		m_toggleUIButton->setFont(
-			pointSize<8>(m_toggleUIButton->font()));
+		m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
 		btnBox->addWidget(m_toggleUIButton, 0);
 	}
 	btnBox->addStretch(1);

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -157,7 +157,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 		m_toggleUIButton->setCheckable(true);
 		m_toggleUIButton->setChecked(false);
 		m_toggleUIButton->setIcon(embed::getIconPixmap("zoom"));
-		m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
+		m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
 		btnBox->addWidget(m_toggleUIButton, 0);
 	}
 	btnBox->addStretch(1);

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -157,7 +157,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 		m_toggleUIButton->setCheckable(true);
 		m_toggleUIButton->setChecked(false);
 		m_toggleUIButton->setIcon(embed::getIconPixmap("zoom"));
-		m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+		m_toggleUIButton->setFont(pointSize<int>(m_toggleUIButton->font(), 8));
 		btnBox->addWidget(m_toggleUIButton, 0);
 	}
 	btnBox->addStretch(1);

--- a/src/gui/MidiSetupWidget.cpp
+++ b/src/gui/MidiSetupWidget.cpp
@@ -28,7 +28,6 @@
 #include <QLineEdit>
 
 #include "ConfigManager.h"
-#include "gui_templates.h"
 
 
 namespace lmms::gui

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -73,7 +73,7 @@ namespace lmms::gui
 
         m_renameLineEdit = new QLineEdit{mixerName, nullptr};
         m_renameLineEdit->setFixedWidth(65);
-        m_renameLineEdit->setFont(pointSizeF(font(), 7.5f));
+        m_renameLineEdit->setFont(pointSize<float>(font(), 7.5f));
         m_renameLineEdit->setReadOnly(true);
         m_renameLineEdit->installEventFilter(this);
 

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -73,7 +73,7 @@ namespace lmms::gui
 
         m_renameLineEdit = new QLineEdit{mixerName, nullptr};
         m_renameLineEdit->setFixedWidth(65);
-        m_renameLineEdit->setFont(pointSize<float>(font(), 7.5f));
+        m_renameLineEdit->setFont(pointSize(font(), 7.5f));
         m_renameLineEdit->setReadOnly(true);
         m_renameLineEdit->installEventFilter(this);
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -33,7 +33,6 @@
 
 #include "EffectRackView.h"
 #include "embed.h"
-#include "gui_templates.h"
 #include "GuiApplication.h"
 #include "Knob.h"
 #include "MainWindow.h"

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1065,7 +1065,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
-	p.setFont(pointSize(p.font(), 8));
+	p.setFont(pointSize<int>(p.font(), 8));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;
 
@@ -1423,7 +1423,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize( f, 14));
+		p.setFont(pointSize<int>(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText( VALUES_WIDTH + 20, TOP_MARGIN + 40,

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1065,7 +1065,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
-	p.setFont(pointSize<int>(p.font(), 8));
+	p.setFont(pointSize(p.font(), 8));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;
 
@@ -1423,7 +1423,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize<int>(f, 14));
+		p.setFont(pointSize(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText( VALUES_WIDTH + 20, TOP_MARGIN + 40,

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1065,7 +1065,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
-	p.setFont( pointSize<8>( p.font() ) );
+	p.setFont(pointSize(p.font(), 8));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;
 
@@ -1423,7 +1423,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont( pointSize<14>( f ) );
+		p.setFont(pointSize( f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText( VALUES_WIDTH + 20, TOP_MARGIN + 40,

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3338,7 +3338,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// display note editing info
 	//QFont f = p.font();
 	f.setBold( false );
-	p.setFont(pointSize<int>(f, 10));
+	p.setFont(pointSize(f, 10));
 	p.setPen(m_noteModeColor);
 	p.drawText( QRect( 0, keyAreaBottom(),
 					  m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()),
@@ -3601,7 +3601,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize<int>(f, 14));
+		p.setFont(pointSize(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText(m_whiteKeyWidth + 20, PR_TOP_MARGIN + 40,

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3338,7 +3338,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// display note editing info
 	//QFont f = p.font();
 	f.setBold( false );
-	p.setFont(pointSize(f, 10));
+	p.setFont(pointSize<int>(f, 10));
 	p.setPen(m_noteModeColor);
 	p.drawText( QRect( 0, keyAreaBottom(),
 					  m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()),
@@ -3601,7 +3601,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize(f, 14));
+		p.setFont(pointSize<int>(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText(m_whiteKeyWidth + 20, PR_TOP_MARGIN + 40,

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3338,7 +3338,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// display note editing info
 	//QFont f = p.font();
 	f.setBold( false );
-	p.setFont( pointSize<10>( f ) );
+	p.setFont(pointSize(f, 10));
 	p.setPen(m_noteModeColor);
 	p.drawText( QRect( 0, keyAreaBottom(),
 					  m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()),
@@ -3601,7 +3601,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont( pointSize<14>( f ) );
+		p.setFont(pointSize(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText(m_whiteKeyWidth + 20, PR_TOP_MARGIN + 40,

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -340,7 +340,7 @@ void EnvelopeAndLfoView::paintEvent( QPaintEvent * )
 	// draw LFO-graph
 	p.drawPixmap(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph);
 
-	p.setFont( pointSize<8>( p.font() ) );
+	p.setFont(pointSize(p.font(), 8));
 
 	const float gray_amount = 1.0f - fabsf( m_amountKnob->value<float>() );
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -207,7 +207,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoWaveBtnGrp->addButton( random_lfo_btn );
 
 	m_x100Cb = new LedCheckBox( tr( "FREQ x 100" ), this );
-	m_x100Cb->setFont( pointSizeF( m_x100Cb->font(), 6.5 ) );
+	m_x100Cb->setFont(pointSize<float>(m_x100Cb->font(), 6.5));
 	m_x100Cb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 36 );
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 
@@ -215,7 +215,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_controlEnvAmountCb = new LedCheckBox( tr( "MODULATE ENV AMOUNT" ),
 			this );
 	m_controlEnvAmountCb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 54 );
-	m_controlEnvAmountCb->setFont( pointSizeF( m_controlEnvAmountCb->font(), 6.5 ) );
+	m_controlEnvAmountCb->setFont(pointSize<float>(m_controlEnvAmountCb->font(), 6.5));
 	m_controlEnvAmountCb->setToolTip(
 				tr( "Control envelope amount by this LFO" ) );
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -207,7 +207,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoWaveBtnGrp->addButton( random_lfo_btn );
 
 	m_x100Cb = new LedCheckBox( tr( "FREQ x 100" ), this );
-	m_x100Cb->setFont(pointSize<float>(m_x100Cb->font(), 6.5));
+	m_x100Cb->setFont(pointSize(m_x100Cb->font(), 6.5));
 	m_x100Cb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 36 );
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 
@@ -215,7 +215,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_controlEnvAmountCb = new LedCheckBox( tr( "MODULATE ENV AMOUNT" ),
 			this );
 	m_controlEnvAmountCb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 54 );
-	m_controlEnvAmountCb->setFont(pointSize<float>(m_controlEnvAmountCb->font(), 6.5));
+	m_controlEnvAmountCb->setFont(pointSize(m_controlEnvAmountCb->font(), 6.5));
 	m_controlEnvAmountCb->setToolTip(
 				tr( "Control envelope amount by this LFO" ) );
 
@@ -340,7 +340,7 @@ void EnvelopeAndLfoView::paintEvent( QPaintEvent * )
 	// draw LFO-graph
 	p.drawPixmap(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph);
 
-	p.setFont(pointSize<int>(p.font(), 8));
+	p.setFont(pointSize(p.font(), 8));
 
 	const float gray_amount = 1.0f - fabsf( m_amountKnob->value<float>() );
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -340,7 +340,7 @@ void EnvelopeAndLfoView::paintEvent( QPaintEvent * )
 	// draw LFO-graph
 	p.drawPixmap(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph);
 
-	p.setFont(pointSize(p.font(), 8));
+	p.setFont(pointSize<int>(p.font(), 8));
 
 	const float gray_amount = 1.0f - fabsf( m_amountKnob->value<float>() );
 

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -57,7 +57,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	mainLayout->setVerticalSpacing( 1 );
 
 	auto chordLabel = new QLabel(tr("Chord:"));
-	chordLabel->setFont( pointSize<8>( chordLabel->font() ) );
+	chordLabel->setFont(pointSize(chordLabel->font(), 8));
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
@@ -146,13 +146,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));
-	arpChordLabel->setFont( pointSize<8>( arpChordLabel->font() ) );
+	arpChordLabel->setFont(pointSize(arpChordLabel->font(), 8));
 
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
-	arpDirectionLabel->setFont( pointSize<8>( arpDirectionLabel->font() ) );
+	arpDirectionLabel->setFont(pointSize(arpDirectionLabel->font(), 8));
 
 	auto arpModeLabel = new QLabel(tr("Mode:"));
-	arpModeLabel->setFont( pointSize<8>( arpModeLabel->font() ) );
+	arpModeLabel->setFont(pointSize(arpModeLabel->font(), 8));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -57,7 +57,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	mainLayout->setVerticalSpacing( 1 );
 
 	auto chordLabel = new QLabel(tr("Chord:"));
-	chordLabel->setFont(pointSize<int>(chordLabel->font(), 8));
+	chordLabel->setFont(pointSize(chordLabel->font(), 8));
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
@@ -146,13 +146,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));
-	arpChordLabel->setFont(pointSize<int>(arpChordLabel->font(), 8));
+	arpChordLabel->setFont(pointSize(arpChordLabel->font(), 8));
 
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
-	arpDirectionLabel->setFont(pointSize<int>(arpDirectionLabel->font(), 8));
+	arpDirectionLabel->setFont(pointSize(arpDirectionLabel->font(), 8));
 
 	auto arpModeLabel = new QLabel(tr("Mode:"));
-	arpModeLabel->setFont(pointSize<int>(arpModeLabel->font(), 8));
+	arpModeLabel->setFont(pointSize(arpModeLabel->font(), 8));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -57,7 +57,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	mainLayout->setVerticalSpacing( 1 );
 
 	auto chordLabel = new QLabel(tr("Chord:"));
-	chordLabel->setFont(pointSize(chordLabel->font(), 8));
+	chordLabel->setFont(pointSize<int>(chordLabel->font(), 8));
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
@@ -146,13 +146,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));
-	arpChordLabel->setFont(pointSize(arpChordLabel->font(), 8));
+	arpChordLabel->setFont(pointSize<int>(arpChordLabel->font(), 8));
 
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
-	arpDirectionLabel->setFont(pointSize(arpDirectionLabel->font(), 8));
+	arpDirectionLabel->setFont(pointSize<int>(arpDirectionLabel->font(), 8));
 
 	auto arpModeLabel = new QLabel(tr("Mode:"));
-	arpModeLabel->setFont(pointSize(arpModeLabel->font(), 8));
+	arpModeLabel->setFont(pointSize<int>(arpModeLabel->font(), 8));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -155,7 +155,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	auto baseVelocityHelp
 		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont( pointSize<8>( baseVelocityHelp->font() ) );
+    baseVelocityHelp->setFont(pointSize(baseVelocityHelp->font(), 8));
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -155,7 +155,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	auto baseVelocityHelp
 		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont(pointSize(baseVelocityHelp->font(), 8));
+    baseVelocityHelp->setFont(pointSize<int>(baseVelocityHelp->font(), 8));
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -155,7 +155,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	auto baseVelocityHelp
 		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont(pointSize<int>(baseVelocityHelp->font(), 8));
+    baseVelocityHelp->setFont(pointSize(baseVelocityHelp->font(), 8));
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -77,7 +77,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
 	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
-	m_filterComboBox->setFont( pointSize<8>( m_filterComboBox->font() ) );
+	m_filterComboBox->setFont(pointSize(m_filterComboBox->font(), 8));
 
 
 	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
@@ -94,7 +94,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
 	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont( pointSize<8>( m_singleStreamInfoLabel->font() ) );
+	m_singleStreamInfoLabel->setFont(pointSize(m_singleStreamInfoLabel->font(), 8));
 
 	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
 						TARGETS_TABWIDGET_Y,

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -77,7 +77,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
 	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
-	m_filterComboBox->setFont(pointSize(m_filterComboBox->font(), 8));
+	m_filterComboBox->setFont(pointSize<int>(m_filterComboBox->font(), 8));
 
 
 	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
@@ -94,7 +94,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
 	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont(pointSize(m_singleStreamInfoLabel->font(), 8));
+	m_singleStreamInfoLabel->setFont(pointSize<int>(m_singleStreamInfoLabel->font(), 8));
 
 	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
 						TARGETS_TABWIDGET_Y,

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -77,7 +77,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
 	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
-	m_filterComboBox->setFont(pointSize<int>(m_filterComboBox->font(), 8));
+	m_filterComboBox->setFont(pointSize(m_filterComboBox->font(), 8));
 
 
 	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
@@ -94,7 +94,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
 	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont(pointSize<int>(m_singleStreamInfoLabel->font(), 8));
+	m_singleStreamInfoLabel->setFont(pointSize(m_singleStreamInfoLabel->font(), 8));
 
 	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
 						TARGETS_TABWIDGET_Y,

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -107,7 +107,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// setup line edit for changing instrument track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont(pointSize<int>(m_nameLineEdit->font(), 9));
+	m_nameLineEdit->setFont(pointSize(m_nameLineEdit->font(), 9));
 	connect( m_nameLineEdit, SIGNAL( textChanged( const QString& ) ),
 				this, SLOT( textChanged( const QString& ) ) );
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -107,7 +107,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// setup line edit for changing instrument track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont(pointSize(m_nameLineEdit->font(), 9));
+	m_nameLineEdit->setFont(pointSize<int>(m_nameLineEdit->font(), 9));
 	connect( m_nameLineEdit, SIGNAL( textChanged( const QString& ) ),
 				this, SLOT( textChanged( const QString& ) ) );
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -107,7 +107,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// setup line edit for changing instrument track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont( pointSize<9>( m_nameLineEdit->font() ) );
+	m_nameLineEdit->setFont(pointSize(m_nameLineEdit->font(), 9));
 	connect( m_nameLineEdit, SIGNAL( textChanged( const QString& ) ),
 				this, SLOT( textChanged( const QString& ) ) );
 

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -60,7 +60,7 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setWordWrap(true);
-	tlabel->setFont(pointSize<8>(tlabel->font()));
+	tlabel->setFont(pointSize(tlabel->font(), 8));
 	masterPitchLayout->addWidget(tlabel);
 
 	// Microtuner settings

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -60,7 +60,7 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setWordWrap(true);
-	tlabel->setFont(pointSize(tlabel->font(), 8));
+	tlabel->setFont(pointSize<int>(tlabel->font(), 8));
 	masterPitchLayout->addWidget(tlabel);
 
 	// Microtuner settings

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -60,7 +60,7 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setWordWrap(true);
-	tlabel->setFont(pointSize<int>(tlabel->font(), 8));
+	tlabel->setFont(pointSize(tlabel->font(), 8));
 	masterPitchLayout->addWidget(tlabel);
 
 	// Microtuner settings

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -807,7 +807,7 @@ void PianoView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 
 	// set smaller font for printing number of every octave
-	p.setFont( pointSize<LABEL_TEXT_SIZE>( p.font() ) );
+	p.setFont(pointSize(p.font(), LABEL_TEXT_SIZE));
 
 
 	// draw bar above the keyboard (there will be the labels

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -807,7 +807,7 @@ void PianoView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 
 	// set smaller font for printing number of every octave
-	p.setFont(pointSize(p.font(), LABEL_TEXT_SIZE));
+	p.setFont(pointSize<int>(p.font(), LABEL_TEXT_SIZE));
 
 
 	// draw bar above the keyboard (there will be the labels

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -807,7 +807,7 @@ void PianoView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 
 	// set smaller font for printing number of every octave
-	p.setFont(pointSize<int>(p.font(), LABEL_TEXT_SIZE));
+	p.setFont(pointSize(p.font(), LABEL_TEXT_SIZE));
 
 
 	// draw bar above the keyboard (there will be the labels

--- a/src/gui/menus/MidiPortMenu.cpp
+++ b/src/gui/menus/MidiPortMenu.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "MidiPortMenu.h"
-#include "gui_templates.h"
 
 namespace lmms::gui
 {

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -37,7 +37,6 @@
 #include "embed.h"
 #include "Engine.h"
 #include "FileDialog.h"
-#include "gui_templates.h"
 #include "MainWindow.h"
 #include "MidiSetupWidget.h"
 #include "ProjectJournal.h"

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -38,7 +38,6 @@
 #include "DataFile.h"
 #include "embed.h"
 #include "Engine.h"
-#include "gui_templates.h"
 #include "InstrumentTrackView.h"
 #include "PixmapButton.h"
 #include "Song.h"

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -49,7 +49,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 {
 	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
 
-	setFont( pointSize<9>( font() ) );
+	setFont(pointSize(font(), 9));
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -49,7 +49,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 {
 	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
 
-	setFont(pointSize(font(), 9));
+	setFont(pointSize<int>(font(), 9));
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -49,7 +49,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 {
 	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
 
-	setFont(pointSize<int>(font(), 9));
+	setFont(pointSize(font(), 9));
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -111,7 +111,7 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
-	p.setFont( pointSize<8>( font() ) );
+	p.setFont(pointSize(font(), 8));
 
 	int const captionX = ledButtonShown() ? 22 : 6;
 	p.drawText(captionX, m_titleBarHeight, m_caption);

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -111,7 +111,7 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
-	p.setFont(pointSize<int>(font(), 8));
+	p.setFont(pointSize(font(), 8));
 
 	int const captionX = ledButtonShown() ? 22 : 6;
 	p.drawText(captionX, m_titleBarHeight, m_caption);

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -111,7 +111,7 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
-	p.setFont(pointSize(font(), 8));
+	p.setFont(pointSize<int>(font(), 8));
 
 	int const captionX = ledButtonShown() ? 22 : 6;
 	p.drawText(captionX, m_titleBarHeight, m_caption);

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -139,7 +139,7 @@ void Knob::setLabel( const QString & txt )
 	if( m_knobPixmap )
 	{
 		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(pointSize<float>(font(), 6.5)), m_label)),
+					horizontalAdvance(QFontMetrics(pointSize(font(), 6.5)), m_label)),
 						m_knobPixmap->height() + 10);
 	}
 
@@ -459,7 +459,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
-			p.setFont(pointSize<float>(p.font(), 6.5f));
+			p.setFont(pointSize(p.font(), 6.5f));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2,
@@ -467,7 +467,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
-			m_tdRenderer->setDefaultFont(pointSize<float>(p.font(), 6.5f));
+			m_tdRenderer->setDefaultFont(pointSize(p.font(), 6.5f));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
 		}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -139,7 +139,7 @@ void Knob::setLabel( const QString & txt )
 	if( m_knobPixmap )
 	{
 		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)),
+					horizontalAdvance(QFontMetrics(pointSize<float>(font(), 6.5)), m_label)),
 						m_knobPixmap->height() + 10);
 	}
 
@@ -459,7 +459,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
-			p.setFont(pointSizeF(p.font(), 6.5));
+			p.setFont(pointSize<float>(p.font(), 6.5f));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2,
@@ -467,7 +467,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
-			m_tdRenderer->setDefaultFont(pointSizeF(p.font(), 6.5));
+			m_tdRenderer->setDefaultFont(pointSize<float>(p.font(), 6.5f));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
 		}

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -245,7 +245,7 @@ void LcdFloatSpinBox::paintEvent(QPaintEvent*)
 	// Label
 	if (!m_label.isEmpty())
 	{
-		p.setFont(pointSize<float>(p.font(), 6.5f));
+		p.setFont(pointSize(p.font(), 6.5f));
 		p.setPen(m_wholeDisplay.textShadowColor());
 		p.drawText(width() / 2 - p.fontMetrics().boundingRect(m_label).width() / 2 + 1, height(), m_label);
 		p.setPen(m_wholeDisplay.textColor());

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -245,7 +245,7 @@ void LcdFloatSpinBox::paintEvent(QPaintEvent*)
 	// Label
 	if (!m_label.isEmpty())
 	{
-		p.setFont(pointSizeF(p.font(), 6.5));
+		p.setFont(pointSize<float>(p.font(), 6.5f));
 		p.setPen(m_wholeDisplay.textShadowColor());
 		p.drawText(width() / 2 - p.fontMetrics().boundingRect(m_label).width() / 2 + 1, height(), m_label);
 		p.setPen(m_wholeDisplay.textColor());

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -203,7 +203,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	// Label
 	if( !m_label.isEmpty() )
 	{
-		p.setFont(pointSize<float>(p.font(), 6.5f));
+		p.setFont(pointSize(p.font(), 6.5f));
 		p.setPen( textShadowColor() );
 		p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1,
@@ -255,7 +255,7 @@ void LcdWidget::updateSize()
 		setFixedSize(
 			qMax<int>(
 				m_cellWidth * m_numDigits + marginX1 + marginX2,
-				horizontalAdvance(QFontMetrics(pointSize<float>(font(), 6.5f)), m_label)
+				horizontalAdvance(QFontMetrics(pointSize(font(), 6.5f)), m_label)
 			),
 			m_cellHeight + (2 * marginY) + 9
 		);

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -203,7 +203,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	// Label
 	if( !m_label.isEmpty() )
 	{
-		p.setFont( pointSizeF( p.font(), 6.5 ) );
+		p.setFont(pointSize<float>(p.font(), 6.5f));
 		p.setPen( textShadowColor() );
 		p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1,
@@ -255,7 +255,7 @@ void LcdWidget::updateSize()
 		setFixedSize(
 			qMax<int>(
 				m_cellWidth * m_numDigits + marginX1 + marginX2,
-				horizontalAdvance(QFontMetrics(pointSizeF(font(), 6.5)), m_label)
+				horizontalAdvance(QFontMetrics(pointSize<float>(font(), 6.5f)), m_label)
 			),
 			m_cellHeight + (2 * marginY) + 9
 		);

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -94,7 +94,7 @@ void LedCheckBox::initUi( LedColor _color )
 
 	if (m_legacyMode)
 	{
-		setFont( pointSize<7>( font() ) );
+		setFont(pointSize(font(), 7));
 	}
 
 	setText( m_text );
@@ -116,7 +116,7 @@ void LedCheckBox::onTextUpdated()
 void LedCheckBox::paintLegacy(QPaintEvent * pe)
 {
 	QPainter p( this );
-	p.setFont( pointSize<7>( font() ) );
+	p.setFont(pointSize(font(), 7));
 
 	p.drawPixmap(0, 0, model()->value() ? m_ledOnPixmap : m_ledOffPixmap);
 

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -92,10 +92,7 @@ void LedCheckBox::initUi( LedColor _color )
 	m_ledOnPixmap = embed::getIconPixmap(names[static_cast<std::size_t>(_color)].toUtf8().constData());
 	m_ledOffPixmap = embed::getIconPixmap("led_off");
 
-	if (m_legacyMode)
-	{
-		setFont(pointSize<int>(font(), 7));
-	}
+	if (m_legacyMode){ setFont(pointSize(font(), 7)); }
 
 	setText( m_text );
 }
@@ -116,7 +113,7 @@ void LedCheckBox::onTextUpdated()
 void LedCheckBox::paintLegacy(QPaintEvent * pe)
 {
 	QPainter p( this );
-	p.setFont(pointSize<int>(font(), 7));
+	p.setFont(pointSize(font(), 7));
 
 	p.drawPixmap(0, 0, model()->value() ? m_ledOnPixmap : m_ledOffPixmap);
 

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -116,7 +116,7 @@ void LedCheckBox::onTextUpdated()
 void LedCheckBox::paintLegacy(QPaintEvent * pe)
 {
 	QPainter p( this );
-	p.setFont(pointSize(font(), 7));
+	p.setFont(pointSize<int>(font(), 7));
 
 	p.drawPixmap(0, 0, model()->value() ? m_ledOnPixmap : m_ledOffPixmap);
 

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -94,7 +94,7 @@ void LedCheckBox::initUi( LedColor _color )
 
 	if (m_legacyMode)
 	{
-		setFont(pointSize(font(), 7));
+		setFont(pointSize<int>(font(), 7));
 	}
 
 	setText( m_text );

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -60,7 +60,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
-		num_label->setFont( pointSize<7>( f ) );
+		num_label->setFont(pointSize(f, 7));
 		num_layout->addSpacing( 5 );
 		num_layout->addWidget( num_label );
 	}
@@ -84,7 +84,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
-		den_label->setFont( pointSize<7>( f ) );
+		den_label->setFont(pointSize(f, 7));
 		den_layout->addSpacing( 5 );
 		den_layout->addWidget( den_label );
 	}

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -60,7 +60,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
-		num_label->setFont(pointSize(f, 7));
+		num_label->setFont(pointSize<int>(f, 7));
 		num_layout->addSpacing( 5 );
 		num_layout->addWidget( num_label );
 	}

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -60,7 +60,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
-		num_label->setFont(pointSize<int>(f, 7));
+		num_label->setFont(pointSize(f, 7));
 		num_layout->addSpacing( 5 );
 		num_layout->addWidget( num_label );
 	}
@@ -84,7 +84,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
-		den_label->setFont(pointSize<int>(f, 7));
+		den_label->setFont(pointSize(f, 7));
 		den_layout->addSpacing( 5 );
 		den_layout->addWidget( den_label );
 	}

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -84,7 +84,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
-		den_label->setFont(pointSize(f, 7));
+		den_label->setFont(pointSize<int>(f, 7));
 		den_layout->addSpacing( 5 );
 		den_layout->addWidget( den_label );
 	}

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -177,7 +177,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 	else
 	{
 		p.setPen( QColor( 192, 192, 192 ) );
-		p.setFont(pointSize(p.font(), 7));
+		p.setFont(pointSize<int>(p.font(), 7));
 		p.drawText( 6, height()-5, tr( "Click to enable" ) );
 	}
 }

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -177,7 +177,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 	else
 	{
 		p.setPen( QColor( 192, 192, 192 ) );
-		p.setFont( pointSize<7>( p.font() ) );
+		p.setFont(pointSize(p.font(), 7));
 		p.drawText( 6, height()-5, tr( "Click to enable" ) );
 	}
 }

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -177,7 +177,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 	else
 	{
 		p.setPen( QColor( 192, 192, 192 ) );
-		p.setFont(pointSize<int>(p.font(), 7));
+		p.setFont(pointSize(p.font(), 7));
 		p.drawText( 6, height()-5, tr( "Click to enable" ) );
 	}
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -90,7 +90,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		_w->setFixedSize( _w->parentWidget()->size() );
 	}
 
-	b->setFont( pointSize<8>( b->font() ) );
+	b->setFont(pointSize(b->font(), 8));
 
 	return( b );
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -90,7 +90,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		_w->setFixedSize( _w->parentWidget()->size() );
 	}
 
-	b->setFont(pointSize(b->font(), 8));
+	b->setFont(pointSize<int>(b->font(), 8));
 
 	return( b );
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -90,7 +90,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		_w->setFixedSize( _w->parentWidget()->size() );
 	}
 
-	b->setFont(pointSize<int>(b->font(), 8));
+	b->setFont(pointSize(b->font(), 8));
 
 	return( b );
 }

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -58,7 +58,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont(pointSize<8>(font()));
+	setFont(pointSize(font(), 8));
 
 	setAutoFillBackground(true);
 	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);
@@ -70,7 +70,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont(pointSize<8>(font()));
+	setFont(pointSize(font(), 8));
 
 	// Append tab when position is not given
 	if (idx < 0/* || m_widgets.contains(idx) == true*/)
@@ -216,7 +216,7 @@ void TabWidget::resizeEvent(QResizeEvent*)
 void TabWidget::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	p.setFont(pointSize<7>(font()));
+	p.setFont(pointSize(font(), 7));
 
 	// Draw background
 	QBrush bg_color = p.background();
@@ -232,7 +232,7 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	// Draw title, if any
 	if (!m_caption.isEmpty())
 	{
-		p.setFont(pointSize<8>(p.font()));
+		p.setFont(pointSize(p.font(), 8));
 		p.setPen(tabTitleText());
 		p.drawText(5, 11, m_caption);
 	}

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -70,7 +70,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont(pointSize(font(), 8));
+	setFont(pointSize<int>(font(), 8));
 
 	// Append tab when position is not given
 	if (idx < 0/* || m_widgets.contains(idx) == true*/)
@@ -216,7 +216,7 @@ void TabWidget::resizeEvent(QResizeEvent*)
 void TabWidget::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	p.setFont(pointSize(font(), 7));
+	p.setFont(pointSize<int>(font(), 7));
 
 	// Draw background
 	QBrush bg_color = p.background();
@@ -232,7 +232,7 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	// Draw title, if any
 	if (!m_caption.isEmpty())
 	{
-		p.setFont(pointSize(p.font(), 8));
+		p.setFont(pointSize<int>(p.font(), 8));
 		p.setPen(tabTitleText());
 		p.drawText(5, 11, m_caption);
 	}

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -58,7 +58,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont(pointSize<int>(font(), 8));
+	setFont(pointSize(font(), 8));
 
 	setAutoFillBackground(true);
 	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);
@@ -70,7 +70,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont(pointSize<int>(font(), 8));
+	setFont(pointSize(font(), 8));
 
 	// Append tab when position is not given
 	if (idx < 0/* || m_widgets.contains(idx) == true*/)
@@ -216,7 +216,7 @@ void TabWidget::resizeEvent(QResizeEvent*)
 void TabWidget::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	p.setFont(pointSize<int>(font(), 7));
+	p.setFont(pointSize(font(), 7));
 
 	// Draw background
 	QBrush bg_color = p.background();
@@ -232,7 +232,7 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	// Draw title, if any
 	if (!m_caption.isEmpty())
 	{
-		p.setFont(pointSize<int>(p.font(), 8));
+		p.setFont(pointSize(p.font(), 8));
 		p.setPen(tabTitleText());
 		p.drawText(5, 11, m_caption);
 	}

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -58,7 +58,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont(pointSize(font(), 8));
+	setFont(pointSize<int>(font(), 8));
 
 	setAutoFillBackground(true);
 	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);


### PR DESCRIPTION
I started off trying to remove the `QApplication::desktop` call per #6614 but I ended up doing a refactor.

I removed the duplicate `pointSizeF` function and merged it into the `pointSize` function. 

There's a chance that this PR might improve HiDPI support as I did some changes in that area but haven't tested.

Todo: delete the file and find a new home for the pointSize function (should we really keep a file for a single function?)

inviting @michaelgregorius for review