### PR TITLE
Set mixer channel LCD when its index changes

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -277,6 +277,7 @@ namespace lmms::gui
         m_muteButton->setModel(&mixerChannel->m_muteModel);
         m_soloButton->setModel(&mixerChannel->m_soloModel);
         m_effectRackView->setModel(&mixerChannel->m_fxChain);
+        m_channelNumberLcd->setValue(index);
         m_channelIndex = index;
     }
 


### PR DESCRIPTION
`MixerChannelView::setChannelIndex` did not set the LCD for the mixer channel when it was called, leading to incorrect channel numbers being displayed on the LCD when you remove unused channels.