### PR TITLE
CMake: Replace EXEC_PROGRAM with execute_process

### DIFF
--- a/cmake/modules/DetectMachine.cmake
+++ b/cmake/modules/DetectMachine.cmake
@@ -92,7 +92,7 @@ IF(WIN32)
 	endif()
 ELSE()
 	# Detect target architecture based on compiler target triple e.g. "x86_64-pc-linux"
-	execute_process(COMMAND ${CMAKE_C_COMPILER} ARGS "-dumpmachine ${CMAKE_C_FLAGS}" OUTPUT_VARIABLE Machine )
+	execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine ${CMAKE_C_FLAGS} OUTPUT_VARIABLE Machine)
 	MESSAGE("Machine: ${Machine}")
 	STRING(REGEX MATCH "i.86" IS_X86 "${Machine}")
 	STRING(REGEX MATCH "86_64|amd64" IS_X86_64 "${Machine}")

--- a/cmake/modules/DetectMachine.cmake
+++ b/cmake/modules/DetectMachine.cmake
@@ -92,7 +92,7 @@ IF(WIN32)
 	endif()
 ELSE()
 	# Detect target architecture based on compiler target triple e.g. "x86_64-pc-linux"
-	EXEC_PROGRAM( ${CMAKE_C_COMPILER} ARGS "-dumpmachine ${CMAKE_C_FLAGS}" OUTPUT_VARIABLE Machine )
+	execute_process(COMMAND ${CMAKE_C_COMPILER} ARGS "-dumpmachine ${CMAKE_C_FLAGS}" OUTPUT_VARIABLE Machine )
 	MESSAGE("Machine: ${Machine}")
 	STRING(REGEX MATCH "i.86" IS_X86 "${Machine}")
 	STRING(REGEX MATCH "86_64|amd64" IS_X86_64 "${Machine}")

--- a/cmake/modules/FindWine.cmake
+++ b/cmake/modules/FindWine.cmake
@@ -32,8 +32,8 @@ FIND_PROGRAM(WINE_CXX
 FIND_PROGRAM(WINE_BUILD NAMES winebuild)
 # Detect wine paths and handle linking problems
 IF(WINE_CXX)
-	EXEC_PROGRAM(${WINE_CXX} ARGS "-m32 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_32)
-	EXEC_PROGRAM(${WINE_CXX} ARGS "-m64 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_64)
+	execute_process(COMMAND ${WINE_CXX} ARGS "-m32 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_32)
+	execute_process(COMMAND ${WINE_CXX} ARGS "-m64 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_64)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "^-isystem/usr/include$" BUGGED_WINEGCC)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "^-isystem" WINEGCC_INCLUDE_DIR)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "libwinecrt0\\.a.*" WINECRT_32)

--- a/cmake/modules/FindWine.cmake
+++ b/cmake/modules/FindWine.cmake
@@ -32,8 +32,8 @@ FIND_PROGRAM(WINE_CXX
 FIND_PROGRAM(WINE_BUILD NAMES winebuild)
 # Detect wine paths and handle linking problems
 IF(WINE_CXX)
-	execute_process(COMMAND ${WINE_CXX} ARGS "-m32 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_32)
-	execute_process(COMMAND ${WINE_CXX} ARGS "-m64 -v /dev/zero" OUTPUT_VARIABLE WINEBUILD_OUTPUT_64)
+	execute_process(COMMAND ${WINE_CXX} -m32 -v /dev/zero OUTPUT_VARIABLE WINEBUILD_OUTPUT_32)
+	execute_process(COMMAND ${WINE_CXX} -m64 -v /dev/zero OUTPUT_VARIABLE WINEBUILD_OUTPUT_64)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "^-isystem/usr/include$" BUGGED_WINEGCC)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "^-isystem" WINEGCC_INCLUDE_DIR)
 	_findwine_find_flags("${WINEBUILD_OUTPUT_32}" "libwinecrt0\\.a.*" WINECRT_32)


### PR DESCRIPTION
exec_program is Deprecated since version 3.0: Use the execute_process() command instead.

https://cmake.org/cmake/help/latest/command/exec_program.html