### PR TITLE
Fix DynamicsProcessor bugs

### DIFF
--- a/plugins/DynamicsProcessor/DynamicsProcessor.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessor.cpp
@@ -163,7 +163,7 @@ bool DynProcEffect::processAudioBuffer( sampleFrame * _buf,
 				m_currentPeak[i] = m_currentPeak[i] * m_relCoeff + (1 - m_relCoeff) * t;
 			}
 
-			m_currentPeak[i] = qMax(DYN_NOISE_FLOOR, m_currentPeak[i]);
+			m_currentPeak[i] = std::max(DYN_NOISE_FLOOR, m_currentPeak[i]);
 		}
 
 // account for stereo mode


### PR DESCRIPTION
Dynamics Processor has... a lot of issues.  This fixes them.

1. Only one of the coefficient calculations has a negative sign.  The reason for this is unknown.  I'm thinking the creator was thrown off by the attack and release coefficient calculations being identical and tossed in a negative due to attack and release being thought of as opposites.
2. The coefficient calculations use `10^x` instead of `e^x`.  This is incorrect.
3. `DNF_LOG` is a seemingly totally arbitrary value of `5`.  I've only ever seen values of `1` and `2.2` used there (the latter of which I'm pretty sure is a bug in online code that thousands wound up copying, given `2.3` is the actual correct value to get the desired 10:1 ratio).  The value of this variable is _not_ something that should be adjusted for personal preference, it is what determines the ratio between the new and old volumes after the exact duration of the attack or release time passes.
4. The coefficients are ultimately used incorrectly, rather than for 1-pole IIR filters as they should be used for.

**THIS BREAKS BACKWARDS COMPATIBILITY,** but there seems to be unanimous agreement that in this case it is entirely acceptable.

This closes #1581 and replaces #7013 (apologies).

Audio examples can be found here:
[avocado.zip](https://github.com/LMMS/lmms/files/14761767/avocado.zip)


