### PR TITLE
Fix QFile close bug with libsndfile

### DIFF
--- a/src/core/SampleDecoder.cpp
+++ b/src/core/SampleDecoder.cpp
@@ -62,18 +62,16 @@ auto decodeSampleSF(const QString& audioFile) -> std::optional<SampleDecoder::Re
 	SNDFILE* sndFile = nullptr;
 	auto sfInfo = SF_INFO{};
 
-	// TODO: Remove use of QFile
-	auto file = QFile{audioFile};
-	if (!file.open(QIODevice::ReadOnly)) { return std::nullopt; }
-
-	sndFile = sf_open_fd(file.handle(), SFM_READ, &sfInfo, false);
-	if (sf_error(sndFile) != 0) { return std::nullopt; }
+	sndFile = sf_open(audioFile.toStdString().c_str(), SFM_READ, &sfInfo);
+	if (sf_error(sndFile)) {
+		sf_close(sndFile);
+		return std::nullopt;
+	}
 
 	auto buf = std::vector<sample_t>(sfInfo.channels * sfInfo.frames);
 	sf_read_float(sndFile, buf.data(), buf.size());
 
 	sf_close(sndFile);
-	file.close();
 
 	auto result = std::vector<sampleFrame>(sfInfo.frames);
 	for (int i = 0; i < static_cast<int>(result.size()); ++i)


### PR DESCRIPTION
While testing loading Krem Kaakkuja in a MSVC LMMS build, when libsndfile was unable to detect the format of the file it would cause QFile to throw an exception that the file handle was already closed. This might be a bug in libsndfile, but we can prevent it altogether by just not using QFile.