### PR TITLE
Optimize map accesses in LadspaManager

### DIFF
--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -122,14 +122,13 @@ LadspaManager::~LadspaManager()
 LadspaManagerDescription * LadspaManager::getDescription(
 						const ladspa_key_t & _plugin )
 {
-	if( m_ladspaManagerMap.contains( _plugin ) )
+	auto const it = m_ladspaManagerMap.find(_plugin);
+	if (it != m_ladspaManagerMap.end())
 	{
-		return( m_ladspaManagerMap[_plugin] );
+		return *it;
 	}
-	else
-	{
-		return( nullptr );
-	}
+
+	return nullptr;
 }
 
 
@@ -523,24 +522,17 @@ bool LadspaManager::isInteger( const ladspa_key_t & _plugin,
 
 bool LadspaManager::isEnum( const ladspa_key_t & _plugin, uint32_t _port )
 {
-	if( m_ladspaManagerMap.contains( _plugin )
-		   && _port < getPortCount( _plugin ) )
+	auto const * desc = getDescriptor(_plugin);
+	if (desc && _port < desc->PortCount)
 	{
-		LADSPA_Descriptor_Function descriptorFunction =
-			m_ladspaManagerMap[_plugin]->descriptorFunction;
-		const LADSPA_Descriptor * descriptor =
-				descriptorFunction(
-					m_ladspaManagerMap[_plugin]->index );
 		LADSPA_PortRangeHintDescriptor hintDescriptor =
-			descriptor->PortRangeHints[_port].HintDescriptor;
+			desc->PortRangeHints[_port].HintDescriptor;
 		// This is an LMMS extension to ladspa
-		return( LADSPA_IS_HINT_INTEGER( hintDescriptor ) &&
-			LADSPA_IS_HINT_TOGGLED( hintDescriptor ) );
+		return(LADSPA_IS_HINT_INTEGER(hintDescriptor) &&
+			LADSPA_IS_HINT_TOGGLED(hintDescriptor));
 	}
-	else
-	{
-		return( false );
-	}
+
+	return false;
 }
 
 
@@ -566,22 +558,20 @@ const void * LadspaManager::getImplementationData(
 
 
 
-const LADSPA_Descriptor * LadspaManager::getDescriptor(
-						const ladspa_key_t & _plugin )
+const LADSPA_Descriptor * LadspaManager::getDescriptor(const ladspa_key_t & _plugin)
 {
-	if( m_ladspaManagerMap.contains( _plugin ) )
+	auto const it = m_ladspaManagerMap.find(_plugin);
+	if (it != m_ladspaManagerMap.end())
 	{
-		LADSPA_Descriptor_Function descriptorFunction =
-			m_ladspaManagerMap[_plugin]->descriptorFunction;
-		const LADSPA_Descriptor * descriptor =
-				descriptorFunction(
-					m_ladspaManagerMap[_plugin]->index );
-		return( descriptor );
+		auto const p = *it;
+
+		LADSPA_Descriptor_Function descriptorFunction = p->descriptorFunction;
+		const LADSPA_Descriptor * descriptor = descriptorFunction(p->index);
+
+		return descriptor;
 	}
-	else
-	{
-		return( nullptr );
-	}
+
+	return nullptr;
 }
 
 

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -123,12 +123,7 @@ LadspaManagerDescription * LadspaManager::getDescription(
 						const ladspa_key_t & _plugin )
 {
 	auto const it = m_ladspaManagerMap.find(_plugin);
-	if (it != m_ladspaManagerMap.end())
-	{
-		return *it;
-	}
-
-	return nullptr;
+	return it != m_ladspaManagerMap.end() ? *it : nullptr;
 }
 
 
@@ -528,8 +523,7 @@ bool LadspaManager::isEnum( const ladspa_key_t & _plugin, uint32_t _port )
 		LADSPA_PortRangeHintDescriptor hintDescriptor =
 			desc->PortRangeHints[_port].HintDescriptor;
 		// This is an LMMS extension to ladspa
-		return(LADSPA_IS_HINT_INTEGER(hintDescriptor) &&
-			LADSPA_IS_HINT_TOGGLED(hintDescriptor));
+		return LADSPA_IS_HINT_INTEGER(hintDescriptor) && LADSPA_IS_HINT_TOGGLED(hintDescriptor);
 	}
 
 	return false;
@@ -563,10 +557,10 @@ const LADSPA_Descriptor * LadspaManager::getDescriptor(const ladspa_key_t & _plu
 	auto const it = m_ladspaManagerMap.find(_plugin);
 	if (it != m_ladspaManagerMap.end())
 	{
-		auto const p = *it;
+		auto const plugin = *it;
 
-		LADSPA_Descriptor_Function descriptorFunction = p->descriptorFunction;
-		const LADSPA_Descriptor * descriptor = descriptorFunction(p->index);
+		LADSPA_Descriptor_Function descriptorFunction = plugin->descriptorFunction;
+		const LADSPA_Descriptor* descriptor = descriptorFunction(plugin->index);
 
 		return descriptor;
 	}


### PR DESCRIPTION
Some methods in `LadspaManager` performed several searches through the map by first calling `contains` and then by actually fetching the entry. This is fixed by using `find` on the map. It returns an iterator which can directly provide the result or show that nothing was found. That way we only search through the map once.