### PR TITLE
Remove use of QApplication::desktop in ComboBox.cpp

### DIFF
--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -26,8 +26,6 @@
 
 #include "ComboBox.h"
 
-#include <QApplication>
-#include <QDesktopWidget>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QStyleOptionFrame>
@@ -116,15 +114,17 @@ void ComboBox::mousePressEvent( QMouseEvent* event )
 				a->setData( i );
 			}
 
-			QPoint gpos = mapToGlobal( QPoint( 0, height() ) );
-			if( gpos.y() + m_menu.sizeHint().height() < qApp->desktop()->height() )
+			QPoint gpos = mapToGlobal(QPoint(0, height()));
+			bool const menuCanBeFullyShown = screen()->geometry().contains(QRect(gpos, m_menu.sizeHint()));
+			if (menuCanBeFullyShown)
 			{
-				m_menu.exec( gpos );
+				m_menu.exec(gpos);
 			}
 			else
 			{
-				m_menu.exec( mapToGlobal( QPoint( width(), 0 ) ) );
+				m_menu.exec(mapToGlobal(QPoint(width(), 0)));
 			}
+
 			m_pressed = false;
 			update();
 		}

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -34,6 +34,13 @@
 #include "CaptionMenu.h"
 #include "gui_templates.h"
 
+// TODO Remove once Qt5 support is dropped (#6614)
+#define QT_SUPPORTS_WIDGET_SCREEN (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
+#if !QT_SUPPORTS_WIDGET_SCREEN
+#include <QApplication>
+#include <QDesktopWidget>
+#endif
+
 namespace lmms::gui
 {
 const int CB_ARROW_BTN_WIDTH = 18;
@@ -115,7 +122,13 @@ void ComboBox::mousePressEvent( QMouseEvent* event )
 			}
 
 			QPoint gpos = mapToGlobal(QPoint(0, height()));
+
+			#if (QT_SUPPORTS_WIDGET_SCREEN)
 			bool const menuCanBeFullyShown = screen()->geometry().contains(QRect(gpos, m_menu.sizeHint()));
+			#else
+			bool const menuCanBeFullyShown = gpos.y() + m_menu.sizeHint().height() < qApp->desktop()->height();
+			#endif
+
 			if (menuCanBeFullyShown)
 			{
 				m_menu.exec(gpos);

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -29,9 +29,9 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QStyleOptionFrame>
+#include <QScreen>
 
 #include "CaptionMenu.h"
-#include "embed.h"
 #include "gui_templates.h"
 
 namespace lmms::gui

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -34,7 +34,6 @@
 #include "CaptionMenu.h"
 #include "gui_templates.h"
 
-// TODO Remove once Qt5 support is dropped (#6614)
 #define QT_SUPPORTS_WIDGET_SCREEN (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 #if !QT_SUPPORTS_WIDGET_SCREEN
 #include <QApplication>


### PR DESCRIPTION
Remove use of `QApplication::desktop` in `ComboBox.cpp`. The method was already deprecated in Qt5 and is removed in Qt6.

Generalize the check if the menu can be shown in the screen. The code now also does handles the case where the menu would go out of screen along the X axis.

Also remove the unused include `embed.h`.