### PR TITLE
Font size adjustments

### DIFF
--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -25,12 +25,8 @@
 #ifndef LMMS_GUI_TEMPLATES_H
 #define LMMS_GUI_TEMPLATES_H
 
-#include "lmmsconfig.h"
-
-#include <algorithm>
 #include <QApplication>
 #include <QFont>
-#include <QGuiApplication>
 
 namespace lmms::gui
 {

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -32,27 +32,15 @@
 #include <QFont>
 #include <QGuiApplication>
 
-// TODO: remove once qt5 support is dropped
-#if (QT_VERSION < QT_VERSION_CHECK(6,0,0))
-	#include <QScreen>
-#endif
-
 namespace lmms::gui
 {
 
-
-// return DPI-independent font-size - font with returned font-size has always
-// the same size in pixels
-inline QFont pointSize(QFont fontPointer, float fontSize)
+// Convenience method to set the font size in pixels
+inline QFont pointSize(QFont fontPointer, int fontSize)
 {
-	// to calculate DPI of a screen to make it HiDPI ready
-	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-    qreal scaleFactor = std::max(devicePixelRatio, 1.0); // Ensure scaleFactor is at least 1.0
-
-	fontPointer.setPointSizeF(fontSize * scaleFactor);
+	fontPointer.setPixelSize(fontSize);
 	return fontPointer;
 }
-
 
 } // namespace lmms::gui
 

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -32,10 +32,10 @@ namespace lmms::gui
 {
 
 // Convenience method to set the font size in pixels
-inline QFont adjustedToPixelSize(QFont fontPointer, int fontSize)
+inline QFont adjustedToPixelSize(QFont font, int size)
 {
-	fontPointer.setPixelSize(fontSize);
-	return fontPointer;
+	font.setPixelSize(size);
+	return font;
 }
 
 } // namespace lmms::gui

--- a/include/gui_templates.h
+++ b/include/gui_templates.h
@@ -36,7 +36,7 @@ namespace lmms::gui
 {
 
 // Convenience method to set the font size in pixels
-inline QFont pointSize(QFont fontPointer, int fontSize)
+inline QFont adjustedToPixelSize(QFont fontPointer, int fontSize)
 {
 	fontPointer.setPixelSize(fontSize);
 	return fontPointer;

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -134,7 +134,6 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 // interpolation selector
 	m_interpBox = new ComboBox(this);
 	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-	m_interpBox->setFont(adjustedToPixelSize(m_interpBox->font(), 8));
 
 // wavegraph
 	m_waveView = 0;

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -134,7 +134,7 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 // interpolation selector
 	m_interpBox = new ComboBox(this);
 	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-	m_interpBox->setFont(pointSize(m_interpBox->font(), 8));
+	m_interpBox->setFont(adjustedToPixelSize(m_interpBox->font(), 8));
 
 // wavegraph
 	m_waveView = 0;
@@ -228,7 +228,7 @@ void AudioFileProcessorView::paintEvent(QPaintEvent*)
 
 	int idx = a->sample().sampleFile().length();
 
-	p.setFont(pointSize(font(), 8));
+	p.setFont(adjustedToPixelSize(font(), 8));
 
 	QFontMetrics fm(p.font());
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -273,7 +273,7 @@ void AudioFileProcessorWaveView::paintEvent(QPaintEvent * pe)
 	p.fillRect(s_padding, s_padding, m_graph.width(), 14, g);
 
 	p.setPen(QColor(255, 255, 255));
-	p.setFont(pointSize(font(), 8));
+	p.setFont(adjustedToPixelSize(font(), 8));
 
 	QString length_text;
 	const int length = m_sample->sampleDuration().count();

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -632,7 +632,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleUIButton->setCheckable( true );
     m_toggleUIButton->setChecked( false );
     m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-    m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+    m_toggleUIButton->setFont(adjustedToPixelSize(m_toggleUIButton->font(), 8));
     connect( m_toggleUIButton, SIGNAL( clicked(bool) ), this, SLOT( toggleUI( bool ) ) );
 
     m_toggleUIButton->setToolTip(
@@ -642,7 +642,7 @@ CarlaInstrumentView::CarlaInstrumentView(CarlaInstrument* const instrument, QWid
     m_toggleParamsWindowButton = new QPushButton(tr("Params"), this);
     m_toggleParamsWindowButton->setIcon(embed::getIconPixmap("controller"));
     m_toggleParamsWindowButton->setCheckable(true);
-    m_toggleParamsWindowButton->setFont(pointSize(m_toggleParamsWindowButton->font(), 8));
+    m_toggleParamsWindowButton->setFont(adjustedToPixelSize(m_toggleParamsWindowButton->font(), 8));
 #if CARLA_VERSION_HEX < CARLA_MIN_PARAM_VERSION
     m_toggleParamsWindowButton->setEnabled(false);
     m_toggleParamsWindowButton->setToolTip(tr("Available from Carla version 2.1 and up."));

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -29,7 +29,6 @@
 #include "Knob.h"
 #include "LedCheckBox.h"
 #include "ComboBox.h"
-#include "gui_templates.h"
 
 namespace lmms::gui
 {

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -76,12 +76,12 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 
 	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter1ComboBox->setFont(pointSize(m_filter1ComboBox->font(), 8));
+	m_filter1ComboBox->setFont(adjustedToPixelSize(m_filter1ComboBox->font(), 8));
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter2ComboBox->setFont(pointSize(m_filter2ComboBox->font(), 8));
+	m_filter2ComboBox->setFont(adjustedToPixelSize(m_filter2ComboBox->font(), 8));
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }
 

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -76,12 +76,10 @@ DualFilterControlDialog::DualFilterControlDialog( DualFilterControls* controls )
 
 	auto m_filter1ComboBox = new ComboBox(this);
 	m_filter1ComboBox->setGeometry( 19, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter1ComboBox->setFont(adjustedToPixelSize(m_filter1ComboBox->font(), 8));
 	m_filter1ComboBox->setModel( &controls->m_filter1Model );
 
 	auto m_filter2ComboBox = new ComboBox(this);
 	m_filter2ComboBox->setGeometry( 217, 70, 137, ComboBox::DEFAULT_HEIGHT );
-	m_filter2ComboBox->setFont(adjustedToPixelSize(m_filter2ComboBox->font(), 8));
 	m_filter2ComboBox->setModel( &controls->m_filter2Model );
 }
 

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -32,7 +32,6 @@
 #include <QLabel>
 
 
-#include "gui_templates.h"
 #include "LadspaDescription.h"
 #include "LadspaPortDialog.h"
 #include "TabBar.h"

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -172,7 +172,7 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
-	title->setFont(pointSize(f, 12));
+	title->setFont(adjustedToPixelSize(f, 12));
 
 	layout->addSpacing( 5 );
 	layout->addWidget( title );

--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -172,7 +172,6 @@ QWidget * LadspaBrowserView::createTab( QWidget * _parent, const QString & _txt,
 	auto title = new QLabel(type + _txt, tab);
 	QFont f = title->font();
 	f.setBold( true );
-	title->setFont(adjustedToPixelSize(f, 12));
 
 	layout->addSpacing( 5 );
 	layout->addWidget( title );

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -30,7 +30,6 @@
 #include "ComboBox.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
-#include "gui_templates.h"
 #include "lmms_math.h"
 #include "interpolation.h"
 

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1694,7 +1694,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc2WaveBox = new ComboBox( view );
 	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc2WaveBox->setFont(pointSize(m_osc2WaveBox->font(), 8));
+	m_osc2WaveBox->setFont(adjustedToPixelSize(m_osc2WaveBox->font(), 8));
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
@@ -1709,18 +1709,18 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc3Wave1Box = new ComboBox( view );
 	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave1Box->setFont(pointSize(m_osc3Wave1Box->font(), 8));
+	m_osc3Wave1Box->setFont(adjustedToPixelSize(m_osc3Wave1Box->font(), 8));
 
 	m_osc3Wave2Box = new ComboBox( view );
 	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave2Box->setFont(pointSize(m_osc3Wave2Box->font(), 8));
+	m_osc3Wave2Box->setFont(adjustedToPixelSize(m_osc3Wave2Box->font(), 8));
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo1WaveBox->setFont(pointSize(m_lfo1WaveBox->font(), 8));
+	m_lfo1WaveBox->setFont(adjustedToPixelSize(m_lfo1WaveBox->font(), 8));
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
 	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
@@ -1728,7 +1728,7 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo2WaveBox->setFont(pointSize(m_lfo2WaveBox->font(), 8));
+	m_lfo2WaveBox->setFont(adjustedToPixelSize(m_lfo2WaveBox->font(), 8));
 
 	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob")
 	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob")

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1694,7 +1694,6 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc2WaveBox = new ComboBox( view );
 	m_osc2WaveBox -> setGeometry( 204, O2ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc2WaveBox->setFont(adjustedToPixelSize(m_osc2WaveBox->font(), 8));
 
 	maketinyled( m_osc2SyncHButton, 212, O2ROW - 3, tr( "Hard sync oscillator 2" ) )
 	maketinyled( m_osc2SyncRButton, 191, O2ROW - 3, tr( "Reverse sync oscillator 2" ) )
@@ -1709,18 +1708,15 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_osc3Wave1Box = new ComboBox( view );
 	m_osc3Wave1Box -> setGeometry( 160, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave1Box->setFont(adjustedToPixelSize(m_osc3Wave1Box->font(), 8));
 
 	m_osc3Wave2Box = new ComboBox( view );
 	m_osc3Wave2Box -> setGeometry( 204, O3ROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_osc3Wave2Box->setFont(adjustedToPixelSize(m_osc3Wave2Box->font(), 8));
 
 	maketinyled( m_osc3SyncHButton, 212, O3ROW - 3, tr( "Hard sync oscillator 3" ) )
 	maketinyled( m_osc3SyncRButton, 191, O3ROW - 3, tr( "Reverse sync oscillator 3" ) )
 
 	m_lfo1WaveBox = new ComboBox( view );
 	m_lfo1WaveBox -> setGeometry( 2, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo1WaveBox->setFont(adjustedToPixelSize(m_lfo1WaveBox->font(), 8));
 
 	maketsknob( m_lfo1AttKnob, LFOCOL1, LFOROW, tr( "Attack" ), " ms", "lfoKnob" )
 	maketsknob( m_lfo1RateKnob, LFOCOL2, LFOROW, tr( "Rate" ), " ms", "lfoKnob" )
@@ -1728,7 +1724,6 @@ QWidget * MonstroView::setupOperatorsView( QWidget * _parent )
 
 	m_lfo2WaveBox = new ComboBox( view );
 	m_lfo2WaveBox -> setGeometry( 127, LFOROW + 7, 42, ComboBox::DEFAULT_HEIGHT );
-	m_lfo2WaveBox->setFont(adjustedToPixelSize(m_lfo2WaveBox->font(), 8));
 
 	maketsknob(m_lfo2AttKnob, LFOCOL4, LFOROW, tr("Attack"), " ms", "lfoKnob")
 	maketsknob(m_lfo2RateKnob, LFOCOL5, LFOROW, tr("Rate"), " ms", "lfoKnob")

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -545,7 +545,7 @@ void PatmanView::updateFilename()
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
 
-	QFontMetrics fm(pointSize(font(), 8));
+	QFontMetrics fm(adjustedToPixelSize(font(), 8));
 
 	// simple algorithm for creating a text from the filename that
 	// matches in the white rectangle
@@ -615,7 +615,7 @@ void PatmanView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
 
-	p.setFont(pointSize(font() ,8));
+	p.setFont(adjustedToPixelSize(font() ,8));
 	p.drawText( 8, 116, 235, 16,
 			Qt::AlignLeft | Qt::TextSingleLine | Qt::AlignVCenter,
 			m_displayFilename );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -450,7 +450,6 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
 	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
-	m_presetsCombo->setFont(adjustedToPixelSize(m_presetsCombo->font(), 8));
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -37,7 +37,6 @@
 #include "AudioEngine.h"
 #include "ConfigManager.h"
 #include "Engine.h"
-#include "gui_templates.h"
 #include "GuiApplication.h"
 #include "InstrumentTrack.h"
 

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -450,7 +450,7 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 
 	m_presetsCombo = new ComboBox( this, tr( "Instrument" ) );
 	m_presetsCombo->setGeometry( 140, 50, 99, ComboBox::DEFAULT_HEIGHT );
-	m_presetsCombo->setFont(pointSize(m_presetsCombo->font(), 8));
+	m_presetsCombo->setFont(adjustedToPixelSize(m_presetsCombo->font(), 8));
 	
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -587,7 +587,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 	m_toggleGUIButton = new QPushButton( tr( "Show/hide GUI" ), this );
 	m_toggleGUIButton->setGeometry( 20, 130, 200, 24 );
 	m_toggleGUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleGUIButton->setFont(pointSize(m_toggleGUIButton->font(), 8));
+	m_toggleGUIButton->setFont(adjustedToPixelSize(m_toggleGUIButton->font(), 8));
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
@@ -596,7 +596,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
-	note_off_all_btn->setFont(pointSize(note_off_all_btn->font(), 8));
+	note_off_all_btn->setFont(adjustedToPixelSize(note_off_all_btn->font(), 8));
 	connect( note_off_all_btn, SIGNAL( clicked() ), this,
 							SLOT( noteOffAll() ) );
 
@@ -881,7 +881,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 				tr( "No VST plugin loaded" );
 	QFont f = p.font();
 	f.setBold( true );
-	p.setFont(pointSize(f, 10));
+	p.setFont(adjustedToPixelSize(f, 10));
 	p.setPen( QColor( 255, 255, 255 ) );
 	p.drawText( 10, 100, plugin_name );
 
@@ -893,7 +893,7 @@ void VestigeInstrumentView::paintEvent( QPaintEvent * )
 	{
 		p.setPen( QColor( 0, 0, 0 ) );
 		f.setBold( false );
-		p.setFont(pointSize(f, 8));
+		p.setFont(adjustedToPixelSize(f, 8));
 		p.drawText( 10, 114, tr( "by " ) +
 					m_vi->m_plugin->vendorString() );
 		p.setPen( QColor( 255, 255, 255 ) );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -583,11 +583,12 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 
 	m_selPresetButton->setMenu(menu);
 
+	constexpr int buttonFontSize = 12;
 
 	m_toggleGUIButton = new QPushButton( tr( "Show/hide GUI" ), this );
 	m_toggleGUIButton->setGeometry( 20, 130, 200, 24 );
 	m_toggleGUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleGUIButton->setFont(adjustedToPixelSize(m_toggleGUIButton->font(), 8));
+	m_toggleGUIButton->setFont(adjustedToPixelSize(m_toggleGUIButton->font(), buttonFontSize));
 	connect( m_toggleGUIButton, SIGNAL( clicked() ), this,
 							SLOT( toggleGUI() ) );
 
@@ -596,7 +597,7 @@ VestigeInstrumentView::VestigeInstrumentView( Instrument * _instrument,
 		this);
 	note_off_all_btn->setGeometry( 20, 160, 200, 24 );
 	note_off_all_btn->setIcon( embed::getIconPixmap( "stop" ) );
-	note_off_all_btn->setFont(adjustedToPixelSize(note_off_all_btn->font(), 8));
+	note_off_all_btn->setFont(adjustedToPixelSize(note_off_all_btn->font(), buttonFontSize));
 	connect( note_off_all_btn, SIGNAL( clicked() ), this,
 							SLOT( noteOffAll() ) );
 

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -246,7 +246,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 		tb->addWidget(space1);
 
 		tbLabel = new QLabel( tr( "Effect by: " ), this );
-		tbLabel->setFont(pointSize(f, 7));
+		tbLabel->setFont(adjustedToPixelSize(f, 7));
 		tbLabel->setTextFormat(Qt::RichText);
 		tbLabel->setAlignment( Qt::AlignTop | Qt::AlignLeft );
 		tb->addWidget( tbLabel );

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -40,7 +40,6 @@
 #include "DataFile.h"
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
-#include "gui_templates.h"
 #include "Song.h"
 #include "StringPairDrag.h"
 #include "RemoteZynAddSubFx.h"

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -541,7 +541,10 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	m_toggleUIButton->setCheckable( true );
 	m_toggleUIButton->setChecked( false );
 	m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleUIButton->setFont(adjustedToPixelSize(m_toggleUIButton->font(), 8));
+	QFont f = m_toggleUIButton->font();
+	f.setPointSizeF(12);
+	m_toggleUIButton->setFont(f);
+
 	connect( m_toggleUIButton, SIGNAL( toggled( bool ) ), this,
 							SLOT( toggleUI() ) );
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -541,7 +541,7 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	m_toggleUIButton->setCheckable( true );
 	m_toggleUIButton->setChecked( false );
 	m_toggleUIButton->setIcon( embed::getIconPixmap( "zoom" ) );
-	m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+	m_toggleUIButton->setFont(adjustedToPixelSize(m_toggleUIButton->font(), 8));
 	connect( m_toggleUIButton, SIGNAL( toggled( bool ) ), this,
 							SLOT( toggleUI() ) );
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -90,7 +90,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	{
 		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
-		ctls_btn->setFont(adjustedToPixelSize(f, 8));
+		ctls_btn->setFont(adjustedToPixelSize(f, 10));
 		ctls_btn->setGeometry( 150, 14, 50, 20 );
 		connect( ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));
@@ -257,7 +257,7 @@ void EffectView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	p.drawPixmap( 0, 0, m_bg );
 
-	QFont f = adjustedToPixelSize(font(), 7.5f);
+	QFont f = adjustedToPixelSize(font(), 10);
 	f.setBold( true );
 	p.setFont( f );
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -90,7 +90,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	{
 		auto ctls_btn = new QPushButton(tr("Controls"), this);
 		QFont f = ctls_btn->font();
-		ctls_btn->setFont(pointSize(f, 8));
+		ctls_btn->setFont(adjustedToPixelSize(f, 8));
 		ctls_btn->setGeometry( 150, 14, 50, 20 );
 		connect( ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));
@@ -257,7 +257,7 @@ void EffectView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	p.drawPixmap( 0, 0, m_bg );
 
-	QFont f = pointSize(font(), 7.5f);
+	QFont f = adjustedToPixelSize(font(), 7.5f);
 	f.setBold( true );
 	p.setFont( f );
 

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -157,7 +157,7 @@ Lv2ViewBase::Lv2ViewBase(QWidget* meAsWidget, Lv2ControlBase *ctrlBase) :
 		m_toggleUIButton->setCheckable(true);
 		m_toggleUIButton->setChecked(false);
 		m_toggleUIButton->setIcon(embed::getIconPixmap("zoom"));
-		m_toggleUIButton->setFont(pointSize(m_toggleUIButton->font(), 8));
+		m_toggleUIButton->setFont(adjustedToPixelSize(m_toggleUIButton->font(), 8));
 		btnBox->addWidget(m_toggleUIButton, 0);
 	}
 	btnBox->addStretch(1);

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -76,7 +76,7 @@ namespace lmms::gui
 
         m_renameLineEdit = new QLineEdit{mixerName, nullptr};
         m_renameLineEdit->setFixedWidth(65);
-        m_renameLineEdit->setFont(pointSize(font(), 7.5f));
+        m_renameLineEdit->setFont(adjustedToPixelSize(font(), 7.5f));
         m_renameLineEdit->setReadOnly(true);
         m_renameLineEdit->installEventFilter(this);
 

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -76,7 +76,7 @@ namespace lmms::gui
 
         m_renameLineEdit = new QLineEdit{mixerName, nullptr};
         m_renameLineEdit->setFixedWidth(65);
-        m_renameLineEdit->setFont(adjustedToPixelSize(font(), 7.5f));
+        m_renameLineEdit->setFont(adjustedToPixelSize(font(), 12));
         m_renameLineEdit->setReadOnly(true);
         m_renameLineEdit->installEventFilter(this);
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1041,7 +1041,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
-	p.setFont(adjustedToPixelSize(p.font(), 8));
+	p.setFont(adjustedToPixelSize(p.font(), 10));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;
 
@@ -1383,9 +1383,9 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	}
 	else
 	{
-		QFont f = p.font();
+		QFont f = font();
 		f.setBold( true );
-		p.setFont(adjustedToPixelSize(f, 14));
+		p.setFont(f);
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText( VALUES_WIDTH + 20, TOP_MARGIN + 40,

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1041,7 +1041,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
 	// set font-size to 8
-	p.setFont(pointSize(p.font(), 8));
+	p.setFont(adjustedToPixelSize(p.font(), 8));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;
 
@@ -1385,7 +1385,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize(f, 14));
+		p.setFont(adjustedToPixelSize(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText( VALUES_WIDTH + 20, TOP_MARGIN + 40,

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1040,7 +1040,6 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 	QBrush bgColor = p.background();
 	p.fillRect( 0, 0, width(), height(), bgColor );
 
-	// set font-size to 8
 	p.setFont(adjustedToPixelSize(p.font(), 10));
 
 	int grid_height = height() - TOP_MARGIN - SCROLLBAR_SIZE;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -59,7 +59,6 @@
 #include "DetuningHelper.h"
 #include "embed.h"
 #include "GuiApplication.h"
-#include "gui_templates.h"
 #include "InstrumentTrack.h"
 #include "MainWindow.h"
 #include "MidiClip.h"

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3598,9 +3598,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	}
 	else
 	{
-		QFont f = p.font();
-		f.setBold( true );
-		p.setFont(adjustedToPixelSize(f, 14));
+		QFont f = font();
+		f.setBold(true);
+		p.setFont(f);
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText(m_whiteKeyWidth + 20, PR_TOP_MARGIN + 40,

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3337,7 +3337,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	// display note editing info
 	//QFont f = p.font();
 	f.setBold( false );
-	p.setFont(pointSize(f, 10));
+	p.setFont(adjustedToPixelSize(f, 10));
 	p.setPen(m_noteModeColor);
 	p.drawText( QRect( 0, keyAreaBottom(),
 					  m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()),
@@ -3600,7 +3600,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 	{
 		QFont f = p.font();
 		f.setBold( true );
-		p.setFont(pointSize(f, 14));
+		p.setFont(adjustedToPixelSize(f, 14));
 		p.setPen( QApplication::palette().color( QPalette::Active,
 							QPalette::BrightText ) );
 		p.drawText(m_whiteKeyWidth + 20, PR_TOP_MARGIN + 40,

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3335,9 +3335,9 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()), bgColor);
 
 	// display note editing info
-	//QFont f = p.font();
-	f.setBold( false );
-	p.setFont(adjustedToPixelSize(f, 10));
+	f.setBold(false);
+	f.setPixelSize(10);
+	p.setFont(f);
 	p.setPen(m_noteModeColor);
 	p.drawText( QRect( 0, keyAreaBottom(),
 					  m_whiteKeyWidth, noteEditBottom() - keyAreaBottom()),

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -207,7 +207,6 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoWaveBtnGrp->addButton( random_lfo_btn );
 
 	m_x100Cb = new LedCheckBox( tr( "FREQ x 100" ), this );
-	m_x100Cb->setFont(adjustedToPixelSize(m_x100Cb->font(), 6.5));
 	m_x100Cb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 36 );
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 
@@ -215,7 +214,6 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_controlEnvAmountCb = new LedCheckBox( tr( "MODULATE ENV AMOUNT" ),
 			this );
 	m_controlEnvAmountCb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 54 );
-	m_controlEnvAmountCb->setFont(adjustedToPixelSize(m_controlEnvAmountCb->font(), 6.5));
 	m_controlEnvAmountCb->setToolTip(
 				tr( "Control envelope amount by this LFO" ) );
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -207,7 +207,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_lfoWaveBtnGrp->addButton( random_lfo_btn );
 
 	m_x100Cb = new LedCheckBox( tr( "FREQ x 100" ), this );
-	m_x100Cb->setFont(pointSize(m_x100Cb->font(), 6.5));
+	m_x100Cb->setFont(adjustedToPixelSize(m_x100Cb->font(), 6.5));
 	m_x100Cb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 36 );
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 
@@ -215,7 +215,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_controlEnvAmountCb = new LedCheckBox( tr( "MODULATE ENV AMOUNT" ),
 			this );
 	m_controlEnvAmountCb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 54 );
-	m_controlEnvAmountCb->setFont(pointSize(m_controlEnvAmountCb->font(), 6.5));
+	m_controlEnvAmountCb->setFont(adjustedToPixelSize(m_controlEnvAmountCb->font(), 6.5));
 	m_controlEnvAmountCb->setToolTip(
 				tr( "Control envelope amount by this LFO" ) );
 
@@ -340,7 +340,7 @@ void EnvelopeAndLfoView::paintEvent( QPaintEvent * )
 	// draw LFO-graph
 	p.drawPixmap(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph);
 
-	p.setFont(pointSize(p.font(), 8));
+	p.setFont(adjustedToPixelSize(p.font(), 8));
 
 	const float gray_amount = 1.0f - fabsf( m_amountKnob->value<float>() );
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -211,8 +211,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 
 
-	m_controlEnvAmountCb = new LedCheckBox( tr( "MODULATE ENV AMOUNT" ),
-			this );
+	m_controlEnvAmountCb = new LedCheckBox(tr("MOD ENV AMOUNT"), this);
 	m_controlEnvAmountCb->move( LFO_PREDELAY_KNOB_X, LFO_GRAPH_Y + 54 );
 	m_controlEnvAmountCb->setToolTip(
 				tr( "Control envelope amount by this LFO" ) );

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -57,7 +57,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	mainLayout->setVerticalSpacing( 1 );
 
 	auto chordLabel = new QLabel(tr("Chord:"));
-	chordLabel->setFont(pointSize(chordLabel->font(), 8));
+	chordLabel->setFont(adjustedToPixelSize(chordLabel->font(), 8));
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
@@ -146,13 +146,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));
-	arpChordLabel->setFont(pointSize(arpChordLabel->font(), 8));
+	arpChordLabel->setFont(adjustedToPixelSize(arpChordLabel->font(), 8));
 
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
-	arpDirectionLabel->setFont(pointSize(arpDirectionLabel->font(), 8));
+	arpDirectionLabel->setFont(adjustedToPixelSize(arpDirectionLabel->font(), 8));
 
 	auto arpModeLabel = new QLabel(tr("Mode:"));
-	arpModeLabel->setFont(pointSize(arpModeLabel->font(), 8));
+	arpModeLabel->setFont(adjustedToPixelSize(arpModeLabel->font(), 8));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -57,7 +57,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	mainLayout->setVerticalSpacing( 1 );
 
 	auto chordLabel = new QLabel(tr("Chord:"));
-	chordLabel->setFont(adjustedToPixelSize(chordLabel->font(), 8));
+	chordLabel->setFont(adjustedToPixelSize(chordLabel->font(), 10));
 
 	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
@@ -145,14 +145,15 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_arpGateKnob->setLabel( tr( "GATE" ) );
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
+	constexpr int labelFontSize = 10;
 	auto arpChordLabel = new QLabel(tr("Chord:"));
-	arpChordLabel->setFont(adjustedToPixelSize(arpChordLabel->font(), 8));
+	arpChordLabel->setFont(adjustedToPixelSize(arpChordLabel->font(), labelFontSize));
 
 	auto arpDirectionLabel = new QLabel(tr("Direction:"));
-	arpDirectionLabel->setFont(adjustedToPixelSize(arpDirectionLabel->font(), 8));
+	arpDirectionLabel->setFont(adjustedToPixelSize(arpDirectionLabel->font(), labelFontSize));
 
 	auto arpModeLabel = new QLabel(tr("Mode:"));
-	arpModeLabel->setFont(adjustedToPixelSize(arpModeLabel->font(), 8));
+	arpModeLabel->setFont(adjustedToPixelSize(arpModeLabel->font(), labelFontSize));
 
 	mainLayout->addWidget( arpChordLabel, 0, 0 );
 	mainLayout->addWidget( m_arpComboBox, 1, 0 );

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -155,7 +155,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	auto baseVelocityHelp
 		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont(adjustedToPixelSize(baseVelocityHelp->font(), 8));
+    baseVelocityHelp->setFont(adjustedToPixelSize(baseVelocityHelp->font(), 10));
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -155,7 +155,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	auto baseVelocityHelp
 		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
 	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont(pointSize(baseVelocityHelp->font(), 8));
+    baseVelocityHelp->setFont(adjustedToPixelSize(baseVelocityHelp->font(), 8));
 
 	baseVelocityLayout->addWidget( baseVelocityHelp );
 

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -77,7 +77,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
 	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
-	m_filterComboBox->setFont(pointSize(m_filterComboBox->font(), 8));
+	m_filterComboBox->setFont(adjustedToPixelSize(m_filterComboBox->font(), 8));
 
 
 	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
@@ -94,7 +94,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
 	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont(pointSize(m_singleStreamInfoLabel->font(), 8));
+	m_singleStreamInfoLabel->setFont(adjustedToPixelSize(m_singleStreamInfoLabel->font(), 8));
 
 	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
 						TARGETS_TABWIDGET_Y,

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -77,7 +77,6 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_filterComboBox = new ComboBox( m_filterGroupBox );
 	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
-	m_filterComboBox->setFont(adjustedToPixelSize(m_filterComboBox->font(), 8));
 
 
 	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
@@ -94,7 +93,8 @@ InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
 
 	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
 	m_singleStreamInfoLabel->setWordWrap( true );
-	m_singleStreamInfoLabel->setFont(adjustedToPixelSize(m_singleStreamInfoLabel->font(), 8));
+	// TODO Could also be rendered in system font size...
+	m_singleStreamInfoLabel->setFont(adjustedToPixelSize(m_singleStreamInfoLabel->font(), 10));
 
 	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
 						TARGETS_TABWIDGET_Y,

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -107,7 +107,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// setup line edit for changing instrument track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont(pointSize(m_nameLineEdit->font(), 9));
+	m_nameLineEdit->setFont(adjustedToPixelSize(m_nameLineEdit->font(), 9));
 	connect( m_nameLineEdit, SIGNAL( textChanged( const QString& ) ),
 				this, SLOT( textChanged( const QString& ) ) );
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -44,7 +44,6 @@
 #include "GroupBox.h"
 #include "MixerChannelLcdSpinBox.h"
 #include "GuiApplication.h"
-#include "gui_templates.h"
 #include "Instrument.h"
 #include "InstrumentFunctions.h"
 #include "InstrumentFunctionViews.h"

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -107,7 +107,6 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	// setup line edit for changing instrument track name
 	m_nameLineEdit = new QLineEdit;
-	m_nameLineEdit->setFont(adjustedToPixelSize(m_nameLineEdit->font(), 9));
 	connect( m_nameLineEdit, SIGNAL( textChanged( const QString& ) ),
 				this, SLOT( textChanged( const QString& ) ) );
 

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -60,7 +60,7 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setWordWrap(true);
-	tlabel->setFont(pointSize(tlabel->font(), 8));
+	tlabel->setFont(adjustedToPixelSize(tlabel->font(), 8));
 	masterPitchLayout->addWidget(tlabel);
 
 	// Microtuner settings

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -60,7 +60,7 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 
 	auto tlabel = new QLabel(tr("Enables the use of global transposition"));
 	tlabel->setWordWrap(true);
-	tlabel->setFont(adjustedToPixelSize(tlabel->font(), 8));
+	tlabel->setFont(adjustedToPixelSize(tlabel->font(), 10));
 	masterPitchLayout->addWidget(tlabel);
 
 	// Microtuner settings

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -807,7 +807,7 @@ void PianoView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 
 	// set smaller font for printing number of every octave
-	p.setFont(pointSize(p.font(), LABEL_TEXT_SIZE));
+	p.setFont(adjustedToPixelSize(p.font(), LABEL_TEXT_SIZE));
 
 
 	// draw bar above the keyboard (there will be the labels

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -53,7 +53,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 {
 	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
 
-	setFont(adjustedToPixelSize(font(), 9));
+	setFont(adjustedToPixelSize(font(), 10));
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -53,7 +53,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 {
 	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
 
-	setFont(pointSize(font(), 9));
+	setFont(adjustedToPixelSize(font(), 9));
 
 	connect( &m_menu, SIGNAL(triggered(QAction*)),
 				this, SLOT(setItem(QAction*)));

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -111,7 +111,7 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
-	p.setFont(adjustedToPixelSize(font(), 8));
+	p.setFont(adjustedToPixelSize(font(), 10));
 
 	int const captionX = ledButtonShown() ? 22 : 6;
 	p.drawText(captionX, m_titleBarHeight, m_caption);

--- a/src/gui/widgets/GroupBox.cpp
+++ b/src/gui/widgets/GroupBox.cpp
@@ -111,7 +111,7 @@ void GroupBox::paintEvent( QPaintEvent * pe )
 
 	// draw text
 	p.setPen( palette().color( QPalette::Active, QPalette::Text ) );
-	p.setFont(pointSize(font(), 8));
+	p.setFont(adjustedToPixelSize(font(), 8));
 
 	int const captionX = ledButtonShown() ? 22 : 6;
 	p.drawText(captionX, m_titleBarHeight, m_caption);

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -139,7 +139,7 @@ void Knob::setLabel( const QString & txt )
 	if( m_knobPixmap )
 	{
 		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 6.5)), m_label)),
+					horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 10)), m_label)),
 						m_knobPixmap->height() + 10);
 	}
 
@@ -459,7 +459,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
-			p.setFont(adjustedToPixelSize(p.font(), 6.5f));
+			p.setFont(adjustedToPixelSize(p.font(), 10));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2,
@@ -467,7 +467,8 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
-			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), 6.5f));
+			// TODO setHtmlLabel is never called so this will never be executed. Remove functionality?
+			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), 10));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
 		}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -139,7 +139,7 @@ void Knob::setLabel( const QString & txt )
 	if( m_knobPixmap )
 	{
 		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(pointSize(font(), 6.5)), m_label)),
+					horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 6.5)), m_label)),
 						m_knobPixmap->height() + 10);
 	}
 
@@ -459,7 +459,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
-			p.setFont(pointSize(p.font(), 6.5f));
+			p.setFont(adjustedToPixelSize(p.font(), 6.5f));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2,
@@ -467,7 +467,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
-			m_tdRenderer->setDefaultFont(pointSize(p.font(), 6.5f));
+			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), 6.5f));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
 		}

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -245,7 +245,7 @@ void LcdFloatSpinBox::paintEvent(QPaintEvent*)
 	// Label
 	if (!m_label.isEmpty())
 	{
-		p.setFont(pointSize(p.font(), 6.5f));
+		p.setFont(adjustedToPixelSize(p.font(), 6.5f));
 		p.setPen(m_wholeDisplay.textShadowColor());
 		p.drawText(width() / 2 - p.fontMetrics().boundingRect(m_label).width() / 2 + 1, height(), m_label);
 		p.setPen(m_wholeDisplay.textColor());

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -245,7 +245,7 @@ void LcdFloatSpinBox::paintEvent(QPaintEvent*)
 	// Label
 	if (!m_label.isEmpty())
 	{
-		p.setFont(adjustedToPixelSize(p.font(), 6.5f));
+		p.setFont(adjustedToPixelSize(p.font(), 10));
 		p.setPen(m_wholeDisplay.textShadowColor());
 		p.drawText(width() / 2 - p.fontMetrics().boundingRect(m_label).width() / 2 + 1, height(), m_label);
 		p.setPen(m_wholeDisplay.textColor());

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -203,7 +203,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	// Label
 	if( !m_label.isEmpty() )
 	{
-		p.setFont(adjustedToPixelSize(p.font(), 6.5f));
+		p.setFont(adjustedToPixelSize(p.font(), 10));
 		p.setPen( textShadowColor() );
 		p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1,
@@ -255,7 +255,7 @@ void LcdWidget::updateSize()
 		setFixedSize(
 			qMax<int>(
 				m_cellWidth * m_numDigits + marginX1 + marginX2,
-				horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 6.5f)), m_label)
+				horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 10)), m_label)
 			),
 			m_cellHeight + (2 * marginY) + 9
 		);

--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -203,7 +203,7 @@ void LcdWidget::paintEvent( QPaintEvent* )
 	// Label
 	if( !m_label.isEmpty() )
 	{
-		p.setFont(pointSize(p.font(), 6.5f));
+		p.setFont(adjustedToPixelSize(p.font(), 6.5f));
 		p.setPen( textShadowColor() );
 		p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2 + 1,
@@ -255,7 +255,7 @@ void LcdWidget::updateSize()
 		setFixedSize(
 			qMax<int>(
 				m_cellWidth * m_numDigits + marginX1 + marginX2,
-				horizontalAdvance(QFontMetrics(pointSize(font(), 6.5f)), m_label)
+				horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), 6.5f)), m_label)
 			),
 			m_cellHeight + (2 * marginY) + 9
 		);

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -92,7 +92,7 @@ void LedCheckBox::initUi( LedColor _color )
 	m_ledOnPixmap = embed::getIconPixmap(names[static_cast<std::size_t>(_color)].toUtf8().constData());
 	m_ledOffPixmap = embed::getIconPixmap("led_off");
 
-	if (m_legacyMode){ setFont(adjustedToPixelSize(font(), 7)); }
+	if (m_legacyMode){ setFont(adjustedToPixelSize(font(), 10)); }
 
 	setText( m_text );
 }
@@ -113,7 +113,7 @@ void LedCheckBox::onTextUpdated()
 void LedCheckBox::paintLegacy(QPaintEvent * pe)
 {
 	QPainter p( this );
-	p.setFont(adjustedToPixelSize(font(), 7));
+	p.setFont(adjustedToPixelSize(font(), 10));
 
 	p.drawPixmap(0, 0, model()->value() ? m_ledOnPixmap : m_ledOffPixmap);
 

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -92,7 +92,7 @@ void LedCheckBox::initUi( LedColor _color )
 	m_ledOnPixmap = embed::getIconPixmap(names[static_cast<std::size_t>(_color)].toUtf8().constData());
 	m_ledOffPixmap = embed::getIconPixmap("led_off");
 
-	if (m_legacyMode){ setFont(pointSize(font(), 7)); }
+	if (m_legacyMode){ setFont(adjustedToPixelSize(font(), 7)); }
 
 	setText( m_text );
 }
@@ -113,7 +113,7 @@ void LedCheckBox::onTextUpdated()
 void LedCheckBox::paintLegacy(QPaintEvent * pe)
 {
 	QPainter p( this );
-	p.setFont(pointSize(font(), 7));
+	p.setFont(adjustedToPixelSize(font(), 7));
 
 	p.drawPixmap(0, 0, model()->value() ? m_ledOnPixmap : m_ledOffPixmap);
 

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -30,7 +30,6 @@
 
 #include "MeterDialog.h"
 #include "MeterModel.h"
-#include "gui_templates.h"
 #include "LcdSpinBox.h"
 
 namespace lmms::gui

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -60,7 +60,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
-		num_label->setFont(pointSize(f, 7));
+		num_label->setFont(adjustedToPixelSize(f, 7));
 		num_layout->addSpacing( 5 );
 		num_layout->addWidget( num_label );
 	}
@@ -84,7 +84,7 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
-		den_label->setFont(pointSize(f, 7));
+		den_label->setFont(adjustedToPixelSize(f, 7));
 		den_layout->addSpacing( 5 );
 		den_layout->addWidget( den_label );
 	}

--- a/src/gui/widgets/MeterDialog.cpp
+++ b/src/gui/widgets/MeterDialog.cpp
@@ -60,7 +60,6 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto num_label = new QLabel(tr("Meter Numerator"), num);
 		QFont f = num_label->font();
-		num_label->setFont(adjustedToPixelSize(f, 7));
 		num_layout->addSpacing( 5 );
 		num_layout->addWidget( num_label );
 	}
@@ -84,7 +83,6 @@ MeterDialog::MeterDialog( QWidget * _parent, bool _simple ) :
 	{
 		auto den_label = new QLabel(tr("Meter Denominator"), den);
 		QFont f = den_label->font();
-		den_label->setFont(adjustedToPixelSize(f, 7));
 		den_layout->addSpacing( 5 );
 		den_layout->addWidget( den_label );
 	}

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -203,7 +203,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 	else
 	{
 		p.setPen( QColor( 192, 192, 192 ) );
-		p.setFont(pointSize(p.font(), 7));
+		p.setFont(adjustedToPixelSize(p.font(), 7));
 		p.drawText( 6, height()-5, tr( "Click to enable" ) );
 	}
 }

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -203,7 +203,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 	else
 	{
 		p.setPen( QColor( 192, 192, 192 ) );
-		p.setFont(adjustedToPixelSize(p.font(), 7));
+		p.setFont(adjustedToPixelSize(p.font(), 10));
 		p.drawText( 6, height()-5, tr( "Click to enable" ) );
 	}
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -90,7 +90,7 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		_w->setFixedSize( _w->parentWidget()->size() );
 	}
 
-	b->setFont(pointSize(b->font(), 8));
+	b->setFont(adjustedToPixelSize(b->font(), 8));
 
 	return( b );
 }

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -25,7 +25,6 @@
 
 #include "TabBar.h"
 #include "TabButton.h"
-#include "gui_templates.h"
 
 
 namespace lmms::gui

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -90,8 +90,6 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 		_w->setFixedSize( _w->parentWidget()->size() );
 	}
 
-	b->setFont(adjustedToPixelSize(b->font(), 8));
-
 	return( b );
 }
 

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -58,7 +58,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont(adjustedToPixelSize(font(), 8));
+	setFont(adjustedToPixelSize(font(), 10));
 
 	setAutoFillBackground(true);
 	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);
@@ -70,8 +70,6 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont(adjustedToPixelSize(font(), 8));
-
 	// Append tab when position is not given
 	if (idx < 0/* || m_widgets.contains(idx) == true*/)
 	{
@@ -216,7 +214,7 @@ void TabWidget::resizeEvent(QResizeEvent*)
 void TabWidget::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	p.setFont(adjustedToPixelSize(font(), 7));
+	p.setFont(adjustedToPixelSize(font(), 10));
 
 	// Draw background
 	QBrush bg_color = p.background();
@@ -232,7 +230,6 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	// Draw title, if any
 	if (!m_caption.isEmpty())
 	{
-		p.setFont(adjustedToPixelSize(p.font(), 8));
 		p.setPen(tabTitleText());
 		p.drawText(5, 11, m_caption);
 	}

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -58,7 +58,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 	m_tabheight = caption.isEmpty() ? m_tabbarHeight - 3 : m_tabbarHeight - 4;
 
-	setFont(pointSize(font(), 8));
+	setFont(adjustedToPixelSize(font(), 8));
 
 	setAutoFillBackground(true);
 	QColor bg_color = QApplication::palette().color(QPalette::Active, QPalette::Window).darker(132);
@@ -70,7 +70,7 @@ TabWidget::TabWidget(const QString& caption, QWidget* parent, bool usePixmap,
 
 void TabWidget::addTab(QWidget* w, const QString& name, const char* pixmap, int idx)
 {
-	setFont(pointSize(font(), 8));
+	setFont(adjustedToPixelSize(font(), 8));
 
 	// Append tab when position is not given
 	if (idx < 0/* || m_widgets.contains(idx) == true*/)
@@ -216,7 +216,7 @@ void TabWidget::resizeEvent(QResizeEvent*)
 void TabWidget::paintEvent(QPaintEvent* pe)
 {
 	QPainter p(this);
-	p.setFont(pointSize(font(), 7));
+	p.setFont(adjustedToPixelSize(font(), 7));
 
 	// Draw background
 	QBrush bg_color = p.background();
@@ -232,7 +232,7 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 	// Draw title, if any
 	if (!m_caption.isEmpty())
 	{
-		p.setFont(pointSize(p.font(), 8));
+		p.setFont(adjustedToPixelSize(p.font(), 8));
 		p.setPen(tabTitleText());
 		p.drawText(5, 11, m_caption);
 	}


### PR DESCRIPTION
This is a proposed fix for the scalability issues reported in #7178. It also helps with the migration to Qt6 as reported in #6614.

It renames `pointSize` to `adjustedToPixelSize` and changes the implementation such that the function sets the font size in pixels instead of points.

This is done under the assumption that LMMS wants to support the model where users with HiDPI screens will set a global fractional scaling factor that's larger than 1. In that case text that's rendered in pixel sizes will be scaled as well and a text that will look good at 96 DPI will also look good at a higher DPI if scaled accordingly.

Example: A user has a display with 120 DPI. If they set the global scaling factor to 120 DPI / 96 DPI = 1.25 then everything is scaled accordingly and the GUI elements including text should have the same visual appearance, size and legibility.

## Other things done
Go through all files that have been adjusted by the PR and check the following aspects:
* If it is a home-grown widget check if it draws itself at fixed sizes. If that's the case potentially adjust the pixel sizes of the used fonts until they are large enough, legible and it looks good overall.
* Consider to switch some calls to `adjustedToPixelSize` with setting the font in point sizes where it potentially does not matter.
* There are some calls to `adjustedToPixelSize` which use `float` values which are not integer. These will be implicitly cast to integer. Adjust all places to appropriate integer values to get a consistent and non-surprising behavior.
* Check if some adjustments override the pixel font sizes of underlying elements like for example combo boxes, etc. Potentially remove these overrides to ensure that everything looks consistent.