### PR TITLE
Only repaint LcdWidget if necessary

### DIFF
--- a/src/gui/widgets/LcdWidget.cpp
+++ b/src/gui/widgets/LcdWidget.cpp
@@ -78,9 +78,12 @@ void LcdWidget::setValue(int value)
 		}
 	}
 
-	m_display = s;
+	if (m_display != s)
+	{
+		m_display = s;
 
-	update();
+		update();
+	}
 }
 
 void LcdWidget::setValue(float value)


### PR DESCRIPTION
Some analysis done with Callgrind showed that the `LcdWidget` spends quite some time repainting itself even when nothing has changed. Some widget instances are used in song update contexts where `LcdWidget::setValue` is called 60 times per second.

This commit fixes the problem by only updating the `LcdWidget` if its value really has changed.