### PR TITLE
Declutter instrument and sample track windows (remove "GENERAL SETTINGS" label/tab)

### DIFF
--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -40,7 +40,6 @@
 #include "SampleTrackView.h"
 #include "Song.h"
 #include "SubWindow.h"
-#include "TabWidget.h"
 #include "TrackLabelButton.h"
 
 namespace lmms::gui
@@ -69,12 +68,8 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 	vlayout->setContentsMargins(0, 0, 0, 0);
 	vlayout->setSpacing(0);
 
-	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
-
+	auto generalSettingsWidget = new QWidget(this);
 	auto generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
-
-	generalSettingsLayout->setContentsMargins(8, 18, 8, 8);
-	generalSettingsLayout->setSpacing(6);
 
 	auto nameWidget = new QWidget(generalSettingsWidget);
 	auto nameLayout = new QHBoxLayout(nameWidget);

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -93,12 +93,8 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	vlayout->setContentsMargins(0, 0, 0, 0);
 	vlayout->setSpacing( 0 );
 
-	auto generalSettingsWidget = new TabWidget(tr("GENERAL SETTINGS"), this);
-
+	auto generalSettingsWidget = new QWidget(this);
 	auto generalSettingsLayout = new QVBoxLayout(generalSettingsWidget);
-
-	generalSettingsLayout->setContentsMargins( 8, 18, 8, 8 );
-	generalSettingsLayout->setSpacing( 6 );
 
 	auto nameAndChangeTrackWidget = new QWidget(generalSettingsWidget);
 	auto nameAndChangeTrackLayout = new QHBoxLayout(nameAndChangeTrackWidget);


### PR DESCRIPTION
Declutter the instrument and sample track windows by removing the "GENERAL SETTINGS" tab. It was the only tab and did not add any meaningful information.

Here's a before and after comparison:
![Declutter-Instrument-Before](https://github.com/LMMS/lmms/assets/9293269/d32b0f7b-34cc-4c67-be07-09dfde657190)![Declutter-Instrument-After](https://github.com/LMMS/lmms/assets/9293269/cf3819da-5136-43af-b154-5f32a93c3122)

![Declutter-SampleTrack-Before](https://github.com/LMMS/lmms/assets/9293269/9e1f1ad7-6bee-42c2-9665-acc7ff273e77)![Declutter-SampleTrack-After](https://github.com/LMMS/lmms/assets/9293269/3cc58ec7-e30d-4e08-8665-546bf6d990f3)

Besides the clutter this also removes dependencies to the non-scalable `TabWidget`.