### PR TITLE
Format `DrumSynth`

### DIFF
--- a/include/DrumSynth.h
+++ b/include/DrumSynth.h
@@ -27,32 +27,32 @@
 #define LMMS_DRUM_SYNTH_H
 
 #include <stdint.h>
+
 #include "lmms_basics.h"
 
 class QString;
 
-namespace lmms
+namespace lmms {
+
+class DrumSynth
 {
+public:
+	DrumSynth() = default;
+	int GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sample_rate_t Fs);
 
-class DrumSynth {
-    public:
-        DrumSynth() = default;
-        int GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs);
+private:
+	float LoudestEnv();
+	int LongestEnv();
+	void UpdateEnv(int e, long t);
+	void GetEnv(int env, const char* sec, const char* key, QString ini);
 
-    private:
-        float LoudestEnv();
-        int   LongestEnv();
-        void  UpdateEnv(int e, long t);
-        void  GetEnv(int env, const char *sec, const char *key, QString ini);
+	float waveform(float ph, int form);
 
-        float waveform(float ph, int form);
-
-        int GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file);
-        int GetPrivateProfileInt(const char *sec, const char *key, int def, QString file);
-        float GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file);
-
+	int GetPrivateProfileString(
+		const char* sec, const char* key, const char* def, char* buffer, int size, QString file);
+	int GetPrivateProfileInt(const char* sec, const char* key, int def, QString file);
+	float GetPrivateProfileFloat(const char* sec, const char* key, float def, QString file);
 };
-
 
 } // namespace lmms
 

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -63,22 +63,22 @@ short DD[1200], clippoint;
 float DF[1200];
 float phi[1200];
 
-long  wavewords, wavemode=0;
-float mem_t=1.0f, mem_o=1.0f, mem_n=1.0f, mem_b=1.0f, mem_tune=1.0f, mem_time=1.0f;
+long  wavewords, wavemode = 0;
+float mem_t = 1.0f, mem_o = 1.0f, mem_n = 1.0f, mem_b = 1.0f, mem_tune = 1.0f, mem_time = 1.0f;
 
 
 int DrumSynth::LongestEnv()
 {
-	float l = 0.f;
+  long e, eon, p;
+  float l = 0.f;
 
-	for (long e = 1; e < 7; e++) // 3
-	{
-		long eon = e - 1;
-		if (eon > 2) { eon = eon - 1; }
-		long p = 0;
-		while (envpts[e][0][p + 1] >= 0.f) { p++; }
-		envData[e][MAX] = envpts[e][0][p] * timestretch;
-		if (chkOn[eon] == 1 && envData[e][MAX] > l) { l = envData[e][MAX]; }
+  for (e = 1; e < 7; e++) //3
+  {
+    eon = e - 1; if (eon > 2) { eon = eon - 1; }
+    p = 0;
+    while (envpts[e][0][p + 1] >= 0.f) { p++; }
+    envData[e][MAX] = envpts[e][0][p] * timestretch;
+    if (chkOn[eon] == 1) if (envData[e][MAX] > l) { l = envData[e][MAX]; }
   }
   //l *= timestretch;
 
@@ -88,12 +88,12 @@ int DrumSynth::LongestEnv()
 
 float DrumSynth::LoudestEnv()
 {
-  float loudest=0.f;
-  int i=0;
+  float loudest = 0.f;
+  int i = 0;
 
-  while (i<5) //2
+  while (i < 5) //2
   {
-    if(chkOn[i]==1) if(sliLev[i]>loudest) loudest=(float)sliLev[i];
+    if (chkOn[i] == 1) if (sliLev[i] > loudest) loudest = (float)sliLev[i];
     i++;
   }
   return (loudest * loudest);
@@ -102,44 +102,45 @@ float DrumSynth::LoudestEnv()
 
 void DrumSynth::UpdateEnv(int e, long t)
 {
-	// 0.2's added
-	envData[e][NEXTT] = envpts[e][0][static_cast<long>(envData[e][PNT] + 1.f)] * timestretch; // get next point
-	if (envData[e][NEXTT] < 0) { envData[e][NEXTT] = 442000 * timestretch; } // if end point, hold
-	envData[e][ENV] = envpts[e][1][static_cast<long>(envData[e][PNT] + 0.f)] * 0.01f; // this level
-	float endEnv = envpts[e][1][static_cast<long>(envData[e][PNT] + 1.f)] * 0.01f; // next level
-	float dT = envData[e][NEXTT] - static_cast<float>(t);
-	if (dT < 1.0) { dT = 1.0; }
-	envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
-	envData[e][PNT] = envData[e][PNT] + 1.0f;
+  float endEnv, dT;
+                                                             //0.2's added
+  envData[e][NEXTT] = envpts[e][0][(long)(envData[e][PNT] + 1.f)] * timestretch; //get next point
+  if(envData[e][NEXTT] < 0) envData[e][NEXTT] = 442000 * timestretch; //if end point, hold
+  envData[e][ENV] = envpts[e][1][(long)(envData[e][PNT] + 0.f)] * 0.01f; //this level
+  endEnv = envpts[e][1][(long)(envData[e][PNT] + 1.f)] * 0.01f;          //next level
+  dT = envData[e][NEXTT] - (float)t;
+  if(dT < 1.0) dT = 1.0;
+  envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
+  envData[e][PNT] = envData[e][PNT] + 1.0f;
 }
 
 
 void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
 {
   char en[256], s[8];
-  int i=0, o=0, ep=0;
+  int i = 0, o = 0, ep = 0;
   GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
 
   //be safe!
-  en[255]=0;
-  s[0]=0;
+  en[255] = 0;
+  s[0] = 0;
 
-  while(en[i]!=0)
+  while (en[i] != 0)
   {
-    if(en[i] == ',')
+    if (en[i] == ',')
     {
-      if(sscanf(s, "%f", &envpts[env][0][ep])==0) envpts[env][0][ep] = 0.f;
-      o=0;
+      if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
+      o = 0;
     }
-    else if(en[i] == ' ')
+    else if (en[i] == ' ')
     {
-      if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
-      o=0; ep++;
+      if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
+      o = 0; ep++;
     }
-    else { s[o]=en[i]; o++; s[o]=0; }
+    else { s[o] = en[i]; o++; s[o] = 0; }
     i++;
   }
-  if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
+  if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
   envpts[env][0][ep + 1] = -1;
 
   envData[env][MAX] = envpts[env][0][ep];
@@ -148,41 +149,34 @@ void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
 
 float DrumSynth::waveform(float ph, int form)
 {
-	float w;
+  float w;
 
-	switch (form)
-	{
-	case 0:
-		w = static_cast<float>(sin(fmod(ph, TwoPi)));
-		break; // sine
-	case 1:
-		w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
-		break; // sine^2
-	case 2:
-		while (ph < TwoPi) { ph += TwoPi; }
-		w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
-		if (w > 1.f) { w = 2.f - w; }
-		break;
-	case 3:
-		w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
-		w = (0.3183098f * w) - 1.f;
-		break;
-	default:
-		w = (sin(fmod(ph, TwoPi)) > 0.0) ? 1.f : -1.f;
-		break; // square
-	}
+  switch (form)
+  {
+     case 0: w = (float)sin(fmod(ph,TwoPi));                            break; //sine
+     case 1: w = (float)fabs(2.0f*(float)sin(fmod(0.5f*ph, TwoPi))) - 1.f; break; //sine^2
+     case 2: while(ph<TwoPi) ph+=TwoPi;
+             w = 0.6366197f * (float)fmod(ph,TwoPi) - 1.f;                     //tri
+             if(w>1.f) w=2.f-w;
+             break;
+     case 3: w = ph - TwoPi * (float)(int)(ph / TwoPi);                        //saw
+             w = (0.3183098f * w) - 1.f;                                break;
+    default: w = (sin(fmod(ph,TwoPi))>0.0)? 1.f: -1.f;                  break; //square
+  }
 
-	return w;
+  return w;
 }
 
 
 int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file)
 {
-	stringstream is;
-	bool inSection = false;
-	int len = 0;
+    stringstream is;
+    bool inSection = false;
+    char *line;
+    char *k, *b;
+    int len = 0;
 
-	char* line = static_cast<char*>(malloc(200));
+    line = (char*)malloc(200);
 
     // Use QFile to handle unicode file name on Windows
     // Previously we used ifstream directly
@@ -191,46 +185,59 @@ int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const c
     QByteArray dat = f.readAll().constData();
     is.str(string(dat.constData(), dat.size()));
 
-    while (is.good()) {
-        if (!inSection) {
-            is.ignore( numeric_limits<streamsize>::max(), '[');
+    while (is.good())
+	{
+        if (!inSection)
+		{
+            is.ignore(numeric_limits<streamsize>::max(), '[');
 
-            if (!is.eof()) {
+            if (!is.eof())
+			{
                 is.getline(line, 200, ']');
-                if (strcasecmp(line, sec)==0) {
+                if (strcasecmp(line, sec) == 0)
+				{
                     inSection = true;
                 }
             }
         }
-        else if (!is.eof()) {
+        else if (!is.eof())
+		{
             is.getline(line, 200);
             if (line[0] == '[')
+			{
                 break;
+			}
 
-            char* k = strtok(line, " \t=");
-            char* b = strtok(nullptr, "\n\r\0");
+            k = strtok(line, " \t=");
+            b = strtok(nullptr, "\n\r\0");
 
-            if (k != 0 && strcasecmp(k, key)==0) {
-                if (b==0) {
+            if (k != 0 && strcasecmp(k, key) == 0)
+			{
+                if (b == 0)
+				{
                     len = 0;
                     buffer[0] = 0;
                 }
-                else {
-                    k = (char *)(b + strlen(b)-1);
-                    while ( (k>=b) && (*k==' ' || *k=='\t') )
+                else
+				{
+                    k = (char *)(b + strlen(b) - 1);
+                    while ((k>=b) && (*k == ' ' || *k == '\t'))
+					{
                         --k;
+					}
                     *(k+1) = '\0';
 
                     len = strlen(b);
-                    if (len > size-1) len = size-1;
-                    strncpy(buffer, b, len+1);
+                    if (len > size - 1) { len = size - 1; }
+                    strncpy(buffer, b, len + 1);
                 }
                 break;
             }
         }
     }
 
-    if (len == 0) {
+    if (len == 0)
+	{
         len = strlen(def);
         strncpy(buffer, def, size);
     }
@@ -246,7 +253,7 @@ int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, Q
   int i=0;
 
   GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-  sscanf(tmp, "%d", &i); if(tmp[0]==0) i=def;
+  sscanf(tmp, "%d", &i); if (tmp[0] == 0) { i = def; }
 
   return i;
 }
@@ -257,7 +264,7 @@ float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float 
     float f=0.f;
 
     GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-    sscanf(tmp, "%f", &f); if(tmp[0]==0) f=def;
+    sscanf(tmp, "%f", &f); if (tmp[0] == 0) { f = def; }
 
     return f;
 }
@@ -274,10 +281,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   char sec[32];
   char ver[32];
   char comment[256];
-  int commentLen=0;
+  int commentLen = 0;
 
   //generation
-  long  Length, tpos=0, tplus, totmp, t, i, j;
+  long  Length, tpos = 0, tplus, totmp, t, i, j;
   float x[3] = {0.f, 0.f, 0.f};
   float MasterTune;
   constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
@@ -285,23 +292,23 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   int   MainFilter, HighPass;
 
   long  NON, NT, TON, DiON, TDroop=0, DStep;
-  float a, b=0.f, c=0.f, d=0.f, g, TT=0.f, TL, NL, F1, F2;
-  float TphiStart=0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
+  float a, b = 0.f, c = 0.f, d = 0.f, g, TT = 0.f, TL, NL, F1, F2;
+  float TphiStart = 0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
 
   long  BON, BON2, BFStep, BFStep2, botmp;
-  float BdF=0.f, BdF2=0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
+  float BdF = 0.f, BdF2 = 0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
 
-  long  OON, OF1Sync=0, OF2Sync=0, OMode, OW1, OW2;
-  float Ophi1, Ophi2, OF1, OF2, OL, Ot=0 /*PG: init */, OBal1, OBal2, ODrive;
+  long  OON, OF1Sync = 0, OF2Sync = 0, OMode, OW1, OW2;
+  float Ophi1, Ophi2, OF1, OF2, OL, Ot = 0 /*PG: init */, OBal1, OBal2, ODrive;
   float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
-  float Oc0=0.0f, Oc1=0.0f, Oc2=0.0f;
+  float Oc0 = 0.0f, Oc1 = 0.0f, Oc2 = 0.0f;
 
-  float MFfb, MFtmp, MFres, MFin=0.f, MFout=0.f;
+  float MFfb, MFtmp, MFres, MFin = 0.f, MFout = 0.f;
   float DownAve;
   long  DownStart, DownEnd, jj;
 
 
-  if(wavemode==0) //semi-real-time adjustments if working in memory!!
+  if (wavemode == 0) //semi-real-time adjustments if working in memory!!
   {
     mem_t = 1.0f;
     mem_o = 1.0f;
@@ -313,47 +320,47 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
 
   //try to read version from input file
   strcpy(sec, "General");
-  GetPrivateProfileString(sec,"Version","",ver,sizeof(ver),dsfile);
-  ver[9]=0;
-  if(strcasecmp(ver, "DrumSynth") != 0) {return 0;} //input fail
-  if(ver[11] != '1' && ver[11] != '2') {return 0;} //version fail
+  GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
+  ver[9] = 0;
+  if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } //input fail
+  if (ver[11] != '1' && ver[11] != '2') { return 0; } //version fail
 
 
   //read master parameters
-  GetPrivateProfileString(sec,"Comment","",comment,sizeof(comment),dsfile);
-  while((comment[commentLen]!=0) && (commentLen<254)) commentLen++;
-  if(commentLen==0) { comment[0]=32; comment[1]=0; commentLen=1;}
-  comment[commentLen+1]=0; commentLen++;
-  if((commentLen % 2)==1) commentLen++;
+  GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
+  while ((comment[commentLen] != 0) && (commentLen < 254)) { commentLen++; }
+  if (commentLen == 0) { comment[0] = 32; comment[1] = 0; commentLen = 1; }
+  comment[commentLen+1] = 0; commentLen++;
+  if ((commentLen % 2) == 1) { commentLen++; }
 
-  timestretch = .01f * mem_time * GetPrivateProfileFloat(sec,"Stretch",100.0,dsfile);
-  if(timestretch<0.2f) timestretch=0.2f;
-  if(timestretch>10.f) timestretch=10.f;
+  timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
+  if (timestretch < 0.2f) { timestretch = 0.2f; }
+  if (timestretch > 10.f) { timestretch = 10.f; }
   // the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
   timestretch *= Fs / 44100.f;
 
   DGain = 1.0f; //leave this here!
-  DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec,"Level",0,dsfile)));
+  DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec, "Level", 0, dsfile)));
 
-  MasterTune = GetPrivateProfileFloat(sec,"Tuning",0.0,dsfile);
+  MasterTune = GetPrivateProfileFloat(sec, "Tuning", 0.0, dsfile);
   MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
-  MainFilter = 2 * GetPrivateProfileInt(sec,"Filter",0,dsfile);
-  MFres = 0.0101f * GetPrivateProfileFloat(sec,"Resonance",0.0,dsfile);
+  MainFilter = 2 * GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+  MFres = 0.0101f * GetPrivateProfileFloat(sec, "Resonance", 0.0, dsfile);
   MFres = static_cast<float>(std::pow(MFres, 0.5f));
 
-  HighPass = GetPrivateProfileInt(sec,"HighPass",0,dsfile);
+  HighPass = GetPrivateProfileInt(sec, "HighPass", 0, dsfile);
   GetEnv(7, sec, "FilterEnv", dsfile);
 
 
   //read noise parameters
   strcpy(sec, "Noise");
-  chkOn[1] = GetPrivateProfileInt(sec,"On",0,dsfile);
-  sliLev[1] = GetPrivateProfileInt(sec,"Level",0,dsfile);
-  NT =  GetPrivateProfileInt(sec,"Slope",0,dsfile);
+  chkOn[1] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+  sliLev[1] = GetPrivateProfileInt(sec,"Level", 0, dsfile);
+  NT =  GetPrivateProfileInt(sec,"Slope", 0, dsfile);
   GetEnv(2, sec, "Envelope", dsfile);
   NON = chkOn[1];
   NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
-  if(NT<0)
+  if (NT < 0)
   { a = 1.f + (NT / 105.f); d = -NT / 105.f;
     g = (1.f + 0.0005f * NT * NT) * NL; }
   else
@@ -369,20 +376,20 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
   GetEnv(1, sec, "Envelope", dsfile);
   F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
-  if(fabs(F1)<0.001f) F1=0.001f; //to prevent overtone ratio div0
-  F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
+  if (fabs(F1) < 0.001f) { F1 = 0.001f; } //to prevent overtone ratio div0
+  F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
   TDroopRate = GetPrivateProfileFloat(sec,"Droop",0.f,dsfile);
-  if(TDroopRate>0.f)
+  if (TDroopRate > 0.f)
   {
     TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
     TDroopRate = TDroopRate * -4.f / envData[1][MAX];
     TDroop = 1;
-    F2 = F1+((F2-F1)/(1.f-(float)exp(TDroopRate * envData[1][MAX])));
+    F2 = F1 + ((F2 - F1)/(1.f - (float)exp(TDroopRate * envData[1][MAX])));
     ddF = F1 - F2;
   }
-  else ddF = F2-F1;
+  else { ddF = F2 - F1; }
 
-  Tphi = GetPrivateProfileFloat(sec,"Phase",90.f,dsfile) / 57.29578f; //degrees>radians
+  Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; //degrees>radians
 
   //read overtone parameters
   strcpy(sec, "Overtones");
@@ -391,22 +398,22 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
   GetEnv(3, sec, "Envelope1", dsfile);
   GetEnv(4, sec, "Envelope2", dsfile);
-  OMode = GetPrivateProfileInt(sec,"Method",2,dsfile);
-  OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
-  OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
-  OW1 = GetPrivateProfileInt(sec,"Wave1",0,dsfile);
-  OW2 = GetPrivateProfileInt(sec,"Wave2",0,dsfile);
-  OBal2 = (float)GetPrivateProfileInt(sec,"Param",50,dsfile);
+  OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
+  OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+  OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+  OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
+  OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
+  OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
   ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
   OBal2 *= 0.01f;
   OBal1 = 1.f - OBal2;
   Ophi1 = Tphi;
   Ophi2 = Tphi;
-  if(MainFilter==0)
-    MainFilter = GetPrivateProfileInt(sec,"Filter",0,dsfile);
-  if((GetPrivateProfileInt(sec,"Track1",0,dsfile)==1) && (TON==1))
+  if (MainFilter == 0)
+  { MainFilter = GetPrivateProfileInt(sec,"Filter",0,dsfile); }
+  if ((GetPrivateProfileInt(sec,"Track1",0,dsfile) == 1) && (TON == 1))
   { OF1Sync = 1;  OF1 = OF1 / F1; }
-  if((GetPrivateProfileInt(sec,"Track2",0,dsfile)==1) && (TON==1))
+  if ((GetPrivateProfileInt(sec,"Track2",0,dsfile) == 1) && (TON == 1))
   { OF2Sync = 1;  OF2 = OF2 / F1; }
 
   OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
@@ -415,61 +422,62 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
   OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
   Ocf1 = TwoPi / OF1;
   Ocf2 = TwoPi / OF2;
-  for(i=0; i<6; i++) Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
+  for (i = 0; i < 6; i++)
+  { Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i; }
 
   //read noise band parameters
   strcpy(sec, "NoiseBand");
-  chkOn[3] = GetPrivateProfileInt(sec,"On",0,dsfile); BON = chkOn[3];
-  sliLev[3] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON = chkOn[3];
+  sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
   BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
-  BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
+  BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
   BPhi = TwoPi / 8.f;
   GetEnv(5, sec, "Envelope", dsfile);
-  BFStep = GetPrivateProfileInt(sec,"dF",50,dsfile);
+  BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
   BQ = (float)BFStep;
-  BQ = BQ * BQ / (10000.f-6600.f*((float)sqrt(BF)-0.19f));
+  BQ = BQ * BQ / (10000.f - 6600.f*((float)sqrt(BF) - 0.19f));
   BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
   strcpy(sec, "NoiseBand2");
-  chkOn[4] = GetPrivateProfileInt(sec,"On",0,dsfile); BON2 = chkOn[4];
-  sliLev[4] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON2 = chkOn[4];
+  sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
   BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
-  BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
+  BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
   BPhi2 = TwoPi / 8.f;
   GetEnv(6, sec, "Envelope", dsfile);
-  BFStep2 = GetPrivateProfileInt(sec,"dF",50,dsfile);
+  BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
   BQ2 = (float)BFStep2;
-  BQ2 = BQ2 * BQ2 / (10000.f-6600.f*((float)sqrt(BF2)-0.19f));
+  BQ2 = BQ2 * BQ2 / (10000.f - 6600.f*((float)sqrt(BF2) - 0.19f));
   BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
   //read distortion parameters
   strcpy(sec, "Distortion");
-  chkOn[5] = GetPrivateProfileInt(sec,"On",0,dsfile); DiON = chkOn[5];
-  DStep = 1 + GetPrivateProfileInt(sec,"Rate",0,dsfile);
-  if(DStep==7) DStep=20;
-  if(DStep==6) DStep=10;
-  if(DStep==5) DStep=8;
+  chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile); DiON = chkOn[5];
+  DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
+  if (DStep == 7) { DStep = 20; }
+  if (DStep == 6) { DStep = 10; }
+  if (DStep == 5) { DStep = 8; }
 
   clippoint = 32700;
   DAtten = 1.0f;
 
-  if(DiON==1)
+  if (DiON == 1)
   {
     DAtten = DGain * (short)LoudestEnv();
-    if(DAtten>32700) clippoint=32700; else clippoint=(short)DAtten;
-    DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec,"Bits",0,dsfile)));
-    DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec,"Clipping",0,dsfile)));
+    if (DAtten > 32700) { clippoint = 32700; } else { clippoint = (short)DAtten; }
+    DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
+    DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
   }
 
   //prepare envelopes
-  for (i=1;i<8;i++) { envData[i][NEXTT]=0; envData[i][PNT]=0; }
+  for (i = 1; i < 8; i++) { envData[i][NEXTT] = 0; envData[i][PNT] = 0; }
   Length = LongestEnv();
 
   //allocate the buffer
   //if(wave!=NULL) free(wave);
   //wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
   wave = new int16_t[channels * Length]; //wave memory buffer
-  if(wave==nullptr) {return 0;}
+  if (wave == nullptr) { return 0; }
   wavewords = 0;
 
   /*
@@ -509,94 +517,105 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
 
   //generate
   tpos = 0;
-  while(tpos<Length)
+  while (tpos < Length)
   {
     tplus = tpos + 1199;
 
-    if(NON==1) //noise
+    if (NON == 1) //noise
     {
-      for(t=tpos; t<=tplus; t++)
+      for (t = tpos; t <= tplus; t++)
       {
-        if(t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
-        else UpdateEnv(2, t);
+        if (t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
+        else { UpdateEnv(2, t); }
         x[2] = x[1];
         x[1] = x[0];
         x[0] = (randmax2 * (float)rand()) - 1.f;
         TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
         DF[t - tpos] = TT * g * envData[2][ENV];
       }
-      if(t>=envData[2][MAX]) NON=0;
+      if (t >= envData[2][MAX]) { NON=0; }
     }
-    else {
-        for(j=0; j<1200; j++) DF[j]=0.f;
+    else
+	{
+        for (j = 0; j < 1200; j++) { DF[j]=0.f; }
     }
 
-    if(TON==1) //tone
+    if (TON == 1) //tone
     {
       TphiStart = Tphi;
-      if(TDroop==1)
+      if (TDroop == 1)
       {
-        for(t=tpos; t<=tplus; t++)
+        for (t = tpos; t <= tplus; t++)
+		{
           phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+		}
       }
       else
       {
-        for(t=tpos; t<=tplus; t++)
+        for (t = tpos; t <= tplus; t++)
+		{
           phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
+		}
       }
-      for(t=tpos; t<=tplus; t++)
+      for (t = tpos; t <= tplus; t++)
       {
         totmp = t - tpos;
-        if(t < envData[1][NEXTT])
+        if (t < envData[1][NEXTT])
+		{
           envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
-        else UpdateEnv(1, t);
+		}
+        else { UpdateEnv(1, t); }
         Tphi = Tphi + phi[totmp];
         DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi,TwoPi));//overflow?
       }
-      if(t>=envData[1][MAX]) TON=0;
+      if (t >= envData[1][MAX]) { TON=0; }
     }
-    else for(j=0; j<1200; j++) phi[j]=F2; //for overtone sync
+    else for (j = 0; j < 1200; j++) { phi[j] = F2; } //for overtone sync
 
-    if(BON==1) //noise band 1
+    if (BON == 1) //noise band 1
     {
-      for(t=tpos; t<=tplus; t++)
+      for (t = tpos; t <= tplus; t++)
       {
-        if(t < envData[5][NEXTT])
+        if (t < envData[5][NEXTT])
+		{
           envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
-        else UpdateEnv(5, t);
-        if((t % BFStep) == 0) BdF = randmax * (float)rand() - 0.5f;
+		}
+        else { UpdateEnv(5, t); }
+        if ((t % BFStep) == 0) { BdF = randmax * (float)rand() - 0.5f; }
         BPhi = BPhi + BF + BQ * BdF;
         botmp = t - tpos;
         DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi,TwoPi)) * envData[5][ENV] * BL;
       }
-      if(t>=envData[5][MAX]) BON=0;
+      if (t >= envData[5][MAX]) { BON=0; }
     }
 
-    if(BON2==1) //noise band 2
+    if (BON2 == 1) //noise band 2
     {
-      for(t=tpos; t<=tplus; t++)
+      for (t = tpos; t <= tplus; t++)
       {
-        if(t < envData[6][NEXTT])
+        if (t < envData[6][NEXTT])
           envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
-        else UpdateEnv(6, t);
-        if((t % BFStep2) == 0) BdF2 = randmax * (float)rand() - 0.5f;
+        else { UpdateEnv(6, t); }
+        if ((t % BFStep2) == 0) { BdF2 = randmax * (float)rand() - 0.5f; }
         BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
         botmp = t - tpos;
         DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2,TwoPi)) * envData[6][ENV] * BL2;
       }
-      if(t>=envData[6][MAX]) BON2=0;
+      if (t >= envData[6][MAX]) { BON2 = 0; }
     }
 
 
-    for (t=tpos; t<=tplus; t++)
+    for (t = tpos; t <= tplus; t++)
     {
-      if(OON==1) //overtones
+      if (OON == 1) //overtones
       {
-        if(t<envData[3][NEXTT])
+        if (t < envData[3][NEXTT])
+		{
           envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+		}
         else
         {
-          if(t>=envData[3][MAX]) //wait for OT2
+          if (t >= envData[3][MAX]) //wait for OT2
           {
             envData[3][ENV] = 0;
             envData[3][dENV] = 0;
@@ -605,23 +624,23 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
           else UpdateEnv(3, t);
         }
         //
-        if(t<envData[4][NEXTT])
+        if (t < envData[4][NEXTT])
           envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
         else
         {
-          if(t>=envData[4][MAX]) //wait for OT1
+          if (t >= envData[4][MAX]) //wait for OT1
           {
             envData[4][ENV] = 0;
             envData[4][dENV] = 0;
             envData[4][NEXTT] = 999999;
           }
-          else UpdateEnv(4, t);
+          else { UpdateEnv(4, t); }
         }
         //
         TphiStart = TphiStart + phi[t - tpos];
-        if(OF1Sync==1) Ophi1 = TphiStart * OF1; else Ophi1 = Ophi1 + OF1;
-        if(OF2Sync==1) Ophi2 = TphiStart * OF2; else Ophi2 = Ophi2 + OF2;
-        Ot=0.0f;
+        if (OF1Sync == 1) { Ophi1 = TphiStart * OF1; } else { Ophi1 = Ophi1 + OF1; }
+        if (OF2Sync == 1) { Ophi2 = TphiStart * OF2; } else { Ophi2 = Ophi2 + OF2; }
+        Ot = 0.0f;
         switch (OMode)
         {
           case 0: //add
@@ -659,14 +678,14 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
         }
       }
 
-      if(MainFilter==1) //filter overtones
+      if (MainFilter == 1) //filter overtones
       {
-        if(t<envData[7][NEXTT])
+        if (t < envData[7][NEXTT])
           envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
         else UpdateEnv(7, t);
 
         MFtmp = envData[7][ENV];
-        if(MFtmp >0.2f)
+        if (MFtmp >0.2f)
           MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
         else
           MFfb = 0.999f - 0.7824f * MFtmp;
@@ -677,17 +696,23 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
 
         DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
       }
-      else if(MainFilter==2) //filter all
+      else if (MainFilter == 2) //filter all
       {
-        if(t<envData[7][NEXTT])
+        if (t < envData[7][NEXTT])
+		{
           envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-        else UpdateEnv(7, t);
+		}
+        else { UpdateEnv(7, t); }
 
         MFtmp = envData[7][ENV];
-        if(MFtmp >0.2f)
+        if (MFtmp > 0.2f)
+		{
           MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+		}
         else
+		{
           MFfb = 0.999f - 0.7824f * MFtmp;
+		}
 
         MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
         MFin = MFfb * (MFin - MFtmp) + MFtmp;
@@ -696,36 +721,48 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sa
         DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
       }
       // PG: Ot is uninitialized
-      else DF[t - tpos] = DF[t - tpos] + Ot; //no filter
+      else { DF[t - tpos] = DF[t - tpos] + Ot; } //no filter
     }
 
-    if(DiON==1) //bit resolution
+    if (DiON == 1) //bit resolution
     {
-      for(j=0; j<1200; j++)
+      for (j = 0; j < 1200; j++)
+	  {
         DF[j] = DGain * (int)(DF[j] / DAtten);
+	  }
 
-      for(j=0; j<1200; j+=DStep) //downsampling
+      for (j = 0; j < 1200; j += DStep) //downsampling
       {
         DownAve = 0;
         DownStart = j;
         DownEnd = j + DStep - 1;
-        for(jj = DownStart; jj<=DownEnd; jj++)
+        for (jj = DownStart; jj <= DownEnd; jj++)
+		{
           DownAve = DownAve + DF[jj];
+		}
         DownAve = DownAve / DStep;
-        for(jj = DownStart; jj<=DownEnd; jj++)
+        for (jj = DownStart; jj <= DownEnd; jj++)
+		{
           DF[jj] = DownAve;
+		}
       }
     }
-    else for(j=0; j<1200; j++) DF[j] *= DGain;
+    else for (j = 0; j < 1200; j++) { DF[j] *= DGain; }
 
-    for(j = 0; j<1200; j++) //clipping + output
+    for (j = 0; j < 1200; j++) //clipping + output
     {
-      if(DF[j] > clippoint)
+      if (DF[j] > clippoint)
+	  {
         wave[wavewords++] = clippoint;
-      else if(DF[j] < -clippoint)
+	  }
+      else if (DF[j] < -clippoint)
+	  {
           wave[wavewords++] = -clippoint;
+	  }
       else
+	  {
           wave[wavewords++] = (short)DF[j];
+	  }
 
       for (int c = 1; c < channels; c++)  {
         wave[wavewords] = wave[wavewords-1];

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -23,49 +23,42 @@
  *
  */
 
-
 #include "DrumSynth.h"
 
-#include <sstream>
-#include <cstring>
-
-#include <cmath>     //sin(), exp(), etc.
-
 #include <QFile>
-
+#include <cmath>
+#include <cstring>
+#include <sstream>
 
 #ifdef _MSC_VER
-//not #if LMMS_BUILD_WIN32 because we have strncasecmp in mingw
+// not #if LMMS_BUILD_WIN32 because we have strncasecmp in mingw
 #define strcasecmp _stricmp
 #endif // _MSC_VER
 
-namespace lmms
-{
-
+namespace lmms {
 
 using namespace std;
 
 // const int     Fs    =  44100;
-const float   TwoPi =  6.2831853f;
-const int     MAX   =  0;
-const int     ENV   =  1;
-const int     PNT   =  2;
-const int     dENV  =  3;
-const int     NEXTT =  4;
+const float TwoPi = 6.2831853f;
+const int MAX = 0;
+const int ENV = 1;
+const int PNT = 2;
+const int dENV = 3;
+const int NEXTT = 4;
 
 // Bah, I'll move these into the class once I sepearate DrumsynthFile from DrumSynth
 // llama
-float envpts[8][3][32];    //envelope/time-level/point
-float envData[8][6];       //envelope running status
-int   chkOn[8], sliLev[8]; //section on/off and level
-float timestretch;         //overall time scaling
+float envpts[8][3][32];	 // envelope/time-level/point
+float envData[8][6];	 // envelope running status
+int chkOn[8], sliLev[8]; // section on/off and level
+float timestretch;		 // overall time scaling
 short DD[1200], clippoint;
 float DF[1200];
 float phi[1200];
 
-long  wavewords, wavemode=0;
-float mem_t=1.0f, mem_o=1.0f, mem_n=1.0f, mem_b=1.0f, mem_tune=1.0f, mem_time=1.0f;
-
+long wavewords, wavemode = 0;
+float mem_t = 1.0f, mem_o = 1.0f, mem_n = 1.0f, mem_b = 1.0f, mem_tune = 1.0f, mem_time = 1.0f;
 
 int DrumSynth::LongestEnv()
 {
@@ -76,75 +69,81 @@ int DrumSynth::LongestEnv()
 		long eon = e - 1;
 		if (eon > 2) { eon = eon - 1; }
 		long p = 0;
-		while (envpts[e][0][p + 1] >= 0.f) { p++; }
+		while (envpts[e][0][p + 1] >= 0.f)
+		{
+			p++;
+		}
 		envData[e][MAX] = envpts[e][0][p] * timestretch;
 		if (chkOn[eon] == 1 && envData[e][MAX] > l) { l = envData[e][MAX]; }
-  }
-  //l *= timestretch;
+	}
+	// l *= timestretch;
 
-  return 2400 + (1200 * (int)(l / 1200));
+	return 2400 + (1200 * (int)(l / 1200));
 }
-
 
 float DrumSynth::LoudestEnv()
 {
-  float loudest=0.f;
-  int i=0;
+	float loudest = 0.f;
+	int i = 0;
 
-  while (i<5) //2
-  {
-    if(chkOn[i]==1) if(sliLev[i]>loudest) loudest=(float)sliLev[i];
-    i++;
-  }
-  return (loudest * loudest);
+	while (i < 5) // 2
+	{
+		if (chkOn[i] == 1)
+			if (sliLev[i] > loudest) loudest = (float)sliLev[i];
+		i++;
+	}
+	return (loudest * loudest);
 }
-
 
 void DrumSynth::UpdateEnv(int e, long t)
 {
 	// 0.2's added
 	envData[e][NEXTT] = envpts[e][0][static_cast<long>(envData[e][PNT] + 1.f)] * timestretch; // get next point
-	if (envData[e][NEXTT] < 0) { envData[e][NEXTT] = 442000 * timestretch; } // if end point, hold
-	envData[e][ENV] = envpts[e][1][static_cast<long>(envData[e][PNT] + 0.f)] * 0.01f; // this level
-	float endEnv = envpts[e][1][static_cast<long>(envData[e][PNT] + 1.f)] * 0.01f; // next level
+	if (envData[e][NEXTT] < 0) { envData[e][NEXTT] = 442000 * timestretch; }				  // if end point, hold
+	envData[e][ENV] = envpts[e][1][static_cast<long>(envData[e][PNT] + 0.f)] * 0.01f;		  // this level
+	float endEnv = envpts[e][1][static_cast<long>(envData[e][PNT] + 1.f)] * 0.01f;			  // next level
 	float dT = envData[e][NEXTT] - static_cast<float>(t);
 	if (dT < 1.0) { dT = 1.0; }
 	envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
 	envData[e][PNT] = envData[e][PNT] + 1.0f;
 }
 
-
-void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
+void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 {
-  char en[256], s[8];
-  int i=0, o=0, ep=0;
-  GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
+	char en[256], s[8];
+	int i = 0, o = 0, ep = 0;
+	GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
 
-  //be safe!
-  en[255]=0;
-  s[0]=0;
+	// be safe!
+	en[255] = 0;
+	s[0] = 0;
 
-  while(en[i]!=0)
-  {
-    if(en[i] == ',')
-    {
-      if(sscanf(s, "%f", &envpts[env][0][ep])==0) envpts[env][0][ep] = 0.f;
-      o=0;
-    }
-    else if(en[i] == ' ')
-    {
-      if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
-      o=0; ep++;
-    }
-    else { s[o]=en[i]; o++; s[o]=0; }
-    i++;
-  }
-  if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
-  envpts[env][0][ep + 1] = -1;
+	while (en[i] != 0)
+	{
+		if (en[i] == ',')
+		{
+			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) envpts[env][0][ep] = 0.f;
+			o = 0;
+		}
+		else if (en[i] == ' ')
+		{
+			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
+			o = 0;
+			ep++;
+		}
+		else
+		{
+			s[o] = en[i];
+			o++;
+			s[o] = 0;
+		}
+		i++;
+	}
+	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
+	envpts[env][0][ep + 1] = -1;
 
-  envData[env][MAX] = envpts[env][0][ep];
+	envData[env][MAX] = envpts[env][0][ep];
 }
-
 
 float DrumSynth::waveform(float ph, int form)
 {
@@ -159,7 +158,10 @@ float DrumSynth::waveform(float ph, int form)
 		w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
 		break; // sine^2
 	case 2:
-		while (ph < TwoPi) { ph += TwoPi; }
+		while (ph < TwoPi)
+		{
+			ph += TwoPi;
+		}
 		w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
 		if (w > 1.f) { w = 2.f - w; }
 		break;
@@ -175,8 +177,8 @@ float DrumSynth::waveform(float ph, int form)
 	return w;
 }
 
-
-int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file)
+int DrumSynth::GetPrivateProfileString(
+	const char* sec, const char* key, const char* def, char* buffer, int size, QString file)
 {
 	stringstream is;
 	bool inSection = false;
@@ -184,572 +186,616 @@ int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const c
 
 	char* line = static_cast<char*>(malloc(200));
 
-    // Use QFile to handle unicode file name on Windows
-    // Previously we used ifstream directly
-    QFile f(file);
-    f.open(QIODevice::ReadOnly);
-    QByteArray dat = f.readAll().constData();
-    is.str(string(dat.constData(), dat.size()));
+	// Use QFile to handle unicode file name on Windows
+	// Previously we used ifstream directly
+	QFile f(file);
+	f.open(QIODevice::ReadOnly);
+	QByteArray dat = f.readAll().constData();
+	is.str(string(dat.constData(), dat.size()));
 
-    while (is.good()) {
-        if (!inSection) {
-            is.ignore( numeric_limits<streamsize>::max(), '[');
+	while (is.good())
+	{
+		if (!inSection)
+		{
+			is.ignore(numeric_limits<streamsize>::max(), '[');
 
-            if (!is.eof()) {
-                is.getline(line, 200, ']');
-                if (strcasecmp(line, sec)==0) {
-                    inSection = true;
-                }
-            }
-        }
-        else if (!is.eof()) {
-            is.getline(line, 200);
-            if (line[0] == '[')
-                break;
+			if (!is.eof())
+			{
+				is.getline(line, 200, ']');
+				if (strcasecmp(line, sec) == 0) { inSection = true; }
+			}
+		}
+		else if (!is.eof())
+		{
+			is.getline(line, 200);
+			if (line[0] == '[') break;
 
-            char* k = strtok(line, " \t=");
-            char* b = strtok(nullptr, "\n\r\0");
+			char* k = strtok(line, " \t=");
+			char* b = strtok(nullptr, "\n\r\0");
 
-            if (k != 0 && strcasecmp(k, key)==0) {
-                if (b==0) {
-                    len = 0;
-                    buffer[0] = 0;
-                }
-                else {
-                    k = (char *)(b + strlen(b)-1);
-                    while ( (k>=b) && (*k==' ' || *k=='\t') )
-                        --k;
-                    *(k+1) = '\0';
+			if (k != 0 && strcasecmp(k, key) == 0)
+			{
+				if (b == 0)
+				{
+					len = 0;
+					buffer[0] = 0;
+				}
+				else
+				{
+					k = (char*)(b + strlen(b) - 1);
+					while ((k >= b) && (*k == ' ' || *k == '\t'))
+						--k;
+					*(k + 1) = '\0';
 
-                    len = strlen(b);
-                    if (len > size-1) len = size-1;
-                    strncpy(buffer, b, len+1);
-                }
-                break;
-            }
-        }
-    }
+					len = strlen(b);
+					if (len > size - 1) len = size - 1;
+					strncpy(buffer, b, len + 1);
+				}
+				break;
+			}
+		}
+	}
 
-    if (len == 0) {
-        len = strlen(def);
-        strncpy(buffer, def, size);
-    }
+	if (len == 0)
+	{
+		len = strlen(def);
+		strncpy(buffer, def, size);
+	}
 
-    free(line);
+	free(line);
 
-    return len;
+	return len;
 }
 
-int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, QString file)
+int DrumSynth::GetPrivateProfileInt(const char* sec, const char* key, int def, QString file)
 {
-  char tmp[16];
-  int i=0;
+	char tmp[16];
+	int i = 0;
 
-  GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-  sscanf(tmp, "%d", &i); if(tmp[0]==0) i=def;
+	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+	sscanf(tmp, "%d", &i);
+	if (tmp[0] == 0) i = def;
 
-  return i;
+	return i;
 }
 
-float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file)
+float DrumSynth::GetPrivateProfileFloat(const char* sec, const char* key, float def, QString file)
 {
-    char tmp[16];
-    float f=0.f;
+	char tmp[16];
+	float f = 0.f;
 
-    GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-    sscanf(tmp, "%f", &f); if(tmp[0]==0) f=def;
+	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+	sscanf(tmp, "%f", &f);
+	if (tmp[0] == 0) f = def;
 
-    return f;
+	return f;
 }
-
 
 //  Constantly opening and scanning each file for the setting really sucks.
 //  But, the original did this, and we know it works.  Will store file into
 //  an associative array or something once we have a datastructure to load in to.
 //  llama
 
-int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
+int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sample_rate_t Fs)
 {
-  //input file
-  char sec[32];
-  char ver[32];
-  char comment[256];
-  int commentLen=0;
+	// input file
+	char sec[32];
+	char ver[32];
+	char comment[256];
+	int commentLen = 0;
 
-  //generation
-  long  Length, tpos=0, tplus, totmp, t, i, j;
-  float x[3] = {0.f, 0.f, 0.f};
-  float MasterTune;
-  constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
-  constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
-  int   MainFilter, HighPass;
+	// generation
+	long Length, tpos = 0, tplus, totmp, t, i, j;
+	float x[3] = {0.f, 0.f, 0.f};
+	float MasterTune;
+	constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
+	constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
+	int MainFilter, HighPass;
 
-  long  NON, NT, TON, DiON, TDroop=0, DStep;
-  float a, b=0.f, c=0.f, d=0.f, g, TT=0.f, TL, NL, F1, F2;
-  float TphiStart=0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
+	long NON, NT, TON, DiON, TDroop = 0, DStep;
+	float a, b = 0.f, c = 0.f, d = 0.f, g, TT = 0.f, TL, NL, F1, F2;
+	float TphiStart = 0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
 
-  long  BON, BON2, BFStep, BFStep2, botmp;
-  float BdF=0.f, BdF2=0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
+	long BON, BON2, BFStep, BFStep2, botmp;
+	float BdF = 0.f, BdF2 = 0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
 
-  long  OON, OF1Sync=0, OF2Sync=0, OMode, OW1, OW2;
-  float Ophi1, Ophi2, OF1, OF2, OL, Ot=0 /*PG: init */, OBal1, OBal2, ODrive;
-  float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
-  float Oc0=0.0f, Oc1=0.0f, Oc2=0.0f;
+	long OON, OF1Sync = 0, OF2Sync = 0, OMode, OW1, OW2;
+	float Ophi1, Ophi2, OF1, OF2, OL, Ot = 0 /*PG: init */, OBal1, OBal2, ODrive;
+	float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2]; // overtone cymbal mode
+	float Oc0 = 0.0f, Oc1 = 0.0f, Oc2 = 0.0f;
 
-  float MFfb, MFtmp, MFres, MFin=0.f, MFout=0.f;
-  float DownAve;
-  long  DownStart, DownEnd, jj;
+	float MFfb, MFtmp, MFres, MFin = 0.f, MFout = 0.f;
+	float DownAve;
+	long DownStart, DownEnd, jj;
 
+	if (wavemode == 0) // semi-real-time adjustments if working in memory!!
+	{
+		mem_t = 1.0f;
+		mem_o = 1.0f;
+		mem_n = 1.0f;
+		mem_b = 1.0f;
+		mem_tune = 0.0f;
+		mem_time = 1.0f;
+	}
 
-  if(wavemode==0) //semi-real-time adjustments if working in memory!!
-  {
-    mem_t = 1.0f;
-    mem_o = 1.0f;
-    mem_n = 1.0f;
-    mem_b = 1.0f;
-    mem_tune = 0.0f;
-    mem_time = 1.0f;
-  }
+	// try to read version from input file
+	strcpy(sec, "General");
+	GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
+	ver[9] = 0;
+	if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } // input fail
+	if (ver[11] != '1' && ver[11] != '2') { return 0; }	 // version fail
 
-  //try to read version from input file
-  strcpy(sec, "General");
-  GetPrivateProfileString(sec,"Version","",ver,sizeof(ver),dsfile);
-  ver[9]=0;
-  if(strcasecmp(ver, "DrumSynth") != 0) {return 0;} //input fail
-  if(ver[11] != '1' && ver[11] != '2') {return 0;} //version fail
+	// read master parameters
+	GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
+	while ((comment[commentLen] != 0) && (commentLen < 254))
+		commentLen++;
+	if (commentLen == 0)
+	{
+		comment[0] = 32;
+		comment[1] = 0;
+		commentLen = 1;
+	}
+	comment[commentLen + 1] = 0;
+	commentLen++;
+	if ((commentLen % 2) == 1) commentLen++;
 
+	timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
+	if (timestretch < 0.2f) timestretch = 0.2f;
+	if (timestretch > 10.f) timestretch = 10.f;
+	// the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
+	timestretch *= Fs / 44100.f;
 
-  //read master parameters
-  GetPrivateProfileString(sec,"Comment","",comment,sizeof(comment),dsfile);
-  while((comment[commentLen]!=0) && (commentLen<254)) commentLen++;
-  if(commentLen==0) { comment[0]=32; comment[1]=0; commentLen=1;}
-  comment[commentLen+1]=0; commentLen++;
-  if((commentLen % 2)==1) commentLen++;
+	DGain = 1.0f; // leave this here!
+	DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec, "Level", 0, dsfile)));
 
-  timestretch = .01f * mem_time * GetPrivateProfileFloat(sec,"Stretch",100.0,dsfile);
-  if(timestretch<0.2f) timestretch=0.2f;
-  if(timestretch>10.f) timestretch=10.f;
-  // the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
-  timestretch *= Fs / 44100.f;
+	MasterTune = GetPrivateProfileFloat(sec, "Tuning", 0.0, dsfile);
+	MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
+	MainFilter = 2 * GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	MFres = 0.0101f * GetPrivateProfileFloat(sec, "Resonance", 0.0, dsfile);
+	MFres = static_cast<float>(std::pow(MFres, 0.5f));
 
-  DGain = 1.0f; //leave this here!
-  DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec,"Level",0,dsfile)));
+	HighPass = GetPrivateProfileInt(sec, "HighPass", 0, dsfile);
+	GetEnv(7, sec, "FilterEnv", dsfile);
 
-  MasterTune = GetPrivateProfileFloat(sec,"Tuning",0.0,dsfile);
-  MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
-  MainFilter = 2 * GetPrivateProfileInt(sec,"Filter",0,dsfile);
-  MFres = 0.0101f * GetPrivateProfileFloat(sec,"Resonance",0.0,dsfile);
-  MFres = static_cast<float>(std::pow(MFres, 0.5f));
+	// read noise parameters
+	strcpy(sec, "Noise");
+	chkOn[1] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	sliLev[1] = GetPrivateProfileInt(sec, "Level", 0, dsfile);
+	NT = GetPrivateProfileInt(sec, "Slope", 0, dsfile);
+	GetEnv(2, sec, "Envelope", dsfile);
+	NON = chkOn[1];
+	NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
+	if (NT < 0)
+	{
+		a = 1.f + (NT / 105.f);
+		d = -NT / 105.f;
+		g = (1.f + 0.0005f * NT * NT) * NL;
+	}
+	else
+	{
+		a = 1.f;
+		b = -NT / 50.f;
+		c = (float)fabs((float)NT) / 100.f;
+		g = NL;
+	}
 
-  HighPass = GetPrivateProfileInt(sec,"HighPass",0,dsfile);
-  GetEnv(7, sec, "FilterEnv", dsfile);
+	// if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
+	// srand(1); //fixed random sequence
 
+	// read tone parameters
+	strcpy(sec, "Tone");
+	chkOn[0] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	TON = chkOn[0];
+	sliLev[0] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
+	GetEnv(1, sec, "Envelope", dsfile);
+	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	if (fabs(F1) < 0.001f) F1 = 0.001f; // to prevent overtone ratio div0
+	F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	TDroopRate = GetPrivateProfileFloat(sec, "Droop", 0.f, dsfile);
+	if (TDroopRate > 0.f)
+	{
+		TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
+		TDroopRate = TDroopRate * -4.f / envData[1][MAX];
+		TDroop = 1;
+		F2 = F1 + ((F2 - F1) / (1.f - (float)exp(TDroopRate * envData[1][MAX])));
+		ddF = F1 - F2;
+	}
+	else
+		ddF = F2 - F1;
 
-  //read noise parameters
-  strcpy(sec, "Noise");
-  chkOn[1] = GetPrivateProfileInt(sec,"On",0,dsfile);
-  sliLev[1] = GetPrivateProfileInt(sec,"Level",0,dsfile);
-  NT =  GetPrivateProfileInt(sec,"Slope",0,dsfile);
-  GetEnv(2, sec, "Envelope", dsfile);
-  NON = chkOn[1];
-  NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
-  if(NT<0)
-  { a = 1.f + (NT / 105.f); d = -NT / 105.f;
-    g = (1.f + 0.0005f * NT * NT) * NL; }
-  else
-  { a = 1.f; b = -NT / 50.f; c = (float)fabs((float)NT) / 100.f; g = NL; }
+	Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; // degrees>radians
 
-  //if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
-    //srand(1); //fixed random sequence
+	// read overtone parameters
+	strcpy(sec, "Overtones");
+	chkOn[2] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	OON = chkOn[2];
+	sliLev[2] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
+	GetEnv(3, sec, "Envelope1", dsfile);
+	GetEnv(4, sec, "Envelope2", dsfile);
+	OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
+	OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
+	OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
+	OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
+	ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
+	OBal2 *= 0.01f;
+	OBal1 = 1.f - OBal2;
+	Ophi1 = Tphi;
+	Ophi2 = Tphi;
+	if (MainFilter == 0) MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	if ((GetPrivateProfileInt(sec, "Track1", 0, dsfile) == 1) && (TON == 1))
+	{
+		OF1Sync = 1;
+		OF1 = OF1 / F1;
+	}
+	if ((GetPrivateProfileInt(sec, "Track2", 0, dsfile) == 1) && (TON == 1))
+	{
+		OF2Sync = 1;
+		OF2 = OF2 / F1;
+	}
 
-   //read tone parameters
-  strcpy(sec, "Tone");
-  chkOn[0] = GetPrivateProfileInt(sec,"On",0,dsfile); TON = chkOn[0];
-  sliLev[0] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
-  GetEnv(1, sec, "Envelope", dsfile);
-  F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
-  if(fabs(F1)<0.001f) F1=0.001f; //to prevent overtone ratio div0
-  F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
-  TDroopRate = GetPrivateProfileFloat(sec,"Droop",0.f,dsfile);
-  if(TDroopRate>0.f)
-  {
-    TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
-    TDroopRate = TDroopRate * -4.f / envData[1][MAX];
-    TDroop = 1;
-    F2 = F1+((F2-F1)/(1.f-(float)exp(TDroopRate * envData[1][MAX])));
-    ddF = F1 - F2;
-  }
-  else ddF = F2-F1;
+	OcA = 0.28f + OBal1 * OBal1; // overtone cymbal mode
+	OcQ = OcA * OcA;
+	OcF = (1.8f - 0.7f * OcQ) * 0.92f; // multiply by env 2
+	OcA *= 1.0f + 4.0f * OBal1;		   // level is a compromise!
+	Ocf1 = TwoPi / OF1;
+	Ocf2 = TwoPi / OF2;
+	for (i = 0; i < 6; i++)
+		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
 
-  Tphi = GetPrivateProfileFloat(sec,"Phase",90.f,dsfile) / 57.29578f; //degrees>radians
+	// read noise band parameters
+	strcpy(sec, "NoiseBand");
+	chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	BON = chkOn[3];
+	sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
+	BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi = TwoPi / 8.f;
+	GetEnv(5, sec, "Envelope", dsfile);
+	BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
+	BQ = (float)BFStep;
+	BQ = BQ * BQ / (10000.f - 6600.f * ((float)sqrt(BF) - 0.19f));
+	BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
-  //read overtone parameters
-  strcpy(sec, "Overtones");
-  chkOn[2] = GetPrivateProfileInt(sec,"On",0,dsfile); OON = chkOn[2];
-  sliLev[2] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
-  GetEnv(3, sec, "Envelope1", dsfile);
-  GetEnv(4, sec, "Envelope2", dsfile);
-  OMode = GetPrivateProfileInt(sec,"Method",2,dsfile);
-  OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
-  OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
-  OW1 = GetPrivateProfileInt(sec,"Wave1",0,dsfile);
-  OW2 = GetPrivateProfileInt(sec,"Wave2",0,dsfile);
-  OBal2 = (float)GetPrivateProfileInt(sec,"Param",50,dsfile);
-  ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
-  OBal2 *= 0.01f;
-  OBal1 = 1.f - OBal2;
-  Ophi1 = Tphi;
-  Ophi2 = Tphi;
-  if(MainFilter==0)
-    MainFilter = GetPrivateProfileInt(sec,"Filter",0,dsfile);
-  if((GetPrivateProfileInt(sec,"Track1",0,dsfile)==1) && (TON==1))
-  { OF1Sync = 1;  OF1 = OF1 / F1; }
-  if((GetPrivateProfileInt(sec,"Track2",0,dsfile)==1) && (TON==1))
-  { OF2Sync = 1;  OF2 = OF2 / F1; }
+	strcpy(sec, "NoiseBand2");
+	chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	BON2 = chkOn[4];
+	sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
+	BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi2 = TwoPi / 8.f;
+	GetEnv(6, sec, "Envelope", dsfile);
+	BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
+	BQ2 = (float)BFStep2;
+	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f * ((float)sqrt(BF2) - 0.19f));
+	BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
-  OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
-  OcQ = OcA * OcA;
-  OcF = (1.8f - 0.7f * OcQ) * 0.92f; //multiply by env 2
-  OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
-  Ocf1 = TwoPi / OF1;
-  Ocf2 = TwoPi / OF2;
-  for(i=0; i<6; i++) Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
+	// read distortion parameters
+	strcpy(sec, "Distortion");
+	chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	DiON = chkOn[5];
+	DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
+	if (DStep == 7) DStep = 20;
+	if (DStep == 6) DStep = 10;
+	if (DStep == 5) DStep = 8;
 
-  //read noise band parameters
-  strcpy(sec, "NoiseBand");
-  chkOn[3] = GetPrivateProfileInt(sec,"On",0,dsfile); BON = chkOn[3];
-  sliLev[3] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
-  BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
-  BPhi = TwoPi / 8.f;
-  GetEnv(5, sec, "Envelope", dsfile);
-  BFStep = GetPrivateProfileInt(sec,"dF",50,dsfile);
-  BQ = (float)BFStep;
-  BQ = BQ * BQ / (10000.f-6600.f*((float)sqrt(BF)-0.19f));
-  BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
+	clippoint = 32700;
+	DAtten = 1.0f;
 
-  strcpy(sec, "NoiseBand2");
-  chkOn[4] = GetPrivateProfileInt(sec,"On",0,dsfile); BON2 = chkOn[4];
-  sliLev[4] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
-  BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
-  BPhi2 = TwoPi / 8.f;
-  GetEnv(6, sec, "Envelope", dsfile);
-  BFStep2 = GetPrivateProfileInt(sec,"dF",50,dsfile);
-  BQ2 = (float)BFStep2;
-  BQ2 = BQ2 * BQ2 / (10000.f-6600.f*((float)sqrt(BF2)-0.19f));
-  BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
+	if (DiON == 1)
+	{
+		DAtten = DGain * (short)LoudestEnv();
+		if (DAtten > 32700) clippoint = 32700;
+		else
+			clippoint = (short)DAtten;
+		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
+		DGain = DAtten * DGain
+			* static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
+	}
 
-  //read distortion parameters
-  strcpy(sec, "Distortion");
-  chkOn[5] = GetPrivateProfileInt(sec,"On",0,dsfile); DiON = chkOn[5];
-  DStep = 1 + GetPrivateProfileInt(sec,"Rate",0,dsfile);
-  if(DStep==7) DStep=20;
-  if(DStep==6) DStep=10;
-  if(DStep==5) DStep=8;
+	// prepare envelopes
+	for (i = 1; i < 8; i++)
+	{
+		envData[i][NEXTT] = 0;
+		envData[i][PNT] = 0;
+	}
+	Length = LongestEnv();
 
-  clippoint = 32700;
-  DAtten = 1.0f;
+	// allocate the buffer
+	// if(wave!=NULL) free(wave);
+	// wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
+	wave = new int16_t[channels * Length]; // wave memory buffer
+	if (wave == nullptr) { return 0; }
+	wavewords = 0;
 
-  if(DiON==1)
-  {
-    DAtten = DGain * (short)LoudestEnv();
-    if(DAtten>32700) clippoint=32700; else clippoint=(short)DAtten;
-    DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec,"Bits",0,dsfile)));
-    DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec,"Clipping",0,dsfile)));
-  }
+	/*
+	if(wavemode==0)
+	{
+	  //open output file
+	  fp = fopen(wavfile, "wb");
+	  if(!fp) {return 3;} //output fail
 
-  //prepare envelopes
-  for (i=1;i<8;i++) { envData[i][NEXTT]=0; envData[i][PNT]=0; }
-  Length = LongestEnv();
+	   //set up INFO chunk
+	  WI.list = 0x5453494C;
+	  WI.listLength = 36 + commentLen;
+	  WI.info = 0x4F464E49;
+	  WI.isft = 0x54465349;
+	  WI.isftLength = 16;
+	  strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
+	  WI.icmt = 0x544D4349;
+	  WI.icmtLength = commentLen;
 
-  //allocate the buffer
-  //if(wave!=NULL) free(wave);
-  //wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
-  wave = new int16_t[channels * Length]; //wave memory buffer
-  if(wave==nullptr) {return 0;}
-  wavewords = 0;
+	  //write WAV header
+	  WH.riff = 0x46464952;
+	  WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
+	  WH.wave = 0x45564157;
+	  WH.fmt = 0x20746D66;
+	  WH.waveLength = 16;
+	  WH.wFormatTag = WAVE_FORMAT_PCM;
+	  WH.nChannels = 1;
+	  WH.nSamplesPerSec = Fs;
+	  WH.nAvgBytesPerSec = 2 * Fs;
+	  WH.nBlockAlign = 2;
+	  WH.wBitsPerSample = 16;
+	  WH.data = 0x61746164;
+	  WH.dataLength = 2 * Length;
+	  fwrite(&WH, 1, 44, fp);
+	}
+	*/
 
-  /*
-  if(wavemode==0)
-  {
-    //open output file
-    fp = fopen(wavfile, "wb");
-    if(!fp) {return 3;} //output fail
+	// generate
+	tpos = 0;
+	while (tpos < Length)
+	{
+		tplus = tpos + 1199;
 
-     //set up INFO chunk
-    WI.list = 0x5453494C;
-    WI.listLength = 36 + commentLen;
-    WI.info = 0x4F464E49;
-    WI.isft = 0x54465349;
-    WI.isftLength = 16;
-    strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
-    WI.icmt = 0x544D4349;
-    WI.icmtLength = commentLen;
+		if (NON == 1) // noise
+		{
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
+				else
+					UpdateEnv(2, t);
+				x[2] = x[1];
+				x[1] = x[0];
+				x[0] = (randmax2 * (float)rand()) - 1.f;
+				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
+				DF[t - tpos] = TT * g * envData[2][ENV];
+			}
+			if (t >= envData[2][MAX]) NON = 0;
+		}
+		else
+		{
+			for (j = 0; j < 1200; j++)
+				DF[j] = 0.f;
+		}
 
-    //write WAV header
-    WH.riff = 0x46464952;
-    WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
-    WH.wave = 0x45564157;
-    WH.fmt = 0x20746D66;
-    WH.waveLength = 16;
-    WH.wFormatTag = WAVE_FORMAT_PCM;
-    WH.nChannels = 1;
-    WH.nSamplesPerSec = Fs;
-    WH.nAvgBytesPerSec = 2 * Fs;
-    WH.nBlockAlign = 2;
-    WH.wBitsPerSample = 16;
-    WH.data = 0x61746164;
-    WH.dataLength = 2 * Length;
-    fwrite(&WH, 1, 44, fp);
-  }
-  */
+		if (TON == 1) // tone
+		{
+			TphiStart = Tphi;
+			if (TDroop == 1)
+			{
+				for (t = tpos; t <= tplus; t++)
+					phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+			}
+			else
+			{
+				for (t = tpos; t <= tplus; t++)
+					phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
+			}
+			for (t = tpos; t <= tplus; t++)
+			{
+				totmp = t - tpos;
+				if (t < envData[1][NEXTT]) envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
+				else
+					UpdateEnv(1, t);
+				Tphi = Tphi + phi[totmp];
+				DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi, TwoPi)); // overflow?
+			}
+			if (t >= envData[1][MAX]) TON = 0;
+		}
+		else
+			for (j = 0; j < 1200; j++)
+				phi[j] = F2; // for overtone sync
 
-  //generate
-  tpos = 0;
-  while(tpos<Length)
-  {
-    tplus = tpos + 1199;
+		if (BON == 1) // noise band 1
+		{
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[5][NEXTT]) envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
+				else
+					UpdateEnv(5, t);
+				if ((t % BFStep) == 0) BdF = randmax * (float)rand() - 0.5f;
+				BPhi = BPhi + BF + BQ * BdF;
+				botmp = t - tpos;
+				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi, TwoPi)) * envData[5][ENV] * BL;
+			}
+			if (t >= envData[5][MAX]) BON = 0;
+		}
 
-    if(NON==1) //noise
-    {
-      for(t=tpos; t<=tplus; t++)
-      {
-        if(t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
-        else UpdateEnv(2, t);
-        x[2] = x[1];
-        x[1] = x[0];
-        x[0] = (randmax2 * (float)rand()) - 1.f;
-        TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
-        DF[t - tpos] = TT * g * envData[2][ENV];
-      }
-      if(t>=envData[2][MAX]) NON=0;
-    }
-    else {
-        for(j=0; j<1200; j++) DF[j]=0.f;
-    }
+		if (BON2 == 1) // noise band 2
+		{
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[6][NEXTT]) envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
+				else
+					UpdateEnv(6, t);
+				if ((t % BFStep2) == 0) BdF2 = randmax * (float)rand() - 0.5f;
+				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
+				botmp = t - tpos;
+				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2, TwoPi)) * envData[6][ENV] * BL2;
+			}
+			if (t >= envData[6][MAX]) BON2 = 0;
+		}
 
-    if(TON==1) //tone
-    {
-      TphiStart = Tphi;
-      if(TDroop==1)
-      {
-        for(t=tpos; t<=tplus; t++)
-          phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
-      }
-      else
-      {
-        for(t=tpos; t<=tplus; t++)
-          phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
-      }
-      for(t=tpos; t<=tplus; t++)
-      {
-        totmp = t - tpos;
-        if(t < envData[1][NEXTT])
-          envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
-        else UpdateEnv(1, t);
-        Tphi = Tphi + phi[totmp];
-        DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi,TwoPi));//overflow?
-      }
-      if(t>=envData[1][MAX]) TON=0;
-    }
-    else for(j=0; j<1200; j++) phi[j]=F2; //for overtone sync
+		for (t = tpos; t <= tplus; t++)
+		{
+			if (OON == 1) // overtones
+			{
+				if (t < envData[3][NEXTT]) envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+				else
+				{
+					if (t >= envData[3][MAX]) // wait for OT2
+					{
+						envData[3][ENV] = 0;
+						envData[3][dENV] = 0;
+						envData[3][NEXTT] = 999999;
+					}
+					else
+						UpdateEnv(3, t);
+				}
+				//
+				if (t < envData[4][NEXTT]) envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
+				else
+				{
+					if (t >= envData[4][MAX]) // wait for OT1
+					{
+						envData[4][ENV] = 0;
+						envData[4][dENV] = 0;
+						envData[4][NEXTT] = 999999;
+					}
+					else
+						UpdateEnv(4, t);
+				}
+				//
+				TphiStart = TphiStart + phi[t - tpos];
+				if (OF1Sync == 1) Ophi1 = TphiStart * OF1;
+				else
+					Ophi1 = Ophi1 + OF1;
+				if (OF2Sync == 1) Ophi2 = TphiStart * OF2;
+				else
+					Ophi2 = Ophi2 + OF2;
+				Ot = 0.0f;
+				switch (OMode)
+				{
+				case 0: // add
+					Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
+					Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
+					break;
 
-    if(BON==1) //noise band 1
-    {
-      for(t=tpos; t<=tplus; t++)
-      {
-        if(t < envData[5][NEXTT])
-          envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
-        else UpdateEnv(5, t);
-        if((t % BFStep) == 0) BdF = randmax * (float)rand() - 0.5f;
-        BPhi = BPhi + BF + BQ * BdF;
-        botmp = t - tpos;
-        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi,TwoPi)) * envData[5][ENV] * BL;
-      }
-      if(t>=envData[5][MAX]) BON=0;
-    }
+				case 1: // FM
+					Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
+					Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
+					break;
 
-    if(BON2==1) //noise band 2
-    {
-      for(t=tpos; t<=tplus; t++)
-      {
-        if(t < envData[6][NEXTT])
-          envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
-        else UpdateEnv(6, t);
-        if((t % BFStep2) == 0) BdF2 = randmax * (float)rand() - 0.5f;
-        BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
-        botmp = t - tpos;
-        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2,TwoPi)) * envData[6][ENV] * BL2;
-      }
-      if(t>=envData[6][MAX]) BON2=0;
-    }
+				case 2: // RM
+					Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
+					Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
+					break;
 
+				case 3: // 808 Cymbal
+					for (j = 0; j < 6; j++)
+					{
+						Oc[j][0] += 1.0f;
 
-    for (t=tpos; t<=tplus; t++)
-    {
-      if(OON==1) //overtones
-      {
-        if(t<envData[3][NEXTT])
-          envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
-        else
-        {
-          if(t>=envData[3][MAX]) //wait for OT2
-          {
-            envData[3][ENV] = 0;
-            envData[3][dENV] = 0;
-            envData[3][NEXTT] = 999999;
-          }
-          else UpdateEnv(3, t);
-        }
-        //
-        if(t<envData[4][NEXTT])
-          envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
-        else
-        {
-          if(t>=envData[4][MAX]) //wait for OT1
-          {
-            envData[4][ENV] = 0;
-            envData[4][dENV] = 0;
-            envData[4][NEXTT] = 999999;
-          }
-          else UpdateEnv(4, t);
-        }
-        //
-        TphiStart = TphiStart + phi[t - tpos];
-        if(OF1Sync==1) Ophi1 = TphiStart * OF1; else Ophi1 = Ophi1 + OF1;
-        if(OF2Sync==1) Ophi2 = TphiStart * OF2; else Ophi2 = Ophi2 + OF2;
-        Ot=0.0f;
-        switch (OMode)
-        {
-          case 0: //add
-            Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
-            Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
-            break;
+						if (Oc[j][0] > Oc[j][1])
+						{
+							Oc[j][0] -= Oc[j][1];
+							Ot = OL * envData[3][ENV];
+						}
+					}
+					Ocf1 = envData[4][ENV] * OcF; // filter freq
+					Oc0 += Ocf1 * Oc1;
+					Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0); // bpf
+					Oc2 = Ot;
+					Ot = Oc1;
+					break;
+				}
+			}
 
-          case 1: //FM
-            Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
-            Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
-            break;
+			if (MainFilter == 1) // filter overtones
+			{
+				if (t < envData[7][NEXTT]) envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				else
+					UpdateEnv(7, t);
 
-          case 2: //RM
-            Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
-            Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
-            break;
+				MFtmp = envData[7][ENV];
+				if (MFtmp > 0.2f) MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				else
+					MFfb = 0.999f - 0.7824f * MFtmp;
 
-          case 3: //808 Cymbal
-            for(j=0; j<6; j++)
-            {
-              Oc[j][0] += 1.0f;
+				MFtmp = Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
+				MFin = MFfb * (MFin - MFtmp) + MFtmp;
+				MFout = MFfb * (MFout - MFin) + MFin;
 
-              if(Oc[j][0]>Oc[j][1])
-              {
-                Oc[j][0] -= Oc[j][1];
-                Ot = OL * envData[3][ENV];
-              }
-            }
-            Ocf1 = envData[4][ENV] * OcF;  //filter freq
-            Oc0 += Ocf1 * Oc1;
-            Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0);  //bpf
-            Oc2 = Ot;
-            Ot = Oc1;
-            break;
-        }
-      }
+				DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
+			}
+			else if (MainFilter == 2) // filter all
+			{
+				if (t < envData[7][NEXTT]) envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				else
+					UpdateEnv(7, t);
 
-      if(MainFilter==1) //filter overtones
-      {
-        if(t<envData[7][NEXTT])
-          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-        else UpdateEnv(7, t);
+				MFtmp = envData[7][ENV];
+				if (MFtmp > 0.2f) MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				else
+					MFfb = 0.999f - 0.7824f * MFtmp;
 
-        MFtmp = envData[7][ENV];
-        if(MFtmp >0.2f)
-          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-        else
-          MFfb = 0.999f - 0.7824f * MFtmp;
+				MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
+				MFin = MFfb * (MFin - MFtmp) + MFtmp;
+				MFout = MFfb * (MFout - MFin) + MFin;
 
-        MFtmp = Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-        MFin = MFfb * (MFin - MFtmp) + MFtmp;
-        MFout = MFfb * (MFout - MFin) + MFin;
+				DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
+			}
+			// PG: Ot is uninitialized
+			else
+				DF[t - tpos] = DF[t - tpos] + Ot; // no filter
+		}
 
-        DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
-      }
-      else if(MainFilter==2) //filter all
-      {
-        if(t<envData[7][NEXTT])
-          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-        else UpdateEnv(7, t);
+		if (DiON == 1) // bit resolution
+		{
+			for (j = 0; j < 1200; j++)
+				DF[j] = DGain * (int)(DF[j] / DAtten);
 
-        MFtmp = envData[7][ENV];
-        if(MFtmp >0.2f)
-          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-        else
-          MFfb = 0.999f - 0.7824f * MFtmp;
+			for (j = 0; j < 1200; j += DStep) // downsampling
+			{
+				DownAve = 0;
+				DownStart = j;
+				DownEnd = j + DStep - 1;
+				for (jj = DownStart; jj <= DownEnd; jj++)
+					DownAve = DownAve + DF[jj];
+				DownAve = DownAve / DStep;
+				for (jj = DownStart; jj <= DownEnd; jj++)
+					DF[jj] = DownAve;
+			}
+		}
+		else
+			for (j = 0; j < 1200; j++)
+				DF[j] *= DGain;
 
-        MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-        MFin = MFfb * (MFin - MFtmp) + MFtmp;
-        MFout = MFfb * (MFout - MFin) + MFin;
+		for (j = 0; j < 1200; j++) // clipping + output
+		{
+			if (DF[j] > clippoint) wave[wavewords++] = clippoint;
+			else if (DF[j] < -clippoint)
+				wave[wavewords++] = -clippoint;
+			else
+				wave[wavewords++] = (short)DF[j];
 
-        DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
-      }
-      // PG: Ot is uninitialized
-      else DF[t - tpos] = DF[t - tpos] + Ot; //no filter
-    }
+			for (int c = 1; c < channels; c++)
+			{
+				wave[wavewords] = wave[wavewords - 1];
+				wavewords++;
+			}
+		}
 
-    if(DiON==1) //bit resolution
-    {
-      for(j=0; j<1200; j++)
-        DF[j] = DGain * (int)(DF[j] / DAtten);
+		tpos = tpos + 1200;
+	}
 
-      for(j=0; j<1200; j+=DStep) //downsampling
-      {
-        DownAve = 0;
-        DownStart = j;
-        DownEnd = j + DStep - 1;
-        for(jj = DownStart; jj<=DownEnd; jj++)
-          DownAve = DownAve + DF[jj];
-        DownAve = DownAve / DStep;
-        for(jj = DownStart; jj<=DownEnd; jj++)
-          DF[jj] = DownAve;
-      }
-    }
-    else for(j=0; j<1200; j++) DF[j] *= DGain;
+	/*
+	if(wavemode==0)
+	{
+	  fwrite(wave, 2, Length, fp);  //write data
+	  fwrite(&WI,  1, 44, fp); //write INFO chunk
+	  fwrite(&comment, 1, commentLen, fp);
+	  fclose(fp);
+	}
+	wavemode = 0; //force compatibility!!
+	*/
 
-    for(j = 0; j<1200; j++) //clipping + output
-    {
-      if(DF[j] > clippoint)
-        wave[wavewords++] = clippoint;
-      else if(DF[j] < -clippoint)
-          wave[wavewords++] = -clippoint;
-      else
-          wave[wavewords++] = (short)DF[j];
-
-      for (int c = 1; c < channels; c++)  {
-        wave[wavewords] = wave[wavewords-1];
-        wavewords++;
-      }
-    }
-
-    tpos = tpos + 1200;
-  }
-
-  /*
-  if(wavemode==0)
-  {
-    fwrite(wave, 2, Length, fp);  //write data
-    fwrite(&WI,  1, 44, fp); //write INFO chunk
-    fwrite(&comment, 1, commentLen, fp);
-    fclose(fp);
-  }
-  wavemode = 0; //force compatibility!!
-  */
-
-
-  return Length;
+	return Length;
 }
-
 
 } // namespace lmms

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -67,14 +67,20 @@ int DrumSynth::LongestEnv()
 	for (long e = 1; e < 7; e++) // 3
 	{
 		long eon = e - 1;
-		if (eon > 2) { eon = eon - 1; }
+		if (eon > 2)
+		{
+			eon = eon - 1;
+		}
 		long p = 0;
 		while (envpts[e][0][p + 1] >= 0.f)
 		{
 			p++;
 		}
 		envData[e][MAX] = envpts[e][0][p] * timestretch;
-		if (chkOn[eon] == 1 && envData[e][MAX] > l) { l = envData[e][MAX]; }
+		if (chkOn[eon] == 1 && envData[e][MAX] > l)
+		{
+			l = envData[e][MAX];
+		}
 	}
 	// l *= timestretch;
 
@@ -90,22 +96,31 @@ float DrumSynth::LoudestEnv()
 	{
 		if (chkOn[i] == 1)
 		{
-			if (sliLev[i] > loudest) { loudest = static_cast<float>(sliLev[i]); }
+			if (sliLev[i] > loudest)
+			{
+				loudest = static_cast<float>(sliLev[i]);
+			}
 		}
 		i++;
 	}
-	return (loudest * loudest);
+	return loudest * loudest;
 }
 
 void DrumSynth::UpdateEnv(int e, long t)
 {
 	// 0.2's added
 	envData[e][NEXTT] = envpts[e][0][static_cast<long>(envData[e][PNT] + 1.f)] * timestretch; // get next point
-	if (envData[e][NEXTT] < 0) { envData[e][NEXTT] = 442000 * timestretch; }				  // if end point, hold
+	if (envData[e][NEXTT] < 0)
+	{
+		envData[e][NEXTT] = 442000 * timestretch; // if end point, hold
+	}
 	envData[e][ENV] = envpts[e][1][static_cast<long>(envData[e][PNT] + 0.f)] * 0.01f;		  // this level
 	float endEnv = envpts[e][1][static_cast<long>(envData[e][PNT] + 1.f)] * 0.01f;			  // next level
 	float dT = envData[e][NEXTT] - static_cast<float>(t);
-	if (dT < 1.0) { dT = 1.0; }
+	if (dT < 1.0)
+	{
+		dT = 1.0;
+	}
 	envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
 	envData[e][PNT] = envData[e][PNT] + 1.0f;
 }
@@ -124,12 +139,18 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 	{
 		if (en[i] == ',')
 		{
-			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
+			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0)
+			{
+				envpts[env][0][ep] = 0.f;
+			}
 			o = 0;
 		}
 		else if (en[i] == ' ')
 		{
-			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
+			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
+			{
+				envpts[env][1][ep] = 0.f;
+			}
 			o = 0;
 			ep++;
 		}
@@ -141,7 +162,10 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 		}
 		i++;
 	}
-	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
+	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
+	{
+		envpts[env][1][ep] = 0.f;
+	}
 	envpts[env][0][ep + 1] = -1;
 
 	envData[env][MAX] = envpts[env][0][ep];
@@ -165,7 +189,10 @@ float DrumSynth::waveform(float ph, int form)
 			ph += TwoPi;
 		}
 		w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
-		if (w > 1.f) { w = 2.f - w; }
+		if (w > 1.f)
+		{
+			w = 2.f - w;
+		}
 		break;
 	case 3:
 		w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
@@ -204,13 +231,19 @@ int DrumSynth::GetPrivateProfileString(
 			if (!is.eof())
 			{
 				is.getline(line, 200, ']');
-				if (strcasecmp(line, sec) == 0) { inSection = true; }
+				if (strcasecmp(line, sec) == 0)
+				{
+					inSection = true;
+				}
 			}
 		}
 		else if (!is.eof())
 		{
 			is.getline(line, 200);
-			if (line[0] == '[') { break; }
+			if (line[0] == '[')
+			{
+				break;
+			}
 
 			char* k = strtok(line, " \t=");
 			char* b = strtok(nullptr, "\n\r\0");
@@ -232,7 +265,10 @@ int DrumSynth::GetPrivateProfileString(
 					*(k + 1) = '\0';
 
 					len = strlen(b);
-					if (len > size - 1) { len = size - 1; }
+					if (len > size - 1)
+					{
+						len = size - 1;
+					}
 					strncpy(buffer, b, len + 1);
 				}
 				break;
@@ -258,7 +294,10 @@ int DrumSynth::GetPrivateProfileInt(const char* sec, const char* key, int def, Q
 
 	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
 	sscanf(tmp, "%d", &i);
-	if (tmp[0] == 0) { i = def; }
+	if (tmp[0] == 0)
+	{
+		i = def;
+	}
 
 	return i;
 }
@@ -270,7 +309,10 @@ float DrumSynth::GetPrivateProfileFloat(const char* sec, const char* key, float 
 
 	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
 	sscanf(tmp, "%f", &f);
-	if (tmp[0] == 0) { f = def; }
+	if (tmp[0] == 0)
+	{
+		f = def;
+	}
 
 	return f;
 }
@@ -343,11 +385,20 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	}
 	comment[commentLen + 1] = 0;
 	commentLen++;
-	if ((commentLen % 2) == 1) { commentLen++; }
+	if ((commentLen % 2) == 1)
+	{
+		commentLen++;
+	}
 
 	timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
-	if (timestretch < 0.2f) { timestretch = 0.2f; }
-	if (timestretch > 10.f) { timestretch = 10.f; }
+	if (timestretch < 0.2f)
+	{
+		timestretch = 0.2f;
+	}
+	if (timestretch > 10.f)
+	{
+		timestretch = 10.f;
+	}
 	// the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
 	timestretch *= Fs / 44100.f;
 
@@ -410,7 +461,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		F2 = F1 + ((F2 - F1) / (1.f - static_cast<float>(exp(TDroopRate * envData[1][MAX]))));
 		ddF = F1 - F2;
 	}
-	else { ddF = F2 - F1; }
+	else
+	{
+		ddF = F2 - F1;
+	}
 
 	Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; // degrees>radians
 
@@ -433,7 +487,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	OBal1 = 1.f - OBal2;
 	Ophi1 = Tphi;
 	Ophi2 = Tphi;
-	if (MainFilter == 0) { MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile); }
+	if (MainFilter == 0)
+	{
+		MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	}
 	if ((GetPrivateProfileInt(sec, "Track1", 0, dsfile) == 1) && (TON == 1))
 	{
 		OF1Sync = 1;
@@ -516,7 +573,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	// if(wave!=NULL) free(wave);
 	// wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
 	wave = new int16_t[channels * Length]; // wave memory buffer
-	if (wave == nullptr) { return 0; }
+	if (wave == nullptr)
+	{
+		return 0;
+	}
 	wavewords = 0;
 
 	/*
@@ -564,15 +624,24 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[2][NEXTT]) { envData[2][ENV] = envData[2][ENV] + envData[2][dENV]; }
-				else { UpdateEnv(2, t); }
+				if (t < envData[2][NEXTT])
+				{
+					envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
+				}
+				else
+				{
+					UpdateEnv(2, t);
+				}
 				x[2] = x[1];
 				x[1] = x[0];
 				x[0] = (randmax2 * static_cast<float>(rand())) - 1.f;
 				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
 				DF[t - tpos] = TT * g * envData[2][ENV];
 			}
-			if (t >= envData[2][MAX]) { NON = 0; }
+			if (t >= envData[2][MAX])
+			{
+				NON = 0;
+			}
 		}
 		else
 		{
@@ -602,12 +671,21 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			for (t = tpos; t <= tplus; t++)
 			{
 				totmp = t - tpos;
-				if (t < envData[1][NEXTT]) { envData[1][ENV] = envData[1][ENV] + envData[1][dENV]; }
-				else { UpdateEnv(1, t); }
+				if (t < envData[1][NEXTT])
+				{
+					envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
+				}
+				else
+				{
+					UpdateEnv(1, t);
+				}
 				Tphi = Tphi + phi[totmp];
 				DF[totmp] += TL * envData[1][ENV] * static_cast<float>(sin(fmod(Tphi, TwoPi))); // overflow?
 			}
-			if (t >= envData[1][MAX]) { TON = 0; }
+			if (t >= envData[1][MAX])
+			{
+				TON = 0;
+			}
 		}
 		else
 		{
@@ -621,35 +699,62 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[5][NEXTT]) { envData[5][ENV] = envData[5][ENV] + envData[5][dENV]; }
-				else { UpdateEnv(5, t); }
-				if ((t % BFStep) == 0) { BdF = randmax * static_cast<float>(rand()) - 0.5f; }
+				if (t < envData[5][NEXTT])
+				{
+					envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
+				}
+				else
+				{
+					UpdateEnv(5, t);
+				}
+				if ((t % BFStep) == 0)
+				{
+					BdF = randmax * static_cast<float>(rand()) - 0.5f;
+				}
 				BPhi = BPhi + BF + BQ * BdF;
 				botmp = t - tpos;
 				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi, TwoPi))) * envData[5][ENV] * BL;
 			}
-			if (t >= envData[5][MAX]) { BON = 0; }
+			if (t >= envData[5][MAX])
+			{
+				BON = 0;
+			}
 		}
 
 		if (BON2 == 1) // noise band 2
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[6][NEXTT]) { envData[6][ENV] = envData[6][ENV] + envData[6][dENV]; }
-				else { UpdateEnv(6, t); }
-				if ((t % BFStep2) == 0) { BdF2 = randmax * static_cast<float>(rand()) - 0.5f; }
+				if (t < envData[6][NEXTT])
+				{
+					envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
+				}
+				else
+				{
+					UpdateEnv(6, t);
+				}
+				if ((t % BFStep2) == 0)
+				{
+					BdF2 = randmax * static_cast<float>(rand()) - 0.5f;
+				}
 				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
 				botmp = t - tpos;
 				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi2, TwoPi))) * envData[6][ENV] * BL2;
 			}
-			if (t >= envData[6][MAX]) { BON2 = 0; }
+			if (t >= envData[6][MAX])
+			{
+				BON2 = 0;
+			}
 		}
 
 		for (t = tpos; t <= tplus; t++)
 		{
 			if (OON == 1) // overtones
 			{
-				if (t < envData[3][NEXTT]) { envData[3][ENV] = envData[3][ENV] + envData[3][dENV]; }
+				if (t < envData[3][NEXTT])
+				{
+					envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+				}
 				else
 				{
 					if (t >= envData[3][MAX]) // wait for OT2
@@ -658,10 +763,16 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 						envData[3][dENV] = 0;
 						envData[3][NEXTT] = 999999;
 					}
-					else { UpdateEnv(3, t); }
+					else
+					{
+						UpdateEnv(3, t);
+					}
 				}
 				//
-				if (t < envData[4][NEXTT]) { envData[4][ENV] = envData[4][ENV] + envData[4][dENV]; }
+				if (t < envData[4][NEXTT])
+				{
+					envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
+				}
 				else
 				{
 					if (t >= envData[4][MAX]) // wait for OT1
@@ -670,14 +781,29 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 						envData[4][dENV] = 0;
 						envData[4][NEXTT] = 999999;
 					}
-					else { UpdateEnv(4, t); }
+					else
+					{
+						UpdateEnv(4, t);
+					}
 				}
 				//
 				TphiStart = TphiStart + phi[t - tpos];
-				if (OF1Sync == 1) { Ophi1 = TphiStart * OF1; }
-				else { Ophi1 = Ophi1 + OF1; }
-				if (OF2Sync == 1) { Ophi2 = TphiStart * OF2; }
-				else { Ophi2 = Ophi2 + OF2; }
+				if (OF1Sync == 1)
+				{
+					Ophi1 = TphiStart * OF1;
+				}
+				else
+				{
+					Ophi1 = Ophi1 + OF1;
+				}
+				if (OF2Sync == 1)
+				{
+					Ophi2 = TphiStart * OF2;
+				}
+				else
+				{
+					Ophi2 = Ophi2 + OF2;
+				}
 				Ot = 0.0f;
 				switch (OMode)
 				{
@@ -718,12 +844,24 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 
 			if (MainFilter == 1) // filter overtones
 			{
-				if (t < envData[7][NEXTT]) { envData[7][ENV] = envData[7][ENV] + envData[7][dENV]; }
-				else { UpdateEnv(7, t); }
+				if (t < envData[7][NEXTT])
+				{
+					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				}
+				else
+				{
+					UpdateEnv(7, t);
+				}
 
 				MFtmp = envData[7][ENV];
-				if (MFtmp > 0.2f) { MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1)); }
-				else { MFfb = 0.999f - 0.7824f * MFtmp; }
+				if (MFtmp > 0.2f)
+				{
+					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				}
+				else
+				{
+					MFfb = 0.999f - 0.7824f * MFtmp;
+				}
 
 				MFtmp = Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
 				MFin = MFfb * (MFin - MFtmp) + MFtmp;
@@ -733,12 +871,24 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			}
 			else if (MainFilter == 2) // filter all
 			{
-				if (t < envData[7][NEXTT]) { envData[7][ENV] = envData[7][ENV] + envData[7][dENV]; }
-				else { UpdateEnv(7, t); }
+				if (t < envData[7][NEXTT])
+				{
+					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				}
+				else
+				{
+					UpdateEnv(7, t);
+				}
 
 				MFtmp = envData[7][ENV];
-				if (MFtmp > 0.2f) { MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1)); }
-				else { MFfb = 0.999f - 0.7824f * MFtmp; }
+				if (MFtmp > 0.2f)
+				{
+					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				}
+				else
+				{
+					MFfb = 0.999f - 0.7824f * MFtmp;
+				}
 
 				MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
 				MFin = MFfb * (MFin - MFtmp) + MFtmp;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -189,7 +189,7 @@ float DrumSynth::waveform(float ph, int form)
 			break; // sine^2
 		case 2:
 			while (ph < TwoPi) { ph += TwoPi; }
-			w = 0.6366197f * (float)fmod(ph, TwoPi) - 1.f;   // tri
+			w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
 			if (w > 1.f) { w = 2.f - w; }
 			break;
 		case 3:

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -78,7 +78,7 @@ int DrumSynth::LongestEnv()
 	}
 	// l *= timestretch;
 
-	return 2400 + (1200 * (int)(l / 1200));
+	return 2400 + (1200 * static_cast<int>(l / 1200));
 }
 
 float DrumSynth::LoudestEnv()
@@ -90,7 +90,7 @@ float DrumSynth::LoudestEnv()
 	{
 		if (chkOn[i] == 1)
 		{
-			if (sliLev[i] > loudest) { loudest = (float)sliLev[i]; }
+			if (sliLev[i] > loudest) { loudest = static_cast<float>(sliLev[i]); }
 		}
 		i++;
 	}
@@ -370,7 +370,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	NT = GetPrivateProfileInt(sec, "Slope", 0, dsfile);
 	GetEnv(2, sec, "Envelope", dsfile);
 	NON = chkOn[1];
-	NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
+	NL = static_cast<float>(sliLev[1] * sliLev[1]) * mem_n;
 	if (NT < 0)
 	{
 		a = 1.f + (NT / 105.f);
@@ -381,7 +381,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	{
 		a = 1.f;
 		b = -NT / 50.f;
-		c = (float)fabs((float)NT) / 100.f;
+		c = static_cast<float>(fabs(static_cast<float>(NT))) / 100.f;
 		g = NL;
 	}
 
@@ -393,7 +393,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	chkOn[0] = GetPrivateProfileInt(sec, "On", 0, dsfile);
 	TON = chkOn[0];
 	sliLev[0] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
+	TL = static_cast<float>(sliLev[0] * sliLev[0]) * mem_t;
 	GetEnv(1, sec, "Envelope", dsfile);
 	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
 	if (fabs(F1) < 0.001f)
@@ -407,7 +407,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
 		TDroopRate = TDroopRate * -4.f / envData[1][MAX];
 		TDroop = 1;
-		F2 = F1 + ((F2 - F1) / (1.f - (float)exp(TDroopRate * envData[1][MAX])));
+		F2 = F1 + ((F2 - F1) / (1.f - static_cast<float>(exp(TDroopRate * envData[1][MAX]))));
 		ddF = F1 - F2;
 	}
 	else { ddF = F2 - F1; }
@@ -419,7 +419,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	chkOn[2] = GetPrivateProfileInt(sec, "On", 0, dsfile);
 	OON = chkOn[2];
 	sliLev[2] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
+	OL = static_cast<float>(sliLev[2] * sliLev[2]) * mem_o;
 	GetEnv(3, sec, "Envelope1", dsfile);
 	GetEnv(4, sec, "Envelope2", dsfile);
 	OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
@@ -427,7 +427,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
 	OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
 	OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
-	OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
+	OBal2 = static_cast<float>(GetPrivateProfileInt(sec, "Param", 50, dsfile));
 	ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
 	OBal2 *= 0.01f;
 	OBal1 = 1.f - OBal2;
@@ -453,7 +453,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	Ocf2 = TwoPi / OF2;
 	for (i = 0; i < 6; i++)
 	{
-		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
+		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * static_cast<float>(i);
 	}
 
 	// read noise band parameters
@@ -461,27 +461,27 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile);
 	BON = chkOn[3];
 	sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
+	BL = static_cast<float>(sliLev[3] * sliLev[3]) * mem_b;
 	BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
 	BPhi = TwoPi / 8.f;
 	GetEnv(5, sec, "Envelope", dsfile);
 	BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-	BQ = (float)BFStep;
-	BQ = BQ * BQ / (10000.f - 6600.f * ((float)sqrt(BF) - 0.19f));
-	BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
+	BQ = static_cast<float>(BFStep);
+	BQ = BQ * BQ / (10000.f - 6600.f * (static_cast<float>(sqrt(BF)) - 0.19f));
+	BFStep = 1 + static_cast<int>((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
 	strcpy(sec, "NoiseBand2");
 	chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile);
 	BON2 = chkOn[4];
 	sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
+	BL2 = static_cast<float>(sliLev[4] * sliLev[4]) * mem_b;
 	BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
 	BPhi2 = TwoPi / 8.f;
 	GetEnv(6, sec, "Envelope", dsfile);
 	BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-	BQ2 = (float)BFStep2;
-	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f * ((float)sqrt(BF2) - 0.19f));
-	BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
+	BQ2 = static_cast<float>(BFStep2);
+	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f * (static_cast<float>(sqrt(BF2)) - 0.19f));
+	BFStep2 = 1 + static_cast<int>((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
 	// read distortion parameters
 	strcpy(sec, "Distortion");
@@ -497,9 +497,9 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 
 	if (DiON == 1)
 	{
-		DAtten = DGain * (short)LoudestEnv();
+		DAtten = DGain * static_cast<short>(LoudestEnv());
 		if (DAtten > 32700) { clippoint = 32700; }
-		else { clippoint = (short)DAtten; }
+		else { clippoint = static_cast<short>(DAtten); }
 		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
 		DGain = DAtten * DGain
 			* static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
@@ -569,7 +569,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 				else { UpdateEnv(2, t); }
 				x[2] = x[1];
 				x[1] = x[0];
-				x[0] = (randmax2 * (float)rand()) - 1.f;
+				x[0] = (randmax2 * static_cast<float>(rand())) - 1.f;
 				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
 				DF[t - tpos] = TT * g * envData[2][ENV];
 			}
@@ -590,7 +590,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			{
 				for (t = tpos; t <= tplus; t++)
 				{
-					phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+					phi[t - tpos] = F2 + (ddF * static_cast<float>(exp(t * TDroopRate)));
 				}
 			}
 			else
@@ -606,7 +606,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 				if (t < envData[1][NEXTT]) { envData[1][ENV] = envData[1][ENV] + envData[1][dENV]; }
 				else { UpdateEnv(1, t); }
 				Tphi = Tphi + phi[totmp];
-				DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi, TwoPi)); // overflow?
+				DF[totmp] += TL * envData[1][ENV] * static_cast<float>(sin(fmod(Tphi, TwoPi))); // overflow?
 			}
 			if (t >= envData[1][MAX]) { TON = 0; }
 		}
@@ -624,10 +624,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			{
 				if (t < envData[5][NEXTT]) { envData[5][ENV] = envData[5][ENV] + envData[5][dENV]; }
 				else { UpdateEnv(5, t); }
-				if ((t % BFStep) == 0) { BdF = randmax * (float)rand() - 0.5f; }
+				if ((t % BFStep) == 0) { BdF = randmax * static_cast<float>(rand()) - 0.5f; }
 				BPhi = BPhi + BF + BQ * BdF;
 				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi, TwoPi)) * envData[5][ENV] * BL;
+				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi, TwoPi))) * envData[5][ENV] * BL;
 			}
 			if (t >= envData[5][MAX]) { BON = 0; }
 		}
@@ -638,10 +638,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			{
 				if (t < envData[6][NEXTT]) { envData[6][ENV] = envData[6][ENV] + envData[6][dENV]; }
 				else { UpdateEnv(6, t); }
-				if ((t % BFStep2) == 0) { BdF2 = randmax * (float)rand() - 0.5f; }
+				if ((t % BFStep2) == 0) { BdF2 = randmax * static_cast<float>(rand()) - 0.5f; }
 				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
 				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2, TwoPi)) * envData[6][ENV] * BL2;
+				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi2, TwoPi))) * envData[6][ENV] * BL2;
 			}
 			if (t >= envData[6][MAX]) { BON2 = 0; }
 		}
@@ -758,7 +758,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		{
 			for (j = 0; j < 1200; j++)
 			{
-				DF[j] = DGain * (int)(DF[j] / DAtten);
+				DF[j] = DGain * static_cast<int>(DF[j] / DAtten);
 			}
 
 			for (j = 0; j < 1200; j += DStep) // downsampling
@@ -789,7 +789,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		{
 			if (DF[j] > clippoint) { wave[wavewords++] = clippoint; }
 			else if (DF[j] < -clippoint) { wave[wavewords++] = -clippoint; }
-			else { wave[wavewords++] = (short)DF[j]; }
+			else { wave[wavewords++] = static_cast<short>(DF[j]); }
 
 			for (int c = 1; c < channels; c++)
 			{

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -72,7 +72,7 @@ int DrumSynth::LongestEnv()
 	long e, eon, p;
 	float l = 0.f;
 
-	for (e = 1; e < 7; e++) //3
+	for (long e = 1; e < 7; e++) // 3
 	{
 		eon = e - 1;
 		if (eon > 2)
@@ -182,23 +182,23 @@ float DrumSynth::waveform(float ph, int form)
 	switch (form)
 	{
 		case 0:
-			w = (float)sin(fmod(ph, TwoPi));
-			break; //sine
+			w = static_cast<float>(sin(fmod(ph, TwoPi)));
+			break; // sine
 		case 1:
-			w = (float)fabs(2.0f*(float)sin(fmod(0.5f*ph, TwoPi))) - 1.f;
-			break; //sine^2
+			w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
+			break; // sine^2
 		case 2:
-			while (ph < TwoPi) { ph+=TwoPi; }
-			w = 0.6366197f * (float)fmod(ph, TwoPi) - 1.f;   //tri
+			while (ph < TwoPi) { ph += TwoPi; }
+			w = 0.6366197f * (float)fmod(ph, TwoPi) - 1.f;   // tri
 			if (w > 1.f) { w = 2.f - w; }
 			break;
 		case 3:
-			w = ph - TwoPi * (float)(int)(ph / TwoPi);      //saw
+			w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
 			w = (0.3183098f * w) - 1.f;
 			break;
 		default:
-			w = (sin(fmod(ph, TwoPi)) > 0.0)? 1.f: -1.f;
-			break; //square
+			w = (sin(fmod(ph, TwoPi)) > 0.0) ? 1.f : -1.f;
+			break; // square
 	}
 
 	return w;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -94,12 +94,9 @@ float DrumSynth::LoudestEnv()
 
 	while (i < 5) // 2
 	{
-		if (chkOn[i] == 1)
+		if ((chkOn[i] == 1) && (sliLev[i] > loudest))
 		{
-			if (sliLev[i] > loudest)
-			{
-				loudest = static_cast<float>(sliLev[i]);
-			}
+			loudest = static_cast<float>(sliLev[i]);
 		}
 		i++;
 	}
@@ -368,8 +365,11 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	strcpy(sec, "General");
 	GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
 	ver[9] = 0;
-	if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } // input fail
-	if (ver[11] != '1' && ver[11] != '2') { return 0; }	 // version fail
+	if ((strcasecmp(ver, "DrumSynth") != 0) // input fail
+		|| (ver[11] != '1' && ver[11] != '2'))  // version fail
+	{
+		return 0;
+	}
 
 	// read master parameters
 	GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
@@ -936,9 +936,18 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 
 		for (j = 0; j < 1200; j++) // clipping + output
 		{
-			if (DF[j] > clippoint) { wave[wavewords++] = clippoint; }
-			else if (DF[j] < -clippoint) { wave[wavewords++] = -clippoint; }
-			else { wave[wavewords++] = static_cast<short>(DF[j]); }
+			if (DF[j] > clippoint)
+			{
+				wave[wavewords++] = clippoint;
+			}
+			else if (DF[j] < -clippoint)
+			{
+				wave[wavewords++] = -clippoint;
+			}
+			else
+			{
+				wave[wavewords++] = static_cast<short>(DF[j]);
+			}
 
 			for (int c = 1; c < channels; c++)
 			{

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -89,7 +89,9 @@ float DrumSynth::LoudestEnv()
 	while (i < 5) // 2
 	{
 		if (chkOn[i] == 1)
-			if (sliLev[i] > loudest) loudest = (float)sliLev[i];
+		{
+			if (sliLev[i] > loudest) { loudest = (float)sliLev[i]; }
+		}
 		i++;
 	}
 	return (loudest * loudest);
@@ -122,12 +124,12 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 	{
 		if (en[i] == ',')
 		{
-			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) envpts[env][0][ep] = 0.f;
+			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
 			o = 0;
 		}
 		else if (en[i] == ' ')
 		{
-			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
+			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
 			o = 0;
 			ep++;
 		}
@@ -139,7 +141,7 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 		}
 		i++;
 	}
-	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
+	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
 	envpts[env][0][ep + 1] = -1;
 
 	envData[env][MAX] = envpts[env][0][ep];
@@ -208,7 +210,7 @@ int DrumSynth::GetPrivateProfileString(
 		else if (!is.eof())
 		{
 			is.getline(line, 200);
-			if (line[0] == '[') break;
+			if (line[0] == '[') { break; }
 
 			char* k = strtok(line, " \t=");
 			char* b = strtok(nullptr, "\n\r\0");
@@ -224,11 +226,13 @@ int DrumSynth::GetPrivateProfileString(
 				{
 					k = (char*)(b + strlen(b) - 1);
 					while ((k >= b) && (*k == ' ' || *k == '\t'))
+					{
 						--k;
+					}
 					*(k + 1) = '\0';
 
 					len = strlen(b);
-					if (len > size - 1) len = size - 1;
+					if (len > size - 1) { len = size - 1; }
 					strncpy(buffer, b, len + 1);
 				}
 				break;
@@ -254,7 +258,7 @@ int DrumSynth::GetPrivateProfileInt(const char* sec, const char* key, int def, Q
 
 	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
 	sscanf(tmp, "%d", &i);
-	if (tmp[0] == 0) i = def;
+	if (tmp[0] == 0) { i = def; }
 
 	return i;
 }
@@ -266,7 +270,7 @@ float DrumSynth::GetPrivateProfileFloat(const char* sec, const char* key, float 
 
 	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
 	sscanf(tmp, "%f", &f);
-	if (tmp[0] == 0) f = def;
+	if (tmp[0] == 0) { f = def; }
 
 	return f;
 }
@@ -328,7 +332,9 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	// read master parameters
 	GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
 	while ((comment[commentLen] != 0) && (commentLen < 254))
+	{
 		commentLen++;
+	}
 	if (commentLen == 0)
 	{
 		comment[0] = 32;
@@ -337,11 +343,11 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	}
 	comment[commentLen + 1] = 0;
 	commentLen++;
-	if ((commentLen % 2) == 1) commentLen++;
+	if ((commentLen % 2) == 1) { commentLen++; }
 
 	timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
-	if (timestretch < 0.2f) timestretch = 0.2f;
-	if (timestretch > 10.f) timestretch = 10.f;
+	if (timestretch < 0.2f) { timestretch = 0.2f; }
+	if (timestretch > 10.f) { timestretch = 10.f; }
 	// the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
 	timestretch *= Fs / 44100.f;
 
@@ -390,7 +396,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
 	GetEnv(1, sec, "Envelope", dsfile);
 	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-	if (fabs(F1) < 0.001f) F1 = 0.001f; // to prevent overtone ratio div0
+	if (fabs(F1) < 0.001f)
+	{
+		F1 = 0.001f; // to prevent overtone ratio div0
+	}
 	F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
 	TDroopRate = GetPrivateProfileFloat(sec, "Droop", 0.f, dsfile);
 	if (TDroopRate > 0.f)
@@ -401,8 +410,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		F2 = F1 + ((F2 - F1) / (1.f - (float)exp(TDroopRate * envData[1][MAX])));
 		ddF = F1 - F2;
 	}
-	else
-		ddF = F2 - F1;
+	else { ddF = F2 - F1; }
 
 	Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; // degrees>radians
 
@@ -425,7 +433,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	OBal1 = 1.f - OBal2;
 	Ophi1 = Tphi;
 	Ophi2 = Tphi;
-	if (MainFilter == 0) MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	if (MainFilter == 0) { MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile); }
 	if ((GetPrivateProfileInt(sec, "Track1", 0, dsfile) == 1) && (TON == 1))
 	{
 		OF1Sync = 1;
@@ -444,7 +452,9 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	Ocf1 = TwoPi / OF1;
 	Ocf2 = TwoPi / OF2;
 	for (i = 0; i < 6; i++)
+	{
 		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
+	}
 
 	// read noise band parameters
 	strcpy(sec, "NoiseBand");
@@ -478,9 +488,9 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile);
 	DiON = chkOn[5];
 	DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
-	if (DStep == 7) DStep = 20;
-	if (DStep == 6) DStep = 10;
-	if (DStep == 5) DStep = 8;
+	if (DStep == 7) { DStep = 20; }
+	if (DStep == 6) { DStep = 10; }
+	if (DStep == 5) { DStep = 8; }
 
 	clippoint = 32700;
 	DAtten = 1.0f;
@@ -488,9 +498,8 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	if (DiON == 1)
 	{
 		DAtten = DGain * (short)LoudestEnv();
-		if (DAtten > 32700) clippoint = 32700;
-		else
-			clippoint = (short)DAtten;
+		if (DAtten > 32700) { clippoint = 32700; }
+		else { clippoint = (short)DAtten; }
 		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
 		DGain = DAtten * DGain
 			* static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
@@ -556,21 +565,22 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
-				else
-					UpdateEnv(2, t);
+				if (t < envData[2][NEXTT]) { envData[2][ENV] = envData[2][ENV] + envData[2][dENV]; }
+				else { UpdateEnv(2, t); }
 				x[2] = x[1];
 				x[1] = x[0];
 				x[0] = (randmax2 * (float)rand()) - 1.f;
 				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
 				DF[t - tpos] = TT * g * envData[2][ENV];
 			}
-			if (t >= envData[2][MAX]) NON = 0;
+			if (t >= envData[2][MAX]) { NON = 0; }
 		}
 		else
 		{
 			for (j = 0; j < 1200; j++)
+			{
 				DF[j] = 0.f;
+			}
 		}
 
 		if (TON == 1) // tone
@@ -579,63 +589,68 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			if (TDroop == 1)
 			{
 				for (t = tpos; t <= tplus; t++)
+				{
 					phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+				}
 			}
 			else
 			{
 				for (t = tpos; t <= tplus; t++)
+				{
 					phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
+				}
 			}
 			for (t = tpos; t <= tplus; t++)
 			{
 				totmp = t - tpos;
-				if (t < envData[1][NEXTT]) envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
-				else
-					UpdateEnv(1, t);
+				if (t < envData[1][NEXTT]) { envData[1][ENV] = envData[1][ENV] + envData[1][dENV]; }
+				else { UpdateEnv(1, t); }
 				Tphi = Tphi + phi[totmp];
 				DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi, TwoPi)); // overflow?
 			}
-			if (t >= envData[1][MAX]) TON = 0;
+			if (t >= envData[1][MAX]) { TON = 0; }
 		}
 		else
+		{
 			for (j = 0; j < 1200; j++)
+			{
 				phi[j] = F2; // for overtone sync
+			}
+		}
 
 		if (BON == 1) // noise band 1
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[5][NEXTT]) envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
-				else
-					UpdateEnv(5, t);
-				if ((t % BFStep) == 0) BdF = randmax * (float)rand() - 0.5f;
+				if (t < envData[5][NEXTT]) { envData[5][ENV] = envData[5][ENV] + envData[5][dENV]; }
+				else { UpdateEnv(5, t); }
+				if ((t % BFStep) == 0) { BdF = randmax * (float)rand() - 0.5f; }
 				BPhi = BPhi + BF + BQ * BdF;
 				botmp = t - tpos;
 				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi, TwoPi)) * envData[5][ENV] * BL;
 			}
-			if (t >= envData[5][MAX]) BON = 0;
+			if (t >= envData[5][MAX]) { BON = 0; }
 		}
 
 		if (BON2 == 1) // noise band 2
 		{
 			for (t = tpos; t <= tplus; t++)
 			{
-				if (t < envData[6][NEXTT]) envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
-				else
-					UpdateEnv(6, t);
-				if ((t % BFStep2) == 0) BdF2 = randmax * (float)rand() - 0.5f;
+				if (t < envData[6][NEXTT]) { envData[6][ENV] = envData[6][ENV] + envData[6][dENV]; }
+				else { UpdateEnv(6, t); }
+				if ((t % BFStep2) == 0) { BdF2 = randmax * (float)rand() - 0.5f; }
 				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
 				botmp = t - tpos;
 				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2, TwoPi)) * envData[6][ENV] * BL2;
 			}
-			if (t >= envData[6][MAX]) BON2 = 0;
+			if (t >= envData[6][MAX]) { BON2 = 0; }
 		}
 
 		for (t = tpos; t <= tplus; t++)
 		{
 			if (OON == 1) // overtones
 			{
-				if (t < envData[3][NEXTT]) envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+				if (t < envData[3][NEXTT]) { envData[3][ENV] = envData[3][ENV] + envData[3][dENV]; }
 				else
 				{
 					if (t >= envData[3][MAX]) // wait for OT2
@@ -644,11 +659,10 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 						envData[3][dENV] = 0;
 						envData[3][NEXTT] = 999999;
 					}
-					else
-						UpdateEnv(3, t);
+					else { UpdateEnv(3, t); }
 				}
 				//
-				if (t < envData[4][NEXTT]) envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
+				if (t < envData[4][NEXTT]) { envData[4][ENV] = envData[4][ENV] + envData[4][dENV]; }
 				else
 				{
 					if (t >= envData[4][MAX]) // wait for OT1
@@ -657,17 +671,14 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 						envData[4][dENV] = 0;
 						envData[4][NEXTT] = 999999;
 					}
-					else
-						UpdateEnv(4, t);
+					else { UpdateEnv(4, t); }
 				}
 				//
 				TphiStart = TphiStart + phi[t - tpos];
-				if (OF1Sync == 1) Ophi1 = TphiStart * OF1;
-				else
-					Ophi1 = Ophi1 + OF1;
-				if (OF2Sync == 1) Ophi2 = TphiStart * OF2;
-				else
-					Ophi2 = Ophi2 + OF2;
+				if (OF1Sync == 1) { Ophi1 = TphiStart * OF1; }
+				else { Ophi1 = Ophi1 + OF1; }
+				if (OF2Sync == 1) { Ophi2 = TphiStart * OF2; }
+				else { Ophi2 = Ophi2 + OF2; }
 				Ot = 0.0f;
 				switch (OMode)
 				{
@@ -708,14 +719,12 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 
 			if (MainFilter == 1) // filter overtones
 			{
-				if (t < envData[7][NEXTT]) envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-				else
-					UpdateEnv(7, t);
+				if (t < envData[7][NEXTT]) { envData[7][ENV] = envData[7][ENV] + envData[7][dENV]; }
+				else { UpdateEnv(7, t); }
 
 				MFtmp = envData[7][ENV];
-				if (MFtmp > 0.2f) MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-				else
-					MFfb = 0.999f - 0.7824f * MFtmp;
+				if (MFtmp > 0.2f) { MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1)); }
+				else { MFfb = 0.999f - 0.7824f * MFtmp; }
 
 				MFtmp = Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
 				MFin = MFfb * (MFin - MFtmp) + MFtmp;
@@ -725,14 +734,12 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			}
 			else if (MainFilter == 2) // filter all
 			{
-				if (t < envData[7][NEXTT]) envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-				else
-					UpdateEnv(7, t);
+				if (t < envData[7][NEXTT]) { envData[7][ENV] = envData[7][ENV] + envData[7][dENV]; }
+				else { UpdateEnv(7, t); }
 
 				MFtmp = envData[7][ENV];
-				if (MFtmp > 0.2f) MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-				else
-					MFfb = 0.999f - 0.7824f * MFtmp;
+				if (MFtmp > 0.2f) { MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1)); }
+				else { MFfb = 0.999f - 0.7824f * MFtmp; }
 
 				MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f / MFfb)) * (MFin - MFout);
 				MFin = MFfb * (MFin - MFtmp) + MFtmp;
@@ -742,13 +749,17 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			}
 			// PG: Ot is uninitialized
 			else
+			{
 				DF[t - tpos] = DF[t - tpos] + Ot; // no filter
+			}
 		}
 
 		if (DiON == 1) // bit resolution
 		{
 			for (j = 0; j < 1200; j++)
+			{
 				DF[j] = DGain * (int)(DF[j] / DAtten);
+			}
 
 			for (j = 0; j < 1200; j += DStep) // downsampling
 			{
@@ -756,23 +767,29 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 				DownStart = j;
 				DownEnd = j + DStep - 1;
 				for (jj = DownStart; jj <= DownEnd; jj++)
+				{
 					DownAve = DownAve + DF[jj];
+				}
 				DownAve = DownAve / DStep;
 				for (jj = DownStart; jj <= DownEnd; jj++)
+				{
 					DF[jj] = DownAve;
+				}
 			}
 		}
 		else
+		{
 			for (j = 0; j < 1200; j++)
+			{
 				DF[j] *= DGain;
+			}
+		}
 
 		for (j = 0; j < 1200; j++) // clipping + output
 		{
-			if (DF[j] > clippoint) wave[wavewords++] = clippoint;
-			else if (DF[j] < -clippoint)
-				wave[wavewords++] = -clippoint;
-			else
-				wave[wavewords++] = (short)DF[j];
+			if (DF[j] > clippoint) { wave[wavewords++] = clippoint; }
+			else if (DF[j] < -clippoint) { wave[wavewords++] = -clippoint; }
+			else { wave[wavewords++] = (short)DF[j]; }
 
 			for (int c = 1; c < channels; c++)
 			{

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -498,8 +498,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	if (DiON == 1)
 	{
 		DAtten = DGain * static_cast<short>(LoudestEnv());
-		if (DAtten > 32700) { clippoint = 32700; }
-		else { clippoint = static_cast<short>(DAtten); }
+		clippoint = DAtten > 32700 ? 32700 : static_cast<short>(DAtten);
 		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
 		DGain = DAtten * DGain
 			* static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -63,68 +63,51 @@ short DD[1200], clippoint;
 float DF[1200];
 float phi[1200];
 
-long  wavewords, wavemode = 0;
-float mem_t = 1.0f, mem_o = 1.0f, mem_n = 1.0f, mem_b = 1.0f, mem_tune = 1.0f, mem_time = 1.0f;
+long  wavewords, wavemode=0;
+float mem_t=1.0f, mem_o=1.0f, mem_n=1.0f, mem_b=1.0f, mem_tune=1.0f, mem_time=1.0f;
 
 
 int DrumSynth::LongestEnv()
 {
-	long e, eon, p;
 	float l = 0.f;
 
 	for (long e = 1; e < 7; e++) // 3
 	{
-		eon = e - 1;
-		if (eon > 2)
-		{
-			eon = eon - 1;
-		}
-		p = 0;
-		while (envpts[e][0][p + 1] >= 0.f)
-		{
-			p++;
-		}
+		long eon = e - 1;
+		if (eon > 2) { eon = eon - 1; }
+		long p = 0;
+		while (envpts[e][0][p + 1] >= 0.f) { p++; }
 		envData[e][MAX] = envpts[e][0][p] * timestretch;
-		if (chkOn[eon] == 1 && envData[e][MAX] > l)
-		{
-			l = envData[e][MAX];
-		}
-	}
-	//l *= timestretch;
+		if (chkOn[eon] == 1 && envData[e][MAX] > l) { l = envData[e][MAX]; }
+  }
+  //l *= timestretch;
 
-	return 2400 + (1200 * (int)(l / 1200));
+  return 2400 + (1200 * (int)(l / 1200));
 }
 
 
 float DrumSynth::LoudestEnv()
 {
-	float loudest = 0.f;
-	int i = 0;
+  float loudest=0.f;
+  int i=0;
 
-	while (i < 5) //2
-	{
-		if (chkOn[i] == 1 && sliLev[i] > loudest)
-		{
-			loudest = (float)sliLev[i];
-		}
-		i++;
-	}
-	return (loudest * loudest);
+  while (i<5) //2
+  {
+    if(chkOn[i]==1) if(sliLev[i]>loudest) loudest=(float)sliLev[i];
+    i++;
+  }
+  return (loudest * loudest);
 }
 
 
 void DrumSynth::UpdateEnv(int e, long t)
 {
-	float endEnv, dT;
-															 //0.2's added
-	envData[e][NEXTT] = envpts[e][0][(long)(envData[e][PNT] + 1.f)] * timestretch; //get next point
-	if (envData[e][NEXTT] < 0)
-	{
-		envData[e][NEXTT] = 442000 * timestretch; //if end point, hold
-	}
-	envData[e][ENV] = envpts[e][1][(long)(envData[e][PNT] + 0.f)] * 0.01f; //this level
-	endEnv = envpts[e][1][(long)(envData[e][PNT] + 1.f)] * 0.01f;          //next level
-	dT = envData[e][NEXTT] - (float)t;
+	// 0.2's added
+	envData[e][NEXTT] = envpts[e][0][static_cast<long>(envData[e][PNT] + 1.f)] * timestretch; // get next point
+	if (envData[e][NEXTT] < 0) { envData[e][NEXTT] = 442000 * timestretch; } // if end point, hold
+	envData[e][ENV] = envpts[e][1][static_cast<long>(envData[e][PNT] + 0.f)] * 0.01f; // this level
+	float endEnv = envpts[e][1][static_cast<long>(envData[e][PNT] + 1.f)] * 0.01f; // next level
+	float dT = envData[e][NEXTT] - static_cast<float>(t);
 	if (dT < 1.0) { dT = 1.0; }
 	envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
 	envData[e][PNT] = envData[e][PNT] + 1.0f;
@@ -133,45 +116,33 @@ void DrumSynth::UpdateEnv(int e, long t)
 
 void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
 {
-	char en[256], s[8];
-	int i = 0, o = 0, ep = 0;
-	GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
+  char en[256], s[8];
+  int i=0, o=0, ep=0;
+  GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
 
-	//be safe!
-	en[255] = 0;
-	s[0] = 0;
+  //be safe!
+  en[255]=0;
+  s[0]=0;
 
-	while (en[i] != 0)
-	{
-		if (en[i] == ',')
-		{
-			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
-			o = 0;
-		}
-		else if (en[i] == ' ')
-		{
-			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
-			{
-				envpts[env][1][ep] = 0.f;
-			}
-			o = 0;
-			ep++;
-		}
-		else
-		{
-			s[o] = en[i];
-			o++;
-			s[o] = 0;
-		}
-		i++;
-	}
-	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
-	{
-		envpts[env][1][ep] = 0.f;
-	}
-	envpts[env][0][ep + 1] = -1;
+  while(en[i]!=0)
+  {
+    if(en[i] == ',')
+    {
+      if(sscanf(s, "%f", &envpts[env][0][ep])==0) envpts[env][0][ep] = 0.f;
+      o=0;
+    }
+    else if(en[i] == ' ')
+    {
+      if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
+      o=0; ep++;
+    }
+    else { s[o]=en[i]; o++; s[o]=0; }
+    i++;
+  }
+  if(sscanf(s, "%f", &envpts[env][1][ep])==0) envpts[env][1][ep] = 0.f;
+  envpts[env][0][ep + 1] = -1;
 
-	envData[env][MAX] = envpts[env][0][ep];
+  envData[env][MAX] = envpts[env][0][ep];
 }
 
 
@@ -181,24 +152,24 @@ float DrumSynth::waveform(float ph, int form)
 
 	switch (form)
 	{
-		case 0:
-			w = static_cast<float>(sin(fmod(ph, TwoPi)));
-			break; // sine
-		case 1:
-			w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
-			break; // sine^2
-		case 2:
-			while (ph < TwoPi) { ph += TwoPi; }
-			w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
-			if (w > 1.f) { w = 2.f - w; }
-			break;
-		case 3:
-			w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
-			w = (0.3183098f * w) - 1.f;
-			break;
-		default:
-			w = (sin(fmod(ph, TwoPi)) > 0.0) ? 1.f : -1.f;
-			break; // square
+	case 0:
+		w = static_cast<float>(sin(fmod(ph, TwoPi)));
+		break; // sine
+	case 1:
+		w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
+		break; // sine^2
+	case 2:
+		while (ph < TwoPi) { ph += TwoPi; }
+		w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
+		if (w > 1.f) { w = 2.f - w; }
+		break;
+	case 3:
+		w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
+		w = (0.3183098f * w) - 1.f;
+		break;
+	default:
+		w = (sin(fmod(ph, TwoPi)) > 0.0) ? 1.f : -1.f;
+		break; // square
 	}
 
 	return w;
@@ -209,109 +180,86 @@ int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const c
 {
 	stringstream is;
 	bool inSection = false;
-	char *line;
-	char *k, *b;
 	int len = 0;
 
 	char* line = static_cast<char*>(malloc(200));
 
-	// Use QFile to handle unicode file name on Windows
-	// Previously we used ifstream directly
-	QFile f(file);
-	f.open(QIODevice::ReadOnly);
-	QByteArray dat = f.readAll().constData();
-	is.str(string(dat.constData(), dat.size()));
+    // Use QFile to handle unicode file name on Windows
+    // Previously we used ifstream directly
+    QFile f(file);
+    f.open(QIODevice::ReadOnly);
+    QByteArray dat = f.readAll().constData();
+    is.str(string(dat.constData(), dat.size()));
 
-	while (is.good())
-	{
-		if (!inSection)
-		{
-			is.ignore(numeric_limits<streamsize>::max(), '[');
+    while (is.good()) {
+        if (!inSection) {
+            is.ignore( numeric_limits<streamsize>::max(), '[');
 
-			if (!is.eof())
-			{
-				is.getline(line, 200, ']');
-				if (strcasecmp(line, sec) == 0)
-				{
-					inSection = true;
-				}
-			}
-		}
-		else if (!is.eof())
-		{
-			is.getline(line, 200);
-			if (line[0] == '[')
-			{
-				break;
-			}
+            if (!is.eof()) {
+                is.getline(line, 200, ']');
+                if (strcasecmp(line, sec)==0) {
+                    inSection = true;
+                }
+            }
+        }
+        else if (!is.eof()) {
+            is.getline(line, 200);
+            if (line[0] == '[')
+                break;
 
-			char* k = strtok(line, " \t=");
-			char* b = strtok(nullptr, "\n\r\0");
+            char* k = strtok(line, " \t=");
+            char* b = strtok(nullptr, "\n\r\0");
 
-			if (k != 0 && strcasecmp(k, key) == 0)
-			{
-				if (b == 0)
-				{
-					len = 0;
-					buffer[0] = 0;
-				}
-				else
-				{
-					k = (char *)(b + strlen(b) - 1);
-					while ((k >= b) && (*k == ' ' || *k == '\t'))
-					{
-						--k;
-					}
-					*(k+1) = '\0';
+            if (k != 0 && strcasecmp(k, key)==0) {
+                if (b==0) {
+                    len = 0;
+                    buffer[0] = 0;
+                }
+                else {
+                    k = (char *)(b + strlen(b)-1);
+                    while ( (k>=b) && (*k==' ' || *k=='\t') )
+                        --k;
+                    *(k+1) = '\0';
 
-					len = strlen(b);
-					if (len > size - 1)
-					{
-						len = size - 1;
-					}
-					strncpy(buffer, b, len + 1);
-				}
-				break;
-			}
-		}
-	}
+                    len = strlen(b);
+                    if (len > size-1) len = size-1;
+                    strncpy(buffer, b, len+1);
+                }
+                break;
+            }
+        }
+    }
 
-	if (len == 0)
-	{
-		len = strlen(def);
-		strncpy(buffer, def, size);
-	}
+    if (len == 0) {
+        len = strlen(def);
+        strncpy(buffer, def, size);
+    }
 
-	free(line);
+    free(line);
 
-	return len;
+    return len;
 }
 
 int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, QString file)
 {
-	char tmp[16];
-	int i=0;
+  char tmp[16];
+  int i=0;
 
-	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-	sscanf(tmp, "%d", &i);
-	if (tmp[0] == 0)
-	{
-		i = def;
-	}
+  GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+  sscanf(tmp, "%d", &i); if(tmp[0]==0) i=def;
 
-	return i;
+  return i;
 }
 
 float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file)
 {
-	char tmp[16];
-	float f = 0.f;
+    char tmp[16];
+    float f=0.f;
 
-	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-	sscanf(tmp, "%f", &f);
-	if (tmp[0] == 0) { f = def; }
+    GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+    sscanf(tmp, "%f", &f); if(tmp[0]==0) f=def;
 
-	return f;
+    return f;
 }
 
 
@@ -322,610 +270,485 @@ float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float 
 
 int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
 {
-	//input file
-	char sec[32];
-	char ver[32];
-	char comment[256];
-	int commentLen = 0;
+  //input file
+  char sec[32];
+  char ver[32];
+  char comment[256];
+  int commentLen=0;
 
-	//generation
-	long  Length, tpos = 0, tplus, totmp, t, i, j;
-	float x[3] = {0.f, 0.f, 0.f};
-	float MasterTune;
-	constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
-	constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
-	int   MainFilter, HighPass;
+  //generation
+  long  Length, tpos=0, tplus, totmp, t, i, j;
+  float x[3] = {0.f, 0.f, 0.f};
+  float MasterTune;
+  constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
+  constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
+  int   MainFilter, HighPass;
 
-	long  NON, NT, TON, DiON, TDroop=0, DStep;
-	float a, b = 0.f, c = 0.f, d = 0.f, g, TT = 0.f, TL, NL, F1, F2;
-	float TphiStart = 0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
+  long  NON, NT, TON, DiON, TDroop=0, DStep;
+  float a, b=0.f, c=0.f, d=0.f, g, TT=0.f, TL, NL, F1, F2;
+  float TphiStart=0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
 
-	long  BON, BON2, BFStep, BFStep2, botmp;
-	float BdF = 0.f, BdF2 = 0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
+  long  BON, BON2, BFStep, BFStep2, botmp;
+  float BdF=0.f, BdF2=0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
 
-	long  OON, OF1Sync = 0, OF2Sync = 0, OMode, OW1, OW2;
-	float Ophi1, Ophi2, OF1, OF2, OL, Ot = 0 /*PG: init */, OBal1, OBal2, ODrive;
-	float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
-	float Oc0 = 0.0f, Oc1 = 0.0f, Oc2 = 0.0f;
+  long  OON, OF1Sync=0, OF2Sync=0, OMode, OW1, OW2;
+  float Ophi1, Ophi2, OF1, OF2, OL, Ot=0 /*PG: init */, OBal1, OBal2, ODrive;
+  float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
+  float Oc0=0.0f, Oc1=0.0f, Oc2=0.0f;
 
-	float MFfb, MFtmp, MFres, MFin = 0.f, MFout = 0.f;
-	float DownAve;
-	long  DownStart, DownEnd, jj;
-
-
-	if (wavemode == 0) //semi-real-time adjustments if working in memory!!
-	{
-		mem_t = 1.0f;
-		mem_o = 1.0f;
-		mem_n = 1.0f;
-		mem_b = 1.0f;
-		mem_tune = 0.0f;
-		mem_time = 1.0f;
-	}
-
-	//try to read version from input file
-	strcpy(sec, "General");
-	GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
-	ver[9] = 0;
-	if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } //input fail
-	if (ver[11] != '1' && ver[11] != '2') { return 0; } //version fail
+  float MFfb, MFtmp, MFres, MFin=0.f, MFout=0.f;
+  float DownAve;
+  long  DownStart, DownEnd, jj;
 
 
-	//read master parameters
-	GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
-	while ((comment[commentLen] != 0) && (commentLen < 254))
-	{
-		commentLen++;
-	}
-	if (commentLen == 0)
-	{
-		comment[0] = 32; comment[1] = 0; commentLen = 1;
-	}
-	comment[commentLen+1] = 0;
-	commentLen++;
-	if ((commentLen % 2) == 1) { commentLen++; }
+  if(wavemode==0) //semi-real-time adjustments if working in memory!!
+  {
+    mem_t = 1.0f;
+    mem_o = 1.0f;
+    mem_n = 1.0f;
+    mem_b = 1.0f;
+    mem_tune = 0.0f;
+    mem_time = 1.0f;
+  }
 
-	timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
-	if (timestretch < 0.2f) { timestretch = 0.2f; }
-	if (timestretch > 10.f) { timestretch = 10.f; }
-	// the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
-	timestretch *= Fs / 44100.f;
-
-	DGain = 1.0f; //leave this here!
-	DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec, "Level", 0, dsfile)));
-
-	MasterTune = GetPrivateProfileFloat(sec, "Tuning", 0.0, dsfile);
-	MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
-	MainFilter = 2 * GetPrivateProfileInt(sec, "Filter", 0, dsfile);
-	MFres = 0.0101f * GetPrivateProfileFloat(sec, "Resonance", 0.0, dsfile);
-	MFres = static_cast<float>(std::pow(MFres, 0.5f));
-
-	HighPass = GetPrivateProfileInt(sec, "HighPass", 0, dsfile);
-	GetEnv(7, sec, "FilterEnv", dsfile);
+  //try to read version from input file
+  strcpy(sec, "General");
+  GetPrivateProfileString(sec,"Version","",ver,sizeof(ver),dsfile);
+  ver[9]=0;
+  if(strcasecmp(ver, "DrumSynth") != 0) {return 0;} //input fail
+  if(ver[11] != '1' && ver[11] != '2') {return 0;} //version fail
 
 
-	//read noise parameters
-	strcpy(sec, "Noise");
-	chkOn[1] = GetPrivateProfileInt(sec, "On", 0, dsfile);
-	sliLev[1] = GetPrivateProfileInt(sec, "Level", 0, dsfile);
-	NT =  GetPrivateProfileInt(sec, "Slope", 0, dsfile);
-	GetEnv(2, sec, "Envelope", dsfile);
-	NON = chkOn[1];
-	NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
-	if (NT < 0)
-	{
-		a = 1.f + (NT / 105.f);
-		d = -NT / 105.f;
-		g = (1.f + 0.0005f * NT * NT) * NL;
-	}
-	else
-	{
-		a = 1.f;
-		b = -NT / 50.f;
-		c = (float)fabs((float)NT) / 100.f;
-		g = NL;
-	}
+  //read master parameters
+  GetPrivateProfileString(sec,"Comment","",comment,sizeof(comment),dsfile);
+  while((comment[commentLen]!=0) && (commentLen<254)) commentLen++;
+  if(commentLen==0) { comment[0]=32; comment[1]=0; commentLen=1;}
+  comment[commentLen+1]=0; commentLen++;
+  if((commentLen % 2)==1) commentLen++;
 
-	//if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
-	//srand(1); //fixed random sequence
+  timestretch = .01f * mem_time * GetPrivateProfileFloat(sec,"Stretch",100.0,dsfile);
+  if(timestretch<0.2f) timestretch=0.2f;
+  if(timestretch>10.f) timestretch=10.f;
+  // the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
+  timestretch *= Fs / 44100.f;
 
-	//read tone parameters
-	strcpy(sec, "Tone");
-	chkOn[0] = GetPrivateProfileInt(sec, "On", 0, dsfile);
-	TON = chkOn[0];
-	sliLev[0] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
-	GetEnv(1, sec, "Envelope", dsfile);
-	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-	if (fabs(F1) < 0.001f) //to prevent overtone ratio div0
-	{
-		F1 = 0.001f;
-	}
-	F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
-	TDroopRate = GetPrivateProfileFloat(sec, "Droop", 0.f, dsfile);
-	if (TDroopRate > 0.f)
-	{
-		TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
-		TDroopRate = TDroopRate * -4.f / envData[1][MAX];
-		TDroop = 1;
-		F2 = F1 + ((F2 - F1) / (1.f - (float)exp(TDroopRate * envData[1][MAX])));
-		ddF = F1 - F2;
-	}
-	else
-	{
-		ddF = F2 - F1;
-	}
+  DGain = 1.0f; //leave this here!
+  DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec,"Level",0,dsfile)));
 
-	Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; //degrees>radians
+  MasterTune = GetPrivateProfileFloat(sec,"Tuning",0.0,dsfile);
+  MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
+  MainFilter = 2 * GetPrivateProfileInt(sec,"Filter",0,dsfile);
+  MFres = 0.0101f * GetPrivateProfileFloat(sec,"Resonance",0.0,dsfile);
+  MFres = static_cast<float>(std::pow(MFres, 0.5f));
 
-	//read overtone parameters
-	strcpy(sec, "Overtones");
-	chkOn[2] = GetPrivateProfileInt(sec, "On", 0, dsfile);
-	OON = chkOn[2];
-	sliLev[2] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
-	GetEnv(3, sec, "Envelope1", dsfile);
-	GetEnv(4, sec, "Envelope2", dsfile);
-	OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
-	OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-	OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
-	OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
-	OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
-	OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
-	ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
-	OBal2 *= 0.01f;
-	OBal1 = 1.f - OBal2;
-	Ophi1 = Tphi;
-	Ophi2 = Tphi;
-	if (MainFilter == 0)
-	{
-		MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile);
-	}
-	if ((GetPrivateProfileInt(sec, "Track1", 0, dsfile) == 1) && (TON == 1))
-	{
-		OF1Sync = 1;
-		OF1 = OF1 / F1;
-	}
-	if ((GetPrivateProfileInt(sec, "Track2", 0, dsfile) == 1) && (TON == 1))
-	{
-		OF2Sync = 1;
-		OF2 = OF2 / F1;
-	}
+  HighPass = GetPrivateProfileInt(sec,"HighPass",0,dsfile);
+  GetEnv(7, sec, "FilterEnv", dsfile);
 
-	OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
-	OcQ = OcA * OcA;
-	OcF = (1.8f - 0.7f * OcQ) * 0.92f; //multiply by env 2
-	OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
-	Ocf1 = TwoPi / OF1;
-	Ocf2 = TwoPi / OF2;
-	for (i = 0; i < 6; i++)
-	{
-		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
-	}
 
-	//read noise band parameters
-	strcpy(sec, "NoiseBand");
-	chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile);
-	BON = chkOn[3];
-	sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
-	BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-	BPhi = TwoPi / 8.f;
-	GetEnv(5, sec, "Envelope", dsfile);
-	BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-	BQ = (float)BFStep;
-	BQ = BQ * BQ / (10000.f - 6600.f*((float)sqrt(BF) - 0.19f));
-	BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
+  //read noise parameters
+  strcpy(sec, "Noise");
+  chkOn[1] = GetPrivateProfileInt(sec,"On",0,dsfile);
+  sliLev[1] = GetPrivateProfileInt(sec,"Level",0,dsfile);
+  NT =  GetPrivateProfileInt(sec,"Slope",0,dsfile);
+  GetEnv(2, sec, "Envelope", dsfile);
+  NON = chkOn[1];
+  NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
+  if(NT<0)
+  { a = 1.f + (NT / 105.f); d = -NT / 105.f;
+    g = (1.f + 0.0005f * NT * NT) * NL; }
+  else
+  { a = 1.f; b = -NT / 50.f; c = (float)fabs((float)NT) / 100.f; g = NL; }
 
-	strcpy(sec, "NoiseBand2");
-	chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON2 = chkOn[4];
-	sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-	BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
-	BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-	BPhi2 = TwoPi / 8.f;
-	GetEnv(6, sec, "Envelope", dsfile);
-	BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-	BQ2 = (float)BFStep2;
-	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f*((float)sqrt(BF2) - 0.19f));
-	BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
+  //if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
+    //srand(1); //fixed random sequence
 
-	//read distortion parameters
-	strcpy(sec, "Distortion");
-	chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile); DiON = chkOn[5];
-	DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
-	if (DStep == 7) { DStep = 20; }
-	if (DStep == 6) { DStep = 10; }
-	if (DStep == 5) { DStep = 8; }
+   //read tone parameters
+  strcpy(sec, "Tone");
+  chkOn[0] = GetPrivateProfileInt(sec,"On",0,dsfile); TON = chkOn[0];
+  sliLev[0] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
+  GetEnv(1, sec, "Envelope", dsfile);
+  F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
+  if(fabs(F1)<0.001f) F1=0.001f; //to prevent overtone ratio div0
+  F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
+  TDroopRate = GetPrivateProfileFloat(sec,"Droop",0.f,dsfile);
+  if(TDroopRate>0.f)
+  {
+    TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
+    TDroopRate = TDroopRate * -4.f / envData[1][MAX];
+    TDroop = 1;
+    F2 = F1+((F2-F1)/(1.f-(float)exp(TDroopRate * envData[1][MAX])));
+    ddF = F1 - F2;
+  }
+  else ddF = F2-F1;
 
-	clippoint = 32700;
-	DAtten = 1.0f;
+  Tphi = GetPrivateProfileFloat(sec,"Phase",90.f,dsfile) / 57.29578f; //degrees>radians
 
-	if (DiON == 1)
-	{
-		DAtten = DGain * (short)LoudestEnv();
-		if (DAtten > 32700) { clippoint = 32700; }
-		else { clippoint = (short)DAtten; }
-		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
-		DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
-	}
+  //read overtone parameters
+  strcpy(sec, "Overtones");
+  chkOn[2] = GetPrivateProfileInt(sec,"On",0,dsfile); OON = chkOn[2];
+  sliLev[2] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
+  GetEnv(3, sec, "Envelope1", dsfile);
+  GetEnv(4, sec, "Envelope2", dsfile);
+  OMode = GetPrivateProfileInt(sec,"Method",2,dsfile);
+  OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
+  OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F2",120.0,dsfile) / Fs;
+  OW1 = GetPrivateProfileInt(sec,"Wave1",0,dsfile);
+  OW2 = GetPrivateProfileInt(sec,"Wave2",0,dsfile);
+  OBal2 = (float)GetPrivateProfileInt(sec,"Param",50,dsfile);
+  ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
+  OBal2 *= 0.01f;
+  OBal1 = 1.f - OBal2;
+  Ophi1 = Tphi;
+  Ophi2 = Tphi;
+  if(MainFilter==0)
+    MainFilter = GetPrivateProfileInt(sec,"Filter",0,dsfile);
+  if((GetPrivateProfileInt(sec,"Track1",0,dsfile)==1) && (TON==1))
+  { OF1Sync = 1;  OF1 = OF1 / F1; }
+  if((GetPrivateProfileInt(sec,"Track2",0,dsfile)==1) && (TON==1))
+  { OF2Sync = 1;  OF2 = OF2 / F1; }
 
-	//prepare envelopes
-	for (i = 1; i < 8; i++)
-	{
-		envData[i][NEXTT] = 0;
-		envData[i][PNT] = 0;
-	}
-	Length = LongestEnv();
+  OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
+  OcQ = OcA * OcA;
+  OcF = (1.8f - 0.7f * OcQ) * 0.92f; //multiply by env 2
+  OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
+  Ocf1 = TwoPi / OF1;
+  Ocf2 = TwoPi / OF2;
+  for(i=0; i<6; i++) Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
 
-	//allocate the buffer
-	//if(wave!=NULL) free(wave);
-	//wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
-	wave = new int16_t[channels * Length]; //wave memory buffer
-	if (wave == nullptr) { return 0; }
-	wavewords = 0;
+  //read noise band parameters
+  strcpy(sec, "NoiseBand");
+  chkOn[3] = GetPrivateProfileInt(sec,"On",0,dsfile); BON = chkOn[3];
+  sliLev[3] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
+  BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
+  BPhi = TwoPi / 8.f;
+  GetEnv(5, sec, "Envelope", dsfile);
+  BFStep = GetPrivateProfileInt(sec,"dF",50,dsfile);
+  BQ = (float)BFStep;
+  BQ = BQ * BQ / (10000.f-6600.f*((float)sqrt(BF)-0.19f));
+  BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
-	/*
-	if(wavemode==0)
-	{
-	//open output file
-	fp = fopen(wavfile, "wb");
-	if(!fp) {return 3;} //output fail
+  strcpy(sec, "NoiseBand2");
+  chkOn[4] = GetPrivateProfileInt(sec,"On",0,dsfile); BON2 = chkOn[4];
+  sliLev[4] = GetPrivateProfileInt(sec,"Level",128,dsfile);
+  BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
+  BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F",1000.0,dsfile) / Fs;
+  BPhi2 = TwoPi / 8.f;
+  GetEnv(6, sec, "Envelope", dsfile);
+  BFStep2 = GetPrivateProfileInt(sec,"dF",50,dsfile);
+  BQ2 = (float)BFStep2;
+  BQ2 = BQ2 * BQ2 / (10000.f-6600.f*((float)sqrt(BF2)-0.19f));
+  BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
-	 //set up INFO chunk
-	WI.list = 0x5453494C;
-	WI.listLength = 36 + commentLen;
-	WI.info = 0x4F464E49;
-	WI.isft = 0x54465349;
-	WI.isftLength = 16;
-	strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
-	WI.icmt = 0x544D4349;
-	WI.icmtLength = commentLen;
+  //read distortion parameters
+  strcpy(sec, "Distortion");
+  chkOn[5] = GetPrivateProfileInt(sec,"On",0,dsfile); DiON = chkOn[5];
+  DStep = 1 + GetPrivateProfileInt(sec,"Rate",0,dsfile);
+  if(DStep==7) DStep=20;
+  if(DStep==6) DStep=10;
+  if(DStep==5) DStep=8;
 
-	//write WAV header
-	WH.riff = 0x46464952;
-	WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
-	WH.wave = 0x45564157;
-	WH.fmt = 0x20746D66;
-	WH.waveLength = 16;
-	WH.wFormatTag = WAVE_FORMAT_PCM;
-	WH.nChannels = 1;
-	WH.nSamplesPerSec = Fs;
-	WH.nAvgBytesPerSec = 2 * Fs;
-	WH.nBlockAlign = 2;
-	WH.wBitsPerSample = 16;
-	WH.data = 0x61746164;
-	WH.dataLength = 2 * Length;
-	fwrite(&WH, 1, 44, fp);
-	}
-	*/
+  clippoint = 32700;
+  DAtten = 1.0f;
+
+  if(DiON==1)
+  {
+    DAtten = DGain * (short)LoudestEnv();
+    if(DAtten>32700) clippoint=32700; else clippoint=(short)DAtten;
+    DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec,"Bits",0,dsfile)));
+    DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec,"Clipping",0,dsfile)));
+  }
+
+  //prepare envelopes
+  for (i=1;i<8;i++) { envData[i][NEXTT]=0; envData[i][PNT]=0; }
+  Length = LongestEnv();
+
+  //allocate the buffer
+  //if(wave!=NULL) free(wave);
+  //wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
+  wave = new int16_t[channels * Length]; //wave memory buffer
+  if(wave==nullptr) {return 0;}
+  wavewords = 0;
+
+  /*
+  if(wavemode==0)
+  {
+    //open output file
+    fp = fopen(wavfile, "wb");
+    if(!fp) {return 3;} //output fail
+
+     //set up INFO chunk
+    WI.list = 0x5453494C;
+    WI.listLength = 36 + commentLen;
+    WI.info = 0x4F464E49;
+    WI.isft = 0x54465349;
+    WI.isftLength = 16;
+    strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
+    WI.icmt = 0x544D4349;
+    WI.icmtLength = commentLen;
+
+    //write WAV header
+    WH.riff = 0x46464952;
+    WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
+    WH.wave = 0x45564157;
+    WH.fmt = 0x20746D66;
+    WH.waveLength = 16;
+    WH.wFormatTag = WAVE_FORMAT_PCM;
+    WH.nChannels = 1;
+    WH.nSamplesPerSec = Fs;
+    WH.nAvgBytesPerSec = 2 * Fs;
+    WH.nBlockAlign = 2;
+    WH.wBitsPerSample = 16;
+    WH.data = 0x61746164;
+    WH.dataLength = 2 * Length;
+    fwrite(&WH, 1, 44, fp);
+  }
+  */
 
   //generate
-	tpos = 0;
-	while (tpos < Length)
-	{
-		tplus = tpos + 1199;
+  tpos = 0;
+  while(tpos<Length)
+  {
+    tplus = tpos + 1199;
 
-		if (NON == 1) //noise
-		{
-			for (t = tpos; t <= tplus; t++)
-			{
-				if (t < envData[2][NEXTT])
-				{
-					envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
-				}
-				else { UpdateEnv(2, t); }
-				x[2] = x[1];
-				x[1] = x[0];
-				x[0] = (randmax2 * (float)rand()) - 1.f;
-				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
-				DF[t - tpos] = TT * g * envData[2][ENV];
-			}
-			if (t >= envData[2][MAX])
-			{
-				NON = 0;
-			}
-		}
-		else
-		{
-			for (j = 0; j < 1200; j++)
-			{
-				DF[j] = 0.f;
-			}
-		}
+    if(NON==1) //noise
+    {
+      for(t=tpos; t<=tplus; t++)
+      {
+        if(t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
+        else UpdateEnv(2, t);
+        x[2] = x[1];
+        x[1] = x[0];
+        x[0] = (randmax2 * (float)rand()) - 1.f;
+        TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
+        DF[t - tpos] = TT * g * envData[2][ENV];
+      }
+      if(t>=envData[2][MAX]) NON=0;
+    }
+    else {
+        for(j=0; j<1200; j++) DF[j]=0.f;
+    }
 
-		if (TON == 1) //tone
-		{
-			TphiStart = Tphi;
-			if (TDroop == 1)
-			{
-				for (t = tpos; t <= tplus; t++)
-				{
-					phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
-				}
-			}
-			else
-			{
-				for (t = tpos; t <= tplus; t++)
-				{
-					phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
-				}
-			}
-			for (t = tpos; t <= tplus; t++)
-			{
-				totmp = t - tpos;
-				if (t < envData[1][NEXTT])
-				{
-				  envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
-				}
-				else
-				{
-					UpdateEnv(1, t);
-				}
-				Tphi = Tphi + phi[totmp];
-				DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi, TwoPi));//overflow?
-			}
-			if (t >= envData[1][MAX]) { TON=0; }
-		}
-		else for (j = 0; j < 1200; j++) { phi[j] = F2; } //for overtone sync
+    if(TON==1) //tone
+    {
+      TphiStart = Tphi;
+      if(TDroop==1)
+      {
+        for(t=tpos; t<=tplus; t++)
+          phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+      }
+      else
+      {
+        for(t=tpos; t<=tplus; t++)
+          phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
+      }
+      for(t=tpos; t<=tplus; t++)
+      {
+        totmp = t - tpos;
+        if(t < envData[1][NEXTT])
+          envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
+        else UpdateEnv(1, t);
+        Tphi = Tphi + phi[totmp];
+        DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi,TwoPi));//overflow?
+      }
+      if(t>=envData[1][MAX]) TON=0;
+    }
+    else for(j=0; j<1200; j++) phi[j]=F2; //for overtone sync
 
-		if (BON == 1) //noise band 1
-		{
-			for (t = tpos; t <= tplus; t++)
-			{
-				if (t < envData[5][NEXTT])
-				{
-				  envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
-				}
-				else
-				{
-					UpdateEnv(5, t);
-				}
-				if ((t % BFStep) == 0)
-				{
-					BdF = randmax * (float)rand() - 0.5f;
-				}
-				BPhi = BPhi + BF + BQ * BdF;
-				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi, TwoPi)) * envData[5][ENV] * BL;
-			}
-			if (t >= envData[5][MAX]) { BON=0; }
-		}
+    if(BON==1) //noise band 1
+    {
+      for(t=tpos; t<=tplus; t++)
+      {
+        if(t < envData[5][NEXTT])
+          envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
+        else UpdateEnv(5, t);
+        if((t % BFStep) == 0) BdF = randmax * (float)rand() - 0.5f;
+        BPhi = BPhi + BF + BQ * BdF;
+        botmp = t - tpos;
+        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi,TwoPi)) * envData[5][ENV] * BL;
+      }
+      if(t>=envData[5][MAX]) BON=0;
+    }
 
-		if (BON2 == 1) //noise band 2
-		{
-			for (t = tpos; t <= tplus; t++)
-			{
-				if (t < envData[6][NEXTT])
-				{
-					envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
-				}
-				else
-				{
-					UpdateEnv(6, t);
-				}
-				if ((t % BFStep2) == 0)
-				{
-					BdF2 = randmax * (float)rand() - 0.5f;
-				}
-				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
-				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2, TwoPi)) * envData[6][ENV] * BL2;
-			}
-			if (t >= envData[6][MAX])
-			{
-				BON2 = 0;
-			}
-		}
+    if(BON2==1) //noise band 2
+    {
+      for(t=tpos; t<=tplus; t++)
+      {
+        if(t < envData[6][NEXTT])
+          envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
+        else UpdateEnv(6, t);
+        if((t % BFStep2) == 0) BdF2 = randmax * (float)rand() - 0.5f;
+        BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
+        botmp = t - tpos;
+        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2,TwoPi)) * envData[6][ENV] * BL2;
+      }
+      if(t>=envData[6][MAX]) BON2=0;
+    }
 
 
-		for (t = tpos; t <= tplus; t++)
-		{
-			if (OON == 1) //overtones
-			{
-				if (t < envData[3][NEXTT])
-				{
-					envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
-				}
-				else
-				{
-					if (t >= envData[3][MAX]) //wait for OT2
-					{
-						envData[3][ENV] = 0;
-						envData[3][dENV] = 0;
-						envData[3][NEXTT] = 999999;
-					}
-					else { UpdateEnv(3, t); }
-				}
-				//
-				if (t < envData[4][NEXTT])
-					envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
-				else
-				{
-					if (t >= envData[4][MAX]) //wait for OT1
-					{
-					envData[4][ENV] = 0;
-					envData[4][dENV] = 0;
-					envData[4][NEXTT] = 999999;
-					}
-					else { UpdateEnv(4, t); }
-				}
-				//
-				TphiStart = TphiStart + phi[t - tpos];
-				if (OF1Sync == 1)
-				{
-					Ophi1 = TphiStart * OF1;
-				}
-				else
-				{
-					Ophi1 = Ophi1 + OF1;
-				}
-				if (OF2Sync == 1)
-				{
-					Ophi2 = TphiStart * OF2;
-				}
-				else
-				{
-					Ophi2 = Ophi2 + OF2;
-				}
-				Ot = 0.0f;
-				switch (OMode)
-				{
-					case 0: //add
-						Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
-						Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
-						break;
+    for (t=tpos; t<=tplus; t++)
+    {
+      if(OON==1) //overtones
+      {
+        if(t<envData[3][NEXTT])
+          envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+        else
+        {
+          if(t>=envData[3][MAX]) //wait for OT2
+          {
+            envData[3][ENV] = 0;
+            envData[3][dENV] = 0;
+            envData[3][NEXTT] = 999999;
+          }
+          else UpdateEnv(3, t);
+        }
+        //
+        if(t<envData[4][NEXTT])
+          envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
+        else
+        {
+          if(t>=envData[4][MAX]) //wait for OT1
+          {
+            envData[4][ENV] = 0;
+            envData[4][dENV] = 0;
+            envData[4][NEXTT] = 999999;
+          }
+          else UpdateEnv(4, t);
+        }
+        //
+        TphiStart = TphiStart + phi[t - tpos];
+        if(OF1Sync==1) Ophi1 = TphiStart * OF1; else Ophi1 = Ophi1 + OF1;
+        if(OF2Sync==1) Ophi2 = TphiStart * OF2; else Ophi2 = Ophi2 + OF2;
+        Ot=0.0f;
+        switch (OMode)
+        {
+          case 0: //add
+            Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
+            Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
+            break;
 
-					case 1: //FM
-						Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
-						Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
-						break;
+          case 1: //FM
+            Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
+            Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
+            break;
 
-					case 2: //RM
-						Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
-						Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
-						break;
+          case 2: //RM
+            Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
+            Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
+            break;
 
-					case 3: //808 Cymbal
-						for (j = 0; j < 6; j++)
-						{
-							Oc[j][0] += 1.0f;
+          case 3: //808 Cymbal
+            for(j=0; j<6; j++)
+            {
+              Oc[j][0] += 1.0f;
 
-							if (Oc[j][0] > Oc[j][1])
-							{
-								Oc[j][0] -= Oc[j][1];
-								Ot = OL * envData[3][ENV];
-							}
-						}
-						Ocf1 = envData[4][ENV] * OcF;  //filter freq
-						Oc0 += Ocf1 * Oc1;
-						Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0);  //bpf
-						Oc2 = Ot;
-						Ot = Oc1;
-						break;
-				}
-			}
+              if(Oc[j][0]>Oc[j][1])
+              {
+                Oc[j][0] -= Oc[j][1];
+                Ot = OL * envData[3][ENV];
+              }
+            }
+            Ocf1 = envData[4][ENV] * OcF;  //filter freq
+            Oc0 += Ocf1 * Oc1;
+            Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0);  //bpf
+            Oc2 = Ot;
+            Ot = Oc1;
+            break;
+        }
+      }
 
-			if (MainFilter == 1) //filter overtones
-			{
-				if (t < envData[7][NEXTT])
-				{
-					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-				}
-				else { UpdateEnv(7, t); }
+      if(MainFilter==1) //filter overtones
+      {
+        if(t<envData[7][NEXTT])
+          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+        else UpdateEnv(7, t);
 
-				MFtmp = envData[7][ENV];
-				if (MFtmp >0.2f)
-				{
-					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-				}
-				else
-				{
-					MFfb = 0.999f - 0.7824f * MFtmp;
-				}
+        MFtmp = envData[7][ENV];
+        if(MFtmp >0.2f)
+          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+        else
+          MFfb = 0.999f - 0.7824f * MFtmp;
 
-				MFtmp = Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-				MFin = MFfb * (MFin - MFtmp) + MFtmp;
-				MFout = MFfb * (MFout - MFin) + MFin;
+        MFtmp = Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
+        MFin = MFfb * (MFin - MFtmp) + MFtmp;
+        MFout = MFfb * (MFout - MFin) + MFin;
 
-				DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
-			}
-			else if (MainFilter == 2) //filter all
-			{
-				if (t < envData[7][NEXTT])
-				{
-					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-				}
-				else { UpdateEnv(7, t); }
+        DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
+      }
+      else if(MainFilter==2) //filter all
+      {
+        if(t<envData[7][NEXTT])
+          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+        else UpdateEnv(7, t);
 
-				MFtmp = envData[7][ENV];
-				if (MFtmp > 0.2f)
-				{
-					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-				}
-				else
-				{
-					MFfb = 0.999f - 0.7824f * MFtmp;
-				}
+        MFtmp = envData[7][ENV];
+        if(MFtmp >0.2f)
+          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+        else
+          MFfb = 0.999f - 0.7824f * MFtmp;
 
-				MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-				MFin = MFfb * (MFin - MFtmp) + MFtmp;
-				MFout = MFfb * (MFout - MFin) + MFin;
+        MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
+        MFin = MFfb * (MFin - MFtmp) + MFtmp;
+        MFout = MFfb * (MFout - MFin) + MFin;
 
-				DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
-			}
-			// PG: Ot is uninitialized
-			else
-			{
-				DF[t - tpos] = DF[t - tpos] + Ot; //no filter
-			}
-		}
+        DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
+      }
+      // PG: Ot is uninitialized
+      else DF[t - tpos] = DF[t - tpos] + Ot; //no filter
+    }
 
-		if (DiON == 1) //bit resolution
-		{
-			for (j = 0; j < 1200; j++)
-			{
-				DF[j] = DGain * (int)(DF[j] / DAtten);
-			}
+    if(DiON==1) //bit resolution
+    {
+      for(j=0; j<1200; j++)
+        DF[j] = DGain * (int)(DF[j] / DAtten);
 
-			for (j = 0; j < 1200; j += DStep) //downsampling
-			{
-				DownAve = 0;
-				DownStart = j;
-				DownEnd = j + DStep - 1;
-				for (jj = DownStart; jj <= DownEnd; jj++)
-				{
-					DownAve = DownAve + DF[jj];
-				}
-				DownAve = DownAve / DStep;
-				for (jj = DownStart; jj <= DownEnd; jj++)
-				{
-					DF[jj] = DownAve;
-				}
-			}
-		}
-		else for (j = 0; j < 1200; j++)
-		{
-			DF[j] *= DGain;
-		}
+      for(j=0; j<1200; j+=DStep) //downsampling
+      {
+        DownAve = 0;
+        DownStart = j;
+        DownEnd = j + DStep - 1;
+        for(jj = DownStart; jj<=DownEnd; jj++)
+          DownAve = DownAve + DF[jj];
+        DownAve = DownAve / DStep;
+        for(jj = DownStart; jj<=DownEnd; jj++)
+          DF[jj] = DownAve;
+      }
+    }
+    else for(j=0; j<1200; j++) DF[j] *= DGain;
 
-		for (j = 0; j < 1200; j++) //clipping + output
-		{
-			if (DF[j] > clippoint)
-			{
-				wave[wavewords++] = clippoint;
-			}
-			else if (DF[j] < -clippoint)
-			{
-				wave[wavewords++] = -clippoint;
-			}
-			else
-			{
-				wave[wavewords++] = (short)DF[j];
-			}
+    for(j = 0; j<1200; j++) //clipping + output
+    {
+      if(DF[j] > clippoint)
+        wave[wavewords++] = clippoint;
+      else if(DF[j] < -clippoint)
+          wave[wavewords++] = -clippoint;
+      else
+          wave[wavewords++] = (short)DF[j];
 
-			for (int c = 1; c < channels; c++)
-			{
-				wave[wavewords] = wave[wavewords-1];
-				wavewords++;
-			}
-		}
+      for (int c = 1; c < channels; c++)  {
+        wave[wavewords] = wave[wavewords-1];
+        wavewords++;
+      }
+    }
 
-		tpos = tpos + 1200;
-	}
+    tpos = tpos + 1200;
+  }
 
-	/*
-	if(wavemode==0)
-	{
-		fwrite(wave, 2, Length, fp);  //write data
-		fwrite(&WI,  1, 44, fp); //write INFO chunk
-		fwrite(&comment, 1, commentLen, fp);
-		fclose(fp);
-	}
-	wavemode = 0; //force compatibility!!
-	*/
+  /*
+  if(wavemode==0)
+  {
+    fwrite(wave, 2, Length, fp);  //write data
+    fwrite(&WI,  1, 44, fp); //write INFO chunk
+    fwrite(&comment, 1, commentLen, fp);
+    fclose(fp);
+  }
+  wavemode = 0; //force compatibility!!
+  */
 
 
-	return Length;
+  return Length;
 }
 
 

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -69,204 +69,249 @@ float mem_t = 1.0f, mem_o = 1.0f, mem_n = 1.0f, mem_b = 1.0f, mem_tune = 1.0f, m
 
 int DrumSynth::LongestEnv()
 {
-  long e, eon, p;
-  float l = 0.f;
+	long e, eon, p;
+	float l = 0.f;
 
-  for (e = 1; e < 7; e++) //3
-  {
-    eon = e - 1; if (eon > 2) { eon = eon - 1; }
-    p = 0;
-    while (envpts[e][0][p + 1] >= 0.f) { p++; }
-    envData[e][MAX] = envpts[e][0][p] * timestretch;
-    if (chkOn[eon] == 1) if (envData[e][MAX] > l) { l = envData[e][MAX]; }
-  }
-  //l *= timestretch;
+	for (e = 1; e < 7; e++) //3
+	{
+		eon = e - 1;
+		if (eon > 2)
+		{
+			eon = eon - 1;
+		}
+		p = 0;
+		while (envpts[e][0][p + 1] >= 0.f)
+		{
+			p++;
+		}
+		envData[e][MAX] = envpts[e][0][p] * timestretch;
+		if (chkOn[eon] == 1 && envData[e][MAX] > l)
+		{
+			l = envData[e][MAX];
+		}
+	}
+	//l *= timestretch;
 
-  return 2400 + (1200 * (int)(l / 1200));
+	return 2400 + (1200 * (int)(l / 1200));
 }
 
 
 float DrumSynth::LoudestEnv()
 {
-  float loudest = 0.f;
-  int i = 0;
+	float loudest = 0.f;
+	int i = 0;
 
-  while (i < 5) //2
-  {
-    if (chkOn[i] == 1) if (sliLev[i] > loudest) loudest = (float)sliLev[i];
-    i++;
-  }
-  return (loudest * loudest);
+	while (i < 5) //2
+	{
+		if (chkOn[i] == 1 && sliLev[i] > loudest)
+		{
+			loudest = (float)sliLev[i];
+		}
+		i++;
+	}
+	return (loudest * loudest);
 }
 
 
 void DrumSynth::UpdateEnv(int e, long t)
 {
-  float endEnv, dT;
-                                                             //0.2's added
-  envData[e][NEXTT] = envpts[e][0][(long)(envData[e][PNT] + 1.f)] * timestretch; //get next point
-  if(envData[e][NEXTT] < 0) envData[e][NEXTT] = 442000 * timestretch; //if end point, hold
-  envData[e][ENV] = envpts[e][1][(long)(envData[e][PNT] + 0.f)] * 0.01f; //this level
-  endEnv = envpts[e][1][(long)(envData[e][PNT] + 1.f)] * 0.01f;          //next level
-  dT = envData[e][NEXTT] - (float)t;
-  if(dT < 1.0) dT = 1.0;
-  envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
-  envData[e][PNT] = envData[e][PNT] + 1.0f;
+	float endEnv, dT;
+															 //0.2's added
+	envData[e][NEXTT] = envpts[e][0][(long)(envData[e][PNT] + 1.f)] * timestretch; //get next point
+	if (envData[e][NEXTT] < 0)
+	{
+		envData[e][NEXTT] = 442000 * timestretch; //if end point, hold
+	}
+	envData[e][ENV] = envpts[e][1][(long)(envData[e][PNT] + 0.f)] * 0.01f; //this level
+	endEnv = envpts[e][1][(long)(envData[e][PNT] + 1.f)] * 0.01f;          //next level
+	dT = envData[e][NEXTT] - (float)t;
+	if (dT < 1.0) { dT = 1.0; }
+	envData[e][dENV] = (endEnv - envData[e][ENV]) / dT;
+	envData[e][PNT] = envData[e][PNT] + 1.0f;
 }
 
 
 void DrumSynth::GetEnv(int env, const char *sec, const char *key, QString ini)
 {
-  char en[256], s[8];
-  int i = 0, o = 0, ep = 0;
-  GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
+	char en[256], s[8];
+	int i = 0, o = 0, ep = 0;
+	GetPrivateProfileString(sec, key, "0,0 100,0", en, sizeof(en), ini);
 
-  //be safe!
-  en[255] = 0;
-  s[0] = 0;
+	//be safe!
+	en[255] = 0;
+	s[0] = 0;
 
-  while (en[i] != 0)
-  {
-    if (en[i] == ',')
-    {
-      if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
-      o = 0;
-    }
-    else if (en[i] == ' ')
-    {
-      if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) { envpts[env][1][ep] = 0.f; }
-      o = 0; ep++;
-    }
-    else { s[o] = en[i]; o++; s[o] = 0; }
-    i++;
-  }
-  if (sscanf(s, "%f", &envpts[env][1][ep]) == 0) envpts[env][1][ep] = 0.f;
-  envpts[env][0][ep + 1] = -1;
+	while (en[i] != 0)
+	{
+		if (en[i] == ',')
+		{
+			if (sscanf(s, "%f", &envpts[env][0][ep]) == 0) { envpts[env][0][ep] = 0.f; }
+			o = 0;
+		}
+		else if (en[i] == ' ')
+		{
+			if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
+			{
+				envpts[env][1][ep] = 0.f;
+			}
+			o = 0;
+			ep++;
+		}
+		else
+		{
+			s[o] = en[i];
+			o++;
+			s[o] = 0;
+		}
+		i++;
+	}
+	if (sscanf(s, "%f", &envpts[env][1][ep]) == 0)
+	{
+		envpts[env][1][ep] = 0.f;
+	}
+	envpts[env][0][ep + 1] = -1;
 
-  envData[env][MAX] = envpts[env][0][ep];
+	envData[env][MAX] = envpts[env][0][ep];
 }
 
 
 float DrumSynth::waveform(float ph, int form)
 {
-  float w;
+	float w;
 
-  switch (form)
-  {
-     case 0: w = (float)sin(fmod(ph,TwoPi));                            break; //sine
-     case 1: w = (float)fabs(2.0f*(float)sin(fmod(0.5f*ph, TwoPi))) - 1.f; break; //sine^2
-     case 2: while(ph<TwoPi) ph+=TwoPi;
-             w = 0.6366197f * (float)fmod(ph,TwoPi) - 1.f;                     //tri
-             if(w>1.f) w=2.f-w;
-             break;
-     case 3: w = ph - TwoPi * (float)(int)(ph / TwoPi);                        //saw
-             w = (0.3183098f * w) - 1.f;                                break;
-    default: w = (sin(fmod(ph,TwoPi))>0.0)? 1.f: -1.f;                  break; //square
-  }
+	switch (form)
+	{
+		case 0:
+			w = (float)sin(fmod(ph, TwoPi));
+			break; //sine
+		case 1:
+			w = (float)fabs(2.0f*(float)sin(fmod(0.5f*ph, TwoPi))) - 1.f;
+			break; //sine^2
+		case 2:
+			while (ph < TwoPi) { ph+=TwoPi; }
+			w = 0.6366197f * (float)fmod(ph, TwoPi) - 1.f;   //tri
+			if (w > 1.f) { w = 2.f - w; }
+			break;
+		case 3:
+			w = ph - TwoPi * (float)(int)(ph / TwoPi);      //saw
+			w = (0.3183098f * w) - 1.f;
+			break;
+		default:
+			w = (sin(fmod(ph, TwoPi)) > 0.0)? 1.f: -1.f;
+			break; //square
+	}
 
-  return w;
+	return w;
 }
 
 
 int DrumSynth::GetPrivateProfileString(const char *sec, const char *key, const char *def, char *buffer, int size, QString file)
 {
-    stringstream is;
-    bool inSection = false;
-    char *line;
-    char *k, *b;
-    int len = 0;
+	stringstream is;
+	bool inSection = false;
+	char *line;
+	char *k, *b;
+	int len = 0;
 
-    line = (char*)malloc(200);
+	char* line = static_cast<char*>(malloc(200));
 
-    // Use QFile to handle unicode file name on Windows
-    // Previously we used ifstream directly
-    QFile f(file);
-    f.open(QIODevice::ReadOnly);
-    QByteArray dat = f.readAll().constData();
-    is.str(string(dat.constData(), dat.size()));
+	// Use QFile to handle unicode file name on Windows
+	// Previously we used ifstream directly
+	QFile f(file);
+	f.open(QIODevice::ReadOnly);
+	QByteArray dat = f.readAll().constData();
+	is.str(string(dat.constData(), dat.size()));
 
-    while (is.good())
+	while (is.good())
 	{
-        if (!inSection)
+		if (!inSection)
 		{
-            is.ignore(numeric_limits<streamsize>::max(), '[');
+			is.ignore(numeric_limits<streamsize>::max(), '[');
 
-            if (!is.eof())
+			if (!is.eof())
 			{
-                is.getline(line, 200, ']');
-                if (strcasecmp(line, sec) == 0)
+				is.getline(line, 200, ']');
+				if (strcasecmp(line, sec) == 0)
 				{
-                    inSection = true;
-                }
-            }
-        }
-        else if (!is.eof())
+					inSection = true;
+				}
+			}
+		}
+		else if (!is.eof())
 		{
-            is.getline(line, 200);
-            if (line[0] == '[')
+			is.getline(line, 200);
+			if (line[0] == '[')
 			{
-                break;
+				break;
 			}
 
-            k = strtok(line, " \t=");
-            b = strtok(nullptr, "\n\r\0");
+			char* k = strtok(line, " \t=");
+			char* b = strtok(nullptr, "\n\r\0");
 
-            if (k != 0 && strcasecmp(k, key) == 0)
+			if (k != 0 && strcasecmp(k, key) == 0)
 			{
-                if (b == 0)
+				if (b == 0)
 				{
-                    len = 0;
-                    buffer[0] = 0;
-                }
-                else
+					len = 0;
+					buffer[0] = 0;
+				}
+				else
 				{
-                    k = (char *)(b + strlen(b) - 1);
-                    while ((k>=b) && (*k == ' ' || *k == '\t'))
+					k = (char *)(b + strlen(b) - 1);
+					while ((k >= b) && (*k == ' ' || *k == '\t'))
 					{
-                        --k;
+						--k;
 					}
-                    *(k+1) = '\0';
+					*(k+1) = '\0';
 
-                    len = strlen(b);
-                    if (len > size - 1) { len = size - 1; }
-                    strncpy(buffer, b, len + 1);
-                }
-                break;
-            }
-        }
-    }
+					len = strlen(b);
+					if (len > size - 1)
+					{
+						len = size - 1;
+					}
+					strncpy(buffer, b, len + 1);
+				}
+				break;
+			}
+		}
+	}
 
-    if (len == 0)
+	if (len == 0)
 	{
-        len = strlen(def);
-        strncpy(buffer, def, size);
-    }
+		len = strlen(def);
+		strncpy(buffer, def, size);
+	}
 
-    free(line);
+	free(line);
 
-    return len;
+	return len;
 }
 
 int DrumSynth::GetPrivateProfileInt(const char *sec, const char *key, int def, QString file)
 {
-  char tmp[16];
-  int i=0;
+	char tmp[16];
+	int i=0;
 
-  GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-  sscanf(tmp, "%d", &i); if (tmp[0] == 0) { i = def; }
+	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+	sscanf(tmp, "%d", &i);
+	if (tmp[0] == 0)
+	{
+		i = def;
+	}
 
-  return i;
+	return i;
 }
 
 float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float def, QString file)
 {
-    char tmp[16];
-    float f=0.f;
+	char tmp[16];
+	float f = 0.f;
 
-    GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
-    sscanf(tmp, "%f", &f); if (tmp[0] == 0) { f = def; }
+	GetPrivateProfileString(sec, key, "", tmp, sizeof(tmp), file);
+	sscanf(tmp, "%f", &f);
+	if (tmp[0] == 0) { f = def; }
 
-    return f;
+	return f;
 }
 
 
@@ -277,515 +322,610 @@ float DrumSynth::GetPrivateProfileFloat(const char *sec, const char *key, float 
 
 int DrumSynth::GetDSFileSamples(QString dsfile, int16_t *&wave, int channels, sample_rate_t Fs)
 {
-  //input file
-  char sec[32];
-  char ver[32];
-  char comment[256];
-  int commentLen = 0;
+	//input file
+	char sec[32];
+	char ver[32];
+	char comment[256];
+	int commentLen = 0;
 
-  //generation
-  long  Length, tpos = 0, tplus, totmp, t, i, j;
-  float x[3] = {0.f, 0.f, 0.f};
-  float MasterTune;
-  constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
-  constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
-  int   MainFilter, HighPass;
+	//generation
+	long  Length, tpos = 0, tplus, totmp, t, i, j;
+	float x[3] = {0.f, 0.f, 0.f};
+	float MasterTune;
+	constexpr float randmax = 1.f / static_cast<float>(RAND_MAX);
+	constexpr float randmax2 = 2.f / static_cast<float>(RAND_MAX);
+	int   MainFilter, HighPass;
 
-  long  NON, NT, TON, DiON, TDroop=0, DStep;
-  float a, b = 0.f, c = 0.f, d = 0.f, g, TT = 0.f, TL, NL, F1, F2;
-  float TphiStart = 0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
+	long  NON, NT, TON, DiON, TDroop=0, DStep;
+	float a, b = 0.f, c = 0.f, d = 0.f, g, TT = 0.f, TL, NL, F1, F2;
+	float TphiStart = 0.f, Tphi, TDroopRate, ddF, DAtten, DGain;
 
-  long  BON, BON2, BFStep, BFStep2, botmp;
-  float BdF = 0.f, BdF2 = 0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
+	long  BON, BON2, BFStep, BFStep2, botmp;
+	float BdF = 0.f, BdF2 = 0.f, BPhi, BPhi2, BF, BF2, BQ, BQ2, BL, BL2;
 
-  long  OON, OF1Sync = 0, OF2Sync = 0, OMode, OW1, OW2;
-  float Ophi1, Ophi2, OF1, OF2, OL, Ot = 0 /*PG: init */, OBal1, OBal2, ODrive;
-  float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
-  float Oc0 = 0.0f, Oc1 = 0.0f, Oc2 = 0.0f;
+	long  OON, OF1Sync = 0, OF2Sync = 0, OMode, OW1, OW2;
+	float Ophi1, Ophi2, OF1, OF2, OL, Ot = 0 /*PG: init */, OBal1, OBal2, ODrive;
+	float Ocf1, Ocf2, OcF, OcQ, OcA, Oc[6][2];  //overtone cymbal mode
+	float Oc0 = 0.0f, Oc1 = 0.0f, Oc2 = 0.0f;
 
-  float MFfb, MFtmp, MFres, MFin = 0.f, MFout = 0.f;
-  float DownAve;
-  long  DownStart, DownEnd, jj;
-
-
-  if (wavemode == 0) //semi-real-time adjustments if working in memory!!
-  {
-    mem_t = 1.0f;
-    mem_o = 1.0f;
-    mem_n = 1.0f;
-    mem_b = 1.0f;
-    mem_tune = 0.0f;
-    mem_time = 1.0f;
-  }
-
-  //try to read version from input file
-  strcpy(sec, "General");
-  GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
-  ver[9] = 0;
-  if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } //input fail
-  if (ver[11] != '1' && ver[11] != '2') { return 0; } //version fail
+	float MFfb, MFtmp, MFres, MFin = 0.f, MFout = 0.f;
+	float DownAve;
+	long  DownStart, DownEnd, jj;
 
 
-  //read master parameters
-  GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
-  while ((comment[commentLen] != 0) && (commentLen < 254)) { commentLen++; }
-  if (commentLen == 0) { comment[0] = 32; comment[1] = 0; commentLen = 1; }
-  comment[commentLen+1] = 0; commentLen++;
-  if ((commentLen % 2) == 1) { commentLen++; }
+	if (wavemode == 0) //semi-real-time adjustments if working in memory!!
+	{
+		mem_t = 1.0f;
+		mem_o = 1.0f;
+		mem_n = 1.0f;
+		mem_b = 1.0f;
+		mem_tune = 0.0f;
+		mem_time = 1.0f;
+	}
 
-  timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
-  if (timestretch < 0.2f) { timestretch = 0.2f; }
-  if (timestretch > 10.f) { timestretch = 10.f; }
-  // the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
-  timestretch *= Fs / 44100.f;
-
-  DGain = 1.0f; //leave this here!
-  DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec, "Level", 0, dsfile)));
-
-  MasterTune = GetPrivateProfileFloat(sec, "Tuning", 0.0, dsfile);
-  MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
-  MainFilter = 2 * GetPrivateProfileInt(sec, "Filter", 0, dsfile);
-  MFres = 0.0101f * GetPrivateProfileFloat(sec, "Resonance", 0.0, dsfile);
-  MFres = static_cast<float>(std::pow(MFres, 0.5f));
-
-  HighPass = GetPrivateProfileInt(sec, "HighPass", 0, dsfile);
-  GetEnv(7, sec, "FilterEnv", dsfile);
+	//try to read version from input file
+	strcpy(sec, "General");
+	GetPrivateProfileString(sec, "Version", "", ver, sizeof(ver), dsfile);
+	ver[9] = 0;
+	if (strcasecmp(ver, "DrumSynth") != 0) { return 0; } //input fail
+	if (ver[11] != '1' && ver[11] != '2') { return 0; } //version fail
 
 
-  //read noise parameters
-  strcpy(sec, "Noise");
-  chkOn[1] = GetPrivateProfileInt(sec, "On", 0, dsfile);
-  sliLev[1] = GetPrivateProfileInt(sec,"Level", 0, dsfile);
-  NT =  GetPrivateProfileInt(sec,"Slope", 0, dsfile);
-  GetEnv(2, sec, "Envelope", dsfile);
-  NON = chkOn[1];
-  NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
-  if (NT < 0)
-  { a = 1.f + (NT / 105.f); d = -NT / 105.f;
-    g = (1.f + 0.0005f * NT * NT) * NL; }
-  else
-  { a = 1.f; b = -NT / 50.f; c = (float)fabs((float)NT) / 100.f; g = NL; }
+	//read master parameters
+	GetPrivateProfileString(sec, "Comment", "", comment, sizeof(comment), dsfile);
+	while ((comment[commentLen] != 0) && (commentLen < 254))
+	{
+		commentLen++;
+	}
+	if (commentLen == 0)
+	{
+		comment[0] = 32; comment[1] = 0; commentLen = 1;
+	}
+	comment[commentLen+1] = 0;
+	commentLen++;
+	if ((commentLen % 2) == 1) { commentLen++; }
 
-  //if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
-    //srand(1); //fixed random sequence
+	timestretch = .01f * mem_time * GetPrivateProfileFloat(sec, "Stretch", 100.0, dsfile);
+	if (timestretch < 0.2f) { timestretch = 0.2f; }
+	if (timestretch > 10.f) { timestretch = 10.f; }
+	// the unit of envelope lengths is a sample in 44100Hz sample rate, so correct it
+	timestretch *= Fs / 44100.f;
 
-   //read tone parameters
-  strcpy(sec, "Tone");
-  chkOn[0] = GetPrivateProfileInt(sec,"On",0,dsfile); TON = chkOn[0];
-  sliLev[0] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
-  GetEnv(1, sec, "Envelope", dsfile);
-  F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec,"F1",200.0,dsfile) / Fs;
-  if (fabs(F1) < 0.001f) { F1 = 0.001f; } //to prevent overtone ratio div0
-  F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
-  TDroopRate = GetPrivateProfileFloat(sec,"Droop",0.f,dsfile);
-  if (TDroopRate > 0.f)
-  {
-    TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
-    TDroopRate = TDroopRate * -4.f / envData[1][MAX];
-    TDroop = 1;
-    F2 = F1 + ((F2 - F1)/(1.f - (float)exp(TDroopRate * envData[1][MAX])));
-    ddF = F1 - F2;
-  }
-  else { ddF = F2 - F1; }
+	DGain = 1.0f; //leave this here!
+	DGain = static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileFloat(sec, "Level", 0, dsfile)));
 
-  Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; //degrees>radians
+	MasterTune = GetPrivateProfileFloat(sec, "Tuning", 0.0, dsfile);
+	MasterTune = static_cast<float>(std::pow(1.0594631f, MasterTune + mem_tune));
+	MainFilter = 2 * GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	MFres = 0.0101f * GetPrivateProfileFloat(sec, "Resonance", 0.0, dsfile);
+	MFres = static_cast<float>(std::pow(MFres, 0.5f));
 
-  //read overtone parameters
-  strcpy(sec, "Overtones");
-  chkOn[2] = GetPrivateProfileInt(sec,"On",0,dsfile); OON = chkOn[2];
-  sliLev[2] = GetPrivateProfileInt(sec,"Level",128,dsfile);
-  OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
-  GetEnv(3, sec, "Envelope1", dsfile);
-  GetEnv(4, sec, "Envelope2", dsfile);
-  OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
-  OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-  OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
-  OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
-  OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
-  OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
-  ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
-  OBal2 *= 0.01f;
-  OBal1 = 1.f - OBal2;
-  Ophi1 = Tphi;
-  Ophi2 = Tphi;
-  if (MainFilter == 0)
-  { MainFilter = GetPrivateProfileInt(sec,"Filter",0,dsfile); }
-  if ((GetPrivateProfileInt(sec,"Track1",0,dsfile) == 1) && (TON == 1))
-  { OF1Sync = 1;  OF1 = OF1 / F1; }
-  if ((GetPrivateProfileInt(sec,"Track2",0,dsfile) == 1) && (TON == 1))
-  { OF2Sync = 1;  OF2 = OF2 / F1; }
+	HighPass = GetPrivateProfileInt(sec, "HighPass", 0, dsfile);
+	GetEnv(7, sec, "FilterEnv", dsfile);
 
-  OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
-  OcQ = OcA * OcA;
-  OcF = (1.8f - 0.7f * OcQ) * 0.92f; //multiply by env 2
-  OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
-  Ocf1 = TwoPi / OF1;
-  Ocf2 = TwoPi / OF2;
-  for (i = 0; i < 6; i++)
-  { Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i; }
 
-  //read noise band parameters
-  strcpy(sec, "NoiseBand");
-  chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON = chkOn[3];
-  sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-  BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
-  BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-  BPhi = TwoPi / 8.f;
-  GetEnv(5, sec, "Envelope", dsfile);
-  BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-  BQ = (float)BFStep;
-  BQ = BQ * BQ / (10000.f - 6600.f*((float)sqrt(BF) - 0.19f));
-  BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
+	//read noise parameters
+	strcpy(sec, "Noise");
+	chkOn[1] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	sliLev[1] = GetPrivateProfileInt(sec, "Level", 0, dsfile);
+	NT =  GetPrivateProfileInt(sec, "Slope", 0, dsfile);
+	GetEnv(2, sec, "Envelope", dsfile);
+	NON = chkOn[1];
+	NL = (float)(sliLev[1] * sliLev[1]) * mem_n;
+	if (NT < 0)
+	{
+		a = 1.f + (NT / 105.f);
+		d = -NT / 105.f;
+		g = (1.f + 0.0005f * NT * NT) * NL;
+	}
+	else
+	{
+		a = 1.f;
+		b = -NT / 50.f;
+		c = (float)fabs((float)NT) / 100.f;
+		g = NL;
+	}
 
-  strcpy(sec, "NoiseBand2");
-  chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON2 = chkOn[4];
-  sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
-  BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
-  BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-  BPhi2 = TwoPi / 8.f;
-  GetEnv(6, sec, "Envelope", dsfile);
-  BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
-  BQ2 = (float)BFStep2;
-  BQ2 = BQ2 * BQ2 / (10000.f - 6600.f*((float)sqrt(BF2) - 0.19f));
-  BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
+	//if(GetPrivateProfileInt(sec,"FixedSeq",0,dsfile)!=0)
+	//srand(1); //fixed random sequence
 
-  //read distortion parameters
-  strcpy(sec, "Distortion");
-  chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile); DiON = chkOn[5];
-  DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
-  if (DStep == 7) { DStep = 20; }
-  if (DStep == 6) { DStep = 10; }
-  if (DStep == 5) { DStep = 8; }
+	//read tone parameters
+	strcpy(sec, "Tone");
+	chkOn[0] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	TON = chkOn[0];
+	sliLev[0] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	TL = (float)(sliLev[0] * sliLev[0]) * mem_t;
+	GetEnv(1, sec, "Envelope", dsfile);
+	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	if (fabs(F1) < 0.001f) //to prevent overtone ratio div0
+	{
+		F1 = 0.001f;
+	}
+	F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	TDroopRate = GetPrivateProfileFloat(sec, "Droop", 0.f, dsfile);
+	if (TDroopRate > 0.f)
+	{
+		TDroopRate = static_cast<float>(std::pow(10.0f, (TDroopRate - 20.0f) / 30.0f));
+		TDroopRate = TDroopRate * -4.f / envData[1][MAX];
+		TDroop = 1;
+		F2 = F1 + ((F2 - F1) / (1.f - (float)exp(TDroopRate * envData[1][MAX])));
+		ddF = F1 - F2;
+	}
+	else
+	{
+		ddF = F2 - F1;
+	}
 
-  clippoint = 32700;
-  DAtten = 1.0f;
+	Tphi = GetPrivateProfileFloat(sec, "Phase", 90.f, dsfile) / 57.29578f; //degrees>radians
 
-  if (DiON == 1)
-  {
-    DAtten = DGain * (short)LoudestEnv();
-    if (DAtten > 32700) { clippoint = 32700; } else { clippoint = (short)DAtten; }
-    DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
-    DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
-  }
+	//read overtone parameters
+	strcpy(sec, "Overtones");
+	chkOn[2] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	OON = chkOn[2];
+	sliLev[2] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	OL = (float)(sliLev[2] * sliLev[2]) * mem_o;
+	GetEnv(3, sec, "Envelope1", dsfile);
+	GetEnv(4, sec, "Envelope2", dsfile);
+	OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
+	OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
+	OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
+	OBal2 = (float)GetPrivateProfileInt(sec, "Param", 50, dsfile);
+	ODrive = static_cast<float>(std::pow(OBal2, 3.0f)) / std::pow(50.0f, 3.0f);
+	OBal2 *= 0.01f;
+	OBal1 = 1.f - OBal2;
+	Ophi1 = Tphi;
+	Ophi2 = Tphi;
+	if (MainFilter == 0)
+	{
+		MainFilter = GetPrivateProfileInt(sec, "Filter", 0, dsfile);
+	}
+	if ((GetPrivateProfileInt(sec, "Track1", 0, dsfile) == 1) && (TON == 1))
+	{
+		OF1Sync = 1;
+		OF1 = OF1 / F1;
+	}
+	if ((GetPrivateProfileInt(sec, "Track2", 0, dsfile) == 1) && (TON == 1))
+	{
+		OF2Sync = 1;
+		OF2 = OF2 / F1;
+	}
 
-  //prepare envelopes
-  for (i = 1; i < 8; i++) { envData[i][NEXTT] = 0; envData[i][PNT] = 0; }
-  Length = LongestEnv();
+	OcA = 0.28f + OBal1 * OBal1;  //overtone cymbal mode
+	OcQ = OcA * OcA;
+	OcF = (1.8f - 0.7f * OcQ) * 0.92f; //multiply by env 2
+	OcA *= 1.0f + 4.0f * OBal1;  //level is a compromise!
+	Ocf1 = TwoPi / OF1;
+	Ocf2 = TwoPi / OF2;
+	for (i = 0; i < 6; i++)
+	{
+		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * (float)i;
+	}
 
-  //allocate the buffer
-  //if(wave!=NULL) free(wave);
-  //wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
-  wave = new int16_t[channels * Length]; //wave memory buffer
-  if (wave == nullptr) { return 0; }
-  wavewords = 0;
+	//read noise band parameters
+	strcpy(sec, "NoiseBand");
+	chkOn[3] = GetPrivateProfileInt(sec, "On", 0, dsfile);
+	BON = chkOn[3];
+	sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	BL = (float)(sliLev[3] * sliLev[3]) * mem_b;
+	BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi = TwoPi / 8.f;
+	GetEnv(5, sec, "Envelope", dsfile);
+	BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
+	BQ = (float)BFStep;
+	BQ = BQ * BQ / (10000.f - 6600.f*((float)sqrt(BF) - 0.19f));
+	BFStep = 1 + (int)((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
-  /*
-  if(wavemode==0)
-  {
-    //open output file
-    fp = fopen(wavfile, "wb");
-    if(!fp) {return 3;} //output fail
+	strcpy(sec, "NoiseBand2");
+	chkOn[4] = GetPrivateProfileInt(sec, "On", 0, dsfile); BON2 = chkOn[4];
+	sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
+	BL2 = (float)(sliLev[4] * sliLev[4]) * mem_b;
+	BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi2 = TwoPi / 8.f;
+	GetEnv(6, sec, "Envelope", dsfile);
+	BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
+	BQ2 = (float)BFStep2;
+	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f*((float)sqrt(BF2) - 0.19f));
+	BFStep2 = 1 + (int)((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
-     //set up INFO chunk
-    WI.list = 0x5453494C;
-    WI.listLength = 36 + commentLen;
-    WI.info = 0x4F464E49;
-    WI.isft = 0x54465349;
-    WI.isftLength = 16;
-    strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
-    WI.icmt = 0x544D4349;
-    WI.icmtLength = commentLen;
+	//read distortion parameters
+	strcpy(sec, "Distortion");
+	chkOn[5] = GetPrivateProfileInt(sec, "On", 0, dsfile); DiON = chkOn[5];
+	DStep = 1 + GetPrivateProfileInt(sec, "Rate", 0, dsfile);
+	if (DStep == 7) { DStep = 20; }
+	if (DStep == 6) { DStep = 10; }
+	if (DStep == 5) { DStep = 8; }
 
-    //write WAV header
-    WH.riff = 0x46464952;
-    WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
-    WH.wave = 0x45564157;
-    WH.fmt = 0x20746D66;
-    WH.waveLength = 16;
-    WH.wFormatTag = WAVE_FORMAT_PCM;
-    WH.nChannels = 1;
-    WH.nSamplesPerSec = Fs;
-    WH.nAvgBytesPerSec = 2 * Fs;
-    WH.nBlockAlign = 2;
-    WH.wBitsPerSample = 16;
-    WH.data = 0x61746164;
-    WH.dataLength = 2 * Length;
-    fwrite(&WH, 1, 44, fp);
-  }
-  */
+	clippoint = 32700;
+	DAtten = 1.0f;
+
+	if (DiON == 1)
+	{
+		DAtten = DGain * (short)LoudestEnv();
+		if (DAtten > 32700) { clippoint = 32700; }
+		else { clippoint = (short)DAtten; }
+		DAtten = static_cast<float>(std::pow(2.0, 2.0 * GetPrivateProfileInt(sec, "Bits", 0, dsfile)));
+		DGain = DAtten * DGain * static_cast<float>(std::pow(10.0, 0.05 * GetPrivateProfileInt(sec, "Clipping", 0, dsfile)));
+	}
+
+	//prepare envelopes
+	for (i = 1; i < 8; i++)
+	{
+		envData[i][NEXTT] = 0;
+		envData[i][PNT] = 0;
+	}
+	Length = LongestEnv();
+
+	//allocate the buffer
+	//if(wave!=NULL) free(wave);
+	//wave = new int16_t[channels * (Length + 1280)]; //wave memory buffer
+	wave = new int16_t[channels * Length]; //wave memory buffer
+	if (wave == nullptr) { return 0; }
+	wavewords = 0;
+
+	/*
+	if(wavemode==0)
+	{
+	//open output file
+	fp = fopen(wavfile, "wb");
+	if(!fp) {return 3;} //output fail
+
+	 //set up INFO chunk
+	WI.list = 0x5453494C;
+	WI.listLength = 36 + commentLen;
+	WI.info = 0x4F464E49;
+	WI.isft = 0x54465349;
+	WI.isftLength = 16;
+	strcpy(WI.software, "DrumSynth v2.0 "); WI.software[15]=0;
+	WI.icmt = 0x544D4349;
+	WI.icmtLength = commentLen;
+
+	//write WAV header
+	WH.riff = 0x46464952;
+	WH.riffLength = 36 + (2 * Length) + 44 + commentLen;
+	WH.wave = 0x45564157;
+	WH.fmt = 0x20746D66;
+	WH.waveLength = 16;
+	WH.wFormatTag = WAVE_FORMAT_PCM;
+	WH.nChannels = 1;
+	WH.nSamplesPerSec = Fs;
+	WH.nAvgBytesPerSec = 2 * Fs;
+	WH.nBlockAlign = 2;
+	WH.wBitsPerSample = 16;
+	WH.data = 0x61746164;
+	WH.dataLength = 2 * Length;
+	fwrite(&WH, 1, 44, fp);
+	}
+	*/
 
   //generate
-  tpos = 0;
-  while (tpos < Length)
-  {
-    tplus = tpos + 1199;
-
-    if (NON == 1) //noise
-    {
-      for (t = tpos; t <= tplus; t++)
-      {
-        if (t < envData[2][NEXTT]) envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
-        else { UpdateEnv(2, t); }
-        x[2] = x[1];
-        x[1] = x[0];
-        x[0] = (randmax2 * (float)rand()) - 1.f;
-        TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
-        DF[t - tpos] = TT * g * envData[2][ENV];
-      }
-      if (t >= envData[2][MAX]) { NON=0; }
-    }
-    else
+	tpos = 0;
+	while (tpos < Length)
 	{
-        for (j = 0; j < 1200; j++) { DF[j]=0.f; }
-    }
+		tplus = tpos + 1199;
 
-    if (TON == 1) //tone
-    {
-      TphiStart = Tphi;
-      if (TDroop == 1)
-      {
-        for (t = tpos; t <= tplus; t++)
+		if (NON == 1) //noise
 		{
-          phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[2][NEXTT])
+				{
+					envData[2][ENV] = envData[2][ENV] + envData[2][dENV];
+				}
+				else { UpdateEnv(2, t); }
+				x[2] = x[1];
+				x[1] = x[0];
+				x[0] = (randmax2 * (float)rand()) - 1.f;
+				TT = a * x[0] + b * x[1] + c * x[2] + d * TT;
+				DF[t - tpos] = TT * g * envData[2][ENV];
+			}
+			if (t >= envData[2][MAX])
+			{
+				NON = 0;
+			}
 		}
-      }
-      else
-      {
-        for (t = tpos; t <= tplus; t++)
+		else
 		{
-          phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
-		}
-      }
-      for (t = tpos; t <= tplus; t++)
-      {
-        totmp = t - tpos;
-        if (t < envData[1][NEXTT])
-		{
-          envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
-		}
-        else { UpdateEnv(1, t); }
-        Tphi = Tphi + phi[totmp];
-        DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi,TwoPi));//overflow?
-      }
-      if (t >= envData[1][MAX]) { TON=0; }
-    }
-    else for (j = 0; j < 1200; j++) { phi[j] = F2; } //for overtone sync
-
-    if (BON == 1) //noise band 1
-    {
-      for (t = tpos; t <= tplus; t++)
-      {
-        if (t < envData[5][NEXTT])
-		{
-          envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
-		}
-        else { UpdateEnv(5, t); }
-        if ((t % BFStep) == 0) { BdF = randmax * (float)rand() - 0.5f; }
-        BPhi = BPhi + BF + BQ * BdF;
-        botmp = t - tpos;
-        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi,TwoPi)) * envData[5][ENV] * BL;
-      }
-      if (t >= envData[5][MAX]) { BON=0; }
-    }
-
-    if (BON2 == 1) //noise band 2
-    {
-      for (t = tpos; t <= tplus; t++)
-      {
-        if (t < envData[6][NEXTT])
-          envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
-        else { UpdateEnv(6, t); }
-        if ((t % BFStep2) == 0) { BdF2 = randmax * (float)rand() - 0.5f; }
-        BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
-        botmp = t - tpos;
-        DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2,TwoPi)) * envData[6][ENV] * BL2;
-      }
-      if (t >= envData[6][MAX]) { BON2 = 0; }
-    }
-
-
-    for (t = tpos; t <= tplus; t++)
-    {
-      if (OON == 1) //overtones
-      {
-        if (t < envData[3][NEXTT])
-		{
-          envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
-		}
-        else
-        {
-          if (t >= envData[3][MAX]) //wait for OT2
-          {
-            envData[3][ENV] = 0;
-            envData[3][dENV] = 0;
-            envData[3][NEXTT] = 999999;
-          }
-          else UpdateEnv(3, t);
-        }
-        //
-        if (t < envData[4][NEXTT])
-          envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
-        else
-        {
-          if (t >= envData[4][MAX]) //wait for OT1
-          {
-            envData[4][ENV] = 0;
-            envData[4][dENV] = 0;
-            envData[4][NEXTT] = 999999;
-          }
-          else { UpdateEnv(4, t); }
-        }
-        //
-        TphiStart = TphiStart + phi[t - tpos];
-        if (OF1Sync == 1) { Ophi1 = TphiStart * OF1; } else { Ophi1 = Ophi1 + OF1; }
-        if (OF2Sync == 1) { Ophi2 = TphiStart * OF2; } else { Ophi2 = Ophi2 + OF2; }
-        Ot = 0.0f;
-        switch (OMode)
-        {
-          case 0: //add
-            Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
-            Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
-            break;
-
-          case 1: //FM
-            Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
-            Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
-            break;
-
-          case 2: //RM
-            Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
-            Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
-            break;
-
-          case 3: //808 Cymbal
-            for(j=0; j<6; j++)
-            {
-              Oc[j][0] += 1.0f;
-
-              if(Oc[j][0]>Oc[j][1])
-              {
-                Oc[j][0] -= Oc[j][1];
-                Ot = OL * envData[3][ENV];
-              }
-            }
-            Ocf1 = envData[4][ENV] * OcF;  //filter freq
-            Oc0 += Ocf1 * Oc1;
-            Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0);  //bpf
-            Oc2 = Ot;
-            Ot = Oc1;
-            break;
-        }
-      }
-
-      if (MainFilter == 1) //filter overtones
-      {
-        if (t < envData[7][NEXTT])
-          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-        else UpdateEnv(7, t);
-
-        MFtmp = envData[7][ENV];
-        if (MFtmp >0.2f)
-          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-        else
-          MFfb = 0.999f - 0.7824f * MFtmp;
-
-        MFtmp = Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-        MFin = MFfb * (MFin - MFtmp) + MFtmp;
-        MFout = MFfb * (MFout - MFin) + MFin;
-
-        DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
-      }
-      else if (MainFilter == 2) //filter all
-      {
-        if (t < envData[7][NEXTT])
-		{
-          envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
-		}
-        else { UpdateEnv(7, t); }
-
-        MFtmp = envData[7][ENV];
-        if (MFtmp > 0.2f)
-		{
-          MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
-		}
-        else
-		{
-          MFfb = 0.999f - 0.7824f * MFtmp;
+			for (j = 0; j < 1200; j++)
+			{
+				DF[j] = 0.f;
+			}
 		}
 
-        MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
-        MFin = MFfb * (MFin - MFtmp) + MFtmp;
-        MFout = MFfb * (MFout - MFin) + MFin;
-
-        DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
-      }
-      // PG: Ot is uninitialized
-      else { DF[t - tpos] = DF[t - tpos] + Ot; } //no filter
-    }
-
-    if (DiON == 1) //bit resolution
-    {
-      for (j = 0; j < 1200; j++)
-	  {
-        DF[j] = DGain * (int)(DF[j] / DAtten);
-	  }
-
-      for (j = 0; j < 1200; j += DStep) //downsampling
-      {
-        DownAve = 0;
-        DownStart = j;
-        DownEnd = j + DStep - 1;
-        for (jj = DownStart; jj <= DownEnd; jj++)
+		if (TON == 1) //tone
 		{
-          DownAve = DownAve + DF[jj];
+			TphiStart = Tphi;
+			if (TDroop == 1)
+			{
+				for (t = tpos; t <= tplus; t++)
+				{
+					phi[t - tpos] = F2 + (ddF * (float)exp(t * TDroopRate));
+				}
+			}
+			else
+			{
+				for (t = tpos; t <= tplus; t++)
+				{
+					phi[t - tpos] = F1 + (t / envData[1][MAX]) * ddF;
+				}
+			}
+			for (t = tpos; t <= tplus; t++)
+			{
+				totmp = t - tpos;
+				if (t < envData[1][NEXTT])
+				{
+				  envData[1][ENV] = envData[1][ENV] + envData[1][dENV];
+				}
+				else
+				{
+					UpdateEnv(1, t);
+				}
+				Tphi = Tphi + phi[totmp];
+				DF[totmp] += TL * envData[1][ENV] * (float)sin(fmod(Tphi, TwoPi));//overflow?
+			}
+			if (t >= envData[1][MAX]) { TON=0; }
 		}
-        DownAve = DownAve / DStep;
-        for (jj = DownStart; jj <= DownEnd; jj++)
+		else for (j = 0; j < 1200; j++) { phi[j] = F2; } //for overtone sync
+
+		if (BON == 1) //noise band 1
 		{
-          DF[jj] = DownAve;
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[5][NEXTT])
+				{
+				  envData[5][ENV] = envData[5][ENV] + envData[5][dENV];
+				}
+				else
+				{
+					UpdateEnv(5, t);
+				}
+				if ((t % BFStep) == 0)
+				{
+					BdF = randmax * (float)rand() - 0.5f;
+				}
+				BPhi = BPhi + BF + BQ * BdF;
+				botmp = t - tpos;
+				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi, TwoPi)) * envData[5][ENV] * BL;
+			}
+			if (t >= envData[5][MAX]) { BON=0; }
 		}
-      }
-    }
-    else for (j = 0; j < 1200; j++) { DF[j] *= DGain; }
 
-    for (j = 0; j < 1200; j++) //clipping + output
-    {
-      if (DF[j] > clippoint)
-	  {
-        wave[wavewords++] = clippoint;
-	  }
-      else if (DF[j] < -clippoint)
-	  {
-          wave[wavewords++] = -clippoint;
-	  }
-      else
-	  {
-          wave[wavewords++] = (short)DF[j];
-	  }
-
-      for (int c = 1; c < channels; c++)  {
-        wave[wavewords] = wave[wavewords-1];
-        wavewords++;
-      }
-    }
-
-    tpos = tpos + 1200;
-  }
-
-  /*
-  if(wavemode==0)
-  {
-    fwrite(wave, 2, Length, fp);  //write data
-    fwrite(&WI,  1, 44, fp); //write INFO chunk
-    fwrite(&comment, 1, commentLen, fp);
-    fclose(fp);
-  }
-  wavemode = 0; //force compatibility!!
-  */
+		if (BON2 == 1) //noise band 2
+		{
+			for (t = tpos; t <= tplus; t++)
+			{
+				if (t < envData[6][NEXTT])
+				{
+					envData[6][ENV] = envData[6][ENV] + envData[6][dENV];
+				}
+				else
+				{
+					UpdateEnv(6, t);
+				}
+				if ((t % BFStep2) == 0)
+				{
+					BdF2 = randmax * (float)rand() - 0.5f;
+				}
+				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
+				botmp = t - tpos;
+				DF[botmp] = DF[botmp] + (float)cos(fmod(BPhi2, TwoPi)) * envData[6][ENV] * BL2;
+			}
+			if (t >= envData[6][MAX])
+			{
+				BON2 = 0;
+			}
+		}
 
 
-  return Length;
+		for (t = tpos; t <= tplus; t++)
+		{
+			if (OON == 1) //overtones
+			{
+				if (t < envData[3][NEXTT])
+				{
+					envData[3][ENV] = envData[3][ENV] + envData[3][dENV];
+				}
+				else
+				{
+					if (t >= envData[3][MAX]) //wait for OT2
+					{
+						envData[3][ENV] = 0;
+						envData[3][dENV] = 0;
+						envData[3][NEXTT] = 999999;
+					}
+					else { UpdateEnv(3, t); }
+				}
+				//
+				if (t < envData[4][NEXTT])
+					envData[4][ENV] = envData[4][ENV] + envData[4][dENV];
+				else
+				{
+					if (t >= envData[4][MAX]) //wait for OT1
+					{
+					envData[4][ENV] = 0;
+					envData[4][dENV] = 0;
+					envData[4][NEXTT] = 999999;
+					}
+					else { UpdateEnv(4, t); }
+				}
+				//
+				TphiStart = TphiStart + phi[t - tpos];
+				if (OF1Sync == 1)
+				{
+					Ophi1 = TphiStart * OF1;
+				}
+				else
+				{
+					Ophi1 = Ophi1 + OF1;
+				}
+				if (OF2Sync == 1)
+				{
+					Ophi2 = TphiStart * OF2;
+				}
+				else
+				{
+					Ophi2 = Ophi2 + OF2;
+				}
+				Ot = 0.0f;
+				switch (OMode)
+				{
+					case 0: //add
+						Ot = OBal1 * envData[3][ENV] * waveform(Ophi1, OW1);
+						Ot = OL * (Ot + OBal2 * envData[4][ENV] * waveform(Ophi2, OW2));
+						break;
+
+					case 1: //FM
+						Ot = ODrive * envData[4][ENV] * waveform(Ophi2, OW2);
+						Ot = OL * envData[3][ENV] * waveform(Ophi1 + Ot, OW1);
+						break;
+
+					case 2: //RM
+						Ot = (1 - ODrive / 8) + (((ODrive / 8) * envData[4][ENV]) * waveform(Ophi2, OW2));
+						Ot = OL * envData[3][ENV] * waveform(Ophi1, OW1) * Ot;
+						break;
+
+					case 3: //808 Cymbal
+						for (j = 0; j < 6; j++)
+						{
+							Oc[j][0] += 1.0f;
+
+							if (Oc[j][0] > Oc[j][1])
+							{
+								Oc[j][0] -= Oc[j][1];
+								Ot = OL * envData[3][ENV];
+							}
+						}
+						Ocf1 = envData[4][ENV] * OcF;  //filter freq
+						Oc0 += Ocf1 * Oc1;
+						Oc1 += Ocf1 * (Ot + Oc2 - OcQ * Oc1 - Oc0);  //bpf
+						Oc2 = Ot;
+						Ot = Oc1;
+						break;
+				}
+			}
+
+			if (MainFilter == 1) //filter overtones
+			{
+				if (t < envData[7][NEXTT])
+				{
+					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				}
+				else { UpdateEnv(7, t); }
+
+				MFtmp = envData[7][ENV];
+				if (MFtmp >0.2f)
+				{
+					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				}
+				else
+				{
+					MFfb = 0.999f - 0.7824f * MFtmp;
+				}
+
+				MFtmp = Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
+				MFin = MFfb * (MFin - MFtmp) + MFtmp;
+				MFout = MFfb * (MFout - MFin) + MFin;
+
+				DF[t - tpos] = DF[t - tpos] + (MFout - (HighPass * Ot));
+			}
+			else if (MainFilter == 2) //filter all
+			{
+				if (t < envData[7][NEXTT])
+				{
+					envData[7][ENV] = envData[7][ENV] + envData[7][dENV];
+				}
+				else { UpdateEnv(7, t); }
+
+				MFtmp = envData[7][ENV];
+				if (MFtmp > 0.2f)
+				{
+					MFfb = 1.001f - static_cast<float>(std::pow(10.0f, MFtmp - 1));
+				}
+				else
+				{
+					MFfb = 0.999f - 0.7824f * MFtmp;
+				}
+
+				MFtmp = DF[t - tpos] + Ot + MFres * (1.f + (1.f/MFfb)) * (MFin - MFout);
+				MFin = MFfb * (MFin - MFtmp) + MFtmp;
+				MFout = MFfb * (MFout - MFin) + MFin;
+
+				DF[t - tpos] = MFout - (HighPass * (DF[t - tpos] + Ot));
+			}
+			// PG: Ot is uninitialized
+			else
+			{
+				DF[t - tpos] = DF[t - tpos] + Ot; //no filter
+			}
+		}
+
+		if (DiON == 1) //bit resolution
+		{
+			for (j = 0; j < 1200; j++)
+			{
+				DF[j] = DGain * (int)(DF[j] / DAtten);
+			}
+
+			for (j = 0; j < 1200; j += DStep) //downsampling
+			{
+				DownAve = 0;
+				DownStart = j;
+				DownEnd = j + DStep - 1;
+				for (jj = DownStart; jj <= DownEnd; jj++)
+				{
+					DownAve = DownAve + DF[jj];
+				}
+				DownAve = DownAve / DStep;
+				for (jj = DownStart; jj <= DownEnd; jj++)
+				{
+					DF[jj] = DownAve;
+				}
+			}
+		}
+		else for (j = 0; j < 1200; j++)
+		{
+			DF[j] *= DGain;
+		}
+
+		for (j = 0; j < 1200; j++) //clipping + output
+		{
+			if (DF[j] > clippoint)
+			{
+				wave[wavewords++] = clippoint;
+			}
+			else if (DF[j] < -clippoint)
+			{
+				wave[wavewords++] = -clippoint;
+			}
+			else
+			{
+				wave[wavewords++] = (short)DF[j];
+			}
+
+			for (int c = 1; c < channels; c++)
+			{
+				wave[wavewords] = wave[wavewords-1];
+				wavewords++;
+			}
+		}
+
+		tpos = tpos + 1200;
+	}
+
+	/*
+	if(wavemode==0)
+	{
+		fwrite(wave, 2, Length, fp);  //write data
+		fwrite(&WI,  1, 44, fp); //write INFO chunk
+		fwrite(&comment, 1, commentLen, fp);
+		fclose(fp);
+	}
+	wavemode = 0; //force compatibility!!
+	*/
+
+
+	return Length;
 }
 
 

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -224,7 +224,7 @@ int DrumSynth::GetPrivateProfileString(
 				}
 				else
 				{
-					k = (char*)(b + strlen(b) - 1);
+					k = static_cast<char*>(b + strlen(b) - 1);
 					while ((k >= b) && (*k == ' ' || *k == '\t'))
 					{
 						--k;


### PR DESCRIPTION
This file is so old I am making a separate pull request for it instead of grouping its cleaning with the rest of my categories.
Several issues here.
Bad formatting includes poor space usage (no space around operators / flow control), bad nextline usage and bad indentation (two space indentation instead of tab).

Additionally there is ugly logic (nested if loops).

I will fix as much of the _formatting_ as I can myself. I cannot speak for the rest.
Hopefully the next person approaching this file will have at least a better formatted task ahead of them.