### PR TITLE
Use layouts for the instrument sound shaping tab / Extract classes for Envelope and LFO graphs

### DIFF
--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -71,7 +71,18 @@ public:
 		using LfoList = QList<EnvelopeAndLfoParameters*>;
 		LfoList m_lfos;
 
-	} ;
+	};
+
+	enum class LfoShape
+	{
+		SineWave,
+		TriangleWave,
+		SawWave,
+		SquareWave,
+		UserDefinedWave,
+		RandomWave,
+		Count
+	};
 
 	EnvelopeAndLfoParameters( float _value_for_zero_amount,
 							Model * _parent );
@@ -114,6 +125,7 @@ public:
 		return m_rFrames;
 	}
 
+	// Envelope
 	const FloatModel& getPredelayModel() const { return m_predelayModel; }
 	const FloatModel& getAttackModel() const { return m_attackModel; }
 	const FloatModel& getHoldModel() const { return m_holdModel; }
@@ -123,6 +135,18 @@ public:
 	const FloatModel& getAmountModel() const { return m_amountModel; }
 	FloatModel& getAmountModel() { return m_amountModel; }
 
+
+	// LFO
+	inline f_cnt_t getLfoPredelayFrames() const { return m_lfoPredelayFrames; }
+	inline f_cnt_t getLfoAttackFrames() const { return m_lfoAttackFrames; }
+	inline f_cnt_t getLfoOscillationFrames() const { return m_lfoOscillationFrames; }
+
+	const FloatModel& getLfoAmountModel() const { return m_lfoAmountModel; }
+	FloatModel& getLfoAmountModel() { return m_lfoAmountModel; }
+	const TempoSyncKnobModel& getLfoSpeedModel() const { return m_lfoSpeedModel; }
+	const BoolModel& getX100Model() const { return m_x100Model; }
+	const IntModel& getLfoWaveModel() const { return m_lfoWaveModel; }
+	std::shared_ptr<const SampleBuffer> getLfoUserWave() const { return m_userWave; }
 
 public slots:
 	void updateSampleVars();
@@ -179,16 +203,6 @@ private:
 	bool m_bad_lfoShapeData;
 	std::shared_ptr<const SampleBuffer> m_userWave = SampleBuffer::emptyBuffer();
 
-	enum class LfoShape
-	{
-		SineWave,
-		TriangleWave,
-		SawWave,
-		SquareWave,
-		UserDefinedWave,
-		RandomWave,
-		Count
-	} ;
 	constexpr static auto NumLfoShapes = static_cast<std::size_t>(LfoShape::Count);
 
 	sample_t lfoShapeSample( fpp_t _frame_offset );

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -114,6 +114,15 @@ public:
 		return m_rFrames;
 	}
 
+	const FloatModel& getPredelayModel() const { return m_predelayModel; }
+	const FloatModel& getAttackModel() const { return m_attackModel; }
+	const FloatModel& getHoldModel() const { return m_holdModel; }
+	const FloatModel& getDecayModel() const { return m_decayModel; }
+	const FloatModel& getSustainModel() const { return m_sustainModel; }
+	const FloatModel& getReleaseModel() const { return m_releaseModel; }
+	const FloatModel& getAmountModel() const { return m_amountModel; }
+	FloatModel& getAmountModel() { return m_amountModel; }
+
 
 public slots:
 	void updateSampleVars();

--- a/include/EnvelopeAndLfoView.h
+++ b/include/EnvelopeAndLfoView.h
@@ -47,6 +47,7 @@ class Knob;
 class LedCheckBox;
 class PixmapButton;
 class TempoSyncKnob;
+class EnvelopeGraph;
 
 
 
@@ -72,13 +73,13 @@ protected slots:
 
 
 private:
-	QPixmap m_envGraph = embed::getIconPixmap("envelope_graph");
 	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
 
 	EnvelopeAndLfoParameters * m_params;
 
 
 	// envelope stuff
+	EnvelopeGraph* m_envelopeGraph;
 	Knob * m_predelayKnob;
 	Knob * m_attackKnob;
 	Knob * m_holdKnob;

--- a/include/EnvelopeAndLfoView.h
+++ b/include/EnvelopeAndLfoView.h
@@ -29,10 +29,6 @@
 #include <QWidget>
 
 #include "ModelView.h"
-#include "embed.h"
-
-class QPaintEvent;
-class QPixmap;
 
 namespace lmms
 {
@@ -48,6 +44,7 @@ class LedCheckBox;
 class PixmapButton;
 class TempoSyncKnob;
 class EnvelopeGraph;
+class LfoGraph;
 
 
 
@@ -64,8 +61,6 @@ protected:
 
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
-	void mousePressEvent( QMouseEvent * _me ) override;
-	void paintEvent( QPaintEvent * _pe ) override;
 
 
 protected slots:
@@ -73,10 +68,7 @@ protected slots:
 
 
 private:
-	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
-
 	EnvelopeAndLfoParameters * m_params;
-
 
 	// envelope stuff
 	EnvelopeGraph* m_envelopeGraph;
@@ -89,6 +81,7 @@ private:
 	Knob * m_amountKnob;
 
 	// LFO stuff
+	LfoGraph* m_lfoGraph;
 	Knob * m_lfoPredelayKnob;
 	Knob * m_lfoAttackKnob;
 	TempoSyncKnob * m_lfoSpeedKnob;
@@ -98,8 +91,6 @@ private:
 
 	LedCheckBox * m_x100Cb;
 	LedCheckBox * m_controlEnvAmountCb;
-	
-	float m_randomGraph;
 } ;
 
 } // namespace gui

--- a/include/EnvelopeGraph.h
+++ b/include/EnvelopeGraph.h
@@ -58,7 +58,7 @@ private:
 private:
 	QPixmap m_envGraph = embed::getIconPixmap("envelope_graph");
 
-	EnvelopeAndLfoParameters * m_params;
+	EnvelopeAndLfoParameters* m_params;
 };
 
 } // namespace gui

--- a/include/EnvelopeGraph.h
+++ b/include/EnvelopeGraph.h
@@ -1,0 +1,68 @@
+/*
+ * EnvelopeGraph.h - Displays envelope graphs
+ *
+ * Copyright (c) 2004-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2024-     Michael Gregorius
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#pragma once
+
+#ifndef LMMS_GUI_ENVELOPE_GRAPH_H
+#define LMMS_GUI_ENVELOPE_GRAPH_H
+
+#include <QWidget>
+
+#include "ModelView.h"
+#include "embed.h"
+
+namespace lmms
+{
+
+class EnvelopeAndLfoParameters;
+
+namespace gui
+{
+
+class EnvelopeGraph : public QWidget, public ModelView
+{
+public:
+	EnvelopeGraph(QWidget* parent);
+
+protected:
+	void modelChanged() override;
+
+	void mousePressEvent(QMouseEvent* me) override;
+	void paintEvent(QPaintEvent* pe) override;
+
+private:
+	void toggleAmountModel();
+
+private:
+	QPixmap m_envGraph = embed::getIconPixmap("envelope_graph");
+
+	EnvelopeAndLfoParameters * m_params;
+};
+
+} // namespace gui
+
+} // namespace lmms
+
+#endif // LMMS_GUI_ENVELOPE_GRAPH_H

--- a/include/EnvelopeGraph.h
+++ b/include/EnvelopeGraph.h
@@ -23,8 +23,6 @@
  *
  */
 
-#pragma once
-
 #ifndef LMMS_GUI_ENVELOPE_GRAPH_H
 #define LMMS_GUI_ENVELOPE_GRAPH_H
 

--- a/include/InstrumentSoundShapingView.h
+++ b/include/InstrumentSoundShapingView.h
@@ -56,7 +56,7 @@ private:
 	void modelChanged() override;
 
 
-	InstrumentSoundShaping * m_ss;
+	InstrumentSoundShaping * m_ss = nullptr;
 	TabWidget * m_targetsTabWidget;
 	EnvelopeAndLfoView * m_envLfoViews[InstrumentSoundShaping::NumTargets];
 

--- a/include/LfoGraph.h
+++ b/include/LfoGraph.h
@@ -1,5 +1,5 @@
 /*
- * EnvelopeGraph.h - Displays LFO graphs
+ * LfoGraph.h - Displays LFO graphs
  *
  * Copyright (c) 2004-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * Copyright (c) 2024-     Michael Gregorius
@@ -22,8 +22,6 @@
  * Boston, MA 02110-1301 USA.
  *
  */
-
-#pragma once
 
 #ifndef LMMS_GUI_LFO_GRAPH_H
 #define LMMS_GUI_LFO_GRAPH_H
@@ -58,7 +56,7 @@ private:
 private:
 	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
 
-	EnvelopeAndLfoParameters* m_params;
+	EnvelopeAndLfoParameters* m_params = nullptr;
 
 	float m_randomGraph {0.};
 };

--- a/include/LfoGraph.h
+++ b/include/LfoGraph.h
@@ -58,7 +58,7 @@ private:
 private:
 	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
 
-	EnvelopeAndLfoParameters * m_params;
+	EnvelopeAndLfoParameters* m_params;
 
 	float m_randomGraph {0.};
 };

--- a/include/LfoGraph.h
+++ b/include/LfoGraph.h
@@ -1,0 +1,70 @@
+/*
+ * EnvelopeGraph.h - Displays LFO graphs
+ *
+ * Copyright (c) 2004-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2024-     Michael Gregorius
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#pragma once
+
+#ifndef LMMS_GUI_LFO_GRAPH_H
+#define LMMS_GUI_LFO_GRAPH_H
+
+#include <QWidget>
+
+#include "ModelView.h"
+#include "embed.h"
+
+namespace lmms
+{
+
+class EnvelopeAndLfoParameters;
+
+namespace gui
+{
+
+class LfoGraph : public QWidget, public ModelView
+{
+public:
+	LfoGraph(QWidget* parent);
+
+protected:
+	void modelChanged() override;
+
+	void mousePressEvent(QMouseEvent* me) override;
+	void paintEvent(QPaintEvent* pe) override;
+
+private:
+	void toggleAmountModel();
+
+private:
+	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
+
+	EnvelopeAndLfoParameters * m_params;
+
+	float m_randomGraph {0.};
+};
+
+} // namespace gui
+
+} // namespace lmms
+
+#endif // LMMS_GUI_LFO_GRAPH_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -69,6 +69,7 @@ SET(LMMS_SRCS
 	gui/instrument/InstrumentSoundShapingView.cpp
 	gui/instrument/InstrumentTrackWindow.cpp
 	gui/instrument/InstrumentView.cpp
+	gui/instrument/LfoGraph.cpp
 	gui/instrument/PianoView.cpp
 
 	gui/menus/MidiPortMenu.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -62,6 +62,7 @@ SET(LMMS_SRCS
 	gui/editors/TrackContainerView.cpp
 
 	gui/instrument/EnvelopeAndLfoView.cpp
+	gui/instrument/EnvelopeGraph.cpp
 	gui/instrument/InstrumentFunctionViews.cpp
 	gui/instrument/InstrumentMidiIOView.cpp
 	gui/instrument/InstrumentTuningView.cpp

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -54,7 +54,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	m_params(nullptr)
 {
 	// Helper lambdas for consistent repeated buiding of certain widgets
-	auto buildKnob = [&](const QString & label, const QString& hintText)
+	auto buildKnob = [&](const QString& label, const QString& hintText)
 	{
 		auto knob = new Knob(KnobType::Bright26, this);
 		knob->setLabel(label);
@@ -138,8 +138,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	auto random_lfo_btn = buildPixmapButton("random_wave_active", "random_wave_inactive");
 	m_userLfoBtn = buildPixmapButton("usr_wave_active", "usr_wave_inactive");
 
-	connect( m_userLfoBtn, SIGNAL(toggled(bool)),
-				this, SLOT(lfoUserWaveChanged()));
+	connect(m_userLfoBtn, SIGNAL(toggled(bool)), this, SLOT(lfoUserWaveChanged()));
 
 	typesLayout->addWidget(sin_lfo_btn);
 	typesLayout->addWidget(triangle_lfo_btn);
@@ -149,12 +148,12 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	typesLayout->addWidget(m_userLfoBtn);
 
 	m_lfoWaveBtnGrp = new automatableButtonGroup(this);
-	m_lfoWaveBtnGrp->addButton( sin_lfo_btn );
-	m_lfoWaveBtnGrp->addButton( triangle_lfo_btn );
-	m_lfoWaveBtnGrp->addButton( saw_lfo_btn );
-	m_lfoWaveBtnGrp->addButton( sqr_lfo_btn );
-	m_lfoWaveBtnGrp->addButton( m_userLfoBtn );
-	m_lfoWaveBtnGrp->addButton( random_lfo_btn );
+	m_lfoWaveBtnGrp->addButton(sin_lfo_btn);
+	m_lfoWaveBtnGrp->addButton(triangle_lfo_btn);
+	m_lfoWaveBtnGrp->addButton(saw_lfo_btn);
+	m_lfoWaveBtnGrp->addButton(sqr_lfo_btn);
+	m_lfoWaveBtnGrp->addButton(m_userLfoBtn);
+	m_lfoWaveBtnGrp->addButton(random_lfo_btn);
 
 	QVBoxLayout* knobsAndCheckBoxesLayout  = new QVBoxLayout();
 	lfoLayout->addLayout(knobsAndCheckBoxesLayout);
@@ -168,9 +167,9 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	m_lfoAttackKnob = buildKnob(tr("ATT"), tr("Attack:"));
 	lfoKnobsLayout->addWidget(m_lfoAttackKnob);
 
-	m_lfoSpeedKnob = new TempoSyncKnob( KnobType::Bright26, this );
-	m_lfoSpeedKnob->setLabel( tr("SPD") );
-	m_lfoSpeedKnob->setHintText( tr("Frequency:"), "");
+	m_lfoSpeedKnob = new TempoSyncKnob(KnobType::Bright26, this);
+	m_lfoSpeedKnob->setLabel(tr("SPD"));
+	m_lfoSpeedKnob->setHintText(tr("Frequency:"), "");
 	lfoKnobsLayout->addWidget(m_lfoSpeedKnob);
 
 	m_lfoAmountKnob = buildKnob(tr("AMT"), tr("Modulation amount:"));
@@ -179,15 +178,15 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	QVBoxLayout* checkBoxesLayout = new QVBoxLayout();
 	knobsAndCheckBoxesLayout->addLayout(checkBoxesLayout);
 
-	m_x100Cb = new LedCheckBox( tr("FREQ x 100"), this );
+	m_x100Cb = new LedCheckBox(tr("FREQ x 100"), this);
 	m_x100Cb->setToolTip(tr("Multiply LFO frequency by 100"));
 	checkBoxesLayout->addWidget(m_x100Cb);
 
 	m_controlEnvAmountCb = new LedCheckBox(tr("MOD ENV AMOUNT"), this);
-	m_controlEnvAmountCb->setToolTip( tr("Control envelope amount by this LFO") );
+	m_controlEnvAmountCb->setToolTip(tr("Control envelope amount by this LFO"));
 	checkBoxesLayout->addWidget(m_controlEnvAmountCb);
 
-	setAcceptDrops( true );
+	setAcceptDrops(true);
 }
 
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -27,6 +27,7 @@
 #include <QPainter>
 
 #include "EnvelopeAndLfoView.h"
+#include "EnvelopeGraph.h"
 #include "EnvelopeAndLfoParameters.h"
 #include "SampleLoader.h"
 #include "embed.h"
@@ -68,8 +69,6 @@ const int SUSTAIN_KNOB_X = DECAY_KNOB_X+KNOB_X_SPACING;
 const int RELEASE_KNOB_X = SUSTAIN_KNOB_X+KNOB_X_SPACING;
 const int AMOUNT_KNOB_X = RELEASE_KNOB_X+KNOB_X_SPACING;
 
-const int TIME_UNIT_WIDTH = 40;
-
 const int LFO_GRAPH_X = 6;
 const int LFO_GRAPH_Y = ENV_KNOBS_LBL_Y+14;
 const int LFO_KNOB_Y = LFO_GRAPH_Y-2;
@@ -85,6 +84,8 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 	ModelView( nullptr, this ),
 	m_params( nullptr )
 {
+	m_envelopeGraph = new EnvelopeGraph(this);
+	m_envelopeGraph->move(ENV_GRAPH_X, ENV_GRAPH_Y);
 
 	m_predelayKnob = new Knob( KnobType::Bright26, this );
 	m_predelayKnob->setLabel( tr( "DEL" ) );
@@ -221,7 +222,6 @@ EnvelopeAndLfoView::EnvelopeAndLfoView( QWidget * _parent ) :
 
 
 	setAcceptDrops( true );
-
 }
 
 
@@ -238,6 +238,7 @@ EnvelopeAndLfoView::~EnvelopeAndLfoView()
 void EnvelopeAndLfoView::modelChanged()
 {
 	m_params = castModel<EnvelopeAndLfoParameters>();
+	m_envelopeGraph->setModel(m_params);
 	m_predelayKnob->setModel( &m_params->m_predelayModel );
 	m_attackKnob->setModel( &m_params->m_attackModel );
 	m_holdKnob->setModel( &m_params->m_holdModel );
@@ -264,18 +265,7 @@ void EnvelopeAndLfoView::mousePressEvent( QMouseEvent * _me )
 		return;
 	}
 
-	if (QRect(ENV_GRAPH_X, ENV_GRAPH_Y, m_envGraph.width(), m_envGraph.height()).contains(_me->pos()))
-	{
-		if( m_params->m_amountModel.value() < 1.0f )
-		{
-			m_params->m_amountModel.setValue( 1.0f );
-		}
-		else
-		{
-			m_params->m_amountModel.setValue( 0.0f );
-		}
-	}
-	else if (QRect(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph.width(), m_lfoGraph.height()).contains(_me->pos()))
+	if (QRect(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph.width(), m_lfoGraph.height()).contains(_me->pos()))
 	{
 		if( m_params->m_lfoAmountModel.value() < 1.0f )
 		{
@@ -335,76 +325,10 @@ void EnvelopeAndLfoView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	p.setRenderHint( QPainter::Antialiasing );
 
-	// draw envelope-graph
-	p.drawPixmap(ENV_GRAPH_X, ENV_GRAPH_Y, m_envGraph);
 	// draw LFO-graph
 	p.drawPixmap(LFO_GRAPH_X, LFO_GRAPH_Y, m_lfoGraph);
 
 	p.setFont(pointSize(p.font(), 8));
-
-	const float gray_amount = 1.0f - fabsf( m_amountKnob->value<float>() );
-
-	p.setPen( QPen( QColor( static_cast<int>( 96 * gray_amount ),
-				static_cast<int>( 255 - 159 * gray_amount ),
-				static_cast<int>( 128 - 32 * gray_amount ) ),
-									2 ) );
-
-	const QColor end_points_color( 0x99, 0xAF, 0xFF );
-	const QColor end_points_bg_color( 0, 0, 2 );
-
-	const int y_base = ENV_GRAPH_Y + m_envGraph.height() - 3;
-	const int avail_height = m_envGraph.height() - 6;
-	
-	int x1 = static_cast<int>( m_predelayKnob->value<float>() * TIME_UNIT_WIDTH );
-	int x2 = x1 + static_cast<int>( m_attackKnob->value<float>() * TIME_UNIT_WIDTH );
-	int x3 = x2 + static_cast<int>( m_holdKnob->value<float>() * TIME_UNIT_WIDTH );
-	int x4 = x3 + static_cast<int>( ( m_decayKnob->value<float>() *
-						( 1 - m_sustainKnob->value<float>() ) ) * TIME_UNIT_WIDTH );
-	int x5 = x4 + static_cast<int>( m_releaseKnob->value<float>() * TIME_UNIT_WIDTH );
-
-	if( x5 > 174 )
-	{
-		x1 = ( x1 * 174 ) / x5;
-		x2 = ( x2 * 174 ) / x5;
-		x3 = ( x3 * 174 ) / x5;
-		x4 = ( x4 * 174 ) / x5;
-		x5 = ( x5 * 174 ) / x5;
-	}
-	x1 += ENV_GRAPH_X + 2;
-	x2 += ENV_GRAPH_X + 2;
-	x3 += ENV_GRAPH_X + 2;
-	x4 += ENV_GRAPH_X + 2;
-	x5 += ENV_GRAPH_X + 2;
-
-	p.drawLine( x1, y_base, x2, y_base - avail_height );
-	p.fillRect( x1 - 1, y_base - 2, 4, 4, end_points_bg_color );
-	p.fillRect( x1, y_base - 1, 2, 2, end_points_color );
-
-	p.drawLine( x2, y_base - avail_height, x3, y_base - avail_height );
-	p.fillRect( x2 - 1, y_base - 2 - avail_height, 4, 4,
-							end_points_bg_color );
-	p.fillRect( x2, y_base - 1 - avail_height, 2, 2, end_points_color );
-
-	p.drawLine( x3, y_base-avail_height, x4, static_cast<int>( y_base -
-								avail_height +
-				( 1 - m_sustainKnob->value<float>() ) * avail_height ) );
-	p.fillRect( x3 - 1, y_base - 2 - avail_height, 4, 4,
-							end_points_bg_color );
-	p.fillRect( x3, y_base - 1 - avail_height, 2, 2, end_points_color );
-	
-	p.drawLine( x4, static_cast<int>( y_base - avail_height +
-						( 1 - m_sustainKnob->value<float>() ) *
-						avail_height ), x5, y_base );
-	p.fillRect( x4 - 1, static_cast<int>( y_base - avail_height +
-						( 1 - m_sustainKnob->value<float>() ) *
-						avail_height ) - 2, 4, 4,
-							end_points_bg_color );
-	p.fillRect( x4, static_cast<int>( y_base - avail_height +
-						( 1 - m_sustainKnob->value<float>() ) *
-						avail_height ) - 1, 2, 2,
-							end_points_color );
-	p.fillRect( x5 - 1, y_base - 2, 4, 4, end_points_bg_color );
-	p.fillRect( x5, y_base - 1, 2, 2, end_points_color );
 
 	int LFO_GRAPH_W = m_lfoGraph.width() - 3;	// subtract border
 	int LFO_GRAPH_H = m_lfoGraph.height() - 6;	// subtract border

--- a/src/gui/instrument/EnvelopeGraph.cpp
+++ b/src/gui/instrument/EnvelopeGraph.cpp
@@ -1,0 +1,157 @@
+/*
+ * EnvelopeGraph.cpp - Displays envelope graphs
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2024-     Michael Gregorius
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <QMouseEvent>
+#include <QPainter>
+
+#include "EnvelopeGraph.h"
+
+#include "EnvelopeAndLfoParameters.h"
+
+namespace lmms
+{
+
+namespace gui
+{
+
+const int TIME_UNIT_WIDTH = 40;
+
+
+EnvelopeGraph::EnvelopeGraph(QWidget* parent) :
+	QWidget(parent),
+	ModelView(nullptr, this),
+	m_params(nullptr)
+{
+	setFixedSize(m_envGraph.size());
+}
+
+void EnvelopeGraph::modelChanged()
+{
+	m_params = castModel<EnvelopeAndLfoParameters>();
+}
+
+void EnvelopeGraph::mousePressEvent(QMouseEvent* me)
+{
+	if(me->button() == Qt::LeftButton)
+	{
+		toggleAmountModel();
+	}
+}
+
+void EnvelopeGraph::paintEvent(QPaintEvent*)
+{
+	QPainter p(this);
+	p.setRenderHint(QPainter::Antialiasing);
+
+	// Draw the graph background
+	p.drawPixmap(rect(), m_envGraph);
+
+	const auto * params = castModel<EnvelopeAndLfoParameters>();
+	if (!params)
+	{
+		return;
+	}
+
+	const float amount = params->getAmountModel().value();
+	const float predelay = params->getPredelayModel().value();
+	const float attack = params->getAttackModel().value();
+	const float hold = params->getHoldModel().value();
+	const float decay = params->getDecayModel().value();
+	const float sustain = params->getSustainModel().value();
+	const float release = params->getReleaseModel().value();
+
+	const float gray_amount = 1.0f - fabsf(amount);
+
+	p.setPen(QPen(QColor(static_cast<int>(96 * gray_amount),
+				static_cast<int>(255 - 159 * gray_amount),
+				static_cast<int>(128 - 32 * gray_amount)),
+									2));
+
+	const QColor end_points_color(0x99, 0xAF, 0xFF);
+	const QColor end_points_bg_color(0, 0, 2);
+
+	const int y_base = m_envGraph.height() - 3;
+	const int avail_height = m_envGraph.height() - 6;
+	
+	int x1 = static_cast<int>(predelay * TIME_UNIT_WIDTH);
+	int x2 = x1 + static_cast<int>(attack * TIME_UNIT_WIDTH);
+	int x3 = x2 + static_cast<int>(hold * TIME_UNIT_WIDTH);
+	int x4 = x3 + static_cast<int>((decay * (1 - sustain)) * TIME_UNIT_WIDTH);
+	int x5 = x4 + static_cast<int>(release * TIME_UNIT_WIDTH);
+
+	if (x5 > 174)
+	{
+		x1 = (x1 * 174) / x5;
+		x2 = (x2 * 174) / x5;
+		x3 = (x3 * 174) / x5;
+		x4 = (x4 * 174) / x5;
+		x5 = (x5 * 174) / x5;
+	}
+	x1 += 2;
+	x2 += 2;
+	x3 += 2;
+	x4 += 2;
+	x5 += 2;
+
+	p.drawLine(x1, y_base, x2, y_base - avail_height);
+	p.fillRect(x1 - 1, y_base - 2, 4, 4, end_points_bg_color);
+	p.fillRect(x1, y_base - 1, 2, 2, end_points_color);
+
+	p.drawLine(x2, y_base - avail_height, x3, y_base - avail_height);
+	p.fillRect(x2 - 1, y_base - 2 - avail_height, 4, 4,
+							end_points_bg_color);
+	p.fillRect(x2, y_base - 1 - avail_height, 2, 2, end_points_color);
+
+	const int sustainHeight = static_cast<int>(y_base - avail_height + (1 - sustain) * avail_height);
+
+	p.drawLine(x3, y_base-avail_height, x4, sustainHeight);
+	p.fillRect(x3 - 1, y_base - 2 - avail_height, 4, 4, end_points_bg_color);
+	p.fillRect(x3, y_base - 1 - avail_height, 2, 2, end_points_color);
+	
+	p.drawLine(x4, sustainHeight, x5, y_base);
+	p.fillRect(x4 - 1, sustainHeight - 2, 4, 4, end_points_bg_color);
+	p.fillRect(x4, sustainHeight - 1, 2, 2, end_points_color);
+	p.fillRect(x5 - 1, y_base - 2, 4, 4, end_points_bg_color);
+	p.fillRect(x5, y_base - 1, 2, 2, end_points_color);
+}
+
+void EnvelopeGraph::toggleAmountModel()
+{
+	auto* params = castModel<EnvelopeAndLfoParameters>();
+	auto& amountModel = params->getAmountModel();
+
+	if (amountModel.value() < 1.0f )
+	{
+		amountModel.setValue( 1.0f );
+	}
+	else
+	{
+		amountModel.setValue( 0.0f );
+	}
+}
+
+} // namespace gui
+
+} // namespace lmms

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -52,7 +52,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 	{
 		m_envLfoViews[i] = new EnvelopeAndLfoView(m_targetsTabWidget);
 		m_targetsTabWidget->addTab(m_envLfoViews[i],
-						tr(InstrumentSoundShaping::targetNames[i][0]), nullptr);
+			tr(InstrumentSoundShaping::targetNames[i][0]), nullptr);
 	}
 
 	mainLayout->addWidget(m_targetsTabWidget, 1);

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -22,10 +22,11 @@
  *
  */
 
+#include "InstrumentSoundShapingView.h"
+
 #include <QLabel>
 #include <QBoxLayout>
 
-#include "InstrumentSoundShapingView.h"
 #include "EnvelopeAndLfoParameters.h"
 #include "EnvelopeAndLfoView.h"
 #include "ComboBox.h"
@@ -40,8 +41,7 @@ namespace lmms::gui
 
 InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 	QWidget(parent),
-	ModelView(nullptr, this),
-	m_ss(nullptr)
+	ModelView(nullptr, this)
 {
 	QVBoxLayout* mainLayout = new QVBoxLayout(this);
 	mainLayout->setContentsMargins(5, 5, 5, 5);

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <QLabel>
+#include <QBoxLayout>
 
 #include "InstrumentSoundShapingView.h"
 #include "EnvelopeAndLfoParameters.h"
@@ -37,69 +38,55 @@
 namespace lmms::gui
 {
 
-const int TARGETS_TABWIDGET_X = 4;
-const int TARGETS_TABWIDGET_Y = 5;
-const int TARGETS_TABWIDGET_WIDTH = 242;
-const int TARGETS_TABWIDGET_HEIGTH = 175;
-
-const int FILTER_GROUPBOX_X = TARGETS_TABWIDGET_X;
-const int FILTER_GROUPBOX_Y = TARGETS_TABWIDGET_Y+TARGETS_TABWIDGET_HEIGTH+5;
-const int FILTER_GROUPBOX_WIDTH = TARGETS_TABWIDGET_WIDTH;
-const int FILTER_GROUPBOX_HEIGHT = 245-FILTER_GROUPBOX_Y;
-
-
-
-InstrumentSoundShapingView::InstrumentSoundShapingView( QWidget * _parent ) :
-	QWidget( _parent ),
-	ModelView( nullptr, this ),
-	m_ss( nullptr )
+InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
+	QWidget(parent),
+	ModelView(nullptr, this),
+	m_ss(nullptr)
 {
-	m_targetsTabWidget = new TabWidget( tr( "TARGET" ), this );
-	m_targetsTabWidget->setGeometry( TARGETS_TABWIDGET_X,
-						TARGETS_TABWIDGET_Y,
-						TARGETS_TABWIDGET_WIDTH,
-						TARGETS_TABWIDGET_HEIGTH );
+	QVBoxLayout* mainLayout = new QVBoxLayout(this);
+	mainLayout->setContentsMargins(5, 5, 5, 5);
 
-	for( int i = 0; i < InstrumentSoundShaping::NumTargets; ++i )
+	m_targetsTabWidget = new TabWidget(tr("TARGET"), this);
+
+	for (int i = 0; i < InstrumentSoundShaping::NumTargets; ++i)
 	{
-		m_envLfoViews[i] = new EnvelopeAndLfoView( m_targetsTabWidget );
-		m_targetsTabWidget->addTab( m_envLfoViews[i],
-						tr( InstrumentSoundShaping::targetNames[i][0] ), 
-                                                nullptr );
+		m_envLfoViews[i] = new EnvelopeAndLfoView(m_targetsTabWidget);
+		m_targetsTabWidget->addTab(m_envLfoViews[i],
+						tr(InstrumentSoundShaping::targetNames[i][0]), nullptr);
 	}
 
-
-	m_filterGroupBox = new GroupBox( tr( "FILTER" ), this );
-	m_filterGroupBox->setGeometry( FILTER_GROUPBOX_X, FILTER_GROUPBOX_Y,
-						FILTER_GROUPBOX_WIDTH,
-						FILTER_GROUPBOX_HEIGHT );
+	mainLayout->addWidget(m_targetsTabWidget, 1);
 
 
-	m_filterComboBox = new ComboBox( m_filterGroupBox );
-	m_filterComboBox->setGeometry( 14, 22, 120, ComboBox::DEFAULT_HEIGHT );
+	m_filterGroupBox = new GroupBox(tr("FILTER"), this);
+	QHBoxLayout* filterLayout = new QHBoxLayout(m_filterGroupBox);
+	QMargins filterMargins = filterLayout->contentsMargins();
+	filterMargins.setTop(18);
+	filterLayout->setContentsMargins(filterMargins);
+
+	m_filterComboBox = new ComboBox(m_filterGroupBox);
 	m_filterComboBox->setFont(pointSize(m_filterComboBox->font(), 8));
+	filterLayout->addWidget(m_filterComboBox);
+
+	m_filterCutKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
+	m_filterCutKnob->setLabel(tr("FREQ"));
+	m_filterCutKnob->setHintText(tr("Cutoff frequency:"), " " + tr("Hz"));
+	filterLayout->addWidget(m_filterCutKnob);
+
+	m_filterResKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
+	m_filterResKnob->setLabel(tr("Q/RESO"));
+	m_filterResKnob->setHintText(tr("Q/Resonance:"), "");
+	filterLayout->addWidget(m_filterResKnob);
+
+	mainLayout->addWidget(m_filterGroupBox);
 
 
-	m_filterCutKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
-	m_filterCutKnob->setLabel( tr( "FREQ" ) );
-	m_filterCutKnob->move( 140, 18 );
-	m_filterCutKnob->setHintText( tr( "Cutoff frequency:" ), " " + tr( "Hz" ) );
-
-
-	m_filterResKnob = new Knob( KnobType::Bright26, m_filterGroupBox );
-	m_filterResKnob->setLabel( tr( "Q/RESO" ) );
-	m_filterResKnob->move( 196, 18 );
-	m_filterResKnob->setHintText( tr( "Q/Resonance:" ), "" );
-
-
-	m_singleStreamInfoLabel = new QLabel( tr( "Envelopes, LFOs and filters are not supported by the current instrument." ), this );
-	m_singleStreamInfoLabel->setWordWrap( true );
+	m_singleStreamInfoLabel = new QLabel(tr("Envelopes, LFOs and filters are not supported by the current instrument."), this);
+	m_singleStreamInfoLabel->setWordWrap(true);
 	m_singleStreamInfoLabel->setFont(pointSize(m_singleStreamInfoLabel->font(), 8));
+	m_singleStreamInfoLabel->setFixedWidth(242);
 
-	m_singleStreamInfoLabel->setGeometry( TARGETS_TABWIDGET_X,
-						TARGETS_TABWIDGET_Y,
-						TARGETS_TABWIDGET_WIDTH,
-						TARGETS_TABWIDGET_HEIGTH );
+	mainLayout->addWidget(m_singleStreamInfoLabel, 0, Qt::AlignTop);
 }
 
 

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -70,11 +70,8 @@ void LfoGraph::paintEvent(QPaintEvent*)
 	// Draw the graph background
 	p.drawPixmap(rect(), m_lfoGraph);
 
-	const auto * params = castModel<EnvelopeAndLfoParameters>();
-	if (!params)
-	{
-		return;
-	}
+	const auto* params = castModel<EnvelopeAndLfoParameters>();
+	if (!params) { return; }
 
 	const float amount = params->getLfoAmountModel().value();
 	const float lfoSpeed = params->getLfoSpeedModel().value();
@@ -89,19 +86,19 @@ void LfoGraph::paintEvent(QPaintEvent*)
 	int graph_x_base = 2;
 	int graph_y_base = 3 + LFO_GRAPH_H / 2;
 
-	const float frames_for_graph = SECS_PER_LFO_OSCILLATION *
-				Engine::audioEngine()->baseSampleRate() / 10;
+	const float frames_for_graph =
+		SECS_PER_LFO_OSCILLATION * Engine::audioEngine()->baseSampleRate() / 10;
 
 	const float gray = 1.0 - fabsf(amount);
-	const QColor penColor(static_cast<int>(96 * gray), static_cast<int>(255 - 159 * gray), static_cast<int>(128 - 32 * gray));
+	const auto red = static_cast<int>(96 * gray);
+	const auto green = static_cast<int>(255 - 159 * gray);
+	const auto blue = static_cast<int>(128 - 32 * gray);
+	const QColor penColor(red, green, blue);
 	p.setPen(QPen(penColor, 1.5));
 
 	float osc_frames = oscillationFrames;
 
-	if (x100)
-	{
-		osc_frames *= 100.0f;
-	}
+	if (x100) { osc_frames *= 100.0f; }
 
 	float old_y = 0;
 	for (int x = 0; x <= LFO_GRAPH_W; ++x)
@@ -163,14 +160,8 @@ void LfoGraph::toggleAmountModel()
 {
 	auto* params = castModel<EnvelopeAndLfoParameters>();
 	auto& lfoAmountModel = params->getLfoAmountModel();
-	if (lfoAmountModel.value() < 1.0)
-	{
-		lfoAmountModel.setValue(1.0);
-	}
-	else
-	{
-		lfoAmountModel.setValue(0.0);
-	}
+
+	lfoAmountModel.setValue(lfoAmountModel.value() < 1.0 ? 1.0 : 0.0);
 }
 
 } // namespace gui

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -1,5 +1,5 @@
 /*
- * EnvelopeGraph.cpp - Displays LFO graphs
+ * LfoGraph.cpp - Displays LFO graphs
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  * Copyright (c) 2024-     Michael Gregorius
@@ -23,10 +23,10 @@
  *
  */
 
+#include "LfoGraph.h"
+
 #include <QMouseEvent>
 #include <QPainter>
-
-#include "LfoGraph.h"
 
 #include "EnvelopeAndLfoParameters.h"
 #include "Oscillator.h"
@@ -43,8 +43,7 @@ namespace gui
 
 LfoGraph::LfoGraph(QWidget* parent) :
 	QWidget(parent),
-	ModelView(nullptr, this),
-	m_params(nullptr)
+	ModelView(nullptr, this)
 {
 	setFixedSize(m_lfoGraph.size());
 }
@@ -64,7 +63,7 @@ void LfoGraph::mousePressEvent(QMouseEvent* me)
 
 void LfoGraph::paintEvent(QPaintEvent*)
 {
-	QPainter p(this);
+	QPainter p{this};
 	p.setRenderHint(QPainter::Antialiasing);
 
 	// Draw the graph background

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -1,0 +1,176 @@
+/*
+ * EnvelopeGraph.cpp - Displays LFO graphs
+ *
+ * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2024-     Michael Gregorius
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <QMouseEvent>
+#include <QPainter>
+
+#include "LfoGraph.h"
+
+#include "EnvelopeAndLfoParameters.h"
+#include "Oscillator.h"
+
+#include "gui_templates.h"
+
+namespace lmms
+{
+
+extern const float SECS_PER_LFO_OSCILLATION;
+
+namespace gui
+{
+
+LfoGraph::LfoGraph(QWidget* parent) :
+	QWidget(parent),
+	ModelView(nullptr, this),
+	m_params(nullptr)
+{
+	setFixedSize(m_lfoGraph.size());
+}
+
+void LfoGraph::modelChanged()
+{
+	m_params = castModel<EnvelopeAndLfoParameters>();
+}
+
+void LfoGraph::mousePressEvent(QMouseEvent* me)
+{
+	if (me->button() == Qt::LeftButton)
+	{
+		toggleAmountModel();
+	}
+}
+
+void LfoGraph::paintEvent(QPaintEvent*)
+{
+	QPainter p(this);
+	p.setRenderHint(QPainter::Antialiasing);
+
+	// Draw the graph background
+	p.drawPixmap(rect(), m_lfoGraph);
+
+	const auto * params = castModel<EnvelopeAndLfoParameters>();
+	if (!params)
+	{
+		return;
+	}
+
+	const float amount = params->getLfoAmountModel().value();
+	const float lfoSpeed = params->getLfoSpeedModel().value();
+	const f_cnt_t predelayFrames = params->getLfoPredelayFrames();
+	const f_cnt_t attackFrames = params->getLfoAttackFrames();
+	const f_cnt_t oscillationFrames = params->getLfoOscillationFrames();
+	const bool x100 = params->getX100Model().value();
+	const int waveModel = params->getLfoWaveModel().value();
+
+	int LFO_GRAPH_W = m_lfoGraph.width() - 3;	// subtract border
+	int LFO_GRAPH_H = m_lfoGraph.height() - 6;	// subtract border
+	int graph_x_base = 2;
+	int graph_y_base = 3 + LFO_GRAPH_H / 2;
+
+	const float frames_for_graph = SECS_PER_LFO_OSCILLATION *
+				Engine::audioEngine()->baseSampleRate() / 10;
+
+	const float gray = 1.0 - fabsf(amount);
+	const QColor penColor(static_cast<int>(96 * gray), static_cast<int>(255 - 159 * gray), static_cast<int>(128 - 32 * gray));
+	p.setPen(QPen(penColor, 1.5));
+
+	float osc_frames = oscillationFrames;
+
+	if (x100)
+	{
+		osc_frames *= 100.0f;
+	}
+
+	float old_y = 0;
+	for (int x = 0; x <= LFO_GRAPH_W; ++x)
+	{
+		float val = 0.0;
+		float cur_sample = x * frames_for_graph / LFO_GRAPH_W;
+		if (static_cast<f_cnt_t>(cur_sample) > predelayFrames)
+		{
+			float phase = (cur_sample -= predelayFrames) / osc_frames;
+			switch (static_cast<EnvelopeAndLfoParameters::LfoShape>(waveModel))
+			{
+				case EnvelopeAndLfoParameters::LfoShape::SineWave:
+				default:
+					val = Oscillator::sinSample(phase);
+					break;
+				case EnvelopeAndLfoParameters::LfoShape::TriangleWave:
+					val = Oscillator::triangleSample(phase);
+					break;
+				case EnvelopeAndLfoParameters::LfoShape::SawWave:
+					val = Oscillator::sawSample(phase);
+					break;
+				case EnvelopeAndLfoParameters::LfoShape::SquareWave:
+					val = Oscillator::squareSample(phase);
+					break;
+				case EnvelopeAndLfoParameters::LfoShape::RandomWave:
+					if (x % (int)(900 * lfoSpeed + 1) == 0)
+					{
+						m_randomGraph = Oscillator::noiseSample(0.0);
+					}
+					val = m_randomGraph;
+					break;
+				case EnvelopeAndLfoParameters::LfoShape::UserDefinedWave:
+					val = Oscillator::userWaveSample(m_params->getLfoUserWave().get(), phase);
+					break;
+			}
+
+			if (static_cast<f_cnt_t>(cur_sample) <= attackFrames)
+			{
+				val *= cur_sample / attackFrames;
+			}
+		}
+
+		float cur_y = -LFO_GRAPH_H / 2.0f * val;
+		p.drawLine(QLineF(graph_x_base + x - 1, graph_y_base + old_y, graph_x_base + x, graph_y_base + cur_y));
+		old_y = cur_y;
+	}
+
+	// Draw the info text
+	int ms_per_osc = static_cast<int>(SECS_PER_LFO_OSCILLATION * lfoSpeed * 1000.0);
+	p.setFont(pointSize(p.font(), 8));
+	p.setPen(QColor(201, 201, 225));
+	p.drawText(4, m_lfoGraph.height() - 6, tr("ms/LFO:"));
+	p.drawText(52, m_lfoGraph.height() - 6, QString::number(ms_per_osc));
+}
+
+void LfoGraph::toggleAmountModel()
+{
+	auto* params = castModel<EnvelopeAndLfoParameters>();
+	auto& lfoAmountModel = params->getLfoAmountModel();
+	if (lfoAmountModel.value() < 1.0)
+	{
+		lfoAmountModel.setValue(1.0);
+	}
+	else
+	{
+		lfoAmountModel.setValue(0.0);
+	}
+}
+
+} // namespace gui
+
+} // namespace lmms

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -151,10 +151,12 @@ void LfoGraph::paintEvent(QPaintEvent*)
 
 	// Draw the info text
 	int ms_per_osc = static_cast<int>(SECS_PER_LFO_OSCILLATION * lfoSpeed * 1000.0);
-	p.setFont(pointSize(p.font(), 8));
+
+	QFont f = p.font();
+	f.setPixelSize(height() * 0.2);
+	p.setFont(f);
 	p.setPen(QColor(201, 201, 225));
-	p.drawText(4, m_lfoGraph.height() - 6, tr("ms/LFO:"));
-	p.drawText(52, m_lfoGraph.height() - 6, QString::number(ms_per_osc));
+	p.drawText(4, m_lfoGraph.height() - 6, tr("%1 ms/LFO").arg(ms_per_osc));
 }
 
 void LfoGraph::toggleAmountModel()


### PR DESCRIPTION
## Layouts for instrument sound shaping
Use layouts to align the elements of the instrument sound shaping page and its children. Here's a comparison before/after:

![InstrumentSoundShaping-01-Before-NoLayouts](https://github.com/LMMS/lmms/assets/9293269/6e217c9b-c206-4e5a-a38e-3427a270f67e)![InstrumentSoundShaping-02-After-WithLayouts](https://github.com/LMMS/lmms/assets/9293269/f655faf8-27fa-46aa-95b3-0a49127959a0)

This can also be considered as further preparation for a later adjustment of the instrument window to make it more scalable and to give the elements more "breathing space" (see [this comment](https://github.com/LMMS/lmms/issues/2510#issuecomment-2032220170)). Most of the other tabs already use layouts.

## New widgets to render the envelope and LFO graphs
This pull requests also extracts the rendering of the envelope and the LFO graphs into their own widget classes. This needed to be done to get rid of the individual mouse handling and painting code in `EnvelopeAndLfoView`. Both events only worked with hard-coded layouts which are removed by this PR.

This also prepares both graphs to be implemented in a scalable and potentially more interactive way, e.g. the envelope graph could be used to directly manipulate the AHDSR curve. For now both graphs are set to the fixed size of their background pixmap so that they have the exact same appearance as before.

## Adjusted rendering of the LFO info text
As can be seen in the screenshot the rendering of the LFO's info text has also been improved. It now displays "2000 ms/LFO" instead of "ms/LFO: 2000". The text is now always rendered at 20% of the widget height in preparation to make the widget resizable.

## TODOs (for later PRs)
* Separate `EnvelopeAndLfoParameters` into two classes `EnvelopeParameters` and `LfoParameters` so that each graph will only operate on the data that's it concerned with.