### PR TITLE
GUI adjustments around base velocity

### DIFF
--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -144,7 +144,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 		midiOutputLayout->insertWidget( 0, m_wpBtn );
 	}
 
-	auto baseVelocityGroupBox = new GroupBox(tr("CUSTOM BASE VELOCITY"));
+	auto baseVelocityGroupBox = new GroupBox(tr("VELOCITY MAPPING"));
 	baseVelocityGroupBox->setLedButtonShown(false);
 	layout->addWidget( baseVelocityGroupBox );
 
@@ -152,15 +152,9 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	baseVelocityLayout->setContentsMargins( 8, 18, 8, 8 );
 	baseVelocityLayout->setSpacing( 6 );
 
-	auto baseVelocityHelp
-		= new QLabel(tr("Specify the velocity normalization base for MIDI-based instruments at 100% note velocity."));
-	baseVelocityHelp->setWordWrap( true );
-    baseVelocityHelp->setFont(adjustedToPixelSize(baseVelocityHelp->font(), 10));
-
-	baseVelocityLayout->addWidget( baseVelocityHelp );
-
 	m_baseVelocitySpinBox = new LcdSpinBox( 3, baseVelocityGroupBox );
-	m_baseVelocitySpinBox->setLabel( tr( "BASE VELOCITY" ) );
+	m_baseVelocitySpinBox->setLabel( tr( "MIDI VELOCITY" ) );
+	m_baseVelocitySpinBox->setToolTip(tr("MIDI notes at this velocity correspond to 100% note velocity."));
 	baseVelocityLayout->addWidget( m_baseVelocitySpinBox );
 
 	layout->addStretch();

--- a/src/gui/instrument/InstrumentMidiIOView.cpp
+++ b/src/gui/instrument/InstrumentMidiIOView.cpp
@@ -153,7 +153,7 @@ InstrumentMidiIOView::InstrumentMidiIOView( QWidget* parent ) :
 	baseVelocityLayout->setSpacing( 6 );
 
 	m_baseVelocitySpinBox = new LcdSpinBox( 3, baseVelocityGroupBox );
-	m_baseVelocitySpinBox->setLabel( tr( "MIDI VELOCITY" ) );
+	m_baseVelocitySpinBox->setLabel(tr("MIDI VELOCITY"));
 	m_baseVelocitySpinBox->setToolTip(tr("MIDI notes at this velocity correspond to 100% note velocity."));
 	baseVelocityLayout->addWidget( m_baseVelocitySpinBox );
 


### PR DESCRIPTION
Change the label of the group box from "CUSTOM BASE VELOCITY" to "VELOCITY MAPPING".

Remove the long explanation text from the group box and add the following tool tip for the LcdSpinBox: "MIDI notes at this velocity correspond to 100% note velocity."

Change the label of the spin box from "BASE VELOCITY" to "MIDI VELOCITY" because that's what the value actually represents.

Here's how it looks (without the tool tip):

![MIDI-Base-Velocity-Changes](https://github.com/LMMS/lmms/assets/9293269/bf09270d-9f26-43b8-86c8-233fa6162d0e)

Fixes #7195.