### PR TITLE
Scalable LFO graph

### DIFF
--- a/include/LfoGraph.h
+++ b/include/LfoGraph.h
@@ -45,8 +45,6 @@ public:
 	LfoGraph(QWidget* parent);
 
 protected:
-	void modelChanged() override;
-
 	void mousePressEvent(QMouseEvent* me) override;
 	void paintEvent(QPaintEvent* pe) override;
 
@@ -55,8 +53,6 @@ private:
 
 private:
 	QPixmap m_lfoGraph = embed::getIconPixmap("lfo_graph");
-
-	EnvelopeAndLfoParameters* m_params = nullptr;
 
 	float m_randomGraph {0.};
 };

--- a/include/LfoGraph.h
+++ b/include/LfoGraph.h
@@ -49,6 +49,7 @@ protected:
 	void paintEvent(QPaintEvent* pe) override;
 
 private:
+	void drawInfoText(const EnvelopeAndLfoParameters&);
 	void toggleAmountModel();
 
 private:

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -150,7 +150,16 @@ void LfoGraph::paintEvent(QPaintEvent*)
 
 	p.drawPolyline(polyLine);
 
-	// Draw the info text
+	drawInfoText(*params);
+}
+
+void LfoGraph::drawInfoText(const EnvelopeAndLfoParameters& params)
+{
+	QPainter p(this);
+
+	const float lfoSpeed = params.getLfoSpeedModel().value();
+	const bool x100 = params.getX100Model().value();
+
 	const float hertz = 1. / (SECS_PER_LFO_OSCILLATION * lfoSpeed) * (x100 ? 100. : 1.);
 	const auto infoText = tr("%1 Hz").arg(hertz, 0, 'f', 3);
 

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -151,13 +151,13 @@ void LfoGraph::paintEvent(QPaintEvent*)
 	p.drawPolyline(polyLine);
 
 	// Draw the info text
-	int msPerOsc = static_cast<int>(SECS_PER_LFO_OSCILLATION * lfoSpeed * 1000.f);
+	const float hertz = 1. / (SECS_PER_LFO_OSCILLATION * lfoSpeed);
 
 	QFont f = p.font();
 	f.setPixelSize(height() * 0.2);
 	p.setFont(f);
 	p.setPen(QColor(201, 201, 225));
-	p.drawText(4, height() - 6, tr("%1 ms/LFO").arg(msPerOsc));
+	p.drawText(4, height() - 6, tr("%1 Hz").arg(hertz, 0, 'f', 3));
 }
 
 void LfoGraph::toggleAmountModel()

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -99,7 +99,8 @@ void LfoGraph::paintEvent(QPaintEvent*)
 		const auto sampleAsFrameCount = static_cast<f_cnt_t>(currentSample);
 		if (sampleAsFrameCount > predelayFrames)
 		{
-			const float phase = (currentSample -= predelayFrames) / oscFrames;
+			currentSample -= predelayFrames;
+			const float phase = currentSample / oscFrames;
 
 			const auto lfoShape = static_cast<EnvelopeAndLfoParameters::LfoShape>(lfoWaveModel);
 			switch (lfoShape)

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -152,12 +152,26 @@ void LfoGraph::paintEvent(QPaintEvent*)
 
 	// Draw the info text
 	const float hertz = 1. / (SECS_PER_LFO_OSCILLATION * lfoSpeed) * (x100 ? 100. : 1.);
+	const auto infoText = tr("%1 Hz").arg(hertz, 0, 'f', 3);
 
+	// First configure the font so that we get correct results for the font metrics used below
 	QFont f = p.font();
 	f.setPixelSize(height() * 0.2);
 	p.setFont(f);
+
+	// This is the position where the text and its rectangle will be rendered
+	const QPoint textPosition(4, height() - 6);
+
+	// Draw a slightly transparent black rectangle underneath the text to keep it legible
+	const QFontMetrics fontMetrics(f);
+	// This gives the bounding rectangle if the text was rendered at the origin ...
+	const auto boundingRect = fontMetrics.boundingRect(infoText);
+	// ... so we translate it to the actual position where the text will be rendered.
+	p.fillRect(boundingRect.translated(textPosition), QColor{0, 0, 0, 192});
+
+	// Now draw the actual info text
 	p.setPen(QColor(201, 201, 225));
-	p.drawText(4, height() - 6, tr("%1 Hz").arg(hertz, 0, 'f', 3));
+	p.drawText(textPosition, infoText);
 }
 
 void LfoGraph::toggleAmountModel()

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -151,7 +151,7 @@ void LfoGraph::paintEvent(QPaintEvent*)
 	p.drawPolyline(polyLine);
 
 	// Draw the info text
-	const float hertz = 1. / (SECS_PER_LFO_OSCILLATION * lfoSpeed);
+	const float hertz = 1. / (SECS_PER_LFO_OSCILLATION * lfoSpeed) * (x100 ? 100. : 1.);
 
 	QFont f = p.font();
 	f.setPixelSize(height() * 0.2);

--- a/src/gui/instrument/LfoGraph.cpp
+++ b/src/gui/instrument/LfoGraph.cpp
@@ -96,7 +96,7 @@ void LfoGraph::paintEvent(QPaintEvent*)
 	{
 		float value = 0.0;
 		float currentSample = x * framesForGraph / lfoGraphWidth;
-		const f_cnt_t sampleAsFrameCount = static_cast<f_cnt_t>(currentSample);
+		const auto sampleAsFrameCount = static_cast<f_cnt_t>(currentSample);
 		if (sampleAsFrameCount > predelayFrames)
 		{
 			const float phase = (currentSample -= predelayFrames) / oscFrames;


### PR DESCRIPTION
Make the rendering of the LFO graph scalable. Change the fixed size to a minimum size. Adjust the rendering code such that it uses the width and height of the widget instead of the background pixmap.

## Use "Hz" instead of "ms/LFO"
Use the more common unit "Hz" to display the frequency of the LFO instead of "ms/LFO". The frequency is always displayed with three digits after the decimal separator to prevent "jumps".

## Keep info text legible
    
Draw a slightly transparent black rectangle underneath the text to keep it legible, e.g. for high frequencies with an LFO amount of 1 which results in a very bright and dense graph.

## Take "Freq * 100" into account
   
This PR also fixes a bug where the "Freq * 100" option was not taken into account when computing and displaying the frequency of the LFO.

## Screenshots

![ScalableLFO](https://github.com/LMMS/lmms/assets/9293269/f098b6ef-74ef-41b0-a1d9-c7e1110edef7)![ScalableLFO-FreqX100](https://github.com/LMMS/lmms/assets/9293269/4064beb4-fee8-4dbb-aca0-abfb70492a18)

## Implementation details
Only draw only poly line once instead of many line segments. Collect the points in the for-loop to be able to do so. This makes the code a bit more understandable because we now compute exacly one point per iteration in the for-loop.
    
Use the same interpolation for the line color like in the envelope graph.
    
Rename some variables to make them consistent with the other code.
    
Remove the member `m_params` which is not used anyway. This also allows for the removal of the overridden `modelChanged` method.

Extract the drawing of the info text into its own private method `drawInfoText`.