### PR TITLE
Fix loading of CMT delays with locale-dependent names

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -129,6 +129,7 @@ private:
 	void upgrade_midiCCIndexing();
 	void upgrade_loopsRename();
 	void upgrade_noteTypes();
+	void upgrade_fixCMTDelays();
 
 	// List of all upgrade methods
 	static const std::vector<UpgradeMethod> UPGRADE_METHODS;

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -83,7 +83,8 @@ const std::vector<DataFile::UpgradeMethod> DataFile::UPGRADE_METHODS = {
 	&DataFile::upgrade_defaultTripleOscillatorHQ,
 	&DataFile::upgrade_mixerRename      ,   &DataFile::upgrade_bbTcoRename,
 	&DataFile::upgrade_sampleAndHold    ,   &DataFile::upgrade_midiCCIndexing,
-	&DataFile::upgrade_loopsRename      ,   &DataFile::upgrade_noteTypes
+	&DataFile::upgrade_loopsRename      ,   &DataFile::upgrade_noteTypes,
+	&DataFile::upgrade_fixCMTDelays
 };
 
 // Vector of all versions that have upgrade routines.
@@ -1680,6 +1681,50 @@ void DataFile::upgrade_noteTypes()
 		{
 			note.setAttribute("len", DefaultTicksPerBar / 16);
 			note.setAttribute("type", static_cast<int>(Note::Type::Step));
+		}
+	}
+}
+
+void DataFile::upgrade_fixCMTDelays()
+{
+	QMap<QString, QString> nameMap;
+	nameMap["delay_0,01s"] = "delay_0.01s";
+	nameMap["delay_0,1s"] = "delay_0.1s";
+	nameMap["fbdelay_0,01s"] = "fbdelay_0.01s";
+	nameMap["fbdelay_0,1s"] = "fbdelay_0.1s";
+
+	const auto effects = elementsByTagName("effect");
+	bool generalInfoPrinted = false;
+
+	for (int i = 0; i < effects.size(); ++i)
+	{
+		auto effect = effects.item(i).toElement();
+
+		// We are only interested in LADSPA plugins
+		if (effect.attribute("name") != "ladspaeffect") continue;
+
+		// Fetch all attributes (LMMS) beneath the LADSPA effect so that we can check the value of the plugin attribute (XML)
+		auto attributes = effect.elementsByTagName("attribute");
+		for (int j = 0; j < attributes.size(); ++j)
+		{
+			auto attribute = attributes.item(j).toElement();
+
+			if (attribute.attribute("name") == "plugin")
+			{
+				const auto attributeValue = attribute.attribute("value");
+
+				QMap<QString, QString>::const_iterator it = nameMap.find(attributeValue);
+				if (it != nameMap.end())
+				{
+					if (!generalInfoPrinted)
+					{
+						qInfo() << "Performing data upgrade for CMT delay(s). See LMMS issue #5167 for more details.";
+						generalInfoPrinted = true;
+					}
+					qInfo() << "Replacing" << attributeValue << "with" << *it;
+					attribute.setAttribute("value", *it);
+				}
+			}
 		}
 	}
 }

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1687,21 +1687,20 @@ void DataFile::upgrade_noteTypes()
 
 void DataFile::upgrade_fixCMTDelays()
 {
-	QMap<QString, QString> nameMap;
+	static QMap<QString, QString> nameMap;
 	nameMap["delay_0,01s"] = "delay_0.01s";
 	nameMap["delay_0,1s"] = "delay_0.1s";
 	nameMap["fbdelay_0,01s"] = "fbdelay_0.01s";
 	nameMap["fbdelay_0,1s"] = "fbdelay_0.1s";
 
 	const auto effects = elementsByTagName("effect");
-	bool generalInfoPrinted = false;
 
 	for (int i = 0; i < effects.size(); ++i)
 	{
 		auto effect = effects.item(i).toElement();
 
 		// We are only interested in LADSPA plugins
-		if (effect.attribute("name") != "ladspaeffect") continue;
+		if (effect.attribute("name") != "ladspaeffect") { continue; }
 
 		// Fetch all attributes (LMMS) beneath the LADSPA effect so that we can check the value of the plugin attribute (XML)
 		auto attributes = effect.elementsByTagName("attribute");
@@ -1713,15 +1712,9 @@ void DataFile::upgrade_fixCMTDelays()
 			{
 				const auto attributeValue = attribute.attribute("value");
 
-				QMap<QString, QString>::const_iterator it = nameMap.find(attributeValue);
+				const QMap<QString, QString>::const_iterator it = nameMap.find(attributeValue);
 				if (it != nameMap.end())
 				{
-					if (!generalInfoPrinted)
-					{
-						qInfo() << "Performing data upgrade for CMT delay(s). See LMMS issue #5167 for more details.";
-						generalInfoPrinted = true;
-					}
-					qInfo() << "Replacing" << attributeValue << "with" << *it;
 					attribute.setAttribute("value", *it);
 				}
 			}

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1687,11 +1687,12 @@ void DataFile::upgrade_noteTypes()
 
 void DataFile::upgrade_fixCMTDelays()
 {
-	static QMap<QString, QString> nameMap;
-	nameMap["delay_0,01s"] = "delay_0.01s";
-	nameMap["delay_0,1s"] = "delay_0.1s";
-	nameMap["fbdelay_0,01s"] = "fbdelay_0.01s";
-	nameMap["fbdelay_0,1s"] = "fbdelay_0.1s";
+	static const QMap<QString, QString> nameMap {
+		{ "delay_0,01s", "delay_0.01s" },
+		{ "delay_0,1s", "delay_0.1s" },
+		{ "fbdelay_0,01s", "fbdelay_0.01s" },
+		{ "fbdelay_0,1s", "fbdelay_0.1s" }
+	};
 
 	const auto effects = elementsByTagName("effect");
 
@@ -1712,8 +1713,8 @@ void DataFile::upgrade_fixCMTDelays()
 			{
 				const auto attributeValue = attribute.attribute("value");
 
-				const QMap<QString, QString>::const_iterator it = nameMap.find(attributeValue);
-				if (it != nameMap.end())
+				const auto it = nameMap.constFind(attributeValue);
+				if (it != nameMap.constEnd())
 				{
 					attribute.setAttribute("value", *it);
 				}


### PR DESCRIPTION
Add an upgrade routine for CMT delays. This fix will only work in conjunction with a fix in the CMT delay itself.

The CMT delay uses `sprintf` calls to generate the technical names and display names of the delays. These calls are locale dependent. As a consequence for example the feedback delay might have been saved either as "fbdelay_0.1s" (point) or "fbdelay_0,1s" (comma) in a save file.

The CMT fix makes sure that all delays use points in their names. Therefore we must upgrade all names that contain commas to ones that contain points.

This pull request must only be merged once https://github.com/LMMS/cmt/pull/6 is merged so that the the LMMS CMT submodule can be bumped to the corresponding commit.