### PR TITLE
Move icon determination into TrackLabelButton again

### DIFF
--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -71,8 +71,6 @@ public:
 	// Create a menu for assigning/creating channels for this track
 	QMenu * createMixerMenu( QString title, QString newMixerLabel ) override;
 
-	QPixmap determinePixmap();
-
 
 protected:
 	void modelChanged() override;

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -41,7 +41,6 @@
 #include "MixerView.h"
 #include "GuiApplication.h"
 #include "Instrument.h"
-#include "InstrumentTrack.h"
 #include "InstrumentTrackWindow.h"
 #include "MainWindow.h"
 #include "MidiClient.h"
@@ -396,12 +395,6 @@ QMenu * InstrumentTrackView::createMixerMenu(QString title, QString newMixerLabe
 
 	return mixerMenu;
 }
-
-QPixmap InstrumentTrackView::determinePixmap()
-{
-	return determinePixmap(dynamic_cast<InstrumentTrack*>(getTrack()));
-}
-
 
 QPixmap InstrumentTrackView::determinePixmap(InstrumentTrack* instrumentTrack)
 {

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -31,6 +31,8 @@
 #include "ConfigManager.h"
 #include "embed.h"
 #include "InstrumentTrackView.h"
+#include "Instrument.h"
+#include "InstrumentTrack.h"
 #include "RenameDialog.h"
 #include "TrackRenameLineEdit.h"
 #include "TrackView.h"
@@ -181,13 +183,28 @@ void TrackLabelButton::mouseReleaseEvent( QMouseEvent *_me )
 
 void TrackLabelButton::paintEvent(QPaintEvent* pe)
 {
-	InstrumentTrackView* instrumentTrackView = dynamic_cast<InstrumentTrackView*>(m_trackView);
-	if (instrumentTrackView)
+	if (m_trackView->getTrack()->type() == Track::Type::Instrument)
 	{
-		setIcon(instrumentTrackView->determinePixmap());
+		auto it = dynamic_cast<InstrumentTrack*>(m_trackView->getTrack());
+		const PixmapLoader * pl;
+		auto get_logo = [](InstrumentTrack* it) -> const PixmapLoader*
+		{
+			return it->instrument()->key().isValid()
+				? it->instrument()->key().logo()
+				: it->instrument()->descriptor()->logo;
+		};
+		if( it && it->instrument() &&
+			it->instrument()->descriptor() &&
+			( pl = get_logo(it) ) )
+		{
+			if( pl->pixmapName() != m_iconName )
+			{
+				m_iconName = pl->pixmapName();
+				setIcon( pl->pixmap() );
+			}
+		}
 	}
-
-	QToolButton::paintEvent(pe);
+	QToolButton::paintEvent( pe );
 }
 
 


### PR DESCRIPTION
Fully undo the changes made in commit 88e0e94dcdb because the intermediate revert made in commit 04ecf733951 seems to have led to a performance problem due to the icon being set over and over again in `TrackLabelButton::paintEvent`.

The original intention of the changes made in pull request #7114 was to remove the paining code that dynamically determines the icon over and over again. Ideally the icon that is used by an instrument should be somewhat of a "static" property that should be known very early on when an instrument view is created. There should not be any need to dynamically resolve the icon over and over, especially not in a button class very far down in the widget hierarchy. However, due to technical reasons this is not the case in the current code. See pull request #7132 for more details.

Should fix #7207.