### PR TITLE
Reorganize SampleWaveform::visualize

### DIFF
--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -58,7 +58,8 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	
 	const size_t STEP_SIZE = std::max<size_t>(framesPerPixel / MAX_FRAMES_PER_PIXEL, 1);
 	
-	for (size_t pixelIndex = 0; pixelIndex < numPixels; pixelIndex++) {
+	for (size_t pixelIndex = 0; pixelIndex < numPixels; pixelIndex++) 
+	{
 		
 		const auto i = pixelIndex * maxFrames / numPixels;
 		size_t frameIndex = !parameters.reversed ? i : maxFrames - i;
@@ -81,11 +82,8 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 			frameIndex += STEP_SIZE;
 		}
 		
-		const auto lengthY1 = max * scaling_factor;
-		const auto lengthY2 = min * scaling_factor;
-		
-		const auto lineY1 = centerY - lengthY1;
-		const auto lineY2 = centerY - lengthY2;
+		const auto lineY1 = centerY - max * scaling_factor;
+		const auto lineY2 = centerY - min * scaling_factor;
 		const auto lineX = pixelIndex + x;
 		painter.drawLine(lineX, lineY1, lineX, lineY2);
 		

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -27,7 +27,7 @@
 namespace lmms::gui {
 
 void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const QRect& rect)
-{
+{	
 	const auto x = rect.x();
 	const auto height = rect.height();
 	const auto width = rect.width();
@@ -35,48 +35,66 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	const auto halfHeight = height / 2;
 
-	const auto color = painter.pen().color();
-	const auto rmsColor = color.lighter(123);
-
 	const auto framesPerPixel = std::max<size_t>(1, parameters.size / width);
 
-	constexpr auto maxFramesPerPixel = 512;
-	const auto resolution = std::max<size_t>(1, framesPerPixel / maxFramesPerPixel);
-	const auto framesPerResolution = framesPerPixel / resolution;
-
 	const auto numPixels = std::min<size_t>(parameters.size, width);
-	auto min = std::vector<float>(numPixels, 1);
-	auto max = std::vector<float>(numPixels, -1);
-	auto squared = std::vector<float>(numPixels);
+
+	const auto scaling_factor = 
+		halfHeight * parameters.amplification 
+		/ static_cast<float>(parameters.buffer[0].size())
+	;
 
 	const auto maxFrames = numPixels * framesPerPixel;
-	for (int i = 0; i < maxFrames; i += resolution)
-	{
-		const auto pixelIndex = i / framesPerPixel;
-		const auto frameIndex = !parameters.reversed ? i : maxFrames - i;
+	
+	const auto color = painter.pen().color();
+	const auto rmsColor = color.lighter(123);
+	
+	// Cap at this many frames per pixel index.
+	constexpr size_t MAX_FRAMES_PER_PIXEL = 16;
+	
+	constexpr float MAX_FRAMES_PER_PIXEL_RECIP = 
+		1.0 / static_cast<float>(MAX_FRAMES_PER_PIXEL)
+	;
+	
+	const size_t STEP_SIZE = std::max<size_t>(framesPerPixel / MAX_FRAMES_PER_PIXEL, 1);
+	
+	for (size_t pixelIndex = 0; pixelIndex < numPixels; pixelIndex++) {
+		
+		const auto i = pixelIndex * maxFrames / numPixels;
+		size_t frameIndex = !parameters.reversed ? i : maxFrames - i;
+		const auto frameIndex_bound = std::min(maxFrames, frameIndex + framesPerPixel);
+		
+		float max = -100.0;
+		float min =  100.0;
+		float squared = 0.0;
+		
+		while (frameIndex < frameIndex_bound)
+		{
+			const auto& frame = parameters.buffer[frameIndex];
+			const auto value = std::accumulate(frame.begin(), frame.end(), 0.0f);
 
-		const auto& frame = parameters.buffer[frameIndex];
-		const auto value = std::accumulate(frame.begin(), frame.end(), 0.0f) / frame.size();
-
-		if (value > max[pixelIndex]) { max[pixelIndex] = value; }
-		if (value < min[pixelIndex]) { min[pixelIndex] = value; }
-
-		squared[pixelIndex] += value * value;
-	}
-
-	for (int i = 0; i < numPixels; i++)
-	{
-		const auto lineY1 = centerY - max[i] * halfHeight * parameters.amplification;
-		const auto lineY2 = centerY - min[i] * halfHeight * parameters.amplification;
-		const auto lineX = i + x;
+			if (max < value) max = value;
+			if (min > value) min = value;
+			
+			squared += value * value;
+			
+			frameIndex += STEP_SIZE;
+		}
+		
+		const auto lengthY1 = max * scaling_factor;
+		const auto lengthY2 = min * scaling_factor;
+		
+		const auto lineY1 = centerY - lengthY1;
+		const auto lineY2 = centerY - lengthY2;
+		const auto lineX = pixelIndex + x;
 		painter.drawLine(lineX, lineY1, lineX, lineY2);
+		
+		const auto rms = std::sqrt(squared * MAX_FRAMES_PER_PIXEL_RECIP);
+		const auto maxRMS = std::clamp(rms, min, max);
+		const auto minRMS = std::clamp(-rms, min, max);
 
-		const auto rms = std::sqrt(squared[i] / framesPerResolution);
-		const auto maxRMS = std::clamp(rms, min[i], max[i]);
-		const auto minRMS = std::clamp(-rms, min[i], max[i]);
-
-		const auto rmsLineY1 = centerY - maxRMS * halfHeight * parameters.amplification;
-		const auto rmsLineY2 = centerY - minRMS * halfHeight * parameters.amplification;
+		const auto rmsLineY1 = centerY - maxRMS * scaling_factor;
+		const auto rmsLineY2 = centerY - minRMS * scaling_factor;
 
 		painter.setPen(rmsColor);
 		painter.drawLine(lineX, rmsLineY1, lineX, rmsLineY2);


### PR DESCRIPTION
Reduces the number of frames to process per pixel index from 512 down to 16. This is the main cause of low performance when operating with many long sample clips.

This also restructures the 2 loops which helps eliminate vector allocation.