### PR TITLE
SlicerT: Fix crash when loading a sample with no detected slices

### DIFF
--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -234,8 +234,9 @@ void SlicerT::findSlices()
 
 	for (float& sliceValue : m_slicePoints)
 	{
-		int closestZeroCrossing = *std::lower_bound(zeroCrossings.begin(), zeroCrossings.end(), sliceValue);
-		if (std::abs(sliceValue - closestZeroCrossing) < windowSize) { sliceValue = closestZeroCrossing; }
+		auto closestZeroCrossing = std::lower_bound(zeroCrossings.begin(), zeroCrossings.end(), sliceValue);
+		if (closestZeroCrossing == zeroCrossings.end()) { continue; }
+		if (std::abs(sliceValue - *closestZeroCrossing) < windowSize) { sliceValue = *closestZeroCrossing; }
 	}
 
 	float beatsPerMin = m_originalBPM.value() / 60.0f;


### PR DESCRIPTION
Upon loading a sample in SlicerT it attempts to find slices. If `std::lower_bound` did not find anything it returns `zeroCrossing.end()` which cannot be dereferenced and causes a vector out of bounds access exception.