### PR TITLE
Instrument release time in milliseconds

### DIFF
--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -34,6 +34,9 @@
 #include "Plugin.h"
 #include "TimePos.h"
 
+#include <cmath>
+
+
 namespace lmms
 {
 
@@ -91,14 +94,25 @@ public:
 	virtual f_cnt_t beatLen( NotePlayHandle * _n ) const;
 
 
-	// some instruments need a certain number of release-frames even
+	// Some instruments need a certain release time even
 	// if no envelope is active - such instruments can re-implement this
-	// method for returning how many frames they at least like to have for
-	// release
-	virtual f_cnt_t desiredReleaseFrames() const
+	// method for returning the time in milliseconds they at least like
+	// to have for the  release stage.
+	virtual float desiredReleaseTimeMs() const
 	{
-		return 0;
+		return 0.f;
 	}
+
+	// Converts the desigred release time in milliseconds to the corresponding
+	// number of frames.
+	f_cnt_t desiredReleaseFrames() const
+	{
+		const sample_rate_t sampleRate = getSampleRate();
+
+		return static_cast<f_cnt_t>(std::ceil(desiredReleaseTimeMs() * sampleRate / 1000.f));
+	}
+
+	sample_rate_t getSampleRate() const;
 
 	virtual Flags flags() const
 	{
@@ -141,6 +155,8 @@ protected:
 	// notes - method does this only if really less or equal
 	// desiredReleaseFrames() frames are left
 	void applyRelease( sampleFrame * buf, const NotePlayHandle * _n );
+
+	float computeReleaseTimeMsByFrameCount(f_cnt_t frames) const;
 
 
 private:

--- a/include/Instrument.h
+++ b/include/Instrument.h
@@ -94,17 +94,17 @@ public:
 	virtual f_cnt_t beatLen( NotePlayHandle * _n ) const;
 
 
-	// Some instruments need a certain release time even
-	// if no envelope is active - such instruments can re-implement this
-	// method for returning the time in milliseconds they at least like
-	// to have for the  release stage.
+	// This method can be overridden by instruments that need a certain
+	// release time even if no envelope is active. It returns the time
+	// in milliseconds that these instruments would like to have for
+	// their release stage.
 	virtual float desiredReleaseTimeMs() const
 	{
 		return 0.f;
 	}
 
-	// Converts the desigred release time in milliseconds to the corresponding
-	// number of frames.
+	// Converts the desired release time in milliseconds to the corresponding
+	// number of frames depending on the sample rate.
 	f_cnt_t desiredReleaseFrames() const
 	{
 		const sample_rate_t sampleRate = getSampleRate();

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -56,9 +56,9 @@ public:
 
 	auto beatLen(NotePlayHandle* note) const -> int override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return 128;
+		return 3.f;
 	}
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;

--- a/plugins/BitInvader/BitInvader.h
+++ b/plugins/BitInvader/BitInvader.h
@@ -85,9 +85,9 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 64 );
+		return 1.5f;
 	}
 
 	gui::PluginView * instantiateView( QWidget * _parent ) override;

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -220,22 +220,10 @@ QString FreeBoyInstrument::nodeName() const
 
 
 
-/*f_cnt_t FreeBoyInstrument::desiredReleaseFrames() const
+float FreeBoyInstrument::desiredReleaseTimeMs() const
 {
-	const float samplerate = Engine::audioEngine()->processingSampleRate();
-	int maxrel = 0;
-	for( int i = 0 ; i < 3 ; ++i )
-	{
-		if( maxrel < m_voice[i]->m_releaseModel.value() )
-			maxrel = m_voice[i]->m_releaseModel.value();
-	}
-
-	return f_cnt_t( float(relTime[maxrel])*samplerate/1000.0 );
-}*/
-
-f_cnt_t FreeBoyInstrument::desiredReleaseFrames() const
-{
-	return f_cnt_t( 1000 );
+	// Previous implementation was 1000 samples. At 44.1 kHz this is somewhat shy of 23. ms.
+	return 23.f;
 }
 
 

--- a/plugins/FreeBoy/FreeBoy.h
+++ b/plugins/FreeBoy/FreeBoy.h
@@ -62,7 +62,7 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override;
+	float desiredReleaseTimeMs() const override;
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -259,11 +259,6 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
-	{
-		return 0;
-	}
-
 	Flags flags() const override
 	{
 		return Flag::IsSingleStreamed | Flag::IsNotBendable;

--- a/plugins/Kicker/Kicker.h
+++ b/plugins/Kicker/Kicker.h
@@ -69,9 +69,9 @@ public:
 		return Flag::IsNotBendable;
 	}
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 512 );
+		return 12.f;
 	}
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;

--- a/plugins/Lb302/Lb302.h
+++ b/plugins/Lb302/Lb302.h
@@ -168,11 +168,6 @@ public:
 		return Flag::IsSingleStreamed;
 	}
 
-	f_cnt_t desiredReleaseFrames() const override
-	{
-		return 0; //4048;
-	}
-
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 
 private:

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1326,12 +1326,11 @@ QString MonstroInstrument::nodeName() const
 	return monstro_plugin_descriptor.name;
 }
 
-
-f_cnt_t MonstroInstrument::desiredReleaseFrames() const
+float MonstroInstrument::desiredReleaseTimeMs() const
 {
-	return qMax( 64, qMax( m_env1_relF, m_env2_relF ) );
+	const auto maxEnvelope = std::max(m_env1_rel, m_env2_rel);
+	return std::max(1.5f, maxEnvelope);
 }
-
 
 gui::PluginView* MonstroInstrument::instantiateView( QWidget * _parent )
 {

--- a/plugins/Monstro/Monstro.h
+++ b/plugins/Monstro/Monstro.h
@@ -366,7 +366,7 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override;
+	float desiredReleaseTimeMs() const override;
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 

--- a/plugins/Nes/Nes.h
+++ b/plugins/Nes/Nes.h
@@ -222,9 +222,9 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 8 );
+		return 0.2f;
 	}
 	
 	gui::PluginView* instantiateView( QWidget * parent ) override;

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -71,9 +71,9 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 128 );
+		return 3.f;
 	}
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -80,11 +80,6 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
-	{
-		return 0;
-	}
-
 	Flags flags() const override
 	{
 		return Flag::IsSingleStreamed;

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -221,22 +221,16 @@ QString SidInstrument::nodeName() const
 }
 
 
-
-
-f_cnt_t SidInstrument::desiredReleaseFrames() const
+float SidInstrument::desiredReleaseTimeMs() const
 {
-	const float samplerate = Engine::audioEngine()->processingSampleRate();
 	int maxrel = 0;
 	for (const auto& voice : m_voice)
 	{
-		if( maxrel < voice->m_releaseModel.value() )
-			maxrel = (int)voice->m_releaseModel.value();
+		maxrel = std::max(maxrel, static_cast<int>(voice->m_releaseModel.value()));
 	}
 
-	return f_cnt_t( float(relTime[maxrel])*samplerate/1000.0 );
+	return computeReleaseTimeMsByFrameCount(relTime[maxrel]);
 }
-
-
 
 
 static int sid_fillbuffer(unsigned char* sidreg, reSID::SID *sid, int tdelta, short *ptr, int samples)

--- a/plugins/Sid/SidInstrument.h
+++ b/plugins/Sid/SidInstrument.h
@@ -111,7 +111,7 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override;
+	float desiredReleaseTimeMs() const override;
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;
 

--- a/plugins/TripleOscillator/TripleOscillator.h
+++ b/plugins/TripleOscillator/TripleOscillator.h
@@ -121,9 +121,9 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 128 );
+		return 3.f;
 	}
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -150,9 +150,9 @@ public:
 
 	QString nodeName() const override;
 
-	f_cnt_t desiredReleaseFrames() const override
+	float desiredReleaseTimeMs() const override
 	{
-		return( 64 );
+		return 1.5f;
 	}
 
 	gui::PluginView* instantiateView( QWidget * _parent ) override;

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -195,7 +195,16 @@ void Instrument::applyRelease( sampleFrame * buf, const NotePlayHandle * _n )
 	}
 }
 
+float Instrument::computeReleaseTimeMsByFrameCount(f_cnt_t frames) const
+{
+	return frames / getSampleRate() * 1000.;
+}
 
+
+sample_rate_t Instrument::getSampleRate() const
+{
+	return Engine::audioEngine()->processingSampleRate();
+}
 
 
 QString Instrument::fullDisplayName() const


### PR DESCRIPTION
Make instruments report their release time in milliseconds so that it becomes independent of the sample rate and sounds the same at any sample rate.

## Implementation details
Technically this is done by removing the virtual keyword from `desiredReleaseFrames` so that it cannot be overridden anymore. The method now only serves to compute the number of frames from the given release time in milliseconds.

A new virtual method `desiredReleaseTimeMs` is added which instruments can override. The default returns 0 ms just like the default implementation previously returned 0 frames.

The method `computeReleaseTimeMsByFrameCount` is added for instruments that still use a hard coded release in frames. As of now this is only `SidInstrument`.

Add the helper method `getSampleRate` to `Instrument`.

Adjust several instruments to report their release times in milliseconds. The times are computed by taking the release in frames and assuming a sample rate of 44.1 kHz. In most cases the times are rounded to a "nice" next value, e.g.:
*  64 frames -> 1.5 ms (66 frames)
* 128 frames -> 3.0 ms (132 frames)
* 512 frames -> 12. ms (529 frames)
* 1000 frames -> 23 ms (1014 samples)

In parentheses the number of frames are shown which result from the rounded number of milliseconds when converted back assuming a sample rate of 44.1 kHz. The difference should not be noticeable in existing projects.

Remove the overrides for instruments that return the same value as the base class `Instrument` anyway. These are:
* GigPlayer
* Lb302
* Sf2Player

For `MonstroInstrument` the implementation is adjusted to behave in a very similar way. First the maximum of the envelope release times is computed. These are already available in milliseconds. Then the maximum of that value and 1.5 ms is taken and returned as the result.

Fixes #7211.