### PR TITLE
Remove high quality mode from codebase

### DIFF
--- a/include/AudioAlsa.h
+++ b/include/AudioAlsa.h
@@ -84,7 +84,6 @@ public:
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 	void run() override;
 
 	int setHWParams( const ch_cnt_t _channels, snd_pcm_access_t _access );

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -89,9 +89,7 @@ public:
 
 	virtual void stopProcessing();
 
-	virtual void applyQualitySettings();
-
-
+	void applyQualitySettings();
 
 protected:
 	// subclasses can re-implement this for being used in conjunction with
@@ -128,8 +126,6 @@ protected:
 	{
 		return m_audioEngine;
 	}
-
-	bool hqAudio() const;
 
 	static void stopProcessingThread( QThread * thread );
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -111,7 +111,6 @@ public:
 		enum class Mode
 		{
 			Draft,
-			HighQuality,
 			FinalMix
 		} ;
 
@@ -141,11 +140,6 @@ public:
 				case Mode::Draft:
 					interpolation = Interpolation::Linear;
 					oversampling = Oversampling::None;
-					break;
-				case Mode::HighQuality:
-					interpolation =
-						Interpolation::SincFastest;
-					oversampling = Oversampling::X2;
 					break;
 				case Mode::FinalMix:
 					interpolation = Interpolation::SincBest;

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -111,6 +111,7 @@ public:
 		enum class Mode
 		{
 			Draft,
+			HighQuality,
 			FinalMix
 		} ;
 
@@ -140,6 +141,11 @@ public:
 				case Mode::Draft:
 					interpolation = Interpolation::Linear;
 					oversampling = Oversampling::None;
+					break;
+				case Mode::HighQuality:
+					interpolation =
+						Interpolation::SincFastest;
+					oversampling = Oversampling::X2;
 					break;
 				case Mode::FinalMix:
 					interpolation = Interpolation::SincBest;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -93,7 +93,6 @@ private:
 
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 
 	void registerPort(AudioPort* port) override;
 	void unregisterPort(AudioPort* port) override;

--- a/include/AudioOss.h
+++ b/include/AudioOss.h
@@ -79,7 +79,6 @@ class setupWidget : public gui::AudioDeviceSetupWidget
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 	void run() override;
 
 	int m_audioFD;

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -109,7 +109,6 @@ public:
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 
 #ifdef PORTAUDIO_V19
 	static int _process_callback( const void *_inputBuffer, void * _outputBuffer,

--- a/include/AudioPulseAudio.h
+++ b/include/AudioPulseAudio.h
@@ -88,7 +88,6 @@ public:
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 	void run() override;
 
 	volatile bool m_quit;

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -74,7 +74,6 @@ public:
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 
 	static void sdlAudioCallback( void * _udata, Uint8 * _buf, int _len );
 	void sdlAudioCallback( Uint8 * _buf, int _len );

--- a/include/AudioSndio.h
+++ b/include/AudioSndio.h
@@ -75,7 +75,6 @@ public:
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
-	void applyQualitySettings() override;
 	void run() override;
 
 	struct sio_hdl *m_hdl;

--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -102,7 +102,6 @@ private slots:
 
 	// Audio settings widget.
 	void audioInterfaceChanged(const QString & driver);
-	void toggleHQAudioDev(bool enabled);
 	void updateBufferSizeWarning(int value);
 	void setBufferSize(int value);
 	void resetBufferSize();
@@ -180,7 +179,6 @@ private:
 	AswMap m_audioIfaceSetupWidgets;
 	trMap m_audioIfaceNames;
 	bool m_NaNHandler;
-	bool m_hqAudioDev;
 	int m_bufferSize;
 	QSlider * m_bufferSizeSlider;
 	QLabel * m_bufferSizeLbl;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -97,8 +97,6 @@ protected:
 	void mouseReleaseEvent(QMouseEvent * me) override;
 
 private slots:
-	void setHighQuality( bool );
-
 	void setMasterVolume( int new_val );
 	void showMasterVolumeFloat();
 	void updateMasterVolumeFloat( int new_val );

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -240,48 +240,6 @@ void AudioAlsa::stopProcessing()
 	stopProcessingThread( this );
 }
 
-
-
-
-void AudioAlsa::applyQualitySettings()
-{
-	if( hqAudio() )
-	{
-		setSampleRate( Engine::audioEngine()->processingSampleRate() );
-
-		if( m_handle != nullptr )
-		{
-			snd_pcm_close( m_handle );
-		}
-
-		if (int err = snd_pcm_open(&m_handle, probeDevice().toLatin1().constData(), SND_PCM_STREAM_PLAYBACK, 0);
-			err < 0)
-		{
-			printf( "Playback open error: %s\n",
-							snd_strerror( err ) );
-			return;
-		}
-
-		if (int err = setHWParams(channels(), SND_PCM_ACCESS_RW_INTERLEAVED); err < 0)
-		{
-			printf( "Setting of hwparams failed: %s\n",
-							snd_strerror( err ) );
-			return;
-		}
-		if (int err = setSWParams(); err < 0)
-		{
-			printf( "Setting of swparams failed: %s\n",
-							snd_strerror( err ) );
-			return;
-		}
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
-
 void AudioAlsa::run()
 {
 	auto temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -250,13 +250,4 @@ void AudioDevice::clearS16Buffer( int_sample_t * _outbuf, const fpp_t _frames )
 	memset( _outbuf, 0,  _frames * channels() * BYTES_PER_INT_SAMPLE );
 }
 
-
-
-
-bool AudioDevice::hqAudio() const
-{
-	return ConfigManager::inst()->value( "audioengine", "hqaudio" ).toInt();
-}
-
-
 } // namespace lmms

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -229,24 +229,6 @@ void AudioJack::stopProcessing()
 	m_stopped = true;
 }
 
-
-
-
-void AudioJack::applyQualitySettings()
-{
-	if (hqAudio())
-	{
-		setSampleRate(Engine::audioEngine()->processingSampleRate());
-
-		if (jack_get_sample_rate(m_client) != sampleRate()) { setSampleRate(jack_get_sample_rate(m_client)); }
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
-
 void AudioJack::registerPort(AudioPort* port)
 {
 #ifdef AUDIO_PORT_SUPPORT

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -254,41 +254,6 @@ void AudioOss::stopProcessing()
 	stopProcessingThread( this );
 }
 
-
-
-
-void AudioOss::applyQualitySettings()
-{
-	if( hqAudio() )
-	{
-		setSampleRate( Engine::audioEngine()->processingSampleRate() );
-
-		unsigned int value = sampleRate();
-		if ( ioctl( m_audioFD, SNDCTL_DSP_SPEED, &value ) < 0 )
-		{
-			perror( "SNDCTL_DSP_SPEED" );
-			printf( "Couldn't set audio frequency\n" );
-			return;
-		}
-		if( value != sampleRate() )
-		{
-			value = audioEngine()->baseSampleRate();
-			if ( ioctl( m_audioFD, SNDCTL_DSP_SPEED, &value ) < 0 )
-			{
-				perror( "SNDCTL_DSP_SPEED" );
-				printf( "Couldn't set audio frequency\n" );
-				return;
-			}
-			setSampleRate( value );
-		}
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
-
 void AudioOss::run()
 {
 	auto temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -229,38 +229,6 @@ void AudioPortAudio::stopProcessing()
 }
 
 
-
-
-void AudioPortAudio::applyQualitySettings()
-{
-	if( hqAudio() )
-	{
-
-		setSampleRate( Engine::audioEngine()->processingSampleRate() );
-		int samples = audioEngine()->framesPerPeriod();
-
-		PaError err = Pa_OpenStream(
-			&m_paStream,
-			supportsCapture() ? &m_inputParameters : nullptr,	// The input parameter
-			&m_outputParameters,	// The outputparameter
-			sampleRate(),
-			samples,
-			paNoFlag,		// Don't use any flags
-			_process_callback, 	// our callback function
-			this );
-	
-		if( err != paNoError )
-		{
-			printf( "Couldn't open PortAudio: %s\n", Pa_GetErrorText( err ) );
-			return;
-		}
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
 int AudioPortAudio::process_callback(
 	const float *_inputBuffer,
 	float * _outputBuffer,

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -109,22 +109,6 @@ void AudioPulseAudio::stopProcessing()
 }
 
 
-
-
-void AudioPulseAudio::applyQualitySettings()
-{
-	if( hqAudio() )
-	{
-//		setSampleRate( engine::audioEngine()->processingSampleRate() );
-
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
-
 /* This routine is called whenever the stream state changes */
 static void stream_state_callback( pa_stream *s, void * userdata )
 {

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -191,37 +191,6 @@ void AudioSdl::stopProcessing()
 	}
 }
 
-
-
-
-void AudioSdl::applyQualitySettings()
-{
-	// Better than if (0)
-#if 0
-	if( 0 )//hqAudio() )
-	{
-		SDL_CloseAudio();
-
-		setSampleRate( Engine::audioEngine()->processingSampleRate() );
-
-		m_audioHandle.freq = sampleRate();
-
-		SDL_AudioSpec actual; 
-
-		// open the audio device, forcing the desired format
-		if( SDL_OpenAudio( &m_audioHandle, &actual ) < 0 )
-		{
-			qCritical( "Couldn't open SDL-audio: %s\n", SDL_GetError() );
-		}
-	}
-#endif
-
-	AudioDevice::applyQualitySettings();
-}
-
-
-
-
 void AudioSdl::sdlAudioCallback( void * _udata, Uint8 * _buf, int _len )
 {
 	auto _this = static_cast<AudioSdl*>(_udata);

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -139,20 +139,6 @@ void AudioSndio::stopProcessing()
 	stopProcessingThread( this );
 }
 
-
-void AudioSndio::applyQualitySettings()
-{
-	if( hqAudio() )
-	{
-		setSampleRate( Engine::audioEngine()->processingSampleRate() );
-
-		/* change sample rate to sampleRate() */
-	}
-
-	AudioDevice::applyQualitySettings();
-}
-
-
 void AudioSndio::run()
 {
 	surroundSampleFrame * temp = new surroundSampleFrame[audioEngine()->framesPerPeriod()];

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -361,7 +361,7 @@ int main( int argc, char * * argv )
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);
 
-	AudioEngine::qualitySettings qs( AudioEngine::qualitySettings::Mode::HighQuality );
+	AudioEngine::qualitySettings qs(AudioEngine::qualitySettings::Mode::Draft);
 	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::BitDepth::Depth16Bit, OutputSettings::StereoMode::JointStereo );
 	ProjectRenderer::ExportFileFormat eff = ProjectRenderer::ExportFileFormat::Wave;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -361,7 +361,7 @@ int main( int argc, char * * argv )
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);
 
-	AudioEngine::qualitySettings qs(AudioEngine::qualitySettings::Mode::Draft);
+	AudioEngine::qualitySettings qs( AudioEngine::qualitySettings::Mode::HighQuality );
 	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::BitDepth::Depth16Bit, OutputSettings::StereoMode::JointStereo );
 	ProjectRenderer::ExportFileFormat eff = ProjectRenderer::ExportFileFormat::Wave;
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -322,19 +322,6 @@ QString SongEditor::getSnapSizeString() const
 	}
 }
 
-
-
-
-void SongEditor::setHighQuality( bool hq )
-{
-	Engine::audioEngine()->changeQuality( AudioEngine::qualitySettings(
-			hq ? AudioEngine::qualitySettings::Mode::HighQuality :
-				AudioEngine::qualitySettings::Mode::Draft ) );
-}
-
-
-
-
 void SongEditor::scrolled( int new_pos )
 {
 	update();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -142,17 +142,6 @@ SongEditor::SongEditor( Song * song ) :
 
 	int tempoSpinBoxCol = getGUI()->mainWindow()->addWidgetToToolBar( m_tempoSpinBox, 0 );
 
-#if 0
-	toolButton * hq_btn = new toolButton( embed::getIconPixmap( "hq_mode" ),
-						tr( "High quality mode" ),
-						nullptr, nullptr, tb );
-	hq_btn->setCheckable( true );
-	connect( hq_btn, SIGNAL(toggled(bool)),
-			this, SLOT(setHighQuality(bool)));
-	hq_btn->setFixedWidth( 42 );
-	getGUI()->mainWindow()->addWidgetToToolBar( hq_btn, 1, col );
-#endif
-
 	getGUI()->mainWindow()->addWidgetToToolBar( new TimeDisplayWidget, 1, tempoSpinBoxCol );
 
 	getGUI()->mainWindow()->addSpacingToToolBar( 10 );

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -142,8 +142,6 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 			"ui", "disableautoquit", "1").toInt()),
 	m_NaNHandler(ConfigManager::inst()->value(
 			"app", "nanhandler", "1").toInt()),
-	m_hqAudioDev(ConfigManager::inst()->value(
-			"audioengine", "hqaudio").toInt()),
 	m_bufferSize(ConfigManager::inst()->value(
 			"audioengine", "framesperaudiobuffer").toInt()),
 	m_midiAutoQuantize(ConfigManager::inst()->value(
@@ -560,10 +558,6 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	// audio_layout->addWidget(useNaNHandler);
 	// useNaNHandler->setChecked(m_NaNHandler);
 
-	// HQ mode checkbox
-	auto hqaudio = addCheckBox(tr("HQ mode for output audio device"), audioInterfaceBox, nullptr,
-		m_hqAudioDev, SLOT(toggleHQAudioDev(bool)), false);
-
 	// Buffer size group
 	QGroupBox * bufferSizeBox = new QGroupBox(tr("Buffer size"), audio_w);
 	QVBoxLayout * bufferSizeLayout = new QVBoxLayout(bufferSizeBox);
@@ -605,7 +599,6 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	// Audio layout ordering.
 	audio_layout->addWidget(audioInterfaceBox);
 	audio_layout->addWidget(as_w);
-	audio_layout->addWidget(hqaudio);
 	audio_layout->addWidget(bufferSizeBox);
 	audio_layout->addStretch();
 
@@ -970,8 +963,6 @@ void SetupDialog::accept()
 					m_audioIfaceNames[m_audioInterfaces->currentText()]);
 	ConfigManager::inst()->setValue("app", "nanhandler",
 					QString::number(m_NaNHandler));
-	ConfigManager::inst()->setValue("audioengine", "hqaudio",
-					QString::number(m_hqAudioDev));
 	ConfigManager::inst()->setValue("audioengine", "framesperaudiobuffer",
 					QString::number(m_bufferSize));
 	ConfigManager::inst()->setValue("audioengine", "mididev",
@@ -1173,17 +1164,6 @@ void SetupDialog::toggleDisableAutoQuit(bool enabled)
 {
 	m_disableAutoQuit = enabled;
 }
-
-
-
-
-// Audio settings slots.
-
-void SetupDialog::toggleHQAudioDev(bool enabled)
-{
-	m_hqAudioDev = enabled;
-}
-
 
 void SetupDialog::audioInterfaceChanged(const QString & iface)
 {


### PR DESCRIPTION
Many, many years ago (93a456c), high quality mode was merely disabled after it was noted that it can be problematic (which in fact it is) rather than being completely removed. Remove it from the codebase so we can get rid of some code and clean things up a bit.

This feature (and `qualitySettings` as a whole actually) is problematic since the settings are not applied for all of our resampling states, and the code currently only applies it for the resampling state in the current audio device (which is only utilized when we are moving from one sample rate to another and does not apply for AFP and sample tracks for example, so essentially the effect of higher quality interpolation is not even observed).

There are other reasons as well (having to reopen a new entire audio stream each time the quality changes, which does not seem like a good workflow, as well as the fact the oversampling multiplier is applied twice, since the sample rate of the audio device is set to `AudioEngine::processingSampleRate`, which is the original rate with the multiplier applied, so calls to `AudioEngine::processingSampleRate` would get a sample rate of `deviceSampleRate * multiplier * multiplier`).

Since its disabled for the most part, its mostly just in the way at this point (regardless of all the problems it would bring if it was implemented in full effect), so there's no need for it to be in the codebase.