### PR TITLE
Only set sample clips for valid files

### DIFF
--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -55,6 +55,7 @@ public:
 	SampleClip& operator=( const SampleClip& that ) = delete;
 
 	void changeLength( const TimePos & _length ) override;
+	void changeLengthToSampleLength();
 	const QString& sampleFile() const;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;

--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -57,6 +57,7 @@ public:
 	void changeLength( const TimePos & _length ) override;
 	void changeLengthToSampleLength();
 	const QString& sampleFile() const;
+	bool hasSampleFileLoaded(const QString & filename) const;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
 	void loadSettings( const QDomElement & _this ) override;

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -112,6 +112,11 @@ void SampleClip::changeLength( const TimePos & _length )
 	Clip::changeLength(std::max(static_cast<int>(_length), 1));
 }
 
+void SampleClip::changeLengthToSampleLength()
+{
+	int length = static_cast<int>(m_sample.sampleSize() / Engine::framesPerTick());
+	changeLength(length);
+}
 
 
 
@@ -129,6 +134,8 @@ void SampleClip::setSampleBuffer(std::shared_ptr<const SampleBuffer> sb)
 	updateLength();
 
 	emit sampleChanged();
+
+	Engine::getSong()->setModified();
 }
 
 void SampleClip::setSampleFile(const QString& sf)
@@ -210,6 +217,8 @@ void SampleClip::setIsPlaying(bool isPlaying)
 void SampleClip::updateLength()
 {
 	emit sampleChanged();
+
+	Engine::getSong()->setModified();
 }
 
 

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -125,6 +125,11 @@ const QString& SampleClip::sampleFile() const
 	return m_sample.sampleFile();
 }
 
+bool SampleClip::hasSampleFileLoaded(const QString & filename) const
+{
+	return m_sample.sampleFile() == filename;
+}
+
 void SampleClip::setSampleBuffer(std::shared_ptr<const SampleBuffer> sb)
 {
 	{

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -114,7 +114,7 @@ void SampleClip::changeLength( const TimePos & _length )
 
 void SampleClip::changeLengthToSampleLength()
 {
-	int length = static_cast<int>(m_sample.sampleSize() / Engine::framesPerTick());
+	int length = m_sample.sampleSize() / Engine::framesPerTick();
 	changeLength(length);
 }
 

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -180,20 +180,17 @@ void SampleClipView::mouseReleaseEvent(QMouseEvent *_me)
 
 void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 {
-	QString af = SampleLoader::openAudioFile();
+	const QString selectedAudioFile = SampleLoader::openAudioFile();
 
-	// Don't do anything if no file is loaded
-	if (af.isEmpty()) { return; }
+	if (selectedAudioFile.isEmpty()) { return; }
 	
-	if (af == m_clip->m_sample.sampleFile())
+	if (m_clip->hasSampleFileLoaded(selectedAudioFile))
 	{
-		// Don't reload the same file again. Just reset the size.
 		m_clip->changeLengthToSampleLength();
 	}
 	else
 	{
-		// Load the new file and set it for the clip
-		auto sampleBuffer = SampleLoader::createBufferFromFile(af);
+		auto sampleBuffer = SampleLoader::createBufferFromFile(selectedAudioFile);
 		if (sampleBuffer != SampleBuffer::emptyBuffer())
 		{
 			m_clip->setSampleBuffer(sampleBuffer);

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -128,7 +128,6 @@ void SampleClipView::dropEvent( QDropEvent * _de )
 		m_clip->updateLength();
 		update();
 		_de->accept();
-		Engine::getSong()->setModified();
 	}
 	else
 	{
@@ -190,8 +189,7 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 	if (af == m_clip->m_sample.sampleFile())
 	{
 		// Don't reload the same file again. Just reset the size.
-		int length = static_cast<int>(m_clip->m_sample.sampleSize() / Engine::framesPerTick());
-		m_clip->changeLength(length);
+		m_clip->changeLengthToSampleLength();
 	}
 	else
 	{
@@ -200,9 +198,6 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 		if (sampleBuffer != SampleBuffer::emptyBuffer())
 		{
 			m_clip->setSampleBuffer(sampleBuffer);
-
-			// TODO Why do we have to do this here? This should happen in the core...
-			Engine::getSong()->setModified();
 		}
 	}
 }

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -26,7 +26,6 @@
 
 #include <QApplication>
 #include <QMenu>
-#include <QMessageBox>
 #include <QPainter>
 
 #include "GuiApplication.h"

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -26,6 +26,7 @@
 
 #include <QApplication>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPainter>
 
 #include "GuiApplication.h"
@@ -183,16 +184,26 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 {
 	QString af = SampleLoader::openAudioFile();
 
-	if ( af.isEmpty() ) {} //Don't do anything if no file is loaded
-	else if (af == m_clip->m_sample.sampleFile())
-	{	//Instead of reloading the existing file, just reset the size
+	// Don't do anything if no file is loaded
+	if (af.isEmpty()) { return; }
+	
+	if (af == m_clip->m_sample.sampleFile())
+	{
+		// Don't reload the same file again. Just reset the size.
 		int length = static_cast<int>(m_clip->m_sample.sampleSize() / Engine::framesPerTick());
 		m_clip->changeLength(length);
 	}
 	else
-	{	//Otherwise load the new file as ususal
-		m_clip->setSampleFile( af );
-		Engine::getSong()->setModified();
+	{
+		// Load the new file and set it for the clip
+		auto sampleBuffer = SampleLoader::createBufferFromFile(af);
+		if (sampleBuffer != SampleBuffer::emptyBuffer())
+		{
+			m_clip->setSampleBuffer(sampleBuffer);
+
+			// TODO Why do we have to do this here? This should happen in the core...
+			Engine::getSong()->setModified();
+		}
 	}
 }
 


### PR DESCRIPTION
Check if a non-empty buffer was loaded and only set the sample clip if that's the case.

Fix code formatting.

Fixes #6287.