### PR TITLE
Remove global oversampling

### DIFF
--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -89,8 +89,6 @@ public:
 
 	virtual void stopProcessing();
 
-	void applyQualitySettings();
-
 protected:
 	// subclasses can re-implement this for being used in conjunction with
 	// processNextBuffer()
@@ -109,13 +107,6 @@ protected:
 	// clear given signed-int-16-buffer
 	void clearS16Buffer( int_sample_t * _outbuf,
 							const fpp_t _frames );
-
-	// resample given buffer from samplerate _src_sr to samplerate _dst_sr
-	fpp_t resample( const surroundSampleFrame * _src,
-					const fpp_t _frames,
-					surroundSampleFrame * _dst,
-					const sample_rate_t _src_sr,
-					const sample_rate_t _dst_sr );
 
 	inline void setSampleRate( const sample_rate_t _new_sr )
 	{
@@ -141,9 +132,6 @@ private:
 	bool m_inProcess;
 
 	QMutex m_devMutex;
-
-	SRC_DATA m_srcData;
-	SRC_STATE * m_srcState;
 
 	surroundSampleFrame * m_buffer;
 

--- a/include/AudioDummy.h
+++ b/include/AudioDummy.h
@@ -104,7 +104,7 @@ private:
 				delete[] b;
 			}
 
-			const int microseconds = static_cast<int>( audioEngine()->framesPerPeriod() * 1000000.0f / audioEngine()->processingSampleRate() - timer.elapsed() );
+			const int microseconds = static_cast<int>( audioEngine()->framesPerPeriod() * 1000000.0f / audioEngine()->outputSampleRate() - timer.elapsed() );
 			if( microseconds > 0 )
 			{
 				usleep( microseconds );

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -108,13 +108,6 @@ public:
 
 	struct qualitySettings
 	{
-		enum class Mode
-		{
-			Draft,
-			HighQuality,
-			FinalMix
-		} ;
-
 		enum class Interpolation
 		{
 			Linear,
@@ -123,53 +116,11 @@ public:
 			SincBest
 		} ;
 
-		enum class Oversampling
-		{
-			None,
-			X2,
-			X4,
-			X8
-		} ;
-
 		Interpolation interpolation;
-		Oversampling oversampling;
 
-		qualitySettings(Mode m)
+		qualitySettings(Interpolation i) :
+			interpolation(i)
 		{
-			switch (m)
-			{
-				case Mode::Draft:
-					interpolation = Interpolation::Linear;
-					oversampling = Oversampling::None;
-					break;
-				case Mode::HighQuality:
-					interpolation =
-						Interpolation::SincFastest;
-					oversampling = Oversampling::X2;
-					break;
-				case Mode::FinalMix:
-					interpolation = Interpolation::SincBest;
-					oversampling = Oversampling::X8;
-					break;
-			}
-		}
-
-		qualitySettings(Interpolation i, Oversampling o) :
-			interpolation(i),
-			oversampling(o)
-		{
-		}
-
-		int sampleRateMultiplier() const
-		{
-			switch( oversampling )
-			{
-				case Oversampling::None: return 1;
-				case Oversampling::X2: return 2;
-				case Oversampling::X4: return 4;
-				case Oversampling::X8: return 8;
-			}
-			return 1;
 		}
 
 		int libsrcInterpolation() const
@@ -289,8 +240,6 @@ public:
 	sample_rate_t baseSampleRate() const;
 	sample_rate_t outputSampleRate() const;
 	sample_rate_t inputSampleRate() const;
-	sample_rate_t processingSampleRate() const;
-
 
 	inline float masterGain() const
 	{

--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -107,7 +107,7 @@ public:
 	 */
 	static inline float freqToLen( float f )
 	{
-		return freqToLen( f, Engine::audioEngine()->processingSampleRate() );
+		return freqToLen( f, Engine::audioEngine()->outputSampleRate() );
 	}
 
 	/*! \brief This method converts frequency to wavelength, but you can use any custom sample rate with it.

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -111,7 +111,7 @@ public:
 
 	inline f_cnt_t timeout() const
 	{
-		const float samples = Engine::audioEngine()->processingSampleRate() * m_autoQuitModel.value() / 1000.0f;
+		const float samples = Engine::audioEngine()->outputSampleRate() * m_autoQuitModel.value() / 1000.0f;
 		return 1 + ( static_cast<int>( samples ) / Engine::audioEngine()->framesPerPeriod() );
 	}
 
@@ -192,7 +192,7 @@ protected:
 							sample_rate_t _dst_sr )
 	{
 		resample( 0, _src_buf,
-				Engine::audioEngine()->processingSampleRate(),
+				Engine::audioEngine()->outputSampleRate(),
 					_dst_buf, _dst_sr,
 					Engine::audioEngine()->framesPerPeriod() );
 	}
@@ -202,9 +202,9 @@ protected:
 							sample_rate_t _src_sr )
 	{
 		resample( 1, _src_buf, _src_sr, _dst_buf,
-				Engine::audioEngine()->processingSampleRate(),
+				Engine::audioEngine()->outputSampleRate(),
 			Engine::audioEngine()->framesPerPeriod() * _src_sr /
-				Engine::audioEngine()->processingSampleRate() );
+				Engine::audioEngine()->outputSampleRate() );
 	}
 	void reinitSRC();
 

--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -204,7 +204,7 @@ public:
 					control.f1 + 1 :
 					0;
 		control.band = waveTableBandFromFreq(
-			m_freq * m_detuning_div_samplerate * Engine::audioEngine()->processingSampleRate());
+			m_freq * m_detuning_div_samplerate * Engine::audioEngine()->outputSampleRate());
 		return control;
 	}
 

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -77,8 +77,8 @@ public:
 	};
 
 	Sample() = default;
-	Sample(const QByteArray& base64, int sampleRate = Engine::audioEngine()->processingSampleRate());
-	Sample(const sampleFrame* data, size_t numFrames, int sampleRate = Engine::audioEngine()->processingSampleRate());
+	Sample(const QByteArray& base64, int sampleRate = Engine::audioEngine()->outputSampleRate());
+	Sample(const sampleFrame* data, size_t numFrames, int sampleRate = Engine::audioEngine()->outputSampleRate());
 	Sample(const Sample& other);
 	Sample(Sample&& other);
 	explicit Sample(const QString& audioFile);

--- a/include/SampleBuffer.h
+++ b/include/SampleBuffer.h
@@ -56,7 +56,7 @@ public:
 	SampleBuffer(const QString& base64, int sampleRate);
 	SampleBuffer(std::vector<sampleFrame> data, int sampleRate);
 	SampleBuffer(
-		const sampleFrame* data, size_t numFrames, int sampleRate = Engine::audioEngine()->processingSampleRate());
+		const sampleFrame* data, size_t numFrames, int sampleRate = Engine::audioEngine()->outputSampleRate());
 
 	friend void swap(SampleBuffer& first, SampleBuffer& second) noexcept;
 	auto toBase64() const -> QString;
@@ -91,7 +91,7 @@ public:
 private:
 	std::vector<sampleFrame> m_data;
 	QString m_audioFile;
-	sample_rate_t m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	sample_rate_t m_sampleRate = Engine::audioEngine()->outputSampleRate();
 };
 
 } // namespace lmms

--- a/include/SampleLoader.h
+++ b/include/SampleLoader.h
@@ -39,7 +39,7 @@ public:
 	static QString openWaveformFile(const QString& previousFile = "");
 	static std::shared_ptr<const SampleBuffer> createBufferFromFile(const QString& filePath);
 	static std::shared_ptr<const SampleBuffer> createBufferFromBase64(
-		const QString& base64, int sampleRate = Engine::audioEngine()->processingSampleRate());
+		const QString& base64, int sampleRate = Engine::audioEngine()->outputSampleRate());
 private:
 	static void displayError(const QString& message);
 };

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -284,7 +284,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 	// Otherwise, use the remaining sample duration
 	const auto baseFreq = instrumentTrack()->baseFreq();
 	const auto freqFactor = baseFreq / note->frequency()
-		* Engine::audioEngine()->processingSampleRate()
+		* Engine::audioEngine()->outputSampleRate()
 		/ Engine::audioEngine()->baseSampleRate();
 
 	const auto startFrame = m_nextPlayStartPoint >= m_sample.endFrame()

--- a/plugins/BassBooster/BassBooster.cpp
+++ b/plugins/BassBooster/BassBooster.cpp
@@ -118,7 +118,7 @@ bool BassBoosterEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames
 
 inline void BassBoosterEffect::changeFrequency()
 {
-	const sample_t fac = Engine::audioEngine()->processingSampleRate() / 44100.0f;
+	const sample_t fac = Engine::audioEngine()->outputSampleRate() / 44100.0f;
 
 	m_bbFX.leftFX().setFrequency( m_bbControls.m_freqModel.value() * fac );
 	m_bbFX.rightFX().setFrequency( m_bbControls.m_freqModel.value() * fac );

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -265,7 +265,7 @@ void BitInvader::playNote( NotePlayHandle * _n,
 					const_cast<float*>( m_graph.samples() ),
 					_n,
 					m_interpolation.value(), factor,
-				Engine::audioEngine()->processingSampleRate() );
+				Engine::audioEngine()->outputSampleRate() );
 	}
 
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -59,7 +59,7 @@ Plugin::Descriptor PLUGIN_EXPORT bitcrush_plugin_descriptor =
 BitcrushEffect::BitcrushEffect( Model * parent, const Descriptor::SubPluginFeatures::Key * key ) :
 	Effect( &bitcrush_plugin_descriptor, parent, key ),
 	m_controls( this ),
-	m_sampleRate( Engine::audioEngine()->processingSampleRate() ),
+	m_sampleRate( Engine::audioEngine()->outputSampleRate() ),
 	m_filter( m_sampleRate )
 {
 	m_buffer = new sampleFrame[Engine::audioEngine()->framesPerPeriod() * OS_RATE];
@@ -83,7 +83,7 @@ BitcrushEffect::~BitcrushEffect()
 
 void BitcrushEffect::sampleRateChanged()
 {
-	m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_sampleRate = Engine::audioEngine()->outputSampleRate();
 	m_filter.setSampleRate( m_sampleRate );
 	m_filter.setLowpass( m_sampleRate * ( CUTOFF_RATIO * OS_RATIO ) );
 	m_needsUpdate = true;

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -259,7 +259,7 @@ uint32_t CarlaInstrument::handleGetBufferSize() const
 
 double CarlaInstrument::handleGetSampleRate() const
 {
-    return Engine::audioEngine()->processingSampleRate();
+    return Engine::audioEngine()->outputSampleRate();
 }
 
 bool CarlaInstrument::handleIsOffline() const

--- a/plugins/Compressor/Compressor.cpp
+++ b/plugins/Compressor/Compressor.cpp
@@ -56,7 +56,7 @@ CompressorEffect::CompressorEffect(Model* parent, const Descriptor::SubPluginFea
 	Effect(&compressor_plugin_descriptor, parent, key),
 	m_compressorControls(this)
 {
-	m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_sampleRate = Engine::audioEngine()->outputSampleRate();
 
 	m_yL[0] = m_yL[1] = COMP_NOISE_FLOOR;
 
@@ -560,7 +560,7 @@ inline void CompressorEffect::calcTiltFilter(sample_t inputSample, sample_t &out
 
 void CompressorEffect::changeSampleRate()
 {
-	m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_sampleRate = Engine::audioEngine()->outputSampleRate();
 
 	m_coeffPrecalc = COMP_LOG / (m_sampleRate * 0.001f);
 

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -55,7 +55,7 @@ Plugin::Descriptor PLUGIN_EXPORT crossovereq_plugin_descriptor =
 CrossoverEQEffect::CrossoverEQEffect( Model* parent, const Descriptor::SubPluginFeatures::Key* key ) :
 	Effect( &crossovereq_plugin_descriptor, parent, key ),
 	m_controls( this ),
-	m_sampleRate( Engine::audioEngine()->processingSampleRate() ),
+	m_sampleRate( Engine::audioEngine()->outputSampleRate() ),
 	m_lp1( m_sampleRate ),
 	m_lp2( m_sampleRate ),
 	m_lp3( m_sampleRate ),
@@ -78,7 +78,7 @@ CrossoverEQEffect::~CrossoverEQEffect()
 
 void CrossoverEQEffect::sampleRateChanged()
 {
-	m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_sampleRate = Engine::audioEngine()->outputSampleRate();
 	m_lp1.setSampleRate( m_sampleRate );
 	m_lp2.setSampleRate( m_sampleRate );
 	m_lp3.setSampleRate( m_sampleRate );

--- a/plugins/Delay/DelayEffect.cpp
+++ b/plugins/Delay/DelayEffect.cpp
@@ -58,8 +58,8 @@ DelayEffect::DelayEffect( Model* parent, const Plugin::Descriptor::SubPluginFeat
 	m_delayControls( this )
 {
 	m_delay = 0;
-	m_delay = new StereoDelay( 20, Engine::audioEngine()->processingSampleRate() );
-	m_lfo = new Lfo( Engine::audioEngine()->processingSampleRate() );
+	m_delay = new StereoDelay( 20, Engine::audioEngine()->outputSampleRate() );
+	m_lfo = new Lfo( Engine::audioEngine()->outputSampleRate() );
 	m_outGain = 1.0;
 }
 
@@ -88,7 +88,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 		return( false );
 	}
 	double outSum = 0.0;
-	const float sr = Engine::audioEngine()->processingSampleRate();
+	const float sr = Engine::audioEngine()->outputSampleRate();
 	const float d = dryLevel();
 	const float w = wetLevel();
 	auto dryS = std::array<sample_t, 2>{};
@@ -123,7 +123,7 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 		m_delay->setFeedback( *feedbackPtr );
 		m_lfo->setFrequency( *lfoTimePtr );
-		m_currentLength = static_cast<int>(*lengthPtr * Engine::audioEngine()->processingSampleRate());
+		m_currentLength = static_cast<int>(*lengthPtr * Engine::audioEngine()->outputSampleRate());
 		m_delay->setLength( m_currentLength + ( *amplitudePtr * ( float )m_lfo->tick() ) );
 		m_delay->tick( buf[f] );
 
@@ -151,8 +151,8 @@ bool DelayEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 
 void DelayEffect::changeSampleRate()
 {
-	m_lfo->setSampleRate( Engine::audioEngine()->processingSampleRate() );
-	m_delay->setSampleRate( Engine::audioEngine()->processingSampleRate() );
+	m_lfo->setSampleRate( Engine::audioEngine()->outputSampleRate() );
+	m_delay->setSampleRate( Engine::audioEngine()->outputSampleRate() );
 }
 
 

--- a/plugins/Dispersion/Dispersion.cpp
+++ b/plugins/Dispersion/Dispersion.cpp
@@ -52,7 +52,7 @@ Plugin::Descriptor PLUGIN_EXPORT dispersion_plugin_descriptor =
 DispersionEffect::DispersionEffect(Model* parent, const Descriptor::SubPluginFeatures::Key* key) :
 	Effect(&dispersion_plugin_descriptor, parent, key),
 	m_dispersionControls(this),
-	m_sampleRate(Engine::audioEngine()->processingSampleRate()),
+	m_sampleRate(Engine::audioEngine()->outputSampleRate()),
 	m_amountVal(0)
 {
 }

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -57,8 +57,8 @@ DualFilterEffect::DualFilterEffect( Model* parent, const Descriptor::SubPluginFe
 	Effect( &dualfilter_plugin_descriptor, parent, key ),
 	m_dfControls( this )
 {
-	m_filter1 = new BasicFilters<2>( Engine::audioEngine()->processingSampleRate() );
-	m_filter2 = new BasicFilters<2>( Engine::audioEngine()->processingSampleRate() );
+	m_filter1 = new BasicFilters<2>( Engine::audioEngine()->outputSampleRate() );
+	m_filter2 = new BasicFilters<2>( Engine::audioEngine()->outputSampleRate() );
 
 	// ensure filters get updated
 	m_filter1changed = true;

--- a/plugins/DualFilter/DualFilterControls.cpp
+++ b/plugins/DualFilter/DualFilterControls.cpp
@@ -111,8 +111,8 @@ void DualFilterControls::updateFilters()
 	
 	delete m_effect->m_filter1;
 	delete m_effect->m_filter2;
-	m_effect->m_filter1 = new BasicFilters<2>( Engine::audioEngine()->processingSampleRate() );
-	m_effect->m_filter2 = new BasicFilters<2>( Engine::audioEngine()->processingSampleRate() );
+	m_effect->m_filter1 = new BasicFilters<2>( Engine::audioEngine()->outputSampleRate() );
+	m_effect->m_filter2 = new BasicFilters<2>( Engine::audioEngine()->outputSampleRate() );
 	
 	// flag filters as needing recalculation
 	

--- a/plugins/DynamicsProcessor/DynamicsProcessor.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessor.cpp
@@ -64,8 +64,8 @@ DynProcEffect::DynProcEffect( Model * _parent,
 	m_dpControls( this )
 {
 	m_currentPeak[0] = m_currentPeak[1] = DYN_NOISE_FLOOR;
-	m_rms[0] = new RmsHelper( 64 * Engine::audioEngine()->processingSampleRate() / 44100 );
-	m_rms[1] = new RmsHelper( 64 * Engine::audioEngine()->processingSampleRate() / 44100 );
+	m_rms[0] = new RmsHelper( 64 * Engine::audioEngine()->outputSampleRate() / 44100 );
+	m_rms[1] = new RmsHelper( 64 * Engine::audioEngine()->outputSampleRate() / 44100 );
 	calcAttack();
 	calcRelease();
 }
@@ -82,12 +82,12 @@ DynProcEffect::~DynProcEffect()
 
 inline void DynProcEffect::calcAttack()
 {
-	m_attCoeff = std::exp((DNF_LOG / (m_dpControls.m_attackModel.value() * 0.001)) / Engine::audioEngine()->processingSampleRate());
+	m_attCoeff = std::exp((DNF_LOG / (m_dpControls.m_attackModel.value() * 0.001)) / Engine::audioEngine()->outputSampleRate());
 }
 
 inline void DynProcEffect::calcRelease()
 {
-	m_relCoeff = std::exp((DNF_LOG / (m_dpControls.m_releaseModel.value() * 0.001)) / Engine::audioEngine()->processingSampleRate());
+	m_relCoeff = std::exp((DNF_LOG / (m_dpControls.m_releaseModel.value() * 0.001)) / Engine::audioEngine()->outputSampleRate());
 }
 
 
@@ -122,8 +122,8 @@ bool DynProcEffect::processAudioBuffer( sampleFrame * _buf,
 
 	if( m_needsUpdate )
 	{
-		m_rms[0]->setSize( 64 * Engine::audioEngine()->processingSampleRate() / 44100 );
-		m_rms[1]->setSize( 64 * Engine::audioEngine()->processingSampleRate() / 44100 );
+		m_rms[0]->setSize( 64 * Engine::audioEngine()->outputSampleRate() / 44100 );
+		m_rms[1]->setSize( 64 * Engine::audioEngine()->outputSampleRate() / 44100 );
 		calcAttack();
 		calcRelease();
 		m_needsUpdate = false;

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -201,7 +201,7 @@ bool EqHandle::mousePressed() const
 float EqHandle::getPeakCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 	double w0 = 2 * LD_PI * freqZ / SR ;
 	double c = cosf( w0 );
 	double s = sinf( w0 );
@@ -238,7 +238,7 @@ float EqHandle::getPeakCurve( float x )
 float EqHandle::getHighShelfCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 	double w0 = 2 * LD_PI * freqZ / SR;
 	double c = cosf( w0 );
 	double s = sinf( w0 );
@@ -274,7 +274,7 @@ float EqHandle::getHighShelfCurve( float x )
 float EqHandle::getLowShelfCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 	double w0 = 2 * LD_PI * freqZ / SR ;
 	double c = cosf( w0 );
 	double s = sinf( w0 );
@@ -310,7 +310,7 @@ float EqHandle::getLowShelfCurve( float x )
 float EqHandle::getLowCutCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 	double w0 = 2 * LD_PI * freqZ / SR ;
 	double c = cosf( w0 );
 	double s = sinf( w0 );
@@ -353,7 +353,7 @@ float EqHandle::getLowCutCurve( float x )
 float EqHandle::getHighCutCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 	double w0 = 2 * LD_PI * freqZ / SR ;
 	double c = cosf( w0 );
 	double s = sinf( w0 );
@@ -527,7 +527,7 @@ void EqHandle::setlp48()
 
 double EqHandle::calculateGain(const double freq, const double a1, const double a2, const double b0, const double b1, const double b2 )
 {
-	const int SR = Engine::audioEngine()->processingSampleRate();
+	const int SR = Engine::audioEngine()->outputSampleRate();
 
 	const double w = 2 * LD_PI * freq / SR ;
 	const double PHI = pow( sin( w / 2 ), 2 ) * 4;

--- a/plugins/Eq/EqEffect.cpp
+++ b/plugins/Eq/EqEffect.cpp
@@ -66,7 +66,7 @@ EqEffect::EqEffect( Model *parent, const Plugin::Descriptor::SubPluginFeatures::
 
 bool EqEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 {
-	const int sampleRate = Engine::audioEngine()->processingSampleRate();
+	const int sampleRate = Engine::audioEngine()->outputSampleRate();
 
 	//wet/dry controls
 	const float dry = dryLevel();

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -102,7 +102,7 @@ void EqAnalyser::analyze( sampleFrame *buf, const fpp_t frames )
 			return;
 		}
 
-		m_sampleRate = Engine::audioEngine()->processingSampleRate();
+		m_sampleRate = Engine::audioEngine()->outputSampleRate();
 		const int LOWEST_FREQ = 0;
 		const int HIGHEST_FREQ = m_sampleRate / 2;
 

--- a/plugins/Flanger/FlangerEffect.cpp
+++ b/plugins/Flanger/FlangerEffect.cpp
@@ -58,9 +58,9 @@ FlangerEffect::FlangerEffect( Model *parent, const Plugin::Descriptor::SubPlugin
 	Effect( &flanger_plugin_descriptor, parent, key ),
 	m_flangerControls( this )
 {
-	m_lfo = new QuadratureLfo( Engine::audioEngine()->processingSampleRate() );
-	m_lDelay = new MonoDelay( 1, Engine::audioEngine()->processingSampleRate() );
-	m_rDelay = new MonoDelay( 1, Engine::audioEngine()->processingSampleRate() );
+	m_lfo = new QuadratureLfo( Engine::audioEngine()->outputSampleRate() );
+	m_lDelay = new MonoDelay( 1, Engine::audioEngine()->outputSampleRate() );
+	m_rDelay = new MonoDelay( 1, Engine::audioEngine()->outputSampleRate() );
 	m_noise = new Noise;
 }
 
@@ -99,9 +99,9 @@ bool FlangerEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 	double outSum = 0.0;
 	const float d = dryLevel();
 	const float w = wetLevel();
-	const float length = m_flangerControls.m_delayTimeModel.value() * Engine::audioEngine()->processingSampleRate();
+	const float length = m_flangerControls.m_delayTimeModel.value() * Engine::audioEngine()->outputSampleRate();
 	const float noise = m_flangerControls.m_whiteNoiseAmountModel.value();
-	float amplitude = m_flangerControls.m_lfoAmountModel.value() * Engine::audioEngine()->processingSampleRate();
+	float amplitude = m_flangerControls.m_lfoAmountModel.value() * Engine::audioEngine()->outputSampleRate();
 	bool invertFeedback = m_flangerControls.m_invertFeedbackModel.value();
 	m_lfo->setFrequency(  1.0/m_flangerControls.m_lfoFrequencyModel.value() );
 	m_lfo->setOffset( m_flangerControls.m_lfoPhaseModel.value() / 180 * D_PI );
@@ -143,9 +143,9 @@ bool FlangerEffect::processAudioBuffer( sampleFrame *buf, const fpp_t frames )
 
 void FlangerEffect::changeSampleRate()
 {
-	m_lfo->setSampleRate( Engine::audioEngine()->processingSampleRate() );
-	m_lDelay->setSampleRate( Engine::audioEngine()->processingSampleRate() );
-	m_rDelay->setSampleRate( Engine::audioEngine()->processingSampleRate() );
+	m_lfo->setSampleRate( Engine::audioEngine()->outputSampleRate() );
+	m_lDelay->setSampleRate( Engine::audioEngine()->outputSampleRate() );
+	m_rDelay->setSampleRate( Engine::audioEngine()->outputSampleRate() );
 }
 
 

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -231,7 +231,7 @@ float FreeBoyInstrument::desiredReleaseTimeMs() const
 void FreeBoyInstrument::playNote(NotePlayHandle* nph, sampleFrame* workingBuffer)
 {
 	const f_cnt_t tfp = nph->totalFramesPlayed();
-	const int samplerate = Engine::audioEngine()->processingSampleRate();
+	const int samplerate = Engine::audioEngine()->outputSampleRate();
 	const fpp_t frames = nph->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = nph->noteOffset();
 

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -323,7 +323,7 @@ void GigInstrument::playNote( NotePlayHandle * _n, sampleFrame * )
 void GigInstrument::play( sampleFrame * _working_buffer )
 {
 	const fpp_t frames = Engine::audioEngine()->framesPerPeriod();
-	const int rate = Engine::audioEngine()->processingSampleRate();
+	const int rate = Engine::audioEngine()->outputSampleRate();
 
 	// Initialize to zeros
 	std::memset( &_working_buffer[0][0], 0, DEFAULT_CHANNELS * frames * sizeof( float ) );
@@ -746,7 +746,7 @@ void GigInstrument::addSamples( GigNote & gignote, bool wantReleaseSample )
 			if( gignote.midiNote >= keyLow && gignote.midiNote <= keyHigh )
 			{
 				float attenuation = pDimRegion->GetVelocityAttenuation( gignote.velocity );
-				float length = (float) pSample->SamplesTotal / Engine::audioEngine()->processingSampleRate();
+				float length = (float) pSample->SamplesTotal / Engine::audioEngine()->outputSampleRate();
 
 				// TODO: sample panning? crossfade different layers?
 

--- a/plugins/Kicker/Kicker.cpp
+++ b/plugins/Kicker/Kicker.cpp
@@ -160,7 +160,7 @@ void KickerInstrument::playNote( NotePlayHandle * _n,
 {
 	const fpp_t frames = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();
-	const float decfr = m_decayModel.value() * Engine::audioEngine()->processingSampleRate() / 1000.0f;
+	const float decfr = m_decayModel.value() * Engine::audioEngine()->outputSampleRate() / 1000.0f;
 	const f_cnt_t tfp = _n->totalFramesPlayed();
 
 	if (!_n->m_pluginData)
@@ -184,7 +184,7 @@ void KickerInstrument::playNote( NotePlayHandle * _n,
 	}
 
 	auto so = static_cast<SweepOsc*>(_n->m_pluginData);
-	so->update( _working_buffer + offset, frames, Engine::audioEngine()->processingSampleRate() );
+	so->update( _working_buffer + offset, frames, Engine::audioEngine()->outputSampleRate() );
 
 	if( _n->isReleased() )
 	{

--- a/plugins/LOMM/LOMM.cpp
+++ b/plugins/LOMM/LOMM.cpp
@@ -50,7 +50,7 @@ extern "C"
 LOMMEffect::LOMMEffect(Model* parent, const Descriptor::SubPluginFeatures::Key* key) :
 	Effect(&lomm_plugin_descriptor, parent, key),
 	m_lommControls(this),
-	m_sampleRate(Engine::audioEngine()->processingSampleRate()),
+	m_sampleRate(Engine::audioEngine()->outputSampleRate()),
 	m_lp1(m_sampleRate),
 	m_lp2(m_sampleRate),
 	m_hp1(m_sampleRate),
@@ -76,7 +76,7 @@ LOMMEffect::LOMMEffect(Model* parent, const Descriptor::SubPluginFeatures::Key* 
 
 void LOMMEffect::changeSampleRate()
 {
-	m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_sampleRate = Engine::audioEngine()->outputSampleRate();
 	m_lp1.setSampleRate(m_sampleRate);
 	m_lp2.setSampleRate(m_sampleRate);
 	m_hp1.setSampleRate(m_sampleRate);

--- a/plugins/LadspaBrowser/LadspaPortDialog.cpp
+++ b/plugins/LadspaBrowser/LadspaPortDialog.cpp
@@ -90,11 +90,11 @@ LadspaPortDialog::LadspaPortDialog( const ladspa_key_t & _key )
 		{
 			if( min != NOHINT )
 			{
-				min *= Engine::audioEngine()->processingSampleRate();
+				min *= Engine::audioEngine()->outputSampleRate();
 			}
 			if( max != NOHINT )
 			{
-				max *= Engine::audioEngine()->processingSampleRate();
+				max *= Engine::audioEngine()->outputSampleRate();
 			}
 		}
 

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -143,13 +143,13 @@ bool LadspaEffect::processAudioBuffer( sampleFrame * _buf,
 	sampleFrame * o_buf = nullptr;
 	QVarLengthArray<sample_t> sBuf(_frames * DEFAULT_CHANNELS);
 
-	if( m_maxSampleRate < Engine::audioEngine()->processingSampleRate() )
+	if( m_maxSampleRate < Engine::audioEngine()->outputSampleRate() )
 	{
 		o_buf = _buf;
 		_buf = reinterpret_cast<sampleFrame*>(sBuf.data());
 		sampleDown( o_buf, _buf, m_maxSampleRate );
 		frames = _frames * m_maxSampleRate /
-				Engine::audioEngine()->processingSampleRate();
+				Engine::audioEngine()->outputSampleRate();
 	}
 
 	// Copy the LMMS audio buffer to the LADSPA input buffer and initialize
@@ -587,7 +587,7 @@ sample_rate_t LadspaEffect::maxSamplerate( const QString & _name )
 	{
 		return( __buggy_plugins[_name] );
 	}
-	return( Engine::audioEngine()->processingSampleRate() );
+	return( Engine::audioEngine()->outputSampleRate() );
 }
 
 

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -72,7 +72,7 @@ namespace lmms
 {
 
 
-//#define engine::audioEngine()->processingSampleRate() 44100.0f
+//#define engine::audioEngine()->outputSampleRate() 44100.0f
 const float sampleRateCutoff = 44100.0f;
 
 extern "C"
@@ -111,8 +111,8 @@ void Lb302Filter::recalc()
 {
 	vcf_e1 = exp(6.109 + 1.5876*(fs->envmod) + 2.1553*(fs->cutoff) - 1.2*(1.0-(fs->reso)));
 	vcf_e0 = exp(5.613 - 0.8*(fs->envmod) + 2.1553*(fs->cutoff) - 0.7696*(1.0-(fs->reso)));
-	vcf_e0*=M_PI/Engine::audioEngine()->processingSampleRate();
-	vcf_e1*=M_PI/Engine::audioEngine()->processingSampleRate();
+	vcf_e0*=M_PI/Engine::audioEngine()->outputSampleRate();
+	vcf_e1*=M_PI/Engine::audioEngine()->outputSampleRate();
 	vcf_e1 -= vcf_e0;
 
 	vcf_rescoeff = exp(-1.20 + 3.455*(fs->reso));
@@ -233,7 +233,7 @@ void Lb302Filter3Pole::envRecalc()
 
 #ifdef LB_24_IGNORE_ENVELOPE
 	// kfcn = fs->cutoff;
-	kfcn = 2.0 * kfco / Engine::audioEngine()->processingSampleRate();
+	kfcn = 2.0 * kfco / Engine::audioEngine()->outputSampleRate();
 #else
 	kfcn = w;
 #endif
@@ -405,7 +405,7 @@ void Lb302Synth::filterChanged()
 
 	float d = 0.2 + (2.3*vcf_dec_knob.value());
 
-	d *= Engine::audioEngine()->processingSampleRate(); // d *= smpl rate
+	d *= Engine::audioEngine()->outputSampleRate(); // d *= smpl rate
 	fs.envdecay = pow(0.1, 1.0/d * ENVINC);    // decay is 0.1 to the 1/d * ENVINC
 	                                           // vcf_envdecay is now adjusted for both
 	                                           // sampling rate and ENVINC
@@ -439,7 +439,7 @@ void Lb302Synth::recalcFilter()
 	// THIS IS OLD 3pole/24dB code, I may reintegrate it.  Don't need it
 	// right now.   Should be toggled by LB_24_RES_TRICK at the moment.
 
-	/*kfcn = 2.0 * (((vcf_cutoff*3000))) / engine::audioEngine()->processingSampleRate();
+	/*kfcn = 2.0 * (((vcf_cutoff*3000))) / engine::audioEngine()->outputSampleRate();
 	kp   = ((-2.7528*kfcn + 3.0429)*kfcn + 1.718)*kfcn - 0.9984;
 	kp1  = kp+1.0;
 	kp1h = 0.5*kp1;
@@ -450,12 +450,12 @@ void Lb302Synth::recalcFilter()
 }
 
 inline float GET_INC(float freq) {
-	return freq/Engine::audioEngine()->processingSampleRate();  // TODO: Use actual sampling rate.
+	return freq/Engine::audioEngine()->outputSampleRate();  // TODO: Use actual sampling rate.
 }
 
 int Lb302Synth::process(sampleFrame *outbuf, const int size)
 {
-	const float sampleRatio = 44100.f / Engine::audioEngine()->processingSampleRate();
+	const float sampleRatio = 44100.f / Engine::audioEngine()->outputSampleRate();
 
 	// Hold on to the current VCF, and use it throughout this period
 	Lb302Filter *filter = vcf.loadAcquire();
@@ -631,7 +631,7 @@ int Lb302Synth::process(sampleFrame *outbuf, const int size)
 		// Handle Envelope
 		if(vca_mode==VcaMode::Attack) {
 			vca_a+=(vca_a0-vca_a)*vca_attack;
-			if(sample_cnt>=0.5*Engine::audioEngine()->processingSampleRate())
+			if(sample_cnt>=0.5*Engine::audioEngine()->outputSampleRate())
 				vca_mode = VcaMode::Idle;
 		}
 		else if(vca_mode == VcaMode::Decay) {

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -1447,7 +1447,7 @@ void MonstroInstrument::updateLFOAtts()
 
 void MonstroInstrument::updateSamplerate()
 {
-	m_samplerate = Engine::audioEngine()->processingSampleRate();
+	m_samplerate = Engine::audioEngine()->outputSampleRate();
 
 	m_integrator = 0.5f - ( 0.5f - INTEGRATOR ) * 44100.0f / m_samplerate;
 	m_fmCorrection = 44100.f / m_samplerate * FM_AMOUNT;

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -55,7 +55,7 @@ MultitapEchoEffect::MultitapEchoEffect( Model* parent, const Descriptor::SubPlug
 	m_stages( 1 ),
 	m_controls( this ),
 	m_buffer( 16100.0f ),
-	m_sampleRate( Engine::audioEngine()->processingSampleRate() ),
+	m_sampleRate( Engine::audioEngine()->outputSampleRate() ),
 	m_sampleRatio( 1.0f / m_sampleRate )
 {
 	m_work = new sampleFrame[Engine::audioEngine()->framesPerPeriod()];

--- a/plugins/MultitapEcho/MultitapEchoControls.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControls.cpp
@@ -172,7 +172,7 @@ void MultitapEchoControls::lengthChanged()
 
 void MultitapEchoControls::sampleRateChanged()
 {
-	m_effect->m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_effect->m_sampleRate = Engine::audioEngine()->outputSampleRate();
 	m_effect->m_sampleRatio = 1.0f / m_effect->m_sampleRate;
 	m_effect->updateFilters( 0, 19 );
 }

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -552,7 +552,7 @@ void NesInstrument::playNote( NotePlayHandle * n, sampleFrame * workingBuffer )
 	
 	if (!n->m_pluginData)
 	{
-		auto nes = new NesObject(this, Engine::audioEngine()->processingSampleRate(), n);
+		auto nes = new NesObject(this, Engine::audioEngine()->outputSampleRate(), n);
 		n->m_pluginData = nes;
 	}
 

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -140,7 +140,7 @@ OpulenzInstrument::OpulenzInstrument( InstrumentTrack * _instrument_track ) :
 
 	// Create an emulator - samplerate, 16 bit, mono
 	emulatorMutex.lock();
-	theEmulator = new CTemuopl(Engine::audioEngine()->processingSampleRate(), true, false);
+	theEmulator = new CTemuopl(Engine::audioEngine()->outputSampleRate(), true, false);
 	theEmulator->init();
 	// Enable waveform selection
 	theEmulator->write(0x01,0x20);
@@ -231,7 +231,7 @@ OpulenzInstrument::~OpulenzInstrument() {
 void OpulenzInstrument::reloadEmulator() {
 	delete theEmulator;
 	emulatorMutex.lock();
-	theEmulator = new CTemuopl(Engine::audioEngine()->processingSampleRate(), true, false);
+	theEmulator = new CTemuopl(Engine::audioEngine()->outputSampleRate(), true, false);
 	theEmulator->init();
 	theEmulator->write(0x01,0x20);
 	emulatorMutex.unlock();

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -605,10 +605,10 @@ void OscillatorObject::updateDetuning()
 {
 	m_detuningLeft = powf( 2.0f, OrganicInstrument::s_harmonics[ static_cast<int>( m_harmModel.value() ) ]
 				+ (float)m_detuneModel.value() * CENT ) /
-				Engine::audioEngine()->processingSampleRate();
+				Engine::audioEngine()->outputSampleRate();
 	m_detuningRight = powf( 2.0f, OrganicInstrument::s_harmonics[ static_cast<int>( m_harmModel.value() ) ]
 				- (float)m_detuneModel.value() * CENT ) /
-				Engine::audioEngine()->processingSampleRate();
+				Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -55,7 +55,7 @@ ReverbSCEffect::ReverbSCEffect( Model* parent, const Descriptor::SubPluginFeatur
 	m_reverbSCControls( this )
 {
 	sp_create(&sp);
-	sp->sr = Engine::audioEngine()->processingSampleRate();
+	sp->sr = Engine::audioEngine()->outputSampleRate();
 
 	sp_revsc_create(&revsc);
 	sp_revsc_init(sp, revsc);
@@ -63,8 +63,8 @@ ReverbSCEffect::ReverbSCEffect( Model* parent, const Descriptor::SubPluginFeatur
 	sp_dcblock_create(&dcblk[0]);
 	sp_dcblock_create(&dcblk[1]);
 
-	sp_dcblock_init(sp, dcblk[0], Engine::audioEngine()->currentQualitySettings().sampleRateMultiplier() );
-	sp_dcblock_init(sp, dcblk[1], Engine::audioEngine()->currentQualitySettings().sampleRateMultiplier() );
+	sp_dcblock_init(sp, dcblk[0], 1);
+	sp_dcblock_init(sp, dcblk[1], 1);
 }
 
 ReverbSCEffect::~ReverbSCEffect()
@@ -132,7 +132,7 @@ bool ReverbSCEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames )
 void ReverbSCEffect::changeSampleRate()
 {
 	// Change sr variable in Soundpipe. does not need to be destroyed
-	sp->sr = Engine::audioEngine()->processingSampleRate();
+	sp->sr = Engine::audioEngine()->outputSampleRate();
 
 	mutex.lock();
 	sp_revsc_destroy(&revsc);
@@ -145,8 +145,8 @@ void ReverbSCEffect::changeSampleRate()
 	sp_dcblock_create(&dcblk[0]);
 	sp_dcblock_create(&dcblk[1]);
 
-	sp_dcblock_init(sp, dcblk[0], Engine::audioEngine()->currentQualitySettings().sampleRateMultiplier() );
-	sp_dcblock_init(sp, dcblk[1], Engine::audioEngine()->currentQualitySettings().sampleRateMultiplier() );
+	sp_dcblock_init(sp, dcblk[0], 1);
+	sp_dcblock_init(sp, dcblk[1], 1);
 	mutex.unlock();
 }
 

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -574,7 +574,7 @@ void Sf2Instrument::reloadSynth()
 	double tempRate;
 
 	// Set & get, returns the true sample rate
-	fluid_settings_setnum( m_settings, (char *) "synth.sample-rate", Engine::audioEngine()->processingSampleRate() );
+	fluid_settings_setnum( m_settings, (char *) "synth.sample-rate", Engine::audioEngine()->outputSampleRate() );
 	fluid_settings_getnum( m_settings, (char *) "synth.sample-rate", &tempRate );
 	m_internalSampleRate = static_cast<int>( tempRate );
 
@@ -616,7 +616,7 @@ void Sf2Instrument::reloadSynth()
 		fluid_synth_set_interp_method( m_synth, -1, FLUID_INTERP_DEFAULT );
 	}
 	m_synthMutex.unlock();
-	if( m_internalSampleRate < Engine::audioEngine()->processingSampleRate() )
+	if( m_internalSampleRate < Engine::audioEngine()->outputSampleRate() )
 	{
 		m_synthMutex.lock();
 		if( m_srcState != nullptr )
@@ -872,10 +872,10 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, sampleFrame * buf )
 {
 	m_synthMutex.lock();
 	fluid_synth_get_gain(m_synth); // This flushes voice updates as a side effect
-	if( m_internalSampleRate < Engine::audioEngine()->processingSampleRate() &&
+	if( m_internalSampleRate < Engine::audioEngine()->outputSampleRate() &&
 							m_srcState != nullptr )
 	{
-		const fpp_t f = frames * m_internalSampleRate / Engine::audioEngine()->processingSampleRate();
+		const fpp_t f = frames * m_internalSampleRate / Engine::audioEngine()->outputSampleRate();
 #ifdef __GNUC__
 		sampleFrame tmp[f];
 #else

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -444,7 +444,7 @@ QString SfxrInstrument::nodeName() const
 
 void SfxrInstrument::playNote( NotePlayHandle * _n, sampleFrame * _working_buffer )
 {
-	float currentSampleRate = Engine::audioEngine()->processingSampleRate();
+	float currentSampleRate = Engine::audioEngine()->outputSampleRate();
 
 	fpp_t frameNum = _n->framesLeftForCurrentPeriod();
 	const f_cnt_t offset = _n->noteOffset();

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -289,7 +289,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 						sampleFrame * _working_buffer )
 {
 	const int clockrate = C64_PAL_CYCLES_PER_SEC;
-	const int samplerate = Engine::audioEngine()->processingSampleRate();
+	const int samplerate = Engine::audioEngine()->outputSampleRate();
 
 	if (!_n->m_pluginData)
 	{

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -88,7 +88,7 @@ void SlicerT::playNote(NotePlayHandle* handle, sampleFrame* workingBuffer)
 	float speedRatio = static_cast<float>(m_originalBPM.value()) / bpm;
 	if (!m_enableSync.value()) { speedRatio = 1; }
 	speedRatio *= pitchRatio;
-	speedRatio *= Engine::audioEngine()->processingSampleRate() / static_cast<float>(m_originalSample.sampleRate());
+	speedRatio *= Engine::audioEngine()->outputSampleRate() / static_cast<float>(m_originalSample.sampleRate());
 
 	float sliceStart, sliceEnd;
 	if (noteIndex == 0) // full sample at base note
@@ -132,7 +132,7 @@ void SlicerT::playNote(NotePlayHandle* handle, sampleFrame* workingBuffer)
 		playbackState->setNoteDone(nextNoteDone);
 
 		// exponential fade out, applyRelease() not used since it extends the note length
-		int fadeOutFrames = m_fadeOutFrames.value() / 1000.0f * Engine::audioEngine()->processingSampleRate();
+		int fadeOutFrames = m_fadeOutFrames.value() / 1000.0f * Engine::audioEngine()->outputSampleRate();
 		int noteFramesLeft = noteLeft * m_originalSample.sampleSize() * speedRatio;
 		for (int i = 0; i < frames; i++)
 		{

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -53,7 +53,7 @@ SaProcessor::SaProcessor(const SaControls *controls) :
 	m_terminate(false),
 	m_inBlockSize(FFT_BLOCK_SIZES[0]),
 	m_fftBlockSize(FFT_BLOCK_SIZES[0]),
-	m_sampleRate(Engine::audioEngine()->processingSampleRate()),
+	m_sampleRate(Engine::audioEngine()->outputSampleRate()),
 	m_framesFilledUp(0),
 	m_spectrumActive(false),
 	m_waterfallActive(false),
@@ -166,7 +166,7 @@ void SaProcessor::analyze(LocklessRingBuffer<sampleFrame> &ring_buffer)
 				#endif
 
 				// update sample rate
-				m_sampleRate = Engine::audioEngine()->processingSampleRate();
+				m_sampleRate = Engine::audioEngine()->outputSampleRate();
 
 				// apply FFT window
 				for (unsigned int i = 0; i < m_inBlockSize; i++)

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -342,7 +342,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 						m_vibratoFreqModel.value(),
 						p,
 						(uint8_t) m_spreadModel.value(),
-				Engine::audioEngine()->processingSampleRate() );
+				Engine::audioEngine()->outputSampleRate() );
 		}
 		else if( p == 9 )
 		{
@@ -355,7 +355,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 						m_lfoSpeedModel.value(),
 						m_adsrModel.value(),
 						(uint8_t) m_spreadModel.value(),
-				Engine::audioEngine()->processingSampleRate() );
+				Engine::audioEngine()->outputSampleRate() );
 		}
 		else
 		{
@@ -368,7 +368,7 @@ void MalletsInstrument::playNote( NotePlayHandle * _n,
 						m_strikeModel.value() * 128.0,
 						speed,
 						(uint8_t) m_spreadModel.value(),
-				Engine::audioEngine()->processingSampleRate() );
+				Engine::audioEngine()->outputSampleRate() );
 		}
 		m.unlock();
 		static_cast<MalletsSynth *>(_n->m_pluginData)->setPresetIndex(p);

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -177,7 +177,7 @@ void OscillatorObject::updateDetuningLeft()
 {
 	m_detuningLeft = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
 				+ (float)m_fineLeftModel.value() ) / 1200.0f )
-				/ Engine::audioEngine()->processingSampleRate();
+				/ Engine::audioEngine()->outputSampleRate();
 }
 
 
@@ -187,7 +187,7 @@ void OscillatorObject::updateDetuningRight()
 {
 	m_detuningRight = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
 				+ (float)m_fineRightModel.value() ) / 1200.0f )
-				/ Engine::audioEngine()->processingSampleRate();
+				/ Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -206,7 +206,7 @@ void Vibed::playNote(NotePlayHandle* n, sampleFrame* workingBuffer)
 	if (!n->m_pluginData)
 	{
 		const auto newContainer = new StringContainer{n->frequency(),
-			Engine::audioEngine()->processingSampleRate(), s_sampleLength};
+			Engine::audioEngine()->outputSampleRate(), s_sampleLength};
 
 		n->m_pluginData = newContainer;
 

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -338,7 +338,7 @@ void VstPlugin::updateSampleRate()
 {
 	lock();
 	sendMessage( message( IdSampleRateInformation ).
-			addInt( Engine::audioEngine()->processingSampleRate() ) );
+			addInt( Engine::audioEngine()->outputSampleRate() ) );
 	waitForMessage( IdInformationUpdated, true );
 	unlock();
 }

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -332,7 +332,7 @@ void WatsynInstrument::playNote( NotePlayHandle * _n,
 	if (!_n->m_pluginData)
 	{
 		auto w = new WatsynObject(&A1_wave[0], &A2_wave[0], &B1_wave[0], &B2_wave[0], m_amod.value(), m_bmod.value(),
-			Engine::audioEngine()->processingSampleRate(), _n, Engine::audioEngine()->framesPerPeriod(), this);
+			Engine::audioEngine()->outputSampleRate(), _n, Engine::audioEngine()->framesPerPeriod(), this);
 
 		_n->m_pluginData = w;
 	}

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -204,14 +204,14 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 	if (!nph->m_pluginData) {
 
 		auto exprO1 = new ExprFront(m_outputExpression[0].constData(),
-			Engine::audioEngine()->processingSampleRate()); // give the "last" function a whole second
-		auto exprO2 = new ExprFront(m_outputExpression[1].constData(), Engine::audioEngine()->processingSampleRate());
+			Engine::audioEngine()->outputSampleRate()); // give the "last" function a whole second
+		auto exprO2 = new ExprFront(m_outputExpression[1].constData(), Engine::audioEngine()->outputSampleRate());
 
 		auto init_expression_step1 = [this, nph](ExprFront* e) { //lambda function to init exprO1 and exprO2
 			//add the constants and the variables to the expression.
 			e->add_constant("key", nph->key());//the key that was pressed.
 			e->add_constant("bnote", nph->instrumentTrack()->baseNote()); // the base note
-			e->add_constant("srate", Engine::audioEngine()->processingSampleRate());// sample rate of the audio engine
+			e->add_constant("srate", Engine::audioEngine()->outputSampleRate());// sample rate of the audio engine
 			e->add_constant("v", nph->getVolume() / 255.0); //volume of the note.
 			e->add_constant("tempo", Engine::getSong()->getTempo());//tempo of the song.
 			e->add_variable("A1", m_A1);//A1,A2,A3: general purpose input controls.
@@ -225,7 +225,7 @@ void Xpressive::playNote(NotePlayHandle* nph, sampleFrame* working_buffer) {
 		m_W2.setInterpolate(m_interpolateW2.value());
 		m_W3.setInterpolate(m_interpolateW3.value());
 		nph->m_pluginData = new ExprSynth(&m_W1, &m_W2, &m_W3, exprO1, exprO2, nph,
-				Engine::audioEngine()->processingSampleRate(), &m_panning1, &m_panning2, m_relTransition.value());
+				Engine::audioEngine()->outputSampleRate(), &m_panning1, &m_panning2, m_relTransition.value());
 	}
 
 	auto ps = static_cast<ExprSynth*>(nph->m_pluginData);

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -451,7 +451,7 @@ void ZynAddSubFxInstrument::initPlugin()
 						QDir( ConfigManager::inst()->factoryPresetsDir() +
 								"/ZynAddSubFX" ).absolutePath() ) ) );
 
-		m_remotePlugin->updateSampleRate( Engine::audioEngine()->processingSampleRate() );
+		m_remotePlugin->updateSampleRate( Engine::audioEngine()->outputSampleRate() );
 
 		// temporary workaround until the VST synchronization feature gets stripped out of the RemotePluginClient class
 		// causing not to send buffer size information requests
@@ -463,7 +463,7 @@ void ZynAddSubFxInstrument::initPlugin()
 	else
 	{
 		m_plugin = new LocalZynAddSubFx;
-		m_plugin->setSampleRate( Engine::audioEngine()->processingSampleRate() );
+		m_plugin->setSampleRate( Engine::audioEngine()->outputSampleRate() );
 		m_plugin->setBufferSize( Engine::audioEngine()->framesPerPeriod() );
 	}
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -83,7 +83,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	m_workers(),
 	m_numWorkers( QThread::idealThreadCount()-1 ),
 	m_newPlayHandles( PlayHandle::MaxNumber ),
-	m_qualitySettings( qualitySettings::Mode::Draft ),
+	m_qualitySettings(qualitySettings::Interpolation::Linear),
 	m_masterGain( 1.0f ),
 	m_audioDev( nullptr ),
 	m_oldAudioDev( nullptr ),
@@ -277,17 +277,6 @@ sample_rate_t AudioEngine::inputSampleRate() const
 							baseSampleRate();
 }
 
-
-
-
-sample_rate_t AudioEngine::processingSampleRate() const
-{
-	return outputSampleRate() * m_qualitySettings.sampleRateMultiplier();
-}
-
-
-
-
 bool AudioEngine::criticalXRuns() const
 {
 	return cpuLoad() >= 99 && Engine::getSong()->isExporting() == false;
@@ -459,7 +448,7 @@ const surroundSampleFrame *AudioEngine::renderNextBuffer()
 	renderStageMix();           // STAGE 3: do master mix in mixer
 
 	s_renderingThread = false;
-	m_profiler.finishPeriod(processingSampleRate(), m_framesPerPeriod);
+	m_profiler.finishPeriod(outputSampleRate(), m_framesPerPeriod);
 
 	return m_outputBufferRead;
 }
@@ -597,7 +586,6 @@ void AudioEngine::changeQuality(const struct qualitySettings & qs)
 	stopProcessing();
 
 	m_qualitySettings = qs;
-	m_audioDev->applyQualitySettings();
 
 	emit sampleRateChanged();
 	emit qualitySettingsChanged();

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -149,7 +149,7 @@ unsigned int Controller::runningFrames()
 // Get position in seconds
 float Controller::runningTime()
 {
-	return runningFrames() / Engine::audioEngine()->processingSampleRate();
+	return runningFrames() / Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -146,7 +146,7 @@ float Engine::framesPerTick(sample_rate_t sampleRate)
 
 void Engine::updateFramesPerTick()
 {
-	s_framesPerTick = s_audioEngine->processingSampleRate() * 60.0f * 4 / DefaultTicksPerBar / s_song->getTempo();
+	s_framesPerTick = s_audioEngine->outputSampleRate() * 60.0f * 4 / DefaultTicksPerBar / s_song->getTempo();
 }
 
 

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -410,7 +410,7 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 	QMutexLocker m(&m_paramMutex);
 
 	const float frames_per_env_seg = SECS_PER_ENV_SEGMENT *
-				Engine::audioEngine()->processingSampleRate();
+				Engine::audioEngine()->outputSampleRate();
 
 	// TODO: Remove the expKnobVals, time should be linear
 	const auto predelay_frames = static_cast<f_cnt_t>(frames_per_env_seg * expKnobVal(m_predelayModel.value()));
@@ -509,7 +509,7 @@ void EnvelopeAndLfoParameters::updateSampleVars()
 
 
 	const float frames_per_lfo_oscillation = SECS_PER_LFO_OSCILLATION *
-				Engine::audioEngine()->processingSampleRate();
+				Engine::audioEngine()->outputSampleRate();
 	m_lfoPredelayFrames = static_cast<f_cnt_t>( frames_per_lfo_oscillation *
 				expKnobVal( m_lfoPredelayModel.value() ) );
 	m_lfoAttackFrames = static_cast<f_cnt_t>( frames_per_lfo_oscillation *

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -203,7 +203,7 @@ float Instrument::computeReleaseTimeMsByFrameCount(f_cnt_t frames) const
 
 sample_rate_t Instrument::getSampleRate() const
 {
-	return Engine::audioEngine()->processingSampleRate();
+	return Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -369,7 +369,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	const int total_range = range * cnphv.size();
 
 	// number of frames that every note should be played
-	const auto arp_frames = (f_cnt_t)(m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->processingSampleRate());
+	const auto arp_frames = (f_cnt_t)(m_arpTimeModel.value() / 1000.0f * Engine::audioEngine()->outputSampleRate());
 	const auto gated_frames = (f_cnt_t)(m_arpGateModel.value() * arp_frames / 100.0f);
 
 	// used for calculating remaining frames for arp-note, we have to add

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -158,7 +158,7 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 
 		if( n->m_filter == nullptr )
 		{
-			n->m_filter = std::make_unique<BasicFilters<>>( Engine::audioEngine()->processingSampleRate() );
+			n->m_filter = std::make_unique<BasicFilters<>>( Engine::audioEngine()->outputSampleRate() );
 		}
 		n->m_filter->setFilterType( static_cast<BasicFilters<>::FilterType>(m_filterModel.value()) );
 

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -155,7 +155,7 @@ void LfoController::updatePhase()
 
 void LfoController::updateDuration()
 {
-	float newDurationF = Engine::audioEngine()->processingSampleRate() * m_speedModel.value();
+	float newDurationF = Engine::audioEngine()->outputSampleRate() * m_speedModel.value();
 
 	switch(m_multiplierModel.value() )
 	{

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -79,7 +79,7 @@ Oscillator::Oscillator(const IntModel *wave_shape_model,
 
 void Oscillator::update(sampleFrame* ab, const fpp_t frames, const ch_cnt_t chnl, bool modulator)
 {
-	if (m_freq >= Engine::audioEngine()->processingSampleRate() / 2)
+	if (m_freq >= Engine::audioEngine()->outputSampleRate() / 2)
 	{
 		BufferManager::clear(ab, frames);
 		return;
@@ -681,7 +681,7 @@ void Oscillator::updateFM( sampleFrame * _ab, const fpp_t _frames,
 	m_subOsc->update( _ab, _frames, _chnl, true );
 	recalcPhase();
 	const float osc_coeff = m_freq * m_detuning_div_samplerate;
-	const float sampleRateCorrection = 44100.0f / Engine::audioEngine()->processingSampleRate();
+	const float sampleRateCorrection = 44100.0f / Engine::audioEngine()->outputSampleRate();
 
 	for( fpp_t frame = 0; frame < _frames; ++frame )
 	{
@@ -697,7 +697,7 @@ void Oscillator::updateFM( sampleFrame * _ab, const fpp_t _frames,
 template<>
 inline sample_t Oscillator::getSample<Oscillator::WaveShape::Sine>(const float sample)
 {
-	const float current_freq = m_freq * m_detuning_div_samplerate * Engine::audioEngine()->processingSampleRate();
+	const float current_freq = m_freq * m_detuning_div_samplerate * Engine::audioEngine()->outputSampleRate();
 
 	if (!m_useWaveTable || current_freq < OscillatorConstants::MAX_FREQ)
 	{

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -80,7 +80,7 @@ void PeakController::updateValueBuffer()
 {
 	if( m_coeffNeedsUpdate )
 	{
-		const float ratio = 44100.0f / Engine::audioEngine()->processingSampleRate();
+		const float ratio = 44100.0f / Engine::audioEngine()->outputSampleRate();
 		m_attackCoeff = 1.0f - powf( 2.0f, -0.3f * ( 1.0f - m_peakEffect->attackModel()->value() ) * ratio );
 		m_decayCoeff = 1.0f -  powf( 2.0f, -0.3f * ( 1.0f - m_peakEffect->decayModel()->value()  ) * ratio );
 		m_coeffNeedsUpdate = false;

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -535,7 +535,7 @@ bool RemotePlugin::processMessage( const message & _m )
 
 		case IdSampleRateInformation:
 			reply = true;
-			reply_message.addInt( Engine::audioEngine()->processingSampleRate() );
+			reply_message.addInt( Engine::audioEngine()->outputSampleRate() );
 			break;
 
 		case IdBufferSizeInformation:

--- a/src/core/RingBuffer.cpp
+++ b/src/core/RingBuffer.cpp
@@ -34,7 +34,7 @@ namespace lmms
  
 RingBuffer::RingBuffer( f_cnt_t size ) : 
 	m_fpp( Engine::audioEngine()->framesPerPeriod() ),
-	m_samplerate( Engine::audioEngine()->processingSampleRate() ),
+	m_samplerate( Engine::audioEngine()->outputSampleRate() ),
 	m_size( size + m_fpp )
 {
 	m_buffer = new sampleFrame[ m_size ];
@@ -45,7 +45,7 @@ RingBuffer::RingBuffer( f_cnt_t size ) :
 
 RingBuffer::RingBuffer( float size ) : 
 	m_fpp( Engine::audioEngine()->framesPerPeriod() ),
-	m_samplerate( Engine::audioEngine()->processingSampleRate() )
+	m_samplerate( Engine::audioEngine()->outputSampleRate() )
 {
 	m_size = msToFrames( size ) + m_fpp;
 	m_buffer = new sampleFrame[ m_size ];
@@ -307,9 +307,9 @@ void RingBuffer::writeSwappedAddingMultiplied( sampleFrame * src, float offset, 
 
 void RingBuffer::updateSamplerate()
 {
-	float newsize = static_cast<float>( ( m_size - m_fpp ) * Engine::audioEngine()->processingSampleRate() ) / m_samplerate;
+	float newsize = static_cast<float>( ( m_size - m_fpp ) * Engine::audioEngine()->outputSampleRate() ) / m_samplerate;
 	m_size = static_cast<f_cnt_t>( ceilf( newsize ) ) + m_fpp;
-	m_samplerate = Engine::audioEngine()->processingSampleRate();
+	m_samplerate = Engine::audioEngine()->outputSampleRate();
 	delete[] m_buffer;
 	m_buffer = new sampleFrame[ m_size ];
 	memset( m_buffer, 0, m_size * sizeof( sampleFrame ) );

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -124,7 +124,7 @@ bool Sample::play(sampleFrame* dst, PlaybackState* state, size_t numFrames, floa
 	const auto pastBounds = state->m_frameIndex >= m_endFrame || (state->m_frameIndex < 0 && state->m_backwards);
 	if (loopMode == Loop::Off && pastBounds) { return false; }
 
-	const auto outputSampleRate = Engine::audioEngine()->processingSampleRate() * m_frequency / desiredFrequency;
+	const auto outputSampleRate = Engine::audioEngine()->outputSampleRate() * m_frequency / desiredFrequency;
 	const auto inputSampleRate = m_buffer->sampleRate();
 	const auto resampleRatio = outputSampleRate / inputSampleRate;
 	const auto marginSize = s_interpolationMargins[state->resampler().interpolationMode()];

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -293,7 +293,7 @@ void SampleClip::loadSettings( const QDomElement & _this )
 	if( sampleFile().isEmpty() && _this.hasAttribute( "data" ) )
 	{
 		auto sampleRate = _this.hasAttribute("sample_rate") ? _this.attribute("sample_rate").toInt() :
-			Engine::audioEngine()->processingSampleRate();
+			Engine::audioEngine()->outputSampleRate();
 
 		auto buffer = gui::SampleLoader::createBufferFromBase64(_this.attribute("data"), sampleRate);
 		m_sample = Sample(std::move(buffer));

--- a/src/core/SampleDecoder.cpp
+++ b/src/core/SampleDecoder.cpp
@@ -101,7 +101,7 @@ auto decodeSampleDS(const QString& audioFile) -> std::optional<SampleDecoder::Re
 	int_sample_t* dataPtr = nullptr;
 
 	auto ds = DrumSynth{};
-	const auto engineRate = Engine::audioEngine()->processingSampleRate();
+	const auto engineRate = Engine::audioEngine()->outputSampleRate();
 	const auto frames = ds.GetDSFileSamples(audioFile, dataPtr, DEFAULT_CHANNELS, engineRate);
 	const auto data = std::unique_ptr<int_sample_t[]>{dataPtr}; // NOLINT, we have to use a C-style array here
 

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -145,7 +145,7 @@ bool SamplePlayHandle::isFromTrack( const Track * _track ) const
 f_cnt_t SamplePlayHandle::totalFrames() const
 {
 	return (m_sample->endFrame() - m_sample->startFrame()) *
-			(static_cast<float>(Engine::audioEngine()->processingSampleRate()) / m_sample->sampleRate());
+			(static_cast<float>(Engine::audioEngine()->outputSampleRate()) / m_sample->sampleRate());
 }
 
 

--- a/src/core/VstSyncController.cpp
+++ b/src/core/VstSyncController.cpp
@@ -155,7 +155,7 @@ void VstSyncController::updateSampleRate()
 {
 	if (!m_syncData) { return; }
 
-	m_syncData->m_sampleRate = Engine::audioEngine()->processingSampleRate();
+	m_syncData->m_sampleRate = Engine::audioEngine()->outputSampleRate();
 
 #ifdef VST_SNC_LATENCY
 	m_syncData->m_latency = m_syncData->m_bufferSize * m_syncData->m_bpm / ( (float) m_syncData->m_sampleRate * 60 );

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -439,7 +439,7 @@ void Lv2Proc::initPlugin()
 	m_features.createFeatureVectors();
 
 	m_instance = lilv_plugin_instantiate(m_plugin,
-		Engine::audioEngine()->processingSampleRate(),
+		Engine::audioEngine()->outputSampleRate(),
 		m_features.featurePointers());
 
 	if (m_instance)
@@ -507,7 +507,7 @@ void Lv2Proc::initMOptions()
 		re-initialize, and this code section will be
 		executed again, creating a new option vector.
 	*/
-	float sampleRate = Engine::audioEngine()->processingSampleRate();
+	float sampleRate = Engine::audioEngine()->outputSampleRate();
 	int32_t blockLength = Engine::audioEngine()->framesPerPeriod();
 	int32_t sequenceSize = defaultEvbufSize();
 
@@ -568,7 +568,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 			{
 				AutoLilvNode node(lilv_port_get_name(m_plugin, lilvPort));
 				QString dispName = lilv_node_as_string(node.get());
-				sample_rate_t sr = Engine::audioEngine()->processingSampleRate();
+				sample_rate_t sr = Engine::audioEngine()->outputSampleRate();
 				if(meta.def() < meta.min(sr) || meta.def() > meta.max(sr))
 				{
 					qWarning()	<< "Warning: Plugin"
@@ -871,7 +871,7 @@ void Lv2Proc::dumpPort(std::size_t num)
 	qDebug() << "  visualization: " << Lv2Ports::toStr(port.m_vis);
 	if (port.m_type == Lv2Ports::Type::Control || port.m_type == Lv2Ports::Type::Cv)
 	{
-		sample_rate_t sr = Engine::audioEngine()->processingSampleRate();
+		sample_rate_t sr = Engine::audioEngine()->outputSampleRate();
 		qDebug() << "  default:" << port.def();
 		qDebug() << "  min:" << port.min(sr);
 		qDebug() << "  max:" << port.max(sr);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -210,7 +210,6 @@ void printHelp()
 		"  -p, --profile <out>            Dump profiling information to file <out>\n"
 		"  -s, --samplerate <samplerate>  Specify output samplerate in Hz\n"
 		"          Range: 44100 (default) to 192000\n"
-		"  -x, --oversampling <value>     Specify oversampling\n"
 		"          Possible values: 1, 2, 4, 8\n"
 		"          Default: 2\n\n",
 		LMMS_VERSION, LMMS_PROJECT_COPYRIGHT );
@@ -361,7 +360,7 @@ int main( int argc, char * * argv )
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);
 
-	AudioEngine::qualitySettings qs( AudioEngine::qualitySettings::Mode::HighQuality );
+	AudioEngine::qualitySettings qs(AudioEngine::qualitySettings::Interpolation::Linear);
 	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::BitDepth::Depth16Bit, OutputSettings::StereoMode::JointStereo );
 	ProjectRenderer::ExportFileFormat eff = ProjectRenderer::ExportFileFormat::Wave;
 
@@ -644,36 +643,6 @@ int main( int argc, char * * argv )
 			else
 			{
 				return usageError( QString( "Invalid interpolation method %1" ).arg( argv[i] ) );
-			}
-		}
-		else if( arg == "--oversampling" || arg == "-x" )
-		{
-			++i;
-
-			if( i == argc )
-			{
-				return usageError( "No oversampling specified" );
-			}
-
-
-			int o = QString( argv[i] ).toUInt();
-
-			switch( o )
-			{
-				case 1:
-		qs.oversampling = AudioEngine::qualitySettings::Oversampling::None;
-		break;
-				case 2:
-		qs.oversampling = AudioEngine::qualitySettings::Oversampling::X2;
-		break;
-				case 4:
-		qs.oversampling = AudioEngine::qualitySettings::Oversampling::X4;
-		break;
-				case 8:
-		qs.oversampling = AudioEngine::qualitySettings::Oversampling::X8;
-		break;
-				default:
-				return usageError( QString( "Invalid oversampling %1" ).arg( argv[i] ) );
 			}
 		}
 		else if( arg == "--import" )

--- a/src/gui/Lv2ViewBase.cpp
+++ b/src/gui/Lv2ViewBase.cpp
@@ -74,7 +74,7 @@ Lv2ViewProc::Lv2ViewProc(QWidget* parent, Lv2Proc* proc, int colNum) :
 						break;
 					case PortVis::Integer:
 					{
-						sample_rate_t sr = Engine::audioEngine()->processingSampleRate();
+						sample_rate_t sr = Engine::audioEngine()->outputSampleRate();
 						auto pMin = port.min(sr);
 						auto pMax = port.max(sr);
 						int numDigits = std::max(numDigitsAsInt(pMin), numDigitsAsInt(pMax));

--- a/src/gui/modals/ExportProjectDialog.cpp
+++ b/src/gui/modals/ExportProjectDialog.cpp
@@ -154,11 +154,8 @@ OutputSettings::StereoMode mapToStereoMode(int index)
 
 void ExportProjectDialog::startExport()
 {
-	AudioEngine::qualitySettings qs =
-			AudioEngine::qualitySettings(
-					static_cast<AudioEngine::qualitySettings::Interpolation>(interpolationCB->currentIndex()),
-					static_cast<AudioEngine::qualitySettings::Oversampling>(oversamplingCB->currentIndex()) );
-
+	auto qs = AudioEngine::qualitySettings(
+		static_cast<AudioEngine::qualitySettings::Interpolation>(interpolationCB->currentIndex()));
 	const auto samplerates = std::array{44100, 48000, 88200, 96000, 192000};
 	const auto bitrates = std::array{64, 128, 160, 192, 256, 320};
 

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -1223,7 +1223,7 @@ void SetupDialog::setBufferSize(int value)
 
 	m_bufferSize = value * BUFFERSIZE_RESOLUTION;
 	m_bufferSizeLbl->setText(tr("Frames: %1\nLatency: %2 ms").arg(m_bufferSize).arg(
-		1000.0f * m_bufferSize / Engine::audioEngine()->processingSampleRate(), 0, 'f', 1));
+		1000.0f * m_bufferSize / Engine::audioEngine()->outputSampleRate(), 0, 'f', 1));
 	updateBufferSizeWarning(m_bufferSize);
 }
 

--- a/src/gui/modals/export_project.ui
+++ b/src/gui/modals/export_project.ui
@@ -405,37 +405,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Oversampling:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="oversamplingCB">
-          <item>
-           <property name="text">
-            <string>1x (None)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>2x</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>4x</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>8x</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
          <spacer>
           <property name="orientation">
            <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Oversampling can have many different effects to the audio signal such as latency, phase issues, clipping, smearing, etc, so this should really be an option on a per-plugin basis, not globally across all of LMMS (which, in some places, shouldn't really need to oversample at all).

Also, since not everything that needs to be hooked up to the `sampleRateChanged` signal is connected to it (e.g., the filters in the EQ plugin), this feature doesn't get applied uniformly.