### PR TITLE
Add support for "factorysample:" prefix

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -101,6 +101,8 @@ private:
 
 	void cleanMetaNodes( QDomElement de );
 
+	void mapSrcAttributeInElementsWithResources(const QMap<QString, QString>& map);
+
 	// helper upgrade routines
 	void upgrade_0_2_1_20070501();
 	void upgrade_0_2_1_20070508();
@@ -130,6 +132,7 @@ private:
 	void upgrade_loopsRename();
 	void upgrade_noteTypes();
 	void upgrade_fixCMTDelays();
+	void upgrade_fixBassLoopsTypo();
 
 	// List of all upgrade methods
 	static const std::vector<UpgradeMethod> UPGRADE_METHODS;

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1871,44 +1871,62 @@ void DataFile::upgrade_sampleAndHold()
 }
 
 
+static QMap<QString, QString> buildReplacementMap()
+{
+	static constexpr auto loopBPMs = std::array{
+		std::pair{"bassloops/briff01", "140"},
+		std::pair{"bassloops/briff01", "140"},
+		std::pair{"bassloops/rave_bass01", "180"},
+		std::pair{"bassloops/rave_bass02", "180"},
+		std::pair{"bassloops/tb303_01", "123"},
+		std::pair{"bassloops/techno_bass01", "140"},
+		std::pair{"bassloops/techno_bass02", "140"},
+		std::pair{"bassloops/techno_synth01", "140"},
+		std::pair{"bassloops/techno_synth02", "140"},
+		std::pair{"bassloops/techno_synth03", "130"},
+		std::pair{"bassloops/techno_synth04", "140"},
+		std::pair{"beats/909beat01", "122"},
+		std::pair{"beats/break01", "168"},
+		std::pair{"beats/break02", "141"},
+		std::pair{"beats/break03", "168"},
+		std::pair{"beats/electro_beat01", "120"},
+		std::pair{"beats/electro_beat02", "119"},
+		std::pair{"beats/house_loop01", "142"},
+		std::pair{"beats/jungle01", "168"},
+		std::pair{"beats/rave_hihat01", "180"},
+		std::pair{"beats/rave_hihat02", "180"},
+		std::pair{"beats/rave_kick01", "180"},
+		std::pair{"beats/rave_kick02", "180"},
+		std::pair{"beats/rave_snare01", "180"},
+		std::pair{"latin/latin_brass01", "140"},
+		std::pair{"latin/latin_guitar01", "126"},
+		std::pair{"latin/latin_guitar02", "140"},
+		std::pair{"latin/latin_guitar03", "120"},
+	};
+
+	QMap<QString, QString> namesToNamesWithBPMsMap;
+
+	auto insertEntry = [&namesToNamesWithBPMsMap](const QString& originalName, const QString& bpm, const QString& prefix = "", const QString& extension = "ogg")
+	{
+		const QString original = prefix + originalName + "." + extension;
+		const QString replacement = prefix + originalName + " - " + bpm + " BPM." + extension;
+		
+		namesToNamesWithBPMsMap.insert(original, replacement);
+	};
+
+	for (const auto & loopBPM : loopBPMs)
+	{
+		insertEntry(loopBPM.first, loopBPM.second);
+		insertEntry(loopBPM.first, loopBPM.second, "factorysample:");
+	}
+
+	return namesToNamesWithBPMsMap;
+}
+
 // Change loops' filenames in <sampleclip>s
 void DataFile::upgrade_loopsRename()
 {
-	auto createEntry = [](const QString& originalName, const QString& bpm, const QString& extension = "ogg")
-	{
-		const QString replacement = originalName + " - " + bpm + " BPM." + extension;
-		return std::pair{originalName + "." + extension, replacement};
-	};
-
-	static const QMap<QString, QString> namesToNamesWithBPMsMap {
-		{ createEntry("bassloops/briff01", "140") },
-		{ createEntry("bassloops/rave_bass01", "180") },
-		{ createEntry("bassloops/rave_bass02", "180") },
-		{ createEntry("bassloops/tb303_01", "123") },
-		{ createEntry("bassloops/techno_bass01", "140") },
-		{ createEntry("bassloops/techno_bass02", "140") },
-		{ createEntry("bassloops/techno_synth01", "140") },
-		{ createEntry("bassloops/techno_synth02", "140") },
-		{ createEntry("bassloops/techno_synth03", "130") },
-		{ createEntry("bassloops/techno_synth04", "140") },
-		{ createEntry("beats/909beat01", "122") },
-		{ createEntry("beats/break01", "168") },
-		{ createEntry("beats/break02", "141") },
-		{ createEntry("beats/break03", "168") },
-		{ createEntry("beats/electro_beat01", "120") },
-		{ createEntry("beats/electro_beat02", "119") },
-		{ createEntry("beats/house_loop01", "142") },
-		{ createEntry("beats/jungle01", "168") },
-		{ createEntry("beats/rave_hihat01", "180") },
-		{ createEntry("beats/rave_hihat02", "180") },
-		{ createEntry("beats/rave_kick01", "180") },
-		{ createEntry("beats/rave_kick02", "180") },
-		{ createEntry("beats/rave_snare01", "180") },
-		{ createEntry("latin/latin_brass01", "140") },
-		{ createEntry("latin/latin_guitar01", "126") },
-		{ createEntry("latin/latin_guitar02", "140") },
-		{ createEntry("latin/latin_guitar03", "120") }
-	};
+	static const QMap<QString, QString> namesToNamesWithBPMsMap = buildReplacementMap();
 
 	// Replace loop sample names
 	for (const auto& [elem, srcAttrs] : ELEMENTS_WITH_RESOURCES)


### PR DESCRIPTION
Add support to upgrade files with `src` tags that are prefixed with `factorysample:`.

Fix the problem for projects that still have "bassloopes" in their source files.

See #7186 for more details.