### PR TITLE
Inform effects about changes in enabled model

### DIFF
--- a/include/Effect.h
+++ b/include/Effect.h
@@ -208,6 +208,8 @@ protected:
 	}
 	void reinitSRC();
 
+	virtual void onEnabledChanged() {}
+
 
 private:
 	EffectChain * m_parent;

--- a/plugins/DualFilter/DualFilter.cpp
+++ b/plugins/DualFilter/DualFilter.cpp
@@ -218,6 +218,11 @@ bool DualFilterEffect::processAudioBuffer( sampleFrame* buf, const fpp_t frames 
 	return isRunning();
 }
 
+void DualFilterEffect::onEnabledChanged()
+{
+	m_filter1->clearHistory();
+	m_filter2->clearHistory();
+}
 
 
 

--- a/plugins/DualFilter/DualFilter.h
+++ b/plugins/DualFilter/DualFilter.h
@@ -47,6 +47,8 @@ public:
 		return &m_dfControls;
 	}
 
+protected:
+	void onEnabledChanged() override;
 
 private:
 	DualFilterControls m_dfControls;

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -61,6 +61,10 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	{
 		m_autoQuitDisabled = true;
 	}
+
+	// Call the virtual method onEnabledChanged so that effects can react to changes,
+	// e.g. by resetting state.
+	connect(&m_enabledModel, &BoolModel::dataChanged, [this] { onEnabledChanged(); });
 }
 
 


### PR DESCRIPTION
Add the virtual method `Effect::onEnabledChanged` which can be overridden by effects so that they can react to state changes with regards to being enabled or bypassed. The call of this methods is connected to state changes of the enabled model in the constructor of `Effect`.

Implement the method in `DualFilterEffect` by resetting the history of the two filters. This is done to prevent pops that have been reported in #4612.

Fixes #4612.