### PR TITLE
Replace `processingSampleRate` with `outputSampleRate` in Lb302

### DIFF
--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -271,7 +271,7 @@ float Lb302Filter3Pole::process(const float& samp)
 static float computeDecayFactor(float decayTimeInSeconds, float targetedAttenuation)
 {
 	// This is the number of samples that correspond to the decay time in seconds
-	auto samplesNeededForDecay = decayTimeInSeconds * Engine::audioEngine()->processingSampleRate();
+	auto samplesNeededForDecay = decayTimeInSeconds * Engine::audioEngine()->outputSampleRate();
 
 	// This computes the factor that's needed to make a signal with a value of 1 decay to the
 	// targeted attenuation over the time in number of samples.


### PR DESCRIPTION
Missed this in #7228, I don't know how, the build compiled fine for me (I might've been on the wrong target again... :facepalm:, though the CI still gave me a green light?)

Oh, I know what happened. Changes were made upstream that involved a call to `processingSampleRate` and I didn't merge it in my branch.