### PR TITLE
Revamp resource embedding

### DIFF
--- a/include/TrackLabelButton.h
+++ b/include/TrackLabelButton.h
@@ -25,6 +25,8 @@
 #ifndef LMMS_GUI_TRACK_LABEL_BUTTON_H
 #define LMMS_GUI_TRACK_LABEL_BUTTON_H
 
+#include <string>
+
 #include <QToolButton>
 
 namespace lmms::gui
@@ -63,7 +65,7 @@ private:
 
 private:
 	TrackView * m_trackView;
-	QString m_iconName;
+	std::string m_iconName;
 	TrackRenameLineEdit * m_renameLineEdit;
 	QRect m_buttonRect;
 	QString elideName( const QString &name );

--- a/plugins/Eq/EqControlsDialog.cpp
+++ b/plugins/Eq/EqControlsDialog.cpp
@@ -123,10 +123,10 @@ EqControlsDialog::EqControlsDialog( EqControls *controls ) :
 		activeButton->setCheckable(true);
 		activeButton->setModel( m_parameterWidget->getBandModels( i )->active );
 
-		QString iconActiveFileName = "bandLabel" + QString::number(i+1);
-		QString iconInactiveFileName = "bandLabel" + QString::number(i+1) + "off";
-		activeButton->setActiveGraphic( PLUGIN_NAME::getIconPixmap( iconActiveFileName.toLatin1() ) );
-		activeButton->setInactiveGraphic( PLUGIN_NAME::getIconPixmap( iconInactiveFileName.toLatin1() ) );
+		const auto iconActiveFileName = "bandLabel" + std::to_string(i + 1);
+		const auto iconInactiveFileName = iconActiveFileName + "off";
+		activeButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap(iconActiveFileName));
+		activeButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap(iconInactiveFileName));
 		activeButton->move( distance - 2, 276 );
 		activeButton->setModel( m_parameterWidget->getBandModels( i )->active );
 

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -185,9 +185,9 @@ QPainterPath EqHandle::getCurvePath()
 
 void EqHandle::loadPixmap()
 {
-	QString fileName = "handle" + QString::number(m_numb+1);
-	if ( !isActiveHandle() ) { fileName = fileName + "inactive"; }
-	m_circlePixmap = PLUGIN_NAME::getIconPixmap( fileName.toLatin1() );
+	auto fileName = "handle" + std::to_string(m_numb + 1);
+	if (!isActiveHandle()) { fileName += "inactive"; }
+	m_circlePixmap = PLUGIN_NAME::getIconPixmap(fileName);
 }
 
 bool EqHandle::mousePressed() const

--- a/plugins/LOMM/LOMMControlDialog.h
+++ b/plugins/LOMM/LOMMControlDialog.h
@@ -86,7 +86,8 @@ public:
 		return spinBox;
 	}
 	
-	PixmapButton* createPixmapButton(const QString& text, QWidget* parent, int x, int y, BoolModel* model, const QString& activeIcon, const QString& inactiveIcon, const QString& tooltip)
+	PixmapButton* createPixmapButton(const QString& text, QWidget* parent, int x, int y, BoolModel* model,
+		std::string_view activeIcon, std::string_view inactiveIcon, const QString& tooltip)
 	{
 		PixmapButton* button = new PixmapButton(parent, text);
 		button->move(x, y);

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -342,7 +342,7 @@ PianoRoll::PianoRoll() :
 	// Set up note length model
 	m_noteLenModel.addItem( tr( "Last note" ),
 					std::make_unique<PixmapLoader>( "edit_draw" ) );
-	const auto pixmaps = std::array<QString, 11>{"whole", "half", "quarter", "eighth",
+	const auto pixmaps = std::array<std::string, 11>{"whole", "half", "quarter", "eighth",
 						"sixteenth", "thirtysecond", "triplethalf",
 						"tripletquarter", "tripleteighth",
 						"tripletsixteenth", "tripletthirtysecond"};

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -25,6 +25,10 @@
 
 #include "EnvelopeAndLfoView.h"
 
+#include <string_view>
+
+#include <QBoxLayout>
+
 #include "EnvelopeGraph.h"
 #include "LfoGraph.h"
 #include "EnvelopeAndLfoParameters.h"
@@ -38,9 +42,6 @@
 #include "TempoSyncKnob.h"
 #include "TextFloat.h"
 #include "Track.h"
-
-#include <QBoxLayout>
-
 
 namespace lmms
 {
@@ -63,7 +64,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 		return knob;
 	};
 
-	auto buildPixmapButton = [&](const QString& activePixmap, const QString& inactivePixmap)
+	auto buildPixmapButton = [&](std::string_view activePixmap, std::string_view inactivePixmap)
 	{
 		auto button = new PixmapButton(this, nullptr);
 		button->setActiveGraphic(embed::getIconPixmap(activePixmap));


### PR DESCRIPTION
This doesn't offer any immediate benefits, but is part of the work I'm doing towards a plugin manager and scanning system. I've separated it out into its own PR for easier reviewing, since it stands well on its own anyway.

The main changes that are relevant to my other work are these:
* The resource name passed to `getIconPixmap` can now be an absolute file path, to reference a file rather than embedded data.
* `PluginPixmapLoader::pixmapName` now returns the actual resource name (as `PixmapLoader` already did), so passing that value to `getIconPixmap` will produce the same results as calling `PluginPixmapLoader::pixmap`.
* The various resource functions and classes now take `std::string_view` or `std::string` instead of `QString`. The vast majority of calls to these pass string literals, so this has no effect in most cases. However, it helps reduce unnecessary Qt usage, and makes it simpler to use with standard library strings in the future.

Other noteable changes:
* `PluginPixmapLoader` can take XPM data too.
* `PixmapLoader::pixmap` now takes optional width and height parameters, like `getIconPixmap`.
* XPM data can now be entirely const.

I have also done some general cleanup and improvements to the code.