### PR TITLE
WIP: new effect rack interface and features

### DIFF
--- a/include/Effect.h
+++ b/include/Effect.h
@@ -125,12 +125,6 @@ public:
 		return 1.0f - m_wetDryModel.value();
 	}
 
-	inline float gate() const
-	{
-		const float level = m_gateModel.value();
-		return level*level * m_processors;
-	}
-
 	inline f_cnt_t bufferCount() const
 	{
 		return m_bufferCount;
@@ -227,7 +221,6 @@ private:
 
 	BoolModel m_enabledModel;
 	FloatModel m_wetDryModel;
-	FloatModel m_gateModel;
 	TempoSyncKnobModel m_autoQuitModel;
 	
 	bool m_autoQuitDisabled;

--- a/include/EffectLabelButton.h
+++ b/include/EffectLabelButton.h
@@ -1,0 +1,55 @@
+/*
+ * EffectLabelButton.h - class trackLabelButton
+ *
+ * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_EFFECT_LABEL_BUTTON_H
+#define LMMS_GUI_EFFECT_LABEL_BUTTON_H
+
+#include <QPushButton>
+
+namespace lmms::gui
+{
+
+class EffectView;
+
+class EffectLabelButton : public QPushButton
+{
+	Q_OBJECT
+public:
+	EffectLabelButton( EffectView * _tv, QWidget * _parent );
+	~EffectLabelButton() override = default;
+
+protected:
+	void paintEvent(QPaintEvent* pe) override;
+
+private:
+	EffectView * m_effectView;
+	QString m_iconName;
+	QRect m_buttonRect;
+	QString elideName( const QString &name );
+} ;
+
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_EFFECT_LABEL_BUTTON_H

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -70,6 +70,8 @@ public:
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseReleaseEvent(QMouseEvent* event) override;
 
+	void setViewWidth(int px);
+
 public slots:
 	void editControls();
 	void moveUp();
@@ -96,9 +98,9 @@ private:
 	QLabel* m_label;
 	Knob * m_wetDry;
 	TempoSyncKnob * m_autoQuit;
-	Knob * m_gate;
 	QMdiSubWindow * m_subWindow;
 	EffectControlDialog * m_controlView;
+	int m_viewWidth;
 	
 	bool m_dragging;
 	QGraphicsOpacityEffect* m_opacityEffect;

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -35,6 +35,8 @@ class QGroupBox;
 class QLabel;
 class QPushButton;
 class QMdiSubWindow;
+class QHBoxLayout;
+class QLabel;
 
 namespace lmms::gui
 {
@@ -62,7 +64,7 @@ public:
 	}
 
 	static constexpr int DEFAULT_WIDTH = 215;
-	static constexpr int DEFAULT_HEIGHT = 60;
+	static constexpr int DEFAULT_HEIGHT = 35;
 	
 	void mouseMoveEvent(QMouseEvent* event) override;
 	void mousePressEvent(QMouseEvent* event) override;
@@ -89,8 +91,9 @@ protected:
 
 
 private:
-	QPixmap m_bg;
+	QHBoxLayout* m_mainLayout;
 	LedCheckBox * m_bypass;
+	QLabel* m_label;
 	Knob * m_wetDry;
 	TempoSyncKnob * m_autoQuit;
 	Knob * m_gate;

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -29,6 +29,7 @@
 #include "AutomatableModel.h"
 #include "PluginView.h"
 #include "Effect.h"
+#include "EffectLabelButton.h"
 
 class QGraphicsOpacityEffect;
 class QGroupBox;
@@ -37,6 +38,7 @@ class QPushButton;
 class QMdiSubWindow;
 class QHBoxLayout;
 class QLabel;
+class QToolButton;
 
 namespace lmms::gui
 {
@@ -95,7 +97,7 @@ protected:
 private:
 	QHBoxLayout* m_mainLayout;
 	LedCheckBox * m_bypass;
-	QLabel* m_label;
+	EffectLabelButton* m_label;
 	Knob * m_wetDry;
 	TempoSyncKnob * m_autoQuit;
 	QMdiSubWindow * m_subWindow;
@@ -105,6 +107,7 @@ private:
 	bool m_dragging;
 	QGraphicsOpacityEffect* m_opacityEffect;
 
+	friend class EffectLabelButton;
 } ;
 
 

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -48,7 +48,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_bufferCount( 0 ),
 	m_enabledModel( true, this, tr( "Effect enabled" ) ),
 	m_wetDryModel( 1.0f, -1.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
-	m_gateModel( 0.0f, 0.0f, 1.0f, 0.01f, this, tr( "Gate" ) ),
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
@@ -89,7 +88,6 @@ void Effect::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	m_enabledModel.saveSettings( _doc, _this, "on" );
 	m_wetDryModel.saveSettings( _doc, _this, "wet" );
 	m_autoQuitModel.saveSettings( _doc, _this, "autoquit" );
-	m_gateModel.saveSettings( _doc, _this, "gate" );
 	controls()->saveState( _doc, _this );
 }
 
@@ -101,7 +99,6 @@ void Effect::loadSettings( const QDomElement & _this )
 	m_enabledModel.loadSettings( _this, "on" );
 	m_wetDryModel.loadSettings( _this, "wet" );
 	m_autoQuitModel.loadSettings( _this, "autoquit" );
-	m_gateModel.loadSettings( _this, "gate" );
 
 	QDomNode node = _this.firstChild();
 	while( !node.isNull() )
@@ -144,19 +141,19 @@ Effect * Effect::instantiate( const QString& pluginName,
 
 
 
-void Effect::checkGate( double _out_sum )
+void Effect::checkGate(double _out_sum)
 {
-	if( m_autoQuitDisabled )
+	if(m_autoQuitDisabled)
 	{
 		return;
 	}
 
 	// Check whether we need to continue processing input.  Restart the
 	// counter if the threshold has been exceeded.
-	if( _out_sum - gate() <= typeInfo<float>::minEps() )
+	if(_out_sum <= typeInfo<float>::minEps())
 	{
 		incrementBufferCount();
-		if( bufferCount() > timeout() )
+		if(bufferCount() > timeout())
 		{
 			stopRunning();
 			resetBufferCount();

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -104,6 +104,7 @@ SET(LMMS_SRCS
 	gui/widgets/CaptionMenu.cpp
 	gui/widgets/ComboBox.cpp
 	gui/widgets/CustomTextKnob.cpp
+	gui/widgets/EffectLabelButton.cpp
 	gui/widgets/Fader.cpp
 	gui/widgets/FloatModelEditorBase.cpp
 	gui/widgets/Graph.cpp

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -54,63 +54,55 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_controlView(nullptr),
 	m_dragging(false)
 {
-	setFixedSize(EffectView::DEFAULT_WIDTH, EffectView::DEFAULT_HEIGHT);
+	setViewWidth(EffectView::DEFAULT_WIDTH);
 
 	m_mainLayout = new QHBoxLayout();
 	m_mainLayout->setContentsMargins(8, 2, 8, 2);
 
 	// Disable effects that are of type "DummyEffect"
 	bool isEnabled = !dynamic_cast<DummyEffect *>( effect() );
-	m_bypass = new LedCheckBox( this, "", isEnabled ? LedCheckBox::LedColor::Green : LedCheckBox::LedColor::Red );
-	m_bypass->setEnabled( isEnabled );
+	m_bypass = new LedCheckBox(this, "", isEnabled ? LedCheckBox::LedColor::Green : LedCheckBox::LedColor::Red);
+	m_bypass->setEnabled(isEnabled);
 	m_bypass->setToolTip(tr("On/Off"));
 	m_mainLayout->addWidget(m_bypass);
 
 	QFont labelFont = adjustedToPixelSize(font(), 10);
-	labelFont.setBold( true );
+	labelFont.setBold(true);
 	m_label = new QLabel(this);
 	m_label->setText(model()->displayName());
 	m_label->setFont(labelFont);
 	m_mainLayout->addWidget(m_label);
 
-	m_wetDry = new Knob( KnobType::Small17, this );
-	m_wetDry->setEnabled( isEnabled );
-	m_wetDry->setHintText( tr( "Wet Level:" ), "" );
+	m_wetDry = new Knob(KnobType::Small17, this);
+	m_wetDry->setEnabled(isEnabled);
+	m_wetDry->setHintText(tr("Wet Level:"), "");
 	m_mainLayout->addWidget(m_wetDry);
 
-	m_autoQuit = new TempoSyncKnob( KnobType::Small17, this );
-	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
-	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
-	m_autoQuit->setVisible(!effect()->m_autoQuitDisabled);
+	m_autoQuit = new TempoSyncKnob(KnobType::Small17, this);
+	m_autoQuit->setEnabled(isEnabled && !effect()->m_autoQuitDisabled);
+	m_autoQuit->setHintText(tr( "Stop after:" ), "ms");
 	m_mainLayout->addWidget(m_autoQuit);
 
-	m_gate = new Knob( KnobType::Small17, this );
-	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
-	m_gate->setHintText( tr( "Gate:" ), "" );
-	m_gate->setVisible(!effect()->m_autoQuitDisabled);
-	m_mainLayout->addWidget(m_gate);
+	setModel(_model);
 
-
-	setModel( _model );
-
-	if( effect()->controls()->controlCount() > 0 )
+	if(effect()->controls()->controlCount() > 0)
 	{
 		auto ctls_btn = new QPushButton(tr("UI"), this);
 		QFont f = ctls_btn->font();
 		ctls_btn->setFont(adjustedToPixelSize(f, 10));
 		ctls_btn->setFixedSize(20, 20);
 		m_mainLayout->addWidget(ctls_btn);
-		connect( ctls_btn, SIGNAL(clicked()),
+		connect(ctls_btn, SIGNAL(clicked()),
 					this, SLOT(editControls()));
 
 		m_controlView = effect()->controls()->createView();
-		if( m_controlView )
+		if(m_controlView)
 		{
-			m_subWindow = getGUI()->mainWindow()->addWindowedWidget( m_controlView );
+			m_subWindow = getGUI()->mainWindow()->addWindowedWidget(m_controlView);
 
-			if ( !m_controlView->isResizable() )
+			if (!m_controlView->isResizable())
 			{
-				m_subWindow->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
+				m_subWindow->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 				if (m_subWindow->layout())
 				{
 					m_subWindow->layout()->setSizeConstraint(QLayout::SetFixedSize);
@@ -119,9 +111,9 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 			Qt::WindowFlags flags = m_subWindow->windowFlags();
 			flags &= ~Qt::WindowMaximizeButtonHint;
-			m_subWindow->setWindowFlags( flags );
+			m_subWindow->setWindowFlags(flags);
 
-			connect( m_controlView, SIGNAL(closed()),
+			connect(m_controlView, SIGNAL(closed()),
 					this, SLOT(closeEffects()));
 
 			m_subWindow->hide();
@@ -265,10 +257,10 @@ void EffectView::paintEvent( QPaintEvent * )
 	QPainter p( this );
 
 	QPainterPath path;
-	path.addRoundedRect(QRectF(2, 2, EffectView::DEFAULT_WIDTH - 4, EffectView::DEFAULT_HEIGHT - 4), 2, 2);
-	QPen pen(Qt::black, 2);
+	path.addRoundedRect(QRectF(2, 2, m_viewWidth - 4, EffectView::DEFAULT_HEIGHT - 4), 2, 2);
+	QPen pen(Qt::black, 1);
 	p.setPen(pen);
-	p.fillPath(path, QColor(32, 34, 36));
+	p.fillPath(path, QColor(0x3b, 0x42, 0x4a));
 	p.drawPath(path);
 }
 
@@ -280,7 +272,12 @@ void EffectView::modelChanged()
 	m_bypass->setModel( &effect()->m_enabledModel );
 	m_wetDry->setModel( &effect()->m_wetDryModel );
 	m_autoQuit->setModel( &effect()->m_autoQuitModel );
-	m_gate->setModel( &effect()->m_gateModel );
+}
+
+void EffectView::setViewWidth(int px)
+{
+	m_viewWidth = px;
+	setFixedSize(m_viewWidth, EffectView::DEFAULT_HEIGHT);
 }
 
 } // namespace lmms::gui

--- a/src/gui/widgets/EffectLabelButton.cpp
+++ b/src/gui/widgets/EffectLabelButton.cpp
@@ -1,0 +1,73 @@
+/*
+ * EffectLabelButton.cpp - implementation of class trackLabelButton, a label
+ *                          which is renamable by double-clicking it
+ *
+ * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#include "EffectLabelButton.h"
+
+#include <QMouseEvent>
+#include <QMdiSubWindow>
+
+#include "ConfigManager.h"
+#include "embed.h"
+#include "EffectView.h"
+#include "Effect.h"
+
+namespace lmms::gui
+{
+
+EffectLabelButton::EffectLabelButton( EffectView * _tv, QWidget * _parent ) :
+	QPushButton( _parent ),
+	m_effectView( _tv ),
+	m_iconName()
+{
+	setAttribute(Qt::WA_OpaquePaintEvent, true);
+	setAcceptDrops(false);
+
+	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
+	setStyleSheet("text-align:left;padding:2px;");
+
+	//setFixedSize( 160, 29 );
+	//setIconSize( QSize( 24, 24 ) );
+}
+
+void EffectLabelButton::paintEvent(QPaintEvent* pe)
+{
+	//setDown(!m_effectView->m_subWindow->isVisible());
+	QPushButton::paintEvent(pe);
+}
+
+QString EffectLabelButton::elideName( const QString &name )
+{
+	const int spacing = 16;
+	const int maxTextWidth = width() - spacing - iconSize().width();
+
+	setToolTip(name);
+
+	QFontMetrics metrics( font() );
+	QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextWidth );
+	return elidedName;
+}
+
+} // namespace lmms::gui


### PR DESCRIPTION
This is still a heavy work-in-progress PR.

- [x] Remove the broken gate knob
- [ ] EffectView redesign
  - [x] Remove fixed-width pixmaps; support arbitrary widths; use QT layouts rather than fixed positioning
  - [x] Hide the decay knob if plugin auto quit is disabled
  - [x] Shrink vertical height of effects
  - [ ] Make EffectView respect theming options/colors
  - [x] Open effect UI by clicking on effect name a la SongEditor