### PR TITLE
Improve audio quality implementation

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -106,40 +106,6 @@ public:
 		AudioEngine* m_audioEngine;
 	};
 
-	struct qualitySettings
-	{
-		enum class Interpolation
-		{
-			Linear,
-			SincFastest,
-			SincMedium,
-			SincBest
-		} ;
-
-		Interpolation interpolation;
-
-		qualitySettings(Interpolation i) :
-			interpolation(i)
-		{
-		}
-
-		int libsrcInterpolation() const
-		{
-			switch( interpolation )
-			{
-				case Interpolation::Linear:
-					return SRC_ZERO_ORDER_HOLD;
-				case Interpolation::SincFastest:
-					return SRC_SINC_FASTEST;
-				case Interpolation::SincMedium:
-					return SRC_SINC_MEDIUM_QUALITY;
-				case Interpolation::SincBest:
-					return SRC_SINC_BEST_QUALITY;
-			}
-			return SRC_LINEAR;
-		}
-	} ;
-
 	void initDevices();
 	void clear();
 	void clearNewPlayHandles();
@@ -161,10 +127,7 @@ public:
 
 	//! Set new audio device. Old device will be deleted,
 	//! unless it's stored using storeAudioDevice
-	void setAudioDevice( AudioDevice * _dev,
-				const struct qualitySettings & _qs,
-				bool _needs_fifo,
-				bool startNow );
+	void setAudioDevice(AudioDevice* _dev, bool _needs_fifo, bool startNow);
 	void storeAudioDevice();
 	void restoreAudioDevice();
 	inline AudioDevice * audioDev()
@@ -231,12 +194,6 @@ public:
 		return m_profiler.detailLoad(type);
 	}
 
-	const qualitySettings & currentQualitySettings() const
-	{
-		return m_qualitySettings;
-	}
-
-
 	sample_rate_t baseSampleRate() const;
 	sample_rate_t outputSampleRate() const;
 	sample_rate_t inputSampleRate() const;
@@ -299,8 +256,6 @@ public:
 		return hasFifoWriter() ? m_fifo->read() : renderNextBuffer();
 	}
 
-	void changeQuality(const struct qualitySettings & qs);
-
 	inline bool isMetronomeActive() const { return m_metronomeActive; }
 	inline void setMetronomeActive(bool value = true) { m_metronomeActive = value; }
 
@@ -318,7 +273,6 @@ public:
 
 
 signals:
-	void qualitySettingsChanged();
 	void sampleRateChanged();
 	void nextAudioBuffer( const lmms::surroundSampleFrame * buffer );
 
@@ -394,7 +348,6 @@ private:
 	ConstPlayHandleList m_playHandlesToRemove;
 
 
-	struct qualitySettings m_qualitySettings;
 	float m_masterGain;
 
 	// audio device stuff

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -35,12 +35,12 @@ namespace lmms {
 class LMMS_EXPORT AudioResampler
 {
 public:
+	//! Minimum number of samples that should be added to the end of the source buffer when resampling.
 	static constexpr auto MinimumResampleMargin = 4;
 
 	//! Resample `numSrcFrames` sample frames from `src` to `numDstFrames` sample frames in `dst` with a ratio of
 	//! `ratio = output_sample_rate/input_sample_rate`. Callers are expected to provide some margin of sample values (at
-	//! least 4 extra samples) at the end of `src` to ensure correct interpolation of sample values. Returns an error
-	//! when this function completes, if any.
+	//! least 4 extra samples) at the end of `src` to ensure correct interpolation of sample values.
 	void resample(float* dst, const float* src, size_t numDstFrames, size_t numSrcFrames, double ratio);
 
 	//! Interpolates the sample value at position `index` within `src` containing `size` samples.

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -43,7 +43,7 @@ public:
 
 	//! Interpolates the sample value at position `index` within `src` containing `size` samples.
 	//! Assumes that `src` represents an array of sample frames containing two samples each.
-	//! `prev` can be provided to provide the sample frame that occurs at `index - 1 < 0`.
+	//! `prev` can be provided to provide the sample frame that occurs at `index - 1`.
 	static float interpolate(
 		const float* src, size_t size, int index, float fractionalOffset, float* prev = nullptr);
 

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -43,6 +43,9 @@ public:
 	//! least 4 extra samples) at the end of `src` to ensure correct interpolation of sample values.
 	void resample(float* dst, const float* src, size_t numDstFrames, size_t numSrcFrames, double ratio);
 
+	//! Clear previous sample state from the resampler.
+	void clear();
+
 	//! Interpolates the sample value at position `index` within `src` containing `size` samples.
 	//! Assumes that `src` represents an array of sample frames containing two samples each.
 	//! `prev` can be provided to provide the sample frame that occurs at `index - 1`.

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -25,39 +25,30 @@
 #ifndef LMMS_AUDIO_RESAMPLER_H
 #define LMMS_AUDIO_RESAMPLER_H
 
+#include <cstddef>
 #include <samplerate.h>
 
+#include "lmms_basics.h"
 #include "lmms_export.h"
 
 namespace lmms {
-
 class LMMS_EXPORT AudioResampler
 {
 public:
-	struct ProcessResult
-	{
-		int error;
-		long inputFramesUsed;
-		long outputFramesGenerated;
-	};
+	//! Resample `numSrcFrames` sample frames from `src` to `numDstFrames` sample frames in `dst` with a ratio of
+	//! `ratio = output_sample_rate/input_sample_rate`. Callers are expected to provide some margin of sample values (at
+	//! least 4 extra samples) at the end of `src` to ensure correct interpolation of sample values. Returns an error
+	//! when this function completes, if any.
+	void resample(float* dst, const float* src, size_t numDstFrames, size_t numSrcFrames, double ratio);
 
-	AudioResampler(int interpolationMode, int channels);
-	AudioResampler(const AudioResampler&) = delete;
-	AudioResampler(AudioResampler&&) = delete;
-	~AudioResampler();
-
-	AudioResampler& operator=(const AudioResampler&) = delete;
-	AudioResampler& operator=(AudioResampler&&) = delete;
-
-	auto resample(const float* in, long inputFrames, float* out, long outputFrames, double ratio) -> ProcessResult;
-	auto interpolationMode() const -> int { return m_interpolationMode; }
-	auto channels() const -> int { return m_channels; }
+	//! Interpolates the sample value at position `index` within `src` containing `size` samples.
+	//! Assumes that `src` represents an array of sample frames containing two samples each.
+	//! `prev` can be provided to provide the sample frame that occurs at `index - 1`.
+	static float interpolate(
+		const float* src, size_t size, int index, float fractionalOffset, float* prev = nullptr);
 
 private:
-	int m_interpolationMode = -1;
-	int m_channels = 0;
-	int m_error = 0;
-	SRC_STATE* m_state = nullptr;
+	std::array<float, DEFAULT_CHANNELS> m_prevSamples{0.0f, 0.0f};
 };
 } // namespace lmms
 

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -1,7 +1,7 @@
 /*
- * AudioResampler.h - wrapper around libsamplerate
+ * AudioResampler.h
  *
- * Copyright (c) 2023 saker <sakertooth@gmail.com>
+ * Copyright (c) 2024 saker
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -35,6 +35,8 @@ namespace lmms {
 class LMMS_EXPORT AudioResampler
 {
 public:
+	static constexpr auto MinimumResampleMargin = 4;
+
 	//! Resample `numSrcFrames` sample frames from `src` to `numDstFrames` sample frames in `dst` with a ratio of
 	//! `ratio = output_sample_rate/input_sample_rate`. Callers are expected to provide some margin of sample values (at
 	//! least 4 extra samples) at the end of `src` to ensure correct interpolation of sample values. Returns an error

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -43,7 +43,7 @@ public:
 
 	//! Interpolates the sample value at position `index` within `src` containing `size` samples.
 	//! Assumes that `src` represents an array of sample frames containing two samples each.
-	//! `prev` can be provided to provide the sample frame that occurs at `index - 1`.
+	//! `prev` can be provided to provide the sample frame that occurs at `index - 1 < 0`.
 	static float interpolate(
 		const float* src, size_t size, int index, float fractionalOffset, float* prev = nullptr);
 

--- a/include/ProjectRenderer.h
+++ b/include/ProjectRenderer.h
@@ -60,11 +60,7 @@ public:
 		AudioFileDeviceInstantiaton m_getDevInst;
 	} ;
 
-
-	ProjectRenderer( const AudioEngine::qualitySettings & _qs,
-				const OutputSettings & _os,
-				ExportFileFormat _file_format,
-				const QString & _out_file );
+	ProjectRenderer(const OutputSettings& _os, ExportFileFormat _file_format, const QString& _out_file);
 	~ProjectRenderer() override = default;
 
 	bool isReady() const
@@ -94,8 +90,6 @@ private:
 	void run() override;
 
 	AudioFileDevice * m_fileDev;
-	AudioEngine::qualitySettings m_qualitySettings;
-
 	volatile int m_progress;
 	volatile bool m_abort;
 

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -40,12 +40,7 @@ class RenderManager : public QObject
 {
 	Q_OBJECT
 public:
-	RenderManager(
-		const AudioEngine::qualitySettings & qualitySettings,
-		const OutputSettings & outputSettings,
-		ProjectRenderer::ExportFileFormat fmt,
-		QString outputPath);
-
+	RenderManager(const OutputSettings& outputSettings, ProjectRenderer::ExportFileFormat fmt, QString outputPath);
 	~RenderManager() override;
 
 	/// Export all unmuted tracks into a single file
@@ -70,8 +65,6 @@ private:
 
 	void render( QString outputPath );
 
-	const AudioEngine::qualitySettings m_qualitySettings;
-	const AudioEngine::qualitySettings m_oldQualitySettings;
 	const OutputSettings m_outputSettings;
 	ProjectRenderer::ExportFileFormat m_format;
 	QString m_outputPath;

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -35,12 +35,6 @@ namespace lmms {
 class LMMS_EXPORT Sample
 {
 public:
-	// values for buffer margins, used for various libsamplerate interpolation modes
-	// the array positions correspond to the converter_type parameter values in libsamplerate
-	// if there appears problems with playback on some interpolation mode, then the value for that mode
-	// may need to be higher - conversely, to optimize, some may work with lower values
-	static constexpr auto s_interpolationMargins = std::array<int, 5>{64, 64, 64, 4, 4};
-
 	enum class Loop
 	{
 		Off,

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -48,27 +48,10 @@ public:
 		PingPong
 	};
 
-	class LMMS_EXPORT PlaybackState
+	struct LMMS_EXPORT PlaybackState
 	{
-	public:
-		PlaybackState(bool varyingPitch = false)
-			: m_varyingPitch(varyingPitch)
-		{
-		}
-
-		auto frameIndex() const -> double { return m_frameIndex; }
-		auto varyingPitch() const -> bool { return m_varyingPitch; }
-		auto backwards() const -> bool { return m_backwards; }
-
-		void setFrameIndex(double frameIndex) { m_frameIndex = frameIndex; }
-		void setVaryingPitch(bool varyingPitch) { m_varyingPitch = varyingPitch; }
-		void setBackwards(bool backwards) { m_backwards = backwards; }
-
-	private:
-		double m_frameIndex = 0;
-		bool m_varyingPitch = false;
-		bool m_backwards = false;
-		friend class Sample;
+		double frameIndex = 0;
+		bool backwards = false;
 	};
 
 	Sample() = default;

--- a/include/interpolation.h
+++ b/include/interpolation.h
@@ -36,48 +36,14 @@
 namespace lmms
 {
 
-inline float hermiteInterpolate( float x0, float x1, float x2, float x3,
-								float frac_pos )
+inline float hermiteInterpolate(float v0, float v1, float v2, float v3, float x)
 {
-	const float frsq = frac_pos*frac_pos;
-	const float frsq2 = 2*frsq;
-	return( ( (x2-x0) *0.5f ) * ( frac_pos * (frsq+1) -frsq2 ) +
-				( frsq2*frac_pos - 3*frsq ) * ( x1-x2 ) +
-			frsq2 * (frac_pos-1) * ( ( x3-x1 ) * 0.25f ) + x1 );
-
-/*
-   const float frsq	= frac_pos*frac_pos;
-   //const float frsq2	= 2*frsq;
-   frac_pos *= 0.5;
-   const float frcu	= frsq*frac_pos;
-   return (
-   
-   (frcu - frsq + frac_pos) * ((x2 - x0)) +
-   
-   (4*frcu - 3*frsq) * (x1 - x2)
-   //frsq*(2*frac_pos-3) * (x1 - x2)
-   
-   + (frcu - 0.5*frsq)*((x3 - x1))  
-    
-   + x1
-   
-   );
-*/
+	float c0 = v1;
+	float c1 = 1 / 2.0 * (v2 - v0);
+	float c2 = v0 - 5 / 2.0 * v1 + 2 * v2 - 1 / 2.0 * v3;
+	float c3 = 1 / 2.0 * (v3 - v0) + 3 / 2.0 * (v1 - v2);
+	return fastFmaf(fastFmaf(fastFmaf(c3, x, c2), x, c1), x, c0);
 }
-
-
-
-inline float cubicInterpolate( float v0, float v1, float v2, float v3, float x )
-{
-	float frsq = x*x;
-	float frcu = frsq*v0;
-	float t1 = v3 + 3*v1;
-
-	return( v1 + fastFmaf( 0.5f, frcu, x ) * ( v2 - frcu * ( 1.0f/6.0f ) -
-		fastFmaf( t1, ( 1.0f/6.0f ), -v0 ) * ( 1.0f/3.0f ) ) + frsq * x * ( t1 *
-		( 1.0f/6.0f ) - 0.5f * v2 ) + frsq * fastFmaf( 0.5f, v2, -v1 ) );
-}
-
 
 
 inline float cosinusInterpolate( float v0, float v1, float x )

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -123,9 +123,9 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 			m_nextPlayBackwards = false;
 		}
 
-		_n->m_pluginData = new Sample::PlaybackState(_n->hasDetuningInfo());
-		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->setFrameIndex(m_nextPlayStartPoint);
-		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->setBackwards(m_nextPlayBackwards);
+		_n->m_pluginData = new Sample::PlaybackState{};
+		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex = m_nextPlayStartPoint;
+		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards = m_nextPlayBackwards;
 
 // debug code
 /*		qDebug( "frames %d", m_sample->frames() );
@@ -141,7 +141,7 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 						static_cast<Sample::Loop>(m_loopModel.value())))
 		{
 			applyRelease( _working_buffer, _n );
-			emit isPlaying(static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex());
+			emit isPlaying(static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex);
 		}
 		else
 		{
@@ -155,8 +155,8 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 	}
 	if( m_stutterModel.value() == true )
 	{
-		m_nextPlayStartPoint = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex();
-		m_nextPlayBackwards = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards();
+		m_nextPlayStartPoint = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex;
+		m_nextPlayBackwards = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards;
 	}
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -72,8 +72,6 @@ public:
 	BoolModel & reverseModel() { return m_reverseModel; }
 	IntModel & loopModel() { return m_loopModel; }
 	BoolModel & stutterModel() { return m_stutterModel; }
-	ComboBoxModel & interpolationModel() { return m_interpolationModel; }
-
 
 public slots:
 	void setAudioFile(const QString& _audio_file, bool _rename = true);
@@ -102,7 +100,6 @@ private:
 	BoolModel m_reverseModel;
 	IntModel m_loopModel;
 	BoolModel m_stutterModel;
-	ComboBoxModel m_interpolationModel;
 
 	f_cnt_t m_nextPlayStartPoint;
 	bool m_nextPlayBackwards;

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -131,11 +131,7 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 	m_loopKnob->move(85, 108);
 	m_loopKnob->setHintText(tr("Loopback point:"), "");
 
-// interpolation selector
-	m_interpBox = new ComboBox(this);
-	m_interpBox->setGeometry(142, 62, 82, ComboBox::DEFAULT_HEIGHT);
-
-// wavegraph
+	// wavegraph
 	m_waveView = 0;
 	newWaveView();
 
@@ -276,7 +272,6 @@ void AudioFileProcessorView::modelChanged()
 	m_reverseButton->setModel(&a->reverseModel());
 	m_loopGroup->setModel(&a->loopModel());
 	m_stutterButton->setModel(&a->stutterModel());
-	m_interpBox->setModel(&a->interpolationModel());
 	sampleUpdated();
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.h
@@ -75,7 +75,6 @@ private:
 	PixmapButton* m_reverseButton;
 	automatableButtonGroup* m_loopGroup;
 	PixmapButton* m_stutterButton;
-	ComboBox* m_interpBox;
 } ;
 
 } // namespace gui

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -460,7 +460,6 @@ void GigInstrument::play( sampleFrame * _working_buffer )
 			{
 				sampleFrame convertBuf[frames];
 
-				// Only output if resampling is successful (note that "used" is output)
 				m_resampler.resample(&convertBuf[0][0], &sampleData[0][0], frames, samples, freq_factor);
 				used = samples;
 

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -461,13 +461,13 @@ void GigInstrument::play( sampleFrame * _working_buffer )
 				sampleFrame convertBuf[frames];
 
 				// Only output if resampling is successful (note that "used" is output)
-				if (sample.convertSampleRate(*sampleData, *convertBuf, samples, frames, freq_factor, used))
+				m_resampler.resample(&convertBuf[0][0], &sampleData[0][0], frames, samples, freq_factor);
+				used = samples;
+
+				for( f_cnt_t i = 0; i < frames; ++i )
 				{
-					for( f_cnt_t i = 0; i < frames; ++i )
-					{
-						_working_buffer[i][0] += convertBuf[i][0];
-						_working_buffer[i][1] += convertBuf[i][1];
-					}
+					_working_buffer[i][0] += convertBuf[i][0];
+					_working_buffer[i][1] += convertBuf[i][1];
 				}
 			}
 			else
@@ -1086,7 +1086,7 @@ void GigInstrumentView::showPatchDialog()
 GigSample::GigSample( gig::Sample * pSample, gig::DimensionRegion * pDimRegion,
 		float attenuation, int interpolation, float desiredFreq )
 	: sample( pSample ), region( pDimRegion ), attenuation( attenuation ),
-	  pos( 0 ), interpolation( interpolation ), srcState( nullptr ),
+	  pos( 0 ),
 	  sampleFreq( 0 ), freqFactor( 1 )
 {
 	if( sample != nullptr && region != nullptr )
@@ -1116,25 +1116,11 @@ GigSample::GigSample( gig::Sample * pSample, gig::DimensionRegion * pDimRegion,
 
 
 
-
-GigSample::~GigSample()
-{
-	if( srcState != nullptr )
-	{
-		src_delete( srcState );
-	}
-}
-
-
-
-
 GigSample::GigSample( const GigSample& g )
 	: sample( g.sample ), region( g.region ), attenuation( g.attenuation ),
-	  adsr( g.adsr ), pos( g.pos ), interpolation( g.interpolation ),
-	  srcState( nullptr ), sampleFreq( g.sampleFreq ), freqFactor( g.freqFactor )
+	  adsr( g.adsr ), pos( g.pos ),
+	  sampleFreq( g.sampleFreq ), freqFactor( g.freqFactor )
 {
-	// On the copy, we want to create the object
-	updateSampleRate();
 }
 
 
@@ -1147,86 +1133,10 @@ GigSample& GigSample::operator=( const GigSample& g )
 	attenuation = g.attenuation;
 	adsr = g.adsr;
 	pos = g.pos;
-	interpolation = g.interpolation;
-	srcState = nullptr;
 	sampleFreq = g.sampleFreq;
 	freqFactor = g.freqFactor;
-
-	if( g.srcState != nullptr )
-	{
-		updateSampleRate();
-	}
-
 	return *this;
 }
-
-
-
-
-void GigSample::updateSampleRate()
-{
-	if( srcState != nullptr )
-	{
-		src_delete( srcState );
-	}
-
-	int error = 0;
-	srcState = src_new( interpolation, DEFAULT_CHANNELS, &error );
-
-	if( srcState == nullptr || error != 0 )
-	{
-		qCritical( "error while creating libsamplerate data structure in GigSample" );
-	}
-}
-
-
-
-
-bool GigSample::convertSampleRate( sampleFrame & oldBuf, sampleFrame & newBuf,
-		f_cnt_t oldSize, f_cnt_t newSize, float freq_factor, f_cnt_t& used )
-{
-	if( srcState == nullptr )
-	{
-		return false;
-	}
-
-	SRC_DATA src_data;
-	src_data.data_in = &oldBuf[0];
-	src_data.data_out = &newBuf[0];
-	src_data.input_frames = oldSize;
-	src_data.output_frames = newSize;
-	src_data.src_ratio = freq_factor;
-	src_data.end_of_input = 0;
-
-	// We don't need to lock this assuming that we're only outputting the
-	// samples in one thread
-	int error = src_process( srcState, &src_data );
-
-	used = src_data.input_frames_used;
-
-	if( error != 0 )
-	{
-		qCritical( "GigInstrument: error while resampling: %s", src_strerror( error ) );
-		return false;
-	}
-
-	if( oldSize != 0 && src_data.output_frames_gen == 0 )
-	{
-		qCritical( "GigInstrument: could not resample, no frames generated" );
-		return false;
-	}
-
-	if( src_data.output_frames_gen > 0 && src_data.output_frames_gen < newSize )
-	{
-		qCritical() << "GigInstrument: not enough frames, wanted"
-			<< newSize << "generated" << src_data.output_frames_gen;
-		return false;
-	}
-
-	return true;
-}
-
-
 
 
 ADSR::ADSR()

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -437,7 +437,7 @@ void GigInstrument::play( sampleFrame * _working_buffer )
 				if (sample.region->PitchTrack == true) { freq_factor *= sample.freqFactor; }
 
 				// We need a bit of margin so we don't get glitching
-				samples = frames / freq_factor + Sample::s_interpolationMargins[m_interpolation];
+				samples = frames / freq_factor + 4;
 			}
 
 			// Load this note's data

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -37,6 +37,7 @@
 #include <QDomDocument>
 
 #include "AudioEngine.h"
+#include "AudioResampler.h"
 #include "ConfigManager.h"
 #include "endian_handling.h"
 #include "Engine.h"
@@ -46,7 +47,6 @@
 #include "Knob.h"
 #include "NotePlayHandle.h"
 #include "PathUtil.h"
-#include "Sample.h"
 #include "Song.h"
 
 #include "PatchesDialog.h"
@@ -437,7 +437,7 @@ void GigInstrument::play( sampleFrame * _working_buffer )
 				if (sample.region->PitchTrack == true) { freq_factor *= sample.freqFactor; }
 
 				// We need a bit of margin so we don't get glitching
-				samples = frames / freq_factor + 4;
+				samples = frames / freq_factor + AudioResampler::MinimumResampleMargin;
 			}
 
 			// Load this note's data

--- a/plugins/GigPlayer/GigPlayer.h
+++ b/plugins/GigPlayer/GigPlayer.h
@@ -32,12 +32,12 @@
 #include <QMutexLocker>
 #include <samplerate.h>
 
+#include "AudioResampler.h"
 #include "Instrument.h"
 #include "PixmapButton.h"
 #include "InstrumentView.h"
 #include "Knob.h"
 #include "LcdSpinBox.h"
-#include "LedCheckBox.h"
 #include "gig.h"
 
 
@@ -149,16 +149,10 @@ class GigSample
 public:
 	GigSample( gig::Sample * pSample, gig::DimensionRegion * pDimRegion,
 			float attenuation, int interpolation, float desiredFreq );
-	~GigSample();
 
 	// Needed when initially creating in QList
 	GigSample( const GigSample& g );
 	GigSample& operator=( const GigSample& g );
-
-	// Needed since libsamplerate stores data internally between calls
-	void updateSampleRate();
-	bool convertSampleRate( sampleFrame & oldBuf, sampleFrame & newBuf,
-		f_cnt_t oldSize, f_cnt_t newSize, float freq_factor, f_cnt_t& used );
 
 	gig::Sample * sample;
 	gig::DimensionRegion * region;
@@ -172,10 +166,6 @@ public:
 	// sample per octave and you want that sample pitch shifted for the rest of
 	// the notes in the octave, this will be true
 	bool pitchtrack;
-
-	// Used to convert sample rates
-	int interpolation;
-	SRC_STATE * srcState;
 
 	// Used changing the pitch of the note if desired
 	float sampleFreq;
@@ -299,6 +289,8 @@ private:
 	// Used when determining which samples to use
 	uint32_t m_RandomSeed;
 	float m_currentKeyDimension;
+
+	AudioResampler m_resampler;
 
 private:
 	// Delete the current GIG instance if one is open

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -407,7 +407,7 @@ void PatmanInstrument::selectSample( NotePlayHandle * _n )
 	auto hdata = new handle_data;
 	hdata->tuned = m_tunedModel.value();
 	hdata->sample = sample ? sample : std::make_shared<Sample>();
-	hdata->state = new Sample::PlaybackState(_n->hasDetuningInfo());
+	hdata->state = new Sample::PlaybackState{};
 
 	_n->m_pluginData = hdata;
 }

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -32,6 +32,7 @@
 
 #include "ArrayVector.h"
 #include "AudioEngine.h"
+#include "AudioResampler.h"
 #include "ConfigManager.h"
 #include "FileDialog.h"
 #include "Engine.h"
@@ -846,7 +847,8 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, sampleFrame * buf )
 	fluid_synth_get_gain(m_synth); // This flushes voice updates as a side effect
 	if (m_internalSampleRate < Engine::audioEngine()->outputSampleRate())
 	{
-		const fpp_t f = frames * m_internalSampleRate / Engine::audioEngine()->outputSampleRate();
+		const fpp_t f = frames * m_internalSampleRate / Engine::audioEngine()->outputSampleRate()
+			+ AudioResampler::MinimumResampleMargin;
 #ifdef __GNUC__
 		sampleFrame tmp[f];
 #else

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -604,6 +604,13 @@ void Sf2Instrument::reloadSynth()
 	fluid_synth_set_interp_method(m_synth, -1, FLUID_INTERP_DEFAULT);
 	m_synthMutex.unlock();
 
+	if (m_internalSampleRate < Engine::audioEngine()->outputSampleRate())
+	{
+		m_synthMutex.lock();
+		m_resampler.clear();
+		m_synthMutex.unlock();
+	}
+
 	updateReverb();
 	updateChorus();
 	updateReverbOn();

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -600,15 +600,7 @@ void Sf2Instrument::reloadSynth()
 	}
 
 	m_synthMutex.lock();
-	if( Engine::audioEngine()->currentQualitySettings().interpolation >=
-			AudioEngine::qualitySettings::Interpolation::SincFastest )
-	{
-		fluid_synth_set_interp_method( m_synth, -1, FLUID_INTERP_7THORDER );
-	}
-	else
-	{
-		fluid_synth_set_interp_method( m_synth, -1, FLUID_INTERP_DEFAULT );
-	}
+	fluid_synth_set_interp_method(m_synth, -1, FLUID_INTERP_DEFAULT);
 	m_synthMutex.unlock();
 
 	updateReverb();

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -31,6 +31,7 @@
 #include <QMutex>
 #include <samplerate.h>
 
+#include "AudioResampler.h"
 #include "Instrument.h"
 #include "InstrumentView.h"
 #include "LcdSpinBox.h"
@@ -103,8 +104,6 @@ public slots:
 	void updateTuning();
 
 private:
-	SRC_STATE * m_srcState;
-
 	fluid_settings_t* m_settings;
 	fluid_synth_t* m_synth;
 
@@ -145,6 +144,8 @@ private:
 
 	QVector<NotePlayHandle *> m_playingNotes;
 	QMutex m_playingNotesMutex;
+
+	AudioResampler m_resampler;
 
 private:
 	void freeFont();

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -28,13 +28,13 @@
 #include <cmath>
 #include <fftw3.h>
 
+#include "AudioResampler.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "PathUtil.h"
 #include "SampleLoader.h"
 #include "Song.h"
 #include "embed.h"
-#include "lmms_constants.h"
 #include "plugin_export.h"
 
 namespace lmms {
@@ -118,9 +118,13 @@ void SlicerT::playNote(NotePlayHandle* handle, sampleFrame* workingBuffer)
 	{
 		int noteFrame = noteDone * m_originalSample.sampleSize();
 
-		playbackState->resampler().resample((workingBuffer + offset)->data(),
-			(m_originalSample.data() + noteFrame)->data(), frames, noteLeft + m_originalSample.sampleSize(),
-			speedRatio);
+		const auto dst = (workingBuffer + offset)->data();
+		const auto src = (m_originalSample.data() + noteFrame)->data();
+		const auto numDstFrames = frames;
+		const auto numSrcFrames = noteLeft * m_originalSample.sampleSize() + AudioResampler::MinimumResampleMargin;
+
+		auto& resampler = playbackState->resampler();
+		resampler.resample(dst, src, numDstFrames, numSrcFrames, speedRatio);
 
 		float nextNoteDone = noteDone + frames * (1.0f / speedRatio) / m_originalSample.sampleSize();
 		playbackState->setNoteDone(nextNoteDone);

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -118,15 +118,9 @@ void SlicerT::playNote(NotePlayHandle* handle, sampleFrame* workingBuffer)
 	{
 		int noteFrame = noteDone * m_originalSample.sampleSize();
 
-		SRC_STATE* resampleState = playbackState->resamplingState();
-		SRC_DATA resampleData;
-		resampleData.data_in = (m_originalSample.data() + noteFrame)->data();
-		resampleData.data_out = (workingBuffer + offset)->data();
-		resampleData.input_frames = noteLeft * m_originalSample.sampleSize();
-		resampleData.output_frames = frames;
-		resampleData.src_ratio = speedRatio;
-
-		src_process(resampleState, &resampleData);
+		playbackState->resampler().resample((workingBuffer + offset)->data(),
+			(m_originalSample.data() + noteFrame)->data(), frames, noteLeft + m_originalSample.sampleSize(),
+			speedRatio);
 
 		float nextNoteDone = noteDone + frames * (1.0f / speedRatio) / m_originalSample.sampleSize();
 		playbackState->setNoteDone(nextNoteDone);

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -121,7 +121,7 @@ void SlicerT::playNote(NotePlayHandle* handle, sampleFrame* workingBuffer)
 		const auto dst = (workingBuffer + offset)->data();
 		const auto src = (m_originalSample.data() + noteFrame)->data();
 		const auto numDstFrames = frames;
-		const auto numSrcFrames = noteLeft * m_originalSample.sampleSize() + AudioResampler::MinimumResampleMargin;
+		const auto numSrcFrames = noteLeft * m_originalSample.sampleSize();
 
 		auto& resampler = playbackState->resampler();
 		resampler.resample(dst, src, numDstFrames, numSrcFrames, speedRatio);

--- a/plugins/SlicerT/SlicerT.h
+++ b/plugins/SlicerT/SlicerT.h
@@ -25,16 +25,13 @@
 #ifndef LMMS_SLICERT_H
 #define LMMS_SLICERT_H
 
-#include <algorithm>
 #include <fftw3.h>
-#include <stdexcept>
 
+#include "AudioResampler.h"
 #include "AutomatableModel.h"
 #include "Instrument.h"
-#include "InstrumentView.h"
 #include "Note.h"
 #include "Sample.h"
-#include "SampleBuffer.h"
 #include "SlicerTView.h"
 #include "lmms_basics.h"
 
@@ -45,20 +42,16 @@ class PlaybackState
 public:
 	explicit PlaybackState(float startFrame)
 		: m_currentNoteDone(startFrame)
-		, m_resamplingState(src_new(SRC_LINEAR, DEFAULT_CHANNELS, nullptr))
 	{
-		if (!m_resamplingState) { throw std::runtime_error{"Failed to create sample rate converter object"}; }
 	}
-	~PlaybackState() noexcept { src_delete(m_resamplingState); }
 
 	float noteDone() const { return m_currentNoteDone; }
 	void setNoteDone(float newNoteDone) { m_currentNoteDone = newNoteDone; }
-
-	SRC_STATE* resamplingState() const { return m_resamplingState; }
+	AudioResampler& resampler() { return m_resampler; }
 
 private:
+	AudioResampler m_resampler;
 	float m_currentNoteDone;
-	SRC_STATE* m_resamplingState;
 };
 
 class SlicerT : public Instrument

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -100,7 +100,7 @@ void VibratingString::resample(const float* src, f_cnt_t srcFrames, f_cnt_t dstF
 		const float srcFrameFloat = frame * static_cast<float>(srcFrames) / dstFrames;
 		const float fracPos = srcFrameFloat - static_cast<f_cnt_t>(srcFrameFloat);
 		const f_cnt_t srcFrame = std::clamp(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
-		m_impulse[frame] = cubicInterpolate(
+		m_impulse[frame] = hermiteInterpolate(
 			src[srcFrame - 1],
 			src[srcFrame + 0],
 			src[srcFrame + 1],

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -190,7 +190,6 @@ private:
 	// memcpy utilizing libsamplerate (src) for sinc interpolation
 	inline void srccpy( float * _dst, float * _src )
 	{
-		int err;
 		const int margin = 64;
 		
 		// copy to temp array

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -26,6 +26,7 @@
 #ifndef WATSYN_H
 #define WATSYN_H
 
+#include "AudioResampler.h"
 #include "Instrument.h"
 #include "InstrumentView.h"
 #include "Graph.h"
@@ -198,17 +199,9 @@ private:
 
 		memcpy( tmp, _src, sizeof( float ) * GRAPHLEN );
 		memcpy( tmp + GRAPHLEN, _src, sizeof( float ) * margin );
-		SRC_STATE * src_state = src_new( SRC_SINC_FASTEST, 1, &err );
-		SRC_DATA src_data;
-		src_data.data_in = tmp;
-		src_data.input_frames = GRAPHLEN + margin;
-		src_data.data_out = _dst;
-		src_data.output_frames = WAVELEN;
-		src_data.src_ratio = static_cast<double>( WAVERATIO );
-		src_data.end_of_input = 0;
-		err = src_process( src_state, &src_data ); 
-		if( err ) { qDebug( "Watsyn SRC error: %s", src_strerror( err ) ); }
-		src_delete( src_state );
+
+		AudioResampler resampler;
+		resampler.resample(_dst, tmp, WAVELEN, GRAPHLEN + margin, static_cast<double>(WAVERATIO));
 	}
 
 	// memcpy utilizing cubic interpolation

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -83,7 +83,6 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	m_workers(),
 	m_numWorkers( QThread::idealThreadCount()-1 ),
 	m_newPlayHandles( PlayHandle::MaxNumber ),
-	m_qualitySettings(qualitySettings::Interpolation::Linear),
 	m_masterGain( 1.0f ),
 	m_audioDev( nullptr ),
 	m_oldAudioDev( nullptr ),
@@ -577,25 +576,6 @@ AudioEngine::StereoSample AudioEngine::getPeakValues(sampleFrame * ab, const f_c
 	return StereoSample(peakLeft, peakRight);
 }
 
-
-
-
-void AudioEngine::changeQuality(const struct qualitySettings & qs)
-{
-	// don't delete the audio-device
-	stopProcessing();
-
-	m_qualitySettings = qs;
-
-	emit sampleRateChanged();
-	emit qualitySettingsChanged();
-
-	startProcessing();
-}
-
-
-
-
 void AudioEngine::doSetAudioDevice( AudioDevice * _dev )
 {
 	// TODO: Use shared_ptr here in the future.
@@ -616,23 +596,11 @@ void AudioEngine::doSetAudioDevice( AudioDevice * _dev )
 	}
 }
 
-
-
-
-void AudioEngine::setAudioDevice(AudioDevice * _dev,
-				const struct qualitySettings & _qs,
-				bool _needs_fifo,
-				bool startNow)
+void AudioEngine::setAudioDevice(AudioDevice* _dev, bool _needs_fifo, bool startNow)
 {
 	stopProcessing();
-
-	m_qualitySettings = _qs;
-
-	doSetAudioDevice( _dev );
-
-	emit qualitySettingsChanged();
+	doSetAudioDevice(_dev);
 	emit sampleRateChanged();
-
 	if (startNow) {startProcessing( _needs_fifo );}
 }
 

--- a/src/core/AudioResampler.cpp
+++ b/src/core/AudioResampler.cpp
@@ -42,12 +42,16 @@ void AudioResampler::resample(float* dst, const float* src, size_t numDstFrames,
 		const auto leftX = truncatedSrcFrameIndex * DEFAULT_CHANNELS;
 		const auto rightX = leftX + 1;
 
-		dst[leftX] = interpolate(src, numSrcSamples, leftX, fractionalOffset, m_prevSamples.data());
-		dst[rightX] = interpolate(src, numSrcSamples, rightX, fractionalOffset, m_prevSamples.data());
+		const auto dstLeftIndex = dstFrameIndex * DEFAULT_CHANNELS;
+		const auto dstRightIndex = dstLeftIndex + 1;
+
+		dst[dstLeftIndex] = interpolate(src, numSrcSamples, leftX, fractionalOffset, m_prevSamples.data());
+		dst[dstRightIndex] = interpolate(src, numSrcSamples, rightX, fractionalOffset, m_prevSamples.data());
 	}
 
-	m_prevSamples[0] = dst[numDstFrames * DEFAULT_CHANNELS - 2];
-	m_prevSamples[1] = dst[numDstFrames * DEFAULT_CHANNELS - 1];
+	const auto endFrame = numDstFrames * DEFAULT_CHANNELS;
+	m_prevSamples[0] = dst[endFrame - 2];
+	m_prevSamples[1] = dst[endFrame - 1];
 }
 
 float AudioResampler::interpolate(const float* src, size_t size, int index, float fractionalOffset, float* prev)

--- a/src/core/AudioResampler.cpp
+++ b/src/core/AudioResampler.cpp
@@ -24,6 +24,7 @@
 
 #include "AudioResampler.h"
 
+#include <algorithm>
 #include <samplerate.h>
 
 #include "interpolation.h"
@@ -67,6 +68,11 @@ float AudioResampler::interpolate(const float* src, size_t size, int index, floa
 	const auto y3 = (x3 < 0 || x3 >= size) ? 0.0f : src[x3];
 
 	return hermiteInterpolate(y0, y1, y2, y3, fractionalOffset);
+}
+
+void AudioResampler::clear()
+{
+	std::fill(m_prevSamples.begin(), m_prevSamples.end(), 0.0f);
 }
 
 } // namespace lmms

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -54,9 +54,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 {
 	m_wetDryModel.setCenterValue(0);
 
-	m_srcState[0] = m_srcState[1] = nullptr;
-	reinitSRC();
-
 	if( ConfigManager::inst()->value( "ui", "disableautoquit").toInt() )
 	{
 		m_autoQuitDisabled = true;
@@ -66,23 +63,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	// e.g. by resetting state.
 	connect(&m_enabledModel, &BoolModel::dataChanged, [this] { onEnabledChanged(); });
 }
-
-
-
-
-Effect::~Effect()
-{
-	for (const auto& state : m_srcState)
-	{
-		if (state != nullptr)
-		{
-			src_delete(state);
-		}
-	}
-}
-
-
-
 
 void Effect::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
@@ -174,52 +154,6 @@ void Effect::checkGate( double _out_sum )
 gui::PluginView * Effect::instantiateView( QWidget * _parent )
 {
 	return new gui::EffectView( this, _parent );
-}
-
-	
-
-
-void Effect::reinitSRC()
-{
-	for (auto& state : m_srcState)
-	{
-		if (state != nullptr)
-		{
-			src_delete(state);
-		}
-		int error;
-		const int currentInterpolation = Engine::audioEngine()->currentQualitySettings().libsrcInterpolation();
-		if((state = src_new(currentInterpolation, DEFAULT_CHANNELS, &error)) == nullptr)
-		{
-			qFatal( "Error: src_new() failed in effect.cpp!\n" );
-		}
-	}
-}
-
-
-
-
-void Effect::resample( int _i, const sampleFrame * _src_buf,
-							sample_rate_t _src_sr,
-				sampleFrame * _dst_buf, sample_rate_t _dst_sr,
-								f_cnt_t _frames )
-{
-	if( m_srcState[_i] == nullptr )
-	{
-		return;
-	}
-	m_srcData[_i].input_frames = _frames;
-	m_srcData[_i].output_frames = Engine::audioEngine()->framesPerPeriod();
-	m_srcData[_i].data_in = const_cast<float*>(_src_buf[0].data());
-	m_srcData[_i].data_out = _dst_buf[0].data ();
-	m_srcData[_i].src_ratio = (double) _dst_sr / _src_sr;
-	m_srcData[_i].end_of_input = 0;
-
-	if (int error = src_process(m_srcState[_i], &m_srcData[_i]))
-	{
-		qFatal( "Effect::resample(): error while resampling: %s\n",
-							src_strerror( error ) );
-	}
 }
 
 } // namespace lmms

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -75,18 +75,12 @@ const std::array<ProjectRenderer::FileEncodeDevice, 5> ProjectRenderer::fileEnco
 
 } ;
 
-
-
-
-ProjectRenderer::ProjectRenderer( const AudioEngine::qualitySettings & qualitySettings,
-					const OutputSettings & outputSettings,
-					ExportFileFormat exportFileFormat,
-					const QString & outputFilename ) :
-	QThread( Engine::audioEngine() ),
-	m_fileDev( nullptr ),
-	m_qualitySettings( qualitySettings ),
-	m_progress( 0 ),
-	m_abort( false )
+ProjectRenderer::ProjectRenderer(
+	const OutputSettings& outputSettings, ExportFileFormat exportFileFormat, const QString& outputFilename)
+	: QThread(Engine::audioEngine())
+	, m_fileDev(nullptr)
+	, m_progress(0)
+	, m_abort(false)
 {
 	AudioFileDeviceInstantiaton audioEncoderFactory = fileEncodeDevices[static_cast<std::size_t>(exportFileFormat)].m_getDevInst;
 
@@ -145,7 +139,7 @@ void ProjectRenderer::startProcessing()
 	{
 		// Have to do audio engine stuff with GUI-thread affinity in order to
 		// make slots connected to sampleRateChanged()-signals being called immediately.
-		Engine::audioEngine()->setAudioDevice( m_fileDev, m_qualitySettings, false, false );
+		Engine::audioEngine()->setAudioDevice(m_fileDev, false, false);
 
 		start(
 #ifndef LMMS_BUILD_WIN32

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -34,17 +34,11 @@
 namespace lmms
 {
 
-
 RenderManager::RenderManager(
-		const AudioEngine::qualitySettings & qualitySettings,
-		const OutputSettings & outputSettings,
-		ProjectRenderer::ExportFileFormat fmt,
-		QString outputPath) :
-	m_qualitySettings(qualitySettings),
-	m_oldQualitySettings( Engine::audioEngine()->currentQualitySettings() ),
-	m_outputSettings(outputSettings),
-	m_format(fmt),
-	m_outputPath(outputPath)
+	const OutputSettings& outputSettings, ProjectRenderer::ExportFileFormat fmt, QString outputPath)
+	: m_outputSettings(outputSettings)
+	, m_format(fmt)
+	, m_outputPath(outputPath)
 {
 	Engine::audioEngine()->storeAudioDevice();
 }
@@ -52,7 +46,6 @@ RenderManager::RenderManager(
 RenderManager::~RenderManager()
 {
 	Engine::audioEngine()->restoreAudioDevice();  // Also deletes audio dev.
-	Engine::audioEngine()->changeQuality( m_oldQualitySettings );
 }
 
 void RenderManager::abortProcessing()
@@ -141,12 +134,7 @@ void RenderManager::renderProject()
 
 void RenderManager::render(QString outputPath)
 {
-	m_activeRenderer = std::make_unique<ProjectRenderer>(
-			m_qualitySettings,
-			m_outputSettings,
-			m_format,
-			outputPath);
-
+	m_activeRenderer = std::make_unique<ProjectRenderer>(m_outputSettings, m_format, outputPath);
 	if( m_activeRenderer->isReady() )
 	{
 		// pass progress signals through

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -124,14 +124,14 @@ bool Sample::play(sampleFrame* dst, PlaybackState* state, size_t numFrames, doub
 	assert(numFrames > 0);
 	assert(frequency > 0);
 
-	const auto pastBounds = state->m_frameIndex >= m_endFrame || (state->m_frameIndex < 0 && state->m_backwards);
+	const auto pastBounds = state->frameIndex >= m_endFrame || (state->frameIndex < 0 && state->backwards);
 	if (m_buffer->empty() || (loopMode == Loop::Off && pastBounds)) { return false; }
 
 	const auto outputSampleRate = Engine::audioEngine()->outputSampleRate() * m_frequency / frequency;
 	const auto inputSampleRate = m_buffer->sampleRate();
 	const auto resampleRatio = outputSampleRate / inputSampleRate;
 
-	state->m_frameIndex = std::max<float>(m_startFrame, state->m_frameIndex);
+	state->frameIndex = std::max<float>(m_startFrame, state->frameIndex);
 	render(dst, numFrames, state, loopMode, resampleRatio);
 
 	if (m_amplification != 1.0f)
@@ -164,32 +164,32 @@ void Sample::render(sampleFrame* dst, size_t numFrames, PlaybackState* state, Lo
 		switch (loopMode)
 		{
 		case Loop::Off:
-			if (state->m_frameIndex < 0 || state->m_frameIndex >= m_endFrame) { return; }
+			if (state->frameIndex < 0 || state->frameIndex >= m_endFrame) { return; }
 			break;
 		case Loop::On:
-			if (state->m_frameIndex < m_loopStartFrame && state->m_backwards)
+			if (state->frameIndex < m_loopStartFrame && state->backwards)
 			{
-				state->m_frameIndex = m_loopEndFrame - 1;
+				state->frameIndex = m_loopEndFrame - 1;
 			}
-			else if (state->m_frameIndex >= m_loopEndFrame) { state->m_frameIndex = m_loopStartFrame; }
+			else if (state->frameIndex >= m_loopEndFrame) { state->frameIndex = m_loopStartFrame; }
 			break;
 		case Loop::PingPong:
-			if (state->m_frameIndex < m_loopStartFrame && state->m_backwards)
+			if (state->frameIndex < m_loopStartFrame && state->backwards)
 			{
-				state->m_frameIndex = m_loopStartFrame;
-				state->m_backwards = false;
+				state->frameIndex = m_loopStartFrame;
+				state->backwards = false;
 			}
-			else if (state->m_frameIndex >= m_loopEndFrame)
+			else if (state->frameIndex >= m_loopEndFrame)
 			{
-				state->m_frameIndex = m_loopEndFrame - 1;
-				state->m_backwards = true;
+				state->frameIndex = m_loopEndFrame - 1;
+				state->backwards = true;
 			}
 			break;
 		default:
 			break;
 		}
 
-		const auto srcIndex = static_cast<int>(state->m_frameIndex);
+		const auto srcIndex = static_cast<int>(state->frameIndex);
 		const auto leftX1Index = srcIndex * DEFAULT_CHANNELS;
 		const auto rightX1Index = leftX1Index + 1;
 
@@ -214,12 +214,12 @@ void Sample::render(sampleFrame* dst, size_t numFrames, PlaybackState* state, Lo
 		const auto rightX2 = (rightX2Index < 0 || rightX2Index >= srcSize) ? 0.0f : src[rightX2Index];
 		const auto rightX3 = (rightX3Index < 0 || rightX3Index >= srcSize) ? 0.0f : src[rightX3Index];
 
-		const auto fractionalPosition = state->m_frameIndex - srcIndex;
+		const auto fractionalPosition = state->frameIndex - srcIndex;
 		const auto leftSample = hermiteInterpolate(leftX0, leftX1, leftX2, leftX3, fractionalPosition);
 		const auto rightSample = hermiteInterpolate(rightX0, rightX1, rightX2, rightX3, fractionalPosition);
 
 		dst[i] = {leftSample, rightSample};
-		state->m_frameIndex += (state->m_backwards ? -1.0 : 1.0)  / resampleRatio;
+		state->frameIndex += (state->backwards ? -1.0 : 1.0)  / resampleRatio;
 	}
 }
 

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -133,9 +133,6 @@ bool Sample::play(sampleFrame* dst, PlaybackState* state, size_t numFrames, doub
 
 	state->frameIndex = std::max<float>(m_startFrame, state->frameIndex);
 	render(dst, numFrames, state, loopMode, resampleRatio);
-
-	if (m_amplification != 1.0f) { MixHelpers::multiply(dst, m_amplification, numFrames); }
-
 	return true;
 }
 
@@ -195,7 +192,7 @@ void Sample::render(sampleFrame* dst, size_t numFrames, PlaybackState* state, Lo
 		const auto leftSample = AudioResampler::interpolate(src, srcSize, leftX, fractionalOffset);
 		const auto rightSample = AudioResampler::interpolate(src, srcSize, rightX, fractionalOffset);
 
-		dst[i] = {leftSample, rightSample};
+		dst[i] = {leftSample * m_amplification, rightSample * m_amplification};
 		state->frameIndex += (state->backwards ? -1.0 : 1.0) / resampleRatio;
 	}
 }

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -27,7 +27,6 @@
 #include <cassert>
 
 #include "AudioResampler.h"
-#include "MixHelpers.h"
 
 namespace lmms {
 
@@ -182,7 +181,7 @@ void Sample::render(sampleFrame* dst, size_t numFrames, PlaybackState* state, Lo
 
 		const auto src = m_buffer->data()->data();
 		const auto srcSize = m_buffer->size() * DEFAULT_CHANNELS;
-	
+
 		const auto frameIndex = static_cast<int>(state->frameIndex);
 		const auto fractionalOffset = state->frameIndex - frameIndex;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -189,12 +189,6 @@ void printHelp()
 		"          Default: 160.\n"
 		"  -f, --format <format>         Specify format of render-output where\n"
 		"          Format is either 'wav', 'flac', 'ogg' or 'mp3'.\n"
-		"  -i, --interpolation <method>   Specify interpolation method\n"
-		"          Possible values:\n"
-		"            - linear\n"
-		"            - sincfastest (default)\n"
-		"            - sincmedium\n"
-		"            - sincbest\n"
 		"  -l, --loop                     Render as a loop\n"
 		"  -m, --mode                     Stereo mode used for MP3 export\n"
 		"          Possible values: s, j, m\n"
@@ -360,7 +354,6 @@ int main( int argc, char * * argv )
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);
 
-	AudioEngine::qualitySettings qs(AudioEngine::qualitySettings::Interpolation::Linear);
 	OutputSettings os( 44100, OutputSettings::BitRateSettings(160, false), OutputSettings::BitDepth::Depth16Bit, OutputSettings::StereoMode::JointStereo );
 	ProjectRenderer::ExportFileFormat eff = ProjectRenderer::ExportFileFormat::Wave;
 
@@ -612,39 +605,6 @@ int main( int argc, char * * argv )
 		{
 			os.setBitDepth(OutputSettings::BitDepth::Depth32Bit);
 		}
-		else if( arg == "--interpolation" || arg == "-i" )
-		{
-			++i;
-
-			if( i == argc )
-			{
-				return usageError( "No interpolation method specified" );
-			}
-
-
-			const QString ip = QString( argv[i] );
-
-			if( ip == "linear" )
-			{
-		qs.interpolation = AudioEngine::qualitySettings::Interpolation::Linear;
-			}
-			else if( ip == "sincfastest" )
-			{
-		qs.interpolation = AudioEngine::qualitySettings::Interpolation::SincFastest;
-			}
-			else if( ip == "sincmedium" )
-			{
-		qs.interpolation = AudioEngine::qualitySettings::Interpolation::SincMedium;
-			}
-			else if( ip == "sincbest" )
-			{
-		qs.interpolation = AudioEngine::qualitySettings::Interpolation::SincBest;
-			}
-			else
-			{
-				return usageError( QString( "Invalid interpolation method %1" ).arg( argv[i] ) );
-			}
-		}
 		else if( arg == "--import" )
 		{
 			++i;
@@ -796,7 +756,7 @@ int main( int argc, char * * argv )
 		}
 
 		// create renderer
-		auto r = new RenderManager(qs, os, eff, renderOut);
+		auto r = new RenderManager(os, eff, renderOut);
 		QCoreApplication::instance()->connect( r,
 				SIGNAL(finished()), SLOT(quit()));
 

--- a/src/gui/modals/ExportProjectDialog.cpp
+++ b/src/gui/modals/ExportProjectDialog.cpp
@@ -154,8 +154,6 @@ OutputSettings::StereoMode mapToStereoMode(int index)
 
 void ExportProjectDialog::startExport()
 {
-	auto qs = AudioEngine::qualitySettings(
-		static_cast<AudioEngine::qualitySettings::Interpolation>(interpolationCB->currentIndex()));
 	const auto samplerates = std::array{44100, 48000, 88200, 96000, 192000};
 	const auto bitrates = std::array{64, 128, 160, 192, 256, 320};
 
@@ -181,7 +179,7 @@ void ExportProjectDialog::startExport()
 	{
 		output_name+=m_fileExtension;
 	}
-	m_renderManager.reset(new RenderManager( qs, os, m_ft, output_name ));
+	m_renderManager.reset(new RenderManager(os, m_ft, output_name));
 
 	Engine::getSong()->setExportLoop( exportLoopCB->isChecked() );
 	Engine::getSong()->setRenderBetweenMarkers( renderMarkersCB->isChecked() );

--- a/src/gui/modals/export_project.ui
+++ b/src/gui/modals/export_project.ui
@@ -364,62 +364,6 @@
        </layout>
       </widget>
      </item>
-     <item>
-      <widget class="QGroupBox" name="qualityGroupBox">
-       <property name="title">
-        <string>Quality settings</string>
-       </property>
-       <layout class="QVBoxLayout">
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Interpolation:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="interpolationCB">
-          <property name="currentIndex">
-           <number>2</number>
-          </property>
-          <item>
-           <property name="text">
-            <string>Zero order hold</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Sinc worst (fastest)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Sinc medium (recommended)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Sinc best (slowest)</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <spacer>
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
-     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
This PR makes the following changes:

1. Always use 4 point Hermite interpolation for resampling, rather than using libsamplerate. More options can be provided later if there's a need for it, otherwise this seems interpolation method like a good compromise to use at least for now in terms of performance and audio quality,
2. Tidy up `interpolation.h` a bit and replace use of `cubicInterpolate` with `hermiteInterpolate` (`cubicInterpolate` was only used by the Vibed plugin, and `hermiteInterpolate` will most likely work just as well anyways. Willing to undo this if there are objections however.)
3. Remove `qualitySettings` and the interpolation options within export and the AFP.