### PR TITLE
Fix macOS libsndfile linking

### DIFF
--- a/cmake/apple/install_apple.sh.in
+++ b/cmake/apple/install_apple.sh.in
@@ -95,27 +95,58 @@ for file in "$APP/Contents/lib/lmms/"libcarla*; do
    done
 done
 
-# Fix libsndfile still linking to homebrew
-for _thisfile in "$APP/Contents/Frameworks/"libsndfile*.dylib; do
-    lines="$(otool -L "$_thisfile")"
+# Attempts to fix a "Frameworks" library which uses @loader_path instead of
+# @executable_path.  Despite the function parameter using a the system library
+# location, this will only attempt to repair the matching filename in the app
+# bundle.
+#
+# See also: https://github.com/LMMS/lmms/issues/7244
+#
+# Usage:
+#    fix_linking "@SndFile_LIBRARY@"
+#
+fix_framework() {
+    sys_lib="$1"
+
+    # Sadly, the lib names are inconsistent (e.g. foo.1.2.3.dylib vs foo.1.dylib ).  Use globbing to guess.
+    lib_name=$(basename "$1")
+    # Remove file extension
+    match=$(echo "$lib_name" | cut -d "." -f1 )
+    # Hope there's only one match
+    app_lib="$(ls "$APP/Contents/Frameworks/"$match*.dylib)"
+    otool_lines="$(otool -L "$app_lib")"
+
+    is_debug=0
+    is_fixed=0
     while IFS= read -r line; do
         # Trim off trailing "... (compatiblity version...""
-        _oldpath=$(echo "$line" | cut -d "(" -f 1)
-        if [[ $_oldpath == *"@loader_path/"* ]]; then
-            # Isolate lib name (may contain trailing whitespace)
-            lib=$(echo "$_oldpath" | rev | cut -d "/" -f 1| rev)
-            # shellcheck disable=SC2086
-            _newpath="@executable_path/../Frameworks/"$lib
-            if ! test -f "$_newpath"; then
-              # Copy any files that are missing
-              # shellcheck disable=SC2086
-              cp "$(brew --prefix)/lib/"$lib "$APP/Contents/Frameworks/"$lib
+        rpath_orig=$(echo "$line" | cut -d "(" -f 1 | xargs)
+        if [[ $rpath_orig == *"@loader_path/"* ]]; then
+            # Isolate dependency lib name (xargs removes trailing whitespace)
+            dep_lib="$(echo "$rpath_orig" | rev | cut -d "/" -f 1 | rev | xargs)"
+            if [ $is_debug -eq 1 ]; then
+                echo "-- Fixing $(basename "$1") @loader_path entry for $dep_lib..."
             fi
-            # shellcheck disable=SC2086
-            install_name_tool -change $_oldpath $_newpath $_thisfile
+            rpath_new="@executable_path/../Frameworks/$dep_lib"
+            app_lib_dep="$APP/Contents/Frameworks/$dep_lib"
+            if ! test -f "$app_lib_dep"; then
+                # Assuming any missing files can be found adjacent
+                sys_lib_dep="$(dirname "$sys_lib")/$dep_lib"
+                cp "$sys_lib_dep" "$app_lib_dep"
+            fi
+            install_name_tool -change "$rpath_orig" "$rpath_new" "$app_lib" 2>/dev/null
+            is_fixed=1
         fi
-    done <<< "$lines"
-done
+    done <<< "$otool_lines"
+
+    if [ $is_debug -eq 1 ] && [ $is_fixed -eq 1 ]; then
+        echo -e "\nBEFORE/AFTER:"
+        # diff returns non-zero exit code
+        diff -u --color=always <(echo "$otool_lines" ) <(otool -L "$app_lib") || true
+    fi
+}
+
+fix_framework "@SndFile_LIBRARY@"
 
 # Cleanup
 rm -rf "$APP/Contents/bin"

--- a/cmake/apple/install_apple.sh.in
+++ b/cmake/apple/install_apple.sh.in
@@ -113,6 +113,7 @@ fix_framework() {
     # Remove file extension
     match=$(echo "$lib_name" | cut -d "." -f1 )
     # Hope there's only one match
+    # shellcheck disable=SC2086
     app_lib="$(ls "$APP/Contents/Frameworks/"$match*.dylib)"
     otool_lines="$(otool -L "$app_lib")"
 

--- a/cmake/apple/install_apple.sh.in
+++ b/cmake/apple/install_apple.sh.in
@@ -95,6 +95,28 @@ for file in "$APP/Contents/lib/lmms/"libcarla*; do
    done
 done
 
+# Fix libsndfile still linking to homebrew
+for _thisfile in "$APP/Contents/Frameworks/"libsndfile*.dylib; do
+    lines="$(otool -L "$_thisfile")"
+    while IFS= read -r line; do
+        # Trim off trailing "... (compatiblity version...""
+        _oldpath=$(echo "$line" | cut -d "(" -f 1)
+        if [[ $_oldpath == *"@loader_path/"* ]]; then
+            # Isolate lib name (may contain trailing whitespace)
+            lib=$(echo "$_oldpath" | rev | cut -d "/" -f 1| rev)
+            # shellcheck disable=SC2086
+            _newpath="@executable_path/../Frameworks/"$lib
+            if ! test -f "$_newpath"; then
+              # Copy any files that are missing
+              # shellcheck disable=SC2086
+              cp "$(brew --prefix)/lib/"$lib "$APP/Contents/Frameworks/"$lib
+            fi
+            # shellcheck disable=SC2086
+            install_name_tool -change $_oldpath $_newpath $_thisfile
+        fi
+    done <<< "$lines"
+done
+
 # Cleanup
 rm -rf "$APP/Contents/bin"
 


### PR DESCRIPTION
Closes #7244

Building LMMS on a Mac M1 (ARM64) produces corrupted installers.

It appears that some assumed prefix is breaking `libsndfile`, but since each dependency's `opt/` is within its own directory, this can't be fixed by a single file copy or symlink, but rather by running `install_name_tool` manually.  Since some of these dependencies are missing from the bundle, they're copied if they're missing.

This is what the broken linking looks like:

   ```diff
 	/opt/homebrew/opt/libsndfile/lib/libsndfile.1.dylib (compatibility version 2.0.0, current version 2.37.0)
 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
-	@loader_path/../../../../opt/libogg/lib/libogg.0.dylib (compatibility version 0.0.0, current version 0.8.5)
-	@loader_path/../../../../opt/libvorbis/lib/libvorbisenc.2.dylib (compatibility version 3.0.0, current version 3.12.0)
-	@loader_path/../../../../opt/flac/lib/libFLAC.12.dylib (compatibility version 14.0.0, current version 14.0.0)
-	@loader_path/../../../../opt/opus/lib/libopus.0.dylib (compatibility version 10.0.0, current version 10.0.0)
-	@loader_path/../../../../opt/mpg123/lib/libmpg123.0.dylib (compatibility version 48.0.0, current version 48.0.0)
-	@loader_path/../../../../opt/lame/lib/libmp3lame.0.dylib (compatibility version 1.0.0, current version 1.0.0)
-	@loader_path/../../../../opt/libvorbis/lib/libvorbis.0.dylib (compatibility version 5.0.0, current version 5.9.0)
   ```
... and this is what it looks like after this patch:

   ```diff
 	/opt/homebrew/opt/libsndfile/lib/libsndfile.1.dylib (compatibility version 2.0.0, current version 2.37.0)
 	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
+	@executable_path/../Frameworks/libogg.0.dylib (compatibility version 0.0.0, current version 0.8.5)
+	@executable_path/../Frameworks/libvorbisenc.2.dylib (compatibility version 3.0.0, current version 3.12.0)
+	@executable_path/../Frameworks/libFLAC.12.dylib (compatibility version 14.0.0, current version 14.0.0)
+	@executable_path/../Frameworks/libopus.0.dylib (compatibility version 10.0.0, current version 10.0.0)
+	@executable_path/../Frameworks/libmpg123.0.dylib (compatibility version 48.0.0, current version 48.0.0)
+	@executable_path/../Frameworks/libmp3lame.0.dylib (compatibility version 1.0.0, current version 1.0.0)
+	@executable_path/../Frameworks/libvorbis.0.dylib (compatibility version 5.0.0, current version 5.9.0)
```

TODO:
1. [x] Find a way to calculate the presumed "homebrew" path without any hard-coded  commands like `brew --prefix`, since these make portability (e.g. macports) much harder.
2. [x] Trim whitespace to remove shellcheck ignores