### PR TITLE
PathUtil UTF-8 support

### DIFF
--- a/include/PathUtil.h
+++ b/include/PathUtil.h
@@ -28,32 +28,65 @@
 #include "lmms_export.h"
 
 #include <QDir>
+#include <optional>
+#include <string>
+#include <string_view>
 
 namespace lmms::PathUtil
 {
 	enum class Base { Absolute, ProjectDir, FactorySample, UserSample, UserVST, Preset,
 		UserLADSPA, DefaultLADSPA, UserSoundfont, DefaultSoundfont, UserGIG, DefaultGIG,
-		LocalDir };
+		LocalDir, Internal };
 
 	//! Return the directory associated with a given base as a QString
 	//! Optionally, if a pointer to boolean is given the method will
 	//! use it to indicate whether the prefix could be resolved properly
 	//! or not.
 	QString LMMS_EXPORT baseLocation(const Base base, bool* error = nullptr);
+
+	//! Return the directory associated with a given base as a std::string.
+	//! Will return std::nullopt if the prefix could not be resolved.
+	std::optional<std::string> LMMS_EXPORT getBaseLocation(Base base);
+
 	//! Return the directory associated with a given base as a QDir.
 	//! Optional pointer to boolean to indicate if the prefix could
 	//! be resolved properly.
 	QDir LMMS_EXPORT baseQDir (const Base base, bool* error = nullptr);
+
 	//! Return the prefix used to denote this base in path strings
-	QString LMMS_EXPORT basePrefix(const Base base);
+	QString LMMS_EXPORT basePrefixQString(const Base base);
+
+	//! Return the prefix used to denote this base in path strings
+	std::string_view LMMS_EXPORT basePrefix(const Base base);
+
+	//! Return whether the path uses the `base` prefix
+	bool LMMS_EXPORT hasBase(const QString& path, Base base);
+
+	//! Return whether the path uses the `base` prefix
+	bool LMMS_EXPORT hasBase(std::string_view path, Base base);
+
 	//! Check the prefix of a path and return the base it corresponds to
 	//! Defaults to Base::Absolute
 	Base LMMS_EXPORT baseLookup(const QString & path);
 
+	//! Check the prefix of a path and return the base it corresponds to
+	//! Defaults to Base::Absolute
+	Base LMMS_EXPORT baseLookup(std::string_view path);
+
 	//! Remove the prefix from a path, iff there is one
 	QString LMMS_EXPORT stripPrefix(const QString & path);
+
+	//! Remove the prefix from a path, iff there is one
+	std::string_view LMMS_EXPORT stripPrefix(std::string_view path);
+
+	//! Return the results of baseLookup() and stripPrefix()
+	std::pair<Base, std::string_view> LMMS_EXPORT parsePath(std::string_view path);
+
 	//! Get the filename for a path, handling prefixed paths correctly
 	QString LMMS_EXPORT cleanName(const QString & path);
+
+	//! Get the filename for a path, handling prefixed paths correctly
+	std::string LMMS_EXPORT cleanName(std::string_view path);
 
 	//! Upgrade prefix-less relative paths to the new format
 	QString LMMS_EXPORT oldRelativeUpgrade(const QString & input);
@@ -61,13 +94,22 @@ namespace lmms::PathUtil
 	//! Make this path absolute. If a pointer to boolean is given
 	//! it will indicate whether the path was converted successfully
 	QString LMMS_EXPORT toAbsolute(const QString & input, bool* error = nullptr);
+
+	//! Make this path absolute. Returns std::nullopt upon failure.
+	std::optional<std::string> LMMS_EXPORT toAbsolute(std::string_view input);
+
 	//! Make this path relative to a given base, return an absolute path if that fails
 	QString LMMS_EXPORT relativeOrAbsolute(const QString & input, const Base base);
+
 	//! Make this path relative to any base, choosing the shortest if there are
 	//! multiple options. allowLocal defines whether local paths should be considered.
 	//! Defaults to an absolute path if all bases fail.
 	QString LMMS_EXPORT toShortestRelative(const QString & input, bool allowLocal = false);
 
+	//! Make this path relative to any base, choosing the shortest if there are
+	//! multiple options. allowLocal defines whether local paths should be considered.
+	//! Defaults to an absolute path if all bases fail.
+	std::string LMMS_EXPORT toShortestRelative(std::string_view input, bool allowLocal = false);
 } // namespace lmms::PathUtil
 
 #endif // LMMS_PATHUTIL_H

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -507,7 +507,8 @@ bool DataFile::copyResources(const QString& resourcesDir)
 					}
 
 					// Update attribute path to point to the bundle file
-					QString newAtt = PathUtil::basePrefix(PathUtil::Base::LocalDir) + "resources/" + finalFileName;
+					QString newAtt = PathUtil::basePrefixQString(PathUtil::Base::LocalDir)
+						+ "resources/" + finalFileName;
 					el.setAttribute(*res, newAtt);
 				}
 				++res;
@@ -567,12 +568,7 @@ bool DataFile::hasLocalPlugins(QDomElement parent /* = QDomElement()*/, bool fir
 			for (int i = 0; i < attributes.size(); ++i)
 			{
 				QDomNode attribute = attributes.item(i);
-				QDomAttr attr = attribute.toAttr();
-				if (attr.value().startsWith(PathUtil::basePrefix(PathUtil::Base::LocalDir),
-					Qt::CaseInsensitive))
-				{
-					return true;
-				}
+				if (PathUtil::hasBase(attribute.toAttr().value(), PathUtil::Base::LocalDir)) { return true; }
 			}
 		}
 

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -1,3 +1,27 @@
+/*
+ * PathUtil.cpp
+ *
+ * Copyright (c) 2019-2022 Spekular <Spekularr@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
 #include "PathUtil.h"
 
 #include <QDir>
@@ -9,9 +33,12 @@
 
 namespace lmms::PathUtil
 {
-	auto relativeBases = std::array{ Base::ProjectDir, Base::FactorySample, Base::UserSample, Base::UserVST, Base::Preset,
-		Base::UserLADSPA, Base::DefaultLADSPA, Base::UserSoundfont, Base::DefaultSoundfont, Base::UserGIG, Base::DefaultGIG,
-		Base::LocalDir };
+	namespace
+	{
+		constexpr auto relativeBases = std::array{ Base::ProjectDir, Base::FactorySample, Base::UserSample, Base::UserVST, Base::Preset,
+			Base::UserLADSPA, Base::DefaultLADSPA, Base::UserSoundfont, Base::DefaultSoundfont, Base::UserGIG, Base::DefaultGIG,
+			Base::LocalDir, Base::Internal };
+	} // namespace
 
 	QString baseLocation(const Base base, bool* error /* = nullptr*/)
 	{
@@ -50,9 +77,20 @@ namespace lmms::PathUtil
 				if (error) { *error = (!s || projectPath.isEmpty()); }
 				break;
 			}
+			case Base::Internal:
+				if (error) { *error = true; }
+				[[fallthrough]];
 			default                   : return QString("");
 		}
 		return QDir::cleanPath(loc) + "/";
+	}
+
+	std::optional<std::string> getBaseLocation(Base base)
+	{
+		bool error = false;
+		const auto str = baseLocation(base, &error);
+		if (error) { return std::nullopt; }
+		return str.toStdString();
 	}
 
 	QDir baseQDir (const Base base, bool* error /* = nullptr*/)
@@ -65,42 +103,97 @@ namespace lmms::PathUtil
 		return QDir(baseLocation(base, error));
 	}
 
-	QString basePrefix(const Base base)
+	QString basePrefixQString(const Base base)
+	{
+		const auto prefix = basePrefix(base);
+		return QString::fromLatin1(prefix.data(), prefix.size());
+	}
+
+	std::string_view basePrefix(const Base base)
 	{
 		switch (base)
 		{
-			case Base::ProjectDir       : return QStringLiteral("userprojects:");
-			case Base::FactorySample    : return QStringLiteral("factorysample:");
-			case Base::UserSample       : return QStringLiteral("usersample:");
-			case Base::UserVST          : return QStringLiteral("uservst:");
-			case Base::Preset           : return QStringLiteral("preset:");
-			case Base::UserLADSPA       : return QStringLiteral("userladspa:");
-			case Base::DefaultLADSPA    : return QStringLiteral("defaultladspa:");
-			case Base::UserSoundfont    : return QStringLiteral("usersoundfont:");
-			case Base::DefaultSoundfont : return QStringLiteral("defaultsoundfont:");
-			case Base::UserGIG          : return QStringLiteral("usergig:");
-			case Base::DefaultGIG       : return QStringLiteral("defaultgig:");
-			case Base::LocalDir         : return QStringLiteral("local:");
-			default                     : return QStringLiteral("");
+			case Base::ProjectDir       : return "userprojects:";
+			case Base::FactorySample    : return "factorysample:";
+			case Base::UserSample       : return "usersample:";
+			case Base::UserVST          : return "uservst:";
+			case Base::Preset           : return "preset:";
+			case Base::UserLADSPA       : return "userladspa:";
+			case Base::DefaultLADSPA    : return "defaultladspa:";
+			case Base::UserSoundfont    : return "usersoundfont:";
+			case Base::DefaultSoundfont : return "defaultsoundfont:";
+			case Base::UserGIG          : return "usergig:";
+			case Base::DefaultGIG       : return "defaultgig:";
+			case Base::LocalDir         : return "local:";
+			case Base::Internal         : return "internal:";
+			default                     : return "";
 		}
+	}
+
+	bool hasBase(const QString& path, Base base)
+	{
+		if (base == Base::Absolute)
+		{
+			return baseLookup(path) == base;
+		}
+
+		return path.startsWith(basePrefixQString(base), Qt::CaseInsensitive);
+	}
+
+	bool hasBase(std::string_view path, Base base)
+	{
+		if (base == Base::Absolute)
+		{
+			return baseLookup(path) == base;
+		}
+
+		auto prefix = basePrefix(base);
+		return path.rfind(prefix, 0) == 0;
 	}
 
 	Base baseLookup(const QString & path)
 	{
-		for (auto base: relativeBases)
+		for (auto base : relativeBases)
 		{
-			QString prefix = basePrefix(base);
+			QString prefix = basePrefixQString(base);
 			if ( path.startsWith(prefix) ) { return base; }
 		}
 		return Base::Absolute;
 	}
 
-
-
+	Base baseLookup(std::string_view path)
+	{
+		for (auto base : relativeBases)
+		{
+			const auto prefix = basePrefix(base);
+			if (path.rfind(prefix, 0) == 0) { return base; }
+		}
+		return Base::Absolute;
+	}
 
 	QString stripPrefix(const QString & path)
 	{
 		return path.mid( basePrefix(baseLookup(path)).length() );
+	}
+
+	std::string_view stripPrefix(std::string_view path)
+	{
+		path.remove_prefix(basePrefix(baseLookup(path)).length());
+		return path;
+	}
+
+	std::pair<Base, std::string_view> parsePath(std::string_view path)
+	{
+		for (auto base : relativeBases)
+		{
+			auto prefix = basePrefix(base);
+			if (path.rfind(prefix, 0) == 0)
+			{
+				path.remove_prefix(prefix.length());
+				return { base, path };
+			}
+		}
+		return { Base::Absolute, path };
 	}
 
 	QString cleanName(const QString & path)
@@ -108,8 +201,11 @@ namespace lmms::PathUtil
 		return stripPrefix(QFileInfo(path).baseName());
 	}
 
-
-
+	std::string cleanName(std::string_view path)
+	{
+		const auto fileInfo = QFileInfo{QString::fromUtf8(path.data(), path.size())};
+		return std::string{stripPrefix(fileInfo.baseName().toStdString())};
+	}
 
 	QString oldRelativeUpgrade(const QString & input)
 	{
@@ -129,33 +225,42 @@ namespace lmms::PathUtil
 		if (vstInfo.exists()) { assumedBase = Base::UserVST; }
 
 		//Assume we've found the correct base location, return the full path
-		return basePrefix(assumedBase) + input;
+		return basePrefixQString(assumedBase) + input;
 	}
-
-
-
 
 	QString toAbsolute(const QString & input, bool* error /* = nullptr*/)
 	{
-		//First, do no harm to absolute paths
+		// First, check if it's Internal
+		if (hasBase(input, Base::Internal)) { return input; }
+
+		// Secondly, do no harm to absolute paths
 		QFileInfo inputFileInfo = QFileInfo(input);
 		if (inputFileInfo.isAbsolute())
 		{
 			if (error) { *error = false; }
 			return input;
 		}
-		//Next, handle old relative paths with no prefix
+
+		// Next, handle old relative paths with no prefix
 		QString upgraded = input.contains(":") ? input : oldRelativeUpgrade(input);
 
 		Base base = baseLookup(upgraded);
 		return baseLocation(base, error) + upgraded.remove(0, basePrefix(base).length());
 	}
 
+	std::optional<std::string> toAbsolute(std::string_view input)
+	{
+		bool error = false;
+		const auto str = toAbsolute(QString::fromUtf8(input.data(), input.size()), &error);
+		if (error) { return std::nullopt; }
+		return str.toStdString();
+	}
+
 	QString relativeOrAbsolute(const QString & input, const Base base)
 	{
 		if (input.isEmpty()) { return input; }
 		QString absolutePath = toAbsolute(input);
-		if (base == Base::Absolute) { return absolutePath; }
+		if (base == Base::Absolute || base == Base::Internal) { return absolutePath; }
 		bool error;
 		QString relativePath = baseQDir(base, &error).relativeFilePath(absolutePath);
 		// Return the relative path if it didn't result in a path starting with ..
@@ -167,6 +272,8 @@ namespace lmms::PathUtil
 
 	QString toShortestRelative(const QString & input, bool allowLocal /* = false*/)
 	{
+		if (hasBase(input, Base::Internal)) { return input; }
+
 		QFileInfo inputFileInfo = QFileInfo(input);
 		QString absolutePath = inputFileInfo.isAbsolute() ? input : toAbsolute(input);
 
@@ -185,7 +292,34 @@ namespace lmms::PathUtil
 				shortestPath = otherPath;
 			}
 		}
-		return basePrefix(shortestBase) + relativeOrAbsolute(absolutePath, shortestBase);
+		return basePrefixQString(shortestBase) + relativeOrAbsolute(absolutePath, shortestBase);
+	}
+
+	std::string toShortestRelative(std::string_view input, bool allowLocal)
+	{
+		if (hasBase(input, Base::Internal)) { return std::string{input}; }
+
+		const auto qstr = QString::fromUtf8(input.data(), input.size());
+		QFileInfo inputFileInfo = QFileInfo(qstr);
+		QString absolutePath = inputFileInfo.isAbsolute() ? qstr : toAbsolute(qstr);
+
+		Base shortestBase = Base::Absolute;
+		QString shortestPath = relativeOrAbsolute(absolutePath, shortestBase);
+		for (auto base : relativeBases)
+		{
+			// Skip local paths when searching for the shortest relative if those
+			// are not allowed for that resource
+			if (base == Base::LocalDir && !allowLocal) { continue; }
+
+			QString otherPath = relativeOrAbsolute(absolutePath, base);
+			if (otherPath.length() < shortestPath.length())
+			{
+				shortestBase = base;
+				shortestPath = otherPath;
+			}
+		}
+
+		return (basePrefixQString(shortestBase) + relativeOrAbsolute(absolutePath, shortestBase)).toStdString();
 	}
 
 } // namespace lmms::PathUtil

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -204,7 +204,7 @@ namespace lmms::PathUtil
 	std::string cleanName(std::string_view path)
 	{
 		const auto fileInfo = QFileInfo{QString::fromUtf8(path.data(), path.size())};
-		return std::string{stripPrefix(fileInfo.baseName().toStdString())};
+		return stripPrefix(fileInfo.baseName()).toStdString();
 	}
 
 	QString oldRelativeUpgrade(const QString & input)

--- a/tests/src/core/RelativePathsTest.cpp
+++ b/tests/src/core/RelativePathsTest.cpp
@@ -43,7 +43,7 @@ private slots:
 
 		QString absPath = fi.absoluteFilePath();
 		QString oldRelPath = "drums/kick01.ogg";
-		QString relPath = PathUtil::basePrefix(PathUtil::Base::FactorySample) + "drums/kick01.ogg";
+		QString relPath = PathUtil::basePrefixQString(PathUtil::Base::FactorySample) + "drums/kick01.ogg";
 		QString fuzPath = absPath;
 		fuzPath.replace(relPath, "drums/.///kick01.ogg");
 
@@ -60,11 +60,51 @@ private slots:
 		QCOMPARE(PathUtil::toAbsolute(fuzPath), absPath);
 
 		//Empty paths should stay empty
-		QString empty = QString("");
-		QCOMPARE(PathUtil::stripPrefix(""), empty);
-		QCOMPARE(PathUtil::cleanName(""), empty);
-		QCOMPARE(PathUtil::toAbsolute(""), empty);
-		QCOMPARE(PathUtil::toShortestRelative(""), empty);
+		const QString empty = QString("");
+		QCOMPARE(PathUtil::stripPrefix(empty), empty);
+		QCOMPARE(PathUtil::cleanName(empty), empty);
+		QCOMPARE(PathUtil::toAbsolute(empty), empty);
+		QCOMPARE(PathUtil::toShortestRelative(empty), empty);
+	}
+
+	void PathUtilComparisonTestsUtf8()
+	{
+		using namespace lmms;
+
+		QFileInfo fi(ConfigManager::inst()->factorySamplesDir() + "/drums/kick01.ogg");
+		QVERIFY(fi.exists());
+
+		std::string absPath = fi.absoluteFilePath().toStdString();
+		std::string oldRelPath = "drums/kick01.ogg";
+		std::string relPath = std::string{PathUtil::basePrefix(PathUtil::Base::FactorySample)} + "drums/kick01.ogg";
+
+		auto replace = [](std::string& str, std::string_view from, std::string_view to) {
+			const auto startPos = str.find(from);
+			if (startPos == std::string::npos) { return; }
+			str.replace(startPos, from.length(), to);
+		};
+
+		std::string fuzPath = absPath;
+		replace(fuzPath, relPath, "drums/.///kick01.ogg");
+
+		//Test nicely formatted paths
+		QCOMPARE(PathUtil::toShortestRelative(absPath), relPath);
+		QCOMPARE(PathUtil::toAbsolute(relPath).value(), absPath);
+
+		//Test upgrading old paths
+		QCOMPARE(PathUtil::toShortestRelative(oldRelPath), relPath);
+		QCOMPARE(PathUtil::toAbsolute(oldRelPath).value(), absPath);
+
+		//Test weird but valid paths
+		QCOMPARE(PathUtil::toShortestRelative(fuzPath), relPath);
+		QCOMPARE(PathUtil::toAbsolute(fuzPath).value(), absPath);
+
+		//Empty paths should stay empty
+		const auto empty = std::string_view{""};
+		QCOMPARE(PathUtil::stripPrefix(empty), empty);
+		QCOMPARE(PathUtil::cleanName(empty), empty);
+		QCOMPARE(PathUtil::toAbsolute(empty).value(), empty);
+		QCOMPARE(PathUtil::toShortestRelative(empty), empty);
 	}
 };
 


### PR DESCRIPTION
I'm moving some of the additions from #7199 into this separate PR to make reviewing the CLAP PR easier.

- Adds UTF8-encoded std::string/std::string_view support to `PathUtil`
- Adds "Internal" Base location for referring to internal DSO locations (needed for CLAP presets stored inside CLAP plugins)
- Adds new tests to RelativePathsTest
