### PR TITLE
Fix UI freeze when zooming in on long samples

### DIFF
--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -42,7 +42,6 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	constexpr float maxFramesPerPixel = 512.0f;
 	const float resolution = std::max(1.0f, framesPerPixel / maxFramesPerPixel);
-	const int resolutionInt = static_cast<int>(resolution);
 	const float framesPerResolution = framesPerPixel / resolution;
 
 	const size_t numPixels = std::min<size_t>(parameters.size, width);
@@ -54,7 +53,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	int pixelIndex = 0;
 
-	for (int i = 0; i < maxFrames; i += resolutionInt)
+	for (int i = 0; i < maxFrames; i += static_cast<int>(resolution))
 	{
 		pixelIndex = i / framesPerPixel;
 		const int frameIndex = !parameters.reversed ? i : maxFrames - i;

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -42,6 +42,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	constexpr float maxFramesPerPixel = 512.0f;
 	const float resolution = std::max(1.0f, framesPerPixel / maxFramesPerPixel);
+	const int resolutionInt = static_cast<int>(resolution);
 	const float framesPerResolution = framesPerPixel / resolution;
 
 	const size_t numPixels = std::min<size_t>(parameters.size, width);
@@ -53,7 +54,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	int pixelIndex = 0;
 
-	for (int i = 0; i < maxFrames; i += resolution)
+	for (int i = 0; i < maxFrames; i += resolutionInt)
 	{
 		pixelIndex = i / framesPerPixel;
 		const int frameIndex = !parameters.reversed ? i : maxFrames - i;


### PR DESCRIPTION
In the first loop of the function, `resolution` (float) gets added to the loop index. On extremely large indices this operation fails, resulting in an infinite loop.

Solution is to declare an `int` version of `resolution` for loop incrementing.

Fixes #7249