### PR TITLE
Update upload-artifact actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           cmake --build build --target install
           cmake --build build --target appimage
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux
           path: build/lmms-*.AppImage
@@ -128,7 +128,7 @@ jobs:
           cmake --build build --target install
           cmake --build build --target dmg
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: build/lmms-*.dmg
@@ -189,7 +189,7 @@ jobs:
       - name: Package
         run: cmake --build build --target package
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mingw${{ matrix.arch }}
           path: build/lmms-*.exe
@@ -281,7 +281,7 @@ jobs:
       - name: Package
         run: cmake --build build --target package
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: msvc-${{ matrix.arch }}
           path: build\lmms-*.exe


### PR DESCRIPTION
The `upload-artifact@v3` action will be deprecated in June and no longer usable on November 30, so this PR updates our usage of it to `v4`.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

The time we spend uploading artifacts drops from 30-60 seconds down to just ~6 seconds with this change.

Blocked by:
-  ~https://github.com/LMMS/lmms/pull/7259~

Needs coordination with:
- https://github.com/LMMS/lmms.io/pull/376/files