### PR TITLE
Qt6: Fix embed.cpp compilation error

### DIFF
--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -58,7 +58,7 @@ auto getIconPixmap(std::string_view name, int width, int height, const char* con
 
 	const auto pixmapName = QString::fromUtf8(name.data(), name.size());
 	const auto cacheName = (width > 0 && height > 0)
-		? QStringLiteral("%1_%2_%3").arg(pixmapName, width, height)
+		? QStringLiteral("%1_%2_%3").arg(pixmapName).arg(width).arg(height)
 		: pixmapName;
 
 	// Return cached pixmap if it exists


### PR DESCRIPTION
Proposed fix for:

```diff
- ~lmms/src/gui/embed.cpp:61:55: error: conversion from 'int' to 'QChar' is ambiguous
                ? QStringLiteral("%1_%2_%3").arg(pixmapName, width, height)
                                                                    ^~~~~~
/opt/homebrew/opt/qt/lib/QtCore.framework/Headers/qchar.h:76:26: note: candidate constructor
    constexpr Q_IMPLICIT QChar(ushort rc) noexcept : ucs(rc) {}
                         ^
/opt/homebrew/opt/qt/lib/QtCore.framework/Headers/qchar.h:78:26: note: candidate constructor
    constexpr Q_IMPLICIT QChar(short rc) noexcept : ucs(char16_t(rc)) {}
                         ^
/opt/homebrew/opt/qt/lib/QtCore.framework/Headers/qchar.h:83:26: note: candidate constructor
    constexpr Q_IMPLICIT QChar(char16_t ch) noexcept : ucs(ch) {}
                         ^
/opt/homebrew/opt/qt/lib/QtCore.framework/Headers/qchar.h:90:45: note: candidate constructor
    QT_ASCII_CAST_WARN constexpr Q_IMPLICIT QChar(char c) noexcept : ucs(uchar(c)) { }
                                            ^
/opt/homebrew/opt/qt/lib/QtCore.framework/Headers/qstring.h:244:23: note: passing argument to parameter 'fillChar' here
                QChar fillChar = u' ') const;
                      ^
1 error generated.
```