### PR TITLE
Fix glitch with automation points

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1654,7 +1654,7 @@ float AutomationEditor::getLevel(int y )
 	// some range-checking-stuff
 	level = qBound( m_bottomLevel, level, m_topLevel );
 
-	return (roundf(level));
+	return std::roundf(level);
 }
 
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1647,14 +1647,14 @@ float AutomationEditor::getLevel(int y )
 {
 	int level_line_y = height() - SCROLLBAR_SIZE - 1;
 	// pressed level
-	float level = roundf( ( m_bottomLevel + ( m_y_auto ?
+	float level = ( ( m_bottomLevel + ( m_y_auto ?
 			( m_maxLevel - m_minLevel ) * ( level_line_y - y )
 					/ (float)( level_line_y - ( TOP_MARGIN + 2 ) ) :
 			( level_line_y - y ) / (float)m_y_delta ) ) / m_step ) * m_step;
 	// some range-checking-stuff
 	level = qBound( m_bottomLevel, level, m_topLevel );
 
-	return( level );
+	return (roundf(level));
 }
 
 


### PR DESCRIPTION
![automationglitch](https://github.com/LMMS/lmms/assets/6368949/65be286e-d234-40d0-85aa-d93d27ab006c)

In the Automation Editor, the automation points are rounded off to integer values. In the last step, the level is bound to the top/bottom values which is depending on the zoom level but also by the editor geometry and the bounding values can actually be fractional values which can cause the automation point to be a fractional value when near the edges.
See the image where the odd value is shown on the cursor.

Proposed fix by rounding off the level after the bounds check. A possible nuisance with this method is that there can be a rather big step where you can no longer move the cursor close to the edges when you zoom in a bit.

Fixes https://github.com/LMMS/lmms/issues/6212