### PR TITLE
Fix missing initialization

### DIFF
--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -69,7 +69,12 @@ TrackContentWidget::TrackContentWidget( TrackView * parent ) :
 	m_coarseGridColor( Qt::SolidPattern ),
 	m_fineGridColor( Qt::SolidPattern ),
 	m_horizontalColor( Qt::SolidPattern ),
-	m_embossColor( Qt::SolidPattern )
+	m_embossColor( Qt::SolidPattern ),
+	m_coarseGridWidth(2),
+	m_fineGridWidth(1),
+	m_horizontalWidth(1),
+	m_embossWidth(0),
+	m_embossOffset(0)
 {
 	setAcceptDrops( true );
 


### PR DESCRIPTION
Fix the missing initialization of some variables in `TrackContentWidget`. This led to some performances issues when the widget was painted because a for loop was executed for which the variable started at a very large negative number and was then incremented.

Related to #7034.