### PR TITLE
Fix broken `activated` signal in Qt 6 builds

### DIFF
--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -146,8 +146,12 @@ void ProjectNotes::setupActions()
 	m_comboFont->setEditable( true );
 	QFontDatabase db;
 	m_comboFont->addItems( db.families() );
-	connect( m_comboFont, SIGNAL( activated( const QString& ) ),
-			m_edit, SLOT( setFontFamily( const QString& ) ) );
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
+	connect(m_comboFont, SIGNAL(activated(const QString&)), m_edit,
+#else
+	connect(m_comboFont, SIGNAL(textActivated(const QString&)), m_edit,
+#endif
+			SLOT(setFontFamily(const QString&)));
 	m_comboFont->lineEdit()->setText( QApplication::font().family() );
 
 	m_comboSize = new QComboBox( tb );
@@ -158,8 +162,12 @@ void ProjectNotes::setupActions()
 	{
 		m_comboSize->addItem( QString::number( *it ) );
 	}
-	connect( m_comboSize, SIGNAL( activated( const QString& ) ),
-		     this, SLOT( textSize( const QString& ) ) );
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
+	connect(m_comboSize, SIGNAL(activated(const QString&)), this, 
+#else
+	connect(m_comboSize, SIGNAL(textActivated(const QString&)), this, 
+#endif
+		    SLOT( textSize( const QString& ) ) );
 	m_comboSize->lineEdit()->setText( QString::number(
 					QApplication::font().pointSize() ) );
 

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -549,7 +549,11 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 		setCurrentIndex(m_audioInterfaces->findText(audioDevName));
 	m_audioIfaceSetupWidgets[audioDevName]->show();
 
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	connect(m_audioInterfaces, SIGNAL(activated(const QString&)),
+#else
+	connect(m_audioInterfaces, SIGNAL(textActivated(const QString&)),
+#endif
 			this, SLOT(audioInterfaceChanged(const QString&)));
 
 	// Advanced setting, hidden for now
@@ -685,7 +689,11 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_midiInterfaces->setCurrentIndex(m_midiInterfaces->findText(midiDevName));
 	m_midiIfaceSetupWidgets[midiDevName]->show();
 
+#if (QT_VERSION < QT_VERSION_CHECK(5,14,0))
 	connect(m_midiInterfaces, SIGNAL(activated(const QString&)),
+#else
+	connect(m_midiInterfaces, SIGNAL(textActivated(const QString&)),
+#endif
 			this, SLOT(midiInterfaceChanged(const QString&)));
 
 


### PR DESCRIPTION
One more step towards #6614 