### PR TITLE
Fix fftw linking when cross-compiling

### DIFF
--- a/plugins/LadspaEffect/swh/CMakeLists.txt
+++ b/plugins/LadspaEffect/swh/CMakeLists.txt
@@ -112,6 +112,6 @@ TARGET_LINK_LIBRARIES(se4_1883 rms db)
 
 ADD_LIBRARY(pitchscale STATIC ladspa/util/pitchscale.c)
 SET_TARGET_PROPERTIES(pitchscale PROPERTIES COMPILE_FLAGS "${PIC_FLAGS}")
-TARGET_LINK_LIBRARIES(pitchscale -lfftw3f)
+TARGET_LINK_LIBRARIES(pitchscale ${FFTW3F_LIBRARIES})
 TARGET_LINK_LIBRARIES(pitch_scale_1193 pitchscale)
 TARGET_LINK_LIBRARIES(pitch_scale_1194 pitchscale)


### PR DESCRIPTION
Found while working on cross-compilation environment for macOS.

The linking format now matches that earlier in the file.