### PR TITLE
Automation Editor - Fix automation point forced snapping to integer value.

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1647,12 +1647,12 @@ float AutomationEditor::getLevel(int y )
 {
 	int level_line_y = height() - SCROLLBAR_SIZE - 1;
 	// pressed level
-	float level = roundf( ( m_bottomLevel + ( m_y_auto ?
+	float level = std::roundf( ( m_bottomLevel + ( m_y_auto ?
 			( m_maxLevel - m_minLevel ) * ( level_line_y - y )
 					/ (float)( level_line_y - ( TOP_MARGIN + 2 ) ) :
 			( level_line_y - y ) / (float)m_y_delta ) ) / m_step ) * m_step;
 	// some range-checking-stuff
-	level = qBound( m_bottomLevel, level, m_topLevel );
+	level = qBound(std::roundf(m_bottomLevel), level, std::roundf(m_topLevel));
 
 	return( level );
 }

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1647,14 +1647,14 @@ float AutomationEditor::getLevel(int y )
 {
 	int level_line_y = height() - SCROLLBAR_SIZE - 1;
 	// pressed level
-	float level = ( ( m_bottomLevel + ( m_y_auto ?
+	float level = roundf( ( m_bottomLevel + ( m_y_auto ?
 			( m_maxLevel - m_minLevel ) * ( level_line_y - y )
 					/ (float)( level_line_y - ( TOP_MARGIN + 2 ) ) :
 			( level_line_y - y ) / (float)m_y_delta ) ) / m_step ) * m_step;
 	// some range-checking-stuff
 	level = qBound( m_bottomLevel, level, m_topLevel );
 
-	return std::roundf(level);
+	return( level );
 }
 
 


### PR DESCRIPTION
The fix for Fixes https://github.com/LMMS/lmms/issues/6212 in https://github.com/LMMS/lmms/pull/7269 causes all automation points to snap to an integer value. Not all controlled values are integer values. Bad. This reverts the earlier fix and tries to solve [the issue](https://github.com/LMMS/lmms/issues/6212) by instead rounding off the values of the top/bottom levels before comparison with the automation point value.

Fixes https://github.com/LMMS/lmms/issues/6212
Fixes https://github.com/LMMS/lmms/issues/7279
