### PR TITLE
Fix to allow NSIS packaging to work for non-MSVC Windows builds

### DIFF
--- a/cmake/nsis/CMakeLists.txt
+++ b/cmake/nsis/CMakeLists.txt
@@ -3,10 +3,9 @@ if(LMMS_MSVC_YEAR)
 	SET(WIN_PLATFORM "msvc${LMMS_MSVC_YEAR}")
 endif()
 
-SET(CPACK_PACKAGE_ICON                  "${CMAKE_SOURCE_DIR}/cmake/nsis/nsis_branding.bmp")
-IF(MSVC)
-	STRING(REPLACE "/" "\\\\" CPACK_PACKAGE_ICON ${CPACK_PACKAGE_ICON})
-ENDIF(MSVC)
+# the final slash needs to be flipped for CPACK_PACKAGE_ICON to work:
+#   https://cmake.org/pipermail/cmake/2008-June/022085.html
+SET(CPACK_PACKAGE_ICON                  "${CMAKE_SOURCE_DIR}/cmake/nsis\\\\nsis_branding.bmp")
 SET(CPACK_NSIS_MUI_ICON                 "${CMAKE_SOURCE_DIR}/cmake/nsis/icon.ico")
 SET(CPACK_NSIS_INSTALLED_ICON_NAME      "${CMAKE_PROJECT_NAME}.exe" PARENT_SCOPE)
 SET(CPACK_NSIS_DISPLAY_NAME             "${PROJECT_NAME_UCASE} ${VERSION}" PARENT_SCOPE)


### PR DESCRIPTION
Needed for example for MSYS2, otherwise the paths break due to wrong separator. Backwards-compatible with existing builds (new condition includes the old one).
See also https://discourse.cmake.org/t/platform-id-vs-win32-vs-cmake-system-name/1226 as to why switching to `CMAKE_SYSTEM_NAME` is a generally good idea (quote from CMake dev):
>The WIN32, APPLE, UNIX, etc. variables are “soft” deprecated due to this. We’ll never actually get them removed in the wider ecosystem, so they mean what they mean with all the conflations and ambiguities they come with. CMAKE_SYSTEM_NAME is what I’d use in CMake code