### PR TITLE
Resizable mixer channels/strips

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -51,8 +51,6 @@ namespace lmms::gui
         m_mixerView(mixerView),
         m_channelIndex(channelIndex)
     {
-        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
-
         auto retainSizeWhenHidden = [](QWidget* widget)
         {
             auto sizePolicy = widget->sizePolicy();
@@ -133,10 +131,9 @@ namespace lmms::gui
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_channelNumberLcd, 0, Qt::AlignHCenter);
-        mainLayout->addStretch();
         mainLayout->addWidget(m_renameLineEditView, 0, Qt::AlignHCenter);
         mainLayout->addLayout(soloMuteLayout, 0);
-        mainLayout->addWidget(m_fader, 0, Qt::AlignHCenter);
+        mainLayout->addWidget(m_fader, 1, Qt::AlignHCenter);
 
         connect(m_renameLineEdit, &QLineEdit::editingFinished, this, &MixerChannelView::renameFinished);
     }

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -89,6 +89,7 @@ MixerView::MixerView(Mixer* mixer) :
 	chLayout->setSizeConstraint(QLayout::SetMinimumSize);
 	chLayout->setSpacing(0);
 	chLayout->setContentsMargins(0, 0, 0, 0);
+	chLayout->setAlignment(Qt::AlignLeft);
 	m_channelAreaWidget->setLayout(chLayout);
 
 	// create rack layout before creating the first channel
@@ -105,7 +106,7 @@ MixerView::MixerView(Mixer* mixer) :
 
 	m_racksLayout->addWidget(m_mixerChannelViews[0]->m_effectRackView);
 
-	ml->addWidget(masterView, 0, Qt::AlignTop);
+	ml->addWidget(masterView, 0);
 
 	auto mixerChannelSize = masterView->sizeHint();
 
@@ -137,18 +138,20 @@ MixerView::MixerView(Mixer* mixer) :
 	channelArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	channelArea->setFrameStyle(QFrame::NoFrame);
 	channelArea->setMinimumWidth(mixerChannelSize.width() * 6);
+	channelArea->setWidgetResizable(true);
 
 	int const scrollBarExtent = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
-	channelArea->setFixedHeight(mixerChannelSize.height() + scrollBarExtent);
+	channelArea->setMinimumHeight(mixerChannelSize.height() + scrollBarExtent);
 
-	ml->addWidget(channelArea, 1, Qt::AlignTop);
+	ml->addWidget(channelArea, 1);
 
 	// show the add new mixer channel button
 	auto newChannelBtn = new QPushButton(embed::getIconPixmap("new_channel"), QString(), this);
 	newChannelBtn->setObjectName("newChannelBtn");
-	newChannelBtn->setFixedSize(mixerChannelSize);
+	newChannelBtn->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
+	newChannelBtn->setFixedWidth(mixerChannelSize.width());
 	connect(newChannelBtn, SIGNAL(clicked()), this, SLOT(addNewChannel()));
-	ml->addWidget(newChannelBtn, 0, Qt::AlignTop);
+	ml->addWidget(newChannelBtn, 0);
 
 
 	// add the stacked layout for the effect racks of mixer channels

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -168,9 +168,6 @@ MixerView::MixerView(Mixer* mixer) :
 
 	// add ourself to workspace
 	QMdiSubWindow* subWin = mainWindow->addWindowedWidget(this);
-	Qt::WindowFlags flags = subWin->windowFlags();
-	flags &= ~Qt::WindowMaximizeButtonHint;
-	subWin->setWindowFlags(flags);
 	layout()->setSizeConstraint(QLayout::SetMinimumSize);
 	subWin->layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
 


### PR DESCRIPTION
This pull request makes the mixer channels/strips grow with the mixer view. The mixer view now also provides the maximize button so that users can mix in almost full screen.

Screenshot:

![Resizable mixer channels](https://github.com/LMMS/lmms/assets/9293269/4bca0170-49de-4112-8203-9197a57d5e0a)
