### PR TITLE
Add peak indicators

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -661,6 +661,11 @@ lmms--gui--MixerChannelView QGraphicsView {
 	border-style: none;
 }
 
+lmms--gui--PeakIndicator {
+	background-color: #111811;
+	font-size: 7pt;
+}
+
 /* persistent peak markers for fx peak meters */
 lmms--gui--Fader {
 	qproperty-peakOk: rgb( 74, 253, 133);

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -710,6 +710,11 @@ lmms--gui--MixerChannelView QGraphicsView {
 	border-style: none;
 }
 
+lmms--gui--PeakIndicator {
+	background-color: #111811;
+	font-size: 7pt;
+}
+
 /* persistent peak markers for fx peak meters */
 lmms--gui--Fader {
 	qproperty-peakOk: #0ad45c;

--- a/include/Fader.h
+++ b/include/Fader.h
@@ -105,6 +105,9 @@ public:
 		setUnit(txt_after);
 	}
 
+signals:
+	void peakChanged(float peak);
+
 private:
 	void contextMenuEvent(QContextMenuEvent* me) override;
 	void mousePressEvent(QMouseEvent* ev) override;

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -123,7 +123,7 @@ namespace lmms::gui
         QLabel* m_receiveArrow;
         PixmapButton* m_muteButton;
         PixmapButton* m_soloButton;
-        PeakIndicator* m_peakIndicator = 0;
+        PeakIndicator* m_peakIndicator = nullptr;
         Fader* m_fader;
         EffectRackView* m_effectRackView;
         MixerView* m_mixerView;

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -45,6 +45,8 @@ namespace lmms
 
 namespace lmms::gui
 {
+    class PeakIndicator;
+
     constexpr int MIXER_CHANNEL_INNER_BORDER_SIZE = 3;
     constexpr int MIXER_CHANNEL_OUTER_BORDER_SIZE = 1;
 
@@ -90,6 +92,8 @@ namespace lmms::gui
         QColor strokeInnerInactive() const;
         void setStrokeInnerInactive(const QColor& c);
 
+        void reset();
+
     public slots:
         void renameChannel();
         void resetColor();
@@ -119,6 +123,7 @@ namespace lmms::gui
         QLabel* m_receiveArrow;
         PixmapButton* m_muteButton;
         PixmapButton* m_soloButton;
+        PeakIndicator* m_peakIndicator = 0;
         Fader* m_fader;
         EffectRackView* m_effectRackView;
         MixerView* m_mixerView;

--- a/include/PeakIndicator.h
+++ b/include/PeakIndicator.h
@@ -1,0 +1,60 @@
+/*
+ * PeakIndicator.h - Peak indicator widget
+ *
+ * Copyright (c) 2024- Michael Gregorius
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#ifndef LMMS_GUI_PEAKINDICATOR_H
+#define LMMS_GUI_PEAKINDICATOR_H
+
+#include "lmms_export.h"
+
+#include <QLabel>
+
+
+namespace lmms::gui
+{
+
+class LMMS_EXPORT PeakIndicator : public QLabel
+{
+	Q_OBJECT
+public:
+	PeakIndicator(QWidget* parent);
+
+	void resetPeakToMinusInf();
+
+public slots:
+	void updatePeak(float peak);
+
+protected:
+	void mousePressEvent(QMouseEvent* e) override;
+
+private:
+	void updatePeakDisplay();
+
+private:
+	float m_peak;
+} ;
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_PEAKINDICATOR_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(LMMS_SRCS
 	gui/widgets/MixerChannelLcdSpinBox.cpp
 	gui/widgets/NStateButton.cpp
 	gui/widgets/Oscilloscope.cpp
+	gui/widgets/PeakIndicator.cpp
 	gui/widgets/PixmapButton.cpp
 	gui/widgets/SimpleTextFloat.cpp
 	gui/widgets/TabBar.cpp

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -28,6 +28,7 @@
 #include "Mixer.h"
 #include "MixerChannelView.h"
 #include "MixerView.h"
+#include "PeakIndicator.h"
 #include "Song.h"
 #include "ConfigManager.h"
 
@@ -123,6 +124,9 @@ namespace lmms::gui
 
         m_fader = new Fader{&mixerChannel->m_volumeModel, tr("Fader %1").arg(channelIndex), this};
 
+        m_peakIndicator = new PeakIndicator(this);
+        connect(m_fader, &Fader::peakChanged, m_peakIndicator, &PeakIndicator::updatePeak);
+
         m_effectRackView = new EffectRackView{&mixerChannel->m_fxChain, mixerView->m_racksWidget};
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
@@ -136,6 +140,7 @@ namespace lmms::gui
         mainLayout->addStretch();
         mainLayout->addWidget(m_renameLineEditView, 0, Qt::AlignHCenter);
         mainLayout->addLayout(soloMuteLayout, 0);
+        mainLayout->addWidget(m_peakIndicator);
         mainLayout->addWidget(m_fader, 0, Qt::AlignHCenter);
 
         connect(m_renameLineEdit, &QLineEdit::editingFinished, this, &MixerChannelView::renameFinished);
@@ -341,6 +346,11 @@ namespace lmms::gui
     void MixerChannelView::setStrokeInnerInactive(const QColor& c)
     {
         m_strokeInnerInactive = c;
+    }
+
+    void MixerChannelView::reset()
+    {
+        m_peakIndicator->resetPeakToMinusInf();
     }
 
     void MixerChannelView::renameChannel()

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -544,6 +544,8 @@ void MixerView::clear()
 	for (auto i = m_mixerChannelViews.size() - 1; i > 0; --i) { deleteChannel(i); }
 	getMixer()->clearChannel(0);
 
+	m_mixerChannelViews[0]->reset();
+
 	refreshDisplay();
 }
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -214,7 +214,7 @@ void Fader::setPeak(float fPeak, float& targetPeak, float& persistentPeak, QElap
 		{
 			persistentPeak = targetPeak;
 			lastPeakTimer.restart();
-			peakChanged(persistentPeak);
+			emit peakChanged(persistentPeak);
 		}
 		update();
 	}
@@ -222,7 +222,7 @@ void Fader::setPeak(float fPeak, float& targetPeak, float& persistentPeak, QElap
 	if (persistentPeak > 0 && lastPeakTimer.elapsed() > 1500)
 	{
 		persistentPeak = qMax<float>(0, persistentPeak-0.05);
-		peakChanged(persistentPeak);
+		emit peakChanged(persistentPeak);
 		update();
 	}
 }

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -207,8 +207,6 @@ void Fader::wheelEvent (QWheelEvent* ev)
 ///
 void Fader::setPeak(float fPeak, float& targetPeak, float& persistentPeak, QElapsedTimer& lastPeakTimer)
 {
-	fPeak = std::clamp(fPeak, m_fMinPeak, m_fMaxPeak);
-
 	if (targetPeak != fPeak)
 	{
 		targetPeak = fPeak;
@@ -216,6 +214,7 @@ void Fader::setPeak(float fPeak, float& targetPeak, float& persistentPeak, QElap
 		{
 			persistentPeak = targetPeak;
 			lastPeakTimer.restart();
+			peakChanged(persistentPeak);
 		}
 		update();
 	}
@@ -223,6 +222,7 @@ void Fader::setPeak(float fPeak, float& targetPeak, float& persistentPeak, QElap
 	if (persistentPeak > 0 && lastPeakTimer.elapsed() > 1500)
 	{
 		persistentPeak = qMax<float>(0, persistentPeak-0.05);
+		peakChanged(persistentPeak);
 		update();
 	}
 }

--- a/src/gui/widgets/PeakIndicator.cpp
+++ b/src/gui/widgets/PeakIndicator.cpp
@@ -1,0 +1,84 @@
+/*
+ * PeakIndicator.cpp - Peak indicator widget
+ *
+ * Copyright (c) 2024- Michael Gregorius
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "PeakIndicator.h"
+
+#include "lmms_math.h"
+
+#include <QBoxLayout>
+#include <QMouseEvent>
+
+
+namespace lmms::gui
+{
+
+PeakIndicator::PeakIndicator(QWidget* parent) :
+	QLabel(parent),
+	m_peak(0.f)
+{
+	setAlignment(Qt::AlignCenter);
+
+	updatePeakDisplay();
+}
+
+void PeakIndicator::resetPeakToMinusInf()
+{
+	m_peak = 0;
+	updatePeakDisplay();
+}
+
+void PeakIndicator::updatePeak(float peak)
+{
+	if (peak > m_peak)
+	{
+		m_peak = peak;
+		updatePeakDisplay();
+	}
+}
+
+void PeakIndicator::mousePressEvent(QMouseEvent* e)
+{
+	if (e->buttons() & Qt::LeftButton)
+	{
+		resetPeakToMinusInf();
+	}
+}
+
+void PeakIndicator::updatePeakDisplay()
+{
+	// Treat everything below -144 dbFS as -inf. Otherwise some residual signals show up
+	// in the form of very small dbFS values, e.g. -857.1 dbFS.
+	// TODO Make the threshold configurable in the settings?
+	if (m_peak <= dbfsToAmp(-144.))
+	{
+		setText(tr("-inf"));
+	}
+	else
+	{
+		auto dbfs = ampToDbfs(m_peak);
+		setText(QString::number(dbfs, 'f', 1));
+	}
+}
+
+} // namespace lmms::gui


### PR DESCRIPTION
Add peak indicators to the mixer strips. They show the maximum peak value that was observed and can be reset by clicking on them.

![PeakIndicators](https://github.com/LMMS/lmms/assets/9293269/54220251-ef16-45a5-9acb-73f2edf16651)

## Implementation details

The implementation works via a signal/slot mechanism. The `Fader` class has a new signal `peakChanged` which reports peak values as amplifications. A new class `PeakIndicator` is added which has a slot `updatePeak` which is connected to the new signal in `Fader`.

The `PeakIndicator` inherits from `QLabel` and mainly deals with updating the label text from the current peak value.

Add a `PeakIndicator` instance to `MixerChannelView`. Add a `reset` method to `MixerChannelView` so that the mixer channel can be reset on the loading of new projects, etc. The current implementation resets the peak indicator back to -inf dbFS. The `reset` method is called in `MixerView::clear`.

Remove the clamping in `Fader::setPeak` so that all peaks are reported. Emit the new signal if the peak changes.