### PR TITLE
Fixed position line disappearing when zoomed out

### DIFF
--- a/src/gui/editors/PositionLine.cpp
+++ b/src/gui/editors/PositionLine.cpp
@@ -93,7 +93,7 @@ void PositionLine::zoomChange(float zoom)
 {
 	int playHeadPos = x() + width() - 1;
 
-	resize(8.0 * zoom, height());
+	resize(std::max(8.0 * zoom, 1.0), height());
 	move(playHeadPos - width() + 1, y());
 
 	update();


### PR DESCRIPTION
Implements a check to ensure that the width of the position line cannot get any smaller than 1. This fixes #7294, which was (presumably?) caused by #7034.