### PR TITLE
Adjust rendering of BarModelEditor

### DIFF
--- a/src/gui/widgets/BarModelEditor.cpp
+++ b/src/gui/widgets/BarModelEditor.cpp
@@ -86,7 +86,7 @@ void BarModelEditor::paintEvent(QPaintEvent *event)
 	// Paint the bar
 	// Compute the percentage as:
 	// min + x * (max - min) = v <=> x = (v - min) / (max - min)
-	auto const percentage = range == 0 ? 1. : (mod->value() - minValue) / range;
+	auto const percentage = range == 0 ? 1. : (model()->inverseScaledValue(model()->value()) - minValue) / range;
 
 	int const margin = 3;
 	QMargins const margins(margin, margin, margin, margin);


### PR DESCRIPTION
Adjust the rendering of BarModelEditor to make it respect logarithmic and linear models. The code now uses `inverseScaledValue` instead of `value` just like the `Knob` class does when calculating the angle.