### PR TITLE
Change the wording of Instrument Plugin Dialogue

### DIFF
--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -62,7 +62,7 @@ PluginBrowser::PluginBrowser( QWidget * _parent ) :
 
 	auto hint = new QLabel( tr( "Drag an instrument "
 					"into either the Song Editor, the "
-					"Pattern Editor or into an "
+					"Pattern Editor or an "
 					"existing instrument track." ),
 								m_view );
 	hint->setWordWrap( true );


### PR DESCRIPTION
"Drag an instrument into either the Song Editor, the Pattern Editor or ~~into~~ an existing instrument track."

The word "into" seems redundant