### PR TITLE
enable envelopes to effect chords

### DIFF
--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -134,6 +134,7 @@ public:
 	const FloatModel& getReleaseModel() const { return m_releaseModel; }
 	const FloatModel& getAmountModel() const { return m_amountModel; }
 	FloatModel& getAmountModel() { return m_amountModel; }
+	const BoolModel& getUseNoteParentModel() const { return m_useNoteParentModel; }
 
 
 	// LFO
@@ -169,6 +170,9 @@ private:
 	FloatModel m_sustainModel;
 	FloatModel m_releaseModel;
 	FloatModel m_amountModel;
+	// used in chores where the envelope is applyed
+	// to the whole chord instead of one note (if active)
+	BoolModel m_useNoteParentModel;
 
 	float  m_sustainLevel;
 	float  m_amount;

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -170,7 +170,7 @@ private:
 	FloatModel m_sustainModel;
 	FloatModel m_releaseModel;
 	FloatModel m_amountModel;
-	// used in chores where the envelope is applyed
+	// used in chords where the envelope is applyed
 	// to the whole chord instead of one note (if active)
 	BoolModel m_useNoteParentModel;
 

--- a/include/EnvelopeAndLfoView.h
+++ b/include/EnvelopeAndLfoView.h
@@ -79,6 +79,7 @@ private:
 	Knob * m_sustainKnob;
 	Knob * m_releaseKnob;
 	Knob * m_amountKnob;
+	LedCheckBox* m_useNoteParentCb;
 
 	// LFO stuff
 	LfoGraph* m_lfoGraph;

--- a/include/InstrumentSoundShaping.h
+++ b/include/InstrumentSoundShaping.h
@@ -75,6 +75,9 @@ public:
 
 
 private:
+	void calculateFillLevel(float* buffer, Target enumTarget,
+		NotePlayHandle* n, f_cnt_t totalFrames, f_cnt_t releaseBegin, fpp_t bufferSize);
+
 	EnvelopeAndLfoParameters * m_envLfoParameters[NumTargets];
 	InstrumentTrack * m_instrumentTrack;
 

--- a/include/NotePlayHandle.h
+++ b/include/NotePlayHandle.h
@@ -136,10 +136,23 @@ public:
 		return m_framesBeforeRelease;
 	}
 
+	// returns the parent's framesBeforeRelease() (or 0 if the note does not hava a parent)
+	inline f_cnt_t getParentFramesBeforeRelease()
+	{
+		return m_hasParent == true ? m_parent->framesBeforeRelease() : 0;
+	}
+
+
 	/*! Returns how many frames were played since release */
 	f_cnt_t releaseFramesDone() const
 	{
 		return m_releaseFramesDone;
+	}
+
+	// returns the parent's releaseFramesDone() (or 0 if the note does not hava a parent)
+	inline f_cnt_t getParentReleaseFramesDone()
+	{
+		return m_hasParent == true ? m_parent->releaseFramesDone() : 0;
 	}
 
 	/*! Returns the number of frames to be played after release according to
@@ -172,6 +185,13 @@ public:
 		return m_totalFramesPlayed;
 	}
 
+	// returns the parent's totalFramesPlayed() (or 0 if the note does not hava a parent)
+	inline f_cnt_t getParentTotalFramesPlayed()
+	{
+		return m_hasParent == true ? m_parent->totalFramesPlayed() : 0;
+	}
+
+
 	/*! Returns volume level at given frame (envelope/LFO) */
 	float volumeLevel( const f_cnt_t frame );
 
@@ -192,6 +212,7 @@ public:
 	{
 		return m_hasParent;
 	}
+
 
 	/*! Returns origin of note */
 	Origin origin() const

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -104,6 +104,7 @@ EnvelopeAndLfoParameters::EnvelopeAndLfoParameters(
 	m_sustainModel( 0.5, 0.0, 1.0, 0.001, this, tr( "Env sustain" ) ),
 	m_releaseModel( 0.1, 0.0, 2.0, 0.001, this, tr( "Env release" ) ),
 	m_amountModel( 0.0, -1.0, 1.0, 0.005, this, tr( "Env mod amount" ) ),
+	m_useNoteParentModel(false, this, tr("Apply envelope to whole chord")),
 	m_valueForZeroAmount( _value_for_zero_amount ),
 	m_pahdFrames( 0 ),
 	m_rFrames( 0 ),
@@ -148,6 +149,8 @@ EnvelopeAndLfoParameters::EnvelopeAndLfoParameters(
 			this, SLOT(updateSampleVars()), Qt::DirectConnection );
 	connect( &m_amountModel, SIGNAL(dataChanged()),
 			this, SLOT(updateSampleVars()), Qt::DirectConnection );
+	connect(&m_useNoteParentModel, SIGNAL(dataChanged()),
+			this, SLOT(updateSampleVars()), Qt::DirectConnection);
 
 	connect( &m_lfoPredelayModel, SIGNAL(dataChanged()),
 			this, SLOT(updateSampleVars()), Qt::DirectConnection );
@@ -184,6 +187,7 @@ EnvelopeAndLfoParameters::~EnvelopeAndLfoParameters()
 	m_sustainModel.disconnect( this );
 	m_releaseModel.disconnect( this );
 	m_amountModel.disconnect( this );
+	m_useNoteParentModel.disconnect(this);
 	m_lfoPredelayModel.disconnect( this );
 	m_lfoAttackModel.disconnect( this );
 	m_lfoSpeedModel.disconnect( this );
@@ -351,6 +355,7 @@ void EnvelopeAndLfoParameters::saveSettings( QDomDocument & _doc,
 	m_sustainModel.saveSettings( _doc, _parent, "sustain" );
 	m_releaseModel.saveSettings( _doc, _parent, "rel" );
 	m_amountModel.saveSettings( _doc, _parent, "amt" );
+	m_useNoteParentModel.saveSettings(_doc, _parent, "noteparent");
 	m_lfoWaveModel.saveSettings( _doc, _parent, "lshp" );
 	m_lfoPredelayModel.saveSettings( _doc, _parent, "lpdel" );
 	m_lfoAttackModel.saveSettings( _doc, _parent, "latt" );
@@ -373,6 +378,7 @@ void EnvelopeAndLfoParameters::loadSettings( const QDomElement & _this )
 	m_sustainModel.loadSettings( _this, "sustain" );
 	m_releaseModel.loadSettings( _this, "rel" );
 	m_amountModel.loadSettings( _this, "amt" );
+	m_useNoteParentModel.loadSettings(_this, "noteparent");
 	m_lfoWaveModel.loadSettings( _this, "lshp" );
 	m_lfoPredelayModel.loadSettings( _this, "lpdel" );
 	m_lfoAttackModel.loadSettings( _this, "latt" );

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -253,7 +253,6 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 			vol_level = vol_level * vol_level;
 			buffer[frame][0] = vol_level * buffer[frame][0];
 			buffer[frame][1] = vol_level * buffer[frame][1];
-			avg = avg + std::abs(volBuffer[frame]);
 		}
 	}
 

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -253,6 +253,7 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 			vol_level = vol_level * vol_level;
 			buffer[frame][0] = vol_level * buffer[frame][0];
 			buffer[frame][1] = vol_level * buffer[frame][1];
+			avg = avg + std::abs(volBuffer[frame]);
 		}
 	}
 
@@ -382,12 +383,6 @@ void InstrumentSoundShaping::calculateFillLevel(float* buffer, Target enumTarget
 		// get the parent note's parameters
 		f_cnt_t parentEnvelopeTotalFrames = n->getParentTotalFramesPlayed();
 		f_cnt_t parentEnvelopeReleaseBegin = parentEnvelopeTotalFrames - n->getParentReleaseFramesDone() + n->getParentFramesBeforeRelease();
-		// for some reason parentEnvelopeTotalFrames could be equal to parentEnvelopeReleaseBegin
-		// fixing this issue
-		if (parentEnvelopeTotalFrames == parentEnvelopeReleaseBegin)
-		{
-			parentEnvelopeTotalFrames = parentEnvelopeTotalFrames - (releaseBegin - totalFrames);
-		}
 		m_envLfoParameters[static_cast<std::size_t>(enumTarget)]->fillLevel(buffer, parentEnvelopeTotalFrames, parentEnvelopeReleaseBegin, bufferSize);
 	}
 	else

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -244,7 +244,16 @@ void InstrumentSoundShaping::processAudioBuffer( sampleFrame* buffer,
 	if( m_envLfoParameters[static_cast<std::size_t>(Target::Volume)]->isUsed() )
 	{
 		QVarLengthArray<float> volBuffer(frames);
-		m_envLfoParameters[static_cast<std::size_t>(Target::Volume)]->fillLevel( volBuffer.data(), envTotalFrames, envReleaseBegin, frames );
+		if (n->hasParent() == true)
+		{
+			f_cnt_t parentEnvelopeTotalFrames = n->getParentTotalFramesPlayed();
+			f_cnt_t parentEnvelopeReleaseBegin = parentEnvelopeTotalFrames - n->getParentReleaseFramesDone() + n->getParentFramesBeforeRelease();
+			m_envLfoParameters[static_cast<std::size_t>(Target::Volume)]->fillLevel(volBuffer.data(), parentEnvelopeTotalFrames, parentEnvelopeReleaseBegin, frames);
+		}
+		else
+		{
+			m_envLfoParameters[static_cast<std::size_t>(Target::Volume)]->fillLevel(volBuffer.data(), envTotalFrames, envReleaseBegin, frames);
+		}
 
 		for( fpp_t frame = 0; frame < frames; ++frame )
 		{

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -382,6 +382,13 @@ void InstrumentSoundShaping::calculateFillLevel(float* buffer, Target enumTarget
 		// get the parent note's parameters
 		f_cnt_t parentEnvelopeTotalFrames = n->getParentTotalFramesPlayed();
 		f_cnt_t parentEnvelopeReleaseBegin = parentEnvelopeTotalFrames - n->getParentReleaseFramesDone() + n->getParentFramesBeforeRelease();
+
+		if(!n->isReleased()
+			|| (n->instrumentTrack()->isSustainPedalPressed() && !n->isReleaseStarted()))
+		{
+			parentEnvelopeReleaseBegin += bufferSize;
+		}
+
 		m_envLfoParameters[static_cast<std::size_t>(enumTarget)]->fillLevel(buffer, parentEnvelopeTotalFrames, parentEnvelopeReleaseBegin, bufferSize);
 	}
 	else

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -110,6 +110,9 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	m_releaseKnob = buildKnob(tr("REL"), tr("Release:"));
 	envKnobsLayout->addWidget(m_releaseKnob);
 
+	m_useNoteParentCb = new LedCheckBox("", this);
+	m_useNoteParentCb->setToolTip(tr("Apply envelope to whole chord"));
+	envKnobsLayout->addWidget(m_useNoteParentCb);
 
 	// Add some space between the envelope and LFO section
 	mainLayout->addSpacing(10);
@@ -211,6 +214,7 @@ void EnvelopeAndLfoView::modelChanged()
 	m_sustainKnob->setModel( &m_params->m_sustainModel );
 	m_releaseKnob->setModel( &m_params->m_releaseModel );
 	m_amountKnob->setModel( &m_params->m_amountModel );
+	m_useNoteParentCb->setModel(&m_params->m_useNoteParentModel);
 
 	m_lfoGraph->setModel(m_params);
 	m_lfoPredelayKnob->setModel( &m_params->m_lfoPredelayModel );


### PR DESCRIPTION
This pull request adds a new button in the instrument sound shaping menu that makes the envelope apply on a chord instead of single notes.
For example this can be useful when the arpeggio is turned on and the user wants to make the chord notes fade out gradually.

mentioned in #7025.

picture:

![Finished15](https://github.com/LMMS/lmms/assets/143485814/423df47c-9d90-477a-af0c-11928cd67aa9)
