### PR TITLE
don't use PollParentThread for the wine process

### DIFF
--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -2404,7 +2404,7 @@ int main( int _argc, char * * _argv )
 		return -1;
 	}
 
-#ifndef LMMS_BUILD_WIN32
+#if !defined(LMMS_BUILD_WIN32) && !defined(__WINE__)
 	const auto pollParentThread = lmms::PollParentThread{};
 #endif
 


### PR DESCRIPTION
In my setup (Ubuntu 22.04 + wine-9.10 (Staging)) the wine Vst process doesn't have a parent and gets killed by PollParentThread shortly after start. Strangely this only happens in 64bit mode and not in 32bit.

In either case it's a bad idea to rely on wine created process having a parent or not because the wine project may change this anytime.