### PR TITLE
New context menu automation items

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -170,6 +170,23 @@ public:
 		return castValue<T>( m_value );
 	}
 
+	inline float getTrueValue(int frameOffset = 0) const
+	{
+		if (m_controllerConnection != nullptr)
+		{
+			if (m_useControllerValue == true)
+			{
+				return controllerValue(frameOffset);
+			}
+		}
+		else if (hasLinkedModels() == true)
+		{
+			return controllerValue(frameOffset);
+		}
+
+		return m_value;
+	}
+
 	float controllerValue( int frameOffset ) const;
 
 	//! @brief Function that returns sample-exact data as a ValueBuffer

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -28,9 +28,14 @@
 
 #include "ModelView.h"
 #include "AutomatableModel.h"
+#include "AutomationTrack.h"
+#include "AutomationClip.h"
+#include "SongEditor.h"
+#include "Song.h"
 
 class QMenu;
 class QMouseEvent;
+class Song;
 
 namespace lmms::gui
 {
@@ -83,6 +88,7 @@ protected:
 	QString m_description;
 	QString m_unit;
 	float m_conversionFactor; // Factor to be applied when the m_model->value is displayed
+
 } ;
 
 
@@ -97,10 +103,17 @@ public:
 public slots:
 	void execConnectionDialog();
 	void removeConnection();
+	void addSongAutomationPoint();
+	void addSongAutomationPointAndClip();
+	void removeSongNearestAutomationPoint();
 	void editSongGlobalAutomation();
 	void unlinkAllModels();
 	void removeSongGlobalAutomation();
 
+private:
+	AutomationTrack* getCurrentAutomationTrack(std::vector<AutomationClip*>* clips);
+	AutomationClip* getCurrentAutomationClip(AutomationTrack* track, bool canAddNewClip);
+	AutomationClip* makeNewClip(AutomationTrack* track, TimePos position, bool canSnap);
 private slots:
 	/// Copy the model's value to the clipboard.
 	void copyToClipboard();

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -112,9 +112,18 @@ public slots:
 	void removeSongGlobalAutomation();
 
 private:
+	// gets the automationTrack with the most amount of clips connected to it
+	// if this track doesn't exists and "canAddNewTrack", then add a new one else return nullptr
+	// "clips" = clips that are connected to this model
 	AutomationTrack* getCurrentAutomationTrack(std::vector<AutomationClip*>* clips, bool canAddNewTrack);
+	// gets the clip that start before or after the song time position (playback pos)
+	// if this clip doesn't exists and "canAddNewClip", then add a new one else return nullptr
 	AutomationClip* getCurrentAutomationClip(AutomationTrack* track, bool canAddNewClip, bool searchAfter);
+	// gets the automationNode closest to the song time position (playback pos)
+	// "clipOut" is the clip that has the node
+	// can return nullptr on "clipOut"
 	const TimePos getNearestAutomationNode(AutomationTrack* track, AutomationClip** clipOut);
+	// makes new clip and connects it to this model
 	AutomationClip* makeNewClip(AutomationTrack* track, TimePos position, bool canSnap);
 private slots:
 	/// Copy the model's value to the clipboard.

--- a/include/AutomatableModelView.h
+++ b/include/AutomatableModelView.h
@@ -103,16 +103,18 @@ public:
 public slots:
 	void execConnectionDialog();
 	void removeConnection();
-	void addSongAutomationPoint();
-	void addSongAutomationPointAndClip();
-	void removeSongNearestAutomationPoint();
+	void addSongAutomationNode();
+	void addSongAutomationNodeAndClip();
+	void updateSongNearestAutomationNode();
+	void removeSongNearestAutomationNode();
 	void editSongGlobalAutomation();
 	void unlinkAllModels();
 	void removeSongGlobalAutomation();
 
 private:
-	AutomationTrack* getCurrentAutomationTrack(std::vector<AutomationClip*>* clips);
-	AutomationClip* getCurrentAutomationClip(AutomationTrack* track, bool canAddNewClip);
+	AutomationTrack* getCurrentAutomationTrack(std::vector<AutomationClip*>* clips, bool canAddNewTrack);
+	AutomationClip* getCurrentAutomationClip(AutomationTrack* track, bool canAddNewClip, bool searchAfter);
+	const TimePos getNearestAutomationNode(AutomationTrack* track, AutomationClip** clipOut);
 	AutomationClip* makeNewClip(AutomationTrack* track, TimePos position, bool canSnap);
 private slots:
 	/// Copy the model's value to the clipboard.

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -415,8 +415,8 @@ AutomationClip* AutomatableModelViewSlots::getCurrentAutomationClip(AutomationTr
 		for (size_t i = 0; i < trackClips.size(); i++)
 		{
 			tick_t currentTime = trackClips[i]->startPosition().getTicks();
-			if ((searchAfter == false && currentTime > closestTime && timePos.getTicks() > currentTime)
-				|| (searchAfter == true && (currentTime < closestTime || closestTime < 0) && timePos.getTicks() < currentTime))
+			if ((searchAfter == false && (currentTime > closestTime || closestTime < 0) && timePos.getTicks() > currentTime)
+				|| (searchAfter == true && (currentTime < closestTime || closestTime < 0) && timePos.getTicks() <= currentTime))
 			{
 				closestTime = trackClips[i]->startPosition().getTicks();
 				closestClipLocation = i;


### PR DESCRIPTION
This PR adds new context menu options for `automatableModels` to improve the automation workflow.

These options are the following:

- "add automation node" - adds an automation node with the model's value to a clip at the song playback position. If there is no clip connected to the model, a new track will be added with a clip that is automatically connected to the model.
- "add automation node to new clip" - first, but it adds a new clip if possible before adding an automation node.
- "update closest automation node" - replaces the value of the closest node to the playback position.
- "remove closest automation node" - deletes the closest node to the playback position.

In my view these options will make the automation system faster to use.