### PR TITLE
Fix TripleOscillator's white noise generator

### DIFF
--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -163,11 +163,7 @@ public:
 
 	static inline sample_t noiseSample( const float )
 	{
-		// Precise implementation
-//		return 1.0f - rand() * 2.0f / RAND_MAX;
-
-		// Fast implementation
-		return 1.0f - fast_rand() * 2.0f / FAST_RAND_MAX;
+		return 1.0f - rand() * 2.0f / RAND_MAX;
 	}
 
 	static sample_t userWaveSample(const SampleBuffer* buffer, const float sample)


### PR DESCRIPTION
TripleOscillator's noise generator has a major bug which causes it to sound atrociously ugly when multiple notes are played simultaneously, due to the random number generator it uses.  This PR switches it from `fast_rand` to `rand` to fix this.

To reproduce the bug, open TripleOscillator, set any oscillator to white noise, and play any chord.

(This PR technically breaks backwards compatibility, but that really shouldn't matter here.)