### PR TITLE
Use `src_set_ratio` to fix artifacts in `Sample` playback

### DIFF
--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -52,6 +52,7 @@ public:
 	auto resample(const float* in, long inputFrames, float* out, long outputFrames, double ratio) -> ProcessResult;
 	auto interpolationMode() const -> int { return m_interpolationMode; }
 	auto channels() const -> int { return m_channels; }
+	void setRatio(double ratio);
 
 private:
 	int m_interpolationMode = -1;

--- a/src/core/AudioResampler.cpp
+++ b/src/core/AudioResampler.cpp
@@ -61,4 +61,9 @@ auto AudioResampler::resample(const float* in, long inputFrames, float* out, lon
 	return {src_process(m_state, &data), data.input_frames_used, data.output_frames_gen};
 }
 
+void AudioResampler::setRatio(double ratio)
+{
+	src_set_ratio(m_state, ratio);
+}
+
 } // namespace lmms

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -134,6 +134,8 @@ bool Sample::play(sampleFrame* dst, PlaybackState* state, size_t numFrames, floa
 	auto playBuffer = std::vector<sampleFrame>(numFrames / resampleRatio + marginSize);
 	playRaw(playBuffer.data(), playBuffer.size(), state, loopMode);
 
+	state->resampler().setRatio(resampleRatio);
+
 	const auto resampleResult
 		= state->resampler().resample(&playBuffer[0][0], playBuffer.size(), &dst[0][0], numFrames, resampleRatio);
 	advance(state, resampleResult.inputFramesUsed, loopMode);


### PR DESCRIPTION
Makes use of the function `src_set_ratio` to allow for smoother transitions in the resampling ratio when playing back a `Sample`, removing the artifacts heard when de-tuning notes for instruments like the AFP down rapidly.