### PR TITLE
Run CMake with -Werror=dev in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
     container: ghcr.io/lmms/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
+        -Werror=dev
         -DUSE_WERROR=ON
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DUSE_COMPILE_CACHE=ON
@@ -79,6 +80,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CMAKE_OPTS: >-
+        -Werror=dev
         -DUSE_WERROR=ON
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DUSE_COMPILE_CACHE=ON
@@ -168,6 +170,7 @@ jobs:
     container: ghcr.io/lmms/linux.mingw:20.04
     env:
       CMAKE_OPTS: >-
+        -Werror=dev
         -DUSE_WERROR=ON
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DUSE_COMPILE_CACHE=ON
@@ -276,6 +279,7 @@ jobs:
             -B build `
             -G Ninja `
             --toolchain C:/vcpkg/scripts/buildsystems/vcpkg.cmake `
+            -Werror=dev `
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DUSE_COMPILE_CACHE=ON `
             -DVCPKG_TARGET_TRIPLET="${{ matrix.arch }}-windows" `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ function(enable_policy_if_exists id)
 	endif()
 endfunction()
 
-# Needed for the SWH Ladspa plugins. See below.
-enable_policy_if_exists(CMP0074) # find_package() uses <PackageName>_ROOT variables.
 # Needed for ccache support with MSVC
 enable_policy_if_exists(CMP0141) # MSVC debug information format flags are selected by an abstraction.
 


### PR DESCRIPTION
This causes CMake warnings (including `AUTHOR_WARNING` and `DEPRECATION` level messages) to be reported as errors, which means that all CMake warnings must be fixed for CI to pass. See [the CMake documentation for this flag](https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-Werror).