### PR TITLE
Fix caching for macOS CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,15 +99,16 @@ jobs:
         with:
           key: n/a - only restore from restore-keys
           restore-keys: |
-            homebrew-
+            homebrew-${{ matrix.arch }}-
           path: ~/Library/Caches/Homebrew/downloads
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
-          key: ccache-${{ github.job }}-${{ github.ref }}-${{ github.run_id }}
+          key: "ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}\
+            -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-${{ github.ref }}-
-            ccache-${{ github.job }}-
+            ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}-
+            ccache-${{ github.job }}-${{ matrix.arch }}-
           path: ~/Library/Caches/ccache
       - name: Install dependencies
         run: |
@@ -156,7 +157,8 @@ jobs:
       - name: Save Homebrew download cache
         uses: actions/cache/save@v3
         with:
-          key: homebrew-${{ hashFiles('Brewfile.lock.json') }}
+          key: "homebrew-${{ matrix.arch }}\
+            -${{ hashFiles('Brewfile.lock.json') }}"
           path: ~/Library/Caches/Homebrew/downloads
   mingw:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Clean up Homebrew download cache
         run: rm -rf ~/Library/Caches/Homebrew/downloads
       - name: Restore Homebrew download cache
+        id: cache-homebrew
         uses: actions/cache/restore@v3
         with:
           key: n/a - only restore from restore-keys
@@ -155,11 +156,14 @@ jobs:
         env:
           CCACHE_MAXSIZE: 500MB
       - name: Save Homebrew download cache
+        if: ${{ steps.cache-homebrew.outputs.cache-matched-key != env.key }}
         uses: actions/cache/save@v3
         with:
+          key: ${{ env.key }} 
+          path: ~/Library/Caches/Homebrew/downloads
+        env:
           key: "homebrew-${{ matrix.arch }}\
             -${{ hashFiles('Brewfile.lock.json') }}"
-          path: ~/Library/Caches/Homebrew/downloads
   mingw:
     strategy:
       fail-fast: false


### PR DESCRIPTION
There are two changes in this PR:
* Make the macOS caches (ccache and Homebrew downloads) architecture-specific. Previously, since caches are immutable, whichever job (x86_64 or arm64) finished first had its cache saved, and the other was unable to cache anything. This meant that one of the macOS jobs effectively ran without any caching. Splitting the caches by architecture should improve performance by avoiding this issue.
* Only save the Homebrew download cache if the lock file changes. Previously, we always tried to save the download cache. This would fail if the cache already existed, but this wasn't fatal for the job, at least. Worse is that the caches are isolated for each branch, but every branch can read caches for the master branch. The result is that we would unnecessarily save a separate copy of the download cache for every PR, which used up a lot of our cache quota, increasing cache churn. It also meant that the master cache was only read once for each PR, and therefore was more likely to expire due to lack of use. All these issues are fixed or reduced in severity by only saving the cache when it changes.