### PR TITLE
Fix pitch shifter glide 0 division

### DIFF
--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -87,7 +87,7 @@ bool GranularPitchShifterEffect::processAudioBuffer(sampleFrame* buf, const fpp_
 	if (glide != m_oldGlide)
 	{
 		m_oldGlide = glide;
-		m_glideCoef = std::exp(-1 / (glide * m_sampleRate));
+		m_glideCoef = glide > 0 ? std::exp(-1 / (glide * m_sampleRate)) : 0;
 	}
 	
 	const float shapeK = cosWindowApproxK(shape);


### PR DESCRIPTION
There's a 0 division when Glide is brought to 0 (which actually works fine, but causes errors in the FPU debug mode thingy).
I fixed this in my personal build but accidentally missed it when transferring things over to the PR.