### PR TITLE
Fix bad Granular Pitch Shifter init values

### DIFF
--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -96,8 +96,8 @@ bool GranularPitchShifterEffect::processAudioBuffer(sampleFrame* buf, const fpp_
 
 	for (fpp_t f = 0; f < frames; ++f)
 	{
-		const double pitch = pitchBuf ? pitchBuf->value(f) : m_granularpitchshifterControls.m_pitchModel.value();
-		const double pitchSpread = (pitchSpreadBuf ? pitchSpreadBuf->value(f) : m_granularpitchshifterControls.m_pitchSpreadModel.value()) * 0.5f;
+		const double pitch = (pitchBuf ? pitchBuf->value(f) : m_granularpitchshifterControls.m_pitchModel.value()) * (1. / 12.);
+		const double pitchSpread = (pitchSpreadBuf ? pitchSpreadBuf->value(f) : m_granularpitchshifterControls.m_pitchSpreadModel.value()) * (1. / 24.);
 		
 		// interpolate pitch depending on glide
 		for (int i = 0; i < 2; ++i)
@@ -118,8 +118,8 @@ bool GranularPitchShifterEffect::processAudioBuffer(sampleFrame* buf, const fpp_
 			m_updatePitches = false;
 			
 			std::array<double, 2> speed = {
-				std::exp2(m_truePitch[0] * (1. / 12.)),
-				std::exp2(m_truePitch[1] * (1. / 12.))
+				std::exp2(m_truePitch[0]),
+				std::exp2(m_truePitch[1])
 			};
 			std::array<double, 2> ratio = {
 				speed[0] / m_speed[0],
@@ -275,12 +275,12 @@ void GranularPitchShifterEffect::changeSampleRate()
 	
 	m_dcCoeff = std::exp(-2.0 * F_PI * DcRemovalHz / m_sampleRate);
 
-	const float pitch = m_granularpitchshifterControls.m_pitchModel.value();
-	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value() * 0.5f;
+	const float pitch = m_granularpitchshifterControls.m_pitchModel.value() * (1. / 12.);
+	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value() * (1. / 24.);
 	m_truePitch[0] = pitch - pitchSpread;
 	m_truePitch[1] = pitch + pitchSpread;
-	m_speed[0] = std::exp2(m_truePitch[0] * (1. / 12.));
-	m_speed[1] = std::exp2(m_truePitch[1] * (1. / 12.));
+	m_speed[0] = std::exp2(m_truePitch[0]);
+	m_speed[1] = std::exp2(m_truePitch[1]);
 }
 
 

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -275,8 +275,8 @@ void GranularPitchShifterEffect::changeSampleRate()
 	
 	m_dcCoeff = std::exp(-2.0 * F_PI * DcRemovalHz / m_sampleRate);
 
-	const float pitch = m_granularpitchshifterControls.m_pitchModel.value() * (1. / 12.);
-	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value() * (1. / 24.);
+	const double pitch = m_granularpitchshifterControls.m_pitchModel.value() * (1. / 12.);
+	const double pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value() * (1. / 24.);
 	m_truePitch[0] = pitch - pitchSpread;
 	m_truePitch[1] = pitch + pitchSpread;
 	m_speed[0] = std::exp2(m_truePitch[0]);

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -276,7 +276,7 @@ void GranularPitchShifterEffect::changeSampleRate()
 	m_dcCoeff = std::exp(-2.0 * F_PI * DcRemovalHz / m_sampleRate);
 
 	const float pitch = m_granularpitchshifterControls.m_pitchModel.value();
-	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value();
+	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value() * 0.5f;
 	m_truePitch[0] = pitch - pitchSpread;
 	m_truePitch[1] = pitch + pitchSpread;
 	m_speed[0] = std::exp2(m_truePitch[0] * (1. / 12.));

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -274,6 +274,13 @@ void GranularPitchShifterEffect::changeSampleRate()
 	m_grains.reserve(8);// arbitrary
 	
 	m_dcCoeff = std::exp(-2.0 * F_PI * DcRemovalHz / m_sampleRate);
+
+	const float pitch = m_granularpitchshifterControls.m_pitchModel.value();
+	const float pitchSpread = m_granularpitchshifterControls.m_pitchSpreadModel.value();
+	m_truePitch[0] = pitch - pitchSpread;
+	m_truePitch[1] = pitch + pitchSpread;
+	m_speed[0] = std::exp2(m_truePitch[0] * (1. / 12.));
+	m_speed[1] = std::exp2(m_truePitch[1] * (1. / 12.));
 }
 
 

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.h
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.h
@@ -168,7 +168,7 @@ private:
 	int m_ringBufLength = 0;
 	int m_writePoint = 0;
 	int m_grainCount = 0;
-	int m_timeSinceLastGrain = 0;
+	int m_timeSinceLastGrain = 999999999;
 
 	double m_oldGlide = -1;
 	double m_glideCoef = 0;


### PR DESCRIPTION
Fixes #7349, the plugin is initialized thinking it just barely spawned a grain so it needs to wait for half of a grain length before spawning the first one.

Also fixes a bug where the pitch is initialized to 0 instead of the current pitch values, which is audible with large glide values.

<sub><sup>(and threw in a small CPU optimization I missed)</sub></sup>