### PR TITLE
Initialize LOMM arrays

### DIFF
--- a/plugins/LOMM/LOMM.cpp
+++ b/plugins/LOMM/LOMM.cpp
@@ -94,7 +94,7 @@ void LOMMEffect::changeSampleRate()
 		}
 	}
 
-	m_yL[0][0] = m_yL[0][1] = m_yL[1][0] = m_yL[1][1] = m_yL[2][0] = m_yL[2][1] = LOMM_MIN_FLOOR;
+	std::fill(m_yL.begin(), m_yL.end(), std::array<float, 2>{LOMM_MIN_FLOOR, LOMM_MIN_FLOOR});
 	m_rms = m_gainResult = m_displayIn = m_displayOut = m_prevOut = m_yL;
 	m_crestPeakVal[0] = m_crestPeakVal[1] = LOMM_MIN_FLOOR;
 	m_crestRmsVal = m_crestFactorVal = m_crestPeakVal;

--- a/plugins/LOMM/LOMM.cpp
+++ b/plugins/LOMM/LOMM.cpp
@@ -64,14 +64,10 @@ LOMMEffect::LOMMEffect(Model* parent, const Descriptor::SubPluginFeatures::Key* 
 {
 	autoQuitModel()->setValue(autoQuitModel()->maxValue());
 	
-	m_yL[0][0] = m_yL[0][1] = LOMM_MIN_FLOOR;
-	m_yL[1][0] = m_yL[1][1] = LOMM_MIN_FLOOR;
-	m_yL[2][0] = m_yL[2][1] = LOMM_MIN_FLOOR;
-	
 	m_ap.setFilterType(BasicFilters<2>::FilterType::AllPass);
 	
 	connect(Engine::audioEngine(), SIGNAL(sampleRateChanged()), this, SLOT(changeSampleRate()));
-	emit changeSampleRate();
+	changeSampleRate();
 }
 
 void LOMMEffect::changeSampleRate()
@@ -97,6 +93,11 @@ void LOMMEffect::changeSampleRate()
 			m_scLookBuf[j][i].resize(m_lookBufLength, LOMM_MIN_FLOOR);
 		}
 	}
+
+	m_yL[0][0] = m_yL[0][1] = m_yL[1][0] = m_yL[1][1] = m_yL[2][0] = m_yL[2][1] = LOMM_MIN_FLOOR;
+	m_rms = m_gainResult = m_displayIn = m_displayOut = m_prevOut = m_yL;
+	m_crestPeakVal[0] = m_crestPeakVal[1] = LOMM_MIN_FLOOR;
+	m_crestRmsVal = m_crestFactorVal = m_crestPeakVal;
 }
 
 


### PR DESCRIPTION
This one's rather embarrassing.  Way back when I made this plugin I was still quite new to C++ and didn't know anything about data manipulation in general.  At that time I believed arrays are initialized to 0 by default, which obviously isn't true.

Fixes #7353.