### PR TITLE
Start running Granular Pitch Shifter upon initialization and sample rate change

### DIFF
--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -281,6 +281,9 @@ void GranularPitchShifterEffect::changeSampleRate()
 	m_truePitch[1] = pitch + pitchSpread;
 	m_speed[0] = std::exp2(m_truePitch[0]);
 	m_speed[1] = std::exp2(m_truePitch[1]);
+
+	// "warm up" the plugin by spawning in all of the grains immediately
+	startRunning();
 }
 
 


### PR DESCRIPTION
Deals with something mentioned in the comments in #7354.  This isn't a bug fix, it just brings things closer to the desired behavior.  
It takes a bit of time for this pitch shifter to "warm up" and get all of its grains spawned (as is the nature of all granular audio processing), so it's best to start flushing some audio through immediately upon plugin initialization or sample rate change.