### PR TITLE
Use recursive mutex for `requestChangeInModel`/`doneChangeInModel`

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -419,7 +419,7 @@ private:
 
 	bool m_clearSignal;
 
-	std::mutex m_changeMutex;
+	std::recursive_mutex m_changeMutex;
 
 	friend class Engine;
 	friend class AudioEngineWorkerThread;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -66,7 +66,7 @@ namespace lmms
 
 using LocklessListElement = LocklessList<PlayHandle*>::Element;
 
-static thread_local bool s_renderingThread;
+static thread_local bool s_renderingThread = false;
 
 
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -67,7 +67,6 @@ namespace lmms
 using LocklessListElement = LocklessList<PlayHandle*>::Element;
 
 static thread_local bool s_renderingThread;
-static thread_local bool s_runningChange;
 
 
 
@@ -784,16 +783,14 @@ void AudioEngine::removePlayHandlesOfTypes(Track * track, PlayHandle::Types type
 
 void AudioEngine::requestChangeInModel()
 {
-	if (s_renderingThread || s_runningChange) { return; }
+	if (s_renderingThread) { return; }
 	m_changeMutex.lock();
-	s_runningChange = true;
 }
 
 void AudioEngine::doneChangeInModel()
 {
-	if (s_renderingThread || !s_runningChange) { return; }
+	if (s_renderingThread) { return; }
 	m_changeMutex.unlock();
-	s_runningChange = false;
 }
 
 bool AudioEngine::isAudioDevNameValid(QString name)


### PR DESCRIPTION
Fixes a possible regression from #6881 (though I did complain of issues like this one when making that PR). It is common for code that calls `requestChangeInModel`/`doneChangeInModel` to then call other functions that call these synchronization functions within, which could allow the audio thread to run prematurely if these recursive calls are not taken into consideration.