### PR TITLE
Revert " Reduce Memory Leaks"

### DIFF
--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -670,9 +670,7 @@ void NotePlayHandleManager::extend( int c )
 
 void NotePlayHandleManager::free()
 {
-	delete s_available[0];
 	delete[] s_available;
-	s_available = nullptr;
 }
 
 


### PR DESCRIPTION
Reverts LMMS/lmms#7345. This seems to have fixed the memory leaks mentioned, but caused a segfault on calls to `NotePlayHandleManager::free`. We are in the process of replacing `NotePlayHandleManager` (or at least refactoring it to make it better in its current state), so any small fixes to it should be postponed for now.