### PR TITLE
Define `fpp_t` and `f_cnt_t` to be of `size_t`

### DIFF
--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -25,11 +25,12 @@
 #ifndef LMMS_INSTRUMENT_FUNCTIONS_H
 #define LMMS_INSTRUMENT_FUNCTIONS_H
 
-#include "JournallingObject.h"
-#include "lmms_basics.h"
+#include <array>
+
 #include "AutomatableModel.h"
-#include "TempoSyncKnobModel.h"
 #include "ComboBoxModel.h"
+#include "JournallingObject.h"
+#include "TempoSyncKnobModel.h"
 
 namespace lmms
 {

--- a/include/Piano.h
+++ b/include/Piano.h
@@ -25,8 +25,10 @@
 #ifndef LMMS_PIANO_H
 #define LMMS_PIANO_H
 
-#include "Note.h"
+#include <array>
+
 #include "Model.h"
+#include "Note.h"
 
 namespace lmms
 {

--- a/include/SampleFrame.h
+++ b/include/SampleFrame.h
@@ -28,7 +28,9 @@
 
 #include "lmms_basics.h"
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 
 
 namespace lmms

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -49,8 +49,8 @@ using sample_t = float;		  // standard sample-type
 using int_sample_t = int16_t; // 16-bit-int-sample
 
 using sample_rate_t = uint32_t; // sample-rate
-using fpp_t = int16_t;			// frames per period (0-16384)
-using f_cnt_t = int32_t;		// standard frame-count
+using fpp_t = std::size_t;		// frames per period (0-16384)
+using f_cnt_t = std::size_t;	// standard frame-count
 using ch_cnt_t = uint8_t;		// channel-count (0-DEFAULT_CHANNELS)
 using bpm_t = uint16_t;			// tempo (MIN_BPM to MAX_BPM)
 using bitrate_t = uint16_t;		// bitrate in kbps

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -46,8 +46,8 @@ using sample_t = float;		  // standard sample-type
 using int_sample_t = int16_t; // 16-bit-int-sample
 
 using sample_rate_t = uint32_t; // sample-rate
-using fpp_t = std::size_t;		// frames per period (0-16384)
-using f_cnt_t = std::size_t;	// standard frame-count
+using fpp_t = size_t;			// frames per period (0-16384)
+using f_cnt_t = size_t;			// standard frame-count
 using ch_cnt_t = uint8_t;		// channel-count (0-DEFAULT_CHANNELS)
 using bpm_t = uint16_t;			// tempo (MIN_BPM to MAX_BPM)
 using bitrate_t = uint16_t;		// bitrate in kbps

--- a/include/lmms_basics.h
+++ b/include/lmms_basics.h
@@ -31,10 +31,7 @@
 #include "lmmsconfig.h"
 
 #include <cstdint>
-#include <array>
 
-#include <cmath>
-#include <algorithm>
 
 
 namespace lmms

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -30,6 +30,7 @@
 #include "SampleLoader.h"
 #include "Song.h"
 
+#include "lmms_basics.h"
 #include "plugin_export.h"
 
 #include <QDomElement>
@@ -276,7 +277,7 @@ QString AudioFileProcessor::nodeName() const
 
 
 
-auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
+auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
 {
 	// If we can play indefinitely, use the default beat note duration
 	if (static_cast<Sample::Loop>(m_loopModel.value()) != Sample::Loop::Off) { return 0; }
@@ -292,7 +293,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 		: m_nextPlayStartPoint;
 	const auto duration = m_sample.endFrame() - startFrame;
 
-	return static_cast<int>(std::floor(duration * freqFactor));
+	return static_cast<f_cnt_t>(std::floor(duration * freqFactor));
 }
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -276,7 +276,7 @@ QString AudioFileProcessor::nodeName() const
 
 
 
-auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
+auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
 {
 	// If we can play indefinitely, use the default beat note duration
 	if (static_cast<Sample::Loop>(m_loopModel.value()) != Sample::Loop::Off) { return 0; }
@@ -292,7 +292,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 		: m_nextPlayStartPoint;
 	const auto duration = m_sample.endFrame() - startFrame;
 
-	return static_cast<int>(std::floor(duration * freqFactor));
+	return static_cast<f_cnt_t>(std::floor(duration * freqFactor));
 }
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -276,7 +276,7 @@ QString AudioFileProcessor::nodeName() const
 
 
 
-auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
+auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> int
 {
 	// If we can play indefinitely, use the default beat note duration
 	if (static_cast<Sample::Loop>(m_loopModel.value()) != Sample::Loop::Off) { return 0; }
@@ -292,7 +292,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
 		: m_nextPlayStartPoint;
 	const auto duration = m_sample.endFrame() - startFrame;
 
-	return static_cast<f_cnt_t>(std::floor(duration * freqFactor));
+	return static_cast<int>(std::floor(duration * freqFactor));
 }
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -32,6 +32,7 @@
 
 #include "Instrument.h"
 #include "Sample.h"
+#include "lmms_basics.h"
 
 
 namespace lmms
@@ -54,7 +55,7 @@ public:
 
 	QString nodeName() const override;
 
-	auto beatLen(NotePlayHandle* note) const -> int override;
+	auto beatLen(NotePlayHandle* note) const -> f_cnt_t override;
 
 	float desiredReleaseTimeMs() const override
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -54,7 +54,7 @@ public:
 
 	QString nodeName() const override;
 
-	auto beatLen(NotePlayHandle* note) const -> f_cnt_t override;
+	auto beatLen(NotePlayHandle* note) const -> int override;
 
 	float desiredReleaseTimeMs() const override
 	{
@@ -89,7 +89,7 @@ private slots:
 
 
 signals:
-	void isPlaying(f_cnt_t _current_frame);
+	void isPlaying( lmms::f_cnt_t _current_frame );
 	void sampleUpdated();
 
 private:

--- a/plugins/AudioFileProcessor/AudioFileProcessor.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.h
@@ -54,7 +54,7 @@ public:
 
 	QString nodeName() const override;
 
-	auto beatLen(NotePlayHandle* note) const -> int override;
+	auto beatLen(NotePlayHandle* note) const -> f_cnt_t override;
 
 	float desiredReleaseTimeMs() const override
 	{
@@ -89,7 +89,7 @@ private slots:
 
 
 signals:
-	void isPlaying( lmms::f_cnt_t _current_frame );
+	void isPlaying(f_cnt_t _current_frame);
 	void sampleUpdated();
 
 private:

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -44,23 +44,23 @@ void AudioFileProcessorWaveView::updateSampleRange()
 {
 	if (m_sample->sampleSize() > 1)
 	{
-		const f_cnt_t marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
+		const auto marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
 		setFrom(m_sample->startFrame() - marging);
 		setTo(m_sample->endFrame() + marging);
 	}
 }
 
-void AudioFileProcessorWaveView::setTo(f_cnt_t to)
+void AudioFileProcessorWaveView::setTo(int to)
 {
-	m_to = std::min(to, static_cast<lmms::f_cnt_t>(m_sample->sampleSize()));
+	m_to = std::min(to, static_cast<int>(m_sample->sampleSize()));
 }
 
-void AudioFileProcessorWaveView::setFrom(f_cnt_t from)
+void AudioFileProcessorWaveView::setFrom(int from)
 {
 	m_from = std::max(from, 0);
 }
 
-f_cnt_t AudioFileProcessorWaveView::range() const
+int AudioFileProcessorWaveView::range() const
 {
 	return m_to - m_from;
 }
@@ -196,7 +196,7 @@ void AudioFileProcessorWaveView::paintEvent(QPaintEvent * pe)
 	p.drawPixmap(s_padding, s_padding, m_graph);
 
 	const QRect graph_rect(s_padding, s_padding, width() - 2 * s_padding, height() - 2 * s_padding);
-	const f_cnt_t frames = range();
+	const auto frames = range();
 	m_startFrameX = graph_rect.x() + (m_sample->startFrame() - m_from) *
 						double(graph_rect.width()) / frames;
 	m_endFrameX = graph_rect.x() + (m_sample->endFrame() - m_from) *
@@ -341,29 +341,30 @@ void AudioFileProcessorWaveView::updateGraph()
 
 void AudioFileProcessorWaveView::zoom(const bool out)
 {
-	const f_cnt_t start = m_sample->startFrame();
-	const f_cnt_t end = m_sample->endFrame();
-	const f_cnt_t frames = m_sample->sampleSize();
-	const f_cnt_t d_from = start - m_from;
-	const f_cnt_t d_to = m_to - end;
+	const auto start = m_sample->startFrame();
+	const auto end = m_sample->endFrame();
+	const auto frames = m_sample->sampleSize();
+	const auto d_from = start - static_cast<int>(m_from);
+	const auto d_to = static_cast<int>(m_to) - end;
 
-	const f_cnt_t step = qMax(1, qMax(d_from, d_to) / 10);
-	const f_cnt_t step_from = (out ? - step : step);
-	const f_cnt_t step_to = (out ? step : - step);
+	const auto step = std::max(1, std::max(d_from, d_to) / 10);
+	const auto step_from = (out ? - step : step);
+	const auto step_to = (out ? step : - step);
 
-	const double comp_ratio = double(qMin(d_from, d_to))
-								/ qMax(1, qMax(d_from, d_to));
+	const auto compRatio = static_cast<double>(std::min(d_from, d_to)) / std::max(1, std::max(d_from, d_to));
 
 	const auto boundedFrom = std::clamp(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp(m_to + step_to, end, frames);
+	const auto boundedTo = std::clamp(m_to + step_to, end, static_cast<int>(frames));
 
-	const auto toStep = static_cast<f_cnt_t>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
-	const auto newFrom
-		= (out && d_from < d_to) || (!out && d_to < d_from) ? boundedFrom : std::clamp(m_from + toStep, 0, start);
+	const auto toStep = step_from * (boundedTo == m_to ? 1 : compRatio);
+	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
+		? boundedFrom
+		: std::clamp(m_from + static_cast<int>(toStep), 0, start);
 
-	const auto fromStep = static_cast<f_cnt_t>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
-	const auto newTo
-		= (out && d_from < d_to) || (!out && d_to < d_from) ? std::clamp(m_to + fromStep, end, frames) : boundedTo;
+	const auto fromStep = step_to * (boundedFrom == m_from ? 1 : compRatio);
+	const auto newTo = (out && d_from < d_to) || (!out && d_to < d_from)
+		? std::clamp(m_to + static_cast<int>(fromStep), end, static_cast<int>(frames))
+		: boundedTo;
 
 	if (static_cast<double>(newTo - newFrom) / m_sample->sampleRate() > 0.05)
 	{
@@ -375,16 +376,11 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 void AudioFileProcessorWaveView::slide(int px)
 {
 	const double fact = qAbs(double(px) / width());
-	f_cnt_t step = range() * fact;
-	if (px > 0)
-	{
-		step = -step;
-	}
+	auto step = range() * fact * (px > 0 ? -1 : 1);
 
-	f_cnt_t step_from = qBound<size_t>(0, m_from + step, m_sample->sampleSize()) - m_from;
-	f_cnt_t step_to = qBound<size_t>(m_from + 1, m_to + step, m_sample->sampleSize()) - m_to;
-
-	step = qAbs(step_from) < qAbs(step_to) ? step_from : step_to;
+	const auto stepFrom = std::clamp<int>(m_from + step, 0, m_sample->sampleSize()) - m_from;
+	const auto stepTo = std::clamp<int>(m_to + step, m_from + 1, m_sample->sampleSize()) - m_to;
+	step = std::abs(stepFrom) < std::abs(stepTo) ? stepFrom : stepTo;
 
 	setFrom(m_from + step);
 	setTo(m_to + step);
@@ -465,10 +461,8 @@ void AudioFileProcessorWaveView::reverse()
 			- m_sample->startFrame()
 	);
 
-	const f_cnt_t from = m_from;
 	setFrom(m_sample->sampleSize() - m_to);
-	setTo(m_sample->sampleSize() - from);
-
+	setTo(m_sample->sampleSize() - m_from);
 	m_reversed = ! m_reversed;
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -45,7 +45,7 @@ void AudioFileProcessorWaveView::updateSampleRange()
 {
 	if (m_sample->sampleSize() > 1)
 	{
-		const auto marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
+		const f_cnt_t marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
 		setFrom(m_sample->startFrame() - marging);
 		setTo(m_sample->endFrame() + marging);
 	}
@@ -53,7 +53,7 @@ void AudioFileProcessorWaveView::updateSampleRange()
 
 void AudioFileProcessorWaveView::setTo(f_cnt_t to)
 {
-	m_to = std::min(to, static_cast<f_cnt_t>(m_sample->sampleSize()));
+	m_to = std::min(to, static_cast<lmms::f_cnt_t>(m_sample->sampleSize()));
 }
 
 void AudioFileProcessorWaveView::setFrom(f_cnt_t from)
@@ -375,13 +375,17 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 
 void AudioFileProcessorWaveView::slide(int px)
 {
-	const auto fact = std::abs(static_cast<double>(px) / width());
-	auto step = static_cast<int>(range() * fact);
-	if (px > 0) { step = -step; }
+	const double fact = qAbs(double(px) / width());
+	f_cnt_t step = range() * fact;
+	if (px > 0)
+	{
+		step = -step;
+	}
 
-	const auto stepFrom = std::clamp<int>(m_from + step, 0, m_sample->sampleSize()) - static_cast<int>(m_from);
-	const auto stepTo = std::clamp<int>(m_to + step, m_from + 1, m_sample->sampleSize()) - static_cast<int>(m_to);
-	step = std::abs(stepFrom) < std::abs(stepTo) ? stepFrom : stepTo;
+	f_cnt_t step_from = qBound<size_t>(0, m_from + step, m_sample->sampleSize()) - m_from;
+	f_cnt_t step_to = qBound<size_t>(m_from + 1, m_to + step, m_sample->sampleSize()) - m_to;
+
+	step = qAbs(step_from) < qAbs(step_to) ? step_from : step_to;
 
 	setFrom(m_from + step);
 	setTo(m_to + step);

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -27,6 +27,7 @@
 #include "ConfigManager.h"
 #include "gui_templates.h"
 #include "SampleWaveform.h"
+#include "lmms_basics.h"
 
 #include <QPainter>
 #include <QMouseEvent>
@@ -57,7 +58,7 @@ void AudioFileProcessorWaveView::setTo(f_cnt_t to)
 
 void AudioFileProcessorWaveView::setFrom(f_cnt_t from)
 {
-	m_from = std::max(from, 0);
+	m_from = std::max<f_cnt_t>(from, 0);
 }
 
 f_cnt_t AudioFileProcessorWaveView::range() const
@@ -347,19 +348,19 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 	const f_cnt_t d_from = start - m_from;
 	const f_cnt_t d_to = m_to - end;
 
-	const f_cnt_t step = qMax(1, qMax(d_from, d_to) / 10);
+	const f_cnt_t step = std::max<f_cnt_t>(1, std::max(d_from, d_to) / 10);
 	const f_cnt_t step_from = (out ? - step : step);
 	const f_cnt_t step_to = (out ? step : - step);
 
-	const double comp_ratio = double(qMin(d_from, d_to))
-								/ qMax(1, qMax(d_from, d_to));
+	const double comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max<f_cnt_t>(1, qMax(d_from, d_to));
 
-	const auto boundedFrom = std::clamp(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp(m_to + step_to, end, frames);
+	const auto boundedFrom = std::clamp<f_cnt_t>(m_from + step_from, 0, start);
+	const auto boundedTo = std::clamp<f_cnt_t>(m_to + step_to, end, frames);
 
 	const auto toStep = static_cast<f_cnt_t>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
-	const auto newFrom
-		= (out && d_from < d_to) || (!out && d_to < d_from) ? boundedFrom : std::clamp(m_from + toStep, 0, start);
+	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
+		? boundedFrom
+		: std::clamp<f_cnt_t>(m_from + toStep, 0, start);
 
 	const auto fromStep = static_cast<f_cnt_t>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
 	const auto newTo

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -27,7 +27,6 @@
 #include "ConfigManager.h"
 #include "gui_templates.h"
 #include "SampleWaveform.h"
-#include "lmms_basics.h"
 
 #include <QPainter>
 #include <QMouseEvent>
@@ -58,7 +57,7 @@ void AudioFileProcessorWaveView::setTo(f_cnt_t to)
 
 void AudioFileProcessorWaveView::setFrom(f_cnt_t from)
 {
-	m_from = std::max<f_cnt_t>(from, 0);
+	m_from = std::max(from, 0);
 }
 
 f_cnt_t AudioFileProcessorWaveView::range() const
@@ -348,19 +347,19 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 	const f_cnt_t d_from = start - m_from;
 	const f_cnt_t d_to = m_to - end;
 
-	const f_cnt_t step = std::max<f_cnt_t>(1, std::max(d_from, d_to) / 10);
+	const f_cnt_t step = qMax(1, qMax(d_from, d_to) / 10);
 	const f_cnt_t step_from = (out ? - step : step);
 	const f_cnt_t step_to = (out ? step : - step);
 
-	const double comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max<f_cnt_t>(1, qMax(d_from, d_to));
+	const double comp_ratio = double(qMin(d_from, d_to))
+								/ qMax(1, qMax(d_from, d_to));
 
-	const auto boundedFrom = std::clamp<f_cnt_t>(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp<f_cnt_t>(m_to + step_to, end, frames);
+	const auto boundedFrom = std::clamp(m_from + step_from, 0, start);
+	const auto boundedTo = std::clamp(m_to + step_to, end, frames);
 
 	const auto toStep = static_cast<f_cnt_t>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
-	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
-		? boundedFrom
-		: std::clamp<f_cnt_t>(m_from + toStep, 0, start);
+	const auto newFrom
+		= (out && d_from < d_to) || (!out && d_to < d_from) ? boundedFrom : std::clamp(m_from + toStep, 0, start);
 
 	const auto fromStep = static_cast<f_cnt_t>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
 	const auto newTo

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -342,29 +342,29 @@ void AudioFileProcessorWaveView::updateGraph()
 
 void AudioFileProcessorWaveView::zoom(const bool out)
 {
-	const f_cnt_t start = m_sample->startFrame();
-	const f_cnt_t end = m_sample->endFrame();
-	const f_cnt_t frames = m_sample->sampleSize();
-	const f_cnt_t d_from = start - m_from;
-	const f_cnt_t d_to = m_to - end;
+	const auto start = m_sample->startFrame();
+	const auto end = m_sample->endFrame();
+	const auto frames = m_sample->sampleSize();
+	const auto d_from = static_cast<int>(start - m_from);
+	const auto d_to = static_cast<int>(m_to - end);
 
-	const f_cnt_t step = std::max<f_cnt_t>(1, std::max(d_from, d_to) / 10);
-	const f_cnt_t step_from = (out ? - step : step);
-	const f_cnt_t step_to = (out ? step : - step);
+	const auto step = std::max(1, std::max(d_from, d_to) / 10);
+	const auto step_from = (out ? - step : step);
+	const auto step_to = (out ? step : - step);
 
-	const double comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max<f_cnt_t>(1, qMax(d_from, d_to));
+	const auto comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max(1, std::max(d_from, d_to));
 
-	const auto boundedFrom = std::clamp<f_cnt_t>(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp<f_cnt_t>(m_to + step_to, end, frames);
+	const auto boundedFrom = std::clamp<int>(m_from + step_from, 0, start);
+	const auto boundedTo = std::clamp<int>(m_to + step_to, end, frames);
 
-	const auto toStep = static_cast<f_cnt_t>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
+	const auto toStep = static_cast<int>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
 	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
 		? boundedFrom
-		: std::clamp<f_cnt_t>(m_from + toStep, 0, start);
+		: std::clamp<int>(m_from + toStep, 0, start);
 
-	const auto fromStep = static_cast<f_cnt_t>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
+	const auto fromStep = static_cast<int>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
 	const auto newTo
-		= (out && d_from < d_to) || (!out && d_to < d_from) ? std::clamp(m_to + fromStep, end, frames) : boundedTo;
+		= (out && d_from < d_to) || (!out && d_to < d_from) ? std::clamp<int>(m_to + fromStep, end, frames) : boundedTo;
 
 	if (static_cast<double>(newTo - newFrom) / m_sample->sampleRate() > 0.05)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -344,29 +344,29 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 	const auto start = m_sample->startFrame();
 	const auto end = m_sample->endFrame();
 	const auto frames = m_sample->sampleSize();
-	const auto d_from = start - static_cast<int>(m_from);
-	const auto d_to = static_cast<int>(m_to) - end;
 
-	const auto step = std::max(1, std::max(d_from, d_to) / 10);
-	const auto step_from = (out ? - step : step);
-	const auto step_to = (out ? step : - step);
+	const auto dFrom = start - m_from;
+	const auto dTo = m_to - end;
 
-	const auto compRatio = static_cast<double>(std::min(d_from, d_to)) / std::max(1, std::max(d_from, d_to));
+	const auto step = std::max(1.0, std::max(dFrom, dTo) / 10.0);
+	const auto stepFrom = out ? -step : step;
+	const auto stepTo = out ? step : -step;
 
-	const auto boundedFrom = std::clamp(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp(m_to + step_to, end, static_cast<int>(frames));
+	const auto boundedFrom = std::clamp(m_from + stepFrom, 0.0, static_cast<double>(start));
+	const auto boundedTo = std::clamp(m_to + stepTo, static_cast<double>(end), static_cast<double>(frames));
 
-	const auto toStep = step_from * (boundedTo == m_to ? 1 : compRatio);
-	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
+	const auto compRatio = std::min(dFrom, dTo) / static_cast<double>(std::max(1, std::max(dFrom, dTo)));
+	const auto toStep = stepFrom * (boundedTo == m_to ? 1 : compRatio);
+	const auto newFrom = (out && dFrom < dTo) || (!out && dTo < dFrom)
 		? boundedFrom
-		: std::clamp(m_from + static_cast<int>(toStep), 0, start);
+		: std::clamp(m_from + toStep, 0.0, static_cast<double>(start));
 
-	const auto fromStep = step_to * (boundedFrom == m_from ? 1 : compRatio);
-	const auto newTo = (out && d_from < d_to) || (!out && d_to < d_from)
-		? std::clamp(m_to + static_cast<int>(fromStep), end, static_cast<int>(frames))
+	const auto fromStep = stepTo * (boundedFrom == m_from ? 1 : compRatio);
+	const auto newTo = (out && dFrom < dTo) || (!out && dTo < dFrom)
+		? std::clamp(m_to + fromStep, static_cast<double>(end), static_cast<double>(frames))
 		: boundedTo;
 
-	if (static_cast<double>(newTo - newFrom) / m_sample->sampleRate() > 0.05)
+	if ((newTo - newFrom) / m_sample->sampleRate() > 0.05)
 	{
 		setFrom(newFrom);
 		setTo(newTo);

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -45,7 +45,7 @@ void AudioFileProcessorWaveView::updateSampleRange()
 {
 	if (m_sample->sampleSize() > 1)
 	{
-		const f_cnt_t marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
+		const auto marging = (m_sample->endFrame() - m_sample->startFrame()) * 0.1;
 		setFrom(m_sample->startFrame() - marging);
 		setTo(m_sample->endFrame() + marging);
 	}
@@ -53,7 +53,7 @@ void AudioFileProcessorWaveView::updateSampleRange()
 
 void AudioFileProcessorWaveView::setTo(f_cnt_t to)
 {
-	m_to = std::min(to, static_cast<lmms::f_cnt_t>(m_sample->sampleSize()));
+	m_to = std::min(to, static_cast<f_cnt_t>(m_sample->sampleSize()));
 }
 
 void AudioFileProcessorWaveView::setFrom(f_cnt_t from)
@@ -375,17 +375,13 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 
 void AudioFileProcessorWaveView::slide(int px)
 {
-	const double fact = qAbs(double(px) / width());
-	f_cnt_t step = range() * fact;
-	if (px > 0)
-	{
-		step = -step;
-	}
+	const auto fact = std::abs(static_cast<double>(px) / width());
+	auto step = static_cast<int>(range() * fact);
+	if (px > 0) { step = -step; }
 
-	f_cnt_t step_from = qBound<size_t>(0, m_from + step, m_sample->sampleSize()) - m_from;
-	f_cnt_t step_to = qBound<size_t>(m_from + 1, m_to + step, m_sample->sampleSize()) - m_to;
-
-	step = qAbs(step_from) < qAbs(step_to) ? step_from : step_to;
+	const auto stepFrom = std::clamp<int>(m_from + step, 0, m_sample->sampleSize()) - static_cast<int>(m_from);
+	const auto stepTo = std::clamp<int>(m_to + step, m_from + 1, m_sample->sampleSize()) - static_cast<int>(m_to);
+	step = std::abs(stepFrom) < std::abs(stepTo) ? stepFrom : stepTo;
 
 	setFrom(m_from + step);
 	setTo(m_to + step);

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -342,29 +342,29 @@ void AudioFileProcessorWaveView::updateGraph()
 
 void AudioFileProcessorWaveView::zoom(const bool out)
 {
-	const auto start = m_sample->startFrame();
-	const auto end = m_sample->endFrame();
-	const auto frames = m_sample->sampleSize();
-	const auto d_from = static_cast<int>(start - m_from);
-	const auto d_to = static_cast<int>(m_to - end);
+	const f_cnt_t start = m_sample->startFrame();
+	const f_cnt_t end = m_sample->endFrame();
+	const f_cnt_t frames = m_sample->sampleSize();
+	const f_cnt_t d_from = start - m_from;
+	const f_cnt_t d_to = m_to - end;
 
-	const auto step = std::max(1, std::max(d_from, d_to) / 10);
-	const auto step_from = (out ? - step : step);
-	const auto step_to = (out ? step : - step);
+	const f_cnt_t step = std::max<f_cnt_t>(1, std::max(d_from, d_to) / 10);
+	const f_cnt_t step_from = (out ? - step : step);
+	const f_cnt_t step_to = (out ? step : - step);
 
-	const auto comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max(1, std::max(d_from, d_to));
+	const double comp_ratio = static_cast<double>(std::min(d_from, d_to)) / std::max<f_cnt_t>(1, qMax(d_from, d_to));
 
-	const auto boundedFrom = std::clamp<int>(m_from + step_from, 0, start);
-	const auto boundedTo = std::clamp<int>(m_to + step_to, end, frames);
+	const auto boundedFrom = std::clamp<f_cnt_t>(m_from + step_from, 0, start);
+	const auto boundedTo = std::clamp<f_cnt_t>(m_to + step_to, end, frames);
 
-	const auto toStep = static_cast<int>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
+	const auto toStep = static_cast<f_cnt_t>(step_from * (boundedTo == m_to ? 1 : comp_ratio));
 	const auto newFrom = (out && d_from < d_to) || (!out && d_to < d_from)
 		? boundedFrom
-		: std::clamp<int>(m_from + toStep, 0, start);
+		: std::clamp<f_cnt_t>(m_from + toStep, 0, start);
 
-	const auto fromStep = static_cast<int>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
+	const auto fromStep = static_cast<f_cnt_t>(step_to * (boundedFrom == m_from ? 1 : comp_ratio));
 	const auto newTo
-		= (out && d_from < d_to) || (!out && d_to < d_from) ? std::clamp<int>(m_to + fromStep, end, frames) : boundedTo;
+		= (out && d_from < d_to) || (!out && d_to < d_from) ? std::clamp(m_to + fromStep, end, frames) : boundedTo;
 
 	if (static_cast<double>(newTo - newFrom) / m_sample->sampleRate() > 0.05)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -378,8 +378,8 @@ void AudioFileProcessorWaveView::slide(int px)
 	const double fact = qAbs(double(px) / width());
 	auto step = range() * fact * (px > 0 ? -1 : 1);
 
-	const auto stepFrom = std::clamp<int>(m_from + step, 0, m_sample->sampleSize()) - m_from;
-	const auto stepTo = std::clamp<int>(m_to + step, m_from + 1, m_sample->sampleSize()) - m_to;
+	const auto stepFrom = std::clamp(m_from + step, 0.0, static_cast<double>(m_sample->sampleSize())) - m_from;
+	const auto stepTo = std::clamp(m_to + step, m_from + 1.0, static_cast<double>(m_sample->sampleSize())) - m_to;
 	step = std::abs(stepFrom) < std::abs(stepTo) ? stepFrom : stepTo;
 
 	setFrom(m_from + step);

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -125,17 +125,17 @@ private:
 
 	Sample const* m_sample;
 	QPixmap m_graph;
-	f_cnt_t m_from;
-	f_cnt_t m_to;
-	f_cnt_t m_last_from;
-	f_cnt_t m_last_to;
+	int m_from;
+	int m_to;
+	int m_last_from;
+	int m_last_to;
 	float m_last_amp;
 	knob* m_startKnob;
 	knob* m_endKnob;
 	knob* m_loopKnob;
-	f_cnt_t m_startFrameX;
-	f_cnt_t m_endFrameX;
-	f_cnt_t m_loopFrameX;
+	int m_startFrameX;
+	int m_endFrameX;
+	int m_loopFrameX;
 	bool m_isDragging;
 	QPoint m_draggingLastPoint;
 	DraggingType m_draggingType;
@@ -152,9 +152,9 @@ public:
 
 	void updateSampleRange();
 private:
-	void setTo(f_cnt_t to);
-	void setFrom(f_cnt_t from);
-	f_cnt_t range() const;
+	void setTo(int to);
+	void setFrom(int from);
+	int range() const;
 	void zoom(const bool out = false);
 	void slide(int px);
 	void slideSamplePointByPx(Point point, int px);

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -750,8 +750,8 @@ void Lb302Synth::playNote( NotePlayHandle * _n, SampleFrame* _working_buffer )
 		m_notes.prepend( _n );
 	}
 	m_notesMutex.unlock();
-	
-	release_frame = qMax( release_frame, _n->framesLeft() + _n->offset() );
+
+	release_frame = std::max(release_frame, static_cast<int>(_n->framesLeft()) + static_cast<int>(_n->offset()));
 }
 
 

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -29,6 +29,7 @@
  */
 
 // Need to include this first to ensure we get M_PI in MinGW with C++11
+#include "lmms_basics.h"
 #define _USE_MATH_DEFINES
 #include <cmath>
 
@@ -750,8 +751,8 @@ void Lb302Synth::playNote( NotePlayHandle * _n, SampleFrame* _working_buffer )
 		m_notes.prepend( _n );
 	}
 	m_notesMutex.unlock();
-	
-	release_frame = qMax( release_frame, _n->framesLeft() + _n->offset() );
+
+	release_frame = std::max<f_cnt_t>(release_frame, _n->framesLeft() + _n->offset());
 }
 
 

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -29,7 +29,6 @@
  */
 
 // Need to include this first to ensure we get M_PI in MinGW with C++11
-#include "lmms_basics.h"
 #define _USE_MATH_DEFINES
 #include <cmath>
 
@@ -751,8 +750,8 @@ void Lb302Synth::playNote( NotePlayHandle * _n, SampleFrame* _working_buffer )
 		m_notes.prepend( _n );
 	}
 	m_notesMutex.unlock();
-
-	release_frame = std::max<f_cnt_t>(release_frame, _n->framesLeft() + _n->offset());
+	
+	release_frame = qMax( release_frame, _n->framesLeft() + _n->offset() );
 }
 
 

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -26,12 +26,13 @@
 #define LV2_INSTRUMENT_H
 
 #include <QString>
+#include <array>
 
 #include "Instrument.h"
 #include "InstrumentView.h"
-#include "Note.h"
 #include "Lv2ControlBase.h"
 #include "Lv2ViewBase.h"
+#include "Note.h"
 
 // whether to use MIDI vs playHandle
 // currently only MIDI works

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -25,7 +25,6 @@
 
 #include "MultitapEcho.h"
 #include "embed.h"
-#include "lmms_basics.h"
 #include "plugin_export.h"
 
 namespace lmms
@@ -119,8 +118,8 @@ bool MultitapEchoEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frame
 	}
 	
 	// add dry buffer - never swap inputs for dry
-	m_buffer.writeAddingMultiplied(buf, static_cast<f_cnt_t>(0), frames, dryGain);
-
+	m_buffer.writeAddingMultiplied( buf, 0, frames, dryGain );
+	
 	// swapped inputs?
 	if( swapInputs )
 	{

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -25,6 +25,7 @@
 
 #include "MultitapEcho.h"
 #include "embed.h"
+#include "lmms_basics.h"
 #include "plugin_export.h"
 
 namespace lmms
@@ -118,8 +119,8 @@ bool MultitapEchoEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frame
 	}
 	
 	// add dry buffer - never swap inputs for dry
-	m_buffer.writeAddingMultiplied( buf, 0, frames, dryGain );
-	
+	m_buffer.writeAddingMultiplied(buf, static_cast<f_cnt_t>(0), frames, dryGain);
+
 	// swapped inputs?
 	if( swapInputs )
 	{

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -119,7 +119,7 @@ bool MultitapEchoEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frame
 	}
 	
 	// add dry buffer - never swap inputs for dry
-	m_buffer.writeAddingMultiplied(buf, static_cast<f_cnt_t>(0), frames, dryGain);
+	m_buffer.writeAddingMultiplied(buf, f_cnt_t{0}, frames, dryGain);
 
 	// swapped inputs?
 	if( swapInputs )

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -900,7 +900,7 @@ void Sf2Instrument::renderFrames( f_cnt_t frames, SampleFrame* buf )
 		}
 		if( src_data.output_frames_gen > frames )
 		{
-			qCritical( "Sf2Instrument: not enough frames: %ld / %d", src_data.output_frames_gen, frames );
+			qCritical("Sf2Instrument: not enough frames: %ld / %zu", src_data.output_frames_gen, frames);
 		}
 	}
 	else

--- a/plugins/Sf2Player/Sf2Player.h
+++ b/plugins/Sf2Player/Sf2Player.h
@@ -27,6 +27,7 @@
 #ifndef SF2_PLAYER_H
 #define SF2_PLAYER_H
 
+#include <array>
 #include <fluidsynth/types.h>
 #include <QMutex>
 #include <samplerate.h>

--- a/plugins/Sfxr/Sfxr.h
+++ b/plugins/Sfxr/Sfxr.h
@@ -28,6 +28,8 @@
 #ifndef SFXR_H
 #define SFXR_H
 
+#include <array>
+
 #include "AutomatableModel.h"
 #include "Instrument.h"
 #include "InstrumentView.h"

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -26,6 +26,7 @@
 #include "interpolation.h"
 #include "AudioEngine.h"
 #include "Engine.h"
+#include "lmms_basics.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -99,7 +100,7 @@ void VibratingString::resample(const float* src, f_cnt_t srcFrames, f_cnt_t dstF
 	{
 		const float srcFrameFloat = frame * static_cast<float>(srcFrames) / dstFrames;
 		const float fracPos = srcFrameFloat - static_cast<f_cnt_t>(srcFrameFloat);
-		const f_cnt_t srcFrame = std::clamp(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
+		const f_cnt_t srcFrame = std::clamp<f_cnt_t>(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
 		m_impulse[frame] = cubicInterpolate(
 			src[srcFrame - 1],
 			src[srcFrame + 0],

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -100,7 +100,7 @@ void VibratingString::resample(const float* src, f_cnt_t srcFrames, f_cnt_t dstF
 	{
 		const float srcFrameFloat = frame * static_cast<float>(srcFrames) / dstFrames;
 		const float fracPos = srcFrameFloat - static_cast<f_cnt_t>(srcFrameFloat);
-		const f_cnt_t srcFrame = std::clamp<f_cnt_t>(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
+		const f_cnt_t srcFrame = std::clamp(static_cast<f_cnt_t>(srcFrameFloat), f_cnt_t{1}, srcFrames - 3);
 		m_impulse[frame] = cubicInterpolate(
 			src[srcFrame - 1],
 			src[srcFrame + 0],

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -26,7 +26,6 @@
 #include "interpolation.h"
 #include "AudioEngine.h"
 #include "Engine.h"
-#include "lmms_basics.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -100,7 +99,7 @@ void VibratingString::resample(const float* src, f_cnt_t srcFrames, f_cnt_t dstF
 	{
 		const float srcFrameFloat = frame * static_cast<float>(srcFrames) / dstFrames;
 		const float fracPos = srcFrameFloat - static_cast<f_cnt_t>(srcFrameFloat);
-		const f_cnt_t srcFrame = std::clamp<f_cnt_t>(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
+		const f_cnt_t srcFrame = std::clamp(static_cast<f_cnt_t>(srcFrameFloat), 1, srcFrames - 3);
 		m_impulse[frame] = cubicInterpolate(
 			src[srcFrame - 1],
 			src[srcFrame + 0],

--- a/plugins/ZynAddSubFx/LocalZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/LocalZynAddSubFx.h
@@ -25,6 +25,8 @@
 #ifndef LOCAL_ZYNADDSUBFX_H
 #define LOCAL_ZYNADDSUBFX_H
 
+#include <array>
+
 #include "Note.h"
 
 class Master;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -283,7 +283,7 @@ void AudioEngine::pushInputFrames( SampleFrame* _ab, const f_cnt_t _frames )
 	requestChangeInModel();
 
 	f_cnt_t frames = m_inputBufferFrames[ m_inputBufferWrite ];
-	int size = m_inputBufferSize[ m_inputBufferWrite ];
+	auto size = m_inputBufferSize[m_inputBufferWrite];
 	SampleFrame* buf = m_inputBuffer[ m_inputBufferWrite ];
 
 	if( frames + _frames > size )

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -27,6 +27,7 @@
 #include "MixHelpers.h"
 #include "denormals.h"
 
+#include "lmms_basics.h"
 #include "lmmsconfig.h"
 
 #include "AudioEngineWorkerThread.h"
@@ -288,7 +289,7 @@ void AudioEngine::pushInputFrames( SampleFrame* _ab, const f_cnt_t _frames )
 
 	if( frames + _frames > size )
 	{
-		size = std::max(size * 2, frames + _frames);
+		size = std::max<f_cnt_t>(size * 2, frames + _frames);
 		auto ab = new SampleFrame[size];
 		memcpy( ab, buf, frames * sizeof( SampleFrame ) );
 		delete [] buf;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -27,7 +27,6 @@
 #include "MixHelpers.h"
 #include "denormals.h"
 
-#include "lmms_basics.h"
 #include "lmmsconfig.h"
 
 #include "AudioEngineWorkerThread.h"
@@ -289,7 +288,7 @@ void AudioEngine::pushInputFrames( SampleFrame* _ab, const f_cnt_t _frames )
 
 	if( frames + _frames > size )
 	{
-		size = std::max<f_cnt_t>(size * 2, frames + _frames);
+		size = std::max(size * 2, frames + _frames);
 		auto ab = new SampleFrame[size];
 		memcpy( ab, buf, frames * sizeof( SampleFrame ) );
 		delete [] buf;

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -28,7 +28,6 @@
 
 #include "DummyInstrument.h"
 #include "InstrumentTrack.h"
-#include "lmms_basics.h"
 #include "lmms_constants.h"
 
 
@@ -186,7 +185,7 @@ void Instrument::applyRelease( SampleFrame* buf, const NotePlayHandle * _n )
 	const auto releaseFrames = desiredReleaseFrames();
 
 	const auto endFrame = _n->framesLeft();
-	const auto startFrame = std::max<f_cnt_t>(0, endFrame - releaseFrames);
+	const auto startFrame = std::max(0, endFrame - releaseFrames);
 
 	for (auto f = startFrame; f < endFrame && f < fpp; f++)
 	{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -186,7 +186,7 @@ void Instrument::applyRelease( SampleFrame* buf, const NotePlayHandle * _n )
 	const auto releaseFrames = desiredReleaseFrames();
 
 	const auto endFrame = _n->framesLeft();
-	const auto startFrame = std::max(0, static_cast<int>(endFrame) - static_cast<int>(releaseFrames));
+	const auto startFrame = endFrame - std::min(endFrame, releaseFrames);
 
 	for (auto f = startFrame; f < endFrame && f < fpp; f++)
 	{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -28,6 +28,7 @@
 
 #include "DummyInstrument.h"
 #include "InstrumentTrack.h"
+#include "lmms_basics.h"
 #include "lmms_constants.h"
 
 
@@ -185,7 +186,7 @@ void Instrument::applyRelease( SampleFrame* buf, const NotePlayHandle * _n )
 	const auto releaseFrames = desiredReleaseFrames();
 
 	const auto endFrame = _n->framesLeft();
-	const auto startFrame = std::max(0, endFrame - releaseFrames);
+	const auto startFrame = std::max(0, static_cast<int>(endFrame) - static_cast<int>(releaseFrames));
 
 	for (auto f = startFrame; f < endFrame && f < fpp; f++)
 	{

--- a/src/core/Instrument.cpp
+++ b/src/core/Instrument.cpp
@@ -28,6 +28,7 @@
 
 #include "DummyInstrument.h"
 #include "InstrumentTrack.h"
+#include "lmms_basics.h"
 #include "lmms_constants.h"
 
 
@@ -185,7 +186,7 @@ void Instrument::applyRelease( SampleFrame* buf, const NotePlayHandle * _n )
 	const auto releaseFrames = desiredReleaseFrames();
 
 	const auto endFrame = _n->framesLeft();
-	const auto startFrame = std::max(0, endFrame - releaseFrames);
+	const auto startFrame = std::max<f_cnt_t>(0, endFrame - releaseFrames);
 
 	for (auto f = startFrame; f < endFrame && f < fpp; f++)
 	{

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -69,7 +69,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 						// to convert the buffers
 #endif
 	m_audioHandle.channels = channels();
-	m_audioHandle.samples = std::max<fpp_t>(1024, audioEngine()->framesPerPeriod() * 2);
+	m_audioHandle.samples = std::max(1024, audioEngine()->framesPerPeriod() * 2);
 
 	m_audioHandle.callback = sdlAudioCallback;
 	m_audioHandle.userdata = this;

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -69,7 +69,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 						// to convert the buffers
 #endif
 	m_audioHandle.channels = channels();
-	m_audioHandle.samples = std::max(1024, audioEngine()->framesPerPeriod() * 2);
+	m_audioHandle.samples = std::max<fpp_t>(1024, audioEngine()->framesPerPeriod() * 2);
 
 	m_audioHandle.callback = sdlAudioCallback;
 	m_audioHandle.userdata = this;

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "AudioSdl.h"
+#include "lmms_basics.h"
 
 #ifdef LMMS_HAVE_SDL
 
@@ -69,7 +70,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 						// to convert the buffers
 #endif
 	m_audioHandle.channels = channels();
-	m_audioHandle.samples = std::max<f_cnt_t>(1024, audioEngine()->framesPerPeriod() * 2);
+	m_audioHandle.samples = std::max(f_cnt_t{1024}, audioEngine()->framesPerPeriod() * 2);
 
 	m_audioHandle.callback = sdlAudioCallback;
 	m_audioHandle.userdata = this;

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -69,7 +69,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 						// to convert the buffers
 #endif
 	m_audioHandle.channels = channels();
-	m_audioHandle.samples = std::max(1024, audioEngine()->framesPerPeriod() * 2);
+	m_audioHandle.samples = std::max<f_cnt_t>(1024, audioEngine()->framesPerPeriod() * 2);
 
 	m_audioHandle.callback = sdlAudioCallback;
 	m_audioHandle.userdata = this;

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -24,8 +24,10 @@
  */
 
 #include "MidiClient.h"
-#include "MidiPort.h"
 
+#include <array>
+
+#include "MidiPort.h"
 
 namespace lmms
 {

--- a/src/gui/widgets/LedCheckBox.cpp
+++ b/src/gui/widgets/LedCheckBox.cpp
@@ -22,11 +22,12 @@
  *
  */
 
+#include "LedCheckBox.h"
 
 #include <QFontMetrics>
 #include <QPainter>
+#include <array>
 
-#include "LedCheckBox.h"
 #include "DeprecationHelper.h"
 #include "embed.h"
 #include "gui_templates.h"


### PR DESCRIPTION
Defines  `fpp_t` and `f_cnt_t` to be of `size_t`. Most of the codebase used `fpp_t` to represent the size of an array of sample frames, which is incorrect, given that `fpp_t` was only 16 bits when sizes greater than `32767` are very possible.

There were discussions about using `std::size_t`, but I left it as `size_t` so that it can be adopted a bit easier in the code, and not end up in a situation where we mix up `std::size_t` and `size_t`.