### PR TITLE
Remove term "blacklist"

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -230,6 +230,7 @@ public:
 
 	QString defaultVersion() const;
 
+	static bool enableBlockedPlugins();
 
 	static QStringList availableVstEmbedMethods();
 	QString vstEmbedMethod() const;

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -81,7 +81,7 @@ public:
 		return s_projectJournal;
 	}
 
-	static bool ignorePluginBlacklist();
+	static bool enableBlockedPlugins();
 
 #ifdef LMMS_HAVE_LV2
 	static class Lv2Manager * getLv2Manager()

--- a/include/Engine.h
+++ b/include/Engine.h
@@ -81,8 +81,6 @@ public:
 		return s_projectJournal;
 	}
 
-	static bool enableBlockedPlugins();
-
 #ifdef LMMS_HAVE_LV2
 	static class Lv2Manager * getLv2Manager()
 	{

--- a/include/Lv2Manager.h
+++ b/include/Lv2Manager.h
@@ -1,7 +1,7 @@
 /*
  * Lv2Manager.h - Implementation of Lv2Manager class
  *
- * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2024 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -131,14 +131,23 @@ public:
 	AutoLilvNodes findNodes(const LilvNode *subject,
 		const LilvNode *predicate, const LilvNode *object);
 
-	static const std::set<std::string_view>& getPluginBlacklist()
+	static bool pluginIsUnstable(const char* pluginUri)
 	{
-		return pluginBlacklist;
+		return unstablePlugins.find(pluginUri) != unstablePlugins.end();
 	}
-	static const std::set<std::string_view>& getPluginBlacklistBuffersizeLessThan32()
+	static bool pluginIsOnlyUsefulWithUi(const char* pluginUri)
 	{
-		return pluginBlacklistBuffersizeLessThan32;
+		return pluginsOnlyUsefulWithUi.find(pluginUri) != pluginsOnlyUsefulWithUi.end();
 	}
+	static bool pluginIsUnstableWithBuffersizeLessEqual32(const char* pluginUri)
+	{
+		return unstablePluginsBuffersizeLessEqual32.find(pluginUri) !=
+			unstablePluginsBuffersizeLessEqual32.end();
+	}
+
+	//! Whether the user generally wants a UI (and we generally support that)
+	//! Since we do not generally support UI right now, this will always return false...
+	static bool wantUi();
 
 private:
 	// general data
@@ -154,8 +163,9 @@ private:
 	Lv2UridCache m_uridCache;
 
 	// static
-	static const std::set<std::string_view>
-		pluginBlacklist, pluginBlacklistBuffersizeLessThan32;
+	static const std::set<std::string_view> unstablePlugins;
+	static const std::set<std::string_view> pluginsOnlyUsefulWithUi;
+	static const std::set<std::string_view> unstablePluginsBuffersizeLessEqual32;
 
 	// functions
 	bool isSubclassOf(const LilvPluginClass *clvss, const char *uriStr);

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -57,7 +57,7 @@ enum class PluginIssueType
 	FeatureNotSupported, //!< plugin requires functionality LMMS can't offer
 	// misc
 	BadPortType, //!< port type not supported
-	Blacklisted,
+	Blocked,
 	NoIssue
 };
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -188,6 +188,12 @@ QString ConfigManager::defaultVersion() const
 	return LMMS_VERSION;
 }
 
+bool ConfigManager::enableBlockedPlugins()
+{
+	const char* envVar = getenv("LMMS_ENABLE_BLOCKED_PLUGINS");
+	return (envVar && *envVar);
+}
+
 QStringList ConfigManager::availableVstEmbedMethods()
 {
 	QStringList methods;

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -512,7 +512,7 @@ void ConfigManager::loadConfigFile(const QString & configFile)
 		cfg_file.close();
 	}
 
-	// Plugins are searched recursively, blacklist problematic locations
+	// Plugins are searched recursively, block problematic locations
 	if( m_vstDir.isEmpty() || m_vstDir == QDir::separator() || m_vstDir == "/" ||
 			m_vstDir == ensureTrailingSlash( QDir::homePath() ) ||
 			!QDir( m_vstDir ).exists() )

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -126,9 +126,9 @@ void Engine::destroy()
 
 
 
-bool Engine::ignorePluginBlacklist()
+bool Engine::enableBlockedPlugins()
 {
-	const char* envVar = getenv("LMMS_IGNORE_BLACKLIST");
+	const char* envVar = getenv("LMMS_BLOCKED_PLUGINS");
 	return (envVar && *envVar);
 }
 

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -126,15 +126,6 @@ void Engine::destroy()
 
 
 
-bool Engine::enableBlockedPlugins()
-{
-	const char* envVar = getenv("LMMS_ENABLE_BLOCKED_PLUGINS");
-	return (envVar && *envVar);
-}
-
-
-
-
 float Engine::framesPerTick(sample_rate_t sampleRate)
 {
 	return sampleRate * 60.0f * 4 /

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -128,7 +128,7 @@ void Engine::destroy()
 
 bool Engine::enableBlockedPlugins()
 {
-	const char* envVar = getenv("LMMS_BLOCKED_PLUGINS");
+	const char* envVar = getenv("LMMS_ENABLE_BLOCKED_PLUGINS");
 	return (envVar && *envVar);
 }
 

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -1,7 +1,7 @@
 /*
- * PluginIssue.h - PluginIssue class
+ * PluginIssue.cpp - PluginIssue class implementation
  *
- * Copyright (c) 2019 Johannes Lorenz <j.git$$$lorenz-ho.me, $$$=@>
+ * Copyright (c) 2019-2024 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -68,8 +68,8 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 			return "required feature not supported";
 		case PluginIssueType::BadPortType:
 			return "unsupported port type";
-		case PluginIssueType::Blacklisted:
-			return "blacklisted plugin";
+		case PluginIssueType::Blocked:
+			return "blocked plugin";
 		case PluginIssueType::NoIssue:
 			return nullptr;
 	}

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2Manager.cpp - Implementation of Lv2Manager class
  *
- * Copyright (c) 2018-2023 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2018-2024 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -47,7 +47,7 @@ namespace lmms
 {
 
 
-const std::set<std::string_view> Lv2Manager::pluginBlacklist =
+const std::set<std::string_view> Lv2Manager::unstablePlugins =
 {
 	// github.com/calf-studio-gear/calf, #278
 	"http://calf.sourceforge.net/plugins/Analyzer",
@@ -67,7 +67,13 @@ const std::set<std::string_view> Lv2Manager::pluginBlacklist =
 	"http://drobilla.net/plugins/blop/square",
 	"http://drobilla.net/plugins/blop/triangle",
 
-	// Visualization, meters, and scopes etc., won't work until we have gui support
+	// unstable
+	"urn:juced:DrumSynth"
+};
+
+const std::set<std::string_view> Lv2Manager::pluginsOnlyUsefulWithUi =
+{
+	// Visualization, meters, and scopes etc., won't work if UI is disabled
 	"http://distrho.sf.net/plugins/ProM",
 	"http://distrho.sf.net/plugins/glBars",
 	"http://gareus.org/oss/lv2/meters#spectr30mono",
@@ -132,13 +138,10 @@ const std::set<std::string_view> Lv2Manager::pluginBlacklist =
 	"urn:juce:TalFilter2",
 	"urn:juce:Vex",
 	"http://zynaddsubfx.sourceforge.net",
-	"http://geontime.com/geonkick/single",
-
-	// unstable
-	"urn:juced:DrumSynth"
+	"http://geontime.com/geonkick/single"
 };
 
-const std::set<std::string_view> Lv2Manager::pluginBlacklistBuffersizeLessThan32 =
+const std::set<std::string_view> Lv2Manager::unstablePluginsBuffersizeLessEqual32 =
 {
 	"http://moddevices.com/plugins/mod-devel/2Voices",
 	"http://moddevices.com/plugins/mod-devel/Capo",
@@ -237,7 +240,7 @@ void Lv2Manager::initPlugins()
 	QElapsedTimer timer;
 	timer.start();
 
-	unsigned blacklisted = 0;
+	unsigned blocked = 0;
 	LILV_FOREACH(plugins, itr, plugins)
 	{
 		const LilvPlugin* curPlug = lilv_plugins_get(plugins, itr);
@@ -266,9 +269,9 @@ void Lv2Manager::initPlugins()
 		{
 			if(std::any_of(issues.begin(), issues.end(),
 				[](const PluginIssue& iss) {
-				return iss.type() == PluginIssueType::Blacklisted; }))
+				return iss.type() == PluginIssueType::Blocked; }))
 			{
-				++blacklisted;
+				++blocked;
 			}
 		}
 		++pluginCount;
@@ -295,19 +298,19 @@ void Lv2Manager::initPlugins()
 	}
 
 	// TODO: might be better in the LMMS core
-	if(Engine::ignorePluginBlacklist())
+	if(Engine::enableBlockedPlugins())
 	{
 		qWarning() <<
-			"WARNING! Plugin blacklist disabled! If you want to use the blacklist,\n"
-			"  please set environment variable \"LMMS_IGNORE_BLACKLIST\" to empty or\n"
+			"WARNING! Blocked plugins enabled! If you want to disable them,\n"
+			"  please set environment variable \"LMMS_BLOCKED_PLUGINS\" to empty or\n"
 			"  do not set it.";
 	}
-	else if(blacklisted > 0)
+	else if(blocked > 0)
 	{
 		qDebug() <<
-			"Lv2 Plugins blacklisted:" << blacklisted << "of" << pluginCount << "\n"
-			"  If you want to ignore the blacklist (dangerous!), please set\n"
-			"  environment variable \"LMMS_IGNORE_BLACKLIST\" to nonempty.";
+			"Blocked Lv2 Plugins:" << blocked << "of" << pluginCount << "\n"
+			"  If you want to enable them (dangerous!), please set\n"
+			"  environment variable \"LMMS_BLOCKED_PLUGINS\" to nonempty.";
 	}
 }
 
@@ -326,6 +329,14 @@ AutoLilvNodes Lv2Manager::findNodes(const LilvNode *subject,
 	const LilvNode *predicate, const LilvNode *object)
 {
 	return AutoLilvNodes(lilv_world_find_nodes (m_world, subject, predicate, object));
+}
+
+
+
+
+bool Lv2Manager::wantUi()
+{
+	return false;
 }
 
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -302,7 +302,7 @@ void Lv2Manager::initPlugins()
 	{
 		qWarning() <<
 			"WARNING! Blocked plugins enabled! If you want to disable them,\n"
-			"  please set environment variable \"LMMS_BLOCKED_PLUGINS\" to empty or\n"
+			"  please set environment variable \"LMMS_ENABLE_BLOCKED_PLUGINS\" to empty or\n"
 			"  do not set it.";
 	}
 	else if(blocked > 0)
@@ -310,7 +310,7 @@ void Lv2Manager::initPlugins()
 		qDebug() <<
 			"Blocked Lv2 Plugins:" << blocked << "of" << pluginCount << "\n"
 			"  If you want to enable them (dangerous!), please set\n"
-			"  environment variable \"LMMS_BLOCKED_PLUGINS\" to nonempty.";
+			"  environment variable \"LMMS_ENABLE_BLOCKED_PLUGINS\" to nonempty.";
 	}
 }
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -36,6 +36,7 @@
 #include <QElapsedTimer>
 
 #include "AudioEngine.h"
+#include "ConfigManager.h"
 #include "Engine.h"
 #include "Plugin.h"
 #include "Lv2ControlBase.h"
@@ -298,7 +299,7 @@ void Lv2Manager::initPlugins()
 	}
 
 	// TODO: might be better in the LMMS core
-	if(Engine::enableBlockedPlugins())
+	if(ConfigManager::enableBlockedPlugins())
 	{
 		qWarning() <<
 			"WARNING! Blocked plugins enabled! If you want to disable them,\n"

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -1,7 +1,7 @@
 /*
  * Lv2Proc.cpp - Lv2 processor class
  *
- * Copyright (c) 2019-2022 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
+ * Copyright (c) 2019-2024 Johannes Lorenz <jlsf2013$users.sourceforge.net, $=@>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -74,21 +74,21 @@ Plugin::Type Lv2Proc::check(const LilvPlugin *plugin,
 	const char* pluginUri = lilv_node_as_uri(lilv_plugin_get_uri(plugin));
 	//qDebug() << "Checking plugin" << pluginUri << "...";
 
-	// TODO: manage a global blacklist outside of the code
+	// TODO: manage a global list of blocked plugins outside of the code
 	//       for now, this will help
 	//       this is only a fix for the meantime
-	if (!Engine::ignorePluginBlacklist())
+	if (!Engine::enableBlockedPlugins())
 	{
-		const auto& pluginBlacklist = Lv2Manager::getPluginBlacklist();
-		const auto& pluginBlacklist32 = Lv2Manager::getPluginBlacklistBuffersizeLessThan32();
-		if(pluginBlacklist.find(pluginUri) != pluginBlacklist.end())
+		if( // plugin unstable?
+			Lv2Manager::pluginIsUnstable(pluginUri) ||
+			// plugins only useful with UI?
+			(!Lv2Manager::wantUi() &&
+			Lv2Manager::pluginIsOnlyUsefulWithUi(pluginUri)) ||
+			// plugin unstable with 32 or less fpp?
+			(Engine::audioEngine()->framesPerPeriod() <= 32 &&
+			Lv2Manager::pluginIsUnstableWithBuffersizeLessEqual32(pluginUri)) )
 		{
-			issues.emplace_back(PluginIssueType::Blacklisted);
-		}
-		else if(Engine::audioEngine()->framesPerPeriod() <= 32 &&
-			pluginBlacklist32.find(pluginUri) != pluginBlacklist32.end())
-		{
-			issues.emplace_back(PluginIssueType::Blacklisted);  // currently no special blacklist category
+			issues.emplace_back(PluginIssueType::Blocked);
 		}
 	}
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -38,6 +38,7 @@
 #include "AudioEngine.h"
 #include "AutomatableModel.h"
 #include "ComboBoxModel.h"
+#include "ConfigManager.h"
 #include "Engine.h"
 #include "Lv2Features.h"
 #include "Lv2Manager.h"
@@ -77,7 +78,7 @@ Plugin::Type Lv2Proc::check(const LilvPlugin *plugin,
 	// TODO: manage a global list of blocked plugins outside of the code
 	//       for now, this will help
 	//       this is only a fix for the meantime
-	if (!Engine::enableBlockedPlugins())
+	if (!ConfigManager::enableBlockedPlugins())
 	{
 		if( // plugin unstable?
 			Lv2Manager::pluginIsUnstable(pluginUri) ||


### PR DESCRIPTION
About the PR:

* We use "blocked" as an abstract term, when there may be different reasons
* If there is a concrete reason, we use a more concrete word like "unstable" or "not useful"
* Double negations like "don't block" or "block unstable" are avoided

Besides this, this PR

* Lets `Lv2Manager` hide the full `std::set` of plugin URIs
* Fixes occurences of "BuffersizeLessThan32" - it is less or equal
* Moves `enableBlockedPlugins` from `Engine` to `ConfigManager`