### PR TITLE
Fix buzz in Monstro's 2nd oscillator (#7334)

### DIFF
--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -514,7 +514,7 @@ void MonstroSynth::renderOutput( fpp_t _frames, SampleFrame* _buf  )
 		}
 		
 		sample_t O2R = 0.;
-		if (len_r != 0.)
+		if (pd_r != 0.)
 		{
 			len_r = BandLimitedWave::pdToLen(pd_r);
 			if (m_counter2r > 0)


### PR DESCRIPTION
Fix a buzzing sound in Monstro's 2nd oscillator. It was introduced with commit c2f2b7e0d76.

The problem was caused by checking if `len_r` is not equal to 0 instead of checking `pd_r`.

Fixes #7334.