### PR TITLE
Fix zooming and sliding of the waveform view in AudioFileProcessor

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -385,11 +385,11 @@ void AudioFileProcessorWaveView::slide(int px)
 	double step = range() * fact * (px > 0 ? 1 : -1);
 
 	// get the real start and end frame
-	const double sampleStart = static_cast<double>(m_sample->startFrame());
-	const double sampleEnd = static_cast<double>(m_sample->endFrame());
+	const auto sampleStart = static_cast<double>(m_sample->startFrame());
+	const auto sampleEnd = static_cast<double>(m_sample->endFrame());
 
-	const double stepFrom = std::clamp(sampleStart + step, 0.0, static_cast<double>(m_sample->sampleSize())) - sampleStart;
-	const double stepTo = std::clamp(sampleEnd + step, sampleStart + 1.0, static_cast<double>(m_sample->sampleSize())) - sampleEnd;
+	const auto stepFrom = std::clamp(sampleStart + step, 0.0, static_cast<double>(m_sample->sampleSize())) - sampleStart;
+	const auto stepTo = std::clamp(sampleEnd + step, sampleStart + 1.0, static_cast<double>(m_sample->sampleSize())) - sampleEnd;
 	step = std::abs(stepFrom) < std::abs(stepTo) ? stepFrom : stepTo;
 
 	slideSampleByFrames(step);
@@ -403,7 +403,7 @@ void AudioFileProcessorWaveView::slideSamplePointByPx(Point point, int px)
 	);
 }
 
-void AudioFileProcessorWaveView::slideSamplePointByFrames(Point point, long frames, bool slide_to)
+void AudioFileProcessorWaveView::slideSamplePointByFrames(Point point, long frameOffset, bool slideTo)
 {
 	knob * a_knob = m_startKnob;
 	switch(point)
@@ -423,8 +423,8 @@ void AudioFileProcessorWaveView::slideSamplePointByFrames(Point point, long fram
 	}
 	else
 	{
-		const double v = static_cast<double>(frames) / m_sample->sampleSize();
-		if (slide_to)
+		const double v = static_cast<double>(frameOffset) / m_sample->sampleSize();
+		if (slideTo)
 		{
 			a_knob->slideTo(v);
 		}
@@ -438,13 +438,13 @@ void AudioFileProcessorWaveView::slideSamplePointByFrames(Point point, long fram
 
 
 
-void AudioFileProcessorWaveView::slideSampleByFrames(long frames)
+void AudioFileProcessorWaveView::slideSampleByFrames(long frameOffset)
 {
 	if (m_sample->sampleSize() <= 1)
 	{
 		return;
 	}
-	const double v = static_cast<double>(frames) / m_sample->sampleSize();
+	const double v = static_cast<double>(frameOffset) / m_sample->sampleSize();
 	// update knobs in the right order
 	// to avoid them clamping each other
 	if (v < 0)
@@ -507,7 +507,6 @@ void AudioFileProcessorWaveView::knob::slideTo(double v, bool check_bound)
 	{
 		return;
 	}
-
 	model()->setValue(v);
 	emit sliderMoved(model()->value());
 }

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -382,9 +382,8 @@ void AudioFileProcessorWaveView::zoom(const bool out)
 void AudioFileProcessorWaveView::slide(int px)
 {
 	const double fact = qAbs(double(px) / width());
-	double step = range() * fact * (px > 0 ? 1 : -1);
+	auto step = range() * fact * (px > 0 ? 1 : -1);
 
-	// get the real start and end frame
 	const auto sampleStart = static_cast<double>(m_sample->startFrame());
 	const auto sampleEnd = static_cast<double>(m_sample->endFrame());
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -127,9 +127,7 @@ private:
 
 	Sample const* m_sample;
 	QPixmap m_graph;
-	// display from
 	int m_from;
-	// display to
 	int m_to;
 	int m_last_from;
 	int m_last_to;
@@ -162,9 +160,8 @@ private:
 	void zoom(const bool out = false);
 	void slide(int px);
 	void slideSamplePointByPx(Point point, int px);
-	// point: wihch knob to slide, frames: how mutch, can be negative, slide_to: should set the value instead of adding it
-	void slideSamplePointByFrames(Point point, long frames, bool slide_to = false);
-	void slideSampleByFrames(long frames);
+	void slideSamplePointByFrames(Point point, long frameOffset, bool slideTo = false);
+	void slideSampleByFrames(long frameOffset);
 
 	void slideSamplePointToFrames(Point point, f_cnt_t frames)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -118,6 +118,8 @@ private:
 	enum class DraggingType
 	{
 		Wave,
+		SlideWave,
+		ZoomWave,
 		SampleStart,
 		SampleEnd,
 		SampleLoop
@@ -125,7 +127,9 @@ private:
 
 	Sample const* m_sample;
 	QPixmap m_graph;
+	// display from
 	int m_from;
+	// display to
 	int m_to;
 	int m_last_from;
 	int m_last_to;
@@ -158,8 +162,9 @@ private:
 	void zoom(const bool out = false);
 	void slide(int px);
 	void slideSamplePointByPx(Point point, int px);
-	void slideSamplePointByFrames(Point point, f_cnt_t frames, bool slide_to = false);
-	void slideSampleByFrames(f_cnt_t frames);
+	// point: wihch knob to slide, frames: how mutch, can be negative, slide_to: should set the value instead of adding it
+	void slideSamplePointByFrames(Point point, long frames, bool slide_to = false);
+	void slideSampleByFrames(long frames);
 
 	void slideSamplePointToFrames(Point point, f_cnt_t frames)
 	{


### PR DESCRIPTION
closes #7375

fixes partially #7074

I have fixed some issues with the graph:

- sliding the start, loop, end indicator
- sliding the waveshape
- zooming in
- possibly segfaults

The sliding and the zooming was separated in mouseMoveEvent, if the user starts sliding or zooming, they will no longer be able to zoom or slide until next mouse press.