### PR TITLE
Remove BufferManager::clear()

### DIFF
--- a/include/BufferManager.h
+++ b/include/BufferManager.h
@@ -39,10 +39,6 @@ class LMMS_EXPORT BufferManager
 public:
 	static void init( fpp_t fpp );
 	static SampleFrame* acquire();
-	// audio-buffer-mgm
-	static void clear( SampleFrame* ab, const f_cnt_t frames,
-						const f_cnt_t offset = 0 );
-
 	static void release( SampleFrame* buf );
 
 private:

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -95,7 +95,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 		m_inputBufferFrames[i] = 0;
 		m_inputBufferSize[i] = DEFAULT_BUFFER_SIZE * 100;
 		m_inputBuffer[i] = new SampleFrame[ DEFAULT_BUFFER_SIZE * 100 ];
-		BufferManager::clear( m_inputBuffer[i], m_inputBufferSize[i] );
+		zeroSampleFrames(m_inputBuffer[i], m_inputBufferSize[i]);
 	}
 
 	// determine FIFO size and number of frames per period

--- a/src/core/BufferManager.cpp
+++ b/src/core/BufferManager.cpp
@@ -47,10 +47,6 @@ SampleFrame* BufferManager::acquire()
 	return new SampleFrame[s_framesPerPeriod];
 }
 
-void BufferManager::clear( SampleFrame* ab, const f_cnt_t frames, const f_cnt_t offset )
-{
-	zeroSampleFrames(ab + offset, frames);
-}
 
 
 void BufferManager::release( SampleFrame* buf )

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -74,7 +74,7 @@ MixerChannel::MixerChannel( int idx, Model * _parent ) :
 	m_queued( false ),
 	m_dependenciesMet(0)
 {
-	BufferManager::clear( m_buffer, Engine::audioEngine()->framesPerPeriod() );
+	zeroSampleFrames(m_buffer, Engine::audioEngine()->framesPerPeriod());
 }
 
 
@@ -612,8 +612,7 @@ void Mixer::mixToChannel( const SampleFrame* _buf, mix_ch_t _ch )
 
 void Mixer::prepareMasterMix()
 {
-	BufferManager::clear( m_mixerChannels[0]->m_buffer,
-					Engine::audioEngine()->framesPerPeriod() );
+	zeroSampleFrames(m_mixerChannels[0]->m_buffer, Engine::audioEngine()->framesPerPeriod());
 }
 
 
@@ -685,8 +684,7 @@ void Mixer::masterMix( SampleFrame* _buf )
 	// reset channel process state
 	for( int i = 0; i < numChannels(); ++i)
 	{
-		BufferManager::clear( m_mixerChannels[i]->m_buffer,
-				Engine::audioEngine()->framesPerPeriod() );
+		zeroSampleFrames(m_mixerChannels[i]->m_buffer, Engine::audioEngine()->framesPerPeriod());
 		m_mixerChannels[i]->reset();
 		m_mixerChannels[i]->m_queued = false;
 		// also reset hasInput

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -81,7 +81,7 @@ void Oscillator::update(SampleFrame* ab, const fpp_t frames, const ch_cnt_t chnl
 {
 	if (m_freq >= Engine::audioEngine()->outputSampleRate() / 2)
 	{
-		BufferManager::clear(ab, frames);
+		zeroSampleFrames(ab, frames);
 		return;
 	}
 	// If this oscillator is used to PM or PF modulate another oscillator, take a note.

--- a/src/core/PlayHandle.cpp
+++ b/src/core/PlayHandle.cpp
@@ -55,7 +55,7 @@ void PlayHandle::doProcessing()
 	if( m_usesBuffer )
 	{
 		m_bufferReleased = false;
-		BufferManager::clear(m_playHandleBuffer, Engine::audioEngine()->framesPerPeriod());
+		zeroSampleFrames(m_playHandleBuffer, Engine::audioEngine()->framesPerPeriod());
 		play( buffer() );
 	}
 	else

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -333,7 +333,7 @@ bool RemotePlugin::process( const SampleFrame* _in_buf, SampleFrame* _out_buf )
 	{
 		if( _out_buf != nullptr )
 		{
-			BufferManager::clear( _out_buf, frames );
+			zeroSampleFrames(_out_buf, frames);
 		}
 		return false;
 	}
@@ -352,7 +352,7 @@ bool RemotePlugin::process( const SampleFrame* _in_buf, SampleFrame* _out_buf )
 		}
 		if( _out_buf != nullptr )
 		{
-			BufferManager::clear( _out_buf, frames );
+			zeroSampleFrames(_out_buf, frames);
 		}
 		return false;
 	}
@@ -426,7 +426,7 @@ bool RemotePlugin::process( const SampleFrame* _in_buf, SampleFrame* _out_buf )
 	{
 		auto o = (SampleFrame*)(m_audioBuffer.get() + m_inputCount * frames);
 		// clear buffer, if plugin didn't fill up both channels
-		BufferManager::clear( _out_buf, frames );
+		zeroSampleFrames(_out_buf, frames);
 
 		for (ch_cnt_t ch = 0; ch <
 				std::min<int>(DEFAULT_CHANNELS, outputs); ++ch)

--- a/src/core/audio/AudioPort.cpp
+++ b/src/core/audio/AudioPort.cpp
@@ -113,7 +113,7 @@ void AudioPort::doProcessing()
 	const fpp_t fpp = Engine::audioEngine()->framesPerPeriod();
 
 	// clear the buffer
-	BufferManager::clear( m_portBuffer, fpp );
+	zeroSampleFrames(m_portBuffer, fpp);
 
 	//qDebug( "Playhandles: %d", m_playHandles.size() );
 	for( PlayHandle * ph : m_playHandles ) // now we mix all playhandle buffers into the audioport buffer

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -57,7 +57,7 @@ Oscilloscope::Oscilloscope( QWidget * _p ) :
 	const fpp_t frames = Engine::audioEngine()->framesPerPeriod();
 	m_buffer = new SampleFrame[frames];
 
-	BufferManager::clear( m_buffer, frames );
+	zeroSampleFrames(m_buffer, frames);
 
 
 	setToolTip(tr("Oscilloscope"));


### PR DESCRIPTION
Previously, `BufferManager::clear()` used to use a memset operation. Since #7156, it is acting as a wrapper around the `zeroSampleFrames` function, so I de nested the code and removed the wrapper function.