### PR TITLE
Re-enable disabled GCC warnings where possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,21 +646,19 @@ option(USE_WERROR "Treat compiler warnings as errors" OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 	set(COMPILE_ERROR_FLAGS
 		"-Wall" # Enable most warnings by default
-		"-Werror=unused-function" # Unused functions are an error
-		# TODO: Fix the code and remove the following:
-		"-Wno-sign-compare" # Permit comparisons between signed and unsigned integers
-		"-Wno-strict-overflow" # Permit optimisations assuming no signed overflow
 	)
 	set(THIRD_PARTY_COMPILE_ERROR_FLAGS
 		"-w" # Disable all warnings
 	)
 
-	# Due to a regression in gcc-4.8.X, we need to disable array-bounds check
-	# TODO: Is this still necessary?
 	if(CMAKE_COMPILER_IS_GNUCXX)
 		list(APPEND COMPILE_ERROR_FLAGS
+			# The following warnings generate false positives that are difficult
+			# to work around, in particular when inlining calls to standard
+			# algorithms performed on single-element arrays. See, for example,
+			# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111273.
 			"-Wno-array-bounds" # Permit out-of-bounds array subscripts
-			"-Wno-attributes" # Permit unrecognised attributes
+			"-Wno-stringop-overread" # Permit string functions overreading the source
 		)
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,13 +653,19 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
 	if(CMAKE_COMPILER_IS_GNUCXX)
 		list(APPEND COMPILE_ERROR_FLAGS
-			# The following warnings generate false positives that are difficult
+			# The following warning generates false positives that are difficult
 			# to work around, in particular when inlining calls to standard
 			# algorithms performed on single-element arrays. See, for example,
 			# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=111273.
 			"-Wno-array-bounds" # Permit out-of-bounds array subscripts
-			"-Wno-stringop-overread" # Permit string functions overreading the source
 		)
+
+		if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11")
+			list(APPEND COMPILE_ERROR_FLAGS
+				# This has the same problems described above for "array-bounds".
+				"-Wno-stringop-overread" # Permit string functions overreading the source
+			)
+		endif()
 	endif()
 
 	if(USE_WERROR)

--- a/include/AudioEngineWorkerThread.h
+++ b/include/AudioEngineWorkerThread.h
@@ -71,8 +71,8 @@ public:
 
 	private:
 		std::atomic<ThreadableJob*> m_items[JOB_QUEUE_SIZE];
-		std::atomic_int m_writeIndex;
-		std::atomic_int m_itemsDone;
+		std::atomic_size_t m_writeIndex;
+		std::atomic_size_t m_itemsDone;
 		OperationMode m_opMode;
 	} ;
 

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -84,11 +84,7 @@ public:
 		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "PortAudio" );
 	}
 
-
-	int process_callback( const float *_inputBuffer,
-		float * _outputBuffer,
-		unsigned long _framesPerBuffer );
-
+	int process_callback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer);
 
 	class setupWidget : public gui::AudioDeviceSetupWidget
 	{

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -151,8 +151,8 @@ private:
 	bool m_wasPAInitError;
 
 	SampleFrame* m_outBuf;
-	int m_outBufPos;
-	int m_outBufSize;
+	std::size_t m_outBufPos;
+	fpp_t m_outBufSize;
 
 	bool m_stopped;
 

--- a/include/LocklessAllocator.h
+++ b/include/LocklessAllocator.h
@@ -50,8 +50,8 @@ private:
 	std::atomic_int * m_freeState;
 	size_t m_freeStateSets;
 
-	std::atomic_int m_available;
-	std::atomic_int m_startIndex;
+	std::atomic_size_t m_available;
+	std::atomic_size_t m_startIndex;
 
 } ;
 

--- a/include/MidiEvent.h
+++ b/include/MidiEvent.h
@@ -190,6 +190,8 @@ public:
 		setParam( 0, pitchBend );
 	}
 
+	auto sysExData() const -> const char* { return m_sysExData; }
+
 	Source source() const
 	{
 		return m_source;
@@ -212,7 +214,7 @@ private:
 		int32_t m_sysExDataLen;	// len of m_sysExData
 	} m_data;
 
-	[[maybe_unused]] const char* m_sysExData;
+	const char* m_sysExData;
 	const void* m_sourcePort;
 
 	// Stores the source of the MidiEvent: Internal or External (hardware controllers).

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -79,7 +79,7 @@ class MixerChannel : public ThreadableJob
 		auto color() const -> const std::optional<QColor>& { return m_color; }
 		void setColor(const std::optional<QColor>& color) { m_color = color; }
 
-		std::atomic_int m_dependenciesMet;
+		std::atomic_size_t m_dependenciesMet;
 		void incrementDeps();
 		void processed();
 		

--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -170,12 +170,8 @@ public:
 	{
 		if (buffer == nullptr || buffer->size() == 0) { return 0; }
 		const auto frames = buffer->size();
-		const auto frame = sample * frames;
-		auto f1 = static_cast<f_cnt_t>(frame) % frames;
-		if (f1 < 0)
-		{
-			f1 += frames;
-		}
+		const auto frame = absFraction(sample) * frames;
+		const auto f1 = static_cast<f_cnt_t>(frame);
 
 		return linearInterpolate(buffer->data()[f1][0], buffer->data()[(f1 + 1) % frames][0], fraction(frame));
 	}
@@ -190,12 +186,8 @@ public:
 	inline wtSampleControl getWtSampleControl(const float sample) const
 	{
 		wtSampleControl control;
-		control.frame = sample * OscillatorConstants::WAVETABLE_LENGTH;
-		control.f1 = static_cast<f_cnt_t>(control.frame) % OscillatorConstants::WAVETABLE_LENGTH;
-		if (control.f1 < 0)
-		{
-			control.f1 += OscillatorConstants::WAVETABLE_LENGTH;
-		}
+		control.frame = absFraction(sample) * OscillatorConstants::WAVETABLE_LENGTH;
+		control.f1 = static_cast<f_cnt_t>(control.frame);
 		control.f2 = control.f1 < OscillatorConstants::WAVETABLE_LENGTH - 1 ?
 					control.f1 + 1 :
 					0;

--- a/include/RemotePlugin.h
+++ b/include/RemotePlugin.h
@@ -189,12 +189,10 @@ private slots:
 	void processErrored(QProcess::ProcessError err );
 } ;
 
-
-LMMS_EXPORT inline std::string QSTR_TO_STDSTR(QString const& qstr)
+inline std::string QSTR_TO_STDSTR(QString const& qstr)
 {
 	return qstr.toStdString();
 }
-
 
 } // namespace lmms
 

--- a/include/RmsHelper.h
+++ b/include/RmsHelper.h
@@ -36,7 +36,7 @@ namespace lmms
 class RmsHelper
 {
 public:
-	RmsHelper( int size ) :
+	RmsHelper(std::size_t size) :
 		m_buffer( nullptr )
 	{
 		setSize( size );
@@ -46,7 +46,7 @@ public:
 		if( m_buffer ) delete[] m_buffer;
 	}
 
-	inline void setSize( int size )
+	void setSize(std::size_t size)
 	{
 		if( m_buffer )
 		{
@@ -90,8 +90,8 @@ public:
 private:
 	float * m_buffer;
 	float m_sum;
-	unsigned int m_pos;
-	unsigned int m_size;
+	std::size_t m_pos;
+	std::size_t m_size;
 	float m_sizef;
 };
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -127,7 +127,7 @@ public:
 	void deleteClips();
 
 	int numOfClips();
-	Clip * getClip( int clipNum );
+	auto getClip(std::size_t clipNum) -> Clip*;
 	int getClipNum(const Clip* clip );
 
 	const clipVector & getClips() const

--- a/include/fft_helpers.h
+++ b/include/fft_helpers.h
@@ -37,7 +37,7 @@ namespace lmms
 // NOTE: FFT_BUFFER_SIZE should be considered deprecated!
 // It is used by Eq plugin and some older code here, but this should be a user
 // switchable parameter, not a constant. Use a value from FFT_BLOCK_SIZES
-const unsigned int FFT_BUFFER_SIZE = 2048;
+constexpr auto FFT_BUFFER_SIZE = std::size_t{2048};
 
 // Allowed FFT block sizes. Ranging from barely useful to barely acceptable
 // because of performance and latency reasons.

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -61,10 +61,9 @@ static inline float fraction( const float _x )
  * If the result is interpreted as a phase of an oscillator, it makes that negative phases are
  * converted to positive phases.
  */
-static inline float absFraction( const float _x )
+static inline float absFraction(const float x)
 {
-	return( _x - ( _x >= 0.0f ? static_cast<int>( _x ) :
-						static_cast<int>( _x ) - 1 ) );
+	return x - std::floor(x);
 }
 
 /*!

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -123,7 +123,7 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 
 	if( !_n->m_pluginData )
 	{
-		if (m_stutterModel.value() == true && m_nextPlayStartPoint >= m_sample.endFrame())
+		if (m_stutterModel.value() == true && m_nextPlayStartPoint >= static_cast<std::size_t>(m_sample.endFrame()))
 		{
 			// Restart playing the note if in stutter mode, not in loop mode,
 			// and we're at the end of the sample.
@@ -288,7 +288,7 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
 		* Engine::audioEngine()->outputSampleRate()
 		/ Engine::audioEngine()->baseSampleRate();
 
-	const auto startFrame = m_nextPlayStartPoint >= m_sample.endFrame()
+	const auto startFrame = m_nextPlayStartPoint >= static_cast<std::size_t>(m_sample.endFrame())
 		? m_sample.startFrame()
 		: m_nextPlayStartPoint;
 	const auto duration = m_sample.endFrame() - startFrame;

--- a/plugins/Bitcrush/Bitcrush.cpp
+++ b/plugins/Bitcrush/Bitcrush.cpp
@@ -153,7 +153,7 @@ bool BitcrushEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames )
 	// read input buffer and write it to oversampled buffer
 	if( m_rateEnabled ) // rate crushing enabled so do that
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			for( int o = 0; o < OS_RATE; ++o )
 			{
@@ -180,7 +180,7 @@ bool BitcrushEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames )
 	}
 	else // rate crushing disabled: simply oversample with zero-order hold
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			for( int o = 0; o < OS_RATE; ++o )
 			{
@@ -196,7 +196,7 @@ bool BitcrushEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames )
 
 	// the oversampled buffer is now written, so filter it to reduce aliasing
 
-	for( int f = 0; f < frames * OS_RATE; ++f )
+	for (auto f = std::size_t{0}; f < frames * OS_RATE; ++f)
 	{
 		if( qMax( qAbs( m_buffer[f][0] ), qAbs( m_buffer[f][1] ) ) >= 1.0e-10f )
 		{
@@ -225,7 +225,7 @@ bool BitcrushEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames )
 	double outSum = 0.0;
 	const float d = dryLevel();
 	const float w = wetLevel();
-	for( int f = 0; f < frames; ++f )
+	for (auto f = std::size_t{0}; f < frames; ++f)
 	{
 		float lsum = 0.0f;
 		float rsum = 0.0f;

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -205,9 +205,9 @@ CarlaInstrument::CarlaInstrument(InstrumentTrack* const instrumentTrack, const D
     m_paramsCompleter->setCompletionMode(QCompleter::PopupCompletion);
 
     // Add static amount of CarlaParamFloatModel's.
-    int paramCount = fDescriptor->get_parameter_count(fHandle);
+    const auto paramCount = fDescriptor->get_parameter_count(fHandle);
     m_paramModels.reserve(paramCount);
-    for (int i=0; i < paramCount; ++i)
+    for (auto i = std::size_t{0}; i < paramCount; ++i)
     {
         m_paramModels.push_back(new CarlaParamFloatModel(this));
         connect(m_paramModels[i], &CarlaParamFloatModel::dataChanged,
@@ -274,7 +274,7 @@ const NativeTimeInfo* CarlaInstrument::handleGetTimeInfo() const
 
 void CarlaInstrument::handleUiParameterChanged(const uint32_t index, const float value) const
 {
-	if (m_paramModels.count() > index)
+	if (m_paramModels.size() > index)
 	{
 		m_paramModels[index]->setValue(value);
 	}
@@ -369,7 +369,7 @@ void CarlaInstrument::saveSettings(QDomDocument& doc, QDomElement& parent)
     std::free(state);
 
 #if CARLA_VERSION_HEX >= CARLA_MIN_PARAM_VERSION
-    for (uint32_t index = 0; index < m_paramModels.count(); ++index)
+    for (uint32_t index = 0; index < m_paramModels.size(); ++index)
     {
         QString idStr = CARLA_SETTING_PREFIX + QString::number(index);
         m_paramModels[index]->saveSettings(doc, parent, idStr);
@@ -439,7 +439,7 @@ void CarlaInstrument::refreshParams(bool init)
 void CarlaInstrument::clearParamModels()
 {
 	//Delete the models, this also disconnects all connections (automation and controller connections)
-	for (uint32_t index=0; index < m_paramModels.count(); ++index)
+	for (uint32_t index = 0; index < m_paramModels.size(); ++index)
 	{
 		delete m_paramModels[index];
 	}
@@ -899,7 +899,7 @@ CarlaParamsView::~CarlaParamsView()
 	m_carlaInstrumentView->m_paramsView = nullptr;
 
 	// Clear models
-	if (m_carlaInstrument->m_paramModels.isEmpty() == false)
+	if (!m_carlaInstrument->m_paramModels.empty())
 	{
 		m_carlaInstrument->clearParamModels();
 	}
@@ -930,7 +930,7 @@ void CarlaParamsView::filterKnobs()
 	m_maxColumns = m_inputScrollArea->width() / maxKnobWidth;
 
 	QString text = m_paramsFilterLineEdit->text();
-	for (uint32_t i=0; i < m_knobs.count(); ++i)
+	for (uint32_t i = 0; i < m_knobs.size(); ++i)
 	{
 		// Don't show disabled (unused) knobs.
 		if (!m_carlaInstrument->m_paramModels[i]->enabled())
@@ -975,7 +975,7 @@ void CarlaParamsView::filterKnobs()
 void CarlaParamsView::refreshKnobs()
 {
 	// Make sure all the knobs are deleted.
-	for (uint32_t i=0; i < m_knobs.count(); ++i)
+	for (uint32_t i = 0; i < m_knobs.size(); ++i)
 	{
 		delete m_knobs[i]; // Delete knob widgets itself.
 	}
@@ -996,15 +996,15 @@ void CarlaParamsView::refreshKnobs()
 		m_maxKnobWidthPerGroup[i] = 0;
 	}
 
-	if (!m_carlaInstrument->m_paramModels.count()) { return; }
+	if (m_carlaInstrument->m_paramModels.empty()) { return; }
 
 	// Make room in QList m_knobs
-	m_knobs.reserve(m_carlaInstrument->m_paramModels.count());
+	m_knobs.reserve(m_carlaInstrument->m_paramModels.size());
 
 	QStringList groupNameList;
 	groupNameList.reserve(m_carlaInstrument->m_paramGroupCount);
 
-	for (uint32_t i=0; i < m_carlaInstrument->m_paramModels.count(); ++i)
+	for (uint32_t i = 0; i < m_carlaInstrument->m_paramModels.size(); ++i)
 	{
 		bool enabled = m_carlaInstrument->m_paramModels[i]->enabled();
 		m_knobs.push_back(new Knob(KnobType::Dark28, m_inputScrollAreaWidgetContent));
@@ -1105,7 +1105,7 @@ void CarlaParamsView::addKnob(uint32_t index)
 void CarlaParamsView::clearKnobs()
 {
 	// Remove knobs from layout.
-	for (uint16_t i=0; i < m_knobs.count(); ++i)
+	for (uint16_t i = 0; i < m_knobs.size(); ++i)
 	{
 		m_knobs[i]->close();
 	}

--- a/plugins/CarlaBase/Carla.h
+++ b/plugins/CarlaBase/Carla.h
@@ -29,6 +29,8 @@
 #define CARLA_MIN_PARAM_VERSION 0x020090
 #define CARLA_VERSION_HEX_3 0x30000
 
+#include <vector>
+
 // qt
 #include <QCloseEvent>
 #include <QDomElement>
@@ -223,7 +225,7 @@ private:
     QMutex fMutex;
 
     uint8_t m_paramGroupCount;
-    QList<CarlaParamFloatModel*> m_paramModels;
+    std::vector<CarlaParamFloatModel*> m_paramModels;
     QDomElement m_settingsElem;
 
     QCompleter* m_paramsCompleter;
@@ -351,7 +353,7 @@ private:
 
 	CarlaInstrument* const m_carlaInstrument;
 	CarlaInstrumentView* const m_carlaInstrumentView;
-	QList<Knob*> m_knobs;
+	std::vector<Knob*> m_knobs;
 
 	// Keep track of the biggest knob width per group
 	QList<uint16_t> m_maxKnobWidthPerGroup;

--- a/plugins/CrossoverEQ/CrossoverEQ.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQ.cpp
@@ -142,7 +142,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	zeroSampleFrames(m_work, frames);
 	
 	// run temp bands
-	for( int f = 0; f < frames; ++f )
+	for (auto f = std::size_t{0}; f < frames; ++f)
 	{
 		m_tmp1[f][0] = m_lp2.update( buf[f][0], 0 );
 		m_tmp1[f][1] = m_lp2.update( buf[f][1], 1 );
@@ -153,7 +153,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	// run band 1
 	if( mute1 )
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			m_work[f][0] += m_lp1.update( m_tmp1[f][0], 0 ) * m_gain1;
 			m_work[f][1] += m_lp1.update( m_tmp1[f][1], 1 ) * m_gain1;
@@ -163,7 +163,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	// run band 2
 	if( mute2 )
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			m_work[f][0] += m_hp2.update( m_tmp1[f][0], 0 ) * m_gain2;
 			m_work[f][1] += m_hp2.update( m_tmp1[f][1], 1 ) * m_gain2;
@@ -173,7 +173,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	// run band 3
 	if( mute3 )
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			m_work[f][0] += m_lp3.update( m_tmp2[f][0], 0 ) * m_gain3;
 			m_work[f][1] += m_lp3.update( m_tmp2[f][1], 1 ) * m_gain3;
@@ -183,7 +183,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	// run band 4
 	if( mute4 )
 	{
-		for( int f = 0; f < frames; ++f )
+		for (auto f = std::size_t{0}; f < frames; ++f)
 		{
 			m_work[f][0] += m_hp4.update( m_tmp2[f][0], 0 ) * m_gain4;
 			m_work[f][1] += m_hp4.update( m_tmp2[f][1], 1 ) * m_gain4;
@@ -193,7 +193,7 @@ bool CrossoverEQEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frames
 	const float d = dryLevel();
 	const float w = wetLevel();
 	double outSum = 0.0;
-	for( int f = 0; f < frames; ++f )
+	for (auto f = std::size_t{0}; f < frames; ++f)
 	{
 		buf[f][0] = d * buf[f][0] + w * m_work[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_work[f][1];

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -54,7 +54,7 @@ EqAnalyser::EqAnalyser() :
 	const float a2 = 0.14128f;
 	const float a3 = 0.01168f;
 
-	for (int i = 0; i < FFT_BUFFER_SIZE; i++)
+	for (auto i = std::size_t{0}; i < FFT_BUFFER_SIZE; i++)
 	{
 		m_fftWindow[i] = (a0 - a1 * cos(2 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))
 								+ a2 * cos(4 * F_PI * i / ((float)FFT_BUFFER_SIZE - 1.0))

--- a/plugins/FreeBoy/FreeBoy.cpp
+++ b/plugins/FreeBoy/FreeBoy.cpp
@@ -380,9 +380,8 @@ void FreeBoyInstrument::playNote(NotePlayHandle* nph, SampleFrame* workingBuffer
 		papu->writeRegister(0xff23, 128);
 	}
 
-	constexpr int bufSize = 2048;
-	int framesLeft = frames;
-	int dataLen = 0;
+	constexpr auto bufSize = f_cnt_t{2048};
+	auto framesLeft = frames;
 	auto buf = std::array<blip_sample_t, bufSize * 2>{};
 	while (framesLeft > 0)
 	{
@@ -392,12 +391,11 @@ void FreeBoyInstrument::playNote(NotePlayHandle* nph, SampleFrame* workingBuffer
 			papu->endFrame(FRAME_LENGTH);
 			avail = papu->samplesAvail();
 		}
-		dataLen = framesLeft > avail ? avail : framesLeft;
-		dataLen = dataLen > bufSize ? bufSize : dataLen;
+		const auto dataLen = std::min({static_cast<f_cnt_t>(avail), framesLeft, bufSize});
 
-		long count = papu->readSamples(buf.data(), dataLen * 2) / 2;
+		const auto count = static_cast<f_cnt_t>(papu->readSamples(buf.data(), dataLen * 2) / 2);
 
-		for (fpp_t frame = 0; frame < count; ++frame)
+		for (auto frame = std::size_t{0}; frame < count; ++frame)
 		{
 			for (ch_cnt_t ch = 0; ch < DEFAULT_CHANNELS; ++ch)
 			{

--- a/plugins/GigPlayer/CMakeLists.txt
+++ b/plugins/GigPlayer/CMakeLists.txt
@@ -6,11 +6,6 @@ if(LMMS_HAVE_GIG)
 	# Required for not crashing loading files with libgig
 	add_compile_options("-fexceptions")
 
-	# disable deprecated check for mingw-x-libgig
-	if(LMMS_BUILD_WIN32)
-		add_compile_options("-Wno-deprecated")
-	endif(LMMS_BUILD_WIN32)
-
 	link_directories(${GIG_LIBRARY_DIRS})
 	link_libraries(${GIG_LIBRARIES})
 	build_plugin(gigplayer

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -323,7 +323,7 @@ void GigInstrument::playNote( NotePlayHandle * _n, SampleFrame* )
 void GigInstrument::play( SampleFrame* _working_buffer )
 {
 	const fpp_t frames = Engine::audioEngine()->framesPerPeriod();
-	const int rate = Engine::audioEngine()->outputSampleRate();
+	const auto rate = Engine::audioEngine()->outputSampleRate();
 
 	// Initialize to zeros
 	std::memset( &_working_buffer[0][0], 0, DEFAULT_CHANNELS * frames * sizeof( float ) );
@@ -1216,7 +1216,7 @@ bool GigSample::convertSampleRate( SampleFrame & oldBuf, SampleFrame & newBuf,
 		return false;
 	}
 
-	if( src_data.output_frames_gen > 0 && src_data.output_frames_gen < newSize )
+	if (src_data.output_frames_gen > 0 && static_cast<f_cnt_t>(src_data.output_frames_gen) < newSize)
 	{
 		qCritical() << "GigInstrument: not enough frames, wanted"
 			<< newSize << "generated" << src_data.output_frames_gen;

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.cpp
@@ -258,7 +258,7 @@ void GranularPitchShifterEffect::changeSampleRate()
 	
 	m_ringBufLength = m_sampleRate * ringBufLength;
 	m_ringBuf.resize(m_ringBufLength);
-	for (size_t i = 0; i < m_ringBufLength; ++i)
+	for (size_t i = 0; i < static_cast<std::size_t>(m_ringBufLength); ++i)
 	{
 		m_ringBuf[i][0] = 0;
 		m_ringBuf[i][1] = 0;

--- a/plugins/GranularPitchShifter/GranularPitchShifterEffect.h
+++ b/plugins/GranularPitchShifter/GranularPitchShifterEffect.h
@@ -58,7 +58,7 @@ public:
 	// double index and fraction are required for good quality
 	float getHermiteSample(double index, int ch)
 	{
-		const int index_floor = static_cast<int>(index);
+		const auto index_floor = static_cast<std::size_t>(index);
 		const double fraction = index - index_floor;
 		
 		float v0, v1, v2, v3;

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -139,7 +139,7 @@ bool LadspaEffect::processAudioBuffer( SampleFrame* _buf,
 		return( false );
 	}
 
-	int frames = _frames;
+	auto frames = _frames;
 	SampleFrame* o_buf = nullptr;
 	QVarLengthArray<SampleFrame> sBuf(_frames);
 

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -685,7 +685,7 @@ void MonstroSynth::renderOutput( fpp_t _frames, SampleFrame* _buf  )
 }
 
 
-inline void MonstroSynth::updateModulators( float * env1, float * env2, float * lfo1, float * lfo2, int frames )
+inline void MonstroSynth::updateModulators(float * env1, float * env2, float * lfo1, float * lfo2, f_cnt_t frames)
 {
 	// frames played before
 	const f_cnt_t tfp = m_nph->totalFramesPlayed();
@@ -790,7 +790,7 @@ inline void MonstroSynth::updateModulators( float * env1, float * env2, float * 
 		// attack
 		for( f_cnt_t f = 0; f < frames; ++f )
 		{
-			if( tfp + f < m_lfoatt[i] ) lfo[i][f] *= ( static_cast<sample_t>( tfp ) / m_lfoatt[i] );
+			if (tfp + f < static_cast<f_cnt_t>(m_lfoatt[i])) { lfo[i][f] *= static_cast<sample_t>(tfp) / m_lfoatt[i]; }
 		}
 
 

--- a/plugins/Monstro/Monstro.h
+++ b/plugins/Monstro/Monstro.h
@@ -184,7 +184,7 @@ private:
 	MonstroInstrument * m_parent;
 	NotePlayHandle * m_nph;
 
-	inline void updateModulators( float * env1, float * env2, float * lfo1, float * lfo2, int frames );
+	inline void updateModulators(float * env1, float * env2, float * lfo1, float * lfo2, f_cnt_t frames);
 
 	// linear interpolation
 /*	inline sample_t interpolate( sample_t s1, sample_t s2, float x )

--- a/plugins/MultitapEcho/MultitapEcho.cpp
+++ b/plugins/MultitapEcho/MultitapEcho.cpp
@@ -86,7 +86,7 @@ void MultitapEchoEffect::updateFilters( int begin, int end )
 
 void MultitapEchoEffect::runFilter( SampleFrame* dst, SampleFrame* src, StereoOnePole & filter, const fpp_t frames )
 {
-	for( int f = 0; f < frames; ++f )
+	for (auto f = std::size_t{0}; f < frames; ++f)
 	{
 		dst[f][0] = filter.update( src[f][0], 0 );
 		dst[f][1] = filter.update( src[f][1], 1 );
@@ -152,7 +152,7 @@ bool MultitapEchoEffect::processAudioBuffer( SampleFrame* buf, const fpp_t frame
 	// pop the buffer and mix it into output
 	m_buffer.pop( m_work );
 
-	for( int f = 0; f < frames; ++f )
+	for (auto f = std::size_t{0}; f < frames; ++f)
 	{
 		buf[f][0] = d * buf[f][0] + w * m_work[f][0];
 		buf[f][1] = d * buf[f][1] + w * m_work[f][1];

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -302,7 +302,7 @@ void OrganicInstrument::playNote( NotePlayHandle * _n,
 	// fxKnob is [0;1]
 	float t =  m_fx1Model.value();
 
-	for (int i=0 ; i < frames + offset ; i++)
+	for (auto i = std::size_t{0}; i < frames + offset; i++)
 	{
 		_working_buffer[i][0] = waveshape( _working_buffer[i][0], t ) *
 						m_volModel.value() / 100.0f;

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -110,7 +110,7 @@ bool PeakControllerEffect::processAudioBuffer( SampleFrame* _buf,
 
 	if( c.m_absModel.value() )
 	{
-		for( int i = 0; i < _frames; ++i )
+		for (auto i = std::size_t{0}; i < _frames; ++i)
 		{
 			// absolute value is achieved because the squares are > 0
 			sum += _buf[i][0]*_buf[i][0] + _buf[i][1]*_buf[i][1];
@@ -118,7 +118,7 @@ bool PeakControllerEffect::processAudioBuffer( SampleFrame* _buf,
 	}
 	else
 	{
-		for( int i = 0; i < _frames; ++i )
+		for (auto i = std::size_t{0}; i < _frames; ++i)
 		{
 			// the value is absolute because of squaring,
 			// so we need to correct it
@@ -131,7 +131,7 @@ bool PeakControllerEffect::processAudioBuffer( SampleFrame* _buf,
 	// this will mute the output after the values were measured
 	if( c.m_muteModel.value() )
 	{
-		for( int i = 0; i < _frames; ++i )
+		for (auto i = std::size_t{0}; i < _frames; ++i)
 		{
 			_buf[i][0] = _buf[i][1] = 0.0f;
 		}

--- a/plugins/ReverbSC/base.c
+++ b/plugins/ReverbSC/base.c
@@ -189,7 +189,7 @@ int sp_set(sp_param *p, SPFLOAT val) {
 
 int sp_out(sp_data *sp, uint32_t chan, SPFLOAT val)
 {
-    if(chan > sp->nchan - 1) {
+    if (chan >= (uint32_t) sp->nchan) {
         fprintf(stderr, "sp_out: Invalid channel\n");
         return SP_NOT_OK;
     }

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -96,7 +96,7 @@ void SlicerT::playNote(NotePlayHandle* handle, SampleFrame* workingBuffer)
 		sliceStart = 0;
 		sliceEnd = 1;
 	}
-	else if (noteIndex > 0 && noteIndex < m_slicePoints.size())
+	else if (noteIndex > 0 && static_cast<std::size_t>(noteIndex) < m_slicePoints.size())
 	{
 		noteIndex -= 1;
 		sliceStart = m_slicePoints[noteIndex];
@@ -134,9 +134,9 @@ void SlicerT::playNote(NotePlayHandle* handle, SampleFrame* workingBuffer)
 		// exponential fade out, applyRelease() not used since it extends the note length
 		int fadeOutFrames = m_fadeOutFrames.value() / 1000.0f * Engine::audioEngine()->outputSampleRate();
 		int noteFramesLeft = noteLeft * m_originalSample.sampleSize() * speedRatio;
-		for (int i = 0; i < frames; i++)
+		for (auto i = std::size_t{0}; i < frames; i++)
 		{
-			float fadeValue = static_cast<float>(noteFramesLeft - i) / fadeOutFrames;
+			float fadeValue = static_cast<float>(noteFramesLeft - static_cast<int>(i)) / fadeOutFrames;
 			fadeValue = std::clamp(fadeValue, 0.0f, 1.0f);
 			fadeValue = cosinusInterpolate(0, 1, fadeValue);
 
@@ -170,7 +170,7 @@ void SlicerT::findSlices()
 
 	float maxMag = -1;
 	std::vector<float> singleChannel(m_originalSample.sampleSize(), 0);
-	for (int i = 0; i < m_originalSample.sampleSize(); i++)
+	for (auto i = std::size_t{0}; i < m_originalSample.sampleSize(); i++)
 	{
 		singleChannel[i] = (m_originalSample.data()[i][0] + m_originalSample.data()[i][1]) / 2;
 		maxMag = std::max(maxMag, singleChannel[i]);
@@ -179,7 +179,7 @@ void SlicerT::findSlices()
 	// normalize and find 0 crossings
 	std::vector<int> zeroCrossings;
 	float lastValue = 1;
-	for (int i = 0; i < singleChannel.size(); i++)
+	for (auto i = std::size_t{0}; i < singleChannel.size(); i++)
 	{
 		singleChannel[i] /= maxMag;
 		if (sign(lastValue) != sign(singleChannel[i]))
@@ -199,7 +199,7 @@ void SlicerT::findSlices()
 	float spectralFlux = 0;
 	float prevFlux = 1E-10f; // small value, no divison by zero
 
-	for (int i = 0; i < singleChannel.size() - windowSize; i += windowSize)
+	for (int i = 0; i < static_cast<int>(singleChannel.size()) - windowSize; i += windowSize)
 	{
 		// fft
 		std::copy_n(singleChannel.data() + i, windowSize, fftIn.data());
@@ -300,7 +300,7 @@ std::vector<Note> SlicerT::getMidi()
 	float totalTicks = outFrames / framesPerTick;
 	float lastEnd = 0;
 
-	for (int i = 0; i < m_slicePoints.size() - 1; i++)
+	for (auto i = std::size_t{0}; i < m_slicePoints.size() - 1; i++)
 	{
 		float sliceStart = lastEnd;
 		float sliceEnd = totalTicks * m_slicePoints[i + 1];
@@ -342,7 +342,7 @@ void SlicerT::saveSettings(QDomDocument& document, QDomElement& element)
 	}
 
 	element.setAttribute("totalSlices", static_cast<int>(m_slicePoints.size()));
-	for (int i = 0; i < m_slicePoints.size(); i++)
+	for (auto i = std::size_t{0}; i < m_slicePoints.size(); i++)
 	{
 		element.setAttribute(tr("slice_%1").arg(i), m_slicePoints[i]);
 	}

--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -195,11 +195,11 @@ void SlicerTWaveform::drawEditor()
 
 	brush.setPen(QPen(s_sliceColor, 2));
 
-	for (int i = 0; i < m_slicerTParent->m_slicePoints.size(); i++)
+	for (auto i = std::size_t{0}; i < m_slicerTParent->m_slicePoints.size(); i++)
 	{
 		float xPos = (m_slicerTParent->m_slicePoints.at(i) - startFrame) / numFramesToDraw * m_editorWidth;
 
-		if (i == m_closestSlice)
+		if (i == static_cast<std::size_t>(m_closestSlice))
 		{
 			brush.setPen(QPen(s_sliceHighlightColor, 2));
 			brush.drawLine(xPos, 0, xPos, m_editorHeight);
@@ -268,7 +268,7 @@ void SlicerTWaveform::updateClosest(QMouseEvent* me)
 		m_closestSlice = -1;
 		float startFrame = m_seekerStart;
 		float endFrame = m_seekerEnd;
-		for (int i = 0; i < m_slicerTParent->m_slicePoints.size(); i++)
+		for (auto i = std::size_t{0}; i < m_slicerTParent->m_slicePoints.size(); i++)
 		{
 			float sliceIndex = m_slicerTParent->m_slicePoints.at(i);
 			float xPos = (sliceIndex - startFrame) / (endFrame - startFrame);

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -232,7 +232,7 @@ void SaProcessor::analyze(LocklessRingBuffer<SampleFrame> &ring_buffer)
 							if (band_end - band_start > 1.0)
 							{
 								// band spans multiple pixels: draw all pixels it covers
-								for (int target = std::max(static_cast<int>(band_start), 0);
+								for (auto target = static_cast<std::size_t>(std::max(band_start, 0.f));
 									 target < band_end && target < waterfallWidth(); target++)
 								{
 									pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);
@@ -259,7 +259,9 @@ void SaProcessor::analyze(LocklessRingBuffer<SampleFrame> &ring_buffer)
 									accL += ((int)band_end - band_start) * m_normSpectrumL[i];
 									accR += ((int)band_end - band_start) * m_normSpectrumR[i];
 
-									if (target >= 0 && target < waterfallWidth()) {pixel[target] = makePixel(accL, accR);}
+									if (target >= 0 && static_cast<std::size_t>(target) < waterfallWidth()) {
+										pixel[target] = makePixel(accL, accR);
+									}
 
 									// save remaining portion of the band for the following band / pixel
 									accL = (band_end - (int)band_end) * m_normSpectrumL[i];
@@ -270,7 +272,7 @@ void SaProcessor::analyze(LocklessRingBuffer<SampleFrame> &ring_buffer)
 						else
 						{
 							// Linear: always draws one or more pixels per band
-							for (int target = std::max(static_cast<int>(band_start), 0);
+							for (auto target = static_cast<std::size_t>(std::max(band_start, 0.f));
 								 target < band_end && target < waterfallWidth(); target++)
 							{
 								pixel[target] = makePixel(m_normSpectrumL[i], m_normSpectrumR[i]);

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -302,7 +302,7 @@ void SaSpectrumView::refreshPaths()
 // part new, part old. At reasonable frame rate, such difference is invisible..
 void SaSpectrumView::updateBuffers(const float *spectrum, float *displayBuffer, float *peakBuffer)
 {
-	for (int n = 0; n < m_processor->binCount(); n++)
+	for (auto n = std::size_t{0}; n < m_processor->binCount(); n++)
 	{
 		// Update the exponential average if enabled, or simply copy the value.
 		if (!m_controls->m_pauseModel.value())

--- a/plugins/StereoEnhancer/StereoEnhancer.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancer.cpp
@@ -145,7 +145,7 @@ bool StereoEnhancerEffect::processAudioBuffer( SampleFrame* _buf,
 
 void StereoEnhancerEffect::clearMyBuffer()
 {
-	for (int i = 0; i < DEFAULT_BUFFER_SIZE; i++)
+	for (auto i = std::size_t{0}; i < DEFAULT_BUFFER_SIZE; i++)
 	{
 		m_delayBuffer[i][0] = 0.0f;
 		m_delayBuffer[i][1] = 0.0f;

--- a/plugins/Vibed/Vibed.cpp
+++ b/plugins/Vibed/Vibed.cpp
@@ -72,11 +72,11 @@ public:
 
 	~StringContainer() = default;
 
-	void addString(int harm, float pick, float pickup, const float* impulse, float randomize,
+	void addString(std::size_t harm, float pick, float pickup, const float* impulse, float randomize,
 		float stringLoss, float detune, int oversample, bool state, int id)
 	{
 		constexpr auto octave = std::array{0.25f, 0.5f, 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f};
-		assert(harm >= 0 && harm < octave.size());
+		assert(harm < octave.size());
 
 		m_strings[id] = VibratingString{m_pitch * octave[harm], pick, pickup, impulse, m_bufferLength,
 			m_sampleRate, oversample, randomize, stringLoss, detune, state};

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -265,7 +265,7 @@ public:
 	void saveChunkToFile( const std::string & _file );
 
 	// restore settings chunk of plugin from file
-	void loadChunkFromFile( const std::string & _file, int _len );
+	void loadChunkFromFile(const std::string& _file, std::size_t _len);
 
 	// restore settings chunk of plugin from file
 	void loadPresetFile( const std::string & _file );
@@ -1303,7 +1303,7 @@ void RemoteVstPlugin::saveChunkToFile( const std::string & _file )
 					"Error opening file for saving chunk.\n" );
 				return;
 			}
-			if ( fwrite( chunk, 1, len, fp ) != len )
+			if (fwrite(chunk, 1, len, fp) != static_cast<std::size_t>(len))
 			{
 				fprintf( stderr,
 					"Error saving chunk to file.\n" );
@@ -1541,7 +1541,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 	unsigned int toUInt;
 	float * pFloat;
 
-	if (m_plugin->uniqueID != pBank->fxID) {
+	if (static_cast<std::uint_fast32_t>(m_plugin->uniqueID) != pBank->fxID) {
 		sendMessage( message( IdVstCurrentProgramName ).
 					addString( "Error: Plugin UniqID not match" ) );
 		fclose( stream );
@@ -1577,7 +1577,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 		else
 		{
 			auto toUIntArray = reinterpret_cast<unsigned int*>(chunk);
-			for (int i = 0; i < pBank->numPrograms; i++ )
+			for (auto i = 0u; i < pBank->numPrograms; i++)
 			{
 				toUInt = endian_swap( toUIntArray[ i ] );
 				pFloat = ( float* ) &toUInt;
@@ -1625,10 +1625,7 @@ void RemoteVstPlugin::loadPresetFile( const std::string & _file )
 	delete[] (char*)chunk;
 }
 
-
-
-
-void RemoteVstPlugin::loadChunkFromFile( const std::string & _file, int _len )
+void RemoteVstPlugin::loadChunkFromFile(const std::string& _file, std::size_t _len)
 {
 	auto chunk = new char[_len];
 

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -147,13 +147,8 @@ struct LastSampleFunction : public exprtk::ifunction<T>
 
 	inline T operator()(const T& x) override
 	{
-		if (!std::isnan(x) && !std::isinf(x))
-		{
-			const int ix=(int)x;
-			if (ix>=1 && ix<=m_history_size)
-			{
-				return m_samples[(ix + m_pivot_last) % m_history_size];
-			}
+		if (!std::isnan(x) && x >= 1 && x <= m_history_size) {
+			return m_samples[(static_cast<std::size_t>(x) + m_pivot_last) % m_history_size];
 		}
 		return 0;
 	}

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -579,9 +579,9 @@ void XpressiveView::expressionChanged() {
 
 		if (parse_ok) {
 			e->exprValid().setValue(0);
-			const int length = m_raw_graph->length();
+			const auto length = static_cast<std::size_t>(m_raw_graph->length());
 			auto const samples = new float[length];
-			for (i = 0; i < length; i++) {
+			for (auto i = std::size_t{0}; i < length; i++) {
 				t = i / (float) length;
 				samples[i] = expr.evaluate();
 				if (std::isinf(samples[i]) != 0 || std::isnan(samples[i]) != 0)

--- a/plugins/ZynAddSubFx/CMakeLists.txt
+++ b/plugins/ZynAddSubFx/CMakeLists.txt
@@ -25,12 +25,8 @@ endif()
 
 # build ZynAddSubFX with full optimizations
 if(NOT MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wno-write-strings -Wno-deprecated-declarations -fpermissive")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -fpermissive")
 endif()
-
-IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "6.0.0")
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-misleading-indentation -Wno-format-truncation")
-ENDIF()
 
 IF(MINGW_PREFIX)
 	SET(FLTK_FLUID_EXECUTABLE "${MINGW_PREFIX}/bin/fluid")

--- a/src/core/AudioEngineWorkerThread.cpp
+++ b/src/core/AudioEngineWorkerThread.cpp
@@ -79,7 +79,7 @@ void AudioEngineWorkerThread::JobQueue::run()
 	while (processedJob && m_itemsDone < m_writeIndex)
 	{
 		processedJob = false;
-		for( int i = 0; i < m_writeIndex && i < JOB_QUEUE_SIZE; ++i )
+		for (auto i = std::size_t{0}; i < m_writeIndex && i < JOB_QUEUE_SIZE; ++i)
 		{
 			ThreadableJob * job = m_items[i].exchange(nullptr);
 			if( job )

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -159,11 +159,10 @@ inline void ControllerConnection::setTargetName( const QString & _name )
  */
 void ControllerConnection::finalizeConnections()
 {
-	for( int i = 0; i < s_connections.size(); ++i )
+	for (auto i = std::size_t{0}; i < s_connections.size(); ++i)
 	{
 		ControllerConnection * c = s_connections[i];
-		if ( !c->isFinalized() && c->m_controllerId <
-				Engine::getSong()->controllers().size() )
+		if (!c->isFinalized() && static_cast<std::size_t>(c->m_controllerId) < Engine::getSong()->controllers().size())
 		{
 			c->setController( Engine::getSong()->
 					controllers().at( c->m_controllerId ) );
@@ -221,7 +220,7 @@ void ControllerConnection::loadSettings( const QDomElement & _this )
 
 		if (!Engine::getSong()->isLoadingProject()
 			&& m_controllerId != -1
-			&& m_controllerId < Engine::getSong()->controllers().size())
+			&& static_cast<std::size_t>(m_controllerId) < Engine::getSong()->controllers().size())
 		{
 			setController( Engine::getSong()->
 					controllers().at( m_controllerId ) );

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1184,7 +1184,7 @@ static void upgradeElement_1_2_0_rc2_42( QDomElement & el )
 		int syncmode = el.attribute( "syncmode" ).toInt();
 		QStringList names;
 		QDomNamedNodeMap atts = el.attributes();
-		for( uint i = 0; i < atts.length(); i++ )
+		for (auto i = 0; i < atts.length(); i++)
 		{
 			QString name = atts.item( i ).nodeName();
 			if( name.endsWith( "_numerator" ) )

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -299,11 +299,6 @@ void EnvelopeAndLfoParameters::fillLevel( float * _buf, f_cnt_t _frame,
 {
 	QMutexLocker m(&m_paramMutex);
 
-	if( _frame < 0 || _release_begin < 0 )
-	{
-		return;
-	}
-
 	fillLfoLevel( _buf, _frame, _frames );
 
 	for( fpp_t offset = 0; offset < _frames; ++offset, ++_buf, ++_frame )

--- a/src/core/InstrumentSoundShaping.cpp
+++ b/src/core/InstrumentSoundShaping.cpp
@@ -66,7 +66,7 @@ InstrumentSoundShaping::InstrumentSoundShaping(
 	m_filterCutModel( 14000.0, 1.0, 14000.0, 1.0, this, tr( "Cutoff frequency" ) ),
 	m_filterResModel(0.5f, BasicFilters<>::minQ(), 10.f, 0.01f, this, tr("Q/Resonance"))
 {
-	for( int i = 0; i < NumTargets; ++i )
+	for (auto i = std::size_t{0}; i < NumTargets; ++i)
 	{
 		float value_for_zero_amount = 0.0;
 		if( static_cast<Target>(i) == Target::Volume )
@@ -279,7 +279,7 @@ f_cnt_t InstrumentSoundShaping::envFrames( const bool _only_vol ) const
 
 	if( _only_vol == false )
 	{
-		for( int i = static_cast<std::size_t>(Target::Volume)+1; i < NumTargets; ++i )
+		for (auto i = static_cast<std::size_t>(Target::Volume) + 1; i < NumTargets; ++i)
 		{
 			if( m_envLfoParameters[i]->isUsed() &&
 				m_envLfoParameters[i]->PAHD_Frames() > ret_val )
@@ -313,7 +313,7 @@ f_cnt_t InstrumentSoundShaping::releaseFrames() const
 		return m_envLfoParameters[static_cast<std::size_t>(Target::Volume)]->releaseFrames();
 	}
 
-	for( int i = static_cast<std::size_t>(Target::Volume)+1; i < NumTargets; ++i )
+	for (auto i = static_cast<std::size_t>(Target::Volume) + 1; i < NumTargets; ++i)
 	{
 		if( m_envLfoParameters[i]->isUsed() )
 		{
@@ -333,7 +333,7 @@ void InstrumentSoundShaping::saveSettings( QDomDocument & _doc, QDomElement & _t
 	m_filterResModel.saveSettings( _doc, _this, "fres" );
 	m_filterEnabledModel.saveSettings( _doc, _this, "fwet" );
 
-	for( int i = 0; i < NumTargets; ++i )
+	for (auto i = std::size_t{0}; i < NumTargets; ++i)
 	{
 		m_envLfoParameters[i]->saveState( _doc, _this ).setTagName(
 			m_envLfoParameters[i]->nodeName() +
@@ -356,7 +356,7 @@ void InstrumentSoundShaping::loadSettings( const QDomElement & _this )
 	{
 		if( node.isElement() )
 		{
-			for( int i = 0; i < NumTargets; ++i )
+			for (auto i = std::size_t{0}; i < NumTargets; ++i)
 			{
 				if( node.nodeName() ==
 					m_envLfoParameters[i]->nodeName() +

--- a/src/core/LocklessAllocator.cpp
+++ b/src/core/LocklessAllocator.cpp
@@ -71,8 +71,7 @@ LocklessAllocator::LocklessAllocator( size_t nmemb, size_t size )
 
 LocklessAllocator::~LocklessAllocator()
 {
-	int available = m_available;
-	if( available != m_capacity )
+	if (m_available != m_capacity)
 	{
 		fprintf( stderr, "LocklessAllocator: "
 				"Destroying with elements still allocated\n" );
@@ -110,7 +109,7 @@ void * LocklessAllocator::alloc()
 	// Some of these CAS loops could probably use relaxed atomics, as discussed
 	// in http://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange.
 	// Let's use sequentially-consistent ops to be safe for now.
-	int available = m_available.load();
+	auto available = m_available.load();
 	do
 	{
 		if( !available )

--- a/src/core/Microtuner.cpp
+++ b/src/core/Microtuner.cpp
@@ -126,14 +126,14 @@ int Microtuner::octaveSize() const
  */
 void Microtuner::updateScaleList(int index)
 {
-	if (index >= 0 && index < MaxScaleCount)
+	if (index >= 0 && static_cast<std::size_t>(index) < MaxScaleCount)
 	{
 		m_scaleModel.replaceItem(index,
 			QString::number(index) + ": " + Engine::getSong()->getScale(index)->getDescription());
 	}
 	else
 	{
-		for (int i = 0; i < MaxScaleCount; i++)
+		for (auto i = std::size_t{0}; i < MaxScaleCount; i++)
 		{
 			m_scaleModel.replaceItem(i,
 				QString::number(i) + ": " + Engine::getSong()->getScale(i)->getDescription());
@@ -147,14 +147,14 @@ void Microtuner::updateScaleList(int index)
  */
 void Microtuner::updateKeymapList(int index)
 {
-	if (index >= 0 && index < MaxKeymapCount)
+	if (index >= 0 && static_cast<std::size_t>(index) < MaxKeymapCount)
 	{
 		m_keymapModel.replaceItem(index,
 			QString::number(index) + ": " + Engine::getSong()->getKeymap(index)->getDescription());
 	}
 	else
 	{
-		for (int i = 0; i < MaxKeymapCount; i++)
+		for (auto i = std::size_t{0}; i < MaxKeymapCount; i++)
 		{
 			m_keymapModel.replaceItem(i,
 				QString::number(i) + ": " + Engine::getSong()->getKeymap(i)->getDescription());

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -99,7 +99,7 @@ inline void MixerChannel::processed()
 
 void MixerChannel::incrementDeps()
 {
-	int i = m_dependenciesMet++ + 1;
+	const auto i = m_dependenciesMet++ + 1;
 	if( i >= m_receives.size() && ! m_queued )
 	{
 		m_queued = true;
@@ -235,7 +235,7 @@ int Mixer::createChannel()
 
 void Mixer::activateSolo()
 {
-	for (int i = 1; i < m_mixerChannels.size(); ++i)
+	for (auto i = std::size_t{1}; i < m_mixerChannels.size(); ++i)
 	{
 		m_mixerChannels[i]->m_muteBeforeSolo = m_mixerChannels[i]->m_muteModel.value();
 		m_mixerChannels[i]->m_muteModel.setValue( true );
@@ -244,7 +244,7 @@ void Mixer::activateSolo()
 
 void Mixer::deactivateSolo()
 {
-	for (int i = 1; i < m_mixerChannels.size(); ++i)
+	for (auto i = std::size_t{1}; i < m_mixerChannels.size(); ++i)
 	{
 		m_mixerChannels[i]->m_muteModel.setValue( m_mixerChannels[i]->m_muteBeforeSolo );
 	}
@@ -260,7 +260,7 @@ void Mixer::toggledSolo()
 		m_mixerChannels[m_lastSoloed]->m_soloModel.setValue( false );
 	}
 	//determine the soloed channel
-	for (int i = 0; i < m_mixerChannels.size(); ++i)
+	for (auto i = std::size_t{0}; i < m_mixerChannels.size(); ++i)
 	{
 		if (m_mixerChannels[i]->m_soloModel.value() == true)
 			soloedChan = i;
@@ -355,7 +355,7 @@ void Mixer::deleteChannel( int index )
 	m_mixerChannels.erase(m_mixerChannels.begin() + index);
 	delete ch;
 
-	for( int i = index; i < m_mixerChannels.size(); ++i )
+	for (auto i = static_cast<std::size_t>(index); i < m_mixerChannels.size(); ++i)
 	{
 		validateChannelName( i, i + 1 );
 
@@ -381,7 +381,7 @@ void Mixer::deleteChannel( int index )
 void Mixer::moveChannelLeft( int index )
 {
 	// can't move master or first channel
-	if( index <= 1 || index >= m_mixerChannels.size() )
+	if (index <= 1 || static_cast<std::size_t>(index) >= m_mixerChannels.size())
 	{
 		return;
 	}
@@ -746,7 +746,7 @@ void Mixer::clearChannel(mix_ch_t index)
 void Mixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	// save channels
-	for( int i = 0; i < m_mixerChannels.size(); ++i )
+	for (auto i = std::size_t{0}; i < m_mixerChannels.size(); ++i)
 	{
 		MixerChannel * ch = m_mixerChannels[i];
 
@@ -757,7 +757,7 @@ void Mixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		ch->m_volumeModel.saveSettings( _doc, mixch, "volume" );
 		ch->m_muteModel.saveSettings( _doc, mixch, "muted" );
 		ch->m_soloModel.saveSettings( _doc, mixch, "soloed" );
-		mixch.setAttribute( "num", i );
+		mixch.setAttribute("num", static_cast<qulonglong>(i));
 		mixch.setAttribute( "name", ch->m_name );
 		if (const auto& color = ch->color()) { mixch.setAttribute("color", color->name()); }
 
@@ -776,7 +776,8 @@ void Mixer::saveSettings( QDomDocument & _doc, QDomElement & _this )
 // make sure we have at least num channels
 void Mixer::allocateChannelsTo(int num)
 {
-	while( num > m_mixerChannels.size() - 1 )
+	if (num <= 0) { return; }
+	while (static_cast<std::size_t>(num) > m_mixerChannels.size() - 1)
 	{
 		createChannel();
 
@@ -815,7 +816,7 @@ void Mixer::loadSettings( const QDomElement & _this )
 
 		// mixer sends
 		QDomNodeList chData = mixch.childNodes();
-		for( unsigned int i=0; i<chData.length(); ++i )
+		for (auto i = 0; i < chData.length(); ++i)
 		{
 			QDomElement chDataItem = chData.at(i).toElement();
 			if( chDataItem.nodeName() == QString( "send" ) )

--- a/src/core/RingBuffer.cpp
+++ b/src/core/RingBuffer.cpp
@@ -144,7 +144,6 @@ void RingBuffer::pop( SampleFrame* dst )
 void RingBuffer::read( SampleFrame* dst, f_cnt_t offset )
 {
 	f_cnt_t pos = ( m_position + offset ) % m_size;
-	if( pos < 0 ) { pos += m_size; }
 	
 	if( pos + m_fpp <= m_size ) // we won't go over the edge so we can just memcpy here
 	{
@@ -171,7 +170,6 @@ void RingBuffer::read( SampleFrame* dst, float offset )
 void RingBuffer::read( SampleFrame* dst, f_cnt_t offset, f_cnt_t length )
 {
 	f_cnt_t pos = ( m_position + offset ) % m_size;
-	if( pos < 0 ) { pos += m_size; }
 	
 	if( pos + length <= m_size ) // we won't go over the edge so we can just memcpy here
 	{

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -140,12 +140,12 @@ bool Sample::play(SampleFrame* dst, PlaybackState* state, size_t numFrames, floa
 		= state->resampler().resample(&playBuffer[0][0], playBuffer.size(), &dst[0][0], numFrames, resampleRatio);
 	advance(state, resampleResult.inputFramesUsed, loopMode);
 
-	const auto outputFrames = resampleResult.outputFramesGenerated;
+	const auto outputFrames = static_cast<f_cnt_t>(resampleResult.outputFramesGenerated);
 	if (outputFrames < numFrames) { std::fill_n(dst + outputFrames, numFrames - outputFrames, SampleFrame{}); }
 
 	if (!typeInfo<float>::isEqual(m_amplification, 1.0f))
 	{
-		for (int i = 0; i < numFrames; ++i)
+		for (auto i = std::size_t{0}; i < numFrames; ++i)
 		{
 			dst[i][0] *= m_amplification;
 			dst[i][1] *= m_amplification;

--- a/src/core/SampleDecoder.cpp
+++ b/src/core/SampleDecoder.cpp
@@ -174,7 +174,7 @@ auto decodeSampleOggVorbis(const QString& audioFile) -> std::optional<SampleDeco
 	}
 
 	auto result = std::vector<SampleFrame>(totalSamplesRead / numChannels);
-	for (int i = 0; i < result.size(); ++i)
+	for (auto i = std::size_t{0}; i < result.size(); ++i)
 	{
 		if (numChannels == 1) { result[i] = {buffer[i], buffer[i]}; }
 		else if (numChannels > 1) { result[i] = {buffer[i * numChannels], buffer[i * numChannels + 1]}; }

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -847,7 +847,7 @@ void Song::clearProject()
 		stop();
 	}
 
-	for( int i = 0; i < PlayModeCount; i++ )
+	for (auto i = std::size_t{0}; i < PlayModeCount; i++)
 	{
 		setPlayPos( 0, ( PlayMode )i );
 	}
@@ -1349,7 +1349,7 @@ void Song::restoreScaleStates(const QDomElement &element)
 {
 	QDomNode node = element.firstChild();
 
-	for (int i = 0; i < MaxScaleCount && !node.isNull() && !isCancelled(); i++)
+	for (auto i = std::size_t{0}; i < MaxScaleCount && !node.isNull() && !isCancelled(); i++)
 	{
 		m_scales[i]->restoreState(node.toElement());
 		node = node.nextSibling();
@@ -1374,7 +1374,7 @@ void Song::restoreKeymapStates(const QDomElement &element)
 {
 	QDomNode node = element.firstChild();
 
-	for (int i = 0; i < MaxKeymapCount && !node.isNull() && !isCancelled(); i++)
+	for (auto i = std::size_t{0}; i < MaxKeymapCount && !node.isNull() && !isCancelled(); i++)
 	{
 		m_keymaps[i]->restoreState(node.toElement());
 		node = node.nextSibling();

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -388,14 +388,14 @@ int Track::numOfClips()
  *  \todo if we create a Clip here, should we somehow attach it to the
  *     track?
  */
-Clip * Track::getClip( int clipNum )
+auto Track::getClip(std::size_t clipNum) -> Clip*
 {
 	if( clipNum < m_clips.size() )
 	{
 		return m_clips[clipNum];
 	}
-	printf( "called Track::getClip( %d ), "
-			"but Clip %d doesn't exist\n", clipNum, clipNum );
+	printf( "called Track::getClip( %zu ), "
+			"but Clip %zu doesn't exist\n", clipNum, clipNum );
 	return createClip( clipNum * TimePos::ticksPerBar() );
 
 }

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -99,10 +99,9 @@ AudioOss::AudioOss( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	fcntl( m_audioFD, F_SETFD, fcntl( m_audioFD, F_GETFD ) | FD_CLOEXEC );
 
 	int frag_spec;
-	for( frag_spec = 0; static_cast<int>( 0x01 << frag_spec ) <
-		audioEngine()->framesPerPeriod() * channels() *
-							BYTES_PER_INT_SAMPLE;
-		++frag_spec )
+	for (frag_spec = 0;
+		1u << frag_spec < audioEngine()->framesPerPeriod() * channels() * BYTES_PER_INT_SAMPLE;
+		++frag_spec)
 	{
 	}
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -229,10 +229,7 @@ void AudioPortAudio::stopProcessing()
 }
 
 
-int AudioPortAudio::process_callback(
-	const float *_inputBuffer,
-	float * _outputBuffer,
-	unsigned long _framesPerBuffer )
+int AudioPortAudio::process_callback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer)
 {
 	if( supportsCapture() )
 	{

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -261,8 +261,7 @@ int AudioPortAudio::process_callback(
 			}
 			m_outBufSize = frames;
 		}
-		const int min_len = std::min(static_cast<int>(_framesPerBuffer),
-			m_outBufSize - m_outBufPos);
+		const auto min_len = std::min(_framesPerBuffer, m_outBufSize - m_outBufPos);
 
 		for( fpp_t frame = 0; frame < min_len; ++frame )
 		{

--- a/src/gui/MainApplication.cpp
+++ b/src/gui/MainApplication.cpp
@@ -92,7 +92,7 @@ bool MainApplication::winEventFilter(MSG* msg, long* result)
 	switch(msg->message)
 	{
 		case WM_STYLECHANGING:
-			if(msg->wParam == GWL_EXSTYLE)
+			if (msg->wParam == static_cast<WPARAM>(GWL_EXSTYLE))
 			{
 				// Prevent plugins making the main window transparent
 				STYLESTRUCT * style = reinterpret_cast<STYLESTRUCT *>(msg->lParam);

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -224,14 +224,14 @@ MicrotunerConfig::MicrotunerConfig() :
  */
 void MicrotunerConfig::updateScaleList(int index)
 {
-	if (index >= 0 && index < MaxScaleCount)
+	if (index >= 0 && static_cast<std::size_t>(index) < MaxScaleCount)
 	{
 		m_scaleComboModel.replaceItem(index,
 			QString::number(index) + ": " + Engine::getSong()->getScale(index)->getDescription());
 	}
 	else
 	{
-		for (int i = 0; i < MaxScaleCount; i++)
+		for (auto i = std::size_t{0}; i < MaxScaleCount; i++)
 		{
 			m_scaleComboModel.replaceItem(i,
 				QString::number(i) + ": " + Engine::getSong()->getScale(i)->getDescription());
@@ -246,14 +246,14 @@ void MicrotunerConfig::updateScaleList(int index)
  */
 void MicrotunerConfig::updateKeymapList(int index)
 {
-	if (index >= 0 && index < MaxKeymapCount)
+	if (index >= 0 && static_cast<std::size_t>(index) < MaxKeymapCount)
 	{
 		m_keymapComboModel.replaceItem(index,
 			QString::number(index) + ": " + Engine::getSong()->getKeymap(index)->getDescription());
 	}
 	else
 	{
-		for (int i = 0; i < MaxKeymapCount; i++)
+		for (auto i = std::size_t{0}; i < MaxKeymapCount; i++)
 		{
 			m_keymapComboModel.replaceItem(i,
 				QString::number(i) + ": " + Engine::getSong()->getKeymap(i)->getDescription());

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -51,12 +51,12 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	const size_t maxFrames = numPixels * static_cast<size_t>(framesPerPixel);
 
-	int pixelIndex = 0;
+	auto pixelIndex = std::size_t{0};
 
-	for (int i = 0; i < maxFrames; i += static_cast<int>(resolution))
+	for (auto i = std::size_t{0}; i < maxFrames; i += static_cast<std::size_t>(resolution))
 	{
 		pixelIndex = i / framesPerPixel;
-		const int frameIndex = !parameters.reversed ? i : maxFrames - i;
+		const auto frameIndex = !parameters.reversed ? i : maxFrames - i;
 
 		const auto& frame = parameters.buffer[frameIndex];
 		const auto value = frame.average();
@@ -75,11 +75,11 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 		pixelIndex++;
 	}
 
-	for (int i = 0; i < numPixels; i++)
+	for (auto i = std::size_t{0}; i < numPixels; i++)
 	{
 		const int lineY1 = centerY - max[i] * halfHeight * parameters.amplification;
 		const int lineY2 = centerY - min[i] * halfHeight * parameters.amplification;
-		const int lineX = i + x;
+		const int lineX = static_cast<int>(i) + x;
 		painter.drawLine(lineX, lineY1, lineX, lineY2);
 
 		const float rms = std::sqrt(squared[i] / framesPerResolution);

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -534,8 +534,9 @@ DataFile ClipView::createClipDataFiles(
 	{
 		// Insert into the dom under the "clips" element
 		Track* clipTrack = clipView->m_trackView->getTrack();
-		int trackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), clipTrack));
-		assert(trackIndex != tc->tracks().size());
+		const auto trackIt = std::find(tc->tracks().begin(), tc->tracks().end(), clipTrack);
+		assert(trackIt != tc->tracks().end());
+		int trackIndex = std::distance(tc->tracks().begin(), trackIt);
 		QDomElement clipElement = dataFile.createElement("clip");
 		clipElement.setAttribute( "trackIndex", trackIndex );
 		clipElement.setAttribute( "trackType", static_cast<int>(clipTrack->type()) );

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -135,10 +135,10 @@ void PatternEditor::dropEvent(QDropEvent* de)
 
 		// Ensure pattern clips exist
 		bool hasValidPatternClips = false;
-		if (t->getClips().size() == m_ps->numOfPatterns())
+		if (t->getClips().size() == static_cast<std::size_t>(m_ps->numOfPatterns()))
 		{
 			hasValidPatternClips = true;
-			for (int i = 0; i < t->getClips().size(); ++i)
+			for (auto i = std::size_t{0}; i < t->getClips().size(); ++i)
 			{
 				if (t->getClips()[i]->startPosition() != TimePos(i, 0))
 				{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -219,7 +219,7 @@ PianoRoll::PianoRoll() :
 
 	m_noteEditMenu = new QMenu( this );
 	m_noteEditMenu->clear();
-	for( int i = 0; i < m_nemStr.size(); ++i )
+	for (auto i = std::size_t{0}; i < m_nemStr.size(); ++i)
 	{
 		auto act = new QAction(m_nemStr.at(i), this);
 		connect( act, &QAction::triggered, [this, i](){ changeNoteEditMode(i); } );

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -48,7 +48,7 @@ InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 
 	m_targetsTabWidget = new TabWidget(tr("TARGET"), this);
 
-	for (int i = 0; i < InstrumentSoundShaping::NumTargets; ++i)
+	for (auto i = std::size_t{0}; i < InstrumentSoundShaping::NumTargets; ++i)
 	{
 		m_envLfoViews[i] = new EnvelopeAndLfoView(m_targetsTabWidget);
 		m_targetsTabWidget->addTab(m_envLfoViews[i],
@@ -115,7 +115,7 @@ void InstrumentSoundShapingView::modelChanged()
 	m_filterComboBox->setModel( &m_ss->m_filterModel );
 	m_filterCutKnob->setModel( &m_ss->m_filterCutModel );
 	m_filterResKnob->setModel( &m_ss->m_filterResModel );
-	for( int i = 0; i < InstrumentSoundShaping::NumTargets; ++i )
+	for (auto i = std::size_t{0}; i < InstrumentSoundShaping::NumTargets; ++i)
 	{
 		m_envLfoViews[i]->setModel( m_ss->m_envLfoParameters[i] );
 	}

--- a/src/gui/modals/ExportProjectDialog.cpp
+++ b/src/gui/modals/ExportProjectDialog.cpp
@@ -56,7 +56,7 @@ ExportProjectDialog::ExportProjectDialog( const QString & _file_name,
 	}
 
 	int cbIndex = 0;
-	for( int i = 0; i < ProjectRenderer::NumFileFormats; ++i )
+	for (auto i = std::size_t{0}; i < ProjectRenderer::NumFileFormats; ++i)
 	{
 		if( ProjectRenderer::fileEncodeDevices[i].isAvailable() )
 		{
@@ -268,7 +268,7 @@ void ExportProjectDialog::startBtnClicked()
 	}
 
 	// Find proper file extension.
-	for( int i = 0; i < ProjectRenderer::NumFileFormats; ++i )
+	for (auto i = std::size_t{0}; i < ProjectRenderer::NumFileFormats; ++i)
 	{
 		if (m_ft == ProjectRenderer::fileEncodeDevices[i].m_fileFormat)
 		{

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -413,7 +413,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 		int finalTrackIndex = trackIndex + currentTrackIndex - initialTrackIndex;
 
 		// Track must be in TrackContainer's tracks
-		if( finalTrackIndex < 0 || finalTrackIndex >= tracks.size() )
+		if (finalTrackIndex < 0 || static_cast<std::size_t>(finalTrackIndex) >= tracks.size())
 		{
 			return false;
 		}

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -190,7 +190,7 @@ void Oscilloscope::paintEvent( QPaintEvent * )
 				otherChannelsColor(); // Any other channel
 			p.setPen(QPen(color, width));
 
-			for( int frame = 0; frame < frames; ++frame )
+			for (auto frame = std::size_t{0}; frame < frames; ++frame)
 			{
 				sample_t const clippedSample = AudioEngine::clip(m_buffer[frame][ch]);
 				m_points[frame] = QPointF(

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -474,7 +474,6 @@ MidiClip * MidiClip::adjacentMidiClipByOffset(int offset) const
 {
 	auto& clips = m_instrumentTrack->getClips();
 	int clipNum = m_instrumentTrack->getClipNum(this);
-	if (clipNum < 0 || clipNum > clips.size() - 1) { return nullptr; }
 	return dynamic_cast<MidiClip*>(clips[clipNum + offset]);
 }
 


### PR DESCRIPTION
This PR removes all `-Wno-<warning>` flags that are unnecessary, or for which the code is fixable. The only one left is `-Wno-array-bounds`, which triggers false positives with sufficient optimisations enabled - see the comment in the code for more information. I added `-Wno-stringop-overread` to this, which suffers from the same problems, for GCC versions 11 and above (required to build with `-Werror` on my machine). I removed `-Werror=unused-function` since `-Wunused-function` is included in `-Wall`, and I see no reason to have it be an error even without `-Werror`.

Most of the code changes are fixes for the reintroduced `-Wsign-compare`. I originally planned to introduce `-Wextra` along with these changes, but there turned out to be enough already for their own PR. There may be one or two extraneous `-Wextra` fixes in here that I didn't split out correctly, but they're still worth including. Other notable changes include an alternative to the old deprecated FluidSynth effect API (again, required to build with `-Werror` on my machine), and a fix for SID hanging since #7363 (I caught this bug via a compiler warning prior to someone mentioning it on Discord, highlighting the utility of these warnings).