### PR TITLE
ZynAddSubFx filter frequency set to 127

### DIFF
--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -108,7 +108,7 @@ ZynAddSubFxInstrument::ZynAddSubFxInstrument(
 	m_plugin( nullptr ),
 	m_remotePlugin( nullptr ),
 	m_portamentoModel( 0, 0, 127, 1, this, tr( "Portamento" ) ),
-	m_filterFreqModel( 64, 0, 127, 1, this, tr( "Filter frequency" ) ),
+	m_filterFreqModel( 127, 0, 127, 1, this, tr( "Filter frequency" ) ),
 	m_filterQModel( 64, 0, 127, 1, this, tr( "Filter resonance" ) ),
 	m_bandwidthModel( 64, 0, 127, 1, this, tr( "Bandwidth" ) ),
 	m_fmGainModel( 127, 0, 127, 1, this, tr( "FM gain" ) ),


### PR DESCRIPTION
I'm tying this PR to the [ZynAddSubFX PR #23](https://github.com/LMMS/zynaddsubfx/pull/23). These two PRs aim to disable the default lowpass filter applied to Zyn's three synths, as well as keeping the possibility of filter automation without affecting Zyn internally.

There is only one change in this PR specifically, that being that the filter frequency is set to the maximum value of 127, as per [Lost Robot's suggestion in the Discord server](https://discord.com/channels/203559236729438208/332258319228207114/1261735891068653609).

![image](https://github.com/user-attachments/assets/a0bf4d70-faed-4bfd-9798-b9076e4a65d9)