### PR TITLE
Add looping option to SlicerT

### DIFF
--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -122,7 +122,9 @@ void SlicerT::playNote(NotePlayHandle* handle, SampleFrame* workingBuffer)
 			playbackState->setNoteDone(sliceStart);
 			noteDone = sliceStart;
 			noteLeft = sliceEnd - noteDone;
-		} else {
+		} 
+		else
+		{
 			emit isPlaying(-1, 0, 0);
 			return;
 		}

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -115,7 +115,7 @@ void SlicerT::playNote(NotePlayHandle* handle, SampleFrame* workingBuffer)
 	float noteDone = playbackState->noteDone();
 	float noteLeft = sliceEnd - noteDone;
 
-	if (noteLeft<=0) 
+	if (noteLeft <= 0) 
 	{
 		if (m_enableLoop.value())
 		{

--- a/plugins/SlicerT/SlicerT.h
+++ b/plugins/SlicerT/SlicerT.h
@@ -95,6 +95,7 @@ private:
 	IntModel m_originalBPM;
 	ComboBoxModel m_sliceSnap;
 	BoolModel m_enableSync;
+	BoolModel m_enableLoop;
 
 	Sample m_originalSample;
 

--- a/plugins/SlicerT/SlicerTView.cpp
+++ b/plugins/SlicerT/SlicerTView.cpp
@@ -68,6 +68,11 @@ SlicerTView::SlicerTView(SlicerT* instrument, QWidget* parent)
 	m_syncToggle->setToolTip(tr("Enable BPM sync"));
 	m_syncToggle->setModel(&m_slicerTParent->m_enableSync);
 
+	m_loopToggle = new LedCheckBox("Loop", this, tr("LoopToggle"), LedCheckBox::LedColor::Green);
+	m_loopToggle->move(185, 187);
+	m_loopToggle->setToolTip(tr("Enable Looping"));
+	m_loopToggle->setModel(&m_slicerTParent->m_enableLoop);
+
 	m_bpmBox = new LcdSpinBox(3, "19purple", this);
 	m_bpmBox->move(130, 201);
 	m_bpmBox->setToolTip(tr("Original sample BPM"));

--- a/plugins/SlicerT/SlicerTView.h
+++ b/plugins/SlicerT/SlicerTView.h
@@ -72,6 +72,7 @@ private:
 	LcdSpinBox* m_bpmBox;
 	ComboBox* m_snapSetting;
 	LedCheckBox* m_syncToggle;
+	LedCheckBox* m_loopToggle;
 
 	QPushButton* m_resetButton;
 	QPushButton* m_midiExportButton;


### PR DESCRIPTION
## Problem
Currently, segments do not loop in SlicerT. This makes sense for many applications such as drums, but if you want to use SlicerT to make unique sounds by looping short segments, that is currently not possible.

## Changes
- If looping is enabled, then when there are zero frames left in the note (`notesLeft<=0`), the note position is reset back to the start of the slice.
- A new `LedCheckBox` was added to the plugin interface to let the user toggle looping.
- `loopEnable` was added as a saveable/loadable setting.

This pull request partially addresses #7364

https://github.com/user-attachments/assets/34b44f1b-1fdf-4d3b-8d13-0ecb5b504ba2

