### PR TITLE
Fix include of array in BasicFilters.h

### DIFF
--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -36,6 +36,7 @@
 #endif
 
 #include <cmath>
+#include <array>
 
 #include "lmms_basics.h"
 #include "lmms_constants.h"


### PR DESCRIPTION
Fix a missing include of `array` in `BasicFilters.h`.