### PR TITLE
Add input dialog to the mixer channel LCD spin box

### DIFF
--- a/include/MixerChannelLcdSpinBox.h
+++ b/include/MixerChannelLcdSpinBox.h
@@ -50,6 +50,8 @@ protected:
 	void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
+	void enterValue();
+
 	TrackView * m_tv;
 };
 

--- a/src/gui/widgets/MixerChannelLcdSpinBox.cpp
+++ b/src/gui/widgets/MixerChannelLcdSpinBox.cpp
@@ -81,23 +81,16 @@ void MixerChannelLcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
 
 void MixerChannelLcdSpinBox::enterValue()
 {
-	bool ok;
-	int new_val;
+	const auto val = model()->value();
+	const auto min = model()->minValue();
+	const auto max = model()->maxValue();
+	const auto step = model()->step<int>();
+	const auto label = tr("Please enter a new value between %1 and %2:").arg(min).arg(max);
 
-	new_val = QInputDialog::getInt(
-			this, tr("Set value"),
-			tr("Please enter a new value between %1 and %2:").
-			arg(model()->minValue()).
-			arg(model()->maxValue()),
-			model()->value(),
-			model()->minValue(),
-			model()->maxValue(),
-			model()->step<int>(), &ok);
+	auto ok = false;
+	const auto newVal = QInputDialog::getInt(this, tr("Set value"), label, val, min, max, step, &ok);
 
-	if(ok)
-	{
-		model()->setValue(new_val);
-	}
+	if (ok) { model()->setValue(newVal); }
 }
 
 } // namespace lmms::gui

--- a/src/gui/widgets/MixerChannelLcdSpinBox.cpp
+++ b/src/gui/widgets/MixerChannelLcdSpinBox.cpp
@@ -24,6 +24,9 @@
 
 #include "MixerChannelLcdSpinBox.h"
 
+#include <QInputDialog>
+#include <QMouseEvent>
+
 #include "CaptionMenu.h"
 #include "MixerView.h"
 #include "GuiApplication.h"
@@ -40,6 +43,13 @@ void MixerChannelLcdSpinBox::setTrackView(TrackView * tv)
 
 void MixerChannelLcdSpinBox::mouseDoubleClickEvent(QMouseEvent* event)
 {
+	if (!(event->modifiers() & Qt::ShiftModifier) &&
+		!(event->modifiers() & Qt::ControlModifier))
+	{
+		enterValue();
+		return;
+	}
+
 	getGUI()->mixerView()->setCurrentMixerChannel(model()->value());
 
 	getGUI()->mixerView()->parentWidget()->show();
@@ -69,5 +79,25 @@ void MixerChannelLcdSpinBox::contextMenuEvent(QContextMenuEvent* event)
 	contextMenu->exec(QCursor::pos());
 }
 
+void MixerChannelLcdSpinBox::enterValue()
+{
+	bool ok;
+	int new_val;
+
+	new_val = QInputDialog::getInt(
+			this, tr("Set value"),
+			tr("Please enter a new value between %1 and %2:").
+			arg(model()->minValue()).
+			arg(model()->maxValue()),
+			model()->value(),
+			model()->minValue(),
+			model()->maxValue(),
+			model()->step<int>(), &ok);
+
+	if(ok)
+	{
+		model()->setValue(new_val);
+	}
+}
 
 } // namespace lmms::gui


### PR DESCRIPTION
Added InputDialog for the mixer channel widget.
This will allow better control when assigning mixer channels for instruments