### PR TITLE
Fix bugs in `Sample::play`

### DIFF
--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -141,7 +141,7 @@ bool Sample::play(SampleFrame* dst, PlaybackState* state, size_t numFrames, doub
 	if (outputFrames > 0 && outputFrames < numFrames)
 	{
 		std::fill_n(dst + outputFrames, numFrames - outputFrames, SampleFrame{});
-		MixHelpers::multiply(dst + outputFrames, m_amplification, numFrames - outputFrames);
+		MixHelpers::multiply(dst, m_amplification, outputFrames);
 		return true;
 	}
 	else if (outputFrames == numFrames)

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -137,7 +137,7 @@ bool Sample::play(SampleFrame* dst, PlaybackState* state, size_t numFrames, doub
 	state->error = src_set_ratio(state->resampleState, resampleRatio);
 	assert(state->error == 0 && src_sterror(state->error));
 
-	const auto outputFrames = src_callback_read(state->resampleState, resampleRatio, numFrames, &dst[0][0]);
+	const auto outputFrames = static_cast<size_t>(src_callback_read(state->resampleState, resampleRatio, numFrames, &dst[0][0]));
 	if (outputFrames > 0 && outputFrames < numFrames)
 	{
 		std::fill_n(dst + outputFrames, numFrames - outputFrames, SampleFrame{});

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -134,7 +134,8 @@ bool Sample::play(SampleFrame* dst, PlaybackState* state, size_t numFrames, doub
 	state->sample = this;
 	state->loop = &loopMode;
 
-	src_set_ratio(state->resampleState, resampleRatio);
+	state->error = src_set_ratio(state->resampleState, resampleRatio);
+	assert(state->error == 0 && src_sterror(state->error));
 
 	const auto outputFrames = src_callback_read(state->resampleState, resampleRatio, numFrames, &dst[0][0]);
 	if (outputFrames > 0 && outputFrames < numFrames)


### PR DESCRIPTION
I missed an edge case in #7361. `src_callback_read` returns the number of frames generated or zero. That means that it is not necessarily the case that `src_callback_read` will return the number of frames requested all the time. Also checked for a potential error (that really shouldn't ever happen) on calls to `src_set_ratio` with an `assert`.

Fixes #7400 (I think?)
Fixes #7395 (I think?)