### PR TITLE
Align the rename box for tracks

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -601,17 +601,11 @@ lmms--gui--TrackLabelButton:hover {
 	background: #3B424A;
 	border: 1px solid #515B66;
 	border-radius: none;
-	font-size: 11px;
-	font-weight: normal;
-	padding: 2px 1px;
 }
 
 lmms--gui--TrackLabelButton:pressed {
 	background: #262B30;
 	border-radius: none;
-	font-size: 11px;
-	font-weight: normal;
-	padding: 2px 1px;
 }
 
 lmms--gui--TrackLabelButton:checked {
@@ -619,17 +613,12 @@ lmms--gui--TrackLabelButton:checked {
 	background: #1C1F24;
 	background-image: url("resources:track_shadow_p.png");
 	border-radius: none;
-	font-size: 11px;
-	font-weight: normal;
-	padding: 2px 1px;
 }
 
 lmms--gui--TrackLabelButton:checked:pressed {
 	border: 1px solid #2f353b;
 	background: #0e1012;
 	background-image: url("resources:track_shadow_p.png");
-	font-size: 11px;
-	padding: 2px 1px;
 	font-weight: solid;
 }
 

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -90,6 +90,10 @@ void TrackLabelButton::rename()
 	else
 	{
 		QString txt = m_trackView->getTrack()->name();
+
+		//hide text behind rename line edit
+		setText("");
+
 		m_renameLineEdit->show();
 		m_renameLineEdit->setText( txt );
 		m_renameLineEdit->selectAll();
@@ -106,14 +110,14 @@ void TrackLabelButton::renameFinished()
 	{
 		m_renameLineEdit->clearFocus();
 		m_renameLineEdit->hide();
-		if( m_renameLineEdit->text() != "" )
-		{
-			if( m_renameLineEdit->text() != m_trackView->getTrack()->name() )
-			{
-				setText( elideName( m_renameLineEdit->text() ) );
-				m_trackView->getTrack()->setName( m_renameLineEdit->text() );
-			}
-		}
+
+		auto textEmpty = m_renameLineEdit->text() == "";
+		auto nameHasChanged = m_renameLineEdit->text() != m_trackView->getTrack()->name();
+
+		if (!textEmpty && nameHasChanged)
+			m_trackView->getTrack()->setName( m_renameLineEdit->text() );
+
+		nameChanged();
 	}
 }
 

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -50,10 +50,8 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	setAcceptDrops( true );
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
+
 	m_renameLineEdit = new TrackRenameLineEdit( this );
-	auto font = QFont();
-	font.setPointSize(8);
-	m_renameLineEdit->setFont(font);
 	m_renameLineEdit->hide();
 	
 	if (isInCompactMode())
@@ -63,8 +61,6 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	else
 	{
 		setFixedSize( 160, 29 );
-		m_renameLineEdit->move(25, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1);
-		m_renameLineEdit->setFixedWidth(width() - 31);
 		connect( m_renameLineEdit, SIGNAL(editingFinished()), this, SLOT(renameFinished()));
 	}
 	
@@ -92,11 +88,22 @@ void TrackLabelButton::rename()
 	}
 	else
 	{
-		QString txt = m_trackView->getTrack()->name();
-		m_renameLineEdit->show();
-		m_renameLineEdit->setText( txt );
+		const auto & trackName = m_trackView->getTrack()->name();
+		m_renameLineEdit->setText(trackName);
 		m_renameLineEdit->selectAll();
 		m_renameLineEdit->setFocus();
+
+		// Make sure that the rename line edit uses the same font as the widget
+		// which is set via style sheets
+		m_renameLineEdit->setFont(font());
+
+		// Move the line edit to the correct position by taking the size of the
+		// icon into account.
+		const auto iconWidth = iconSize().width();
+		m_renameLineEdit->move(iconWidth + 1, (height() / 2  - m_renameLineEdit->sizeHint().height() / 2) + 1);
+		m_renameLineEdit->setFixedWidth(width() - (iconWidth + 6));
+
+		m_renameLineEdit->show();
 	}
 }
 

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -63,7 +63,7 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	else
 	{
 		setFixedSize( 160, 29 );
-		m_renameLineEdit->move(26, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1);
+		m_renameLineEdit->move(25, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1);
 		m_renameLineEdit->setFixedWidth(width() - 31);
 		connect( m_renameLineEdit, SIGNAL(editingFinished()), this, SLOT(renameFinished()));
 	}

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -51,6 +51,9 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 	m_renameLineEdit = new TrackRenameLineEdit( this );
+	auto font = QFont();
+	font.setPointSize(8);
+	m_renameLineEdit->setFont(font);
 	m_renameLineEdit->hide();
 	
 	if (isInCompactMode())
@@ -60,8 +63,8 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	else
 	{
 		setFixedSize( 160, 29 );
-		m_renameLineEdit->move( 30, ( height() / 2 ) - ( m_renameLineEdit->sizeHint().height() / 2 ) );
-		m_renameLineEdit->setFixedWidth( width() - 33 );
+		m_renameLineEdit->move( 26, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1 );
+		m_renameLineEdit->setFixedWidth( width() - 31 );
 		connect( m_renameLineEdit, SIGNAL(editingFinished()), this, SLOT(renameFinished()));
 	}
 	
@@ -69,8 +72,6 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	connect( m_trackView->getTrack(), SIGNAL(dataChanged()), this, SLOT(update()));
 	connect( m_trackView->getTrack(), SIGNAL(nameChanged()), this, SLOT(nameChanged()));
 }
-
-
 
 
 
@@ -90,10 +91,6 @@ void TrackLabelButton::rename()
 	else
 	{
 		QString txt = m_trackView->getTrack()->name();
-
-		//hide text behind rename line edit
-		setText("");
-
 		m_renameLineEdit->show();
 		m_renameLineEdit->setText( txt );
 		m_renameLineEdit->selectAll();
@@ -110,14 +107,14 @@ void TrackLabelButton::renameFinished()
 	{
 		m_renameLineEdit->clearFocus();
 		m_renameLineEdit->hide();
-
-		auto textEmpty = m_renameLineEdit->text() == "";
-		auto nameHasChanged = m_renameLineEdit->text() != m_trackView->getTrack()->name();
-
-		if (!textEmpty && nameHasChanged)
-			m_trackView->getTrack()->setName( m_renameLineEdit->text() );
-
-		nameChanged();
+		if( m_renameLineEdit->text() != "" )
+		{
+			if( m_renameLineEdit->text() != m_trackView->getTrack()->name() )
+			{
+				setText( elideName( m_renameLineEdit->text() ) );
+				m_trackView->getTrack()->setName( m_renameLineEdit->text() );
+			}
+		}
 	}
 }
 

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -63,8 +63,8 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	else
 	{
 		setFixedSize( 160, 29 );
-		m_renameLineEdit->move( 26, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1 );
-		m_renameLineEdit->setFixedWidth( width() - 31 );
+		m_renameLineEdit->move(26, ( height() / 2  - m_renameLineEdit->sizeHint().height() / 2 ) + 1);
+		m_renameLineEdit->setFixedWidth(width() - 31);
 		connect( m_renameLineEdit, SIGNAL(editingFinished()), this, SLOT(renameFinished()));
 	}
 	
@@ -72,6 +72,8 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	connect( m_trackView->getTrack(), SIGNAL(dataChanged()), this, SLOT(update()));
 	connect( m_trackView->getTrack(), SIGNAL(nameChanged()), this, SLOT(nameChanged()));
 }
+
+
 
 
 


### PR DESCRIPTION
Fixing #7413 , on rename we set the text of the TrackLabelButton to an empty String. After renaming we set the text to the tracks name.

It's my first PR after a cuple of years. I hope I did it right.;)