### PR TITLE
SDL driver's input and output device configuration via combo box

### DIFF
--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -39,7 +39,6 @@
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
 
-class QLineEdit;
 class QComboBox;
 
 namespace lmms
@@ -67,10 +66,10 @@ public:
 		void saveSettings() override;
 
 	private:
-		QLineEdit * m_device;
+		QComboBox* m_playbackDeviceComboBox;
 		QComboBox* m_inputDeviceComboBox = nullptr;
 
-		static QString s_defaultInputDevice;
+		static QString s_systemDefaultDevice;
 	} ;
 
 

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -64,6 +64,10 @@ public:
 		~setupWidget() override = default;
 
 		void saveSettings() override;
+	
+	private:
+		void populatePlaybackDeviceComboBox();
+		void populateInputDeviceComboBox();
 
 	private:
 		QComboBox* m_playbackDeviceComboBox = nullptr;

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -69,6 +69,8 @@ public:
 	private:
 		QLineEdit * m_device;
 		QComboBox* m_inputDeviceComboBox = nullptr;
+
+		static QString s_defaultInputDevice;
 	} ;
 
 

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -40,6 +40,7 @@
 #include "AudioDeviceSetupWidget.h"
 
 class QLineEdit;
+class QComboBox;
 
 namespace lmms
 {
@@ -67,7 +68,7 @@ public:
 
 	private:
 		QLineEdit * m_device;
-
+		QComboBox* m_inputDeviceComboBox = nullptr;
 	} ;
 
 

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -66,7 +66,7 @@ public:
 		void saveSettings() override;
 
 	private:
-		QComboBox* m_playbackDeviceComboBox;
+		QComboBox* m_playbackDeviceComboBox = nullptr;
 		QComboBox* m_inputDeviceComboBox = nullptr;
 
 		static QString s_systemDefaultDevice;

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -331,7 +331,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	}
 #endif
 
-	form->addRow(tr("Device"), m_playbackDeviceComboBox);
+	form->addRow(tr("Playback device"), m_playbackDeviceComboBox);
 
 	m_inputDeviceComboBox = new QComboBox(this);
 

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -314,38 +314,13 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 
 	m_playbackDeviceComboBox = new QComboBox(this);
 
-#ifdef LMMS_HAVE_SDL2
-	m_playbackDeviceComboBox->addItem(s_systemDefaultDevice);
-
-	const int numberOfPlaybackDevices = SDL_GetNumAudioDevices(0);
-	for (int i = 0; i < numberOfPlaybackDevices; ++i)
-	{
-		const QString deviceName = SDL_GetAudioDeviceName(i, 0);
-		m_playbackDeviceComboBox->addItem(deviceName);
-	}
-
-	const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
-	m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
-#endif
+	populatePlaybackDeviceComboBox();
 
 	form->addRow(tr("Playback device"), m_playbackDeviceComboBox);
 
 	m_inputDeviceComboBox = new QComboBox(this);
 
-#ifdef LMMS_HAVE_SDL2
-	m_inputDeviceComboBox->addItem(s_systemDefaultDevice);
-
-	const int numberOfInputDevices = SDL_GetNumAudioDevices(1);
-	for (int i = 0; i < numberOfInputDevices; ++i)
-	{
-		const QString deviceName = SDL_GetAudioDeviceName(i, 1);
-		m_inputDeviceComboBox->addItem(deviceName);
-	}
-
-	// Set the current device to the one in the configuration
-	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL);
-	m_inputDeviceComboBox->setCurrentText(inputDevice.isEmpty() ? s_systemDefaultDevice : inputDevice);
-#endif
+	populateInputDeviceComboBox();
 
 	form->addRow(tr("Input device"), m_inputDeviceComboBox);
 }
@@ -376,6 +351,41 @@ void AudioSdl::setupWidget::saveSettings()
 	{
 		ConfigManager::inst()->setValue(SectionSDL, InputDeviceSDL, currentInputDevice);
 	}
+}
+
+void AudioSdl::setupWidget::populatePlaybackDeviceComboBox()
+{
+#ifdef LMMS_HAVE_SDL2
+	m_playbackDeviceComboBox->addItem(s_systemDefaultDevice);
+
+	const int numberOfPlaybackDevices = SDL_GetNumAudioDevices(0);
+	for (int i = 0; i < numberOfPlaybackDevices; ++i)
+	{
+		const QString deviceName = SDL_GetAudioDeviceName(i, 0);
+		m_playbackDeviceComboBox->addItem(deviceName);
+	}
+
+	const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
+	m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
+#endif
+}
+
+void AudioSdl::setupWidget::populateInputDeviceComboBox()
+{
+#ifdef LMMS_HAVE_SDL2
+	m_inputDeviceComboBox->addItem(s_systemDefaultDevice);
+
+	const int numberOfInputDevices = SDL_GetNumAudioDevices(1);
+	for (int i = 0; i < numberOfInputDevices; ++i)
+	{
+		const QString deviceName = SDL_GetAudioDeviceName(i, 1);
+		m_inputDeviceComboBox->addItem(deviceName);
+	}
+
+	// Set the current device to the one in the configuration
+	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL);
+	m_inputDeviceComboBox->setCurrentText(inputDevice.isEmpty() ? s_systemDefaultDevice : inputDevice);
+#endif
 }
 
 

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -358,12 +358,17 @@ void AudioSdl::setupWidget::populatePlaybackDeviceComboBox()
 #ifdef LMMS_HAVE_SDL2
 	m_playbackDeviceComboBox->addItem(s_systemDefaultDevice);
 
+	QStringList playbackDevices;
 	const int numberOfPlaybackDevices = SDL_GetNumAudioDevices(0);
 	for (int i = 0; i < numberOfPlaybackDevices; ++i)
 	{
 		const QString deviceName = SDL_GetAudioDeviceName(i, 0);
-		m_playbackDeviceComboBox->addItem(deviceName);
+		playbackDevices.append(deviceName);
 	}
+
+	playbackDevices.sort();
+
+	m_playbackDeviceComboBox->addItems(playbackDevices);
 
 	const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
 	m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
@@ -375,12 +380,17 @@ void AudioSdl::setupWidget::populateInputDeviceComboBox()
 #ifdef LMMS_HAVE_SDL2
 	m_inputDeviceComboBox->addItem(s_systemDefaultDevice);
 
+	QStringList inputDevices;
 	const int numberOfInputDevices = SDL_GetNumAudioDevices(1);
 	for (int i = 0; i < numberOfInputDevices; ++i)
 	{
 		const QString deviceName = SDL_GetAudioDeviceName(i, 1);
-		m_inputDeviceComboBox->addItem(deviceName);
+		inputDevices.append(deviceName);
 	}
+
+	inputDevices.sort();
+
+	m_inputDeviceComboBox->addItems(inputDevices);
 
 	// Set the current device to the one in the configuration
 	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL);

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -38,9 +38,9 @@
 namespace lmms
 {
 
-constexpr char const* const c_sectionSDL = "audiosdl";
-constexpr char const* const c_playbackDeviceSDL = "device";
-constexpr char const* const c_inputDeviceSDL = "inputdevice";
+constexpr char const* const SectionSDL = "audiosdl";
+constexpr char const* const PlaybackDeviceSDL = "device";
+constexpr char const* const InputDeviceSDL = "inputdevice";
 
 AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	AudioDevice( DEFAULT_CHANNELS, _audioEngine ),
@@ -83,11 +83,11 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
   	SDL_AudioSpec actual; 
 
 #ifdef LMMS_HAVE_SDL2
-	const QString playbackDevice = ConfigManager::inst()->value(c_sectionSDL, c_playbackDeviceSDL);
-	const bool isDefaultPlayback = playbackDevice.isEmpty();
+	const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL).toStdString();
+	const bool isDefaultPlayback = playbackDevice.empty();
 
 	// Try with the configured device
-	const auto playbackDeviceCStr = isDefaultPlayback ? nullptr : playbackDevice.toLocal8Bit().data();
+	const auto playbackDeviceCStr = isDefaultPlayback ? nullptr : playbackDevice.c_str();
 	m_outputDevice = SDL_OpenAudioDevice(playbackDeviceCStr, 0, &m_audioHandle, &actual, 0);
 
 	// If we did not get a device ID try again with the default device if we did not try that before
@@ -121,11 +121,11 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	m_inputAudioHandle = m_audioHandle;
 	m_inputAudioHandle.callback = sdlInputAudioCallback;
 
-	const QString inputDevice = ConfigManager::inst()->value(c_sectionSDL, c_inputDeviceSDL);
-	const bool isDefaultInput = inputDevice.isEmpty();
+	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL).toStdString();
+	const bool isDefaultInput = inputDevice.empty();
 
 	// Try with the configured device
-	const auto inputDeviceCStr = isDefaultInput ? nullptr : inputDevice.toLocal8Bit().data();
+	const auto inputDeviceCStr = isDefaultInput ? nullptr : inputDevice.c_str();
 	m_inputDevice = SDL_OpenAudioDevice (inputDeviceCStr, 1, &m_inputAudioHandle, &actual, 0);
 
 	// If we did not get a device ID try again with the default device if we did not try that before
@@ -324,15 +324,8 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 		m_playbackDeviceComboBox->addItem(deviceName);
 	}
 
-	QString playbackDevice = ConfigManager::inst()->value(c_sectionSDL, c_playbackDeviceSDL);
-	if (playbackDevice.isEmpty())
-	{
-		m_playbackDeviceComboBox->setCurrentText(s_systemDefaultDevice);
-	}
-	else
-	{
-		m_playbackDeviceComboBox->setCurrentText(playbackDevice);
-	}
+	const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
+	m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
 #endif
 
 	form->addRow(tr("Playback device"), m_playbackDeviceComboBox);
@@ -350,7 +343,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	}
 
 	// Set the current device to the one in the configuration
-	const auto inputDevice = ConfigManager::inst()->value(c_sectionSDL, c_inputDeviceSDL);
+	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL);
 	if (inputDevice.isEmpty())
 	{
 		m_inputDeviceComboBox->setCurrentText(s_systemDefaultDevice);
@@ -373,22 +366,22 @@ void AudioSdl::setupWidget::saveSettings()
 	if (currentPlaybackDevice == s_systemDefaultDevice)
 	{
 		// Represent the default input device with an empty string
-		ConfigManager::inst()->setValue(c_sectionSDL, c_playbackDeviceSDL, "");
+		ConfigManager::inst()->setValue(SectionSDL, PlaybackDeviceSDL, "");
 	}
 	else if (!currentPlaybackDevice.isEmpty())
 	{
-		ConfigManager::inst()->setValue(c_sectionSDL, c_playbackDeviceSDL, currentPlaybackDevice);
+		ConfigManager::inst()->setValue(SectionSDL, PlaybackDeviceSDL, currentPlaybackDevice);
 	}
 
 	const auto currentInputDevice = m_inputDeviceComboBox->currentText();
 	if (currentInputDevice == s_systemDefaultDevice)
 	{
 		// Represent the default input device with an empty string
-		ConfigManager::inst()->setValue(c_sectionSDL, c_inputDeviceSDL, "");
+		ConfigManager::inst()->setValue(SectionSDL, InputDeviceSDL, "");
 	}
 	else if (!currentInputDevice.isEmpty())
 	{
-		ConfigManager::inst()->setValue(c_sectionSDL, c_inputDeviceSDL, currentInputDevice);
+		ConfigManager::inst()->setValue(SectionSDL, InputDeviceSDL, currentInputDevice);
 	}
 }
 

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -38,6 +38,10 @@
 namespace lmms
 {
 
+constexpr char const* const c_sectionSDL = "audiosdl";
+constexpr char const* const c_playbackDeviceSDL = "device";
+constexpr char const* const c_inputDeviceSDL = "inputdevice";
+
 AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	AudioDevice( DEFAULT_CHANNELS, _audioEngine ),
 	m_outBuf(new SampleFrame[audioEngine()->framesPerPeriod()])
@@ -79,7 +83,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
   	SDL_AudioSpec actual; 
 
 #ifdef LMMS_HAVE_SDL2
-	const QString playbackDevice = ConfigManager::inst()->value("audiosdl", "device");
+	const QString playbackDevice = ConfigManager::inst()->value(c_sectionSDL, c_playbackDeviceSDL);
 	const bool isDefaultPlayback = playbackDevice.isEmpty();
 
 	// Try with the configured device
@@ -117,7 +121,7 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	m_inputAudioHandle = m_audioHandle;
 	m_inputAudioHandle.callback = sdlInputAudioCallback;
 
-	const QString inputDevice = ConfigManager::inst()->value("audiosdl", "inputdevice");
+	const QString inputDevice = ConfigManager::inst()->value(c_sectionSDL, c_inputDeviceSDL);
 	const bool isDefaultInput = inputDevice.isEmpty();
 
 	// Try with the configured device
@@ -320,7 +324,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 		m_playbackDeviceComboBox->addItem(deviceName);
 	}
 
-	QString playbackDevice = ConfigManager::inst()->value("audiosdl", "device");
+	QString playbackDevice = ConfigManager::inst()->value(c_sectionSDL, c_playbackDeviceSDL);
 	if (playbackDevice.isEmpty())
 	{
 		m_playbackDeviceComboBox->setCurrentText(s_systemDefaultDevice);
@@ -346,7 +350,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	}
 
 	// Set the current device to the one in the configuration
-	const auto inputDevice = ConfigManager::inst()->value("audiosdl", "inputdevice");
+	const auto inputDevice = ConfigManager::inst()->value(c_sectionSDL, c_inputDeviceSDL);
 	if (inputDevice.isEmpty())
 	{
 		m_inputDeviceComboBox->setCurrentText(s_systemDefaultDevice);
@@ -369,22 +373,22 @@ void AudioSdl::setupWidget::saveSettings()
 	if (currentPlaybackDevice == s_systemDefaultDevice)
 	{
 		// Represent the default input device with an empty string
-		ConfigManager::inst()->setValue("audiosdl", "device", "");
+		ConfigManager::inst()->setValue(c_sectionSDL, c_playbackDeviceSDL, "");
 	}
 	else if (!currentPlaybackDevice.isEmpty())
 	{
-		ConfigManager::inst()->setValue("audiosdl", "device", currentPlaybackDevice);
+		ConfigManager::inst()->setValue(c_sectionSDL, c_playbackDeviceSDL, currentPlaybackDevice);
 	}
 
 	const auto currentInputDevice = m_inputDeviceComboBox->currentText();
 	if (currentInputDevice == s_systemDefaultDevice)
 	{
 		// Represent the default input device with an empty string
-		ConfigManager::inst()->setValue("audiosdl", "inputdevice", "");
+		ConfigManager::inst()->setValue(c_sectionSDL, c_inputDeviceSDL, "");
 	}
 	else if (!currentInputDevice.isEmpty())
 	{
-		ConfigManager::inst()->setValue("audiosdl", "inputdevice", currentInputDevice);
+		ConfigManager::inst()->setValue(c_sectionSDL, c_inputDeviceSDL, currentInputDevice);
 	}
 }
 

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -304,7 +304,7 @@ void AudioSdl::sdlInputAudioCallback(Uint8 *_buf, int _len) {
 
 #endif
 
-QString AudioSdl::setupWidget::s_systemDefaultDevice = QObject::tr("[System Default]");
+QString AudioSdl::setupWidget::s_systemDefaultDevice = AudioDeviceSetupWidget::tr("[System Default]");
 
 AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	AudioDeviceSetupWidget( AudioSdl::name(), _parent )
@@ -333,7 +333,7 @@ void AudioSdl::setupWidget::saveSettings()
 	const auto currentPlaybackDevice = m_playbackDeviceComboBox->currentText();
 	if (currentPlaybackDevice == s_systemDefaultDevice)
 	{
-		// Represent the default input device with an empty string
+		// Represent the default playback device with an empty string
 		ConfigManager::inst()->setValue(SectionSDL, PlaybackDeviceSDL, "");
 	}
 	else if (!currentPlaybackDevice.isEmpty())

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -110,13 +110,14 @@ AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	m_inputAudioHandle.callback = sdlInputAudioCallback;
 
 	const QString inputDevice = ConfigManager::inst()->value("audiosdl", "inputdevice");
+	const bool isDefaultInput = inputDevice.isEmpty();
 
 	// Try with the configured device
-	const auto inputDeviceCStr = inputDevice.toLocal8Bit().data();
+	const auto inputDeviceCStr = isDefaultInput ? nullptr : inputDevice.toLocal8Bit().data();
 	m_inputDevice = SDL_OpenAudioDevice (inputDeviceCStr, 1, &m_inputAudioHandle, &actual, 0);
 
-	// If we did not get a device ID try again with the default device
-	if (m_inputDevice == 0)
+	// If we did not get a device ID try again with the default device if we did not try that before
+	if (m_inputDevice == 0 && !isDefaultInput)
 	{
 		m_inputDevice = SDL_OpenAudioDevice(nullptr, 1, &m_inputAudioHandle, &actual, 0);
 	}
@@ -291,6 +292,8 @@ void AudioSdl::sdlInputAudioCallback(Uint8 *_buf, int _len) {
 
 #endif
 
+QString AudioSdl::setupWidget::s_defaultInputDevice = QObject::tr("[System Default]");
+
 AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	AudioDeviceSetupWidget( AudioSdl::name(), _parent )
 {
@@ -304,6 +307,8 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	m_inputDeviceComboBox = new QComboBox(this);
 
 #ifdef LMMS_HAVE_SDL2
+	m_inputDeviceComboBox->addItem(s_defaultInputDevice);
+
 	const int numberOfInputDevices = SDL_GetNumAudioDevices(1);
 	for (int i = 0; i < numberOfInputDevices; ++i)
 	{
@@ -313,7 +318,14 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 
 	// Set the current device to the one in the configuration
 	const auto inputDevice = ConfigManager::inst()->value("audiosdl", "inputdevice");
-	m_inputDeviceComboBox->setCurrentText(inputDevice);
+	if (inputDevice.isEmpty())
+	{
+		m_inputDeviceComboBox->setCurrentText(s_defaultInputDevice);
+	}
+	else
+	{
+		m_inputDeviceComboBox->setCurrentText(inputDevice);
+	}
 #endif
 
 	form->addRow(tr("Input device"), m_inputDeviceComboBox);
@@ -328,7 +340,12 @@ void AudioSdl::setupWidget::saveSettings()
 							m_device->text() );
 
 	const auto currentInputDevice = m_inputDeviceComboBox->currentText();
-	if (!currentInputDevice.isEmpty())
+	if (currentInputDevice == s_defaultInputDevice)
+	{
+		// Represent the default input device with an empty string
+		ConfigManager::inst()->setValue("audiosdl", "inputdevice", "");
+	}
+	else if (!currentInputDevice.isEmpty())
 	{
 		ConfigManager::inst()->setValue("audiosdl", "inputdevice", currentInputDevice);
 	}

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -344,14 +344,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 
 	// Set the current device to the one in the configuration
 	const auto inputDevice = ConfigManager::inst()->value(SectionSDL, InputDeviceSDL);
-	if (inputDevice.isEmpty())
-	{
-		m_inputDeviceComboBox->setCurrentText(s_systemDefaultDevice);
-	}
-	else
-	{
-		m_inputDeviceComboBox->setCurrentText(inputDevice);
-	}
+	m_inputDeviceComboBox->setCurrentText(inputDevice.isEmpty() ? s_systemDefaultDevice : inputDevice);
 #endif
 
 	form->addRow(tr("Input device"), m_inputDeviceComboBox);

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -38,9 +38,9 @@
 namespace lmms
 {
 
-constexpr char const* const SectionSDL = "audiosdl";
-constexpr char const* const PlaybackDeviceSDL = "device";
-constexpr char const* const InputDeviceSDL = "inputdevice";
+constexpr auto SectionSDL = "audiosdl";
+constexpr auto PlaybackDeviceSDL = "device";
+constexpr auto InputDeviceSDL = "inputdevice";
 
 AudioSdl::AudioSdl( bool & _success_ful, AudioEngine*  _audioEngine ) :
 	AudioDevice( DEFAULT_CHANNELS, _audioEngine ),

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -306,6 +306,7 @@ AudioSdl::setupWidget::setupWidget( QWidget * _parent ) :
 	AudioDeviceSetupWidget( AudioSdl::name(), _parent )
 {
 	QFormLayout * form = new QFormLayout(this);
+	form->setRowWrapPolicy(QFormLayout::WrapLongRows);
 
 	m_playbackDeviceComboBox = new QComboBox(this);
 


### PR DESCRIPTION
This pull request cherry-picks the changes from pull request #5990 which enable the configuration of the SDL driver's input and output devices via combo boxes. The feature was extracted into this PR because it is questionable if and when #5990 will be merged and the combo box feature is already useful on it's own. It looks as follows:

![5990-PlaybackAndInputDeviceSelection](https://github.com/LMMS/lmms/assets/9293269/f88939fa-ba98-469c-bf46-c4d0775e43f3)

My comments in #5990 regarding this feature started around here: https://github.com/LMMS/lmms/pull/5990#issuecomment-2143493829

This feature was also proposed independently here: https://github.com/LMMS/lmms/pull/6070#issuecomment-2258330139

Similar designs for the other drivers should be done in separate pull requests as they will all have different API on how to retrieve the devices and change them.