### PR TITLE
CI: Run LMMS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,11 @@ jobs:
         run: |
           cmake --build build --target install
           cmake --build build --target appimage
+      - name: Display help
+        run: >
+          build/install/bin/lmms --help | grep "Usage: lmms"
+      - name: Display version
+        run: build/install/bin/lmms --version | grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -144,6 +149,11 @@ jobs:
         run: |
           cmake --build build --target install
           cmake --build build --target dmg
+      - name: Display help
+        run: >
+          build/LMMS.app/Contents/MacOS/lmms --help | grep "Usage: lmms"
+      - name: Display version
+        run: build/LMMS.app/Contents/MacOS/lmms --version | grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -193,6 +203,12 @@ jobs:
           update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
       - name: Configure git
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Install wine and p7zip
+      - run: |
+          apt-get --yes install wine-stable p7zip-full
+          dpkg --add-architecture i386  # add i386 arch for wine32
+          apt-get --yes update
+          apt-get --yes install wine32
       - name: Check out
         uses: actions/checkout@v3
         with:
@@ -219,6 +235,20 @@ jobs:
         run: cmake --build build
       - name: Package
         run: cmake --build build --target package
+      - name: Unpack
+        run: |
+          mkdir build/install
+          7z x -obuild/install build/lmms-*.exe
+      - name: Display help
+        run: >
+          WINEPREFIX=/tmp/lmms-wineprefix
+          wine "build/install/lmms.exe" --help |
+          grep "Usage: lmms"
+      - name: Display version
+        run: >
+          WINEPREFIX=/tmp/lmms-wineprefix
+          wine "build/install/lmms.exe" --version |
+          grep "Copyright (c) .* LMMS Developers"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -237,8 +267,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['x86', 'x64']
-    name: msvc-${{ matrix.arch }}
+        config:
+          - arch: 'x86'
+            programfiles-suffix: '(x86)'
+          - arch: 'x64'
+            programfiles-suffix: ''
+    name: msvc-${{ matrix.config.arch }}
     runs-on: windows-2019
     env:
       CCACHE_MAXSIZE: 0
@@ -253,19 +287,19 @@ jobs:
         id: cache-deps
         uses: actions/cache@v3
         with:
-          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ matrix.config.arch }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ matrix.arch }}-
+            vcpkg-${{ matrix.config.arch }}-
           path: build\vcpkg_installed
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
           # yamllint disable rule:line-length
-          key: "ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}\
+          key: "ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}-
-            ccache-${{ github.job }}-${{ matrix.arch }}-
+            ccache-${{ github.job }}-${{ matrix.config.arch }}-${{ github.ref }}-
+            ccache-${{ github.job }}-${{ matrix.config.arch }}-
           path: ~\AppData\Local\ccache
           # yamllint enable rule:line-length
       - name: Install tools
@@ -288,7 +322,7 @@ jobs:
       - name: Set up build environment
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
         with:
-          arch: ${{ matrix.arch }}
+          arch: ${{ matrix.config.arch }}
       - name: Configure
         run: |
           ccache --zero-stats
@@ -301,8 +335,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DUSE_COMPILE_CACHE=ON `
             -DUSE_WERROR=ON `
-            -DVCPKG_TARGET_TRIPLET="${{ matrix.arch }}-windows" `
-            -DVCPKG_HOST_TRIPLET="${{ matrix.arch }}-windows" `
+            -DVCPKG_TARGET_TRIPLET="${{ matrix.config.arch }}-windows" `
+            -DVCPKG_HOST_TRIPLET="${{ matrix.config.arch }}-windows" `
             -DVCPKG_MANIFEST_INSTALL="${{ env.should_install_manifest }}"
         env:
           should_install_manifest:
@@ -315,10 +349,24 @@ jobs:
           ctest --output-on-failure -j2
       - name: Package
         run: cmake --build build --target package
+      - name: Unpack
+        run: Start-Process @(gci build/lmms-*.exe)[0] -ArgumentList /S -Wait
+        # yamllint disable rule:line-length
+      - name: Display help
+        run: >
+            $result = & "${env:ProgramFiles${{ matrix.config.programfiles-suffix }}}/LMMS/lmms.exe" "--help" |
+            Select-String "Usage: lmms";
+            if($result.Matches.Count -eq 0) { exit 1 }
+      - name: Display version
+        run: >
+            $result = & "${env:ProgramFiles${{ matrix.config.programfiles-suffix }}}/LMMS/lmms.exe" "--version" |
+            Select-String -Pattern "Copyright \(c\) .* LMMS Developers";
+            if($result.Matches.Count -eq 0) { exit 1 }
+        # yamllint enable rule:line-length
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: msvc-${{ matrix.arch }}
+          name: msvc-${{ matrix.config.arch }}
           path: build\lmms-*.exe
       - name: Trim ccache and print statistics
         run: |


### PR DESCRIPTION
This runs `lmms --version` and `lmms --help` in the github CI. Further checks, like importing an LMMS project to WAV via CLI, are conceivable.

Note: This is a split of https://github.com/LMMS/lmms/pull/6983 . Mutliple reviews have been done there, but one from DomClark is still outstanding, which I am reworking here.