### PR TITLE
Fix #5851: Implement `EffectRackView::sizeHint()`

### DIFF
--- a/include/EffectRackView.h
+++ b/include/EffectRackView.h
@@ -64,6 +64,8 @@ private slots:
 
 private:
 	void modelChanged() override;
+	QSize sizeHint() const override;
+	QSize minimumSizeHint() const override { return sizeHint(); }
 
 	inline EffectChain* fxChain()
 	{

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -276,7 +276,7 @@ void EffectRackView::modelChanged()
 QSize EffectRackView::sizeHint() const
 {
 	// Use the formula from InstrumentTrackWindow.cpp
-	return QSize{EffectRackView::DEFAULT_WIDTH, 254 - 4 - 1};
+	return QSize{EffectRackView::DEFAULT_WIDTH, 254 /* INSTRUMENT_HEIGHT */ - 4 - 1};
 }
 
 

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -273,4 +273,13 @@ void EffectRackView::modelChanged()
 
 
 
+QSize EffectRackView::sizeHint() const
+{
+	// Use the formula from InstrumentTrackWindow.cpp
+	return QSize{EffectRackView::DEFAULT_WIDTH, 254 - 4 - 1};
+}
+
+
+
+
 } // namespace lmms::gui

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -265,7 +265,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	m_tabWidget->addTab(m_tuningView, tr("Tuning and transposition"), "tuning_tab", 5);
 	adjustTabSize(m_ssView);
 	adjustTabSize(instrumentFunctions);
-	m_effectView->resize(EffectRackView::DEFAULT_WIDTH, INSTRUMENT_HEIGHT - 4 - 1);
+	// EffectRackView has sizeHint to be QSize(EffectRackView::DEFAULT_WIDTH, INSTRUMENT_HEIGHT - 4 - 1)
 	adjustTabSize(m_midiView);
 	adjustTabSize(m_tuningView);
 


### PR DESCRIPTION
This fixes `EffectRackView` to have a permanent size hint instead of resizing the widget once in `InstrumentTrackWindow`. The size hint tells the `InstrumentTrackWindow` to not increase with a growing number of effects in the `EffectRackView`.