### PR TITLE
FileDialog: Add URLs only if they're not present

### DIFF
--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -26,6 +26,8 @@
 #define LMMS_GUI_FILE_DIALOG_H
 
 #include <QFileDialog>
+#include <QList>
+#include <QUrl>
 
 #include "lmms_export.h"
 
@@ -40,6 +42,8 @@ public:
 	explicit FileDialog( QWidget *parent = 0, const QString &caption = QString(),
 						const QString &directory = QString(),
 						const QString &filter = QString() );
+						
+	~FileDialog();
 
 	static QString getExistingDirectory(QWidget *parent,
 										const QString &caption,
@@ -51,6 +55,9 @@ public:
 									const QString &filter = QString(),
 									QString *selectedFilter = 0);
 	void clearSelection();
+	
+private:
+	QList<QUrl> m_oldURLs;
 };
 
 

--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -26,8 +26,6 @@
 #define LMMS_GUI_FILE_DIALOG_H
 
 #include <QFileDialog>
-#include <QList>
-#include <QUrl>
 
 #include "lmms_export.h"
 
@@ -42,8 +40,6 @@ public:
 	explicit FileDialog( QWidget *parent = 0, const QString &caption = QString(),
 						const QString &directory = QString(),
 						const QString &filter = QString() );
-						
-	~FileDialog();
 
 	static QString getExistingDirectory(QWidget *parent,
 										const QString &caption,
@@ -55,9 +51,6 @@ public:
 									const QString &filter = QString(),
 									QString *selectedFilter = 0);
 	void clearSelection();
-	
-private:
-	QList<QUrl> m_oldURLs;
 };
 
 

--- a/src/gui/modals/FileDialog.cpp
+++ b/src/gui/modals/FileDialog.cpp
@@ -46,24 +46,23 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 
 	setOption( QFileDialog::DontUseNativeDialog );
 
-	auto addIfUnavailable = [](QList<QUrl>& urls, const QString& path)
+	QList<QUrl> urls = sidebarUrls();
+
+	auto addUnique = [&](const QString& path)
 	{
 		auto newUrl = QUrl::fromLocalFile(path);
-	
+
 		if (!urls.contains(newUrl))
 		{
 			urls << newUrl;
 		}
 	};
 
-	m_oldURLs = sidebarUrls();
-	QList<QUrl> urls = sidebarUrls();
-
 	QDir desktopDir;
 	desktopDir.setPath(QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
 	if (desktopDir.exists())
 	{
-	    addIfUnavailable(urls, desktopDir.absolutePath());
+	    addUnique(desktopDir.absolutePath());
 	}
 
 	QDir downloadDir(QDir::homePath() + "/Downloads");
@@ -73,24 +72,24 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 	}
 	if (downloadDir.exists())
 	{
-		addIfUnavailable(urls, downloadDir.absolutePath());
+		addUnique(downloadDir.absolutePath());
 	}
 
 	QDir musicDir;
 	musicDir.setPath(QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
 	if (musicDir.exists())
 	{
-		addIfUnavailable(urls, musicDir.absolutePath());
+		addUnique(musicDir.absolutePath());
 	}
 
-	addIfUnavailable(urls, ConfigManager::inst()->workingDir());
+	addUnique(ConfigManager::inst()->workingDir());
 
 	// Add `/Volumes` directory on OS X systems, this allows the user to browse
 	// external disk drives.
 #ifdef LMMS_BUILD_APPLE
 	QDir volumesDir( QDir("/Volumes") );
 	if ( volumesDir.exists() )
-		addIfUnavailable(urls, volumesDir.absolutePath());
+		addUnique(volumesDir.absolutePath());
 #endif
 
 #ifdef LMMS_BUILD_LINUX
@@ -104,19 +103,13 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 
 		if (usableFileSystems.contains(QString(storage.fileSystemType()), Qt::CaseInsensitive) && storage.isValid() && storage.isReady())
 		{
-			addIfUnavailable(urls, storage.rootPath());
+			addUnique(storage.rootPath());
 		}
 	}
 #endif
 
 	setSidebarUrls(urls);
 }
-
-FileDialog::~FileDialog()
-{
-	setSidebarUrls(m_oldURLs);
-}
-
 
 QString FileDialog::getExistingDirectory(QWidget *parent,
 										const QString &caption,


### PR DESCRIPTION
 As #7405 states, all user-saved bookmarks/URLs on the sidebar is lost when LMMS launches the FileDialog, which affects other QT apps that share the same file dialog in the system.

This does:
1. Keep the original code, but load all the preexisting URLs and only insert to the sidebar the URLs that aren't there. Some users might have their own configuration and want it to stay that way, therefore we should keep all the original URLs. 
~~2. Store a list of the old URLs and restore them when the destructor of FileDialog is called.~~ *Removed, see [reason](https://github.com/LMMS/lmms/pull/7430#issuecomment-2282366259)*

I initially wanted to have FileDialog(...) open the sidebar as is, but that would mean removing the implementation the previous contributor intended.