### PR TITLE
Fix Bug with Continuous Autoscrolling when Smooth Scrolling is Enabled

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -774,7 +774,7 @@ void SongEditor::updatePosition( const TimePos & t )
 		}
 		else if (m_timeLine->autoScroll() == TimeLineWidget::AutoScrollState::Continuous)
 		{
-			animateScroll(m_leftRightScroll, std::max(t.getTicks() - w * TimePos::ticksPerBar() / pixelsPerBar() / 2, 0.0f), m_smoothScroll);
+			m_leftRightScroll->setValue(std::max(t.getTicks() - w * TimePos::ticksPerBar() / pixelsPerBar() / 2, 0.0f));
 		}
 		m_scrollBack = false;
 	}


### PR DESCRIPTION
Fixing a bug Gabrielxd195 pointed out, where enabling smooth scroll in the song editor causes the view to move at an uneven rate.

This is fixed by setting the scroll value directly through `m_leftRightScroll->setValue()` instead of using `animateScroll()`.

Also one thing I wanted to point out is that this means there will be no smooth scrolling for continuous autoscrolling whatsoever. So if the view needs to move a long distance to get to the current play position (like if you are editing the end of the song but then play it from the start), then it will do so instantly, without any smooth transition. That's probably fine for most people, but it means that the smooth scroll setting doesn't have any effect for continuous autoscrolling.