### PR TITLE
Do not put the main thread in realtime or high priority

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -43,10 +43,6 @@
 #include <windows.h>
 #endif
 
-#ifdef LMMS_HAVE_SCHED_H
-#include "sched.h"
-#endif
-
 #ifdef LMMS_HAVE_PROCESS_H
 #include <process.h>
 #endif

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -743,29 +743,6 @@ int main( int argc, char * * argv )
 	// override it with bundled/custom one, if exists
 	loadTranslation(QString("qt_") + pos, ConfigManager::inst()->localeDir());
 
-
-	// try to set realtime priority
-#if defined(LMMS_BUILD_LINUX) || defined(LMMS_BUILD_FREEBSD)
-#ifdef LMMS_HAVE_SCHED_H
-#ifndef __OpenBSD__
-	struct sched_param sparam;
-	sparam.sched_priority = ( sched_get_priority_max( SCHED_FIFO ) +
-				sched_get_priority_min( SCHED_FIFO ) ) / 2;
-	if( sched_setscheduler( 0, SCHED_FIFO, &sparam ) == -1 )
-	{
-		printf( "Notice: could not set realtime priority.\n" );
-	}
-#endif
-#endif // LMMS_HAVE_SCHED_H
-#endif
-
-#ifdef LMMS_BUILD_WIN32
-	if( !SetPriorityClass( GetCurrentProcess(), HIGH_PRIORITY_CLASS ) )
-	{
-		printf( "Notice: could not set high priority.\n" );
-	}
-#endif
-
 #if _POSIX_C_SOURCE >= 1 || _XOPEN_SOURCE || _POSIX_SOURCE
 	struct sigaction sa;
 	sa.sa_handler = SIG_IGN;


### PR DESCRIPTION
The main thread was set to run in real-time (or at high priority on Windows) to fix an annoying warning in 733491d36dd3783396bda501e88c7e542d8aed17. I'm not sure what warning would've popped up at the time that justifies doing something like this, but as of right now, this is definitely not something we should doing. The main thread has no business running in real-time and can potentially preempt the processing of the audio threads (which should actually be the threads at a higher priority) because Qt may want to do drawing.

Another major problem is that it seems like GNOME (maybe DE's or something else completely, not sure) enforce a limit on the amount of CPU time a real-time process can take. On my system, its 200ms. It shouldn't come as a surprise that the main thread needs a lot more time to do its work than that. It's allocating memory, loading up the `Engine`, loading plugins, etc. The problem with this is that if the main thread takes more than 200ms of CPU time at any given instance, it will be killed, causing the application to not even start.