### PR TITLE
WIP: mini fx rewrite without merge conflicts

### DIFF
--- a/include/Effect.h
+++ b/include/Effect.h
@@ -125,12 +125,6 @@ public:
 		return 1.0f - m_wetDryModel.value();
 	}
 
-	inline float gate() const
-	{
-		const float level = m_gateModel.value();
-		return level*level * m_processors;
-	}
-
 	inline f_cnt_t bufferCount() const
 	{
 		return m_bufferCount;
@@ -227,7 +221,6 @@ private:
 
 	BoolModel m_enabledModel;
 	FloatModel m_wetDryModel;
-	FloatModel m_gateModel;
 	TempoSyncKnobModel m_autoQuitModel;
 	
 	bool m_autoQuitDisabled;

--- a/include/EffectLabelButton.h
+++ b/include/EffectLabelButton.h
@@ -1,0 +1,55 @@
+/*
+ * EffectLabelButton.h - class trackLabelButton
+ *
+ * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_EFFECT_LABEL_BUTTON_H
+#define LMMS_GUI_EFFECT_LABEL_BUTTON_H
+
+#include <QPushButton>
+
+namespace lmms::gui
+{
+
+class EffectView;
+
+class EffectLabelButton : public QPushButton
+{
+	Q_OBJECT
+public:
+	EffectLabelButton( EffectView * _tv, QWidget * _parent );
+	~EffectLabelButton() override = default;
+
+protected:
+	void paintEvent(QPaintEvent* pe) override;
+
+private:
+	EffectView * m_effectView;
+	QString m_iconName;
+	QRect m_buttonRect;
+	QString elideName( const QString &name );
+} ;
+
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_EFFECT_LABEL_BUTTON_H

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -29,12 +29,16 @@
 #include "AutomatableModel.h"
 #include "PluginView.h"
 #include "Effect.h"
+#include "EffectLabelButton.h"
 
 class QGraphicsOpacityEffect;
 class QGroupBox;
 class QLabel;
 class QPushButton;
 class QMdiSubWindow;
+class QHBoxLayout;
+class QLabel;
+class QToolButton;
 
 namespace lmms::gui
 {
@@ -62,11 +66,13 @@ public:
 	}
 
 	static constexpr int DEFAULT_WIDTH = 215;
-	static constexpr int DEFAULT_HEIGHT = 60;
+	static constexpr int DEFAULT_HEIGHT = 35;
 	
 	void mouseMoveEvent(QMouseEvent* event) override;
 	void mousePressEvent(QMouseEvent* event) override;
 	void mouseReleaseEvent(QMouseEvent* event) override;
+
+	void setViewWidth(int px);
 
 public slots:
 	void editControls();
@@ -88,17 +94,19 @@ protected:
 
 
 private:
-	QPixmap m_bg;
+	QHBoxLayout* m_mainLayout;
 	LedCheckBox * m_bypass;
+	EffectLabelButton* m_label;
 	Knob * m_wetDry;
 	TempoSyncKnob * m_autoQuit;
-	Knob * m_gate;
 	QMdiSubWindow * m_subWindow;
 	EffectControlDialog * m_controlView;
 	
+	int m_viewWidth;
 	bool m_dragging;
 	QGraphicsOpacityEffect* m_opacityEffect;
 
+	friend class EffectLabelButton;
 } ;
 
 

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -50,7 +50,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_bufferCount( 0 ),
 	m_enabledModel( true, this, tr( "Effect enabled" ) ),
 	m_wetDryModel( 1.0f, -1.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
-	m_gateModel( 0.0f, 0.0f, 1.0f, 0.01f, this, tr( "Gate" ) ),
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
@@ -91,7 +90,6 @@ void Effect::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	m_enabledModel.saveSettings( _doc, _this, "on" );
 	m_wetDryModel.saveSettings( _doc, _this, "wet" );
 	m_autoQuitModel.saveSettings( _doc, _this, "autoquit" );
-	m_gateModel.saveSettings( _doc, _this, "gate" );
 	controls()->saveState( _doc, _this );
 }
 
@@ -103,7 +101,6 @@ void Effect::loadSettings( const QDomElement & _this )
 	m_enabledModel.loadSettings( _this, "on" );
 	m_wetDryModel.loadSettings( _this, "wet" );
 	m_autoQuitModel.loadSettings( _this, "autoquit" );
-	m_gateModel.loadSettings( _this, "gate" );
 
 	QDomNode node = _this.firstChild();
 	while( !node.isNull() )
@@ -146,19 +143,19 @@ Effect * Effect::instantiate( const QString& pluginName,
 
 
 
-void Effect::checkGate( double _out_sum )
+void Effect::checkGate(double _out_sum)
 {
-	if( m_autoQuitDisabled )
+	if(m_autoQuitDisabled)
 	{
 		return;
 	}
 
 	// Check whether we need to continue processing input.  Restart the
 	// counter if the threshold has been exceeded.
-	if (_out_sum - gate() <= F_EPSILON)
+	if (_out_sum <= F_EPSILON)
 	{
 		incrementBufferCount();
-		if( bufferCount() > timeout() )
+		if(bufferCount() > timeout())
 		{
 			stopRunning();
 			resetBufferCount();

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -103,6 +103,7 @@ SET(LMMS_SRCS
 	gui/widgets/CaptionMenu.cpp
 	gui/widgets/ComboBox.cpp
 	gui/widgets/CustomTextKnob.cpp
+	gui/widgets/EffectLabelButton.cpp
 	gui/widgets/Fader.cpp
 	gui/widgets/FloatModelEditorBase.cpp
 	gui/widgets/Graph.cpp

--- a/src/gui/widgets/EffectLabelButton.cpp
+++ b/src/gui/widgets/EffectLabelButton.cpp
@@ -1,0 +1,73 @@
+/*
+ * EffectLabelButton.cpp - implementation of class trackLabelButton, a label
+ *                          which is renamable by double-clicking it
+ *
+ * Copyright (c) 2004-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * 
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+
+#include "EffectLabelButton.h"
+
+#include <QMouseEvent>
+#include <QMdiSubWindow>
+
+#include "ConfigManager.h"
+#include "embed.h"
+#include "EffectView.h"
+#include "Effect.h"
+
+namespace lmms::gui
+{
+
+EffectLabelButton::EffectLabelButton( EffectView * _tv, QWidget * _parent ) :
+	QPushButton( _parent ),
+	m_effectView( _tv ),
+	m_iconName()
+{
+	setAttribute(Qt::WA_OpaquePaintEvent, true);
+	setAcceptDrops(false);
+
+	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
+	setStyleSheet("text-align:left;padding:2px;");
+
+	//setFixedSize( 160, 29 );
+	//setIconSize( QSize( 24, 24 ) );
+}
+
+void EffectLabelButton::paintEvent(QPaintEvent* pe)
+{
+	//setDown(!m_effectView->m_subWindow->isVisible());
+	QPushButton::paintEvent(pe);
+}
+
+QString EffectLabelButton::elideName( const QString &name )
+{
+	const int spacing = 16;
+	const int maxTextWidth = width() - spacing - iconSize().width();
+
+	setToolTip(name);
+
+	QFontMetrics metrics( font() );
+	QString elidedName = metrics.elidedText( name, Qt::ElideRight, maxTextWidth );
+	return elidedName;
+}
+
+} // namespace lmms::gui


### PR DESCRIPTION
Recent commits introduced some merge conflicts with #7242; this PR replaces that one. This PR also does not attempt to make the EffectView resizable or modify the wet/dry behavior and instead just focuses on UI improvements:
- Hide the auto quit decay knob if autoquit is disabled in settings.
- Remove the gate knob.
- Shrink the height of effects from 60px to 35px.
- Use the effect label itself as the button to open the controls rather than a separate button.

The new design in action:
![image](https://github.com/user-attachments/assets/741c6762-ed83-458c-9851-29bb4457a514)

This is mostly complete. Currently hunting down a small bug where the controls button stays in the "open" state even when you close the FX window, but this is likely an easy fix.

Replaces #7242.