### PR TITLE
Clean up PortAudio backend

### DIFF
--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -52,12 +52,26 @@ public:
 	ComboBoxModel m_deviceModel;
 };
 
-namespace gui
-{
+namespace gui {
+
 class ComboBox;
 class LcdSpinBox;
-}
 
+class AudioPortAudioSetupWidget : public gui::AudioDeviceSetupWidget
+{
+public:
+	AudioPortAudioSetupWidget(QWidget* _parent);
+	~AudioPortAudioSetupWidget() override;
+
+	void saveSettings() override;
+	void show() override;
+
+private:
+	ComboBox* m_backend;
+	ComboBox* m_device;
+	AudioPortAudioSetupUtil m_setupUtil;
+};
+} // namespace gui
 
 class AudioPortAudio : public AudioDevice
 {
@@ -71,22 +85,6 @@ public:
 	}
 
 	int process_callback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer);
-
-	class setupWidget : public gui::AudioDeviceSetupWidget
-	{
-	public:
-		setupWidget( QWidget * _parent );
-		~setupWidget() override;
-
-		void saveSettings() override;
-		void show() override;
-
-	private:
-		gui::ComboBox * m_backend;
-		gui::ComboBox * m_device;
-		AudioPortAudioSetupUtil m_setupUtil;
-
-	} ;
 
 private:
 	void startProcessing() override;

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -39,19 +39,6 @@
 namespace lmms
 {
 
-class AudioPortAudioSetupUtil : public QObject
-{
-Q_OBJECT
-public slots:
-	void updateBackends();
-	void updateDevices();
-	void updateChannels();
-
-public:
-	ComboBoxModel m_backendModel;
-	ComboBoxModel m_deviceModel;
-};
-
 namespace gui {
 
 class ComboBox;
@@ -63,13 +50,18 @@ public:
 	AudioPortAudioSetupWidget(QWidget* _parent);
 	~AudioPortAudioSetupWidget() override;
 
+	void updateBackends();
+	void updateDevices();
+	void updateChannels();
+
 	void saveSettings() override;
 	void show() override;
 
 private:
 	ComboBox* m_backend;
 	ComboBox* m_device;
-	AudioPortAudioSetupUtil m_setupUtil;
+	ComboBoxModel m_backendModel;
+	ComboBoxModel m_deviceModel;
 };
 } // namespace gui
 

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -68,7 +68,7 @@ private:
 class AudioPortAudio : public AudioDevice
 {
 public:
-	AudioPortAudio( bool & _success_ful, AudioEngine* audioEngine );
+	AudioPortAudio(bool& successful, AudioEngine* engine);
 	~AudioPortAudio() override;
 
 	inline static QString name()

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -25,26 +25,16 @@
 #ifndef LMMS_AUDIO_PORTAUDIO_H
 #define LMMS_AUDIO_PORTAUDIO_H
 
-#include <QObject>
-
 #include "lmmsconfig.h"
-#include "ComboBoxModel.h"
 
 #ifdef LMMS_HAVE_PORTAUDIO
 
-#   include <portaudio.h>
+#include <QObject>
+#include "ComboBoxModel.h"
 
-#   include "AudioDevice.h"
-#   include "AudioDeviceSetupWidget.h"
-
-#   if defined paNeverDropInput || defined paNonInterleaved
-#	    define PORTAUDIO_V19
-#   else
-#	    define PORTAUDIO_V18
-#   endif
-
-#endif
-
+#include <portaudio.h>
+#include "AudioDevice.h"
+#include "AudioDeviceSetupWidget.h"
 
 namespace lmms
 {
@@ -61,10 +51,6 @@ public:
 	ComboBoxModel m_backendModel;
 	ComboBoxModel m_deviceModel;
 };
-
-
-#ifdef LMMS_HAVE_PORTAUDIO
-
 
 namespace gui
 {
@@ -106,39 +92,11 @@ private:
 	void startProcessing() override;
 	void stopProcessing() override;
 
-#ifdef PORTAUDIO_V19
 	static int _process_callback( const void *_inputBuffer, void * _outputBuffer,
 		unsigned long _framesPerBuffer,
 		const PaStreamCallbackTimeInfo * _timeInfo,
 		PaStreamCallbackFlags _statusFlags,
 		void *arg );
-
-#else
-
-#define paContinue 0
-#define paComplete 1
-#define Pa_GetDeviceCount Pa_CountDevices
-#define Pa_GetDefaultInputDevice Pa_GetDefaultInputDeviceID
-#define Pa_GetDefaultOutputDevice Pa_GetDefaultOutputDeviceID
-#define Pa_IsStreamActive Pa_StreamActive
-
-	static int _process_callback( void * _inputBuffer, void * _outputBuffer,
-		unsigned long _framesPerBuffer, PaTimestamp _outTime, void * _arg );
-
-
-	using PaTime = double;
-	using PaDeviceIndex = PaDeviceID;
-
-	using PaStreamParameters = struct
-	{
-		PaDeviceIndex device;
-		int channelCount;
-		PaSampleFormat sampleFormat;
-		PaTime suggestedLatency;
-		void *hostApiSpecificStreamInfo;
-
-	} PaStreamParameters;
-#endif // PORTAUDIO_V19
 
 	PaStream * m_paStream;
 	PaStreamParameters m_outputParameters;

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -80,9 +80,9 @@ private:
 	void startProcessing() override;
 	void stopProcessing() override;
 
-	int processCallback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer);
-	static int processCallback(const void* _inputBuffer, void* _outputBuffer, unsigned long _framesPerBuffer,
-		const PaStreamCallbackTimeInfo* _timeInfo, PaStreamCallbackFlags _statusFlags, void* arg);
+	int processCallback(const float* inputBuffer, float* outputBuffer, f_cnt_t framesPerBuffer);
+	static int processCallback(const void* inputBuffer, void* outputBuffer, unsigned long framesPerBuffer,
+		const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* arg);
 
 	PaStream * m_paStream;
 	PaStreamParameters m_outputParameters;

--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -84,17 +84,13 @@ public:
 		return QT_TRANSLATE_NOOP( "AudioDeviceSetupWidget", "PortAudio" );
 	}
 
-	int process_callback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer);
-
 private:
 	void startProcessing() override;
 	void stopProcessing() override;
 
-	static int _process_callback( const void *_inputBuffer, void * _outputBuffer,
-		unsigned long _framesPerBuffer,
-		const PaStreamCallbackTimeInfo * _timeInfo,
-		PaStreamCallbackFlags _statusFlags,
-		void *arg );
+	int processCallback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer);
+	static int processCallback(const void* _inputBuffer, void* _outputBuffer, unsigned long _framesPerBuffer,
+		const PaStreamCallbackTimeInfo* _timeInfo, PaStreamCallbackFlags _statusFlags, void* arg);
 
 	PaStream * m_paStream;
 	PaStreamParameters m_outputParameters;

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -112,7 +112,7 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 	m_inputParameters.hostApiSpecificStreamInfo = nullptr;
 
 	err = Pa_OpenStream(&m_paStream, supportsCapture() ? &m_inputParameters : nullptr, &m_outputParameters,
-		sampleRate(), samples, paNoFlag, _process_callback, this);
+		sampleRate(), samples, paNoFlag, processCallback, this);
 
 	if( err == paInvalidDevice && sampleRate() < 48000 )
 	{
@@ -120,15 +120,8 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 		// some backends or drivers do not allow 32 bit floating point data
 		// with a samplerate of 44100 Hz
 		setSampleRate( 48000 );
-		err = Pa_OpenStream(
-				&m_paStream,
-				supportsCapture() ? &m_inputParameters : nullptr,
-				&m_outputParameters,
-				sampleRate(),
-				samples,
-				paNoFlag,
-				_process_callback, 
-				this );
+		err = Pa_OpenStream(&m_paStream, supportsCapture() ? &m_inputParameters : nullptr, &m_outputParameters,
+			sampleRate(), samples, paNoFlag, processCallback, this);
 	}
 
 	if( err != paNoError )
@@ -190,7 +183,7 @@ void AudioPortAudio::stopProcessing()
 }
 
 
-int AudioPortAudio::process_callback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer)
+int AudioPortAudio::processCallback(const float* _inputBuffer, float* _outputBuffer, f_cnt_t _framesPerBuffer)
 {
 	if( supportsCapture() )
 	{
@@ -239,7 +232,7 @@ int AudioPortAudio::process_callback(const float* _inputBuffer, float* _outputBu
 
 
 
-int AudioPortAudio::_process_callback(
+int AudioPortAudio::processCallback(
 	const void *_inputBuffer,
 	void * _outputBuffer,
 	unsigned long _framesPerBuffer,
@@ -251,8 +244,7 @@ int AudioPortAudio::_process_callback(
 	Q_UNUSED(_statusFlags);
 
 	auto _this = static_cast<AudioPortAudio*>(_arg);
-	return _this->process_callback( (const float*)_inputBuffer,
-		(float*)_outputBuffer, _framesPerBuffer );
+	return _this->processCallback((const float*)_inputBuffer, (float*)_outputBuffer, _framesPerBuffer);
 }
 
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -323,11 +323,8 @@ void AudioPortAudioSetupUtil::updateChannels()
 	Pa_Terminate();
 }
 
-
-
-
-AudioPortAudio::setupWidget::setupWidget( QWidget * _parent ) :
-	AudioDeviceSetupWidget( AudioPortAudio::name(), _parent )
+gui::AudioPortAudioSetupWidget::AudioPortAudioSetupWidget(QWidget* _parent)
+	: AudioDeviceSetupWidget(AudioPortAudio::name(), _parent)
 {
 	using gui::ComboBox;
 
@@ -352,7 +349,7 @@ AudioPortAudio::setupWidget::setupWidget( QWidget * _parent ) :
 
 
 
-AudioPortAudio::setupWidget::~setupWidget()
+gui::AudioPortAudioSetupWidget::~AudioPortAudioSetupWidget()
 {
 	disconnect( &m_setupUtil.m_backendModel, SIGNAL(dataChanged()),
 			&m_setupUtil, SLOT(updateDevices()));
@@ -364,7 +361,7 @@ AudioPortAudio::setupWidget::~setupWidget()
 
 
 
-void AudioPortAudio::setupWidget::saveSettings()
+void gui::AudioPortAudioSetupWidget::saveSettings()
 {
 	ConfigManager::inst()->setValue( "audioportaudio", "backend",
 							m_setupUtil.m_backendModel.currentText() );
@@ -375,7 +372,7 @@ void AudioPortAudio::setupWidget::saveSettings()
 
 
 
-void AudioPortAudio::setupWidget::show()
+void gui::AudioPortAudioSetupWidget::show()
 {
 	if( m_setupUtil.m_backendModel.size() == 0 )
 	{

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -250,7 +250,7 @@ int AudioPortAudio::processCallback(
 
 
 
-void AudioPortAudioSetupUtil::updateBackends()
+void gui::AudioPortAudioSetupWidget::updateBackends()
 {
 	PaError err = Pa_Initialize();
 	if( err != paNoError ) {
@@ -270,7 +270,7 @@ void AudioPortAudioSetupUtil::updateBackends()
 
 
 
-void AudioPortAudioSetupUtil::updateDevices()
+void gui::AudioPortAudioSetupWidget::updateDevices()
 {
 	PaError err = Pa_Initialize();
 	if( err != paNoError ) {
@@ -305,7 +305,7 @@ void AudioPortAudioSetupUtil::updateDevices()
 
 
 
-void AudioPortAudioSetupUtil::updateChannels()
+void gui::AudioPortAudioSetupWidget::updateChannels()
 {
 	PaError err = Pa_Initialize();
 	if( err != paNoError ) {
@@ -328,14 +328,11 @@ gui::AudioPortAudioSetupWidget::AudioPortAudioSetupWidget(QWidget* _parent)
 	m_device = new ComboBox( this, "DEVICE" );
 	form->addRow(tr("Device"), m_device);
 
-	connect( &m_setupUtil.m_backendModel, SIGNAL(dataChanged()),
-			&m_setupUtil, SLOT(updateDevices()));
-			
-	connect( &m_setupUtil.m_deviceModel, SIGNAL(dataChanged()),
-			&m_setupUtil, SLOT(updateChannels()));
-			
-	m_backend->setModel( &m_setupUtil.m_backendModel );
-	m_device->setModel( &m_setupUtil.m_deviceModel );
+	connect(&m_backendModel, &ComboBoxModel::dataChanged, this, &AudioPortAudioSetupWidget::updateDevices);
+	connect(&m_deviceModel, &ComboBoxModel::dataChanged, this, &AudioPortAudioSetupWidget::updateChannels);
+
+	m_backend->setModel(&m_backendModel);
+	m_device->setModel(&m_deviceModel);
 }
 
 
@@ -343,11 +340,8 @@ gui::AudioPortAudioSetupWidget::AudioPortAudioSetupWidget(QWidget* _parent)
 
 gui::AudioPortAudioSetupWidget::~AudioPortAudioSetupWidget()
 {
-	disconnect( &m_setupUtil.m_backendModel, SIGNAL(dataChanged()),
-			&m_setupUtil, SLOT(updateDevices()));
-			
-	disconnect( &m_setupUtil.m_deviceModel, SIGNAL(dataChanged()),
-			&m_setupUtil, SLOT(updateChannels()));
+	disconnect(&m_backendModel, &ComboBoxModel::dataChanged, this, &AudioPortAudioSetupWidget::updateDevices);
+	disconnect(&m_deviceModel, &ComboBoxModel::dataChanged, this, &AudioPortAudioSetupWidget::updateChannels);
 }
 
 
@@ -355,10 +349,8 @@ gui::AudioPortAudioSetupWidget::~AudioPortAudioSetupWidget()
 
 void gui::AudioPortAudioSetupWidget::saveSettings()
 {
-	ConfigManager::inst()->setValue( "audioportaudio", "backend",
-							m_setupUtil.m_backendModel.currentText() );
-	ConfigManager::inst()->setValue( "audioportaudio", "device",
-							m_setupUtil.m_deviceModel.currentText() );
+	ConfigManager::inst()->setValue("audioportaudio", "backend", m_backendModel.currentText());
+	ConfigManager::inst()->setValue("audioportaudio", "device", m_deviceModel.currentText());
 }
 
 
@@ -366,23 +358,23 @@ void gui::AudioPortAudioSetupWidget::saveSettings()
 
 void gui::AudioPortAudioSetupWidget::show()
 {
-	if( m_setupUtil.m_backendModel.size() == 0 )
+	if (m_backendModel.size() == 0)
 	{
 		// populate the backend model the first time we are shown
-		m_setupUtil.updateBackends();
+		updateBackends();
 
 		const QString& backend = ConfigManager::inst()->value(
 			"audioportaudio", "backend" );
 		const QString& device = ConfigManager::inst()->value(
 			"audioportaudio", "device" );
-		
-		int i = std::max(0, m_setupUtil.m_backendModel.findText(backend));
-		m_setupUtil.m_backendModel.setValue( i );
-		
-		m_setupUtil.updateDevices();
-		
-		i = std::max(0, m_setupUtil.m_deviceModel.findText(device));
-		m_setupUtil.m_deviceModel.setValue( i );
+
+		int i = std::max(0, m_backendModel.findText(backend));
+		m_backendModel.setValue(i);
+
+		updateDevices();
+
+		i = std::max(0, m_deviceModel.findText(device));
+		m_deviceModel.setValue(i);
 	}
 
 	AudioDeviceSetupWidget::show();

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -26,27 +26,6 @@
 
 #include "AudioPortAudio.h"
 
-#ifndef LMMS_HAVE_PORTAUDIO
-namespace lmms
-{
-
-
-void AudioPortAudioSetupUtil::updateBackends()
-{
-}
-
-void AudioPortAudioSetupUtil::updateDevices()
-{
-}
-
-void AudioPortAudioSetupUtil::updateChannels()
-{
-}
-
-
-} // namespace lmms
-#endif
-
 #ifdef LMMS_HAVE_PORTAUDIO
 
 #include <QFormLayout>

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -38,19 +38,16 @@
 namespace lmms
 {
 
-
-AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine ) :
-	AudioDevice(std::clamp<ch_cnt_t>(
-		ConfigManager::inst()->value("audioportaudio", "channels").toInt(),
-		DEFAULT_CHANNELS,
-		DEFAULT_CHANNELS), _audioEngine),
-	m_paStream( nullptr ),
-	m_wasPAInitError( false ),
-	m_outBuf(new SampleFrame[audioEngine()->framesPerPeriod()]),
-	m_outBufPos( 0 )
+AudioPortAudio::AudioPortAudio(bool& successful, AudioEngine* engine)
+	: AudioDevice(std::clamp<ch_cnt_t>(ConfigManager::inst()->value("audioportaudio", "channels").toInt(),
+					  DEFAULT_CHANNELS, DEFAULT_CHANNELS),
+		  engine)
+	, m_paStream(nullptr)
+	, m_wasPAInitError(false)
+	, m_outBuf(new SampleFrame[audioEngine()->framesPerPeriod()])
+	, m_outBufPos(0)
 {
-	_success_ful = false;
-
+	successful = false;
 	m_outBufSize = audioEngine()->framesPerPeriod();
 
 	PaError err = Pa_Initialize();
@@ -133,7 +130,7 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 	printf( "Input device: '%s' backend: '%s'\n", Pa_GetDeviceInfo( inDevIdx )->name, Pa_GetHostApiInfo( Pa_GetDeviceInfo( inDevIdx )->hostApi )->name );
 	printf( "Output device: '%s' backend: '%s'\n", Pa_GetDeviceInfo( outDevIdx )->name, Pa_GetHostApiInfo( Pa_GetDeviceInfo( outDevIdx )->hostApi )->name );
 
-	_success_ful = true;
+	successful = true;
 }
 
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -120,30 +120,20 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 
 	const int samples = audioEngine()->framesPerPeriod();
 	
-	// Configure output parameters.
 	m_outputParameters.device = outDevIdx;
 	m_outputParameters.channelCount = channels();
-	m_outputParameters.sampleFormat = paFloat32; // 32 bit floating point output
+	m_outputParameters.sampleFormat = paFloat32;
 	m_outputParameters.suggestedLatency = Pa_GetDeviceInfo(outDevIdx)->defaultLowOutputLatency;
 	m_outputParameters.hostApiSpecificStreamInfo = nullptr;
 
-	// Configure input parameters.
 	m_inputParameters.device = inDevIdx;
 	m_inputParameters.channelCount = DEFAULT_CHANNELS;
-	m_inputParameters.sampleFormat = paFloat32; // 32 bit floating point input
+	m_inputParameters.sampleFormat = paFloat32;
 	m_inputParameters.suggestedLatency = Pa_GetDeviceInfo(inDevIdx)->defaultLowInputLatency;
 	m_inputParameters.hostApiSpecificStreamInfo = nullptr;
-	
-	// Open an audio I/O stream. 
-	err = Pa_OpenStream(
-			&m_paStream,
-			supportsCapture() ? &m_inputParameters : nullptr,	// The input parameter
-			&m_outputParameters,	// The outputparameter
-			sampleRate(),
-			samples,
-			paNoFlag,		// Don't use any flags
-			_process_callback, 	// our callback function
-			this );
+
+	err = Pa_OpenStream(&m_paStream, supportsCapture() ? &m_inputParameters : nullptr, &m_outputParameters,
+		sampleRate(), samples, paNoFlag, _process_callback, this);
 
 	if( err == paInvalidDevice && sampleRate() < 48000 )
 	{
@@ -153,12 +143,12 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 		setSampleRate( 48000 );
 		err = Pa_OpenStream(
 				&m_paStream,
-				supportsCapture() ? &m_inputParameters : nullptr,	// The input parameter
-				&m_outputParameters,	// The outputparameter
+				supportsCapture() ? &m_inputParameters : nullptr,
+				&m_outputParameters,
 				sampleRate(),
 				samples,
-				paNoFlag,		// Don't use any flags
-				_process_callback, 	// our callback function
+				paNoFlag,
+				_process_callback, 
 				this );
 	}
 
@@ -170,9 +160,6 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 
 	printf( "Input device: '%s' backend: '%s'\n", Pa_GetDeviceInfo( inDevIdx )->name, Pa_GetHostApiInfo( Pa_GetDeviceInfo( inDevIdx )->hostApi )->name );
 	printf( "Output device: '%s' backend: '%s'\n", Pa_GetDeviceInfo( outDevIdx )->name, Pa_GetHostApiInfo( Pa_GetDeviceInfo( outDevIdx )->hostApi )->name );
-
-	// TODO: debug AudioEngine::pushInputFrames()
-	//m_supportsCapture = true;
 
 	_success_ful = true;
 }
@@ -242,7 +229,6 @@ int AudioPortAudio::process_callback(const float* _inputBuffer, float* _outputBu
 	{
 		if( m_outBufPos == 0 )
 		{
-			// frames depend on the sample rate
 			const fpp_t frames = getNextBuffer( m_outBuf );
 			if( !frames )
 			{
@@ -321,7 +307,6 @@ void AudioPortAudioSetupUtil::updateDevices()
 		return;
 	}
 
-	// get active backend 
 	const QString& backend = m_backendModel.currentText();
 	int hostApi = 0;
 	for( int i = 0; i < Pa_GetHostApiCount(); ++i )
@@ -334,7 +319,6 @@ void AudioPortAudioSetupUtil::updateDevices()
 		}
 	}
 
-	// get devices for selected backend
 	m_deviceModel.clear();
 	for( int i = 0; i < Pa_GetDeviceCount(); ++i )
 	{
@@ -357,7 +341,6 @@ void AudioPortAudioSetupUtil::updateChannels()
 		printf( "Couldn't initialize PortAudio: %s\n", Pa_GetErrorText( err ) );
 		return;
 	}
-	// get active backend 
 	Pa_Terminate();
 }
 
@@ -376,17 +359,6 @@ AudioPortAudio::setupWidget::setupWidget( QWidget * _parent ) :
 
 	m_device = new ComboBox( this, "DEVICE" );
 	form->addRow(tr("Device"), m_device);
-	
-/*	LcdSpinBoxModel * m = new LcdSpinBoxModel(  );
-	m->setRange( DEFAULT_CHANNELS, DEFAULT_CHANNELS );
-	m->setStep( 2 );
-	m->setValue( ConfigManager::inst()->value( "audioportaudio",
-							"channels" ).toInt() );
-
-	m_channels = new LcdSpinBox( 1, this );
-	m_channels->setModel( m );
-	m_channels->setLabel( tr( "Channels" ) );
-	m_channels->move( 308, 20 );*/
 
 	connect( &m_setupUtil.m_backendModel, SIGNAL(dataChanged()),
 			&m_setupUtil, SLOT(updateDevices()));
@@ -415,14 +387,10 @@ AudioPortAudio::setupWidget::~setupWidget()
 
 void AudioPortAudio::setupWidget::saveSettings()
 {
-
 	ConfigManager::inst()->setValue( "audioportaudio", "backend",
 							m_setupUtil.m_backendModel.currentText() );
 	ConfigManager::inst()->setValue( "audioportaudio", "device",
 							m_setupUtil.m_deviceModel.currentText() );
-/*	ConfigManager::inst()->setValue( "audioportaudio", "channels",
-				QString::number( m_channels->value<int>() ) );*/
-
 }
 
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -118,25 +118,20 @@ AudioPortAudio::AudioPortAudio( bool & _success_ful, AudioEngine * _audioEngine 
 		return;
 	}
 
-	double inLatency = 0;//(double)audioEngine()->framesPerPeriod() / (double)sampleRate();
-	double outLatency = 0;//(double)audioEngine()->framesPerPeriod() / (double)sampleRate();
-
-	//inLatency = Pa_GetDeviceInfo( inDevIdx )->defaultLowInputLatency;
-	//outLatency = Pa_GetDeviceInfo( outDevIdx )->defaultLowOutputLatency;
 	const int samples = audioEngine()->framesPerPeriod();
 	
 	// Configure output parameters.
 	m_outputParameters.device = outDevIdx;
 	m_outputParameters.channelCount = channels();
 	m_outputParameters.sampleFormat = paFloat32; // 32 bit floating point output
-	m_outputParameters.suggestedLatency = outLatency;
+	m_outputParameters.suggestedLatency = Pa_GetDeviceInfo(outDevIdx)->defaultLowOutputLatency;
 	m_outputParameters.hostApiSpecificStreamInfo = nullptr;
-	
+
 	// Configure input parameters.
 	m_inputParameters.device = inDevIdx;
 	m_inputParameters.channelCount = DEFAULT_CHANNELS;
 	m_inputParameters.sampleFormat = paFloat32; // 32 bit floating point input
-	m_inputParameters.suggestedLatency = inLatency;
+	m_inputParameters.suggestedLatency = Pa_GetDeviceInfo(inDevIdx)->defaultLowInputLatency;
 	m_inputParameters.hostApiSpecificStreamInfo = nullptr;
 	
 	// Open an audio I/O stream. 

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -496,7 +496,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 
 #ifdef LMMS_HAVE_PORTAUDIO
 	m_audioIfaceSetupWidgets[AudioPortAudio::name()] =
-			new AudioPortAudio::setupWidget(as_w);
+			new AudioPortAudioSetupWidget(as_w);
 #endif
 
 #ifdef LMMS_HAVE_SOUNDIO


### PR DESCRIPTION
Fixes a latency bug caused by suggesting the wrong (supposedly?) latency to PortAudio, which caused stuttering on certain occasions. We now fetch an appropriate latency for the device using `PaDeviceInfo::defaultLowInputLatency` and `PaDeviceInfo::defaultLowOutputLatency`.

Also cleaned up the code a bit. Moved the GUI specific widget code in the GUI namespace, completely removed the PortAudio v18 code, among other things.

Testing on Windows will be appreciated. I am curious to see if this fixed any issues relating to PortAudio for anyone else.