### PR TITLE
Do not save MIDI connections in presets

### DIFF
--- a/include/AutomationTrack.h
+++ b/include/AutomationTrack.h
@@ -50,8 +50,7 @@ public:
 	gui::TrackView * createView( gui::TrackContainerView* ) override;
 	Clip* createClip(const TimePos & pos) override;
 
-	void saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _parent ) override;
+	void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
 private:

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -137,6 +137,9 @@ public:
 							QDomElement & _parent ) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
+	void savePreset(QDomDocument & doc, QDomElement & element);
+	void loadPreset(const QDomElement & element);
+
 	using Track::setJournalling;
 
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -133,8 +133,7 @@ public:
 
 
 	// called by track
-	void saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _parent ) override;
+	void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
 	void savePreset(QDomDocument & doc, QDomElement & element);

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -136,9 +136,6 @@ public:
 	void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
-	void savePreset(QDomDocument & doc, QDomElement & element);
-	void loadPreset(const QDomElement & element);
-
 	using Track::setJournalling;
 
 

--- a/include/PatternTrack.h
+++ b/include/PatternTrack.h
@@ -57,8 +57,7 @@ public:
 	gui::TrackView * createView( gui::TrackContainerView* tcv ) override;
 	Clip* createClip(const TimePos & pos) override;
 
-	void saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _parent ) override;
+	void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
 	static PatternTrack* findPatternTrack(int pattern_num);

--- a/include/SampleTrack.h
+++ b/include/SampleTrack.h
@@ -54,8 +54,7 @@ public:
 	Clip* createClip(const TimePos & pos) override;
 
 
-	void saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _parent ) override;
+	void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) override;
 	void loadTrackSpecificSettings( const QDomElement & _this ) override;
 
 	inline IntModel * mixerChannelModel()

--- a/include/Track.h
+++ b/include/Track.h
@@ -206,10 +206,9 @@ public slots:
 
 protected:
 	bool isPresetMode() const { return m_presetMode; }
-	void setPresetMode(bool presetMode = true)
-	{
-		m_presetMode = presetMode;
-	}
+
+protected:
+	bool m_presetMode = false;
 
 private:
 	TrackContainer* m_trackContainer;
@@ -223,8 +222,6 @@ protected:
 private:
 	BoolModel m_soloModel;
 	bool m_mutedBeforeSolo;
-
-	bool m_presetMode = false;
 
 	clipVector m_clips;
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -210,10 +210,7 @@ public slots:
 	void toggleSolo();
 
 protected:
-	bool isPresetMode() const
-	{
-		return m_presetMode;
-	}
+	bool isPresetMode() const { return m_presetMode; }
 
 private:
 	TrackContainer* m_trackContainer;
@@ -228,7 +225,7 @@ private:
 	BoolModel m_soloModel;
 	bool m_mutedBeforeSolo;
 
-	bool m_presetMode;
+	bool m_presetMode = false;
 
 	clipVector m_clips;
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -115,9 +115,9 @@ public:
 	void saveSettings( QDomDocument & doc, QDomElement & element ) override;
 	void loadSettings( const QDomElement & element ) override;
 
-	void setSimpleSerializing()
+	void setSimpleSerializing(bool simpleSerializing = true)
 	{
-		m_simpleSerializingMode = true;
+		m_simpleSerializingMode = simpleSerializing;
 	}
 
 	// -- for usage by Clip only ---------------

--- a/include/Track.h
+++ b/include/Track.h
@@ -115,11 +115,6 @@ public:
 	void saveSettings( QDomDocument & doc, QDomElement & element ) override;
 	void loadSettings( const QDomElement & element ) override;
 
-	void setPresetMode(bool presetMode = true)
-	{
-		m_presetMode = presetMode;
-	}
-
 	// -- for usage by Clip only ---------------
 	Clip * addClip( Clip * clip );
 	void removeClip( Clip * clip );
@@ -211,6 +206,10 @@ public slots:
 
 protected:
 	bool isPresetMode() const { return m_presetMode; }
+	void setPresetMode(bool presetMode = true)
+	{
+		m_presetMode = presetMode;
+	}
 
 private:
 	TrackContainer* m_trackContainer;

--- a/include/Track.h
+++ b/include/Track.h
@@ -107,11 +107,12 @@ public:
 	virtual gui::TrackView * createView( gui::TrackContainerView * view ) = 0;
 	virtual Clip * createClip( const TimePos & pos ) = 0;
 
-	virtual void saveTrackSpecificSettings( QDomDocument & doc,
-						QDomElement & parent ) = 0;
+	virtual void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) = 0;
 	virtual void loadTrackSpecificSettings( const QDomElement & element ) = 0;
 
 
+	void saveTrack(QDomDocument& doc, QDomElement& element, bool presetMode);
+	void loadTrack(const QDomElement& element, bool presetMode);
 	void saveSettings( QDomDocument & doc, QDomElement & element ) override;
 	void loadSettings( const QDomElement & element ) override;
 
@@ -203,12 +204,6 @@ public slots:
 	}
 
 	void toggleSolo();
-
-protected:
-	bool isPresetMode() const { return m_presetMode; }
-
-protected:
-	bool m_presetMode = false;
 
 private:
 	TrackContainer* m_trackContainer;

--- a/include/Track.h
+++ b/include/Track.h
@@ -115,9 +115,9 @@ public:
 	void saveSettings( QDomDocument & doc, QDomElement & element ) override;
 	void loadSettings( const QDomElement & element ) override;
 
-	void setSimpleSerializing(bool simpleSerializing = true)
+	void setPresetMode(bool presetMode = true)
 	{
-		m_simpleSerializingMode = simpleSerializing;
+		m_presetMode = presetMode;
 	}
 
 	// -- for usage by Clip only ---------------
@@ -210,9 +210,9 @@ public slots:
 	void toggleSolo();
 
 protected:
-	bool isSimpleSerializing() const
+	bool isPresetMode() const
 	{
-		return m_simpleSerializingMode;
+		return m_presetMode;
 	}
 
 private:
@@ -228,7 +228,7 @@ private:
 	BoolModel m_soloModel;
 	bool m_mutedBeforeSolo;
 
-	bool m_simpleSerializingMode;
+	bool m_presetMode;
 
 	clipVector m_clips;
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -110,9 +110,11 @@ public:
 	virtual void saveTrackSpecificSettings(QDomDocument& doc, QDomElement& parent, bool presetMode) = 0;
 	virtual void loadTrackSpecificSettings( const QDomElement & element ) = 0;
 
+	// Saving and loading of presets which do not necessarily contain all the track information
+	void savePreset(QDomDocument & doc, QDomElement & element);
+	void loadPreset(const QDomElement & element);
 
-	void saveTrack(QDomDocument& doc, QDomElement& element, bool presetMode);
-	void loadTrack(const QDomElement& element, bool presetMode);
+	// Saving and loading of full tracks
 	void saveSettings( QDomDocument & doc, QDomElement & element ) override;
 	void loadSettings( const QDomElement & element ) override;
 
@@ -204,6 +206,10 @@ public slots:
 	}
 
 	void toggleSolo();
+
+private:
+	void saveTrack(QDomDocument& doc, QDomElement& element, bool presetMode);
+	void loadTrack(const QDomElement& element, bool presetMode);
 
 private:
 	TrackContainer* m_trackContainer;

--- a/include/Track.h
+++ b/include/Track.h
@@ -209,6 +209,12 @@ public slots:
 
 	void toggleSolo();
 
+protected:
+	bool isSimpleSerializing() const
+	{
+		return m_simpleSerializingMode;
+	}
+
 private:
 	TrackContainer* m_trackContainer;
 	Type m_type;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -63,7 +63,7 @@ Track::Track( Type type, TrackContainer * tc ) :
 	m_name(),                       /*!< The track's name */
 	m_mutedModel( false, this, tr( "Mute" ) ), /*!< For controlling track muting */
 	m_soloModel( false, this, tr( "Solo" ) ), /*!< For controlling track soloing */
-	m_simpleSerializingMode( false ),
+	m_presetMode( false ),
 	m_clips()        /*!< The clips (segments) */
 {	
 	m_trackContainer->addTrack( this );
@@ -191,7 +191,7 @@ Track* Track::clone()
  */
 void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 {
-	if (!isSimpleSerializing())
+	if (!isPresetMode())
 	{
 		element.setTagName( "track" );
 	}
@@ -217,9 +217,9 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	element.appendChild( tsDe );
 	saveTrackSpecificSettings( doc, tsDe );
 
-	if (isSimpleSerializing())
+	if (isPresetMode())
 	{
-		setSimpleSerializing(false);
+		setPresetMode(false);
 		return;
 	}
 
@@ -267,7 +267,7 @@ void Track::loadSettings( const QDomElement & element )
 		setColor(QColor{element.attribute("color")});
 	}
 
-	if (isSimpleSerializing())
+	if (isPresetMode())
 	{
 		QDomNode node = element.firstChild();
 		while( !node.isNull() )
@@ -280,7 +280,7 @@ void Track::loadSettings( const QDomElement & element )
 			node = node.nextSibling();
 		}
 
-		setSimpleSerializing(false);
+		setPresetMode(false);
 
 		return;
 	}

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -63,7 +63,6 @@ Track::Track( Type type, TrackContainer * tc ) :
 	m_name(),                       /*!< The track's name */
 	m_mutedModel( false, this, tr( "Mute" ) ), /*!< For controlling track muting */
 	m_soloModel( false, this, tr( "Solo" ) ), /*!< For controlling track soloing */
-	m_presetMode(false),
 	m_clips()        /*!< The clips (segments) */
 {	
 	m_trackContainer->addTrack( this );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -218,7 +218,7 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 
 	if (isPresetMode())
 	{
-		setPresetMode(false);
+		// No need to unset preset mode here as this will done by the guard in InstrumentTrack::savePreset
 		return;
 	}
 
@@ -279,7 +279,7 @@ void Track::loadSettings( const QDomElement & element )
 			node = node.nextSibling();
 		}
 
-		setPresetMode(false);
+		// No need to unset preset mode here as this will done by the guard in InstrumentTrack::loadPreset
 
 		return;
 	}

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -309,13 +309,25 @@ void Track::loadTrack(const QDomElement& element, bool presetMode)
 	}
 }
 
+void Track::savePreset(QDomDocument & doc, QDomElement & element)
+{
+	saveTrack(doc, element, true);
+}
+
+void Track::loadPreset(const QDomElement & element)
+{
+	loadTrack(element, true);
+}
+
 void Track::saveSettings(QDomDocument& doc, QDomElement& element)
 {
+	// Assume that everything should be saved if we are called through SerializingObject::saveSettings
 	saveTrack(doc, element, false);
 }
 
 void Track::loadSettings(const QDomElement& element)
 {
+	// Assume that everything should be loaded if we are called through SerializingObject::loadSettings 
 	loadTrack(element, false);
 }
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -191,7 +191,7 @@ Track* Track::clone()
  */
 void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 {
-	if( !m_simpleSerializingMode )
+	if (!isSimpleSerializing())
 	{
 		element.setTagName( "track" );
 	}
@@ -217,9 +217,9 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	element.appendChild( tsDe );
 	saveTrackSpecificSettings( doc, tsDe );
 
-	if( m_simpleSerializingMode )
+	if (isSimpleSerializing())
 	{
-		m_simpleSerializingMode = false;
+		setSimpleSerializing(false);
 		return;
 	}
 
@@ -267,7 +267,7 @@ void Track::loadSettings( const QDomElement & element )
 		setColor(QColor{element.attribute("color")});
 	}
 
-	if( m_simpleSerializingMode )
+	if (isSimpleSerializing())
 	{
 		QDomNode node = element.firstChild();
 		while( !node.isNull() )
@@ -279,7 +279,9 @@ void Track::loadSettings( const QDomElement & element )
 			}
 			node = node.nextSibling();
 		}
-		m_simpleSerializingMode = false;
+
+		setSimpleSerializing(false);
+
 		return;
 	}
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -63,7 +63,7 @@ Track::Track( Type type, TrackContainer * tc ) :
 	m_name(),                       /*!< The track's name */
 	m_mutedModel( false, this, tr( "Mute" ) ), /*!< For controlling track muting */
 	m_soloModel( false, this, tr( "Solo" ) ), /*!< For controlling track soloing */
-	m_presetMode( false ),
+	m_presetMode(false),
 	m_clips()        /*!< The clips (segments) */
 {	
 	m_trackContainer->addTrack( this );

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -173,10 +173,6 @@ Track* Track::clone()
 }
 
 
-
-
-
-
 /*! \brief Save this track's settings to file
  *
  *  We save the track type and its muted state and solo state, then append the track-
@@ -185,12 +181,13 @@ Track* Track::clone()
  *
  *  \param doc The QDomDocument to use to save
  *  \param element The The QDomElement to save into
+ *  \param presetMode Describes whether to save the track as a preset or not.
  *  \todo Does this accurately describe the parameters?  I think not!?
  *  \todo Save the track height
  */
-void Track::saveSettings( QDomDocument & doc, QDomElement & element )
+void Track::saveTrack(QDomDocument& doc, QDomElement& element, bool presetMode)
 {
-	if (!isPresetMode())
+	if (!presetMode)
 	{
 		element.setTagName( "track" );
 	}
@@ -214,11 +211,10 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 	QDomElement tsDe = doc.createElement( nodeName() );
 	// let actual track (InstrumentTrack, PatternTrack, SampleTrack etc.) save its settings
 	element.appendChild( tsDe );
-	saveTrackSpecificSettings( doc, tsDe );
+	saveTrackSpecificSettings(doc, tsDe, presetMode);
 
-	if (isPresetMode())
+	if (presetMode)
 	{
-		// No need to unset preset mode here as this will done by the guard in InstrumentTrack::savePreset
 		return;
 	}
 
@@ -228,9 +224,6 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
 		clip->saveState(doc, element);
 	}
 }
-
-
-
 
 /*! \brief Load the settings from a file
  *
@@ -242,9 +235,10 @@ void Track::saveSettings( QDomDocument & doc, QDomElement & element )
  *  one at a time.
  *
  *  \param element the QDomElement to load track settings from
+ *  \param presetMode Indicates if a preset or a full track is loaded
  *  \todo Load the track height.
  */
-void Track::loadSettings( const QDomElement & element )
+void Track::loadTrack(const QDomElement& element, bool presetMode)
 {
 	if( static_cast<Type>(element.attribute( "type" ).toInt()) != type() )
 	{
@@ -266,7 +260,7 @@ void Track::loadSettings( const QDomElement & element )
 		setColor(QColor{element.attribute("color")});
 	}
 
-	if (isPresetMode())
+	if (presetMode)
 	{
 		QDomNode node = element.firstChild();
 		while( !node.isNull() )
@@ -278,8 +272,6 @@ void Track::loadSettings( const QDomElement & element )
 			}
 			node = node.nextSibling();
 		}
-
-		// No need to unset preset mode here as this will done by the guard in InstrumentTrack::loadPreset
 
 		return;
 	}
@@ -315,6 +307,16 @@ void Track::loadSettings( const QDomElement & element )
 	{
 		m_height = storedHeight;
 	}
+}
+
+void Track::saveSettings(QDomDocument& doc, QDomElement& element)
+{
+	saveTrack(doc, element, false);
+}
+
+void Track::loadSettings(const QDomElement& element)
+{
+	loadTrack(element, false);
 }
 
 

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -416,7 +416,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 	{
 		DataFile dataFile( value );
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
-		it->setSimpleSerializing();
+		it->setPresetMode();
 		it->loadSettings( dataFile.content().toElement() );
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -416,8 +416,8 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 	{
 		DataFile dataFile( value );
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
-		it->setPresetMode();
-		it->loadSettings( dataFile.content().toElement() );
+		it->loadPreset(dataFile.content().toElement());
+
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -424,7 +424,7 @@ void InstrumentTrackWindow::saveSettingsBtnClicked()
 		DataFile dataFile(DataFile::Type::InstrumentTrackSettings);
 		QDomElement& content(dataFile.content());
 
-		m_track->setSimpleSerializing();
+		m_track->setPresetMode();
 		m_track->saveSettings(dataFile, content);
 		//We don't want to save muted & solo settings when we're saving a preset
 		content.setAttribute("muted", 0);

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -424,8 +424,7 @@ void InstrumentTrackWindow::saveSettingsBtnClicked()
 		DataFile dataFile(DataFile::Type::InstrumentTrackSettings);
 		QDomElement& content(dataFile.content());
 
-		m_track->setPresetMode();
-		m_track->saveSettings(dataFile, content);
+		m_track->savePreset(dataFile, content);
 		//We don't want to save muted & solo settings when we're saving a preset
 		content.setAttribute("muted", 0);
 		content.setAttribute("solo", 0);

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -66,8 +66,7 @@ Clip* AutomationTrack::createClip(const TimePos & pos)
 
 
 
-void AutomationTrack::saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _this )
+void AutomationTrack::saveTrackSpecificSettings(QDomDocument& doc, QDomElement& _this, bool presetMode)
 {
 }
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -871,7 +871,7 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 		// Only save the MIDI port information if we are not saving a preset.
 		if (!isPresetMode())
 		{
-			m_midiPort.saveState( doc, thisElement );
+			m_midiPort.saveState(doc, thisElement);
 		}
 
 		autoAssignMidiDevice(hasAuto);

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -868,7 +868,11 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 		bool hasAuto = m_hasAutoMidiDev;
 		autoAssignMidiDevice(false);
 
-		m_midiPort.saveState( doc, thisElement );
+		// Only save the MIDI port information if we are not saving a preset.
+		if (!isSimpleSerializing())
+		{
+			m_midiPort.saveState( doc, thisElement );
+		}
 
 		autoAssignMidiDevice(hasAuto);
 	}

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -994,7 +994,17 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 	unlock();
 }
 
+void InstrumentTrack::savePreset(QDomDocument & doc, QDomElement & element)
+{
+	setPresetMode();
+	saveSettings(doc, element);
+}
 
+void InstrumentTrack::loadPreset(const QDomElement & element)
+{
+	setPresetMode();
+	loadSettings(element);
+}
 
 
 void InstrumentTrack::setPreviewMode( const bool value )
@@ -1011,14 +1021,13 @@ void InstrumentTrack::replaceInstrument(DataFile dataFile)
 	int mixerChannel = mixerChannelModel()->value();
 
 	InstrumentTrack::removeMidiPortNode(dataFile);
-	setPresetMode();
 	
 	//Replacing an instrument shouldn't change the solo/mute state.
 	bool oldMute = isMuted();
 	bool oldSolo = isSolo();
 	bool oldMutedBeforeSolo = isMutedBeforeSolo();
 
-	loadSettings(dataFile.content().toElement());
+	loadPreset(dataFile.content().toElement());
 	
 	setMuted(oldMute);
 	setSolo(oldSolo);

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -860,7 +860,7 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 
 	// Save the midi port info if we are not in song saving mode, e.g. in
 	// track cloning mode or if we are in song saving mode and the user
-	// has chosen to discard the MIDI connections.
+	// has chosen not to discard the MIDI connections.
 	if (!Engine::getSong()->isSavingProject() ||
 	    !Engine::getSong()->getSaveOptions().discardMIDIConnections.value())
 	{

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -869,7 +869,7 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 		autoAssignMidiDevice(false);
 
 		// Only save the MIDI port information if we are not saving a preset.
-		if (!isSimpleSerializing())
+		if (!isPresetMode())
 		{
 			m_midiPort.saveState( doc, thisElement );
 		}
@@ -1011,7 +1011,7 @@ void InstrumentTrack::replaceInstrument(DataFile dataFile)
 	int mixerChannel = mixerChannelModel()->value();
 
 	InstrumentTrack::removeMidiPortNode(dataFile);
-	setSimpleSerializing();
+	setPresetMode();
 	
 	//Replacing an instrument shouldn't change the solo/mute state.
 	bool oldMute = isMuted();

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -821,7 +821,7 @@ gui::TrackView* InstrumentTrack::createView( gui::TrackContainerView* tcv )
 
 
 
-void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement & thisElement )
+void InstrumentTrack::saveTrackSpecificSettings(QDomDocument& doc, QDomElement& thisElement, bool presetMode)
 {
 	m_volumeModel.saveSettings( doc, thisElement, "vol" );
 	m_panningModel.saveSettings( doc, thisElement, "pan" );
@@ -869,7 +869,7 @@ void InstrumentTrack::saveTrackSpecificSettings( QDomDocument& doc, QDomElement 
 		autoAssignMidiDevice(false);
 
 		// Only save the MIDI port information if we are not saving a preset.
-		if (!isPresetMode())
+		if (!presetMode)
 		{
 			m_midiPort.saveState(doc, thisElement);
 		}
@@ -994,46 +994,14 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 	unlock();
 }
 
-/**
- * @brief RAII "guard" used to safely change and reset booleans even during exceptions
- * 
- * Needed to safely reset m_presetMode in savePreset and loadPreset. For this reason
- * only defined locally because at least the pattern used by these methods should not
- * spread outside.
- */
-class BoolGuard
-{
-public:
-	BoolGuard(bool& member, bool temporaryValue) :
-	m_member(member),
-	m_oldValue(member)
-	{
-		m_member = temporaryValue;
-	}
-
-	~BoolGuard()
-	{
-		m_member = m_oldValue;
-	}
-
-	BoolGuard(const BoolGuard&) = delete;
-    BoolGuard& operator=(const BoolGuard&) = delete;
-
-private:
-	bool & m_member;
-	bool const m_oldValue;
-};
-
 void InstrumentTrack::savePreset(QDomDocument & doc, QDomElement & element)
 {
-	BoolGuard guard(m_presetMode, true);
-	saveSettings(doc, element);
+	saveTrack(doc, element, true);
 }
 
 void InstrumentTrack::loadPreset(const QDomElement & element)
 {
-	BoolGuard guard(m_presetMode, true);
-	loadSettings(element);
+	loadTrack(element, true);
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -994,15 +994,7 @@ void InstrumentTrack::loadTrackSpecificSettings( const QDomElement & thisElement
 	unlock();
 }
 
-void InstrumentTrack::savePreset(QDomDocument & doc, QDomElement & element)
-{
-	saveTrack(doc, element, true);
-}
 
-void InstrumentTrack::loadPreset(const QDomElement & element)
-{
-	loadTrack(element, true);
-}
 
 
 void InstrumentTrack::setPreviewMode( const bool value )

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -154,7 +154,7 @@ Clip* PatternTrack::createClip(const TimePos & pos)
 
 
 
-void PatternTrack::saveTrackSpecificSettings(QDomDocument& doc, QDomElement& _this)
+void PatternTrack::saveTrackSpecificSettings(QDomDocument& doc, QDomElement& _this, bool presetMode)
 {
 //	_this.setAttribute( "icon", m_trackLabel->pixmapFile() );
 /*	_this.setAttribute( "current", s_infoMap[this] ==

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -188,8 +188,7 @@ Clip * SampleTrack::createClip(const TimePos & pos)
 
 
 
-void SampleTrack::saveTrackSpecificSettings( QDomDocument & _doc,
-							QDomElement & _this )
+void SampleTrack::saveTrackSpecificSettings(QDomDocument& _doc, QDomElement& _this, bool presetMode)
 {
 	m_audioPort.effects()->saveState( _doc, _this );
 #if 0


### PR DESCRIPTION
The relevant change can be found in `InstrumentTrack::saveTrackSpecificSettings` where the new method `isPresetMode` is used to decide whether to store the MIDI port or not.

The other changes are mostly refactoring.

Fixes #3922.