### PR TITLE
Fix deadlocks when exporting

### DIFF
--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -89,8 +89,6 @@ private:
 	size_t m_currentBufferFramePos;
 	size_t m_currentBufferFramesCount;
 
-	bool m_stopped;
-
 	SDL_AudioDeviceID m_outputDevice;
 
 	SDL_AudioSpec m_inputAudioHandle;

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -549,15 +549,9 @@ void AudioEngine::clearInternal()
 
 void AudioEngine::changeQuality(const struct qualitySettings & qs)
 {
-	// don't delete the audio-device
-	stopProcessing();
-
 	m_qualitySettings = qs;
-
 	emit sampleRateChanged();
 	emit qualitySettingsChanged();
-
-	startProcessing();
 }
 
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -235,9 +235,6 @@ void Song::processNextBuffer()
 			return;
 	}
 
-	// If we have no tracks to play, there is nothing to do
-	if (trackList.empty()) { return; }
-
 	// If the playback position is outside of the range [begin, end), move it to
 	// begin and inform interested parties.
 	// Returns true if the playback position was moved, else false.

--- a/src/core/audio/AudioSdl.cpp
+++ b/src/core/audio/AudioSdl.cpp
@@ -139,8 +139,6 @@ AudioSdl::~AudioSdl()
 
 void AudioSdl::startProcessing()
 {
-	m_stopped = false;
-
 	SDL_PauseAudioDevice (m_outputDevice, 0);
 	SDL_PauseAudioDevice (m_inputDevice, 0);
 }
@@ -150,19 +148,8 @@ void AudioSdl::startProcessing()
 
 void AudioSdl::stopProcessing()
 {
-	if( SDL_GetAudioDeviceStatus(m_outputDevice) == SDL_AUDIO_PLAYING )
-	{
-		SDL_LockAudioDevice (m_inputDevice);
-		SDL_LockAudioDevice (m_outputDevice);
-
-		m_stopped = true;
-
-		SDL_PauseAudioDevice (m_inputDevice,	1);
-		SDL_PauseAudioDevice (m_outputDevice,	1);
-
-		SDL_UnlockAudioDevice (m_inputDevice);
-		SDL_UnlockAudioDevice (m_outputDevice);
-	}
+	SDL_PauseAudioDevice (m_inputDevice,	1);
+	SDL_PauseAudioDevice (m_outputDevice,	1);
 }
 
 void AudioSdl::sdlAudioCallback( void * _udata, Uint8 * _buf, int _len )
@@ -177,11 +164,6 @@ void AudioSdl::sdlAudioCallback( void * _udata, Uint8 * _buf, int _len )
 
 void AudioSdl::sdlAudioCallback( Uint8 * _buf, int _len )
 {
-	if( m_stopped )
-	{
-		memset( _buf, 0, _len );
-		return;
-	}
 
 	// SDL2: process float samples
 	while( _len )


### PR DESCRIPTION
Should fix some bugs with export.

* Fixes the "export bomb" bug, where when exporting an empty project, the bug makes it so that the `ProjectRenderer` thread keeps rendering silence as fast as possible, eliminating the space on the hard drive in seconds.

* Should fix an export deadlock when exporting an empty project when it reaches 100%

These classes probably need more thorough refactoring though.