### PR TITLE
Continue processing `Song` even when no tracks are found

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -235,9 +235,6 @@ void Song::processNextBuffer()
 			return;
 	}
 
-	// If we have no tracks to play, there is nothing to do
-	if (trackList.empty()) { return; }
-
 	// If the playback position is outside of the range [begin, end), move it to
 	// begin and inform interested parties.
 	// Returns true if the playback position was moved, else false.


### PR DESCRIPTION
See title. Meant to fix an issue where, given that enough time has passed, exporting a completely empty project attempts to generate an infinitely large file and thus eliminate the available space on the storage device very quickly.