### PR TITLE
Fix Automation Editor Playing from Start of Song

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -233,6 +233,7 @@ private:
 
 	MidiClip* m_ghostNotes = nullptr;
 	QPointer<SampleClip> m_ghostSample = nullptr; // QPointer to set to nullptr on deletion
+	TimePos m_detuningOffset;
 	bool m_renderSample = false;
 
 	void centerTopBottomScroll();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1699,6 +1699,7 @@ void AutomationEditor::play()
 	{
 		if( Engine::getSong()->isStopped() == true )
 		{
+			Engine::getSong()->setToTime(m_clip->startPosition().getTicks(), Song::PlayMode::Song);
 			Engine::getSong()->playSong();
 		}
 		else

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1240,6 +1240,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 				if (note->detuning()->automationClip() == m_clip) {
 					detuningOffset = note->pos();
+					m_detuningOffset = detuningOffset;
 					detuningNote = note;
 				}
 
@@ -1680,6 +1681,7 @@ void AutomationEditor::play()
 		if( Engine::getSong()->playMode() != Song::PlayMode::MidiClip )
 		{
 			Engine::getSong()->stop();
+			Engine::getSong()->setToTime(m_detuningOffset, Song::PlayMode::MidiClip);
 			Engine::getSong()->playMidiClip( getGUI()->pianoRoll()->currentMidiClip() );
 		}
 		else if( Engine::getSong()->isStopped() == false )
@@ -1688,6 +1690,7 @@ void AutomationEditor::play()
 		}
 		else
 		{
+			Engine::getSong()->setToTime(m_detuningOffset, Song::PlayMode::MidiClip);
 			Engine::getSong()->playMidiClip( getGUI()->pianoRoll()->currentMidiClip() );
 		}
 	}


### PR DESCRIPTION
This pull request makes the play button in the automation editor teleport the playhead position to where the clip begins before playing the song, instead of playing from the very start. In the case of note detuning, it teleports the playhead to the position of the note being detuned.

## Changes
In `AutomationEditor::play()`
- Added `Engine::getSong()->setToTime(m_clip->startPosition().getTicks(), Song::PlayMode::Song);` for when the automation clip is standalone.
- Added `Engine::getSong()->setToTime(m_detuningOffset, Song::PlayMode::MidiClip);` in two places for when the automation editor is being used for note detuning. 

However, since the position of the note which is being detuned is only stored in a temportary variable, a new private member was also added, `m_detuningOffset`, which is assigned when the notes are being looped over to find the detuning note in `paintEvent()`, so that it can be accessed in AutomationEditor::play().

### Note
I am not sure what the purpose of the `playMidiClip()` on line 1694, as I could never get it to execute during normal usage, playing/stopping in the detuner. I have added a `setToTime()` there anyway, but if I am misunderstanding its purpose that may not be necessary.