### PR TITLE
Fix drawing of ghost notes when detuning

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1273,13 +1273,16 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 				float absNoteHeight = static_cast<float>(note->key() - minKey) / (maxKey - minKey);
 				int graphHeight = grid_bottom - NOTE_HEIGHT - NOTE_MARGIN - TOP_MARGIN;
-				const int y = (graphHeight - graphHeight * absNoteHeight) + NOTE_HEIGHT / 2.0f + TOP_MARGIN;
+				const int actualNoteHeight = (yCoordOfLevel(0) - yCoordOfLevel(1)); // Using yCoordOfLevel to find the exact height of 1 semitone for use when detuning notes
+				const int y = detuningNote != nullptr
+							? yCoordOfLevel(note->key() - detuningNote->key()) - actualNoteHeight / 2.0f
+							: (graphHeight - graphHeight * absNoteHeight) + NOTE_HEIGHT / 2.0f + TOP_MARGIN;
 				const int x = xCoordOfTick(notePos);
 
 				if (note == detuningNote) {
-					p.fillRect(x, y, note_width, NOTE_HEIGHT, m_detuningNoteColor);
+					p.fillRect(x, y, note_width, detuningNote != nullptr ? actualNoteHeight : NOTE_HEIGHT, m_detuningNoteColor);
 				} else {
-					p.fillRect(x, y, note_width, NOTE_HEIGHT, m_ghostNoteColor);
+					p.fillRect(x, y, note_width, detuningNote != nullptr ? actualNoteHeight : NOTE_HEIGHT, m_ghostNoteColor);
 				}
 			}
 		}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -189,6 +189,16 @@ void AutomationEditor::setCurrentClip(AutomationClip * new_clip )
 	if (m_clip != nullptr)
 	{
 		connect(m_clip, SIGNAL(dataChanged()), this, SLOT(update()));
+
+		// Set the vertical zoom to 200% when detuning notes
+		if (!m_clip->getTrack())
+		{
+			m_zoomingYModel.setValue(4);
+		}
+		else
+		{
+			m_zoomingYModel.setValue(0);
+		}
 	}
 
 	emit currentClipChanged();


### PR DESCRIPTION
## Description
This pull request makes the detuning ghost notes actually be drawn in their proper position and size in the Automation Editor. Additionally, when opening the Automation Editor for detuning, the default vertical zoom is changed to 200% to focus on smaller changes instead of the whole -60 to 60 semitones. However, since that default vertical zoom persists between Automation Editor sessions, the default vertical zoom for all other automation clips is changed to `Auto` so that the 200% zoom is reset. 

## Changes
- In `AutomationEditor::setCurrentClip()`, an if statement is added which sets the default vertical zoom depending on whether it is for detuning or not.
- In `AutomationEditor::paintEvent()`, if the ghost notes are for detuning, the `y` pixel position of each ghost note is calculated using `yCoordOfLevel()` to get the correct position relative to the grid. Additionally, the height of each semitone is calculated via `yCoordOfLevel(0) - yCoordOfLevel(1)`.

## Note
I am aware that setting the zoom to default every time an automation clip is opened is not ideal, since some individuals may wish to have their zoom preferences persist between clips. On the other hand, some may find it useful that the zoom resets each time. I would love to hear your opinions.
