### PR TITLE
Selected clip length updates

### DIFF
--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -107,7 +107,7 @@ public:
 		const bool ignoreSurroundingPoints = true
 	);
 
-	void removeNode(const TimePos & time);
+	void removeNode(const TimePos & time, bool lengthUpdate = true);
 	void removeNodes(const int tick0, const int tick1);
 
 	void resetNodes(const int tick0, const int tick1);

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -107,7 +107,7 @@ public:
 		const bool ignoreSurroundingPoints = true
 	);
 
-	void removeNode(const TimePos & time, bool lengthUpdate = true);
+	void removeNode(const TimePos & time);
 	void removeNodes(const int tick0, const int tick1);
 
 	void resetNodes(const int tick0, const int tick1);

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -339,7 +339,7 @@ TimePos AutomationClip::putValues(
 
 
 
-void AutomationClip::removeNode(const TimePos & time)
+void AutomationClip::removeNode(const TimePos & time, bool lengthUpdate)
 {
 	QMutexLocker m(&m_clipMutex);
 
@@ -353,7 +353,10 @@ void AutomationClip::removeNode(const TimePos & time)
 	}
 	generateTangents(it, 3);
 
-	updateLength();
+	if (lengthUpdate)
+	{
+		updateLength();
+	}
 
 	emit dataChanged();
 }
@@ -520,7 +523,7 @@ TimePos AutomationClip::setDragValue(
 			}
 		}
 
-		this->removeNode(newTime);
+		this->removeNode(newTime, false);
 		m_oldTimeMap = m_timeMap;
 		m_dragging = true;
 	}

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -339,7 +339,7 @@ TimePos AutomationClip::putValues(
 
 
 
-void AutomationClip::removeNode(const TimePos & time, bool lengthUpdate)
+void AutomationClip::removeNode(const TimePos & time)
 {
 	QMutexLocker m(&m_clipMutex);
 
@@ -352,11 +352,6 @@ void AutomationClip::removeNode(const TimePos & time, bool lengthUpdate)
 		--it;
 	}
 	generateTangents(it, 3);
-
-	if (lengthUpdate)
-	{
-		updateLength();
-	}
 
 	emit dataChanged();
 }
@@ -374,6 +369,7 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 	if (tick0 == tick1)
 	{
 		removeNode(TimePos(tick0));
+		updateLength();
 		return;
 	}
 
@@ -393,6 +389,12 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 	for (auto node: nodesToRemove)
 	{
 		removeNode(node);
+	}
+
+	if (!nodesToRemove.empty())
+	{
+		// Only update the length if we have actually removed nodes
+		updateLength();
 	}
 }
 
@@ -463,6 +465,7 @@ void AutomationClip::recordValue(TimePos time, float value)
 	else if( valueAt( time ) != value )
 	{
 		removeNode(time);
+		updateLength();
 	}
 }
 
@@ -523,7 +526,7 @@ TimePos AutomationClip::setDragValue(
 			}
 		}
 
-		this->removeNode(newTime, false);
+		this->removeNode(newTime);
 		m_oldTimeMap = m_timeMap;
 		m_dragging = true;
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -340,6 +340,7 @@ void AutomationEditor::drawLine( int x0In, float y0, int x1In, float y1 )
 		x += xstep;
 		m_clip->removeNode(TimePos(x));
 		m_clip->putValue( TimePos( x ), y );
+		m_clip->updateLength();
 	}
 }
 
@@ -406,6 +407,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 		if (node != m_clip->getTimeMap().end())
 		{
 			m_clip->removeNode(POS(node));
+			m_clip->updateLength();
 			Engine::getSong()->setModified();
 		}
 	};


### PR DESCRIPTION
Do not update the clip length when dragging a node in `AutomationClip::setDragValue`.

This is achieved by removing the call to `updateLength` from `AutomationClip::removeNode` and explicitly calling the update in all other places that call `removeNode` except in `setDragValue`.

This commit therefore also improves the separation of concerns. Removing a node now only update the data structures. Updating the clip length is a completely different thing and rather a "policy" and therefore both calls should be done independently.

Fixes #7466.