### PR TITLE
Adding proportional scrolling

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -241,7 +241,7 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
-	void incrementLeftRightScoll(int value);
+	void adjustLeftRightScoll(int value);
 
 	TimePos m_currentPosition;
 

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -241,6 +241,8 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
+	void incrementLeftRightScoll(int value);
+
 	TimePos m_currentPosition;
 
 	Action m_action;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -374,6 +374,8 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
+	void incrementLeftRightScoll(int value);
+
 	TimePos m_currentPosition;
 	bool m_recording;
 	bool m_doAutoQuantization{false};

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -374,7 +374,7 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
-	void incrementLeftRightScoll(int value);
+	void adjustLeftRightScoll(int value);
 
 	TimePos m_currentPosition;
 	bool m_recording;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -128,7 +128,7 @@ private:
 
 	QScrollBar * m_leftRightScroll;
 
-	void incrementLeftRightScoll(int value);
+	void adjustLeftRightScoll(int value);
 
 	LcdSpinBox * m_tempoSpinBox;
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -128,6 +128,8 @@ private:
 
 	QScrollBar * m_leftRightScroll;
 
+	void incrementLeftRightScoll(int value);
+
 	LcdSpinBox * m_tempoSpinBox;
 
 	TimeLineWidget * m_timeLine;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1626,12 +1626,12 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15 / m_zoomXLevels[m_zoomingXModel.value()]);
+							we->angleDelta().x() * 2 / 6 / m_zoomXLevels[m_zoomingXModel.value()]);
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15 / m_zoomXLevels[m_zoomingXModel.value()]);
+							we->angleDelta().y() * 2 / 6 / m_zoomXLevels[m_zoomingXModel.value()]);
 	}
 	else
 	{

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1560,7 +1560,11 @@ void AutomationEditor::resizeEvent(QResizeEvent * re)
 	update();
 }
 
-
+void AutomationEditor::incrementLeftRightScoll(int value)
+{
+	m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							value * 0.3f / m_zoomXLevels[m_zoomingXModel.value()]);
+}
 
 
 // TODO: Move this method up so it's closer to the other mouse events
@@ -1625,13 +1629,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 6 / m_zoomXLevels[m_zoomingXModel.value()]);
+		incrementLeftRightScoll(we->angleDelta().x());
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 6 / m_zoomXLevels[m_zoomingXModel.value()]);
+		incrementLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1626,12 +1626,12 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15);
+							we->angleDelta().x() * 2 / 15 / m_zoomXLevels[m_zoomingXModel.value()]);
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15);
+							we->angleDelta().y() * 2 / 15 / m_zoomXLevels[m_zoomingXModel.value()]);
 	}
 	else
 	{

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1560,7 +1560,7 @@ void AutomationEditor::resizeEvent(QResizeEvent * re)
 	update();
 }
 
-void AutomationEditor::incrementLeftRightScoll(int value)
+void AutomationEditor::adjustLeftRightScoll(int value)
 {
 	m_leftRightScroll->setValue(m_leftRightScroll->value() -
 							value * 0.3f / m_zoomXLevels[m_zoomingXModel.value()]);
@@ -1629,11 +1629,11 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		incrementLeftRightScoll(we->angleDelta().x());
+		adjustLeftRightScoll(we->angleDelta().x());
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		incrementLeftRightScoll(we->angleDelta().y());
+		adjustLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3876,12 +3876,12 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15 / m_zoomLevels[m_zoomingModel.value()]);
+							we->angleDelta().x() * 2 / 6 / m_zoomLevels[m_zoomingModel.value()]);
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15 / m_zoomLevels[m_zoomingModel.value()]);
+							we->angleDelta().y() * 2 / 6 / m_zoomLevels[m_zoomingModel.value()]);
 	}
 	else
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3743,6 +3743,12 @@ void PianoRoll::resizeEvent(QResizeEvent* re)
 }
 
 
+void PianoRoll::incrementLeftRightScoll(int value)
+{
+	m_leftRightScroll->setValue(m_leftRightScroll->value() -
+							value * 0.3f / m_zoomXLevels[m_zoomingXModel.value()]);
+}
+
 
 
 void PianoRoll::wheelEvent(QWheelEvent * we )
@@ -3875,13 +3881,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 6 / m_zoomLevels[m_zoomingModel.value()]);
+		incrementLeftRightScoll(we->angleDelta().x());
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 6 / m_zoomLevels[m_zoomingModel.value()]);
+		incrementLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3746,7 +3746,7 @@ void PianoRoll::resizeEvent(QResizeEvent* re)
 void PianoRoll::incrementLeftRightScoll(int value)
 {
 	m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							value * 0.3f / m_zoomXLevels[m_zoomingXModel.value()]);
+							value * 0.3f / m_zoomLevels[m_zoomingModel.value()]);
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3743,7 +3743,7 @@ void PianoRoll::resizeEvent(QResizeEvent* re)
 }
 
 
-void PianoRoll::incrementLeftRightScoll(int value)
+void PianoRoll::adjustLeftRightScoll(int value)
 {
 	m_leftRightScroll->setValue(m_leftRightScroll->value() -
 							value * 0.3f / m_zoomLevels[m_zoomingModel.value()]);
@@ -3881,11 +3881,11 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		incrementLeftRightScoll(we->angleDelta().x());
+		adjustLeftRightScoll(we->angleDelta().x());
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
-		incrementLeftRightScoll(we->angleDelta().y());
+		adjustLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3876,12 +3876,12 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().x() * 2 / 15);
+							we->angleDelta().x() * 2 / 15 / m_zoomLevels[m_zoomingModel.value()]);
 	}
 	else if(we->modifiers() & Qt::ShiftModifier)
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							we->angleDelta().y() * 2 / 15);
+							we->angleDelta().y() * 2 / 15 / m_zoomLevels[m_zoomingModel.value()]);
 	}
 	else
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -545,12 +545,12 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value()
-							- we->angleDelta().x());
+							- we->angleDelta().x() * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
 	}
 	else if (we->modifiers() & Qt::ShiftModifier)
 	{
 		m_leftRightScroll->setValue(m_leftRightScroll->value()
-							- we->angleDelta().y());
+							- we->angleDelta().y() * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
 	}
 	else
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -516,7 +516,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 
 
-void SongEditor::incrementLeftRightScoll(int value)
+void SongEditor::adjustLeftRightScoll(int value)
 {
 	m_leftRightScroll->setValue(m_leftRightScroll->value()
 						- value * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
@@ -550,11 +550,11 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		incrementLeftRightScoll(we->angleDelta().x());
+		adjustLeftRightScoll(we->angleDelta().x());
 	}
 	else if (we->modifiers() & Qt::ShiftModifier)
 	{
-		incrementLeftRightScoll(we->angleDelta().y());
+		adjustLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -516,6 +516,12 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 
 
+void SongEditor::incrementLeftRightScoll(int value)
+{
+	m_leftRightScroll->setValue(m_leftRightScroll->value()
+						- value * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
+}
+
 
 void SongEditor::wheelEvent( QWheelEvent * we )
 {
@@ -544,13 +550,11 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
 	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value()
-							- we->angleDelta().x() * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
+		incrementLeftRightScoll(we->angleDelta().x());
 	}
 	else if (we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue(m_leftRightScroll->value()
-							- we->angleDelta().y() * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
+		incrementLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #7474 by making the scroll amount change based on the zoom amount. 

The implementation is slightly different in the `SongEditor` versus the `PianoRoll` and the `AutomationEditor`, since the `SongEditor` has precise zoom control while the others have zoom levels. I opted to use `pixelsPerBar()` in the `SongEditor` to calculate the zoom level for simplicity, since the zooming model is in log scale.

I actually had this on feature my mind awhile ago when I was implementing continuous autoscrolling, but I decided to leave it to a different pr and forgot about it. Now I've been reminded, so here it is.

Also, please let me know if the scrolling speed is too fast/too slow. Currently the scrolling speed is equal to the old scrolling speed at default zoom.