### PR TITLE
Process metronome every MIDI tick

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -289,9 +289,6 @@ public:
 
 	void changeQuality(const struct qualitySettings & qs);
 
-	inline bool isMetronomeActive() const { return m_metronomeActive; }
-	inline void setMetronomeActive(bool value = true) { m_metronomeActive = value; }
-
 	//! Block until a change in model can be done (i.e. wait for audio thread)
 	void requestChangeInModel();
 	void doneChangeInModel();
@@ -352,8 +349,6 @@ private:
 
 	void swapBuffers();
 
-	void handleMetronome();
-
 	void clearInternal();
 
 	bool m_renderOnly;
@@ -401,8 +396,6 @@ private:
 	fifoWriter * m_fifoWriter;
 
 	AudioEngineProfiler m_profiler;
-
-	bool m_metronomeActive;
 
 	bool m_clearSignal;
 

--- a/include/Metronome.h
+++ b/include/Metronome.h
@@ -31,12 +31,12 @@ namespace lmms {
 class Metronome
 {
 public:
-	static bool active();
-	static void setActive(bool active);
-	static void process(size_t bufferSize);
+	bool active() const;
+	void setActive(bool active);
+	void process(size_t bufferSize);
 
 private:
-	inline static bool s_active = false;
+	bool m_active = false;
 };
 } // namespace lmms
 

--- a/include/Metronome.h
+++ b/include/Metronome.h
@@ -33,7 +33,7 @@ class Metronome
 public:
 	bool active() const;
 	void setActive(bool active);
-	void process(size_t bufferSize);
+	void processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset);
 
 private:
 	bool m_active = false;

--- a/include/Metronome.h
+++ b/include/Metronome.h
@@ -1,0 +1,43 @@
+/*
+ * Metronome.h
+ *
+ * Copyright (c) 2024 saker
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_METRONOME_H
+#define LMMS_METRONOME_H
+
+#include <cstddef>
+
+namespace lmms {
+class Metronome
+{
+public:
+	static bool active();
+	static void setActive(bool active);
+	static void process(size_t bufferSize);
+
+private:
+	inline static bool s_active = false;
+};
+} // namespace lmms
+
+#endif // LMMS_METRONOME_H

--- a/include/Metronome.h
+++ b/include/Metronome.h
@@ -31,8 +31,8 @@ namespace lmms {
 class Metronome
 {
 public:
-	bool active() const;
-	void setActive(bool active);
+	bool active() const { return m_active; }
+	void setActive(bool active) { m_active = active; }
 	void processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset);
 
 private:

--- a/include/Song.h
+++ b/include/Song.h
@@ -33,6 +33,7 @@
 
 #include "AudioEngine.h"
 #include "Controller.h"
+#include "Metronome.h"
 #include "lmms_constants.h"
 #include "MeterModel.h"
 #include "Timeline.h"
@@ -375,6 +376,8 @@ public:
 
 	const std::string& syncKey() const noexcept { return m_vstSyncController.sharedMemoryKey(); }
 
+	Metronome& metronome();
+
 public slots:
 	void playSong();
 	void record();
@@ -512,6 +515,8 @@ private:
 	std::shared_ptr<Keymap> m_keymaps[MaxKeymapCount];
 
 	AutomatedValueMap m_oldAutomatedValues;
+
+	Metronome m_metronome;
 
 	friend class Engine;
 	friend class gui::SongEditor;

--- a/include/Song.h
+++ b/include/Song.h
@@ -451,6 +451,7 @@ private:
 	void restoreKeymapStates(const QDomElement &element);
 
 	void processAutomations(const TrackList& tracks, TimePos timeStart, fpp_t frames);
+	void processMetronome(size_t bufferOffset);
 
 	void setModified(bool value);
 

--- a/include/Song.h
+++ b/include/Song.h
@@ -376,7 +376,7 @@ public:
 
 	const std::string& syncKey() const noexcept { return m_vstSyncController.sharedMemoryKey(); }
 
-	Metronome& metronome();
+	Metronome& metronome() { return m_metronome; }
 
 public slots:
 	void playSong();

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -345,8 +345,6 @@ void AudioEngine::renderStageNoteSetup()
 	Mixer * mixer = Engine::mixer();
 	mixer->prepareMasterMix();
 
-	Metronome::process(m_framesPerPeriod);
-
 	// create play-handles for new notes, samples etc.
 	Engine::getSong()->processNextBuffer();
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -31,7 +31,6 @@
 
 #include "AudioEngineWorkerThread.h"
 #include "AudioPort.h"
-#include "Metronome.h"
 #include "Mixer.h"
 #include "Song.h"
 #include "EnvelopeAndLfoParameters.h"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -40,6 +40,7 @@ set(LMMS_SRCS
 	core/LinkedModelGroups.cpp
 	core/LocklessAllocator.cpp
 	core/MeterModel.cpp
+	core/Metronome.cpp
 	core/MicroTimer.cpp
 	core/Microtuner.cpp
 	core/MixHelpers.cpp

--- a/src/core/Metronome.cpp
+++ b/src/core/Metronome.cpp
@@ -1,0 +1,84 @@
+/*
+ * Metronome.cpp
+ *
+ * Copyright (c) 2024 saker
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "Metronome.h"
+
+#include "Engine.h"
+#include "SamplePlayHandle.h"
+#include "Song.h"
+
+namespace lmms {
+
+bool Metronome::active()
+{
+	return s_active;
+}
+
+void Metronome::setActive(bool active)
+{
+	s_active = active;
+}
+
+void Metronome::process(size_t bufferSize)
+{
+	const auto song = Engine::getSong();
+	const auto currentPlayMode = song->playMode();
+	const auto supported = currentPlayMode == Song::PlayMode::MidiClip || currentPlayMode == Song::PlayMode::Song
+		|| currentPlayMode == Song::PlayMode::Pattern;
+
+	if (!supported || !s_active || song->isExporting() || song->countTracks() == 0) { return; }
+
+	const auto ticksPerBar = TimePos::ticksPerBar();
+	const auto beatsPerBar = song->getTimeSigModel().getNumerator();
+	const auto framesPerTick = static_cast<std::size_t>(Engine::framesPerTick());
+
+	auto currentTick = song->getPlayPos(song->playMode()).getTicks();
+	auto currentFrameOffset = song->getPlayPos(song->playMode()).currentFrame();
+	auto currentFrame = static_cast<std::size_t>(currentTick * framesPerTick + currentFrameOffset);
+
+	for (auto frame = std::size_t{0}; frame < bufferSize; ++frame, ++currentFrame)
+	{
+		if (currentFrame % framesPerTick == 0 && currentFrame != framesPerTick)
+		{
+			auto handle = static_cast<SamplePlayHandle*>(nullptr);
+			if (currentTick % ticksPerBar == 0)
+            {
+                handle = new SamplePlayHandle("misc/metronome02.ogg");
+            }
+			else if (currentTick % (ticksPerBar / beatsPerBar) == 0)
+			{
+				handle = new SamplePlayHandle("misc/metronome01.ogg");
+			}
+
+			if (handle)
+			{
+				handle->setOffset(frame);
+				Engine::audioEngine()->addPlayHandle(handle);
+			}
+
+			++currentTick;
+		}
+	}
+}
+} // namespace lmms

--- a/src/core/Metronome.cpp
+++ b/src/core/Metronome.cpp
@@ -51,34 +51,23 @@ void Metronome::process(size_t bufferSize)
 
 	const auto ticksPerBar = TimePos::ticksPerBar();
 	const auto beatsPerBar = song->getTimeSigModel().getNumerator();
-	const auto framesPerTick = static_cast<std::size_t>(Engine::framesPerTick());
 
-	auto currentTick = song->getPlayPos(song->playMode()).getTicks();
-	auto currentFrameOffset = song->getPlayPos(song->playMode()).currentFrame();
+	const auto framesPerTick = static_cast<std::size_t>(Engine::framesPerTick());
+	const auto framesPerBar = framesPerTick * ticksPerBar;
+	const auto framesPerBeat = framesPerBar / beatsPerBar;
+
+	const auto currentTick = song->getPlayPos(song->playMode()).getTicks();
+	const auto currentFrameOffset = song->getPlayPos(song->playMode()).currentFrame();
 	auto currentFrame = static_cast<std::size_t>(currentTick * framesPerTick + currentFrameOffset);
 
 	for (auto frame = std::size_t{0}; frame < bufferSize; ++frame, ++currentFrame)
 	{
-		if (currentFrame % framesPerTick == 0 && currentFrame != framesPerTick)
-		{
-			auto handle = static_cast<SamplePlayHandle*>(nullptr);
-			if (currentTick % ticksPerBar == 0)
-            {
-                handle = new SamplePlayHandle("misc/metronome02.ogg");
-            }
-			else if (currentTick % (ticksPerBar / beatsPerBar) == 0)
-			{
-				handle = new SamplePlayHandle("misc/metronome01.ogg");
-			}
+		if (currentFrame % framesPerBeat != 0) { continue; }
 
-			if (handle)
-			{
-				handle->setOffset(frame);
-				Engine::audioEngine()->addPlayHandle(handle);
-			}
-
-			++currentTick;
-		}
+		const auto handle = currentFrame % framesPerBar == 0 ? new SamplePlayHandle("misc/metronome02.ogg")
+															 : new SamplePlayHandle("misc/metronome01.ogg");
+		handle->setOffset(frame);
+		Engine::audioEngine()->addPlayHandle(handle);
 	}
 }
 } // namespace lmms

--- a/src/core/Metronome.cpp
+++ b/src/core/Metronome.cpp
@@ -30,14 +30,14 @@
 
 namespace lmms {
 
-bool Metronome::active()
+bool Metronome::active() const
 {
-	return s_active;
+	return m_active;
 }
 
 void Metronome::setActive(bool active)
 {
-	s_active = active;
+	m_active = active;
 }
 
 void Metronome::process(size_t bufferSize)
@@ -47,7 +47,7 @@ void Metronome::process(size_t bufferSize)
 	const auto supported = currentPlayMode == Song::PlayMode::MidiClip || currentPlayMode == Song::PlayMode::Song
 		|| currentPlayMode == Song::PlayMode::Pattern;
 
-	if (!supported || !s_active || song->isExporting() || song->countTracks() == 0) { return; }
+	if (!supported || !m_active || song->isExporting() || song->countTracks() == 0) { return; }
 
 	const auto ticksPerBar = TimePos::ticksPerBar();
 	const auto beatsPerBar = song->getTimeSigModel().getNumerator();

--- a/src/core/Metronome.cpp
+++ b/src/core/Metronome.cpp
@@ -28,17 +28,6 @@
 #include "SamplePlayHandle.h"
 
 namespace lmms {
-
-bool Metronome::active() const
-{
-	return m_active;
-}
-
-void Metronome::setActive(bool active)
-{
-	m_active = active;
-}
-
 void Metronome::processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset)
 {
 	const auto ticksPerBeat = ticksPerBar / beatsPerBar;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -428,6 +428,17 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 	}
 }
 
+void Song::processMetronome(size_t bufferOffset)
+{
+	const auto currentPlayMode = playMode();
+	const auto supported = currentPlayMode == PlayMode::MidiClip
+		|| currentPlayMode == PlayMode::Song
+		|| currentPlayMode == PlayMode::Pattern;
+
+	if (!supported || m_exporting) { return; } 
+	m_metronome.processTick(currentTick(), ticksPerBar(), m_timeSigModel.getNumerator(), bufferOffset);
+}
+
 void Song::setModified(bool value)
 {
 	if( !m_loadingProject && m_modified != value)
@@ -1544,16 +1555,4 @@ void Song::setKeymap(unsigned int index, std::shared_ptr<Keymap> newMap)
 	emit keymapListChanged(index);
 	Engine::audioEngine()->doneChangeInModel();
 }
-
-void Song::processMetronome(size_t bufferOffset)
-{
-	const auto currentPlayMode = playMode();
-	const auto supported = currentPlayMode == PlayMode::MidiClip
-		|| currentPlayMode == PlayMode::Song
-		|| currentPlayMode == PlayMode::Pattern;
-
-	if (!supported || isExporting()) { return; } 
-	m_metronome.processTick(currentTick(), ticksPerBar(), m_timeSigModel.getNumerator(), bufferOffset);
-}
-
 } // namespace lmms

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1548,17 +1548,12 @@ void Song::setKeymap(unsigned int index, std::shared_ptr<Keymap> newMap)
 void Song::processMetronome(size_t bufferOffset)
 {
 	const auto currentPlayMode = playMode();
-	const auto supported = currentPlayMode == Song::PlayMode::MidiClip
-		|| currentPlayMode == Song::PlayMode::Song
-		|| currentPlayMode == Song::PlayMode::Pattern;
+	const auto supported = currentPlayMode == PlayMode::MidiClip
+		|| currentPlayMode == PlayMode::Song
+		|| currentPlayMode == PlayMode::Pattern;
 
 	if (!supported || isExporting()) { return; } 
 	m_metronome.processTick(currentTick(), ticksPerBar(), m_timeSigModel.getNumerator(), bufferOffset);
-}
-
-Metronome& Song::metronome()
-{
-	return m_metronome;
 }
 
 } // namespace lmms

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -267,6 +267,8 @@ void Song::processNextBuffer()
 	const auto framesPerTick = Engine::framesPerTick();
 	const auto framesPerPeriod = Engine::audioEngine()->framesPerPeriod();
 
+	m_metronome.process(framesPerPeriod);
+
 	f_cnt_t frameOffsetInPeriod = 0;
 
 	while (frameOffsetInPeriod < framesPerPeriod)
@@ -1543,5 +1545,9 @@ void Song::setKeymap(unsigned int index, std::shared_ptr<Keymap> newMap)
 	Engine::audioEngine()->doneChangeInModel();
 }
 
+Metronome& Song::metronome()
+{
+	return m_metronome;
+}
 
 } // namespace lmms

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -43,6 +43,7 @@
 #include "ExportProjectDialog.h"
 #include "FileBrowser.h"
 #include "FileDialog.h"
+#include "Metronome.h"
 #include "MixerView.h"
 #include "GuiApplication.h"
 #include "ImportFilter.h"
@@ -430,7 +431,7 @@ void MainWindow::finalize()
 				this, SLOT(onToggleMetronome()),
 							m_toolBar );
 	m_metronomeToggle->setCheckable(true);
-	m_metronomeToggle->setChecked(Engine::audioEngine()->isMetronomeActive());
+	m_metronomeToggle->setChecked(Metronome::active());
 
 	m_toolBarLayout->setColumnMinimumWidth( 0, 5 );
 	m_toolBarLayout->addWidget( project_new, 0, 1 );
@@ -1173,7 +1174,7 @@ void MainWindow::updateConfig( QAction * _who )
 
 void MainWindow::onToggleMetronome()
 {
-	Engine::audioEngine()->setMetronomeActive( m_metronomeToggle->isChecked() );
+	Metronome::setActive(m_metronomeToggle->isChecked());
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -431,7 +431,7 @@ void MainWindow::finalize()
 				this, SLOT(onToggleMetronome()),
 							m_toolBar );
 	m_metronomeToggle->setCheckable(true);
-	m_metronomeToggle->setChecked(Metronome::active());
+	m_metronomeToggle->setChecked(Engine::getSong()->metronome().active());
 
 	m_toolBarLayout->setColumnMinimumWidth( 0, 5 );
 	m_toolBarLayout->addWidget( project_new, 0, 1 );
@@ -1174,7 +1174,7 @@ void MainWindow::updateConfig( QAction * _who )
 
 void MainWindow::onToggleMetronome()
 {
-	Metronome::setActive(m_metronomeToggle->isChecked());
+	Engine::getSong()->metronome().setActive(m_metronomeToggle->isChecked());
 }
 
 


### PR DESCRIPTION
Processes the metronome every MIDI tick instead of every buffer. This allows the metronome to work correctly without skips, which was previously a problem when playing at high tempos. This was cherry-picked from a larger body of work that plans to revamp how our buffer processing works, which requires that the applicable operations run at their proper rates.

Fixes #4038