### PR TITLE
Widget highlighting and shortcut system implementation

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -11,6 +11,10 @@ QMdiArea {
 	background-image: url("resources:background_artwork.png");
 }
 
+lmms--gui--InteractiveModelView {
+	qproperty-highlightColor: rgb(38, 237, 231);
+}
+
 lmms--gui--Knob {
 	qproperty-lineInactiveColor: rgb(120, 120, 120);
 	qproperty-arcInactiveColor: rgba(120, 120, 120, 70);

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -46,6 +46,10 @@ lmms--gui--FileBrowser QCheckBox
 	color: white;
 }
 
+lmms--gui--InteractiveModelView {
+	qproperty-highlightColor: rgb(42, 219, 49);
+}
+
 lmms--gui--Knob {
 	qproperty-lineInactiveColor: rgb(120, 120, 120);
 	qproperty-arcInactiveColor: rgba(120, 120, 120, 70);

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -67,11 +67,18 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
-
+	
+	std::vector<ModelShortcut> getShortcuts() override;
+	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
+	QString getShortcutMessage() override;
+	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
+	bool processPaste(const QMimeData* mimeData) override;
 
 private:
 	AutomationClip * m_clip;
 	QPixmap m_paintPixmap;
+	
+	static QString m_shortcutMessage;
 	
 	QStaticText m_staticTextName;
 	void scaleTimemapToFit( float oldMin, float oldMax );

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -178,6 +178,14 @@ protected:
 		m_needsUpdate = true;
 		selectableObject::resizeEvent( re );
 	}
+	
+	// InteractiveModelView methods
+	std::vector<ModelShortcut> getShortcuts() override;
+	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
+	QString getShortcutMessage() override;
+	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
+	bool processPaste(const QMimeData* mimeData) override;
+	void overrideSetIsHighlighted(bool isHighlighted) override;
 
 	bool unquantizedModHeld( QMouseEvent * me );
 	TimePos quantizeSplitPos( TimePos, bool shiftMode );
@@ -195,7 +203,7 @@ protected slots:
 	void updateLength();
 	void updatePosition();
 
-
+	static QString getDefaultSortcutMessage();
 private:
 	enum class Action
 	{
@@ -210,6 +218,7 @@ private:
 	} ;
 
 	static TextFloat * s_textFloat;
+	static QString m_shortcutMessage;
 
 	Clip * m_clip;
 	Action m_action;

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -32,6 +32,7 @@
 #include "ModelView.h"
 #include "Rubberband.h"
 #include "Clip.h"
+#include "Clipboard.h"
 
 
 class QMenu;
@@ -125,6 +126,9 @@ public:
 
 	// Returns true if selection can be merged and false if not
 	static bool canMergeSelection(QVector<ClipView*> clipvs);
+	
+	//! used for getting the correct clip `StringPairDataType` for a given track
+	static Clipboard::StringPairDataType getClipStringPairType(Track* track);
 
 	QColor getColorForDisplay( QColor );
 

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -49,6 +49,7 @@ namespace lmms::Clipboard
 		FloatValue,
 		AutomatableModelLink,
 		Instrument,
+		
 		PresetFile,
 		PluginPresetFile,
 		SampleFile,
@@ -56,7 +57,20 @@ namespace lmms::Clipboard
 		PatchFile,
 		VstPluginFile,
 		ImportedProject,
-		ProjectFile
+		ProjectFile,
+		
+		SampleData,
+		
+		InstrumentTrack,
+		PatternTrack,
+		SampleTrack,
+		AutomationTrack,
+		HiddenAutomationTrack,
+		
+		MidiClip,
+		PatternClip,
+		SampleClip,
+		AutomationClip
 	};
 
 	// Convenience Methods
@@ -89,11 +103,12 @@ namespace lmms::Clipboard
 		}
 	}
 
-	const std::array<QString, 12> StringPairDataTypeNames = {
+	const std::array<QString, 22> StringPairDataTypeNames = {
 		QString("None_error"),
 		QString("FloatValue"),
 		QString("AutomatableModelLink"),
 		QString("Instrument"),
+		
 		QString("PresetFile"),
 		QString("PluginPresetFile"),
 		QString("SampleFile"),
@@ -101,7 +116,20 @@ namespace lmms::Clipboard
 		QString("PatchFile"),
 		QString("VstPluginFile"),
 		QString("ImportedProject"),
-		QString("ProjectFile")
+		QString("ProjectFile"),
+		
+		QString("SampleData"),
+		
+		QString("InstrumentTrack"),
+		QString("PatternTrack"),
+		QString("SampleTrack"),
+		QString("AutomationTrack"),
+		QString("HiddenAutomationTrack"),
+		
+		QString("MidiClip"),
+		QString("PatternClip"),
+		QString("SampleClip"),
+		QString("AutomationClip")
 	};
 
 } // namespace lmms::Clipboard

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -25,6 +25,8 @@
 #ifndef LMMS_CLIPBOARD_H
 #define LMMS_CLIPBOARD_H
 
+#include <array>
+
 #include <QDomElement>
 #include <QMap>
 
@@ -40,6 +42,22 @@ namespace lmms::Clipboard
 		StringPair,
 		Default
 	};
+	
+	enum StringPairDataType
+	{
+		None, //!< only use for error handling
+		FloatValue,
+		AutomatableModelLink,
+		Instrument,
+		PresetFile,
+		PluginPresetFile,
+		SampleFile,
+		SoundFontFile,
+		PatchFile,
+		VstPluginFile,
+		ImportedProject,
+		ProjectFile
+	};
 
 	// Convenience Methods
 	const QMimeData * getMimeData();
@@ -50,9 +68,12 @@ namespace lmms::Clipboard
 	QString getString( MimeType mT );
 
 	// Helper methods for String Pair data
-	void copyStringPair( const QString & key, const QString & value );
-	QString decodeKey( const QMimeData * mimeData );
+	void copyStringPair(StringPairDataType key, const QString& value);
+	StringPairDataType decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
+
+	QString clipboardEncodeFloatValue(float value);
+	QString clipboardEncodeAutomatableModelLink(size_t id);
 
 	inline const char * mimeType( MimeType type )
 	{
@@ -67,6 +88,21 @@ namespace lmms::Clipboard
 				break;
 		}
 	}
+
+	const std::array<QString, 12> StringPairDataTypeNames = {
+		QString("None_error"),
+		QString("FloatValue"),
+		QString("AutomatableModelLink"),
+		QString("Instrument"),
+		QString("PresetFile"),
+		QString("PluginPresetFile"),
+		QString("SampleFile"),
+		QString("SoundFontFile"),
+		QString("PatchFile"),
+		QString("VstPluginFile"),
+		QString("ImportedProject"),
+		QString("ProjectFile")
+	};
 
 } // namespace lmms::Clipboard
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -88,7 +88,7 @@ protected:
 	// InteractiveModelView methods
 	std::vector<ModelShortcut> getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
-	QString& getShortcutMessage() override;
+	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
 	bool processPaste(const QMimeData* mimeData) override;
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -90,7 +90,7 @@ protected:
 	bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
 	QString& getShortcutMessage();
 	std::vector<ModelShortcut> getShortcuts();
-	bool processPaste(Clipboard::StringPairDataType type, QString value);
+	bool processPaste(const QMimeData* mimeData);
 
 	virtual float getValue(const QPoint & p);
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -86,11 +86,11 @@ protected:
 	void leaveEvent(QEvent *event) override;
 
 	// InteractiveModelView methods
-	void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event);
-	bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
-	QString& getShortcutMessage();
-	std::vector<ModelShortcut> getShortcuts();
-	bool processPaste(const QMimeData* mimeData);
+	std::vector<ModelShortcut> getShortcuts() override;
+	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
+	QString& getShortcutMessage() override;
+	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
+	bool processPaste(const QMimeData* mimeData) override;
 
 	virtual float getValue(const QPoint & p);
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -30,6 +30,7 @@
 #include <QPoint>
 
 #include "AutomatableModelView.h"
+#include "InteractiveModelView.h"
 
 
 namespace lmms::gui
@@ -37,7 +38,7 @@ namespace lmms::gui
 
 class SimpleTextFloat;
 
-class LMMS_EXPORT FloatModelEditorBase : public QWidget, public FloatModelView
+class LMMS_EXPORT FloatModelEditorBase : public InteractiveModelView, public FloatModelView
 {
 	Q_OBJECT
 
@@ -84,6 +85,13 @@ protected:
 	void enterEvent(QEvent *event) override;
 	void leaveEvent(QEvent *event) override;
 
+	// InteractiveModelView methods
+	void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event);
+	bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
+	QString& getShortcutMessage();
+	std::vector<ModelShortcut> getShortcuts();
+	bool processPaste(Clipboard::StringPairDataType type, QString value);
+
 	virtual float getValue(const QPoint & p);
 
 private slots:
@@ -105,6 +113,7 @@ private:
 	}
 
 	static SimpleTextFloat * s_textFloat;
+	static QString m_shortcutMessage;
 
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -26,9 +26,9 @@
 #define LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
 
 #include <list>
-#include <memory>
 #include <vector>
 
+#include <QApplication>
 #include <QWidget>
 
 #include "Clipboard.h"
@@ -38,7 +38,8 @@
 namespace lmms::gui
 {
 
-
+//class QPainter;
+class SimpleTextFloat;
 
 class LMMS_EXPORT InteractiveModelView : public QWidget
 {
@@ -47,63 +48,88 @@ public:
 	InteractiveModelView(QWidget* widget);
 	~InteractiveModelView() override;
 
-	//virtual void setModel( Model* model, bool isOldModelValid = true );
-	//virtual void unsetModel();
-
-
-
-	// highlighting
-	// keyboard
-	// display shortcuts -> mouse enter event
-
-
 	static void startHighlighting(Clipboard::StringPairDataType dataType);
 	static void stopHighlighting();
+	static void showMessage(QString& message);
+	static void hideMessage();
 
 protected:
 	class ModelShortcut
 	{
 	public:
-	
+		inline ModelShortcut() {}
+		inline ModelShortcut(Qt::Key key, Qt::KeyboardModifier modifier, unsigned int times, QString description, bool shouldLoop) :
+			m_key(key),
+			m_modifier(modifier),
+			m_times(times),
+			m_shortcutDescription(description),
+			m_shouldLoop(shouldLoop)
+		{
+		}
+
 		inline bool operator==(ModelShortcut& rhs)
 		{
-			return m_key == rhs.m_key &&
-				m_modifier == rhs.m_modifier &&
-				m_times == rhs.m_times;
+			return m_key == rhs.m_key
+				&& m_modifier == rhs.m_modifier
+				&& m_times == rhs.m_times
+				&& m_shouldLoop == rhs.m_shouldLoop;
 		}
-		
-		/*
-		inline bool operator==(const ModelShortcut& firstShortcut, const ModelShortcut& secondShortcut)
+
+		inline void reset()
 		{
-    		return firstShortcut.m_key == secondShortcut.m_key &&
-    			firstShortcut.m_modifier == secondShortcut.m_modifier &&
-    			firstShortcut.m_times == secondShortcut.m_times;
+			m_key = Qt::Key_F35;
+			m_modifier = Qt::NoModifier;
+			m_times = 0;
+			m_shortcutDescription = "";
+			m_shouldLoop = false;
 		}
-		*/
-		Qt::Key m_key;
-		Qt::KeyboardModifier m_modifier;
-		unsigned int m_times;
-		QString m_shortcutDescription;
+
+		Qt::Key m_key = Qt::Key_F35;
+		Qt::KeyboardModifier m_modifier = Qt::NoModifier;
+		//! how many times do the keys need to be pressed to activate this shortcut
+		unsigned int m_times = 0;
+		//! what the shortcut does
+		QString m_shortcutDescription = "";
+		//! should it loop back if m_times is reached
+		bool m_shouldLoop = false;
 	};
 
 	void keyPressEvent(QKeyEvent* event) override;
 	void enterEvent(QEvent* event) override;
 	void leaveEvent(QEvent* event) override;
 	
-	virtual void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
-	virtual bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
+	//! return the avalible shortcuts for the widget
 	virtual std::vector<ModelShortcut> getShortcuts() = 0;
+	//! called when a `getShortcuts()` shortcut shortcut is pressed
+	virtual void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
+	//! called when a shortcut message needs to be displayed
+	//! should return the message built with `buildShortcutMessage()`
+	virtual QString& getShortcutMessage() = 0;
+	//! return true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
+	virtual bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType) = 0;
+	//! should implement dragging and dropping widgets or pasting from clipboard
+	//! should return if `QDropEvent` event can be accepted
+	//! force implement this method
+	virtual bool processPaste(Clipboard::StringPairDataType type, QString value) = 0;
+
+	//void drawAutoHighlight(QPainter* painter);
+	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;
 private:
 	void setIsHighlighted(bool isHighlighted);
-	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event, unsigned int times) const;
+	//! draws
+	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const;
+	bool doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const;
 
 	bool m_isHighlighted;
 	
 	ModelShortcut m_lastShortcut;
 	unsigned int m_lastShortcutCounter;
-	
+
+	QWidget* m_focusedBeforeWidget;
+
+	static SimpleTextFloat* s_simpleTextFloat;
 	static std::list<InteractiveModelView*> s_interactiveWidgets;
 };
 

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -1,0 +1,97 @@
+/*
+ * InteractiveModelView.h - TODO
+ *
+ * Copyright (c) 2024 szeli1 <TODO/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
+#define LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
+
+#include <array>
+#include <list>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Model.h"
+
+namespace lmms::gui
+{
+
+class LMMS_EXPORT InteractiveModelView : public ModelView
+{
+public:
+	InteractiveModelView(Model* model, QWidget* widget);
+	~InteractiveModelView() override;
+
+	//virtual void setModel( Model* model, bool isOldModelValid = true );
+	//virtual void unsetModel();
+
+
+
+	// highlighting
+	// keyboard
+	// display shortcuts -> mouse enter event
+
+
+	static void startHighlighting(Clipboard::StringPairDataType dataType);
+	static void stopHighlighting();
+
+protected:
+	struct ModelShortcut
+	{
+		Qt::Key m_key;
+		Qt::KeyboardModifier m_modifier;
+		unsigned int m_times;
+		QString m_shortcutDescription;
+	};
+
+	void keyPressEvent(QKeyEvent* event) override;
+	void enterEvent(QEnterEvent* event) override;
+	void leaveEvent(QLeaveEvent* event) override;
+	
+	virtual shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
+	virtual bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
+	virtual const std::vector<ModelShortcut> getShortcuts() = 0;
+
+	bool getIsHighlighted() const;
+private:
+	bool setIsHighlighted(bool isHighlighted);
+	bool doesShortcutMatch(ModelShortcut& shortcut, QKeyEvent* event, unsigned int times);
+
+	bool m_isHighlighted;
+	
+	ModelShortcut m_lastShortcut;
+	unsigned int m_lastShortcutCounter;
+
+	/*
+	static const std::array<std::pair<Qt::Key, QString>, 2> s_keyNames = {
+		std::make_pair<Qt::Key, QString>(Qt::Key_C, "c"),
+		std::make_pair<Qt::Key, QString>(Qt::Key_V, "v")
+	};
+	*/
+	
+	static std::list<InteractiveModelView*> s_interactiveWidgets;
+};
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_INTERACTIVE_MODEL_VIEW_H

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -110,29 +110,33 @@ protected:
 	//! return the avalible shortcuts for the widget
 	virtual std::vector<ModelShortcut> getShortcuts() = 0;
 	//! called when a `getShortcuts()` shortcut shortcut is pressed
-	virtual void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
+	virtual void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) = 0;
 	//! called when a shortcut message needs to be displayed
 	//! should return the message built with `buildShortcutMessage()`
-	virtual QString& getShortcutMessage() = 0;
+	virtual QString getShortcutMessage() = 0;
 	//! return true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
-	virtual bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType) = 0;
+	virtual bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) = 0;
 	//! should implement dragging and dropping widgets or pasting from clipboard
 	//! should return if `QDropEvent` event can be accepted
 	//! force implement this method
 	virtual bool processPaste(const QMimeData* mimeData) = 0;
+	//! return isHighlighted
+	//! override this if the widget requires custom updating code
+	virtual void overrideSetIsHighlighted(bool isHighlighted);
 
+	//! draws the highlight automatically for the widget if highilighted
 	void drawAutoHighlight(QPainter* painter);
+	//! builds a string from getShortcuts()
 	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;
+	void setIsHighlighted(bool isHighlighted);
 private slots:
 	inline static void timerStopHighlighting()
 	{
 		stopHighlighting();
 	}
 private:
-	void setIsHighlighted(bool isHighlighted);
-	//! draws
 	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const;
 	bool doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const;
 	

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -26,17 +26,21 @@
 #define LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
 
 #include <list>
+#include <memory>
 #include <vector>
 
 #include <QApplication>
 #include <QWidget>
+#include <QColor>
 
 #include "Clipboard.h"
 #include "lmms_export.h"
 #include "ModelView.h"
 
+class QColor;
 class QMimeData;
 class QPainter;
+class QTimer;
 
 namespace lmms::gui
 {
@@ -46,6 +50,7 @@ class SimpleTextFloat;
 class LMMS_EXPORT InteractiveModelView : public QWidget
 {
 Q_OBJECT
+	Q_PROPERTY(QColor highlightColor READ getHighlightColor WRITE setHighlightColor)
 public:
 	InteractiveModelView(QWidget* widget);
 	~InteractiveModelView() override;
@@ -55,6 +60,8 @@ public:
 	static void showMessage(QString& message);
 	static void hideMessage();
 
+	static QColor getHighlightColor();
+	static void setHighlightColor(QColor& color);
 protected:
 	class ModelShortcut
 	{
@@ -118,11 +125,17 @@ protected:
 	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;
+private slots:
+	inline static void timerStopHighlighting()
+	{
+		stopHighlighting();
+	}
 private:
 	void setIsHighlighted(bool isHighlighted);
 	//! draws
 	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const;
 	bool doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const;
+	
 
 	bool m_isHighlighted;
 	
@@ -131,6 +144,8 @@ private:
 
 	QWidget* m_focusedBeforeWidget;
 
+	static std::unique_ptr<QColor> s_highlightColor;
+	static QTimer* s_highlightTimer;
 	static SimpleTextFloat* s_simpleTextFloat;
 	static std::list<InteractiveModelView*> s_interactiveWidgets;
 };

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -25,21 +25,26 @@
 #ifndef LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
 #define LMMS_GUI_INTERACTIVE_MODEL_VIEW_H
 
-#include <array>
 #include <list>
 #include <memory>
-#include <utility>
 #include <vector>
 
-#include "Model.h"
+#include <QWidget>
+
+#include "Clipboard.h"
+#include "lmms_export.h"
+#include "ModelView.h"
 
 namespace lmms::gui
 {
 
-class LMMS_EXPORT InteractiveModelView : public ModelView
+
+
+class LMMS_EXPORT InteractiveModelView : public QWidget
 {
+Q_OBJECT
 public:
-	InteractiveModelView(Model* model, QWidget* widget);
+	InteractiveModelView(QWidget* widget);
 	~InteractiveModelView() override;
 
 	//virtual void setModel( Model* model, bool isOldModelValid = true );
@@ -56,8 +61,25 @@ public:
 	static void stopHighlighting();
 
 protected:
-	struct ModelShortcut
+	class ModelShortcut
 	{
+	public:
+	
+		inline bool operator==(ModelShortcut& rhs)
+		{
+			return m_key == rhs.m_key &&
+				m_modifier == rhs.m_modifier &&
+				m_times == rhs.m_times;
+		}
+		
+		/*
+		inline bool operator==(const ModelShortcut& firstShortcut, const ModelShortcut& secondShortcut)
+		{
+    		return firstShortcut.m_key == secondShortcut.m_key &&
+    			firstShortcut.m_modifier == secondShortcut.m_modifier &&
+    			firstShortcut.m_times == secondShortcut.m_times;
+		}
+		*/
 		Qt::Key m_key;
 		Qt::KeyboardModifier m_modifier;
 		unsigned int m_times;
@@ -65,29 +87,22 @@ protected:
 	};
 
 	void keyPressEvent(QKeyEvent* event) override;
-	void enterEvent(QEnterEvent* event) override;
-	void leaveEvent(QLeaveEvent* event) override;
+	void enterEvent(QEvent* event) override;
+	void leaveEvent(QEvent* event) override;
 	
-	virtual shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
+	virtual void shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event) = 0;
 	virtual bool canAcceptClipBoardData(Clipboard::StringPairDataType dataType);
-	virtual const std::vector<ModelShortcut> getShortcuts() = 0;
+	virtual std::vector<ModelShortcut> getShortcuts() = 0;
 
 	bool getIsHighlighted() const;
 private:
-	bool setIsHighlighted(bool isHighlighted);
-	bool doesShortcutMatch(ModelShortcut& shortcut, QKeyEvent* event, unsigned int times);
+	void setIsHighlighted(bool isHighlighted);
+	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event, unsigned int times) const;
 
 	bool m_isHighlighted;
 	
 	ModelShortcut m_lastShortcut;
 	unsigned int m_lastShortcutCounter;
-
-	/*
-	static const std::array<std::pair<Qt::Key, QString>, 2> s_keyNames = {
-		std::make_pair<Qt::Key, QString>(Qt::Key_C, "c"),
-		std::make_pair<Qt::Key, QString>(Qt::Key_V, "v")
-	};
-	*/
 	
 	static std::list<InteractiveModelView*> s_interactiveWidgets;
 };

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -35,10 +35,12 @@
 #include "lmms_export.h"
 #include "ModelView.h"
 
+class QMimeData;
+class QPainter;
+
 namespace lmms::gui
 {
 
-//class QPainter;
 class SimpleTextFloat;
 
 class LMMS_EXPORT InteractiveModelView : public QWidget
@@ -110,9 +112,9 @@ protected:
 	//! should implement dragging and dropping widgets or pasting from clipboard
 	//! should return if `QDropEvent` event can be accepted
 	//! force implement this method
-	virtual bool processPaste(Clipboard::StringPairDataType type, QString value) = 0;
+	virtual bool processPaste(const QMimeData* mimeData) = 0;
 
-	//void drawAutoHighlight(QPainter* painter);
+	void drawAutoHighlight(QPainter* painter);
 	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;

--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -29,16 +29,18 @@
 #include <QRubberBand>
 #include <QVector>
 
+#include "InteractiveModelView.h"
+
 namespace lmms::gui
 {
 
 
-class selectableObject : public QWidget
+class selectableObject : public InteractiveModelView
 {
 	Q_OBJECT
 public:
-	selectableObject( QWidget * _parent ) :
-		QWidget( _parent ),
+	selectableObject(QWidget* parent) :
+		InteractiveModelView(parent),
 		m_selected( false )
 	{
 	}
@@ -64,10 +66,23 @@ public slots:
 		QWidget::update();
 	}
 
+protected:
+	
+	// InteractiveModelView methods
+	/*
+	inline std::vector<ModelShortcut> getShortcuts() override { return std::vector<ModelShortcut>(); };
+	inline void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override {};
+	inline QString& getShortcutMessage() override
+	{
+		return m_tempString;
+	};
+	inline bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override { return false; };
+	inline bool processPaste(const QMimeData* mimeData) override { return false; };
+	*/
 
 private:
 	bool m_selected;
-
+	//QString m_tempString = "";
 } ;
 
 

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -60,6 +60,8 @@ protected:
 	void mouseDoubleClickEvent( QMouseEvent * ) override;
 	void paintEvent( QPaintEvent * ) override;
 
+	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
+	bool processPaste(const QMimeData* mimeData) override;
 
 private:
 	SampleClip * m_clip;

--- a/include/SimpleTextFloat.h
+++ b/include/SimpleTextFloat.h
@@ -53,6 +53,11 @@ public:
 	{
 		move(w->mapToGlobal(QPoint(0, 0)) + offset);
 	}
+	
+	inline void moveToGlobal(const QPoint& offset)
+	{
+		move(offset);
+	}
 
 	void hide();
 

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -26,11 +26,14 @@
 #ifndef LMMS_GUI_STRING_PAIR_DRAG_H
 #define LMMS_GUI_STRING_PAIR_DRAG_H
 
+#include <vector>
+
 #include <QDrag>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QMimeData>
 
+#include "Clipboard.h"
 #include "lmms_export.h"
 
 class QPixmap;
@@ -42,13 +45,15 @@ namespace lmms::gui
 class LMMS_EXPORT StringPairDrag : public QDrag
 {
 public:
-	StringPairDrag( const QString & _key, const QString & _value,
-					const QPixmap & _icon, QWidget * _w );
+	StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
+					const QPixmap& _icon, QWidget* _w);
 	~StringPairDrag() override;
 
-	static bool processDragEnterEvent( QDragEnterEvent * _dee,
-						const QString & _allowed_keys );
-	static QString decodeKey( QDropEvent * _de );
+	static bool processDragEnterEvent(QDragEnterEvent* _dee,
+						Clipboard::StringPairDataType allowedKey);
+	static bool processDragEnterEvent(QDragEnterEvent* _dee,
+						const std::vector<Clipboard::StringPairDataType>* allowedKeys);
+	static Clipboard::StringPairDataType decodeKey(QDropEvent * _de);
 	static QString decodeValue( QDropEvent * _de );
 } ;
 

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -46,7 +46,7 @@ class LMMS_EXPORT StringPairDrag : public QDrag
 {
 public:
 	StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
-					const QPixmap& _icon, QWidget* _w);
+					const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets = true);
 	~StringPairDrag() override;
 
 	static bool processDragEnterEvent(QDragEnterEvent* _dee,

--- a/include/Track.h
+++ b/include/Track.h
@@ -72,6 +72,7 @@ class LMMS_EXPORT Track : public Model, public JournallingObject
 public:
 	using clipVector = std::vector<Clip*>;
 
+	// Note: implement StringPairDrag for new track types in `ClipView` and `TrackView`
 	enum class Type
 	{
 		Instrument,

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -27,6 +27,7 @@
 
 #include <QWidget>
 
+#include "Clipboard.h"
 #include "JournallingObject.h"
 #include "ModelView.h"
 #include "TrackContentWidget.h"
@@ -104,7 +105,7 @@ public:
 	// Currently instrument track and sample track supports it
 	virtual QMenu * createMixerMenu(QString title, QString newMixerLabel);
 
-
+	static Clipboard::StringPairDataType getTrackStringPairType(Track* track);
 public slots:
 	virtual bool close();
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -197,7 +197,7 @@ void AudioFileProcessorView::dropEvent(QDropEvent* de)
 	const auto type = StringPairDrag::decodeKey(de);
 	const auto value = StringPairDrag::decodeValue(de);
 
-	if (type == "samplefile") { castModel<AudioFileProcessor>()->setAudioFile(value); }
+	if (type == Clipboard::StringPairDataType::SampleFile) { castModel<AudioFileProcessor>()->setAudioFile(value); }
 	else if (type == QString("clip_%1").arg(static_cast<int>(Track::Type::Sample)))
 	{
 		DataFile dataFile(value.toUtf8());

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -596,9 +596,9 @@ void PatmanView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void PatmanView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	auto type = StringPairDrag::decodeKey( _de );
 	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "samplefile" )
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		m_pi->setFile( value );
 		_de->accept();

--- a/plugins/SlicerT/SlicerTView.cpp
+++ b/plugins/SlicerT/SlicerTView.cpp
@@ -156,15 +156,15 @@ void SlicerTView::dragEnterEvent(QDragEnterEvent* dee)
 
 void SlicerTView::dropEvent(QDropEvent* de)
 {
-	QString type = StringPairDrag::decodeKey(de);
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue(de);
-	if (type == "samplefile")
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		// set m_wf wave file
 		m_slicerTParent->updateFile(value);
 		return;
 	}
-	else if (type == QString("clip_%1").arg(static_cast<int>(Track::Type::Sample)))
+	else if (type == Clipboard::StringPairDataType::SampleClip)
 	{
 		DataFile dataFile(value.toUtf8());
 		m_slicerTParent->updateFile(dataFile.content().firstChild().toElement().attribute("src"));

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -854,9 +854,9 @@ void VestigeInstrumentView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void VestigeInstrumentView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	auto type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "vstplugin" )
+	if (type == Clipboard::StringPairDataType::VstPluginFile)
 	{
 		m_vi->loadFile( value );
 		_de->accept();
@@ -1210,9 +1210,9 @@ void ManageVestigeInstrumentView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void ManageVestigeInstrumentView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	auto type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "vstplugin" )
+	if (type == Clipboard::StringPairDataType::VstPluginFile)
 	{
 		m_vi->loadFile( value );
 		_de->accept();

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -601,9 +601,9 @@ void ZynAddSubFxView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void ZynAddSubFxView::dropEvent( QDropEvent * _de )
 {
-	const QString type = StringPairDrag::decodeKey( _de );
+	const auto type = StringPairDrag::decodeKey(_de);
 	const QString value = StringPairDrag::decodeValue( _de );
-	if( type == "pluginpresetfile" )
+	if (type == Clipboard::StringPairDataType::PluginPresetFile)
 	{
 		castModel<ZynAddSubFxInstrument>()->loadFile( value );
 		_de->accept();

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -69,7 +69,7 @@ namespace lmms::Clipboard
 
 	void copyStringPair(StringPairDataType key, const QString & value )
 	{
-		QString finalString = key + ":" + value;
+		QString finalString = StringPairDataTypeNames[static_cast<size_t>(key)] + ":" + value;
 
 		auto content = new QMimeData;
 		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -67,7 +67,7 @@ namespace lmms::Clipboard
 
 
 
-	void copyStringPair( const QString & key, const QString & value )
+	void copyStringPair(StringPairDataType key, const QString & value )
 	{
 		QString finalString = key + ":" + value;
 
@@ -79,9 +79,17 @@ namespace lmms::Clipboard
 
 
 
-	QString decodeKey( const QMimeData * mimeData )
+	StringPairDataType decodeKey(const QMimeData* mimeData)
 	{
-		return( QString::fromUtf8( mimeData->data( mimeType( MimeType::StringPair ) ) ).section( ':', 0, 0 ) );
+		QString keyString = QString::fromUtf8(mimeData->data(mimeType(MimeType::StringPair))).section(':', 0, 0);
+		for (size_t i = 0; i < StringPairDataTypeNames.size(); i++)
+		{
+			if (StringPairDataTypeNames[i] == keyString)
+			{
+				return static_cast<StringPairDataType>(i);
+			}
+		}
+		return StringPairDataType::None;
 	}
 
 
@@ -90,6 +98,16 @@ namespace lmms::Clipboard
 	QString decodeValue( const QMimeData * mimeData )
 	{
 		return( QString::fromUtf8( mimeData->data( mimeType( MimeType::StringPair ) ) ).section( ':', 1, -1 ) );
+	}
+	
+	QString clipboardEncodeFloatValue(float value)
+	{
+		return QString::number(value);
+	}
+	
+	QString clipboardEncodeAutomatableModelLink(size_t id)
+	{
+		return QString::number(id);
 	}
 
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -67,7 +67,7 @@ namespace lmms::Clipboard
 
 
 
-	void copyStringPair(StringPairDataType key, const QString & value )
+	void copyStringPair(StringPairDataType key, const QString& value)
 	{
 		QString finalString = StringPairDataTypeNames[static_cast<size_t>(key)] + ":" + value;
 

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -173,7 +173,8 @@ void AutomatableModelView::mousePressEvent( QMouseEvent* event )
 {
 	if( event->button() == Qt::LeftButton && event->modifiers() & Qt::ControlModifier )
 	{
-		new gui::StringPairDrag( "automatable_model", QString::number( modelUntyped()->id() ), QPixmap(), widget() );
+		new gui::StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink,
+			Clipboard::clipboardEncodeAutomatableModelLink(modelUntyped()->id()), QPixmap(), widget());
 		event->accept();
 	}
 	else if( event->button() == Qt::MiddleButton )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(LMMS_SRCS
 	gui/embed.cpp
 	gui/FileBrowser.cpp
 	gui/GuiApplication.cpp
+	gui/InteractiveModelView.cpp
 	gui/LadspaControlView.cpp
 	gui/LfoControllerDialog.cpp
 	gui/LinkedModelGroupViews.cpp

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -818,33 +818,33 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 			{
 				case FileItem::FileType::Preset:
 					new StringPairDrag( f->handling() == FileItem::FileHandling::LoadAsPreset ?
-							"presetfile" : "pluginpresetfile",
+							Clipboard::StringPairDataType::PresetFile : Clipboard::StringPairDataType::PluginPresetFile,
 							f->fullName(),
 							embed::getIconPixmap( "preset_file" ), this );
 					break;
 
 				case FileItem::FileType::Sample:
-					new StringPairDrag( "samplefile", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::SampleFile, f->fullName(),
 							embed::getIconPixmap( "sample_file" ), this );
 					break;
 				case FileItem::FileType::SoundFont:
-					new StringPairDrag( "soundfontfile", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::SoundFontFile, f->fullName(),
 							embed::getIconPixmap( "soundfont_file" ), this );
 					break;
 				case FileItem::FileType::Patch:
-					new StringPairDrag( "patchfile", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::PatchFile, f->fullName(),
 							embed::getIconPixmap( "sample_file" ), this );
 					break;
 				case FileItem::FileType::VstPlugin:
-					new StringPairDrag( "vstpluginfile", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::VstPluginFile, f->fullName(),
 							embed::getIconPixmap( "vst_plugin_file" ), this );
 					break;
 				case FileItem::FileType::Midi:
-					new StringPairDrag( "importedproject", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::ImportedProject, f->fullName(),
 							embed::getIconPixmap( "midi_file" ), this );
 					break;
 				case FileItem::FileType::Project:
-					new StringPairDrag( "projectfile", f->fullName(),
+					new StringPairDrag(Clipboard::StringPairDataType::ProjectFile, f->fullName(),
 							embed::getIconPixmap( "project_file" ), this );
 					break;
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -98,7 +98,8 @@ void InteractiveModelView::showMessage(QString& message)
 		s_simpleTextFloat = new SimpleTextFloat();
 	}
 	s_simpleTextFloat->setText(message);
-	s_simpleTextFloat->moveToGlobal(QPoint(2, getGUI()->mainWindow()->height()));
+	s_simpleTextFloat->moveToGlobal(QPoint(getGUI()->mainWindow()->pos().x() + 2,
+		getGUI()->mainWindow()->pos().y() + getGUI()->mainWindow()->height()));
 	s_simpleTextFloat->showWithDelay(0, 60000);
 }
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -185,12 +185,10 @@ void InteractiveModelView::leaveEvent(QEvent* event)
 	}
 }
 
-/*
 void InteractiveModelView::drawAutoHighlight(QPainter* painter)
 {
-	
+	//TODO
 }
-*/
 
 QString InteractiveModelView::buildShortcutMessage()
 {

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -31,6 +31,8 @@
 namespace lmms::gui
 {
 
+std::list<InteractiveModelView*> InteractiveModelView::s_interactiveWidgets;
+
 InteractiveModelView::InteractiveModelView(QWidget* widget) :
 	QWidget(widget),
 	m_isHighlighted(false),

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -1,0 +1,138 @@
+/*
+ * InteractiveModelView.h - TODO
+ *
+ * Copyright (c) 2024 szeli1 <TODO/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "InteractiveModelView.h"
+
+namespace lmms::gui
+{
+
+InteractiveModelView::InteractiveModelView(Model* model, QWidget* widget) :
+	ModelView(model, widget),
+	m_isHighlighted(false),
+	m_lastShortcutCounter(0)
+{
+	s_interactiveWidgets.push_back(this);
+
+	m_lastShortcut.m_key = Qt::Key_F35;
+	m_lastShortcut.m_modifier = Qt::NoModifier;
+	m_lastShortcut.m_times = 0;
+	m_lastShortcut.m_shortcutDescription = "";
+}
+
+InteractiveModelView::~InteractiveModelView()
+{
+	for (auto it = s_interactiveWidgets.begin(); it != s_interactiveWidgets.end(); ++it)
+	{
+		if (it == this)
+		{
+			s_interactiveWidgets.erase(it);
+			break;
+		}
+	}
+}
+
+static void InteractiveModelView::startHighlighting(Clipboard::StringPairDataType dataType)
+{
+	for (auto it = s_interactiveWidgets.begin(); it != s_interactiveWidgets.end(); ++it)
+	{
+		if (it->canAcceptClipBoardData(dataType))
+		{
+			it->setIsHighlighted(true);
+		}
+	}
+}
+
+static void InteractiveModelView::stopHighlighting()
+{
+	for (auto it = s_interactiveWidgets.begin(); it != s_interactiveWidgets.end(); ++it)
+	{
+		it->setIsHighlighted(false);
+	}
+}
+
+void InteractiveModelView::keyPressEvent(QKeyEvent* event)
+{
+	const std::vector<ModelShortcut> shortcuts(getShortcuts());
+	for (size_t i = 0; i < shortcuts.size(); i++)
+	{
+		if (doesShortcutMatch(shortcuts[i], event, m_lastShortcutCounter))
+		{
+			if (m_lastShortcut == shortcuts[i])
+			{
+				m_lastShortcutCounter++;
+			}
+			else
+			{
+				m_lastShortcut = shortcuts[i];
+				m_lastShortcutCounter = 0;
+			}
+			qDebug("found shortcut");
+			shortcutPressedEvent(i, event);
+			break;
+		}
+	}
+}
+
+void InteractiveModelView::enterEvent(QEnterEvent* event)
+{
+	m_lastShortcutCounter = 0;
+
+	m_lastShortcut.m_key = Qt::Key_F35;
+	m_lastShortcut.m_modifier = Qt::NoModifier;
+	m_lastShortcut.m_times = 0;
+	m_lastShortcut.m_shortcutDescription = "";
+	
+	qDebug("enter event");
+}
+
+void InteractiveModelView::leaveEvent(QLeaveEvent* event)
+{
+	qDebug("leave event");
+}
+
+bool InteractiveModelView::canAcceptClipBoardData(Clipboard::StringPairDataType dataType)
+{
+	return false;
+}
+
+bool InteractiveModelView::getIsHighlighted() const
+{
+	return m_isHighlighted;
+}
+
+bool InteractiveModelView::setIsHighlighted(bool isHighlighted)
+{
+	if (m_isHighlighted != isHighlighted)
+	{
+		m_isHighlighted = isHighlighted;
+		update();
+	}
+}
+
+bool InteractiveModelView::doesShortcutMatch(ModelShortcut& shortcut, QKeyEvent* event, unsigned int times)
+{
+	return shortcut.m_key == event->key() && (event->modifiers() & shortcut.m_modifier) && shortcut.m_times == times;
+}
+
+} // namespace lmms::gui

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -27,23 +27,27 @@
 #include <algorithm>
 
 #include <QKeyEvent>
+#include <QKeySequence> // displaying qt key names
+
+#include "GuiApplication.h"
+#include "MainWindow.h"
+#include "SimpleTextFloat.h"
 
 namespace lmms::gui
 {
 
+SimpleTextFloat* InteractiveModelView::s_simpleTextFloat = nullptr;
 std::list<InteractiveModelView*> InteractiveModelView::s_interactiveWidgets;
 
 InteractiveModelView::InteractiveModelView(QWidget* widget) :
 	QWidget(widget),
 	m_isHighlighted(false),
-	m_lastShortcutCounter(0)
+	m_lastShortcutCounter(0),
+	m_focusedBeforeWidget(nullptr)
 {
 	s_interactiveWidgets.push_back(this);
 
-	m_lastShortcut.m_key = Qt::Key_F35;
-	m_lastShortcut.m_modifier = Qt::NoModifier;
-	m_lastShortcut.m_times = 0;
-	m_lastShortcut.m_shortcutDescription = "";
+	m_lastShortcut.reset();
 }
 
 InteractiveModelView::~InteractiveModelView()
@@ -74,50 +78,140 @@ void InteractiveModelView::stopHighlighting()
 	}
 }
 
+void InteractiveModelView::showMessage(QString& message)
+{
+	if (s_simpleTextFloat == nullptr)
+	{
+		// we don't own this object, so we do not need to delete it
+		s_simpleTextFloat = new SimpleTextFloat();
+	}
+	s_simpleTextFloat->setText(message);
+	s_simpleTextFloat->moveToGlobal(QPoint(2, getGUI()->mainWindow()->height()));
+	s_simpleTextFloat->showWithDelay(0, 60000);
+}
+
+void InteractiveModelView::hideMessage()
+{
+	if (s_simpleTextFloat == nullptr)
+	{
+		s_simpleTextFloat = new SimpleTextFloat();
+	}
+	s_simpleTextFloat->hide();
+}
+
 void InteractiveModelView::keyPressEvent(QKeyEvent* event)
 {
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
-	for (size_t i = 0; i < shortcuts.size(); i++)
+
+	size_t foundIndex = 0;
+	unsigned int minMaxTimes = 0;
+	bool found = false;
+
+	// if the last shortcut's keys mach the current keys
+	if (doesShortcutMatch(&m_lastShortcut, event))
 	{
-		if (doesShortcutMatch(&(shortcuts[i]), event, m_lastShortcutCounter))
+		// find the highest m_times or
+		// the shortcut that's m_times == m_lastShortcutCounter
+		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
-			ModelShortcut temp = shortcuts[i];
-			if (m_lastShortcut == temp)
+			if (doesShortcutMatch(&shortcuts[i], event))
 			{
-				m_lastShortcutCounter++;
+				// selecting the shortcut with the largest m_times
+				if (found == false || minMaxTimes < shortcuts[i].m_times)
+				{
+					foundIndex = i;
+					minMaxTimes = shortcuts[i].m_times;
+				}
+				found = true;
+			
+				if (m_lastShortcutCounter == shortcuts[i].m_times)
+				{
+					m_lastShortcutCounter = shortcuts[i].m_shouldLoop ? 0 : m_lastShortcutCounter + 1;
+					foundIndex = i;
+					break;
+				}
 			}
-			else
-			{
-				m_lastShortcut = shortcuts[i];
-				m_lastShortcutCounter = 0;
-			}
-			qDebug("found shortcut");
-			shortcutPressedEvent(i, event);
-			break;
 		}
+	}
+	else
+	{
+		// find the lowest m_times
+		for (size_t i = 0; i < shortcuts.size(); i++)
+		{
+			if (doesShortcutMatch(&shortcuts[i], event))
+			{
+				// selecting the shortcut with the largest m_times
+				if (found == false || minMaxTimes > shortcuts[i].m_times)
+				{
+					foundIndex = i;
+					minMaxTimes = shortcuts[i].m_times;
+				}
+				m_lastShortcut = shortcuts[i];
+				m_lastShortcutCounter = 1;
+				found = true;
+			}
+		}
+	}
+	if (found)
+	{
+		QString message = shortcuts[foundIndex].m_shortcutDescription;
+		showMessage(message);
+		shortcutPressedEvent(foundIndex, event);
 	}
 }
 
 void InteractiveModelView::enterEvent(QEvent* event)
 {
 	m_lastShortcutCounter = 0;
+	m_lastShortcut.reset();
 
-	m_lastShortcut.m_key = Qt::Key_F35;
-	m_lastShortcut.m_modifier = Qt::NoModifier;
-	m_lastShortcut.m_times = 0;
-	m_lastShortcut.m_shortcutDescription = "";
-	
-	qDebug("enter event");
+	showMessage(getShortcutMessage());
+
+	if (isVisible())
+	{
+		m_focusedBeforeWidget = QApplication::focusWidget();
+		// focus on this widget so keyPressEvent works
+		setFocus();
+	}
 }
 
 void InteractiveModelView::leaveEvent(QEvent* event)
 {
-	qDebug("leave event");
+	hideMessage();
+	// reset focus
+	if (m_focusedBeforeWidget)
+	{
+		m_focusedBeforeWidget->setFocus();
+	}
 }
 
-bool InteractiveModelView::canAcceptClipBoardData(Clipboard::StringPairDataType dataType)
+/*
+void InteractiveModelView::drawAutoHighlight(QPainter* painter)
 {
-	return false;
+	
+}
+*/
+
+QString InteractiveModelView::buildShortcutMessage()
+{
+	QString message = "";
+	std::vector<ModelShortcut> shortcuts(getShortcuts());
+	for (size_t i = 0; i < shortcuts.size(); i++)
+	{
+		message = message + QString("\"") + QKeySequence(shortcuts[i].m_modifier).toString()
+			+ QKeySequence(shortcuts[i].m_key).toString();
+		if (shortcuts[i].m_times > 0)
+		{
+			message = message + QString(" (x") + QString::number(shortcuts[i].m_times + 1) + QString(")");
+		}
+		message = message + QString("\": ")
+			+ shortcuts[i].m_shortcutDescription;
+		if (i + 1 < shortcuts.size())
+		{
+			message = message + QString(", ");
+		}
+	}
+	return message;
 }
 
 bool InteractiveModelView::getIsHighlighted() const
@@ -130,13 +224,21 @@ void InteractiveModelView::setIsHighlighted(bool isHighlighted)
 	if (m_isHighlighted != isHighlighted)
 	{
 		m_isHighlighted = isHighlighted;
-		update();
+		if (isVisible())
+		{
+			update();
+		}
 	}
 }
 
-bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event, unsigned int times) const
+bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const
 {
-	return shortcut->m_key == event->key() && (event->modifiers() & shortcut->m_modifier) && shortcut->m_times == times;
+	return shortcut->m_key == event->key() && (event->modifiers() & shortcut->m_modifier);
+}
+
+bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const
+{
+	return shortcutA->m_key == shortcutB->m_key && (shortcutA->m_modifier & shortcutB->m_modifier);
 }
 
 } // namespace lmms::gui

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -285,7 +285,7 @@ void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 	Engine::setDndPluginKey(&m_pluginKey);
 	if ( _me->button() == Qt::LeftButton )
 	{
-		new StringPairDrag("instrument",
+		new StringPairDrag(Clipboard::StringPairDataType::Instrument,
 			QString::fromUtf8(m_pluginKey.desc->name), m_logo, this);
 		leaveEvent( _me );
 	}

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -39,8 +39,8 @@ namespace lmms::gui
 {
 
 
-StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
-					const QPixmap & _icon, QWidget * _w ) :
+StringPairDrag::StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
+				const QPixmap& _icon, QWidget* _w) :
 	QDrag( _w )
 {
 	// For mimeType() and MimeType enum class
@@ -57,7 +57,7 @@ StringPairDrag::StringPairDrag( const QString & _key, const QString & _value,
 	{
 		setPixmap( _icon );
 	}
-	QString txt = _key + ":" + _value;
+	QString txt = Clipboard::StringPairDataTypeNames[static_cast<size_t>(key)] + ":" + _value;
 	auto m = new QMimeData();
 	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
 	setMimeData( m );
@@ -78,23 +78,38 @@ StringPairDrag::~StringPairDrag()
 }
 
 
-
-
-bool StringPairDrag::processDragEnterEvent( QDragEnterEvent * _dee,
-						const QString & _allowed_keys )
+bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
+						Clipboard::StringPairDataType allowedKey)
 {
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if( !_dee->mimeData()->hasFormat( mimeType( MimeType::StringPair ) ) )
+	if (!_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
 		return( false );
 	}
-	QString txt = _dee->mimeData()->data( mimeType( MimeType::StringPair ) );
-	if( _allowed_keys.split( ',' ).contains( txt.section( ':', 0, 0 ) ) )
+	Clipboard::StringPairDataType curKey = Clipboard::decodeKey(_dee->mimeData());
+	if (allowedKey == curKey)
 	{
 		_dee->acceptProposedAction();
-		return( true );
+		return(true);
+	}
+	_dee->ignore();
+	return( false );
+}
+
+bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
+						const std::vector<Clipboard::StringPairDataType>* allowedKeys)
+{
+	if (!_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
+	{
+		return( false );
+	}
+	Clipboard::StringPairDataType curKey = Clipboard::decodeKey(_dee->mimeData());
+	for (auto& i : (*allowedKeys))
+	{
+		if (i == curKey)
+		{
+			_dee->acceptProposedAction();
+			return(true);
+		}
 	}
 	_dee->ignore();
 	return( false );
@@ -103,9 +118,9 @@ bool StringPairDrag::processDragEnterEvent( QDragEnterEvent * _dee,
 
 
 
-QString StringPairDrag::decodeKey( QDropEvent * _de )
+Clipboard::StringPairDataType StringPairDrag::decodeKey(QDropEvent * _de)
 {
-	return Clipboard::decodeKey( _de->mimeData() );
+	return Clipboard::decodeKey(_de->mimeData());
 }
 
 

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -30,9 +30,11 @@
 
 
 #include "StringPairDrag.h"
-#include "GuiApplication.h"
-#include "MainWindow.h"
+
 #include "Clipboard.h"
+#include "GuiApplication.h"
+#include "InteractiveModelView.h"
+#include "MainWindow.h"
 
 
 namespace lmms::gui
@@ -40,7 +42,7 @@ namespace lmms::gui
 
 
 StringPairDrag::StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
-				const QPixmap& _icon, QWidget* _w) :
+				const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets) :
 	QDrag( _w )
 {
 	// For mimeType() and MimeType enum class
@@ -61,6 +63,10 @@ StringPairDrag::StringPairDrag(Clipboard::StringPairDataType key, const QString&
 	auto m = new QMimeData();
 	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
 	setMimeData( m );
+	if (shouldHighlightWidgets)
+	{
+		InteractiveModelView::startHighlighting(key);
+	}
 	exec( Qt::LinkAction, Qt::LinkAction );
 }
 

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -401,7 +401,7 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 
 void AutomationClipView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee, "automatable_model" );
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
 	if( !_dee->isAccepted() )
 	{
 		ClipView::dragEnterEvent( _dee );
@@ -413,9 +413,9 @@ void AutomationClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void AutomationClipView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString val = StringPairDrag::decodeValue( _de );
-	if( type == "automatable_model" )
+	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -44,6 +44,8 @@
 namespace lmms::gui
 {
 
+QString AutomationClipView::m_shortcutMessage = "";
+
 AutomationClipView::AutomationClipView( AutomationClip * _clip,
 						TrackView * _parent ) :
 	ClipView( _clip, _parent ),
@@ -56,6 +58,11 @@ AutomationClipView::AutomationClipView( AutomationClip * _clip,
 			this, SLOT(update()));
 
 	setAttribute( Qt::WA_OpaquePaintEvent, true );
+
+	if (m_shortcutMessage == "")
+	{
+		m_shortcutMessage = buildShortcutMessage();
+	}
 
 	setToolTip(m_clip->name());
 	setStyle( QApplication::style() );
@@ -202,6 +209,78 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 				this, SLOT(disconnectObject(QAction*)));
 		_cm->addMenu( m );
 	}
+}
+
+std::vector<InteractiveModelView::ModelShortcut> AutomationClipView::getShortcuts()
+{
+	std::vector<InteractiveModelView::ModelShortcut> clipShortcuts = ClipView::getShortcuts();
+	clipShortcuts.emplace_back(Qt::Key_F, Qt::ControlModifier, 0, QString(tr("Open in Automation editor")), false);
+	return clipShortcuts;
+}
+
+void AutomationClipView::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
+{
+	switch (shortcutLocation)
+	{
+		case 3:
+			openInAutomationEditor();
+			break;
+		default:
+			ClipView::processShortcutPressed(shortcutLocation, event);
+			break;
+	}
+}
+
+QString AutomationClipView::getShortcutMessage()
+{
+	return m_shortcutMessage;
+}
+
+bool AutomationClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+{
+	return dataType == Clipboard::StringPairDataType::AutomatableModelLink || ClipView::canAcceptClipboardData(dataType);
+}
+
+bool AutomationClipView::processPaste(const QMimeData* mimeData)
+{
+	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
+	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+	QString value = Clipboard::decodeValue(mimeData);
+
+	bool shouldAccept = false;
+	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
+	{
+		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(value.toInt()));
+		if (mod != nullptr)
+		{
+			bool added = m_clip->addObject(mod);
+			shouldAccept = added;
+			if (!added)
+			{
+				TextFloat::displayMessage(mod->displayName(),
+					tr("Model is already connected to this clip."),
+					embed::getIconPixmap("automation"), 2000);
+			}
+		}
+
+		update();
+
+		if (getGUI()->automationEditor()
+			&& getGUI()->automationEditor()->currentClip() == m_clip)
+		{
+			getGUI()->automationEditor()->setCurrentClip(m_clip);
+		}
+	}
+	
+	if (shouldAccept)
+	{
+		InteractiveModelView::stopHighlighting();
+	}
+	else
+	{
+		shouldAccept = ClipView::processPaste(mimeData);
+	}
+	return shouldAccept;
 }
 
 
@@ -391,8 +470,9 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 			embed::getIconPixmap( "muted", size, size ) );
 	}
 
+	drawAutoHighlight(&p);
 	p.end();
-
+	
 	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 
@@ -413,34 +493,11 @@ void AutomationClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void AutomationClipView::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
-	QString val = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
-	{
-		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
-		if( mod != nullptr )
-		{
-			bool added = m_clip->addObject( mod );
-			if ( !added )
-			{
-				TextFloat::displayMessage( mod->displayName(),
-							   tr( "Model is already connected "
-							   "to this clip." ),
-							   embed::getIconPixmap( "automation" ),
-							   2000 );
-			}
-		}
-		update();
+	bool shouldAccept = processPaste(_de->mimeData());
 
-		if( getGUI()->automationEditor() &&
-			getGUI()->automationEditor()->currentClip() == m_clip )
-		{
-			getGUI()->automationEditor()->setCurrentClip( m_clip );
-		}
-	}
-	else
+	if (shouldAccept)
 	{
-		ClipView::dropEvent( _de );
+		_de->accept();
 	}
 }
 

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -424,8 +424,7 @@ void ClipView::dragEnterEvent( QDragEnterEvent * dee )
 	}
 	else
 	{
-		StringPairDrag::processDragEnterEvent( dee, "clip_" +
-					QString::number( static_cast<int>(m_clip->getTrack()->type()) ) );
+		StringPairDrag::processDragEnterEvent(dee, getClipStringPairType(m_clip->getTrack()));
 	}
 }
 
@@ -443,11 +442,11 @@ void ClipView::dragEnterEvent( QDragEnterEvent * dee )
  */
 void ClipView::dropEvent( QDropEvent * de )
 {
-	QString type = StringPairDrag::decodeKey( de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
 
 	// Track must be the same type to paste into
-	if( type != ( "clip_" + QString::number( static_cast<int>(m_clip->getTrack()->type()) ) ) )
+	if (type != getClipStringPairType(m_clip->getTrack()) || type == Clipboard::StringPairDataType::None)
 	{
 		return;
 	}
@@ -818,9 +817,8 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				128, 128,
 				Qt::KeepAspectRatio,
 				Qt::SmoothTransformation );
-			new StringPairDrag( QString( "clip_%1" ).arg(
-								static_cast<int>(m_clip->getTrack()->type()) ),
-								dataFile.toString(), thumbnail, this );
+			new StringPairDrag(getClipStringPairType(m_clip->getTrack()),
+					dataFile.toString(), thumbnail, this);
 		}
 	}
 
@@ -1190,15 +1188,11 @@ void ClipView::remove( QVector<ClipView *> clipvs )
 
 void ClipView::copy( QVector<ClipView *> clipvs )
 {
-	// For copyStringPair()
-	using namespace Clipboard;
-
 	// Write the Clips to a DataFile for copying
 	DataFile dataFile = createClipDataFiles( clipvs );
 
 	// Copy the Clip type as a key and the Clip data file to the clipboard
-	copyStringPair( QString( "clip_%1" ).arg( static_cast<int>(m_clip->getTrack()->type()) ),
-		dataFile.toString() );
+	Clipboard::copyStringPair(getClipStringPairType(m_clip->getTrack()), dataFile.toString());
 }
 
 void ClipView::cut( QVector<ClipView *> clipvs )
@@ -1511,6 +1505,31 @@ QColor ClipView::getColorForDisplay( QColor defaultColor )
 auto ClipView::hasCustomColor() const -> bool
 {
 	return m_clip->color().has_value() || m_clip->getTrack()->color().has_value();
+}
+
+Clipboard::StringPairDataType ClipView::getClipStringPairType(Track* track)
+{
+	switch (track->type())
+	{
+		case Track::Type::Instrument:
+			return Clipboard::StringPairDataType::MidiClip;
+			break;
+		case Track::Type::Pattern:
+			return Clipboard::StringPairDataType::PatternClip;
+			break;
+		case Track::Type::Sample:
+			return Clipboard::StringPairDataType::SampleClip;
+			break;
+		case Track::Type::Automation:
+			return Clipboard::StringPairDataType::AutomationClip;
+			break;
+		case Track::Type::HiddenAutomation:
+			return Clipboard::StringPairDataType::AutomationClip;
+			break;
+		default:
+			break;
+	}
+	return Clipboard::StringPairDataType::None;
 }
 
 } // namespace lmms::gui

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -671,6 +671,7 @@ void MidiClipView::paintEvent( QPaintEvent * )
 			embed::getIconPixmap( "muted", size, size ) );
 	}
 
+	drawAutoHighlight(&p);
 	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -155,6 +155,7 @@ void PatternClipView::paintEvent(QPaintEvent*)
 			embed::getIconPixmap( "muted", size, size ) );
 	}
 	
+	drawAutoHighlight(&p);
 	p.end();
 	
 	painter.drawPixmap( 0, 0, m_paintPixmap );

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -119,22 +119,11 @@ void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void SampleClipView::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	bool shouldAccept = processPaste(_de->mimeData());
+
+	if (shouldAccept)
 	{
-		m_clip->setSampleFile( StringPairDrag::decodeValue( _de ) );
 		_de->accept();
-	}
-	else if (type == Clipboard::StringPairDataType::SampleData)
-	{
-		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(StringPairDrag::decodeValue(_de)));
-		m_clip->updateLength();
-		update();
-		_de->accept();
-	}
-	else
-	{
-		ClipView::dropEvent( _de );
 	}
 }
 
@@ -323,12 +312,48 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 		p.drawEllipse( 4, 5, 4, 4 );
 	}*/
 
+	drawAutoHighlight(&p);
 	p.end();
 
 	painter.drawPixmap( 0, 0, m_paintPixmap );
 }
 
+bool SampleClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+{
+	return dataType == Clipboard::StringPairDataType::SampleFile
+		|| dataType == Clipboard::StringPairDataType::SampleData
+		|| ClipView::canAcceptClipboardData(dataType);
+}
 
+bool SampleClipView::processPaste(const QMimeData* mimeData)
+{
+	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
+	bool shouldAccept = false;
+	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+
+	if (type == Clipboard::StringPairDataType::SampleFile)
+	{
+		m_clip->setSampleFile( Clipboard::decodeValue(mimeData));
+		shouldAccept = true;
+	}
+	else if (type == Clipboard::StringPairDataType::SampleData)
+	{
+		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(Clipboard::decodeValue(mimeData)));
+		m_clip->updateLength();
+		update();
+		shouldAccept = true;
+	}
+
+	if (shouldAccept)
+	{
+		InteractiveModelView::stopHighlighting();
+	}
+	else
+	{
+		shouldAccept = ClipView::processPaste(mimeData);
+	}
+	return shouldAccept;
+}
 
 
 void SampleClipView::reverseSample()

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -102,8 +102,11 @@ void SampleClipView::constructContextMenu(QMenu* cm)
 
 void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	if( StringPairDrag::processDragEnterEvent( _dee,
-					"samplefile,sampledata" ) == false )
+	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
+		Clipboard::StringPairDataType::SampleFile,
+		Clipboard::StringPairDataType::SampleData
+	};
+	if (StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys) == false)
 	{
 		ClipView::dragEnterEvent( _dee );
 	}
@@ -116,12 +119,13 @@ void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void SampleClipView::dropEvent( QDropEvent * _de )
 {
-	if( StringPairDrag::decodeKey( _de ) == "samplefile" )
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		m_clip->setSampleFile( StringPairDrag::decodeValue( _de ) );
 		_de->accept();
 	}
-	else if( StringPairDrag::decodeKey( _de ) == "sampledata" )
+	else if (type == Clipboard::StringPairDataType::SampleData)
 	{
 		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(StringPairDrag::decodeValue(_de)));
 		m_clip->updateLength();

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2236,9 +2236,9 @@ const AutomationClip* AutomationEditorWindow::currentClip()
 
 void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString val = StringPairDrag::decodeValue( _de );
-	if( type == "automatable_model" )
+	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if (mod != nullptr)
@@ -2264,7 +2264,7 @@ void AutomationEditorWindow::dragEnterEvent( QDragEnterEvent *_dee )
 	if (! m_editor->validClip() ) {
 		return;
 	}
-	StringPairDrag::processDragEnterEvent( _dee, "automatable_model" );
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
 }
 
 void AutomationEditorWindow::open(AutomationClip* clip)

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -125,10 +125,14 @@ void PatternEditor::loadSettings(const QDomElement& element)
 
 void PatternEditor::dropEvent(QDropEvent* de)
 {
-	QString type = StringPairDrag::decodeKey( de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
 
-	if( type.left( 6 ) == "track_" )
+	if (type == Clipboard::StringPairDataType::InstrumentTrack
+		|| type == Clipboard::StringPairDataType::PatternTrack
+		|| type == Clipboard::StringPairDataType::SampleTrack
+		|| type == Clipboard::StringPairDataType::AutomationTrack
+		|| type == Clipboard::StringPairDataType::HiddenAutomationTrack)
 	{
 		DataFile dataFile( value.toUtf8() );
 		Track * t = Track::create( dataFile.content().firstChild().toElement(), model() );

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -369,12 +369,21 @@ void TrackContainerView::clearAllTracks()
 
 void TrackContainerView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee,
-		QString( "presetfile,pluginpresetfile,samplefile,instrument,"
-				"importedproject,soundfontfile,patchfile,vstpluginfile,projectfile,"
-				"track_%1,track_%2" ).
-						arg( static_cast<int>(Track::Type::Instrument) ).
-						arg( static_cast<int>(Track::Type::Sample) ) );
+	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
+		Clipboard::StringPairDataType::PresetFile,
+		Clipboard::StringPairDataType::PluginPresetFile,
+		Clipboard::StringPairDataType::SampleFile,
+		Clipboard::StringPairDataType::Instrument,
+		Clipboard::StringPairDataType::SoundFontFile,
+		Clipboard::StringPairDataType::PatchFile,
+		Clipboard::StringPairDataType::VstPluginFile,
+		Clipboard::StringPairDataType::ImportedProject,
+		Clipboard::StringPairDataType::ProjectFile,
+		Clipboard::StringPairDataType::InstrumentTrack,
+		Clipboard::StringPairDataType::SampleTrack
+	};
+
+	StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys);
 }
 
 
@@ -391,9 +400,9 @@ void TrackContainerView::stopRubberBand()
 
 void TrackContainerView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "instrument" )
+	if (type == Clipboard::StringPairDataType::Instrument)
 	{
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
 		auto ilt = new InstrumentLoaderThread(this, it, value);
@@ -401,9 +410,9 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if( type == "samplefile" || type == "pluginpresetfile"
-		|| type == "soundfontfile" || type == "vstpluginfile"
-		|| type == "patchfile" )
+	else if (type == Clipboard::StringPairDataType::SampleFile || type == Clipboard::StringPairDataType::PluginPresetFile
+		|| type == Clipboard::StringPairDataType::SoundFontFile || type == Clipboard::StringPairDataType::PatchFile
+		|| type == Clipboard::StringPairDataType::VstPluginFile)
 	{
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
 		PluginFactory::PluginInfoAndKey piakn =
@@ -413,7 +422,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if( type == "presetfile" )
+	else if (type == Clipboard::StringPairDataType::PresetFile)
 	{
 		DataFile dataFile( value );
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
@@ -422,13 +431,13 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if( type == "importedproject" )
+	else if (type == Clipboard::StringPairDataType::ImportedProject)
 	{
 		ImportFilter::import( value, m_tc );
 		_de->accept();
 	}
 
-	else if( type == "projectfile")
+	else if (type == Clipboard::StringPairDataType::ProjectFile)
 	{
 		if( getGUI()->mainWindow()->mayChangeProject(true) )
 		{
@@ -437,7 +446,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		_de->accept();
 	}
 
-	else if( type.left( 6 ) == "track_" )
+	else if (type == Clipboard::StringPairDataType::InstrumentTrack || type == Clipboard::StringPairDataType::SampleTrack)
 	{
 		DataFile dataFile( value.toUtf8() );
 		Track::create( dataFile.content().firstChild().toElement(), m_tc );

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -228,9 +228,11 @@ void EnvelopeAndLfoView::modelChanged()
 
 void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee,
-					QString( "samplefile,clip_%1" ).arg(
-							static_cast<int>(Track::Type::Sample) ) );
+	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
+		Clipboard::StringPairDataType::SampleFile,
+		Clipboard::StringPairDataType::SampleClip
+	};
+	StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys);
 }
 
 
@@ -238,9 +240,9 @@ void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "samplefile" )
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		m_params->m_userWave = SampleLoader::createBufferFromFile(value);
 		m_userLfoBtn->model()->setValue( true );
@@ -248,7 +250,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 		_de->accept();
 		update();
 	}
-	else if( type == QString( "clip_%1" ).arg( static_cast<int>(Track::Type::Sample) ) )
+	else if (type == Clipboard::StringPairDataType::SampleClip)
 	{
 		DataFile dataFile( value.toUtf8() );
 		auto file = dataFile.content().

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -541,7 +541,12 @@ void InstrumentTrackWindow::focusInEvent( QFocusEvent* )
 
 void InstrumentTrackWindow::dragEnterEventGeneric( QDragEnterEvent* event )
 {
-	StringPairDrag::processDragEnterEvent( event, "instrument,presetfile,pluginpresetfile" );
+	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
+		Clipboard::StringPairDataType::Instrument,
+		Clipboard::StringPairDataType::PresetFile,
+		Clipboard::StringPairDataType::PluginPresetFile
+	};
+	StringPairDrag::processDragEnterEvent(event, &acceptedKeys);
 }
 
 
@@ -557,10 +562,10 @@ void InstrumentTrackWindow::dragEnterEvent( QDragEnterEvent* event )
 
 void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 {
-	QString type = StringPairDrag::decodeKey( event );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(event);
 	QString value = StringPairDrag::decodeValue( event );
 
-	if( type == "instrument" )
+	if (type == Clipboard::StringPairDataType::Instrument)
 	{
 		m_track->loadInstrument( value, nullptr, true /* DnD */ );
 
@@ -569,14 +574,14 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 		event->accept();
 		setFocus();
 	}
-	else if( type == "presetfile" )
+	else if (type == Clipboard::StringPairDataType::PresetFile)
 	{
 		DataFile dataFile(value);
 		m_track->replaceInstrument(dataFile);
 		event->accept();
 		setFocus();
 	}
-	else if( type == "pluginpresetfile" )
+	else if (type == Clipboard::StringPairDataType::PluginPresetFile)
 	{
 		const QString ext = FileItem::extension( value );
 		Instrument * i = m_track->instrument();

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -648,20 +648,6 @@ void PianoView::focusOutEvent( QFocusEvent * )
 		return;
 	}
 
-	// focus just switched to another control inside the instrument track
-	// window we live in?
-	if( parentWidget()->parentWidget()->focusWidget() != this &&
-		parentWidget()->parentWidget()->focusWidget() != nullptr &&
-		!(parentWidget()->parentWidget()->
-				focusWidget()->inherits( "QLineEdit" ) ||
-		parentWidget()->parentWidget()->
-				focusWidget()->inherits( "QPlainTextEdit" ) ))
-	{
-		// then reclaim keyboard focus!
-		setFocus();
-		return;
-	}
-
 	// if we loose focus, we HAVE to note off all running notes because
 	// we don't receive key-release-events anymore and so the notes would
 	// hang otherwise

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -449,7 +449,7 @@ void PianoView::mousePressEvent(QMouseEvent *me)
 
 			if (me->modifiers() & Qt::ControlModifier)
 			{
-				new StringPairDrag("automatable_model",	QString::number(m_movedNoteModel->id()), QPixmap(), this);
+				new StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::clipboardEncodeAutomatableModelLink(m_movedNoteModel->id()), QPixmap(), this);
 				me->accept();
 			}
 			else

--- a/src/gui/tracks/AutomationTrackView.cpp
+++ b/src/gui/tracks/AutomationTrackView.cpp
@@ -49,7 +49,7 @@ AutomationTrackView::AutomationTrackView( AutomationTrack * _at, TrackContainerV
 
 void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee, "automatable_model" );
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
 }
 
 
@@ -57,9 +57,9 @@ void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void AutomationTrackView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString val = StringPairDrag::decodeValue( _de );
-	if( type == "automatable_model" )
+	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -190,7 +190,7 @@ void SampleTrackView::modelChanged()
 
 void SampleTrackView::dragEnterEvent(QDragEnterEvent *dee)
 {
-	StringPairDrag::processDragEnterEvent(dee, QString("samplefile"));
+	StringPairDrag::processDragEnterEvent(dee, Clipboard::StringPairDataType::SampleFile);
 }
 
 
@@ -198,10 +198,10 @@ void SampleTrackView::dragEnterEvent(QDragEnterEvent *dee)
 
 void SampleTrackView::dropEvent(QDropEvent *de)
 {
-	QString type  = StringPairDrag::decodeKey(de);
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue(de);
 
-	if (type == "samplefile")
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		int trackHeadWidth = ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt()==1
 				? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -328,8 +328,7 @@ void TrackContentWidget::dragEnterEvent( QDragEnterEvent * dee )
 	}
 	else
 	{
-		StringPairDrag::processDragEnterEvent( dee, "clip_" +
-						QString::number( static_cast<int>(getTrack()->type()) ) );
+		StringPairDrag::processDragEnterEvent(dee, ClipView::getClipStringPairType(getTrack()));
 	}
 }
 
@@ -355,15 +354,12 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QDropEvent* d
 // Overloaded method to make it possible to call this method without a Drag&Drop event
 bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md , bool allowSameBar )
 {
-	// For decodeKey() and decodeValue()
-	using namespace Clipboard;
-
 	Track * t = getTrack();
-	QString type = decodeKey( md );
-	QString value = decodeValue( md );
+	Clipboard::StringPairDataType type = Clipboard::decodeKey(md);
+	QString value = Clipboard::decodeValue(md);
 
 	// We can only paste into tracks of the same type
-	if (type != ("clip_" + QString::number(static_cast<int>(t->type()))))
+	if (type != ClipView::getClipStringPairType(getTrack()))
 	{
 		return false;
 	}
@@ -452,17 +448,13 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, QDropEvent * de )
 // Overloaded method so we can call it without a Drag&Drop event
 bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, bool skipSafetyCheck )
 {
-	// For decodeKey() and decodeValue()
-	using namespace Clipboard;
-
 	// When canPasteSelection was already called before, skipSafetyCheck will skip this
 	if( !skipSafetyCheck && canPasteSelection( clipPos, md ) == false )
 	{
 		return false;
 	}
 
-	QString type = decodeKey( md );
-	QString value = decodeValue( md );
+	QString value = Clipboard::decodeValue(md);
 
 	getTrack()->addJournalCheckPoint();
 
@@ -676,9 +668,6 @@ TimePos TrackContentWidget::endPosition( const TimePos & posStart )
 
 void TrackContentWidget::contextMenuEvent( QContextMenuEvent * cme )
 {
-	// For hasFormat(), MimeType enum class and getMimeData()
-	using namespace Clipboard;
-
 	if( cme->modifiers() )
 	{
 		return;
@@ -686,7 +675,7 @@ void TrackContentWidget::contextMenuEvent( QContextMenuEvent * cme )
 
 	// If we don't have Clip data in the clipboard there's no need to create this menu
 	// since "paste" is the only action at the moment.
-	if( ! hasFormat( MimeType::StringPair )  )
+	if (!Clipboard::hasFormat(Clipboard::MimeType::StringPair))
 	{
 		return;
 	}
@@ -695,7 +684,7 @@ void TrackContentWidget::contextMenuEvent( QContextMenuEvent * cme )
 	QAction *pasteA = contextMenu.addAction( embed::getIconPixmap( "edit_paste" ),
 					tr( "Paste" ), [this, cme](){ contextMenuAction( cme, ContextMenuAction::Paste ); } );
 	// If we can't paste in the current TCW for some reason, disable the action so the user knows
-	pasteA->setEnabled( canPasteSelection( getPosition( cme->x() ), getMimeData() ) ? true : false );
+	pasteA->setEnabled(canPasteSelection(getPosition(cme->x()), Clipboard::getMimeData()) ? true : false);
 
 	contextMenu.exec( QCursor::pos() );
 }

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -139,8 +139,7 @@ void TrackOperationsWidget::mousePressEvent( QMouseEvent * me )
 	{
 		DataFile dataFile( DataFile::Type::DragNDropData );
 		m_trackView->getTrack()->saveState( dataFile, dataFile.content() );
-		new StringPairDrag( QString( "track_%1" ).arg(
-					static_cast<int>(m_trackView->getTrack()->type()) ),
+		new StringPairDrag(TrackView::getTrackStringPairType(m_trackView->getTrack()),
 			dataFile.toString(), m_trackView->getTrackSettingsWidget()->grab(),
 									this );
 	}

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -168,6 +168,33 @@ QMenu * TrackView::createMixerMenu(QString title, QString newMixerLabel)
 	return nullptr;
 }
 
+/*! \brief Gets a StringPairDataType for this tracks, used for StringPairDrag.
+ *
+ */
+Clipboard::StringPairDataType TrackView::getTrackStringPairType(Track* track)
+{
+	switch (track->type())
+	{
+		case Track::Type::Instrument:
+			return Clipboard::StringPairDataType::InstrumentTrack;
+			break;
+		case Track::Type::Pattern:
+			return Clipboard::StringPairDataType::PatternTrack;
+			break;
+		case Track::Type::Sample:
+			return Clipboard::StringPairDataType::SampleTrack;
+			break;
+		case Track::Type::Automation:
+			return Clipboard::StringPairDataType::AutomationTrack;
+			break;
+		case Track::Type::HiddenAutomation:
+			return Clipboard::StringPairDataType::HiddenAutomationTrack;
+			break;
+		default:
+			break;
+	}
+	return Clipboard::StringPairDataType::None;
+}
 
 
 
@@ -206,8 +233,7 @@ void TrackView::modelChanged()
  */
 void TrackView::dragEnterEvent( QDragEnterEvent * dee )
 {
-	StringPairDrag::processDragEnterEvent( dee, "track_" +
-					QString::number( static_cast<int>(m_track->type()) ) );
+	StringPairDrag::processDragEnterEvent(dee, getTrackStringPairType(getTrack()));
 }
 
 
@@ -223,9 +249,9 @@ void TrackView::dragEnterEvent( QDragEnterEvent * dee )
  */
 void TrackView::dropEvent( QDropEvent * de )
 {
-	QString type = StringPairDrag::decodeKey( de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
-	if( type == ( "track_" + QString::number( static_cast<int>(m_track->type()) ) ) )
+	if (type == getTrackStringPairType(getTrack()))
 	{
 		// value contains our XML-data so simply create a
 		// DataFile which does the rest for us...

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -127,7 +127,7 @@ void AutomatableButton::mousePressEvent( QMouseEvent * _me )
 		{
 			// A group, we must get process it instead
 			auto groupView = (AutomatableModelView*)m_group;
-			new StringPairDrag( "automatable_model",
+			new StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink,
 					QString::number( groupView->modelUntyped()->id() ),
 					QPixmap(), widget() );
 			// TODO: ^^ Maybe use a predefined icon instead of the button they happened to select

--- a/src/gui/widgets/BarModelEditor.cpp
+++ b/src/gui/widgets/BarModelEditor.cpp
@@ -112,6 +112,9 @@ void BarModelEditor::paintEvent(QPaintEvent *event)
 	// Now draw the text
 	painter.setPen(getTextColor());
 	painter.drawText(textRect, elidedText);
+	
+	// draw `InteractiveModelView` highlight
+	drawAutoHighlight(&painter);
 }
 
 } // namespace lmms::gui

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -146,13 +146,7 @@ void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
-	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false)
-	{
-		de->ignore();
-		return;
-	}
-
-	bool canAccept = processPaste(StringPairDrag::decodeKey(de), StringPairDrag::decodeValue(de));
+	bool canAccept = processPaste(de->mimeData());
 	if (canAccept == true)
 	{
 		de->accept();
@@ -307,8 +301,7 @@ void FloatModelEditorBase::shortcutPressedEvent(size_t shortcutLocation, QKeyEve
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::clipboardEncodeAutomatableModelLink(model()->id()));
 			break;
 		case 2:
-			if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { break; }
-			processPaste(Clipboard::decodeKey(Clipboard::getMimeData()), Clipboard::decodeValue(Clipboard::getMimeData()));
+			processPaste(Clipboard::getMimeData());
 			break;
 		default:
 			break;
@@ -330,9 +323,14 @@ std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::getShortc
 	return shortcuts;
 }
 
-bool FloatModelEditorBase::processPaste(Clipboard::StringPairDataType type, QString value)
+bool FloatModelEditorBase::processPaste(const QMimeData* mimeData)
 {
+	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
 	bool shouldAccept = false;
+
+	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+	QString value = Clipboard::decodeValue(mimeData);
+	
 	if (type == Clipboard::StringPairDataType::FloatValue)
 	{
 		model()->setValue(LocaleHelper::toFloat(value));

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -130,21 +130,24 @@ void FloatModelEditorBase::toggleScale()
 
 void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 {
-	StringPairDrag::processDragEnterEvent(dee, "float_value,"
-							"automatable_model");
+	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
+		Clipboard::StringPairDataType::FloatValue,
+		Clipboard::StringPairDataType::AutomatableModelLink
+	};
+	StringPairDrag::processDragEnterEvent(dee, &acceptedKeys);
 }
 
 
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
-	QString type = StringPairDrag::decodeKey(de);
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
 	QString val = StringPairDrag::decodeValue(de);
-	if (type == "float_value")
+	if (type == Clipboard::StringPairDataType::FloatValue)
 	{
 		model()->setValue(LocaleHelper::toFloat(val));
 		de->accept();
 	}
-	else if (type == "automatable_model")
+	else if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if (mod != nullptr)
@@ -186,7 +189,7 @@ void FloatModelEditorBase::mousePressEvent(QMouseEvent * me)
 	else if (me->button() == Qt::LeftButton &&
 			(me->modifiers() & Qt::ShiftModifier))
 	{
-		new StringPairDrag("float_value",
+		new StringPairDrag(Clipboard::StringPairDataType::FloatValue,
 					QString::number(model()->value()),
 							QPixmap(), this);
 	}

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -285,13 +285,17 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 	drawAutoHighlight(&p);
 }
 
-bool FloatModelEditorBase::canAcceptClipBoardData(Clipboard::StringPairDataType dataType)
+std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::getShortcuts()
 {
-	return dataType == Clipboard::StringPairDataType::FloatValue
-		|| dataType == Clipboard::StringPairDataType::AutomatableModelLink;
+	std::vector<InteractiveModelView::ModelShortcut> shortcuts = {
+		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
+		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
+		InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false)
+	};
+	return shortcuts;
 }
 
-void FloatModelEditorBase::shortcutPressedEvent(size_t shortcutLocation, QKeyEvent* event)
+void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
 {
 	switch (shortcutLocation)
 	{
@@ -316,14 +320,10 @@ QString& FloatModelEditorBase::getShortcutMessage()
 	return m_shortcutMessage;
 }
 
-std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::getShortcuts()
+bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
 {
-	std::vector<InteractiveModelView::ModelShortcut> shortcuts = {
-		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false)
-	};
-	return shortcuts;
+	return dataType == Clipboard::StringPairDataType::FloatValue
+		|| dataType == Clipboard::StringPairDataType::AutomatableModelLink;
 }
 
 bool FloatModelEditorBase::processPaste(const QMimeData* mimeData)

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -305,7 +305,7 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 			break;
 		case 1:
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::clipboardEncodeAutomatableModelLink(model()->id()));
-			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::FloatValue);
+			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::AutomatableModelLink);
 			break;
 		case 2:
 			processPaste(Clipboard::getMimeData());
@@ -315,7 +315,7 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 	}
 }
 
-QString& FloatModelEditorBase::getShortcutMessage()
+QString FloatModelEditorBase::getShortcutMessage()
 {
 	return m_shortcutMessage;
 }

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -282,6 +282,7 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 	p.setPen(foreground);
 	p.setBrush(foreground);
 	p.drawRect(QRect(r.topLeft(), QPoint(r.width() * percentage, r.height())));
+	drawAutoHighlight(&p);
 }
 
 bool FloatModelEditorBase::canAcceptClipBoardData(Clipboard::StringPairDataType dataType)
@@ -296,9 +297,11 @@ void FloatModelEditorBase::shortcutPressedEvent(size_t shortcutLocation, QKeyEve
 	{
 		case 0:
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::FloatValue, Clipboard::clipboardEncodeFloatValue(model()->value() * getConversionFactor()));
+			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::FloatValue);
 			break;
 		case 1:
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::clipboardEncodeAutomatableModelLink(model()->id()));
+			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::FloatValue);
 			break;
 		case 2:
 			processPaste(Clipboard::getMimeData());
@@ -345,6 +348,10 @@ bool FloatModelEditorBase::processPaste(const QMimeData* mimeData)
 			mod->setValue(model()->value());
 			shouldAccept = true;
 		}
+	}
+	if (shouldAccept)
+	{
+		InteractiveModelView::stopHighlighting();
 	}
 	return shouldAccept;
 }

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -410,10 +410,10 @@ void Graph::paintEvent( QPaintEvent * )
 
 void Graph::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
+	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
 
-	if( type == "samplefile" )
+	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
 		// TODO: call setWaveToUser
 		// loadSampleFromFile( value );
@@ -423,8 +423,7 @@ void Graph::dropEvent( QDropEvent * _de )
 
 void Graph::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	if( StringPairDrag::processDragEnterEvent( _dee,
-		QString( "samplefile" ) ) == false )
+	if (StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::SampleFile) == false)
 	{
 		_dee->ignore();
 	}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -473,6 +473,9 @@ void Knob::paintEvent( QPaintEvent * _me )
 			m_tdRenderer->drawContents(&p);
 		}
 	}
+	
+	// draw `InteractiveModelView` highlight
+	drawAutoHighlight(&p);
 }
 
 void Knob::changeEvent(QEvent * ev)


### PR DESCRIPTION
This PR contains multiple changes and overall it is focused on improving lmms functionality communication with the user and on immediate feedback to the user.

These changes are the following:
- The `StringPairDrag` system and the `StringPair` system now uses a unified `enum` as key instead of custom strings. Before this, key names weren't documented and they were scattered across multiple files.
- A new class was added that implements handling shortcuts and highlighting widgets:
    - This class was designed to encourage developers to implement shortcuts and pasting data into the widget.
    - Shortcuts:
        - Shortcuts support all QT keys and modifiers and they can differentiate between how many times a shortcut was pressed. Each shortcut has a description.
        - Shortcuts are easy to implement and they are easy to work with.
        - If the user moves the mouse over the widget, then the available shortcuts will automatically be displayed.
    - Highlighting:
        - The idea behind highlighting is to show users which widget can accept which `StringPair` key while dragging or copying. If the user starts to drag a clip, the other clips will be highlighted to show that they can accept the datatype associated with the drag event.
        - Highlighting will be active for 30 seconds after the user starts to ctrl + drag a widget or when a widget is copied.
        - Highlighting will stop after a successful paste, but the user can keep pasting into other widgets.
- The new class is implemented inside Knobs (`FloatModelEditorBase`) and all clips. I plan to implement it in other widgets in the future (if this gets merged).
### 
**Problems:**
- For shortcuts to work the widgets set the focus on themself when a mouse enters them. This can cause issues inside Instruments (especially the piano widget inside instruments). Changing a knob's value while pressing down a piano key is now impossible. I do not know how to solve this issue.
- `ClipView::getClipStringPairType` and `TrackView::getTrackStringPairType` does not implement Special types of tracks (video, event) 
- I removed `ClipView::dropEvent` copying code because I found that this condition is never true:
```
// Defer to rubberband paste if we're in that mode
if (m_trackView->trackContainerView()->allowRubberband() == true)
```

Picture showing highlighting:

![widget_highlighting6](https://github.com/user-attachments/assets/1bf7e2f9-d19c-4b2f-80b1-dcecbf073879)

