### PR TITLE
Add a database for samples

### DIFF
--- a/include/FileSystemHelpers.h
+++ b/include/FileSystemHelpers.h
@@ -1,0 +1,55 @@
+/*
+ * FileSystemHelpers.h
+ *
+ * Copyright (c) 2024 saker
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_FILE_SYSTEM_HELPERS_H
+#define LMMS_FILE_SYSTEM_HELPERS_H
+
+#include <QString>
+#include <filesystem>
+
+namespace lmms {
+class FileSystemHelpers
+{
+public:
+	static std::filesystem::path pathFromQString(const QString& path)
+	{
+#ifdef _WIN32
+		return std::filesystem::path{path.toStdWString()};
+#else
+		return std::filesystem::path{path.toStdString()};
+#endif
+	}
+
+	static QString qStringFromPath(const std::filesystem::path& path)
+	{
+#ifdef _WIN32
+		return QString::fromStdWString(path.generic_wstring());
+#else
+		return QString::fromStdString(path.native());
+#endif
+	}
+};
+} // namespace lmms
+
+#endif // LMMS_FILE_SYSTEM_HELPERS_H

--- a/include/SampleDatabase.h
+++ b/include/SampleDatabase.h
@@ -1,0 +1,82 @@
+/*
+ * SampleDatabase.h
+ *
+ * Copyright (c) 2024 saker
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_SAMPLE_DATABASE_H
+#define LMMS_SAMPLE_DATABASE_H
+
+#include <QString>
+#include <filesystem>
+#include <memory>
+#include <unordered_map>
+
+#include "SampleBuffer.h"
+
+namespace lmms {
+class SampleDatabase
+{
+public:
+	/**
+		Fetches a sample from the database through a path to an audio file,
+		and returns the stored buffer.
+
+		If `path` exists in the database, its creation time and last write time
+		is checked with what is currently in the database. If there is a mismatch, the sample is reloaded from disk, its
+		entry in the database is updated, and the sample is returned.
+
+		If `path` does not exist in the database, the sample is loaded from disk and
+		then returned.
+
+		If `path` does not exist on disk, an empty buffer is returned.
+	 */
+	auto fetch(const QString& path) -> std::shared_ptr<SampleBuffer>;
+
+	/**
+		Fetches a sample from the database through a Base64 string and a sample rate
+		and returns the stored buffer.
+
+		If an entry for a `base64` string with a certain `sampleRate` exists in the database, the stored sample is
+		returned. Otherwise, if it does not exist in the database, the sample is loaded and then returned.
+	 */
+	auto fetch(const std::string& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>;
+
+private:
+	struct AudioFileEntry
+	{
+		std::filesystem::path path;
+		std::filesystem::file_time_type creationTime;
+		std::filesystem::file_time_type lastWriteTime;
+	};
+
+	struct Base64Entry
+	{
+		std::string base64;
+		int sampleRate;
+	};
+
+	std::unordered_map<AudioFileEntry, std::weak_ptr<SampleBuffer>> m_audioFileMap;
+	std::unordered_map<Base64Entry, std::weak_ptr<SampleBuffer>> m_base64Map;
+};
+} // namespace lmms
+
+#endif // LMMS_SAMPLE_DATABASE_H

--- a/include/SampleDatabase.h
+++ b/include/SampleDatabase.h
@@ -94,6 +94,29 @@ private:
 		}
 	};
 
+	template <typename T, typename ...Args>
+	static auto get(const T& entry, std::unordered_map<T, std::weak_ptr<SampleBuffer>, Hash>& map, Args... args)
+	{
+		const auto it = map.find(entry);
+
+		if (it == map.end())
+		{
+			const auto buffer = std::make_shared<SampleBuffer>(std::forward<Args>(args)...);
+			map.insert(std::make_pair(entry, buffer));
+			return buffer;
+		}
+
+		const auto entryLock = it->second.lock();
+		if (!entryLock)
+		{
+			const auto buffer = std::make_shared<SampleBuffer>(std::forward<Args>(args)...);
+			map[entry] = buffer;
+			return buffer;
+		}
+
+		return entryLock;
+	}
+
 	inline static std::unordered_map<AudioFileEntry, std::weak_ptr<SampleBuffer>, Hash> s_audioFileMap;
 	inline static std::unordered_map<Base64Entry, std::weak_ptr<SampleBuffer>, Hash> s_base64Map;
 };

--- a/include/SampleDatabase.h
+++ b/include/SampleDatabase.h
@@ -46,10 +46,8 @@ public:
 
 		If `path` does not exist in the database, the sample is loaded from disk and
 		then returned.
-
-		If `path` does not exist on disk, an empty buffer is returned.
 	 */
-	static auto fetch(const std::filesystem::path& path) -> std::shared_ptr<SampleBuffer>;
+	static auto fetch(const QString& path) -> std::shared_ptr<SampleBuffer>;
 
 	/**
 		Fetches a sample from the database through a Base64 string and a sample rate
@@ -58,7 +56,7 @@ public:
 		If an entry for a `base64` string with a certain `sampleRate` exists in the database, the stored sample is
 		returned. Otherwise, if it does not exist in the database, the sample is loaded and then returned.
 	 */
-	static auto fetch(const std::string& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>;
+	static auto fetch(const QString& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>;
 
 private:
 	struct AudioFileEntry

--- a/include/SampleLoader.h
+++ b/include/SampleLoader.h
@@ -37,8 +37,8 @@ class LMMS_EXPORT SampleLoader
 public:
 	static QString openAudioFile(const QString& previousFile = "");
 	static QString openWaveformFile(const QString& previousFile = "");
-	static std::shared_ptr<const SampleBuffer> createBufferFromFile(const QString& filePath);
-	static std::shared_ptr<const SampleBuffer> createBufferFromBase64(
+	static std::shared_ptr<const SampleBuffer> loadBufferFromFile(const QString& filePath);
+	static std::shared_ptr<const SampleBuffer> loadBufferFromBase64(
 		const QString& base64, int sampleRate = Engine::audioEngine()->outputSampleRate());
 private:
 	static void displayError(const QString& message);

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -224,7 +224,7 @@ void AudioFileProcessor::loadSettings(const QDomElement& elem)
 	}
 	else if (auto sampleData = elem.attribute("sampledata"); !sampleData.isEmpty())
 	{
-		m_sample = Sample(gui::SampleLoader::createBufferFromBase64(sampleData));
+		m_sample = Sample(gui::SampleLoader::loadBufferFromBase64(sampleData));
 	}
 
 	m_loopModel.loadSettings(elem, "looped");
@@ -317,7 +317,7 @@ void AudioFileProcessor::setAudioFile(const QString& _audio_file, bool _rename)
 	}
 	// else we don't touch the track-name, because the user named it self
 
-	m_sample = Sample(gui::SampleLoader::createBufferFromFile(_audio_file));
+	m_sample = Sample(gui::SampleLoader::loadBufferFromFile(_audio_file));
 	loopPointChanged();
 	emit sampleUpdated();
 }

--- a/plugins/SlicerT/SlicerT.cpp
+++ b/plugins/SlicerT/SlicerT.cpp
@@ -319,7 +319,7 @@ std::vector<Note> SlicerT::getMidi()
 
 void SlicerT::updateFile(QString file)
 {
-	if (auto buffer = gui::SampleLoader::createBufferFromFile(file)) { m_originalSample = Sample(std::move(buffer)); }
+	if (auto buffer = gui::SampleLoader::loadBufferFromFile(file)) { m_originalSample = Sample(std::move(buffer)); }
 
 	findBPM();
 	findSlices();
@@ -359,7 +359,7 @@ void SlicerT::loadSettings(const QDomElement& element)
 	{
 		if (QFileInfo(PathUtil::toAbsolute(srcFile)).exists())
 		{
-			auto buffer = gui::SampleLoader::createBufferFromFile(srcFile);
+			auto buffer = gui::SampleLoader::loadBufferFromFile(srcFile);
 			m_originalSample = Sample(std::move(buffer));
 		}
 		else
@@ -370,7 +370,7 @@ void SlicerT::loadSettings(const QDomElement& element)
 	}
 	else if (auto sampleData = element.attribute("sampledata"); !sampleData.isEmpty())
 	{
-		auto buffer = gui::SampleLoader::createBufferFromBase64(sampleData);
+		auto buffer = gui::SampleLoader::loadBufferFromBase64(sampleData);
 		m_originalSample = Sample(std::move(buffer));
 	}
 

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -140,7 +140,7 @@ void OscillatorObject::oscUserDefWaveDblClick()
 	auto af = gui::SampleLoader::openWaveformFile();
 	if( af != "" )
 	{
-		m_sampleBuffer = gui::SampleLoader::createBufferFromFile(af);
+		m_sampleBuffer = gui::SampleLoader::loadBufferFromFile(af);
 		m_userAntiAliasWaveTable = Oscillator::generateAntiAliasUserWaveTable(m_sampleBuffer.get());
 		// TODO:
 		//m_usrWaveBtn->setToolTip(m_sampleBuffer->audioFile());
@@ -287,7 +287,7 @@ void TripleOscillator::loadSettings( const QDomElement & _this )
 		{
 			if (QFileInfo(PathUtil::toAbsolute(userWaveFile)).exists())
 			{
-				m_osc[i]->m_sampleBuffer = gui::SampleLoader::createBufferFromFile(userWaveFile);
+				m_osc[i]->m_sampleBuffer = gui::SampleLoader::loadBufferFromFile(userWaveFile);
 				m_osc[i]->m_userAntiAliasWaveTable = Oscillator::generateAntiAliasUserWaveTable(m_osc[i]->m_sampleBuffer.get());
 			}
 			else { Engine::getSong()->collectError(QString("%1: %2").arg(tr("Sample not found"), userWaveFile)); }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -67,6 +67,7 @@ set(LMMS_SRCS
 	core/RenderManager.cpp
 	core/RingBuffer.cpp
 	core/Sample.cpp
+	core/SampleDatabase.cpp
 	core/SampleBuffer.cpp
 	core/SampleClip.cpp
 	core/SampleDecoder.cpp

--- a/src/core/EnvelopeAndLfoParameters.cpp
+++ b/src/core/EnvelopeAndLfoParameters.cpp
@@ -389,7 +389,7 @@ void EnvelopeAndLfoParameters::loadSettings( const QDomElement & _this )
 	{
 		if (QFileInfo(PathUtil::toAbsolute(userWaveFile)).exists())
 		{
-			m_userWave = gui::SampleLoader::createBufferFromFile(_this.attribute("userwavefile"));
+			m_userWave = gui::SampleLoader::loadBufferFromFile(_this.attribute("userwavefile"));
 		}
 		else { Engine::getSong()->collectError(QString("%1: %2").arg(tr("Sample not found"), userWaveFile)); }  
 	}

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -243,7 +243,7 @@ void LfoController::loadSettings( const QDomElement & _this )
 	{
 		if (QFileInfo(PathUtil::toAbsolute(userWaveFile)).exists())
 		{
-			m_userDefSampleBuffer = gui::SampleLoader::createBufferFromFile(_this.attribute("userwavefile"));
+			m_userDefSampleBuffer = gui::SampleLoader::loadBufferFromFile(_this.attribute("userwavefile"));
 		}
 		else { Engine::getSong()->collectError(QString("%1: %2").arg(tr("Sample not found"), userWaveFile)); }
 	}

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -150,7 +150,7 @@ void SampleClip::setSampleFile(const QString& sf)
 	if (!sf.isEmpty())
 	{
 		//Otherwise set it to the sample's length
-		m_sample = Sample(gui::SampleLoader::createBufferFromFile(sf));
+		m_sample = Sample(gui::SampleLoader::loadBufferFromFile(sf));
 		length = sampleLength();
 	}
 
@@ -309,7 +309,7 @@ void SampleClip::loadSettings( const QDomElement & _this )
 		auto sampleRate = _this.hasAttribute("sample_rate") ? _this.attribute("sample_rate").toInt() :
 			Engine::audioEngine()->outputSampleRate();
 
-		auto buffer = gui::SampleLoader::createBufferFromBase64(_this.attribute("data"), sampleRate);
+		auto buffer = gui::SampleLoader::loadBufferFromBase64(_this.attribute("data"), sampleRate);
 		m_sample = Sample(std::move(buffer));
 	}
 	changeLength( _this.attribute( "len" ).toInt() );

--- a/src/core/SampleDatabase.cpp
+++ b/src/core/SampleDatabase.cpp
@@ -30,14 +30,15 @@
 #include "SampleBuffer.h"
 
 namespace lmms {
-auto SampleDatabase::fetch(const std::filesystem::path& path) -> std::shared_ptr<SampleBuffer>
+auto SampleDatabase::fetch(const QString& path) -> std::shared_ptr<SampleBuffer>
 {
-	const auto entry = AudioFileEntry{path, std::filesystem::last_write_time(path)};
+	const auto fsPath = FileSystemHelpers::pathFromQString(path);
+	const auto entry = AudioFileEntry{fsPath, std::filesystem::last_write_time(fsPath)};
 	const auto it = s_audioFileMap.find(entry);
 
 	if (it == s_audioFileMap.end())
 	{
-		const auto buffer = std::make_shared<SampleBuffer>(FileSystemHelpers::qStringFromPath(path));
+		const auto buffer = std::make_shared<SampleBuffer>(path);
 		s_audioFileMap.insert(std::make_pair(entry, buffer));
 		return buffer;
 	}
@@ -45,14 +46,14 @@ auto SampleDatabase::fetch(const std::filesystem::path& path) -> std::shared_ptr
 	return it->second.lock();
 }
 
-auto SampleDatabase::fetch(const std::string& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>
+auto SampleDatabase::fetch(const QString& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>
 {
-	const auto entry = Base64Entry{base64, sampleRate};
+	const auto entry = Base64Entry{base64.toStdString(), sampleRate};
 	const auto it = s_base64Map.find(entry);
 
 	if (it == s_base64Map.end())
 	{
-		const auto buffer = std::make_shared<SampleBuffer>(QString::fromStdString(base64), sampleRate);
+		const auto buffer = std::make_shared<SampleBuffer>(base64, sampleRate);
 		s_base64Map.insert(std::make_pair(entry, buffer));
 		return buffer;
 	}

--- a/src/core/SampleDatabase.cpp
+++ b/src/core/SampleDatabase.cpp
@@ -43,7 +43,15 @@ auto SampleDatabase::fetch(const QString& path) -> std::shared_ptr<SampleBuffer>
 		return buffer;
 	}
 
-	return it->second.lock();
+	const auto entryLock = it->second.lock();
+	if (!entryLock)
+	{
+		const auto buffer = std::make_shared<SampleBuffer>(path);
+		s_audioFileMap[entry] = buffer;
+		return buffer;
+	}
+
+	return entryLock;
 }
 
 auto SampleDatabase::fetch(const QString& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>
@@ -58,6 +66,14 @@ auto SampleDatabase::fetch(const QString& base64, int sampleRate) -> std::shared
 		return buffer;
 	}
 
-	return it->second.lock();
+	const auto entryLock = it->second.lock();
+	if (!entryLock)
+	{
+		const auto buffer = std::make_shared<SampleBuffer>(base64, sampleRate);
+		s_base64Map[entry] = buffer;
+		return buffer;
+	}
+
+	return entryLock;
 }
 } // namespace lmms

--- a/src/core/SampleDatabase.cpp
+++ b/src/core/SampleDatabase.cpp
@@ -34,46 +34,12 @@ auto SampleDatabase::fetch(const QString& path) -> std::shared_ptr<SampleBuffer>
 {
 	const auto fsPath = FileSystemHelpers::pathFromQString(path);
 	const auto entry = AudioFileEntry{fsPath, std::filesystem::last_write_time(fsPath)};
-	const auto it = s_audioFileMap.find(entry);
-
-	if (it == s_audioFileMap.end())
-	{
-		const auto buffer = std::make_shared<SampleBuffer>(path);
-		s_audioFileMap.insert(std::make_pair(entry, buffer));
-		return buffer;
-	}
-
-	const auto entryLock = it->second.lock();
-	if (!entryLock)
-	{
-		const auto buffer = std::make_shared<SampleBuffer>(path);
-		s_audioFileMap[entry] = buffer;
-		return buffer;
-	}
-
-	return entryLock;
+	return get(entry, s_audioFileMap, path);
 }
 
 auto SampleDatabase::fetch(const QString& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>
 {
 	const auto entry = Base64Entry{base64.toStdString(), sampleRate};
-	const auto it = s_base64Map.find(entry);
-
-	if (it == s_base64Map.end())
-	{
-		const auto buffer = std::make_shared<SampleBuffer>(base64, sampleRate);
-		s_base64Map.insert(std::make_pair(entry, buffer));
-		return buffer;
-	}
-
-	const auto entryLock = it->second.lock();
-	if (!entryLock)
-	{
-		const auto buffer = std::make_shared<SampleBuffer>(base64, sampleRate);
-		s_base64Map[entry] = buffer;
-		return buffer;
-	}
-
-	return entryLock;
+	return get(entry, s_base64Map, base64, sampleRate);
 }
 } // namespace lmms

--- a/src/core/SampleDatabase.cpp
+++ b/src/core/SampleDatabase.cpp
@@ -1,0 +1,62 @@
+/*
+ * SampleDatabase.cpp
+ *
+ * Copyright (c) 2024 saker
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "SampleDatabase.h"
+
+#include <filesystem>
+
+#include "FileSystemHelpers.h"
+#include "SampleBuffer.h"
+
+namespace lmms {
+auto SampleDatabase::fetch(const std::filesystem::path& path) -> std::shared_ptr<SampleBuffer>
+{
+	const auto entry = AudioFileEntry{path, std::filesystem::last_write_time(path)};
+	const auto it = s_audioFileMap.find(entry);
+
+	if (it == s_audioFileMap.end())
+	{
+		const auto buffer = std::make_shared<SampleBuffer>(FileSystemHelpers::qStringFromPath(path));
+		s_audioFileMap.insert(std::make_pair(entry, buffer));
+		return buffer;
+	}
+
+	return it->second.lock();
+}
+
+auto SampleDatabase::fetch(const std::string& base64, int sampleRate) -> std::shared_ptr<SampleBuffer>
+{
+	const auto entry = Base64Entry{base64, sampleRate};
+	const auto it = s_base64Map.find(entry);
+
+	if (it == s_base64Map.end())
+	{
+		const auto buffer = std::make_shared<SampleBuffer>(QString::fromStdString(base64), sampleRate);
+		s_base64Map.insert(std::make_pair(entry, buffer));
+		return buffer;
+	}
+
+	return it->second.lock();
+}
+} // namespace lmms

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -743,7 +743,7 @@ void FileBrowserTreeWidget::previewFileItem(FileItem* file)
 			embed::getIconPixmap("sample_file", 24, 24), 0);
 		// TODO: this can be removed once we do this outside the event thread
 		qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-		if (auto buffer = SampleLoader::createBufferFromFile(fileName))
+		if (auto buffer = SampleLoader::loadBufferFromFile(fileName))
 		{
 			auto s = new SamplePlayHandle(new lmms::Sample{std::move(buffer)});
 			s->setDoneMayReturnTrue(false);

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -216,7 +216,7 @@ void LfoControllerDialog::askUserDefWave()
 
 	auto lfoModel = dynamic_cast<LfoController*>(model());
 	auto& buffer = lfoModel->m_userDefSampleBuffer;
-	buffer = SampleLoader::createBufferFromFile(fileName);
+	buffer = SampleLoader::loadBufferFromFile(fileName);
 
 	m_userWaveBtn->setToolTip(buffer->audioFile());
 }

--- a/src/gui/SampleLoader.cpp
+++ b/src/gui/SampleLoader.cpp
@@ -32,8 +32,8 @@
 #include "FileDialog.h"
 #include "GuiApplication.h"
 #include "PathUtil.h"
+#include "SampleDatabase.h"
 #include "SampleDecoder.h"
-#include "Song.h"
 
 namespace lmms::gui {
 QString SampleLoader::openAudioFile(const QString& previousFile)
@@ -94,7 +94,7 @@ std::shared_ptr<const SampleBuffer> SampleLoader::loadBufferFromFile(const QStri
 
 	try
 	{
-		return std::make_shared<SampleBuffer>(filePath);
+		return SampleDatabase::fetch(filePath);
 	}
 	catch (const std::runtime_error& error)
 	{
@@ -109,7 +109,7 @@ std::shared_ptr<const SampleBuffer> SampleLoader::loadBufferFromBase64(const QSt
 
 	try
 	{
-		return std::make_shared<SampleBuffer>(base64, sampleRate);
+		return SampleDatabase::fetch(base64, sampleRate);
 	}
 	catch (const std::runtime_error& error)
 	{

--- a/src/gui/SampleLoader.cpp
+++ b/src/gui/SampleLoader.cpp
@@ -88,7 +88,7 @@ QString SampleLoader::openWaveformFile(const QString& previousFile)
 		previousFile.isEmpty() ? ConfigManager::inst()->factorySamplesDir() + "waveforms/10saw.flac" : previousFile);
 }
 
-std::shared_ptr<const SampleBuffer> SampleLoader::createBufferFromFile(const QString& filePath)
+std::shared_ptr<const SampleBuffer> SampleLoader::loadBufferFromFile(const QString& filePath)
 {
 	if (filePath.isEmpty()) { return SampleBuffer::emptyBuffer(); }
 
@@ -103,7 +103,7 @@ std::shared_ptr<const SampleBuffer> SampleLoader::createBufferFromFile(const QSt
 	}
 }
 
-std::shared_ptr<const SampleBuffer> SampleLoader::createBufferFromBase64(const QString& base64, int sampleRate)
+std::shared_ptr<const SampleBuffer> SampleLoader::loadBufferFromBase64(const QString& base64, int sampleRate)
 {
 	if (base64.isEmpty()) { return SampleBuffer::emptyBuffer(); }
 

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -123,7 +123,7 @@ void SampleClipView::dropEvent( QDropEvent * _de )
 	}
 	else if( StringPairDrag::decodeKey( _de ) == "sampledata" )
 	{
-		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(StringPairDrag::decodeValue(_de)));
+		m_clip->setSampleBuffer(SampleLoader::loadBufferFromBase64(StringPairDrag::decodeValue(_de)));
 		m_clip->updateLength();
 		update();
 		_de->accept();
@@ -190,7 +190,7 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 	}
 	else
 	{
-		auto sampleBuffer = SampleLoader::createBufferFromFile(selectedAudioFile);
+		auto sampleBuffer = SampleLoader::loadBufferFromFile(selectedAudioFile);
 		if (sampleBuffer != SampleBuffer::emptyBuffer())
 		{
 			m_clip->setSampleBuffer(sampleBuffer);

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -242,7 +242,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 	QString value = StringPairDrag::decodeValue( _de );
 	if( type == "samplefile" )
 	{
-		m_params->m_userWave = SampleLoader::createBufferFromFile(value);
+		m_params->m_userWave = SampleLoader::loadBufferFromFile(value);
 		m_userLfoBtn->model()->setValue( true );
 		m_params->m_lfoWaveModel.setValue(static_cast<int>(EnvelopeAndLfoParameters::LfoShape::UserDefinedWave));
 		_de->accept();
@@ -254,7 +254,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 		auto file = dataFile.content().
 					firstChildElement().firstChildElement().
 					firstChildElement().attribute("src");
-		m_params->m_userWave = SampleLoader::createBufferFromFile(file);
+		m_params->m_userWave = SampleLoader::loadBufferFromFile(file);
 		m_userLfoBtn->model()->setValue( true );
 		m_params->m_lfoWaveModel.setValue(static_cast<int>(EnvelopeAndLfoParameters::LfoShape::UserDefinedWave));
 		_de->accept();

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -592,7 +592,7 @@ QString graphModel::setWaveToUser()
 	QString fileName = gui::SampleLoader::openWaveformFile();
 	if( fileName.isEmpty() == false )
 	{
-		auto sampleBuffer = gui::SampleLoader::createBufferFromFile(fileName);
+		auto sampleBuffer = gui::SampleLoader::loadBufferFromFile(fileName);
 		for( int i = 0; i < length(); i++ )
 		{
 			m_samples[i] = Oscillator::userWaveSample(sampleBuffer.get(), i / static_cast<float>(length()));


### PR DESCRIPTION
Adds a database for samples. Callers can fetch data from the database using two overloads: one for audio files, and another for Base64 strings. The database stores weak pointers to the samples and returns shared pointers to the callers. However, the database in the future will probably need to store the weak pointers along with sample thumbnails and possibly other kinds of metadata for each sample, which should be fairly easy to do as all that needs to be done is to store a collection of the data we need in a `struct`/`class` instead of just the weak pointer to the buffer.

For audio files, we check the last write time for the file to see if it needs updating each time it is fetched, and update it if necessary. For Base64 strings, we just compare the contents.

`SampleLoader` loads audio data by querying the database for it, rather than creating them manually. As such, the `SampleLoader::create*` functions where renamed to `SampleLoader::load*`.

The memory usage has dropped significantly when using duplicate samples (`htop` readings went from 28.5% to 3.6% for me with a project that had a number of sample clips, each ~3 minutes long), and projects load faster (There is still some delay because of the waveform drawing, but this should be addressed soon. The speedup is more noticeable when you zoom all the way out before loading a project as a result).

Should supersede #7058 I believe.

PS: This is sample caching, but branded under being a sample database instead of a sample cache. Since this PR uses two hashmaps (which can resemble tables in a database), a database seems like a more accurate term, but if there are objections we can stick to saying it is a sample cache.