### PR TITLE
Shrink mixer channel strip

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -129,7 +129,7 @@ namespace lmms::gui
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
         auto mainLayout = new QVBoxLayout{this};
-        mainLayout->setContentsMargins(4, 4, 4, 4);
+        mainLayout->setContentsMargins(2, 2, 2, 2);
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -33,7 +33,6 @@
 #include "ConfigManager.h"
 
 #include "gui_templates.h"
-#include "lmms_math.h"
 
 #include <QGraphicsProxyWidget>
 #include <QGraphicsScene>
@@ -129,7 +128,7 @@ namespace lmms::gui
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
         auto mainLayout = new QVBoxLayout{this};
-        mainLayout->setContentsMargins(2, 2, 2, 2);
+        mainLayout->setContentsMargins(0, 0, 0, 0);
         mainLayout->setSpacing(0);
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -130,6 +130,7 @@ namespace lmms::gui
 
         auto mainLayout = new QVBoxLayout{this};
         mainLayout->setContentsMargins(2, 2, 2, 2);
+        mainLayout->setSpacing(0);
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);


### PR DESCRIPTION
Lots of user complained that the mixer channel strip got a lot larger after the layout rework in #6591. This PR shrinks the mixer channel strip by removing the content margins and any spacing between the child widgets.