### PR TITLE
Fix Lb302 silence

### DIFF
--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -462,7 +462,7 @@ inline float GET_INC(float freq) {
 	return freq/Engine::audioEngine()->outputSampleRate();  // TODO: Use actual sampling rate.
 }
 
-int Lb302Synth::process(SampleFrame* outbuf, const int size)
+int Lb302Synth::process(SampleFrame* outbuf, const std::size_t size)
 {
 	const float sampleRatio = 44100.f / Engine::audioEngine()->outputSampleRate();
 
@@ -498,13 +498,10 @@ int Lb302Synth::process(SampleFrame* outbuf, const int size)
 	// hard coded value of 0.99897516.
 	auto decay = computeDecayFactor(0.245260770975f, 1.f / 65536.f);
 
-	for( int i=0; i<size; i++ ) 
+	for (auto i = std::size_t{0}; i < size; i++)
 	{
 		// start decay if we're past release
-		if( i >= release_frame )
-		{
-			vca_mode = VcaMode::Decay;
-		}
+		if (i >= release_frame) { vca_mode = VcaMode::Decay; }
 
 		// update vcf
 		if(vcf_envpos >= ENVINC) {

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -751,7 +751,7 @@ void Lb302Synth::playNote( NotePlayHandle * _n, SampleFrame* _working_buffer )
 	}
 	m_notesMutex.unlock();
 
-	release_frame = std::max(release_frame, static_cast<int>(_n->framesLeft()) + static_cast<int>(_n->offset()));
+	release_frame = std::max(release_frame, _n->framesLeft() + _n->offset());
 }
 
 

--- a/plugins/Lb302/Lb302.h
+++ b/plugins/Lb302/Lb302.h
@@ -214,7 +214,7 @@ private:
 	Lb302FilterKnobState fs;
 	QAtomicPointer<Lb302Filter> vcf;
 
-	int release_frame;
+	size_t release_frame;
 
 	// More States
 	int   vcf_envpos;       // Update counter. Updates when >= ENVINC

--- a/plugins/Lb302/Lb302.h
+++ b/plugins/Lb302/Lb302.h
@@ -246,7 +246,7 @@ private:
 
 	void recalcFilter();
 
-	int process(SampleFrame* outbuf, const int size);
+	int process(SampleFrame* outbuf, const std::size_t size);
 
 	friend class gui::Lb302SynthView;
 


### PR DESCRIPTION
Meant to fix a regression from #7363, which makes LB302 completely silent. This problem seem to arise due to casting `_n->framesLeft()` and `_n->offset()` from an unsigned type (`size_t`) to a signed type (`int`). The fix is to use `size_t` across the board.