### PR TITLE
Restore some whitespace to the mixer channel layout

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -128,8 +128,8 @@ namespace lmms::gui
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
         auto mainLayout = new QVBoxLayout{this};
-        mainLayout->setContentsMargins(0, 0, 0, 0);
-        mainLayout->setSpacing(0);
+        mainLayout->setContentsMargins(3, 3, 3, 3);
+        mainLayout->setSpacing(3);
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -113,12 +113,6 @@ namespace lmms::gui
         m_soloButton->setCheckable(true);
         m_soloButton->setToolTip(tr("Solo this channel"));        
 
-        QVBoxLayout* soloMuteLayout = new QVBoxLayout();
-        soloMuteLayout->setContentsMargins(0, 0, 0, 0);
-        soloMuteLayout->setSpacing(0);
-        soloMuteLayout->addWidget(m_soloButton, 0, Qt::AlignHCenter);
-        soloMuteLayout->addWidget(m_muteButton, 0, Qt::AlignHCenter);
-
         m_fader = new Fader{&mixerChannel->m_volumeModel, tr("Fader %1").arg(channelIndex), this};
 
         m_peakIndicator = new PeakIndicator(this);
@@ -136,7 +130,8 @@ namespace lmms::gui
         mainLayout->addWidget(m_sendArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_channelNumberLcd, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_renameLineEditView, 0, Qt::AlignHCenter);
-        mainLayout->addLayout(soloMuteLayout, 0);
+        mainLayout->addWidget(m_soloButton, 0, Qt::AlignHCenter);
+        mainLayout->addWidget(m_muteButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_peakIndicator);
         mainLayout->addWidget(m_fader, 1, Qt::AlignHCenter);
 

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -113,6 +113,12 @@ namespace lmms::gui
         m_soloButton->setCheckable(true);
         m_soloButton->setToolTip(tr("Solo this channel"));        
 
+        QVBoxLayout* soloMuteLayout = new QVBoxLayout();
+        soloMuteLayout->setContentsMargins(0, 0, 0, 0);
+        soloMuteLayout->setSpacing(0);
+        soloMuteLayout->addWidget(m_soloButton, 0, Qt::AlignHCenter);
+        soloMuteLayout->addWidget(m_muteButton, 0, Qt::AlignHCenter);
+
         m_fader = new Fader{&mixerChannel->m_volumeModel, tr("Fader %1").arg(channelIndex), this};
 
         m_peakIndicator = new PeakIndicator(this);
@@ -130,8 +136,7 @@ namespace lmms::gui
         mainLayout->addWidget(m_sendArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_channelNumberLcd, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_renameLineEditView, 0, Qt::AlignHCenter);
-        mainLayout->addWidget(m_soloButton, 0, Qt::AlignHCenter);
-        mainLayout->addWidget(m_muteButton, 0, Qt::AlignHCenter);
+        mainLayout->addLayout(soloMuteLayout, 0);
         mainLayout->addWidget(m_peakIndicator);
         mainLayout->addWidget(m_fader, 1, Qt::AlignHCenter);
 

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -113,7 +113,7 @@ namespace lmms::gui
         m_soloButton->setCheckable(true);
         m_soloButton->setToolTip(tr("Solo this channel"));        
 
-        QVBoxLayout* soloMuteLayout = new QVBoxLayout();
+        auto soloMuteLayout = new QVBoxLayout();
         soloMuteLayout->setContentsMargins(0, 0, 0, 0);
         soloMuteLayout->setSpacing(0);
         soloMuteLayout->addWidget(m_soloButton, 0, Qt::AlignHCenter);
@@ -128,15 +128,16 @@ namespace lmms::gui
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
         auto mainLayout = new QVBoxLayout{this};
+        mainLayout->setContentsMargins(4, 4, 4, 4);
         mainLayout->setSpacing(2);
-        mainLayout->setContentsMargins(4, mainLayout->spacing(), 4, mainLayout->spacing());
+
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_channelNumberLcd, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_renameLineEditView, 0, Qt::AlignHCenter);
-        mainLayout->addLayout(soloMuteLayout, 0);
+        mainLayout->addLayout(soloMuteLayout);
         mainLayout->addWidget(m_peakIndicator);
         mainLayout->addWidget(m_fader, 1, Qt::AlignHCenter);
 

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -128,8 +128,8 @@ namespace lmms::gui
         m_effectRackView->setFixedWidth(EffectRackView::DEFAULT_WIDTH);
 
         auto mainLayout = new QVBoxLayout{this};
-        mainLayout->setContentsMargins(3, 3, 3, 3);
-        mainLayout->setSpacing(3);
+        mainLayout->setSpacing(2);
+        mainLayout->setContentsMargins(4, mainLayout->spacing(), 4, mainLayout->spacing());
         mainLayout->addWidget(m_receiveArrow, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendButton, 0, Qt::AlignHCenter);
         mainLayout->addWidget(m_sendKnob, 0, Qt::AlignHCenter);


### PR DESCRIPTION
Trying to reach a compromise with #7505 and #7502.

I think I initially believed that users were complaining about the spacing being too much horizontally. However, the vertical spacing in `QVBoxLayout` was 6 for me by default, which could be a bit large, and wasn't set to something smaller in #6591.

I changed the margin size and spacing to make the mixer channel a bit shorter, while also trying to not compromise useful whitespace.

I'm waiting for two approvals for this PR in particular before merge (I should probably require two approvals in general anyways).

Fixes #7505 (I think)