### PR TITLE
Fix empty editor windows

### DIFF
--- a/include/Editor.h
+++ b/include/Editor.h
@@ -56,7 +56,7 @@ protected:
 	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 	DropToolBar * addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 
-	void closeEvent( QCloseEvent * _ce ) override;
+	void closeEvent(QCloseEvent * event) override;
 protected slots:
 	virtual void play() {}
 	virtual void record() {}

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -72,6 +72,8 @@ public:
 	LMMS_EXPORT SubWindow* addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags = QFlag(0));
 
 
+	void refocus();
+
 	///
 	/// \brief	Asks whether changes made to the project are to be saved.
 	///
@@ -195,7 +197,6 @@ private:
 	void finalize();
 
 	void toggleWindow( QWidget *window, bool forceShow = false );
-	void refocus();
 
 	void exportProject(bool multiExport = false);
 	void handleSaveResult(QString const & filename, bool songSavedSuccessfully);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -978,12 +978,10 @@ void MainWindow::refocus()
 	const auto gui = getGUI();
 
 	// Attempt to set the focus on the first of these editors that is not hidden...
-	const auto editorParents = std::array{ gui->songEditor()->parentWidget(), gui->patternEditor()->parentWidget(),
-		gui->pianoRoll()->parentWidget(), gui->automationEditor()->parentWidget() };
-
-	for (auto editorParent : editorParents)
+	for (auto editorParent : { gui->songEditor()->parentWidget(), gui->patternEditor()->parentWidget(),
+		gui->pianoRoll()->parentWidget(), gui->automationEditor()->parentWidget() })
 	{
-		if(!editorParent->isHidden())
+		if (!editorParent->isHidden())
 		{
 			editorParent->setFocus();
 			return;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -978,7 +978,7 @@ void MainWindow::refocus()
 	const auto gui = getGUI();
 
 	// Attempt to set the focus on the first of these editors that is not hidden...
-	const std::vector<QWidget*> editorParents = { gui->songEditor()->parentWidget(), gui->patternEditor()->parentWidget(),
+	const auto editorParents = std::array{ gui->songEditor()->parentWidget(), gui->patternEditor()->parentWidget(),
 		gui->pianoRoll()->parentWidget(), gui->automationEditor()->parentWidget() };
 
 	for (auto editorParent : editorParents)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -975,26 +975,23 @@ void MainWindow::toggleFullscreen()
  */
 void MainWindow::refocus()
 {
-	QList<QWidget*> editors;
-	editors
-		<< getGUI()->songEditor()->parentWidget()
-		<< getGUI()->patternEditor()->parentWidget()
-		<< getGUI()->pianoRoll()->parentWidget()
-		<< getGUI()->automationEditor()->parentWidget();
+	const auto gui = getGUI();
 
-	bool found = false;
-	QList<QWidget*>::Iterator editor;
-	for( editor = editors.begin(); editor != editors.end(); ++editor )
+	// Attempt to set the focus on the first of these editors that is not hidden...
+	const std::vector<QWidget*> editorParents = { gui->songEditor()->parentWidget(), gui->patternEditor()->parentWidget(),
+		gui->pianoRoll()->parentWidget(), gui->automationEditor()->parentWidget() };
+
+	for (auto editorParent : editorParents)
 	{
-		if( ! (*editor)->isHidden() ) {
-			(*editor)->setFocus();
-			found = true;
-			break;
+		if(!editorParent->isHidden())
+		{
+			editorParent->setFocus();
+			return;
 		}
 	}
 
-	if( ! found )
-		this->setFocus();
+	// ... otherwise set the focus on the main window.
+	this->setFocus();	
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -991,7 +991,7 @@ void MainWindow::refocus()
 	}
 
 	// ... otherwise set the focus on the main window.
-	this->setFocus();	
+	this->setFocus();
 }
 
 

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -140,7 +140,7 @@ QAction *Editor::playAction() const
 	return m_playAction;
 }
 
-void Editor::closeEvent( QCloseEvent * _ce )
+void Editor::closeEvent(QCloseEvent * event)
 {
 	if( parentWidget() )
 	{
@@ -151,7 +151,7 @@ void Editor::closeEvent( QCloseEvent * _ce )
 		hide();
 	}
 	getGUI()->mainWindow()->refocus();
-	_ce->ignore();
+	event->ignore();
  }
 
 DropToolBar::DropToolBar(QWidget* parent) : QToolBar(parent)

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -24,6 +24,8 @@
 
 #include "Editor.h"
 
+#include "GuiApplication.h"
+#include "MainWindow.h"
 #include "Song.h"
 
 #include "embed.h"
@@ -148,7 +150,8 @@ void Editor::closeEvent( QCloseEvent * _ce )
 	{
 		hide();
 	}
-	_ce->accept();
+	getGUI()->mainWindow()->refocus();
+	_ce->ignore();
  }
 
 DropToolBar::DropToolBar(QWidget* parent) : QToolBar(parent)


### PR DESCRIPTION
(1) Bug affects not only Song Editor window, but also Piano Roll, Pattern Editor, Automation Editor windows (all are extending Editor class). Using MainWindow::refocus() makes closing event handling close to closing by shortcut (from MainWindow code)
(2) This is BugFix PR so I do not change coding convention violation ( variable _ce ).
[Edited: after some refactoring commits by LMMS member I decide to change **_ce** to **event**]

Reworks #7035
Fixes #7412