### PR TITLE
Partially revert #7453

### DIFF
--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -223,7 +223,7 @@ void EffectRackView::update()
 		}
 	}
 
-	w->setFixedSize( EffectView::DEFAULT_WIDTH + 2*EffectViewMargin, m_lastY);
+	w->setFixedSize(EffectView::DEFAULT_WIDTH + 2 * EffectViewMargin, m_lastY);
 
 	QWidget::update();
 }

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -216,16 +216,14 @@ void EffectRackView::update()
 		}
 		else
 		{
-			(*it)->resize(width() - 35, EffectView::DEFAULT_HEIGHT);
 			( *it )->move( EffectViewMargin, m_lastY );
-			(*it)->update();
 			m_lastY += ( *it )->height();
 			++nView;
 			++it;
 		}
 	}
 
-	w->resize(width() - 35 + 2 * EffectViewMargin, m_lastY);
+	w->setFixedSize( EffectView::DEFAULT_WIDTH + 2*EffectViewMargin, m_lastY);
 
 	QWidget::update();
 }

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -52,7 +52,8 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_controlView(nullptr),
 	m_dragging(false)
 {
-	setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding); // TODO: Actual effect resizing
+	setFixedSize(EffectView::DEFAULT_WIDTH, EffectView::DEFAULT_HEIGHT);
+	setFocusPolicy(Qt::StrongFocus);
 
 	// Disable effects that are of type "DummyEffect"
 	bool isEnabled = !dynamic_cast<DummyEffect *>( effect() );

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -85,11 +85,9 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	envelopeLayout->addLayout(graphAndAmountLayout);
 
 	m_envelopeGraph = new EnvelopeGraph(this);
-	m_envelopeGraph->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	graphAndAmountLayout->addWidget(m_envelopeGraph);
 
 	m_amountKnob = buildKnob(tr("AMT"), tr("Modulation amount:"));
-	m_amountKnob->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 	graphAndAmountLayout->addWidget(m_amountKnob, 0, Qt::AlignCenter);
 
 	QHBoxLayout* envKnobsLayout = new QHBoxLayout();

--- a/src/gui/instrument/EnvelopeGraph.cpp
+++ b/src/gui/instrument/EnvelopeGraph.cpp
@@ -211,8 +211,8 @@ void EnvelopeGraph::paintEvent(QPaintEvent*)
 	const QColor lineColor{ColorHelper::interpolateInRgb(noAmountColor, fullAmountColor, absAmount)};
 
 	// Determine the line width so that it scales with the widget
-	// Use the diagonal of the box to compute it
-	const qreal lineWidth = sqrt(width()*width() + height()*height()) / 80.;
+	// Use the minimum value of the current width and height to compute it.
+	const qreal lineWidth = std::min(width(), height()) / 20.;
 	const QPen linePen{lineColor, lineWidth};
 	p.setPen(linePen);
 

--- a/src/gui/instrument/InstrumentView.cpp
+++ b/src/gui/instrument/InstrumentView.cpp
@@ -45,7 +45,6 @@ InstrumentView::InstrumentView( Instrument * _Instrument, QWidget * _parent ) :
 
 InstrumentView::~InstrumentView()
 {
-	setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 	if( instrumentTrackWindow() )
 	{
 		instrumentTrackWindow()->m_instrumentView = nullptr;


### PR DESCRIPTION
Partially reverts #7453 to fix regressions. SlicerT remains big and resizable, but most the out of scope changes (i.e., those involving `EffectRackView`, `EffectView`, `EnvelopeGraph`, etc) were reverted.

We should revisit the layout implementation for `InstrumentTrackWindow` and `SampleTrackWindow`. I still think there is a need for a better implementation to make them bigger/resizable. Whatever that entails (layout rework, widget rework, etc) can be discussed when we get around doing that, but for now I am fixing the alarming regressions.