### PR TITLE
Individual knob labels rendered using the widget font

### DIFF
--- a/include/CustomTextKnob.h
+++ b/include/CustomTextKnob.h
@@ -42,6 +42,8 @@ public:
 
 	CustomTextKnob( const Knob& other ) = delete;
 
+	static CustomTextKnob* buildLegacyKnob(KnobType knob_num, QWidget* parent, const QString& description, const QString& label);
+
 	inline void setValueText(const QString & _value_text)
 	{
 		m_value_text = _value_text;

--- a/include/CustomTextKnob.h
+++ b/include/CustomTextKnob.h
@@ -42,7 +42,7 @@ public:
 
 	CustomTextKnob( const Knob& other ) = delete;
 
-	static CustomTextKnob* buildLegacyKnob(KnobType knob_num, QWidget* parent, const QString& description, const QString& label);
+	static CustomTextKnob* buildKnobWithSmallPixelFont(KnobType knob_num, QWidget* parent, const QString& description, const QString& label);
 
 	inline void setValueText(const QString & _value_text)
 	{

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -81,7 +81,8 @@ public:
 	Knob( QWidget * _parent = nullptr, const QString & _name = QString() ); //!< default ctor
 	Knob( const Knob& other ) = delete;
 
-	void setLabel( const QString & txt );
+	void setLabel(const QString & txt, bool legacyMode = true);
+	void setLabelLegacy(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );
 
 	void setTotalAngle( float angle );

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -81,6 +81,8 @@ public:
 	Knob( QWidget * _parent = nullptr, const QString & _name = QString() ); //!< default ctor
 	Knob( const Knob& other ) = delete;
 
+	static Knob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent);
+
 	void setLabel(const QString & txt);
 	void setLabelLegacy(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -85,6 +85,9 @@ public:
 	void setLabelLegacy(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );
 
+	bool legacyMode() const { return m_legacyMode; }
+	void setLegacyMode(bool legacyMode);
+
 	void setTotalAngle( float angle );
 
 	// Begin styled knob accessors
@@ -129,6 +132,8 @@ private:
 	{
 		return static_cast<int>( ( value - 0.5 * ( minValue + maxValue ) ) / ( maxValue - minValue ) * m_totalAngle ) % 360;
 	}
+
+	void updateFixedSize();
 
 	QString m_label;
 	bool m_legacyMode = false;

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -82,6 +82,7 @@ public:
 	Knob( const Knob& other ) = delete;
 
 	static Knob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent, const QString & _name = QString());
+	static Knob* buildKnobWithSmallPixelFont(KnobType knob_num, const QString& label, QWidget* parent, const QString & _name = QString());
 
 	void setLabel(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -81,7 +81,7 @@ public:
 	Knob( QWidget * _parent = nullptr, const QString & _name = QString() ); //!< default ctor
 	Knob( const Knob& other ) = delete;
 
-	void setLabel(const QString & txt, bool legacyMode = true);
+	void setLabel(const QString & txt);
 	void setLabelLegacy(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );
 
@@ -131,6 +131,7 @@ private:
 	}
 
 	QString m_label;
+	bool m_legacyMode = false;
 	bool m_isHtmlLabel;
 	QTextDocument* m_tdRenderer;
 

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -127,6 +127,7 @@ private:
 						float _innerRadius = 1) const;
 
 	void drawKnob( QPainter * _p );
+	void drawLabel(QPainter& p);
 	bool updateAngle();
 
 	int angleFromValue( float value, float minValue, float maxValue, float totalAngle ) const

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -84,7 +84,6 @@ public:
 	static Knob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent, const QString & _name = QString());
 
 	void setLabel(const QString & txt);
-	void setLabelLegacy(const QString & txt);
 	void setHtmlLabel( const QString &htmltxt );
 
 	bool legacyMode() const { return m_legacyMode; }

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -81,7 +81,7 @@ public:
 	Knob( QWidget * _parent = nullptr, const QString & _name = QString() ); //!< default ctor
 	Knob( const Knob& other ) = delete;
 
-	static Knob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent);
+	static Knob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent, const QString & _name = QString());
 
 	void setLabel(const QString & txt);
 	void setLabelLegacy(const QString & txt);

--- a/include/TempoSyncKnob.h
+++ b/include/TempoSyncKnob.h
@@ -44,6 +44,8 @@ public:
 	TempoSyncKnob( KnobType knobNum, QWidget* parent = nullptr, const QString& name = QString() );
 	~TempoSyncKnob() override;
 
+	static TempoSyncKnob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent);
+
 	const QString & syncDescription();
 	void setSyncDescription( const QString & _new_description );
 

--- a/include/TempoSyncKnob.h
+++ b/include/TempoSyncKnob.h
@@ -45,6 +45,7 @@ public:
 	~TempoSyncKnob() override;
 
 	static TempoSyncKnob* buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent);
+	static TempoSyncKnob* buildKnobWithSmallPixelFont(KnobType knob_num, const QString& label, QWidget* parent);
 
 	const QString & syncDescription();
 	void setSyncDescription( const QString & _new_description );

--- a/plugins/Amplifier/AmplifierControlDialog.cpp
+++ b/plugins/Amplifier/AmplifierControlDialog.cpp
@@ -45,7 +45,7 @@ AmplifierControlDialog::AmplifierControlDialog(AmplifierControls* controls) :
         Knob* newKnob = new Knob(KnobType::Bright26, this);
         newKnob->move(x, y);
         newKnob->setModel(model);
-        newKnob->setLabel(label);
+        newKnob->setLabelLegacy(label);
         newKnob->setHintText(hintText, unit);
         newKnob->setVolumeKnob(isVolume);
         return newKnob;

--- a/plugins/Amplifier/AmplifierControlDialog.cpp
+++ b/plugins/Amplifier/AmplifierControlDialog.cpp
@@ -28,6 +28,9 @@
 #include "embed.h"
 #include "Knob.h"
 
+#include <QGridLayout>
+
+
 namespace lmms::gui
 {
 
@@ -38,23 +41,23 @@ AmplifierControlDialog::AmplifierControlDialog(AmplifierControls* controls) :
 	QPalette pal;
 	pal.setBrush(backgroundRole(), PLUGIN_NAME::getIconPixmap("artwork"));
 	setPalette(pal);
-	setFixedSize(100, 110);
+
+	QGridLayout* gridLayout = new QGridLayout(this);
 	
-	auto makeKnob = [this](int x, int y, const QString& label, const QString& hintText, const QString& unit, FloatModel* model, bool isVolume)
+	auto makeKnob = [this](const QString& label, const QString& hintText, const QString& unit, FloatModel* model, bool isVolume)
 	{
-        Knob* newKnob = new Knob(KnobType::Bright26, this);
-        newKnob->move(x, y);
+		Knob* newKnob = new Knob(KnobType::Bright26, this);
         newKnob->setModel(model);
-        newKnob->setLabelLegacy(label);
+		newKnob->setLabel(label);
         newKnob->setHintText(hintText, unit);
         newKnob->setVolumeKnob(isVolume);
         return newKnob;
     };
 
-	makeKnob(16, 10, tr("VOL"), tr("Volume:"), "%", &controls->m_volumeModel, true);
-	makeKnob(57, 10, tr("PAN"), tr("Panning:"), "%", &controls->m_panModel, false);
-	makeKnob(16, 65, tr("LEFT"), tr("Left gain:"), "%", &controls->m_leftModel, true);
-	makeKnob(57, 65, tr("RIGHT"), tr("Right gain:"), "%", &controls->m_rightModel, true);
+	gridLayout->addWidget(makeKnob(tr("VOL"), tr("Volume:"), "%", &controls->m_volumeModel, true), 0, 0, Qt::AlignHCenter);
+	gridLayout->addWidget(makeKnob(tr("PAN"), tr("Panning:"), "%", &controls->m_panModel, false), 0, 1, Qt::AlignHCenter);
+	gridLayout->addWidget(makeKnob(tr("LEFT"), tr("Left gain:"), "%", &controls->m_leftModel, true), 1, 0, Qt::AlignHCenter);
+	gridLayout->addWidget(makeKnob(tr("RIGHT"), tr("Right gain:"), "%", &controls->m_rightModel, true), 1, 1, Qt::AlignHCenter);
 }
 
 } // namespace lmms::gui

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -52,17 +52,17 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 
 	auto freqKnob = new Knob(KnobType::Bright26, this);
 	freqKnob->setModel( &controls->m_freqModel );
-	freqKnob->setLabel( tr( "FREQ" ) );
+	freqKnob->setLabelLegacy( tr( "FREQ" ) );
 	freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
 
 	auto gainKnob = new Knob(KnobType::Bright26, this);
 	gainKnob->setModel( &controls->m_gainModel );
-	gainKnob->setLabel( tr( "GAIN" ) );
+	gainKnob->setLabelLegacy( tr( "GAIN" ) );
 	gainKnob->setHintText( tr( "Gain:" ) , "" );
 
 	auto ratioKnob = new Knob(KnobType::Bright26, this);
 	ratioKnob->setModel( &controls->m_ratioModel );
-	ratioKnob->setLabel( tr( "RATIO" ) );
+	ratioKnob->setLabelLegacy( tr( "RATIO" ) );
 	ratioKnob->setHintText( tr( "Ratio:" ) , "" );
 
 	l->addWidget( freqKnob );

--- a/plugins/BassBooster/BassBoosterControlDialog.cpp
+++ b/plugins/BassBooster/BassBoosterControlDialog.cpp
@@ -43,7 +43,6 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 	QPalette pal;
 	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
-	setFixedSize( 120, 60 );
 
 	auto tl = new QVBoxLayout(this);
 	tl->addSpacing( 4 );
@@ -52,17 +51,17 @@ BassBoosterControlDialog::BassBoosterControlDialog( BassBoosterControls* control
 
 	auto freqKnob = new Knob(KnobType::Bright26, this);
 	freqKnob->setModel( &controls->m_freqModel );
-	freqKnob->setLabelLegacy( tr( "FREQ" ) );
+	freqKnob->setLabel(tr("FREQ"));
 	freqKnob->setHintText( tr( "Frequency:" ) , "Hz" );
 
 	auto gainKnob = new Knob(KnobType::Bright26, this);
 	gainKnob->setModel( &controls->m_gainModel );
-	gainKnob->setLabelLegacy( tr( "GAIN" ) );
+	gainKnob->setLabel(tr("GAIN"));
 	gainKnob->setHintText( tr( "Gain:" ) , "" );
 
 	auto ratioKnob = new Knob(KnobType::Bright26, this);
 	ratioKnob->setModel( &controls->m_ratioModel );
-	ratioKnob->setLabelLegacy( tr( "RATIO" ) );
+	ratioKnob->setLabel(tr("RATIO"));
 	ratioKnob->setHintText( tr( "Ratio:" ) , "" );
 
 	l->addWidget( freqKnob );

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -29,6 +29,7 @@
 #include "embed.h"
 #include "BitcrushControlDialog.h"
 #include "BitcrushControls.h"
+#include "FontHelper.h"
 #include "LedCheckBox.h"
 #include "Knob.h"
 
@@ -46,31 +47,35 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	setFixedSize( 181, 128 );
 	
 	// labels
+	const auto labelFont = adjustedToPixelSize(font(), DEFAULT_FONT_SIZE);
+
 	auto inLabel = new QLabel(tr("IN"), this);
+	inLabel->setFont(labelFont);
 	inLabel->move( 24, 15 );
 
 	auto outLabel = new QLabel(tr("OUT"), this);
+	outLabel->setFont(labelFont);
 	outLabel->move( 139, 15 );
 	
 	// input knobs
-	auto inGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("GAIN"), this);
+	auto inGain = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("GAIN"), this);
 	inGain->move( 16, 32 );
 	inGain->setModel( & controls->m_inGain );
 	inGain->setHintText( tr( "Input gain:" ) , " dBFS" );
 
-	auto inNoise = Knob::buildLegacyKnob(KnobType::Bright26, tr("NOISE"), this);
+	auto inNoise = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("NOISE"), this);
 	inNoise->move( 14, 76 );
 	inNoise->setModel( & controls->m_inNoise );
 	inNoise->setHintText( tr( "Input noise:" ) , "%" );
 	
 	
 	// output knobs
-	auto outGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("GAIN"), this);
+	auto outGain = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("GAIN"), this);
 	outGain->move( 138, 32 );
 	outGain->setModel( & controls->m_outGain );
 	outGain->setHintText( tr( "Output gain:" ) , " dBFS" );
 
-	auto outClip = Knob::buildLegacyKnob(KnobType::Bright26, tr("CLIP"), this);
+	auto outClip = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("CLIP"), this);
 	outClip->move( 138, 76 );
 	outClip->setModel( & controls->m_outClip );
     outClip->setHintText( tr( "Output clip:" ) , " dBFS");
@@ -90,19 +95,19 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// rate crushing knobs
-	auto rate = Knob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
+	auto rate = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("FREQ"), this);
 	rate->move( 59, 32 );
 	rate->setModel( & controls->m_rate );
 	rate->setHintText( tr( "Sample rate:" ) , " Hz" );
 
-	auto stereoDiff = Knob::buildLegacyKnob(KnobType::Bright26, tr("STEREO"), this);
+	auto stereoDiff = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("STEREO"), this);
 	stereoDiff->move( 72, 76 );
 	stereoDiff->setModel( & controls->m_stereoDiff );
 	stereoDiff->setHintText( tr( "Stereo difference:" ) , "%" );
 	
 	
 	// depth crushing knob
-	auto levels = Knob::buildLegacyKnob(KnobType::Bright26, tr("QUANT"), this);
+	auto levels = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("QUANT"), this);
 	levels->move( 92, 32 );
 	levels->setModel( & controls->m_levels );
 	levels->setHintText( tr( "Levels:" ) , "" );

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -56,13 +56,13 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	auto inGain = new Knob(KnobType::Bright26, this);
 	inGain->move( 16, 32 );
 	inGain->setModel( & controls->m_inGain );
-	inGain->setLabel( tr( "GAIN" ) );
+	inGain->setLabelLegacy( tr( "GAIN" ) );
 	inGain->setHintText( tr( "Input gain:" ) , " dBFS" );
 
 	auto inNoise = new Knob(KnobType::Bright26, this);
 	inNoise->move( 14, 76 );
 	inNoise->setModel( & controls->m_inNoise );
-	inNoise->setLabel( tr( "NOISE" ) );
+	inNoise->setLabelLegacy( tr( "NOISE" ) );
 	inNoise->setHintText( tr( "Input noise:" ) , "%" );
 	
 	
@@ -70,13 +70,13 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	auto outGain = new Knob(KnobType::Bright26, this);
 	outGain->move( 138, 32 );
 	outGain->setModel( & controls->m_outGain );
-	outGain->setLabel( tr( "GAIN" ) );
+	outGain->setLabelLegacy( tr( "GAIN" ) );
 	outGain->setHintText( tr( "Output gain:" ) , " dBFS" );
 
 	auto outClip = new Knob(KnobType::Bright26, this);
 	outClip->move( 138, 76 );
 	outClip->setModel( & controls->m_outClip );
-	outClip->setLabel( tr( "CLIP" ) );
+	outClip->setLabelLegacy( tr( "CLIP" ) );
     outClip->setHintText( tr( "Output clip:" ) , " dBFS");
 
 	
@@ -97,13 +97,13 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	auto rate = new Knob(KnobType::Bright26, this);
 	rate->move( 59, 32 );
 	rate->setModel( & controls->m_rate );
-	rate->setLabel( tr( "FREQ" ) );
+	rate->setLabelLegacy( tr( "FREQ" ) );
 	rate->setHintText( tr( "Sample rate:" ) , " Hz" );
 
 	auto stereoDiff = new Knob(KnobType::Bright26, this);
 	stereoDiff->move( 72, 76 );
 	stereoDiff->setModel( & controls->m_stereoDiff );
-	stereoDiff->setLabel( tr( "STEREO" ) );
+	stereoDiff->setLabelLegacy( tr( "STEREO" ) );
 	stereoDiff->setHintText( tr( "Stereo difference:" ) , "%" );
 	
 	
@@ -111,7 +111,7 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	auto levels = new Knob(KnobType::Bright26, this);
 	levels->move( 92, 32 );
 	levels->setModel( & controls->m_levels );
-	levels->setLabel( tr( "QUANT" ) );
+	levels->setLabelLegacy( tr( "QUANT" ) );
 	levels->setHintText( tr( "Levels:" ) , "" );
 }
 

--- a/plugins/Bitcrush/BitcrushControlDialog.cpp
+++ b/plugins/Bitcrush/BitcrushControlDialog.cpp
@@ -53,30 +53,26 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	outLabel->move( 139, 15 );
 	
 	// input knobs
-	auto inGain = new Knob(KnobType::Bright26, this);
+	auto inGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("GAIN"), this);
 	inGain->move( 16, 32 );
 	inGain->setModel( & controls->m_inGain );
-	inGain->setLabelLegacy( tr( "GAIN" ) );
 	inGain->setHintText( tr( "Input gain:" ) , " dBFS" );
 
-	auto inNoise = new Knob(KnobType::Bright26, this);
+	auto inNoise = Knob::buildLegacyKnob(KnobType::Bright26, tr("NOISE"), this);
 	inNoise->move( 14, 76 );
 	inNoise->setModel( & controls->m_inNoise );
-	inNoise->setLabelLegacy( tr( "NOISE" ) );
 	inNoise->setHintText( tr( "Input noise:" ) , "%" );
 	
 	
 	// output knobs
-	auto outGain = new Knob(KnobType::Bright26, this);
+	auto outGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("GAIN"), this);
 	outGain->move( 138, 32 );
 	outGain->setModel( & controls->m_outGain );
-	outGain->setLabelLegacy( tr( "GAIN" ) );
 	outGain->setHintText( tr( "Output gain:" ) , " dBFS" );
 
-	auto outClip = new Knob(KnobType::Bright26, this);
+	auto outClip = Knob::buildLegacyKnob(KnobType::Bright26, tr("CLIP"), this);
 	outClip->move( 138, 76 );
 	outClip->setModel( & controls->m_outClip );
-	outClip->setLabelLegacy( tr( "CLIP" ) );
     outClip->setHintText( tr( "Output clip:" ) , " dBFS");
 
 	
@@ -94,24 +90,21 @@ BitcrushControlDialog::BitcrushControlDialog( BitcrushControls * controls ) :
 	
 	
 	// rate crushing knobs
-	auto rate = new Knob(KnobType::Bright26, this);
+	auto rate = Knob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
 	rate->move( 59, 32 );
 	rate->setModel( & controls->m_rate );
-	rate->setLabelLegacy( tr( "FREQ" ) );
 	rate->setHintText( tr( "Sample rate:" ) , " Hz" );
 
-	auto stereoDiff = new Knob(KnobType::Bright26, this);
+	auto stereoDiff = Knob::buildLegacyKnob(KnobType::Bright26, tr("STEREO"), this);
 	stereoDiff->move( 72, 76 );
 	stereoDiff->setModel( & controls->m_stereoDiff );
-	stereoDiff->setLabelLegacy( tr( "STEREO" ) );
 	stereoDiff->setHintText( tr( "Stereo difference:" ) , "%" );
 	
 	
 	// depth crushing knob
-	auto levels = new Knob(KnobType::Bright26, this);
+	auto levels = Knob::buildLegacyKnob(KnobType::Bright26, tr("QUANT"), this);
 	levels->move( 92, 32 );
 	levels->setModel( & controls->m_levels );
-	levels->setLabelLegacy( tr( "QUANT" ) );
 	levels->setHintText( tr( "Levels:" ) , "" );
 }
 

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -1010,7 +1010,7 @@ void CarlaParamsView::refreshKnobs()
 		m_knobs.push_back(new Knob(KnobType::Dark28, m_inputScrollAreaWidgetContent));
 		QString name = (*m_carlaInstrument->m_paramModels[i]).displayName();
 		m_knobs[i]->setHintText(name, "");
-		m_knobs[i]->setLabel(name);
+		m_knobs[i]->setLabelLegacy(name);
 		m_knobs[i]->setObjectName(name); // this is being used for filtering the knobs.
 
 		// Set the newly created model to the knob.

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -1007,10 +1007,9 @@ void CarlaParamsView::refreshKnobs()
 	for (uint32_t i = 0; i < m_carlaInstrument->m_paramModels.size(); ++i)
 	{
 		bool enabled = m_carlaInstrument->m_paramModels[i]->enabled();
-		m_knobs.push_back(new Knob(KnobType::Dark28, m_inputScrollAreaWidgetContent));
-		QString name = (*m_carlaInstrument->m_paramModels[i]).displayName();
+		const QString name = (*m_carlaInstrument->m_paramModels[i]).displayName();
+		m_knobs.push_back(Knob::buildLegacyKnob(KnobType::Dark28, name, m_inputScrollAreaWidgetContent));
 		m_knobs[i]->setHintText(name, "");
-		m_knobs[i]->setLabelLegacy(name);
 		m_knobs[i]->setObjectName(name); // this is being used for filtering the knobs.
 
 		// Set the newly created model to the knob.

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -49,22 +49,19 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	setFixedSize( 167, 178 );
 	
 	// knobs
-	auto xover12 = new Knob(KnobType::Bright26, this);
+	auto xover12 = Knob::buildLegacyKnob(KnobType::Bright26, "1/2", this);
 	xover12->move( 29, 11 );
 	xover12->setModel( & controls->m_xover12 );
-	xover12->setLabelLegacy( "1/2" );
 	xover12->setHintText( tr( "Band 1/2 crossover:" ), " Hz" );
 
-	auto xover23 = new Knob(KnobType::Bright26, this);
+	auto xover23 = Knob::buildLegacyKnob(KnobType::Bright26, "2/3", this);
 	xover23->move( 69, 11 );
 	xover23->setModel( & controls->m_xover23 );
-	xover23->setLabelLegacy( "2/3" );
 	xover23->setHintText( tr( "Band 2/3 crossover:" ), " Hz" );
 
-	auto xover34 = new Knob(KnobType::Bright26, this);
+	auto xover34 = Knob::buildLegacyKnob(KnobType::Bright26, "3/4", this);
 	xover34->move( 109, 11 );
 	xover34->setModel( & controls->m_xover34 );
-	xover34->setLabelLegacy( "3/4" );
 	xover34->setHintText( tr( "Band 3/4 crossover:" ), " Hz" );
 	
 	QPixmap const fader_knob(PLUGIN_NAME::getIconPixmap("fader_knob2"));

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -49,17 +49,17 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	setFixedSize( 167, 178 );
 	
 	// knobs
-	auto xover12 = Knob::buildLegacyKnob(KnobType::Bright26, "1/2", this);
+	auto xover12 = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, "1/2", this);
 	xover12->move( 29, 11 );
 	xover12->setModel( & controls->m_xover12 );
 	xover12->setHintText( tr( "Band 1/2 crossover:" ), " Hz" );
 
-	auto xover23 = Knob::buildLegacyKnob(KnobType::Bright26, "2/3", this);
+	auto xover23 = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, "2/3", this);
 	xover23->move( 69, 11 );
 	xover23->setModel( & controls->m_xover23 );
 	xover23->setHintText( tr( "Band 2/3 crossover:" ), " Hz" );
 
-	auto xover34 = Knob::buildLegacyKnob(KnobType::Bright26, "3/4", this);
+	auto xover34 = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, "3/4", this);
 	xover34->move( 109, 11 );
 	xover34->setModel( & controls->m_xover34 );
 	xover34->setHintText( tr( "Band 3/4 crossover:" ), " Hz" );

--- a/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
+++ b/plugins/CrossoverEQ/CrossoverEQControlDialog.cpp
@@ -52,19 +52,19 @@ CrossoverEQControlDialog::CrossoverEQControlDialog( CrossoverEQControls * contro
 	auto xover12 = new Knob(KnobType::Bright26, this);
 	xover12->move( 29, 11 );
 	xover12->setModel( & controls->m_xover12 );
-	xover12->setLabel( "1/2" );
+	xover12->setLabelLegacy( "1/2" );
 	xover12->setHintText( tr( "Band 1/2 crossover:" ), " Hz" );
 
 	auto xover23 = new Knob(KnobType::Bright26, this);
 	xover23->move( 69, 11 );
 	xover23->setModel( & controls->m_xover23 );
-	xover23->setLabel( "2/3" );
+	xover23->setLabelLegacy( "2/3" );
 	xover23->setHintText( tr( "Band 2/3 crossover:" ), " Hz" );
 
 	auto xover34 = new Knob(KnobType::Bright26, this);
 	xover34->move( 109, 11 );
 	xover34->setModel( & controls->m_xover34 );
-	xover34->setLabel( "3/4" );
+	xover34->setLabelLegacy( "3/4" );
 	xover34->setHintText( tr( "Band 3/4 crossover:" ), " Hz" );
 	
 	QPixmap const fader_knob(PLUGIN_NAME::getIconPixmap("fader_knob2"));

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -44,32 +44,28 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	setPalette( pal );
 	setFixedSize( 300, 208 );
 
-	auto sampleDelayKnob = new TempoSyncKnob(KnobType::Bright26, this);
+	auto sampleDelayKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("DELAY"), this);
 	sampleDelayKnob->move( 10,14 );
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
-	sampleDelayKnob->setLabelLegacy( tr( "DELAY" ) );
 	sampleDelayKnob->setHintText( tr( "Delay time" ) + " ", " s" );
 
-	auto feedbackKnob = new Knob(KnobType::Bright26, this);
+	auto feedbackKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("FDBK"), this);
 	feedbackKnob->move( 11, 58 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel);
-	feedbackKnob->setLabelLegacy( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
 
-	auto lfoFreqKnob = new TempoSyncKnob(KnobType::Bright26, this);
+	auto lfoFreqKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("RATE"), this);
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
-	lfoFreqKnob->setLabelLegacy( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
 
-	auto lfoAmtKnob = new TempoSyncKnob(KnobType::Bright26, this);
+	auto lfoAmtKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("AMNT"), this);
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-	lfoAmtKnob->setLabelLegacy( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
 
 	auto outFader

--- a/plugins/Delay/DelayControlsDialog.cpp
+++ b/plugins/Delay/DelayControlsDialog.cpp
@@ -48,28 +48,28 @@ DelayControlsDialog::DelayControlsDialog( DelayControls *controls ) :
 	sampleDelayKnob->move( 10,14 );
 	sampleDelayKnob->setVolumeKnob( false );
 	sampleDelayKnob->setModel( &controls->m_delayTimeModel );
-	sampleDelayKnob->setLabel( tr( "DELAY" ) );
+	sampleDelayKnob->setLabelLegacy( tr( "DELAY" ) );
 	sampleDelayKnob->setHintText( tr( "Delay time" ) + " ", " s" );
 
 	auto feedbackKnob = new Knob(KnobType::Bright26, this);
 	feedbackKnob->move( 11, 58 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel);
-	feedbackKnob->setLabel( tr( "FDBK" ) );
+	feedbackKnob->setLabelLegacy( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr ( "Feedback amount" ) + " " , "" );
 
 	auto lfoFreqKnob = new TempoSyncKnob(KnobType::Bright26, this);
 	lfoFreqKnob->move( 11, 119 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoTimeModel );
-	lfoFreqKnob->setLabel( tr( "RATE" ) );
+	lfoFreqKnob->setLabelLegacy( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr ( "LFO frequency") + " ", " s" );
 
 	auto lfoAmtKnob = new TempoSyncKnob(KnobType::Bright26, this);
 	lfoAmtKnob->move( 11, 159 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-	lfoAmtKnob->setLabel( tr( "AMNT" ) );
+	lfoAmtKnob->setLabelLegacy( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr ( "LFO amount" ) + " " , " s" );
 
 	auto outFader

--- a/plugins/Dispersion/DispersionControlDialog.cpp
+++ b/plugins/Dispersion/DispersionControlDialog.cpp
@@ -31,6 +31,8 @@
 #include "LcdSpinBox.h"
 #include "PixmapButton.h"
 
+#include <QHBoxLayout>
+
 
 namespace lmms::gui
 {
@@ -43,39 +45,41 @@ DispersionControlDialog::DispersionControlDialog(DispersionControls* controls) :
 	QPalette pal;
 	pal.setBrush(backgroundRole(), PLUGIN_NAME::getIconPixmap("artwork"));
 	setPalette(pal);
-	setFixedSize(207, 50);
+
+	auto layout = new QHBoxLayout(this);
 
 	LcdSpinBox * m_amountBox = new LcdSpinBox(3, this, "Amount");
 	m_amountBox->setModel(&controls->m_amountModel);
-	m_amountBox->move(5, 10);
 	m_amountBox->setLabel(tr("AMOUNT"));
 	m_amountBox->setToolTip(tr("Number of all-pass filters"));
 	
 	Knob * freqKnob = new Knob(KnobType::Bright26, this);
-	freqKnob->move(59, 8);
 	freqKnob->setModel(&controls->m_freqModel);
-	freqKnob->setLabelLegacy(tr("FREQ"));
+	freqKnob->setLabel(tr("FREQ"));
 	freqKnob->setHintText(tr("Frequency:") , " Hz");
 	
 	Knob * resoKnob = new Knob(KnobType::Bright26, this);
-	resoKnob->move(99, 8);
 	resoKnob->setModel(&controls->m_resoModel);
-	resoKnob->setLabelLegacy(tr("RESO"));
+	resoKnob->setLabel(tr("RESO"));
 	resoKnob->setHintText(tr("Resonance:") , " octaves");
 	
 	Knob * feedbackKnob = new Knob(KnobType::Bright26, this);
-	feedbackKnob->move(139, 8);
 	feedbackKnob->setModel(&controls->m_feedbackModel);
-	feedbackKnob->setLabelLegacy(tr("FEED"));
+	feedbackKnob->setLabel(tr("FEED"));
 	feedbackKnob->setHintText(tr("Feedback:") , "");
 	
 	PixmapButton * dcButton = new PixmapButton(this, tr("DC Offset Removal"));
-	dcButton->move(176, 16);
 	dcButton->setActiveGraphic(PLUGIN_NAME::getIconPixmap("dc_active"));
 	dcButton->setInactiveGraphic(PLUGIN_NAME::getIconPixmap("dc_inactive"));
 	dcButton->setCheckable(true);
 	dcButton->setModel(&controls->m_dcModel);
 	dcButton->setToolTip(tr("Remove DC Offset"));
+
+	layout->addWidget(m_amountBox);
+	layout->addWidget(freqKnob);
+	layout->addWidget(resoKnob);
+	layout->addWidget(feedbackKnob);
+	layout->addWidget(dcButton);
 }
 
 

--- a/plugins/Dispersion/DispersionControlDialog.cpp
+++ b/plugins/Dispersion/DispersionControlDialog.cpp
@@ -54,19 +54,19 @@ DispersionControlDialog::DispersionControlDialog(DispersionControls* controls) :
 	Knob * freqKnob = new Knob(KnobType::Bright26, this);
 	freqKnob->move(59, 8);
 	freqKnob->setModel(&controls->m_freqModel);
-	freqKnob->setLabel(tr("FREQ"));
+	freqKnob->setLabelLegacy(tr("FREQ"));
 	freqKnob->setHintText(tr("Frequency:") , " Hz");
 	
 	Knob * resoKnob = new Knob(KnobType::Bright26, this);
 	resoKnob->move(99, 8);
 	resoKnob->setModel(&controls->m_resoModel);
-	resoKnob->setLabel(tr("RESO"));
+	resoKnob->setLabelLegacy(tr("RESO"));
 	resoKnob->setHintText(tr("Resonance:") , " octaves");
 	
 	Knob * feedbackKnob = new Knob(KnobType::Bright26, this);
 	feedbackKnob->move(139, 8);
 	feedbackKnob->setModel(&controls->m_feedbackModel);
-	feedbackKnob->setLabel(tr("FEED"));
+	feedbackKnob->setLabelLegacy(tr("FEED"));
 	feedbackKnob->setHintText(tr("Feedback:") , "");
 	
 	PixmapButton * dcButton = new PixmapButton(this, tr("DC Offset Removal"));

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -35,7 +35,7 @@ namespace lmms::gui
 
 
 #define makeknob( name, x, y, model, label, hint, unit ) 	\
-	Knob * name = Knob::buildLegacyKnob(KnobType::Bright26, label, this); 			\
+	Knob * name = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, label, this); 			\
 	(name) -> move( x, y );									\
 	(name) ->setModel( &controls-> model );					\
 	(name) ->setHintText( hint, unit );

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -35,10 +35,9 @@ namespace lmms::gui
 
 
 #define makeknob( name, x, y, model, label, hint, unit ) 	\
-	Knob * name = new Knob( KnobType::Bright26, this); 			\
+	Knob * name = Knob::buildLegacyKnob(KnobType::Bright26, label, this); 			\
 	(name) -> move( x, y );									\
 	(name) ->setModel( &controls-> model );					\
-	(name) ->setLabelLegacy( label );							\
 	(name) ->setHintText( hint, unit );
 
 

--- a/plugins/DualFilter/DualFilterControlDialog.cpp
+++ b/plugins/DualFilter/DualFilterControlDialog.cpp
@@ -38,7 +38,7 @@ namespace lmms::gui
 	Knob * name = new Knob( KnobType::Bright26, this); 			\
 	(name) -> move( x, y );									\
 	(name) ->setModel( &controls-> model );					\
-	(name) ->setLabel( label );							\
+	(name) ->setLabelLegacy( label );							\
 	(name) ->setHintText( hint, unit );
 
 

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -58,32 +58,28 @@ DynProcControlDialog::DynProcControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	auto inputKnob = new Knob(KnobType::Bright26, this);
+	auto inputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("INPUT"), this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 223 );
 	inputKnob->setModel( &_controls->m_inputModel );
-	inputKnob->setLabelLegacy( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	auto outputKnob = new Knob(KnobType::Bright26, this);
+	auto outputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("OUTPUT"), this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 223 );
 	outputKnob->setModel( &_controls->m_outputModel );
-	outputKnob->setLabelLegacy( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ) , "" );
 
-	auto attackKnob = new Knob(KnobType::Bright26, this);
+	auto attackKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("ATTACK"), this);
 	attackKnob -> move( 24, 268 );
 	attackKnob->setModel( &_controls->m_attackModel );
-	attackKnob->setLabelLegacy( tr( "ATTACK" ) );
 	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
 
-	auto releaseKnob = new Knob(KnobType::Bright26, this);
+	auto releaseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("RELEASE"), this);
 	releaseKnob -> move( 74, 268 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
-	releaseKnob->setLabelLegacy( tr( "RELEASE" ) );
 	releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );
 
 //wavegraph control buttons

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -58,26 +58,26 @@ DynProcControlDialog::DynProcControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	auto inputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("INPUT"), this);
+	auto inputKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("INPUT"), this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 223 );
 	inputKnob->setModel( &_controls->m_inputModel );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	auto outputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("OUTPUT"), this);
+	auto outputKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("OUTPUT"), this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 223 );
 	outputKnob->setModel( &_controls->m_outputModel );
 	outputKnob->setHintText( tr( "Output gain:" ) , "" );
 
-	auto attackKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("ATTACK"), this);
+	auto attackKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("ATTACK"), this);
 	attackKnob -> move( 24, 268 );
 	attackKnob->setModel( &_controls->m_attackModel );
 	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
 
-	auto releaseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("RELEASE"), this);
+	auto releaseKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("RELEASE"), this);
 	releaseKnob -> move( 74, 268 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
 	releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );

--- a/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
+++ b/plugins/DynamicsProcessor/DynamicsProcessorControlDialog.cpp
@@ -63,7 +63,7 @@ DynProcControlDialog::DynProcControlDialog(
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 223 );
 	inputKnob->setModel( &_controls->m_inputModel );
-	inputKnob->setLabel( tr( "INPUT" ) );
+	inputKnob->setLabelLegacy( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
 	auto outputKnob = new Knob(KnobType::Bright26, this);
@@ -71,19 +71,19 @@ DynProcControlDialog::DynProcControlDialog(
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 223 );
 	outputKnob->setModel( &_controls->m_outputModel );
-	outputKnob->setLabel( tr( "OUTPUT" ) );
+	outputKnob->setLabelLegacy( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ) , "" );
 
 	auto attackKnob = new Knob(KnobType::Bright26, this);
 	attackKnob -> move( 24, 268 );
 	attackKnob->setModel( &_controls->m_attackModel );
-	attackKnob->setLabel( tr( "ATTACK" ) );
+	attackKnob->setLabelLegacy( tr( "ATTACK" ) );
 	attackKnob->setHintText( tr( "Peak attack time:" ) , "ms" );
 
 	auto releaseKnob = new Knob(KnobType::Bright26, this);
 	releaseKnob -> move( 74, 268 );
 	releaseKnob->setModel( &_controls->m_releaseModel );
-	releaseKnob->setLabel( tr( "RELEASE" ) );
+	releaseKnob->setLabelLegacy( tr( "RELEASE" ) );
 	releaseKnob->setHintText( tr( "Peak release time:" ) , "ms" );
 
 //wavegraph control buttons

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -46,42 +46,42 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	delayKnob->move( 10,10 );
 	delayKnob->setVolumeKnob( false );
 	delayKnob->setModel( &controls->m_delayTimeModel );
-	delayKnob->setLabel( tr( "DELAY" ) );
+	delayKnob->setLabelLegacy( tr( "DELAY" ) );
 	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
 
 	auto lfoFreqKnob = new TempoSyncKnob(KnobType::Bright26, this);
 	lfoFreqKnob->move( 48,10 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
-	lfoFreqKnob->setLabel( tr( "RATE" ) );
+	lfoFreqKnob->setLabelLegacy( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr( "Period:" ) , " Sec" );
 
 	auto lfoAmtKnob = new Knob(KnobType::Bright26, this);
 	lfoAmtKnob->move( 85,10 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-	lfoAmtKnob->setLabel( tr( "AMNT" ) );
+	lfoAmtKnob->setLabelLegacy( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr( "Amount:" ) , "" );
 
 	auto lfoPhaseKnob = new Knob(KnobType::Bright26, this);
 	lfoPhaseKnob->move( 123,10 );
 	lfoPhaseKnob->setVolumeKnob( false );
 	lfoPhaseKnob->setModel( &controls->m_lfoPhaseModel );
-	lfoPhaseKnob->setLabel( tr( "PHASE" ) );
+	lfoPhaseKnob->setLabelLegacy( tr( "PHASE" ) );
 	lfoPhaseKnob->setHintText( tr( "Phase:" ) , " degrees" );
 
 	auto feedbackKnob = new Knob(KnobType::Bright26, this);
 	feedbackKnob->move( 160,10 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel );
-	feedbackKnob->setLabel( tr( "FDBK" ) );
+	feedbackKnob->setLabelLegacy( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr( "Feedback amount:" ) , "" );
 
 	auto whiteNoiseKnob = new Knob(KnobType::Bright26, this);
 	whiteNoiseKnob->move( 196,10 );
 	whiteNoiseKnob->setVolumeKnob( true) ;
 	whiteNoiseKnob->setModel( &controls->m_whiteNoiseAmountModel );
-	whiteNoiseKnob->setLabel( tr( "NOISE" ) );
+	whiteNoiseKnob->setLabelLegacy( tr( "NOISE" ) );
 	whiteNoiseKnob->setHintText( tr( "White noise amount:" ) , "" );
 
 	auto invertCb = new LedCheckBox(tr("Invert"), this);

--- a/plugins/Flanger/FlangerControlsDialog.cpp
+++ b/plugins/Flanger/FlangerControlsDialog.cpp
@@ -29,6 +29,8 @@
 #include "LedCheckBox.h"
 #include "TempoSyncKnob.h"
 
+#include <QBoxLayout>
+
 namespace lmms::gui
 {
 
@@ -40,55 +42,57 @@ FlangerControlsDialog::FlangerControlsDialog( FlangerControls *controls ) :
 	QPalette pal;
 	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
-	setFixedSize( 233, 75 );
+
+	auto mainLayout = new QVBoxLayout(this);
+	auto knobLayout = new QHBoxLayout();
+	mainLayout->addLayout(knobLayout);
 
 	auto delayKnob = new Knob(KnobType::Bright26, this);
-	delayKnob->move( 10,10 );
 	delayKnob->setVolumeKnob( false );
 	delayKnob->setModel( &controls->m_delayTimeModel );
-	delayKnob->setLabelLegacy( tr( "DELAY" ) );
+	delayKnob->setLabel( tr( "DELAY" ) );
 	delayKnob->setHintText( tr( "Delay time:" ) + " ", "s" );
 
 	auto lfoFreqKnob = new TempoSyncKnob(KnobType::Bright26, this);
-	lfoFreqKnob->move( 48,10 );
 	lfoFreqKnob->setVolumeKnob( false );
 	lfoFreqKnob->setModel( &controls->m_lfoFrequencyModel );
-	lfoFreqKnob->setLabelLegacy( tr( "RATE" ) );
+	lfoFreqKnob->setLabel( tr( "RATE" ) );
 	lfoFreqKnob->setHintText( tr( "Period:" ) , " Sec" );
 
 	auto lfoAmtKnob = new Knob(KnobType::Bright26, this);
-	lfoAmtKnob->move( 85,10 );
 	lfoAmtKnob->setVolumeKnob( false );
 	lfoAmtKnob->setModel( &controls->m_lfoAmountModel );
-	lfoAmtKnob->setLabelLegacy( tr( "AMNT" ) );
+	lfoAmtKnob->setLabel( tr( "AMNT" ) );
 	lfoAmtKnob->setHintText( tr( "Amount:" ) , "" );
 
 	auto lfoPhaseKnob = new Knob(KnobType::Bright26, this);
-	lfoPhaseKnob->move( 123,10 );
 	lfoPhaseKnob->setVolumeKnob( false );
 	lfoPhaseKnob->setModel( &controls->m_lfoPhaseModel );
-	lfoPhaseKnob->setLabelLegacy( tr( "PHASE" ) );
+	lfoPhaseKnob->setLabel( tr( "PHASE" ) );
 	lfoPhaseKnob->setHintText( tr( "Phase:" ) , " degrees" );
 
 	auto feedbackKnob = new Knob(KnobType::Bright26, this);
-	feedbackKnob->move( 160,10 );
 	feedbackKnob->setVolumeKnob( true) ;
 	feedbackKnob->setModel( &controls->m_feedbackModel );
-	feedbackKnob->setLabelLegacy( tr( "FDBK" ) );
+	feedbackKnob->setLabel( tr( "FDBK" ) );
 	feedbackKnob->setHintText( tr( "Feedback amount:" ) , "" );
 
 	auto whiteNoiseKnob = new Knob(KnobType::Bright26, this);
-	whiteNoiseKnob->move( 196,10 );
 	whiteNoiseKnob->setVolumeKnob( true) ;
 	whiteNoiseKnob->setModel( &controls->m_whiteNoiseAmountModel );
-	whiteNoiseKnob->setLabelLegacy( tr( "NOISE" ) );
+	whiteNoiseKnob->setLabel( tr( "NOISE" ) );
 	whiteNoiseKnob->setHintText( tr( "White noise amount:" ) , "" );
 
+	knobLayout->addWidget(delayKnob);
+	knobLayout->addWidget(lfoFreqKnob);
+	knobLayout->addWidget(lfoAmtKnob);
+	knobLayout->addWidget(lfoPhaseKnob);
+	knobLayout->addWidget(feedbackKnob);
+	knobLayout->addWidget(whiteNoiseKnob);
+
 	auto invertCb = new LedCheckBox(tr("Invert"), this);
-	invertCb->move( 10,53 );
-
-
-
+	
+	mainLayout->addWidget(invertCb, 0, Qt::AlignLeft);
 }
 
 

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -831,22 +831,18 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	m_vcfCutKnob = new Knob( KnobType::Bright26, this );
 	m_vcfCutKnob->move( 75, 130 );
 	m_vcfCutKnob->setHintText( tr( "Cutoff Freq:" ), "" );
-	m_vcfCutKnob->setLabelLegacy( "" );
 
 	m_vcfResKnob = new Knob( KnobType::Bright26, this );
 	m_vcfResKnob->move( 120, 130 );
 	m_vcfResKnob->setHintText( tr( "Resonance:" ), "" );
-	m_vcfResKnob->setLabelLegacy( "" );
 
 	m_vcfModKnob = new Knob( KnobType::Bright26, this );
 	m_vcfModKnob->move( 165, 130 );
 	m_vcfModKnob->setHintText( tr( "Env Mod:" ), "" );
-	m_vcfModKnob->setLabelLegacy( "" );
 
 	m_vcfDecKnob = new Knob( KnobType::Bright26, this );
 	m_vcfDecKnob->move( 210, 130 );
 	m_vcfDecKnob->setHintText( tr( "Decay:" ), "" );
-	m_vcfDecKnob->setLabelLegacy( "" );
 
 	m_slideToggle = new LedCheckBox( "", this );
 	m_slideToggle->move( 10, 180 );
@@ -867,12 +863,10 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	m_slideDecKnob = new Knob( KnobType::Bright26, this );
 	m_slideDecKnob->move( 210, 75 );
 	m_slideDecKnob->setHintText( tr( "Slide Decay:" ), "" );
-	m_slideDecKnob->setLabelLegacy( "");
 
 	m_distKnob = new Knob( KnobType::Bright26, this );
 	m_distKnob->move( 210, 190 );
 	m_distKnob->setHintText( tr( "DIST:" ), "" );
-	m_distKnob->setLabelLegacy( tr( ""));
 
 
 	// Shapes

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -831,22 +831,22 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	m_vcfCutKnob = new Knob( KnobType::Bright26, this );
 	m_vcfCutKnob->move( 75, 130 );
 	m_vcfCutKnob->setHintText( tr( "Cutoff Freq:" ), "" );
-	m_vcfCutKnob->setLabel( "" );
+	m_vcfCutKnob->setLabelLegacy( "" );
 
 	m_vcfResKnob = new Knob( KnobType::Bright26, this );
 	m_vcfResKnob->move( 120, 130 );
 	m_vcfResKnob->setHintText( tr( "Resonance:" ), "" );
-	m_vcfResKnob->setLabel( "" );
+	m_vcfResKnob->setLabelLegacy( "" );
 
 	m_vcfModKnob = new Knob( KnobType::Bright26, this );
 	m_vcfModKnob->move( 165, 130 );
 	m_vcfModKnob->setHintText( tr( "Env Mod:" ), "" );
-	m_vcfModKnob->setLabel( "" );
+	m_vcfModKnob->setLabelLegacy( "" );
 
 	m_vcfDecKnob = new Knob( KnobType::Bright26, this );
 	m_vcfDecKnob->move( 210, 130 );
 	m_vcfDecKnob->setHintText( tr( "Decay:" ), "" );
-	m_vcfDecKnob->setLabel( "" );
+	m_vcfDecKnob->setLabelLegacy( "" );
 
 	m_slideToggle = new LedCheckBox( "", this );
 	m_slideToggle->move( 10, 180 );
@@ -867,12 +867,12 @@ Lb302SynthView::Lb302SynthView( Instrument * _instrument, QWidget * _parent ) :
 	m_slideDecKnob = new Knob( KnobType::Bright26, this );
 	m_slideDecKnob->move( 210, 75 );
 	m_slideDecKnob->setHintText( tr( "Slide Decay:" ), "" );
-	m_slideDecKnob->setLabel( "");
+	m_slideDecKnob->setLabelLegacy( "");
 
 	m_distKnob = new Knob( KnobType::Bright26, this );
 	m_distKnob->move( 210, 190 );
 	m_distKnob->setHintText( tr( "DIST:" ), "" );
-	m_distKnob->setLabel( tr( ""));
+	m_distKnob->setLabelLegacy( tr( ""));
 
 
 	// Shapes

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -78,22 +78,19 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	
 	// knobs
 
-	auto stepLength = new TempoSyncKnob(KnobType::Bright26, this);
+	auto stepLength = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("Length"), this);
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
-	stepLength->setLabelLegacy( tr( "Length" ) );
 	stepLength->setHintText( tr( "Step length:" ) , " ms" );
 
-	auto dryGain = new Knob(KnobType::Bright26, this);
+	auto dryGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("Dry"), this);
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
-	dryGain->setLabelLegacy( tr( "Dry" ) );
 	dryGain->setHintText( tr( "Dry gain:" ) , " dBFS" );
 
-	auto stages = new Knob(KnobType::Bright26, this);
+	auto stages = Knob::buildLegacyKnob(KnobType::Bright26, tr("Stages"), this);
 	stages->move( 200, 245 );
 	stages->setModel( & controls->m_stages );
-	stages->setLabelLegacy( tr( "Stages" ) );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );
 	// switch led
 

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -78,17 +78,17 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	
 	// knobs
 
-	auto stepLength = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("Length"), this);
+	auto stepLength = TempoSyncKnob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("Length"), this);
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
 	stepLength->setHintText( tr( "Step length:" ) , " ms" );
 
-	auto dryGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("Dry"), this);
+	auto dryGain = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("Dry"), this);
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
 	dryGain->setHintText( tr( "Dry gain:" ) , " dBFS" );
 
-	auto stages = Knob::buildLegacyKnob(KnobType::Bright26, tr("Stages"), this);
+	auto stages = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("Stages"), this);
 	stages->move( 200, 245 );
 	stages->setModel( & controls->m_stages );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );

--- a/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
+++ b/plugins/MultitapEcho/MultitapEchoControlDialog.cpp
@@ -81,19 +81,19 @@ MultitapEchoControlDialog::MultitapEchoControlDialog( MultitapEchoControls * con
 	auto stepLength = new TempoSyncKnob(KnobType::Bright26, this);
 	stepLength->move( 100, 245 );
 	stepLength->setModel( & controls->m_stepLength );
-	stepLength->setLabel( tr( "Length" ) );
+	stepLength->setLabelLegacy( tr( "Length" ) );
 	stepLength->setHintText( tr( "Step length:" ) , " ms" );
 
 	auto dryGain = new Knob(KnobType::Bright26, this);
 	dryGain->move( 150, 245 );
 	dryGain->setModel( & controls->m_dryGain );
-	dryGain->setLabel( tr( "Dry" ) );
+	dryGain->setLabelLegacy( tr( "Dry" ) );
 	dryGain->setHintText( tr( "Dry gain:" ) , " dBFS" );
 
 	auto stages = new Knob(KnobType::Bright26, this);
 	stages->move( 200, 245 );
 	stages->setModel( & controls->m_stages );
-	stages->setLabel( tr( "Stages" ) );
+	stages->setLabelLegacy( tr( "Stages" ) );
 	stages->setHintText( tr( "Low-pass stages:" ) , "x" );
 	// switch led
 

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
@@ -47,35 +47,34 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	QPalette pal;
 	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
-	setFixedSize( 240, 80 );
 
 	m_baseKnob = new Knob( KnobType::Bright26, this );
-	m_baseKnob->setLabelLegacy( tr( "BASE" ) );
+	m_baseKnob->setLabel(tr("BASE"));
 	m_baseKnob->setModel( &_controls->m_baseModel );
 	m_baseKnob->setHintText( tr( "Base:" ) , "" );
 
 	m_amountKnob = new Knob( KnobType::Bright26, this );
-	m_amountKnob->setLabelLegacy( tr( "AMNT" ) );
+	m_amountKnob->setLabel(tr("AMNT"));
 	m_amountKnob->setModel( &_controls->m_amountModel );
 	m_amountKnob->setHintText( tr( "Modulation amount:" ) , "" );
 
 	m_amountMultKnob = new Knob( KnobType::Bright26, this );
-	m_amountMultKnob->setLabelLegacy( tr( "MULT" ) );
+	m_amountMultKnob->setLabel(tr("MULT"));
 	m_amountMultKnob->setModel( &_controls->m_amountMultModel );
 	m_amountMultKnob->setHintText( tr( "Amount multiplicator:" ) , "" );
 
 	m_attackKnob = new Knob( KnobType::Bright26, this );
-	m_attackKnob->setLabelLegacy( tr( "ATCK" ) );
+	m_attackKnob->setLabel(tr("ATCK"));
 	m_attackKnob->setModel( &_controls->m_attackModel );
 	m_attackKnob->setHintText( tr( "Attack:" ) , "" );
 
 	m_decayKnob = new Knob( KnobType::Bright26, this );
-	m_decayKnob->setLabelLegacy( tr( "DCAY" ) );
+	m_decayKnob->setLabel(tr("DCAY"));
 	m_decayKnob->setModel( &_controls->m_decayModel );
 	m_decayKnob->setHintText( tr( "Release:" ) , "" );
 	
 	m_tresholdKnob = new Knob( KnobType::Bright26, this );
-	m_tresholdKnob->setLabelLegacy( tr( "TRSH" ) );
+	m_tresholdKnob->setLabel(tr("TRSH"));
 	m_tresholdKnob->setModel( &_controls->m_tresholdModel );
 	m_tresholdKnob->setHintText( tr( "Treshold:" ) , "" );
 

--- a/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffectControlDialog.cpp
@@ -50,32 +50,32 @@ PeakControllerEffectControlDialog::PeakControllerEffectControlDialog(
 	setFixedSize( 240, 80 );
 
 	m_baseKnob = new Knob( KnobType::Bright26, this );
-	m_baseKnob->setLabel( tr( "BASE" ) );
+	m_baseKnob->setLabelLegacy( tr( "BASE" ) );
 	m_baseKnob->setModel( &_controls->m_baseModel );
 	m_baseKnob->setHintText( tr( "Base:" ) , "" );
 
 	m_amountKnob = new Knob( KnobType::Bright26, this );
-	m_amountKnob->setLabel( tr( "AMNT" ) );
+	m_amountKnob->setLabelLegacy( tr( "AMNT" ) );
 	m_amountKnob->setModel( &_controls->m_amountModel );
 	m_amountKnob->setHintText( tr( "Modulation amount:" ) , "" );
 
 	m_amountMultKnob = new Knob( KnobType::Bright26, this );
-	m_amountMultKnob->setLabel( tr( "MULT" ) );
+	m_amountMultKnob->setLabelLegacy( tr( "MULT" ) );
 	m_amountMultKnob->setModel( &_controls->m_amountMultModel );
 	m_amountMultKnob->setHintText( tr( "Amount multiplicator:" ) , "" );
 
 	m_attackKnob = new Knob( KnobType::Bright26, this );
-	m_attackKnob->setLabel( tr( "ATCK" ) );
+	m_attackKnob->setLabelLegacy( tr( "ATCK" ) );
 	m_attackKnob->setModel( &_controls->m_attackModel );
 	m_attackKnob->setHintText( tr( "Attack:" ) , "" );
 
 	m_decayKnob = new Knob( KnobType::Bright26, this );
-	m_decayKnob->setLabel( tr( "DCAY" ) );
+	m_decayKnob->setLabelLegacy( tr( "DCAY" ) );
 	m_decayKnob->setModel( &_controls->m_decayModel );
 	m_decayKnob->setHintText( tr( "Release:" ) , "" );
 	
 	m_tresholdKnob = new Knob( KnobType::Bright26, this );
-	m_tresholdKnob->setLabel( tr( "TRSH" ) );
+	m_tresholdKnob->setLabelLegacy( tr( "TRSH" ) );
 	m_tresholdKnob->setModel( &_controls->m_tresholdModel );
 	m_tresholdKnob->setHintText( tr( "Treshold:" ) , "" );
 

--- a/plugins/ReverbSC/ReverbSCControlDialog.cpp
+++ b/plugins/ReverbSC/ReverbSCControlDialog.cpp
@@ -45,25 +45,25 @@ ReverbSCControlDialog::ReverbSCControlDialog( ReverbSCControls* controls ) :
 	auto inputGainKnob = new Knob(KnobType::Bright26, this);
 	inputGainKnob -> move( 16, 10 );
 	inputGainKnob->setModel( &controls->m_inputGainModel );
-	inputGainKnob->setLabel( tr( "Input" ) );
+	inputGainKnob->setLabelLegacy( tr( "Input" ) );
 	inputGainKnob->setHintText( tr( "Input gain:" ) , "dB" );
 
 	auto sizeKnob = new Knob(KnobType::Bright26, this);
 	sizeKnob -> move( 57, 10 );
 	sizeKnob->setModel( &controls->m_sizeModel );
-	sizeKnob->setLabel( tr( "Size" ) );
+	sizeKnob->setLabelLegacy( tr( "Size" ) );
 	sizeKnob->setHintText( tr( "Size:" ) , "" );
 
 	auto colorKnob = new Knob(KnobType::Bright26, this);
 	colorKnob -> move( 98, 10 );
 	colorKnob->setModel( &controls->m_colorModel );
-	colorKnob->setLabel( tr( "Color" ) );
+	colorKnob->setLabelLegacy( tr( "Color" ) );
 	colorKnob->setHintText( tr( "Color:" ) , "" );
 
 	auto outputGainKnob = new Knob(KnobType::Bright26, this);
 	outputGainKnob -> move( 139, 10 );
 	outputGainKnob->setModel( &controls->m_outputGainModel );
-	outputGainKnob->setLabel( tr( "Output" ) );
+	outputGainKnob->setLabelLegacy( tr( "Output" ) );
 	outputGainKnob->setHintText( tr( "Output gain:" ) , "dB" );
 }
 

--- a/plugins/ReverbSC/ReverbSCControlDialog.cpp
+++ b/plugins/ReverbSC/ReverbSCControlDialog.cpp
@@ -29,6 +29,8 @@
 #include "Knob.h"
 #include "ReverbSCControls.h"
 
+#include <QHBoxLayout>
+
 namespace lmms::gui
 {
 
@@ -40,31 +42,33 @@ ReverbSCControlDialog::ReverbSCControlDialog( ReverbSCControls* controls ) :
 	QPalette pal;
 	pal.setBrush( backgroundRole(), PLUGIN_NAME::getIconPixmap( "artwork" ) );
 	setPalette( pal );
-	setFixedSize( 185, 55 );
+
+	auto knobLayout = new QHBoxLayout(this);
 
 	auto inputGainKnob = new Knob(KnobType::Bright26, this);
-	inputGainKnob -> move( 16, 10 );
 	inputGainKnob->setModel( &controls->m_inputGainModel );
-	inputGainKnob->setLabelLegacy( tr( "Input" ) );
+	inputGainKnob->setLabel(tr("Input"));
 	inputGainKnob->setHintText( tr( "Input gain:" ) , "dB" );
 
 	auto sizeKnob = new Knob(KnobType::Bright26, this);
-	sizeKnob -> move( 57, 10 );
 	sizeKnob->setModel( &controls->m_sizeModel );
-	sizeKnob->setLabelLegacy( tr( "Size" ) );
+	sizeKnob->setLabel(tr("Size"));
 	sizeKnob->setHintText( tr( "Size:" ) , "" );
 
 	auto colorKnob = new Knob(KnobType::Bright26, this);
-	colorKnob -> move( 98, 10 );
 	colorKnob->setModel( &controls->m_colorModel );
-	colorKnob->setLabelLegacy( tr( "Color" ) );
+	colorKnob->setLabel(tr("Color"));
 	colorKnob->setHintText( tr( "Color:" ) , "" );
 
 	auto outputGainKnob = new Knob(KnobType::Bright26, this);
-	outputGainKnob -> move( 139, 10 );
 	outputGainKnob->setModel( &controls->m_outputGainModel );
-	outputGainKnob->setLabelLegacy( tr( "Output" ) );
+	outputGainKnob->setLabel(tr("Output"));
 	outputGainKnob->setHintText( tr( "Output gain:" ) , "dB" );
+
+	knobLayout->addWidget(inputGainKnob);
+	knobLayout->addWidget(sizeKnob);
+	knobLayout->addWidget(colorKnob);
+	knobLayout->addWidget(outputGainKnob);
 }
 
 

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -238,7 +238,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Peak envelope resolution
 	auto envelopeResolutionKnob = new Knob(KnobType::Small17, this);
 	envelopeResolutionKnob->setModel(&controls->m_envelopeResolutionModel);
-	envelopeResolutionKnob->setLabel(tr("Envelope res."));
+	envelopeResolutionKnob->setLabelLegacy(tr("Envelope res."));
 	envelopeResolutionKnob->setToolTip(tr("Increase envelope resolution for better details, decrease for better GUI performance."));
 	envelopeResolutionKnob->setHintText(tr("Maximum number of envelope points drawn per pixel:"), "");
 	advanced_layout->addWidget(envelopeResolutionKnob, 0, 0, 1, 1, Qt::AlignCenter);
@@ -246,7 +246,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Spectrum graph resolution
 	auto spectrumResolutionKnob = new Knob(KnobType::Small17, this);
 	spectrumResolutionKnob->setModel(&controls->m_spectrumResolutionModel);
-	spectrumResolutionKnob->setLabel(tr("Spectrum res."));
+	spectrumResolutionKnob->setLabelLegacy(tr("Spectrum res."));
 	spectrumResolutionKnob->setToolTip(tr("Increase spectrum resolution for better details, decrease for better GUI performance."));
 	spectrumResolutionKnob->setHintText(tr("Maximum number of spectrum points drawn per pixel:"), "");
 	advanced_layout->addWidget(spectrumResolutionKnob, 1, 0, 1, 1, Qt::AlignCenter);
@@ -254,7 +254,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Peak falloff speed
 	auto peakDecayFactorKnob = new Knob(KnobType::Small17, this);
 	peakDecayFactorKnob->setModel(&controls->m_peakDecayFactorModel);
-	peakDecayFactorKnob->setLabel(tr("Falloff factor"));
+	peakDecayFactorKnob->setLabelLegacy(tr("Falloff factor"));
 	peakDecayFactorKnob->setToolTip(tr("Decrease to make peaks fall faster."));
 	peakDecayFactorKnob->setHintText(tr("Multiply buffered value by"), "");
 	advanced_layout->addWidget(peakDecayFactorKnob, 0, 1, 1, 1, Qt::AlignCenter);
@@ -262,7 +262,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Averaging weight
 	auto averagingWeightKnob = new Knob(KnobType::Small17, this);
 	averagingWeightKnob->setModel(&controls->m_averagingWeightModel);
-	averagingWeightKnob->setLabel(tr("Averaging weight"));
+	averagingWeightKnob->setLabelLegacy(tr("Averaging weight"));
 	averagingWeightKnob->setToolTip(tr("Decrease to make averaging slower and smoother."));
 	averagingWeightKnob->setHintText(tr("New sample contributes"), "");
 	advanced_layout->addWidget(averagingWeightKnob, 1, 1, 1, 1, Qt::AlignCenter);
@@ -270,7 +270,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Waterfall history size
 	auto waterfallHeightKnob = new Knob(KnobType::Small17, this);
 	waterfallHeightKnob->setModel(&controls->m_waterfallHeightModel);
-	waterfallHeightKnob->setLabel(tr("Waterfall height"));
+	waterfallHeightKnob->setLabelLegacy(tr("Waterfall height"));
 	waterfallHeightKnob->setToolTip(tr("Increase to get slower scrolling, decrease to see fast transitions better. Warning: medium CPU usage."));
 	waterfallHeightKnob->setHintText(tr("Number of lines to keep:"), "");
 	advanced_layout->addWidget(waterfallHeightKnob, 0, 2, 1, 1, Qt::AlignCenter);
@@ -280,7 +280,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// Waterfall gamma correction
 	auto waterfallGammaKnob = new Knob(KnobType::Small17, this);
 	waterfallGammaKnob->setModel(&controls->m_waterfallGammaModel);
-	waterfallGammaKnob->setLabel(tr("Waterfall gamma"));
+	waterfallGammaKnob->setLabelLegacy(tr("Waterfall gamma"));
 	waterfallGammaKnob->setToolTip(tr("Decrease to see very weak signals, increase to get better contrast."));
 	waterfallGammaKnob->setHintText(tr("Gamma value:"), "");
 	advanced_layout->addWidget(waterfallGammaKnob, 1, 2, 1, 1, Qt::AlignCenter);
@@ -288,7 +288,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// FFT window overlap
 	auto windowOverlapKnob = new Knob(KnobType::Small17, this);
 	windowOverlapKnob->setModel(&controls->m_windowOverlapModel);
-	windowOverlapKnob->setLabel(tr("Window overlap"));
+	windowOverlapKnob->setLabelLegacy(tr("Window overlap"));
 	windowOverlapKnob->setToolTip(tr("Increase to prevent missing fast transitions arriving near FFT window edges. Warning: high CPU usage."));
 	windowOverlapKnob->setHintText(tr("Number of times each sample is processed:"), "");
 	advanced_layout->addWidget(windowOverlapKnob, 0, 3, 1, 1, Qt::AlignCenter);
@@ -296,7 +296,7 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	// FFT zero padding
 	auto zeroPaddingKnob = new Knob(KnobType::Small17, this);
 	zeroPaddingKnob->setModel(&controls->m_zeroPaddingModel);
-	zeroPaddingKnob->setLabel(tr("Zero padding"));
+	zeroPaddingKnob->setLabelLegacy(tr("Zero padding"));
 	zeroPaddingKnob->setToolTip(tr("Increase to get smoother-looking spectrum. Warning: high CPU usage."));
 	zeroPaddingKnob->setHintText(tr("Processing buffer is"), tr(" steps larger than input block"));
 	advanced_layout->addWidget(zeroPaddingKnob, 1, 3, 1, 1, Qt::AlignCenter);

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -236,35 +236,35 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	controls_layout->setStretchFactor(advanced_widget, 10);
 
 	// Peak envelope resolution
-	auto envelopeResolutionKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Envelope res."), this);
+	auto envelopeResolutionKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Envelope res."), this);
 	envelopeResolutionKnob->setModel(&controls->m_envelopeResolutionModel);
 	envelopeResolutionKnob->setToolTip(tr("Increase envelope resolution for better details, decrease for better GUI performance."));
 	envelopeResolutionKnob->setHintText(tr("Maximum number of envelope points drawn per pixel:"), "");
 	advanced_layout->addWidget(envelopeResolutionKnob, 0, 0, 1, 1, Qt::AlignCenter);
 
 	// Spectrum graph resolution
-	auto spectrumResolutionKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Spectrum res."), this);
+	auto spectrumResolutionKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Spectrum res."), this);
 	spectrumResolutionKnob->setModel(&controls->m_spectrumResolutionModel);
 	spectrumResolutionKnob->setToolTip(tr("Increase spectrum resolution for better details, decrease for better GUI performance."));
 	spectrumResolutionKnob->setHintText(tr("Maximum number of spectrum points drawn per pixel:"), "");
 	advanced_layout->addWidget(spectrumResolutionKnob, 1, 0, 1, 1, Qt::AlignCenter);
 
 	// Peak falloff speed
-	auto peakDecayFactorKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Falloff factor"), this);
+	auto peakDecayFactorKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Falloff factor"), this);
 	peakDecayFactorKnob->setModel(&controls->m_peakDecayFactorModel);
 	peakDecayFactorKnob->setToolTip(tr("Decrease to make peaks fall faster."));
 	peakDecayFactorKnob->setHintText(tr("Multiply buffered value by"), "");
 	advanced_layout->addWidget(peakDecayFactorKnob, 0, 1, 1, 1, Qt::AlignCenter);
 
 	// Averaging weight
-	auto averagingWeightKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Averaging weight"), this);
+	auto averagingWeightKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Averaging weight"), this);
 	averagingWeightKnob->setModel(&controls->m_averagingWeightModel);
 	averagingWeightKnob->setToolTip(tr("Decrease to make averaging slower and smoother."));
 	averagingWeightKnob->setHintText(tr("New sample contributes"), "");
 	advanced_layout->addWidget(averagingWeightKnob, 1, 1, 1, 1, Qt::AlignCenter);
 
 	// Waterfall history size
-	auto waterfallHeightKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Waterfall height"), this);
+	auto waterfallHeightKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Waterfall height"), this);
 	waterfallHeightKnob->setModel(&controls->m_waterfallHeightModel);
 	waterfallHeightKnob->setToolTip(tr("Increase to get slower scrolling, decrease to see fast transitions better. Warning: medium CPU usage."));
 	waterfallHeightKnob->setHintText(tr("Number of lines to keep:"), "");
@@ -273,21 +273,21 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_waterfallHeightModel, &FloatModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// Waterfall gamma correction
-	auto waterfallGammaKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Waterfall gamma"), this);
+	auto waterfallGammaKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Waterfall gamma"), this);
 	waterfallGammaKnob->setModel(&controls->m_waterfallGammaModel);
 	waterfallGammaKnob->setToolTip(tr("Decrease to see very weak signals, increase to get better contrast."));
 	waterfallGammaKnob->setHintText(tr("Gamma value:"), "");
 	advanced_layout->addWidget(waterfallGammaKnob, 1, 2, 1, 1, Qt::AlignCenter);
 
 	// FFT window overlap
-	auto windowOverlapKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Window overlap"), this);
+	auto windowOverlapKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Window overlap"), this);
 	windowOverlapKnob->setModel(&controls->m_windowOverlapModel);
 	windowOverlapKnob->setToolTip(tr("Increase to prevent missing fast transitions arriving near FFT window edges. Warning: high CPU usage."));
 	windowOverlapKnob->setHintText(tr("Number of times each sample is processed:"), "");
 	advanced_layout->addWidget(windowOverlapKnob, 0, 3, 1, 1, Qt::AlignCenter);
 
 	// FFT zero padding
-	auto zeroPaddingKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Zero padding"), this);
+	auto zeroPaddingKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Small17, tr("Zero padding"), this);
 	zeroPaddingKnob->setModel(&controls->m_zeroPaddingModel);
 	zeroPaddingKnob->setToolTip(tr("Increase to get smoother-looking spectrum. Warning: high CPU usage."));
 	zeroPaddingKnob->setHintText(tr("Processing buffer is"), tr(" steps larger than input block"));

--- a/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
+++ b/plugins/SpectrumAnalyzer/SaControlsDialog.cpp
@@ -236,41 +236,36 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	controls_layout->setStretchFactor(advanced_widget, 10);
 
 	// Peak envelope resolution
-	auto envelopeResolutionKnob = new Knob(KnobType::Small17, this);
+	auto envelopeResolutionKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Envelope res."), this);
 	envelopeResolutionKnob->setModel(&controls->m_envelopeResolutionModel);
-	envelopeResolutionKnob->setLabelLegacy(tr("Envelope res."));
 	envelopeResolutionKnob->setToolTip(tr("Increase envelope resolution for better details, decrease for better GUI performance."));
 	envelopeResolutionKnob->setHintText(tr("Maximum number of envelope points drawn per pixel:"), "");
 	advanced_layout->addWidget(envelopeResolutionKnob, 0, 0, 1, 1, Qt::AlignCenter);
 
 	// Spectrum graph resolution
-	auto spectrumResolutionKnob = new Knob(KnobType::Small17, this);
+	auto spectrumResolutionKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Spectrum res."), this);
 	spectrumResolutionKnob->setModel(&controls->m_spectrumResolutionModel);
-	spectrumResolutionKnob->setLabelLegacy(tr("Spectrum res."));
 	spectrumResolutionKnob->setToolTip(tr("Increase spectrum resolution for better details, decrease for better GUI performance."));
 	spectrumResolutionKnob->setHintText(tr("Maximum number of spectrum points drawn per pixel:"), "");
 	advanced_layout->addWidget(spectrumResolutionKnob, 1, 0, 1, 1, Qt::AlignCenter);
 
 	// Peak falloff speed
-	auto peakDecayFactorKnob = new Knob(KnobType::Small17, this);
+	auto peakDecayFactorKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Falloff factor"), this);
 	peakDecayFactorKnob->setModel(&controls->m_peakDecayFactorModel);
-	peakDecayFactorKnob->setLabelLegacy(tr("Falloff factor"));
 	peakDecayFactorKnob->setToolTip(tr("Decrease to make peaks fall faster."));
 	peakDecayFactorKnob->setHintText(tr("Multiply buffered value by"), "");
 	advanced_layout->addWidget(peakDecayFactorKnob, 0, 1, 1, 1, Qt::AlignCenter);
 
 	// Averaging weight
-	auto averagingWeightKnob = new Knob(KnobType::Small17, this);
+	auto averagingWeightKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Averaging weight"), this);
 	averagingWeightKnob->setModel(&controls->m_averagingWeightModel);
-	averagingWeightKnob->setLabelLegacy(tr("Averaging weight"));
 	averagingWeightKnob->setToolTip(tr("Decrease to make averaging slower and smoother."));
 	averagingWeightKnob->setHintText(tr("New sample contributes"), "");
 	advanced_layout->addWidget(averagingWeightKnob, 1, 1, 1, 1, Qt::AlignCenter);
 
 	// Waterfall history size
-	auto waterfallHeightKnob = new Knob(KnobType::Small17, this);
+	auto waterfallHeightKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Waterfall height"), this);
 	waterfallHeightKnob->setModel(&controls->m_waterfallHeightModel);
-	waterfallHeightKnob->setLabelLegacy(tr("Waterfall height"));
 	waterfallHeightKnob->setToolTip(tr("Increase to get slower scrolling, decrease to see fast transitions better. Warning: medium CPU usage."));
 	waterfallHeightKnob->setHintText(tr("Number of lines to keep:"), "");
 	advanced_layout->addWidget(waterfallHeightKnob, 0, 2, 1, 1, Qt::AlignCenter);
@@ -278,25 +273,22 @@ SaControlsDialog::SaControlsDialog(SaControls *controls, SaProcessor *processor)
 	connect(&controls->m_waterfallHeightModel, &FloatModel::dataChanged, [=] {processor->reallocateBuffers();});
 
 	// Waterfall gamma correction
-	auto waterfallGammaKnob = new Knob(KnobType::Small17, this);
+	auto waterfallGammaKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Waterfall gamma"), this);
 	waterfallGammaKnob->setModel(&controls->m_waterfallGammaModel);
-	waterfallGammaKnob->setLabelLegacy(tr("Waterfall gamma"));
 	waterfallGammaKnob->setToolTip(tr("Decrease to see very weak signals, increase to get better contrast."));
 	waterfallGammaKnob->setHintText(tr("Gamma value:"), "");
 	advanced_layout->addWidget(waterfallGammaKnob, 1, 2, 1, 1, Qt::AlignCenter);
 
 	// FFT window overlap
-	auto windowOverlapKnob = new Knob(KnobType::Small17, this);
+	auto windowOverlapKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Window overlap"), this);
 	windowOverlapKnob->setModel(&controls->m_windowOverlapModel);
-	windowOverlapKnob->setLabelLegacy(tr("Window overlap"));
 	windowOverlapKnob->setToolTip(tr("Increase to prevent missing fast transitions arriving near FFT window edges. Warning: high CPU usage."));
 	windowOverlapKnob->setHintText(tr("Number of times each sample is processed:"), "");
 	advanced_layout->addWidget(windowOverlapKnob, 0, 3, 1, 1, Qt::AlignCenter);
 
 	// FFT zero padding
-	auto zeroPaddingKnob = new Knob(KnobType::Small17, this);
+	auto zeroPaddingKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("Zero padding"), this);
 	zeroPaddingKnob->setModel(&controls->m_zeroPaddingModel);
-	zeroPaddingKnob->setLabelLegacy(tr("Zero padding"));
 	zeroPaddingKnob->setToolTip(tr("Increase to get smoother-looking spectrum. Warning: high CPU usage."));
 	zeroPaddingKnob->setHintText(tr("Processing buffer is"), tr(" steps larger than input block"));
 	advanced_layout->addWidget(zeroPaddingKnob, 1, 3, 1, 1, Qt::AlignCenter);

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
@@ -42,7 +42,7 @@ StereoEnhancerControlDialog::StereoEnhancerControlDialog(
 
 	auto widthKnob = new Knob(KnobType::Bright26, this);
 	widthKnob->setModel( &_controls->m_widthModel );
-	widthKnob->setLabelLegacy( tr( "WIDTH" ) );
+	widthKnob->setLabel(tr("WIDTH"));
 	widthKnob->setHintText( tr( "Width:" ) , " samples" );
 
 	l->addWidget( widthKnob );

--- a/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
+++ b/plugins/StereoEnhancer/StereoEnhancerControlDialog.cpp
@@ -42,7 +42,7 @@ StereoEnhancerControlDialog::StereoEnhancerControlDialog(
 
 	auto widthKnob = new Knob(KnobType::Bright26, this);
 	widthKnob->setModel( &_controls->m_widthModel );
-	widthKnob->setLabel( tr( "WIDTH" ) );
+	widthKnob->setLabelLegacy( tr( "WIDTH" ) );
 	widthKnob->setHintText( tr( "Width:" ) , " samples" );
 
 	l->addWidget( widthKnob );

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -454,12 +454,12 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 		 this, SLOT( changePreset() ) );
 	
 	m_spreadKnob = new Knob( KnobType::Vintage32, this );
-	m_spreadKnob->setLabel( tr( "Spread" ) );
+	m_spreadKnob->setLabelLegacy( tr( "Spread" ) );
 	m_spreadKnob->move( 190, 140 );
 	m_spreadKnob->setHintText( tr( "Spread:" ), "" );
 
 	m_randomKnob = new Knob(KnobType::Vintage32, this);
-	m_randomKnob->setLabel(tr("Random"));
+	m_randomKnob->setLabelLegacy(tr("Random"));
 	m_randomKnob->move(190, 190);
 	m_randomKnob->setHintText(tr("Random:"), "");
 
@@ -495,27 +495,27 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 	widget->setFixedSize( 250, 250 );
 		
 	m_hardnessKnob = new Knob( KnobType::Vintage32, widget );
-	m_hardnessKnob->setLabel( tr( "Hardness" ) );
+	m_hardnessKnob->setLabelLegacy( tr( "Hardness" ) );
 	m_hardnessKnob->move( 30, 90 );
 	m_hardnessKnob->setHintText( tr( "Hardness:" ), "" );
 
 	m_positionKnob = new Knob( KnobType::Vintage32, widget );
-	m_positionKnob->setLabel( tr( "Position" ) );
+	m_positionKnob->setLabelLegacy( tr( "Position" ) );
 	m_positionKnob->move( 110, 90 );
 	m_positionKnob->setHintText( tr( "Position:" ), "" );
 
 	m_vibratoGainKnob = new Knob( KnobType::Vintage32, widget );
-	m_vibratoGainKnob->setLabel( tr( "Vibrato gain" ) );
+	m_vibratoGainKnob->setLabelLegacy( tr( "Vibrato gain" ) );
 	m_vibratoGainKnob->move( 30, 140 );
 	m_vibratoGainKnob->setHintText( tr( "Vibrato gain:" ), "" );
 
 	m_vibratoFreqKnob = new Knob( KnobType::Vintage32, widget );
-	m_vibratoFreqKnob->setLabel( tr( "Vibrato frequency" ) );
+	m_vibratoFreqKnob->setLabelLegacy( tr( "Vibrato frequency" ) );
 	m_vibratoFreqKnob->move( 110, 140 );
 	m_vibratoFreqKnob->setHintText( tr( "Vibrato frequency:" ), "" );
 
 	m_stickKnob = new Knob( KnobType::Vintage32, widget );
-	m_stickKnob->setLabel( tr( "Stick mix" ) );
+	m_stickKnob->setLabelLegacy( tr( "Stick mix" ) );
 	m_stickKnob->move( 190, 90 );
 	m_stickKnob->setHintText( tr( "Stick mix:" ), "" );
 
@@ -531,27 +531,27 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 	widget->setFixedSize( 250, 250 );
 	
 	m_modulatorKnob = new Knob( KnobType::Vintage32, widget );
-	m_modulatorKnob->setLabel( tr( "Modulator" ) );
+	m_modulatorKnob->setLabelLegacy( tr( "Modulator" ) );
 	m_modulatorKnob->move( 30, 90 );
 	m_modulatorKnob->setHintText( tr( "Modulator:" ), "" );
 
 	m_crossfadeKnob = new Knob( KnobType::Vintage32, widget );
-	m_crossfadeKnob->setLabel( tr( "Crossfade" ) );
+	m_crossfadeKnob->setLabelLegacy( tr( "Crossfade" ) );
 	m_crossfadeKnob->move( 110, 90 );
 	m_crossfadeKnob->setHintText( tr( "Crossfade:" ), "" );
 	
 	m_lfoSpeedKnob = new Knob( KnobType::Vintage32, widget );
-	m_lfoSpeedKnob->setLabel( tr( "LFO speed" ) );
+	m_lfoSpeedKnob->setLabelLegacy( tr( "LFO speed" ) );
 	m_lfoSpeedKnob->move( 30, 140 );
 	m_lfoSpeedKnob->setHintText( tr( "LFO speed:" ), "" );
 	
 	m_lfoDepthKnob = new Knob( KnobType::Vintage32, widget );
-	m_lfoDepthKnob->setLabel( tr( "LFO depth" ) );
+	m_lfoDepthKnob->setLabelLegacy( tr( "LFO depth" ) );
 	m_lfoDepthKnob->move( 110, 140 );
 	m_lfoDepthKnob->setHintText( tr( "LFO depth:" ), "" );
 	
 	m_adsrKnob = new Knob( KnobType::Vintage32, widget );
-	m_adsrKnob->setLabel( tr( "ADSR" ) );
+	m_adsrKnob->setLabelLegacy( tr( "ADSR" ) );
 	m_adsrKnob->move( 190, 90 );
 	m_adsrKnob->setHintText( tr( "ADSR:" ), "" );
 
@@ -571,22 +571,22 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 	m_strikeLED->move( 138, 25 );*/
 
 	m_pressureKnob = new Knob( KnobType::Vintage32, widget );
-	m_pressureKnob->setLabel( tr( "Pressure" ) );
+	m_pressureKnob->setLabelLegacy( tr( "Pressure" ) );
 	m_pressureKnob->move( 30, 90 );
 	m_pressureKnob->setHintText( tr( "Pressure:" ), "" );
 
 /*	m_motionKnob = new Knob( KnobType::Vintage32, widget );
-	m_motionKnob->setLabel( tr( "Motion" ) );
+	m_motionKnob->setLabelLegacy( tr( "Motion" ) );
 	m_motionKnob->move( 110, 90 );
 	m_motionKnob->setHintText( tr( "Motion:" ), "" );*/
 
 	m_velocityKnob = new Knob( KnobType::Vintage32, widget );
-	m_velocityKnob->setLabel( tr( "Speed" ) );
+	m_velocityKnob->setLabelLegacy( tr( "Speed" ) );
 	m_velocityKnob->move( 30, 140 );
 	m_velocityKnob->setHintText( tr( "Speed:" ), "" );
 	
 /*	m_vibratoKnob = new Knob( KnobType::Vintage32, widget, tr( "Vibrato" ) );
-	m_vibratoKnob->setLabel( tr( "Vibrato" ) );
+	m_vibratoKnob->setLabelLegacy( tr( "Vibrato" ) );
 	m_vibratoKnob->move( 110, 140 );
 	m_vibratoKnob->setHintText( tr( "Vibrato:" ), "" );*/
 	

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -453,13 +453,11 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );
 	
-	m_spreadKnob = new Knob( KnobType::Vintage32, this );
-	m_spreadKnob->setLabelLegacy( tr( "Spread" ) );
+	m_spreadKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Spread"), this);
 	m_spreadKnob->move( 190, 140 );
 	m_spreadKnob->setHintText( tr( "Spread:" ), "" );
 
-	m_randomKnob = new Knob(KnobType::Vintage32, this);
-	m_randomKnob->setLabelLegacy(tr("Random"));
+	m_randomKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Random"), this);
 	m_randomKnob->move(190, 190);
 	m_randomKnob->setHintText(tr("Random:"), "");
 
@@ -494,28 +492,23 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 		
-	m_hardnessKnob = new Knob( KnobType::Vintage32, widget );
-	m_hardnessKnob->setLabelLegacy( tr( "Hardness" ) );
+	m_hardnessKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Hardness"), widget);
 	m_hardnessKnob->move( 30, 90 );
 	m_hardnessKnob->setHintText( tr( "Hardness:" ), "" );
 
-	m_positionKnob = new Knob( KnobType::Vintage32, widget );
-	m_positionKnob->setLabelLegacy( tr( "Position" ) );
+	m_positionKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Position"), widget);
 	m_positionKnob->move( 110, 90 );
 	m_positionKnob->setHintText( tr( "Position:" ), "" );
 
-	m_vibratoGainKnob = new Knob( KnobType::Vintage32, widget );
-	m_vibratoGainKnob->setLabelLegacy( tr( "Vibrato gain" ) );
+	m_vibratoGainKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato gain"), widget);
 	m_vibratoGainKnob->move( 30, 140 );
 	m_vibratoGainKnob->setHintText( tr( "Vibrato gain:" ), "" );
 
-	m_vibratoFreqKnob = new Knob( KnobType::Vintage32, widget );
-	m_vibratoFreqKnob->setLabelLegacy( tr( "Vibrato frequency" ) );
+	m_vibratoFreqKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato frequency"), widget);
 	m_vibratoFreqKnob->move( 110, 140 );
 	m_vibratoFreqKnob->setHintText( tr( "Vibrato frequency:" ), "" );
 
-	m_stickKnob = new Knob( KnobType::Vintage32, widget );
-	m_stickKnob->setLabelLegacy( tr( "Stick mix" ) );
+	m_stickKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Stick mix"), widget);
 	m_stickKnob->move( 190, 90 );
 	m_stickKnob->setHintText( tr( "Stick mix:" ), "" );
 
@@ -530,28 +523,23 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
-	m_modulatorKnob = new Knob( KnobType::Vintage32, widget );
-	m_modulatorKnob->setLabelLegacy( tr( "Modulator" ) );
+	m_modulatorKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Modulator"), widget);
 	m_modulatorKnob->move( 30, 90 );
 	m_modulatorKnob->setHintText( tr( "Modulator:" ), "" );
 
-	m_crossfadeKnob = new Knob( KnobType::Vintage32, widget );
-	m_crossfadeKnob->setLabelLegacy( tr( "Crossfade" ) );
+	m_crossfadeKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Crossfade"), widget);
 	m_crossfadeKnob->move( 110, 90 );
 	m_crossfadeKnob->setHintText( tr( "Crossfade:" ), "" );
 	
-	m_lfoSpeedKnob = new Knob( KnobType::Vintage32, widget );
-	m_lfoSpeedKnob->setLabelLegacy( tr( "LFO speed" ) );
+	m_lfoSpeedKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("LFO speed"), widget);
 	m_lfoSpeedKnob->move( 30, 140 );
 	m_lfoSpeedKnob->setHintText( tr( "LFO speed:" ), "" );
 	
-	m_lfoDepthKnob = new Knob( KnobType::Vintage32, widget );
-	m_lfoDepthKnob->setLabelLegacy( tr( "LFO depth" ) );
+	m_lfoDepthKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("LFO depth"), widget);
 	m_lfoDepthKnob->move( 110, 140 );
 	m_lfoDepthKnob->setHintText( tr( "LFO depth:" ), "" );
 	
-	m_adsrKnob = new Knob( KnobType::Vintage32, widget );
-	m_adsrKnob->setLabelLegacy( tr( "ADSR" ) );
+	m_adsrKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("ADSR"), widget);
 	m_adsrKnob->move( 190, 90 );
 	m_adsrKnob->setHintText( tr( "ADSR:" ), "" );
 
@@ -570,23 +558,19 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 /*	m_strikeLED = new LedCheckBox( tr( "Bowed" ), widget );
 	m_strikeLED->move( 138, 25 );*/
 
-	m_pressureKnob = new Knob( KnobType::Vintage32, widget );
-	m_pressureKnob->setLabelLegacy( tr( "Pressure" ) );
+	m_pressureKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Pressure"), widget);
 	m_pressureKnob->move( 30, 90 );
 	m_pressureKnob->setHintText( tr( "Pressure:" ), "" );
 
-/*	m_motionKnob = new Knob( KnobType::Vintage32, widget );
-	m_motionKnob->setLabelLegacy( tr( "Motion" ) );
+/*	m_motionKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Motion"), widget);
 	m_motionKnob->move( 110, 90 );
 	m_motionKnob->setHintText( tr( "Motion:" ), "" );*/
 
-	m_velocityKnob = new Knob( KnobType::Vintage32, widget );
-	m_velocityKnob->setLabelLegacy( tr( "Speed" ) );
+	m_velocityKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Speed"), widget);
 	m_velocityKnob->move( 30, 140 );
 	m_velocityKnob->setHintText( tr( "Speed:" ), "" );
 	
-/*	m_vibratoKnob = new Knob( KnobType::Vintage32, widget, tr( "Vibrato" ) );
-	m_vibratoKnob->setLabelLegacy( tr( "Vibrato" ) );
+/*	m_vibratoKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato"), widget);
 	m_vibratoKnob->move( 110, 140 );
 	m_vibratoKnob->setHintText( tr( "Vibrato:" ), "" );*/
 	

--- a/plugins/Stk/Mallets/Mallets.cpp
+++ b/plugins/Stk/Mallets/Mallets.cpp
@@ -453,11 +453,11 @@ MalletsInstrumentView::MalletsInstrumentView( MalletsInstrument * _instrument,
 	connect( &_instrument->m_presetsModel, SIGNAL( dataChanged() ),
 		 this, SLOT( changePreset() ) );
 	
-	m_spreadKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Spread"), this);
+	m_spreadKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Spread"), this);
 	m_spreadKnob->move( 190, 140 );
 	m_spreadKnob->setHintText( tr( "Spread:" ), "" );
 
-	m_randomKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Random"), this);
+	m_randomKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Random"), this);
 	m_randomKnob->move(190, 190);
 	m_randomKnob->setHintText(tr("Random:"), "");
 
@@ -492,23 +492,23 @@ QWidget * MalletsInstrumentView::setupModalBarControls( QWidget * _parent )
 	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 		
-	m_hardnessKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Hardness"), widget);
+	m_hardnessKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Hardness"), widget);
 	m_hardnessKnob->move( 30, 90 );
 	m_hardnessKnob->setHintText( tr( "Hardness:" ), "" );
 
-	m_positionKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Position"), widget);
+	m_positionKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Position"), widget);
 	m_positionKnob->move( 110, 90 );
 	m_positionKnob->setHintText( tr( "Position:" ), "" );
 
-	m_vibratoGainKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato gain"), widget);
+	m_vibratoGainKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Vibrato gain"), widget);
 	m_vibratoGainKnob->move( 30, 140 );
 	m_vibratoGainKnob->setHintText( tr( "Vibrato gain:" ), "" );
 
-	m_vibratoFreqKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato frequency"), widget);
+	m_vibratoFreqKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Vibrato frequency"), widget);
 	m_vibratoFreqKnob->move( 110, 140 );
 	m_vibratoFreqKnob->setHintText( tr( "Vibrato frequency:" ), "" );
 
-	m_stickKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Stick mix"), widget);
+	m_stickKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Stick mix"), widget);
 	m_stickKnob->move( 190, 90 );
 	m_stickKnob->setHintText( tr( "Stick mix:" ), "" );
 
@@ -523,23 +523,23 @@ QWidget * MalletsInstrumentView::setupTubeBellControls( QWidget * _parent )
 	auto widget = new QWidget(_parent);
 	widget->setFixedSize( 250, 250 );
 	
-	m_modulatorKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Modulator"), widget);
+	m_modulatorKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Modulator"), widget);
 	m_modulatorKnob->move( 30, 90 );
 	m_modulatorKnob->setHintText( tr( "Modulator:" ), "" );
 
-	m_crossfadeKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Crossfade"), widget);
+	m_crossfadeKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Crossfade"), widget);
 	m_crossfadeKnob->move( 110, 90 );
 	m_crossfadeKnob->setHintText( tr( "Crossfade:" ), "" );
 	
-	m_lfoSpeedKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("LFO speed"), widget);
+	m_lfoSpeedKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("LFO speed"), widget);
 	m_lfoSpeedKnob->move( 30, 140 );
 	m_lfoSpeedKnob->setHintText( tr( "LFO speed:" ), "" );
 	
-	m_lfoDepthKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("LFO depth"), widget);
+	m_lfoDepthKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("LFO depth"), widget);
 	m_lfoDepthKnob->move( 110, 140 );
 	m_lfoDepthKnob->setHintText( tr( "LFO depth:" ), "" );
 	
-	m_adsrKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("ADSR"), widget);
+	m_adsrKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("ADSR"), widget);
 	m_adsrKnob->move( 190, 90 );
 	m_adsrKnob->setHintText( tr( "ADSR:" ), "" );
 
@@ -558,19 +558,19 @@ QWidget * MalletsInstrumentView::setupBandedWGControls( QWidget * _parent )
 /*	m_strikeLED = new LedCheckBox( tr( "Bowed" ), widget );
 	m_strikeLED->move( 138, 25 );*/
 
-	m_pressureKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Pressure"), widget);
+	m_pressureKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Pressure"), widget);
 	m_pressureKnob->move( 30, 90 );
 	m_pressureKnob->setHintText( tr( "Pressure:" ), "" );
 
-/*	m_motionKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Motion"), widget);
+/*	m_motionKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Motion"), widget);
 	m_motionKnob->move( 110, 90 );
 	m_motionKnob->setHintText( tr( "Motion:" ), "" );*/
 
-	m_velocityKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Speed"), widget);
+	m_velocityKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Speed"), widget);
 	m_velocityKnob->move( 30, 140 );
 	m_velocityKnob->setHintText( tr( "Speed:" ), "" );
 	
-/*	m_vibratoKnob = Knob::buildLegacyKnob(KnobType::Vintage32, tr("Vibrato"), widget);
+/*	m_vibratoKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Vintage32, tr("Vibrato"), widget);
 	m_vibratoKnob->move( 110, 140 );
 	m_vibratoKnob->setHintText( tr( "Vibrato:" ), "" );*/
 	

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -78,8 +78,10 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 
 	// Persistence knob
 	auto persistenceKnob = new Knob(KnobType::Small17, this);
+	// Make the font the same size as the other controls
+	persistenceKnob->setFont(highQualityButton->font());
 	persistenceKnob->setModel(&controls->m_persistenceModel);
-	persistenceKnob->setLabelLegacy(tr("Persist."));
+	persistenceKnob->setLabel(tr("Persist."));
 	persistenceKnob->setToolTip(tr("Trace persistence: higher amount means the trace will stay bright for longer time."));
 	persistenceKnob->setHintText(tr("Trace persistence"), "");
 	config_layout->addWidget(persistenceKnob);

--- a/plugins/Vectorscope/VecControlsDialog.cpp
+++ b/plugins/Vectorscope/VecControlsDialog.cpp
@@ -79,7 +79,7 @@ VecControlsDialog::VecControlsDialog(VecControls *controls) :
 	// Persistence knob
 	auto persistenceKnob = new Knob(KnobType::Small17, this);
 	persistenceKnob->setModel(&controls->m_persistenceModel);
-	persistenceKnob->setLabel(tr("Persist."));
+	persistenceKnob->setLabelLegacy(tr("Persist."));
 	persistenceKnob->setToolTip(tr("Trace persistence: higher amount means the trace will stay bright for longer time."));
 	persistenceKnob->setHintText(tr("Trace persistence"), "");
 	config_layout->addWidget(persistenceKnob);

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -992,7 +992,7 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 
 		const auto & description = s_dumpValues.at(1);
 
-		auto knob = CustomTextKnob::buildLegacyKnob(KnobType::Bright26, this, description, description.left(15));
+		auto knob = CustomTextKnob::buildKnobWithSmallPixelFont(KnobType::Bright26, this, description, description.left(15));
 		knob->setDescription(description + ":" );
 		vstKnobs[i] = knob;
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -990,9 +990,11 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 		sprintf(paramStr.data(), "param%d", i);
 		s_dumpValues = dump[paramStr.data()].split(":");
 
-		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, this, s_dumpValues.at( 1 ) );
-		vstKnobs[ i ]->setDescription( s_dumpValues.at( 1 ) + ":" );
-		vstKnobs[ i ]->setLabelLegacy( s_dumpValues.at( 1 ).left( 15 ) );
+		const auto & description = s_dumpValues.at(1);
+
+		auto knob = CustomTextKnob::buildLegacyKnob(KnobType::Bright26, this, description, description.left(15));
+		knob->setDescription(description + ":" );
+		vstKnobs[i] = knob;
 
 		if( !hasKnobModel )
 		{

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -992,7 +992,7 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 
 		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, this, s_dumpValues.at( 1 ) );
 		vstKnobs[ i ]->setDescription( s_dumpValues.at( 1 ) + ":" );
-		vstKnobs[ i ]->setLabel( s_dumpValues.at( 1 ).left( 15 ) );
+		vstKnobs[ i ]->setLabelLegacy( s_dumpValues.at( 1 ).left( 15 ) );
 
 		if( !hasKnobModel )
 		{

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -389,9 +389,11 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 		sprintf(paramStr.data(), "param%d", i);
 		s_dumpValues = dump[paramStr.data()].split(":");
 
-		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, widget, s_dumpValues.at( 1 ) );
-		vstKnobs[ i ]->setDescription( s_dumpValues.at( 1 ) + ":" );
-		vstKnobs[ i ]->setLabelLegacy( s_dumpValues.at( 1 ).left( 15 ) );
+		const auto & description = s_dumpValues.at(1);
+
+		auto knob = CustomTextKnob::buildLegacyKnob(KnobType::Bright26, widget, description, description.left(15));
+		knob->setDescription(description + ":" );
+		vstKnobs[i] = knob;
 
 		if( !hasKnobModel )
 		{

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -391,7 +391,7 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 
 		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, widget, s_dumpValues.at( 1 ) );
 		vstKnobs[ i ]->setDescription( s_dumpValues.at( 1 ) + ":" );
-		vstKnobs[ i ]->setLabel( s_dumpValues.at( 1 ).left( 15 ) );
+		vstKnobs[ i ]->setLabelLegacy( s_dumpValues.at( 1 ).left( 15 ) );
 
 		if( !hasKnobModel )
 		{

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -391,7 +391,7 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 
 		const auto & description = s_dumpValues.at(1);
 
-		auto knob = CustomTextKnob::buildLegacyKnob(KnobType::Bright26, widget, description, description.left(15));
+		auto knob = CustomTextKnob::buildKnobWithSmallPixelFont(KnobType::Bright26, widget, description, description.left(15));
 		knob->setDescription(description + ":" );
 		vstKnobs[i] = knob;
 

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -59,20 +59,18 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	auto inputKnob = new Knob(KnobType::Bright26, this);
+	auto inputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("INPUT"), this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 225 );
 	inputKnob->setModel( &_controls->m_inputModel );
-	inputKnob->setLabelLegacy( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	auto outputKnob = new Knob(KnobType::Bright26, this);
+	auto outputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("OUTPUT"), this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 225 );
 	outputKnob->setModel( &_controls->m_outputModel );
-	outputKnob->setLabelLegacy( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
 	auto resetButton = new PixmapButton(this, tr("Reset wavegraph"));

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -59,14 +59,14 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	waveGraph->setGraphColor( QColor( 85, 204, 145 ) );
 	waveGraph -> setMaximumSize( 204, 205 );
 
-	auto inputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("INPUT"), this);
+	auto inputKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("INPUT"), this);
 	inputKnob -> setVolumeKnob( true );
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 225 );
 	inputKnob->setModel( &_controls->m_inputModel );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
-	auto outputKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("OUTPUT"), this);
+	auto outputKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("OUTPUT"), this);
 	outputKnob -> setVolumeKnob( true );
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 225 );

--- a/plugins/WaveShaper/WaveShaperControlDialog.cpp
+++ b/plugins/WaveShaper/WaveShaperControlDialog.cpp
@@ -64,7 +64,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	inputKnob -> setVolumeRatio( 1.0 );
 	inputKnob -> move( 26, 225 );
 	inputKnob->setModel( &_controls->m_inputModel );
-	inputKnob->setLabel( tr( "INPUT" ) );
+	inputKnob->setLabelLegacy( tr( "INPUT" ) );
 	inputKnob->setHintText( tr( "Input gain:" ) , "" );
 
 	auto outputKnob = new Knob(KnobType::Bright26, this);
@@ -72,7 +72,7 @@ WaveShaperControlDialog::WaveShaperControlDialog(
 	outputKnob -> setVolumeRatio( 1.0 );
 	outputKnob -> move( 76, 225 );
 	outputKnob->setModel( &_controls->m_outputModel );
-	outputKnob->setLabel( tr( "OUTPUT" ) );
+	outputKnob->setLabelLegacy( tr( "OUTPUT" ) );
 	outputKnob->setHintText( tr( "Output gain:" ), "" );
 
 	auto resetButton = new PixmapButton(this, tr("Reset wavegraph"));

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -512,33 +512,26 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	l->setVerticalSpacing( 16 );
 	l->setHorizontalSpacing( 10 );
 
-	m_portamento = new Knob( KnobType::Bright26, this );
+	m_portamento = Knob::buildLegacyKnob(KnobType::Bright26, tr("PORT"), this);
 	m_portamento->setHintText( tr( "Portamento:" ), "" );
-	m_portamento->setLabelLegacy( tr( "PORT" ) );
 
-	m_filterFreq = new Knob( KnobType::Bright26, this );
+	m_filterFreq = Knob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
 	m_filterFreq->setHintText( tr( "Filter frequency:" ), "" );
-	m_filterFreq->setLabelLegacy( tr( "FREQ" ) );
 
-	m_filterQ = new Knob( KnobType::Bright26, this );
+	m_filterQ = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES"), this);
 	m_filterQ->setHintText( tr( "Filter resonance:" ), "" );
-	m_filterQ->setLabelLegacy( tr( "RES" ) );
 
-	m_bandwidth = new Knob( KnobType::Bright26, this );
+	m_bandwidth = Knob::buildLegacyKnob(KnobType::Bright26, tr("BW"), this);
 	m_bandwidth->setHintText( tr( "Bandwidth:" ), "" );
-	m_bandwidth->setLabelLegacy( tr( "BW" ) );
 
-	m_fmGain = new Knob( KnobType::Bright26, this );
+	m_fmGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("FM GAIN"), this);
 	m_fmGain->setHintText( tr( "FM gain:" ), "" );
-	m_fmGain->setLabelLegacy( tr( "FM GAIN" ) );
 
-	m_resCenterFreq = new Knob( KnobType::Bright26, this );
+	m_resCenterFreq = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES CF"), this);
 	m_resCenterFreq->setHintText( tr( "Resonance center frequency:" ), "" );
-	m_resCenterFreq->setLabelLegacy( tr( "RES CF" ) );
 
-	m_resBandwidth = new Knob( KnobType::Bright26, this );
+	m_resBandwidth = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES BW"), this);
 	m_resBandwidth->setHintText( tr( "Resonance bandwidth:" ), "" );
-	m_resBandwidth->setLabelLegacy( tr( "RES BW" ) );
 
 	m_forwardMidiCC = new LedCheckBox( tr( "Forward MIDI control changes" ), this );
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -514,31 +514,31 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 
 	m_portamento = new Knob( KnobType::Bright26, this );
 	m_portamento->setHintText( tr( "Portamento:" ), "" );
-	m_portamento->setLabel( tr( "PORT" ) );
+	m_portamento->setLabelLegacy( tr( "PORT" ) );
 
 	m_filterFreq = new Knob( KnobType::Bright26, this );
 	m_filterFreq->setHintText( tr( "Filter frequency:" ), "" );
-	m_filterFreq->setLabel( tr( "FREQ" ) );
+	m_filterFreq->setLabelLegacy( tr( "FREQ" ) );
 
 	m_filterQ = new Knob( KnobType::Bright26, this );
 	m_filterQ->setHintText( tr( "Filter resonance:" ), "" );
-	m_filterQ->setLabel( tr( "RES" ) );
+	m_filterQ->setLabelLegacy( tr( "RES" ) );
 
 	m_bandwidth = new Knob( KnobType::Bright26, this );
 	m_bandwidth->setHintText( tr( "Bandwidth:" ), "" );
-	m_bandwidth->setLabel( tr( "BW" ) );
+	m_bandwidth->setLabelLegacy( tr( "BW" ) );
 
 	m_fmGain = new Knob( KnobType::Bright26, this );
 	m_fmGain->setHintText( tr( "FM gain:" ), "" );
-	m_fmGain->setLabel( tr( "FM GAIN" ) );
+	m_fmGain->setLabelLegacy( tr( "FM GAIN" ) );
 
 	m_resCenterFreq = new Knob( KnobType::Bright26, this );
 	m_resCenterFreq->setHintText( tr( "Resonance center frequency:" ), "" );
-	m_resCenterFreq->setLabel( tr( "RES CF" ) );
+	m_resCenterFreq->setLabelLegacy( tr( "RES CF" ) );
 
 	m_resBandwidth = new Knob( KnobType::Bright26, this );
 	m_resBandwidth->setHintText( tr( "Resonance bandwidth:" ), "" );
-	m_resBandwidth->setLabel( tr( "RES BW" ) );
+	m_resBandwidth->setLabelLegacy( tr( "RES BW" ) );
 
 	m_forwardMidiCC = new LedCheckBox( tr( "Forward MIDI control changes" ), this );
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -512,25 +512,25 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	l->setVerticalSpacing( 16 );
 	l->setHorizontalSpacing( 10 );
 
-	m_portamento = Knob::buildLegacyKnob(KnobType::Bright26, tr("PORT"), this);
+	m_portamento = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("PORT"), this);
 	m_portamento->setHintText( tr( "Portamento:" ), "" );
 
-	m_filterFreq = Knob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
+	m_filterFreq = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("FREQ"), this);
 	m_filterFreq->setHintText( tr( "Filter frequency:" ), "" );
 
-	m_filterQ = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES"), this);
+	m_filterQ = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("RES"), this);
 	m_filterQ->setHintText( tr( "Filter resonance:" ), "" );
 
-	m_bandwidth = Knob::buildLegacyKnob(KnobType::Bright26, tr("BW"), this);
+	m_bandwidth = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("BW"), this);
 	m_bandwidth->setHintText( tr( "Bandwidth:" ), "" );
 
-	m_fmGain = Knob::buildLegacyKnob(KnobType::Bright26, tr("FM GAIN"), this);
+	m_fmGain = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("FM GAIN"), this);
 	m_fmGain->setHintText( tr( "FM gain:" ), "" );
 
-	m_resCenterFreq = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES CF"), this);
+	m_resCenterFreq = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("RES CF"), this);
 	m_resCenterFreq->setHintText( tr( "Resonance center frequency:" ), "" );
 
-	m_resBandwidth = Knob::buildLegacyKnob(KnobType::Bright26, tr("RES BW"), this);
+	m_resBandwidth = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("RES BW"), this);
 	m_resBandwidth->setHintText( tr( "Resonance bandwidth:" ), "" );
 
 	m_forwardMidiCC = new LedCheckBox( tr( "Forward MIDI control changes" ), this );

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -38,7 +38,7 @@ namespace lmms::gui
 {
 
 
-void KnobControl::setText(const QString &text) { m_knob->setLabel(text); }
+void KnobControl::setText(const QString &text) { m_knob->setLabelLegacy(text); }
 
 QWidget *KnobControl::topWidget() { return m_knob; }
 

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -40,14 +40,7 @@ namespace lmms::gui
 
 void KnobControl::setText(const QString &text)
 {
-	if (m_knob->legacyMode())
-	{
-		m_knob->setLabelLegacy(text);
-	}
-	else
-	{
-		m_knob->setLabel(text);
-	}
+	m_knob->setLabel(text);
 }
 
 QWidget *KnobControl::topWidget() { return m_knob; }

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -38,7 +38,17 @@ namespace lmms::gui
 {
 
 
-void KnobControl::setText(const QString &text) { m_knob->setLabelLegacy(text); }
+void KnobControl::setText(const QString &text)
+{
+	if (m_knob->legacyMode())
+	{
+		m_knob->setLabelLegacy(text);
+	}
+	else
+	{
+		m_knob->setLabel(text);
+	}
+}
 
 QWidget *KnobControl::topWidget() { return m_knob; }
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -64,22 +64,19 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_bypass->setToolTip(tr("On/Off"));
 
 
-	m_wetDry = new Knob( KnobType::Bright26, this );
-	m_wetDry->setLabelLegacy( tr( "W/D" ) );
+	m_wetDry = Knob::buildLegacyKnob(KnobType::Bright26, tr("W/D"), this);
 	m_wetDry->move( 40 - m_wetDry->width() / 2, 5 );
 	m_wetDry->setEnabled( isEnabled );
 	m_wetDry->setHintText( tr( "Wet Level:" ), "" );
 
 
-	m_autoQuit = new TempoSyncKnob( KnobType::Bright26, this );
-	m_autoQuit->setLabelLegacy( tr( "DECAY" ) );
+	m_autoQuit = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("DECAY"), this);
 	m_autoQuit->move( 78 - m_autoQuit->width() / 2, 5 );
 	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 
 
-	m_gate = new Knob( KnobType::Bright26, this );
-	m_gate->setLabelLegacy( tr( "GATE" ) );
+	m_gate = Knob::buildLegacyKnob(KnobType::Bright26, tr("GATE"), this);
 	m_gate->move( 116 - m_gate->width() / 2, 5 );
 	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_gate->setHintText( tr( "Gate:" ), "" );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -65,21 +65,21 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 
 
 	m_wetDry = new Knob( KnobType::Bright26, this );
-	m_wetDry->setLabel( tr( "W/D" ) );
+	m_wetDry->setLabelLegacy( tr( "W/D" ) );
 	m_wetDry->move( 40 - m_wetDry->width() / 2, 5 );
 	m_wetDry->setEnabled( isEnabled );
 	m_wetDry->setHintText( tr( "Wet Level:" ), "" );
 
 
 	m_autoQuit = new TempoSyncKnob( KnobType::Bright26, this );
-	m_autoQuit->setLabel( tr( "DECAY" ) );
+	m_autoQuit->setLabelLegacy( tr( "DECAY" ) );
 	m_autoQuit->move( 78 - m_autoQuit->width() / 2, 5 );
 	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 
 
 	m_gate = new Knob( KnobType::Bright26, this );
-	m_gate->setLabel( tr( "GATE" ) );
+	m_gate->setLabelLegacy( tr( "GATE" ) );
 	m_gate->move( 116 - m_gate->width() / 2, 5 );
 	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_gate->setHintText( tr( "Gate:" ), "" );

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -64,19 +64,19 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_bypass->setToolTip(tr("On/Off"));
 
 
-	m_wetDry = Knob::buildLegacyKnob(KnobType::Bright26, tr("W/D"), this);
+	m_wetDry = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("W/D"), this);
 	m_wetDry->move( 40 - m_wetDry->width() / 2, 5 );
 	m_wetDry->setEnabled( isEnabled );
 	m_wetDry->setHintText( tr( "Wet Level:" ), "" );
 
 
-	m_autoQuit = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("DECAY"), this);
+	m_autoQuit = TempoSyncKnob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("DECAY"), this);
 	m_autoQuit->move( 78 - m_autoQuit->width() / 2, 5 );
 	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 
 
-	m_gate = Knob::buildLegacyKnob(KnobType::Bright26, tr("GATE"), this);
+	m_gate = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("GATE"), this);
 	m_gate->move( 116 - m_gate->width() / 2, 5 );
 	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_gate->setHintText( tr( "Gate:" ), "" );

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -102,7 +102,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 		{
 			knb->setModel( m_ctl->tempoSyncKnobModel() );
 		}
-		knb->setLabelLegacy( m_ctl->port()->name );
+		knb->setLabel(m_ctl->port()->name);
 		knb->setHintText( tr( "Value:" ), "" );
 		layout->addWidget( knb );
 		if( link != nullptr )

--- a/src/gui/LadspaControlView.cpp
+++ b/src/gui/LadspaControlView.cpp
@@ -102,7 +102,7 @@ LadspaControlView::LadspaControlView( QWidget * _parent,
 		{
 			knb->setModel( m_ctl->tempoSyncKnobModel() );
 		}
-		knb->setLabel( m_ctl->port()->name );
+		knb->setLabelLegacy( m_ctl->port()->name );
 		knb->setHintText( tr( "Value:" ), "" );
 		layout->addWidget( knb );
 		if( link != nullptr )

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -62,19 +62,19 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	setWindowIcon( embed::getIconPixmap( "controller" ) );
 	setFixedSize( 240, 58 );
 	
-	m_baseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("BASE"), this);
+	m_baseKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("BASE"), this);
 	m_baseKnob->move( CD_LFO_BASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_baseKnob->setHintText( tr( "Base:" ), "" );
 
-	m_speedKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
+	m_speedKnob = TempoSyncKnob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("FREQ"), this);
 	m_speedKnob->move( CD_LFO_SPEED_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_speedKnob->setHintText( tr( "LFO frequency:" ), "" );
 
-	m_amountKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("AMNT"), this);
+	m_amountKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("AMNT"), this);
 	m_amountKnob->move( CD_LFO_AMOUNT_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
 
-	m_phaseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("PHS"), this);
+	m_phaseKnob = Knob::buildKnobWithSmallPixelFont(KnobType::Bright26, tr("PHS"), this);
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -63,22 +63,22 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	setFixedSize( 240, 58 );
 	
 	m_baseKnob = new Knob( KnobType::Bright26, this );
-	m_baseKnob->setLabel( tr( "BASE" ) );
+	m_baseKnob->setLabelLegacy( tr( "BASE" ) );
 	m_baseKnob->move( CD_LFO_BASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_baseKnob->setHintText( tr( "Base:" ), "" );
 
 	m_speedKnob = new TempoSyncKnob( KnobType::Bright26, this );
-	m_speedKnob->setLabel( tr( "FREQ" ) );
+	m_speedKnob->setLabelLegacy( tr( "FREQ" ) );
 	m_speedKnob->move( CD_LFO_SPEED_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_speedKnob->setHintText( tr( "LFO frequency:" ), "" );
 
 	m_amountKnob = new Knob( KnobType::Bright26, this );
-	m_amountKnob->setLabel( tr( "AMNT" ) );
+	m_amountKnob->setLabelLegacy( tr( "AMNT" ) );
 	m_amountKnob->move( CD_LFO_AMOUNT_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
 
 	m_phaseKnob = new Knob( KnobType::Bright26, this );
-	m_phaseKnob->setLabel( tr( "PHS" ) );
+	m_phaseKnob->setLabelLegacy( tr( "PHS" ) );
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -62,23 +62,19 @@ LfoControllerDialog::LfoControllerDialog( Controller * _model, QWidget * _parent
 	setWindowIcon( embed::getIconPixmap( "controller" ) );
 	setFixedSize( 240, 58 );
 	
-	m_baseKnob = new Knob( KnobType::Bright26, this );
-	m_baseKnob->setLabelLegacy( tr( "BASE" ) );
+	m_baseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("BASE"), this);
 	m_baseKnob->move( CD_LFO_BASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_baseKnob->setHintText( tr( "Base:" ), "" );
 
-	m_speedKnob = new TempoSyncKnob( KnobType::Bright26, this );
-	m_speedKnob->setLabelLegacy( tr( "FREQ" ) );
+	m_speedKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), this);
 	m_speedKnob->move( CD_LFO_SPEED_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_speedKnob->setHintText( tr( "LFO frequency:" ), "" );
 
-	m_amountKnob = new Knob( KnobType::Bright26, this );
-	m_amountKnob->setLabelLegacy( tr( "AMNT" ) );
+	m_amountKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("AMNT"), this);
 	m_amountKnob->move( CD_LFO_AMOUNT_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_amountKnob->setHintText( tr( "Modulation amount:" ), "" );
 
-	m_phaseKnob = new Knob( KnobType::Bright26, this );
-	m_phaseKnob->setLabelLegacy( tr( "PHS" ) );
+	m_phaseKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("PHS"), this);
 	m_phaseKnob->move( CD_LFO_PHASE_CD_KNOB_X, CD_LFO_CD_KNOB_Y );
 	m_phaseKnob->setHintText( tr( "Phase offset:" ) , "" + tr( " degrees" ) );
 

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -79,6 +79,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	auto knobsScrollArea = new QScrollArea();
 	auto knobsArea = new QWidget();
 	auto knobsAreaLayout = new QGridLayout();
+	knobsAreaLayout->setVerticalSpacing(10);
 
 	knobsArea->setLayout(knobsAreaLayout);
 	knobsScrollArea->setWidget(knobsArea);
@@ -86,23 +87,21 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 
 	knobsGroupBoxLayout->addWidget(knobsScrollArea);
 
-	// Adds the controller knobs
+	// Adds the controller knobs and sets their models
 	for (int i = 0; i < MidiControllerCount; ++i)
 	{
-		m_controllerKnob[i] = new Knob(KnobType::Bright26);
-		m_controllerKnob[i]->setLabelLegacy(tr("CC %1").arg(i));
-		knobsAreaLayout->addWidget(m_controllerKnob[i], i/4, i%4);
+		auto knob = new Knob(KnobType::Bright26, this);
+		knob->setLabel(tr("CC %1").arg(i));
+		knob->setModel(m_track->m_midiCCModel[i].get());
+		knobsAreaLayout->addWidget(knob, i/4, i%4, Qt::AlignHCenter);
+
+		// TODO It seems that this is not really used/needed?
+		m_controllerKnob[i] = knob;
 	}
 
 	// Set all the models
 	// Set the LED button to enable/disable the track midi cc
 	m_midiCCGroupBox->setModel(m_track->m_midiCCEnable.get());
-
-	// Set the model for each Knob
-	for (int i = 0; i < MidiControllerCount; ++i)
-	{
-		m_controllerKnob[i]->setModel(m_track->m_midiCCModel[i].get());
-	}
 
 	// Connection to update the name of the track on the label
 	connect(m_track, SIGNAL(nameChanged()),

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -90,7 +90,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	for (int i = 0; i < MidiControllerCount; ++i)
 	{
 		m_controllerKnob[i] = new Knob(KnobType::Bright26);
-		m_controllerKnob[i]->setLabel(tr("CC %1").arg(i));
+		m_controllerKnob[i]->setLabelLegacy(tr("CC %1").arg(i));
 		knobsAreaLayout->addWidget(m_controllerKnob[i], i/4, i%4);
 	}
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -56,8 +56,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	// Helper lambdas for consistent repeated buiding of certain widgets
 	auto buildKnob = [&](const QString& label, const QString& hintText)
 	{
-		auto knob = new Knob(KnobType::Bright26, this);
-		knob->setLabelLegacy(label);
+		auto knob = Knob::buildLegacyKnob(KnobType::Bright26, label, this);
 		knob->setHintText(hintText, "");
 		
 		return knob;
@@ -167,8 +166,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	m_lfoAttackKnob = buildKnob(tr("ATT"), tr("Attack:"));
 	lfoKnobsLayout->addWidget(m_lfoAttackKnob);
 
-	m_lfoSpeedKnob = new TempoSyncKnob(KnobType::Bright26, this);
-	m_lfoSpeedKnob->setLabelLegacy(tr("SPD"));
+	m_lfoSpeedKnob = TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("SPD"), this);
 	m_lfoSpeedKnob->setHintText(tr("Frequency:"), "");
 	lfoKnobsLayout->addWidget(m_lfoSpeedKnob);
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -57,7 +57,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	auto buildKnob = [&](const QString& label, const QString& hintText)
 	{
 		auto knob = new Knob(KnobType::Bright26, this);
-		knob->setLabel(label);
+		knob->setLabelLegacy(label);
 		knob->setHintText(hintText, "");
 		
 		return knob;
@@ -168,7 +168,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	lfoKnobsLayout->addWidget(m_lfoAttackKnob);
 
 	m_lfoSpeedKnob = new TempoSyncKnob(KnobType::Bright26, this);
-	m_lfoSpeedKnob->setLabel(tr("SPD"));
+	m_lfoSpeedKnob->setLabelLegacy(tr("SPD"));
 	m_lfoSpeedKnob->setHintText(tr("Frequency:"), "");
 	lfoKnobsLayout->addWidget(m_lfoSpeedKnob);
 

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -44,7 +44,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	m_cc( cc ),
 	m_chordsGroupBox( new GroupBox( tr( "STACKING" ) ) ),
 	m_chordsComboBox( new ComboBox() ),
-	m_chordRangeKnob( new Knob( KnobType::Bright26 ) )
+	m_chordRangeKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("RANGE"), this))
 {
 	auto topLayout = new QHBoxLayout(this);
 	topLayout->setContentsMargins(0, 0, 0, 0);
@@ -59,7 +59,6 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	auto chordLabel = new QLabel(tr("Chord:"));
 	chordLabel->setFont(adjustedToPixelSize(chordLabel->font(), DEFAULT_FONT_SIZE));
 
-	m_chordRangeKnob->setLabelLegacy( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
 
 	mainLayout->addWidget( chordLabel, 0, 0 );
@@ -98,13 +97,13 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	m_a( arp ),
 	m_arpGroupBox( new GroupBox( tr( "ARPEGGIO" ) ) ),
 	m_arpComboBox( new ComboBox() ),
-	m_arpRangeKnob( new Knob( KnobType::Bright26 ) ),
-	m_arpRepeatsKnob( new Knob( KnobType::Bright26 ) ),
-	m_arpCycleKnob( new Knob( KnobType::Bright26 ) ),
-	m_arpSkipKnob( new Knob( KnobType::Bright26 ) ),
-	m_arpMissKnob( new Knob( KnobType::Bright26 ) ),
-	m_arpTimeKnob( new TempoSyncKnob( KnobType::Bright26 ) ),
-	m_arpGateKnob( new Knob( KnobType::Bright26 ) ),
+	m_arpRangeKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("RANGE"), this)),
+	m_arpRepeatsKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("REP"), this)),
+	m_arpCycleKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("CYCLE"), this)),
+	m_arpSkipKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("SKIP"), this)),
+	m_arpMissKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("MISS"), this)),
+	m_arpTimeKnob(TempoSyncKnob::buildLegacyKnob(KnobType::Bright26, tr("TIME"), this)),
+	m_arpGateKnob(Knob::buildLegacyKnob(KnobType::Bright26, tr("GATE"), this)),
 	m_arpDirectionComboBox( new ComboBox() ),
 	m_arpModeComboBox( new ComboBox() )
 {
@@ -118,31 +117,12 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	mainLayout->setHorizontalSpacing( 20 );
 	mainLayout->setVerticalSpacing( 1 );
 
-	m_arpRangeKnob->setLabelLegacy( tr( "RANGE" ) );
 	m_arpRangeKnob->setHintText( tr( "Arpeggio range:" ), " " + tr( "octave(s)" ) );
-
-
-	m_arpRepeatsKnob->setLabelLegacy( tr( "REP" ) );
 	m_arpRepeatsKnob->setHintText( tr( "Note repeats:" ) + " ", " " + tr( "time(s)" ) );
-
-
-	m_arpCycleKnob->setLabelLegacy( tr( "CYCLE" ) );
 	m_arpCycleKnob->setHintText( tr( "Cycle notes:" ) + " ", " " + tr( "note(s)" ) );
-
-
-	m_arpSkipKnob->setLabelLegacy( tr( "SKIP" ) );
 	m_arpSkipKnob->setHintText( tr( "Skip rate:" ), tr( "%" ) );
-
-
-	m_arpMissKnob->setLabelLegacy( tr( "MISS" ) );
 	m_arpMissKnob->setHintText( tr( "Miss rate:" ), tr( "%" ) );
-
-
-	m_arpTimeKnob->setLabelLegacy( tr( "TIME" ) );
 	m_arpTimeKnob->setHintText( tr( "Arpeggio time:" ), " " + tr( "ms" ) );
-
-
-	m_arpGateKnob->setLabelLegacy( tr( "GATE" ) );
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));

--- a/src/gui/instrument/InstrumentFunctionViews.cpp
+++ b/src/gui/instrument/InstrumentFunctionViews.cpp
@@ -59,7 +59,7 @@ InstrumentFunctionNoteStackingView::InstrumentFunctionNoteStackingView( Instrume
 	auto chordLabel = new QLabel(tr("Chord:"));
 	chordLabel->setFont(adjustedToPixelSize(chordLabel->font(), DEFAULT_FONT_SIZE));
 
-	m_chordRangeKnob->setLabel( tr( "RANGE" ) );
+	m_chordRangeKnob->setLabelLegacy( tr( "RANGE" ) );
 	m_chordRangeKnob->setHintText( tr( "Chord range:" ), " " + tr( "octave(s)" ) );
 
 	mainLayout->addWidget( chordLabel, 0, 0 );
@@ -118,31 +118,31 @@ InstrumentFunctionArpeggioView::InstrumentFunctionArpeggioView( InstrumentFuncti
 	mainLayout->setHorizontalSpacing( 20 );
 	mainLayout->setVerticalSpacing( 1 );
 
-	m_arpRangeKnob->setLabel( tr( "RANGE" ) );
+	m_arpRangeKnob->setLabelLegacy( tr( "RANGE" ) );
 	m_arpRangeKnob->setHintText( tr( "Arpeggio range:" ), " " + tr( "octave(s)" ) );
 
 
-	m_arpRepeatsKnob->setLabel( tr( "REP" ) );
+	m_arpRepeatsKnob->setLabelLegacy( tr( "REP" ) );
 	m_arpRepeatsKnob->setHintText( tr( "Note repeats:" ) + " ", " " + tr( "time(s)" ) );
 
 
-	m_arpCycleKnob->setLabel( tr( "CYCLE" ) );
+	m_arpCycleKnob->setLabelLegacy( tr( "CYCLE" ) );
 	m_arpCycleKnob->setHintText( tr( "Cycle notes:" ) + " ", " " + tr( "note(s)" ) );
 
 
-	m_arpSkipKnob->setLabel( tr( "SKIP" ) );
+	m_arpSkipKnob->setLabelLegacy( tr( "SKIP" ) );
 	m_arpSkipKnob->setHintText( tr( "Skip rate:" ), tr( "%" ) );
 
 
-	m_arpMissKnob->setLabel( tr( "MISS" ) );
+	m_arpMissKnob->setLabelLegacy( tr( "MISS" ) );
 	m_arpMissKnob->setHintText( tr( "Miss rate:" ), tr( "%" ) );
 
 
-	m_arpTimeKnob->setLabel( tr( "TIME" ) );
+	m_arpTimeKnob->setLabelLegacy( tr( "TIME" ) );
 	m_arpTimeKnob->setHintText( tr( "Arpeggio time:" ), " " + tr( "ms" ) );
 
 
-	m_arpGateKnob->setLabel( tr( "GATE" ) );
+	m_arpGateKnob->setLabelLegacy( tr( "GATE" ) );
 	m_arpGateKnob->setHintText( tr( "Arpeggio gate:" ), tr( "%" ) );
 
 	auto arpChordLabel = new QLabel(tr("Chord:"));

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -67,13 +67,11 @@ InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 	m_filterComboBox = new ComboBox(m_filterGroupBox);
 	filterLayout->addWidget(m_filterComboBox);
 
-	m_filterCutKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
-	m_filterCutKnob->setLabelLegacy(tr("FREQ"));
+	m_filterCutKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("FREQ"), m_filterGroupBox);
 	m_filterCutKnob->setHintText(tr("Cutoff frequency:"), " " + tr("Hz"));
 	filterLayout->addWidget(m_filterCutKnob);
 
-	m_filterResKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
-	m_filterResKnob->setLabelLegacy(tr("Q/RESO"));
+	m_filterResKnob = Knob::buildLegacyKnob(KnobType::Bright26, tr("Q/RESO"), m_filterGroupBox);
 	m_filterResKnob->setHintText(tr("Q/Resonance:"), "");
 	filterLayout->addWidget(m_filterResKnob);
 

--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -68,12 +68,12 @@ InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 	filterLayout->addWidget(m_filterComboBox);
 
 	m_filterCutKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
-	m_filterCutKnob->setLabel(tr("FREQ"));
+	m_filterCutKnob->setLabelLegacy(tr("FREQ"));
 	m_filterCutKnob->setHintText(tr("Cutoff frequency:"), " " + tr("Hz"));
 	filterLayout->addWidget(m_filterCutKnob);
 
 	m_filterResKnob = new Knob(KnobType::Bright26, m_filterGroupBox);
-	m_filterResKnob->setLabel(tr("Q/RESO"));
+	m_filterResKnob->setLabelLegacy(tr("Q/RESO"));
 	m_filterResKnob->setHintText(tr("Q/Resonance:"), "");
 	filterLayout->addWidget(m_filterResKnob);
 

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -77,13 +77,19 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
 
-	m_volumeKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), tr("Volume"));
+	auto f = font();
+	f.setPixelSize(9);
+	m_volumeKnob = new Knob(KnobType::Small17, getTrackSettingsWidget(), tr("Volume"));
+	m_volumeKnob->setFont(f);
+	m_volumeKnob->setLabel(tr("VOL"));
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_it->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
 	m_volumeKnob->show();
 
-	m_panningKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("PAN"), getTrackSettingsWidget(), tr("Panning"));
+	m_panningKnob = new Knob(KnobType::Small17, getTrackSettingsWidget(), tr("Panning"));
+	m_panningKnob->setFont(f);
+	m_panningKnob->setLabel(tr("PAN"));
 	m_panningKnob->setModel( &_it->m_panningModel );
 	m_panningKnob->setHintText(tr("Panning:"), "%");
 	m_panningKnob->show();

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -77,19 +77,15 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
 
-	m_volumeKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
-							tr( "Volume" ) );
+	m_volumeKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), tr("Volume"));
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_it->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
-	m_volumeKnob->setLabelLegacy( tr( "VOL" ) );
 	m_volumeKnob->show();
 
-	m_panningKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
-							tr( "Panning" ) );
+	m_panningKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("PAN"), getTrackSettingsWidget(), tr("Panning"));
 	m_panningKnob->setModel( &_it->m_panningModel );
 	m_panningKnob->setHintText(tr("Panning:"), "%");
-	m_panningKnob->setLabelLegacy( tr( "PAN" ) );
 	m_panningKnob->show();
 
 	m_midiMenu = new QMenu( tr( "MIDI" ), this );

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -82,14 +82,14 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_it->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Volume:" ), "%" );
-	m_volumeKnob->setLabel( tr( "VOL" ) );
+	m_volumeKnob->setLabelLegacy( tr( "VOL" ) );
 	m_volumeKnob->show();
 
 	m_panningKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
 							tr( "Panning" ) );
 	m_panningKnob->setModel( &_it->m_panningModel );
 	m_panningKnob->setHintText(tr("Panning:"), "%");
-	m_panningKnob->setLabel( tr( "PAN" ) );
+	m_panningKnob->setLabelLegacy( tr( "PAN" ) );
 	m_panningKnob->show();
 
 	m_midiMenu = new QMenu( tr( "MIDI" ), this );

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -61,14 +61,20 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
 
-	m_volumeKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), tr("Track volume"));
+	auto f = font();
+	f.setPixelSize(9);
+	m_volumeKnob = new Knob(KnobType::Small17, getTrackSettingsWidget(), tr("Track volume"));
+	m_volumeKnob->setFont(f);
+	m_volumeKnob->setLabel(tr("VOL"));
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_t->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
 
 	m_volumeKnob->show();
 
-	m_panningKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("PAN"), getTrackSettingsWidget(), tr("Panning"));
+	m_panningKnob = new Knob(KnobType::Small17, getTrackSettingsWidget(), tr("Panning"));
+	m_panningKnob->setFont(f);
+	m_panningKnob->setLabel(tr("PAN"));
 	m_panningKnob->setModel( &_t->m_panningModel );
 	m_panningKnob->setHintText( tr( "Panning:" ), "%" );
 	m_panningKnob->show();

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -67,14 +67,14 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_volumeKnob->setModel( &_t->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
 
-	m_volumeKnob->setLabel( tr( "VOL" ) );
+	m_volumeKnob->setLabelLegacy( tr( "VOL" ) );
 	m_volumeKnob->show();
 
 	m_panningKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
 							tr( "Panning" ) );
 	m_panningKnob->setModel( &_t->m_panningModel );
 	m_panningKnob->setHintText( tr( "Panning:" ), "%" );
-	m_panningKnob->setLabel( tr( "PAN" ) );
+	m_panningKnob->setLabelLegacy( tr( "PAN" ) );
 	m_panningKnob->show();
 
 	m_activityIndicator = new FadeButton(

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -61,20 +61,16 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
 
-	m_volumeKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
-						    tr( "Track volume" ) );
+	m_volumeKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("VOL"), getTrackSettingsWidget(), tr("Track volume"));
 	m_volumeKnob->setVolumeKnob( true );
 	m_volumeKnob->setModel( &_t->m_volumeModel );
 	m_volumeKnob->setHintText( tr( "Channel volume:" ), "%" );
 
-	m_volumeKnob->setLabelLegacy( tr( "VOL" ) );
 	m_volumeKnob->show();
 
-	m_panningKnob = new Knob( KnobType::Small17, getTrackSettingsWidget(),
-							tr( "Panning" ) );
+	m_panningKnob = Knob::buildLegacyKnob(KnobType::Small17, tr("PAN"), getTrackSettingsWidget(), tr("Panning"));
 	m_panningKnob->setModel( &_t->m_panningModel );
 	m_panningKnob->setHintText( tr( "Panning:" ), "%" );
-	m_panningKnob->setLabelLegacy( tr( "PAN" ) );
 	m_panningKnob->show();
 
 	m_activityIndicator = new FadeButton(

--- a/src/gui/widgets/CustomTextKnob.cpp
+++ b/src/gui/widgets/CustomTextKnob.cpp
@@ -37,11 +37,10 @@ CustomTextKnob::CustomTextKnob( QWidget * _parent, const QString & _name, const 
 	Knob( _parent, _name ),
 	m_value_text( _value_text ) {}
 
-CustomTextKnob* CustomTextKnob::buildLegacyKnob(KnobType knob_num, QWidget* parent, const QString& description, const QString& label)
+CustomTextKnob* CustomTextKnob::buildKnobWithSmallPixelFont(KnobType knob_num, QWidget* parent, const QString& description, const QString& label)
 {
 	auto result = new CustomTextKnob(knob_num, parent, description);
 
-	result->setLegacyMode(true);
 	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
 	result->setLabel(label);
 

--- a/src/gui/widgets/CustomTextKnob.cpp
+++ b/src/gui/widgets/CustomTextKnob.cpp
@@ -36,6 +36,16 @@ CustomTextKnob::CustomTextKnob( QWidget * _parent, const QString & _name, const 
 	Knob( _parent, _name ),
 	m_value_text( _value_text ) {}
 
+CustomTextKnob* CustomTextKnob::buildLegacyKnob(KnobType knob_num, QWidget* parent, const QString& description, const QString& label)
+{
+	auto result = new CustomTextKnob(knob_num, parent, description);
+
+	result->setLegacyMode(true);
+	result->setLabelLegacy(label);
+
+	return result;
+}
+
 QString CustomTextKnob::displayValue() const
 {
 	return m_description.trimmed() + m_value_text;

--- a/src/gui/widgets/CustomTextKnob.cpp
+++ b/src/gui/widgets/CustomTextKnob.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "CustomTextKnob.h"
+#include "FontHelper.h"
 
 namespace lmms::gui
 {
@@ -41,7 +42,8 @@ CustomTextKnob* CustomTextKnob::buildLegacyKnob(KnobType knob_num, QWidget* pare
 	auto result = new CustomTextKnob(knob_num, parent, description);
 
 	result->setLegacyMode(true);
-	result->setLabelLegacy(label);
+	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
+	result->setLabel(label);
 
 	return result;
 }

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -135,37 +135,19 @@ void Knob::onKnobNumUpdated()
 void Knob::setLabel(const QString & txt)
 {
 	m_label = txt;
-	m_legacyMode = false;
 	m_isHtmlLabel = false;
 
-	QSize pixmapSize = m_knobPixmap ? m_knobPixmap->size() : QSize(0, 0);
-
-	auto fm = QFontMetrics(font());
-
-	const int width = std::max(pixmapSize.width(), horizontalAdvance(fm, m_label));
-	const int height = pixmapSize.height() + fm.height();
-
-	setFixedSize(width, height);
-
-	update();
+	setLegacyMode(false);
 }
 
 void Knob::setLabelLegacy(const QString & txt)
 {
 	m_label = txt;
-	m_legacyMode = true;
 	m_isHtmlLabel = false;
 
 	setFont(adjustedToPixelSize(font(), SMALL_FONT_SIZE));
 
-	if( m_knobPixmap )
-	{
-		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(font()), m_label)),
-						m_knobPixmap->height() + 10);
-	}
-
-	update();
+	setLegacyMode(true);
 }
 
 
@@ -190,8 +172,41 @@ void Knob::setHtmlLabel(const QString &htmltxt)
 	update();
 }
 
+void Knob::setLegacyMode(bool legacyMode)
+{
+	if (m_legacyMode != legacyMode)
+	{
+		m_legacyMode = legacyMode;
 
+		updateFixedSize();
 
+		update();
+	}
+}
+
+void Knob::updateFixedSize()
+{
+	if (legacyMode())
+	{
+		if( m_knobPixmap )
+		{
+			setFixedSize(qMax<int>( m_knobPixmap->width(),
+						horizontalAdvance(QFontMetrics(font()), m_label)),
+							m_knobPixmap->height() + 10);
+		}
+	}
+	else
+	{
+		QSize pixmapSize = m_knobPixmap ? m_knobPixmap->size() : QSize(0, 0);
+
+		auto fm = QFontMetrics(font());
+
+		const int width = std::max(pixmapSize.width(), horizontalAdvance(fm, m_label));
+		const int height = pixmapSize.height() + fm.height();
+
+		setFixedSize(width, height);
+	}
+}
 
 void Knob::setTotalAngle( float angle )
 {

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -493,10 +493,13 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
+			auto fm = p.fontMetrics();
+			const auto x = (width() - horizontalAdvance(fm, m_label)) / 2;
+			const auto descent = legacyMode() ? 2 : fm.descent();
+			const auto y = height() - descent; 
+
 			p.setPen(textColor());
-			p.drawText(width() / 2 -
-				horizontalAdvance(p.fontMetrics(), m_label) / 2,
-				height() - 2, m_label);
+			p.drawText(x, y, m_label);
 		}
 		else
 		{

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -132,16 +132,10 @@ void Knob::onKnobNumUpdated()
 
 
 
-void Knob::setLabel(const QString & txt, bool legacyMode)
+void Knob::setLabel(const QString & txt)
 {
-	// TODO Remove this block so that everyone has to explicitly call setLabelLegacy
-	if (legacyMode)
-	{
-		setLabelLegacy(txt);
-		return;
-	}
-
 	m_label = txt;
+	m_legacyMode = false;
 	m_isHtmlLabel = false;
 
 	QSize pixmapSize = m_knobPixmap ? m_knobPixmap->size() : QSize(0, 0);
@@ -159,6 +153,7 @@ void Knob::setLabel(const QString & txt, bool legacyMode)
 void Knob::setLabelLegacy(const QString & txt)
 {
 	m_label = txt;
+	m_legacyMode = true;
 	m_isHtmlLabel = false;
 
 	setFont(adjustedToPixelSize(font(), SMALL_FONT_SIZE));
@@ -508,7 +503,15 @@ void Knob::changeEvent(QEvent * ev)
 		onKnobNumUpdated();
 		if (!m_label.isEmpty())
 		{
-			setLabel(m_label);
+			if (m_legacyMode)
+			{
+				setLabelLegacy(m_label);
+			}
+			else
+			{
+				setLabel(m_label);
+			}
+			
 		}
 		m_cache = QImage();
 		update();

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -57,9 +57,9 @@ Knob::Knob( QWidget * _parent, const QString & _name ) :
 {
 }
 
-Knob* Knob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget * parent)
+Knob* Knob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget * parent, const QString & name)
 {
-	auto result = new Knob(knob_num, parent);
+	auto result = new Knob(knob_num, parent, name);
 
 	result->setLegacyMode(true);
 	result->setLabelLegacy(label);

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -484,11 +484,8 @@ void Knob::drawKnob( QPainter * _p )
 	_p->drawImage( 0, 0, m_cache );
 }
 
-void Knob::paintEvent( QPaintEvent * _me )
+void Knob::drawLabel(QPainter& p)
 {
-	QPainter p( this );
-
-	drawKnob( &p );
 	if( !m_label.isEmpty() )
 	{
 		if (!m_isHtmlLabel)
@@ -509,6 +506,14 @@ void Knob::paintEvent( QPaintEvent * _me )
 			m_tdRenderer->drawContents(&p);
 		}
 	}
+}
+
+void Knob::paintEvent( QPaintEvent * _me )
+{
+	QPainter p(this);
+
+	drawKnob(&p);
+	drawLabel(p);
 }
 
 void Knob::changeEvent(QEvent * ev)

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -203,6 +203,14 @@ void Knob::updateFixedSize()
 	}
 	else
 	{
+		// Styled knobs do not use pixmaps and have no labels. Their size is set from the outside and
+		// they are painted within these limits. Hence we should not compute a new size from a pixmap
+		// and/or label the case of styled knobs.
+		if (knobNum() == KnobType::Styled)
+		{
+			return;
+		}
+
 		QSize pixmapSize = m_knobPixmap ? m_knobPixmap->size() : QSize(0, 0);
 
 		auto fm = QFontMetrics(font());

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -67,6 +67,15 @@ Knob* Knob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget * p
 	return result;
 }
 
+Knob* Knob::buildKnobWithSmallPixelFont(KnobType knob_num, const QString& label, QWidget * parent, const QString & name)
+{
+	auto result = new Knob(knob_num, parent, name);
+	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
+	result->setLabel(label);
+
+	return result;
+}
+
 
 void Knob::initUi( const QString & _name )
 {

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -132,14 +132,41 @@ void Knob::onKnobNumUpdated()
 
 
 
-void Knob::setLabel( const QString & txt )
+void Knob::setLabel(const QString & txt, bool legacyMode)
+{
+	// TODO Remove this block so that everyone has to explicitly call setLabelLegacy
+	if (legacyMode)
+	{
+		setLabelLegacy(txt);
+		return;
+	}
+
+	m_label = txt;
+	m_isHtmlLabel = false;
+
+	QSize pixmapSize = m_knobPixmap ? m_knobPixmap->size() : QSize(0, 0);
+
+	auto fm = QFontMetrics(font());
+
+	const int width = std::max(pixmapSize.width(), horizontalAdvance(fm, m_label));
+	const int height = pixmapSize.height() + fm.height();
+
+	setFixedSize(width, height);
+
+	update();
+}
+
+void Knob::setLabelLegacy(const QString & txt)
 {
 	m_label = txt;
 	m_isHtmlLabel = false;
+
+	setFont(adjustedToPixelSize(font(), SMALL_FONT_SIZE));
+
 	if( m_knobPixmap )
 	{
 		setFixedSize(qMax<int>( m_knobPixmap->width(),
-					horizontalAdvance(QFontMetrics(adjustedToPixelSize(font(), SMALL_FONT_SIZE)), m_label)),
+					horizontalAdvance(QFontMetrics(font()), m_label)),
 						m_knobPixmap->height() + 10);
 	}
 
@@ -459,7 +486,6 @@ void Knob::paintEvent( QPaintEvent * _me )
 	{
 		if (!m_isHtmlLabel)
 		{
-			p.setFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
 				horizontalAdvance(p.fontMetrics(), m_label) / 2,
@@ -468,7 +494,7 @@ void Knob::paintEvent( QPaintEvent * _me )
 		else
 		{
 			// TODO setHtmlLabel is never called so this will never be executed. Remove functionality?
-			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
+			m_tdRenderer->setDefaultFont(font());
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
 		}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -60,9 +60,9 @@ Knob::Knob( QWidget * _parent, const QString & _name ) :
 Knob* Knob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget * parent, const QString & name)
 {
 	auto result = new Knob(knob_num, parent, name);
-
 	result->setLegacyMode(true);
-	result->setLabelLegacy(label);
+	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
+	result->setLabel(label);
 
 	return result;
 }
@@ -145,17 +145,9 @@ void Knob::setLabel(const QString & txt)
 	m_label = txt;
 	m_isHtmlLabel = false;
 
-	setLegacyMode(false);
-}
+	updateFixedSize();
 
-void Knob::setLabelLegacy(const QString & txt)
-{
-	m_label = txt;
-	m_isHtmlLabel = false;
-
-	setFont(adjustedToPixelSize(font(), SMALL_FONT_SIZE));
-
-	setLegacyMode(true);
+	update();
 }
 
 
@@ -523,17 +515,17 @@ void Knob::changeEvent(QEvent * ev)
 		onKnobNumUpdated();
 		if (!m_label.isEmpty())
 		{
-			if (m_legacyMode)
-			{
-				setLabelLegacy(m_label);
-			}
-			else
-			{
-				setLabel(m_label);
-			}
-			
+			setLabel(m_label);
 		}
 		m_cache = QImage();
+		update();
+	}
+	else if (ev->type() == QEvent::FontChange)
+	{
+		// The size of the label might have changed so update
+		// the size of this widget.
+		updateFixedSize();
+
 		update();
 	}
 }

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -57,7 +57,15 @@ Knob::Knob( QWidget * _parent, const QString & _name ) :
 {
 }
 
+Knob* Knob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget * parent)
+{
+	auto result = new Knob(knob_num, parent);
 
+	result->setLegacyMode(true);
+	result->setLabelLegacy(label);
+
+	return result;
+}
 
 
 void Knob::initUi( const QString & _name )
@@ -174,14 +182,11 @@ void Knob::setHtmlLabel(const QString &htmltxt)
 
 void Knob::setLegacyMode(bool legacyMode)
 {
-	if (m_legacyMode != legacyMode)
-	{
-		m_legacyMode = legacyMode;
+	m_legacyMode = legacyMode;
 
-		updateFixedSize();
+	updateFixedSize();
 
-		update();
-	}
+	update();
 }
 
 void Knob::updateFixedSize()

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -30,6 +30,7 @@
 #include "Engine.h"
 #include "CaptionMenu.h"
 #include "embed.h"
+#include "FontHelper.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
 #include "MeterDialog.h"
@@ -68,7 +69,8 @@ TempoSyncKnob* TempoSyncKnob::buildLegacyKnob(KnobType knob_num, const QString& 
 	auto result = new TempoSyncKnob(knob_num, parent);
 
 	result->setLegacyMode(true);
-	result->setLabelLegacy(label);
+	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
+	result->setLabel(label);
 
 	return result;
 }

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -63,6 +63,15 @@ TempoSyncKnob::~TempoSyncKnob()
 }
 
 
+TempoSyncKnob* TempoSyncKnob::buildLegacyKnob(KnobType knob_num, const QString& label, QWidget* parent)
+{
+	auto result = new TempoSyncKnob(knob_num, parent);
+
+	result->setLegacyMode(true);
+	result->setLabelLegacy(label);
+
+	return result;
+}
 
 
 void TempoSyncKnob::modelChanged()

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -75,6 +75,16 @@ TempoSyncKnob* TempoSyncKnob::buildLegacyKnob(KnobType knob_num, const QString& 
 	return result;
 }
 
+TempoSyncKnob* TempoSyncKnob::buildKnobWithSmallPixelFont(KnobType knob_num, const QString& label, QWidget* parent)
+{
+	auto result = new TempoSyncKnob(knob_num, parent);
+
+	result->setFont(adjustedToPixelSize(result->font(), SMALL_FONT_SIZE));
+	result->setLabel(label);
+
+	return result;
+}
+
 
 void TempoSyncKnob::modelChanged()
 {


### PR DESCRIPTION
Up until now it was only possible to change the size of the knob labels in the actual implementation of `Knob`. This means that the changes affected all places where knobs are used and it was not possible to fix a specific instance of a knob. Also, if the font size was increase the label started to "bleed" into the knob because the size of the font was not taken into account when determining the size of the `Knob` instance.

This pull request enables the `Knob` class to render its label correctly at arbitrary sizes using the font that's set for the widget. This means that it's now also possible to render the labels using the application font and size. The knob can also be set into a legacy mode so that it will render itself like before, i.e. as "buggy" as described above.

# Knobs using the application font
Several elements now make use of the fact that the knob label can be rendered using the application font.
## Plugins
The following plugins were adjusted so that they now use the application font to render their labels:
* Amplifier
* BassBooster
* Dispersion
* Flanger
* Peak Controller
* ReverbSC
* StereoEnhancer Effect

## Other components
The following components now render the labels of their knobs with the application font size:
* MIDI CC Rack
* The class `LadspaControlView` (which is not in used anymore though)

# Non-legacy knobs with small font sizes
There are several places where the implementation of the knobs was switched to the non-legacy mode which gives better separation between the knob and the label. The font size was kept at a small size though. This was mostly done in places with manual layouts where there's enough space to have the bit of extra space between the knob and the label.

In most places this was accomplished by using the builder method `buildKnobWithSmallPixelFont` which can be found for `Knob` and `TempoSyncKnob`.

## Plugins
The following plugins use these knobs:
* Bitcrush
* Crossover EQ
* Dual Filter
* Dynamics Processor
* Multitap Echo
* Spectrum analyzer
* Mallets
* Waveshaper
* VST instruments and effects (for their parameter lists)
* ZynAddSubFx

## Other components
They are also used in the following component:
* Effect view, i.e. the "W/D", "DECAY", "GATE" knobs of an effect
* LFO Controller
* The "VOL" and "PAN" knobs of the instrument and sample track. To make this work the font size had to be decreased by one pixel and could not use `buildKnobWithSmallPixelFont`.

# Styled knobs

Styled knobs do not use pixmaps and have no labels. Their size is set from the outside and they are painted within these limits. Hence we should not compute a new size from a pixmap and/or label in `Knob::updateFixedSize`.

This mostly applies to the following plugins: FreeBoy, Kicker, Monstro, Nescaline, Opulenz, Organic, Sf2 Player, sfxr, SID, SlicerT, TripleOscillator, Watsyn, Xpressive.

The best solution would likely be to create an own class for styled knobs and to pull that functionality out of Knob because they somewhat clash in their handling.

# Legacy knobs
Everything related to the instrument window for now uses the legacy knobs.
* Envelope and LFO
* Functions
* Sound Shaping

The Carla plugin also uses the legacy knobs as I was not able to test it due to crashes that existed before. The LMMS Delay also uses the legacy knobs because it is rather "crammed" already.

You can find the code that uses legacy knobs if you search for calls to the method `buildLegacyKnob`. It's provided by `Knob`, `CustomTextKnob` and `TempoSyncKnob`.

# Other changes
The Vectorscope now shows the "Persist." label in the same size as the label of the check boxes.

Some vertical spacing was added to the MIDI CC Rack for slightly improved separation of the elements. The knobs are center aligned in the layout so that the transition between element under and over "CC 100" is cleaner. Setting the models in an explicit loop was removed and is now done when the knobs are created.

The "IN" and "OUT" label of the Bitcrush plugin use the default fixed font size now because the plugin uses a pixel based layout. Using the point based application font looked off.

# Technical details
## Changes in the Knob class
### Legacy mode
Add the member `m_legacyMode` as it is needed in several places to do the right thing, e.g. in the update of the fixed size or the paining of the label. Add the getter `legacyMode` and the setter `setLegacyMode`.

### Size updates
Make sure that the Knob updates its size in the following situations:
* The label is set.
* The font changes.
* Legacy mode is set or unset (already implemented).

The handling of font changes has been added to Knob::changeEvent. The update in case of a changed label is added to Knob::setLabel.

Extract the method `updateFixedSize`.

### Paining code
The painting code now always renders the label with the font that's set for the widget.

Extract the method `Knob::drawLabel` which draws the label. It is called from `paintEvent`.

### Use descent to calculate base line

Use the descent of the font to calculate the distance of the base line from the bottom of the knob widget if we are not in legacy mode. In legacy mode we still assume the descent to have a value of 2, i.e. the base line will always have a distance of 2 from the bottom of the knob widget regardless of the used font.

## Other
Setting an empty label was removed for Lb302.