### PR TITLE
Fix the maximization of sub windows

### DIFF
--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -78,6 +78,8 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
 
+	QPushButton* addTitleButton(const std::string & iconName, const QString & toolTip);
+
 signals:
 	void focusLost();
 

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -78,7 +78,7 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
 
-	QPushButton* addTitleButton(const std::string & iconName, const QString & toolTip);
+	QPushButton* addTitleButton(const std::string& iconName, const QString& toolTip);
 
 signals:
 	void focusLost();

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -296,6 +296,9 @@ void SubWindow::adjustTitleBar()
 		return;
 	}
 
+	// The sub window is not maximized, i.e. the title must be shown
+	// as well as some buttons.
+
 	// Title adjustments
 	m_windowTitle->show();
 
@@ -327,12 +330,12 @@ void SubWindow::adjustTitleBar()
 		buttonBarWidth = buttonBarWidth + m_buttonSize.width() + buttonGap;
 		m_maximizeBtn->move( middleButtonPos );
 		m_restoreBtn->move( middleButtonPos );
-		m_maximizeBtn->setHidden( isMaximized() );
+		m_maximizeBtn->setVisible(true);
 	}
 
 	// we're keeping the restore button around if we open projects
 	// from older versions that have saved minimized windows
-	m_restoreBtn->setVisible( isMaximized() || isMinimized() );
+	m_restoreBtn->setVisible(isMinimized());
 	if( isMinimized() )
 	{
 		m_restoreBtn->move( m_maximizeBtn->isHidden() ?  middleButtonPos : leftButtonPos );

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -96,7 +96,7 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 void SubWindow::paintEvent( QPaintEvent * )
 {
 	// Don't paint any of the other stuff if the sub window is maximized
-	// so that only it child content is painted.
+	// so that only its child content is painted.
 	if (isMaximized())
 	{
 		return;

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -58,28 +58,13 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 	m_borderColor = Qt::black;
 
 	// close, maximize and restore (after maximizing) buttons
-	m_closeBtn = new QPushButton( embed::getIconPixmap( "close" ), QString(), this );
-	m_closeBtn->resize( m_buttonSize );
-	m_closeBtn->setFocusPolicy( Qt::NoFocus );
-	m_closeBtn->setCursor( Qt::ArrowCursor );
-	m_closeBtn->setAttribute( Qt::WA_NoMousePropagation );
-	m_closeBtn->setToolTip( tr( "Close" ) );
+	m_closeBtn = addTitleButton("close", tr("Close"));
 	connect( m_closeBtn, SIGNAL(clicked(bool)), this, SLOT(close()));
 
-	m_maximizeBtn = new QPushButton( embed::getIconPixmap( "maximize" ), QString(), this );
-	m_maximizeBtn->resize( m_buttonSize );
-	m_maximizeBtn->setFocusPolicy( Qt::NoFocus );
-	m_maximizeBtn->setCursor( Qt::ArrowCursor );
-	m_maximizeBtn->setAttribute( Qt::WA_NoMousePropagation );
-	m_maximizeBtn->setToolTip( tr( "Maximize" ) );
+	m_maximizeBtn = addTitleButton("maximize", tr("Maximize"));
 	connect( m_maximizeBtn, SIGNAL(clicked(bool)), this, SLOT(showMaximized()));
 
-	m_restoreBtn = new QPushButton( embed::getIconPixmap( "restore" ), QString(), this );
-	m_restoreBtn->resize( m_buttonSize );
-	m_restoreBtn->setFocusPolicy( Qt::NoFocus );
-	m_restoreBtn->setCursor( Qt::ArrowCursor );
-	m_restoreBtn->setAttribute( Qt::WA_NoMousePropagation );
-	m_restoreBtn->setToolTip( tr( "Restore" ) );
+	m_restoreBtn = addTitleButton("restore", tr("Restore"));
 	connect( m_restoreBtn, SIGNAL(clicked(bool)), this, SLOT(showNormal()));
 
 	// QLabel for the window title and the shadow effect
@@ -424,6 +409,18 @@ void SubWindow::resizeEvent( QResizeEvent * event )
 	{
 		m_trackedNormalGeom.setSize( event->size() );
 	}
+}
+
+QPushButton* SubWindow::addTitleButton(const std::string & iconName, const QString & toolTip)
+{
+	auto button = new QPushButton(embed::getIconPixmap(iconName), QString(), this);
+	button->resize(m_buttonSize);
+	button->setFocusPolicy(Qt::NoFocus);
+	button->setCursor(Qt::ArrowCursor);
+	button->setAttribute(Qt::WA_NoMousePropagation);
+	button->setToolTip(toolTip);
+
+	return button;
 }
 
 

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -111,6 +111,13 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
  */
 void SubWindow::paintEvent( QPaintEvent * )
 {
+	// Don't paint any of the other stuff if the sub window is maximized
+	// so that only it child content is painted.
+	if (isMaximized())
+	{
+		return;
+	}
+
 	QPainter p( this );
 	QRect rect( 0, 0, width(), m_titleBarHeight );
 
@@ -295,9 +302,25 @@ void SubWindow::moveEvent( QMoveEvent * event )
  */
 void SubWindow::adjustTitleBar()
 {
+	// Don't show the title or any button if the sub window is maximized. Otherwise they
+	// might show up behind the actual maximized content of the child widget.
+	if (isMaximized())
+	{
+		m_closeBtn->hide();
+		m_maximizeBtn->hide();
+		m_restoreBtn->hide();
+		m_windowTitle->hide();
+
+		return;
+	}
+
+	// Title adjustments
+	m_windowTitle->show();
+
 	// button adjustments
 	m_maximizeBtn->hide();
 	m_restoreBtn->hide();
+	m_closeBtn->show();
 
 	const int rightSpace = 3;
 	const int buttonGap = 1;

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -78,8 +78,8 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 	m_windowTitle->setAttribute( Qt::WA_TransparentForMouseEvents, true );
 	m_windowTitle->setGraphicsEffect( m_shadow );
 
-	// disable the minimize button
-	setWindowFlags(this->windowFlags() & ~Qt::WindowMinimizeButtonHint);
+	// Disable the minimize button and make sure that the custom window hint is set
+	setWindowFlags((this->windowFlags() & ~Qt::WindowMinimizeButtonHint) | Qt::CustomizeWindowHint);
 
 	connect( mdiArea(), SIGNAL(subWindowActivated(QMdiSubWindow*)), this, SLOT(focusChanged(QMdiSubWindow*)));
 }

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -105,9 +105,7 @@ void SubWindow::paintEvent( QPaintEvent * )
 	QPainter p( this );
 	QRect rect( 0, 0, width(), m_titleBarHeight );
 
-	bool isActive = mdiArea()
-			? mdiArea()->activeSubWindow() == this
-			: false;
+	const bool isActive = windowState() & Qt::WindowActive;
 
 	p.fillRect( rect, isActive ? activeColor() : p.pen().brush() );
 

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -97,10 +97,7 @@ void SubWindow::paintEvent( QPaintEvent * )
 {
 	// Don't paint any of the other stuff if the sub window is maximized
 	// so that only its child content is painted.
-	if (isMaximized())
-	{
-		return;
-	}
+	if (isMaximized()) { return; }
 
 	QPainter p( this );
 	QRect rect( 0, 0, width(), m_titleBarHeight );

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -411,7 +411,7 @@ void SubWindow::resizeEvent( QResizeEvent * event )
 	}
 }
 
-QPushButton* SubWindow::addTitleButton(const std::string & iconName, const QString & toolTip)
+QPushButton* SubWindow::addTitleButton(const std::string& iconName, const QString& toolTip)
 {
 	auto button = new QPushButton(embed::getIconPixmap(iconName), QString(), this);
 	button->resize(m_buttonSize);

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -79,9 +79,8 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 	m_windowTitle->setGraphicsEffect( m_shadow );
 
 	// disable the minimize button
-	setWindowFlags( Qt::SubWindow | Qt::WindowMaximizeButtonHint |
-		Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint |
-		Qt::CustomizeWindowHint );
+	setWindowFlags(this->windowFlags() & ~Qt::WindowMinimizeButtonHint);
+
 	connect( mdiArea(), SIGNAL(subWindowActivated(QMdiSubWindow*)), this, SLOT(focusChanged(QMdiSubWindow*)));
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -285,24 +285,30 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	QMdiSubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget( this );
 	Qt::WindowFlags flags = subWin->windowFlags();
-	if (!m_instrumentView->isResizable()) {
-		flags |= Qt::MSWindowsFixedSizeDialogHint;
-		// any better way than this?
-	} else {
-		subWin->setMaximumSize(m_instrumentView->maximumHeight() + 12, m_instrumentView->maximumWidth() + 208);
-		subWin->setMinimumSize( m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
+
+	if (m_instrumentView->isResizable())
+	{
+		// TODO As of writing SlicerT is the only resizable instrument. Is this code specific to SlicerT?
+		const auto extraSpace = QSize(12, 208);
+		subWin->setMaximumSize(m_instrumentView->maximumSize() + extraSpace);
+		subWin->setMinimumSize(m_instrumentView->minimumSize() + extraSpace);
+
+		flags |= Qt::WindowMaximizeButtonHint;
 	}
-	flags &= ~Qt::WindowMaximizeButtonHint;
-	subWin->setWindowFlags( flags );
+	else
+	{
+		flags |= Qt::MSWindowsFixedSizeDialogHint;
+		flags &= ~Qt::WindowMaximizeButtonHint;
 
+		// Hide the Size and Maximize options from the system menu since the dialog size is fixed.
+		QMenu * systemMenu = subWin->systemMenu();
+		systemMenu->actions().at(2)->setVisible(false); // Size
+		systemMenu->actions().at(4)->setVisible(false); // Maximize
+	}
 
-	// Hide the Size and Maximize options from the system menu
-	// since the dialog size is fixed.
-	QMenu * systemMenu = subWin->systemMenu();
-	systemMenu->actions().at( 2 )->setVisible( false ); // Size
-	systemMenu->actions().at( 4 )->setVisible( false ); // Maximize
+	subWin->setWindowFlags(flags);
 
-	subWin->setWindowIcon( embed::getIconPixmap( "instrument_track" ) );
+	subWin->setWindowIcon(embed::getIconPixmap("instrument_track"));
 	subWin->hide();
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -285,30 +285,24 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	QMdiSubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget( this );
 	Qt::WindowFlags flags = subWin->windowFlags();
-
-	if (m_instrumentView->isResizable())
-	{
-		// TODO As of writing SlicerT is the only resizable instrument. Is this code specific to SlicerT?
-		const auto extraSpace = QSize(12, 208);
-		subWin->setMaximumSize(m_instrumentView->maximumSize() + extraSpace);
-		subWin->setMinimumSize(m_instrumentView->minimumSize() + extraSpace);
-
-		flags |= Qt::WindowMaximizeButtonHint;
-	}
-	else
-	{
+	if (!m_instrumentView->isResizable()) {
 		flags |= Qt::MSWindowsFixedSizeDialogHint;
-		flags &= ~Qt::WindowMaximizeButtonHint;
-
-		// Hide the Size and Maximize options from the system menu since the dialog size is fixed.
-		QMenu * systemMenu = subWin->systemMenu();
-		systemMenu->actions().at(2)->setVisible(false); // Size
-		systemMenu->actions().at(4)->setVisible(false); // Maximize
+		// any better way than this?
+	} else {
+		subWin->setMaximumSize(m_instrumentView->maximumHeight() + 12, m_instrumentView->maximumWidth() + 208);
+		subWin->setMinimumSize( m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
 	}
+	flags &= ~Qt::WindowMaximizeButtonHint;
+	subWin->setWindowFlags( flags );
 
-	subWin->setWindowFlags(flags);
 
-	subWin->setWindowIcon(embed::getIconPixmap("instrument_track"));
+	// Hide the Size and Maximize options from the system menu
+	// since the dialog size is fixed.
+	QMenu * systemMenu = subWin->systemMenu();
+	systemMenu->actions().at( 2 )->setVisible( false ); // Size
+	systemMenu->actions().at( 4 )->setVisible( false ); // Maximize
+
+	subWin->setWindowIcon( embed::getIconPixmap( "instrument_track" ) );
 	subWin->hide();
 }
 


### PR DESCRIPTION
Pull request https://github.com/LMMS/lmms/pull/7514 more or less consists of two fixes. The first one fixes the rendering of maximized `SubWindow` instances and the second one enables instrument windows to be maximizable. This pull request separates out the first fix into its own pull request.

Technically its the same pull request as https://github.com/LMMS/lmms/pull/7514 but commit 9a1eaac8ec1 has been reverted in this branch.