### PR TITLE
fix nullptr deref in AudioFileProcessor (qt6 branch)

### DIFF
--- a/include/DeprecationHelper.h
+++ b/include/DeprecationHelper.h
@@ -55,7 +55,7 @@ inline int horizontalAdvance(const QFontMetrics& metrics, const QString& text)
  * @param wheelEvent
  * @return the position of wheelEvent
  */
-inline QPoint position(QWheelEvent *wheelEvent)
+inline QPoint position(const QWheelEvent *wheelEvent)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
 	return wheelEvent->position().toPoint();
@@ -70,7 +70,7 @@ inline QPoint position(QWheelEvent *wheelEvent)
  * @param me
  * @return the position of the mouse event
  */
-inline QPoint position(QMouseEvent* me)
+inline QPoint position(const QMouseEvent* me)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 	return me->position().toPoint();
@@ -85,7 +85,7 @@ inline QPoint position(QMouseEvent* me)
  * @param me
  * @return the position of the drop event
  */
-inline QPoint position(QDropEvent* de)
+inline QPoint position(const QDropEvent* de)
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 	return de->position().toPoint();

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -480,7 +480,10 @@ void AudioFileProcessorWaveView::reverse()
 
 void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
 {
-	const auto pos = position(me);
+	QPoint pos;
+	if (me != nullptr) {
+		pos = position(me);
+	}
 
 	bool const waveIsDragged = m_isDragging && (m_draggingType == DraggingType::Wave);
 	bool const pointerCloseToStartEndOrLoop = (me != nullptr) &&

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -490,7 +490,7 @@ void AudioFileProcessorWaveView::updateCursor(const QMouseEvent * me)
 		setCursor(Qt::OpenHandCursor);
 }
 
-bool AudioFileProcessorWaveView::pointerCloseToStartEndOrLoop(const QMouseEvent * me)
+bool AudioFileProcessorWaveView::pointerCloseToStartEndOrLoop(const QMouseEvent * me) const
 {
 	if (me == nullptr)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -480,21 +480,26 @@ void AudioFileProcessorWaveView::reverse()
 
 void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
 {
-	QPoint pos;
-	if (me) { pos = position(me); }
-
 	bool const waveIsDragged = m_isDragging && (m_draggingType == DraggingType::Wave);
-	bool const pointerCloseToStartEndOrLoop = (me != nullptr) &&
-			(isCloseTo(pos.x(), m_startFrameX) ||
-			  isCloseTo(pos.x(), m_endFrameX) ||
-			  isCloseTo(pos.x(), m_loopFrameX));
 
-	if (!m_isDragging && pointerCloseToStartEndOrLoop)
+	if (!m_isDragging && pointerCloseToStartEndOrLoop(me))
 		setCursor(Qt::SizeHorCursor);
 	else if (waveIsDragged)
 		setCursor(Qt::ClosedHandCursor);
 	else
 		setCursor(Qt::OpenHandCursor);
+}
+
+bool AudioFileProcessorWaveView::pointerCloseToStartEndOrLoop(QMouseEvent * me)
+{
+	if (me == nullptr)
+	{
+		return false;
+	}
+
+	const QPoint pos = position(me);
+
+	return isCloseTo(pos.x(), m_startFrameX) || isCloseTo(pos.x(), m_endFrameX) || isCloseTo(pos.x(), m_loopFrameX);
 }
 
 void AudioFileProcessorWaveView::configureKnobRelationsAndWaveViews()

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -478,7 +478,7 @@ void AudioFileProcessorWaveView::reverse()
 	m_reversed = ! m_reversed;
 }
 
-void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
+void AudioFileProcessorWaveView::updateCursor(const QMouseEvent * me)
 {
 	bool const waveIsDragged = m_isDragging && (m_draggingType == DraggingType::Wave);
 
@@ -490,7 +490,7 @@ void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
 		setCursor(Qt::OpenHandCursor);
 }
 
-bool AudioFileProcessorWaveView::pointerCloseToStartEndOrLoop(QMouseEvent * me)
+bool AudioFileProcessorWaveView::pointerCloseToStartEndOrLoop(const QMouseEvent * me)
 {
 	if (me == nullptr)
 	{

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -481,9 +481,7 @@ void AudioFileProcessorWaveView::reverse()
 void AudioFileProcessorWaveView::updateCursor(QMouseEvent * me)
 {
 	QPoint pos;
-	if (me != nullptr) {
-		pos = position(me);
-	}
+	if (me) { pos = position(me); }
 
 	bool const waveIsDragged = m_isDragging && (m_draggingType == DraggingType::Wave);
 	bool const pointerCloseToStartEndOrLoop = (me != nullptr) &&

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -170,8 +170,8 @@ private:
 
 	void updateGraph();
 	void reverse();
-	void updateCursor(QMouseEvent* me = nullptr);
-	bool pointerCloseToStartEndOrLoop(QMouseEvent* me);
+	void updateCursor(const QMouseEvent* me = nullptr);
+	bool pointerCloseToStartEndOrLoop(const QMouseEvent* me);
 
 	void configureKnobRelationsAndWaveViews();
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -171,7 +171,7 @@ private:
 	void updateGraph();
 	void reverse();
 	void updateCursor(const QMouseEvent* me = nullptr);
-	bool pointerCloseToStartEndOrLoop(const QMouseEvent* me);
+	bool pointerCloseToStartEndOrLoop(const QMouseEvent* me) const;
 
 	void configureKnobRelationsAndWaveViews();
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -171,6 +171,7 @@ private:
 	void updateGraph();
 	void reverse();
 	void updateCursor(QMouseEvent* me = nullptr);
+	bool pointerCloseToStartEndOrLoop(QMouseEvent* me);
 
 	void configureKnobRelationsAndWaveViews();
 


### PR DESCRIPTION
opening AFP was consistently crashing LMMS on the qt6 branch before - this patch checks whether the passed event pointer is a nullptr, and only derefs it if not.