### PR TITLE
fix various AudioFileProcessor bugs

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -467,9 +467,11 @@ void AudioFileProcessorWaveView::reverse()
 			- m_sample->endFrame()
 			- m_sample->startFrame()
 	);
+	
+	const int m_from_ = m_from;
 
 	setFrom(m_sample->sampleSize() - m_to);
-	setTo(m_sample->sampleSize() - m_from);
+	setTo(m_sample->sampleSize() - m_from_);
 	m_reversed = ! m_reversed;
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -470,10 +470,10 @@ void AudioFileProcessorWaveView::reverse()
 			- m_sample->startFrame()
 	);
 	
-	const int m_from_ = m_from;
+	const int fromTmp = m_from;
 
 	setFrom(m_sample->sampleSize() - m_to);
-	setTo(m_sample->sampleSize() - m_from_);
+	setTo(m_sample->sampleSize() - fromTmp);
 	m_reversed = ! m_reversed;
 }
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -338,10 +338,12 @@ void AudioFileProcessorWaveView::updateGraph()
 	m_graph.fill(Qt::transparent);
 	QPainter p(&m_graph);
 	p.setPen(QColor(255, 255, 255));
+	
+	const auto dataOffset = m_reversed ? m_sample->sampleSize() - m_to : m_from;
 
 	const auto rect = QRect{0, 0, m_graph.width(), m_graph.height()};
 	const auto waveform = SampleWaveform::Parameters{
-		m_sample->data() + m_from, static_cast<size_t>(range()), m_sample->amplification(), m_sample->reversed()};
+		m_sample->data() + dataOffset, static_cast<size_t>(range()), m_sample->amplification(), m_sample->reversed()};
 	SampleWaveform::visualize(waveform, p, rect);
 }
 

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -44,7 +44,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	const float resolution = std::max(1.0f, framesPerPixel / maxFramesPerPixel);
 	const float framesPerResolution = framesPerPixel / resolution;
 
-	const size_t numPixels = std::min<size_t>(parameters.size, width);
+	size_t numPixels = std::min<size_t>(parameters.size, width);
 	auto min = std::vector<float>(numPixels, 1);
 	auto max = std::vector<float>(numPixels, -1);
 	auto squared = std::vector<float>(numPixels, 0);
@@ -67,12 +67,9 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 		squared[pixelIndex] += value * value;
 	}
 	
-	while (pixelIndex < numPixels)
+	if (pixelIndex < numPixels)
 	{
-		max[pixelIndex] = 0.0;
-		min[pixelIndex] = 0.0;
-		
-		pixelIndex++;
+		numPixels = pixelIndex;
 	}
 
 	for (auto i = std::size_t{0}; i < numPixels; i++)

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -49,7 +49,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	auto max = std::vector<float>(numPixels, -1);
 	auto squared = std::vector<float>(numPixels, 0);
 
-	const size_t maxFrames = static_cast<size_t>(static_cast<float>(numPixels) * framesPerPixel);
+	const size_t maxFrames = static_cast<size_t>(numPixels * framesPerPixel);
 
 	auto pixelIndex = std::size_t{0};
 

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -44,7 +44,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	const float resolution = std::max(1.0f, framesPerPixel / maxFramesPerPixel);
 	const float framesPerResolution = framesPerPixel / resolution;
 
-	size_t numPixels = std::min<size_t>(parameters.size, width);
+	size_t numPixels = std::min(parameters.size, static_cast<size_t>(width));
 	auto min = std::vector<float>(numPixels, 1);
 	auto max = std::vector<float>(numPixels, -1);
 	auto squared = std::vector<float>(numPixels, 0);

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -49,7 +49,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	auto max = std::vector<float>(numPixels, -1);
 	auto squared = std::vector<float>(numPixels, 0);
 
-	const size_t maxFrames = numPixels * static_cast<size_t>(framesPerPixel);
+	const size_t maxFrames = static_cast<size_t>(static_cast<float>(numPixels) * framesPerPixel);
 
 	auto pixelIndex = std::size_t{0};
 


### PR DESCRIPTION
- fixed crash by correctly setting m_from and m_to without them interfering with each other (bdfecb60b914abfaa1fffff8e11893b77deddd78)
  <sup>crash is reproducable by fiddling with the endpoint and reversing every now and then, especially when zoomed in very far.</sup>
- fixed flattened wave caused by inaccurate math (18b0e8cba)
  <sup>note: since this affects maxFrames, other less obvious inaccuracies are also fixed by this</sup>
  
    <details><summary>Before/After Comparison</summary>
    <p>
    Reproducable by loading AcousticDrumset preset and looking at bassdrum_acoustic01.ogg.
    
     | Before | After |
    |--------|--------|
    | ![image](https://github.com/user-attachments/assets/028cf916-b04b-4890-912f-bd6e4daeda00) | ![image](https://github.com/user-attachments/assets/d05bc5a2-b74c-4a74-bfae-d40190d0f481) | 
    
    </p>
    </details> 
- stop drawing waveform after end of data d108c48
  <sup>very subtle, but it kept bugging me, and it also helps with debugging the rest of this mess</sup>
  
    <details><summary>Before/After Comparison</summary>
    <p>
    Reproducable by loading AcousticDrumset preset, setting bassdrum_acoustic01.ogg endpoint to 0.6, and fiddling with the volume knob.
    
  | Before | After |
  |--------|--------|
  | ![image](https://github.com/user-attachments/assets/ffce03cd-4416-49f7-9fd7-ec98bccc9a97) |![image](https://github.com/user-attachments/assets/cebad46e-ed58-456d-bd26-cc63547510d9) |
    
    </p>
    </details> 
- correctly wrap drawing of waveform (2b7a3bff8e4b652001ef757df9889df339a44ba9)
    <details><summary>Before/After Comparison</summary>
    <p>
    Reproducable by loading AcousticDrumset preset, setting bassdrum_acoustic01.ogg endpoint to 0.5, and clicking on reverse.
    
  | Before | After |
  |--------|--------|
  | ![image](https://github.com/user-attachments/assets/ee160e94-9cd0-4691-a55d-2285739a1a20) |![image](https://github.com/user-attachments/assets/67689fa0-1ac8-4891-bcd8-0312421475e4) |
    
    </p>
    </details> 