### PR TITLE
Optimize dBFS/amplitude conversion functions

### DIFF
--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -166,12 +166,12 @@ inline float linearToLogScale(float min, float max, float value)
 
 inline float fastPow10f(float x)
 {
-	return expf(2.302585092994046f * x);
+	return std::exp(2.302585092994046f * x);
 }
 
 inline float fastLog10f(float x)
 {
-	return logf(x) * 0.4342944819032518f;
+	return std::log(x) * 0.4342944819032518f;
 }
 
 //! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -171,7 +171,7 @@ static inline float fastPow10f(float x)
 
 static inline float fastLog10f(float x)
 {
-    return logf(x) * 0.4342944819032518f;
+	return logf(x) * 0.4342944819032518f;
 }
 
 //! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -164,12 +164,12 @@ inline float linearToLogScale(float min, float max, float value)
 	return std::isnan( result ) ? 0 : result;
 }
 
-static inline float fastPow10f(float x)
+inline float fastPow10f(float x)
 {
 	return expf(2.302585092994046f * x);
 }
 
-static inline float fastLog10f(float x)
+inline float fastLog10f(float x)
 {
 	return logf(x) * 0.4342944819032518f;
 }
@@ -177,7 +177,7 @@ static inline float fastLog10f(float x)
 //! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 
 //! @param amp Linear amplitude, where 1.0 = 0dBFS. ** Must be larger than zero! **
 //! @return Amplitude in dBFS. 
-static inline float ampToDbfs(float amp)
+inline float ampToDbfs(float amp)
 {
 	return fastLog10f(amp) * 20.0f;
 }
@@ -186,7 +186,7 @@ static inline float ampToDbfs(float amp)
 //! @brief Converts dBFS-scale to linear amplitude with 0dBFS = 1.0
 //! @param dbfs The dBFS value to convert. ** Must be a real number - not inf/nan! **
 //! @return Linear amplitude
-static inline float dbfsToAmp(float dbfs)
+inline float dbfsToAmp(float dbfs)
 {
 	return fastPow10f(dbfs * 0.05f);
 }
@@ -197,9 +197,7 @@ static inline float dbfsToAmp(float dbfs)
 //! @return Amplitude in dBFS. -inf for 0 amplitude.
 inline float safeAmpToDbfs(float amp)
 {
-	return amp == 0.0f
-		? -INFINITY
-		: ampToDbfs(amp);
+	return amp == 0.0f ? -INFINITY : ampToDbfs(amp);
 }
 
 
@@ -208,9 +206,7 @@ inline float safeAmpToDbfs(float amp)
 //! @return Linear amplitude
 inline float safeDbfsToAmp(float dbfs)
 {
-	return std::isinf( dbfs )
-		? 0.0f
-		: dbfsToAmp(dbfs);
+	return std::isinf(dbfs) ? 0.0f : dbfsToAmp(dbfs);
 }
 
 

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -164,7 +164,32 @@ inline float linearToLogScale(float min, float max, float value)
 	return std::isnan( result ) ? 0 : result;
 }
 
+static inline float fastPow10f(float x)
+{
+	return expf(2.302585092994046f * x);
+}
 
+static inline float fastLog10f(float x)
+{
+    return logf(x) * 0.4342944819032518f;
+}
+
+//! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 
+//! @param amp Linear amplitude, where 1.0 = 0dBFS. ** Must be larger than zero! **
+//! @return Amplitude in dBFS. 
+static inline float ampToDbfs(float amp)
+{
+	return fastLog10f(amp) * 20.0f;
+}
+
+
+//! @brief Converts dBFS-scale to linear amplitude with 0dBFS = 1.0
+//! @param dbfs The dBFS value to convert. ** Must be a real number - not inf/nan! **
+//! @return Linear amplitude
+static inline float dbfsToAmp(float dbfs)
+{
+	return fastPow10f(dbfs * 0.05f);
+}
 
 
 //! @brief Converts linear amplitude (0-1.0) to dBFS scale. Handles zeroes as -inf.
@@ -174,7 +199,7 @@ inline float safeAmpToDbfs(float amp)
 {
 	return amp == 0.0f
 		? -INFINITY
-		: log10f( amp ) * 20.0f;
+		: ampToDbfs(amp);
 }
 
 
@@ -185,26 +210,9 @@ inline float safeDbfsToAmp(float dbfs)
 {
 	return std::isinf( dbfs )
 		? 0.0f
-		: std::pow(10.f, dbfs * 0.05f );
+		: dbfsToAmp(dbfs);
 }
 
-
-//! @brief Converts linear amplitude (>0-1.0) to dBFS scale. 
-//! @param amp Linear amplitude, where 1.0 = 0dBFS. ** Must be larger than zero! **
-//! @return Amplitude in dBFS. 
-inline float ampToDbfs(float amp)
-{
-	return log10f(amp) * 20.0f;
-}
-
-
-//! @brief Converts dBFS-scale to linear amplitude with 0dBFS = 1.0
-//! @param dbfs The dBFS value to convert. ** Must be a real number - not inf/nan! **
-//! @return Linear amplitude
-inline float dbfsToAmp(float dbfs)
-{
-	return std::pow(10.f, dbfs * 0.05f);
-}
 
 
 //! Returns the linear interpolation of the two values


### PR DESCRIPTION
`std::pow(10.f, x)` and `log10f` are painfully slow functions when run per-sample, as is commonly required via `dbfsToAmp` and `ampToDbfs`.  This PR sacrifices a completely negligible amount of precision for a significant performance boost for several LMMS plugins:

```
static inline float fastPow10f(float x)
{
	return expf(2.302585092994046f * x);
}

static inline float fastLog10f(float x)
{
	return logf(x) * 0.4342944819032518f;
}
```

Notice that these are mathematically equivalent operations, not approximations.  The lost precision, which is very nearly 0, is solely due to the limited precision of floats.  

-----
Compiled via GCC with -O2:

```
1 billion iterations of log10f(x):
31,138,340,305      cycles
8.419502684 seconds time elapsed

1 billion iterations of fastLog10f(x):
15,626,908,607      cycles
4.226729945 seconds time elapsed
```

fastLog10f is **1.993x** as fast on this hardware.

```
1 billion cycles of pow(10.f, x):
26,823,368,193      cycles
7.258407044 seconds time elapsed

1 billion cycles of fastPow10f(x):
16,135,296,386      cycles
4.315204418 seconds time elapsed
```

fastPow10f is **1.662x** as fast on this hardware.
(This might even provide a larger benefit on older hardware, I've seen performance benefits of up to 3x reported by others.)

-----

It might be worth exploring some faster and less-precise alternatives in the future, but what this PR provides is a significant improvement for no actual downsides whatsoever.  