### PR TITLE
Remove deprecated code in GigPlayer

### DIFF
--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -260,26 +260,19 @@ QString GigInstrument::getCurrentPatchName()
 	int iBankSelected = m_bankNum.value();
 	int iProgSelected = m_patchNum.value();
 
-	gig::Instrument * pInstrument = m_instance->gig.GetFirstInstrument();
-
-	while( pInstrument != nullptr )
+	for (size_t i = 0; i < m_instance->gig.CountInstruments(); ++i)
 	{
+		auto pInstrument = m_instance->gig.GetInstrument(i);
+
 		int iBank = pInstrument->MIDIBank;
 		int iProg = pInstrument->MIDIProgram;
 
-		if( iBank == iBankSelected && iProg == iProgSelected )
+		if (iBank == iBankSelected && iProg == iProgSelected)
 		{
-			QString name = QString::fromStdString( pInstrument->pInfo->Name );
+			QString name = QString::fromStdString(pInstrument->pInfo->Name);
 
-			if( name == "" )
-			{
-				name = "<no name>";
-			}
-
-			return name;
+			return name.isEmpty() ? "<no name>" : name;
 		}
-
-		pInstrument = m_instance->gig.GetNextInstrument();
 	}
 
 	return "";
@@ -719,10 +712,10 @@ void GigInstrument::addSamples( GigNote & gignote, bool wantReleaseSample )
 					m_instrument->DimensionKeyRange.low + 1 );
 	}
 
-	gig::Region* pRegion = m_instrument->GetFirstRegion();
-
-	while( pRegion != nullptr )
+	for (size_t i = 0; i < m_instrument->CountRegions(); ++i)
 	{
+		gig::Region* pRegion = m_instrument->GetRegionAt(i);
+
 		Dimension dim = getDimensions( pRegion, gignote.velocity, wantReleaseSample );
 		gig::DimensionRegion * pDimRegion = pRegion->GetDimensionRegionByValue( dim.DimValues );
 		gig::Sample * pSample = pDimRegion->pSample;
@@ -764,8 +757,6 @@ void GigInstrument::addSamples( GigNote & gignote, bool wantReleaseSample )
 							attenuation, m_interpolation, gignote.frequency ) );
 			}
 		}
-
-		pRegion = m_instrument->GetNextRegion();
 	}
 }
 
@@ -863,22 +854,19 @@ void GigInstrument::getInstrument()
 
 	if( m_instance != nullptr )
 	{
-		gig::Instrument * pInstrument = m_instance->gig.GetFirstInstrument();
-
-		while( pInstrument != nullptr )
+		for (size_t i = 0; i < m_instance->gig.CountInstruments(); ++i)
 		{
+			gig::Instrument* pInstrument = m_instance->gig.GetInstrument(i);
+
 			int iBank = pInstrument->MIDIBank;
 			int iProg = pInstrument->MIDIProgram;
 
-			if( iBank == iBankSelected && iProg == iProgSelected )
+			if (iBank == iBankSelected && iProg == iProgSelected)
 			{
-				break;
+				m_instrument = pInstrument;
+				return;
 			}
-
-			pInstrument = m_instance->gig.GetNextInstrument();
 		}
-
-		m_instrument = pInstrument;
 	}
 }
 

--- a/plugins/GigPlayer/PatchesDialog.cpp
+++ b/plugins/GigPlayer/PatchesDialog.cpp
@@ -143,10 +143,10 @@ void PatchesDialog::setup( GigInstance * pSynth, int iChan,
 	int iBankDefault = -1;
 	int iProgDefault = -1;
 
-	gig::Instrument * pInstrument = m_pSynth->gig.GetFirstInstrument();
-
-	while( pInstrument )
+	for (size_t i = 0; i < m_pSynth->gig.CountInstruments(); ++i)
 	{
+		gig::Instrument * pInstrument = m_pSynth->gig.GetInstrument(i);
+
 		int iBank = pInstrument->MIDIBank;
 		int iProg = pInstrument->MIDIProgram;
 
@@ -165,8 +165,6 @@ void PatchesDialog::setup( GigInstance * pSynth, int iChan,
 				}
 			}
 		}
-
-		pInstrument = m_pSynth->gig.GetNextInstrument();
 	}
 
 	m_bankListView->setSortingEnabled( true );
@@ -341,10 +339,10 @@ void PatchesDialog::bankChanged()
 	m_progListView->clear();
 	QTreeWidgetItem * pProgItem = nullptr;
 
-	gig::Instrument * pInstrument = m_pSynth->gig.GetFirstInstrument();
-
-	while( pInstrument )
+	for (size_t i = 0; i < m_pSynth->gig.CountInstruments(); ++i)
 	{
+		gig::Instrument * pInstrument = m_pSynth->gig.GetInstrument(i);
+
 		QString name = QString::fromStdString( pInstrument->pInfo->Name );
 
 		if( name == "" )
@@ -365,8 +363,6 @@ void PatchesDialog::bankChanged()
 				pProgItem->setText( 1, name );
 			}
 		}
-
-		pInstrument = m_pSynth->gig.GetNextInstrument();
 	}
 
 	m_progListView->setSortingEnabled( true );


### PR DESCRIPTION
Use `CountInstruments` and `GetInstrument` instead of the deprecated methods `GetFirstInstrument` and `GetNextInstrument`.

Use `CountRegions` and `GetRegionAt` instead of the deprecated `GetFirstRegion` and `GetNextRegion`.

Both changes turn `while` loops into `for` loops.