### PR TITLE
Make `EffectControlDialog` inherit `PluginView`

### DIFF
--- a/include/EffectControlDialog.h
+++ b/include/EffectControlDialog.h
@@ -28,7 +28,7 @@
 
 #include <QWidget>
 
-#include "ModelView.h"
+#include "PluginView.h"
 
 namespace lmms
 {
@@ -39,26 +39,21 @@ class EffectControls;
 namespace gui
 {
 
-class LMMS_EXPORT EffectControlDialog : public QWidget, public ModelView
+class LMMS_EXPORT EffectControlDialog : public PluginView
 {
 	Q_OBJECT
 public:
-	EffectControlDialog( EffectControls * _controls );
+	EffectControlDialog(EffectControls *controls);
 	~EffectControlDialog() override = default;
-
-	virtual bool isResizable() const {return false;}
-
 
 signals:
 	void closed();
 
-
 protected:
-	void closeEvent( QCloseEvent * _ce ) override;
+	void closeEvent(QCloseEvent *closeEv) override;
 
 	EffectControls * m_effectControls;
-
-} ;
+};
 
 } // namespace gui
 

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -26,8 +26,9 @@
 #ifndef LMMS_GUI_EFFECT_VIEW_H
 #define LMMS_GUI_EFFECT_VIEW_H
 
-#include "AutomatableModel.h"
-#include "PluginView.h"
+#include <QPixmap>
+#include <QWidget>
+#include "ModelView.h"
 #include "Effect.h"
 
 class QGraphicsOpacityEffect;
@@ -35,6 +36,7 @@ class QGroupBox;
 class QLabel;
 class QPushButton;
 class QMdiSubWindow;
+class QMouseEvent;
 
 namespace lmms::gui
 {
@@ -45,11 +47,11 @@ class LedCheckBox;
 class TempoSyncKnob;
 
 
-class EffectView : public PluginView
+class EffectView : public QWidget, public ModelView
 {
 	Q_OBJECT
 public:
-	EffectView( Effect * _model, QWidget * _parent );
+	EffectView(Effect *model, QWidget *parent);
 	~EffectView() override;
 
 	inline Effect * effect()

--- a/include/ModelView.h
+++ b/include/ModelView.h
@@ -34,7 +34,7 @@ namespace lmms::gui
 class LMMS_EXPORT ModelView
 {
 public:
-	ModelView( Model* model, QWidget* widget );
+	ModelView(Model* model, QWidget* parent);
 	virtual ~ModelView();
 
 	virtual void setModel( Model* model, bool isOldModelValid = true );

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -210,7 +210,8 @@ void Effect::checkGate(double outSum)
 
 gui::PluginView * Effect::instantiateView( QWidget * _parent )
 {
-	return new gui::EffectView( this, _parent );
+	assert(false);  // This function implements a virtual, but for Effects, this is unused
+	return nullptr;
 }
 
 	

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -32,21 +32,20 @@ namespace lmms::gui
 {
 
 
-EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
-	QWidget( nullptr ),
-	ModelView( _controls, this ),
-	m_effectControls( _controls )
+EffectControlDialog::EffectControlDialog(EffectControls *controls) :
+	PluginView(controls->effect(), nullptr),
+	m_effectControls(controls)
 {
-	setWindowTitle( m_effectControls->effect()->displayName() );
-	setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred );
+	setWindowTitle(m_effectControls->effect()->displayName());
+	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 }
 
 
 
 
-void EffectControlDialog::closeEvent( QCloseEvent * _ce )
+void EffectControlDialog::closeEvent(QCloseEvent *closeEv)
 {
-	_ce->ignore();
+	closeEv->ignore();
 	emit closed();
 }
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -45,10 +45,11 @@
 namespace lmms::gui
 {
 
-EffectView::EffectView( Effect * _model, QWidget * _parent ) :
-	PluginView( _model, _parent ),
-	m_bg( embed::getIconPixmap( "effect_plugin" ) ),
-	m_subWindow( nullptr ),
+EffectView::EffectView(Effect * modelParam, QWidget *parent) :
+	QWidget(parent),
+	ModelView(modelParam, this),
+	m_bg(embed::getIconPixmap("effect_plugin")),
+	m_subWindow(nullptr),
 	m_controlView(nullptr),
 	m_dragging(false)
 {
@@ -85,7 +86,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_gate->setHintText( tr( "Gate:" ), "" );
 
 
-	setModel( _model );
+	setModel(modelParam);
 
 	if( effect()->controls()->controlCount() > 0 )
 	{
@@ -126,7 +127,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	setGraphicsEffect(m_opacityEffect);
 
 	//move above vst effect view creation
-	//setModel( _model );
+	//setModel(modelParam);
 }
 
 

--- a/src/gui/ModelView.cpp
+++ b/src/gui/ModelView.cpp
@@ -30,9 +30,9 @@ namespace lmms::gui
 {
 
 
-ModelView::ModelView( Model* model, QWidget* widget ) :
-	m_widget( widget ),
-	m_model( model )
+ModelView::ModelView(Model* model, QWidget* parent) :
+	m_widget(parent),
+	m_model(model)
 {
 }
 


### PR DESCRIPTION
Before this commit, `EffectView` inherits `PluginView` and `EffectControlDialog` inherits `ModelView`. This commit switches those base classes.

The reason is that we previously had no base class for the 2 classes `InstrumentView` and `EffectControlDialog`: `PluginView` was the base class for `InstrumentView`, which does not contain the models for e.g. the "Volume" knob, and for `EffectView`, which does contain models for e.g. the "D/W" knob. This makes it questionable whether it is good that `Effect` contains an `m_wetDryModel`, but `Instrument` contains no "volume model" - but this commit does not fix this.

Notes:

1. This commit should be a no-op, but isn't exactly: While before, `EffectControlDialog` passed `EffectControls*` to the `ModelView`, now, it passes `Effect*` to the `PluginView`, which passes it directly to the `ModelView`.
2. The function `Effect::instantiateView(QWidget*)` seemed to be never executed. Nonetheless, it needs an implementation in order to provide a virtual method - we thus replace the content of this function with an `assert(false)`.