### PR TITLE
Change how PatternTrack clones are named

### DIFF
--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -194,8 +194,20 @@ void PatternTrack::loadTrackSpecificSettings(const QDomElement& _this)
 		{
 			Clip::copyStateTo(track->getClip(src), track->getClip(dst));
 		}
-		setName( tr( "Clone of %1" ).arg(
-					_this.parentNode().toElement().attribute( "name" ) ) );
+		// Check if track name has number at end; if so, increment the number
+		QStringList splitName = _this.parentNode().toElement().attribute( "name" ).split(" ");
+		bool isNumberAtEnd;
+		int number = splitName.takeLast().toInt(&isNumberAtEnd);
+		if (isNumberAtEnd)
+		{
+			setName(splitName.join(" ") + " " + QString::number(number + 1));
+		}
+		else
+		{
+			// Else just add "2" at the end of the name
+			setName(tr( "%1 2" ).arg(
+						_this.parentNode().toElement().attribute( "name" )));
+		}
 	}
 	else
 	{

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -205,8 +205,7 @@ void PatternTrack::loadTrackSpecificSettings(const QDomElement& _this)
 		else
 		{
 			// Else just add "2" at the end of the name
-			setName(tr( "%1 2" ).arg(
-						_this.parentNode().toElement().attribute( "name" )));
+			setName(tr("%1 2").arg(_this.parentNode().toElement().attribute("name")));
 		}
 	}
 	else


### PR DESCRIPTION
## Description
Instead of naming cloned `PatternTrack`s  "Clone of ..." which can quickly build up with "Clone of Clone of Clone of Clone of Clone of ....", this PR changes clones to be named "... 2", and any tracks which have a number at the end to simply increment the number when naming the clone, like "... 3" and "... 4".

## How it works
When you clone a track, the current name of the track is split by `" "`, and the last substring is checked to see if it can be converted to a number. If it can, then the name of the clone is set to the old name plus the number incremented, else it is set to the old name plus "2" at the end.

## Notes:
I tried to use `.arg()` instead of string concatenation for inserting the name and number, but I was unsuccessful. I can try again to see if I can get it working if any of you would like.

Also, I'm guessing we don't need to translate it anymore? I still have `tr("%1 2")` there, but I can remove the `tr` it if you want.