### PR TITLE
Copy/Merge a selection of PatternClips into a single new pattern

### DIFF
--- a/include/PatternClipView.h
+++ b/include/PatternClipView.h
@@ -61,6 +61,8 @@ protected:
 
 
 private:
+	void copySelectionToNewPatternTrack();
+
 	PatternClip* m_patternClip;
 	QPixmap m_paintPixmap;
 	

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -24,16 +24,24 @@
 
 #include "PatternClipView.h"
 
+#include <set>
+
 #include <QApplication>
 #include <QMenu>
 #include <QPainter>
 
+#include "AutomationClip.h"
 #include "Engine.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
+#include "MidiClip.h"
 #include "PatternClip.h"
+#include "PatternTrack.h"
+#include "PatternTrackView.h"
 #include "PatternStore.h"
 #include "RenameDialog.h"
+#include "SampleClip.h"
+#include "Song.h"
 
 namespace lmms::gui
 {
@@ -63,10 +71,110 @@ void PatternClipView::constructContextMenu(QMenu* _cm)
 	_cm->addAction( embed::getIconPixmap( "edit_rename" ),
 						tr( "Change name" ),
 						this, SLOT(changeName()));
+	_cm->addAction(
+		embed::getIconPixmap("pattern_track"),
+		tr("Copy Clip to new Pattern Track"),
+		this,
+		&PatternClipView::copySelectionToNewPatternTrack
+	);
 }
 
+void PatternClipView::copySelectionToNewPatternTrack()
+{
+	QVector<ClipView*> clipvs = getClickedClips();
+	// We check if the owner of the first Clip is a Pattern Track
+	bool isPatternTrack = dynamic_cast<PatternTrackView*>(clipvs.at(0)->getTrackView());
+	if (!isPatternTrack) { return; }
+	// Then we create a set with all the Clips owners
+	std::set<TrackView*> ownerTracks;
+	for (auto clipv: clipvs) { ownerTracks.insert(clipv->getTrackView()); }
 
+	// Can merge if there's only one owner track
+	bool allSameTrack = ownerTracks.size() == 1;
+	if (!allSameTrack) { return; }
 
+	// Find the first clip's start position in the selection
+	TimePos firstClipStartPos = m_patternClip->startPosition();
+	for (auto clipv: clipvs)
+	{
+		firstClipStartPos = std::min(firstClipStartPos, clipv->getClip()->startPosition());
+	}
+
+	// Create new pattern track and clip
+	Track* new_track = Track::create(Track::Type::Pattern, Engine::getSong());
+	PatternClip* new_clip = new PatternClip(new_track);
+
+	new_clip->movePosition(firstClipStartPos);
+
+	const int oldPatternTrackIndex = static_cast<PatternTrack*>(m_patternClip->getTrack())->patternIndex();
+	const int newPatternTrackIndex = static_cast<PatternTrack*>(new_track)->patternIndex();
+
+	TimePos maxNotePos = 0;
+
+	for (const auto& track : Engine::patternStore()->tracks())
+	{
+		Clip* clip = track->getClip(oldPatternTrackIndex);
+		auto sClip = dynamic_cast<SampleClip*>(clip);
+		auto mClip = dynamic_cast<MidiClip*>(clip);
+		auto aClip = dynamic_cast<AutomationClip*>(clip);
+		Clip* newClip = track->getClip(newPatternTrackIndex);
+		if (sClip)
+		{
+			// TODO
+			Clip::copyStateTo(clip, newClip);
+		}
+		else if (mClip)
+		{
+			MidiClip* newMidiClip = dynamic_cast<MidiClip*>(newClip);
+
+			for (auto clipv: clipvs)
+			{
+				// Figure out how many times this clip repeats itself. At maximum it could touch (length roudned up + 1) bars
+				// when accounting for the fact that the start offset could make it play the end of a bar before starting the first full bar.
+				// Here we go the safe way and iterate through the maximum possible repetitions, and discard any notes outside of the range.
+				// First +1 for ceiling, second +1 for possible previous bar.
+				int maxPossibleRepetitions = clipv->getClip()->length() / mClip->length() + 1 + 1; 
+
+				TimePos clipRelativePos = clipv->getClip()->startPosition() - firstClipStartPos;
+				TimePos startTimeOffset = clipv->getClip()->startTimeOffset();
+
+				for (Note const* note : mClip->notes())
+				{
+					// Start loop at i = -1 to get the bar touched by start offset
+					for (int i = -1; i < maxPossibleRepetitions - 1; i++)
+					{
+						auto newNote = Note{*note};
+
+						TimePos newNotePos = note->pos() + clipRelativePos + startTimeOffset + i * mClip->length().nextFullBar() * TimePos::ticksPerBar();
+						TimePos newNotePosRelativeToClip = note->pos() + startTimeOffset + i * mClip->length().nextFullBar()  * TimePos::ticksPerBar();
+						
+						if (newNotePosRelativeToClip < 0 || newNotePosRelativeToClip >= clipv->getClip()->length()) { continue; }
+
+						newNote.setPos(newNotePos);
+						newMidiClip->addNote(newNote, false);
+						maxNotePos = std::max(maxNotePos, newNotePos);
+					}
+				}
+			}
+		}
+		else if (aClip)
+		{
+			// TODO
+			Clip::copyStateTo(clip, newClip);
+		}
+	}
+	// Update the number of steps/bars for all tracks. For some reason addNote for midi clips does not update the length automatically.
+	for (const auto& track : Engine::patternStore()->tracks())
+	{
+		for (int i = 0; i < maxNotePos.getBar(); i++)
+		{
+			static_cast<MidiClip*>(track->getClip(newPatternTrackIndex))->addSteps();
+		}
+	}
+
+	// Now that we know the maximum number of bars, set the length of the new pattern clip
+	new_clip->changeLength(maxNotePos.nextFullBar() * TimePos::ticksPerBar());
+}
 
 void PatternClipView::mouseDoubleClickEvent(QMouseEvent*)
 {

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -73,7 +73,7 @@ void PatternClipView::constructContextMenu(QMenu* _cm)
 						this, SLOT(changeName()));
 	_cm->addAction(
 		embed::getIconPixmap("pattern_track"),
-		tr("Copy Clip to new Pattern Track"),
+		tr("Copy to New Pattern Track"),
 		this,
 		&PatternClipView::copySelectionToNewPatternTrack
 	);


### PR DESCRIPTION
This PR allows the user to select a group of PatternClips on the same track, rightclick, and select the option to "Copy to New Pattern Track", which will merge the selected clips into one new clip on a new PattenTrack.

Currently, this is only implemented for MidiClips, due to the limitation of PatternClips that they cannot store more than one AutomationClip or SampleClip in a row.