### PR TITLE
Add member variable for base sample rate and inline sample rate getter functions

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <vector>
 
+#include "AudioDevice.h"
 #include "lmms_basics.h"
 #include "SampleFrame.h"
 #include "LocklessList.h"

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -361,6 +361,7 @@ private:
 	SampleFrame* m_inputBuffer[2];
 	f_cnt_t m_inputBufferFrames[2];
 	f_cnt_t m_inputBufferSize[2];
+	sample_rate_t m_sampleRate;
 	int m_inputBufferRead;
 	int m_inputBufferWrite;
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -235,9 +235,7 @@ public:
 	}
 
 
-	inline sample_rate_t baseSampleRate() const{
-		return m_baseSampleRate;
-	}
+	sample_rate_t baseSampleRate() const { return m_baseSampleRate; }
 
 	sample_rate_t outputSampleRate() const;
 	sample_rate_t inputSampleRate() const;

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -235,7 +235,10 @@ public:
 	}
 
 
-	sample_rate_t baseSampleRate() const;
+	inline sample_rate_t baseSampleRate() const{
+		return m_baseSampleRate;
+	}
+
 	sample_rate_t outputSampleRate() const;
 	sample_rate_t inputSampleRate() const;
 
@@ -361,7 +364,7 @@ private:
 	SampleFrame* m_inputBuffer[2];
 	f_cnt_t m_inputBufferFrames[2];
 	f_cnt_t m_inputBufferSize[2];
-	sample_rate_t m_sampleRate;
+	sample_rate_t m_baseSampleRate;
 	int m_inputBufferRead;
 	int m_inputBufferWrite;
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -237,8 +237,16 @@ public:
 
 	sample_rate_t baseSampleRate() const { return m_baseSampleRate; }
 
-	sample_rate_t outputSampleRate() const;
-	sample_rate_t inputSampleRate() const;
+
+	sample_rate_t outputSampleRate() const{
+		return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
+	}
+	
+
+	sample_rate_t inputSampleRate() const{
+		return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
+	}
+
 
 	inline float masterGain() const
 	{

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -239,12 +239,14 @@ public:
 	sample_rate_t baseSampleRate() const { return m_baseSampleRate; }
 
 
-	sample_rate_t outputSampleRate() const{
+	sample_rate_t outputSampleRate() const
+	{
 		return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
 	}
 	
 
-	sample_rate_t inputSampleRate() const{
+	sample_rate_t inputSampleRate() const	
+	{
 		return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
 	}
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -74,6 +74,7 @@ static thread_local bool s_renderingThread = false;
 AudioEngine::AudioEngine( bool renderOnly ) :
 	m_renderOnly( renderOnly ),
 	m_framesPerPeriod( DEFAULT_BUFFER_SIZE ),
+	m_sampleRate(0),
 	m_inputBufferRead( 0 ),
 	m_inputBufferWrite( 1 ),
 	m_outputBufferRead(nullptr),
@@ -99,6 +100,9 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 	// determine FIFO size and number of frames per period
 	int fifoSize = 1;
+
+	// get sample rate from config manager
+	m_sampleRate = ConfigManager::inst()->value("audioengine", "samplerate").toInt();
 
 	// if not only rendering (that is, using the GUI), load the buffer
 	// size from user configuration
@@ -243,12 +247,11 @@ void AudioEngine::stopProcessing()
 
 sample_rate_t AudioEngine::baseSampleRate() const
 {
-	sample_rate_t sr = ConfigManager::inst()->value( "audioengine", "samplerate" ).toInt();
-	if( sr < 44100 )
+	if (m_sampleRate < 44100)
 	{
-		sr = 44100;
+		m_sampleRate = 44100;
 	}
-	return sr;
+	return m_sampleRate;
 }
 
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -254,7 +254,7 @@ void AudioEngine::stopProcessing()
 
 sample_rate_t AudioEngine::outputSampleRate() const
 {
-	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSamplerate;
+	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
 }
 
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -74,7 +74,7 @@ static thread_local bool s_renderingThread = false;
 AudioEngine::AudioEngine( bool renderOnly ) :
 	m_renderOnly( renderOnly ),
 	m_framesPerPeriod( DEFAULT_BUFFER_SIZE ),
-	m_baseSampleRate(0),
+	m_baseSampleRate(std::max(ConfigManager::inst()->value("audioengine", "samplerate").toInt(), 44100)),
 	m_inputBufferRead( 0 ),
 	m_inputBufferWrite( 1 ),
 	m_outputBufferRead(nullptr),
@@ -101,16 +101,6 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	// determine FIFO size and number of frames per period
 	int fifoSize = 1;
 
-	// get sample rate from config manager
-	m_baseSampleRate = ConfigManager::inst()->value("audioengine", "samplerate").toInt();
-	
-	// if sample rate < 41000, it should be raised to 41000 as minimum value
-	if (m_baseSampleRate < 44100)
-	{
-		m_baseSampleRate = 44100;
-	}
-
-	
 	// if not only rendering (that is, using the GUI), load the buffer
 	// size from user configuration
 	if( renderOnly == false )

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -74,7 +74,7 @@ static thread_local bool s_renderingThread = false;
 AudioEngine::AudioEngine( bool renderOnly ) :
 	m_renderOnly( renderOnly ),
 	m_framesPerPeriod( DEFAULT_BUFFER_SIZE ),
-	m_sampleRate(0),
+	m_baseSampleRate(0),
 	m_inputBufferRead( 0 ),
 	m_inputBufferWrite( 1 ),
 	m_outputBufferRead(nullptr),
@@ -102,12 +102,12 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 	int fifoSize = 1;
 
 	// get sample rate from config manager
-	m_sampleRate = ConfigManager::inst()->value("audioengine", "samplerate").toInt();
+	m_baseSampleRate = ConfigManager::inst()->value("audioengine", "samplerate").toInt();
 	
 	// if sample rate < 41000, it should be raised to 41000 as minimum value
-	if (m_sampleRate < 44100)
+	if (m_baseSampleRate < 44100)
 	{
-		m_sampleRate = 44100;
+		m_baseSampleRate = 44100;
 	}
 
 	
@@ -252,18 +252,9 @@ void AudioEngine::stopProcessing()
 
 
 
-sample_rate_t AudioEngine::baseSampleRate() const
-{
-	return m_sampleRate;
-}
-
-
-
-
 sample_rate_t AudioEngine::outputSampleRate() const
 {
-	return m_audioDev != nullptr ? m_audioDev->sampleRate() :
-							baseSampleRate();
+	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSamplerate;
 }
 
 
@@ -271,8 +262,7 @@ sample_rate_t AudioEngine::outputSampleRate() const
 
 sample_rate_t AudioEngine::inputSampleRate() const
 {
-	return m_audioDev != nullptr ? m_audioDev->sampleRate() :
-							baseSampleRate();
+	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
 }
 
 bool AudioEngine::criticalXRuns() const

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -103,7 +103,14 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 
 	// get sample rate from config manager
 	m_sampleRate = ConfigManager::inst()->value("audioengine", "samplerate").toInt();
+	
+	// if sample rate < 41000, it should be raised to 41000 as minimum value
+	if (m_sampleRate < 44100)
+	{
+		m_sampleRate = 44100;
+	}
 
+	
 	// if not only rendering (that is, using the GUI), load the buffer
 	// size from user configuration
 	if( renderOnly == false )
@@ -247,10 +254,6 @@ void AudioEngine::stopProcessing()
 
 sample_rate_t AudioEngine::baseSampleRate() const
 {
-	if (m_sampleRate < 44100)
-	{
-		m_sampleRate = 44100;
-	}
 	return m_sampleRate;
 }
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -242,19 +242,6 @@ void AudioEngine::stopProcessing()
 
 
 
-sample_rate_t AudioEngine::outputSampleRate() const
-{
-	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
-}
-
-
-
-
-sample_rate_t AudioEngine::inputSampleRate() const
-{
-	return m_audioDev != nullptr ? m_audioDev->sampleRate() : m_baseSampleRate;
-}
-
 bool AudioEngine::criticalXRuns() const
 {
 	return cpuLoad() >= 99 && Engine::getSong()->isExporting() == false;


### PR DESCRIPTION
Optimised calls to `outputSampleRate` by inlining functions and using member variable to speed up access. Makes function calls a lot lesser as this function seems to get called nearly a million times, as a nested call for `outputSampleRate`. 

also inlined the two functions to improve performance