### PR TITLE
generating unique names for new tracks

### DIFF
--- a/include/Track.h
+++ b/include/Track.h
@@ -197,6 +197,8 @@ public:
 	
 	BoolModel* getMutedModel();
 
+	//! returns a name that isn't used by any track and conatins `sourceName`
+	QString findUniqueName(const QString& sourceName) const;
 public slots:
 	virtual void setName(const QString& newName);
 
@@ -210,6 +212,9 @@ public slots:
 private:
 	void saveTrack(QDomDocument& doc, QDomElement& element, bool presetMode);
 	void loadTrack(const QDomElement& element, bool presetMode);
+
+	//! returns the number characters at the end of a string
+	static QString getNameNumberEnding(const QString& name);
 
 private:
 	TrackContainer* m_trackContainer;

--- a/src/tracks/AutomationTrack.cpp
+++ b/src/tracks/AutomationTrack.cpp
@@ -36,7 +36,7 @@ namespace lmms
 AutomationTrack::AutomationTrack( TrackContainer* tc, bool _hidden ) :
 	Track( _hidden ? Type::HiddenAutomation : Type::Automation, tc )
 {
-	setName( tr( "Automation track" ) );
+	setName(findUniqueName(tr("Automation track")));
 }
 
 bool AutomationTrack::play( const TimePos & time_start, const fpp_t _frames,

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -104,7 +104,7 @@ InstrumentTrack::InstrumentTrack( TrackContainer* tc ) :
 			this, [this, i]{ processCCEvent(i); }, Qt::DirectConnection);
 	}
 
-	setName( tr( "Default preset" ) );
+	setName(findUniqueName(tr("Default preset")));
 
 	connect(&m_baseNoteModel, SIGNAL(dataChanged()), this, SLOT(updateBaseNote()), Qt::DirectConnection);
 	connect(&m_pitchModel, SIGNAL(dataChanged()), this, SLOT(updatePitch()), Qt::DirectConnection);
@@ -1056,7 +1056,7 @@ Instrument * InstrumentTrack::loadInstrument(const QString & _plugin_name,
 	m_instrument = Instrument::instantiate(_plugin_name, this,
 					key, keyFromDnd);
 	unlock();
-	setName(m_instrument->displayName());
+	setName(findUniqueName(m_instrument->displayName()));
 
 	emit instrumentChanged();
 

--- a/src/tracks/PatternTrack.cpp
+++ b/src/tracks/PatternTrack.cpp
@@ -46,7 +46,7 @@ PatternTrack::PatternTrack(TrackContainer* tc) :
 	int patternNum = s_infoMap.size();
 	s_infoMap[this] = patternNum;
 
-	setName(tr("Pattern %1").arg(patternNum));
+	setName(findUniqueName(tr("Pattern")));
 	Engine::patternStore()->createClipsForPattern(patternNum);
 	Engine::patternStore()->setCurrentPattern(patternNum);
 	Engine::patternStore()->updateComboBox();
@@ -194,8 +194,6 @@ void PatternTrack::loadTrackSpecificSettings(const QDomElement& _this)
 		{
 			Clip::copyStateTo(track->getClip(src), track->getClip(dst));
 		}
-		setName( tr( "Clone of %1" ).arg(
-					_this.parentNode().toElement().attribute( "name" ) ) );
 	}
 	else
 	{

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -52,7 +52,7 @@ SampleTrack::SampleTrack(TrackContainer* tc) :
 	m_audioPort(tr("Sample track"), true, &m_volumeModel, &m_panningModel, &m_mutedModel),
 	m_isPlaying(false)
 {
-	setName(tr("Sample track"));
+	setName(findUniqueName(tr("Sample track")));
 	m_panningModel.setCenterValue(DefaultPanning);
 	m_mixerChannelModel.setRange(0, Engine::mixer()->numChannels()-1, 1);
 


### PR DESCRIPTION
This Pull request adds 2 methods that concatenates numbers to tracks that would have the same name otherwise.

Tracks with the same name are still possible, but all new tracks and all cloned tracks will have a unique name by default. Instruments of the same kind will also have differentiating numbers added to them.

Tracks loaded from a save should not be effected.