### PR TITLE
Smarter fill

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -245,7 +245,8 @@ protected slots:
 
 	void clearGhostClip();
 	void glueNotes();
-	void fitNoteLengths(bool fill);
+	void fillGapsBetweenNotes();
+	void cutOverlappingNotes();
 	void constrainNoteLengths(bool constrainMax);
 
 	void changeSnapMode();


### PR DESCRIPTION
Hey guys :cat:

I wanted to keep this PR simple, because I don't want this to end like the last time...
But the PR turned out quite big somehow, so sorry if it's a lot to review.
If you can, just give it a test ride.

---

# Don't fill notes that overlap slightly

*Fill* removes gaps between notes by extending their endpoints to the next note. But currently if it overlaps the next note, it will be extended until yet another note starts. In this example the last bar should not be filled:

![bild](https://github.com/user-attachments/assets/e6354cbc-67be-4e45-8082-d226c8cbbb3d)

Here's the logic I implemented.

![bild](https://github.com/user-attachments/assets/e335a88b-2981-41bf-9061-6557084b932a)

If you don't agree on the percentage, keep in mind that the current code fills if it overlaps more than 0%.

# Fill selected notes independently

Imagine you wanted to extend the chords below. Before you couldn't, because they would interfere with the melody. Now you can by pressing Fill twice.

https://github.com/user-attachments/assets/f927a35b-50d4-4a5f-a0d7-33b843030190

The popup is only shown *if* filling a second time would have effect.

# Cut overlaps of selected notes

Since I had to redo the *Cut overlaps* code for this PR, I decided to implement the same feature there. The first cut will be with respect to the selected notes only, the second cut the notes more so they don't overlap any other note (this is the default behavior right now).