### PR TITLE
Fix PeakController attack/decay, lerp between samples (#7383)

### DIFF
--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -78,8 +78,7 @@ private:
 	static int m_loadCount;
 	static bool m_buggedFile;
 	
-	float m_attackCoeff;
-	float m_decayCoeff;
+	float m_coeff;
 	bool m_coeffNeedsUpdate;
 } ;
 

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -132,8 +132,18 @@ Effect::ProcessStatus PeakControllerEffect::processImpl(SampleFrame* buf, const 
 	float curRMS = sqrt_neg(sum / frames);
 	const float tres = c.m_tresholdModel.value();
 	const float amount = c.m_amountModel.value() * c.m_amountMultModel.value();
+	const float attack = 1.0f - c.m_attackModel.value();
+	const float decay = 1.0f - c.m_decayModel.value();
+
 	curRMS = qAbs( curRMS ) < tres ? 0.0f : curRMS;
-	m_lastSample = qBound( 0.0f, c.m_baseModel.value() + amount * curRMS, 1.0f );
+	float target = c.m_baseModel.value() + amount * curRMS;
+	// Use decay when the volume is decreasing, attack otherwise.
+	// Since direction can change as often as every sampleBuffer, it's difficult
+	// to witness attack/decay working in isolation unless using large buffer sizes.
+	const float t = target < m_lastSample ? decay : attack;
+	// Set m_lastSample to the interpolation between itself and target.
+	// When t is 1.0, m_lastSample snaps to target. When t is 0.0, m_lastSample shouldn't change.
+	m_lastSample = std::clamp(m_lastSample + t * (target - m_lastSample), 0.0f, 1.0f);
 
 	return ProcessStatus::Continue;
 }

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -80,9 +80,7 @@ void PeakController::updateValueBuffer()
 {
 	if( m_coeffNeedsUpdate )
 	{
-		const float ratio = 44100.0f / Engine::audioEngine()->outputSampleRate();
-		m_attackCoeff = 1.0f - powf( 2.0f, -0.3f * ( 1.0f - m_peakEffect->attackModel()->value() ) * ratio );
-		m_decayCoeff = 1.0f -  powf( 2.0f, -0.3f * ( 1.0f - m_peakEffect->decayModel()->value()  ) * ratio );
+		m_coeff = 100.0f / Engine::audioEngine()->outputSampleRate();
 		m_coeffNeedsUpdate = false;
 	}
 
@@ -97,14 +95,7 @@ void PeakController::updateValueBuffer()
 			for( f_cnt_t f = 0; f < frames; ++f )
 			{
 				const float diff = ( targetSample - m_currentSample );
-				if( m_currentSample < targetSample ) // going up...
-				{
-					m_currentSample += diff * m_attackCoeff;
-				}
-				else if( m_currentSample > targetSample ) // going down
-				{
-					m_currentSample += diff * m_decayCoeff;
-				}
+				m_currentSample += diff * m_coeff;
 				values[f] = m_currentSample;
 			}
 		}


### PR DESCRIPTION
Historically, the PeakController has had issues like attack/decay knobs acting like on/off switches, and audio artifacts like buzzing or clicking. This patch aims to address those issues.

The PeakController previously used lerp (linear interpolation) when looping through the sample buffer, which was in updateValueBuffer. This lerp utilized attack/decay values from control knobs. This is not the correct place to utilize attack/decay because the only temporal data available to the function is the frame and sample size. Therefore the coefficient should simply be the sample rate instead.

Between each sample, processImpl would set m_lastSample to the RMS without any sort of lerp. This resulted in m_lastSample producing stair-like patterns over time, rather than a smooth line.

For context, m_lastSample is used to set the value of whatever is connected to the PeakController. The basic lerp formula is:

m_lastSample = m_lastSample + ((1 - attack) * (RMS - m_lastSample))

This is useful because an attack of 0 sets m_lastSample to RMS, whereas an attack of 1 would set m_lastSample to m_lastSample. This means our attack/decay knobs can be used on a range from "snap to the next value immediately" to "never stray from the last value".

* Remove attack/decay from PeakController frame lerp.
* Set frame lerp coefficient to 100.0 / sample_rate to fix buzzing.
* Add lerp between samples for PeakController to fix stairstep bug.
* The newly added lerp utilizes (1 - attack or decay) as the coefficient, which means the knobs actually do something now.

Fixes #7383 