### PR TITLE
Don't fill notes that overlap slightly

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -245,8 +245,9 @@ protected slots:
 
 	void clearGhostClip();
 	void glueNotes();
-	void fitNoteLengths(bool fill);
 	void constrainNoteLengths(bool constrainMax);
+	void cutOverlappingNotes();
+	void fillGapsBetweenNotes();
 
 	void changeSnapMode();
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -711,8 +711,12 @@ void PianoRoll::glueNotes()
 	}
 }
 
-void PianoRoll::fitNoteLengths(bool fill)
+void PianoRoll::cutOverlappingNotes()
 {
+	// TODO remove the code for fill=true
+	// it has been replaced by fillGapsBetweenNotes()
+	bool fill = false;
+
 	if (!hasValidMidiClip()) { return; }
 	m_midiClip->addJournalCheckPoint();
 	m_midiClip->rearrangeAllNotes();
@@ -764,6 +768,79 @@ void PianoRoll::fitNoteLengths(bool fill)
 	getGUI()->songEditor()->update();
 	Engine::getSong()->setModified();
 }
+
+
+
+bool fillGapsBetweenNotesInVector(
+	const NoteVector& notes,
+	bool onlyEditSelected)
+{
+	bool success = false;
+
+	// Keep track of where the clip ends
+	TimePos lastEndPos;
+
+	for (auto currentNote = notes.begin(); currentNote != notes.end(); ++currentNote)
+	{
+		if (onlyEditSelected && !(*currentNote)->selected()) { continue; }
+
+		/* Note to self:
+		 * Reset the nextNote iterator to currentNote each time. We don't know how far it iterated
+		 * on the previous note since note lengths differ. Also, never start on currentNote + 1
+		 * because that would not set lastEndPos in case the clip only has a single note.
+		 */
+		auto nextNote = currentNote;
+
+		for (; nextNote != notes.end(); ++nextNote)
+		{
+			lastEndPos = std::max(lastEndPos, (*nextNote)->endPos());
+
+			// Break when the overlap between currentNote and nextNote is less than
+			// 50% of the shortest note's length
+			int lengthOfShortestNote = std::min((*currentNote)->length(), (*nextNote)->length());
+			int overlap = (*currentNote)->endPos() - (*nextNote)->pos();
+			if (overlap < (lengthOfShortestNote / 2)) { break; }
+		}
+
+		// If there are no more notes after currentNote, extend it to the end of the bar
+		if (nextNote == notes.end())
+		{
+			TimePos endOfLastBar = lastEndPos.nextFullBar() * TimePos::ticksPerBar();
+			if ((*currentNote)->endPos() < endOfLastBar)
+			{
+				success = true;
+				(*currentNote)->setLength(endOfLastBar - (*currentNote)->pos());
+			}
+		}
+
+		// If there's a gap between currentNote and nextNote, extend currentNote
+		else if ((*currentNote)->endPos() < (*nextNote)->pos())
+		{
+			success = true;
+			(*currentNote)->setLength((*nextNote)->pos() - (*currentNote)->pos());
+		}
+	}
+
+	return success;
+}
+
+
+
+void PianoRoll::fillGapsBetweenNotes()
+{
+	if (!hasValidMidiClip()) { return; }
+	m_midiClip->addJournalCheckPoint();
+
+	// Make sure notes are sorted by start position
+	m_midiClip->rearrangeAllNotes();
+
+	bool hasSelection = !getSelectedNotes().empty();
+
+	fillGapsBetweenNotesInVector(
+		m_midiClip->notes(),
+		/*onlyEditSelected*/ hasSelection);
+}
+
 
 
 void PianoRoll::constrainNoteLengths(bool constrainMax)
@@ -4856,11 +4933,11 @@ PianoRollWindow::PianoRollWindow() :
 	knifeAction->setShortcut( Qt::SHIFT | Qt::Key_K );
 
 	auto fillAction = new QAction(embed::getIconPixmap("fill"), tr("Fill"), noteToolsButton);
-	connect(fillAction, &QAction::triggered, [this](){ m_editor->fitNoteLengths(true); });
+	connect(fillAction, &QAction::triggered, m_editor, &PianoRoll::fillGapsBetweenNotes);
 	fillAction->setShortcut(Qt::SHIFT | Qt::Key_F);
 
 	auto cutOverlapsAction = new QAction(embed::getIconPixmap("cut_overlaps"), tr("Cut overlaps"), noteToolsButton);
-	connect(cutOverlapsAction, &QAction::triggered, [this](){ m_editor->fitNoteLengths(false); });
+	connect(cutOverlapsAction, &QAction::triggered, m_editor, &PianoRoll::cutOverlappingNotes);
 	cutOverlapsAction->setShortcut(Qt::SHIFT | Qt::Key_C);
 
 	auto minLengthAction = new QAction(embed::getIconPixmap("min_length"), tr("Min length as last"), noteToolsButton);


### PR DESCRIPTION
If a note overlaps the next by a hair, pressing shift+F will fill it all the way across the other note. That's annoying.

This PR fixes that by only filling overlapping notes if the overlap by more than 50%

![bild](https://github.com/user-attachments/assets/cf29f8ab-86e9-4034-90cb-5bd1c6c9eada)