### PR TITLE
Song Editor: Improve performance of auto-scroll, scroll, zoom, and clip dragging

### DIFF
--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -137,6 +137,8 @@ void Clip::movePosition( const TimePos & pos )
  */
 void Clip::changeLength( const TimePos & length )
 {
+	if (m_length == length) { return; }
+
 	m_length = length;
 	Engine::getSong()->updateLength();
 	emit lengthChanged();

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -156,9 +156,8 @@ TrackView * TrackContainerView::addTrackView( TrackView * _tv )
 {
 	m_trackViews.push_back( _tv );
 	m_scrollLayout->addWidget( _tv );
-	connect( this, SIGNAL( positionChanged( const lmms::TimePos& ) ),
-				_tv->getTrackContentWidget(),
-				SLOT( changePosition( const lmms::TimePos& ) ) );
+	connect(this, &TrackContainerView::positionChanged,
+		_tv->getTrackContentWidget(), &TrackContentWidget::changePosition);
 	realignTracks();
 	return( _tv );
 }
@@ -173,7 +172,7 @@ void TrackContainerView::removeTrackView( TrackView * _tv )
 	{
 		m_trackViews.removeAt( index );
 
-		disconnect( _tv );
+		disconnect(_tv->getTrackContentWidget());
 		m_scrollLayout->removeWidget( _tv );
 
 		realignTracks();

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -271,8 +271,6 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 	{
 		Clip* clip = clipView->getClip();
 
-		clip->changeLength( clip->length() );
-
 		const int ts = clip->startPosition();
 		const int te = clip->endPosition()-3;
 		if( ( ts >= begin && ts <= end ) ||

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -256,43 +256,24 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 		return;
 	}
 
-	TimePos pos = newPos;
-	if( pos < 0 )
-	{
-		pos = m_trackView->trackContainerView()->currentPosition();
-	}
-
-	const int begin = pos;
-	const int end = endPosition( pos );
+	const TimePos begin = newPos < 0 ? m_trackView->trackContainerView()->currentPosition() : newPos;
 	const float ppb = m_trackView->trackContainerView()->pixelsPerBar();
 
-	setUpdatesEnabled( false );
-	for (const auto& clipView : m_clipViews)
+	setUpdatesEnabled(false);
+	for (ClipView* clipView : m_clipViews)
 	{
 		Clip* clip = clipView->getClip();
 
-		const int ts = clip->startPosition();
-		const int te = clip->endPosition()-3;
-		if( ( ts >= begin && ts <= end ) ||
-			( te >= begin && te <= end ) ||
-			( ts <= begin && te >= end ) )
+		const auto xPos = static_cast<int>((clip->startPosition() - begin) * ppb / TimePos::ticksPerBar());
+		clipView->move(xPos, clipView->y());
+		if (!clipView->isVisible())
 		{
-			clipView->move(static_cast<int>((ts - begin) * ppb / TimePos::ticksPerBar()), clipView->y());
-			if (!clipView->isVisible())
-			{
-				clipView->show();
-			}
-		}
-		else
-		{
-			clipView->move(-clipView->width() - 10, clipView->y());
+			clipView->show();
 		}
 	}
-	setUpdatesEnabled( true );
+	setUpdatesEnabled(true);
 
-	// redraw background
 	updateBackground();
-//	update();
 }
 
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -79,10 +79,6 @@ TrackContentWidget::TrackContentWidget( TrackView * parent ) :
 {
 	setAcceptDrops( true );
 
-	connect( parent->trackContainerView(),
-			SIGNAL( positionChanged( const lmms::TimePos& ) ),
-			this, SLOT( changePosition( const lmms::TimePos& ) ) );
-
 	// Update background if snap size changes
 	connect(getGUI()->songEditor()->m_editor->snappingModel(), &Model::dataChanged,
 			this, &TrackContentWidget::updateBackground);


### PR DESCRIPTION
Remove the call to `Clip::changeLength` from `TrackContentWidget::changePosition` as it results in bad performance, especially when the Song Editor is in auto-scroll mode and the position is changed very often.

The call in question has set the clip to the length that it already has which in turn resulted in lots of needless calls to `Song::updateLength`.

It also should not be necessary to update a clip length if all that we do is change the position of the `TrackContentWidget`.

Fixes #7462