### PR TITLE
Update macOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
             xcode: "15.2"
           - arch: arm64
             os: macos-14
-            xcode: "14.3.1"
+            xcode: "15.4"
     name: macos-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
         arch: [ x86_64, arm64 ]
         include:
           - arch: x86_64
-            os: macos-12
+            os: macos-13
             xcode: "13.1"
           - arch: arm64
             os: macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         include:
           - arch: x86_64
             os: macos-13
-            xcode: "13.1"
+            xcode: "15.2"
           - arch: arm64
             os: macos-14
             xcode: "14.3.1"

--- a/include/RemotePluginBase.h
+++ b/include/RemotePluginBase.h
@@ -398,7 +398,7 @@ public:
 		message & addInt( int _i )
 		{
 			char buf[32];
-			sprintf( buf, "%d", _i );
+			std::snprintf(buf, 32, "%d", _i);
 			data.emplace_back( buf );
 			return *this;
 		}
@@ -406,7 +406,7 @@ public:
 		message & addFloat( float _f )
 		{
 			char buf[32];
-			sprintf( buf, "%f", _f );
+			std::snprintf(buf, 32, "%f", _f);
 			data.emplace_back( buf );
 			return *this;
 		}

--- a/include/RemotePluginClient.h
+++ b/include/RemotePluginClient.h
@@ -309,7 +309,7 @@ bool RemotePluginClient::processMessage( const message & _m )
 		default:
 		{
 			char buf[64];
-			sprintf( buf, "undefined message: %d\n", (int) _m.id );
+			std::snprintf(buf, 64, "undefined message: %d\n", _m.id);
 			debugMessage( buf );
 			break;
 		}

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -226,7 +226,7 @@ void VestigeInstrument::loadSettings( const QDomElement & _this )
 		QStringList s_dumpValues;
 		for( int i = 0; i < paramCount; i++ )
 		{
-			sprintf(paramStr.data(), "param%d", i);
+			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 			s_dumpValues = dump[paramStr.data()].split(":");
 
 			knobFModel[i] = new FloatModel( 0.0f, 0.0f, 1.0f, 0.01f, this, QString::number(i) );
@@ -290,7 +290,7 @@ void VestigeInstrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 			for( int i = 0; i < paramCount; i++ )
 			{
 				if (knobFModel[i]->isAutomated() || knobFModel[i]->controllerConnection()) {
-					sprintf(paramStr.data(), "param%d", i);
+					std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 					knobFModel[i]->saveSettings(_doc, _this, paramStr.data());
 				}
 
@@ -987,7 +987,7 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 
 	for( int i = 0; i < m_vi->paramCount; i++ )
 	{
-		sprintf(paramStr.data(), "param%d", i);
+		std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 		s_dumpValues = dump[paramStr.data()].split(":");
 
 		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, this, s_dumpValues.at( 1 ) );
@@ -996,7 +996,7 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 
 		if( !hasKnobModel )
 		{
-			sprintf(paramStr.data(), "%d", i);
+			std::snprintf(paramStr.data(), paramStr.size(), "%d", i);
 			m_vi->knobFModel[i] = new FloatModel(LocaleHelper::toFloat(s_dumpValues.at(2)),
 				0.0f, 1.0f, 0.01f, castModel<VestigeInstrument>(), paramStr.data());
 		}
@@ -1059,8 +1059,8 @@ void ManageVestigeInstrumentView::syncPlugin( void )
 		// those auto-setted values are not jurnaled, tracked for undo / redo
 		if( !( m_vi->knobFModel[ i ]->isAutomated() || m_vi->knobFModel[ i ]->controllerConnection() ) )
 		{
-			sprintf(paramStr.data(), "param%d", i);
-    		s_dumpValues = dump[paramStr.data()].split(":");
+			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
+			s_dumpValues = dump[paramStr.data()].split(":");
 			float f_value = LocaleHelper::toFloat(s_dumpValues.at(2));
 			m_vi->knobFModel[ i ]->setAutomatedValue( f_value );
 			m_vi->knobFModel[ i ]->setInitValue( f_value );

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -87,7 +87,7 @@ void VstEffectControls::loadSettings( const QDomElement & _this )
 		QStringList s_dumpValues;
 		for( int i = 0; i < paramCount; i++ )
 		{
-			sprintf(paramStr.data(), "param%d", i);
+			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 			s_dumpValues = dump[paramStr.data()].split(":");
 
 			knobFModel[i] = new FloatModel( 0.0f, 0.0f, 1.0f, 0.01f, this, QString::number(i) );
@@ -137,7 +137,7 @@ void VstEffectControls::saveSettings( QDomDocument & _doc, QDomElement & _this )
 			for( int i = 0; i < paramCount; i++ )
 			{
 				if (knobFModel[i]->isAutomated() || knobFModel[i]->controllerConnection()) {
-					sprintf(paramStr.data(), "param%d", i);
+					std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 					knobFModel[i]->saveSettings(_doc, _this, paramStr.data());
 				}
 			}
@@ -386,7 +386,7 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 
 	for( int i = 0; i < m_vi->paramCount; i++ )
 	{
-		sprintf(paramStr.data(), "param%d", i);
+		std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 		s_dumpValues = dump[paramStr.data()].split(":");
 
 		vstKnobs[ i ] = new CustomTextKnob( KnobType::Bright26, widget, s_dumpValues.at( 1 ) );
@@ -395,7 +395,7 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 
 		if( !hasKnobModel )
 		{
-			sprintf(paramStr.data(), "%d", i);
+			std::snprintf(paramStr.data(), paramStr.size(), "%d", i);
 			m_vi->knobFModel[i] = new FloatModel(LocaleHelper::toFloat(s_dumpValues.at(2)),
 					0.0f, 1.0f, 0.01f, _eff, paramStr.data());
 		}
@@ -460,7 +460,7 @@ void ManageVSTEffectView::syncPlugin()
 		if( !( m_vi2->knobFModel[ i ]->isAutomated() ||
 					m_vi2->knobFModel[ i ]->controllerConnection() ) )
 		{
-			sprintf(paramStr.data(), "param%d", i);
+			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 			s_dumpValues = dump[paramStr.data()].split(":");
 			float f_value = LocaleHelper::toFloat(s_dumpValues.at(2));
 			m_vi2->knobFModel[ i ]->setAutomatedValue( f_value );

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -29,20 +29,17 @@
 namespace lmms
 {
 
-using std::unique_ptr;
-using std::move;
-
-void ComboBoxModel::addItem( QString item, unique_ptr<PixmapLoader> loader )
+void ComboBoxModel::addItem(QString item, std::unique_ptr<PixmapLoader> loader)
 {
-	m_items.emplace_back( move(item), move(loader) );
+	m_items.emplace_back(std::move(item), std::move(loader));
 	setRange( 0, m_items.size() - 1 );
 }
 
 
-void ComboBoxModel::replaceItem(std::size_t index, QString item, unique_ptr<PixmapLoader> loader)
+void ComboBoxModel::replaceItem(std::size_t index, QString item, std::unique_ptr<PixmapLoader> loader)
 {
 	assert(index < m_items.size());
-	m_items[index] = Item(move(item), move(loader));
+	m_items[index] = Item(std::move(item), std::move(loader));
 	emit propertiesChanged();
 }
 

--- a/src/core/Keymap.cpp
+++ b/src/core/Keymap.cpp
@@ -147,7 +147,7 @@ void Keymap::loadSettings(const QDomElement &element)
 	QDomNode node = element.firstChild();
 	m_map.clear();
 
-	for (int i = 0; !node.isNull(); i++)
+	while (!node.isNull())
 	{
 		m_map.push_back(node.toElement().attribute("value").toInt());
 		node = node.nextSibling();

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -210,7 +210,7 @@ void ProjectRenderer::abortProcessing()
 
 void ProjectRenderer::updateConsoleProgress()
 {
-	const int cols = 50;
+	constexpr int cols = 50;
 	static int rot = 0;
 	auto buf = std::array<char, 80>{};
 	auto prog = std::array<char, cols + 1>{};
@@ -221,9 +221,9 @@ void ProjectRenderer::updateConsoleProgress()
 	}
 	prog[cols] = 0;
 
-	const auto activity = (const char*)"|/-\\";
+	const auto activity = "|/-\\";
 	std::fill(buf.begin(), buf.end(), 0);
-	sprintf(buf.data(), "\r|%s|    %3d%%   %c  ", prog.data(), m_progress,
+	std::snprintf(buf.data(), buf.size(), "\r|%s|    %3d%%   %c  ", prog.data(), m_progress,
 							activity[rot] );
 	rot = ( rot+1 ) % 4;
 

--- a/src/core/Scale.cpp
+++ b/src/core/Scale.cpp
@@ -116,7 +116,7 @@ void Scale::loadSettings(const QDomElement &element)
 	QDomNode node = element.firstChild();
 	m_intervals.clear();
 
-	for (int i = 0; !node.isNull(); i++)
+	while (!node.isNull())
 	{
 		Interval temp;
 		temp.restoreState(node.toElement());

--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -159,7 +159,7 @@ void MidiApple::removePort( MidiPort* port )
 
 QString MidiApple::sourcePortName( const MidiEvent& event ) const
 {
-	qDebug("sourcePortName return '%s'?\n", event.sourcePort());
+	qDebug("sourcePortName");
 	/*
 	if( event.sourcePort() )
 	{

--- a/src/core/midi/MidiApple.cpp
+++ b/src/core/midi/MidiApple.cpp
@@ -501,7 +501,7 @@ void MidiApple::openDevices()
 void MidiApple::openMidiReference( MIDIEndpointRef reference, QString refName, bool isIn )
 {
 	char * registeredName = (char*) malloc(refName.length()+1);
-	sprintf(registeredName, "%s",refName.toLatin1().constData());
+	std::snprintf(registeredName, refName.length() + 1, "%s",refName.toLatin1().constData());
 	qDebug("openMidiReference refName '%s'",refName.toLatin1().constData());
 	
 	MIDIClientRef mClient = getMidiClientRef();
@@ -623,7 +623,7 @@ char * MidiApple::getFullName(MIDIEndpointRef &endpoint_ref)
 	size_t deviceNameLen = deviceName == nullptr ? 0 : strlen(deviceName);
 	size_t endPointNameLen = endPointName == nullptr ? 0 : strlen(endPointName);
 	char * fullName = (char *)malloc(deviceNameLen + endPointNameLen + 2);
-	sprintf(fullName, "%s:%s", deviceName,endPointName);
+	std::snprintf(fullName, deviceNameLen + endPointNameLen + 2, "%s:%s", deviceName,endPointName);
 	if (deviceName != nullptr) { free(deviceName); }
 	if (endPointName != nullptr) { free(endPointName); }
 	return fullName;

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -283,8 +283,8 @@ void Fader::paintEvent(QPaintEvent* ev)
 void Fader::paintLevels(QPaintEvent* ev, QPainter& painter, bool linear)
 {
 	const auto mapper = linear
-		? [](float value) -> float { return value; }
-		: [](float value) -> float { return ampToDbfs(qMax(0.0001f, value)); };
+		? +[](float value) -> float { return value; }
+		: +[](float value) -> float { return ampToDbfs(qMax(0.0001f, value)); };
 
 	const float mappedMinPeak = mapper(m_fMinPeak);
 	const float mappedMaxPeak = mapper(m_fMaxPeak);

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -282,20 +282,17 @@ void Fader::paintEvent(QPaintEvent* ev)
 
 void Fader::paintLevels(QPaintEvent* ev, QPainter& painter, bool linear)
 {
-	std::function<float(float value)> mapper = [this](float value) { return ampToDbfs(qMax(0.0001f, value)); };
+	const auto mapper = linear
+		? [](float value) -> float { return value; }
+		: [](float value) -> float { return ampToDbfs(qMax(0.0001f, value)); };
 
-	if (linear)
-	{
-		mapper = [this](float value) { return value; };
-	}
-
-	const float mappedMinPeak(mapper(m_fMinPeak));
-	const float mappedMaxPeak(mapper(m_fMaxPeak));
-	const float mappedPeakL(mapper(m_fPeakValue_L));
-	const float mappedPeakR(mapper(m_fPeakValue_R));
-	const float mappedPersistentPeakL(mapper(m_persistentPeak_L));
-	const float mappedPersistentPeakR(mapper(m_persistentPeak_R));
-	const float mappedUnity(mapper(1.f));
+	const float mappedMinPeak = mapper(m_fMinPeak);
+	const float mappedMaxPeak = mapper(m_fMaxPeak);
+	const float mappedPeakL = mapper(m_fPeakValue_L);
+	const float mappedPeakR = mapper(m_fPeakValue_R);
+	const float mappedPersistentPeakL = mapper(m_persistentPeak_L);
+	const float mappedPersistentPeakR = mapper(m_persistentPeak_R);
+	const float mappedUnity = mapper(1.f);
 
 	painter.save();
 
@@ -375,10 +372,10 @@ void Fader::paintLevels(QPaintEvent* ev, QPainter& painter, bool linear)
 	// Please ensure that "clip starts" is the maximum value and that "ok ends"
 	// is the minimum value and that all other values lie inbetween. Otherwise
 	// there will be warnings when the gradient is defined.
-	const float mappedClipStarts(mapper(dbfsToAmp(0.f)));
-	const float mappedWarnEnd(mapper(dbfsToAmp(-0.01f)));
-	const float mappedWarnStart(mapper(dbfsToAmp(-6.f)));
-	const float mappedOkEnd(mapper(dbfsToAmp(-12.f)));
+	const float mappedClipStarts = mapper(dbfsToAmp(0.f));
+	const float mappedWarnEnd = mapper(dbfsToAmp(-0.01f));
+	const float mappedWarnStart = mapper(dbfsToAmp(-6.f));
+	const float mappedOkEnd = mapper(dbfsToAmp(-12.f));
 
 	// Prepare the gradient for the meters
 	//


### PR DESCRIPTION
GitHub is [removing the macOS 12 build runners](https://github.com/actions/runner-images/issues/10721) on December 3, and is [removing XCode 14 and 16 from macOS 14](https://github.com/actions/runner-images/issues/10703) on November 4 (today!).

This PR:
- Updates our macOS x86-64 build runner from macOS 12 to macOS 13
- Updates our macOS x86-64 XCode version from 13.1 to 15.2
- Updates our macOS ARM64 XCode version from 14.3.1 to 15.4
- Fixes a number of compiler warnings on macOS
  - Note: There are still some `sprintf` deprecation warnings coming from 3rd party libraries, but all usages of `sprintf` in LMMS itself have been converted to `std::snprintf`