### PR TITLE
Cache and interpolate resolutions when drawing sample waveforms

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -36,6 +36,7 @@
 #include "JournallingObject.h"
 #include "MidiClip.h"
 #include "SampleClip.h"
+#include "SampleWaveform.h"
 #include "TimePos.h"
 #include "lmms_basics.h"
 
@@ -233,6 +234,7 @@ private:
 
 	MidiClip* m_ghostNotes = nullptr;
 	QPointer<SampleClip> m_ghostSample = nullptr; // QPointer to set to nullptr on deletion
+	SampleWaveform m_waveform;
 	bool m_renderSample = false;
 
 	void centerTopBottomScroll();

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -26,6 +26,7 @@
 #define LMMS_GUI_SAMPLE_CLIP_VIEW_H
 
 #include "ClipView.h"
+#include "SampleWaveform.h"
 
 namespace lmms
 {
@@ -63,6 +64,7 @@ protected:
 
 private:
 	SampleClip * m_clip;
+	SampleWaveform m_waveform;
 	QPixmap m_paintPixmap;
 	bool splitClip( const TimePos pos ) override;
 } ;

--- a/include/SampleWaveform.h
+++ b/include/SampleWaveform.h
@@ -42,7 +42,8 @@ public:
 	void visualize(QPainter& painter, const QRect& rect,
 		float amplification = 1.0f, bool reversed = false,
 		std::optional<size_t> from = std::nullopt,
-		std::optional<size_t> to = std::nullopt);
+		std::optional<size_t> to = std::nullopt,
+		std::optional<int> clipWidth = std::nullopt);
 	void reset(const SampleFrame* buffer, size_t size);
 
 private:

--- a/include/SampleWaveform.h
+++ b/include/SampleWaveform.h
@@ -26,23 +26,30 @@
 #define LMMS_GUI_SAMPLE_WAVEFORM_H
 
 #include <QPainter>
+#include <optional>
 
-#include "Sample.h"
+#include "SampleFrame.h"
 #include "lmms_export.h"
 
 namespace lmms::gui {
 class LMMS_EXPORT SampleWaveform
 {
 public:
-	struct Parameters
-	{
-		const SampleFrame* buffer;
-		size_t size;
-		float amplification;
-		bool reversed;
-	};
+	SampleWaveform() = default;
+	SampleWaveform(const SampleFrame* buffer, size_t size);
 
-	static void visualize(Parameters parameters, QPainter& painter, const QRect& rect);
+	void generate();
+	void visualize(QPainter& painter, const QRect& rect,
+		float amplification = 1.0f, bool reversed = false,
+		std::optional<size_t> from = std::nullopt,
+		std::optional<size_t> to = std::nullopt);
+	void reset(const SampleFrame* buffer, size_t size);
+
+private:
+	const SampleFrame* m_buffer = nullptr;
+	size_t m_size = 0;
+	std::unordered_map<int, std::vector<float>> m_min;
+	std::unordered_map<int, std::vector<float>> m_max;
 };
 } // namespace lmms::gui
 

--- a/include/SampleWaveform.h
+++ b/include/SampleWaveform.h
@@ -42,8 +42,7 @@ public:
 	void visualize(QPainter& painter, const QRect& rect,
 		float amplification = 1.0f, bool reversed = false,
 		std::optional<size_t> from = std::nullopt,
-		std::optional<size_t> to = std::nullopt,
-		std::optional<int> clipWidth = std::nullopt);
+		std::optional<size_t> to = std::nullopt);
 	void reset(const SampleFrame* buffer, size_t size);
 
 private:

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -210,6 +210,7 @@ void AudioFileProcessorView::dropEvent(QDropEvent* de)
 	}
 
 	m_waveView->updateSampleRange();
+	m_waveView->updateWaveform();
 	Engine::getSong()->setModified();
 	de->accept();
 }
@@ -263,6 +264,7 @@ void AudioFileProcessorView::openAudioFile()
 	castModel<AudioFileProcessor>()->setAudioFile(af);
 	Engine::getSong()->setModified();
 	m_waveView->updateSampleRange();
+	m_waveView->updateWaveform();
 }
 
 void AudioFileProcessorView::modelChanged()

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -26,6 +26,7 @@
 
 #include "ConfigManager.h"
 #include "FontHelper.h"
+#include "Sample.h"
 #include "SampleWaveform.h"
 
 #include <QPainter>
@@ -48,6 +49,8 @@ void AudioFileProcessorWaveView::updateSampleRange()
 		setFrom(m_sample->startFrame() - marging);
 		setTo(m_sample->endFrame() + marging);
 	}
+
+	m_waveform.reset(m_sample->data(), m_sample->sampleSize());
 }
 
 void AudioFileProcessorWaveView::setTo(int to)
@@ -339,12 +342,8 @@ void AudioFileProcessorWaveView::updateGraph()
 	QPainter p(&m_graph);
 	p.setPen(QColor(255, 255, 255));
 	
-	const auto dataOffset = m_reversed ? m_sample->sampleSize() - m_to : m_from;
-
 	const auto rect = QRect{0, 0, m_graph.width(), m_graph.height()};
-	const auto waveform = SampleWaveform::Parameters{
-		m_sample->data() + dataOffset, static_cast<size_t>(range()), m_sample->amplification(), m_sample->reversed()};
-	SampleWaveform::visualize(waveform, p, rect);
+	m_waveform.visualize(p, rect, m_sample->amplification(), m_sample->reversed(), m_from, m_to);
 }
 
 void AudioFileProcessorWaveView::zoom(const bool out)

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -49,7 +49,10 @@ void AudioFileProcessorWaveView::updateSampleRange()
 		setFrom(m_sample->startFrame() - marging);
 		setTo(m_sample->endFrame() + marging);
 	}
+}
 
+void AudioFileProcessorWaveView::updateWaveform()
+{
 	m_waveform.reset(m_sample->data(), m_sample->sampleSize());
 }
 
@@ -92,6 +95,7 @@ AudioFileProcessorWaveView::AudioFileProcessorWaveView(QWidget* parent, int w, i
 	configureKnobRelationsAndWaveViews();
 
 	updateSampleRange();
+	updateWaveform();
 
 	m_graph.fill(Qt::transparent);
 	update();

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -155,6 +155,7 @@ public:
 
 
 	void updateSampleRange();
+	void updateWaveform();
 private:
 	void setTo(int to);
 	void setFrom(int from);

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -27,6 +27,7 @@
 
 
 #include "Knob.h"
+#include "SampleWaveform.h"
 
 
 namespace lmms
@@ -126,6 +127,7 @@ private:
 	} ;
 
 	Sample const* m_sample;
+	SampleWaveform m_waveform;
 	QPixmap m_graph;
 	int m_from;
 	int m_to;

--- a/plugins/SlicerT/SlicerTWaveform.h
+++ b/plugins/SlicerT/SlicerTWaveform.h
@@ -31,6 +31,7 @@
 #include <QInputDialog>
 #include <QMouseEvent>
 #include <QPainter>
+#include "SampleWaveform.h"
 
 namespace lmms {
 
@@ -44,6 +45,7 @@ class SlicerTWaveform : public QWidget
 
 public slots:
 	void updateUI();
+	void updateWaveform();
 	void isPlaying(float current, float start, float end);
 
 public:
@@ -112,6 +114,9 @@ private:
 	SlicerT* m_slicerTParent;
 
 	QElapsedTimer m_updateTimer;
+
+	SampleWaveform m_waveform;
+
 	void drawSeekerWaveform();
 	void drawSeeker();
 	void drawEditorWaveform();

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -68,14 +68,13 @@ void SampleWaveform::generate()
 }
 
 void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float amplification, bool reversed,
-	std::optional<size_t> from, std::optional<size_t> to, std::optional<int> clipWidth)
+	std::optional<size_t> from, std::optional<size_t> to)
 {
 	if (!m_buffer || m_size == 0) { return; }
 
 	const auto sampleBegin = from.has_value() ? from.value() : 0;
 	const auto sampleEnd = to.has_value() ? to.value() : m_size;
-	const auto sampleRange = sampleEnd - sampleBegin;
-	const auto samplesPerPixel = std::max(1, static_cast<int>(sampleRange) / rect.width());
+	const auto samplesPerPixel = std::max(1, static_cast<int>(sampleEnd - sampleBegin) / rect.width());
 
 	const auto downsampledLevelLow = static_cast<int>(std::log2(samplesPerPixel));
 	const auto downsampledLevelHigh = static_cast<int>(std::ceil(std::log2(samplesPerPixel)));
@@ -89,9 +88,8 @@ void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float ampli
 
 	const auto centerY = rect.center().y();
 	const auto centerHeight = rect.height() / 2.0f;
-	const auto maxWidth = clipWidth.has_value() ? clipWidth.value() : rect.width();
 
-	for (auto i = 0; i < maxWidth; ++i)
+	for (auto i = 0; i < rect.width(); ++i)
 	{	
 		const auto index = static_cast<float>(i * samplesPerPixel);
 		const auto lowIndex = static_cast<int>(std::floor(index / downsampledFactorLow));
@@ -102,7 +100,7 @@ void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float ampli
 
 		const auto lineMin = centerY - minPeak * centerHeight * amplification;
 		const auto lineMax = centerY - maxPeak * centerHeight * amplification;
-		const auto lineX = reversed ? maxWidth - i : i;
+		const auto lineX = rect.x() + (reversed ? rect.width() - i : i);
 		painter.drawLine(lineX, lineMax, lineX, lineMin);
 	}
 }

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -72,8 +72,8 @@ void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float ampli
 {
 	if (!m_buffer || m_size == 0) { return; }
 
-	const auto sampleBegin = from.has_value() ? from.value() : 0;
-	const auto sampleEnd = to.has_value() ? to.value() : m_size;
+	const auto sampleBegin = from.value_or(0);
+	const auto sampleEnd = to.value_or(m_size);
 	const auto samplesPerPixel = std::max(1, static_cast<int>(sampleEnd - sampleBegin) / rect.width());
 
 	const auto downsampledLevelLow = static_cast<int>(std::log2(samplesPerPixel));

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -67,7 +67,8 @@ void SampleWaveform::generate()
 	}
 }
 
-void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float amplification, bool reversed, std::optional<size_t> from, std::optional<size_t> to)
+void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float amplification, bool reversed,
+	std::optional<size_t> from, std::optional<size_t> to, std::optional<int> clipWidth)
 {
 	if (!m_buffer || m_size == 0) { return; }
 
@@ -88,8 +89,9 @@ void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float ampli
 
 	const auto centerY = rect.center().y();
 	const auto centerHeight = rect.height() / 2.0f;
+	const auto maxWidth = clipWidth.has_value() ? clipWidth.value() : rect.width();
 
-	for (auto i = 0; i < rect.width(); ++i)
+	for (auto i = 0; i < maxWidth; ++i)
 	{	
 		const auto index = static_cast<float>(i * samplesPerPixel);
 		const auto lowIndex = static_cast<int>(std::floor(index / downsampledFactorLow));
@@ -100,7 +102,7 @@ void SampleWaveform::visualize(QPainter& painter, const QRect& rect, float ampli
 
 		const auto lineMin = centerY - minPeak * centerHeight * amplification;
 		const auto lineMax = centerY - maxPeak * centerHeight * amplification;
-		const auto lineX = rect.x() + static_cast<int>(i);
+		const auto lineX = reversed ? maxWidth - i : i;
 		painter.drawLine(lineX, lineMax, lineX, lineMin);
 	}
 }

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -274,7 +274,8 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	QRect r = QRect( offset, spacing,
 			qMax( static_cast<int>( m_clip->sampleLength() * ppb / ticksPerBar ), 1 ), rect().bottom() - 2 * spacing );
 
-	m_waveform.visualize(p, r);
+	const auto& sample = m_clip->sample();
+	m_waveform.visualize(p, r, sample.amplification(), sample.reversed(), std::nullopt, std::nullopt, width());
 
 	QString name = PathUtil::cleanName(m_clip->m_sample.sampleFile());
 	paintTextLabel(name, p);

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -275,7 +275,7 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 			qMax( static_cast<int>( m_clip->sampleLength() * ppb / ticksPerBar ), 1 ), rect().bottom() - 2 * spacing );
 
 	const auto& sample = m_clip->sample();
-	m_waveform.visualize(p, r, sample.amplification(), sample.reversed(), std::nullopt, std::nullopt, width());
+	m_waveform.visualize(p, r, sample.amplification(), sample.reversed());
 
 	QString name = PathUtil::cleanName(m_clip->m_sample.sampleFile());
 	paintTextLabel(name, p);

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -61,6 +61,8 @@ SampleClipView::SampleClipView( SampleClip * _clip, TrackView * _tv ) :
 void SampleClipView::updateSample()
 {
 	update();
+	m_waveform.reset(m_clip->m_sample.data(), m_clip->m_sample.sampleSize());
+
 	// set tooltip to filename so that user can see what sample this
 	// sample-clip contains
 	setToolTip(
@@ -272,9 +274,7 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	QRect r = QRect( offset, spacing,
 			qMax( static_cast<int>( m_clip->sampleLength() * ppb / ticksPerBar ), 1 ), rect().bottom() - 2 * spacing );
 
-	const auto& sample = m_clip->m_sample;
-	const auto waveform = SampleWaveform::Parameters{sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
-	SampleWaveform::visualize(waveform, p, r);
+	m_waveform.visualize(p, r);
 
 	QString name = PathUtil::cleanName(m_clip->m_sample.sampleFile());
 	paintTextLabel(name, p);

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1025,6 +1025,7 @@ void AutomationEditor::setGhostSample(SampleClip* newGhostSample)
 	// Expects a pointer to a Sample buffer or nullptr.
 	m_ghostSample = newGhostSample;
 	m_renderSample = true;
+	m_waveform.reset(newGhostSample->sample().data(), newGhostSample->sample().sampleSize());
 }
 
 void AutomationEditor::paintEvent(QPaintEvent * pe )
@@ -1217,12 +1218,10 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 			int yOffset = (editorHeight - sampleHeight) / 2.0f + TOP_MARGIN;
 
 			p.setPen(m_ghostSampleColor);
-			
-			const auto& sample = m_ghostSample->sample();
-			const auto waveform = SampleWaveform::Parameters{
-				sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
+
 			const auto rect = QRect(startPos, yOffset, sampleWidth, sampleHeight);
-			SampleWaveform::visualize(waveform, p, rect);
+			const auto& sample = m_ghostSample->sample();
+			m_waveform.visualize(p, rect, sample.amplification(), sample.reversed());
 		}
 
 		// draw ghost notes


### PR DESCRIPTION
This PR is meant to improve performance when drawing sample waveforms by:
1. Caching multiple waveform resolutions that are decimated in logarithms (currently by powers of 2)
2. Interpolating between the cached waveform resolutions to get the resolution necessary for the current zoom level (currently done using linear interpolation)

That's about it. I do want to note that when stretching sample clips vertically and using continuous scrolling, there is still a major drop in performance due to the drawing that's being done on the CPU. In the future, we should migrate such drawing to be done by the GPU using something like OpenGL.

Below is an attachment for the results of `perf` when sampling cycles in the scenario stated above: as shown, most of the overhead in this case lies within the Qt library itself, more specifically its software rasterization that is done on the CPU.
![image](https://github.com/user-attachments/assets/597cdf84-5116-4317-affa-89c7ac0717f7)

I have also omitted RMS calculations from the waveform visualization since most DAWs (and now even Audacity when using default settings) don't consider this, and I wanted to prioritize more performance.