### PR TITLE
Filedialog Enhancements

### DIFF
--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -26,7 +26,6 @@
 #define LMMS_GUI_FILE_DIALOG_H
 
 #include <QFileDialog>
-
 #include "lmms_export.h"
 
 namespace lmms::gui
@@ -37,20 +36,48 @@ class LMMS_EXPORT FileDialog : public QFileDialog
 {
 	Q_OBJECT
 public:
+
+	enum Operation {
+		OpBegin = 0, // This variant is purely for looping conveviences.
+		OpGeneric = OpBegin,
+		OpProject,
+		OpMidi,
+		OpPreset,
+		OpPlugin,
+		OpSample,
+		OpSong,
+		OpEnd, // This variant is purely for looping conveviences
+	};
+
 	explicit FileDialog( QWidget *parent = 0, const QString &caption = QString(),
 						const QString &directory = QString(),
-						const QString &filter = QString() );
+						const QString &filter = QString(),
+						const Operation operation = OpGeneric);
+
+	~FileDialog();
 
 	static QString getExistingDirectory(QWidget *parent,
 										const QString &caption,
 										const QString &directory,
-										QFileDialog::Options options = QFileDialog::ShowDirsOnly);
+										QFileDialog::Options options = QFileDialog::ShowDirsOnly,
+										const Operation operation = OpGeneric);
     static QString getOpenFileName(QWidget *parent = 0,
 									const QString &caption = QString(),
 									const QString &directory = QString(),
 									const QString &filter = QString(),
-									QString *selectedFilter = 0);
+									QString *selectedFilter = 0,
+									const Operation operation = OpGeneric);
 	void clearSelection();
+
+private:
+	Operation operation;
+
+	static std::vector<QString> OperationPaths;
+	static bool OperationPathsReady;
+	static void prepareOperationPaths();
+	// If existing path is not empty, getOperationPath returns it instead.
+	static QString getOperationPath(const enum Operation op, const QString& existing);
+	static void setOperationPath(const enum Operation op, const QString& path);
 };
 
 

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -1033,7 +1033,7 @@ void GigInstrumentView::showFileDialog()
 {
 	auto k = castModel<GigInstrument>();
 
-	FileDialog ofd( nullptr, tr( "Open GIG file" ) );
+	FileDialog ofd( nullptr, tr( "Open GIG file" ), "", "", FileDialog::Operation::OpSample );
 	ofd.setFileMode( FileDialog::ExistingFiles );
 
 	QStringList types;

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -490,7 +490,7 @@ PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 
 void PatmanView::openFile()
 {
-	FileDialog ofd( nullptr, tr( "Open patch file" ) );
+	FileDialog ofd( nullptr, tr( "Open patch file" ), "", "", FileDialog::Operation::OpSample);
 	ofd.setFileMode( FileDialog::ExistingFiles );
 
 	QStringList types;

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -211,7 +211,7 @@ Sf2Instrument::Sf2Instrument( InstrumentTrack * _instrument_track ) :
 	connect( &m_chorusLevel, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusSpeed, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
 	connect( &m_chorusDepth, SIGNAL( dataChanged() ), this, SLOT( updateChorus() ) );
-	
+
 	// Microtuning
 	connect(Engine::getSong(), &Song::scaleListChanged, this, &Sf2Instrument::updateTuning);
 	connect(Engine::getSong(), &Song::keymapListChanged, this, &Sf2Instrument::updateTuning);
@@ -1200,7 +1200,7 @@ void Sf2InstrumentView::showFileDialog()
 {
 	auto k = castModel<Sf2Instrument>();
 
-	FileDialog ofd( nullptr, tr( "Open SoundFont file" ) );
+	FileDialog ofd( nullptr, tr( "Open SoundFont file" ), "", "", FileDialog::Operation::OpPreset );
 	ofd.setFileMode( FileDialog::ExistingFiles );
 
 	QStringList types;

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -665,7 +665,7 @@ void VestigeInstrumentView::modelChanged()
 
 void VestigeInstrumentView::openPlugin()
 {
-	FileDialog ofd( nullptr, tr( "Open VST plugin" ) );
+	FileDialog ofd( nullptr, tr( "Open VST plugin" ) , "", "", FileDialog::Operation::OpPlugin);
 
 	// set filters
 	QStringList types;

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -504,7 +504,7 @@ QWidget *VstPlugin::editor()
 
 void VstPlugin::openPreset()
 {
-	gui::FileDialog ofd(nullptr, tr("Open Preset"), "", tr("VST Plugin Preset (*.fxp *.fxb)"));
+	gui::FileDialog ofd(nullptr, tr("Open Preset"), "", tr("VST Plugin Preset (*.fxp *.fxb)"), gui::FileDialog::Operation::OpPlugin);
 	ofd.setFileMode(gui::FileDialog::ExistingFiles);
 	if (ofd.exec() == QDialog::Accepted && !ofd.selectedFiles().isEmpty())
 	{

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -757,9 +757,8 @@ void MainWindow::openProject()
 {
 	if( mayChangeProject(false) )
 	{
-		FileDialog ofd( this, tr( "Open Project" ), "", tr( "LMMS (*.mmp *.mmpz)" ) );
+		FileDialog ofd( this, tr( "Open Project" ), "", tr( "LMMS (*.mmp *.mmpz)" ), FileDialog::Operation::OpProject );
 
-		ofd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 		ofd.setFileMode( FileDialog::ExistingFiles );
 		if( ofd.exec () == QDialog::Accepted &&
 						!ofd.selectedFiles().isEmpty() )
@@ -1087,7 +1086,7 @@ void MainWindow::updateViewMenu()
 		);
 
 	m_viewMenu->addSeparator();
-	
+
 	m_viewMenu->addAction(embed::getIconPixmap( "fullscreen" ),
 				tr( "Fullscreen" ) + "\tF11",
 				this, SLOT(toggleFullscreen())
@@ -1403,7 +1402,7 @@ void MainWindow::autoSave()
 
 void MainWindow::onExportProjectMidi()
 {
-	FileDialog efd( this );
+	FileDialog efd( this, "Export Project", "", "", FileDialog::Operation::OpMidi);
 
 	efd.setFileMode( FileDialog::AnyFile );
 
@@ -1419,7 +1418,6 @@ void MainWindow::onExportProjectMidi()
 	}
 	else
 	{
-		efd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 		base_filename = tr( "untitled" );
 	}
 	efd.selectFile( base_filename + ".mid" );
@@ -1444,16 +1442,12 @@ void MainWindow::exportProject(bool multiExport)
 {
 	QString const & projectFileName = Engine::getSong()->projectFileName();
 
-	FileDialog efd( getGUI()->mainWindow() );
+	FileDialog efd( getGUI()->mainWindow(), "", "", "", FileDialog::Operation::OpSong);
 
 	if ( multiExport )
 	{
 		efd.setFileMode( FileDialog::Directory);
 		efd.setWindowTitle( tr( "Select directory for writing exported tracks..." ) );
-		if( !projectFileName.isEmpty() )
-		{
-			efd.setDirectory( QFileInfo( projectFileName ).absolutePath() );
-		}
 	}
 	else
 	{
@@ -1471,12 +1465,10 @@ void MainWindow::exportProject(bool multiExport)
 		QString baseFilename;
 		if( !projectFileName.isEmpty() )
 		{
-			efd.setDirectory( QFileInfo( projectFileName ).absolutePath() );
 			baseFilename = QFileInfo( projectFileName ).completeBaseName();
 		}
 		else
 		{
-			efd.setDirectory( ConfigManager::inst()->userProjectsDir() );
 			baseFilename = tr( "untitled" );
 		}
 		efd.selectFile( baseFilename + ProjectRenderer::fileEncodeDevices[0].m_extension );
@@ -1575,13 +1567,15 @@ void MainWindow::onImportProject()
 	if (song)
 	{
 		FileDialog ofd( nullptr, tr( "Import file" ),
-				ConfigManager::inst()->userProjectsDir(),
+				"",
 				tr("MIDI sequences") +
 				" (*.mid *.midi *.rmi);;" +
 				tr("Hydrogen projects") +
 				" (*.h2song);;" +
 				tr("All file types") +
-				" (*.*)");
+				" (*.*)",
+				FileDialog::Operation::OpProject
+		);
 
 		ofd.setFileMode( FileDialog::ExistingFiles );
 		if( ofd.exec () == QDialog::Accepted && !ofd.selectedFiles().isEmpty() )

--- a/src/gui/SampleLoader.cpp
+++ b/src/gui/SampleLoader.cpp
@@ -38,11 +38,8 @@
 namespace lmms::gui {
 QString SampleLoader::openAudioFile(const QString& previousFile)
 {
-	auto openFileDialog = FileDialog(nullptr, QObject::tr("Open audio file"));
-	auto dir = !previousFile.isEmpty() ? PathUtil::toAbsolute(previousFile) : ConfigManager::inst()->userSamplesDir();
-
-	// change dir to position of previously opened file
-	openFileDialog.setDirectory(dir);
+	auto dir = !previousFile.isEmpty() ? PathUtil::toAbsolute(previousFile) : "";
+	auto openFileDialog = FileDialog(nullptr, QObject::tr("Open audio file"), dir, "", FileDialog::Operation::OpSample);
 	openFileDialog.setFileMode(FileDialog::ExistingFiles);
 
 	// set filters

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -21,7 +21,7 @@
  * Boston, MA 02110-1301 USA.
  *
  */
- 
+
 #include "SampleClipView.h"
 
 #include <QApplication>
@@ -180,10 +180,10 @@ void SampleClipView::mouseReleaseEvent(QMouseEvent *_me)
 
 void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 {
-	const QString selectedAudioFile = SampleLoader::openAudioFile();
+	const QString selectedAudioFile = SampleLoader::openAudioFile(m_clip ? m_clip->sample().sampleFile() : QString());
 
 	if (selectedAudioFile.isEmpty()) { return; }
-	
+
 	if (m_clip->hasSampleFileLoaded(selectedAudioFile))
 	{
 		m_clip->changeLengthToSampleLength();

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -413,7 +413,7 @@ void InstrumentTrackWindow::modelChanged()
 
 void InstrumentTrackWindow::saveSettingsBtnClicked()
 {
-	FileDialog sfd(this, tr("Save preset"), "", tr("XML preset file (*.xpf)"));
+	FileDialog sfd(this, tr("Save preset"), "", tr("XML preset file (*.xpf)"), FileDialog::Operation::OpPreset);
 
 	QString presetRoot = ConfigManager::inst()->userPresetsDir();
 	if(!QDir(presetRoot).exists())

--- a/src/gui/modals/FileDialog.cpp
+++ b/src/gui/modals/FileDialog.cpp
@@ -135,6 +135,7 @@ QString FileDialog::getOperationPath(const FileDialog::Operation op, const QStri
 			return OperationPaths[i];
 		}
 	}
+
 	return OperationPaths[OpGeneric];
 }
 
@@ -145,6 +146,7 @@ void FileDialog::setOperationPath(const FileDialog::Operation op, const QString&
 		if (i == op)
 		{
 			OperationPaths[i] = path;
+			return;
 		}
 	}
 }

--- a/src/gui/modals/VersionedSaveDialog.cpp
+++ b/src/gui/modals/VersionedSaveDialog.cpp
@@ -31,6 +31,7 @@
 
 #include "DeprecationHelper.h"
 #include "VersionedSaveDialog.h"
+#include "FileDialog.h"
 #include "LedCheckBox.h"
 
 
@@ -43,7 +44,7 @@ VersionedSaveDialog::VersionedSaveDialog( QWidget *parent,
 										  const QString &caption,
 										  const QString &directory,
 										  const QString &filter ) :
-	FileDialog(parent, caption, directory, filter)
+	FileDialog(parent, caption, directory, filter, FileDialog::Operation::OpProject)
 {
 	setAcceptMode( QFileDialog::AcceptSave );
 	setFileMode( QFileDialog::AnyFile );


### PR DESCRIPTION
This PR attempts to improve the File Dialog UX by doing the following things:

- [x] Remember the bookmarks in the QT file picker (See https://github.com/LMMS/lmms/issues/7405). Any code that modifies the bookmarks have been removed in this PR as this should be left to the user's choice.
- [x] Remember the last opened directory for:
    - Project files
    - Midi files
    - Presets
    - VST plugins
    - Samples
    - Song export
    - Other file types

- [ ] Remember the last opened directories above across different LMMS sessions.