### PR TITLE
Fix corruption crash when zooming on a large sample

### DIFF
--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -49,7 +49,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	auto max = std::vector<float>(numPixels, -1);
 	auto squared = std::vector<float>(numPixels, 0);
 
-	const size_t maxFrames = static_cast<size_t>(numPixels * framesPerPixel);
+	const size_t maxFrames = numPixels * static_cast<size_t>(framesPerPixel);
 
 	auto pixelIndex = std::size_t{0};
 
@@ -66,7 +66,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 		squared[pixelIndex] += value * value;
 	}
-	
+
 	if (pixelIndex < numPixels)
 	{
 		numPixels = pixelIndex;


### PR DESCRIPTION
Fixes #7576

Bug is very weird, so is PR.

I'd like to hear if there is a more solid fix.