### PR TITLE
Transport buttons midi assignable

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -522,7 +522,12 @@ QToolButton#stopButton {
 
 /* all tool buttons */
 
-QToolButton, QToolButton::menu-button {
+lmms--gui--TransportButton {
+	width: 27px;
+	height: 27px;
+}
+
+lmms--gui--TransportButton, QToolButton, QToolButton::menu-button {
 	padding: 1px 1px 1px 1px;
 	border-radius: 5px;
 	border: 1px solid rgba(63, 63, 63, 128);
@@ -531,12 +536,12 @@ QToolButton, QToolButton::menu-button {
 	color: black;
 }
 
-QToolButton:hover {
+lmms--gui--TransportButton:hover, QToolButton:hover {
 	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #c0cdd3, stop:1 #71797d);
 	color: white;
 }
 
-QToolButton:pressed {
+lmms--gui--TransportButton:pressed, QToolButton:pressed {
 	background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #969696, stop:0.5 #c9c9c9, stop:1 #969696 );
 	padding: 2px 1px 0px 1px;
 	color: white;

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -533,7 +533,12 @@ QToolBar::separator {
 
 /* all tool buttons */
 
-QToolButton, QToolButton::menu-button {
+lmms--gui--TransportButton {
+	width: 27px;
+	height: 27px;
+}
+
+lmms--gui--TransportButton, QToolButton, QToolButton::menu-button {
 	margin: 1px;
 	padding: 2px 2px 2px 2px;
 	border-top: 1px solid #778394;
@@ -544,7 +549,7 @@ QToolButton, QToolButton::menu-button {
 	color: #fff;
 }
 
-QToolButton:hover {
+lmms--gui--TransportButton:hover, QToolButton:hover {
 	border-top: 1px solid #909eb3;
 	border-bottom: 1px solid #1e2226;
 	border-radius: 2px;
@@ -557,7 +562,7 @@ QToolButton:hover:checked {
 	background: qlineargradient(spread:reflect, x1:0, y1:0, x2:0, y2:1, stop:0 #292d33, stop:1 #22262c)
 }
 
-QToolButton:pressed {
+lmms--gui--TransportButton:pressed, QToolButton:pressed {
 	border-top: 1px solid #778394;
 	border-bottom: 1px solid #1e2226;
 	border-radius: 2px;

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -27,6 +27,7 @@
 
 #include <QMainWindow>
 #include <QToolBar>
+#include <QWidgetAction>
 
 class QAction;
 
@@ -86,11 +87,11 @@ protected:
 
 	DropToolBar* m_toolBar;
 
-	QAction* m_playAction;
-	QAction* m_recordAction;
-	QAction* m_recordAccompanyAction;
+	QWidgetAction* m_playAction;
+	QWidgetAction* m_recordAction;
+	QWidgetAction* m_recordAccompanyAction;
 	QAction* m_toggleStepRecordingAction;
-	QAction* m_stopAction;
+	QWidgetAction* m_stopAction;
 };
 
 

--- a/include/TransportButton.h
+++ b/include/TransportButton.h
@@ -20,6 +20,6 @@ protected:
 	void contextMenuEvent( QContextMenuEvent * _me ) override;
 } ;
 
-}
+} // namespace lmms::gui
 
 #endif // TRANSPORTBUTTON_H

--- a/include/TransportButton.h
+++ b/include/TransportButton.h
@@ -1,0 +1,25 @@
+#ifndef TRANSPORTBUTTON_H
+#define TRANSPORTBUTTON_H
+
+#include "AutomatableButton.h"
+
+namespace lmms::gui
+{
+
+class LMMS_EXPORT TransportButton : public AutomatableButton
+{
+	Q_OBJECT
+public:
+	TransportButton( QWidget * _parent,
+					const QString & _name = QString() );
+	~TransportButton() override = default;
+
+protected:
+	void mousePressEvent( QMouseEvent * _me ) override;
+	void mouseReleaseEvent( QMouseEvent * _me ) override;
+	void contextMenuEvent( QContextMenuEvent * _me ) override;
+} ;
+
+}
+
+#endif // TRANSPORTBUTTON_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -128,6 +128,7 @@ SET(LMMS_SRCS
 	gui/widgets/TextFloat.cpp
 	gui/widgets/TimeDisplayWidget.cpp
 	gui/widgets/ToolButton.cpp
+	gui/widgets/TransportButton.cpp
 
 	PARENT_SCOPE
 )

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -27,6 +27,7 @@
 #include "GuiApplication.h"
 #include "MainWindow.h"
 #include "Song.h"
+#include "TransportButton.h"
 
 #include "embed.h"
 
@@ -41,11 +42,13 @@ namespace lmms::gui
 
 void Editor::setPauseIcon(bool displayPauseIcon)
 {
+	QPushButton* widget = static_cast<QPushButton*> (m_playAction->defaultWidget());
+
 	// If we're playing, show a pause icon
 	if (displayPauseIcon)
-		m_playAction->setIcon(embed::getIconPixmap("pause"));
+		widget->setIcon(embed::getIconPixmap("pause"));
 	else
-		m_playAction->setIcon(embed::getIconPixmap("play"));
+		widget->setIcon(embed::getIconPixmap("play"));
 }
 
 DropToolBar * Editor::addDropToolBarToTop(QString const & windowTitle)
@@ -103,12 +106,23 @@ Editor::Editor(bool record, bool stepRecord) :
 		m_toolBar->widgetForAction(action)->setObjectName(objectName);
 	};
 
-	// Set up play and record actions
-	m_playAction = new QAction(embed::getIconPixmap("play"), tr("Play (Space)"), this);
-	m_stopAction = new QAction(embed::getIconPixmap("stop"), tr("Stop (Space)"), this);
+	auto addTransportButton = [this](QWidgetAction* action, QString objectName,const char* icon,
+										const char* tooltip,QString menuName)
+	{
+		TransportButton* widget = new TransportButton(nullptr,menuName);
+		widget->setIcon(embed::getIconPixmap(icon));
+		widget->setToolTip(tr(tooltip));
+		action->setDefaultWidget(widget);
+		connect(widget, SIGNAL(toggled(bool)), action, SIGNAL(triggered()));
+		m_toolBar->addAction(action);
+		m_toolBar->widgetForAction(action)->setObjectName(objectName);
+	};
 
-	m_recordAction = new QAction(embed::getIconPixmap("record"), tr("Record"), this);
-	m_recordAccompanyAction = new QAction(embed::getIconPixmap("record_accompany"), tr("Record while playing"), this);
+	// Set up play and record actions
+	m_playAction = new QWidgetAction( this);
+	m_stopAction = new QWidgetAction(this);
+	m_recordAction = new QWidgetAction(this);
+	m_recordAccompanyAction=new QWidgetAction(this);
 	m_toggleStepRecordingAction = new QAction(embed::getIconPixmap("record_step_off"), tr("Toggle Step Recording"), this);
 
 	// Set up connections
@@ -122,17 +136,18 @@ Editor::Editor(bool record, bool stepRecord) :
 	new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_F11), this, SLOT(toggleMaximize()));
 
 	// Add actions to toolbar
-	addButton(m_playAction, "playButton");
+	addTransportButton(m_playAction,"playButton","play","Play (Space)","Play");
 	if (record)
 	{
-		addButton(m_recordAction, "recordButton");
-		addButton(m_recordAccompanyAction, "recordAccompanyButton");
+		addTransportButton(m_recordAction,"recordButton","record","Record","Record");
+		addTransportButton(m_recordAccompanyAction,"recordAccompanyButton","record_accompany",
+							 "Record while playing","Record while playing");
 	}
-	if(stepRecord)
+	if (stepRecord)
 	{
 		addButton(m_toggleStepRecordingAction, "stepRecordButton");
 	}
-	addButton(m_stopAction, "stopButton");
+	addTransportButton(m_stopAction,"stopButton","stop","Stop (Space)","Stop");
 }
 
 QAction *Editor::playAction() const

--- a/src/gui/widgets/TransportButton.cpp
+++ b/src/gui/widgets/TransportButton.cpp
@@ -1,0 +1,79 @@
+#include "TransportButton.h"
+
+#include <QMouseEvent>
+
+#include "ControllerConnection.h"
+#include "CaptionMenu.h"
+#include "embed.h"
+
+namespace lmms::gui
+{
+
+TransportButton::TransportButton(QWidget * _parent, const QString & _name) :
+	AutomatableButton(_parent, _name)
+{
+	setCheckable(true);
+	model()->setStrictStepSize(true);
+}
+
+
+void TransportButton::mousePressEvent(QMouseEvent * _me)
+{
+	if (_me->button() == Qt::LeftButton)
+	{
+		toggle();
+	}
+	QPushButton::mousePressEvent(_me);
+}
+
+void TransportButton::mouseReleaseEvent(QMouseEvent * _me)
+{
+	if (_me)
+	{
+		QPushButton::mouseReleaseEvent(_me);
+	}
+}
+
+void TransportButton::contextMenuEvent(QContextMenuEvent * _me)
+{
+	// for the case, the user clicked right while pressing left mouse-
+	// button, the context-menu appears while mouse-cursor is still hidden
+	// and it isn't shown again until user does something which causes
+	// an QApplication::restoreOverrideCursor()-call...
+	mouseReleaseEvent(nullptr);
+
+	CaptionMenu contextMenu(this->model()->displayName());
+	AutomatableModel* model = modelUntyped();
+	auto amvSlots = new AutomatableModelViewSlots(this, &contextMenu);
+	QString controllerTxt;
+	if (model->controllerConnection())
+	{
+		Controller* cont = model->controllerConnection()->getController();
+		if (cont)
+		{
+			controllerTxt = AutomatableModel::tr("Connected to %1").arg(cont->name());
+		}
+		else
+		{
+			controllerTxt = AutomatableModel::tr("Connected to controller");
+		}
+
+		QMenu* contMenu = contextMenu.addMenu(embed::getIconPixmap("controller"), controllerTxt);
+
+		contMenu->addAction(embed::getIconPixmap("controller"),
+								AutomatableModel::tr("Edit connection..."),
+								amvSlots, SLOT(execConnectionDialog()));
+		contMenu->addAction(embed::getIconPixmap( "cancel" ),
+								AutomatableModel::tr("Remove connection"),
+								amvSlots, SLOT(removeConnection()));
+	}
+	else
+	{
+		contextMenu.addAction( embed::getIconPixmap("controller"),
+							AutomatableModel::tr("Connect to controller..."),
+							amvSlots, SLOT(execConnectionDialog()));
+	}
+	contextMenu.exec(QCursor::pos());
+}
+
+}

--- a/src/gui/widgets/TransportButton.cpp
+++ b/src/gui/widgets/TransportButton.cpp
@@ -19,10 +19,6 @@ TransportButton::TransportButton(QWidget * _parent, const QString & _name) :
 
 void TransportButton::mousePressEvent(QMouseEvent * _me)
 {
-	if (_me->button() == Qt::LeftButton)
-	{
-		toggle();
-	}
 	QPushButton::mousePressEvent(_me);
 }
 
@@ -76,4 +72,4 @@ void TransportButton::contextMenuEvent(QContextMenuEvent * _me)
 	contextMenu.exec(QCursor::pos());
 }
 
-}
+} // namespace lmms::gui


### PR DESCRIPTION
Implementation of #1071 consolidated in #1472.
Subclassed AutomatableButton as TransportButton for stripping out functions not pertinent to transport buttons.
Made it checkable to leverage the toggled() signal and allow buttons activation in both directions of the midi controller, otherwise you have to move the midi controller to the original position before activating it again.
Changed the toolbar buttons from QAction to QWidgetAction and set TransportButton as the widget.
Updated themes styles for new buttons.