### PR TITLE
Detach windows

### DIFF
--- a/data/themes/default/window.svg
+++ b/data/themes/default/window.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16mm"
+   height="16mm"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="window.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="5.2756058"
+     inkscape:cy="35.983984"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="2517"
+     inkscape:window-height="1407"
+     inkscape:window-x="43"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="false"
+     inkscape:snap-to-guides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4546"
+       snapvisiblegridlinesonly="true"
+       visible="true"
+       enabled="true"
+       dotted="false"
+       empspacing="5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-281)">
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.88672155;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4548"
+       width="13.758334"
+       height="0.79373622"
+       x="1.0583321"
+       y="-284.98651"
+       transform="scale(1,-1)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.88672161;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4548-3"
+       width="13.758334"
+       height="0.79373622"
+       x="1.058333"
+       y="-294.77612"
+       transform="scale(1,-1)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.73265666;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4548-3-6"
+       width="9.3927393"
+       height="0.79373622"
+       x="284.72195"
+       y="1.0583333"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.73265666;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4548-3-6-7"
+       width="9.3927393"
+       height="0.79373622"
+       x="284.85422"
+       y="14.02293"
+       transform="matrix(0,1,1,0,0,0)" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.88672161;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4548-5"
+       width="13.758334"
+       height="0.79373622"
+       x="1.0583333"
+       y="-286.83859"
+       transform="scale(1,-1)" />
+  </g>
+</svg>

--- a/include/ControllerDialog.h
+++ b/include/ControllerDialog.h
@@ -26,8 +26,7 @@
 #ifndef LMMS_GUI_CONTROLLER_DIALOG_H
 #define LMMS_GUI_CONTROLLER_DIALOG_H
 
-#include <QWidget>
-
+#include "DetachableWidget.h"
 #include "ModelView.h"
 
 namespace lmms
@@ -38,24 +37,12 @@ class Controller;
 namespace gui
 {
 
-class ControllerDialog : public QWidget, public ModelView
+class ControllerDialog : public DetachableWidget, public ModelView
 {
-    Q_OBJECT
 public:
-	ControllerDialog( Controller * _controller, QWidget * _parent );
-
+	ControllerDialog(Controller* controller, QWidget* parent);
 	~ControllerDialog() override = default;
-
-
-signals:
-	void closed();
-
-
-protected:
-	void closeEvent( QCloseEvent * _ce ) override;
-
-} ;
-
+};
 
 } // namespace gui
 

--- a/include/ControllerRackView.h
+++ b/include/ControllerRackView.h
@@ -25,17 +25,13 @@
 #ifndef LMMS_GUI_CONTROLLER_RACK_VIEW_H
 #define LMMS_GUI_CONTROLLER_RACK_VIEW_H
 
-#include <QWidget>
-#include <QCloseEvent>
-
+#include "DetachableWidget.h"
 #include "SerializingObject.h"
 #include "lmms_basics.h"
-
 
 class QPushButton;
 class QScrollArea;
 class QVBoxLayout;
-
 
 namespace lmms
 {
@@ -47,8 +43,7 @@ namespace gui
 
 class ControllerView;
 
-
-class ControllerRackView : public QWidget, public SerializingObject
+class ControllerRackView : public DetachableWidget, public SerializingObject
 {
 	Q_OBJECT
 public:
@@ -70,9 +65,6 @@ public slots:
 	void moveDown(ControllerView* view);
 	void addController(Controller* controller);
 	void removeController(Controller* controller);
-
-protected:
-	void closeEvent( QCloseEvent * _ce ) override;
 
 private slots:
 	void addController();

--- a/include/DetachableWidget.h
+++ b/include/DetachableWidget.h
@@ -1,8 +1,8 @@
 /*
- * EffectControlDialog.h - base-class for effect-dialogs for displaying and
- *                         editing control port values
+ * DetachableWidget.h - Allows a widget to be detached from
+ *                      LMMS's main window
  *
- * Copyright (c) 2006-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2023 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -23,34 +23,25 @@
  *
  */
 
-#ifndef LMMS_GUI_EFFECT_CONTROL_DIALOG_H
-#define LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+#ifndef LMMS_GUI_DETACHABLE_WIDGET
+#define LMMS_GUI_DETACHABLE_WIDGET
 
-#include "DetachableWidget.h"
-#include "ModelView.h"
+#include <QWidget>
 
-namespace lmms
+namespace lmms::gui {
+
+class DetachableWidget : public QWidget
 {
-
-class EffectControls;
-
-namespace gui
-{
-
-class LMMS_EXPORT EffectControlDialog : public DetachableWidget, public ModelView
-{
+	Q_OBJECT
 public:
-	EffectControlDialog(EffectControls* controls);
-	~EffectControlDialog() override = default;
+	explicit DetachableWidget(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags{});
 
-	virtual bool isResizable() const { return false; }
+	void closeEvent(QCloseEvent* ce) override;
 
-protected:
-	EffectControls* m_effectControls;
+signals:
+	void closed();
 };
 
-} // namespace gui
+} // namespace lmms::gui
 
-} // namespace lmms
-
-#endif // LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+#endif // LMMS_GUI_DETACHABLE_WIDGET

--- a/include/DetachableWidget.h
+++ b/include/DetachableWidget.h
@@ -36,7 +36,7 @@ class LMMS_EXPORT DetachableWidget : public QWidget
 {
 	Q_OBJECT
 public:
-	explicit DetachableWidget(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags{});
+	using QWidget::QWidget;
 
 	void closeEvent(QCloseEvent* ce) override;
 

--- a/include/DetachableWidget.h
+++ b/include/DetachableWidget.h
@@ -28,9 +28,11 @@
 
 #include <QWidget>
 
+#include "lmms_export.h"
+
 namespace lmms::gui {
 
-class DetachableWidget : public QWidget
+class LMMS_EXPORT DetachableWidget : public QWidget
 {
 	Q_OBJECT
 public:

--- a/include/DetachableWindow.h
+++ b/include/DetachableWindow.h
@@ -36,7 +36,7 @@ class LMMS_EXPORT DetachableWindow : public QMainWindow
 {
 	Q_OBJECT
 public:
-	explicit DetachableWindow(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags{});
+	using QMainWindow::QMainWindow;
 
 	void closeEvent(QCloseEvent* ce) override;
 

--- a/include/DetachableWindow.h
+++ b/include/DetachableWindow.h
@@ -28,9 +28,11 @@
 
 #include <QMainWindow>
 
+#include "lmms_export.h"
+
 namespace lmms::gui {
 
-class DetachableWindow : public QMainWindow
+class LMMS_EXPORT DetachableWindow : public QMainWindow
 {
 	Q_OBJECT
 public:

--- a/include/DetachableWindow.h
+++ b/include/DetachableWindow.h
@@ -1,8 +1,8 @@
 /*
- * EffectControlDialog.h - base-class for effect-dialogs for displaying and
- *                         editing control port values
+ * DetachableWindow.h - Allows a window to be detached from
+ *                      LMMS's main window
  *
- * Copyright (c) 2006-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2023 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -23,34 +23,25 @@
  *
  */
 
-#ifndef LMMS_GUI_EFFECT_CONTROL_DIALOG_H
-#define LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+#ifndef LMMS_GUI_DETACHABLE_WINDOW
+#define LMMS_GUI_DETACHABLE_WINDOW
 
-#include "DetachableWidget.h"
-#include "ModelView.h"
+#include <QMainWindow>
 
-namespace lmms
+namespace lmms::gui {
+
+class DetachableWindow : public QMainWindow
 {
-
-class EffectControls;
-
-namespace gui
-{
-
-class LMMS_EXPORT EffectControlDialog : public DetachableWidget, public ModelView
-{
+	Q_OBJECT
 public:
-	EffectControlDialog(EffectControls* controls);
-	~EffectControlDialog() override = default;
+	explicit DetachableWindow(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags{});
 
-	virtual bool isResizable() const { return false; }
+	void closeEvent(QCloseEvent* ce) override;
 
-protected:
-	EffectControls* m_effectControls;
+signals:
+	void closed();
 };
 
-} // namespace gui
+} // namespace lmms::gui
 
-} // namespace lmms
-
-#endif // LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+#endif // LMMS_GUI_DETACHABLE_WINDOW

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -25,8 +25,9 @@
 #ifndef LMMS_GUI_EDITOR_H
 #define LMMS_GUI_EDITOR_H
 
-#include <QMainWindow>
 #include <QToolBar>
+
+#include "DetachableWindow.h"
 
 class QAction;
 
@@ -45,7 +46,7 @@ class DropToolBar;
 ///
 /// Those editors include the Song Editor, the Automation Editor, B&B Editor,
 /// and the Piano Roll.
-class Editor : public QMainWindow
+class Editor : public DetachableWindow
 {
 	Q_OBJECT
 public:
@@ -56,7 +57,6 @@ protected:
 	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 	DropToolBar * addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 
-	void closeEvent(QCloseEvent * event) override;
 protected slots:
 	virtual void play() {}
 	virtual void record() {}

--- a/include/MicrotunerConfig.h
+++ b/include/MicrotunerConfig.h
@@ -25,10 +25,9 @@
 #ifndef LMMS_GUI_MICROTUNER_CONFIG_H
 #define LMMS_GUI_MICROTUNER_CONFIG_H
 
-#include <QWidget>
-
 #include "AutomatableModel.h"
 #include "ComboBoxModel.h"
+#include "DetachableWidget.h"
 #include "SerializingObject.h"
 
 class QLineEdit;
@@ -38,7 +37,7 @@ namespace lmms::gui
 {
 
 
-class LMMS_EXPORT MicrotunerConfig : public QWidget, public SerializingObject
+class LMMS_EXPORT MicrotunerConfig : public DetachableWidget, public SerializingObject
 {
 	Q_OBJECT
 public:
@@ -58,9 +57,6 @@ public slots:
 	void updateKeymapList(int index);
 	void updateScaleForm();
 	void updateKeymapForm();
-
-protected:
-	void closeEvent(QCloseEvent *ce) override;
 
 private slots:
 	bool loadScaleFromFile();

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -25,12 +25,12 @@
 #ifndef LMMS_GUI_MIXER_VIEW_H
 #define LMMS_GUI_MIXER_VIEW_H
 
-#include <QWidget>
 #include <QHBoxLayout>
 #include <QStackedLayout>
 #include <QScrollArea>
 
 #include "MixerChannelView.h"
+#include "DetachableWidget.h"
 #include "ModelView.h"
 #include "Engine.h"
 #include "Fader.h"
@@ -45,8 +45,11 @@ namespace lmms
 
 namespace lmms::gui
 {
-class LMMS_EXPORT MixerView : public QWidget, public ModelView,
-					public SerializingObjectHook
+
+class LMMS_EXPORT MixerView
+	: public DetachableWidget
+	, public ModelView
+	, public SerializingObjectHook
 {
 	Q_OBJECT
 public:
@@ -95,9 +98,6 @@ public:
 
 public slots:
 	int addNewChannel();
-
-protected:
-	void closeEvent(QCloseEvent* ce) override;
 
 private slots:
 	void updateFaders();

--- a/include/ProjectNotes.h
+++ b/include/ProjectNotes.h
@@ -25,8 +25,7 @@
 #ifndef LMMS_GUI_PROJECT_NOTES_H
 #define LMMS_GUI_PROJECT_NOTES_H
 
-#include <QMainWindow>
-
+#include "DetachableWindow.h"
 #include "SerializingObject.h"
 
 class QAction;
@@ -38,7 +37,7 @@ namespace lmms::gui
 {
 
 
-class LMMS_EXPORT ProjectNotes : public QMainWindow, public SerializingObject
+class LMMS_EXPORT ProjectNotes : public DetachableWindow, public SerializingObject
 {
 	Q_OBJECT
 public:
@@ -58,7 +57,6 @@ public:
 
 
 protected:
-	void closeEvent( QCloseEvent * _ce ) override;
 	void setupActions();
 
 

--- a/include/SampleTrackWindow.h
+++ b/include/SampleTrackWindow.h
@@ -25,8 +25,7 @@
 #ifndef LMMS_GUI_SAMPLE_TRACK_WINDOW_H
 #define LMMS_GUI_SAMPLE_TRACK_WINDOW_H
 
-#include <QWidget>
-
+#include "DetachableWidget.h"
 #include "ModelView.h"
 #include "SampleTrack.h"
 #include "SerializingObject.h"
@@ -42,11 +41,11 @@ class MixerChannelLcdSpinBox;
 class SampleTrackView;
 
 
-class SampleTrackWindow : public QWidget, public ModelView, public SerializingObjectHook
+class SampleTrackWindow : public DetachableWidget, public ModelView, public SerializingObjectHook
 {
 	Q_OBJECT
 public:
-	SampleTrackWindow(SampleTrackView * tv);
+	SampleTrackWindow(SampleTrackView* stv);
 	~SampleTrackWindow() override = default;
 
 	SampleTrack * model()
@@ -75,7 +74,7 @@ public slots:
 
 protected:
 	// capture close-events for toggling sample-track-button
-	void closeEvent(QCloseEvent * ce) override;
+	void closeEvent(QCloseEvent* ce) override;
 
 	void saveSettings(QDomDocument & doc, QDomElement & element) override;
 	void loadSettings(const QDomElement & element) override;

--- a/include/SimpleTextFloat.h
+++ b/include/SimpleTextFloat.h
@@ -30,7 +30,6 @@
 
 #include "lmms_export.h"
 
-class QLabel;
 class QTimer;
 
 namespace lmms::gui
@@ -55,9 +54,10 @@ public:
 	}
 
 	void hide();
+	void show();
 
 private:
-	QLabel * m_textLabel;
+	QString m_text;
 	QTimer * m_showTimer;
 	QTimer * m_hideTimer;
 };

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -91,7 +91,6 @@ public slots:
 	void selectAllClips( bool select );
 
 protected:
-	void closeEvent( QCloseEvent * ce ) override;
 	void mousePressEvent(QMouseEvent * me) override;
 	void mouseMoveEvent(QMouseEvent * me) override;
 	void mouseReleaseEvent(QMouseEvent * me) override;

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -81,12 +81,10 @@ protected:
 	void resizeEvent( QResizeEvent * event ) override;
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
-	void showEvent( QShowEvent* event ) override;
-	bool eventFilter( QObject * obj, QEvent * event ) override;
+	void showEvent(QShowEvent* event) override;
+	bool eventFilter(QObject* obj, QEvent* event) override;
 
 	bool isDetached() const;
-
-	QPushButton* addTitleButton(const std::string& iconName, const QString& toolTip);
 
 signals:
 	void focusLost();
@@ -97,7 +95,7 @@ private:
 	QPushButton * m_closeBtn;
 	QPushButton * m_maximizeBtn;
 	QPushButton * m_restoreBtn;
-	QPushButton * m_detachBtn;
+	QPushButton* m_detachBtn;
 	QBrush m_activeColor;
 	QColor m_textShadowColor;
 	QColor m_borderColor;

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -71,12 +71,19 @@ public:
 	int titleBarHeight() const;
 	int frameWidth() const;
 
+public slots:
+	void detach();
+	void attach();
+
 protected:
 	// hook the QWidget move/resize events to update the tracked geometry
 	void moveEvent( QMoveEvent * event ) override;
 	void resizeEvent( QResizeEvent * event ) override;
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
+	void showEvent( QShowEvent* event ) override;
+
+	bool isDetached() const;
 
 	QPushButton* addTitleButton(const std::string& iconName, const QString& toolTip);
 
@@ -89,6 +96,7 @@ private:
 	QPushButton * m_closeBtn;
 	QPushButton * m_maximizeBtn;
 	QPushButton * m_restoreBtn;
+	QPushButton * m_detachBtn;
 	QBrush m_activeColor;
 	QColor m_textShadowColor;
 	QColor m_borderColor;

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -82,6 +82,7 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 	void changeEvent( QEvent * event ) override;
 	void showEvent( QShowEvent* event ) override;
+	bool eventFilter( QObject * obj, QEvent * event ) override;
 
 	bool isDetached() const;
 

--- a/plugins/LadspaEffect/LadspaControlDialog.cpp
+++ b/plugins/LadspaEffect/LadspaControlDialog.cpp
@@ -46,7 +46,8 @@ LadspaControlDialog::LadspaControlDialog( LadspaControls * _ctl ) :
 	m_effectLayout( nullptr ),
 	m_stereoLink( nullptr )
 {
-	auto mainLay = new QVBoxLayout(this);
+	QVBoxLayout * mainLay = new QVBoxLayout( this );
+	mainLay->setSizeConstraint(QLayout::SetFixedSize);
 
 	m_effectLayout = new QHBoxLayout();
 	mainLay->addLayout( m_effectLayout );

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -109,8 +109,15 @@ public:
 	{
 		// ignore close-events - for some reason otherwise the VST GUI
 		// remains hidden when re-opening
-		hide();
-		e->ignore();
+		if (windowFlags().testFlag(Qt::Window))
+		{
+			e->accept();
+		}
+		else
+		{
+			hide();
+			e->ignore();
+		}
 	}
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -9,6 +9,8 @@ SET(LMMS_SRCS
 	gui/ControllerRackView.cpp
 	gui/ControllerView.cpp
 	gui/Controls.cpp
+	gui/DetachableWidget.cpp
+	gui/DetachableWindow.cpp
 	gui/EffectControlDialog.cpp
 	gui/EffectRackView.cpp
 	gui/EffectView.cpp

--- a/src/gui/ControllerDialog.cpp
+++ b/src/gui/ControllerDialog.cpp
@@ -23,45 +23,17 @@
  *
  */
 
-#include <QCloseEvent>
-
 #include "ControllerDialog.h"
+
 #include "Controller.h"
-#include "GuiApplication.h"
-#include "MainWindow.h"
 
 namespace lmms::gui
 {
 
-
-ControllerDialog::ControllerDialog( Controller * _controller,
-							QWidget * _parent ) :
-	QWidget( _parent ),
-	ModelView( _controller, this )
+ControllerDialog::ControllerDialog(Controller* controller, QWidget* parent)
+	: DetachableWidget{parent}
+	, ModelView{controller, this}
 {
 }
-
-
-
-void ControllerDialog::closeEvent( QCloseEvent * _ce )
-{
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		_ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		_ce->ignore();
-	}
-	else
-	{
-		hide();
-		_ce->ignore();
-	}
-	emit closed();
-}
-
-
 
 } // namespace lmms::gui

--- a/src/gui/ControllerDialog.cpp
+++ b/src/gui/ControllerDialog.cpp
@@ -27,6 +27,8 @@
 
 #include "ControllerDialog.h"
 #include "Controller.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
 
 namespace lmms::gui
 {
@@ -43,7 +45,20 @@ ControllerDialog::ControllerDialog( Controller * _controller,
 
 void ControllerDialog::closeEvent( QCloseEvent * _ce )
 {
-	_ce->ignore();
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		_ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
+	{
+		parentWidget()->hide();
+		_ce->ignore();
+	}
+	else
+	{
+		hide();
+		_ce->ignore();
+	}
 	emit closed();
 }
 

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -232,15 +232,20 @@ void ControllerRackView::addController()
 
 void ControllerRackView::closeEvent( QCloseEvent * _ce )
  {
-	if( parentWidget() )
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		_ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
 	{
 		parentWidget()->hide();
+		_ce->ignore();
 	}
 	else
 	{
 		hide();
+		_ce->ignore();
 	}
-	_ce->ignore();
  }
 
 

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -23,6 +23,8 @@
  *
  */
 
+#include "ControllerRackView.h"
+
 #include <QApplication>
 #include <QAction>
 #include <QPushButton>
@@ -31,21 +33,20 @@
 #include <QVBoxLayout>
 
 #include "Song.h"
-#include "embed.h"
 #include "GuiApplication.h"
 #include "MainWindow.h"
-#include "ControllerRackView.h"
 #include "ControllerView.h"
 #include "LfoController.h"
 #include "SubWindow.h"
+#include "embed.h"
 
 namespace lmms::gui
 {
 
 
-ControllerRackView::ControllerRackView() :
-	QWidget(),
-	m_nextIndex(0)
+ControllerRackView::ControllerRackView()
+	: DetachableWidget{}
+	, m_nextIndex{0}
 {
 	setWindowIcon( embed::getIconPixmap( "controller" ) );
 	setWindowTitle( tr( "Controller Rack" ) );
@@ -226,27 +227,5 @@ void ControllerRackView::addController()
 	// new controller
 	setFocus();
 }
-
-
-
-
-void ControllerRackView::closeEvent( QCloseEvent * _ce )
- {
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		_ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		_ce->ignore();
-	}
-	else
-	{
-		hide();
-		_ce->ignore();
-	}
- }
-
 
 } // namespace lmms::gui

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -78,10 +78,15 @@ ControllerRackView::ControllerRackView()
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
+	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget( this );
+
+	// TODO: Automate setting one of these, stop hardcoding title bar height
+	// Set dimensions for detached mode
 	setFixedWidth(350);
 	setMinimumHeight(200);
-
-	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget( this );
+	// Set dimensions for embedded mode
+	subWin->setFixedWidth(350);
+	subWin->setMinimumHeight(230);
 
 	// No maximize button
 	Qt::WindowFlags flags = subWin->windowFlags();

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -77,8 +77,8 @@ ControllerRackView::ControllerRackView() :
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
-	setFixedWidth( 350 );
-	setMinimumHeight( 200 );
+	setFixedWidth(350);
+	setMinimumHeight(200);
 
 	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget( this );
 

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -77,6 +77,9 @@ ControllerRackView::ControllerRackView() :
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
+	setFixedWidth( 350 );
+	setMinimumHeight( 200 );
+
 	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget( this );
 
 	// No maximize button
@@ -86,9 +89,6 @@ ControllerRackView::ControllerRackView() :
 	
 	subWin->setAttribute( Qt::WA_DeleteOnClose, false );
 	subWin->move( 680, 310 );
-	subWin->resize( 350, 200 );
-	subWin->setFixedWidth( 350 );
-	subWin->setMinimumHeight( 200 );
 }
 
 

--- a/src/gui/DetachableWidget.cpp
+++ b/src/gui/DetachableWidget.cpp
@@ -25,18 +25,12 @@
 
 #include "DetachableWidget.h"
 
-#include <QWidget>
 #include <QCloseEvent>
 
 #include "GuiApplication.h"
 #include "MainWindow.h"
 
 namespace lmms::gui {
-
-DetachableWidget::DetachableWidget(QWidget* parent, Qt::WindowFlags f)
-	: QWidget{parent, f}
-{
-}
 
 void DetachableWidget::closeEvent(QCloseEvent* ce)
 {

--- a/src/gui/DetachableWidget.cpp
+++ b/src/gui/DetachableWidget.cpp
@@ -1,8 +1,8 @@
 /*
- * EffectControlDialog.h - base-class for effect-dialogs for displaying and
- *                         editing control port values
+ * DetachableWidget.cpp - Allows a widget to be detached from
+ *                        LMMS's main window
  *
- * Copyright (c) 2006-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2023 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -23,34 +23,38 @@
  *
  */
 
-#ifndef LMMS_GUI_EFFECT_CONTROL_DIALOG_H
-#define LMMS_GUI_EFFECT_CONTROL_DIALOG_H
-
 #include "DetachableWidget.h"
-#include "ModelView.h"
 
-namespace lmms
+#include <QWidget>
+#include <QCloseEvent>
+
+#include "GuiApplication.h"
+#include "MainWindow.h"
+
+namespace lmms::gui {
+
+DetachableWidget::DetachableWidget(QWidget* parent, Qt::WindowFlags f)
+	: QWidget{parent, f}
 {
+}
 
-class EffectControls;
-
-namespace gui
+void DetachableWidget::closeEvent(QCloseEvent* ce)
 {
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
+	{
+		parentWidget()->hide();
+		ce->ignore();
+	}
+	else
+	{
+		hide();
+		ce->ignore();
+	}
+	emit closed();
+}
 
-class LMMS_EXPORT EffectControlDialog : public DetachableWidget, public ModelView
-{
-public:
-	EffectControlDialog(EffectControls* controls);
-	~EffectControlDialog() override = default;
-
-	virtual bool isResizable() const { return false; }
-
-protected:
-	EffectControls* m_effectControls;
-};
-
-} // namespace gui
-
-} // namespace lmms
-
-#endif // LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+} // namespace lmms::gui

--- a/src/gui/DetachableWindow.cpp
+++ b/src/gui/DetachableWindow.cpp
@@ -1,8 +1,8 @@
 /*
- * EffectControlDialog.h - base-class for effect-dialogs for displaying and
- *                         editing control port values
+ * DetachableWindow.cpp - Allows a window to be detached from
+ *                        LMMS's main window
  *
- * Copyright (c) 2006-2009 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2023 Dalton Messmer <messmer.dalton/at/gmail.com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -23,34 +23,38 @@
  *
  */
 
-#ifndef LMMS_GUI_EFFECT_CONTROL_DIALOG_H
-#define LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+#include "DetachableWindow.h"
 
-#include "DetachableWidget.h"
-#include "ModelView.h"
+#include <QWidget>
+#include <QCloseEvent>
 
-namespace lmms
+#include "GuiApplication.h"
+#include "MainWindow.h"
+
+namespace lmms::gui {
+
+DetachableWindow::DetachableWindow(QWidget* parent, Qt::WindowFlags f)
+	: QMainWindow{parent, f}
 {
+}
 
-class EffectControls;
-
-namespace gui
+void DetachableWindow::closeEvent(QCloseEvent* ce)
 {
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
+	{
+		parentWidget()->hide();
+		ce->ignore();
+	}
+	else
+	{
+		hide();
+		ce->ignore();
+	}
+	emit closed();
+}
 
-class LMMS_EXPORT EffectControlDialog : public DetachableWidget, public ModelView
-{
-public:
-	EffectControlDialog(EffectControls* controls);
-	~EffectControlDialog() override = default;
-
-	virtual bool isResizable() const { return false; }
-
-protected:
-	EffectControls* m_effectControls;
-};
-
-} // namespace gui
-
-} // namespace lmms
-
-#endif // LMMS_GUI_EFFECT_CONTROL_DIALOG_H
+} // namespace lmms::gui

--- a/src/gui/DetachableWindow.cpp
+++ b/src/gui/DetachableWindow.cpp
@@ -25,18 +25,12 @@
 
 #include "DetachableWindow.h"
 
-#include <QWidget>
 #include <QCloseEvent>
 
 #include "GuiApplication.h"
 #include "MainWindow.h"
 
 namespace lmms::gui {
-
-DetachableWindow::DetachableWindow(QWidget* parent, Qt::WindowFlags f)
-	: QMainWindow{parent, f}
-{
-}
 
 void DetachableWindow::closeEvent(QCloseEvent* ce)
 {

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -27,6 +27,8 @@
 
 #include "EffectControlDialog.h"
 #include "EffectControls.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
 
 namespace lmms::gui
 {
@@ -46,7 +48,20 @@ EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
 
 void EffectControlDialog::closeEvent( QCloseEvent * _ce )
 {
-	_ce->ignore();
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		_ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
+	{
+		parentWidget()->hide();
+		_ce->ignore();
+	}
+	else
+	{
+		hide();
+		_ce->ignore();
+	}
 	emit closed();
 }
 

--- a/src/gui/EffectControlDialog.cpp
+++ b/src/gui/EffectControlDialog.cpp
@@ -23,47 +23,20 @@
  *
  */
 
-#include <QCloseEvent>
-
 #include "EffectControlDialog.h"
+
 #include "EffectControls.h"
-#include "GuiApplication.h"
-#include "MainWindow.h"
 
 namespace lmms::gui
 {
 
-
-EffectControlDialog::EffectControlDialog( EffectControls * _controls ) :
-	QWidget( nullptr ),
-	ModelView( _controls, this ),
-	m_effectControls( _controls )
+EffectControlDialog::EffectControlDialog(EffectControls* controls)
+	: DetachableWidget{nullptr}
+	, ModelView{controls, this}
+	, m_effectControls{controls}
 {
-	setWindowTitle( m_effectControls->effect()->displayName() );
-	setSizePolicy( QSizePolicy::Preferred, QSizePolicy::Preferred );
+	setWindowTitle(m_effectControls->effect()->displayName());
+	setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 }
-
-
-
-
-void EffectControlDialog::closeEvent( QCloseEvent * _ce )
-{
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		_ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		_ce->ignore();
-	}
-	else
-	{
-		hide();
-		_ce->ignore();
-	}
-	emit closed();
-}
-
 
 } // namespace lmms::gui

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -55,7 +55,7 @@ namespace lmms::gui
 
 
 MicrotunerConfig::MicrotunerConfig() :
-	QWidget(),
+	DetachableWidget(),
 	m_scaleComboModel(nullptr, tr("Selected scale slot")),
 	m_keymapComboModel(nullptr, tr("Selected keymap slot")),
 	m_firstKeyModel(0, 0, NumKeys - 1, nullptr, tr("First key")),
@@ -677,14 +677,6 @@ void MicrotunerConfig::saveSettings(QDomDocument &document, QDomElement &element
 void MicrotunerConfig::loadSettings(const QDomElement &element)
 {
 	MainWindow::restoreWidgetState(this, element);
-}
-
-
-void MicrotunerConfig::closeEvent(QCloseEvent *ce)
-{
-	if (parentWidget()) {parentWidget()->hide();}
-	else {hide();}
-	ce->ignore();
 }
 
 

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -50,11 +50,11 @@ namespace lmms::gui
 {
 
 
-MixerView::MixerView(Mixer* mixer) :
-	QWidget(),
-	ModelView(nullptr, this),
-	SerializingObjectHook(),
-	m_mixer(mixer)
+MixerView::MixerView(Mixer* mixer)
+	: DetachableWidget{}
+	, ModelView{nullptr, this}
+	, SerializingObjectHook{}
+	, m_mixer{mixer}
 {
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
@@ -518,26 +518,6 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 		case Qt::Key_F2:
 			renameChannel(m_currentMixerChannel->channelIndex());
 			break;
-	}
-}
-
-
-
-void MixerView::closeEvent( QCloseEvent * _ce )
-{
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		_ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		_ce->ignore();
-	}
-	else
-	{
-		hide();
-		_ce->ignore();
 	}
 }
 

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -166,6 +166,15 @@ MixerView::MixerView(Mixer* mixer)
 	// timer for updating faders
 	connect(mainWindow, &MainWindow::periodicUpdate, this, &MixerView::updateFaders);
 
+	// adjust window size
+	layout()->invalidate();
+	resize(sizeHint());
+	if (parentWidget())
+	{
+		parentWidget()->resize(parentWidget()->sizeHint());
+	}
+	setFixedHeight(height());
+
 	// add ourself to workspace
 	QMdiSubWindow* subWin = mainWindow->addWindowedWidget(this);
 	layout()->setSizeConstraint(QLayout::SetMinimumSize);

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -523,18 +523,23 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 
 
 
-void MixerView::closeEvent(QCloseEvent * ce)
- {
-	if (parentWidget())
+void MixerView::closeEvent( QCloseEvent * _ce )
+{
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		_ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
 	{
 		parentWidget()->hide();
+		_ce->ignore();
 	}
 	else
 	{
 		hide();
+		_ce->ignore();
 	}
-	ce->ignore();
- }
+}
 
 
 

--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -27,7 +27,6 @@
 
 #include <QAction>
 #include <QApplication>
-#include <QCloseEvent>
 #include <QColorDialog>
 #include <QComboBox>
 #include <QFontDatabase>
@@ -48,8 +47,8 @@ namespace lmms::gui
 {
 
 
-ProjectNotes::ProjectNotes() :
-	QMainWindow( getGUI()->mainWindow()->workspace() )
+ProjectNotes::ProjectNotes()
+	: DetachableWindow{getGUI()->mainWindow()->workspace()}
 {
 	m_edit = new QTextEdit( this );
 	m_edit->setAutoFillBackground( true );
@@ -386,26 +385,5 @@ void ProjectNotes::loadSettings( const QDomElement & _this )
 	MainWindow::restoreWidgetState( this, _this );
 	m_edit->setHtml( _this.text() );
 }
-
-
-
-
-void ProjectNotes::closeEvent( QCloseEvent * _ce )
-{
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		_ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		_ce->ignore();
-	}
-	else
-	{
-		hide();
-		_ce->ignore();
-	}
- }
 
 } // namespace lmms::gui

--- a/src/gui/ProjectNotes.cpp
+++ b/src/gui/ProjectNotes.cpp
@@ -392,15 +392,20 @@ void ProjectNotes::loadSettings( const QDomElement & _this )
 
 void ProjectNotes::closeEvent( QCloseEvent * _ce )
 {
-	if( parentWidget() )
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		_ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
 	{
 		parentWidget()->hide();
+		_ce->ignore();
 	}
 	else
 	{
 		hide();
+		_ce->ignore();
 	}
-	_ce->ignore();
  }
 
 } // namespace lmms::gui

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -46,11 +46,11 @@ namespace lmms::gui
 {
 
 
-SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
-	QWidget(),
-	ModelView(nullptr, this),
-	m_track(tv->model()),
-	m_stv(tv)
+SampleTrackWindow::SampleTrackWindow(SampleTrackView* stv)
+	: DetachableWidget{}
+	, ModelView{nullptr, this}
+	, m_track{stv->model()}
+	, m_stv{stv}
 {
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
@@ -139,14 +139,14 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 
 	generalSettingsLayout->addLayout(basicControlsLayout);
 
-	m_effectRack = new EffectRackView(tv->model()->audioPort()->effects());
+	m_effectRack = new EffectRackView(stv->model()->audioPort()->effects());
 	m_effectRack->setFixedSize(EffectRackView::DEFAULT_WIDTH, 242);
 
 	vlayout->addWidget(generalSettingsWidget);
 	vlayout->addWidget(m_effectRack);
 
 
-	setModel(tv->model());
+	setModel(stv->model());
 
 	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 	Qt::WindowFlags flags = subWin->windowFlags();
@@ -238,20 +238,7 @@ void SampleTrackWindow::toggleVisibility(bool on)
 
 void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 {
-	if (windowFlags().testFlag(Qt::Window))
-	{
-		ce->accept();
-	}
-	else if (getGUI()->mainWindow()->workspace())
-	{
-		parentWidget()->hide();
-		ce->ignore();
-	}
-	else
-	{
-		hide();
-		ce->ignore();
-	}
+	DetachableWidget::closeEvent(ce);
 
 	m_stv->m_tlb->setFocus();
 	m_stv->m_tlb->setChecked(false);
@@ -259,10 +246,9 @@ void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 
 
 
-void SampleTrackWindow::saveSettings(QDomDocument& doc, QDomElement & element)
+void SampleTrackWindow::saveSettings([[maybe_unused]] QDomDocument& doc, QDomElement& element)
 {
 	MainWindow::saveWidgetState(this, element);
-	Q_UNUSED(element)
 }
 
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -238,15 +238,19 @@ void SampleTrackWindow::toggleVisibility(bool on)
 
 void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 {
-	ce->ignore();
-
-	if(getGUI()->mainWindow()->workspace())
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		ce->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
 	{
 		parentWidget()->hide();
+		ce->ignore();
 	}
 	else
 	{
 		hide();
+		ce->ignore();
 	}
 
 	m_stv->m_tlb->setFocus();

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -154,6 +154,15 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView* stv)
 	flags &= ~Qt::WindowMaximizeButtonHint;
 	subWin->setWindowFlags(flags);
 
+	// adjust window size
+	layout()->invalidate();
+	resize(sizeHint());
+	if (parentWidget())
+	{
+		parentWidget()->resize(parentWidget()->sizeHint());
+	}
+	setFixedSize(size());
+
 	// Hide the Size and Maximize options from the system menu
 	// since the dialog size is fixed.
 	QMenu * systemMenu = subWin->systemMenu();

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -252,6 +252,7 @@ void SubWindow::detach()
 	if (isDetached()) {
 		return;
 	}
+
 	auto pos = mapToGlobal(widget()->pos());
 	widget()->setWindowFlags(Qt::Window);
 	widget()->show();
@@ -480,6 +481,20 @@ QPushButton* SubWindow::addTitleButton(const std::string& iconName, const QStrin
 	button->setToolTip(toolTip);
 
 	return button;
+}
+
+bool SubWindow::eventFilter(QObject * obj, QEvent * event)
+{
+	if (obj != static_cast<QObject *>(widget())) {
+		return QMdiSubWindow::eventFilter(obj, event);
+	}
+	switch (event->type()) {
+	case QEvent::WindowStateChange:
+		event->accept();
+		return true;
+	default:
+		return QMdiSubWindow::eventFilter(obj, event);
+	}
 }
 
 

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -67,6 +67,14 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 	m_restoreBtn = addTitleButton("restore", tr("Restore"));
 	connect( m_restoreBtn, SIGNAL(clicked(bool)), this, SLOT(showNormal()));
 
+	m_detachBtn = new QPushButton( embed::getIconPixmap( "window" ), QString(), this );
+	m_detachBtn->resize( m_buttonSize );
+	m_detachBtn->setFocusPolicy( Qt::NoFocus );
+	m_detachBtn->setCursor( Qt::ArrowCursor );
+	m_detachBtn->setAttribute( Qt::WA_NoMousePropagation );
+	m_detachBtn->setToolTip( tr( "Detach" ) );
+	connect( m_detachBtn, SIGNAL( clicked( bool ) ), this, SLOT( detach() ) );
+
 	// QLabel for the window title and the shadow effect
 	m_shadow = new QGraphicsDropShadowEffect();
 	m_shadow->setColor( m_textShadowColor );
@@ -140,6 +148,17 @@ void SubWindow::changeEvent( QEvent *event )
 		adjustTitleBar();
 	}
 
+}
+
+void SubWindow::showEvent(QShowEvent *e)
+{
+	attach();
+	QMdiSubWindow::showEvent(e);
+}
+
+bool SubWindow::isDetached() const
+{
+	return widget()->windowFlags().testFlag(Qt::Window);
 }
 
 
@@ -225,6 +244,29 @@ void SubWindow::setBorderColor( const QColor &c )
 	m_borderColor = c;
 }
 
+void SubWindow::detach()
+{
+	if (isDetached()) {
+		return;
+	}
+	auto pos = mapToGlobal(widget()->pos());
+	widget()->setWindowFlags(Qt::Window);
+	widget()->show();
+	widget()->move(pos);
+	hide();
+}
+
+void SubWindow::attach()
+{
+	if (! isDetached()) {
+		return;
+	}
+	auto pos = widget()->pos();
+	widget()->setWindowFlags(Qt::Widget);
+	widget()->show();
+	show();
+	move(mdiArea()->mapFromGlobal(pos));
+}
 
 
 
@@ -308,9 +350,8 @@ void SubWindow::adjustTitleBar()
 	const int buttonGap = 1;
 	const int menuButtonSpace = 24;
 
-	QPoint rightButtonPos( width() - rightSpace - m_buttonSize.width(), 3 );
-	QPoint middleButtonPos( width() - rightSpace - ( 2 * m_buttonSize.width() ) - buttonGap, 3 );
-	QPoint leftButtonPos( width() - rightSpace - ( 3 * m_buttonSize.width() ) - ( 2 * buttonGap ), 3 );
+	QPoint buttonPos( width() - rightSpace - m_buttonSize.width(), 3 );
+	const QPoint buttonStep( m_buttonSize.width() + buttonGap, 0 );
 
 	// the buttonBarWidth depends on the number of buttons.
 	// we need it to calculate the width of window title label
@@ -318,25 +359,35 @@ void SubWindow::adjustTitleBar()
 
 	// set the buttons on their positions.
 	// the close button is always needed and on the rightButtonPos
-	m_closeBtn->move( rightButtonPos );
+	m_closeBtn->move( buttonPos );
+	buttonPos -= buttonStep;
 
 	// here we ask: is the Subwindow maximizable and
 	// then we set the buttons and show them if needed
 	if( windowFlags() & Qt::WindowMaximizeButtonHint )
 	{
 		buttonBarWidth = buttonBarWidth + m_buttonSize.width() + buttonGap;
-		m_maximizeBtn->move( middleButtonPos );
-		m_restoreBtn->move( middleButtonPos );
+		m_maximizeBtn->move( buttonPos );
+		m_restoreBtn->move( buttonPos );
+		// TODO: May be incorrect:
 		m_maximizeBtn->setVisible(true);
+		if ( ! isMaximized() ) {
+			m_maximizeBtn->show();
+			buttonPos -= buttonStep;
+		}
 	}
 
 	// we're keeping the restore button around if we open projects
 	// from older versions that have saved minimized windows
+	// TODO: May be incorrect:
 	m_restoreBtn->setVisible(isMinimized());
-	if( isMinimized() )
-	{
-		m_restoreBtn->move( m_maximizeBtn->isHidden() ?  middleButtonPos : leftButtonPos );
+	if ( isMaximized() || isMinimized() ) {
+		m_restoreBtn->show();
+		buttonPos -= buttonStep;
 	}
+
+	m_detachBtn->move( buttonPos );
+	m_detachBtn->show();
 
 	if( widget() )
 	{

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -254,10 +254,24 @@ void SubWindow::setBorderColor( const QColor &c )
 
 void SubWindow::detach()
 {
+#if QT_VERSION < 0x50C00
+	// Workaround for a bug in Qt versions below 5.12,
+	// where argument-dependent-lookup fails for QFlags operators
+	// declared inside a namepsace.
+	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
+	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
+
+	using ::operator|;
+#endif
+
 	if (isDetached()) { return; }
 
-	auto pos = mapToGlobal(widget()->pos());
-	widget()->setWindowFlags(Qt::Window);
+	const auto pos = mapToGlobal(widget()->pos());
+
+	auto flags = windowFlags();
+	flags |= Qt::Window;
+	flags &= ~Qt::Widget;
+	widget()->setWindowFlags(flags);
 	widget()->show();
 	hide();
 
@@ -266,10 +280,24 @@ void SubWindow::detach()
 
 void SubWindow::attach()
 {
+#if QT_VERSION < 0x50C00
+	// Workaround for a bug in Qt versions below 5.12,
+	// where argument-dependent-lookup fails for QFlags operators
+	// declared inside a namepsace.
+	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
+	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
+
+	using ::operator|;
+#endif
+
 	if (!isDetached()) { return; }
 
 	auto frame = widget()->windowHandle()->frameGeometry();
-	widget()->setWindowFlags(Qt::Widget);
+
+	auto flags = windowFlags();
+	flags &= ~Qt::Window;
+	flags |= Qt::Widget;
+	widget()->setWindowFlags(flags);
 	widget()->show();
 	show();
 

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -24,16 +24,11 @@
 
 #include "Editor.h"
 
-#include "GuiApplication.h"
-#include "MainWindow.h"
-#include "Song.h"
-
-#include "embed.h"
-
 #include <QAction>
 #include <QShortcut>
-#include <QCloseEvent>
 
+#include "Song.h"
+#include "embed.h"
 
 namespace lmms::gui
 {
@@ -89,6 +84,7 @@ void Editor::toggleMaximize()
 }
 
 Editor::Editor(bool record, bool stepRecord) :
+	DetachableWindow(),
 	m_toolBar(new DropToolBar(this)),
 	m_playAction(nullptr),
 	m_recordAction(nullptr),
@@ -139,20 +135,6 @@ QAction *Editor::playAction() const
 {
 	return m_playAction;
 }
-
-void Editor::closeEvent(QCloseEvent * event)
-{
-	if( parentWidget() )
-	{
-		parentWidget()->hide();
-	}
-	else
-	{
-		hide();
-	}
-	getGUI()->mainWindow()->refocus();
-	event->ignore();
- }
 
 DropToolBar::DropToolBar(QWidget* parent) : QToolBar(parent)
 {

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -566,21 +566,6 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 
 
 
-void SongEditor::closeEvent( QCloseEvent * ce )
-{
-	if( parentWidget() )
-	{
-		parentWidget()->hide();
-	}
-	else
-	{
-		hide();
-	}
-	ce->ignore();
-}
-
-
-
 
 void SongEditor::mousePressEvent(QMouseEvent *me)
 {

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -526,15 +526,19 @@ void InstrumentTrackWindow::toggleVisibility( bool on )
 
 void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 {
-	event->ignore();
-
-	if( getGUI()->mainWindow()->workspace() )
+	if (windowFlags().testFlag(Qt::Window))
+	{
+		event->accept();
+	}
+	else if (getGUI()->mainWindow()->workspace())
 	{
 		parentWidget()->hide();
+		event->ignore();
 	}
 	else
 	{
 		hide();
+		event->ignore();
 	}
 
 	m_itv->m_tlb->setFocus();

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -272,7 +272,6 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// setup sizes and policies
 	generalSettingsWidget->setMaximumHeight(90);
 	generalSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-	vlayout->setSizeConstraint(QLayout::SetFixedSize);
 	m_tabWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
 	vlayout->addWidget( generalSettingsWidget );
@@ -289,9 +288,13 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	if (!m_instrumentView->isResizable()) {
 		flags |= Qt::MSWindowsFixedSizeDialogHint;
 		// any better way than this?
+		setFixedSize(sizeHint());
+		// this should replace that; it does not. Ask Qt why.
+		// Does the same thing, for detached detached windows, for other OSs.
+		
 	} else {
-		subWin->setMaximumSize(m_instrumentView->maximumHeight() + 12, m_instrumentView->maximumWidth() + 208);
-		subWin->setMinimumSize( m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
+		subWin->setMaximumSize(m_instrumentView->maximumWidth() + 12, m_instrumentView->maximumHeight() + 208);
+		subWin->setMinimumSize(m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
 	}
 	flags &= ~Qt::WindowMaximizeButtonHint;
 	subWin->setWindowFlags( flags );

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -518,6 +518,7 @@ void InstrumentTrackWindow::toggleVisibility( bool on )
 	else
 	{
 		parentWidget()->hide();
+		hide();
 	}
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -526,6 +526,7 @@ void InstrumentTrackWindow::toggleVisibility( bool on )
 
 void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 {
+	// TODO: When is this event used?
 	if (windowFlags().testFlag(Qt::Window))
 	{
 		event->accept();

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -272,6 +272,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// setup sizes and policies
 	generalSettingsWidget->setMaximumHeight(90);
 	generalSettingsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+	vlayout->setSizeConstraint(QLayout::SetFixedSize);
 	m_tabWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
 	vlayout->addWidget( generalSettingsWidget );

--- a/src/gui/widgets/SimpleTextFloat.cpp
+++ b/src/gui/widgets/SimpleTextFloat.cpp
@@ -25,26 +25,16 @@
 #include "SimpleTextFloat.h"
 
 #include <QTimer>
-#include <QStyleOption>
-#include <QHBoxLayout>
-#include <QLabel>
-
-#include "GuiApplication.h"
-#include "MainWindow.h"
+#include <QToolTip>
 
 namespace lmms::gui
 {
 
 
 SimpleTextFloat::SimpleTextFloat() :
-	QWidget(getGUI()->mainWindow(), Qt::ToolTip)
+	QWidget()
 {
-	QHBoxLayout * layout = new QHBoxLayout(this);
-	layout->setMargin(3);
-	setLayout(layout);
-
-	m_textLabel = new QLabel(this);
-	layout->addWidget(m_textLabel);
+	m_text = QString();
 
 	m_showTimer = new QTimer(this);
 	m_showTimer->setSingleShot(true);
@@ -57,7 +47,7 @@ SimpleTextFloat::SimpleTextFloat() :
 
 void SimpleTextFloat::setText(const QString & text)
 {
-	m_textLabel->setText(text);
+	m_text = text;
 }
 
 void SimpleTextFloat::showWithDelay(int msecBeforeDisplay, int msecDisplayTime)
@@ -77,11 +67,16 @@ void SimpleTextFloat::showWithDelay(int msecBeforeDisplay, int msecDisplayTime)
 	}
 }
 
+void SimpleTextFloat::show()
+{
+	QToolTip::showText(mapToGlobal(QPoint(0, 0)), m_text);
+}
+
 void SimpleTextFloat::hide()
 {
 	m_showTimer->stop();
 	m_hideTimer->stop();
-	QWidget::hide();
+	QToolTip::hideText();
 }
 
 void SimpleTextFloat::setVisibilityTimeOut(int msecs)


### PR DESCRIPTION
Allows detaching a window from LMMS's main window, making things like working on multiple screens easier.

Closes #1259

Quick demonstration:
![lmms-window-detach](https://cloud.githubusercontent.com/assets/2879917/25752905/fb023c4c-31b9-11e7-9938-e3dce88f6eca.gif)

This PR supersedes #3532, since I messed up the `LMMS/lmms:feature/detach-window` branch's history after I merged from master incorrectly.