### PR TITLE
Fix the MSVC CI fail happening due to outdated vcpkg 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
         id: cache-deps
         uses: actions/cache@v3
         with:
-          key: vcpkg-force-refresh-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ matrix.arch }}-
           path: build\vcpkg_installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,12 +249,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Set up or Update vcpkg
+      - name: Update vcpkg (TEMPORARY)
         run: |
-          if (!(Test-Path C:/vcpkg)) {
-            git clone https://github.com/microsoft/vcpkg.git C:/vcpkg
-          }
-          cd C:/vcpkg
+          cd ${VCPKG_INSTALLATION_ROOT}
           git pull
           .\bootstrap-vcpkg.bat
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
           archives: qtbase qtsvg qttools
           cache: true
       - name: Set up build environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
         with:
           arch: ${{ matrix.arch }}
       - name: Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,7 @@ jobs:
           submodules: recursive
       - name: Update vcpkg (TEMPORARY)
         run: |
-          cd ${VCPKG_INSTALLATION_ROOT}
+          cd $env:VCPKG_INSTALLATION_ROOT
           git pull
           .\bootstrap-vcpkg.bat
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       matrix:
         arch: ['x86', 'x64']
     name: msvc-${{ matrix.arch }}
-    runs-on: windows-2022
+    runs-on: windows-2019
     env:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,15 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Set up or Update vcpkg
+        run: |
+          if (!(Test-Path C:/vcpkg)) {
+            git clone https://github.com/microsoft/vcpkg.git C:/vcpkg
+          }
+          cd C:/vcpkg
+          git pull
+          .\bootstrap-vcpkg.bat
+        shell: pwsh
       - name: Cache vcpkg dependencies
         id: cache-deps
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,7 +239,7 @@ jobs:
       matrix:
         arch: ['x86', 'x64']
     name: msvc-${{ matrix.arch }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,7 +253,7 @@ jobs:
         id: cache-deps
         uses: actions/cache@v3
         with:
-          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-force-refresh-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ matrix.arch }}-
           path: build\vcpkg_installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,7 @@ jobs:
           archives: qtbase qtsvg qttools
           cache: true
       - name: Set up build environment
-        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
+        uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
       - name: Configure


### PR DESCRIPTION
Fixes a build fail on our MSVC CI due to outdated version of vcpkg used. 

Also bumps the version of the `msvc-dev-cmd` github action.