### PR TITLE
Transition FloatModelEditorBase to QToolTip so the hint can be displayed outside window

### DIFF
--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -104,8 +104,6 @@ private:
 		return (model()->maxValue() - model()->minValue()) / 100.0f;
 	}
 
-	static SimpleTextFloat * s_textFloat;
-
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;
 


### PR DESCRIPTION
This is mostly relevant for #3532, however is a (sort of) unrelated change and not a bugfix, hence I'm submitting it here.

Known issues:
- Tooltips show up immediately, and I'm unsure how to achieve configurable delay.
- Tooltips remain in place when the subject is switched. This probably won't matter once we figure out the delay.

I've run out of clues how to fix any of these, any help would be welcome.