### PR TITLE
Improving movement inside workspace

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -29,6 +29,7 @@
 #include <QTimer>
 #include <QList>
 #include <QMainWindow>
+#include <QMdiArea>
 
 #include "ConfigManager.h"
 
@@ -45,6 +46,7 @@ class ConfigManager;
 namespace gui
 {
 
+class CustomQMdiArea;
 class PluginView;
 class SubWindow;
 class ToolButton;
@@ -57,7 +59,7 @@ class MainWindow : public QMainWindow
 public:
 	QMdiArea* workspace()
 	{
-		return m_workspace;
+		return reinterpret_cast<QMdiArea*>(m_workspace);
 	}
 
 	QWidget* toolBar()
@@ -203,7 +205,7 @@ private:
 	bool guiSaveProject();
 	bool guiSaveProjectAs( const QString & filename );
 
-	QMdiArea * m_workspace;
+	CustomQMdiArea * m_workspace;
 
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;
@@ -258,6 +260,20 @@ signals:
 
 } ;
 
+class CustomQMdiArea : public QMdiArea
+{
+public:
+	CustomQMdiArea(QWidget* parent = nullptr);
+	~CustomQMdiArea() {}
+protected:
+	void mousePressEvent(QMouseEvent* event) override;
+	void mouseMoveEvent(QMouseEvent* event) override;
+	void mouseReleaseEvent(QMouseEvent* event) override;
+private:
+	bool m_isBeingMoved;
+	int m_lastX;
+	int m_lastY;
+};
 
 } // namespace gui
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -59,7 +59,7 @@ class MainWindow : public QMainWindow
 public:
 	QMdiArea* workspace()
 	{
-		return reinterpret_cast<QMdiArea*>(m_workspace);
+		return static_cast<QMdiArea*>(m_workspace);
 	}
 
 	QWidget* toolBar()

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -57,10 +57,7 @@ class MainWindow : public QMainWindow
 {
 	Q_OBJECT
 public:
-	QMdiArea* workspace()
-	{
-		return reinterpret_cast<QMdiArea*>(m_workspace);
-	}
+	QMdiArea* workspace();
 
 	QWidget* toolBar()
 	{
@@ -205,6 +202,21 @@ private:
 	bool guiSaveProject();
 	bool guiSaveProjectAs( const QString & filename );
 
+	class CustomQMdiArea : public QMdiArea
+	{
+	public:
+		CustomQMdiArea(QWidget* parent = nullptr);
+		~CustomQMdiArea() {}
+	protected:
+		void mousePressEvent(QMouseEvent* event) override;
+		void mouseMoveEvent(QMouseEvent* event) override;
+		void mouseReleaseEvent(QMouseEvent* event) override;
+	private:
+		bool m_isBeingMoved;
+		int m_lastX;
+		int m_lastY;
+	};
+
 	CustomQMdiArea * m_workspace;
 
 	QWidget * m_toolBar;
@@ -259,21 +271,6 @@ signals:
 	void initProgress(const QString &msg);
 
 } ;
-
-class CustomQMdiArea : public QMdiArea
-{
-public:
-	CustomQMdiArea(QWidget* parent = nullptr);
-	~CustomQMdiArea() {}
-protected:
-	void mousePressEvent(QMouseEvent* event) override;
-	void mouseMoveEvent(QMouseEvent* event) override;
-	void mouseReleaseEvent(QMouseEvent* event) override;
-private:
-	bool m_isBeingMoved;
-	int m_lastX;
-	int m_lastY;
-};
 
 } // namespace gui
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -56,7 +56,10 @@ class MainWindow : public QMainWindow
 {
 	Q_OBJECT
 public:
-	QMdiArea* workspace();
+	inline QMdiArea* workspace()
+	{
+		return static_cast<QMdiArea*>(m_workspace);
+	}
 
 	QWidget* toolBar()
 	{

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -56,7 +56,7 @@ class MainWindow : public QMainWindow
 {
 	Q_OBJECT
 public:
-	inline QMdiArea* workspace()
+	QMdiArea* workspace()
 	{
 		return static_cast<QMdiArea*>(m_workspace);
 	}

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -59,7 +59,7 @@ class MainWindow : public QMainWindow
 public:
 	QMdiArea* workspace()
 	{
-		return static_cast<QMdiArea*>(m_workspace);
+		return reinterpret_cast<QMdiArea*>(m_workspace);
 	}
 
 	QWidget* toolBar()

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -46,7 +46,6 @@ class ConfigManager;
 namespace gui
 {
 
-class CustomQMdiArea;
 class PluginView;
 class SubWindow;
 class ToolButton;
@@ -202,11 +201,11 @@ private:
 	bool guiSaveProject();
 	bool guiSaveProjectAs( const QString & filename );
 
-	class CustomQMdiArea : public QMdiArea
+	class MovableQMdiArea : public QMdiArea
 	{
 	public:
-		CustomQMdiArea(QWidget* parent = nullptr);
-		~CustomQMdiArea() {}
+		MovableQMdiArea(QWidget* parent = nullptr);
+		~MovableQMdiArea() {}
 	protected:
 		void mousePressEvent(QMouseEvent* event) override;
 		void mouseMoveEvent(QMouseEvent* event) override;
@@ -217,7 +216,7 @@ private:
 		int m_lastY;
 	};
 
-	CustomQMdiArea * m_workspace;
+	MovableQMdiArea * m_workspace;
 
 	QWidget * m_toolBar;
 	QGridLayout * m_toolBarLayout;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -531,11 +531,6 @@ void MainWindow::finalize()
 }
 
 
-QMdiArea* MainWindow::workspace()
-{
-	return static_cast<QMdiArea*>(m_workspace);
-}
-
 int MainWindow::addWidgetToToolBar( QWidget * _w, int _row, int _col )
 {
 	int col = ( _col == -1 ) ? m_toolBarLayout->columnCount() + 7 : _col;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -159,7 +159,7 @@ MainWindow::MainWindow() :
 	sideBar->appendTab(new FileBrowser(root_paths.join("*"), FileItem::defaultFilters(), title,
 		embed::getIconPixmap("computer").transformed(QTransform().rotate(90)), splitter, dirs_as_items));
 
-	m_workspace = new QMdiArea(splitter);
+	m_workspace = new CustomQMdiArea(splitter);
 
 	// Load background
 	emit initProgress(tr("Loading background picture"));
@@ -1611,5 +1611,36 @@ void MainWindow::onProjectFileNameChanged()
 	this->resetWindowTitle();
 }
 
+CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
+	QMdiArea(parent),
+	m_isBeingMoved(false)
+{
+	
+}
+void CustomQMdiArea::mousePressEvent(QMouseEvent* event)
+{
+	m_lastX = event->x();
+	m_lastY = event->y();
+	m_isBeingMoved = true;
+}
+void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
+{
+	if (m_isBeingMoved == false) { return; }
+	if (m_lastX != event->x())
+	{
+		horizontalScrollBar()->setValue(horizontalScrollBar()->value() + m_lastX - event->x());
+		m_lastX = event->x();
+	}
+	if (m_lastY != event->y())
+	{
+		verticalScrollBar()->setValue(verticalScrollBar()->value() + m_lastY - event->y());
+		//verticalScrollBar()->setValue(newScroll);
+		m_lastY = event->y();
+	}
+}
+void CustomQMdiArea::mouseReleaseEvent(QMouseEvent* event)
+{
+	m_isBeingMoved = false;
+}
 
 } // namespace lmms::gui

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1613,7 +1613,9 @@ void MainWindow::onProjectFileNameChanged()
 
 CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
 	QMdiArea(parent),
-	m_isBeingMoved(false)
+	m_isBeingMoved(false),
+	m_lastX(0),
+	m_lastY(0)
 {}
 
 void CustomQMdiArea::mousePressEvent(QMouseEvent* event)
@@ -1626,11 +1628,14 @@ void CustomQMdiArea::mousePressEvent(QMouseEvent* event)
 void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 {
 	if (m_isBeingMoved == false) { return; }
+
+
 	if (m_lastX != event->x())
 	{
 		horizontalScrollBar()->setValue(horizontalScrollBar()->value() + m_lastX - event->x());
 		m_lastX = event->x();
 	}
+
 	if (m_lastY != event->y())
 	{
 		verticalScrollBar()->setValue(verticalScrollBar()->value() + m_lastY - event->y());

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1634,7 +1634,6 @@ void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 	if (m_lastY != event->y())
 	{
 		verticalScrollBar()->setValue(verticalScrollBar()->value() + m_lastY - event->y());
-		//verticalScrollBar()->setValue(newScroll);
 		m_lastY = event->y();
 	}
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1614,9 +1614,7 @@ MainWindow::MovableQMdiArea::MovableQMdiArea(QWidget* parent) :
 	m_isBeingMoved(false),
 	m_lastX(0),
 	m_lastY(0)
-{
-	setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
-}
+{}
 
 void MainWindow::MovableQMdiArea::mousePressEvent(QMouseEvent* event)
 {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1614,15 +1614,15 @@ void MainWindow::onProjectFileNameChanged()
 CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
 	QMdiArea(parent),
 	m_isBeingMoved(false)
-{
-	
-}
+{}
+
 void CustomQMdiArea::mousePressEvent(QMouseEvent* event)
 {
 	m_lastX = event->x();
 	m_lastY = event->y();
 	m_isBeingMoved = true;
 }
+
 void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 {
 	if (m_isBeingMoved == false) { return; }
@@ -1638,6 +1638,7 @@ void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 		m_lastY = event->y();
 	}
 }
+
 void CustomQMdiArea::mouseReleaseEvent(QMouseEvent* event)
 {
 	m_isBeingMoved = false;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1614,13 +1614,16 @@ MainWindow::MovableQMdiArea::MovableQMdiArea(QWidget* parent) :
 	m_isBeingMoved(false),
 	m_lastX(0),
 	m_lastY(0)
-{}
+{
+	setSizeAdjustPolicy(QAbstractScrollArea::AdjustIgnored);
+}
 
 void MainWindow::MovableQMdiArea::mousePressEvent(QMouseEvent* event)
 {
 	m_lastX = event->x();
 	m_lastY = event->y();
 	m_isBeingMoved = true;
+	setCursor(Qt::ClosedHandCursor);
 }
 
 void MainWindow::MovableQMdiArea::mouseMoveEvent(QMouseEvent* event)
@@ -1643,6 +1646,7 @@ void MainWindow::MovableQMdiArea::mouseMoveEvent(QMouseEvent* event)
 
 void MainWindow::MovableQMdiArea::mouseReleaseEvent(QMouseEvent* event)
 {
+	setCursor(Qt::ArrowCursor);
 	m_isBeingMoved = false;
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1638,10 +1638,10 @@ void MainWindow::MovableQMdiArea::mouseMoveEvent(QMouseEvent* event)
 	{
 		if (curWindow->isVisible())
 		{
-			minX = minX > curWindow->x() ? curWindow->x() : minX;
-			maxX = maxX < curWindow->x() + curWindow->width() ? curWindow->x() + curWindow->width() : maxX;
-			minY = minY > curWindow->y() ? curWindow->y() : minY;
-			maxY = maxY < curWindow->y() + curWindow->height() ? curWindow->y() + curWindow->height() : maxY;
+			minX = std::min(minX, curWindow->x());
+			maxX = std::max(maxX, curWindow->x() + curWindow->width());
+			minY = std::min(minY, curWindow->y());
+			maxY = std::max(maxY, curWindow->y() + curWindow->height());
 		}
 	}
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -159,7 +159,7 @@ MainWindow::MainWindow() :
 	sideBar->appendTab(new FileBrowser(root_paths.join("*"), FileItem::defaultFilters(), title,
 		embed::getIconPixmap("computer").transformed(QTransform().rotate(90)), splitter, dirs_as_items));
 
-	m_workspace = new CustomQMdiArea(splitter);
+	m_workspace = new MovableQMdiArea(splitter);
 
 	// Load background
 	emit initProgress(tr("Loading background picture"));
@@ -1614,21 +1614,21 @@ void MainWindow::onProjectFileNameChanged()
 	this->resetWindowTitle();
 }
 
-MainWindow::CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
+MainWindow::MovableQMdiArea::MovableQMdiArea(QWidget* parent) :
 	QMdiArea(parent),
 	m_isBeingMoved(false),
 	m_lastX(0),
 	m_lastY(0)
 {}
 
-void MainWindow::CustomQMdiArea::mousePressEvent(QMouseEvent* event)
+void MainWindow::MovableQMdiArea::mousePressEvent(QMouseEvent* event)
 {
 	m_lastX = event->x();
 	m_lastY = event->y();
 	m_isBeingMoved = true;
 }
 
-void MainWindow::CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
+void MainWindow::MovableQMdiArea::mouseMoveEvent(QMouseEvent* event)
 {
 	if (m_isBeingMoved == false) { return; }
 
@@ -1646,7 +1646,7 @@ void MainWindow::CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 	}
 }
 
-void MainWindow::CustomQMdiArea::mouseReleaseEvent(QMouseEvent* event)
+void MainWindow::MovableQMdiArea::mouseReleaseEvent(QMouseEvent* event)
 {
 	m_isBeingMoved = false;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -531,7 +531,10 @@ void MainWindow::finalize()
 }
 
 
-
+QMdiArea* MainWindow::workspace()
+{
+	return static_cast<QMdiArea*>(m_workspace);
+}
 
 int MainWindow::addWidgetToToolBar( QWidget * _w, int _row, int _col )
 {
@@ -1611,21 +1614,21 @@ void MainWindow::onProjectFileNameChanged()
 	this->resetWindowTitle();
 }
 
-CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
+MainWindow::CustomQMdiArea::CustomQMdiArea(QWidget* parent) :
 	QMdiArea(parent),
 	m_isBeingMoved(false),
 	m_lastX(0),
 	m_lastY(0)
 {}
 
-void CustomQMdiArea::mousePressEvent(QMouseEvent* event)
+void MainWindow::CustomQMdiArea::mousePressEvent(QMouseEvent* event)
 {
 	m_lastX = event->x();
 	m_lastY = event->y();
 	m_isBeingMoved = true;
 }
 
-void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
+void MainWindow::CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 {
 	if (m_isBeingMoved == false) { return; }
 
@@ -1643,7 +1646,7 @@ void CustomQMdiArea::mouseMoveEvent(QMouseEvent* event)
 	}
 }
 
-void CustomQMdiArea::mouseReleaseEvent(QMouseEvent* event)
+void MainWindow::CustomQMdiArea::mouseReleaseEvent(QMouseEvent* event)
 {
 	m_isBeingMoved = false;
 }


### PR DESCRIPTION
This Pull Request adds the ability for users to move inside the workspace without using the scroll bars.

This change allows the user to click on the workspace (where the editors are located) without clicking on a `SubWindow`, and move by mouse drag. I believe this improves the workflow significantly, because instead of needing to move the mouse over to the scroll bars, the user can simply click on the workspace background and move both vertically and horizontally.

As far as I know there is no Issue open referencing this feature.