### PR TITLE
[feature/detach-window] Transfer size restrictions to embedded widget from SubWindow

### DIFF
--- a/plugins/LadspaBrowser/LadspaBrowser.cpp
+++ b/plugins/LadspaBrowser/LadspaBrowser.cpp
@@ -140,18 +140,13 @@ LadspaBrowserView::LadspaBrowserView( ToolPlugin * _tool ) :
 	hlayout->addWidget( ws );
 	hlayout->addSpacing( 10 );
 	hlayout->addStretch();
+	
+	layout()->setSizeConstraint(QLayout::SetFixedSize);
 
 	hide();
 	if( parentWidget() )
 	{
 		parentWidget()->hide();
-		parentWidget()->layout()->setSizeConstraint(
-							QLayout::SetFixedSize );
-		
-		Qt::WindowFlags flags = parentWidget()->windowFlags();
-		flags |= Qt::MSWindowsFixedSizeDialogHint;
-		flags &= ~Qt::WindowMaximizeButtonHint;
-		parentWidget()->setWindowFlags( flags );
 	}
 }
 

--- a/plugins/TapTempo/TapTempoView.cpp
+++ b/plugins/TapTempo/TapTempoView.cpp
@@ -129,10 +129,10 @@ TapTempoView::TapTempoView(TapTempo* plugin)
 	});
 
 	hide();
+	layout()->setSizeConstraint(QLayout::SetFixedSize);
 	if (parentWidget())
 	{
 		parentWidget()->hide();
-		parentWidget()->layout()->setSizeConstraint(QLayout::SetFixedSize);
 
 		Qt::WindowFlags flags = parentWidget()->windowFlags();
 		flags |= Qt::MSWindowsFixedSizeDialogHint;

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -937,12 +937,9 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 	widget = new QWidget(this);
 	l = new QGridLayout( this );
 
-	m_vi->m_subWindow = getGUI()->mainWindow()->addWindowedWidget(nullptr, Qt::SubWindow |
-			Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint);
-	m_vi->m_subWindow->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::MinimumExpanding );
-	m_vi->m_subWindow->setFixedWidth( 960 );
-	m_vi->m_subWindow->setMinimumHeight( 300 );
-	m_vi->m_subWindow->setWidget(m_vi->m_scrollArea);
+	m_vi->m_subWindow = getGUI()->mainWindow()->addWindowedWidget(m_vi->m_scrollArea);
+	m_vi->m_scrollArea->setFixedWidth(960);
+	m_vi->m_scrollArea->setMinimumHeight(300);
 	m_vi->m_subWindow->setWindowTitle( m_vi->instrumentTrack()->name()
 								+ tr( " - VST plugin control" ) );
 	m_vi->m_subWindow->setWindowIcon( PLUGIN_NAME::getIconPixmap( "logo" ) );

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -32,6 +32,7 @@
 
 #include "Instrument.h"
 #include "InstrumentView.h"
+#include "SubWindow.h"
 
 
 class QPixmap;
@@ -87,7 +88,7 @@ private:
 	QMutex m_pluginMutex;
 
 	QString m_pluginDLL;
-	QMdiSubWindow * m_subWindow;
+	gui::SubWindow* m_subWindow;
 	QScrollArea * m_scrollArea;
 	FloatModel ** knobFModel;
 	QObject * p_subWindow;

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -78,7 +78,7 @@ ControllerRackView::ControllerRackView()
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
-	SubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
+	SubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 
 	setFixedWidth(350);
 	setMinimumHeight(200);

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -78,15 +78,10 @@ ControllerRackView::ControllerRackView()
 	layout->addWidget( m_addButton );
 	this->setLayout( layout );
 
-	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget( this );
+	SubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 
-	// TODO: Automate setting one of these, stop hardcoding title bar height
-	// Set dimensions for detached mode
 	setFixedWidth(350);
 	setMinimumHeight(200);
-	// Set dimensions for embedded mode
-	subWin->setFixedWidth(350);
-	subWin->setMinimumHeight(230);
 
 	// No maximize button
 	Qt::WindowFlags flags = subWin->windowFlags();

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -202,7 +202,7 @@ MicrotunerConfig::MicrotunerConfig() :
 	this->setLayout(microtunerLayout);
 
 	// Add to the main window and setup fixed size etc.
-	SubWindow *subWin = getGUI()->mainWindow()->addWindowedWidget(this);
+	SubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 	subWin->setAttribute(Qt::WA_DeleteOnClose, false);
 	setMinimumSize(300, 300);
 	setMaximumSize(500, 700);

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -202,13 +202,10 @@ MicrotunerConfig::MicrotunerConfig() :
 	this->setLayout(microtunerLayout);
 
 	// Add to the main window and setup fixed size etc.
-	QMdiSubWindow *subWin = getGUI()->mainWindow()->addWindowedWidget(this);
-
+	SubWindow *subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 	subWin->setAttribute(Qt::WA_DeleteOnClose, false);
-	subWin->setMinimumWidth(300);
-	subWin->setMinimumHeight(300);
-	subWin->setMaximumWidth(500);
-	subWin->setMaximumHeight(700);
+	setMinimumSize(300, 300);
+	setMaximumSize(500, 700);
 	subWin->hide();
 
 	// No maximize button

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -49,7 +49,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	setWindowIcon(embed::getIconPixmap("midi_cc_rack"));
 	setWindowTitle(tr("MIDI CC Rack - %1").arg(m_track->name()));
 
-	SubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
+	SubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 
 	// Remove maximize button
 	Qt::WindowFlags flags = subWin->windowFlags();

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -49,7 +49,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	setWindowIcon(embed::getIconPixmap("midi_cc_rack"));
 	setWindowTitle(tr("MIDI CC Rack - %1").arg(m_track->name()));
 
-	QMdiSubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
+	SubWindow * subWin = getGUI()->mainWindow()->addWindowedWidget(this);
 
 	// Remove maximize button
 	Qt::WindowFlags flags = subWin->windowFlags();
@@ -58,9 +58,8 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 
 	// Adjust window attributes, sizing and position
 	subWin->setAttribute(Qt::WA_DeleteOnClose, false);
-	subWin->resize(350, 300);
-	subWin->setFixedWidth(350);
-	subWin->setMinimumHeight(300);
+	setFixedWidth(350);
+	setMinimumHeight(300);
 	subWin->hide();
 
 	// Main window layout

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -173,7 +173,7 @@ MixerView::MixerView(Mixer* mixer) :
 	layout()->setSizeConstraint(QLayout::SetMinimumSize);
 
 	// add ourself to workspace
-	QMdiSubWindow* subWin = mainWindow->addWindowedWidget(this);
+	[[maybe_unused]] SubWindow* subWin = mainWindow->addWindowedWidget(this);
 
 	parentWidget()->setAttribute(Qt::WA_DeleteOnClose, false);
 	parentWidget()->move(5, 310);

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -169,17 +169,11 @@ MixerView::MixerView(Mixer* mixer) :
 	// adjust window size
 	layout()->invalidate();
 	resize(sizeHint());
-	if (parentWidget())
-	{
-		parentWidget()->resize(parentWidget()->sizeHint());
-	}
 	setFixedHeight(height());
+	layout()->setSizeConstraint(QLayout::SetMinimumSize);
 
 	// add ourself to workspace
 	QMdiSubWindow* subWin = mainWindow->addWindowedWidget(this);
-	layout()->setSizeConstraint(QLayout::SetMinimumSize);
-	subWin->layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
-	subWin->setFixedHeight(subWin->height());
 
 	parentWidget()->setAttribute(Qt::WA_DeleteOnClose, false);
 	parentWidget()->move(5, 310);

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -38,6 +38,7 @@
 #include <QPushButton>
 #include <QWindow>
 #include <QStyleOption>
+#include <QLayout>
 
 #include "embed.h"
 
@@ -92,6 +93,8 @@ SubWindow::SubWindow(QWidget *parent, Qt::WindowFlags windowFlags) :
 	m_windowTitle->setFocusPolicy( Qt::NoFocus );
 	m_windowTitle->setAttribute( Qt::WA_TransparentForMouseEvents, true );
 	m_windowTitle->setGraphicsEffect( m_shadow );
+
+	layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
 
 	// Disable the minimize button and make sure that the custom window hint is set
 	setWindowFlags((this->windowFlags() & ~Qt::WindowMinimizeButtonHint) | Qt::CustomizeWindowHint);
@@ -517,5 +520,6 @@ bool SubWindow::eventFilter(QObject* obj, QEvent* event)
 		return QMdiSubWindow::eventFilter(obj, event);
 	}
 }
+
 
 } // namespace lmms::gui

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -283,7 +283,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 
 	updateInstrumentView();
 
-	QMdiSubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget( this );
+	SubWindow* subWin = getGUI()->mainWindow()->addWindowedWidget( this );
 	Qt::WindowFlags flags = subWin->windowFlags();
 	if (!m_instrumentView->isResizable()) {
 		flags |= Qt::MSWindowsFixedSizeDialogHint;
@@ -293,8 +293,8 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 		// Does the same thing, for detached detached windows, for other OSs.
 		
 	} else {
-		subWin->setMaximumSize(m_instrumentView->maximumWidth() + 12, m_instrumentView->maximumHeight() + 208);
-		subWin->setMinimumSize(m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
+		setMaximumSize(m_instrumentView->maximumWidth() + 12, m_instrumentView->maximumHeight() + 208);
+		setMinimumSize(m_instrumentView->minimumWidth() + 12, m_instrumentView->minimumHeight() + 208);
 	}
 	flags &= ~Qt::WindowMaximizeButtonHint;
 	subWin->setWindowFlags( flags );

--- a/src/gui/widgets/TempoSyncBarModelEditor.cpp
+++ b/src/gui/widgets/TempoSyncBarModelEditor.cpp
@@ -202,7 +202,7 @@ void TempoSyncBarModelEditor::showCustom()
 	if(m_custom == nullptr)
 	{
 		m_custom = new MeterDialog(getGUI()->mainWindow()->workspace());
-		SubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
+		SubWindow* subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
 		Qt::WindowFlags flags = subWindow->windowFlags();
 		flags &= ~Qt::WindowMaximizeButtonHint;
 		subWindow->setWindowFlags(flags);

--- a/src/gui/widgets/TempoSyncBarModelEditor.cpp
+++ b/src/gui/widgets/TempoSyncBarModelEditor.cpp
@@ -202,11 +202,11 @@ void TempoSyncBarModelEditor::showCustom()
 	if(m_custom == nullptr)
 	{
 		m_custom = new MeterDialog(getGUI()->mainWindow()->workspace());
-		QMdiSubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
+		SubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
 		Qt::WindowFlags flags = subWindow->windowFlags();
 		flags &= ~Qt::WindowMaximizeButtonHint;
 		subWindow->setWindowFlags(flags);
-		subWindow->setFixedSize(subWindow->size());
+		setFixedSize(size());
 		m_custom->setWindowTitle("Meter");
 		m_custom->setModel(&model()->getCustomMeterModel());
 	}

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -295,7 +295,7 @@ void TempoSyncKnob::showCustom()
 	if( m_custom == nullptr )
 	{
 		m_custom = new MeterDialog( getGUI()->mainWindow()->workspace() );
-		SubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
+		SubWindow* subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
 		Qt::WindowFlags flags = subWindow->windowFlags();
 		flags &= ~Qt::WindowMaximizeButtonHint;
 		subWindow->setWindowFlags( flags );

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -295,11 +295,11 @@ void TempoSyncKnob::showCustom()
 	if( m_custom == nullptr )
 	{
 		m_custom = new MeterDialog( getGUI()->mainWindow()->workspace() );
-		QMdiSubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget( m_custom );
+		SubWindow * subWindow = getGUI()->mainWindow()->addWindowedWidget(m_custom);
 		Qt::WindowFlags flags = subWindow->windowFlags();
 		flags &= ~Qt::WindowMaximizeButtonHint;
 		subWindow->setWindowFlags( flags );
-		subWindow->setFixedSize( subWindow->size() );
+		setFixedSize(size());
 		m_custom->setWindowTitle( "Meter" );
 		m_custom->setModel( &model()->m_custom );
 	}


### PR DESCRIPTION
This is the first part which mostly unifies how existing size restrictions are handled. It seems most other restrictions happen in plugins, I intend to do them a bit later.