### PR TITLE
Disable focus for new channel button

### DIFF
--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -150,6 +150,7 @@ MixerView::MixerView(Mixer* mixer) :
 	newChannelBtn->setObjectName("newChannelBtn");
 	newChannelBtn->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
 	newChannelBtn->setFixedWidth(mixerChannelSize.width());
+	newChannelBtn->setFocusPolicy(Qt::NoFocus);
 	connect(newChannelBtn, SIGNAL(clicked()), this, SLOT(addNewChannel()));
 	ml->addWidget(newChannelBtn, 0);
 


### PR DESCRIPTION
Disable grabbing focus for the new channel button in Mixer. I think this button grabbing focus goes against expectations but let me know what you think.