### PR TITLE
Add support for drawing sample waveforms in viewports

### DIFF
--- a/include/SampleWaveform.h
+++ b/include/SampleWaveform.h
@@ -26,8 +26,9 @@
 #define LMMS_GUI_SAMPLE_WAVEFORM_H
 
 #include <QPainter>
+#include <cmath>
 
-#include "Sample.h"
+#include "SampleFrame.h"
 #include "lmms_export.h"
 
 namespace lmms::gui {
@@ -36,13 +37,17 @@ class LMMS_EXPORT SampleWaveform
 public:
 	struct Parameters
 	{
-		const SampleFrame* buffer;
-		size_t size;
-		float amplification;
-		bool reversed;
+		const SampleFrame* buffer; //!< The buffer to all the samples contained within the rectangle
+		size_t size;			   //!< The number of samples contained within the rectangle
+		float amplification;	   //!< Amplfication to apply to the waveform
+		bool reversed;			   //!< If the waveform should be drawn in reverse
 	};
 
-	static void visualize(Parameters parameters, QPainter& painter, const QRect& rect);
+	//! Visualize a sample waveform.
+	//! `rect` is the rectangle that contains the all the samples. It specifies where the full waveform would be drawn
+	//! and for how long. `viewport` is a viewport into `rect` and specifies where the drawing will happen and for how
+	//! long. The position of `rect` should be specified relative to the `viewport`.
+	static void visualize(Parameters parameters, QPainter& painter, const QRect& rect, const QRect& viewport);
 };
 } // namespace lmms::gui
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -344,7 +344,7 @@ void AudioFileProcessorWaveView::updateGraph()
 	const auto rect = QRect{0, 0, m_graph.width(), m_graph.height()};
 	const auto waveform = SampleWaveform::Parameters{
 		m_sample->data() + dataOffset, static_cast<size_t>(range()), m_sample->amplification(), m_sample->reversed()};
-	SampleWaveform::visualize(waveform, p, rect);
+	SampleWaveform::visualize(waveform, p, rect, rect);
 }
 
 void AudioFileProcessorWaveView::zoom(const bool out)

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.h
@@ -27,7 +27,7 @@
 
 
 #include "Knob.h"
-
+#include "Sample.h"
 
 namespace lmms
 {

--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -118,7 +118,7 @@ void SlicerTWaveform::drawSeekerWaveform()
 	const auto waveform
 		= SampleWaveform::Parameters{sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
 	const auto rect = QRect(0, 0, m_seekerWaveform.width(), m_seekerWaveform.height());
-	SampleWaveform::visualize(waveform, brush, rect);
+	SampleWaveform::visualize(waveform, brush, rect, rect);
 
 	// increase brightness in inner color
 	QBitmap innerMask = m_seekerWaveform.createMaskFromColor(s_waveformMaskColor, Qt::MaskMode::MaskOutColor);
@@ -177,7 +177,7 @@ void SlicerTWaveform::drawEditorWaveform()
 	const auto waveform = SampleWaveform::Parameters{
 		sample.data() + startFrame, endFrame - startFrame, sample.amplification(), sample.reversed()};
 	const auto rect = QRect(0, zoomOffset, m_editorWidth, m_zoomLevel * m_editorHeight);
-	SampleWaveform::visualize(waveform, brush, rect);
+	SampleWaveform::visualize(waveform, brush, rect, rect);
 
 	// increase brightness in inner color
 	QBitmap innerMask = m_editorWaveform.createMaskFromColor(s_waveformMaskColor, Qt::MaskMode::MaskOutColor);

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -53,7 +53,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 		const auto lineY1 = centerY - maxPeak * halfHeight * parameters.amplification;
 		const auto lineY2 = centerY - minPeak * halfHeight * parameters.amplification;
-		const auto lineX = rect.x() + i;
+		const auto lineX = rect.x() + (parameters.reversed ? numPixelsToDraw - i : i);
 
 		const auto squaredSum = std::accumulate(start, end, 0.0f, squaredSumFn);
 		const auto rms = std::sqrt(squaredSum / samplesPerPixel);

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -51,8 +51,8 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 		const auto endSample = parameters.buffer + endSampleIndex;
 
 		const auto [minPeak, maxPeak] = std::minmax_element(&startSample->left(), &endSample->right());
-		const auto yMin = rect.center().y() - *minPeak * parameters.amplification * verticalScale;
-		const auto yMax = rect.center().y() - *maxPeak * parameters.amplification * verticalScale;
+		const auto yMin = rect.center().y() - (*minPeak) * parameters.amplification * verticalScale;
+		const auto yMax = rect.center().y() - (*maxPeak) * parameters.amplification * verticalScale;
 
 		painter.drawLine(xPos, yMin, xPos, yMax);
 	}

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -53,16 +53,16 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 		const auto lineY1 = centerY - maxPeak * halfHeight * parameters.amplification;
 		const auto lineY2 = centerY - minPeak * halfHeight * parameters.amplification;
-		const auto lineX = static_cast<float>(rect.x() + i);
+		const auto lineX = rect.x() + i;
 
 		const auto squaredSum = std::accumulate(start, end, 0.0f, squaredSumFn);
 		const auto rms = std::sqrt(squaredSum / samplesPerPixel);
 		const auto rmsLineY1 = centerY - rms * halfHeight * parameters.amplification;
 		const auto rmsLineY2 = centerY + rms * halfHeight * parameters.amplification;
 
-		painter.drawLine(QLineF{lineX, lineY1, lineX, lineY2});
+		painter.drawLine(lineX, lineY1, lineX, lineY2);
 		painter.setPen(rmsColor);
-		painter.drawLine(QLineF{lineX, rmsLineY1, lineX, rmsLineY2});
+		painter.drawLine(lineX, rmsLineY1, lineX, rmsLineY2);
 		painter.setPen(color);
 	}
 }

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -36,7 +36,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	const auto color = painter.pen().color();
 	const auto rmsColor = color.lighter(123);
 
-	const auto samplesPerPixel = std::max(1.0f, static_cast<float>(parameters.size) / rect.width());
+	const auto samplesPerPixel = std::max(1.0, static_cast<double>(parameters.size) / rect.width());
 	const auto numPixelsToDraw = std::min(static_cast<int>(parameters.size), rect.width());
 
 	const auto compFn = [](const SampleFrame& a, const SampleFrame& b) { return a.average() < b.average(); };

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -36,17 +36,16 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	const auto color = painter.pen().color();
 	const auto rmsColor = color.lighter(123);
 
-	const auto samplesPerPixel = std::max(1, static_cast<int>(parameters.size) / rect.width());
+	const auto samplesPerPixel = std::max(1.0f, static_cast<float>(parameters.size) / rect.width());
+	const auto numDrawPixels = std::min(static_cast<int>(parameters.size), rect.width());
 
 	const auto compFn = [](const SampleFrame& a, const SampleFrame& b) { return a.average() < b.average(); };
 	const auto squaredSumFn = [](const float acc, const SampleFrame& x) { return acc + x.average() * x.average(); };
 
-	for (auto i = 0; i < rect.width(); i++)
+	for (auto i = 0; i < numDrawPixels; i++)
 	{
-		const auto start = parameters.buffer + i * samplesPerPixel;
-		const auto end = start + samplesPerPixel;
-
-		if (start >= parameters.buffer + parameters.size || end > parameters.buffer + parameters.size) { return; }
+		const auto start = parameters.buffer + static_cast<int>(std::floor(i * samplesPerPixel));
+		const auto end = parameters.buffer + static_cast<int>(std::ceil((i + 1) * samplesPerPixel));
 
 		const auto [min, max] = std::minmax_element(start, end, compFn);
 		const auto minPeak = min->average();

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -37,12 +37,12 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 	const auto rmsColor = color.lighter(123);
 
 	const auto samplesPerPixel = std::max(1.0f, static_cast<float>(parameters.size) / rect.width());
-	const auto numDrawPixels = std::min(static_cast<int>(parameters.size), rect.width());
+	const auto numPixelsToDraw = std::min(static_cast<int>(parameters.size), rect.width());
 
 	const auto compFn = [](const SampleFrame& a, const SampleFrame& b) { return a.average() < b.average(); };
 	const auto squaredSumFn = [](const float acc, const SampleFrame& x) { return acc + x.average() * x.average(); };
 
-	for (auto i = 0; i < numDrawPixels; i++)
+	for (auto i = 0; i < numPixelsToDraw; i++)
 	{
 		const auto start = parameters.buffer + static_cast<int>(std::floor(i * samplesPerPixel));
 		const auto end = parameters.buffer + static_cast<int>(std::ceil((i + 1) * samplesPerPixel));

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -35,6 +35,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	painter.save();
 	painter.setRenderHint(QPainter::Antialiasing, true);
+	painter.setClipRect(viewport);
 
 	for (auto xPos = viewport.x(); xPos < viewport.x() + viewport.width(); ++xPos)
 	{

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -54,16 +54,16 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 		const auto lineY1 = centerY - maxPeak * halfHeight * parameters.amplification;
 		const auto lineY2 = centerY - minPeak * halfHeight * parameters.amplification;
-		const auto lineX = rect.x() + i;
+		const auto lineX = static_cast<float>(rect.x() + i);
 
 		const auto squaredSum = std::accumulate(start, end, 0.0f, squaredSumFn);
 		const auto rms = std::sqrt(squaredSum / samplesPerPixel);
 		const auto rmsLineY1 = centerY - rms * halfHeight * parameters.amplification;
 		const auto rmsLineY2 = centerY + rms * halfHeight * parameters.amplification;
 
-		painter.drawLine(lineX, lineY1, lineX, lineY2);
+		painter.drawLine(QLineF{lineX, lineY1, lineX, lineY2});
 		painter.setPen(rmsColor);
-		painter.drawLine(lineX, rmsLineY1, lineX, rmsLineY2);
+		painter.drawLine(QLineF{lineX, rmsLineY1, lineX, rmsLineY2});
 		painter.setPen(color);
 	}
 }

--- a/src/gui/SampleWaveform.cpp
+++ b/src/gui/SampleWaveform.cpp
@@ -41,7 +41,7 @@ void SampleWaveform::visualize(Parameters parameters, QPainter& painter, const Q
 
 	const auto squaredSumFn = [](auto acc, auto x) { return acc + x * x; };
 
-	for (auto i = 0; i < numPixelsToDraw; i++)
+	for (auto i = 0; i < numPixelsToDraw; ++i)
 	{
 		const auto start = parameters.buffer + static_cast<int>(std::floor(i * samplesPerPixel));
 		const auto end = parameters.buffer + static_cast<int>(std::ceil((i + 1) * samplesPerPixel));

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -269,14 +269,13 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	const auto fullSampleWidth = static_cast<int>(m_clip->sampleLength() * pixelsPerBar / ticksPerBar);
 	const auto fullSampleHeight = rect().bottom() - 2 * spacing;
 	const auto fullSampleRect = QRect{sampleOffset, spacing, fullSampleWidth, fullSampleHeight};
-	const auto viewportSampleRect = QRect{pe->rect().left(), fullSampleRect.top(), pe->rect().width(), fullSampleRect.height()};
 
 	auto parameters = SampleWaveform::Parameters{};
 	parameters.buffer = m_clip->m_sample.data();
 	parameters.size = m_clip->m_sample.sampleSize();
 	parameters.amplification = m_clip->m_sample.amplification();
 	parameters.reversed = m_clip->m_sample.reversed();
-	SampleWaveform::visualize(parameters, p, fullSampleRect, viewportSampleRect);
+	SampleWaveform::visualize(parameters, p, fullSampleRect, pe->rect());
 
 	QString name = PathUtil::cleanName(m_clip->m_sample.sampleFile());
 	paintTextLabel(name, p);

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -263,7 +263,6 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 		? (parentWidget()->width() - 2 * BORDER_WIDTH) / (float)m_clip->length().getBar()
 		: ClipView::pixelsPerBar();
 
-
 	const auto ticksPerBar = Engine::getSong()->ticksPerBar();
 	const auto sampleOffset = static_cast<int>(static_cast<double>(m_clip->startTimeOffset()) / ticksPerBar * pixelsPerBar);
 

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1222,8 +1222,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 			const auto waveform = SampleWaveform::Parameters{
 				sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
 			const auto fullSampleRect = QRect(startPos, yOffset, sampleWidth, sampleHeight);
-			const auto viewportSampleRect = QRect{pe->rect().left(), fullSampleRect.top(), pe->rect().width(), fullSampleRect.height()};
-			SampleWaveform::visualize(waveform, p, fullSampleRect, viewportSampleRect);
+			SampleWaveform::visualize(waveform, p, fullSampleRect, pe->rect());
 		}
 
 		// draw ghost notes

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1221,8 +1221,9 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 			const auto& sample = m_ghostSample->sample();
 			const auto waveform = SampleWaveform::Parameters{
 				sample.data(), sample.sampleSize(), sample.amplification(), sample.reversed()};
-			const auto rect = QRect(startPos, yOffset, sampleWidth, sampleHeight);
-			SampleWaveform::visualize(waveform, p, rect);
+			const auto fullSampleRect = QRect(startPos, yOffset, sampleWidth, sampleHeight);
+			const auto viewportSampleRect = QRect{pe->rect().left(), fullSampleRect.top(), pe->rect().width(), fullSampleRect.height()};
+			SampleWaveform::visualize(waveform, p, fullSampleRect, viewportSampleRect);
 		}
 
 		// draw ghost notes


### PR DESCRIPTION
This PR was originally a refactor PR, but since the performance would get slower than what is currently there (i.e., current master skips some samples when rendering to save on performance, while the refactor didn't), I decided to go through with an overhaul.

Changes:

+ Added support for drawing sample waveforms in viewports - The number of samples to render can be limited to the visible region, giving a bunch of performance.
+ Removed RMS - Most users did not care for it. Can add it back if necessary
+ Add anti aliasing - Makes the waveforms look nicer