### PR TITLE
Add Midi Reversing

### DIFF
--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -79,6 +79,9 @@ public:
 	Note * addStepNote( int step );
 	void setStep( int step, bool enabled );
 
+	//! Horizontally flip the positions of the given notes.
+	void reverseNotes(const NoteVector& notes);
+
 	// Split the list of notes on the given position
 	void splitNotes(const NoteVector& notes, TimePos pos);
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -246,6 +246,7 @@ protected slots:
 	void clearGhostClip();
 	void glueNotes();
 	void fitNoteLengths(bool fill);
+	void reverseNotes();
 	void constrainNoteLengths(bool constrainMax);
 
 	void changeSnapMode();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -791,29 +791,11 @@ void PianoRoll::constrainNoteLengths(bool constrainMax)
 void PianoRoll::reverseNotes()
 {
 	if (!hasValidMidiClip()) { return; }
-	m_midiClip->addJournalCheckPoint();
 
 	const NoteVector selectedNotes = getSelectedNotes();
 	const auto& notes = selectedNotes.empty() ? m_midiClip->notes() : selectedNotes;
 
-	TimePos firstPos = notes.front()->pos();
-	TimePos lastPos = notes.back()->endPos();
-	// Find the actual min/max positions
-	for (auto note : notes)
-	{
-		if (note->pos() < firstPos) { firstPos = note->pos(); }
-		if (note->endPos() > lastPos) { lastPos = note->endPos(); }
-	}
-
-	for (auto note : notes)
-	{
-		TimePos oldStart = note->pos();
-		TimePos newStart = lastPos - (oldStart - firstPos) - note->length();
-		note->setPos(newStart);
-	}
-	
-	m_midiClip->rearrangeAllNotes();
-	m_midiClip->dataChanged();
+	m_midiClip->reverseNotes(notes);
 
 	update();
 	getGUI()->songEditor()->update();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4901,7 +4901,7 @@ PianoRollWindow::PianoRollWindow() :
 	auto maxLengthAction = new QAction(embed::getIconPixmap("max_length"), tr("Max length as last"), noteToolsButton);
 	connect(maxLengthAction, &QAction::triggered, [this](){ m_editor->constrainNoteLengths(true); });
 
-	auto reverseAction = new QAction(embed::getIconPixmap("back_to_start"), tr("Reverse Notes"), noteToolsButton);
+	auto reverseAction = new QAction(embed::getIconPixmap("flip_x"), tr("Reverse Notes"), noteToolsButton);
 	connect(reverseAction, &QAction::triggered, [this](){ m_editor->reverseNotes(); });
 	reverseAction->setShortcut(combine(Qt::SHIFT, Qt::Key_R));
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -808,8 +808,7 @@ void PianoRoll::reverseNotes()
 	for (auto note : notes)
 	{
 		TimePos oldStart = note->pos();
-		TimePos newEnd = lastPos - (oldStart - firstPos);
-		TimePos newStart = newEnd - note->length();
+		TimePos newStart = lastPos - (oldStart - firstPos) - note->length();
 		note->setPos(newStart);
 	}
 	

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -795,10 +795,15 @@ void PianoRoll::reverseNotes()
 
 	const NoteVector selectedNotes = getSelectedNotes();
 	const auto& notes = selectedNotes.empty() ? m_midiClip->notes() : selectedNotes;
-	const auto firstNote = notes.front();
-	const auto lastNote = notes.back();
-	const TimePos firstPos = firstNote->pos();
-	const TimePos lastPos = lastNote->endPos();
+
+	TimePos firstPos = notes.front()->pos();
+	TimePos lastPos = notes.back()->endPos();
+	// Find the actual min/max positions
+	for (auto note : notes)
+	{
+		if (note->pos() < firstPos) { firstPos = note->pos(); }
+		if (note->endPos() > lastPos) { lastPos = note->endPos(); }
+	}
 
 	for (auto note : notes)
 	{
@@ -807,6 +812,9 @@ void PianoRoll::reverseNotes()
 		TimePos newStart = newEnd - note->length();
 		note->setPos(newStart);
 	}
+	
+	m_midiClip->rearrangeAllNotes();
+	m_midiClip->dataChanged();
 
 	update();
 	getGUI()->songEditor()->update();

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -314,6 +314,25 @@ void MidiClip::setStep( int step, bool enabled )
 
 
 
+void MidiClip::reverseNotes(const NoteVector& notes)
+{
+	addJournalCheckPoint();
+
+	TimePos firstPos = (*std::min_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return Note::lessThan(n1, n2); }))->pos();
+	TimePos lastPos = (*std::max_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return n1->endPos() < n2->endPos(); }))->endPos();
+
+	for (auto note : notes)
+	{
+		TimePos oldStart = note->pos();
+		TimePos newStart = lastPos - (oldStart - firstPos) - note->length();
+		note->setPos(newStart);
+	}
+
+	rearrangeAllNotes();
+	emit dataChanged();
+}
+
+
 
 void MidiClip::splitNotes(const NoteVector& notes, TimePos pos)
 {

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -318,13 +318,13 @@ void MidiClip::reverseNotes(const NoteVector& notes)
 {
 	addJournalCheckPoint();
 
+	// Find the very first start position and the very last end position of all the notes.
 	TimePos firstPos = (*std::min_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return Note::lessThan(n1, n2); }))->pos();
 	TimePos lastPos = (*std::max_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return n1->endPos() < n2->endPos(); }))->endPos();
 
 	for (auto note : notes)
 	{
-		TimePos oldStart = note->pos();
-		TimePos newStart = lastPos - (oldStart - firstPos) - note->length();
+		TimePos newStart = lastPos - (note->pos() - firstPos) - note->length();
 		note->setPos(newStart);
 	}
 


### PR DESCRIPTION
Adds the ability to reverse the selected midi notes in the PianoRoll.

The tool is located under the wrench icon in the PianoRoll and can also be triggered with Shift-R.

![image](https://github.com/user-attachments/assets/e31c64c8-ae3b-41c7-90ed-b9229b9d6f2d)
