### PR TITLE
Fix Delete Confirmation Button Regression

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -343,7 +343,7 @@ bool MixerChannelView::confirmRemoval(int index)
 		ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning", state ? "0" : "1");
 	});
 
-	QMessageBox mb(this);
+	QMessageBox mb;
 	mb.setText(messageRemoveTrack);
 	mb.setWindowTitle(messageTitleRemoveTrack);
 	mb.setIcon(QMessageBox::Warning);

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -232,7 +232,7 @@ bool TrackOperationsWidget::confirmRemoval()
 		ConfigManager::inst()->setValue("ui", "trackdeletionwarning", state ? "0" : "1");
 	});
 
-	QMessageBox mb(this);
+	QMessageBox mb;
 	mb.setText(messageRemoveTrack);
 	mb.setWindowTitle(messageTitleRemoveTrack);
 	mb.setIcon(QMessageBox::Warning);


### PR DESCRIPTION
This pr fixes the buttons in the QMessageBox when you delete a track or a mixer channel to use the default style instead of inheriting the QPushButton style from the parent object. This is done by passing a nullptr as the parent to the constructor (or not passing anything at all).

There are other places in the lmms codebase where QMessageBox is used but the parent is not nullptr (in LOMM, AudioJack, MidiJack, MainWindow, MicrotunerConfig, ControllerConnectionDialog, and ExportProjectDialog). However, I don't believe any of them are experiencing any visual issues currently. I only fixed these two because they were noticeable.

Before:
![Screenshot From 2024-11-29 12-44-25](https://github.com/user-attachments/assets/9615a21b-a00c-4533-92ed-127be013a9d6)

After:
![Screenshot From 2024-11-29 17-17-08](https://github.com/user-attachments/assets/d610e1ce-29bd-4cc5-a3c9-5af578019961)
