### PR TITLE
Fix coarse gridlines being half as wide every 8 bars.

### DIFF
--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -140,7 +140,7 @@ void TrackContentWidget::updateBackground()
 
 	// draw coarse grid
 	pmp.setPen( QPen( coarseGridColor(), coarseGridWidth() ) );
-	for (float x = 0; x < w * 2; x += ppb * coarseGridResolution)
+	for (float x = 0; x <= w * 2; x += ppb * coarseGridResolution)
 	{
 		pmp.drawLine( QLineF( x, 0.0, x, h ) );
 	}


### PR DESCRIPTION
Addresses #7305

This fixes the issue that every 8th bar line was half as wide. This was due to an off-by-one error where the very last bar line is not drawn. This works fine when the coarse grid lines are 1px wide, but in the default theme it is 2px, so the thinness every 8 bars is quite noticeable. This is fixed by changing `<` to `<=` in the loop condition.

Before:
![Screenshot From 2024-11-30 12-50-10](https://github.com/user-attachments/assets/8b6c10f5-a37b-45ee-a5ea-ab006a8ec606)

After:
![Screenshot From 2024-11-30 13-17-59](https://github.com/user-attachments/assets/f2361051-a4e3-48e5-8b53-7a443bd1e496)


## Note
This does not address the original issue's point that the grid lines are too thick. This simply makes them all uniform. However, the thickness can be changed in the theme style.css.

Also, I do have a fear that since floats are used in the loop, that simply changing `<` to `<=` may not fully solve the issue. In my tested, it appears to have solved it, but I don't know.