### PR TITLE
Change tooltip window flags

### DIFF
--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -44,7 +44,7 @@ TextFloat::TextFloat() :
 }
 
 TextFloat::TextFloat(const QString & title, const QString & text, const QPixmap & pixmap) :
-	QWidget(getGUI()->mainWindow(), Qt::ToolTip)
+	QWidget(getGUI()->mainWindow(), Qt::Tool | Qt::FramelessWindowHint)
 {
 	QHBoxLayout * mainLayout = new QHBoxLayout();
 	setLayout(mainLayout);

--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -24,6 +24,7 @@
 
 #include "TextFloat.h"
 
+#include <QCoreApplication>
 #include <QTimer>
 #include <QPainter>
 #include <QStyleOption>
@@ -123,6 +124,8 @@ TextFloat * TextFloat::displayMessage(const QString & title,
 		tf->setAttribute(Qt::WA_DeleteOnClose, true);
 		QTimer::singleShot(timeout, tf, SLOT(close()));
 	}
+
+	QCoreApplication::processEvents();
 
 	return tf;
 }

--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -24,7 +24,6 @@
 
 #include "TextFloat.h"
 
-#include <QCoreApplication>
 #include <QTimer>
 #include <QPainter>
 #include <QStyleOption>
@@ -124,8 +123,6 @@ TextFloat * TextFloat::displayMessage(const QString & title,
 		tf->setAttribute(Qt::WA_DeleteOnClose, true);
 		QTimer::singleShot(timeout, tf, SLOT(close()));
 	}
-
-	QCoreApplication::processEvents();
 
 	return tf;
 }


### PR DESCRIPTION
Partially addresses #7145.

This PR changes the window flags of `TextFloat`s (the tooltip things which appear when loading samples/vst/etc) so that they do not stay on top of other windows.