### PR TITLE
Loop first bar until input is received when recording in PianoRoll

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -440,7 +440,7 @@ private:
 
 	bool m_mouseDownRight; //true if right click is being held down
 
-	TimeLineWidget * m_timeLine;
+	TimeLineWidget * m_timeLineWidget;
 	bool m_scrollBack;
 
 	void copyToClipboard(const NoteVector & notes ) const;

--- a/include/Song.h
+++ b/include/Song.h
@@ -229,6 +229,17 @@ public:
 	{
 		return m_recording;
 	}
+
+	inline bool isMidiClipLooping() const
+	{
+		return m_loopMidiClip;
+	}
+
+	inline void setMidiClipLooping(bool loop)
+	{
+		m_loopMidiClip = loop;
+	}
+	
 	
 	inline void setLoopRenderCount(int count)
 	{


### PR DESCRIPTION
At least two users in the span of a few days have requested a pre-roll/countdown feature in the discord. This is not that, but it is something similar:

This PR makes it so that when you press the circle record button in the PianoRoll, it will loop the first bar until you press a key. This helps when the user wants to have a "pre-roll" or countdown before you start recording so that you have time to prepare. Or if you are like me and can't figure out what to play until many bars of silence have past, this removes the need to move all the notes back to the start of the clip.

The looping does not happen if the midi clip already has notes in it, or if the loop points are enabled.

I had to add a couple functions to `Song.h` so that I could change the looping status of the playback mid-way through playing, so that I could disable the loop once input is received.

Additionally, I changed the name of `m_timeLine` in the PianoRoll code to `m_timeLineWidget`, since that more accurately reflects what it is (It's a TimeLineWidget, not a Timeline). On second thought, this may be out of the scope of this PR.