### PR TITLE
Fuse Rhythm to Melody

### DIFF
--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -122,9 +122,12 @@ public:
 	static void remove( QVector<ClipView *> clipvs );
 	static void toggleMute( QVector<ClipView *> clipvs );
 	static void mergeClips(QVector<ClipView*> clipvs);
+	void fuseRhythm(QVector<ClipView*> clipvs);
 
 	// Returns true if selection can be merged and false if not
 	static bool canMergeSelection(QVector<ClipView*> clipvs);
+	// Returns true if selection can be rhythm fused and false if not
+	bool canFuseRhythm(QVector<ClipView*> clipvs);
 
 	QColor getColorForDisplay( QColor );
 
@@ -148,7 +151,8 @@ protected:
 		Copy,
 		Paste,
 		Mute,
-		Merge
+		Merge,
+		FuseRhythm
 	};
 
 	TrackView * m_trackView;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -1362,13 +1362,13 @@ bool ClipView::canFuseRhythm(QVector<ClipView*> clipvs)
 void ClipView::fuseRhythm(QVector<ClipView*> clipvs)
 {
 	Track* melodyTrack = this->getClip()->getTrack();
-	Track* rhythmTrack;
+	Track* rhythmTrack = melodyTrack; // Temporary initialization
 	for (ClipView* clipv : clipvs)
 	{
 		if (clipv->getClip()->getTrack() != melodyTrack) { rhythmTrack = clipv->getClip()->getTrack(); break; }
 	}
 
-	if (!melodyTrack || !rhythmTrack)
+	if (!melodyTrack || melodyTrack == rhythmTrack)
 	{
 		qWarning("Warning: Couldn't retrieve melody or rhythm InstrumentTrack in fuseRhythm()");
 		return;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -1414,7 +1414,6 @@ void ClipView::fuseRhythm(QVector<ClipView*> clipvs)
 				movedNote.setPos(movedNote.pos() + clipOffset);
 				melodyNotes.push_back(movedNote);
 			}
-			clipv->getClip()->saveJournallingState(false);
 			clipv->remove();
 		}
 		else if (mclip->getTrack() == rhythmTrack)

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -1431,19 +1431,21 @@ void ClipView::fuseRhythm(QVector<ClipView*> clipvs)
 	std::sort(melodyNotes.begin(), melodyNotes.end(), [](Note a, Note b){ return a.pos() < b.pos(); });
 	std::sort(rhythmNotes.begin(), rhythmNotes.end(), [](Note a, Note b){ return a.pos() < b.pos(); });
 
-	TimePos lastTime = TimePos(0);
-	int noteCount = 0;
-	for (Note note : melodyNotes)
+	size_t noteCount = 0;
+	for (auto it = melodyNotes.begin(); it != melodyNotes.end(); ++it)
 	{
-		Note* newNote = newMidiClip->addNote(note, false);
-		Note rhythmNote = rhythmNotes.at(noteCount);
-		newNote->setPos(rhythmNote.pos());
-		newNote->setLength(rhythmNote.length());
-		newNote->setVolume(rhythmNote.getVolume());
-		newNote->setPanning(rhythmNote.getPanning());
-
-		// Only increment if the notes are at different times (not a chord)
-		if (note.pos() > lastTime) { noteCount++; lastTime = note.pos(); }
+		Note* newNote = newMidiClip->addNote(*it, false);
+		
+		if (noteCount < rhythmNotes.size())
+		{
+			Note rhythmNote = rhythmNotes.at(noteCount);
+			newNote->setPos(rhythmNote.pos());
+			newNote->setLength(rhythmNote.length());
+			newNote->setVolume(rhythmNote.getVolume());
+			newNote->setPanning(rhythmNote.getPanning());
+		}
+		// Only increment if the next note is at a different time (to prevent chords from getting split up)
+		if ((*it).pos() != (*std::next(it, 1)).pos()) { noteCount++; }
 	}
 	// Update length since we might have moved notes beyond the end of the MidiClip length
 	newMidiClip->updateLength();

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -30,6 +30,7 @@
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QDebug>
 
 #include "AutomationClip.h"
 #include "Clipboard.h"
@@ -1090,6 +1091,15 @@ void ClipView::contextMenuEvent( QContextMenuEvent * cme )
 				[this]() { contextMenuAction(ContextMenuAction::Merge); }
 			);
 		}
+
+		if (canFuseRhythm(selectedClips))
+		{
+			contextMenu.addAction(
+				embed::getIconPixmap("edit_merge"),
+				tr("Fuse Rhythm to Melody"),
+				[this]() { contextMenuAction(ContextMenuAction::FuseRhythm); }
+			);
+		}
 	}
 
 	contextMenu.addAction(
@@ -1152,6 +1162,9 @@ void ClipView::contextMenuAction( ContextMenuAction action )
 			break;
 		case ContextMenuAction::Merge:
 			mergeClips(active);
+			break;
+		case ContextMenuAction::FuseRhythm:
+			fuseRhythm(active);
 			break;
 	}
 }
@@ -1328,6 +1341,93 @@ void ClipView::mergeClips(QVector<ClipView*> clipvs)
 	Engine::getSong()->setModified();
 	getGUI()->songEditor()->update();
 }
+
+bool ClipView::canFuseRhythm(QVector<ClipView*> clipvs)
+{
+	// Can only fuse rhythm from one clip to another.
+	// TODO change this someday to allow multiple clips on the same tracks.
+	if (clipvs.size() != 2) { return false; }
+	if (this != clipvs.at(0) && this != clipvs.at(1)) { return false; }
+
+	// We check if the owner of the first Clip is an Instrument Track
+	bool isInstrumentTrack = dynamic_cast<InstrumentTrackView*>(clipvs.at(0)->getTrackView());
+
+	// Then we create a set with all the Clips owners
+	std::set<TrackView*> ownerTracks;
+	for (auto clipv: clipvs) { ownerTracks.insert(clipv->getTrackView()); }
+
+	// Can only fuse if the rhythm clip and melody clip are on different tracks.
+	return isInstrumentTrack && ownerTracks.size() == 2;
+}
+
+void ClipView::fuseRhythm(QVector<ClipView*> clipvs)
+{
+	auto melodyClip = dynamic_cast<MidiClip*>(getClip());
+	auto rhythmClip = clipvs.at(0) == this?
+		dynamic_cast<MidiClip*>(clipvs.at(1)->getClip()) :
+		dynamic_cast<MidiClip*>(clipvs.at(1)->getClip());
+
+	// Get the track with the melody Clip in it
+	auto track = dynamic_cast<InstrumentTrack*>(melodyClip->getTrack());
+
+	if (!track)
+	{
+		qWarning("Warning: Couldn't retrieve melody InstrumentTrack in fuseRhythm()");
+		return;
+	}
+
+	int numberNotesOfMelody = melodyClip->notes().size();
+	int numberNotesOfRhythm = rhythmClip->notes().size();
+
+	// For Undo/Redo
+	track->addJournalCheckPoint();
+	track->saveJournallingState(false);
+
+	// Create a clip where all notes will be added
+	auto newMidiClip = dynamic_cast<MidiClip*>(track->createClip(melodyClip->startPosition()));
+	if (!newMidiClip)
+	{
+		qWarning("Warning: Failed to convert Clip to MidiClip on fuseRhythm");
+		return;
+	}
+	newMidiClip->saveJournallingState(false);
+
+	TimePos lastTime = TimePos(0);
+	int noteCount = 0;
+	// Iterate to the min number of notes in either clip (TODO: maybe rhythm implicitly loop via modulo if the melody is too long?)
+	for (int i = 0; i < std::min(numberNotesOfMelody, numberNotesOfRhythm); i++)
+	{
+		Note* newNote = newMidiClip->addNote(*melodyClip->notes().at(noteCount), false);
+
+		TimePos rhythmNotePos = rhythmClip->notes().at(noteCount)->pos();
+		newNote->setPos(rhythmNotePos);
+
+		TimePos rhythmNoteLength = rhythmClip->notes().at(noteCount)->length();
+		newNote->setLength(rhythmNoteLength);
+
+		auto rhythmNoteVolume = rhythmClip->notes().at(noteCount)->getVolume();
+		newNote->setVolume(rhythmNoteVolume);
+
+		auto rhythmNotePanning = rhythmClip->notes().at(noteCount)->getPanning();
+		newNote->setPanning(rhythmNotePanning);
+
+		// Only increment if the notes are at different times (not a chord)
+		if (newNote->pos() > lastTime) { noteCount++; }
+	}
+	// Remove old Clip
+	this->remove();
+	// Update length since we might have moved notes beyond the end of the MidiClip length
+	newMidiClip->updateLength();
+	// Rearrange notes because we might have moved them
+	newMidiClip->rearrangeAllNotes();
+	// Restore journalling states now that the operation is finished
+	newMidiClip->restoreJournallingState();
+	track->restoreJournallingState();
+	// Update song
+	Engine::getSong()->setModified();
+	getGUI()->songEditor()->update();
+}
+
 
 
 


### PR DESCRIPTION
## Decription

This feature allows the user to select two sets of clips on different tracks; one with the rhythm, and one with the melody. Then, by rightclicking on one of the melody clips, they can select "Fuse Rhythm to Melody," which will replace the old melody clips with a new clip which contains all the same notes, but while the keys of the notes are taken from the melody clips, the positions, velocity, and panning are taken from the rhythm clips.

Based on #7126

https://github.com/user-attachments/assets/6dd5a020-0dbf-440d-92f3-6b2ddc8dcc03

![Screenshot From 2024-12-09 14-58-07](https://github.com/user-attachments/assets/c8b53b0d-fef0-480f-a26c-95f19c2c6059)
