### PR TITLE
Remove 32 bit CI support for windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,9 +236,7 @@ jobs:
   msvc:
     strategy:
       fail-fast: false
-      matrix:
-        arch: ['x86', 'x64']
-    name: msvc-${{ matrix.arch }}
+    name: msvc-x64
     runs-on: windows-2019
     env:
       CCACHE_MAXSIZE: 0
@@ -259,19 +257,19 @@ jobs:
         id: cache-deps
         uses: actions/cache@v3
         with:
-          key: vcpkg-${{ matrix.arch }}-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-x64-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ matrix.arch }}-
+            vcpkg-x64-
           path: build\vcpkg_installed
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
           # yamllint disable rule:line-length
-          key: "ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}\
+          key: "ccache-${{ github.job }}-x64-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}-
-            ccache-${{ github.job }}-${{ matrix.arch }}-
+            ccache-${{ github.job }}-x64-${{ github.ref }}-
+            ccache-${{ github.job }}-x64-
           path: ~\AppData\Local\ccache
           # yamllint enable rule:line-length
       - name: Install tools
@@ -280,21 +278,13 @@ jobs:
         uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           version: '5.15.2'
-          arch: |-
-            ${{
-              fromJSON('
-                {
-                  "x86": "win32_msvc2019",
-                  "x64": "win64_msvc2019_64"
-                }
-              ')[matrix.arch]
-            }}
+          arch: "win64_msvc2019_64" # if fails, replace with x64
           archives: qtbase qtsvg qttools
           cache: true
       - name: Set up build environment
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89
         with:
-          arch: ${{ matrix.arch }}
+          arch: x64
       - name: Configure
         run: |
           ccache --zero-stats
@@ -307,8 +297,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo `
             -DUSE_COMPILE_CACHE=ON `
             -DUSE_WERROR=ON `
-            -DVCPKG_TARGET_TRIPLET="${{ matrix.arch }}-windows" `
-            -DVCPKG_HOST_TRIPLET="${{ matrix.arch }}-windows" `
+            -DVCPKG_TARGET_TRIPLET="x64-windows" `
+            -DVCPKG_HOST_TRIPLET="x64-windows" `
             -DVCPKG_MANIFEST_INSTALL="${{ env.should_install_manifest }}"
         env:
           should_install_manifest:
@@ -324,7 +314,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: msvc-${{ matrix.arch }}
+          name: msvc-x64
           path: build\lmms-*.exe
       - name: Trim ccache and print statistics
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,9 +170,7 @@ jobs:
   mingw:
     strategy:
       fail-fast: false
-      matrix:
-        arch: ['32', '64']
-    name: mingw${{ matrix.arch }}
+    name: mingw64
     runs-on: ubuntu-latest
     container: ghcr.io/lmms/linux.mingw:20.04
     env:
@@ -201,11 +199,11 @@ jobs:
       - name: Cache ccache data
         uses: actions/cache@v3
         with:
-          key: "ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}\
+          key: "ccache-${{ github.job }}-64-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-${{ matrix.arch }}-${{ github.ref }}-
-            ccache-${{ github.job }}-${{ matrix.arch }}-
+            ccache-${{ github.job }}-64-${{ github.ref }}-
+            ccache-${{ github.job }}-64-
           path: ~/.ccache
       - name: Configure
         run: |
@@ -213,7 +211,7 @@ jobs:
           cmake -S . \
                 -B build \
                 -DCMAKE_INSTALL_PREFIX=./install \
-                -DCMAKE_TOOLCHAIN_FILE="./cmake/toolchains/MinGW-W64-${{ matrix.arch }}.cmake" \
+                -DCMAKE_TOOLCHAIN_FILE="./cmake/toolchains/MinGW-W64-64.cmake" \
                 $CMAKE_OPTS
       - name: Build
         run: cmake --build build
@@ -222,7 +220,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: mingw${{ matrix.arch }}
+          name: mingw64
           path: build/lmms-*.exe
       - name: Trim ccache and print statistics
         run: |


### PR DESCRIPTION
closes: #7286 
Linux and Mac OS didn't have first class 32 bit support in the CI since we started. It's been 20 years since 32 bit support has been obsoleted and per surveys, there is no hardware in use anymore.