### PR TITLE
Recording logarithmic automation hotfix

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -396,6 +396,13 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 		if (p->isRecording() && relTime >= 0 && relTime < p->length())
 		{
 			const AutomatableModel* recordedModel = p->firstObject();
+			// The automation system really needs to be reworked.
+			// For whatever reason, the values in an automation clip are stored in un-un-scaled format, so if you
+			// are automating a log knob, when you draw an curve, the values being stored are not the actual values the
+			// knob will take, but instead the unscaled version of the unscaled numbers. The tooltip shows the number you expect, but if you double-click,
+			// you can see that the true values are stored by their inverse scaled value....which is wrong, since they weren't scaled in the first place...?
+			// Anyhow, in the meantime before we redo the automation system, when recording automations, we have to get the inverseScaledValue
+			// and store that so that when playing it back, it scales the value correctly.
 			p->recordValue(relTime, recordedModel->inverseScaledValue(recordedModel->value<float>()));
 
 			recordedModels << recordedModel;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -396,7 +396,7 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 		if (p->isRecording() && relTime >= 0 && relTime < p->length())
 		{
 			const AutomatableModel* recordedModel = p->firstObject();
-			p->recordValue(relTime, recordedModel->value<float>());
+			p->recordValue(relTime, recordedModel->inverseScaledValue(recordedModel->value<float>()));
 
 			recordedModels << recordedModel;
 		}


### PR DESCRIPTION
When you record an automation clip with a logarithmic knob (for example, a freq knob in the equalizer) the recorded values in the automation editor are correct.....

....*But*, for whatever reason, lmms tries to scale the recorded values back to linear when playing the automation, which causes the recorded frequency to be much lower.

This pr does not fix the underlying issue, but instead just scales the recorded values so that everything works.

Imo, the whole automation system needs some reorganizing, but that will have to wait. Just one example of the choas caused by swithcing between scaled/unscaled values: The automation editor conflicts with itself when showing scaled parameters. The tooltip shows the scaled value, while the actual stored value which you can edit when double-clicking on a node is unscaled. But again, that's for another day.

Fixes #6954 and #6209 and maybe #6490