### PR TITLE
Add option to connect last changed model to AutomationClip

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -94,6 +94,8 @@ public:
 	virtual void accept(ModelVisitor& v) = 0;
 	virtual void accept(ConstModelVisitor& v) const = 0;
 
+	static AutomatableModel* s_lastChangedModel;
+
 public:
 	/**
 	   @brief Return this class casted to Target

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -60,6 +60,7 @@ protected slots:
 	void toggleRecording();
 	void flipY();
 	void flipX();
+	void connectLastChangedModel();
 
 protected:
 	void constructContextMenu( QMenu * ) override;

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -37,6 +37,7 @@ namespace lmms
 {
 
 long AutomatableModel::s_periodCounter = 0;
+AutomatableModel* AutomatableModel::s_lastChangedModel = nullptr;
 
 
 
@@ -294,6 +295,7 @@ void AutomatableModel::loadSettings( const QDomElement& element, const QString& 
 
 void AutomatableModel::setValue( const float value )
 {
+	s_lastChangedModel = this;
 	m_oldValue = m_value;
 	++m_setValueDepth;
 	const float old_val = m_value;

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -205,7 +205,7 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	if (AutomatableModel::s_lastChangedModel != nullptr && !AutomatableModel::s_lastChangedModel->displayName().isEmpty())
 	{
 		_cm->addAction(tr("Connect last changed model (%1)").arg(AutomatableModel::s_lastChangedModel->fullDisplayName()),
-						this, SLOT(connectLastChangedModel()));
+						this, &AutomationClipView::connectLastChangedModel);
 	}
 	if (!m_clip->m_objects.empty())
 	{

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -100,6 +100,23 @@ void AutomationClipView::changeName()
 
 
 
+void AutomationClipView::connectLastChangedModel()
+{
+	if (AutomatableModel::s_lastChangedModel != nullptr)
+	{
+		bool added = m_clip->addObject(AutomatableModel::s_lastChangedModel);
+		if (!added)
+		{
+			TextFloat::displayMessage(AutomatableModel::s_lastChangedModel->displayName(),
+							tr("Model is already connected to this clip."),
+							embed::getIconPixmap("automation"),
+							2000);
+		}
+		update();
+	}
+}
+
+
 
 void AutomationClipView::disconnectObject( QAction * _a )
 {
@@ -185,6 +202,11 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "flip_x" ),
 						tr( "Flip Horizontally (Visible)" ),
 						this, SLOT(flipX()));
+	if (AutomatableModel::s_lastChangedModel != nullptr && !AutomatableModel::s_lastChangedModel->displayName().isEmpty())
+	{
+		_cm->addAction(tr("Connect last changed model (%1)").arg(AutomatableModel::s_lastChangedModel->fullDisplayName()),
+						this, SLOT(connectLastChangedModel()));
+	}
 	if (!m_clip->m_objects.empty())
 	{
 		_cm->addSeparator();


### PR DESCRIPTION
This PR adds a new context menu action to `AutomationClipView`s which allows users to connect the last changed model.

A pointer to the last changed model is kept as a static variable `AutomatableModel::s_lastChangedModel`, which is updated in `AutomatableModel::setValue()`. When the `AutomationClipView` context menu is constructed, if `AutomatableModel::s_lastChangedModel` is not a nullptr and if the model's display name is not empty (Many hidden models have empty names, and it would be confusing to show them to users), then an option to connect it is given.

Demo:

https://github.com/user-attachments/assets/afcb769d-21f8-409a-9e69-60602b8f0457

