### PR TITLE
Allow fine control of TripleOscillator oscillator volumes

### DIFF
--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -72,7 +72,7 @@ Plugin::Descriptor PLUGIN_EXPORT tripleoscillator_plugin_descriptor =
 OscillatorObject::OscillatorObject( Model * _parent, int _idx ) :
 	Model( _parent ),
 	m_volumeModel( DefaultVolume / NUM_OF_OSCILLATORS, MinVolume,
-			MaxVolume, 1.0f, this, tr( "Osc %1 volume" ).arg( _idx+1 ) ),
+			MaxVolume, 0.001f, this, tr( "Osc %1 volume" ).arg( _idx+1 ) ),
 	m_panModel( DefaultPanning, PanningLeft, PanningRight, 1.0f, this,
 			tr( "Osc %1 panning" ).arg( _idx+1 ) ),
 	m_coarseModel( -_idx*KeysPerOctave,


### PR DESCRIPTION
This changes the step size for the volume models in TripleOscillator to be 0.001f instead of 1.0f. This makes FM more usable, as previously only setting the lower osc to 1%, 2%, and maybe 3% volume would give useful tonal results, but now many more values which can be chosen.