### PR TITLE
Downgrade RemoteVstPlugin build back to C++17

### DIFF
--- a/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
+++ b/plugins/VstBase/RemoteVstPlugin/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 project(RemoteVstPlugin 
 	LANGUAGES CXX)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 
 include(CheckCXXPreprocessor)
 include(CheckCXXSourceCompiles)
@@ -73,7 +73,7 @@ if(MSVC)
 endif()
 
 if(IS_MINGW)
-	SET(CMAKE_REQUIRED_FLAGS "-std=c++20")
+	SET(CMAKE_REQUIRED_FLAGS "-std=c++17")
 endif()
 
 if(LMMS_BUILD_WIN32)


### PR DESCRIPTION
For some reason, upgrading RemoteVstPlugin to build in C++20 causes a `malloc` regression when loading them from a project. I wonder if there is a better fix.

``
Fatal glibc error: malloc.c:2599 (sysmalloc): assertion failed: (old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_to
p) && ((unsigned long) old_end & (pagesize - 1)) == 0)
``