### PR TITLE
Do not set Qt::WA_OpaquePaintEvent

### DIFF
--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -48,7 +48,6 @@ CompressorControlDialog::CompressorControlDialog(CompressorControls* controls) :
 	m_controls(controls)
 {
 	setAutoFillBackground(false);
-	setAttribute(Qt::WA_OpaquePaintEvent, true);
 	setAttribute(Qt::WA_NoSystemBackground, true);
 	
 	setMinimumSize(MIN_COMP_SCREEN_X, MIN_COMP_SCREEN_Y);

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -55,8 +55,6 @@ AutomationClipView::AutomationClipView( AutomationClip * _clip,
 	connect( getGUI()->automationEditor(), SIGNAL(currentClipChanged()),
 			this, SLOT(update()));
 
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
-
 	setToolTip(m_clip->name());
 	setStyle( QApplication::style() );
 	update();

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -113,7 +113,6 @@ ClipView::ClipView( Clip * clip,
 		s_textFloat->setPixmap( embed::getIconPixmap( "clock" ) );
 	}
 
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	setAttribute( Qt::WA_DeleteOnClose, true );
 	setFocusPolicy( Qt::StrongFocus );
 	setCursor( m_cursorHand );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -115,8 +115,6 @@ AutomationEditor::AutomationEditor() :
 	connect( Engine::getSong(), SIGNAL(timeSignatureChanged(int,int)),
 						this, SLOT(update()));
 
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
-
 	//keeps the direction of the widget, undepended on the locale
 	setLayoutDirection( Qt::LeftToRight );
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -274,8 +274,6 @@ PianoRoll::PianoRoll() :
 		s_textFloat = new SimpleTextFloat;
 	}
 
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
-
 	// add time-line
 	m_timeLine = new TimeLineWidget(m_whiteKeyWidth, 0, m_ppb,
 		Engine::getSong()->getPlayPos(Song::PlayMode::MidiClip),

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -58,7 +58,6 @@ TimeLineWidget::TimeLineWidget(const int xoff, const int yoff, const float ppb, 
 	m_begin{begin},
 	m_mode{mode}
 {
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	move( 0, yoff );
 
 	setMouseTracking(true);

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -90,7 +90,6 @@ PianoView::PianoView(QWidget *parent) :
 	m_lastKey(-1),                   /*!< The last key displayed? */
 	m_movedNoteModel(nullptr)        /*!< Key marker which is being moved */
 {
-	setAttribute(Qt::WA_OpaquePaintEvent, true);
 	setFocusPolicy(Qt::StrongFocus);
 
 	// Black keys are drawn halfway between successive white keys, so they do not

--- a/src/gui/tracks/FadeButton.cpp
+++ b/src/gui/tracks/FadeButton.cpp
@@ -47,7 +47,6 @@ FadeButton::FadeButton(const QColor & _normal_color,
 	m_activatedColor( _activated_color ),
 	m_holdColor( holdColor )
 {
-	setAttribute(Qt::WA_OpaquePaintEvent, true);
 	setCursor(QCursor(embed::getIconPixmap("hand"), 3, 3));
 	setFocusPolicy(Qt::NoFocus);
 	activeNotes = 0;

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -46,7 +46,6 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	m_trackView( _tv ),
 	m_iconName()
 {
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	setAcceptDrops( true );
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );

--- a/src/gui/widgets/CPULoadWidget.cpp
+++ b/src/gui/widgets/CPULoadWidget.cpp
@@ -46,7 +46,6 @@ CPULoadWidget::CPULoadWidget( QWidget * _parent ) :
 	m_changed( true ),
 	m_updateTimer()
 {
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	setFixedSize( m_background.width(), m_background.height() );
 
 	m_temp = QPixmap( width(), height() );

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -72,7 +72,6 @@ Fader::Fader(FloatModel* model, const QString& name, QWidget* parent) :
 	}
 
 	setWindowTitle(name);
-	setAttribute(Qt::WA_OpaquePaintEvent, false);
 	// For now resize the widget to the size of the previous background image "fader_background.png" as it was found in the classic and default theme
 	constexpr QSize minimumSize(23, 116);
 	setMinimumSize(minimumSize);

--- a/src/gui/widgets/Oscilloscope.cpp
+++ b/src/gui/widgets/Oscilloscope.cpp
@@ -51,7 +51,6 @@ Oscilloscope::Oscilloscope( QWidget * _p ) :
 	m_clippingColor(255, 64, 64)
 {
 	setFixedSize( m_background.width(), m_background.height() );
-	setAttribute( Qt::WA_OpaquePaintEvent, true );
 	setActive( ConfigManager::inst()->value( "ui", "displaywaveform").toInt() );
 
 	const fpp_t frames = Engine::audioEngine()->framesPerPeriod();


### PR DESCRIPTION
From the Qt docs, `Qt:WA_OpaquePaintEvent`:

``
Indicates that the widget paints all its pixels when it receives a paint event. Thus, it is not required for operations like updating, resizing, scrolling and focus changes to erase the widget before generating paint events. The use of WA_OpaquePaintEvent provides a small optimization by helping to reduce flicker on systems that do not support double buffering and avoiding computational cycles necessary to erase the background prior to painting. Note: Unlike WA_NoSystemBackground, WA_OpaquePaintEvent makes an effort to avoid transparent window backgrounds. This flag is set or cleared by the widget's author.
``

Removing calls to set this attribute seems to have fixed the infamous glitch problem where child widgets (like clips from the song editor) start drawing on top on other, completely different widgets. Maybe there's something I'm missing though, so extra insight would be appreciated.