### PR TITLE
Fix logarithmic behavior when dragging knobs and sliders

### DIFF
--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -110,7 +110,7 @@ private:
 	FloatModel m_volumeRatio;
 
 	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
-	float m_leftOver;
+	float m_lastModelValue; //!< model value in last mouseMoveEvent
 	bool m_buttonPressed;
 
 	DirectionOfManipulation m_directionOfManipulation;

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -110,7 +110,7 @@ private:
 	FloatModel m_volumeRatio;
 
 	QPoint m_lastMousePos; //!< mouse position in last mouseMoveEvent
-	float m_lastModelValue; //!< model value in last mouseMoveEvent
+	float m_leftOver;
 	bool m_buttonPressed;
 
 	DirectionOfManipulation m_directionOfManipulation;

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -332,7 +332,10 @@ void FloatModelEditorBase::wheelEvent(QWheelEvent * we)
 	}
 
 	// Compute the number of steps but make sure that we always do at least one step
-	const float stepMult = std::max(range / numberOfStepsForFullSweep / step, 1.f);
+	const float currentValue = model()->value();
+	const float valueOffset = range / numberOfStepsForFullSweep;
+	const float scaledValueOffset = model()->scaledValue(model()->inverseScaledValue(currentValue) + valueOffset) - currentValue;
+	const float stepMult = std::max(scaledValueOffset / step, 1.f);
 	const int inc = direction * stepMult;
 	model()->incValue(inc);
 

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -172,7 +172,6 @@ void FloatModelEditorBase::mousePressEvent(QMouseEvent * me)
 		const QPoint & p = me->pos();
 		m_lastMousePos = p;
 		m_lastModelValue = model()->value();
-		m_leftOver = 0.0f;
 
 		emit sliderPressed();
 

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -362,7 +362,14 @@ void FloatModelEditorBase::setPosition(const QPoint & p)
 	}
 	else
 	{
-		m_leftOver = valueOffset;
+		if (valueOffset > 0 && currentValue == model()->minValue())
+		{
+			m_leftOver = 0.0f;
+		}
+		else
+		{
+			m_leftOver = valueOffset;
+		}
 	}
 }
 

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -96,7 +96,6 @@ float FloatModelEditorBase::getValue(const QPoint & p)
 	if (getGUI()->mainWindow()->isShiftPressed())
 	{
 		value /= 4.0f;
-		value = qBound(-4.0f, value, 4.0f);
 	}
 
 	return value * pageSize();

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -350,7 +350,7 @@ void FloatModelEditorBase::setPosition(const QPoint & p)
 	const float currentValue = model()->value();
 	const float scaledValueOffset = currentValue - model()->scaledValue(model()->inverseScaledValue(currentValue) - valueOffset);
 	const auto step = model()->step<float>();
-	const float roundedValue = qRound((currentValue - scaledValueOffset) / step) * step;
+	const float roundedValue = std::round((currentValue - scaledValueOffset) / step) * step;
 
 	if (roundedValue != currentValue)
 	{

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -355,14 +355,14 @@ void FloatModelEditorBase::setPosition(const QPoint & p)
 	const auto step = model()->step<float>();
 	const float roundedValue = std::round((currentValue - scaledValueOffset) / step) * step;
 
-	if (roundedValue != currentValue)
+	if (!approximatelyEqual(roundedValue, currentValue))
 	{
 		model()->setValue(roundedValue);
 		m_leftOver = 0.0f;
 	}
 	else
 	{
-		if (valueOffset > 0 && currentValue == model()->minValue())
+		if (valueOffset > 0 && approximatelyEqual(currentValue, model()->minValue()))
 		{
 			m_leftOver = 0.0f;
 		}


### PR DESCRIPTION
## The Problem

Currently, logarithmic knobs and sliders act very weirdly when dragging them. Instead of visually moving at the same rate as the mouse while internally moving logarithmically, the internal value changes *linearly* with the mouse movement, while only the visual was displayed logarithmically. 

This makes log knobs \*literally\* pointless, as they don't change the sensitivity for values of different magnitudes. They just display their current value logarithmically. In addition, this also causes the knobs to jump at the start and become sluggish relative to the mouse movement, which feels weird.

Might fix #3871

## The Solution

This PR addresses this issue by correctly scaling the mouse movement for all knobs.

### Changes
- Knobs tend to draw their visuals using the inverse scaled value of the model. This means that we need to calculate what internal (scaled) value is needed to move the knob by the same number of "pixels" as the mouse moved. Let's talk through the maths:
  - Imagine a simple inverse scaling curve. LMMS's is super complex, but think of something like a sqrt() curve.
  - The x axis is the internal model value. The y axis is pixels. (well, it's not *really* pixels, but it's close enough)
  - We need to find how much we need to adjust the internal value to change the output by some number of pixels.
  - Imagine that the current internal value of the model is some number, say 0.5. Say that we need to move 5 pixels. How far left/right does the x value need to move so that the y value goes up by 5 pixels?
  - We can use the inverse of the inverse scaling function! I.e., the normal scaling function.
  - The change in internal value given a desired change in pixels is the difference between the current pixel value and the scaledValue(current pixel value + 5 pixels). Since the current pixel value is just inverseScaledValue(model value), it comes out to be:
  - `model()->scaledValue(model()->inverseScaledValue(m_lastModelValue) - valueOffset)`
  And adding that on to the current model value, we get `m_lastModelValue - model()->scaledValue(model()->inverseScaledValue(m_lastModelValue) - valueOffset);`
  - (note: for some reason the offsets are subtracted, not added. Don't ask me why.)

Also, these changes make the knobs more generalizable, since it does not depend on how the knob scaling is implemented, and it does not require any derivatives. If we wanted to add more interesting knob scalings in the future, this would make it easier.