### PR TITLE
Add VST support for Gentoo linux

### DIFF
--- a/cmake/modules/FindWine.cmake
+++ b/cmake/modules/FindWine.cmake
@@ -35,6 +35,8 @@ list(APPEND WINE_LOCATIONS
 	/opt/wine-staging
 	/opt/wine-devel
 	/opt/wine-stable
+	# Gentoo Systems
+	/etc/eselect/wine
 	/usr/lib/wine)
 
 # Prepare bin search


### PR DESCRIPTION
Gentoo uses the eselect system for system administrators ease of changing between wine-vanilla, wine-staging and wine-proton packages on the fly

Which leads to winegcc/wineg++ residing on /etc/eselect/wine/bin instead of any normal and/or expected location, naturally breaking LMMS's FindWine.cmake

Of course, switching between different versions of wine on the fly may break LMMS's VST functionality, but this is considered the system administrator's responsibility