### PR TITLE
Fix dropout with SID instrument when used for the first time

### DIFF
--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -471,6 +471,7 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 							QWidget * _parent ) :
 	InstrumentViewFixedSize( _instrument, _parent )
 {
+	reSID::SID sid; // make instrument ready by side effect
 
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -128,10 +128,10 @@ SidInstrument::SidInstrument( InstrumentTrack * _instrument_track ) :
 	m_volumeModel( 15.0f, 0.0f, 15.0f, 1.0f, this, tr( "Volume" ) ),
 	m_chipModel( static_cast<int>(ChipModel::MOS8580), 0, NumChipModels-1, this, tr( "Chip model" ) )
 {
-    // A Filter object needs to be created only once to do some static initialization and avoid
-    // dropouts down the line when we have to play a note for the first time.
-    static auto s_init = std::once_flag{};
-    std::call_once(s_init, [] { reSID::Filter{}; });
+    // A Filter object needs to be created only once to do some initialization, avoiding
+	// dropouts down the line when we have to play a note for the first time.
+	[[maybe_unused]] static auto s_filter = reSID::Filter{};
+
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voice[i] = new VoiceObject( this, i );

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -128,6 +128,7 @@ SidInstrument::SidInstrument( InstrumentTrack * _instrument_track ) :
 	m_volumeModel( 15.0f, 0.0f, 15.0f, 1.0f, this, tr( "Volume" ) ),
 	m_chipModel( static_cast<int>(ChipModel::MOS8580), 0, NumChipModels-1, this, tr( "Chip model" ) )
 {
+	reSID::SID sid; // make instrument ready by side effect
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voice[i] = new VoiceObject( this, i );
@@ -471,7 +472,6 @@ SidInstrumentView::SidInstrumentView( Instrument * _instrument,
 							QWidget * _parent ) :
 	InstrumentViewFixedSize( _instrument, _parent )
 {
-	reSID::SID sid; // make instrument ready by side effect
 
 	setAutoFillBackground( true );
 	QPalette pal;

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -128,7 +128,10 @@ SidInstrument::SidInstrument( InstrumentTrack * _instrument_track ) :
 	m_volumeModel( 15.0f, 0.0f, 15.0f, 1.0f, this, tr( "Volume" ) ),
 	m_chipModel( static_cast<int>(ChipModel::MOS8580), 0, NumChipModels-1, this, tr( "Chip model" ) )
 {
-	reSID::SID sid; // make instrument ready by side effect
+    // A Filter object needs to be created only once to do some static initialization and avoid
+    // dropouts down the line when we have to play a note for the first time.
+    static auto s_init = std::once_flag{};
+    std::call_once(s_init, [] { reSID::Filter{}; });
 	for( int i = 0; i < 3; ++i )
 	{
 		m_voice[i] = new VoiceObject( this, i );


### PR DESCRIPTION
By one line change , using reSID::SID constructor side effect, SID became ready to play without xrun's after loading.

