### PR TITLE
Improve mono compatibility with LADSPA plugins

### DIFF
--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -65,7 +65,6 @@ public:
 	virtual void unregisterPort( AudioPort * _port );
 	virtual void renamePort( AudioPort * _port );
 
-
 	inline bool supportsCapture() const
 	{
 		return m_supportsCapture;
@@ -74,11 +73,6 @@ public:
 	inline sample_rate_t sampleRate() const
 	{
 		return m_sampleRate;
-	}
-
-	ch_cnt_t channels() const
-	{
-		return m_channels;
 	}
 
 	void processNextBuffer();
@@ -108,6 +102,11 @@ protected:
 	// clear given signed-int-16-buffer
 	void clearS16Buffer( int_sample_t * _outbuf,
 							const fpp_t _frames );
+
+	ch_cnt_t channels() const
+	{
+		return m_channels;
+	}
 
 	inline void setSampleRate( const sample_rate_t _new_sr )
 	{

--- a/plugins/LadspaBrowser/LadspaDescription.cpp
+++ b/plugins/LadspaBrowser/LadspaDescription.cpp
@@ -74,8 +74,7 @@ LadspaDescription::LadspaDescription( QWidget * _parent,
 	QList<QString> pluginNames;
 	for (const auto& plugin : plugins)
 	{
-		ch_cnt_t audioDeviceChannels = Engine::audioEngine()->audioDev()->channels();
-		if (_type != LadspaPluginType::Valid || manager->getDescription(plugin.second)->inputChannels <= audioDeviceChannels)
+		if (_type != LadspaPluginType::Valid || manager->getDescription(plugin.second)->inputChannels <= DEFAULT_CHANNELS)
 		{
 			pluginNames.push_back(plugin.first);
 			m_pluginKeys.push_back(plugin.second);

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -279,9 +279,8 @@ void LadspaEffect::pluginInstantiation()
 	Ladspa2LMMS * manager = Engine::getLADSPAManager();
 
 	// Calculate how many processing units are needed.
-	const ch_cnt_t lmms_chnls = Engine::audioEngine()->audioDev()->channels();
 	int effect_channels = manager->getDescription( m_key )->inputChannels;
-	setProcessorCount( lmms_chnls / effect_channels );
+	setProcessorCount(DEFAULT_CHANNELS / effect_channels);
 
 	// get inPlaceBroken property
 	m_inPlaceBroken = manager->isInplaceBroken( m_key );

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -157,7 +157,7 @@ void LadspaSubPluginFeatures::listSubPluginKeys(
 	for( l_sortable_plugin_t::const_iterator it = plugins.begin();
 						it != plugins.end(); ++it )
 	{
-		if( lm->getDescription( ( *it ).second )->inputChannels <= Engine::audioEngine()->audioDev()->channels() )
+		if (lm->getDescription((*it).second)->inputChannels <= DEFAULT_CHANNELS)
 		{
 			_kl.push_back( ladspaKeyToSubPluginKey( _desc, ( *it ).first, ( *it ).second ) );
 		}


### PR DESCRIPTION
When requesting the number of channels, LADSPA incorrectly asks the playback device for that number. LMMS always gives stereo output, with any downmixing to mono (if applicable) to be handled at the very last stage when converting the rendered buffer to be played back on the hardware, not during the processing of said buffer.

`AudioDevice::channels` was also made to be `protected` as it should only be relevant to the conversion layer mentioned previously.