### PR TITLE
CI: Switch linux-x86_64 to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   linux-x86_64:
     name: linux-x86_64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,11 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo mkdir -pm755 /etc/apt/keyrings
-          wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
-          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-noble.sources
+          wget -O - https://dl.winehq.org/wine-builds/winehq.key | \
+          sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
+          sudo wget -NP /etc/apt/sources.list.d/ \
+          https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-noble.sources
+          sudo apt-get update -y
           sudo apt-get install -y --install-recommends g++-multilib gcc-multilib winehq-stable wine-stable-dev
       - name: Cache ccache data
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,13 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends \
           $(xargs < .github/workflows/deps-ubuntu-24.04-gcc.txt)
+      - name: Install winehq
+        run: |
           sudo dpkg --add-architecture i386
-          sudo apt-get install -y --no-install-recommends \
-          $(xargs < .github/workflows/deps-ubuntu-24.04-wine.txt)
+          sudo mkdir -pm755 /etc/apt/keyrings
+          wget -O - https://dl.winehq.org/wine-builds/winehq.key | sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-noble.sources
+          sudo apt-get install -y --install-recommends g++-multilib gcc-multilib winehq-stable wine-stable-dev
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           wget -O - https://dl.winehq.org/wine-builds/winehq.key | \
           sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
           sudo wget -NP /etc/apt/sources.list.d/ \
-          https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-noble.sources
+          https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
           sudo apt-get update -y
           sudo apt-get install -y --install-recommends g++-multilib gcc-multilib winehq-stable wine-stable-dev
       - name: Cache ccache data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install system packages
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends \
-          $(xargs < .github/workflows/deps-ubuntu-24.04-gcc.txt)
-      - name: Install winehq
+      - name: Configure winehq
         run: |
           sudo dpkg --add-architecture i386
           sudo mkdir -pm755 /etc/apt/keyrings
@@ -38,7 +33,11 @@ jobs:
           sudo gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key -
           sudo wget -NP /etc/apt/sources.list.d/ \
           https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+      - name: Install packages
+        run: |
           sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+          $(xargs < .github/workflows/deps-ubuntu-24.04-gcc.txt)
           sudo apt-get install -y --install-recommends g++-multilib gcc-multilib winehq-stable wine-stable-dev
       - name: Cache ccache data
         uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,12 @@ jobs:
   linux-x86_64:
     name: linux-x86_64
     runs-on: ubuntu-latest
-    container: ghcr.io/lmms/linux.gcc:20.04
     env:
       CMAKE_OPTS: >-
         -DUSE_WERROR=ON
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DUSE_COMPILE_CACHE=ON
+        -DWANT_DEBUG_CPACK=ON
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
       MAKEFLAGS: -j2
@@ -25,6 +25,14 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Install system packages
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+          $(xargs < .github/workflows/deps-ubuntu-24.04-gcc.txt)
+          sudo dpkg --add-architecture i386
+          sudo apt-get install -y --no-install-recommends \
+          $(xargs < .github/workflows/deps-ubuntu-24.04-wine.txt)
       - name: Cache ccache data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/deps-ubuntu-24.04-wine.txt
+++ b/.github/workflows/deps-ubuntu-24.04-wine.txt
@@ -1,0 +1,6 @@
+g++-multilib
+gcc-multilib
+libwine-dev
+libwine-dev:i386
+wine64-tools
+

--- a/.github/workflows/deps-ubuntu-24.04-wine.txt
+++ b/.github/workflows/deps-ubuntu-24.04-wine.txt
@@ -1,6 +1,0 @@
-g++-multilib
-gcc-multilib
-libwine-dev
-libwine-dev:i386
-wine64-tools
-


### PR DESCRIPTION
This fixes -- in part #7669 -- but introduces a newer libc requirement, breaking the nightlies from running on older distributions such as Linux Mint 21.

Compatibility:

| OS      | Works      |
|--------|------------|
| Mint 21 | 🚫 |
| Mint 22 | ✅ |
| Ubuntu 24.04 | ✅  |
| Ubuntu 22.04 | ✅ |
| Ubuntu 20.04 | 🚫  |
| Fedora 32 | 🚫  |

Downloads:
https://lmms.io/download/pull-request/7678



