### PR TITLE
SharedMemory: Make key optional, default to shorter UID on macOS

### DIFF
--- a/cmake/apple/MacDeployQt.cmake
+++ b/cmake/apple/MacDeployQt.cmake
@@ -107,8 +107,8 @@ file(GLOB LIBS "${APP}/Contents/lib/${lmms}/*.so")
 # Inform macdeployqt about LADSPA plugins; may depend on bundled fftw3f, etc.
 file(GLOB LADSPA "${APP}/Contents/lib/${lmms}/ladspa/*.so")
 
-# Inform linuxdeploy about remote plugins
-list(APPEND REMOTE_PLUGINS "${APP}/Contents/MacOS/*Remote*")
+# Inform macdeployqt about remote plugins
+file(GLOB REMOTE_PLUGINS "${APP}/Contents/MacOS/*Remote*")
 
 # Collect, sort and dedupe all libraries
 list(APPEND LIBS ${LADSPA})

--- a/include/RemotePluginBase.h
+++ b/include/RemotePluginBase.h
@@ -125,7 +125,7 @@ public:
 		m_master( true ),
 		m_lockDepth( 0 )
 	{
-		m_data.create(QUuid::createUuid().toString().toStdString());
+		m_data.create();
 		m_data->startPtr = m_data->endPtr = 0;
 		static int k = 0;
 		m_data->dataSem.semKey = ( getpid()<<10 ) + ++k;

--- a/include/RemotePluginBase.h
+++ b/include/RemotePluginBase.h
@@ -71,7 +71,6 @@
 #include <QProcess>
 #include <QThread>
 #include <QString>
-#include <QUuid>
 
 #ifndef SYNC_WITH_SHM_FIFO
 #include <poll.h>

--- a/include/SharedMemory.h
+++ b/include/SharedMemory.h
@@ -29,7 +29,6 @@
 
 #include <memory>
 #include <random>
-#include <sstream>
 #include <string>
 #include <type_traits>
 
@@ -86,10 +85,9 @@ private:
 		std::mt19937 gen(rd()); // mersenne twister, seeded
 		std::uniform_int_distribution<> distrib(0, 15); // hex range (0-15)
 
+		key.reserve(length);
 		for (int i = 0; i < length; i++) {
-			std::stringstream ss;
-			ss << std::hex << distrib(gen);
-			key += ss.str();
+			key += "0123456789ABCDEF"[distrib(gen)];
 		}
 
 		return key;

--- a/include/SharedMemory.h
+++ b/include/SharedMemory.h
@@ -65,6 +65,7 @@ public:
 
 	const std::string& key() const noexcept { return m_key; }
 	void* get() const noexcept { return m_ptr; }
+	std::size_t size_bytes() const noexcept;
 
 private:
 	std::string m_key;
@@ -109,6 +110,9 @@ public:
 	const std::string& key() const noexcept { return m_data.key(); }
 	T* get() const noexcept { return static_cast<T*>(m_data.get()); }
 
+	std::size_t size() const noexcept { return get() ? 1 : 0; }
+	std::size_t size_bytes() const noexcept { return get() ? sizeof(T) : 0; }
+
 	T* operator->() const noexcept { return get(); }
 	T& operator*() const noexcept { return *get(); }
 	explicit operator bool() const noexcept { return get() != nullptr; }
@@ -150,6 +154,9 @@ public:
 
 	const std::string& key() const noexcept { return m_data.key(); }
 	T* get() const noexcept { return static_cast<T*>(m_data.get()); }
+
+	std::size_t size() const noexcept { return m_data.size_bytes() / sizeof(T); }
+	std::size_t size_bytes() const noexcept { return m_data.size_bytes(); }
 
 	T& operator[](std::size_t index) const noexcept { return get()[index]; }
 	explicit operator bool() const noexcept { return get() != nullptr; }

--- a/include/SharedMemory.h
+++ b/include/SharedMemory.h
@@ -77,9 +77,9 @@ private:
 
 	static inline std::string createKey() {
 #if defined(LMMS_BUILD_APPLE) || defined(LMMS_BUILD_FREEBSD) || defined(LMMS_BUILD_OPENBSD)
-		const int &length = 30; // PSHMNAMLEN=31
+		constexpr int length = 30; // PSHMNAMLEN=31
 #else
-		const int &length = 32; // mimic UUID
+		constexpr int length = 32; // mimic UUID
 #endif
 		std::string key;
 		std::random_device rd;

--- a/include/SharedMemory.h
+++ b/include/SharedMemory.h
@@ -114,9 +114,14 @@ public:
 		m_data = detail::SharedMemoryData{std::move(key), std::is_const_v<T>};
 	}
 
-	void create(std::string key = "")
+	void create()
 	{
-		m_data = detail::SharedMemoryData{std::move(key.empty() ? detail::createKey() : key), sizeof(T), std::is_const_v<T>};
+		create(detail::createKey());
+	}
+
+	void create(std::string key)
+	{
+		m_data = detail::SharedMemoryData{std::move(key), sizeof(T), std::is_const_v<T>};
 	}
 
 	void detach() noexcept

--- a/src/common/SharedMemory.cpp
+++ b/src/common/SharedMemory.cpp
@@ -23,9 +23,9 @@
 
 #include "SharedMemory.h"
 
+#include <random>
 #include <system_error>
 #include <utility>
-#include <random>
 
 #include "lmmsconfig.h"
 #include "RaiiHelpers.h"
@@ -76,7 +76,7 @@ class SharedMemoryImpl
 {
 public:
 	SharedMemoryImpl(const std::string& key, bool readOnly) :
-		m_key{"/" + key}
+		m_key{'/' + key}
 	{
 		const auto openFlags = readOnly ? O_RDONLY : O_RDWR;
 		const auto fd = FileDescriptor{
@@ -94,7 +94,7 @@ public:
 	}
 
 	SharedMemoryImpl(const std::string& key, std::size_t size, bool readOnly) :
-		m_key{"/" + key},
+		m_key{'/' + key},
 		m_size{size}
 	{
 		const auto fd = FileDescriptor{
@@ -125,8 +125,8 @@ public:
 
 private:
 	std::string m_key;
-	std::size_t m_size;
-	void* m_mapping;
+	std::size_t m_size = 0;
+	void* m_mapping = nullptr;
 	ShmObject m_object;
 };
 
@@ -219,8 +219,8 @@ auto createKey() -> std::string
 	auto gen = std::mt19937{rd()}; // mersenne twister, seeded
 	auto distrib = std::uniform_int_distribution{0, 15}; // hex range (0-15)
 
-	key.reserve(length);
-	for (int i = 0; i < length; i++)
+	key.reserve(length + 1);
+	for (int i = 0; i < length; ++i)
 	{
 		key += "0123456789ABCDEF"[distrib(gen)];
 	}

--- a/src/core/RemotePlugin.cpp
+++ b/src/core/RemotePlugin.cpp
@@ -485,7 +485,7 @@ void RemotePlugin::resizeSharedProcessingMemory()
 	const size_t s = (m_inputCount + m_outputCount) * Engine::audioEngine()->framesPerPeriod();
 	try
 	{
-		m_audioBuffer.create(QUuid::createUuid().toString().toStdString(), s);
+		m_audioBuffer.create(s);
 	}
 	catch (const std::runtime_error& error)
 	{

--- a/src/core/VstSyncController.cpp
+++ b/src/core/VstSyncController.cpp
@@ -28,7 +28,6 @@
 #include <stdexcept>
 
 #include <QDebug>
-#include <QUuid>
 
 #include "AudioEngine.h"
 #include "ConfigManager.h"
@@ -44,7 +43,7 @@ VstSyncController::VstSyncController()
 {
 	try
 	{
-		m_syncData.create(QUuid::createUuid().toString().toStdString());
+		m_syncData.create();
 	}
 	catch (const std::runtime_error& error)
 	{


### PR DESCRIPTION
Remote plugins use [QUuid](https://doc.qt.io/qt-5/quuid.html) key for a unique shared memory mapping (e.g. `67C8770B-44F1-410A-AB9A-F9B5446F13EE`) but this value is too long on macOS for `shm_get`: https://stackoverflow.com/a/38075686/3196753 and causes the UI for ZynAddSubFx to never open properly.

This PR proposes a change to create our own 128-bit/32-character unique ID "key" in `SharedMemory` .
* To simplify the implementation of it, starting with this PR, this key is generated directly inside `SharedMemory` (unless one's manually provided).  This simplifies calls to `create(...)`.
*  For macOS and other BSD flavors, I shorten this value to 30-characters to workaround the [`shm_get` limitation](https://stackoverflow.com/a/38075686/3196753).
* Windows had previously used a built-in [`Uuidgen`](https://learn.microsoft.com/en-us/windows/win32/rpc/generating-interface-uuids) -- provided by Qt.  Since this may offer benefits over rolling our own, I wanted to mention is specifically/invite comments about its removal.
* Added `size` and `size_bytes` getters. This required a modification to the MSVC implementation to query the shared memory size using [VirtualQuery](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualquery).
 
Fixes #7666 

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c07f4ab9-ef56-4286-b487-8a28c1ca50ae" />
