### PR TITLE
Update math functions to C++ standard library

### DIFF
--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -806,8 +806,8 @@ public:
 		// other filters
 		_freq = std::clamp(_freq, minFreq(), 20000.0f);
 		const float omega = numbers::tau_v<float> * _freq * m_sampleRatio;
-		const float tsin = sinf( omega ) * 0.5f;
-		const float tcos = cosf( omega );
+		const float tsin = std::sin(omega) * 0.5f;
+		const float tcos = std::cos(omega);
 
 		const float alpha = tsin / _q;
 

--- a/include/DspEffectLibrary.h
+++ b/include/DspEffectLibrary.h
@@ -289,7 +289,7 @@ namespace lmms::DspEffectLibrary
 		{
 			if( in >= m_threshold || in < -m_threshold )
 			{
-				return ( fabsf( fabsf( fmodf( in - m_threshold, m_threshold*4 ) ) - m_threshold*2 ) - m_threshold ) * m_gain;
+				return (std::abs(std::abs(std::fmod(in - m_threshold, m_threshold * 4)) - m_threshold * 2) - m_threshold) * m_gain;
 			}
 			return in * m_gain;
 		}
@@ -303,7 +303,7 @@ namespace lmms::DspEffectLibrary
 
 		sample_t nextSample( sample_t in )
 		{
-			return m_gain * ( in * ( fabsf( in )+m_threshold ) / ( in*in +( m_threshold-1 )* fabsf( in ) + 1 ) );
+			return m_gain * (in * (std::abs(in) + m_threshold) / (in * in + (m_threshold - 1) * std::abs(in) + 1));
 		}
 	} ;
 
@@ -330,8 +330,8 @@ namespace lmms::DspEffectLibrary
 		{
 			const float toRad = numbers::pi_v<float> / 180;
 			const sample_t tmp = inLeft;
-			inLeft += inRight * sinf( m_wideCoeff * ( .5 * toRad ) );
-			inRight -= tmp * sinf( m_wideCoeff * ( .5 * toRad ) );
+			inLeft += inRight * std::sin(m_wideCoeff * toRad * .5f);
+			inRight -= tmp * std::sin(m_wideCoeff * toRad * .5f);
 		}
 
 	private:

--- a/include/QuadratureLfo.h
+++ b/include/QuadratureLfo.h
@@ -77,11 +77,10 @@ public:
 
 	void tick( float *l, float *r )
 	{
-		*l = sinf( m_phase );
-		*r = sinf( m_phase + m_offset );
+		*l = std::sin(m_phase);
+		*r = std::sin(m_phase + m_offset);
 		m_phase += m_increment;
-
-		while (m_phase >= numbers::tau)	{	m_phase -= numbers::tau; }
+		while (m_phase >= numbers::tau)	{ m_phase -= numbers::tau; }
 	}
 
 private:

--- a/include/RmsHelper.h
+++ b/include/RmsHelper.h
@@ -84,7 +84,7 @@ public:
 		m_sum -= m_buffer[ m_pos ];
 		m_sum += m_buffer[ m_pos ] = in * in;
 		++m_pos %= m_size;
-		return sqrtf( m_sum * m_sizef );
+		return std::sqrtf(m_sum * m_sizef);
 	}
 
 private:

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -42,6 +42,12 @@ template<typename T>
 inline constexpr T tau_v = T(pi_v<T> * 2.0);
 inline constexpr double tau = tau_v<double>;
 
+// [TODO] C++20: Use std::floating_point instead of typename
+// [TODO] C++20: Use std::numbers::inv_pi_v<T> instead of computed value
+template<typename T>
+inline constexpr T inv_pi_v = T(1.0 / pi_v<T>);
+inline constexpr double inv_pi = inv_pi_v<double>;
+
 //TODO C++20: Use std::floating_point instead of typename
 template<typename T>
 inline constexpr T pi_half_v = T(pi_v<T> / 2.0);

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -65,6 +65,7 @@ inline constexpr double inv_e = e_v<double>;
 
 //TODO C++20: Use std::floating_point instead of typename
 //TODO C++20: Use std::numbers::sqrt2_v<T> instead of literal value
+//TODO C++26: Remove since std::sqrt(2.0) is constexpr
 template<typename T>
 inline constexpr T sqrt2_v = T(1.41421356237309504880168872420969807856967187537695);
 inline constexpr double sqrt2 = sqrt2_v<double>;

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -42,17 +42,6 @@ template<typename T>
 inline constexpr T tau_v = T(pi_v<T> * 2.0);
 inline constexpr double tau = tau_v<double>;
 
-// TODO C++20: Use std::floating_point instead of typename
-// TODO C++20: Use std::numbers::inv_pi_v<T> instead of computed value
-template<typename T>
-inline constexpr T inv_pi_v = T(1.0 / pi_v<T>);
-inline constexpr double inv_pi = inv_pi_v<double>;
-
-// TODO C++20: Use std::floating_point instead of typename
-template<typename T>
-inline constexpr T inv_tau_v = T(1.0 / tau_v<T>);
-inline constexpr double inv_tau = inv_tau_v<double>;
-
 //TODO C++20: Use std::floating_point instead of typename
 template<typename T>
 inline constexpr T pi_half_v = T(pi_v<T> / 2.0);

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -42,11 +42,16 @@ template<typename T>
 inline constexpr T tau_v = T(pi_v<T> * 2.0);
 inline constexpr double tau = tau_v<double>;
 
-// [TODO] C++20: Use std::floating_point instead of typename
-// [TODO] C++20: Use std::numbers::inv_pi_v<T> instead of computed value
+// TODO C++20: Use std::floating_point instead of typename
+// TODO C++20: Use std::numbers::inv_pi_v<T> instead of computed value
 template<typename T>
 inline constexpr T inv_pi_v = T(1.0 / pi_v<T>);
 inline constexpr double inv_pi = inv_pi_v<double>;
+
+// TODO C++20: Use std::floating_point instead of typename
+template<typename T>
+inline constexpr T inv_tau_v = T(1.0 / tau_v<T>);
+inline constexpr double inv_tau = inv_tau_v<double>;
 
 //TODO C++20: Use std::floating_point instead of typename
 template<typename T>

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -119,7 +119,7 @@ inline float sign(float val)
 }
 
 
-//! if val >= 0.0f, returns sqrtf(val), else: -sqrtf(-val)
+//! if val >= 0.0f, returns sqrt(val), else: -sqrt(-val)
 inline float sqrt_neg(float val) 
 {
 	return std::sqrt(std::abs(val)) * sign(val);

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -38,7 +38,7 @@
 namespace lmms
 {
 
-// [TODO] C++20: Use template<std::signed_integral> instead of int
+// TODO C++20: Use template<std::signed_integral> instead of int
 /*!
  * @brief Performs euclidean division on two integers.
  * @details
@@ -56,8 +56,8 @@ constexpr int ediv(int k, int n)
 	return (k %= n) < 0 ? k + n : k;
 }
 
-// [TODO] C++20: Use template<std::floating_point> instead of float
-// [TODO] C++26: Make constexpr, since std::fmod will be constexpr
+// TODO C++20: Use template<std::floating_point> instead of float
+// TODO C++23: Make constexpr, since std::fmod will be constexpr
 /*!
  * @brief Performs euclidean division on two floats.
  * @details

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -38,6 +38,40 @@
 namespace lmms
 {
 
+// [TODO] C++20: Use template<std::signed_integral> instead of int
+/*!
+ * @brief Performs euclidean division on two integers.
+ * @details
+ * Performs euclidean (or "remainder") division. This is similar to
+ * modulo, but it handles negative values for `k` differently.
+ * Like indexing with negative values in python, negative values for `k`
+ * "count backwards" from `n`, so output values will always be in the
+ * range 0..<`n`.
+ *
+ * If `n` is a power of 2, it may be better to use the bitwise hack
+ * `k & (n - 1)` instead.
+ */
+constexpr inline int ediv(int k, int n)
+{
+	return (k %= n) < 0 ? k + n : k;
+}
+
+// [TODO] C++20: Use template<std::floating_point> instead of float
+// [TODO] C++26: Make constexpr, since std::fmod will be constexpr
+/*!
+ * @brief Performs euclidean division on two floats.
+ * @details
+ * Performs euclidean (or "remainder") division. This is similar to
+ * modulo, but it handles negative values for `k` differently.
+ * Like indexing with negative values in python, negative values for `k`
+ * "count backwards" from `n`, so output values will always be in the
+ * range 0..<`n`.
+ */
+inline float ediv(float k, float n)
+{
+	return (k = std::fmod(k, n)) < 0 ? k + n : k;
+}
+
 inline bool approximatelyEqual(float x, float y)
 {
 	return x == y ? true : std::abs(x - y) < F_EPSILON;

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -67,7 +67,7 @@ constexpr int ediv(int k, int n)
  * "count backwards" from `n`, so output values will always be in the
  * range 0..<`n`.
  */
-inline float ediv(float k, float n)
+float ediv(float k, float n)
 {
 	return (k = std::fmod(k, n)) < 0 ? k + n : k;
 }

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -51,7 +51,7 @@ namespace lmms
  * If `n` is a power of 2, it may be better to use the bitwise hack
  * `k & (n - 1)` instead.
  */
-constexpr inline int ediv(int k, int n)
+constexpr int ediv(int k, int n)
 {
 	return (k %= n) < 0 ? k + n : k;
 }

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -67,7 +67,7 @@ constexpr int ediv(int k, int n)
  * "count backwards" from `n`, so output values will always be in the
  * range 0..<`n`.
  */
-float ediv(float k, float n)
+inline float ediv(float k, float n)
 {
 	return (k = std::fmod(k, n)) < 0 ? k + n : k;
 }

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -38,40 +38,6 @@
 namespace lmms
 {
 
-// TODO C++20: Use template<std::signed_integral> instead of int
-/*!
- * @brief Performs euclidean division on two integers.
- * @details
- * Performs euclidean (or "remainder") division. This is similar to
- * modulo, but it handles negative values for `k` differently.
- * Like indexing with negative values in python, negative values for `k`
- * "count backwards" from `n`, so output values will always be in the
- * range 0..<`n`.
- *
- * If `n` is a power of 2, it may be better to use the bitwise hack
- * `k & (n - 1)` instead.
- */
-constexpr int ediv(int k, int n)
-{
-	return (k %= n) < 0 ? k + n : k;
-}
-
-// TODO C++20: Use template<std::floating_point> instead of float
-// TODO C++23: Make constexpr, since std::fmod will be constexpr
-/*!
- * @brief Performs euclidean division on two floats.
- * @details
- * Performs euclidean (or "remainder") division. This is similar to
- * modulo, but it handles negative values for `k` differently.
- * Like indexing with negative values in python, negative values for `k`
- * "count backwards" from `n`, so output values will always be in the
- * range 0..<`n`.
- */
-inline float ediv(float k, float n)
-{
-	return (k = std::fmod(k, n)) < 0 ? k + n : k;
-}
-
 inline bool approximatelyEqual(float x, float y)
 {
 	return x == y ? true : std::abs(x - y) < F_EPSILON;

--- a/plugins/BitInvader/BitInvader.cpp
+++ b/plugins/BitInvader/BitInvader.cpp
@@ -86,7 +86,7 @@ BSynth::BSynth( float * _shape, NotePlayHandle * _nph, bool _interpolation,
 		i.e., the absolute value of all samples is <= 1.0 if _factor
 		is different to the default normalization factor. If there is
 		a value > 1.0, clip the sample to 1.0 to limit the range. */
-		if ((_factor != defaultNormalizationFactor) && (fabsf(buf) > 1.0f))
+		if ((_factor != defaultNormalizationFactor) && (std::abs(buf) > 1.0f))
 		{
 			buf = (buf < 0) ? -1.0f : 1.0f;
 		}
@@ -238,7 +238,7 @@ void BitInvader::normalize()
 	const float* samples = m_graph.samples();
 	for(int i=0; i < m_graph.length(); i++)
 	{
-		const float f = fabsf( samples[i] );
+		const float f = std::abs(samples[i]);
 		if (f > max) { max = f; }
 	}
 	m_normalizeFactor = 1.0 / max;

--- a/plugins/Compressor/Compressor.cpp
+++ b/plugins/Compressor/Compressor.cpp
@@ -528,22 +528,6 @@ void CompressorEffect::processBypassedImpl()
 	}
 }
 
-// [TODO] Move to lmms_math.h?
-// Regular modulo doesn't handle negative numbers correctly.  This does.
-inline int CompressorEffect::realmod(int k, int n)
-{
-	return (k %= n) < 0 ? k+n : k;
-}
-
-// [TODO] Move to lmms_math.h?
-// Regular fmod doesn't handle negative numbers correctly.  This does.
-inline float CompressorEffect::realfmod(float k, float n)
-{
-	return (k = std::fmod(k, n)) < 0 ? k + n : k;
-}
-
-
-
 inline void CompressorEffect::calcTiltFilter(sample_t inputSample, sample_t &outputSample, int filtNum)
 {
 	m_tiltOut[filtNum] = m_a0 * inputSample + m_b1 * m_tiltOut[filtNum];

--- a/plugins/Compressor/Compressor.cpp
+++ b/plugins/Compressor/Compressor.cpp
@@ -61,7 +61,7 @@ CompressorEffect::CompressorEffect(Model* parent, const Descriptor::SubPluginFea
 	m_yL[0] = m_yL[1] = COMP_NOISE_FLOOR;
 
 	// 200 ms
-	m_crestTimeConst = exp(-1.f / (0.2f * m_sampleRate));
+	m_crestTimeConst = std::exp(-1.f / (0.2f * m_sampleRate));
 
 	connect(&m_compressorControls.m_attackModel, SIGNAL(dataChanged()), this, SLOT(calcAttack()), Qt::DirectConnection);
 	connect(&m_compressorControls.m_releaseModel, SIGNAL(dataChanged()), this, SLOT(calcRelease()), Qt::DirectConnection);
@@ -97,7 +97,7 @@ CompressorEffect::CompressorEffect(Model* parent, const Descriptor::SubPluginFea
 float CompressorEffect::msToCoeff(float ms)
 {
 	// Convert time in milliseconds to applicable lowpass coefficient
-	return exp(m_coeffPrecalc / ms);
+	return std::exp(m_coeffPrecalc / ms);
 }
 
 
@@ -175,7 +175,7 @@ void CompressorEffect::calcRange()
 void CompressorEffect::resizeRMS()
 {
 	const float rmsValue = m_compressorControls.m_rmsModel.value();
-	m_rmsTimeConst = (rmsValue > 0) ? exp(-1.f / (rmsValue * 0.001f * m_sampleRate)) : 0;
+	m_rmsTimeConst = (rmsValue > 0) ? std::exp(-1.f / (rmsValue * 0.001f * m_sampleRate)) : 0;
 }
 
 void CompressorEffect::calcLookaheadLength()
@@ -211,14 +211,14 @@ void CompressorEffect::calcTiltCoeffs()
 {
 	m_tiltVal = m_compressorControls.m_tiltModel.value();
 
-	const float amp = 6 / log(2);
+	const float amp = 6.f / std::log(2.f);
 
 	const float gfactor = 5;
 	const float g1 = m_tiltVal > 0 ? -gfactor * m_tiltVal : -m_tiltVal;
 	const float g2 = m_tiltVal > 0 ? m_tiltVal : gfactor * m_tiltVal;
 
-	m_lgain = exp(g1 / amp) - 1;
-	m_hgain = exp(g2 / amp) - 1;
+	m_lgain = std::exp(g1 / amp) - 1;
+	m_hgain = std::exp(g2 / amp) - 1;
 
 	const float omega = numbers::tau_v<float> * m_compressorControls.m_tiltFreqModel.value();
 	const float n = 1 / (m_sampleRate * 3 + omega);
@@ -528,16 +528,18 @@ void CompressorEffect::processBypassedImpl()
 	}
 }
 
+// [TODO] Move to lmms_math.h?
 // Regular modulo doesn't handle negative numbers correctly.  This does.
 inline int CompressorEffect::realmod(int k, int n)
 {
 	return (k %= n) < 0 ? k+n : k;
 }
 
+// [TODO] Move to lmms_math.h?
 // Regular fmod doesn't handle negative numbers correctly.  This does.
 inline float CompressorEffect::realfmod(float k, float n)
 {
-	return (k = fmod(k, n)) < 0 ? k+n : k;
+	return (k = std::fmod(k, n)) < 0 ? k + n : k;
 }
 
 
@@ -557,7 +559,7 @@ void CompressorEffect::changeSampleRate()
 	m_coeffPrecalc = COMP_LOG / (m_sampleRate * 0.001f);
 
 	// 200 ms
-	m_crestTimeConst = exp(-1.f / (0.2f * m_sampleRate));
+	m_crestTimeConst = std::exp(-1.f / (0.2f * m_sampleRate));
 
 	m_lookBufLength = std::ceil((20.f / 1000.f) * m_sampleRate) + 2;
 	for (int i = 0; i < 2; ++i)

--- a/plugins/Compressor/Compressor.h
+++ b/plugins/Compressor/Compressor.h
@@ -78,8 +78,6 @@ private:
 	float msToCoeff(float ms);
 
 	inline void calcTiltFilter(sample_t inputSample, sample_t &outputSample, int filtNum);
-	inline int realmod(int k, int n);
-	inline float realfmod(float k, float n);
 
 	enum class StereoLinkMode { Unlinked, Maximum, Average, Minimum, Blend };
 

--- a/plugins/Delay/Lfo.cpp
+++ b/plugins/Delay/Lfo.cpp
@@ -41,7 +41,7 @@ Lfo::Lfo( int samplerate )
 
 float Lfo::tick()
 {
-	float output = sinf( m_phase );
+	float output = std::sin(m_phase);
 	m_phase += m_increment;
 
 	return output;

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -82,7 +82,7 @@ float EqHandle::xPixelToFreq( float x , int w )
 	float min = std::log10(20);
 	float max = std::log10(20000);
 	float range = max - min;
-	return std::pow(10 , x * (range / w) + min);
+	return fastPow10f(x * (range / w) + min);
 }
 
 
@@ -205,7 +205,7 @@ float EqHandle::getPeakCurve( float x )
 	double c = std::cos(w0);
 	double s = std::sin(w0);
 	double Q = getResonance();
-	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
+	double A = fastPow10f(yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
 	double alpha = s * std::sinh(std::log(2.0) / 2 * Q * w0 / std::sin(w0));
 
 	//calc coefficents
@@ -240,7 +240,7 @@ float EqHandle::getHighShelfCurve( float x )
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
 	double c = std::cos(w0);
 	double s = std::sin(w0);
-	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) * 0.025);
+	double A = fastPow10f(yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) * 0.025);
 	double beta = std::sqrt(A) / m_resonance;
 
 	//calc coefficents
@@ -275,7 +275,7 @@ float EqHandle::getLowShelfCurve( float x )
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
 	double c = std::cos(w0);
 	double s = std::sin(w0);
-	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
+	double A = fastPow10f(yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
 	double beta = std::sqrt(A) / m_resonance;
 
 	//calc coefficents
@@ -525,8 +525,10 @@ double EqHandle::calculateGain(const double freq, const double a1, const double 
 	const double w = std::sin(numbers::pi * freq / Engine::audioEngine()->outputSampleRate());
 	const double PHI = w * w * 4;
 
-	double gain = 10 * std::log10(std::pow(b0 + b1 + b2 , 2) + (b0 * b2 * PHI - (b1 * (b0 + b2) + 4 * b0 * b2)) * PHI)
-		- 10 * std::log10(std::pow(1 + a1 + a2, 2) + (1 * a2 * PHI - (a1 * (1 + a2) + 4 * 1 * a2)) * PHI);
+	auto bb = b0 + b1 + b2;
+	auto aa = 1 + a1 + a2;
+	double gain = 10 * std::log10(bb * bb + (b0 * b2 * PHI - (b1 * (b0 + b2) + 4 * b0 * b2)) * PHI)
+		- 10 * std::log10(aa * aa + (1 * a2 * PHI - (a1 * (1 + a2) + 4 * 1 * a2)) * PHI);
 	return gain;
 }
 

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -68,10 +68,10 @@ QRectF EqHandle::boundingRect() const
 float EqHandle::freqToXPixel( float freq , int w )
 {
 	if (approximatelyEqual(freq, 0.0f)) { return 0.0f; }
-	float min = log10f( 20 );
-	float max = log10f( 20000 );
+	float min = std::log10(20);
+	float max = std::log10(20000);
 	float range = max - min;
-	return ( log10f( freq ) - min ) / range * w;
+	return (std::log10(freq) - min) / range * w;
 }
 
 
@@ -79,10 +79,10 @@ float EqHandle::freqToXPixel( float freq , int w )
 
 float EqHandle::xPixelToFreq( float x , int w )
 {
-	float min = log10f( 20 );
-	float max = log10f( 20000 );
+	float min = std::log10(20);
+	float max = std::log10(20000);
 	float range = max - min;
-	return powf( 10 , x * ( range / w ) + min );
+	return std::pow(10 , x * (range / w) + min);
 }
 
 
@@ -202,11 +202,11 @@ float EqHandle::getPeakCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
-	double c = cosf( w0 );
-	double s = sinf( w0 );
+	double c = std::cos(w0);
+	double s = std::sin(w0);
 	double Q = getResonance();
-	double A =  pow( 10, yPixelToGain( EqHandle::y(), m_heigth, m_pixelsPerUnitHeight ) / 40 );
-	double alpha = s * sinh( log( 2 ) / 2 * Q * w0 / sinf( w0 ) );
+	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
+	double alpha = s * std::sinh(std::log(2.0) / 2 * Q * w0 / std::sin(w0));
 
 	//calc coefficents
 	double b0 = 1 + alpha * A;
@@ -238,10 +238,10 @@ float EqHandle::getHighShelfCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
-	double c = cosf( w0 );
-	double s = sinf( w0 );
-	double A =  pow( 10, yPixelToGain( EqHandle::y(), m_heigth, m_pixelsPerUnitHeight ) * 0.025 );
-	double beta = sqrt( A ) / m_resonance;
+	double c = std::cos(w0);
+	double s = std::sin(w0);
+	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) * 0.025);
+	double beta = std::sqrt(A) / m_resonance;
 
 	//calc coefficents
 	double b0 = A * ((A + 1) + (A - 1) * c + beta * s);
@@ -273,10 +273,10 @@ float EqHandle::getLowShelfCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
-	double c = cosf( w0 );
-	double s = sinf( w0 );
-	double A =  pow( 10, yPixelToGain( EqHandle::y(), m_heigth, m_pixelsPerUnitHeight ) / 40 );
-	double beta = sqrt( A ) / m_resonance;
+	double c = std::cos(w0);
+	double s = std::sin(w0);
+	double A = std::pow(10, yPixelToGain(EqHandle::y(), m_heigth, m_pixelsPerUnitHeight) / 40);
+	double beta = std::sqrt(A) / m_resonance;
 
 	//calc coefficents
 	double b0 = A * ((A + 1) - (A - 1) * c + beta * s);
@@ -308,8 +308,8 @@ float EqHandle::getLowCutCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
-	double c = cosf( w0 );
-	double s = sinf( w0 );
+	double c = std::cos(w0);
+	double s = std::sin(w0);
 	double resonance = getResonance();
 	double alpha = s / (2 * resonance);
 
@@ -350,8 +350,8 @@ float EqHandle::getHighCutCurve( float x )
 {
 	double freqZ = xPixelToFreq( EqHandle::x(), m_width );
 	double w0 = numbers::tau * freqZ / Engine::audioEngine()->outputSampleRate();
-	double c = cosf( w0 );
-	double s = sinf( w0 );
+	double c = std::cos(w0);
+	double s = std::sin(w0);
 	double resonance = getResonance();
 	double alpha = s / (2 * resonance);
 
@@ -525,9 +525,8 @@ double EqHandle::calculateGain(const double freq, const double a1, const double 
 	const double w = std::sin(numbers::pi * freq / Engine::audioEngine()->outputSampleRate());
 	const double PHI = w * w * 4;
 
-	double gain = 10 * log10( pow( b0 + b1 + b2 , 2 ) + ( b0 * b2 * PHI - ( b1 * ( b0 + b2 )
-				+ 4 * b0 * b2 ) ) * PHI ) - 10 * log10( pow( 1 + a1 + a2, 2 )
-				+ ( 1 * a2 * PHI - ( a1 * ( 1 + a2 ) + 4 * 1 * a2 ) ) * PHI );
+	double gain = 10 * std::log10(std::pow(b0 + b1 + b2 , 2) + (b0 * b2 * PHI - (b1 * (b0 + b2) + 4 * b0 * b2)) * PHI)
+		- 10 * std::log10(std::pow(1 + a1 + a2, 2) + (1 * a2 * PHI - (a1 * (1 + a2) + 4 * 1 * a2)) * PHI);
 	return gain;
 }
 

--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -272,7 +272,7 @@ public:
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
 		float c = std::cos(w0);
 		float s = std::sin(w0);
-		float A = std::pow(10, m_gain * 0.025);
+		float A = fastPow10f(m_gain * 0.025);
 		float alpha = s * std::sinh(std::log(2.f) / 2 * m_bw * w0 / std::sin(w0));
 
 		//calc coefficents
@@ -335,7 +335,7 @@ public :
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
 		float c = std::cos(w0);
 		float s = std::sin(w0);
-		float A = std::pow(10, m_gain * 0.025);
+		float A = fastPow10f(m_gain * 0.025);
 		// float alpha = s / (2 * m_res);
 		float beta = std::sqrt(A) / m_res;
 
@@ -372,7 +372,7 @@ public :
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
 		float c = std::cos(w0);
 		float s = std::sin(w0);
-		float A = std::pow(10, m_gain * 0.025);
+		float A = fastPow10f(m_gain * 0.025);
 		float beta = std::sqrt(A) / m_res;
 
 		//calc coefficents

--- a/plugins/Eq/EqFilter.h
+++ b/plugins/Eq/EqFilter.h
@@ -186,8 +186,8 @@ public :
 
 		// calc intermediate
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
-		float c = cosf( w0 );
-		float s = sinf( w0 );
+		float c = std::cos(w0);
+		float s = std::sin(w0);
 		float alpha = s / ( 2 * m_res );
 
 		//calc coefficents
@@ -229,8 +229,8 @@ public :
 
 		// calc intermediate
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
-		float c = cosf( w0 );
-		float s = sinf( w0 );
+		float c = std::cos(w0);
+		float s = std::sin(w0);
 		float alpha = s / ( 2 * m_res );
 
 		//calc coefficents
@@ -270,10 +270,10 @@ public:
 	{
 		// calc intermediate
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
-		float c = cosf( w0 );
-		float s = sinf( w0 );
-		float A =  pow( 10, m_gain * 0.025);
-		float alpha = s * sinh( log( 2 ) / 2 * m_bw * w0 / sinf(w0) );
+		float c = std::cos(w0);
+		float s = std::sin(w0);
+		float A = std::pow(10, m_gain * 0.025);
+		float alpha = s * std::sinh(std::log(2.f) / 2 * m_bw * w0 / std::sin(w0));
 
 		//calc coefficents
 		float b0 = 1 + alpha * A;
@@ -333,11 +333,11 @@ public :
 
 		// calc intermediate
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
-		float c = cosf( w0 );
-		float s = sinf( w0 );
-		float A =  pow( 10, m_gain * 0.025);
-		//        float alpha = s / ( 2 * m_res );
-		float beta = sqrt( A ) / m_res;
+		float c = std::cos(w0);
+		float s = std::sin(w0);
+		float A = std::pow(10, m_gain * 0.025);
+		// float alpha = s / (2 * m_res);
+		float beta = std::sqrt(A) / m_res;
 
 		//calc coefficents
 		float b0 = A * ((A + 1) - (A - 1) * c + beta * s);
@@ -370,10 +370,10 @@ public :
 
 		// calc intermediate
 		float w0 = numbers::tau_v<float> * m_freq / m_sampleRate;
-		float c = cosf( w0 );
-		float s = sinf( w0 );
-		float A =  pow( 10, m_gain * 0.025 );
-		float beta = sqrt( A ) / m_res;
+		float c = std::cos(w0);
+		float s = std::sin(w0);
+		float A = std::pow(10, m_gain * 0.025);
+		float beta = std::sqrt(A) / m_res;
 
 		//calc coefficents
 		float b0 = A * ((A + 1) + (A - 1) * c + beta * s);

--- a/plugins/Eq/EqSpectrumView.cpp
+++ b/plugins/Eq/EqSpectrumView.cpp
@@ -193,7 +193,7 @@ EqSpectrumView::EqSpectrumView(EqAnalyser *b, QWidget *_parent) :
 	connect( getGUI()->mainWindow(), SIGNAL( periodicUpdate() ), this, SLOT( periodicalUpdate() ) );
 	setAttribute( Qt::WA_TranslucentBackground, true );
 	m_skipBands = MAX_BANDS * 0.5;
-	float totalLength = log10( 20000 );
+	const float totalLength = std::log10(20000);
 	m_pixelsPerUnitWidth = width() / totalLength ;
 	m_scale = 1.5;
 	m_color = QColor( 255, 255, 255, 255 );
@@ -233,7 +233,7 @@ void EqSpectrumView::paintEvent(QPaintEvent *event)
 	const float fallOff = 1.07f;
 	for( int x = 0; x < MAX_BANDS; ++x, ++bands )
 	{
-		float peak = *bands != 0. ? (fh * 2.0 / 3.0 * (20. * log10(*bands / energy) - LOWER_Y) / (-LOWER_Y)) : 0.;
+		float peak = *bands != 0. ? (fh * 2.0 / 3.0 * (20. * std::log10(*bands / energy) - LOWER_Y) / (-LOWER_Y)) : 0.;
 
 		if( peak < 0 )
 		{

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -1101,9 +1101,7 @@ GigSample::GigSample( gig::Sample * pSample, gig::DimensionRegion * pDimRegion,
 		if( region->PitchTrack == true )
 		{
 			// Calculate what frequency the provided sample is
-			sampleFreq = 440.0 * powf( 2, 1.0 / 12 * (
-						1.0 * region->UnityNote - 69 -
-						0.01 * region->FineTune ) );
+			sampleFreq = 440.0f * std::pow(2.0f, (region->UnityNote - 69 - region->FineTune * 0.01) / 12.0f);
 			freqFactor = sampleFreq / desiredFreq;
 		}
 
@@ -1342,7 +1340,7 @@ float ADSR::value()
 	{
 		// Maybe not the best way of doing this, but it appears to be about right
 		// Satisfies f(0) = sustain and f(releaseLength) = very small
-		amplitude = ( sustain + 1e-3 ) * expf( -5.0 / releaseLength * releasePosition ) - 1e-3;
+		amplitude = (sustain + 1e-3) * std::exp(-5.0f / releaseLength * releasePosition) - 1e-3;
 
 		// Don't have an infinite exponential decay
 		if( amplitude <= 0 || releasePosition >= releaseLength )

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -1101,7 +1101,7 @@ GigSample::GigSample( gig::Sample * pSample, gig::DimensionRegion * pDimRegion,
 		if( region->PitchTrack == true )
 		{
 			// Calculate what frequency the provided sample is
-			sampleFreq = 440.0f * std::pow(2.0f, (region->UnityNote - 69 - region->FineTune * 0.01) / 12.0f);
+			sampleFreq = 440.0f * std::exp2((region->UnityNote - 69 - region->FineTune * 0.01) / 12.0f);
 			freqFactor = sampleFreq / desiredFreq;
 		}
 

--- a/plugins/LOMM/LOMM.cpp
+++ b/plugins/LOMM/LOMM.cpp
@@ -82,7 +82,7 @@ void LOMMEffect::changeSampleRate()
 	m_coeffPrecalc = -2.2f / (m_sampleRate * 0.001f);
 	m_needsUpdate = true;
 	
-	m_crestTimeConst = exp(-1.f / (0.2f * m_sampleRate));
+	m_crestTimeConst = std::exp(-1.f / (0.2f * m_sampleRate));
 	
 	m_lookBufLength = std::ceil((LOMM_MAX_LOOKAHEAD / 1000.f) * m_sampleRate) + 2;
 	for (int i = 0; i < 2; ++i)
@@ -171,7 +171,7 @@ Effect::ProcessStatus LOMMEffect::processImpl(SampleFrame* buf, const fpp_t fram
 	float rel[3] = {relH, relM, relL};
 	float relCoef[3] = {relCoefH, relCoefM, relCoefL};
 	const float rmsTime = m_lommControls.m_rmsTimeModel.value();
-	const float rmsTimeConst = (rmsTime == 0) ? 0 : exp(-1.f / (rmsTime * 0.001f * m_sampleRate));
+	const float rmsTimeConst = (rmsTime == 0) ? 0 : std::exp(-1.f / (rmsTime * 0.001f * m_sampleRate));
 	const float knee = m_lommControls.m_kneeModel.value() * 0.5f;
 	const float range = m_lommControls.m_rangeModel.value();
 	const float rangeAmp = dbfsToAmp(range);

--- a/plugins/LOMM/LOMM.h
+++ b/plugins/LOMM/LOMM.h
@@ -55,7 +55,7 @@ public:
 	
 	inline float msToCoeff(float ms)
 	{
-		return (ms == 0) ? 0 : exp(m_coeffPrecalc / ms);
+		return (ms == 0) ? 0 : std::exp(m_coeffPrecalc / ms);
 	}
 
 private slots:

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -563,7 +563,7 @@ int Lb302Synth::process(SampleFrame* outbuf, const std::size_t size)
 				break;
 
 			case VcoShape::RoundSquare: // p0: width of round
-				vco_k = vco_c < 0.f ? std::sqrt(1.f - (vco_c * vco_c * 4.f)) - 0.5f : -0.5f;
+				vco_k = (vco_c < 0.f) ? (std::sqrt(1.f - (vco_c * vco_c * 4.f)) - 0.5f) : -0.5f;
 				break;
 
 			case VcoShape::Moog: // Maybe the fall should be exponential/sinsoidal instead of quadric.

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -574,7 +574,7 @@ int Lb302Synth::process(SampleFrame* outbuf, const std::size_t size)
 				}
 				else if (vco_k>0.5) {
 					float w = 2.0 * (vco_k - 0.5) - 1.0;
-					vco_k = 0.5 - std::sqrt(1.0-(w*w));
+					vco_k = 0.5 - std::sqrt(1.0 - (w * w));
 				}
 				vco_k *= 2.0;  // MOOG wave gets filtered away
 				break;

--- a/plugins/Lb302/Lb302.cpp
+++ b/plugins/Lb302/Lb302.cpp
@@ -109,20 +109,20 @@ Lb302Filter::Lb302Filter(Lb302FilterKnobState* p_fs) :
 
 void Lb302Filter::recalc()
 {
-	vcf_e1 = exp(6.109 + 1.5876*(fs->envmod) + 2.1553*(fs->cutoff) - 1.2*(1.0-(fs->reso)));
-	vcf_e0 = exp(5.613 - 0.8*(fs->envmod) + 2.1553*(fs->cutoff) - 0.7696*(1.0-(fs->reso)));
+	vcf_e1 = std::exp(6.109f + 1.5876f * fs->envmod + 2.1553f * fs->cutoff - 1.2f * (1.0f - fs->reso));
+	vcf_e0 = std::exp(5.613f - 0.8f * fs->envmod + 2.1553f * fs->cutoff - 0.7696f * (1.0f - fs->reso));
 	vcf_e0*=M_PI/Engine::audioEngine()->outputSampleRate();
 	vcf_e1*=M_PI/Engine::audioEngine()->outputSampleRate();
 	vcf_e1 -= vcf_e0;
 
-	vcf_rescoeff = exp(-1.20 + 3.455*(fs->reso));
+	vcf_rescoeff = std::exp(-1.20f + 3.455f * fs->reso);
 };
 
 
 void Lb302Filter::envRecalc()
 {
 	vcf_c0 *= fs->envdecay;       // Filter Decay. vcf_decay is adjusted for Hz and ENVINC
-	// vcf_rescoeff = exp(-1.20 + 3.455*(fs->reso)); moved above
+	// vcf_rescoeff = std::exp(-1.20f + 3.455f * fs->reso); moved above
 };
 
 
@@ -169,9 +169,9 @@ void Lb302FilterIIR2::envRecalc()
 	Lb302Filter::envRecalc();
 
 	float w = vcf_e0 + vcf_c0;          // e0 is adjusted for Hz and doesn't need ENVINC
-	float k = exp(-w/vcf_rescoeff);     // Does this mean c0 is inheritantly?
+	float k = std::exp(-w / vcf_rescoeff); // Does this mean c0 is inheritantly?
 
-	vcf_a = 2.0*cos(2.0*w) * k;
+	vcf_a = 2.0 * std::cos(2.0 * w) * k;
 	vcf_b = -k*k;
 	vcf_c = 1.0 - vcf_a - vcf_b;
 }
@@ -241,7 +241,7 @@ void Lb302Filter3Pole::envRecalc()
 	kp1  = kp+1.0;
 	kp1h = 0.5*kp1;
 #ifdef LB_24_RES_TRICK
-	k = exp(-w/vcf_rescoeff);
+	k = std::exp(-w / vcf_rescoeff);
 	kres = (((k))) * (((-2.7079*kp1 + 10.963)*kp1 - 14.934)*kp1 + 8.4974);
 #else
 	kres = (((fs->reso))) * (((-2.7079*kp1 + 10.963)*kp1 - 14.934)*kp1 + 8.4974);
@@ -415,7 +415,7 @@ void Lb302Synth::filterChanged()
 	float d = 0.2 + (2.3*vcf_dec_knob.value());
 
 	d *= Engine::audioEngine()->outputSampleRate(); // d *= smpl rate
-	fs.envdecay = pow(0.1, 1.0/d * ENVINC);    // decay is 0.1 to the 1/d * ENVINC
+	fs.envdecay = std::pow(0.1f, 1.0f / d * ENVINC); // decay is 0.1 to the 1/d * ENVINC
 	                                           // vcf_envdecay is now adjusted for both
 	                                           // sampling rate and ENVINC
 	recalcFilter();
@@ -563,7 +563,7 @@ int Lb302Synth::process(SampleFrame* outbuf, const std::size_t size)
 				break;
 
 			case VcoShape::RoundSquare: // p0: width of round
-				vco_k = (vco_c<0)?(sqrtf(1-(vco_c*vco_c*4))-0.5):-0.5;
+				vco_k = vco_c < 0.f ? std::sqrt(1.f - (vco_c * vco_c * 4.f)) - 0.5f : -0.5f;
 				break;
 
 			case VcoShape::Moog: // Maybe the fall should be exponential/sinsoidal instead of quadric.
@@ -574,7 +574,7 @@ int Lb302Synth::process(SampleFrame* outbuf, const std::size_t size)
 				}
 				else if (vco_k>0.5) {
 					float w = 2.0 * (vco_k - 0.5) - 1.0;
-					vco_k = 0.5 - sqrtf(1.0-(w*w));
+					vco_k = 0.5 - std::sqrt(1.0-(w*w));
 				}
 				vco_k *= 2.0;  // MOOG wave gets filtered away
 				break;

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -120,7 +120,7 @@ void MonstroSynth::renderOutput( fpp_t _frames, SampleFrame* _buf  )
 		if( mod##_e2 != 0.0f ) modtmp += m_env[1][f] * mod##_e2; \
 		if( mod##_l1 != 0.0f ) modtmp += m_lfo[0][f] * mod##_l1; \
 		if( mod##_l2 != 0.0f ) modtmp += m_lfo[1][f] * mod##_l2; \
-		(car) = qBound( MIN_FREQ, (car) * std::pow(2.0f, modtmp), MAX_FREQ);
+		(car) = qBound( MIN_FREQ, (car) * std::exp2(modtmp), MAX_FREQ);
 
 #define modulateabs( car, mod ) \
 		if( mod##_e1 != 0.0f ) car += m_env[0][f] * mod##_e1; \
@@ -1361,25 +1361,25 @@ void MonstroInstrument::updateVolume3()
 
 void MonstroInstrument::updateFreq1()
 {
-	m_osc1l_freq = std::pow(2.0f, m_osc1Crs.value() / 12.0f)
-		* std::pow(2.0f, m_osc1Ftl.value() / 1200.0f);
-	m_osc1r_freq = std::pow(2.0f, m_osc1Crs.value() / 12.0f)
-		* std::pow(2.0f, m_osc1Ftr.value() / 1200.0f);
+	m_osc1l_freq = std::exp2(m_osc1Crs.value() / 12.0f)
+		* std::exp2(m_osc1Ftl.value() / 1200.0f);
+	m_osc1r_freq = std::exp2(m_osc1Crs.value() / 12.0f)
+		* std::exp2(m_osc1Ftr.value() / 1200.0f);
 }
 
 
 void MonstroInstrument::updateFreq2()
 {
-	m_osc2l_freq = std::pow(2.0f, m_osc2Crs.value() / 12.0f)
-		* std::pow(2.0f, m_osc2Ftl.value() / 1200.0f);
-	m_osc2r_freq = std::pow(2.0f, m_osc2Crs.value() / 12.0f)
-		* std::pow(2.0f, m_osc2Ftr.value() / 1200.0f);
+	m_osc2l_freq = std::exp2(m_osc2Crs.value() / 12.0f)
+		* std::exp2(m_osc2Ftl.value() / 1200.0f);
+	m_osc2r_freq = std::exp2(m_osc2Crs.value() / 12.0f)
+		* std::exp2(m_osc2Ftr.value() / 1200.0f);
 }
 
 
 void MonstroInstrument::updateFreq3()
 {
-	m_osc3_freq = std::pow(2.0f, m_osc3Crs.value() / 12.0f);
+	m_osc3_freq = std::exp2(m_osc3Crs.value() / 12.0f);
 }
 
 

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -120,7 +120,7 @@ void MonstroSynth::renderOutput( fpp_t _frames, SampleFrame* _buf  )
 		if( mod##_e2 != 0.0f ) modtmp += m_env[1][f] * mod##_e2; \
 		if( mod##_l1 != 0.0f ) modtmp += m_lfo[0][f] * mod##_l1; \
 		if( mod##_l2 != 0.0f ) modtmp += m_lfo[1][f] * mod##_l2; \
-		car = qBound( MIN_FREQ, car * powf( 2.0f, modtmp ), MAX_FREQ );
+		(car) = qBound( MIN_FREQ, (car) * std::pow(2.0f, modtmp), MAX_FREQ);
 
 #define modulateabs( car, mod ) \
 		if( mod##_e1 != 0.0f ) car += m_env[0][f] * mod##_e1; \
@@ -1361,25 +1361,25 @@ void MonstroInstrument::updateVolume3()
 
 void MonstroInstrument::updateFreq1()
 {
-	m_osc1l_freq = powf( 2.0f, m_osc1Crs.value() / 12.0f ) *
-					powf( 2.0f, m_osc1Ftl.value() / 1200.0f );
-	m_osc1r_freq = powf( 2.0f, m_osc1Crs.value() / 12.0f ) *
-					powf( 2.0f, m_osc1Ftr.value() / 1200.0f );
+	m_osc1l_freq = std::pow(2.0f, m_osc1Crs.value() / 12.0f)
+		* std::pow(2.0f, m_osc1Ftl.value() / 1200.0f);
+	m_osc1r_freq = std::pow(2.0f, m_osc1Crs.value() / 12.0f)
+		* std::pow(2.0f, m_osc1Ftr.value() / 1200.0f);
 }
 
 
 void MonstroInstrument::updateFreq2()
 {
-	m_osc2l_freq = powf( 2.0f, m_osc2Crs.value() / 12.0f ) *
-					powf( 2.0f, m_osc2Ftl.value() / 1200.0f );
-	m_osc2r_freq = powf( 2.0f, m_osc2Crs.value() / 12.0f ) *
-					powf( 2.0f, m_osc2Ftr.value() / 1200.0f );
+	m_osc2l_freq = std::pow(2.0f, m_osc2Crs.value() / 12.0f)
+		* std::pow(2.0f, m_osc2Ftl.value() / 1200.0f);
+	m_osc2r_freq = std::pow(2.0f, m_osc2Crs.value() / 12.0f)
+		* std::pow(2.0f, m_osc2Ftr.value() / 1200.0f);
 }
 
 
 void MonstroInstrument::updateFreq3()
 {
-	m_osc3_freq = powf( 2.0f, m_osc3Crs.value() / 12.0f );
+	m_osc3_freq = std::pow(2.0f, m_osc3Crs.value() / 12.0f);
 }
 
 

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -700,19 +700,19 @@ gui::PluginView* NesInstrument::instantiateView( QWidget * parent )
 
 void NesInstrument::updateFreq1()
 {
-	m_freq1 = std::pow(2, m_ch1Crs.value() / 12.0f);
+	m_freq1 = std::exp2(m_ch1Crs.value() / 12.0f);
 }
 
 
 void NesInstrument::updateFreq2()
 {
-	m_freq2 = std::pow(2, m_ch2Crs.value() / 12.0f);
+	m_freq2 = std::exp2(m_ch2Crs.value() / 12.0f);
 }
 
 
 void NesInstrument::updateFreq3()
 {
-	m_freq3 = std::pow(2, m_ch3Crs.value() / 12.0f);
+	m_freq3 = std::exp2(m_ch3Crs.value() / 12.0f);
 }
 
 

--- a/plugins/Nes/Nes.cpp
+++ b/plugins/Nes/Nes.cpp
@@ -700,19 +700,19 @@ gui::PluginView* NesInstrument::instantiateView( QWidget * parent )
 
 void NesInstrument::updateFreq1()
 {
-	m_freq1 = powf( 2, m_ch1Crs.value() / 12.0f );
+	m_freq1 = std::pow(2, m_ch1Crs.value() / 12.0f);
 }
 
 
 void NesInstrument::updateFreq2()
 {
-	m_freq2 = powf( 2, m_ch2Crs.value() / 12.0f );
+	m_freq2 = std::pow(2, m_ch2Crs.value() / 12.0f);
 }
 
 
 void NesInstrument::updateFreq3()
 {
-	m_freq3 = powf( 2, m_ch3Crs.value() / 12.0f );
+	m_freq3 = std::pow(2, m_ch3Crs.value() / 12.0f);
 }
 
 

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -497,7 +497,7 @@ void OpulenzInstrument::loadPatch(const unsigned char inst[14]) {
 
 void OpulenzInstrument::tuneEqual(int center, float Hz) {
 	for(int n=0; n<128; ++n) {
-		float tmp = Hz * pow(2.0, (n - center) * (1.0 / 12.0) + pitchbend * (1.0 / 1200.0));
+		float tmp = Hz * std::pow(2.0f, (n - center) / 12.0f + pitchbend / 1200.0f);
 		fnums[n] = Hz2fnum( tmp );
 	}
 }
@@ -505,7 +505,7 @@ void OpulenzInstrument::tuneEqual(int center, float Hz) {
 // Find suitable F number in lowest possible block
 int OpulenzInstrument::Hz2fnum(float Hz) {
 	for(int block=0; block<8; ++block) {
-		unsigned int fnum = Hz * pow( 2.0, 20.0 - (double)block ) * ( 1.0 / 49716.0 );
+		auto fnum = static_cast<unsigned>(Hz * std::pow(2.0f, 20.0f - static_cast<float>(block)) / 49716.0f);
 		if(fnum<1023) {
 			return fnum + (block << 10);
 		}

--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -497,7 +497,7 @@ void OpulenzInstrument::loadPatch(const unsigned char inst[14]) {
 
 void OpulenzInstrument::tuneEqual(int center, float Hz) {
 	for(int n=0; n<128; ++n) {
-		float tmp = Hz * std::pow(2.0f, (n - center) / 12.0f + pitchbend / 1200.0f);
+		float tmp = Hz * std::exp2((n - center) / 12.0f + pitchbend / 1200.0f);
 		fnums[n] = Hz2fnum( tmp );
 	}
 }
@@ -505,7 +505,7 @@ void OpulenzInstrument::tuneEqual(int center, float Hz) {
 // Find suitable F number in lowest possible block
 int OpulenzInstrument::Hz2fnum(float Hz) {
 	for(int block=0; block<8; ++block) {
-		auto fnum = static_cast<unsigned>(Hz * std::pow(2.0f, 20.0f - static_cast<float>(block)) / 49716.0f);
+		auto fnum = static_cast<unsigned>(Hz * std::exp2(20.0f - static_cast<float>(block)) / 49716.0f);
 		if(fnum<1023) {
 			return fnum + (block << 10);
 		}

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -342,7 +342,7 @@ void OrganicInstrument::deleteNotePluginData( NotePlayHandle * _n )
 float inline OrganicInstrument::waveshape(float in, float amount)
 {
 	float k = 2.0f * amount / ( 1.0f - amount );
-	return((1.0f + k) * in / (1.0f + k * std::abs(in)));
+	return (1.0f + k) * in / (1.0f + k * std::abs(in));
 }
 
 
@@ -602,12 +602,11 @@ void OscillatorObject::updateVolume()
 
 void OscillatorObject::updateDetuning()
 {
-	m_detuningLeft = std::exp2(OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
-		+ m_detuneModel.value() * CENT)
-		/ Engine::audioEngine()->outputSampleRate();
-	m_detuningRight = std::exp2(OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
-		- m_detuneModel.value() * CENT)
-		/ Engine::audioEngine()->outputSampleRate();
+	const auto harmonic = OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())];
+	const auto sr = Engine::audioEngine()->outputSampleRate();
+
+	m_detuningLeft = std::exp2(harmonic + m_detuneModel.value() * CENT) / sr;
+	m_detuningRight = std::exp2(harmonic - m_detuneModel.value() * CENT) / sr;
 }
 
 

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -602,12 +602,12 @@ void OscillatorObject::updateVolume()
 
 void OscillatorObject::updateDetuning()
 {
-	m_detuningLeft = std::pow(2.0f, OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
-				+ (float)m_detuneModel.value() * CENT)
-				/ Engine::audioEngine()->outputSampleRate();
-	m_detuningRight = std::pow(2.0f, OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
-				- (float)m_detuneModel.value() * CENT)
-				/ Engine::audioEngine()->outputSampleRate();
+	m_detuningLeft = std::exp2(OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
+		+ m_detuneModel.value() * CENT)
+		/ Engine::audioEngine()->outputSampleRate();
+	m_detuningRight = std::exp2(OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
+		- m_detuneModel.value() * CENT)
+		/ Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -342,8 +342,7 @@ void OrganicInstrument::deleteNotePluginData( NotePlayHandle * _n )
 float inline OrganicInstrument::waveshape(float in, float amount)
 {
 	float k = 2.0f * amount / ( 1.0f - amount );
-
-	return( ( 1.0f + k ) * in / ( 1.0f + k * fabs( in ) ) );
+	return((1.0f + k) * in / (1.0f + k * std::abs(in)));
 }
 
 
@@ -603,12 +602,12 @@ void OscillatorObject::updateVolume()
 
 void OscillatorObject::updateDetuning()
 {
-	m_detuningLeft = powf( 2.0f, OrganicInstrument::s_harmonics[ static_cast<int>( m_harmModel.value() ) ]
-				+ (float)m_detuneModel.value() * CENT ) /
-				Engine::audioEngine()->outputSampleRate();
-	m_detuningRight = powf( 2.0f, OrganicInstrument::s_harmonics[ static_cast<int>( m_harmModel.value() ) ]
-				- (float)m_detuneModel.value() * CENT ) /
-				Engine::audioEngine()->outputSampleRate();
+	m_detuningLeft = std::pow(2.0f, OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
+				+ (float)m_detuneModel.value() * CENT)
+				/ Engine::audioEngine()->outputSampleRate();
+	m_detuningRight = std::pow(2.0f, OrganicInstrument::s_harmonics[static_cast<int>(m_harmModel.value())]
+				- (float)m_detuneModel.value() * CENT)
+				/ Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -24,10 +24,8 @@
 #include "ReverbSC.h"
 
 #include "embed.h"
+#include "lmms_math.h"
 #include "plugin_export.h"
-
-// [TODO] Convert macro to constexpr function in ReverbSC.h
-#define DB2LIN(X) std::pow(10, (X) / 20.0f)
 
 namespace lmms
 {
@@ -93,10 +91,10 @@ Effect::ProcessStatus ReverbSCEffect::processImpl(SampleFrame* buf, const fpp_t 
 	{
 		auto s = std::array{buf[f][0], buf[f][1]};
 
-		const auto inGain
-			= (SPFLOAT)DB2LIN((inGainBuf ? inGainBuf->values()[f] : m_reverbSCControls.m_inputGainModel.value()));
-		const auto outGain
-			= (SPFLOAT)DB2LIN((outGainBuf ? outGainBuf->values()[f] : m_reverbSCControls.m_outputGainModel.value()));
+		const auto inGain = static_cast<SPFLOAT>(fastPow10f(
+			(inGainBuf ? inGainBuf->values()[f] : m_reverbSCControls.m_inputGainModel.value()) / 20.f));
+		const auto outGain = static_cast<SPFLOAT>(fastPow10f(
+			(outGainBuf ? outGainBuf->values()[f] : m_reverbSCControls.m_outputGainModel.value()) / 20.f));
 
 		s[0] *= inGain;
 		s[1] *= inGain;

--- a/plugins/ReverbSC/ReverbSC.cpp
+++ b/plugins/ReverbSC/ReverbSC.cpp
@@ -26,7 +26,8 @@
 #include "embed.h"
 #include "plugin_export.h"
 
-#define DB2LIN(X) pow(10, X / 20.0f);
+// [TODO] Convert macro to constexpr function in ReverbSC.h
+#define DB2LIN(X) std::pow(10, (X) / 20.0f)
 
 namespace lmms
 {

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -556,7 +556,7 @@ void Sf2Instrument::updateTuning()
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
 		auto centArray = std::array<double, 128>{};
-		double lowestHz = pow(2., -69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
+		double lowestHz = std::pow(2., -69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
 			// Get desired Hz of note

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -556,7 +556,7 @@ void Sf2Instrument::updateTuning()
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
 		auto centArray = std::array<double, 128>{};
-		double lowestHz = std::exp2(-69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
+		double lowestHz = std::exp2(-69. / 12.) * 440.; // Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
 			// Get desired Hz of note

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -556,7 +556,7 @@ void Sf2Instrument::updateTuning()
 	if (instrumentTrack()->microtuner()->enabledModel()->value())
 	{
 		auto centArray = std::array<double, 128>{};
-		double lowestHz = std::pow(2., -69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
+		double lowestHz = std::exp2(-69. / 12.) * 440.;// Frequency of MIDI note 0, which is approximately 8.175798916 Hz
 		for (int i = 0; i < 128; ++i)
 		{
 			// Get desired Hz of note

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -105,7 +105,7 @@ void SfxrSynth::resetSample( bool restart )
 	square_slide=-s->m_sqrSweepModel.value()*0.00005f;
 	const auto cha = static_cast<double>(s->m_changeAmtModel.value());
 	arp_mod = (cha >= 0.0)
-		? 1.0 - cha * cha * 00.9
+		? 1.0 - cha * cha * 0.9
 		: 1.0 + cha * cha * 10.0;
 	arp_time = 0;
 	const auto chs = 1.f - s->m_changeSpeedModel.value();

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -214,7 +214,7 @@ void SfxrSynth::update( SampleFrame* buffer, const int32_t frameNum )
 		if(env_stage==0)
 			env_vol=(float)env_time/env_length[0];
 		if(env_stage==1)
-			{ env_vol = 1.0f + std::pow(1.0f - static_cast<float>(env_time) / env_length[1], 1.0f) * 2.0f * s->m_susModel.value(); }
+			{ env_vol = 1.0f + (1.0f - static_cast<float>(env_time) / env_length[1]) * 2.0f * s->m_susModel.value(); }
 		if(env_stage==2)
 			env_vol=1.0f-(float)env_time/env_length[2];
 

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -114,16 +114,16 @@ void SfxrSynth::resetSample( bool restart )
 		// reset filter
 		fltp=0.0f;
 		fltdp=0.0f;
-		fltw=pow(s->m_lpFilCutModel.value(), 3.0f)*0.1f;
+		fltw = std::pow(s->m_lpFilCutModel.value(), 3.f) * 0.1f;
 		fltw_d=1.0f+s->m_lpFilCutSweepModel.value()*0.0001f;
 		fltdmp = 5.0f / (1.0f + std::pow(s->m_lpFilResoModel.value(), 2.0f) * 20.0f) * (0.01f + fltw);
 		if(fltdmp>0.8f) fltdmp=0.8f;
 		fltphp=0.0f;
-		flthp=pow(s->m_hpFilCutModel.value(), 2.0f)*0.1f;
+		flthp = std::pow(s->m_hpFilCutModel.value(), 2.f) * 0.1f;
 		flthp_d=1.0+s->m_hpFilCutSweepModel.value()*0.0003f;
 		// reset vibrato
 		vib_phase=0.0f;
-		vib_speed=pow(s->m_vibSpeedModel.value(), 2.0f)*0.01f;
+		vib_speed = std::pow(s->m_vibSpeedModel.value(), 2.f) * 0.01f;
 		vib_amp=s->m_vibDepthModel.value()*0.5f;
 		// reset envelope
 		env_vol=0.0f;
@@ -134,9 +134,9 @@ void SfxrSynth::resetSample( bool restart )
 		env_length[1]=(int)(s->m_holdModel.value()*s->m_holdModel.value()*99999.0f)+1;
 		env_length[2]=(int)(s->m_decModel.value()*s->m_decModel.value()*99999.0f)+1;
 
-		fphase=pow(s->m_phaserOffsetModel.value(), 2.0f)*1020.0f;
+		fphase = std::pow(s->m_phaserOffsetModel.value(), 2.f) * 1020.f;
 		if(s->m_phaserOffsetModel.value()<0.0f) fphase=-fphase;
-		fdphase=pow(s->m_phaserSweepModel.value(), 2.0f)*1.0f;
+		fdphase = std::pow(s->m_phaserSweepModel.value(), 2.f) * 1.f;
 		if(s->m_phaserSweepModel.value()<0.0f) fdphase=-fdphase;
 		iphase=abs((int)fphase);
 		ipp=0;

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -97,16 +97,16 @@ void SfxrSynth::resetSample( bool restart )
 	fperiod=100.0/(s->m_startFreqModel.value()*s->m_startFreqModel.value()+0.001);
 	period=(int)fperiod;
 	fmaxperiod=100.0/(s->m_minFreqModel.value()*s->m_minFreqModel.value()+0.001);
-	fslide=1.0-pow((double)s->m_slideModel.value(), 3.0)*0.01;
-	fdslide=-pow((double)s->m_dSlideModel.value(), 3.0)*0.000001;
+	fslide = 1.0 - std::pow(static_cast<double>(s->m_slideModel.value()), 3.0) * 0.01;
+	fdslide = -std::pow(static_cast<double>(s->m_dSlideModel.value()), 3.0) * 0.000001;
 	square_duty=0.5f-s->m_sqrDutyModel.value()*0.5f;
 	square_slide=-s->m_sqrSweepModel.value()*0.00005f;
 	if(s->m_changeAmtModel.value()>=0.0f)
-		arp_mod=1.0-pow((double)s->m_changeAmtModel.value(), 2.0)*0.9;
+		{ arp_mod = 1.0 - std::pow(static_cast<double>(s->m_changeAmtModel.value()), 2.0) * 0.9; }
 	else
-		arp_mod=1.0+pow((double)s->m_changeAmtModel.value(), 2.0)*10.0;
+		{ arp_mod= 1.0 + std::pow(static_cast<double>(s->m_changeAmtModel.value()), 2.0) * 10.0; }
 	arp_time=0;
-	arp_limit=(int)(pow(1.0f-s->m_changeSpeedModel.value(), 2.0f)*20000+32);
+	arp_limit = static_cast<int>(std::pow(1.0f - s->m_changeSpeedModel.value(), 2.0f) * 20000 + 32);
 	if(s->m_changeSpeedModel.value()==1.0f)
 		arp_limit=0;
 	if(!restart)
@@ -116,7 +116,7 @@ void SfxrSynth::resetSample( bool restart )
 		fltdp=0.0f;
 		fltw=pow(s->m_lpFilCutModel.value(), 3.0f)*0.1f;
 		fltw_d=1.0f+s->m_lpFilCutSweepModel.value()*0.0001f;
-		fltdmp=5.0f/(1.0f+pow(s->m_lpFilResoModel.value(), 2.0f)*20.0f)*(0.01f+fltw);
+		fltdmp = 5.0f / (1.0f + std::pow(s->m_lpFilResoModel.value(), 2.0f) * 20.0f) * (0.01f + fltw);
 		if(fltdmp>0.8f) fltdmp=0.8f;
 		fltphp=0.0f;
 		flthp=pow(s->m_hpFilCutModel.value(), 2.0f)*0.1f;
@@ -148,10 +148,10 @@ void SfxrSynth::resetSample( bool restart )
 		}
 
 		rep_time=0;
-		rep_limit=(int)(pow(1.0f-s->m_repeatSpeedModel.value(), 2.0f)*20000+32);
+		rep_limit = static_cast<int>(std::pow(1.0f - s->m_repeatSpeedModel.value(), 2.0f) * 20000 + 32);
 		if(s->m_repeatSpeedModel.value()==0.0f)
 			rep_limit=0;
-    }
+	}
 }
 
 
@@ -195,7 +195,7 @@ void SfxrSynth::update( SampleFrame* buffer, const int32_t frameNum )
 		if(vib_amp>0.0f)
 		{
 			vib_phase+=vib_speed;
-			rfperiod=fperiod*(1.0+sin(vib_phase)*vib_amp);
+			rfperiod = fperiod * (1.0 + std::sin(vib_phase) * vib_amp);
 		}
 		period=(int)rfperiod;
 		if(period<8) period=8;
@@ -214,7 +214,7 @@ void SfxrSynth::update( SampleFrame* buffer, const int32_t frameNum )
 		if(env_stage==0)
 			env_vol=(float)env_time/env_length[0];
 		if(env_stage==1)
-			env_vol=1.0f+pow(1.0f-(float)env_time/env_length[1], 1.0f)*2.0f*s->m_susModel.value();
+			{ env_vol = 1.0f + std::pow(1.0f - static_cast<float>(env_time) / env_length[1], 1.0f) * 2.0f * s->m_susModel.value(); }
 		if(env_stage==2)
 			env_vol=1.0f-(float)env_time/env_length[2];
 
@@ -1000,13 +1000,13 @@ void SfxrInstrumentView::randomize()
 {
 	auto s = castModel<SfxrInstrument>();
 
-	s->m_startFreqModel.setValue( pow(frnd(2.0f)-1.0f, 2.0f) );
+	s->m_startFreqModel.setValue(std::pow(frnd(2.0f) - 1.0f, 2.0f));
 	if(rnd(1))
 	{
-		s->m_startFreqModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f)+0.5f );
+		s->m_startFreqModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f) + 0.5f);
 	}
 	s->m_minFreqModel.setValue( 0.0f );
-	s->m_slideModel.setValue( pow(frnd(2.0f)-1.0f, 5.0f) );
+	s->m_slideModel.setValue(std::pow(frnd(2.0f) - 1.0f, 5.0f));
 	if( s->m_startFreqModel.value()>0.7f && s->m_slideModel.value()>0.2f )
 	{
 		s->m_slideModel.setValue( -s->m_slideModel.value() );
@@ -1015,19 +1015,19 @@ void SfxrInstrumentView::randomize()
 	{
 		s->m_slideModel.setValue( -s->m_slideModel.value() );
 	}
-	s->m_dSlideModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
+	s->m_dSlideModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
 
 	s->m_sqrDutyModel.setValue( frnd(2.0f)-1.0f );
-	s->m_sqrSweepModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
+	s->m_sqrSweepModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
 
-	s->m_vibDepthModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
+	s->m_vibDepthModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
 	s->m_vibSpeedModel.setValue( frnd(2.0f)-1.0f );
 	//s->m_vibDelayModel.setValue( frnd(2.0f)-1.0f );
 
-	s->m_attModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
-	s->m_holdModel.setValue( pow(frnd(2.0f)-1.0f, 2.0f) );
+	s->m_attModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
+	s->m_holdModel.setValue(std::pow(frnd(2.0f) - 1.0f, 2.0f));
 	s->m_decModel.setValue( frnd(2.0f)-1.0f );
-	s->m_susModel.setValue( pow(frnd(0.8f), 2.0f) );
+	s->m_susModel.setValue(std::pow(frnd(0.8f), 2.0f));
 	if(s->m_attModel.value()+s->m_holdModel.value()+s->m_decModel.value()<0.2f)
 	{
 		s->m_holdModel.setValue( s->m_holdModel.value()+0.2f+frnd(0.3f) );
@@ -1035,17 +1035,17 @@ void SfxrInstrumentView::randomize()
 	}
 
 	s->m_lpFilResoModel.setValue( frnd(2.0f)-1.0f );
-	s->m_lpFilCutModel.setValue( 1.0f-pow(frnd(1.0f), 3.0f) );
-	s->m_lpFilCutSweepModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
+	s->m_lpFilCutModel.setValue(1.0f - std::pow(frnd(1.0f), 3.0f));
+	s->m_lpFilCutSweepModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
 	if(s->m_lpFilCutModel.value()<0.1f && s->m_lpFilCutSweepModel.value()<-0.05f)
 	{
 		s->m_lpFilCutSweepModel.setValue( -s->m_lpFilCutSweepModel.value() );
 	}
-	s->m_hpFilCutModel.setValue( pow(frnd(1.0f), 5.0f) );
-	s->m_hpFilCutSweepModel.setValue( pow(frnd(2.0f)-1.0f, 5.0f) );
+	s->m_hpFilCutModel.setValue(std::pow(frnd(1.0f), 5.0f));
+	s->m_hpFilCutSweepModel.setValue(std::pow(frnd(2.0f) - 1.0f, 5.0f));
 
-	s->m_phaserOffsetModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
-	s->m_phaserSweepModel.setValue( pow(frnd(2.0f)-1.0f, 3.0f) );
+	s->m_phaserOffsetModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
+	s->m_phaserSweepModel.setValue(std::pow(frnd(2.0f) - 1.0f, 3.0f));
 
 	s->m_repeatSpeedModel.setValue( frnd(2.0f)-1.0f );
 

--- a/plugins/Sfxr/Sfxr.cpp
+++ b/plugins/Sfxr/Sfxr.cpp
@@ -97,18 +97,19 @@ void SfxrSynth::resetSample( bool restart )
 	fperiod=100.0/(s->m_startFreqModel.value()*s->m_startFreqModel.value()+0.001);
 	period=(int)fperiod;
 	fmaxperiod=100.0/(s->m_minFreqModel.value()*s->m_minFreqModel.value()+0.001);
-	fslide = 1.0 - std::pow(static_cast<double>(s->m_slideModel.value()), 3.0) * 0.01;
-	fdslide = -std::pow(static_cast<double>(s->m_dSlideModel.value()), 3.0) * 0.000001;
+	const auto sv = static_cast<double>(s->m_slideModel.value());
+	const auto dsv = static_cast<double>(s->m_dSlideModel.value());
+	fslide = 1.0 - sv * sv * sv * 0.01;
+	fdslide = -dsv * dsv * dsv * 0.000001;
 	square_duty=0.5f-s->m_sqrDutyModel.value()*0.5f;
 	square_slide=-s->m_sqrSweepModel.value()*0.00005f;
-	if(s->m_changeAmtModel.value()>=0.0f)
-		{ arp_mod = 1.0 - std::pow(static_cast<double>(s->m_changeAmtModel.value()), 2.0) * 0.9; }
-	else
-		{ arp_mod= 1.0 + std::pow(static_cast<double>(s->m_changeAmtModel.value()), 2.0) * 10.0; }
-	arp_time=0;
-	arp_limit = static_cast<int>(std::pow(1.0f - s->m_changeSpeedModel.value(), 2.0f) * 20000 + 32);
-	if(s->m_changeSpeedModel.value()==1.0f)
-		arp_limit=0;
+	const auto cha = static_cast<double>(s->m_changeAmtModel.value());
+	arp_mod = (cha >= 0.0)
+		? 1.0 - cha * cha * 00.9
+		: 1.0 + cha * cha * 10.0;
+	arp_time = 0;
+	const auto chs = 1.f - s->m_changeSpeedModel.value();
+	arp_limit = (chs == 0.f) ? 0 : static_cast<int>(chs * chs * 20000 + 32);
 	if(!restart)
 	{
 		// reset filter

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -337,7 +337,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 		base = i*7;
 		// freq ( Fn = Fout / Fclk * 16777216 ) + coarse detuning
 		freq = _n->frequency();
-		note = 69.0 + 12.0 * std::log(freq / 440.0) / std::log(2.f);
+		note = 69.0 + 12.0 * std::log2(freq / 440.0);
 		note += m_voice[i]->m_coarseModel.value();
 		freq = 440.0 * std::exp2((note - 69.0) / 12.0);
 		data16 = int( freq / float(clockrate) * 16777216.0 );

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -337,9 +337,9 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 		base = i*7;
 		// freq ( Fn = Fout / Fclk * 16777216 ) + coarse detuning
 		freq = _n->frequency();
-		note = 69.0 + 12.0 * log( freq / 440.0 ) / log( 2 );
+		note = 69.0 + 12.0 * std::log(freq / 440.0) / std::log(2.f);
 		note += m_voice[i]->m_coarseModel.value();
-		freq = 440.0 * pow( 2.0, (note-69.0)/12.0 );
+		freq = 440.0 * std::pow(2.0, (note - 69.0) / 12.0);
 		data16 = int( freq / float(clockrate) * 16777216.0 );
 
 		sidreg[base+0] = data16&0x00FF;

--- a/plugins/Sid/SidInstrument.cpp
+++ b/plugins/Sid/SidInstrument.cpp
@@ -339,7 +339,7 @@ void SidInstrument::playNote( NotePlayHandle * _n,
 		freq = _n->frequency();
 		note = 69.0 + 12.0 * std::log(freq / 440.0) / std::log(2.f);
 		note += m_voice[i]->m_coarseModel.value();
-		freq = 440.0 * std::pow(2.0, (note - 69.0) / 12.0);
+		freq = 440.0 * std::exp2((note - 69.0) / 12.0);
 		data16 = int( freq / float(clockrate) * 16777216.0 );
 
 		sidreg[base+0] = data16&0x00FF;

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -331,15 +331,15 @@ QRgb SaProcessor::makePixel(float left, float right) const
 	const float gamma_correction = m_controls->m_waterfallGammaModel.value();
 	if (m_controls->m_stereoModel.value())
 	{
-		float ampL = pow(left, gamma_correction);
-		float ampR = pow(right, gamma_correction);
+		float ampL = std::pow(left, gamma_correction);
+		float ampR = std::pow(right, gamma_correction);
 		return qRgb(m_controls->m_colorL.red() * ampL + m_controls->m_colorR.red() * ampR,
 					m_controls->m_colorL.green() * ampL + m_controls->m_colorR.green() * ampR,
 					m_controls->m_colorL.blue() * ampL + m_controls->m_colorR.blue() * ampR);
 	}
 	else
 	{
-		float ampL = pow(left, gamma_correction);
+		float ampL = std::pow(left, gamma_correction);
 		// make mono color brighter to compensate for the fact it is not summed
 		return qRgb(m_controls->m_colorMonoW.red() * ampL,
 					m_controls->m_colorMonoW.green() * ampL,
@@ -576,9 +576,9 @@ float SaProcessor::freqToXPixel(float freq, unsigned int width) const
 	if (m_controls->m_logXModel.value())
 	{
 		if (freq <= 1) {return 0;}
-		float min = log10(getFreqRangeMin());
-		float range = log10(getFreqRangeMax()) - min;
-		return (log10(freq) - min) / range * width;
+		float min = std::log10(getFreqRangeMin());
+		float range = std::log10(getFreqRangeMax()) - min;
+		return (std::log10(freq) - min) / range * width;
 	}
 	else
 	{
@@ -594,10 +594,10 @@ float SaProcessor::xPixelToFreq(float x, unsigned int width) const
 {
 	if (m_controls->m_logXModel.value())
 	{
-		float min = log10(getFreqRangeMin());
-		float max = log10(getFreqRangeMax());
+		float min = std::log10(getFreqRangeMin());
+		float max = std::log10(getFreqRangeMax());
 		float range = max - min;
-		return pow(10, min + x / width * range);
+		return std::pow(10, min + x / width * range);
 	}
 	else
 	{
@@ -662,8 +662,8 @@ float SaProcessor::ampToYPixel(float amplitude, unsigned int height) const
 	else
 	{
 		// linear scale: convert returned ranges from dB to linear scale
-		float max = pow(10, getAmpRangeMax() / 10);
-		float range = pow(10, getAmpRangeMin() / 10) - max;
+		float max = std::pow(10, getAmpRangeMax() / 10);
+		float range = std::pow(10, getAmpRangeMin() / 10) - max;
 		return (amplitude - max) / range * height;
 	}
 }
@@ -683,8 +683,8 @@ float SaProcessor::yPixelToAmp(float y, unsigned int height) const
 	else
 	{
 		// linear scale: convert returned ranges from dB to linear scale
-		float max = pow(10, getAmpRangeMax() / 10);
-		float range = pow(10, getAmpRangeMin() / 10) - max;
+		float max = std::pow(10, getAmpRangeMax() / 10);
+		float range = std::pow(10, getAmpRangeMin() / 10) - max;
 		return max + range * (y / height);
 	}
 }

--- a/plugins/SpectrumAnalyzer/SaProcessor.cpp
+++ b/plugins/SpectrumAnalyzer/SaProcessor.cpp
@@ -26,6 +26,7 @@
 #include "SaProcessor.h"
 
 #include <algorithm>
+#include "lmms_math.h"
 #ifdef SA_DEBUG
 	#include <chrono>
 #endif
@@ -597,7 +598,7 @@ float SaProcessor::xPixelToFreq(float x, unsigned int width) const
 		float min = std::log10(getFreqRangeMin());
 		float max = std::log10(getFreqRangeMax());
 		float range = max - min;
-		return std::pow(10, min + x / width * range);
+		return fastPow10f(min + x / width * range);
 	}
 	else
 	{
@@ -662,8 +663,8 @@ float SaProcessor::ampToYPixel(float amplitude, unsigned int height) const
 	else
 	{
 		// linear scale: convert returned ranges from dB to linear scale
-		float max = std::pow(10, getAmpRangeMax() / 10);
-		float range = std::pow(10, getAmpRangeMin() / 10) - max;
+		float max = fastPow10f(getAmpRangeMax() / 10);
+		float range = fastPow10f(getAmpRangeMin() / 10) - max;
 		return (amplitude - max) / range * height;
 	}
 }
@@ -683,8 +684,8 @@ float SaProcessor::yPixelToAmp(float y, unsigned int height) const
 	else
 	{
 		// linear scale: convert returned ranges from dB to linear scale
-		float max = std::pow(10, getAmpRangeMax() / 10);
-		float range = std::pow(10, getAmpRangeMin() / 10) - max;
+		float max = fastPow10f(getAmpRangeMax() / 10);
+		float range = fastPow10f(getAmpRangeMin() / 10) - max;
 		return max + range * (y / height);
 	}
 }

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -38,6 +38,7 @@
 #include "MainWindow.h"
 #include "SaControls.h"
 #include "SaProcessor.h"
+#include "lmms_math.h"
 
 #ifdef SA_DEBUG
 	#include <chrono>
@@ -729,11 +730,11 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLogAmpTics(int lo
 	// to the sizeHint() (denser scale for bigger window).
 	if ((high - low) < 20 * ((float)height() / sizeHint().height()))
 	{
-		increment = std::pow(10, 0.3);	// 3 dB steps when really zoomed in
+		increment = fastPow10f(0.3); // 3 dB steps when really zoomed in
 	}
 	else if (high - low < 45 * ((float)height() / sizeHint().height()))
 	{
-		increment = std::pow(10, 0.6);	// 6 dB steps when sufficiently zoomed in
+		increment = fastPow10f(0.6); // 6 dB steps when sufficiently zoomed in
 	}
 	else
 	{
@@ -766,8 +767,8 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLinearAmpTics(int
 	float split = (float)height() / sizeHint().height() >= 1.5 ? 10.0 : 5.0;
 
 	// convert limits to linear scale
-	float lin_low = std::pow(10, low / 10.0);
-	float lin_high = std::pow(10, high / 10.0);
+	float lin_low = fastPow10f(low / 10.0);
+	float lin_high = fastPow10f(high / 10.0);
 
 	// Linear scale will vary widely, so instead of trying to craft extra nice
 	// multiples, just generate a few evenly spaced increments across the range,

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -668,7 +668,7 @@ std::vector<std::pair<int, std::string>> SaSpectrumView::makeLogFreqTics(int low
 				}
 			}
 			// also insert denser series if high and low values are close
-			if ((log10(high) - log10(low) < 2) && (i * b[j] >= low && i * b[j] <= high))
+			if ((std::log10(high) - std::log10(low) < 2) && (i * b[j] >= low && i * b[j] <= high))
 			{
 				if (i * b[j] < 1500)
 				{
@@ -729,11 +729,11 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLogAmpTics(int lo
 	// to the sizeHint() (denser scale for bigger window).
 	if ((high - low) < 20 * ((float)height() / sizeHint().height()))
 	{
-		increment = pow(10, 0.3);	// 3 dB steps when really zoomed in
+		increment = std::pow(10, 0.3);	// 3 dB steps when really zoomed in
 	}
 	else if (high - low < 45 * ((float)height() / sizeHint().height()))
 	{
-		increment = pow(10, 0.6);	// 6 dB steps when sufficiently zoomed in
+		increment = std::pow(10, 0.6);	// 6 dB steps when sufficiently zoomed in
 	}
 	else
 	{
@@ -742,11 +742,11 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLogAmpTics(int lo
 
 	// Generate n dB increments, start checking at -90 dB. Limits are tweaked
 	// just a little bit to make sure float comparisons do not miss edges.
-	for (float i = 0.000000001f; 10 * log10(i) <= (high + 0.001); i *= increment)
+	for (float i = 0.000000001f; 10 * std::log10(i) <= (high + 0.001); i *= increment)
 	{
-		if (10 * log10(i) >= (low - 0.001))
+		if (10 * std::log10(i) >= (low - 0.001))
 		{
-			result.emplace_back(i, std::to_string((int)std::round(10 * log10(i))));
+			result.emplace_back(i, std::to_string((int)std::round(10 * std::log10(i))));
 		}
 	}
 	return result;
@@ -766,8 +766,8 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLinearAmpTics(int
 	float split = (float)height() / sizeHint().height() >= 1.5 ? 10.0 : 5.0;
 
 	// convert limits to linear scale
-	float lin_low = pow(10, low / 10.0);
-	float lin_high = pow(10, high / 10.0);
+	float lin_low = std::pow(10, low / 10.0);
+	float lin_high = std::pow(10, high / 10.0);
 
 	// Linear scale will vary widely, so instead of trying to craft extra nice
 	// multiples, just generate a few evenly spaced increments across the range,

--- a/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
+++ b/plugins/SpectrumAnalyzer/SaSpectrumView.cpp
@@ -730,11 +730,11 @@ std::vector<std::pair<float, std::string>> SaSpectrumView::makeLogAmpTics(int lo
 	// to the sizeHint() (denser scale for bigger window).
 	if ((high - low) < 20 * ((float)height() / sizeHint().height()))
 	{
-		increment = fastPow10f(0.3); // 3 dB steps when really zoomed in
+		increment = fastPow10f(0.3f); // 3 dB steps when really zoomed in
 	}
 	else if (high - low < 45 * ((float)height() / sizeHint().height()))
 	{
-		increment = fastPow10f(0.6); // 6 dB steps when sufficiently zoomed in
+		increment = fastPow10f(0.6f); // 6 dB steps when sufficiently zoomed in
 	}
 	else
 	{

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -175,7 +175,7 @@ void OscillatorObject::updateVolume()
 
 void OscillatorObject::updateDetuningLeft()
 {
-	m_detuningLeft = std::pow(2.0f, (m_coarseModel.value() * 100.0f + m_fineLeftModel.value()) / 1200.0f)
+	m_detuningLeft = std::exp2((m_coarseModel.value() * 100.0f + m_fineLeftModel.value()) / 1200.0f)
 		/ Engine::audioEngine()->outputSampleRate();
 }
 
@@ -184,7 +184,7 @@ void OscillatorObject::updateDetuningLeft()
 
 void OscillatorObject::updateDetuningRight()
 {
-	m_detuningRight = std::pow(2.0f, (m_coarseModel.value() * 100.0f + m_fineRightModel.value()) / 1200.0f)
+	m_detuningRight = std::exp2((m_coarseModel.value() * 100.0f + m_fineRightModel.value()) / 1200.0f)
 		/ Engine::audioEngine()->outputSampleRate();
 }
 

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -175,9 +175,8 @@ void OscillatorObject::updateVolume()
 
 void OscillatorObject::updateDetuningLeft()
 {
-	m_detuningLeft = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
-				+ (float)m_fineLeftModel.value() ) / 1200.0f )
-				/ Engine::audioEngine()->outputSampleRate();
+	m_detuningLeft = std::pow(2.0f, (m_coarseModel.value() * 100.0f + m_fineLeftModel.value()) / 1200.0f)
+		/ Engine::audioEngine()->outputSampleRate();
 }
 
 
@@ -185,9 +184,8 @@ void OscillatorObject::updateDetuningLeft()
 
 void OscillatorObject::updateDetuningRight()
 {
-	m_detuningRight = powf( 2.0f, ( (float)m_coarseModel.value() * 100.0f
-				+ (float)m_fineRightModel.value() ) / 1200.0f )
-				/ Engine::audioEngine()->outputSampleRate();
+	m_detuningRight = std::pow(2.0f, (m_coarseModel.value() * 100.0f + m_fineRightModel.value()) / 1200.0f)
+		/ Engine::audioEngine()->outputSampleRate();
 }
 
 

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -596,32 +596,32 @@ void WatsynInstrument::updateVolumes()
 void WatsynInstrument::updateFreqA1()
 {
 	// calculate frequencies
-	m_lfreq[A1_OSC] = (a1_mult.value() / 8) * std::pow(2, a1_ltune.value() / 1200);
-	m_rfreq[A1_OSC] = (a1_mult.value() / 8) * std::pow(2, a1_rtune.value() / 1200);
+	m_lfreq[A1_OSC] = (a1_mult.value() / 8) * std::exp2(a1_ltune.value() / 1200);
+	m_rfreq[A1_OSC] = (a1_mult.value() / 8) * std::exp2(a1_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqA2()
 {
 	// calculate frequencies
-	m_lfreq[A2_OSC] = (a2_mult.value() / 8) * std::pow(2, a2_ltune.value() / 1200);
-	m_rfreq[A2_OSC] = (a2_mult.value() / 8) * std::pow(2, a2_rtune.value() / 1200);
+	m_lfreq[A2_OSC] = (a2_mult.value() / 8) * std::exp2(a2_ltune.value() / 1200);
+	m_rfreq[A2_OSC] = (a2_mult.value() / 8) * std::exp2(a2_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqB1()
 {
 	// calculate frequencies
-	m_lfreq[B1_OSC] = (b1_mult.value() / 8) * std::pow(2, b1_ltune.value() / 1200);
-	m_rfreq[B1_OSC] = (b1_mult.value() / 8) * std::pow(2, b1_rtune.value() / 1200);
+	m_lfreq[B1_OSC] = (b1_mult.value() / 8) * std::exp2(b1_ltune.value() / 1200);
+	m_rfreq[B1_OSC] = (b1_mult.value() / 8) * std::exp2(b1_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqB2()
 {
 	// calculate frequencies
-	m_lfreq[B2_OSC] = (b2_mult.value() / 8) * std::pow(2, b2_ltune.value() / 1200);
-	m_rfreq[B2_OSC] = (b2_mult.value() / 8) * std::pow(2, b2_rtune.value() / 1200);	
+	m_lfreq[B2_OSC] = (b2_mult.value() / 8) * std::exp2(b2_ltune.value() / 1200);
+	m_rfreq[B2_OSC] = (b2_mult.value() / 8) * std::exp2(b2_rtune.value() / 1200);	
 }
 
 

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -132,9 +132,9 @@ void WatsynObject::renderOutput( fpp_t _frames )
 		// if phase mod, add to phases
 		if( m_amod == MOD_PM )
 		{
-			A1_lphase = fmodf( A1_lphase + A2_L * PMOD_AMT, WAVELEN );
+			A1_lphase = std::fmod(A1_lphase + A2_L * PMOD_AMT, WAVELEN);
 			if( A1_lphase < 0 ) A1_lphase += WAVELEN;
-			A1_rphase = fmodf( A1_rphase + A2_R * PMOD_AMT, WAVELEN );
+			A1_rphase = std::fmod(A1_rphase + A2_R * PMOD_AMT, WAVELEN);
 			if( A1_rphase < 0 ) A1_rphase += WAVELEN;
 		}
 		// A1
@@ -166,9 +166,9 @@ void WatsynObject::renderOutput( fpp_t _frames )
 		// if phase mod, add to phases
 		if( m_bmod == MOD_PM )
 		{
-			B1_lphase = fmodf( B1_lphase + B2_L * PMOD_AMT, WAVELEN );
+			B1_lphase = std::fmod(B1_lphase + B2_L * PMOD_AMT, WAVELEN);
 			if( B1_lphase < 0 ) B1_lphase += WAVELEN;
-			B1_rphase = fmodf( B1_rphase + B2_R * PMOD_AMT, WAVELEN );
+			B1_rphase = std::fmod(B1_rphase + B2_R * PMOD_AMT, WAVELEN);
 			if( B1_rphase < 0 ) B1_rphase += WAVELEN;
 		}
 		// B1
@@ -222,9 +222,9 @@ void WatsynObject::renderOutput( fpp_t _frames )
 		for( int i = 0; i < NUM_OSCS; i++ )
 		{
 			m_lphase[i] += ( static_cast<float>( WAVELEN ) / ( m_samplerate / ( m_nph->frequency() * m_parent->m_lfreq[i] ) ) );
-			m_lphase[i] = fmodf( m_lphase[i], WAVELEN );
+			m_lphase[i] = std::fmod(m_lphase[i], WAVELEN);
 			m_rphase[i] += ( static_cast<float>( WAVELEN ) / ( m_samplerate / ( m_nph->frequency() * m_parent->m_rfreq[i] ) ) );
-			m_rphase[i] = fmodf( m_rphase[i], WAVELEN );
+			m_rphase[i] = std::fmod(m_rphase[i], WAVELEN);
 		}
 	}
 
@@ -596,32 +596,32 @@ void WatsynInstrument::updateVolumes()
 void WatsynInstrument::updateFreqA1()
 {
 	// calculate frequencies
-	m_lfreq[A1_OSC] = ( a1_mult.value() / 8 ) * powf( 2, a1_ltune.value() / 1200 );
-	m_rfreq[A1_OSC] = ( a1_mult.value() / 8 ) * powf( 2, a1_rtune.value() / 1200 );
+	m_lfreq[A1_OSC] = (a1_mult.value() / 8) * std::pow(2, a1_ltune.value() / 1200);
+	m_rfreq[A1_OSC] = (a1_mult.value() / 8) * std::pow(2, a1_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqA2()
 {
 	// calculate frequencies
-	m_lfreq[A2_OSC] = ( a2_mult.value() / 8 ) * powf( 2, a2_ltune.value() / 1200 );
-	m_rfreq[A2_OSC] = ( a2_mult.value() / 8 ) * powf( 2, a2_rtune.value() / 1200 );
+	m_lfreq[A2_OSC] = (a2_mult.value() / 8) * std::pow(2, a2_ltune.value() / 1200);
+	m_rfreq[A2_OSC] = (a2_mult.value() / 8) * std::pow(2, a2_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqB1()
 {
 	// calculate frequencies
-	m_lfreq[B1_OSC] = ( b1_mult.value() / 8 ) * powf( 2, b1_ltune.value() / 1200 );
-	m_rfreq[B1_OSC] = ( b1_mult.value() / 8 ) * powf( 2, b1_rtune.value() / 1200 );
+	m_lfreq[B1_OSC] = (b1_mult.value() / 8) * std::pow(2, b1_ltune.value() / 1200);
+	m_rfreq[B1_OSC] = (b1_mult.value() / 8) * std::pow(2, b1_rtune.value() / 1200);
 }
 
 
 void WatsynInstrument::updateFreqB2()
 {
 	// calculate frequencies
-	m_lfreq[B2_OSC] = ( b2_mult.value() / 8 ) * powf( 2, b2_ltune.value() / 1200 );
-	m_rfreq[B2_OSC] = ( b2_mult.value() / 8 ) * powf( 2, b2_rtune.value() / 1200 );	
+	m_lfreq[B2_OSC] = (b2_mult.value() / 8) * std::pow(2, b2_ltune.value() / 1200);
+	m_rfreq[B2_OSC] = (b2_mult.value() / 8) * std::pow(2, b2_rtune.value() / 1200);	
 }
 
 

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -511,7 +511,7 @@ struct harmonic_cent
 {
 	static inline float process(float x)
 	{
-		return std::pow(2, x / 1200);
+		return std::exp2(x / 1200);
 	}
 };
 static freefunc1<float,harmonic_cent,true> harmonic_cent_func;
@@ -519,7 +519,7 @@ struct harmonic_semitone
 {
 	static inline float process(float x)
 	{
-		return std::pow(2, x / 12);
+		return std::exp2(x / 12);
 	}
 };
 static freefunc1<float,harmonic_semitone,true> harmonic_semitone_func;

--- a/plugins/Xpressive/ExprSynth.cpp
+++ b/plugins/Xpressive/ExprSynth.cpp
@@ -511,7 +511,7 @@ struct harmonic_cent
 {
 	static inline float process(float x)
 	{
-		return powf(2, x / 1200);
+		return std::pow(2, x / 1200);
 	}
 };
 static freefunc1<float,harmonic_cent,true> harmonic_cent_func;
@@ -519,7 +519,7 @@ struct harmonic_semitone
 {
 	static inline float process(float x)
 	{
-		return powf(2, x / 12);
+		return std::pow(2, x / 12);
 	}
 };
 static freefunc1<float,harmonic_semitone,true> harmonic_semitone_func;

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -647,8 +647,8 @@ float AutomationClip::valueAt( timeMap::const_iterator v, int offset ) const
 		float m1 = OUTTAN(v) * numValues * m_tension;
 		float m2 = INTAN(v + 1) * numValues * m_tension;
 
-		auto t2 = std::pow(t, 2);
-		auto t3 = std::pow(t, 3);
+		auto t2 = t * t;
+		auto t3 = t * t * t;
 		return (2 * t3 - 3 * t2 + 1) * OUTVAL(v)
 			+ (t3 - 2 * t2 + t) * m1
 			+ (-2 * t3 + 3 * t2) * INVAL(v + 1)

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -647,8 +647,7 @@ float AutomationClip::valueAt( timeMap::const_iterator v, int offset ) const
 		float m1 = OUTTAN(v) * numValues * m_tension;
 		float m2 = INTAN(v + 1) * numValues * m_tension;
 
-		auto t2 = t * t;
-		auto t3 = t * t * t;
+		auto t2 = t * t, t3 = t2 * t;
 		return (2 * t3 - 3 * t2 + 1) * OUTVAL(v)
 			+ (t3 - 2 * t2 + t) * m1
 			+ (-2 * t3 + 3 * t2) * INVAL(v + 1)

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -647,8 +647,8 @@ float AutomationClip::valueAt( timeMap::const_iterator v, int offset ) const
 		float m1 = OUTTAN(v) * numValues * m_tension;
 		float m2 = INTAN(v + 1) * numValues * m_tension;
 
-		auto t2 = pow(t, 2);
-		auto t3 = pow(t, 3);
+		auto t2 = std::pow(t, 2);
+		auto t3 = std::pow(t, 3);
 		return (2 * t3 - 3 * t2 + 1) * OUTVAL(v)
 			+ (t3 - 2 * t2 + t) * m1
 			+ (-2 * t3 + 3 * t2) * INVAL(v + 1)

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -174,7 +174,7 @@ float DrumSynth::waveform(float ph, int form)
 	// sine
 	if (form == 0) { return std::sin(ph); }
 	// sine^2
-	if (form == 1) { return 2.f * std::abs(std::sin(0.5f * ph)) - 1.f; }
+	if (form == 1) { return std::abs(2.f * std::sin(0.5f * ph)) - 1.f; }
 	// sawtooth with range [0, 1], used to generate triangle, sawtooth, and square
 	auto ph_tau = ph * numbers::inv_tau_v<float>;
 	auto saw01 = ph_tau - std::floor(ph_tau);

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -28,6 +28,7 @@
 #include <QFile>
 #include <cmath>
 #include <cstring>
+#include <numbers>
 #include <sstream>
 
 #include "lmms_math.h"
@@ -182,11 +183,11 @@ float DrumSynth::waveform(float ph, int form)
 		w = std::abs(2.f * std::sin(.5f * p)) - 1.f;
 		break;
 	case 2: // triangle
-		w = p * 0.6366197f;
+		w = p * 0.6366197f; // [TODO] C++20: Replace magic number with 2 * std::numbers::inv_pi_v<float>
 		if (w > 1.f) { w = 2.f - w; }
 		break;
 	case 3: // sawtooth
-		w = p * 0.3183098f - 1.f;
+		w = p * 0.3183098f - 1.f; // [TODO] C++20: Replace magic number with std::numbers::inv_pi_v<float>
 		break;
 	default: // square
 		w = (p < numbers::pi_v<float>) ? 1.f : -1.f;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -171,34 +171,26 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 
 float DrumSynth::waveform(float ph, int form)
 {
-	float w;
+	float w, p = ediv(ph, numbers::tau_v<float>);
 
 	switch (form)
 	{
-	case 0:
-		w = std::sin(std::fmod(ph, numbers::tau_v<float>));
-		break; // sine
-	case 1:
-		w = std::abs(2.0f * std::sin(std::fmod(0.5f * ph, numbers::tau_v<float>)) - 1.f);
-		break; // sine^2
-	case 2:
-		while (ph < numbers::tau_v<float>)
-		{
-			ph += numbers::tau_v<float>;
-		}
-		w = 0.6366197f * (std::fmod(ph, numbers::tau_v<float>) - 1.f); // tri
-		if (w > 1.f)
-		{
-			w = 2.f - w;
-		}
+	case 0: // sine
+		w = std::sin(p);
 		break;
-	case 3:
-		w = ph - numbers::tau_v<float> * static_cast<float>(static_cast<int>(ph / numbers::tau_v<float>)); // saw
-		w = (0.3183098f * w) - 1.f;
+	case 1: // sine^2
+		w = std::abs(2.f * std::sin(.5f * p)) - 1.f;
 		break;
-	default:
-		w = (std::sin(std::fmod(ph, numbers::tau_v<float>)) > 0.0) ? 1.f : -1.f;
-		break; // square
+	case 2: // triangle
+		w = p * 0.6366197f;
+		if (w > 1.f) { w = 2.f - w; }
+		break;
+	case 3: // sawtooth
+		w = p * 0.3183098f - 1.f;
+		break;
+	default: // square
+		w = (p < numbers::pi_v<float>) ? 1.f : -1.f;
+		break;
 	}
 
 	return w;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -174,13 +174,12 @@ float DrumSynth::waveform(float ph, int form)
 	// sine
 	if (form == 0) { return std::sin(ph); }
 	// sine^2
-	if (form == 1) { return 2.f * std::abs(std::sin(.5 * ph)) - 1.f; }
-	// (ph / τ), used for triangle, sawtooth, and square
+	if (form == 1) { return 2.f * std::abs(std::sin(0.5f * ph)) - 1.f; }
+	// sawtooth with range [0, 1], used to generate triangle, sawtooth, and square
 	auto ph_tau = ph * numbers::inv_tau_v<float>;
-	// triangle
-	if (form == 2) { return 4.f * std::abs(ph_tau - std::floor(ph_tau + 0.5f)) - 1.f; }
-	// sawtooth with range [0, 1], used for both sawtooth and square
 	auto saw01 = ph_tau - std::floor(ph_tau);
+	// triangle
+	if (form == 2) { return 1.f - 4.f * std::abs(saw01 - 0.5f); }
 	// sawtooth
 	if (form == 3) { return 2.f * saw01 - 1.f; }
 	// square

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -28,7 +28,6 @@
 #include <QFile>
 #include <cmath>
 #include <cstring>
-#include <numbers>
 #include <sstream>
 
 #include "lmms_math.h"
@@ -183,11 +182,11 @@ float DrumSynth::waveform(float ph, int form)
 		w = std::abs(2.f * std::sin(.5f * p)) - 1.f;
 		break;
 	case 2: // triangle
-		w = p * 0.6366197f; // [TODO] C++20: Replace magic number with 2 * std::numbers::inv_pi_v<float>
+		w = p * 2.f * numbers::inv_pi_v<float>;
 		if (w > 1.f) { w = 2.f - w; }
 		break;
 	case 3: // sawtooth
-		w = p * 0.3183098f - 1.f; // [TODO] C++20: Replace magic number with std::numbers::inv_pi_v<float>
+		w = p * numbers::inv_pi_v<float> - 1.f;
 		break;
 	default: // square
 		w = (p < numbers::pi_v<float>) ? 1.f : -1.f;

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -42,7 +42,6 @@ namespace lmms {
 using namespace std;
 
 // const int     Fs    =  44100;
-const float TwoPi = 6.2831853f;
 const int MAX = 0;
 const int ENV = 1;
 const int PNT = 2;
@@ -177,28 +176,28 @@ float DrumSynth::waveform(float ph, int form)
 	switch (form)
 	{
 	case 0:
-		w = static_cast<float>(sin(fmod(ph, TwoPi)));
+		w = std::sin(std::fmod(ph, numbers::tau_v<float>));
 		break; // sine
 	case 1:
-		w = static_cast<float>(fabs(2.0f * static_cast<float>(sin(fmod(0.5f * ph, TwoPi))) - 1.f));
+		w = std::abs(2.0f * std::sin(std::fmod(0.5f * ph, numbers::tau_v<float>)) - 1.f);
 		break; // sine^2
 	case 2:
-		while (ph < TwoPi)
+		while (ph < numbers::tau_v<float>)
 		{
-			ph += TwoPi;
+			ph += numbers::tau_v<float>;
 		}
-		w = 0.6366197f * static_cast<float>(fmod(ph, TwoPi) - 1.f); // tri
+		w = 0.6366197f * (std::fmod(ph, numbers::tau_v<float>) - 1.f); // tri
 		if (w > 1.f)
 		{
 			w = 2.f - w;
 		}
 		break;
 	case 3:
-		w = ph - TwoPi * static_cast<float>(static_cast<int>(ph / TwoPi)); // saw
+		w = ph - numbers::tau_v<float> * static_cast<float>(static_cast<int>(ph / numbers::tau_v<float>)); // saw
 		w = (0.3183098f * w) - 1.f;
 		break;
 	default:
-		w = (sin(fmod(ph, TwoPi)) > 0.0) ? 1.f : -1.f;
+		w = (std::sin(std::fmod(ph, numbers::tau_v<float>)) > 0.0) ? 1.f : -1.f;
 		break; // square
 	}
 
@@ -434,7 +433,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	{
 		a = 1.f;
 		b = -NT / 50.f;
-		c = static_cast<float>(fabs(static_cast<float>(NT))) / 100.f;
+		c = std::abs(static_cast<float>(NT)) / 100.f;
 		g = NL;
 	}
 
@@ -448,19 +447,19 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	sliLev[0] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
 	TL = static_cast<float>(sliLev[0] * sliLev[0]) * mem_t;
 	GetEnv(1, sec, "Envelope", dsfile);
-	F1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-	if (fabs(F1) < 0.001f)
+	F1 = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	if (std::abs(F1) < 0.001f)
 	{
 		F1 = 0.001f; // to prevent overtone ratio div0
 	}
-	F2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	F2 = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
 	TDroopRate = GetPrivateProfileFloat(sec, "Droop", 0.f, dsfile);
 	if (TDroopRate > 0.f)
 	{
 		TDroopRate = fastPow10f((TDroopRate - 20.0f) / 30.0f);
 		TDroopRate = TDroopRate * -4.f / envData[1][MAX];
 		TDroop = 1;
-		F2 = F1 + ((F2 - F1) / (1.f - static_cast<float>(exp(TDroopRate * envData[1][MAX]))));
+		F2 = F1 + ((F2 - F1) / (1.f - std::exp(TDroopRate * envData[1][MAX])));
 		ddF = F1 - F2;
 	}
 	else
@@ -479,8 +478,8 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	GetEnv(3, sec, "Envelope1", dsfile);
 	GetEnv(4, sec, "Envelope2", dsfile);
 	OMode = GetPrivateProfileInt(sec, "Method", 2, dsfile);
-	OF1 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
-	OF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
+	OF1 = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F1", 200.0, dsfile) / Fs;
+	OF2 = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F2", 120.0, dsfile) / Fs;
 	OW1 = GetPrivateProfileInt(sec, "Wave1", 0, dsfile);
 	OW2 = GetPrivateProfileInt(sec, "Wave2", 0, dsfile);
 	OBal2 = static_cast<float>(GetPrivateProfileInt(sec, "Param", 50, dsfile));
@@ -508,8 +507,8 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	OcQ = OcA * OcA;
 	OcF = (1.8f - 0.7f * OcQ) * 0.92f; // multiply by env 2
 	OcA *= 1.0f + 4.0f * OBal1;		   // level is a compromise!
-	Ocf1 = TwoPi / OF1;
-	Ocf2 = TwoPi / OF2;
+	Ocf1 = numbers::tau_v<float> / OF1;
+	Ocf2 = numbers::tau_v<float> / OF2;
 	for (i = 0; i < 6; i++)
 	{
 		Oc[i][0] = Oc[i][1] = Ocf1 + (Ocf2 - Ocf1) * 0.2f * static_cast<float>(i);
@@ -521,12 +520,12 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	BON = chkOn[3];
 	sliLev[3] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
 	BL = static_cast<float>(sliLev[3] * sliLev[3]) * mem_b;
-	BF = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-	BPhi = TwoPi / 8.f;
+	BF = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi = numbers::tau_v<float> / 8.f;
 	GetEnv(5, sec, "Envelope", dsfile);
 	BFStep = GetPrivateProfileInt(sec, "dF", 50, dsfile);
 	BQ = static_cast<float>(BFStep);
-	BQ = BQ * BQ / (10000.f - 6600.f * (static_cast<float>(sqrt(BF)) - 0.19f));
+	BQ = BQ * BQ / (10000.f - 6600.f * (std::sqrt(BF) - 0.19f));
 	BFStep = 1 + static_cast<int>((40.f - (BFStep / 2.5f)) / (BQ + 1.f + (1.f * BF)));
 
 	strcpy(sec, "NoiseBand2");
@@ -534,12 +533,12 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 	BON2 = chkOn[4];
 	sliLev[4] = GetPrivateProfileInt(sec, "Level", 128, dsfile);
 	BL2 = static_cast<float>(sliLev[4] * sliLev[4]) * mem_b;
-	BF2 = MasterTune * TwoPi * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
-	BPhi2 = TwoPi / 8.f;
+	BF2 = MasterTune * numbers::tau_v<float> * GetPrivateProfileFloat(sec, "F", 1000.0, dsfile) / Fs;
+	BPhi2 = numbers::tau_v<float> / 8.f;
 	GetEnv(6, sec, "Envelope", dsfile);
 	BFStep2 = GetPrivateProfileInt(sec, "dF", 50, dsfile);
 	BQ2 = static_cast<float>(BFStep2);
-	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f * (static_cast<float>(sqrt(BF2)) - 0.19f));
+	BQ2 = BQ2 * BQ2 / (10000.f - 6600.f * (std::sqrt(BF2) - 0.19f));
 	BFStep2 = 1 + static_cast<int>((40 - (BFStep2 / 2.5)) / (BQ2 + 1 + (1 * BF2)));
 
 	// read distortion parameters
@@ -659,7 +658,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 			{
 				for (t = tpos; t <= tplus; t++)
 				{
-					phi[t - tpos] = F2 + (ddF * static_cast<float>(exp(t * TDroopRate)));
+					phi[t - tpos] = F2 + (ddF * std::exp(t * TDroopRate));
 				}
 			}
 			else
@@ -681,7 +680,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 					UpdateEnv(1, t);
 				}
 				Tphi = Tphi + phi[totmp];
-				DF[totmp] += TL * envData[1][ENV] * static_cast<float>(sin(fmod(Tphi, TwoPi))); // overflow?
+				DF[totmp] += TL * envData[1][ENV] * std::sin(std::fmod(Tphi, numbers::tau_v<float>)); // overflow?
 			}
 			if (t >= envData[1][MAX])
 			{
@@ -714,7 +713,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 				}
 				BPhi = BPhi + BF + BQ * BdF;
 				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi, TwoPi))) * envData[5][ENV] * BL;
+				DF[botmp] = DF[botmp] + std::cos(std::fmod(BPhi, numbers::tau_v<float>)) * envData[5][ENV] * BL;
 			}
 			if (t >= envData[5][MAX])
 			{
@@ -740,7 +739,7 @@ int DrumSynth::GetDSFileSamples(QString dsfile, int16_t*& wave, int channels, sa
 				}
 				BPhi2 = BPhi2 + BF2 + BQ2 * BdF2;
 				botmp = t - tpos;
-				DF[botmp] = DF[botmp] + static_cast<float>(cos(fmod(BPhi2, TwoPi))) * envData[6][ENV] * BL2;
+				DF[botmp] = DF[botmp] + std::cos(std::fmod(BPhi2, numbers::tau_v<float>)) * envData[6][ENV] * BL2;
 			}
 			if (t >= envData[6][MAX])
 			{

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -176,7 +176,7 @@ float DrumSynth::waveform(float ph, int form)
 	// sine^2
 	if (form == 1) { return std::abs(2.f * std::sin(0.5f * ph)) - 1.f; }
 	// sawtooth with range [0, 1], used to generate triangle, sawtooth, and square
-	auto ph_tau = ph * numbers::inv_tau_v<float>;
+	auto ph_tau = ph / numbers::tau_v<float>;
 	auto saw01 = ph_tau - std::floor(ph_tau);
 	// triangle
 	if (form == 2) { return 1.f - 4.f * std::abs(saw01 - 0.5f); }

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -171,29 +171,20 @@ void DrumSynth::GetEnv(int env, const char* sec, const char* key, QString ini)
 
 float DrumSynth::waveform(float ph, int form)
 {
-	float w, p = ediv(ph, numbers::tau_v<float>);
-
-	switch (form)
-	{
-	case 0: // sine
-		w = std::sin(p);
-		break;
-	case 1: // sine^2
-		w = std::abs(2.f * std::sin(.5f * p)) - 1.f;
-		break;
-	case 2: // triangle
-		w = p * 2.f * numbers::inv_pi_v<float>;
-		if (w > 1.f) { w = 2.f - w; }
-		break;
-	case 3: // sawtooth
-		w = p * numbers::inv_pi_v<float> - 1.f;
-		break;
-	default: // square
-		w = (p < numbers::pi_v<float>) ? 1.f : -1.f;
-		break;
-	}
-
-	return w;
+	// sine
+	if (form == 0) { return std::sin(ph); }
+	// sine^2
+	if (form == 1) { return 2.f * std::abs(std::sin(.5 * ph)) - 1.f; }
+	// (ph / τ), used for triangle, sawtooth, and square
+	auto ph_tau = ph * numbers::inv_tau_v<float>;
+	// triangle
+	if (form == 2) { return 4.f * std::abs(ph_tau - std::floor(ph_tau + 0.5f)) - 1.f; }
+	// sawtooth with range [0, 1], used for both sawtooth and square
+	auto saw01 = ph_tau - std::floor(ph_tau);
+	// sawtooth
+	if (form == 3) { return 2.f * saw01 - 1.f; }
+	// square
+	return (saw01 < 0.5f) ? 1.f : -1.f;
 }
 
 int DrumSynth::GetPrivateProfileString(

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -436,8 +436,8 @@ float LadspaManager::getDefaultSetting( const ladspa_key_t & _plugin,
 				if( LADSPA_IS_HINT_LOGARITHMIC
 							( hintDescriptor ) )
 				{
-					return( exp( log( portRangeHint->LowerBound ) * 0.75 +
-								 log( portRangeHint->UpperBound ) * 0.25 ) );
+					return std::exp(std::log(portRangeHint->LowerBound)
+						* 0.75 + std::log(portRangeHint->UpperBound) * 0.25);
 				}
 				else 
 				{
@@ -448,8 +448,7 @@ float LadspaManager::getDefaultSetting( const ladspa_key_t & _plugin,
 				if( LADSPA_IS_HINT_LOGARITHMIC
 						( hintDescriptor ) ) 
 				{
-					return( sqrt( portRangeHint->LowerBound
-								  * portRangeHint->UpperBound ) );
+					return std::sqrt(portRangeHint->LowerBound * portRangeHint->UpperBound);
 				}
 				else 
 				{
@@ -460,8 +459,8 @@ float LadspaManager::getDefaultSetting( const ladspa_key_t & _plugin,
 				if( LADSPA_IS_HINT_LOGARITHMIC
 						( hintDescriptor ) ) 
 				{
-					return( exp( log( portRangeHint->LowerBound ) * 0.25 +
-								 log( portRangeHint->UpperBound ) * 0.75 ) );
+					return std::exp(std::log(portRangeHint->LowerBound)
+						* 0.25 + std::log(portRangeHint->UpperBound) * 0.75);
 				}
 				else 
 				{

--- a/src/core/Microtuner.cpp
+++ b/src/core/Microtuner.cpp
@@ -102,10 +102,10 @@ float Microtuner::keyToFreq(int key, int userBaseNote) const
 
 	// Compute frequency of the middle note and return the final frequency
 	const double octaveRatio = intervals[octaveDegree].getRatio();
-	const float middleFreq = (keymap->getBaseFreq() / pow(octaveRatio, (baseScaleOctave + baseKeymapOctave)))
-								/ intervals[baseScaleDegree].getRatio();
+	const float middleFreq = (keymap->getBaseFreq() / std::pow(octaveRatio, baseScaleOctave + baseKeymapOctave))
+		/ intervals[baseScaleDegree].getRatio();
 
-	return middleFreq * intervals[scaleDegree].getRatio() * pow(octaveRatio, keymapOctave + scaleOctave);
+	return middleFreq * intervals[scaleDegree].getRatio() * std::pow(octaveRatio, keymapOctave + scaleOctave);
 }
 
 int Microtuner::octaveSize() const

--- a/src/core/MixHelpers.cpp
+++ b/src/core/MixHelpers.cpp
@@ -71,7 +71,7 @@ bool isSilent( const SampleFrame* src, int frames )
 
 	for( int i = 0; i < frames; ++i )
 	{
-		if( fabsf( src[i][0] ) >= silenceThreshold || fabsf( src[i][1] ) >= silenceThreshold )
+		if (std::abs(src[i][0]) >= silenceThreshold || std::abs(src[i][1]) >= silenceThreshold)
 		{
 			return false;
 		}

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -532,8 +532,8 @@ void NotePlayHandle::updateFrequency()
 		if (m_instrumentTrack->isKeyMapped(transposedKey))
 		{
 			const auto frequency = m_instrumentTrack->m_microtuner.keyToFreq(transposedKey, baseNote);
-			m_frequency = frequency * powf(2.f, (detune + instrumentPitch / 100) / 12.f);
-			m_unpitchedFrequency = frequency * powf(2.f, detune / 12.f);
+			m_frequency = frequency * std::pow(2.f, (detune + instrumentPitch / 100) / 12.f);
+			m_unpitchedFrequency = frequency * std::pow(2.f, detune / 12.f);
 		}
 		else
 		{
@@ -544,8 +544,8 @@ void NotePlayHandle::updateFrequency()
 	{
 		// default key mapping and 12-TET frequency computation with default 440 Hz base note frequency
 		const float pitch = (key() - baseNote + masterPitch + detune) / 12.0f;
-		m_frequency = DefaultBaseFreq * powf(2.0f, pitch + instrumentPitch / (100 * 12.0f));
-		m_unpitchedFrequency = DefaultBaseFreq * powf(2.0f, pitch);
+		m_frequency = DefaultBaseFreq * std::pow(2.0f, pitch + instrumentPitch / (100 * 12.0f));
+		m_unpitchedFrequency = DefaultBaseFreq * std::pow(2.0f, pitch);
 	}
 
 	for (auto it : m_subNotes)

--- a/src/core/NotePlayHandle.cpp
+++ b/src/core/NotePlayHandle.cpp
@@ -532,8 +532,8 @@ void NotePlayHandle::updateFrequency()
 		if (m_instrumentTrack->isKeyMapped(transposedKey))
 		{
 			const auto frequency = m_instrumentTrack->m_microtuner.keyToFreq(transposedKey, baseNote);
-			m_frequency = frequency * std::pow(2.f, (detune + instrumentPitch / 100) / 12.f);
-			m_unpitchedFrequency = frequency * std::pow(2.f, detune / 12.f);
+			m_frequency = frequency * std::exp2((detune + instrumentPitch / 100) / 12.f);
+			m_unpitchedFrequency = frequency * std::exp2(detune / 12.f);
 		}
 		else
 		{
@@ -544,8 +544,8 @@ void NotePlayHandle::updateFrequency()
 	{
 		// default key mapping and 12-TET frequency computation with default 440 Hz base note frequency
 		const float pitch = (key() - baseNote + masterPitch + detune) / 12.0f;
-		m_frequency = DefaultBaseFreq * std::pow(2.0f, pitch + instrumentPitch / (100 * 12.0f));
-		m_unpitchedFrequency = DefaultBaseFreq * std::pow(2.0f, pitch);
+		m_frequency = DefaultBaseFreq * std::exp2(pitch + instrumentPitch / (100 * 12.0f));
+		m_unpitchedFrequency = DefaultBaseFreq * std::exp2(pitch);
 	}
 
 	for (auto it : m_subNotes)

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -142,8 +142,8 @@ void Oscillator::generateTriangleWaveTable(int bands, sample_t* table, int first
 	{
 		for (int n = firstBand | 1; n <= bands; n += 2)
 		{
-			table[i] += (n & 2 ? -1.0f : 1.0f) / powf(n, 2.0f) *
-				std::sin(numbers::tau_v<float> * n * i / (float)OscillatorConstants::WAVETABLE_LENGTH) / (numbers::pi_sqr_v<float> / 8);
+			table[i] += (n & 2 ? -1.0f : 1.0f) / (n * n) *
+				std::sin(numbers::tau_v<float> * n * i / (float)OscillatorConstants::WAVETABLE_LENGTH) / (numbers::pi_sqr_v<float> / 8.0f);
 		}
 	}
 }

--- a/src/core/Scale.cpp
+++ b/src/core/Scale.cpp
@@ -36,7 +36,7 @@ Interval::Interval(float cents) :
 	m_denominator(0),
 	m_cents(cents)
 {
-	m_ratio = std::pow(2.f, m_cents / 1200.f);
+	m_ratio = std::exp2(m_cents / 1200.f);
 }
 
 Interval::Interval(uint32_t numerator, uint32_t denominator) :
@@ -68,7 +68,7 @@ void Interval::loadSettings(const QDomElement &element)
 	m_denominator = element.attribute("den", "0").toULong();
 	m_cents = element.attribute("cents", "0").toDouble();
 	if (m_denominator) {m_ratio = static_cast<float>(m_numerator) / m_denominator;}
-	else { m_ratio = std::pow(2.f, m_cents / 1200.f); }
+	else { m_ratio = std::exp2(m_cents / 1200.f); }
 }
 
 

--- a/src/core/Scale.cpp
+++ b/src/core/Scale.cpp
@@ -36,7 +36,7 @@ Interval::Interval(float cents) :
 	m_denominator(0),
 	m_cents(cents)
 {
-	m_ratio = powf(2.f, m_cents / 1200.f);
+	m_ratio = std::pow(2.f, m_cents / 1200.f);
 }
 
 Interval::Interval(uint32_t numerator, uint32_t denominator) :
@@ -68,7 +68,7 @@ void Interval::loadSettings(const QDomElement &element)
 	m_denominator = element.attribute("den", "0").toULong();
 	m_cents = element.attribute("cents", "0").toDouble();
 	if (m_denominator) {m_ratio = static_cast<float>(m_numerator) / m_denominator;}
-	else {m_ratio = powf(2.f, m_cents / 1200.f);}
+	else { m_ratio = std::pow(2.f, m_cents / 1200.f); }
 }
 
 

--- a/src/core/audio/AudioSoundIo.cpp
+++ b/src/core/audio/AudioSoundIo.cpp
@@ -152,7 +152,7 @@ AudioSoundIo::AudioSoundIo( bool & outSuccessful, AudioEngine * _audioEngine ) :
 			break;
 		}
 		if (closestSupportedSampleRate == -1 ||
-			abs(range->max - currentSampleRate) < abs(closestSupportedSampleRate - currentSampleRate))
+			std::abs(range->max - currentSampleRate) < std::abs(closestSupportedSampleRate - currentSampleRate))
 		{
 			closestSupportedSampleRate = range->max;
 		}

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -591,7 +591,7 @@ void Lv2Proc::createPort(std::size_t portNum)
 
 						// make multiples of 0.01 (or 0.1 for larger values)
 						float minStep = (stepSize >= 1.0f) ? 0.1f : 0.01f;
-						stepSize -= fmodf(stepSize, minStep);
+						stepSize -= std::fmod(stepSize, minStep);
 						stepSize = std::max(stepSize, minStep);
 
 						ctrl->m_connectedModel.reset(

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -253,7 +253,7 @@ QFont GuiApplication::getWin32SystemFont()
 	{
 		// height is in pixels, convert to points
 		HDC hDC = GetDC( nullptr );
-		pointSize = MulDiv( abs( pointSize ), 72, GetDeviceCaps( hDC, LOGPIXELSY ) );
+		pointSize = MulDiv(std::abs(pointSize), 72, GetDeviceCaps(hDC, LOGPIXELSY));
 		ReleaseDC( nullptr, hDC );
 	}
 

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -1414,7 +1414,7 @@ TimePos ClipView::draggedClipPos( QMouseEvent * me )
 		endQ = endQ - m_clip->length();
 
 		// Select the position closest to actual position
-		if ( abs(newPos - startQ) < abs(newPos - endQ) ) newPos = startQ;
+		if (std::abs(newPos - startQ) < std::abs(newPos - endQ)) { newPos = startQ; }
 		else newPos = endQ;
 	}
 	else
@@ -1457,7 +1457,7 @@ TimePos ClipView::quantizeSplitPos( TimePos midiPos, bool shiftMode )
 		const TimePos rightOff = m_clip->length() - midiPos;
 		const TimePos rightPos = m_clip->length() - rightOff.quantize( snapSize );
 		//...whichever gives a position closer to the cursor
-		if ( abs(leftPos - midiPos) < abs(rightPos - midiPos) ) { return leftPos; }
+		if (std::abs(leftPos - midiPos) < std::abs(rightPos - midiPos)) { return leftPos; }
 		else { return rightPos; }
 	}
 	else

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1623,7 +1623,7 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
+	else if(std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		adjustLeftRightScoll(we->angleDelta().x());
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1623,7 +1623,7 @@ void AutomationEditor::wheelEvent(QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if(std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
+	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		adjustLeftRightScoll(we->angleDelta().x());
 	}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2813,7 +2813,7 @@ void PianoRoll::dragNotes(int x, int y, bool alt, bool shift, bool ctrl)
 			TimePos mousePosQ = mousePos.quantize(static_cast<float>(quantization()) / DefaultTicksPerBar);
 			TimePos mousePosEndQ = mousePosEnd.quantize(static_cast<float>(quantization()) / DefaultTicksPerBar);
 
-			bool snapEnd = abs(mousePosEndQ - mousePosEnd) < abs(mousePosQ - mousePos);
+			bool snapEnd = std::abs(mousePosEndQ - mousePosEnd) < std::abs(mousePosQ - mousePos);
 
 			// Set the offset
 			noteOffset = snapEnd
@@ -3878,7 +3878,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	}
 
 	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if(abs(we->angleDelta().x()) > abs(we->angleDelta().y())) // scrolling is horizontal
+	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
 	{
 		adjustLeftRightScoll(we->angleDelta().x());
 	}

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -777,12 +777,12 @@ IntModel* PianoView::getNearestMarker(int key, QString* title)
 	const int first = m_piano->instrumentTrack()->firstKey();
 	const int last = m_piano->instrumentTrack()->lastKey();
 
-	if (abs(key - base) < abs(key - first) && abs(key - base) < abs(key - last))
+	if (std::abs(key - base) < std::abs(key - first) && std::abs(key - base) < std::abs(key - last))
 	{
 		if (title) {*title = tr("Base note");}
 		return m_piano->instrumentTrack()->baseNoteModel();
 	}
-	else if (abs(key - first) < abs(key - last))
+	else if (std::abs(key - first) < std::abs(key - last))
 	{
 		if (title) {*title = tr("First note");}
 		return m_piano->instrumentTrack()->firstKeyModel();

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -735,7 +735,7 @@ void graphModel::clearInvisible()
 void graphModel::drawSampleAt( int x, float val )
 {
 	//snap to the grid
-	val -= ( m_step != 0.0 ) ? fmod( val, m_step ) * m_step : 0;
+	val -= (m_step != 0.0) ? std::fmod(val, m_step) * m_step : 0;
 
 	// boundary crop
 	x = qMax( 0, qMin( length()-1, x ) );

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -313,8 +313,8 @@ void Knob::setTextColor( const QColor & c )
 QLineF Knob::calculateLine( const QPointF & _mid, float _radius, float _innerRadius ) const
 {
 	const float rarc = m_angle * numbers::pi_v<float> / 180.0;
-	const float ca = cos( rarc );
-	const float sa = -sin( rarc );
+	const float ca = std::cos(rarc);
+	const float sa = -std::sin(rarc);
 
 	return QLineF( _mid.x() - sa*_innerRadius, _mid.y() - ca*_innerRadius,
 					_mid.x() - sa*_radius, _mid.y() - ca*_radius );

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -43,6 +43,7 @@
 #include "GuiApplication.h"
 #include "FontHelper.h"
 #include "MainWindow.h"
+#include "lmms_math.h"
 
 namespace lmms::gui
 {
@@ -109,7 +110,7 @@ void LcdFloatSpinBox::layoutSetup(const QString &style)
 
 void LcdFloatSpinBox::update()
 {
-	const int digitValue = std::pow(10.f, m_fractionDisplay.numDigits());
+	const int digitValue = fastPow10f(m_fractionDisplay.numDigits());
 	float value = model()->value();
 	int fraction = std::abs(std::round((value - static_cast<int>(value)) * digitValue));
 	if (fraction == digitValue)


### PR DESCRIPTION
This updates usages of `sin()`, `cos()`, `tan()`, `pow()`, `exp()`, `log()`, `log10()`, `sqrt()`, `fmod()`, `fabs()`, and `fabsf()`, excluding any usages that look like they might be part of a submodule or 3rd-party code. There's probably some math functions not listed above that haven't been updated yet. 

I haven't touched any of the following items. If these *should* be updated, I can do that:
- `plugins/CarlaBase/*`
- `plugins/LadspaEffect/*`
- `plugins/ZynAddSubFx/*`
- `src/3rdparty/*`
- Any file matching `*test*`

Also fixes regressions in the `float DrumSynth::waveform(float ph, int form)` implementation (specifically the sine^2, triangle, and saw generators) which were introduced in #7143.

> [!NOTE]
>  Updating these function usages was brought up in #7558, somewhat related, probably not important.