### PR TITLE
Allow plugins to be skipped at runtime

### DIFF
--- a/cmake/linux/apprun-hooks/carla-hook.sh
+++ b/cmake/linux/apprun-hooks/carla-hook.sh
@@ -23,7 +23,8 @@ if command -v carla > /dev/null 2>&1; then
 		fi
 	done
 else
-	echo "[$ME] Carla does not appear to be installed.  That's OK, please ignore any related library errors." >&2
+	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing.." >&2
+	export "LMMS_EXCLUDE_PLUGINS=*carla*,${LMMS_EXCLUDE_PLUGINS}"
 fi
 
 # Additional workarounds for library conflicts

--- a/cmake/linux/apprun-hooks/carla-hook.sh
+++ b/cmake/linux/apprun-hooks/carla-hook.sh
@@ -24,7 +24,7 @@ if command -v carla > /dev/null 2>&1; then
 	done
 else
 	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing." >&2
-	export "LMMS_EXCLUDE_PLUGINS=*carla*,${LMMS_EXCLUDE_PLUGINS}"
+	export "LMMS_EXCLUDE_PLUGINS=libcarla,${LMMS_EXCLUDE_PLUGINS}"
 fi
 
 # Additional workarounds for library conflicts

--- a/cmake/linux/apprun-hooks/carla-hook.sh
+++ b/cmake/linux/apprun-hooks/carla-hook.sh
@@ -23,7 +23,7 @@ if command -v carla > /dev/null 2>&1; then
 		fi
 	done
 else
-	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing.." >&2
+	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing." >&2
 	export "LMMS_EXCLUDE_PLUGINS=*carla*,${LMMS_EXCLUDE_PLUGINS}"
 fi
 

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -104,6 +104,8 @@ private:
 	QHash<QString, QString> m_errors;
 
 	static std::unique_ptr<PluginFactory> s_instance;
+
+	static QList<QRegularExpression> filterPlugins(QSet<QFileInfo>& files);
 };
 
 //Short-hand function

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -105,7 +105,7 @@ private:
 
 	static std::unique_ptr<PluginFactory> s_instance;
 
-	static QList<QRegularExpression> filterPlugins(QSet<QFileInfo>& files);
+	static void filterPlugins(QSet<QFileInfo>& files);
 };
 
 //Short-hand function

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -250,7 +250,7 @@ void PluginFactory::discoverPlugins()
 }
 
 // Filter plugins based on environment variable, e.g. export LMMS_EXCLUDE_PLUGINS="*carla*"
-QSet<QFileInfo> filterPlugins(QSet<QFileInfo>& files) {
+void PluginFactory::filterPlugins(QSet<QFileInfo>& files) {
 	// Get filter
 	QList<QRegularExpression> excludedPatterns;
 	QString excludePatternString = std::getenv("LMMS_EXCLUDE_PLUGINS");

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -28,6 +28,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QLibrary>
+#include <QRegularExpression>
 #include <memory>
 #include "lmmsconfig.h"
 
@@ -157,6 +158,9 @@ void PluginFactory::discoverPlugins()
 #endif
 	}
 
+	// Apply any plugin filters from environment LMMS_EXCLUDE_PLUGINS
+	filterPlugins(files);
+
 	// Cheap dependency handling: zynaddsubfx needs ZynAddSubFxCore. By loading
 	// all libraries twice we ensure that libZynAddSubFxCore is found.
 	for (const QFileInfo& file : files)
@@ -245,7 +249,47 @@ void PluginFactory::discoverPlugins()
 	m_descriptors = descriptors;
 }
 
+// Filter plugins based on environment variable, e.g. export LMMS_EXCLUDE_PLUGINS="*carla*"
+QSet<QFileInfo> filterPlugins(QSet<QFileInfo>& files) {
+	// Get filter
+	QList<QRegularExpression> excludedPatterns;
+	QString excludePatternString = std::getenv("LMMS_EXCLUDE_PLUGINS");
 
+	if (!excludePatternString.isEmpty()) {
+		QStringList patterns = excludePatternString.split(',');
+		for (const QString& pattern : patterns) {
+			QRegularExpression regex(pattern.trimmed());
+			if (!pattern.trimmed().isEmpty() && regex.isValid()) {
+				excludedPatterns << regex;
+			} else {
+				qWarning() << "Invalid regular expression:" << pattern;
+			}
+		}
+	}
+
+  	// Get files to remove
+	QSet<QFileInfo> filesToRemove;
+	for (const QFileInfo& fileInfo : files) {
+		bool excluded = false;
+		QString filePath = fileInfo.filePath();
+
+		for (const QRegularExpression& pattern : excludedPatterns) {
+			if (pattern.match(filePath).hasMatch()) {
+				excluded = true;
+				break;
+			}
+		}
+
+		if (excluded) {
+			filesToRemove.insert(fileInfo);
+		}
+	}
+
+	// Remove them
+	for (const QFileInfo& fileInfo : filesToRemove) {
+		files.remove(fileInfo);
+	}
+}
 
 QString PluginFactory::PluginInfo::name() const
 {

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -249,7 +249,7 @@ void PluginFactory::discoverPlugins()
 	m_descriptors = descriptors;
 }
 
-// Filter plugins based on environment variable, e.g. export LMMS_EXCLUDE_PLUGINS="*carla*"
+// Filter plugins based on environment variable, e.g. export LMMS_EXCLUDE_PLUGINS="libcarla"
 void PluginFactory::filterPlugins(QSet<QFileInfo>& files) {
 	// Get filter
 	QList<QRegularExpression> excludedPatterns;


### PR DESCRIPTION
When LMMS starts up on a Linux system without Carla installed, the log shows warnings:


BEFORE:
```
[carla-hook.sh] Carla does not appear to be installed.  That's OK, please ignore any related library errors.
Cannot load library /home/owner/Downloads/squashfs-root/usr/lib/libcarlabase.so: (libcarla_native-plugin.so: cannot open shared object file: No such file or directory)
Cannot load library /home/owner/Downloads/squashfs-root/usr/lib/libcarlarack.so: (libcarla_native-plugin.so: cannot open shared object file: No such file or directory)
Cannot load library /home/owner/Downloads/squashfs-root/usr/lib/libcarlapatchbay.so: (libcarla_native-plugin.so: cannot open shared object file: No such file or directory)
```

... however, as can be observed by the logs, we already detected this problem, so we should have a way of informing LMMS to not load plugin at startup.

This PR adds a plugin filter called `LMMS_EXCLUDE_PLUGINS` that can be set as an environment variable to suppress this by skipping the loading of the a plugin based on name or wildcard (`QRegexExpression`).

AFTER:
```
[carla-hook.sh] Carla does not appear to be installed, we'll remove it from the plugin listing.
```

