### PR TITLE
Remove libgallium from the appimage

### DIFF
--- a/cmake/linux/LinuxDeploy.cmake
+++ b/cmake/linux/LinuxDeploy.cmake
@@ -160,7 +160,7 @@ foreach(_lib IN LISTS LIBS)
 	endif()
 endforeach()
 
-list(APPEND SKIP_LIBRARIES "--exclude-library=libgallium*")
+list(APPEND SKIP_LIBRARIES "--exclude-library=*libgallium*")
 
 # Call linuxdeploy
 message(STATUS "Calling ${LINUXDEPLOY_BIN} --appdir \"${APP}\" ... [... libraries].")

--- a/cmake/linux/LinuxDeploy.cmake
+++ b/cmake/linux/LinuxDeploy.cmake
@@ -268,6 +268,9 @@ if(relocated_jack)
 	endif()
 endif()
 
+# cleanup empty directories
+file(REMOVE_RECURSE "${APP}/usr/lib/${lmms}/optional/")
+
 if(CPACK_TOOL STREQUAL "appimagetool")
 	# Create ".AppImage" file using appimagetool (default)
 

--- a/cmake/linux/LinuxDeploy.cmake
+++ b/cmake/linux/LinuxDeploy.cmake
@@ -169,6 +169,7 @@ execute_process(COMMAND "${LINUXDEPLOY_BIN}"
 	--desktop-file "${DESKTOP_FILE}"
 	--plugin qt
 	${LIBRARIES}
+	${SKIP_LIBRARIES}
 	--verbosity ${VERBOSITY}
 	${OUTPUT_QUIET}
 	COMMAND_ECHO ${COMMAND_ECHO}

--- a/cmake/linux/LinuxDeploy.cmake
+++ b/cmake/linux/LinuxDeploy.cmake
@@ -160,6 +160,8 @@ foreach(_lib IN LISTS LIBS)
 	endif()
 endforeach()
 
+list(APPEND SKIP_LIBRARIES "--exclude-library=libgallium*")
+
 # Call linuxdeploy
 message(STATUS "Calling ${LINUXDEPLOY_BIN} --appdir \"${APP}\" ... [... libraries].")
 execute_process(COMMAND "${LINUXDEPLOY_BIN}"


### PR DESCRIPTION
When testing #7690 I noticed that only on the aarch64 version of openSUSE Tumbleweed the following error occured:

```
Cannot load library /home/owner/Downloads/squashfs-root/usr/lib/libgallium-24.2.8-1ubuntu1~24.04.1.so: (libxcb-dri2.so.0: cannot open shared object file: No such file or directory)
```

I assume that this is a transient dependency caused by Ubuntu 24.04 that `linuxdeploy` just hasn't filtered for yet.  What's even stranger is that I can't reproduce on my own Ubuntu 24.04 aarch machine.

Regardless, based on the `ubuntu` branding (and after carefully confirming that **every file we ship** doesn't link against it) I've decided to remove it.  If this causes problems down the road, you can blame this PR.


