### PR TITLE
[Follow up] Improve performance when rendering sample waveforms

### DIFF
--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -67,6 +67,7 @@ private:
 	SampleClip * m_clip;
 	SampleThumbnail m_sampleThumbnail;
 	QPixmap m_paintPixmap;
+	long m_paintPixmapXPosition;
 	bool splitClip( const TimePos pos ) override;
 } ;
 

--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -103,6 +103,7 @@ private:
 
 		Thumbnail zoomOut(float factor) const;
 
+		Peak* data() { return m_peaks.data(); }
 		Peak& operator[](size_t index) { return m_peaks[index]; }
 		const Peak& operator[](size_t index) const { return m_peaks[index]; }
 

--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -132,7 +132,7 @@ private:
 
 	using ThumbnailCache = std::vector<Thumbnail>;
 	std::shared_ptr<ThumbnailCache> m_thumbnailCache = std::make_shared<ThumbnailCache>();
-
+	std::shared_ptr<const SampleBuffer> m_buffer = SampleBuffer::emptyBuffer();
 	inline static std::unordered_map<SampleThumbnailEntry, std::shared_ptr<ThumbnailCache>, Hash> s_sampleThumbnailCacheMap;
 };
 

--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -54,10 +54,8 @@ public:
 	{
 		QRect sampleRect; //!< A rectangle that covers the entire range of samples.
 
-		QRect drawRect; //!< Specifies the location in `sampleRect` where the waveform will be drawn. Equals
-						//!< `sampleRect` when null.
-
-		QRect viewportRect; //!< Clips `drawRect`. Equals `drawRect` when null.
+		QRect viewportRect; //!< Specifies the location in `sampleRect` where the waveform will be drawn. Equals
+							//!< `sampleRect` when null.
 
 		float amplification = 1.0f; //!< The amount of amplification to apply to the waveform.
 

--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -93,8 +93,8 @@ private:
 			Peak operator+(const Peak& other) const { return Peak(std::min(min, other.min), std::max(max, other.max)); }
 			Peak operator+(const SampleFrame& frame) const { return *this + Peak{frame}; }
 
-			float min = std::numeric_limits<float>::max();
-			float max = std::numeric_limits<float>::min();
+			float min = std::numeric_limits<float>::infinity();
+			float max = -std::numeric_limits<float>::infinity();
 		};
 
 		Thumbnail() = default;

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -145,8 +145,8 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 		}
 		else
 		{
-			const auto beginIndex = static_cast<size_t>(std::floor(i * finerThumbnailScaleFactor));
-			const auto endIndex = static_cast<size_t>(std::ceil((i + 1) * finerThumbnailScaleFactor));
+			const auto beginIndex = std::clamp<size_t>(std::floor(i * finerThumbnailScaleFactor), 0, finerThumbnail->width() - 1);
+			const auto endIndex = std::clamp<size_t>(std::ceil((i + 1) * finerThumbnailScaleFactor), 0, finerThumbnail->width() - 1);
 
 			auto minPeak = 0.f;
 			auto maxPeak = 0.f;

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -160,8 +160,8 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 			}
 			else
 			{
-				const auto beginAggregationAt = &(*finerThumbnail)[beginIndex];
-				const auto endAggregationAt = &(*finerThumbnail)[endIndex];
+				const auto beginAggregationAt = finerThumbnail->data() + beginIndex;
+				const auto endAggregationAt = finerThumbnail->data() + endIndex;
 				const auto peak = std::accumulate(beginAggregationAt, endAggregationAt, Thumbnail::Peak{});
 				minPeak = peak.min;
 				maxPeak = peak.max;

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -95,7 +95,7 @@ SampleThumbnail::SampleThumbnail(const Sample& sample)
 	if (sample.sampleSize() == 0) { return; }
 
 	const auto fullResolutionWidth = sample.sampleSize() * DEFAULT_CHANNELS;
-	m_thumbnailCache->emplace_back(&sample.buffer()->data()->left(), fullResolutionWidth, fullResolutionWidth);
+	m_thumbnailCache->emplace_back(sample.buffer()->data()->data(), fullResolutionWidth, fullResolutionWidth);
 
 	while (m_thumbnailCache->back().width() >= AggregationPerZoomStep)
 	{

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -141,7 +141,7 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 		{
 			const auto value = m_buffer->data()->data()[i];
 			painter.drawPoint(x, renderRect.center().y() - value * yScale);
-			return;
+			continue;
 		}
 		else
 		{

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -107,14 +107,13 @@ SampleThumbnail::SampleThumbnail(const Sample& sample)
 void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painter) const
 {
 	const auto& sampleRect = parameters.sampleRect;
-	const auto& drawRect = parameters.drawRect.isNull() ? sampleRect : parameters.drawRect;
-	const auto& viewportRect = parameters.viewportRect.isNull() ? drawRect : parameters.viewportRect;
+	const auto& viewportRect = parameters.viewportRect.isNull() ? sampleRect : parameters.viewportRect;
 
-	const auto renderRect = sampleRect.intersected(drawRect).intersected(viewportRect);
+	const auto renderRect = sampleRect.intersected(viewportRect);
 	if (renderRect.isNull()) { return; }
 
 	const auto sampleRange = parameters.sampleEnd - parameters.sampleStart;
-	if (sampleRange <= 0 || sampleRange > 1) { return; }
+	if (sampleRange <= 0.0f || sampleRange > 1.0f) { return; }
 
 	const auto targetThumbnailWidth = static_cast<int>(static_cast<double>(sampleRect.width()) / sampleRange);
 	const auto finerThumbnail = std::find_if(m_thumbnailCache->rbegin(), m_thumbnailCache->rend(),
@@ -136,7 +135,7 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	const auto advanceThumbnailBy = parameters.reversed ? -1 : 1;
 
 	const auto finerThumbnailScaleFactor = static_cast<double>(finerThumbnail->width()) / targetThumbnailWidth;
-	const auto yScale = drawRect.height() / 2 * parameters.amplification;
+	const auto yScale = renderRect.height() / 2 * parameters.amplification;
 
 	for (auto x = renderRect.x(), i = thumbnailBegin; x < renderRect.x() + renderRect.width() && i != thumbnailEnd;
 		 ++x, i += advanceThumbnailBy)
@@ -145,8 +144,8 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 		const auto endAggregationAt = &(*finerThumbnail)[static_cast<int>(std::ceil((i + 1) * finerThumbnailScaleFactor))];
 		const auto peak = std::accumulate(beginAggregationAt, endAggregationAt, Thumbnail::Peak{});
 
-		const auto yMin = drawRect.center().y() - peak.min * yScale;
-		const auto yMax = drawRect.center().y() - peak.max * yScale;
+		const auto yMin = renderRect.center().y() - peak.min * yScale;
+		const auto yMax = renderRect.center().y() - peak.max * yScale;
 
 		painter.drawLine(x, yMin, x, yMax);
 	}

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -135,39 +135,42 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	const auto yScale = renderRect.height() / 2 * parameters.amplification;
 
 	for (auto x = renderRect.x(), i = thumbnailBegin; x < renderRect.x() + renderRect.width() && i != thumbnailEnd;
-		 ++x, i += advanceThumbnailBy)
+		++x, i += advanceThumbnailBy)
 	{
-		const auto beginIndex = static_cast<size_t>(std::floor(i * finerThumbnailScaleFactor));
-		const auto endIndex = static_cast<size_t>(std::ceil((i + 1) * finerThumbnailScaleFactor));
-
-		auto minPeak = 0.f;
-		auto maxPeak = 0.f;
-
 		if (useOriginalBuffer && drawOriginalBuffer)
 		{
 			const auto value = m_buffer->data()->data()[i];
 			painter.drawPoint(x, renderRect.center().y() - value * yScale);
 			return;
 		}
-		else if (useOriginalBuffer)
-		{
-			const auto flatBuffer = m_buffer->data()->data();
-			const auto [min, max] = std::minmax_element(flatBuffer + beginIndex, flatBuffer + endIndex);
-			minPeak = *min;
-			maxPeak = *max;
-		}
 		else
 		{
-			const auto beginAggregationAt = &(*finerThumbnail)[beginIndex];
-			const auto endAggregationAt = &(*finerThumbnail)[endIndex];
-			const auto peak = std::accumulate(beginAggregationAt, endAggregationAt, Thumbnail::Peak{});
-			minPeak = peak.min;
-			maxPeak = peak.max;
-		}
+			const auto beginIndex = static_cast<size_t>(std::floor(i * finerThumbnailScaleFactor));
+			const auto endIndex = static_cast<size_t>(std::ceil((i + 1) * finerThumbnailScaleFactor));
 
-		const auto yMin = renderRect.center().y() - minPeak * yScale;
-		const auto yMax = renderRect.center().y() - maxPeak * yScale;
-		painter.drawLine(x, yMin, x, yMax);
+			auto minPeak = 0.f;
+			auto maxPeak = 0.f;
+
+			if (useOriginalBuffer)
+			{
+				const auto flatBuffer = m_buffer->data()->data();
+				const auto [min, max] = std::minmax_element(flatBuffer + beginIndex, flatBuffer + endIndex);
+				minPeak = *min;
+				maxPeak = *max;
+			}
+			else
+			{
+				const auto beginAggregationAt = &(*finerThumbnail)[beginIndex];
+				const auto endAggregationAt = &(*finerThumbnail)[endIndex];
+				const auto peak = std::accumulate(beginAggregationAt, endAggregationAt, Thumbnail::Peak{});
+				minPeak = peak.min;
+				maxPeak = peak.max;
+			}
+
+			const auto yMin = renderRect.center().y() - minPeak * yScale;
+			const auto yMax = renderRect.center().y() - maxPeak * yScale;
+			painter.drawLine(x, yMin, x, yMax);
+		}
 	}
 
 	painter.restore();

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -115,7 +115,7 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	const auto sampleRange = parameters.sampleEnd - parameters.sampleStart;
 	if (sampleRange <= 0.0f || sampleRange > 1.0f) { return; }
 
-	const auto targetThumbnailWidth = static_cast<int>(static_cast<double>(sampleRect.width()) / sampleRange);
+	const auto targetThumbnailWidth = static_cast<int>(sampleRect.width() / sampleRange);
 	const auto finerThumbnail = std::find_if(m_thumbnailCache->rbegin(), m_thumbnailCache->rend(),
 		[&](const auto& thumbnail) { return thumbnail.width() >= targetThumbnailWidth; });
 
@@ -128,8 +128,8 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	painter.save();
 	painter.setRenderHint(QPainter::Antialiasing, true);
 
-	const auto thumbnailBeginForward = std::max<int>(renderRect.x() - sampleRect.x(), static_cast<int>(parameters.sampleStart * targetThumbnailWidth));
-	const auto thumbnailEndForward = std::max<int>(renderRect.x() + renderRect.width() - sampleRect.x(), static_cast<int>(parameters.sampleEnd * targetThumbnailWidth));
+	const auto thumbnailBeginForward = std::max<int>(renderRect.x() - sampleRect.x(), parameters.sampleStart * targetThumbnailWidth);
+	const auto thumbnailEndForward = std::max<int>(renderRect.x() + renderRect.width() - sampleRect.x(), parameters.sampleEnd * targetThumbnailWidth);
 	const auto thumbnailBegin = parameters.reversed ? targetThumbnailWidth - thumbnailBeginForward - 1 : thumbnailBeginForward;
 	const auto thumbnailEnd = parameters.reversed ? targetThumbnailWidth - thumbnailEndForward : thumbnailEndForward;
 	const auto advanceThumbnailBy = parameters.reversed ? -1 : 1;
@@ -140,8 +140,8 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	for (auto x = renderRect.x(), i = thumbnailBegin; x < renderRect.x() + renderRect.width() && i != thumbnailEnd;
 		 ++x, i += advanceThumbnailBy)
 	{
-		const auto beginAggregationAt = &(*finerThumbnail)[static_cast<int>(std::floor(i * finerThumbnailScaleFactor))];
-		const auto endAggregationAt = &(*finerThumbnail)[static_cast<int>(std::ceil((i + 1) * finerThumbnailScaleFactor))];
+		const auto beginAggregationAt = &(*finerThumbnail)[static_cast<size_t>(std::floor(i * finerThumbnailScaleFactor))];
+		const auto endAggregationAt = &(*finerThumbnail)[static_cast<size_t>(std::ceil((i + 1) * finerThumbnailScaleFactor))];
 		const auto peak = std::accumulate(beginAggregationAt, endAggregationAt, Thumbnail::Peak{});
 
 		const auto yMin = renderRect.center().y() - peak.min * yScale;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -306,6 +306,8 @@ void ClipView::remove()
 	// as actually deleting the Clip with the deleteLater function. That being said, it shouldn't
 	// be possible to make a Clip without a Track (i.e., Clip::getTrack is never nullptr).
 	m_clip->deleteLater();
+
+	m_trackView->update();
 }
 
 

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -37,6 +37,7 @@
 #include "SampleThumbnail.h"
 #include "Song.h"
 #include "StringPairDrag.h"
+#include "TrackView.h"
 
 namespace lmms::gui
 {
@@ -217,10 +218,12 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 
 	setNeedsUpdate( false );
 
-	// Use the clip's height to avoid artifacts when rendering while something else is overlaying the clip.
-	const auto viewPortRect = QRect(0, 0, pe->rect().width(), rect().height());
+	const auto trackViewWidth = getTrackView()->rect().width();
 
-	m_paintPixmapXPosition = pe->rect().x();
+	// Use the clip's height to avoid artifacts when rendering while something else is overlaying the clip.
+	const auto viewPortRect = QRect(0, 0, trackViewWidth * 2, rect().height());
+
+	m_paintPixmapXPosition = std::max(0, pe->rect().x() - trackViewWidth);
 
 	if (m_paintPixmap.isNull() || m_paintPixmap.size() != viewPortRect.size())
 	{

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -311,7 +311,7 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 
 	// outer border
 	p.setPen( c.darker( 200 ) );
-	p.drawRect( -m_paintPixmapXPosition, 0, rect().right(), rect().bottom() );
+	p.drawRect(-m_paintPixmapXPosition, 0, rect().right(), rect().bottom());
 
 	// draw the 'muted' pixmap only if the clip was manualy muted
 	if( m_clip->isMuted() )

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -281,10 +281,12 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 
 	const auto& sample = m_clip->m_sample;
 
+	const auto sampleRextX = static_cast<int>(offsetStart) - m_paintPixmapXPosition;
+
 	if (sample.sampleSize() > 0)
 	{
 		const auto param = SampleThumbnail::VisualizeParameters{
-			.sampleRect = QRect(offsetStart - m_paintPixmapXPosition, spacing, sampleLength, height() - spacing),
+			.sampleRect = QRect(sampleRextX, spacing, sampleLength, height() - spacing),
 			.viewportRect = viewPortRect,
 			.amplification = sample.amplification(),
 			.reversed = sample.reversed()
@@ -301,12 +303,15 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 
 	// inner border
 	p.setPen( c.lighter( 135 ) );
-	p.drawRect( 1, 1, rect().right() - BORDER_WIDTH,
+	p.drawRect(
+		-m_paintPixmapXPosition + 1,
+		1,
+		rect().right() - BORDER_WIDTH,
 		rect().bottom() - BORDER_WIDTH );
 
 	// outer border
 	p.setPen( c.darker( 200 ) );
-	p.drawRect( 0, 0, rect().right(), rect().bottom() );
+	p.drawRect( -m_paintPixmapXPosition, 0, rect().right(), rect().bottom() );
 
 	// draw the 'muted' pixmap only if the clip was manualy muted
 	if( m_clip->isMuted() )

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1219,7 +1219,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 			const auto param = SampleThumbnail::VisualizeParameters{
 				.sampleRect = QRect(startPos, yOffset, sampleWidth, sampleHeight),
-				.viewportRect = pe->rect(),
+				.viewportRect = rect(),
 				.amplification = sample.amplification(),
 				.sampleStart = static_cast<float>(sample.startFrame()) / sample.sampleSize(),
 				.sampleEnd = static_cast<float>(sample.endFrame()) / sample.sampleSize(),

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1219,6 +1219,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 
 			const auto param = SampleThumbnail::VisualizeParameters{
 				.sampleRect = QRect(startPos, yOffset, sampleWidth, sampleHeight),
+				.viewportRect = pe->rect(),
 				.amplification = sample.amplification(),
 				.sampleStart = static_cast<float>(sample.startFrame()) / sample.sampleSize(),
 				.sampleEnd = static_cast<float>(sample.endFrame()) / sample.sampleSize(),


### PR DESCRIPTION
This PR adds additional changes on top of #7366:

- Attempts to resolve the garbage rendering issue when viewing large samples.

<details>
<summary>Details</summary>
In the old code, `m_paintPixmap` in `SampleClipView` is allocated to the size of the whole clip, and painted at (0, 0) no matter what. On large samples, when the width exceeds 32768 (QPixmap's resolution limit), garbage data will be shown.

In this PR, `m_paintPixmap` is allocated to the paintEvent's size (but with the clip's height), and painted onto the clip at the paintEvent's X coordinate. To make sure the m_paintPixmap doesn't get drawn on the wrong coordinate (due to something overlaying the clip and changing the paintEvent region), we paint on the coordinate obtained from the last full redraw.

![ảnh](https://github.com/user-attachments/assets/8dadf809-c55b-4c12-a381-85a95e331f7b)

This change allows some fields of VisualizeParameters to be omitted (drawRect).
</details>

- Fixes lagging in Automation Editor by specifying the viewportRect.

- Fixes crashes:
  - #7723
  - #7789

- Simplifies and enhances the implementation.

Should resolve the sample clips part of #3378 