### PR TITLE
HiDPI support in VST windows

### DIFF
--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -809,6 +809,7 @@ void RemoteVstPlugin::initEditor()
 		dwStyle = WS_OVERLAPPEDWINDOW & ~WS_MAXIMIZEBOX;
 	}
 
+	SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 	m_window = CreateWindowEx( WS_EX_APPWINDOW, "LVSL", pluginName(),
 		dwStyle,
 		0, 0, 10, 10, nullptr, nullptr, hInst, nullptr );


### PR DESCRIPTION
NEEDS TESTING.
Addresses #7683 for non-linux-native VSTs.

Testing is wanted for embedded, detached and multi-monitor detached modes, preferably on both windows and wine. I didn't set per_monitor_v2 because (a) I don't hae any clue on what I am doing and (b) it might unnecessarily break backwards compatability.