### PR TITLE
Fix incorrect graph step size behavior

### DIFF
--- a/include/Graph.h
+++ b/include/Graph.h
@@ -182,7 +182,7 @@ public:
 
 public slots:
 	//! Set range of y values
-	void setRange( float _min, float _max );
+	void setRange(float ymin, float ymax);
 
 	void setLength( int _size );
 	//! Update one sample

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -732,15 +732,14 @@ void graphModel::clearInvisible()
 	emit samplesChanged( graph_length, full_graph_length - 1 );
 }
 
-void graphModel::drawSampleAt( int x, float val )
+void graphModel::drawSampleAt(int x, float val)
 {
-	//snap to the grid
-	val -= (m_step != 0.0) ? std::fmod(val, m_step) * m_step : 0;
-
+	// snap to the grid
+	// Should there be validation to make sure m_step <= 2 * maxvalue()?
+	if (m_step > 0.f) { val = std::floor(val / m_step) * m_step; }
 	// boundary crop
-	x = qMax( 0, qMin( length()-1, x ) );
-	val = qMax( minValue(), qMin( maxValue(), val ) );
-
+	x = std::clamp(x, 0, length() - 1);
+	val = std::clamp(val, minValue(), maxValue());
 	// change sample shape
 	m_samples[x] = val;
 }

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -459,8 +459,8 @@ void Graph::updateGraph()
 
 } // namespace gui
 
-graphModel::graphModel(float ymin, float ymax, int length, Model* parent, bool default_constructed, float step) :
-	Model(parent, tr("Graph"), default_constructed),
+graphModel::graphModel(float ymin, float ymax, int length, Model* parent, bool defaultConstructed, float step) :
+	Model(parent, tr("Graph"), defaultConstructed),
 	m_samples(length),
 	m_length(length),
 	m_minValue(ymin),

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -735,7 +735,6 @@ void graphModel::clearInvisible()
 void graphModel::drawSampleAt(int x, float val)
 {
 	// snap to the grid
-	// Should there be validation to make sure m_step <= 2 * maxvalue()?
 	if (m_step > 0.f) { val = std::floor(val / m_step) * m_step; }
 	// boundary crop
 	x = std::clamp(x, 0, length() - 1);

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -459,38 +459,30 @@ void Graph::updateGraph()
 
 } // namespace gui
 
-graphModel::graphModel( float _min, float _max, int _length,
-			Model* _parent, bool _default_constructed,  float _step ) :
-	Model( _parent, tr( "Graph" ), _default_constructed ),
-	m_samples( _length ),
-	m_length( _length ),
-	m_minValue( _min ),
-	m_maxValue( _max ),
-	m_step( _step )
+graphModel::graphModel(float ymin, float ymax, int length, Model* parent, bool default_constructed, float step) :
+	Model(parent, tr("Graph"), default_constructed),
+	m_samples(length),
+	m_length(length),
+	m_minValue(ymin),
+	m_maxValue(ymax),
+	m_step(std::clamp(step, 0.f, std::abs(ymax - ymin)))
 {
 }
 
-void graphModel::setRange( float _min, float _max )
+void graphModel::setRange(float ymin, float ymax)
 {
-	if( _min != m_minValue || _max != m_maxValue )
-	{
-		m_minValue = _min;
-		m_maxValue = _max;
-
-		if( !m_samples.isEmpty() )
-		{
-			// Trim existing values
-			for( int i=0; i < length(); i++ )
-			{
-				m_samples[i] = fmaxf( _min, fminf( m_samples[i], _max ) );
-			}
-		}
-
-		emit rangeChanged();
+	if (ymin == m_minValue && ymax == m_maxValue) { return; }
+	// Step sizes less than zero or larger than the entire range of
+	// values are nonsense, clamp those
+	m_step = std::clamp(m_step, 0.f, std::abs(ymax - ymin));
+	m_minValue = ymin;
+	m_maxValue = ymax;
+	// Trim existing values
+	for (float& sample : m_samples) {
+		sample = std::clamp(sample, ymin, ymax);
 	}
+	emit rangeChanged();
 }
-
-
 
 void graphModel::setLength( int _length )
 {
@@ -735,7 +727,7 @@ void graphModel::clearInvisible()
 void graphModel::drawSampleAt(int x, float val)
 {
 	// snap to the grid
-	if (m_step > 0.f) { val = std::floor(val / m_step) * m_step; }
+	if (m_step > 0) { val = std::floor(val / m_step) * m_step; }
 	// boundary crop
 	x = std::clamp(x, 0, length() - 1);
 	val = std::clamp(val, minValue(), maxValue());


### PR DESCRIPTION
The y-axis quantization for graph values was being calculated incorrectly. Since the only step sizes used in the code base AFAIK are 0 (quantization disabled) or 1, this would not have been noticed until someone tried a new value. Values besides 1 produce "sloped" quantization, which is certainly unintended.

![Recording 2025-02-12 at 19 29 15](https://github.com/user-attachments/assets/00d1da4b-993a-407d-a60e-bbd006713467)

![image](https://github.com/user-attachments/assets/1e5e5c8d-a6c8-4167-971b-4162365f377d) ![image](https://github.com/user-attachments/assets/73033a78-1988-44b4-8e15-7814a0f9ffb6)

