### PR TITLE
Add Wayland support to the AppImage

### DIFF
--- a/.github/workflows/deps-ubuntu-24.04-gcc.txt
+++ b/.github/workflows/deps-ubuntu-24.04-gcc.txt
@@ -46,6 +46,7 @@ qtbase5-dev
 qtbase5-dev-tools
 qtbase5-private-dev
 qttools5-dev-tools
+qtwayland5
 software-properties-common
 ssh-client
 stk

--- a/cmake/linux/LinuxDeploy.cmake
+++ b/cmake/linux/LinuxDeploy.cmake
@@ -135,6 +135,10 @@ file(GLOB LADSPA "${APP}/usr/lib/${lmms}/ladspa/*.so")
 # Inform linuxdeploy about remote plugins
 file(GLOB REMOTE_PLUGINS "${APP}/usr/lib/${lmms}/*Remote*")
 
+# Inform linuxdeploy-plugin-qt about wayland plugin
+set(ENV{EXTRA_PLATFORM_PLUGINS} "libqwayland-generic.so")
+set(ENV{EXTRA_QT_MODULES} "waylandcompositor")
+
 # Collect, sort and dedupe all libraries
 list(APPEND LIBS ${LADSPA})
 list(APPEND LIBS ${REMOTE_PLUGINS})

--- a/cmake/linux/apprun-hooks/wayland-hook.sh
+++ b/cmake/linux/apprun-hooks/wayland-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Configure QPlatform Abstraction (qpa) to prefer X-Protocol C-Bindings (xcb) over Wayland 
+ME="$( basename "${BASH_SOURCE[0]}")"
+
+if [ -n "$QT_QPA_PLATFORM" ]; then
+	echo "[$ME] QT_QPA_PLATFORM=\"$QT_QPA_PLATFORM\" was provided, using." >&2
+else
+	export QT_QPA_PLATFORM="xcb"
+	echo "[$ME] Defaulting to QT_QPA_PLATFORM=\"$QT_QPA_PLATFORM\" for compatibility purposes." >&2
+	echo "[$ME] To force wayland, set QT_QPA_PLATFORM=\"wayland\" or call using \"-platform wayland\"." >&2
+fi


### PR DESCRIPTION
Adds wayland support to the AppImage.  It's off by default.  To toggle it on:
* Call the appimage with `-platform wayland`<br>--- OR ---
* Set  `QT_QPA_PLATFORM=wayland` before running.

We may eventually decide to toggled on for some platform by default (e.g. KDE) as it works much better in some environments over others.  For example:
* Gnome-based desktops such as Ubuntu and Fedora, there are many bugs: Splash screen isn't centered, mouse loses control of widgets, window controls are odd.
* There also have been some KDE bugs reported on Discord, such as flickering in LMMS when Carla is opened

I've added some logging to startup to guide users into switching between the two:
```
[wayland-hook.sh] Defaulting to QT_QPA_PLATFORM="xcb" for compatibility purposes.
[wayland-hook.sh] To force wayland, set QT_QPA_PLATFORM="wayland" or call using "-platform wayland"
```