### PR TITLE
Prefer snprintf() over sprintf()

### DIFF
--- a/plugins/MidiImport/portsmf/allegrosmfrd.cpp
+++ b/plugins/MidiImport/portsmf/allegrosmfrd.cpp
@@ -183,14 +183,13 @@ void Alg_midifile_reader::Mf_error(const char *msg)
 
 void Alg_midifile_reader::Mf_header(int format, int ntrks, int division)
 {
-    if (format > 1) {
-        char msg[80];
-//#pragma warning(disable: 4996) // msg is long enough
-        sprintf(msg, "file format %d not implemented", format);
-//#pragma warning(default: 4996)
-        Mf_error(msg);
-    }
-    divisions = division;
+	if (format > 1)
+	{
+		char msg[80];
+		snprintf(msg, sizeof(msg), "file format %d not implemented", format);
+		Mf_error(msg);
+	}
+	divisions = division;
 }
 
 
@@ -272,15 +271,13 @@ void Alg_midifile_reader::Mf_pressure(int chan, int key, int val)
 
 void Alg_midifile_reader::Mf_controller(int chan, int control, int val)
 {
-    Alg_parameter parameter;
-    char name[32];
-//#pragma warning(disable: 4996) // name is long enough
-    sprintf(name, "control%dr", control);
-//#pragma warning(default: 4996)
-    parameter.set_attr(symbol_table.insert_string(name));
-    parameter.r = val / 127.0;
-    update(chan, -1, &parameter);
-    meta_channel = -1;
+	Alg_parameter parameter;
+	char name[32];
+	snprintf(name, sizeof(name), "control%dr", control);
+	parameter.set_attr(symbol_table.insert_string(name));
+	parameter.r = val / 127.0;
+	update(chan, -1, &parameter);
+	meta_channel = -1;
 }
 
 
@@ -314,19 +311,17 @@ void Alg_midifile_reader::Mf_chanpressure(int chan, int val)
 }
 
 
-void Alg_midifile_reader::binary_msg(int len, unsigned char *msg, 
-                                     const char *attr_string)
+void Alg_midifile_reader::binary_msg(int len, unsigned char *msg, const char *attr_string)
 {
-    Alg_parameter parameter;
-    char *hexstr = new char[len * 2 + 1];
-    for (int i = 0; i < len; i++) {
-//#pragma warning(disable: 4996) // hexstr is long enough
-        sprintf(hexstr + 2 * i, "%02x", (0xFF & msg[i]));
-//#pragma warning(default: 4996)
-    }
-    parameter.s = hexstr;
-    parameter.set_attr(symbol_table.insert_string(attr_string));
-    update(meta_channel, -1, &parameter);
+	Alg_parameter parameter;
+	char *hexstr = new char[len * 2 + 1];
+	for (int i = 0; i < len; i++)
+	{
+		snprintf(hexstr + 2 * i, 3, "%02x", (0xFF & msg[i]));
+	}
+	parameter.s = hexstr;
+	parameter.set_attr(symbol_table.insert_string(attr_string));
+	update(meta_channel, -1, &parameter);
 }
 
 
@@ -345,11 +340,9 @@ void Alg_midifile_reader::Mf_arbitrary(int len, unsigned char *msg)
 
 void Alg_midifile_reader::Mf_metamisc(int type, int len, unsigned char *msg)
 {
-    char text[128];
-//#pragma warning(disable: 4996) // text is long enough
-    sprintf(text, "metamsic data, type 0x%x, ignored", type);
-//#pragma warning(default: 4996)
-    Mf_error(text);
+	char text[128];
+	snprintf(text, sizeof(text), "metamsic data, type 0x%x, ignored", type);
+	Mf_error(text);
 }
 
 
@@ -361,23 +354,20 @@ void Alg_midifile_reader::Mf_seqnum(int n)
 
 static const char *fpsstr[4] = {"24", "25", "29.97", "30"};
 
-void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs,
-                                   int frames, int subframes)
+void Alg_midifile_reader::Mf_smpte(int hours, int mins, int secs, int frames, int subframes)
 {
-    // string will look like "24fps:01h:27m:07s:19.00f"
-    // 30fps (drop frame) is notated as "29.97fps"
-    char text[32];
-    int fps = (hours >> 6) & 3;
-    hours &= 0x1F;
-//#pragma warning(disable: 4996) // text is long enough
-    sprintf(text, "%sfps:%02dh:%02dm:%02ds:%02d.%02df", 
-            fpsstr[fps], hours, mins, secs, frames, subframes);
-//#pragma warning(default: 4996)
-    Alg_parameter smpteoffset;
-    smpteoffset.s = heapify(text);
-    smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));
-    update(meta_channel, -1, &smpteoffset);
-    // Mf_error("SMPTE data ignored");
+	// string will look like "24fps:01h:27m:07s:19.00f"
+	// 30fps (drop frame) is notated as "29.97fps"
+	char text[32];
+	int fps = (hours >> 6) & 3;
+	hours &= 0x1F;
+	snprintf(text, sizeof(text), "%sfps:%02dh:%02dm:%02ds:%02d.%02df",
+		fpsstr[fps], hours, mins, secs, frames, subframes);
+	Alg_parameter smpteoffset;
+	smpteoffset.s = heapify(text);
+	smpteoffset.set_attr(symbol_table.insert_string("smpteoffsets"));
+	update(meta_channel, -1, &smpteoffset);
+	// Mf_error("SMPTE data ignored");
 }
 
 

--- a/plugins/MidiImport/portsmf/mfmidi.cpp
+++ b/plugins/MidiImport/portsmf/mfmidi.cpp
@@ -256,11 +256,9 @@ void Midifile_reader::readtrack()
 
 void Midifile_reader::badbyte(int c)
 {
-    char buff[32];
-//#pragma warning(disable: 4996) // safe in this case
-    (void) sprintf(buff,"unexpected byte: 0x%02x",c);
-//#pragma warning(default: 4996)
-    mferror(buff);
+	char buff[32];
+	(void)snprintf(buff, sizeof(buff), "unexpected byte: 0x%02x", c);
+	mferror(buff);
 }
 
 void Midifile_reader::metaevent(int type)

--- a/plugins/ReverbSC/base.c
+++ b/plugins/ReverbSC/base.c
@@ -4,36 +4,16 @@
 #include <math.h>
 #include "base.h"
 
-int sp_create(sp_data **spp)
-{
-    *spp = (sp_data *) malloc(sizeof(sp_data));
-    sp_data *sp = *spp;
-    sprintf(sp->filename, "test.wav");
-    sp->nchan = 1;
-    SPFLOAT *out = malloc(sizeof(SPFLOAT) * sp->nchan);
-    *out = 0;
-    sp->out = out;
-    sp->sr = 44100;
-    sp->len = 5 * sp->sr;
-    sp->pos = 0;
-    sp->rand = 0;
-    return 0;
-}
+int sp_create(sp_data **spp) { return sp_createn(spp, 1); }
 
 int sp_createn(sp_data **spp, int nchan)
 {
-    *spp = (sp_data *) malloc(sizeof(sp_data));
-    sp_data *sp = *spp;
-    sprintf(sp->filename, "test.wav");
-    sp->nchan = nchan;
-    SPFLOAT *out = malloc(sizeof(SPFLOAT) * sp->nchan);
-    *out = 0;
-    sp->out = out;
-    sp->sr = 44100;
-    sp->len = 5 * sp->sr;
-    sp->pos = 0;
-    sp->rand = 0;
-    return 0;
+	sp_data *sp = malloc(sizeof(sp_data));
+	*sp = (sp_data){ .out = calloc(nchan, sizeof(SPFLOAT)), .sr = 44100, .nchan = nchan, .pos = 0, .rand = 0 };
+	sp->len = 5 * sp->sr;
+	snprintf(sp->filename, sizeof(sp->filename), "test.wav");
+	*spp = sp;
+	return 0;
 }
 
 int sp_destroy(sp_data **spp)
@@ -61,7 +41,7 @@ int sp_process(sp_data *sp, void *ud, void (*callback)(sp_data *, void *))
         sf[0] = sf_open(sp->filename, SFM_WRITE, &info);
     } else {
         for(chan = 0; chan < sp->nchan; chan++) {
-            sprintf(tmp, "%02d_%s", chan, sp->filename);
+            snprintf(tmp, sizeof(tmp), "%02d_%s", chan, sp->filename);
             sf[chan] = sf_open(tmp, SFM_WRITE, &info);
         }
     }


### PR DESCRIPTION
Resolves #3949 by replacing all calls to `sprintf()` in first-party code (read: not in a git submodule or `src/3rdparty`) with calls to `snprintf()` or some other reasonable alternative.

This does not resolve the memory management issue raised in [this comment](https://github.com/LMMS/lmms/pull/3948#issuecomment-342446909); it only addresses the uses of `sprintf()`.