### PR TITLE
Fix: SlicerT selects last slice point in range of mouse pointer not the closest to it

### DIFF
--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -331,17 +331,17 @@ void SlicerTWaveform::updateClosest(QMouseEvent* me)
 			
 			if (currentDistance < s_distanceForClick)
 			{
-                if( currentDistance < nearestSoFar)
-                {
-                    m_closestObject = UIObjects::SlicePoint;
-                    m_closestSlice = i;
-                    nearestSoFar = currentDistance;
-                }
-                else
-                {
-                    // Done, this can't get any better
-                    break;
-                }
+				if( currentDistance < nearestSoFar)
+				{
+					m_closestObject = UIObjects::SlicePoint;
+					m_closestSlice = i;
+					nearestSoFar = currentDistance;
+				}
+				else
+				{
+					// Done, this can't get any better
+					break;
+				}
 			}
 		}
 	}

--- a/plugins/SlicerT/SlicerTWaveform.cpp
+++ b/plugins/SlicerT/SlicerTWaveform.cpp
@@ -51,7 +51,7 @@ static QColor s_playHighlightColor = QColor(255, 255, 255, 70); // now playing n
 // slice markers
 static QColor s_sliceColor = QColor(218, 193, 255);			 // color of slice marker
 static QColor s_sliceShadowColor = QColor(136, 120, 158);	 // color of dark side of slice marker
-static QColor s_sliceHighlightColor = QColor(255, 255, 255); // color of highlighted slice marker
+static QColor s_sliceHighlightColor = QColor(255, 0, 0);     // color of highlighted slice marker
 
 // seeker rect colors
 static QColor s_seekerColor = QColor(178, 115, 255);			   // outline of seeker
@@ -321,15 +321,27 @@ void SlicerTWaveform::updateClosest(QMouseEvent* me)
 		m_closestSlice = -1;
 		float startFrame = m_seekerStart;
 		float endFrame = m_seekerEnd;
+		float nearestSoFar = s_distanceForClick;
+		
 		for (auto i = std::size_t{0}; i < m_slicerTParent->m_slicePoints.size(); i++)
 		{
 			float sliceIndex = m_slicerTParent->m_slicePoints.at(i);
 			float xPos = (sliceIndex - startFrame) / (endFrame - startFrame);
-
-			if (std::abs(xPos - normalizedClickEditor) < s_distanceForClick)
+			float currentDistance = std::abs(xPos - normalizedClickEditor);
+			
+			if (currentDistance < s_distanceForClick)
 			{
-				m_closestObject = UIObjects::SlicePoint;
-				m_closestSlice = i;
+                if( currentDistance < nearestSoFar)
+                {
+                    m_closestObject = UIObjects::SlicePoint;
+                    m_closestSlice = i;
+                    nearestSoFar = currentDistance;
+                }
+                else
+                {
+                    // Done, this can't get any better
+                    break;
+                }
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

I provide this patch in hope of it being usefull.

The loop in SlicerT's SlicerTWaveform::updateClosest currently picks the last slice point in range of the mouse pointer. This change makes it pick the closest one. Since (as fr as I observed) the list is sorted the loop can be exited if the distance starts to get bigger again.

I also find it hard to see the difference between light gray and white I also changed the highlight color to a more distinct one. (I need to figure out how to detect when the mouse leaves the area to clear the highlight.)

Please excuse any indentation issues. I made more changes (currently for my own benefit) and created this branch/PR with the Github online editor.

Regards,
_Dirk_