### PR TITLE
Multiple Mixer Channel Selection

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -651,7 +651,7 @@ lmms--gui--MixerChannelView {
 	color: #e0e0e0;
 	qproperty-backgroundActive: qlineargradient(spread:reflect, x1:0, y1:0, x2:1, y2:0,
 								stop:0 #7b838d, stop:1 #6b7581 );
-	qproperty-strokeOuterActive: rgb( 0, 0, 0 );
+	qproperty-strokeOuterActive: rgb( 0, 255, 0 );
 	qproperty-strokeOuterInactive: rgba( 0, 0, 0, 50 );
 	qproperty-strokeInnerActive: rgba( 255, 255, 255, 100 );
 	qproperty-strokeInnerInactive: rgba( 255, 255, 255, 50 );

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -691,7 +691,7 @@ lmms--gui--MixerChannelView {
 	qproperty-backgroundActive: #3B424A;
 	qproperty-strokeOuterActive: #262B30;
 	qproperty-strokeOuterInactive: #262B30;
-	qproperty-strokeInnerActive: #0C0D0F;
+	qproperty-strokeInnerActive: #0bd556;
 	qproperty-strokeInnerInactive: #0C0D0F;
 }
 

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -113,12 +113,12 @@ public slots:
 private slots:
 	void renameFinished();
 	static void removeSelectedChannels();
-	void removeUnusedChannels();
-	void moveChannelLeft();
-	void moveChannelRight();
+	static void removeUnusedChannels();
+	static void moveChannelLeft();
+	static void moveChannelRight();
 
 private:
-	bool confirmRemoval(int index);
+	static bool confirmRemoval(int index);
 	QString elideName(const QString& name);
 	MixerChannel* mixerChannel() const;
 	auto isMasterChannel() const -> bool { return m_channelIndex == 0; }

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -34,10 +34,13 @@
 
 #include "EffectRackView.h"
 #include "Fader.h"
+#include "GuiApplication.h"
 #include "Knob.h"
 #include "LcdWidget.h"
 #include "PixmapButton.h"
 #include "SendButtonIndicator.h"
+
+#include <set>
 
 namespace lmms {
 class MixerChannel;
@@ -82,6 +85,25 @@ public:
 	QColor strokeInnerInactive() const { return m_strokeInnerInactive; }
 	void setStrokeInnerInactive(const QColor& c) { m_strokeInnerInactive = c; }
 
+	static const std::set<MixerChannelView*>& selectedChannels()
+	{
+		return s_selectedChannels;
+	}
+	static void select(MixerChannelView* mcv)
+	{
+		s_selectedChannels.insert(mcv);
+	}
+	static void deselect(MixerChannelView* mcv)
+	{
+		s_selectedChannels.erase(mcv);
+	}
+	static void deselectAll()
+	{
+		s_selectedChannels.clear();
+	}
+	static void sanitizeSelection();
+
+
 public slots:
 	void renameChannel();
 	void resetColor();
@@ -90,7 +112,7 @@ public slots:
 
 private slots:
 	void renameFinished();
-	void removeSelectedChannels();
+	static void removeSelectedChannels();
 	void removeUnusedChannels();
 	void moveChannelLeft();
 	void moveChannelRight();
@@ -127,6 +149,8 @@ private:
 	QColor m_strokeOuterInactive;
 	QColor m_strokeInnerActive;
 	QColor m_strokeInnerInactive;
+
+	static std::set<MixerChannelView*> s_selectedChannels;
 
 	friend class MixerView;
 };

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -90,7 +90,7 @@ public slots:
 
 private slots:
 	void renameFinished();
-	void removeChannel();
+	void removeSelectedChannels();
 	void removeUnusedChannels();
 	void moveChannelLeft();
 	void moveChannelRight();

--- a/include/MixerChannelView.h
+++ b/include/MixerChannelView.h
@@ -109,6 +109,8 @@ public slots:
 	void resetColor();
 	void selectColor();
 	void randomizeColor();
+	void toggledSolo();
+	void toggledMute();
 
 private slots:
 	void renameFinished();

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -105,17 +105,9 @@ protected:
 
 private slots:
 	void updateFaders();
-	// TODO This should be improved. Currently the solo and mute models are connected via
-	// the MixerChannelView's constructor with the MixerView. It would already be an improvement
-	// if the MixerView connected itself to each new MixerChannel that it creates/handles.
-	void toggledSolo();
-	void toggledMute();
 
 private:
 	Mixer* getMixer() const;
-	void updateAllMixerChannels();
-	void connectToSoloAndMute(int channelIndex);
-	void disconnectFromSoloAndMute(int channelIndex);
 
 private:
 	QVector<MixerChannelView*> m_mixerChannelViews;

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -38,8 +38,6 @@
 #include "embed.h"
 #include "EffectRackView.h"
 
-#include <set>
-
 namespace lmms
 {
 	class Mixer;
@@ -63,11 +61,6 @@ public:
 		return m_currentMixerChannel;
 	}
 
-	inline const std::set<MixerChannelView*>& selectedChannels()
-	{
-		return m_selectedChannels;
-	}
-
 	inline MixerChannelView* channelView(int index)
 	{
 		return m_mixerChannelViews[index];
@@ -87,7 +80,6 @@ public:
 	// display the send button and knob correctly
 	void updateMixerChannel(int index);
 
-	void deleteSelectedChannels();
 	// notify the view that a mixer channel was deleted
 	void deleteChannel(int index);
 
@@ -138,8 +130,6 @@ private:
 	Mixer* m_mixer;
 
 	void updateMaxChannelSelector();
-
-	std::set<MixerChannelView*> m_selectedChannels;
 
 	friend class MixerChannelView;
 } ;

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -38,6 +38,8 @@
 #include "embed.h"
 #include "EffectRackView.h"
 
+#include <set>
+
 namespace lmms
 {
 	class Mixer;
@@ -61,14 +63,23 @@ public:
 		return m_currentMixerChannel;
 	}
 
+	inline const std::set<MixerChannelView*>& selectedChannels()
+	{
+		return m_selectedChannels;
+	}
+
 	inline MixerChannelView* channelView(int index)
 	{
 		return m_mixerChannelViews[index];
 	}
 
 
-	void setCurrentMixerChannel(MixerChannelView* channel);
-	void setCurrentMixerChannel(int channel);
+	void setCurrentMixerChannel(MixerChannelView* channel, bool keepSelection = false, bool rangeSelect = false);
+	void setCurrentMixerChannel(int channel, bool keepSelection = false, bool rangeSelect = false);
+
+	void selectMixerChannelsInRange(int index1, int index2);
+
+	void sanitizeSelection();
 
 	void clear();
 
@@ -76,6 +87,7 @@ public:
 	// display the send button and knob correctly
 	void updateMixerChannel(int index);
 
+	void deleteSelectedChannels();
 	// notify the view that a mixer channel was deleted
 	void deleteChannel(int index);
 
@@ -126,6 +138,8 @@ private:
 	Mixer* m_mixer;
 
 	void updateMaxChannelSelector();
+
+	std::set<MixerChannelView*> m_selectedChannels;
 
 	friend class MixerChannelView;
 } ;

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -337,9 +337,10 @@ void MixerChannelView::selectColor()
 
 void MixerChannelView::randomizeColor()
 {
+	const QColor randomColor = ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48];
 	for (auto mcv : selectedChannels())
 	{
-		mcv->mixerChannel()->setColor(ColorChooser::getPalette(ColorChooser::Palette::Mixer)[rand() % 48]);
+		mcv->mixerChannel()->setColor(randomColor);
 		mcv->update();
 	}
 	Engine::getSong()->setModified();

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -124,6 +124,8 @@ MixerChannelView::MixerChannelView(QWidget* parent, MixerView* mixerView, int ch
 	m_soloButton->setInactiveGraphic(embed::getIconPixmap("led_off"));
 	m_soloButton->setCheckable(true);
 	m_soloButton->setToolTip(tr("Solo this channel"));
+	connect(m_muteButton, &PixmapButton::toggled, this, &MixerChannelView::toggledMute);
+	connect(m_soloButton, &PixmapButton::toggled, this, &MixerChannelView::toggledSolo);
 
 	auto soloMuteLayout = new QVBoxLayout();
 	soloMuteLayout->setContentsMargins(0, 0, 0, 0);
@@ -342,6 +344,44 @@ void MixerChannelView::randomizeColor()
 	}
 	Engine::getSong()->setModified();
 }
+
+void MixerChannelView::toggledMute()
+{
+	if (selectedChannels().contains(this))
+	{
+		for (auto mcv : selectedChannels())
+		{
+			getGUI()->mixerView()->getMixer()->mixerChannel(mcv->channelIndex())->m_muteModel.setValue(Engine::mixer()->mixerChannel(channelIndex())->m_muteModel.value());
+			mcv->update();
+		}
+	}
+	else
+	{
+		update();
+	}
+}
+
+// TODO PLEAE FIX
+void MixerChannelView::toggledSolo()
+{
+	getGUI()->mixerView()->getMixer()->toggledSolo();
+	if (selectedChannels().contains(this))
+	{
+		for (auto mcv : selectedChannels())
+		{
+			if (mcv != this)
+			{
+				getGUI()->mixerView()->getMixer()->mixerChannel(mcv->channelIndex())->m_muteModel.setValue(!getGUI()->mixerView()->getMixer()->mixerChannel(mcv->channelIndex())->m_muteBeforeSolo);
+			}
+			mcv->update();
+		}
+	}
+	else
+	{
+		update();
+	}
+}
+
 
 bool MixerChannelView::confirmRemoval(int index)
 {

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -101,7 +101,6 @@ MixerView::MixerView(Mixer* mixer) :
 	// add master channel
 	m_mixerChannelViews.resize(mixer->numChannels());
 	MixerChannelView * masterView = new MixerChannelView(this, this, 0);
-	connectToSoloAndMute(0);
 	m_mixerChannelViews[0] = masterView;
 
 	m_racksLayout->addWidget(m_mixerChannelViews[0]->m_effectRackView);
@@ -114,7 +113,6 @@ MixerView::MixerView(Mixer* mixer) :
 	for (int i = 1; i < m_mixerChannelViews.size(); ++i)
 	{
 		m_mixerChannelViews[i] = new MixerChannelView(m_channelAreaWidget, this, i);
-		connectToSoloAndMute(i);
 		chLayout->addWidget(m_mixerChannelViews[i]);
 	}
 
@@ -189,7 +187,6 @@ int MixerView::addNewChannel()
 
 	int newChannelIndex = mix->createChannel();
 	m_mixerChannelViews.push_back(new MixerChannelView(m_channelAreaWidget, this, newChannelIndex));
-	connectToSoloAndMute(newChannelIndex);
 	chLayout->addWidget(m_mixerChannelViews[newChannelIndex]);
 	m_racksLayout->addWidget(m_mixerChannelViews[newChannelIndex]->m_effectRackView);
 
@@ -206,9 +203,6 @@ void MixerView::refreshDisplay()
 	// delete all views and re-add them
 	for (int i = 1; i<m_mixerChannelViews.size(); ++i)
 	{
-		// First disconnect from the solo/mute models.
-		disconnectFromSoloAndMute(i);
-
 		auto * mixerChannelView = m_mixerChannelViews[i];
 		chLayout->removeWidget(mixerChannelView);
 		m_racksLayout->removeWidget(mixerChannelView->m_effectRackView);
@@ -222,7 +216,6 @@ void MixerView::refreshDisplay()
 	for (int i = 1; i < m_mixerChannelViews.size(); ++i)
 	{
 		m_mixerChannelViews[i] = new MixerChannelView(m_channelAreaWidget, this, i);
-		connectToSoloAndMute(i);
 
 		chLayout->addWidget(m_mixerChannelViews[i]);
 		m_racksLayout->addWidget(m_mixerChannelViews[i]->m_effectRackView);
@@ -281,60 +274,10 @@ void MixerView::loadSettings(const QDomElement& domElement)
 	MainWindow::restoreWidgetState(this, domElement);
 }
 
-
-
-
-
-void MixerView::toggledSolo()
-{
-	getMixer()->toggledSolo();
-	/*for (auto mcv : m_selectedChannels)
-	{
-		getMixer()->mixerChannel(mcv->channelIndex())->m_muteModel.setValue(getMixer()->mixerChannel(mcv->channelIndex())->m_muteBeforeSolo);
-	}*/
-	updateAllMixerChannels();
-}
-
-
-void MixerView::toggledMute()
-{
-	/*bool muted = getMixer()->mixerChannel(m_currentMixerChannel->channelIndex())->m_muteModel.value();
-	for (auto mcv : m_selectedChannels)
-	{
-		getMixer()->mixerChannel(mcv->channelIndex())->m_muteModel.setValue(muted);
-	}*/
-	updateAllMixerChannels();
-}
-
 Mixer* MixerView::getMixer() const
 {
 	return m_mixer;
 }
-
-void MixerView::updateAllMixerChannels()
-{
-	for (int i = 0; i < m_mixerChannelViews.size(); ++i)
-	{
-		m_mixerChannelViews[i]->update();
-	}
-}
-
-void MixerView::connectToSoloAndMute(int channelIndex)
-{
-	auto * mixerChannel = getMixer()->mixerChannel(channelIndex);
-
-	connect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, this, &MixerView::toggledMute, Qt::DirectConnection);
-	connect(&mixerChannel->m_soloModel, &BoolModel::dataChanged, this, &MixerView::toggledSolo, Qt::DirectConnection);
-}
-
-void MixerView::disconnectFromSoloAndMute(int channelIndex)
-{
-	auto * mixerChannel = getMixer()->mixerChannel(channelIndex);
-
-	disconnect(&mixerChannel->m_muteModel, &BoolModel::dataChanged, this, &MixerView::toggledMute);
-	disconnect(&mixerChannel->m_soloModel, &BoolModel::dataChanged, this, &MixerView::toggledSolo);
-}
-
 
 void MixerView::setCurrentMixerChannel(MixerChannelView* channel, bool keepSelection, bool rangeSelect)
 {
@@ -402,9 +345,6 @@ void MixerView::deleteChannel(int index)
 {
 	// can't delete master
 	if (index == 0) return;
-
-	// Disconnect from the solo/mute models of the channel we are about to delete
-	disconnectFromSoloAndMute(index);
 
 	Mixer* mixer = getMixer();
 	// in case the deleted channel is soloed or the remaining

--- a/src/gui/SendButtonIndicator.cpp
+++ b/src/gui/SendButtonIndicator.cpp
@@ -29,11 +29,29 @@ void SendButtonIndicator::mousePressEvent(QMouseEvent* e)
 	{
 		// not sending. create a mixer send.
 		mix->createChannelSend(from, to);
+		// create mixer sends for all other selected channels if they don't have them already
+		for (auto mcv : m_mv->selectedChannels())
+		{
+			if (mcv->channelIndex() != from && mcv->channelIndex() != to
+				&& mix->channelSendModel(mcv->channelIndex(), to) == nullptr)
+			{
+				mix->createChannelSend(mcv->channelIndex(), to);
+			}
+		}
 	}
 	else
 	{
 		// sending. delete the mixer send.
 		mix->deleteChannelSend(from, to);
+		// delete mixer sends for all other selected channels if they have them
+		for (auto mcv : m_mv->selectedChannels())
+		{
+			if (mcv->channelIndex() != from && mcv->channelIndex() != to
+				&& mix->channelSendModel(mcv->channelIndex(), to) != nullptr)
+			{
+				mix->deleteChannelSend(mcv->channelIndex(), to);
+			}
+		}
 	}
 
 	m_mv->updateMixerChannel(m_parent->channelIndex());

--- a/src/gui/SendButtonIndicator.cpp
+++ b/src/gui/SendButtonIndicator.cpp
@@ -30,7 +30,7 @@ void SendButtonIndicator::mousePressEvent(QMouseEvent* e)
 		// not sending. create a mixer send.
 		mix->createChannelSend(from, to);
 		// create mixer sends for all other selected channels if they don't have them already
-		for (auto mcv : m_mv->selectedChannels())
+		for (auto mcv : MixerChannelView::selectedChannels())
 		{
 			if (mcv->channelIndex() != from && mcv->channelIndex() != to
 				&& mix->channelSendModel(mcv->channelIndex(), to) == nullptr)
@@ -44,7 +44,7 @@ void SendButtonIndicator::mousePressEvent(QMouseEvent* e)
 		// sending. delete the mixer send.
 		mix->deleteChannelSend(from, to);
 		// delete mixer sends for all other selected channels if they have them
-		for (auto mcv : m_mv->selectedChannels())
+		for (auto mcv : MixerChannelView::selectedChannels())
 		{
 			if (mcv->channelIndex() != from && mcv->channelIndex() != to
 				&& mix->channelSendModel(mcv->channelIndex(), to) != nullptr)


### PR DESCRIPTION
This PR adds the ability to select multiple mixer channels at once and do simple operations on all of them, such as sending, muting, deleting, and changing color.

## Implementation
- The currently selected mixer channels are stored in a `std::set` within `MixerChannelView`
- Lots of methods which used to work on a single channel have been changed to work with the entire selection of channels In particular,
  - Send/unsend
  - Changing color
  - Moving left/right
  - Deleting selected channels
  - Muting/soloing

## Known Bugs
- Bulk solo is buggy
- Bulk moving left/right is buggy when some unselected channels have send/receives. I'm not sure why.


Now that I think about it, this code is really messy and this probably isn't the best way to handle it. If you all don't think this is a good PR, I can wait for someone else to do it better lol.