### PR TITLE
Allow cutting multiple notes at once in Piano Roll

### DIFF
--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -82,6 +82,9 @@ public:
 	// Split the list of notes on the given position
 	void splitNotes(const NoteVector& notes, TimePos pos);
 
+	// Split the list of notes along a line
+	void splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2);
+
 	// clip-type stuff
 	inline Type type() const
 	{

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -83,7 +83,7 @@ public:
 	void splitNotes(const NoteVector& notes, TimePos pos);
 
 	// Split the list of notes along a line
-	void splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2);
+	void splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds);
 
 	// clip-type stuff
 	inline Type type() const

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -83,7 +83,7 @@ public:
 	void splitNotes(const NoteVector& notes, TimePos pos);
 
 	// Split the list of notes along a line
-	void splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds);
+	void splitNotesAlongLine(const NoteVector notes, TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds);
 
 	// clip-type stuff
 	inline Type type() const

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -456,9 +456,14 @@ private:
 	// did we start a mouseclick with shift pressed
 	bool m_startedWithShift;
 
-	// Variable that holds the position in ticks for the knife action
-	int m_knifeTickPos;
-	void updateKnifePos(QMouseEvent* me);
+	// Variables that hold the start and end position for the knife line
+	TimePos m_knifeStartTickPos;
+	int m_knifeStartKey;
+	TimePos m_knifeEndTickPos;
+	int m_knifeEndKey;
+	bool m_knifeDown;
+
+	void updateKnifePos(QMouseEvent* me, bool initial);
 
 	friend class PianoRollWindow;
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1610,19 +1610,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 	// -- Knife
 	if (m_editMode == EditMode::Knife && me->button() == Qt::LeftButton)
 	{
-		NoteVector n;
-		Note* note = noteUnderMouse();
-
-		if (note)
-		{
-			n.push_back(note);
-
-			updateKnifePos(me);
-
-			// Call splitNotes for the note
-			m_midiClip->splitNotes(n, TimePos(m_knifeTickPos));
-		}
-
+		updateKnifePos(me, true);
+		m_knifeDown = true;
 		update();
 		return;
 	}
@@ -2140,6 +2129,7 @@ void PianoRoll::setKnifeAction()
 		m_knifeMode = m_editMode;
 		m_editMode = EditMode::Knife;
 		m_action = Action::Knife;
+		m_knifeDown = false;
 		setCursor(Qt::ArrowCursor);
 		update();
 	}
@@ -2149,6 +2139,7 @@ void PianoRoll::cancelKnifeAction()
 {
 	m_editMode = m_knifeMode;
 	m_action = Action::None;
+	m_knifeDown = false;
 	update();
 }
 
@@ -2277,6 +2268,11 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 			m_midiClip->rearrangeAllNotes();
 
 		}
+		else if (m_action == Action::Knife)
+		{
+			m_midiClip->splitNotesAlongLine(TimePos(m_knifeStartTickPos), m_knifeStartKey, TimePos(m_knifeEndTickPos), m_knifeEndKey);
+			m_knifeDown = false;
+		}
 
 		if( m_action == Action::MoveNote || m_action == Action::ResizeNote )
 		{
@@ -2380,7 +2376,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	// Update Knife position if we are on knife mode
 	if (m_editMode == EditMode::Knife)
 	{
-		updateKnifePos(me);
+		updateKnifePos(me, false);
 	}
 
 	if( me->y() > PR_TOP_MARGIN || m_action != Action::None )
@@ -2761,11 +2757,13 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 
 
 
-void PianoRoll::updateKnifePos(QMouseEvent* me)
+void PianoRoll::updateKnifePos(QMouseEvent* me, bool initial)
 {
 	// Calculate the TimePos from the mouse
-	int mouseViewportPos = me->x() - m_whiteKeyWidth;
-	int mouseTickPos = mouseViewportPos * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+	int mouseViewportPosX = me->x() - m_whiteKeyWidth;
+	int mouseViewportPosY = keyAreaBottom() - 1 - me->y();
+	int mouseTickPos = mouseViewportPosX * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+	int mouseKey = mouseViewportPosY / m_keyLineHeight + m_startKey - 1;
 
 	// If ctrl is not pressed, quantize the position
 	if (!(me->modifiers() & Qt::ControlModifier))
@@ -2773,7 +2771,13 @@ void PianoRoll::updateKnifePos(QMouseEvent* me)
 		mouseTickPos = floor(mouseTickPos / quantization()) * quantization();
 	}
 
-	m_knifeTickPos = mouseTickPos;
+	if (initial)
+	{
+		m_knifeStartTickPos = mouseTickPos;
+		m_knifeStartKey = mouseKey;
+	}
+	m_knifeEndTickPos = mouseTickPos;
+	m_knifeEndKey = mouseKey;
 }
 
 
@@ -3533,37 +3537,21 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		}
 
 		// -- Knife tool (draw cut line)
-		if (m_action == Action::Knife)
+		if (m_action == Action::Knife && m_knifeDown)
 		{
 			auto xCoordOfTick = [this](int tick) {
 				return m_whiteKeyWidth + (
 					(tick - m_currentPosition) * m_ppb / TimePos::ticksPerBar());
 			};
-			Note* n = noteUnderMouse();
-			if (n)
-			{
-				const int key = n->key() - m_startKey + 1;
-				int y = y_base - key * m_keyLineHeight;
+			int x1 = xCoordOfTick(m_knifeStartTickPos);
+			int y1 = y_base - (m_knifeStartKey - m_startKey + 1) * m_keyLineHeight;
+			int x2 = xCoordOfTick(m_knifeEndTickPos);
+			int y2 = y_base - (m_knifeEndKey - m_startKey + 1) * m_keyLineHeight;
 
-				int x = xCoordOfTick(m_knifeTickPos);
+			p.setPen(QPen(m_knifeCutLineColor, 1));
+			p.drawLine(x1, y1, x2, y2);
 
-				if (x > xCoordOfTick(n->pos()) &&
-					x < xCoordOfTick(n->pos() + n->length()))
-				{
-					p.setPen(QPen(m_knifeCutLineColor, 1));
-					p.drawLine(x, y, x, y + m_keyLineHeight);
-
-					setCursor(Qt::BlankCursor);
-				}
-				else
-				{
-					setCursor(Qt::ArrowCursor);
-				}
-			}
-			else
-			{
-				setCursor(Qt::ArrowCursor);
-			}
+			setCursor(Qt::BlankCursor);
 		}
 		// -- End knife tool
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2268,10 +2268,11 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 			m_midiClip->rearrangeAllNotes();
 
 		}
-		else if (m_action == Action::Knife)
+		else if (m_action == Action::Knife && hasValidMidiClip())
 		{
 			bool deleteShortEnds = me->modifiers() & Qt::ShiftModifier;
-			m_midiClip->splitNotesAlongLine(TimePos(m_knifeStartTickPos), m_knifeStartKey, TimePos(m_knifeEndTickPos), m_knifeEndKey, deleteShortEnds);
+			const NoteVector selectedNotes = getSelectedNotes();
+			m_midiClip->splitNotesAlongLine(!selectedNotes.empty() ? selectedNotes : m_midiClip->notes(), TimePos(m_knifeStartTickPos), m_knifeStartKey, TimePos(m_knifeEndTickPos), m_knifeEndKey, deleteShortEnds);
 			m_knifeDown = false;
 		}
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3551,8 +3551,6 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 
 			p.setPen(QPen(m_knifeCutLineColor, 1));
 			p.drawLine(x1, y1, x2, y2);
-
-			setCursor(Qt::BlankCursor);
 		}
 		// -- End knife tool
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2764,12 +2764,12 @@ void PianoRoll::updateKnifePos(QMouseEvent* me, bool initial)
 	int mouseViewportPosX = me->x() - m_whiteKeyWidth;
 	int mouseViewportPosY = keyAreaBottom() - 1 - me->y();
 	int mouseTickPos = mouseViewportPosX * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-	int mouseKey = mouseViewportPosY / m_keyLineHeight + m_startKey - 1;
+	int mouseKey = std::round(1.f * mouseViewportPosY / m_keyLineHeight) + m_startKey - 1;
 
 	// If ctrl is not pressed, quantize the position
 	if (!(me->modifiers() & Qt::ControlModifier))
 	{
-		mouseTickPos = floor(mouseTickPos / quantization()) * quantization();
+		mouseTickPos = std::round(1.f * mouseTickPos / quantization()) * quantization();
 	}
 
 	if (initial)

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2270,7 +2270,8 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 		}
 		else if (m_action == Action::Knife)
 		{
-			m_midiClip->splitNotesAlongLine(TimePos(m_knifeStartTickPos), m_knifeStartKey, TimePos(m_knifeEndTickPos), m_knifeEndKey);
+			bool deleteShortEnds = me->modifiers() & Qt::ShiftModifier;
+			m_midiClip->splitNotesAlongLine(TimePos(m_knifeStartTickPos), m_knifeStartKey, TimePos(m_knifeEndTickPos), m_knifeEndKey, deleteShortEnds);
 			m_knifeDown = false;
 		}
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -344,20 +344,19 @@ void MidiClip::splitNotes(const NoteVector& notes, TimePos pos)
 	}
 }
 
-void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds)
+void MidiClip::splitNotesAlongLine(const NoteVector notes, TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds)
 {
-	if (m_notes.empty()) { return; }
+	if (notes.empty()) { return; }
 
 	// Don't split if the line is horitzontal
 	if (key1 == key2) { return; }
 
 	addJournalCheckPoint();
 
-	const auto notesCopy = m_notes;
 	const auto slope = 1.f * (pos2 - pos1) / (key2 - key1);
 	const auto& [minKey, maxKey] = std::minmax(key1, key2);
 
-	for (const auto& note : notesCopy)
+	for (const auto& note : notes)
 	{
 		// Skip if the key is <= to minKey, since the line is drawn from the top of minKey to the top of maxKey, but only passes through maxKey - minKey - 1 total keys.
 		if (note->key() <= minKey || note->key() > maxKey) { continue; }

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -359,7 +359,7 @@ void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key
 
 	for (const auto& note : notesCopy)
 	{
-		// Continuing if the key is <= to minKey, since the line is drawn from the top of minKey to the top of maxKey, but only passes through maxKey - minKey - 1 total keys.
+		// Skip if the key is <= to minKey, since the line is drawn from the top of minKey to the top of maxKey, but only passes through maxKey - minKey - 1 total keys.
 		if (note->key() <= minKey || note->key() > maxKey) { continue; }
 
 		// Subtracting 0.5 to get the line's intercept at the "center" of the key, not the top.

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -344,6 +344,36 @@ void MidiClip::splitNotes(const NoteVector& notes, TimePos pos)
 	}
 }
 
+void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2)
+{
+	if (m_notes.empty()) { return; }
+	// Don't split if the line is horitzontal
+	if (key1 == key2) { return; }
+
+	addJournalCheckPoint();
+
+	NoteVector notesCopy = m_notes;
+
+	float slope = 1.f * (pos2 - pos1) / (key2 - key1);
+
+	for (const auto& note : notesCopy)
+	{
+		TimePos keyIntercept = slope * (note->key() - key1) + pos1;
+		if (note->pos() < keyIntercept && note->endPos() > keyIntercept)
+		{
+			Note newNote1 = Note(*note);
+			newNote1.setLength(keyIntercept - note->pos());
+			addNote(newNote1, false);
+
+			Note newNote2 = Note(*note);
+			newNote2.setPos(keyIntercept);
+			newNote2.setLength(note->endPos() - keyIntercept);
+			addNote(newNote2, false);
+
+			removeNote(note);
+		}
+	}
+}
 
 
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -358,6 +358,8 @@ void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key
 
 	for (const auto& note : notesCopy)
 	{
+		if (note->key() < std::min(key1, key2) || note->key() > std::max(key1, key2)) { continue; }
+
 		TimePos keyIntercept = slope * (note->key() - key1) + pos1;
 		if (note->pos() < keyIntercept && note->endPos() > keyIntercept)
 		{

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -344,7 +344,7 @@ void MidiClip::splitNotes(const NoteVector& notes, TimePos pos)
 	}
 }
 
-void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2)
+void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds)
 {
 	if (m_notes.empty()) { return; }
 	// Don't split if the line is horitzontal
@@ -365,12 +365,21 @@ void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key
 		{
 			Note newNote1 = Note(*note);
 			newNote1.setLength(keyIntercept - note->pos());
-			addNote(newNote1, false);
 
 			Note newNote2 = Note(*note);
 			newNote2.setPos(keyIntercept);
 			newNote2.setLength(note->endPos() - keyIntercept);
-			addNote(newNote2, false);
+
+			if (deleteShortEnds)
+			{
+				if (newNote1.length() >= newNote2.length()) { addNote(newNote1, false); }
+				else { addNote(newNote2, false); }
+			}
+			else
+			{
+				addNote(newNote1, false);
+				addNote(newNote2, false);
+			}
 
 			removeNote(note);
 		}

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -347,33 +347,33 @@ void MidiClip::splitNotes(const NoteVector& notes, TimePos pos)
 void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key2, bool deleteShortEnds)
 {
 	if (m_notes.empty()) { return; }
+
 	// Don't split if the line is horitzontal
 	if (key1 == key2) { return; }
 
 	addJournalCheckPoint();
 
-	NoteVector notesCopy = m_notes;
-
-	float slope = 1.f * (pos2 - pos1) / (key2 - key1);
+	const auto notesCopy = m_notes;
+	const auto slope = 1.f * (pos2 - pos1) / (key2 - key1);
+	const auto& [minKey, maxKey] = std::minmax(key1, key2);
 
 	for (const auto& note : notesCopy)
 	{
-		if (note->key() < std::min(key1, key2) || note->key() > std::max(key1, key2)) { continue; }
+		if (note->key() < minKey || note->key() > maxKey) { continue; }
 
-		TimePos keyIntercept = slope * (note->key() - key1) + pos1;
+		const TimePos keyIntercept = slope * (note->key() - key1) + pos1;
 		if (note->pos() < keyIntercept && note->endPos() > keyIntercept)
 		{
-			Note newNote1 = Note(*note);
+			auto newNote1 = Note{*note};
 			newNote1.setLength(keyIntercept - note->pos());
 
-			Note newNote2 = Note(*note);
+			auto newNote2 = Note{*note};
 			newNote2.setPos(keyIntercept);
 			newNote2.setLength(note->endPos() - keyIntercept);
 
 			if (deleteShortEnds)
 			{
-				if (newNote1.length() >= newNote2.length()) { addNote(newNote1, false); }
-				else { addNote(newNote2, false); }
+				addNote(newNote1.length() >= newNote2.length() ? newNote1 : newNote2, false);
 			}
 			else
 			{

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -359,9 +359,11 @@ void MidiClip::splitNotesAlongLine(TimePos pos1, int key1, TimePos pos2, int key
 
 	for (const auto& note : notesCopy)
 	{
-		if (note->key() < minKey || note->key() > maxKey) { continue; }
+		// Continuing if the key is <= to minKey, since the line is drawn from the top of minKey to the top of maxKey, but only passes through maxKey - minKey - 1 total keys.
+		if (note->key() <= minKey || note->key() > maxKey) { continue; }
 
-		const TimePos keyIntercept = slope * (note->key() - key1) + pos1;
+		// Subtracting 0.5 to get the line's intercept at the "center" of the key, not the top.
+		const TimePos keyIntercept = slope * (note->key() - 0.5 - key1) + pos1;
 		if (note->pos() < keyIntercept && note->endPos() > keyIntercept)
 		{
 			auto newNote1 = Note{*note};


### PR DESCRIPTION
This PR expands the ability of the piano roll's knife tool to allow splitting multiple notes at once. Additionally, it allows splitting notes at an angle, as demonstrated in the video below. The user can drag out the knife line over the notes they want to cut, and once they release, the notes are cut down the line.

Also, you can hold `Shift` while using the knife too to have the cut-off parts of the notes deleted automatically (whichever side of the cut is shorter).

## Demo

https://github.com/user-attachments/assets/c0a94f6c-83b1-4cf2-94d4-056ad7da1861

## Changes
- New variables added to `PianoRoll` to store the knife status, and start/end pos/key.
- New function added to `MidiClip`, `splitNotesAlongLine`, which handles the splitting.
- Updated the drawing and other logic.