### PR TITLE
Fix clang warning due to implicit conversion from int to float for the RAND_MAX macro

### DIFF
--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -163,7 +163,7 @@ public:
 
 	static inline sample_t noiseSample( const float )
 	{
-		return 1.0f - rand() * 2.0f / RAND_MAX;
+		return 1.0f - rand() * 2.0f / static_cast<float>(RAND_MAX);
 	}
 
 	static sample_t userWaveSample(const SampleBuffer* buffer, const float sample)

--- a/plugins/Organic/Organic.cpp
+++ b/plugins/Organic/Organic.cpp
@@ -236,9 +236,9 @@ void OrganicInstrument::playNote( NotePlayHandle * _n,
 		for( int i = m_numOscillators - 1; i >= 0; --i )
 		{
 			static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetLeft[i]
-				= rand() / ( RAND_MAX + 1.0f );
+				= rand() / (static_cast<float>(RAND_MAX) + 1.0f);
 			static_cast<oscPtr *>( _n->m_pluginData )->phaseOffsetRight[i]
-				= rand() / ( RAND_MAX + 1.0f );
+				= rand() / (static_cast<float>(RAND_MAX) + 1.0f);
 
 			// initialise ocillators
 

--- a/plugins/Vibed/VibratingString.cpp
+++ b/plugins/Vibed/VibratingString.cpp
@@ -40,7 +40,7 @@ VibratingString::VibratingString(float pitch, float pick, float pickup, const fl
 	m_oversample{2 * oversample / static_cast<int>(sampleRate / Engine::audioEngine()->baseSampleRate())},
 	m_randomize{randomize},
 	m_stringLoss{1.0f - stringLoss},
-	m_choice{static_cast<int>(m_oversample * static_cast<float>(std::rand()) / RAND_MAX)},
+	m_choice{static_cast<int>(m_oversample * static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX))},
 	m_state{0.1f},
 	m_outsamp{std::make_unique<sample_t[]>(m_oversample)}
 {
@@ -78,7 +78,7 @@ std::unique_ptr<VibratingString::DelayLine> VibratingString::initDelayLine(int l
 		dl->data = std::make_unique<sample_t[]>(len);
 		for (int i = 0; i < dl->length; ++i)
 		{
-			float r = static_cast<float>(std::rand()) / RAND_MAX;
+			float r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 			float offset = (m_randomize / 2.0f - m_randomize) * r;
 			dl->data[i] = offset;
 		}

--- a/plugins/Vibed/VibratingString.h
+++ b/plugins/Vibed/VibratingString.h
@@ -107,13 +107,13 @@ private:
 		{
 			for (int i = 0; i < pick; ++i)
 			{
-				float r = static_cast<float>(std::rand()) / RAND_MAX;
+				float r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 				float offset = (m_randomize / 2.0f - m_randomize) * r;
 				dl->data[i] = scale * values[dl->length - i - 1] + offset;
 			}
 			for (int i = pick; i < dl->length; ++i)
 			{
-				float r = static_cast<float>(std::rand()) / RAND_MAX;
+				float r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 				float offset = (m_randomize / 2.0f - m_randomize) * r;
 				dl->data[i] = scale * values[i - pick]  + offset;
 			}
@@ -124,7 +124,7 @@ private:
 			{
 				for (int i = pick; i < dl->length; ++i)
 				{
-					float r = static_cast<float>(std::rand()) / RAND_MAX;
+					float r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 					float offset = (m_randomize / 2.0f - m_randomize) * r;
 					dl->data[i] = scale * values[i - pick] + offset;
 				}
@@ -133,7 +133,7 @@ private:
 			{
 				for (int i = 0; i < len; ++i)
 				{
-					float r = static_cast<float>(std::rand()) / RAND_MAX;
+					float r = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
 					float offset = (m_randomize / 2.0f - m_randomize) * r;
 					dl->data[i+pick] = scale * values[i] + offset;
 				}


### PR DESCRIPTION
A minor warning, and a minor fix. RAND_MAX is an integer macro, which seems to introduce a warning when divided.