### PR TITLE
Add shortcut for Chord Inversions

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -247,6 +247,7 @@ protected slots:
 	void clearGhostClip();
 	void glueNotes();
 	void fitNoteLengths(bool fill);
+	void invertSelection(bool up);
 	void constrainNoteLengths(bool constrainMax);
 
 	void changeSnapMode();


### PR DESCRIPTION
This PR adds the ability to invert a selection of notes in the PianoRoll, where the top note moves down `n` octaves/bottom note moves up `n` octaves. This feature works on selections of notes too, moving all notes on the min/max key up/down. It also works on microtonal scales which may have different octave sizes.

![image](https://github.com/user-attachments/assets/1e7c52e4-8003-4bd0-a369-4793737c446e)

The icons probably need to be changed. Also I think the two options might take up too much space in the menu. I was thinking of adding a sub menu, but I'm not sure Qt allows that.

https://github.com/user-attachments/assets/3b93cb8b-2a8c-4f6a-af25-c863c339303e


