### PR TITLE
Fix more warnings when Carla is missing

### DIFF
--- a/cmake/linux/apprun-hooks/carla-hook.sh
+++ b/cmake/linux/apprun-hooks/carla-hook.sh
@@ -25,7 +25,7 @@ if command -v carla > /dev/null 2>&1; then
 else
 	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing." >&2
 	export "LMMS_EXCLUDE_PLUGINS=libcarla,${LMMS_EXCLUDE_PLUGINS}"
-	export "LMMS_LADSPA_EXCLUDE_PLUGINS=libcarla,${LMMS_LADSPA_EXCLUDE_PLUGINS}"
+	export "LMMS_EXCLUDE_LADSPA=libcarla,${LMMS_EXCLUDE_LADSPA}"
 fi
 
 # Additional workarounds for library conflicts

--- a/cmake/linux/apprun-hooks/carla-hook.sh
+++ b/cmake/linux/apprun-hooks/carla-hook.sh
@@ -25,6 +25,7 @@ if command -v carla > /dev/null 2>&1; then
 else
 	echo "[$ME] Carla does not appear to be installed, we'll remove it from the plugin listing." >&2
 	export "LMMS_EXCLUDE_PLUGINS=libcarla,${LMMS_EXCLUDE_PLUGINS}"
+	export "LMMS_LADSPA_EXCLUDE_PLUGINS=libcarla,${LMMS_LADSPA_EXCLUDE_PLUGINS}"
 fi
 
 # Additional workarounds for library conflicts

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -61,7 +61,7 @@ public:
 	~PluginFactory() = default;
 
 	static void setupSearchPaths();
-	static QList<QRegularExpression> getExcludePatterns(const char*);
+	static QList<QRegularExpression> getExcludePatterns(const char* envVar);
 
 	/// Returns the singleton instance of PluginFactory. You won't need to call
 	/// this directly, use pluginFactory instead.

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -61,6 +61,7 @@ public:
 	~PluginFactory() = default;
 
 	static void setupSearchPaths();
+	static QList<QRegularExpression> getExcludePatterns(const char*);
 
 	/// Returns the singleton instance of PluginFactory. You won't need to call
 	/// this directly, use pluginFactory instead.

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -82,7 +82,7 @@ LadspaManager::LadspaManager()
 				continue;
 			}
 
-			if(!f.isFile() || f.fileName().right( 3 ).toLower() !=
+			if (!f.isFile() || f.fileName().right(3).toLower() !=
 #ifdef LMMS_BUILD_WIN32
 													"dll"
 #else

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -79,11 +79,7 @@ LadspaManager::LadspaManager()
 				}
 			}
 
-			if (exclude) {
-				continue;
-			}
-
-			if (!f.isFile() || f.fileName().right(3).toLower() !=
+			if (exclude || !f.isFile() || f.fileName().right(3).toLower() !=
 #ifdef LMMS_BUILD_WIN32
 													"dll"
 #else

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -72,8 +72,8 @@ LadspaManager::LadspaManager()
 		for (const auto& f : list)
 		{
 			bool exclude = false;
-			for(const auto& pattern : excludePatterns) {
-				if(pattern.match(f.filePath()).hasMatch()) {
+			for (const auto& pattern : excludePatterns) {
+				if (pattern.match(f.filePath()).hasMatch()) {
 					exclude = true;
 				}
 			}

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -28,6 +28,8 @@
 #include <QDebug>
 #include <QDir>
 #include <QLibrary>
+#include <QList>
+#include <QRegularExpression>
 
 #include <cmath>
 
@@ -44,6 +46,8 @@ LadspaManager::LadspaManager()
 {
 	// Make sure plugin search paths are set up
 	PluginFactory::setupSearchPaths();
+
+	QList<QRegularExpression> excludePatterns = PluginFactory::getExcludePatterns("LMMS_LADSPA_EXCLUDE_PLUGINS");
 
 	QStringList ladspaDirectories = QString( getenv( "LADSPA_PATH" ) ).
 								split( LADSPA_PATH_SEPERATOR );
@@ -67,7 +71,18 @@ LadspaManager::LadspaManager()
 		QFileInfoList list = directory.entryInfoList();
 		for (const auto& f : list)
 		{
-				if(!f.isFile() || f.fileName().right( 3 ).toLower() !=
+			bool exclude = false;
+			for(const auto& pattern : excludePatterns) {
+				if(pattern.match(f.filePath()).hasMatch()) {
+					exclude = true;
+				}
+			}
+
+			if (exclude) {
+				continue;
+			}
+
+			if(!f.isFile() || f.fileName().right( 3 ).toLower() !=
 #ifdef LMMS_BUILD_WIN32
 													"dll"
 #else

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -47,7 +47,7 @@ LadspaManager::LadspaManager()
 	// Make sure plugin search paths are set up
 	PluginFactory::setupSearchPaths();
 
-	QList<QRegularExpression> excludePatterns = PluginFactory::getExcludePatterns("LMMS_LADSPA_EXCLUDE_PLUGINS");
+	QList<QRegularExpression> excludePatterns = PluginFactory::getExcludePatterns("LMMS_EXCLUDE_LADSPA");
 
 	QStringList ladspaDirectories = QString( getenv( "LADSPA_PATH" ) ).
 								split( LADSPA_PATH_SEPERATOR );

--- a/src/core/LadspaManager.cpp
+++ b/src/core/LadspaManager.cpp
@@ -75,6 +75,7 @@ LadspaManager::LadspaManager()
 			for (const auto& pattern : excludePatterns) {
 				if (pattern.match(f.filePath()).hasMatch()) {
 					exclude = true;
+					break;
 				}
 			}
 

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -262,7 +262,7 @@ QList<QRegularExpression> PluginFactory::getExcludePatterns(const char* envVar) 
 			}
 			QRegularExpression regex(pattern.trimmed());
 			if (regex.isValid()) {
-				excludedPatterns << regex;
+				excludePatterns << regex;
 			} else {
 				qWarning() << "Invalid regular expression:" << pattern;
 			}

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -257,7 +257,7 @@ QList<QRegularExpression> PluginFactory::getExcludePatterns(const char* envVar) 
 	if (!excludePatternString.isEmpty()) {
 		QStringList patterns = excludePatternString.split(',');
 		for (const QString& pattern : patterns) {
-			if(pattern.trimmed().isEmpty()) {
+			if (pattern.trimmed().isEmpty()) {
 				continue;
 			}
 			QRegularExpression regex(pattern.trimmed());

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -258,8 +258,11 @@ void PluginFactory::filterPlugins(QSet<QFileInfo>& files) {
 	if (!excludePatternString.isEmpty()) {
 		QStringList patterns = excludePatternString.split(',');
 		for (const QString& pattern : patterns) {
+			if(pattern.trimmed().isEmpty()) {
+				continue;
+			}
 			QRegularExpression regex(pattern.trimmed());
-			if (!pattern.trimmed().isEmpty() && regex.isValid()) {
+			if (regex.isValid()) {
 				excludedPatterns << regex;
 			} else {
 				qWarning() << "Invalid regular expression:" << pattern;

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -275,7 +275,7 @@ QList<QRegularExpression> PluginFactory::getExcludePatterns(const char* envVar) 
 void PluginFactory::filterPlugins(QSet<QFileInfo>& files) {
 	// Get filter
 	QList<QRegularExpression> excludePatterns = getExcludePatterns("LMMS_EXCLUDE_PLUGINS");
-	if(excludePatterns.size() == 0) {
+	if (excludePatterns.isEmpty()) {
 		return;
 	}
 


### PR DESCRIPTION
Fix a regex warning when `LMMS_EXCLUDE_PLUGINS` has a trailing comma.

```
Invalid regular expression: ""
```

... also fixes more library loading console messages.

Related #7691