### PR TITLE
Center PianoView in resizeable plugins (SlicerT)

### DIFF
--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -264,9 +264,11 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	m_tabWidget->addTab(m_tuningView, tr("Tuning and transposition"), "tuning_tab", 5);
 
 	// setup piano-widget
+	auto pianoLayout = new QHBoxLayout(this);
 	m_pianoView = new PianoView( this );
 	m_pianoView->setMinimumHeight( PIANO_HEIGHT );
 	m_pianoView->setMaximumHeight( PIANO_HEIGHT );
+	pianoLayout->addWidget(m_pianoView);
 
 	// setup sizes and policies
 	generalSettingsWidget->setMaximumHeight(90);
@@ -277,7 +279,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	// Use QWidgetItem explicitly to make the size hint change on instrument changes
 	// QLayout::addWidget() uses QWidgetItemV2 with size hint caching
 	vlayout->insertItem(1, new QWidgetItem(m_tabWidget));
-	vlayout->addWidget( m_pianoView );
+	vlayout->addLayout(pianoLayout);
 	setModel( _itv->model() );
 
 	updateInstrumentView();


### PR DESCRIPTION
Now that the instrument window for SlicerT is resizeable, one of the many issues is that the piano at the bottom of the window is not centered when you resize the window to be larger than the piano width. This PR attempts to fix that.

Before:

![image](https://github.com/user-attachments/assets/44c402db-6c40-42c4-a2ee-e3701f3babf0)


After:

![image](https://github.com/user-attachments/assets/b8fd4686-d0af-4c32-acdf-179becfd5e2e)



Simply setting the alignment of the piano view to `Qt::AlignHCenter` did not work, since that broke the automatic resizing. However, putting the piano view into a `QHBoxLayout` and putting that into the instrument window worked nicely.

However, I would like to get someone's opinion on whether I am managing the layout pointer correctly. Passing `this` as the parent for the layout caused warnings, since that automatically tries to set the layout as the default layout for the parent. Should I leave it as is and add an explicit call to `setParent(this)` to make sure `this` is responsible for deleting the layout?