### PR TITLE
Fix ZynAddSubFX preset regression

### DIFF
--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -181,6 +181,9 @@ void ZynAddSubFxInstrument::saveSettings( QDomDocument & _doc,
 	m_resCenterFreqModel.saveSettings( _doc, _this, "rescenterfreq" );
 	m_resBandwidthModel.saveSettings( _doc, _this, "resbandwidth" );
 
+	// We always modify the cutoff freq (see CTOR), so save this change
+	m_modifiedControllers[C_filtercutoff] = true;
+
 	QString modifiedControllers;
 	for( QMap<int, bool>::ConstIterator it = m_modifiedControllers.begin();
 									it != m_modifiedControllers.end(); ++it )
@@ -319,6 +322,10 @@ void ZynAddSubFxInstrument::loadFile( const QString & _file )
 	instrumentTrack()->setName(QFileInfo(_file).baseName().replace(QRegularExpression("^[0-9]{4}-"), QString()));
 
 	m_modifiedControllers.clear();
+
+	// While we use "100" in the CTOR, for old XIZ files, we use the old value
+	m_filterFreqModel.setValue(64);
+	updateFilterFreq();
 
 	emit settingsChanged();
 }


### PR DESCRIPTION
Attempting to fix #7720 . ~~I think this is wrong yet, because the VK in Zyn has different filter freq than the Piano in LMMS.~~

Please test or give feedback.

Credits to the idea of this fix go to LostRobot.