### PR TITLE
Fix Envelope and LFO Graph Size on Resizeable Instruments

### DIFF
--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -28,6 +28,7 @@
 #include <string_view>
 
 #include <QBoxLayout>
+#include <QSizePolicy>
 
 #include "EnvelopeGraph.h"
 #include "LfoGraph.h"
@@ -85,6 +86,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 
 	m_envelopeGraph = new EnvelopeGraph(this);
 	graphAndAmountLayout->addWidget(m_envelopeGraph);
+	m_envelopeGraph->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
 	m_amountKnob = buildKnob(tr("AMT"), tr("Modulation amount:"));
 	graphAndAmountLayout->addWidget(m_amountKnob, 0, Qt::AlignCenter);
@@ -124,6 +126,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	lfoLayout->addLayout(graphAndTypesLayout);
 
 	m_lfoGraph = new LfoGraph(this);
+	m_lfoGraph->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	graphAndTypesLayout->addWidget(m_lfoGraph);
 
 	QHBoxLayout* typesLayout = new QHBoxLayout();


### PR DESCRIPTION
This PR changes the size policies of the layouts holding the LFO and Envelope graphs which makes them a bit more usable with resizeable instruments such as SlicerT.

Before:

![image](https://github.com/user-attachments/assets/2c90cda8-983e-4553-9492-280e332887ed)

After:

![image](https://github.com/user-attachments/assets/4c35a882-0ad2-4cd8-8e8d-7b1e75c5db1c)

Unfortunately, the text in the graphs is part of the texture, so more work will have to be done to make that more flexible (in a separate PR).
