### PR TITLE
Revert "Change tooltip window flags"

### DIFF
--- a/src/gui/widgets/TextFloat.cpp
+++ b/src/gui/widgets/TextFloat.cpp
@@ -44,7 +44,7 @@ TextFloat::TextFloat() :
 }
 
 TextFloat::TextFloat(const QString & title, const QString & text, const QPixmap & pixmap) :
-	QWidget(getGUI()->mainWindow(), Qt::Tool | Qt::FramelessWindowHint)
+	QWidget(getGUI()->mainWindow(), Qt::ToolTip)
 {
 	QHBoxLayout * mainLayout = new QHBoxLayout();
 	setLayout(mainLayout);


### PR DESCRIPTION
I heard a report that on certain desktop envs/window managers(?), `TextFloat`s are now being auto-focused when they appear, making it almost impossible to drag clips. I am not an expert in Qt window flags, and I do not think I was qualified to make that PR in the first place.