### PR TITLE
Fix Clip Creation Quantization in Song Editor

### DIFF
--- a/include/TimePos.h
+++ b/include/TimePos.h
@@ -70,7 +70,7 @@ public:
 	TimePos( const bar_t bar, const tick_t ticks );
 	TimePos( const tick_t ticks = 0 );
 
-	TimePos quantize(float) const;
+	TimePos quantize(float bars, bool forceRoundDown = false) const;
 	TimePos toAbsoluteBar() const { return getBar() * s_ticksPerBar; }
 
 	TimePos& operator+=(const TimePos& time)

--- a/src/core/TimePos.cpp
+++ b/src/core/TimePos.cpp
@@ -53,7 +53,7 @@ TimePos::TimePos( const tick_t ticks ) :
 {
 }
 
-TimePos TimePos::quantize(float bars) const
+TimePos TimePos::quantize(float bars, bool forceRoundDown) const
 {
 	//The intervals we should snap to, our new position should be a factor of this
 	int interval = s_ticksPerBar * bars;
@@ -65,7 +65,7 @@ TimePos TimePos::quantize(float bars) const
 	// Ternary expression is making sure that the snap happens in the direction to
 	// the right even if m_ticks is negative and the offset is exactly half-way
 	// More details on issue #5840 and PR #5847
-	int snapUp = ((2 * offset) == -interval)
+	int snapUp = forceRoundDown || ((2 * offset) == -interval)
 		? 0
 		: (2 * offset) / interval;
 

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -217,8 +217,7 @@ void SampleTrackView::dropEvent(QDropEvent *de)
 				? TimePos(0)
 				: TimePos(((xPos - trackHeadWidth) / trackContainerView()->pixelsPerBar()
 							* TimePos::ticksPerBar()) + trackContainerView()->currentPosition()
-							- TimePos::ticksPerBar() * snapSize / 2
-						).quantize(snapSize);
+						).quantize(snapSize, true);
 
 		auto sClip = static_cast<SampleClip*>(getTrack()->createClip(clipPos));
 		if (sClip) { sClip->setSampleFile(value); }

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -37,6 +37,7 @@
 #include "Knob.h"
 #include "SampleClip.h"
 #include "SampleTrackWindow.h"
+#include "SongEditor.h"
 #include "StringPairDrag.h"
 #include "TrackContainerView.h"
 #include "TrackLabelButton.h"
@@ -211,11 +212,13 @@ void SampleTrackView::dropEvent(QDropEvent *de)
 				? trackHeadWidth
 				: de->pos().x();
 
+		const float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
 		TimePos clipPos = trackContainerView()->fixedClips()
 				? TimePos(0)
 				: TimePos(((xPos - trackHeadWidth) / trackContainerView()->pixelsPerBar()
 							* TimePos::ticksPerBar()) + trackContainerView()->currentPosition()
-						).quantize(1.0);
+							- TimePos::ticksPerBar() * snapSize / 2
+						).quantize(snapSize);
 
 		auto sClip = static_cast<SampleClip*>(getTrack()->createClip(clipPos));
 		if (sClip) { sClip->setSampleFile(value); }

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -599,7 +599,7 @@ void TrackContentWidget::mousePressEvent( QMouseEvent * me )
 		}
 		getTrack()->addJournalCheckPoint();
 		const float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
-		const TimePos pos = TimePos(getPosition(me->x()) - TimePos::ticksPerBar() * snapSize / 2).quantize(snapSize);
+		const TimePos pos = TimePos(getPosition(me->x())).quantize(snapSize, true);
 		getTrack()->createClip(pos);
 	}
 }

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -598,9 +598,8 @@ void TrackContentWidget::mousePressEvent( QMouseEvent * me )
 			so.at( i )->setSelected( false);
 		}
 		getTrack()->addJournalCheckPoint();
-		const tick_t snapSizeTicks = getGUI()->songEditor()->m_editor->getSnapSize() * TimePos::ticksPerBar();
-		// Manually quantize with modulo to ensure the position is always rounded down.
-		const TimePos pos = getPosition(me->x()).getTicks() - (getPosition(me->x()).getTicks() % snapSizeTicks);
+		const float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
+		const TimePos pos = TimePos(getPosition(me->x()) - TimePos::ticksPerBar() * snapSize / 2).quantize(snapSize);
 		getTrack()->createClip(pos);
 	}
 }

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -598,8 +598,9 @@ void TrackContentWidget::mousePressEvent( QMouseEvent * me )
 			so.at( i )->setSelected( false);
 		}
 		getTrack()->addJournalCheckPoint();
-		const TimePos pos = getPosition( me->x() ).getBar() *
-						TimePos::ticksPerBar();
+		const tick_t snapSizeTicks = getGUI()->songEditor()->m_editor->getSnapSize() * TimePos::ticksPerBar();
+		// Manually quantize with modulo to ensure the position is always rounded down.
+		const TimePos pos = getPosition(me->x()).getTicks() - (getPosition(me->x()).getTicks() % snapSizeTicks);
 		getTrack()->createClip(pos);
 	}
 }


### PR DESCRIPTION
When you click to add a clip on a track in the Song Editor, it adds it quantized to the previous bar, no matter what the snap size is set to. Similarly, when dragging a sample from the sidebar onto a sample track, the sample clip is created quantized to the last bar, ignoring the snap size.

This PR addresses this issue by adding proper quantization based on the song editor snap size (also subtracting half of the snap size so that it always rounds down).