### PR TITLE
Fix SVG Scaling; Allow SVGs to be rendered at sizes other than their natural size.

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -369,6 +369,7 @@ int main( int argc, char * * argv )
 	}
 #endif
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+	// QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QCoreApplication * app = coreOnly ?
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -369,7 +369,7 @@ int main( int argc, char * * argv )
 	}
 #endif
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	// QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QCoreApplication * app = coreOnly ?
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -369,7 +369,6 @@ int main( int argc, char * * argv )
 	}
 #endif
 	QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-	QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 	QCoreApplication * app = coreOnly ?
 			new QCoreApplication( argc, argv ) :
 					new gui::MainApplication(argc, argv);

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -42,9 +42,7 @@ auto loadSvgPixmap(const QString& resourceName, int width, int height) -> QPixma
 {
 	// QFile requires the file extension to be present, unlike QImageReader
 	QString fileName = resourceName;
-	if (!fileName.endsWith(".svg", Qt::CaseInsensitive)) {
-		fileName += ".svg";
-	}
+	if (!fileName.endsWith(".svg", Qt::CaseInsensitive)) { fileName += ".svg"; }
 
 	QFile file(fileName);
 	if (!file.open(QIODevice::ReadOnly))

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -43,15 +43,13 @@ auto loadPixmap(const QString& name, int width, int height, const char* const* x
 
 	const auto resourceName = QDir::isAbsolutePath(name) ? name : "artwork:" + name;
 
-	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-
 	// Check if the resource is an SVG or a raster image
 	QImageReader reader(resourceName);
 	const QByteArray format = reader.format();
 
 	if (format.toLower() == "svg")
 	{
-		// Handle SVG with QSvgRenderer
+		// Handle SVG with QSvgRenderer. QFile requires the file extension to be present, unlike QPixmap
 		QFile file(resourceName + ".svg");
 		if (!file.open(QIODevice::ReadOnly))
 		{
@@ -75,6 +73,7 @@ auto loadPixmap(const QString& name, int width, int height, const char* const* x
 		if (height >= 0) svgSize.setHeight(height);
 
 		// Scale the svg
+		qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
 		svgSize.setWidth(static_cast<int>(svgSize.width() * devicePixelRatio));
 		svgSize.setHeight(static_cast<int>(svgSize.height() * devicePixelRatio));
 

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -64,15 +64,13 @@ auto loadSvgPixmap(const QString& resourceName, int width, int height) -> QPixma
 	QSize svgSize = renderer.defaultSize();
 
 	// If width/height are provided, use them
-	if (width >= 0) svgSize.setWidth(width);
-	if (height >= 0) svgSize.setHeight(height);
+	if (width > 0 && height > 0) svgSize.scale(width, height, Qt::IgnoreAspectRatio);
 
 	// Scale the svg
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
-	svgSize.setWidth(static_cast<int>(svgSize.width() * devicePixelRatio));
-	svgSize.setHeight(static_cast<int>(svgSize.height() * devicePixelRatio));
+	svgSize *= devicePixelRatio;
 
-	QImage image(svgSize.width(), svgSize.height(), QImage::Format_ARGB32);
+	QImage image(svgSize, QImage::Format_ARGB32);
 	image.fill(Qt::transparent);
 	QPainter painter(&image);
 	renderer.render(&painter);

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -39,72 +39,74 @@ namespace {
 
 auto loadPixmap(const QString& name, int width, int height, const char* const* xpm) -> QPixmap
 {
-    if (xpm) { return QPixmap{xpm}; }
+	if (xpm) { return QPixmap{xpm}; }
 
-    const auto resourceName = QDir::isAbsolutePath(name) ? name : "artwork:" + name;
+	const auto resourceName = QDir::isAbsolutePath(name) ? name : "artwork:" + name;
 
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();
 
-    // Check if the resource is an SVG or a raster image
-    QImageReader reader(resourceName);
-    const QByteArray format = reader.format();
+	// Check if the resource is an SVG or a raster image
+	QImageReader reader(resourceName);
+	const QByteArray format = reader.format();
 
-    if (format.toLower() == "svg") {
-        // Handle SVG with QSvgRenderer
-        QFile file(resourceName + ".svg");
-        if (!file.open(QIODevice::ReadOnly)) {
-            qWarning() << "Failed to open resource for SVG: " << resourceName;
-            return QPixmap{1, 1};
-        }
+	if (format.toLower() == "svg")
+	{
+		// Handle SVG with QSvgRenderer
+		QFile file(resourceName + ".svg");
+		if (!file.open(QIODevice::ReadOnly))
+		{
+			qWarning() << "Failed to open resource for SVG: " << resourceName;
+			return QPixmap{1, 1};
+		}
 
-        QByteArray svgData = file.readAll();
-        QSvgRenderer renderer(svgData);
-        if (!renderer.isValid()) {
-            qWarning() << "Error loading SVG file: " << resourceName;
-            return QPixmap{1, 1};
-        }
+		QByteArray svgData = file.readAll();
+		QSvgRenderer renderer(svgData);
+		if (!renderer.isValid())
+		{
+			qWarning() << "Error loading SVG file: " << resourceName;
+			return QPixmap{1, 1};
+		}
 
-    	// Get the default size of the SVG (without scaling)
-    	QSize svgSize = renderer.defaultSize();
+		// Get the default size of the SVG (without scaling)
+		QSize svgSize = renderer.defaultSize();
 
-    	// If width/height are provided, use them
-    	if (width >= 0) svgSize.setWidth(width);
-    	if (height >= 0) svgSize.setHeight(height);
+		// If width/height are provided, use them
+		if (width >= 0) svgSize.setWidth(width);
+		if (height >= 0) svgSize.setHeight(height);
 
-    	// Scale the svg
-    	svgSize.setWidth(static_cast<int>(svgSize.width() * devicePixelRatio));
-    	svgSize.setHeight(static_cast<int>(svgSize.height() * devicePixelRatio));
+		// Scale the svg
+		svgSize.setWidth(static_cast<int>(svgSize.width() * devicePixelRatio));
+		svgSize.setHeight(static_cast<int>(svgSize.height() * devicePixelRatio));
 
-        QImage image(svgSize.width(), svgSize.height(), QImage::Format_ARGB32);
-        image.fill(Qt::transparent);
-        QPainter painter(&image);
-        renderer.render(&painter);
-    	painter.end();
+		QImage image(svgSize.width(), svgSize.height(), QImage::Format_ARGB32);
+		image.fill(Qt::transparent);
+		QPainter painter(&image);
+		renderer.render(&painter);
+		painter.end();
 
-    	auto pixmap = QPixmap::fromImage(image);
-    	pixmap.setDevicePixelRatio(devicePixelRatio);
+		auto pixmap = QPixmap::fromImage(image);
+		pixmap.setDevicePixelRatio(devicePixelRatio);
 
-        return pixmap;
-    }
+		return pixmap;
+	}
 
-	if (!format.isEmpty()) {
-        // Handle other formats (PNG, JPG, etc.) with QImageReader
-        if (width > 0 && height > 0) {
-            reader.setScaledSize(QSize(width, height));
-        }
+	if (!format.isEmpty())
+	{
+		// Handle other formats (PNG, JPG, etc.) with QImageReader
+		if (width > 0 && height > 0) { reader.setScaledSize(QSize(width, height)); }
 
-        QPixmap pixmap = QPixmap::fromImageReader(&reader);
-        if (pixmap.isNull()) {
-            qWarning().nospace() << "Error loading icon pixmap " << name << ": " << reader.errorString();
-            return QPixmap{1, 1};
-        }
-        return pixmap;
-    }
+		QPixmap pixmap = QPixmap::fromImageReader(&reader);
+		if (pixmap.isNull())
+		{
+			qWarning().nospace() << "Error loading icon pixmap " << name << ": " << reader.errorString();
+			return QPixmap{1, 1};
+		}
+		return pixmap;
+	}
 
-    qWarning() << "Unsupported image format: " << resourceName;
-    return QPixmap{1, 1};
+	qWarning() << "Unsupported image format: " << resourceName;
+	return QPixmap{1, 1};
 }
-
 
 } // namespace
 

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -24,7 +24,7 @@
 
 #include "embed.h"
 
-#include <QDIR>
+#include <QDir>
 #include <QGuiApplication>
 #include <QImageReader>
 #include <QPainter>

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -40,8 +40,13 @@ namespace {
 // QPixmapCache and HiDPI compatible SVG-->QPixmap wrapper
 auto loadSvgPixmap(const QString& resourceName, int width, int height) -> QPixmap
 {
-	// Handle SVG with QSvgRenderer. QFile requires the file extension to be present, unlike QImageReader
-	QFile file(resourceName + ".svg");
+	// QFile requires the file extension to be present, unlike QImageReader
+	QString fileName = resourceName;
+	if (!fileName.endsWith(".svg", Qt::CaseInsensitive)) {
+		fileName += ".svg";
+	}
+
+	QFile file(fileName);
 	if (!file.open(QIODevice::ReadOnly))
 	{
 		qWarning() << "Failed to open resource for SVG: " << resourceName;

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -62,7 +62,7 @@ auto loadSvgPixmap(const QString& resourceName, int width, int height) -> QPixma
 	QSize svgSize = renderer.defaultSize();
 
 	// If width/height are provided, use them
-	if (width > 0 && height > 0) svgSize.scale(width, height, Qt::IgnoreAspectRatio);
+	if (width > 0 && height > 0) { svgSize.scale(width, height, Qt::IgnoreAspectRatio); }
 
 	// Scale the svg
 	qreal devicePixelRatio = QGuiApplication::primaryScreen()->devicePixelRatio();

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -108,7 +108,9 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 		const auto activePixmap = embed::getIconPixmap(activeGraphic);
 		const auto inactivePixmap = embed::getIconPixmap(inactiveGraphic);
 
-		auto necessarySize = activePixmap.size().expandedTo(inactivePixmap.size());
+		const auto activeSize = activePixmap.size() / activePixmap.devicePixelRatio();
+		const auto inactiveSize = inactivePixmap.size() / inactivePixmap.devicePixelRatio();
+		auto necessarySize = activeSize.expandedTo(inactiveSize);
 
 		auto wrapperWidget = new QWidget(parent);
 		wrapperWidget->setFixedSize(necessarySize);

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -108,18 +108,15 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 		const auto activePixmap = embed::getIconPixmap(activeGraphic);
 		const auto inactivePixmap = embed::getIconPixmap(inactiveGraphic);
 
-		const auto activeSize = activePixmap.size() / activePixmap.devicePixelRatio();
-		const auto inactiveSize = inactivePixmap.size() / inactivePixmap.devicePixelRatio();
-		auto necessarySize = activeSize.expandedTo(inactiveSize);
-
 		auto wrapperWidget = new QWidget(parent);
-		wrapperWidget->setFixedSize(necessarySize);
 
 		auto button = new PixmapButton(wrapperWidget, toolTip);
 		button->setCheckable(true);
 		button->setActiveGraphic(activePixmap);
 		button->setInactiveGraphic(inactivePixmap);
 		button->setToolTip(toolTip);
+
+		wrapperWidget->setFixedSize(button->minimumSizeHint());
 
 		pixmapButton = button;
 

--- a/src/gui/widgets/PixmapButton.cpp
+++ b/src/gui/widgets/PixmapButton.cpp
@@ -107,7 +107,7 @@ void PixmapButton::mouseDoubleClickEvent( QMouseEvent * _me )
 void PixmapButton::setActiveGraphic( const QPixmap & _pm )
 {
 	m_activePixmap = _pm;
-	resize( m_activePixmap.width(), m_activePixmap.height() );
+	resize(m_activePixmap.size() / m_activePixmap.devicePixelRatio());
 }
 
 
@@ -129,7 +129,9 @@ QSize PixmapButton::sizeHint() const
 
 QSize PixmapButton::minimumSizeHint() const
 {
-	return m_activePixmap.size().expandedTo(m_inactivePixmap.size());
+	const auto activeSize = m_activePixmap.size() / m_activePixmap.devicePixelRatio();
+	const auto inactiveSize = m_inactivePixmap.size() / m_inactivePixmap.devicePixelRatio();
+	return activeSize.expandedTo(inactiveSize);
 }
 
 bool PixmapButton::isActive() const


### PR DESCRIPTION
Fix svg scaling (especially on hidpi displays) by switching to `QSvgRenderer` in `embed::loadPixmap`.

fixes one step of #7767
> embed::getIconPixmap() quality is ["stuck"](https://github.com/user-attachments/assets/dd75605d-4d55-4efc-b6ef-6852c9f3daf4) at an SVGs "natural" resolution.

To test:
```bash
 QT_SCALE_FACTOR=4 ./lmms
```

<img width="405" alt="image" src="https://github.com/user-attachments/assets/37a9d647-4d19-4108-94a0-d54a7180ee06" />

> [!NOTE]
> Observe the quality of the new mute/solo buttons

