### PR TITLE
Fix crash when switching opened projects

### DIFF
--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -369,7 +369,7 @@ int Fader::calculateKnobPosYFromModel() const
 	else
 	{
 		// The model is in dB so we just show that in a linear fashion
-
+		
 		auto const clampedValue = std::clamp(value, minV, maxV);
 
 		auto const ratio = (clampedValue - minV) / (maxV - minV);

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -369,7 +369,7 @@ int Fader::calculateKnobPosYFromModel() const
 	else
 	{
 		// The model is in dB so we just show that in a linear fashion
-		
+
 		auto const clampedValue = std::clamp(value, minV, maxV);
 
 		auto const ratio = (clampedValue - minV) / (maxV - minV);
@@ -512,9 +512,16 @@ void Fader::modelValueChanged()
 
 QString Fader::getModelValueAsDbString() const
 {
-	const auto value = model()->value();
-
 	QString label(tr("Volume: %1 dB"));
+	// Check that the pointer isn't dangling, which can happen if the
+	// model was dropped in order to load a new project from an existing one.
+	auto* newModel = model();
+	if (!newModel)
+	{
+		// model() was a dangling pointer, so return a sane default value.
+		return label.arg(tr("-inf"));
+	}
+	const auto value = newModel->value();
 
 	if (modelIsLinear())
 	{


### PR DESCRIPTION
When the DAW is already running and you attempt to open another project
via File > Open (or probably when you switch projects via any other
method as well), a segfault previously occurred.

The crash seems to have been caused by `model()->value()`, which was
called in `Fader::getModelValueAsDbString()`. The `model()` function
looked like it should return a pointer to an AutomatableModel.

I suspect that when a model was dropped in favor of loading models for
a new project, the AutomatableModel pointer became a null pointer.

Add a check to the pointer returned by `model()` to confirm it's
true-ish (E.g. not a null pointer) before calling any member
functions we expect to exist. This fixes the crash.

Fixes #7793