### PR TITLE
Enable CMAKE_EXPORT_COMPILE_COMMANDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
+SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Set the given policy to NEW. If it does not exist, it will not be set. If it
 # is already set to NEW (most likely due to predating the minimum required CMake


### PR DESCRIPTION
This setting instructs CMake to generate `compile_commands.json` for use with `clangd`. This is useful for those of us who don't use an IDE, and doesn't place any significant strain on the build system, since it's just CMake writing down stuff it already has to compute in the first place.

Enabling this is already possible when invoking `cmake` by passing `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`, but I'm sick of typing that out, lmao