### PR TITLE
Fix microtuning warning text widening instruments

### DIFF
--- a/src/gui/instrument/InstrumentSoundShapingView.cpp
+++ b/src/gui/instrument/InstrumentSoundShapingView.cpp
@@ -85,7 +85,6 @@ InstrumentSoundShapingView::InstrumentSoundShapingView(QWidget* parent) :
 	m_singleStreamInfoLabel->setWordWrap(true);
 	// TODO Could also be rendered in system font size...
 	m_singleStreamInfoLabel->setFont(adjustedToPixelSize(m_singleStreamInfoLabel->font(), DEFAULT_FONT_SIZE));
-	m_singleStreamInfoLabel->setFixedWidth(242);
 
 	mainLayout->addWidget(m_singleStreamInfoLabel, 0, Qt::AlignTop);
 }

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -480,10 +480,15 @@ void InstrumentTrackWindow::updateInstrumentView()
 		m_tabWidget->addTab( m_instrumentView, tr( "Plugin" ), "plugin_tab", 0 );
 		m_tabWidget->setActiveTab( 0 );
 
-		const auto maxSize = QSize{
-			std::max(INSTRUMENT_WIDTH, m_instrumentView->width()),
-			std::max(INSTRUMENT_HEIGHT, m_instrumentView->height()),
-		};
+		// If instrument is resizable, unset size constraints on tabs.
+		// Otherwise, prevent other tabs from exceeding the size of the
+		// instrument tab
+		const auto maxSize = m_instrumentView->isResizable()
+			? QSize{QWIDGETSIZE_MAX, QWIDGETSIZE_MAX}
+			: QSize{
+				std::max(INSTRUMENT_WIDTH, m_instrumentView->width()),
+				std::max(INSTRUMENT_HEIGHT, m_instrumentView->maximumHeight()),
+			};
 		m_tabWidget->setMaximumSize(maxSize);
 		// Individual tabs must also have their maximum widths set,
 		// otherwise they will remain wide, and their overflowing contents
@@ -770,6 +775,9 @@ void InstrumentTrackWindow::updateSubWindow()
 		}
 		else
 		{
+			subWindow->setMaximumSize(m_instrumentView->maximumSize());
+			subWindow->setMinimumSize(m_instrumentView->minimumSize());
+
 			flags |= Qt::MSWindowsFixedSizeDialogHint;
 			flags &= ~Qt::WindowMaximizeButtonHint;
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -480,6 +480,20 @@ void InstrumentTrackWindow::updateInstrumentView()
 		m_tabWidget->addTab( m_instrumentView, tr( "Plugin" ), "plugin_tab", 0 );
 		m_tabWidget->setActiveTab( 0 );
 
+		const auto maxSize = QSize{
+			std::max(INSTRUMENT_WIDTH, m_instrumentView->width()),
+			std::max(INSTRUMENT_HEIGHT, m_instrumentView->height()),
+		};
+		m_tabWidget->setMaximumSize(maxSize);
+		// Individual tabs must also have their maximum widths set,
+		// otherwise they will remain wide, and their overflowing contents
+		// will get clipped.
+		m_ssView->setMaximumSize(maxSize);
+		m_instrumentFunctionsView->setMaximumSize(maxSize);
+		m_effectView->setMaximumSize(maxSize);
+		m_midiView->setMaximumSize(maxSize);
+		m_tuningView->setMaximumSize(maxSize);
+
 		m_ssView->setFunctionsHidden(m_track->m_instrument->isSingleStreamed());
 
 		modelChanged(); 		// Get the instrument window to refresh

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -775,9 +775,6 @@ void InstrumentTrackWindow::updateSubWindow()
 		}
 		else
 		{
-			subWindow->setMaximumSize(m_instrumentView->maximumSize());
-			subWindow->setMinimumSize(m_instrumentView->minimumSize());
-
 			flags |= Qt::MSWindowsFixedSizeDialogHint;
 			flags &= ~Qt::WindowMaximizeButtonHint;
 

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -67,7 +67,13 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 	m_microtunerNotSupportedLabel = new QLabel(tr("Microtuner is not available for MIDI-based instruments."));
 	m_microtunerNotSupportedLabel->setWordWrap(true);
 	m_microtunerNotSupportedLabel->hide();
-	// HACK This is also how InstrumentSoundShapingView does it
+	// HACK Gives the label a fixed width, since the overall window
+	// width is determined by the greatest width from among all tabs,
+	// even if the instrument is an InstrumentViewFixedSize. This is
+	// also how InstrumentSoundShapingView does it
+	// (see d447cb0648cff249f0f4c2311ea17217576354e4).
+	// A better solution for both tab views would be to restrict the
+	// maximum width of all tabs to that of the instrument view tab.
 	m_microtunerNotSupportedLabel->setFixedWidth(242);
 	layout->addWidget(m_microtunerNotSupportedLabel);
 

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -67,14 +67,6 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 	m_microtunerNotSupportedLabel = new QLabel(tr("Microtuner is not available for MIDI-based instruments."));
 	m_microtunerNotSupportedLabel->setWordWrap(true);
 	m_microtunerNotSupportedLabel->hide();
-	// HACK Gives the label a fixed width, since the overall window
-	// width is determined by the greatest width from among all tabs,
-	// even if the instrument is an InstrumentViewFixedSize. This is
-	// also how InstrumentSoundShapingView does it
-	// (see d447cb0648cff249f0f4c2311ea17217576354e4).
-	// A better solution for both tab views would be to restrict the
-	// maximum width of all tabs to that of the instrument view tab.
-	m_microtunerNotSupportedLabel->setFixedWidth(242);
 	layout->addWidget(m_microtunerNotSupportedLabel);
 
 	m_microtunerGroupBox = new GroupBox(tr("MICROTUNER"));

--- a/src/gui/instrument/InstrumentTuningView.cpp
+++ b/src/gui/instrument/InstrumentTuningView.cpp
@@ -67,6 +67,8 @@ InstrumentTuningView::InstrumentTuningView(InstrumentTrack *it, QWidget *parent)
 	m_microtunerNotSupportedLabel = new QLabel(tr("Microtuner is not available for MIDI-based instruments."));
 	m_microtunerNotSupportedLabel->setWordWrap(true);
 	m_microtunerNotSupportedLabel->hide();
+	// HACK This is also how InstrumentSoundShapingView does it
+	m_microtunerNotSupportedLabel->setFixedWidth(242);
 	layout->addWidget(m_microtunerNotSupportedLabel);
 
 	m_microtunerGroupBox = new GroupBox(tr("MICROTUNER"));


### PR DESCRIPTION
Resolves #7798.

The culprit was the little text warning under the instrument tuning view informing the user that MIDI-based instruments do not support the microtuner. The entire instrument window was expanding horizontally to accommodate this. The "fixed size" of the instrument itself has no bearing on the other tabs in the instrument window, it seems.

This PR solves this by setting the width of the other tabs to be no wider than the instrument they belong to.

![Recording 2025-11-04 at 22 26 31](https://github.com/user-attachments/assets/f2fbdd6d-0536-421b-a5f9-8edfd590877b)