### PR TITLE
Make buttons automatable on macOS

### DIFF
--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -29,6 +29,7 @@
 
 #include "CaptionMenu.h"
 #include "StringPairDrag.h"
+#include "KeyboardShortcuts.h"
 
 
 namespace lmms::gui
@@ -111,7 +112,7 @@ void AutomatableButton::contextMenuEvent( QContextMenuEvent * _me )
 void AutomatableButton::mousePressEvent( QMouseEvent * _me )
 {
 	if( _me->button() == Qt::LeftButton &&
-			! ( _me->modifiers() & Qt::ControlModifier ) )
+			! ( _me->modifiers() & KBD_COPY_MODIFIER ) )
 	{
         // User simply clicked, toggle if needed
 		if( isCheckable() )


### PR DESCRIPTION
#7325 changed the shortcut key used for dragging items to an automation track.  Some other shortcuts were missed as part of that PR.  This PR fixes the buttons.  There may still be others.

Fixes #7812 