### PR TITLE
Fix Vestige file browser filter

### DIFF
--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -79,14 +79,14 @@ Plugin::Descriptor Q_DECL_EXPORT  vestige_plugin_descriptor =
 	0x0100,
 	Plugin::Type::Instrument,
 	new PluginPixmapLoader( "logo" ),
-#ifdef LMMS_BUILD_LINUX
-#if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
-	"dll,so",
-#else
-	"so",
-#endif
-#else
+#if defined(LMMS_BUILD_WIN32)
 	"dll",
+#elif defined(LMMS_BUILD_LINUX)
+#	if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
+		"dll,so",
+#	else
+		"so",
+#	endif
 #endif
 	nullptr,
 } ;
@@ -673,14 +673,14 @@ void VestigeInstrumentView::openPlugin()
 
 	// set filters
 	QStringList types;
-#ifdef LMMS_BUILD_LINUX
-#if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
-	types << tr("All VST files (*.dll *.so)")
-		<< tr("Windows VST2 files (*.dll)");
-#endif
-	types << tr("LinuxVST files (*.so)");
-#else
+#if defined(LMMS_BUILD_WIN32)
 	types << tr("VST2 files (*.dll)");
+#elif defined(LMMS_BUILD_LINUX)
+#	if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
+		types << tr("All VST files (*.dll *.so)")
+			<< tr("Windows VST2 files (*.dll)");
+#	endif
+	types << tr("LinuxVST files (*.so)");
 #endif
 
 	ofd.setNameFilters(types);

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -676,13 +676,11 @@ void VestigeInstrumentView::openPlugin()
 #ifdef LMMS_BUILD_LINUX
 #if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
 	types << tr("All VST files (*.dll *.so)")
-		<< tr("Windows VST2 files (*.dll)" )
-		<< tr("LinuxVST files (*.so)");
-#else
-	types << tr("LinuxVST files (*.so)");
+		<< tr("Windows VST2 files (*.dll)");
 #endif
+	types << tr("LinuxVST files (*.so)");
 #else
-	types << tr("VST2 files (*.dll)" )
+	types << tr("VST2 files (*.dll)");
 #endif
 
 	ofd.setNameFilters(types);

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -80,7 +80,11 @@ Plugin::Descriptor Q_DECL_EXPORT  vestige_plugin_descriptor =
 	Plugin::Type::Instrument,
 	new PluginPixmapLoader( "logo" ),
 #ifdef LMMS_BUILD_LINUX
+#if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
 	"dll,so",
+#else
+	"so",
+#endif
 #else
 	"dll",
 #endif
@@ -669,13 +673,19 @@ void VestigeInstrumentView::openPlugin()
 
 	// set filters
 	QStringList types;
-	types << tr( "DLL-files (*.dll)" )
-		<< tr( "EXE-files (*.exe)" )
 #ifdef LMMS_BUILD_LINUX
-		<< tr( "SO-files (*.so)" )
+#if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
+	types << tr("All VST files (*.dll *.so)")
+		<< tr("Windows VST2 files (*.dll)" )
+		<< tr("LinuxVST files (*.so)");
+#else
+	types << tr("LinuxVST files (*.so)");
 #endif
-		;
-	ofd.setNameFilters( types );
+#else
+	types << tr("VST2 files (*.dll)" )
+#endif
+
+	ofd.setNameFilters(types);
 
 	if( m_vi->m_pluginDLL != "" )
 	{

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1222,9 +1222,18 @@ void FileItem::determineFileType()
 		m_type = FileType::Midi;
 		m_handling = FileHandling::ImportAsProject;
 	}
-	else if( ext == "dll"
-#ifdef LMMS_BUILD_LINUX
-		|| ext == "so" 
+	else if (
+#ifdef LMMS_HAVE_VST
+#	if defined(LMMS_BUILD_WIN32)
+		ext == "dll"
+#	elif defined(LMMS_BUILD_LINUX)
+		ext == "so"
+#		if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
+			|| ext == "dll"
+#		endif
+#	endif
+#else
+		false
 #endif
 	)
 	{

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1222,24 +1222,21 @@ void FileItem::determineFileType()
 		m_type = FileType::Midi;
 		m_handling = FileHandling::ImportAsProject;
 	}
-	else if (
 #ifdef LMMS_HAVE_VST
-#	if defined(LMMS_BUILD_WIN32)
-		ext == "dll"
-#	elif defined(LMMS_BUILD_LINUX)
-		ext == "so"
-#		if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
-			|| ext == "dll"
-#		endif
+	else if (
+#	if defined(LMMS_BUILD_LINUX)
+		ext == "so" ||
 #	endif
-#else
+#	if defined(LMMS_HAVE_VST_32) || defined(LMMS_HAVE_VST_64)
+		ext == "dll" ||
+#	endif
 		false
-#endif
 	)
 	{
 		m_type = FileType::VstPlugin;
 		m_handling = FileHandling::LoadByPlugin;
 	}
+#endif
 	else if ( ext == "lv2" )
 	{
 		m_type = FileType::Preset;

--- a/src/lmmsconfig.h.in
+++ b/src/lmmsconfig.h.in
@@ -33,6 +33,8 @@
 #cmakedefine LMMS_HAVE_SDL
 #cmakedefine LMMS_HAVE_STK
 #cmakedefine LMMS_HAVE_VST
+#cmakedefine LMMS_HAVE_VST_32
+#cmakedefine LMMS_HAVE_VST_64
 #cmakedefine LMMS_HAVE_SF_COMPLEVEL
 
 #cmakedefine LMMS_DEBUG_FPE


### PR DESCRIPTION
The Vestige file browser filter has a number of issues:

- Contains a pointless `*.exe` option
- Lack of an "All VST files" option on Linux (which makes opening a LinuxVST cumbersome)
- Linux builds without Wine VST support (i.e. LinuxVST-only builds) still contain a `*.dll` option

This PR fixes all of these issues.
