### PR TITLE
Add Undo/Redo History

### DIFF
--- a/include/JournallingObject.h
+++ b/include/JournallingObject.h
@@ -58,7 +58,7 @@ public:
 		}
 	}
 
-	void addJournalCheckPoint();
+	void addJournalCheckPoint(QString reason = "Unknown");
 
 	QDomElement saveState( QDomDocument & _doc,
 									QDomElement & _parent ) override;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -238,8 +238,8 @@ private:
 	} m_keyMods;
 
 	QMenu * m_toolsMenu;
-	QAction * m_undoAction;
-	QAction * m_redoAction;
+	QMenu * m_undoMenu;
+	QMenu * m_redoMenu;
 	QList<PluginView *> m_tools;
 
 	QBasicTimer m_updateTimer;

--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -54,7 +54,7 @@ public:
 	bool canUndo() const;
 	bool canRedo() const;
 
-	void addJournalCheckPoint( JournallingObject *jo );
+	void addJournalCheckPoint(JournallingObject *jo, QString reason);
 
 	bool isJournalling() const
 	{
@@ -98,21 +98,26 @@ public:
 		return nullptr;
 	}
 
-
-private:
-	using JoIdMap = QHash<jo_id_t, JournallingObject*>;
-
 	struct CheckPoint
 	{
-		CheckPoint( jo_id_t initID = 0, const DataFile& initData = DataFile( DataFile::Type::JournalData ) ) :
-			joID( initID ),
-			data( initData )
+		CheckPoint(jo_id_t initID = 0, const DataFile& initData = DataFile(DataFile::Type::JournalData), QString description = "") :
+			joID(initID),
+			data(initData),
+			description(description)
 		{
 		}
 		jo_id_t joID;
 		DataFile data;
+		QString description;
 	} ;
 	using CheckPointStack = QStack<CheckPoint>;
+
+	const CheckPointStack& undoCheckPoints() { return m_undoCheckPoints; }
+	const CheckPointStack& redoCheckPoints() { return m_redoCheckPoints; }
+
+
+private:
+	using JoIdMap = QHash<jo_id_t, JournallingObject*>;
 
 	JoIdMap m_joIDs;
 

--- a/include/UndoRedoMenu.h
+++ b/include/UndoRedoMenu.h
@@ -1,0 +1,49 @@
+/*
+ * UndoRedoMenu.h
+ *
+ * Copyright (c) 2004-2022 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_UNDO_REDO_MENU_H
+#define LMMS_GUI_UNDO_REDO_MENU_H
+
+#include <QMenu>
+
+namespace lmms::gui
+{
+
+
+class UndoRedoMenu : public QMenu
+{
+	Q_OBJECT
+public:
+	UndoRedoMenu(QWidget *parent = nullptr, bool isUndo = true);
+
+private slots:
+	void fillMenu();
+private:
+	bool m_isUndo = true;
+};
+
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_UNDO_REDO_MENU_H

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -302,7 +302,7 @@ void AutomatableModel::setValue( const float value )
 	if( old_val != m_value )
 	{
 		// add changes to history so user can undo it
-		addJournalCheckPoint();
+		addJournalCheckPoint(tr("Set value of %1").arg(fullDisplayName()));
 
 		// notify linked models
 		for (const auto& linkedModel : m_linkedModels)

--- a/src/core/JournallingObject.cpp
+++ b/src/core/JournallingObject.cpp
@@ -55,11 +55,11 @@ JournallingObject::~JournallingObject()
 
 
 
-void JournallingObject::addJournalCheckPoint()
+void JournallingObject::addJournalCheckPoint(QString reason)
 {
 	if( isJournalling() )
 	{
-		Engine::projectJournal()->addJournalCheckPoint( this );
+		Engine::projectJournal()->addJournalCheckPoint(this, reason);
 	}
 }
 

--- a/src/core/ProjectJournal.cpp
+++ b/src/core/ProjectJournal.cpp
@@ -62,7 +62,7 @@ void ProjectJournal::undo()
 		{
 			DataFile curState( DataFile::Type::JournalData );
 			jo->saveState( curState, curState.content() );
-			m_redoCheckPoints.push( CheckPoint( c.joID, curState ) );
+			m_redoCheckPoints.push( CheckPoint( c.joID, curState, c.description ) );
 
 			bool prev = isJournalling();
 			setJournalling( false );
@@ -93,7 +93,7 @@ void ProjectJournal::redo()
 		{
 			DataFile curState( DataFile::Type::JournalData );
 			jo->saveState( curState, curState.content() );
-			m_undoCheckPoints.push( CheckPoint( c.joID, curState ) );
+			m_undoCheckPoints.push( CheckPoint( c.joID, curState, c.description ) );
 
 			bool prev = isJournalling();
 			setJournalling( false );
@@ -117,7 +117,7 @@ bool ProjectJournal::canRedo() const
 
 
 
-void ProjectJournal::addJournalCheckPoint( JournallingObject *jo )
+void ProjectJournal::addJournalCheckPoint(JournallingObject *jo, QString reason)
 {
 	if( isJournalling() )
 	{
@@ -126,7 +126,7 @@ void ProjectJournal::addJournalCheckPoint( JournallingObject *jo )
 		DataFile dataFile( DataFile::Type::JournalData );
 		jo->saveState( dataFile, dataFile.content() );
 
-		m_undoCheckPoints.push( CheckPoint( jo->id(), dataFile ) );
+		m_undoCheckPoints.push(CheckPoint(jo->id(), dataFile, reason));
 		if( m_undoCheckPoints.size() > MAX_UNDO_STATES )
 		{
 			m_undoCheckPoints.remove( 0, m_undoCheckPoints.size() - MAX_UNDO_STATES );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -75,6 +75,7 @@ SET(LMMS_SRCS
 	gui/menus/MidiPortMenu.cpp
 	gui/menus/RecentProjectsMenu.cpp
 	gui/menus/TemplatesMenu.cpp
+	gui/menus/UndoRedoMenu.cpp
 
 	gui/modals/AboutDialog.cpp
 	gui/modals/ColorChooser.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -71,6 +71,7 @@
 #include "TimeLineWidget.h"
 #include "ToolButton.h"
 #include "ToolPlugin.h"
+#include "UndoRedoMenu.h"
 #include "VersionedSaveDialog.h"
 
 #include "lmmsversion.h"
@@ -333,14 +334,15 @@ void MainWindow::finalize()
 
 	auto edit_menu = new QMenu(this);
 	menuBar()->addMenu( edit_menu )->setText( tr( "&Edit" ) );
-	m_undoAction = edit_menu->addAction( embed::getIconPixmap( "edit_undo" ),
-					tr( "Undo" ),
-					this, SLOT(undo()),
-					QKeySequence::Undo );
-	m_redoAction = edit_menu->addAction( embed::getIconPixmap( "edit_redo" ),
-					tr( "Redo" ),
-					this, SLOT(redo()),
-					QKeySequence::Redo );
+
+	m_undoMenu = new UndoRedoMenu(this, true);
+	edit_menu->addMenu(m_undoMenu);
+	m_redoMenu = new UndoRedoMenu(this, false);
+	edit_menu->addMenu(m_redoMenu);
+
+	new QShortcut(QKeySequence::Undo, this, SLOT(undo()));
+	new QShortcut(QKeySequence::Redo, this, SLOT(redo()));
+
 	// Ensure that both (Ctrl+Y) and (Ctrl+Shift+Z) activate redo shortcut regardless of OS defaults
 	if (QKeySequence(QKeySequence::Redo) != QKeySequence(combine(Qt::CTRL, Qt::Key_Y)))
 	{
@@ -1203,8 +1205,8 @@ void MainWindow::updateUndoRedoButtons()
 {
 	// when the edit menu is shown, grey out the undo/redo buttons if there's nothing to undo/redo
 	// else, un-grey them
-	m_undoAction->setEnabled(Engine::projectJournal()->canUndo());
-	m_redoAction->setEnabled(Engine::projectJournal()->canRedo());
+	m_undoMenu->setEnabled(Engine::projectJournal()->canUndo());
+	m_redoMenu->setEnabled(Engine::projectJournal()->canRedo());
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1752,7 +1752,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				if (it == notes.rend())
 				{
 					is_new_note = true;
-					m_midiClip->addJournalCheckPoint();
+					m_midiClip->addJournalCheckPoint(tr("Add note"));
 
 					// then set new note
 
@@ -1846,7 +1846,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - RESIZE_AREA_WIDTH
 					&& m_currentNote->length() > 0 )
 				{
-					m_midiClip->addJournalCheckPoint();
+					m_midiClip->addJournalCheckPoint(tr("Resize note"));
 					// then resize the note
 					m_action = Action::ResizeNote;
 

--- a/src/gui/menus/UndoRedoMenu.cpp
+++ b/src/gui/menus/UndoRedoMenu.cpp
@@ -1,0 +1,77 @@
+/*
+ * UndoRedoMenu.cpp
+ *
+ * Copyright (c) 2004-2022 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2025 regulus79
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "UndoRedoMenu.h"
+
+#include <QFileInfo>
+
+#include "Engine.h"
+#include "Song.h"
+
+#include "embed.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
+#include "ProjectJournal.h"
+
+namespace lmms::gui
+{
+
+
+UndoRedoMenu::UndoRedoMenu(QWidget *parent, bool isUndo) :
+	QMenu(tr(isUndo? "Undo" : "Redo"), parent),
+	m_isUndo(isUndo)
+{
+	setIcon(embed::getIconPixmap(m_isUndo ? "edit_undo" : "edit_redo"));
+
+	connect(this, &UndoRedoMenu::aboutToShow, this, &UndoRedoMenu::fillMenu);
+}
+
+
+void UndoRedoMenu::fillMenu()
+{
+	clear();
+	ProjectJournal::CheckPointStack history = m_isUndo
+		? Engine::projectJournal()->undoCheckPoints()
+		: Engine::projectJournal()->redoCheckPoints();
+
+	int index = 0;
+	for (auto it = history.rbegin(); it != history.rend(); ++it)
+	{
+		auto cp = *it;
+		addAction(cp.description, this,
+			[this, cp, index]()
+			{
+				for (int i = 0; i < index + 1; ++i)
+				{
+					if (m_isUndo) { Engine::projectJournal()->undo(); }
+					else { Engine::projectJournal()->redo(); }
+				}
+			}
+		);
+		++index;
+	}
+}
+
+} // namespace lmms::gui


### PR DESCRIPTION
This PR adds a menu showing a list of all the recorded actions the user has done which are stored in the undo/redo checkpoint list. If the user wants to undo back a long distance to a particular action, they can do that by clicking on the entry in the undo history.

The main purpose of this PR is less about user experience and more for debugging purposes. If we are able to see all of the recorded actions, it may help us track down issues in the undo system which may be hard to catch otherwise.

## Demo

https://github.com/user-attachments/assets/8362dcf3-0af6-460a-98bb-4352cc87cf2e

## Changes
- Added a parameter to `addJournalCheckPoint` to give a user-readable name for the action.
- Reworked the undo/redo buttons in the `Edit` menu to be actual menus themselves.
  - Currently when you click to undo an action in the history, `undo` is called `n` times in a row. This does not seem ideal.
- Added a new class, `UndoRedoMenu`, to handle the population of the undo/redo menus with the actions.
  - Most of the code for this class was copied from `RecentProjectsMenu`.
- Made `CheckPoint` public in `ProjectJournal`, along with adding getter functions for the undo/redo histories.
- Added reasons/descriptions to a few actions, namely moving/resizing a note, and setting the value of a model. Currently, all other actions are labeled as "Unknown".