### PR TITLE
Update src/3rdparty/qt5-x11embed to latest version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/3rdparty/qt5-x11embed"]
 	path = src/3rdparty/qt5-x11embed
-	url = https://github.com/tresf/qt5-x11embed.git
+	url = https://github.com/Lukas-W/qt5-x11embed.git
 [submodule "plugins/ZynAddSubFx/zynaddsubfx"]
 	path = plugins/ZynAddSubFx/zynaddsubfx
 	url = https://github.com/lmms/zynaddsubfx.git


### PR DESCRIPTION
Set DCMAKE_POLICY_VERSION_MINIMUM to 3.5 to make LMMS build with CMake 4 and newer.