### PR TITLE
Fix Sidebar Menu Focus

### DIFF
--- a/src/gui/SideBarWidget.cpp
+++ b/src/gui/SideBarWidget.cpp
@@ -49,6 +49,7 @@ SideBarWidget::SideBarWidget( const QString & _title, const QPixmap & _icon,
 	m_closeBtn = new QPushButton(embed::getIconPixmap("close"), QString(), this);
 	m_closeBtn->resize(m_buttonSize);
 	m_closeBtn->setToolTip(tr("Close"));
+	m_closeBtn->setFocusPolicy(Qt::NoFocus);
 	connect(m_closeBtn, &QPushButton::clicked,
 		[this]() { this->closeButtonClicked(); });
 }


### PR DESCRIPTION
This PR makes it so that the spacebar will not keep triggering open/closing the sidebar menus (like the instruments tab, and the file browser tabs).

All that was required was to set the focus policy of the close button to `Qt::NoFocus` which prevents the spacebar from triggering it after you click on it.