### PR TITLE
Use system cursors instead of embedded raster images where possible

### DIFF
--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -49,7 +49,7 @@ AutomatableModelView::AutomatableModelView( Model* model, QWidget* _this ) :
 	m_conversionFactor( 1.0 )
 {
 	widget()->setAcceptDrops( true );
-	widget()->setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
+	widget()->setCursor(Qt::PointingHandCursor);
 }
 
 void AutomatableModelView::addDefaultActions( QMenu* menu )

--- a/src/gui/tracks/FadeButton.cpp
+++ b/src/gui/tracks/FadeButton.cpp
@@ -47,7 +47,7 @@ FadeButton::FadeButton(const QColor & _normal_color,
 	m_activatedColor( _activated_color ),
 	m_holdColor( holdColor )
 {
-	setCursor(QCursor(embed::getIconPixmap("hand"), 3, 3));
+	setCursor(Qt::PointingHandCursor);
 	setFocusPolicy(Qt::NoFocus);
 	activeNotes = 0;
 }

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -47,7 +47,7 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	m_iconName()
 {
 	setAcceptDrops( true );
-	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
+	setCursor(Qt::PointingHandCursor);
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 
 	m_renameLineEdit = new TrackRenameLineEdit( this );

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -90,6 +90,7 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 	m_trackOps->setFocusPolicy( Qt::NoFocus );
 	m_trackOps->setMenu( toMenu );
 	m_trackOps->setToolTip(tr("Actions"));
+	m_trackOps->setCursor(Qt::PointingHandCursor);
 
 	m_muteBtn = new AutomatableButton(operationsWidget, tr("Mute"));
 	m_muteBtn->setCheckable(true);


### PR DESCRIPTION
This PR changes several views to utilize the system's cursors where possible instead of setting the cursor to raster images.

Marking this as draft, since this currently only modifies uses of `hand.png`. There are other cursors that can also be updated in this same way.