### PR TITLE
Add Setting for UI Scale Factor

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -86,6 +86,7 @@ private slots:
 	void toggleDisableBackup(bool enabled);
 	void toggleOpenLastProject(bool enabled);
 	void loopMarkerModeChanged();
+	void UIScaleFactorChanged();
 	void setLanguage(int lang);
 
 	// Performance settings widget.
@@ -149,6 +150,9 @@ private:
 	bool m_openLastProject;
 	QString m_loopMarkerMode;
 	QComboBox* m_loopMarkerComboBox;
+	float m_UIScaleFactor;
+	QSlider * m_UIScaleFactorSlider;
+	QLabel * m_UIScaleFactorLbl;
 	QString m_lang;
 	QStringList m_languages;
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -262,9 +262,10 @@ int main( int argc, char * * argv )
 	bool renderTracks = false;
 	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
 
+	QApplication* temporaryApp = new QApplication(argc, argv);
 	ConfigManager::inst()->loadConfigFile(configFile);
-
 	qputenv("QT_SCALE_FACTOR", ConfigManager::inst()->value("app", "uiscalefactor", "1").toUtf8());
+	delete temporaryApp;
 
 	// first of two command-line parsing stages
 	for (int i = 1; i < argc; ++i)

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -262,6 +262,10 @@ int main( int argc, char * * argv )
 	bool renderTracks = false;
 	QString fileToLoad, fileToImport, renderOut, profilerOutputFile, configFile;
 
+	ConfigManager::inst()->loadConfigFile(configFile);
+
+	qputenv("QT_SCALE_FACTOR", ConfigManager::inst()->value("app", "uiscalefactor", "1").toUtf8());
+
 	// first of two command-line parsing stages
 	for (int i = 1; i < argc; ++i)
 	{

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -119,6 +119,8 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_openLastProject(ConfigManager::inst()->value(
 			"app", "openlastproject").toInt()),
 	m_loopMarkerMode{ConfigManager::inst()->value("app", "loopmarkermode", "dual")},
+	m_UIScaleFactor(ConfigManager::inst()->value(
+		"app", "uiscalefactor", "1.0").toFloat()),
 	m_lang(ConfigManager::inst()->value(
 			"app", "language")),
 	m_saveInterval(	ConfigManager::inst()->value(
@@ -267,6 +269,21 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 
 	guiGroupLayout->addWidget(new QLabel{tr("Loop edit mode"), guiGroupBox});
 	guiGroupLayout->addWidget(m_loopMarkerComboBox);
+
+	guiGroupLayout->addWidget(new QLabel{tr("UI Scale Factor"), guiGroupBox});
+	m_UIScaleFactorSlider = new QSlider(Qt::Horizontal, guiGroupBox);
+	m_UIScaleFactorSlider->setRange(100, 300);
+	m_UIScaleFactorSlider->setValue(m_UIScaleFactor * 100);
+	m_UIScaleFactorSlider->setTickPosition(QSlider::TicksBelow);
+
+	connect(m_UIScaleFactorSlider, &QSlider::valueChanged,
+			this, &ConfigManager::UIScaleFactorChanged);
+	connect(m_UIScaleFactorSlider, &QSlider::valueChanged,
+			this, &ConfigManager::showRestartWarning);
+	guiGroupLayout->addWidget(m_UIScaleFactorSlider);
+
+	m_UIScaleFactorLbl = new QLabel(QString("%1%").arg(m_UIScaleFactor * 100), guiGroupBox);
+	guiGroupLayout->addWidget(m_UIScaleFactorLbl);
 
 	generalControlsLayout->addWidget(guiGroupBox);
 
@@ -982,6 +999,8 @@ void SetupDialog::accept()
 	ConfigManager::inst()->setValue("app", "openlastproject",
 					QString::number(m_openLastProject));
 	ConfigManager::inst()->setValue("app", "loopmarkermode", m_loopMarkerMode);
+	ConfigManager::inst()->setValue("app", "uiscalefactor",
+					QString::number(m_UIScaleFactor));
 	ConfigManager::inst()->setValue("app", "language", m_lang);
 	ConfigManager::inst()->setValue("ui", "saveinterval",
 					QString::number(m_saveInterval));
@@ -1123,6 +1142,12 @@ void SetupDialog::toggleOpenLastProject(bool enabled)
 void SetupDialog::loopMarkerModeChanged()
 {
 	m_loopMarkerMode = m_loopMarkerComboBox->currentData().toString();
+}
+
+void SetupDialog::UIScaleFactorChanged()
+{
+	m_UIScaleFactor = m_UIScaleFactorSlider->value() * 0.01f;
+	m_UIScaleFactorLbl->setText(QString("%1%").arg(m_UIScaleFactor * 100));
 }
 
 

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -277,9 +277,9 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_UIScaleFactorSlider->setTickPosition(QSlider::TicksBelow);
 
 	connect(m_UIScaleFactorSlider, &QSlider::valueChanged,
-			this, &ConfigManager::UIScaleFactorChanged);
+			this, &SetupDialog::UIScaleFactorChanged);
 	connect(m_UIScaleFactorSlider, &QSlider::valueChanged,
-			this, &ConfigManager::showRestartWarning);
+			this, &SetupDialog::showRestartWarning);
 	guiGroupLayout->addWidget(m_UIScaleFactorSlider);
 
 	m_UIScaleFactorLbl = new QLabel(QString("%1%").arg(m_UIScaleFactor * 100), guiGroupBox);


### PR DESCRIPTION
This PR adds a slider to the setup dialog/settings window, allowing users to set the `QT_SCALE_FACTOR` from within LMMS. This is done by calling `qputenv` to set the environment variable before the `QApplication` starts.

## Demo


https://github.com/user-attachments/assets/6cd97e40-11e1-4ef9-83de-6fa30aebd4a2


![image](https://github.com/user-attachments/assets/a0294252-6b54-45bb-a851-7b898365f258)



However, there is a problem; I assumed that we wanted to store the scale factor in the config file, but you cannot load the config file until the qApp starts. But you have to set the scale factor env var before the qApp starts for it to take effect. So, I decided to add a temproary qApp object which would be used to load the settings, then set the env var, delete the qApp, and continue with the startup (kind of based on https://stackoverflow.com/a/55408574).

Does anyone have any better idea on how this could be done? Should we even be using the scale factor environment variable for ui scaling?