### PR TITLE
Add clangd cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /plugins/ZynAddSubFx/zynaddsubfx/doc/gen/Makefile
 /data/locale/*.qm
 Brewfile.lock.json
+/.cache/


### PR DESCRIPTION
#7804 enabled cmake to generate the necessary files for clangd to index the project. Normally this `.cache/` exists in `/build/`, which is already in the `.gitignore`, but if cmake is run in the repository root instead of `/build/` the cache is in turn generated in the repository root. Adding this gitignore rule should prevent the clangd cache from being mistakenly staged and committed via `git add .` or `git commit -a`.