### PR TITLE
Save Autoscroll State

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -52,7 +52,7 @@ class TextFloat;
 class SongEditor;
 
 
-class TimeLineWidget : public QWidget
+class TimeLineWidget : public QWidget, public JournallingObject
 {
 	Q_OBJECT
 public:
@@ -157,6 +157,11 @@ public:
 					m_ppb / TimePos::ticksPerBar() );
 	}
 
+	auto nodeName() const -> QString override { return "timelinewidget"; }
+
+	void saveSettings(QDomDocument& doc, QDomElement& element) override;
+	void loadSettings(const QDomElement& element) override;
+
 signals:
 	void positionChanged(const lmms::TimePos& postion);
 	void regionSelectedFromPixels( int, int );
@@ -214,6 +219,7 @@ private:
 	QCursor m_cursorSelectRight = QCursor{embed::getIconPixmap("cursor_select_right"), 32, 16};
 
 	AutoScrollState m_autoScroll = AutoScrollState::Stepped;
+	NStateButton* m_autoScrollButton;
 
 	// Width of the unused region on the widget's left (above track labels or piano)
 	int m_xOffset;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5356,6 +5356,8 @@ void PianoRollWindow::saveSettings( QDomDocument & doc, QDomElement & de )
 	de.setAttribute("stopbehaviour", static_cast<int>(
 		Engine::getSong()->getTimeline(Song::PlayMode::MidiClip).stopBehaviour()));
 
+	m_editor->m_timeLine->saveSettings(doc, de);
+
 	MainWindow::saveWidgetState( this, de );
 }
 
@@ -5379,6 +5381,7 @@ void PianoRollWindow::loadSettings( const QDomElement & de )
 	qm.setLeft(m_editor->m_whiteKeyWidth);
 	m_editor->m_stepRecorderWidget.setMargins(qm);
 	m_editor->m_timeLine->setXOffset(m_editor->m_whiteKeyWidth);
+	m_editor->m_timeLine->loadSettings(de);
 }
 
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -275,11 +275,13 @@ SongEditor::SongEditor( Song * song ) :
 void SongEditor::saveSettings( QDomDocument& doc, QDomElement& element )
 {
 	MainWindow::saveWidgetState( parentWidget(), element );
+	m_timeLine->saveSettings(doc, element);
 }
 
 void SongEditor::loadSettings( const QDomElement& element )
 {
 	MainWindow::restoreWidgetState(parentWidget(), element);
+	m_timeLine->loadSettings(element);
 }
 
 

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -87,12 +87,12 @@ void TimeLineWidget::setXOffset(const int x)
 
 void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 {
-	auto autoScroll = new NStateButton(_tool_bar);
-	autoScroll->setGeneralToolTip(tr("Auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_stepped_on"), tr("Stepped auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_continuous_on"), tr("Continuous auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_off"), tr("Auto scrolling disabled"));
-	connect( autoScroll, SIGNAL(changedState(int)), this,
+	m_autoScrollButton = new NStateButton(_tool_bar);
+	m_autoScrollButton->setGeneralToolTip(tr("Auto scrolling"));
+	m_autoScrollButton->addState(embed::getIconPixmap("autoscroll_stepped_on"), tr("Stepped auto scrolling"));
+	m_autoScrollButton->addState(embed::getIconPixmap("autoscroll_continuous_on"), tr("Continuous auto scrolling"));
+	m_autoScrollButton->addState(embed::getIconPixmap("autoscroll_off"), tr("Auto scrolling disabled"));
+	connect(m_autoScrollButton, SIGNAL(changedState(int)), this,
 					SLOT(toggleAutoScroll(int)));
 
 	auto loopPoints = new NStateButton(_tool_bar);
@@ -126,7 +126,7 @@ void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
 	);
 	behaviourAtStop->changeState(static_cast<int>(m_timeline->stopBehaviour()));
 
-	_tool_bar->addWidget( autoScroll );
+	_tool_bar->addWidget(m_autoScrollButton);
 	_tool_bar->addWidget( loopPoints );
 	_tool_bar->addWidget( behaviourAtStop );
 }
@@ -454,5 +454,19 @@ void TimeLineWidget::contextMenuEvent(QContextMenuEvent* event)
 
 	menu.exec(event->globalPos());
 }
+
+
+void TimeLineWidget::saveSettings(QDomDocument& doc, QDomElement& element)
+{
+	element.setAttribute("autoscroll", static_cast<int>(m_autoScroll));
+}
+
+void TimeLineWidget::loadSettings(const QDomElement& element)
+{
+	toggleAutoScroll(element.attribute("autoscroll").toInt());
+	m_autoScrollButton->changeState(element.attribute("autoscroll").toInt());
+}
+
+
 
 } // namespace lmms::gui


### PR DESCRIPTION
Currently, the autoscroll state of the song editor and piano roll (continuous, stepped, none) is not saved when the user saves the project or creates a template. This can be an issue for users who want to permanently set their autoscroll settings, without having to change them every time they start up LMMS.

This PR adds `loadSettings` and `saveSettings` functions to `TimeLineWidget`, which save/load the autoscroll settings. However, since `TimeLineWidget` was not a `JournallingObject`, it was not able to override these functions, so in the process I made `TimeLineWidget` inherit `JournallingObject`. This also required adding a `nodeName` function.

Additionally, in order to update the autoscroll state button when loading a project, I had to have access to the `NStateButton` which controlled it. However, previously the button was simply declared on the stack in the constructor, so I changed it to be a member variable in order to keep access to it throughout the class.