### PR TITLE
Use native file dialog

### DIFF
--- a/include/SetupDialog.h
+++ b/include/SetupDialog.h
@@ -82,6 +82,7 @@ private slots:
 	void toggleSoloLegacyBehavior(bool enabled);
 	void toggleTrackDeletionWarning(bool enabled);
 	void toggleMixerChannelDeletionWarning(bool enabled);
+	void toggleNativeFileDialog(bool enabled);
 	void toggleMMPZ(bool enabled);
 	void toggleDisableBackup(bool enabled);
 	void toggleOpenLastProject(bool enabled);
@@ -144,6 +145,7 @@ private:
 	bool m_soloLegacyBehavior;
 	bool m_trackDeletionWarning;
 	bool m_mixerChannelDeletionWarning;
+	bool m_nativeFileDialog;
 	bool m_MMPZ;
 	bool m_disableBackup;
 	bool m_openLastProject;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -799,18 +799,31 @@ bool MainWindow::saveProject()
 bool MainWindow::saveProjectAs()
 {
 	auto optionsWidget = new SaveOptionsWidget(Engine::getSong()->getSaveOptions());
-	VersionedSaveDialog sfd( this, optionsWidget, tr( "Save Project" ), "",
-			tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
-				tr( "LMMS Project Template" ) + " (*.mpt)" );
+	bool native = ConfigManager::inst()->value("ui", "nativefiledialog").toInt();
+
+	FileDialog* sfd;
+
+	if (native)
+	{
+		sfd = new FileDialog( this, tr( "Save Project" ), "",
+		tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
+			tr( "LMMS Project Template" ) + " (*.mpt)" );
+	} else
+	{
+		sfd = new VersionedSaveDialog( this, optionsWidget, tr( "Save Project" ), "",
+tr( "LMMS Project" ) + " (*.mmpz *.mmp);;" +
+	tr( "LMMS Project Template" ) + " (*.mpt)" );
+	}
+
 	QString f = Engine::getSong()->projectFileName();
 	if( f != "" )
 	{
-		sfd.setDirectory( QFileInfo( f ).absolutePath() );
-		sfd.selectFile( QFileInfo( f ).fileName() );
+		sfd->setDirectory( QFileInfo( f ).absolutePath() );
+		sfd->selectFile( QFileInfo( f ).fileName() );
 	}
 	else
 	{
-		sfd.setDirectory( ConfigManager::inst()->userProjectsDir() );
+		sfd->setDirectory( ConfigManager::inst()->userProjectsDir() );
 	}
 
 	// Don't write over file with suffix if no suffix is provided.
@@ -818,34 +831,89 @@ bool MainWindow::saveProjectAs()
 							"nommpz" ).toInt() == 0
 						? "mmpz"
 						: "mmp" ;
-	sfd.setDefaultSuffix( suffix );
+	sfd->setDefaultSuffix( suffix );
 
-	if( sfd.exec () == FileDialog::Accepted &&
-		!sfd.selectedFiles().isEmpty() && sfd.selectedFiles()[0] != "" )
+	QString fileName;
+
+	if (native)
 	{
-		QString fname = sfd.selectedFiles()[0] ;
-		if( sfd.selectedNameFilter().contains( "(*.mpt)" ) )
+		fileName = sfd->getSaveFileName();
+		if (fileName.isEmpty())
 		{
-			// Remove the default suffix
-			fname.remove( "." + suffix );
-			if( !sfd.selectedFiles()[0].endsWith( ".mpt" ) )
+			delete sfd;
+			return false;
+		}
+	}
+	else
+	{
+		if(sfd->exec() != FileDialog::Accepted || sfd->selectedFiles().isEmpty() || sfd->selectedFiles()[0] == "" )
+		{
+			delete sfd;
+			return false;
+		}
+
+		fileName = sfd->selectedFiles()[0] ;
+	}
+
+	if( sfd->selectedNameFilter().contains( "(*.mpt)" ) )
+	{
+		// Remove the default suffix
+		fileName.remove( "." + suffix );
+		if( !sfd->selectedFiles()[0].endsWith( ".mpt" ) )
+		{
+			if( VersionedSaveDialog::fileExistsQuery( fileName + ".mpt",
+					tr( "Save project template" ) ) )
 			{
-				if( VersionedSaveDialog::fileExistsQuery( fname + ".mpt",
-						tr( "Save project template" ) ) )
-				{
-					fname += ".mpt";
-				}
+				fileName += ".mpt";
 			}
 		}
-		if( this->guiSaveProjectAs( fname ) )
+	}
+
+	delete sfd;
+
+	if (native)
+	{
+		// Show SaveOptionsWidget in its own dialog
+		QDialog* optionsDialog = new QDialog(this);
+		optionsDialog->setWindowTitle(tr("Save Options"));
+		QVBoxLayout* layout = new QVBoxLayout(optionsDialog);
+		layout->addWidget(optionsWidget);
+
+		// Add OK/Cancel buttons
+		QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+		layout->addWidget(buttons);
+		connect(buttons, &QDialogButtonBox::accepted, optionsDialog, &QDialog::accept);
+		connect(buttons, &QDialogButtonBox::rejected, optionsDialog, &QDialog::reject);
+
+		if (optionsDialog->exec() == QDialog::Accepted)
+		{
+			if( this->guiSaveProjectAs( fileName ) )
+			{
+				if( getSession() == SessionState::Recover )
+				{
+					sessionCleanup();
+				}
+
+				delete optionsDialog;
+				return true;
+			}
+		}
+		delete optionsDialog;
+		return false;
+	} else
+	{
+		if( this->guiSaveProjectAs( fileName ) )
 		{
 			if( getSession() == SessionState::Recover )
 			{
 				sessionCleanup();
 			}
+
 			return true;
 		}
 	}
+
+
 	return false;
 }
 

--- a/src/gui/modals/FileDialog.cpp
+++ b/src/gui/modals/FileDialog.cpp
@@ -44,7 +44,12 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 	setOption( QFileDialog::DontUseCustomDirectoryIcons );
 #endif
 
-	setOption( QFileDialog::DontUseNativeDialog );
+
+
+	if (ConfigManager::inst()->value("ui", "nativefiledialog").toInt() != 1)
+	{
+		setOption( QFileDialog::DontUseNativeDialog );
+	}
 
 #ifdef LMMS_BUILD_LINUX
 	QList<QUrl> urls;

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -112,6 +112,8 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 			"ui", "trackdeletionwarning", "1").toInt()),
 	m_mixerChannelDeletionWarning(ConfigManager::inst()->value(
 			"ui", "mixerchanneldeletionwarning", "1").toInt()),
+	m_nativeFileDialog(ConfigManager::inst()->value(
+			"ui", "nativefiledialog", "1").toInt()),
 	m_MMPZ(!ConfigManager::inst()->value(
 			"app", "nommpz").toInt()),
 	m_disableBackup(!ConfigManager::inst()->value(
@@ -254,6 +256,8 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 		m_trackDeletionWarning, SLOT(toggleTrackDeletionWarning(bool)), false);
 	addCheckBox(tr("Show warning when deleting a mixer channel that is in use"), guiGroupBox, guiGroupLayout,
 		m_mixerChannelDeletionWarning,	SLOT(toggleMixerChannelDeletionWarning(bool)), false);
+	addCheckBox(tr("Use native file dialog"), guiGroupBox, guiGroupLayout,
+		m_nativeFileDialog, SLOT(toggleNativeFileDialog(bool)), false);
 
 	m_loopMarkerComboBox = new QComboBox{guiGroupBox};
 
@@ -975,6 +979,8 @@ void SetupDialog::accept()
 					QString::number(m_trackDeletionWarning));
 	ConfigManager::inst()->setValue("ui", "mixerchanneldeletionwarning",
 					QString::number(m_mixerChannelDeletionWarning));
+	ConfigManager::inst()->setValue("ui", "nativefiledialog",
+				QString::number(m_nativeFileDialog));
 	ConfigManager::inst()->setValue("app", "nommpz",
 					QString::number(!m_MMPZ));
 	ConfigManager::inst()->setValue("app", "disablebackup",
@@ -1100,6 +1106,12 @@ void SetupDialog::toggleMixerChannelDeletionWarning(bool enabled)
 {
 	m_mixerChannelDeletionWarning = enabled;
 }
+
+void SetupDialog::toggleNativeFileDialog(bool enabled)
+{
+	m_nativeFileDialog = enabled;
+}
+
 
 
 void SetupDialog::toggleMMPZ(bool enabled)


### PR DESCRIPTION
Uses native file dialog for save and open dialogs. This is optional, but enabled by default. In the "Save As" dialog, if native dialogs are enabled, the save options will appear as a seperate dialog.
![Screenshot_20250421_200545](https://github.com/user-attachments/assets/e71a6ae6-d2af-4058-8c5a-91eac664f5f4)
(only tested in KDE with dolphin)