### PR TITLE
Improve correctness of `AudioResampler`

### DIFF
--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -49,17 +49,11 @@ public:
 		Count
 	};
 
-	struct Result
-	{
-		int error;
-		long outputFramesGenerated;
-		long inputFramesUsed;
-	};
-
 	//! The callback that writes input data to @p dst of the given size to the resampler when necessary.
+	//! The callback should return the number of frames actually written to @p dst.
 	//! @p data is an optional parameter that can be specified by callers for any additional context needed to
 	//! process their callback.
-	using WriteCallback = void (*)(SampleFrame* dst, std::size_t frames, void* data);
+	using WriteCallback = std::size_t (*)(SampleFrame* dst, std::size_t frames, void* data);
 
 	AudioResampler(InterpolationMode interpolationMode, int channels);
 	AudioResampler(const AudioResampler&) = delete;
@@ -71,7 +65,7 @@ public:
 
 	//! Resample the audio outputted from the write callback at the given conversion @p ratio. 
 	//! @p dst is expected to consist of @p frames frames (number of samples / number of channels)
-	auto resample(SampleFrame* dst, size_t frames, double ratio, WriteCallback writeCallback, void* writeCallbackData) -> Result;
+	void resample(SampleFrame* dst, size_t frames, double ratio, WriteCallback writeCallback, void* writeCallbackData);
 
 	//! Returns the interpolation mode the resampler is using.
 	auto interpolationMode() const -> InterpolationMode { return m_interpolationMode; }

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -55,7 +55,7 @@ public:
 	//! process their callback.
 	using WriteCallback = std::size_t (*)(SampleFrame* dst, std::size_t frames, void* data);
 
-	AudioResampler(InterpolationMode interpolationMode, int channels);
+	AudioResampler(InterpolationMode interpolationMode);
 	AudioResampler(const AudioResampler&) = delete;
 	AudioResampler(AudioResampler&&) = delete;
 	~AudioResampler();
@@ -71,7 +71,7 @@ public:
 	auto interpolationMode() const -> InterpolationMode { return m_interpolationMode; }
 
 	//! Returns the number of channels expected by the resampler.
-	auto channels() const -> int { return m_channels; }
+	constexpr auto channels() const -> int { return DEFAULT_CHANNELS; }
 
 	//! Returns the textual name for the given interpolation mode.
 	static auto interpolationModeName(InterpolationMode mode) -> const char* { return src_get_name(static_cast<int>(mode)); }
@@ -80,7 +80,6 @@ private:
 	InterpolationMode m_interpolationMode = AudioResampler::InterpolationMode::None;
 	std::array<SampleFrame, 32> m_writeBuffer;
 	SRC_STATE* m_state = nullptr;
-	int m_channels = 0;
 	int m_error = 0;
 };
 } // namespace lmms

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -64,7 +64,7 @@ public:
 	AudioResampler& operator=(const AudioResampler&);
 	AudioResampler& operator=(AudioResampler&&) noexcept = delete;
 
-	//! Resample the audio outputted from the write callback at the given conversion @p ratio. 
+	//! Resample the audio outputted from the write callback at the given conversion @p ratio.
 	//! @p dst is expected to consist of @p frames frames (number of samples / number of channels)
 	void resample(SampleFrame* dst, size_t frames, double ratio, WriteCallback writeCallback, void* writeCallbackData);
 
@@ -75,12 +75,16 @@ public:
 	constexpr auto channels() const -> int { return DEFAULT_CHANNELS; }
 
 	//! Returns the textual name for the given interpolation mode.
-	static auto interpolationModeName(InterpolationMode mode) -> const char* { return src_get_name(static_cast<int>(mode)); }
+	static auto interpolationModeName(InterpolationMode mode) -> const char*
+	{
+		return src_get_name(static_cast<int>(mode));
+	}
 
 private:
 	InterpolationMode m_interpolationMode = AudioResampler::InterpolationMode::None;
 	std::array<SampleFrame, 32> m_writeBuffer;
 	SRC_STATE* m_state = nullptr;
+	SRC_DATA m_data = SRC_DATA{};
 	int m_error = 0;
 };
 } // namespace lmms

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <samplerate.h>
 
+#include "SampleFrame.h"
 #include "lmms_export.h"
 
 namespace lmms {
@@ -58,7 +59,7 @@ public:
 	//! The callback that writes input data to @p dst of the given size to the resampler when necessary.
 	//! @p data is an optional parameter that can be specified by callers for any additional context needed to
 	//! process their callback.
-	using WriteCallback = void (*)(float* dst, std::size_t frames, std::size_t channels, void* data);
+	using WriteCallback = void (*)(SampleFrame* dst, std::size_t frames, void* data);
 
 	AudioResampler(InterpolationMode interpolationMode, int channels);
 	AudioResampler(const AudioResampler&) = delete;
@@ -69,9 +70,8 @@ public:
 	AudioResampler& operator=(AudioResampler&&) noexcept = delete;
 
 	//! Resample the audio outputted from the write callback at the given conversion @p ratio. 
-	//! @p dst is expected to be a interleaved audio buffer (e.g. LRLRLR for stereo)
 	//! @p dst is expected to consist of @p frames frames (number of samples / number of channels)
-	auto resample(float* dst, long frames, double ratio, WriteCallback writeCallback, void* writeCallbackData) -> Result;
+	auto resample(SampleFrame* dst, size_t frames, double ratio, WriteCallback writeCallback, void* writeCallbackData) -> Result;
 
 	//! Returns the interpolation mode the resampler is using.
 	auto interpolationMode() const -> InterpolationMode { return m_interpolationMode; }
@@ -84,7 +84,7 @@ public:
 
 private:
 	InterpolationMode m_interpolationMode = AudioResampler::InterpolationMode::None;
-	std::array<float, 64> m_writeBuffer;
+	std::array<SampleFrame, 32> m_writeBuffer;
 	SRC_STATE* m_state = nullptr;
 	int m_channels = 0;
 	int m_error = 0;

--- a/include/AudioResampler.h
+++ b/include/AudioResampler.h
@@ -51,9 +51,10 @@ public:
 
 	//! The callback that writes input data to @p dst of the given size to the resampler when necessary.
 	//! The callback should return the number of frames actually written to @p dst.
+	//! When the callback cannot write any more data or an error occurred, a value less than zero should be returned.
 	//! @p data is an optional parameter that can be specified by callers for any additional context needed to
 	//! process their callback.
-	using WriteCallback = std::size_t (*)(SampleFrame* dst, std::size_t frames, void* data);
+	using WriteCallback = long (*)(SampleFrame* dst, std::size_t frames, void* data);
 
 	AudioResampler(InterpolationMode interpolationMode);
 	AudioResampler(const AudioResampler&) = delete;

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -108,7 +108,7 @@ public:
 	void setReversed(bool reversed) { m_reversed.store(reversed, std::memory_order_relaxed); }
 
 private:
-	static void render(SampleFrame* dst, std::size_t frames, void* data);
+	static std::size_t render(SampleFrame* dst, std::size_t frames, void* data);
 	std::shared_ptr<const SampleBuffer> m_buffer = SampleBuffer::emptyBuffer();
 	std::atomic<int> m_startFrame = 0;
 	std::atomic<int> m_endFrame = 0;

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -108,7 +108,7 @@ public:
 	void setReversed(bool reversed) { m_reversed.store(reversed, std::memory_order_relaxed); }
 
 private:
-	static std::size_t render(SampleFrame* dst, std::size_t frames, void* data);
+	static long render(SampleFrame* dst, std::size_t frames, void* data);
 	std::shared_ptr<const SampleBuffer> m_buffer = SampleBuffer::emptyBuffer();
 	std::atomic<int> m_startFrame = 0;
 	std::atomic<int> m_endFrame = 0;

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -108,7 +108,7 @@ public:
 	void setReversed(bool reversed) { m_reversed.store(reversed, std::memory_order_relaxed); }
 
 private:
-	static void render(float* dst, std::size_t frames, std::size_t channels, void* data);
+	static void render(SampleFrame* dst, std::size_t frames, void* data);
 	void advance(PlaybackState* state, size_t advanceAmount, Loop loopMode) const;
 
 private:

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -48,7 +48,7 @@ public:
 	{
 
 		PlaybackState(bool varyingPitch = false, int interpolationMode = SRC_LINEAR)
-			: resampler(static_cast<AudioResampler::InterpolationMode>(interpolationMode), DEFAULT_CHANNELS)
+			: resampler(static_cast<AudioResampler::InterpolationMode>(interpolationMode))
 			, varyingPitch(varyingPitch)
 		{
 		}

--- a/include/Sample.h
+++ b/include/Sample.h
@@ -109,9 +109,6 @@ public:
 
 private:
 	static void render(SampleFrame* dst, std::size_t frames, void* data);
-	void advance(PlaybackState* state, size_t advanceAmount, Loop loopMode) const;
-
-private:
 	std::shared_ptr<const SampleBuffer> m_buffer = SampleBuffer::emptyBuffer();
 	std::atomic<int> m_startFrame = 0;
 	std::atomic<int> m_endFrame = 0;

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -145,8 +145,8 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 				break;
 		}
 		_n->m_pluginData = new Sample::PlaybackState(_n->hasDetuningInfo(), srcmode);
-		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->setFrameIndex(m_nextPlayStartPoint);
-		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->setBackwards(m_nextPlayBackwards);
+		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex = m_nextPlayStartPoint;
+		static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards = m_nextPlayBackwards;
 
 // debug code
 /*		qDebug( "frames %d", m_sample->frames() );
@@ -162,7 +162,7 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 						static_cast<Sample::Loop>(m_loopModel.value())))
 		{
 			applyRelease( _working_buffer, _n );
-			emit isPlaying(static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex());
+			emit isPlaying(static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex);
 		}
 		else
 		{
@@ -176,8 +176,8 @@ void AudioFileProcessor::playNote( NotePlayHandle * _n,
 	}
 	if( m_stutterModel.value() == true )
 	{
-		m_nextPlayStartPoint = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex();
-		m_nextPlayBackwards = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards();
+		m_nextPlayStartPoint = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->frameIndex;
+		m_nextPlayBackwards = static_cast<Sample::PlaybackState*>(_n->m_pluginData)->backwards;
 	}
 }
 

--- a/plugins/GigPlayer/GigPlayer.cpp
+++ b/plugins/GigPlayer/GigPlayer.cpp
@@ -436,8 +436,14 @@ void GigInstrument::play( SampleFrame* _working_buffer )
 				// Factor for pitch shifting as well as resampling
 				if (sample.region->PitchTrack == true) { freq_factor *= sample.freqFactor; }
 
+				// values for buffer margins, used for various libsamplerate interpolation modes
+				// the array positions correspond to the converter_type parameter values in libsamplerate
+				// if there appears problems with playback on some interpolation mode, then the value for that mode
+				// may need to be higher - conversely, to optimize, some may work with lower values
+				static constexpr auto s_interpolationMargins = std::array<int, 5>{64, 64, 64, 4, 4};
+
 				// We need a bit of margin so we don't get glitching
-				samples = frames / freq_factor + Sample::s_interpolationMargins[m_interpolation];
+				samples = frames / freq_factor + s_interpolationMargins[m_interpolation];
 			}
 
 			// Load this note's data

--- a/src/core/AudioResampler.cpp
+++ b/src/core/AudioResampler.cpp
@@ -30,10 +30,9 @@
 
 namespace lmms {
 
-AudioResampler::AudioResampler(InterpolationMode interpolationMode, int channels)
+AudioResampler::AudioResampler(InterpolationMode interpolationMode)
 	: m_interpolationMode(interpolationMode)
-	, m_state(src_new(static_cast<int>(interpolationMode), channels, &m_error))
-	, m_channels(channels)
+	, m_state(src_new(static_cast<int>(interpolationMode), DEFAULT_CHANNELS, &m_error))
 {
 	if (!m_state)
 	{

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -160,7 +160,7 @@ void Sample::setAllPointFrames(int startFrame, int endFrame, int loopStartFrame,
 	setLoopEndFrame(loopEndFrame);
 }
 
-void Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
+std::size_t Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
 {
 	const auto callbackData = static_cast<CallbackData*>(data);
 	const auto state = callbackData->state;
@@ -175,12 +175,7 @@ void Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
 		switch (loopMode)
 		{
 		case Loop::Off:
-			if (index < 0 || index >= sample->m_endFrame)
-			{
-				std::fill(dst + frame, dst + frames, SampleFrame{});
-				return;
-			}
-
+			if (index < 0 || index >= sample->m_endFrame) { return frame; }
 			break;
 		case Loop::On:
 			if (index < sample->m_loopStartFrame && backwards) { index = sample->m_loopEndFrame - 1; }
@@ -206,6 +201,8 @@ void Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
 		dst[frame] = value;
 		backwards ? --index : ++index;
 	}
+
+	return frames;
 }
 
 } // namespace lmms

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -24,8 +24,6 @@
 
 #include "Sample.h"
 
-#include "lmms_math.h"
-
 #include <cassert>
 
 namespace lmms {

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -126,9 +126,9 @@ bool Sample::play(SampleFrame* dst, PlaybackState* state, size_t numFrames, floa
 	const auto pastBounds = state->frameIndex >= m_endFrame || (state->frameIndex < 0 && state->backwards);
 	if (loopMode == Loop::Off && pastBounds) { return false; }
 
-	const auto outputSampleRate = Engine::audioEngine()->outputSampleRate() * desiredFrequency;
-	const auto inputSampleRate = m_buffer->sampleRate() * m_frequency;
-	const auto resampleRatio = outputSampleRate / inputSampleRate;
+	const auto outputRatio = Engine::audioEngine()->outputSampleRate() * m_frequency;
+	const auto inputRatio = m_buffer->sampleRate() * desiredFrequency;
+	const auto resampleRatio = outputRatio / inputRatio;
 
 	state->frameIndex = std::max<int>(m_startFrame, state->frameIndex);
 

--- a/src/core/Sample.cpp
+++ b/src/core/Sample.cpp
@@ -158,7 +158,7 @@ void Sample::setAllPointFrames(int startFrame, int endFrame, int loopStartFrame,
 	setLoopEndFrame(loopEndFrame);
 }
 
-std::size_t Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
+long Sample::render(SampleFrame* dst, const std::size_t frames, void* data)
 {
 	const auto callbackData = static_cast<CallbackData*>(data);
 	const auto state = callbackData->state;
@@ -173,7 +173,7 @@ std::size_t Sample::render(SampleFrame* dst, const std::size_t frames, void* dat
 		switch (loopMode)
 		{
 		case Loop::Off:
-			if (index < 0 || index >= sample->m_endFrame) { return frame; }
+			if (index < 0 || index >= sample->m_endFrame) { return -1; }
 			break;
 		case Loop::On:
 			if (index < sample->m_loopStartFrame && backwards) { index = sample->m_loopEndFrame - 1; }

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -634,6 +634,11 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 
 	setBufferSize(m_bufferSizeSlider->value());
 
+	// Resampling quality group
+	auto resamplingQuality = new QGroupBox(tr("Resampling quality"), audio_w);
+	auto liveResamplingQualityBox = new QComboBox(resamplingQuality);
+	
+
 
 	// Audio layout ordering.
 	audio_layout->addWidget(audioInterfaceBox);


### PR DESCRIPTION
After the `SampleBuffer` refactor in #6610, `AudioResampler` was introduced, and the sample playback logic was refactored as well (now within `Sample::play`). This left a couple of issues:

1. The sample playback functionality in `Sample::play` was not safe to call in real-time since it needed to make an allocation up front to store a temporary buffer of the necessary size.
2. The resampling logic in `AudioResampler` was not correct in a sense that it would not properly resample the signal. On each callback, `AudioResampler` would process the chunk of input samples as is, but it not take into consideration the previous input samples that it didn't get a chance to resample in the previous iteration. I believe this was the reason for the artifacts if buffer margins weren't used, but buffer margins were not the correct way to fix this. I also think they caused problems with the audio quality in `Sample::play`, in particular near the high frequencies (just from my own observations).

I addressed these two issues here. This is my second take at doing something like this after #7361, which was a nightmare on Windows builds, so any testing will be greatly appreciated. Note that unlike in there, I am not using the callback API, but still the full API in `AudioResampler`, just in a different way. `AudioResampler` allows callers to specify a callback to write into a very small `SampleFrame` buffer, which it will then be fed into libsamplerate over time. The libsamplerate state in `AudioResampler` is now correctly persisted across calls.

#### TODO
* After this PR, we may want to allow the user to specify the live interpolation quality in the audio settings. For now, sample playback always uses `SRC_LINEAR` (linear interpolation).
* In this PR, I might make sure we are using `AudioResampler` where libsamplerate is used directly if we aren't doing so already.