### PR TITLE
Fix crash when playing Pattern Editor without Pattern Track

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -366,7 +366,7 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, fpp
 		break;
 	case PlayMode::Pattern:
 	{
-		Q_ASSERT(tracklist.size() == 1);
+		if (tracklist.size() != 1) { return; }
 		Q_ASSERT(tracklist.at(0)->type() == Track::Type::Pattern);
 		auto patternTrack = dynamic_cast<PatternTrack*>(tracklist.at(0));
 		container = Engine::patternStore();


### PR DESCRIPTION
Fixes #7861, where playing the pattern editor in the Empty template would crash lmms.

Basically, I just added a check which makes sure the `tracklist` is of size 1, and if not, returns.