### PR TITLE
Improve MIDI device listing & selection

### DIFF
--- a/include/MidiAlsaSeq.h
+++ b/include/MidiAlsaSeq.h
@@ -83,13 +83,42 @@ public:
 	// list seq-ports from ALSA
 	QStringList readablePorts() const override
 	{
-		return m_readablePorts;
+		return m_readablePortMap.keys();
 	}
 
 	QStringList writablePorts() const override
 	{
-		return m_writablePorts;
+		return m_writablePortMap.keys();
 	}
+
+	QStringList friendlyReadablePorts() const override
+	{
+		return m_readablePortMap.values();
+	}
+
+	QStringList friendlyWritablePorts() const override
+	{
+		return m_writablePortMap.values();
+	}
+
+	QString toFriendly(const QString& port) const
+	{
+		return m_readablePortMap.value(port, m_writablePortMap.value(port, port));
+	}
+
+	QString fromFriendly(const QString& friendlyPort) const
+	{
+		QString key = m_readablePortMap.key(friendlyPort);
+		if (!key.isEmpty())
+			return key;
+
+		key = m_writablePortMap.key(friendlyPort);
+		if (!key.isEmpty())
+			return key;
+
+		return friendlyPort;
+	}
+
 
 	// return name of port which specified MIDI event came from
 	QString sourcePortName( const MidiEvent & ) const override;
@@ -141,8 +170,9 @@ private:
 	volatile bool m_quit;
 
 	QTimer m_portListUpdateTimer;
-	QStringList m_readablePorts;
-	QStringList m_writablePorts;
+
+	QMap<QString, QString> m_readablePortMap = QMap<QString, QString>();
+	QMap<QString, QString> m_writablePortMap = QMap<QString, QString>();
 
 	int m_pipe[2];
 

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -81,6 +81,26 @@ public:
 		return QStringList();
 	}
 
+	virtual QStringList friendlyReadablePorts() const
+	{
+		return QStringList();
+	}
+	virtual QStringList friendlyWritablePorts() const
+	{
+		return QStringList();
+	}
+
+	virtual QString toFriendly(const QString& port) const
+	{
+		return port;
+	}
+
+	virtual QString fromFriendly(const QString& friendlyPort) const
+	{
+		return friendlyPort;
+	}
+
+
 	// return name of port which specified MIDI event came from
 	virtual QString sourcePortName( const MidiEvent & ) const
 	{

--- a/src/core/midi/MidiAlsaSeq.cpp
+++ b/src/core/midi/MidiAlsaSeq.cpp
@@ -23,11 +23,13 @@
  */
 
 #include "MidiAlsaSeq.h"
+
+#include <qset.h>
+
 #include "ConfigManager.h"
 #include "Engine.h"
-#include "Song.h"
 #include "MidiPort.h"
-
+#include "Song.h"
 
 #ifdef LMMS_HAVE_ALSA
 
@@ -47,6 +49,11 @@ static QString portName( snd_seq_client_info_t * _cinfo,
 					arg( snd_seq_port_info_get_port( _pinfo ) ).
 					arg( snd_seq_client_info_get_name( _cinfo ) ).
 					arg( snd_seq_port_info_get_name( _pinfo ) );
+}
+
+static QString friendlyPortName(snd_seq_client_info_t* _cinfo)
+{
+	return snd_seq_client_info_get_name( _cinfo );
 }
 
 static QString portName( snd_seq_t * _seq, const snd_seq_addr_t * _addr )
@@ -631,10 +638,9 @@ void MidiAlsaSeq::changeQueueTempo( bpm_t _bpm )
 
 void MidiAlsaSeq::updatePortList()
 {
-	QStringList readablePorts;
-	QStringList writablePorts;
+	QMap<QString, QString> readablePortMap;
+	QMap<QString, QString> writablePortMap;
 
-	// get input- and output-ports
 	snd_seq_client_info_t * cinfo;
 	snd_seq_port_info_t * pinfo;
 
@@ -653,41 +659,47 @@ void MidiAlsaSeq::updatePortList()
 		snd_seq_port_info_set_port( pinfo, -1 );
 		while( snd_seq_query_next_port( m_seqHandle, pinfo ) >= 0 )
 		{
-			// we need both READ and SUBS_READ
-			if( ( snd_seq_port_info_get_capability( pinfo )
-			     & ( SND_SEQ_PORT_CAP_READ |
-					SND_SEQ_PORT_CAP_SUBS_READ ) ) ==
-					( SND_SEQ_PORT_CAP_READ |
-					  	SND_SEQ_PORT_CAP_SUBS_READ ) )
+			const int portType = snd_seq_port_info_get_type( pinfo );
+			if( !( portType & SND_SEQ_PORT_TYPE_MIDI_GENERIC ) &&
+				!( portType & SND_SEQ_PORT_TYPE_MIDI_GM ) &&
+				!( portType & SND_SEQ_PORT_TYPE_MIDI_GS ) &&
+				!( portType & SND_SEQ_PORT_TYPE_MIDI_XG ) )
 			{
-				readablePorts.push_back( portName( cinfo, pinfo ) );
+				continue;
 			}
-			if( ( snd_seq_port_info_get_capability( pinfo )
-			     & ( SND_SEQ_PORT_CAP_WRITE |
-					SND_SEQ_PORT_CAP_SUBS_WRITE ) ) ==
-					( SND_SEQ_PORT_CAP_WRITE |
-					  	SND_SEQ_PORT_CAP_SUBS_WRITE ) )
+
+			QString portId = portName(cinfo, pinfo);
+			QString portName = friendlyPortName(cinfo);
+
+			const int cap = snd_seq_port_info_get_capability( pinfo );
+			if( ( cap & ( SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ ) ) ==
+				( SND_SEQ_PORT_CAP_READ | SND_SEQ_PORT_CAP_SUBS_READ ))
 			{
-				writablePorts.push_back( portName( cinfo, pinfo ) );
+				readablePortMap.insert(portId, portName);
+			}
+
+			if( ( cap & ( SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE ) ) ==
+				( SND_SEQ_PORT_CAP_WRITE | SND_SEQ_PORT_CAP_SUBS_WRITE ))
+			{
+				writablePortMap.insert(portId, portName);
 			}
 		}
 	}
 
 	m_seqMutex.unlock();
 
-
 	snd_seq_client_info_free( cinfo );
 	snd_seq_port_info_free( pinfo );
 
-	if( m_readablePorts != readablePorts )
+	if( m_readablePortMap != readablePortMap)
 	{
-		m_readablePorts = readablePorts;
+		m_readablePortMap = readablePortMap;
 		emit readablePortsChanged();
 	}
 
-	if( m_writablePorts != writablePorts )
+	if( m_writablePortMap != writablePortMap)
 	{
-		m_writablePorts = writablePorts;
+		m_writablePortMap = writablePortMap;
 		emit writablePortsChanged();
 	}
 }

--- a/src/gui/menus/MidiPortMenu.cpp
+++ b/src/gui/menus/MidiPortMenu.cpp
@@ -25,6 +25,10 @@
 
 #include "MidiPortMenu.h"
 
+#include <AudioEngine.h>
+#include <Engine.h>
+#include <MidiClient.h>
+
 namespace lmms::gui
 {
 
@@ -79,6 +83,8 @@ void MidiPortMenu::activatedPort( QAction * _item )
 
 void MidiPortMenu::updateMenu()
 {
+	MidiClient* midiClient = Engine::audioEngine()->midiClient();
+
 	auto mp = castModel<MidiPort>();
 	const MidiPort::Map & map = ( m_mode == MidiPort::Mode::Input ) ?
 				mp->readablePorts() : mp->writablePorts();
@@ -86,7 +92,7 @@ void MidiPortMenu::updateMenu()
 	for( MidiPort::Map::ConstIterator it = map.begin();
 							it != map.end(); ++it )
 	{
-		QAction * a = addAction( it.key() );
+		QAction * a = addAction(midiClient->toFriendly(it.key()));
 		a->setCheckable( true );
 		a->setChecked( it.value() );
 	}

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -733,18 +733,22 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	QGroupBox * midiAutoAssignBox = new QGroupBox(tr("Automatically assign MIDI controller to selected track"), midi_w);
 	QVBoxLayout * midiAutoAssignLayout = new QVBoxLayout(midiAutoAssignBox);
 
+	MidiClient* midiClient = Engine::audioEngine()->midiClient();
+
 	m_assignableMidiDevices = new QComboBox(midiAutoAssignBox);
 	midiAutoAssignLayout->addWidget(m_assignableMidiDevices);
 	m_assignableMidiDevices->addItem("none");
-	if ( !Engine::audioEngine()->midiClient()->isRaw() )
+
+	if (!midiClient->isRaw())
 	{
-		m_assignableMidiDevices->addItems(Engine::audioEngine()->midiClient()->readablePorts());
+		m_assignableMidiDevices->addItems(midiClient->friendlyReadablePorts());
 	}
 	else
 	{
 		m_assignableMidiDevices->addItem("all");
 	}
-	int current = m_assignableMidiDevices->findText(ConfigManager::inst()->value("midi", "midiautoassign"));
+
+	int current = m_assignableMidiDevices->findText(midiClient->toFriendly(ConfigManager::inst()->value("midi", "midiautoassign")));
 	if (current >= 0)
 	{
 		m_assignableMidiDevices->setCurrentIndex(current);
@@ -1010,7 +1014,7 @@ void SetupDialog::accept()
 	ConfigManager::inst()->setValue("audioengine", "mididev",
 					m_midiIfaceNames[m_midiInterfaces->currentText()]);
 	ConfigManager::inst()->setValue("midi", "midiautoassign",
-					m_assignableMidiDevices->currentText());
+					Engine::audioEngine()->midiClient()->fromFriendly(m_assignableMidiDevices->currentText()));
 	ConfigManager::inst()->setValue("midi", "autoquantize", QString::number(m_midiAutoQuantize));
 
 


### PR DESCRIPTION
This PR aims to bring midi device listing to be on par with other apps. I mainly compared it to musescore.

**Before:**
input:
![image](https://github.com/user-attachments/assets/e4277e52-0a45-462c-9334-89189afc8085)
output:
![image](https://github.com/user-attachments/assets/2cd1ac9e-f7ce-4368-ac8f-deaa1c9bc173)
auto assign midi:
![image](https://github.com/user-attachments/assets/470f5428-e938-4618-9db9-5f61738f6b70)

**After:**
input:
![image](https://github.com/user-attachments/assets/d86c9f4b-d987-4ab6-95dc-964630db5915)
output:
![image](https://github.com/user-attachments/assets/bd0e2d54-7e67-4b7a-8dc8-30adab06b019)
auto assign midi:
![image](https://github.com/user-attachments/assets/c6b17c41-b9d7-4984-ab51-322bcaa5bf89)

The main goal is to remove the dummy devices like "System:Announce", but note how the names are friendlier now. Note that the longer names are still used by the system and stored in config, but the "friendly names" are only displayed to the user.


Musescore for comparison:
![image](https://github.com/user-attachments/assets/37ed2d73-385e-451e-9780-1b22aa1d735f)




 