### PR TITLE
Add Project-Specific Settings (And Export Metadata!)

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -166,6 +166,7 @@ public slots:
 	void toggleSongEditorWin();
 	void toggleProjectNotesWin();
 	void toggleMicrotunerWin();
+	void showProjectPropertiesDialog();
 	void toggleMixerWin();
 	void togglePianoRollWin();
 	void toggleControllerRack();

--- a/include/ProjectProperties.h
+++ b/include/ProjectProperties.h
@@ -61,6 +61,8 @@ public:
 
 	void deleteValue(const QString & cls, const QString & attribute);
 
+	void reset();
+
 
 	QString nodeName() const override
 	{

--- a/include/ProjectProperties.h
+++ b/include/ProjectProperties.h
@@ -1,0 +1,90 @@
+/*
+* ProjectProperties.h - class ProjectProperties, a class for managing project-specific settings
+*
+* Copyright (c) 2005-2008 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+* Copyright (c) 2025 regulus79
+*
+* This file is part of LMMS - https://lmms.io
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program (see COPYING); if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA.
+*
+*/
+
+#ifndef LMMS_PROJECT_PROPERTIES_H
+#define LMMS_PROJECT_PROPERTIES_H
+
+#include "JournallingObject.h"
+
+#include <QMap>
+#include <QObject>
+#include <QPair>
+#include <QStringList>
+
+#include <vector>
+#include "lmms_export.h"
+#include "lmmsconfig.h"
+
+
+namespace lmms
+{
+
+
+class LMMS_EXPORT ProjectProperties : public QObject, public JournallingObject
+{
+	Q_OBJECT
+public:
+	static inline ProjectProperties * inst()
+	{
+		if(s_instanceOfMe == nullptr )
+		{
+			s_instanceOfMe = new ProjectProperties();
+		}
+		return s_instanceOfMe;
+	}
+
+	QString value(const QString& cls, const QString& attribute, const QString& defaultVal = "") const;
+
+	void setValue(const QString & cls, const QString & attribute, const QString & value);
+
+	void deleteValue(const QString & cls, const QString & attribute);
+
+
+	QString nodeName() const override
+	{
+		return "projectproperties";
+	}
+
+	void saveSettings(QDomDocument& doc, QDomElement& element) override;
+	void loadSettings(const QDomElement& element) override;
+
+signals:
+	void valueChanged( QString cls, QString attribute, QString value );
+
+private:
+	static ProjectProperties * s_instanceOfMe;
+
+	ProjectProperties();
+	ProjectProperties(const ProjectProperties & _c);
+
+	using stringPairVector = std::vector<QPair<QString, QString>>;
+	using settingsMap = QMap<QString, stringPairVector>;
+	settingsMap m_settings;
+};
+
+
+} // namespace lmms
+
+#endif // LMMS_PROJECT_PROPERTIES_H

--- a/include/ProjectPropertiesDialog.h
+++ b/include/ProjectPropertiesDialog.h
@@ -52,16 +52,12 @@ private:
 	QString m_metaAlbum;
 	QString m_metaYear;
 	QString m_metaComment;
-	QString m_metaGenre;
-	QString m_metaSoftware;
 
 	QLineEdit * m_metaTitleLineEdit;
 	QLineEdit * m_metaArtistLineEdit;
 	QLineEdit * m_metaAlbumLineEdit;
 	QLineEdit * m_metaYearLineEdit;
 	QLineEdit * m_metaCommentLineEdit;
-	QLineEdit * m_metaGenreLineEdit;
-	QLineEdit * m_metaSoftwareLineEdit;
 
 };
 

--- a/include/ProjectPropertiesDialog.h
+++ b/include/ProjectPropertiesDialog.h
@@ -1,0 +1,52 @@
+/*
+ * ProjectPropertiesDialog.h - Configuration widget for project-specific settings
+ *
+ * Copyright (c) 2025 regulus79
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+*/
+
+#ifndef LMMS_GUI_PROJECT_PROPERTIES_DIALOG_H
+#define LMMS_GUI_PROJECT_PROPERTIES_DIALOG_H
+
+#include <QDialog>
+
+namespace lmms::gui
+{
+
+class TabBar;
+
+class ProjectPropertiesDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	ProjectPropertiesDialog();
+
+protected slots:
+	void accept() override;
+
+private:
+	TabBar * m_tabBar;
+
+};
+
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_PROJECT_PROPERTIES_DIALOG_H

--- a/include/ProjectPropertiesDialog.h
+++ b/include/ProjectPropertiesDialog.h
@@ -27,6 +27,9 @@
 
 #include <QDialog>
 
+
+class QLineEdit;
+
 namespace lmms::gui
 {
 
@@ -43,6 +46,22 @@ protected slots:
 
 private:
 	TabBar * m_tabBar;
+
+	QString m_metaTitle;
+	QString m_metaArtist;
+	QString m_metaAlbum;
+	QString m_metaYear;
+	QString m_metaComment;
+	QString m_metaGenre;
+	QString m_metaSoftware;
+
+	QLineEdit * m_metaTitleLineEdit;
+	QLineEdit * m_metaArtistLineEdit;
+	QLineEdit * m_metaAlbumLineEdit;
+	QLineEdit * m_metaYearLineEdit;
+	QLineEdit * m_metaCommentLineEdit;
+	QLineEdit * m_metaGenreLineEdit;
+	QLineEdit * m_metaSoftwareLineEdit;
 
 };
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -62,6 +62,7 @@ set(LMMS_SRCS
 	core/PluginFactory.cpp
 	core/PresetPreviewPlayHandle.cpp
 	core/ProjectJournal.cpp
+	core/ProjectProperties.cpp
 	core/ProjectRenderer.cpp
 	core/ProjectVersion.cpp
 	core/RemotePlugin.cpp

--- a/src/core/ProjectProperties.cpp
+++ b/src/core/ProjectProperties.cpp
@@ -98,15 +98,47 @@ void ProjectProperties::deleteValue(const QString & cls, const QString & attribu
 	}
 }
 
+void ProjectProperties::reset()
+{
+	m_settings.clear();
+}
+
 void ProjectProperties::saveSettings(QDomDocument& doc, QDomElement& element)
 {
-
+	for (auto it = m_settings.begin(); it != m_settings.end(); ++it)
+	{
+		QDomElement n = doc.createElement(it.key());
+		for (const auto& [first, second] : *it)
+		{
+			n.setAttribute(first, second);
+		}
+		element.appendChild(n);
+	}
 }
 
 
 void ProjectProperties::loadSettings(const QDomElement& element)
 {
+	QDomNode node = element.firstChild();
 
+	while(!node.isNull())
+	{
+		if(node.isElement() && node.toElement().hasAttributes())
+		{
+			stringPairVector attr;
+			QDomNamedNodeMap node_attr = node.toElement().attributes();
+			for(int i = 0; i < node_attr.count(); ++i)
+			{
+				QDomNode n = node_attr.item(i);
+				if(n.isAttr())
+				{
+					attr.push_back(qMakePair(n.toAttr().name(), n.toAttr().value()));
+				}
+			}
+			m_settings[node.nodeName()] = attr;
+		}
+		node = node.nextSibling();
+	}
 }
 
 

--- a/src/core/ProjectProperties.cpp
+++ b/src/core/ProjectProperties.cpp
@@ -1,0 +1,113 @@
+/*
+* ProjectProperties.cpp - implementation of class ProjectProperties, for project-specific settings
+*
+* Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+* Copyright (c) 2025 regulus79
+*
+* This file is part of LMMS - https://lmms.io
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program (see COPYING); if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA.
+*
+*/
+
+
+#include <QDomElement>
+
+#include "ProjectProperties.h"
+
+namespace lmms
+{
+
+
+ProjectProperties * ProjectProperties::s_instanceOfMe = nullptr;
+
+
+ProjectProperties::ProjectProperties()
+{
+}
+
+
+QString ProjectProperties::value(const QString& cls, const QString& attribute, const QString& defaultVal) const
+{
+	if (m_settings.find(cls) != m_settings.end())
+	{
+		for (const auto& setting : m_settings[cls])
+		{
+			if (setting.first == attribute)
+			{
+				return setting.second;
+			}
+		}
+	}
+	return defaultVal;
+}
+
+
+
+
+void ProjectProperties::setValue(const QString & cls,
+				const QString & attribute,
+				const QString & value)
+{
+	if(m_settings.contains(cls))
+	{
+		for(QPair<QString, QString>& pair : m_settings[cls])
+		{
+			if(pair.first == attribute)
+			{
+				if (pair.second != value)
+				{
+					pair.second = value;
+					emit valueChanged(cls, attribute, value);
+				}
+				return;
+			}
+		}
+	}
+	// not in map yet, so we have to add it...
+	m_settings[cls].push_back(qMakePair(attribute, value));
+}
+
+
+void ProjectProperties::deleteValue(const QString & cls, const QString & attribute)
+{
+	if(m_settings.contains(cls))
+	{
+		for(stringPairVector::iterator it = m_settings[cls].begin();
+					it != m_settings[cls].end(); ++it)
+		{
+			if((*it).first == attribute)
+			{
+				m_settings[cls].erase(it);
+				return;
+			}
+		}
+	}
+}
+
+void ProjectProperties::saveSettings(QDomDocument& doc, QDomElement& element)
+{
+
+}
+
+
+void ProjectProperties::loadSettings(const QDomElement& element)
+{
+
+}
+
+
+} // namespace lmms

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -917,6 +917,8 @@ void Song::clearProject()
 
 	removeAllControllers();
 
+	ProjectProperties::inst()->reset();
+
 	emit dataChanged();
 
 	Engine::projectJournal()->clearJournal();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -52,6 +52,7 @@
 #include "PianoRoll.h"
 #include "ProjectJournal.h"
 #include "ProjectNotes.h"
+#include "ProjectProperties.h"
 #include "Scale.h"
 #include "SongEditor.h"
 #include "TimeLineWidget.h"
@@ -1082,6 +1083,13 @@ void Song::loadProject( const QString & fileName )
 	//Backward compatibility for LMMS <= 0.4.15
 	PeakController::initGetControllerBySetting();
 
+	// Load project-specific settings
+	node = dataFile.content().firstChildElement(ProjectProperties::inst()->nodeName());
+	if(!node.isNull())
+	{
+		ProjectProperties::inst()->restoreState(node.toElement());
+	}
+
 	// Load mixer first to be able to set the correct range for mixer channels
 	node = dataFile.content().firstChildElement( Engine::mixer()->nodeName() );
 	if( !node.isNull() )
@@ -1232,6 +1240,8 @@ bool Song::saveProjectFile(const QString & filename, bool withResources)
 	m_masterPitchModel.saveSettings( dataFile, dataFile.head(), "masterpitch" );
 
 	saveState( dataFile, dataFile.content() );
+
+	ProjectProperties::inst()->saveState(dataFile, dataFile.content());
 
 	Engine::mixer()->saveState( dataFile, dataFile.content() );
 	if( getGUI() != nullptr )

--- a/src/core/audio/AudioFileFlac.cpp
+++ b/src/core/audio/AudioFileFlac.cpp
@@ -30,6 +30,7 @@
 #include "AudioFileFlac.h"
 #include "endian_handling.h"
 #include "AudioEngine.h"
+#include "ProjectProperties.h"
 
 namespace lmms
 {
@@ -84,6 +85,11 @@ bool AudioFileFlac::startEncoding()
 
 	sf_command(m_sf, SFC_SET_CLIPPING, nullptr, SF_TRUE);
 
+	sf_set_string(m_sf, SF_STR_TITLE, ProjectProperties::inst()->value("meta", "title").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_ARTIST, ProjectProperties::inst()->value("meta", "artist").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_ALBUM, ProjectProperties::inst()->value("meta", "album").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_DATE, ProjectProperties::inst()->value("meta", "year").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_COMMENT, ProjectProperties::inst()->value("meta", "comment", "Created with LMMS").toLocal8Bit().constData());
 	sf_set_string(m_sf, SF_STR_SOFTWARE, "LMMS");
 
 	return true;

--- a/src/core/audio/AudioFileMP3.cpp
+++ b/src/core/audio/AudioFileMP3.cpp
@@ -25,6 +25,7 @@
 
 #include "AudioFileMP3.h"
 
+#include "ProjectProperties.h"
 #include "SampleFrame.h"
 
 #ifdef LMMS_HAVE_MP3LAME
@@ -120,7 +121,11 @@ bool AudioFileMP3::initEncoder()
 
 	// Add a comment
 	id3tag_init(m_lame);
-	id3tag_set_comment(m_lame, "Created with LMMS");
+	id3tag_set_title(m_lame, ProjectProperties::inst()->value("meta", "title").toLocal8Bit().constData());
+	id3tag_set_artist(m_lame, ProjectProperties::inst()->value("meta", "artist").toLocal8Bit().constData());
+	id3tag_set_album(m_lame, ProjectProperties::inst()->value("meta", "album").toLocal8Bit().constData());
+	id3tag_set_year(m_lame, ProjectProperties::inst()->value("meta", "year").toLocal8Bit().constData());
+	id3tag_set_comment(m_lame, ProjectProperties::inst()->value("meta", "comment", "Created with LMMS").toLocal8Bit().constData());
 
 	return lame_init_params(m_lame) != -1;
 }

--- a/src/core/audio/AudioFileOgg.cpp
+++ b/src/core/audio/AudioFileOgg.cpp
@@ -33,6 +33,7 @@
 #include <vorbis/vorbisenc.h>
 
 #include "AudioEngine.h"
+#include "ProjectProperties.h"
 
 namespace lmms
 {
@@ -54,7 +55,11 @@ AudioFileOgg::AudioFileOgg(OutputSettings const& outputSettings, const ch_cnt_t 
 
 	vorbis_analysis_init(&m_vds, &m_vi);
 	vorbis_comment_init(&m_vc);
-	vorbis_comment_add_tag(&m_vc, "Cool", "This song has been made using LMMS");
+	vorbis_comment_add_tag(&m_vc, "Title", ProjectProperties::inst()->value("meta", "title").toLocal8Bit().constData());
+	vorbis_comment_add_tag(&m_vc, "Artist", ProjectProperties::inst()->value("meta", "artist").toLocal8Bit().constData());
+	vorbis_comment_add_tag(&m_vc, "Album", ProjectProperties::inst()->value("meta", "album").toLocal8Bit().constData());
+	vorbis_comment_add_tag(&m_vc, "Year", ProjectProperties::inst()->value("meta", "year").toLocal8Bit().constData()); // TODO why does this not show up in nautilus?
+	vorbis_comment_add_tag(&m_vc, "Comment", ProjectProperties::inst()->value("meta", "comment", "Created with LMMS").toLocal8Bit().constData());
 
 	auto headerPackets = std::array<ogg_packet, 3>{};
 	vorbis_analysis_headerout(&m_vds, &m_vc, &headerPackets[0], &headerPackets[1], &headerPackets[2]);

--- a/src/core/audio/AudioFileWave.cpp
+++ b/src/core/audio/AudioFileWave.cpp
@@ -26,6 +26,7 @@
 #include "AudioFileWave.h"
 #include "endian_handling.h"
 #include "AudioEngine.h"
+#include "ProjectProperties.h"
 
 
 namespace lmms
@@ -88,6 +89,11 @@ bool AudioFileWave::startEncoding()
 	// Prevent fold overs when encountering clipped data
 	sf_command(m_sf, SFC_SET_CLIPPING, nullptr, SF_TRUE);
 
+	sf_set_string(m_sf, SF_STR_TITLE, ProjectProperties::inst()->value("meta", "title").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_ARTIST, ProjectProperties::inst()->value("meta", "artist").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_ALBUM, ProjectProperties::inst()->value("meta", "album").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_DATE, ProjectProperties::inst()->value("meta", "year").toLocal8Bit().constData());
+	sf_set_string(m_sf, SF_STR_COMMENT, ProjectProperties::inst()->value("meta", "comment", "Created with LMMS").toLocal8Bit().constData());
 	sf_set_string ( m_sf, SF_STR_SOFTWARE, "LMMS" );
 
 	return true;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(LMMS_SRCS
 	gui/PeakControllerDialog.cpp
 	gui/PluginBrowser.cpp
 	gui/ProjectNotes.cpp
+	gui/ProjectPropertiesDialog.cpp
 	gui/RowTableView.cpp
 	gui/SampleLoader.cpp
 	gui/SampleTrackWindow.cpp

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -59,6 +59,7 @@
 #include "PluginView.h"
 #include "ProjectJournal.h"
 #include "ProjectNotes.h"
+#include "ProjectPropertiesDialog.h"
 #include "ProjectRenderer.h"
 #include "RecentProjectsMenu.h"
 #include "RemotePlugin.h"
@@ -354,6 +355,8 @@ void MainWindow::finalize()
 	edit_menu->addSeparator();
 	edit_menu->addAction(embed::getIconPixmap("microtuner"), tr("Scales and keymaps"),
 		this, SLOT(toggleMicrotunerWin()));
+	edit_menu->addAction(embed::getIconPixmap("setup_general"), tr("Project Properties"),
+		this, SLOT(showProjectPropertiesDialog()));
 	edit_menu->addAction(embed::getIconPixmap("setup_general"), tr("Settings"),
 		this, SLOT(showSettingsDialog()));
 
@@ -1041,6 +1044,11 @@ void MainWindow::toggleMicrotunerWin()
 }
 
 
+void MainWindow::showProjectPropertiesDialog()
+{
+	ProjectPropertiesDialog ppd;
+	ppd.exec();
+}
 
 
 void MainWindow::updateViewMenu()

--- a/src/gui/ProjectPropertiesDialog.cpp
+++ b/src/gui/ProjectPropertiesDialog.cpp
@@ -65,10 +65,8 @@ ProjectPropertiesDialog::ProjectPropertiesDialog():
 	m_metaTitle(ProjectProperties::inst()->value("meta","title", QFileInfo(Engine::getSong()->projectFileName()).baseName())),
 	m_metaArtist(ProjectProperties::inst()->value("meta","artist", "")),
 	m_metaAlbum(ProjectProperties::inst()->value("meta","album", "")),
-	m_metaYear(ProjectProperties::inst()->value("meta","year", "1970")),
-	m_metaComment(ProjectProperties::inst()->value("meta","comment", "")),
-	m_metaGenre(ProjectProperties::inst()->value("meta","genre", "")),
-	m_metaSoftware(ProjectProperties::inst()->value("meta","software", "LMMS"))
+	m_metaYear(ProjectProperties::inst()->value("meta","year", "")),
+	m_metaComment(ProjectProperties::inst()->value("meta","comment", "Created with LMMS"))
 {
 	setWindowIcon(embed::getIconPixmap("setup_general"));
 	setWindowTitle(tr("Project Properties"));
@@ -144,8 +142,6 @@ ProjectPropertiesDialog::ProjectPropertiesDialog():
 	addMetaDataLine(tr("Album"), m_metaAlbumLineEdit, &m_metaAlbum);
 	addMetaDataLine(tr("Year"), m_metaYearLineEdit, &m_metaYear);
 	addMetaDataLine(tr("Comment"), m_metaCommentLineEdit, &m_metaComment);
-	addMetaDataLine(tr("Genre"), m_metaGenreLineEdit, &m_metaGenre);
-	addMetaDataLine(tr("Software"), m_metaSoftwareLineEdit, &m_metaSoftware);
 
 	generalControlsLayout->addWidget(metaDataGroupBox);
 	generalControlsLayout->addSpacing(10);
@@ -224,8 +220,6 @@ void ProjectPropertiesDialog::accept()
 	ProjectProperties::inst()->setValue("meta", "album", m_metaAlbum);
 	ProjectProperties::inst()->setValue("meta", "year", m_metaYear);
 	ProjectProperties::inst()->setValue("meta", "comment", m_metaComment);
-	ProjectProperties::inst()->setValue("meta", "genre", m_metaGenre);
-	ProjectProperties::inst()->setValue("meta", "software", m_metaSoftware);
 }
 
 

--- a/src/gui/ProjectPropertiesDialog.cpp
+++ b/src/gui/ProjectPropertiesDialog.cpp
@@ -1,0 +1,179 @@
+/*
+ * ProjectPropertiesDialog.cpp - Configuration widget for project-specific settings
+ *
+ * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2025 regulus79
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+*/
+
+#include "ProjectPropertiesDialog.h"
+
+#include <QLabel>
+#include <QLayout>
+#include <QPushButton>
+#include <QScrollArea>
+
+#include "embed.h"
+#include "GuiApplication.h"
+#include "MainWindow.h"
+#include "TabBar.h"
+#include "TabButton.h"
+
+namespace lmms::gui
+{
+
+
+inline void labelWidget(QWidget * w, const QString & txt)
+{
+	auto title = new QLabel(txt, w);
+	QFont f = title->font();
+	f.setBold(true);
+	title->setFont(f);
+
+	QBoxLayout * boxLayout = dynamic_cast<QBoxLayout *>(w->layout());
+	assert(boxLayout);
+
+	boxLayout->addWidget(title);
+}
+
+
+
+ProjectPropertiesDialog::ProjectPropertiesDialog()
+{
+	setWindowIcon(embed::getIconPixmap("setup_general"));
+	setWindowTitle(tr("Project Properties"));
+	setWindowFlag(Qt::WindowContextHelpButtonHint, false);
+	setModal(true);
+
+
+
+	// Main widget.
+	auto main_w = new QWidget(this);
+
+	// Vertical layout.
+	auto vlayout = new QVBoxLayout(this);
+	vlayout->setSpacing(0);
+	vlayout->setContentsMargins(0, 0, 0, 0);
+
+	// Horizontal layout.
+	auto hlayout = new QHBoxLayout(main_w);
+	hlayout->setSpacing(0);
+	hlayout->setContentsMargins(0, 0, 0, 0);
+
+	// Tab bar for the main tabs.
+	m_tabBar = new TabBar(main_w, QBoxLayout::TopToBottom);
+	m_tabBar->setExclusive(true);
+	m_tabBar->setFixedWidth(72);
+
+	// Settings widget.
+	auto settings_w = new QWidget(main_w);
+
+	QVBoxLayout * settingsLayout = new QVBoxLayout(settings_w);
+
+
+
+
+
+	// General widget.
+	auto general_w = new QWidget(settings_w);
+	auto general_layout = new QVBoxLayout(general_w);
+	general_layout->setSpacing(10);
+	general_layout->setContentsMargins(0, 0, 0, 0);
+	labelWidget(general_w, tr("General"));
+
+	// General scroll area.
+	auto generalScroll = new QScrollArea(general_w);
+	generalScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+	generalScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+	// General controls widget.
+	auto generalControls = new QWidget(general_w);
+
+	// Path selectors layout.
+	auto generalControlsLayout = new QVBoxLayout;
+	generalControlsLayout->setSpacing(10);
+	generalControlsLayout->setContentsMargins(0, 0, 0, 0);
+
+
+	generalControlsLayout->addWidget(new QLabel{tr("Loop edit mode"), generalControls});
+
+
+	// General layout ordering.
+	generalControlsLayout->addStretch();
+	generalControls->setLayout(generalControlsLayout);
+	generalScroll->setWidget(generalControls);
+	generalScroll->setWidgetResizable(true);
+	general_layout->addWidget(generalScroll, 1);
+
+	// Add all main widgets to the layout of the settings widget
+	// This is needed so that we automatically get the correct sizes.
+	settingsLayout->addWidget(general_w);
+
+	// Major tabs ordering.
+	m_tabBar->addTab(general_w,
+		tr("General"), 0, false, true, false)->setIcon(
+				embed::getIconPixmap("setup_general"));
+
+	m_tabBar->setActiveTab(0);
+
+
+	// Horizontal layout ordering.
+	hlayout->addSpacing(2);
+	hlayout->addWidget(m_tabBar);
+	hlayout->addSpacing(10);
+	hlayout->addWidget(settings_w);
+	hlayout->addSpacing(10);
+
+
+	// Extras widget and layout.
+	auto extras_w = new QWidget(this);
+	auto extras_layout = new QHBoxLayout(extras_w);
+	extras_layout->setSpacing(0);
+	extras_layout->setContentsMargins(0, 0, 0, 0);
+
+	// OK button.
+	auto ok_btn = new QPushButton(embed::getIconPixmap("apply"), tr("OK"), extras_w);
+	connect(ok_btn, SIGNAL(clicked()),
+			this, SLOT(accept()));
+
+	// Cancel button.
+	auto cancel_btn = new QPushButton(embed::getIconPixmap("cancel"), tr("Cancel"), extras_w);
+	connect(cancel_btn, SIGNAL(clicked()),
+			this, SLOT(reject()));
+
+	vlayout->addWidget(main_w, 1);
+	vlayout->addSpacing(10);
+	vlayout->addWidget(extras_w);
+	vlayout->addSpacing(10);
+
+	// Ensure that we cannot make the dialog smaller than it wants to be
+	setMinimumWidth(width());
+
+	show();
+}
+
+
+void ProjectPropertiesDialog::accept()
+{
+	QDialog::accept();
+}
+
+
+} // namespace lmms::gui


### PR DESCRIPTION
Basically, we have no way to store project properties. And that's okay for the most part, but for things like metadata or (in the future, the ticks per bar), we have no place to store them.

Usually for settings like that you would use `ConfigManager::inst()->value()`, and it would store it in the lmmsrc file, and maybe let the user see/edit the settings in the `SetupDialog`.

So, I decided to implement a `ProjectProperties` class analogous to `ConfigManager`, but it saves to the project file instead of the lmmsrc file. Also, I added a `ProjectPropertiesDialog` analogous to the `SetupDialog` to let the user edit them.

I copied a lot of code from `ConfigManager` and `SetupDialog`, so they do act/look quite similar. (Also `ProjectPropertiesDialog` is kind of a mess)

## Images

To demo the functionality, I've added a way to edit the export metadata of the song. (And yes, this is functional when exporting wav, ogg, flac, and mp3, so now you can edit your audio metadata from within LMMS!)

![Screenshot From 2025-04-27 11-48-55](https://github.com/user-attachments/assets/bfcbbd8d-0bf8-49c5-b57a-f7f62528eaf5)

Note, I'm not done with the UI! It looks really bad right now but I want to improve it (I would love feedback)

## Usage
Anytime you want to access/save a project-specific setting, just put

```
#include "ProjectProperties.h";
```
at the top of your file, and then do
```
ProjectProperties::inst()->value("category", "name", "default");
```
to access a value, and
```
ProjectProperties::inst()->setValue("category", "name", "value");
```
to set it.
The settings will be saved to the project file whenever the user saves the project. 
