### PR TITLE
Fix PeakController for short attacks

### DIFF
--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -61,7 +61,6 @@ public:
 public slots:
 	gui::ControllerDialog * createDialog( QWidget * _parent ) override;
 	void handleDestroyedEffect();
-	void updateCoeffs();
 
 protected:
 	// The internal per-controller get-value function
@@ -77,9 +76,6 @@ private:
 	static int m_getCount;
 	static int m_loadCount;
 	static bool m_buggedFile;
-	
-	float m_coeff;
-	bool m_coeffNeedsUpdate;
 } ;
 
 namespace gui


### PR DESCRIPTION
Long story short, current is on top, fixed is on the bottom:
![image](https://github.com/user-attachments/assets/413eeeee-8f8c-4c92-97ff-47910e4f3e6c)

And in case you're worried about artifacts (similar to the original, before the current version), there aren't any:
![image](https://github.com/user-attachments/assets/a59b28c0-fd2b-4a28-ba24-80d4380c8140)

The file I used to test is [uploaded to Discord](https://canary.discord.com/channels/203559236729438208/784594576223633478/1367042579392368652). Basically, it shows activating a peak controller with 0 attack and 0 decay, then a peak controller with high (0.95-ish?) attack and high decay. As shown, the current version does not execute a fast attack; it takes 34 milliseconds to transition from 0 dbFS to -30 dbFS, 68 milliseconds to get to -60 dbFS, and in that time the transient the peak controller is supposed to be following might have ended in the first 8 milliseconds.

PeakController presently having such a long minimum tail is preventing one of my friends from updating to the newest LMMS because it breaks all of his sidechains, and there is no other way to replicate the sidechain effect. This will fix it.