### PR TITLE
Fix issue with Mixer key events and Track Label Button focus

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -235,6 +235,10 @@ void MixerChannelView::keyPressEvent(QKeyEvent* ke)
 	{
 		m_fader->adjustByDialog();
 	}
+	else
+	{
+		ke->ignore();
+	}
 }
 
 void MixerChannelView::setChannelIndex(int index)

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -267,7 +267,7 @@ void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 		hide();
 	}
 
-	m_stv->parentWidget()->setFocus();
+	m_stv->setFocus();
 	m_stv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -39,7 +39,6 @@
 #include "MixerChannelLcdSpinBox.h"
 #include "SampleTrackView.h"
 #include "Song.h"
-#include "SongEditor.h"
 #include "SubWindow.h"
 #include "TrackLabelButton.h"
 
@@ -268,7 +267,7 @@ void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 		hide();
 	}
 
-	getGUI()->songEditor()->parentWidget()->setFocus();
+	m_stv->parentWidget()->setFocus();
 	m_stv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -39,6 +39,7 @@
 #include "MixerChannelLcdSpinBox.h"
 #include "SampleTrackView.h"
 #include "Song.h"
+#include "SongEditor.h"
 #include "SubWindow.h"
 #include "TrackLabelButton.h"
 
@@ -267,7 +268,7 @@ void SampleTrackWindow::closeEvent(QCloseEvent* ce)
 		hide();
 	}
 
-	m_stv->m_tlb->setFocus();
+	getGUI()->songEditor()->parentWidget()->setFocus();
 	m_stv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -60,6 +60,7 @@
 #include "PianoView.h"
 #include "PluginFactory.h"
 #include "Song.h"
+#include "SongEditor.h"
 #include "StringPairDrag.h"
 #include "SubWindow.h"
 #include "TabWidget.h"
@@ -539,6 +540,7 @@ void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 		hide();
 	}
 
+	getGUI()->songEditor()->parentWidget()->setFocus();
 	m_itv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -539,7 +539,7 @@ void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 		hide();
 	}
 
-	m_itv->parentWidget()->setFocus();
+	m_itv->setFocus();
 	m_itv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -539,8 +539,7 @@ void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 		hide();
 	}
 
-	m_itv->m_tlb->setFocus();
-	m_itv->m_tlb->setChecked( false );
+	m_itv->m_tlb->setChecked(false);
 }
 
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -60,7 +60,6 @@
 #include "PianoView.h"
 #include "PluginFactory.h"
 #include "Song.h"
-#include "SongEditor.h"
 #include "StringPairDrag.h"
 #include "SubWindow.h"
 #include "TabWidget.h"
@@ -540,7 +539,7 @@ void InstrumentTrackWindow::closeEvent( QCloseEvent* event )
 		hide();
 	}
 
-	getGUI()->songEditor()->parentWidget()->setFocus();
+	m_itv->parentWidget()->setFocus();
 	m_itv->m_tlb->setChecked(false);
 }
 

--- a/src/gui/tracks/TrackLabelButton.cpp
+++ b/src/gui/tracks/TrackLabelButton.cpp
@@ -47,6 +47,7 @@ TrackLabelButton::TrackLabelButton( TrackView * _tv, QWidget * _parent ) :
 	m_iconName()
 {
 	setAcceptDrops( true );
+	setFocusPolicy(Qt::NoFocus);
 	setCursor( QCursor( embed::getIconPixmap( "hand" ), 3, 3 ) );
 	setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
 


### PR DESCRIPTION
After #7762 was merged, I forgot to add `ke->ignore()` to the end of `MixerChannelView::keyPressEvent`, which meant that the mixer's keyboard shortcuts kind of broke.

Additionally, bratpeki noticed that the track label button grabs the focus after the instrument window has been closed, which means pressing space reopens the window. I have also fixed this by adding `setFocusPolicy(Qt::NoFocus)` to the TrackLabelButton. But that didn't seem to fix it, so I also removed the calls to set focus on the button, instead setting the focus on the ~~song editor window~~ parent widget of the track view.