### PR TITLE
Fix old projects loading clips with auto-resize disabled

### DIFF
--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -865,7 +865,7 @@ void AutomationClip::loadSettings( const QDomElement & _this )
 							"prog" ).toInt() ) );
 	setTension( _this.attribute( "tens" ) );
 	setMuted(_this.attribute( "mute", QString::number( false ) ).toInt() );
-	setAutoResize(_this.attribute("autoresize").toInt());
+	setAutoResize(_this.attribute("autoresize", "1").toInt());
 	setStartTimeOffset(_this.attribute("off").toInt());
 
 	for( QDomNode node = _this.firstChild(); !node.isNull();

--- a/src/core/PatternClip.cpp
+++ b/src/core/PatternClip.cpp
@@ -80,7 +80,7 @@ void PatternClip::loadSettings(const QDomElement& element)
 		movePosition( element.attribute( "pos" ).toInt() );
 	}
 	changeLength( element.attribute( "len" ).toInt() );
-	setAutoResize(element.attribute("autoresize").toInt());
+	setAutoResize(element.attribute("autoresize", "1").toInt());
 	setStartTimeOffset(element.attribute("off").toInt());
 	if (static_cast<bool>(element.attribute("muted").toInt()) != isMuted())
 	{

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -356,7 +356,7 @@ void SampleClip::loadSettings( const QDomElement & _this )
 	changeLength( _this.attribute( "len" ).toInt() );
 	setMuted( _this.attribute( "muted" ).toInt() );
 	setStartTimeOffset( _this.attribute( "off" ).toInt() );
-	setAutoResize(_this.attribute("autoresize").toInt());
+	setAutoResize(_this.attribute("autoresize", "1").toInt());
 
 	if (_this.hasAttribute("color"))
 	{

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -532,7 +532,7 @@ void MidiClip::loadSettings( const QDomElement & _this )
 		changeLength(len);
 	}
 	
-	setAutoResize(_this.attribute("autoresize").toInt());
+	setAutoResize(_this.attribute("autoresize", "1").toInt());
 	setStartTimeOffset(_this.attribute("off").toInt());
 
 	emit dataChanged();


### PR DESCRIPTION
In #7477, I forgot that clips in old projects are not saved with an "autoresize" attribute, so when loading them, it defaults to 0. However, this causes old clips in projects to be loaded without auto-resize which is not the normal behavior.

This PR fixes this by setting the default value when accessing the attribute to be 1.