### PR TITLE
Fix Position Line gradient appearing in all editors no matter which one is playing

### DIFF
--- a/include/PositionLine.h
+++ b/include/PositionLine.h
@@ -28,6 +28,8 @@
 
 #include <QWidget>
 
+#include "Song.h"
+
 namespace lmms::gui
 {
 
@@ -37,13 +39,15 @@ class PositionLine : public QWidget
 	Q_PROPERTY(bool tailGradient MEMBER m_hasTailGradient)
 	Q_PROPERTY(QColor lineColor MEMBER m_lineColor)
 public:
-	PositionLine(QWidget* parent);
+	PositionLine(QWidget* parent, Song::PlayMode playMode);
 
 public slots:
 	void zoomChange(float zoom);
 
 private:
 	void paintEvent(QPaintEvent* pe) override;
+
+	Song::PlayMode m_playMode;
 
 	bool m_hasTailGradient;
 	QColor m_lineColor;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -283,7 +283,7 @@ PianoRoll::PianoRoll() :
 			this, SLOT( updatePosition( const lmms::TimePos& ) ) );
 
 	// white position line follows timeline marker
-	m_positionLine = new PositionLine(this);
+	m_positionLine = new PositionLine(this, Song::PlayMode::MidiClip);
 
 	//update timeline when in step-recording mode
 	connect( &m_stepRecorderWidget, SIGNAL( positionChanged( const lmms::TimePos& ) ),

--- a/src/gui/editors/PositionLine.cpp
+++ b/src/gui/editors/PositionLine.cpp
@@ -26,14 +26,13 @@
 
 #include <QPainter>
 
-#include "Song.h"
-
 
 namespace lmms::gui
 {
 
-PositionLine::PositionLine(QWidget* parent) :
+PositionLine::PositionLine(QWidget* parent, Song::PlayMode playMode) :
 	QWidget(parent),
+	m_playMode(playMode),
 	m_hasTailGradient(false),
 	m_lineColor(0, 0, 0, 0)
 {
@@ -64,8 +63,7 @@ void PositionLine::paintEvent(QPaintEvent* pe)
 		// If gradient is enabled, we're in focus and we're playing, enable gradient
 		if (m_hasTailGradient &&
 			Engine::getSong()->isPlaying() &&
-			(Engine::getSong()->playMode() == Song::PlayMode::Song ||
-			 Engine::getSong()->playMode() == Song::PlayMode::MidiClip))
+			(Engine::getSong()->playMode() == m_playMode))
 		{
 			c.setAlpha(60);
 			gradient.setColorAt(w, c);

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -113,7 +113,7 @@ SongEditor::SongEditor( Song * song ) :
 	// when tracks realign, adjust height of position line
 	connect(this, &TrackContainerView::tracksRealigned, this, &SongEditor::updatePositionLine);
 
-	m_positionLine = new PositionLine(this);
+	m_positionLine = new PositionLine(this, Song::PlayMode::Song);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );
 
 	connect( m_song, SIGNAL(playbackStateChanged()),


### PR DESCRIPTION
Currently in master, if you zoom in on both the song editor and the piano roll, then play either of them, both playhead/position lines will have their gradient/tail appear, even though only one of them is playing.

This is because the position line only checks if either the song or a midi clip is playing, as it doesn't directly know which editor it belongs to.

I fixed this issue by adding the PlayMode for the position line as an argument in its constructor, which it can use to check whether it's corresponding editor is playing, and if so, show the gradient.