### PR TITLE
implementing actions 2

### DIFF
--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -72,7 +72,7 @@ protected:
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPaste(const QMimeData* mimeData) override;
+	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
 
 private:
 	AutomationClip * m_clip;

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -68,9 +68,6 @@ protected:
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
 
-	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
-	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
-
 private:
 	AutomationClip * m_clip;
 	QPixmap m_paintPixmap;

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -67,19 +67,13 @@ protected:
 	void paintEvent( QPaintEvent * pe ) override;
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
-	
-	const std::vector<ModelShortcut>& getShortcuts() override;
-	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
-	QString getShortcutMessage() override;
+
 	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
 	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 
 private:
 	AutomationClip * m_clip;
 	QPixmap m_paintPixmap;
-	
-	static QString m_shortcutMessage;
-	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 	
 	QStaticText m_staticTextName;
 	void scaleTimemapToFit( float oldMin, float oldMax );

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -71,8 +71,8 @@ protected:
 	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
-	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
+	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
+	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 
 private:
 	AutomationClip * m_clip;

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -68,7 +68,7 @@ protected:
 	void dragEnterEvent( QDragEnterEvent * _dee ) override;
 	void dropEvent( QDropEvent * _de ) override;
 	
-	std::vector<ModelShortcut> getShortcuts() override;
+	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
@@ -79,6 +79,7 @@ private:
 	QPixmap m_paintPixmap;
 	
 	static QString m_shortcutMessage;
+	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 	
 	QStaticText m_staticTextName;
 	void scaleTimemapToFit( float oldMin, float oldMax );

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -181,7 +181,7 @@ protected:
 	
 	// InteractiveModelView methods
 	void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate) override;
-	void addActions(std::vector<CommandData>& targetList) override {}
+	void addCommands(std::vector<CommandData>& targetList) override {}
 
 	bool unquantizedModHeld( QMouseEvent * me );
 	TimePos quantizeSplitPos(TimePos);

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -73,7 +73,7 @@ class ClipView : public selectableObject, public ModelView
 public:
 	const static int BORDER_WIDTH = 2;
 
-	ClipView( Clip * clip, TrackView * tv );
+	ClipView(Clip * clip, TrackView * tv, size_t typeId);
 	~ClipView() override;
 
 	bool fixedClips();
@@ -180,9 +180,8 @@ protected:
 	}
 	
 	// InteractiveModelView methods
-	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
-	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 	void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate) override;
+	void addActions(std::vector<CommandData>& targetList) override {}
 
 	bool unquantizedModHeld( QMouseEvent * me );
 	TimePos quantizeSplitPos(TimePos);

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -180,7 +180,7 @@ protected:
 	}
 	
 	// InteractiveModelView methods
-	std::vector<ModelShortcut> getShortcuts() override;
+	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
@@ -219,6 +219,7 @@ private:
 
 	static TextFloat * s_textFloat;
 	static QString m_shortcutMessage;
+	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 
 	Clip * m_clip;
 	Action m_action;

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -185,7 +185,7 @@ protected:
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
 	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
-	void overrideSetIsHighlighted(bool isHighlighted) override;
+	void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate) override;
 
 	bool unquantizedModHeld( QMouseEvent * me );
 	TimePos quantizeSplitPos(TimePos);

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -180,9 +180,6 @@ protected:
 	}
 	
 	// InteractiveModelView methods
-	const std::vector<ModelShortcut>& getShortcuts() override;
-	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
-	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
 	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 	void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate) override;
@@ -202,8 +199,6 @@ protected:
 protected slots:
 	void updateLength();
 	void updatePosition();
-
-	static QString getDefaultSortcutMessage();
 private:
 	enum class Action
 	{
@@ -218,8 +213,6 @@ private:
 	} ;
 
 	static TextFloat * s_textFloat;
-	static QString m_shortcutMessage;
-	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 
 	Clip * m_clip;
 	Action m_action;

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -128,8 +128,8 @@ public:
 
 	void toggleSelectedAutoResize();
 	
-	//! used for getting the correct clip `StringPairDataType` for a given track
-	static Clipboard::StringPairDataType getClipStringPairType(Track* track);
+	//! used for getting the correct clip `DataType` for a given track
+	static Clipboard::DataType getClipStringPairType(Track* track);
 
 	QColor getColorForDisplay( QColor );
 
@@ -183,8 +183,8 @@ protected:
 	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
-	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
+	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
+	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 	void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate) override;
 
 	bool unquantizedModHeld( QMouseEvent * me );

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -48,7 +48,10 @@ namespace Clipboard
 	
 	enum DataType
 	{
-		None, //!< only use for error handling
+		Error, //!< only use for error handling
+		All, //!< use if all kinds of data is accepted (used by actions)
+		Any, //!< use if the data type is ignored when parsing (used by actions)
+	
 		FloatValue,
 		AutomatableModelLink,
 		Instrument,
@@ -88,8 +91,8 @@ namespace Clipboard
 
 	// Helper methods for String Pair data
 	QString getStringPairKeyName(DataType type);
-	void copyStringPair(DataType key, const QString& value, bool shouldHighlightWidgets = true);
-	DataType LMMS_EXPORT decodeKey(const QMimeData* mimeData);
+	void copyStringPair(DataType key, const QString& value);
+	DataType decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
 
 	QString encodeFloatValue(float value);

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -89,7 +89,7 @@ namespace Clipboard
 	// Helper methods for String Pair data
 	QString getStringPairKeyName(DataType type);
 	void copyStringPair(DataType key, const QString& value, bool shouldHighlightWidgets = true);
-	DataType decodeKey(const QMimeData* mimeData);
+	DataType LMMS_EXPORT decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
 
 	QString encodeFloatValue(float value);

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -46,7 +46,7 @@ namespace Clipboard
 		Default
 	};
 	
-	enum StringPairDataType
+	enum DataType
 	{
 		None, //!< only use for error handling
 		FloatValue,
@@ -87,9 +87,9 @@ namespace Clipboard
 	QString getString( MimeType mT );
 
 	// Helper methods for String Pair data
-	QString getStringPairKeyName(StringPairDataType type);
-	void copyStringPair(StringPairDataType key, const QString& value);
-	StringPairDataType decodeKey(const QMimeData* mimeData);
+	QString getStringPairKeyName(DataType type);
+	void copyStringPair(DataType key, const QString& value);
+	DataType decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
 
 	QString encodeFloatValue(float value);

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -88,7 +88,7 @@ namespace Clipboard
 
 	// Helper methods for String Pair data
 	QString getStringPairKeyName(DataType type);
-	void copyStringPair(DataType key, const QString& value);
+	void copyStringPair(DataType key, const QString& value, bool shouldHighlightWidgets = true);
 	DataType decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
 

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -92,7 +92,7 @@ namespace Clipboard
 	// Helper methods for String Pair data
 	QString getStringPairKeyName(DataType type);
 	void copyStringPair(DataType key, const QString& value);
-	DataType decodeKey(const QMimeData* mimeData);
+	DataType LMMS_EXPORT decodeKey(const QMimeData* mimeData);
 	QString decodeValue( const QMimeData * mimeData );
 
 	QString encodeFloatValue(float value);

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -86,9 +86,6 @@ protected:
 	void leaveEvent(QEvent *event) override;
 
 	// InteractiveModelView methods
-	const std::vector<ModelShortcut>& getShortcuts() override;
-	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
-	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
 	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 
@@ -113,8 +110,6 @@ private:
 	}
 
 	static SimpleTextFloat * s_textFloat;
-	static QString m_shortcutMessage;
-	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -89,8 +89,8 @@ protected:
 	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
-	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
+	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
+	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 
 	virtual float getValue(const QPoint & p);
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -77,6 +77,7 @@ public:
 	void openInputDialogCommand();
 	void toggleScaleCommand();
 	void setScaleLogarithmicCommand(bool isLogarithmic);
+	void setPositionCommand(QPoint p);
 
 signals:
 	void sliderPressed();
@@ -113,7 +114,6 @@ private:
 	void doConnections() override;
 
 	void showTextFloat(int msecBeforeDisplay, int msecDisplayTime);
-	void setPosition(const QPoint & p);
 
 	inline float pageSize() const
 	{

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -86,8 +86,7 @@ protected:
 	void leaveEvent(QEvent *event) override;
 
 	// InteractiveModelView methods
-	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
-	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
+	void addActions(std::vector<CommandData>& targetList) override {}
 
 	virtual float getValue(const QPoint & p);
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -90,7 +90,7 @@ protected:
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPaste(const QMimeData* mimeData) override;
+	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
 
 	virtual float getValue(const QPoint & p);
 

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -64,6 +64,20 @@ public:
 		setUnit(txt_after);
 	}
 
+	void copyValueCommand();
+	void pasteNoReturnCommand();
+	void pasteCommand(bool* isSuccessful);
+	void linkCommand(int id);
+	void unlinkCommand(int id);
+	void getLinkCommand();
+	void unlinkAllCommand();
+	void increaseValueCommand();
+	void decreaseValueCommand();
+	void setValueCommand(float floatValue);
+	void openInputDialogCommand();
+	void toggleScaleCommand();
+	void setScaleLogarithmicCommand(bool isLogarithmic);
+
 signals:
 	void sliderPressed();
 	void sliderReleased();
@@ -86,14 +100,12 @@ protected:
 	void leaveEvent(QEvent *event) override;
 
 	// InteractiveModelView methods
-	void addActions(std::vector<CommandData>& targetList) override {}
+	void addCommands(std::vector<CommandData>& targetList) override;
 
 	virtual float getValue(const QPoint & p);
 
 private slots:
-	virtual void enterValue();
 	void friendlyUpdate();
-	void toggleScale();
 
 private:
 	virtual QString displayValue() const;

--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -86,7 +86,7 @@ protected:
 	void leaveEvent(QEvent *event) override;
 
 	// InteractiveModelView methods
-	std::vector<ModelShortcut> getShortcuts() override;
+	const std::vector<ModelShortcut>& getShortcuts() override;
 	void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override;
 	QString getShortcutMessage() override;
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
@@ -114,6 +114,7 @@ private:
 
 	static SimpleTextFloat * s_textFloat;
 	static QString m_shortcutMessage;
+	static std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray;
 
 	BoolModel m_volumeKnob;
 	FloatModel m_volumeRatio;

--- a/include/GuiAction.h
+++ b/include/GuiAction.h
@@ -1,0 +1,196 @@
+/*
+ * GuiAction.h - implements Commands, a layer between the user and widgets
+ *
+ * Copyright (c) 2025 szeli1 <TODO/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_ACTION_H
+#define LMMS_GUI_ACTION_H
+
+#include <cassert>
+#include <memory>
+#include <utility>
+
+#include <QString>
+//#include <QUndoCommand>
+
+namespace lmms::gui
+{
+
+class InteractiveModelView;
+
+// a safe function pointer for commands
+class CommandFnPtr
+{
+public:
+	template<typename DataType>
+	void callFn(InteractiveModelView* object, DataType data)
+	{
+		callFnInternal(object, baseTypeId, static_cast<void*>(&data), typeid(DataType).hash_code())
+	}
+	void callFnTypeless(InteractiveModelView* object)
+	{
+		callFnInternal(object, baseTypeId, nullptr, 0)
+	}
+	
+	bool isValid() const = 0;
+	bool isMatch(void* functionPtr) const = 0;
+private:
+	virtual void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) = 0;
+};
+
+template<typename BaseType, typename DataType>
+class TypedCommandFnPtr : public CommandFnPtr
+{
+public:
+	typedef void (BaseType::*InternalFnPtr)(DataType);
+	
+	TypedCommandFnPtr(InternalFnPtr fnPtr) :
+		m_functionPtr(fnPtr)
+	{}
+	TypedCommandFnPtr() :
+		m_functionPtr(nullptr)
+	{}
+
+	bool isValid() const override { return m_functionPtr != nullptr; };
+	bool isMatch(void* functionPtr) const override { return static_cast<void*>(m_functionPtr) == functionPtr};
+private:
+	void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) override
+	{
+		qDebug("type assert debug: %ld, %ld, %s", dataTypeId, typeid(DataType).hash_code(), typeid(DataType).name());
+		if (m_functionPtr == nullptr || object == nullptr) { return; }
+		assert(data != nullptr);
+		// if this assert fails, `InteractiveModelView::getStoredTypeId()` is wrong type
+		assert(typeid(BaseType).hash_code() == baseTypeId);
+		// if this assert fails, you need to change your `DataType` template to the one this class was constructed with
+		assert(typeid(DataType).hash_code() == dataTypeId);
+		// calling the function ptr
+		(static_cast<BaseType>(object)->*m_functionPtr)(*static_cast<DataType>(data));
+	}
+	InternalFnPtr* m_functionPtr;
+};
+
+template<typename BaseType>
+class BasicCommandFnPtr : public CommandFnPtr
+{
+public:
+	typedef void (BaseType::*InternalFnPtr)();
+	
+	BasicCommandFnPtr(InternalFnPtr fnPtr) :
+		m_functionPtr(fnPtr)
+	{}
+	BasicCommandFnPtr() :
+		m_functionPtr(nullptr)
+	{}
+
+	bool isValid() const override { return m_functionPtr != nullptr; };
+	bool isMatch(void* functionPtr) const override { return static_cast<void*>(m_functionPtr) == functionPtr};
+private:
+	void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) override
+	{
+		qDebug("type assert debug: %ld, %ld, %s", baseTypeId, typeid(BaseType).hash_code(), typeid(BaseType).name());
+		if (m_functionPtr == nullptr || object == nullptr) { return; }
+		// if this assert fails, `InteractiveModelView::getStoredTypeId()` is wrong type (function isn't member to type)
+		assert(typeid(BaseType).hash_code() == object->getStoredTypeId());
+		// calling the function ptr
+		(static_cast<BaseType>(object)->*m_functionPtr)();
+	}
+	InternalFnPtr* m_functionPtr;
+};
+
+
+class AbstractGuiAction// : public QUndoCommand
+{
+public:
+	AbstractGuiAction(const QString& name, InteractiveModelView* object, bool linkBack);
+	~AbstractGuiAction() {}
+	//! should be undone along with the action before this
+	bool getShouldLinkBack();
+	//! returns true if cleared, use this to delete pointers to destructing objects
+	bool clearObjectIfMatch(InteractiveModelView* object);
+protected:
+	const QString m_name;
+	InteractiveModelView* m_target;
+	bool m_isLinkedBack; //! if this is undone, undo the one before this
+};
+
+class GuiAction : public AbstractGuiAction
+{
+public:
+	GuiAction(const QString& name, InteractiveModelView* object, CommandFnPtr doFn, CommandFnPtr undoFn, size_t runAmount, bool linkBack);
+	void undo();// override
+	void redo();// override
+private:
+	size_t m_runAmount;
+	CommandFnPtr m_doFn;
+	CommandFnPtr m_undoFn;
+};
+
+
+
+template<typename DataType>
+class GuiActionTyped : public AbstractGuiAction
+{
+public:
+	GuiActionTyped(const QString& name, InteractiveModelView* object, CommandFnPtr doFn, CommandFnPtr undoFn, DataType doData, DataType* undoData bool linkBack) :
+		AbstractGuiAction(name, object, linkBack),
+		m_doData(nullptr),
+		m_undoData(nullptr),
+		m_doFn(doFn),
+		m_undoFn(undoFn)
+	{
+		m_doData = std::make_unique<DataType>(doData);
+		m_undoData = undoData != nullptr ? std::make_unique<DataType>(*undoData) : nullptr;
+	}
+	void undo()// override
+	{
+		if (m_target == nullptr) { return; }
+		if (m_undoFn.isValid())
+		{
+			if (m_undoData.get() != nullptr)
+			{
+				m_undoFn.callFn<DataType>(m_target, *m_undoData.get());
+			}
+			else
+			{
+				m_undoFn.callFn<DataType>(m_target, *m_doData.get());
+			}
+		}
+		else if (m_doFn.isValid() && m_undoData.get() != nullptr)
+		{
+			m_doFn.callFn<BDataType>(m_target, *m_undoData.get());
+		}
+	}
+	void redo()// override
+	{
+		if (m_target == nullptr || m_doFn.isValid() == false) { return; }
+		m_doFn.callFn<DataType>(m_target, *m_doData.get());
+	}
+private:
+	std::unique_ptr<DataType> m_doData;
+	std::unique_ptr<DataType> m_undoData;
+	CommandFnPtr m_doFn;
+	CommandFnPtr m_undoFn;
+};
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_ACTION_H

--- a/include/GuiCommand.h
+++ b/include/GuiCommand.h
@@ -41,6 +41,7 @@ class InteractiveModelView;
 class CommandFnPtr
 {
 public:
+	virtual ~CommandFnPtr() {};
 	template<typename DataType>
 	void callFn(InteractiveModelView* object, DataType data)
 	{
@@ -63,13 +64,14 @@ class TypedCommandFnPtr : public CommandFnPtr
 {
 public:
 	typedef void (BaseType::*InternalFnPtr)(DataType);
-	
+
 	TypedCommandFnPtr(InternalFnPtr fnPtr) :
 		m_functionPtr(fnPtr)
 	{}
 	TypedCommandFnPtr() :
 		m_functionPtr(nullptr)
 	{}
+	~TypedCommandFnPtr() { qDebug("typed destructed"); };
 
 	CommandFnPtr* clone() const override
 	{
@@ -103,6 +105,7 @@ public:
 	BasicCommandFnPtr() :
 		m_functionPtr(nullptr)
 	{}
+	~BasicCommandFnPtr() {};
 
 	CommandFnPtr* clone() const override
 	{

--- a/include/GuiCommand.h
+++ b/include/GuiCommand.h
@@ -122,11 +122,11 @@ private:
 };
 
 
-class AbstractGuiCommand// : public QUndoCommand
+class AbstractCommand// : public QUndoCommand
 {
 public:
-	AbstractGuiCommand(const QString& name, InteractiveModelView* object, bool linkBack);
-	~AbstractGuiCommand() {}
+	AbstractCommand(const QString& name, InteractiveModelView* object, bool linkBack);
+	~AbstractCommand() {}
 	//! should be undone along with the action before this
 	bool getShouldLinkBack();
 	//! returns true if cleared, use this to delete pointers to destructing objects
@@ -137,10 +137,10 @@ protected:
 	bool m_isLinkedBack; //! if this is undone, undo the one before this
 };
 
-class GuiCommand : public AbstractGuiCommand
+class BasicCommand : public AbstractCommand
 {
 public:
-	GuiCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, size_t runAmount, bool linkBack);
+	BasicCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, size_t runAmount, bool linkBack);
 	void undo();// override
 	void redo();// override
 private:
@@ -152,11 +152,11 @@ private:
 
 
 template<typename DataType>
-class GuiCommandTyped : public AbstractGuiCommand
+class TypedCommand : public AbstractCommand
 {
 public:
-	GuiCommandTyped(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, DataType doData, DataType* undoData, bool linkBack) :
-		AbstractGuiCommand(name, object, linkBack),
+	TypedCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, DataType doData, DataType* undoData, bool linkBack) :
+		AbstractCommand(name, object, linkBack),
 		m_doData(nullptr),
 		m_undoData(nullptr),
 		m_doFn(doFn),

--- a/include/GuiCommand.h
+++ b/include/GuiCommand.h
@@ -54,7 +54,6 @@ public:
 	
 	virtual CommandFnPtr* clone() const = 0;
 	virtual bool isValid() const = 0;
-	virtual bool isMatch(void* functionPtr) const = 0;
 private:
 	virtual void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) = 0;
 };
@@ -77,11 +76,9 @@ public:
 		return new TypedCommandFnPtr<BaseType, DataType>(m_functionPtr);
 	}
 	bool isValid() const override { return m_functionPtr != nullptr; }
-	bool isMatch(void* functionPtr) const override { return reinterpret_cast<void*>(m_functionPtr) == functionPtr; }
 private:
 	void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) override
 	{
-		qDebug("type assert debug: %ld, %ld, %s", dataTypeId, typeid(DataType).hash_code(), typeid(DataType).name());
 		if (m_functionPtr == nullptr || object == nullptr) { return; }
 		assert(data != nullptr);
 		// if this assert fails, `InteractiveModelView::getStoredTypeId()` is wrong type
@@ -112,11 +109,9 @@ public:
 		return new BasicCommandFnPtr<BaseType>(m_functionPtr);
 	}
 	bool isValid() const override { return m_functionPtr != nullptr; }
-	bool isMatch(void* functionPtr) const override { return reinterpret_cast<void*>(m_functionPtr) == functionPtr; }
 private:
 	void callFnInternal(InteractiveModelView* object, void* data, size_t dataTypeId) override
 	{
-		qDebug("type assert debug: %ld, %ld, %s", getTypeIdFromInteractiveModelView(object), typeid(BaseType).hash_code(), typeid(BaseType).name());
 		if (m_functionPtr == nullptr || object == nullptr) { return; }
 		// if this assert fails, `InteractiveModelView::getStoredTypeId()` is wrong type (function isn't member to type)
 		assert(typeid(BaseType).hash_code() == getTypeIdFromInteractiveModelView(object));

--- a/include/GuiCommand.h
+++ b/include/GuiCommand.h
@@ -168,7 +168,7 @@ public:
 	void undo()// override
 	{
 		if (m_target == nullptr) { return; }
-		if (m_undoFn->isValid())
+		if (m_undoFn.get() != nullptr && m_undoFn->isValid())
 		{
 			if (m_undoData.get() != nullptr)
 			{

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -151,8 +151,6 @@ private:
 	ModelShortcut m_lastShortcut;
 	unsigned int m_lastShortcutCounter;
 
-	QWidget* m_focusedBeforeWidget;
-
 	static std::unique_ptr<QColor> s_highlightColor;
 	static QTimer* s_highlightTimer;
 	static SimpleTextFloat* s_simpleTextFloat;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -1,7 +1,7 @@
 /*
- * InteractiveModelView.h - Implements shortcut system, StringPair system and highlighting for widgets
+ * InteractiveModelView.h - Implements shortcut and action system for widgets
  *
- * Copyright (c) 2024 szeli1 <TODO/at/gmail/dot/com>
+ * Copyright (c) 2024 -2025 szeli1 <TODO/at/gmail/dot/com>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -29,13 +29,14 @@
 #include <memory>
 #include <vector>
 
+#include <QAction>
 #include <QApplication>
 #include <QWidget>
 #include <QColor>
 
 #include "Clipboard.h"
+#include "GuiAction.h"
 #include "lmms_export.h"
-#include "ModelView.h"
 
 class QColor;
 class QMimeData;
@@ -47,12 +48,71 @@ namespace lmms::gui
 
 class SimpleTextFloat;
 
+struct ActionStruct
+{
+	/*
+	* id: should be unique, used to refer to this action
+	* doFnIn: what function should run if this action is triggered
+	* undoFnIn: what function should run if this action is undone
+	* isTypeSpecific: if the action can not be performed with other kinds of widgets (example for false: delete action)
+	* acceptedType: what kind of datatype does this action accept, use `Clipboard::DataType::Ignore` if datatype doesn't matter, use `Clipboard::DataType::Error` to later define the datatype
+	*/
+	ActionStruct(size_t id, QAction& doFnIn, QAction* undoFnIn, bool isTypeSpecific, Clipboard::DataType acceptedType);
+	ActionStruct() { resetShortcut(); }
+	~ActionStruct();
+	//! sets the shortcut and isShortcut will be true
+	void setShortcut(Qt::Key shortcutKey, Qt::KeyboardModifier shortcutModifier, size_t shortcutTimes, bool isShortcutLoop);
+	//! use this to add more datatypes to an action `Clipboard::DataType::Error` will not be added
+	void addAcceptedDataType(Clipboard::DataType type);
+	//! display name
+	//QString actionName = "";
+	size_t actionId = 0;
+
+	//! `QActions` needed for `GuiAction`
+	QAction* doFn = nullptr;
+	QAction* undoFn = nullptr;
+	GuiActionIO data;
+
+	//! if the action can not be performed with other kinds of widgets (example for false: delete action)
+	bool isTypeSpecific = true;
+	bool isShortcut = false;
+
+	//! what kind of data does this action accept
+	std::vector<Clipboard::DataType> acceptedType = {Clipboard::DataType::Any};
+
+	// shortcut logic
+	Qt::Key key = Qt::Key_F35;
+	Qt::KeyboardModifier modifier = Qt::NoModifier;
+	//! how many times do the keys need to be pressed to activate this shortcut
+	size_t times = 0;
+	//! should it loop back if m_times is reached
+	bool isLoop = false;
+
+	//! resets the shortcut and isShortcut will be false
+	void resetShortcut();
+	
+	bool doesShortcutMatch(QKeyEvent* event) const;
+	bool doesShortcutMatch(const ActionStruct& otherShortcut) const;
+	bool doesFullShortcutMatch(const ActionStruct& otherShortcut) const;
+	void copyShortcut(const ActionStruct& otherShortcut);
+	//! true if `type` is in `acceptedType`, isn't true if `acceptedType` has `Clipboard::DataType::Any`
+	bool doesTypeMatch(Clipboard::DataType type) const;
+	//! true if `type` is in `acceptedType`, true if `acceptedType` has `Clipboard::DataType::Any`
+	bool isTypeAccepted(Clipboard::DataType type) const;
+	const QString getText() const;
+	GuiActionIO* getData();
+	void setData(const GuiActionIO& newData);
+};
+
+
+
 class LMMS_EXPORT InteractiveModelView : public QWidget
 {
 Q_OBJECT
 	Q_PROPERTY(QColor highlightColor READ getHighlightColor WRITE setHighlightColor)
 public:
-	InteractiveModelView(QWidget* widget);
+	//! typeId: get it by using `getTypeId()` with your inherited class
+	InteractiveModelView(QWidget* widget, size_t typeId);
 	~InteractiveModelView() override;
 
 	//! highlight every InteractiveModelView that accepts dataType
@@ -65,38 +125,75 @@ public:
 	static void setHighlightColor(QColor& color);
 
 	//! highlights this widgets specifically
-	//! @param duration highlight time in milliseconds
-	//! @param shouldStopHighlightingOrhers calls `stopHighlighting()`,
+	//! duration: highlight time in milliseconds
+	//! shouldStopHighlightingOrhers: calls `stopHighlighting()`,
 	//! should be false if multiple widgets are highlighted and `this` is not the first one
 	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);
-protected:
 
-	//! returns true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
-	virtual bool canAcceptClipboardData(Clipboard::DataType dataType) = 0;
-	//! should implement dragging and dropping widgets or pasting from clipboard
-	//! should return if `QDropEvent` event can be accepted
-	//! force implement this method
-	virtual bool processPasteImplementation(Clipboard::DataType type, QString& value) = 0;
-	//! calls `processPasteImplementation()` to process paste
-	bool processPaste(const QMimeData* mimeData);
+	//! returns true if successful
+	//! checks if QKeyEvent maches with a known shortcut and calls `processShortcutPressed()`
+	bool HandleKeyPress(QKeyEvent* event);
+
+	//! do a specified action on this widget
+	//! actionId: what action to do from the `getActions()` array
+	//! shouldLinkBack: should the Action before this be undone as well?
+	//! NOTE: ONLY USE `doAction()` IN QT FUNCTIONS OR ACTION FUNCTIONS
+	//! actions are meant to be triggered by users, triggering them from an internal function could lead to bad journalling
+	void doAction(size_t actionId, bool shouldLinkBack = false);
+	//static void doActions(size_t actionId, const std::vector<InteractiveModelView*> widgets, const std::vector<ActionStruct>& actions);
+	void doAction(size_t actionId, GuiActionIO data, bool shouldLinkBack = false);
+	void doActionAt(size_t actionIndex, bool shouldLinkBack = false);
+	void doActionAt(size_t actionIndex, GuiActionIO data, bool shouldLinkBack = false);
+
+	//! should return a unique id for different widget classes
+	template<typename BaseType>
+	static constexpr size_t getTypeId() { return typeid(BaseType).hash_code(); };
+	size_t getStoredTypeId();
+protected:
+	void keyPressEvent(QKeyEvent* event) override;
+	void enterEvent(QEvent* event) override;
+	void leaveEvent(QEvent* event) override;
+
+	//! returns the avalible shortcuts for the widget
+	const std::vector<ActionStruct>& getActions() { return m_actionArray; };
+	std::vector<ActionStruct>& getActionsNotConst() { return m_actionArray; };
+	//! called when a shortcut message needs to be displayed
+	//! shortcut messages can be generated with `buildShortcutMessage()` (but it can be unoptimized to return `buildShortcutMessage()`)
+	virtual const QString& getShortcutMessage() = 0;
 	//! override this if the widget requires custom updating code
+	//! shouldOverrideUpdate: should `update()` widget if `isHighlighted` didn't changed but for example color changed
 	virtual void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
+	//! place here the `QAction` and `ActionStruct` code and call it in constructor
+	virtual void addActions(std::vector<ActionStruct>& targetList) = 0;
 
 	//! draws the highlight automatically for the widget if highlighted
 	void drawAutoHighlight(QPainter* painter);
+	//! builds a string from a provided action array
+	static QString buildShortcutMessage(const std::vector<ActionStruct>& actions);
 
 	bool getIsHighlighted() const;
-	//! @param shouldOverrideUpdate should update if visible, ignore optimizations
+	//! shouldOverrideUpdate: should update if visible, ignore optimizations
 	//! shouldOverrideUpdate could be needed if the color was changed
 	void setIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
+
+	//! returns an index of an action from a given id, returns `getActions().size()` if not found
+	size_t getIndexFromId(size_t id);
+
+	//! construct in derived constructor
+	std::vector<ActionStruct> m_actionArray;
 private slots:
 	inline static void timerStopHighlighting()
 	{
 		stopHighlighting();
 	}
 private:
-
 	bool m_isHighlighted;
+	
+	ActionStruct m_lastShortcut;
+	//! how many times was the last shortcut pressed
+	size_t m_lastShortcutCounter;
+	//! stores the widget's type id that created this object
+	const size_t m_interactiveModelViewTypeId;
 
 	static std::unique_ptr<QColor> s_highlightColor;
 	static std::unique_ptr<QColor> s_usedHighlightColor;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -35,7 +35,7 @@
 #include <QColor>
 
 #include "Clipboard.h"
-#include "GuiAction.h"
+#include "GuiCommand.h"
 #include "lmms_export.h"
 
 class QColor;
@@ -64,11 +64,11 @@ struct CommandData
 	//! use this to add more datatypes to an action `Clipboard::DataType::Error` will not be added
 	void addAcceptedDataType(Clipboard::DataType type);
 	//! display name
-	QString actionName = "";
+	QString commandName = "";
 
-	//! Function pointers needed to construct `GuiAction`
-	CommandFnPtr doFn;
-	CommandFnPtr undoFn;
+	//! Function pointers needed to construct `GuiCommand`
+	std::unique_ptr<CommandFnPtr> doFn;
+	std::unique_ptr<CommandFnPtr> undoFn;
 
 	//! if the action can not be performed with other kinds of widgets (example for false: delete action)
 	bool isTypeSpecific = true;
@@ -121,7 +121,7 @@ public:
 	//! @param duration: highlight time in milliseconds
 	//! @param shouldStopHighlightingOrhers: calls `stopHighlighting()`,
 	//! should be false if multiple widgets are highlighted and `this` is not the first one
-	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);s
+	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);
 
 	//! do a specified action on this widget
 	//! @param functionPointer: what action to do from the `getActions()` array
@@ -134,6 +134,7 @@ public:
 	template<typename DataType>
 	void doAction(void* functionPointer, DataType doData, bool shouldLinkBack = false)
 		{ doActionAt(getIndexFromFn(functionPointer), doData, nullptr, shouldLinkBack); }
+	template<typename DataType>
 	void doAction(void* functionPointer, DataType doData, DataType undoData, bool shouldLinkBack = false)
 		{ doActionAt(getIndexFromFn(functionPointer), doData, &undoData, shouldLinkBack); }
 	template<typename DataType>
@@ -147,7 +148,7 @@ public:
 		qDebug("doActionAt typed after type return");
 
 		qDebug("doAction typed, %ld, %s", actionIndex, actions[actionIndex].getText().toStdString().c_str());
-		GuiActionTyped<DataType> action(actions[actionIndex].getText(), this, actions[actionIndex].doFn, actions[actionIndex].undoFn, doData, undoData, shouldLinkBack);
+		GuiActionTyped<DataType> action(actions[actionIndex].getText(), this, *actions[actionIndex].doFn, *actions[actionIndex].undoFn, doData, undoData, shouldLinkBack);
 		action.redo();
 	}
 

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -48,8 +48,9 @@ namespace lmms::gui
 
 class SimpleTextFloat;
 
-struct CommandData
+class CommandData
 {
+public:
 	/*
 	* @param id: a unique identifier for the command, used to make handling commands easy
 	* @param name: a name that describes what this command does
@@ -58,46 +59,45 @@ struct CommandData
 	* @param isTypeSpecific: if the command can not be performed with other kinds of widgets (example for false: delete command)
 	* @param acceptedType: what kind of datatype does this command accept, use `Clipboard::DataType::Ignore` if datatype doesn't matter, use `Clipboard::DataType::Error` to later define the datatype
 	*/
-	CommandData(size_t id, const QString&& name, const CommandFnPtr& doFnIn, const CommandFnPtr* undoFnIn, bool isTypeSpecific);
+	CommandData(size_t id, const QString&& name, const CommandFnPtr& doFnIn, const CommandFnPtr& undoFnIn, bool isTypeSpecific);
+	CommandData(size_t id, const QString&& name, const CommandFnPtr& doFnIn, bool isTypeSpecific);
 	~CommandData(); // TODO
 	//! sets the shortcut and isShortcut will be true
 	void setShortcut(Qt::Key shortcutKey, Qt::KeyboardModifier shortcutModifier, bool isShortcutLoop);
 	//! use this to add more datatypes to a command `Clipboard::DataType::Error` will not be added
 	void addAcceptedDataType(Clipboard::DataType type);
 
-	size_t commandId = 0;
-	//! display name
-	QString commandName = "";
-
-	//! Function pointers needed to construct `GuiCommand`
-	std::shared_ptr<CommandFnPtr> doFn;
-	std::shared_ptr<CommandFnPtr> undoFn;
-
-	//! if the command can not be performed with other kinds of widgets (example for false: delete command)
-	bool isTypeSpecific = true;
-	bool isShortcut = false;
-
-	//! what kind of data does this command accept
-	std::vector<Clipboard::DataType> acceptedType = {Clipboard::DataType::Any};
-
-	// shortcut logic
-	Qt::Key key = Qt::Key_F35;
-	Qt::KeyboardModifier modifier = Qt::NoModifier;
-	//! should it loop back if m_times is reached
-	bool isLoop = false;
-
-	//! resets the shortcut and isShortcut will be false
-	void resetShortcut();
-	
 	bool doesShortcutMatch(QKeyEvent* event) const;
 	bool doesShortcutMatch(const CommandData& otherShortcut) const;
-	bool doesFullShortcutMatch(const CommandData& otherShortcut) const;
 	void copyShortcut(const CommandData& otherShortcut);
 	//! true if `type` is in `acceptedType`, isn't true if `acceptedType` has `Clipboard::DataType::Any`
 	bool doesTypeMatch(Clipboard::DataType type) const;
 	//! true if `type` is in `acceptedType`, true if `acceptedType` has `Clipboard::DataType::Any`
 	bool isTypeAccepted(Clipboard::DataType type) const;
 	const QString& getText() const;
+
+	size_t getId() const;
+	std::shared_ptr<CommandFnPtr> getDoFn() const;
+	std::shared_ptr<CommandFnPtr> getUndoFn() const;
+private:
+	size_t m_commandId = 0;
+	//! display name
+	QString m_commandName = "";
+
+	//! Function pointers needed to construct `GuiCommand`
+	std::shared_ptr<CommandFnPtr> m_doFn;
+	std::shared_ptr<CommandFnPtr> m_undoFn;
+
+	//! if the command can not be performed with other kinds of widgets (example for false: delete command)
+	bool m_isTypeSpecific = true;
+	bool m_isShortcut = false;
+
+	//! what kind of data does this command accept
+	std::vector<Clipboard::DataType> m_acceptedType = {Clipboard::DataType::Any};
+
+	// shortcut logic
+	Qt::Key m_key = Qt::Key_F35;
+	Qt::KeyboardModifier m_modifier = Qt::NoModifier;
 };
 
 
@@ -148,8 +148,8 @@ public:
 		// if the command accepts the current clipboard data, `Clipboard::DataType::Any` will accept anything
 		if (commands[commandIndex].isTypeAccepted(Clipboard::decodeKey(Clipboard::getMimeData())) == false) { return; }
 
-		assert(commands[commandIndex].doFn.get() != nullptr);
-		GuiCommandTyped<DataType> command(commands[commandIndex].getText(), this, commands[commandIndex].doFn, commands[commandIndex].undoFn, doData, undoData, shouldLinkBack);
+		assert(commands[commandIndex].getDoFn().get() != nullptr);
+		GuiCommandTyped<DataType> command(commands[commandIndex].getText(), this, commands[commandIndex].getDoFn(), commands[commandIndex].getUndoFn(), doData, undoData, shouldLinkBack);
 		command.redo();
 	}
 

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -69,61 +69,8 @@ public:
 	//! shouldStopHighlightingOrhers: calls `stopHighlighting()`,
 	//! should be false if multiple widgets are highlighted and `this` is not the first one
 	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);
-
-	//! returns true if successful
-	//! checks if QKeyEvent maches with a known shortcut and calls `processShortcutPressed()`
-	bool HandleKeyPress(QKeyEvent* event);
 protected:
-	struct ModelShortcut
-	{
-		ModelShortcut() {}
-		ModelShortcut(Qt::Key key, Qt::KeyboardModifier modifier, unsigned int times, QString description, bool shouldLoop) :
-			key(key),
-			modifier(modifier),
-			times(times),
-			shortcutDescription(description),
-			shouldLoop(shouldLoop)
-		{
-		}
 
-		bool operator==(ModelShortcut& rhs)
-		{
-			return key == rhs.key
-				&& modifier == rhs.modifier
-				&& times == rhs.times
-				&& shouldLoop == rhs.shouldLoop;
-		}
-
-		void reset()
-		{
-			key = Qt::Key_F35;
-			modifier = Qt::NoModifier;
-			times = 0;
-			shortcutDescription = "";
-			shouldLoop = false;
-		}
-
-		Qt::Key key = Qt::Key_F35;
-		Qt::KeyboardModifier modifier = Qt::NoModifier;
-		//! how many times do the keys need to be pressed to activate this shortcut
-		unsigned int times = 0;
-		//! what the shortcut does
-		QString shortcutDescription = "";
-		//! should it loop back if m_times is reached
-		bool shouldLoop = false;
-	};
-
-	void keyPressEvent(QKeyEvent* event) override;
-	void enterEvent(QEvent* event) override;
-	void leaveEvent(QEvent* event) override;
-	
-	//! returns the avalible shortcuts for the widget
-	virtual const std::vector<ModelShortcut>& getShortcuts() = 0;
-	//! called when a shortcut from `getShortcuts()` is pressed
-	virtual void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) = 0;
-	//! called when a shortcut message needs to be displayed
-	//! shortcut messages can be generated with `buildShortcutMessage()` (but it can be unoptimized to return `buildShortcutMessage()`)
-	virtual QString getShortcutMessage() = 0;
 	//! returns true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
 	virtual bool canAcceptClipboardData(Clipboard::DataType dataType) = 0;
 	//! should implement dragging and dropping widgets or pasting from clipboard
@@ -137,8 +84,6 @@ protected:
 
 	//! draws the highlight automatically for the widget if highlighted
 	void drawAutoHighlight(QPainter* painter);
-	//! builds a string from `getShortcuts()`
-	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;
 	//! shouldOverrideUpdate: should update if visible, ignore optimizations
@@ -150,13 +95,8 @@ private slots:
 		stopHighlighting();
 	}
 private:
-	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const;
-	bool doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const;
 
 	bool m_isHighlighted;
-	
-	ModelShortcut m_lastShortcut;
-	unsigned int m_lastShortcutCounter;
 
 	static std::unique_ptr<QColor> s_highlightColor;
 	static std::unique_ptr<QColor> s_usedHighlightColor;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -67,44 +67,43 @@ public:
 	// returns true if successful
 	bool HandleKeyPress(QKeyEvent* event);
 protected:
-	class ModelShortcut
+	struct ModelShortcut
 	{
-	public:
-		inline ModelShortcut() {}
-		inline ModelShortcut(Qt::Key key, Qt::KeyboardModifier modifier, unsigned int times, QString description, bool shouldLoop) :
-			m_key(key),
-			m_modifier(modifier),
-			m_times(times),
-			m_shortcutDescription(description),
-			m_shouldLoop(shouldLoop)
+		ModelShortcut() {}
+		ModelShortcut(Qt::Key key, Qt::KeyboardModifier modifier, unsigned int times, QString description, bool shouldLoop) :
+			key(key),
+			modifier(modifier),
+			times(times),
+			shortcutDescription(description),
+			shouldLoop(shouldLoop)
 		{
 		}
 
-		inline bool operator==(ModelShortcut& rhs)
+		bool operator==(ModelShortcut& rhs)
 		{
-			return m_key == rhs.m_key
-				&& m_modifier == rhs.m_modifier
-				&& m_times == rhs.m_times
-				&& m_shouldLoop == rhs.m_shouldLoop;
+			return key == rhs.key
+				&& modifier == rhs.modifier
+				&& times == rhs.times
+				&& shouldLoop == rhs.shouldLoop;
 		}
 
-		inline void reset()
+		void reset()
 		{
-			m_key = Qt::Key_F35;
-			m_modifier = Qt::NoModifier;
-			m_times = 0;
-			m_shortcutDescription = "";
-			m_shouldLoop = false;
+			key = Qt::Key_F35;
+			modifier = Qt::NoModifier;
+			times = 0;
+			shortcutDescription = "";
+			shouldLoop = false;
 		}
 
-		Qt::Key m_key = Qt::Key_F35;
-		Qt::KeyboardModifier m_modifier = Qt::NoModifier;
+		Qt::Key key = Qt::Key_F35;
+		Qt::KeyboardModifier modifier = Qt::NoModifier;
 		//! how many times do the keys need to be pressed to activate this shortcut
-		unsigned int m_times = 0;
+		unsigned int times = 0;
 		//! what the shortcut does
-		QString m_shortcutDescription = "";
+		QString shortcutDescription = "";
 		//! should it loop back if m_times is reached
-		bool m_shouldLoop = false;
+		bool shouldLoop = false;
 	};
 
 	void keyPressEvent(QKeyEvent* event) override;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -65,8 +65,8 @@ public:
 	static void setHighlightColor(QColor& color);
 
 	//! highlights this widgets specifically
-	//! duration: highlight time in milliseconds
-	//! shouldStopHighlightingOrhers: calls `stopHighlighting()`,
+	//! @param duration highlight time in milliseconds
+	//! @param shouldStopHighlightingOrhers calls `stopHighlighting()`,
 	//! should be false if multiple widgets are highlighted and `this` is not the first one
 	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);
 protected:
@@ -86,7 +86,7 @@ protected:
 	void drawAutoHighlight(QPainter* painter);
 
 	bool getIsHighlighted() const;
-	//! shouldOverrideUpdate: should update if visible, ignore optimizations
+	//! @param shouldOverrideUpdate should update if visible, ignore optimizations
 	//! shouldOverrideUpdate could be needed if the color was changed
 	void setIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
 private slots:

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -56,7 +56,7 @@ public:
 	~InteractiveModelView() override;
 
 	//! highlight every InteractiveModelView that accepts dataType
-	static void startHighlighting(Clipboard::StringPairDataType dataType);
+	static void startHighlighting(Clipboard::DataType dataType);
 	static void stopHighlighting();
 	static void showMessage(QString& message);
 	static void hideMessage();
@@ -125,11 +125,11 @@ protected:
 	//! shortcut messages can be generated with `buildShortcutMessage()` (but it can be unoptimized to return `buildShortcutMessage()`)
 	virtual QString getShortcutMessage() = 0;
 	//! returns true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
-	virtual bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) = 0;
+	virtual bool canAcceptClipboardData(Clipboard::DataType dataType) = 0;
 	//! should implement dragging and dropping widgets or pasting from clipboard
 	//! should return if `QDropEvent` event can be accepted
 	//! force implement this method
-	virtual bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) = 0;
+	virtual bool processPasteImplementation(Clipboard::DataType type, QString& value) = 0;
 	//! calls `processPasteImplementation()` to process paste
 	bool processPaste(const QMimeData* mimeData);
 	//! override this if the widget requires custom updating code

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -64,6 +64,12 @@ public:
 	static QColor getHighlightColor();
 	static void setHighlightColor(QColor& color);
 
+	//! highlights this widgets specifically
+	//! duration: highlight time in milliseconds
+	//! shouldStopHighlightingOrhers: calls `stopHighlighting()`,
+	//! should be false if multiple widgets are highlighted and `this` is not the first one
+	void HighlightThisWidget(const QColor& color, size_t duration, bool shouldStopHighlightingOrhers = true);
+
 	//! returns true if successful
 	//! checks if QKeyEvent maches with a known shortcut and calls `processShortcutPressed()`
 	bool HandleKeyPress(QKeyEvent* event);
@@ -127,7 +133,7 @@ protected:
 	//! calls `processPasteImplementation()` to process paste
 	bool processPaste(const QMimeData* mimeData);
 	//! override this if the widget requires custom updating code
-	virtual void overrideSetIsHighlighted(bool isHighlighted);
+	virtual void overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
 
 	//! draws the highlight automatically for the widget if highlighted
 	void drawAutoHighlight(QPainter* painter);
@@ -135,7 +141,9 @@ protected:
 	QString buildShortcutMessage();
 
 	bool getIsHighlighted() const;
-	void setIsHighlighted(bool isHighlighted);
+	//! shouldOverrideUpdate: should update if visible, ignore optimizations
+	//! shouldOverrideUpdate could be needed if the color was changed
+	void setIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
 private slots:
 	inline static void timerStopHighlighting()
 	{
@@ -144,7 +152,6 @@ private slots:
 private:
 	bool doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const;
 	bool doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const;
-	
 
 	bool m_isHighlighted;
 	
@@ -152,6 +159,7 @@ private:
 	unsigned int m_lastShortcutCounter;
 
 	static std::unique_ptr<QColor> s_highlightColor;
+	static std::unique_ptr<QColor> s_usedHighlightColor;
 	static QTimer* s_highlightTimer;
 	static SimpleTextFloat* s_simpleTextFloat;
 	static std::list<InteractiveModelView*> s_interactiveWidgets;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -84,7 +84,7 @@ private:
 	//! display name
 	QString m_commandName = "";
 
-	//! Function pointers needed to construct `GuiCommand`
+	//! Function pointers needed to construct commands
 	std::shared_ptr<CommandFnPtr> m_doFn;
 	std::shared_ptr<CommandFnPtr> m_undoFn;
 
@@ -149,7 +149,7 @@ public:
 		if (commands[commandIndex].isTypeAccepted(Clipboard::decodeKey(Clipboard::getMimeData())) == false) { return; }
 
 		assert(commands[commandIndex].getDoFn().get() != nullptr);
-		GuiCommandTyped<DataType> command(commands[commandIndex].getText(), this, commands[commandIndex].getDoFn(), commands[commandIndex].getUndoFn(), doData, undoData, shouldLinkBack);
+		TypedCommand<DataType> command(commands[commandIndex].getText(), this, commands[commandIndex].getDoFn(), commands[commandIndex].getUndoFn(), doData, undoData, shouldLinkBack);
 		command.redo();
 	}
 

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -146,12 +146,9 @@ public:
 		const std::vector<CommandData>& commands = getCommands();
 		if (commandIndex > commands.size()) { return; }
 		// if the command accepts the current clipboard data, `Clipboard::DataType::Any` will accept anything
-		qDebug("doCommandAt typed before type return");
 		if (commands[commandIndex].isTypeAccepted(Clipboard::decodeKey(Clipboard::getMimeData())) == false) { return; }
-		qDebug("doCommandAt typed after type return");
 
 		assert(commands[commandIndex].doFn.get() != nullptr);
-		qDebug("doCommand typed, %ld, %s", commandIndex, commands[commandIndex].getText().toStdString().c_str());
 		GuiCommandTyped<DataType> command(commands[commandIndex].getText(), this, commands[commandIndex].doFn, commands[commandIndex].undoFn, doData, undoData, shouldLinkBack);
 		command.redo();
 	}
@@ -177,9 +174,8 @@ protected:
 	//! shouldOverrideUpdate could be needed if the color was changed
 	void setIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate);
 
-	//! returns an index of a command from a given ID / funcion ptr, reutrns getCommands().size() if not found
+	//! @return: an index of a command from a given ID, reutrns getCommands().size() if not found
 	size_t getIndexFromId(size_t id);
-	size_t getIndexFromFn(void* functionPointer);
 
 	//! construct in derived constructor
 	std::vector<CommandData> m_commandArray;

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -111,7 +111,7 @@ protected:
 	void leaveEvent(QEvent* event) override;
 	
 	//! return the avalible shortcuts for the widget
-	virtual std::vector<ModelShortcut> getShortcuts() = 0;
+	virtual const std::vector<ModelShortcut>& getShortcuts() = 0;
 	//! called when a shortcut from `getShortcuts()` is pressed
 	virtual void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) = 0;
 	//! called when a shortcut message needs to be displayed

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -63,6 +63,9 @@ public:
 
 	static QColor getHighlightColor();
 	static void setHighlightColor(QColor& color);
+	
+	// returns true if successful
+	bool HandleKeyPress(QKeyEvent* event);
 protected:
 	class ModelShortcut
 	{

--- a/include/InteractiveModelView.h
+++ b/include/InteractiveModelView.h
@@ -1,5 +1,5 @@
 /*
- * InteractiveModelView.h - TODO
+ * InteractiveModelView.h - Implements shortcut system, StringPair system and highlighting for widgets
  *
  * Copyright (c) 2024 szeli1 <TODO/at/gmail/dot/com>
  *
@@ -63,8 +63,9 @@ public:
 
 	static QColor getHighlightColor();
 	static void setHighlightColor(QColor& color);
-	
-	// returns true if successful
+
+	//! returns true if successful
+	//! checks if QKeyEvent maches with a known shortcut and calls `processShortcutPressed()`
 	bool HandleKeyPress(QKeyEvent* event);
 protected:
 	struct ModelShortcut
@@ -110,14 +111,14 @@ protected:
 	void enterEvent(QEvent* event) override;
 	void leaveEvent(QEvent* event) override;
 	
-	//! return the avalible shortcuts for the widget
+	//! returns the avalible shortcuts for the widget
 	virtual const std::vector<ModelShortcut>& getShortcuts() = 0;
 	//! called when a shortcut from `getShortcuts()` is pressed
 	virtual void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) = 0;
 	//! called when a shortcut message needs to be displayed
 	//! shortcut messages can be generated with `buildShortcutMessage()` (but it can be unoptimized to return `buildShortcutMessage()`)
 	virtual QString getShortcutMessage() = 0;
-	//! return true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
+	//! returns true if the widget supports pasting / dropping `dataType` (used for StringPairDrag and Copying)
 	virtual bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) = 0;
 	//! should implement dragging and dropping widgets or pasting from clipboard
 	//! should return if `QDropEvent` event can be accepted
@@ -128,7 +129,7 @@ protected:
 	//! override this if the widget requires custom updating code
 	virtual void overrideSetIsHighlighted(bool isHighlighted);
 
-	//! draws the highlight automatically for the widget if highilighted
+	//! draws the highlight automatically for the widget if highlighted
 	void drawAutoHighlight(QPainter* painter);
 	//! builds a string from `getShortcuts()`
 	QString buildShortcutMessage();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -47,6 +47,7 @@ namespace gui
 {
 
 class FileBrowser;
+class InteractiveModelView;
 class PluginView;
 class SubWindow;
 class ToolButton;
@@ -149,6 +150,8 @@ public:
 
 	bool eventFilter(QObject* watched, QEvent* event) override;
 
+	void setFocusedInteractiveModel(InteractiveModelView* model);
+	bool focusedInteractiveModelHandleKeyPress(QKeyEvent* event);
 public slots:
 	void resetWindowTitle();
 
@@ -242,6 +245,8 @@ private:
 	QAction * m_undoAction;
 	QAction * m_redoAction;
 	QList<PluginView *> m_tools;
+	//! used to handle widget shotrcuts
+	InteractiveModelView* m_focusedInteractiveModel;
 
 	QBasicTimer m_updateTimer;
 	QTimer m_autoSaveTimer;

--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -39,8 +39,8 @@ class selectableObject : public InteractiveModelView
 {
 	Q_OBJECT
 public:
-	selectableObject(QWidget* parent) :
-		InteractiveModelView(parent),
+	selectableObject(QWidget* parent, size_t typeId) :
+		InteractiveModelView(parent, typeId),
 		m_selected( false )
 	{
 	}

--- a/include/Rubberband.h
+++ b/include/Rubberband.h
@@ -67,18 +67,6 @@ public slots:
 	}
 
 protected:
-	
-	// InteractiveModelView methods
-	/*
-	inline std::vector<ModelShortcut> getShortcuts() override { return std::vector<ModelShortcut>(); };
-	inline void processShortcutPressed(size_t shortcutLocation, QKeyEvent* event) override {};
-	inline QString& getShortcutMessage() override
-	{
-		return m_tempString;
-	};
-	inline bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override { return false; };
-	inline bool processPaste(const QMimeData* mimeData) override { return false; };
-	*/
 
 private:
 	bool m_selected;

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -63,7 +63,7 @@ protected:
 	void paintEvent( QPaintEvent * ) override;
 
 	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPaste(const QMimeData* mimeData) override;
+	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
 
 private:
 	SampleClip * m_clip;

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -62,8 +62,8 @@ protected:
 	void mouseDoubleClickEvent( QMouseEvent * ) override;
 	void paintEvent( QPaintEvent * ) override;
 
-	bool canAcceptClipboardData(Clipboard::StringPairDataType dataType) override;
-	bool processPasteImplementation(Clipboard::StringPairDataType type, QString& value) override;
+	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
+	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
 
 private:
 	SampleClip * m_clip;

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -62,9 +62,6 @@ protected:
 	void mouseDoubleClickEvent( QMouseEvent * ) override;
 	void paintEvent( QPaintEvent * ) override;
 
-	bool canAcceptClipboardData(Clipboard::DataType dataType) override;
-	bool processPasteImplementation(Clipboard::DataType type, QString& value) override;
-
 private:
 	SampleClip * m_clip;
 	SampleThumbnail m_sampleThumbnail;

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -45,15 +45,15 @@ namespace lmms::gui
 class LMMS_EXPORT StringPairDrag : public QDrag
 {
 public:
-	StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
+	StringPairDrag(Clipboard::DataType key, const QString& _value,
 					const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets = true);
 	~StringPairDrag() override;
 
 	static bool processDragEnterEvent(QDragEnterEvent* _dee,
-						Clipboard::StringPairDataType allowedKey);
+						Clipboard::DataType allowedKey);
 	static bool processDragEnterEvent(QDragEnterEvent* _dee,
-						const std::vector<Clipboard::StringPairDataType>* allowedKeys);
-	static Clipboard::StringPairDataType decodeKey(QDropEvent * _de);
+						const std::vector<Clipboard::DataType>* allowedKeys);
+	static Clipboard::DataType decodeKey(QDropEvent * _de);
 	static QString decodeValue( QDropEvent * _de );
 } ;
 

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -45,6 +45,7 @@ namespace lmms::gui
 class LMMS_EXPORT StringPairDrag : public QDrag
 {
 public:
+	// use this class if you want to drag and drop, use `Clipboard::copyStringPair` to copy to clipboard
 	StringPairDrag(Clipboard::DataType key, const QString& _value,
 					const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets = true);
 	~StringPairDrag() override;

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -29,6 +29,7 @@
 
 #include "JournallingObject.h"
 #include "TimePos.h"
+#include "Clipboard.h"
 
 
 class QMimeData;
@@ -78,9 +79,9 @@ public:
 	}
 
 	bool canPasteSelection( TimePos clipPos, const QDropEvent *de );
-	bool canPasteSelection( TimePos clipPos, const QMimeData *md, bool allowSameBar = false );
+	bool canPasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool allowSameBar = false);
 	bool pasteSelection( TimePos clipPos, QDropEvent * de );
-	bool pasteSelection( TimePos clipPos, const QMimeData * md, bool skipSafetyCheck = false );
+	bool pasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool skipSafetyCheck = false);
 
 	TimePos endPosition( const TimePos & posStart );
 

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -79,9 +79,9 @@ public:
 	}
 
 	bool canPasteSelection( TimePos clipPos, const QDropEvent *de );
-	bool canPasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool allowSameBar = false);
+	bool canPasteSelection(TimePos clipPos, Clipboard::DataType type, QString& value, bool allowSameBar = false);
 	bool pasteSelection( TimePos clipPos, QDropEvent * de );
-	bool pasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool skipSafetyCheck = false);
+	bool pasteSelection(TimePos clipPos, Clipboard::DataType type, QString& value, bool skipSafetyCheck = false);
 
 	TimePos endPosition( const TimePos & posStart );
 

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -105,7 +105,7 @@ public:
 	// Currently instrument track and sample track supports it
 	virtual QMenu * createMixerMenu(QString title, QString newMixerLabel);
 
-	static Clipboard::StringPairDataType getTrackStringPairType(Track* track);
+	static Clipboard::DataType getTrackStringPairType(Track* track);
 public slots:
 	virtual bool close();
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -197,7 +197,7 @@ void AudioFileProcessorView::dropEvent(QDropEvent* de)
 	const auto type = StringPairDrag::decodeKey(de);
 	const auto value = StringPairDrag::decodeValue(de);
 
-	if (type == Clipboard::StringPairDataType::SampleFile) { castModel<AudioFileProcessor>()->setAudioFile(value); }
+	if (type == Clipboard::DataType::SampleFile) { castModel<AudioFileProcessor>()->setAudioFile(value); }
 	else if (type == QString("clip_%1").arg(static_cast<int>(Track::Type::Sample)))
 	{
 		DataFile dataFile(value.toUtf8());

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -261,8 +261,8 @@ void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 
 	if (_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
-		const Clipboard::StringPairDataType type = Clipboard::decodeKey(_dee->mimeData());
-		if (type == Clipboard::StringPairDataType::PluginPresetFile)
+		const Clipboard::DataType type = Clipboard::decodeKey(_dee->mimeData());
+		if (type == Clipboard::DataType::PluginPresetFile)
 		{
 			reaction = &QDragEnterEvent::acceptProposedAction;
 		}
@@ -276,9 +276,9 @@ void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 
 void Lv2InsView::dropEvent(QDropEvent *_de)
 {
-	const Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	const Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	const QString value = StringPairDrag::decodeValue(_de);
-	if (type == Clipboard::StringPairDataType::PluginPresetFile)
+	if (type == Clipboard::DataType::PluginPresetFile)
 	{
 		castModel<Lv2Instrument>()->loadFile(value);
 		_de->accept();

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -259,11 +259,9 @@ void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 {
 	void (QDragEnterEvent::*reaction)() = &QDragEnterEvent::ignore;
 
-	if (_dee->mimeData()->hasFormat( Clipboard::mimeType(Clipboard::MimeType::StringPair)))
+	if (_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
-		const QString txt =
-			_dee->mimeData()->data(Clipboard::mimeType(Clipboard::MimeType::StringPair));
-		const Clipboard::StringPairDataType type = Clipboard::decodeKey(_dee.mimeData());
+		const Clipboard::StringPairDataType type = Clipboard::decodeKey(_dee->mimeData());
 		if (type == Clipboard::StringPairDataType::PluginPresetFile)
 		{
 			reaction = &QDragEnterEvent::acceptProposedAction;

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -257,16 +257,15 @@ Lv2InsView::Lv2InsView(Lv2Instrument *_instrument, QWidget *_parent) :
 
 void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 {
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
 	void (QDragEnterEvent::*reaction)() = &QDragEnterEvent::ignore;
 
-	if (_dee->mimeData()->hasFormat( mimeType( MimeType::StringPair )))
+	if (_dee->mimeData()->hasFormat( Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
 		const QString txt =
-			_dee->mimeData()->data( mimeType( MimeType::StringPair ) );
-		if (txt.section(':', 0, 0) == "pluginpresetfile") {
+			_dee->mimeData()->data(Clipboard::mimeType(Clipboard::MimeType::StringPair));
+		const Clipboard::StringPairDataType type = Clipboard::decodeKey(_dee.mimeData());
+		if (type == Clipboard::StringPairDataType::PluginPresetFile)
+		{
 			reaction = &QDragEnterEvent::acceptProposedAction;
 		}
 	}
@@ -279,9 +278,9 @@ void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
 
 void Lv2InsView::dropEvent(QDropEvent *_de)
 {
-	const QString type = StringPairDrag::decodeKey(_de);
+	const Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
 	const QString value = StringPairDrag::decodeValue(_de);
-	if (type == "pluginpresetfile")
+	if (type == Clipboard::StringPairDataType::PluginPresetFile)
 	{
 		castModel<Lv2Instrument>()->loadFile(value);
 		_de->accept();

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -598,7 +598,7 @@ void PatmanView::dropEvent( QDropEvent * _de )
 {
 	auto type = StringPairDrag::decodeKey( _de );
 	QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		m_pi->setFile( value );
 		_de->accept();

--- a/plugins/SlicerT/SlicerTView.cpp
+++ b/plugins/SlicerT/SlicerTView.cpp
@@ -181,15 +181,15 @@ void SlicerTView::dragEnterEvent(QDragEnterEvent* dee)
 
 void SlicerTView::dropEvent(QDropEvent* de)
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue(de);
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		// set m_wf wave file
 		m_slicerTParent->updateFile(value);
 		return;
 	}
-	else if (type == Clipboard::StringPairDataType::SampleClip)
+	else if (type == Clipboard::DataType::SampleClip)
 	{
 		DataFile dataFile(value.toUtf8());
 		m_slicerTParent->updateFile(dataFile.content().firstChild().toElement().attribute("src"));

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -862,7 +862,7 @@ void VestigeInstrumentView::dropEvent( QDropEvent * _de )
 {
 	auto type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::VstPluginFile)
+	if (type == Clipboard::DataType::VstPluginFile)
 	{
 		m_vi->loadFile( value );
 		_de->accept();
@@ -1218,7 +1218,7 @@ void ManageVestigeInstrumentView::dropEvent( QDropEvent * _de )
 {
 	auto type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::VstPluginFile)
+	if (type == Clipboard::DataType::VstPluginFile)
 	{
 		m_vi->loadFile( value );
 		_de->accept();

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -598,7 +598,7 @@ void ZynAddSubFxView::dropEvent( QDropEvent * _de )
 {
 	const auto type = StringPairDrag::decodeKey(_de);
 	const QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::PluginPresetFile)
+	if (type == Clipboard::DataType::PluginPresetFile)
 	{
 		castModel<ZynAddSubFxInstrument>()->loadFile( value );
 		_de->accept();

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -492,34 +492,24 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 
 void AutomatableModel::linkModels( AutomatableModel* model1, AutomatableModel* model2 )
 {
-	qDebug("AutomatableModel::linkModels 1");
 	auto model1ContainsModel2 = std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) != model1->m_linkedModels.end();
 	if (!model1ContainsModel2 && model1 != model2)
 	{
-		qDebug("AutomatableModel::linkModels 2");
 		// copy data
 		model1->m_value = model2->m_value;
-		qDebug("AutomatableModel::linkModels 3");
 		if (model1->valueBuffer() && model2->valueBuffer())
 		{
-			qDebug("AutomatableModel::linkModels 3.1");
 			std::copy_n(model2->valueBuffer()->data(),
 				model1->valueBuffer()->length(),
 				model1->valueBuffer()->data());
-			qDebug("AutomatableModel::linkModels 4");
 		}
 		// send dataChanged() before linking (because linking will
 		// connect the two dataChanged() signals)
-		qDebug("AutomatableModel::linkModels 4.1");
 		emit model1->dataChanged();
-		qDebug("AutomatableModel::linkModels 5");
 		// finally: link the models
 		model1->linkModel( model2 );
-		qDebug("AutomatableModel::linkModels 6");
 		model2->linkModel( model1 );
-		qDebug("AutomatableModel::linkModels 7");
 	}
-	qDebug("AutomatableModel::linkModels 8");
 }
 
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -492,24 +492,34 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 
 void AutomatableModel::linkModels( AutomatableModel* model1, AutomatableModel* model2 )
 {
+	qDebug("AutomatableModel::linkModels 1");
 	auto model1ContainsModel2 = std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) != model1->m_linkedModels.end();
 	if (!model1ContainsModel2 && model1 != model2)
 	{
+		qDebug("AutomatableModel::linkModels 2");
 		// copy data
 		model1->m_value = model2->m_value;
+		qDebug("AutomatableModel::linkModels 3");
 		if (model1->valueBuffer() && model2->valueBuffer())
 		{
+			qDebug("AutomatableModel::linkModels 3.1");
 			std::copy_n(model2->valueBuffer()->data(),
 				model1->valueBuffer()->length(),
 				model1->valueBuffer()->data());
+			qDebug("AutomatableModel::linkModels 4");
 		}
 		// send dataChanged() before linking (because linking will
 		// connect the two dataChanged() signals)
+		qDebug("AutomatableModel::linkModels 4.1");
 		emit model1->dataChanged();
+		qDebug("AutomatableModel::linkModels 5");
 		// finally: link the models
 		model1->linkModel( model2 );
+		qDebug("AutomatableModel::linkModels 6");
 		model2->linkModel( model1 );
+		qDebug("AutomatableModel::linkModels 7");
 	}
+	qDebug("AutomatableModel::linkModels 8");
 }
 
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -155,13 +155,11 @@ namespace lmms::Clipboard
 	
 	QString encodeFloatValue(float value)
 	{
-		qDebug("encodeFloatValue, outout: %f", value);
 		return QString::number(value);
 	}
 	
 	QString encodeAutomatableModelLink(const AutomatableModel& model)
 	{
-		qDebug("encodeAutomatableModelLink, outout: %d", model.id());
 		return QString::number(model.id());
 	}
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -132,7 +132,7 @@ namespace lmms::Clipboard
 
 
 
-	DataType decodeKey(const QMimeData* mimeData)
+	Clipboard::DataType decodeKey(const QMimeData* mimeData)
 	{
 		QString keyString = QString::fromUtf8(mimeData->data(mimeType(MimeType::StringPair))).section(':', 0, 0);
 		for (size_t i = 0; i < static_cast<size_t>(DataType::Count); i++)

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -155,11 +155,13 @@ namespace lmms::Clipboard
 	
 	QString encodeFloatValue(float value)
 	{
+		qDebug("encodeFloatValue, outout: %f", value);
 		return QString::number(value);
 	}
 	
 	QString encodeAutomatableModelLink(const AutomatableModel& model)
 	{
+		qDebug("encodeAutomatableModelLink, outout: %d", model.id());
 		return QString::number(model.id());
 	}
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -29,7 +29,6 @@
 #include "Clipboard.h"
 
 #include "AutomatableModel.h"
-#include "InteractiveModelView.h"
 
 
 namespace lmms::Clipboard
@@ -72,6 +71,10 @@ namespace lmms::Clipboard
 	{
 		switch (type)
 		{
+			case DataType::All:
+				return QString("All");
+			case DataType::Any:
+				return QString("Any");
 			case DataType::FloatValue:
 				return QString("FloatValue");
 			case DataType::AutomatableModelLink:
@@ -117,29 +120,26 @@ namespace lmms::Clipboard
 			default:
 				break;
 		};
-		return QString("None_error");
+		return QString("Error");
 	}
 
 
-	void copyStringPair(DataType key, const QString& value, bool shouldHighlightWidgets)
+	void copyStringPair(DataType key, const QString& value)
 	{
 		QString finalString = getStringPairKeyName(key) + ":" + value;
 
 		auto content = new QMimeData;
-		content->setData(mimeType(MimeType::StringPair), finalString.toUtf8());
-		QApplication::clipboard()->setMimeData(content, QClipboard::Clipboard);
-
-		if (shouldHighlightWidgets)
-		{
-			lmms::gui::InteractiveModelView::startHighlighting(key);
-		}
+		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );
+		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
 	}
 
 
 
 
-	Clipboard::DataType decodeKey(const QMimeData* mimeData)
+	DataType decodeKey(const QMimeData* mimeData)
 	{
+		if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return DataType::Error; }
+
 		QString keyString = QString::fromUtf8(mimeData->data(mimeType(MimeType::StringPair))).section(':', 0, 0);
 		for (size_t i = 0; i < static_cast<size_t>(DataType::Count); i++)
 		{
@@ -148,7 +148,7 @@ namespace lmms::Clipboard
 				return static_cast<DataType>(i);
 			}
 		}
-		return DataType::None;
+		return DataType::Error;
 	}
 
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -29,6 +29,7 @@
 #include "Clipboard.h"
 
 #include "AutomatableModel.h"
+#include "InteractiveModelView.h"
 
 
 namespace lmms::Clipboard
@@ -120,13 +121,18 @@ namespace lmms::Clipboard
 	}
 
 
-	void copyStringPair(DataType key, const QString& value)
+	void copyStringPair(DataType key, const QString& value, bool shouldHighlightWidgets)
 	{
 		QString finalString = getStringPairKeyName(key) + ":" + value;
 
 		auto content = new QMimeData;
-		content->setData( mimeType( MimeType::StringPair ), finalString.toUtf8() );
-		QApplication::clipboard()->setMimeData( content, QClipboard::Clipboard );
+		content->setData(mimeType(MimeType::StringPair), finalString.toUtf8());
+		QApplication::clipboard()->setMimeData(content, QClipboard::Clipboard);
+
+		if (shouldHighlightWidgets)
+		{
+			lmms::gui::InteractiveModelView::startHighlighting(key);
+		}
 	}
 
 

--- a/src/core/Clipboard.cpp
+++ b/src/core/Clipboard.cpp
@@ -67,51 +67,51 @@ namespace lmms::Clipboard
 	}
 
 
-	QString getStringPairKeyName(StringPairDataType type)
+	QString getStringPairKeyName(DataType type)
 	{
 		switch (type)
 		{
-			case StringPairDataType::FloatValue:
+			case DataType::FloatValue:
 				return QString("FloatValue");
-			case StringPairDataType::AutomatableModelLink:
+			case DataType::AutomatableModelLink:
 				return QString("AutomatableModelLink");
-			case StringPairDataType::Instrument:
+			case DataType::Instrument:
 				return QString("Instrument");
-			case StringPairDataType::PresetFile:
+			case DataType::PresetFile:
 				return QString("PresetFile");
-			case StringPairDataType::PluginPresetFile:
+			case DataType::PluginPresetFile:
 				return QString("PluginPresetFile");
-			case StringPairDataType::SampleFile:
+			case DataType::SampleFile:
 				return QString("SampleFile");
-			case StringPairDataType::SoundFontFile:
+			case DataType::SoundFontFile:
 				return QString("SoundFontFile");
-			case StringPairDataType::PatchFile:
+			case DataType::PatchFile:
 				return QString("PatchFile");
-			case StringPairDataType::VstPluginFile:
+			case DataType::VstPluginFile:
 				return QString("VstPluginFile");
-			case StringPairDataType::ImportedProject:
+			case DataType::ImportedProject:
 				return QString("ImportedProject");
-			case StringPairDataType::ProjectFile:
+			case DataType::ProjectFile:
 				return QString("ProjectFile");
-			case StringPairDataType::SampleData:
+			case DataType::SampleData:
 				return QString("SampleData");
-			case StringPairDataType::InstrumentTrack:
+			case DataType::InstrumentTrack:
 				return QString("InstrumentTrack");
-			case StringPairDataType::PatternTrack:
+			case DataType::PatternTrack:
 				return QString("PatternTrack");
-			case StringPairDataType::SampleTrack:
+			case DataType::SampleTrack:
 				return QString("SampleTrack");
-			case StringPairDataType::AutomationTrack:
+			case DataType::AutomationTrack:
 				return QString("AutomationTrack");
-			case StringPairDataType::HiddenAutomationTrack:
+			case DataType::HiddenAutomationTrack:
 				return QString("HiddenAutomationTrack");
-			case StringPairDataType::MidiClip:
+			case DataType::MidiClip:
 				return QString("MidiClip");
-			case StringPairDataType::PatternClip:
+			case DataType::PatternClip:
 				return QString("PatternClip");
-			case StringPairDataType::SampleClip:
+			case DataType::SampleClip:
 				return QString("SampleClip");
-			case StringPairDataType::AutomationClip:
+			case DataType::AutomationClip:
 				return QString("AutomationClip");
 			default:
 				break;
@@ -120,7 +120,7 @@ namespace lmms::Clipboard
 	}
 
 
-	void copyStringPair(StringPairDataType key, const QString& value)
+	void copyStringPair(DataType key, const QString& value)
 	{
 		QString finalString = getStringPairKeyName(key) + ":" + value;
 
@@ -132,17 +132,17 @@ namespace lmms::Clipboard
 
 
 
-	StringPairDataType decodeKey(const QMimeData* mimeData)
+	DataType decodeKey(const QMimeData* mimeData)
 	{
 		QString keyString = QString::fromUtf8(mimeData->data(mimeType(MimeType::StringPair))).section(':', 0, 0);
-		for (size_t i = 0; i < static_cast<size_t>(StringPairDataType::Count); i++)
+		for (size_t i = 0; i < static_cast<size_t>(DataType::Count); i++)
 		{
-			if (getStringPairKeyName(static_cast<StringPairDataType>(i)) == keyString)
+			if (getStringPairKeyName(static_cast<DataType>(i)) == keyString)
 			{
-				return static_cast<StringPairDataType>(i);
+				return static_cast<DataType>(i);
 			}
 		}
-		return StringPairDataType::None;
+		return DataType::None;
 	}
 
 

--- a/src/gui/AutomatableModelView.cpp
+++ b/src/gui/AutomatableModelView.cpp
@@ -174,7 +174,7 @@ void AutomatableModelView::mousePressEvent( QMouseEvent* event )
 {
 	if (event->button() == Qt::LeftButton && event->modifiers() & KBD_COPY_MODIFIER)
 	{
-		new gui::StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink,
+		new gui::StringPairDrag(Clipboard::DataType::AutomatableModelLink,
 			Clipboard::encodeAutomatableModelLink((*modelUntyped())), QPixmap(), widget());
 		event->accept();
 	}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(LMMS_SRCS
 	gui/embed.cpp
 	gui/FileBrowser.cpp
 	gui/FileRevealer.cpp
+	gui/GuiAction.cpp
 	gui/GuiApplication.cpp
 	gui/InteractiveModelView.cpp
 	gui/LadspaControlView.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -15,8 +15,8 @@ SET(LMMS_SRCS
 	gui/embed.cpp
 	gui/FileBrowser.cpp
 	gui/FileRevealer.cpp
-	gui/GuiAction.cpp
 	gui/GuiApplication.cpp
+	gui/GuiCommand.cpp
 	gui/InteractiveModelView.cpp
 	gui/LadspaControlView.cpp
 	gui/LfoControllerDialog.cpp

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -885,33 +885,33 @@ void FileBrowserTreeWidget::mouseMoveEvent( QMouseEvent * me )
 			{
 				case FileItem::FileType::Preset:
 					new StringPairDrag( f->handling() == FileItem::FileHandling::LoadAsPreset ?
-							Clipboard::StringPairDataType::PresetFile : Clipboard::StringPairDataType::PluginPresetFile,
+							Clipboard::DataType::PresetFile : Clipboard::DataType::PluginPresetFile,
 							f->fullName(),
 							embed::getIconPixmap( "preset_file" ), this );
 					break;
 
 				case FileItem::FileType::Sample:
-					new StringPairDrag(Clipboard::StringPairDataType::SampleFile, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::SampleFile, f->fullName(),
 							embed::getIconPixmap( "sample_file" ), this );
 					break;
 				case FileItem::FileType::SoundFont:
-					new StringPairDrag(Clipboard::StringPairDataType::SoundFontFile, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::SoundFontFile, f->fullName(),
 							embed::getIconPixmap( "soundfont_file" ), this );
 					break;
 				case FileItem::FileType::Patch:
-					new StringPairDrag(Clipboard::StringPairDataType::PatchFile, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::PatchFile, f->fullName(),
 							embed::getIconPixmap( "sample_file" ), this );
 					break;
 				case FileItem::FileType::VstPlugin:
-					new StringPairDrag(Clipboard::StringPairDataType::VstPluginFile, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::VstPluginFile, f->fullName(),
 							embed::getIconPixmap( "vst_plugin_file" ), this );
 					break;
 				case FileItem::FileType::Midi:
-					new StringPairDrag(Clipboard::StringPairDataType::ImportedProject, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::ImportedProject, f->fullName(),
 							embed::getIconPixmap( "midi_file" ), this );
 					break;
 				case FileItem::FileType::Project:
-					new StringPairDrag(Clipboard::StringPairDataType::ProjectFile, f->fullName(),
+					new StringPairDrag(Clipboard::DataType::ProjectFile, f->fullName(),
 							embed::getIconPixmap( "project_file" ), this );
 					break;
 

--- a/src/gui/GuiAction.cpp
+++ b/src/gui/GuiAction.cpp
@@ -1,0 +1,76 @@
+/*
+ * GuiAction.h - implements Actions, a layer between the user and widgets
+ *
+ * Copyright (c) 2025 szeli1 <TODO/at/gmail/dot/com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <cassert>
+
+#include "GuiAction.h"
+
+namespace lmms::gui
+{
+
+AbstractGuiAction::AbstractGuiAction(const QString& name, InteractiveModelView* object, bool linkBack) :
+	m_name(name),
+	m_target(object),
+	m_isLinkedBack(linkBack)
+{
+	assert(m_target != nullptr);
+}
+bool AbstractGuiAction::getShouldLinkBack()
+{
+	return m_isLinkedBack;
+}
+bool AbstractGuiAction::clearObjectIfMatch(InteractiveModelView* object)
+{
+	if (m_target == nullptr) { return false; }
+	if (object == m_target)
+	{
+		m_target = nullptr;
+		return true;
+	}
+	return false;
+}
+GuiAction::GuiAction(const QString& name, InteractiveModelView* object, CommandFnPtr doFn, CommandFnPtr undoFn, size_t runAmount, bool linkBack) :
+	AbstractGuiAction(name, object, linkBack),
+	m_runAmount(runAmount),
+	m_doFn(doFn),
+	m_undoFn(undoFn)
+{}
+void GuiAction::undo()
+{
+	if (m_target == nullptr || m_undoFn == nullptr) { return; }
+	for (size_t i = 0; i < m_runAmount; i++)
+	{
+		m_undoFn.callFnTypeless(m_target);
+	}
+}
+void GuiAction::redo()
+{
+	if (m_target == nullptr || m_doFn == nullptr) { return; }
+	for (size_t i = 0; i < m_runAmount; i++)
+	{
+		m_doFn.callFnTypeless(m_target);
+	}
+}
+
+} // template<typename DataType>

--- a/src/gui/GuiCommand.cpp
+++ b/src/gui/GuiCommand.cpp
@@ -57,15 +57,14 @@ bool AbstractGuiCommand::clearObjectIfMatch(InteractiveModelView* object)
 	return false;
 }
 
-GuiCommand::GuiCommand(const QString& name, InteractiveModelView* object, CommandFnPtr& doFn, CommandFnPtr& undoFn, size_t runAmount, bool linkBack) :
+GuiCommand::GuiCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, size_t runAmount, bool linkBack) :
 	AbstractGuiCommand(name, object, linkBack),
-	m_runAmount(&runAmount),
-	m_doFn(&doFn),
+	m_runAmount(runAmount),
+	m_doFn(doFn),
 	m_undoFn(undoFn)
 {}
 void GuiCommand::undo()
 {
-	gae
 	if (m_target == nullptr || m_undoFn == nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
 	{

--- a/src/gui/GuiCommand.cpp
+++ b/src/gui/GuiCommand.cpp
@@ -35,18 +35,18 @@ size_t CommandFnPtr::getTypeIdFromInteractiveModelView(InteractiveModelView* obj
 	return object->getStoredTypeId();
 }
 
-AbstractGuiCommand::AbstractGuiCommand(const QString& name, InteractiveModelView* object, bool linkBack) :
+AbstractCommand::AbstractCommand(const QString& name, InteractiveModelView* object, bool linkBack) :
 	m_name(name),
 	m_target(object),
 	m_isLinkedBack(linkBack)
 {
 	assert(m_target != nullptr);
 }
-bool AbstractGuiCommand::getShouldLinkBack()
+bool AbstractCommand::getShouldLinkBack()
 {
 	return m_isLinkedBack;
 }
-bool AbstractGuiCommand::clearObjectIfMatch(InteractiveModelView* object)
+bool AbstractCommand::clearObjectIfMatch(InteractiveModelView* object)
 {
 	if (m_target == nullptr) { return false; }
 	if (object == m_target)
@@ -57,13 +57,13 @@ bool AbstractGuiCommand::clearObjectIfMatch(InteractiveModelView* object)
 	return false;
 }
 
-GuiCommand::GuiCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, size_t runAmount, bool linkBack) :
-	AbstractGuiCommand(name, object, linkBack),
+BasicCommand::BasicCommand(const QString& name, InteractiveModelView* object, std::shared_ptr<CommandFnPtr> doFn, std::shared_ptr<CommandFnPtr> undoFn, size_t runAmount, bool linkBack) :
+	AbstractCommand(name, object, linkBack),
 	m_runAmount(runAmount),
 	m_doFn(doFn),
 	m_undoFn(undoFn)
 {}
-void GuiCommand::undo()
+void BasicCommand::undo()
 {
 	if (m_target == nullptr || m_undoFn.get() == nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
@@ -71,7 +71,7 @@ void GuiCommand::undo()
 		m_undoFn->callFnTypeless(m_target);
 	}
 }
-void GuiCommand::redo()
+void BasicCommand::redo()
 {
 	if (m_target == nullptr || m_doFn.get()== nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)

--- a/src/gui/GuiCommand.cpp
+++ b/src/gui/GuiCommand.cpp
@@ -65,7 +65,7 @@ GuiCommand::GuiCommand(const QString& name, InteractiveModelView* object, std::s
 {}
 void GuiCommand::undo()
 {
-	if (m_target == nullptr || m_undoFn == nullptr) { return; }
+	if (m_target == nullptr || m_undoFn.get() == nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
 	{
 		m_undoFn->callFnTypeless(m_target);
@@ -73,7 +73,7 @@ void GuiCommand::undo()
 }
 void GuiCommand::redo()
 {
-	if (m_target == nullptr || m_doFn == nullptr) { return; }
+	if (m_target == nullptr || m_doFn.get()== nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
 	{
 		m_doFn->callFnTypeless(m_target);

--- a/src/gui/GuiCommand.cpp
+++ b/src/gui/GuiCommand.cpp
@@ -1,5 +1,5 @@
 /*
- * GuiAction.h - implements Actions, a layer between the user and widgets
+ * GuiCommand.h - implements Actions, a layer between the user and widgets
  *
  * Copyright (c) 2025 szeli1 <TODO/at/gmail/dot/com>
  *
@@ -24,23 +24,29 @@
 
 #include <cassert>
 
-#include "GuiAction.h"
+#include "GuiCommand.h"
+#include "InteractiveModelView.h"
 
 namespace lmms::gui
 {
 
-AbstractGuiAction::AbstractGuiAction(const QString& name, InteractiveModelView* object, bool linkBack) :
+size_t CommandFnPtr::getTypeIdFromInteractiveModelView(InteractiveModelView* object)
+{
+	return object->getStoredTypeId();
+}
+
+AbstractGuiCommand::AbstractGuiCommand(const QString& name, InteractiveModelView* object, bool linkBack) :
 	m_name(name),
 	m_target(object),
 	m_isLinkedBack(linkBack)
 {
 	assert(m_target != nullptr);
 }
-bool AbstractGuiAction::getShouldLinkBack()
+bool AbstractGuiCommand::getShouldLinkBack()
 {
 	return m_isLinkedBack;
 }
-bool AbstractGuiAction::clearObjectIfMatch(InteractiveModelView* object)
+bool AbstractGuiCommand::clearObjectIfMatch(InteractiveModelView* object)
 {
 	if (m_target == nullptr) { return false; }
 	if (object == m_target)
@@ -50,27 +56,29 @@ bool AbstractGuiAction::clearObjectIfMatch(InteractiveModelView* object)
 	}
 	return false;
 }
-GuiAction::GuiAction(const QString& name, InteractiveModelView* object, CommandFnPtr doFn, CommandFnPtr undoFn, size_t runAmount, bool linkBack) :
-	AbstractGuiAction(name, object, linkBack),
-	m_runAmount(runAmount),
-	m_doFn(doFn),
+
+GuiCommand::GuiCommand(const QString& name, InteractiveModelView* object, CommandFnPtr& doFn, CommandFnPtr& undoFn, size_t runAmount, bool linkBack) :
+	AbstractGuiCommand(name, object, linkBack),
+	m_runAmount(&runAmount),
+	m_doFn(&doFn),
 	m_undoFn(undoFn)
 {}
-void GuiAction::undo()
+void GuiCommand::undo()
 {
+	gae
 	if (m_target == nullptr || m_undoFn == nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
 	{
-		m_undoFn.callFnTypeless(m_target);
+		m_undoFn->callFnTypeless(m_target);
 	}
 }
-void GuiAction::redo()
+void GuiCommand::redo()
 {
 	if (m_target == nullptr || m_doFn == nullptr) { return; }
 	for (size_t i = 0; i < m_runAmount; i++)
 	{
-		m_doFn.callFnTypeless(m_target);
+		m_doFn->callFnTypeless(m_target);
 	}
 }
 
-} // template<typename DataType>
+} // namespace lmms::gui

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -161,12 +161,9 @@ void InteractiveModelView::doCommandAt(size_t commandIndex, bool shouldLinkBack)
 	const std::vector<CommandData>& commands = getCommands();
 	if (commandIndex > commands.size()) { return; }
 	// if the command accepts the current clipboard data, `Clipboard::DataType::Any` will accept anything
-	qDebug("doCommandAt before type return");
 	if (commands[commandIndex].isTypeAccepted(Clipboard::decodeKey(Clipboard::getMimeData())) == false) { return; }
-	qDebug("doCommandAt after type return");
 
 	assert(commands[commandIndex].doFn.get() != nullptr);
-	qDebug("doCommand typed, %ld, %s", commandIndex, commands[commandIndex].getText().toStdString().c_str());
 	GuiCommand command(commands[commandIndex].getText(), this, commands[commandIndex].doFn, commands[commandIndex].undoFn, 1, shouldLinkBack);
 	command.redo();
 }
@@ -223,17 +220,6 @@ size_t InteractiveModelView::getIndexFromId(size_t id)
 	}
 	return commands.size();
 }
-
-size_t InteractiveModelView::getIndexFromFn(void* functionPointer)
-{
-	const std::vector<CommandData>& commands = getCommands();
-	for (size_t i = 0; i < commands.size(); i++)
-	{
-		if (commands[i].doFn->isMatch(functionPointer)) { return i; }
-	}
-	return commands.size();
-}
-
 
 CommandData::CommandData(size_t id, const QString&& name, const CommandFnPtr& doFnIn, const CommandFnPtr* undoFnIn, bool isTypeSpecific) :
 	commandId(id),

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -147,13 +147,9 @@ void InteractiveModelView::HighlightThisWidget(const QColor& color, size_t durat
 
 bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 {
-	qDebug("HandleKeyPress 1");
 	std::cout << "InteractiveModelView::HandleKeyPress this:" << this << "\n";
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
-	qDebug("HandleKeyPress 2");
 	
-	qDebug("HandleKeyPress 2 + 1, shortcut: " + QKeySequence(event->modifiers()).toString().toLatin1() + " " + QKeySequence(event->key()).toString().toLatin1());
-
 	size_t foundIndex = 0;
 	unsigned int minMaxTimes = 0;
 	bool found = false;
@@ -165,7 +161,6 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 		// the shortcut that's `ModelShortcut::times` == m_lastShortcutCounter
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
-			qDebug("HandleKeyPress 3");
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
 				// selecting the shortcut with the largest m_times
@@ -180,7 +175,6 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 				{
 					m_lastShortcutCounter = shortcuts[i].shouldLoop ? 0 : m_lastShortcutCounter + 1;
 					foundIndex = i;
-					qDebug("HandleKeyPress 4");
 					break;
 				}
 			}
@@ -188,20 +182,16 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	else
 	{
-		qDebug("HandleKeyPress 5");
 		// find the lowest `ModelShortcut::times`
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
-			qDebug("HandleKeyPress 6");
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
-				qDebug("HandleKeyPress 7");
 				// selecting the shortcut with the lowest `ModelShortcut::times`
 				if (found == false || minMaxTimes > shortcuts[i].times)
 				{
 					foundIndex = i;
 					minMaxTimes = shortcuts[i].times;
-					qDebug("HandleKeyPress 8");
 				}
 				m_lastShortcut = shortcuts[i];
 				m_lastShortcutCounter = 1;
@@ -211,31 +201,23 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	if (found)
 	{
-		qDebug("HandleKeyPress 9");
 		QString message = shortcuts[foundIndex].shortcutDescription;
-		qDebug("HandleKeyPress 10");
 		showMessage(message);
-		qDebug("HandleKeyPress 11");
 		processShortcutPressed(foundIndex, event);
-		qDebug("HandleKeyPress 12");
 
 		event->accept();
 	}
 	else
 	{
-		qDebug("HandleKeyPress 13");
 		// reset focus
 		if (event->key() != Qt::Key_Control
 			&& event->key() != Qt::Key_Shift
 			&& event->key() != Qt::Key_Alt
 			&& event->key() != Qt::Key_AltGr)
 		{
-			qDebug("HandleKeyPress 14");
 			getGUI()->mainWindow()->setFocusedInteractiveModel(nullptr);
-			qDebug("HandleKeyPress 15");
 		}
 	}
-	qDebug("HandleKeyPress 16");
 	return found;
 }
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -1,5 +1,5 @@
 /*
- * InteractiveModelView.h - TODO
+ * InteractiveModelView.cpp - Implements shortcut system, StringPair system and highlighting for widgets
  *
  * Copyright (c) 2024 szeli1 <TODO/at/gmail/dot/com>
  *

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -210,8 +210,6 @@ void InteractiveModelView::enterEvent(QEvent* event)
 	if (isVisible())
 	{
 		// focus on this widget so keyPressEvent works
-		//setFocus();
-		qDebug("focus set");
 		getGUI()->mainWindow()->setFocusedInteractiveModel(this);
 	}
 }

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -124,23 +124,23 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	// if the last shortcut's keys mach the current keys
 	if (doesShortcutMatch(&m_lastShortcut, event))
 	{
-		// find the highest m_times or
-		// the shortcut that's m_times == m_lastShortcutCounter
+		// find the highest `ModelShortcut::times` or
+		// the shortcut that's `ModelShortcut::times` == m_lastShortcutCounter
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
 				// selecting the shortcut with the largest m_times
-				if (found == false || minMaxTimes < shortcuts[i].m_times)
+				if (found == false || minMaxTimes < shortcuts[i].times)
 				{
 					foundIndex = i;
-					minMaxTimes = shortcuts[i].m_times;
+					minMaxTimes = shortcuts[i].times;
 				}
 				found = true;
 			
-				if (m_lastShortcutCounter == shortcuts[i].m_times)
+				if (m_lastShortcutCounter == shortcuts[i].times)
 				{
-					m_lastShortcutCounter = shortcuts[i].m_shouldLoop ? 0 : m_lastShortcutCounter + 1;
+					m_lastShortcutCounter = shortcuts[i].shouldLoop ? 0 : m_lastShortcutCounter + 1;
 					foundIndex = i;
 					break;
 				}
@@ -149,16 +149,16 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	else
 	{
-		// find the lowest m_times
+		// find the lowest `ModelShortcut::times`
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
-				// selecting the shortcut with the largest m_times
-				if (found == false || minMaxTimes > shortcuts[i].m_times)
+				// selecting the shortcut with the largest `ModelShortcut::times`
+				if (found == false || minMaxTimes > shortcuts[i].times)
 				{
 					foundIndex = i;
-					minMaxTimes = shortcuts[i].m_times;
+					minMaxTimes = shortcuts[i].times;
 				}
 				m_lastShortcut = shortcuts[i];
 				m_lastShortcutCounter = 1;
@@ -168,7 +168,7 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	if (found)
 	{
-		QString message = shortcuts[foundIndex].m_shortcutDescription;
+		QString message = shortcuts[foundIndex].shortcutDescription;
 		showMessage(message);
 		processShortcutPressed(foundIndex, event);
 
@@ -262,14 +262,14 @@ QString InteractiveModelView::buildShortcutMessage()
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
 	for (size_t i = 0; i < shortcuts.size(); i++)
 	{
-		message = message + QString("\"") + QKeySequence(shortcuts[i].m_modifier).toString()
-			+ QKeySequence(shortcuts[i].m_key).toString();
-		if (shortcuts[i].m_times > 0)
+		message = message + QString("\"") + QKeySequence(shortcuts[i].modifier).toString()
+			+ QKeySequence(shortcuts[i].key).toString();
+		if (shortcuts[i].times > 0)
 		{
-			message = message + QString(" (x") + QString::number(shortcuts[i].m_times + 1) + QString(")");
+			message = message + QString(" (x") + QString::number(shortcuts[i].times + 1) + QString(")");
 		}
 		message = message + QString("\": ")
-			+ shortcuts[i].m_shortcutDescription;
+			+ shortcuts[i].shortcutDescription;
 		if (i + 1 < shortcuts.size())
 		{
 			message = message + QString(", ");
@@ -297,12 +297,12 @@ void InteractiveModelView::setIsHighlighted(bool isHighlighted)
 
 bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const
 {
-	return shortcut->m_key == event->key() && (event->modifiers() & shortcut->m_modifier);
+	return shortcut->key == event->key() && (event->modifiers() & shortcut->modifier);
 }
 
 bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const
 {
-	return shortcutA->m_key == shortcutB->m_key && (shortcutA->m_modifier & shortcutB->m_modifier);
+	return shortcutA->key == shortcutB->key && (shortcutA->modifier & shortcutB->modifier);
 }
 
 } // namespace lmms::gui

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -114,12 +114,7 @@ QColor InteractiveModelView::getHighlightColor()
 	return *s_highlightColor;
 }
 
-void InteractiveModelView::setHighlightColor(QColor& color)
-{
-	s_highlightColor = std::make_unique<QColor>(color);
-}
-
-void InteractiveModelView::keyPressEvent(QKeyEvent* event)
+bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 {
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
 
@@ -177,6 +172,8 @@ void InteractiveModelView::keyPressEvent(QKeyEvent* event)
 		QString message = shortcuts[foundIndex].m_shortcutDescription;
 		showMessage(message);
 		processShortcutPressed(foundIndex, event);
+
+		event->accept();
 	}
 	else
 	{
@@ -186,9 +183,22 @@ void InteractiveModelView::keyPressEvent(QKeyEvent* event)
 			&& event->key() != Qt::Key_Alt
 			&& event->key() != Qt::Key_AltGr)
 		{
-			m_focusedBeforeWidget->setFocus();
+			//m_focusedBeforeWidget->setFocus();
+			getGUI()->mainWindow()->setFocusedInteractiveModel(nullptr);
 		}
 	}
+	return found;
+}
+
+void InteractiveModelView::setHighlightColor(QColor& color)
+{
+	s_highlightColor = std::make_unique<QColor>(color);
+}
+
+void InteractiveModelView::keyPressEvent(QKeyEvent* event)
+{
+	// this will run `HandleKeyPress()` for the widget that is focused inside MainWindow
+	getGUI()->mainWindow()->focusedInteractiveModelHandleKeyPress(event);
 }
 
 void InteractiveModelView::enterEvent(QEvent* event)
@@ -203,7 +213,9 @@ void InteractiveModelView::enterEvent(QEvent* event)
 	{
 		m_focusedBeforeWidget = QApplication::focusWidget();
 		// focus on this widget so keyPressEvent works
-		setFocus();
+		//setFocus();
+		qDebug("focus set");
+		getGUI()->mainWindow()->setFocusedInteractiveModel(this);
 	}
 }
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -147,7 +147,6 @@ void InteractiveModelView::HighlightThisWidget(const QColor& color, size_t durat
 
 bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 {
-	std::cout << "InteractiveModelView::HandleKeyPress this:" << this << "\n";
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
 	
 	size_t foundIndex = 0;
@@ -250,7 +249,6 @@ void InteractiveModelView::leaveEvent(QEvent* event)
 bool InteractiveModelView::processPaste(const QMimeData* mimeData)
 {
 	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
-	std::cout << "InteractiveModelView::processPaste this:" << this << "\n";
 
 	Clipboard::DataType type = Clipboard::decodeKey(mimeData);
 	QString value = Clipboard::decodeValue(mimeData);

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -145,7 +145,11 @@ void InteractiveModelView::HighlightThisWidget(const QColor& color, size_t durat
 
 bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 {
+	qDebug("HandleKeyPress 1");
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
+	qDebug("HandleKeyPress 2");
+	
+	qDebug("HandleKeyPress 2 + 1, shortcut: " + QKeySequence(event->modifiers()).toString().toLatin1() + " " + QKeySequence(event->key()).toString().toLatin1());
 
 	size_t foundIndex = 0;
 	unsigned int minMaxTimes = 0;
@@ -158,6 +162,7 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 		// the shortcut that's `ModelShortcut::times` == m_lastShortcutCounter
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
+			qDebug("HandleKeyPress 3");
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
 				// selecting the shortcut with the largest m_times
@@ -172,6 +177,7 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 				{
 					m_lastShortcutCounter = shortcuts[i].shouldLoop ? 0 : m_lastShortcutCounter + 1;
 					foundIndex = i;
+					qDebug("HandleKeyPress 4");
 					break;
 				}
 			}
@@ -179,16 +185,20 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	else
 	{
+		qDebug("HandleKeyPress 5");
 		// find the lowest `ModelShortcut::times`
 		for (size_t i = 0; i < shortcuts.size(); i++)
 		{
+			qDebug("HandleKeyPress 6");
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
+				qDebug("HandleKeyPress 7");
 				// selecting the shortcut with the lowest `ModelShortcut::times`
 				if (found == false || minMaxTimes > shortcuts[i].times)
 				{
 					foundIndex = i;
 					minMaxTimes = shortcuts[i].times;
+					qDebug("HandleKeyPress 8");
 				}
 				m_lastShortcut = shortcuts[i];
 				m_lastShortcutCounter = 1;
@@ -198,23 +208,31 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	}
 	if (found)
 	{
+		qDebug("HandleKeyPress 9");
 		QString message = shortcuts[foundIndex].shortcutDescription;
+		qDebug("HandleKeyPress 10");
 		showMessage(message);
+		qDebug("HandleKeyPress 11");
 		processShortcutPressed(foundIndex, event);
+		qDebug("HandleKeyPress 12");
 
 		event->accept();
 	}
 	else
 	{
+		qDebug("HandleKeyPress 13");
 		// reset focus
 		if (event->key() != Qt::Key_Control
 			&& event->key() != Qt::Key_Shift
 			&& event->key() != Qt::Key_Alt
 			&& event->key() != Qt::Key_AltGr)
 		{
+			qDebug("HandleKeyPress 14");
 			getGUI()->mainWindow()->setFocusedInteractiveModel(nullptr);
+			qDebug("HandleKeyPress 15");
 		}
 	}
+	qDebug("HandleKeyPress 16");
 	return found;
 }
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -75,7 +75,7 @@ void InteractiveModelView::startHighlighting(Clipboard::StringPairDataType dataT
 	{
 		(*it)->overrideSetIsHighlighted((*it)->canAcceptClipboardData(dataType));
 	}
-	s_highlightTimer->start(20000);
+	s_highlightTimer->start(10000);
 }
 
 void InteractiveModelView::stopHighlighting()

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -66,7 +66,7 @@ InteractiveModelView::~InteractiveModelView()
 	}
 }
 
-void InteractiveModelView::startHighlighting(Clipboard::StringPairDataType dataType)
+void InteractiveModelView::startHighlighting(Clipboard::DataType dataType)
 {
 	if (s_highlightTimer == nullptr)
 	{
@@ -270,7 +270,7 @@ bool InteractiveModelView::processPaste(const QMimeData* mimeData)
 	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
 	std::cout << "InteractiveModelView::processPaste this:" << this << "\n";
 
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+	Clipboard::DataType type = Clipboard::decodeKey(mimeData);
 	QString value = Clipboard::decodeValue(mimeData);
 	bool shouldAccept = processPasteImplementation(type, value);
 	if (shouldAccept)

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -154,7 +154,7 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 		{
 			if (doesShortcutMatch(&shortcuts[i], event))
 			{
-				// selecting the shortcut with the largest `ModelShortcut::times`
+				// selecting the shortcut with the lowest `ModelShortcut::times`
 				if (found == false || minMaxTimes > shortcuts[i].times)
 				{
 					foundIndex = i;
@@ -295,7 +295,9 @@ void InteractiveModelView::setIsHighlighted(bool isHighlighted)
 
 bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcut, QKeyEvent* event) const
 {
-	return shortcut->key == event->key() && (event->modifiers() & shortcut->modifier);
+	// if shortcut key == event key and the shortcut modifier can be found inside event modifiers or there is no modifier
+	return shortcut->key == event->key() && ((event->modifiers() & shortcut->modifier)
+		|| (event->nativeModifiers() <= 0 && shortcut->modifier == Qt::NoModifier));
 }
 
 bool InteractiveModelView::doesShortcutMatch(const ModelShortcut* shortcutA, const ModelShortcut* shortcutB) const

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -164,7 +164,7 @@ void InteractiveModelView::doCommandAt(size_t commandIndex, bool shouldLinkBack)
 	if (commands[commandIndex].isTypeAccepted(Clipboard::decodeKey(Clipboard::getMimeData())) == false) { return; }
 
 	assert(commands[commandIndex].getDoFn().get() != nullptr);
-	GuiCommand command(commands[commandIndex].getText(), this, commands[commandIndex].getDoFn(), commands[commandIndex].getUndoFn(), 1, shouldLinkBack);
+	BasicCommand command(commands[commandIndex].getText(), this, commands[commandIndex].getDoFn(), commands[commandIndex].getUndoFn(), 1, shouldLinkBack);
 	command.redo();
 }
 

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -35,6 +35,8 @@
 #include "MainWindow.h"
 #include "SimpleTextFloat.h"
 
+#include <iostream> // DEBUG REMOVE TODO
+
 namespace lmms::gui
 {
 
@@ -146,6 +148,7 @@ void InteractiveModelView::HighlightThisWidget(const QColor& color, size_t durat
 bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 {
 	qDebug("HandleKeyPress 1");
+	std::cout << "InteractiveModelView::HandleKeyPress this:" << this << "\n";
 	std::vector<ModelShortcut> shortcuts(getShortcuts());
 	qDebug("HandleKeyPress 2");
 	
@@ -265,6 +268,7 @@ void InteractiveModelView::leaveEvent(QEvent* event)
 bool InteractiveModelView::processPaste(const QMimeData* mimeData)
 {
 	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
+	std::cout << "InteractiveModelView::processPaste this:" << this << "\n";
 
 	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
 	QString value = Clipboard::decodeValue(mimeData);

--- a/src/gui/InteractiveModelView.cpp
+++ b/src/gui/InteractiveModelView.cpp
@@ -47,8 +47,7 @@ std::list<InteractiveModelView*> InteractiveModelView::s_interactiveWidgets;
 InteractiveModelView::InteractiveModelView(QWidget* widget) :
 	QWidget(widget),
 	m_isHighlighted(false),
-	m_lastShortcutCounter(0),
-	m_focusedBeforeWidget(nullptr)
+	m_lastShortcutCounter(0)
 {
 	s_interactiveWidgets.push_back(this);
 
@@ -178,12 +177,11 @@ bool InteractiveModelView::HandleKeyPress(QKeyEvent* event)
 	else
 	{
 		// reset focus
-		if (m_focusedBeforeWidget && event->key() != Qt::Key_Control
+		if (event->key() != Qt::Key_Control
 			&& event->key() != Qt::Key_Shift
 			&& event->key() != Qt::Key_Alt
 			&& event->key() != Qt::Key_AltGr)
 		{
-			//m_focusedBeforeWidget->setFocus();
 			getGUI()->mainWindow()->setFocusedInteractiveModel(nullptr);
 		}
 	}
@@ -211,7 +209,6 @@ void InteractiveModelView::enterEvent(QEvent* event)
 
 	if (isVisible())
 	{
-		m_focusedBeforeWidget = QApplication::focusWidget();
 		// focus on this widget so keyPressEvent works
 		//setFocus();
 		qDebug("focus set");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -50,6 +50,7 @@
 #include "ImportFilter.h"
 #include "InstrumentTrackView.h"
 #include "InstrumentTrackWindow.h"
+#include "InteractiveModelView.h"
 #include "MicrotunerConfig.h"
 #include "PatternEditor.h"
 #include "PianoRoll.h"
@@ -285,7 +286,7 @@ void MainWindow::finalize()
 	project_menu->addMenu(new RecentProjectsMenu(this));
 
 	project_menu->addAction( embed::getIconPixmap( "project_save" ),
-					tr( "&Save" ),
+					tr( "Save" ),
 					this, SLOT(saveProject()),
 					QKeySequence::Save );
 	project_menu->addAction( embed::getIconPixmap( "project_save" ),
@@ -1263,6 +1264,19 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 }
 
 
+void MainWindow::setFocusedInteractiveModel(InteractiveModelView* model)
+{
+	m_focusedInteractiveModel = model;
+}
+
+bool MainWindow::focusedInteractiveModelHandleKeyPress(QKeyEvent* event)
+{
+	if (m_focusedInteractiveModel != nullptr)
+	{
+		return m_focusedInteractiveModel->HandleKeyPress(event);
+	}
+	return false;
+}
 
 
 void MainWindow::focusOutEvent( QFocusEvent * _fe )
@@ -1279,6 +1293,7 @@ void MainWindow::focusOutEvent( QFocusEvent * _fe )
 
 void MainWindow::keyPressEvent( QKeyEvent * _ke )
 {
+qDebug("KeyPressed event");
 	switch( _ke->key() )
 	{
 		case Qt::Key_Control: m_keyMods.m_ctrl = true; break;
@@ -1311,6 +1326,9 @@ void MainWindow::keyPressEvent( QKeyEvent * _ke )
 		}
 		default:
 		{
+			bool accepted = focusedInteractiveModelHandleKeyPress(_ke);
+			if (accepted) { break; }
+			
 			InstrumentTrackWindow * w =
 						InstrumentTrackView::topLevelInstrumentTrackWindow();
 			if( w )

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1269,15 +1269,6 @@ void MainWindow::setFocusedInteractiveModel(InteractiveModelView* model)
 	m_focusedInteractiveModel = model;
 }
 
-bool MainWindow::focusedInteractiveModelHandleKeyPress(QKeyEvent* event)
-{
-	if (m_focusedInteractiveModel != nullptr)
-	{
-		return m_focusedInteractiveModel->HandleKeyPress(event);
-	}
-	return false;
-}
-
 
 void MainWindow::focusOutEvent( QFocusEvent * _fe )
 {
@@ -1325,9 +1316,6 @@ void MainWindow::keyPressEvent( QKeyEvent * _ke )
 		}
 		default:
 		{
-			bool accepted = focusedInteractiveModelHandleKeyPress(_ke);
-			if (accepted) { break; }
-			
 			InstrumentTrackWindow * w =
 						InstrumentTrackView::topLevelInstrumentTrackWindow();
 			if( w )

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1293,7 +1293,6 @@ void MainWindow::focusOutEvent( QFocusEvent * _fe )
 
 void MainWindow::keyPressEvent( QKeyEvent * _ke )
 {
-qDebug("KeyPressed event");
 	switch( _ke->key() )
 	{
 		case Qt::Key_Control: m_keyMods.m_ctrl = true; break;

--- a/src/gui/PluginBrowser.cpp
+++ b/src/gui/PluginBrowser.cpp
@@ -285,7 +285,7 @@ void PluginDescWidget::mousePressEvent( QMouseEvent * _me )
 	Engine::setDndPluginKey(&m_pluginKey);
 	if ( _me->button() == Qt::LeftButton )
 	{
-		new StringPairDrag(Clipboard::StringPairDataType::Instrument,
+		new StringPairDrag(Clipboard::DataType::Instrument,
 			QString::fromUtf8(m_pluginKey.desc->name), m_logo, this);
 		leaveEvent( _me );
 	}

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -41,7 +41,7 @@ namespace lmms::gui
 {
 
 
-StringPairDrag::StringPairDrag(Clipboard::StringPairDataType key, const QString& _value,
+StringPairDrag::StringPairDrag(Clipboard::DataType key, const QString& _value,
 				const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets) :
 	QDrag( _w )
 {
@@ -85,13 +85,13 @@ StringPairDrag::~StringPairDrag()
 
 
 bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
-	Clipboard::StringPairDataType allowedKey)
+	Clipboard::DataType allowedKey)
 {
 	if (!_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
 		return(false);
 	}
-	Clipboard::StringPairDataType curKey = Clipboard::decodeKey(_dee->mimeData());
+	Clipboard::DataType curKey = Clipboard::decodeKey(_dee->mimeData());
 	if (allowedKey == curKey)
 	{
 		_dee->acceptProposedAction();
@@ -102,13 +102,13 @@ bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
 }
 
 bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
-	const std::vector<Clipboard::StringPairDataType>* allowedKeys)
+	const std::vector<Clipboard::DataType>* allowedKeys)
 {
 	if (!_dee->mimeData()->hasFormat(Clipboard::mimeType(Clipboard::MimeType::StringPair)))
 	{
 		return(false);
 	}
-	Clipboard::StringPairDataType curKey = Clipboard::decodeKey(_dee->mimeData());
+	Clipboard::DataType curKey = Clipboard::decodeKey(_dee->mimeData());
 	for (auto& i : (*allowedKeys))
 	{
 		if (i == curKey)
@@ -122,7 +122,7 @@ bool StringPairDrag::processDragEnterEvent(QDragEnterEvent* _dee,
 }
 
 
-Clipboard::StringPairDataType StringPairDrag::decodeKey(QDropEvent * _de)
+Clipboard::DataType StringPairDrag::decodeKey(QDropEvent * _de)
 {
 	return Clipboard::decodeKey(_de->mimeData());
 }

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -45,9 +45,6 @@ StringPairDrag::StringPairDrag(Clipboard::DataType key, const QString& _value,
 				const QPixmap& _icon, QWidget* _w, bool shouldHighlightWidgets) :
 	QDrag( _w )
 {
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
 	if( _icon.isNull() && _w )
 	{
 		setPixmap( _w->grab().scaled(
@@ -61,12 +58,13 @@ StringPairDrag::StringPairDrag(Clipboard::DataType key, const QString& _value,
 	}
 	QString txt = Clipboard::getStringPairKeyName(key) + ":" + _value;
 	auto m = new QMimeData();
-	m->setData( mimeType( MimeType::StringPair ), txt.toUtf8() );
-	setMimeData( m );
+	m->setData(Clipboard::mimeType(Clipboard::MimeType::StringPair), txt.toUtf8());
+	setMimeData(m); // QDrag
 	if (shouldHighlightWidgets)
 	{
 		InteractiveModelView::startHighlighting(key);
 	}
+
 	exec( Qt::CopyAction, Qt::CopyAction );
 }
 

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -244,12 +244,8 @@ bool AutomationClipView::canAcceptClipboardData(Clipboard::StringPairDataType da
 	return dataType == Clipboard::StringPairDataType::AutomatableModelLink || ClipView::canAcceptClipboardData(dataType);
 }
 
-bool AutomationClipView::processPaste(const QMimeData* mimeData)
+bool AutomationClipView::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
 {
-	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
-	QString value = Clipboard::decodeValue(mimeData);
-
 	bool shouldAccept = false;
 	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
@@ -275,13 +271,9 @@ bool AutomationClipView::processPaste(const QMimeData* mimeData)
 		}
 	}
 	
-	if (shouldAccept)
+	if (shouldAccept == false)
 	{
-		InteractiveModelView::stopHighlighting();
-	}
-	else
-	{
-		shouldAccept = ClipView::processPaste(mimeData);
+		shouldAccept = ClipView::processPasteImplementation(type, value);
 	}
 	return shouldAccept;
 }

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -64,9 +64,9 @@ AutomationClipView::AutomationClipView( AutomationClip * _clip,
 
 	if (m_shortcutMessage == "")
 	{
-		m_shortcutMessage = buildShortcutMessage();
-		std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray = ClipView::getShortcuts();
+		s_shortcutArray = ClipView::getShortcuts();
 		s_shortcutArray.emplace_back(Qt::Key_F, Qt::ControlModifier, 0, QString(tr("Open in Automation editor")), false);
+		m_shortcutMessage = buildShortcutMessage();
 	}
 
 	setToolTip(m_clip->name());

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -240,15 +240,15 @@ QString AutomationClipView::getShortcutMessage()
 	return m_shortcutMessage;
 }
 
-bool AutomationClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+bool AutomationClipView::canAcceptClipboardData(Clipboard::DataType dataType)
 {
-	return dataType == Clipboard::StringPairDataType::AutomatableModelLink || ClipView::canAcceptClipboardData(dataType);
+	return dataType == Clipboard::DataType::AutomatableModelLink || ClipView::canAcceptClipboardData(dataType);
 }
 
-bool AutomationClipView::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
+bool AutomationClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	bool shouldAccept = false;
-	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
+	if (type == Clipboard::DataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(value.toInt()));
 		if (mod != nullptr)
@@ -485,7 +485,7 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 
 void AutomationClipView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::DataType::AutomatableModelLink);
 	if( !_dee->isAccepted() )
 	{
 		ClipView::dragEnterEvent( _dee );

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -48,9 +48,8 @@
 namespace lmms::gui
 {
 
-AutomationClipView::AutomationClipView( AutomationClip * _clip,
-						TrackView * _parent ) :
-	ClipView( _clip, _parent ),
+AutomationClipView::AutomationClipView(AutomationClip* _clip, TrackView* _parent) :
+	ClipView(_clip, _parent, getTypeId<AutomationClipView>()),
 	m_clip( _clip ),
 	m_paintPixmap()
 {
@@ -207,11 +206,8 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	}
 }
 
-bool AutomationClipView::canAcceptClipboardData(Clipboard::DataType dataType)
-{
-	return dataType == Clipboard::DataType::AutomatableModelLink || ClipView::canAcceptClipboardData(dataType);
-}
 
+/*
 bool AutomationClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	bool shouldAccept = false;
@@ -245,6 +241,7 @@ bool AutomationClipView::processPasteImplementation(Clipboard::DataType type, QS
 	}
 	return shouldAccept;
 }
+*/
 
 
 
@@ -464,12 +461,14 @@ void AutomationClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void AutomationClipView::dropEvent( QDropEvent * _de )
 {
-	bool shouldAccept = processPaste(_de->mimeData());
+	/*
+	bool shouldAccept = processPaste(_de->mimeData()); TODO
 
 	if (shouldAccept)
 	{
 		_de->accept();
 	}
+	*/
 }
 
 

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -48,9 +48,6 @@
 namespace lmms::gui
 {
 
-QString AutomationClipView::m_shortcutMessage = "";
-std::vector<InteractiveModelView::ModelShortcut> AutomationClipView::s_shortcutArray = {};
-
 AutomationClipView::AutomationClipView( AutomationClip * _clip,
 						TrackView * _parent ) :
 	ClipView( _clip, _parent ),
@@ -61,13 +58,6 @@ AutomationClipView::AutomationClipView( AutomationClip * _clip,
 			this, SLOT(update()));
 	connect( getGUI()->automationEditor(), SIGNAL(currentClipChanged()),
 			this, SLOT(update()));
-
-	if (m_shortcutMessage == "")
-	{
-		s_shortcutArray = ClipView::getShortcuts();
-		s_shortcutArray.emplace_back(Qt::Key_F, Qt::ControlModifier, 0, QString(tr("Open in Automation editor")), false);
-		m_shortcutMessage = buildShortcutMessage();
-	}
 
 	setToolTip(m_clip->name());
 	setStyle( QApplication::style() );
@@ -215,29 +205,6 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 				this, SLOT(disconnectObject(QAction*)));
 		_cm->addMenu( m );
 	}
-}
-
-const std::vector<InteractiveModelView::ModelShortcut>& AutomationClipView::getShortcuts()
-{
-	return s_shortcutArray;
-}
-
-void AutomationClipView::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
-{
-	switch (shortcutLocation)
-	{
-		case 3:
-			openInAutomationEditor();
-			break;
-		default:
-			ClipView::processShortcutPressed(shortcutLocation, event);
-			break;
-	}
-}
-
-QString AutomationClipView::getShortcutMessage()
-{
-	return m_shortcutMessage;
 }
 
 bool AutomationClipView::canAcceptClipboardData(Clipboard::DataType dataType)

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -49,6 +49,7 @@ namespace lmms::gui
 {
 
 QString AutomationClipView::m_shortcutMessage = "";
+std::vector<InteractiveModelView::ModelShortcut> AutomationClipView::s_shortcutArray = {};
 
 AutomationClipView::AutomationClipView( AutomationClip * _clip,
 						TrackView * _parent ) :
@@ -64,6 +65,8 @@ AutomationClipView::AutomationClipView( AutomationClip * _clip,
 	if (m_shortcutMessage == "")
 	{
 		m_shortcutMessage = buildShortcutMessage();
+		std::vector<InteractiveModelView::ModelShortcut> s_shortcutArray = ClipView::getShortcuts();
+		s_shortcutArray.emplace_back(Qt::Key_F, Qt::ControlModifier, 0, QString(tr("Open in Automation editor")), false);
 	}
 
 	setToolTip(m_clip->name());
@@ -214,11 +217,9 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	}
 }
 
-std::vector<InteractiveModelView::ModelShortcut> AutomationClipView::getShortcuts()
+const std::vector<InteractiveModelView::ModelShortcut>& AutomationClipView::getShortcuts()
 {
-	std::vector<InteractiveModelView::ModelShortcut> clipShortcuts = ClipView::getShortcuts();
-	clipShortcuts.emplace_back(Qt::Key_F, Qt::ControlModifier, 0, QString(tr("Open in Automation editor")), false);
-	return clipShortcuts;
+	return s_shortcutArray;
 }
 
 void AutomationClipView::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -1226,10 +1226,10 @@ bool ClipView::processPasteImplementation(Clipboard::StringPairDataType type, QS
 	return shouldAccept;
 }
 
-void ClipView::overrideSetIsHighlighted(bool isHighlighted)
+void ClipView::overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate)
 {
-	if (getIsHighlighted() != isHighlighted) { setNeedsUpdate(true); }
-	setIsHighlighted(isHighlighted);
+	if (shouldOverrideUpdate || getIsHighlighted() != isHighlighted) { setNeedsUpdate(true); }
+	setIsHighlighted(isHighlighted, shouldOverrideUpdate);
 }
 
 

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -79,6 +79,15 @@ TextFloat * ClipView::s_textFloat = nullptr;
  */
 QString ClipView::m_shortcutMessage = "";
 
+/*! Vector storing the widget's shortcuts.
+ */
+std::vector<InteractiveModelView::ModelShortcut> ClipView::s_shortcutArray =
+{
+	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy clip")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste clip")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_X, Qt::ControlModifier, 0, QString(tr("Cut out clip")), false)
+};
+
 
 /*! \brief Create a new ClipView
  *
@@ -1162,14 +1171,9 @@ void ClipView::contextMenuAction( ContextMenuAction action )
 	}
 }
 
-std::vector<InteractiveModelView::ModelShortcut> ClipView::getShortcuts()
+const std::vector<InteractiveModelView::ModelShortcut>& ClipView::getShortcuts()
 {
-	std::vector<InteractiveModelView::ModelShortcut> shortcuts = {
-		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy clip")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste clip")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_X, Qt::ControlModifier, 0, QString(tr("Cut out clip")), false)
-	};
-	return shortcuts;
+	return s_shortcutArray;
 }
 
 void ClipView::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -81,9 +81,8 @@ TextFloat * ClipView::s_textFloat = nullptr;
  * \param _clip The clip to be displayed
  * \param _tv  The track view that will contain the new object
  */
-ClipView::ClipView( Clip * clip,
-							TrackView * tv ) :
-	selectableObject( tv->getTrackContentWidget() ),
+ClipView::ClipView(Clip * clip, TrackView * tv, size_t typeId) :
+	selectableObject(tv->getTrackContentWidget(), typeId),
 	ModelView( nullptr, this ),
 	m_trackView( tv ),
 	m_initialClipPos( TimePos(0) ),
@@ -452,12 +451,14 @@ void ClipView::dragEnterEvent( QDragEnterEvent * dee )
  */
 void ClipView::dropEvent( QDropEvent * de )
 {
-	bool shouldAccept = processPaste(de->mimeData());
+	/*
+	bool shouldAccept = processPaste(de->mimeData()); TODO
 
 	if (shouldAccept)
 	{
 		de->accept();
 	}
+	*/
 }
 
 
@@ -1137,10 +1138,12 @@ void ClipView::contextMenuAction( ContextMenuAction action )
 	}
 }
 
+/*
 bool ClipView::canAcceptClipboardData(Clipboard::DataType dataType)
 {
 	return dataType == getClipStringPairType(m_clip->getTrack());;
 }
+
 
 bool ClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
@@ -1159,6 +1162,7 @@ bool ClipView::processPasteImplementation(Clipboard::DataType type, QString& val
 	}
 	return shouldAccept;
 }
+*/
 
 void ClipView::overrideSetIsHighlighted(bool isHighlighted, bool shouldOverrideUpdate)
 {
@@ -1219,7 +1223,7 @@ void ClipView::cut( QVector<ClipView *> clipvs )
 
 void ClipView::paste()
 {
-	processPaste(Clipboard::getMimeData());
+	//processPaste(Clipboard::getMimeData()); TODO
 
 	/*
 	// If possible, paste the selection on the TimePos of the selected Track and remove it
@@ -1484,7 +1488,7 @@ Clipboard::DataType ClipView::getClipStringPairType(Track* track)
 		default:
 			break;
 	}
-	return Clipboard::DataType::None;
+	return Clipboard::DataType::Error;
 }
 
 } // namespace lmms::gui

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -477,11 +477,11 @@ void ClipView::dragEnterEvent( QDragEnterEvent * dee )
 void ClipView::dropEvent( QDropEvent * de )
 {
 	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return; }
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
 
 	// Track must be the same type to paste into
-	if (type != getClipStringPairType(m_clip->getTrack()) || type == Clipboard::StringPairDataType::None)
+	if (type != getClipStringPairType(m_clip->getTrack()) || type == Clipboard::DataType::None)
 	{
 		return;
 	}
@@ -1182,7 +1182,7 @@ void ClipView::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
 	{
 		case 0:
 			contextMenuAction(ContextMenuAction::Copy);
-			//static void startHighlighting(Clipboard::StringPairDataType dataType);
+			//static void startHighlighting(Clipboard::DataType dataType);
 			break;
 		case 1:
 			contextMenuAction(ContextMenuAction::Paste);
@@ -1203,15 +1203,15 @@ QString ClipView::getShortcutMessage()
 	return m_shortcutMessage;
 }
 
-bool ClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+bool ClipView::canAcceptClipboardData(Clipboard::DataType dataType)
 {
 	return dataType == getClipStringPairType(m_clip->getTrack());;
 }
 
-bool ClipView::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
+bool ClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	// Track must be the same type to paste into
-	if (type != getClipStringPairType(m_clip->getTrack()) || type == Clipboard::StringPairDataType::None) { return false; }
+	if (type != getClipStringPairType(m_clip->getTrack()) || type == Clipboard::DataType::None) { return false; }
 
 	bool shouldAccept = false;
 
@@ -1529,29 +1529,29 @@ bool ClipView::splitClip(const TimePos pos)
 	return true;
 }
 
-Clipboard::StringPairDataType ClipView::getClipStringPairType(Track* track)
+Clipboard::DataType ClipView::getClipStringPairType(Track* track)
 {
 	switch (track->type())
 	{
 		case Track::Type::Instrument:
-			return Clipboard::StringPairDataType::MidiClip;
+			return Clipboard::DataType::MidiClip;
 			break;
 		case Track::Type::Pattern:
-			return Clipboard::StringPairDataType::PatternClip;
+			return Clipboard::DataType::PatternClip;
 			break;
 		case Track::Type::Sample:
-			return Clipboard::StringPairDataType::SampleClip;
+			return Clipboard::DataType::SampleClip;
 			break;
 		case Track::Type::Automation:
-			return Clipboard::StringPairDataType::AutomationClip;
+			return Clipboard::DataType::AutomationClip;
 			break;
 		case Track::Type::HiddenAutomation:
-			return Clipboard::StringPairDataType::AutomationClip;
+			return Clipboard::DataType::AutomationClip;
 			break;
 		default:
 			break;
 	}
-	return Clipboard::StringPairDataType::None;
+	return Clipboard::DataType::None;
 }
 
 } // namespace lmms::gui

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -52,8 +52,8 @@ namespace lmms::gui
 
 constexpr int BeatStepButtonOffset = 4;
 
-MidiClipView::MidiClipView( MidiClip* clip, TrackView* parent ) :
-	ClipView( clip, parent ),
+MidiClipView::MidiClipView(MidiClip* clip, TrackView* parent) :
+	ClipView(clip, parent, getTypeId<MidiClipView>()),
 	m_clip( clip ),
 	m_paintPixmap(),
 	m_noteFillColor(255, 255, 255, 220),

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -42,7 +42,7 @@ namespace lmms::gui
 
 
 PatternClipView::PatternClipView(Clip* _clip, TrackView* _tv) :
-	ClipView( _clip, _tv ),
+	ClipView(_clip, _tv, getTypeId<PatternClipView>()),
 	m_patternClip(dynamic_cast<PatternClip*>(_clip)),
 	m_paintPixmap()
 {

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -354,32 +354,25 @@ bool SampleClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataTy
 		|| ClipView::canAcceptClipboardData(dataType);
 }
 
-bool SampleClipView::processPaste(const QMimeData* mimeData)
+bool SampleClipView::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
 {
-	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
 	bool shouldAccept = false;
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
-
 	if (type == Clipboard::StringPairDataType::SampleFile)
 	{
-		m_clip->setSampleFile( Clipboard::decodeValue(mimeData));
+		m_clip->setSampleFile(value);
 		shouldAccept = true;
 	}
 	else if (type == Clipboard::StringPairDataType::SampleData)
 	{
-		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(Clipboard::decodeValue(mimeData)));
+		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(value));
 		m_clip->updateLength();
 		update();
 		shouldAccept = true;
 	}
 
-	if (shouldAccept)
+	if (shouldAccept == false)
 	{
-		InteractiveModelView::stopHighlighting();
-	}
-	else
-	{
-		shouldAccept = ClipView::processPaste(mimeData);
+		shouldAccept = ClipView::processPasteImplementation(type, value);
 	}
 	return shouldAccept;
 }

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -108,9 +108,9 @@ void SampleClipView::constructContextMenu(QMenu* cm)
 
 void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
-		Clipboard::StringPairDataType::SampleFile,
-		Clipboard::StringPairDataType::SampleData
+	std::vector<Clipboard::DataType> acceptedKeys = {
+		Clipboard::DataType::SampleFile,
+		Clipboard::DataType::SampleData
 	};
 	if (StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys) == false)
 	{
@@ -347,22 +347,22 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	painter.drawPixmap(m_paintPixmapXPosition, 0, m_paintPixmap);
 }
 
-bool SampleClipView::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+bool SampleClipView::canAcceptClipboardData(Clipboard::DataType dataType)
 {
-	return dataType == Clipboard::StringPairDataType::SampleFile
-		|| dataType == Clipboard::StringPairDataType::SampleData
+	return dataType == Clipboard::DataType::SampleFile
+		|| dataType == Clipboard::DataType::SampleData
 		|| ClipView::canAcceptClipboardData(dataType);
 }
 
-bool SampleClipView::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
+bool SampleClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	bool shouldAccept = false;
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		m_clip->setSampleFile(value);
 		shouldAccept = true;
 	}
-	else if (type == Clipboard::StringPairDataType::SampleData)
+	else if (type == Clipboard::DataType::SampleData)
 	{
 		m_clip->setSampleBuffer(SampleLoader::createBufferFromBase64(value));
 		m_clip->updateLength();

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -108,7 +108,7 @@ void SampleClipView::constructContextMenu(QMenu* cm)
 
 void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::DataType> acceptedKeys = {
+	static std::vector<Clipboard::DataType> acceptedKeys = {
 		Clipboard::DataType::SampleFile,
 		Clipboard::DataType::SampleData
 	};

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -45,7 +45,7 @@ namespace lmms::gui
 
 
 SampleClipView::SampleClipView( SampleClip * _clip, TrackView * _tv ) :
-	ClipView( _clip, _tv ),
+	ClipView(_clip, _tv, getTypeId<SampleClipView>()),
 	m_clip( _clip ),
 	m_paintPixmap(),
 	m_paintPixmapXPosition(0)
@@ -125,12 +125,14 @@ void SampleClipView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void SampleClipView::dropEvent( QDropEvent * _de )
 {
+	/*
 	bool shouldAccept = processPaste(_de->mimeData());
 
 	if (shouldAccept)
 	{
 		_de->accept();
 	}
+	*/
 }
 
 
@@ -347,13 +349,7 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	painter.drawPixmap(m_paintPixmapXPosition, 0, m_paintPixmap);
 }
 
-bool SampleClipView::canAcceptClipboardData(Clipboard::DataType dataType)
-{
-	return dataType == Clipboard::DataType::SampleFile
-		|| dataType == Clipboard::DataType::SampleData
-		|| ClipView::canAcceptClipboardData(dataType);
-}
-
+/*
 bool SampleClipView::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	bool shouldAccept = false;
@@ -376,6 +372,7 @@ bool SampleClipView::processPasteImplementation(Clipboard::DataType type, QStrin
 	}
 	return shouldAccept;
 }
+*/
 
 
 void SampleClipView::reverseSample()

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2258,9 +2258,9 @@ const AutomationClip* AutomationEditorWindow::currentClip()
 
 void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	QString val = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
+	if (type == Clipboard::DataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if (mod != nullptr)
@@ -2286,7 +2286,7 @@ void AutomationEditorWindow::dragEnterEvent( QDragEnterEvent *_dee )
 	if (! m_editor->validClip() ) {
 		return;
 	}
-	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::DataType::AutomatableModelLink);
 }
 
 void AutomationEditorWindow::open(AutomationClip* clip)

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -127,14 +127,14 @@ void PatternEditor::loadSettings(const QDomElement& element)
 
 void PatternEditor::dropEvent(QDropEvent* de)
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
 
-	if (type == Clipboard::StringPairDataType::InstrumentTrack
-		|| type == Clipboard::StringPairDataType::PatternTrack
-		|| type == Clipboard::StringPairDataType::SampleTrack
-		|| type == Clipboard::StringPairDataType::AutomationTrack
-		|| type == Clipboard::StringPairDataType::HiddenAutomationTrack)
+	if (type == Clipboard::DataType::InstrumentTrack
+		|| type == Clipboard::DataType::PatternTrack
+		|| type == Clipboard::DataType::SampleTrack
+		|| type == Clipboard::DataType::AutomationTrack
+		|| type == Clipboard::DataType::HiddenAutomationTrack)
 	{
 		DataFile dataFile( value.toUtf8() );
 		Track * t = Track::create( dataFile.content().firstChild().toElement(), model() );

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -369,7 +369,7 @@ void TrackContainerView::clearAllTracks()
 
 void TrackContainerView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::DataType> acceptedKeys = {
+	static std::vector<Clipboard::DataType> acceptedKeys = {
 		Clipboard::DataType::PresetFile,
 		Clipboard::DataType::PluginPresetFile,
 		Clipboard::DataType::SampleFile,

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -369,18 +369,18 @@ void TrackContainerView::clearAllTracks()
 
 void TrackContainerView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
-		Clipboard::StringPairDataType::PresetFile,
-		Clipboard::StringPairDataType::PluginPresetFile,
-		Clipboard::StringPairDataType::SampleFile,
-		Clipboard::StringPairDataType::Instrument,
-		Clipboard::StringPairDataType::SoundFontFile,
-		Clipboard::StringPairDataType::PatchFile,
-		Clipboard::StringPairDataType::VstPluginFile,
-		Clipboard::StringPairDataType::ImportedProject,
-		Clipboard::StringPairDataType::ProjectFile,
-		Clipboard::StringPairDataType::InstrumentTrack,
-		Clipboard::StringPairDataType::SampleTrack
+	std::vector<Clipboard::DataType> acceptedKeys = {
+		Clipboard::DataType::PresetFile,
+		Clipboard::DataType::PluginPresetFile,
+		Clipboard::DataType::SampleFile,
+		Clipboard::DataType::Instrument,
+		Clipboard::DataType::SoundFontFile,
+		Clipboard::DataType::PatchFile,
+		Clipboard::DataType::VstPluginFile,
+		Clipboard::DataType::ImportedProject,
+		Clipboard::DataType::ProjectFile,
+		Clipboard::DataType::InstrumentTrack,
+		Clipboard::DataType::SampleTrack
 	};
 
 	StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys);
@@ -400,9 +400,9 @@ void TrackContainerView::stopRubberBand()
 
 void TrackContainerView::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::Instrument)
+	if (type == Clipboard::DataType::Instrument)
 	{
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
 		auto ilt = new InstrumentLoaderThread(this, it, value);
@@ -410,9 +410,9 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if (type == Clipboard::StringPairDataType::SampleFile || type == Clipboard::StringPairDataType::PluginPresetFile
-		|| type == Clipboard::StringPairDataType::SoundFontFile || type == Clipboard::StringPairDataType::PatchFile
-		|| type == Clipboard::StringPairDataType::VstPluginFile)
+	else if (type == Clipboard::DataType::SampleFile || type == Clipboard::DataType::PluginPresetFile
+		|| type == Clipboard::DataType::SoundFontFile || type == Clipboard::DataType::PatchFile
+		|| type == Clipboard::DataType::VstPluginFile)
 	{
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
 		PluginFactory::PluginInfoAndKey piakn =
@@ -422,7 +422,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if (type == Clipboard::StringPairDataType::PresetFile)
+	else if (type == Clipboard::DataType::PresetFile)
 	{
 		DataFile dataFile( value );
 		auto it = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, m_tc));
@@ -431,13 +431,13 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		//it->toggledInstrumentTrackButton( true );
 		_de->accept();
 	}
-	else if (type == Clipboard::StringPairDataType::ImportedProject)
+	else if (type == Clipboard::DataType::ImportedProject)
 	{
 		ImportFilter::import( value, m_tc );
 		_de->accept();
 	}
 
-	else if (type == Clipboard::StringPairDataType::ProjectFile)
+	else if (type == Clipboard::DataType::ProjectFile)
 	{
 		if( getGUI()->mainWindow()->mayChangeProject(true) )
 		{
@@ -446,7 +446,7 @@ void TrackContainerView::dropEvent( QDropEvent * _de )
 		_de->accept();
 	}
 
-	else if (type == Clipboard::StringPairDataType::InstrumentTrack || type == Clipboard::StringPairDataType::SampleTrack)
+	else if (type == Clipboard::DataType::InstrumentTrack || type == Clipboard::DataType::SampleTrack)
 	{
 		DataFile dataFile( value.toUtf8() );
 		Track::create( dataFile.content().firstChild().toElement(), m_tc );

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -230,7 +230,7 @@ void EnvelopeAndLfoView::modelChanged()
 
 void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::DataType> acceptedKeys = {
+	static std::vector<Clipboard::DataType> acceptedKeys = {
 		Clipboard::DataType::SampleFile,
 		Clipboard::DataType::SampleClip
 	};

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -230,9 +230,9 @@ void EnvelopeAndLfoView::modelChanged()
 
 void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
-		Clipboard::StringPairDataType::SampleFile,
-		Clipboard::StringPairDataType::SampleClip
+	std::vector<Clipboard::DataType> acceptedKeys = {
+		Clipboard::DataType::SampleFile,
+		Clipboard::DataType::SampleClip
 	};
 	StringPairDrag::processDragEnterEvent(_dee, &acceptedKeys);
 }
@@ -242,9 +242,9 @@ void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		m_params->m_userWave = SampleLoader::createBufferFromFile(value);
 		m_userLfoBtn->model()->setValue( true );
@@ -252,7 +252,7 @@ void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 		_de->accept();
 		update();
 	}
-	else if (type == Clipboard::StringPairDataType::SampleClip)
+	else if (type == Clipboard::DataType::SampleClip)
 	{
 		DataFile dataFile( value.toUtf8() );
 		auto file = dataFile.content().

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -558,7 +558,7 @@ void InstrumentTrackWindow::focusInEvent( QFocusEvent* )
 
 void InstrumentTrackWindow::dragEnterEventGeneric( QDragEnterEvent* event )
 {
-	std::vector<Clipboard::DataType> acceptedKeys = {
+	static std::vector<Clipboard::DataType> acceptedKeys = {
 		Clipboard::DataType::Instrument,
 		Clipboard::DataType::PresetFile,
 		Clipboard::DataType::PluginPresetFile

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -558,10 +558,10 @@ void InstrumentTrackWindow::focusInEvent( QFocusEvent* )
 
 void InstrumentTrackWindow::dragEnterEventGeneric( QDragEnterEvent* event )
 {
-	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
-		Clipboard::StringPairDataType::Instrument,
-		Clipboard::StringPairDataType::PresetFile,
-		Clipboard::StringPairDataType::PluginPresetFile
+	std::vector<Clipboard::DataType> acceptedKeys = {
+		Clipboard::DataType::Instrument,
+		Clipboard::DataType::PresetFile,
+		Clipboard::DataType::PluginPresetFile
 	};
 	StringPairDrag::processDragEnterEvent(event, &acceptedKeys);
 }
@@ -579,10 +579,10 @@ void InstrumentTrackWindow::dragEnterEvent( QDragEnterEvent* event )
 
 void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(event);
+	Clipboard::DataType type = StringPairDrag::decodeKey(event);
 	QString value = StringPairDrag::decodeValue( event );
 
-	if (type == Clipboard::StringPairDataType::Instrument)
+	if (type == Clipboard::DataType::Instrument)
 	{
 		m_track->loadInstrument( value, nullptr, true /* DnD */ );
 
@@ -591,14 +591,14 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 		event->accept();
 		setFocus();
 	}
-	else if (type == Clipboard::StringPairDataType::PresetFile)
+	else if (type == Clipboard::DataType::PresetFile)
 	{
 		DataFile dataFile(value);
 		m_track->replaceInstrument(dataFile);
 		event->accept();
 		setFocus();
 	}
-	else if (type == Clipboard::StringPairDataType::PluginPresetFile)
+	else if (type == Clipboard::DataType::PluginPresetFile)
 	{
 		const QString ext = FileItem::extension( value );
 		Instrument * i = m_track->instrument();

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -450,7 +450,7 @@ void PianoView::mousePressEvent(QMouseEvent *me)
 
 			if (me->modifiers() & Qt::ControlModifier)
 			{
-				new StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*m_movedNoteModel), QPixmap(), this);
+				new StringPairDrag(Clipboard::DataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*m_movedNoteModel), QPixmap(), this);
 				me->accept();
 			}
 			else

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -589,10 +589,6 @@ void PianoView::mouseMoveEvent( QMouseEvent * _me )
  */
 void PianoView::keyPressEvent( QKeyEvent * _ke )
 {
-	// focusing is weird, workaround PianoView's agressive focus and see if InteractiveModelView can accept it
-	bool accepted = getGUI()->mainWindow()->focusedInteractiveModelHandleKeyPress(_ke);
-	if (accepted) { return; }
-	
 	const int key_num = getKeyFromKeyEvent( _ke );
 
 	if( _ke->isAutoRepeat() == false && key_num > -1 )

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -111,7 +111,7 @@ PianoView::PianoView(QWidget *parent) :
 	connect( m_pianoScroll, SIGNAL(valueChanged(int)),
 			this, SLOT(pianoScrolled(int)));
 
-	// create a layout for ourselvesr
+	// create a layout for ourselves
 	auto layout = new QVBoxLayout(this);
 	layout->setSpacing( 0 );
 	layout->setContentsMargins(0, 0, 0, 0);
@@ -589,7 +589,7 @@ void PianoView::mouseMoveEvent( QMouseEvent * _me )
  */
 void PianoView::keyPressEvent( QKeyEvent * _ke )
 {
-	// focusing is wird, workaround PianoView's agressive focus and see if InteractiveModelView can accept it
+	// focusing is weird, workaround PianoView's agressive focus and see if InteractiveModelView can accept it
 	bool accepted = getGUI()->mainWindow()->focusedInteractiveModelHandleKeyPress(_ke);
 	if (accepted) { return; }
 	

--- a/src/gui/tracks/AutomationTrackView.cpp
+++ b/src/gui/tracks/AutomationTrackView.cpp
@@ -49,7 +49,7 @@ AutomationTrackView::AutomationTrackView( AutomationTrack * _at, TrackContainerV
 
 void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::AutomatableModelLink);
+	StringPairDrag::processDragEnterEvent(_dee, Clipboard::DataType::AutomatableModelLink);
 }
 
 
@@ -57,9 +57,9 @@ void AutomationTrackView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void AutomationTrackView::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	QString val = StringPairDrag::decodeValue( _de );
-	if (type == Clipboard::StringPairDataType::AutomatableModelLink)
+	if (type == Clipboard::DataType::AutomatableModelLink)
 	{
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -191,7 +191,7 @@ void SampleTrackView::modelChanged()
 
 void SampleTrackView::dragEnterEvent(QDragEnterEvent *dee)
 {
-	StringPairDrag::processDragEnterEvent(dee, Clipboard::StringPairDataType::SampleFile);
+	StringPairDrag::processDragEnterEvent(dee, Clipboard::DataType::SampleFile);
 }
 
 
@@ -199,10 +199,10 @@ void SampleTrackView::dragEnterEvent(QDragEnterEvent *dee)
 
 void SampleTrackView::dropEvent(QDropEvent *de)
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue(de);
 
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		int trackHeadWidth = ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt()==1
 				? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -344,7 +344,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QDropEvent* d
 {
 	const QMimeData * mimeData = de->mimeData();
 
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+	Clipboard::DataType type = Clipboard::decodeKey(mimeData);
 	QString value = Clipboard::decodeValue(mimeData);
 
 	// If the source of the DropEvent is the current instance of LMMS we don't allow pasting in the same bar
@@ -355,7 +355,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QDropEvent* d
 }
 
 // Overloaded method to make it possible to call this method without a Drag&Drop event
-bool TrackContentWidget::canPasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool allowSameBar)
+bool TrackContentWidget::canPasteSelection(TimePos clipPos, Clipboard::DataType type, QString& value, bool allowSameBar)
 {
 	Track * t = getTrack();
 
@@ -437,7 +437,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, QDropEvent * de )
 {
 	const QMimeData * mimeData = de->mimeData();
 
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
+	Clipboard::DataType type = Clipboard::decodeKey(mimeData);
 	QString value = Clipboard::decodeValue(mimeData);
 
 	if (canPasteSelection(clipPos, type, value) == false)
@@ -450,7 +450,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, QDropEvent * de )
 }
 
 // Overloaded method so we can call it without a Drag&Drop event
-bool TrackContentWidget::pasteSelection(TimePos clipPos, Clipboard::StringPairDataType type, QString& value, bool skipSafetyCheck)
+bool TrackContentWidget::pasteSelection(TimePos clipPos, Clipboard::DataType type, QString& value, bool skipSafetyCheck)
 {
 	// When canPasteSelection was already called before, skipSafetyCheck will skip this
 	if (skipSafetyCheck == false && canPasteSelection(clipPos, type, value) == false)
@@ -686,7 +686,7 @@ void TrackContentWidget::contextMenuEvent( QContextMenuEvent * cme )
 	QAction *pasteA = contextMenu.addAction( embed::getIconPixmap( "edit_paste" ),
 					tr( "Paste" ), [this, cme](){ contextMenuAction( cme, ContextMenuAction::Paste ); } );
 	
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(Clipboard::getMimeData());
+	Clipboard::DataType type = Clipboard::decodeKey(Clipboard::getMimeData());
 	QString value = Clipboard::decodeValue(Clipboard::getMimeData());
 	
 	// If we can't paste in the current TCW for some reason, disable the action so the user knows
@@ -703,7 +703,7 @@ void TrackContentWidget::contextMenuAction( QContextMenuEvent * cme, ContextMenu
 		// Paste the selection on the TimePos of the context menu event
 		TimePos clipPos = getPosition( cme->x() );
 
-		Clipboard::StringPairDataType type = Clipboard::decodeKey(Clipboard::getMimeData());
+		Clipboard::DataType type = Clipboard::decodeKey(Clipboard::getMimeData());
 		QString value = Clipboard::decodeValue(Clipboard::getMimeData());
 
 		pasteSelection(clipPos, type, value);

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -198,7 +198,7 @@ Clipboard::DataType TrackView::getTrackStringPairType(Track* track)
 		default:
 			break;
 	}
-	return Clipboard::DataType::None;
+	return Clipboard::DataType::Error;
 }
 
 

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -173,32 +173,32 @@ QMenu * TrackView::createMixerMenu(QString title, QString newMixerLabel)
 	return nullptr;
 }
 
-/*! \brief Gets a StringPairDataType for this tracks, used for StringPairDrag.
+/*! \brief Gets a DataType for this tracks, used for StringPairDrag.
  *
  */
-Clipboard::StringPairDataType TrackView::getTrackStringPairType(Track* track)
+Clipboard::DataType TrackView::getTrackStringPairType(Track* track)
 {
 	switch (track->type())
 	{
 		case Track::Type::Instrument:
-			return Clipboard::StringPairDataType::InstrumentTrack;
+			return Clipboard::DataType::InstrumentTrack;
 			break;
 		case Track::Type::Pattern:
-			return Clipboard::StringPairDataType::PatternTrack;
+			return Clipboard::DataType::PatternTrack;
 			break;
 		case Track::Type::Sample:
-			return Clipboard::StringPairDataType::SampleTrack;
+			return Clipboard::DataType::SampleTrack;
 			break;
 		case Track::Type::Automation:
-			return Clipboard::StringPairDataType::AutomationTrack;
+			return Clipboard::DataType::AutomationTrack;
 			break;
 		case Track::Type::HiddenAutomation:
-			return Clipboard::StringPairDataType::HiddenAutomationTrack;
+			return Clipboard::DataType::HiddenAutomationTrack;
 			break;
 		default:
 			break;
 	}
-	return Clipboard::StringPairDataType::None;
+	return Clipboard::DataType::None;
 }
 
 
@@ -254,7 +254,7 @@ void TrackView::dragEnterEvent( QDragEnterEvent * dee )
  */
 void TrackView::dropEvent( QDropEvent * de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(de);
 	QString value = StringPairDrag::decodeValue( de );
 	if (type == getTrackStringPairType(getTrack()))
 	{

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -128,7 +128,7 @@ void AutomatableButton::mousePressEvent( QMouseEvent * _me )
 		{
 			// A group, we must get process it instead
 			auto groupView = (AutomatableModelView*)m_group;
-			new StringPairDrag(Clipboard::StringPairDataType::AutomatableModelLink,
+			new StringPairDrag(Clipboard::DataType::AutomatableModelLink,
 					QString::number( groupView->modelUntyped()->id() ),
 					QPixmap(), widget() );
 			// TODO: ^^ Maybe use a predefined icon instead of the button they happened to select

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -47,7 +47,7 @@ namespace lmms::gui
 SimpleTextFloat * FloatModelEditorBase::s_textFloat = nullptr;
 
 FloatModelEditorBase::FloatModelEditorBase(DirectionOfManipulation directionOfManipulation, QWidget * parent, const QString & name) :
-	InteractiveModelView(parent),
+	InteractiveModelView(parent, getTypeId<FloatModelEditorBase>()),
 	FloatModelView(new FloatModel(0, 0, 0, 1, nullptr, name, true), this),
 	m_volumeKnob(false),
 	m_volumeRatio(100.0, 0.0, 1000000.0),
@@ -137,7 +137,8 @@ void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
-	bool canAccept = processPaste(de->mimeData());
+	/*
+	bool canAccept = processPaste(de->mimeData()); TODO
 	if (canAccept == true)
 	{
 		de->accept();
@@ -146,6 +147,7 @@ void FloatModelEditorBase::dropEvent(QDropEvent * de)
 	{
 		de->ignore();
 	}
+	*/
 }
 
 
@@ -276,12 +278,7 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 	drawAutoHighlight(&p);
 }
 
-bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::DataType dataType)
-{
-	return dataType == Clipboard::DataType::FloatValue
-		|| dataType == Clipboard::DataType::AutomatableModelLink;
-}
-
+/*
 bool FloatModelEditorBase::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	bool shouldAccept = false;
@@ -302,6 +299,7 @@ bool FloatModelEditorBase::processPasteImplementation(Clipboard::DataType type, 
 	}
 	return shouldAccept;
 }
+*/
 
 void FloatModelEditorBase::wheelEvent(QWheelEvent * we)
 {

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -323,14 +323,9 @@ bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::StringPairDataType 
 		|| dataType == Clipboard::StringPairDataType::AutomatableModelLink;
 }
 
-bool FloatModelEditorBase::processPaste(const QMimeData* mimeData)
+bool FloatModelEditorBase::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
 {
-	if (Clipboard::hasFormat(Clipboard::MimeType::StringPair) == false) { return false; }
 	bool shouldAccept = false;
-
-	Clipboard::StringPairDataType type = Clipboard::decodeKey(mimeData);
-	QString value = Clipboard::decodeValue(mimeData);
-	
 	if (type == Clipboard::StringPairDataType::FloatValue)
 	{
 		model()->setValue(LocaleHelper::toFloat(value));
@@ -345,10 +340,6 @@ bool FloatModelEditorBase::processPaste(const QMimeData* mimeData)
 			mod->setValue(model()->value());
 			shouldAccept = true;
 		}
-	}
-	if (shouldAccept)
-	{
-		InteractiveModelView::stopHighlighting();
 	}
 	return shouldAccept;
 }

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -51,9 +51,9 @@ std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::s_shortcu
 	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
 	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
 	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_E, Qt::ShiftModifier, 0, QString(tr("increase value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_Q, Qt::ShiftModifier, 0, QString(tr("decrease value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_U, Qt::ControlModifier, 0, QString(tr("unlink widget")), false)
+	InteractiveModelView::ModelShortcut(Qt::Key_E, Qt::ShiftModifier, 0, QString(tr("Increase value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_Q, Qt::ShiftModifier, 0, QString(tr("Decrease value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_U, Qt::ControlModifier, 0, QString(tr("Unlink widget")), false)
 };
 
 FloatModelEditorBase::FloatModelEditorBase(DirectionOfManipulation directionOfManipulation, QWidget * parent, const QString & name) :

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -152,7 +152,9 @@ void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
+	qDebug("dropEvent 1, THISid: %d", model()->id());
 	bool canAccept = processPaste(de->mimeData());
+	qDebug("dropEvent 2");
 	if (canAccept == true)
 	{
 		de->accept();
@@ -195,7 +197,7 @@ void FloatModelEditorBase::mousePressEvent(QMouseEvent * me)
 			(me->modifiers() & Qt::ShiftModifier))
 	{
 		new StringPairDrag(Clipboard::StringPairDataType::FloatValue,
-					QString::number(model()->value()),
+					Clipboard::encodeFloatValue(model()->value()),
 							QPixmap(), this);
 	}
 	else
@@ -293,29 +295,41 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 
 const std::vector<InteractiveModelView::ModelShortcut>& FloatModelEditorBase::getShortcuts()
 {
+	qDebug("getShortcuts 1, THISid: %d", model()->id());
 	return s_shortcutArray;
 }
 
 void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
 {
+	qDebug("processShortcutPressed 1, THISid: %d", model()->id());
 	switch (shortcutLocation)
 	{
 		case 0:
+			qDebug("processShortcutPressed 2, val: %f", (model()->value() * getConversionFactor()));
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::FloatValue, Clipboard::encodeFloatValue(model()->value() * getConversionFactor()));
 			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::FloatValue);
+			qDebug("processShortcutPressed 3");
 			break;
 		case 1:
+			qDebug("processShortcutPressed 4, THISid: %d", model()->id());
 			Clipboard::copyStringPair(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*model()));
 			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::AutomatableModelLink);
+			qDebug("processShortcutPressed 5");
 			break;
 		case 2:
+			qDebug("processShortcutPressed 6");
 			processPaste(Clipboard::getMimeData());
+			qDebug("processShortcutPressed 7");
 			break;
 		case 3:
+			qDebug("processShortcutPressed 8");
 			model()->setValue(model()->value() + model()->range() / 20.0f);
+			qDebug("processShortcutPressed 9");
 			break;
 		case 4:
+			qDebug("processShortcutPressed 10");
 			model()->setValue(model()->value() - model()->range() / 20.0f);
+			qDebug("processShortcutPressed 11");
 			break;
 		case 5:
 			model()->unlinkAllModels();
@@ -327,33 +341,44 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 
 QString FloatModelEditorBase::getShortcutMessage()
 {
+	qDebug("getShortcutMessage 1, THISid: %d", model()->id());
 	return m_shortcutMessage;
 }
 
 bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
 {
+	qDebug("canAcceptClipboardData 1, THISid: %d", model()->id());
 	return dataType == Clipboard::StringPairDataType::FloatValue
 		|| dataType == Clipboard::StringPairDataType::AutomatableModelLink;
 }
 
 bool FloatModelEditorBase::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
 {
+	qDebug("processPasteImplementation 1, THISid: %d", model()->id());
 	bool shouldAccept = false;
 	if (type == Clipboard::StringPairDataType::FloatValue)
 	{
+		qDebug("processPasteImplementation 2");
 		model()->setValue(LocaleHelper::toFloat(value));
 		shouldAccept = true;
+		qDebug("processPasteImplementation 3");
 	}
 	else if (type == Clipboard::StringPairDataType::AutomatableModelLink)
 	{
+		qDebug("processPasteImplementation 4, id: %d", value.toInt());
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(value.toInt()));
+		qDebug("processPasteImplementation 5");
 		if (mod != nullptr)
 		{
+			qDebug("processPasteImplementation 6");
 			AutomatableModel::linkModels(model(), mod);
+			qDebug("processPasteImplementation 6 + 1");
 			mod->setValue(model()->value());
 			shouldAccept = true;
+			qDebug("processPasteImplementation 7");
 		}
 	}
+	qDebug("processPasteImplementation 8");
 	return shouldAccept;
 }
 
@@ -497,11 +522,31 @@ void FloatModelEditorBase::enterValue()
 
 void FloatModelEditorBase::friendlyUpdate()
 {
-	if (model() && (model()->controllerConnection() == nullptr ||
-		model()->controllerConnection()->getController()->frequentUpdates() == false ||
-				Controller::runningFrames() % (256*4) == 0))
+	qDebug("friendlyUpdate 1");
+	if (model())
 	{
-		update();
+		qDebug("friendlyUpdate 2");
+		bool shouldUpdate = false;
+		if (model()->controllerConnection() == nullptr)
+		{
+			qDebug("friendlyUpdate 3");
+			shouldUpdate = true;
+		}
+		else
+		{
+			if (model()->controllerConnection()->getController()->frequentUpdates() == false)
+			{ shouldUpdate = true; qDebug("friendlyUpdate 4"); } else
+			{
+				if (Controller::runningFrames() % (256*4) == 0) { shouldUpdate = true; qDebug("friendlyUpdate 5"); }
+				qDebug("friendlyUpdate 6");
+			}
+			qDebug("friendlyUpdate 7");
+		}
+		if (shouldUpdate)
+		{
+			qDebug("friendlyUpdate 8");
+			update();
+		}
 	}
 }
 

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -76,23 +76,22 @@ void FloatModelEditorBase::initUi(const QString & name)
 
 void FloatModelEditorBase::addCommands(std::vector<CommandData>& targetList)
 {
-	auto unlinkCommand = TypedCommandFnPtr<FloatModelEditorBase, int>(&FloatModelEditorBase::unlinkCommand);
 	targetList =
 	{
-		CommandData(1, "Copy value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::copyValueCommand), nullptr, true),
-		CommandData(2, "Paste value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::pasteNoReturnCommand), nullptr, true),
-		CommandData(3, "Paste value", TypedCommandFnPtr<FloatModelEditorBase, bool*>(&FloatModelEditorBase::pasteCommand), nullptr, true),
+		CommandData(1, "Copy value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::copyValueCommand), true),
+		CommandData(2, "Paste value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::pasteNoReturnCommand), true),
+		CommandData(3, "Paste value", TypedCommandFnPtr<FloatModelEditorBase, bool*>(&FloatModelEditorBase::pasteCommand), true),
 		CommandData(4, "Link widget", TypedCommandFnPtr<FloatModelEditorBase, int>(&FloatModelEditorBase::linkCommand),
-			&unlinkCommand, true),
-		CommandData(5, "Copy link", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::getLinkCommand), nullptr, true),
-		CommandData(6, "Unlink from all", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::unlinkAllCommand), nullptr, true),
-		CommandData(7, "Increase value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::increaseValueCommand), nullptr, true),
-		CommandData(8, "Decrease value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::decreaseValueCommand), nullptr, true),
-		CommandData(9, "Set value", TypedCommandFnPtr<FloatModelEditorBase, float>(&FloatModelEditorBase::setValueCommand), nullptr, true),
-		CommandData(11, "Edit value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::openInputDialogCommand), nullptr, true),
-		CommandData(12, "Toggle scale", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::toggleScaleCommand), nullptr, true),
-		CommandData(13, "Set scale logarithmic", TypedCommandFnPtr<FloatModelEditorBase, bool>(&FloatModelEditorBase::setScaleLogarithmicCommand), nullptr, true),
-		CommandData(14, "Set position", TypedCommandFnPtr<FloatModelEditorBase, QPoint>(&FloatModelEditorBase::setPositionCommand), nullptr, true)
+			TypedCommandFnPtr<FloatModelEditorBase, int>(&FloatModelEditorBase::unlinkCommand), true),
+		CommandData(5, "Copy link", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::getLinkCommand), true),
+		CommandData(6, "Unlink from all", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::unlinkAllCommand), true),
+		CommandData(7, "Increase value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::increaseValueCommand), true),
+		CommandData(8, "Decrease value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::decreaseValueCommand), true),
+		CommandData(9, "Set value", TypedCommandFnPtr<FloatModelEditorBase, float>(&FloatModelEditorBase::setValueCommand), true),
+		CommandData(11, "Edit value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::openInputDialogCommand), true),
+		CommandData(12, "Toggle scale", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::toggleScaleCommand), true),
+		CommandData(13, "Set scale logarithmic", TypedCommandFnPtr<FloatModelEditorBase, bool>(&FloatModelEditorBase::setScaleLogarithmicCommand), true),
+		CommandData(14, "Set position", TypedCommandFnPtr<FloatModelEditorBase, QPoint>(&FloatModelEditorBase::setPositionCommand), true)
 	};
 }
 
@@ -291,6 +290,7 @@ void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
 	bool canAccept = false;
+	// TODO this checks the wrong mime data when pasting leading to commands returning
 	doCommand<bool*>(3, &canAccept);
 	if (canAccept == true)
 	{

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -142,9 +142,9 @@ void FloatModelEditorBase::toggleScale()
 
 void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 {
-	std::vector<Clipboard::StringPairDataType> acceptedKeys = {
-		Clipboard::StringPairDataType::FloatValue,
-		Clipboard::StringPairDataType::AutomatableModelLink
+	std::vector<Clipboard::DataType> acceptedKeys = {
+		Clipboard::DataType::FloatValue,
+		Clipboard::DataType::AutomatableModelLink
 	};
 	StringPairDrag::processDragEnterEvent(dee, &acceptedKeys);
 }
@@ -196,7 +196,7 @@ void FloatModelEditorBase::mousePressEvent(QMouseEvent * me)
 	else if (me->button() == Qt::LeftButton &&
 			(me->modifiers() & Qt::ShiftModifier))
 	{
-		new StringPairDrag(Clipboard::StringPairDataType::FloatValue,
+		new StringPairDrag(Clipboard::DataType::FloatValue,
 					Clipboard::encodeFloatValue(model()->value()),
 							QPixmap(), this);
 	}
@@ -306,14 +306,14 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 	{
 		case 0:
 			qDebug("processShortcutPressed 2, val: %f", (model()->value() * getConversionFactor()));
-			Clipboard::copyStringPair(Clipboard::StringPairDataType::FloatValue, Clipboard::encodeFloatValue(model()->value() * getConversionFactor()));
-			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::FloatValue);
+			Clipboard::copyStringPair(Clipboard::DataType::FloatValue, Clipboard::encodeFloatValue(model()->value() * getConversionFactor()));
+			InteractiveModelView::startHighlighting(Clipboard::DataType::FloatValue);
 			qDebug("processShortcutPressed 3");
 			break;
 		case 1:
 			qDebug("processShortcutPressed 4, THISid: %d", model()->id());
-			Clipboard::copyStringPair(Clipboard::StringPairDataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*model()));
-			InteractiveModelView::startHighlighting(Clipboard::StringPairDataType::AutomatableModelLink);
+			Clipboard::copyStringPair(Clipboard::DataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*model()));
+			InteractiveModelView::startHighlighting(Clipboard::DataType::AutomatableModelLink);
 			qDebug("processShortcutPressed 5");
 			break;
 		case 2:
@@ -345,25 +345,25 @@ QString FloatModelEditorBase::getShortcutMessage()
 	return m_shortcutMessage;
 }
 
-bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::StringPairDataType dataType)
+bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::DataType dataType)
 {
 	qDebug("canAcceptClipboardData 1, THISid: %d", model()->id());
-	return dataType == Clipboard::StringPairDataType::FloatValue
-		|| dataType == Clipboard::StringPairDataType::AutomatableModelLink;
+	return dataType == Clipboard::DataType::FloatValue
+		|| dataType == Clipboard::DataType::AutomatableModelLink;
 }
 
-bool FloatModelEditorBase::processPasteImplementation(Clipboard::StringPairDataType type, QString& value)
+bool FloatModelEditorBase::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
 	qDebug("processPasteImplementation 1, THISid: %d", model()->id());
 	bool shouldAccept = false;
-	if (type == Clipboard::StringPairDataType::FloatValue)
+	if (type == Clipboard::DataType::FloatValue)
 	{
 		qDebug("processPasteImplementation 2");
 		model()->setValue(LocaleHelper::toFloat(value));
 		shouldAccept = true;
 		qDebug("processPasteImplementation 3");
 	}
-	else if (type == Clipboard::StringPairDataType::AutomatableModelLink)
+	else if (type == Clipboard::DataType::AutomatableModelLink)
 	{
 		qDebug("processPasteImplementation 4, id: %d", value.toInt());
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(value.toInt()));

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -142,7 +142,7 @@ void FloatModelEditorBase::toggleScale()
 
 void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 {
-	std::vector<Clipboard::DataType> acceptedKeys = {
+	static std::vector<Clipboard::DataType> acceptedKeys = {
 		Clipboard::DataType::FloatValue,
 		Clipboard::DataType::AutomatableModelLink
 	};

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -46,6 +46,12 @@ namespace lmms::gui
 
 SimpleTextFloat * FloatModelEditorBase::s_textFloat = nullptr;
 QString FloatModelEditorBase::m_shortcutMessage = "";
+std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::s_shortcutArray =
+{
+	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false)
+};
 
 FloatModelEditorBase::FloatModelEditorBase(DirectionOfManipulation directionOfManipulation, QWidget * parent, const QString & name) :
 	InteractiveModelView(parent),
@@ -282,14 +288,9 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 	drawAutoHighlight(&p);
 }
 
-std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::getShortcuts()
+const std::vector<InteractiveModelView::ModelShortcut>& FloatModelEditorBase::getShortcuts()
 {
-	std::vector<InteractiveModelView::ModelShortcut> shortcuts = {
-		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
-		InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false)
-	};
-	return shortcuts;
+	return s_shortcutArray;
 }
 
 void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -50,7 +50,10 @@ std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::s_shortcu
 {
 	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
 	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false)
+	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_E, Qt::ShiftModifier, 0, QString(tr("increase value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_Q, Qt::ShiftModifier, 0, QString(tr("decrease value")), false),
+	InteractiveModelView::ModelShortcut(Qt::Key_U, Qt::ControlModifier, 0, QString(tr("unlink widget")), false)
 };
 
 FloatModelEditorBase::FloatModelEditorBase(DirectionOfManipulation directionOfManipulation, QWidget * parent, const QString & name) :
@@ -307,6 +310,15 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 			break;
 		case 2:
 			processPaste(Clipboard::getMimeData());
+			break;
+		case 3:
+			model()->setValue(model()->value() + model()->range() / 20.0f);
+			break;
+		case 4:
+			model()->setValue(model()->value() - model()->range() / 20.0f);
+			break;
+		case 5:
+			model()->unlinkAllModels();
 			break;
 		default:
 			break;

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -152,9 +152,7 @@ void FloatModelEditorBase::dragEnterEvent(QDragEnterEvent * dee)
 
 void FloatModelEditorBase::dropEvent(QDropEvent * de)
 {
-	qDebug("dropEvent 1, THISid: %d", model()->id());
 	bool canAccept = processPaste(de->mimeData());
-	qDebug("dropEvent 2");
 	if (canAccept == true)
 	{
 		de->accept();
@@ -295,41 +293,29 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 
 const std::vector<InteractiveModelView::ModelShortcut>& FloatModelEditorBase::getShortcuts()
 {
-	qDebug("getShortcuts 1, THISid: %d", model()->id());
 	return s_shortcutArray;
 }
 
 void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
 {
-	qDebug("processShortcutPressed 1, THISid: %d", model()->id());
 	switch (shortcutLocation)
 	{
 		case 0:
-			qDebug("processShortcutPressed 2, val: %f", (model()->value() * getConversionFactor()));
 			Clipboard::copyStringPair(Clipboard::DataType::FloatValue, Clipboard::encodeFloatValue(model()->value() * getConversionFactor()));
 			InteractiveModelView::startHighlighting(Clipboard::DataType::FloatValue);
-			qDebug("processShortcutPressed 3");
 			break;
 		case 1:
-			qDebug("processShortcutPressed 4, THISid: %d", model()->id());
 			Clipboard::copyStringPair(Clipboard::DataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*model()));
 			InteractiveModelView::startHighlighting(Clipboard::DataType::AutomatableModelLink);
-			qDebug("processShortcutPressed 5");
 			break;
 		case 2:
-			qDebug("processShortcutPressed 6");
 			processPaste(Clipboard::getMimeData());
-			qDebug("processShortcutPressed 7");
 			break;
 		case 3:
-			qDebug("processShortcutPressed 8");
 			model()->setValue(model()->value() + model()->range() / 20.0f);
-			qDebug("processShortcutPressed 9");
 			break;
 		case 4:
-			qDebug("processShortcutPressed 10");
 			model()->setValue(model()->value() - model()->range() / 20.0f);
-			qDebug("processShortcutPressed 11");
 			break;
 		case 5:
 			model()->unlinkAllModels();
@@ -341,44 +327,33 @@ void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyE
 
 QString FloatModelEditorBase::getShortcutMessage()
 {
-	qDebug("getShortcutMessage 1, THISid: %d", model()->id());
 	return m_shortcutMessage;
 }
 
 bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::DataType dataType)
 {
-	qDebug("canAcceptClipboardData 1, THISid: %d", model()->id());
 	return dataType == Clipboard::DataType::FloatValue
 		|| dataType == Clipboard::DataType::AutomatableModelLink;
 }
 
 bool FloatModelEditorBase::processPasteImplementation(Clipboard::DataType type, QString& value)
 {
-	qDebug("processPasteImplementation 1, THISid: %d", model()->id());
 	bool shouldAccept = false;
 	if (type == Clipboard::DataType::FloatValue)
 	{
-		qDebug("processPasteImplementation 2");
 		model()->setValue(LocaleHelper::toFloat(value));
 		shouldAccept = true;
-		qDebug("processPasteImplementation 3");
 	}
 	else if (type == Clipboard::DataType::AutomatableModelLink)
 	{
-		qDebug("processPasteImplementation 4, id: %d", value.toInt());
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(value.toInt()));
-		qDebug("processPasteImplementation 5");
 		if (mod != nullptr)
 		{
-			qDebug("processPasteImplementation 6");
 			AutomatableModel::linkModels(model(), mod);
-			qDebug("processPasteImplementation 6 + 1");
 			mod->setValue(model()->value());
 			shouldAccept = true;
-			qDebug("processPasteImplementation 7");
 		}
 	}
-	qDebug("processPasteImplementation 8");
 	return shouldAccept;
 }
 
@@ -522,29 +497,22 @@ void FloatModelEditorBase::enterValue()
 
 void FloatModelEditorBase::friendlyUpdate()
 {
-	qDebug("friendlyUpdate 1");
 	if (model())
 	{
-		qDebug("friendlyUpdate 2");
 		bool shouldUpdate = false;
 		if (model()->controllerConnection() == nullptr)
 		{
-			qDebug("friendlyUpdate 3");
 			shouldUpdate = true;
 		}
 		else
 		{
 			if (model()->controllerConnection()->getController()->frequentUpdates() == false)
-			{ shouldUpdate = true; qDebug("friendlyUpdate 4"); } else
 			{
-				if (Controller::runningFrames() % (256*4) == 0) { shouldUpdate = true; qDebug("friendlyUpdate 5"); }
-				qDebug("friendlyUpdate 6");
+				if (Controller::runningFrames() % (256*4) == 0) { shouldUpdate = true; }
 			}
-			qDebug("friendlyUpdate 7");
 		}
 		if (shouldUpdate)
 		{
-			qDebug("friendlyUpdate 8");
 			update();
 		}
 	}

--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -45,16 +45,6 @@ namespace lmms::gui
 {
 
 SimpleTextFloat * FloatModelEditorBase::s_textFloat = nullptr;
-QString FloatModelEditorBase::m_shortcutMessage = "";
-std::vector<InteractiveModelView::ModelShortcut> FloatModelEditorBase::s_shortcutArray =
-{
-	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 0, QString(tr("Copy value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_C, Qt::ControlModifier, 1, QString(tr("Link widget")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_V, Qt::ControlModifier, 0, QString(tr("Paste value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_E, Qt::ShiftModifier, 0, QString(tr("Increase value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_Q, Qt::ShiftModifier, 0, QString(tr("Decrease value")), false),
-	InteractiveModelView::ModelShortcut(Qt::Key_U, Qt::ControlModifier, 0, QString(tr("Unlink widget")), false)
-};
 
 FloatModelEditorBase::FloatModelEditorBase(DirectionOfManipulation directionOfManipulation, QWidget * parent, const QString & name) :
 	InteractiveModelView(parent),
@@ -73,11 +63,6 @@ void FloatModelEditorBase::initUi(const QString & name)
 	if (s_textFloat == nullptr)
 	{
 		s_textFloat = new SimpleTextFloat;
-	}
-
-	if (m_shortcutMessage == "")
-	{
-		m_shortcutMessage = buildShortcutMessage();
 	}
 
 	setWindowTitle(name);
@@ -289,45 +274,6 @@ void FloatModelEditorBase::paintEvent(QPaintEvent *)
 	p.setBrush(foreground);
 	p.drawRect(QRect(r.topLeft(), QPoint(r.width() * percentage, r.height())));
 	drawAutoHighlight(&p);
-}
-
-const std::vector<InteractiveModelView::ModelShortcut>& FloatModelEditorBase::getShortcuts()
-{
-	return s_shortcutArray;
-}
-
-void FloatModelEditorBase::processShortcutPressed(size_t shortcutLocation, QKeyEvent* event)
-{
-	switch (shortcutLocation)
-	{
-		case 0:
-			Clipboard::copyStringPair(Clipboard::DataType::FloatValue, Clipboard::encodeFloatValue(model()->value() * getConversionFactor()));
-			InteractiveModelView::startHighlighting(Clipboard::DataType::FloatValue);
-			break;
-		case 1:
-			Clipboard::copyStringPair(Clipboard::DataType::AutomatableModelLink, Clipboard::encodeAutomatableModelLink(*model()));
-			InteractiveModelView::startHighlighting(Clipboard::DataType::AutomatableModelLink);
-			break;
-		case 2:
-			processPaste(Clipboard::getMimeData());
-			break;
-		case 3:
-			model()->setValue(model()->value() + model()->range() / 20.0f);
-			break;
-		case 4:
-			model()->setValue(model()->value() - model()->range() / 20.0f);
-			break;
-		case 5:
-			model()->unlinkAllModels();
-			break;
-		default:
-			break;
-	}
-}
-
-QString FloatModelEditorBase::getShortcutMessage()
-{
-	return m_shortcutMessage;
 }
 
 bool FloatModelEditorBase::canAcceptClipboardData(Clipboard::DataType dataType)

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -410,10 +410,10 @@ void Graph::paintEvent( QPaintEvent * )
 
 void Graph::dropEvent( QDropEvent * _de )
 {
-	Clipboard::StringPairDataType type = StringPairDrag::decodeKey(_de);
+	Clipboard::DataType type = StringPairDrag::decodeKey(_de);
 	QString value = StringPairDrag::decodeValue( _de );
 
-	if (type == Clipboard::StringPairDataType::SampleFile)
+	if (type == Clipboard::DataType::SampleFile)
 	{
 		// TODO: call setWaveToUser
 		// loadSampleFromFile( value );
@@ -423,7 +423,7 @@ void Graph::dropEvent( QDropEvent * _de )
 
 void Graph::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	if (StringPairDrag::processDragEnterEvent(_dee, Clipboard::StringPairDataType::SampleFile) == false)
+	if (StringPairDrag::processDragEnterEvent(_dee, Clipboard::DataType::SampleFile) == false)
 	{
 		_dee->ignore();
 	}

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -449,17 +449,13 @@ void Knob::drawKnob( QPainter * _p )
 
 void Knob::paintEvent( QPaintEvent * _me )
 {
-	qDebug("Knob::paintEvent 1");
 	QPainter p( this );
 
-	qDebug("Knob::paintEvent 2");
 	drawKnob( &p );
 	if( !m_label.isEmpty() )
 	{
-		qDebug("Knob::paintEvent 3");
 		if (!m_isHtmlLabel)
 		{
-			qDebug("Knob::paintEvent 4");
 			p.setFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
@@ -468,19 +464,15 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
-			qDebug("Knob::paintEvent 5");
 			// TODO setHtmlLabel is never called so this will never be executed. Remove functionality?
 			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
-			qDebug("Knob::paintEvent 6");
 		}
 	}
 	
-	qDebug("Knob::paintEvent 7");
 	// draw `InteractiveModelView` highlight
 	drawAutoHighlight(&p);
-	qDebug("Knob::paintEvent 8");
 }
 
 void Knob::changeEvent(QEvent * ev)

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -449,13 +449,17 @@ void Knob::drawKnob( QPainter * _p )
 
 void Knob::paintEvent( QPaintEvent * _me )
 {
+	qDebug("Knob::paintEvent 1");
 	QPainter p( this );
 
+	qDebug("Knob::paintEvent 2");
 	drawKnob( &p );
 	if( !m_label.isEmpty() )
 	{
+		qDebug("Knob::paintEvent 3");
 		if (!m_isHtmlLabel)
 		{
+			qDebug("Knob::paintEvent 4");
 			p.setFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
 			p.setPen(textColor());
 			p.drawText(width() / 2 -
@@ -464,15 +468,19 @@ void Knob::paintEvent( QPaintEvent * _me )
 		}
 		else
 		{
+			qDebug("Knob::paintEvent 5");
 			// TODO setHtmlLabel is never called so this will never be executed. Remove functionality?
 			m_tdRenderer->setDefaultFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
 			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
 			m_tdRenderer->drawContents(&p);
+			qDebug("Knob::paintEvent 6");
 		}
 	}
 	
+	qDebug("Knob::paintEvent 7");
 	// draw `InteractiveModelView` highlight
 	drawAutoHighlight(&p);
+	qDebug("Knob::paintEvent 8");
 }
 
 void Knob::changeEvent(QEvent * ev)


### PR DESCRIPTION
This is the first PR in a series of PRs in the goal of achieving #7734
#7859 is an older version of this

Roadmap:
![Refactoring_gui_branching2](https://github.com/user-attachments/assets/ce25b3a0-a717-461b-b936-af750b85ae13)


This PR implements Commands, a layer between the user and the GUI. Every user interaction will be routed through Commands. Commands will provide a better way of journalling and overall clarity in code. The end goal is replacing core JO and Project Journal without saving to xml text. This way loading in data is faster and takes up less space in memory.

The CommandData class holds all the data needed to construct a command, and some additional data that decides how commands are called. A gui command class is also implemented, it will be derived from the `QUndoCommand` class in the future. It will aim to replace the journalling code. Classes that inherit `InteractiveModelView` need to implement 1 virtual function:
```c++
//! place here the `CommandData` code and call it in constructor
virtual void addCommands(std::vector<CommandData>& targetList) = 0;
```

`CommandData` is stored by objects that receive an action. `CommandData` does not store the object they act upon. This allows storing commands statically, and allows anything to call a command on an object with 1 line of code. The command system does runtime dynamic type checking ensuring that member functions are called for the correct type and input types match the function input types.
```c++
// Exaple for adding commands to a knob (in FloatModelEditorBase):
// id: 1, name: "Copy value", do function: member copyValueCommand(), no undo function
CommandData(1, "Copy value", BasicCommandFnPtr<FloatModelEditorBase>(&FloatModelEditorBase::copyValueCommand), true),
// id: 2, name: "Link widget", do function: member linkCommand(int), undo function: member unlinkCommand(int)
CommandData(2, "Link widget", TypedCommandFnPtr<FloatModelEditorBase, int>(&FloatModelEditorBase::linkCommand),
    TypedCommandFnPtr<FloatModelEditorBase, int>(&FloatModelEditorBase::unlinkCommand), true),
```
```c++
// Exaple for calling commands:
// id: 9, do function: member setValueCommand(float), (no undo function), do data is 0, undo data
// is the current value
doCommand<float>(9, 0.0f, model()->value(), true); // setValueCommand
// id: 11, function: openInputDialogCommand(), no do data and undo data
doCommand(11); // openInputDialogCommand
```


**How to test:** test if the features in #7488 work (this PR is more like a refactor, so the 7488 features should work)

Everything should work the same way it worked in #7488
This PR branches off off #7488, so #7488 should be merged before this