### PR TITLE
Upgrade to Windows 2022 / Visual Studio 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,7 +339,7 @@ jobs:
           CCACHE_MAXSIZE: 500M
   msvc:
     name: msvc-x64
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       CCACHE_MAXSIZE: 0
       CCACHE_NOCOMPRESS: 1
@@ -374,7 +374,7 @@ jobs:
         uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           version: '5.15.2'
-          arch: "win64_msvc2019_64"
+          arch: "win64_msvc2022_64"
           archives: qtbase qtsvg qttools
           cache: true
       - name: Set up build environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
         with:
           key: vcpkg-msvc-x86_64-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-msvc-x86_64-
+            vcpkg-msvc-x86_64-FORCE_UPDATE
           path: build\vcpkg_installed
       - name: Cache ccache data
         uses: actions/cache@v3
@@ -364,8 +364,8 @@ jobs:
           key: "ccache-${{ github.job }}-x64-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-x64-${{ github.ref }}-
-            ccache-${{ github.job }}-x64-
+            ccache-${{ github.job }}-x64-FORCE_UPDATE-${{ github.ref }}-
+            ccache-${{ github.job }}-x64-FORCE_UPDATE
           path: ~\AppData\Local\ccache
           # yamllint enable rule:line-length
       - name: Install tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,7 @@ jobs:
         uses: jurplel/install-qt-action@b3ea5275e37b734d027040e2c7fe7a10ea2ef946
         with:
           version: '5.15.2'
-          arch: "win64_msvc2022_64"
+          arch: "win64_msvc2019_64"
           archives: qtbase qtsvg qttools
           cache: true
       - name: Set up build environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
         with:
           key: vcpkg-msvc-x86_64-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-msvc-x86_64-FORCE_UPDATE
+            vcpkg-msvc-x86_64-
           path: build\vcpkg_installed
       - name: Cache ccache data
         uses: actions/cache@v3
@@ -364,8 +364,8 @@ jobs:
           key: "ccache-${{ github.job }}-x64-${{ github.ref }}\
             -${{ github.run_id }}"
           restore-keys: |
-            ccache-${{ github.job }}-x64-FORCE_UPDATE-${{ github.ref }}-
-            ccache-${{ github.job }}-x64-FORCE_UPDATE
+            ccache-${{ github.job }}-x64-${{ github.ref }}-
+            ccache-${{ github.job }}-x64-
           path: ~\AppData\Local\ccache
           # yamllint enable rule:line-length
       - name: Install tools


### PR DESCRIPTION
The Windows 2019 runner image is being deprecated and removed in June, so this PR upgrades to Windows 2022 and Visual Studio 2022.

See [here](https://github.com/messmerd/lmms/actions/runs/15130279393/job/42529819572) for a successful build without cache hits.

This upgrade will allow using Qt 6.6 and onward in [#7339](https://github.com/LMMS/lmms/pull/7339) since Qt 6.5 was the last version to support VS 2019.