### PR TITLE
Update Sample Length when Loading New Sample via Double-Click

### DIFF
--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -54,7 +54,6 @@ public:
 	SampleClip& operator=( const SampleClip& that ) = delete;
 
 	void changeLength( const TimePos & _length ) override;
-	void changeLengthToSampleLength();
 	const QString& sampleFile() const;
 	bool hasSampleFileLoaded(const QString & filename) const;
 

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -152,12 +152,6 @@ void SampleClip::changeLength( const TimePos & _length )
 	Clip::changeLength(std::max(static_cast<int>(_length), 1));
 }
 
-void SampleClip::changeLengthToSampleLength()
-{
-	int length = m_sample.sampleSize() / Engine::framesPerTick();
-	changeLength(length);
-}
-
 
 
 const QString& SampleClip::sampleFile() const
@@ -261,6 +255,14 @@ void SampleClip::setIsPlaying(bool isPlaying)
 
 void SampleClip::updateLength()
 {
+	// If the clip has already been manually resized, don't automatically resize it.
+	// Unless we are in a pattern, where you can't resize stuff manually
+	if (getAutoResize() || !getResizable())
+	{
+		changeLength(sampleLength());
+		setStartTimeOffset(0);
+	}
+
 	emit sampleChanged();
 
 	Engine::getSong()->setModified();

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -200,10 +200,7 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 			m_clip->setSampleBuffer(sampleBuffer);
 		}
 	}
-	if (m_clip->getAutoResize())
-	{
-		m_clip->changeLengthToSampleLength();
-	}
+	m_clip->updateLength();
 }
 
 

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -192,17 +192,17 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 
 	if (selectedAudioFile.isEmpty()) { return; }
 	
-	if (m_clip->hasSampleFileLoaded(selectedAudioFile))
-	{
-		m_clip->changeLengthToSampleLength();
-	}
-	else
+	if (!m_clip->hasSampleFileLoaded(selectedAudioFile))
 	{
 		auto sampleBuffer = SampleLoader::createBufferFromFile(selectedAudioFile);
 		if (sampleBuffer != SampleBuffer::emptyBuffer())
 		{
 			m_clip->setSampleBuffer(sampleBuffer);
 		}
+	}
+	if (m_clip->getAutoResize())
+	{
+		m_clip->changeLengthToSampleLength();
 	}
 }
 


### PR DESCRIPTION
This PR make it so that when you double-click on a sample clip and select a new sample, it will automatically update the length of the clip, as long as the clip has auto-resize enabled.