### PR TITLE
Ignore "Keep plugin windows on top" setting when on wayland

### DIFF
--- a/include/GuiApplication.h
+++ b/include/GuiApplication.h
@@ -55,6 +55,7 @@ public:
 
 	static GuiApplication* instance();
 	static void sigintHandler(int);
+	static bool isWayland();
 #ifdef LMMS_BUILD_WIN32
 	static QFont getWin32SystemFont();
 #endif

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -47,14 +47,16 @@
 #	include <QLayout>
 #endif
 
+#include <QGuiApplication>
+
 #include "AudioEngine.h"
 #include "ConfigManager.h"
+#include "FileDialog.h"
 #include "GuiApplication.h"
 #include "LocaleHelper.h"
 #include "MainWindow.h"
 #include "PathUtil.h"
 #include "Song.h"
-#include "FileDialog.h"
 
 #ifdef LMMS_BUILD_LINUX
 #	include <X11/Xlib.h>
@@ -404,9 +406,8 @@ bool VstPlugin::processMessage( const message & _m )
 	{
 	case IdVstPluginWindowID:
 		m_pluginWindowID = _m.getInt();
-		if( m_embedMethod == "none"
-			&& ConfigManager::inst()->value(
-				"ui", "vstalwaysontop" ).toInt() )
+		if (m_embedMethod == "none" && !QGuiApplication::platformName().toLower().contains("wayland")
+			&& ConfigManager::inst()->value("ui", "vstalwaysontop").toInt())
 		{
 #ifdef LMMS_BUILD_WIN32
 			// We're changing the owner, not the parent,

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -47,8 +47,6 @@
 #	include <QLayout>
 #endif
 
-#include <QGuiApplication>
-
 #include "AudioEngine.h"
 #include "ConfigManager.h"
 #include "FileDialog.h"
@@ -406,7 +404,7 @@ bool VstPlugin::processMessage( const message & _m )
 	{
 	case IdVstPluginWindowID:
 		m_pluginWindowID = _m.getInt();
-		if (m_embedMethod == "none" && !QGuiApplication::platformName().toLower().contains("wayland")
+		if (m_embedMethod == "none" && !gui::GuiApplication::isWayland()
 			&& ConfigManager::inst()->value("ui", "vstalwaysontop").toInt())
 		{
 #ifdef LMMS_BUILD_WIN32

--- a/src/gui/GuiApplication.cpp
+++ b/src/gui/GuiApplication.cpp
@@ -79,6 +79,11 @@ GuiApplication* GuiApplication::instance()
 	return s_instance;
 }
 
+bool GuiApplication::isWayland()
+{
+	return QGuiApplication::platformName().contains("wayland");
+}
+
 
 
 GuiApplication::GuiApplication()


### PR DESCRIPTION
Fixes #7896