### PR TITLE
Add Per-Note Pitch Bending to Local ZynAddSubFX

### DIFF
--- a/plugins/ZynAddSubFx/LocalZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/LocalZynAddSubFx.cpp
@@ -222,6 +222,11 @@ void LocalZynAddSubFx::setPitchWheelBendRange( int semitones )
 }
 
 
+void LocalZynAddSubFx::setKeyDetuning(int key, float detuning)
+{
+	m_master->setKeyDetuning(key, detuning);
+}
+
 
 void LocalZynAddSubFx::processMidiEvent( const MidiEvent& event )
 {

--- a/plugins/ZynAddSubFx/LocalZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/LocalZynAddSubFx.h
@@ -61,6 +61,8 @@ public:
 
 	void setPitchWheelBendRange( int semitones );
 
+	void setKeyDetuning(int key, float detuning);
+
 	void processMidiEvent( const MidiEvent& event );
 
 	void processAudio( SampleFrame* _out );

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -98,6 +98,10 @@ bool ZynAddSubFxRemotePlugin::processMessage( const message & _m )
 	return RemotePlugin::processMessage( _m );
 }
 
+void ZynAddSubFxRemotePlugin::setKeyDetuning(int key, float detuning)
+{
+	//LocalZynAddSubFx::setKeyDetuning(key, detuning)
+}
 
 
 
@@ -341,6 +345,31 @@ void ZynAddSubFxInstrument::play( SampleFrame* _buf )
 		m_plugin->processAudio( _buf );
 	}
 	m_pluginMutex.unlock();
+}
+
+
+
+
+void ZynAddSubFxInstrument::playNote(NotePlayHandle * _n, SampleFrame* _working_buffer)
+{
+	if( _n->isMasterNote() || ( _n->hasParent() && _n->isReleased() ) )
+	{
+		return;
+	}
+
+	int masterPitch = instrumentTrack()->useMasterPitchModel()->value() ? Engine::getSong()->masterPitch() : 0;
+	int baseNote = instrumentTrack()->baseNoteModel()->value();
+	int midiNote = _n->midiKey() - baseNote + DefaultBaseKey + masterPitch;
+	const auto detuning = _n->currentDetuning();
+
+	if (m_remotePlugin)
+	{
+		m_remotePlugin->setKeyDetuning(midiNote, detuning);
+	}
+	else
+	{
+		m_plugin->setKeyDetuning(midiNote, detuning);
+	}
 }
 
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -59,6 +59,7 @@ public:
 
 	bool processMessage( const message & _m ) override;
 
+	void setKeyDetuning(int key, float detuning);
 
 signals:
 	void clickedCloseButton();
@@ -75,6 +76,7 @@ public:
 	~ZynAddSubFxInstrument() override;
 
 	void play( SampleFrame* _working_buffer ) override;
+	void playNote( NotePlayHandle * _n, SampleFrame* _working_buffer ) override;
 
 	bool handleMidiEvent( const MidiEvent& event, const TimePos& time = TimePos(), f_cnt_t offset = 0 ) override;
 


### PR DESCRIPTION
This PR adds pitch bending support to the local ZynAddSubFX plugin, so you can pitch bend from the piano roll and have the notes actually change pitch correctly.

## Demo

https://github.com/user-attachments/assets/16747424-43c8-4ff7-9c0e-5d2c3ba74249

Per-note demonstration (because I forgot to in the previous video)

https://github.com/user-attachments/assets/db7df50b-33f7-4777-ad40-57dad3bf0c3b

## How it works

1. A note is played by the user
2. `ZynAddSubFX::playNote()` is triggered, which calls `LocalZynAddSubFX::setKeyDetuning(note, detuning)`
3. `LocalZynAddSubFX::setKeyDetuning` reaches into the actual ZynAddSubFX plugin and calls `Master::setKeyDetuning`
4. `Master::setKeyDetuning` calls `Part::setKeyDetuning` on each of its parts, which saves the detuning float in the note struct corresponding to the note being pitch-bended.
   - This is possible because ZynAddSubFX only allows one note to be played per key at once, so instead of indexing each note by some kind of global id which would need to be shared with LMMS, you can index it by its key and it works just fine.
6. In the audio side, `Part::RunNote` calls `SynthNote::setKeyDetuning` on the note about to be played. The behavior of this function depends on which synth is used, AdSynth, SubSynth, or PadSynth.
7. In each synth implementation, `Ad/Sub/PadSynth::computecurrentparameters()` is usually changed to incorperate the detuning amount in the pitch calculation. It depends though, since each synth is different.

## Notes

Unfortunately, this PR only works when the UI is closed. This is because when the UI is open, the ZynAddSubFXRemotePlugin is used, which appears to only accept communication via standard midi signal codes/remote plugin codes. I do not believe per-note pitch bending is one of them, so it may be difficult to get that working.

... Or I could just invent a new midi code and use that I guess LOL... That's probably a bad idea though.

Also, I can't figure out how to modify the pitch of SubSynth, so currently it only works for AdSynth and PadSynth.