### PR TITLE
Fix Piano Roll key events from leaking to other instrument windows

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1300,6 +1300,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 			//  if a chord is set, play all chord notes (simulate click on all):
 			playChordNotes(key_num);
 			ke->accept();
+			return;
 		}
 	}
 
@@ -1560,6 +1561,8 @@ void PianoRoll::keyReleaseEvent(QKeyEvent* ke )
 				update();
 			}
 			break;
+		default:
+			ke->ignore();
 	}
 
 	update();

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1537,6 +1537,7 @@ void PianoRoll::keyReleaseEvent(QKeyEvent* ke )
 			// if a chord is set, simulate click release on all chord notes
 			pauseChordNotes(key_num);
 			ke->accept();
+			return;
 		}
 	}
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1564,6 +1564,7 @@ void PianoRoll::keyReleaseEvent(QKeyEvent* ke )
 			break;
 		default:
 			ke->ignore();
+			break;
 	}
 
 	update();


### PR DESCRIPTION
When #7762 was merged, it introduced a `default: ke->ignore()` to the end of `PianoRoll::keyPressEvent`. This was required in order for the spacebar key events to be propagated up to `MainWindow` to handle the play/pause.

However, further up in `PianoRoll::keyPressEvent`, the code which checked if the key event was supposed to play a note did not include a return statement. This caused the code to continue down and run the switch statement even though the event was already accepted, which triggered the default ignore statement, causing the events to leak back up to `MainWindow`. And because the global keyboard instrument playing is handled by `MainWindow`, this caused other instruments to play at the same time as the Piano Roll while improvising on a keyboard.

This PR fixes that by adding a return statement at the correct position.

Additionally, I also added a `return` and `default: ke->ignore()` to the end of `PianoRoll::keyReleaseEvent`. This is not the major fix for the issue, but it makes everything consistent and prevents similar event leaking occurring with key releases.