### PR TITLE
Output combo boxes for Jack driver

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -107,6 +107,10 @@ private:
 	bool initJackClient();
 	void resizeInputBuffer(jack_nframes_t nframes);
 
+	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
+	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
+	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
+
 	void startProcessing() override;
 	void stopProcessing() override;
 

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -92,11 +92,8 @@ public:
 		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
 		jack_client_t* m_client;
 
-		QToolButton* m_outputDevice1 = nullptr;
-		QToolButton* m_outputDevice2 = nullptr;
-
-		QToolButton* m_inputDevice1 = nullptr;
-		QToolButton* m_inputDevice2 = nullptr;
+		std::vector<QToolButton*> m_outputDevices;
+		std::vector<QToolButton*> m_inputDevices;
 	};
 
 private slots:

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -83,13 +83,18 @@ public:
 		void saveSettings() override;
 
 	private:
+		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
+		std::vector<std::string> getAudioOutputNames() const;
 		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
 
 	private:
 		QLineEdit* m_clientName;
 		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
 		jack_client_t* m_client;
+
+		QComboBox* m_outputDevice1 = nullptr;
+		QComboBox* m_outputDevice2 = nullptr;
 
 		QComboBox* m_inputDevice1 = nullptr;
 		QComboBox* m_inputDevice2 = nullptr;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -47,7 +47,8 @@
 #endif
 
 class QLineEdit;
-class QComboBox;
+class QMenu;
+class QToolButton;
 
 namespace lmms
 {
@@ -84,18 +85,18 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
+		QMenu* buildMenu(QToolButton* toolButton, const std::vector<std::string>& names, const QString& filteredLMMSClientName);
 
 	private:
 		QLineEdit* m_clientName;
 		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
 		jack_client_t* m_client;
 
-		QComboBox* m_outputDevice1 = nullptr;
-		QComboBox* m_outputDevice2 = nullptr;
+		QToolButton* m_outputDevice1 = nullptr;
+		QToolButton* m_outputDevice2 = nullptr;
 
-		QComboBox* m_inputDevice1 = nullptr;
-		QComboBox* m_inputDevice2 = nullptr;
+		QToolButton* m_inputDevice1 = nullptr;
+		QToolButton* m_inputDevice2 = nullptr;
 	};
 
 private slots:

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -86,7 +86,7 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
+		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
 	private:
 		QLineEdit* m_clientName;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -47,6 +47,7 @@
 #endif
 
 class QLineEdit;
+class QComboBox;
 
 namespace lmms
 {
@@ -68,6 +69,8 @@ public:
 	void removeMidiClient() { m_midiClient = nullptr; }
 	jack_client_t* jackClient() { return m_client; };
 
+	void handleRegistrationEvent(jack_port_id_t port, int reg);
+
 	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP("AudioDeviceSetupWidget", "JACK (JACK Audio Connection Kit)");
@@ -80,7 +83,16 @@ public:
 		void saveSettings() override;
 
 	private:
+		std::vector<std::string> getAudioInputNames() const;
+		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
+
+	private:
 		QLineEdit* m_clientName;
+		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
+		jack_client_t* m_client;
+
+		QComboBox* m_inputDevice1 = nullptr;
+		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -82,7 +82,6 @@ public:
 
 	private:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
-		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
 		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
@@ -93,9 +92,6 @@ public:
 
 		QComboBox* m_outputDevice1 = nullptr;
 		QComboBox* m_outputDevice2 = nullptr;
-
-		QComboBox* m_inputDevice1 = nullptr;
-		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:
@@ -107,7 +103,6 @@ private:
 
 	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
 	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
-	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
 
 	void startProcessing() override;
 	void stopProcessing() override;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -86,7 +86,7 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
+		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
 	private:
 		QLineEdit* m_clientName;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -85,7 +85,7 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		QMenu* buildMenu(QToolButton* toolButton, const std::vector<std::string>& names, const QString& filteredLMMSClientName);
+		static QMenu* buildMenu(QToolButton* toolButton, const std::vector<std::string>& names, const QString& filteredLMMSClientName);
 
 	private:
 		QLineEdit* m_clientName;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -82,6 +82,7 @@ public:
 
 	private:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
+		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
 		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
@@ -92,6 +93,9 @@ public:
 
 		QComboBox* m_outputDevice1 = nullptr;
 		QComboBox* m_outputDevice2 = nullptr;
+
+		QComboBox* m_inputDevice1 = nullptr;
+		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:
@@ -103,6 +107,7 @@ private:
 
 	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
 	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
+	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
 
 	void startProcessing() override;
 	void stopProcessing() override;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -69,8 +69,6 @@ public:
 	void removeMidiClient() { m_midiClient = nullptr; }
 	jack_client_t* jackClient() { return m_client; };
 
-	void handleRegistrationEvent(jack_port_id_t port, int reg);
-
 	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP("AudioDeviceSetupWidget", "JACK (JACK Audio Connection Kit)");

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -233,11 +233,8 @@ void AudioJack::resizeInputBuffer(jack_nframes_t nframes)
 
 void AudioJack::attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port)
 {
-	const auto result = jack_connect(m_client, source_port, destination_port);
-
-#ifdef LMMS_DEBUG
 	printf("Attempting to reconnect %s port %u: %s -> %s", lmms_port_type, static_cast<unsigned int>(index), source_port, destination_port);
-	if (!result)
+	if (!jack_connect(m_client, source_port, destination_port))
 	{
 		printf(" - Success!\n");
 	}
@@ -245,7 +242,6 @@ void AudioJack::attemptToConnect(size_t index, const char *lmms_port_type, const
 	{
 		printf(" - Failure\n");
 	}
-#endif
 }
 
 void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targetPort)
@@ -254,9 +250,7 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 
 	if (targetPort == disconnectedRepresentation)
 	{
-#ifdef LMMS_DEBUG
-	printf("Output port %u is not connected.\n", static_cast<unsigned int>(outputIndex));
-#endif
+		printf("Output port %u is not connected.\n", static_cast<unsigned int>(outputIndex));
 		return;
 	}
 
@@ -272,9 +266,7 @@ void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& source
 
 	if (sourcePort == disconnectedRepresentation)
 	{
-#ifdef LMMS_DEBUG
-	printf("Input port %u is not connected.\n", static_cast<unsigned int>(inputIndex));
-#endif
+		printf("Input port %u is not connected.\n", static_cast<unsigned int>(inputIndex));
 		return;
 	}
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -232,8 +232,12 @@ void AudioJack::resizeInputBuffer(jack_nframes_t nframes)
 
 void AudioJack::attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port)
 {
+	// #ifdef LMMS_DEBUG
+	const auto result = jack_connect(m_client, source_port, destination_port);
+
+#ifdef LMMS_DEBUG
 	printf("Attempting to reconnect %s port %u: %s -> %s", lmms_port_type, static_cast<unsigned int>(index), source_port, destination_port);
-	if (!jack_connect(m_client, source_port, destination_port))
+	if (!result)
 	{
 		printf(" - Success!\n");
 	}
@@ -241,6 +245,7 @@ void AudioJack::attemptToConnect(size_t index, const char *lmms_port_type, const
 	{
 		printf(" - Failure\n");
 	}
+#endif
 }
 
 void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targetPort)

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -607,7 +607,6 @@ QMenu* AudioJack::setupWidget::buildMenu(QToolButton* toolButton, const std::vec
 			connect(action, &QAction::triggered, actionLambda);
 			topLevelActions.append(action);
 		}
-		
 	}
 
 	// First add the sub menus. By iterating the map they will be sorted automatically

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -55,6 +55,20 @@ static const QString input2Key("input2");
 namespace lmms
 {
 
+static QString buildChannelSuffix(ch_cnt_t ch)
+{
+	return (ch % 2 ? "R" : "L") + QString::number(ch / 2 + 1);
+}
+
+static QString buildOutputName(ch_cnt_t ch)
+{
+	return QString("master out ") + buildChannelSuffix(ch);
+}
+
+static QString buildInputName(ch_cnt_t ch)
+{
+	return QString("master in ") + buildChannelSuffix(ch);
+}
 
 AudioJack::AudioJack(bool& successful, AudioEngine* audioEngineParam)
 	: AudioDevice(
@@ -184,11 +198,11 @@ bool AudioJack::initJackClient()
 
 	for (ch_cnt_t ch = 0; ch < channels(); ++ch)
 	{
-		QString name = QString("master out ") + ((ch % 2) ? "R" : "L") + QString::number(ch / 2 + 1);
+		const QString name = buildOutputName(ch);
 		m_outputPorts.push_back(
 			jack_port_register(m_client, name.toLatin1().constData(), JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0));
 
-		QString input_name = QString("master in ") + ((ch % 2) ? "R" : "L") + QString::number(ch / 2 + 1);
+		const QString input_name = buildInputName(ch);
 		m_inputPorts.push_back(jack_port_register(m_client, input_name.toLatin1().constData(), JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0));
 
 		if (m_outputPorts.back() == nullptr)
@@ -478,22 +492,22 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 	const auto output1 = cm->value(audioJackClass, output1Key);
 	m_outputDevice1 = buildToolButton(this, output1, audioOutputNames, cn);
-	form->addRow(tr("Output 1"), m_outputDevice1);
+	form->addRow(buildOutputName(0) + ":", m_outputDevice1);
 
 	const auto output2 = cm->value(audioJackClass, output2Key);
 	m_outputDevice2 = buildToolButton(this, output2, audioOutputNames, cn);
-	form->addRow(tr("Output 2"), m_outputDevice2);
+	form->addRow(buildOutputName(1) + ":", m_outputDevice2);
 
 	// Inputs
 	const auto audioInputNames = getAudioInputNames();
 
 	const auto input1 = cm->value(audioJackClass, input1Key);
 	m_inputDevice1 = buildToolButton(this, input1, audioInputNames, cn);
-	form->addRow(tr("Input 1"), m_inputDevice1);
+	form->addRow(buildInputName(0) + ":", m_inputDevice1);
 
 	const auto input2 = cm->value(audioJackClass, input2Key);
 	m_inputDevice2 = buildToolButton(this, input2, audioInputNames, cn);
-	form->addRow(tr("Input 2"), m_inputDevice2);
+	form->addRow(buildInputName(1) + ":", m_inputDevice2);
 
 	if (m_client != nullptr)
 	{

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -131,21 +131,6 @@ AudioJack* AudioJack::addMidiClient(MidiJack* midiClient)
 }
 
 
-void AudioJack::handleRegistrationEvent(jack_port_id_t port, int reg)
-{
-	auto jackPort = jack_port_by_id(m_client, port);
-
-	auto name = jack_port_name(jackPort);
-	auto type = jack_port_type(jackPort);
-	auto flags = jack_port_flags(jackPort);
-	
-	const bool isAudioPort = strcmp(type, JACK_DEFAULT_AUDIO_TYPE) == 0;
-	const bool isInputDevice = flags & JackPortIsOutput;
-
-	printf("Reg code %d for name %s and type %s, audio: %d, input: %d\n", reg, name, type, isAudioPort, isInputDevice);
-}
-
-
 bool AudioJack::initJackClient()
 {
 	QString clientName = ConfigManager::inst()->value("audiojack", "clientname");
@@ -182,13 +167,6 @@ bool AudioJack::initJackClient()
 
 	// set shutdown-callback
 	jack_on_shutdown(m_client, shutdownCallback, this);
-
-	jack_set_port_registration_callback(m_client,
-		[](jack_port_id_t port, int reg, void *arg) {
-			auto audioJack = static_cast<AudioJack*>(arg);
-			audioJack->handleRegistrationEvent(port, reg);
-		},
-		this);
 
 	if (jack_get_sample_rate(m_client) != sampleRate()) { setSampleRate(jack_get_sample_rate(m_client)); }
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -40,6 +40,17 @@
 #include "MainWindow.h"
 #include "MidiJack.h"
 
+
+namespace
+{
+static const QString audioJackClass("audiojack");
+static const QString clientNameKey("clientname");
+static const QString output1Key("output1");
+static const QString output2Key("output2");
+static const QString input1Key("input1");
+static const QString input2Key("input2");
+}
+
 namespace lmms
 {
 
@@ -133,7 +144,7 @@ AudioJack* AudioJack::addMidiClient(MidiJack* midiClient)
 
 bool AudioJack::initJackClient()
 {
-	QString clientName = ConfigManager::inst()->value("audiojack", "clientname");
+	QString clientName = ConfigManager::inst()->value(audioJackClass, clientNameKey);
 	if (clientName.isEmpty()) { clientName = "lmms"; }
 
 	const char* serverName = nullptr;
@@ -252,11 +263,11 @@ void AudioJack::startProcessing()
 
 	const auto cm = ConfigManager::inst();
 
-	attemptToReconnectOutput(0, cm->value("audiojack", "output1"));
-	attemptToReconnectOutput(1, cm->value("audiojack", "output2"));
+	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
+	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
 
-	attemptToReconnectInput(0, cm->value("audiojack", "input1"));
-	attemptToReconnectInput(1, cm->value("audiojack", "input2"));
+	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
+	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -441,7 +452,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	mainLayout->addLayout(form);
 
 	const auto cm = ConfigManager::inst();
-	QString cn = cm->value("audiojack", "clientname");
+	QString cn = cm->value(audioJackClass, clientNameKey);
 	if (cn.isEmpty()) { cn = "lmms"; }
 	m_clientName = new QLineEdit(cn, this);
 
@@ -456,12 +467,12 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioOutputNames = getAudioOutputNames();
 
 	m_outputDevice1 = new QComboBox(this);
-	const auto output1 = cm->value("audiojack", "output1");
+	const auto output1 = cm->value(audioJackClass, output1Key);
 	allPortsFound &= populateComboBox(m_outputDevice1, audioOutputNames, output1);
 	form->addRow(tr("Output 1"), m_outputDevice1);
 
 	m_outputDevice2 = new QComboBox(this);
-	const auto output2 = cm->value("audiojack", "output2");
+	const auto output2 = cm->value(audioJackClass, output2Key);
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
@@ -469,12 +480,12 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioInputNames = getAudioInputNames();
 
 	m_inputDevice1 = new QComboBox(this);
-	const auto input1 = cm->value("audiojack", "input1");
+	const auto input1 = cm->value(audioJackClass, input1Key);
 	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
 	form->addRow(tr("Input 1"), m_inputDevice1);
 
 	m_inputDevice2 = new QComboBox(this);
-	const auto input2 = cm->value("audiojack", "input2");
+	const auto input2 = cm->value(audioJackClass, input2Key);
 	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
 	form->addRow(tr("Input 2"), m_inputDevice2);
 
@@ -494,11 +505,11 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 void AudioJack::setupWidget::saveSettings()
 {
-	ConfigManager::inst()->setValue("audiojack", "clientname", m_clientName->text());
-	ConfigManager::inst()->setValue("audiojack", "output1", m_outputDevice1->currentText());
-	ConfigManager::inst()->setValue("audiojack", "output2", m_outputDevice2->currentText());
-	ConfigManager::inst()->setValue("audiojack", "input1", m_inputDevice1->currentText());
-	ConfigManager::inst()->setValue("audiojack", "input2", m_inputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
+	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -481,7 +481,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 		toolButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		toolButton->setPopupMode(QToolButton::InstantPopup);
 		toolButton->setText(currentSelection);
-		auto menu = this->buildMenu(toolButton, names, filteredLMMSClientName);
+		auto menu = AudioJack::setupWidget::buildMenu(toolButton, names, filteredLMMSClientName);
 		toolButton->setMenu(menu);
 
 		return toolButton;

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -493,6 +493,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
 	}
+
 	if (m_client != nullptr)
 	{
 		jack_deactivate(m_client);

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -450,6 +450,9 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 	QFormLayout * form = new QFormLayout(this);
 
+	// Set the field growth policy to allow fields to expand horizontally
+	form->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
+
 	const auto cm = ConfigManager::inst();
 	QString cn = cm->value(audioJackClass, clientNameKey);
 	if (cn.isEmpty()) { cn = "lmms"; }
@@ -460,6 +463,8 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	auto buildToolButton = [this](QWidget* parent, const QString& currentSelection, const std::vector<std::string>& names, const QString& filteredLMMSClientName)
 	{
 		auto toolButton = new QToolButton(parent);
+		// Make sure that the tool button will fill out the available space in the form layout
+		toolButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		toolButton->setPopupMode(QToolButton::MenuButtonPopup);
 		toolButton->setText(currentSelection);
 		auto menu = this->buildMenu(toolButton, names, filteredLMMSClientName);

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -522,7 +522,6 @@ std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags
 		for (int i = 0; inputAudioPorts[i] != nullptr; ++i)
 		{
 			auto currentPortName = inputAudioPorts[i];
-			printf("Port %d: %s\n", i, currentPortName);
 
 			audioPorts.push_back(currentPortName);
 		}

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -47,8 +47,6 @@ static const QString audioJackClass("audiojack");
 static const QString clientNameKey("clientname");
 static const QString output1Key("output1");
 static const QString output2Key("output2");
-static const QString input1Key("input1");
-static const QString input2Key("input2");
 }
 
 namespace lmms
@@ -231,17 +229,6 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 	attemptToConnect(outputIndex, "output", outputName, targetName);
 }
 
-void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
-{
-	if (inputIndex > m_inputPorts.size()) return;
-
-	auto inputName = jack_port_name(m_inputPorts[inputIndex]);
-	auto sourceName = sourcePort.toLatin1().constData();
-
-	attemptToConnect(inputIndex, "input", sourceName, inputName);
-}
-
-
 void AudioJack::startProcessing()
 {
 	if (m_active || m_client == nullptr)
@@ -265,9 +252,6 @@ void AudioJack::startProcessing()
 
 	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
 	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
-
-	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
-	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -476,19 +460,6 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
-	// Inputs
-	const auto audioInputNames = getAudioInputNames();
-
-	m_inputDevice1 = new QComboBox(this);
-	const auto input1 = cm->value(audioJackClass, input1Key);
-	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
-	form->addRow(tr("Input 1"), m_inputDevice1);
-
-	m_inputDevice2 = new QComboBox(this);
-	const auto input2 = cm->value(audioJackClass, input2Key);
-	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
-	form->addRow(tr("Input 2"), m_inputDevice2);
-
 	if (!allPortsFound)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
@@ -509,8 +480,6 @@ void AudioJack::setupWidget::saveSettings()
 	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
 	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
 	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
-	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
-	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const
@@ -536,11 +505,6 @@ std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags
 std::vector<std::string> AudioJack::setupWidget::getAudioOutputNames() const
 {
 	return getAudioPortNames(JackPortIsInput);
-}
-
-std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
-{
-	return getAudioPortNames(JackPortIsOutput);
 }
 
 bool AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -47,6 +47,8 @@ static const QString audioJackClass("audiojack");
 static const QString clientNameKey("clientname");
 static const QString output1Key("output1");
 static const QString output2Key("output2");
+static const QString input1Key("input1");
+static const QString input2Key("input2");
 }
 
 namespace lmms
@@ -229,6 +231,17 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 	attemptToConnect(outputIndex, "output", outputName, targetName);
 }
 
+void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
+{
+	if (inputIndex > m_inputPorts.size()) return;
+
+	auto inputName = jack_port_name(m_inputPorts[inputIndex]);
+	auto sourceName = sourcePort.toLatin1().constData();
+
+	attemptToConnect(inputIndex, "input", sourceName, inputName);
+}
+
+
 void AudioJack::startProcessing()
 {
 	if (m_active || m_client == nullptr)
@@ -252,6 +265,9 @@ void AudioJack::startProcessing()
 
 	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
 	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
+
+	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
+	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -460,6 +476,19 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
+	// Inputs
+	const auto audioInputNames = getAudioInputNames();
+
+	m_inputDevice1 = new QComboBox(this);
+	const auto input1 = cm->value(audioJackClass, input1Key);
+	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
+	form->addRow(tr("Input 1"), m_inputDevice1);
+
+	m_inputDevice2 = new QComboBox(this);
+	const auto input2 = cm->value(audioJackClass, input2Key);
+	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
+	form->addRow(tr("Input 2"), m_inputDevice2);
+
 	if (!allPortsFound)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
@@ -480,6 +509,8 @@ void AudioJack::setupWidget::saveSettings()
 	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
 	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
 	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const
@@ -505,6 +536,11 @@ std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags
 std::vector<std::string> AudioJack::setupWidget::getAudioOutputNames() const
 {
 	return getAudioPortNames(JackPortIsInput);
+}
+
+std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
+{
+	return getAudioPortNames(JackPortIsOutput);
 }
 
 bool AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -459,7 +459,8 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 	QFormLayout * form = new QFormLayout(this);
 
-	QString cn = ConfigManager::inst()->value("audiojack", "clientname");
+	const auto cm = ConfigManager::inst();
+	QString cn = cm->value("audiojack", "clientname");
 	if (cn.isEmpty()) { cn = "lmms"; }
 	m_clientName = new QLineEdit(cn, this);
 
@@ -469,30 +470,26 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioOutputNames = getAudioOutputNames();
 
 	m_outputDevice1 = new QComboBox(this);
-
-	populateComboBox(m_outputDevice1, audioOutputNames);
-
+	const auto output1 = cm->value("audiojack", "output1");
+	populateComboBox(m_outputDevice1, audioOutputNames, output1);
 	form->addRow(tr("Output 1"), m_outputDevice1);
 
 	m_outputDevice2 = new QComboBox(this);
-
-	populateComboBox(m_outputDevice2, audioOutputNames);
-
+	const auto output2 = cm->value("audiojack", "output2");
+	populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
 	// Inputs
 	const auto audioInputNames = getAudioInputNames();
 
 	m_inputDevice1 = new QComboBox(this);
-
-	populateComboBox(m_inputDevice1, audioInputNames);
-
+	const auto input1 = cm->value("audiojack", "input1");
+	populateComboBox(m_inputDevice1, audioInputNames, input1);
 	form->addRow(tr("Input 1"), m_inputDevice1);
 
 	m_inputDevice2 = new QComboBox(this);
-
-	populateComboBox(m_inputDevice2, audioInputNames);
-
+	const auto input2 = cm->value("audiojack", "input2");
+	populateComboBox(m_inputDevice2, audioInputNames, input2);
 	form->addRow(tr("Input 2"), m_inputDevice2);
 	if (m_client != nullptr)
 	{
@@ -543,7 +540,7 @@ std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
 	return getAudioPortNames(JackPortIsOutput);
 }
 
-void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames)
+void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)
 {
 	QStringList playbackDevices;
 	for (const auto & inputName : inputNames)
@@ -551,13 +548,9 @@ void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::ve
 		playbackDevices.append(QString::fromStdString(inputName));
 	}
 
-	//playbackDevices.sort();
-
 	comboBox->addItems(playbackDevices);
 
-	// TODO Select device from configuration
-	// const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
-	// m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
+	comboBox->setCurrentText(selectedEntry);
 }
 
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -479,7 +479,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 		auto toolButton = new QToolButton(parent);
 		// Make sure that the tool button will fill out the available space in the form layout
 		toolButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-		toolButton->setPopupMode(QToolButton::MenuButtonPopup);
+		toolButton->setPopupMode(QToolButton::InstantPopup);
 		toolButton->setText(currentSelection);
 		auto menu = this->buildMenu(toolButton, names, filteredLMMSClientName);
 		toolButton->setMenu(menu);


### PR DESCRIPTION
Implements #7918. The dialog looks as follows with the PR:

![Image](https://github.com/user-attachments/assets/0599315f-d6b0-436d-a9de-022f9f59fc8c)

Edit: I should have renamed the branch. It contained code for input selection as well but does not anymore. The reason is that this PR already brings benefits to users and can go into master without the sample recording feature.