### PR TITLE
Input selection for Jack driver

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -107,6 +107,10 @@ private:
 	bool initJackClient();
 	void resizeInputBuffer(jack_nframes_t nframes);
 
+	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
+	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
+	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
+
 	void startProcessing() override;
 	void stopProcessing() override;
 

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -83,13 +83,18 @@ public:
 		void saveSettings() override;
 
 	private:
+		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
+		std::vector<std::string> getAudioOutputNames() const;
 		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
 
 	private:
 		QLineEdit* m_clientName;
 		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
 		jack_client_t* m_client;
+
+		QComboBox* m_outputDevice1 = nullptr;
+		QComboBox* m_outputDevice2 = nullptr;
 
 		QComboBox* m_inputDevice1 = nullptr;
 		QComboBox* m_inputDevice2 = nullptr;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -86,7 +86,7 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
+		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
 	private:
 		QLineEdit* m_clientName;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -47,6 +47,7 @@
 #endif
 
 class QLineEdit;
+class QComboBox;
 
 namespace lmms
 {
@@ -68,6 +69,8 @@ public:
 	void removeMidiClient() { m_midiClient = nullptr; }
 	jack_client_t* jackClient() { return m_client; };
 
+	void handleRegistrationEvent(jack_port_id_t port, int reg);
+
 	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP("AudioDeviceSetupWidget", "JACK (JACK Audio Connection Kit)");
@@ -80,7 +83,16 @@ public:
 		void saveSettings() override;
 
 	private:
+		std::vector<std::string> getAudioInputNames() const;
+		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames);
+
+	private:
 		QLineEdit* m_clientName;
+		// Because we do not have access to a JackAudio driver instance we have to be our own client to display inputs and outputs...
+		jack_client_t* m_client;
+
+		QComboBox* m_inputDevice1 = nullptr;
+		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -82,7 +82,6 @@ public:
 
 	private:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
-		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
 		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
@@ -93,9 +92,6 @@ public:
 
 		QComboBox* m_outputDevice1 = nullptr;
 		QComboBox* m_outputDevice2 = nullptr;
-
-		QComboBox* m_inputDevice1 = nullptr;
-		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:
@@ -107,7 +103,6 @@ private:
 
 	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
 	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
-	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
 
 	void startProcessing() override;
 	void stopProcessing() override;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -86,7 +86,7 @@ public:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
 		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
-		void populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
+		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
 	private:
 		QLineEdit* m_clientName;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -82,6 +82,7 @@ public:
 
 	private:
 		std::vector<std::string> getAudioPortNames(JackPortFlags portFlags) const;
+		std::vector<std::string> getAudioInputNames() const;
 		std::vector<std::string> getAudioOutputNames() const;
 		bool populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry);
 
@@ -92,6 +93,9 @@ public:
 
 		QComboBox* m_outputDevice1 = nullptr;
 		QComboBox* m_outputDevice2 = nullptr;
+
+		QComboBox* m_inputDevice1 = nullptr;
+		QComboBox* m_inputDevice2 = nullptr;
 	};
 
 private slots:
@@ -103,6 +107,7 @@ private:
 
 	void attemptToConnect(size_t index, const char *lmms_port_type, const char *source_port, const char *destination_port);
 	void attemptToReconnectOutput(size_t outputIndex, const QString& targetPort);
+	void attemptToReconnectInput(size_t inputIndex, const QString& sourcePort);
 
 	void startProcessing() override;
 	void stopProcessing() override;

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -69,8 +69,6 @@ public:
 	void removeMidiClient() { m_midiClient = nullptr; }
 	jack_client_t* jackClient() { return m_client; };
 
-	void handleRegistrationEvent(jack_port_id_t port, int reg);
-
 	inline static QString name()
 	{
 		return QT_TRANSLATE_NOOP("AudioDeviceSetupWidget", "JACK (JACK Audio Connection Kit)");

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -131,21 +131,6 @@ AudioJack* AudioJack::addMidiClient(MidiJack* midiClient)
 }
 
 
-void AudioJack::handleRegistrationEvent(jack_port_id_t port, int reg)
-{
-	auto jackPort = jack_port_by_id(m_client, port);
-
-	auto name = jack_port_name(jackPort);
-	auto type = jack_port_type(jackPort);
-	auto flags = jack_port_flags(jackPort);
-	
-	const bool isAudioPort = strcmp(type, JACK_DEFAULT_AUDIO_TYPE) == 0;
-	const bool isInputDevice = flags & JackPortIsOutput;
-
-	printf("Reg code %d for name %s and type %s, audio: %d, input: %d\n", reg, name, type, isAudioPort, isInputDevice);
-}
-
-
 bool AudioJack::initJackClient()
 {
 	QString clientName = ConfigManager::inst()->value("audiojack", "clientname");
@@ -182,13 +167,6 @@ bool AudioJack::initJackClient()
 
 	// set shutdown-callback
 	jack_on_shutdown(m_client, shutdownCallback, this);
-
-	jack_set_port_registration_callback(m_client,
-		[](jack_port_id_t port, int reg, void *arg) {
-			auto audioJack = static_cast<AudioJack*>(arg);
-			audioJack->handleRegistrationEvent(port, reg);
-		},
-		this);
 
 	if (jack_get_sample_rate(m_client) != sampleRate()) { setSampleRate(jack_get_sample_rate(m_client)); }
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -40,6 +40,17 @@
 #include "MainWindow.h"
 #include "MidiJack.h"
 
+
+namespace
+{
+static const QString audioJackClass("audiojack");
+static const QString clientNameKey("clientname");
+static const QString output1Key("output1");
+static const QString output2Key("output2");
+static const QString input1Key("input1");
+static const QString input2Key("input2");
+}
+
 namespace lmms
 {
 
@@ -133,7 +144,7 @@ AudioJack* AudioJack::addMidiClient(MidiJack* midiClient)
 
 bool AudioJack::initJackClient()
 {
-	QString clientName = ConfigManager::inst()->value("audiojack", "clientname");
+	QString clientName = ConfigManager::inst()->value(audioJackClass, clientNameKey);
 	if (clientName.isEmpty()) { clientName = "lmms"; }
 
 	const char* serverName = nullptr;
@@ -252,11 +263,11 @@ void AudioJack::startProcessing()
 
 	const auto cm = ConfigManager::inst();
 
-	attemptToReconnectOutput(0, cm->value("audiojack", "output1"));
-	attemptToReconnectOutput(1, cm->value("audiojack", "output2"));
+	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
+	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
 
-	attemptToReconnectInput(0, cm->value("audiojack", "input1"));
-	attemptToReconnectInput(1, cm->value("audiojack", "input2"));
+	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
+	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -441,7 +452,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	mainLayout->addLayout(form);
 
 	const auto cm = ConfigManager::inst();
-	QString cn = cm->value("audiojack", "clientname");
+	QString cn = cm->value(audioJackClass, clientNameKey);
 	if (cn.isEmpty()) { cn = "lmms"; }
 	m_clientName = new QLineEdit(cn, this);
 
@@ -456,12 +467,12 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioOutputNames = getAudioOutputNames();
 
 	m_outputDevice1 = new QComboBox(this);
-	const auto output1 = cm->value("audiojack", "output1");
+	const auto output1 = cm->value(audioJackClass, output1Key);
 	allPortsFound &= populateComboBox(m_outputDevice1, audioOutputNames, output1);
 	form->addRow(tr("Output 1"), m_outputDevice1);
 
 	m_outputDevice2 = new QComboBox(this);
-	const auto output2 = cm->value("audiojack", "output2");
+	const auto output2 = cm->value(audioJackClass, output2Key);
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
@@ -469,12 +480,12 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioInputNames = getAudioInputNames();
 
 	m_inputDevice1 = new QComboBox(this);
-	const auto input1 = cm->value("audiojack", "input1");
+	const auto input1 = cm->value(audioJackClass, input1Key);
 	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
 	form->addRow(tr("Input 1"), m_inputDevice1);
 
 	m_inputDevice2 = new QComboBox(this);
-	const auto input2 = cm->value("audiojack", "input2");
+	const auto input2 = cm->value(audioJackClass, input2Key);
 	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
 	form->addRow(tr("Input 2"), m_inputDevice2);
 
@@ -494,11 +505,11 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 void AudioJack::setupWidget::saveSettings()
 {
-	ConfigManager::inst()->setValue("audiojack", "clientname", m_clientName->text());
-	ConfigManager::inst()->setValue("audiojack", "output1", m_outputDevice1->currentText());
-	ConfigManager::inst()->setValue("audiojack", "output2", m_outputDevice2->currentText());
-	ConfigManager::inst()->setValue("audiojack", "input1", m_inputDevice1->currentText());
-	ConfigManager::inst()->setValue("audiojack", "input2", m_inputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
+	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -493,6 +493,7 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
 	}
+
 	if (m_client != nullptr)
 	{
 		jack_deactivate(m_client);

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -47,8 +47,6 @@ static const QString audioJackClass("audiojack");
 static const QString clientNameKey("clientname");
 static const QString output1Key("output1");
 static const QString output2Key("output2");
-static const QString input1Key("input1");
-static const QString input2Key("input2");
 }
 
 namespace lmms
@@ -231,17 +229,6 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 	attemptToConnect(outputIndex, "output", outputName, targetName);
 }
 
-void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
-{
-	if (inputIndex > m_inputPorts.size()) return;
-
-	auto inputName = jack_port_name(m_inputPorts[inputIndex]);
-	auto sourceName = sourcePort.toLatin1().constData();
-
-	attemptToConnect(inputIndex, "input", sourceName, inputName);
-}
-
-
 void AudioJack::startProcessing()
 {
 	if (m_active || m_client == nullptr)
@@ -265,9 +252,6 @@ void AudioJack::startProcessing()
 
 	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
 	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
-
-	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
-	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -476,19 +460,6 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
-	// Inputs
-	const auto audioInputNames = getAudioInputNames();
-
-	m_inputDevice1 = new QComboBox(this);
-	const auto input1 = cm->value(audioJackClass, input1Key);
-	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
-	form->addRow(tr("Input 1"), m_inputDevice1);
-
-	m_inputDevice2 = new QComboBox(this);
-	const auto input2 = cm->value(audioJackClass, input2Key);
-	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
-	form->addRow(tr("Input 2"), m_inputDevice2);
-
 	if (!allPortsFound)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
@@ -509,8 +480,6 @@ void AudioJack::setupWidget::saveSettings()
 	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
 	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
 	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
-	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
-	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const
@@ -536,11 +505,6 @@ std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags
 std::vector<std::string> AudioJack::setupWidget::getAudioOutputNames() const
 {
 	return getAudioPortNames(JackPortIsInput);
-}
-
-std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
-{
-	return getAudioPortNames(JackPortIsOutput);
 }
 
 bool AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -47,6 +47,8 @@ static const QString audioJackClass("audiojack");
 static const QString clientNameKey("clientname");
 static const QString output1Key("output1");
 static const QString output2Key("output2");
+static const QString input1Key("input1");
+static const QString input2Key("input2");
 }
 
 namespace lmms
@@ -229,6 +231,17 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 	attemptToConnect(outputIndex, "output", outputName, targetName);
 }
 
+void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
+{
+	if (inputIndex > m_inputPorts.size()) return;
+
+	auto inputName = jack_port_name(m_inputPorts[inputIndex]);
+	auto sourceName = sourcePort.toLatin1().constData();
+
+	attemptToConnect(inputIndex, "input", sourceName, inputName);
+}
+
+
 void AudioJack::startProcessing()
 {
 	if (m_active || m_client == nullptr)
@@ -252,6 +265,9 @@ void AudioJack::startProcessing()
 
 	attemptToReconnectOutput(0, cm->value(audioJackClass, output1Key));
 	attemptToReconnectOutput(1, cm->value(audioJackClass, output2Key));
+
+	attemptToReconnectInput(0, cm->value(audioJackClass, input1Key));
+	attemptToReconnectInput(1, cm->value(audioJackClass, input2Key));
 
 	m_stopped = false;
 }
@@ -460,6 +476,19 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	allPortsFound &= populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
+	// Inputs
+	const auto audioInputNames = getAudioInputNames();
+
+	m_inputDevice1 = new QComboBox(this);
+	const auto input1 = cm->value(audioJackClass, input1Key);
+	allPortsFound &= populateComboBox(m_inputDevice1, audioInputNames, input1);
+	form->addRow(tr("Input 1"), m_inputDevice1);
+
+	m_inputDevice2 = new QComboBox(this);
+	const auto input2 = cm->value(audioJackClass, input2Key);
+	allPortsFound &= populateComboBox(m_inputDevice2, audioInputNames, input2);
+	form->addRow(tr("Input 2"), m_inputDevice2);
+
 	if (!allPortsFound)
 	{
 		mainLayout->addWidget(new QLabel(tr("Some inputs/outputs could not be found and have been reset!"), this));
@@ -480,6 +509,8 @@ void AudioJack::setupWidget::saveSettings()
 	ConfigManager::inst()->setValue(audioJackClass, clientNameKey, m_clientName->text());
 	ConfigManager::inst()->setValue(audioJackClass, output1Key, m_outputDevice1->currentText());
 	ConfigManager::inst()->setValue(audioJackClass, output2Key, m_outputDevice2->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input1Key, m_inputDevice1->currentText());
+	ConfigManager::inst()->setValue(audioJackClass, input2Key, m_inputDevice2->currentText());
 }
 
 std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags portFlags) const
@@ -505,6 +536,11 @@ std::vector<std::string> AudioJack::setupWidget::getAudioPortNames(JackPortFlags
 std::vector<std::string> AudioJack::setupWidget::getAudioOutputNames() const
 {
 	return getAudioPortNames(JackPortIsInput);
+}
+
+std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
+{
+	return getAudioPortNames(JackPortIsOutput);
 }
 
 bool AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -459,7 +459,8 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 
 	QFormLayout * form = new QFormLayout(this);
 
-	QString cn = ConfigManager::inst()->value("audiojack", "clientname");
+	const auto cm = ConfigManager::inst();
+	QString cn = cm->value("audiojack", "clientname");
 	if (cn.isEmpty()) { cn = "lmms"; }
 	m_clientName = new QLineEdit(cn, this);
 
@@ -469,30 +470,26 @@ AudioJack::setupWidget::setupWidget(QWidget* parent)
 	const auto audioOutputNames = getAudioOutputNames();
 
 	m_outputDevice1 = new QComboBox(this);
-
-	populateComboBox(m_outputDevice1, audioOutputNames);
-
+	const auto output1 = cm->value("audiojack", "output1");
+	populateComboBox(m_outputDevice1, audioOutputNames, output1);
 	form->addRow(tr("Output 1"), m_outputDevice1);
 
 	m_outputDevice2 = new QComboBox(this);
-
-	populateComboBox(m_outputDevice2, audioOutputNames);
-
+	const auto output2 = cm->value("audiojack", "output2");
+	populateComboBox(m_outputDevice2, audioOutputNames, output2);
 	form->addRow(tr("Output 2"), m_outputDevice2);
 
 	// Inputs
 	const auto audioInputNames = getAudioInputNames();
 
 	m_inputDevice1 = new QComboBox(this);
-
-	populateComboBox(m_inputDevice1, audioInputNames);
-
+	const auto input1 = cm->value("audiojack", "input1");
+	populateComboBox(m_inputDevice1, audioInputNames, input1);
 	form->addRow(tr("Input 1"), m_inputDevice1);
 
 	m_inputDevice2 = new QComboBox(this);
-
-	populateComboBox(m_inputDevice2, audioInputNames);
-
+	const auto input2 = cm->value("audiojack", "input2");
+	populateComboBox(m_inputDevice2, audioInputNames, input2);
 	form->addRow(tr("Input 2"), m_inputDevice2);
 	if (m_client != nullptr)
 	{
@@ -543,7 +540,7 @@ std::vector<std::string> AudioJack::setupWidget::getAudioInputNames() const
 	return getAudioPortNames(JackPortIsOutput);
 }
 
-void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames)
+void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::vector<std::string>& inputNames, const QString& selectedEntry)
 {
 	QStringList playbackDevices;
 	for (const auto & inputName : inputNames)
@@ -551,13 +548,9 @@ void AudioJack::setupWidget::populateComboBox(QComboBox* comboBox, const std::ve
 		playbackDevices.append(QString::fromStdString(inputName));
 	}
 
-	//playbackDevices.sort();
-
 	comboBox->addItems(playbackDevices);
 
-	// TODO Select device from configuration
-	// const auto playbackDevice = ConfigManager::inst()->value(SectionSDL, PlaybackDeviceSDL);
-	// m_playbackDeviceComboBox->setCurrentText(playbackDevice.isEmpty() ? s_systemDefaultDevice : playbackDevice);
+	comboBox->setCurrentText(selectedEntry);
 }
 
 


### PR DESCRIPTION
This pull request introduces input selection for the Jack driver and should be merged after https://github.com/LMMS/lmms/pull/7786 because input selection only makes sense if recording is implemented/merged.

The dialog looks as follows with the PR:

![JackDriverWithInputSelectionAndWarning](https://github.com/user-attachments/assets/4ef3da8c-f520-46b0-8207-346920a32d6d)

A warning is shown in case the users have inputs or outputs in their configuration which are not available at the time when the dialog was created. Users can then either cancel out of the dialog or select the inputs/outputs so that everything is configured fine again.

Note: it shares many commits with https://github.com/LMMS/lmms/pull/7919 which will disappear if https://github.com/LMMS/lmms/pull/7919 is merged before this one.