### PR TITLE
Remove `m_inBuf`

### DIFF
--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -113,7 +113,6 @@ private:
 	jack_default_audio_sample_t** m_tempOutBufs;
 	std::vector<SampleFrame> m_inputFrameBuffer;
 	SampleFrame* m_outBuf;
-	SampleFrame* m_inBuf;
 
 	f_cnt_t m_framesDoneInCurBuf;
 	f_cnt_t m_framesToDoInCurBuf;

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -50,7 +50,6 @@ AudioJack::AudioJack(bool& successful, AudioEngine* audioEngineParam)
 	, m_midiClient(nullptr)
 	, m_tempOutBufs(new jack_default_audio_sample_t*[channels()])
 	, m_outBuf(new SampleFrame[audioEngine()->framesPerPeriod()])
-	, m_inBuf(new SampleFrame[audioEngine()->framesPerPeriod()])
 	, m_framesDoneInCurBuf(0)
 	, m_framesToDoInCurBuf(0)
 {
@@ -86,7 +85,6 @@ AudioJack::~AudioJack()
 	delete[] m_tempOutBufs;
 
 	delete[] m_outBuf;
-	delete[] m_inBuf;
 }
 
 


### PR DESCRIPTION
Extra variable in `AudioJack` that can be removed, as `m_inputFrameBuffer` is used instead. Should be a really easy merge.