### PR TITLE
move FileRevealer into the gui namespace

### DIFF
--- a/include/FileRevealer.h
+++ b/include/FileRevealer.h
@@ -27,7 +27,7 @@
 
 #include <QFileInfo>
 
-namespace lmms {
+namespace lmms::gui {
 
 /**
  * @class FileRevealer

--- a/include/FileRevealer.h
+++ b/include/FileRevealer.h
@@ -73,5 +73,5 @@ protected:
 	static bool supportsArg(const QString& command, const QString& arg);
 };
 
-} // namespace lmms
+} // namespace lmms::gui
 #endif // LMMS_FILE_REVEALER_H

--- a/src/gui/FileRevealer.cpp
+++ b/src/gui/FileRevealer.cpp
@@ -35,7 +35,7 @@
 
 #include "lmmsconfig.h"
 
-namespace lmms {
+namespace lmms::gui {
 bool FileRevealer::s_canSelect = false;
 
 const QString& FileRevealer::getDefaultFileManager()

--- a/src/gui/FileRevealer.cpp
+++ b/src/gui/FileRevealer.cpp
@@ -180,4 +180,4 @@ bool FileRevealer::supportsArg(const QString& command, const QString& arg)
 	return output.contains(arg);
 }
 
-} // namespace lmms
+} // namespace lmms::gui


### PR DESCRIPTION
moved `FileRevealer` from `lmms` to `lmms::gui`. It was in the wrong namespace as pointed out by @sakertooth 