### PR TITLE
Refactor Global Spacebar Play

### DIFF
--- a/include/Editor.h
+++ b/include/Editor.h
@@ -51,9 +51,9 @@ class Editor : public QMainWindow
 public:
 	void setPauseIcon(bool displayPauseIcon=true);
 	QAction *playAction() const;
-	static Editor* s_lastPlayedEditor = nullptr;
 	static void togglePlayStopLastEditor();
 	static void togglePauseLastEditor();
+	static Editor* s_lastPlayedEditor;
 protected:
 	DropToolBar * addDropToolBarToTop(QString const & windowTitle);
 	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);

--- a/include/Editor.h
+++ b/include/Editor.h
@@ -51,6 +51,9 @@ class Editor : public QMainWindow
 public:
 	void setPauseIcon(bool displayPauseIcon=true);
 	QAction *playAction() const;
+	static Editor* s_lastPlayedEditor = nullptr;
+	static void togglePlayStopLastEditor();
+	static void togglePauseLastEditor();
 protected:
 	DropToolBar * addDropToolBarToTop(QString const & windowTitle);
 	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);

--- a/include/Song.h
+++ b/include/Song.h
@@ -257,7 +257,6 @@ public:
 		return m_playMode;
 	}
 
-	PlayMode lastPlayMode() const { return m_lastPlayMode; }
 	inline PlayPos & getPlayPos( PlayMode pm )
 	{
 		return m_playPos[static_cast<std::size_t>(pm)];
@@ -493,7 +492,6 @@ private:
 	std::array<Timeline, PlayModeCount> m_timelines;
 
 	PlayMode m_playMode;
-	PlayMode m_lastPlayMode;
 	PlayPos m_playPos[PlayModeCount];
 	bar_t m_length;
 

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -493,7 +493,6 @@ void Song::playSong()
 	}
 
 	m_playMode = PlayMode::Song;
-	m_lastPlayMode = m_playMode;
 	m_playing = true;
 	m_paused = false;
 
@@ -533,7 +532,6 @@ void Song::playPattern()
 	}
 
 	m_playMode = PlayMode::Pattern;
-	m_lastPlayMode = m_playMode;
 	m_playing = true;
 	m_paused = false;
 
@@ -560,7 +558,6 @@ void Song::playMidiClip( const MidiClip* midiClipToPlay, bool loop )
 	if( m_midiClipToPlay != nullptr )
 	{
 		m_playMode = PlayMode::MidiClip;
-		m_lastPlayMode = m_playMode;
 		m_playing = true;
 		m_paused = false;
 	}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1286,27 +1286,8 @@ void MainWindow::keyPressEvent( QKeyEvent * _ke )
 		case Qt::Key_Alt: m_keyMods.m_alt = true; break;
 		case Qt::Key_Space:
 		{
-			Editor* lastEditor = nullptr;
-			switch (Engine::getSong()->lastPlayMode())
-			{
-			case Song::PlayMode::Song:
-				lastEditor = getGUI()->songEditor();
-				break;
-			case Song::PlayMode::MidiClip:
-				lastEditor = getGUI()->pianoRoll();
-				break;
-			case Song::PlayMode::Pattern:
-				lastEditor = getGUI()->patternEditor();
-				break;
-			case Song::PlayMode::AutomationClip:
-				lastEditor = getGUI()->automationEditor();
-				break;
-			default:
-				lastEditor = getGUI()->songEditor();
-				break;
-			}
-			if (m_keyMods.m_shift) { lastEditor->togglePause(); }
-			else { lastEditor->togglePlayStop(); }
+			if (m_keyMods.m_shift) { Editor::togglePauseLastEditor(); }
+			else { Editor::togglePlayStopLastEditor(); }
 			break;
 		}
 		default:

--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -231,10 +231,6 @@ void MixerChannelView::keyPressEvent(QKeyEvent* ke)
 			renameFinished();
 		}
 	}
-	else if (ke->key() == Qt::Key_Space)
-	{
-		m_fader->adjustByDialog();
-	}
 	else
 	{
 		ke->ignore();

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -39,6 +39,8 @@
 namespace lmms::gui
 {
 
+Editor* Editor::s_lastPlayedEditor = nullptr;
+
 
 void Editor::setPauseIcon(bool displayPauseIcon)
 {

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -71,8 +71,19 @@ DropToolBar * Editor::addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAd
 	return toolBar;
 }
 
+void Editor::togglePlayStopLastEditor()
+{
+	if (s_lastPlayedEditor) { s_lastPlayedEditor->togglePlayStop(); }
+}
+
+void Editor::togglePauseLastEditor()
+{
+	if (s_lastPlayedEditor) { s_lastPlayedEditor->togglePause(); }
+}
+
 void Editor::togglePlayStop()
 {
+	s_lastPlayedEditor = this;
 	if (Engine::getSong()->isPlaying())
 		stop();
 	else
@@ -81,6 +92,7 @@ void Editor::togglePlayStop()
 
 void Editor::togglePause()
 {
+	s_lastPlayedEditor = this;
 	Engine::getSong()->togglePause();
 }
 
@@ -118,7 +130,6 @@ Editor::Editor(bool record, bool stepRecord) :
 	connect(m_recordAccompanyAction, SIGNAL(triggered()), this, SLOT(recordAccompany()));
 	connect(m_toggleStepRecordingAction, SIGNAL(triggered()), this, SLOT(toggleStepRecording()));
 	connect(m_stopAction, SIGNAL(triggered()), this, SLOT(stop()));
-	new QShortcut(QKeySequence(combine(Qt::SHIFT, Qt::Key_Space)), this, SLOT(togglePause()));
 	new QShortcut(QKeySequence(combine(Qt::SHIFT, Qt::Key_F11)), this, SLOT(toggleMaximize()));
 
 	// Add actions to toolbar


### PR DESCRIPTION
This PR simplifies #7762 by removing the editor-specific code from `MainWindow` and `m_lastPlayMode` from `Song`, and instead uses a static variable in `Editor` which keeps track of the last played editor.

This PR also removes the spacebar shortcut from `MixerChannelView` for changing the volume, as multiple users have noticed that it clashes with their intuition after getting used to the spacebar working everywhere else.