### PR TITLE
Fix quick access letter conflict with Export and Export Tracks

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -312,7 +312,7 @@ void MainWindow::finalize()
 					SLOT(onExportProject()),
 					combine(Qt::CTRL, Qt::Key_E));
 	project_menu->addAction( embed::getIconPixmap( "project_export" ),
-					tr( "Export &Tracks..." ),
+					tr("Export &Tracks..."),
 					this,
 					SLOT(onExportProjectTracks()),
 					combine(Qt::CTRL, Qt::SHIFT, Qt::Key_E));


### PR DESCRIPTION
Update shortcut `T` for exporting Tracks, so that `x` is default export.
#7925 