### PR TITLE
Use complete basename in `PathUtil::cleanName` instead of basename

### DIFF
--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -103,9 +103,9 @@ namespace lmms::PathUtil
 		return path.mid( basePrefix(baseLookup(path)).length() );
 	}
 
-	QString cleanName(const QString & path)
+	QString cleanName(const QString& path)
 	{
-		return stripPrefix(QFileInfo(path).baseName());
+		return stripPrefix(QFileInfo(path).fileName());
 	}
 
 

--- a/src/core/PathUtil.cpp
+++ b/src/core/PathUtil.cpp
@@ -105,7 +105,7 @@ namespace lmms::PathUtil
 
 	QString cleanName(const QString& path)
 	{
-		return stripPrefix(QFileInfo(path).fileName());
+		return stripPrefix(QFileInfo(path).completeBaseName());
 	}
 
 


### PR DESCRIPTION
Use `completeBaseName()` in `PathUtill::cleanName` instead of the `baseName()`. Needed for handling filenames with periods correctly.