### PR TITLE
Better support for smooth scrolling trackpads and mice

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -243,8 +243,6 @@ private:
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
 
-	void adjustLeftRightScoll(int value);
-
 	TimePos m_currentPosition;
 
 	Action m_action;
@@ -254,8 +252,11 @@ private:
 	float m_drawLastLevel;
 	tick_t m_drawLastTick;
 
+	//! Pixels per bar
 	int m_ppb;
+	//! Pixels per step on the Y axis (when Y zoom is not Auto)
 	int m_y_delta;
+	//! True if Y zoom is Auto
 	bool m_y_auto;
 
 	// Time position (key) of automation node whose outValue is being dragged

--- a/include/PianoView.h
+++ b/include/PianoView.h
@@ -65,6 +65,7 @@ protected:
 	void focusOutEvent( QFocusEvent * _fe ) override;
 	void focusInEvent( QFocusEvent * fe ) override;
 	void resizeEvent( QResizeEvent * _event ) override;
+	void wheelEvent(QWheelEvent* event) override;
 
 
 private:

--- a/include/Scroll.h
+++ b/include/Scroll.h
@@ -1,0 +1,130 @@
+/*
+ * Scroll.h - calculate scroll distance
+ *
+ * Copyright (c) 2025 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef SCROLL_H
+#define SCROLL_H
+
+#include "Flags.h"
+#include "lmms_export.h"
+
+
+class QWheelEvent;
+
+
+namespace lmms {
+
+
+class LMMS_EXPORT Scroll
+{
+public:
+	/*! \brief Scroll delta
+	 *
+	 *  This class measures scroll delta in "wheel ticks",
+	 *  unlike QWheelEvent which measures scroll delta in 1/8ths of a degree.
+	 */
+	Scroll(QWheelEvent* event);
+
+
+	enum class Flag {
+		NoFlag = 0x0,
+		Horizontal = 0x1,
+		//! Change any natural (inverted) scroll to regular scroll.
+		//! This is useful for widgets like faders, where you want up to be up.
+		//! Some operating systems does not support this.
+		DisableNaturalScrolling = 0x2,
+		//! Swap x/y scroll orientation when pressing Alt.
+		//! On some platforms Qt does this by default,
+		//! but Scroll() will also compensate for that by default.
+		SwapOrientationWithAlt = 0x4,
+	};
+
+	using Flags = lmms::Flags<Flag>;
+
+
+	/*! \brief Return angleDelta
+	 *
+	 *  The value is positive when the wheel is rotated away from the hand.
+	 *
+	 *  If you intend to divide this value and round it or store it as an
+	 *  integer, you should probably use getSteps() instead to avoid rounding
+	 *  issues with smooth scrolling trackpads and mice.
+	 */
+	int getDelta(const Flags flags = Flag::NoFlag);
+
+
+	/*! \brief Return number of completely scrolled steps of some size
+	 *
+	 *  The return value is positive when the wheel is rotated away from the hand.
+	 *
+	 *  `stepsPerWheelTick` is the number of steps to count for every wheel tick.
+	 *  If set to 5 it will count a step whenever the wheel has moved 1/5 of a tick.
+	 *  It will always cound at least one step per wheel tick.
+	 *
+	 *  --------------------------------------------------------------------------
+	 *
+	 *  You should always use this function instead of the following:
+	 * 	    int steps = wheelEvent->angleDelta().y() / some_value
+	 *
+	 * 	This is because some trackpads and mice report much smaller chunks of angleDelta
+	 *  than the standard 120 (which is a "wheel tick"). In the worst case scenario
+	 *  the result will always be rounded down to 0. This function solves it by accumulating
+	 *  the angleDelta until a complete step is reached.
+	 *
+	 *  Note: don't call this function if you intend to ignore() the event, as it
+	 *  may result in double-counting scroll delta.
+	 */
+	int getSteps(const float stepsPerWheelTick = 1.0, const Flags flags = Flag::NoFlag);
+
+	inline int getSteps(const Flags flags)
+	{
+		return getSteps(1.0, flags);
+	}
+
+
+	//! \brief True when scrolling vertically
+	bool isVertical();
+
+	//! \brief True when scrolling horizontally
+	bool isHorizontal();
+
+private:
+	int calculateSteps(const int angleDelta, const float stepsPerTick, const bool horizontal);
+
+	QWheelEvent* m_event;
+
+	// These are used by calculateSteps() to accumulate partially scrolled steps
+	// They are shared across all widgets but that doesn't notisable affect the user experience
+	static float s_partialStepX;
+	static float s_partialStepY;
+
+	const float m_initialPartialStepX;
+	const float m_initialPartialStepY;
+};
+
+LMMS_DECLARE_OPERATORS_FOR_FLAGS(Scroll::Flag)
+
+
+} // namespace lmms
+
+#endif

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -128,8 +128,6 @@ private:
 
 	QScrollBar * m_leftRightScroll;
 
-	void adjustLeftRightScoll(int value);
-
 	LcdSpinBox * m_tempoSpinBox;
 
 	TimeLineWidget * m_timeLine;

--- a/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorWaveView.cpp
@@ -28,6 +28,7 @@
 #include "ConfigManager.h"
 #include "SampleThumbnail.h"
 #include "FontHelper.h"
+#include "Scroll.h"
 
 #include <QPainter>
 #include <QMouseEvent>
@@ -192,7 +193,14 @@ void AudioFileProcessorWaveView::mouseMoveEvent(QMouseEvent * me)
 
 void AudioFileProcessorWaveView::wheelEvent(QWheelEvent * we)
 {
-	zoom(we->angleDelta().y() > 0);
+	auto scroll = Scroll(we);
+	we->accept();
+
+	int scrolledSteps = scroll.getSteps();
+	if (scrolledSteps == 0) { return; }
+
+	bool zoomOut = scrolledSteps < 0;
+	zoom(zoomOut);
 	update();
 }
 

--- a/plugins/Compressor/CompressorControlDialog.cpp
+++ b/plugins/Compressor/CompressorControlDialog.cpp
@@ -38,6 +38,7 @@
 #include "Knob.h"
 #include "MainWindow.h"
 #include "PixmapButton.h"
+#include "Scroll.h"
 
 namespace lmms::gui
 {
@@ -645,9 +646,12 @@ void CompressorControlDialog::resizeEvent(QResizeEvent *event)
 
 void CompressorControlDialog::wheelEvent(QWheelEvent * event)
 {
+	auto scroll = Scroll(event);
+	event->accept();
+
 	const float temp = m_dbRange;
-	const float dbRangeNew = m_dbRange - copysignf(COMP_GRID_SPACING, event->angleDelta().y());
-	m_dbRange = round(qBound(COMP_GRID_SPACING, dbRangeNew, COMP_GRID_MAX) / COMP_GRID_SPACING) * COMP_GRID_SPACING;
+	const float dbRangeNew = m_dbRange - scroll.getSteps() * COMP_GRID_SPACING;
+	m_dbRange = std::clamp(dbRangeNew, COMP_GRID_SPACING, COMP_GRID_MAX);
 
 	// Only reset view if the scolling had an effect
 	if (m_dbRange != temp)

--- a/plugins/Eq/EqCurve.cpp
+++ b/plugins/Eq/EqCurve.cpp
@@ -561,8 +561,10 @@ void EqHandle::mouseReleaseEvent( QGraphicsSceneMouseEvent *event )
 
 void EqHandle::wheelEvent( QGraphicsSceneWheelEvent *wevent )
 {
+	wevent->accept();
+
 	float highestBandwich = m_type != EqHandleType::Para ? 10 : 4;
-	int numDegrees = wevent->delta() / 120;
+	float numDegrees = wevent->delta() / 120.f;
 	float numSteps = 0;
 	if( wevent->modifiers() == Qt::ControlModifier )
 	{
@@ -579,7 +581,6 @@ void EqHandle::wheelEvent( QGraphicsSceneWheelEvent *wevent )
 
 		emit positionChanged();
 	}
-	wevent->accept();
 }
 
 

--- a/plugins/Vectorscope/VectorView.cpp
+++ b/plugins/Vectorscope/VectorView.cpp
@@ -34,6 +34,7 @@
 #include "GuiApplication.h"
 #include "FontHelper.h"
 #include "MainWindow.h"
+#include "Scroll.h"
 #include "VecControls.h"
 
 namespace lmms::gui
@@ -241,12 +242,18 @@ void VectorView::mouseDoubleClickEvent(QMouseEvent *event)
 // Change zoom level using the mouse wheel
 void VectorView::wheelEvent(QWheelEvent *event)
 {
-	// Go through integers to avoid accumulating errors
-	const unsigned short old_zoom = round(100 * m_zoom);
-	// Min-max bounds are 20 and 1000 %, step for 15°-increment mouse wheel is 20 %
-	const unsigned short new_zoom = qBound(20, old_zoom + event->angleDelta().y() / 6, 1000);
-	m_zoom = new_zoom / 100.f;
+	auto scroll = Scroll(event);
 	event->accept();
+
+	// Increment 20% per mouse wheel step
+	const int increment = scroll.getSteps(20);
+
+	// Round zoom percentage to integers to avoid accumulating errors
+	const unsigned short old_zoom = round(100 * m_zoom);
+	// Min-max bounds are 20 and 1000 %
+	const unsigned short new_zoom = std::clamp(old_zoom + increment, 20, 1000);
+
+	m_zoom = new_zoom / 100.f;
 	m_zoomTimestamp = std::chrono::duration_cast<std::chrono::milliseconds>
 	(
 		std::chrono::high_resolution_clock::now().time_since_epoch()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -37,6 +37,7 @@ SET(LMMS_SRCS
 	gui/SampleLoader.cpp
 	gui/SampleTrackWindow.cpp
 	gui/SampleThumbnail.cpp
+	gui/Scroll.cpp
 	gui/SendButtonIndicator.cpp
 	gui/SideBar.cpp
 	gui/SideBarWidget.cpp

--- a/src/gui/Scroll.cpp
+++ b/src/gui/Scroll.cpp
@@ -1,0 +1,121 @@
+/*
+ * Scroll.cpp - calculate scroll distance
+ *
+ * Copyright (c) 2025 Alex <allejok96/gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "Scroll.h"
+
+#include <QGraphicsSceneWheelEvent>
+#include <QWheelEvent>
+
+
+namespace lmms {
+
+
+static const float ANGLE_DELTA_PER_TICK = 120.f;
+
+
+float Scroll::s_partialStepX = 0;
+float Scroll::s_partialStepY = 0;
+
+
+
+Scroll::Scroll(QWheelEvent* event) :
+	m_event(event),
+	m_initialPartialStepX(s_partialStepX),
+	m_initialPartialStepY(s_partialStepY)
+{
+}
+
+
+
+int Scroll::getDelta(const Flags flags)
+{
+	bool useHorizontal = flags.testFlag(Scroll::Flag::Horizontal);
+
+	if (m_event->modifiers() & Qt::AltModifier)
+	{
+#ifdef LMMS_BUILD_APPLE
+		// Enable scroll orientation swapping when pression Option on macOS
+		if (flags & ScrollFlag::SwapOrientationWithAlt) { useHorizontal = !useHorizontal; }
+#else
+		// Compensate for Qt swapping scroll orientation when pressing Alt on Windows and Linux
+		if (!flags.testFlag(Scroll::Flag::SwapOrientationWithAlt)) { useHorizontal = !useHorizontal; }
+#endif
+	}
+
+	int delta = useHorizontal ? m_event->angleDelta().x() : m_event->angleDelta().y();
+
+	// Compensate natural scrolling
+	if (m_event->inverted() && flags & Scroll::Flag::DisableNaturalScrolling)
+	{
+		delta = -delta;
+	}
+
+	return delta;
+}
+
+
+
+int Scroll::getSteps(const float stepsPerWheelTick, const Flags flags)
+{
+	return calculateSteps(getDelta(flags), stepsPerWheelTick, flags.testFlag(Flag::Horizontal));
+}
+
+
+
+bool Scroll::isVertical()
+{
+	return getDelta() != 0;
+}
+
+
+
+bool Scroll::isHorizontal()
+{
+	return getDelta(Flag::Horizontal) != 0;
+}
+
+
+
+int Scroll::calculateSteps(const int delta, const float stepsPerTick, const bool horizontal)
+{
+	// Partial step saved from another wheel event
+	float& partialStep = horizontal ? s_partialStepX : s_partialStepY;
+
+	// Prevent partial steps from building up if this is called multiple times for the same event
+	partialStep = horizontal ? m_initialPartialStepX : m_initialPartialStepY;
+
+	// If scroll changed direction, forget the partial step
+	if (delta * partialStep < 0) { partialStep = 0; }
+
+	const float steps = partialStep + (delta / ANGLE_DELTA_PER_TICK) * std::max(1.f, stepsPerTick);
+	const int wholeSteps = static_cast<int>(steps);
+
+	partialStep = (steps - wholeSteps);
+
+	return wholeSteps;
+}
+
+
+
+} // namespace lmms

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -43,6 +43,7 @@
 #include "MidiClip.h"
 #include "PianoRoll.h"
 #include "RenameDialog.h"
+#include "Scroll.h"
 #include "SongEditor.h"
 #include "TrackContainerView.h"
 #include "TrackView.h"
@@ -495,9 +496,12 @@ void MidiClipView::mouseDoubleClickEvent(QMouseEvent *_me)
 
 void MidiClipView::wheelEvent(QWheelEvent * we)
 {
+	auto scroll = Scroll(we);
+
 	if(m_clip->m_clipType == MidiClip::Type::BeatClip &&
 				(fixedClips() || pixelsPerBar() >= 96) &&
-				position(we).y() > height() - m_stepBtnOff.height())
+				position(we).y() > height() - m_stepBtnOff.height() &&
+				scroll.isVertical())
 	{
 //	get the step number that was wheeled on and
 //	do calculations in floats to prevent rounding errors...
@@ -512,8 +516,11 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 		}
 
 		Note * n = m_clip->noteAtStep( step );
-		const int direction = (we->angleDelta().y() > 0 ? 1 : -1) * (we->inverted() ? -1 : 1);
-		if(!n && direction > 0)
+
+		// Increment the volume by 5 for every scroll wheel tick
+		int volumeIncrement = scroll.getSteps(5, Scroll::Flag::DisableNaturalScrolling);
+
+		if (!n && volumeIncrement > 0)
 		{
 			n = m_clip->addStepNote( step );
 			n->setVolume( 0 );
@@ -521,14 +528,9 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 		if( n != nullptr )
 		{
 			int vol = n->getVolume();
-			if(direction > 0)
-			{
-				n->setVolume( qMin( 100, vol + 5 ) );
-			}
-			else
-			{
-				n->setVolume( qMax( 0, vol - 5 ) );
-			}
+
+			// Don't pass negative volume as it would fold over
+			n->setVolume(static_cast<volume_t>(std::max(0, vol + volumeIncrement)));
 
 			Engine::getSong()->setModified();
 			update();
@@ -537,6 +539,8 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 				getGUI()->pianoRoll()->update();
 			}
 		}
+
+		// Accept the event so it doesn't get passed on to the editor window
 		we->accept();
 	}
 	else

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -55,6 +55,7 @@
 #include "PianoRoll.h"
 #include "ProjectJournal.h"
 #include "SampleBuffer.h"
+#include "Scroll.h"
 #include "StringPairDrag.h"
 #include "TextFloat.h"
 #include "TimeLineWidget.h"
@@ -66,6 +67,9 @@ namespace lmms::gui
 {
 const std::array<float, 7> AutomationEditor::m_zoomXLevels =
 		{ 0.125f, 0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f };
+
+const std::array<float, 7> zoomYLevels =
+	{0.25f, 0.5f, 1.0f, 2.0f, 4.0f, 8.0f, 16.0f};
 
 
 
@@ -1580,85 +1584,51 @@ void AutomationEditor::resizeEvent(QResizeEvent * re)
 	update();
 }
 
-void AutomationEditor::adjustLeftRightScoll(int value)
-{
-	m_leftRightScroll->setValue(m_leftRightScroll->value() -
-							value * 0.3f / m_zoomXLevels[m_zoomingXModel.value()]);
-}
 
 
 // TODO: Move this method up so it's closer to the other mouse events
 void AutomationEditor::wheelEvent(QWheelEvent * we )
 {
+	auto scroll = Scroll(we);
 	we->accept();
+
 	if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::ShiftModifier )
 	{
-		int y = m_zoomingYModel.value();
-		if(we->angleDelta().y() > 0)
-		{
-			y++;
-		}
-		else if(we->angleDelta().y() < 0)
-		{
-			y--;
-		}
-		y = qBound( 0, y, m_zoomingYModel.size() - 1 );
-		m_zoomingYModel.setValue( y );
+		m_zoomingYModel.setValue(m_zoomingYModel.value() + scroll.getSteps());
 	}
 	else if( we->modifiers() & Qt::ControlModifier && we->modifiers() & Qt::AltModifier )
 	{
-		int q = m_quantizeModel.value();
-		if((we->angleDelta().x() + we->angleDelta().y()) > 0) // alt + scroll becomes horizontal scroll on KDE
-		{
-			q--;
-		}
-		else if((we->angleDelta().x() + we->angleDelta().y()) < 0) // alt + scroll becomes horizontal scroll on KDE
-		{
-			q++;
-		}
-		q = qBound( 0, q, m_quantizeModel.size() - 1 );
-		m_quantizeModel.setValue( q );
+		m_quantizeModel.setValue(m_quantizeModel.value() - scroll.getSteps());
 		update();
 	}
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
-		int x = m_zoomingXModel.value();
-		if(we->angleDelta().y() > 0)
-		{
-			x++;
-		}
-		else if(we->angleDelta().y() < 0)
-		{
-			x--;
-		}
-		x = qBound( 0, x, m_zoomingXModel.size() - 1 );
-
 		int mouseX = (position( we ).x() - VALUES_WIDTH)* TimePos::ticksPerBar();
 		// ticks based on the mouse x-position where the scroll wheel was used
 		int ticks = mouseX / m_ppb;
-		// what would be the ticks in the new zoom level on the very same mouse x
-		int newTicks = mouseX / (DEFAULT_PPB * m_zoomXLevels[x]);
 
+		m_zoomingXModel.setValue(m_zoomingXModel.value() + scroll.getSteps());
+
+		// ticks in the new zoom level on the very same mouse x
+		int newTicks = mouseX / m_ppb;
 		// scroll so the tick "selected" by the mouse x doesn't move on the screen
 		m_leftRightScroll->setValue(m_leftRightScroll->value() + ticks - newTicks);
-
-
-		m_zoomingXModel.setValue( x );
-	}
-
-	// FIXME: Reconsider if determining orientation is necessary in Qt6.
-	else if (std::abs(we->angleDelta().x()) > std::abs(we->angleDelta().y())) // scrolling is horizontal
-	{
-		adjustLeftRightScoll(we->angleDelta().x());
-	}
-	else if(we->modifiers() & Qt::ShiftModifier)
-	{
-		adjustLeftRightScoll(we->angleDelta().y());
 	}
 	else
 	{
-		m_topBottomScroll->setValue(m_topBottomScroll->value() -
-							(we->angleDelta().x() + we->angleDelta().y()) / 30);
+		// How much the scroll wheel moves the screen depends on zoom level
+		const float xScrollSpeed = 36 / m_zoomXLevels[m_zoomingXModel.value()];
+
+		// Ignore calculating the speed for the first value of Y zoom because it's "Auto"
+		const float yScrollSpeed = m_zoomingYModel.value() == 0
+			? 1
+			: 4 / zoomYLevels[m_zoomingYModel.value() - 1];
+
+		const int xSteps = scroll.getSteps(xScrollSpeed, Scroll::Flag::SwapOrientationWithAlt|Scroll::Flag::Horizontal);
+		const int ySteps = scroll.getSteps(yScrollSpeed, Scroll::Flag::SwapOrientationWithAlt);
+
+		m_leftRightScroll->setValue(m_leftRightScroll->value() - xSteps);
+		m_topBottomScroll->setValue(m_topBottomScroll->value() - ySteps);
 	}
 }
 
@@ -1867,12 +1837,13 @@ void AutomationEditor::zoomingXChanged()
 
 void AutomationEditor::zoomingYChanged()
 {
-	const QString & zfac = m_zoomingYModel.currentText();
-	m_y_auto = zfac == "Auto";
+	// Is the zoom level "Auto"?
+	m_y_auto = m_zoomingYModel.value() == 0;
+
 	if( !m_y_auto )
 	{
-		m_y_delta = zfac.left( zfac.length() - 1 ).toInt()
-							* DEFAULT_Y_DELTA / 100;
+		// Remove 1 from the selected zoom level because the first is "Auto"
+		m_y_delta = DEFAULT_Y_DELTA * zoomYLevels[m_zoomingYModel.value() - 1];
 	}
 #ifdef LMMS_DEBUG
 	assert( m_y_delta > 0 );
@@ -2145,12 +2116,12 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	m_zoomingYComboBox->setFixedSize( 80, ComboBox::DEFAULT_HEIGHT );
 	m_zoomingYComboBox->setToolTip( tr( "Vertical zooming" ) );
 
-	m_editor->m_zoomingYModel.addItem( "Auto" );
-	for( int i = 0; i < 7; ++i )
+	m_editor->m_zoomingYModel.addItem(tr("Auto"));
+	for (const auto& zoomLevel : zoomYLevels)
 	{
-		m_editor->m_zoomingYModel.addItem( QString::number( 25 << i ) + "%" );
+		m_editor->m_zoomingYModel.addItem(QString("%1%").arg(zoomLevel * 100));
 	}
-	m_editor->m_zoomingYModel.setValue( m_editor->m_zoomingYModel.findText( "Auto" ) );
+	m_editor->m_zoomingYModel.setValue(0);
 
 	m_zoomingYComboBox->setModel( &m_editor->m_zoomingYModel );
 

--- a/src/gui/instrument/PianoView.cpp
+++ b/src/gui/instrument/PianoView.cpp
@@ -698,6 +698,15 @@ void PianoView::resizeEvent(QResizeEvent* event)
 
 
 
+void PianoView::wheelEvent(QWheelEvent* event)
+{
+	// Send event to scroll bar
+	QApplication::sendEvent(m_pianoScroll, event);
+	// Never let it propagate to parent
+	event->accept();
+}
+
+
 
 /*! \brief Convert a key number to an X coordinate in the piano display view
  *

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -39,6 +39,7 @@
 #include "Engine.h"
 #include "FadeButton.h"
 #include "PixmapButton.h"
+#include "Scroll.h"
 #include "StringPairDrag.h"
 #include "Track.h"
 #include "TrackGrip.h"
@@ -382,17 +383,18 @@ void TrackView::mouseReleaseEvent( QMouseEvent * me )
 
 void TrackView::wheelEvent(QWheelEvent* we)
 {
-	// Note: we add the values because one of them will be 0. If the alt modifier
-	// is pressed x is non-zero and otherwise y.
-	const int deltaY = we->angleDelta().x() + we->angleDelta().y();
-	int const direction = deltaY < 0 ? -1 : 1;
+	auto scroll = Scroll(we);
+	if (!scroll.isVertical()) { return; }
 
 	auto const modKeys = we->modifiers();
-	int stepSize = modKeys == (Qt::ControlModifier | Qt::AltModifier) ? 1 : modKeys == (Qt::ShiftModifier | Qt::AltModifier) ? 5 : 0;
 
-	if (stepSize != 0)
+	// If Ctrl+Alt or Shift+Alt is pressed
+	if (modKeys & (Qt::ControlModifier | Qt::ShiftModifier) && modKeys & Qt::AltModifier)
 	{
-		resizeToHeight(height() + stepSize * direction);
+		// Pressing shift will resize 5x faster
+		float scrollSpeed = modKeys & Qt::ShiftModifier ? 5 : 1;
+
+		resizeToHeight(height() + scroll.getSteps(scrollSpeed));
 		we->accept();
 	}
 }

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -33,6 +33,7 @@
 
 #include "CaptionMenu.h"
 #include "FontHelper.h"
+#include "Scroll.h"
 
 #define QT_SUPPORTS_WIDGET_SCREEN (QT_VERSION >= QT_VERSION_CHECK(5,14,0))
 #if !QT_SUPPORTS_WIDGET_SCREEN
@@ -218,12 +219,15 @@ void ComboBox::paintEvent( QPaintEvent * _pe )
 
 void ComboBox::wheelEvent( QWheelEvent* event )
 {
+	auto scroll = Scroll(event);
+	if (!scroll.isVertical()) { return; }
+
+	event->accept();
+
 	if( model() )
 	{
-		const int direction = (event->angleDelta().y() < 0 ? 1 : -1) * (event->inverted() ? -1 : 1);
-		model()->setInitValue(model()->value() + direction);
+		model()->setInitValue(model()->value() - scroll.getSteps());
 		update();
-		event->accept();
 	}
 }
 

--- a/src/gui/widgets/Fader.cpp
+++ b/src/gui/widgets/Fader.cpp
@@ -56,6 +56,7 @@
 #include "CaptionMenu.h"
 #include "ConfigManager.h"
 #include "KeyboardShortcuts.h"
+#include "Scroll.h"
 #include "SimpleTextFloat.h"
 
 namespace
@@ -266,11 +267,13 @@ void Fader::mouseReleaseEvent(QMouseEvent* mouseEvent)
 
 void Fader::wheelEvent (QWheelEvent* ev)
 {
-	const int direction = (ev->angleDelta().y() > 0 ? 1 : -1) * (ev->inverted() ? -1 : 1);
+	auto scroll = Scroll(ev);
+	if (!scroll.isVertical()) { return; }
 
-	const float increment = determineAdjustmentDelta(ev->modifiers()) * direction;
+	const int scrollDelta = scroll.getDelta(Scroll::Flag::DisableNaturalScrolling);
+	const float adjustmentDelta = determineAdjustmentDelta(ev->modifiers());
 
-	adjustByDecibelDelta(increment);
+	adjustByDecibelDelta(scrollDelta * adjustmentDelta);
 
 	ev->accept();
 }
@@ -287,11 +290,6 @@ float Fader::determineAdjustmentDelta(const Qt::KeyboardModifiers & modifiers) c
 	{
 		// The control key gives more control, i.e. it enables more fine-grained adjustments
 		return 0.1f;
-	}
-	else if (modifiers & Qt::AltModifier)
-	{
-		// Work around a Qt bug in conjunction with the scroll wheel and the Alt key
-		return 0.f;
 	}
 
 	return 1.f;

--- a/src/gui/widgets/LcdFloatSpinBox.cpp
+++ b/src/gui/widgets/LcdFloatSpinBox.cpp
@@ -45,6 +45,7 @@
 #include "KeyboardShortcuts.h"
 #include "MainWindow.h"
 #include "lmms_math.h"
+#include "Scroll.h"
 
 namespace lmms::gui
 {
@@ -188,12 +189,17 @@ void LcdFloatSpinBox::mouseReleaseEvent(QMouseEvent*)
 
 void LcdFloatSpinBox::wheelEvent(QWheelEvent *event)
 {
+	auto scroll = Scroll(event);
+	if (!scroll.isVertical()) { return; }
+
+	event->accept();
+
 	// switch between integer and fractional step based on cursor position
 	if (position(event).x() < m_wholeDisplay.width()) { m_intStep = true; }
 	else { m_intStep = false; }
 
-	event->accept();
-	model()->setValue(model()->value() + ((event->angleDelta().y() > 0) ? 1 : -1) * getStep());
+	const int steps = scroll.getSteps(Scroll::Flag::DisableNaturalScrolling);
+	model()->setValue(model()->value() + steps * getStep());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/LcdSpinBox.cpp
+++ b/src/gui/widgets/LcdSpinBox.cpp
@@ -30,6 +30,7 @@
 #include "LcdSpinBox.h"
 #include "KeyboardShortcuts.h"
 #include "CaptionMenu.h"
+#include "Scroll.h"
 
 
 namespace lmms::gui
@@ -141,10 +142,13 @@ void LcdSpinBox::mouseReleaseEvent(QMouseEvent*)
 
 void LcdSpinBox::wheelEvent(QWheelEvent * we)
 {
-	we->accept();
-	const int direction = (we->angleDelta().y() > 0 ? 1 : -1) * (we->inverted() ? -1 : 1);
+	auto scroll = Scroll(we);
+	if (!scroll.isVertical()) { return; }
 
-	model()->setValue(model()->value() + direction * model()->step<int>());
+	we->accept();
+
+	const int steps = scroll.getSteps(Scroll::Flag::DisableNaturalScrolling);
+	model()->setValue(model()->value() + steps * model()->step<int>());
 	emit manualChange();
 }
 

--- a/src/gui/widgets/TabWidget.cpp
+++ b/src/gui/widgets/TabWidget.cpp
@@ -34,6 +34,7 @@
 #include "DeprecationHelper.h"
 #include "embed.h"
 #include "FontHelper.h"
+#include "Scroll.h"
 
 namespace lmms::gui
 {
@@ -298,13 +299,19 @@ void TabWidget::paintEvent(QPaintEvent* pe)
 // Switch between tabs with mouse wheel
 void TabWidget::wheelEvent(QWheelEvent* we)
 {
+	auto scroll = Scroll(we);
+
 	if (position(we).y() > m_tabheight)
 	{
 		return;
 	}
 
 	we->accept();
-	int dir = (we->angleDelta().y() < 0) ? 1 : -1;
+
+	int steps = 0 - scroll.getSteps() - scroll.getSteps(Scroll::Flag::Horizontal);
+	if (steps == 0) { return; }
+
+	int dir = std::clamp(steps, -1, 1);
 	int tab = m_activeTab;
 	while(tab > -1 && static_cast<int>(tab) < m_widgets.count())
 	{


### PR DESCRIPTION
Continuation of #6700. Many of the those things have already been fixed in other PRs since then.

## Main issue

Scrolling in LMMS has not been designed for high-resolution trackpads and mice. It either violently reacts on every tiny movement, or completely ignores it. This PR introduces a `Scroll` class used to calculate scroll values. It handles high-resolution scrolling, natural scrolling and modifier keys that swap scroll direction.

### Other small improvements
- Vertical scrolling in Automation Editor and Piano Roll is now relative to *vertical* zoom level
- Enable horizontal scrolling in Piano Roll's note edit area
- Enable scrolling on Piano in the bottom of instrument window
- Horizontal scrolling on LCD spinboxes and Knobs doesn't continuously decrease their value

### Changes 
- Remove Shift+scroll for horizontal scrolling in the editors 😱
  - Alt+scroll already does the same thing and is built-in system-wide in Qt on Windows and Linux.
  - This PR brings Alt+scroll (Option+scroll) to macOS too.
  - It's confusing to have two modifiers do the same thing:
      - #5169
- Allow macOS to use natural scrolling on ComboBoxes (swipe up to move to next item)
  - Is this how macOS does it on other drop down menus?

## Things to test

Hey tester. There's a lot of widgets to test, I'm glad if you can help. Here's some stuff you should look out for:

- [ ] Scroll speeds are the same as before.
- [ ] Scroll directions are the same as before.
- [ ] Scroll directions for natural scrolling on macOS.
- [ ] Scrolling on high-resolution trackpads.
- [ ] Is it possible to scroll diagonally in the editors? (Are there trackpads that support this?)
- [ ] Press modifier keys when scrolling (see list below)
- [ ] Test that the point under the mouse does not change when scrolling to zoom
- [ ] Test the scroll speed on logarithmic knobs

### Widgets that have been edited and needs testing
| Where to scroll |  Expected behavior | Modifier keys |
|--------|------------|------|
|  AudioFileProcessor wave view  |  zoom  |  
|  Compressor | zoom | 
 | Equalizer handle | change resonance | 
 | Vectorscope | zoom | 
 | Midi clip (in Pattern editor) | add note/change note volume | 
 | Automation editor | scroll vertically | none
 | Automation editor | scroll horizontally  |  alt  | 
 | Automation editor | zoom | ctrl | 
 | Automation editor | zoom Y direction | ctrl+shift | 
 | Automation editor | change quantization | ctrl+alt | 
 | Piano roll | scroll vertically | none
 | Piano roll | scroll horizontally  |  alt  | 
 | Piano roll | zoom | ctrl
 | Piano roll | change quantization | ctrl+alt
 | Piano roll | change note length | ctrl+shift
 | Piano roll note edit area | change note volume
 | Song editor  |  scroll vertically  |  none  | 
 | Song editor  |  scroll horizontally  |  alt  | 
 | Song editor  |  zoom  |  ctrl  | 
 | Song editor  |  zoom slower  |  ctrl+shift  | 
 | Piano in instrument window | scroll horizontally | 
 | Track | resize height | ctrl+alt
 | Track | resize height faster | ctrl+shift
 | Combo box | change value | 
 | Fader  |  change value | 
 | Knob |  change value (check the speed when it's set to logarithmic too) | 
 | Knob |  change value faster  | shift
 | Knob |  change value slower (on knobs with a lot of values)  | ctrl
 | Knob |  change value super slow (on knobs with a lot of values)  | alt
 | LcdFloatSpinBox (in Scales and Keymaps) | change value | 
 | LcdSpinBox | change value | 
 | Envelope/FX tabs in instrument window  |  change tab | 