### PR TITLE
Don't undo zoom!

### DIFF
--- a/include/ComboBoxModel.h
+++ b/include/ComboBoxModel.h
@@ -45,6 +45,7 @@ public:
 					bool isDefaultConstructed = false ) :
 		IntModel( 0, 0, 0, parent, displayName, isDefaultConstructed )
 	{
+		setJournalling(false);
 	}
 
 	void addItem( QString item, std::unique_ptr<PixmapLoader> loader = nullptr );

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -114,10 +114,13 @@ AutomationEditor::AutomationEditor() :
 	//keeps the direction of the widget, undepended on the locale
 	setLayoutDirection( Qt::LeftToRight );
 
+	// Set up tension model
 	m_tensionModel = new FloatModel(1.f, 0.f, 1.f, 0.01f);
+	m_tensionModel->setJournalling(false);
 	connect( m_tensionModel, SIGNAL(dataChanged()),
 				this, SLOT(setTension()));
 
+	// Set up quantization model
 	for (auto q : Quantizations) {
 		m_quantizeModel.addItem(QString("1/%1").arg(q));
 	}

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -94,9 +94,7 @@ SongEditor::SongEditor( Song * song ) :
 					 : DEFAULT_SETTINGS_WIDGET_WIDTH + TRACK_OP_WIDTH),
 	m_selectRegion(false)
 {
-	m_zoomingModel->setParent(this);
-	m_snappingModel->setParent(this);
-
+	// Set up time line
 	m_timeLine = new TimeLineWidget(m_trackHeadWidth, 32, pixelsPerBar(),
 		m_song->getPlayPos(Song::PlayMode::Song),
 		m_song->getTimeline(Song::PlayMode::Song),
@@ -244,10 +242,15 @@ SongEditor::SongEditor( Song * song ) :
 	connect(contentWidget()->verticalScrollBar(), SIGNAL(valueChanged(int)),this, SLOT(updateRubberband()));
 	connect(m_timeLine, SIGNAL(selectionFinished()), this, SLOT(stopSelectRegion()));
 
-	//zoom connects
+
+	// Set up zooming model
+	m_zoomingModel->setParent(this);
+	m_zoomingModel->setJournalling(false);
 	connect(m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(zoomingChanged()));
 
+
 	// Set up snapping model
+	m_snappingModel->setParent(this);
 	for (float bars : SNAP_SIZES)
 	{
 		if (bars > 1.0f)

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -69,7 +69,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 
 void ComboBox::selectNext()
 {
-	model()->setInitValue( model()->value() + 1 );
+	model()->setValue( model()->value() + 1 );
 }
 
 
@@ -77,7 +77,7 @@ void ComboBox::selectNext()
 
 void ComboBox::selectPrevious()
 {
-	model()->setInitValue( model()->value() - 1 );
+	model()->setValue( model()->value() - 1 );
 }
 
 
@@ -221,7 +221,7 @@ void ComboBox::wheelEvent( QWheelEvent* event )
 	if( model() )
 	{
 		const int direction = (event->angleDelta().y() < 0 ? 1 : -1) * (event->inverted() ? -1 : 1);
-		model()->setInitValue(model()->value() + direction);
+		model()->setValue(model()->value() + direction);
 		update();
 		event->accept();
 	}
@@ -234,7 +234,7 @@ void ComboBox::setItem( QAction* item )
 {
 	if( model() )
 	{
-		model()->setInitValue( item->data().toInt() );
+		model()->setValue( item->data().toInt() );
 	}
 }
 


### PR DESCRIPTION
Zoom, quantization, note length are all added to the undo history. This is driving me absolutely mad.

"But note length isn't undoable" you say. You fool! Have you tried ctrl+shift+scroll?

Comboboxes are not added to the undo history when clicked or scrolled. But if their value is changed from the backend, it becomes undoable. If we don't want comboboxes to be undoable, we should define that in the backend model not the GUI.

You could argue some comboboxes should be undoable, but since they and their child classes are used all over the place, and since they are kind-of-not-undoable at the moment, it's better to stick to that for now and maybe in the future make a PR that defines what comboboxes should be undoable.