### PR TITLE
Fix Auto Resize when Dragging Sample Files onto Sample Clips

### DIFF
--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -179,25 +179,21 @@ void SampleClip::setSampleBuffer(std::shared_ptr<const SampleBuffer> sb)
 
 void SampleClip::setSampleFile(const QString& sf)
 {
-	int length = 0;
-
 	if (!sf.isEmpty())
 	{
 		//Otherwise set it to the sample's length
 		m_sample = Sample(gui::SampleLoader::createBufferFromFile(sf));
-		length = sampleLength();
+		setStartTimeOffset(0);
+		updateLength();
 	}
-
-	if (length == 0)
+	else
 	{
 		//If there is no sample, make the clip a bar long
 		float nom = Engine::getSong()->getTimeSigModel().getNumerator();
 		float den = Engine::getSong()->getTimeSigModel().getDenominator();
-		length = DefaultTicksPerBar * (nom / den);
+		changeLength(DefaultTicksPerBar * (nom / den));
+		setStartTimeOffset(0);
 	}
-
-	changeLength(length);
-	setStartTimeOffset(0);
 
 	emit sampleChanged();
 	emit playbackPositionChanged();

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -181,14 +181,14 @@ void SampleClip::setSampleFile(const QString& sf)
 {
 	if (!sf.isEmpty())
 	{
-		//Otherwise set it to the sample's length
 		m_sample = Sample(gui::SampleLoader::createBufferFromFile(sf));
+		// Remove any prior offset in the clip
 		setStartTimeOffset(0);
 		updateLength();
 	}
 	else
 	{
-		//If there is no sample, make the clip a bar long
+		// If there is no sample, make the clip a bar long
 		float nom = Engine::getSong()->getTimeSigModel().getNumerator();
 		float den = Engine::getSong()->getTimeSigModel().getDenominator();
 		changeLength(DefaultTicksPerBar * (nom / den));

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -179,11 +179,11 @@ void SampleClip::setSampleBuffer(std::shared_ptr<const SampleBuffer> sb)
 
 void SampleClip::setSampleFile(const QString& sf)
 {
+	// Remove any prior offset in the clip
+	setStartTimeOffset(0);
 	if (!sf.isEmpty())
 	{
 		m_sample = Sample(gui::SampleLoader::createBufferFromFile(sf));
-		// Remove any prior offset in the clip
-		setStartTimeOffset(0);
 		updateLength();
 	}
 	else
@@ -192,7 +192,6 @@ void SampleClip::setSampleFile(const QString& sf)
 		float nom = Engine::getSong()->getTimeSigModel().getNumerator();
 		float den = Engine::getSong()->getTimeSigModel().getDenominator();
 		changeLength(DefaultTicksPerBar * (nom / den));
-		setStartTimeOffset(0);
 	}
 
 	emit sampleChanged();


### PR DESCRIPTION
Currently, when you drag and drop a sample from the side bar onto an existing sample clip, the length of the clip will expand/decrease to the length of the sample, regardless of whether auto-resize is enabled in the clip.

This PR changes it so that only clips with auto-resize enabled will be automatically resized to the clip length. Non-auto-resize clips will keep their original length, but still update so that their start time offset is 0.