### PR TITLE
Add Info TextFloat for Piano Roll Knife Tool

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2171,6 +2171,10 @@ void PianoRoll::setKnifeAction()
 		m_knifeDown = false;
 		setCursor(Qt::ArrowCursor);
 		update();
+
+		TextFloat::displayMessage(tr("Knife Tool"),
+			tr("Click and drag over notes to cut along a line\nHold Shift to automatically remove short ends"),
+			embed::getIconPixmap("edit_knife"), 4000);
 	}
 }
 


### PR DESCRIPTION
This PR adds an informational `TextFloat` to inform users that you can use Shift to cut off the short ends of the notes after the cut.

The `TextFloat` appears when you enter knife mode, and lasts for 4 seconds.

![image](https://github.com/user-attachments/assets/73f5dd32-3955-49c0-b633-0a62d003e8e9)
