### PR TITLE
Remove m_resizable from Clips

### DIFF
--- a/include/Clip.h
+++ b/include/Clip.h
@@ -99,6 +99,7 @@ public:
 
 	bool isInPattern() const;
 
+	bool manuallyResizable() const;
 
 	/*! \brief Set whether a clip has been resized yet by the user or the knife tool.
 	 *

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -95,6 +95,8 @@ public:
 	}
 
 
+	bool hasTrackContainer() const;
+
 	bool isInPattern() const;
 
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -94,21 +94,6 @@ public:
 		return m_length;
 	}
 
-	/*! \brief Specify whether or not a TCO automatically resizes.
-	 *
-	 *  If a TCO does automatically resize, it cannot be manually
-	 *  resized by clicking and dragging its edge.
-	 *
-	 */
-	inline void setResizable( const bool r )
-	{
-		m_resizable = r;
-	}
-
-	inline const bool getResizable() const
-	{
-		return m_resizable;
-	}
 
 	/*! \brief Set whether a clip has been resized yet by the user or the knife tool.
 	 *
@@ -183,7 +168,6 @@ private:
 
 	BoolModel m_mutedModel;
 	BoolModel m_soloModel;
-	bool m_resizable = true;
 	bool m_autoResize = true;
 
 	bool m_selectViewOnCreate;

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -95,6 +95,9 @@ public:
 	}
 
 
+	bool isInPattern() const;
+
+
 	/*! \brief Set whether a clip has been resized yet by the user or the knife tool.
 	 *
 	 *  If a clip has been resized previously, it will not automatically 

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -60,21 +60,6 @@ AutomationClip::AutomationClip( AutomationTrack * _auto_track ) :
 	m_lastRecordedValue( 0 )
 {
 	changeLength( TimePos( 1, 0 ) );
-	if( getTrack() )
-	{
-		switch( getTrack()->trackContainer()->type() )
-		{
-			case TrackContainer::Type::Pattern:
-				setResizable(false);
-				break;
-
-			case TrackContainer::Type::Song:
-				// move down
-			default:
-				setResizable(true);
-				break;
-		}
-	}
 }
 
 
@@ -104,19 +89,6 @@ AutomationClip::AutomationClip( const AutomationClip & _clip_to_copy ) :
 		m_timeMap[POS(it)] = it.value();
 		// Sets the node's clip to this one
 		m_timeMap[POS(it)].setClip(this);
-	}
-	if (!getTrack()){ return; }
-	switch( getTrack()->trackContainer()->type() )
-	{
-		case TrackContainer::Type::Pattern:
-			setResizable(false);
-			break;
-
-		case TrackContainer::Type::Song:
-			// move down
-		default:
-			setResizable(true);
-			break;
 	}
 }
 

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -174,11 +174,14 @@ void Clip::copyStateTo( Clip *src, Clip *dst )
 	}
 }
 
+bool Clip::hasTrackContainer() const
+{
+	return getTrack() != nullptr && getTrack()->trackContainer() != nullptr;
+}
 
 bool Clip::isInPattern() const
 {
-	return getTrack() != nullptr
-		&& getTrack()->trackContainer() != nullptr
+	return hasTrackContainer()
 		&& getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern;
 }
 

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -185,6 +185,11 @@ bool Clip::isInPattern() const
 		&& getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern;
 }
 
+bool Clip::manuallyResizable() const
+{
+	return !isInPattern();
+}
+
 
 
 /*! \brief Mutes this Clip

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -75,7 +75,6 @@ Clip::Clip(const Clip& other):
 	m_length(other.m_length),
 	m_startTimeOffset(other.m_startTimeOffset),
 	m_mutedModel(other.m_mutedModel.value(), this, tr( "Mute" )),
-	m_resizable(other.m_resizable),
 	m_autoResize(other.m_autoResize),
 	m_selectViewOnCreate{other.m_selectViewOnCreate},
 	m_color(other.m_color)

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -31,6 +31,8 @@
 #include "Engine.h"
 #include "GuiApplication.h"
 #include "Song.h"
+#include "Track.h"
+#include "TrackContainer.h"
 
 
 namespace lmms
@@ -172,6 +174,13 @@ void Clip::copyStateTo( Clip *src, Clip *dst )
 	}
 }
 
+
+bool Clip::isInPattern() const
+{
+	return getTrack() != nullptr
+		&& getTrack()->trackContainer() != nullptr
+		&& getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern;
+}
 
 
 

--- a/src/core/PatternClip.cpp
+++ b/src/core/PatternClip.cpp
@@ -45,7 +45,6 @@ PatternClip::PatternClip(Track* track) :
 		changeLength( TimePos( t, 0 ) );
 		restoreJournallingState();
 	}
-	setResizable(true);
 }
 
 void PatternClip::saveSettings(QDomDocument& doc, QDomElement& element)

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -228,7 +228,7 @@ void SampleClip::updateLength()
 {
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || isInPattern())
+	if (getAutoResize() || !manuallyResizable())
 	{
 		changeLength(sampleLength());
 		setStartTimeOffset(0);

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -67,18 +67,6 @@ SampleClip::SampleClip(Track* _track, Sample sample, bool isPlaying)
 	//care about Clip position
 	connect( this, SIGNAL(positionChanged()), this, SLOT(updateTrackClips()));
 
-	switch( getTrack()->trackContainer()->type() )
-	{
-		case TrackContainer::Type::Pattern:
-			setResizable(false);
-			break;
-
-		case TrackContainer::Type::Song:
-			// move down
-		default:
-			setResizable(true);
-			break;
-	}
 	updateTrackClips();
 }
 
@@ -117,18 +105,6 @@ SampleClip::SampleClip(const SampleClip& orig) :
 	//care about Clip position
 	connect( this, SIGNAL(positionChanged()), this, SLOT(updateTrackClips()));
 
-	switch( getTrack()->trackContainer()->type() )
-	{
-		case TrackContainer::Type::Pattern:
-			setResizable(false);
-			break;
-
-		case TrackContainer::Type::Song:
-			// move down
-		default:
-			setResizable(true);
-			break;
-	}
 	updateTrackClips();
 }
 
@@ -252,7 +228,7 @@ void SampleClip::updateLength()
 {
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || !getResizable())
+	if (getAutoResize() || getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern)
 	{
 		changeLength(sampleLength());
 		setStartTimeOffset(0);

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -227,8 +227,7 @@ void SampleClip::setIsPlaying(bool isPlaying)
 void SampleClip::updateLength()
 {
 	// If the clip has already been manually resized, don't automatically resize it.
-	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || !manuallyResizable())
+	if (getAutoResize())
 	{
 		changeLength(sampleLength());
 		setStartTimeOffset(0);

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -228,7 +228,7 @@ void SampleClip::updateLength()
 {
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern)
+	if (getAutoResize() || isInPattern())
 	{
 		changeLength(sampleLength());
 		setStartTimeOffset(0);

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -298,7 +298,7 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 				continue;
 			}
 			TimePos relTime = time - p->startPosition() - p->startTimeOffset();
-			if (p->getResizable()) {
+			if (p->getTrack()->trackContainer()->type() != TrackContainer::Type::Pattern) {
 				relTime = std::min(static_cast<int>(relTime), p->length() - p->startTimeOffset());
 			}
 			float value = p->valueAt(relTime);

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -298,7 +298,7 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 				continue;
 			}
 			TimePos relTime = time - p->startPosition() - p->startTimeOffset();
-			if (p->getTrack()->trackContainer()->type() != TrackContainer::Type::Pattern) {
+			if (!p->isInPattern()) {
 				relTime = std::min(static_cast<int>(relTime), p->length() - p->startTimeOffset());
 			}
 			float value = p->valueAt(relTime);

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -669,7 +669,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 				setInitialPos( me->pos() );
 				setInitialOffsets();
 
-				if (m_clip->getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern && !knifeMode)
+				if (m_clip->isInPattern() && !knifeMode)
 				{	// Always move clips that can't be manually resized
 					m_action = Action::Move;
 					setCursor( Qt::SizeAllCursor );

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -502,7 +502,7 @@ void ClipView::dropEvent( QDropEvent * de )
 void ClipView::updateCursor(QMouseEvent * me)
 {
 	// If we are at the edges, use the resize cursor
-	if (!me->buttons() && m_clip->getResizable() && !isSelected()
+	if (!me->buttons() && m_clip->getTrack()->trackContainer()->type() != TrackContainer::Type::Pattern && !isSelected()
 		&& ((me->x() > width() - RESIZE_GRIP_WIDTH) || (me->x() < RESIZE_GRIP_WIDTH)))
 	{
 		setCursor(Qt::SizeHorCursor);
@@ -669,7 +669,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 				setInitialPos( me->pos() );
 				setInitialOffsets();
 
-				if (!m_clip->getResizable() && !knifeMode)
+				if (m_clip->getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern && !knifeMode)
 				{	// Always move clips that can't be manually resized
 					m_action = Action::Move;
 					setCursor( Qt::SizeAllCursor );

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -502,7 +502,7 @@ void ClipView::dropEvent( QDropEvent * de )
 void ClipView::updateCursor(QMouseEvent * me)
 {
 	// If we are at the edges, use the resize cursor
-	if (!me->buttons() && m_clip->getTrack()->trackContainer()->type() != TrackContainer::Type::Pattern && !isSelected()
+	if (!me->buttons() && !m_clip->isInPattern() && !isSelected()
 		&& ((me->x() > width() - RESIZE_GRIP_WIDTH) || (me->x() < RESIZE_GRIP_WIDTH)))
 	{
 		setCursor(Qt::SizeHorCursor);

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -502,7 +502,7 @@ void ClipView::dropEvent( QDropEvent * de )
 void ClipView::updateCursor(QMouseEvent * me)
 {
 	// If we are at the edges, use the resize cursor
-	if (!me->buttons() && !m_clip->isInPattern() && !isSelected()
+	if (!me->buttons() && m_clip->manuallyResizable() && !isSelected()
 		&& ((me->x() > width() - RESIZE_GRIP_WIDTH) || (me->x() < RESIZE_GRIP_WIDTH)))
 	{
 		setCursor(Qt::SizeHorCursor);
@@ -669,7 +669,7 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 				setInitialPos( me->pos() );
 				setInitialOffsets();
 
-				if (m_clip->isInPattern() && !knifeMode)
+				if (!m_clip->manuallyResizable() && !knifeMode)
 				{	// Always move clips that can't be manually resized
 					m_action = Action::Move;
 					setCursor( Qt::SizeAllCursor );

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -132,9 +132,8 @@ void MidiClip::updateLength()
 		return;
 	}
 
-	// If the clip has already been manually resized, don't automatically resize it.
-	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || !manuallyResizable())
+	// If the clip hasn't already been manually resized, automatically resize it.
+	if (getAutoResize())
 	{
 		tick_t max_length = TimePos::ticksPerBar();
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -48,11 +48,6 @@ MidiClip::MidiClip( InstrumentTrack * _instrument_track ) :
 	if (_instrument_track->trackContainer()	== Engine::patternStore())
 	{
 		resizeToFirstTrack();
-		setResizable(false);
-	}
-	else
-	{
-		setResizable(true);
 	}
 	init();
 }
@@ -72,18 +67,6 @@ MidiClip::MidiClip( const MidiClip& other ) :
 	}
 
 	init();
-	switch( getTrack()->trackContainer()->type() )
-	{
-		case TrackContainer::Type::Pattern:
-			setResizable(false);
-			break;
-
-		case TrackContainer::Type::Song:
-			// move down
-		default:
-			setResizable(true);
-			break;
-	}
 }
 
 
@@ -151,7 +134,7 @@ void MidiClip::updateLength()
 
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || !getResizable())
+	if (getAutoResize() || getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern)
 	{
 		tick_t max_length = TimePos::ticksPerBar();
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -134,7 +134,7 @@ void MidiClip::updateLength()
 
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || getTrack()->trackContainer()->type() == TrackContainer::Type::Pattern)
+	if (getAutoResize() || isInPattern())
 	{
 		tick_t max_length = TimePos::ticksPerBar();
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -134,7 +134,7 @@ void MidiClip::updateLength()
 
 	// If the clip has already been manually resized, don't automatically resize it.
 	// Unless we are in a pattern, where you can't resize stuff manually
-	if (getAutoResize() || isInPattern())
+	if (getAutoResize() || !manuallyResizable())
 	{
 		tick_t max_length = TimePos::ticksPerBar();
 


### PR DESCRIPTION
I saw on the discord how there was confusion regarding the difference between `Clip::getAutoResize` and `Clip::getResizable`, and the commends surrounding those functions were not helpful. But saker pointed out that it would be simple to just remove the `m_resizable` property all together, since the only function is serves is to distinguish whether the clip is within a pattern or not.

If you guys are planning a larger clip/track refactor and this PR would get in the way, let me know and I can close this one.