### PR TITLE
Note editing shortcut changes

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4965,7 +4965,6 @@ PianoRollWindow::PianoRollWindow() :
 
 	drawAction->setShortcut(combine(Qt::SHIFT, Qt::Key_D));
 	eraseAction->setShortcut(combine(Qt::SHIFT, Qt::Key_E));
-	selectAction->setShortcut(combine(Qt::SHIFT, Qt::Key_S));
 	pitchBendAction->setShortcut(combine(Qt::SHIFT, Qt::Key_T));
 
 	connect( editModeGroup, SIGNAL(triggered(int)), m_editor, SLOT(setEditMode(int)));
@@ -5056,7 +5055,7 @@ PianoRollWindow::PianoRollWindow() :
 
 	auto strumAction = new QAction(embed::getIconPixmap("arp_free"), tr("Strum"), noteToolsButton);
 	connect(strumAction, &QAction::triggered, m_editor, &PianoRoll::setStrumAction);
-	strumAction->setShortcut(combine(Qt::SHIFT, Qt::Key_J));
+	strumAction->setShortcut(combine(Qt::SHIFT, Qt::Key_S));
 
 	auto fillAction = new QAction(embed::getIconPixmap("fill"), tr("Fill"), noteToolsButton);
 	connect(fillAction, &QAction::triggered, [this](){ m_editor->fitNoteLengths(true); });
@@ -5075,9 +5074,10 @@ PianoRollWindow::PianoRollWindow() :
 	auto reverseAction = new QAction(embed::getIconPixmap("flip_x"), tr("Reverse"), noteToolsButton);
 	connect(reverseAction, &QAction::triggered, [this](){ m_editor->reverseNotes(); });
 	reverseAction->setShortcut(combine(Qt::CTRL, Qt::SHIFT, Qt::Key_R));
-
+	// Editing tools
 	noteToolsButton->addAction(knifeAction);
 	noteToolsButton->addAction(strumAction);
+	// Instant actions
 	noteToolsButton->addAction(glueAction);
 	noteToolsButton->addAction(fillAction);
 	noteToolsButton->addAction(cutOverlapsAction);


### PR DESCRIPTION
## Shift+X for knife

![bild](https://github.com/user-attachments/assets/3f2b65cb-9aba-4458-b347-885109b53e46)

## Ctrl+Shift+KEY for instant actions

When switching tool with Shift+KEY it's easy to accidentally press wrong and cause harm to notes outside the visible area without realizing it. So I changed the shortcuts for actions with an instant effect to Ctrl+Shift+KEY. Also rearranged the menu accordingly.

![bild](https://github.com/user-attachments/assets/2654c3e5-91cc-4950-9232-4ee45d53d1c3)

## Shift+S for strum

Select doesn't need Shift+S as shortcut. If you can press Shift+S you can press Control.