### PR TITLE
Update clip length after clearing all notes

### DIFF
--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -288,6 +288,7 @@ void MidiClip::clearNotes()
 	instrumentTrack()->unlock();
 
 	checkType();
+	updateLength();
 	emit dataChanged();
 }
 


### PR DESCRIPTION
Fixes this issue:

When clearing notes from a long melody clip in pattern editor, it looks like the clip becomes short, but it actually remains the same length (despite empty), and that affects the length of the whole pattern.