### PR TITLE
Vestige: resize on IdVstPluginEditorGeometry

### DIFF
--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -426,7 +426,14 @@ bool VstPlugin::processMessage( const message & _m )
 	case IdVstPluginEditorGeometry:
 		m_pluginGeometry = QSize( _m.getInt( 0 ),
 								  _m.getInt( 1 ) );
-			break;
+
+		if(m_pluginWidget)
+		{
+			hideUI();
+			m_pluginWidget->setFixedSize( m_pluginGeometry );
+			showUI();
+		}
+		break;
 
 		case IdVstPluginName:
 			m_name = _m.getQString();


### PR DESCRIPTION
Some VST windows are not properly sized (on Windows).
So if the window was already created resize it when the IdVstPluginEditorGeometry message has been received.
Tested on Windows with a couple of free VSTs only, please review. It works for me...

(edited by @tresf)

Before:
![Screenshot - before fix](https://github.com/user-attachments/assets/6e84bf36-0bdc-4c8b-826b-1b79a1ab3637)

After:
![Screenshot - after fix](https://github.com/user-attachments/assets/52620e7b-7c4a-4790-9d9c-93e408baa257)
