### PR TITLE
Fix effect gate logic (that I broke)

### DIFF
--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -190,7 +190,7 @@ void Effect::checkGate(double outSum)
 
 	// Check whether we need to continue processing input.  Restart the
 	// counter if the threshold has been exceeded.
-	if (approximatelyEqual(outSum, gate()))
+	if (outSum - gate() <= F_EPSILON)
 	{
 		incrementBufferCount();
 		if( bufferCount() > timeout() )


### PR DESCRIPTION
In #7696, I mistakenly replaced `signal - threshold <= epsilon` with `abs(signal - threshold) < epsilon`, which made it so that effect gates only silence the signal when it is approximately equal to the threshold, rather than approximately less than or equal to the threshold. This commit rectifies this utter nonsense of a change

> [!NOTE]
> https://github.com/LMMS/lmms/pull/7696#discussion_r2165815823, in which the broken logic is examined 