### PR TITLE
Fix Octave Chord Stacking

### DIFF
--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -135,6 +135,7 @@ private:
 	void upgrade_fixBassLoopsTypo();
 	void findProblematicLadspaPlugins();
 	void upgrade_noHiddenAutomationTracks();
+	void upgrade_octaveChordStacking();
 
 	// List of all upgrade methods
 	static const std::vector<UpgradeMethod> UPGRADE_METHODS;

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -1961,7 +1961,7 @@ void DataFile::upgrade_octaveChordStacking()
 		// 1 is the index of the octave chord
 		if (e.attribute("chord").toInt() == 0)
 		{
-			e.setAttribute("chordrange", std::max(0, e.attribute("chordrange").toInt() - 1));
+			e.setAttribute("chordrange", std::max(1, e.attribute("chordrange").toInt() - 1));
 		}
 	}
 }

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -41,7 +41,7 @@ std::array<InstrumentFunctionNoteStacking::ChordTable::Init, InstrumentFunctionN
 	InstrumentFunctionNoteStacking::ChordTable::s_initTable =
 	std::array<InstrumentFunctionNoteStacking::ChordTable::Init, NUM_CHORD_TABLES>
 {{
-	{ QT_TRANSLATE_NOOP( "InstrumentFunctionNoteStacking", "octave" ), { 0, -1 } },
+	{ QT_TRANSLATE_NOOP( "InstrumentFunctionNoteStacking", "octave" ), { 0, 12, -1 } },
 	{ QT_TRANSLATE_NOOP( "InstrumentFunctionNoteStacking", "Major" ), { 0, 4, 7, -1 } },
 	{ QT_TRANSLATE_NOOP( "InstrumentFunctionNoteStacking", "Majb5" ), { 0, 4, 6, -1 } },
 	{ QT_TRANSLATE_NOOP( "InstrumentFunctionNoteStacking", "minor" ), { 0, 3, 7, -1 } },
@@ -244,6 +244,8 @@ void InstrumentFunctionNoteStacking::processNote( NotePlayHandle * _n )
 		// then insert sub-notes for chord
 		const int selected_chord = m_chordsModel.value();
 
+		std::vector<int> playedKeys;
+
 		for( int octave_cnt = 0; octave_cnt < m_chordRangeModel.value(); ++octave_cnt )
 		{
 			const int sub_note_key_base = base_note_key + octave_cnt * KeysPerOctave;
@@ -253,6 +255,8 @@ void InstrumentFunctionNoteStacking::processNote( NotePlayHandle * _n )
 			{
 				// add interval to sub-note-key
 				const int sub_note_key = sub_note_key_base + (int) chord_table.chords()[selected_chord][i];
+				// If we've already played the note, don't double-play it! (like when stacking octave chords)
+				if (std::find(playedKeys.begin(), playedKeys.end(), sub_note_key) != playedKeys.end()) { continue; }
 				// maybe we're out of range -> let's get outta
 				// here!
 				if( sub_note_key > NumKeys )
@@ -261,6 +265,7 @@ void InstrumentFunctionNoteStacking::processNote( NotePlayHandle * _n )
 				}
 				// create copy of base-note
 				Note note_copy( _n->length(), 0, sub_note_key, _n->getVolume(), _n->getPanning(), _n->detuning() );
+				playedKeys.push_back(sub_note_key);
 
 				// create sub-note-play-handle, only note is
 				// different


### PR DESCRIPTION
Previously, the "octave" chord feature didn't do anything. If you went into the piano roll, set the chord to "octave", and placed a note, it only placed a single note, not an octave.

Similarly, if you enabled chord stacking on an instrument, set the chord to "octave", and set the range to 1, it only played a single not, not a whole octave. You would have to increase the range to 2 in order to get an octave.

This PR fixes the issue by correctly defining the octave chord as having the semitones 0 and 12, instead of just 0.

### But wait! Doesn't that mean that if you do chord stacking of multiple octaves, the root notes will overlap?

Yes! I had to add a check so that we don't double-count any notes.

### But wait again! Won't this break old projects which coped with the bug by setting the chord `range` to be +1 more?

Yes, I also had to add an upgrade routine to decrement the chord stack range for each instrument if and only if it's using an octave chord. So if you were relying on setting the chord range to 2 to play one octave, it will automatically go down to 1 and sound exactly the same.



## Potential issues

- If you automated the chord stack range with the octave chord, this upgrade routine will not fix it.
- If you had the chord range set to 1 with octave (which previously would do nothing), then the upgrade routine can't decrement it any further, so it will remain at 1, and unless you disable chord stacking, it will now play an octave.

I am not aware of how often users do these sorts of things. Are these potential issues serious enough that we should reconsider? Should we work around the odd nature of octave chord stacking and somehow only fix it in the piano roll, not chord stacking? Should we just leave the bug all together?