### PR TITLE
Fix Octave Chord in Piano Roll Only

### DIFF
--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -140,6 +140,7 @@ public:
 			static ChordTable inst;
 			return inst;
 		}
+		static Chord s_alternativeOctave;
 
 		const Chord & getByName( const QString & name, bool is_scale = false ) const;
 

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -146,6 +146,11 @@ std::array<InstrumentFunctionNoteStacking::ChordTable::Init, InstrumentFunctionN
 }};
 
 
+// Because the octave chord is actually just a single note, not a true octave, we have to redefine it here.
+// Ideally this would be fixed by actually changing the octave chord definition, but that would require some
+// very extensive upgrade routines due to how instrument chord stacking and arpeggiation use it.
+InstrumentFunctionNoteStacking::Chord InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave = InstrumentFunctionNoteStacking::Chord(QT_TRANSLATE_NOOP("InstrumentFunctionNoteStacking", "octave"), {0, 12, -1});
+
 
 
 InstrumentFunctionNoteStacking::Chord::Chord( const char * n, const ChordSemiTones & semi_tones ) :

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -551,8 +551,12 @@ void PianoRoll::markSemiTone(SemiToneMarkerAction i, bool fromMenu)
 		{
 			if( ! chord )
 			{
-				chord = & InstrumentFunctionNoteStacking::ChordTable::getInstance()
-						.getChordByName( m_chordModel.currentText() );
+				// Because the octave chord is actually just a single note not a true octave, we have to redefine it here.
+				// Ideally this would be fixed by actually changing the octave chord definition, but that would require some
+				// very extensive upgrade routines due to how instrument chord stacking and arpeggiation use it.
+				chord = m_chordModel.currentText() == "octave"
+					? &InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave
+					: &InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(m_chordModel.currentText());
 			}
 
 			if( chord->isEmpty() )
@@ -1794,8 +1798,10 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 					new_note.setVolume( m_lastNoteVolume );
 					created_new_note = m_midiClip->addNote( new_note );
 
-					const InstrumentFunctionNoteStacking::Chord & chord = InstrumentFunctionNoteStacking::ChordTable::getInstance()
-						.getChordByName( m_chordModel.currentText() );
+					// Unfortunately, because the defined octave chord is actually just a single note, not a true octave, we have to use an alternative version which has both notes
+					const InstrumentFunctionNoteStacking::Chord& chord = m_chordModel.currentText() == "octave"
+						? InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave
+						: InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(m_chordModel.currentText());
 
 					if( ! chord.isEmpty() )
 					{
@@ -2133,9 +2139,10 @@ void PianoRoll::playChordNotes(int key, int velocity)
 {
 	// if a chord is set, play the chords notes beside the base note.
 	Piano *pianoModel = m_midiClip->instrumentTrack()->pianoModel();
-	const InstrumentFunctionNoteStacking::Chord & chord =
-			InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(
-				m_chordModel.currentText());
+	// Unfortunately, because the defined octave chord is actually just a single note, not a true octave, we have to use an alternative version which has both notes
+	const InstrumentFunctionNoteStacking::Chord& chord = m_chordModel.currentText() == "octave"
+		? InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave
+		: InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(m_chordModel.currentText());
 	if (!chord.isEmpty())
 	{
 		for (int i = 1; i < chord.size(); ++i)
@@ -2149,9 +2156,10 @@ void PianoRoll::pauseChordNotes(int key)
 {
 	// if a chord was set, stop the chords notes beside the base note.
 	Piano *pianoModel = m_midiClip->instrumentTrack()->pianoModel();
-	const InstrumentFunctionNoteStacking::Chord & chord =
-			InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(
-				m_chordModel.currentText());
+	// Unfortunately, because the defined octave chord is actually just a single note, not a true octave, we have to use an alternative version which has both notes
+	const InstrumentFunctionNoteStacking::Chord& chord = m_chordModel.currentText() == "octave"
+		? InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave
+		: InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(m_chordModel.currentText());
 	if (!chord.isEmpty())
 	{
 		for (int i = 1; i < chord.size(); ++i)
@@ -4866,8 +4874,10 @@ void PianoRoll::updateSemiToneMarkerMenu()
 			InstrumentFunctionNoteStacking::ChordTable::getInstance();
 	const InstrumentFunctionNoteStacking::Chord& scale =
 			chord_table.getScaleByName( m_scaleModel.currentText() );
-	const InstrumentFunctionNoteStacking::Chord& chord =
-			chord_table.getChordByName( m_chordModel.currentText() );
+	// Unfortunately, because the defined octave chord is actually just a single note, not a true octave, we have to use an alternative version which has both notes
+	const InstrumentFunctionNoteStacking::Chord& chord = m_chordModel.currentText() == "octave"
+		? InstrumentFunctionNoteStacking::ChordTable::s_alternativeOctave
+		: InstrumentFunctionNoteStacking::ChordTable::getInstance().getChordByName(m_chordModel.currentText());
 
 	emit semiToneMarkerMenuScaleSetEnabled( ! scale.isEmpty() );
 	emit semiToneMarkerMenuChordSetEnabled( ! chord.isEmpty() );


### PR DESCRIPTION
A few hours ago, I made a PR #7973 which fixed this issue by fixing how the octave chord was defined. However, that resulted in the need for some serious upgrade routines and impacts to user experience. You can read more about the problem in that PR's description

This PR instead does the simple and easy solution of only fixing the problem with the piano roll, not with chord stacking or arpeggiation. I defined a new octave chord which contains both notes, checked if the current chord is an octave, and if so used that one instead of the normal octave.