### PR TITLE
Fixed missing emails in the author section. 

### DIFF
--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -88,7 +88,7 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	maker_content->setText(makerString);
 	maker_content->setWordWrap( true );
 	l->addWidget( maker_label );
-	l->addWidget( maker_content);
+	l->addWidget(maker_content);
 	
 
 	auto copyright = new QWidget(_parent);

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -62,76 +62,55 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 {
 	const ladspa_key_t & lkey = subPluginKeyToLadspaKey( _key );
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
+	const auto ldesc = lm->getDescription(lkey);
 
-	auto label = new QLabel(_parent);
-	label->setText( QWidget::tr( "Name: " ) + lm->getName( lkey ) );
+	QString labelText =
+		"<p><b>" + QWidget::tr("Name") + ":</b> " + lm->getName(lkey) + "</p>"
+		"<p><b>" + QWidget::tr("File") + ":</b> <code>" + lkey.first + "</code></p>"
+		"<p><b>" + QWidget::tr("Author") + ":</b> "
+			+ lm->getMaker(lkey)
+				.replace(" at ", "@")
+				.replace(" dot ", ".")
+				.toHtmlEscaped()
+			+ "</p>"
+		"<p><b>" + QWidget::tr("Copyright") + ":</b> " + lm->getCopyright(lkey) + "</p>"
+		"<p><b>" + QWidget::tr("Channels") + ":</b> "
+			+ QString::number(ldesc->inputChannels) + " " + QWidget::tr("in") + ", "
+			+ QString::number(ldesc->outputChannels) + " " + QWidget::tr("out")
+			+ "</p>";
 
-	auto fileInfo = new QLabel(_parent);
-	fileInfo->setText( QWidget::tr( "File: %1" ).arg( lkey.first ) );
+	if (lm->hasRealTimeDependency(lkey))
+	{
+		labelText += "<p><b>" + QWidget::tr("Real-time Dependency")
+			+ ":</b> " + QWidget::tr(
+				"This plugin has a real-time dependency (e.g. listens "
+				"to a MIDI device) so its output must not be cached or "
+				"subject to significant latency."
+			) + "</p>";
+	}
 
-	auto maker = new QWidget(_parent);
-	auto l = new QHBoxLayout(maker);
-	l->setContentsMargins(0, 0, 0, 0);
-	l->setSpacing( 0 );
+	if (lm->isRealTimeCapable(lkey))
+	{
+		labelText += "<p><b>" + QWidget::tr("Real-time Capable")
+			+ ":</b> " + QWidget::tr(
+				"This plugin is capable of running in a &lsquo;hard "
+				"real-time&rsquo; environment."
+			) + "</p>";
+	}
 
-	auto maker_label = new QLabel(maker);
-	maker_label->setText( QWidget::tr( "Maker: " ) );
-	maker_label->setAlignment( Qt::AlignTop );
-	auto maker_content = new QLabel(maker);
+	if (lm->isInplaceBroken(lkey))
+	{
+		labelText += "<p><b>" + QWidget::tr("In-place Broken")
+			+ ":</b> " + QWidget::tr(
+				"This plugin cannot process audio &lsquo;in "
+				"place&rsquo; and may cease to work correctly if the "
+				"host elects to use the same data location for both "
+				"input and output."
+			) + "</p>";
+	}
 
-	auto makerString = lm->getMaker(lkey);
-
-	makerString.replace(" at ", "@");
-	makerString.replace(" dot ", ".");
-
-	maker_content->setTextFormat(Qt::PlainText);
-	maker_content->setText(makerString);
-	maker_content->setWordWrap( true );
-	l->addWidget( maker_label );
-	l->addWidget(maker_content);
-	
-
-	auto copyright = new QWidget(_parent);
-	l = new QHBoxLayout( copyright );
-	l->setContentsMargins(0, 0, 0, 0);
-	l->setSpacing( 0 );
-
-	copyright->setMinimumWidth( _parent->minimumWidth() );
-	auto copyright_label = new QLabel(copyright);
-	copyright_label->setText( QWidget::tr( "Copyright: " ) );
-	copyright_label->setAlignment( Qt::AlignTop );
-
-	auto copyright_content = new QLabel(copyright);
-	copyright_content->setText( lm->getCopyright( lkey ) );
-	copyright_content->setWordWrap( true );
-	l->addWidget( copyright_label );
-	l->addWidget( copyright_content, 1 );
-
-	auto requiresRealTime = new QLabel(_parent);
-	requiresRealTime->setText( QWidget::tr( "Requires Real Time: " ) +
-					( lm->hasRealTimeDependency( lkey ) ?
-							QWidget::tr( "Yes" ) :
-							QWidget::tr( "No" ) ) );
-
-	auto realTimeCapable = new QLabel(_parent);
-	realTimeCapable->setText( QWidget::tr( "Real Time Capable: " ) +
-					( lm->isRealTimeCapable( lkey ) ?
-							QWidget::tr( "Yes" ) :
-							QWidget::tr( "No" ) ) );
-
-	auto inplaceBroken = new QLabel(_parent);
-	inplaceBroken->setText( QWidget::tr( "In Place Broken: " ) +
-					( lm->isInplaceBroken( lkey ) ?
-							QWidget::tr( "Yes" ) :
-							QWidget::tr( "No" ) ) );
-
-	auto channelsIn = new QLabel(_parent);
-	channelsIn->setText( QWidget::tr( "Channels In: " ) +
-		QString::number( lm->getDescription( lkey )->inputChannels ) );
-
-	auto channelsOut = new QLabel(_parent);
-	channelsOut->setText( QWidget::tr( "Channels Out: " ) +
-		QString::number( lm->getDescription( lkey )->outputChannels ) );	
+	auto label = new QLabel(labelText, _parent);
+	label->setWordWrap(true);
 }
 
 

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -95,15 +95,6 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 		);
 	}
 
-	if (lm->isInplaceBroken(lkey))
-	{
-		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
-			QWidget::tr("In-place Broken: "),
-			QWidget::tr("This plugin cannot process audio &lsquo;in place&rsquo; and may cease to work correctly if "
-				"the host elects to use the same data location for both input and output.")
-		);
-	}
-
 	auto label = new QLabel(labelText, _parent);
 	label->setWordWrap(true);
 }

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -64,49 +64,44 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
 	const auto ldesc = lm->getDescription(lkey);
 
-	QString labelText =
-		"<p><b>" + QWidget::tr("Name") + ":</b> " + lm->getName(lkey) + "</p>"
-		"<p><b>" + QWidget::tr("File") + ":</b> <code>" + lkey.first + "</code></p>"
-		"<p><b>" + QWidget::tr("Author") + ":</b> "
-			+ lm->getMaker(lkey)
-				.replace(" at ", "@")
-				.replace(" dot ", ".")
-				.toHtmlEscaped()
-			+ "</p>"
-		"<p><b>" + QWidget::tr("Copyright") + ":</b> " + lm->getCopyright(lkey) + "</p>"
-		"<p><b>" + QWidget::tr("Channels") + ":</b> "
-			+ QString::number(ldesc->inputChannels) + " " + QWidget::tr("in") + ", "
-			+ QString::number(ldesc->outputChannels) + " " + QWidget::tr("out")
-			+ "</p>";
+	auto labelText = QString{
+		"<p><b>%1</b>%2</p>" // Name
+		"<p><b>%3</b><code>%4</code></p>" // File
+		"<p><b>%5</b>%6</p>" // Author
+		"<p><b>%7</b>%8</p>" // Copyright
+		"<p><b>%9</b>%10</p>" // Channels
+	}.arg(
+		QWidget::tr("Name: "), lm->getName(lkey),
+		QWidget::tr("File: "), lkey.first,
+		QWidget::tr("Author: "), lm->getMaker(lkey).replace(" at ", "@").replace(" dot ", ".").toHtmlEscaped(),
+		QWidget::tr("Copyright: "), lm->getCopyright(lkey),
+		QWidget::tr("Channels: "), QWidget::tr("%1 in, %2 out").arg(ldesc->inputChannels).arg(ldesc->outputChannels)
+	);
 
 	if (lm->hasRealTimeDependency(lkey))
 	{
-		labelText += "<p><b>" + QWidget::tr("Real-time Dependency")
-			+ ":</b> " + QWidget::tr(
-				"This plugin has a real-time dependency (e.g. listens "
-				"to a MIDI device) so its output must not be cached or "
-				"subject to significant latency."
-			) + "</p>";
+		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
+			QWidget::tr("Real-time Dependency: "),
+			QWidget::tr("This plugin has a real-time dependency (e.g. listens to a MIDI device) so its output must "
+				"not be cached or subject to significant latency.")
+		);
 	}
 
-	if (lm->isRealTimeCapable(lkey))
+	if (!lm->isRealTimeCapable(lkey))
 	{
-		labelText += "<p><b>" + QWidget::tr("Real-time Capable")
-			+ ":</b> " + QWidget::tr(
-				"This plugin is capable of running in a &lsquo;hard "
-				"real-time&rsquo; environment."
-			) + "</p>";
+		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
+			QWidget::tr("Not Real-time Capable: "),
+			QWidget::tr("This plugin is not suitable for use in a &lsquo;hard real-time&rsquo; environment.")
+		);
 	}
 
 	if (lm->isInplaceBroken(lkey))
 	{
-		labelText += "<p><b>" + QWidget::tr("In-place Broken")
-			+ ":</b> " + QWidget::tr(
-				"This plugin cannot process audio &lsquo;in "
-				"place&rsquo; and may cease to work correctly if the "
-				"host elects to use the same data location for both "
-				"input and output."
-			) + "</p>";
+		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
+			QWidget::tr("In-place Broken: "),
+			QWidget::tr("This plugin cannot process audio &lsquo;in place&rsquo; and may cease to work correctly if "
+				"the host elects to use the same data location for both input and output.")
+		);
 	}
 
 	auto label = new QLabel(labelText, _parent);

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -78,10 +78,19 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	maker_label->setText( QWidget::tr( "Maker: " ) );
 	maker_label->setAlignment( Qt::AlignTop );
 	auto maker_content = new QLabel(maker);
-	maker_content->setText( lm->getMaker( lkey ) );
+
+	auto makerString = lm->getMaker(lkey).toHtmlEscaped();
+
+	makerString.replace("&lt;", "<");
+	makerString.replace("&gt;", ">");
+	makerString.replace("&amp;", "&");
+
+	maker_content->setTextFormat(Qt::PlainText);
+	maker_content->setText(makerString);
 	maker_content->setWordWrap( true );
 	l->addWidget( maker_label );
-	l->addWidget( maker_content, 1 );
+	l->addWidget( maker_content);
+	
 
 	auto copyright = new QWidget(_parent);
 	l = new QHBoxLayout( copyright );

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -35,9 +35,6 @@
 #include "Ladspa2LMMS.h"
 #include "LadspaBase.h"
 
-#include <QDebug>
-#include <typeinfo>
-
 namespace lmms
 {
 

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -79,25 +79,10 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	maker_label->setAlignment( Qt::AlignTop );
 	auto maker_content = new QLabel(maker);
 
-	auto makerString = lm->getMaker(lkey).toHtmlEscaped();
+	auto makerString = lm->getMaker(lkey);
 
-	makerString.replace("&lt;", "<");
-	makerString.replace("&gt;", ">");
-	makerString.replace("&amp;", "&");
-
-	if (makerString.contains("Andy Wingo"))
-	{
-		int startString = makerString.indexOf("<");
-		int endString = makerString.indexOf(">");
-		makerString.replace(startString + 1, endString - startString - 1, "wingo@pobox.com");
-	}
-	
-	if (makerString.contains("Jesse Chappel"))
-	{
-		int startString = makerString.indexOf("<");
-		int endString = makerString.indexOf(">");
-		makerString.replace(startString + 1, endString - startString - 1, "jesse@essej.net");
-	}
+	makerString.replace(" at ", "@");
+	makerString.replace(" dot ", ".");
 
 	maker_content->setTextFormat(Qt::PlainText);
 	maker_content->setText(makerString);

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -35,6 +35,9 @@
 #include "Ladspa2LMMS.h"
 #include "LadspaBase.h"
 
+#include <QDebug>
+#include <typeinfo>
+
 namespace lmms
 {
 
@@ -84,6 +87,20 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	makerString.replace("&lt;", "<");
 	makerString.replace("&gt;", ">");
 	makerString.replace("&amp;", "&");
+
+	if (makerString.contains("Andy Wingo"))
+	{
+		int startString = makerString.indexOf("<");
+		int endString = makerString.indexOf(">");
+		makerString.replace(startString + 1, endString - startString - 1, "wingo@pobox.com");
+	}
+	
+	if (makerString.contains("Jesse Chappel"))
+	{
+		int startString = makerString.indexOf("<");
+		int endString = makerString.indexOf(">");
+		makerString.replace(startString + 1, endString - startString - 1, "jesse@essej.net");
+	}
 
 	maker_content->setTextFormat(Qt::PlainText);
 	maker_content->setText(makerString);

--- a/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
+++ b/plugins/LadspaEffect/LadspaSubPluginFeatures.cpp
@@ -64,24 +64,26 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 	Ladspa2LMMS * lm = Engine::getLADSPAManager();
 	const auto ldesc = lm->getDescription(lkey);
 
+	// HACK: Markup inside translation strings due to RTL not being handled correctly.
+	// Move the markup out of the translation strings and into the QString template as soon as RTL layout works properly
 	auto labelText = QString{
-		"<p><b>%1</b>%2</p>" // Name
-		"<p><b>%3</b><code>%4</code></p>" // File
-		"<p><b>%5</b>%6</p>" // Author
-		"<p><b>%7</b>%8</p>" // Copyright
-		"<p><b>%9</b>%10</p>" // Channels
+		"<p>%1%2</p>" // Name
+		"<p>%3<code>%4</code></p>" // File
+		"<p>%5%6</p>" // Author
+		"<p>%7%8</p>" // Copyright
+		"<p>%9%10</p>" // Channels
 	}.arg(
-		QWidget::tr("Name: "), lm->getName(lkey),
-		QWidget::tr("File: "), lkey.first,
-		QWidget::tr("Author: "), lm->getMaker(lkey).replace(" at ", "@").replace(" dot ", ".").toHtmlEscaped(),
-		QWidget::tr("Copyright: "), lm->getCopyright(lkey),
-		QWidget::tr("Channels: "), QWidget::tr("%1 in, %2 out").arg(ldesc->inputChannels).arg(ldesc->outputChannels)
+		QWidget::tr("<b>Name: </b>"), lm->getName(lkey),
+		QWidget::tr("<b>File: </b>"), lkey.first,
+		QWidget::tr("<b>Author: </b>"), lm->getMaker(lkey).replace(" at ", "@").replace(" dot ", ".").toHtmlEscaped(),
+		QWidget::tr("<b>Copyright: </b>"), lm->getCopyright(lkey),
+		QWidget::tr("<b>Channels: </b>"), QWidget::tr("%1 in, %2 out").arg(ldesc->inputChannels).arg(ldesc->outputChannels)
 	);
 
 	if (lm->hasRealTimeDependency(lkey))
 	{
-		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
-			QWidget::tr("Real-time Dependency: "),
+		labelText += QString{"<p>%1%2</p>"}.arg(
+			QWidget::tr("<b>Real-time Dependency: </b>"),
 			QWidget::tr("This plugin has a real-time dependency (e.g. listens to a MIDI device) so its output must "
 				"not be cached or subject to significant latency.")
 		);
@@ -89,8 +91,8 @@ void LadspaSubPluginFeatures::fillDescriptionWidget( QWidget * _parent,
 
 	if (!lm->isRealTimeCapable(lkey))
 	{
-		labelText += QString{"<p><b>%1</b>%2</p>"}.arg(
-			QWidget::tr("Not Real-time Capable: "),
+		labelText += QString{"<p>%1%2</p>"}.arg(
+			QWidget::tr("<b>Not Real-time Capable: </b>"),
 			QWidget::tr("This plugin is not suitable for use in a &lsquo;hard real-time&rsquo; environment.")
 		);
 	}

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -280,7 +280,18 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 			auto label = new QLabel(m_descriptionWidget);
 			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
 			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate("PluginBrowser", descriptor.description) + "</p>";
-			labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author) + "</p>";
+			
+			QString authorString = QString::fromUtf8(descriptor.author).toHtmlEscaped();
+
+			if (authorString.contains("/dot/")){
+				authorString.replace("/dot/", ".");
+			}
+			
+			if (authorString.contains("/at/")){
+				authorString.replace("/at/", "@");
+			}
+
+			labelText += "<p><b>" + tr("Author") + ":</b> " + authorString + "</p>";
 
 			label->setText(labelText);
 			label->setWordWrap(true);

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -278,19 +278,19 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 		}
 		else
 		{
-			auto label = new QLabel(m_descriptionWidget);
-			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
-			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate("PluginBrowser", descriptor.description) + "</p>";
-
-			QString authorString = QString::fromUtf8(descriptor.author).toHtmlEscaped();
-			authorString.replace("/dot/", ".");
-			authorString.replace("/at/", "@");
-
-			labelText += "<p><b>" + tr("Author") + ":</b> " + authorString + "</p>";
-
-			label->setText(labelText);
+			auto labelText = QString{
+				"<p><b>%1</b>%2</p>"
+				"<p><b>%3</b>%4</p>"
+				"<p><b>%5</b>%6</p>"
+			}.arg(
+				tr("Name: "), descriptor.displayName,
+				tr("Description: "), qApp->translate("PluginBrowser", descriptor.description).toHtmlEscaped(),
+				tr("Author: "), QString::fromUtf8(descriptor.author)
+					.replace("/dot/", ".").replace("/at/", "@").toHtmlEscaped()
+			);
+		
+			auto label = new QLabel(labelText, m_descriptionWidget);
 			label->setWordWrap(true);
-
 			textWidgetLayout->addWidget(label);
 		}
 

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -250,6 +250,7 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 		}
 
 		auto textualInfoWidget = new QWidget(m_descriptionWidget);
+		textualInfoWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 		hbox->addWidget(textualInfoWidget);
 
 		auto textWidgetLayout = new QVBoxLayout(textualInfoWidget);

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -280,16 +280,10 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 			auto label = new QLabel(m_descriptionWidget);
 			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
 			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate("PluginBrowser", descriptor.description) + "</p>";
-			
-			QString authorString = QString::fromUtf8(descriptor.author).toHtmlEscaped();
 
-			if (authorString.contains("/dot/")){
-				authorString.replace("/dot/", ".");
-			}
-			
-			if (authorString.contains("/at/")){
-				authorString.replace("/at/", "@");
-			}
+			QString authorString = QString::fromUtf8(descriptor.author).toHtmlEscaped();
+			authorString.replace("/dot/", ".");
+			authorString.replace("/at/", "@");
 
 			labelText += "<p><b>" + tr("Author") + ":</b> " + authorString + "</p>";
 

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -278,14 +278,16 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 		}
 		else
 		{
+			// HACK: Markup inside translation strings due to RTL not being handled correctly.
+			// Move the markup out of the translation strings and into the QString template as soon as RTL layout works properly
 			auto labelText = QString{
-				"<p><b>%1</b>%2</p>"
-				"<p><b>%3</b>%4</p>"
-				"<p><b>%5</b>%6</p>"
+				"<p>%1%2</p>"
+				"<p>%3%4</p>"
+				"<p>%5%6</p>"
 			}.arg(
-				tr("Name: "), descriptor.displayName,
-				tr("Description: "), qApp->translate("PluginBrowser", descriptor.description).toHtmlEscaped(),
-				tr("Author: "), QString::fromUtf8(descriptor.author)
+				tr("<b>Name: </b>"), descriptor.displayName,
+				tr("<b>Description: </b>"), qApp->translate("PluginBrowser", descriptor.description).toHtmlEscaped(),
+				tr("<b>Author: </b>"), QString::fromUtf8(descriptor.author)
 					.replace("/dot/", ".").replace("/at/", "@").toHtmlEscaped()
 			);
 		

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -286,9 +286,10 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 				"<p>%5%6</p>"
 			}.arg(
 				tr("<b>Name: </b>"), descriptor.displayName,
-				tr("<b>Description: </b>"), qApp->translate("PluginBrowser", descriptor.description).toHtmlEscaped(),
 				tr("<b>Author: </b>"), QString::fromUtf8(descriptor.author)
-					.replace("/dot/", ".").replace("/at/", "@").toHtmlEscaped()
+					.replace("/dot/", ".").replace("/at/", "@").toHtmlEscaped(),
+				tr("<b>Description: </b>"), qApp->translate("PluginBrowser", descriptor.description)
+					.toHtmlEscaped()
 			);
 		
 			auto label = new QLabel(labelText, m_descriptionWidget);


### PR DESCRIPTION
As per #7936, here is the attempt in order to fix the missing emails as described. 

Some things to note, most of the email format have the characters `/dot/` and `/at` in them and that they had to be converted to the correct characters of `.` and `@` respectively. 

LADSPA plugins, however, are a different story. Originally, the solution was to manually change the email format but it did not work since it is dependent on the [ladspa](https://github.com/swh/ladspa/tree/0f54d2430febb4d5f02d13132dd91d7345e080b5) repository. Meaning, no changes can be made in , unless that repository is changed. Anyway, some author emails have a, rather, peculiar email format and that they've been manually changed. This case happens for the authors: Andy Wingo and Jesse Chappel. They both have spaces, and they are inconsistent with the other authors' emails present in the `plugins/swh` folder