### PR TITLE
Remove currentPatternChanged slot that does nothing

### DIFF
--- a/include/PatternStore.h
+++ b/include/PatternStore.h
@@ -98,7 +98,6 @@ public slots:
 	void play();
 	void stop();
 	void updateComboBox();
-	void currentPatternChanged();
 
 signals:
 	void trackUpdated();

--- a/src/core/PatternStore.cpp
+++ b/src/core/PatternStore.cpp
@@ -38,12 +38,6 @@ PatternStore::PatternStore() :
 	TrackContainer(),
 	m_patternComboBoxModel(this)
 {
-	connect(&m_patternComboBoxModel, SIGNAL(dataChanged()),
-			this, SLOT(currentPatternChanged()));
-	// we *always* want to receive updates even in case pattern actually did
-	// not change upon setCurrentPattern()-call
-	connect(&m_patternComboBoxModel, SIGNAL(dataUnchanged()),
-			this, SLOT(currentPatternChanged()));
 	setType(Type::Pattern);
 }
 
@@ -208,22 +202,6 @@ void PatternStore::updateComboBox()
 		m_patternComboBoxModel.addItem(pt->name());
 	}
 	setCurrentPattern(curPattern);
-}
-
-
-
-
-void PatternStore::currentPatternChanged()
-{
-	// now update all track-labels (the current one has to become white, the others gray)
-	const TrackList& tl = Engine::getSong()->tracks();
-	for (Track * t : tl)
-	{
-		if (t->type() == Track::Type::Pattern)
-		{
-			t->dataChanged();
-		}
-	}
 }
 
 


### PR DESCRIPTION
The motivation behind this PR is to remove all uses of `AutomatableModel::dataUnchanged` and one of them happens to be this obsolete piece of code...

------

When the user opens a pattern track in the editor, `PatternStore::currentPatternChanged` triggers an update of all `PatternTrackViews`. The purpose is according to the comment:

> update all track-labels (the current one has to become white, the others gray)

This refers to is [this line of code](https://github.com/LMMS/lmms/blob/3d0a8e95a2e89bd9e55157b9e405a050735e1b04/src/gui/widgets/name_label.cpp#L229) that was [removed](https://github.com/LMMS/lmms/commit/c08cc778fd05000cf6a63161e4fecc27f4b24536) back in 2008.

