### PR TITLE
Fix import of xpt and xptz files (#7986)

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -605,6 +605,11 @@ DataFile::Type DataFile::type( const QString& typeName )
 		return Type::InstrumentTrackSettings;
 	}
 
+	if (typeName == "pattern")
+	{
+		return Type::MidiClip;
+	}
+
 	return Type::Unknown;
 }
 


### PR DESCRIPTION
Fix the import of `xpt` and `xptz` files by adding upgrade code to `DataFile::type`. The new code maps the old textual representation "pattern" to the enum `Type::MidiClip`.

Without the extra upgrade code the text "pattern" is mapped to `Type::Unknown`. This then leads to problems at the end of `DataFile::loadData` where the enum representation is mapped back to the textual representation again to retrieve the root element from the upgraded XML.

So without the upgrade it's:
* Map "pattern" to `Type::Unknown`
* Upgrade XML from "pattern" to "midiclip"
* `Type::Unknown` does not map to "midiclip" and fetching the root element fails.

With the upgrade it's:
* Map "pattern" to `Type::MidiClip`
* Upgrade XML from "pattern" to "midiclip"
* `Type::MidiClip` is mapped to "midiclip" and fetching the root element succeeds.