### PR TITLE
Remove Knob::setHtmlLabel

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -136,6 +136,9 @@ public:
 	
 	Knob( const Knob& other ) = delete;
 
+	const QString& getLabel() const;
+	void setLabel(const QString& txt);
+
 	void setTotalAngle( float angle );
 
 	// Begin styled knob accessors
@@ -165,8 +168,6 @@ public:
 
 
 protected:
-	void setLabel(const QString& txt);
-	
 	void paintEvent(QPaintEvent*) override;
 
 	void changeEvent(QEvent * ev) override;

--- a/include/Knob.h
+++ b/include/Knob.h
@@ -136,8 +136,6 @@ public:
 	
 	Knob( const Knob& other ) = delete;
 
-	void setHtmlLabel( const QString &htmltxt );
-
 	void setTotalAngle( float angle );
 
 	// Begin styled knob accessors
@@ -216,8 +214,6 @@ private:
 
 	QString m_label;
 	bool m_fixedFontSizeLabelRendering = false;
-	bool m_isHtmlLabel;
-	QTextDocument* m_tdRenderer;
 
 	std::unique_ptr<QPixmap> m_knobPixmap;
 

--- a/src/gui/Controls.cpp
+++ b/src/gui/Controls.cpp
@@ -40,8 +40,7 @@ namespace lmms::gui
 
 void KnobControl::setText(const QString& text)
 {
-	// For KnobControls the text is set in the constructor
-	// so we do nothing here
+	m_knob->setLabel(text);
 }
 
 QWidget *KnobControl::topWidget() { return m_knob; }

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -144,6 +144,10 @@ void Knob::onKnobNumUpdated()
 }
 
 
+const QString& Knob::getLabel() const
+{
+	return m_label;
+}
 
 
 void Knob::setLabel(const QString& txt)

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -41,8 +41,6 @@ namespace lmms::gui
 Knob::Knob( KnobType _knob_num, QWidget * _parent, const QString & _name ) :
 	FloatModelEditorBase(DirectionOfManipulation::Vertical, _parent, _name),
 	m_label( "" ),
-	m_isHtmlLabel(false),
-	m_tdRenderer(nullptr),
 	m_angle( -10 ),
 	m_lineWidth( 0 ),
 	m_textColor( 255, 255, 255 ),
@@ -151,34 +149,12 @@ void Knob::onKnobNumUpdated()
 void Knob::setLabel(const QString& txt)
 {
 	m_label = txt;
-	m_isHtmlLabel = false;
 
 	updateFixedSize();
 
 	update();
 }
 
-
-void Knob::setHtmlLabel(const QString &htmltxt)
-{
-	m_label = htmltxt;
-	m_isHtmlLabel = true;
-	// Put the rendered HTML content into cache
-	if (!m_tdRenderer)
-	{
-		m_tdRenderer = new QTextDocument(this);
-	}
-
-	m_tdRenderer->setHtml(QString("<span style=\"color:%1;\">%2</span>").arg(textColor().name(), m_label));
-
-	if (m_knobPixmap)
-	{
-		setFixedSize(m_knobPixmap->width(),
-				m_knobPixmap->height() + 15);
-	}
-
-	update();
-}
 
 void Knob::setFixedFontSizeLabelRendering()
 {
@@ -507,27 +483,17 @@ void Knob::drawLabel(QPainter& p)
 {
 	if( !m_label.isEmpty() )
 	{
-		if (!m_isHtmlLabel)
+		if (fixedFontSizeLabelRendering())
 		{
-			if (fixedFontSizeLabelRendering())
-			{
-				p.setFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
-			}
-			auto fm = p.fontMetrics();
-			const auto x = (width() - horizontalAdvance(fm, m_label)) / 2;
-			const auto descent = fixedFontSizeLabelRendering() ? 2 : fm.descent();
-			const auto y = height() - descent; 
+			p.setFont(adjustedToPixelSize(p.font(), SMALL_FONT_SIZE));
+		}
+		auto fm = p.fontMetrics();
+		const auto x = (width() - horizontalAdvance(fm, m_label)) / 2;
+		const auto descent = fixedFontSizeLabelRendering() ? 2 : fm.descent();
+		const auto y = height() - descent; 
 
-			p.setPen(textColor());
-			p.drawText(x, y, m_label);
-		}
-		else
-		{
-			// TODO setHtmlLabel is never called so this will never be executed. Remove functionality?
-			m_tdRenderer->setDefaultFont(font());
-			p.translate((width() - m_tdRenderer->idealWidth()) / 2, (height() - m_tdRenderer->pageSize().height()) / 2);
-			m_tdRenderer->drawContents(&p);
-		}
+		p.setPen(textColor());
+		p.drawText(x, y, m_label);
 	}
 }
 


### PR DESCRIPTION
Remove the unused method `Knob::setHtmlLabel` and its associated members. This removes some unnecessary complexity from the code.