### PR TITLE
Set the sample rate for MP3 exports

### DIFF
--- a/src/core/audio/AudioFileMP3.cpp
+++ b/src/core/audio/AudioFileMP3.cpp
@@ -117,6 +117,7 @@ bool AudioFileMP3::initEncoder()
 
 	lame_set_VBR(m_lame, vbr_off);
 	lame_set_brate(m_lame, bitRate);
+	lame_set_in_samplerate(m_lame, getOutputSettings().getSampleRate());
 
 	// Add a comment
 	id3tag_init(m_lame);


### PR DESCRIPTION
This sets the sample rate to that of the engine's rate for MP3 exports. Fixes #7997.