### PR TITLE
Update Piano Roll Knife Tool

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4965,7 +4965,7 @@ PianoRollWindow::PianoRollWindow() :
 	QAction* eraseAction = editModeGroup->addAction( embed::getIconPixmap( "edit_erase" ), tr("Erase mode (Shift+E)" ) );
 	QAction* selectAction = editModeGroup->addAction( embed::getIconPixmap( "edit_select" ), tr( "Select mode (Shift+S)" ) );
 	QAction* pitchBendAction = editModeGroup->addAction( embed::getIconPixmap( "automation" ), tr("Pitch Bend mode (Shift+T)" ) );
-	QAction* knifeAction = editModeGroup->addAction( embed::getIconPixmap("edit_knife"), tr("Knife"));
+	QAction* knifeAction = editModeGroup->addAction(embed::getIconPixmap("edit_knife"), tr("Knife"));
 
 	drawAction->setChecked( true );
 
@@ -4999,7 +4999,7 @@ PianoRollWindow::PianoRollWindow() :
 	notesActionsToolBar->addAction( eraseAction );
 	notesActionsToolBar->addAction( selectAction );
 	notesActionsToolBar->addAction( pitchBendAction );
-	notesActionsToolBar->addAction( knifeAction );
+	notesActionsToolBar->addAction(knifeAction);
 	notesActionsToolBar->addSeparator();
 	notesActionsToolBar->addWidget(quantizeButton);
 


### PR DESCRIPTION
This pull request attempts to resolve #7814 by moving the knife tool to the piano roll toolbar, and adding a hint for its usage.
The changes are :
- Set a hint to display on calling PianoRoll:setKnifeAction.
- Added an extra if statement to PianoRoll:setEditMode, which, if the selected mode is EditMode::Knife, will call the setKnifeAction function. 
<t>I'm not too pleased with this to be honest, but it works alright and makes other code cleaner.

**NOTE** : I'm not sure whether it would be a good idea to only show the hint once - If the user misses it, that could be problematic. Therefore, I've left it as displaying every time for now. Maybe a 'Don't show again' button would solve this ? I don't know how I would program that though \\(°v°)/