### PR TITLE
remove braces while returning

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -777,7 +777,7 @@ bool MainWindow::saveProject()
 {
 	if( Engine::getSong()->projectFileName() == "" )
 	{
-		return( saveProjectAs() );
+		return saveProjectAs();
 	}
 	else if( this->guiSaveProject() )
 	{


### PR DESCRIPTION
return(...); => return ...;
Not necessary to enclose the returning function call within braces,