### PR TITLE
Remove the Gate knob from effects

### DIFF
--- a/data/presets/AudioFileProcessor/Erazor.xpf
+++ b/data/presets/AudioFileProcessor/Erazor.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="2" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.3745"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 data_numerator="4" data_denominator="4" syncmode="0" link="1" data="200"/>
             <port01 link="1" data="0.24"/>
@@ -42,7 +42,7 @@
             <attribute value="fbdelay_5s" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="bassbooster" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="bassbooster" wet="1" on="1">
           <bassboostercontrols ratio="2" freq="100" gain="1"/>
           <key/>
         </effect>

--- a/data/presets/AudioFileProcessor/SString.xpf
+++ b/data/presets/AudioFileProcessor/SString.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="4" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.005"/>
             <port03 data="0.749"/>
@@ -28,11 +28,11 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="0.35" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereomatrix" wet="0.35" on="1">
           <stereomatrixcontrols l-l="-0.5" l-r="-0.5" r-l="-0.5" r-r="-0.5"/>
           <key/>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="400" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="400" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="8">
             <port01 link="0" data="0.08"/>
             <port02 link="1" data="1"/>
@@ -48,7 +48,7 @@
             <attribute value="PhaserII" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="20">
             <port01 link="1" data="-48"/>
             <port02 link="1" data="-23.94"/>

--- a/data/presets/AudioFileProcessor/orion.xpf
+++ b/data/presets/AudioFileProcessor/orion.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="8">
             <port00 link="1" data="-24"/>
             <port01 link="1" data="15995"/>
@@ -32,7 +32,7 @@
             <attribute value="tap_deesser" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="-1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="-1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.749"/>
@@ -44,7 +44,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="0.2" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereomatrix" wet="0.2" on="1">
           <stereomatrixcontrols l-l="-0.5" l-r="-0.5" r-l="-0.5" r-r="-0.5"/>
           <key/>
         </effect>

--- a/data/presets/BitInvader/alien_strings.xpf
+++ b/data/presets/BitInvader/alien_strings.xpf
@@ -14,7 +14,7 @@
       <midiport inputchannel="0" outputchannel="1" send="0" receive="0"/>
       <chordcreator chorddisabled="1" arptime="107" arprange="1" arpsyncmode="6" arpmode="1" chord="0" chordrange="4" arp="74" arp-enabled="0" chord-enabled="0" arpdisabled="1" arpdir="0" arpgate="100"/>
       <fxchain enabled="1" numofeffects="1">
-        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0">
+        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0">
           <ladspacontrols ports="0" link="1"/>
           <key>
             <attribute name="file" value="dc_remove_1207"/>

--- a/data/presets/BitInvader/drama.xpf
+++ b/data/presets/BitInvader/drama.xpf
@@ -14,7 +14,7 @@
       <midiport inputchannel="0" outputchannel="1" send="0" receive="0"/>
       <chordcreator chorddisabled="1" arptime="107" arprange="1" arpsyncmode="6" arpmode="1" chord="0" chordrange="4" arp="74" arp-enabled="1" chord-enabled="0" arpdisabled="0" arpdir="0" arpgate="100"/>
       <fxchain enabled="1" numofeffects="1">
-        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0">
+        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0">
           <ladspacontrols ports="0" link="1"/>
           <key>
             <attribute name="file" value="dc_remove_1207"/>

--- a/data/presets/BitInvader/invaders_must_die.xpf
+++ b/data/presets/BitInvader/invaders_must_die.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="27" arprange="2" arptime_denominator="16" syncmode="8" arpmode="0" arp-enabled="1" arp="0" arptime_numerator="1" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.749"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereoenhancer" wet="1" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereoenhancer" wet="1" on="0">
           <stereoenhancercontrols width="42"/>
           <key/>
         </effect>

--- a/data/presets/BitInvader/pluck.xpf
+++ b/data/presets/BitInvader/pluck.xpf
@@ -14,7 +14,7 @@
       <midiport inports="80:0 CS46XX:CS46XX" inputchannel="0" outputchannel="1" send="0" receive="1"/>
       <chordcreator chorddisabled="0" arptime="100" arprange="1" arpsyncmode="0" arpmode="0" chord="0" chordrange="2" arp="0" arp-enabled="0" chord-enabled="1" arpdisabled="1" arpdir="0" arpgate="100"/>
       <fxchain enabled="1" numofeffects="1">
-        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0">
+        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0">
           <ladspacontrols ports="0" link="1"/>
           <key>
             <attribute name="file" value="dc_remove_1207"/>

--- a/data/presets/Kicker/Clap dry.xpf
+++ b/data/presets/Kicker/Clap dry.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" scale_type="linear" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" scale_type="linear" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" scale_type="linear" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" scale_type="linear" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 scale_type="linear" data="-47.97"/>
             <port03 scale_type="linear" data="0"/>
@@ -34,7 +34,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" scale_type="linear" autoquit="1" gate="0" name="dualfilter" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" scale_type="linear" autoquit="1" name="dualfilter" wet="1" on="1">
           <DualFilterControls gain2="100" cut1="1721" cut2="6461" mix="-0.4" res1="1.64" res2="0.5" scale_type="linear" filter1="0" filter2="1" enabled1="1" enabled2="1" gain1="100"/>
           <key/>
         </effect>

--- a/data/presets/Kicker/Clap.xpf
+++ b/data/presets/Kicker/Clap.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="0"/>
             <port03 data="0"/>
@@ -34,7 +34,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.121765"/>
             <port03 data="0.10486"/>

--- a/data/presets/Kicker/SnareMarch.xpf
+++ b/data/presets/Kicker/SnareMarch.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="6" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="0"/>
             <port03 data="0"/>
@@ -34,7 +34,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.5" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.5" on="0">
           <ladspacontrols ports="4">
             <port02 data="0.370265"/>
             <port03 data="0"/>
@@ -46,7 +46,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="9">
             <port07>
               <data scale_type="log" value="0.4" id="6315252"/>
@@ -71,7 +71,7 @@
             <attribute value="Reverb" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.18" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.18" on="1">
           <ladspacontrols ports="13">
             <port04 data="0"/>
             <port05 data="1.02375"/>
@@ -104,7 +104,7 @@
             <attribute value="Saturator" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="13">
             <port04 data="0"/>
             <port05 data="1.02375"/>
@@ -137,7 +137,7 @@
             <attribute value="Saturator" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-47.97"/>
             <port03 data="-10.8"/>

--- a/data/presets/LB302/AcidLead.xpf
+++ b/data/presets/LB302/AcidLead.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port04 data="144.113"/>
             <port05 data="16"/>

--- a/data/presets/LB302/AngryLead.xpf
+++ b/data/presets/LB302/AngryLead.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.14231"/>

--- a/data/presets/LB302/STrash.xpf
+++ b/data/presets/LB302/STrash.xpf
@@ -8,18 +8,18 @@
         <lb302 db24="0" vcf_res="1.01" vcf_dec="0.1" dead="0" vcf_cut="0.18" vcf_mod="1" dist="1" slide_dec="0.5" slide="1" shape="0"/>
       </instrument>
       <fxchain numofeffects="6" enabled="1">
-        <effect autoquit="1" gate="0" name="ladspaeffect" wet="0.5" on="1">
+        <effect autoquit="1" name="ladspaeffect" wet="0.5" on="1">
           <ladspacontrols port11="0.1" port01="0.1" port12="1" port02="1" port13="3.14159" port03="3.14159" port14="0.74925" port04="0.74925" port04link="1" port02link="1" port03link="1" link="0" ports="8" port01link="0"/>
           <key>
             <attribute value="caps" name="file"/>
             <attribute value="PhaserI" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit="1" gate="0" name="stereoenhancer" wet="1" on="1">
+        <effect autoquit="1" name="stereoenhancer" wet="1" on="1">
           <stereoenhancercontrols width="177"/>
           <key/>
         </effect>
-        <effect autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/Monstro/Growl.xpf
+++ b/data/presets/Monstro/Growl.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arprange="1" arpmiss="0" arpmode="0" arptime_syncmode="0" arp-enabled="0" arpskip="0" arptime="100" arptime_denominator="4" arpgate="100" arp="0" arpcycle="0" arpdir="0" arptime_numerator="4"/>
       <midiport basevelocity="127" inputcontroller="0" fixedinputvelocity="-1" outputcontroller="0" inputchannel="0" fixedoutputvelocity="-1" outputchannel="1" outputprogram="1" readable="0" writable="0" fixedoutputnote="-1"/>
       <fxchain numofeffects="6" enabled="1">
-        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <ladspacontrols ports="10">
             <port02 data="-47.97"/>
             <port03 data="-47.97"/>
@@ -34,7 +34,7 @@
             <attribute name="plugin" value="Eq2x2"/>
           </key>
         </effect>
-        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <ladspacontrols ports="2" link="1">
             <port01 data="50.76" link="1"/>
             <port11 data="50.76"/>
@@ -44,11 +44,11 @@
             <attribute name="plugin" value="Clip"/>
           </key>
         </effect>
-        <effect name="dualfilter" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0.02" autoquit="1">
+        <effect name="dualfilter" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <DualFilterControls mix="-0.14" filter1="1" filter2="1" res1="0.5" res2="0.5" cut1="197" enabled1="1" gain1="100" cut2="229" enabled2="1" gain2="100"/>
           <key/>
         </effect>
-        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="1" autoquit="1">
+        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <ladspacontrols ports="6" link="1">
             <port00 data="-4.875" link="1"/>
             <port01 data="1" link="1"/>
@@ -62,7 +62,7 @@
             <attribute name="plugin" value="hardLimiter"/>
           </key>
         </effect>
-        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="ladspaeffect" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <ladspacontrols ports="4">
             <port02 data="0.87472"/>
             <port03 data="0"/>
@@ -74,7 +74,7 @@
             <attribute name="plugin" value="Plate2x2"/>
           </key>
         </effect>
-        <effect name="stereoenhancer" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="stereoenhancer" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <stereoenhancercontrols width="6"/>
           <key/>
         </effect>

--- a/data/presets/Monstro/HorrorLead.xpf
+++ b/data/presets/Monstro/HorrorLead.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="62" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0.15" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.749"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-10.5"/>
             <port01 link="1" data="1"/>
@@ -42,7 +42,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="amplifier" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="amplifier" wet="1" on="1">
           <AmplifierControls right="100" pan="0" left="100" volume="200"/>
           <key/>
         </effect>

--- a/data/presets/Monstro/Phat.xpf
+++ b/data/presets/Monstro/Phat.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="187" arprange="2" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="1" arp="0" arptime_numerator="4" arpdir="4" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.302409"/>

--- a/data/presets/Monstro/ScaryBell.xpf
+++ b/data/presets/Monstro/ScaryBell.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.375436"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="0">
           <ladspacontrols ports="10">
             <port02 data="-47.97"/>
             <port03 data="-47.97"/>

--- a/data/presets/Nescaline/Detune_lead.xpf
+++ b/data/presets/Nescaline/Detune_lead.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/Nescaline/Fireball_flick.xpf
+++ b/data/presets/Nescaline/Fireball_flick.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/OpulenZ/Bagpipe.xpf
+++ b/data/presets/OpulenZ/Bagpipe.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/OpulenZ/Combo_organ.xpf
+++ b/data/presets/OpulenZ/Combo_organ.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/OpulenZ/Funky.xpf
+++ b/data/presets/OpulenZ/Funky.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/OpulenZ/Harp.xpf
+++ b/data/presets/OpulenZ/Harp.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/OpulenZ/Organ_leslie.xpf
+++ b/data/presets/OpulenZ/Organ_leslie.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols port04="2" port05="0.5" port06="0.5" port07="0.5" port08="28.025" port09="28.025" ports="10" port010="0.75" port011="0.25" port012="0.5" port013="0"/>
           <key>
             <attribute value="calf" name="file"/>

--- a/data/presets/OpulenZ/Square.xpf
+++ b/data/presets/OpulenZ/Square.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/Organic/Pwnage.xpf
+++ b/data/presets/Organic/Pwnage.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="6" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="14">
             <port01 link="1" data="2.8775"/>
             <port02 link="1" data="0.999975"/>
@@ -38,7 +38,7 @@
             <attribute value="AmpIV" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="20">
             <port00 link="1" data="1"/>
             <port01 link="1" data="0.025"/>
@@ -66,7 +66,7 @@
             <attribute value="harmonicGen" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-9.375"/>
             <port01 link="1" data="1"/>
@@ -80,7 +80,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-47.97"/>
             <port03 data="-47.97"/>
@@ -98,7 +98,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-6.625"/>
             <port01 link="1" data="1"/>
@@ -112,7 +112,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="20">
             <port01 link="1" data="-47.97"/>
             <port02 link="1" data="-35.28"/>

--- a/data/presets/Organic/Rubberband.xpf
+++ b/data/presets/Organic/Rubberband.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="250" arprange="2" arptime_denominator="4" syncmode="0" arpmode="1" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="32"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain enabled="1" numofeffects="1">
-        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0">
+        <effect name="ladspaeffect" on="1" autoquit="1" autoquit_denominator="4" autoquit_numerator="4" wet="1" autoquit_syncmode="0">
           <ladspacontrols ports="0" link="1"/>
           <key>
             <attribute name="file" value="dc_remove_1207"/>

--- a/data/presets/SID/CheesyGuitar.xpf
+++ b/data/presets/SID/CheesyGuitar.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="1">
             <port00 data="5.4625"/>
           </ladspacontrols>
@@ -25,7 +25,7 @@
             <attribute value="amp_stereo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-12.625"/>
             <port01 link="1" data="1"/>

--- a/data/presets/SID/MadMind.xpf
+++ b/data/presets/SID/MadMind.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="1" arp="5" arptime_numerator="4" arpdir="3" arpgate="36"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="1">
             <port00 data="5.4625"/>
           </ladspacontrols>
@@ -25,7 +25,7 @@
             <attribute value="amp_stereo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-12.625"/>
             <port01 link="1" data="1"/>
@@ -39,7 +39,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.3745"/>

--- a/data/presets/SID/Overdrive.xpf
+++ b/data/presets/SID/Overdrive.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="1">
             <port00 data="10"/>
           </ladspacontrols>
@@ -25,7 +25,7 @@
             <attribute value="amp_stereo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-14"/>
             <port01 link="1" data="1"/>
@@ -39,7 +39,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.279003"/>

--- a/data/presets/TripleOscillator/Bell.xpf
+++ b/data/presets/TripleOscillator/Bell.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.49434"/>

--- a/data/presets/TripleOscillator/BrokenToy.xpf
+++ b/data/presets/TripleOscillator/BrokenToy.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="20">
             <port01 link="1" data="-48"/>
             <port02 link="1" data="-48"/>

--- a/data/presets/TripleOscillator/CryingPads.xpf
+++ b/data/presets/TripleOscillator/CryingPads.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.670355"/>

--- a/data/presets/TripleOscillator/DetunedGhost.xpf
+++ b/data/presets/TripleOscillator/DetunedGhost.xpf
@@ -18,7 +18,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.90454"/>
             <port03 data="0.749"/>

--- a/data/presets/TripleOscillator/DirtyReece.xpf
+++ b/data/presets/TripleOscillator/DirtyReece.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="4" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="12">
             <port04 data="3.168"/>
             <port05 data="9.999"/>
@@ -36,7 +36,7 @@
             <attribute value="MultiChorus" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="0">
           <ladspacontrols ports="7">
             <port00 data="2.8"/>
             <port01 data="90"/>
@@ -51,7 +51,7 @@
             <attribute value="tap_chorusflanger" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="0">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.3745"/>
@@ -63,7 +63,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-3"/>
             <port01 link="1" data="1"/>

--- a/data/presets/TripleOscillator/Drums_HardKick.xpf
+++ b/data/presets/TripleOscillator/Drums_HardKick.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="5" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="14">
             <port01 link="1" data="1.5925"/>
             <port02 link="1" data="0.999975"/>
@@ -38,7 +38,7 @@
             <attribute value="AmpIV" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-15"/>
             <port01 link="1" data="1"/>
@@ -52,7 +52,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="0"/>
             <port03 data="11.34"/>
@@ -70,7 +70,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-48"/>
             <port03 data="5.04"/>
@@ -88,7 +88,7 @@
             <attribute value="Eq2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="0"/>
             <port01 link="1" data="1"/>

--- a/data/presets/TripleOscillator/Drums_Kick.xpf
+++ b/data/presets/TripleOscillator/Drums_Kick.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arprange="1" arpmiss="0" arpmode="0" arptime_syncmode="0" arp-enabled="0" arpskip="0" arptime="100" arptime_denominator="4" arpgate="100" arp="0" arpcycle="0" arpdir="0" arptime_numerator="4"/>
       <midiport basevelocity="127" inputcontroller="0" fixedinputvelocity="-1" outputcontroller="0" inputchannel="0" fixedoutputvelocity="-1" outputchannel="1" outputprogram="1" readable="0" writable="0" fixedoutputnote="-1"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect name="stereomatrix" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="stereomatrix" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <stereomatrixcontrols l-l="1" r-l="0" l-r="1" r-r="0"/>
           <key/>
         </effect>

--- a/data/presets/TripleOscillator/Drums_Snare.xpf
+++ b/data/presets/TripleOscillator/Drums_Snare.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arprange="1" arpmiss="0" arpmode="0" arptime_syncmode="0" arp-enabled="0" arpskip="0" arptime="100" arptime_denominator="4" arpgate="100" arp="0" arpcycle="0" arpdir="0" arptime_numerator="4"/>
       <midiport basevelocity="127" inputcontroller="0" fixedinputvelocity="-1" outputcontroller="0" inputchannel="0" fixedoutputvelocity="-1" outputchannel="1" outputprogram="1" readable="0" writable="0" fixedoutputnote="-1"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect name="stereomatrix" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" gate="0" autoquit="1">
+        <effect name="stereomatrix" autoquit_denominator="4" on="1" autoquit_numerator="4" wet="1" autoquit_syncmode="0" autoquit="1">
           <stereomatrixcontrols l-l="1" r-l="0" l-r="1" r-r="0"/>
           <key/>
         </effect>

--- a/data/presets/TripleOscillator/E-Organ2.xpf
+++ b/data/presets/TripleOscillator/E-Organ2.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="1" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="1" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" defvelout="0" readable="0" defvelin="0"/>
       <fxchain numofeffects="1" enabled="0">
-        <effect key="AAAACQAAAAACAAAACgAAAABmAEMAKgAgAFAAbABhAHQAZQAyAHgAMgAgAC0AIABWAGUAcgBzAGEAdABpAGwAZQAgAHAAbABhAHQAZQAgAHIAZQB2AGUAcgBiACwAIABzAHQAZQByAGUAbwAgAGkAbgBwAHUAdABzAAAACwAAAAACAAAAEABQAGwAYQB0AGUAMgB4ADIAAAAOAGMAYQBwAHMALgBzAG8=" autoquit="0" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect key="AAAACQAAAAACAAAACgAAAABmAEMAKgAgAFAAbABhAHQAZQAyAHgAMgAgAC0AIABWAGUAcgBzAGEAdABpAGwAZQAgAHAAbABhAHQAZQAgAHIAZQB2AGUAcgBiACwAIABzAHQAZQByAGUAbwAgAGkAbgBwAHUAdABzAAAACwAAAAACAAAAEABQAGwAYQB0AGUAMgB4ADIAAAAOAGMAYQBwAHMALgBzAG8=" autoquit="0" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols port02="0.99897" port03="0.749" port04="0.55972" port05="0.54" ports="4"/>
           <key>
             <attribute value="caps.so" name="file"/>

--- a/data/presets/TripleOscillator/ElectricOboe.xpf
+++ b/data/presets/TripleOscillator/ElectricOboe.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.749"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="20">
             <port01 link="1" data="-48"/>
             <port02 link="1" data="-48"/>

--- a/data/presets/TripleOscillator/Erazzor.xpf
+++ b/data/presets/TripleOscillator/Erazzor.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="0" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="7" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="2">
             <port01 link="1" data="72"/>
             <port11 data="72"/>
@@ -26,7 +26,7 @@
             <attribute value="Clip" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="2">
             <port01 link="1" data="-10.08"/>
             <port11 data="-10.08"/>
@@ -36,7 +36,7 @@
             <attribute value="Clip" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.5" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.5" on="1">
           <ladspacontrols link="1" ports="20">
             <port01 link="1" data="-30.06"/>
             <port02 link="1" data="0"/>
@@ -64,7 +64,7 @@
             <attribute value="Eq" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="8">
             <port01 link="1" data="0.25"/>
             <port02 link="1" data="0.75"/>
@@ -80,7 +80,7 @@
             <attribute value="PhaserII" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.749"/>
@@ -92,7 +92,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="-0.5" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="-0.5" on="1">
           <ladspacontrols ports="10">
             <port00 data="320"/>
             <port01 data="50"/>
@@ -110,7 +110,7 @@
             <attribute value="tap_stereo_echo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereomatrix" wet="1" on="1">
           <stereomatrixcontrols l-l="0.66" l-r="0" r-l="0.33" r-r="0.5"/>
           <key/>
         </effect>

--- a/data/presets/TripleOscillator/FuzzyAnalogBass.xpf
+++ b/data/presets/TripleOscillator/FuzzyAnalogBass.xpf
@@ -17,7 +17,7 @@
       <chordcreator chordrange="1" chord-enabled="1" chord="0"/>
       <arpeggiator arp-enabled="0" arptime_denominator="1" arpcycle="0" arp="0" arpmiss="0" arpmode="0" arpskip="0" arptime="100" arprange="3" arptime_numerator="1" arpdir="0" arptime_syncmode="0" arpgate="100"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" autoquit_syncmode="0" wet="1" autoquit="1" on="1" gate="0" name="ladspaeffect">
+        <effect autoquit_numerator="4" autoquit_denominator="4" autoquit_syncmode="0" wet="1" autoquit="1" on="1" name="ladspaeffect">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/TripleOscillator/Garfunkel.xpf
+++ b/data/presets/TripleOscillator/Garfunkel.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="4" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="1">
             <port00 data="2"/>
           </ladspacontrols>
@@ -25,7 +25,7 @@
             <attribute value="amp_stereo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-16"/>
             <port01 link="1" data="1"/>
@@ -39,7 +39,7 @@
             <attribute value="hardLimiter" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.3745"/>
@@ -51,7 +51,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port01 link="1" data="2.12"/>
             <port02 link="1" data="0.313425"/>

--- a/data/presets/TripleOscillator/GhostBoy.xpf
+++ b/data/presets/TripleOscillator/GhostBoy.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="25" arprange="4" arptime_denominator="4" syncmode="0" arpmode="1" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="1"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="1" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="127" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0.3745"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port04 data="149.85"/>
             <port05 data="16"/>
@@ -46,7 +46,7 @@
             <attribute value="VintageDelay" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="0">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="0">
           <ladspacontrols link="0" ports="20">
             <port01 link="1" data="-42.66"/>
             <port02 link="1" data="-30.42"/>

--- a/data/presets/TripleOscillator/OldComputerGames.xpf
+++ b/data/presets/TripleOscillator/OldComputerGames.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="105" arprange="1" arptime_denominator="4" syncmode="0" arpmode="2" arp-enabled="1" arp="3" arptime_numerator="4" arpdir="0" arpgate="26"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="5" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="8">
             <port01 link="1" data="0"/>
             <port02 link="1" data="0.14"/>
@@ -32,7 +32,7 @@
             <attribute value="ToneStack" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port00 data="640"/>
             <port01 data="18"/>
@@ -50,7 +50,7 @@
             <attribute value="tap_stereo_echo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="3">
             <port00 data="0.2"/>
             <port01 data="27"/>
@@ -61,7 +61,7 @@
             <attribute value="tap_autopan" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.733075"/>
             <port03 data="0.363265"/>

--- a/data/presets/TripleOscillator/PM-FMstring.xpf
+++ b/data/presets/TripleOscillator/PM-FMstring.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.75047"/>
             <port03 data="0.35952"/>

--- a/data/presets/TripleOscillator/PMFMFTWbass.xpf
+++ b/data/presets/TripleOscillator/PMFMFTWbass.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.99897"/>
             <port03 data="0"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="20">
             <port00 link="1" data="1"/>
             <port01 link="1" data="1"/>

--- a/data/presets/TripleOscillator/PMbass.xpf
+++ b/data/presets/TripleOscillator/PMbass.xpf
@@ -16,11 +16,11 @@
       <arpeggiator arptime="273" arprange="3" arptime_denominator="4" syncmode="5" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="1" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="5" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="0.38" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereomatrix" wet="0.38" on="1">
           <stereomatrixcontrols l-l="-0.5" l-r="-0.5" r-l="-0.5" r-r="-0.5"/>
           <key/>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="8">
             <port01 link="0" data="0.1"/>
             <port02 link="1" data="1"/>
@@ -36,7 +36,7 @@
             <attribute value="PhaserII" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.75" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.75" on="1">
           <ladspacontrols link="1" ports="8">
             <port01 link="1" data="0"/>
             <port02 link="1" data="0.5"/>
@@ -52,7 +52,7 @@
             <attribute value="ToneStack" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="2">
             <port01 link="1" data="14.04"/>
             <port11 data="14.04"/>
@@ -62,7 +62,7 @@
             <attribute value="Clip" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>

--- a/data/presets/TripleOscillator/PercussiveBass.xpf
+++ b/data/presets/TripleOscillator/PercussiveBass.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="97" arprange="3" arptime_denominator="4" syncmode="6" arpmode="1" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="86"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="14">
             <port01 link="1" data="2.0275"/>
             <port02 link="1" data="0.502475"/>

--- a/data/presets/TripleOscillator/Play-some-rock.xpf
+++ b/data/presets/TripleOscillator/Play-some-rock.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="205" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="78" arptime_numerator="4" arpdir="0" arpgate="142"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 link="1" data="-5"/>
             <port01 link="1" data="1"/>

--- a/data/presets/TripleOscillator/PowerStrings.xpf
+++ b/data/presets/TripleOscillator/PowerStrings.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="158" arprange="2" arptime_denominator="1" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="1" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.54677"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-48"/>
             <port03 data="-22.32"/>

--- a/data/presets/TripleOscillator/SEGuitar.xpf
+++ b/data/presets/TripleOscillator/SEGuitar.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="0" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="6" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="2">
             <port01 link="1" data="72"/>
             <port11 data="72"/>
@@ -26,7 +26,7 @@
             <attribute value="Clip" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="2">
             <port01 link="1" data="-17.28"/>
             <port11 data="-17.28"/>
@@ -36,7 +36,7 @@
             <attribute value="Clip" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.5" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.5" on="1">
           <ladspacontrols link="1" ports="20">
             <port01 link="1" data="-30.06"/>
             <port02 link="1" data="0"/>
@@ -64,7 +64,7 @@
             <attribute value="Eq" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="8">
             <port01 link="1" data="0.25"/>
             <port02 link="1" data="0.75"/>
@@ -80,7 +80,7 @@
             <attribute value="PhaserII" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="0.88" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="0.88" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.89957"/>
             <port03 data="0.749"/>
@@ -92,7 +92,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="0.1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="stereomatrix" wet="0.1" on="1">
           <stereomatrixcontrols l-l="-0.5" l-r="-0.5" r-l="-0.5" r-r="-0.5"/>
           <key/>
         </effect>

--- a/data/presets/TripleOscillator/SquarePing.xpf
+++ b/data/presets/TripleOscillator/SquarePing.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.50197"/>
             <port03 data="0.3745"/>

--- a/data/presets/TripleOscillator/SuperSawLead.xpf
+++ b/data/presets/TripleOscillator/SuperSawLead.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port04 data="174.825"/>
             <port05 data="8"/>
@@ -34,7 +34,7 @@
             <attribute value="VintageDelay" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="dualfilter" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="dualfilter" wet="1" on="1">
           <DualFilterControls gain2="100" cut1="10" cut2="7000" mix="0" res1="0.01" res2="0.5" filter1="1" filter2="0" enabled1="1" enabled2="0" gain1="100"/>
           <key/>
         </effect>

--- a/data/presets/TripleOscillator/Supernova.xpf
+++ b/data/presets/TripleOscillator/Supernova.xpf
@@ -16,11 +16,11 @@
       <arpeggiator arptime="273" arprange="3" arptime_denominator="4" syncmode="5" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="1" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="7" enabled="1">
-        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" gate="0" name="stereomatrix" wet="0.38" on="1">
+        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" name="stereomatrix" wet="0.38" on="1">
           <stereomatrixcontrols l-l="-0.5" l-r="-0.5" r-l="-0.5" r-r="-0.5"/>
           <key/>
         </effect>
-        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="0" ports="8">
             <port01 link="0" data="0.16"/>
             <port02 link="1" data="1"/>
@@ -36,7 +36,7 @@
             <attribute value="PhaserII" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="0.75" on="1">
+        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" name="ladspaeffect" wet="0.75" on="1">
           <ladspacontrols link="1" ports="8">
             <port01 link="1" data="0"/>
             <port02 link="1" data="0.5"/>
@@ -52,14 +52,14 @@
             <attribute value="ToneStack" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="0">
+        <effect autoquit_numerator="1" autoquit_denominator="1" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="0">
           <ladspacontrols link="1" ports="0"/>
           <key>
             <attribute value="dc_remove_1207" name="file"/>
             <attribute value="dcRemove" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="0.25" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="0.25" on="1">
           <ladspacontrols ports="10">
             <port00 data="365"/>
             <port01 data="50"/>
@@ -77,7 +77,7 @@
             <attribute value="tap_stereo_echo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="1">
             <port00 data="1.5"/>
           </ladspacontrols>
@@ -86,7 +86,7 @@
             <attribute value="amp_stereo" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-48"/>
             <port03 data="-48"/>

--- a/data/presets/TripleOscillator/TINTNpad.xpf
+++ b/data/presets/TripleOscillator/TINTNpad.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="127" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="2" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.91945"/>
             <port03 data="0.47936"/>
@@ -28,7 +28,7 @@
             <attribute value="Plate2x2" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port02 data="-45.18"/>
             <port03 data="-48"/>

--- a/data/presets/TripleOscillator/WarmStack.xpf
+++ b/data/presets/TripleOscillator/WarmStack.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="108" arprange="2" arptime_denominator="4" syncmode="0" arpmode="1" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="1"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="127" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="6">
             <port04 data="0"/>
             <port05 data="0.8"/>
@@ -30,7 +30,7 @@
             <attribute value="freeverb3" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols link="1" ports="6">
             <port00 data_numerator="4" data_denominator="4" syncmode="4" link="1" data="412.5"/>
             <port01 link="1" data="0.31"/>
@@ -44,7 +44,7 @@
             <attribute value="fbdelay_5s" name="plugin"/>
           </key>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="3">
             <port00 data="0"/>
             <port01 data="0"/>

--- a/data/presets/Watsyn/Epic_lead.xpf
+++ b/data/presets/Watsyn/Epic_lead.xpf
@@ -16,15 +16,15 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="3" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="dualfilter" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="dualfilter" wet="1" on="1">
           <DualFilterControls gain2="100" cut1="4262" cut2="1713" mix="0.17" res1="1.33" res2="5.92" filter1="0" filter2="13" enabled1="1" enabled2="1" gain1="100"/>
           <key/>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" gate="0" name="waveshaper" wet="0.54" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1" name="waveshaper" wet="0.54" on="1">
           <waveshapercontrols clipInput="1" outputGain="1" waveShape="ehQhPGZmQzzCdX889uikPDPzzDwexfU8KVwPPX9dJD0ULD09N3xhPVUBjD1Oc649CZrRPfLn8D0LWwY+7ZYTPjW5ID592y0+xf06Pg0gSD5WQlU+nmRiPuaGbz4uqXw+u+WEPt92iz4DCJI+J5mYPkwqnz5QvKU+xU6sPjbFsj7TtLg+/nG9PoSUwD7QX8I+PnrDPgNhxD42QcU+aiHGPp4Bxz7S4cc+BcLIPjmiyT5tgso+oWLLPtRCzD4II80+PAPOPm/jzj6jw88+16PQPguE0T4+ZNI+ckTTPqYk1D7aBNU+DeXVPkHF1j51pdc+qYXYPtxl2T4QRto+RCbbPngG3D6r5tw+38bdPiqg3j6vS98+yoHfPiw/3z5ULd8+HzLgPuqJ4j6qtOU+kiTpPv2d7D5oF/A+05DzPj4K9z6og/o+E/39Pj+7AD/0dwI/qjQEP1/xBT8Vrgc/ymoJP38nCz815Aw/6qAOP59dED9VGhI/CtcTP+CTFT8kUhc/jBcZP/TxGj/V8xw/WCUfPyN3IT/8ySM/NQYmP9koKD8MPCo/nkksPwRWLj9OYjA/mG4yP+J6ND8rhzY/dZM4P7+fOj8QrDw/mLg+P33FQD9A0EI/Es1EP0ahRj+iKkg/eFRJPyUnSj/HwEo/JUBLP2i3Sz8qLUw/y6JMP2wYTT8Mjk0/rQNOP055Tj/v7k4/kGRPPzHaTz/ST1A/c8VQPxQ7UT+1sFE/ViZSP/ebUj+YEVM/OYdTP9r8Uz/kd1Q/bhpVPz02Vj9KF1g/pJ9aP7VOXT/gwV8/pPZhP54SZD/TKmY/3kFoP45Naj8PKGw/D4dtP7Mfbj/f5G0/UhRtP9v/az962Wo/ArFpP4mIaD8QYGc/lzdmPx4PZT+l5mM/LL5iP7OVYT86bWA/wURfP0kcXj/y9Vw/1eFbP7cSWz9+21o/dXpbP/ThXD8Jxl4/nNtgP5b8Yj+5HmU/20BnP/1iaT9EhGs/uJ5tP0ihbz8OdHE/GAtzP1hydD+0wXU/PQp3P+xReD+GmXk/FeB6P2YgfD/XSX0/FDp+P1zDfj8=" inputGain="1"/>
           <key/>
         </effect>
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="1000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="10">
             <port04 data="140.4"/>
             <port05 data="16"/>

--- a/data/presets/Watsyn/Pulse.xpf
+++ b/data/presets/Watsyn/Pulse.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="100" arprange="1" arptime_denominator="4" syncmode="0" arpmode="0" arp-enabled="0" arp="0" arptime_numerator="4" arpdir="0" arpgate="100"/>
       <midiport inputcontroller="0" inports="" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="62" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_numerator="4" autoquit_denominator="4" syncmode="0" autoquit="8000" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.80017"/>
             <port03 data="0.3745"/>

--- a/data/presets/Xpressive/Dream.xpf
+++ b/data/presets/Xpressive/Dream.xpf
@@ -16,7 +16,7 @@
       <arpeggiator arptime="250" arprange="3" arpskip="0" arptime_denominator="4" arptime_syncmode="0" arpmode="2" arpcycle="0" arp-enabled="0" arp="3" arptime_numerator="4" arpdir="4" arpmiss="0" arpgate="77.4135"/>
       <midiport inputcontroller="0" fixedoutputvelocity="-1" inputchannel="0" outputcontroller="0" writable="0" outputchannel="1" fixedinputvelocity="-1" fixedoutputnote="-1" outputprogram="1" basevelocity="63" readable="0"/>
       <fxchain numofeffects="1" enabled="1">
-        <effect autoquit_syncmode="0" autoquit_numerator="4" autoquit_denominator="4" autoquit="1" gate="0" name="ladspaeffect" wet="1" on="1">
+        <effect autoquit_syncmode="0" autoquit_numerator="4" autoquit_denominator="4" autoquit="1" name="ladspaeffect" wet="1" on="1">
           <ladspacontrols ports="4">
             <port02 data="0.711953"/>
             <port03 data="0.610435"/>

--- a/data/projects/demos/StrictProduction-DearJonDoe.mmp
+++ b/data/projects/demos/StrictProduction-DearJonDoe.mmp
@@ -21,7 +21,7 @@
                 <arpeggiator arp="0" arptime_numerator="1" arptime_denominator="1" arprange="1" arpmode="0" arptime="100" arpdir="0" arpgate="100" syncmode="0" arp-enabled="0"/>
                 <midiport outputchannel="1" outputcontroller="0" basevelocity="127" outputprogram="1" fixedinputvelocity="-1" fixedoutputvelocity="-1" fixedoutputnote="-1" inputchannel="0" inputcontroller="0" readable="0" writable="0"/>
                 <fxchain enabled="1" numofeffects="1">
-                  <effect autoquit="1" gate="0" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
+                  <effect autoquit="1" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
                     <ladspacontrols ports="4">
                       <port02 data="0.50197"/>
                       <port03 data="0.3745"/>
@@ -94,7 +94,7 @@
                 <arpeggiator arp="0" arptime_numerator="1" arptime_denominator="1" arprange="1" arpmode="0" arptime="100" arpdir="0" arpgate="100" syncmode="0" arp-enabled="0"/>
                 <midiport outputchannel="1" outputcontroller="0" basevelocity="127" outputprogram="1" fixedinputvelocity="-1" fixedoutputvelocity="-1" fixedoutputnote="-1" inputchannel="0" inputcontroller="0" readable="0" writable="0"/>
                 <fxchain enabled="1" numofeffects="1">
-                  <effect autoquit="1" gate="0" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
+                  <effect autoquit="1" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
                     <ladspacontrols ports="4">
                       <port02 data="0.23359"/>
                       <port03 data="0.53928"/>
@@ -317,7 +317,7 @@
                 <arpeggiator arp="0" arptime_numerator="1" arptime_denominator="1" arprange="1" arpmode="0" arptime="100" arpdir="0" arpgate="100" syncmode="0" arp-enabled="0"/>
                 <midiport outputchannel="1" outputcontroller="0" basevelocity="127" outputprogram="1" fixedinputvelocity="-1" fixedoutputvelocity="-1" fixedoutputnote="-1" inputchannel="0" inputcontroller="0" readable="0" writable="0"/>
                 <fxchain enabled="1" numofeffects="1">
-                  <effect autoquit="1" gate="0" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
+                  <effect autoquit="1" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
                     <ladspacontrols ports="5">
                       <port00 data="1900.01"/>
                       <port01 data="44.2125"/>

--- a/data/projects/shorties/Crunk(Demo).mmp
+++ b/data/projects/shorties/Crunk(Demo).mmp
@@ -66,7 +66,7 @@
           <arpeggiator arp="0" arptime_numerator="4" arptime_denominator="4" arprange="1" arpmode="0" arptime="100" arpdir="0" arpgate="100" syncmode="0" arp-enabled="0"/>
           <midiport outputchannel="1" outputcontroller="0" basevelocity="127" outputprogram="1" fixedinputvelocity="-1" fixedoutputvelocity="-1" fixedoutputnote="-1" inputchannel="0" inputcontroller="0" readable="0" writable="0"/>
           <fxchain enabled="1" numofeffects="1">
-            <effect autoquit="1" gate="0" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
+            <effect autoquit="1" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
               <ladspacontrols ports="4">
                 <port02 data="0.50197"/>
                 <port03 data="0.3745"/>
@@ -131,7 +131,7 @@
           <arpeggiator arp="0" arptime_numerator="4" arptime_denominator="4" arprange="1" arpmode="0" arptime="100" arpdir="0" arpgate="100" syncmode="0" arp-enabled="0"/>
           <midiport outputchannel="1" outputcontroller="0" basevelocity="127" outputprogram="1" fixedinputvelocity="-1" fixedoutputvelocity="-1" fixedoutputnote="-1" inputchannel="0" inputcontroller="0" readable="0" writable="0"/>
           <fxchain enabled="1" numofeffects="1">
-            <effect autoquit="1" gate="0" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
+            <effect autoquit="1" autoquit_denominator="4" wet="1" name="ladspaeffect" on="1" autoquit_numerator="4" syncmode="0">
               <ladspacontrols ports="4">
                 <port02 data="0.18389"/>
                 <port03 data="0.57673"/>

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -66,16 +66,6 @@ public:
 	//! Returns true if audio was processed and should continue being processed
 	bool processAudioBuffer(SampleFrame* buf, const fpp_t frames);
 
-	inline ch_cnt_t processorCount() const
-	{
-		return m_processors;
-	}
-
-	inline void setProcessorCount( ch_cnt_t _processors )
-	{
-		m_processors = _processors;
-	}
-
 	inline bool isOkay() const
 	{
 		return m_okay;
@@ -233,8 +223,6 @@ private:
 					sample_rate_t _src_sr,
 					SampleFrame* _dst_buf, sample_rate_t _dst_sr,
 					const f_cnt_t _frames );
-
-	ch_cnt_t m_processors;
 
 	bool m_okay;
 	bool m_noRun;

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -124,12 +124,6 @@ public:
 		return 1.0f - m_wetDryModel.value();
 	}
 
-	inline float gate() const
-	{
-		const float level = m_gateModel.value();
-		return level*level * m_processors;
-	}
-
 	inline f_cnt_t bufferCount() const
 	{
 		return m_bufferCount;
@@ -249,7 +243,6 @@ private:
 
 	BoolModel m_enabledModel;
 	FloatModel m_wetDryModel;
-	FloatModel m_gateModel;
 	TempoSyncKnobModel m_autoQuitModel;
 	
 	bool m_autoQuitDisabled;

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -92,7 +92,6 @@ private:
 	LedCheckBox * m_bypass;
 	Knob * m_wetDry;
 	TempoSyncKnob * m_autoQuit;
-	Knob * m_gate;
 	QMdiSubWindow * m_subWindow;
 	EffectControlDialog * m_controlView;
 	

--- a/plugins/LadspaEffect/LadspaEffect.cpp
+++ b/plugins/LadspaEffect/LadspaEffect.cpp
@@ -280,7 +280,7 @@ void LadspaEffect::pluginInstantiation()
 
 	// Calculate how many processing units are needed.
 	int effect_channels = manager->getDescription( m_key )->inputChannels;
-	setProcessorCount(DEFAULT_CHANNELS / effect_channels);
+	m_processors = DEFAULT_CHANNELS / effect_channels;
 
 	// get inPlaceBroken property
 	m_inPlaceBroken = manager->isInplaceBroken( m_key );

--- a/plugins/LadspaEffect/LadspaEffect.h
+++ b/plugins/LadspaEffect/LadspaEffect.h
@@ -61,6 +61,10 @@ public:
 		return m_portControls;
 	}
 
+	ch_cnt_t processorCount() const
+	{
+		return m_processors;
+	}
 
 private slots:
 	void changeSampleRate();
@@ -87,7 +91,8 @@ private:
 	QVector<multi_proc_t> m_ports;
 	multi_proc_t m_portControls;
 
-} ;
+	ch_cnt_t m_processors = 1;
+};
 
 
 } // namespace lmms

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -50,7 +50,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_bufferCount( 0 ),
 	m_enabledModel( true, this, tr( "Effect enabled" ) ),
 	m_wetDryModel( 1.0f, -1.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
-	m_gateModel( 0.0f, 0.0f, 1.0f, 0.01f, this, tr( "Gate" ) ),
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitDisabled( false )
 {
@@ -91,7 +90,6 @@ void Effect::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	m_enabledModel.saveSettings( _doc, _this, "on" );
 	m_wetDryModel.saveSettings( _doc, _this, "wet" );
 	m_autoQuitModel.saveSettings( _doc, _this, "autoquit" );
-	m_gateModel.saveSettings( _doc, _this, "gate" );
 	controls()->saveState( _doc, _this );
 }
 
@@ -103,7 +101,6 @@ void Effect::loadSettings( const QDomElement & _this )
 	m_enabledModel.loadSettings( _this, "on" );
 	m_wetDryModel.loadSettings( _this, "wet" );
 	m_autoQuitModel.loadSettings( _this, "autoquit" );
-	m_gateModel.loadSettings( _this, "gate" );
 
 	QDomNode node = _this.firstChild();
 	while( !node.isNull() )
@@ -190,7 +187,7 @@ void Effect::checkGate(double outSum)
 
 	// Check whether we need to continue processing input.  Restart the
 	// counter if the threshold has been exceeded.
-	if (outSum - gate() <= F_EPSILON)
+	if (outSum <= F_EPSILON)
 	{
 		incrementBufferCount();
 		if( bufferCount() > timeout() )

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -43,7 +43,6 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 			const Descriptor::SubPluginFeatures::Key * _key ) :
 	Plugin( _desc, _parent, _key ),
 	m_parent( nullptr ),
-	m_processors( 1 ),
 	m_okay( true ),
 	m_noRun( false ),
 	m_running( false ),

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -74,13 +74,6 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_autoQuit->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
 	m_autoQuit->setHintText( tr( "Time:" ), "ms" );
 
-
-	m_gate = new Knob(KnobType::Bright26, tr("GATE"), this, Knob::LabelRendering::LegacyFixedFontSize);
-	m_gate->move( 116 - m_gate->width() / 2, 5 );
-	m_gate->setEnabled( isEnabled && !effect()->m_autoQuitDisabled );
-	m_gate->setHintText( tr( "Gate:" ), "" );
-
-
 	setModel( _model );
 
 	if( effect()->controls()->controlCount() > 0 )
@@ -275,7 +268,6 @@ void EffectView::modelChanged()
 	m_bypass->setModel( &effect()->m_enabledModel );
 	m_wetDry->setModel( &effect()->m_wetDryModel );
 	m_autoQuit->setModel( &effect()->m_autoQuitModel );
-	m_gate->setModel( &effect()->m_gateModel );
 }
 
 } // namespace lmms::gui


### PR DESCRIPTION
This PR removes the gate knob from effects, effectively hard coding it to `0`.

I also removed the gate's XML attribute from the preset files and mmp project files. This isn't strictly necessary but I just wanted to be thorough.

Out of all the presets, only Monstro's `Growl.xpf` and `HorrorLead.xpf` used gate values that were non-zero, though I could not hear any difference with them set to 0. And when autoquit is disabled (as it has been by default since #4378 over 5 years ago), there is no difference anyway.

Supersedes #7486

### Next step

After this, I'd like to convert the Decay knob for effects into a context menu entry. Because it's such a niche feature, it should not be taking up valuable space in the effect views. Once in the context menu it would no longer be automatable, though this should not be a problem.

After that is done, #7438 will no longer need to conditionally display the Decay knob.