### PR TITLE
Better loop handles + prevent negative loops

### DIFF
--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -734,10 +734,6 @@ lmms--gui--TimeLineWidget {
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );
 	qproperty-barNumberColor: rgb( 192, 192, 192 );
-
-	/* Cursor hotspots for loop marker adjustment */
-	qproperty-mouseHotspotSelLeft: 0px 16px;
-	qproperty-mouseHotspotSelRight: 32px 16px;
 }
 
 QTreeView {

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -729,7 +729,7 @@ lmms--gui--TimeLineWidget {
 	qproperty-activeLoopInnerColor: rgba( 74, 155, 100, 255 );
 	qproperty-activeLoopHandleColor: rgba( 192, 192, 192, 200 );
 
-	/* Width of loop marker handles (when handle mode is active) */
+	/* Width of loop move handle (when grab closest mode is active) */
 	qproperty-loopHandleWidth: 30;
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );

--- a/data/themes/classic/style.css
+++ b/data/themes/classic/style.css
@@ -730,7 +730,7 @@ lmms--gui--TimeLineWidget {
 	qproperty-activeLoopHandleColor: rgba( 192, 192, 192, 200 );
 
 	/* Width of loop marker handles (when handle mode is active) */
-	qproperty-loopHandleWidth: 8;
+	qproperty-loopHandleWidth: 30;
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );
 	qproperty-barNumberColor: rgb( 192, 192, 192 );

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -799,10 +799,6 @@ lmms--gui--TimeLineWidget {
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );
 	qproperty-barNumberColor: rgb( 192, 192, 192 );
-
-	/* Cursor hotspots for loop marker adjustment */
-	qproperty-mouseHotspotSelLeft: 0px 16px;
-	qproperty-mouseHotspotSelRight: 32px 16px;
 }
 
 lmms--gui--TrackContainerView QLabel

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -795,7 +795,7 @@ lmms--gui--TimeLineWidget {
 	   A value of zero draws the rectangle at the full height of the widget. */
 	qproperty-loopRectangleVerticalPadding: 1;
 	/* Width of loop marker handles (when handle mode is active) */
-	qproperty-loopHandleWidth: 8;
+	qproperty-loopHandleWidth: 30;
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );
 	qproperty-barNumberColor: rgb( 192, 192, 192 );

--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -794,7 +794,7 @@ lmms--gui--TimeLineWidget {
 	/* Vertical padding for the loop indicator rectangle.
 	   A value of zero draws the rectangle at the full height of the widget. */
 	qproperty-loopRectangleVerticalPadding: 1;
-	/* Width of loop marker handles (when handle mode is active) */
+	/* Width of loop move handle (when grab closest mode is active) */
 	qproperty-loopHandleWidth: 30;
 
 	qproperty-barLineColor: rgb( 192, 192, 192 );

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -68,6 +68,7 @@ public:
 	Q_PROPERTY(QColor activeLoopHandleColor MEMBER m_activeLoopHandleColor)
 	Q_PROPERTY( int loopRectangleVerticalPadding READ getLoopRectangleVerticalPadding WRITE setLoopRectangleVerticalPadding )
 	Q_PROPERTY(int loopHandleWidth MEMBER m_loopHandleWidth)
+	Q_PROPERTY(int loopMoveHandleWidth MEMBER m_loopMoveHandleWidth)
 	Q_PROPERTY(QSize mouseHotspotSelLeft READ mouseHotspotSelLeft WRITE setMouseHotspotSelLeft)
 	Q_PROPERTY(QSize mouseHotspotSelRight READ mouseHotspotSelRight WRITE setMouseHotspotSelRight)
 
@@ -206,6 +207,7 @@ private:
 
 	int m_loopRectangleVerticalPadding = 1;
 	int m_loopHandleWidth = 5;
+	int m_loopMoveHandleWidth = 30;
 
 	QColor m_barLineColor = QColor{192, 192, 192};
 	QColor m_barNumberColor = m_barLineColor.darker(120);

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -68,8 +68,6 @@ public:
 	Q_PROPERTY(QColor activeLoopHandleColor MEMBER m_activeLoopHandleColor)
 	Q_PROPERTY( int loopRectangleVerticalPadding READ getLoopRectangleVerticalPadding WRITE setLoopRectangleVerticalPadding )
 	Q_PROPERTY(int loopHandleWidth MEMBER m_loopHandleWidth)
-	Q_PROPERTY(QSize mouseHotspotSelLeft READ mouseHotspotSelLeft WRITE setMouseHotspotSelLeft)
-	Q_PROPERTY(QSize mouseHotspotSelRight READ mouseHotspotSelRight WRITE setMouseHotspotSelRight)
 
 	enum class AutoScrollState
 	{
@@ -108,28 +106,6 @@ public:
 
 	inline int const & getLoopRectangleVerticalPadding() const { return m_loopRectangleVerticalPadding; }
 	inline void setLoopRectangleVerticalPadding(int const & loopRectangleVerticalPadding) { m_loopRectangleVerticalPadding = loopRectangleVerticalPadding; }
-
-	auto mouseHotspotSelLeft() const -> QSize
-	{
-		const auto point = m_cursorSelectLeft.hotSpot();
-		return QSize{point.x(), point.y()};
-	}
-
-	void setMouseHotspotSelLeft(const QSize& s)
-	{
-		m_cursorSelectLeft = QCursor{m_cursorSelectLeft.pixmap(), s.width(), s.height()};
-	}
-
-	auto mouseHotspotSelRight() const -> QSize
-	{
-		const auto point = m_cursorSelectRight.hotSpot();
-		return QSize{point.x(), point.y()};
-	}
-
-	void setMouseHotspotSelRight(const QSize& s)
-	{
-		m_cursorSelectRight = QCursor{m_cursorSelectRight.pixmap(), s.width(), s.height()};
-	}
 
 	inline Song::PlayPos & pos()
 	{

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -68,7 +68,6 @@ public:
 	Q_PROPERTY(QColor activeLoopHandleColor MEMBER m_activeLoopHandleColor)
 	Q_PROPERTY( int loopRectangleVerticalPadding READ getLoopRectangleVerticalPadding WRITE setLoopRectangleVerticalPadding )
 	Q_PROPERTY(int loopHandleWidth MEMBER m_loopHandleWidth)
-	Q_PROPERTY(int loopMoveHandleWidth MEMBER m_loopMoveHandleWidth)
 	Q_PROPERTY(QSize mouseHotspotSelLeft READ mouseHotspotSelLeft WRITE setMouseHotspotSelLeft)
 	Q_PROPERTY(QSize mouseHotspotSelRight READ mouseHotspotSelRight WRITE setMouseHotspotSelRight)
 
@@ -206,8 +205,7 @@ private:
 	QColor m_activeLoopHandleColor = QColor{74, 155, 100, 255};
 
 	int m_loopRectangleVerticalPadding = 1;
-	int m_loopHandleWidth = 5;
-	int m_loopMoveHandleWidth = 30;
+	int m_loopHandleWidth = 400;
 
 	QColor m_barLineColor = QColor{192, 192, 192};
 	QColor m_barNumberColor = m_barLineColor.darker(120);

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -33,16 +33,22 @@ namespace lmms {
 
 void Timeline::setLoopBegin(TimePos begin)
 {
+	if (begin < 0 || begin == m_loopEnd) { return; }
+
 	std::tie(m_loopBegin, m_loopEnd) = std::minmax(begin, TimePos{m_loopEnd});
 }
 
 void Timeline::setLoopEnd(TimePos end)
 {
+	if (end < 0 || end == m_loopBegin) { return; }
+
 	std::tie(m_loopBegin, m_loopEnd) = std::minmax(TimePos{m_loopBegin}, end);
 }
 
 void Timeline::setLoopPoints(TimePos begin, TimePos end)
 {
+	if (begin < 0 || end < 0 || begin == end) { return; }
+
 	std::tie(m_loopBegin, m_loopEnd) = std::minmax(begin, end);
 }
 

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -211,7 +211,7 @@ void TimeLineWidget::paintEvent( QPaintEvent * )
 	
 	// Draw loop move handle if necessary
 	const auto markerMode = ConfigManager::inst()->value("app", "loopmarkermode");
-	const auto handleMode = markerMode == "handles" || markerMode == "closest"; // for compatibility
+	const auto handleMode = markerMode == "closest" || markerMode == "handles"; // for backwards-compatibility
 	const auto shiftPressed = QGuiApplication::keyboardModifiers().testFlag(Qt::ShiftModifier);
 	const auto bigEnough = loopRectWidth >= m_loopHandleWidth * 3;
    // Hide handle during move because it moves slower than the cursor when a loop end goes off screen
@@ -252,7 +252,7 @@ auto TimeLineWidget::getLoopAction(QMouseEvent* event) const -> TimeLineWidget::
 	const auto xPos = event->x();
 	const auto button = event->button();
 
-	if (mode == "handles" || mode == "closest" /* for compatibility */)
+	if (mode == "closest" || mode == "handles" /* for compatibility */)
 	{
 		// Loop start and end pos, or closest edge of screen if loop extends off it
 		const auto leftMost = std::max(markerX(m_timeline->loopBegin()), m_xOffset);
@@ -450,7 +450,7 @@ void TimeLineWidget::contextMenuEvent(QContextMenuEvent* event)
 		if (loopMode == mode) { action->setChecked(true); }
 	};
 	addLoopModeAction(tr("Dual-button"), "dual");
-	addLoopModeAction(tr("Handles"), "handles");
+	addLoopModeAction(tr("Grab closest"), "closest");
 
 	menu.exec(event->globalPos());
 }

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -258,7 +258,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_loopMarkerComboBox = new QComboBox{guiGroupBox};
 
 	m_loopMarkerComboBox->addItem(tr("Dual-button"), "dual");
-	m_loopMarkerComboBox->addItem(tr("Handles"), "handles");
+	m_loopMarkerComboBox->addItem(tr("Grab closest"), "closest");
 
 	m_loopMarkerComboBox->setCurrentIndex(m_loopMarkerComboBox->findData(m_loopMarkerMode));
 	connect(m_loopMarkerComboBox, qOverload<int>(&QComboBox::currentIndexChanged),

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -258,7 +258,6 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_loopMarkerComboBox = new QComboBox{guiGroupBox};
 
 	m_loopMarkerComboBox->addItem(tr("Dual-button"), "dual");
-	m_loopMarkerComboBox->addItem(tr("Grab closest"), "closest");
 	m_loopMarkerComboBox->addItem(tr("Handles"), "handles");
 
 	m_loopMarkerComboBox->setCurrentIndex(m_loopMarkerComboBox->findData(m_loopMarkerMode));


### PR DESCRIPTION
Fixes #7984

Currently the "Handles" loop edit mode is kinda useless since the most common use (move one end of the loop) is restricted to a tiny area. On the other hand the "Grab closest" mode is infamously annoying because it cannot reach the other loop marker if it's far off screen.

This PR merges both modes into one. It grabs the closest handle, whether you click inside our outside the loop. If one handle is off screen it acts if that handle was at the screen's edge (so if you click closer to the edge, it grabs that handle instead). There's a small move handle in the middle. The move cursor is a hand instead of <-> to make it easier on your brain. If the loop is tiny, the whole loop becomes a move handle, and the empty spaces beside is used to resize.

https://github.com/user-attachments/assets/554305dd-ea72-44e7-95d9-3e35acc4ec26

The video is a bit laggy...

Update: now only the middle handle is drawn and the setting is called "Grab closest".