### PR TITLE
Audio buffer view improvements

### DIFF
--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -63,7 +63,7 @@ public:
 	}
 
 	constexpr auto data() const noexcept -> SampleT* { return m_data; }
-	constexpr auto channels() const noexcept -> proc_ch_t { return channelCount; }
+	static constexpr auto channels() noexcept -> proc_ch_t { return channelCount; }
 	constexpr auto frames() const noexcept -> f_cnt_t { return m_frames; }
 
 protected:
@@ -156,7 +156,7 @@ public:
 
 	constexpr auto empty() const noexcept -> bool
 	{
-		return !this->m_data || this->channels() == 0 || this->m_frames == 0;
+		return !this->m_data || Base::channels() == 0 || this->m_frames == 0;
 	}
 
 	//! @return the frame at the given index
@@ -164,11 +164,11 @@ public:
 	{
 		if constexpr (channelCount == DynamicChannelCount)
 		{
-			return std::span<SampleT>{framePtr(index), this->channels()};
+			return std::span<SampleT>{framePtr(index), Base::channels()};
 		}
 		else
 		{
-			return std::span<SampleT, channelCount>{framePtr(index), this->channels()};
+			return std::span<SampleT, channelCount>{framePtr(index), Base::channels()};
 		}
 	}
 
@@ -179,7 +179,7 @@ public:
 	constexpr auto framePtr(f_cnt_t index) const noexcept -> SampleT*
 	{
 		assert(index < this->m_frames);
-		return this->m_data + index * this->channels();
+		return this->m_data + index * Base::channels();
 	}
 
 	/**
@@ -237,7 +237,7 @@ public:
 
 	constexpr auto empty() const noexcept -> bool
 	{
-		return !this->m_data || this->channels() == 0 || this->m_frames == 0;
+		return !this->m_data || Base::channels() == 0 || this->m_frames == 0;
 	}
 
 	//! @return the buffer of the given channel
@@ -259,7 +259,7 @@ public:
 	 */
 	constexpr auto bufferPtr(proc_ch_t channel) const noexcept -> SampleT*
 	{
-		assert(channel < this->channels());
+		assert(channel < Base::channels());
 		assert(this->m_data != nullptr);
 		return this->m_data[channel];
 	}

--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -49,7 +49,7 @@ public:
 	constexpr BufferViewData() = default;
 	constexpr BufferViewData(const BufferViewData&) = default;
 
-	constexpr BufferViewData(SampleT* data, proc_ch_t channels, f_cnt_t frames) noexcept
+	constexpr BufferViewData(SampleT* data, [[maybe_unused]] proc_ch_t channels, f_cnt_t frames) noexcept
 		: m_data{data}
 		, m_frames{frames}
 	{
@@ -157,6 +157,16 @@ public:
 	constexpr auto empty() const noexcept -> bool
 	{
 		return !this->m_data || Base::channels() == 0 || this->m_frames == 0;
+	}
+
+	constexpr auto dataSizeBytes() const noexcept -> std::size_t
+	{
+		return Base::channels() * this->m_frames * sizeof(SampleT);
+	}
+
+	constexpr auto dataView() noexcept -> std::span<SampleT>
+	{
+		return std::span<SampleT>{this->m_data, this->m_frames * Base::channels()};
 	}
 
 	//! @return the frame at the given index

--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -97,7 +97,26 @@ protected:
 	f_cnt_t m_frames = 0;
 };
 
+template<typename T, typename... AllowedTs>
+inline constexpr bool OneOf = (std::is_same_v<T, AllowedTs> || ...);
+
 } // namespace detail
+
+
+//! Recognized sample types, either const or non-const
+template<typename T>
+concept SampleType = detail::OneOf<std::remove_const_t<T>,
+	float,
+	double,
+	std::int8_t,
+	std::uint8_t,
+	std::int16_t,
+	std::uint16_t,
+	std::int32_t,
+	std::uint32_t,
+	std::int64_t,
+	std::uint64_t
+>;
 
 
 /**
@@ -105,7 +124,7 @@ protected:
  *
  * TODO C++23: Use std::mdspan?
  */
-template<typename SampleT, proc_ch_t channelCount = DynamicChannelCount>
+template<SampleType SampleT, proc_ch_t channelCount = DynamicChannelCount>
 class InterleavedBufferView : public detail::BufferViewData<SampleT, channelCount>
 {
 	using Base = detail::BufferViewData<SampleT, channelCount>;
@@ -186,7 +205,7 @@ static_assert(sizeof(InterleavedBufferView<float, 2>) == sizeof(void*) + sizeof(
  *
  * TODO C++23: Use std::mdspan?
  */
-template<typename SampleT, proc_ch_t channelCount = DynamicChannelCount>
+template<SampleType SampleT, proc_ch_t channelCount = DynamicChannelCount>
 class PlanarBufferView : public detail::BufferViewData<SampleT* const, channelCount>
 {
 	using Base = detail::BufferViewData<SampleT* const, channelCount>;

--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -387,6 +387,21 @@ public:
 		return framePtr(index);
 	}
 
+	//! @returns a subview at the given frame offset `offset` with a frame count of `frames`
+	constexpr auto subspan(f_cnt_t offset, f_cnt_t frames) const -> InterleavedBufferView<SampleT, channelCount>
+	{
+		assert(offset <= this->m_frames);
+		assert(offset + frames <= this->m_frames);
+		if constexpr (channelCount == DynamicChannelCount)
+		{
+			return {this->m_data + offset * Base::channels(), Base::channels(), frames};
+		}
+		else
+		{
+			return {this->m_data + offset * Base::channels(), frames};
+		}
+	}
+
 	//! @returns a const view over the frames. Iterates in chunks containing `channels()` elements.
 	constexpr auto framesView() const noexcept -> std::ranges::subrange<ConstFrameIter, const SampleT*>
 	{


### PR DESCRIPTION
After some experience using the new [audio buffer views](https://github.com/LMMS/lmms/pull/7945) in #7459 and #7858, it became clear that there was some useful quality-of-life functionality still missing (especially in `InterleavedBufferView`).

This PR adds that extra functionality we found useful.