### PR TITLE
Glue all notes if none are selected

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -646,11 +646,7 @@ void PianoRoll::glueNotes()
 		NoteVector selectedNotes = getSelectedNotes();
 		if (selectedNotes.empty())
 		{
-			TextFloat::displayMessage( tr( "Glue notes failed" ),
-					tr( "Please select notes to glue first." ),
-					embed::getIconPixmap( "glue", 24, 24 ),
-					3000 );
-			return;
+			selectedNotes = m_midiClip->notes();
 		}
 
 		// Make undo possible


### PR DESCRIPTION
All the other actions work without selection, now Glue that too.

Motivation: I frequently do Shift+F Shift+G on clips.

https://github.com/user-attachments/assets/3752f6f9-f867-4a2f-9e20-41610c79eb44

