### PR TITLE
Fix the sidebar bookmarks getting reset when opening a file dialog

### DIFF
--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -37,9 +37,15 @@ class LMMS_EXPORT FileDialog : public QFileDialog
 {
 	Q_OBJECT
 public:
+	QList<QUrl> m_urls;
+	QList<QUrl> m_beforeUrls;
+	QList<QUrl> m_addedSidebarUrls;
+
 	explicit FileDialog( QWidget *parent = 0, const QString &caption = QString(),
 						const QString &directory = QString(),
 						const QString &filter = QString() );
+
+	~FileDialog();
 
 	static QString getExistingDirectory(QWidget *parent,
 										const QString &caption,


### PR DESCRIPTION
Fixes an issue introduced in 89baab6b87df8401cea43118a067573c1e99d303 where the Qt bookmark list would get reset to a pre-defined list when opening a file dialog (Opening a project file, saving a project file, etc)

Tested Platforms:
- [x] Linux
- [x] Windows
- [ ] macOS

Closes #7405