### PR TITLE
Make LMMS not constantly crash when debugging

### DIFF
--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -48,7 +48,7 @@ class LMMS_EXPORT EffectChain : public Model, public SerializingObject
 {
 	Q_OBJECT
 public:
-	EffectChain( Model * _parent );
+	EffectChain();
 	~EffectChain() override;
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -39,12 +39,15 @@ public:
 	{
 	}
 
-	InlineAutomation(const InlineAutomation& _copy) :
-		FloatModel(_copy.value(), _copy.minValue(), _copy.maxValue(), _copy.step<float>()),
-		m_autoClip(_copy.m_autoClip->clone())
+	InlineAutomation(const InlineAutomation& _copy)
+		: FloatModel(_copy.value(), _copy.minValue(), _copy.maxValue(), _copy.step<float>())
 	{
-		m_autoClip->clearObjects();
-		m_autoClip->addObject(this);
+		if (_copy.m_autoClip)
+		{
+			m_autoClip = _copy.m_autoClip->clone();
+			m_autoClip->clearObjects();
+			m_autoClip->addObject(this);
+		}
 	}
 
 	~InlineAutomation() override

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -49,7 +49,7 @@ public:
 
 	~InlineAutomation() override
 	{
-		m_autoClip->deleteLater();
+		if (m_autoClip) { m_autoClip->deleteLater(); }
 	}
 
 	virtual float defaultValue() const = 0;

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -49,6 +49,7 @@ public:
 
 	~InlineAutomation() override
 	{
+		m_autoClip->deleteLater();
 	}
 
 	virtual float defaultValue() const = 0;
@@ -82,10 +83,10 @@ public:
 	{
 		if( m_autoClip == nullptr )
 		{
-			m_autoClip = std::make_unique<AutomationClip>(nullptr);
+			m_autoClip = new AutomationClip(nullptr);
 			m_autoClip->addObject( this );
 		}
-		return m_autoClip.get();
+		return m_autoClip;
 	}
 
 	void saveSettings( QDomDocument & _doc, QDomElement & _parent ) override;
@@ -93,7 +94,7 @@ public:
 
 
 private:
-	std::unique_ptr<AutomationClip> m_autoClip;
+	AutomationClip* m_autoClip = nullptr;
 
 } ;
 

--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -308,7 +308,7 @@ private:
 
 	Microtuner m_microtuner;
 
-	std::unique_ptr<BoolModel> m_midiCCEnable;
+	BoolModel m_midiCCEnable;
 	std::unique_ptr<FloatModel> m_midiCCModel[MidiControllerCount];
 
 	friend class gui::InstrumentTrackView;

--- a/include/Model.h
+++ b/include/Model.h
@@ -44,8 +44,6 @@ public:
 
 	bool isDefaultConstructed() const;
 
-	Model* parentModel() const;
-
 	virtual QString displayName() const;
 
 	virtual void setDisplayName(const QString& displayName);

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -148,14 +148,15 @@ inline float signedPowf(float v, float e)
 inline float logToLinearScale(float min, float max, float value)
 {
 	using namespace std::numbers;
+	const float valueLimited = std::clamp(value, 0.f, 1.f);
 	if (min < 0)
 	{
 		const float mmax = std::max(std::abs(min), std::abs(max));
-		const float val = value * (max - min) + min;
+		const float val = valueLimited * (max - min) + min;
 		float result = signedPowf(val / mmax, e_v<float>) * mmax;
 		return std::isnan(result) ? 0 : result;
 	}
-	float result = std::pow(value, e_v<float>) * (max - min) + min;
+	float result = std::pow(valueLimited, e_v<float>) * (max - min) + min;
 	return std::isnan(result) ? 0 : result;
 }
 

--- a/src/core/AudioBusHandle.cpp
+++ b/src/core/AudioBusHandle.cpp
@@ -45,7 +45,7 @@ AudioBusHandle::AudioBusHandle(const QString& name, bool hasEffectChain,
 	m_extOutputEnabled(false),
 	m_nextMixerChannel(0),
 	m_name(name),
-	m_effects(hasEffectChain ? new EffectChain(nullptr) : nullptr),
+	m_effects(hasEffectChain ? new EffectChain : nullptr),
 	m_volumeModel(volumeModel),
 	m_panningModel(panningModel),
 	m_mutedModel(mutedModel)

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -104,7 +104,7 @@ void EffectChain::loadSettings( const QDomElement & _this )
 			else
 			{
 				delete e;
-				e = new DummyEffect( parentModel(), effectData );
+				e = new DummyEffect(this, effectData);
 			}
 
 			m_effects.push_back( e );

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -36,8 +36,8 @@ namespace lmms
 {
 
 
-EffectChain::EffectChain( Model * _parent ) :
-	Model( _parent ),
+EffectChain::EffectChain() :
+	Model(nullptr),
 	SerializingObject(),
 	m_enabledModel( false, nullptr, tr( "Effects enabled" ) )
 {

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -58,7 +58,7 @@ void MixerRoute::updateName()
 
 
 MixerChannel::MixerChannel( int idx, Model * _parent ) :
-	m_fxChain( nullptr ),
+	m_fxChain(),
 	m_hasInput( false ),
 	m_stillRunning( false ),
 	m_peakLeft( 0.0f ),

--- a/src/core/Model.cpp
+++ b/src/core/Model.cpp
@@ -39,11 +39,6 @@ bool Model::isDefaultConstructed() const
 	return m_defaultConstructed;
 }
 
-Model* Model::parentModel() const
-{
-	return dynamic_cast<Model*>(parent());
-}
-
 QString Model::displayName() const
 {
 	return m_displayName;
@@ -58,9 +53,9 @@ QString Model::fullDisplayName() const
 {
 	const QString n = displayName();
 
-	if (parentModel())
+	if (auto parentModel = dynamic_cast<Model*>(parent()))
 	{
-		const QString p = parentModel()->fullDisplayName();
+		const QString p = parentModel->fullDisplayName();
 
 		if (!p.isEmpty())
 		{

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -100,7 +100,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 
 	// Set all the models
 	// Set the LED button to enable/disable the track midi cc
-	m_midiCCGroupBox->setModel(m_track->m_midiCCEnable.get());
+	m_midiCCGroupBox->setModel(&m_track->m_midiCCEnable);
 
 	// Connection to update the name of the track on the label
 	connect(m_track, SIGNAL(nameChanged()),


### PR DESCRIPTION
This is some cleanup that came from me trying to run LMMS on a Qt debug build with FPE debugging and getting crashes. And then investigating all usages of `unique_ptr<QObject>` to see if there would be more potential crashes.

### 1. Fix NaN error in `logToLinearScale`

With FPE debugging enabled, dragging a knob below 0 raised an error. This is because it tries to compute -1^e which is not a real number. Solution: clamp input to safe range, so this never happens even if function is sloppily called.

### 2. Fix assertion error on Qt debug builds

When LMMS is built using a Qt debug build there's an assertion error when a note stops playing. The note play handle is created in the main thread and deleted in an audio thread. The play handle contains an AutomationClip which is a QObject. When deleting the clip and its child models Qt tries to send a `ChildRemoved` signal to it, but because this happens in a different thread than the Clip was created in, the signal mechanism fails and this triggers the error.

Solution: don't store the clip in a `unique_ptr`, instead manually call `AutomationClip::deleteLater()` and let Qt delete it in the correct thread.

### 3. Store `m_midiCCEnable` directly, not as pointer

Remove another unnecessary usage of `unique_ptr` which was potentially unsafe because nowhere did it check if the pointer was `nullptr`.

### 4. Remove unused argument from `EffectChain()`

`EffectChain` is always instantiated with `nullptr` as its argument (which is eventually passed down to QObject as the parent). To make the code easier to follow, I removed this argument.

### 5. Remove `Model::parentModel()`

One usage of `parentModel()` referenced the EffectChain's parent which is always `nullptr` as I said. The only other usage was internal to `Model` so I removed this public function altogether.