### PR TITLE
Fix memory problems

### DIFF
--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -270,9 +270,9 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 	}
 
 	auto outputName = jack_port_name(m_outputPorts[outputIndex]);
-	auto targetName = targetPort.toLatin1().constData();
+	auto targetName = targetPort.toLatin1();
 
-	attemptToConnect(outputIndex, "output", outputName, targetName);
+	attemptToConnect(outputIndex, "output", outputName, targetName.constData());
 }
 
 void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
@@ -286,9 +286,9 @@ void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& source
 	}
 
 	auto inputName = jack_port_name(m_inputPorts[inputIndex]);
-	auto sourceName = sourcePort.toLatin1().constData();
+	auto sourceName = sourcePort.toLatin1();
 
-	attemptToConnect(inputIndex, "input", sourceName, inputName);
+	attemptToConnect(inputIndex, "input", sourceName.constData(), inputName);
 }
 
 

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -261,7 +261,7 @@ void AudioJack::attemptToConnect(size_t index, const char *lmms_port_type, const
 
 void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targetPort)
 {
-	if (outputIndex > m_outputPorts.size()) return;
+	if (outputIndex >= m_outputPorts.size()) return;
 
 	if (targetPort == disconnectedRepresentation)
 	{
@@ -277,7 +277,7 @@ void AudioJack::attemptToReconnectOutput(size_t outputIndex, const QString& targ
 
 void AudioJack::attemptToReconnectInput(size_t inputIndex, const QString& sourcePort)
 {
-	if (inputIndex > m_inputPorts.size()) return;
+	if (inputIndex >= m_inputPorts.size()) return;
 
 	if (sourcePort == disconnectedRepresentation)
 	{


### PR DESCRIPTION
Fix a memory problems that has been found by a second review of #7919 and a potential out-of-index access.

## Fix problems with lifetime of QByteArray

Fix a problem with the lifetime of a `QByteArray` in `attemptToReconnectOutput` and `attemptToReconnectInput` (also see here: https://github.com/LMMS/lmms/pull/7919#discussion_r2257756049).

The method `constData` was called on a temporary which gets destroyed before `targetName` and `sourceName` are used, thus leading to undefined behavior.


## Fix index checks

Fix index checks in `attemptToReconnectOutput` and `attemptToReconnectInput`.

The previous code would have allowed an index to be `size` of the underlying vector which would access out-of-bounds memory.