### PR TITLE
OpulenZ: Fix compilation error

### DIFF
--- a/plugins/OpulenZ/OpulenZ.cpp
+++ b/plugins/OpulenZ/OpulenZ.cpp
@@ -514,7 +514,7 @@ int OpulenzInstrument::Hz2fnum(float Hz) {
 
 // Load one of the default patches
 void OpulenzInstrument::loadGMPatch() {
-	unsigned char *inst = midi_fm_instruments[m_patchModel.value()];
+	const unsigned char* inst = midi_fm_instruments[m_patchModel.value()];
 	loadPatch(inst);
 }
 


### PR DESCRIPTION
This patch fixes the error: `invalid conversion from 'const unsigned char*' to 'unsigned char*'`