### PR TITLE
Fix null pointer deref when getting VST window size

### DIFF
--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -813,16 +813,24 @@ void RemoteVstPlugin::initEditor()
 	pluginDispatch( effEditOpen, 0, 0, m_window );
 
 	ERect* er = nullptr;
-	pluginDispatch( effEditGetRect, 0, 0, &er );
+	pluginDispatch(effEditGetRect, 0, 0, &er);
 
-	m_windowWidth = er->right - er->left;
-	m_windowHeight = er->bottom - er->top;
+	if (er)
+	{
+		assert(er->right > er->left);
+		m_windowWidth = er->right - er->left;
+		assert(er->bottom > er->top);
+		m_windowHeight = er->bottom - er->top;
 
-	RECT windowSize = { 0, 0, m_windowWidth, m_windowHeight };
-	AdjustWindowRect( &windowSize, dwStyle, false );
-	SetWindowPos( m_window, 0, 0, 0, windowSize.right - windowSize.left,
-			windowSize.bottom - windowSize.top, SWP_NOACTIVATE |
-						SWP_NOMOVE | SWP_NOZORDER );
+		RECT windowSize = { 0, 0, m_windowWidth, m_windowHeight };
+		AdjustWindowRect(&windowSize, dwStyle, false);
+		SetWindowPos(m_window, 0, 0, 0,
+			windowSize.right - windowSize.left,
+			windowSize.bottom - windowSize.top,
+			SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER
+		);
+	}
+
 	pluginDispatch( effEditTop );
 
 #ifdef LMMS_BUILD_LINUX
@@ -834,36 +842,42 @@ void RemoteVstPlugin::initEditor()
 
 #else
 	Atom prop_atom, val_atom;
-	
+
 	if (m_display == nullptr)
 	{
 		m_display = XOpenDisplay(nullptr);
 	}
 	m_window = XCreateSimpleWindow(m_display, DefaultRootWindow(m_display), 0, 0, 400, 400, 0, 0, 0);
-	
+
 	m_wmDeleteMessage = XInternAtom(m_display, "WM_DELETE_WINDOW", false);
 	XSetWMProtocols(m_display, m_window, &m_wmDeleteMessage, 1);
-	
+
 	// make tool window
 	prop_atom = XInternAtom(m_display, "_NET_WM_WINDOW_TYPE", False);
 	val_atom = XInternAtom(m_display, "_NET_WM_WINDOW_TYPE_DIALOG", False);
 	XChangeProperty(m_display, m_window, prop_atom, XA_ATOM, 32, PropModeReplace, (unsigned char *)&val_atom, 1);
-	
+
 	// change name
 	XStoreName(m_display, m_window, pluginName());
-	
+
+	XMapWindow(m_display, m_window);
+	XFlush(m_display);
+
 	ERect* er = nullptr;
 	pluginDispatch(effEditGetRect, 0, 0, &er);
 
-	m_windowWidth = er->right - er->left;
-	m_windowHeight = er->bottom - er->top;
-	XResizeWindow(m_display, m_window, m_windowWidth, m_windowHeight);
-	
-	XMapWindow(m_display, m_window);
-	XFlush(m_display);
-	
+	if (er)
+	{
+		assert(er->right > er->left);
+		m_windowWidth = er->right - er->left;
+		assert(er->bottom > er->top);
+		m_windowHeight = er->bottom - er->top;
+		XResizeWindow(m_display, m_window,
+			static_cast<unsigned int>(m_windowWidth), static_cast<unsigned int>(m_windowHeight));
+	}
+
 	pluginDispatch(effEditOpen, 0, (intptr_t) m_display, (void*) m_window);
-	
+
 	XSelectInput(m_display, m_window, SubstructureNotifyMask | ButtonPressMask | ButtonReleaseMask
 			| ButtonMotionMask | ExposureMask | KeyPressMask);
 	

--- a/plugins/VstBase/RemoteVstPlugin.cpp
+++ b/plugins/VstBase/RemoteVstPlugin.cpp
@@ -860,9 +860,6 @@ void RemoteVstPlugin::initEditor()
 	// change name
 	XStoreName(m_display, m_window, pluginName());
 
-	XMapWindow(m_display, m_window);
-	XFlush(m_display);
-
 	ERect* er = nullptr;
 	pluginDispatch(effEditGetRect, 0, 0, &er);
 
@@ -875,6 +872,9 @@ void RemoteVstPlugin::initEditor()
 		XResizeWindow(m_display, m_window,
 			static_cast<unsigned int>(m_windowWidth), static_cast<unsigned int>(m_windowHeight));
 	}
+
+	XMapWindow(m_display, m_window);
+	XFlush(m_display);
 
 	pluginDispatch(effEditOpen, 0, (intptr_t) m_display, (void*) m_window);
 


### PR DESCRIPTION
Fixes a regression from #7916 which caused Linux Studio Plugins (LSP) to crash.

The culprit was this code:
```cpp
ERect* er = nullptr;
pluginDispatch(effEditGetRect, 0, 0, &er);

m_windowWidth = er->right - er->left;
m_windowHeight = er->bottom - er->top;
```

Prior to #7916, the `er` pointer was declared uninitialized rather than set to nullptr.

Unlike most VST plugins, the LSP LinuxVSTs do not implement the `effEditGetRect` dispatch command and instead send window size information to the host via a `RemoteVstPlugin::hostCallback` message with the `audioMasterSizeWindow` opcode, so after `pluginDispatch` was called, the `er` pointer remained uninitialized pre-7916 and null post-7916.

Pre-7916, this meant it was dereferencing an uninitialized pointer to read what it thought was the window size. This is incredibly bad, but apparently did not cause a crash - at least not all of the time. But post-7916, this always caused a segfault rather than a silent error.

I fixed this with a simple null pointer check, and I also added a couple asserts to ensure the window size values are not invalid.