### PR TITLE
Hitting Home in the Song-Editor or PianoRoll-Editor resets Time Display

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -611,6 +611,7 @@ void Song::setPlayPos( tick_t ticks, PlayMode playMode )
 	getPlayPos(playMode).setTicks( ticks );
 	getPlayPos(playMode).setCurrentFrame( 0.0f );
 	getPlayPos(playMode).setJumped( true );
+	setToTime(0);
 
 // send a signal if playposition changes during playback
 	if( isPlaying() )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1459,7 +1459,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 		case Qt::Key_Home:
 			m_timeLine->pos().setTicks( 0 );
 			m_timeLine->updatePosition();
-			Engine::getSong()->setToTimeByTicks(0);
+			Engine::getSong()->setToTime(0);
 			ke->accept();
 			break;
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1459,6 +1459,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 		case Qt::Key_Home:
 			m_timeLine->pos().setTicks( 0 );
 			m_timeLine->updatePosition();
+			Engine::getSong()->setToTimeByTicks(0);
 			ke->accept();
 			break;
 


### PR DESCRIPTION
The TimeDisplayWidget retrieves the current song position using getMilliseconds() or playPos().
This time value is not reset to 0 when the Home key is pressed.

#7956