### PR TITLE
Allow Tempo Sync Knobs and Bars to be logarithmic

### DIFF
--- a/src/gui/widgets/TempoSyncBarModelEditor.cpp
+++ b/src/gui/widgets/TempoSyncBarModelEditor.cpp
@@ -89,6 +89,9 @@ void TempoSyncBarModelEditor::contextMenuEvent(QContextMenuEvent *)
 
 	CaptionMenu contextMenu(tempoSyncModel->displayName(), this);
 	addDefaultActions(&contextMenu);
+	contextMenu.addAction(QPixmap(),
+		model()->isScaleLogarithmic() ? tr("Set linear") : tr("Set logarithmic"),
+		this, SLOT(toggleScale()));
 
 	contextMenu.addSeparator();
 

--- a/src/gui/widgets/TempoSyncKnob.cpp
+++ b/src/gui/widgets/TempoSyncKnob.cpp
@@ -107,6 +107,9 @@ void TempoSyncKnob::contextMenuEvent( QContextMenuEvent * )
 
 	CaptionMenu contextMenu( model()->displayName(), this );
 	addDefaultActions( &contextMenu );
+	contextMenu.addAction(QPixmap(),
+		model()->isScaleLogarithmic() ? tr("Set linear") : tr("Set logarithmic"),
+		this, SLOT(toggleScale()));
 	contextMenu.addSeparator();
 
 	float limit = 60000.0f / ( Engine::getSong()->getTempo() *


### PR DESCRIPTION
Fixes #7810. The tempo sync seems to still work properly.

Before:
<img width="323" height="345" alt="image" src="https://github.com/user-attachments/assets/99b5f8f9-e84d-4b8c-9242-a988fea5a888" />
<img width="453" height="495" alt="image" src="https://github.com/user-attachments/assets/84c777e2-2ccc-4734-ba0d-98e5dc06c210" />

After:
<img width="323" height="345" alt="image" src="https://github.com/user-attachments/assets/f1655363-ff21-4714-bc4c-9e80c0b21986" />
<img width="381" height="490" alt="image" src="https://github.com/user-attachments/assets/23245fd3-c7d0-4094-b366-2948f81e25a5" />
