### PR TITLE
Auto-quit rework

### DIFF
--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -319,17 +319,17 @@ public:
 	{
 	}
 
-	//! Construct from std::span<SampleFrame>
-	InterleavedBufferView(std::span<SampleFrame> buffer) noexcept
+	//! Construct from SampleFrame*
+	InterleavedBufferView(SampleFrame* data, f_cnt_t frames) noexcept
 		requires (std::is_same_v<std::remove_const_t<T>, float> && channelCount == 2)
-		: Base{reinterpret_cast<float*>(buffer.data()), buffer.size()}
+		: Base{reinterpret_cast<float*>(data), frames}
 	{
 	}
 
-	//! Construct from std::span<const SampleFrame>
-	InterleavedBufferView(std::span<const SampleFrame> buffer) noexcept
+	//! Construct from const SampleFrame*
+	InterleavedBufferView(const SampleFrame* data, f_cnt_t frames) noexcept
 		requires (std::is_same_v<T, const float> && channelCount == 2)
-		: Base{reinterpret_cast<const float*>(buffer.data()), buffer.size()}
+		: Base{reinterpret_cast<const float*>(data), frames}
 	{
 	}
 

--- a/include/AudioBus.h
+++ b/include/AudioBus.h
@@ -1,0 +1,149 @@
+/*
+ * AudioBus.h
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_AUDIO_BUS_H
+#define LMMS_AUDIO_BUS_H
+
+#include <bitset>
+
+#include "AudioBufferView.h"
+#include "LmmsTypes.h"
+#include "lmms_constants.h"
+#include "lmms_export.h"
+#include "SampleFrame.h"
+
+namespace lmms
+{
+
+/**
+ * A non-owning span of the track channels for an instrument or effect chain
+ * which keeps track of signal flow.
+ */
+class LMMS_EXPORT AudioBus
+{
+public:
+	AudioBus() = default;
+	AudioBus(const AudioBus&) = default;
+
+	AudioBus(SampleFrame* const* bus, track_ch_t channelPairs, f_cnt_t frames)
+		: m_bus{bus}
+		, m_channelPairs{channelPairs}
+		, m_frames{frames}
+	{
+	}
+
+	auto trackChannelPair(track_ch_t pairIndex) const -> InterleavedBufferView<const float, 2>
+	{
+		return {m_bus[pairIndex], m_frames};
+	}
+
+	auto trackChannelPair(track_ch_t pairIndex) -> InterleavedBufferView<float, 2>
+	{
+		return {m_bus[pairIndex], m_frames};
+	}
+
+	//! @returns 2-channel interleaved buffer for the given track channel pair
+	auto operator[](track_ch_t pairIndex) const -> const float*
+	{
+		return reinterpret_cast<const float*>(m_bus[pairIndex]);
+	}
+
+	//! @returns 2-channel interleaved buffer for the given track channel pair
+	auto operator[](track_ch_t pairIndex) -> float*
+	{
+		return reinterpret_cast<float*>(m_bus[pairIndex]);
+	}
+
+	//! @returns 2D array that can be accessed like: bus()[channel pair index][sample index]
+	auto bus() const -> const SampleFrame* const* { return m_bus; }
+
+	//! @returns 2D array that can be accessed like: bus()[channel pair index][sample index]
+	auto bus() -> SampleFrame* const* { return m_bus; }
+
+	auto channels() const -> track_ch_t { return m_channelPairs * 2; }
+	auto channelPairs() const -> track_ch_t { return m_channelPairs; }
+	auto frames() const -> f_cnt_t { return m_frames; }
+
+	auto quietChannels() const -> const std::bitset<MaxTrackChannels>& { return m_quietChannels; }
+	auto quietChannels() -> std::bitset<MaxTrackChannels>& { return m_quietChannels; }
+
+	/**
+	 * Determines whether a processor has input noise given
+	 * which track channels are routed to the processor's inputs.
+	 *
+	 * For `usedChannels`:
+	 *   0 = track channel is not routed to any processor inputs
+	 *   1 = track channel is routed to at least one processor input
+	 *
+	 * If the processor is sleeping and has input noise, it should wake up.
+	 */
+	auto hasInputNoise(const std::bitset<MaxTrackChannels>& usedChannels) const -> bool;
+
+	/**
+	 * @brief Sanitizes specified track channels of any Inf/NaN values if "nanhandler" setting is enabled
+	 *
+	 * @param channels track channels to sanitize; 1 = selected, 0 = skip
+	 * @param upperBound any track channel indexes at or above this are skipped
+	 */
+	void sanitize(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound = MaxTrackChannels);
+
+	void sanitizeAll();
+
+	/**
+	 * @brief Updates the silence status of the given channels, up to the upperBound index.
+	 *
+	 * @param channels track channels to update; 1 = selected, 0 = skip
+	 * @param upperBound any track channel indexes at or above this are skipped
+	 * @returns true if all updated channels were silent
+	 */
+	auto update(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound = MaxTrackChannels) -> bool;
+
+	auto updateAll() -> bool;
+
+	/**
+	 * @brief Silences (zeroes) the given channels
+	 *
+	 * @param channels track channels to silence; 1 = selected, 0 = skip
+	 * @param upperBound any track channel indexes at or above this are skipped
+	 */
+	void silenceChannels(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound = MaxTrackChannels);
+
+	void silenceAllChannels();
+
+private:
+	SampleFrame* const* m_bus = nullptr; //!< [channel pair index][sample index]
+	const track_ch_t m_channelPairs = 0;
+	const f_cnt_t m_frames = 0;
+
+	/**
+	 * Track channels which are known to be quiet.
+	 * 1 = track channel is quiet
+	 * 0 = track channel is assumed to carry a signal
+	 */
+	std::bitset<MaxTrackChannels> m_quietChannels;
+};
+
+} // namespace lmms
+
+#endif // LMMS_AUDIO_BUS_H

--- a/include/AudioBusHandle.h
+++ b/include/AudioBusHandle.h
@@ -30,6 +30,7 @@
 #include <QString>
 #include <QMutex>
 
+#include "AudioBus.h"
 #include "PlayHandle.h"
 
 namespace lmms
@@ -86,6 +87,7 @@ private:
 	volatile bool m_bufferUsage;
 
 	SampleFrame* const m_buffer;
+	AudioBus m_bus;
 
 	bool m_extOutputEnabled;
 	mix_ch_t m_nextMixerChannel;

--- a/include/Effect.h
+++ b/include/Effect.h
@@ -37,6 +37,7 @@
 namespace lmms
 {
 
+class AudioBus;
 class EffectChain;
 class EffectControls;
 
@@ -66,7 +67,7 @@ public:
 	}
 
 	//! Returns true if audio was processed and should continue being processed
-	bool processAudioBuffer(SampleFrame* buf, const fpp_t frames);
+	bool processAudioBuffer(AudioBus& inOut);
 
 	inline bool isOkay() const
 	{
@@ -78,22 +79,10 @@ public:
 		m_okay = _state;
 	}
 
-
-	inline bool isRunning() const
+	//! "Awake" means the effect has not been put to sleep by auto-quit
+	bool isAwake() const
 	{
-		return m_running;
-	}
-
-	void startRunning()
-	{
-		m_quietBufferCount = 0;
-		m_running = true;
-	}
-
-	void stopRunning()
-	{
-		m_quietBufferCount = 0;
-		m_running = false;
+		return m_awake;
 	}
 
 	inline bool isEnabled() const
@@ -126,7 +115,13 @@ public:
 	{
 		m_noRun = _state;
 	}
-	
+
+	//! "Running" means the effect will be processing audio
+	bool isRunning() const
+	{
+		return isEnabled() && isAwake() && isOkay() && !dontRun();
+	}
+
 	inline TempoSyncKnobModel* autoQuitModel()
 	{
 		return &m_autoQuitModel;
@@ -163,18 +158,30 @@ protected:
 	};
 
 	/**
-	 * The main audio processing method that runs when plugin is not asleep
+	 * The main audio processing method that runs when plugin is awake and running
 	 */
 	virtual ProcessStatus processImpl(SampleFrame* buf, const fpp_t frames) = 0;
 
 	/**
-	 * Optional method that runs when plugin is sleeping (not enabled,
-	 * not running, not in the Okay state, or in the Don't Run state)
+	 * Optional method that runs instead of `processImpl` when an effect
+	 * is awake but not running.
 	 */
 	virtual void processBypassedImpl() {}
 
 
 	gui::PluginView* instantiateView( QWidget * ) override;
+
+	void startRunning()
+	{
+		m_quietBufferCount = 0;
+		m_awake = true;
+	}
+
+	void stopRunning()
+	{
+		m_quietBufferCount = 0;
+		m_awake = false;
+	}
 
 	// some effects might not be capable of higher sample-rates so they can
 	// sample it down before processing and back after processing
@@ -208,7 +215,7 @@ private:
 	 * after "decay" ms of the output buffer remaining below the silence threshold, the effect is
 	 * turned off and won't be processed again until it receives new audio input.
 	 */
-	void handleAutoQuit(std::span<const SampleFrame> output);
+	void handleAutoQuit(bool silentOutput);
 
 
 	EffectChain * m_parent;
@@ -219,7 +226,7 @@ private:
 
 	bool m_okay;
 	bool m_noRun;
-	bool m_running;
+	bool m_awake;
 
 	//! The number of consecutive periods where output buffers remain below the silence threshold
 	f_cnt_t m_quietBufferCount = 0;

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -33,8 +33,8 @@
 namespace lmms
 {
 
+class AudioBus;
 class Effect;
-class SampleFrame;
 
 namespace gui
 {
@@ -63,8 +63,7 @@ public:
 	void removeEffect( Effect * _effect );
 	void moveDown( Effect * _effect );
 	void moveUp( Effect * _effect );
-	bool processAudioBuffer( SampleFrame* _buf, const fpp_t _frames, bool hasInputNoise );
-	void startRunning();
+	bool processAudioBuffer(AudioBus& bus);
 
 	void clear();
 

--- a/include/LmmsPolyfill.h
+++ b/include/LmmsPolyfill.h
@@ -1,0 +1,58 @@
+/*
+ * LmmsPolyfill.h - Small helpers and stand-in for newer C++ features
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_POLYFILL_H
+#define LMMS_POLYFILL_H
+
+namespace lmms
+{
+
+/**
+ * Stand-in for C++23's std::unreachable
+ * Taken from https://en.cppreference.com/w/cpp/utility/unreachable
+ *
+ * TODO C++23: Use std::unreachable instead
+ */
+[[noreturn]] inline void unreachable()
+{
+#if defined(_MSC_VER) && !defined(__clang__) // MSVC
+	__assume(false);
+#else // GCC, Clang
+	__builtin_unreachable();
+#endif
+}
+
+
+/**
+ * Can be used with static_assert() in an uninstantiated template
+ * as a workaround for static_assert(false)
+ *
+ * TODO C++23: No longer needed with resolution of CWG2518
+ */
+template<class... T>
+inline constexpr bool always_false_v = false;
+
+} // namespace lmms
+
+#endif // LMMS_POLYFILL_H

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -25,6 +25,7 @@
 #ifndef LMMS_MIXER_H
 #define LMMS_MIXER_H
 
+#include "AudioBus.h"
 #include "Model.h"
 #include "EffectChain.h"
 #include "JournallingObject.h"
@@ -57,6 +58,7 @@ class MixerChannel : public ThreadableJob
 		float m_peakLeft;
 		float m_peakRight;
 		SampleFrame* m_buffer;
+		AudioBus m_bus;
 		bool m_muteBeforeSolo;
 		BoolModel m_muteModel;
 		BoolModel m_soloModel;
@@ -143,7 +145,7 @@ public:
 	Mixer();
 	~Mixer() override;
 
-	void mixToChannel( const SampleFrame* _buf, mix_ch_t _ch );
+	void mixToChannel(const AudioBus& bus, mix_ch_t channel);
 
 	void prepareMasterMix();
 	void masterMix( SampleFrame* _buf );

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -35,6 +35,7 @@ namespace lmms
 inline constexpr float F_EPSILON = 1.0e-10f; // 10^-10
 
 inline constexpr ch_cnt_t DEFAULT_CHANNELS = 2;
+inline constexpr track_ch_t MaxTrackChannels = 256;
 
 // Microtuner
 inline constexpr unsigned MaxScaleCount = 10;  //!< number of scales per project

--- a/src/core/AudioBus.cpp
+++ b/src/core/AudioBus.cpp
@@ -1,0 +1,312 @@
+/*
+ * AudioBus.cpp
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "AudioBus.h"
+
+#include <algorithm>
+#include <type_traits>
+
+#include "LmmsPolyfill.h"
+#include "MixHelpers.h"
+
+namespace lmms
+{
+
+namespace
+{
+/*
+ * In the past, the RMS was calculated then compared with a threshold of 10^(-10).
+ * Now we use a different algorithm to determine whether a buffer is non-quiet, so
+ * a new threshold is needed for the best compatibility. The following is how it's derived.
+ *
+ * Old method:
+ * RMS = average (L^2 + R^2) across stereo buffer.
+ * RMS threshold = 10^(-10)
+ *
+ * So for a single channel, it would be:
+ * RMS/2 = average M^2 across single channel buffer.
+ * RMS/2 threshold = 5^(-11)
+ *
+ * The new algorithm for determining whether a buffer is non-silent compares M with the threshold,
+ * not M^2, so the square root of M^2's threshold should give us the most compatible threshold for
+ * the new algorithm:
+ *
+ * (RMS/2)^0.5 = (5^(-11))^0.5 = 0.0001431 (approx.)
+ *
+ * In practice though, the exact value shouldn't really matter so long as it's sufficiently small.
+ */
+constexpr auto SilenceThreshold = 0.0001431f;
+
+} // namespace
+
+auto AudioBus::hasInputNoise(const std::bitset<MaxTrackChannels>& usedChannels) const -> bool
+{
+	auto nonQuiet = ~m_quietChannels;
+	nonQuiet &= usedChannels;
+	return nonQuiet.any();
+}
+
+void AudioBus::sanitize(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound)
+{
+	if (!MixHelpers::useNaNHandler()) { return; }
+
+	const auto numTrackChannels = std::min(upperBound, this->channels());
+
+	// Like MixHelpers::sanitize(), but works for a single channel
+	auto sanitizeChannel = [](InterleavedBufferView<float, 2> output, auto channelIndex) -> bool {
+		constexpr auto channel = channelIndex();
+		for (float* frame : output.framesView())
+		{
+			float& sample = frame[channel];
+
+			if (std::isinf(sample) || std::isnan(sample))
+			{
+#ifdef LMMS_DEBUG
+				// TODO: don't use std::cout here?
+				std::cout << "Bad data, clearing buffer. frame: " << static_cast<std::size_t>(frame - output.data());
+				std::cout << ": value " << sample << " (" << (channel == 0 ? "L" : "R") << ")\n";
+#endif
+
+				// Clear the whole channel if a problem is found
+				for (float* f : output.framesView())
+				{
+					f[channel] = 0.f;
+				}
+
+				return true;
+			}
+			else
+			{
+				sample = std::clamp(sample, sample_t(-1000.0), sample_t(1000.0));
+			}
+		}
+		return false;
+	};
+
+	for (track_ch_t tc = 0; tc < numTrackChannels; tc += 2)
+	{
+		switch ((channels[tc] << 1) | std::uint8_t{channels[tc + 1]})
+		{
+			case 0b11:
+			{
+				const auto tcPair = m_bus[tc / 2];
+				if (MixHelpers::sanitize(tcPair, m_frames))
+				{
+					// Inf/NaN detected and buffer cleared
+					m_quietChannels[tc] = true;
+					m_quietChannels[tc + 1] = true;
+				}
+				break;
+			}
+			case 0b10:
+			{
+				if (sanitizeChannel(trackChannelPair(tc / 2), std::integral_constant<proc_ch_t, 0>{}))
+				{
+					// Inf/NaN detected and buffer cleared
+					m_quietChannels[tc] = true;
+				}
+				break;
+			}
+			case 0b01:
+			{
+				if (sanitizeChannel(trackChannelPair(tc / 2), std::integral_constant<proc_ch_t, 1>{}))
+				{
+					// Inf/NaN detected and buffer cleared
+					m_quietChannels[tc + 1] = true;
+				}
+				break;
+			}
+			case 0b00:
+				// Neither track channel needs to be sanitized
+				break;
+			default:
+				unreachable();
+				break;
+		}
+	}
+}
+
+void AudioBus::sanitizeAll()
+{
+	if (!MixHelpers::useNaNHandler()) { return; }
+
+	for (track_ch_t tc = 0; tc < channelPairs(); ++tc)
+	{
+		if (MixHelpers::sanitize(m_bus[tc], m_frames))
+		{
+			// Inf/NaN detected and buffer cleared
+			m_quietChannels[tc * 2] = true;
+			m_quietChannels[tc * 2 + 1] = true;
+		}
+	}
+}
+
+auto AudioBus::update(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound) -> bool
+{
+	assert(upperBound <= MaxTrackChannels);
+	assert(upperBound % 2 == 0);
+
+	bool allQuiet = true;
+
+	const auto numTrackChannels = std::min(upperBound, this->channels());
+	for (track_ch_t tc = 0; tc < numTrackChannels; tc += 2)
+	{
+		switch ((channels[tc] << 1) | std::uint8_t{channels[tc + 1]})
+		{
+			case 0b11:
+			{
+				const float* tcPair = (*this)[tc / 2];
+				const auto samples = frames() * 2;
+
+				bool quietL = true;
+				bool quietR = true;
+				for (std::size_t idx = 0; idx < samples; idx += 2)
+				{
+					if (std::abs(tcPair[idx]) > SilenceThreshold)
+					{
+						quietL = false;
+						++idx;
+						for (; idx < samples; idx += 2)
+						{
+							if (std::abs(tcPair[idx]) > SilenceThreshold)
+							{
+								quietR = false;
+								break;
+							}
+						}
+						break;
+					}
+					if (std::abs(tcPair[idx + 1]) > SilenceThreshold)
+					{
+						quietR = false;
+						for (; idx < samples; idx += 2)
+						{
+							if (std::abs(tcPair[idx]) > SilenceThreshold)
+							{
+								quietL = false;
+								break;
+							}
+						}
+						break;
+					}
+				}
+				m_quietChannels[tc] = quietL;
+				m_quietChannels[tc + 1] = quietR;
+				allQuiet = allQuiet && quietL && quietR;
+				break;
+			}
+			case 0b10:
+			{
+				const auto tcPair = trackChannelPair(tc / 2);
+				const auto quiet = std::ranges::all_of(tcPair.framesView(), [](const float* frame) {
+					return std::abs(frame[0]) < SilenceThreshold;
+				});
+				m_quietChannels[tc] = quiet;
+				allQuiet = allQuiet && quiet;
+				break;
+			}
+			case 0b01:
+			{
+				const auto tcPair = trackChannelPair(tc / 2);
+				const auto quiet = std::ranges::all_of(tcPair.framesView(), [](const float* frame) {
+					return std::abs(frame[1]) < SilenceThreshold;
+				});
+				m_quietChannels[tc + 1] = quiet;
+				allQuiet = allQuiet && quiet;
+				break;
+			}
+			case 0b00:
+				// Neither track channel needs to be updated
+				break;
+			default:
+				unreachable();
+				break;
+		}
+	}
+
+	return allQuiet;
+}
+
+auto AudioBus::updateAll() -> bool
+{
+	return update(std::bitset<MaxTrackChannels>{}.set());
+}
+
+void AudioBus::silenceChannels(const std::bitset<MaxTrackChannels>& channels, track_ch_t upperBound)
+{
+	auto needSilenced = ~m_quietChannels;
+	needSilenced &= channels;
+
+	const auto numTrackChannels = std::min(upperBound, this->channels());
+	for (track_ch_t tc = 0; tc < numTrackChannels; tc += 2)
+	{
+		switch ((needSilenced[tc] << 1) | std::uint8_t{needSilenced[tc + 1]})
+		{
+			case 0b11:
+				// Zero both track channels
+				std::ranges::fill(trackChannelPair(tc / 2).dataView(), 0.f);
+				break;
+			case 0b10:
+			{
+				// Zero left track channel
+				auto tcPair = trackChannelPair(tc / 2);
+				for (float* frame : tcPair.framesView())
+				{
+					frame[0] = 0.f;
+				}
+				break;
+			}
+			case 0b01:
+			{
+				// Zero right track channel
+				auto tcPair = trackChannelPair(tc / 2);
+				for (float* frame : tcPair.framesView())
+				{
+					frame[1] = 0.f;
+				}
+				break;
+			}
+			case 0b00:
+				// Neither track channel is used
+				break;
+			default:
+				unreachable();
+				break;
+		}
+	}
+
+	m_quietChannels |= channels;
+}
+
+void AudioBus::silenceAllChannels()
+{
+	for (track_ch_t tc = 0; tc < m_channelPairs; tc += 2)
+	{
+		std::fill_n(m_bus[tc], m_frames, SampleFrame{});
+	}
+
+	m_quietChannels.set();
+}
+
+} // namespace lmms

--- a/src/core/AudioBusHandle.cpp
+++ b/src/core/AudioBusHandle.cpp
@@ -53,9 +53,6 @@ AudioBusHandle::AudioBusHandle(const QString& name, bool hasEffectChain,
 	m_panningModel(panningModel),
 	m_mutedModel(mutedModel)
 {
-	// Mark all track channels as quiet
-	m_bus.quietChannels().set();
-
 	Engine::audioEngine()->addAudioBusHandle(this);
 	setExtOutputEnabled(true);
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LMMS_SRCS
 	${LMMS_SRCS}
 
+	core/AudioBus.cpp
 	core/AudioBusHandle.cpp
 	core/AudioEngine.cpp
 	core/AudioEngineProfiler.cpp

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -25,6 +25,7 @@
 
 #include <QDomElement>
 
+#include "AudioBus.h"
 #include "Effect.h"
 #include "EffectChain.h"
 #include "EffectControls.h"
@@ -44,7 +45,7 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_parent( nullptr ),
 	m_okay( true ),
 	m_noRun( false ),
-	m_running( false ),
+	m_awake(false),
 	m_enabledModel( true, this, tr( "Effect enabled" ) ),
 	m_wetDryModel( 1.0f, -1.0f, 1.0f, 0.01f, this, tr( "Wet/Dry mix" ) ),
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
@@ -111,29 +112,55 @@ void Effect::loadSettings( const QDomElement & _this )
 
 
 
-bool Effect::processAudioBuffer(SampleFrame* buf, const fpp_t frames)
+bool Effect::processAudioBuffer(AudioBus& inOut)
 {
-	if (!isOkay() || dontRun() || !isEnabled() || !isRunning())
+	if (!isAwake())
 	{
+		if (inOut.hasInputNoise(0b11))
+		{
+			startRunning();
+		}
+		else
+		{
+			// Sleeping plugins need to zero any track channels their output is routed to in order to
+			// prevent sudden track channel passthrough behavior when the plugin is put to sleep.
+			// Otherwise auto-quit could become audibly noticeable, which is not intended.
+
+			inOut.silenceChannels(0b11);
+
+			return false;
+		}
+	}
+
+	if (!isRunning())
+	{
+		// Plugin is awake but not running
 		processBypassedImpl();
 		return false;
 	}
 
-	const auto status = processImpl(buf, frames);
+	const auto status = processImpl(inOut.bus()[0], inOut.frames());
+
+	inOut.sanitize(0b11);
+
+	// Update silence status for track channels the processor wrote to
+	const bool silentOutput = inOut.update(0b11);
+
 	switch (status)
 	{
 		case ProcessStatus::Continue:
 			break;
 		case ProcessStatus::ContinueIfNotQuiet:
-			handleAutoQuit({buf, frames});
+			handleAutoQuit(silentOutput);
 			break;
 		case ProcessStatus::Sleep:
+			stopRunning();
 			return false;
 		default:
 			break;
 	}
 
-	return isRunning();
+	return isAwake();
 }
 
 
@@ -162,55 +189,29 @@ Effect * Effect::instantiate( const QString& pluginName,
 
 
 
-void Effect::handleAutoQuit(std::span<const SampleFrame> output)
+void Effect::handleAutoQuit(bool silentOutput)
 {
 	if (!m_autoQuitEnabled)
 	{
 		return;
 	}
 
-	/*
-	 * In the past, the RMS was calculated then compared with a threshold of 10^(-10).
-	 * Now we use a different algorithm to determine whether a buffer is non-quiet, so
-	 * a new threshold is needed for the best compatibility. The following is how it's derived.
-	 *
-	 * Old method:
-	 * RMS = average (L^2 + R^2) across stereo buffer.
-	 * RMS threshold = 10^(-10)
-	 *
-	 * So for a single channel, it would be:
-	 * RMS/2 = average M^2 across single channel buffer.
-	 * RMS/2 threshold = 5^(-11)
-	 *
-	 * The new algorithm for determining whether a buffer is non-silent compares M with the threshold,
-	 * not M^2, so the square root of M^2's threshold should give us the most compatible threshold for
-	 * the new algorithm:
-	 *
-	 * (RMS/2)^0.5 = (5^(-11))^0.5 = 0.0001431 (approx.)
-	 *
-	 * In practice though, the exact value shouldn't really matter so long as it's sufficiently small.
-	 */
-	static constexpr auto threshold = 0.0001431f;
-
 	// Check whether we need to continue processing input. Restart the
 	// counter if the threshold has been exceeded.
 
-	for (const SampleFrame& frame : output)
+	if (silentOutput)
 	{
-		const auto abs = frame.abs();
-		if (abs.left() >= threshold || abs.right() >= threshold)
+		// The output buffer is quiet, so check if auto-quit should be activated yet
+		if (++m_quietBufferCount > timeout())
 		{
-			// The output buffer is not quiet
-			m_quietBufferCount = 0;
-			return;
+			// Activate auto-quit
+			stopRunning();
 		}
 	}
-
-	// The output buffer is quiet, so check if auto-quit should be activated yet
-	if (++m_quietBufferCount > timeout())
+	else
 	{
-		// Activate auto-quit
-		stopRunning();
+		// The output buffer is not quiet
+		m_quietBufferCount = 0;
 	}
 }
 

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -27,6 +27,7 @@
 #include <QDomElement>
 #include <cassert>
 
+#include "AudioBus.h"
 #include "EffectChain.h"
 #include "Effect.h"
 #include "DummyEffect.h"
@@ -184,42 +185,22 @@ void EffectChain::moveUp( Effect * _effect )
 
 
 
-bool EffectChain::processAudioBuffer( SampleFrame* _buf, const fpp_t _frames, bool hasInputNoise )
+bool EffectChain::processAudioBuffer(AudioBus& bus)
 {
 	if( m_enabledModel.value() == false )
 	{
 		return false;
 	}
 
-	MixHelpers::sanitize( _buf, _frames );
+	bus.sanitizeAll();
 
 	bool moreEffects = false;
-	for (const auto& effect : m_effects)
+	for (Effect* effect : m_effects)
 	{
-		if (hasInputNoise || effect->isRunning())
-		{
-			moreEffects |= effect->processAudioBuffer(_buf, _frames);
-			MixHelpers::sanitize(_buf, _frames);
-		}
+		moreEffects |= effect->processAudioBuffer(bus);
 	}
 
 	return moreEffects;
-}
-
-
-
-
-void EffectChain::startRunning()
-{
-	if( m_enabledModel.value() == false )
-	{
-		return;
-	}
-
-	for (const auto& effect : m_effects)
-	{
-		effect->startRunning();
-	}
 }
 
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -74,7 +74,6 @@ MixerChannel::MixerChannel( int idx, Model * _parent ) :
 	m_dependenciesMet(0),
 	m_channelIndex(idx)
 {
-	m_bus.silenceAllChannels();
 }
 
 
@@ -203,7 +202,7 @@ void MixerChannel::doProcessing()
 					const float v = sender->m_volumeModel.value();
 					MixHelpers::addSanitizedMultipliedByBuffer( m_buffer, ch_buf, v, sendBuf, fpp );
 				}
-				m_bus.quietChannels() &= sender->m_bus.quietChannels(); // mix silence status
+				m_bus.mixQuietChannels(sender->m_bus);
 				m_hasInput = true;
 			}
 		}
@@ -646,7 +645,7 @@ void Mixer::mixToChannel(const AudioBus& bus, mix_ch_t channel)
 		mixerChannel->m_lock.lock();
 
 		MixHelpers::add(mixerChannel->m_bus.bus()[0], bus.bus()[0], bus.frames());
-		mixerChannel->m_bus.quietChannels() &= bus.quietChannels(); // mix silence status
+		mixerChannel->m_bus.mixQuietChannels(bus);
 		mixerChannel->m_hasInput = true;
 
 		mixerChannel->m_lock.unlock();

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -249,10 +249,6 @@ void InstrumentTrack::processAudioBuffer( SampleFrame* buf, const fpp_t frames, 
 		m_silentBuffersProcessed = false;
 	}
 
-	// if effects "went to sleep" because there was no input, wake them up
-	// now
-	m_audioBusHandle.effects()->startRunning();
-
 	// get volume knob data
 	static const float DefaultVolumeRatio = 1.0f / DefaultVolume;
 	/*ValueBuffer * volBuf = m_volumeModel.valueBuffer();

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -73,7 +73,6 @@ SampleTrack::~SampleTrack()
 bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 					const f_cnt_t _offset, int _clip_num )
 {
-	m_audioBusHandle.effects()->startRunning();
 	bool played_a_note = false; // will be return variable
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,4 +30,5 @@ foreach(LMMS_TEST_SRC IN LISTS LMMS_TESTS)
 	)
 
 	target_compile_features(${LMMS_TEST_NAME} PRIVATE cxx_std_20)
+	target_compile_definitions(${LMMS_TEST_NAME} PRIVATE LMMS_TESTING)
 endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_AUTOMOC ON)
 
 set(LMMS_TESTS
 	src/core/ArrayVectorTest.cpp
+	src/core/AudioBusTest.cpp
 	src/core/AutomatableModelTest.cpp
 	src/core/MathTest.cpp
 	src/core/ProjectVersionTest.cpp

--- a/tests/src/core/AudioBusTest.cpp
+++ b/tests/src/core/AudioBusTest.cpp
@@ -59,7 +59,7 @@ private:
 		}
 
 		auto ab = AudioBus{m_trackChannels.data(), channelPairs, frames};
-		ab.quietChannels().set(); // mark all silent
+		ab.setAutoQuitEnabled(true);
 
 		return ab;
 	}

--- a/tests/src/core/AudioBusTest.cpp
+++ b/tests/src/core/AudioBusTest.cpp
@@ -1,0 +1,310 @@
+/*
+ * AudioBusTest.cpp
+ *
+ * Copyright (c) 2025 Dalton Messmer <messmer.dalton/at/gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "AudioBus.h"
+
+#include <QObject>
+#include <QtTest>
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+
+#include "MixHelpers.h"
+
+using lmms::AudioBus;
+
+class AudioBusTest : public QObject
+{
+	Q_OBJECT
+
+private:
+	std::vector<lmms::SampleFrame> m_buffers;
+	std::vector<lmms::SampleFrame*> m_trackChannels;
+
+	// Creates new AudioBus with quiet buffers
+	auto createBus(lmms::track_ch_t channels, lmms::f_cnt_t frames) -> AudioBus
+	{
+		assert(channels % 2 == 0);
+		const auto channelPairs = static_cast<lmms::track_ch_t>(channels / 2);
+
+		m_trackChannels.resize(channelPairs);
+
+		m_buffers.resize(channelPairs * frames);
+		std::ranges::fill(m_buffers, lmms::SampleFrame{});
+
+		for (lmms::track_ch_t channelPair = 0; channelPair < channelPairs; ++channelPair)
+		{
+			m_trackChannels[channelPair] = &m_buffers[channelPair * frames];
+		}
+
+		auto ab = AudioBus{m_trackChannels.data(), channelPairs, frames};
+		ab.quietChannels().set(); // mark all silent
+
+		return ab;
+	}
+
+private slots:
+	//! Verifies correct default construction
+	void DefaultConstructor()
+	{
+		auto ab = AudioBus{};
+		QCOMPARE(ab.bus(), nullptr);
+		QCOMPARE(ab.channels(), 0);
+		QCOMPARE(ab.frames(), 0);
+		QCOMPARE(ab.quietChannels().none(), true);
+	}
+
+	//! Verifies correct construction
+	void Constructor()
+	{
+		auto ab = createBus(2, 10);
+		QCOMPARE(ab.bus() == nullptr, false);
+		QCOMPARE(ab.channels(), 2);
+		QCOMPARE(ab.frames(), 10);
+		QCOMPARE(ab.quietChannels().all(), true);
+	}
+
+	//! Verifies that the `update` method works as intended
+	void Update()
+	{
+		auto ab = createBus(4, 10);
+
+		// Both channels should be silent
+		QCOMPARE(ab.update(0b1111), true);
+		QCOMPARE(ab.quietChannels().all(), true);
+
+		// Now introduce a non-zero sample to the right channel of 2nd track channel bus
+		// but update all channels except that one
+		ab.trackChannelPair(1).frame(5)[1] = 1.f;
+		QCOMPARE(ab.update(0b0111), true);
+		QCOMPARE(ab.quietChannels().all(), true);
+
+		// Now update that channel
+		QCOMPARE(ab.update(0b1000), false);
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Should return true if no channels are selected for update
+		QCOMPARE(ab.update(0), true);
+
+		// Make the left channel of the 1st track channel bus non-zero too
+		ab.trackChannelPair(0).frame(5)[0] = 1.f;
+
+		// Update the left channel of the 1st track channel bus
+		QCOMPARE(ab.update(0b0001), false);
+		QCOMPARE(ab.quietChannels()[0], false);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Make the left channel of the 2nd track channel bus non-zero,
+		// and set the left channel of 1st track channel bus back to zero
+		ab.trackChannelPair(1).frame(5)[0] = 1.f;
+		ab.trackChannelPair(0).frame(5)[0] = 0.f;
+
+		// Update only the 2nd track channel bus
+		QCOMPARE(ab.update(0b1100), false);
+		QCOMPARE(ab.quietChannels()[0], false);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], false);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Now update the 1st track channel bus
+		QCOMPARE(ab.update(0b0011), true);
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], false);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Zero out all channels again
+		ab.trackChannelPair(1).frame(5)[0] = 0.f;
+		ab.trackChannelPair(1).frame(5)[1] = 0.f;
+		QCOMPARE(ab.update(0b0000), true);
+		QCOMPARE(ab.quietChannels().all(), false);
+		QCOMPARE(ab.update(0b1111), true);
+		QCOMPARE(ab.quietChannels().all(), true);
+	}
+
+	//! Verifies that the `updateAll` method works as intended
+	void UpdateAll()
+	{
+		auto ab = createBus(4, 10);
+
+		// Both channels should be silent
+		QCOMPARE(ab.updateAll(), true);
+		QCOMPARE(ab.quietChannels().all(), true);
+
+		// Now introduce a non-zero sample to the right channel of 2nd track channel bus
+		ab.trackChannelPair(1).frame(5)[1] = 1.f;
+		QCOMPARE(ab.updateAll(), false);
+		QCOMPARE(ab.quietChannels().all(), false);
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Make the left channel of the 1st track channel bus non-zero too
+		ab.trackChannelPair(0).frame(5)[0] = 1.f;
+		QCOMPARE(ab.updateAll(), false);
+		QCOMPARE(ab.quietChannels().all(), false);
+		QCOMPARE(ab.quietChannels()[0], false);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], false);
+
+		// Zero out all channels again
+		ab.trackChannelPair(0).frame(5)[0] = 0.f;
+		ab.trackChannelPair(1).frame(5)[1] = 0.f;
+		QCOMPARE(ab.updateAll(), true);
+		QCOMPARE(ab.quietChannels().all(), true);
+	}
+
+	//! Verifies that the `hasInputNoise` method works as intended
+	void HasInputNoise()
+	{
+		auto ab = createBus(4, 10);
+
+		// No input noise since all track channels are silent
+		QCOMPARE(ab.hasInputNoise(0b1111), false);
+
+		// Make the left channels in both busses non-zero and manually update the silence status
+		ab.trackChannelPair(0).frame(5)[0] = 1.f;
+		ab.trackChannelPair(1).frame(5)[0] = 1.f;
+		ab.quietChannels()[0] = false;
+		ab.quietChannels()[2] = false;
+
+		// Check if any channels are non-zero
+		QCOMPARE(ab.hasInputNoise(0b1111), true);
+
+		// Check if either of the left channels are non-zero
+		QCOMPARE(ab.hasInputNoise(0b0101), true);
+
+		// Check if either of the right channels are non-zero
+		QCOMPARE(ab.hasInputNoise(0b1010), false);
+
+		// Check if either channel in the 1st bus are non-zero
+		QCOMPARE(ab.hasInputNoise(0b0011), true);
+	}
+
+	//! Verifies that the `sanitize` method works as intended
+	void Sanitize()
+	{
+		lmms::MixHelpers::setNaNHandler(true);
+
+		auto ab = createBus(4, 10);
+
+		// Should have no effect when all buffers are zeroed
+		QCOMPARE(ab.quietChannels().all(), true);
+		ab.sanitize(0b1111);
+		QCOMPARE(ab.quietChannels().all(), true);
+
+		// Make left channel of 1st track channel bus contain an Inf, and force the channel to non-quiet
+		ab.trackChannelPair(0).frame(5)[0] = std::numeric_limits<float>::infinity();
+		ab.quietChannels()[0] = false;
+
+		// Make right channel of 1st track channel bus non-zero too, but using a valid value
+		ab.trackChannelPair(0).frame(5)[1] = 1.f;
+		ab.quietChannels()[1] = false;
+
+		// Sanitize only the left channel
+		ab.sanitize(0b0001);
+
+		// The left channel's buffer should be zeroed, while the right channel should be unaffected
+		QCOMPARE(ab.trackChannelPair(0).frame(5)[0], 0.f);
+		QCOMPARE(ab.trackChannelPair(0).frame(5)[1], 1.f);
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], false);
+
+		// Try again
+		ab.trackChannelPair(0).frame(5)[0] = std::numeric_limits<float>::infinity();
+		ab.quietChannels()[0] = false;
+
+		// This time, sanitize both channels of the 1st track channel bus
+		ab.sanitize(0b0011);
+
+		// When the left/right channels are both sanitized, it is allowed to zero both buffers if
+		// an Inf/NaN is detected in either channel
+		QCOMPARE(ab.trackChannelPair(0).frame(5)[0], 0.f);
+		QCOMPARE(ab.trackChannelPair(0).frame(5)[1], 0.f);
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+	}
+
+	//! Verifies that the `silenceChannels` method works as intended
+	void SilenceChannels()
+	{
+		auto ab = createBus(4, 10);
+
+		// Should have no effect when all buffers are zeroed
+		QCOMPARE(ab.quietChannels().all(), true);
+		ab.silenceChannels(0b1111);
+		QCOMPARE(ab.quietChannels().all(), true);
+
+		// Make left channel of 2nd track channel bus contain a non-zero value, and force the channel to non-quiet
+		ab.trackChannelPair(1).frame(5)[0] = 1.f;
+		ab.quietChannels()[2] = false;
+
+		// Silence only the left channel
+		ab.silenceChannels(0b0100);
+
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], true);
+
+		// Make right channel of 2nd track channel bus contain a non-zero value, and force the channel to non-quiet
+		ab.trackChannelPair(1).frame(5)[1] = 1.f;
+		ab.quietChannels()[3] = false;
+
+		// Silence only the right channel
+		ab.silenceChannels(0b1000);
+
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], true);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], true);
+
+		// Make right channel of 1st track channel bus and both channels of 2nd track channel bus contain
+		// a non-zero value, and force those channels to non-quiet
+		ab.trackChannelPair(1).frame(5)[1] = 1.f;
+		ab.quietChannels()[1] = false;
+		ab.trackChannelPair(1).frame(5)[0] = 1.f;
+		ab.quietChannels()[2] = false;
+		ab.trackChannelPair(1).frame(5)[1] = 1.f;
+		ab.quietChannels()[3] = false;
+
+		// Silence both channels of the 2nd track channel bus, plus the already-quiet left channel of the 1st bus
+		ab.silenceChannels(0b1101);
+
+		QCOMPARE(ab.quietChannels()[0], true);
+		QCOMPARE(ab.quietChannels()[1], false);
+		QCOMPARE(ab.quietChannels()[2], true);
+		QCOMPARE(ab.quietChannels()[3], true);
+	}
+};
+
+QTEST_GUILESS_MAIN(AudioBusTest)
+#include "AudioBusTest.moc"


### PR DESCRIPTION
This is another PR coming out of the work done in #7459, and probably the last one needed before that PR can be merged.

It reworks the auto-quit feature by introducing a new `AudioBus` class which keeps track of which track channels are currently silent as audio flows through the effects chain.

When track channels going into an effect's input are not marked as quiet, it is assumed a signal is present and the plugin needs to wake up if it is asleep due to auto-quit. After a plugin processes a buffer, the silence status is updated.

When the auto-quit setting is disabled (that is, when effects are always kept running), effects are always assumed to have input noise (a non-quiet signal present at the plugin inputs), which should result in the same behavior as before.

Benefits:
- The auto-quit system now closely follows how it is supposed to function by only waking plugins which have non-zero input rather than waking all plugins at once whenever an instrument plays a note or a sample track plays. This granularity better fits multi-channel plugins and pin connector routing where not all plugin inputs are connected to the same track channels. This means a sleeping plugin whose inputs are connected to channels 3/4 would not need to wake up if a signal is only present on channels 1/2.
- Silencing channels that are already known to be silent is a no-op
- The silence flags also could be useful for other purposes, such as adding visual indicators to represent how audio signals flow in and out of each plugin

This new system works so long as the silence flags for each channel remain valid at each point along the effect chain. Modifying the buffers without an accompanying update of the silence flags could violate assumptions. Through unit tests, the correct functioning of `AudioBus` itself can be validated, but its usage in `AudioBusHandle`, `Mixer`, and a few other places where track channels are handled will need to be done with care.
