### PR TITLE
Drag and drop from external applications v3

### DIFF
--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -35,6 +35,8 @@
 
 
 class QMenu;
+class QMimeData;
+
 
 namespace lmms
 {
@@ -178,8 +180,9 @@ protected:
 
 	float pixelsPerBar();
 
-
+	//! Turn a selection of clips into a DataFile used for drag-and-drop or copy
 	DataFile createClipDataFiles(const QVector<ClipView *> & clips) const;
+	virtual QMimeData* createClipboardData();
 
 	virtual void paintTextLabel(QString const & text, QPainter & painter);
 

--- a/include/Clipboard.h
+++ b/include/Clipboard.h
@@ -85,10 +85,10 @@ namespace lmms::Clipboard
 namespace lmms::MimeData
 {
 	//! Create a new QMimeData from a string pair
-	QMimeData* fromStringPair(const QString& key, const QString& value);
+	LMMS_EXPORT QMimeData* fromStringPair(const QString& key, const QString& value);
 
 	//! Extract string pair from QMimeData
-	std::pair<QString, QString> toStringPair(const QMimeData* md);
+	LMMS_EXPORT std::pair<QString, QString> toStringPair(const QMimeData* md);
 
 } // namespace lmms::MimeData
 
@@ -98,16 +98,16 @@ namespace lmms::MimeData
 namespace lmms::DragAndDrop
 {
 	//! Start a QDrag from given widget, return mouse is released
-	void exec(QWidget* widget, QMimeData* md, const QPixmap& icon = {});
+	LMMS_EXPORT void exec(QWidget* widget, QMimeData* md, const QPixmap& icon = {});
 
 	//! Start a QDrag containing a string pair
-	void execStringPairDrag(const QString& key, const QString& value, const QPixmap& icon, QWidget* widget);
+	LMMS_EXPORT void execStringPairDrag(const QString& key, const QString& value, const QPixmap& icon, QWidget* widget);
 
 	//! Accept drag enter event if it contains a file of allowed type
-	bool acceptFile(QDragEnterEvent* dee, const std::initializer_list<FileType> allowedTypes);
+	LMMS_EXPORT bool acceptFile(QDragEnterEvent* dee, const std::initializer_list<FileType> allowedTypes);
 
 	//! Accept drag enter event if it contains a string pair of allowed type
-	bool acceptStringPair(QDragEnterEvent* dee, const std::initializer_list<QString> allowedKeys);
+	LMMS_EXPORT bool acceptStringPair(QDragEnterEvent* dee, const std::initializer_list<QString> allowedKeys);
 
 	//! Get file path from drop event (empty if it doesn't match allowedType)
 	LMMS_EXPORT QString getFile(const QDropEvent* de, FileType allowedType);

--- a/include/DataFile.h
+++ b/include/DataFile.h
@@ -30,6 +30,7 @@
 #include <QDomDocument>
 #include <vector>
 
+#include "FileTypes.h"
 #include "lmms_export.h"
 
 class QTextStream;
@@ -72,6 +73,12 @@ public:
 	bool validate( QString extension );
 
 	QString nameWithExtension( const QString& fn ) const;
+
+	//! Return preferred file extension for type
+	static QString extension(Type type);
+
+	//! List all DataFile file extensions (used to build FileTypes database)
+	static std::vector<std::pair<FileType, QString>> allSupportedFileTypes();
 
 	void write( QTextStream& strm );
 	bool writeFile(const QString& fn, bool withResources = false);

--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -33,6 +33,7 @@
 
 #include <QTreeWidget>
 
+#include "FileTypes.h"
 #include "SideBarWidget.h"
 #include "lmmsconfig.h"
 
@@ -255,30 +256,6 @@ private:
 class FileItem : public QTreeWidgetItem
 {
 public:
-	enum class FileType
-	{
-		Project,
-		Preset,
-		Sample,
-		SoundFont,
-		Patch,
-		Midi,
-		VstPlugin,
-		Unknown
-	} ;
-
-	enum class FileHandling
-	{
-		NotSupported,
-		LoadAsProject,
-		LoadAsPreset,
-		LoadByPlugin,
-		ImportAsProject
-	} ;
-
-
-	FileItem( QTreeWidget * parent, const QString & name,
-							const QString & path );
 	FileItem( const QString & name, const QString & path );
 
 	QString fullName() const
@@ -291,29 +268,24 @@ public:
 		return( m_type );
 	}
 
-	inline FileHandling handling() const
-	{
-		return( m_handling );
-	}
-
+	//! True if the file can be added to a track
 	inline bool isTrack() const
 	{
-		return m_handling == FileHandling::LoadAsPreset || m_handling == FileHandling::LoadByPlugin;
+		return m_type == FileType::InstrumentPreset
+			|| m_type == FileType::InstrumentAsset
+			|| m_type == FileType::Sample
+			|| m_type == FileType::MidiClipData;
 	}
 
 	QString extension();
 	static QString extension( const QString & file );
 	static QString defaultFilters();
 
+	void startFileDrag(QWidget* dragSource);
 
 private:
-	void initPixmaps();
-	void determineFileType();
-
 	QString m_path;
 	FileType m_type;
-	FileHandling m_handling;
-
 } ;
 
 

--- a/include/FileTypes.h
+++ b/include/FileTypes.h
@@ -1,0 +1,66 @@
+/*
+ * FileTypes.h
+ *
+ * Copyright (c) 2025 allejok96 <gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+#ifndef LMMS_FILE_TYPES_H
+#define LMMS_FILE_TYPES_H
+
+#include <QString>
+
+
+namespace lmms
+{
+
+class DataFile;
+
+enum class FileType
+{
+	Unknown,
+	ImportableProject, //!< any file that can be imported by some import filter
+	InstrumentAsset, //!< any file that can be loaded by some instrument plugin
+	InstrumentPreset, //!< DataFile of Instrument
+	MidiClipData, //!< DataFile of MidiClip
+	Project,
+	ProjectTemplate,
+	Sample, //! any audio file supported by SampleDecoder
+};
+
+
+namespace FileTypes
+{
+	//! Create a filter string to be used in file dialogs
+	QString compileFilter(const std::initializer_list<FileType> fileTypes = {}, const QString& label = {});
+
+	//! Return a FileType for the given file extension
+	FileType find(const QString& ext);
+
+	//! Return an icon name for the given file extension
+	std::string iconName(const QString& ext);
+
+	//! True if any of the file types matches the path
+	bool matchPath(const std::initializer_list<FileType> fileTypes, const QString& path);
+
+} // namespace FileTypes
+
+} // namespace lmms
+
+#endif // LMMS_FILE_TYPES_H

--- a/include/FileTypes.h
+++ b/include/FileTypes.h
@@ -26,6 +26,7 @@
 
 #include <QString>
 
+#include "lmms_export.h"
 
 namespace lmms
 {
@@ -48,16 +49,16 @@ enum class FileType
 namespace FileTypes
 {
 	//! Create a filter string to be used in file dialogs
-	QString compileFilter(const std::initializer_list<FileType> fileTypes = {}, const QString& label = {});
+	LMMS_EXPORT QString compileFilter(const std::initializer_list<FileType> fileTypes = {}, const QString& label = {});
 
 	//! Return a FileType for the given file extension
-	FileType find(const QString& ext);
+	LMMS_EXPORT FileType find(const QString& ext);
 
 	//! Return an icon name for the given file extension
-	std::string iconName(const QString& ext);
+	LMMS_EXPORT std::string iconName(const QString& ext);
 
 	//! True if any of the file types matches the path
-	bool matchPath(const std::initializer_list<FileType> fileTypes, const QString& path);
+	LMMS_EXPORT bool matchPath(const std::initializer_list<FileType> fileTypes, const QString& path);
 
 } // namespace FileTypes
 

--- a/include/Plugin.h
+++ b/include/Plugin.h
@@ -97,7 +97,7 @@ public:
 		int version;
 		Type type;
 		const PixmapLoader * logo;
-		const char * supportedFileTypes; //!< csv list of extensions
+		const QString supportedFileTypes; //!< comma separated list of file extensions
 
 		inline bool supportsFileType( const QString& extension ) const
 		{
@@ -124,7 +124,7 @@ public:
 				its sub plugin (using the attributes).
 				When keys are saved, those attributes are
 				written to XML in order to find the right sub
-				plugin when realoading.
+				plugin when reloading.
 
 				@note Any data that is not required to reference
 					the right Plugin or sub plugin should

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -79,6 +79,8 @@ public:
 
 	/// Returns a list of all found plugins' PluginFactory::PluginInfo objects.
 	const PluginInfoList& pluginInfos() const;
+	/// Returns a list of all file extensions supported by any plugin
+	QStringList allSupportedExtensions();
 	/// Returns a plugin that support the given file extension
 	PluginInfoAndKey pluginSupportingExtension(const QString& ext);
 

--- a/include/PluginView.h
+++ b/include/PluginView.h
@@ -25,8 +25,11 @@
 #ifndef LMMS_GUI_PLUGIN_VIEW_H
 #define LMMS_GUI_PLUGIN_VIEW_H
 
+#include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QWidget>
 
+#include "Clipboard.h"
 #include "ModelView.h"
 #include "Plugin.h"
 
@@ -42,6 +45,28 @@ public:
 	}
 
 	virtual bool isResizable() const { return false; }
+
+protected:
+	void dragEnterEvent(QDragEnterEvent* dee) override
+	{
+		const auto [path, ext] = DragAndDrop::getFileAndExt(dee);
+
+		if (castModel<Plugin>()->descriptor()->supportsFileType(ext))
+		{
+			dee->acceptProposedAction();
+		}
+	}
+
+	void dropEvent(QDropEvent* de) override
+	{
+		const auto [path, ext] = DragAndDrop::getFileAndExt(de);
+
+		if (castModel<Plugin>()->descriptor()->supportsFileType(ext))
+		{
+			castModel<Plugin>()->loadFile(path);
+			de->accept();
+		}
+	}
 };
 
 } // namespace lmms::gui

--- a/include/SampleClipView.h
+++ b/include/SampleClipView.h
@@ -62,6 +62,7 @@ protected:
 	void mouseDoubleClickEvent( QMouseEvent * ) override;
 	void paintEvent( QPaintEvent * ) override;
 
+	QMimeData* createClipboardData() override;
 
 private:
 	SampleClip * m_clip;

--- a/include/StringPairDrag.h
+++ b/include/StringPairDrag.h
@@ -42,13 +42,17 @@ namespace lmms::gui
 class LMMS_EXPORT StringPairDrag : public QDrag
 {
 public:
+	[[deprecated("Use DragAndDrop::execStringPairDrag instead")]]
 	StringPairDrag( const QString & _key, const QString & _value,
 					const QPixmap & _icon, QWidget * _w );
 	~StringPairDrag() override;
 
+	[[deprecated("Use DragAndDrop::acceptStringPair instead")]]
 	static bool processDragEnterEvent( QDragEnterEvent * _dee,
 						const QString & _allowed_keys );
+	[[deprecated("Use MimeData::toStringPair instead")]]
 	static QString decodeKey( QDropEvent * _de );
+	[[deprecated("Use MimeData::toStringPair instead")]]
 	static QString decodeValue( QDropEvent * _de );
 } ;
 

--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -27,6 +27,7 @@
 
 #include "InstrumentTrack.h"
 #include "PathUtil.h"
+#include "SampleDecoder.h"
 #include "SampleLoader.h"
 #include "Song.h"
 
@@ -38,6 +39,18 @@
 
 namespace lmms
 {
+
+
+static QString audioFileExtensions()
+{
+	QStringList extensions;
+	for (const auto& audioType : SampleDecoder::supportedAudioTypes())
+	{
+		extensions << QString::fromStdString(audioType.extension);
+	}
+	return extensions.join(",");
+}
+
 
 extern "C"
 {
@@ -54,11 +67,7 @@ Plugin::Descriptor PLUGIN_EXPORT audiofileprocessor_plugin_descriptor =
 	0x0100,
 	Plugin::Type::Instrument,
 	new PluginPixmapLoader( "logo" ),
-	"wav,ogg,ds,spx,au,voc,aif,aiff,flac,raw"
-#ifdef LMMS_HAVE_SNDFILE_MP3
-	",mp3"
-#endif
-	,
+	audioFileExtensions(),
 	nullptr,
 } ;
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -35,7 +35,6 @@
 #include "PixmapButton.h"
 #include "SampleLoader.h"
 #include "Song.h"
-#include "StringPairDrag.h"
 #include "Track.h"
 #include "Clipboard.h"
 
@@ -147,34 +146,6 @@ AudioFileProcessorView::AudioFileProcessorView(Instrument* instrument,
 	setAcceptDrops(true);
 }
 
-void AudioFileProcessorView::dragEnterEvent(QDragEnterEvent* dee)
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if (dee->mimeData()->hasFormat(mimeType(MimeType::StringPair)))
-	{
-		QString txt = dee->mimeData()->data(
-						mimeType(MimeType::StringPair));
-		if (txt.section(':', 0, 0) == QString("clip_%1").arg(
-							static_cast<int>(Track::Type::Sample)))
-		{
-			dee->acceptProposedAction();
-		}
-		else if (txt.section(':', 0, 0) == "samplefile")
-		{
-			dee->acceptProposedAction();
-		}
-		else
-		{
-			dee->ignore();
-		}
-	}
-	else
-	{
-		dee->ignore();
-	}
-}
 
 void AudioFileProcessorView::newWaveView()
 {
@@ -192,27 +163,6 @@ void AudioFileProcessorView::newWaveView()
 	m_waveView->show();
 }
 
-void AudioFileProcessorView::dropEvent(QDropEvent* de)
-{
-	const auto type = StringPairDrag::decodeKey(de);
-	const auto value = StringPairDrag::decodeValue(de);
-
-	if (type == "samplefile") { castModel<AudioFileProcessor>()->setAudioFile(value); }
-	else if (type == QString("clip_%1").arg(static_cast<int>(Track::Type::Sample)))
-	{
-		DataFile dataFile(value.toUtf8());
-		castModel<AudioFileProcessor>()->setAudioFile(dataFile.content().firstChild().toElement().attribute("src"));
-	}
-	else
-	{
-		de->ignore();
-		return;
-	}
-
-	m_waveView->updateSampleRange();
-	Engine::getSong()->setModified();
-	de->accept();
-}
 
 void AudioFileProcessorView::paintEvent(QPaintEvent*)
 {

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.h
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.h
@@ -55,8 +55,6 @@ protected slots:
 	void openAudioFile();
 
 protected:
-	virtual void dragEnterEvent(QDragEnterEvent* dee);
-	virtual void dropEvent(QDropEvent* de);
 	virtual void paintEvent(QPaintEvent*);
 
 	// Private methods

--- a/plugins/HydrogenImport/HydrogenImport.cpp
+++ b/plugins/HydrogenImport/HydrogenImport.cpp
@@ -33,7 +33,7 @@ Plugin::Descriptor PLUGIN_EXPORT hydrogenimport_plugin_descriptor =
 	0x0100,
 	Plugin::Type::ImportFilter,
 	nullptr,
-	nullptr,
+	"h2song",
 	nullptr,
 } ;
 

--- a/plugins/Lv2Instrument/Lv2Instrument.cpp
+++ b/plugins/Lv2Instrument/Lv2Instrument.cpp
@@ -33,8 +33,6 @@
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
 #include "Lv2SubPluginFeatures.h"
-#include "StringPairDrag.h"
-#include "Clipboard.h"
 
 #include "embed.h"
 #include "plugin_export.h"
@@ -57,7 +55,7 @@ Plugin::Descriptor PLUGIN_EXPORT lv2instrument_plugin_descriptor =
 	0x0100,
 	Plugin::Type::Instrument,
 	new PluginPixmapLoader("logo"),
-	nullptr,
+	"lv2",
 	new Lv2SubPluginFeatures(Plugin::Type::Instrument)
 };
 
@@ -250,44 +248,6 @@ Lv2InsView::Lv2InsView(Lv2Instrument *_instrument, QWidget *_parent) :
 		connect(m_helpButton, &QPushButton::toggled,
 			this, [this](bool visible){ toggleHelp(visible); });
 	}
-}
-
-
-
-
-void Lv2InsView::dragEnterEvent(QDragEnterEvent *_dee)
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	void (QDragEnterEvent::*reaction)() = &QDragEnterEvent::ignore;
-
-	if (_dee->mimeData()->hasFormat( mimeType( MimeType::StringPair )))
-	{
-		const QString txt =
-			_dee->mimeData()->data( mimeType( MimeType::StringPair ) );
-		if (txt.section(':', 0, 0) == "pluginpresetfile") {
-			reaction = &QDragEnterEvent::acceptProposedAction;
-		}
-	}
-
-	(_dee->*reaction)();
-}
-
-
-
-
-void Lv2InsView::dropEvent(QDropEvent *_de)
-{
-	const QString type = StringPairDrag::decodeKey(_de);
-	const QString value = StringPairDrag::decodeValue(_de);
-	if (type == "pluginpresetfile")
-	{
-		castModel<Lv2Instrument>()->loadFile(value);
-		_de->accept();
-		return;
-	}
-	_de->ignore();
 }
 
 

--- a/plugins/Lv2Instrument/Lv2Instrument.h
+++ b/plugins/Lv2Instrument/Lv2Instrument.h
@@ -113,8 +113,6 @@ public:
 	Lv2InsView(Lv2Instrument *_instrument, QWidget *_parent);
 
 protected:
-	void dragEnterEvent(QDragEnterEvent *_dee) override;
-	void dropEvent(QDropEvent *_de) override;
 	void hideEvent(QHideEvent* event) override;
 
 private:

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -72,7 +72,7 @@ Plugin::Descriptor PLUGIN_EXPORT midiimport_plugin_descriptor =
 	0x0100,
 	Plugin::Type::ImportFilter,
 	nullptr,
-	nullptr,
+	"mid,midi,rmi",
 	nullptr,
 } ;
 

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -39,7 +39,6 @@
 #include "PathUtil.h"
 #include "PixmapButton.h"
 #include "Song.h"
-#include "StringPairDrag.h"
 #include "Clipboard.h"
 
 #include "embed.h"
@@ -562,50 +561,6 @@ void PatmanView::updateFilename()
 	}
 
 	update();
-}
-
-
-
-
-void PatmanView::dragEnterEvent( QDragEnterEvent * _dee )
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if( _dee->mimeData()->hasFormat( mimeType( MimeType::StringPair ) ) )
-	{
-		QString txt = _dee->mimeData()->data(
-						mimeType( MimeType::StringPair ) );
-		if( txt.section( ':', 0, 0 ) == "samplefile" )
-		{
-			_dee->acceptProposedAction();
-		}
-		else
-		{
-			_dee->ignore();
-		}
-	}
-	else
-	{
-		_dee->ignore();
-	}
-}
-
-
-
-
-void PatmanView::dropEvent( QDropEvent * _de )
-{
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "samplefile" )
-	{
-		m_pi->setFile( value );
-		_de->accept();
-		return;
-	}
-
-	_de->ignore();
 }
 
 

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -138,8 +138,6 @@ public slots:
 
 
 protected:
-	void dragEnterEvent( QDragEnterEvent * _dee ) override;
-	void dropEvent( QDropEvent * _de ) override;
 	void paintEvent( QPaintEvent * ) override;
 
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -54,7 +54,6 @@
 #include "PathUtil.h"
 #include "PixmapButton.h"
 #include "Song.h"
-#include "StringPairDrag.h"
 #include "SubWindow.h"
 #include "TextFloat.h"
 #include "Clipboard.h"
@@ -831,49 +830,6 @@ void VestigeInstrumentView::noteOffAll( void )
 
 
 
-void VestigeInstrumentView::dragEnterEvent( QDragEnterEvent * _dee )
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if( _dee->mimeData()->hasFormat( mimeType( MimeType::StringPair ) ) )
-	{
-		QString txt = _dee->mimeData()->data(
-						mimeType( MimeType::StringPair ) );
-		if( txt.section( ':', 0, 0 ) == "vstplugin" )
-		{
-			_dee->acceptProposedAction();
-		}
-		else
-		{
-			_dee->ignore();
-		}
-	}
-	else
-	{
-		_dee->ignore();
-	}
-}
-
-
-
-
-void VestigeInstrumentView::dropEvent( QDropEvent * _de )
-{
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "vstplugin" )
-	{
-		m_vi->loadFile( value );
-		_de->accept();
-		return;
-	}
-	_de->ignore();
-}
-
-
-
-
 void VestigeInstrumentView::paintEvent( QPaintEvent * )
 {
 	QPainter p( this );
@@ -1185,48 +1141,6 @@ void ManageVestigeInstrumentView::syncParameterText()
 	{
 		vstKnobs[i]->setValueText(paramDisplayList[i] + ' ' + paramLabelList[i]);
 	}
-}
-
-
-
-void ManageVestigeInstrumentView::dragEnterEvent( QDragEnterEvent * _dee )
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if( _dee->mimeData()->hasFormat( mimeType( MimeType::StringPair ) ) )
-	{
-		QString txt = _dee->mimeData()->data(
-						mimeType( MimeType::StringPair ) );
-		if( txt.section( ':', 0, 0 ) == "vstplugin" )
-		{
-			_dee->acceptProposedAction();
-		}
-		else
-		{
-			_dee->ignore();
-		}
-	}
-	else
-	{
-		_dee->ignore();
-	}
-}
-
-
-
-
-void ManageVestigeInstrumentView::dropEvent( QDropEvent * _de )
-{
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "vstplugin" )
-	{
-		m_vi->loadFile( value );
-		_de->accept();
-		return;
-	}
-	_de->ignore();
 }
 
 

--- a/plugins/Vestige/Vestige.h
+++ b/plugins/Vestige/Vestige.h
@@ -119,8 +119,6 @@ protected slots:
 
 
 protected:
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
 	virtual void paintEvent( QPaintEvent * _pe );
 
 
@@ -159,8 +157,6 @@ protected slots:
 
 
 protected:
-	virtual void dragEnterEvent( QDragEnterEvent * _dee );
-	virtual void dropEvent( QDropEvent * _de );
 	virtual void paintEvent( QPaintEvent * _pe );
 
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.cpp
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.cpp
@@ -42,7 +42,6 @@
 #include "InstrumentPlayHandle.h"
 #include "InstrumentTrack.h"
 #include "Song.h"
-#include "StringPairDrag.h"
 #include "RemoteZynAddSubFx.h"
 #include "LocalZynAddSubFx.h"
 #include "AudioEngine.h"
@@ -556,49 +555,6 @@ ZynAddSubFxView::ZynAddSubFxView( Instrument * _instrument, QWidget * _parent ) 
 	l->setColumnStretch( 4, 10 );
 
 	setAcceptDrops( true );
-}
-
-
-
-
-void ZynAddSubFxView::dragEnterEvent( QDragEnterEvent * _dee )
-{
-	// For mimeType() and MimeType enum class
-	using namespace Clipboard;
-
-	if( _dee->mimeData()->hasFormat( mimeType( MimeType::StringPair ) ) )
-	{
-		QString txt = _dee->mimeData()->data(
-						mimeType( MimeType::StringPair ) );
-		if( txt.section( ':', 0, 0 ) == "pluginpresetfile" )
-		{
-			_dee->acceptProposedAction();
-		}
-		else
-		{
-			_dee->ignore();
-		}
-	}
-	else
-	{
-		_dee->ignore();
-	}
-}
-
-
-
-
-void ZynAddSubFxView::dropEvent( QDropEvent * _de )
-{
-	const QString type = StringPairDrag::decodeKey( _de );
-	const QString value = StringPairDrag::decodeValue( _de );
-	if( type == "pluginpresetfile" )
-	{
-		castModel<ZynAddSubFxInstrument>()->loadFile( value );
-		_de->accept();
-		return;
-	}
-	_de->ignore();
 }
 
 

--- a/plugins/ZynAddSubFx/ZynAddSubFx.h
+++ b/plugins/ZynAddSubFx/ZynAddSubFx.h
@@ -143,11 +143,6 @@ public:
 	ZynAddSubFxView( Instrument * _instrument, QWidget * _parent );
 
 
-protected:
-	void dragEnterEvent( QDragEnterEvent * _dee ) override;
-	void dropEvent( QDropEvent * _de ) override;
-
-
 private:
 	void modelChanged() override;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LMMS_SRCS
 	core/EnvelopeAndLfoParameters.cpp
 	core/fft_helpers.cpp
 	core/FileSearch.cpp
+	core/FileTypes.cpp
 	core/Mixer.cpp
 	core/ImportFilter.cpp
 	core/InlineAutomation.cpp

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -105,19 +105,25 @@ namespace
 	{
 		DataFile::Type m_type;
 		QString m_name;
+		std::vector<QString> m_extensions = {};
 	};
 
 	const auto s_types = std::array{
 		TypeDescStruct{ DataFile::Type::Unknown, "unknown" },
-		TypeDescStruct{ DataFile::Type::SongProject, "song" },
-		TypeDescStruct{ DataFile::Type::SongProjectTemplate, "songtemplate" },
-		TypeDescStruct{ DataFile::Type::InstrumentTrackSettings, "instrumenttracksettings" },
+		TypeDescStruct{ DataFile::Type::SongProject, "song" , {"mmp", "mmpz"}},
+		TypeDescStruct{ DataFile::Type::SongProjectTemplate, "songtemplate", {"mpt"}},
+		TypeDescStruct{ DataFile::Type::InstrumentTrackSettings, "instrumenttracksettings", {"xpf", "xml"}},
 		TypeDescStruct{ DataFile::Type::DragNDropData, "dnddata" },
 		TypeDescStruct{ DataFile::Type::ClipboardData, "clipboard-data" },
 		TypeDescStruct{ DataFile::Type::JournalData, "journaldata" },
 		TypeDescStruct{ DataFile::Type::EffectSettings, "effectsettings" },
-		TypeDescStruct{ DataFile::Type::MidiClip, "midiclip" }
+		TypeDescStruct{ DataFile::Type::MidiClip, "midiclip", {"xpt", "xptz"}},
 	};
+
+	bool isCompressed(const QString& ext)
+	{
+		return ext == "mmpz" || ext == "xptz";
+	}
 }
 
 
@@ -193,101 +199,21 @@ DataFile::DataFile( const QByteArray & _data ) :
 
 
 
-
-bool DataFile::validate( QString extension )
-{
-	switch( m_type )
-	{
-	case Type::SongProject:
-		if( extension == "mmp" || extension == "mmpz" )
-		{
-			return true;
-		}
-		break;
-	case Type::SongProjectTemplate:
-		if(  extension == "mpt" )
-		{
-			return true;
-		}
-		break;
-	case Type::InstrumentTrackSettings:
-		if ( extension == "xpf" || extension == "xml" )
-		{
-			return true;
-		}
-		break;
-	case Type::MidiClip:
-		if (extension == "xpt" || extension == "xptz")
-		{
-			return true;
-		}
-		break;
-	case Type::Unknown:
-		if (! ( extension == "mmp" || extension == "mpt" || extension == "mmpz" ||
-				extension == "xpf" || extension == "xml" ||
-				( extension == "xiz" && ! getPluginFactory()->pluginSupportingExtension(extension).isNull()) ||
-				extension == "sf2" || extension == "sf3" || extension == "pat" || extension == "mid" ||
-				extension == "dll"
-#ifdef LMMS_BUILD_LINUX
-				|| extension == "so"
-#endif
-#ifdef LMMS_HAVE_LV2
-				|| extension == "lv2"
-#endif
-				) )
-		{
-			return true;
-		}
-		if( extension == "wav" || extension == "ogg" || extension == "ds"
-#ifdef LMMS_HAVE_SNDFILE_MP3
-				|| extension == "mp3"
-#endif
-				)
-		{
-			return true;
-		}
-		break;
-	default:
-		return false;
-	}
-	return false;
-}
-
-
-
-
 QString DataFile::nameWithExtension( const QString & _fn ) const
 {
 	const QString extension = _fn.section( '.', -1 );
 
-	switch( type() )
+	// SongProjects may be saved with template extension
+	if (type() == Type::SongProject && FileTypes::find(extension) == FileType::ProjectTemplate)
 	{
-		case Type::SongProject:
-			if( extension != "mmp" &&
-					extension != "mpt" &&
-					extension != "mmpz" )
-			{
-				if( ConfigManager::inst()->value( "app",
-						"nommpz" ).toInt() == 0 )
-				{
-					return _fn + ".mmpz";
-				}
-				return _fn + ".mmp";
-			}
-			break;
-		case Type::SongProjectTemplate:
-			if( extension != "mpt" )
-			{
-				return _fn + ".mpt";
-			}
-			break;
-		case Type::InstrumentTrackSettings:
-			if( extension != "xpf" )
-			{
-				return _fn + ".xpf";
-			}
-			break;
-		default: ;
+		return _fn;
+	}
+
+	// Add extension if it's missing
+	QString correctExt = DataFile::extension(type());
+	if (!correctExt.isEmpty() && extension != correctExt)
+	{
+			return _fn + "." + correctExt;
 	}
 	return _fn;
 }
@@ -399,7 +325,7 @@ bool DataFile::writeFile(const QString& filename, bool withResources)
 	}
 
 	const QString extension = fullName.section('.', -1);
-	if (extension == "mmpz" || extension == "xptz")
+	if (isCompressed(extension))
 	{
 		QString xml;
 		QTextStream ts( &xml );
@@ -619,6 +545,74 @@ DataFile::Type DataFile::type( const QString& typeName )
 QString DataFile::typeName( Type type )
 {
 	return s_types[static_cast<std::size_t>(type)].m_name;
+}
+
+
+
+
+QString DataFile::extension(Type type)
+{
+	bool wantCompressed = ConfigManager::inst()->value("app", "nommpz" ).toInt() == 0;
+
+	QString firstMatch;
+	for (const auto& desc : s_types)
+	{
+		if (desc.m_type == type)
+		{
+			for (const auto& ext: desc.m_extensions)
+			{
+				// In case there's a suffix that matches the user setting for compressed files, use that
+				// Otherwise use the first suffix in the list
+				if (isCompressed(ext) == wantCompressed)
+				{
+					return ext;
+				}
+				else if (firstMatch.isEmpty())
+				{
+					firstMatch = ext;
+				}
+			}
+
+		}
+	}
+	return firstMatch;
+}
+
+
+
+
+std::vector<std::pair<FileType, QString>> DataFile::allSupportedFileTypes()
+{
+	std::vector<std::pair<FileType, QString>> result;
+
+	for (const auto& desc : s_types)
+	{
+		// Convert the DataFile::Type to a more generic FileType
+		auto type = FileType::Unknown;
+		switch (desc.m_type)
+		{
+		case Type::SongProject:
+			type = FileType::Project;
+			break;
+		case Type::SongProjectTemplate:
+			type = FileType::ProjectTemplate;
+			break;
+		case Type::InstrumentTrackSettings:
+			type = FileType::InstrumentPreset;
+			break;
+		case Type::MidiClip:
+			type = FileType::MidiClipData;
+			break;
+		default:
+			continue;
+		}
+
+		for (const auto& ext: desc.m_extensions)
+		{
+			result.push_back({type, ext});
+		}
+	}
+	return result;
 }
 
 

--- a/src/core/FileTypes.cpp
+++ b/src/core/FileTypes.cpp
@@ -1,0 +1,166 @@
+/*
+ * FileTypes.cpp
+ *
+ * Copyright (c) 2025 allejok96 <gmail>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ */
+
+#include "FileTypes.h"
+
+#include <QFileInfo>
+
+#include "DataFile.h"
+#include "PluginFactory.h"
+#include "SampleDecoder.h"
+
+
+namespace lmms
+{
+
+namespace FileTypes
+{
+
+namespace
+{
+
+// Static map of supported extensions and their FileType, only updated on first call
+std::map<QString, FileType> extensionMap()
+{
+	static std::map<QString, FileType> s_extensions;
+
+	if (!s_extensions.empty()) { return s_extensions; }
+
+	// Get file extensions that can be opened or imported by a plugin
+	for (const auto& desc: getPluginFactory()->descriptors())
+	{
+		for (const auto& ext: desc->supportedFileTypes)
+		{
+			switch (desc->type)
+			{
+			case Plugin::Type::Instrument:
+				s_extensions[ext] = FileType::InstrumentAsset;
+				break;
+			case Plugin::Type::ImportFilter:
+				s_extensions[ext] = FileType::InstrumentAsset;
+				break;
+			default:
+				break;
+			}
+		}
+	}
+
+	// Get audio file extensions
+	// Do this AFTER the plugins so it doesn't map AudioFileProcessor to all audio files
+	for (const auto& [name, ext]: SampleDecoder::supportedAudioTypes())
+	{
+		s_extensions[QString::fromStdString(ext)] = FileType::Sample;
+	}
+
+	// Get DataFile extensions
+	for (const auto& [type, ext]: DataFile::allSupportedFileTypes())
+	{
+		s_extensions[ext] = type;
+	}
+
+	return s_extensions;
+};
+
+}
+
+
+
+
+QString compileFilter(const std::initializer_list<FileType> fileTypes, const QString& label)
+{
+	bool includeAll = fileTypes.size() == 0;
+
+	QStringList filterParts;
+	for (const auto& [ext, type]: extensionMap())
+	{
+		if (includeAll || std::find(fileTypes.begin(), fileTypes.end(), type) != fileTypes.end())
+		{
+			filterParts.append("*." + ext);
+		}
+	}
+
+	QString filterString = filterParts.join(" ");
+	return label.isEmpty() ? filterString : label + " (" + filterString + ")";
+}
+
+
+
+
+FileType find(const QString& ext)
+{
+	return extensionMap().contains(ext) ? extensionMap().at(ext) : FileType::Unknown;
+}
+
+
+
+
+std::string iconName(const QString& ext)
+{
+	// TODO icon for .pat files
+
+	if (ext == "sf2" || ext == "sf3")
+	{
+		return "soundfont_file";
+	}
+	else if (ext == "dll" || ext == "so")
+	{
+		return "vst_plugin_file";
+	}
+	else if (ext == "mid" || ext == "midi" || ext == "rmi")
+	{
+		return "midi_file";
+	}
+	else
+	{
+		switch (FileTypes::find(ext))
+		{
+		case FileType::Sample:
+			return "sample_file";
+		case FileType::Project:
+		case FileType::ProjectTemplate:
+		case FileType::ImportableProject:
+			return "project_file";
+		case FileType::InstrumentPreset:
+		case FileType::InstrumentAsset:
+			return "preset_file";
+		default:
+			return "unknown_file";
+		}
+	}
+}
+
+
+
+
+bool matchPath(const std::initializer_list<FileType> types, const QString& path)
+{
+	auto type = FileTypes::find(QFileInfo(path).suffix().toLower());
+	auto it = std::find(types.begin(), types.end(), type);
+	return it != types.end();
+}
+
+
+} // namespace FileTypes
+
+
+} // namespace lmms

--- a/src/core/PluginFactory.cpp
+++ b/src/core/PluginFactory.cpp
@@ -125,6 +125,13 @@ PluginFactory::PluginInfoAndKey PluginFactory::pluginSupportingExtension(const Q
 	return m_pluginByExt.value(ext, PluginInfoAndKey());
 }
 
+
+QStringList PluginFactory::allSupportedExtensions()
+{
+	return QStringList(m_pluginByExt.keys());
+}
+
+
 PluginFactory::PluginInfo PluginFactory::pluginInfo(const char* name) const
 {
 	for (const PluginInfo& info : m_pluginInfos)
@@ -224,7 +231,7 @@ void PluginFactory::discoverPlugins()
 				}
 			};
 
-			if (info.descriptor->supportedFileTypes)
+			if (!info.descriptor->supportedFileTypes.isEmpty())
 				addSupportedFileTypes(QString(info.descriptor->supportedFileTypes), info);
 
 			if (info.descriptor->subPluginFeatures)

--- a/src/gui/StringPairDrag.cpp
+++ b/src/gui/StringPairDrag.cpp
@@ -105,7 +105,7 @@ bool StringPairDrag::processDragEnterEvent( QDragEnterEvent * _dee,
 
 QString StringPairDrag::decodeKey( QDropEvent * _de )
 {
-	return Clipboard::decodeKey( _de->mimeData() );
+	return MimeData::toStringPair(_de->mimeData()).first;
 }
 
 
@@ -113,7 +113,7 @@ QString StringPairDrag::decodeKey( QDropEvent * _de )
 
 QString StringPairDrag::decodeValue( QDropEvent * _de )
 {
-	return Clipboard::decodeValue( _de->mimeData() );
+	return MimeData::toStringPair(_de->mimeData()).second;
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5429,10 +5429,7 @@ void PianoRollWindow::exportMidiClip()
 		!exportDialog.selectedFiles().isEmpty() &&
 		!exportDialog.selectedFiles().first().isEmpty())
 	{
-		QString suffix =
-			ConfigManager::inst()->value("app", "nommpz").toInt() == 0
-				? "xptz"
-				: "xpt";
+		QString suffix = DataFile::extension(DataFile::Type::MidiClip);
 		exportDialog.setDefaultSuffix(suffix);
 
 		const QString fullPath = exportDialog.selectedFiles()[0];

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -30,6 +30,7 @@
 #include <QSizePolicy>
 #include <QVBoxLayout>
 
+#include "Clipboard.h"
 #include "EnvelopeGraph.h"
 #include "LfoGraph.h"
 #include "EnvelopeAndLfoParameters.h"
@@ -38,7 +39,6 @@
 #include "LedCheckBox.h"
 #include "DataFile.h"
 #include "PixmapButton.h"
-#include "StringPairDrag.h"
 #include "TempoSyncKnob.h"
 #include "TextFloat.h"
 #include "Track.h"
@@ -228,9 +228,7 @@ void EnvelopeAndLfoView::modelChanged()
 
 void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 {
-	StringPairDrag::processDragEnterEvent( _dee,
-					QString( "samplefile,clip_%1" ).arg(
-							static_cast<int>(Track::Type::Sample) ) );
+	DragAndDrop::acceptFile(_dee, {FileType::Sample});
 }
 
 
@@ -238,22 +236,9 @@ void EnvelopeAndLfoView::dragEnterEvent( QDragEnterEvent * _dee )
 
 void EnvelopeAndLfoView::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
-	if( type == "samplefile" )
+	auto file = DragAndDrop::getFile(_de, FileType::Sample);
+	if (!file.isEmpty())
 	{
-		m_params->m_userWave = SampleLoader::createBufferFromFile(value);
-		m_userLfoBtn->model()->setValue( true );
-		m_params->m_lfoWaveModel.setValue(static_cast<int>(EnvelopeAndLfoParameters::LfoShape::UserDefinedWave));
-		_de->accept();
-		update();
-	}
-	else if( type == QString( "clip_%1" ).arg( static_cast<int>(Track::Type::Sample) ) )
-	{
-		DataFile dataFile( value.toUtf8() );
-		auto file = dataFile.content().
-					firstChildElement().firstChildElement().
-					firstChildElement().attribute("src");
 		m_params->m_userWave = SampleLoader::createBufferFromFile(file);
 		m_userLfoBtn->model()->setValue( true );
 		m_params->m_lfoWaveModel.setValue(static_cast<int>(EnvelopeAndLfoParameters::LfoShape::UserDefinedWave));

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -1375,7 +1375,8 @@ void SetupDialog::openSF2File()
 {
 #ifdef LMMS_HAVE_FLUIDSYNTH
 	QString new_file = FileDialog::getOpenFileName(this,
-		tr("Choose your default SF2"), m_sf2File, "SoundFont 2 files (*.sf2)");
+		// TODO should this be linked to SoundFont player's formats in some way?
+		tr("Choose your default soundfont"), m_sf2File, "SoundFont files (*.sf2 *.sf3)");
 
 	if (!new_file.isEmpty())
 	{

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -30,10 +30,13 @@
 #include <QSpacerItem>
 #include <QVBoxLayout>
 
+#include "Clipboard.h"
 #include "ConfigManager.h"
 #include "embed.h"
 #include "Engine.h"
 #include "FadeButton.h"
+#include "FileTypes.h"
+#include "FontHelper.h"
 #include "Mixer.h"
 #include "MixerChannelLcdSpinBox.h"
 #include "MixerView.h"
@@ -42,7 +45,6 @@
 #include "SampleClip.h"
 #include "SampleTrackWindow.h"
 #include "SongEditor.h"
-#include "StringPairDrag.h"
 #include "TrackContainerView.h"
 #include "TrackLabelButton.h"
 
@@ -188,20 +190,18 @@ void SampleTrackView::modelChanged()
 
 
 
-void SampleTrackView::dragEnterEvent(QDragEnterEvent *dee)
+void SampleTrackView::dragEnterEvent(QDragEnterEvent* dee)
 {
-	StringPairDrag::processDragEnterEvent(dee, QString("samplefile"));
+	DragAndDrop::acceptFile(dee, {FileType::Sample});
 }
 
 
 
 
-void SampleTrackView::dropEvent(QDropEvent *de)
+void SampleTrackView::dropEvent(QDropEvent* de)
 {
-	QString type  = StringPairDrag::decodeKey(de);
-	QString value = StringPairDrag::decodeValue(de);
-
-	if (type == "samplefile")
+	const auto value = DragAndDrop::getFile(de, FileType::Sample);
+	if (!value.isEmpty())
 	{
 		int trackHeadWidth = ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt()==1
 				? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -355,12 +355,8 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QDropEvent* d
 // Overloaded method to make it possible to call this method without a Drag&Drop event
 bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md , bool allowSameBar )
 {
-	// For decodeKey() and decodeValue()
-	using namespace Clipboard;
-
 	Track * t = getTrack();
-	QString type = decodeKey( md );
-	QString value = decodeValue( md );
+	const auto [type, value] = MimeData::toStringPair(md);
 
 	// We can only paste into tracks of the same type
 	if (type != ("clip_" + QString::number(static_cast<int>(t->type()))))
@@ -461,8 +457,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 		return false;
 	}
 
-	QString type = decodeKey( md );
-	QString value = decodeValue( md );
+	const auto [type, value] = MimeData::toStringPair(md);
 
 	getTrack()->addJournalCheckPoint();
 

--- a/src/gui/widgets/Graph.cpp
+++ b/src/gui/widgets/Graph.cpp
@@ -25,9 +25,10 @@
 
 #include <QPainter>
 
+#include "Clipboard.h"
+#include "FileTypes.h"
 #include "Graph.h"
 #include "SampleLoader.h"
-#include "StringPairDrag.h"
 #include "Oscillator.h"
 
 namespace lmms
@@ -409,24 +410,13 @@ void Graph::paintEvent( QPaintEvent * )
 
 void Graph::dropEvent( QDropEvent * _de )
 {
-	QString type = StringPairDrag::decodeKey( _de );
-	QString value = StringPairDrag::decodeValue( _de );
-
-	if( type == "samplefile" )
-	{
 		// TODO: call setWaveToUser
 		// loadSampleFromFile( value );
-		_de->accept();
-	}
 }
 
-void Graph::dragEnterEvent( QDragEnterEvent * _dee )
+void Graph::dragEnterEvent(QDragEnterEvent* _dee)
 {
-	if( StringPairDrag::processDragEnterEvent( _dee,
-		QString( "samplefile" ) ) == false )
-	{
-		_dee->ignore();
-	}
+	DragAndDrop::acceptFile(_dee, {FileType::Sample});
 }
 
 


### PR DESCRIPTION
continued from @AW1534's work on #7849 ... I had to start clean on the changed I made to it

- `FileTypes` helpers for dynamic loading of file extensions
- `Clipboard.h` split into 3 namespaces
  -  `Clipboard` for system clipboard helpers
  - `DragAndDrop` for string pair drag and QDropEvent helpers
  - `MimeData` for QMimeData helpers
- `PluginView` handles drop events so plugins doesn't have to
- `SampleClipView` includes the path of the sample so it can be dropped anywhere (even in other apps)
- Keeping some old code to keep changes to a minimum

I haven't tested it so much