### PR TITLE
Fix for LFO Controller desync on changing play position with the mouse.

### DIFF
--- a/include/Song.h
+++ b/include/Song.h
@@ -410,7 +410,9 @@ private slots:
 
 	void updateFramesPerTick();
 
+public:
 
+	void setPlayPos( tick_t ticks, PlayMode playMode );
 
 private:
 	Song();
@@ -434,7 +436,6 @@ private:
 			getPlayPos(m_playMode).currentFrame();
 	}
 
-	void setPlayPos( tick_t ticks, PlayMode playMode );
 
 	void saveControllerStates( QDomDocument & doc, QDomElement & element );
 	void restoreControllerStates( const QDomElement & element );

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -332,6 +332,24 @@ void TimeLineWidget::mouseMoveEvent( QMouseEvent* event )
 	switch( m_action )
 	{
 		case Action::MovePositionMarker:
+			// Using both setToTime and setPlayPos are required in this context.
+			// setToTime sets the time display at the top.
+			// setPlayPos updated the LFO Controller and probably other stuff as well.
+			m_pos.setTicks(timeAtCursor.getTicks());
+			if (!( Engine::getSong()->isPlaying()))
+			{
+				//Song::PlayMode::None is used when nothing is being played.
+				Engine::getSong()->setToTime(timeAtCursor, Song::PlayMode::None);
+				Engine::getSong()->setPlayPos(timeAtCursor.getTicks(), Song::PlayMode::None);
+			} else {
+				Engine::getSong()->setToTime(timeAtCursor, m_mode);
+				Engine::getSong()->setPlayPos(timeAtCursor.getTicks(), m_mode);
+			}
+			m_pos.setCurrentFrame( 0 );
+			m_pos.setJumped( true );
+			updatePosition();
+			break;
+
 			m_pos.setTicks(timeAtCursor.getTicks());
 			Engine::getSong()->setToTime(timeAtCursor, m_mode);
 			if (!( Engine::getSong()->isPlaying()))


### PR DESCRIPTION
Fixes https://github.com/LMMS/lmms/issues/7528

LFO Controller phase is now updated properly on moving the playhead with the mouse.

Unsure whether this fix has far reaching consequences.