### PR TITLE
UI: Good space for two LFO controllers

### DIFF
--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -90,7 +90,7 @@ ControllerRackView::ControllerRackView() :
 	subWin->move( 680, 310 );
 	subWin->resize(350, 230);
 	subWin->setFixedWidth( 350 );
-	subWin->setMinimumHeight( 230 );
+	subWin->setMinimumHeight(230);
 }
 
 


### PR DESCRIPTION
The current height for the controller rack causes scrollbar to appear for the second one and on-wards. This proposal adds 30 pixels height for the rack so that there is an enough space for at least two LFO Controllers, comfortably.