### PR TITLE
Fix several typos

### DIFF
--- a/cmake/modules/BashCompletion.cmake
+++ b/cmake/modules/BashCompletion.cmake
@@ -39,7 +39,7 @@ endif()
 set(BASHCOMP_USER_PATH "share/${PROJECT_NAME}/bash-completion/completions")
 
 macro(BASHCOMP_INSTALL SCRIPT_NAME)
-	# Note:  When running from CPack, message(...) will be supressed unless WARNING
+	# Note:  When running from CPack, message(...) will be suppressed unless WARNING
 	if(WIN32)
 		message(STATUS "Bash completion is not supported on this platform.")
 	else()

--- a/cmake/modules/CheckSubmodules.cmake
+++ b/cmake/modules/CheckSubmodules.cmake
@@ -7,7 +7,7 @@
 #       INCLUDE(CheckSubmodules)
 #
 # Options:
-#       SET(PLUGIN_LIST "ZynAddSubFx;...") # skips submodules for plugins not explicitely listed
+#       SET(PLUGIN_LIST "ZynAddSubFx;...") # skips submodules for plugins not explicitly listed
 #
 # Or via command line:       
 #       cmake -PLUGIN_LIST=foo;bar
@@ -43,7 +43,7 @@ SET(LANG_BACKUP "$ENV{LANG}")
 SET(ENV{LC_ALL} "C")
 SET(ENV{LANG} "en_US")
 
-# Submodule list pairs, unparsed (WARNING: Assumes alpha-numeric paths)
+# Submodule list pairs, unparsed (WARNING: Assumes alphanumeric paths)
 STRING(REGEX MATCHALL "path = [-0-9A-Za-z/]+" SUBMODULE_LIST_RAW ${SUBMODULE_DATA})
 STRING(REGEX MATCHALL "url = [.:%-0-9A-Za-z/]+" SUBMODULE_URL_RAW ${SUBMODULE_DATA})
 

--- a/data/presets/ZynAddSubFX/Laba170bank/descriptions.txt
+++ b/data/presets/ZynAddSubFX/Laba170bank/descriptions.txt
@@ -5,4 +5,4 @@ Made in Zynaddsubfx vsti ver 2.4.1.420
 
 * Some of these presets needs unison to sound like they were intended.
 
-* Relative bandwith (relBW) can on many patches be tweaked to fatten up the sound or make it sharper.
+* Relative bandwidth (relBW) can on many patches be tweaked to fatten up the sound or make it sharper.

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1070,7 +1070,7 @@ HTML_STYLESHEET        =
 # defined cascading style sheet that is included after the standard style sheets
 # created by doxygen. Using this option one can overrule certain style aspects.
 # This is preferred over using HTML_STYLESHEET since it does not replace the
-# standard style sheet and is therefor more robust against future updates.
+# standard style sheet and is therefore more robust against future updates.
 # Doxygen will copy the style sheet file to the output directory. For an example
 # see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
@@ -1954,7 +1954,7 @@ PREDEFINED             =
 EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
-# remove all refrences to function-like macros that are alone on a line, have an
+# remove all references to function-like macros that are alone on a line, have an
 # all uppercase name, and do not end with a semicolon. Such function macros are
 # typically used for boiler-plate code, and will confuse the parser if not
 # removed.

--- a/include/AudioBufferView.h
+++ b/include/AudioBufferView.h
@@ -297,14 +297,14 @@ class InterleavedBufferView : public detail::BufferViewData<T, channelCount>
 public:
 	using Base::Base;
 
-	//! Contruct const from mutable (static channel count)
+	//! Construct const from mutable (static channel count)
 	template<typename U = T> requires (std::is_const_v<U> && channelCount != DynamicChannelCount)
 	constexpr InterleavedBufferView(InterleavedBufferView<std::remove_const_t<U>, channelCount> other) noexcept
 		: Base{other.data(), other.frames()}
 	{
 	}
 
-	//! Contruct const from mutable (dynamic channel count)
+	//! Construct const from mutable (dynamic channel count)
 	template<typename U = T> requires (std::is_const_v<U> && channelCount == DynamicChannelCount)
 	constexpr InterleavedBufferView(InterleavedBufferView<std::remove_const_t<U>, channelCount> other) noexcept
 		: Base{other.data(), other.channels(), other.frames()}
@@ -474,14 +474,14 @@ class PlanarBufferView : public detail::BufferViewData<T* const, channelCount>
 public:
 	using Base::Base;
 
-	//! Contruct const from mutable (static channel count)
+	//! Construct const from mutable (static channel count)
 	template<typename U = T> requires (std::is_const_v<U> && channelCount != DynamicChannelCount)
 	constexpr PlanarBufferView(PlanarBufferView<std::remove_const_t<U>, channelCount> other) noexcept
 		: Base{other.data(), other.frames()}
 	{
 	}
 
-	//! Contruct const from mutable (dynamic channel count)
+	//! Construct const from mutable (dynamic channel count)
 	template<typename U = T> requires (std::is_const_v<U> && channelCount == DynamicChannelCount)
 	constexpr PlanarBufferView(PlanarBufferView<std::remove_const_t<U>, channelCount> other) noexcept
 		: Base{other.data(), other.channels(), other.frames()}

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -57,7 +57,7 @@ public:
 	}
 
 
-	// if audio-driver supports ports, classes inherting AudioBusHandle
+	// if audio-driver supports ports, classes inheriting AudioBusHandle
 	// (e.g. channel-tracks) can register themselves for making
 	// audio-driver able to collect their individual output and provide
 	// them at a specific port - currently only supported by JACK

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -347,7 +347,7 @@ private slots:
 	void setProgressionType(int progType);
 	/**
 	 * @brief The Edit Tangent edit mode should only be available for
-	 * Cubic Hermite progressions, so this method is responsable for disabling it
+	 * Cubic Hermite progressions, so this method is responsible for disabling it
 	 * for other edit modes and reenabling it when it changes back to the Edit Tangent
 	 * mode.
 	 */

--- a/include/BasicFilters.h
+++ b/include/BasicFilters.h
@@ -770,7 +770,7 @@ public:
 		{
 			// [ 0 - 0.5 ]
 			const float f = std::clamp(_freq, minFreq(), 20000.0f) * m_sampleRatio;
-			// (Empirical tunning)
+			// (Empirical tuning)
 			m_p = ( 3.6f - 3.2f * f ) * f;
 			m_k = 2.0f * m_p - 1;
 			m_r = _q * std::exp((1 - m_p) * 1.386249f);

--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -108,7 +108,7 @@ public:
 
 signals:
 	// NOTE: when separating core from UI, this will need to be removed
-	// (who would kno if the client is Qt, i.e. it may not have slots at all)
+	// (who would know if the client is Qt, i.e. it may not have slots at all)
 	// In this case you'd e.g. send the UI something like
 	// "/added <model meta info>"
 	void modelAdded(lmms::AutomatableModel* added);

--- a/include/LmmsSemaphore.h
+++ b/include/LmmsSemaphore.h
@@ -55,7 +55,7 @@ namespace lmms {
    be 0 so the semaphore can be used as a simple signal where each post
    corresponds to one wait.
 
-   Semaphores are very efficient (much moreso than a mutex/cond pair).  In
+   Semaphores are very efficient (much more so than a mutex/cond pair).  In
    particular, at least on Linux, post is async-signal-safe, which means it
    does not block and will not be interrupted.  If you need to signal from
    a realtime thread, this is the most appropriate primitive to use.

--- a/include/MeterModel.h
+++ b/include/MeterModel.h
@@ -46,7 +46,7 @@ public:
 
 	void reset();
 
-	// Must have the sub-models exposed to programatically connect
+	// Must have the sub-models exposed to programmatically connect
 	// to automation or controllers
 	IntModel & numeratorModel()
 	{

--- a/include/Note.h
+++ b/include/Note.h
@@ -1,5 +1,5 @@
 /*
- * Note.h - declaration of class note which contains all informations about a
+ * Note.h - declaration of class note which contains all information about a
  *          note + definitions of several constants and enums
  *
  * Copyright (c) 2004-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
@@ -148,7 +148,7 @@ public:
 
 	static inline bool lessThan( const Note * lhs, const Note * rhs )
 	{
-		// function to compare two notes - must be called explictly when
+		// function to compare two notes - must be called explicitly when
 		// using qSort
 		if( (int)( *lhs ).pos() < (int)( *rhs ).pos() )
 		{

--- a/include/QuadratureLfo.h
+++ b/include/QuadratureLfo.h
@@ -1,5 +1,5 @@
 /*
- * quadraturelfo.h - defination of QuadratureLfo class.
+ * quadraturelfo.h - definition of QuadratureLfo class.
  *
  * Copyright (c) 2014 David French <dave/dot/french3/at/googlemail/dot/com>
  *

--- a/include/SubWindow.h
+++ b/include/SubWindow.h
@@ -46,7 +46,7 @@ namespace lmms::gui
  * 
  *  Because of a bug in the QMdiSubWindow class to save the right position and size
  *  of a subwindow in a project and because of the inability
- *  for cusomizing the title bar appearance, lmms implements its own subwindow
+ *  for customizing the title bar appearance, lmms implements its own subwindow
  *  class.
  */
 class LMMS_EXPORT SubWindow : public QMdiSubWindow

--- a/include/endian_handling.h
+++ b/include/endian_handling.h
@@ -1,5 +1,5 @@
 /*
- * endian_handling.h - handle endianess
+ * endian_handling.h - handle endianness
  *
  * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
  *

--- a/include/lmms_constants.h
+++ b/include/lmms_constants.h
@@ -86,7 +86,7 @@ inline constexpr auto ARANGE_SILENT_START   = -60;
 inline constexpr auto ARANGE_SILENT_END     = -10;
 
 
-// This macro is used to handle path seperation properly in windows
+// This macro is used to handle path separation properly in windows
 constexpr char LADSPA_PATH_SEPERATOR =
 #ifdef LMMS_BUILD_WIN32
 ';';

--- a/plugins/CarlaBase/Carla.cpp
+++ b/plugins/CarlaBase/Carla.cpp
@@ -849,7 +849,7 @@ CarlaParamsView::CarlaParamsView(CarlaInstrumentView* const instrumentView, QWid
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 
@@ -1054,7 +1054,7 @@ void CarlaParamsView::addKnob(uint32_t index)
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -925,7 +925,7 @@ ManageVestigeInstrumentView::ManageVestigeInstrumentView( Instrument * _instrume
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/plugins/VstEffect/VstEffectControlDialog.cpp
+++ b/plugins/VstEffect/VstEffectControlDialog.cpp
@@ -51,7 +51,7 @@ VstEffectControlDialog::VstEffectControlDialog( VstEffectControls * _ctl ) :
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -318,7 +318,7 @@ ManageVSTEffectView::ManageVSTEffectView( VstEffect * _eff, VstEffectControls * 
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/plugins/Xpressive/Xpressive.cpp
+++ b/plugins/Xpressive/Xpressive.cpp
@@ -865,7 +865,7 @@ XpressiveHelpView::XpressiveHelpView():QTextEdit(s_helpText)
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ foreach (_define_var ${_define_vars})
     endif()
 endforeach()
 
-# Format for readibility
+# Format for readability
 string(REPLACE ";" " " LMMS_BUILD_OPTIONS "${LMMS_BUILD_OPTIONS}")
 
 CONFIGURE_FILE("lmmsversion.h.in"       "${CMAKE_BINARY_DIR}/lmmsversion.h")

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -128,7 +128,7 @@ AudioEngine::AudioEngine( bool renderOnly ) :
 		}
 	}
 
-	// allocte the FIFO from the determined size
+	// allocate the FIFO from the determined size
 	m_fifo = new Fifo( fifoSize );
 
 	// now that framesPerPeriod is fixed initialize global BufferManager

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -48,7 +48,7 @@ const int PNT = 2;
 const int dENV = 3;
 const int NEXTT = 4;
 
-// Bah, I'll move these into the class once I sepearate DrumsynthFile from DrumSynth
+// Bah, I'll move these into the class once I separate DrumsynthFile from DrumSynth
 // llama
 float envpts[8][3][32];	 // envelope/time-level/point
 float envData[8][6];	 // envelope running status

--- a/src/core/Engine.cpp
+++ b/src/core/Engine.cpp
@@ -62,7 +62,7 @@ void Engine::init( bool renderOnly )
 	emit engine->initProgress(tr("Generating wavetables"));
 	// generate (load from file) bandlimited wavetables
 	BandLimitedWave::generateWaves();
-	//initilize oscillators
+	//initialize oscillators
 	Oscillator::waveTableInit();
 
 	emit engine->initProgress(tr("Initializing data structures"));

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -156,7 +156,7 @@ void Oscillator::generateSquareWaveTable(int bands, sample_t* table, int firstBa
 {
 	using namespace std::numbers;
 	// square waves only contain odd harmonics,
-	// at diffrent levels when compared to triangle waves
+	// at different levels when compared to triangle waves
 	// https://en.wikipedia.org/wiki/Square_wave
 	for (int i = 0; i < OscillatorConstants::WAVETABLE_LENGTH; i++)
 	{

--- a/src/core/ProjectVersion.cpp
+++ b/src/core/ProjectVersion.cpp
@@ -39,7 +39,7 @@ ProjectVersion::ProjectVersion(QString version, CompareType c) :
 	// Version numbers may have build data, prefixed with a '+',
 	// but this mustn't affect version precedence in comparisons
 	QString metadataStripped = version.split("+").first();
-	// They must have an obligatory initial segement, and may have
+	// They must have an obligatory initial segment, and may have
 	// optional identifiers prefaced by a '-'. Both parts affect precedence
 	QString obligatorySegment = metadataStripped.section('-', 0, 0);
 	QString prereleaseSegment = metadataStripped.section('-', 1);

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -84,7 +84,7 @@ void StepRecorder::notePressed(const Note & n)
 	{
 		m_isStepInProgress = true;
 
-		//move curser one step forwards
+		//move cursor one step forwards
 		stepForwards();
 	}
 
@@ -115,7 +115,7 @@ void StepRecorder::noteReleased(const Note & n)
 			m_updateReleasedTimer.start(REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS);
 		}
 
-		//check if all note are released, apply notes to clips (or dimiss if length is zero) and prepare to record next step
+		//check if all note are released, apply notes to clips (or dismiss if length is zero) and prepare to record next step
 		if(allCurStepNotesReleased())
 		{
 			if(m_curStepLength > 0)
@@ -292,7 +292,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	{
 		if (stepNote->isReleased())
 		{
-			const int timeSinceReleased = stepNote->timeSinceReleased(); // capture value to avoid wraparound when calculting nextTimout
+			const int timeSinceReleased = stepNote->timeSinceReleased(); // capture value to avoid wraparound when calculating nextTimout
 			if (timeSinceReleased >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS)
 			{
 				notesRemoved = true;
@@ -326,7 +326,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 	}
 	else
 	{
-		// no released note found for next timout, stop timer
+		// no released note found for next timeout, stop timer
 		m_updateReleasedTimer.stop();
 	}
 }

--- a/src/core/audio/AudioPulseAudio.cpp
+++ b/src/core/audio/AudioPulseAudio.cpp
@@ -154,7 +154,7 @@ static void context_state_callback(pa_context *c, void *userdata)
 
 			buffer_attr.maxlength = (uint32_t)(-1);
 
-			// play silence in case of buffer underun instead of using default rewind
+			// play silence in case of buffer underrun instead of using default rewind
 			buffer_attr.prebuf = 0;
 
 			buffer_attr.minreq = (uint32_t)(-1);

--- a/src/core/lv2/Lv2Ports.cpp
+++ b/src/core/lv2/Lv2Ports.cpp
@@ -262,7 +262,7 @@ std::vector<PluginIssue> Meta::get(const LilvPlugin *plugin,
 	if (hasProperty(LV2_PORT_PROPS__logarithmic))
 	{
 		// check min/max available
-		// we requre them anyways, but this will detect plugins that will
+		// we require them anyways, but this will detect plugins that will
 		// be non-Lv2-conforming
 		if(m_min == std::numeric_limits<decltype(m_min)>::lowest())
 		{

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -358,7 +358,7 @@ int main( int argc, char * * argv )
 	// initialize memory managers
 	NotePlayHandleManager::init();
 
-	// intialize RNG
+	// initialize RNG
 	srand( getpid() + time( 0 ) );
 
 	disable_denormals();

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -1129,7 +1129,7 @@ void Directory::update()
 							"--- Factory files ---" ) );
 					sep->setIcon( 0, embed::getIconPixmap(
 								"factory_files" ) );
-					// add delimeter after last file before appending our files
+					// add delimiter after last file before appending our files
 					insertChild( filesBeforeAdd + m_dirCount, sep );
 				}
 			}

--- a/src/gui/MicrotunerConfig.cpp
+++ b/src/gui/MicrotunerConfig.cpp
@@ -67,7 +67,7 @@ MicrotunerConfig::MicrotunerConfig() :
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 
@@ -560,7 +560,7 @@ bool MicrotunerConfig::loadKeymapFromFile()
 		QString line = stream.readLine();
 		if (line != "" && line[0] == '!')
 		{
-			if (line.length() > 1 && line[1] == '!' && i == -7)		// LMMS extension: double "!" occuring before any
+			if (line.length() > 1 && line[1] == '!' && i == -7)		// LMMS extension: double "!" occurring before any
 			{														// value is loaded marks a description field.
 				m_keymapNameEdit->setText(line.mid(2));
 			}

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -64,7 +64,7 @@ MixerView::MixerView(Mixer* mixer) :
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -56,7 +56,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView * tv) :
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -150,10 +150,10 @@ void SubWindow::changeEvent( QEvent *event )
  * 
  *  Stores the given text into the given label.
  *  Shorts the text if it's too big for the labels width
- *  ans adds three dots (...)
+ *  and adds three dots (...)
  * 
  * @param label - holds a pointer to the QLabel
- * @param text  - the text which will be stored (and if needed breaked down) into the QLabel.
+ * @param text  - the text which will be stored (and if needed broken down) into the QLabel.
  */
 void SubWindow::elideText( QLabel *label, QString text )
 {
@@ -255,9 +255,9 @@ void SubWindow::updateTitleBar()
 /**
  * @brief SubWindow::moveEvent
  * 
- *  overides the QMdiSubWindow::moveEvent() for saving the position
+ *  overrides the QMdiSubWindow::moveEvent() for saving the position
  *  of the subwindow into m_trackedNormalGeom. This position
- *  will be saved with the project because of an Qt bug wich doesn't
+ *  will be saved with the project because of an Qt bug which doesn't
  *  save the right position. look at: https://bugreports.qt.io/browse/QTBUG-256
  * @param event
  */
@@ -391,7 +391,7 @@ void SubWindow::focusChanged( QMdiSubWindow *subWindow )
  *  On every resize event we have to adjust our title label.
  * 
  *  At last we store the current size into m_trackedNormalGeom. This size
- *  will be saved with the project because of an Qt bug wich doesn't
+ *  will be saved with the project because of an Qt bug which doesn't
  *  save the right size. look at: https://bugreports.qt.io/browse/QTBUG-256
  * 
  * @param event

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -385,7 +385,7 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 	p.setPen( current? c.lighter( 130 ) : c.darker( 300 ) );
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
 
-	// draw the 'muted' pixmap only if the clip was manualy muted
+	// draw the 'muted' pixmap only if the clip was manually muted
 	if( m_clip->isMuted() )
 	{
 		const int spacing = BORDER_WIDTH;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -330,7 +330,7 @@ void ClipView::updateLength()
 	else
 	{
 		// this std::max function is needed for clips that do not start or end on the beat, otherwise, they "disappear" when zooming to min 
-		// 3 is the minimun width needed to make a clip visible
+		// 3 is the minimum width needed to make a clip visible
 		setFixedWidth(std::max(static_cast<int>(m_clip->length() * pixelsPerBar() / TimePos::ticksPerBar() + 1), 3));
 	}
 	m_trackView->trackContainerView()->update();

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -140,7 +140,7 @@ void MidiClipView::transposeSelection()
 {
 	const auto selection = getClickedClips();
 
-	// Calculate the key boundries for all clips
+	// Calculate the key boundaries for all clips
 	int highest = 0;
 	int lowest = NumKeys - 1;
 	for (ClipView* clipview: selection)
@@ -759,7 +759,7 @@ void MidiClipView::paintEvent( QPaintEvent * )
 
 		int const notesBorder = 4; // Border for the notes towards the top and bottom in pixels
 
-		// The relavant painting code starts here
+		// The relevant painting code starts here
 		p.save();
 
 		p.translate(0., distanceToTop + notesBorder);

--- a/src/gui/clips/PatternClipView.cpp
+++ b/src/gui/clips/PatternClipView.cpp
@@ -150,7 +150,7 @@ void PatternClipView::paintEvent(QPaintEvent*)
 	p.setPen( c.darker( 300 ) );
 	p.drawRect( 0, 0, rect().right(), rect().bottom() );
 	
-	// draw the 'muted' pixmap only if the clip was manualy muted
+	// draw the 'muted' pixmap only if the clip was manually muted
 	if (m_patternClip->isMuted())
 	{
 		const int spacing = BORDER_WIDTH;

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -316,7 +316,7 @@ void SampleClipView::paintEvent( QPaintEvent * pe )
 	p.setPen( c.darker( 200 ) );
 	p.drawRect(-m_paintPixmapXPosition, 0, rect().right(), rect().bottom());
 
-	// draw the 'muted' pixmap only if the clip was manualy muted
+	// draw the 'muted' pixmap only if the clip was manually muted
 	if( m_clip->isMuted() )
 	{
 		const int spacing = BORDER_WIDTH;

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -479,7 +479,7 @@ void AutomationEditor::mousePressEvent( QMouseEvent* mouseEvent )
 					}
 					else // No shift, we are just creating/moving nodes
 					{
-						// Starts actually moving/draging the node
+						// Starts actually moving/dragging the node
 						TimePos newTime = m_clip->setDragValue(
 							// The TimePos of either the clicked node or a new one
 							TimePos(
@@ -814,7 +814,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				{
 					if (m_action == Action::ResetOutValues)
 					{
-						// Reseting outValues
+						// Resetting outValues
 
 						// Resets all values from the last clicked tick up to the current position tick
 						m_clip->resetNodes(m_drawLastTick, posTicks);
@@ -850,7 +850,7 @@ void AutomationEditor::mouseMoveEvent(QMouseEvent * mouseEvent )
 				{
 					if (m_action == Action::ResetOutValues)
 					{
-						// Reseting outValues
+						// Resetting outValues
 
 						// Resets all values from the last clicked tick up to the current position tick
 						m_clip->resetNodes(m_drawLastTick, posTicks);

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -421,7 +421,7 @@ PianoRoll::PianoRoll() :
 	connect( Engine::getSong(), SIGNAL(timeSignatureChanged(int,int)),
 						this, SLOT(update()));
 
-	//connection for selecion from timeline
+	//connection for selection from timeline
 	connect( m_timeLine, SIGNAL(regionSelectedFromPixels(int,int)),
 			this, SLOT(selectRegionFromPixels(int,int)));
 
@@ -3176,7 +3176,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 				m_pianoKeysVisible += 1;
 				partialKeyVisible = 0;
 			}
-			// have to modifiy the notes edit area height instead
+			// have to modify the notes edit area height instead
 			m_notesEditHeight = height() - (m_pianoKeysVisible * m_keyLineHeight)
 				- PR_TOP_MARGIN - PR_BOTTOM_MARGIN;
 		}

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -1133,7 +1133,7 @@ void SongEditorWindow::adjustUiAfterProjectLoad()
 {
 	// make sure to bring us to front as the song editor is the central
 	// widget in a song and when just opening a song in order to listen to
-	// it, it's very annyoing to manually bring up the song editor each time
+	// it, it's very annoying to manually bring up the song editor each time
 	getGUI()->mainWindow()->workspace()->setActiveSubWindow(
 			qobject_cast<QMdiSubWindow *>( parentWidget() ) );
 	connect( qobject_cast<SubWindow *>( parentWidget() ), SIGNAL(focusLost()), this, SLOT(lostFocus()));

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -176,7 +176,7 @@ void TimeLineWidget::paintEvent( QPaintEvent * )
 	bar_t barNumber = m_begin.getBar();
 	int const x = m_xOffset - ((static_cast<int>(m_begin * m_ppb) / TimePos::ticksPerBar()) % static_cast<int>(m_ppb));
 
-	// Double the interval between bar numbers until they are far enough appart
+	// Double the interval between bar numbers until they are far enough apart
 	int barLabelInterval = 1;
 	while (barLabelInterval * m_ppb < MIN_BAR_LABEL_DISTANCE) { barLabelInterval *= 2; }
 

--- a/src/gui/instrument/EnvelopeAndLfoView.cpp
+++ b/src/gui/instrument/EnvelopeAndLfoView.cpp
@@ -54,7 +54,7 @@ EnvelopeAndLfoView::EnvelopeAndLfoView(QWidget * parent) :
 	ModelView(nullptr, this),
 	m_params(nullptr)
 {
-	// Helper lambdas for consistent repeated buiding of certain widgets
+	// Helper lambdas for consistent repeated building of certain widgets
 	auto buildKnob = [&](const QString& label, const QString& hintText)
 	{
 		auto knob = new Knob(KnobType::Bright26, label, this, Knob::LabelRendering::LegacyFixedFontSize);

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -130,7 +130,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 #if QT_VERSION < 0x50C00
 	// Workaround for a bug in Qt versions below 5.12,
 	// where argument-dependent-lookup fails for QFlags operators
-	// declared inside a namepsace.
+	// declared inside a namespace.
 	// This affects the Q_DECLARE_OPERATORS_FOR_FLAGS macro in Instrument.h
 	// See also: https://codereview.qt-project.org/c/qt/qtbase/+/225348
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -222,7 +222,7 @@ void TrackContentWidget::update()
 
 
 
-// resposible for moving track-content-widgets to appropriate position after
+// responsible for moving track-content-widgets to appropriate position after
 // change of visible viewport
 /*! \brief Move the trackContentWidget to a new place in time
  *
@@ -643,7 +643,7 @@ void TrackContentWidget::paintEvent( QPaintEvent * pe )
  */
 void TrackContentWidget::resizeEvent( QResizeEvent * resizeEvent )
 {
-	// Update backgroud
+	// Update background
 	updateBackground();
 	// Force redraw
 	QWidget::resizeEvent( resizeEvent );

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -519,7 +519,7 @@ void InstrumentTrack::processOutEvent( const MidiEvent& event, const TimePos& ti
 			break;
 	}
 
-	// if appropriate, midi-port does futher routing
+	// if appropriate, midi-port does further routing
 	m_midiPort.processOutEvent( event, time );
 }
 


### PR DESCRIPTION
This cleans up typos in source comments and some user-facing strings.

Found via `codespell -q 3 -S "./plugins,./src/3rdparty,./data/locale,*.in,*.xpf" -L continous,currenty,globaly,inports,localy,nd,ot,sie,te,trough`