### PR TITLE
Update macOS runner image and XCode version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,11 +181,11 @@ jobs:
         arch: [ x86_64, arm64 ]
         include:
           - arch: x86_64
-            os: macos-13
-            xcode: "15.2"
+            os: macos-15-intel
+            xcode: "16.4"
           - arch: arm64
-            os: macos-14
-            xcode: "15.4"
+            os: macos-15
+            xcode: "16.4"
     name: macos-${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
The macOS 13 build runner we use for macOS x86_64 builds is deprecated as of September 22 and will be fully unsupported by December 4. ([source](https://github.com/actions/runner-images/issues/13046))

It initially seemed that macOS 13 would be the last free-to-use x86_64 GitHub build runner for macOS, so a few months ago I was experimenting with cross-compiling x86_64 builds from Apple Silicon [on this branch](https://github.com/messmerd/lmms/tree/0aa5ba50c19aa116d02eaef8b2ebb4b9abb620a7). This worked, but build times were nearly an hour which I felt was unacceptable.

Fortunately, GitHub added a new build runner called `macos-15-intel` which will be the last free-to-use Intel build runner for macOS and will be supported until August 2027.

In this PR, I've switched to that `macos-15-intel` build runner for x86_64, upgraded the arm64 build runner to `macos-15`, and for both architectures, I've also bumped the XCode version to 16.4 which is the default. This gives us better C++20 support while still keeping the same minimum deployment target.

Most notably, we now have `consteval` functions and library support for the spaceship operator. There's even `std::jthread` support, though it's guarded behind the `-fexperimental-library` compiler flag.