### PR TITLE
Add creatorplatform to determine where a project originated for future use.

### DIFF
--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -2103,8 +2103,8 @@ void DataFile::upgrade()
 	documentElement().setAttribute( "type", typeName( type() ) );
 	documentElement().setAttribute( "creator", "LMMS" );
 	documentElement().setAttribute( "creatorversion", LMMS_VERSION );
-	documentElement().setAttribute( "creatorplatform", QSysInfo::kernelType() );
-	documentElement().setAttribute( "creatorplatformtype", QSysInfo::productType() );
+	documentElement().setAttribute("creatorplatform", QSysInfo::kernelType());
+	documentElement().setAttribute("creatorplatformtype", QSysInfo::productType());
 
 	if( type() == Type::SongProject || type() == Type::SongProjectTemplate )
 	{


### PR DESCRIPTION
As mentioned in https://github.com/LMMS/lmms/pull/8103#issuecomment-3473978146 , a platform identifier should be added.

KernelType delivers the most agnostic platform info from native Qt, as ProductType would return "Fedora", "OpenSUSE", etc..
If we want to decollate the rest (Android vs. Desktop Linux = "linux", iOS vs. Mac OS X = "darwin"), we'd have to write our own implementation.