### PR TITLE
Adjust model rounding behavior to avoid a potential future mystery bug

### DIFF
--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -401,29 +401,19 @@ void AutomatableModel::setStep( const float step )
 
 
 
-float AutomatableModel::fittedValue( float value ) const
+float AutomatableModel::fittedValue(float value) const
 {
 	value = std::clamp(value, m_minValue, m_maxValue);
 
-	if( m_step != 0 && m_hasStrictStepSize )
+	if (m_step != 0 && m_hasStrictStepSize)
 	{
-		value = nearbyintf( value / m_step ) * m_step;
+		value = std::round(value / m_step) * m_step;
 	}
 
-	roundAt( value, m_maxValue );
-	roundAt( value, m_minValue );
-	roundAt( value, 0.0f );
-
-	if( value < m_minValue )
-	{
-		return m_minValue;
-	}
-	else if( value > m_maxValue )
-	{
-		return m_maxValue;
-	}
-
-	return value;
+	roundAt(value, m_maxValue);
+	roundAt(value, m_minValue);
+	roundAt(value, 0.0f);
+	return std::clamp(value, m_minValue, m_maxValue);
 }
 
 


### PR DESCRIPTION
`AutomatableModel::fittedValue()` currently rounds values using `nearbyintf()`, whose behavior depends on the current rounding mode. The default rounding mode appears to be `FE_TONEAREST` and is not ever changed in the entire LMMS codebase, so `fittedValue()` has been doing the same thing as `round()`, but with the added possibility of exploding if someone in the future decides to call `fesetround()` somewhere. This PR replaces `nearbyintf()` with `round()` to be more explicit about the behavior and eliminate the possibility of any spooky action resulting from different rounding modes.

This PR also cleans up formatting and replaces two `if`s with a call to `clamp()`.