### PR TITLE
Fix Note Quantization Resetting Clip Length

### DIFF
--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -128,9 +128,9 @@ void MidiClip::updateLength()
 	// If the clip hasn't already been manually resized, automatically resize it.
 	if (getAutoResize())
 	{
-		if( m_clipType == Type::BeatClip )
+		if (m_clipType == Type::BeatClip)
 		{
-			changeLength( beatClipLength() );
+			changeLength(beatClipLength());
 			updatePatternTrack();
 			return;
 		}


### PR DESCRIPTION
If you add a single note in a clip and quantize it in the piano roll, nothing happens. Its length stays the same.

<img width="986" height="807" alt="Screenshot From 2025-11-12 19-55-41" src="https://github.com/user-attachments/assets/2f0faa93-e26c-4774-8279-582efb8f152b" />

Nice! However, if you manually resize the clip in the song editor, and then quantize the note in the piano roll, suddenly the clip will reset its length to be 1 bar.

<img width="986" height="807" alt="Screenshot From 2025-11-12 19-55-55" src="https://github.com/user-attachments/assets/6db7ce52-25be-4cd4-b71e-bde91c16126a" />

This is because in `PianoRoll:quantizeNotes`, the way it works is by removing each note and replacing it with a quantized version.

If your clip only has one note in it, then for a brief period of time, the `quantizeNotes` function removes that note, leaving an empty clip.

When it calls the `removeNote` function, one of the things it does is it checks and updates the type of the midi clip (normal vs beat, like for the pattern editor).

This means that empty clips are automatically converted into beat clips (those grey looking clips before a midi clip has any notes in it.)

And beat clips are automatically set to a minimum of 1 bar long, no matter if auto-resize is enabled on them.

This essentially causes the empty clip to be reset to 1 bar during the brief time it was a beat clip, and once the replacement note is added back, it goes back to being a normal midi clip, but because auto resize was disabled, it's stuck at 1 bar.

## Changes

This PR disables the automatic resizing of beat clips when they have auto-resize disabled.

This also means you can resize those grey midi beat clips and they will keep their size.