### PR TITLE
Save & restore Song-Editor zoom

### DIFF
--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -278,11 +278,16 @@ SongEditor::SongEditor( Song * song ) :
 void SongEditor::saveSettings( QDomDocument& doc, QDomElement& element )
 {
 	MainWindow::saveWidgetState( parentWidget(), element );
+	element.setAttribute("timelinezoom", m_zoomingModel->value());
 }
 
 void SongEditor::loadSettings( const QDomElement& element )
 {
 	MainWindow::restoreWidgetState(parentWidget(), element);
+	if (element.hasAttribute("timelinezoom"))
+	{
+		m_zoomingModel->setValue(element.attribute("timelinezoom").toFloat());
+	}
 }
 
 


### PR DESCRIPTION
Saves and loads the horizontal song-editor zoom, so that you don't have to scroll back the knob each time you open LMMS.

Considerations:
1. Should this be global instead of per-project?
2. `timelinezoom` dom attribute name is subject to change
3. Add a dom node instead of adding directly to element root?
4. Zoom is saved as a float directly originating from slider position, rather than e.g pixelsPerBar, should that be changed?
5. It's probably also best to save snapping in this case (maybe puts more emphasis at 2. since they're fairly intertwined?)
6. PR behavior for loading a project without the element is to keep current zoom (upstream behavior). Should it instead reset to default zoom?
7. Is a toggle in settings needed to allow disabling this?