### PR TITLE
[feature/detach-window] Render SVG properly inside subwindow title bar buttons

### DIFF
--- a/data/themes/default/style.css
+++ b/data/themes/default/style.css
@@ -918,6 +918,18 @@ lmms--gui--SubWindow > QPushButton:hover{
 	border-radius: 2px;
 }
 
+QPushButton#btn-window-detach {
+	image: url("resources:detach.svg");
+}
+
+QPushButton#btn-window-maximize {
+	image: url("resources:maximize.png");
+}
+
+QPushButton#btn-window-close {
+	image: url("resources:close.png");
+}
+
 /* Instrument */
 
 /* Envelope graph */

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -44,7 +44,6 @@
 #include <QWindow>
 
 #include "ConfigManager.h"
-#include "embed.h"
 
 namespace lmms::gui
 {
@@ -68,7 +67,8 @@ SubWindow::SubWindow(QWidget* parent, Qt::WindowFlags windowFlags)
 
 	// close, maximize, restore, and detach buttons
 	auto createButton = [this](std::string_view iconName, const QString& tooltip) -> QPushButton* {
-		auto button = new QPushButton{embed::getIconPixmap(iconName), QString{}, this};
+		auto button = new QPushButton{QString{}, this};
+		button->setObjectName(std::format("btn-window-{}", iconName));  // set icons in theme CSS
 		button->resize(m_buttonSize);
 		button->setFocusPolicy(Qt::NoFocus);
 		button->setCursor(Qt::ArrowCursor);


### PR DESCRIPTION
**This is a PR to #3532, not to master!**

Uses the same solution as `TrackOperationsWidget`, which is making the object have a name and setting the icon with CSS.