### PR TITLE
Fix untoggleable buttons not updating connected models

### DIFF
--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -119,6 +119,10 @@ void AutomatableButton::mousePressEvent( QMouseEvent * _me )
 		{
 			toggle();
 		}
+		else
+		{
+			model()->setValue(true);
+		}
 		_me->accept();
 	}
 	else
@@ -150,6 +154,10 @@ void AutomatableButton::mouseReleaseEvent( QMouseEvent * _me )
 {
 	if( _me && _me->button() == Qt::LeftButton )
 	{
+		if(!isCheckable())
+		{
+			model()->setValue(false);
+		}
 		emit clicked();
 	}
 }


### PR DESCRIPTION
Untoggleable buttons don't update their model values for some reason.  This fixes that.