### PR TITLE
Fix ghost channels

### DIFF
--- a/src/gui/MixerChannelView.cpp
+++ b/src/gui/MixerChannelView.cpp
@@ -117,16 +117,16 @@ MixerChannelView::MixerChannelView(QWidget* parent, MixerView* mixerView, int ch
 	m_renameLineEditView->setFixedSize(m_renameLineEdit->height() + 5, m_renameLineEdit->width() + 5);
 
 	m_muteButton = new AutomatableButton(this, tr("Mute"));
-	m_muteButton->setModel(&mixerChannel->m_muteModel);
-	m_muteButton->setCheckable(true);
 	m_muteButton->setObjectName("btn-mute");
 	m_muteButton->setToolTip(tr("Mute this channel"));
+	m_muteButton->setCheckable(true);
+	m_muteButton->setModel(&mixerChannel->m_muteModel);
 
 	m_soloButton = new AutomatableButton(this, tr("Solo"));
-	m_soloButton->setModel(&mixerChannel->m_soloModel);
-	m_soloButton->setCheckable(true);
 	m_soloButton->setObjectName("btn-solo");
 	m_soloButton->setToolTip(tr("Solo this channel"));
+	m_soloButton->setCheckable(true);
+	m_soloButton->setModel(&mixerChannel->m_soloModel);
 
 	auto soloMuteLayout = new QVBoxLayout();
 	soloMuteLayout->setContentsMargins(0, 2, 0, 2);


### PR DESCRIPTION
Fixes an issue whereby muting a mixer channel, saving, and reloading the project  causes the mixer icon to be in an unmuted state even though the channel is muted. The solution was to change the initialization order for the mute and solo buttons in `MixerChannelView`, making the icons aware of the model values.