### PR TITLE
Fix missing icon in Slew Distortion help window

### DIFF
--- a/plugins/SlewDistortion/SlewDistortionControlDialog.cpp
+++ b/plugins/SlewDistortion/SlewDistortionControlDialog.cpp
@@ -478,7 +478,7 @@ SlewDistortionHelpView::SlewDistortionHelpView() : QTextEdit(s_helpText)
 	setTextInteractionFlags(Qt::TextSelectableByKeyboard | Qt::TextSelectableByMouse);
 	getGUI()->mainWindow()->addWindowedWidget(this);
 	parentWidget()->setAttribute(Qt::WA_DeleteOnClose, false);
-	parentWidget()->setWindowIcon(PLUGIN_NAME::getIconPixmap("logo"));
+	parentWidget()->setWindowIcon(QIcon(PixmapLoader("lmms-plugin-logo").pixmap()));
 	
 	// No maximize button
 	Qt::WindowFlags flags = parentWidget()->windowFlags();


### PR DESCRIPTION
As part of #8124, `logo.svg` was removed from the plugin directories, because it's shared.

Then, a call to `new PixmapLoader("lmms-plugin-logo")` checks `data/themes/default` for the logo. ([8124 files, to verify](https://github.com/LMMS/lmms/pull/8124/files)).

However, Slew Distortion has a question mark in the bottom right corner which opens a window explaining how the plugin works. This window's icon relied on the logo, too, as seen [here](https://github.com/LMMS/lmms/blob/master/plugins/SlewDistortion/SlewDistortionControlDialog.cpp#L481):

```cpp
	parentWidget()->setWindowIcon(PLUGIN_NAME::getIconPixmap("logo"));
```

The fix is passing `getIconPixmap` a pixmap reference like how it's done in the PR.