### PR TITLE
Fix Clang compiler misidentification in About dialog

### DIFF
--- a/include/versioninfo.h
+++ b/include/versioninfo.h
@@ -3,10 +3,10 @@
 
 #include "LmmsCommonMacros.h"
 
-#if defined(__GNUC__)
-constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "GCC " __VERSION__;
-#elif defined(__clang__)
+#if defined(__clang__)
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "Clang " __clang_version__;
+#elif defined(__GNUC__)
+constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "GCC " __VERSION__;
 #elif defined(_MSC_VER)
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "MSVC " LMMS_STRINGIFY(_MSC_FULL_VER);
 #else


### PR DESCRIPTION
Clang was incorrectly displayed as 'GCC Clang' because \_\_GNUC__ is defined by Clang for compatibility. Reordered preprocessor checks in versioninfo.h to test for \_\_clang__ before \_\_GNUC__.

Fixes #8120

Screenshot of fix: 
<img width="2330" height="1014" alt="image" src="https://github.com/user-attachments/assets/35313706-3338-46db-ba31-0f34a60bcb6d" />
