### PR TITLE
Fix Shift+Space corrupting playback state when used on stopped editors

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -626,7 +626,7 @@ void Song::setPlayPos( tick_t ticks, PlayMode playMode )
 void Song::togglePause()
 {
 	// Pause/unpause only works when something is actually playing
-	if( m_playMode == PlayMode::None )
+	if (m_playMode == PlayMode::None)
 	{
 		return;
 	}


### PR DESCRIPTION
Shift+Space (togglePause) was allowing state corruption by modifying m_playing and m_paused without checking m_playMode. This created an impossible state where m_playing=true while m_playMode=None, causing the regular Space key to stop working.

Added a guard to ensure togglePause() only operates when something is actually playing (m_playMode != PlayMode::None). This prevents the corrupted state and maintains proper play/pause/stop behavior.

To put it simply: Space starts and stops playback, and Shift+Space pauses and resumes playback, but **does not** start playback.

Fixes #8036