### PR TITLE
fix: AFP reverse sample on new sample load

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -320,6 +320,7 @@ void AudioFileProcessor::setAudioFile(const QString& _audio_file, bool _rename)
 
 	m_sample = Sample(gui::SampleLoader::createBufferFromFile(_audio_file));
 	loopPointChanged();
+	reverseModelChanged();
 	emit sampleUpdated();
 }
 


### PR DESCRIPTION
Previously the model and sample data would desync, causing the sample to not be reversed, while the button would claim that it is.

steps to reproduce original bug:

1. load sample into AFP
2. toggle reverse on
3. load sample into AFP (can even be same sample)
4. observe how the sample plays back as - and gets displayed as - non-reversed, while the reverser button is still toggled on

Considering all the other buttons up there worked that way, I just made the reverse button apply whatever was set before to the new sample.