### PR TITLE
fix: unknown arch+os info in versioninfo

### DIFF
--- a/include/versioninfo.h
+++ b/include/versioninfo.h
@@ -2,6 +2,7 @@
 #define LMMS_VERSION_INFO_H
 
 #include "LmmsCommonMacros.h"
+#include "lmmsconfig.h"
 
 #if defined(__GNUC__)
 constexpr const char* LMMS_BUILDCONF_COMPILER_VERSION = "GCC " __VERSION__;


### PR DESCRIPTION
someone just straight up forgot to include the necessary defines… welp

| | Before | After |
|---|--------|--------|
| clang | <img width="500" src="https://github.com/user-attachments/assets/633ba059-e53f-4de4-8c61-2add1ac774e4" /> | <img width="500" src="https://github.com/user-attachments/assets/600252b4-cab5-449d-bd6f-d2ce98fc1656" /> |
| gcc | <img width="500" src="https://github.com/user-attachments/assets/7d5cf932-521e-4c2f-a4bd-21226eb74dfa" /> | <img width="500" src="https://github.com/user-attachments/assets/9340aa82-94b4-429c-9d63-ea53a8f4b5d4" /> | 

~~also to note: it seems `#include "LmmsCommonMacros.h"` is completely unused here? I haven't tested yet but unless anyone has objections, I'd remove that import in the same PR.~~ nvm, used in MSVC thingy, clangd led me astray here. no action needed