### PR TITLE
Increase Clip Resize Grip Width

### DIFF
--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -57,7 +57,7 @@ namespace lmms::gui
 
 /*! The width of the resize grip in pixels
  */
-const int RESIZE_GRIP_WIDTH = 4;
+const int RESIZE_GRIP_WIDTH = 8;
 
 
 /*! A pointer for that text bubble used when moving segments, etc.


### PR DESCRIPTION
Requested by a user on the forum https://lmms.io/forum/viewtopic.php?t=37686

> Jonathan790 wrote:
> Resize clip sensitivity;
> It's difficult to target as there are only 2-3 pixels that you need to position the mouse at. I suggest increasing it by x2 or x3 times, at least when there is only one clip and no adjacent one.

Sometimes, it can get tricky when two clips are right next to each other, and you're trying to resize one of them. Either you resize the right one, or the other one starts resizing behind the other, so you end up having to move one over, then resize it, then move it back. And it's just not awesome.

<img width="323" height="104" alt="image" src="https://github.com/user-attachments/assets/26ed4479-5c42-4a48-b7aa-279be4b80ec4" />

However, this can be midigated by simply increasing the clip resize grip width. Currently, it is at 4 px, but increasing it to 8 px makes it easier to specifically target which clip you want to resize. It also probably makes it easier to resize clips in general for users who may struggle to aim the mouse perfectly within that 4 pixel gap.
