### PR TITLE
Add help message & icon to empty automation editor

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2009,6 +2009,7 @@ AutomationEditorWindow::AutomationEditorWindow() :
 	setCentralWidget(m_editor);
 
 	// disable all controls when no clip is selected
+	setEnabled(m_editor->validClip());
 	connect(m_editor, &AutomationEditor::currentClipChanged, this, [this] { setEnabled(m_editor->validClip()); });
 
 	// Play/stop buttons


### PR DESCRIPTION
This PR brings the changes from #8148 into the automation editor

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b8d2d468-0954-4934-9196-c781367bc064" />
