### PR TITLE
Fix PianoRoll toolbar buttons not being disabled initially

### DIFF
--- a/include/Clip.h
+++ b/include/Clip.h
@@ -68,7 +68,7 @@ public:
 	inline void setName( const QString & name )
 	{
 		m_name = name;
-		emit dataChanged();
+		emit nameChanged();
 	}
 
 	QString displayName() const override
@@ -156,9 +156,11 @@ public slots:
 
 signals:
 	void lengthChanged();
+	void nameChanged();
 	void positionChanged();
 	void destroyedClip();
 	void colorChanged();
+
 
 protected:
 	Clip(const Clip& other);

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -161,7 +161,6 @@ signals:
 	void destroyedClip();
 	void colorChanged();
 
-
 protected:
 	Clip(const Clip& other);
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -252,6 +252,7 @@ protected slots:
 
 signals:
 	void currentMidiClipChanged();
+	void currentMidiClipRenamed();
 	void ghostClipSet(bool);
 	void semiToneMarkerMenuScaleSetEnabled(bool);
 	void semiToneMarkerMenuChordSetEnabled(bool);
@@ -584,9 +585,9 @@ private slots:
 	void ghostClipSet( bool state );
 	void exportMidiClip();
 	void importMidiClip();
+	void updateWindowTitle();
 
 private:
-	void clipRenamed();
 	void focusInEvent(QFocusEvent * event) override;
 	void showEvent(QShowEvent* se) override;
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -595,7 +595,6 @@ private:
 
 	PianoRoll* m_editor;
 
-	QToolButton* m_fileToolsButton;
 	ComboBox * m_zoomingComboBox;
 	ComboBox * m_zoomingYComboBox;
 	ComboBox * m_quantizeComboBox;

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -55,7 +55,6 @@ Clip::Clip( Track * track ) :
 	if( getTrack() )
 	{
 		getTrack()->addClip( this );
-		connect(track, &Track::nameChanged, this, &Clip::nameChanged);
 	}
 	setJournalling( false );
 	movePosition( 0 );

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -85,7 +85,6 @@ Clip::Clip(const Clip& other):
 	if (getTrack())
 	{
 		getTrack()->addClip(this);
-		connect(getTrack(), &Track::nameChanged, this, &Clip::nameChanged);
 	}
 }
 

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -55,6 +55,7 @@ Clip::Clip( Track * track ) :
 	if( getTrack() )
 	{
 		getTrack()->addClip( this );
+		connect(track, &Track::nameChanged, this, &Clip::nameChanged);
 	}
 	setJournalling( false );
 	movePosition( 0 );
@@ -84,6 +85,7 @@ Clip::Clip(const Clip& other):
 	if (getTrack())
 	{
 		getTrack()->addClip(this);
+		connect(getTrack(), &Track::nameChanged, this, &Clip::nameChanged);
 	}
 }
 

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -117,7 +117,7 @@ ClipView::ClipView( Clip * clip,
 
 	connect( m_clip, SIGNAL(lengthChanged()),
 			this, SLOT(updateLength()));
-	connect(m_clip, &Clip::nameChanged, this, qOverload<>(&QWidget::update));
+	connect(m_clip, &Clip::nameChanged, this, qOverload<>(&ClipView::update));
 	connect(getGUI()->songEditor()->m_editor, &SongEditor::pixelsPerBarChanged, this, &ClipView::updateLength);
 	connect( m_clip, SIGNAL(positionChanged()),
 			this, SLOT(updatePosition()));

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -117,6 +117,7 @@ ClipView::ClipView( Clip * clip,
 
 	connect( m_clip, SIGNAL(lengthChanged()),
 			this, SLOT(updateLength()));
+	connect(m_clip, &Clip::nameChanged, this, qOverload<>(&QWidget::update));
 	connect(getGUI()->songEditor()->m_editor, &SongEditor::pixelsPerBarChanged, this, &ClipView::updateLength);
 	connect( m_clip, SIGNAL(positionChanged()),
 			this, SLOT(updatePosition()));

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2251,7 +2251,7 @@ void AutomationEditorWindow::setCurrentClip(AutomationClip* clip)
 	if (clip)
 	{
 		connect(clip, SIGNAL(dataChanged()), this, SLOT(update()));
-		connect( clip, SIGNAL(dataChanged()), this, SLOT(updateWindowTitle()));
+		connect(clip, &Clip::nameChanged, this, &AutomationEditorWindow::updateWindowTitle);
 		connect(clip, SIGNAL(destroyed()), this, SLOT(clearCurrentClip()));
 
 		connect(m_flipXAction, SIGNAL(triggered()), clip, SLOT(flipX()));

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4966,18 +4966,18 @@ PianoRollWindow::PianoRollWindow() :
 	DropToolBar* fileActionsToolBar = addDropToolBarToTop(tr("File actions"));
 
 	// -- File ToolButton
-	m_fileToolsButton = new QToolButton(m_toolBar);
-	m_fileToolsButton->setIcon(embed::getIconPixmap("file"));
-	m_fileToolsButton->setPopupMode(QToolButton::InstantPopup);
+	auto fileToolsButton = new QToolButton(m_toolBar);
+	fileToolsButton->setIcon(embed::getIconPixmap("file"));
+	fileToolsButton->setPopupMode(QToolButton::InstantPopup);
 
 	// Import / export
-	auto importAction = new QAction(embed::getIconPixmap("project_import"), tr("Import clip"), m_fileToolsButton);
+	auto importAction = new QAction(embed::getIconPixmap("project_import"), tr("Import clip"), fileToolsButton);
 
-	auto exportAction = new QAction(embed::getIconPixmap("project_export"), tr("Export clip"), m_fileToolsButton);
+	auto exportAction = new QAction(embed::getIconPixmap("project_export"), tr("Export clip"), fileToolsButton);
 
-	m_fileToolsButton->addAction(importAction);
-	m_fileToolsButton->addAction(exportAction);
-	fileActionsToolBar->addWidget(m_fileToolsButton);
+	fileToolsButton->addAction(importAction);
+	fileToolsButton->addAction(exportAction);
+	fileActionsToolBar->addWidget(fileToolsButton);
 
 	connect(importAction, SIGNAL(triggered()), this, SLOT(importMidiClip()));
 	connect(exportAction, SIGNAL(triggered()), this, SLOT(exportMidiClip()));
@@ -5206,11 +5206,12 @@ PianoRollWindow::PianoRollWindow() :
 	setFocusPolicy( Qt::StrongFocus );
 	setFocus();
 	setWindowIcon( embed::getIconPixmap( "piano" ) );
-	setCurrentMidiClip( nullptr );
 
 	// Connections
 	connect( m_editor, SIGNAL(currentMidiClipChanged()), this, SIGNAL(currentMidiClipChanged()));
 	connect( m_editor, SIGNAL(currentMidiClipChanged()), this, SLOT(updateAfterMidiClipChange()));
+	// Initial setup of window title etc
+	setCurrentMidiClip(nullptr);
 }
 
 
@@ -5238,15 +5239,8 @@ void PianoRollWindow::setCurrentMidiClip( MidiClip* clip )
 
 	if ( clip )
 	{
-		setWindowTitle( tr( "Piano-Roll - %1" ).arg( clip->name() ) );
-		m_fileToolsButton->setEnabled(true);
 		connect( clip->instrumentTrack(), SIGNAL(nameChanged()), this, SLOT(updateAfterMidiClipChange()));
 		connect( clip, SIGNAL(dataChanged()), this, SLOT(updateAfterMidiClipChange()));
-	}
-	else
-	{
-		setWindowTitle( tr( "Piano-Roll - no clip" ) );
-		m_fileToolsButton->setEnabled(false);
 	}
 }
 
@@ -5475,12 +5469,10 @@ void PianoRollWindow::clipRenamed()
 	if ( currentMidiClip() )
 	{
 		setWindowTitle( tr( "Piano-Roll - %1" ).arg( currentMidiClip()->name() ) );
-		m_fileToolsButton->setEnabled(true);
 	}
 	else
 	{
 		setWindowTitle( tr( "Piano-Roll - no clip" ) );
-		m_fileToolsButton->setEnabled(false);
 	}
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -907,6 +907,7 @@ void PianoRoll::setCurrentMidiClip( MidiClip* newMidiClip )
 		this, SLOT(update()));
 	connect(m_midiClip, &MidiClip::lengthChanged, this, qOverload<>(&QWidget::update));
 	connect(m_midiClip, &MidiClip::nameChanged, this, &PianoRoll::currentMidiClipRenamed);
+	connect(m_midiClip->getTrack(), &Track::nameChanged, this, &PianoRoll::currentMidiClipRenamed);
 
 	update();
 	emit currentMidiClipChanged();
@@ -5464,7 +5465,10 @@ void PianoRollWindow::updateWindowTitle()
 {
 	if ( currentMidiClip() )
 	{
-		setWindowTitle( tr( "Piano-Roll - %1" ).arg( currentMidiClip()->name() ) );
+		const auto& name = currentMidiClip()->name().isEmpty()
+			? currentMidiClip()->getTrack()->name()
+			: currentMidiClip()->name();
+		setWindowTitle(tr("Piano-Roll - %1").arg(name));
 	}
 	else
 	{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -906,6 +906,7 @@ void PianoRoll::setCurrentMidiClip( MidiClip* newMidiClip )
 	connect(m_midiClip->instrumentTrack()->microtuner()->keyRangeImportModel(), SIGNAL(dataChanged()),
 		this, SLOT(update()));
 	connect(m_midiClip, &MidiClip::lengthChanged, this, qOverload<>(&QWidget::update));
+	connect(m_midiClip, &MidiClip::nameChanged, this, &PianoRoll::currentMidiClipRenamed);
 
 	update();
 	emit currentMidiClipChanged();
@@ -5210,7 +5211,8 @@ PianoRollWindow::PianoRollWindow() :
 	// Connections
 	connect( m_editor, SIGNAL(currentMidiClipChanged()), this, SIGNAL(currentMidiClipChanged()));
 	connect( m_editor, SIGNAL(currentMidiClipChanged()), this, SLOT(updateAfterMidiClipChange()));
-	// Initial setup of window title etc
+	connect(m_editor, &PianoRoll::currentMidiClipRenamed, this, &PianoRollWindow::updateWindowTitle);
+	// Trigger initial setup of window title etc
 	setCurrentMidiClip(nullptr);
 }
 
@@ -5236,12 +5238,6 @@ void PianoRollWindow::setGhostMidiClip( MidiClip* clip )
 void PianoRollWindow::setCurrentMidiClip( MidiClip* clip )
 {
 	m_editor->setCurrentMidiClip( clip );
-
-	if ( clip )
-	{
-		connect( clip->instrumentTrack(), SIGNAL(nameChanged()), this, SLOT(updateAfterMidiClipChange()));
-		connect( clip, SIGNAL(dataChanged()), this, SLOT(updateAfterMidiClipChange()));
-	}
 }
 
 
@@ -5460,11 +5456,11 @@ void PianoRollWindow::updateAfterMidiClipChange()
 	setEnabled(m_editor->hasValidMidiClip());
 	m_editor->m_timeLine->setVisible(m_editor->hasValidMidiClip());
 
-	clipRenamed();
+	updateWindowTitle();
 	updateStepRecordingIcon(); //MIDI clip change turn step recording OFF - update icon accordingly
 }
 
-void PianoRollWindow::clipRenamed()
+void PianoRollWindow::updateWindowTitle()
 {
 	if ( currentMidiClip() )
 	{


### PR DESCRIPTION
When piano roll is opened for the first time in a project that has clips, it shows the help icon, but the toolbar is not grayed-out. If a clip is opened and then deleted, the toolbar gets grayed-out. This fixes it so the toolbar is disabled by default (by running `setCurrentMidiClip(nullptr)` *after* the connections are made)

Also:
- Remove `m_fileToolsButton` as a class member, since all tool buttons get enabled/disabled
- Remove redundant window naming in `PianoRollWindow::setCurrentMidiClip`
