### PR TITLE
Fix Pattern Editor Not Updatring

### DIFF
--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -198,6 +198,7 @@ void PatternEditor::updatePosition()
 	{
 		trackView->update();
 	}
+	emit positionChanged(m_currentPosition);
 }
 
 void PatternEditor::updatePixelsPerBar()


### PR DESCRIPTION
The `TrackContentWidgets` in the pattern editor rely on the `positionChanged` signal to be sent when the pattern index changes so that they know when to update. This signal was removed in #7454, but this PR puts it back.

I don't like the system at all. It feels very sketchy the way the pattern editor is trying to piggyback off the signals intended for the song editor in order to get everything done. But it fixes the bug, so for now it's fine.

Steps to reproduce bug:
- Open a project with more than one pattern track
- Try to switch pattern tracks
- The pattern editor gui does not update

This should be fixed now.