### PR TITLE
Fix AudioFileProcessor Wrong Beat Length Depending on Sample Rate

### DIFF
--- a/plugins/AudioFileProcessor/AudioFileProcessor.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessor.cpp
@@ -295,8 +295,6 @@ auto AudioFileProcessor::beatLen(NotePlayHandle* note) const -> f_cnt_t
 		: m_nextPlayStartPoint;
 	const auto duration = m_sample.endFrame() - startFrame;
 
-	qDebug() << baseFreq << freqFactor << note->frequency() << Engine::audioEngine()->outputSampleRate() << Engine::audioEngine()->baseSampleRate();
-
 	return static_cast<f_cnt_t>(std::floor(duration * freqFactor * sampleRateRatio));
 }
 


### PR DESCRIPTION
Fixes #8138 

Essentially, when playing beat notes in the pattern editor, technically, they have an internal length of 0. However, when the `NotePlayHandle` is created and recieves that value of 0, it realizes it's supposed to be a beat note, so it asks the instrument track what the default length of note should be. For most instruments, that defaults to whatever the length of the envelope is (no matter whether the envelope is enabled or not. Is that a good system? I don't know.) However, AudioFileProcessor does it custom and returns the length of its sample in frames.

However, the frame count it returned did not take into account that the sample rate of lmms could be different from the sample rate of the sample.