### PR TITLE
Sync Playback Between Editors (And Upgrade Automation Editor Timeline)

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -158,6 +158,7 @@ protected slots:
 	void setTension();
 
 	void updatePosition();
+	void updatePositionAccompany();
 
 	void zoomingXChanged();
 	void zoomingYChanged();
@@ -233,6 +234,7 @@ private:
 	MidiClip* m_ghostNotes = nullptr;
 	QPointer<SampleClip> m_ghostSample = nullptr; // QPointer to set to nullptr on deletion
 	bool m_renderSample = false;
+	TimePos m_detuningNoteOffset = TimePos{0};
 
 	void centerTopBottomScroll();
 	void updateTopBottomLevels();
@@ -241,6 +243,8 @@ private:
 	QScrollBar * m_topBottomScroll;
 
 	void adjustLeftRightScoll(int value);
+
+	void autoScroll(const TimePos & t);
 
 	TimePos m_currentPosition;
 
@@ -269,7 +273,6 @@ private:
 	bool m_mouseDownRight; //true if right click is being held down
 
 	TimeLineWidget * m_timeLine;
-	bool m_scrollBack;
 
 	void drawCross(QPainter & p );
 	void drawAutomationPoint( QPainter & p, timeMap::iterator it );

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -304,7 +304,7 @@ private:
 	PianoRoll( const PianoRoll & );
 	~PianoRoll() override = default;
 
-	void autoScroll(const TimePos & t );
+	void autoScroll(const TimePos & t);
 
 	TimePos newNoteLen() const;
 
@@ -449,7 +449,6 @@ private:
 	bool m_mouseDownRight; //true if right click is being held down
 
 	TimeLineWidget * m_timeLine;
-	bool m_scrollBack;
 
 	void copyToClipboard(const NoteVector & notes ) const;
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -133,6 +133,8 @@ private:
 
 	void adjustLeftRightScoll(int value);
 
+	void autoScroll(const TimePos & t);
+
 	LcdSpinBox * m_tempoSpinBox;
 
 	TimeLineWidget* m_timeLine;
@@ -149,9 +151,6 @@ private:
 	IntModel* m_zoomingModel;
 	ComboBoxModel* m_snappingModel;
 	bool m_proportionalSnap;
-
-	bool m_scrollBack;
-	bool m_smoothScroll;
 
 	EditMode m_mode;
 	EditMode m_ctrlMode; // mode they were in before they hit ctrl

--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -145,7 +145,7 @@ public:
 
 	void setXOffset(const int x);
 
-	void addToolButtons(QToolBar* _tool_bar );
+	void addToolButtons(QToolBar* _tool_bar, bool addAutoScrolling = true, bool addLoopPoints = true, bool addStopBehavior = true);
 
 	inline int markerX( const TimePos & _t ) const
 	{

--- a/src/gui/editors/TimeLineWidget.cpp
+++ b/src/gui/editors/TimeLineWidget.cpp
@@ -78,51 +78,52 @@ void TimeLineWidget::setXOffset(const int x)
 	m_xOffset = x;
 }
 
-void TimeLineWidget::addToolButtons( QToolBar * _tool_bar )
+void TimeLineWidget::addToolButtons(QToolBar * _tool_bar, bool addAutoScrolling, bool addLoopPoints, bool addStopBehavior)
 {
-	auto autoScroll = new NStateButton(_tool_bar);
-	autoScroll->setGeneralToolTip(tr("Auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_stepped_on"), tr("Stepped auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_continuous_on"), tr("Continuous auto scrolling"));
-	autoScroll->addState(embed::getIconPixmap("autoscroll_off"), tr("Auto scrolling disabled"));
-	autoScroll->changeState(static_cast<int>(m_autoScroll));
-	connect( autoScroll, SIGNAL(changedState(int)), this,
-					SLOT(toggleAutoScroll(int)));
+	if (addAutoScrolling)
+	{
+		auto autoScroll = new NStateButton(_tool_bar);
+		autoScroll->setGeneralToolTip(tr("Auto scrolling"));
+		autoScroll->addState(embed::getIconPixmap("autoscroll_stepped_on"), tr("Stepped auto scrolling"));
+		autoScroll->addState(embed::getIconPixmap("autoscroll_continuous_on"), tr("Continuous auto scrolling"));
+		autoScroll->addState(embed::getIconPixmap("autoscroll_off"), tr("Auto scrolling disabled"));
+		autoScroll->changeState(static_cast<int>(m_autoScroll));
+		connect(autoScroll, &NStateButton::changedState, this, &TimeLineWidget::toggleAutoScroll);
+		_tool_bar->addWidget(autoScroll);
+	}
 
-	auto loopPoints = new NStateButton(_tool_bar);
-	loopPoints->setGeneralToolTip( tr( "Loop points" ) );
-	loopPoints->addState( embed::getIconPixmap( "loop_points_off" ) );
-	loopPoints->addState( embed::getIconPixmap( "loop_points_on" ) );
-	connect(loopPoints, &NStateButton::changedState, m_timeline, &Timeline::setLoopEnabled);
-	connect(m_timeline, &Timeline::loopEnabledChanged, loopPoints, &NStateButton::changeState);
-	connect(m_timeline, &Timeline::loopEnabledChanged, this, static_cast<void (QWidget::*)()>(&QWidget::update));
-	loopPoints->changeState(static_cast<int>(m_timeline->loopEnabled()));
+	if (addLoopPoints)
+	{
+		auto loopPoints = new NStateButton(_tool_bar);
+		loopPoints->setGeneralToolTip(tr("Loop points"));
+		loopPoints->addState(embed::getIconPixmap("loop_points_off"));
+		loopPoints->addState(embed::getIconPixmap("loop_points_on"));
+		connect(loopPoints, &NStateButton::changedState, m_timeline, &Timeline::setLoopEnabled);
+		connect(m_timeline, &Timeline::loopEnabledChanged, loopPoints, &NStateButton::changeState);
+		connect(m_timeline, &Timeline::loopEnabledChanged, this, static_cast<void (QWidget::*)()>(&QWidget::update));
+		loopPoints->changeState(static_cast<int>(m_timeline->loopEnabled()));
+		_tool_bar->addWidget(loopPoints);
+	}
 
-	auto behaviourAtStop = new NStateButton(_tool_bar);
-	behaviourAtStop->addState( embed::getIconPixmap( "back_to_zero" ),
-					tr( "After stopping go back to beginning" )
-									);
-	behaviourAtStop->addState( embed::getIconPixmap( "back_to_start" ),
-					tr( "After stopping go back to "
-						"position at which playing was "
-						"started" ) );
-	behaviourAtStop->addState( embed::getIconPixmap( "keep_stop_position" ),
-					tr( "After stopping keep position" ) );
-	connect(behaviourAtStop, &NStateButton::changedState, m_timeline,
-		[timeline = m_timeline](int value) {
-			timeline->setStopBehaviour(static_cast<Timeline::StopBehaviour>(value));
-		}
-	);
-	connect(m_timeline, &Timeline::stopBehaviourChanged, behaviourAtStop,
-		[button = behaviourAtStop](Timeline::StopBehaviour value) {
-			button->changeState(static_cast<int>(value));
-		}
-	);
-	behaviourAtStop->changeState(static_cast<int>(m_timeline->stopBehaviour()));
-
-	_tool_bar->addWidget( autoScroll );
-	_tool_bar->addWidget( loopPoints );
-	_tool_bar->addWidget( behaviourAtStop );
+	if (addStopBehavior)
+	{
+		auto behaviourAtStop = new NStateButton(_tool_bar);
+		behaviourAtStop->addState(embed::getIconPixmap("back_to_zero"), tr("After stopping go back to beginning"));
+		behaviourAtStop->addState(embed::getIconPixmap( "back_to_start" ), tr("After stopping go back to position at which playing was started"));
+		behaviourAtStop->addState(embed::getIconPixmap("keep_stop_position"), tr("After stopping keep position"));
+		connect(behaviourAtStop, &NStateButton::changedState, m_timeline,
+			[timeline = m_timeline](int value) {
+				timeline->setStopBehaviour(static_cast<Timeline::StopBehaviour>(value));
+			}
+		);
+		connect(m_timeline, &Timeline::stopBehaviourChanged, behaviourAtStop,
+			[button = behaviourAtStop](Timeline::StopBehaviour value) {
+				button->changeState(static_cast<int>(value));
+			}
+		);
+		behaviourAtStop->changeState(static_cast<int>(m_timeline->stopBehaviour()));
+		_tool_bar->addWidget(behaviourAtStop);
+	}
 }
 
 void TimeLineWidget::toggleAutoScroll( int _n )


### PR DESCRIPTION
This PR makes it so that when playing the Song Editor, the playheads in the Piano Roll and Automation Editor sync up when the song playhead passes over their clips. This is just like what happens when doing record-play in the piano roll, except now it happens by default.

Additionally, when pressing play in the Automation Editor, it starts playing the song relative to the position of the clip, not the start of the song.

While I was at it, I also decided to upgrade the automation editor timeline to support proper auto scrolling. It already did previously, but it was a bit broken and couldn't be turned on or off.

This feature also works when detuning a note in the piano roll via the automation editor, and also when editing midi clips or automation clips within a pattern track.

https://github.com/user-attachments/assets/f6cf5f77-c3da-4752-9271-628b7aaf9af0


There's a lot of repeated code across the editors, but it's a bit tricky to combine them, since our editors don't share a common inherited class (`Editor` exists, but that's for the editor windows, not the editors themselves). That may have to wait for a future PR to refactor things, as I don't want to make this PR too big. For now, there is come duplicated code, but it works. 