### PR TITLE
CMake: Check for PERL's List::MoreUtils

### DIFF
--- a/plugins/LadspaEffect/swh/CMakeLists.txt
+++ b/plugins/LadspaEffect/swh/CMakeLists.txt
@@ -1,5 +1,16 @@
 set_directory_properties(PROPERTIES SYSTEM TRUE)
 
+execute_process(
+    COMMAND ${PERL_EXECUTABLE} -MList::MoreUtils -e "1"
+    RESULT_VARIABLE MOREUTILS_RESULT
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+
+if (NOT MOREUTILS_RESULT EQUAL 0)
+    message(FATAL_ERROR "Perl module \"List::MoreUtils\" is required for building LadspaEffect/swh.\n")
+endif()
+
 # Create blank config.h
 FILE(WRITE ladspa/config.h "")
 


### PR DESCRIPTION
This fixes a very annoying compile warning which always comes on a fresh Linux where `List::MoreUtils` is yet missing. This warning should already come at CMake time, so this is what this PR does.