### PR TITLE
Fix Sample Clips Getting Out of Sync

### DIFF
--- a/include/Timeline.h
+++ b/include/Timeline.h
@@ -68,8 +68,8 @@ public:
 		emit positionChanged();
 	}
 
-	auto frameOffset() const -> f_cnt_t { return m_frameOffset; }
-	void setFrameOffset(const f_cnt_t frame) { m_frameOffset = frame; }
+	auto frameOffset() const -> float { return m_frameOffset; }
+	void setFrameOffset(const float frame) { m_frameOffset = frame; }
 
 	auto loopBegin() const -> TimePos { return m_loopBegin; }
 	auto loopEnd() const -> TimePos { return m_loopEnd; }
@@ -106,7 +106,7 @@ private:
 	bool m_loopEnabled = false;
 	TimePos m_pos = TimePos{0};
 
-	f_cnt_t m_frameOffset = 0;
+	float m_frameOffset = 0;
 
 	double m_elapsedSeconds = 0;
 


### PR DESCRIPTION
Fixes #8182

When #7454 was merged, the `frameOffset` variable inside `Song::PlayPos` which kept track of the actual frame position which the song was playing at relative to the last tick, was moved to `Timeline`. In the process, the type was inadvertently changed from `float` to `f_cnt_t`.

This caused the frame offset to be truncated ever time it was updated in `Song::processNextBuffer`, causing the song playback to slowly drift back ever so slightly, just a handful of frames every bar. This caused any new sample clips spawned to be created slightly late, becoming out of sync with any existing playing samples.

This PR fixes the issue by reverting the `frameOffset` variable type to be `float` again, allowing it to track sub-sample offsets over time.