### PR TITLE
 Add Horizontal Scroll Bar to the File Browser

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -147,7 +147,8 @@ protected:
 	void keyReleaseEvent( QKeyEvent * ke ) override;
 	void hideEvent( QHideEvent * he ) override;
 	void focusOutEvent( QFocusEvent * fe ) override;
-	void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible);
+	void scrollTo(const QModelIndex &index, ScrollHint hint = EnsureVisible) override;
+	void wheelEvent(QWheelEvent * event) override;
 
 
 private:

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -516,6 +516,21 @@ void FileBrowserTreeWidget::scrollTo(const QModelIndex &index, ScrollHint hint)
 	horizontalScrollBar()->setValue(barPos);
 }
 
+void FileBrowserTreeWidget::wheelEvent(QWheelEvent * event)
+{
+	// When shift is pressed, scroll horizontally instead of vertically
+	if (event->modifiers() & Qt::ShiftModifier)
+	{
+		horizontalScrollBar()->setValue(
+			horizontalScrollBar()->value() - event->angleDelta().y());
+		event->accept();
+	}
+	else
+	{
+		QTreeWidget::wheelEvent(event);
+	}
+}
+
 void FileBrowserTreeWidget::keyPressEvent(QKeyEvent * ke )
 {
 	// Shorter names for some commonly used properties of the event


### PR DESCRIPTION
fixes #7879
It reuse the content of #7913 and iterate over it by preventing the scroll bar to return at the beginning when navigating with arrow keys.