### PR TITLE
Piano Roll Detuning - QoL Port

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -487,7 +487,7 @@ private:
 	//! Updates the currently dragged node position in the detuning/parameter curves of the selected notes.
 	void updateParameterEditPos(QMouseEvent* me, Note::ParameterType paramType);
 	//! Finishes the dragging of the current node of the detuning/parameter curves
-	void applyParameterEditPos(Note::ParameterType paramType);
+	void applyParameterEditPos(QMouseEvent* me, Note::ParameterType paramType);
 
 	//! Stores the chords for the strum tool
 	std::vector<NoteVector> m_selectedChords;


### PR DESCRIPTION
This is a WIP port of https://github.com/regulus79/lmms/pull/3 to the merged master https://github.com/LMMS/lmms/pull/7759 for some QoL changes to the Piano Roll Detuning:
 
-Better visual feedback to detuning curves
--Hooks to signify the end of a detuning curve
--outValue changes having small dots in detuning mode
--CubicHermite curves actually displaying properly

-Better handling of the first node
--Right click to reset to default tuning
NOTE: This is currently wonky in how it selects the node, and basically requires you to zoom in.
--Allow dragging over again

-Allow Alt+Drag to allow outValue editing

-Auditory feedback when detuning notes

https://github.com/LMMS/lmms/pull/8104 will break the outValue editing functionality.

I will update this while I work through the code changes.