### PR TITLE
Fix Hardcoded Max dB Value When Double-Clicking Knobs

### DIFF
--- a/src/gui/widgets/FloatModelEditorBase.cpp
+++ b/src/gui/widgets/FloatModelEditorBase.cpp
@@ -387,9 +387,8 @@ void FloatModelEditorBase::enterValue()
 
 		new_val = QInputDialog::getDouble(
 			this, tr("Set value"),
-			tr("Please enter a new value between "
-					"-96.0 dBFS and 6.0 dBFS:"),
-				initialDbValue, -96.0, 6.0, model()->getDigitCount(), &ok);
+			tr("Please enter a new value between -96.0 dBFS and %1 dBFS:").arg(ampToDbfs(model()->maxValue() / 100.0f)),
+				initialDbValue, -96.0, ampToDbfs(model()->maxValue() / 100.0f), model()->getDigitCount(), &ok);
 
 		if (new_val <= -96.0)
 		{


### PR DESCRIPTION
Partially addresses #8188

For some reason, when a knob is set to be a "volume knob", the max volume allowed via double-clicking and typing in a value is 6.0 dB. For knobs such as the amplifier knob in Audio File Processor which go up to 500% (~14 db), this is not enough.

This PR makes it so that the dialog shows the actual max dB value based on the underlying model's max value, instead of being hardcoded to 6.0 dB. This PR does not address the minimum value.