### PR TITLE
Fix Sample Clip Loop Exporting

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -124,7 +124,7 @@ Song::Song() :
 		connect(&timeline, &Timeline::positionJumped, this, [this](){
 			// Only emit the signal when the song is actually playing
 			// This prevents LFOs from changing phase when the user drags the timeline while paused
-			if (isPlaying()) { emit playbackPositionJumped(); }
+			if (m_playing) { emit playbackPositionJumped(); }
 		}, Qt::DirectConnection);
 	}
 


### PR DESCRIPTION
Fixes #8190

When #7454 was merged, I added a check before emitting `playbackPositionJumped` to only emit when the song was playing, to prevent LFOs from being reset when the user dragged the timeline while the song was paused. However, I used `Song::isPlaying()`, which only returns true when the song is not exporting. This caused sample clips to not be updated when the playback position jumped back every loop, which means they just kept playing, ignoring the loop. To fix this, I have changed it to use `m_playing`, which is true for both exporting and normal playing.