### PR TITLE
Improve strum tool LMB event

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1666,8 +1666,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 	if (m_editMode == EditMode::Strum && me->button() == Qt::LeftButton)
 	{
 		// Only strum if the user is dragging a selected note
-		const auto& selectedNotes = getSelectedNotes();
-		if (std::find(selectedNotes.begin(), selectedNotes.end(), noteUnderMouse()) != selectedNotes.end())
+		if (Note* note = noteUnderMouse(); note && note->selected())
 		{
 			updateStrumPos(me, true, me->modifiers() & Qt::ShiftModifier);
 			m_strumEnabled = true;


### PR DESCRIPTION
This is just a quick little improvement for some strum tool code, which I mentioned [here](https://github.com/LMMS/lmms/pull/7725#discussion_r2605648388) a month ago and then forgot about.

I was originally thinking there might be a dangling reference, but surprisingly, local const references extend the lifetimes of temporaries bound to them, so it was actually fine due to a weird language loophole. However, this PR still removes the unnecessary loop and `std::vector` allocation which should help with performance a bit.