### PR TITLE
Track Instrument Changes in Journal

### DIFF
--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -586,6 +586,7 @@ void InstrumentTrackWindow::dropEvent( QDropEvent* event )
 {
 	QString type = StringPairDrag::decodeKey( event );
 	QString value = StringPairDrag::decodeValue( event );
+	m_track->addJournalCheckPoint();
 
 	if( type == "instrument" )
 	{


### PR DESCRIPTION
This fixes #1262 by making a journal checkpoint when a track's instrument changes. It sometimes requires multiple undos to undo an instrument change because some instruments create journal checkpoints upon being loaded, but that's a preexisting issue that's unrelated to this fix.