### PR TITLE
Avoid adding journal checkpoints when initially creating volume knobs

### DIFF
--- a/include/FloatModelEditorBase.h
+++ b/include/FloatModelEditorBase.h
@@ -62,12 +62,12 @@ public:
 		setUnit(txt_after);
 	}
 
-	inline bool isVolumeKnob() const
+	bool isVolumeKnob() const
 	{
 		return m_volumeKnob;
 	}	
 
-	inline void setVolumeKnob( const bool val )
+	void setVolumeKnob(const bool val)
 	{
 		m_volumeKnob = val;
 	}


### PR DESCRIPTION
fixes #8211

The cause of this "bug" is that the method setValue of the class AutomatableModel is creating a journal checkpoint.

```
void AutomatableModel::setValue(const float value, const bool isAutomated)
{
	if (fittedValue(value) == m_value)
	{
		// TODO check why we need this signal, is there a better solution?
		if (!isAutomated) { emit dataUnchanged(); }
		return;
	}

	if (!isAutomated) { addJournalCheckPoint(); }

	// set value for this and the other linked models
	setValueInternal(value);
	for (auto model = m_nextLink; model != this; model = model->m_nextLink)
	{
		model->setValueInternal(value);
	}
}
```

When a new instrument / sample track is created, the setter "SetVolumeKnob( true )" of the member m_volumeKnob FloatModelEditorBase is called. Currently, this create a journal checkpoint that, when undone, is falsely setting back m_volumeKnob to false (hence why % is showing instead of dBFS on the label).

My proposal to avoid this behavior is to rewrite SetVolumeKnob so it set the parameter "isAutomated" of setValue to true, as automated Models are not creating journal checkpoint.
It's a rudimentary workaround, but it avoids rewriting a larger portion of the code.