### PR TITLE
Fix `AutomatableSlider` Creating Too Many Journal Entries

### DIFF
--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -95,7 +95,7 @@ void AutomatableSlider::mouseReleaseEvent( QMouseEvent * _me )
 	{
 		thisModel->restoreJournallingState();
 	}
-    
+
 	m_showStatus = false;
 	QSlider::mouseReleaseEvent( _me );
 }


### PR DESCRIPTION
This fixes #8222 by only creating one journal entry when a slider is first pressed, similar to how the `Fader` and `Knob` classes currently work.