### PR TITLE
Fix clips not retaining colors or names after using "Clear notes out of bounds"

### DIFF
--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -374,9 +374,8 @@ void MidiClipView::clearNotesOutOfBounds()
 	m_clip->getTrack()->addJournalCheckPoint();
 	m_clip->getTrack()->saveJournallingState(false);
 
-	auto newClip = new MidiClip(static_cast<InstrumentTrack*>(m_clip->getTrack()));
-	newClip->setAutoResize(m_clip->getAutoResize());
-	newClip->movePosition(m_clip->startPosition());
+	auto newClip = m_clip->clone();
+	newClip->clearNotes();
 
 	TimePos startBound = -m_clip->startTimeOffset();
 	TimePos endBound = m_clip->length() - m_clip->startTimeOffset();
@@ -394,9 +393,9 @@ void MidiClipView::clearNotesOutOfBounds()
 			newClip->addNote(newNote, false);
 		}
 	}
+	newClip->setStartTimeOffset(0);
 	newClip->changeLength(m_clip->length());
 	newClip->updateLength();
-	newClip->setColor(m_clip->color());
 
 	remove();
 	m_clip->getTrack()->restoreJournallingState();


### PR DESCRIPTION
Fixing something that went under the radar with #7477.

Steps to reproduce:

1. Make a clip and add some notes
2. Apply a color to it
3. Slice or shorten it
4. Use "Clear notes out of bounds" on the clip
5. The clip doesn't retain the color

Also works in bulk.