### PR TITLE
Set file format combo box unconditionally

### DIFF
--- a/src/gui/modals/ExportProjectDialog.cpp
+++ b/src/gui/modals/ExportProjectDialog.cpp
@@ -186,14 +186,10 @@ ExportProjectDialog::ExportProjectDialog(const QString& path, Mode mode, QWidget
 	connect(m_fileFormatComboBox, qOverload<int>(&QComboBox::currentIndexChanged), this,
 		&ExportProjectDialog::onFileFormatChanged);
 
-	if (mode == Mode::ExportProject)
-	{
-		const auto pathExtension = QFileInfo{path}.completeSuffix().prepend(".");
-		const auto pathFormat = ProjectRenderer::getFileFormatFromExtension(pathExtension);
-		m_fileFormatComboBox->setCurrentIndex(
-			std::max(0, m_fileFormatComboBox->findData(static_cast<int>(pathFormat))));
-	}
+	const auto pathExtension = QFileInfo{path}.completeSuffix().prepend(".");
+	const auto pathFormat = ProjectRenderer::getFileFormatFromExtension(pathExtension);
 
+	m_fileFormatComboBox->setCurrentIndex(std::max(0, m_fileFormatComboBox->findData(static_cast<int>(pathFormat))));
 	m_bitRateComboBox->setCurrentIndex(std::max(0, m_bitRateComboBox->findData(defaultBitRate)));
 	m_bitDepthComboBox->setCurrentIndex(std::max(0, m_bitDepthComboBox->findData(static_cast<int>(defaultBitDepth))));
 	m_stereoModeComboBox->setCurrentIndex(


### PR DESCRIPTION
Fixes a regression from #8215 where trying to export tracks shows the dialog without a file format initially selected.