### PR TITLE
Enable ASIO support in MSVC builds

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -59,7 +59,10 @@
 		},
 		{
 			"name": "portaudio",
-			"default-features": false
+			"default-features": false,
+			"features": [
+				"asio"
+			]
 		},
 		{
 			"name": "sdl2",


### PR DESCRIPTION
Last week I added support for building PortAudio with [ASIO](https://en.wikipedia.org/wiki/Audio_Stream_Input/Output) to [vcpkg](https://github.com/microsoft/vcpkg/pull/49512), and now I'm enabling it here.

Only our Windows MSVC builds use vcpkg at the moment, so it will only be enabled there. However, with #8218 the MinGW builds will also support it. Unfortunately the Windows ARM64 builds use the MSYS2 PortAudio package which does not have ASIO support yet.

Progress towards #1173

TODO:
- [ ] MinGW support
- [ ] Audio issues?
- [ ] Licensing concerns? (GPLv3 library in a GPLv2+ application)