### PR TITLE
Fix default filetype for "export tracks" mode

### DIFF
--- a/src/gui/modals/ExportProjectDialog.cpp
+++ b/src/gui/modals/ExportProjectDialog.cpp
@@ -193,6 +193,10 @@ ExportProjectDialog::ExportProjectDialog(const QString& path, Mode mode, QWidget
 		m_fileFormatComboBox->setCurrentIndex(
 			std::max(0, m_fileFormatComboBox->findData(static_cast<int>(pathFormat))));
 	}
+	else if (mode == Mode::ExportTracks)
+	{
+		m_fileFormatComboBox->setCurrentIndex(0);
+	}
 
 	m_bitRateComboBox->setCurrentIndex(std::max(0, m_bitRateComboBox->findData(defaultBitRate)));
 	m_bitDepthComboBox->setCurrentIndex(std::max(0, m_bitDepthComboBox->findData(static_cast<int>(defaultBitDepth))));


### PR DESCRIPTION
A quick fix. Without this, doing multiple-track export opens up a window with no selected filetype (even though it defaults to WAV anyway).
<img width="460" height="380" alt="image" src="https://github.com/user-attachments/assets/06d32b5d-9f87-4468-a3e7-ad598565c3fd" />
