### PR TITLE
Emit the `playbackPositionJumped` signal only when the active timeline jumps

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -120,7 +120,7 @@ Song::Song() :
 
 	// Aggregate the `positionJumped` signals from all the timelines into a single `playbackPositionJumped` signal for
 	// other objects (sample tracks, LFOs, etc) to use.
-	for (auto i = 0; i < static_cast<std::size_t>(PlayMode::Count); ++i)
+	for (auto i = std::size_t{0}; i < static_cast<std::size_t>(PlayMode::Count); ++i)
 	{
 		const auto onPositionJumped = [this, playMode = static_cast<PlayMode>(i)] {
 			// Only emit the signal when the song is actually playing and the active timeline jumps


### PR DESCRIPTION
#7454 introduced a change where it aggregated all the timelines and emitted the `playbackPositionChanged` signal whenever any of the timelines move and the song is playing. This PR brings fourth a stronger guarantee: only emit the `playbackPositionChanged` signal when the song is playing *and* the timeline that jumped is responsible for the current play mode.

Fixes #8251 