### PR TITLE
Fixed key inputs not updating time display

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1476,6 +1476,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 
 		case Qt::Key_Home:
 			m_timeLine->timeline()->setTicks(0);
+			Engine::getSong()->setPlayPos(0, Song::PlayMode::None);
 			ke->accept();
 			break;
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -478,6 +478,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 		if( t >= 0 )
 		{
 			m_song->setPlayPos( t, Song::PlayMode::Song );
+			if (!m_song->isPlaying()) { m_song->setPlayPos(t, Song::PlayMode::None); }
 		}
 	}
 	else if( ke->key() == Qt::Key_Right )
@@ -486,11 +487,13 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 		if( t < MaxSongLength )
 		{
 			m_song->setPlayPos( t, Song::PlayMode::Song );
+			if (!m_song->isPlaying()) { m_song->setPlayPos(t, Song::PlayMode::None); }
 		}
 	}
 	else if( ke->key() == Qt::Key_Home )
 	{
 		m_song->setPlayPos( 0, Song::PlayMode::Song );
+		if (!m_song->isPlaying()) { m_song->setPlayPos(0, Song::PlayMode::None); }
 	}
 	else if( ke->key() == Qt::Key_Delete || ke->key() == Qt::Key_Backspace )
 	{


### PR DESCRIPTION
Fixed #7956 where home, right arrow, and left arrow keys did not properly update the time display.