### PR TITLE
Fix empty value returned by FileRevealer::getSelectCommand()

### DIFF
--- a/src/gui/FileRevealer.cpp
+++ b/src/gui/FileRevealer.cpp
@@ -147,7 +147,7 @@ const QStringList& FileRevealer::getSelectCommand()
 	}
 
 	// Fallback to empty list
-	selectCommandCache = {};
+	selectCommandCache = QStringList{};
 	return selectCommandCache.value();
 }
 


### PR DESCRIPTION
Apparently the value being constructed here was an empty `std::optional`, not an emptry `QStringList`, so it was crashing when it came across an unknown file manager.