### PR TITLE
Prevent key modifiers in `MainWindow` from getting stuck

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -132,12 +132,7 @@ public:
 
 	void clearKeyModifiers();
 
-	// TODO Remove this function, since m_shift can get stuck down.
-	// [[deprecated]]
-	bool isShiftPressed()
-	{
-		return m_keyMods.m_shift;
-	}
+	bool isShiftPressed() { return m_keyMods.m_shift; }
 
 	static void saveWidgetState( QWidget * _w, QDomElement & _de );
 	static void restoreWidgetState( QWidget * _w, const QDomElement & _de );
@@ -180,7 +175,6 @@ private slots:
 
 protected:
 	void closeEvent( QCloseEvent * _ce ) override;
-	void focusOutEvent( QFocusEvent * _fe ) override;
 	void keyPressEvent( QKeyEvent * _ke ) override;
 	void keyReleaseEvent( QKeyEvent * _ke ) override;
 	void timerEvent( QTimerEvent * _ev ) override;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -132,7 +132,7 @@ public:
 
 	void clearKeyModifiers();
 
-	bool isShiftPressed() { return m_keyMods.m_shift; }
+	bool isShiftPressed() const { return m_keyMods.m_shift; }
 
 	static void saveWidgetState( QWidget * _w, QDomElement & _de );
 	static void restoreWidgetState( QWidget * _w, const QDomElement & _de );

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -234,6 +234,8 @@ MainWindow::MainWindow() :
 	{
 		qApp->installEventFilter(this);
 	}
+
+	installEventFilter(this);
 }
 
 
@@ -1256,23 +1258,41 @@ void MainWindow::sessionCleanup()
 
 bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 {
-	// For now this function is only used to globally block tooltips
-	// It must be installed to QApplication through installEventFilter
+	const auto isWinDeactivate = [](QEvent* event) -> bool
+	{
+		if (event->type() == QEvent::WindowDeactivate) { return true; }
+
+		if (event->type() == QEvent::FocusOut)
+		{
+			auto* fe = dynamic_cast<QFocusEvent*>(event);
+			switch (fe->reason())
+			{
+			case Qt::ActiveWindowFocusReason:
+			case Qt::PopupFocusReason:
+			case Qt::OtherFocusReason:
+				return true;
+				break;
+			default:
+				break;
+			}
+		}
+
+		return false;
+	};
+
+	// Clear modifiers when the window has been unfocused
+	// (Install event filter on the window itself)
+	if (dynamic_cast<MainWindow*>(watched) != nullptr && isWinDeactivate(event))
+	{
+		clearKeyModifiers();
+		return QObject::eventFilter(watched, event);
+	}
+
+	// Block tooltips globally
+	// (Install event filter on QApplication instance)
 	if (event->type() == QEvent::ToolTip) { return true; }
 
 	return QObject::eventFilter(watched, event);
-}
-
-
-
-
-void MainWindow::focusOutEvent( QFocusEvent * _fe )
-{
-	// TODO Remove this function, since it is apparently never actually called!
-	// when loosing focus we do not receive key-(release!)-events anymore,
-	// so we might miss release-events of one the modifiers we're watching!
-	clearKeyModifiers();
-	QMainWindow::leaveEvent( _fe );
 }
 
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1271,7 +1271,6 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 			case Qt::PopupFocusReason:
 			case Qt::OtherFocusReason:
 				return true;
-				break;
 			default:
 				break;
 			}
@@ -1280,16 +1279,14 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 		return false;
 	};
 
-	// Clear modifiers when the window has been unfocused
-	// (Install event filter on the window itself)
+	// Clear modifiers when the window has been unfocused (install event filter on the window itself)
 	if (dynamic_cast<MainWindow*>(watched) != nullptr && isWinDeactivate(event))
 	{
 		clearKeyModifiers();
 		return QObject::eventFilter(watched, event);
 	}
 
-	// Block tooltips globally
-	// (Install event filter on QApplication instance)
+	// Block tooltips globally (install event filter on QApplication instance)
 	if (event->type() == QEvent::ToolTip) { return true; }
 
 	return QObject::eventFilter(watched, event);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1267,8 +1267,8 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 			auto* fe = dynamic_cast<QFocusEvent*>(event);
 			switch (fe->reason())
 			{
-			case Qt::ActiveWindowFocusReason:
-			case Qt::PopupFocusReason:
+			case Qt::ActiveWindowFocusReason: [[fallthrough]];
+			case Qt::PopupFocusReason: [[fallthrough]];
 			case Qt::OtherFocusReason:
 				return true;
 			default:

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1264,7 +1264,7 @@ bool MainWindow::eventFilter(QObject* watched, QEvent* event)
 
 		if (event->type() == QEvent::FocusOut)
 		{
-			auto* fe = dynamic_cast<QFocusEvent*>(event);
+			auto* fe = static_cast<QFocusEvent*>(event);
 			switch (fe->reason())
 			{
 			case Qt::ActiveWindowFocusReason: [[fallthrough]];


### PR DESCRIPTION
This PR adds some extra code to `MainWindow::eventFilter`, and adds such event filter to itself, in order to detect events which may suppress key-release events of modifiers, which in my experience have been the ones such of type `QEvent::WindowDeactivate`. It also removes the `MainWindow::focusOutEvent` overload, which indeed didn't seem to be called. In case that event ever gets received, though, the event filter should be handling it properly.

Previously, the bug could be replicated by holding shift in LMMS, then changing to another window, then releasing shift. After going back to LMMS (without pressing shift again) and using a knob, it would change values slowly (as if shift was still being pressed).

I've also removed the `[[deprecated]]` notice from `MainWindow::isShiftPressed`, though I'm not sure if this was the sole reason for its deprecation.