### PR TITLE
Enabled the piano roll and automation editor buttons only when not empty

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -328,6 +328,8 @@ public:
 
 	QSize sizeHint() const override;
 
+	bool hasValidClip();
+
 public slots:
 	void clearCurrentClip();
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -588,6 +588,7 @@ public:
 
 	QSize sizeHint() const override;
 	bool hasFocus() const;
+	bool hasValidMidiClip();
 
 signals:
 	void currentMidiClipChanged();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -34,6 +34,7 @@
 #include <QMessageBox>
 #include <QShortcut>
 #include <QSplitter>
+#include <qtoolbutton.h>
 
 #include "AboutDialog.h"
 #include "AutomationEditor.h"
@@ -438,10 +439,15 @@ void MainWindow::finalize()
 	auto piano_roll_window = new ToolButton(
 		embed::getIconPixmap("piano"), tr("Piano Roll") + " (Ctrl+3)", this, SLOT(togglePianoRollWin()), m_toolBar);
 	piano_roll_window->setShortcut(keySequence(Qt::CTRL, Qt::Key_3));
+	piano_roll_window->setEnabled(false);
+	connect(getGUI()->pianoRoll(), &PianoRollWindow::currentMidiClipChanged, this, [piano_roll_window](){ piano_roll_window->setEnabled(getGUI()->pianoRoll()->hasValidMidiClip()); });
 
 	auto automation_editor_window = new ToolButton(embed::getIconPixmap("automation"),
 		tr("Automation Editor") + " (Ctrl+4)", this, SLOT(toggleAutomationEditorWin()), m_toolBar);
 	automation_editor_window->setShortcut(keySequence(Qt::CTRL, Qt::Key_4));
+	automation_editor_window->setEnabled(false);
+	connect(getGUI()->automationEditor(), &AutomationEditorWindow::currentClipChanged, this, [automation_editor_window](){ automation_editor_window->setEnabled(getGUI()->automationEditor()->hasValidClip()); });
+	connect(getGUI()->automationEditor()->m_editor, &AutomationEditor::currentClipChanged, this, [automation_editor_window](){ automation_editor_window->setEnabled(getGUI()->automationEditor()->m_editor->validClip()); });
 
 	auto mixer_window = new ToolButton(
 		embed::getIconPixmap("mixer"), tr("Mixer") + " (Ctrl+5)", this, SLOT(toggleMixerWin()), m_toolBar);
@@ -1042,8 +1048,6 @@ void MainWindow::toggleMicrotunerWin()
 {
 	toggleWindow( getGUI()->getMicrotunerConfig() );
 }
-
-
 
 
 void MainWindow::updateViewMenu()

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -2167,6 +2167,7 @@ void AutomationEditorWindow::setCurrentClip(AutomationClip* clip)
 
 	m_editor->setCurrentClip(clip);
 
+
 	// Set our window's title
 	if (clip == nullptr)
 	{
@@ -2306,6 +2307,11 @@ void AutomationEditorWindow::updateEditTanButton()
 	auto progType = currentClip()->progressionType();
 	m_editTanAction->setEnabled(AutomationClip::supportsTangentEditing(progType));
 	if (!m_editTanAction->isEnabled() && m_editTanAction->isChecked()) { m_drawAction->trigger(); }
+}
+
+bool AutomationEditorWindow::hasValidClip()
+{
+	return m_editor->validClip();
 }
 
 } // namespace lmms::gui

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -5856,6 +5856,10 @@ void PianoRollWindow::updateStepRecordingIcon()
 	}
 }
 
+bool PianoRollWindow::hasValidMidiClip()
+{
+	return m_editor->hasValidMidiClip();
+}
 
 } // namespace gui
 


### PR DESCRIPTION
Resolves #1132 by enabling the piano roll and automation editor only if they have associated data.

# Changes
- Enable/disable the piano roll and automation editor depending on whether they have associated data

# Notes
- I'm new and don't have much experience with QT/C++, so I kept the dev simple.
    - By the way, I find the documentation good for a newcomer. I was able to quickly start compiling/testing (on Linux Mint).
- I didn't use a formatter because it made too many changes compared to what I actually changed. Please let me know if I made any formatting mistakes.
- I thought about only displaying these buttons if they have data, but that tended to result in a weird display and broke the keyboard shortcuts.
- `currentClipChanged` from AutomationEditorWindow was not enough to handle all cases. So I also had to integrate `currentClipChanged` from AutomationEditor.

# Questions
- I'm not sure if accessing automationEditor directly via `getGUI()->automationEditor()->m_editor` is a good idea. Is there a better way to do this?
- Should I add tests to my dev or is that overkill?