### PR TITLE
Fix piano roll opening with minimum height

### DIFF
--- a/include/Editor.h
+++ b/include/Editor.h
@@ -57,6 +57,7 @@ protected:
 	DropToolBar * addDropToolBar(Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 	DropToolBar * addDropToolBar(QWidget * parent, Qt::ToolBarArea whereToAdd, QString const & windowTitle);
 
+	void closeEvent(QCloseEvent* event) override;
 	void keyPressEvent(QKeyEvent* ke) override;
 
 public slots:

--- a/src/gui/editors/Editor.cpp
+++ b/src/gui/editors/Editor.cpp
@@ -139,6 +139,11 @@ QAction *Editor::playAction() const
 	return m_playAction;
 }
 
+void Editor::closeEvent(QCloseEvent* event)
+{
+	event->ignore();
+}
+
 void Editor::keyPressEvent(QKeyEvent* ke)
 {
 	if (ke->key() == Qt::Key_Space)


### PR DESCRIPTION
Fixes #8292 by handling and ignoring `Editor::closeEvent`. I'm not sure if this is the best way to fix this bug, but it does fix the issue.