### PR TITLE
Fix Settings bug that occurs when not using JACK

### DIFF
--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -495,14 +495,14 @@ void AudioJack::shutdownCallback(void* udata)
 AudioJack::setupWidget::setupWidget(QWidget* parent)
 	: AudioDeviceSetupWidget(AudioJack::name(), parent)
 {
-	// TODO: Add a button to start the JACK server?
+	// TODO: Once backend can be changed without restarting LMMS, add a button to start/stop
+	//       the JACK server and an indicator for the JACK server status.
 
 	jack_status_t status;
 	m_client = jack_client_open("LMMS-Setup Dialog", JackNoStartServer, &status);
 	if (!m_client)
 	{
-		std::fprintf(stderr, "jack_client_open() failed, ");
-		printJackStatus(status);
+		// Failure is expected when not using the JACK backend
 	}
 
 	QFormLayout * form = new QFormLayout(this);


### PR DESCRIPTION
This fixes a regression from #7919.

Opening the Settings would unconditionally try to start the JACK server if it was not already running, even if the user was using an audio backend other than JACK. When it failed to start the JACK server, it would retry a few times which made opening the Settings take several seconds. For me, it also broke my whole system's audio, requiring me to restart pipewire (see the console logs below).

This PR fixes that problem by passing the `JackNoStartServer` option to `jack_client_open()` in the `setupWidget` used by the Settings. `AudioJack::initJackClient()` continues to use the `JackNullOption` option, so like before, it will still attempt to start the JACK server if you select the JACK backend and restart LMMS.

I also moved some `static` free functions into a nearby anonymous namespace, and I removed the server name argument from the `jack_client_open()` calls since that variadic argument is only supposed to be passed if the `JackServerName` option is passed (see [documentation](https://jackaudio.org/api/group__ClientFunctions.html#gabbd2041bca191943b6ef29a991a131c5)).

----

#### Console output showing the bug that was fixed by this PR
<details>
<summary>Click to expand</summary>
<pre>
$ ./lmms 
*** WEAK-JACK: initializing
*** WEAK-JACK: OK. (0)
lilv_world_add_plugin(): warning: Duplicate plugin <http://spectmorph.org/plugins/spectmorph>
lilv_world_add_plugin(): warning: ... found in file:///home/dalton/.lv2/spectmorph.lv2/
lilv_world_add_plugin(): warning: ... and      file:///usr/local/lib/lv2/spectmorph.lv2/ (ignored)
Lv2 plugin SUMMARY: 18 of 40  loaded in 119 msecs.
For details about not loaded plugins, please set
  environment variable "LMMS_LV2_DEBUG" to nonempty.
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jackdmp 1.9.21
Copyright 2001-2005 Paul Davis and others.
Copyright 2004-2016 Grame.
Copyright 2016-2022 Filipe Coelho.
jackdmp comes with ABSOLUTELY NO WARRANTY
This is free software, and you are welcome to redistribute it
under certain conditions; see the file COPYING for details
no message buffer overruns
no message buffer overruns
no message buffer overruns
JACK server starting in realtime mode with priority 10
self-connect-mode is "Don't restrict self connect requests"
audio_reservation_init
Acquire audio card Audio0
creating alsa driver ... hw:0|hw:0|1024|2|48000|0|0|nomon|swmeter|-|32bit
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel


ATTENTION: The playback device "hw:0" is already in use. The following applications  are using your soundcard(s) so you should  check them and stop them as necessary before  trying to start JACK again:

pipewire (process ID 2501)

JackTemporaryException : now quits...
Released audio card Audio0
audio_reservation_finish
Cannot initialize driver
JackServer::Open failed with -1
Failed to open server
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
Cannot connect to server socket err = No such file or directory
Cannot connect to server request channel
jack server is not running or cannot be started
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
JackShmReadWritePtr::~JackShmReadWritePtr - Init not done for -1, skipping unlock
jack_client_open() failed, Status: 0x11
Overall operation failed. JACK dependencies might need to be installed.
Could not connect to JACK server.
</pre>
</details>