### PR TITLE
Fix missing entires when searching in the file browser

### DIFF
--- a/include/FileSearchJob.h
+++ b/include/FileSearchJob.h
@@ -74,6 +74,7 @@ signals:
 
 private:
 	void runSearch(Task task);
+	bool validEntry(QString entry, QStringList tokens, QStringList extensions);
 	std::future<void> m_task;
 	std::atomic_flag m_stop = ATOMIC_FLAG_INIT;
 };

--- a/include/FileSearchJob.h
+++ b/include/FileSearchJob.h
@@ -43,7 +43,7 @@ public:
 		QString filter;					 //! The filter to be tokenized.
 		QStringList paths;				 //! The list of paths to search recursively through.
 		QStringList extensions;			 //! The list of allowed extensions.
-		QFlags<QDir::Filter> dirFilters; //! The directory filter flag.
+		bool hidden;					 //! Include hidden entries.
 	};
 
 	//! Create a search job with the given @p parent (if any).

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -229,13 +229,10 @@ void FileBrowser::onSearch(const QString& filter)
 	if (m_showFactoryContent && !m_showFactoryContent->isChecked()) { directories.removeAll(m_factoryDir); }
 	if (directories.isEmpty()) { return; }
 
-	auto directoryFilters = QDir::AllEntries | QDir::NoDotAndDotDot;
-	if (m_showHiddenContent) { directoryFilters |= QDir::Hidden; }
-
 	const auto searchTask = FileSearchJob::Task{.filter = filter,
 		.paths = directories,
 		.extensions = FileItem::defaultFilters().split(" "),
-		.dirFilters = directoryFilters};
+		.hidden = m_showHiddenContent->isChecked()};
 
 	m_searchTreeWidget->clear();
 	m_searchTreeWidget->show();

--- a/src/gui/FileSearchJob.cpp
+++ b/src/gui/FileSearchJob.cpp
@@ -81,9 +81,10 @@ void FileSearchJob::runSearch(Task task)
 	{
 		if (validEntry(path, tokens, task.extensions)) { emit foundMatch(path); }
 
-		auto dirIt = QDirIterator{path, task.dirFilters,
-			QDirIterator::IteratorFlag::Subdirectories | QDirIterator::IteratorFlag::FollowSymlinks};
+		auto searchFilters = QDir::AllEntries | QDir::NoDotAndDotDot;
+		if (task.hidden) { searchFilters |= QDir::Hidden; }
 
+		auto dirIt = QDirIterator{path, searchFilters, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks};
 		while (dirIt.hasNext() && !m_stop.test(std::memory_order_relaxed))
 		{
 			if (validEntry(dirIt.next(), tokens, task.extensions)) { emit foundMatch(dirIt.filePath()); }

--- a/src/gui/FileSearchJob.cpp
+++ b/src/gui/FileSearchJob.cpp
@@ -79,25 +79,32 @@ void FileSearchJob::runSearch(Task task)
 
 	for (const auto& path : task.paths)
 	{
+		if (validEntry(path, tokens, task.extensions)) { emit foundMatch(path); }
+
 		auto dirIt = QDirIterator{path, task.dirFilters,
 			QDirIterator::IteratorFlag::Subdirectories | QDirIterator::IteratorFlag::FollowSymlinks};
 
 		while (dirIt.hasNext() && !m_stop.test(std::memory_order_relaxed))
 		{
-			const auto fileInfo = QFileInfo{dirIt.next()};
-			const auto fileName = fileInfo.fileName();
-			const auto containsToken = std::all_of(tokens.begin(), tokens.end(),
-				[&](const auto& token) { return fileName.contains(token, Qt::CaseInsensitive); });
-
-			const auto validDir = fileInfo.isDir() && containsToken;
-			const auto validFile = fileInfo.isFile() && containsToken
-				&& task.extensions.contains(QString{"*.%1"}.arg(fileInfo.completeSuffix()), Qt::CaseInsensitive);
-
-			if (validDir || validFile) { emit foundMatch(fileInfo.filePath()); }
+			if (validEntry(dirIt.next(), tokens, task.extensions)) { emit foundMatch(dirIt.filePath()); }
 		}
 	}
 
 	emit finished();
+}
+
+bool FileSearchJob::validEntry(QString entry, QStringList tokens, QStringList extensions)
+{
+	const auto fileInfo = QFileInfo{entry};
+	const auto fileName = fileInfo.fileName();
+	const auto containsToken = std::all_of(
+		tokens.begin(), tokens.end(), [&](const auto& token) { return fileName.contains(token, Qt::CaseInsensitive); });
+
+	const auto validDir = fileInfo.isDir() && containsToken;
+	const auto validFile = fileInfo.isFile() && containsToken
+		&& extensions.contains(QString{"*.%1"}.arg(fileInfo.completeSuffix()), Qt::CaseInsensitive);
+
+	return validDir || validFile;
 }
 
 } // namespace lmms::gui


### PR DESCRIPTION
Fixes some bugs with the search.

Changes:
1. The root directories are now included in the search rather than just their subdirectories.
2. "Hidden content" now works for searches (hidden entries were always listed before)
3. Enforce the possible directory filters used in the search (i.e., the option to specify directory filters in `FileSearchJob::Task`  has been removed).

Future:
There were a couple of bugs I ran into while writing this PR. One of them I already reported on the tracker (see #8319). There is also another subtle issue where in the favorite browser, if you have two entries "folder_a/folder_b" and "folder_b" (which is in "folder_a"), duplicate search results will appear. Instead, "folder_b" should only be searched recursively once. This is something I might fix in here later or another PR (or maybe because of performance reasons I'll just leave it for now).