### PR TITLE
Fix segfault when opening SF2 Player GUI during load #8227

### DIFF
--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -79,8 +79,6 @@ protected:
 
 
 private slots:
-	//! Slot to update the state of the track label button when the instrument changes.
-	//! An instrument may be loaded or removed, so the button should be enabled or disabled accordingly.
 	void onInstrumentChanged();
 	void toggleInstrumentWindow( bool _on );
 	void toggleMidiCCRack();

--- a/include/InstrumentTrackView.h
+++ b/include/InstrumentTrackView.h
@@ -79,6 +79,9 @@ protected:
 
 
 private slots:
+	//! Slot to update the state of the track label button when the instrument changes.
+	//! An instrument may be loaded or removed, so the button should be enabled or disabled accordingly.
+	void onInstrumentChanged();
 	void toggleInstrumentWindow( bool _on );
 	void toggleMidiCCRack();
 	void activityIndicatorPressed();

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -721,11 +721,6 @@ void InstrumentTrackWindow::viewPrevInstrument()
 
 void InstrumentTrackWindow::adjustTabSize(QWidget *w)
 {
-	// Check if the widget is null, as not all tabs are always present (e.g. the plugin tab is only present if an instrument is loaded)
-	if( w == nullptr )
-	{
-		return;
-	}
 	// "-1" :
 	// in "TabWidget::addTab", under "Position tab's window", the widget is
 	// moved up by 1 pixel

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -721,6 +721,11 @@ void InstrumentTrackWindow::viewPrevInstrument()
 
 void InstrumentTrackWindow::adjustTabSize(QWidget *w)
 {
+	// Check if the widget is null, as not all tabs are always present (e.g. the plugin tab is only present if an instrument is loaded)
+	if( w == nullptr )
+	{
+		return;
+	}
 	// "-1" :
 	// in "TabWidget::addTab", under "Position tab's window", the widget is
 	// moved up by 1 pixel

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -71,6 +71,11 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_tlb->setIcon(determinePixmap(_it));
 	m_tlb->show();
 
+	// Check if an instrument has been loaded, if not disable the track label button to prevent opening an empty instrument window.
+	if( !_it->m_instrument ) {
+		m_tlb->setEnabled( false );
+	}
+
 	connect( m_tlb, SIGNAL(toggled(bool)),
 			this, SLOT(toggleInstrumentWindow(bool)));
 
@@ -79,6 +84,10 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 
 	connect(ConfigManager::inst(), SIGNAL(valueChanged(QString,QString,QString)),
 			this, SLOT(handleConfigChange(QString,QString,QString)));
+
+	// update the state of the track label button when the instrument changes, as an instrument may be loaded or removed.
+	connect( _it, SIGNAL(instrumentChanged()),
+			this, SLOT(onInstrumentChanged()));
 
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
@@ -295,6 +304,15 @@ void InstrumentTrackView::dropEvent( QDropEvent * _de )
 {
 	getInstrumentTrackWindow()->dropEvent( _de );
 	TrackView::dropEvent( _de );
+}
+
+
+
+
+void InstrumentTrackView::onInstrumentChanged()
+{
+	// Check if an instrument has been loaded, if not disable the track label button to prevent opening an empty instrument window.
+	m_tlb->setEnabled( model()->m_instrument != nullptr );
 }
 
 

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -71,11 +71,6 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	m_tlb->setIcon(determinePixmap(_it));
 	m_tlb->show();
 
-	// Check if an instrument has been loaded, if not disable the track label button to prevent opening an empty instrument window.
-	if( !_it->m_instrument ) {
-		m_tlb->setEnabled( false );
-	}
-
 	connect( m_tlb, SIGNAL(toggled(bool)),
 			this, SLOT(toggleInstrumentWindow(bool)));
 
@@ -85,9 +80,7 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	connect(ConfigManager::inst(), SIGNAL(valueChanged(QString,QString,QString)),
 			this, SLOT(handleConfigChange(QString,QString,QString)));
 
-	// update the state of the track label button when the instrument changes, as an instrument may be loaded or removed.
-	connect( _it, SIGNAL(instrumentChanged()),
-			this, SLOT(onInstrumentChanged()));
+	connect(_it, &InstrumentTrack::instrumentChanged, this, &InstrumentTrackView::onInstrumentChanged);
 
 	m_mixerChannelNumber = new MixerChannelLcdSpinBox(2, getTrackSettingsWidget(), tr("Mixer channel"), this);
 	m_mixerChannelNumber->show();
@@ -176,6 +169,8 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	 		m_activityIndicator, SLOT(noteEnd()));
 
 	setModel( _it );
+
+	onInstrumentChanged();
 }
 
 
@@ -312,7 +307,7 @@ void InstrumentTrackView::dropEvent( QDropEvent * _de )
 void InstrumentTrackView::onInstrumentChanged()
 {
 	// Check if an instrument has been loaded, if not disable the track label button to prevent opening an empty instrument window.
-	m_tlb->setEnabled( model()->m_instrument != nullptr );
+	m_tlb->setEnabled(model()->m_instrument != nullptr);
 }
 
 


### PR DESCRIPTION
Clicking the ```TrackLabelButton``` while a soundfont was still loading triggered ```InstrumentTrackWindow::adjustTabSize()``` with a null widget pointer, causing a segmentation fault.

Changes:
1. Disable ```TrackLabelButton``` in constructor when no instrument is loaded
2. Re-enable ```TrackLabelButton``` via ```onInstrumentChanged()``` slot connected to ```InstrumentTrack::instrumentChanged()``` signal
3. Add null guard in ```adjustTabSize()``` as an additional safety measure

Closes #8227