### PR TITLE
Fix Patman crash on invalid patch loading #8163

### DIFF
--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -25,12 +25,14 @@
 
 #include "Patman.h"
 
-#include <QDragEnterEvent>
-#include <QPainter>
+#include <QDebug>
 #include <QDomElement>
+#include <QDragEnterEvent>
+#include <QMessageBox>
+#include <QPainter>
 
+#include "Clipboard.h"
 #include "ConfigManager.h"
-#include "endian_handling.h"
 #include "Engine.h"
 #include "FileDialog.h"
 #include "FontHelper.h"
@@ -40,7 +42,7 @@
 #include "PixmapButton.h"
 #include "Song.h"
 #include "StringPairDrag.h"
-#include "Clipboard.h"
+#include "endian_handling.h"
 
 #include "embed.h"
 
@@ -48,6 +50,26 @@
 
 namespace lmms
 {
+
+namespace
+{
+
+bool shouldRenameInstrumentTrack( InstrumentTrack* track, const QString& previousPatchFile )
+{
+	if (track->name().isEmpty())
+	{
+		return true;
+	}
+
+	if (previousPatchFile.isEmpty())
+	{
+		return false;
+	}
+
+	return track->name() == QFileInfo( previousPatchFile ).fileName();
+}
+
+}
 
 
 extern "C"
@@ -109,7 +131,7 @@ void PatmanInstrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 void PatmanInstrument::loadSettings( const QDomElement & _this )
 {
-	setFile( _this.attribute( "src" ), false );
+	setFile( _this.attribute( "src" ), false, false );
 	m_loopedModel.loadSettings( _this, "looped" );
 	m_tunedModel.loadSettings( _this, "tuned" );
 }
@@ -119,7 +141,7 @@ void PatmanInstrument::loadSettings( const QDomElement & _this )
 
 void PatmanInstrument::loadFile( const QString & _file )
 {
-	setFile( _file );
+	setFile( _file, true, false );
 }
 
 
@@ -136,8 +158,14 @@ QString PatmanInstrument::nodeName() const
 void PatmanInstrument::playNote( NotePlayHandle * _n,
 						SampleFrame* _working_buffer )
 {
-	if( m_patchFile == "" )
+	if( m_patchFile.isEmpty() )
 	{
+		return;
+	}
+
+	if( m_patchSamples.empty() )
+	{
+		qWarning() << "Patman: skipping note playback because patch has no loaded samples:" << m_patchFile;
 		return;
 	}
 
@@ -148,19 +176,23 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 	{
 		selectSample( _n );
 	}
-	auto hdata = (handle_data*)_n->m_pluginData;
+	auto hdata = static_cast<handle_data*>(_n->m_pluginData);
 
 	float play_freq = hdata->tuned ? _n->frequency() :
 						hdata->sample->frequency();
 
-	if (hdata->sample->play(_working_buffer + offset, hdata->state, frames,
-			m_loopedModel.value() ? Sample::Loop::On : Sample::Loop::Off, DefaultBaseFreq / play_freq))
+	if (hdata->sample->play(
+		_working_buffer + offset,
+		hdata->state,
+		frames,
+		m_loopedModel.value() ? Sample::Loop::On : Sample::Loop::Off,
+		DefaultBaseFreq / play_freq))
 	{
 		applyRelease( _working_buffer, _n );
 	}
 	else
 	{
-		zeroSampleFrames(_working_buffer, frames + offset);
+		zeroSampleFrames( _working_buffer, frames + offset );
 	}
 }
 
@@ -169,7 +201,7 @@ void PatmanInstrument::playNote( NotePlayHandle * _n,
 
 void PatmanInstrument::deleteNotePluginData( NotePlayHandle * _n )
 {
-	auto hdata = (handle_data*)_n->m_pluginData;
+	auto hdata = static_cast<handle_data*>(_n->m_pluginData);
 	delete hdata->state;
 	delete hdata;
 }
@@ -177,31 +209,57 @@ void PatmanInstrument::deleteNotePluginData( NotePlayHandle * _n )
 
 
 
-void PatmanInstrument::setFile( const QString & _patch_file, bool _rename )
+void PatmanInstrument::setFile( const QString & _patch_file, bool _rename, bool showErrorDialog )
 {
-	if( _patch_file.size() <= 0 )
+	if( _patch_file.isEmpty() )
 	{
 		m_patchFile = QString();
 		return;
 	}
 
-	// is current instrument-track-name equal to previous-filename??
-	if( _rename &&
-		( instrumentTrack()->name() ==
-					QFileInfo( m_patchFile ).fileName() ||
-				   	m_patchFile == "" ) )
-	{
-		// then set it to new one
-		instrumentTrack()->setName( PathUtil::cleanName( _patch_file ) );
-	}
-	// else we don't touch the instrument-track-name, because the user
-	// named it self
+	const QString previousPatchFile = m_patchFile;
 
 	m_patchFile = PathUtil::toShortestRelative( _patch_file );
 	LoadError error = loadPatch( PathUtil::toAbsolute( _patch_file ) );
 	if( error != LoadError::OK )
 	{
-		printf("Load error\n");
+		m_patchFile = QString();
+		QString errorMessage;
+		switch( error )
+		{
+		case LoadError::Open:
+			errorMessage = tr( "Failed to open patch file." );
+			break;
+		case LoadError::NotGUS:
+			errorMessage = tr( "File is not a valid GUS patch." );
+			break;
+		case LoadError::Instruments:
+			errorMessage = tr( "Unsupported number of instruments." );
+			break;
+		case LoadError::Layers:
+			errorMessage = tr( "Unsupported number of layers." );
+			break;
+		case LoadError::IO:
+			errorMessage = tr( "I/O failure while reading patch." );
+			break;
+		default:
+			errorMessage = tr( "Unknown load error." );
+			break;
+		}
+
+		qWarning() << "Patman: load error for" << _patch_file
+			<< '-' << errorMessage;
+
+		if( showErrorDialog )
+		{
+			QMessageBox::warning( nullptr,
+				tr( "PatMan" ),
+				tr( "Unable to load patch file:\n%1" ).arg( errorMessage ) );
+		}
+	}
+	else if( _rename && shouldRenameInstrumentTrack( instrumentTrack(), previousPatchFile ) )
+	{
+		instrumentTrack()->setName( PathUtil::cleanName( _patch_file ) );
 	}
 
 	emit fileChanged();
@@ -475,7 +533,7 @@ PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 
 	if (m_pi->m_patchFile.isEmpty())
 	{
-		m_displayFilename = tr("No file selected");
+		m_displayFilename = tr( "No file selected" );
 	}
 	else
 	{
@@ -497,7 +555,7 @@ void PatmanView::openFile()
 	types << tr( "Patch-Files (*.pat)" );
 	ofd.setNameFilters( types );
 
-	if( m_pi->m_patchFile == "" )
+	if( m_pi->m_patchFile.isEmpty() )
 	{
 		if( QDir( "/usr/share/midi/freepats" ).exists() )
 		{
@@ -529,9 +587,9 @@ void PatmanView::openFile()
 	if( ofd.exec() == QDialog::Accepted && !ofd.selectedFiles().isEmpty() )
 	{
 		QString f = ofd.selectedFiles()[0];
-		if( f != "" )
+		if( !f.isEmpty() )
 		{
-			m_pi->setFile( f );
+			m_pi->setFile( f, true, true );
 			Engine::getSong()->setModified();
 		}
 	}
@@ -542,6 +600,13 @@ void PatmanView::openFile()
 
 void PatmanView::updateFilename()
 {
+	if( m_pi->m_patchFile.isEmpty() )
+	{
+		m_displayFilename = tr( "No file selected" );
+		update();
+		return;
+	}
+
  	m_displayFilename = "";
 	int idx = m_pi->m_patchFile.length();
 
@@ -600,7 +665,7 @@ void PatmanView::dropEvent( QDropEvent * _de )
 	QString value = StringPairDrag::decodeValue( _de );
 	if( type == "samplefile" )
 	{
-		m_pi->setFile( value );
+		m_pi->setFile( value, true, true );
 		_de->accept();
 		return;
 	}

--- a/plugins/Patman/Patman.h
+++ b/plugins/Patman/Patman.h
@@ -79,7 +79,7 @@ public:
 
 
 public slots:
-	void setFile( const QString & _patch_file, bool _rename = true );
+	void setFile( const QString & _patch_file, bool _rename = true, bool _showErrorDialog = false );
 
 
 private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LMMS_TESTS
 	src/core/RelativePathsTest.cpp
 	src/core/TimelineTest.cpp
 	src/tracks/AutomationTrackTest.cpp
+	src/plugins/PatmanTest.cpp
 )
 
 foreach(LMMS_TEST_SRC IN LISTS LMMS_TESTS)
@@ -29,6 +30,20 @@ foreach(LMMS_TEST_SRC IN LISTS LMMS_TESTS)
 		${QT_LIBRARIES}
 		${QT_QTTEST_LIBRARY}
 	)
+
+	if(LMMS_TEST_NAME STREQUAL "PatmanTest")
+		target_sources(${LMMS_TEST_NAME} PRIVATE
+			${CMAKE_SOURCE_DIR}/plugins/Patman/Patman.cpp
+		)
+		target_include_directories(${LMMS_TEST_NAME} PRIVATE
+			${CMAKE_SOURCE_DIR}/plugins/Patman
+			${CMAKE_BINARY_DIR}/plugins/Patman
+		)
+		target_compile_definitions(${LMMS_TEST_NAME} PRIVATE
+			PLUGIN_NAME=patman
+			PLUGIN_STATIC_DEFINE
+		)
+	endif()
 
 	target_compile_features(${LMMS_TEST_NAME} PRIVATE cxx_std_20)
 	target_compile_definitions(${LMMS_TEST_NAME} PRIVATE LMMS_TESTING)

--- a/tests/src/plugins/PatmanTest.cpp
+++ b/tests/src/plugins/PatmanTest.cpp
@@ -1,0 +1,202 @@
+/*
+ * PatmanTest.cpp
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#include <QApplication>
+#include <QDir>
+#include <QDomDocument>
+#include <QTemporaryFile>
+#include <QtTest>
+
+#include "Engine.h"
+#include "InstrumentTrack.h"
+#include "Patman.h"
+#include "PathUtil.h"
+#include "ProjectJournal.h"
+#include "Song.h"
+
+namespace
+{
+
+QByteArray validPatchHeaderWithNoSamples()
+{
+	QByteArray header(239, '\0');
+	const char signature[] = "GF1PATCH110\0ID#000002";
+	memcpy(header.data(), signature, 22);
+	header[82] = 1;
+	header[151] = 1;
+	header[198] = 0;
+	return header;
+}
+
+QString createTempPatchFile( const QByteArray& bytes )
+{
+	QTemporaryFile file( QDir::tempPath() + "/patman-test-XXXXXX.pat" );
+	file.setAutoRemove( false );
+	if (!file.open())
+	{
+		return {};
+	}
+
+	file.write( bytes );
+	file.flush();
+	const QString filePath = file.fileName();
+	file.close();
+	return filePath;
+}
+
+QString patchFileFromInstrument( lmms::PatmanInstrument& instrument )
+{
+	QDomDocument doc;
+	QDomElement element = doc.createElement( "instrument" );
+	instrument.saveSettings( doc, element );
+	return element.attribute( "src" );
+}
+
+}
+
+class PatmanTest : public QObject
+{
+	Q_OBJECT
+
+	void ensureJournalReady()
+	{
+		using namespace lmms;
+
+		if (Engine::projectJournal() == nullptr)
+		{
+			Engine::destroy();
+			Engine::init( true );
+		}
+
+		QVERIFY2( Engine::projectJournal() != nullptr,
+			"ProjectJournal must be initialized before constructing InstrumentTrack" );
+		Engine::projectJournal()->setJournalling( false );
+	}
+
+private slots:
+	void initTestCase()
+	{
+		using namespace lmms;
+		Engine::init( true );
+		ensureJournalReady();
+	}
+
+	void cleanupTestCase()
+	{
+		using namespace lmms;
+		Engine::destroy();
+	}
+
+	void missingPatchClearsFile()
+	{
+		using namespace lmms;
+		ensureJournalReady();
+
+		InstrumentTrack track( Engine::getSong() );
+		track.setName( "Manual Name" );
+		PatmanInstrument instrument( &track );
+
+		instrument.setFile( "/tmp/does-not-exist-patman-test.pat" );
+
+		QCOMPARE( patchFileFromInstrument( instrument ), QString() );
+		QCOMPARE( track.name(), QString( "Manual Name" ) );
+	}
+
+	void invalidPatchClearsFile()
+	{
+		using namespace lmms;
+		ensureJournalReady();
+
+		const QString invalidPatchPath = createTempPatchFile( "not-a-valid-gus-patch" );
+		QVERIFY( !invalidPatchPath.isEmpty() );
+
+		InstrumentTrack track( Engine::getSong() );
+		track.setName( "Manual Name" );
+		PatmanInstrument instrument( &track );
+
+		instrument.setFile( invalidPatchPath );
+
+		QCOMPARE( patchFileFromInstrument( instrument ), QString() );
+		QCOMPARE( track.name(), QString( "Manual Name" ) );
+
+		QFile::remove( invalidPatchPath );
+	}
+
+	void playNoteWithNoLoadedSamplesDoesNotCrash()
+	{
+		using namespace lmms;
+		ensureJournalReady();
+
+		const QString validZeroSamplePatchPath = createTempPatchFile( validPatchHeaderWithNoSamples() );
+		QVERIFY( !validZeroSamplePatchPath.isEmpty() );
+
+		InstrumentTrack track( Engine::getSong() );
+		PatmanInstrument instrument( &track );
+
+		instrument.setFile( validZeroSamplePatchPath );
+		QVERIFY( !patchFileFromInstrument( instrument ).isEmpty() );
+
+		QTest::ignoreMessage(
+			QtWarningMsg,
+			QRegularExpression( "Patman: skipping note playback because patch has no loaded samples:.*" ) );
+		instrument.playNote( nullptr, nullptr );
+
+		QFile::remove( validZeroSamplePatchPath );
+	}
+
+	void manualTrackNameIsPreservedOnSuccessfulLoad()
+	{
+		using namespace lmms;
+		ensureJournalReady();
+
+		const QString validZeroSamplePatchPath = createTempPatchFile( validPatchHeaderWithNoSamples() );
+		QVERIFY( !validZeroSamplePatchPath.isEmpty() );
+
+		InstrumentTrack track( Engine::getSong() );
+		track.setName( "Custom Manual Name" );
+		PatmanInstrument instrument( &track );
+
+		instrument.setFile( validZeroSamplePatchPath, true );
+
+		QCOMPARE( track.name(), QString( "Custom Manual Name" ) );
+
+		QFile::remove( validZeroSamplePatchPath );
+	}
+
+	void trackRenamesWhenPreviousPatchWasEmpty()
+	{
+		using namespace lmms;
+		ensureJournalReady();
+
+		const QString validZeroSamplePatchPath = createTempPatchFile( validPatchHeaderWithNoSamples() );
+		QVERIFY( !validZeroSamplePatchPath.isEmpty() );
+
+		InstrumentTrack track( Engine::getSong() );
+		track.setName( "" );
+		PatmanInstrument instrument( &track );
+
+		instrument.setFile( validZeroSamplePatchPath, true );
+
+		QCOMPARE( track.name(), PathUtil::cleanName( validZeroSamplePatchPath ) );
+
+		QFile::remove( validZeroSamplePatchPath );
+	}
+};
+
+int main( int argc, char** argv )
+{
+	qputenv( "QT_QPA_PLATFORM", QByteArray( "offscreen" ) );
+	QApplication app( argc, argv );
+	PatmanTest tc;
+	return QTest::qExec( &tc, argc, argv );
+}
+
+#include "PatmanTest.moc"


### PR DESCRIPTION
The function ```setFile()``` could keep ```m_patchFile``` set even when ```loadPatch()``` failed, so, this left an inconsistent state (path set, sample list empty) that reached ```playNote()```.

Changes:
1. guard ```playNote()``` when no samples are loaded and emit a diagnostic warning
2.  clear patch path on load failure and report specific load errors
3. preserve user-defined track names by refining rename conditions
4. normalize empty-string handling with ```isEmpty()```
5. add ```Patman``` unit tests for missing/invalid patch files, empty-sample playback safety, and rename behavior
6. load errors are shown via ```QMessageBox``` only for explicit user actions

Validation:
- ```ctest --test-dir build/tests -R PatmanTest --output-on-failure```

Closes #8163 