### PR TITLE
Add normalizePhase() for normalizing phase

### DIFF
--- a/include/BandLimitedWave.h
+++ b/include/BandLimitedWave.h
@@ -135,7 +135,7 @@ public:
 		while( t < MAXTBL && _wavelen >= TLENS[t+1] ) { t++; }
 
 		int tlen = TLENS[t];
-		const float ph = fraction( _ph );
+		const float ph = normalizePhase<1>(_ph);
 		const float lookupf = ph * static_cast<float>( tlen );
 		int lookup = static_cast<int>( lookupf );
 		const float ip = fraction( lookupf );

--- a/include/Oscillator.h
+++ b/include/Oscillator.h
@@ -118,7 +118,7 @@ public:
 
 	static inline sample_t triangleSample( const float _sample )
 	{
-		const float ph = absFraction( _sample );
+		const float ph = normalizePhase<1>(_sample);
 		if( ph <= 0.25f )
 		{
 			return ph * 4.0f;
@@ -132,17 +132,17 @@ public:
 
 	static inline sample_t sawSample( const float _sample )
 	{
-		return -1.0f + absFraction( _sample ) * 2.0f;
+		return -1.0f + normalizePhase<1>(_sample) * 2.0f;
 	}
 
 	static inline sample_t squareSample( const float _sample )
 	{
-		return ( absFraction( _sample ) > 0.5f ) ? -1.0f : 1.0f;
+		return normalizePhase<1>(_sample) > 0.5f ? -1.0f : 1.0f;
 	}
 
 	static inline sample_t moogSawSample( const float _sample )
 	{
-		const float ph = absFraction( _sample );
+		const float ph = normalizePhase<1>(_sample);
 		if( ph < 0.5f )
 		{
 			return -1.0f + ph * 4.0f;
@@ -152,7 +152,7 @@ public:
 
 	static inline sample_t expSample( const float _sample )
 	{
-		float ph = absFraction( _sample );
+		float ph = normalizePhase<1>(_sample);
 		if( ph > 0.5f )
 		{
 			ph = 1.0f - ph;
@@ -169,7 +169,7 @@ public:
 	{
 		if (buffer == nullptr || buffer->size() == 0) { return 0; }
 		const auto frames = buffer->size();
-		const auto frame = absFraction(sample) * frames;
+		const auto frame = normalizePhase<1>(sample) * frames;
 		const auto f1 = static_cast<f_cnt_t>(frame);
 
 		return std::lerp(buffer->data()[f1][0], buffer->data()[(f1 + 1) % frames][0], fraction(frame));
@@ -185,7 +185,7 @@ public:
 	inline wtSampleControl getWtSampleControl(const float sample) const
 	{
 		wtSampleControl control;
-		control.frame = absFraction(sample) * OscillatorConstants::WAVETABLE_LENGTH;
+		control.frame = normalizePhase<1>(sample) * OscillatorConstants::WAVETABLE_LENGTH;
 		control.f1 = static_cast<f_cnt_t>(control.frame);
 		control.f2 = control.f1 < OscillatorConstants::WAVETABLE_LENGTH - 1 ?
 					control.f1 + 1 :

--- a/include/QuadratureLfo.h
+++ b/include/QuadratureLfo.h
@@ -25,9 +25,6 @@
 #ifndef LMMS_QUADRATURE_LFO_H
 #define LMMS_QUADRATURE_LFO_H
 
-#include <numbers>
-#include <cmath>
-
 #include "lmms_math.h"
 
 namespace lmms

--- a/include/QuadratureLfo.h
+++ b/include/QuadratureLfo.h
@@ -28,6 +28,8 @@
 #include <numbers>
 #include <cmath>
 
+#include "lmms_math.h"
+
 namespace lmms
 {
 
@@ -80,8 +82,7 @@ public:
 	{
 		*l = std::sin(m_phase);
 		*r = std::sin(m_phase + m_offset);
-		m_phase += m_increment;
-		m_phase = std::fmod(m_phase, 2 * std::numbers::pi);
+		m_phase = normalizePhase(m_phase + m_increment);
 	}
 
 private:

--- a/include/lmms_math.h
+++ b/include/lmms_math.h
@@ -67,19 +67,17 @@ inline auto fraction(std::floating_point auto x) noexcept
 
 
 // TODO C++23: Make constexpr since std::floor() will be constexpr
-/*!
- * @brief Returns the wrapped fractional part of a float, a value between 0.0f and 1.0f.
- *
- * absFraction( 2.3) =>  0.3
- * absFraction(-2.3) =>  0.7
- *
- * Note that this not the same as the absolute value of the fraction (as the function name suggests).
- * If the result is interpreted as a phase of an oscillator, it makes that negative phases are
- * converted to positive phases.
- */
-inline auto absFraction(std::floating_point auto x) noexcept
+//! @brief Normalizes a phase, such that it is wrapped within [0, Period).
+//! This safely converts negative phases into an equivalent positive phase.
+//! @param x The phase to normalize.
+//! @tparam Period The exclusive upper bound of the range in which to wrap the phase.
+//! @returns A phase greater than or equal to 0 and less than Period.
+template<auto Period = 2 * std::numbers::pi_v<long double>, std::floating_point T>
+inline T normalizePhase(T x) noexcept
 {
-	return x - std::floor(x);
+	constexpr auto p = static_cast<T>(Period);
+	constexpr auto r = static_cast<T>(1.0 / Period);
+	return x - p * std::floor(x * r);
 }
 
 

--- a/plugins/Delay/Lfo.h
+++ b/plugins/Delay/Lfo.h
@@ -25,9 +25,6 @@
 #ifndef LFO_H
 #define LFO_H
 
-#include <cmath>
-#include <numbers>
-
 #include "lmms_math.h"
 
 namespace lmms

--- a/plugins/Delay/Lfo.h
+++ b/plugins/Delay/Lfo.h
@@ -28,6 +28,8 @@
 #include <cmath>
 #include <numbers>
 
+#include "lmms_math.h"
+
 namespace lmms
 {
 
@@ -50,7 +52,7 @@ public:
 		m_frequency = frequency;
 		m_increment = m_frequency * m_twoPiOverSr;
 
-		m_phase = std::fmod(m_phase, 2 * std::numbers::pi_v<float>);
+		m_phase = normalizePhase(m_phase);
 	}
 
 

--- a/plugins/FrequencyShifter/FrequencyShifterEffect.cpp
+++ b/plugins/FrequencyShifter/FrequencyShifterEffect.cpp
@@ -110,10 +110,10 @@ Effect::ProcessStatus FrequencyShifterEffect::processImpl(SampleFrame* buf, cons
 	const float glideCoeff = glide ? std::exp(-1.f / (glide * m_sampleRate)) : 0.f;
 
 	// we only bother with wrapping phases once per buffer
-	m_lfoPhase = std::fmod(m_lfoPhase, twoPi);
+	m_lfoPhase = normalizePhase(m_lfoPhase);
 	for (int ch = 0; ch < 2; ++ch)
 	{
-		m_phase[ch] = std::fmod(m_phase[ch], twoPi);
+		m_phase[ch] = normalizePhase(m_phase[ch]);
 	}
 
 	for (size_t i = 0; i < frames; ++i)

--- a/plugins/Monstro/Monstro.cpp
+++ b/plugins/Monstro/Monstro.cpp
@@ -153,8 +153,8 @@ void MonstroSynth::renderOutput( f_cnt_t _frames, SampleFrame* _buf  )
 	const float lfo2_po = m_parent->m_lfo2Phs.value() / 360.0f;
 
 	// remove cruft from phase counters to prevent overflow, add phase offset
-	m_lfo_phase[0] = absFraction( m_lfo_phase[0] + lfo1_po );
-	m_lfo_phase[1] = absFraction( m_lfo_phase[1] + lfo2_po );
+	m_lfo_phase[0] = normalizePhase<1>(m_lfo_phase[0] + lfo1_po);
+	m_lfo_phase[1] = normalizePhase<1>(m_lfo_phase[1] + lfo2_po);
 
 	// LFO rates and increment
 	m_lfo_rate[0] = ( m_parent->m_lfo1Rate.value() * 0.001f * m_parent->m_samplerate );
@@ -385,8 +385,8 @@ void MonstroSynth::renderOutput( f_cnt_t _frames, SampleFrame* _buf  )
 		}
 
 		// pulse wave osc
-		sample_t O1L = ( absFraction( leftph ) < o1_pw ) ? 1.0f : -1.0f;
-		sample_t O1R = ( absFraction( rightph ) < o1_pw ) ? 1.0f : -1.0f;
+		sample_t O1L = (normalizePhase<1>(leftph ) < o1_pw) ? 1.0f : -1.0f;
+		sample_t O1R = (normalizePhase<1>(rightph) < o1_pw) ? 1.0f : -1.0f;
 
 		// check for rise/fall, and sync if appropriate
 		// sync on rise
@@ -489,8 +489,8 @@ void MonstroSynth::renderOutput( f_cnt_t _frames, SampleFrame* _buf  )
 			modulatephs( leftph, o2p )
 			modulatephs( rightph, o2p )
 		}
-		leftph = absFraction( leftph );
-		rightph = absFraction( rightph );
+		leftph  = normalizePhase<1>(leftph );
+		rightph = normalizePhase<1>(rightph);
 
 		// phase delta
 		pd_l = qAbs( leftph - m_ph2l_last );
@@ -569,8 +569,8 @@ void MonstroSynth::renderOutput( f_cnt_t _frames, SampleFrame* _buf  )
 			leftph += O2L * 0.5f;
 			rightph += O2R * 0.5f;
 		}
-		leftph = absFraction( leftph );
-		rightph = absFraction( rightph );
+		leftph  = normalizePhase<1>(leftph );
+		rightph = normalizePhase<1>(rightph);
 
 		// phase delta
 		pd_l = qAbs( leftph - m_ph3l_last );
@@ -670,15 +670,15 @@ void MonstroSynth::renderOutput( f_cnt_t _frames, SampleFrame* _buf  )
 	}
 
 	// update phases
-	m_osc1l_phase = absFraction( o1l_p - o1lpo );
-	m_osc1r_phase = absFraction( o1r_p - o1rpo );
-	m_osc2l_phase = absFraction( o2l_p - o2lpo );
-	m_osc2r_phase = absFraction( o2r_p - o2rpo );
-	m_osc3l_phase = absFraction( o3l_p - o3lpo );
-	m_osc3r_phase = absFraction( o3r_p - o3rpo );
+	m_osc1l_phase = normalizePhase<1>(o1l_p - o1lpo);
+	m_osc1r_phase = normalizePhase<1>(o1r_p - o1rpo);
+	m_osc2l_phase = normalizePhase<1>(o2l_p - o2lpo);
+	m_osc2r_phase = normalizePhase<1>(o2r_p - o2rpo);
+	m_osc3l_phase = normalizePhase<1>(o3l_p - o3lpo);
+	m_osc3r_phase = normalizePhase<1>(o3r_p - o3rpo);
 
-	m_lfo_phase[0] = absFraction( m_lfo_phase[0] - lfo1_po );
-	m_lfo_phase[1] = absFraction( m_lfo_phase[1] - lfo2_po );
+	m_lfo_phase[0] = normalizePhase<1>(m_lfo_phase[0] - lfo1_po);
+	m_lfo_phase[1] = normalizePhase<1>(m_lfo_phase[1] - lfo2_po);
 }
 
 

--- a/plugins/Monstro/Monstro.h
+++ b/plugins/Monstro/Monstro.h
@@ -200,7 +200,7 @@ private:
 				break;
 			case WAVE_SQRSOFT:
 			{
-				const float ph = fraction( _ph );
+				const float ph = normalizePhase<1>(_ph);
 				if( ph < 0.1 )	return Oscillator::sinSample( ph * 5 + 0.75 );
 				else if( ph < 0.5 ) return 1.0f;
 				else if( ph < 0.6 ) return Oscillator::sinSample( ph * 5 + 0.75 );

--- a/plugins/Watsyn/Watsyn.cpp
+++ b/plugins/Watsyn/Watsyn.cpp
@@ -135,10 +135,8 @@ void WatsynObject::renderOutput( f_cnt_t _frames )
 		// if phase mod, add to phases
 		if( m_amod == MOD_PM )
 		{
-			A1_lphase = std::fmod(A1_lphase + A2_L * PMOD_AMT, WAVELEN);
-			if( A1_lphase < 0 ) A1_lphase += WAVELEN;
-			A1_rphase = std::fmod(A1_rphase + A2_R * PMOD_AMT, WAVELEN);
-			if( A1_rphase < 0 ) A1_rphase += WAVELEN;
+			A1_lphase = normalizePhase<WAVELEN>(A1_lphase + A2_L * PMOD_AMT);
+			A1_rphase = normalizePhase<WAVELEN>(A1_rphase + A2_R * PMOD_AMT);
 		}
 		// A1
 		sample_t A1_L = m_parent->m_lvol[A1_OSC] * std::lerp(
@@ -177,10 +175,8 @@ void WatsynObject::renderOutput( f_cnt_t _frames )
 		// if phase mod, add to phases
 		if( m_bmod == MOD_PM )
 		{
-			B1_lphase = std::fmod(B1_lphase + B2_L * PMOD_AMT, WAVELEN);
-			if( B1_lphase < 0 ) B1_lphase += WAVELEN;
-			B1_rphase = std::fmod(B1_rphase + B2_R * PMOD_AMT, WAVELEN);
-			if( B1_rphase < 0 ) B1_rphase += WAVELEN;
+			B1_lphase = normalizePhase<WAVELEN>(B1_lphase + B2_L * PMOD_AMT);
+			B1_rphase = normalizePhase<WAVELEN>(B1_rphase + B2_R * PMOD_AMT);
 		}
 		// B1
 		sample_t B1_L = m_parent->m_lvol[B1_OSC] * std::lerp(
@@ -236,10 +232,9 @@ void WatsynObject::renderOutput( f_cnt_t _frames )
 		// update phases
 		for( int i = 0; i < NUM_OSCS; i++ )
 		{
-			m_lphase[i] += ( static_cast<float>( WAVELEN ) / ( m_samplerate / ( m_nph->frequency() * m_parent->m_lfreq[i] ) ) );
-			m_lphase[i] = std::fmod(m_lphase[i], WAVELEN);
-			m_rphase[i] += ( static_cast<float>( WAVELEN ) / ( m_samplerate / ( m_nph->frequency() * m_parent->m_rfreq[i] ) ) );
-			m_rphase[i] = std::fmod(m_rphase[i], WAVELEN);
+			const auto phasePerSample = static_cast<float>(WAVELEN) * m_nph->frequency() / m_samplerate; 
+			m_lphase[i] = normalizePhase<WAVELEN>(m_lphase[i] + phasePerSample * m_parent->m_lfreq[i]);
+			m_rphase[i] = normalizePhase<WAVELEN>(m_rphase[i] + phasePerSample * m_parent->m_rfreq[i]);
 		}
 	}
 

--- a/plugins/Watsyn/Watsyn.h
+++ b/plugins/Watsyn/Watsyn.h
@@ -42,25 +42,22 @@ namespace lmms
 #define B1ROW 72
 #define B2ROW 95
 
+constexpr int GRAPHLEN  = 220; // don't change - must be same as the size of the widget
+constexpr int WAVERATIO = 32; //!< Oversampling ratio
+constexpr int WAVELEN   = GRAPHLEN * WAVERATIO;
+constexpr int PMOD_AMT  = WAVELEN / 2;
 
-const int GRAPHLEN = 220; // don't change - must be same as the size of the widget
+constexpr int MOD_MIX  = 0;
+constexpr int MOD_AM   = 1;
+constexpr int MOD_RM   = 2;
+constexpr int MOD_PM   = 3;
+constexpr int NUM_MODS = 4;
 
-const int WAVERATIO = 32; // oversampling ratio
-
-const int WAVELEN = GRAPHLEN * WAVERATIO;
-const int PMOD_AMT = WAVELEN / 2;
-
-const int	MOD_MIX = 0;
-const int	MOD_AM = 1;
-const int	MOD_RM = 2;
-const int	MOD_PM = 3;
-const int  NUM_MODS = 4;
-
-const int	A1_OSC = 0;
-const int	A2_OSC = 1;
-const int	B1_OSC = 2;
-const int	B2_OSC = 3;
-const int	NUM_OSCS = 4;
+constexpr int A1_OSC   = 0;
+constexpr int A2_OSC   = 1;
+constexpr int B1_OSC   = 2;
+constexpr int B2_OSC   = 3;
+constexpr int NUM_OSCS = 4;
 
 class WatsynInstrument;
 

--- a/src/core/DrumSynth.cpp
+++ b/src/core/DrumSynth.cpp
@@ -177,7 +177,7 @@ float DrumSynth::waveform(float ph, int form)
 	// sine^2
 	if (form == 1) { return std::abs(2.f * std::sin(0.5f * ph)) - 1.f; }
 	// sawtooth with range [0, 1], used to generate triangle, sawtooth, and square
-	auto saw01 = absFraction(ph / (2 * std::numbers::pi_v<float>));
+	auto saw01 = normalizePhase<1>(ph / (2 * std::numbers::pi_v<float>));
 	// triangle
 	if (form == 2) { return 1.f - 4.f * std::abs(saw01 - 0.5f); }
 	// sawtooth

--- a/src/core/LfoController.cpp
+++ b/src/core/LfoController.cpp
@@ -113,7 +113,7 @@ void LfoController::updateValueBuffer()
 		{
 		case Oscillator::WaveShape::WhiteNoise:
 		{
-			if (absFraction(phase) < absFraction(phasePrev))
+			if (normalizePhase<1>(phase) < normalizePhase<1>(phasePrev))
 			{
 				// Resample when phase period has completed
 				m_heldSample = m_sampleFunction(phase);
@@ -142,7 +142,7 @@ void LfoController::updateValueBuffer()
 		amountPtr += amountInc;
 	}
 
-	m_currentPhase = absFraction(phase - m_phaseOffset);
+	m_currentPhase = normalizePhase<1>(phase - m_phaseOffset);
 	m_bufferLastUpdated = s_periods;
 }
 

--- a/src/core/Oscillator.cpp
+++ b/src/core/Oscillator.cpp
@@ -547,7 +547,7 @@ inline void Oscillator::recalcPhase()
 		m_phaseOffset = m_ext_phaseOffset;
 		m_phase += m_phaseOffset;
 	}
-	m_phase = absFraction( m_phase );
+	m_phase = normalizePhase<1>(m_phase);
 }
 
 


### PR DESCRIPTION
- Replaces `std::fmod(x, 2 * pi)` with `normalizePhase(x)`
- Replaces `std::fmod(x, LengthOfWavetable)` with `normalizePhase<LengthOfWavetable>(x)`
- Replaces `absFraction(x)` with `normalizePhase<1>(x)`, which more clearly communicates the intent of the function call
- Does the same for calls to `fraction(x)` where the input and output are obviously intended to be an oscillator or LFO phase
- Makes some constants in Watsyn `constexpr`

There are some places* in SlewDistortion using `std::fmod()` which I didn't touch, since it's not working with phase, so the function name might be misleading. Should I use a more generic function name like `wrap()`?

*The SSE2 code is already doing what `normalizePhase()` does, just on four `floats` at a time. The non-SIMD code uses `std::fmod()`.