### PR TITLE
Add a zero note check for MIDI recording

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -26,6 +26,7 @@
 
 #include "PianoRoll.h"
 
+#include <algorithm>
 #include <QtMath>  // IWYU pragma: keep
 #include <QApplication>
 #include <QCheckBox>
@@ -4471,10 +4472,7 @@ void PianoRoll::finishRecordNote(const Note & n )
 						n1.quantizeLength(quantization());
 						n1.quantizePos(quantization());
 					}
-					if (n1.length() == 0)
-					{
-						n1.setLength(1);
-					}
+					n1.setLength(std::max(n1.length(), 1));
 					m_midiClip->addNote(n1, false);
 					update();
 					m_recordingNotes.erase( it );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -26,7 +26,6 @@
 
 #include "PianoRoll.h"
 
-#include <algorithm>
 #include <QtMath>  // IWYU pragma: keep
 #include <QApplication>
 #include <QCheckBox>
@@ -44,6 +43,7 @@
 #include <QStyleOption>
 #include <QToolButton>
 
+#include <algorithm>
 #include <cmath>
 #include <utility>
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4472,7 +4472,7 @@ void PianoRoll::finishRecordNote(const Note & n )
 						n1.quantizeLength(quantization());
 						n1.quantizePos(quantization());
 					}
-					n1.setLength(std::max(n1.length(), 1));
+					n1.setLength(std::max(n1.length(), TimePos(1)));
 					m_midiClip->addNote(n1, false);
 					update();
 					m_recordingNotes.erase( it );

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4471,6 +4471,10 @@ void PianoRoll::finishRecordNote(const Note & n )
 						n1.quantizeLength(quantization());
 						n1.quantizePos(quantization());
 					}
+					if (n1.length() == 0)
+					{
+						n1.setLength(1);
+					}
 					m_midiClip->addNote(n1, false);
 					update();
 					m_recordingNotes.erase( it );


### PR DESCRIPTION
  that floors notes to at least 1 tick.  This fixes a few things:

  1. All recorded notes are selectable & visible
  2. No more "ghost" notes that disappear if you copy and paste
  
Testing:

Manually reproduce zero length notes prior to fix via recording un-quantized, then repeat after the fix to show that no zero length notes are created.  It's very repeatable.

closes #8297 