### PR TITLE
Add the ability to zoom and scroll horizontally in the pattern editor

### DIFF
--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -72,20 +72,23 @@ public slots:
 
 signals:
 	void zoomLevelChanged();
+	void offsetValueChanged();
 
 protected slots:
 	void dropEvent(QDropEvent * de ) override;
 	void resizeEvent(QResizeEvent* de) override;
 	void updatePosition();
 	void updatePixelsPerBar();
+	void updateScrollBar();
 
-	int getZoom()
+	double getZoom()
 	{
-		return m_zoomingModel->value();
+		return 1 + m_zoomingModel->value() / 100.0;
 	}
 
 private:
 	IntModel* m_zoomingModel;
+	QScrollBar* m_leftRightScroll;
 
 	PatternStore* m_ps;
 	TimeLineWidget* m_timeLine;
@@ -95,6 +98,7 @@ private:
 
 private slots:
 	void zoomingChanged();
+	void horizontalScrollChanged();
 
 	friend class PatternEditorWindow;
 };
@@ -111,8 +115,10 @@ public:
 
 	double zoomLevel() const
 	{
-		return 1 + (double)m_editor->getZoom() / 100;
+		return m_editor->getZoom();
 	}
+
+	double horizontalScrollValue() const;
 
 	PatternEditor* m_editor;
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -92,6 +92,8 @@ protected slots:
 	void updateScrollBar();
 
 private:
+	void wheelEvent( QWheelEvent * we ) override;
+
 	IntModel* m_zoomingModel;
 	QScrollBar* m_leftRightScroll;
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -76,7 +76,6 @@ signals:
 	void zoomControlsVisibilityChanged( bool show );
 
 protected:
-
 	double getZoom() const
 	{
 		// The zoom level is calculated such as exactly one bar is visible when the zoom slider is at its maximum value,

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -73,6 +73,16 @@ public slots:
 signals:
 	void zoomLevelChanged();
 	void offsetValueChanged();
+	void zoomControlsVisibilityChanged( bool show );
+
+protected:
+
+	double getZoom()
+	{
+		// The zoom level is calculated such as exactly one bar is visible when the zoom slider is at its maximum value,
+		// and the whole pattern is visible when the zoom slider is at its minimum value.
+		return 1 + m_zoomingModel->value() * ( m_maxClipLength / TimePos::ticksPerBar() - 1 ) / static_cast<double>(m_zoomingModel->maxValue());
+	}
 
 protected slots:
 	void dropEvent(QDropEvent * de ) override;
@@ -80,11 +90,6 @@ protected slots:
 	void updatePosition();
 	void updatePixelsPerBar();
 	void updateScrollBar();
-
-	double getZoom()
-	{
-		return 1 + m_zoomingModel->value() / 100.0;
-	}
 
 private:
 	IntModel* m_zoomingModel;
@@ -126,9 +131,14 @@ public slots:
 	void play() override;
 	void stop() override;
 
+	void showZoomControls( bool show );
+
 private:
 	AutomatableSlider * m_zoomingSlider;
 	ComboBox* m_patternComboBox;
+
+	QAction* m_zoomIconAction;
+	QAction* m_zoomSliderAction;
 };
 
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -27,6 +27,7 @@
 
 #include "Editor.h"
 #include "TrackContainerView.h"
+#include "AutomatableModel.h"
 
 class QLabel;
 class QScrollBar;
@@ -69,11 +70,19 @@ public slots:
 	void cloneClip();
 	void updateMaxSteps();
 
+signals:
+	void zoomLevelChanged();
+
 protected slots:
 	void dropEvent(QDropEvent * de ) override;
 	void resizeEvent(QResizeEvent* de) override;
 	void updatePosition();
 	void updatePixelsPerBar();
+
+	int getZoom()
+	{
+		return m_zoomingModel->value();
+	}
 
 private:
 	IntModel* m_zoomingModel;
@@ -83,6 +92,9 @@ private:
 	int m_trackHeadWidth;
 	tick_t m_maxClipLength;
 	void makeSteps( bool clone );
+
+private slots:
+	void zoomingChanged();
 
 	friend class PatternEditorWindow;
 };
@@ -96,6 +108,11 @@ public:
 	~PatternEditorWindow() = default;
 
 	QSize sizeHint() const override;
+
+	double zoomLevel() const
+	{
+		return 1 + (double)m_editor->getZoom() / 100;
+	}
 
 	PatternEditor* m_editor;
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -28,17 +28,21 @@
 #include "Editor.h"
 #include "TrackContainerView.h"
 
+class QLabel;
+class QScrollBar;
+
 namespace lmms
 {
 
+class IntModel;
 class PatternStore;
 
 namespace gui
 {
 
+class AutomatableSlider;
 class ComboBox;
 class TimeLineWidget;
-
 
 class PatternEditor : public TrackContainerView
 {
@@ -72,11 +76,15 @@ protected slots:
 	void updatePixelsPerBar();
 
 private:
+	IntModel* m_zoomingModel;
+
 	PatternStore* m_ps;
 	TimeLineWidget* m_timeLine;
 	int m_trackHeadWidth;
 	tick_t m_maxClipLength;
 	void makeSteps( bool clone );
+
+	friend class PatternEditorWindow;
 };
 
 
@@ -96,6 +104,7 @@ public slots:
 	void stop() override;
 
 private:
+	AutomatableSlider * m_zoomingSlider;
 	ComboBox* m_patternComboBox;
 };
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -73,14 +73,15 @@ public slots:
 signals:
 	void zoomLevelChanged();
 	void offsetValueChanged();
-	void zoomControlsVisibilityChanged( bool show );
+	void zoomControlsVisibilityChanged(bool show);
 
 protected:
 	double getZoom() const
 	{
 		// The zoom level is calculated such as exactly one bar is visible when the zoom slider is at its maximum value,
 		// and the whole pattern is visible when the zoom slider is at its minimum value.
-		return 1 + m_zoomingModel->value() * ( m_maxClipLength / TimePos::ticksPerBar() - 1 ) / static_cast<double>(m_zoomingModel->maxValue());
+		return 1 + m_zoomingModel->value() * (m_maxClipLength / TimePos::ticksPerBar() - 1)
+			/ static_cast<double>(m_zoomingModel->maxValue());
 	}
 
 protected slots:
@@ -91,7 +92,7 @@ protected slots:
 	void updateScrollBar();
 
 private:
-	void wheelEvent( QWheelEvent * we ) override;
+	void wheelEvent(QWheelEvent* we) override;
 
 	IntModel* m_zoomingModel;
 	QScrollBar* m_leftRightScroll;
@@ -132,10 +133,10 @@ public slots:
 	void play() override;
 	void stop() override;
 
-	void showZoomControls( bool show );
+	void showZoomControls(bool show);
 
 private:
-	AutomatableSlider * m_zoomingSlider;
+	AutomatableSlider* m_zoomingSlider;
 	ComboBox* m_patternComboBox;
 
 	QAction* m_zoomIconAction;

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -77,7 +77,7 @@ signals:
 
 protected:
 
-	double getZoom()
+	double getZoom() const
 	{
 		// The zoom level is calculated such as exactly one bar is visible when the zoom slider is at its maximum value,
 		// and the whole pattern is visible when the zoom slider is at its minimum value.

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -121,6 +121,7 @@ ClipView::ClipView( Clip * clip,
 			this, SLOT(updateLength()));
 	connect(getGUI()->songEditor()->m_editor, &SongEditor::pixelsPerBarChanged, this, &ClipView::updateLength);
 	connect(getGUI()->patternEditor()->m_editor, &PatternEditor::zoomLevelChanged, this, &ClipView::updateLength);
+	connect(getGUI()->patternEditor()->m_editor, &PatternEditor::offsetValueChanged, this, &ClipView::updatePosition);
 	connect( m_clip, SIGNAL(positionChanged()),
 			this, SLOT(updatePosition()));
 	connect( m_clip, SIGNAL(destroyedClip()), this, SLOT(close()));
@@ -339,10 +340,17 @@ void ClipView::updateLength()
  */
 void ClipView::updatePosition()
 {
-	m_trackView->getTrackContentWidget()->changePosition();
-	// moving a Clip can result in change of song-length etc.,
-	// therefore we update the track-container
-	m_trackView->trackContainerView()->update();
+	if ( fixedClips() )
+	{
+		move( -parentWidget()->width() * getGUI()->patternEditor()->horizontalScrollValue(), 0 );
+	}
+	else
+	{	
+		m_trackView->getTrackContentWidget()->changePosition();
+		// moving a Clip can result in change of song-length etc.,
+		// therefore we update the track-container
+		m_trackView->trackContainerView()->update();
+	}
 }
 
 void ClipView::selectColor()

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -317,7 +317,7 @@ void ClipView::updateLength()
 {
 	if( fixedClips() )
 	{
-		setFixedWidth( parentWidget()->width() * getGUI()->patternEditor()->zoomLevel() );
+		setFixedWidth(parentWidget()->width() * getGUI()->patternEditor()->zoomLevel());
 	}
 	else
 	{
@@ -340,9 +340,9 @@ void ClipView::updateLength()
  */
 void ClipView::updatePosition()
 {
-	if ( fixedClips() )
+	if (fixedClips())
 	{
-		move( -parentWidget()->width() * getGUI()->patternEditor()->horizontalScrollValue(), 0 );
+		move(-parentWidget()->width() * getGUI()->patternEditor()->horizontalScrollValue(), 0);
 	}
 	else
 	{	

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -42,6 +42,7 @@
 #include "KeyboardShortcuts.h"
 #include "lmms_math.h"
 #include "MidiClipView.h"
+#include "PatternEditor.h"
 #include "PatternClip.h"
 #include "PatternStore.h"
 #include "Song.h"
@@ -119,6 +120,7 @@ ClipView::ClipView( Clip * clip,
 	connect( m_clip, SIGNAL(lengthChanged()),
 			this, SLOT(updateLength()));
 	connect(getGUI()->songEditor()->m_editor, &SongEditor::pixelsPerBarChanged, this, &ClipView::updateLength);
+	connect(getGUI()->patternEditor()->m_editor, &PatternEditor::zoomLevelChanged, this, &ClipView::updateLength);
 	connect( m_clip, SIGNAL(positionChanged()),
 			this, SLOT(updatePosition()));
 	connect( m_clip, SIGNAL(destroyedClip()), this, SLOT(close()));
@@ -314,7 +316,7 @@ void ClipView::updateLength()
 {
 	if( fixedClips() )
 	{
-		setFixedWidth( parentWidget()->width() );
+		setFixedWidth( parentWidget()->width() * getGUI()->patternEditor()->zoomLevel() );
 	}
 	else
 	{

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -823,16 +823,46 @@ void MidiClipView::paintEvent( QPaintEvent * )
 	const int lineSize = 3;
 	p.setPen( c.darker( 200 ) );
 
-	for(float t = (offset % TimePos::ticksPerBar()) * pixelsPerBar / TimePos::ticksPerBar(); t < m_clip->length(); t += pixelsPerBar)
+	if (fixedClips())
 	{
-		p.drawLine( x_base + t - 1,
+		// We don't draw the bar lines the same way in the pattern editor as the view's lenght and position are
+		// modified arbitrarily by zoom and scroll values, and the clip always start at t=0
+		const int steps = std::max(1, m_clip->m_steps);
+		const int w = width() - 2 * BORDER_WIDTH;
+
+		for (int step = TimePos::stepsPerBar(); step < steps; step += TimePos::stepsPerBar())
+		{
+			p.drawLine(
+				BORDER_WIDTH + step * w / static_cast<float>(steps),
+				BORDER_WIDTH,
+				BORDER_WIDTH + step * w / static_cast<float>(steps),
+				BORDER_WIDTH + lineSize
+			);
+			p.drawLine(
+				BORDER_WIDTH + step * w / static_cast<float>(steps),
+				rect().bottom() - (lineSize + BORDER_WIDTH),
+				BORDER_WIDTH + step * w / static_cast<float>(steps),
+				rect().bottom() - BORDER_WIDTH
+			);
+		}
+	}
+	else
+	{
+		for(float t = (offset % TimePos::ticksPerBar()) * pixelsPerBar / TimePos::ticksPerBar(); t < m_clip->length(); t += pixelsPerBar)
+		{
+			p.drawLine(
+				x_base + t - 1,
 				BORDER_WIDTH,
 				x_base + t - 1,
-				BORDER_WIDTH + lineSize );
-		p.drawLine( x_base + t - 1,
-				rect().bottom() - ( lineSize + BORDER_WIDTH ),
+				BORDER_WIDTH + lineSize
+			);
+			p.drawLine(
 				x_base + t - 1,
-				rect().bottom() - BORDER_WIDTH );
+				rect().bottom() - (lineSize + BORDER_WIDTH),
+				x_base + t - 1,
+				rect().bottom() - BORDER_WIDTH
+			);
+		}
 	}
 
 	// clip name

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -498,7 +498,8 @@ void MidiClipView::wheelEvent(QWheelEvent * we)
 	const auto pos = we->position().toPoint();
 	if(m_clip->m_clipType == MidiClip::Type::BeatClip &&
 				(fixedClips() || pixelsPerBar() >= 96) &&
-				pos.y() > height() - m_stepBtnOff.height())
+				pos.y() > height() - m_stepBtnOff.height() &&
+				!(we->modifiers() & (Qt::ControlModifier | Qt::ShiftModifier)))
 	{
 //	get the step number that was wheeled on and
 //	do calculations in floats to prevent rounding errors...

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -65,6 +65,7 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 		Engine::getSong()->getTimeline(Song::PlayMode::Pattern),
 		m_currentPosition, this
 	);
+	connect(this, &TrackContainerView::positionChanged, m_timeLine, qOverload<>(&QWidget::update));
 	connect(m_timeLine->timeline(), &Timeline::positionChanged, this, &PatternEditor::updatePosition);
 	static_cast<QVBoxLayout*>(layout())->insertWidget(0, m_timeLine);
 
@@ -75,6 +76,15 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 	m_zoomingModel->setParent(this);
 	m_zoomingModel->setJournalling(false);
 	connect(m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(zoomingChanged()));
+
+	// Set up horizontal scroll bar
+	m_leftRightScroll = new QScrollBar( Qt::Horizontal, this );
+	m_leftRightScroll->setMinimum(0);
+	m_leftRightScroll->setMaximum(0);
+	m_leftRightScroll->setSingleStep(1);
+	m_leftRightScroll->setPageStep( m_maxClipLength );
+	static_cast<QVBoxLayout *>( layout() )->addWidget( m_leftRightScroll );
+	connect(m_leftRightScroll, SIGNAL(valueChanged(int)),this, SLOT(horizontalScrollChanged()));
 
 	setFocusPolicy(Qt::StrongFocus);
 	setFocus();
@@ -216,7 +226,7 @@ void PatternEditor::updatePixelsPerBar()
 	setPixelsPerBar(m_maxClipLength != 0
 		? (width() - m_trackHeadWidth) * TimePos::ticksPerBar() / m_maxClipLength
 		: (width() - m_trackHeadWidth));
-	m_timeLine->setPixelsPerBar(pixelsPerBar() * (1 + (double)getZoom() / 100));
+	m_timeLine->setPixelsPerBar(pixelsPerBar() * getZoom());
 }
 
 void PatternEditor::updateMaxSteps()
@@ -233,6 +243,14 @@ void PatternEditor::updateMaxSteps()
 		}
 	}
 	updatePixelsPerBar();
+	updateScrollBar();
+}
+
+
+void PatternEditor::updateScrollBar()
+{
+	m_leftRightScroll->setPageStep( m_maxClipLength / getZoom() );
+	m_leftRightScroll->setMaximum( m_maxClipLength - m_leftRightScroll->pageStep() );
 }
 
 
@@ -283,11 +301,18 @@ void PatternEditor::cloneClip()
 
 void PatternEditor::zoomingChanged()
 {
-	int value = m_zoomingModel->value();
-
 	updatePixelsPerBar();
+	updateScrollBar();
 
 	emit zoomLevelChanged();
+}
+
+void PatternEditor::horizontalScrollChanged()
+{
+	m_currentPosition = TimePos( m_leftRightScroll->value() );
+	updatePosition();
+
+	emit offsetValueChanged();
 }
 
 
@@ -391,6 +416,12 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 QSize PatternEditorWindow::sizeHint() const
 {
 	return {minimumWidth() + 10, 300};
+}
+
+
+double PatternEditorWindow::horizontalScrollValue() const
+{
+	return m_editor->m_leftRightScroll->value() / static_cast<double>(m_editor->m_leftRightScroll->pageStep());
 }
 
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -25,8 +25,12 @@
 #include "PatternEditor.h"
 
 #include <QAction>
+#include <QLabel>
+#include <QScrollBar>
+#include <QSlider>
 #include <QVBoxLayout>
 
+#include "AutomatableSlider.h"
 #include "ClipView.h"
 #include "ComboBox.h"
 #include "DataFile.h"
@@ -48,6 +52,7 @@ namespace lmms::gui
 
 PatternEditor::PatternEditor(PatternStore* ps) :
 	TrackContainerView(ps),
+	m_zoomingModel(new IntModel(0, 0, 200, nullptr, tr("Zoom"))),
 	m_ps(ps),
 	m_trackHeadWidth(ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt() == 1
 		? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT
@@ -65,6 +70,10 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 
 	connect(m_ps, &PatternStore::trackUpdated,
 		this, &PatternEditor::updateMaxSteps);
+
+	// Set up zooming model
+	m_zoomingModel->setParent(this);
+	m_zoomingModel->setJournalling(false);
 
 	setFocusPolicy(Qt::StrongFocus);
 	setFocus();
@@ -327,6 +336,22 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	trackAndStepActionsToolBar->addWidget(stretch);
 
+	auto zoom_lbl = new QLabel(m_toolBar);
+	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
+
+	// Set slider zoom
+	m_zoomingSlider = new AutomatableSlider(m_toolBar, tr("Zoom"));
+	m_zoomingSlider->setModel(m_editor->m_zoomingModel);
+	m_zoomingSlider->setOrientation(Qt::Horizontal);
+	m_zoomingSlider->setPageStep(1);
+	m_zoomingSlider->setFocusPolicy(Qt::NoFocus);
+	m_zoomingSlider->setFixedSize(100, 26);
+	m_zoomingSlider->setToolTip(tr("Zoom"));
+	m_zoomingSlider->setContextMenuPolicy(Qt::NoContextMenu);
+	connect(m_editor->m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(updateSnapLabel()));
+
+	trackAndStepActionsToolBar->addWidget(zoom_lbl);
+	trackAndStepActionsToolBar->addWidget(m_zoomingSlider);
 
 	// Step actions
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("step_btn_remove"), tr("Remove steps"),

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -393,7 +393,6 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	m_zoomingSlider->setFixedSize(100, 26);
 	m_zoomingSlider->setToolTip(tr("Zoom"));
 	m_zoomingSlider->setContextMenuPolicy(Qt::NoContextMenu);
-	connect(m_editor->m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(updateSnapLabel()));
 	connect(m_editor, &PatternEditor::zoomControlsVisibilityChanged, this, &PatternEditorWindow::showZoomControls);
 
 	m_zoomIconAction =  trackAndStepActionsToolBar->addWidget(zoom_lbl);

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -52,7 +52,7 @@ namespace lmms::gui
 
 PatternEditor::PatternEditor(PatternStore* ps) :
 	TrackContainerView(ps),
-	m_zoomingModel(new IntModel(0, 0, 200, nullptr, tr("Zoom"))),
+	m_zoomingModel(new IntModel(0, 0, 100, nullptr, tr("Zoom"))),
 	m_ps(ps),
 	m_trackHeadWidth(ConfigManager::inst()->value("ui", "compacttrackbuttons").toInt() == 1
 		? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT + TRACK_OP_WIDTH_COMPACT
@@ -260,6 +260,30 @@ void PatternEditor::updateScrollBar()
 {
 	m_leftRightScroll->setPageStep( m_maxClipLength / getZoom() );
 	m_leftRightScroll->setMaximum( m_maxClipLength - m_leftRightScroll->pageStep() );
+}
+
+
+void PatternEditor::wheelEvent( QWheelEvent * we )
+{
+	const auto posX = we->position().toPoint().x();
+	if ((we->modifiers() & Qt::ControlModifier) && (posX > m_trackHeadWidth))
+	{
+		// move zoom slider (pixelsPerBar will change automatically)
+		int step = we->modifiers() & Qt::ShiftModifier ? 1 : 5;
+		// when Alt is pressed, wheelEvent returns delta for x coordinate (mimics horizontal mouse wheel)
+		int direction = (we->angleDelta().y() + we->angleDelta().x()) > 0 ? 1 : -1;
+		m_zoomingModel->incValue(step * direction);
+	}
+	else if (we->modifiers() & Qt::ShiftModifier)
+	{
+		m_leftRightScroll->setValue( m_leftRightScroll->value() - we->angleDelta().y() );
+	}
+	else
+	{
+		we->ignore();
+		return;
+	}
+	we->accept();
 }
 
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -266,7 +266,7 @@ void PatternEditor::updateScrollBar()
 void PatternEditor::wheelEvent(QWheelEvent* we)
 {
 	const auto posX = we->position().toPoint().x();
-	if ((we->modifiers() & Qt::ControlModifier) && (posX > m_trackHeadWidth))
+	if ((we->modifiers() & Qt::ControlModifier) && (posX > m_trackHeadWidth) && !Engine::getSong()->isPlaying())
 	{
 		// move zoom slider (pixelsPerBar will change automatically)
 		int step = we->modifiers() & Qt::ShiftModifier ? 1 : 5;

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -244,6 +244,9 @@ void PatternEditor::updateMaxSteps()
 	}
 	updatePixelsPerBar();
 	updateScrollBar();
+
+	// Show zoom controls if the pattern is longer than one bar, hide them otherwise as they would have no effect anyway
+	emit zoomControlsVisibilityChanged( m_maxClipLength / TimePos::ticksPerBar() > 1 );
 }
 
 
@@ -372,7 +375,7 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	trackAndStepActionsToolBar->addWidget(stretch);
 
-	auto zoom_lbl = new QLabel(m_toolBar);
+	QLabel* zoom_lbl = new QLabel(m_toolBar);
 	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
 
 	// Set slider zoom
@@ -385,9 +388,11 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	m_zoomingSlider->setToolTip(tr("Zoom"));
 	m_zoomingSlider->setContextMenuPolicy(Qt::NoContextMenu);
 	connect(m_editor->m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(updateSnapLabel()));
+	connect(m_editor, &PatternEditor::zoomControlsVisibilityChanged, this, &PatternEditorWindow::showZoomControls);
 
-	trackAndStepActionsToolBar->addWidget(zoom_lbl);
-	trackAndStepActionsToolBar->addWidget(m_zoomingSlider);
+	m_zoomIconAction =  trackAndStepActionsToolBar->addWidget(zoom_lbl);
+	m_zoomSliderAction = trackAndStepActionsToolBar->addWidget(m_zoomingSlider);
+	showZoomControls( false );
 
 	// Step actions
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("step_btn_remove"), tr("Remove steps"),
@@ -441,6 +446,13 @@ void PatternEditorWindow::play()
 void PatternEditorWindow::stop()
 {
 	Engine::getSong()->stop();
+}
+
+
+void PatternEditorWindow::showZoomControls( bool show )
+{
+	m_zoomIconAction->setVisible( show );
+	m_zoomSliderAction->setVisible( show );
 }
 
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -80,17 +80,17 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 	connect(Engine::getSong(), &Song::stopped, this, [this]()
 	{
 		// Show zoom controls again as they are hidden during playback
-		emit zoomControlsVisibilityChanged( m_maxClipLength / TimePos::ticksPerBar() > 1 );
+		emit zoomControlsVisibilityChanged(m_maxClipLength / TimePos::ticksPerBar() > 1);
 	});
 
 	// Set up horizontal scroll bar
-	m_leftRightScroll = new QScrollBar( Qt::Horizontal, this );
+	m_leftRightScroll = new QScrollBar(Qt::Horizontal, this);
 	m_leftRightScroll->setMinimum(0);
 	m_leftRightScroll->setMaximum(0);
 	m_leftRightScroll->setSingleStep(1);
-	m_leftRightScroll->setPageStep( m_maxClipLength );
-	static_cast<QVBoxLayout *>( layout() )->addWidget( m_leftRightScroll );
-	connect(m_leftRightScroll, SIGNAL(valueChanged(int)),this, SLOT(horizontalScrollChanged()));
+	m_leftRightScroll->setPageStep(m_maxClipLength);
+	static_cast<QVBoxLayout*>(layout())->addWidget(m_leftRightScroll);
+	connect(m_leftRightScroll, SIGNAL(valueChanged(int)), this, SLOT(horizontalScrollChanged()));
 
 	setFocusPolicy(Qt::StrongFocus);
 	setFocus();
@@ -252,18 +252,18 @@ void PatternEditor::updateMaxSteps()
 	updateScrollBar();
 
 	// Show zoom controls if the pattern is longer than one bar, hide them otherwise as they would have no effect anyway
-	emit zoomControlsVisibilityChanged( m_maxClipLength / TimePos::ticksPerBar() > 1 );
+	emit zoomControlsVisibilityChanged(m_maxClipLength / TimePos::ticksPerBar() > 1);
 }
 
 
 void PatternEditor::updateScrollBar()
 {
-	m_leftRightScroll->setPageStep( m_maxClipLength / getZoom() );
-	m_leftRightScroll->setMaximum( m_maxClipLength - m_leftRightScroll->pageStep() );
+	m_leftRightScroll->setPageStep(m_maxClipLength / getZoom());
+	m_leftRightScroll->setMaximum(m_maxClipLength - m_leftRightScroll->pageStep());
 }
 
 
-void PatternEditor::wheelEvent( QWheelEvent * we )
+void PatternEditor::wheelEvent(QWheelEvent* we)
 {
 	const auto posX = we->position().toPoint().x();
 	if ((we->modifiers() & Qt::ControlModifier) && (posX > m_trackHeadWidth))
@@ -276,7 +276,7 @@ void PatternEditor::wheelEvent( QWheelEvent * we )
 	}
 	else if (we->modifiers() & Qt::ShiftModifier)
 	{
-		m_leftRightScroll->setValue( m_leftRightScroll->value() - we->angleDelta().y() );
+		m_leftRightScroll->setValue(m_leftRightScroll->value() - we->angleDelta().y());
 	}
 	else
 	{
@@ -342,7 +342,7 @@ void PatternEditor::zoomingChanged()
 
 void PatternEditor::horizontalScrollChanged()
 {
-	m_currentPosition = TimePos( m_leftRightScroll->value() );
+	m_currentPosition = TimePos(m_leftRightScroll->value());
 	updatePosition();
 
 	emit offsetValueChanged();
@@ -406,7 +406,7 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 	trackAndStepActionsToolBar->addWidget(stretch);
 
 	QLabel* zoom_lbl = new QLabel(m_toolBar);
-	zoom_lbl->setPixmap( embed::getIconPixmap( "zoom" ) );
+	zoom_lbl->setPixmap(embed::getIconPixmap("zoom"));
 
 	// Set slider zoom
 	m_zoomingSlider = new AutomatableSlider(m_toolBar, tr("Zoom"));
@@ -461,7 +461,7 @@ double PatternEditorWindow::horizontalScrollValue() const
 
 void PatternEditorWindow::play()
 {
-	showZoomControls( false );
+	showZoomControls(false);
 
 	if (Engine::getSong()->playMode() != Song::PlayMode::Pattern)
 	{
@@ -471,9 +471,9 @@ void PatternEditorWindow::play()
 	else
 	{
 		Engine::getSong()->togglePause();
-		if ( Engine::getSong()->isPaused())
+		if (Engine::getSong()->isPaused())
 		{
-			showZoomControls( true );
+			showZoomControls(true);
 		}
 	}
 }
@@ -485,12 +485,12 @@ void PatternEditorWindow::stop()
 }
 
 
-void PatternEditorWindow::showZoomControls( bool show )
+void PatternEditorWindow::showZoomControls(bool show)
 {
-	if ( !Engine::getSong()->isPlaying() )
+	if (!Engine::getSong()->isPlaying())
 	{
-		m_zoomIconAction->setVisible( show );
-		m_zoomSliderAction->setVisible( show );
+		m_zoomIconAction->setVisible(show);
+		m_zoomSliderAction->setVisible(show);
 	}
 }
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -77,6 +77,12 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 	m_zoomingModel->setJournalling(false);
 	connect(m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(zoomingChanged()));
 
+	connect(Engine::getSong(), &Song::stopped, this, [this]()
+	{
+		// Show zoom controls again as they are hidden during playback
+		emit zoomControlsVisibilityChanged( m_maxClipLength / TimePos::ticksPerBar() > 1 );
+	});
+
 	// Set up horizontal scroll bar
 	m_leftRightScroll = new QScrollBar( Qt::Horizontal, this );
 	m_leftRightScroll->setMinimum(0);
@@ -432,13 +438,20 @@ double PatternEditorWindow::horizontalScrollValue() const
 
 void PatternEditorWindow::play()
 {
+	showZoomControls( false );
+
 	if (Engine::getSong()->playMode() != Song::PlayMode::Pattern)
 	{
+		m_zoomingSlider->setValue(0);
 		Engine::getSong()->playPattern();
 	}
 	else
 	{
 		Engine::getSong()->togglePause();
+		if ( Engine::getSong()->isPaused())
+		{
+			showZoomControls( true );
+		}
 	}
 }
 
@@ -451,8 +464,11 @@ void PatternEditorWindow::stop()
 
 void PatternEditorWindow::showZoomControls( bool show )
 {
-	m_zoomIconAction->setVisible( show );
-	m_zoomSliderAction->setVisible( show );
+	if ( !Engine::getSong()->isPlaying() )
+	{
+		m_zoomIconAction->setVisible( show );
+		m_zoomSliderAction->setVisible( show );
+	}
 }
 
 

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -74,6 +74,7 @@ PatternEditor::PatternEditor(PatternStore* ps) :
 	// Set up zooming model
 	m_zoomingModel->setParent(this);
 	m_zoomingModel->setJournalling(false);
+	connect(m_zoomingModel, SIGNAL(dataChanged()), this, SLOT(zoomingChanged()));
 
 	setFocusPolicy(Qt::StrongFocus);
 	setFocus();
@@ -215,7 +216,7 @@ void PatternEditor::updatePixelsPerBar()
 	setPixelsPerBar(m_maxClipLength != 0
 		? (width() - m_trackHeadWidth) * TimePos::ticksPerBar() / m_maxClipLength
 		: (width() - m_trackHeadWidth));
-	m_timeLine->setPixelsPerBar(pixelsPerBar());
+	m_timeLine->setPixelsPerBar(pixelsPerBar() * (1 + (double)getZoom() / 100));
 }
 
 void PatternEditor::updateMaxSteps()
@@ -277,6 +278,16 @@ void PatternEditor::cloneClip()
 		newTrack->deleteClips();
 		newTrack->unlock();
 	}
+}
+
+
+void PatternEditor::zoomingChanged()
+{
+	int value = m_zoomingModel->value();
+
+	updatePixelsPerBar();
+
+	emit zoomLevelChanged();
 }
 
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -241,7 +241,6 @@ void TrackContentWidget::changePosition( const TimePos & newPos )
 		{
 			if (clipView->getClip()->startPosition().getBar() == curPattern)
 			{
-				clipView->move(0, clipView->y());
 				clipView->raise();
 				clipView->show();
 			}


### PR DESCRIPTION
closes #7313 

Add a zoom slider and an horizontal scroll bar in the pattern editor window, to make the editing of lengthy patterns easier in a small window.
<img width="764" height="251" alt="image" src="https://github.com/user-attachments/assets/f95f1eff-95a7-4b34-90c4-f3338ca4f598" />

During playback, the zoom level is set to 1 and the zoom controls are hidden. I made it this way for the sake of simplicity, but it can be changed latter if someone is courageous enough to dig deeper than I did.

To test this PR, simply open a pattern at least 2 bars long in the pattern editor.