### PR TITLE
Fix "Send to new SlicerT instance" not sending to Pattern Editor

### DIFF
--- a/include/FileBrowser.h
+++ b/include/FileBrowser.h
@@ -176,7 +176,7 @@ private slots:
 	void activateListItem(QTreeWidgetItem* item, int column);
 	void openInNewInstrumentTrack(FileItem* item, bool songEditor);
 	bool openInNewSampleTrack(FileItem* item);
-	void openInSlicerT(FileItem* item);
+	void openInSlicerT(FileItem* item, bool songEditor);
 	void sendToActiveInstrumentTrack(FileItem* item);
 	void updateDirectory(QTreeWidgetItem* item);
 } ;

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -700,10 +700,10 @@ void FileBrowserTreeWidget::openInSlicerT(FileItem* item, bool songEditor)
 {
 	// Get the right TrackContainer. Ternary doesn't compile due to a type mismatch
 	// (similar to FileBrowserTreeWidget::openInNewInstrumentTrack)
-    TrackContainer* tc = Engine::getSong();
+	TrackContainer* tc = Engine::getSong();
 	if (!songEditor) { tc = Engine::patternStore(); }
 
-    auto* track = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, tc));
+	auto* track = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, tc));
 
 	track->loadInstrument("slicert");
 	track->instrument()->loadFile(item->fullName());

--- a/src/gui/FileBrowser.cpp
+++ b/src/gui/FileBrowser.cpp
@@ -696,9 +696,12 @@ void FileBrowserTreeWidget::contextMenuEvent(QContextMenuEvent* e)
 	if (!contextMenu.isEmpty()) { contextMenu.exec(e->globalPos()); }
 }
 
-void FileBrowserTreeWidget::openInSlicerT(FileItem* item)
+void FileBrowserTreeWidget::openInSlicerT(FileItem* item, bool songEditor)
 {
+	// Get the right TrackContainer. Ternary doesn't compile due to a type mismatch
+	// (similar to FileBrowserTreeWidget::openInNewInstrumentTrack)
     TrackContainer* tc = Engine::getSong();
+	if (!songEditor) { tc = Engine::patternStore(); }
 
     auto* track = dynamic_cast<InstrumentTrack*>(Track::create(Track::Type::Instrument, tc));
 
@@ -733,7 +736,7 @@ QList<QAction*> FileBrowserTreeWidget::getContextActions(FileItem* file, bool so
 	{
 		auto openInSlicer = new QAction(tr("Send to new SlicerT instance"));
 		connect(openInSlicer, &QAction::triggered,
-			[=, this]{ openInSlicerT(file); });
+			[=, this]{ openInSlicerT(file, songEditor); });
 		result.append(openInSlicer);
 	}
 


### PR DESCRIPTION
Currently, right-clicking on a sample in the sidebar and clicking "Send to new SlicerT instance" under the Pattern Editor section will always create the instance in the Song Editor, rather than the Pattern Editor like it suggests. This PR fixes this.