### PR TITLE
Scroll mixer horizontally when moving channel out of view with arrow keys

### DIFF
--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -55,6 +55,7 @@ class LMMS_EXPORT MixerView
 public:
 	MixerView(Mixer* mixer);
 	void keyPressEvent(QKeyEvent* e) override;
+	void wheelEvent(QWheelEvent* e) override;
 
 	void saveSettings(QDomDocument& doc, QDomElement& domElement) override;
 	void loadSettings(const QDomElement& domElement) override;

--- a/include/MixerView.h
+++ b/include/MixerView.h
@@ -25,6 +25,7 @@
 #ifndef LMMS_GUI_MIXER_VIEW_H
 #define LMMS_GUI_MIXER_VIEW_H
 
+#include <QScrollBar>
 #include <QWidget>
 
 #include "MixerChannelView.h"
@@ -119,6 +120,7 @@ private:
 	QScrollArea* channelArea;
 	QHBoxLayout* chLayout;
 	QWidget* m_channelAreaWidget;
+	QScrollBar* m_channelAreaScrollBar;
 	QStackedLayout* m_racksLayout;
 	QWidget* m_racksWidget;
 	Mixer* m_mixer;

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -134,6 +134,7 @@ MixerView::MixerView(Mixer* mixer) :
 	channelArea->setFrameStyle(QFrame::NoFrame);
 	channelArea->setMinimumWidth(mixerChannelSize.width() * 6);
 	channelArea->setWidgetResizable(true);
+	m_channelAreaScrollBar = channelArea->horizontalScrollBar();
 
 	int const scrollBarExtent = style()->pixelMetric(QStyle::PM_ScrollBarExtent);
 	channelArea->setMinimumHeight(mixerChannelSize.height() + scrollBarExtent);
@@ -478,6 +479,8 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 		}
 	};
 
+	int overflow;
+
 	switch(e->key())
 	{
 		case Qt::Key_Delete:
@@ -493,6 +496,11 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 				// select channel to the left
 				setCurrentMixerChannel(m_currentMixerChannel->channelIndex() - 1);
 			}
+			if ( ( overflow = m_channelAreaScrollBar->value() - m_currentMixerChannel->x() ) > 0 )
+			{
+				// scroll to the left if the current channel is going out of view
+				m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() - overflow );
+			}
 			break;
 		case Qt::Key_Right:
 			if (e->modifiers() & Qt::AltModifier)
@@ -503,6 +511,11 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 			{
 				// select channel to the right
 				setCurrentMixerChannel(m_currentMixerChannel->channelIndex() + 1);
+			}
+			if ( ( overflow = m_currentMixerChannel->x() + m_currentMixerChannel->width() - m_channelAreaScrollBar->value() - m_channelAreaScrollBar->pageStep() ) > 0 )
+			{
+				// scroll to the right if the current channel is going out of view
+				m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() + overflow );
 			}
 			break;
 		case Qt::Key_Up:

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -545,6 +545,23 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 
 
 
+void MixerView::wheelEvent(QWheelEvent* e)
+{
+	if (e->modifiers() & Qt::ShiftModifier)
+	{
+		if ( e->angleDelta().y() > 0 )
+		{
+			m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() - m_currentMixerChannel->width() );
+		}
+		else
+		{
+			m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() + m_currentMixerChannel->width() );
+		}
+	}
+}
+
+
+
 void MixerView::setCurrentMixerChannel(int channel)
 {
 	if (channel >= 0 && channel < m_mixerChannelViews.size())

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -512,10 +512,10 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 				// select channel to the right
 				setCurrentMixerChannel(m_currentMixerChannel->channelIndex() + 1);
 			}
-			if ( ( overflow = m_currentMixerChannel->x() + m_currentMixerChannel->width() - m_channelAreaScrollBar->value() - m_channelAreaScrollBar->pageStep() ) > 0 )
+			if ((overflow = m_currentMixerChannel->x() + m_currentMixerChannel->width() - m_channelAreaScrollBar->value() - m_channelAreaScrollBar->pageStep()) > 0)
 			{
 				// scroll to the right if the current channel is going out of view
-				m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() + overflow );
+				m_channelAreaScrollBar->setValue(m_channelAreaScrollBar->value() + overflow);
 			}
 			break;
 		case Qt::Key_Up:

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -496,10 +496,10 @@ void MixerView::keyPressEvent(QKeyEvent * e)
 				// select channel to the left
 				setCurrentMixerChannel(m_currentMixerChannel->channelIndex() - 1);
 			}
-			if ( ( overflow = m_channelAreaScrollBar->value() - m_currentMixerChannel->x() ) > 0 )
+			if ((overflow = m_channelAreaScrollBar->value() - m_currentMixerChannel->x()) > 0)
 			{
 				// scroll to the left if the current channel is going out of view
-				m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() - overflow );
+				m_channelAreaScrollBar->setValue(m_channelAreaScrollBar->value() - overflow);
 			}
 			break;
 		case Qt::Key_Right:

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -549,13 +549,13 @@ void MixerView::wheelEvent(QWheelEvent* e)
 {
 	if (e->modifiers() & Qt::ShiftModifier)
 	{
-		if ( e->angleDelta().y() > 0 )
+		if (e->angleDelta().y() > 0)
 		{
-			m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() - m_currentMixerChannel->width() );
+			m_channelAreaScrollBar->setValue(m_channelAreaScrollBar->value() - m_currentMixerChannel->width());
 		}
 		else
 		{
-			m_channelAreaScrollBar->setValue( m_channelAreaScrollBar->value() + m_currentMixerChannel->width() );
+			m_channelAreaScrollBar->setValue(m_channelAreaScrollBar->value() + m_currentMixerChannel->width());
 		}
 	}
 }


### PR DESCRIPTION
closes #8345 

While at it, I also added tied horizontal scroll to mouse wheel + shift event.

Here is a short clip demonstrating the changes :


https://github.com/user-attachments/assets/e6d4ab0a-9ade-4222-9635-892e0f14f4aa



