### PR TITLE
Remove unused volume model in `SamplePlayHandle`

### DIFF
--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -74,12 +74,12 @@ public:
 
 private:
 	Sample::PlaybackState m_state;
-	f_cnt_t m_frame;
-	Sample* m_sample;
-	Track * m_track;
-	PatternTrack* m_patternTrack;
-	bool m_doneMayReturnTrue;
-	bool m_ownAudioBusHandle;
+	f_cnt_t m_frame = 0;
+	Sample* m_sample = nullptr;
+	Track* m_track = nullptr;
+	PatternTrack* m_patternTrack = nullptr;
+	bool m_doneMayReturnTrue = true;
+	bool m_ownAudioBusHandle = false;
 } ;
 
 

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -27,7 +27,6 @@
 #define LMMS_SAMPLE_PLAY_HANDLE_H
 
 #include "Sample.h"
-#include "AutomatableModel.h"
 #include "PlayHandle.h"
 
 namespace lmms
@@ -73,27 +72,14 @@ public:
 		m_patternTrack = pt;
 	}
 
-	void setVolumeModel( FloatModel * _model )
-	{
-		m_volumeModel = _model;
-	}
-
-
 private:
-	Sample* m_sample;
-	bool m_doneMayReturnTrue;
-
-	f_cnt_t m_frame;
 	Sample::PlaybackState m_state;
-
-	const bool m_ownAudioBusHandle;
-
-	FloatModel m_defaultVolumeModel;
-	FloatModel * m_volumeModel;
+	f_cnt_t m_frame;
+	Sample* m_sample;
 	Track * m_track;
-
 	PatternTrack* m_patternTrack;
-
+	bool m_doneMayReturnTrue;
+	bool m_ownAudioBusHandle;
 } ;
 
 

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -26,7 +26,6 @@
 #include "AudioEngine.h"
 #include "AudioBusHandle.h"
 #include "Engine.h"
-#include "Note.h"
 #include "PatternTrack.h"
 #include "SampleClip.h"
 #include "SampleTrack.h"
@@ -37,14 +36,12 @@ namespace lmms
 
 SamplePlayHandle::SamplePlayHandle(Sample* sample, bool ownAudioBusHandle) :
 	PlayHandle(Type::SamplePlayHandle),
-	m_sample(sample),
-	m_doneMayReturnTrue(true),
 	m_frame(0),
-	m_ownAudioBusHandle(ownAudioBusHandle),
-	m_defaultVolumeModel(DefaultVolume, MinVolume, MaxVolume, 1),
-	m_volumeModel(&m_defaultVolumeModel),
+	m_sample(sample),
 	m_track(nullptr),
-	m_patternTrack(nullptr)
+	m_patternTrack(nullptr),
+	m_doneMayReturnTrue(true),
+	m_ownAudioBusHandle(ownAudioBusHandle)
 {
 	if (ownAudioBusHandle)
 	{

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -33,15 +33,10 @@
 namespace lmms
 {
 
-
-SamplePlayHandle::SamplePlayHandle(Sample* sample, bool ownAudioBusHandle) :
-	PlayHandle(Type::SamplePlayHandle),
-	m_frame(0),
-	m_sample(sample),
-	m_track(nullptr),
-	m_patternTrack(nullptr),
-	m_doneMayReturnTrue(true),
-	m_ownAudioBusHandle(ownAudioBusHandle)
+SamplePlayHandle::SamplePlayHandle(Sample* sample, bool ownAudioBusHandle)
+	: PlayHandle(Type::SamplePlayHandle)
+	, m_sample(sample)
+	, m_ownAudioBusHandle(ownAudioBusHandle)
 {
 	if (ownAudioBusHandle)
 	{

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -152,7 +152,6 @@ bool SampleTrack::play( const TimePos & _start, const f_cnt_t _frames,
 			else
 			{
 				auto smpHandle = new SamplePlayHandle(st);
-				smpHandle->setVolumeModel( &m_volumeModel );
 				smpHandle->setPatternTrack(pattern_track);
 				handle = smpHandle;
 			}


### PR DESCRIPTION
Removes the unused volume model in `SamplePlayHandle`, as allocating this was causing performance issues under extreme conditions (see #8348). Profiling showed a performance bottleneck in `lmms::ProjectJournal::allocID`, which creates a new journaling ID for the model.

```cpp
jo_id_t ProjectJournal::allocID(JournallingObject* obj)
{
	jo_id_t id;
	for (jo_id_t tid = fastRand(); m_joIDs.contains(id = tid % EO_ID_MSB | EO_ID_MSB); tid++) {}
	m_joIDs[id] = obj;
	return id;
}
```
Given that this was called so rapidly, its likely that the map filled very quickly (`fastRand` only has a range of 32,767 values) and over time, `tid` kept incrementing for longer and longer periods of time, taking up CPU cycles.

Here is the backtrace as well:
```bash
Thread 4 (Thread 0x7f4357fff6c0 (LWP 172461) "SDLAudioP15"):
#0  0x000055989de4889b in lmms::ProjectJournal::allocID(lmms::JournallingObject*) ()
#1  0x000055989de19532 in lmms::JournallingObject::JournallingObject() ()
#2  0x000055989ddbd386 in lmms::AutomatableModel::AutomatableModel(float, float, float, float, lmms::Model*, QString const&, bool) ()
#3  0x000055989de58bc2 in lmms::SamplePlayHandle::SamplePlayHandle(lmms::Sample*, bool) ()
#4  0x000055989de58d9b in lmms::SamplePlayHandle::SamplePlayHandle(QString const&) ()
#5  0x000055989de27a4d in lmms::Metronome::processTick(int, int, int, unsigned long) ()
#6  0x000055989de5e124 in lmms::Song::processMetronome(unsigned long) ()
#7  0x000055989de5d8c1 in lmms::Song::processNextBuffer() ()
#8  0x000055989ddba3b7 in lmms::AudioEngine::renderStageNoteSetup() ()
#9  0x000055989ddbad66 in lmms::AudioEngine::renderNextPeriod() ()
#10 0x000055989de73f4e in _ZN4lmms11AudioEngine16renderNextBufferITkNS_15AudioBufferViewIfEENS_21InterleavedBufferViewIfLt65535EEEEEvT_ ()
#11 0x000055989de83140 in lmms::AudioSdl::sdlAudioCallback(void*, unsigned char*, int) ()
```

Couple of points:
1. There are still performance issues because rapid allocations of `SamplePlayHandle` objects (when not allocated from a `SampleClip*` but a path to a sample) lead to decoding the audio file repetitively on the audio thread. This problem is currently only seen with the metronome (and theoretically also tap tempo).
2. At some point we still may need to figure out a design if we want to control the volume from the `SamplePlayHandle` object directly without performance headaches. Currently, we can't and don't do that anyways (e.g., clips and their volume are handled via `AudioBusHandle`, which has a pointer to the volume model contained within the track) so this unused volume model was causing more problems than anything else.
3. I'm not focusing on the allocations of the voice objects themselves, since this is more of an issue with the overall design of the audio engine, which allocates the handles on demand. Eventually, we will use some kind of voice pool for these allocations.

Fixes #8348.