### PR TITLE
Allocate metronome sounds only once

### DIFF
--- a/include/Metronome.h
+++ b/include/Metronome.h
@@ -31,9 +31,11 @@ namespace lmms {
 class Metronome
 {
 public:
+	Metronome(bool active = false);
+
 	bool active() const { return m_active; }
 	void setActive(bool active) { m_active = active; }
-	void processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset);
+	void processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset = 0);
 
 private:
 	bool m_active = false;

--- a/include/SamplePlayHandle.h
+++ b/include/SamplePlayHandle.h
@@ -43,7 +43,6 @@ class LMMS_EXPORT SamplePlayHandle : public PlayHandle
 {
 public:
 	SamplePlayHandle(Sample* sample, bool ownAudioBusHandle = true);
-	SamplePlayHandle( const QString& sampleFile );
 	SamplePlayHandle( SampleClip* clip );
 	~SamplePlayHandle() override;
 

--- a/include/TimePos.h
+++ b/include/TimePos.h
@@ -96,7 +96,6 @@ public:
 
 	operator int() const { return m_ticks; }
 
-	tick_t ticksPerBeat(const TimeSig& sig) const { return ticksPerBar(sig) / sig.numerator(); }
 
 	// Remainder ticks after bar is removed
 	tick_t getTickWithinBar(const TimeSig& sig) const { return m_ticks % ticksPerBar(sig); }
@@ -124,6 +123,7 @@ public:
 		return TimePos(static_cast<int>(frames / framesPerTick));
 	}
 
+	static tick_t ticksPerBeat(const TimeSig& sig) { return ticksPerBar(sig) / sig.numerator(); }
 	static tick_t ticksPerBar() { return s_ticksPerBar; }
 	static tick_t ticksPerBar(const TimeSig& sig) { return DefaultTicksPerBar * sig.numerator() / sig.denominator(); }
 

--- a/plugins/TapTempo/TapTempo.cpp
+++ b/plugins/TapTempo/TapTempo.cpp
@@ -26,7 +26,6 @@
 
 #include <string>
 
-#include "SamplePlayHandle.h"
 #include "Song.h"
 #include "embed.h"
 #include "plugin_export.h"
@@ -46,6 +45,7 @@ PLUGIN_EXPORT Plugin* lmms_plugin_main(Model*, void*)
 
 TapTempo::TapTempo()
 	: ToolPlugin(&taptempo_plugin_descriptor, nullptr)
+	, m_intervals({})
 {
 	m_intervals.fill(std::chrono::milliseconds::zero());
 }
@@ -54,13 +54,15 @@ void TapTempo::tap(bool play)
 {
 	using namespace std::literals;
 
+	const auto& timeSig = Engine::getSong()->getTimeSigModel();
+
 	if (play)
 	{
-		const auto metronomeFile = m_beat == 0 ? "misc/metronome02.ogg" : "misc/metronome01.ogg";
-		Engine::audioEngine()->addPlayHandle(new SamplePlayHandle(metronomeFile));
+		const auto currentTick = m_beat * TimePos::ticksPerBeat(timeSig);
+		m_metronome.processTick(currentTick, TimePos::ticksPerBar(timeSig), timeSig.getNumerator());
 	}
 
-	m_beat = (m_beat + 1) % Engine::getSong()->getTimeSigModel().getNumerator();
+	m_beat = (m_beat + 1) % timeSig.getNumerator();
 
 	if (m_lastTap.time_since_epoch() == 0ms)
 	{

--- a/plugins/TapTempo/TapTempo.h
+++ b/plugins/TapTempo/TapTempo.h
@@ -27,6 +27,7 @@
 
 #include <chrono>
 
+#include "Metronome.h"
 #include "TapTempoView.h"
 #include "ToolPlugin.h"
 
@@ -50,6 +51,7 @@ public:
 
 private:
 	static constexpr auto MaxIntervals = 3;
+	Metronome m_metronome{true};
 	using clock = std::chrono::steady_clock;
 	std::chrono::time_point<clock> m_lastTap;
 	std::array<std::chrono::milliseconds, MaxIntervals> m_intervals;

--- a/src/core/Metronome.cpp
+++ b/src/core/Metronome.cpp
@@ -28,13 +28,25 @@
 #include "SamplePlayHandle.h"
 
 namespace lmms {
+Metronome::Metronome(bool active)
+	: m_active(active)
+{
+}
+
 void Metronome::processTick(int currentTick, int ticksPerBar, int beatsPerBar, size_t bufferOffset)
 {
+	// Normally, these would be allocated outside of the processTick entirely, but because of some Qt shenanigans likely
+	// related to PathUtil and the error handling in fromFile (error in console was
+	// "QCoreApplication::applicationDirPath: Please instantiate the QApplication object first"), we have do it in here
+	// for now
+	static auto s_metronomeStrong = SampleBuffer::fromFile("misc/metronome02.ogg");
+	static auto s_metronomeWeak = SampleBuffer::fromFile("misc/metronome01.ogg");
+
 	const auto ticksPerBeat = ticksPerBar / beatsPerBar;
 	if (currentTick % ticksPerBeat != 0 || !m_active) { return; }
 
-	const auto handle = currentTick % ticksPerBar == 0 ? new SamplePlayHandle("misc/metronome02.ogg")
-													   : new SamplePlayHandle("misc/metronome01.ogg");
+	const auto handle = currentTick % ticksPerBar == 0 ? new SamplePlayHandle{new Sample{s_metronomeStrong}}
+													   : new SamplePlayHandle{new Sample{s_metronomeWeak}};
 	handle->setOffset(bufferOffset);
 	Engine::audioEngine()->addPlayHandle(handle);
 }

--- a/src/core/SamplePlayHandle.cpp
+++ b/src/core/SamplePlayHandle.cpp
@@ -52,17 +52,6 @@ SamplePlayHandle::SamplePlayHandle(Sample* sample, bool ownAudioBusHandle) :
 	}
 }
 
-
-
-
-SamplePlayHandle::SamplePlayHandle( const QString& sampleFile ) :
-	SamplePlayHandle(new Sample(SampleBuffer::fromFile(sampleFile)), true)
-{
-}
-
-
-
-
 SamplePlayHandle::SamplePlayHandle( SampleClip* clip ) :
 	SamplePlayHandle(&clip->sample(), false)
 {


### PR DESCRIPTION
Allocates and reads the metronome sounds `misc/metronome01.ogg` and `misc/metronome02.ogg` out to `SampleBuffer` objects only once, improving the performance when playing these sounds with the metronome or the Tap Tempo plugin.