### PR TITLE
Fix: Escape HTML in effect author names to show email addresses

### DIFF
--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -280,7 +280,8 @@ void EffectSelectDialog::rowChanged(const QModelIndex& idx, const QModelIndex&)
 			auto label = new QLabel(m_descriptionWidget);
 			QString labelText = "<p><b>" + tr("Name") + ":</b> " + QString::fromUtf8(descriptor.displayName) + "</p>";
 			labelText += "<p><b>" + tr("Description") + ":</b> " + qApp->translate("PluginBrowser", descriptor.description) + "</p>";
-			labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author) + "</p>";
+			labelText += "<p><b>" + tr("Author") + ":</b> " + QString::fromUtf8(descriptor.author).toHtmlEscaped() + "</p>";
+
 
 			label->setText(labelText);
 			label->setWordWrap(true);


### PR DESCRIPTION
 **Summary**
Fixed a bug where plugin author email addresses (and any strings containing < or >) were hidden in the Effect Browser. This occurred because the UI treats the author string as Rich Text, causing the renderer to interpret email brackets as malformed HTML tags.
**Changes**
Applied toHtmlEscaped() to the descriptor.author string in the plugin browser UI.
This ensures special characters are rendered as literal text instead of HTML tags.
