### PR TITLE
Fix AudioResampler crash on empty buffer input

### DIFF
--- a/src/core/AudioResampler.cpp
+++ b/src/core/AudioResampler.cpp
@@ -67,6 +67,9 @@ auto AudioResampler::process(InterleavedBufferView<const float> input, Interleav
 		throw std::invalid_argument{"Invalid channel count"};
 	}
 
+	// libsamplerate throws on empty buffers; bail before touching it.
+	if (input.frames() == 0 || output.frames() == 0) { return {0, 0}; }
+
 	auto data = SRC_DATA{};
 
 	data.data_in = input.data();


### PR DESCRIPTION
## Summary

`AudioResampler::process()` aborts the application when handed an empty buffer view. libsamplerate's `src_process()` throws when `SRC_DATA->data_in` or `data_out` is null, and an empty `std::span` yields `data() == nullptr`.

## Crash report

Reproduced during long playback with an SF2 instrument track on LMMS 1.3.0-alpha (commit `ab0ed11`):

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  SRC_DATA->data_out or SRC_DATA->data_in is NULL.
```

The resampler's sample-rate conversion path (used when the plugin's internal rate differs from the engine's output rate) can present a zero-frame slice of `Sf2Instrument::m_bufferView` to `process()` between refill checks. libsamplerate then aborts.

## Root cause

`AudioResampler::process()` populates `SRC_DATA` from `InterleavedBufferView::data()` without checking whether the view has any frames. An empty span has no underlying storage, so `data() == nullptr`. libsamplerate's documented behavior on null pointers is `SRC_ERR_BAD_DATA`, which `process()` rethrows as `std::runtime_error`.

## Fix

Early-return `{0, 0}` when either buffer has zero frames. The zero/zero pair is already the documented "no progress" signal existing callers handle — e.g. `Sf2Instrument::renderFrames` breaks the inner loop when both `inputFramesUsed` and `outputFramesGenerated` are zero.

## Test plan

- [x] Build clean, no new warnings introduced.
- [x] Long playback with an SF2 instrument at a non-default internal rate no longer aborts with `SRC_DATA NULL`.
- [x] Regression: tracks where the internal rate matches the engine rate go through the early `fluid_synth_write_float` path and never call `AudioResampler::process()` — unaffected.