### PR TITLE
Fix length of non-beat clips in the pattern editor

### DIFF
--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -95,6 +95,7 @@ protected:
 	SampleClip( const SampleClip& orig );
 
 private:
+	Track* m_sampleTrack;
 	Sample m_sample;
 	BoolModel m_recordModel;
 	bool m_isPlaying;

--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -95,7 +95,6 @@ protected:
 	SampleClip( const SampleClip& orig );
 
 private:
-	Track* m_sampleTrack;
 	Sample m_sample;
 	BoolModel m_recordModel;
 	bool m_isPlaying;

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -197,9 +197,9 @@ void AutomationClip::updateLength()
 	// checks if it has been resized from either direction.
 	if (getAutoResize())
 	{
-		if ( m_autoTrack != nullptr && m_autoTrack->trackContainer() == Engine::patternStore() )
+		if (m_autoTrack != nullptr && m_autoTrack->trackContainer() == Engine::patternStore())
 		{
-			// If inside a pattern, the clip is always the lenght of it.
+			// If inside a pattern, the clip is always the length of it.
 			changeLength(TimePos::ticksPerBar() * Engine::patternStore()->lengthOfPattern(m_autoTrack->getClipNum(this)));
 			return;
 		}

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -197,6 +197,12 @@ void AutomationClip::updateLength()
 	// checks if it has been resized from either direction.
 	if (getAutoResize())
 	{
+		if ( m_autoTrack != nullptr && m_autoTrack->trackContainer() == Engine::patternStore() )
+		{
+			// If inside a pattern, the clip is always the lenght of it.
+			changeLength(TimePos::ticksPerBar() * Engine::patternStore()->lengthOfPattern(m_autoTrack->getClipNum(this)));
+			return;
+		}
 		// Using 1 bar as the min length for an un-resized clip. 
 		// This does not prevent the user from resizing the clip to be less than a bar later on.
 		changeLength(std::max(TimePos::ticksPerBar(), static_cast<tick_t>(timeMapLength())));

--- a/src/core/PatternStore.cpp
+++ b/src/core/PatternStore.cpp
@@ -89,7 +89,7 @@ bar_t PatternStore::lengthOfPattern(int pattern) const
 	for (Track * t : tl)
 	{
 		// Don't create Clips here if they don't exist
-		if (pattern < t->numOfClips())
+		if (pattern < t->numOfClips() && t->type() == Track::Type::Instrument)
 		{
 			maxLength = std::max(maxLength, t->getClip(pattern)->length());
 		}

--- a/src/core/PatternStore.cpp
+++ b/src/core/PatternStore.cpp
@@ -88,7 +88,8 @@ bar_t PatternStore::lengthOfPattern(int pattern) const
 	const TrackList & tl = tracks();
 	for (Track * t : tl)
 	{
-		// Don't create Clips here if they don't exist
+		// Don't create Clips here if they don't exist, and only takes into account MIDI clips
+		// because the length of Automation / Sample clips is defined based on this method's output.
 		if (pattern < t->numOfClips() && t->type() == Track::Type::Instrument)
 		{
 			maxLength = std::max(maxLength, t->getClip(pattern)->length());

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -38,7 +38,6 @@ namespace lmms
 
 SampleClip::SampleClip(Track* _track, Sample sample, bool isPlaying)
 	: Clip(_track)
-	, m_sampleTrack(_track)
 	, m_sample(std::move(sample))
 	, m_isPlaying(false)
 {
@@ -77,7 +76,6 @@ SampleClip::SampleClip(Track* track)
 
 SampleClip::SampleClip(const SampleClip& orig) :
 	Clip(orig),
-	m_sampleTrack(orig.m_sampleTrack),
 	m_sample(std::move(orig.m_sample)),
 	m_isPlaying(orig.m_isPlaying)
 {
@@ -230,9 +228,9 @@ void SampleClip::updateLength()
 	// If the clip has already been manually resized, don't automatically resize it.
 	if (getAutoResize())
 	{
-		if (m_sampleTrack->trackContainer() == Engine::patternStore())
+		if (getTrack()->trackContainer() == Engine::patternStore())
 		{
-			changeLength(TimePos::ticksPerBar() * Engine::patternStore()->lengthOfPattern(m_sampleTrack->getClipNum(this)));
+			changeLength(TimePos::ticksPerBar() * Engine::patternStore()->lengthOfPattern(getTrack()->getClipNum(this)));
 			return;
 		}
 		changeLength(sampleLength());

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -27,6 +27,7 @@
 #include <QDomElement>
 #include <QFileInfo>
 
+#include "PatternStore.h"
 #include "PathUtil.h"
 #include "SampleClipView.h"
 #include "SampleTrack.h"
@@ -37,6 +38,7 @@ namespace lmms
 
 SampleClip::SampleClip(Track* _track, Sample sample, bool isPlaying)
 	: Clip(_track)
+	, m_sampleTrack(_track)
 	, m_sample(std::move(sample))
 	, m_isPlaying(false)
 {
@@ -75,6 +77,7 @@ SampleClip::SampleClip(Track* track)
 
 SampleClip::SampleClip(const SampleClip& orig) :
 	Clip(orig),
+	m_sampleTrack(orig.m_sampleTrack),
 	m_sample(std::move(orig.m_sample)),
 	m_isPlaying(orig.m_isPlaying)
 {
@@ -227,6 +230,11 @@ void SampleClip::updateLength()
 	// If the clip has already been manually resized, don't automatically resize it.
 	if (getAutoResize())
 	{
+		if (m_sampleTrack->trackContainer() == Engine::patternStore())
+		{
+			changeLength(TimePos::ticksPerBar() * Engine::patternStore()->lengthOfPattern(m_sampleTrack->getClipNum(this)));
+			return;
+		}
 		changeLength(sampleLength());
 		setStartTimeOffset(0);
 	}

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -265,7 +265,7 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 	// pixels per bar
 	const float ppb = fixedClips() ?
 			( parentWidget()->width() - 2 * BORDER_WIDTH )
-				/ (float) m_clip->timeMapLength().getBar() :
+				/ (float) m_clip->length().getBar() :
 								pixelsPerBar();
 
 	const auto min = m_clip->firstObject()->minValue<float>();

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -216,18 +216,14 @@ void PatternEditor::updateMaxSteps()
 	m_maxClipLength = 0;
 	for (const auto& track : tl)
 	{
-		if (track->type() == Track::Type::Instrument)
-		{
-			auto mClip = static_cast<MidiClip*>(track->getClip(m_ps->currentPattern()));
-			m_maxClipLength = std::max(m_maxClipLength, static_cast<tick_t>(mClip->length()));
-		}
-		else
+		auto clip = track->getClip(m_ps->currentPattern());
+		if (track->type() == Track::Type::Automation || track->type() == Track::Type::Sample)
 		{
 			// The length of automation and sample clips is updated here.
 			// "Why here ?" will you ask. The answer is: Because.
-			auto clip = track->getClip(m_ps->currentPattern());
 			clip->updateLength();
 		}
+		m_maxClipLength = std::max(m_maxClipLength, static_cast<tick_t>(clip->length()));
 	}
 	updatePixelsPerBar();
 }

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -221,6 +221,13 @@ void PatternEditor::updateMaxSteps()
 			auto mClip = static_cast<MidiClip*>(track->getClip(m_ps->currentPattern()));
 			m_maxClipLength = std::max(m_maxClipLength, static_cast<tick_t>(mClip->length()));
 		}
+		else
+		{
+			// The length of automation and sample clips is updated here.
+			// "Why here ?" will you ask. The answer is: Because.
+			auto clip = track->getClip(m_ps->currentPattern());
+			clip->updateLength();
+		}
 	}
 	updatePixelsPerBar();
 }

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -380,3 +380,4 @@ void PatternEditorWindow::stop()
 
 
 } // namespace lmms::gui
+

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -219,8 +219,7 @@ void PatternEditor::updateMaxSteps()
 		auto clip = track->getClip(m_ps->currentPattern());
 		if (track->type() == Track::Type::Automation || track->type() == Track::Type::Sample)
 		{
-			// The length of automation and sample clips is updated here.
-			// "Why here ?" will you ask. The answer is: Because.
+			// The length of automation and sample clips is updated to match the pattern length.
 			clip->updateLength();
 		}
 		m_maxClipLength = std::max(m_maxClipLength, static_cast<tick_t>(clip->length()));

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -380,4 +380,3 @@ void PatternEditorWindow::stop()
 
 
 } // namespace lmms::gui
-

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -128,7 +128,7 @@ void MidiClip::updateLength()
 	// If the clip hasn't already been manually resized, automatically resize it.
 	if (getAutoResize())
 	{
-		if (m_clipType == Type::BeatClip)
+		if (m_instrumentTrack->trackContainer()->type() == TrackContainer::Type::Pattern)
 		{
 			changeLength(beatClipLength());
 			updatePatternTrack();


### PR DESCRIPTION
This PR is correcting the following:
- The melody / automation / sample clips were displayed with a constant length. They now scale with the pattern length.
- The length of melody / automation clips was independent from the number of steps in the pattern, which was causing some weird and unexpected behaviors.

Before:

https://github.com/user-attachments/assets/857045dd-cc3e-4818-bb23-3544ee1dcf93



After:

https://github.com/user-attachments/assets/7d7efa4a-3f5c-4b29-bb91-d033fa9f0169



Fixes #4224