### PR TITLE
fix missing "enter value" on double click

### DIFF
--- a/include/AutomatableSlider.h
+++ b/include/AutomatableSlider.h
@@ -56,12 +56,14 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
 	void wheelEvent( QWheelEvent * _me ) override;
+	void mouseDoubleClickEvent(QMouseEvent* ev) override;
 
 	void modelChanged() override;
 
 
 private:
 	bool m_showStatus;
+	void enterValue();
 
 
 private slots:

--- a/include/AutomatableSlider.h
+++ b/include/AutomatableSlider.h
@@ -56,7 +56,7 @@ protected:
 	void mousePressEvent( QMouseEvent * _me ) override;
 	void mouseReleaseEvent( QMouseEvent * _me ) override;
 	void wheelEvent( QWheelEvent * _me ) override;
-	void mouseDoubleClickEvent(QMouseEvent* ev) override;
+	void mouseDoubleClickEvent(QMouseEvent*) override;
 
 	void modelChanged() override;
 

--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -26,6 +26,7 @@
 #include "AutomatableSlider.h"
 
 #include <QMouseEvent>
+#include <QInputDialog>
 
 #include "CaptionMenu.h"
 
@@ -111,7 +112,31 @@ void AutomatableSlider::wheelEvent( QWheelEvent * _me )
 	m_showStatus = old_status;
 }
 
+void AutomatableSlider::mouseDoubleClickEvent(QMouseEvent*)
+{
+	enterValue();
+}
 
+void AutomatableSlider::enterValue()
+{
+	bool ok;
+	int newVal;
+
+	newVal = QInputDialog::getInt(
+		this, tr("Set value"),
+		tr("Please enter a new value between %1 and %2:")
+			.arg(model()->minValue())
+			.arg(model()->maxValue()),
+		model()->value(),
+		model()->minValue(),
+		model()->maxValue(),
+		model()->step<int>(), &ok);
+
+	if (ok)
+	{
+		model()->setValue(newVal);
+	}
+}
 
 
 void AutomatableSlider::modelChanged()

--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -117,9 +117,7 @@ void AutomatableSlider::mouseDoubleClickEvent(QMouseEvent*) { enterValue(); }
 void AutomatableSlider::enterValue()
 {
 	bool ok;
-	int newVal;
-
-	newVal = QInputDialog::getInt(
+	const int newVal = QInputDialog::getInt(
 		this, tr("Set value"),
 		tr("Please enter a new value between %1 and %2:")
 			.arg(model()->minValue())

--- a/src/gui/widgets/AutomatableSlider.cpp
+++ b/src/gui/widgets/AutomatableSlider.cpp
@@ -112,10 +112,7 @@ void AutomatableSlider::wheelEvent( QWheelEvent * _me )
 	m_showStatus = old_status;
 }
 
-void AutomatableSlider::mouseDoubleClickEvent(QMouseEvent*)
-{
-	enterValue();
-}
+void AutomatableSlider::mouseDoubleClickEvent(QMouseEvent*) { enterValue(); }
 
 void AutomatableSlider::enterValue()
 {
@@ -132,10 +129,7 @@ void AutomatableSlider::enterValue()
 		model()->maxValue(),
 		model()->step<int>(), &ok);
 
-	if (ok)
-	{
-		model()->setValue(newVal);
-	}
+	if (ok) { model()->setValue(newVal); }
 }
 
 


### PR DESCRIPTION
Fixes #8371, by introducing code copied from another automatable widget (I don't remember which...).