### PR TITLE
Fix sample track playback in pattern editor

### DIFF
--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -80,18 +80,24 @@ bool SampleTrack::play( const TimePos & _start, const f_cnt_t _frames,
 	class PatternTrack * pattern_track = nullptr;
 	if( _clip_num >= 0 )
 	{
-		if (_start > getClip(_clip_num)->length())
+		SampleClip* sClip = dynamic_cast<SampleClip*>( getClip(_clip_num) );
+
+		if (_start > sClip->length())
 		{
 			setPlaying(false);
 		}
-		if( _start != 0 )
+		if( sClip->isPlaying() )
 		{
 			return false;
 		}
-		clips.push_back( getClip( _clip_num ) );
+		clips.push_back( sClip );
 		if (trackContainer() == Engine::patternStore())
 		{
+			auto bufferFramesPerTick = Engine::framesPerTick(sClip->sample().sampleRate());
+			f_cnt_t sampleStart = bufferFramesPerTick * ( _start );
 			pattern_track = PatternTrack::findPatternTrack(_clip_num);
+			sClip->setSampleStartFrame( sampleStart );
+			sClip->setIsPlaying( true );
 			setPlaying(true);
 		}
 	}

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -86,7 +86,7 @@ bool SampleTrack::play( const TimePos & _start, const f_cnt_t _frames,
 		{
 			setPlaying(false);
 		}
-		if(sClip->isPlaying())
+		if (sClip->isPlaying())
 		{
 			return false;
 		}

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -22,7 +22,7 @@
  * Boston, MA 02110-1301 USA.
  *
  */
- 
+
 #include "SampleTrack.h"
 
 #include <QDomElement>
@@ -80,24 +80,24 @@ bool SampleTrack::play( const TimePos & _start, const f_cnt_t _frames,
 	class PatternTrack * pattern_track = nullptr;
 	if( _clip_num >= 0 )
 	{
-		SampleClip* sClip = dynamic_cast<SampleClip*>( getClip(_clip_num) );
+		auto sClip = dynamic_cast<SampleClip*>(getClip(_clip_num));
 
 		if (_start > sClip->length())
 		{
 			setPlaying(false);
 		}
-		if( sClip->isPlaying() )
+		if(sClip->isPlaying())
 		{
 			return false;
 		}
-		clips.push_back( sClip );
+		clips.push_back(sClip);
 		if (trackContainer() == Engine::patternStore())
 		{
 			auto bufferFramesPerTick = Engine::framesPerTick(sClip->sample().sampleRate());
-			f_cnt_t sampleStart = bufferFramesPerTick * ( _start );
+			f_cnt_t sampleStart = bufferFramesPerTick * _start;
 			pattern_track = PatternTrack::findPatternTrack(_clip_num);
-			sClip->setSampleStartFrame( sampleStart );
-			sClip->setIsPlaying( true );
+			sClip->setSampleStartFrame(sampleStart);
+			sClip->setIsPlaying(true);
 			setPlaying(true);
 		}
 	}


### PR DESCRIPTION
closes #4422
(this issue is tagged as enhancement, but I really see this as a bug fix)

Allow playback of a sample clip in the pattern editor to start at any position and not only at t=0 as it is currently the case.
This also ensure that the sample is played each loop, which is currently very inconsistent.