### PR TITLE
Oscilloscope: Add missing QApplication and QThread includes

### DIFF
--- a/plugins/Oscilloscope/OscilloscopeGraph.cpp
+++ b/plugins/Oscilloscope/OscilloscopeGraph.cpp
@@ -28,8 +28,10 @@
 #include "GuiApplication.h"
 #include "MainWindow.h"
 
+#include <QApplication>
 #include <QPainter>
 #include <QSizePolicy>
+#include <QThread>
 #include <QWheelEvent>
 
 #include <functional>


### PR DESCRIPTION
## Summary

`plugins/Oscilloscope/OscilloscopeGraph.cpp` uses `QApplication::instance()` and `QThread::currentThread()` inside an `assert()` call at line 57, but does not include `<QApplication>` or `<QThread>`, which breaks Debug builds.

Fix: add the two missing includes, sorted alphabetically inside the existing Qt block.

## Error reproduced before fix

```
plugins/Oscilloscope/OscilloscopeGraph.cpp:57:30: error: incomplete type 'QApplication' used in nested name specifier
   57 |     assert(QApplication::instance()->thread() == QThread::currentThread());
ninja: build stopped: subcommand failed.
```

## Test plan

- [x] Clean configure: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug`
- [x] Build green: `cmake --build build` (Manjaro, GCC 15.2.1, Qt 5.15.18)
- [x] All unit tests pass (8/8 suites green via direct execution)
- [x] No behavior change — only headers added

## Related

Closes #8376