### PR TITLE
Fix Slow Midi Operations by Only Initializing the Detuning Clip When Needed

### DIFF
--- a/src/core/Note.cpp
+++ b/src/core/Note.cpp
@@ -49,10 +49,6 @@ Note::Note( const TimePos & length, const TimePos & pos,
 	m_pos(pos),
 	m_detuning(std::move(detuning))
 {
-	if (!detuning)
-	{
-		createDetuning();
-	}
 }
 
 
@@ -97,7 +93,10 @@ Note& Note::operator=(const Note& note)
 Note* Note::clone() const
 {
 	Note* newNote = new Note(*this);
-	newNote->m_detuning = std::make_shared<DetuningHelper>(*newNote->m_detuning);
+	if (newNote->m_detuning != nullptr)
+	{
+		newNote->m_detuning = std::make_shared<DetuningHelper>(*newNote->m_detuning);
+	}
 	return newNote;
 }
 
@@ -230,7 +229,10 @@ AutomationClip* Note::parameterCurve(ParameterType paramType)
 	{
 	// TODO: In the future, more per-note parameters which can be automated are planned. Perhaps velocity, panning, and/or some other plugin-specific parameter.
 	case ParameterType::Detuning:
-		return detuning()->automationClip();
+		if (detuning() != nullptr)
+		{
+			return detuning()->automationClip();
+		}
 	default:
 		return nullptr;
 	}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1237,7 +1237,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 			{
 				int noteKey = note->key();
 
-				if (note->detuning()->automationClip() == m_clip) {
+				if (note->detuning() != nullptr && note->detuning()->automationClip() == m_clip) {
 					detuningOffset = note->pos();
 					detuningNote = note;
 				}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -3762,7 +3762,7 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 			int pos_ticks = note->pos();
 			int note_width = len_ticks * m_ppb / TimePos::ticksPerBar();
 
-			int detuningLength = !note->detuning()->automationClip()->getTimeMap().isEmpty()
+			int detuningLength = note->detuning() != nullptr && !note->detuning()->automationClip()->getTimeMap().isEmpty()
 				? note->detuning()->automationClip()->getTimeMap().lastKey() * m_ppb / TimePos::ticksPerBar()
 				: note_width;
 


### PR DESCRIPTION
TLDR: Normally, the `AutomationClip` containing the detuning curve of a `Note` is created for every single note, no matter if it actually has detuning or not. This PR changes that so it is only created when the user edits the detuning.

I tried loading an example 84-bar-long midi file. Before this PR, this took about 16 second to load. After this PR, it takes *less than half a second*.
I can even take that 84 bar midi clip and ctrl-drag copy it around to other tracks, and again it takes less than half a second to copy all of those notes to the new clip.

----

When #7477 and later #7888 were merged, they reworked how `Note` objects were copied to prevent two different notes from sharing the same detuning automation curve, which would mean editing one's detuning would edit the other's at the same time.

This made the workflow more correct, but it came at the cost of performance. Unfortunately, every single `Note` object had to have a `DetuningHelper` object which contained an `AutomationClip`. These `AutomationClips` are complex `QObjects` with signals and slots and models inside them, which is not great when you need to copy a whole bunch of notes at once.

Ideally, I think we could replace the detuning clip with something simpler than an automation clip; something which only holds the bare minimum curve data. But that is for a later time; this PR uses a different solution.

Detuning automation clips are only needed by the `Note` if the user has added any pitch bending. But for the vast majority of notes, there is no pitch bending, so they do not really need the detuning clip. Currently, the detuning object is initialized right when the `Note` is created. However, this can be changed so that it is only created when the user decided to edit the detuning. This saves an enormous amount of processing when copying notes.

This technically means that there is the possibility that `note->detuning()` could be `nullptr`. However, I went through all of the occurances in the codebase, and I added checks where there was the potential it could be `nullptr`.

