### PR TITLE
Support translucency in top-level windows

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -88,6 +88,7 @@ MainWindow::MainWindow() :
 	m_session( SessionState::Normal )
 {
 	setAttribute( Qt::WA_DeleteOnClose );
+	setAttribute(Qt::WA_TranslucentBackground);
 
 	auto main_widget = new QWidget(this);
 	auto vbox = new QVBoxLayout(main_widget);
@@ -547,6 +548,7 @@ SubWindow* MainWindow::addWindowedWidget(QWidget *w, Qt::WindowFlags windowFlags
 	{
 		// TODO: somehow make this work on any setWidget
 		connect(w, &QWidget::destroyed, win, &SubWindow::deleteLater);
+		w->setAttribute(Qt::WA_TranslucentBackground);
 
 		if (w->sizeHint().isValid())
 		{


### PR DESCRIPTION

<img width="669" height="500" alt="image" src="https://github.com/user-attachments/assets/18fda086-65a0-43b0-ac00-aec8847032cf" />

<sub>This is for demonstration purposes. To see the change in effect, one needs to tweak the theme CSS. To make workspace transparent, `QMdiArea` background needs to have the desired alpha (e.g. `QMdiArea { background: rgba(0,0,0,0); }` That will also support background images with translucent elements.</sub>

Modals are not supported yet (just because they're neither subwindows nor top-level), changes to support them are trivial.

Subwindow translucency flag is forceful, this probably shouldn't impact anything since it only changes things on compositor level. Alternatively could be done individually for each child window. Unfortunately flag needs to be set before the window is shown (even if it was shown attached), so dynamically tweaking it doesn't seem to work. Forcing is done in order to have the proof-of-concept done with a smaller diff.

Overall flag change shouldn't introduce any significant performance drawbacks, if it does converting it to a config option is trivial.