### PR TITLE
Fix Midi Import of Multi-track File and CC Automation

### DIFF
--- a/include/InstrumentTrack.h
+++ b/include/InstrumentTrack.h
@@ -239,6 +239,9 @@ public:
 
 	void autoAssignMidiDevice( bool );
 
+	//! Returns a non-owning pointer to the model for the knob at the given index in the track's MIDI CC rack
+	FloatModel* midiCCModel(int index) const { return m_midiCCModel[index].get(); }
+
 signals:
 	void instrumentChanged();
 	void midiNoteOn( const lmms::Note& );

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -460,57 +460,57 @@ bool MidiImport::readSMF(TrackContainer* tc)
 					{
 						double cc = evt->get_real_value();
 						// By default, set the knob in the CC rack of the instrument track
-						AutomatableModel* ccModel = (ccid >= 0 && ccid < 128)
-							? ch->it->midiCCModel(ccid)
-							: nullptr;
+						AutomatableModel* modelObject = nullptr;
 						// Some CC knobs correspond to specific things like pitch and volume, so in that case, also set the lmms pitch/volume/etc knobs.
-						AutomatableModel* lmmsSpecificModel = nullptr;
-
 						switch (ccid)
 						{
 							case 0:
 								if (ch->isSF2 && ch->it_inst)
 								{
-									lmmsSpecificModel = ch->it_inst->childModel("bank");
+									modelObject = ch->it_inst->childModel("bank");
 									printf("BANK SELECT %f %d\n", cc, static_cast<int>(cc * 127));
 									cc *= 127.0f;
 								}
 								break;
 
 							case 7:
-								lmmsSpecificModel = ch->it->volumeModel();
+								modelObject = ch->it->volumeModel();
 								cc *= 100.0f;
 								break;
 
 							case 10:
-								lmmsSpecificModel = ch->it->panningModel();
+								modelObject = ch->it->panningModel();
 								cc = cc * 200.f - 100.0f;
 								break;
 
 							case 128:
-								lmmsSpecificModel = ch->it->pitchModel();
+								modelObject = ch->it->pitchModel();
 								cc = cc * 100.0f;
 								break;
 
 							default:
-								//TODO: something useful for other CCs
+								if (ccid >= 0 && ccid < 128)
+								{
+									modelObject = ch->it->midiCCModel(ccid);
+									cc = cc * 127.0f;
+								}
 								break;
 						}
 
-						if (time == 0)
+						if (modelObject)
 						{
-							if (ccModel) { ccModel->setInitValue(cc * 127.0f); }
-							if (lmmsSpecificModel) { lmmsSpecificModel->setInitValue(cc); }
-						}
-						else
-						{
-							if (ccs[ccid].at == nullptr)
+							if (time == 0)
 							{
-								if (ccModel) { ccs[ccid].create(tc, trackName + " > " + ccModel->displayName()); }
-								if (lmmsSpecificModel) { ccs[ccid].create(tc, trackName + " > " + lmmsSpecificModel->displayName()); }
+								modelObject->setInitValue(cc);
 							}
-							if (ccModel) { ccs[ccid].putValue(time, ccModel, cc * 127.0f); }
-							if (lmmsSpecificModel) { ccs[ccid].putValue(time, lmmsSpecificModel, cc); }
+							else
+							{
+								if (ccs[ccid].at == nullptr)
+								{
+									ccs[ccid].create(tc, trackName + " > " + modelObject->displayName());
+								}
+								ccs[ccid].putValue(time, modelObject, cc);
+							}
 						}
 					}
 				}

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -459,9 +459,9 @@ bool MidiImport::readSMF(TrackContainer* tc)
 					if (ccid <= 128)
 					{
 						double cc = evt->get_real_value();
-						// By default, set the knob in the CC rack of the instrument track
 						AutomatableModel* modelObject = nullptr;
-						// Some CC knobs correspond to specific things like pitch and volume, so in that case, also set the lmms pitch/volume/etc knobs.
+						// Some CC knobs correspond to specific things like pitch and volume, so in that case, set the lmms pitch/volume/etc knobs.
+						// Otherwise, set the knob in the instrument track CC rack
 						switch (ccid)
 						{
 							case 0:

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -405,7 +405,9 @@ bool MidiImport::readSMF(TrackContainer* tc)
 			}
 			else if (evt->is_note())
 			{
-				smfMidiChannel* ch = chs[evt->chan].create(tc, trackName);
+				// LMMS does not currently support specifying the channel of a single note
+				// To be safe, put the notes from different channels on separate tracks so that no information is lost
+				smfMidiChannel* ch = chs[evt->chan + 16 * t].create(tc, trackName);
 				auto noteEvt = dynamic_cast<Alg_note_ptr>(evt);
 				tick_t ticks = noteEvt->get_duration() * ticksPerBeat;
 				Note n(
@@ -419,7 +421,7 @@ bool MidiImport::readSMF(TrackContainer* tc)
 			}
 			else if (evt->is_update())
 			{
-				smfMidiChannel* ch = chs[evt->chan].create(tc, trackName);
+				smfMidiChannel* ch = chs[evt->chan + 16 * t].create(tc, trackName);
 
 				double time = evt->time*ticksPerBeat;
 				QString update(evt->get_attribute());
@@ -457,31 +459,36 @@ bool MidiImport::readSMF(TrackContainer* tc)
 					if (ccid <= 128)
 					{
 						double cc = evt->get_real_value();
-						AutomatableModel* objModel = nullptr;
+						// By default, set the knob in the CC rack of the instrument track
+						AutomatableModel* ccModel = (ccid >= 0 && ccid < 128)
+							? ch->it->midiCCModel(ccid)
+							: nullptr;
+						// Some CC knobs correspond to specific things like pitch and volume, so in that case, also set the lmms pitch/volume/etc knobs.
+						AutomatableModel* lmmsSpecificModel = nullptr;
 
 						switch (ccid)
 						{
 							case 0:
 								if (ch->isSF2 && ch->it_inst)
 								{
-									objModel = ch->it_inst->childModel("bank");
+									lmmsSpecificModel = ch->it_inst->childModel("bank");
 									printf("BANK SELECT %f %d\n", cc, static_cast<int>(cc * 127));
 									cc *= 127.0f;
 								}
 								break;
 
 							case 7:
-								objModel = ch->it->volumeModel();
+								lmmsSpecificModel = ch->it->volumeModel();
 								cc *= 100.0f;
 								break;
 
 							case 10:
-								objModel = ch->it->panningModel();
+								lmmsSpecificModel = ch->it->panningModel();
 								cc = cc * 200.f - 100.0f;
 								break;
 
 							case 128:
-								objModel = ch->it->pitchModel();
+								lmmsSpecificModel = ch->it->pitchModel();
 								cc = cc * 100.0f;
 								break;
 
@@ -490,23 +497,20 @@ bool MidiImport::readSMF(TrackContainer* tc)
 								break;
 						}
 
-						if (objModel)
+						if (time == 0)
 						{
-							if (time == 0 && objModel)
+							if (ccModel) { ccModel->setInitValue(cc * 127.0f); }
+							if (lmmsSpecificModel) { lmmsSpecificModel->setInitValue(cc); }
+						}
+						else
+						{
+							if (ccs[ccid].at == nullptr)
 							{
-								objModel->setInitValue(cc);
+								if (ccModel) { ccs[ccid].create(tc, trackName + " > " + ccModel->displayName()); }
+								if (lmmsSpecificModel) { ccs[ccid].create(tc, trackName + " > " + lmmsSpecificModel->displayName()); }
 							}
-							else
-							{
-								if (ccs[ccid].at == nullptr) {
-									ccs[ccid].create(tc, trackName + " > " +
-										// This is inside if (objModel), so objModel should never be nullptr
-										// (objModel != nullptr ? objModel->displayName() : QString("CC %1").arg(ccid))
-										objModel->displayName()
-									);
-								}
-								ccs[ccid].putValue(time, objModel, cc);
-							}
+							if (ccModel) { ccs[ccid].putValue(time, ccModel, cc * 127.0f); }
+							if (lmmsSpecificModel) { ccs[ccid].putValue(time, lmmsSpecificModel, cc); }
 						}
 					}
 				}


### PR DESCRIPTION
Currently, importing midi files containing multiple tracks is not supported. All of the notes get merged onto a single track.

Except, LMMS actually *does* support multi-track midi import, it just ignores the track index when placing the notes, and simply puts them in tracks based on their midi channel instead. LMMS does not support setting the channel of an individual note, so separating the loaded midi events onto separate tracks based on their channel does make sense.

But we don't have to choose one or the other! This PR makes it so that the notes in midi files are split into different tracks based on both their midi channel and midi track. This allows midi files which contain multiple tracks to be loaded normally, and hopefully even multi-channel multi-track midi files.

Additionally, some midi files contain a wealth of information regarding midi CC automation. Currently, we only handle pitch, panning, volume, and bank automation when importing midi files, but this PR also makes it so that the knobs in the instrument track CC rack are also automated.

## Before

I'm using METAL-GTX_Demo2.mid as an example. This midi files should contain several tracks for the different guitars, along with many CC knob parameter modulations for things like vibrato, etc to be handled by the SFZ player.

Currently, everything is loaded as a single track. This made things like key switches appear stacked, which made no sense, and everything sounded wrong when played on my SFZ player. There are a few automation clips for pitch, but that's about it.

<img width="1457" height="425" alt="image" src="https://github.com/user-attachments/assets/dc98c2c0-9c19-46d0-8ad3-412ab5d09cf9" />

## After

Now all of the tracks in the midi file are loaded correctly. The key switches make sense now, and all the midi CC modulations are loaded too.

<img width="1522" height="781" alt="Screenshot From 2026-05-13 11-28-20" src="https://github.com/user-attachments/assets/33ac2aa7-0d12-4ac2-a3a8-d8cbcee521da" />

NOTE: Regarding the CC automations, some CC numbers correspond to things like panning and volume, which are real knobs in lmms. In the case that one of these CC's are automated, it creates an automation track for that specific lmms knob. Otherwise, it automates the knob in the instrument track's midi CC rack.