### PR TITLE
Fix Clips Being Hard to Move When Zoomed Out

### DIFF
--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -172,7 +172,7 @@ protected:
 	bool unquantizedModHeld( QMouseEvent * me );
 	TimePos quantizeSplitPos(TimePos);
 
-	float pixelsPerBar();
+	float pixelsPerBar() const;
 
 
 	DataFile createClipDataFiles(const QVector<ClipView *> & clips) const;
@@ -234,6 +234,9 @@ private:
 	TimePos draggedClipPos( QMouseEvent * me );
 	int knifeMarkerPos( QMouseEvent * me );
 	void setColor(const std::optional<QColor>& color);
+
+	//! Returns the width of the resize grip in pixels. When zoomed in, this is a constant pixel value, but when zoomed far out, it is a fraction of the clip width.
+	int resizeGripWidth() const;
 	
 	//! Returns whether the user can left-resize this clip so that the start of the clip bounds is before the start of the clip content.
 	virtual bool isResizableBeforeStart() { return true; };

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -235,7 +235,11 @@ private:
 	int knifeMarkerPos( QMouseEvent * me );
 	void setColor(const std::optional<QColor>& color);
 
-	//! Returns the width of the resize grip in pixels. When zoomed in, this is a constant pixel value, but when zoomed far out, it is a fraction of the clip width.
+	/**
+	 * @returns the width of a note's resize area in pixels.
+	 * @note When zoomed in, this is a constant pixel value, but when zoomed far out,
+	 * it is a fraction of the clip width.
+	 */
 	int resizeGripWidth() const;
 	
 	//! Returns whether the user can left-resize this clip so that the start of the clip bounds is before the start of the clip content.

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -402,7 +402,7 @@ void ClipView::setColor(const std::optional<QColor>& color)
 int ClipView::resizeGripWidth() const
 {
 	const int clipWidth = m_clip->length() * pixelsPerBar() / TimePos::ticksPerBar();
-	return std::min(RESIZE_GRIP_WIDTH, static_cast<int>(std::round(RESIZE_GRIP_MAX_WIDTH_FRACTION * clipWidth)));
+	return std::clamp(static_cast<int>(std::round(RESIZE_GRIP_MAX_WIDTH_FRACTION * clipWidth)), 1, RESIZE_GRIP_WIDTH);
 }
 
 
@@ -498,7 +498,7 @@ void ClipView::updateCursor(QMouseEvent * me)
 
 	// If we are at the edges, use the resize cursor
 	if (!me->buttons() && m_clip->manuallyResizable() && !isSelected()
-		&& ((posX > width() - resizeGripWidth()) || (posX < resizeGripWidth())))
+		&& ((posX >= width() - resizeGripWidth()) || (posX < resizeGripWidth())))
 	{
 		setCursor(Qt::SizeHorCursor);
 	}

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -57,9 +57,9 @@ namespace lmms::gui
 
 
 //! The default width of the resize grip in pixels
-const int RESIZE_GRIP_WIDTH = 8;
+constexpr int RESIZE_GRIP_WIDTH = 8;
 //! The maximum fraction of the clip width that the resize grip is allowed to take up
-const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1f;
+constexpr float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1f;
 
 
 /*! A pointer for that text bubble used when moving segments, etc.

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -56,9 +56,10 @@ namespace lmms::gui
 {
 
 
-/*! The width of the resize grip in pixels
- */
+//! The default width of the resize grip in pixels
 const int RESIZE_GRIP_WIDTH = 8;
+//! The maximum fraction of the clip width that the resize grip is allowed to take up
+const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1;
 
 
 /*! A pointer for that text bubble used when moving segments, etc.
@@ -397,6 +398,15 @@ void ClipView::setColor(const std::optional<QColor>& color)
 	Engine::getSong()->setModified();
 }
 
+
+int ClipView::resizeGripWidth() const
+{
+	const int clipWidth = m_clip->length() * pixelsPerBar() / TimePos::ticksPerBar();
+	return std::min(RESIZE_GRIP_WIDTH, static_cast<int>(std::round(RESIZE_GRIP_MAX_WIDTH_FRACTION * clipWidth)));
+}
+
+
+
 /*! \brief Change the ClipView's display when something
  *  being dragged enters it.
  *
@@ -488,7 +498,7 @@ void ClipView::updateCursor(QMouseEvent * me)
 
 	// If we are at the edges, use the resize cursor
 	if (!me->buttons() && m_clip->manuallyResizable() && !isSelected()
-		&& ((posX > width() - RESIZE_GRIP_WIDTH) || (posX < RESIZE_GRIP_WIDTH)))
+		&& ((posX > width() - resizeGripWidth()) || (posX < resizeGripWidth())))
 	{
 		setCursor(Qt::SizeHorCursor);
 	}
@@ -661,12 +671,12 @@ void ClipView::mousePressEvent( QMouseEvent * me )
 					m_action = Action::Move;
 					setCursor( Qt::SizeAllCursor );
 				}
-				else if (pos.x() >= width() - RESIZE_GRIP_WIDTH)
+				else if (pos.x() >= width() - resizeGripWidth())
 				{
 					m_action = Action::Resize;
 					setCursor( Qt::SizeHorCursor );
 				}
-				else if (pos.x() < RESIZE_GRIP_WIDTH)
+				else if (pos.x() < resizeGripWidth())
 				{
 					m_action = Action::ResizeLeft;
 					setCursor( Qt::SizeHorCursor );
@@ -1255,7 +1265,7 @@ void ClipView::toggleSelectedAutoResize()
  *
  * \return the number of pixels per bar.
  */
-float ClipView::pixelsPerBar()
+float ClipView::pixelsPerBar() const
 {
 	return m_trackView->trackContainerView()->pixelsPerBar();
 }

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -59,7 +59,7 @@ namespace lmms::gui
 //! The default width of the resize grip in pixels
 const int RESIZE_GRIP_WIDTH = 8;
 //! The maximum fraction of the clip width that the resize grip is allowed to take up
-const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1;
+const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1f;
 
 
 /*! A pointer for that text bubble used when moving segments, etc.


### PR DESCRIPTION
When #8169 was merged, the resize grip of clips was increased to 8 pixels to make it easier to resize clips which were right next to each other. However, this constant 8 pixel region on either end of the clip gets in the way when zoomed far out, since the width of the clip itself could be on the order of 8 pixels.

To fix this, this PR makes it so that the clip resize grip width dynamically changes with the zoom level. When zoomed far in, it's 8 pixels, but as you zoom out, the grip width is capped to be no more than 10% of the clip width. This makes it much easier to move the clip around without it getting in the way.

Fixes #8384