### PR TITLE
Make Tiny Notes Easier to Move

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -371,6 +371,9 @@ private:
 	static const std::vector<float> m_zoomLevels;
 	static const std::vector<float> m_zoomYLevels;
 
+	//! Returns the width of the resize area in pixels. When zoomed in, this is a constant pixel value, but when zoomed far out, it is a fraction of the note width, to make it easier to move short notes.
+	int resizeGripWidth(tick_t noteLength) const;
+
 	MidiClip* m_midiClip;
 	NoteVector m_ghostNotes;
 

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -376,7 +376,7 @@ private:
 	 * @note When zoomed in, this is a constant pixel value, but when zoomed far out,
 	 * it is a fraction of the note width, to make it easier to move short notes.
 	 */
-	int resizeGripWidth(tick_t noteLength) const;
+	int resizeGripWidth(const Note& note) const;
 
 	MidiClip* m_midiClip;
 	NoteVector m_ghostNotes;

--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -371,7 +371,11 @@ private:
 	static const std::vector<float> m_zoomLevels;
 	static const std::vector<float> m_zoomYLevels;
 
-	//! Returns the width of the resize area in pixels. When zoomed in, this is a constant pixel value, but when zoomed far out, it is a fraction of the note width, to make it easier to move short notes.
+	/**
+	 * @returns the width of a note's resize area in pixels.
+	 * @note When zoomed in, this is a constant pixel value, but when zoomed far out,
+	 * it is a fraction of the note width, to make it easier to move short notes.
+	 */
 	int resizeGripWidth(tick_t noteLength) const;
 
 	MidiClip* m_midiClip;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1925,7 +1925,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 				// clicked at the "tail" of the note?
 				if (x + m_currentPosition * m_ppb / TimePos::ticksPerBar() >
-						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - resizeGripWidth(m_currentNote->length())
+						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - resizeGripWidth(*m_currentNote)
 					&& m_currentNote->length() > 0 )
 				{
 					m_midiClip->addJournalCheckPoint();
@@ -2721,7 +2721,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				int noteRightX = ( note->pos() + note->length() -
 					m_currentPosition) * m_ppb/TimePos::ticksPerBar();
 				// cursor at the "tail" of the note?
-				bool atTail = note->length() > 0 && x > noteRightX - resizeGripWidth(note->length());
+				bool atTail = note->length() > 0 && x > noteRightX - resizeGripWidth(*note);
 				Qt::CursorShape cursorShape = atTail ? Qt::SizeHorCursor :
 													Qt::SizeAllCursor;
 				setCursor( cursorShape );
@@ -3291,9 +3291,9 @@ void PianoRoll::dragNotes(int x, int y, bool alt, bool shift, bool ctrl)
 }
 
 
-int PianoRoll::resizeGripWidth(tick_t noteLength) const
+int PianoRoll::resizeGripWidth(const Note& note) const
 {
-	const int noteWidth = noteLength * m_ppb / TimePos::ticksPerBar();
+	const int noteWidth = note.length() * m_ppb / TimePos::ticksPerBar();
 	return std::min(RESIZE_GRIP_WIDTH, static_cast<int>(std::round(RESIZE_GRIP_MAX_WIDTH_FRACTION * noteWidth)));
 }
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -109,7 +109,7 @@ const int PR_RIGHT_MARGIN = SCROLLBAR_SIZE;
 //! Width of area used for resizing (the grip at the end of a note)
 const int RESIZE_GRIP_WIDTH = 9;
 //! The maximum fraction of the note width that the resize grip is allowed to take up
-const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1;
+const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.25;
 
 // width of line for setting volume/panning of note
 const int NOTE_EDIT_LINE_WIDTH = 3;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -107,9 +107,9 @@ const int PR_RIGHT_MARGIN = SCROLLBAR_SIZE;
 
 
 //! Width of area used for resizing (the grip at the end of a note)
-const int RESIZE_GRIP_WIDTH = 9;
+constexpr int RESIZE_GRIP_WIDTH = 9;
 //! The maximum fraction of the note width that the resize grip is allowed to take up
-const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.25;
+constexpr float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.25f;
 
 // width of line for setting volume/panning of note
 const int NOTE_EDIT_LINE_WIDTH = 3;
@@ -1924,7 +1924,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				}
 
 				// clicked at the "tail" of the note?
-				if(x + m_currentPosition * m_ppb / TimePos::ticksPerBar() >
+				if (x + m_currentPosition * m_ppb / TimePos::ticksPerBar() >
 						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - resizeGripWidth(m_currentNote->length())
 					&& m_currentNote->length() > 0 )
 				{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1924,7 +1924,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 				}
 
 				// clicked at the "tail" of the note?
-				if( pos_ticks * m_ppb / TimePos::ticksPerBar() >
+				if(x + m_currentPosition * m_ppb / TimePos::ticksPerBar() >
 						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - resizeGripWidth(m_currentNote->length())
 					&& m_currentNote->length() > 0 )
 				{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -106,8 +106,10 @@ const int PR_TOP_MARGIN = 18;
 const int PR_RIGHT_MARGIN = SCROLLBAR_SIZE;
 
 
-// width of area used for resizing (the grip at the end of a note)
-const int RESIZE_AREA_WIDTH = 9;
+//! Width of area used for resizing (the grip at the end of a note)
+const int RESIZE_GRIP_WIDTH = 9;
+//! The maximum fraction of the note width that the resize grip is allowed to take up
+const float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1;
 
 // width of line for setting volume/panning of note
 const int NOTE_EDIT_LINE_WIDTH = 3;
@@ -1923,7 +1925,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 				// clicked at the "tail" of the note?
 				if( pos_ticks * m_ppb / TimePos::ticksPerBar() >
-						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - RESIZE_AREA_WIDTH
+						m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - resizeGripWidth(m_currentNote->length())
 					&& m_currentNote->length() > 0 )
 				{
 					m_midiClip->addJournalCheckPoint();
@@ -2719,8 +2721,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 				int noteRightX = ( note->pos() + note->length() -
 					m_currentPosition) * m_ppb/TimePos::ticksPerBar();
 				// cursor at the "tail" of the note?
-				bool atTail = note->length() > 0 && x > noteRightX -
-							RESIZE_AREA_WIDTH;
+				bool atTail = note->length() > 0 && x > noteRightX - resizeGripWidth(note->length());
 				Qt::CursorShape cursorShape = atTail ? Qt::SizeHorCursor :
 													Qt::SizeAllCursor;
 				setCursor( cursorShape );
@@ -3290,6 +3291,11 @@ void PianoRoll::dragNotes(int x, int y, bool alt, bool shift, bool ctrl)
 }
 
 
+int PianoRoll::resizeGripWidth(tick_t noteLength) const
+{
+	const int noteWidth = noteLength * m_ppb / TimePos::ticksPerBar();
+	return std::min(RESIZE_GRIP_WIDTH, static_cast<int>(std::round(RESIZE_GRIP_MAX_WIDTH_FRACTION * noteWidth)));
+}
 
 
 void PianoRoll::paintEvent(QPaintEvent * pe )


### PR DESCRIPTION
Essentially the same fix as #8385, but for notes in the Piano Roll.

Before:


https://github.com/user-attachments/assets/befe3e81-09ed-438d-b423-d9e85a436268



After:


https://github.com/user-attachments/assets/6ea32106-7e5a-4da1-b7cd-57bbbb7e1a16

