### PR TITLE
Fix attached subwindows occasionally snapping to minimum size

### DIFF
--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -169,7 +169,8 @@ void SubWindow::changeEvent( QEvent *event )
 
 void SubWindow::setVisible(bool visible)
 {
-	if (isDetached()) {
+	if (isDetached())
+	{
 		// When detached, top-level window is the child widget itself. (This is janky and is best changed at some point.)
 		// For that reason we forward show/hide to the child widget, and don't touch the hidden attached window frame.
 		widget()->setVisible(visible);

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -169,8 +169,21 @@ void SubWindow::changeEvent( QEvent *event )
 
 void SubWindow::setVisible(bool visible)
 {
-	if (isDetached() || visible) { widget()->setVisible(visible); }
-	if (!isDetached()) { QMdiSubWindow::setVisible(visible); }
+	if (isDetached()) {
+		// When detached, top-level window is the child widget itself. (This is janky and is best changed at some point.)
+		// For that reason we forward show/hide to the child widget, and don't touch the hidden attached window frame.
+		widget()->setVisible(visible);
+	}
+	else
+	{
+		// When attached, visibility of the actual window is controlled by SubWindow.
+		// SubWindow::hide() when it's already hidden still causes a size recalculation,
+		// if the child widget is hidden it does not get included into the layout, and maximum size is set to 0x0.
+		// There shouldn't be a reason to keep the child widget hidden when the subwindow is attached.
+		// see bug #8292
+		widget()->show();
+		QMdiSubWindow::setVisible(visible);
+	}
 }
 
 


### PR DESCRIPTION
Fixes #8292.

Presumable cause of bug:

`QLayout::SetMinAndMaxSize` on `SubWindow` layout causes it to calculate minimum and maximum sizes based on all **visible** children. If (child) window contents widget happens to be marked as hidden when a resize is requested, it does not get included into the layout, and as such the engine thinks there are no children and sets maximum size to 0x0. Then, whenever the child is shown again, minimum (and maximum) sizes are correct again, and window is resized from it's current size (0x0) to closest valid size (i.e. minimum size).

Now that i think about it, forcing show on resizeEvent instead of setVisible might cover more (all) cases, but this seems to be enough as it is.