### PR TITLE
Fix time display not updating when Home is pressed while paused

### DIFF
--- a/src/gui/widgets/TimeDisplayWidget.cpp
+++ b/src/gui/widgets/TimeDisplayWidget.cpp
@@ -57,6 +57,11 @@ TimeDisplayWidget::TimeDisplayWidget() :
 
 	connect( getGUI()->mainWindow(), SIGNAL(periodicUpdate()),
 					this, SLOT(updateTime()));
+
+	// positionJumped fires when the user moves the playhead while paused;
+	// periodicUpdate() alone would lag by up to one timer tick in that case.
+	connect(&Engine::getSong()->getTimeline(Song::PlayMode::None),
+		&Timeline::positionJumped, this, &TimeDisplayWidget::updateTime);
 }
 
 void TimeDisplayWidget::setDisplayMode( DisplayMode displayMode )


### PR DESCRIPTION
Fixes #7956

## Problem

When the song is stopped, `m_playMode` is `PlayMode::None`. Pressing Home (or Left/Right arrows) while paused jumped the playhead immediately, but `TimeDisplayWidget::updateTime()` was only connected to `MainWindow::periodicUpdate()` — a timer — so the MIN-SEC-MSEC display lagged by up to one timer tick before refreshing.

## Fix

Add a single connection from `Timeline::positionJumped` on the `PlayMode::None` timeline to `TimeDisplayWidget::updateTime()`.

- When paused, `updateTime()` reads `getTimeline(m_playMode)` = `getTimeline(PlayMode::None)`, so this is the only timeline whose jumps are visible in the display.
- `positionJumped` is emitted by `Timeline::setTicks()` (explicit seeks) but **not** by `incrementTicks()` (normal playback advancement), so this connection is silent during playback and adds no overhead on the hot path.
- Connecting to all timelines (the naive approach) would cause ordering issues: the `Song` timeline fires before `None` is updated, so the first `updateTime()` call would show a stale value.

## Changed file

`src/gui/widgets/TimeDisplayWidget.cpp` — two lines added to the constructor.