### PR TITLE
Fix pan/velocity underflow when dragging lower than window bottom

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2604,15 +2604,15 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 
 			if( me->buttons() & Qt::LeftButton )
 			{
-				vol = qBound(MinVolume, static_cast<volume_t>(MinVolume
-					+ static_cast<float>(noteEditBottom() - pos.y())
+				vol = std::clamp(static_cast<volume_t>(MinVolume
+					+ static_cast<float>(noteEditBottom() -  std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
-					* (MaxVolume - MinVolume)), MaxVolume);
+					* (MaxVolume - MinVolume)), MinVolume, MaxVolume);
 
-				pan = qBound(PanningLeft, static_cast<panning_t>(PanningLeft
-					+ static_cast<float>(noteEditBottom() - pos.y())
+				pan = std::clamp(static_cast<panning_t>(PanningLeft
+					+ static_cast<float>(noteEditBottom() - std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
-					* (PanningRight - PanningLeft)), PanningRight);
+					* (PanningRight - PanningLeft)), PanningLeft, PanningRight);
 			}
 
 			if( m_noteEditMode == NoteEditMode::Volume )

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2530,6 +2530,9 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	}
 	else if (pos.y() > PR_TOP_MARGIN || m_action != Action::None)
 	{
+		// TODO convert this into a proper separate action so that it doesn't require
+		// cursor to be within the bounds *while* dragging.
+		// See: https://github.com/LMMS/lmms/pull/8389#issuecomment-4486111452
 		bool edit_note = (pos.y() > noteEditTop())
 			&& m_action != Action::SelectNotes;
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2608,12 +2608,12 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			if( me->buttons() & Qt::LeftButton )
 			{
 				vol = std::clamp(static_cast<volume_t>(MinVolume
-					+ static_cast<float>(noteEditBottom() -  std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
+					+ static_cast<float>(std::max(0, noteEditBottom() - pos.y()))
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (MaxVolume - MinVolume)), MinVolume, MaxVolume);
 
 				pan = std::clamp(static_cast<panning_t>(PanningLeft
-					+ static_cast<float>(noteEditBottom() - std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
+					+ static_cast<float>(std::max(0, noteEditBottom() - pos.y()))
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (PanningRight - PanningLeft)), PanningLeft, PanningRight);
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2530,8 +2530,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	}
 	else if (pos.y() > PR_TOP_MARGIN || m_action != Action::None)
 	{
-		bool edit_note = pos.y() > noteEditTop()
-			&& pos.y() <= noteEditBottom()
+		bool edit_note = (pos.y() > noteEditTop())
 			&& m_action != Action::SelectNotes;
 
 
@@ -2606,12 +2605,12 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			if( me->buttons() & Qt::LeftButton )
 			{
 				vol = std::clamp(static_cast<volume_t>(MinVolume
-					+ static_cast<float>(noteEditBottom() - pos.y())
+					+ static_cast<float>(noteEditBottom() -  std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (MaxVolume - MinVolume)), MinVolume, MaxVolume);
 
 				pan = std::clamp(static_cast<panning_t>(PanningLeft
-					+ static_cast<float>(noteEditBottom() - pos.y())
+					+ static_cast<float>(noteEditBottom() - std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (PanningRight - PanningLeft)), PanningLeft, PanningRight);
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2530,7 +2530,8 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 	}
 	else if (pos.y() > PR_TOP_MARGIN || m_action != Action::None)
 	{
-		bool edit_note = (pos.y() > noteEditTop())
+		bool edit_note = pos.y() > noteEditTop()
+			&& pos.y() <= noteEditBottom()
 			&& m_action != Action::SelectNotes;
 
 
@@ -2605,12 +2606,12 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			if( me->buttons() & Qt::LeftButton )
 			{
 				vol = std::clamp(static_cast<volume_t>(MinVolume
-					+ static_cast<float>(noteEditBottom() -  std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
+					+ static_cast<float>(noteEditBottom() - pos.y())
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (MaxVolume - MinVolume)), MinVolume, MaxVolume);
 
 				pan = std::clamp(static_cast<panning_t>(PanningLeft
-					+ static_cast<float>(noteEditBottom() - std::min(noteEditBottom(), pos.y())) // TODO C++26: saturating_sub
+					+ static_cast<float>(noteEditBottom() - pos.y())
 					/ static_cast<float>(noteEditBottom() - noteEditTop())
 					* (PanningRight - PanningLeft)), PanningLeft, PanningRight);
 			}


### PR DESCRIPTION
Bug:

https://github.com/user-attachments/assets/4a6a4f42-93fe-4879-8acb-31843c510699



Simple fix, perhaps the equation could be optimized more. `__builtin_sub_overflow` could be used instead of manual sub/max before C++26, would probably be faster. Don't know if relying on builtins here is permitted.