### PR TITLE
Disable vst embedding by default

### DIFF
--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -216,8 +216,8 @@ QStringList ConfigManager::availableVstEmbedMethods()
 QString ConfigManager::vstEmbedMethod() const
 {
 	QStringList methods = availableVstEmbedMethods();
-	QString defaultMethod = *(methods.end() - 1);
-	QString currentMethod = value( "ui", "vstembedmethod", defaultMethod );
+	QString defaultMethod = "none";
+	QString currentMethod = value("ui", "vstembedmethod", defaultMethod);
 	return methods.contains(currentMethod) ? currentMethod : defaultMethod;
 }
 


### PR DESCRIPTION
Almost all embedding methods on all platforms are broken in some way. To provide a more stable experience by default and ease some tech support (at least the user will know how a VST window is supposed to behave and what to change to make it work again), it seems best to disable embedding by default.

This does not impact any features any embedding methods provide.