### PR TITLE
Fix `FloatModel::getDigitCount()` returning wrong value

### DIFF
--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -737,14 +737,7 @@ float FloatModel::getRoundedValue() const
 
 int FloatModel::getDigitCount() const
 {
-	auto steptemp = step<float>();
-	int digits = 0;
-	while ( steptemp < 1 )
-	{
-		steptemp = steptemp * 10.0f;
-		digits++;
-	}
-	return digits;
+	return static_cast<int>(std::ceil(-std::log10(step<float>())));
 }
 
 


### PR DESCRIPTION
Fixes #8393 by refactoring `FloatModel::getDigitCount()` to use a logarithm instead of a while loop to calculate the number of digits from the model's step size. This prevents any issues from floating-point imprecision.