### PR TITLE
Aggregate plugin load failed into a single popup

### DIFF
--- a/include/PluginLoadFailedDialog.h
+++ b/include/PluginLoadFailedDialog.h
@@ -1,0 +1,41 @@
+#ifndef PLUGIN_LOAD_FAILED_DIALOG
+#define PLUGIN_LOAD_FAILED_DIALOG
+
+#include <QDialog>
+
+class QLabel;
+class QTableWidget;
+
+namespace lmms
+{
+
+void pluginLoadFailed(QString pluginName, QString error);
+
+namespace gui
+{
+
+class PluginLoadFailedDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	static inline PluginLoadFailedDialog* inst()
+	{
+		if (s_inst == nullptr) { s_inst = new PluginLoadFailedDialog; }
+		return s_inst;
+	}
+	PluginLoadFailedDialog();
+	~PluginLoadFailedDialog() override;
+	void addEntry(QString pluginName, QString error);
+
+private:
+	static PluginLoadFailedDialog* s_inst;
+	QTableWidget* m_table;
+	QLabel* m_label;
+};
+
+} // namespace gui
+
+} // namespace lmms
+
+#endif

--- a/src/core/Plugin.cpp
+++ b/src/core/Plugin.cpp
@@ -35,6 +35,7 @@
 #include "AutomatableModel.h"
 #include "Song.h"
 #include "PluginFactory.h"
+#include "PluginLoadFailedDialog.h"
 
 namespace lmms
 {
@@ -213,14 +214,7 @@ Plugin * Plugin::instantiate(const QString& pluginName, Model * parent,
 	Plugin* inst;
 	if( pi.isNull() )
 	{
-		if (gui::getGUI() != nullptr)
-		{
-			QMessageBox::information( nullptr,
-				tr( "Plugin not found" ),
-				tr( "The plugin \"%1\" wasn't found or could not be loaded!\nReason: \"%2\"" ).
-						arg( pluginName ).arg( getPluginFactory()->errorString(pluginName) ),
-				QMessageBox::Ok | QMessageBox::Default );
-		}
+		pluginLoadFailed(pluginName, getPluginFactory()->errorString(pluginName));
 		inst = new DummyPlugin();
 	}
 	else
@@ -235,13 +229,7 @@ Plugin * Plugin::instantiate(const QString& pluginName, Model * parent,
 		}
 		else
 		{
-			if (gui::getGUI() != nullptr)
-			{
-				QMessageBox::information( nullptr,
-					tr( "Error while loading plugin" ),
-					tr( "Failed to load plugin \"%1\"!").arg( pluginName ),
-					QMessageBox::Ok | QMessageBox::Default );
-			}
+			pluginLoadFailed(pluginName, tr("Unable to find an entry point"));
 			inst = new DummyPlugin();
 		}
 	}

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(LMMS_SRCS
 	gui/modals/EffectSelectDialog.cpp
 	gui/modals/ExportProjectDialog.cpp
 	gui/modals/FileDialog.cpp
+	gui/modals/PluginLoadFailedDialog.cpp
 	gui/modals/RenameDialog.cpp
 	gui/modals/SetupDialog.cpp
 	gui/modals/VersionedSaveDialog.cpp

--- a/src/gui/modals/PluginLoadFailedDialog.cpp
+++ b/src/gui/modals/PluginLoadFailedDialog.cpp
@@ -37,7 +37,7 @@ PluginLoadFailedDialog::PluginLoadFailedDialog()
 	setAttribute(Qt::WA_DeleteOnClose);
 	setLayout(new QVBoxLayout);
 
-	m_label = new QLabel{tr("<strong>The following plugin(s) failed to load:</strong>")};
+	m_label = new QLabel{tr("<strong>The following plugins failed to load:</strong>")};
 	layout()->addWidget(m_label);
 
 	m_table = new QTableWidget;

--- a/src/gui/modals/PluginLoadFailedDialog.cpp
+++ b/src/gui/modals/PluginLoadFailedDialog.cpp
@@ -1,0 +1,63 @@
+#include "PluginLoadFailedDialog.h"
+
+#include "GuiApplication.h"
+
+#include <QBoxLayout>
+#include <QDebug>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLayout>
+#include <QTableWidget>
+#include <QString>
+
+namespace lmms
+{
+
+void pluginLoadFailed(QString pluginName, QString error)
+{
+	if (gui::getGUI())
+	{
+		gui::PluginLoadFailedDialog::inst()->addEntry(pluginName, error);
+	}
+	else
+	{
+		qWarning() << "Plugin" << pluginName << "failed to load:" <<  error;
+	}
+}
+
+namespace gui {
+
+PluginLoadFailedDialog::PluginLoadFailedDialog()
+	: QDialog{}
+{
+	setModal(false);
+	setAttribute(Qt::WA_DeleteOnClose);
+	setLayout(new QVBoxLayout);
+	m_label = new QLabel{tr("<strong>The following plugin(s) failed to load:</strong>")};
+	layout()->addWidget(m_label);
+	m_table = new QTableWidget;
+	m_table->setColumnCount(2);
+	m_table->setHorizontalHeaderLabels({tr("Plugin name"), tr("Reason")});
+	m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+	m_table->verticalHeader()->hide(); // Hides row numbers
+	layout()->addWidget(m_table);
+}
+
+PluginLoadFailedDialog::~PluginLoadFailedDialog()
+{
+	if (s_inst == this) { s_inst = nullptr; }
+}
+
+void PluginLoadFailedDialog::addEntry(QString pluginName, QString error)
+{
+	m_table->insertRow(m_table->rowCount());
+	m_table->setItem(m_table->rowCount()-1, 0, new QTableWidgetItem{pluginName});
+	m_table->setItem(m_table->rowCount()-1, 1, new QTableWidgetItem{error});
+	show();
+}
+
+PluginLoadFailedDialog* PluginLoadFailedDialog::s_inst = nullptr;
+
+} // namespace gui
+
+} // namespace lmms

--- a/src/gui/modals/PluginLoadFailedDialog.cpp
+++ b/src/gui/modals/PluginLoadFailedDialog.cpp
@@ -1,6 +1,7 @@
 #include "PluginLoadFailedDialog.h"
 
 #include "GuiApplication.h"
+#include "MainWindow.h"
 
 #include <QBoxLayout>
 #include <QDebug>
@@ -30,7 +31,7 @@ void pluginLoadFailed(QString pluginName, QString error)
 namespace gui {
 
 PluginLoadFailedDialog::PluginLoadFailedDialog()
-	: QDialog{}
+	: QDialog{getGUI()->mainWindow()}
 {
 	setModal(false);
 	setAttribute(Qt::WA_DeleteOnClose);

--- a/src/gui/modals/PluginLoadFailedDialog.cpp
+++ b/src/gui/modals/PluginLoadFailedDialog.cpp
@@ -4,6 +4,8 @@
 
 #include <QBoxLayout>
 #include <QDebug>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QHeaderView>
 #include <QLabel>
 #include <QLayout>
@@ -33,14 +35,23 @@ PluginLoadFailedDialog::PluginLoadFailedDialog()
 	setModal(false);
 	setAttribute(Qt::WA_DeleteOnClose);
 	setLayout(new QVBoxLayout);
+
 	m_label = new QLabel{tr("<strong>The following plugin(s) failed to load:</strong>")};
 	layout()->addWidget(m_label);
+
 	m_table = new QTableWidget;
+	m_table->setEditTriggers(QAbstractItemView::NoEditTriggers); // Disable cell editing
+	m_table->setFocusPolicy(Qt::NoFocus);
+	m_table->setSelectionMode(QAbstractItemView::NoSelection); // Disable cell focus/selection
 	m_table->setColumnCount(2);
 	m_table->setHorizontalHeaderLabels({tr("Plugin name"), tr("Reason")});
 	m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-	m_table->verticalHeader()->hide(); // Hides row numbers
+	m_table->verticalHeader()->hide(); // Hide row numbers
 	layout()->addWidget(m_table);
+
+	auto* dialogButtons = new QDialogButtonBox{QDialogButtonBox::Ok};
+	connect(dialogButtons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+	layout()->addWidget(dialogButtons);
 }
 
 PluginLoadFailedDialog::~PluginLoadFailedDialog()

--- a/src/gui/modals/PluginLoadFailedDialog.cpp
+++ b/src/gui/modals/PluginLoadFailedDialog.cpp
@@ -43,6 +43,7 @@ PluginLoadFailedDialog::PluginLoadFailedDialog()
 	m_table->setEditTriggers(QAbstractItemView::NoEditTriggers); // Disable cell editing
 	m_table->setFocusPolicy(Qt::NoFocus);
 	m_table->setSelectionMode(QAbstractItemView::NoSelection); // Disable cell focus/selection
+	m_table->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel); // Smooth scroll
 	m_table->setColumnCount(2);
 	m_table->setHorizontalHeaderLabels({tr("Plugin name"), tr("Reason")});
 	m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);


### PR DESCRIPTION

https://github.com/user-attachments/assets/65391c98-89c4-49dd-b092-561d3a3119aa

Popup is deleted when closed (so no memory leaks or anything) and reopened on the next load fail. This has a nice bonus of cleaning the list.