### PR TITLE
Fix subwindows occasionally snapping to minimum size 2: Electric Boogaloo

### DIFF
--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -648,6 +648,7 @@ bool SubWindow::eventFilter(QObject* obj, QEvent* event)
 
 		case QEvent::Show:
 			layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
+			resize(widget()->size().addMargins(decorationMargins())); // manually sync the sizes again
 			return QMdiSubWindow::eventFilter(obj, event);
 
 		default:

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -175,7 +175,7 @@ void SubWindow::setVisible(bool visible)
 		// For that reason we forward show/hide to the child widget, and don't touch the hidden attached window frame.
 		widget()->setVisible(visible);
 	}
-	else
+	if (!isDetached())
 	{
 		// When attached, visibility of the actual window is controlled by SubWindow.
 		// Nevertheless, the subwindow contents still need to be visible, which is addressed above.

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -169,7 +169,7 @@ void SubWindow::changeEvent( QEvent *event )
 
 void SubWindow::setVisible(bool visible)
 {
-	if (isDetached())
+	if (isDetached() || visible)
 	{
 		// When detached, top-level window is the child widget itself. (This is janky and is best changed at some point.)
 		// For that reason we forward show/hide to the child widget, and don't touch the hidden attached window frame.
@@ -178,11 +178,7 @@ void SubWindow::setVisible(bool visible)
 	else
 	{
 		// When attached, visibility of the actual window is controlled by SubWindow.
-		// SubWindow::hide() when it's already hidden still causes a size recalculation,
-		// if the child widget is hidden it does not get included into the layout, and maximum size is set to 0x0.
-		// There shouldn't be a reason to keep the child widget hidden when the subwindow is attached.
-		// see bug #8292
-		widget()->show();
+		// Nevertheless, the subwindow contents still need to be visible, which is addressed above.
 		QMdiSubWindow::setVisible(visible);
 	}
 }
@@ -617,10 +613,6 @@ bool SubWindow::eventFilter(QObject* obj, QEvent* event)
 
 	switch (event->type())
 	{
-		case QEvent::WindowStateChange:
-			event->accept();
-			return true;
-
 		case QEvent::Close:
 			if (isDetached())
 			{
@@ -648,6 +640,14 @@ bool SubWindow::eventFilter(QObject* obj, QEvent* event)
 			{
 				hide();
 			}
+			return QMdiSubWindow::eventFilter(obj, event);
+			
+		case QEvent::Hide:
+			layout()->setSizeConstraint(QLayout::SetNoConstraint);
+			return QMdiSubWindow::eventFilter(obj, event);
+
+		case QEvent::Show:
+			layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
 			return QMdiSubWindow::eventFilter(obj, event);
 
 		default:

--- a/src/gui/SubWindow.cpp
+++ b/src/gui/SubWindow.cpp
@@ -648,7 +648,6 @@ bool SubWindow::eventFilter(QObject* obj, QEvent* event)
 
 		case QEvent::Show:
 			layout()->setSizeConstraint(QLayout::SetMinAndMaxSize);
-			resize(widget()->size().addMargins(decorationMargins())); // manually sync the sizes again
 			return QMdiSubWindow::eventFilter(obj, event);
 
 		default:


### PR DESCRIPTION
Unlike the previous PR (which this pretty much reverts aside from documentation), this completely removes the layout size constraints on SubWindow when child widget is hidden, essentially allowing it to resize freely, and reapplies them once it's shown.

Possible remaining edge cases:
- I don't know if just applying size constraints triggers a resize if necessary; if not, it might be beneficial to manually trigger one.
- I don't remember how the resizes behave when sizes are desynced, i.e. whether the widget fits to subwindow, or if subwindow wraps the child. Second is ideal, it's possible to emulate it by doing `setGeometry` on child frame plus margin, don't know if there's a better way. Need a test case to do something about it, it's possible that nothing does that as of right now. <sub>this was also a thing without this PR, probably better off as a separate issue tbh if it ever becomes relevant</sub>
  + looks like Qt doesn't do anything until the first resize event? not really sure, but a resize is now called when layout is set so this should no longer be an issue
- When the frame is initially constructed the layout is always `SetMinAndMaxSize`, so if the widget was added while hidden it is possible for the bug to still occur. To do better we need to track childEvent, which is not particularly fun, or rewrite the damn thing without hijacking QMdiSubWindow (i promise i will get to it at some point ( ._.)

i also removed WindowStateChange event suppression because it seems to only cause issues and i never knew what it's even supposed to do.

Fixes #8503