### PR TITLE
Add descriptive tooltips to MIDI CC Rack knobs

### DIFF
--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -39,67 +39,53 @@
 
 namespace lmms::gui {
 
-namespace {
-QString getMidiCCName(int cc)
+namespace
 {
-	switch (cc)
+	struct CCMapping {
+		int cc;
+		const char* name;
+	};
+
+	static const CCMapping s_ccMappings[] = {
+		{ MidiControllerBankSelect, QT_TRANSLATE_NOOP("MidiCCRackView", "Bank Select") },
+		{ MidiControllerModulationWheel, QT_TRANSLATE_NOOP("MidiCCRackView", "Modulation Wheel") },
+		{ MidiControllerBreathController, QT_TRANSLATE_NOOP("MidiCCRackView", "Breath Controller") },
+		{ MidiControllerFootController, QT_TRANSLATE_NOOP("MidiCCRackView", "Foot Controller") },
+		{ MidiControllerPortamentoTime, QT_TRANSLATE_NOOP("MidiCCRackView", "Portamento Time") },
+		{ MidiControllerDataEntry, QT_TRANSLATE_NOOP("MidiCCRackView", "Data Entry") },
+		{ MidiControllerMainVolume, QT_TRANSLATE_NOOP("MidiCCRackView", "Main Volume") },
+		{ MidiControllerBalance, QT_TRANSLATE_NOOP("MidiCCRackView", "Balance") },
+		{ MidiControllerPan, QT_TRANSLATE_NOOP("MidiCCRackView", "Pan") },
+		{ MidiControllerEffectControl1, QT_TRANSLATE_NOOP("MidiCCRackView", "Effect Control 1") },
+		{ MidiControllerEffectControl2, QT_TRANSLATE_NOOP("MidiCCRackView", "Effect Control 2") },
+		{ MidiControllerSustain, QT_TRANSLATE_NOOP("MidiCCRackView", "Sustain") },
+		{ MidiControllerPortamento, QT_TRANSLATE_NOOP("MidiCCRackView", "Portamento") },
+		{ MidiControllerSostenuto, QT_TRANSLATE_NOOP("MidiCCRackView", "Sostenuto") },
+		{ MidiControllerSoftPedal, QT_TRANSLATE_NOOP("MidiCCRackView", "Soft Pedal") },
+		{ MidiControllerLegatoFootswitch, QT_TRANSLATE_NOOP("MidiCCRackView", "Legato Footswitch") },
+		{ MidiControllerRegisteredParameterNumberLSB, QT_TRANSLATE_NOOP("MidiCCRackView", "Registered Parameter Number (LSB)") },
+		{ MidiControllerRegisteredParameterNumberMSB, QT_TRANSLATE_NOOP("MidiCCRackView", "Registered Parameter Number (MSB)") },
+		{ MidiControllerAllSoundOff, QT_TRANSLATE_NOOP("MidiCCRackView", "All Sound Off") },
+		{ MidiControllerResetAllControllers, QT_TRANSLATE_NOOP("MidiCCRackView", "Reset All Controllers") },
+		{ MidiControllerLocalControl, QT_TRANSLATE_NOOP("MidiCCRackView", "Local Control") },
+		{ MidiControllerAllNotesOff, QT_TRANSLATE_NOOP("MidiCCRackView", "All Notes Off") },
+		{ MidiControllerOmniOn, QT_TRANSLATE_NOOP("MidiCCRackView", "Omni On") },
+		{ MidiControllerOmniOff, QT_TRANSLATE_NOOP("MidiCCRackView", "Omni Off") },
+		{ MidiControllerMonoOn, QT_TRANSLATE_NOOP("MidiCCRackView", "Mono On") },
+		{ MidiControllerPolyOn, QT_TRANSLATE_NOOP("MidiCCRackView", "Poly On") }
+	};
+
+	QString getMidiCCName(int cc)
 	{
-	case MidiControllerBankSelect:
-		return MidiCCRackView::tr("Bank Select");
-	case MidiControllerModulationWheel:
-		return MidiCCRackView::tr("Modulation Wheel");
-	case MidiControllerBreathController:
-		return MidiCCRackView::tr("Breath Controller");
-	case MidiControllerFootController:
-		return MidiCCRackView::tr("Foot Controller");
-	case MidiControllerPortamentoTime:
-		return MidiCCRackView::tr("Portamento Time");
-	case MidiControllerDataEntry:
-		return MidiCCRackView::tr("Data Entry");
-	case MidiControllerMainVolume:
-		return MidiCCRackView::tr("Main Volume");
-	case MidiControllerBalance:
-		return MidiCCRackView::tr("Balance");
-	case MidiControllerPan:
-		return MidiCCRackView::tr("Pan");
-	case MidiControllerEffectControl1:
-		return MidiCCRackView::tr("Effect Control 1");
-	case MidiControllerEffectControl2:
-		return MidiCCRackView::tr("Effect Control 2");
-	case MidiControllerSustain:
-		return MidiCCRackView::tr("Sustain");
-	case MidiControllerPortamento:
-		return MidiCCRackView::tr("Portamento");
-	case MidiControllerSostenuto:
-		return MidiCCRackView::tr("Sostenuto");
-	case MidiControllerSoftPedal:
-		return MidiCCRackView::tr("Soft Pedal");
-	case MidiControllerLegatoFootswitch:
-		return MidiCCRackView::tr("Legato Footswitch");
-	case MidiControllerRegisteredParameterNumberLSB:
-		return MidiCCRackView::tr("Registered Parameter Number (LSB)");
-	case MidiControllerRegisteredParameterNumberMSB:
-		return MidiCCRackView::tr("Registered Parameter Number (MSB)");
-	case MidiControllerAllSoundOff:
-		return MidiCCRackView::tr("All Sound Off");
-	case MidiControllerResetAllControllers:
-		return MidiCCRackView::tr("Reset All Controllers");
-	case MidiControllerLocalControl:
-		return MidiCCRackView::tr("Local Control");
-	case MidiControllerAllNotesOff:
-		return MidiCCRackView::tr("All Notes Off");
-	case MidiControllerOmniOn:
-		return MidiCCRackView::tr("Omni On");
-	case MidiControllerOmniOff:
-		return MidiCCRackView::tr("Omni Off");
-	case MidiControllerMonoOn:
-		return MidiCCRackView::tr("Mono On");
-	case MidiControllerPolyOn:
-		return MidiCCRackView::tr("Poly On");
-	default:
+		for (const auto& mapping : s_ccMappings)
+		{
+			if (mapping.cc == cc)
+			{
+				return MidiCCRackView::tr(mapping.name);
+			}
+		}
 		return QString();
 	}
-}
 } // namespace
 
 MidiCCRackView::MidiCCRackView(InstrumentTrack* track)

--- a/src/gui/MidiCCRackView.cpp
+++ b/src/gui/MidiCCRackView.cpp
@@ -22,7 +22,6 @@
  *
  */
 
-
 #include "MidiCCRackView.h"
 
 #include <QGridLayout>
@@ -30,21 +29,82 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-#include "embed.h"
 #include "GroupBox.h"
 #include "GuiApplication.h"
 #include "InstrumentTrack.h"
 #include "Knob.h"
 #include "MainWindow.h"
 #include "SubWindow.h"
+#include "embed.h"
 
-namespace lmms::gui
+namespace lmms::gui {
+
+namespace {
+QString getMidiCCName(int cc)
 {
+	switch (cc)
+	{
+	case MidiControllerBankSelect:
+		return MidiCCRackView::tr("Bank Select");
+	case MidiControllerModulationWheel:
+		return MidiCCRackView::tr("Modulation Wheel");
+	case MidiControllerBreathController:
+		return MidiCCRackView::tr("Breath Controller");
+	case MidiControllerFootController:
+		return MidiCCRackView::tr("Foot Controller");
+	case MidiControllerPortamentoTime:
+		return MidiCCRackView::tr("Portamento Time");
+	case MidiControllerDataEntry:
+		return MidiCCRackView::tr("Data Entry");
+	case MidiControllerMainVolume:
+		return MidiCCRackView::tr("Main Volume");
+	case MidiControllerBalance:
+		return MidiCCRackView::tr("Balance");
+	case MidiControllerPan:
+		return MidiCCRackView::tr("Pan");
+	case MidiControllerEffectControl1:
+		return MidiCCRackView::tr("Effect Control 1");
+	case MidiControllerEffectControl2:
+		return MidiCCRackView::tr("Effect Control 2");
+	case MidiControllerSustain:
+		return MidiCCRackView::tr("Sustain");
+	case MidiControllerPortamento:
+		return MidiCCRackView::tr("Portamento");
+	case MidiControllerSostenuto:
+		return MidiCCRackView::tr("Sostenuto");
+	case MidiControllerSoftPedal:
+		return MidiCCRackView::tr("Soft Pedal");
+	case MidiControllerLegatoFootswitch:
+		return MidiCCRackView::tr("Legato Footswitch");
+	case MidiControllerRegisteredParameterNumberLSB:
+		return MidiCCRackView::tr("Registered Parameter Number (LSB)");
+	case MidiControllerRegisteredParameterNumberMSB:
+		return MidiCCRackView::tr("Registered Parameter Number (MSB)");
+	case MidiControllerAllSoundOff:
+		return MidiCCRackView::tr("All Sound Off");
+	case MidiControllerResetAllControllers:
+		return MidiCCRackView::tr("Reset All Controllers");
+	case MidiControllerLocalControl:
+		return MidiCCRackView::tr("Local Control");
+	case MidiControllerAllNotesOff:
+		return MidiCCRackView::tr("All Notes Off");
+	case MidiControllerOmniOn:
+		return MidiCCRackView::tr("Omni On");
+	case MidiControllerOmniOff:
+		return MidiCCRackView::tr("Omni Off");
+	case MidiControllerMonoOn:
+		return MidiCCRackView::tr("Mono On");
+	case MidiControllerPolyOn:
+		return MidiCCRackView::tr("Poly On");
+	default:
+		return QString();
+	}
+}
+} // namespace
 
-
-MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
-	QWidget(),
-	m_track(track)
+MidiCCRackView::MidiCCRackView(InstrumentTrack* track)
+	: QWidget()
+	, m_track(track)
 {
 	setWindowIcon(embed::getIconPixmap("midi_cc_rack"));
 	setWindowTitle(tr("MIDI CC Rack - %1").arg(m_track->name()));
@@ -90,8 +150,16 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	for (int i = 0; i < MidiControllerCount; ++i)
 	{
 		auto knob = new Knob(KnobType::Bright26, tr("CC %1").arg(i), this);
+
+		QString ccName = getMidiCCName(i);
+		if (!ccName.isEmpty()) { knob->setToolTip(tr("CC %1: %2").arg(i).arg(ccName)); }
+		else
+		{
+			knob->setToolTip(tr("CC %1").arg(i));
+		}
+
 		knob->setModel(m_track->m_midiCCModel[i].get());
-		knobsAreaLayout->addWidget(knob, i/4, i%4, Qt::AlignHCenter);
+		knobsAreaLayout->addWidget(knob, i / 4, i % 4, Qt::AlignHCenter);
 
 		// TODO It seems that this is not really used/needed?
 		m_controllerKnob[i] = knob;
@@ -102,8 +170,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 	m_midiCCGroupBox->setModel(m_track->m_midiCCEnable.get());
 
 	// Connection to update the name of the track on the label
-	connect(m_track, SIGNAL(nameChanged()),
-		this, SLOT(renameWindow()));
+	connect(m_track, SIGNAL(nameChanged()), this, SLOT(renameWindow()));
 
 	// Adding everything to the main layout
 	mainLayout->addWidget(m_midiCCGroupBox);
@@ -111,7 +178,7 @@ MidiCCRackView::MidiCCRackView(InstrumentTrack * track) :
 
 MidiCCRackView::~MidiCCRackView()
 {
-	if(parentWidget())
+	if (parentWidget())
 	{
 		parentWidget()->hide();
 		parentWidget()->deleteLater();
@@ -123,13 +190,12 @@ void MidiCCRackView::renameWindow()
 	setWindowTitle(tr("MIDI CC Rack - %1").arg(m_track->name()));
 }
 
-void MidiCCRackView::saveSettings(QDomDocument & doc, QDomElement & parent)
+void MidiCCRackView::saveSettings(QDomDocument& doc, QDomElement& parent)
 {
 }
 
-void MidiCCRackView::loadSettings(const QDomElement &)
+void MidiCCRackView::loadSettings(const QDomElement&)
 {
 }
-
 
 } // namespace lmms::gui


### PR DESCRIPTION
- Added a getMidiCCName helper function in an anonymous namespace within MidiCCRackView.cpp to resolve standard MIDI CC designations defined in include/Midi.h.
- Updated the MidiCCRackView constructor to fetch these descriptive names and apply them as tooltips to the individual Knob widgets.
- If a CC has a standard name, hovering over the knob will now display something like CC 1: Modulation Wheel or CC 7: Main Volume. If no standard name exists, it simply falls back to the default CC #.
- The visual layout of the rack remains unaffected to keep the interface clean, with the new information unobtrusively accessible via hover.

Fixes #8354 