### PR TITLE
Add the ability to hide tracks in the pattern editor

### DIFF
--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -103,6 +103,11 @@ public:
 		const bool ignoreSurroundingPoints = true
 	);
 
+	bool isEmpty() override
+	{
+		return m_timeMap.empty();
+	}
+
 	void removeNode(const TimePos & time);
 	void removeNodes(const int tick0, const int tick1);
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -99,6 +99,11 @@ public:
 
 	bool isInPattern() const;
 
+	virtual bool isEmpty()
+	{
+		return false;
+	}
+
 	bool manuallyResizable() const;
 
 	/*! \brief Set whether a clip has been resized yet by the user or the knife tool.

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -49,6 +49,7 @@ class TrackView;
 class LMMS_EXPORT Clip : public Model, public JournallingObject
 {
 	Q_OBJECT
+	mapPropertyFromModel(bool,isHidden,setHidden,m_hiddenModel);
 	mapPropertyFromModel(bool,isMuted,setMuted,m_mutedModel);
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
@@ -171,6 +172,7 @@ private:
 	TimePos m_length;
 	TimePos m_startTimeOffset;
 
+	BoolModel m_hiddenModel;
 	BoolModel m_mutedModel;
 	BoolModel m_soloModel;
 	bool m_autoResize = true;

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -93,6 +93,11 @@ public:
 		return m_clipType;
 	}
 
+	bool isEmpty() override
+	{
+		return !m_notes.size();
+	}
+
 
 	// next/previous track based on position in the containing track
 	MidiClip * previousMidiClip() const;

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -69,6 +69,7 @@ protected slots:
 	void dropEvent(QDropEvent * de ) override;
 	void resizeEvent(QResizeEvent* de) override;
 	void showAllTracks();
+	void hideEmptyTracks();
 	void updatePosition();
 	void updatePixelsPerBar();
 

--- a/include/PatternEditor.h
+++ b/include/PatternEditor.h
@@ -68,6 +68,7 @@ public slots:
 protected slots:
 	void dropEvent(QDropEvent * de ) override;
 	void resizeEvent(QResizeEvent* de) override;
+	void showAllTracks();
 	void updatePosition();
 	void updatePixelsPerBar();
 

--- a/include/SampleClip.h
+++ b/include/SampleClip.h
@@ -79,6 +79,11 @@ public:
 	void setIsPlaying(bool isPlaying);
 	void setSampleBuffer(std::shared_ptr<const SampleBuffer> sb);
 
+	bool isEmpty() override
+	{
+		return !m_sample.sampleSize();
+	}
+
 	SampleClip* clone() override
 	{
 		return new SampleClip(*this);

--- a/include/Track.h
+++ b/include/Track.h
@@ -140,6 +140,7 @@ public:
 
 	bool hiddenForPattern(int pattern);
 	void setVisibilityForPattern(bool hidden, int pattern);
+	void hideForPatternIfEmpty(int pattern);
 
 	void insertBar( const TimePos & pos );
 	void removeBar( const TimePos & pos );

--- a/include/Track.h
+++ b/include/Track.h
@@ -138,9 +138,9 @@ public:
 
 	void createClipsForPattern(int pattern);
 
-	bool hiddenForPattern(int pattern);
-	void setVisibilityForPattern(bool hidden, int pattern);
-	void hideForPatternIfEmpty(int pattern);
+	bool hiddenForPattern(size_t pattern);
+	void setVisibilityForPattern(bool hidden, size_t pattern);
+	void hideForPatternIfEmpty(size_t pattern);
 
 	void insertBar( const TimePos & pos );
 	void removeBar( const TimePos & pos );

--- a/include/Track.h
+++ b/include/Track.h
@@ -138,6 +138,8 @@ public:
 
 	void createClipsForPattern(int pattern);
 
+	bool hiddenForPattern(int pattern);
+	void setVisibilityForPattern(bool hidden, int pattern);
 
 	void insertBar( const TimePos & pos );
 	void removeBar( const TimePos & pos );
@@ -238,6 +240,7 @@ signals:
 	void nameChanged();
 	void clipAdded( lmms::Clip * );
 	void colorChanged();
+	void visibilityChanged();
 } ;
 
 

--- a/include/TrackOperationsWidget.h
+++ b/include/TrackOperationsWidget.h
@@ -63,6 +63,7 @@ private slots:
 	void recordingOn();
 	void recordingOff();
 	void clearTrack();
+	void hideTrack();
 
 private:
 	TrackView * m_trackView;

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -104,9 +104,12 @@ public:
 	// Currently instrument track and sample track supports it
 	virtual QMenu * createMixerMenu(QString title, QString newMixerLabel);
 
+	void setVisibleForThisPattern(bool hidden);
+
 
 public slots:
 	virtual bool close();
+	void visibilityChanged();
 
 
 protected:

--- a/include/TrackView.h
+++ b/include/TrackView.h
@@ -105,6 +105,7 @@ public:
 	virtual QMenu * createMixerMenu(QString title, QString newMixerLabel);
 
 	void setVisibleForThisPattern(bool hidden);
+	void hideIfEmpty();
 
 
 public slots:

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -785,6 +785,7 @@ void AutomationClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 	_this.setAttribute( "name", name() );
 	_this.setAttribute( "prog", QString::number( static_cast<int>(progressionType()) ) );
 	_this.setAttribute( "tens", QString::number( getTension() ) );
+	_this.setAttribute( "hidden", QString::number( isHidden() ) );
 	_this.setAttribute( "mute", QString::number( isMuted() ) );
 	_this.setAttribute("off", startTimeOffset());
 	_this.setAttribute("autoresize", QString::number(getAutoResize()));
@@ -837,6 +838,7 @@ void AutomationClip::loadSettings( const QDomElement & _this )
 	setProgressionType( static_cast<ProgressionType>( _this.attribute(
 							"prog" ).toInt() ) );
 	setTension( _this.attribute( "tens" ) );
+	setHidden(_this.attribute( "hidden", QString::number( false ) ).toInt() );
 	setMuted(_this.attribute( "mute", QString::number( false ) ).toInt() );
 	setAutoResize(_this.attribute("autoresize", "1").toInt());
 	setStartTimeOffset(_this.attribute("off").toInt());

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -55,6 +55,8 @@ Clip::Clip( Track * track ) :
 	if( getTrack() )
 	{
 		getTrack()->addClip( this );
+		connect(&m_hiddenModel, SIGNAL(dataChanged()),
+				getTrack(), SIGNAL(visibilityChanged()));
 	}
 	setJournalling( false );
 	movePosition( 0 );
@@ -84,6 +86,8 @@ Clip::Clip(const Clip& other):
 	if (getTrack())
 	{
 		getTrack()->addClip(this);
+		connect(&m_hiddenModel, SIGNAL(dataChanged()),
+				getTrack(), SIGNAL(visibilityChanged()));
 	}
 }
 

--- a/src/core/SampleClip.cpp
+++ b/src/core/SampleClip.cpp
@@ -274,6 +274,7 @@ void SampleClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		_this.setAttribute( "pos", startPosition() );
 	}
 	_this.setAttribute( "len", length() );
+	_this.setAttribute( "hidden", isHidden() );
 	_this.setAttribute( "muted", isMuted() );
 	_this.setAttribute( "src", sampleFile() );
 	_this.setAttribute( "off", startTimeOffset() );
@@ -324,6 +325,7 @@ void SampleClip::loadSettings( const QDomElement & _this )
 		m_sample = Sample(std::move(buffer));
 	}
 	changeLength( _this.attribute( "len" ).toInt() );
+	setHidden( _this.attribute( "hidden" ).toInt() );
 	setMuted( _this.attribute( "muted" ).toInt() );
 	setStartTimeOffset( _this.attribute( "off" ).toInt() );
 	setAutoResize(_this.attribute("autoresize", "1").toInt());

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -517,7 +517,6 @@ void Track::setVisibilityForPattern(bool hidden, size_t pattern)
 	if (pattern < m_clips.size())
 	{
 		m_clips[pattern]->setHidden(hidden);
-		emit visibilityChanged();
 	}
 }
 
@@ -527,7 +526,7 @@ void Track::hideForPatternIfEmpty(size_t pattern)
 	{
 		if (m_clips[pattern]->isEmpty())
 		{
-			setVisibilityForPattern(true, pattern);
+			m_clips[pattern]->setHidden(true);
 		}
 	}
 }

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -521,6 +521,17 @@ void Track::setVisibilityForPattern(bool hidden, int pattern)
 	}
 }
 
+void Track::hideForPatternIfEmpty(int pattern)
+{
+	if (pattern < m_clips.size())
+	{
+		if (m_clips[pattern]->isEmpty())
+		{
+			setVisibilityForPattern(true, pattern);
+		}
+	}
+}
+
 
 
 

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -505,14 +505,14 @@ void Track::createClipsForPattern(int pattern)
 }
 
 
-bool Track::hiddenForPattern(int pattern)
+bool Track::hiddenForPattern(size_t pattern)
 {
 	if (pattern >= m_clips.size())
 		return false;
 	return m_clips[pattern]->isHidden();
 }
 
-void Track::setVisibilityForPattern(bool hidden, int pattern)
+void Track::setVisibilityForPattern(bool hidden, size_t pattern)
 {
 	if (pattern < m_clips.size())
 	{
@@ -521,7 +521,7 @@ void Track::setVisibilityForPattern(bool hidden, int pattern)
 	}
 }
 
-void Track::hideForPatternIfEmpty(int pattern)
+void Track::hideForPatternIfEmpty(size_t pattern)
 {
 	if (pattern < m_clips.size())
 	{

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -505,6 +505,23 @@ void Track::createClipsForPattern(int pattern)
 }
 
 
+bool Track::hiddenForPattern(int pattern)
+{
+	if (pattern >= m_clips.size())
+		return false;
+	return m_clips[pattern]->isHidden();
+}
+
+void Track::setVisibilityForPattern(bool hidden, int pattern)
+{
+	if (pattern < m_clips.size())
+	{
+		m_clips[pattern]->setHidden(hidden);
+		emit visibilityChanged();
+	}
+}
+
+
 
 
 /*! \brief Move all the clips after a certain time later by one bar.

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -199,6 +199,14 @@ void PatternEditor::showAllTracks()
 	}
 }
 
+void PatternEditor::hideEmptyTracks()
+{
+	for (const auto& trackView : trackViews())
+	{
+		trackView->hideIfEmpty();
+	}
+}
+
 
 void PatternEditor::updatePosition()
 {
@@ -333,6 +341,8 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 						m_editor, SLOT(addAutomationTrack()));
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap(""), tr("Show all"),
 						m_editor, SLOT(showAllTracks()));
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap(""), tr("Hide empty"),
+						m_editor, SLOT(hideEmptyTracks()));
 
 	auto stretch = new QWidget(m_toolBar);
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/src/gui/editors/PatternEditor.cpp
+++ b/src/gui/editors/PatternEditor.cpp
@@ -191,6 +191,15 @@ void PatternEditor::resizeEvent(QResizeEvent* re)
 }
 
 
+void PatternEditor::showAllTracks()
+{
+	for (const auto& trackView : trackViews())
+	{
+		trackView->setVisibleForThisPattern(false);
+	}
+}
+
+
 void PatternEditor::updatePosition()
 {
 	//realignTracks();
@@ -322,6 +331,8 @@ PatternEditorWindow::PatternEditorWindow(PatternStore* ps) :
 						m_editor, SLOT(addSampleTrack()));
 	trackAndStepActionsToolBar->addAction(embed::getIconPixmap("add_automation"), tr("Add automation-track"),
 						m_editor, SLOT(addAutomationTrack()));
+	trackAndStepActionsToolBar->addAction(embed::getIconPixmap(""), tr("Show all"),
+						m_editor, SLOT(showAllTracks()));
 
 	auto stretch = new QWidget(m_toolBar);
 	stretch->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -43,6 +43,7 @@
 #include "InstrumentTrackView.h"
 #include "lmms_math.h"
 #include "KeyboardShortcuts.h"
+#include "PatternStore.h"
 #include "Song.h"
 #include "StringPairDrag.h"
 #include "Track.h"
@@ -236,6 +237,12 @@ void TrackOperationsWidget::clearTrack()
 }
 
 
+void TrackOperationsWidget::hideTrack()
+{
+	m_trackView->setVisibleForThisPattern(true);
+}
+
+
 /*! \brief Remove this track from the track list
  *
  */
@@ -312,6 +319,10 @@ void TrackOperationsWidget::updateMenu()
 	if( ! m_trackView->trackContainerView()->fixedClips() )
 	{
 		toMenu->addAction( tr( "Clear this track" ), this, SLOT(clearTrack()));
+	}
+	if (m_trackView->getTrack()->trackContainer() == Engine::patternStore())
+	{
+		toMenu->addAction(tr( "Hide this track for current pattern" ), this, SLOT(hideTrack()));
 	}
 	if (QMenu *mixerMenu = m_trackView->createMixerMenu(tr("Channel %1: %2"), tr("Assign to new Mixer Channel")))
 	{

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -39,6 +39,7 @@
 #include "DeprecationHelper.h"
 #include "Engine.h"
 #include "FadeButton.h"
+#include "PatternStore.h"
 #include "StringPairDrag.h"
 #include "Track.h"
 #include "TrackGrip.h"
@@ -95,6 +96,8 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 			this, SLOT(createClipView(lmms::Clip*)),
 			Qt::QueuedConnection );
 
+	connect(m_track, SIGNAL(visibilityChanged()), this, SLOT(visibilityChanged()));
+
 	connect( &m_track->m_mutedModel, SIGNAL(dataChanged()),
 			&m_trackContentWidget, SLOT(update()));
 
@@ -115,6 +118,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	}
 
 	m_trackContainerView->addTrackView( this );
+	visibilityChanged();
 }
 
 
@@ -157,7 +161,7 @@ void TrackView::update()
 	{
 		m_trackContentWidget.changePosition();
 	}
-	QWidget::update();
+	visibilityChanged();
 }
 
 
@@ -435,11 +439,29 @@ void TrackView::createClipView( Clip * clip )
 
 
 
+void TrackView::setVisibleForThisPattern(bool hidden)
+{
+	m_track->setVisibilityForPattern(hidden, Engine::patternStore()->currentPattern());
+}
+
+
+
 
 void TrackView::muteChanged()
 {
 	FadeButton * indicator = getActivityIndicator();
 	if (indicator) { setIndicatorMute(indicator, m_track->m_mutedModel.value()); }
+}
+
+
+void TrackView::visibilityChanged()
+{
+	PatternStore* ps = Engine::patternStore();
+	if (m_track->trackContainer() == ps)
+	{
+		setVisible(!m_track->hiddenForPattern(ps->currentPattern()));
+	}
+	QWidget::update();
 }
 
 

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -443,7 +443,10 @@ void TrackView::setVisibleForThisPattern(bool hidden)
 {
 	m_track->setVisibilityForPattern(hidden, Engine::patternStore()->currentPattern());
 }
-
+void TrackView::hideIfEmpty()
+{
+	m_track->hideForPatternIfEmpty(Engine::patternStore()->currentPattern());
+}
 
 
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -451,6 +451,7 @@ void MidiClip::exportToXML(QDomDocument& doc, QDomElement& midiClipElement, bool
 	{
 		midiClipElement.setAttribute("pos", startPosition());
 	}
+	midiClipElement.setAttribute("hidden", isHidden());
 	midiClipElement.setAttribute("muted", isMuted());
 	midiClipElement.setAttribute("steps", m_steps);
 	midiClipElement.setAttribute("len", length());
@@ -489,6 +490,8 @@ void MidiClip::loadSettings( const QDomElement & _this )
 	{
 		movePosition( _this.attribute( "pos" ).toInt() );
 	}
+	setHidden(static_cast<bool>(_this.attribute("hidden").toInt()));
+	
 	if (static_cast<bool>(_this.attribute("muted").toInt()) != isMuted())
 	{
 		toggleMute();


### PR DESCRIPTION
This PR introduce the ability to hide tracks for a specific pattern in the pattern editor.
- One option is added in the track's actions menu: "Hide track for the current pattern"
- Two buttons are added in the pattern editor window toolbar: "Show all" and "Hide empty"

https://github.com/user-attachments/assets/ad7ef0cc-be89-431c-8f94-7f7c4f0d6d9a



**General principle:**
A new BoolModel member is added to `Clip` (`m_hiddenModel`).
In the `PatternStore` (the track container that stores all the patterns), each track contain one clip for each pattern. If `m_hiddenModel` is true for a clip, the track is hidden in the corresponding pattern.

**Remaining tasks:**
- ~~Update track view after an undo/redo of its visibility~~
- Add svg icons for the new buttons
- (Maybe) design a better UI for the new functionality