### PR TITLE
Map BarModelEditor (aka "fader" even though it's a different thing) progress directly to cursor

### DIFF
--- a/include/BarModelEditor.h
+++ b/include/BarModelEditor.h
@@ -44,6 +44,8 @@ public:
 
 	BarModelEditor(QString text, FloatModel * floatModel, QWidget * parent = nullptr);
 
+	void setPositionAbsolute(const QPoint& p);
+
 	// Define how the widget will behave in a layout
 	QSizePolicy sizePolicy() const;
 
@@ -62,6 +64,7 @@ public:
 
 protected:
 	void paintEvent(QPaintEvent *event) override;
+	void mouseMoveEvent(QMouseEvent* me) override;
 
 private:
 	QString const m_text;

--- a/src/gui/widgets/BarModelEditor.cpp
+++ b/src/gui/widgets/BarModelEditor.cpp
@@ -2,6 +2,8 @@
 
 #include <QPainter>
 
+#include "DeprecationHelper.h"
+
 
 namespace lmms::gui
 {
@@ -61,6 +63,45 @@ void BarModelEditor::setTextColor(QColor const & textColor)
 {
 	m_textColor = textColor;
 }
+
+void BarModelEditor::setPositionAbsolute(const QPoint& p)
+{
+	auto* mod = model();
+	const auto minValue = mod->minValue();
+	const auto maxValue = mod->maxValue();
+	const auto range = maxValue - minValue;
+	if (range == 0) { return; }
+
+	QRect const r = rect();
+
+	const int margin = 3;
+	const QMargins margins(margin, margin, margin, margin);
+	const QRect valueRect = r.marginsRemoved(margins);
+
+	const float percentage = static_cast<float>(p.x() - valueRect.left()) / valueRect.width();
+	const float scaledValue = mod->scaledValue(percentage * range + minValue);
+	const auto step = mod->step<float>();
+	const float roundedValue = std::round(scaledValue / step) * step;
+	mod->setValue(roundedValue);
+}
+
+
+void BarModelEditor::mouseMoveEvent(QMouseEvent * me)
+{
+	const auto pos = position(me);
+
+	if (m_buttonPressed && pos != m_lastMousePos)
+	{
+		// knob position is changed depending on last mouse position
+		setPositionAbsolute(pos);
+		emit sliderMoved(model()->value());
+		// original position for next time is current position
+		m_lastMousePos = pos;
+	}
+
+	showTextFloat();
+}
+	
 
 void BarModelEditor::paintEvent(QPaintEvent *event)
 {


### PR DESCRIPTION

https://github.com/user-attachments/assets/7aad1104-1dc3-436b-862c-ac62883eb72c

List of sins:

- `BarModelEditor::setPositionAbsolute` feels like it shouldn't exist, or at least should be in `FloatModelEditorBase`
- `BarModelEditor::setPositionAbsolute` steals some code from `BarModelEditor::paintEvent`
- `BarModelEditor::setPositionAbsolute` steals everything else from `FloatModelEditorBase::setPosition`
- `BarModelEditor::mouseMoveEvent` is a very close copy of `FloatModelEditorBase::mouseMoveEvent`, but position isn't relative
- single click doesn't change the value, only dragging does
- undocumented