### PR TITLE
docs: fix update libstk0-dev to libstk-dev for debian/ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ IF(WANT_STK)
 		SET(STATUS_STK "OK")
 	ELSE(STK_FOUND)
 		SET(STK_INCLUDE_DIR "")
-		SET(STATUS_STK "not found, please install libstk0-dev (or libstk-dev) "
+		SET(STATUS_STK "not found, please install libstk-dev (or similar) "
 			"if you require the Mallets instrument")
 	ENDIF(STK_FOUND)
 ENDIF(WANT_STK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ IF(WANT_STK)
 		SET(STATUS_STK "OK")
 	ELSE(STK_FOUND)
 		SET(STK_INCLUDE_DIR "")
-		SET(STATUS_STK "not found, please install libstk-dev (or similar) "
+		SET(STATUS_STK "not found, please install libstk-dev or libstk0-dev (or similar)"
 			"if you require the Mallets instrument")
 	ENDIF(STK_FOUND)
 ENDIF(WANT_STK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ IF(WANT_STK)
 		SET(STATUS_STK "OK")
 	ELSE(STK_FOUND)
 		SET(STK_INCLUDE_DIR "")
-		SET(STATUS_STK "not found, please install libstk0-dev (or similar) "
+		SET(STATUS_STK "not found, please install libstk0-dev (or libstk-dev) "
 			"if you require the Mallets instrument")
 	ENDIF(STK_FOUND)
 ENDIF(WANT_STK)


### PR DESCRIPTION
Fixes #8408 

I have changes on wiki submodule, but it seems like github doesn't support PR for submodule

This PR specifies similar dependency of `libstk0-dev`
Feel free to close this PR if you think the change is trivial.

For wiki changes, see my [commit](https://github.com/NewBieCoderXD/lmms-wiki-fork/commit/1a66833dff30267956d612d635f0bee213bf95b0).