### PR TITLE
Add missing Q_OBJECT macros

### DIFF
--- a/include/AudioPortAudio.h
+++ b/include/AudioPortAudio.h
@@ -93,6 +93,7 @@ private:
 namespace lmms::gui {
 class AudioPortAudioSetupWidget : public AudioDeviceSetupWidget
 {
+	Q_OBJECT
 public:
 	AudioPortAudioSetupWidget(QWidget* parent);
 

--- a/include/AudioSdl.h
+++ b/include/AudioSdl.h
@@ -54,6 +54,7 @@ public:
 
 	class setupWidget : public gui::AudioDeviceSetupWidget
 	{
+		Q_OBJECT
 	public:
 		setupWidget( QWidget * _parent );
 		~setupWidget() override = default;

--- a/include/AudioSoundIo.h
+++ b/include/AudioSoundIo.h
@@ -71,6 +71,7 @@ public:
 
 	class setupWidget : public gui::AudioDeviceSetupWidget
 	{
+		Q_OBJECT
 	public:
 		setupWidget( QWidget * _parent );
 		virtual ~setupWidget();

--- a/include/ExportProjectDialog.h
+++ b/include/ExportProjectDialog.h
@@ -43,6 +43,7 @@ namespace lmms::gui {
 
 class ExportProjectDialog : public QDialog
 {
+	Q_OBJECT
 public:
 	enum class Mode
 	{

--- a/include/LmmsStyle.h
+++ b/include/LmmsStyle.h
@@ -36,6 +36,7 @@ namespace lmms::gui
 
 class LmmsStyle : public QProxyStyle
 {
+	Q_OBJECT
 public:
 	LmmsStyle();
 	~LmmsStyle() override = default;

--- a/include/VersionedSaveDialog.h
+++ b/include/VersionedSaveDialog.h
@@ -38,6 +38,7 @@ namespace lmms::gui
 class LedCheckBox;
 
 class SaveOptionsWidget : public QWidget {
+	Q_OBJECT
 public:
 	SaveOptionsWidget(Song::SaveOptions &saveOptions);
 

--- a/src/core/audio/AudioPortAudio.cpp
+++ b/src/core/audio/AudioPortAudio.cpp
@@ -210,6 +210,7 @@ namespace lmms::gui {
 
 class AudioPortAudioSetupWidget::DeviceSelectorWidget : public QGroupBox
 {
+	Q_OBJECT
 public:
 	DeviceSelectorWidget(const QString& deviceLabel, Direction direction, QWidget* parent = nullptr)
 		: QGroupBox{parent}


### PR DESCRIPTION
This simple fix adds missing Q_OBJECT macros to some headers.

I got warnings for these classes when running `lupdate` to generate translation files. From the docs:

> We strongly recommend the use of this macro in all subclasses of QObject regardless of whether or not they actually use signals, slots and properties, since failure to do so may lead certain functions to exhibit strange behavior.