### PR TITLE
Fix clip name not showing on empty MIDI clips

### DIFF
--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -120,7 +120,7 @@ void MidiClipView::setGhostInAutomationEditor()
 	aEditor->setFocus();
 }
 
-void MidiClipView::resetName() { m_clip->setName(""); }
+void MidiClipView::resetName() { m_clip->setName(""); update(); }
 
 
 
@@ -131,6 +131,7 @@ void MidiClipView::changeName()
 	RenameDialog rename_dlg( s );
 	rename_dlg.exec();
 	m_clip->setName( s );
+	update();
 }
 
 
@@ -603,7 +604,7 @@ void MidiClipView::paintEvent( QPaintEvent * )
 	// Check whether we will paint a text box and compute its potential height
 	// This is needed so we can paint the notes underneath it.
 	bool const drawName = !m_clip->name().isEmpty();
-	bool const drawTextBox = !beatClip && drawName;
+	bool const drawTextBox = drawName && (!beatClip || m_clip->m_notes.empty());
 
 	// TODO Warning! This might cause problems if ClipView::paintTextLabel changes
 	int textBoxHeight = 0;


### PR DESCRIPTION
## Summary

Fixes #7808. Empty MIDI clips did not display their name for two reasons:

- `resetName()` and `changeName()` never called `update()`, so the cached pixmap was not invalidated after renaming
- The `drawTextBox` condition suppressed the name text box for beat-type clips, which is how empty clips are classified (`std::all_of` on an empty range returns `true`)

## Changes

- Call `update()` after `setName()` in both `resetName()` and `changeName()`
- Relax the `drawTextBox` condition to allow the name on clips with no notes

## Note

Empty beat clips in the Pattern editor will now also show their name if renamed. This was not previously possible but is harmless since their default name is empty. If undesirable, the condition could be tightened by also checking the track type.

## Test plan

- [ ] Create an empty MIDI clip (add an instrument, do not open the piano roll)
- [ ] Right-click the clip and rename it
- [ ] Verify the name appears immediately without needing to hover
- [ ] Add notes to the clip, rename again, verify name still displays
- [ ] Reset the name (right-click > Reset name) and verify it clears
