### PR TITLE
Fix piano roll not updating after pitch bend node value change

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -374,6 +374,8 @@ bool AutomationEditor::fineTuneValue(timeMap::iterator node, bool editingOutValu
 		node.value().setInValue(value);
 	}
 
+	// Notify listeners (e.g. PianoRoll) that clip data changed
+	emit m_clip->dataChanged();
 	Engine::getSong()->setModified();
 	return true;
 }


### PR DESCRIPTION
## Summary

Fixes #7675. When double-clicking a pitch bend node in the Automation Editor to change its value, the Piano Roll did not update until the cursor hovered over it.

## Root cause

`fineTuneValue()` changes node values directly via `AutomationNode::setInValue()` / `setOutValue()`. Those methods recalculate tangents but do not emit `dataChanged()`. The Piano Roll's repaint is wired to `AutomationClip::dataChanged()` (connected when the detuning curve is created), so it never received a signal to redraw.

By contrast, dragging nodes goes through `AutomationClip::putValue()`, which does emit `dataChanged()` -- this is why dragging works but double-click did not.

## Fix

Emit `dataChanged()` on the clip at the end of `fineTuneValue()`, after the node value is set. `AutomationEditor` is already a declared friend of `AutomationClip`, so it has access to the protected signal.

## Test plan

- [ ] Open a new project and create a MIDI clip
- [ ] Place a note in the Piano Roll and enter pitch bend mode (Shift+T)
- [ ] Click the note to create a detuning curve, add a couple of nodes
- [ ] Shift-click the note to open the Automation Editor
- [ ] Double-click a node and enter a new value
- [ ] Verify the Piano Roll pitch bend line updates immediately without needing to hover
