### PR TITLE
Remove suil from msys2 dependencies

### DIFF
--- a/.github/workflows/deps-msys2-clangarm64.txt
+++ b/.github/workflows/deps-msys2-clangarm64.txt
@@ -16,7 +16,6 @@ mingw-w64-clang-aarch64-lilv
 mingw-w64-clang-aarch64-lv2
 mingw-w64-clang-aarch64-qt5-base
 mingw-w64-clang-aarch64-qt5-svg
-mingw-w64-clang-aarch64-suil
 mingw-w64-clang-aarch64-stk
 mingw-w64-clang-x86_64-nsis
 mingw-w64-clang-x86_64-ccache


### PR DESCRIPTION
The `suil` library for loading and wrapping LV2 plugin GUIs was recently [dropped from MINGW-Packages](https://github.com/msys2/MINGW-packages/pull/29735), causing our Windows ARM builds to break.

It was dropped from MINGW-Packages because it only supports GTK2 on Windows and they removed their GTK2 package.

We plan to use `suil` in the future, but are not using it currently, so it's not an issue for us to remove the dependency at this time. And `suil` does not support Qt yet, so we could not use it even if we wanted to without adding that feature upstream first.
