### PR TITLE
Fix missing include in TapTempo.h

### DIFF
--- a/plugins/TapTempo/TapTempo.h
+++ b/plugins/TapTempo/TapTempo.h
@@ -25,6 +25,7 @@
 #ifndef LMMS_TAP_TEMPO_H
 #define LMMS_TAP_TEMPO_H
 
+#include <array>
 #include <chrono>
 
 #include "TapTempoView.h"


### PR DESCRIPTION
Adds a missing include to `TapTempo.h`.

For some reason TapTempo builds successfully in the CI, but [according to a user on Discord](https://discord.com/channels/203559236729438208/332258319228207114/1511242746105565304), their local build is broken due to the missing include.