### PR TITLE
Lv2 Worker: Only access if initiated

### DIFF
--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -444,12 +444,23 @@ void Lv2Proc::initPlugin()
 
 	if (m_instance)
 	{
-		const auto iface = static_cast<const LV2_Worker_Interface*>(
-			lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
-		if (iface)
+		if (m_worker)
 		{
-			m_worker->setHandle(lilv_instance_get_handle(m_instance));
-			m_worker->setInterface(iface);
+			const auto iface = static_cast<const LV2_Worker_Interface*>(
+				lilv_instance_get_extension_data(m_instance, LV2_WORKER__interface));
+			if (iface)
+			{
+				m_worker->setHandle(lilv_instance_get_handle(m_instance));
+				m_worker->setInterface(iface);
+			}
+			else
+			{
+				qWarning() << "Plugin" << qStringFromPluginNode(m_plugin, lilv_plugin_get_name)
+					<< "(URI:"
+					<< lilv_node_as_uri(lilv_plugin_get_uri(m_plugin))
+					<< ") announces Lv2 Worker extension data in TTL metadata, but does not provide it."
+					<< "Will continue without the extension.";
+			}
 		}
 		for (std::size_t portNum = 0; portNum < m_ports.size(); ++portNum)
 		{


### PR DESCRIPTION
There are two different lilv functions:

1. `lilv_plugin_has_extension_data` checks whether a plugin has extension data due to its TTL metadata
2. `lilv_instance_get_extension_data` tries to execute the `extension_data` function directly on the plugin instance

The previous implementation first emplaces the Lv2Worker iff `lilv_plugin_has_extension_data` returns `true` and later calls `Lv2Worker::setHandle` (and others) iff `lilv_instance_get_extension_data` returns non-null. This means inconsistent plugins can cause accessing non-instantiated pointers.

So the fix is to only call `lilv_instance_get_extension_data` if `lilv_plugin_has_extension_data` has indicated that this extension data exists. This is consistent with Ardour.

Fixes #8425.