### PR TITLE
Sf2Player: Fix loading when no soundfont is specified

### DIFF
--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -265,10 +265,14 @@ void Sf2Instrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 
 void Sf2Instrument::loadSettings( const QDomElement & _this )
 {
-	openFile( _this.attribute( "src" ), false );
-	m_patchNum.loadSettings( _this, "patch" );
-	m_bankNum.loadSettings( _this, "bank" );
-
+	QString src = _this.attribute("src");
+	if(!src.isEmpty())
+	{
+		openFile(src, false);
+		m_patchNum.loadSettings(_this, "patch");
+		m_bankNum.loadSettings(_this, "bank");
+	}
+	
 	m_gain.loadSettings( _this, "gain" );
 
 	m_reverbOn.loadSettings( _this, "reverbOn" );

--- a/plugins/Sf2Player/Sf2Player.cpp
+++ b/plugins/Sf2Player/Sf2Player.cpp
@@ -266,7 +266,7 @@ void Sf2Instrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 void Sf2Instrument::loadSettings( const QDomElement & _this )
 {
 	QString src = _this.attribute("src");
-	if(!src.isEmpty())
+	if (!src.isEmpty())
 	{
 		openFile(src, false);
 		m_patchNum.loadSettings(_this, "patch");


### PR DESCRIPTION
fixes #8430 

When deserializing, in `Sf2Instrument::loadSettings`, the sf2 instrument is trying to load its source .sf2 file, even if there no such file was loaded when the instrument was serialized. This is what is causing #8430.

This PR is a adding a simple check in `Sf2Instrument::loadSettings`:
If the _"src"_ attribute of the serialized object is an empty string, the method `Sf2Instrument::openFile` isn't called.