### PR TITLE
Remove `Model` constraints on `VolumeKnob`

### DIFF
--- a/include/Knob.h
+++ b/include/Knob.h
@@ -242,7 +242,6 @@ private:
  * Notes:
  * - The units displayed in the tooltip and the @a enterValue() dialog box are hardcoded to dBFS,
  *   but units shown in the context menu must be set via @a setUnit(). Usually this should be "%".
- * - The model is expected to be linearly scaled. (?)
  * - The model's value of 0 must mean -inf dBFS and the
  *   value @a zeroDbfsPoint() (whose default is 100) must mean 0 dBFS.
  * - Models with both positive and negative values are allowed. A negative value is assumed to have
@@ -255,8 +254,6 @@ class LMMS_EXPORT VolumeKnob : public Knob
 
 public:
 	using Knob::Knob;
-
-	void setModel(Model* model, bool isOldModelValid = true) override;
 
 	//! The value where the volume model is at 0 dBFS (default is 100)
 	auto zeroDbfsPoint() const -> float { return m_zeroDbfsPoint; }

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -535,15 +535,6 @@ void Knob::changeEvent(QEvent * ev)
 void VolumeKnob::setModel(Model* model, bool isOldModelValid)
 {
 	AutomatableModelView::setModel(model, isOldModelValid);
-
-	if (auto m = this->model())
-	{
-		// TODO: Maybe enforce these constraints in the constructor instead?
-		// TODO: Are these constraints overly strict (no explanation given)?
-		// Check for some incompatible models
-		if (m->minValue() > 0) { throw std::logic_error{"VolumeKnob: model must have a non-positive min value"}; }
-		if (m->maxValue() <= 0) { throw std::logic_error{"VolumeKnob: model must have a positive max value"}; }
-	}
 }
 
 QString VolumeKnob::currentValueToText()

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -531,12 +531,6 @@ void Knob::changeEvent(QEvent * ev)
 	}
 }
 
-
-void VolumeKnob::setModel(Model* model, bool isOldModelValid)
-{
-	AutomatableModelView::setModel(model, isOldModelValid);
-}
-
 QString VolumeKnob::currentValueToText()
 {
 	const auto* m = model();

--- a/src/gui/widgets/Knob.cpp
+++ b/src/gui/widgets/Knob.cpp
@@ -538,8 +538,9 @@ void VolumeKnob::setModel(Model* model, bool isOldModelValid)
 
 	if (auto m = this->model())
 	{
+		// TODO: Maybe enforce these constraints in the constructor instead?
+		// TODO: Are these constraints overly strict (no explanation given)?
 		// Check for some incompatible models
-		if (m->isScaleLogarithmic()) { throw std::logic_error{"VolumeKnob: model must use linear scaling"}; } // TODO: Is this true?
 		if (m->minValue() > 0) { throw std::logic_error{"VolumeKnob: model must have a non-positive min value"}; }
 		if (m->maxValue() <= 0) { throw std::logic_error{"VolumeKnob: model must have a positive max value"}; }
 	}


### PR DESCRIPTION
`VolumeKnob`'s can be logarithmic. The recently added constraints prevented a project of mine from opening, which had the following: `<vol scale_type="log" value="30.4" id="3363"/>`. I'm not sure why these constraints are here though, and they seem overly strict and misplaced. Hoping @messmerd can clear up the confusion.