### PR TITLE
agent addition to LMMS?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 Brewfile.lock.json
 /.cache/
 compile_commands.json
+__pycache__/
+*.pyc

--- a/AGENT_COMMAND_MAP.md
+++ b/AGENT_COMMAND_MAP.md
@@ -1,0 +1,508 @@
+# LMMS Agent Command Map
+
+This file maps natural-language agent commands to the LMMS source paths that
+can execute them.
+
+It is based on:
+
+- `README.md`
+- `doc/wiki/LMMS-Architecture.md`
+- `doc/wiki/Plugin-development.md`
+- `src/gui/MainWindow.cpp`
+- `src/core/Track.cpp`
+- `src/tracks/InstrumentTrack.cpp`
+- `src/tracks/SampleTrack.cpp`
+- `src/core/ImportFilter.cpp`
+- `src/gui/FileBrowser.cpp`
+- `src/gui/instrument/InstrumentTrackWindow.cpp`
+- `src/core/EffectChain.cpp`
+- `src/gui/PluginBrowser.cpp`
+- `plugins/AgentControl/*`
+
+
+## 1. Commands that are valid now
+
+These already have a real code path in `plugins/AgentControl`.
+
+### `add 808`
+### `add kick`
+
+Agent behavior:
+
+- Create a new `SampleTrack`
+- Load a kick sample
+- Add clips at steps `1, 5, 9, 13`
+
+Source hooks:
+
+- `plugins/AgentControl/AgentControl.cpp`
+- `src/tracks/SampleTrack.cpp`
+- `src/core/Track.cpp`
+
+
+### `import <filename>`
+
+Agent behavior:
+
+- Resolve the file in Downloads
+- Create a new `SampleTrack`
+- Create one `SampleClip`
+- Call `setSampleFile(...)`
+
+Source hooks:
+
+- `plugins/AgentControl/AgentControl.cpp`
+- `src/core/SampleClip.cpp`
+- `src/tracks/SampleTrack.cpp`
+
+
+## 2. Commands that are straightforward next
+
+These map cleanly onto existing LMMS APIs and should be implemented next.
+
+### `new project`
+
+LMMS action:
+
+- `Engine::getSong()->createNewProject()`
+
+Source:
+
+- `src/gui/MainWindow.cpp`
+
+
+### `open project`
+
+LMMS action:
+
+- `Song::loadProject(...)`
+
+Notes:
+
+- Current UI path uses a dialog. Agent version should accept a path.
+
+Source:
+
+- `src/gui/MainWindow.cpp`
+
+
+### `save project`
+### `save project as <path>`
+
+LMMS action:
+
+- `Song::guiSaveProject()`
+- `Song::guiSaveProjectAs(...)`
+
+Source:
+
+- `src/gui/MainWindow.cpp`
+
+
+### `show song editor`
+### `show pattern editor`
+### `show piano roll`
+### `show automation editor`
+### `show mixer`
+### `show controller rack`
+### `show project notes`
+### `show microtuner`
+
+LMMS action:
+
+- Existing main-window slots already exist for these windows.
+
+Source:
+
+- `src/gui/MainWindow.cpp`
+
+Mapped slots:
+
+- `toggleSongEditorWin()`
+- `togglePatternEditorWin()`
+- `togglePianoRollWin()`
+- `toggleAutomationEditorWin()`
+- `toggleMixerWin()`
+- `toggleControllerRack()`
+- `toggleProjectNotesWin()`
+- `toggleMicrotunerWin()`
+
+
+### `show tool <name>`
+
+LMMS action:
+
+- Tool plugins are loaded into `MainWindow::m_tools`
+- `showTool(QAction*)` displays the selected tool view
+
+Source:
+
+- `src/gui/MainWindow.cpp`
+- `src/core/ToolPlugin.cpp`
+
+Examples:
+
+- `show tool agent control`
+- `show tool tap tempo`
+- `show tool ladspa browser`
+
+
+### `import midi <file>`
+### `import hydrogen <file>`
+
+LMMS action:
+
+- `ImportFilter::import(file, Engine::getSong())`
+
+Notes:
+
+- LMMS already has import plugins for MIDI and Hydrogen.
+
+Source:
+
+- `src/core/ImportFilter.cpp`
+- `plugins/MidiImport/MidiImport.cpp`
+- `plugins/HydrogenImport/HydrogenImport.cpp`
+- `src/gui/MainWindow.cpp`
+
+
+### `new sample track`
+### `new instrument track`
+### `new automation track`
+
+LMMS action:
+
+- `Track::create(Track::Type::Sample, song)`
+- `Track::create(Track::Type::Instrument, song)`
+- `Track::create(Track::Type::Automation, song)`
+
+Source:
+
+- `src/core/Track.cpp`
+
+
+### `load instrument <plugin>`
+### `set instrument <plugin>`
+
+LMMS action:
+
+- Create or target an `InstrumentTrack`
+- Call `InstrumentTrack::loadInstrument(pluginName, ...)`
+
+Source:
+
+- `src/tracks/InstrumentTrack.cpp`
+- `include/InstrumentTrack.h`
+
+Good first targets:
+
+- `kicker`
+- `tripleoscillator`
+- `slicert`
+- `sf2player`
+- `patman`
+
+
+### `open slicer`
+### `send <sample> to slicer`
+
+LMMS action:
+
+- Existing file-browser code already creates an instrument track,
+  loads `slicert`, and then calls `instrument()->loadFile(...)`
+
+Source:
+
+- `src/gui/FileBrowser.cpp`
+
+
+### `load sample into current instrument`
+### `load preset file into current instrument`
+
+LMMS action:
+
+- `instrument()->loadFile(...)`
+- `replaceInstrument(DataFile(...))`
+
+Source:
+
+- `src/gui/instrument/InstrumentTrackWindow.cpp`
+
+
+### `add effect <effect>`
+### `remove effect <effect>`
+
+LMMS action:
+
+- Instantiate an `Effect`
+- Append it to `EffectChain`
+
+Source:
+
+- `src/core/EffectChain.cpp`
+- `src/gui/EffectRackView.cpp`
+- `src/gui/modals/EffectSelectDialog.cpp`
+
+Good first targets:
+
+- `amplifier`
+- `eq`
+- `delay`
+- `compressor`
+- `stereoenhancer`
+
+
+## 3. Commands that need one level more work
+
+These are feasible, but need targeting rules or new helper APIs in the agent.
+
+### `open plugin <name>`
+
+Meaning is ambiguous in LMMS:
+
+- open a tool plugin window
+- create an instrument track with that plugin
+- focus an existing instrument window that already uses that plugin
+- add an effect plugin to a selected effect chain
+
+Recommended split:
+
+- `show tool <name>`
+- `new instrument <name>`
+- `focus instrument <track name>`
+- `add effect <name> to <track>`
+
+Relevant source:
+
+- `src/gui/MainWindow.cpp`
+- `src/tracks/InstrumentTrack.cpp`
+- `src/core/EffectChain.cpp`
+
+
+### `import audio from <full path>`
+
+Current agent only imports from Downloads.
+
+Needed:
+
+- accept arbitrary absolute path
+- validate extension and existence
+
+Relevant source:
+
+- `plugins/AgentControl/AgentControl.cpp`
+- `src/core/SampleClip.cpp`
+
+
+### `focus track <name>`
+### `focus instrument window <track>`
+
+Needed:
+
+- track lookup by name
+- bring the correct `InstrumentTrackWindow` or `SampleTrackWindow` to front
+
+Relevant source:
+
+- `src/gui/tracks/InstrumentTrackView.cpp`
+- `src/gui/instrument/InstrumentTrackWindow.cpp`
+- `src/gui/SampleTrackWindow.cpp`
+
+
+### `play`
+### `pause`
+### `stop`
+
+LMMS has playback control paths, but the clean agent entry point should target
+the active editor or the song explicitly.
+
+Relevant source:
+
+- `src/gui/MainWindow.cpp`
+- editor playback paths used by key handling
+
+
+### `rename track <old> to <new>`
+
+Needed:
+
+- track lookup by `Track::name()`
+- call `setName(...)`
+
+Relevant source:
+
+- `src/core/Track.cpp`
+- `src/tracks/InstrumentTrack.cpp`
+- `src/tracks/SampleTrack.cpp`
+
+
+### `mute track <name>`
+### `solo track <name>`
+
+Needed:
+
+- track lookup
+- update mute or solo model
+
+Relevant source:
+
+- `src/core/Track.cpp`
+- `include/Track.h`
+
+
+## 4. Commands that need deeper LMMS-specific logic
+
+These are possible, but not just one API call.
+
+### `add 808 drum pattern to my song`
+
+There are at least two valid implementations:
+
+- current shortcut: sample-track clips on the song timeline
+- richer version: instrument track or BB/pattern-based drum programming
+
+For a real beat agent, the better target is beat/bassline or pattern-track
+authoring, not only sample clips.
+
+Relevant source/doc:
+
+- `doc/wiki/LMMS-Architecture.md`
+- `src/tracks/PatternTrack.cpp`
+- `src/core/Track.cpp`
+
+
+### `add hi hats`
+### `add snare on 2 and 4`
+### `humanize drums`
+
+Needed:
+
+- a pattern representation
+- step or note placement rules
+- clip selection and target track rules
+
+This is where the command model should become intent-based instead of
+simple keyword matching.
+
+
+### `open splicer`
+
+This is not an LMMS internal command unless you mean the external Splice app.
+That should be treated as an OS command, not an LMMS command.
+
+Recommended split:
+
+- LMMS agent handles LMMS internals
+- optional desktop helper handles macOS app launching
+
+
+### `do anything in LMMS`
+
+LMMS has a strong internal API for:
+
+- project lifecycle
+- tracks
+- instruments
+- effects
+- imports
+- tool windows
+
+It does not expose a single generic command bus for all GUI actions. To reach
+"do anything" you need:
+
+- a command grammar
+- object targeting (`current track`, `selected track`, `track named X`)
+- safe mutation helpers on the GUI thread
+- more explicit editor/window control APIs
+
+
+## 5. Recommended command grammar
+
+Use commands in these families so the agent stays deterministic.
+
+### Project
+
+- `new project`
+- `open project <path>`
+- `save project`
+- `save project as <path>`
+- `import midi <path>`
+- `import hydrogen <path>`
+
+
+### Windows
+
+- `show song editor`
+- `show pattern editor`
+- `show piano roll`
+- `show automation editor`
+- `show mixer`
+- `show controller rack`
+- `show project notes`
+- `show microtuner`
+- `show tool <name>`
+
+
+### Tracks
+
+- `new instrument track`
+- `new sample track`
+- `new automation track`
+- `rename track <name>`
+- `mute track <name>`
+- `solo track <name>`
+
+
+### Instruments
+
+- `new instrument <plugin>`
+- `set instrument <plugin> on <track>`
+- `load file <path> into instrument <track>`
+- `open slicer`
+- `send <sample> to slicer`
+
+
+### Effects
+
+- `add effect <plugin> to <track>`
+- `remove effect <plugin> from <track>`
+
+
+### Clips and patterns
+
+- `import audio <path>`
+- `add 808`
+- `add kick`
+- `add snare pattern`
+- `add hi hats`
+
+
+## 6. Recommended implementation order
+
+1. Stabilize the text command bus around explicit verbs and arguments.
+2. Add window commands via `MainWindow` slots.
+3. Add track lookup helpers by name and type.
+4. Add instrument commands through `InstrumentTrack::loadInstrument(...)`.
+5. Add effect commands through `EffectChain`.
+6. Add richer beat/pattern authoring once track targeting is stable.
+7. Add voice on top of the same command bus, not as a separate control path.
+
+
+## 7. Practical next batch to implement
+
+These are the best next commands because the source already supports them
+cleanly:
+
+- `new project`
+- `show mixer`
+- `show piano roll`
+- `show song editor`
+- `new instrument track`
+- `new sample track`
+- `open slicer`
+- `new instrument kicker`
+- `new instrument tripleoscillator`
+- `add effect amplifier to <track>`
+- `import midi <path>`
+- `import hydrogen <path>`
+- `import audio <full path>`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,7 @@ else()
 	set(STATUS_QT6 "Disabled")
 endif()
 
-find_package(Qt${QT_VERSION_MAJOR} ${LMMS_QT_MIN_VERSION} COMPONENTS Core Gui Widgets Xml Svg REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} ${LMMS_QT_MIN_VERSION} COMPONENTS Core Gui Widgets Xml Svg Network REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS LinguistTools QUIET)
 
 include_directories(SYSTEM
@@ -197,6 +197,7 @@ include_directories(SYSTEM
 	${Qt${QT_VERSION_MAJOR}Gui_INCLUDE_DIRS}
 	${Qt${QT_VERSION_MAJOR}Widgets_INCLUDE_DIRS}
 	${Qt${QT_VERSION_MAJOR}Xml_INCLUDE_DIRS}
+	${Qt${QT_VERSION_MAJOR}Network_INCLUDE_DIRS}
 )
 
 set(QT_LIBRARIES
@@ -205,6 +206,7 @@ set(QT_LIBRARIES
 	Qt${QT_VERSION_MAJOR}::Widgets
 	Qt${QT_VERSION_MAJOR}::Xml
 	Qt${QT_VERSION_MAJOR}::Svg
+	Qt${QT_VERSION_MAJOR}::Network
 )
 
 IF(LMMS_BUILD_LINUX AND WANT_VST AND NOT WANT_QT6)

--- a/cmake/modules/PluginList.cmake
+++ b/cmake/modules/PluginList.cmake
@@ -78,6 +78,7 @@ SET(LMMS_PLUGIN_LIST
 	Vibed
 	Xpressive
 	ZynAddSubFx
+	AgentControl
 )
 
 IF("${PLUGIN_LIST}" STREQUAL "")

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -64,6 +64,7 @@ public:
 	void moveDown( Effect * _effect );
 	void moveUp( Effect * _effect );
 	bool processAudioBuffer(AudioBuffer& buffer);
+	const std::vector<Effect*>& effects() const { return m_effects; }
 
 	void clear();
 

--- a/lmmsagent/README.md
+++ b/lmmsagent/README.md
@@ -7,12 +7,14 @@ Local LMMS agent stack built around typed `AgentControl` tools, with a productio
 - Confirm-on-risk for destructive/ambiguous actions.
 - Context-aware command chaining (`open slicer and import sample.wav and split into 16`).
 - Structured stage traces for debugging and latency tuning.
+- Persistent daemon mode (`lmms-agentd`) for runtime split and retries.
 
 ## Structure
 
 - `integrations/lmms/AgentControl/`: integration contract and schema.
 - `plugins/AgentControl/`: typed LMMS tool server implementation.
 - `shared/`: deterministic discovery, planner, orchestrator, and project memory.
+- `lmms-agentd/`: persistent daemon API (`run_goal`, `health`, `warmup`) with idempotency and timeout classes.
 - `lmms-text-agent/`: text frontend over shared planner/orchestrator.
 - `lmms-voice-agent/`: voice frontend using `whisper.cpp` transcript + same planner/orchestrator.
 - `scripts/`: build/install/run helpers.
@@ -46,6 +48,8 @@ All tool responses follow:
 ## Run Text Agent
 
 ```bash
+./lmmsagent/scripts/run_agentd.sh
+# then in another shell:
 ./lmmsagent/scripts/run_text_agent.sh --interactive
 # or single command
 ./lmmsagent/scripts/run_text_agent.sh "set tempo to 124"
@@ -59,10 +63,22 @@ All tool responses follow:
 ## Run Voice Agent
 
 ```bash
+./lmmsagent/scripts/run_agentd.sh
+# then in another shell:
 ./lmmsagent/scripts/run_voice_agent.sh --audio /path/to/input.wav --whisper-model /path/to/ggml-model.bin
 # or bypass ASR
 ./lmmsagent/scripts/run_voice_agent.sh --transcript "load instrument triple oscillator"
 ```
+
+Use `--direct` on text/voice commands to bypass daemon and call the orchestrator in-process.
+
+## Phase 0 Baseline Benchmark
+
+```bash
+python3 ./lmmsagent/scripts/benchmark_phase01.py --repeat 2
+```
+
+The script writes a report JSON under `lmmsagent/evals/reports/` with success/clarification rates and p50/p95 latencies.
 
 ## Voice Runtime Configuration
 

--- a/lmmsagent/README.md
+++ b/lmmsagent/README.md
@@ -1,0 +1,66 @@
+# LMMS Agent
+
+Local LMMS agent stack built around typed `AgentControl` tools.
+
+## Structure
+
+- `integrations/lmms/AgentControl/`: integration contract and schema.
+- `plugins/AgentControl/`: typed LMMS tool server implementation.
+- `shared/`: deterministic discovery, planner, orchestrator, and project memory.
+- `lmms-text-agent/`: text frontend over shared planner/orchestrator.
+- `lmms-voice-agent/`: voice frontend using `whisper.cpp` transcript + same planner/orchestrator.
+- `scripts/`: build/install/run helpers.
+- `evals/`: fixed evaluation task taxonomy.
+- `docs/MANUAL_TASK_MAP.md`: compatibility-aware transfer from LMMS 0.4.12 manual.
+- `docs/MANUAL_FEATURE_COVERAGE.md`: full feature-family map from manual to agent capabilities.
+- `docs/MANUAL_TOC_EXTRACTED.md`: extracted TOC index used for manual coverage.
+
+## Core Tool Contract
+
+All tool responses follow:
+
+```json
+{
+  "ok": true,
+  "result": {},
+  "state_delta": {},
+  "warnings": [],
+  "error_code": null,
+  "error_message": null
+}
+```
+
+## Build + Install
+
+```bash
+./lmmsagent/scripts/build_agentcontrol.sh
+./lmmsagent/scripts/install_agentcontrol.sh
+```
+
+## Run Text Agent
+
+```bash
+./lmmsagent/scripts/run_text_agent.sh --interactive
+# or single command
+./lmmsagent/scripts/run_text_agent.sh "set tempo to 124"
+# guided mode (confirm each step)
+./lmmsagent/scripts/run_text_agent.sh --guided "compose from score sheet"
+# manual capability map
+./lmmsagent/scripts/run_text_agent.sh "manual map"
+./lmmsagent/scripts/run_text_agent.sh "manual map automation"
+```
+
+## Run Voice Agent
+
+```bash
+./lmmsagent/scripts/run_voice_agent.sh --audio /path/to/input.wav --whisper-model /path/to/ggml-model.bin
+# or bypass ASR
+./lmmsagent/scripts/run_voice_agent.sh --transcript "load instrument triple oscillator"
+```
+
+## Notes
+
+- Planner output is always structured (`plan`, `clarify`, or `reject`).
+- Clarification is triggered for low confidence, subjective prompts, and risky operations.
+- Project memory is append-only journal + preference cache under `~/.lmmsagent/memory/`.
+- Beginner prompts are mapped to manual-driven playbooks with explicit compatibility cautions.

--- a/lmmsagent/README.md
+++ b/lmmsagent/README.md
@@ -1,6 +1,12 @@
 # LMMS Agent
 
-Local LMMS agent stack built around typed `AgentControl` tools.
+Local LMMS agent stack built around typed `AgentControl` tools, with a production-first voice layer:
+
+- Continuous listening with wake-phrase execution gate.
+- Hybrid interpreter (deterministic + heuristic + Ollama structured parser).
+- Confirm-on-risk for destructive/ambiguous actions.
+- Context-aware command chaining (`open slicer and import sample.wav and split into 16`).
+- Structured stage traces for debugging and latency tuning.
 
 ## Structure
 
@@ -58,9 +64,38 @@ All tool responses follow:
 ./lmmsagent/scripts/run_voice_agent.sh --transcript "load instrument triple oscillator"
 ```
 
+## Voice Runtime Configuration
+
+Key environment variables:
+
+```bash
+export LMMS_OLLAMA_MODEL=qwen2.5:7b-instruct
+export LMMS_WAKE_REQUIRED=1
+export LMMS_WAKE_PHRASES="hey lmms,ok lmms"
+export LMMS_WAKE_WINDOW_MS=8000
+export LMMS_HYBRID_MARGIN=0.12
+export LMMS_CONFIRM_CONFIDENCE=0.74
+export LMMS_CONFIRM_WINDOW_MS=9000
+export LMMS_VOICE_TRACE=1
+```
+
+Per-intent rollout/canary flags are exposed as `LMMS_CAP_*` (for example `LMMS_CAP_SLICER_IMPORT=0` to disable one command family without disabling the whole pipeline).
+
 ## Notes
 
 - Planner output is always structured (`plan`, `clarify`, or `reject`).
 - Clarification is triggered for low confidence, subjective prompts, and risky operations.
 - Project memory is append-only journal + preference cache under `~/.lmmsagent/memory/`.
 - Beginner prompts are mapped to manual-driven playbooks with explicit compatibility cautions.
+
+## Contract / Regression Checks
+
+```bash
+python3 ./lmmsagent/scripts/validate_voice_contracts.py
+```
+
+This validates:
+
+- command manifest shape and intent uniqueness,
+- structured LLM output schema requirements,
+- golden scenario metadata consistency.

--- a/lmmsagent/__init__.py
+++ b/lmmsagent/__init__.py
@@ -1,0 +1,1 @@
+"""LMMS agent package root."""

--- a/lmmsagent/docs/ARCHITECTURE.md
+++ b/lmmsagent/docs/ARCHITECTURE.md
@@ -45,7 +45,23 @@
 - `rollback_to_snapshot`
 - `diff_since_snapshot`
 
-## 2) Discovery Layer (`lmmsagent/shared/discovery.py`)
+## 2) Runtime Split (Phase 1)
+
+`lmmsagent/lmms-agentd/main.py` is a persistent daemon that owns:
+
+- discovery refresh/index cache
+- planner/orchestrator lifecycle
+- retry policy by timeout class
+- idempotency cache for duplicate request suppression
+
+Protocol envelope (newline-delimited JSON over localhost, default `127.0.0.1:7781`):
+
+- request: `op`, `request_id`, `idempotency_key`, `timeout_class`, `retries`, payload fields
+- response: `ok`, `request_id`, `op`, `attempts`, `duration_ms`, `result|error`
+
+LMMS plugin stays the executor behind `ToolClient` on `127.0.0.1:7777`.
+
+## 3) Discovery Layer (`lmmsagent/shared/discovery.py`)
 
 Deterministic resolution pipeline:
 
@@ -61,7 +77,7 @@ Indexed asset sources:
 - project-local audio
 - Downloads and configured sample roots
 
-## 3) Planner + Orchestrator
+## 4) Planner + Orchestrator
 
 - Planner (`planner.py`) emits JSON-only `plan` / `clarify` / `reject`.
 - Orchestrator (`orchestrator.py`) executes step-by-step with verify loop:
@@ -78,7 +94,23 @@ Clarification policy:
 - risky/destructive steps
 - subjective prompts (e.g. texture/vibe/harder)
 
-## 4) Project Memory (`memory.py`)
+## 5) Phase 0 Observability Baseline
+
+Orchestrator returns per-request telemetry:
+
+- `request_id`
+- `total_runtime_ms`
+- `stage_timings_ms` (`discovery_refresh`, `planning`, `step_execution`, etc.)
+- structured `trace_events` (`start/end/error` by stage)
+
+`ToolClient` also attaches transport timing to each tool response as `_transport.latency_ms`.
+
+Baseline benchmark script:
+
+- `lmmsagent/scripts/benchmark_phase01.py`
+- computes success/clarification rates and p50/p95 latency from reproducible command buckets.
+
+## 6) Project Memory (`memory.py`)
 
 Project-scoped data under `~/.lmmsagent/memory/<project_hash>/`:
 

--- a/lmmsagent/docs/ARCHITECTURE.md
+++ b/lmmsagent/docs/ARCHITECTURE.md
@@ -1,0 +1,88 @@
+# Architecture
+
+## 1) Typed LMMS Tool Server
+
+`plugins/AgentControl/` exposes JSON tools over localhost transport.
+
+### Query tools
+
+- `get_project_state`
+- `list_tracks`
+- `get_track_details`
+- `list_patterns`
+- `list_instruments`
+- `list_effects`
+- `list_tool_windows`
+- `get_selection_state`
+- `find_track_by_name`
+- `search_project_audio`
+
+### Write tools
+
+- `create_track`
+- `rename_track`
+- `load_instrument`
+- `load_sample`
+- `create_pattern`
+- `add_notes`
+- `add_steps`
+- `set_tempo`
+- `add_effect`
+- `remove_effect`
+- `set_effect_param` (stub, returns not implemented)
+- `open_tool`
+- `import_audio`
+- `import_midi`
+- `import_hydrogen`
+- `select_track`
+- `mute_track`
+- `solo_track`
+
+### Safety tools
+
+- `create_snapshot`
+- `undo_last_action`
+- `rollback_to_snapshot`
+- `diff_since_snapshot`
+
+## 2) Discovery Layer (`lmmsagent/shared/discovery.py`)
+
+Deterministic resolution pipeline:
+
+1. exact normalized match
+2. lexical contains/prefix match
+3. token overlap ranking
+4. tag/type boost
+
+Indexed asset sources:
+
+- plugin inventory (instruments/effects/tools)
+- LMMS windows/tools
+- project-local audio
+- Downloads and configured sample roots
+
+## 3) Planner + Orchestrator
+
+- Planner (`planner.py`) emits JSON-only `plan` / `clarify` / `reject`.
+- Orchestrator (`orchestrator.py`) executes step-by-step with verify loop:
+  1. refresh discovery + read state
+  2. plan
+  3. snapshot before risky steps
+  4. execute typed step
+  5. re-read state
+  6. rollback on failure
+
+Clarification policy:
+
+- confidence `< 0.70`
+- risky/destructive steps
+- subjective prompts (e.g. texture/vibe/harder)
+
+## 4) Project Memory (`memory.py`)
+
+Project-scoped data under `~/.lmmsagent/memory/<project_hash>/`:
+
+- `journal.jsonl` append-only execution history
+- `preferences.json` last-writer-wins preference cache
+
+LMMS project state remains authoritative; memory is advisory.

--- a/lmmsagent/docs/COMMANDS.md
+++ b/lmmsagent/docs/COMMANDS.md
@@ -1,0 +1,50 @@
+# Tool Commands
+
+## Query
+
+- `get_project_state`
+- `list_tracks`
+- `get_track_details`
+- `list_patterns`
+- `list_instruments`
+- `list_effects`
+- `list_tool_windows`
+- `get_selection_state`
+- `find_track_by_name`
+- `search_project_audio`
+
+## Write
+
+- `create_track`
+- `rename_track`
+- `load_instrument`
+- `load_sample`
+- `create_pattern`
+- `add_notes`
+- `add_steps`
+- `set_tempo`
+- `add_effect`
+- `remove_effect`
+- `set_effect_param` (not implemented)
+- `open_tool`
+- `import_audio`
+- `import_midi`
+- `import_hydrogen`
+- `select_track`
+- `mute_track`
+- `solo_track`
+
+## Safety
+
+- `create_snapshot`
+- `undo_last_action`
+- `rollback_to_snapshot`
+- `diff_since_snapshot`
+
+## Planner Intents (text agent)
+
+- `beginner help`
+- `manual map`
+- `manual map song editor`
+- `manual map automation`
+- `manual map samples`

--- a/lmmsagent/docs/MANUAL_FEATURE_COVERAGE.md
+++ b/lmmsagent/docs/MANUAL_FEATURE_COVERAGE.md
@@ -1,0 +1,57 @@
+# LMMS Manual Feature Coverage (0.4.12 -> Current Agent)
+
+Source PDF: `/Users/saksham/Downloads/lmms-manual-0.4.12.pdf`  
+TOC extraction: `/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/docs/MANUAL_TOC_EXTRACTED.md` (192 entries)
+
+This is the full mapping layer for "what LMMS can do" from the manual, and where each capability lands in the agent stack.
+
+## Coverage method
+
+- Parsed full manual TOC and indexed all chapter families.
+- Mapped each feature family into one of:
+  - **Automated now** (typed AgentControl tool calls)
+  - **Guided now** (agent gives step-by-step instructions with confirmations)
+  - **Deferred** (needs new typed LMMS API surface)
+- Added runtime feature map in code:
+  - `/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/shared/manual_features.py`
+
+## Feature-area mapping
+
+| Feature area | Manual sections | Automated now | Guided now | Deferred |
+|---|---|---|---|---|
+| Main Window + Navigation | Main Window, Menu/Toolbar, Sidebar tabs | `open_tool`, `list_tool_windows`, `get_project_state` | browser tab workflows, drag-drop | typed sidebar navigation API |
+| Song Editor + Tracks | Song Editor, track workflows, context menus | `create_track`, `rename_track`, `select_track`, `mute_track`, `solo_track`, `create_pattern`, `list_tracks` | clip timeline gestures | clip move/split/clone typed API |
+| Piano Roll | Piano Roll interface and composing | `open_tool`, `create_pattern`, `add_notes`, `add_steps` | precise note editing workflow | full typed note selection/edit API |
+| Beat+Bassline | BB Editor, rhythm process flow | `create_track(type=sample)`, `load_sample`, `add_steps` | groove design and per-step feel | native typed BB timeline API |
+| Instruments + Presets | Instrument window, ENV/LFO, Func, MIDI, plugin appendix | `list_instruments`, `resolve_plugin`, `load_instrument` | deep preset/program editing | typed per-plugin parameter schema |
+| FX Mixer + Effects | FX Mixer, effect chain, effects appendix | `open_tool(mixer)`, `list_effects`, `add_effect`, `remove_effect` | chain tuning, side-chain procedure | `set_effect_param`, typed routing graph |
+| Automation + Controllers | Automation editor, controller rack, LFO/Peak controller | `create_track(type=automation)`, snapshots/undo/rollback | curve shaping and controller linking | typed automation point API |
+| Import + Samples | sample tracks, sample appendix, import workflows | `import_audio`, `import_midi`, `import_hydrogen`, `search_project_audio`, `resolve_sample`, `load_sample` | sample preparation and audition flow | typed trim/slice/normalize APIs |
+| Beginner Song Building | compose from score, rhythm, automation, export | playbooks + guided mode over typed tools | manual checkpoints and confirms | autonomous section generation without confirmation |
+| Shortcuts + Power-use | keyboard shortcuts appendix | guidance/documentation | human-driven hotkey workflow | shortcut simulation layer |
+
+## Runtime commands added for manual mapping
+
+Use these in text agent to get manual-aware capability responses:
+
+- `manual map`
+- `manual map song editor`
+- `manual map automation`
+- `manual map samples`
+- `manual map mixer`
+- `manual map piano roll`
+
+The planner now returns capability map notes and recommended prompts per matched section.
+
+## Beginner-first behavior
+
+- If a requested operation is risky/underspecified, the planner asks for clarification.
+- Guided mode (`--guided`) can require confirmation before each step.
+- Manual version drift is always acknowledged (0.4.12 is old).
+
+## Current gap summary (high priority)
+
+1. Implement `set_effect_param` in AgentControl for real plugin tuning.  
+2. Add typed automation point editing (create/move/delete points).  
+3. Add typed clip operations in Song Editor (move/split/clone).  
+4. Add typed BB Editor grid APIs (step accents/swing/timing).

--- a/lmmsagent/docs/MANUAL_TASK_MAP.md
+++ b/lmmsagent/docs/MANUAL_TASK_MAP.md
@@ -1,0 +1,113 @@
+# LMMS 0.4.12 Manual Task Map (Compatibility-Aware)
+
+Source used: `/Users/saksham/Downloads/lmms-manual-0.4.12.pdf`
+
+For full chapter-family coverage mapped from the manual TOC, see:
+`/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/docs/MANUAL_FEATURE_COVERAGE.md`
+
+This map transfers beginner workflows from the old manual into the current agent stack while marking what is:
+
+- **Automated now** via typed AgentControl tools.
+- **Guided/manual** in current build (UI step still needed).
+- **Deferred** for future implementation.
+
+## 1) Compose from score sheet
+
+Manual section: `Editing and Composing Songs -> Composing a song from score sheet`
+
+- Automated now:
+  - set tempo
+  - create instrument track
+  - load Triple Oscillator
+  - create pattern clip
+- Guided/manual:
+  - entering exact notes from score in Piano Roll
+  - detailed quantization/octave editing
+- Deferred:
+  - score-sheet parsing into note events
+
+## 2) Add rhythm in Beat+Bassline workflow
+
+Manual section: `Beat+Bassline Editor -> process flow for composing a rhythm`
+
+- Automated now:
+  - create sample track
+- Guided/manual:
+  - choosing drum samples in browser
+  - step programming in BB editor timeline
+- Deferred:
+  - direct BB timeline tool APIs
+
+## 3) Automation contrast (distance/loudness)
+
+Manual section: `Adding Automation`
+
+- Automated now:
+  - create snapshot
+  - create automation track
+- Guided/manual:
+  - ctrl-drag knob linking
+  - draw automation curve shape in automation editor
+- Deferred:
+  - typed automation-curve editing tool
+
+## 4) Multiple instruments / dialogue split
+
+Manual section: `Further experimentation -> Using multiple instruments`
+
+- Automated now:
+  - create secondary instrument track
+  - load SF2 Player (if available)
+- Guided/manual:
+  - select SF2 patch
+  - clone clip and prune note ranges
+- Deferred:
+  - clip clone/cut operations as typed tools
+
+## 5) Working with samples
+
+Manual section: `Appendix D -> Working with samples`
+
+- Automated now:
+  - create sample track
+  - load sample by path (when provided)
+- Guided/manual:
+  - classify usage as melodic vs percussion
+  - sample prep and browser navigation
+- Deferred:
+  - automatic pitched-sample instrument pipeline
+
+## 6) Export song
+
+Manual section: `Exporting the Song`
+
+- Automated now:
+  - guidance only
+- Guided/manual:
+  - export dialog flow (Ctrl+E)
+  - choose sample-rate/bitrate/codec based on destination
+- Deferred:
+  - typed export/render API
+
+## Safety policy applied
+
+- Snapshots required before risky write operations in guided workflows.
+- `undo_last_action` and `rollback_to_snapshot` available.
+- Old manual assumptions are treated as advisory, not authoritative.
+
+## Practical use
+
+These workflows are exposed as **beginner playbooks** through planner matching. Ask with prompts like:
+
+- `beginner help`
+- `compose from score sheet`
+- `add rhythm`
+- `volume automation`
+- `multiple instruments`
+- `working with samples`
+- `export song`
+- `edit existing song`
+- `sample as melodic instrument`
+- `sample as percussion instrument`
+- `sidechain through mixer`
+- `lfo controller modulation`

--- a/lmmsagent/docs/MANUAL_TOC_EXTRACTED.md
+++ b/lmmsagent/docs/MANUAL_TOC_EXTRACTED.md
@@ -1,0 +1,198 @@
+# Extracted TOC
+
+Source: `/Users/saksham/Downloads/lmms-manual-0.4.12.pdf`
+
+| Page | Section |
+|---:|---|
+| 3 | Contents |
+| 9 | About this Manual |
+| 9 | How to use this manual |
+| 9 | Disclaimer |
+| 9 | Version Number |
+| 9 | What's new |
+| 9 | Copyrights |
+| 10 | Acknowledgments |
+| 10 | Feedback |
+| 11 | Basic Concepts |
+| 11 | Fundamental Terms |
+| 14 | Controls in LMMS interface |
+| 16 | Automation of controls |
+| 17 | Applications of Automation Curves |
+| 17 | Automation using LFO controllers |
+| 19 | Introduction to LMMS |
+| 19 | Features |
+| 20 | Comparison with a sound-recording studio |
+| 22 | How LMMS works |
+| 23 | Functional Parts of LMMS |
+| 24 | A look around LMMS |
+| 25 | Windows in LMMS |
+| 25 | Getting a feel of LMMS with a demo song |
+| 29 | LMMS Main Window |
+| 29 | Main Menu Bar |
+| 29 | Project Menu |
+| 30 | Edit Menu |
+| 30 | Tools Menu |
+| 30 | Help Menu |
+| 30 | Tool Bar |
+| 31 | File Controls |
+| 31 | Window Controls |
+| 32 | Tempo Control |
+| 32 | Time Signature Controls |
+| 32 | Volume and Pitch Controls |
+| 32 | Wave and CPU Usage Display |
+| 32 | The Side Bar |
+| 33 | The Instrument Plugins Tab |
+| 33 | The My Projects Tab |
+| 34 | The My Samples Tab |
+| 34 | The My Presets Tab |
+| 34 | The My Home Tab |
+| 35 | The My Computer Tab |
+| 37 | The Song Editor |
+| 38 | The Song Editor window |
+| 39 | Working with tracks in Song Editor |
+| 39 | The structure of a typical track |
+| 41 | Working with an element |
+| 44 | Working with Instrument tracks |
+| 45 | Using the instrument track to play an audio track with pitch-shift |
+| 46 | Working with sample tracks |
+| 47 | Working with Beat/Bassline tracks |
+| 48 | Working with automation tracks |
+| 49 | The Context menus in Song Editor |
+| 49 | Context menu for Instrument track element |
+| 50 | Context menu for Beat track element |
+| 51 | Context menu for Sample track element |
+| 52 | Context menu for Automation track element |
+| 53 | The Piano Roll Editor |
+| 53 | The Piano Roll Editor Interface |
+| 56 | Editing Toolbar buttons |
+| 57 | Clipboard toolbar buttons |
+| 58 | Note Length |
+| 58 | Note pane |
+| 58 | Note Volume |
+| 59 | Note Panning |
+| 59 | Composing in the Piano Roll Editor |
+| 59 | Writing Notes with mouse |
+| 60 | Creating notes with keyboard |
+| 61 | The Beat+Bassline Editor |
+| 61 | The Beat+Bassline Editor window |
+| 62 | How Beat+Bassline Editor works |
+| 63 | Creating Beats |
+| 64 | Editing Beats |
+| 64 | Changing the volume of beats |
+| 64 | Changing the pitch of different beats |
+| 65 | Creating and Editing a bassline |
+| 66 | How the BB Editor works with the Song Editor |
+| 67 | Using Automation in the Beat+Bassline Editor |
+| 68 | The process flow for composing a rhythm |
+| 69 | Philosophies of pattern-design |
+| 70 | Which approach is best? |
+| 70 | The timeline in BB Editor |
+| 70 | Adding Steps to Timeline |
+| 71 | Effect of Time Signature on BB Editor's Timeline |
+| 72 | The Context Menu in Pattern Track |
+| 73 | The Context Menu in Automation Track |
+| 75 | The FX Mixer |
+| 76 | The channel structure |
+| 77 | The Effects Chain pane |
+| 79 | The Instrument Window |
+| 80 | Instrument Sound controls Section |
+| 80 | The ENV/LFO tab |
+| 83 | The Func tab |
+| 83 | Chords |
+| 84 | Arpeggios |
+| 84 | The FX tab |
+| 86 | The MIDI tab |
+| 86 | The Piano Keys section |
+| 89 | The Automation Editor |
+| 89 | The Automation Editor Window |
+| 92 | More about the Automation Graph |
+| 93 | The Controller Rack |
+| 93 | Controllers- General |
+| 93 | Adding a Controller |
+| 93 | Deleting a Controller |
+| 93 | Attaching a Controller to Target control |
+| 93 | Changing the settings of a Controller |
+| 94 | Naming the Controllers |
+| 94 | Editing or Removing a Controller |
+| 94 | The LFO Controllers |
+| 94 | LFO Controller Settings |
+| 95 | Applying the LFO Controller |
+| 95 | The Peak Controller |
+| 96 | Applying the Peak Controller |
+| 97 | The Project Notes Editor |
+| 97 | Typical uses of Project Notes |
+| 99 | Editing and Composing Songs |
+| 99 | Editing an existing song |
+| 99 | Experimenting with the Song Editor |
+| 100 | Experimenting with the Beat+Bassline Editor |
+| 100 | Experimenting with the FX-Mixer |
+| 102 | Composing a song from score sheet |
+| 102 | Preparing |
+| 103 | Creating the Melody |
+| 104 | Adding Rhythm |
+| 105 | Adding Automation |
+| 105 | Applying song-global automation |
+| 105 | Applying Automation Track |
+| 106 | Further experimentation |
+| 106 | Using multiple instruments |
+| 106 | Miscellaneous changes |
+| 107 | Exporting the Song |
+| 109 | Summary |
+| 111 | Appendices |
+| 113 | A. Plugins |
+| 114 | Instrument Plugins |
+| 115 | AudioFileProcessor |
+| 117 | BitInvader |
+| 118 | Kicker |
+| 119 | LB302 |
+| 120 | Mallets |
+| 121 | Organic |
+| 122 | FreeBoy |
+| 123 | PatMan |
+| 124 | SF2 Player |
+| 125 | SID |
+| 126 | The Triple Oscillator plugin |
+| 128 | VeSTige |
+| 129 | Vibed |
+| 131 | ZynAddSubFX |
+| 132 | Effect Plugins |
+| 132 | Bass Booster |
+| 132 | Peak Controller |
+| 133 | Spectrum Analyzer |
+| 133 | Stereo Enhancer |
+| 133 | Stereophonic Matrix |
+| 135 | B. Keyboard shortcuts |
+| 135 | Main Window (anywhere in LMMS) |
+| 136 | Instrument Plugins |
+| 136 | All editors that include a time line |
+| 136 | Beat+Bassline Editor |
+| 136 | Piano Roll Editor |
+| 137 | Song Editor |
+| 138 | Automation Editor |
+| 139 | Project Notes |
+| 139 | File Browser (in Side Bar) |
+| 141 | C. Editing the Automation Curve |
+| 143 | D. Working with samples |
+| 143 | Sample Used as a Melody Instrument |
+| 143 | Preparing the sample |
+| 143 | Creating an instrument with the sample |
+| 144 | Playing the instrument |
+| 144 | Sample Used as a Percussion Instrument |
+| 144 | Preparing the sample |
+| 144 | Creating the percussion instrument from the sample |
+| 144 | Playing the percussion |
+| 145 | E. Adding Special Effects |
+| 145 | Effects Created With an Automation Curve |
+| 146 | Effects Created with Controllers |
+| 146 | Side-chaining the Tracks Directly |
+| 148 | Side-chaining through FX-Mixer |
+| 151 | F. LMMS and World Music |
+| 151 | Non-Western music |
+| 151 | Limitations of Percussion |
+| 153 | G. FAQ |
+| 153 | About LMMS |
+| 153 | Plugins |
+| 153 | Miscellaneous |
+| 155 | H. Glossary |
+| 159 | I. What's new? |
+| 161 | J. References |

--- a/lmmsagent/evals/reports/phase01_baseline_20260402T233133Z.json
+++ b/lmmsagent/evals/reports/phase01_baseline_20260402T233133Z.json
@@ -1,0 +1,886 @@
+{
+  "started_at": "2026-04-02T23:31:33.152277+00:00",
+  "finished_at": "2026-04-02T23:31:33.594018+00:00",
+  "suite_path": "/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/evals/task_suite.json",
+  "buckets": [
+    "atomic",
+    "compositional"
+  ],
+  "repeat": 1,
+  "total_commands": 8,
+  "success_count": 8,
+  "failure_count": 0,
+  "clarification_count": 0,
+  "success_rate": 1.0,
+  "clarification_rate": 0.0,
+  "latency_ms": {
+    "wall_p50": 53,
+    "wall_p95": 65,
+    "wall_max": 65
+  },
+  "stage_latency_ms": {
+    "discovery_refresh": {
+      "p50": 48,
+      "p95": 55,
+      "max": 55
+    },
+    "final_state_read": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "initial_state_read": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "journal_write": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "planning": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "post_step_state_reads": {
+      "p50": 2,
+      "p95": 5,
+      "max": 5
+    },
+    "preferences_load": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "preferences_update": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "snapshot_calls": {
+      "p50": 0,
+      "p95": 0,
+      "max": 0
+    },
+    "step_execution": {
+      "p50": 0,
+      "p95": 4,
+      "max": 4
+    }
+  },
+  "rows": [
+    {
+      "command": "set tempo to 120",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 53,
+      "telemetry": {
+        "request_id": "req_fe4dfcdf8cbd",
+        "total_runtime_ms": 53,
+        "stage_timings_ms": {
+          "discovery_refresh": 52,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 0,
+          "post_step_state_reads": 0,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 1,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693152,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "set tempo to 120"
+            }
+          },
+          {
+            "ts_ms": 1775172693205,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 1
+            }
+          },
+          {
+            "ts_ms": 1775172693205,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "set_tempo"
+            }
+          },
+          {
+            "ts_ms": 1775172693205,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "set_tempo",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693206,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "show mixer",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 52,
+      "telemetry": {
+        "request_id": "req_08db54883fc7",
+        "total_runtime_ms": 52,
+        "stage_timings_ms": {
+          "discovery_refresh": 50,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 0,
+          "post_step_state_reads": 0,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 1,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693206,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "show mixer"
+            }
+          },
+          {
+            "ts_ms": 1775172693257,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 1
+            }
+          },
+          {
+            "ts_ms": 1775172693257,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "open_tool"
+            }
+          },
+          {
+            "ts_ms": 1775172693258,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "open_tool",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693259,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "add effect reverb",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 53,
+      "telemetry": {
+        "request_id": "req_2e1a304a329a",
+        "total_runtime_ms": 53,
+        "stage_timings_ms": {
+          "discovery_refresh": 47,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "snapshot_calls": 0,
+          "step_execution": 0,
+          "post_step_state_reads": 3,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 1,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693259,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "add effect reverb"
+            }
+          },
+          {
+            "ts_ms": 1775172693307,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 1
+            }
+          },
+          {
+            "ts_ms": 1775172693308,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "add_effect"
+            }
+          },
+          {
+            "ts_ms": 1775172693312,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "add_effect",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693312,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 1
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "import /tmp/loop.wav",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 49,
+      "telemetry": {
+        "request_id": "req_a20910043a8b",
+        "total_runtime_ms": 49,
+        "stage_timings_ms": {
+          "discovery_refresh": 47,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 0,
+          "post_step_state_reads": 0,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 4,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693312,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "import /tmp/loop.wav"
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 4
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693361,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693362,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693362,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693362,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693362,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 4
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "create sample track and load sample /tmp/kick.wav",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 57,
+      "telemetry": {
+        "request_id": "req_c71b20288b74",
+        "total_runtime_ms": 57,
+        "stage_timings_ms": {
+          "discovery_refresh": 47,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 1,
+          "post_step_state_reads": 5,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 4,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693362,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "create sample track and load sample /tmp/kick.wav"
+            }
+          },
+          {
+            "ts_ms": 1775172693411,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 4
+            }
+          },
+          {
+            "ts_ms": 1775172693411,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693411,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693411,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "create_track"
+            }
+          },
+          {
+            "ts_ms": 1775172693418,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "create_track",
+              "latency_ms": 1
+            }
+          },
+          {
+            "ts_ms": 1775172693418,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693419,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693419,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693419,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693420,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 4
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "load instrument triple oscillator and add effect compressor",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 65,
+      "telemetry": {
+        "request_id": "req_8c3384d494d2",
+        "total_runtime_ms": 65,
+        "stage_timings_ms": {
+          "discovery_refresh": 55,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 4,
+          "post_step_state_reads": 2,
+          "snapshot_calls": 0,
+          "final_state_read": 0,
+          "preferences_update": 0,
+          "journal_write": 0
+        },
+        "step_count": 2,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693420,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "load instrument triple oscillator and add effect compressor"
+            }
+          },
+          {
+            "ts_ms": 1775172693477,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 2
+            }
+          },
+          {
+            "ts_ms": 1775172693477,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "resolve_plugin"
+            }
+          },
+          {
+            "ts_ms": 1775172693478,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "resolve_plugin",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693478,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg2",
+              "action": "load_instrument"
+            }
+          },
+          {
+            "ts_ms": 1775172693484,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg2",
+              "action": "load_instrument",
+              "latency_ms": 4
+            }
+          },
+          {
+            "ts_ms": 1775172693485,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 2
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "import audio /tmp/vocal.wav and open slicer",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 51,
+      "telemetry": {
+        "request_id": "req_969a602086e5",
+        "total_runtime_ms": 51,
+        "stage_timings_ms": {
+          "discovery_refresh": 48,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 0,
+          "post_step_state_reads": 0,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 4,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693485,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "import audio /tmp/vocal.wav and open slicer"
+            }
+          },
+          {
+            "ts_ms": 1775172693535,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 4
+            }
+          },
+          {
+            "ts_ms": 1775172693535,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693535,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693535,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693536,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693536,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693536,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg2",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693536,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693536,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693537,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 4
+            }
+          }
+        ]
+      }
+    },
+    {
+      "command": "create instrument track and rename track to Bass Layer",
+      "ok": true,
+      "mode": "plan",
+      "status": "success",
+      "needs_clarification": false,
+      "wall_time_ms": 56,
+      "telemetry": {
+        "request_id": "req_e3119d41f2b4",
+        "total_runtime_ms": 56,
+        "stage_timings_ms": {
+          "discovery_refresh": 48,
+          "initial_state_read": 0,
+          "preferences_load": 0,
+          "planning": 0,
+          "step_execution": 2,
+          "post_step_state_reads": 2,
+          "snapshot_calls": 0,
+          "final_state_read": 0,
+          "journal_write": 0
+        },
+        "step_count": 4,
+        "trace_events": [
+          {
+            "ts_ms": 1775172693537,
+            "stage": "orchestrator",
+            "event": "start",
+            "data": {
+              "goal": "create instrument track and rename track to Bass Layer"
+            }
+          },
+          {
+            "ts_ms": 1775172693586,
+            "stage": "planner",
+            "event": "result",
+            "data": {
+              "mode": "plan",
+              "subgoals": 4
+            }
+          },
+          {
+            "ts_ms": 1775172693586,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693586,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg0",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693586,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg1",
+              "action": "create_track"
+            }
+          },
+          {
+            "ts_ms": 1775172693590,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg1",
+              "action": "create_track",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693590,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg2",
+              "action": "load_instrument"
+            }
+          },
+          {
+            "ts_ms": 1775172693593,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg2",
+              "action": "load_instrument",
+              "latency_ms": 2
+            }
+          },
+          {
+            "ts_ms": 1775172693593,
+            "stage": "step",
+            "event": "start",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note"
+            }
+          },
+          {
+            "ts_ms": 1775172693593,
+            "stage": "step",
+            "event": "end",
+            "data": {
+              "subgoal": "sg3",
+              "action": "guide_note",
+              "latency_ms": 0
+            }
+          },
+          {
+            "ts_ms": 1775172693593,
+            "stage": "orchestrator",
+            "event": "finish",
+            "data": {
+              "outcome": "success",
+              "steps": 4
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lmmsagent/evals/task_suite.json
+++ b/lmmsagent/evals/task_suite.json
@@ -1,0 +1,31 @@
+{
+  "version": "v1",
+  "buckets": {
+    "atomic": [
+      "set tempo to 120",
+      "show mixer",
+      "add effect reverb",
+      "import /tmp/loop.wav"
+    ],
+    "compositional": [
+      "create sample track and load sample /tmp/kick.wav",
+      "load instrument triple oscillator and add effect compressor",
+      "import audio /tmp/vocal.wav and open slicer",
+      "create instrument track and rename track to Bass Layer"
+    ],
+    "creative_constrained": [
+      "make this bass darker",
+      "add texture to intro",
+      "make drums hit harder"
+    ]
+  },
+  "metrics": [
+    "task_success_rate",
+    "discovery_resolution_accuracy",
+    "clarification_precision",
+    "repair_success_after_failure",
+    "rollback_correctness",
+    "median_latency_ms",
+    "p95_latency_ms"
+  ]
+}

--- a/lmmsagent/evals/voice_golden_scenarios.v2.json
+++ b/lmmsagent/evals/voice_golden_scenarios.v2.json
@@ -1,0 +1,65 @@
+{
+  "version": "2.0",
+  "description": "Golden scenarios for hybrid LMMS voice command interpretation and safety gating.",
+  "cases": [
+    {
+      "utterance": "hey lmms open splicer",
+      "expected_intent": "slicer.open",
+      "expected_command": "open slicer",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms import sample.wav from downloads into slicer",
+      "expected_intent": "slicer.import",
+      "expected_command": "import sample.wav into slicer",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms split it into 16 segments",
+      "expected_intent": "slicer.split.equal",
+      "expected_command": "divide into 16 equal segments",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms divide into transient segments",
+      "expected_intent": "slicer.split.transient",
+      "expected_command": "divide into transient segments",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms create instrument track and open piano roll",
+      "expected_chain": [
+        "create instrument track",
+        "open piano roll"
+      ],
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms remove effect reverb from bass",
+      "expected_intent": "mixer.effect.remove",
+      "needs_confirmation": true
+    },
+    {
+      "utterance": "ambient chatter without wake phrase open slicer",
+      "expected_outcome": "ignored_no_wake"
+    },
+    {
+      "utterance": "hey lmms raise tempo to 150",
+      "expected_intent": "tempo.set",
+      "expected_command": "set tempo to 150",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms play",
+      "expected_intent": "transport.play",
+      "expected_command": "play",
+      "needs_confirmation": false
+    },
+    {
+      "utterance": "hey lmms stop playback",
+      "expected_intent": "transport.stop",
+      "expected_command": "stop",
+      "needs_confirmation": false
+    }
+  ]
+}

--- a/lmmsagent/integrations/lmms/AgentControl/README.md
+++ b/lmmsagent/integrations/lmms/AgentControl/README.md
@@ -12,6 +12,12 @@ Transport:
 - TCP localhost `127.0.0.1:7777`
 - newline-delimited JSON request/response
 
+Phase 1 runtime split:
+
+- external daemon `lmmsagent/lmms-agentd/main.py` on `127.0.0.1:7781`
+- daemon request envelope fields: `op`, `request_id`, `idempotency_key`, `timeout_class`, `retries`
+- daemon forwards typed actions to this AgentControl transport
+
 Request:
 
 ```json
@@ -78,3 +84,9 @@ Core environment knobs:
 - `LMMS_VOICE_SILENCE_ABS_THRESHOLD` (default `120`)
 - `LMMS_VOICE_TRACE` (`1` enables JSON stage traces)
 - `LMMS_CAP_*` per-intent capability flags (for phased rollout).
+
+Daemon controls:
+
+- `--host` (default `127.0.0.1`)
+- `--port` (default `7781`)
+- `--cache-ttl-s` idempotency cache TTL

--- a/lmmsagent/integrations/lmms/AgentControl/README.md
+++ b/lmmsagent/integrations/lmms/AgentControl/README.md
@@ -1,0 +1,38 @@
+# AgentControl Integration
+
+Canonical LMMS integration boundary for the agent stack.
+
+Implementation lives in the LMMS plugin source:
+
+- `/Users/saksham/grp/docs/lmmsagent/lmms/plugins/AgentControl/AgentControl.h`
+- `/Users/saksham/grp/docs/lmmsagent/lmms/plugins/AgentControl/AgentControl.cpp`
+
+Transport:
+
+- TCP localhost `127.0.0.1:7777`
+- newline-delimited JSON request/response
+
+Request:
+
+```json
+{
+  "tool": "load_sample",
+  "args": {
+    "track": "Agent 808",
+    "sample_path": "/path/to/sample.wav"
+  }
+}
+```
+
+Response envelope:
+
+```json
+{
+  "ok": true,
+  "result": {},
+  "state_delta": {},
+  "warnings": [],
+  "error_code": null,
+  "error_message": null
+}
+```

--- a/lmmsagent/integrations/lmms/AgentControl/README.md
+++ b/lmmsagent/integrations/lmms/AgentControl/README.md
@@ -36,3 +36,45 @@ Response envelope:
   "error_message": null
 }
 ```
+
+## Voice Command Contracts (v2)
+
+- Command manifest schema: `/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/integrations/lmms/AgentControl/command_manifest.schema.json`
+- Default command manifest: `/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/integrations/lmms/AgentControl/command_manifest.v2.json`
+- LLM parse schema: `/Users/saksham/grp/docs/lmmsagent/lmms/lmmsagent/integrations/lmms/AgentControl/llm_interpretation.schema.json`
+
+`AgentControl` loads the default manifest at runtime when available from the current working tree path, or from `LMMS_COMMAND_MANIFEST` when explicitly set.
+
+## Internal Interpreter Contract
+
+Interpreter output is normalized before dispatch:
+
+```json
+{
+  "intent": "slicer.split.equal",
+  "args": { "segments": 16 },
+  "confidence": 0.91,
+  "risk_level": "safe",
+  "source": "deterministic|llm|hybrid"
+}
+```
+
+## Runtime Controls
+
+Core environment knobs:
+
+- `LMMS_OLLAMA_MODEL` (default planner model; expected `qwen2.5:7b-instruct`)
+- `LMMS_OLLAMA_URL` (default `http://127.0.0.1:11434/api/chat`)
+- `LMMS_OLLAMA_TIMEOUT_MS` (default `2500`)
+- `LMMS_OLLAMA_CONFIDENCE` (LLM viability threshold; default `0.72`)
+- `LMMS_HYBRID_MARGIN` (LLM arbitration margin over heuristic; default `0.12`)
+- `LMMS_CONFIRM_CONFIDENCE` (low-confidence confirm gate; default `0.74`)
+- `LMMS_CONFIRM_WINDOW_MS` (confirm timeout; default `9000`)
+- `LMMS_WAKE_REQUIRED` (default `1`)
+- `LMMS_WAKE_PHRASES` (comma-separated, default `hey lmms,ok lmms`)
+- `LMMS_WAKE_WINDOW_MS` (default `8000`)
+- `LMMS_VOICE_POLL_MS` (default `250`)
+- `LMMS_VOICE_MIN_BYTES` (default `4096`)
+- `LMMS_VOICE_SILENCE_ABS_THRESHOLD` (default `120`)
+- `LMMS_VOICE_TRACE` (`1` enables JSON stage traces)
+- `LMMS_CAP_*` per-intent capability flags (for phased rollout).

--- a/lmmsagent/integrations/lmms/AgentControl/command_manifest.schema.json
+++ b/lmmsagent/integrations/lmms/AgentControl/command_manifest.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LMMSVoiceCommandManifestV2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "intents"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^2\\.[0-9]+$"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "intents": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "intent",
+          "aliases",
+          "risk_level",
+          "capability_flag",
+          "side_effect_level",
+          "confirmation_policy"
+        ],
+        "properties": {
+          "intent": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_.-]+$"
+          },
+          "aliases": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "risk_level": {
+            "type": "string",
+            "enum": ["safe", "confirm"]
+          },
+          "capability_flag": {
+            "type": "string",
+            "pattern": "^[A-Z0-9_]+$"
+          },
+          "side_effect_level": {
+            "type": "string",
+            "enum": ["none", "ui", "mutate", "export"]
+          },
+          "requires_context": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "confirmation_policy": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["mode"],
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["never", "always", "confidence_below"]
+              },
+              "threshold": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0
+              }
+            }
+          },
+          "slot_rules": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "enabled_by_default": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lmmsagent/integrations/lmms/AgentControl/command_manifest.v2.json
+++ b/lmmsagent/integrations/lmms/AgentControl/command_manifest.v2.json
@@ -1,0 +1,353 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "description": "Canonical LMMS voice command manifest for deterministic + hybrid interpretation.",
+    "default_model": "qwen2.5:7b-instruct",
+    "runtime": "AgentControl"
+  },
+  "intents": [
+    {
+      "intent": "project.new",
+      "aliases": [
+        "new project",
+        "create project"
+      ],
+      "risk_level": "confirm",
+      "capability_flag": "PROJECT_NEW",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "always"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "project.open",
+      "aliases": [
+        "open project",
+        "load project"
+      ],
+      "risk_level": "confirm",
+      "capability_flag": "PROJECT_OPEN",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "always"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "project.save",
+      "aliases": [
+        "save project",
+        "save current project"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "PROJECT_SAVE",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "project.export",
+      "aliases": [
+        "export song",
+        "render song",
+        "export tracks"
+      ],
+      "risk_level": "confirm",
+      "capability_flag": "PROJECT_EXPORT",
+      "side_effect_level": "export",
+      "confirmation_policy": {
+        "mode": "always"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "window.open",
+      "aliases": [
+        "open song editor",
+        "open piano roll",
+        "open automation editor",
+        "open mixer",
+        "open pattern editor",
+        "open controller rack",
+        "open project notes"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "WINDOW_OPEN",
+      "side_effect_level": "ui",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "transport.play",
+      "aliases": [
+        "play",
+        "start playback",
+        "resume playback"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TRANSPORT_PLAY",
+      "side_effect_level": "ui",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "transport.pause",
+      "aliases": [
+        "pause",
+        "pause playback"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TRANSPORT_PAUSE",
+      "side_effect_level": "ui",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "transport.stop",
+      "aliases": [
+        "stop",
+        "stop playback"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TRANSPORT_STOP",
+      "side_effect_level": "ui",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "track.create",
+      "aliases": [
+        "create instrument track",
+        "create sample track",
+        "create automation track",
+        "create pattern track",
+        "create arpeggiator lane",
+        "new arpeggiator lane"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TRACK_CREATE",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "track.state",
+      "aliases": [
+        "mute track",
+        "unmute track",
+        "solo track",
+        "unsolo track"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TRACK_STATE",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "instrument.load",
+      "aliases": [
+        "load instrument",
+        "add piano",
+        "new instrument"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "INSTRUMENT_LOAD",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "slicer.open",
+      "aliases": [
+        "open slicer",
+        "show slicer",
+        "open splicer"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "SLICER_OPEN",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "slicer.import",
+      "aliases": [
+        "import sample into slicer",
+        "load sample into slicer",
+        "import from downloads into slicer"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "SLICER_IMPORT",
+      "side_effect_level": "mutate",
+      "requires_context": [
+        "last_plugin",
+        "last_imported_file"
+      ],
+      "slot_rules": {
+        "audio_file": {
+          "required": true,
+          "sources": [
+            "absolute_path",
+            "downloads_fuzzy",
+            "recent_context"
+          ]
+        }
+      },
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "slicer.split.equal",
+      "aliases": [
+        "divide into equal segments",
+        "split into equal segments",
+        "split into 16 segments"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "SLICER_SPLIT_EQUAL",
+      "side_effect_level": "mutate",
+      "requires_context": [
+        "last_plugin"
+      ],
+      "slot_rules": {
+        "segments": {
+          "required": false,
+          "default": 16,
+          "min": 1,
+          "max": 128
+        }
+      },
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "slicer.split.transient",
+      "aliases": [
+        "divide into transient segments",
+        "split by transients"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "SLICER_SPLIT_TRANSIENT",
+      "side_effect_level": "mutate",
+      "requires_context": [
+        "last_plugin"
+      ],
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "tempo.set",
+      "aliases": [
+        "set tempo",
+        "set bpm",
+        "raise tempo",
+        "lower tempo"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "TEMPO_SET",
+      "side_effect_level": "mutate",
+      "slot_rules": {
+        "tempo": {
+          "required": true,
+          "min": 20,
+          "max": 260
+        }
+      },
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "pattern.rhythm",
+      "aliases": [
+        "add kick drums",
+        "add snare",
+        "add 808",
+        "add hi hat",
+        "add hi-hat",
+        "add hihat",
+        "add hats",
+        "add crash",
+        "add crash cymbal",
+        "add ride",
+        "add cymbal"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "PATTERN_RHYTHM",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "mixer.effect.add",
+      "aliases": [
+        "add effect reverb",
+        "add effect"
+      ],
+      "risk_level": "safe",
+      "capability_flag": "MIXER_EFFECT_ADD",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "never"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "mixer.effect.remove",
+      "aliases": [
+        "remove effect",
+        "remove effect from track"
+      ],
+      "risk_level": "confirm",
+      "capability_flag": "MIXER_EFFECT_REMOVE",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "always"
+      },
+      "enabled_by_default": true
+    },
+    {
+      "intent": "undo",
+      "aliases": [
+        "undo",
+        "rollback"
+      ],
+      "risk_level": "confirm",
+      "capability_flag": "UNDO",
+      "side_effect_level": "mutate",
+      "confirmation_policy": {
+        "mode": "always"
+      },
+      "enabled_by_default": true
+    }
+  ]
+}

--- a/lmmsagent/integrations/lmms/AgentControl/llm_interpretation.schema.json
+++ b/lmmsagent/integrations/lmms/AgentControl/llm_interpretation.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LMMSHybridInterpreterOutput",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "familiar",
+    "intent",
+    "command",
+    "arguments",
+    "confidence",
+    "risk_level",
+    "reason"
+  ],
+  "properties": {
+    "familiar": {
+      "type": "boolean"
+    },
+    "intent": {
+      "type": "string"
+    },
+    "command": {
+      "type": "string"
+    },
+    "arguments": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "risk_level": {
+      "type": "string",
+      "enum": ["safe", "confirm"]
+    },
+    "reason": {
+      "type": "string"
+    },
+    "needs_confirmation": {
+      "type": "boolean"
+    },
+    "missing_context": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["intent", "command"],
+        "properties": {
+          "intent": {"type": "string"},
+          "command": {"type": "string"},
+          "confidence": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0
+          }
+        }
+      }
+    }
+  }
+}

--- a/lmmsagent/integrations/lmms/AgentControl/tool_response.schema.json
+++ b/lmmsagent/integrations/lmms/AgentControl/tool_response.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AgentControlToolResponse",
+  "type": "object",
+  "required": [
+    "ok",
+    "result",
+    "state_delta",
+    "warnings",
+    "error_code",
+    "error_message"
+  ],
+  "properties": {
+    "ok": {"type": "boolean"},
+    "result": {"type": "object"},
+    "state_delta": {"type": "object"},
+    "warnings": {"type": "array"},
+    "error_code": {"type": ["string", "null"]},
+    "error_message": {"type": ["string", "null"]}
+  },
+  "additionalProperties": true
+}

--- a/lmmsagent/lmms-agentd/main.py
+++ b/lmmsagent/lmms-agentd/main.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import socketserver
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+
+
+TIMEOUT_CLASS_RETRIES = {
+    "interactive": 1,
+    "standard": 2,
+    "background": 3,
+}
+
+TIMEOUT_CLASS_BACKOFF_MS = {
+    "interactive": 120,
+    "standard": 250,
+    "background": 400,
+}
+
+
+def now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@dataclass
+class CachedResponse:
+    payload: Dict[str, Any]
+    expires_at: float
+
+
+@dataclass
+class AgentRuntime:
+    sample_roots: list[str] = field(default_factory=list)
+    cache_ttl_s: float = 300.0
+
+    def __post_init__(self) -> None:
+        self._lock = threading.RLock()
+        self._started = time.monotonic()
+        self._idempotency: Dict[str, CachedResponse] = {}
+        self._requests_total = 0
+        self._tool_client = ToolClient()
+        self._discovery = DiscoveryIndex(self._tool_client, sample_roots=self.sample_roots)
+        self._planner = Planner()
+        self._memory = ProjectMemory()
+        self._orchestrator = Orchestrator(
+            tool_client=self._tool_client,
+            discovery=self._discovery,
+            planner=self._planner,
+            memory=self._memory,
+        )
+
+    def _cleanup_cache(self) -> None:
+        now = time.monotonic()
+        expired = [key for key, cached in self._idempotency.items() if cached.expires_at <= now]
+        for key in expired:
+            del self._idempotency[key]
+
+    def _ok(
+        self,
+        *,
+        request_id: str,
+        op: str,
+        started: float,
+        result: Dict[str, Any],
+        timeout_class: str,
+        attempts: int = 1,
+        replayed: bool = False,
+    ) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "request_id": request_id,
+            "op": op,
+            "timeout_class": timeout_class,
+            "attempts": attempts,
+            "replayed": replayed,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "result": result,
+            "meta": {
+                "server_uptime_s": int(time.monotonic() - self._started),
+                "requests_total": self._requests_total,
+            },
+        }
+
+    def _error(
+        self,
+        *,
+        request_id: str,
+        op: str,
+        started: float,
+        timeout_class: str,
+        code: str,
+        message: str,
+        attempts: int = 1,
+    ) -> Dict[str, Any]:
+        return {
+            "ok": False,
+            "request_id": request_id,
+            "op": op,
+            "timeout_class": timeout_class,
+            "attempts": attempts,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "error": {"code": code, "message": message},
+            "meta": {
+                "server_uptime_s": int(time.monotonic() - self._started),
+                "requests_total": self._requests_total,
+            },
+        }
+
+    def _normalize_retries(self, timeout_class: str, raw_retries: Any) -> int:
+        default_retries = TIMEOUT_CLASS_RETRIES.get(timeout_class, TIMEOUT_CLASS_RETRIES["standard"])
+        if raw_retries is None:
+            return default_retries
+        try:
+            parsed = int(raw_retries)
+        except (TypeError, ValueError):
+            return default_retries
+        return max(0, min(parsed, 6))
+
+    def _health_result(self) -> Dict[str, Any]:
+        return {
+            "status": "ok",
+            "server_time_ms": now_ms(),
+            "uptime_s": int(time.monotonic() - self._started),
+            "idempotency_cache_size": len(self._idempotency),
+            "requests_total": self._requests_total,
+        }
+
+    def _warmup_result(self, project_path: Optional[str]) -> Dict[str, Any]:
+        with self._lock:
+            discovery_stats = self._discovery.refresh(project_path=project_path)
+            state = self._tool_client.get_project_state()
+        return {
+            "discovery": discovery_stats,
+            "project_state": {
+                "tempo": state.get("tempo"),
+                "track_count": state.get("track_count"),
+                "project_file": state.get("project_file"),
+            },
+        }
+
+    def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        started = time.monotonic()
+        self._requests_total += 1
+        self._cleanup_cache()
+
+        op = request.get("op")
+        if not isinstance(op, str) or not op.strip():
+            request_id = str(request.get("request_id") or f"daemon_{uuid.uuid4().hex[:12]}")
+            return self._error(
+                request_id=request_id,
+                op="unknown",
+                started=started,
+                timeout_class="standard",
+                code="invalid_request",
+                message="missing op",
+            )
+
+        op = op.strip()
+        request_id = str(request.get("request_id") or f"daemon_{uuid.uuid4().hex[:12]}")
+        timeout_class = str(request.get("timeout_class") or "standard").strip().lower()
+        if timeout_class not in TIMEOUT_CLASS_RETRIES:
+            timeout_class = "standard"
+        retries = self._normalize_retries(timeout_class, request.get("retries"))
+
+        if op == "health":
+            return self._ok(
+                request_id=request_id,
+                op=op,
+                started=started,
+                result=self._health_result(),
+                timeout_class=timeout_class,
+            )
+
+        if op == "warmup":
+            try:
+                result = self._warmup_result(request.get("project_path"))
+                return self._ok(
+                    request_id=request_id,
+                    op=op,
+                    started=started,
+                    result=result,
+                    timeout_class=timeout_class,
+                )
+            except ToolClientError as exc:
+                return self._error(
+                    request_id=request_id,
+                    op=op,
+                    started=started,
+                    timeout_class=timeout_class,
+                    code="tool_client_error",
+                    message=str(exc),
+                )
+
+        if op != "run_goal":
+            return self._error(
+                request_id=request_id,
+                op=op,
+                started=started,
+                timeout_class=timeout_class,
+                code="unknown_op",
+                message=f"Unsupported op: {op}",
+            )
+
+        goal = request.get("goal")
+        if not isinstance(goal, str) or not goal.strip():
+            return self._error(
+                request_id=request_id,
+                op=op,
+                started=started,
+                timeout_class=timeout_class,
+                code="invalid_request",
+                message="run_goal requires non-empty goal",
+            )
+
+        idempotency_key = request.get("idempotency_key")
+        if isinstance(idempotency_key, str) and idempotency_key:
+            cached = self._idempotency.get(idempotency_key)
+            if cached and cached.expires_at > time.monotonic():
+                return self._ok(
+                    request_id=request_id,
+                    op=op,
+                    started=started,
+                    result=cached.payload,
+                    timeout_class=timeout_class,
+                    replayed=True,
+                )
+
+        project_path = request.get("project_path")
+        if project_path is not None and not isinstance(project_path, str):
+            project_path = None
+
+        attempts = 0
+        backoff_ms = TIMEOUT_CLASS_BACKOFF_MS.get(timeout_class, 250)
+        last_error: Optional[Exception] = None
+
+        while attempts <= retries:
+            attempts += 1
+            try:
+                with self._lock:
+                    result = self._orchestrator.run(
+                        goal.strip(),
+                        project_path=project_path,
+                        request_id=request_id,
+                    )
+                response = self._ok(
+                    request_id=request_id,
+                    op=op,
+                    started=started,
+                    result=result,
+                    timeout_class=timeout_class,
+                    attempts=attempts,
+                )
+                if isinstance(idempotency_key, str) and idempotency_key:
+                    self._idempotency[idempotency_key] = CachedResponse(
+                        payload=result,
+                        expires_at=time.monotonic() + self.cache_ttl_s,
+                    )
+                return response
+            except ToolClientError as exc:
+                last_error = exc
+                if attempts > retries:
+                    break
+                time.sleep(backoff_ms / 1000.0)
+                backoff_ms = min(backoff_ms * 2, 1500)
+
+        return self._error(
+            request_id=request_id,
+            op=op,
+            started=started,
+            timeout_class=timeout_class,
+            code="tool_client_error",
+            message=str(last_error) if last_error else "unknown run_goal failure",
+            attempts=attempts,
+        )
+
+
+class AgentRequestHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        while True:
+            line = self.rfile.readline()
+            if not line:
+                return
+            raw = line.strip()
+            if not raw:
+                continue
+            try:
+                request = json.loads(raw.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                response = {
+                    "ok": False,
+                    "request_id": f"daemon_{uuid.uuid4().hex[:12]}",
+                    "op": "unknown",
+                    "timeout_class": "standard",
+                    "attempts": 1,
+                    "duration_ms": 0,
+                    "error": {
+                        "code": "invalid_json",
+                        "message": str(exc),
+                    },
+                }
+            else:
+                if not isinstance(request, dict):
+                    response = {
+                        "ok": False,
+                        "request_id": f"daemon_{uuid.uuid4().hex[:12]}",
+                        "op": "unknown",
+                        "timeout_class": "standard",
+                        "attempts": 1,
+                        "duration_ms": 0,
+                        "error": {
+                            "code": "invalid_request",
+                            "message": "request payload must be a JSON object",
+                        },
+                    }
+                else:
+                    response = self.server.runtime.handle_request(request)  # type: ignore[attr-defined]
+
+            self.wfile.write((json.dumps(response, ensure_ascii=True) + "\n").encode("utf-8"))
+            self.wfile.flush()
+
+
+class ThreadedAgentServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, server_address: tuple[str, int], runtime: AgentRuntime) -> None:
+        self.runtime = runtime
+        super().__init__(server_address, AgentRequestHandler)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Persistent LMMS agent daemon (phase 1 runtime split)")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=7781)
+    parser.add_argument("--sample-root", action="append", default=[])
+    parser.add_argument("--cache-ttl-s", type=float, default=300.0)
+    args = parser.parse_args()
+
+    runtime = AgentRuntime(sample_roots=args.sample_root, cache_ttl_s=max(1.0, args.cache_ttl_s))
+    with ThreadedAgentServer((args.host, args.port), runtime) as server:
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "message": "lmms-agentd started",
+                    "host": args.host,
+                    "port": args.port,
+                },
+                ensure_ascii=True,
+            ),
+            flush=True,
+        )
+        try:
+            server.serve_forever(poll_interval=0.25)
+        except KeyboardInterrupt:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/lmms-text-agent/main.py
+++ b/lmmsagent/lmms-text-agent/main.py
@@ -11,7 +11,16 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+from shared import (
+    AgentDaemonClient,
+    AgentDaemonError,
+    DiscoveryIndex,
+    Orchestrator,
+    Planner,
+    ProjectMemory,
+    ToolClient,
+    ToolClientError,
+)
 
 
 def build_orchestrator(sample_roots: list[str]) -> Orchestrator:
@@ -20,6 +29,10 @@ def build_orchestrator(sample_roots: list[str]) -> Orchestrator:
     planner = Planner()
     memory = ProjectMemory()
     return Orchestrator(client, discovery, planner, memory)
+
+
+def build_daemon_client(host: str, port: int, timeout_s: float) -> AgentDaemonClient:
+    return AgentDaemonClient(host=host, port=port, timeout_s=timeout_s)
 
 
 def prompt_step_confirmation(step: Dict[str, Any]) -> bool:
@@ -37,12 +50,61 @@ def prompt_step_confirmation(step: Dict[str, Any]) -> bool:
         print("Please answer y or n.")
 
 
-def run_once(orchestrator: Orchestrator, goal: str, project_path: str | None, guided: bool = False) -> int:
+def run_once(
+    *,
+    goal: str,
+    project_path: str | None,
+    guided: bool,
+    orchestrator: Orchestrator,
+    daemon_client: AgentDaemonClient | None,
+    timeout_class: str,
+    retries: int,
+    no_direct_fallback: bool,
+) -> int:
+    result: Dict[str, Any]
+    if guided:
+        try:
+            result = orchestrator.run(
+                goal,
+                project_path=project_path,
+                confirm_step=prompt_step_confirmation,
+            )
+        except ToolClientError as exc:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+            return 2
+        print(json.dumps(result, indent=2, ensure_ascii=True))
+        return 0
+
+    if daemon_client is not None:
+        try:
+            result = daemon_client.run_goal(
+                goal,
+                project_path=project_path,
+                timeout_class=timeout_class,
+                retries=retries,
+            )
+            print(json.dumps(result, indent=2, ensure_ascii=True))
+            return 0
+        except AgentDaemonError as exc:
+            if no_direct_fallback:
+                print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+                return 2
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "warning": "daemon_unavailable_falling_back_to_direct",
+                        "detail": str(exc),
+                    },
+                    ensure_ascii=True,
+                ),
+                file=sys.stderr,
+            )
+
     try:
         result = orchestrator.run(
             goal,
             project_path=project_path,
-            confirm_step=prompt_step_confirmation if guided else None,
         )
     except ToolClientError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
@@ -58,6 +120,22 @@ def main() -> int:
     parser.add_argument("--project-path", default=None, help="project file path for memory scoping")
     parser.add_argument("--sample-root", action="append", default=[], help="additional sample library root")
     parser.add_argument("--interactive", action="store_true", help="read goals in a loop")
+    parser.add_argument("--direct", action="store_true", help="bypass lmms-agentd and run in-process")
+    parser.add_argument("--daemon-host", default="127.0.0.1", help="lmms-agentd host")
+    parser.add_argument("--daemon-port", type=int, default=7781, help="lmms-agentd port")
+    parser.add_argument("--daemon-timeout-s", type=float, default=30.0, help="lmms-agentd request timeout")
+    parser.add_argument(
+        "--timeout-class",
+        default="interactive",
+        choices=["interactive", "standard", "background"],
+        help="daemon timeout class",
+    )
+    parser.add_argument("--retries", type=int, default=1, help="daemon retry attempts for run_goal")
+    parser.add_argument(
+        "--no-direct-fallback",
+        action="store_true",
+        help="fail when daemon is unavailable instead of falling back to direct mode",
+    )
     parser.add_argument(
         "--guided",
         action="store_true",
@@ -66,6 +144,9 @@ def main() -> int:
     args = parser.parse_args()
 
     orchestrator = build_orchestrator(args.sample_root)
+    daemon_client = None if args.direct or args.guided else build_daemon_client(
+        args.daemon_host, args.daemon_port, args.daemon_timeout_s
+    )
 
     if args.interactive:
         print("LMMS text agent interactive mode. Type 'exit' to quit.")
@@ -79,14 +160,32 @@ def main() -> int:
                 continue
             if goal.lower() in {"exit", "quit"}:
                 return 0
-            rc = run_once(orchestrator, goal, args.project_path, guided=args.guided)
+            rc = run_once(
+                goal=goal,
+                project_path=args.project_path,
+                guided=args.guided,
+                orchestrator=orchestrator,
+                daemon_client=daemon_client,
+                timeout_class=args.timeout_class,
+                retries=args.retries,
+                no_direct_fallback=args.no_direct_fallback,
+            )
             if rc != 0:
                 return rc
         
     goal = " ".join(args.goal).strip()
     if not goal:
         parser.error("goal is required unless --interactive is used")
-    return run_once(orchestrator, goal, args.project_path, guided=args.guided)
+    return run_once(
+        goal=goal,
+        project_path=args.project_path,
+        guided=args.guided,
+        orchestrator=orchestrator,
+        daemon_client=daemon_client,
+        timeout_class=args.timeout_class,
+        retries=args.retries,
+        no_direct_fallback=args.no_direct_fallback,
+    )
 
 
 if __name__ == "__main__":

--- a/lmmsagent/lmms-text-agent/main.py
+++ b/lmmsagent/lmms-text-agent/main.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+
+
+def build_orchestrator(sample_roots: list[str]) -> Orchestrator:
+    client = ToolClient()
+    discovery = DiscoveryIndex(client, sample_roots=sample_roots)
+    planner = Planner()
+    memory = ProjectMemory()
+    return Orchestrator(client, discovery, planner, memory)
+
+
+def prompt_step_confirmation(step: Dict[str, Any]) -> bool:
+    print(
+        f"\n[Step] {step.get('subgoal_title', step.get('subgoal'))}: "
+        f"{step['action']} args={json.dumps(step.get('args', {}), ensure_ascii=True)} "
+        f"(confidence={step.get('confidence', 0):.2f}, risk={step.get('risk', 'safe')})"
+    )
+    while True:
+        choice = input("Run this step? [y/n] ").strip().lower()
+        if choice in {"y", "yes"}:
+            return True
+        if choice in {"n", "no"}:
+            return False
+        print("Please answer y or n.")
+
+
+def run_once(orchestrator: Orchestrator, goal: str, project_path: str | None, guided: bool = False) -> int:
+    try:
+        result = orchestrator.run(
+            goal,
+            project_path=project_path,
+            confirm_step=prompt_step_confirmation if guided else None,
+        )
+    except ToolClientError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+
+    print(json.dumps(result, indent=2, ensure_ascii=True))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LMMS text agent over typed AgentControl tools")
+    parser.add_argument("goal", nargs="*", help="request text")
+    parser.add_argument("--project-path", default=None, help="project file path for memory scoping")
+    parser.add_argument("--sample-root", action="append", default=[], help="additional sample library root")
+    parser.add_argument("--interactive", action="store_true", help="read goals in a loop")
+    parser.add_argument(
+        "--guided",
+        action="store_true",
+        help="confirm each planned step before execution",
+    )
+    args = parser.parse_args()
+
+    orchestrator = build_orchestrator(args.sample_root)
+
+    if args.interactive:
+        print("LMMS text agent interactive mode. Type 'exit' to quit.")
+        while True:
+            try:
+                goal = input("lmms> ").strip()
+            except EOFError:
+                print()
+                return 0
+            if not goal:
+                continue
+            if goal.lower() in {"exit", "quit"}:
+                return 0
+            rc = run_once(orchestrator, goal, args.project_path, guided=args.guided)
+            if rc != 0:
+                return rc
+        
+    goal = " ".join(args.goal).strip()
+    if not goal:
+        parser.error("goal is required unless --interactive is used")
+    return run_once(orchestrator, goal, args.project_path, guided=args.guided)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/lmms-voice-agent/main.py
+++ b/lmmsagent/lmms-voice-agent/main.py
@@ -5,13 +5,23 @@ import argparse
 import json
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+from shared import (
+    AgentDaemonClient,
+    AgentDaemonError,
+    DiscoveryIndex,
+    Orchestrator,
+    Planner,
+    ProjectMemory,
+    ToolClient,
+    ToolClientError,
+)
 
 
 def transcribe_with_whisper(audio_path: str, whisper_bin: str, model_path: str) -> str:
@@ -43,6 +53,22 @@ def main() -> int:
     parser.add_argument("--whisper-model", default=None, help="path to whisper model file")
     parser.add_argument("--project-path", default=None, help="project file path for memory scoping")
     parser.add_argument("--sample-root", action="append", default=[], help="additional sample library root")
+    parser.add_argument("--direct", action="store_true", help="bypass lmms-agentd and run in-process")
+    parser.add_argument("--daemon-host", default="127.0.0.1", help="lmms-agentd host")
+    parser.add_argument("--daemon-port", type=int, default=7781, help="lmms-agentd port")
+    parser.add_argument("--daemon-timeout-s", type=float, default=30.0, help="lmms-agentd request timeout")
+    parser.add_argument(
+        "--timeout-class",
+        default="interactive",
+        choices=["interactive", "standard", "background"],
+        help="daemon timeout class",
+    )
+    parser.add_argument("--retries", type=int, default=1, help="daemon retry attempts")
+    parser.add_argument(
+        "--no-direct-fallback",
+        action="store_true",
+        help="fail when daemon is unavailable instead of falling back to direct mode",
+    )
     args = parser.parse_args()
 
     if not args.transcript and not args.audio:
@@ -55,12 +81,44 @@ def main() -> int:
             parser.error("--whisper-model is required when using --audio")
         transcript = transcribe_with_whisper(args.audio, args.whisper_bin, args.whisper_model)
 
-    orchestrator = build_orchestrator(args.sample_root)
-    try:
-        result = orchestrator.run(transcript, project_path=args.project_path)
-    except (ToolClientError, RuntimeError) as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
-        return 2
+    result = None
+    if not args.direct:
+        daemon = AgentDaemonClient(
+            host=args.daemon_host,
+            port=args.daemon_port,
+            timeout_s=args.daemon_timeout_s,
+        )
+        try:
+            result = daemon.run_goal(
+                transcript,
+                project_path=args.project_path,
+                timeout_class=args.timeout_class,
+                retries=args.retries,
+                idempotency_key=f"voice_{uuid.uuid4().hex}",
+            )
+        except AgentDaemonError as exc:
+            if args.no_direct_fallback:
+                print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+                return 2
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "warning": "daemon_unavailable_falling_back_to_direct",
+                        "detail": str(exc),
+                    },
+                    ensure_ascii=True,
+                ),
+                file=sys.stderr,
+            )
+
+    if result is None:
+        orchestrator = build_orchestrator(args.sample_root)
+        try:
+            result = orchestrator.run(transcript, project_path=args.project_path)
+        except (ToolClientError, RuntimeError) as exc:
+            print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+            return 2
 
     print(
         json.dumps(

--- a/lmmsagent/lmms-voice-agent/main.py
+++ b/lmmsagent/lmms-voice-agent/main.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+
+
+def transcribe_with_whisper(audio_path: str, whisper_bin: str, model_path: str) -> str:
+    cmd = [whisper_bin, audio_path, "-m", model_path, "-nt", "-l", "en"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(f"whisper.cpp failed: {proc.stderr.strip() or proc.stdout.strip()}")
+
+    lines = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    # whisper.cpp commonly prints the final transcript as the last non-empty line.
+    if not lines:
+        raise RuntimeError("whisper.cpp returned no transcript")
+    return lines[-1]
+
+
+def build_orchestrator(sample_roots: list[str]) -> Orchestrator:
+    client = ToolClient()
+    discovery = DiscoveryIndex(client, sample_roots=sample_roots)
+    planner = Planner()
+    memory = ProjectMemory()
+    return Orchestrator(client, discovery, planner, memory)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="LMMS voice agent using whisper.cpp + shared planner")
+    parser.add_argument("--audio", default=None, help="audio file to transcribe")
+    parser.add_argument("--transcript", default=None, help="bypass ASR and use this transcript")
+    parser.add_argument("--whisper-bin", default="whisper-cli", help="path to whisper.cpp executable")
+    parser.add_argument("--whisper-model", default=None, help="path to whisper model file")
+    parser.add_argument("--project-path", default=None, help="project file path for memory scoping")
+    parser.add_argument("--sample-root", action="append", default=[], help="additional sample library root")
+    args = parser.parse_args()
+
+    if not args.transcript and not args.audio:
+        parser.error("either --transcript or --audio is required")
+
+    if args.transcript:
+        transcript = args.transcript.strip()
+    else:
+        if not args.whisper_model:
+            parser.error("--whisper-model is required when using --audio")
+        transcript = transcribe_with_whisper(args.audio, args.whisper_bin, args.whisper_model)
+
+    orchestrator = build_orchestrator(args.sample_root)
+    try:
+        result = orchestrator.run(transcript, project_path=args.project_path)
+    except (ToolClientError, RuntimeError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+
+    print(
+        json.dumps(
+            {
+                "transcript": transcript,
+                "result": result,
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/scripts/benchmark_phase01.py
+++ b/lmmsagent/scripts/benchmark_phase01.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import time
+import wave
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+ROOT = Path(__file__).resolve().parents[1]
+
+import sys
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from shared import DiscoveryIndex, Orchestrator, Planner, ProjectMemory, ToolClient, ToolClientError
+
+
+def percentile(values: List[int], pct: float) -> int:
+    if not values:
+        return 0
+    ordered = sorted(values)
+    idx = int(round((pct / 100.0) * (len(ordered) - 1)))
+    return ordered[max(0, min(idx, len(ordered) - 1))]
+
+
+def ensure_silent_wav(path: Path, duration_s: float = 0.2, sample_rate: int = 16000) -> None:
+    if path.exists():
+        return
+    frame_count = int(duration_s * sample_rate)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(sample_rate)
+        handle.writeframes(b"\x00\x00" * frame_count)
+
+
+def load_commands(suite_path: Path, selected_buckets: List[str]) -> List[str]:
+    payload = json.loads(suite_path.read_text(encoding="utf-8"))
+    buckets = payload.get("buckets", {})
+    commands: List[str] = []
+    for bucket in selected_buckets:
+        for command in buckets.get(bucket, []):
+            if isinstance(command, str) and command.strip():
+                commands.append(command.strip())
+    return commands
+
+
+def build_orchestrator(sample_roots: List[str]) -> Orchestrator:
+    client = ToolClient()
+    discovery = DiscoveryIndex(client, sample_roots=sample_roots)
+    planner = Planner()
+    memory = ProjectMemory()
+    return Orchestrator(client, discovery, planner, memory)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Phase 0/1 baseline benchmark for LMMS agent orchestration latency and success"
+    )
+    parser.add_argument(
+        "--suite",
+        default=str(ROOT / "evals" / "task_suite.json"),
+        help="path to benchmark suite JSON",
+    )
+    parser.add_argument(
+        "--bucket",
+        action="append",
+        default=["atomic", "compositional"],
+        help="suite bucket to include (repeatable)",
+    )
+    parser.add_argument("--repeat", type=int, default=1, help="number of times to execute each command")
+    parser.add_argument("--project-path", default=None, help="project file path for memory scoping")
+    parser.add_argument("--sample-root", action="append", default=[], help="additional sample search roots")
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="optional explicit output JSON report path",
+    )
+    args = parser.parse_args()
+
+    if args.repeat < 1:
+        raise SystemExit("--repeat must be >= 1")
+
+    ensure_silent_wav(Path("/tmp/loop.wav"))
+    ensure_silent_wav(Path("/tmp/kick.wav"))
+    ensure_silent_wav(Path("/tmp/vocal.wav"))
+
+    suite_path = Path(args.suite).expanduser().resolve()
+    commands = load_commands(suite_path, selected_buckets=args.bucket)
+    if not commands:
+        raise SystemExit(f"No benchmark commands loaded from {suite_path}")
+
+    orchestrator = build_orchestrator(args.sample_root)
+    started_at = datetime.now(timezone.utc).isoformat()
+
+    rows: List[Dict[str, Any]] = []
+    failures = 0
+    clarifications = 0
+    wall_times: List[int] = []
+    stage_samples: Dict[str, List[int]] = {}
+
+    for _ in range(args.repeat):
+        for command in commands:
+            run_started = time.monotonic()
+            try:
+                result = orchestrator.run(command, project_path=args.project_path)
+                wall_ms = int((time.monotonic() - run_started) * 1000)
+                wall_times.append(wall_ms)
+
+                mode = result.get("mode")
+                status = result.get("status")
+                success = status == "success"
+                needs_clarification = mode == "clarify" or bool(result.get("needs_clarification", False))
+
+                if not success:
+                    failures += 1
+                if needs_clarification:
+                    clarifications += 1
+
+                telemetry = result.get("telemetry", {})
+                stage_timings = telemetry.get("stage_timings_ms", {})
+                if isinstance(stage_timings, dict):
+                    for stage, value in stage_timings.items():
+                        if isinstance(value, int):
+                            stage_samples.setdefault(stage, []).append(value)
+
+                rows.append(
+                    {
+                        "command": command,
+                        "ok": success,
+                        "mode": mode,
+                        "status": status,
+                        "needs_clarification": needs_clarification,
+                        "wall_time_ms": wall_ms,
+                        "telemetry": telemetry,
+                    }
+                )
+            except ToolClientError as exc:
+                wall_ms = int((time.monotonic() - run_started) * 1000)
+                wall_times.append(wall_ms)
+                failures += 1
+                rows.append(
+                    {
+                        "command": command,
+                        "ok": False,
+                        "mode": "error",
+                        "status": "failed",
+                        "needs_clarification": False,
+                        "wall_time_ms": wall_ms,
+                        "error": str(exc),
+                    }
+                )
+
+    total = len(rows)
+    success_count = sum(1 for row in rows if row.get("ok"))
+
+    report: Dict[str, Any] = {
+        "started_at": started_at,
+        "finished_at": datetime.now(timezone.utc).isoformat(),
+        "suite_path": str(suite_path),
+        "buckets": args.bucket,
+        "repeat": args.repeat,
+        "total_commands": total,
+        "success_count": success_count,
+        "failure_count": failures,
+        "clarification_count": clarifications,
+        "success_rate": round((success_count / total), 4) if total else 0.0,
+        "clarification_rate": round((clarifications / total), 4) if total else 0.0,
+        "latency_ms": {
+            "wall_p50": percentile(wall_times, 50),
+            "wall_p95": percentile(wall_times, 95),
+            "wall_max": max(wall_times) if wall_times else 0,
+        },
+        "stage_latency_ms": {
+            stage: {
+                "p50": percentile(samples, 50),
+                "p95": percentile(samples, 95),
+                "max": max(samples) if samples else 0,
+            }
+            for stage, samples in sorted(stage_samples.items())
+        },
+        "rows": rows,
+    }
+
+    if args.out:
+        out_path = Path(args.out).expanduser().resolve()
+    else:
+        report_dir = ROOT / "evals" / "reports"
+        report_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        out_path = report_dir / f"phase01_baseline_{stamp}.json"
+
+    out_path.write_text(json.dumps(report, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({"ok": True, "report": str(out_path), "summary": report["latency_ms"]}, ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/scripts/build_agentcontrol.sh
+++ b/lmmsagent/scripts/build_agentcontrol.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${1:-$ROOT_DIR/build}"
+JOBS="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+
+cmake -S "$ROOT_DIR" -B "$BUILD_DIR"
+cmake --build "$BUILD_DIR" --target AgentControl -j"$JOBS"
+
+echo "Built AgentControl plugin at: $BUILD_DIR/plugins/libAgentControl.so"

--- a/lmmsagent/scripts/extract_manual_toc.py
+++ b/lmmsagent/scripts/extract_manual_toc.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import pdfplumber
+
+
+def extract_toc_entries(pdf_path: Path) -> list[tuple[str, int]]:
+    entries: list[tuple[str, int]] = []
+    with pdfplumber.open(str(pdf_path)) as pdf:
+        # The LMMS 0.4.12 manual TOC is on pages 3-7 (1-indexed).
+        for page_index in range(2, min(7, len(pdf.pages))):
+            text = pdf.pages[page_index].extract_text() or ""
+            for raw_line in text.splitlines():
+                line = raw_line.strip()
+                match = re.match(r"^(.*?)\.{2,}\s*([0-9]+)\s*$", line)
+                if not match:
+                    continue
+                title = match.group(1).strip()
+                page_num = int(match.group(2))
+                entries.append((title, page_num))
+    return entries
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract TOC entries from LMMS PDF manual")
+    parser.add_argument("--pdf", required=True, help="path to manual PDF")
+    parser.add_argument("--out", required=True, help="path to output markdown file")
+    args = parser.parse_args()
+
+    pdf_path = Path(args.pdf)
+    out_path = Path(args.out)
+
+    entries = extract_toc_entries(pdf_path)
+    lines = [
+        "# Extracted TOC",
+        "",
+        f"Source: `{pdf_path}`",
+        "",
+        "| Page | Section |",
+        "|---:|---|",
+    ]
+    for title, page_num in entries:
+        safe_title = title.replace("|", "\\|")
+        lines.append(f"| {page_num} | {safe_title} |")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"wrote {len(entries)} entries to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/scripts/install_agentcontrol.sh
+++ b/lmmsagent/scripts/install_agentcontrol.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${1:-$ROOT_DIR/build}"
+TARGET_DIR="${2:-$HOME/.lmms/plugins}"
+PLUGIN_PATH="$BUILD_DIR/plugins/libAgentControl.so"
+
+if [[ ! -f "$PLUGIN_PATH" ]]; then
+  echo "Missing plugin at $PLUGIN_PATH" >&2
+  echo "Run lmmsagent/scripts/build_agentcontrol.sh first" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+cp "$PLUGIN_PATH" "$TARGET_DIR/libAgentControl.so"
+
+echo "Installed AgentControl plugin to: $TARGET_DIR/libAgentControl.so"

--- a/lmmsagent/scripts/run_agentd.sh
+++ b/lmmsagent/scripts/run_agentd.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python3 "$ROOT_DIR/lmms-agentd/main.py" "$@"

--- a/lmmsagent/scripts/run_text_agent.sh
+++ b/lmmsagent/scripts/run_text_agent.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python3 "$ROOT_DIR/lmms-text-agent/main.py" "$@"

--- a/lmmsagent/scripts/run_voice_agent.sh
+++ b/lmmsagent/scripts/run_voice_agent.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python3 "$ROOT_DIR/lmms-voice-agent/main.py" "$@"

--- a/lmmsagent/scripts/validate_voice_contracts.py
+++ b/lmmsagent/scripts/validate_voice_contracts.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Validate LMMS Agent voice command contracts (manifest + schema consistency)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_DIR = ROOT / "integrations" / "lmms" / "AgentControl"
+MANIFEST = INTEGRATION_DIR / "command_manifest.v2.json"
+MANIFEST_SCHEMA = INTEGRATION_DIR / "command_manifest.schema.json"
+LLM_SCHEMA = INTEGRATION_DIR / "llm_interpretation.schema.json"
+GOLDEN = ROOT / "evals" / "voice_golden_scenarios.v2.json"
+
+
+def load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}")
+    raise SystemExit(1)
+
+
+def validate_manifest(manifest: dict) -> None:
+    version = str(manifest.get("version", "")).strip()
+    if not version.startswith("2."):
+        fail(f"manifest version must start with '2.' but got '{version}'")
+
+    intents = manifest.get("intents")
+    if not isinstance(intents, list) or not intents:
+        fail("manifest intents must be a non-empty array")
+
+    intent_names: set[str] = set()
+    capability_names: set[str] = set()
+
+    for idx, item in enumerate(intents):
+        where = f"intents[{idx}]"
+        if not isinstance(item, dict):
+            fail(f"{where} must be an object")
+
+        intent = str(item.get("intent", "")).strip()
+        if not intent:
+            fail(f"{where}.intent is required")
+        if intent in intent_names:
+            fail(f"duplicate intent '{intent}'")
+        intent_names.add(intent)
+
+        aliases = item.get("aliases")
+        if not isinstance(aliases, list) or not aliases:
+            fail(f"{where}.aliases must be a non-empty array")
+
+        risk = item.get("risk_level")
+        if risk not in {"safe", "confirm"}:
+            fail(f"{where}.risk_level must be safe|confirm")
+
+        capability = str(item.get("capability_flag", "")).strip()
+        if not capability:
+            fail(f"{where}.capability_flag is required")
+        if capability in capability_names:
+            fail(f"duplicate capability_flag '{capability}'")
+        capability_names.add(capability)
+
+        policy = item.get("confirmation_policy")
+        if not isinstance(policy, dict):
+            fail(f"{where}.confirmation_policy must be an object")
+
+        mode = policy.get("mode")
+        if mode not in {"never", "always", "confidence_below"}:
+            fail(f"{where}.confirmation_policy.mode must be never|always|confidence_below")
+        if mode == "confidence_below":
+            threshold = policy.get("threshold")
+            if not isinstance(threshold, (int, float)):
+                fail(f"{where}.confirmation_policy.threshold must be numeric when mode=confidence_below")
+            if threshold < 0.0 or threshold > 1.0:
+                fail(f"{where}.confirmation_policy.threshold must be in [0,1]")
+
+
+def validate_llm_schema(schema: dict) -> None:
+    required = set(schema.get("required", []))
+    expected = {"familiar", "intent", "command", "arguments", "confidence", "risk_level", "reason"}
+    if not expected.issubset(required):
+        fail("llm_interpretation.schema.json missing required fields for structured parser output")
+
+
+def validate_golden(golden: dict, manifest: dict) -> None:
+    cases = golden.get("cases")
+    if not isinstance(cases, list) or not cases:
+        fail("golden scenarios must contain a non-empty cases array")
+
+    known_intents = {str(item.get("intent", "")).strip() for item in manifest.get("intents", [])}
+    for idx, case in enumerate(cases):
+        where = f"golden.cases[{idx}]"
+        if not isinstance(case, dict):
+            fail(f"{where} must be an object")
+        utterance = str(case.get("utterance", "")).strip()
+        if not utterance:
+            fail(f"{where}.utterance is required")
+        expected_intent = str(case.get("expected_intent", "")).strip()
+        if expected_intent and expected_intent not in known_intents:
+            fail(f"{where}.expected_intent '{expected_intent}' does not exist in manifest")
+
+
+def main() -> int:
+    for path in (MANIFEST, MANIFEST_SCHEMA, LLM_SCHEMA, GOLDEN):
+        if not path.exists():
+            fail(f"missing required contract file: {path}")
+
+    manifest = load_json(MANIFEST)
+    _ = load_json(MANIFEST_SCHEMA)
+    llm_schema = load_json(LLM_SCHEMA)
+    golden = load_json(GOLDEN)
+
+    validate_manifest(manifest)
+    validate_llm_schema(llm_schema)
+    validate_golden(golden, manifest)
+
+    print("Voice contract validation passed:")
+    print(f"- manifest: {MANIFEST}")
+    print(f"- manifest schema: {MANIFEST_SCHEMA}")
+    print(f"- llm schema: {LLM_SCHEMA}")
+    print(f"- golden scenarios: {GOLDEN}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lmmsagent/shared/__init__.py
+++ b/lmmsagent/shared/__init__.py
@@ -1,3 +1,4 @@
+from .agentd_client import AgentDaemonClient, AgentDaemonError
 from .discovery import DiscoveryIndex
 from .memory import ProjectMemory
 from .orchestrator import Orchestrator
@@ -5,6 +6,8 @@ from .planner import Planner
 from .tool_client import ToolClient, ToolClientError
 
 __all__ = [
+    "AgentDaemonClient",
+    "AgentDaemonError",
     "DiscoveryIndex",
     "ProjectMemory",
     "Orchestrator",

--- a/lmmsagent/shared/__init__.py
+++ b/lmmsagent/shared/__init__.py
@@ -1,0 +1,14 @@
+from .discovery import DiscoveryIndex
+from .memory import ProjectMemory
+from .orchestrator import Orchestrator
+from .planner import Planner
+from .tool_client import ToolClient, ToolClientError
+
+__all__ = [
+    "DiscoveryIndex",
+    "ProjectMemory",
+    "Orchestrator",
+    "Planner",
+    "ToolClient",
+    "ToolClientError",
+]

--- a/lmmsagent/shared/agentd_client.py
+++ b/lmmsagent/shared/agentd_client.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+import socket
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+class AgentDaemonError(RuntimeError):
+    pass
+
+
+@dataclass
+class AgentDaemonClient:
+    host: str = "127.0.0.1"
+    port: int = 7781
+    timeout_s: float = 30.0
+
+    def _exchange(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        raw = (json.dumps(payload, ensure_ascii=True) + "\n").encode("utf-8")
+        try:
+            with socket.create_connection((self.host, self.port), timeout=self.timeout_s) as conn:
+                conn.sendall(raw)
+                conn.settimeout(self.timeout_s)
+                buffer = b""
+                while b"\n" not in buffer:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    buffer += chunk
+        except OSError as exc:
+            raise AgentDaemonError(
+                f"Could not connect to lmms-agentd at {self.host}:{self.port}: {exc}"
+            ) from exc
+
+        if not buffer:
+            raise AgentDaemonError("No response from lmms-agentd")
+
+        line = buffer.split(b"\n", 1)[0]
+        try:
+            response = json.loads(line.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise AgentDaemonError(f"Invalid lmms-agentd JSON response: {line!r}") from exc
+        if not isinstance(response, dict):
+            raise AgentDaemonError("lmms-agentd returned a non-object response")
+        return response
+
+    def call(self, op: str, payload: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        body = dict(payload or {})
+        body.setdefault("request_id", f"client_{uuid.uuid4().hex[:12]}")
+        body["op"] = op
+        response = self._exchange(body)
+        if not response.get("ok", False):
+            error = response.get("error") or {}
+            code = error.get("code") or "daemon_failed"
+            message = error.get("message") or "unknown daemon error"
+            raise AgentDaemonError(f"{code}: {message}")
+        return response
+
+    def health(self) -> Dict[str, Any]:
+        return self.call("health").get("result", {})
+
+    def warmup(self, project_path: str | None = None) -> Dict[str, Any]:
+        return self.call("warmup", {"project_path": project_path}).get("result", {})
+
+    def run_goal(
+        self,
+        goal: str,
+        *,
+        project_path: str | None = None,
+        timeout_class: str = "interactive",
+        retries: int = 1,
+        idempotency_key: str | None = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "goal": goal,
+            "project_path": project_path,
+            "timeout_class": timeout_class,
+            "retries": retries,
+        }
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
+        response = self.call("run_goal", payload)
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise AgentDaemonError("lmms-agentd returned invalid run_goal result")
+        return result

--- a/lmmsagent/shared/discovery.py
+++ b/lmmsagent/shared/discovery.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .tool_client import ToolClient
+
+AUDIO_EXTS = {".wav", ".aiff", ".aif", ".flac", ".ogg", ".mp3"}
+
+
+@dataclass
+class Asset:
+    id: str
+    type: str
+    display_name: str
+    canonical_name: str
+    aliases: List[str] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    path: Optional[str] = None
+    source: str = "unknown"
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "display_name": self.display_name,
+            "canonical_name": self.canonical_name,
+            "aliases": self.aliases,
+            "tags": self.tags,
+            "path": self.path,
+            "source": self.source,
+        }
+
+
+class DiscoveryIndex:
+    def __init__(self, tool_client: ToolClient, sample_roots: Optional[List[str]] = None) -> None:
+        self.tool_client = tool_client
+        self.sample_roots = sample_roots or []
+        self._assets: List[Asset] = []
+
+    @staticmethod
+    def _norm(value: str) -> str:
+        return "".join(ch for ch in value.lower() if ch.isalnum())
+
+    @staticmethod
+    def _tokens(value: str) -> List[str]:
+        return [part for part in "".join(ch.lower() if ch.isalnum() else " " for ch in value).split() if part]
+
+    def _score(self, query: str, asset: Asset, preferred_type: Optional[str] = None) -> float:
+        q_norm = self._norm(query)
+        if not q_norm:
+            return 0.0
+
+        names = [asset.canonical_name, asset.display_name, *asset.aliases]
+        normalized_names = [self._norm(name) for name in names if name]
+
+        if q_norm in normalized_names:
+            base = 1.0
+        elif any(name.startswith(q_norm) for name in normalized_names):
+            base = 0.9
+        elif any(q_norm in name for name in normalized_names):
+            base = 0.75
+        else:
+            q_tokens = set(self._tokens(query))
+            a_tokens = set(self._tokens(" ".join(names + asset.tags)))
+            overlap = len(q_tokens & a_tokens)
+            union = max(1, len(q_tokens | a_tokens))
+            base = overlap / union
+
+        if preferred_type and asset.type == preferred_type:
+            base += 0.1
+        if any(token in asset.tags for token in self._tokens(query)):
+            base += 0.05
+        return min(base, 1.0)
+
+    def _add_asset(self, asset: Asset) -> None:
+        self._assets.append(asset)
+
+    def index_plugins(self) -> Dict[str, int]:
+        self._assets = [a for a in self._assets if a.type == "sample"]
+        instruments = self.tool_client.call_tool("list_instruments")["result"].get("installed", [])
+        effects = self.tool_client.call_tool("list_effects")["result"].get("installed", [])
+        tools = self.tool_client.call_tool("list_tool_windows")["result"].get("tools", [])
+
+        for item in instruments:
+            name = item.get("name", "")
+            display_name = item.get("display_name", name)
+            self._add_asset(
+                Asset(
+                    id=f"plugin:instrument:{name}",
+                    type="instrument_plugin",
+                    display_name=display_name,
+                    canonical_name=name,
+                    aliases=[display_name],
+                    tags=["instrument", "plugin"],
+                    source="plugin",
+                )
+            )
+
+        for item in effects:
+            name = item.get("name", "")
+            display_name = item.get("display_name", name)
+            self._add_asset(
+                Asset(
+                    id=f"plugin:effect:{name}",
+                    type="effect_plugin",
+                    display_name=display_name,
+                    canonical_name=name,
+                    aliases=[display_name],
+                    tags=["effect", "plugin"],
+                    source="plugin",
+                )
+            )
+
+        for item in tools:
+            name = item.get("name", "")
+            display_name = item.get("display_name", name)
+            self._add_asset(
+                Asset(
+                    id=f"tool:{name}",
+                    type="tool_window",
+                    display_name=display_name,
+                    canonical_name=name,
+                    aliases=[display_name],
+                    tags=["tool", "window"],
+                    source="plugin",
+                )
+            )
+
+        windows = self.tool_client.call_tool("list_tool_windows")["result"].get("windows", [])
+        for window_name in windows:
+            self._add_asset(
+                Asset(
+                    id=f"window:{self._norm(window_name)}",
+                    type="tool_window",
+                    display_name=window_name,
+                    canonical_name=window_name,
+                    aliases=[],
+                    tags=["window"],
+                    source="factory",
+                )
+            )
+
+        return {
+            "instruments": len(instruments),
+            "effects": len(effects),
+            "tool_windows": len(windows),
+        }
+
+    def index_samples(self, project_path: Optional[str] = None) -> Dict[str, int]:
+        self._assets = [a for a in self._assets if a.type != "sample"]
+
+        added = 0
+        project_audio = self.tool_client.call_tool("search_project_audio", {"query": ""})["result"].get("matches", [])
+        for idx, item in enumerate(project_audio):
+            sample_path = item.get("sample_path")
+            if not sample_path:
+                continue
+            sample_name = Path(sample_path).name
+            self._add_asset(
+                Asset(
+                    id=f"sample:project:{idx}",
+                    type="sample",
+                    display_name=sample_name,
+                    canonical_name=sample_name,
+                    aliases=[item.get("track_name", "")],
+                    tags=["project", "audio"],
+                    path=sample_path,
+                    source="project",
+                )
+            )
+            added += 1
+
+        roots = list(self.sample_roots)
+        if project_path:
+            roots.append(str(Path(project_path).parent))
+        roots.append(str(Path.home() / "Downloads"))
+
+        seen_paths = {asset.path for asset in self._assets if asset.path}
+        for root in roots:
+            if not root:
+                continue
+            root_path = Path(root).expanduser()
+            if not root_path.exists() or not root_path.is_dir():
+                continue
+            for path in root_path.rglob("*"):
+                if not path.is_file() or path.suffix.lower() not in AUDIO_EXTS:
+                    continue
+                path_str = str(path)
+                if path_str in seen_paths:
+                    continue
+                seen_paths.add(path_str)
+                self._add_asset(
+                    Asset(
+                        id=f"sample:file:{len(seen_paths)}",
+                        type="sample",
+                        display_name=path.name,
+                        canonical_name=path.name,
+                        aliases=[path.stem],
+                        tags=["audio", path.suffix.lower().lstrip(".")],
+                        path=path_str,
+                        source="downloads" if "Downloads" in path_str else "user_library",
+                    )
+                )
+                added += 1
+
+        return {"samples": added}
+
+    def search_assets(
+        self,
+        query: str,
+        *,
+        asset_type: Optional[str] = None,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        scored = []
+        for asset in self._assets:
+            if asset_type and asset.type != asset_type:
+                continue
+            score = self._score(query, asset, preferred_type=asset_type)
+            if score <= 0:
+                continue
+            scored.append((score, asset))
+
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [
+            {
+                **asset.as_dict(),
+                "score": round(score, 3),
+            }
+            for score, asset in scored[:limit]
+        ]
+
+    def resolve_plugin(self, query: str, plugin_type: str) -> Optional[Dict[str, Any]]:
+        expected_type = "instrument_plugin" if plugin_type == "instrument" else "effect_plugin"
+        matches = self.search_assets(query, asset_type=expected_type, limit=3)
+        return matches[0] if matches else None
+
+    def resolve_sample(self, query: str) -> Optional[Dict[str, Any]]:
+        matches = self.search_assets(query, asset_type="sample", limit=3)
+        return matches[0] if matches else None
+
+    def resolve_track_reference(self, query: str) -> Optional[Dict[str, Any]]:
+        tracks = self.tool_client.call_tool("list_tracks")["result"].get("tracks", [])
+        if not tracks:
+            return None
+        wanted = self._norm(query)
+        exact = next((t for t in tracks if self._norm(t.get("name", "")) == wanted), None)
+        if exact:
+            return exact
+        return next((t for t in tracks if wanted in self._norm(t.get("name", ""))), None)
+
+    def refresh(self, project_path: Optional[str] = None) -> Dict[str, Any]:
+        return {
+            "plugins": self.index_plugins(),
+            "samples": self.index_samples(project_path=project_path),
+            "asset_count": len(self._assets),
+        }

--- a/lmmsagent/shared/manual_features.py
+++ b/lmmsagent/shared/manual_features.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class FeatureArea:
+    id: str
+    title: str
+    manual_refs: List[str]
+    keywords: List[str]
+    automated_now: List[str] = field(default_factory=list)
+    guided_now: List[str] = field(default_factory=list)
+    deferred: List[str] = field(default_factory=list)
+    example_prompts: List[str] = field(default_factory=list)
+
+
+FEATURE_AREAS: List[FeatureArea] = [
+    FeatureArea(
+        id="main_window_navigation",
+        title="Main Window and global navigation",
+        manual_refs=[
+            "LMMS Main Window",
+            "Main Menu Bar",
+            "Tool Bar",
+            "The Side Bar",
+        ],
+        keywords=["main window", "toolbar", "side bar", "browser", "projects tab", "samples tab"],
+        automated_now=[
+            "open_tool (song editor, mixer, piano roll, automation editor, controller rack, project notes)",
+            "list_tool_windows",
+            "get_project_state",
+        ],
+        guided_now=[
+            "drag-drop operations in sidebar",
+            "window docking/arrangement",
+        ],
+        deferred=["typed API for browser tab selection and drag-drop"],
+        example_prompts=["open mixer", "show song editor", "what windows are open"],
+    ),
+    FeatureArea(
+        id="song_editor_tracks",
+        title="Song Editor and track arrangement",
+        manual_refs=[
+            "The Song Editor window",
+            "Working with tracks in Song Editor",
+            "Context menus in Song Editor",
+        ],
+        keywords=["song editor", "track", "arrangement", "pattern track", "sample track", "automation track"],
+        automated_now=[
+            "create_track",
+            "rename_track",
+            "select_track",
+            "mute_track",
+            "solo_track",
+            "create_pattern",
+            "list_tracks",
+            "get_track_details",
+            "find_track_by_name",
+        ],
+        guided_now=[
+            "timeline drag/resize/split/clone gestures",
+            "right-click context menu item selection",
+        ],
+        deferred=["typed clip move/split/clone/edit operations"],
+        example_prompts=["create instrument track", "rename track bass to Sub Bass", "solo drum track"],
+    ),
+    FeatureArea(
+        id="piano_roll_composition",
+        title="Piano Roll note editing and composition",
+        manual_refs=[
+            "The Piano Roll Editor",
+            "Note Length",
+            "Note Volume",
+            "Note Panning",
+            "Composing in the Piano Roll Editor",
+        ],
+        keywords=["piano roll", "notes", "melody", "chord", "arpeggio", "quantize"],
+        automated_now=[
+            "add_notes",
+            "add_steps",
+            "create_pattern",
+            "open_tool (piano roll)",
+        ],
+        guided_now=[
+            "precise note-drawing by mouse",
+            "humanize/quantize workflows",
+            "clipboard-heavy edits across bars",
+        ],
+        deferred=["full typed piano-roll note selection/move/resize APIs"],
+        example_prompts=["open piano roll", "add notes C4 E4 G4", "create pattern Melody A"],
+    ),
+    FeatureArea(
+        id="beat_bassline",
+        title="Beat+Bassline rhythm workflow",
+        manual_refs=[
+            "The Beat+Bassline Editor",
+            "Creating Beats",
+            "Editing Beats",
+            "The process flow for composing a rhythm",
+        ],
+        keywords=["beat", "bassline", "bb editor", "rhythm", "drums", "steps"],
+        automated_now=[
+            "create_track(type=sample)",
+            "load_sample",
+            "add_steps",
+            "open_tool (bb editor if available in your build name map)",
+        ],
+        guided_now=[
+            "step-grid editing nuances",
+            "pattern-level rhythm design decisions",
+        ],
+        deferred=["native typed BB timeline and per-step accent/swing API"],
+        example_prompts=["add rhythm", "create sample track", "load sample kick"],
+    ),
+    FeatureArea(
+        id="instrument_plugins",
+        title="Instrument plugins and presets",
+        manual_refs=[
+            "Instrument Sound controls",
+            "The ENV/LFO tab",
+            "The Func tab",
+            "The FX tab",
+            "The MIDI tab",
+            "Appendix A: Instrument Plugins",
+        ],
+        keywords=["instrument", "plugin", "preset", "triple oscillator", "sf2", "zynaddsubfx"],
+        automated_now=[
+            "list_instruments",
+            "resolve_plugin(type=instrument)",
+            "load_instrument",
+        ],
+        guided_now=[
+            "preset browser deep navigation",
+            "fine-grained per-plugin envelope/LFO configuration",
+        ],
+        deferred=["typed per-plugin parameter schema and preset save/load"],
+        example_prompts=["load instrument triple oscillator", "list instruments"],
+    ),
+    FeatureArea(
+        id="fx_mixer_and_effects",
+        title="FX Mixer and effect processing",
+        manual_refs=[
+            "The FX Mixer",
+            "The channel structure",
+            "The Effects Chain pane",
+            "Appendix A: Effect Plugins",
+            "Appendix E: Adding Special Effects",
+        ],
+        keywords=["mixer", "fx", "effect", "reverb", "delay", "eq", "sidechain"],
+        automated_now=[
+            "open_tool(mixer)",
+            "list_effects",
+            "add_effect",
+            "remove_effect",
+        ],
+        guided_now=[
+            "effect chain ordering fine-tuning",
+            "side-chain routing in mixer",
+            "A/B listening workflow",
+        ],
+        deferred=["set_effect_param implementation", "typed routing graph edits"],
+        example_prompts=["show mixer", "add effect reverb", "remove effect compressor"],
+    ),
+    FeatureArea(
+        id="automation_and_controllers",
+        title="Automation Editor and Controller Rack",
+        manual_refs=[
+            "The Automation Editor",
+            "Controller Rack",
+            "LFO Controllers",
+            "Peak Controller",
+            "Appendix C: Editing the Automation Curve",
+        ],
+        keywords=["automation", "lfo", "controller", "peak controller", "curve"],
+        automated_now=[
+            "create_track(type=automation)",
+            "create_snapshot",
+            "undo_last_action",
+            "rollback_to_snapshot",
+        ],
+        guided_now=[
+            "curve drawing and shape editing",
+            "controller-to-target linkage",
+            "song-global automation attachment",
+        ],
+        deferred=["typed automation point edit API", "typed controller binding API"],
+        example_prompts=["create automation track", "undo", "rollback to snapshot"],
+    ),
+    FeatureArea(
+        id="import_and_samples",
+        title="Import, samples, and audio assets",
+        manual_refs=[
+            "Working with sample tracks",
+            "Appendix D: Working with samples",
+            "Import workflows in practical chapters",
+        ],
+        keywords=["sample", "import", "audio", "wav", "mp3", "midi", "hydrogen"],
+        automated_now=[
+            "import_audio",
+            "import_midi",
+            "import_hydrogen",
+            "search_project_audio",
+            "resolve_sample",
+            "load_sample",
+        ],
+        guided_now=[
+            "manual sample trimming and pitch preparation",
+            "browser-only sample audition workflows",
+        ],
+        deferred=["typed sample trim/normalize/slice API"],
+        example_prompts=["import midi /path/file.mid", "load sample 808 kick"],
+    ),
+    FeatureArea(
+        id="beginner_song_building",
+        title="Beginner song-building playbooks",
+        manual_refs=[
+            "Editing and Composing Songs",
+            "Composing a song from score sheet",
+            "Adding Rhythm",
+            "Adding Automation",
+            "Exporting the Song",
+        ],
+        keywords=["beginner", "playbook", "compose from score", "add rhythm", "export song"],
+        automated_now=[
+            "planner playbooks for score/rhythm/automation/multiple instruments/samples/export",
+            "guided interactive mode (confirm each step)",
+        ],
+        guided_now=[
+            "manual confirmation checkpoints",
+            "UI-only checks before export",
+        ],
+        deferred=["fully autonomous full-song generation without confirmation"],
+        example_prompts=["beginner help", "compose from score sheet", "export song"],
+    ),
+    FeatureArea(
+        id="shortcuts_and_power_use",
+        title="Keyboard shortcuts and power-user workflow",
+        manual_refs=["Appendix B: Keyboard shortcuts"],
+        keywords=["shortcut", "hotkey", "keyboard", "workflow speed"],
+        automated_now=["documented guidance only"],
+        guided_now=["human-operated keyboard workflow in LMMS UI"],
+        deferred=["typed shortcut simulation layer (not planned for v1)"],
+        example_prompts=["beginner help", "show me shortcut-friendly flow"],
+    ),
+]
+
+
+def list_feature_areas() -> List[FeatureArea]:
+    return FEATURE_AREAS
+
+
+def find_feature_areas(query: str, limit: int = 3) -> List[FeatureArea]:
+    text = query.lower()
+    ranked = []
+    for area in FEATURE_AREAS:
+        score = 0
+        for kw in area.keywords:
+            if kw in text:
+                score += 3
+        for ref in area.manual_refs:
+            if ref.lower() in text:
+                score += 2
+        if area.id.replace("_", " ") in text:
+            score += 2
+        if score > 0:
+            ranked.append((score, area))
+    ranked.sort(key=lambda item: item[0], reverse=True)
+    return [area for _, area in ranked[:limit]]
+
+
+def render_feature_area(area: FeatureArea) -> str:
+    lines = [
+        f"Feature Area: {area.title}",
+        f"Manual refs: {', '.join(area.manual_refs)}",
+        "Automated now:",
+    ]
+    lines.extend([f"- {item}" for item in area.automated_now])
+    lines.append("Guided/manual now:")
+    lines.extend([f"- {item}" for item in area.guided_now])
+    lines.append("Deferred:")
+    lines.extend([f"- {item}" for item in area.deferred])
+    lines.append("Try saying:")
+    lines.extend([f"- {item}" for item in area.example_prompts])
+    return "\n".join(lines)
+
+
+def render_feature_catalog() -> str:
+    lines = ["LMMS feature map from manual (0.4.12):"]
+    for area in FEATURE_AREAS:
+        lines.append(f"- {area.title} [{area.id}]")
+    lines.append("Use commands like: manual map song editor, manual map automation, manual map samples")
+    return "\n".join(lines)

--- a/lmmsagent/shared/manual_playbooks.py
+++ b/lmmsagent/shared/manual_playbooks.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class PlaybookStep:
+    title: str
+    action: str
+    args: Dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.9
+    risk: str = "safe"
+    requires_snapshot: bool = False
+
+
+@dataclass
+class Playbook:
+    id: str
+    title: str
+    manual_section: str
+    caution: str
+    keywords: List[str]
+    steps: List[PlaybookStep]
+
+
+PLAYBOOKS: List[Playbook] = [
+    Playbook(
+        id="compose_from_score_sheet",
+        title="Compose a melody from score sheet (beginner)",
+        manual_section="Editing and Composing Songs -> Composing a song from score sheet",
+        caution=(
+            "Manual is from LMMS 0.4.12. Core workflow still applies, but UI labels and defaults may differ."
+        ),
+        keywords=["score", "sheet", "compose", "melody", "song from score", "beginner song"],
+        steps=[
+            PlaybookStep(
+                title="Compatibility note",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Validate defaults first: check tempo, time signature, and which tracks are auto-created in your LMMS build."
+                    )
+                },
+                confidence=0.99,
+            ),
+            PlaybookStep(
+                title="Set working tempo",
+                action="set_tempo",
+                args={"tempo": 140},
+                confidence=0.96,
+            ),
+            PlaybookStep(
+                title="Open Song Editor",
+                action="open_tool",
+                args={"name": "song editor", "kind": "window"},
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Create an instrument track",
+                action="create_track",
+                args={"type": "instrument"},
+                confidence=0.93,
+            ),
+            PlaybookStep(
+                title="Load Triple Oscillator",
+                action="load_instrument",
+                args={"plugin": "tripleoscillator"},
+                confidence=0.92,
+                requires_snapshot=True,
+            ),
+            PlaybookStep(
+                title="Create first pattern clip",
+                action="create_pattern",
+                args={"tick": 0, "name": "Melody A"},
+                confidence=0.86,
+            ),
+            PlaybookStep(
+                title="Enter notes",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Open Piano Roll and enter notes measure-by-measure. Use 1/4 note length first, then refine 1/8 notes."
+                    )
+                },
+                confidence=0.94,
+            ),
+        ],
+    ),
+    Playbook(
+        id="add_rhythm_bb",
+        title="Add rhythm with Beat+Bassline workflow",
+        manual_section="Beat+Bassline Editor -> process flow for composing a rhythm",
+        caution="Beat+Bassline internals changed across LMMS versions; use this as guided workflow.",
+        keywords=["rhythm", "drums", "beat", "bassline", "bb editor", "groove"],
+        steps=[
+            PlaybookStep(
+                title="Open Beat+Bassline editor",
+                action="guide_note",
+                args={"note": "Open Beat+Bassline Editor from toolbar/window menu."},
+                confidence=0.95,
+            ),
+            PlaybookStep(
+                title="Create sample track for drums",
+                action="create_track",
+                args={"type": "sample", "name": "Drum One-shot"},
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Load drum sample",
+                action="guide_note",
+                args={
+                    "note": (
+                        "From My Samples -> Drums, audition sounds and load kick/snare/hat samples onto tracks."
+                    )
+                },
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Program 4/4 skeleton",
+                action="guide_note",
+                args={
+                    "note": "Start with hits on steps 1, 5, 9, 13 (four beats), then add syncopation."
+                },
+                confidence=0.9,
+            ),
+        ],
+    ),
+    Playbook(
+        id="automation_volume_contrast",
+        title="Create beginner automation contrast",
+        manual_section="Automation Editor + Song-global automation",
+        caution="Song-global automation behavior differs by version; prefer automation track for reversible edits.",
+        keywords=["automation", "volume automation", "fade", "lfo", "controller"],
+        steps=[
+            PlaybookStep(
+                title="Snapshot before automation",
+                action="create_snapshot",
+                args={"label": "before_automation"},
+                confidence=0.97,
+            ),
+            PlaybookStep(
+                title="Create automation track",
+                action="create_track",
+                args={"type": "automation", "name": "Volume Automation"},
+                confidence=0.92,
+            ),
+            PlaybookStep(
+                title="Link target control",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Ctrl-drag the target knob (for example track volume) onto automation track timeline to create linked automation clip."
+                    )
+                },
+                confidence=0.92,
+            ),
+            PlaybookStep(
+                title="Draw step curve",
+                action="guide_note",
+                args={
+                    "note": "Draw low level for first 2 measures, higher level for later measures to create distance contrast."
+                },
+                confidence=0.9,
+            ),
+        ],
+    ),
+    Playbook(
+        id="multiple_instruments_dialogue",
+        title="Split melody across multiple instruments",
+        manual_section="Further experimentation -> Using multiple instruments",
+        caution="SF2 patch browsing is plugin-specific; keep the split workflow, adapt patch selection UI.",
+        keywords=["multiple instruments", "layer", "sf2", "split melody", "orchestration"],
+        steps=[
+            PlaybookStep(
+                title="Create secondary instrument track",
+                action="create_track",
+                args={"type": "instrument", "name": "Secondary Voice"},
+                confidence=0.93,
+            ),
+            PlaybookStep(
+                title="Load SF2 Player",
+                action="load_instrument",
+                args={"plugin": "sf2player", "track": "Secondary Voice"},
+                confidence=0.86,
+                requires_snapshot=True,
+            ),
+            PlaybookStep(
+                title="Clone original clip",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Copy original melody clip to Secondary Voice track, then delete non-relevant notes from each track."
+                    )
+                },
+                confidence=0.9,
+            ),
+        ],
+    ),
+    Playbook(
+        id="sample_workflow",
+        title="Work with samples (melodic and percussion)",
+        manual_section="Appendix D -> Working with samples",
+        caution="Sample browser paths changed since 0.4.12; workflow remains valid.",
+        keywords=["sample", "vocal chop", "one-shot", "percussion sample", "audio clip"],
+        steps=[
+            PlaybookStep(
+                title="Create sample track",
+                action="create_track",
+                args={"type": "sample", "name": "Sample Source"},
+                confidence=0.93,
+            ),
+            PlaybookStep(
+                title="Resolve and load sample",
+                action="guide_note",
+                args={
+                    "note": "Use load sample command with an actual file path, or browse My Samples and drag-drop onto track."
+                },
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Choose melodic vs percussion usage",
+                action="guide_note",
+                args={
+                    "note": (
+                        "For melodic use, map pitch in instrument workflow; for percussion, keep one-shot timing in Song/BB editor."
+                    )
+                },
+                confidence=0.88,
+            ),
+        ],
+    ),
+    Playbook(
+        id="export_song",
+        title="Export/render final song",
+        manual_section="Editing and Composing Songs -> Exporting the Song",
+        caution="Export codec options vary by build and installed codecs.",
+        keywords=["export", "render", "bounce", "wav", "ogg", "mp3", "final mix"],
+        steps=[
+            PlaybookStep(
+                title="Save project first",
+                action="guide_note",
+                args={"note": "Save project before export to avoid losing last-minute edits."},
+                confidence=0.98,
+            ),
+            PlaybookStep(
+                title="Open export dialog",
+                action="guide_note",
+                args={"note": "Use File -> Export (Ctrl+E), choose output format and destination."},
+                confidence=0.98,
+            ),
+            PlaybookStep(
+                title="Select quality settings",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Pick sample rate/bitrate by balancing quality vs file size; validate with a quick re-import listen pass."
+                    )
+                },
+                confidence=0.94,
+            ),
+        ],
+    ),
+    Playbook(
+        id="edit_existing_song",
+        title="Edit an existing project safely",
+        manual_section="Editing and Composing Songs -> Editing an existing song",
+        caution="Manual workflow is valid, but exact panel names can vary by LMMS version/theme.",
+        keywords=["edit existing song", "edit project", "open project and edit", "revise song"],
+        steps=[
+            PlaybookStep(
+                title="Create recovery snapshot",
+                action="create_snapshot",
+                args={"label": "before_existing_song_edit"},
+                confidence=0.98,
+            ),
+            PlaybookStep(
+                title="Inspect current project state",
+                action="get_project_state",
+                args={},
+                confidence=0.97,
+            ),
+            PlaybookStep(
+                title="Open Song Editor for arrangement pass",
+                action="open_tool",
+                args={"name": "song editor"},
+                confidence=0.95,
+            ),
+            PlaybookStep(
+                title="Open Mixer for level/effect pass",
+                action="open_tool",
+                args={"name": "mixer"},
+                confidence=0.94,
+            ),
+            PlaybookStep(
+                title="Manual pass checklist",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Do one pass each for arrangement, sound design, and levels. After each pass, render 20-30s preview and compare."
+                    )
+                },
+                confidence=0.93,
+            ),
+        ],
+    ),
+    Playbook(
+        id="samples_melodic_instrument",
+        title="Use a sample as a melodic instrument",
+        manual_section="Appendix D -> Sample Used as a Melody Instrument",
+        caution="Sample browser and sampler controls changed since 0.4.12; keep to same concept flow.",
+        keywords=["sample melody", "sample instrument", "melodic sample", "sample as instrument"],
+        steps=[
+            PlaybookStep(
+                title="Create instrument track for sampler",
+                action="create_track",
+                args={"type": "instrument", "name": "Sample Instrument"},
+                confidence=0.93,
+            ),
+            PlaybookStep(
+                title="Load AudioFileProcessor",
+                action="load_instrument",
+                args={"plugin": "audiofileprocessor", "track": "Sample Instrument"},
+                confidence=0.88,
+                requires_snapshot=True,
+            ),
+            PlaybookStep(
+                title="Resolve and load source sample",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Load your sample into the sampler, set a sensible root key, then test pitch across at least one octave."
+                    )
+                },
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Create pattern for melodic test",
+                action="create_pattern",
+                args={"tick": 0, "name": "Sample Melody Test"},
+                confidence=0.85,
+            ),
+            PlaybookStep(
+                title="Write a short phrase",
+                action="guide_note",
+                args={"note": "Open Piano Roll and write a 1-2 bar phrase to validate tuning and envelope behavior."},
+                confidence=0.9,
+            ),
+        ],
+    ),
+    Playbook(
+        id="samples_percussion_instrument",
+        title="Use a sample as a percussion instrument",
+        manual_section="Appendix D -> Sample Used as a Percussion Instrument",
+        caution="Step-sequencer and sample-track UI differs by version; sequence remains valid.",
+        keywords=["sample percussion", "drum sample", "one shot", "sample as drum"],
+        steps=[
+            PlaybookStep(
+                title="Create drum sample track",
+                action="create_track",
+                args={"type": "sample", "name": "Percussion Sample"},
+                confidence=0.94,
+            ),
+            PlaybookStep(
+                title="Load percussion sample",
+                action="guide_note",
+                args={"note": "Load a short one-shot with clean transient (kick/snare/hat/clap)."},
+                confidence=0.91,
+            ),
+            PlaybookStep(
+                title="Program basic rhythm",
+                action="add_steps",
+                args={"track": "Percussion Sample", "steps": [0, 4, 8, 12]},
+                confidence=0.82,
+            ),
+            PlaybookStep(
+                title="Refine groove manually",
+                action="guide_note",
+                args={"note": "Adjust velocity/timing accents by ear to avoid robotic repetition."},
+                confidence=0.88,
+            ),
+        ],
+    ),
+    Playbook(
+        id="sidechain_through_mixer",
+        title="Create side-chain style pumping through mixer",
+        manual_section="Appendix E -> Side-chaining through FX-Mixer",
+        caution="Routing UI and plugin choices differ by build; use this as controlled guided workflow.",
+        keywords=["sidechain", "ducking", "pumping", "mixer routing"],
+        steps=[
+            PlaybookStep(
+                title="Create safety snapshot",
+                action="create_snapshot",
+                args={"label": "before_sidechain"},
+                confidence=0.98,
+            ),
+            PlaybookStep(
+                title="Open mixer",
+                action="open_tool",
+                args={"name": "mixer"},
+                confidence=0.97,
+            ),
+            PlaybookStep(
+                title="Insert controller-capable effect",
+                action="guide_note",
+                args={
+                    "note": (
+                        "Insert a gain/volume-capable effect on target channel, then prepare a controller source for ducking signal."
+                    )
+                },
+                confidence=0.86,
+            ),
+            PlaybookStep(
+                title="Link controller to volume",
+                action="guide_note",
+                args={"note": "Link controller output to target gain/volume parameter and tune depth/release by ear."},
+                confidence=0.88,
+            ),
+            PlaybookStep(
+                title="Rollback path reminder",
+                action="guide_note",
+                args={"note": "If routing gets messy, run rollback_to_snapshot using the last snapshot id."},
+                confidence=0.99,
+            ),
+        ],
+    ),
+    Playbook(
+        id="lfo_controller_modulation",
+        title="Apply LFO controller modulation",
+        manual_section="Controller Rack -> LFO Controllers",
+        caution="Controller rack visuals changed since 0.4.12; concept and signal flow remain same.",
+        keywords=["lfo controller", "lfo modulation", "controller rack", "modulate knob"],
+        steps=[
+            PlaybookStep(
+                title="Open controller rack",
+                action="open_tool",
+                args={"name": "controller rack"},
+                confidence=0.95,
+            ),
+            PlaybookStep(
+                title="Prepare target track",
+                action="guide_note",
+                args={"note": "Pick one target control first (filter cutoff, pan, or volume) to keep modulation predictable."},
+                confidence=0.92,
+            ),
+            PlaybookStep(
+                title="Add LFO and bind target",
+                action="guide_note",
+                args={"note": "Create LFO controller, link it to target control, then tune speed/depth in small increments."},
+                confidence=0.9,
+            ),
+            PlaybookStep(
+                title="Snapshot tuned state",
+                action="create_snapshot",
+                args={"label": "after_lfo_modulation"},
+                confidence=0.95,
+            ),
+        ],
+    ),
+]
+
+
+def list_playbooks() -> List[Dict[str, str]]:
+    return [
+        {
+            "id": pb.id,
+            "title": pb.title,
+            "manual_section": pb.manual_section,
+            "caution": pb.caution,
+        }
+        for pb in PLAYBOOKS
+    ]
+
+
+def find_playbook_for_goal(goal: str) -> Optional[Playbook]:
+    text = goal.lower()
+    best: Optional[Playbook] = None
+    best_score = 0
+    for playbook in PLAYBOOKS:
+        score = sum(1 for kw in playbook.keywords if kw in text)
+        if score > best_score:
+            best = playbook
+            best_score = score
+    return best

--- a/lmmsagent/shared/memory.py
+++ b/lmmsagent/shared/memory.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class ProjectMemory:
+    base_dir: Path = Path.home() / ".lmmsagent" / "memory"
+
+    def _project_id(self, project_path: Optional[str]) -> str:
+        key = (project_path or "untitled").encode("utf-8")
+        return hashlib.sha1(key).hexdigest()
+
+    def _project_dir(self, project_path: Optional[str]) -> Path:
+        pid = self._project_id(project_path)
+        path = self.base_dir / pid
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def append_journal_entry(self, project_path: Optional[str], entry: Dict[str, Any]) -> Dict[str, Any]:
+        path = self._project_dir(project_path)
+        entry_with_meta = {
+            "project_id": self._project_id(project_path),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **entry,
+        }
+        with (path / "journal.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry_with_meta, ensure_ascii=True) + "\n")
+        return entry_with_meta
+
+    def read_journal(self, project_path: Optional[str], limit: int = 100) -> List[Dict[str, Any]]:
+        journal_path = self._project_dir(project_path) / "journal.jsonl"
+        if not journal_path.exists():
+            return []
+        lines = journal_path.read_text(encoding="utf-8").splitlines()
+        rows = [json.loads(line) for line in lines if line.strip()]
+        return rows[-limit:]
+
+    def load_preferences(self, project_path: Optional[str]) -> Dict[str, Any]:
+        pref_path = self._project_dir(project_path) / "preferences.json"
+        if not pref_path.exists():
+            return {}
+        return json.loads(pref_path.read_text(encoding="utf-8"))
+
+    def update_preferences(self, project_path: Optional[str], updates: Dict[str, Any]) -> Dict[str, Any]:
+        prefs = self.load_preferences(project_path)
+        prefs.update(updates)
+        pref_path = self._project_dir(project_path) / "preferences.json"
+        pref_path.write_text(json.dumps(prefs, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+        return prefs

--- a/lmmsagent/shared/orchestrator.py
+++ b/lmmsagent/shared/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+import uuid
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
@@ -75,18 +76,62 @@ class Orchestrator:
         *,
         project_path: Optional[str] = None,
         confirm_step: Optional[Callable[[Dict[str, Any]], bool]] = None,
+        request_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        resolved_request_id = request_id or f"req_{uuid.uuid4().hex[:12]}"
+        total_started = time.monotonic()
+        stage_timings_ms: Dict[str, int] = {}
+        trace_events: List[Dict[str, Any]] = []
+
+        def add_stage_timing(stage: str, elapsed_ms: int) -> None:
+            stage_timings_ms[stage] = stage_timings_ms.get(stage, 0) + elapsed_ms
+
+        def trace(stage: str, event: str, **data: Any) -> None:
+            trace_events.append(
+                {
+                    "ts_ms": int(time.time() * 1000),
+                    "stage": stage,
+                    "event": event,
+                    "data": data,
+                }
+            )
+
+        def telemetry(step_count: int) -> Dict[str, Any]:
+            return {
+                "request_id": resolved_request_id,
+                "total_runtime_ms": int((time.monotonic() - total_started) * 1000),
+                "stage_timings_ms": stage_timings_ms,
+                "step_count": step_count,
+                "trace_events": trace_events,
+            }
+
+        trace("orchestrator", "start", goal=goal)
+
+        started = time.monotonic()
         self.discovery.refresh(project_path=project_path)
+        add_stage_timing("discovery_refresh", int((time.monotonic() - started) * 1000))
+
+        started = time.monotonic()
         state = self.tool_client.get_project_state()
+        add_stage_timing("initial_state_read", int((time.monotonic() - started) * 1000))
+
+        started = time.monotonic()
         preferences = self.memory.load_preferences(project_path)
+        add_stage_timing("preferences_load", int((time.monotonic() - started) * 1000))
+
+        started = time.monotonic()
         plan = self.planner.plan(goal, state=state, discovery=self.discovery, preferences=preferences)
+        add_stage_timing("planning", int((time.monotonic() - started) * 1000))
+        trace("planner", "result", mode=plan.mode, subgoals=len(plan.subgoals))
 
         if plan.mode in {"clarify", "reject"}:
             payload = plan.to_dict()
+            started = time.monotonic()
             self.memory.append_journal_entry(
                 project_path,
                 {
                     "request": goal,
+                    "request_id": resolved_request_id,
                     "plan_id": None,
                     "clarification": payload.get("clarification_question"),
                     "steps": [],
@@ -94,12 +139,15 @@ class Orchestrator:
                     "outcome": "clarify" if plan.mode == "clarify" else "reject",
                 },
             )
+            add_stage_timing("journal_write", int((time.monotonic() - started) * 1000))
+            payload["telemetry"] = telemetry(step_count=0)
+            trace("orchestrator", "finish", outcome=plan.mode)
             return payload
 
         flat_steps = [step for subgoal in plan.subgoals for step in subgoal.steps]
         for step in flat_steps:
             if step.confidence < self.planner.low_confidence_threshold:
-                return {
+                payload = {
                     "goal": goal,
                     "mode": "clarify",
                     "needs_clarification": True,
@@ -108,8 +156,11 @@ class Orchestrator:
                         "Can you confirm this operation?"
                     ),
                 }
+                payload["telemetry"] = telemetry(step_count=0)
+                trace("orchestrator", "finish", outcome="clarify_low_confidence", action=step.action)
+                return payload
             if step.risk in {"destructive", "irreversible"}:
-                return {
+                payload = {
                     "goal": goal,
                     "mode": "clarify",
                     "needs_clarification": True,
@@ -117,6 +168,9 @@ class Orchestrator:
                         f"'{step.action}' is marked as {step.risk}. Should I proceed?"
                     ),
                 }
+                payload["telemetry"] = telemetry(step_count=0)
+                trace("orchestrator", "finish", outcome="clarify_risk", action=step.action)
+                return payload
 
         step_results: List[Dict[str, Any]] = []
         resolved_entities: List[Dict[str, Any]] = []
@@ -145,10 +199,12 @@ class Orchestrator:
                             "aborted_step": step.action,
                             "steps": step_results,
                         }
+                        started = time.monotonic()
                         self.memory.append_journal_entry(
                             project_path,
                             {
                                 "request": goal,
+                                "request_id": resolved_request_id,
                                 "clarification": None,
                                 "plan_id": "p_001",
                                 "steps": step_results,
@@ -156,17 +212,24 @@ class Orchestrator:
                                 "outcome": "aborted",
                             },
                         )
+                        add_stage_timing("journal_write", int((time.monotonic() - started) * 1000))
+                        aborted["telemetry"] = telemetry(step_count=len(step_results))
+                        trace("orchestrator", "finish", outcome="aborted", action=step.action)
                         return aborted
 
                 snapshot_id = None
                 if step.requires_snapshot and step.action not in {"create_snapshot", "rollback_to_snapshot"}:
+                    snap_started = time.monotonic()
                     snapshot_resp = self.tool_client.call_tool("create_snapshot", {"label": f"pre_{step.action}"})
+                    add_stage_timing("snapshot_calls", int((time.monotonic() - snap_started) * 1000))
                     snapshot_id = snapshot_resp.get("result", {}).get("snapshot_id")
 
                 started = time.monotonic()
+                trace("step", "start", subgoal=subgoal.id, action=step.action)
                 try:
                     response = self._execute_step(step.action, step.args, context)
                     elapsed_ms = int((time.monotonic() - started) * 1000)
+                    add_stage_timing("step_execution", elapsed_ms)
 
                     if step.action.startswith("resolve_"):
                         resolved_entities.append(
@@ -177,7 +240,16 @@ class Orchestrator:
                             }
                         )
 
+                    state_started = time.monotonic()
                     state_after = self.tool_client.get_project_state()
+                    add_stage_timing("post_step_state_reads", int((time.monotonic() - state_started) * 1000))
+                    tool_transport_ms = None
+                    transport = response.get("_transport", {})
+                    if isinstance(transport, dict):
+                        value = transport.get("latency_ms")
+                        if isinstance(value, int):
+                            tool_transport_ms = value
+
                     step_results.append(
                         {
                             "subgoal": subgoal.id,
@@ -186,17 +258,23 @@ class Orchestrator:
                             "result": response.get("result", {}),
                             "state_delta": response.get("state_delta", {}),
                             "latency_ms": elapsed_ms,
+                            "tool_transport_ms": tool_transport_ms,
                             "state_after_tempo": state_after.get("tempo"),
                         }
                     )
+                    trace("step", "end", subgoal=subgoal.id, action=step.action, latency_ms=elapsed_ms)
                 except ToolClientError as exc:
+                    add_stage_timing("step_execution", int((time.monotonic() - started) * 1000))
+                    trace("step", "error", subgoal=subgoal.id, action=step.action, error=str(exc))
                     rollback_result: Dict[str, Any] = {}
                     if snapshot_id:
                         try:
+                            rollback_started = time.monotonic()
                             rollback_result = self.tool_client.call_tool(
                                 "rollback_to_snapshot",
                                 {"snapshot_id": snapshot_id},
                             )
+                            add_stage_timing("rollback_calls", int((time.monotonic() - rollback_started) * 1000))
                         except ToolClientError:
                             rollback_result = {
                                 "ok": False,
@@ -213,10 +291,12 @@ class Orchestrator:
                         "rollback": rollback_result,
                         "steps": step_results,
                     }
+                    started = time.monotonic()
                     self.memory.append_journal_entry(
                         project_path,
                         {
                             "request": goal,
+                            "request_id": resolved_request_id,
                             "clarification": None,
                             "plan_id": "p_001",
                             "steps": step_results,
@@ -224,15 +304,22 @@ class Orchestrator:
                             "outcome": "failed",
                         },
                     )
+                    add_stage_timing("journal_write", int((time.monotonic() - started) * 1000))
+                    failure["telemetry"] = telemetry(step_count=len(step_results))
+                    trace("orchestrator", "finish", outcome="failed", failed_step=step.action)
                     return failure
 
+        started = time.monotonic()
         final_state = self.tool_client.get_project_state()
+        add_stage_timing("final_state_read", int((time.monotonic() - started) * 1000))
         if resolved_entities:
             last_entity = resolved_entities[-1].get("result", {})
             if isinstance(last_entity, dict):
                 pref_key = "last_resolved_asset"
                 if "canonical_name" in last_entity:
+                    started = time.monotonic()
                     self.memory.update_preferences(project_path, {pref_key: last_entity["canonical_name"]})
+                    add_stage_timing("preferences_update", int((time.monotonic() - started) * 1000))
 
         response = {
             "goal": goal,
@@ -248,10 +335,12 @@ class Orchestrator:
             },
         }
 
+        started = time.monotonic()
         self.memory.append_journal_entry(
             project_path,
             {
                 "request": goal,
+                "request_id": resolved_request_id,
                 "clarification": None,
                 "plan_id": "p_001",
                 "steps": step_results,
@@ -259,4 +348,7 @@ class Orchestrator:
                 "outcome": "success",
             },
         )
+        add_stage_timing("journal_write", int((time.monotonic() - started) * 1000))
+        response["telemetry"] = telemetry(step_count=len(step_results))
+        trace("orchestrator", "finish", outcome="success", steps=len(step_results))
         return response

--- a/lmmsagent/shared/orchestrator.py
+++ b/lmmsagent/shared/orchestrator.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from .discovery import DiscoveryIndex
+from .memory import ProjectMemory
+from .planner import Planner
+from .tool_client import ToolClient, ToolClientError
+
+
+@dataclass
+class Orchestrator:
+    tool_client: ToolClient
+    discovery: DiscoveryIndex
+    planner: Planner
+    memory: ProjectMemory
+
+    def _execute_step(
+        self,
+        action: str,
+        args: Dict[str, Any],
+        context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        if action == "guide_note":
+            return {"ok": True, "result": {"note": args.get("note", "")}}
+
+        if action == "resolve_plugin":
+            plugin_type = args.get("type", "instrument")
+            resolved = self.discovery.resolve_plugin(args.get("query", ""), plugin_type)
+            if not resolved:
+                raise ToolClientError(f"could_not_resolve_plugin: {args.get('query', '')}")
+            context["resolved_plugin"] = resolved
+            return {"ok": True, "result": resolved}
+
+        if action == "resolve_sample":
+            resolved = self.discovery.resolve_sample(args.get("query", ""))
+            if not resolved:
+                raise ToolClientError(f"could_not_resolve_sample: {args.get('query', '')}")
+            context["resolved_sample"] = resolved
+            return {"ok": True, "result": resolved}
+
+        if action == "resolve_track_reference":
+            resolved = self.discovery.resolve_track_reference(args.get("query", ""))
+            if not resolved:
+                raise ToolClientError(f"could_not_resolve_track: {args.get('query', '')}")
+            context["resolved_track"] = resolved
+            return {"ok": True, "result": resolved}
+
+        runtime_args = dict(args)
+        if action in {"load_sample", "import_audio"} and not runtime_args.get("sample_path"):
+            resolved = context.get("resolved_sample")
+            if isinstance(resolved, dict):
+                runtime_args["sample_path"] = resolved.get("path")
+
+        if action in {"load_instrument", "add_effect"} and not runtime_args.get("plugin") and not runtime_args.get("effect"):
+            resolved_plugin = context.get("resolved_plugin")
+            if isinstance(resolved_plugin, dict):
+                if action == "load_instrument":
+                    runtime_args["plugin"] = resolved_plugin.get("canonical_name")
+                if action == "add_effect":
+                    runtime_args["effect"] = resolved_plugin.get("canonical_name")
+
+        if "track" not in runtime_args:
+            resolved_track = context.get("resolved_track")
+            if isinstance(resolved_track, dict) and resolved_track.get("name"):
+                runtime_args["track"] = resolved_track["name"]
+
+        return self.tool_client.call_tool(action, runtime_args)
+
+    def run(
+        self,
+        goal: str,
+        *,
+        project_path: Optional[str] = None,
+        confirm_step: Optional[Callable[[Dict[str, Any]], bool]] = None,
+    ) -> Dict[str, Any]:
+        self.discovery.refresh(project_path=project_path)
+        state = self.tool_client.get_project_state()
+        preferences = self.memory.load_preferences(project_path)
+        plan = self.planner.plan(goal, state=state, discovery=self.discovery, preferences=preferences)
+
+        if plan.mode in {"clarify", "reject"}:
+            payload = plan.to_dict()
+            self.memory.append_journal_entry(
+                project_path,
+                {
+                    "request": goal,
+                    "plan_id": None,
+                    "clarification": payload.get("clarification_question"),
+                    "steps": [],
+                    "resolved_entities": [],
+                    "outcome": "clarify" if plan.mode == "clarify" else "reject",
+                },
+            )
+            return payload
+
+        flat_steps = [step for subgoal in plan.subgoals for step in subgoal.steps]
+        for step in flat_steps:
+            if step.confidence < self.planner.low_confidence_threshold:
+                return {
+                    "goal": goal,
+                    "mode": "clarify",
+                    "needs_clarification": True,
+                    "clarification_question": (
+                        f"I am only {step.confidence:.2f} confident about '{step.action}'. "
+                        "Can you confirm this operation?"
+                    ),
+                }
+            if step.risk in {"destructive", "irreversible"}:
+                return {
+                    "goal": goal,
+                    "mode": "clarify",
+                    "needs_clarification": True,
+                    "clarification_question": (
+                        f"'{step.action}' is marked as {step.risk}. Should I proceed?"
+                    ),
+                }
+
+        step_results: List[Dict[str, Any]] = []
+        resolved_entities: List[Dict[str, Any]] = []
+        context: Dict[str, Any] = {}
+
+        for subgoal in plan.subgoals:
+            for step in subgoal.steps:
+                if confirm_step is not None:
+                    should_run = confirm_step(
+                        {
+                            "subgoal": subgoal.id,
+                            "subgoal_title": subgoal.title,
+                            "action": step.action,
+                            "args": step.args,
+                            "confidence": step.confidence,
+                            "risk": step.risk,
+                            "requires_snapshot": step.requires_snapshot,
+                        }
+                    )
+                    if not should_run:
+                        aborted = {
+                            "goal": goal,
+                            "mode": "plan",
+                            "needs_clarification": False,
+                            "status": "aborted",
+                            "aborted_step": step.action,
+                            "steps": step_results,
+                        }
+                        self.memory.append_journal_entry(
+                            project_path,
+                            {
+                                "request": goal,
+                                "clarification": None,
+                                "plan_id": "p_001",
+                                "steps": step_results,
+                                "resolved_entities": resolved_entities,
+                                "outcome": "aborted",
+                            },
+                        )
+                        return aborted
+
+                snapshot_id = None
+                if step.requires_snapshot and step.action not in {"create_snapshot", "rollback_to_snapshot"}:
+                    snapshot_resp = self.tool_client.call_tool("create_snapshot", {"label": f"pre_{step.action}"})
+                    snapshot_id = snapshot_resp.get("result", {}).get("snapshot_id")
+
+                started = time.monotonic()
+                try:
+                    response = self._execute_step(step.action, step.args, context)
+                    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+                    if step.action.startswith("resolve_"):
+                        resolved_entities.append(
+                            {
+                                "type": step.action,
+                                "query": step.args.get("query"),
+                                "result": response.get("result", {}),
+                            }
+                        )
+
+                    state_after = self.tool_client.get_project_state()
+                    step_results.append(
+                        {
+                            "subgoal": subgoal.id,
+                            "action": step.action,
+                            "args": step.args,
+                            "result": response.get("result", {}),
+                            "state_delta": response.get("state_delta", {}),
+                            "latency_ms": elapsed_ms,
+                            "state_after_tempo": state_after.get("tempo"),
+                        }
+                    )
+                except ToolClientError as exc:
+                    rollback_result: Dict[str, Any] = {}
+                    if snapshot_id:
+                        try:
+                            rollback_result = self.tool_client.call_tool(
+                                "rollback_to_snapshot",
+                                {"snapshot_id": snapshot_id},
+                            )
+                        except ToolClientError:
+                            rollback_result = {
+                                "ok": False,
+                                "error": "rollback_failed",
+                            }
+
+                    failure = {
+                        "goal": goal,
+                        "mode": "plan",
+                        "needs_clarification": False,
+                        "status": "failed",
+                        "failed_step": step.action,
+                        "error": str(exc),
+                        "rollback": rollback_result,
+                        "steps": step_results,
+                    }
+                    self.memory.append_journal_entry(
+                        project_path,
+                        {
+                            "request": goal,
+                            "clarification": None,
+                            "plan_id": "p_001",
+                            "steps": step_results,
+                            "resolved_entities": resolved_entities,
+                            "outcome": "failed",
+                        },
+                    )
+                    return failure
+
+        final_state = self.tool_client.get_project_state()
+        if resolved_entities:
+            last_entity = resolved_entities[-1].get("result", {})
+            if isinstance(last_entity, dict):
+                pref_key = "last_resolved_asset"
+                if "canonical_name" in last_entity:
+                    self.memory.update_preferences(project_path, {pref_key: last_entity["canonical_name"]})
+
+        response = {
+            "goal": goal,
+            "mode": "plan",
+            "needs_clarification": False,
+            "status": "success",
+            "subgoals_executed": len(plan.subgoals),
+            "steps": step_results,
+            "final_state": {
+                "tempo": final_state.get("tempo"),
+                "track_count": final_state.get("track_count"),
+                "project_file": final_state.get("project_file"),
+            },
+        }
+
+        self.memory.append_journal_entry(
+            project_path,
+            {
+                "request": goal,
+                "clarification": None,
+                "plan_id": "p_001",
+                "steps": step_results,
+                "resolved_entities": resolved_entities,
+                "outcome": "success",
+            },
+        )
+        return response

--- a/lmmsagent/shared/planner.py
+++ b/lmmsagent/shared/planner.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .discovery import DiscoveryIndex
+from .manual_features import find_feature_areas, render_feature_area, render_feature_catalog
+from .manual_playbooks import find_playbook_for_goal, list_playbooks
+from .types import PlanStep, PlannerOutput, Subgoal
+
+AMBIGUOUS_TERMS = {
+    "harder",
+    "texture",
+    "vibe",
+    "darker",
+    "brighter",
+    "better",
+    "clean up",
+    "clean",
+    "that plugin",
+    "some plugin",
+}
+
+CREATIVE_PHRASES = {
+    "add energy to drums": "Do you want denser hits, heavier sample choice, or stronger processing?",
+    "darken": "Do you want darker timbre (sample/instrument swap) or darker processing (EQ/filter)?",
+    "brighten": "Do you want brighter timbre (new source) or brighter processing (EQ/exciter)?",
+    "add texture": "Should texture come from ambience effects, layered samples, or a new instrument layer?",
+    "hit harder": "Do you want a punchier pattern, a heavier sample, or stronger processing?",
+    "muddy": "Should I clean low-mids on bass, drums, or the full mix bus first?",
+}
+
+
+@dataclass
+class Planner:
+    low_confidence_threshold: float = 0.70
+
+    @staticmethod
+    def _norm(text: str) -> str:
+        return " ".join(text.lower().split())
+
+    def _find_creative_question(self, goal: str) -> Optional[str]:
+        goal_norm = self._norm(goal)
+        for phrase, question in CREATIVE_PHRASES.items():
+            if phrase in goal_norm:
+                return question
+        return None
+
+    def _is_ambiguous(self, goal: str) -> bool:
+        goal_norm = self._norm(goal)
+        return any(term in goal_norm for term in AMBIGUOUS_TERMS)
+
+    def _single_step_plan(self, goal: str, action: str, args: Dict[str, Any], confidence: float) -> PlannerOutput:
+        return PlannerOutput(
+            goal=goal,
+            mode="plan",
+            needs_clarification=False,
+            subgoals=[
+                Subgoal(
+                    id="sg1",
+                    title="Execute request",
+                    steps=[
+                        PlanStep(
+                            action=action,
+                            args=args,
+                            confidence=confidence,
+                            risk="safe",
+                            requires_snapshot=False,
+                        )
+                    ],
+                )
+            ],
+        )
+
+    def _compose_track_oriented_plan(self, goal: str, track_query: str, operation_step: PlanStep) -> PlannerOutput:
+        return PlannerOutput(
+            goal=goal,
+            mode="plan",
+            needs_clarification=False,
+            subgoals=[
+                Subgoal(
+                    id="sg1",
+                    title="Resolve target track",
+                    steps=[
+                        PlanStep(
+                            action="resolve_track_reference",
+                            args={"query": track_query},
+                            confidence=0.86,
+                            risk="safe",
+                            requires_snapshot=False,
+                        )
+                    ],
+                ),
+                Subgoal(id="sg2", title="Apply change", steps=[operation_step]),
+            ],
+        )
+
+    def plan(
+        self,
+        goal: str,
+        *,
+        state: Dict[str, Any],
+        discovery: DiscoveryIndex,
+        preferences: Optional[Dict[str, Any]] = None,
+    ) -> PlannerOutput:
+        text = self._norm(goal)
+        if not text:
+            return PlannerOutput(
+                goal=goal,
+                mode="reject",
+                needs_clarification=False,
+                clarification_question="Please provide a request.",
+                subgoals=[],
+            )
+
+        if any(token in text for token in ["list playbooks", "what is possible", "what can i do", "beginner help"]):
+            catalog_lines = [f"- {pb['title']} ({pb['id']})" for pb in list_playbooks()]
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[
+                    Subgoal(
+                        id="sg1",
+                        title="Beginner playbook catalog",
+                        steps=[
+                            PlanStep(
+                                action="guide_note",
+                                args={"note": "Available beginner workflows:\n" + "\n".join(catalog_lines)},
+                                confidence=0.99,
+                                risk="safe",
+                                requires_snapshot=False,
+                            )
+                        ],
+                    )
+                ],
+            )
+
+        if any(
+            token in text
+            for token in [
+                "manual map",
+                "manual feature",
+                "full manual",
+                "map features",
+                "all features",
+                "feature map",
+            ]
+        ):
+            matches = find_feature_areas(text, limit=3)
+            note = render_feature_catalog()
+            if matches:
+                detail_chunks = [render_feature_area(area) for area in matches]
+                note = note + "\n\n" + "\n\n".join(detail_chunks)
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[
+                    Subgoal(
+                        id="sg1",
+                        title="Manual feature mapping",
+                        steps=[
+                            PlanStep(
+                                action="guide_note",
+                                args={"note": note},
+                                confidence=0.99,
+                                risk="safe",
+                                requires_snapshot=False,
+                            )
+                        ],
+                    )
+                ],
+            )
+
+        if "manual" in text and ("how to" in text or "where" in text or "map" in text):
+            matches = find_feature_areas(text, limit=2)
+            if matches:
+                note = "\n\n".join([render_feature_area(area) for area in matches])
+                return PlannerOutput(
+                    goal=goal,
+                    mode="plan",
+                    needs_clarification=False,
+                    subgoals=[
+                        Subgoal(
+                            id="sg1",
+                            title="Manual-guided capability map",
+                            steps=[
+                                PlanStep(
+                                    action="guide_note",
+                                    args={"note": note},
+                                    confidence=0.97,
+                                    risk="safe",
+                                    requires_snapshot=False,
+                                )
+                            ],
+                        )
+                    ],
+                )
+
+        playbook = find_playbook_for_goal(text)
+        if playbook is not None:
+            subgoals: List[Subgoal] = [
+                Subgoal(
+                    id="sg0",
+                    title="Compatibility check",
+                    steps=[
+                        PlanStep(
+                            action="guide_note",
+                            args={
+                                "note": (
+                                    f"Using manual playbook '{playbook.title}' from '{playbook.manual_section}'. "
+                                    + playbook.caution
+                                )
+                            },
+                            confidence=0.99,
+                            risk="safe",
+                            requires_snapshot=False,
+                        )
+                    ],
+                )
+            ]
+            for idx, step in enumerate(playbook.steps, start=1):
+                subgoals.append(
+                    Subgoal(
+                        id=f"sg{idx}",
+                        title=step.title,
+                        steps=[
+                            PlanStep(
+                                action=step.action,
+                                args=step.args,
+                                confidence=step.confidence,
+                                risk=step.risk,  # type: ignore[arg-type]
+                                requires_snapshot=step.requires_snapshot,
+                            )
+                        ],
+                    )
+                )
+            return PlannerOutput(goal=goal, mode="plan", needs_clarification=False, subgoals=subgoals)
+
+        question = self._find_creative_question(text)
+        if question:
+            return PlannerOutput(
+                goal=goal,
+                mode="clarify",
+                needs_clarification=True,
+                clarification_question=question,
+                subgoals=[],
+            )
+
+        if self._is_ambiguous(text):
+            return PlannerOutput(
+                goal=goal,
+                mode="clarify",
+                needs_clarification=True,
+                clarification_question="Can you specify one target track and one exact change to apply?",
+                subgoals=[],
+            )
+
+        if "tempo" in text or text.startswith("bpm"):
+            tempo = next((int(tok) for tok in text.split() if tok.isdigit()), None)
+            if tempo is None:
+                return PlannerOutput(
+                    goal=goal,
+                    mode="clarify",
+                    needs_clarification=True,
+                    clarification_question="What BPM should I set?",
+                    subgoals=[],
+                )
+            return self._single_step_plan(goal, "set_tempo", {"tempo": tempo}, 0.97)
+
+        if text.startswith("show ") or text.startswith("open "):
+            target = text.replace("show", "", 1).replace("open", "", 1).strip()
+            return self._single_step_plan(goal, "open_tool", {"name": target}, 0.88)
+
+        if "import midi" in text:
+            path = goal.split("import midi", 1)[-1].strip()
+            return self._single_step_plan(goal, "import_midi", {"path": path}, 0.92)
+
+        if "import hydrogen" in text:
+            path = goal.split("import hydrogen", 1)[-1].strip()
+            return self._single_step_plan(goal, "import_hydrogen", {"path": path}, 0.92)
+
+        if "import" in text and any(ext in text for ext in [".wav", ".mp3", ".aiff", ".flac", ".ogg"]):
+            path = goal.split("import", 1)[-1].strip()
+            return self._single_step_plan(goal, "import_audio", {"path": path}, 0.90)
+
+        if text.startswith("create ") and "track" in text:
+            track_type = "instrument"
+            for candidate in ("sample", "instrument", "automation", "pattern"):
+                if candidate in text:
+                    track_type = candidate
+                    break
+            return self._single_step_plan(goal, "create_track", {"type": track_type}, 0.91)
+
+        if "rename track" in text and " to " in text:
+            left, right = text.split(" to ", 1)
+            old_name = left.replace("rename track", "").strip()
+            new_name = right.strip()
+            return self._single_step_plan(
+                goal,
+                "rename_track",
+                {"track": old_name, "new_name": new_name},
+                0.89,
+            )
+
+        if "load instrument" in text:
+            plugin_query = text.split("load instrument", 1)[-1].strip()
+            resolved = discovery.resolve_plugin(plugin_query, "instrument")
+            if not resolved:
+                return PlannerOutput(
+                    goal=goal,
+                    mode="clarify",
+                    needs_clarification=True,
+                    clarification_question=f"I could not resolve '{plugin_query}'. Which instrument plugin should I load?",
+                    subgoals=[],
+                )
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[
+                    Subgoal(
+                        id="sg1",
+                        title="Resolve instrument plugin",
+                        steps=[
+                            PlanStep(
+                                action="resolve_plugin",
+                                args={"query": plugin_query, "type": "instrument"},
+                                confidence=0.84,
+                                risk="safe",
+                                requires_snapshot=False,
+                            )
+                        ],
+                    ),
+                    Subgoal(
+                        id="sg2",
+                        title="Load instrument",
+                        steps=[
+                            PlanStep(
+                                action="load_instrument",
+                                args={"plugin": resolved["canonical_name"]},
+                                confidence=0.9,
+                                risk="safe",
+                                requires_snapshot=True,
+                            )
+                        ],
+                    ),
+                ],
+            )
+
+        if "load sample" in text or "add sample" in text:
+            sample_query = text.replace("load sample", "").replace("add sample", "").strip()
+            resolved = discovery.resolve_sample(sample_query)
+            if not resolved:
+                return PlannerOutput(
+                    goal=goal,
+                    mode="clarify",
+                    needs_clarification=True,
+                    clarification_question=f"I could not resolve sample '{sample_query}'. Which file should I use?",
+                    subgoals=[],
+                )
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[
+                    Subgoal(
+                        id="sg1",
+                        title="Resolve sample asset",
+                        steps=[
+                            PlanStep(
+                                action="resolve_sample",
+                                args={"query": sample_query},
+                                confidence=0.82,
+                                risk="safe",
+                                requires_snapshot=False,
+                            )
+                        ],
+                    ),
+                    Subgoal(
+                        id="sg2",
+                        title="Load sample",
+                        steps=[
+                            PlanStep(
+                                action="load_sample",
+                                args={"sample_path": resolved.get("path", sample_query)},
+                                confidence=0.87,
+                                risk="safe",
+                                requires_snapshot=True,
+                            )
+                        ],
+                    ),
+                ],
+            )
+
+        if "add effect" in text:
+            effect_name = text.split("add effect", 1)[-1].strip()
+            resolved = discovery.resolve_plugin(effect_name, "effect")
+            if not resolved:
+                return PlannerOutput(
+                    goal=goal,
+                    mode="clarify",
+                    needs_clarification=True,
+                    clarification_question=f"Which effect plugin should I use for '{effect_name}'?",
+                    subgoals=[],
+                )
+            step = PlanStep(
+                action="add_effect",
+                args={"effect": resolved["canonical_name"]},
+                confidence=0.86,
+                risk="safe",
+                requires_snapshot=True,
+            )
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[Subgoal(id="sg1", title="Add effect", steps=[step])],
+            )
+
+        if "remove effect" in text:
+            effect_name = text.split("remove effect", 1)[-1].strip()
+            step = PlanStep(
+                action="remove_effect",
+                args={"effect": effect_name},
+                confidence=0.78,
+                risk="destructive",
+                requires_snapshot=True,
+            )
+            return PlannerOutput(
+                goal=goal,
+                mode="plan",
+                needs_clarification=False,
+                subgoals=[Subgoal(id="sg1", title="Remove effect", steps=[step])],
+            )
+
+        if "mute" in text and "track" in text:
+            target = text.split("mute", 1)[-1].replace("track", "").strip()
+            step = PlanStep(
+                action="mute_track",
+                args={"track": target, "mute": True},
+                confidence=0.83,
+                risk="safe",
+                requires_snapshot=False,
+            )
+            return self._compose_track_oriented_plan(goal, target, step)
+
+        if "solo" in text and "track" in text:
+            target = text.split("solo", 1)[-1].replace("track", "").strip()
+            step = PlanStep(
+                action="solo_track",
+                args={"track": target, "solo": True},
+                confidence=0.83,
+                risk="safe",
+                requires_snapshot=False,
+            )
+            return self._compose_track_oriented_plan(goal, target, step)
+
+        if "undo" in text:
+            return self._single_step_plan(goal, "undo_last_action", {}, 0.96)
+
+        if "rollback" in text and "snapshot" in text:
+            snapshot_id = text.split()[-1]
+            return self._single_step_plan(goal, "rollback_to_snapshot", {"snapshot_id": snapshot_id}, 0.91)
+
+        return PlannerOutput(
+            goal=goal,
+            mode="clarify",
+            needs_clarification=True,
+            clarification_question="I can execute this with typed LMMS tools. Which exact operation should I run first?",
+            subgoals=[],
+        )

--- a/lmmsagent/shared/tool_client.py
+++ b/lmmsagent/shared/tool_client.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+class ToolClientError(RuntimeError):
+    pass
+
+
+@dataclass
+class ToolClient:
+    host: str = "127.0.0.1"
+    port: int = 7777
+    timeout_s: float = 5.0
+
+    def _exchange(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        raw = (json.dumps(payload, ensure_ascii=True) + "\n").encode("utf-8")
+        try:
+            with socket.create_connection((self.host, self.port), timeout=self.timeout_s) as conn:
+                conn.sendall(raw)
+                conn.settimeout(self.timeout_s)
+                buffer = b""
+                while b"\n" not in buffer:
+                    chunk = conn.recv(4096)
+                    if not chunk:
+                        break
+                    buffer += chunk
+        except OSError as exc:
+            raise ToolClientError(
+                f"Could not connect to AgentControl server at {self.host}:{self.port}: {exc}"
+            ) from exc
+        if not buffer:
+            raise ToolClientError("No response from AgentControl tool server")
+        line = buffer.split(b"\n", 1)[0]
+        try:
+            response = json.loads(line.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ToolClientError(f"Invalid JSON response: {line!r}") from exc
+        if not isinstance(response, dict):
+            raise ToolClientError("Tool server returned a non-object response")
+        return response
+
+    def call_tool(self, tool: str, args: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        response = self._exchange({"tool": tool, "args": args or {}})
+        if not response.get("ok", False):
+            code = response.get("error_code") or "tool_failed"
+            message = response.get("error_message") or "unknown tool failure"
+            raise ToolClientError(f"{code}: {message}")
+        return response
+
+    def get_project_state(self) -> Dict[str, Any]:
+        return self.call_tool("get_project_state")["result"]

--- a/lmmsagent/shared/tool_client.py
+++ b/lmmsagent/shared/tool_client.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import socket
+import time
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 
 class ToolClientError(RuntimeError):
@@ -16,8 +17,9 @@ class ToolClient:
     port: int = 7777
     timeout_s: float = 5.0
 
-    def _exchange(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+    def _exchange(self, payload: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
         raw = (json.dumps(payload, ensure_ascii=True) + "\n").encode("utf-8")
+        started = time.monotonic()
         try:
             with socket.create_connection((self.host, self.port), timeout=self.timeout_s) as conn:
                 conn.sendall(raw)
@@ -41,10 +43,16 @@ class ToolClient:
             raise ToolClientError(f"Invalid JSON response: {line!r}") from exc
         if not isinstance(response, dict):
             raise ToolClientError("Tool server returned a non-object response")
-        return response
+        latency_ms = int((time.monotonic() - started) * 1000)
+        return response, latency_ms
 
     def call_tool(self, tool: str, args: Dict[str, Any] | None = None) -> Dict[str, Any]:
-        response = self._exchange({"tool": tool, "args": args or {}})
+        response, latency_ms = self._exchange({"tool": tool, "args": args or {}})
+        response["_transport"] = {
+            "host": self.host,
+            "port": self.port,
+            "latency_ms": latency_ms,
+        }
         if not response.get("ok", False):
             code = response.get("error_code") or "tool_failed"
             message = response.get("error_message") or "unknown tool failure"

--- a/lmmsagent/shared/types.py
+++ b/lmmsagent/shared/types.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+RiskLevel = Literal["safe", "destructive", "irreversible"]
+PlannerMode = Literal["plan", "clarify", "reject"]
+
+
+@dataclass
+class PlanStep:
+    action: str
+    args: Dict[str, Any]
+    confidence: float
+    risk: RiskLevel
+    requires_snapshot: bool
+
+
+@dataclass
+class Subgoal:
+    id: str
+    title: str
+    steps: List[PlanStep] = field(default_factory=list)
+
+
+@dataclass
+class PlannerOutput:
+    goal: str
+    mode: PlannerMode
+    needs_clarification: bool
+    clarification_question: Optional[str] = None
+    subgoals: List[Subgoal] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "goal": self.goal,
+            "mode": self.mode,
+            "needs_clarification": self.needs_clarification,
+            "subgoals": [
+                {
+                    "id": subgoal.id,
+                    "title": subgoal.title,
+                    "steps": [
+                        {
+                            "action": step.action,
+                            "args": step.args,
+                            "confidence": round(step.confidence, 3),
+                            "risk": step.risk,
+                            "requires_snapshot": step.requires_snapshot,
+                        }
+                        for step in subgoal.steps
+                    ],
+                }
+                for subgoal in self.subgoals
+            ],
+        }
+        if self.clarification_question:
+            payload["clarification_question"] = self.clarification_question
+        return payload

--- a/plugins/AgentControl/AgentControl.cpp
+++ b/plugins/AgentControl/AgentControl.cpp
@@ -1,6 +1,7 @@
 #include "AgentControl.h"
 
 #include <QDir>
+#include <QCoreApplication>
 #include <QFile>
 #include <QFileInfo>
 #include <QHostAddress>
@@ -54,10 +55,23 @@ PLUGIN_EXPORT Plugin * lmms_plugin_main( Model *, void * )
 }
 }
 
-AgentControlPlugin::AgentControlPlugin() :
-	ToolPlugin( &AgentControl_plugin_descriptor, nullptr )
+AgentControlService* AgentControlService::instance()
 {
-	connect( &m_server, &QTcpServer::newConnection, this, &AgentControlPlugin::onNewConnection );
+	static AgentControlService* service = nullptr;
+	if( service == nullptr )
+	{
+		service = new AgentControlService;
+		if( auto *app = QCoreApplication::instance() )
+		{
+			service->setParent( app );
+		}
+	}
+	return service;
+}
+
+AgentControlService::AgentControlService()
+{
+	connect( &m_server, &QTcpServer::newConnection, this, &AgentControlService::onNewConnection );
 
 	if( !m_server.listen( QHostAddress::LocalHost, 7777 ) )
 	{
@@ -69,7 +83,7 @@ AgentControlPlugin::AgentControlPlugin() :
 	}
 }
 
-AgentControlPlugin::~AgentControlPlugin()
+AgentControlService::~AgentControlService()
 {
 	for( auto *client : m_clients )
 	{
@@ -82,6 +96,21 @@ AgentControlPlugin::~AgentControlPlugin()
 	}
 	m_clients.clear();
 	m_server.close();
+}
+
+AgentControlPlugin::AgentControlPlugin() :
+	ToolPlugin( &AgentControl_plugin_descriptor, nullptr )
+{
+	auto *svc = service();
+	connect( svc, &AgentControlService::logMessage, this, &AgentControlPlugin::logMessage );
+	connect( svc, &AgentControlService::commandResult, this, &AgentControlPlugin::commandResult );
+}
+
+AgentControlPlugin::~AgentControlPlugin() = default;
+
+AgentControlService* AgentControlPlugin::service()
+{
+	return AgentControlService::instance();
 }
 
 QString AgentControlPlugin::nodeName() const
@@ -104,6 +133,16 @@ gui::PluginView* AgentControlPlugin::instantiateView( QWidget* )
 
 QString AgentControlPlugin::handleCommand( const QString& rawText )
 {
+	return service()->handleCommand( rawText );
+}
+
+QString AgentControlPlugin::handleJson( const QJsonObject& obj )
+{
+	return service()->handleJson( obj );
+}
+
+QString AgentControlService::handleCommand( const QString& rawText )
+{
 	const QString trimmed = rawText.trimmed();
 	if( trimmed.isEmpty() )
 	{
@@ -114,7 +153,7 @@ QString AgentControlPlugin::handleCommand( const QString& rawText )
 	return dispatchTokens( parts, trimmed );
 }
 
-QString AgentControlPlugin::handleJson( const QJsonObject& obj )
+QString AgentControlService::handleJson( const QJsonObject& obj )
 {
 	QStringList tokens;
 	const QString command = obj.value( "command" ).toString().trimmed();
@@ -152,7 +191,7 @@ QString AgentControlPlugin::handleJson( const QJsonObject& obj )
 	return dispatchTokens( tokens, command );
 }
 
-QString AgentControlPlugin::dispatchTokens( const QStringList& tokens, const QString& rawText )
+QString AgentControlService::dispatchTokens( const QStringList& tokens, const QString& rawText )
 {
 	QString result;
 	QString error;
@@ -289,19 +328,19 @@ QString AgentControlPlugin::dispatchTokens( const QStringList& tokens, const QSt
 	return tr( "Unknown command: %1" ).arg( rawText );
 }
 
-void AgentControlPlugin::onNewConnection()
+void AgentControlService::onNewConnection()
 {
 	while( m_server.hasPendingConnections() )
 	{
 		QTcpSocket *sock = m_server.nextPendingConnection();
 		m_clients.insert( sock );
-		connect( sock, &QTcpSocket::readyRead, this, &AgentControlPlugin::onSocketReady );
-		connect( sock, &QTcpSocket::disconnected, this, &AgentControlPlugin::onSocketClosed );
+		connect( sock, &QTcpSocket::readyRead, this, &AgentControlService::onSocketReady );
+		connect( sock, &QTcpSocket::disconnected, this, &AgentControlService::onSocketClosed );
 		emit logMessage( tr( "Client connected" ) );
 	}
 }
 
-void AgentControlPlugin::onSocketReady()
+void AgentControlService::onSocketReady()
 {
 	auto *sock = qobject_cast<QTcpSocket *>( sender() );
 	if( !sock )
@@ -330,7 +369,7 @@ void AgentControlPlugin::onSocketReady()
 	}
 }
 
-void AgentControlPlugin::onSocketClosed()
+void AgentControlService::onSocketClosed()
 {
 	auto *sock = qobject_cast<QTcpSocket *>( sender() );
 	if( !sock )
@@ -342,7 +381,7 @@ void AgentControlPlugin::onSocketClosed()
 	emit logMessage( tr( "Client disconnected" ) );
 }
 
-bool AgentControlPlugin::newProject( QString& result, QString& error )
+bool AgentControlService::newProject( QString& result, QString& error )
 {
 	Song *song = Engine::getSong();
 	auto *guiApp = gui::getGUI();
@@ -359,7 +398,7 @@ bool AgentControlPlugin::newProject( QString& result, QString& error )
 	return true;
 }
 
-bool AgentControlPlugin::openProject( const QString& path, QString& result, QString& error )
+bool AgentControlService::openProject( const QString& path, QString& result, QString& error )
 {
 	const QString fullPath = canonicalPath( path );
 	if( fullPath.isEmpty() )
@@ -382,7 +421,7 @@ bool AgentControlPlugin::openProject( const QString& path, QString& result, QStr
 	return true;
 }
 
-bool AgentControlPlugin::saveProject( QString& result, QString& error )
+bool AgentControlService::saveProject( QString& result, QString& error )
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -404,7 +443,7 @@ bool AgentControlPlugin::saveProject( QString& result, QString& error )
 	return true;
 }
 
-bool AgentControlPlugin::saveProjectAs( const QString& path, QString& result, QString& error )
+bool AgentControlService::saveProjectAs( const QString& path, QString& result, QString& error )
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -424,7 +463,7 @@ bool AgentControlPlugin::saveProjectAs( const QString& path, QString& result, QS
 	return true;
 }
 
-bool AgentControlPlugin::showWindowCommand( const QString& windowName, QString& result, QString& error )
+bool AgentControlService::showWindowCommand( const QString& windowName, QString& result, QString& error )
 {
 	auto *guiApp = gui::getGUI();
 	if( guiApp == nullptr || guiApp->mainWindow() == nullptr )
@@ -493,7 +532,7 @@ bool AgentControlPlugin::showWindowCommand( const QString& windowName, QString& 
 	return true;
 }
 
-bool AgentControlPlugin::showToolCommand( const QString& toolName, QString& result, QString& error )
+bool AgentControlService::showToolCommand( const QString& toolName, QString& result, QString& error )
 {
 	const QString desired = normalizeName( toolName );
 	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Tool ) )
@@ -532,7 +571,7 @@ bool AgentControlPlugin::showToolCommand( const QString& toolName, QString& resu
 	return false;
 }
 
-bool AgentControlPlugin::createTrack( Track::Type type, QString& result, QString& error )
+bool AgentControlService::createTrack( Track::Type type, QString& result, QString& error )
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -552,7 +591,7 @@ bool AgentControlPlugin::createTrack( Track::Type type, QString& result, QString
 	return true;
 }
 
-bool AgentControlPlugin::createInstrumentTrack( const QString& pluginName, QString& result, QString& error )
+bool AgentControlService::createInstrumentTrack( const QString& pluginName, QString& result, QString& error )
 {
 	Song *song = Engine::getSong();
 	auto *guiApp = gui::getGUI();
@@ -594,12 +633,12 @@ bool AgentControlPlugin::createInstrumentTrack( const QString& pluginName, QStri
 	return true;
 }
 
-bool AgentControlPlugin::importFromDownloads( const QString& fileName, QString& error )
+bool AgentControlService::importFromDownloads( const QString& fileName, QString& error )
 {
 	return importAudioFile( resolveDownloadsFile( fileName ), error );
 }
 
-bool AgentControlPlugin::importAudioFile( const QString& path, QString& error )
+bool AgentControlService::importAudioFile( const QString& path, QString& error )
 {
 	const QString fullPath = canonicalPath( path );
 	if( fullPath.isEmpty() )
@@ -627,7 +666,7 @@ bool AgentControlPlugin::importAudioFile( const QString& path, QString& error )
 	return true;
 }
 
-bool AgentControlPlugin::importProjectFile( const QString& path, QString& error )
+bool AgentControlService::importProjectFile( const QString& path, QString& error )
 {
 	const QString fullPath = canonicalPath( path );
 	if( fullPath.isEmpty() )
@@ -645,7 +684,7 @@ bool AgentControlPlugin::importProjectFile( const QString& path, QString& error 
 	return true;
 }
 
-bool AgentControlPlugin::addKickPattern( QString& error )
+bool AgentControlService::addKickPattern( QString& error )
 {
 	const QString samplePath = defaultKickSample();
 	if( samplePath.isEmpty() )
@@ -670,7 +709,7 @@ bool AgentControlPlugin::addKickPattern( QString& error )
 	return true;
 }
 
-bool AgentControlPlugin::addEffectToTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
+bool AgentControlService::addEffectToTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
 {
 	Track *track = trackName.isEmpty()
 		? findLastTrackOfTypes( { Track::Type::Instrument, Track::Type::Sample } )
@@ -738,7 +777,7 @@ bool AgentControlPlugin::addEffectToTrack( const QString& effectName, const QStr
 	return true;
 }
 
-bool AgentControlPlugin::removeEffectFromTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
+bool AgentControlService::removeEffectFromTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
 {
 	Track *track = trackName.isEmpty()
 		? findLastTrackOfTypes( { Track::Type::Instrument, Track::Type::Sample } )
@@ -775,7 +814,7 @@ bool AgentControlPlugin::removeEffectFromTrack( const QString& effectName, const
 	return false;
 }
 
-Track* AgentControlPlugin::findTrackByName( const QString& trackName ) const
+Track* AgentControlService::findTrackByName( const QString& trackName ) const
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -795,7 +834,7 @@ Track* AgentControlPlugin::findTrackByName( const QString& trackName ) const
 	return nullptr;
 }
 
-Track* AgentControlPlugin::findLastTrackOfTypes( const QList<Track::Type>& types ) const
+Track* AgentControlService::findLastTrackOfTypes( const QList<Track::Type>& types ) const
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -814,12 +853,12 @@ Track* AgentControlPlugin::findLastTrackOfTypes( const QList<Track::Type>& types
 	return nullptr;
 }
 
-InstrumentTrack* AgentControlPlugin::findInstrumentTrack( const QString& trackName ) const
+InstrumentTrack* AgentControlService::findInstrumentTrack( const QString& trackName ) const
 {
 	return dynamic_cast<InstrumentTrack *>( findTrackByName( trackName ) );
 }
 
-SampleTrack* AgentControlPlugin::createSampleTrack( const QString& name ) const
+SampleTrack* AgentControlService::createSampleTrack( const QString& name ) const
 {
 	Song *song = Engine::getSong();
 	if( song == nullptr )
@@ -834,7 +873,7 @@ SampleTrack* AgentControlPlugin::createSampleTrack( const QString& name ) const
 	return track;
 }
 
-EffectChain* AgentControlPlugin::effectChainForTrack( Track* track ) const
+EffectChain* AgentControlService::effectChainForTrack( Track* track ) const
 {
 	if( auto *instrumentTrack = dynamic_cast<InstrumentTrack *>( track ) )
 	{
@@ -847,7 +886,7 @@ EffectChain* AgentControlPlugin::effectChainForTrack( Track* track ) const
 	return nullptr;
 }
 
-bool AgentControlPlugin::addSampleClip( SampleTrack *track, const QString& samplePath, int tickPos )
+bool AgentControlService::addSampleClip( SampleTrack *track, const QString& samplePath, int tickPos )
 {
 	auto *clip = dynamic_cast<SampleClip *>( track->createClip( TimePos( tickPos ) ) );
 	if( clip == nullptr )
@@ -860,7 +899,7 @@ bool AgentControlPlugin::addSampleClip( SampleTrack *track, const QString& sampl
 	return true;
 }
 
-QString AgentControlPlugin::resolveDownloadsFile( const QString& fileName ) const
+QString AgentControlService::resolveDownloadsFile( const QString& fileName ) const
 {
 	if( fileName.isEmpty() )
 	{
@@ -876,14 +915,14 @@ QString AgentControlPlugin::resolveDownloadsFile( const QString& fileName ) cons
 	return QFile::exists( absPath ) ? absPath : QString{};
 }
 
-QString AgentControlPlugin::defaultKickSample() const
+QString AgentControlService::defaultKickSample() const
 {
 	const QString base = ConfigManager::inst()->factorySamplesDir();
 	const QString candidate = QDir( base ).filePath( "drums/bassdrum04.ogg" );
 	return QFile::exists( candidate ) ? candidate : QString{};
 }
 
-QString AgentControlPlugin::canonicalPath( const QString& path ) const
+QString AgentControlService::canonicalPath( const QString& path ) const
 {
 	if( path.isEmpty() )
 	{
@@ -911,12 +950,12 @@ QString AgentControlPlugin::canonicalPath( const QString& path ) const
 	return {};
 }
 
-QString AgentControlPlugin::joinTokens( const QStringList& tokens, int startIndex ) const
+QString AgentControlService::joinTokens( const QStringList& tokens, int startIndex ) const
 {
 	return startIndex < tokens.size() ? tokens.mid( startIndex ).join( " " ).trimmed() : QString{};
 }
 
-QString AgentControlPlugin::normalizeName( const QString& text ) const
+QString AgentControlService::normalizeName( const QString& text ) const
 {
 	QString out;
 	out.reserve( text.size() );

--- a/plugins/AgentControl/AgentControl.cpp
+++ b/plugins/AgentControl/AgentControl.cpp
@@ -1,5 +1,6 @@
 #include "AgentControl.h"
 
+#include <QDateTime>
 #include <QDir>
 #include <QCoreApplication>
 #include <QFile>
@@ -15,6 +16,7 @@
 #include <QProcess>
 #include <QRegularExpressionMatch>
 #include <QMetaObject>
+#include <QPointer>
 #include <QRegularExpression>
 #include <QStandardPaths>
 #include <QThread>
@@ -55,6 +57,240 @@
 
 namespace lmms
 {
+
+namespace
+{
+
+struct IntentProfile
+{
+	QString intent;
+	QString risk;
+	QString capabilityKey;
+	QStringList aliases;
+};
+
+QString normalizeManifestToken( const QString& value )
+{
+	QString normalized = value.toLower();
+	normalized.replace( QRegularExpression( R"([^a-z0-9])" ), QString() );
+	return normalized;
+}
+
+QList<IntentProfile> defaultIntentProfiles()
+{
+	return
+	{
+		{ QStringLiteral( "project.new" ), QStringLiteral( "confirm" ), QStringLiteral( "PROJECT_NEW" ), { QStringLiteral( "newproject" ) } },
+		{ QStringLiteral( "project.open" ), QStringLiteral( "confirm" ), QStringLiteral( "PROJECT_OPEN" ), { QStringLiteral( "openproject" ) } },
+		{ QStringLiteral( "project.save" ), QStringLiteral( "safe" ), QStringLiteral( "PROJECT_SAVE" ), { QStringLiteral( "saveproject" ), QStringLiteral( "saveprojectas" ) } },
+		{ QStringLiteral( "project.export" ), QStringLiteral( "confirm" ), QStringLiteral( "PROJECT_EXPORT" ), { QStringLiteral( "exportsong" ), QStringLiteral( "rendersong" ), QStringLiteral( "exporttracks" ) } },
+		{ QStringLiteral( "window.open" ), QStringLiteral( "safe" ), QStringLiteral( "WINDOW_OPEN" ), { QStringLiteral( "opensongeditor" ), QStringLiteral( "openpianoroll" ), QStringLiteral( "openautomationeditor" ), QStringLiteral( "openmixer" ), QStringLiteral( "showwindow" ) } },
+		{ QStringLiteral( "track.create" ), QStringLiteral( "safe" ), QStringLiteral( "TRACK_CREATE" ), { QStringLiteral( "createsampletrack" ), QStringLiteral( "createinstrumenttrack" ), QStringLiteral( "createautomationtrack" ), QStringLiteral( "createpatterntrack" ) } },
+		{ QStringLiteral( "track.state" ), QStringLiteral( "safe" ), QStringLiteral( "TRACK_STATE" ), { QStringLiteral( "mutetrack" ), QStringLiteral( "solotrack" ), QStringLiteral( "unmutetrack" ), QStringLiteral( "unsolotrack" ) } },
+		{ QStringLiteral( "slicer.open" ), QStringLiteral( "safe" ), QStringLiteral( "SLICER_OPEN" ), { QStringLiteral( "openslicer" ), QStringLiteral( "showslicer" ) } },
+		{ QStringLiteral( "slicer.import" ), QStringLiteral( "safe" ), QStringLiteral( "SLICER_IMPORT" ), { QStringLiteral( "intoslicer" ), QStringLiteral( "loadslicer" ) } },
+		{ QStringLiteral( "slicer.split.equal" ), QStringLiteral( "safe" ), QStringLiteral( "SLICER_SPLIT_EQUAL" ), { QStringLiteral( "equalsegments" ), QStringLiteral( "equalslices" ), QStringLiteral( "splitinto" ) } },
+		{ QStringLiteral( "slicer.split.transient" ), QStringLiteral( "safe" ), QStringLiteral( "SLICER_SPLIT_TRANSIENT" ), { QStringLiteral( "transientsegments" ), QStringLiteral( "transientslices" ) } },
+		{ QStringLiteral( "transport.play" ), QStringLiteral( "safe" ), QStringLiteral( "TRANSPORT_PLAY" ), { QStringLiteral( "play" ), QStringLiteral( "startplayback" ), QStringLiteral( "resumeplayback" ) } },
+		{ QStringLiteral( "transport.pause" ), QStringLiteral( "safe" ), QStringLiteral( "TRANSPORT_PAUSE" ), { QStringLiteral( "pause" ), QStringLiteral( "pauseplayback" ) } },
+		{ QStringLiteral( "transport.stop" ), QStringLiteral( "safe" ), QStringLiteral( "TRANSPORT_STOP" ), { QStringLiteral( "stop" ), QStringLiteral( "stopplayback" ) } },
+		{ QStringLiteral( "tempo.set" ), QStringLiteral( "safe" ), QStringLiteral( "TEMPO_SET" ), { QStringLiteral( "settempo" ), QStringLiteral( "bpm" ), QStringLiteral( "raisetempo" ), QStringLiteral( "lowertempo" ) } },
+		{ QStringLiteral( "pattern.rhythm" ), QStringLiteral( "safe" ), QStringLiteral( "PATTERN_RHYTHM" ), { QStringLiteral( "addkick" ), QStringLiteral( "addsnare" ), QStringLiteral( "add808" ), QStringLiteral( "addhihat" ), QStringLiteral( "addhats" ), QStringLiteral( "addcrash" ), QStringLiteral( "addride" ), QStringLiteral( "addcymbal" ) } },
+		{ QStringLiteral( "instrument.load" ), QStringLiteral( "safe" ), QStringLiteral( "INSTRUMENT_LOAD" ), { QStringLiteral( "loadinstrument" ), QStringLiteral( "newinstrument" ), QStringLiteral( "addpiano" ) } },
+		{ QStringLiteral( "mixer.effect.add" ), QStringLiteral( "safe" ), QStringLiteral( "MIXER_EFFECT_ADD" ), { QStringLiteral( "addeffect" ) } },
+		{ QStringLiteral( "mixer.effect.remove" ), QStringLiteral( "confirm" ), QStringLiteral( "MIXER_EFFECT_REMOVE" ), { QStringLiteral( "removeeffect" ) } },
+		{ QStringLiteral( "undo" ), QStringLiteral( "confirm" ), QStringLiteral( "UNDO" ), { QStringLiteral( "undo" ) } }
+	};
+}
+
+bool loadIntentProfilesFromManifest( const QString& manifestPath, QList<IntentProfile>& profiles, QString& error )
+{
+	QFile file( manifestPath );
+	if( !file.open( QIODevice::ReadOnly ) )
+	{
+		error = QObject::tr( "could not open %1" ).arg( manifestPath );
+		return false;
+	}
+
+	QJsonParseError parseError{};
+	const QJsonDocument doc = QJsonDocument::fromJson( file.readAll(), &parseError );
+	if( parseError.error != QJsonParseError::NoError || !doc.isObject() )
+	{
+		error = QObject::tr( "invalid JSON (%1)" ).arg( parseError.errorString() );
+		return false;
+	}
+
+	const QJsonArray intents = doc.object().value( QStringLiteral( "intents" ) ).toArray();
+	if( intents.isEmpty() )
+	{
+		error = QObject::tr( "missing intents array" );
+		return false;
+	}
+
+	QList<IntentProfile> loaded;
+	for( const QJsonValue& value : intents )
+	{
+		if( !value.isObject() )
+		{
+			continue;
+		}
+		const QJsonObject obj = value.toObject();
+		const QString intent = obj.value( QStringLiteral( "intent" ) ).toString().trimmed();
+		if( intent.isEmpty() )
+		{
+			continue;
+		}
+
+		QString risk = obj.value( QStringLiteral( "risk_level" ) ).toString().trimmed().toLower();
+		if( risk != QStringLiteral( "confirm" ) )
+		{
+			risk = QStringLiteral( "safe" );
+		}
+		const QString capability = obj.value( QStringLiteral( "capability_flag" ) ).toString().trimmed();
+		QStringList aliases;
+		for( const QJsonValue& alias : obj.value( QStringLiteral( "aliases" ) ).toArray() )
+		{
+			const QString normalizedAlias = normalizeManifestToken( alias.toString() );
+			if( !normalizedAlias.isEmpty() )
+			{
+				aliases << normalizedAlias;
+			}
+		}
+		aliases.removeDuplicates();
+		loaded.push_back( IntentProfile{ intent, risk, capability, aliases } );
+	}
+
+	if( loaded.isEmpty() )
+	{
+		error = QObject::tr( "no valid intent entries found" );
+		return false;
+	}
+	profiles = loaded;
+	return true;
+}
+
+bool validateLlmInterpretationObject( const QJsonObject& obj, QString& error )
+{
+	const auto hasType = [&obj]( const QString& key, QJsonValue::Type type )
+	{
+		return obj.contains( key ) && obj.value( key ).type() == type;
+	};
+
+	if( !hasType( QStringLiteral( "familiar" ), QJsonValue::Bool ) )
+	{
+		error = QObject::tr( "missing familiar bool" );
+		return false;
+	}
+	if( !obj.value( QStringLiteral( "familiar" ) ).toBool( false ) )
+	{
+		error = QObject::tr( "Ollama marked command as unfamiliar" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "intent" ), QJsonValue::String ) )
+	{
+		error = QObject::tr( "missing intent string" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "command" ), QJsonValue::String ) )
+	{
+		error = QObject::tr( "missing command string" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "arguments" ), QJsonValue::Object ) )
+	{
+		error = QObject::tr( "missing arguments object" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "confidence" ), QJsonValue::Double ) )
+	{
+		error = QObject::tr( "missing confidence number" );
+		return false;
+	}
+	const double confidence = obj.value( QStringLiteral( "confidence" ) ).toDouble( -1.0 );
+	if( confidence < 0.0 || confidence > 1.0 )
+	{
+		error = QObject::tr( "confidence out of range" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "risk_level" ), QJsonValue::String ) )
+	{
+		error = QObject::tr( "missing risk_level string" );
+		return false;
+	}
+	const QString risk = obj.value( QStringLiteral( "risk_level" ) ).toString().trimmed().toLower();
+	if( risk != QStringLiteral( "safe" ) && risk != QStringLiteral( "confirm" ) )
+	{
+		error = QObject::tr( "invalid risk_level value" );
+		return false;
+	}
+	if( !hasType( QStringLiteral( "reason" ), QJsonValue::String ) )
+	{
+		error = QObject::tr( "missing reason string" );
+		return false;
+	}
+	return true;
+}
+
+const QList<IntentProfile>& intentProfiles()
+{
+	static QList<IntentProfile> kProfiles;
+	static bool initialized = false;
+	if( initialized )
+	{
+		return kProfiles;
+	}
+
+	initialized = true;
+	kProfiles = defaultIntentProfiles();
+
+	QString manifestPath = qEnvironmentVariable( "LMMS_COMMAND_MANIFEST" ).trimmed();
+	if( manifestPath.isEmpty() )
+	{
+		const QString localRelative = QStringLiteral( "lmmsagent/integrations/lmms/AgentControl/command_manifest.v2.json" );
+		const QString cwdRelative = QDir::current().absoluteFilePath( localRelative );
+		if( QFileInfo::exists( cwdRelative ) )
+		{
+			manifestPath = cwdRelative;
+		}
+	}
+
+	if( !manifestPath.isEmpty() )
+	{
+		QString manifestError;
+		QList<IntentProfile> loadedProfiles;
+		if( loadIntentProfilesFromManifest( manifestPath, loadedProfiles, manifestError ) )
+		{
+			kProfiles = loadedProfiles;
+		}
+		else
+		{
+			qWarning() << "AgentControl: failed to load command manifest" << manifestPath << ":" << manifestError;
+		}
+	}
+
+	return kProfiles;
+}
+
+QString capabilityEnvForIntent( const QString& intent )
+{
+	for( const auto& profile : intentProfiles() )
+	{
+		if( intent == profile.intent )
+		{
+			if( !profile.capabilityKey.trimmed().isEmpty() )
+			{
+				return QStringLiteral( "LMMS_CAP_" ) + profile.capabilityKey;
+			}
+			break;
+		}
+	}
+
+	QString normalized = intent.toUpper();
+	normalized.replace( QRegularExpression( R"([^A-Z0-9]+)" ), QStringLiteral( "_" ) );
+	return QStringLiteral( "LMMS_CAP_" ) + normalized;
+}
+
+} // namespace
 
 extern "C"
 {
@@ -172,67 +408,239 @@ QString AgentControlService::handleCommand( const QString& rawText )
 		return tr( "No command provided" );
 	}
 
-	const QString directResult = dispatchCommandText( trimmed );
-	if( !isUnknownResponse( directResult ) )
+	const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+	if( !m_pendingConfirmationCommand.isEmpty() )
 	{
-		return directResult;
+		if( nowMs > m_pendingConfirmationExpiresMs )
+		{
+			emitTrace( "confirm_expired", QJsonObject
+			{
+				{ "intent", m_pendingConfirmationIntent },
+				{ "command", m_pendingConfirmationCommand }
+			} );
+			m_pendingConfirmationCommand.clear();
+			m_pendingConfirmationIntent.clear();
+			m_pendingConfirmationExpiresMs = 0;
+		}
+		else
+		{
+			const QString normalized = normalizeName( trimmed );
+			if( isConfirmationUtterance( trimmed ) )
+			{
+				const QString command = m_pendingConfirmationCommand;
+				const QString intent = m_pendingConfirmationIntent;
+				m_pendingConfirmationCommand.clear();
+				m_pendingConfirmationIntent.clear();
+				m_pendingConfirmationExpiresMs = 0;
+				const QString confirmedResult = dispatchCommandText( command );
+				emitTrace( "confirm_executed", QJsonObject
+				{
+					{ "intent", intent },
+					{ "command", command },
+					{ "result", confirmedResult }
+				} );
+				return tr( "Confirmed \"%1\". %2" ).arg( command, confirmedResult );
+			}
+			if( normalized == "no" || normalized == "cancel" || normalized == "stop" )
+			{
+				m_pendingConfirmationCommand.clear();
+				m_pendingConfirmationIntent.clear();
+				m_pendingConfirmationExpiresMs = 0;
+				emitTrace( "confirm_cancelled" );
+				return tr( "Cancelled pending command." );
+			}
+			if( !isFamiliarIntentText( trimmed ) )
+			{
+				return tr( "Awaiting confirmation. Say \"yes\" to run \"%1\" or \"cancel\"." )
+					.arg( m_pendingConfirmationCommand );
+			}
+
+			// Override pending confirmation when a new command intent arrives.
+			m_pendingConfirmationCommand.clear();
+			m_pendingConfirmationIntent.clear();
+			m_pendingConfirmationExpiresMs = 0;
+		}
 	}
 
-	const bool familiarRawIntent = isFamiliarIntentText( trimmed );
+	// Multi-step chaining for direct text/socket commands.
+	// Voice mode already performs chain splitting before dispatch, but this keeps
+	// the same behavior available across all command entry points.
+	QStringList chainedSegments;
+	{
+		QString chain = trimmed;
+		chain.replace(
+			QRegularExpression( R"(\b(?:and then|then|after that|next)\b)", QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "|" ) );
+		chain.replace(
+			QRegularExpression(
+				R"(\band\s+(?=(?:open|show|new|create|make|import|load|set|add|remove|mute|solo|undo|divide|split|slice|raise|lower|increase|decrease|save|export|play|pause|stop)\b))",
+				QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "|" ) );
+		chain.replace( QRegularExpression( R"([,;])" ), QStringLiteral( "|" ) );
+		chainedSegments = chain.split( '|', Qt::SkipEmptyParts );
+	}
+	if( chainedSegments.size() > 1 )
+	{
+		QStringList stepResults;
+		stepResults.reserve( chainedSegments.size() );
+		for( const QString& segment : chainedSegments )
+		{
+			const QString step = segment.trimmed();
+			if( step.isEmpty() )
+			{
+				continue;
+			}
+			stepResults << handleCommand( step );
+		}
+		if( !stepResults.isEmpty() )
+		{
+			return stepResults.join( QStringLiteral( ". " ) );
+		}
+	}
 
+	struct Candidate
+	{
+		QString command;
+		QString intent;
+		QString source;
+		QString reason;
+		QString risk;
+		double confidence = 0.0;
+		bool viable = false;
+		bool exact = false;
+	};
+
+	const bool familiarRawIntent = isFamiliarIntentText( trimmed );
+	Candidate directCandidate;
+	directCandidate.command = trimmed;
+	directCandidate.intent = inferIntentForCommand( trimmed );
+	directCandidate.source = QStringLiteral( "deterministic" );
+	directCandidate.confidence = 0.96;
+	directCandidate.exact = true;
+	directCandidate.viable = familiarRawIntent;
+
+	Candidate mappedCandidate;
 	QString mappedCommand;
 	QString mapReason;
 	if( applyHeuristicMappings( trimmed, mappedCommand, mapReason ) &&
 		!mappedCommand.isEmpty() &&
 		normalizeName( mappedCommand ) != normalizeName( trimmed ) )
 	{
-		const bool familiarMappedIntent = isFamiliarIntentText( mappedCommand );
-		if( familiarRawIntent || familiarMappedIntent )
+		mappedCandidate.command = mappedCommand;
+		mappedCandidate.source = QStringLiteral( "heuristic" );
+		mappedCandidate.reason = mapReason;
+		mappedCandidate.intent = inferIntentForCommand( mappedCommand );
+		mappedCandidate.confidence = 0.80;
+		mappedCandidate.viable = isFamiliarIntentText( mappedCommand );
+		if( mappedCandidate.viable )
 		{
-			const QString mappedResult = dispatchCommandText( mappedCommand );
-			if( !isUnknownResponse( mappedResult ) )
-			{
-				const QString reasonSuffix = mapReason.isEmpty() ? QString() : tr( " (%1)" ).arg( mapReason );
-				return tr( "Interpreted as \"%1\"%2. %3" )
-					.arg( mappedCommand, reasonSuffix, mappedResult );
-			}
+			// If heuristics found a cleaner deterministic command, prefer it over raw text.
+			directCandidate.viable = false;
+			directCandidate.exact = false;
 		}
 	}
 
-	// Hard safety gate: do not run LLM/planner fallbacks for unrelated speech.
-	if( !familiarRawIntent )
-	{
-		return directResult;
-	}
-
+	Candidate llmCandidate;
 	const QString ollamaModel = qEnvironmentVariable( "LMMS_OLLAMA_MODEL" ).trimmed();
 	if( !ollamaModel.isEmpty() )
 	{
-		double confidence = 0.0;
 		QString ollamaError;
-		QString ollamaCommand;
-		if( resolveWithOllama( trimmed, ollamaCommand, confidence, ollamaError ) )
+		QJsonObject llmArgs;
+		if( resolveWithOllama(
+			trimmed,
+			llmCandidate.command,
+			llmCandidate.intent,
+			llmArgs,
+			llmCandidate.risk,
+			llmCandidate.confidence,
+			llmCandidate.reason,
+			ollamaError ) )
 		{
-			const bool familiar = isFamiliarIntentText( ollamaCommand );
-			const double threshold = qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).toDouble() > 0.0
-				? qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).toDouble()
-				: 0.78;
-			if( familiar && confidence >= threshold )
+			llmCandidate.source = QStringLiteral( "llm" );
+			if( llmCandidate.intent.isEmpty() )
 			{
-				const QString ollamaResult = dispatchCommandText( ollamaCommand );
-				if( !isUnknownResponse( ollamaResult ) )
-				{
-					return tr( "Interpreted as \"%1\" (confidence %2). %3" )
-						.arg( ollamaCommand )
-						.arg( QString::number( confidence, 'f', 2 ) )
-						.arg( ollamaResult );
-				}
+				llmCandidate.intent = inferIntentForCommand( llmCandidate.command );
 			}
+			const double llmConfidenceFloor = qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).trimmed().toDouble() > 0.0
+				? qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).trimmed().toDouble()
+				: 0.72;
+			llmCandidate.viable = isFamiliarIntentText( llmCandidate.command ) &&
+				llmCandidate.confidence >= llmConfidenceFloor;
 		}
 		else if( !ollamaError.isEmpty() )
 		{
-			emit logMessage( tr( "Ollama fallback skipped: %1" ).arg( ollamaError ) );
+			emit logMessage( tr( "Ollama parse skipped: %1" ).arg( ollamaError ) );
 		}
+	}
+
+	emitTrace( "candidate_summary", QJsonObject
+	{
+		{ "input", trimmed },
+		{ "familiar_raw", familiarRawIntent },
+		{ "direct_ok", directCandidate.viable },
+		{ "mapped_ok", mappedCandidate.viable },
+		{ "llm_ok", llmCandidate.viable },
+		{ "llm_confidence", llmCandidate.confidence }
+	} );
+
+	Candidate chosen;
+	bool hasChosen = false;
+	if( directCandidate.viable )
+	{
+		// Exact deterministic match wins unless it is disabled by capability policy.
+		chosen = directCandidate;
+		hasChosen = true;
+	}
+	else if( mappedCandidate.viable )
+	{
+		chosen = mappedCandidate;
+		hasChosen = true;
+	}
+
+	if( llmCandidate.viable )
+	{
+		const double arbitrationMargin = qEnvironmentVariable( "LMMS_HYBRID_MARGIN" ).trimmed().toDouble() > 0.0
+			? qEnvironmentVariable( "LMMS_HYBRID_MARGIN" ).trimmed().toDouble()
+			: 0.12;
+		if( !hasChosen )
+		{
+			chosen = llmCandidate;
+			hasChosen = true;
+		}
+		else if( !chosen.exact &&
+			llmCandidate.confidence >= chosen.confidence + arbitrationMargin &&
+			!llmCandidate.reason.trimmed().isEmpty() )
+		{
+			chosen = llmCandidate;
+			hasChosen = true;
+		}
+	}
+
+	if( hasChosen )
+	{
+		const QString execution = executeWithSafetyGate(
+			chosen.command,
+			chosen.source,
+			chosen.confidence,
+			chosen.reason,
+			chosen.risk );
+		if( !isUnknownResponse( execution ) )
+		{
+			return execution;
+		}
+		emitTrace( "candidate_failed_dispatch", QJsonObject
+		{
+			{ "input", trimmed },
+			{ "chosen_source", chosen.source },
+			{ "chosen_command", chosen.command },
+			{ "result", execution }
+		} );
+	}
+
+	// Hard safety gate: do not run planner fallbacks for unrelated speech.
+	if( !familiarRawIntent )
+	{
+		return dispatchCommandText( trimmed );
 	}
 
 	QString plannerResult;
@@ -246,7 +654,7 @@ QString AgentControlService::handleCommand( const QString& rawText )
 		emit logMessage( tr( "Text-agent fallback skipped: %1" ).arg( plannerError ) );
 	}
 
-	return directResult;
+	return dispatchCommandText( trimmed );
 }
 
 QString AgentControlService::dispatchCommandText( const QString& rawText )
@@ -298,7 +706,7 @@ bool AgentControlService::isFamiliarIntentText( const QString& rawText ) const
 
 	const QSet<QString> simpleCommands =
 	{
-		"undo", "version", "help"
+		"undo", "version", "help", "play", "pause", "stop"
 	};
 	if( simpleCommands.contains( normalizeName( tokens.first() ) ) )
 	{
@@ -309,13 +717,15 @@ bool AgentControlService::isFamiliarIntentText( const QString& rawText ) const
 	{
 		"open", "show", "new", "create", "make", "import", "load", "set", "add", "remove",
 		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide",
-		"split", "slice", "raise", "lower", "increase", "decrease", "save", "list"
+		"split", "slice", "raise", "lower", "increase", "decrease", "save", "list",
+		"play", "pause", "stop", "resume", "start"
 	};
 	const QSet<QString> domainKeywords =
 	{
 		"project", "track", "instrument", "sample", "automation", "pattern", "mixer",
 		"piano", "roll", "editor", "song", "slicer", "splicer", "segment", "transient",
-		"slice", "effect", "plugin", "window", "tool", "file", "downloads"
+		"slice", "effect", "plugin", "window", "tool", "file", "downloads",
+		"hihat", "hat", "hats", "crash", "ride", "cymbal", "arpeggiator", "lane"
 	};
 
 	bool hasAction = false;
@@ -341,7 +751,9 @@ bool AgentControlService::isFamiliarIntentText( const QString& rawText ) const
 	{
 		"open", "show", "new", "create", "make", "import", "load", "set", "add", "remove",
 		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide",
-		"split", "slice", "openslicer", "showslicer", "manualmap", "beginnerhelp"
+		"split", "slice", "openslicer", "showslicer", "manualmap", "beginnerhelp",
+		"play", "pause", "stop", "resume", "startplayback", "stopplayback",
+		"hihat", "crash", "ride", "cymbal", "arpeggiator", "lane"
 	};
 
 	for( const QString& keyword : keywords )
@@ -379,7 +791,7 @@ bool AgentControlService::applyHeuristicMappings(
 	// Remove polite wrappers so command verbs are easier to parse.
 	bool removedConversationFiller = false;
 	const QRegularExpression leadingFiller(
-		R"(^(?:(?:hey|hi|yo|okay|ok|please|pls)\s+)*(?:(?:can|could|would)\s+(?:you|u)\s+)?(?:please|pls\s+)?(?:just\s+)?(?:hey\s+)?(?:can|could|would)?\s*(?:you|u)?\s*)",
+		R"(^(?:(?:hey|hi|yo|okay|ok|please|pls)\s+)*(?:(?:can|could|would)\s+(?:you|u)\s+)?(?:please|pls\s+)?(?:just\s+)?(?:hey\s+)?(?:can|could|would)?\s*(?:\b(?:you|u)\b\s*)?)",
 		QRegularExpression::CaseInsensitiveOption );
 	for( int i = 0; i < 2; ++i )
 	{
@@ -513,6 +925,12 @@ bool AgentControlService::applyHeuristicMappings(
 		}
 	}
 
+	if( collapsed.contains( "arpeggiator" ) && collapsed.contains( "lane" ) )
+	{
+		mappedCommand = QStringLiteral( "create arpeggiator lane" );
+		setReasonIfEmpty( tr( "normalized arpeggiator lane phrasing" ) );
+	}
+
 	// "lets go 128 bpm" -> "set tempo to 128"
 	const QRegularExpression bpmPhrase( R"(\b(\d{2,3})\s*bpm\b)", QRegularExpression::CaseInsensitiveOption );
 	const auto bpmMatch = bpmPhrase.match( mappedCommand );
@@ -520,6 +938,26 @@ bool AgentControlService::applyHeuristicMappings(
 	{
 		mappedCommand = tr( "set tempo to %1" ).arg( bpmMatch.captured( 1 ) );
 		setReasonIfEmpty( tr( "inferred tempo set intent" ) );
+	}
+
+	// Normalize common transport phrasing.
+	if( QRegularExpression( R"(\b(start|resume)\s+(playback|song)\b)",
+			QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand = QStringLiteral( "play" );
+		setReasonIfEmpty( tr( "normalized transport command" ) );
+	}
+	else if( QRegularExpression( R"(\bpause\s+(playback|song)\b)",
+		QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand = QStringLiteral( "pause" );
+		setReasonIfEmpty( tr( "normalized transport command" ) );
+	}
+	else if( QRegularExpression( R"(\bstop\s+(playback|song)\b)",
+		QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand = QStringLiteral( "stop" );
+		setReasonIfEmpty( tr( "normalized transport command" ) );
 	}
 
 	// "divide into 16 segments" -> "divide into 16 equal segments"
@@ -546,7 +984,9 @@ bool AgentControlService::applyHeuristicMappings(
 		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide", "split",
 		"slice", "slicer", "track", "instrument", "sample", "automation", "pattern",
 		"mixer", "project", "downloads", "equal", "segments", "transient",
-		"song", "editor", "piano", "roll", "window"
+		"hihat", "hat", "hats", "crash", "ride", "cymbal", "arpeggiator", "lane",
+		"song", "editor", "piano", "roll", "window", "play", "pause", "stop",
+		"start", "resume", "playback"
 	};
 	auto editDistance = []( const QString& a, const QString& b )
 	{
@@ -673,11 +1113,19 @@ bool AgentControlService::applyHeuristicMappings(
 bool AgentControlService::resolveWithOllama(
 	const QString& rawText,
 	QString& mappedCommand,
+	QString& intent,
+	QJsonObject& arguments,
+	QString& riskLevel,
 	double& confidence,
+	QString& reason,
 	QString& error ) const
 {
 	mappedCommand.clear();
+	intent.clear();
+	arguments = QJsonObject();
+	riskLevel.clear();
 	confidence = 0.0;
+	reason.clear();
 	error.clear();
 
 	const QString model = qEnvironmentVariable( "LMMS_OLLAMA_MODEL" ).trimmed();
@@ -693,10 +1141,12 @@ bool AgentControlService::resolveWithOllama(
 
 	const QString systemPrompt =
 		QStringLiteral(
-			"You map noisy LMMS voice commands to the closest valid command. "
-			"Only map if familiar with these command families: open/show/new/create/import/load/set/add/remove/mute/solo/undo/tempo/slicer. "
-			"Return JSON only: {\"familiar\":true|false,\"command\":\"...\",\"confidence\":0.0-1.0}. "
-			"If unclear or unrelated, return familiar=false, empty command, low confidence." );
+			"You map noisy LMMS voice commands to the closest executable LMMS command. "
+			"Use these command families: open/show/new/create/import/load/set/add/remove/mute/solo/undo/tempo/slicer/save/export. "
+			"Return JSON only with this schema: "
+			"{\"familiar\":bool,\"intent\":string,\"command\":string,\"arguments\":object,"
+			"\"confidence\":number,\"risk_level\":\"safe|confirm\",\"reason\":string}. "
+			"If unclear or unrelated, return familiar=false with low confidence and empty command." );
 
 	const QJsonObject payload
 	{
@@ -717,7 +1167,10 @@ bool AgentControlService::resolveWithOllama(
 	QNetworkReply *reply = manager.post( request, QJsonDocument( payload ).toJson( QJsonDocument::Compact ) );
 	QEventLoop loop;
 	QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
-	QTimer::singleShot( 2500, &loop, &QEventLoop::quit );
+	const int timeoutMs = qEnvironmentVariableIntValue( "LMMS_OLLAMA_TIMEOUT_MS" ) > 0
+		? qEnvironmentVariableIntValue( "LMMS_OLLAMA_TIMEOUT_MS" )
+		: 2500;
+	QTimer::singleShot( qMax( 800, timeoutMs ), &loop, &QEventLoop::quit );
 	loop.exec();
 
 	if( reply->isRunning() )
@@ -769,18 +1222,25 @@ bool AgentControlService::resolveWithOllama(
 	}
 
 	const QJsonObject mappedObj = mappedDoc.object();
-	if( !mappedObj.value( "familiar" ).toBool( false ) )
+	if( !validateLlmInterpretationObject( mappedObj, error ) )
 	{
-		error = tr( "Ollama marked command as unfamiliar" );
 		return false;
 	}
 
 	mappedCommand = mappedObj.value( "command" ).toString().trimmed();
+	intent = mappedObj.value( "intent" ).toString().trimmed();
+	arguments = mappedObj.value( "arguments" ).toObject();
 	confidence = mappedObj.value( "confidence" ).toDouble( 0.0 );
+	riskLevel = mappedObj.value( "risk_level" ).toString().trimmed().toLower();
+	reason = mappedObj.value( "reason" ).toString().trimmed();
 	if( mappedCommand.isEmpty() )
 	{
 		error = tr( "Ollama returned an empty command" );
 		return false;
+	}
+	if( riskLevel != QStringLiteral( "safe" ) && riskLevel != QStringLiteral( "confirm" ) )
+	{
+		riskLevel = QStringLiteral( "safe" );
 	}
 	return true;
 }
@@ -882,6 +1342,311 @@ bool AgentControlService::maybeRunTextAgentFallback(
 
 	result = tr( "Planner interpreted as \"%1\". %2" ).arg( mappedCommand, mappedResult );
 	return true;
+}
+
+QString AgentControlService::inferIntentForCommand( const QString& commandText ) const
+{
+	const QString normalized = normalizeName( commandText );
+	if( normalized.isEmpty() )
+	{
+		return {};
+	}
+
+	if( normalized == QStringLiteral( "undo" ) )
+	{
+		return QStringLiteral( "undo" );
+	}
+	if( normalized.contains( QStringLiteral( "openslicer" ) ) || normalized == QStringLiteral( "slicer" ) )
+	{
+		return QStringLiteral( "slicer.open" );
+	}
+	if( normalized.contains( QStringLiteral( "intoslicer" ) ) ||
+		( normalized.contains( QStringLiteral( "import" ) ) && normalized.contains( QStringLiteral( "slicer" ) ) ) )
+	{
+		return QStringLiteral( "slicer.import" );
+	}
+	if( normalized.contains( QStringLiteral( "transient" ) ) &&
+		( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) )
+	{
+		return QStringLiteral( "slicer.split.transient" );
+	}
+	if( ( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) &&
+		normalized.contains( QStringLiteral( "segment" ) ) )
+	{
+		return QStringLiteral( "slicer.split.equal" );
+	}
+	if( normalized.startsWith( QStringLiteral( "newproject" ) ) )
+	{
+		return QStringLiteral( "project.new" );
+	}
+	if( normalized.startsWith( QStringLiteral( "openproject" ) ) )
+	{
+		return QStringLiteral( "project.open" );
+	}
+	if( normalized.startsWith( QStringLiteral( "saveproject" ) ) )
+	{
+		return QStringLiteral( "project.save" );
+	}
+	if( normalized.contains( QStringLiteral( "exportsong" ) ) ||
+		normalized.contains( QStringLiteral( "rendersong" ) ) ||
+		normalized.contains( QStringLiteral( "exporttracks" ) ) )
+	{
+		return QStringLiteral( "project.export" );
+	}
+	if( ( normalized.startsWith( QStringLiteral( "open" ) ) || normalized.startsWith( QStringLiteral( "show" ) ) ) &&
+		( normalized.contains( QStringLiteral( "editor" ) ) || normalized.contains( QStringLiteral( "mixer" ) ) ||
+		  normalized.contains( QStringLiteral( "rack" ) ) || normalized.contains( QStringLiteral( "notes" ) ) ) )
+	{
+		return QStringLiteral( "window.open" );
+	}
+	if( normalized.contains( QStringLiteral( "create" ) ) && normalized.contains( QStringLiteral( "track" ) ) )
+	{
+		return QStringLiteral( "track.create" );
+	}
+	if( normalized.startsWith( QStringLiteral( "mute" ) ) ||
+		normalized.startsWith( QStringLiteral( "unmute" ) ) ||
+		normalized.startsWith( QStringLiteral( "solo" ) ) ||
+		normalized.startsWith( QStringLiteral( "unsolo" ) ) )
+	{
+		return QStringLiteral( "track.state" );
+	}
+	if( normalized.contains( QStringLiteral( "settempo" ) ) ||
+		normalized.contains( QStringLiteral( "bpm" ) ) ||
+		normalized.contains( QStringLiteral( "raisetempo" ) ) ||
+		normalized.contains( QStringLiteral( "lowertempo" ) ) )
+	{
+		return QStringLiteral( "tempo.set" );
+	}
+	if( normalized == QStringLiteral( "play" ) || normalized.contains( QStringLiteral( "startplayback" ) ) ||
+		normalized.contains( QStringLiteral( "resumeplayback" ) ) )
+	{
+		return QStringLiteral( "transport.play" );
+	}
+	if( normalized == QStringLiteral( "pause" ) || normalized.contains( QStringLiteral( "pauseplayback" ) ) )
+	{
+		return QStringLiteral( "transport.pause" );
+	}
+	if( normalized == QStringLiteral( "stop" ) || normalized.contains( QStringLiteral( "stopplayback" ) ) )
+	{
+		return QStringLiteral( "transport.stop" );
+	}
+	if( normalized.contains( QStringLiteral( "addkick" ) ) ||
+		normalized.contains( QStringLiteral( "addsnare" ) ) ||
+		normalized.contains( QStringLiteral( "add808" ) ) ||
+		normalized.contains( QStringLiteral( "addhihat" ) ) ||
+		normalized.contains( QStringLiteral( "addhats" ) ) ||
+		normalized.contains( QStringLiteral( "addcrash" ) ) ||
+		normalized.contains( QStringLiteral( "addride" ) ) ||
+		normalized.contains( QStringLiteral( "addcymbal" ) ) )
+	{
+		return QStringLiteral( "pattern.rhythm" );
+	}
+	if( normalized.contains( QStringLiteral( "arpeggiator" ) ) &&
+		normalized.contains( QStringLiteral( "lane" ) ) )
+	{
+		return QStringLiteral( "track.create" );
+	}
+	if( normalized.contains( QStringLiteral( "loadinstrument" ) ) ||
+		normalized.contains( QStringLiteral( "newinstrument" ) ) ||
+		normalized.contains( QStringLiteral( "addpiano" ) ) )
+	{
+		return QStringLiteral( "instrument.load" );
+	}
+	if( normalized.startsWith( QStringLiteral( "addeffect" ) ) )
+	{
+		return QStringLiteral( "mixer.effect.add" );
+	}
+	if( normalized.startsWith( QStringLiteral( "removeeffect" ) ) )
+	{
+		return QStringLiteral( "mixer.effect.remove" );
+	}
+
+	for( const auto& profile : intentProfiles() )
+	{
+		for( const QString& alias : profile.aliases )
+		{
+			if( normalized.contains( alias ) )
+			{
+				return profile.intent;
+			}
+		}
+	}
+
+	return {};
+}
+
+QString AgentControlService::normalizedRiskForIntent( const QString& intent ) const
+{
+	for( const auto& profile : intentProfiles() )
+	{
+		if( intent == profile.intent )
+		{
+			return profile.risk;
+		}
+	}
+	return QStringLiteral( "safe" );
+}
+
+bool AgentControlService::isIntentEnabled( const QString& intent ) const
+{
+	if( intent.trimmed().isEmpty() )
+	{
+		return true;
+	}
+	const QString envName = capabilityEnvForIntent( intent );
+	const QString raw = qEnvironmentVariable( envName.toUtf8().constData() ).trimmed().toLower();
+	if( raw.isEmpty() )
+	{
+		return true;
+	}
+	return !( raw == QStringLiteral( "0" ) ||
+		raw == QStringLiteral( "false" ) ||
+		raw == QStringLiteral( "off" ) ||
+		raw == QStringLiteral( "disabled" ) );
+}
+
+bool AgentControlService::commandNeedsConfirmation(
+	const QString& intent,
+	const QString& commandText,
+	const QString& riskHint ) const
+{
+	QString risk = riskHint.trimmed().toLower();
+	if( risk.isEmpty() )
+	{
+		risk = normalizedRiskForIntent( intent );
+	}
+	if( risk == QStringLiteral( "confirm" ) )
+	{
+		return true;
+	}
+
+	const QString normalized = normalizeName( commandText );
+	if( normalized.contains( QStringLiteral( "removeeffect" ) ) ||
+		normalized.contains( QStringLiteral( "deletetrack" ) ) ||
+		normalized.contains( QStringLiteral( "newproject" ) ) ||
+		normalized.contains( QStringLiteral( "openproject" ) ) ||
+		normalized.contains( QStringLiteral( "saveasdefaulttemplate" ) ) ||
+		normalized.contains( QStringLiteral( "export" ) ) )
+	{
+		return true;
+	}
+	return false;
+}
+
+bool AgentControlService::isConfirmationUtterance( const QString& rawText ) const
+{
+	const QString normalized = normalizeName( rawText );
+	return normalized == QStringLiteral( "yes" ) ||
+		normalized == QStringLiteral( "yep" ) ||
+		normalized == QStringLiteral( "confirm" ) ||
+		normalized == QStringLiteral( "confirmed" ) ||
+		normalized == QStringLiteral( "dothething" ) ||
+		normalized == QStringLiteral( "doit" ) ||
+		normalized == QStringLiteral( "proceed" );
+}
+
+QString AgentControlService::executeWithSafetyGate(
+	const QString& commandText,
+	const QString& source,
+	double confidence,
+	const QString& reason,
+	const QString& riskHint )
+{
+	const QString intent = inferIntentForCommand( commandText );
+	if( !isIntentEnabled( intent ) )
+	{
+		const QString capability = capabilityEnvForIntent( intent );
+		return tr( "Capability disabled for intent \"%1\". Set %2=1 to enable." )
+			.arg( intent, capability );
+	}
+
+	const double confirmConfidence = qEnvironmentVariable( "LMMS_CONFIRM_CONFIDENCE" ).trimmed().toDouble() > 0.0
+		? qEnvironmentVariable( "LMMS_CONFIRM_CONFIDENCE" ).trimmed().toDouble()
+		: 0.74;
+	const bool lowConfidenceLlm = source == QStringLiteral( "llm" ) && confidence < confirmConfidence;
+	const bool needsConfirmation = commandNeedsConfirmation( intent, commandText, riskHint ) || lowConfidenceLlm;
+	if( needsConfirmation )
+	{
+		QString commandForConfirm = commandText;
+		if( intent == QStringLiteral( "mixer.effect.remove" ) )
+		{
+			const QStringList parts = tokenizeCommand( commandText );
+			int fromIdx = -1;
+			for( int i = 0; i < parts.size(); ++i )
+			{
+				if( parts[i].compare( QStringLiteral( "from" ), Qt::CaseInsensitive ) == 0 )
+				{
+					fromIdx = i;
+					break;
+				}
+			}
+			if( fromIdx < 0 )
+			{
+				if( Track *track = findLastTrackOfTypes( { Track::Type::Instrument, Track::Type::Sample } ) )
+				{
+					commandForConfirm = commandText + QStringLiteral( " from " ) + track->name();
+				}
+			}
+		}
+
+		const int confirmWindowMs = qEnvironmentVariableIntValue( "LMMS_CONFIRM_WINDOW_MS" ) > 0
+			? qEnvironmentVariableIntValue( "LMMS_CONFIRM_WINDOW_MS" )
+			: 9000;
+		m_pendingConfirmationCommand = commandForConfirm;
+		m_pendingConfirmationIntent = intent;
+		m_pendingConfirmationExpiresMs = QDateTime::currentMSecsSinceEpoch() + qMax( 3000, confirmWindowMs );
+		emitTrace( "confirm_required", QJsonObject
+		{
+			{ "intent", intent },
+			{ "command", commandForConfirm },
+			{ "source", source },
+			{ "confidence", confidence },
+			{ "risk", riskHint.isEmpty() ? normalizedRiskForIntent( intent ) : riskHint }
+		} );
+		return tr( "Confirmation required: \"%1\". Say \"yes\" to execute or \"cancel\"." )
+			.arg( commandText );
+	}
+
+	const QString result = dispatchCommandText( commandText );
+	emitTrace( "command_executed", QJsonObject
+	{
+		{ "intent", intent },
+		{ "source", source },
+		{ "command", commandText },
+		{ "confidence", confidence },
+		{ "result", result }
+	} );
+
+	if( source == QStringLiteral( "deterministic" ) )
+	{
+		return result;
+	}
+
+	QString explanation = tr( "Interpreted as \"%1\"" ).arg( commandText );
+	if( !reason.trimmed().isEmpty() )
+	{
+		explanation += tr( " (%1)" ).arg( reason.trimmed() );
+	}
+	if( confidence > 0.0 )
+	{
+		explanation += tr( " [confidence %1]" ).arg( QString::number( confidence, 'f', 2 ) );
+	}
+	return explanation + QStringLiteral( ". " ) + result;
+}
+
+void AgentControlService::emitTrace( const QString& stage, const QJsonObject& payload )
+{
+	const int traceEnabled = qEnvironmentVariableIntValue( "LMMS_VOICE_TRACE" );
+	if( traceEnabled != 1 )
+	{
+		return;
+	}
+
+	QJsonObject event = payload;
+	event.insert( "stage", stage );
+	event.insert( "ts_ms", QString::number( QDateTime::currentMSecsSinceEpoch() ) );
+	emit logMessage( QStringLiteral( "TRACE %1" )
+		.arg( QString::fromUtf8( QJsonDocument( event ).toJson( QJsonDocument::Compact ) ) ) );
 }
 
 QString AgentControlService::handleJson( const QJsonObject& obj )
@@ -1047,6 +1812,41 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		return error.isEmpty() ? result : error;
 	}
 
+	// Transport controls: keep these deterministic and low latency.
+	if( first == "play" || ( first == "start" && containsPhrase( "playback" ) ) ||
+		( first == "resume" && containsPhrase( "playback" ) ) )
+	{
+		Song *song = Engine::getSong();
+		if( song == nullptr )
+		{
+			return tr( "No active song" );
+		}
+		song->playSong();
+		return tr( "Playback started" );
+	}
+
+	if( first == "pause" )
+	{
+		Song *song = Engine::getSong();
+		if( song == nullptr )
+		{
+			return tr( "No active song" );
+		}
+		song->togglePause();
+		return tr( "Playback toggled" );
+	}
+
+	if( first == "stop" && !containsPhrase( "confirm" ) )
+	{
+		Song *song = Engine::getSong();
+		if( song == nullptr )
+		{
+			return tr( "No active song" );
+		}
+		song->stop();
+		return tr( "Playback stopped" );
+	}
+
 	// Keep direct command mode usable for quick tempo changes from the plugin UI.
 	// Natural-language planning still lives in the text/voice agent.
 	if( mentionsTempo &&
@@ -1206,6 +2006,22 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 
 	if( first == "new" )
 	{
+		if( normalizeName( rawText ).contains( "arpeggiator" ) &&
+			normalizeName( rawText ).contains( "lane" ) )
+		{
+			QString createResult;
+			if( !createTrack( Track::Type::Pattern, createResult, error ) )
+			{
+				return error;
+			}
+			QString openResult;
+			QString openError;
+			if( !showWindowCommand( QStringLiteral( "piano roll" ), openResult, openError ) )
+			{
+				return createResult;
+			}
+			return tr( "Mapped arpeggiator lane to pattern workflow. %1. %2" ).arg( createResult, openResult );
+		}
 		if( tokens.size() >= 2 && tokens[1].compare( "project", Qt::CaseInsensitive ) == 0 )
 		{
 			return newProject( result, error ) ? result : error;
@@ -1232,6 +2048,22 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 	}
 	if( first == "create" )
 	{
+		if( normalizeName( rawText ).contains( "arpeggiator" ) &&
+			normalizeName( rawText ).contains( "lane" ) )
+		{
+			QString createResult;
+			if( !createTrack( Track::Type::Pattern, createResult, error ) )
+			{
+				return error;
+			}
+			QString openResult;
+			QString openError;
+			if( !showWindowCommand( QStringLiteral( "piano roll" ), openResult, openError ) )
+			{
+				return createResult;
+			}
+			return tr( "Mapped arpeggiator lane to pattern workflow. %1. %2" ).arg( createResult, openResult );
+		}
 		if( tokens.size() >= 3 && tokens[1].compare( "sample", Qt::CaseInsensitive ) == 0 &&
 			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
 		{
@@ -1342,6 +2174,13 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 
 	if( first == "add" )
 	{
+		if( tokens.size() >= 3 && tokens[1].compare( "effect", Qt::CaseInsensitive ) == 0 )
+		{
+			int toIndex = tokens.indexOf( "to" );
+			const QString effectName = toIndex > 2 ? tokens.mid( 2, toIndex - 2 ).join( " " ) : joinTokens( tokens, 2 );
+			const QString trackName = toIndex >= 0 ? joinTokens( tokens, toIndex + 1 ) : QString();
+			return addEffectToTrack( effectName, trackName, result, error ) ? result : error;
+		}
 		if( rawText.contains( "piano", Qt::CaseInsensitive ) )
 		{
 			QString createResult;
@@ -1359,12 +2198,21 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		{
 			return addSnarePattern( error ) ? tr( "Added snare pattern" ) : error;
 		}
-		if( tokens.size() >= 3 && tokens[1].compare( "effect", Qt::CaseInsensitive ) == 0 )
+		if( rawText.contains( "hihat", Qt::CaseInsensitive ) ||
+			rawText.contains( "hi-hat", Qt::CaseInsensitive ) ||
+			rawText.contains( "hi hat", Qt::CaseInsensitive ) ||
+			rawText.contains( "hats", Qt::CaseInsensitive ) )
 		{
-			int toIndex = tokens.indexOf( "to" );
-			const QString effectName = toIndex > 2 ? tokens.mid( 2, toIndex - 2 ).join( " " ) : joinTokens( tokens, 2 );
-			const QString trackName = toIndex >= 0 ? joinTokens( tokens, toIndex + 1 ) : QString();
-			return addEffectToTrack( effectName, trackName, result, error ) ? result : error;
+			return addHiHatPattern( error ) ? tr( "Added hi-hat pattern" ) : error;
+		}
+		if( rawText.contains( "ride", Qt::CaseInsensitive ) )
+		{
+			return addRidePattern( error ) ? tr( "Added ride pattern" ) : error;
+		}
+		if( rawText.contains( "crash", Qt::CaseInsensitive ) ||
+			rawText.contains( "cymbal", Qt::CaseInsensitive ) )
+		{
+			return addCrashPattern( error ) ? tr( "Added crash cymbal pattern" ) : error;
 		}
 	}
 
@@ -1533,11 +2381,17 @@ bool AgentControlService::handleSlicerWorkflow(
 			QRegularExpression::CaseInsensitiveOption );
 		const QRegularExpression afterEqual( R"(equal\s+(?:segments?|slices?)(?:\s+of)?\s+(\d+))",
 			QRegularExpression::CaseInsensitiveOption );
+		const QRegularExpression genericSegments( R"((\d+)\s+(?:segments?|slices?))",
+			QRegularExpression::CaseInsensitiveOption );
 
 		auto match = beforeEqual.match( rawText );
 		if( !match.hasMatch() )
 		{
 			match = afterEqual.match( rawText );
+		}
+		if( !match.hasMatch() )
+		{
+			match = genericSegments.match( rawText );
 		}
 		if( match.hasMatch() )
 		{
@@ -1989,21 +2843,35 @@ void AgentControlService::onNewConnection()
 
 void AgentControlService::onSocketReady()
 {
-	auto *sock = qobject_cast<QTcpSocket *>( sender() );
-	if( !sock )
+	QPointer<QTcpSocket> sock = qobject_cast<QTcpSocket *>( sender() );
+	if( !sock || !m_clients.contains( sock.data() ) )
 	{
 		return;
 	}
 
-	QByteArray& buffer = m_readBuffers[sock];
-	buffer.append( sock->readAll() );
+	m_readBuffers[sock.data()].append( sock->readAll() );
 
-	int newlineIndex = buffer.indexOf( '\n' );
-	while( newlineIndex >= 0 )
+	while( true )
 	{
-		const QByteArray line = buffer.left( newlineIndex );
-		buffer.remove( 0, newlineIndex + 1 );
-		newlineIndex = buffer.indexOf( '\n' );
+		if( !sock || !m_clients.contains( sock.data() ) )
+		{
+			return;
+		}
+
+		auto bufferIt = m_readBuffers.find( sock.data() );
+		if( bufferIt == m_readBuffers.end() )
+		{
+			return;
+		}
+
+		const int newlineIndex = bufferIt->indexOf( '\n' );
+		if( newlineIndex < 0 )
+		{
+			return;
+		}
+
+		const QByteArray line = bufferIt->left( newlineIndex );
+		bufferIt->remove( 0, newlineIndex + 1 );
 
 		if( line.trimmed().isEmpty() )
 		{
@@ -2044,7 +2912,19 @@ void AgentControlService::onSocketReady()
 			displayResult = reply.value( "error_message" ).toString();
 		}
 		emit commandResult( displayResult );
-		sock->write( QJsonDocument( reply ).toJson( QJsonDocument::Compact ) + "\n" );
+
+		if( !sock || !m_clients.contains( sock.data() ) ||
+			sock->state() != QAbstractSocket::ConnectedState )
+		{
+			return;
+		}
+
+		const QByteArray payload = QJsonDocument( reply ).toJson( QJsonDocument::Compact ) + "\n";
+		if( sock->write( payload ) < 0 )
+		{
+			emit logMessage( tr( "Failed to write response to client socket" ) );
+			return;
+		}
 		sock->flush();
 	}
 }
@@ -2081,6 +2961,7 @@ bool AgentControlService::newProject( QString& result, QString& error )
 	{
 		song->createNewProject();
 		m_projectTransitionQueued = false;
+		processDeferredOpenProject();
 	} );
 	result = tr( "Queued new project" );
 	return true;
@@ -2103,17 +2984,85 @@ bool AgentControlService::openProject( const QString& path, QString& result, QSt
 	}
 	if( m_projectTransitionQueued )
 	{
-		error = tr( "A project open/new operation is already in progress" );
-		return false;
+		scheduleDeferredOpenProject( fullPath );
+		result = tr( "Queued open project retry for %1" ).arg( QFileInfo( fullPath ).fileName() );
+		return true;
 	}
 	m_projectTransitionQueued = true;
 	QTimer::singleShot( 0, guiApp->mainWindow(), [this, song, fullPath]()
 	{
 		song->loadProject( fullPath );
 		m_projectTransitionQueued = false;
+		processDeferredOpenProject();
 	} );
 	result = tr( "Queued open project %1" ).arg( QFileInfo( fullPath ).fileName() );
 	return true;
+}
+
+void AgentControlService::scheduleDeferredOpenProject( const QString& fullPath )
+{
+	if( fullPath.isEmpty() )
+	{
+		return;
+	}
+
+	m_deferredOpenProjectPath = fullPath;
+	m_deferredOpenProjectRetries = 0;
+	QTimer::singleShot( 250, this, [this]()
+	{
+		processDeferredOpenProject();
+	} );
+}
+
+void AgentControlService::processDeferredOpenProject()
+{
+	if( m_deferredOpenProjectPath.isEmpty() )
+	{
+		return;
+	}
+
+	if( m_projectTransitionQueued )
+	{
+		++m_deferredOpenProjectRetries;
+		if( m_deferredOpenProjectRetries > 24 )
+		{
+			emit logMessage( tr( "Deferred open project timed out for %1" )
+				.arg( QFileInfo( m_deferredOpenProjectPath ).fileName() ) );
+			m_deferredOpenProjectPath.clear();
+			m_deferredOpenProjectRetries = 0;
+			return;
+		}
+
+		QTimer::singleShot( 250, this, [this]()
+		{
+			processDeferredOpenProject();
+		} );
+		return;
+	}
+
+	Song *song = Engine::getSong();
+	auto *guiApp = gui::getGUI();
+	if( song == nullptr || guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		emit logMessage( tr( "Deferred open project skipped: GUI is not ready" ) );
+		m_deferredOpenProjectPath.clear();
+		m_deferredOpenProjectRetries = 0;
+		return;
+	}
+
+	const QString fullPath = m_deferredOpenProjectPath;
+	m_deferredOpenProjectPath.clear();
+	m_deferredOpenProjectRetries = 0;
+	m_projectTransitionQueued = true;
+
+	QTimer::singleShot( 0, guiApp->mainWindow(), [this, song, fullPath]()
+	{
+		song->loadProject( fullPath );
+		m_projectTransitionQueued = false;
+		emit logMessage( tr( "Deferred open project executed: %1" )
+			.arg( QFileInfo( fullPath ).fileName() ) );
+		processDeferredOpenProject();
+	} );
 }
 
 bool AgentControlService::saveProject( QString& result, QString& error )
@@ -2450,6 +3399,75 @@ bool AgentControlService::addSnarePattern( QString& error )
 	return true;
 }
 
+bool AgentControlService::addHiHatPattern( QString& error )
+{
+	const QString samplePath = defaultHiHatSample();
+	if( samplePath.isEmpty() )
+	{
+		error = tr( "Hi-hat sample missing" );
+		return false;
+	}
+
+	auto *track = createSampleTrack( tr( "Agent Hi-Hat" ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	const int stepTicks = DefaultTicksPerBar / DefaultStepsPerBar;
+	for( int step = 0; step < DefaultStepsPerBar; step += 2 )
+	{
+		addSampleClip( track, samplePath, step * stepTicks );
+	}
+	return true;
+}
+
+bool AgentControlService::addCrashPattern( QString& error )
+{
+	const QString samplePath = defaultCrashSample();
+	if( samplePath.isEmpty() )
+	{
+		error = tr( "Crash sample missing" );
+		return false;
+	}
+
+	auto *track = createSampleTrack( tr( "Agent Crash" ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	addSampleClip( track, samplePath, 0 );
+	return true;
+}
+
+bool AgentControlService::addRidePattern( QString& error )
+{
+	const QString samplePath = defaultRideSample();
+	if( samplePath.isEmpty() )
+	{
+		error = tr( "Ride sample missing" );
+		return false;
+	}
+
+	auto *track = createSampleTrack( tr( "Agent Ride" ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	const int stepTicks = DefaultTicksPerBar / DefaultStepsPerBar;
+	const int steps[] = { 0, 4, 8, 12 };
+	for( int s : steps )
+	{
+		addSampleClip( track, samplePath, s * stepTicks );
+	}
+	return true;
+}
+
 bool AgentControlService::addEffectToTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
 {
 	Track *track = trackName.isEmpty()
@@ -2467,20 +3485,8 @@ bool AgentControlService::addEffectToTrack( const QString& effectName, const QSt
 		return false;
 	}
 
-	QString resolvedEffect;
 	QString displayName = effectName.trimmed();
-	const QString requested = normalizeName( effectName );
-	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Effect ) )
-	{
-		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
-		const QString byDisplayName = normalizeName( QString::fromUtf8( desc->displayName ) );
-		if( requested == byName || requested == byDisplayName )
-		{
-			resolvedEffect = QString::fromUtf8( desc->name );
-			displayName = QString::fromUtf8( desc->displayName );
-			break;
-		}
-	}
+	const QString resolvedEffect = resolveEffectPlugin( effectName, displayName );
 	if( resolvedEffect.isEmpty() )
 	{
 		error = tr( "Unknown effect: %1" ).arg( effectName );
@@ -2537,11 +3543,16 @@ bool AgentControlService::removeEffectFromTrack( const QString& effectName, cons
 	}
 
 	const QString requested = normalizeName( effectName );
+	QString resolvedDisplay;
+	const QString resolvedEffect = normalizeName( resolveEffectPlugin( effectName, resolvedDisplay ) );
 	for( Effect *effect : chain->effects() )
 	{
 		const QString byName = normalizeName( QString::fromUtf8( effect->descriptor()->name ) );
 		const QString byDisplayName = normalizeName( effect->displayName() );
-		if( requested == byName || requested == byDisplayName )
+		const bool fuzzyRequested = requested.size() >= 4 &&
+			( byName.contains( requested ) || byDisplayName.contains( requested ) );
+		const bool canonicalResolved = !resolvedEffect.isEmpty() && byName == resolvedEffect;
+		if( requested == byName || requested == byDisplayName || fuzzyRequested || canonicalResolved )
 		{
 			const QString removedName = effect->displayName();
 			chain->removeEffect( effect );
@@ -3022,6 +4033,42 @@ QString AgentControlService::defaultSnareSample() const
 	return QFile::exists( fallback ) ? fallback : QString{};
 }
 
+QString AgentControlService::defaultHiHatSample() const
+{
+	const QString base = ConfigManager::inst()->factorySamplesDir();
+	const QString preferred = QDir( base ).filePath( "drums/hihat_closed01.ogg" );
+	if( QFile::exists( preferred ) )
+	{
+		return preferred;
+	}
+	const QString fallback = QDir( base ).filePath( "drums/hihat_closed03.ogg" );
+	return QFile::exists( fallback ) ? fallback : QString{};
+}
+
+QString AgentControlService::defaultCrashSample() const
+{
+	const QString base = ConfigManager::inst()->factorySamplesDir();
+	const QString preferred = QDir( base ).filePath( "drums/crash01.ogg" );
+	if( QFile::exists( preferred ) )
+	{
+		return preferred;
+	}
+	const QString fallback = QDir( base ).filePath( "drums/crash02.ogg" );
+	return QFile::exists( fallback ) ? fallback : QString{};
+}
+
+QString AgentControlService::defaultRideSample() const
+{
+	const QString base = ConfigManager::inst()->factorySamplesDir();
+	const QString preferred = QDir( base ).filePath( "drums/ride01.ogg" );
+	if( QFile::exists( preferred ) )
+	{
+		return preferred;
+	}
+	const QString fallback = QDir( base ).filePath( "drums/ride02.ogg" );
+	return QFile::exists( fallback ) ? fallback : QString{};
+}
+
 QString AgentControlService::canonicalPath( const QString& path ) const
 {
 	if( path.isEmpty() )
@@ -3422,6 +4469,24 @@ QString AgentControlService::resolveInstrumentPlugin( const QString& pluginName,
 QString AgentControlService::resolveEffectPlugin( const QString& effectName, QString& displayName ) const
 {
 	const QString wanted = normalizeName( effectName );
+	QString aliasWanted;
+	if( wanted == QStringLiteral( "reverb" ) )
+	{
+		aliasWanted = QStringLiteral( "reverbsc" );
+	}
+	else if( wanted == QStringLiteral( "equalizer" ) || wanted == QStringLiteral( "eq" ) )
+	{
+		aliasWanted = QStringLiteral( "eq" );
+	}
+	else if( wanted == QStringLiteral( "comp" ) || wanted == QStringLiteral( "compressor" ) )
+	{
+		aliasWanted = QStringLiteral( "compressor" );
+	}
+	else if( wanted == QStringLiteral( "distortion" ) )
+	{
+		aliasWanted = QStringLiteral( "slewdistortion" );
+	}
+
 	QString fuzzyMatch;
 	QString fuzzyDisplay;
 
@@ -3429,12 +4494,14 @@ QString AgentControlService::resolveEffectPlugin( const QString& effectName, QSt
 	{
 		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
 		const QString byDisplay = normalizeName( QString::fromUtf8( desc->displayName ) );
-		if( byName == wanted || byDisplay == wanted )
+		if( byName == wanted || byDisplay == wanted || ( !aliasWanted.isEmpty() && byName == aliasWanted ) )
 		{
 			displayName = QString::fromUtf8( desc->displayName );
 			return QString::fromUtf8( desc->name );
 		}
-		if( fuzzyMatch.isEmpty() && ( byName.contains( wanted ) || byDisplay.contains( wanted ) ) )
+		if( fuzzyMatch.isEmpty() &&
+			( byName.contains( wanted ) || byDisplay.contains( wanted ) ||
+			  ( !aliasWanted.isEmpty() && ( byName.contains( aliasWanted ) || byDisplay.contains( aliasWanted ) ) ) ) )
 		{
 			fuzzyMatch = QString::fromUtf8( desc->name );
 			fuzzyDisplay = QString::fromUtf8( desc->displayName );

--- a/plugins/AgentControl/AgentControl.cpp
+++ b/plugins/AgentControl/AgentControl.cpp
@@ -5,13 +5,17 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QHostAddress>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QMetaObject>
+#include <QRegularExpression>
 #include <QStandardPaths>
 #include <QTimer>
+#include <QUuid>
 
 #include "ConfigManager.h"
+#include "Clip.h"
 #include "Effect.h"
 #include "EffectChain.h"
 #include "Engine.h"
@@ -21,7 +25,10 @@
 #include "InstrumentTrack.h"
 #include "LmmsCommonMacros.h"
 #include "MainWindow.h"
+#include "MidiClip.h"
+#include "Note.h"
 #include "PluginFactory.h"
+#include "ProjectJournal.h"
 #include "SampleClip.h"
 #include "SampleTrack.h"
 #include "Song.h"
@@ -30,6 +37,8 @@
 #include "plugin_export.h"
 
 #include "AgentControlView.h"
+
+#include <set>
 
 namespace lmms
 {
@@ -95,6 +104,7 @@ AgentControlService::~AgentControlService()
 		}
 	}
 	m_clients.clear();
+	m_readBuffers.clear();
 	m_server.close();
 }
 
@@ -155,11 +165,28 @@ QString AgentControlService::handleCommand( const QString& rawText )
 
 QString AgentControlService::handleJson( const QJsonObject& obj )
 {
+	const QJsonObject response = handleRequest( obj );
+	return toCommandResponseText( response );
+}
+
+QJsonObject AgentControlService::handleRequest( const QJsonObject& obj )
+{
+	if( obj.contains( "tool" ) )
+	{
+		const QString toolName = obj.value( "tool" ).toString().trimmed();
+		const QJsonObject args = obj.value( "args" ).toObject();
+		if( toolName.isEmpty() )
+		{
+			return errorResponse( "missing_tool", tr( "Missing tool field" ) );
+		}
+		return dispatchTool( toolName, args );
+	}
+
 	QStringList tokens;
 	const QString command = obj.value( "command" ).toString().trimmed();
 	if( command.isEmpty() )
 	{
-		return tr( "Missing command field" );
+		return errorResponse( "missing_command", tr( "Missing command field" ) );
 	}
 
 	tokens = command.split( ' ', Qt::SkipEmptyParts );
@@ -188,7 +215,10 @@ QString AgentControlService::handleJson( const QJsonObject& obj )
 		tokens << "to" << track;
 	}
 
-	return dispatchTokens( tokens, command );
+	return successResponse( QJsonObject
+	{
+		{ "message", dispatchTokens( tokens, command ) }
+	} );
 }
 
 QString AgentControlService::dispatchTokens( const QStringList& tokens, const QString& rawText )
@@ -201,6 +231,252 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 	}
 
 	const QString first = tokens[0].toLower();
+	const QString normalizedRaw = normalizeName( rawText );
+	auto containsPhrase = [&normalizedRaw, this]( const QString& phrase )
+	{
+		return normalizedRaw.contains( normalizeName( phrase ) );
+	};
+
+	auto beginnerHelpText = []()
+	{
+		return QString(
+			"Beginner commands:\n"
+			"- set tempo to 140\n"
+			"- open mixer | open song editor | open piano roll\n"
+			"- create instrument track | create sample track | create automation track\n"
+			"- load instrument triple oscillator\n"
+			"- add effect reverb | remove effect reverb\n"
+			"- mute track <name> | solo track <name> | undo\n"
+			"- manual map | manual map automation | manual map samples\n"
+			"- compose from score sheet | add rhythm | sample as melodic instrument\n"
+		"- sidechain through mixer | edit existing song | export song" );
+	};
+
+	if( ( first == "agent" && tokens.size() >= 2 && tokens[1].compare( "version", Qt::CaseInsensitive ) == 0 ) ||
+		( first == "version" ) )
+	{
+		return tr( "AgentControl build %1 %2 (direct parser enabled: tempo, beginner help, manual map, playbook aliases)" )
+			.arg( QString::fromLatin1( __DATE__ ) )
+			.arg( QString::fromLatin1( __TIME__ ) );
+	}
+
+	auto manualMapText = []( const QString& area )
+	{
+		const QString key = area.trimmed().toLower();
+		if( key.contains( "automation" ) )
+		{
+			return QString(
+				"Manual map (Automation):\n"
+				"- Automated now: create automation track, snapshots, undo, rollback\n"
+				"- Guided now: draw curves, controller links, song-global automation\n"
+				"- Deferred: typed automation point editing API" );
+		}
+		if( key.contains( "sample" ) )
+		{
+			return QString(
+				"Manual map (Samples):\n"
+				"- Automated now: create/load sample track, import audio/midi/hydrogen, search project audio\n"
+				"- Guided now: sample prep and browser audition workflow\n"
+				"- Deferred: typed trim/slice/normalize APIs" );
+		}
+		if( key.contains( "song" ) || key.contains( "track" ) )
+		{
+			return QString(
+				"Manual map (Song Editor):\n"
+				"- Automated now: create/rename/select/mute/solo tracks, create pattern\n"
+				"- Guided now: timeline clip gestures (move/split/clone)\n"
+				"- Deferred: typed clip-editing API" );
+		}
+		return QString(
+			"Manual map (LMMS 0.4.12 compatibility):\n"
+			"- Main window/navigation\n"
+			"- Song editor/tracks\n"
+			"- Piano roll composition\n"
+			"- Beat+Bassline rhythm\n"
+			"- Instruments/presets\n"
+			"- FX mixer/effects\n"
+			"- Automation/controllers\n"
+			"- Import/samples\n"
+			"Try: manual map song editor | manual map automation | manual map samples" );
+	};
+	const bool mentionsTempo = tokens.contains( "tempo", Qt::CaseInsensitive ) ||
+		tokens.contains( "bpm", Qt::CaseInsensitive );
+	auto parseFirstInteger = []( const QStringList& parts, int startIndex, int& valueOut )
+	{
+		const QRegularExpression intPattern( R"((-?\d+))" );
+		for( int i = qMax( 0, startIndex ); i < parts.size(); ++i )
+		{
+			const auto match = intPattern.match( parts[i] );
+			if( match.hasMatch() )
+			{
+				bool ok = false;
+				const int parsed = match.captured( 1 ).toInt( &ok );
+				if( ok )
+				{
+					valueOut = parsed;
+					return true;
+				}
+			}
+		}
+		return false;
+	};
+
+	// Keep direct command mode usable for quick tempo changes from the plugin UI.
+	// Natural-language planning still lives in the text/voice agent.
+	if( mentionsTempo &&
+		( first == "set" || first == "increase" || first == "decrease" ||
+		  first == "raise" || first == "lower" || first == "tempo" ) )
+	{
+		const int toIndex = tokens.indexOf( "to" );
+		const int byIndex = tokens.indexOf( "by" );
+		const bool isDecrease = ( first == "decrease" || first == "lower" );
+		const bool isRelative = ( first == "increase" || first == "decrease" || first == "raise" || first == "lower" );
+
+		int targetTempo = 0;
+		bool hasTarget = false;
+
+		if( first == "tempo" )
+		{
+			hasTarget = parseFirstInteger( tokens, 1, targetTempo );
+		}
+		else if( isRelative && byIndex >= 0 )
+		{
+			int delta = 0;
+			hasTarget = parseFirstInteger( tokens, byIndex + 1, delta );
+			if( hasTarget )
+			{
+				if( const auto *song = Engine::getSong() )
+				{
+					targetTempo = song->getTempo() + ( isDecrease ? -delta : delta );
+				}
+				else
+				{
+					hasTarget = false;
+				}
+			}
+		}
+		else if( toIndex >= 0 || first == "set" || isRelative )
+		{
+			hasTarget = parseFirstInteger( tokens, toIndex >= 0 ? toIndex + 1 : 1, targetTempo );
+		}
+
+		if( !hasTarget )
+		{
+			return tr( "Could not parse tempo. Try: set tempo to 140" );
+		}
+
+		QJsonObject tempoResult;
+		if( !setTempoValue( targetTempo, tempoResult, error ) )
+		{
+			return error;
+		}
+		return tr( "Set tempo to %1" ).arg( tempoResult.value( "tempo_after" ).toInt( targetTempo ) );
+	}
+
+	if( containsPhrase( "beginner help" ) )
+	{
+		return beginnerHelpText();
+	}
+
+	if( first == "manual" && tokens.size() >= 2 && tokens[1].compare( "map", Qt::CaseInsensitive ) == 0 )
+	{
+		return manualMapText( joinTokens( tokens, 2 ) );
+	}
+
+	if( first == "list" && tokens.size() >= 2 && tokens[1].compare( "windows", Qt::CaseInsensitive ) == 0 )
+	{
+		return QString(
+			"Openable windows:\n"
+			"- song editor\n"
+			"- piano roll\n"
+			"- automation editor\n"
+			"- mixer (aliases: fx mixer, fx mixer/effects, effects)\n"
+			"- controller rack\n"
+			"- project notes\n"
+			"- microtuner" );
+	}
+
+	if( containsPhrase( "compose from score sheet" ) )
+	{
+		QJsonObject tempoResult;
+		if( !setTempoValue( 140, tempoResult, error ) )
+		{
+			return error;
+		}
+		QString trackResult;
+		if( !createTrack( Track::Type::Instrument, trackResult, error ) )
+		{
+			return error;
+		}
+		QString instrumentResult;
+		if( !createInstrumentTrack( "tripleoscillator", instrumentResult, error ) )
+		{
+			return error;
+		}
+		QJsonObject patternResult;
+		if( !createPatternClip( QJsonObject(), patternResult, error ) )
+		{
+			return tr( "Started score-sheet workflow: tempo 140, instrument ready. Next: open piano roll and enter notes." );
+		}
+		return tr( "Started score-sheet workflow: tempo 140, TripleOscillator loaded, first pattern created." );
+	}
+
+	if( containsPhrase( "add rhythm" ) )
+	{
+		QString trackResult;
+		if( !createTrack( Track::Type::Sample, trackResult, error ) )
+		{
+			return error;
+		}
+		if( !addKickPattern( error ) )
+		{
+			return tr( "Created sample track. Next: load drum samples and program BB rhythm." );
+		}
+		return tr( "Created sample track and added starter kick pattern." );
+	}
+
+	if( containsPhrase( "sample as melodic instrument" ) )
+	{
+		QString trackResult;
+		if( !createTrack( Track::Type::Instrument, trackResult, error ) )
+		{
+			return error;
+		}
+		QString instrumentResult;
+		if( !createInstrumentTrack( "audiofileprocessor", instrumentResult, error ) )
+		{
+			return tr( "Created instrument track. Next: load AudioFileProcessor manually and set root note." );
+		}
+		return tr( "Created sample-instrument track with AudioFileProcessor. Next: load sample and test pitch range." );
+	}
+
+	if( containsPhrase( "sidechain through mixer" ) )
+	{
+		if( !showWindowCommand( "mixer", result, error ) )
+		{
+			return error;
+		}
+		return tr( "Opened mixer. Next: route source/target, bind controller to gain, then tune depth/release." );
+	}
+
+	if( containsPhrase( "edit existing song" ) )
+	{
+		QJsonObject snapshotResult;
+		if( !createSnapshot( "before_existing_song_edit", snapshotResult, error ) )
+		{
+			return error;
+		}
+		QString songEditorResult;
+		showWindowCommand( "song editor", songEditorResult, error );
+		QString mixerResult;
+		showWindowCommand( "mixer", mixerResult, error );
+		return tr( "Snapshot created. Opened Song Editor and Mixer for edit pass." );
+	}
+
+	if( containsPhrase( "export song" ) || containsPhrase( "render song" ) )
+	{
+		return tr( "Use File -> Export (Ctrl+E). Choose format and destination, then render." );
+	}
 
 	if( first == "new" )
 	{
@@ -228,6 +504,29 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 			return createInstrumentTrack( joinTokens( tokens, 2 ), result, error ) ? result : error;
 		}
 	}
+	if( first == "create" )
+	{
+		if( tokens.size() >= 3 && tokens[1].compare( "sample", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Sample, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "instrument", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Instrument, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "automation", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Automation, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "pattern", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Pattern, result, error ) ? result : error;
+		}
+	}
 
 	if( first == "show" )
 	{
@@ -247,6 +546,10 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		if( tokens.size() >= 2 && normalizeName( joinTokens( tokens, 1 ) ) == "slicer" )
 		{
 			return createInstrumentTrack( "slicert", result, error ) ? result : error;
+		}
+		if( tokens.size() >= 2 )
+		{
+			return showWindowCommand( joinTokens( tokens, 1 ), result, error ) ? result : error;
 		}
 	}
 
@@ -301,9 +604,22 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 
 	if( first == "add" )
 	{
+		if( rawText.contains( "piano", Qt::CaseInsensitive ) )
+		{
+			QString createResult;
+			if( createInstrumentTrack( "tripleoscillator", createResult, error ) )
+			{
+				return tr( "Queued piano instrument (TripleOscillator)" );
+			}
+			return error;
+		}
 		if( rawText.contains( "808", Qt::CaseInsensitive ) || rawText.contains( "kick", Qt::CaseInsensitive ) )
 		{
 			return addKickPattern( error ) ? tr( "Added kick pattern" ) : error;
+		}
+		if( rawText.contains( "snare", Qt::CaseInsensitive ) )
+		{
+			return addSnarePattern( error ) ? tr( "Added snare pattern" ) : error;
 		}
 		if( tokens.size() >= 3 && tokens[1].compare( "effect", Qt::CaseInsensitive ) == 0 )
 		{
@@ -311,6 +627,16 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 			const QString effectName = toIndex > 2 ? tokens.mid( 2, toIndex - 2 ).join( " " ) : joinTokens( tokens, 2 );
 			const QString trackName = toIndex >= 0 ? joinTokens( tokens, toIndex + 1 ) : QString();
 			return addEffectToTrack( effectName, trackName, result, error ) ? result : error;
+		}
+	}
+
+	if( first == "make" )
+	{
+		if( rawText.contains( "drums", Qt::CaseInsensitive ) &&
+			rawText.contains( "hit", Qt::CaseInsensitive ) &&
+			rawText.contains( "harder", Qt::CaseInsensitive ) )
+		{
+			return addKickPattern( error ) ? tr( "Added kick pattern" ) : error;
 		}
 	}
 
@@ -325,7 +651,463 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		}
 	}
 
-	return tr( "Unknown command: %1" ).arg( rawText );
+	if( first == "mute" )
+	{
+		const QString trackName = ( tokens.size() >= 2 && tokens[1].compare( "track", Qt::CaseInsensitive ) == 0 ) ?
+			joinTokens( tokens, 2 ) : joinTokens( tokens, 1 );
+		QJsonObject muteResult;
+		if( setTrackMute( trackName, true, muteResult, error ) )
+		{
+			return tr( "Muted track %1" ).arg( muteResult.value( "track_name" ).toString( trackName ) );
+		}
+		return error;
+	}
+
+	if( first == "unmute" )
+	{
+		const QString trackName = ( tokens.size() >= 2 && tokens[1].compare( "track", Qt::CaseInsensitive ) == 0 ) ?
+			joinTokens( tokens, 2 ) : joinTokens( tokens, 1 );
+		QJsonObject muteResult;
+		if( setTrackMute( trackName, false, muteResult, error ) )
+		{
+			return tr( "Unmuted track %1" ).arg( muteResult.value( "track_name" ).toString( trackName ) );
+		}
+		return error;
+	}
+
+	if( first == "solo" )
+	{
+		const QString trackName = ( tokens.size() >= 2 && tokens[1].compare( "track", Qt::CaseInsensitive ) == 0 ) ?
+			joinTokens( tokens, 2 ) : joinTokens( tokens, 1 );
+		QJsonObject soloResult;
+		if( setTrackSolo( trackName, true, soloResult, error ) )
+		{
+			return tr( "Soloed track %1" ).arg( soloResult.value( "track_name" ).toString( trackName ) );
+		}
+		return error;
+	}
+
+	if( first == "unsolo" )
+	{
+		const QString trackName = ( tokens.size() >= 2 && tokens[1].compare( "track", Qt::CaseInsensitive ) == 0 ) ?
+			joinTokens( tokens, 2 ) : joinTokens( tokens, 1 );
+		QJsonObject soloResult;
+		if( setTrackSolo( trackName, false, soloResult, error ) )
+		{
+			return tr( "Unsoloed track %1" ).arg( soloResult.value( "track_name" ).toString( trackName ) );
+		}
+		return error;
+	}
+
+	if( first == "undo" )
+	{
+		QJsonObject undoResult;
+		if( undoLastAction( undoResult, error ) )
+		{
+			return tr( "Undid last action" );
+		}
+		return error;
+	}
+
+	return tr( "Unknown command: %1. For natural-language tasks use lmmsagent/scripts/run_text_agent.sh" ).arg( rawText );
+}
+
+QJsonObject AgentControlService::dispatchTool( const QString& toolName, const QJsonObject& args )
+{
+	const QString tool = normalizeName( toolName );
+	const QSet<QString> writeTools =
+	{
+		"createtrack", "renametrack", "loadinstrument", "loadsample", "createpattern",
+		"addnotes", "addsteps", "settempo", "addeffect", "removeeffect", "seteffectparam",
+		"opentool", "importaudio", "importmidi", "importhydrogen", "selecttrack", "mutetrack",
+		"solotrack", "undoslastaction", "undolastaction", "createsnapshot", "rollbacktosnapshot"
+	};
+	const QSet<QString> mutatingTools =
+	{
+		"createtrack", "renametrack", "loadinstrument", "loadsample", "createpattern",
+		"addnotes", "addsteps", "settempo", "addeffect", "removeeffect", "seteffectparam",
+		"importaudio", "importmidi", "importhydrogen", "mutetrack", "solotrack"
+	};
+
+	const bool isWriteTool = writeTools.contains( tool );
+	const QJsonObject beforeState = isWriteTool ? projectStateObject() : QJsonObject();
+	QJsonObject result;
+	QString error;
+	bool ok = true;
+	QJsonArray warnings;
+
+	auto isKnownWindow = [this]( const QString& name )
+	{
+		const QString wanted = normalizeName( name );
+		for( const auto &value : availableWindows() )
+		{
+			if( normalizeName( value.toString() ) == wanted )
+			{
+				return true;
+			}
+		}
+		return false;
+	};
+
+	if( tool == "getprojectstate" )
+	{
+		result = projectStateObject();
+	}
+	else if( tool == "listtracks" )
+	{
+		result = QJsonObject{ { "tracks", trackArray() } };
+	}
+	else if( tool == "gettrackdetails" )
+	{
+		Track* track = resolveTrackRef( args );
+		if( track == nullptr )
+		{
+			return errorResponse( "track_not_found", tr( "Track not found" ) );
+		}
+		result = trackObject( track, trackIndex( track ) );
+	}
+	else if( tool == "listpatterns" )
+	{
+		result = QJsonObject{ { "patterns", listPatternArray() } };
+	}
+	else if( tool == "listinstruments" )
+	{
+		QJsonArray activeTracks;
+		Song* song = Engine::getSong();
+		if( song != nullptr )
+		{
+			int idx = 0;
+			for( const auto *track : song->tracks() )
+			{
+				if( dynamic_cast<const InstrumentTrack *>( track ) != nullptr )
+				{
+					activeTracks.append( trackObject( track, idx ) );
+				}
+				++idx;
+			}
+		}
+		result = QJsonObject
+		{
+			{ "installed", availableInstruments() },
+			{ "active_tracks", activeTracks }
+		};
+	}
+	else if( tool == "listeffects" )
+	{
+		Track* track = resolveTrackRef( args );
+		result = QJsonObject
+		{
+			{ "installed", availableEffects() },
+			{ "track_effects", track != nullptr ? effectArrayForTrack( track ) : QJsonArray() }
+		};
+	}
+	else if( tool == "listtoolwindows" )
+	{
+		result = QJsonObject
+		{
+			{ "windows", availableWindows() },
+			{ "tools", availableTools() }
+		};
+	}
+	else if( tool == "getselectionstate" )
+	{
+		result = QJsonObject
+		{
+			{ "selected_track", m_selectedTrackName },
+			{ "has_selection", !m_selectedTrackName.isEmpty() }
+		};
+	}
+	else if( tool == "findtrackbyname" )
+	{
+		const QString query = args.value( "query" ).toString().trimmed().isEmpty()
+			? args.value( "name" ).toString().trimmed()
+			: args.value( "query" ).toString().trimmed();
+		if( query.isEmpty() )
+		{
+			return errorResponse( "invalid_args", tr( "Missing query for find_track_by_name" ) );
+		}
+		const QString wanted = normalizeName( query );
+		Song* song = Engine::getSong();
+		if( song == nullptr )
+		{
+			return errorResponse( "no_song", tr( "No active song" ) );
+		}
+		const auto &tracks = song->tracks();
+		Track* best = nullptr;
+		for( auto *track : tracks )
+		{
+			const QString trackName = normalizeName( track->name() );
+			if( trackName == wanted )
+			{
+				best = track;
+				break;
+			}
+			if( best == nullptr && trackName.contains( wanted ) )
+			{
+				best = track;
+			}
+		}
+		if( best == nullptr )
+		{
+			return errorResponse( "track_not_found", tr( "No track matched %1" ).arg( query ) );
+		}
+		result = QJsonObject{ { "match", trackObject( best, trackIndex( best ) ) } };
+	}
+	else if( tool == "searchprojectaudio" )
+	{
+		const QString query = args.value( "query" ).toString().trimmed();
+		result = QJsonObject{ { "matches", searchProjectAudio( query ) } };
+	}
+	else if( tool == "createtrack" )
+	{
+		const QString typeName = normalizeName( args.value( "type" ).toString().trimmed() );
+		Track::Type type = Track::Type::Instrument;
+		if( typeName == "sample" || typeName == "sampletrack" )
+		{
+			type = Track::Type::Sample;
+		}
+		else if( typeName == "automation" || typeName == "automationtrack" )
+		{
+			type = Track::Type::Automation;
+		}
+		else if( typeName == "pattern" || typeName == "patterntrack" )
+		{
+			type = Track::Type::Pattern;
+		}
+		Song* song = Engine::getSong();
+		if( song == nullptr )
+		{
+			return errorResponse( "no_song", tr( "No active song" ) );
+		}
+		Track* track = Track::create( type, song );
+		if( track == nullptr )
+		{
+			return errorResponse( "create_failed", tr( "Failed to create track" ) );
+		}
+		const QString name = args.value( "name" ).toString().trimmed();
+		if( !name.isEmpty() )
+		{
+			track->setName( name );
+		}
+		m_selectedTrackName = track->name();
+		result = QJsonObject{ { "track", trackObject( track, trackIndex( track ) ) } };
+	}
+	else if( tool == "renametrack" )
+	{
+		ok = renameTrack(
+			args.value( "track" ).toString().trimmed().isEmpty()
+				? args.value( "track_name" ).toString().trimmed()
+				: args.value( "track" ).toString().trimmed(),
+			args.value( "new_name" ).toString().trimmed(),
+			result, error );
+	}
+	else if( tool == "loadinstrument" )
+	{
+		const QString pluginQuery = args.value( "plugin" ).toString().trimmed().isEmpty()
+			? args.value( "name" ).toString().trimmed()
+			: args.value( "plugin" ).toString().trimmed();
+		if( pluginQuery.isEmpty() )
+		{
+			return errorResponse( "invalid_args", tr( "Missing plugin for load_instrument" ) );
+		}
+
+		QString displayName;
+		const QString pluginName = resolveInstrumentPlugin( pluginQuery, displayName );
+		if( pluginName.isEmpty() )
+		{
+			return errorResponse( "plugin_not_found", tr( "Unknown instrument: %1" ).arg( pluginQuery ) );
+		}
+
+		InstrumentTrack* track = resolveInstrumentTrack( args );
+		if( track == nullptr )
+		{
+			Song* song = Engine::getSong();
+			if( song == nullptr )
+			{
+				return errorResponse( "no_song", tr( "No active song" ) );
+			}
+			track = dynamic_cast<InstrumentTrack *>( Track::create( Track::Type::Instrument, song ) );
+		}
+		if( track == nullptr )
+		{
+			return errorResponse( "create_failed", tr( "Could not create instrument track" ) );
+		}
+		track->loadInstrument( pluginName );
+		if( !args.value( "track_name" ).toString().trimmed().isEmpty() )
+		{
+			track->setName( args.value( "track_name" ).toString().trimmed() );
+		}
+		m_selectedTrackName = track->name();
+		result = QJsonObject
+		{
+			{ "plugin", pluginName },
+			{ "plugin_display_name", displayName },
+			{ "track", trackObject( track, trackIndex( track ) ) }
+		};
+	}
+	else if( tool == "loadsample" )
+	{
+		const QString samplePath = args.value( "sample_path" ).toString().trimmed().isEmpty()
+			? args.value( "path" ).toString().trimmed()
+			: args.value( "sample_path" ).toString().trimmed();
+		const QString trackName = args.value( "track" ).toString().trimmed().isEmpty()
+			? args.value( "track_name" ).toString().trimmed()
+			: args.value( "track" ).toString().trimmed();
+		ok = loadSampleToTrack( samplePath, trackName, result, error );
+	}
+	else if( tool == "createpattern" )
+	{
+		ok = createPatternClip( args, result, error );
+	}
+	else if( tool == "addnotes" )
+	{
+		ok = addNotesToPattern( args, result, error );
+	}
+	else if( tool == "addsteps" )
+	{
+		ok = addStepsToPattern( args, result, error );
+	}
+	else if( tool == "settempo" )
+	{
+		const int tempo = args.value( "tempo" ).toInt( 0 );
+		ok = setTempoValue( tempo, result, error );
+	}
+	else if( tool == "addeffect" )
+	{
+		QString message;
+		const QString effectName = args.value( "effect" ).toString().trimmed().isEmpty()
+			? args.value( "name" ).toString().trimmed()
+			: args.value( "effect" ).toString().trimmed();
+		const QString trackName = args.value( "track" ).toString().trimmed();
+		ok = addEffectToTrack( effectName, trackName, message, error );
+		result = QJsonObject{ { "message", message } };
+	}
+	else if( tool == "removeeffect" )
+	{
+		QString message;
+		const QString effectName = args.value( "effect" ).toString().trimmed().isEmpty()
+			? args.value( "name" ).toString().trimmed()
+			: args.value( "effect" ).toString().trimmed();
+		const QString trackName = args.value( "track" ).toString().trimmed();
+		ok = removeEffectFromTrack( effectName, trackName, message, error );
+		result = QJsonObject{ { "message", message } };
+	}
+	else if( tool == "seteffectparam" )
+	{
+		return errorResponse( "not_implemented", tr( "set_effect_param is not implemented yet" ) );
+	}
+	else if( tool == "opentool" )
+	{
+		QString message;
+		const QString name = args.value( "name" ).toString().trimmed();
+		if( name.isEmpty() )
+		{
+			return errorResponse( "invalid_args", tr( "Missing tool or window name" ) );
+		}
+		const QString kind = normalizeName( args.value( "kind" ).toString().trimmed() );
+		if( kind == "window" )
+		{
+			ok = showWindowCommand( name, message, error );
+		}
+		else if( kind == "tool" )
+		{
+			ok = showToolCommand( name, message, error );
+		}
+		else if( isKnownWindow( name ) )
+		{
+			ok = showWindowCommand( name, message, error );
+		}
+		else
+		{
+			ok = showToolCommand( name, message, error );
+			if( !ok )
+			{
+				ok = showWindowCommand( name, message, error );
+			}
+		}
+		result = QJsonObject{ { "message", message } };
+	}
+	else if( tool == "importaudio" )
+	{
+		const QString path = args.value( "path" ).toString().trimmed();
+		ok = importAudioFile( path, error );
+		result = QJsonObject{ { "path", path } };
+	}
+	else if( tool == "importmidi" )
+	{
+		const QString path = args.value( "path" ).toString().trimmed();
+		ok = importProjectFile( path, error );
+		result = QJsonObject{ { "path", path }, { "format", "midi" } };
+	}
+	else if( tool == "importhydrogen" )
+	{
+		const QString path = args.value( "path" ).toString().trimmed();
+		ok = importProjectFile( path, error );
+		result = QJsonObject{ { "path", path }, { "format", "hydrogen" } };
+	}
+	else if( tool == "selecttrack" )
+	{
+		const QString trackName = args.value( "track" ).toString().trimmed().isEmpty()
+			? args.value( "track_name" ).toString().trimmed()
+			: args.value( "track" ).toString().trimmed();
+		ok = selectTrack( trackName, result, error );
+	}
+	else if( tool == "mutetrack" )
+	{
+		const QString trackName = args.value( "track" ).toString().trimmed().isEmpty()
+			? args.value( "track_name" ).toString().trimmed()
+			: args.value( "track" ).toString().trimmed();
+		const bool mute = args.value( "mute" ).toBool( true );
+		ok = setTrackMute( trackName, mute, result, error );
+	}
+	else if( tool == "solotrack" )
+	{
+		const QString trackName = args.value( "track" ).toString().trimmed().isEmpty()
+			? args.value( "track_name" ).toString().trimmed()
+			: args.value( "track" ).toString().trimmed();
+		const bool solo = args.value( "solo" ).toBool( true );
+		ok = setTrackSolo( trackName, solo, result, error );
+	}
+	else if( tool == "createsnapshot" )
+	{
+		ok = createSnapshot( args.value( "label" ).toString().trimmed(), result, error );
+	}
+	else if( tool == "undolastaction" || tool == "undoslastaction" )
+	{
+		ok = undoLastAction( result, error );
+	}
+	else if( tool == "rollbacktosnapshot" )
+	{
+		const QString snapshotId = args.value( "snapshot_id" ).toString().trimmed();
+		ok = rollbackSnapshot( snapshotId, result, error );
+	}
+	else if( tool == "diffsincesnapshot" || tool == "diffsincesnapshop" || tool == "diffsince_snapshot" )
+	{
+		const QString snapshotId = args.value( "snapshot_id" ).toString().trimmed();
+		ok = diffSinceSnapshot( snapshotId, result, error );
+	}
+	else
+	{
+		return errorResponse( "unknown_tool", tr( "Unknown tool: %1" ).arg( toolName ) );
+	}
+
+	if( !ok )
+	{
+		return errorResponse( "tool_failed", error.isEmpty() ? tr( "Tool execution failed" ) : error, warnings );
+	}
+
+	QJsonObject stateDelta;
+	if( isWriteTool )
+	{
+		const QJsonObject afterState = projectStateObject();
+		stateDelta = diffState( beforeState, afterState );
+		if( mutatingTools.contains( tool ) )
+		{
+			++m_actionCounter;
+		}
+	}
+
+	return successResponse( result, stateDelta, warnings );
 }
 
 void AgentControlService::onNewConnection()
@@ -348,9 +1130,16 @@ void AgentControlService::onSocketReady()
 		return;
 	}
 
-	const QByteArray payload = sock->readAll();
-	for( const QByteArray &line : payload.split( '\n' ) )
+	QByteArray& buffer = m_readBuffers[sock];
+	buffer.append( sock->readAll() );
+
+	int newlineIndex = buffer.indexOf( '\n' );
+	while( newlineIndex >= 0 )
 	{
+		const QByteArray line = buffer.left( newlineIndex );
+		buffer.remove( 0, newlineIndex + 1 );
+		newlineIndex = buffer.indexOf( '\n' );
+
 		if( line.trimmed().isEmpty() )
 		{
 			continue;
@@ -358,12 +1147,38 @@ void AgentControlService::onSocketReady()
 
 		QJsonParseError parseError {};
 		const QJsonDocument doc = QJsonDocument::fromJson( line, &parseError );
-		const QString result = parseError.error == QJsonParseError::NoError && doc.isObject()
-			? handleJson( doc.object() )
-			: handleCommand( QString::fromUtf8( line ) );
+		QJsonObject reply;
+		QString displayResult;
+		if( parseError.error == QJsonParseError::NoError && doc.isObject() )
+		{
+			reply = handleRequest( doc.object() );
+			displayResult = toCommandResponseText( reply );
+		}
+		else
+		{
+			const QString result = handleCommand( QString::fromUtf8( line ) );
+			displayResult = result;
+			reply = successResponse( QJsonObject
+			{
+				{ "message", result }
+			} );
+		}
 
-		emit commandResult( result );
-		const QJsonObject reply {{ "result", result }};
+		if( !reply.contains( "ok" ) )
+		{
+			reply = errorResponse( "invalid_response", tr( "AgentControl returned an invalid response" ) );
+		}
+
+		const bool ok = reply.value( "ok" ).toBool( false );
+		if( !ok && reply.value( "error_message" ).toString().isEmpty() )
+		{
+			reply["error_message"] = tr( "Request failed" );
+		}
+		if( !ok )
+		{
+			displayResult = reply.value( "error_message" ).toString();
+		}
+		emit commandResult( displayResult );
 		sock->write( QJsonDocument( reply ).toJson( QJsonDocument::Compact ) + "\n" );
 		sock->flush();
 	}
@@ -377,6 +1192,7 @@ void AgentControlService::onSocketClosed()
 		return;
 	}
 	m_clients.remove( sock );
+	m_readBuffers.remove( sock );
 	sock->deleteLater();
 	emit logMessage( tr( "Client disconnected" ) );
 }
@@ -390,9 +1206,16 @@ bool AgentControlService::newProject( QString& result, QString& error )
 		error = tr( "GUI is not ready" );
 		return false;
 	}
-	QTimer::singleShot( 100, guiApp->mainWindow(), [song]()
+	if( m_projectTransitionQueued )
+	{
+		error = tr( "A project open/new operation is already in progress" );
+		return false;
+	}
+	m_projectTransitionQueued = true;
+	QTimer::singleShot( 0, guiApp->mainWindow(), [this, song]()
 	{
 		song->createNewProject();
+		m_projectTransitionQueued = false;
 	} );
 	result = tr( "Queued new project" );
 	return true;
@@ -413,9 +1236,16 @@ bool AgentControlService::openProject( const QString& path, QString& result, QSt
 		error = tr( "GUI is not ready" );
 		return false;
 	}
-	QTimer::singleShot( 100, guiApp->mainWindow(), [song, fullPath]()
+	if( m_projectTransitionQueued )
+	{
+		error = tr( "A project open/new operation is already in progress" );
+		return false;
+	}
+	m_projectTransitionQueued = true;
+	QTimer::singleShot( 0, guiApp->mainWindow(), [this, song, fullPath]()
 	{
 		song->loadProject( fullPath );
+		m_projectTransitionQueued = false;
 	} );
 	result = tr( "Queued open project %1" ).arg( QFileInfo( fullPath ).fileName() );
 	return true;
@@ -472,7 +1302,27 @@ bool AgentControlService::showWindowCommand( const QString& windowName, QString&
 		return false;
 	}
 
-	const QString normalized = normalizeName( windowName );
+	QString normalized = normalizeName( windowName );
+	// Accept common feature labels and human aliases used in docs/manual text.
+	if( normalized == "fxmixer" || normalized == "fxmixereffects" ||
+		normalized == "mixereffects" || normalized == "effectsmixer" ||
+		normalized == "effectchain" || normalized == "effects" )
+	{
+		normalized = "mixer";
+	}
+	else if( normalized == "songeditortracks" || normalized == "songarrangement" )
+	{
+		normalized = "songeditor";
+	}
+	else if( normalized == "pianorolleditor" || normalized == "melodyeditor" )
+	{
+		normalized = "pianoroll";
+	}
+	else if( normalized == "automationeditorandcontrollerrack" || normalized == "automationcontrollers" )
+	{
+		normalized = "automationeditor";
+	}
+
 	const char *slot = nullptr;
 	if( normalized == "songeditor" )
 	{
@@ -660,7 +1510,6 @@ bool AgentControlService::importAudioFile( const QString& path, QString& error )
 		return false;
 	}
 
-	track->addClip( clip );
 	clip->setSampleFile( fullPath );
 	clip->updateLength();
 	return true;
@@ -702,6 +1551,31 @@ bool AgentControlService::addKickPattern( QString& error )
 
 	const int stepTicks = DefaultTicksPerBar / DefaultStepsPerBar;
 	const int steps[] = { 0, 4, 8, 12 };
+	for( int s : steps )
+	{
+		addSampleClip( track, samplePath, s * stepTicks );
+	}
+	return true;
+}
+
+bool AgentControlService::addSnarePattern( QString& error )
+{
+	const QString samplePath = defaultSnareSample();
+	if( samplePath.isEmpty() )
+	{
+		error = tr( "Snare sample missing" );
+		return false;
+	}
+
+	auto *track = createSampleTrack( tr( "Agent Snare" ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	const int stepTicks = DefaultTicksPerBar / DefaultStepsPerBar;
+	const int steps[] = { 4, 12 };
 	for( int s : steps )
 	{
 		addSampleClip( track, samplePath, s * stepTicks );
@@ -893,7 +1767,6 @@ bool AgentControlService::addSampleClip( SampleTrack *track, const QString& samp
 	{
 		return false;
 	}
-	track->addClip( clip );
 	clip->setSampleFile( samplePath );
 	clip->updateLength();
 	return true;
@@ -920,6 +1793,18 @@ QString AgentControlService::defaultKickSample() const
 	const QString base = ConfigManager::inst()->factorySamplesDir();
 	const QString candidate = QDir( base ).filePath( "drums/bassdrum04.ogg" );
 	return QFile::exists( candidate ) ? candidate : QString{};
+}
+
+QString AgentControlService::defaultSnareSample() const
+{
+	const QString base = ConfigManager::inst()->factorySamplesDir();
+	const QString preferred = QDir( base ).filePath( "drums/snare01.ogg" );
+	if( QFile::exists( preferred ) )
+	{
+		return preferred;
+	}
+	const QString fallback = QDir( base ).filePath( "drums/snare03.ogg" );
+	return QFile::exists( fallback ) ? fallback : QString{};
 }
 
 QString AgentControlService::canonicalPath( const QString& path ) const
@@ -967,6 +1852,926 @@ QString AgentControlService::normalizeName( const QString& text ) const
 		}
 	}
 	return out;
+}
+
+QJsonObject AgentControlService::successResponse(
+	const QJsonObject& result,
+	const QJsonObject& stateDelta,
+	const QJsonArray& warnings ) const
+{
+	return QJsonObject
+	{
+		{ "ok", true },
+		{ "result", result },
+		{ "state_delta", stateDelta },
+		{ "warnings", warnings },
+		{ "error_code", QJsonValue::Null },
+		{ "error_message", QJsonValue::Null }
+	};
+}
+
+QJsonObject AgentControlService::errorResponse(
+	const QString& errorCode,
+	const QString& errorMessage,
+	const QJsonArray& warnings ) const
+{
+	return QJsonObject
+	{
+		{ "ok", false },
+		{ "result", QJsonObject() },
+		{ "state_delta", QJsonObject() },
+		{ "warnings", warnings },
+		{ "error_code", errorCode },
+		{ "error_message", errorMessage }
+	};
+}
+
+QString AgentControlService::toCommandResponseText( const QJsonObject& response ) const
+{
+	if( !response.value( "ok" ).toBool( false ) )
+	{
+		return response.value( "error_message" ).toString( tr( "Request failed" ) );
+	}
+
+	const QJsonObject result = response.value( "result" ).toObject();
+	const QString message = result.value( "message" ).toString();
+	if( !message.isEmpty() )
+	{
+		return message;
+	}
+	return QString::fromUtf8( QJsonDocument( result ).toJson( QJsonDocument::Compact ) );
+}
+
+QString AgentControlService::trackTypeName( Track::Type type ) const
+{
+	switch( type )
+	{
+	case Track::Type::Instrument:
+		return "instrument";
+	case Track::Type::Pattern:
+		return "pattern";
+	case Track::Type::Sample:
+		return "sample";
+	case Track::Type::Event:
+		return "event";
+	case Track::Type::Video:
+		return "video";
+	case Track::Type::Automation:
+		return "automation";
+	case Track::Type::HiddenAutomation:
+		return "hidden_automation";
+	case Track::Type::Count:
+	default:
+		return "unknown";
+	}
+}
+
+int AgentControlService::trackIndex( const Track* track ) const
+{
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return -1;
+	}
+	const auto &tracks = song->tracks();
+	for( std::size_t i = 0; i < tracks.size(); ++i )
+	{
+		if( tracks[i] == track )
+		{
+			return static_cast<int>( i );
+		}
+	}
+	return -1;
+}
+
+QJsonArray AgentControlService::effectArrayForTrack( Track* track ) const
+{
+	QJsonArray effects;
+	EffectChain* chain = effectChainForTrack( track );
+	if( chain == nullptr )
+	{
+		return effects;
+	}
+
+	for( Effect* effect : chain->effects() )
+	{
+		QJsonObject item
+		{
+			{ "display_name", effect->displayName() }
+		};
+		if( effect->descriptor() != nullptr )
+		{
+			item.insert( "plugin_name", QString::fromUtf8( effect->descriptor()->name ) );
+		}
+		effects.append( item );
+	}
+	return effects;
+}
+
+QJsonObject AgentControlService::trackObject( const Track* track, int index ) const
+{
+	QJsonObject obj
+	{
+		{ "id", QString( "t_%1" ).arg( index ) },
+		{ "index", index },
+		{ "name", track->name() },
+		{ "type", trackTypeName( track->type() ) },
+		{ "muted", track->isMuted() },
+		{ "solo", track->isSolo() },
+		{ "clip_count", static_cast<int>( track->getClips().size() ) },
+		{ "effects", effectArrayForTrack( const_cast<Track *>( track ) ) }
+	};
+
+	if( const auto *instrumentTrack = dynamic_cast<const InstrumentTrack *>( track ) )
+	{
+		obj.insert( "instrument_name", instrumentTrack->instrumentName() );
+	}
+	if( const auto *sampleTrack = dynamic_cast<const SampleTrack *>( track ) )
+	{
+		QJsonArray sampleFiles;
+		for( auto *clip : sampleTrack->getClips() )
+		{
+			if( auto *sampleClip = dynamic_cast<SampleClip *>( clip ) )
+			{
+				sampleFiles.append( sampleClip->sampleFile() );
+			}
+		}
+		obj.insert( "sample_files", sampleFiles );
+	}
+	return obj;
+}
+
+QJsonArray AgentControlService::trackArray() const
+{
+	QJsonArray tracksJson;
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return tracksJson;
+	}
+
+	int index = 0;
+	for( const auto *track : song->tracks() )
+	{
+		tracksJson.append( trackObject( track, index ) );
+		++index;
+	}
+	return tracksJson;
+}
+
+QJsonArray AgentControlService::listPatternArray() const
+{
+	QJsonArray patterns;
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return patterns;
+	}
+
+	int trackIdx = 0;
+	for( auto *track : song->tracks() )
+	{
+		int clipIdx = 0;
+		for( auto *clip : track->getClips() )
+		{
+			if( auto *midiClip = dynamic_cast<MidiClip *>( clip ) )
+			{
+				patterns.append( QJsonObject
+				{
+					{ "track_id", QString( "t_%1" ).arg( trackIdx ) },
+					{ "track_name", track->name() },
+					{ "clip_index", clipIdx },
+					{ "clip_name", midiClip->name() },
+					{ "start_tick", static_cast<int>( midiClip->startPosition() ) },
+					{ "length_ticks", static_cast<int>( midiClip->length() ) },
+					{ "note_count", static_cast<int>( midiClip->notes().size() ) }
+				} );
+			}
+			++clipIdx;
+		}
+		++trackIdx;
+	}
+	return patterns;
+}
+
+QJsonObject AgentControlService::projectStateObject() const
+{
+	QJsonObject state;
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return state;
+	}
+
+	state.insert( "project_file", song->projectFileName() );
+	state.insert( "tempo", song->getTempo() );
+	state.insert( "track_count", static_cast<int>( song->tracks().size() ) );
+	state.insert( "selected_track", m_selectedTrackName );
+	state.insert( "tracks", trackArray() );
+	return state;
+}
+
+QJsonObject AgentControlService::diffState( const QJsonObject& before, const QJsonObject& after ) const
+{
+	QJsonObject diff;
+	diff.insert( "track_count_before", before.value( "track_count" ).toInt() );
+	diff.insert( "track_count_after", after.value( "track_count" ).toInt() );
+	diff.insert( "tempo_before", before.value( "tempo" ).toInt() );
+	diff.insert( "tempo_after", after.value( "tempo" ).toInt() );
+
+	QSet<QString> beforeTracks;
+	QSet<QString> afterTracks;
+	for( const auto &value : before.value( "tracks" ).toArray() )
+	{
+		beforeTracks.insert( value.toObject().value( "name" ).toString() );
+	}
+	for( const auto &value : after.value( "tracks" ).toArray() )
+	{
+		afterTracks.insert( value.toObject().value( "name" ).toString() );
+	}
+
+	int added = 0;
+	for( const auto &name : afterTracks )
+	{
+		if( !beforeTracks.contains( name ) )
+		{
+			++added;
+		}
+	}
+
+	int removed = 0;
+	for( const auto &name : beforeTracks )
+	{
+		if( !afterTracks.contains( name ) )
+		{
+			++removed;
+		}
+	}
+
+	diff.insert( "tracks_added", added );
+	diff.insert( "tracks_removed", removed );
+	diff.insert( "selected_track_before", before.value( "selected_track" ).toString() );
+	diff.insert( "selected_track_after", after.value( "selected_track" ).toString() );
+	return diff;
+}
+
+Track* AgentControlService::resolveTrackRef( const QJsonObject& args ) const
+{
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return nullptr;
+	}
+
+	const QString trackId = args.value( "track_id" ).toString().trimmed();
+	if( !trackId.isEmpty() )
+	{
+		const QRegularExpression re( "^t_(\\d+)$" );
+		const auto match = re.match( trackId );
+		if( match.hasMatch() )
+		{
+			const int idx = match.captured( 1 ).toInt();
+			if( idx >= 0 && idx < static_cast<int>( song->tracks().size() ) )
+			{
+				return song->tracks()[idx];
+			}
+		}
+	}
+
+	QString trackName = args.value( "track" ).toString().trimmed();
+	if( trackName.isEmpty() )
+	{
+		trackName = args.value( "track_name" ).toString().trimmed();
+	}
+	if( trackName.isEmpty() )
+	{
+		trackName = m_selectedTrackName;
+	}
+	if( trackName.isEmpty() )
+	{
+		return nullptr;
+	}
+
+	if( auto *exact = findTrackByName( trackName ) )
+	{
+		return exact;
+	}
+
+	const QString wanted = normalizeName( trackName );
+	for( auto *track : song->tracks() )
+	{
+		if( normalizeName( track->name() ).contains( wanted ) )
+		{
+			return track;
+		}
+	}
+	return nullptr;
+}
+
+InstrumentTrack* AgentControlService::resolveInstrumentTrack( const QJsonObject& args ) const
+{
+	return dynamic_cast<InstrumentTrack *>( resolveTrackRef( args ) );
+}
+
+SampleTrack* AgentControlService::resolveSampleTrack( const QJsonObject& args ) const
+{
+	return dynamic_cast<SampleTrack *>( resolveTrackRef( args ) );
+}
+
+QString AgentControlService::resolveInstrumentPlugin( const QString& pluginName, QString& displayName ) const
+{
+	const QString wanted = normalizeName( pluginName );
+	QString fuzzyMatch;
+	QString fuzzyDisplay;
+
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Instrument ) )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
+		const QString byDisplay = normalizeName( QString::fromUtf8( desc->displayName ) );
+		if( byName == wanted || byDisplay == wanted )
+		{
+			displayName = QString::fromUtf8( desc->displayName );
+			return QString::fromUtf8( desc->name );
+		}
+		if( fuzzyMatch.isEmpty() && ( byName.contains( wanted ) || byDisplay.contains( wanted ) ) )
+		{
+			fuzzyMatch = QString::fromUtf8( desc->name );
+			fuzzyDisplay = QString::fromUtf8( desc->displayName );
+		}
+	}
+
+	displayName = fuzzyDisplay;
+	return fuzzyMatch;
+}
+
+QString AgentControlService::resolveEffectPlugin( const QString& effectName, QString& displayName ) const
+{
+	const QString wanted = normalizeName( effectName );
+	QString fuzzyMatch;
+	QString fuzzyDisplay;
+
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Effect ) )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
+		const QString byDisplay = normalizeName( QString::fromUtf8( desc->displayName ) );
+		if( byName == wanted || byDisplay == wanted )
+		{
+			displayName = QString::fromUtf8( desc->displayName );
+			return QString::fromUtf8( desc->name );
+		}
+		if( fuzzyMatch.isEmpty() && ( byName.contains( wanted ) || byDisplay.contains( wanted ) ) )
+		{
+			fuzzyMatch = QString::fromUtf8( desc->name );
+			fuzzyDisplay = QString::fromUtf8( desc->displayName );
+		}
+	}
+
+	displayName = fuzzyDisplay;
+	return fuzzyMatch;
+}
+
+QJsonArray AgentControlService::availableWindows() const
+{
+	return QJsonArray
+	{
+		"song editor",
+		"pattern editor",
+		"piano roll",
+		"automation editor",
+		"mixer",
+		"controller rack",
+		"project notes",
+		"microtuner"
+	};
+}
+
+QJsonArray AgentControlService::availableTools() const
+{
+	QJsonArray tools;
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Tool ) )
+	{
+		tools.append( QJsonObject
+		{
+			{ "name", QString::fromUtf8( desc->name ) },
+			{ "display_name", QString::fromUtf8( desc->displayName ) }
+		} );
+	}
+	return tools;
+}
+
+QJsonArray AgentControlService::availableInstruments() const
+{
+	QJsonArray instruments;
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Instrument ) )
+	{
+		instruments.append( QJsonObject
+		{
+			{ "name", QString::fromUtf8( desc->name ) },
+			{ "display_name", QString::fromUtf8( desc->displayName ) }
+		} );
+	}
+	return instruments;
+}
+
+QJsonArray AgentControlService::availableEffects() const
+{
+	QJsonArray effects;
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Effect ) )
+	{
+		effects.append( QJsonObject
+		{
+			{ "name", QString::fromUtf8( desc->name ) },
+			{ "display_name", QString::fromUtf8( desc->displayName ) }
+		} );
+	}
+	return effects;
+}
+
+QJsonArray AgentControlService::searchProjectAudio( const QString& query ) const
+{
+	QJsonArray matches;
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return matches;
+	}
+
+	const QString wanted = query.trimmed().toLower();
+	for( auto *track : song->tracks() )
+	{
+		auto *sampleTrack = dynamic_cast<SampleTrack *>( track );
+		if( sampleTrack == nullptr )
+		{
+			continue;
+		}
+		int clipIdx = 0;
+		for( auto *clip : sampleTrack->getClips() )
+		{
+			auto *sampleClip = dynamic_cast<SampleClip *>( clip );
+			if( sampleClip == nullptr )
+			{
+				++clipIdx;
+				continue;
+			}
+			const QString path = sampleClip->sampleFile();
+			if( wanted.isEmpty() || path.toLower().contains( wanted ) || QFileInfo( path ).fileName().toLower().contains( wanted ) )
+			{
+				matches.append( QJsonObject
+				{
+					{ "track_name", track->name() },
+					{ "clip_index", clipIdx },
+					{ "sample_path", path }
+				} );
+			}
+			++clipIdx;
+		}
+	}
+	return matches;
+}
+
+bool AgentControlService::createSnapshot( const QString& label, QJsonObject& result, QString& error )
+{
+	if( Engine::getSong() == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+
+	Snapshot snapshot;
+	snapshot.id = QString( "snap_%1" ).arg( ++m_snapshotCounter );
+	snapshot.label = label.isEmpty() ? snapshot.id : label;
+	snapshot.state = projectStateObject();
+	snapshot.actionCounter = m_actionCounter;
+	m_snapshots.insert( snapshot.id, snapshot );
+
+	result = QJsonObject
+	{
+		{ "snapshot_id", snapshot.id },
+		{ "label", snapshot.label },
+		{ "action_counter", snapshot.actionCounter }
+	};
+	return true;
+}
+
+bool AgentControlService::undoLastAction( QJsonObject& result, QString& error )
+{
+	ProjectJournal* journal = Engine::projectJournal();
+	if( journal == nullptr || !journal->canUndo() )
+	{
+		error = tr( "Nothing to undo" );
+		return false;
+	}
+
+	journal->undo();
+	if( m_actionCounter > 0 )
+	{
+		--m_actionCounter;
+	}
+	result = QJsonObject
+	{
+		{ "undone", true },
+		{ "action_counter", m_actionCounter }
+	};
+	return true;
+}
+
+bool AgentControlService::rollbackSnapshot( const QString& snapshotId, QJsonObject& result, QString& error )
+{
+	if( snapshotId.isEmpty() || !m_snapshots.contains( snapshotId ) )
+	{
+		error = tr( "Snapshot not found: %1" ).arg( snapshotId );
+		return false;
+	}
+	ProjectJournal* journal = Engine::projectJournal();
+	if( journal == nullptr )
+	{
+		error = tr( "Project journal is unavailable" );
+		return false;
+	}
+
+	const Snapshot snapshot = m_snapshots.value( snapshotId );
+	int undosRequired = m_actionCounter - snapshot.actionCounter;
+	if( undosRequired < 0 )
+	{
+		undosRequired = 0;
+	}
+
+	int applied = 0;
+	while( undosRequired > 0 && journal->canUndo() )
+	{
+		journal->undo();
+		--undosRequired;
+		++applied;
+	}
+
+	m_actionCounter = snapshot.actionCounter + undosRequired;
+	result = QJsonObject
+	{
+		{ "snapshot_id", snapshotId },
+		{ "undos_applied", applied },
+		{ "action_counter", m_actionCounter }
+	};
+	return true;
+}
+
+bool AgentControlService::diffSinceSnapshot( const QString& snapshotId, QJsonObject& result, QString& error ) const
+{
+	if( snapshotId.isEmpty() || !m_snapshots.contains( snapshotId ) )
+	{
+		error = tr( "Snapshot not found: %1" ).arg( snapshotId );
+		return false;
+	}
+
+	const Snapshot snapshot = m_snapshots.value( snapshotId );
+	result = QJsonObject
+	{
+		{ "snapshot_id", snapshotId },
+		{ "diff", diffState( snapshot.state, projectStateObject() ) }
+	};
+	return true;
+}
+
+bool AgentControlService::loadSampleToTrack(
+	const QString& samplePath,
+	const QString& trackName,
+	QJsonObject& result,
+	QString& error )
+{
+	const QString fullPath = canonicalPath( samplePath );
+	if( fullPath.isEmpty() )
+	{
+		error = tr( "File not found: %1" ).arg( samplePath );
+		return false;
+	}
+
+	SampleTrack* track = nullptr;
+	if( !trackName.isEmpty() )
+	{
+		track = dynamic_cast<SampleTrack *>( findTrackByName( trackName ) );
+		if( track == nullptr )
+		{
+			track = createSampleTrack( trackName );
+		}
+	}
+	else if( !m_selectedTrackName.isEmpty() )
+	{
+		track = dynamic_cast<SampleTrack *>( findTrackByName( m_selectedTrackName ) );
+	}
+	if( track == nullptr )
+	{
+		track = createSampleTrack( QFileInfo( fullPath ).baseName() );
+	}
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	if( !addSampleClip( track, fullPath, 0 ) )
+	{
+		error = tr( "Failed to add sample clip" );
+		return false;
+	}
+
+	m_selectedTrackName = track->name();
+	result = QJsonObject
+	{
+		{ "sample_path", fullPath },
+		{ "track", trackObject( track, trackIndex( track ) ) }
+	};
+	return true;
+}
+
+bool AgentControlService::setTempoValue( int tempo, QJsonObject& result, QString& error )
+{
+	Song* song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+	if( tempo < MinTempo || tempo > MaxTempo )
+	{
+		error = tr( "Tempo must be between %1 and %2" ).arg( MinTempo ).arg( MaxTempo );
+		return false;
+	}
+
+	const int oldTempo = song->getTempo();
+	song->setTempo( tempo );
+	result = QJsonObject
+	{
+		{ "tempo_before", oldTempo },
+		{ "tempo_after", song->getTempo() }
+	};
+	return true;
+}
+
+bool AgentControlService::renameTrack(
+	const QString& trackName,
+	const QString& newName,
+	QJsonObject& result,
+	QString& error )
+{
+	if( newName.isEmpty() )
+	{
+		error = tr( "new_name must not be empty" );
+		return false;
+	}
+
+	Track* track = findTrackByName( trackName.isEmpty() ? m_selectedTrackName : trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName );
+		return false;
+	}
+
+	const QString oldName = track->name();
+	track->setName( newName );
+	m_selectedTrackName = track->name();
+	result = QJsonObject
+	{
+		{ "old_name", oldName },
+		{ "new_name", track->name() },
+		{ "track", trackObject( track, trackIndex( track ) ) }
+	};
+	return true;
+}
+
+bool AgentControlService::selectTrack( const QString& trackName, QJsonObject& result, QString& error )
+{
+	Track* track = findTrackByName( trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName );
+		return false;
+	}
+	m_selectedTrackName = track->name();
+	result = QJsonObject
+	{
+		{ "selected_track", track->name() },
+		{ "track", trackObject( track, trackIndex( track ) ) }
+	};
+	return true;
+}
+
+bool AgentControlService::setTrackMute( const QString& trackName, bool mute, QJsonObject& result, QString& error )
+{
+	Track* track = findTrackByName( trackName.isEmpty() ? m_selectedTrackName : trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName );
+		return false;
+	}
+	track->setMuted( mute );
+	result = QJsonObject
+	{
+		{ "track", track->name() },
+		{ "muted", track->isMuted() }
+	};
+	return true;
+}
+
+bool AgentControlService::setTrackSolo( const QString& trackName, bool solo, QJsonObject& result, QString& error )
+{
+	Track* track = findTrackByName( trackName.isEmpty() ? m_selectedTrackName : trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName );
+		return false;
+	}
+	track->setSolo( solo );
+	result = QJsonObject
+	{
+		{ "track", track->name() },
+		{ "solo", track->isSolo() }
+	};
+	return true;
+}
+
+bool AgentControlService::createPatternClip( const QJsonObject& args, QJsonObject& result, QString& error )
+{
+	InstrumentTrack* track = resolveInstrumentTrack( args );
+	if( track == nullptr )
+	{
+		track = dynamic_cast<InstrumentTrack *>( findLastTrackOfTypes( { Track::Type::Instrument } ) );
+	}
+	if( track == nullptr )
+	{
+		error = tr( "No instrument track available for create_pattern" );
+		return false;
+	}
+
+	const int tick = args.value( "tick" ).toInt( 0 );
+	Clip* clip = track->createClip( TimePos( tick ) );
+	if( clip == nullptr )
+	{
+		error = tr( "Failed to create pattern clip" );
+		return false;
+	}
+	const QString clipName = args.value( "name" ).toString().trimmed();
+	if( !clipName.isEmpty() )
+	{
+		clip->setName( clipName );
+	}
+
+	m_selectedTrackName = track->name();
+	result = QJsonObject
+	{
+		{ "track", track->name() },
+		{ "clip_index", track->getClipNum( clip ) },
+		{ "clip_name", clip->name() },
+		{ "start_tick", tick }
+	};
+	return true;
+}
+
+bool AgentControlService::addNotesToPattern( const QJsonObject& args, QJsonObject& result, QString& error )
+{
+	InstrumentTrack* track = resolveInstrumentTrack( args );
+	if( track == nullptr )
+	{
+		track = dynamic_cast<InstrumentTrack *>( findLastTrackOfTypes( { Track::Type::Instrument } ) );
+	}
+	if( track == nullptr )
+	{
+		error = tr( "No instrument track available for add_notes" );
+		return false;
+	}
+
+	MidiClip* targetClip = nullptr;
+	const int requestedClipIndex = args.value( "clip_index" ).toInt( -1 );
+	if( requestedClipIndex >= 0 && requestedClipIndex < static_cast<int>( track->getClips().size() ) )
+	{
+		targetClip = dynamic_cast<MidiClip *>( track->getClip( static_cast<std::size_t>( requestedClipIndex ) ) );
+	}
+	if( targetClip == nullptr )
+	{
+		for( auto it = track->getClips().rbegin(); it != track->getClips().rend(); ++it )
+		{
+			targetClip = dynamic_cast<MidiClip *>( *it );
+			if( targetClip != nullptr )
+			{
+				break;
+			}
+		}
+	}
+	if( targetClip == nullptr )
+	{
+		Clip* clip = track->createClip( TimePos( 0 ) );
+		targetClip = dynamic_cast<MidiClip *>( clip );
+	}
+	if( targetClip == nullptr )
+	{
+		error = tr( "Failed to resolve target pattern clip" );
+		return false;
+	}
+
+	QJsonArray notes = args.value( "notes" ).toArray();
+	if( notes.isEmpty() && args.contains( "key" ) )
+	{
+		notes.append( QJsonObject
+		{
+			{ "key", args.value( "key" ).toInt( DefaultKey ) },
+			{ "pos", args.value( "pos" ).toInt( 0 ) },
+			{ "length", args.value( "length" ).toInt( DefaultTicksPerBar / 4 ) },
+			{ "velocity", args.value( "velocity" ).toInt( 100 ) }
+		} );
+	}
+	if( notes.isEmpty() )
+	{
+		error = tr( "add_notes requires notes array or key/pos/length fields" );
+		return false;
+	}
+
+	int added = 0;
+	for( const auto &entry : notes )
+	{
+		const QJsonObject noteObj = entry.toObject();
+		const int key = noteObj.value( "key" ).toInt( DefaultKey );
+		const int pos = noteObj.value( "pos" ).toInt( 0 );
+		const int length = noteObj.value( "length" ).toInt( DefaultTicksPerBar / 4 );
+		const int velocity = qBound( 1, noteObj.value( "velocity" ).toInt( 100 ), 200 );
+		Note note( TimePos( length ), TimePos( pos ), key, velocity );
+		targetClip->addNote( note, false );
+		++added;
+	}
+	targetClip->updateLength();
+
+	result = QJsonObject
+	{
+		{ "track", track->name() },
+		{ "clip_index", track->getClipNum( targetClip ) },
+		{ "notes_added", added }
+	};
+	return true;
+}
+
+bool AgentControlService::addStepsToPattern( const QJsonObject& args, QJsonObject& result, QString& error )
+{
+	InstrumentTrack* track = resolveInstrumentTrack( args );
+	if( track == nullptr )
+	{
+		track = dynamic_cast<InstrumentTrack *>( findLastTrackOfTypes( { Track::Type::Instrument } ) );
+	}
+	if( track == nullptr )
+	{
+		error = tr( "No instrument track available for add_steps" );
+		return false;
+	}
+
+	MidiClip* targetClip = nullptr;
+	const int requestedClipIndex = args.value( "clip_index" ).toInt( -1 );
+	if( requestedClipIndex >= 0 && requestedClipIndex < static_cast<int>( track->getClips().size() ) )
+	{
+		targetClip = dynamic_cast<MidiClip *>( track->getClip( static_cast<std::size_t>( requestedClipIndex ) ) );
+	}
+	if( targetClip == nullptr )
+	{
+		for( auto it = track->getClips().rbegin(); it != track->getClips().rend(); ++it )
+		{
+			targetClip = dynamic_cast<MidiClip *>( *it );
+			if( targetClip != nullptr )
+			{
+				break;
+			}
+		}
+	}
+	if( targetClip == nullptr )
+	{
+		Clip* clip = track->createClip( TimePos( 0 ) );
+		targetClip = dynamic_cast<MidiClip *>( clip );
+	}
+	if( targetClip == nullptr )
+	{
+		error = tr( "Failed to resolve target pattern clip" );
+		return false;
+	}
+
+	if( args.value( "clear_existing" ).toBool( false ) )
+	{
+		targetClip->clearNotes();
+	}
+
+	QJsonArray steps = args.value( "steps" ).toArray();
+	if( steps.isEmpty() )
+	{
+		steps = QJsonArray{ 0, 4, 8, 12 };
+	}
+
+	int added = 0;
+	for( const auto &stepValue : steps )
+	{
+		targetClip->setStep( stepValue.toInt(), true );
+		++added;
+	}
+
+	result = QJsonObject
+	{
+		{ "track", track->name() },
+		{ "clip_index", track->getClipNum( targetClip ) },
+		{ "steps_enabled", added }
+	};
+	return true;
 }
 
 } // namespace lmms

--- a/plugins/AgentControl/AgentControl.cpp
+++ b/plugins/AgentControl/AgentControl.cpp
@@ -1,0 +1,933 @@
+#include "AgentControl.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QHostAddress>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QMetaObject>
+#include <QStandardPaths>
+#include <QTimer>
+
+#include "ConfigManager.h"
+#include "Effect.h"
+#include "EffectChain.h"
+#include "Engine.h"
+#include "GuiApplication.h"
+#include "ImportFilter.h"
+#include "Instrument.h"
+#include "InstrumentTrack.h"
+#include "LmmsCommonMacros.h"
+#include "MainWindow.h"
+#include "PluginFactory.h"
+#include "SampleClip.h"
+#include "SampleTrack.h"
+#include "Song.h"
+#include "TimePos.h"
+#include "Track.h"
+#include "plugin_export.h"
+
+#include "AgentControlView.h"
+
+namespace lmms
+{
+
+extern "C"
+{
+Plugin::Descriptor PLUGIN_EXPORT AgentControl_plugin_descriptor =
+{
+	LMMS_STRINGIFY( PLUGIN_NAME ),
+	"Agent Control",
+	QT_TRANSLATE_NOOP( "PluginBrowser", "Voice/text command bridge for LMMS" ),
+	"codex",
+	0x0100,
+	Plugin::Type::Tool,
+	nullptr,
+	nullptr,
+	nullptr,
+};
+
+PLUGIN_EXPORT Plugin * lmms_plugin_main( Model *, void * )
+{
+	return new AgentControlPlugin;
+}
+}
+
+AgentControlPlugin::AgentControlPlugin() :
+	ToolPlugin( &AgentControl_plugin_descriptor, nullptr )
+{
+	connect( &m_server, &QTcpServer::newConnection, this, &AgentControlPlugin::onNewConnection );
+
+	if( !m_server.listen( QHostAddress::LocalHost, 7777 ) )
+	{
+		emit logMessage( tr( "IPC server failed: %1" ).arg( m_server.errorString() ) );
+	}
+	else
+	{
+		emit logMessage( tr( "IPC listening on 127.0.0.1:%1" ).arg( m_server.serverPort() ) );
+	}
+}
+
+AgentControlPlugin::~AgentControlPlugin()
+{
+	for( auto *client : m_clients )
+	{
+		if( client != nullptr )
+		{
+			client->disconnect( this );
+			client->close();
+			client->deleteLater();
+		}
+	}
+	m_clients.clear();
+	m_server.close();
+}
+
+QString AgentControlPlugin::nodeName() const
+{
+	return AgentControl_plugin_descriptor.name;
+}
+
+void AgentControlPlugin::saveSettings( QDomDocument&, QDomElement& )
+{
+}
+
+void AgentControlPlugin::loadSettings( const QDomElement& )
+{
+}
+
+gui::PluginView* AgentControlPlugin::instantiateView( QWidget* )
+{
+	return new gui::AgentControlView( this );
+}
+
+QString AgentControlPlugin::handleCommand( const QString& rawText )
+{
+	const QString trimmed = rawText.trimmed();
+	if( trimmed.isEmpty() )
+	{
+		return tr( "No command provided" );
+	}
+
+	const auto parts = trimmed.split( ' ', Qt::SkipEmptyParts );
+	return dispatchTokens( parts, trimmed );
+}
+
+QString AgentControlPlugin::handleJson( const QJsonObject& obj )
+{
+	QStringList tokens;
+	const QString command = obj.value( "command" ).toString().trimmed();
+	if( command.isEmpty() )
+	{
+		return tr( "Missing command field" );
+	}
+
+	tokens = command.split( ' ', Qt::SkipEmptyParts );
+
+	const QString file = obj.value( "file" ).toString().trimmed();
+	if( !file.isEmpty() )
+	{
+		tokens << file;
+	}
+
+	const QString path = obj.value( "path" ).toString().trimmed();
+	if( !path.isEmpty() )
+	{
+		tokens << path;
+	}
+
+	const QString plugin = obj.value( "plugin" ).toString().trimmed();
+	if( !plugin.isEmpty() )
+	{
+		tokens << plugin;
+	}
+
+	const QString track = obj.value( "track" ).toString().trimmed();
+	if( !track.isEmpty() )
+	{
+		tokens << "to" << track;
+	}
+
+	return dispatchTokens( tokens, command );
+}
+
+QString AgentControlPlugin::dispatchTokens( const QStringList& tokens, const QString& rawText )
+{
+	QString result;
+	QString error;
+	if( tokens.isEmpty() )
+	{
+		return tr( "No command provided" );
+	}
+
+	const QString first = tokens[0].toLower();
+
+	if( first == "new" )
+	{
+		if( tokens.size() >= 2 && tokens[1].compare( "project", Qt::CaseInsensitive ) == 0 )
+		{
+			return newProject( result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "sample", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Sample, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "instrument", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Instrument, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "automation", Qt::CaseInsensitive ) == 0 &&
+			tokens[2].compare( "track", Qt::CaseInsensitive ) == 0 )
+		{
+			return createTrack( Track::Type::Automation, result, error ) ? result : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "instrument", Qt::CaseInsensitive ) == 0 )
+		{
+			return createInstrumentTrack( joinTokens( tokens, 2 ), result, error ) ? result : error;
+		}
+	}
+
+	if( first == "show" )
+	{
+		if( tokens.size() >= 3 && tokens[1].compare( "tool", Qt::CaseInsensitive ) == 0 )
+		{
+			return showToolCommand( joinTokens( tokens, 2 ), result, error ) ? result : error;
+		}
+		return showWindowCommand( joinTokens( tokens, 1 ), result, error ) ? result : error;
+	}
+
+	if( first == "open" )
+	{
+		if( tokens.size() >= 2 && tokens[1].compare( "project", Qt::CaseInsensitive ) == 0 )
+		{
+			return openProject( joinTokens( tokens, 2 ), result, error ) ? result : error;
+		}
+		if( tokens.size() >= 2 && normalizeName( joinTokens( tokens, 1 ) ) == "slicer" )
+		{
+			return createInstrumentTrack( "slicert", result, error ) ? result : error;
+		}
+	}
+
+	if( first == "save" )
+	{
+		if( tokens.size() >= 2 && tokens[1].compare( "project", Qt::CaseInsensitive ) == 0 )
+		{
+			if( tokens.size() >= 4 && tokens[2].compare( "as", Qt::CaseInsensitive ) == 0 )
+			{
+				return saveProjectAs( joinTokens( tokens, 3 ), result, error ) ? result : error;
+			}
+			return saveProject( result, error ) ? result : error;
+		}
+	}
+
+	if( first == "import" )
+	{
+		if( tokens.size() >= 3 && tokens[1].compare( "audio", Qt::CaseInsensitive ) == 0 )
+		{
+			return importAudioFile( joinTokens( tokens, 2 ), error ) ? tr( "Imported %1" ).arg( joinTokens( tokens, 2 ) ) : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "midi", Qt::CaseInsensitive ) == 0 )
+		{
+			return importProjectFile( joinTokens( tokens, 2 ), error ) ? tr( "Imported MIDI %1" ).arg( joinTokens( tokens, 2 ) ) : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "hydrogen", Qt::CaseInsensitive ) == 0 )
+		{
+			return importProjectFile( joinTokens( tokens, 2 ), error ) ? tr( "Imported Hydrogen project %1" ).arg( joinTokens( tokens, 2 ) ) : error;
+		}
+		if( tokens.size() >= 2 )
+		{
+			const QString fileName = joinTokens( tokens, 1 );
+			if( importAudioFile( fileName, error ) )
+			{
+				return tr( "Imported %1" ).arg( fileName );
+			}
+			if( importFromDownloads( fileName, error ) )
+			{
+				return tr( "Imported %1" ).arg( fileName );
+			}
+			return error;
+		}
+	}
+
+	if( first == "load" || first == "set" )
+	{
+		if( tokens.size() >= 3 && tokens[1].compare( "instrument", Qt::CaseInsensitive ) == 0 )
+		{
+			return createInstrumentTrack( joinTokens( tokens, 2 ), result, error ) ? result : error;
+		}
+	}
+
+	if( first == "add" )
+	{
+		if( rawText.contains( "808", Qt::CaseInsensitive ) || rawText.contains( "kick", Qt::CaseInsensitive ) )
+		{
+			return addKickPattern( error ) ? tr( "Added kick pattern" ) : error;
+		}
+		if( tokens.size() >= 3 && tokens[1].compare( "effect", Qt::CaseInsensitive ) == 0 )
+		{
+			int toIndex = tokens.indexOf( "to" );
+			const QString effectName = toIndex > 2 ? tokens.mid( 2, toIndex - 2 ).join( " " ) : joinTokens( tokens, 2 );
+			const QString trackName = toIndex >= 0 ? joinTokens( tokens, toIndex + 1 ) : QString();
+			return addEffectToTrack( effectName, trackName, result, error ) ? result : error;
+		}
+	}
+
+	if( first == "remove" )
+	{
+		if( tokens.size() >= 3 && tokens[1].compare( "effect", Qt::CaseInsensitive ) == 0 )
+		{
+			int fromIndex = tokens.indexOf( "from" );
+			const QString effectName = fromIndex > 2 ? tokens.mid( 2, fromIndex - 2 ).join( " " ) : joinTokens( tokens, 2 );
+			const QString trackName = fromIndex >= 0 ? joinTokens( tokens, fromIndex + 1 ) : QString();
+			return removeEffectFromTrack( effectName, trackName, result, error ) ? result : error;
+		}
+	}
+
+	return tr( "Unknown command: %1" ).arg( rawText );
+}
+
+void AgentControlPlugin::onNewConnection()
+{
+	while( m_server.hasPendingConnections() )
+	{
+		QTcpSocket *sock = m_server.nextPendingConnection();
+		m_clients.insert( sock );
+		connect( sock, &QTcpSocket::readyRead, this, &AgentControlPlugin::onSocketReady );
+		connect( sock, &QTcpSocket::disconnected, this, &AgentControlPlugin::onSocketClosed );
+		emit logMessage( tr( "Client connected" ) );
+	}
+}
+
+void AgentControlPlugin::onSocketReady()
+{
+	auto *sock = qobject_cast<QTcpSocket *>( sender() );
+	if( !sock )
+	{
+		return;
+	}
+
+	const QByteArray payload = sock->readAll();
+	for( const QByteArray &line : payload.split( '\n' ) )
+	{
+		if( line.trimmed().isEmpty() )
+		{
+			continue;
+		}
+
+		QJsonParseError parseError {};
+		const QJsonDocument doc = QJsonDocument::fromJson( line, &parseError );
+		const QString result = parseError.error == QJsonParseError::NoError && doc.isObject()
+			? handleJson( doc.object() )
+			: handleCommand( QString::fromUtf8( line ) );
+
+		emit commandResult( result );
+		const QJsonObject reply {{ "result", result }};
+		sock->write( QJsonDocument( reply ).toJson( QJsonDocument::Compact ) + "\n" );
+		sock->flush();
+	}
+}
+
+void AgentControlPlugin::onSocketClosed()
+{
+	auto *sock = qobject_cast<QTcpSocket *>( sender() );
+	if( !sock )
+	{
+		return;
+	}
+	m_clients.remove( sock );
+	sock->deleteLater();
+	emit logMessage( tr( "Client disconnected" ) );
+}
+
+bool AgentControlPlugin::newProject( QString& result, QString& error )
+{
+	Song *song = Engine::getSong();
+	auto *guiApp = gui::getGUI();
+	if( song == nullptr || guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+	QTimer::singleShot( 100, guiApp->mainWindow(), [song]()
+	{
+		song->createNewProject();
+	} );
+	result = tr( "Queued new project" );
+	return true;
+}
+
+bool AgentControlPlugin::openProject( const QString& path, QString& result, QString& error )
+{
+	const QString fullPath = canonicalPath( path );
+	if( fullPath.isEmpty() )
+	{
+		error = tr( "Project not found: %1" ).arg( path );
+		return false;
+	}
+	Song *song = Engine::getSong();
+	auto *guiApp = gui::getGUI();
+	if( song == nullptr || guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+	QTimer::singleShot( 100, guiApp->mainWindow(), [song, fullPath]()
+	{
+		song->loadProject( fullPath );
+	} );
+	result = tr( "Queued open project %1" ).arg( QFileInfo( fullPath ).fileName() );
+	return true;
+}
+
+bool AgentControlPlugin::saveProject( QString& result, QString& error )
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+	if( song->projectFileName().isEmpty() )
+	{
+		error = tr( "Project has no filename. Use save project as <path>" );
+		return false;
+	}
+	if( !song->guiSaveProject() )
+	{
+		error = tr( "Save failed" );
+		return false;
+	}
+	result = tr( "Saved project %1" ).arg( QFileInfo( song->projectFileName() ).fileName() );
+	return true;
+}
+
+bool AgentControlPlugin::saveProjectAs( const QString& path, QString& result, QString& error )
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+	const QString fullPath = QFileInfo( path ).isAbsolute()
+		? QDir::cleanPath( path )
+		: QDir::current().absoluteFilePath( path );
+	if( !song->guiSaveProjectAs( fullPath ) )
+	{
+		error = tr( "Save failed for %1" ).arg( fullPath );
+		return false;
+	}
+	result = tr( "Saved project as %1" ).arg( fullPath );
+	return true;
+}
+
+bool AgentControlPlugin::showWindowCommand( const QString& windowName, QString& result, QString& error )
+{
+	auto *guiApp = gui::getGUI();
+	if( guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+
+	const QString normalized = normalizeName( windowName );
+	const char *slot = nullptr;
+	if( normalized == "songeditor" )
+	{
+		slot = "toggleSongEditorWin";
+	}
+	else if( normalized == "patterneditor" )
+	{
+		slot = "togglePatternEditorWin";
+	}
+	else if( normalized == "pianoroll" )
+	{
+		slot = "togglePianoRollWin";
+	}
+	else if( normalized == "automationeditor" )
+	{
+		slot = "toggleAutomationEditorWin";
+	}
+	else if( normalized == "mixer" )
+	{
+		slot = "toggleMixerWin";
+	}
+	else if( normalized == "controllerrack" )
+	{
+		slot = "toggleControllerRack";
+	}
+	else if( normalized == "projectnotes" )
+	{
+		slot = "toggleProjectNotesWin";
+	}
+	else if( normalized == "microtuner" )
+	{
+		slot = "toggleMicrotunerWin";
+	}
+	else
+	{
+		error = tr( "Unknown window: %1" ).arg( windowName );
+		return false;
+	}
+
+	bool invoked = false;
+	if( normalized == "patterneditor" )
+	{
+		invoked = QMetaObject::invokeMethod( guiApp->mainWindow(), slot, Qt::DirectConnection,
+			Q_ARG( bool, true ) );
+	}
+	else
+	{
+		invoked = QMetaObject::invokeMethod( guiApp->mainWindow(), slot, Qt::DirectConnection );
+	}
+
+	if( !invoked )
+	{
+		error = tr( "Failed to show %1" ).arg( windowName );
+		return false;
+	}
+	result = tr( "Toggled %1" ).arg( windowName );
+	return true;
+}
+
+bool AgentControlPlugin::showToolCommand( const QString& toolName, QString& result, QString& error )
+{
+	const QString desired = normalizeName( toolName );
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Tool ) )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
+		const QString byDisplayName = normalizeName( QString::fromUtf8( desc->displayName ) );
+		if( desired != byName && desired != byDisplayName )
+		{
+			continue;
+		}
+
+		auto *tool = ToolPlugin::instantiate( QString::fromUtf8( desc->name ), nullptr );
+		if( tool == nullptr )
+		{
+			error = tr( "Failed to instantiate tool %1" ).arg( toolName );
+			return false;
+		}
+		auto *view = tool->createView( gui::getGUI()->mainWindow() );
+		if( view == nullptr )
+		{
+			delete tool;
+			error = tr( "Failed to create view for tool %1" ).arg( toolName );
+			return false;
+		}
+		view->show();
+		if( view->parentWidget() )
+		{
+			view->parentWidget()->show();
+		}
+		view->setFocus();
+		result = tr( "Opened tool %1" ).arg( QString::fromUtf8( desc->displayName ) );
+		return true;
+	}
+
+	error = tr( "Unknown tool: %1" ).arg( toolName );
+	return false;
+}
+
+bool AgentControlPlugin::createTrack( Track::Type type, QString& result, QString& error )
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+
+	Track *track = Track::create( type, song );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create track" );
+		return false;
+	}
+
+	result = tr( "Created %1" ).arg( track->name() );
+	return true;
+}
+
+bool AgentControlPlugin::createInstrumentTrack( const QString& pluginName, QString& result, QString& error )
+{
+	Song *song = Engine::getSong();
+	auto *guiApp = gui::getGUI();
+	if( song == nullptr || guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+
+	const QString requested = normalizeName( pluginName );
+	QString resolvedPlugin;
+	QString displayName = pluginName.trimmed();
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Instrument ) )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
+		const QString byDisplayName = normalizeName( QString::fromUtf8( desc->displayName ) );
+		if( requested == byName || requested == byDisplayName )
+		{
+			resolvedPlugin = QString::fromUtf8( desc->name );
+			displayName = QString::fromUtf8( desc->displayName );
+			break;
+		}
+	}
+	if( resolvedPlugin.isEmpty() )
+	{
+		error = tr( "Unknown instrument: %1" ).arg( pluginName );
+		return false;
+	}
+
+	QTimer::singleShot( 0, guiApp->mainWindow(), [song, resolvedPlugin]()
+	{
+		auto *track = dynamic_cast<InstrumentTrack *>( Track::create( Track::Type::Instrument, song ) );
+		if( track != nullptr )
+		{
+			track->loadInstrument( resolvedPlugin );
+		}
+	} );
+	result = tr( "Queued instrument %1" ).arg( displayName );
+	return true;
+}
+
+bool AgentControlPlugin::importFromDownloads( const QString& fileName, QString& error )
+{
+	return importAudioFile( resolveDownloadsFile( fileName ), error );
+}
+
+bool AgentControlPlugin::importAudioFile( const QString& path, QString& error )
+{
+	const QString fullPath = canonicalPath( path );
+	if( fullPath.isEmpty() )
+	{
+		error = tr( "File not found: %1" ).arg( path );
+		return false;
+	}
+	auto *track = createSampleTrack( QFileInfo( fullPath ).fileName() );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	auto *clip = dynamic_cast<SampleClip *>( track->createClip( TimePos( 0 ) ) );
+	if( clip == nullptr )
+	{
+		error = tr( "Failed to create sample clip" );
+		return false;
+	}
+
+	track->addClip( clip );
+	clip->setSampleFile( fullPath );
+	clip->updateLength();
+	return true;
+}
+
+bool AgentControlPlugin::importProjectFile( const QString& path, QString& error )
+{
+	const QString fullPath = canonicalPath( path );
+	if( fullPath.isEmpty() )
+	{
+		error = tr( "File not found: %1" ).arg( path );
+		return false;
+	}
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+	ImportFilter::import( fullPath, song );
+	return true;
+}
+
+bool AgentControlPlugin::addKickPattern( QString& error )
+{
+	const QString samplePath = defaultKickSample();
+	if( samplePath.isEmpty() )
+	{
+		error = tr( "Kick sample missing" );
+		return false;
+	}
+
+	auto *track = createSampleTrack( tr( "Agent 808" ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create sample track" );
+		return false;
+	}
+
+	const int stepTicks = DefaultTicksPerBar / DefaultStepsPerBar;
+	const int steps[] = { 0, 4, 8, 12 };
+	for( int s : steps )
+	{
+		addSampleClip( track, samplePath, s * stepTicks );
+	}
+	return true;
+}
+
+bool AgentControlPlugin::addEffectToTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
+{
+	Track *track = trackName.isEmpty()
+		? findLastTrackOfTypes( { Track::Type::Instrument, Track::Type::Sample } )
+		: findTrackByName( trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName.isEmpty() ? tr( "last audio track" ) : trackName );
+		return false;
+	}
+
+	if( effectChainForTrack( track ) == nullptr )
+	{
+		error = tr( "Track %1 does not support effects" ).arg( track->name() );
+		return false;
+	}
+
+	QString resolvedEffect;
+	QString displayName = effectName.trimmed();
+	const QString requested = normalizeName( effectName );
+	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors( Plugin::Type::Effect ) )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( desc->name ) );
+		const QString byDisplayName = normalizeName( QString::fromUtf8( desc->displayName ) );
+		if( requested == byName || requested == byDisplayName )
+		{
+			resolvedEffect = QString::fromUtf8( desc->name );
+			displayName = QString::fromUtf8( desc->displayName );
+			break;
+		}
+	}
+	if( resolvedEffect.isEmpty() )
+	{
+		error = tr( "Unknown effect: %1" ).arg( effectName );
+		return false;
+	}
+
+	const QString targetTrackName = track->name();
+	auto *guiApp = gui::getGUI();
+	if( guiApp == nullptr || guiApp->mainWindow() == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+
+	QTimer::singleShot( 0, guiApp->mainWindow(), [this, resolvedEffect, targetTrackName]()
+	{
+		Track *targetTrack = findTrackByName( targetTrackName );
+		if( targetTrack == nullptr )
+		{
+			return;
+		}
+
+		EffectChain *chain = effectChainForTrack( targetTrack );
+		if( chain == nullptr )
+		{
+			return;
+		}
+
+		if( auto *effect = Effect::instantiate( resolvedEffect, chain, nullptr ) )
+		{
+			chain->appendEffect( effect );
+		}
+	} );
+	result = tr( "Queued effect %1 for %2" ).arg( displayName, targetTrackName );
+	return true;
+}
+
+bool AgentControlPlugin::removeEffectFromTrack( const QString& effectName, const QString& trackName, QString& result, QString& error )
+{
+	Track *track = trackName.isEmpty()
+		? findLastTrackOfTypes( { Track::Type::Instrument, Track::Type::Sample } )
+		: findTrackByName( trackName );
+	if( track == nullptr )
+	{
+		error = tr( "Track not found: %1" ).arg( trackName.isEmpty() ? tr( "last audio track" ) : trackName );
+		return false;
+	}
+
+	EffectChain *chain = effectChainForTrack( track );
+	if( chain == nullptr )
+	{
+		error = tr( "Track %1 does not support effects" ).arg( track->name() );
+		return false;
+	}
+
+	const QString requested = normalizeName( effectName );
+	for( Effect *effect : chain->effects() )
+	{
+		const QString byName = normalizeName( QString::fromUtf8( effect->descriptor()->name ) );
+		const QString byDisplayName = normalizeName( effect->displayName() );
+		if( requested == byName || requested == byDisplayName )
+		{
+			const QString removedName = effect->displayName();
+			chain->removeEffect( effect );
+			delete effect;
+			result = tr( "Removed effect %1 from %2" ).arg( removedName, track->name() );
+			return true;
+		}
+	}
+
+	error = tr( "Effect %1 not found on %2" ).arg( effectName, track->name() );
+	return false;
+}
+
+Track* AgentControlPlugin::findTrackByName( const QString& trackName ) const
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return nullptr;
+	}
+
+	const QString wanted = normalizeName( trackName );
+	const auto &tracks = song->tracks();
+	for( auto it = tracks.rbegin(); it != tracks.rend(); ++it )
+	{
+		if( normalizeName( (*it)->name() ) == wanted )
+		{
+			return *it;
+		}
+	}
+	return nullptr;
+}
+
+Track* AgentControlPlugin::findLastTrackOfTypes( const QList<Track::Type>& types ) const
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return nullptr;
+	}
+
+	const auto &tracks = song->tracks();
+	for( auto it = tracks.rbegin(); it != tracks.rend(); ++it )
+	{
+		if( types.contains( (*it)->type() ) )
+		{
+			return *it;
+		}
+	}
+	return nullptr;
+}
+
+InstrumentTrack* AgentControlPlugin::findInstrumentTrack( const QString& trackName ) const
+{
+	return dynamic_cast<InstrumentTrack *>( findTrackByName( trackName ) );
+}
+
+SampleTrack* AgentControlPlugin::createSampleTrack( const QString& name ) const
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return nullptr;
+	}
+	auto *track = dynamic_cast<SampleTrack *>( Track::create( Track::Type::Sample, song ) );
+	if( track != nullptr && !name.isEmpty() )
+	{
+		track->setName( name );
+	}
+	return track;
+}
+
+EffectChain* AgentControlPlugin::effectChainForTrack( Track* track ) const
+{
+	if( auto *instrumentTrack = dynamic_cast<InstrumentTrack *>( track ) )
+	{
+		return instrumentTrack->audioBusHandle()->effects();
+	}
+	if( auto *sampleTrack = dynamic_cast<SampleTrack *>( track ) )
+	{
+		return sampleTrack->audioBusHandle()->effects();
+	}
+	return nullptr;
+}
+
+bool AgentControlPlugin::addSampleClip( SampleTrack *track, const QString& samplePath, int tickPos )
+{
+	auto *clip = dynamic_cast<SampleClip *>( track->createClip( TimePos( tickPos ) ) );
+	if( clip == nullptr )
+	{
+		return false;
+	}
+	track->addClip( clip );
+	clip->setSampleFile( samplePath );
+	clip->updateLength();
+	return true;
+}
+
+QString AgentControlPlugin::resolveDownloadsFile( const QString& fileName ) const
+{
+	if( fileName.isEmpty() )
+	{
+		return {};
+	}
+
+	QString downloads = QStandardPaths::writableLocation( QStandardPaths::DownloadLocation );
+	if( downloads.isEmpty() )
+	{
+		downloads = QDir::homePath() + "/Downloads";
+	}
+	const QString absPath = QDir( downloads ).filePath( fileName );
+	return QFile::exists( absPath ) ? absPath : QString{};
+}
+
+QString AgentControlPlugin::defaultKickSample() const
+{
+	const QString base = ConfigManager::inst()->factorySamplesDir();
+	const QString candidate = QDir( base ).filePath( "drums/bassdrum04.ogg" );
+	return QFile::exists( candidate ) ? candidate : QString{};
+}
+
+QString AgentControlPlugin::canonicalPath( const QString& path ) const
+{
+	if( path.isEmpty() )
+	{
+		return {};
+	}
+
+	const QFileInfo absoluteInfo( path );
+	if( absoluteInfo.isAbsolute() && absoluteInfo.exists() )
+	{
+		return absoluteInfo.canonicalFilePath();
+	}
+
+	const QString fromDownloads = resolveDownloadsFile( path );
+	if( !fromDownloads.isEmpty() )
+	{
+		return fromDownloads;
+	}
+
+	QFileInfo relativeInfo( QDir::current().absoluteFilePath( path ) );
+	if( relativeInfo.exists() )
+	{
+		return relativeInfo.canonicalFilePath();
+	}
+
+	return {};
+}
+
+QString AgentControlPlugin::joinTokens( const QStringList& tokens, int startIndex ) const
+{
+	return startIndex < tokens.size() ? tokens.mid( startIndex ).join( " " ).trimmed() : QString{};
+}
+
+QString AgentControlPlugin::normalizeName( const QString& text ) const
+{
+	QString out;
+	out.reserve( text.size() );
+	for( const QChar ch : text.toLower() )
+	{
+		if( ch.isLetterOrNumber() )
+		{
+			out.append( ch );
+		}
+	}
+	return out;
+}
+
+} // namespace lmms

--- a/plugins/AgentControl/AgentControl.cpp
+++ b/plugins/AgentControl/AgentControl.cpp
@@ -5,14 +5,24 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QHostAddress>
+#include <QEventLoop>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonParseError>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProcess>
+#include <QRegularExpressionMatch>
 #include <QMetaObject>
 #include <QRegularExpression>
 #include <QStandardPaths>
+#include <QThread>
 #include <QTimer>
+#include <QUrl>
+#include <QUrlQuery>
 #include <QUuid>
+#include <QVector>
 
 #include "ConfigManager.h"
 #include "Clip.h"
@@ -29,11 +39,14 @@
 #include "Note.h"
 #include "PluginFactory.h"
 #include "ProjectJournal.h"
+#include "SongEditor.h"
 #include "SampleClip.h"
 #include "SampleTrack.h"
 #include "Song.h"
 #include "TimePos.h"
 #include "Track.h"
+#include "InstrumentTrackView.h"
+#include "InstrumentTrackWindow.h"
 #include "plugin_export.h"
 
 #include "AgentControlView.h"
@@ -159,8 +172,716 @@ QString AgentControlService::handleCommand( const QString& rawText )
 		return tr( "No command provided" );
 	}
 
-	const auto parts = trimmed.split( ' ', Qt::SkipEmptyParts );
-	return dispatchTokens( parts, trimmed );
+	const QString directResult = dispatchCommandText( trimmed );
+	if( !isUnknownResponse( directResult ) )
+	{
+		return directResult;
+	}
+
+	const bool familiarRawIntent = isFamiliarIntentText( trimmed );
+
+	QString mappedCommand;
+	QString mapReason;
+	if( applyHeuristicMappings( trimmed, mappedCommand, mapReason ) &&
+		!mappedCommand.isEmpty() &&
+		normalizeName( mappedCommand ) != normalizeName( trimmed ) )
+	{
+		const bool familiarMappedIntent = isFamiliarIntentText( mappedCommand );
+		if( familiarRawIntent || familiarMappedIntent )
+		{
+			const QString mappedResult = dispatchCommandText( mappedCommand );
+			if( !isUnknownResponse( mappedResult ) )
+			{
+				const QString reasonSuffix = mapReason.isEmpty() ? QString() : tr( " (%1)" ).arg( mapReason );
+				return tr( "Interpreted as \"%1\"%2. %3" )
+					.arg( mappedCommand, reasonSuffix, mappedResult );
+			}
+		}
+	}
+
+	// Hard safety gate: do not run LLM/planner fallbacks for unrelated speech.
+	if( !familiarRawIntent )
+	{
+		return directResult;
+	}
+
+	const QString ollamaModel = qEnvironmentVariable( "LMMS_OLLAMA_MODEL" ).trimmed();
+	if( !ollamaModel.isEmpty() )
+	{
+		double confidence = 0.0;
+		QString ollamaError;
+		QString ollamaCommand;
+		if( resolveWithOllama( trimmed, ollamaCommand, confidence, ollamaError ) )
+		{
+			const bool familiar = isFamiliarIntentText( ollamaCommand );
+			const double threshold = qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).toDouble() > 0.0
+				? qEnvironmentVariable( "LMMS_OLLAMA_CONFIDENCE" ).toDouble()
+				: 0.78;
+			if( familiar && confidence >= threshold )
+			{
+				const QString ollamaResult = dispatchCommandText( ollamaCommand );
+				if( !isUnknownResponse( ollamaResult ) )
+				{
+					return tr( "Interpreted as \"%1\" (confidence %2). %3" )
+						.arg( ollamaCommand )
+						.arg( QString::number( confidence, 'f', 2 ) )
+						.arg( ollamaResult );
+				}
+			}
+		}
+		else if( !ollamaError.isEmpty() )
+		{
+			emit logMessage( tr( "Ollama fallback skipped: %1" ).arg( ollamaError ) );
+		}
+	}
+
+	QString plannerResult;
+	QString plannerError;
+	if( maybeRunTextAgentFallback( trimmed, plannerResult, plannerError ) )
+	{
+		return plannerResult;
+	}
+	if( !plannerError.isEmpty() )
+	{
+		emit logMessage( tr( "Text-agent fallback skipped: %1" ).arg( plannerError ) );
+	}
+
+	return directResult;
+}
+
+QString AgentControlService::dispatchCommandText( const QString& rawText )
+{
+	const QStringList tokens = tokenizeCommand( rawText );
+	return dispatchTokens( tokens, rawText );
+}
+
+QStringList AgentControlService::tokenizeCommand( const QString& rawText ) const
+{
+	const auto rawParts = rawText.split( ' ', Qt::SkipEmptyParts );
+	QStringList parts;
+	parts.reserve( rawParts.size() );
+
+	for( QString token : rawParts )
+	{
+		while( !token.isEmpty() && QStringLiteral( ".,!?;:\"'" ).contains( token.at( 0 ) ) )
+		{
+			token.remove( 0, 1 );
+		}
+		while( !token.isEmpty() && QStringLiteral( ".,!?;:\"'" ).contains( token.at( token.size() - 1 ) ) )
+		{
+			token.chop( 1 );
+		}
+		if( !token.isEmpty() )
+		{
+			parts << token;
+		}
+	}
+	return parts;
+}
+
+bool AgentControlService::isUnknownResponse( const QString& response ) const
+{
+	const QString normalized = response.trimmed();
+	return normalized.startsWith( "Unknown command:", Qt::CaseInsensitive ) ||
+		normalized.startsWith( "Unknown window:", Qt::CaseInsensitive ) ||
+		normalized.startsWith( "Unknown instrument:", Qt::CaseInsensitive );
+}
+
+bool AgentControlService::isFamiliarIntentText( const QString& rawText ) const
+{
+	const QString normalized = normalizeName( rawText );
+	const QStringList tokens = tokenizeCommand( rawText );
+	if( tokens.isEmpty() )
+	{
+		return false;
+	}
+
+	const QSet<QString> simpleCommands =
+	{
+		"undo", "version", "help"
+	};
+	if( simpleCommands.contains( normalizeName( tokens.first() ) ) )
+	{
+		return true;
+	}
+
+	const QSet<QString> actionKeywords =
+	{
+		"open", "show", "new", "create", "make", "import", "load", "set", "add", "remove",
+		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide",
+		"split", "slice", "raise", "lower", "increase", "decrease", "save", "list"
+	};
+	const QSet<QString> domainKeywords =
+	{
+		"project", "track", "instrument", "sample", "automation", "pattern", "mixer",
+		"piano", "roll", "editor", "song", "slicer", "splicer", "segment", "transient",
+		"slice", "effect", "plugin", "window", "tool", "file", "downloads"
+	};
+
+	bool hasAction = false;
+	bool hasDomain = false;
+	for( const QString& token : tokens )
+	{
+		const QString lowered = normalizeName( token );
+		if( actionKeywords.contains( lowered ) )
+		{
+			hasAction = true;
+		}
+		if( domainKeywords.contains( lowered ) )
+		{
+			hasDomain = true;
+		}
+	}
+	if( hasAction && hasDomain )
+	{
+		return true;
+	}
+
+	const QStringList keywords =
+	{
+		"open", "show", "new", "create", "make", "import", "load", "set", "add", "remove",
+		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide",
+		"split", "slice", "openslicer", "showslicer", "manualmap", "beginnerhelp"
+	};
+
+	for( const QString& keyword : keywords )
+	{
+		if( normalized.contains( keyword ) )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool AgentControlService::applyHeuristicMappings(
+	const QString& rawText,
+	QString& mappedCommand,
+	QString& reason ) const
+{
+	reason.clear();
+	mappedCommand = rawText.trimmed();
+	if( mappedCommand.isEmpty() )
+	{
+		return false;
+	}
+
+	const auto setReasonIfEmpty = [&reason]( const QString& value )
+	{
+		if( reason.isEmpty() )
+		{
+			reason = value;
+		}
+	};
+
+	auto lower = mappedCommand.toLower();
+
+	// Remove polite wrappers so command verbs are easier to parse.
+	bool removedConversationFiller = false;
+	const QRegularExpression leadingFiller(
+		R"(^(?:(?:hey|hi|yo|okay|ok|please|pls)\s+)*(?:(?:can|could|would)\s+(?:you|u)\s+)?(?:please|pls\s+)?(?:just\s+)?(?:hey\s+)?(?:can|could|would)?\s*(?:you|u)?\s*)",
+		QRegularExpression::CaseInsensitiveOption );
+	for( int i = 0; i < 2; ++i )
+	{
+		const QString before = mappedCommand;
+		mappedCommand.replace( leadingFiller, QString() );
+		mappedCommand.replace(
+			QRegularExpression( R"(\s+(?:please|pls|thanks|thank\s+you)\s*$)",
+				QRegularExpression::CaseInsensitiveOption ),
+			QString() );
+		mappedCommand = mappedCommand.simplified();
+		if( mappedCommand == before )
+		{
+			break;
+		}
+		removedConversationFiller = true;
+	}
+	if( removedConversationFiller )
+	{
+		setReasonIfEmpty( tr( "removed conversational filler" ) );
+	}
+	lower = mappedCommand.toLower();
+
+	if( lower.contains( "splicer" ) )
+	{
+		mappedCommand.replace( QRegularExpression( R"(\bsplicer\b)", QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "slicer" ) );
+		setReasonIfEmpty( tr( "corrected plugin name typo" ) );
+	}
+
+	struct RegexReplacement
+	{
+		const char* pattern;
+		const char* replacement;
+		const char* why;
+	};
+	const RegexReplacement regexReplacements[] =
+	{
+		{ R"(\bautomaton\b)", "automation", "corrected common typo" },
+		{ R"(\btepmo\b)", "tempo", "corrected common typo" },
+		{ R"(\binsrument\b)", "instrument", "corrected common typo" },
+		{ R"(\btrakc\b)", "track", "corrected common typo" },
+		{ R"(\bpattarn\b)", "pattern", "corrected common typo" },
+		{ R"(\beditr\b)", "editor", "corrected common typo" }
+	};
+	for( const auto& replacement : regexReplacements )
+	{
+		const QString before = mappedCommand;
+		mappedCommand.replace(
+			QRegularExpression( QString::fromLatin1( replacement.pattern ),
+				QRegularExpression::CaseInsensitiveOption ),
+			QString::fromLatin1( replacement.replacement ) );
+		if( mappedCommand != before )
+		{
+			setReasonIfEmpty( tr( replacement.why ) );
+		}
+	}
+	const QString beforeArticleDrop = mappedCommand;
+	mappedCommand.replace(
+		QRegularExpression( R"(\b(create|new|open|show|set|import|load|add|remove|make)\s+(?:a|an)\s+)",
+			QRegularExpression::CaseInsensitiveOption ),
+		QStringLiteral( "\\1 " ) );
+	if( mappedCommand != beforeArticleDrop )
+	{
+		setReasonIfEmpty( tr( "normalized command wording" ) );
+	}
+
+	// Normalize "make ... track" to existing create-track actions.
+	if( QRegularExpression( R"(^\s*make\s+.+\btrack\b)",
+			QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand.replace( QRegularExpression( R"(^\s*make\b)", QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "create" ) );
+		setReasonIfEmpty( tr( "normalized create-track phrasing" ) );
+	}
+
+	// Normalize "open the ... window/panel/view" variants.
+	const QString normalizedLower = normalizeName( mappedCommand );
+	if( normalizedLower.startsWith( "open" ) || normalizedLower.startsWith( "show" ) )
+	{
+		mappedCommand.replace(
+			QRegularExpression( R"(\b(the|window|panel|view)\b)", QRegularExpression::CaseInsensitiveOption ),
+			QString() );
+		mappedCommand = mappedCommand.simplified();
+
+		const QString openLower = normalizeName( mappedCommand );
+		if( openLower.contains( "song" ) && ( openLower.contains( "editor" ) || openLower.contains( "edit" ) ) )
+		{
+			mappedCommand = QStringLiteral( "open song editor" );
+			setReasonIfEmpty( tr( "normalized song editor window name" ) );
+		}
+		else if( openLower.contains( "automation" ) && openLower.contains( "editor" ) )
+		{
+			mappedCommand = QStringLiteral( "open automation editor" );
+			setReasonIfEmpty( tr( "normalized automation editor window name" ) );
+		}
+		else if( openLower.contains( "piano" ) && openLower.contains( "roll" ) )
+		{
+			mappedCommand = QStringLiteral( "open piano roll" );
+			setReasonIfEmpty( tr( "normalized piano roll window name" ) );
+		}
+		else if( openLower.contains( "mixer" ) || openLower.contains( "fxmixer" ) || openLower.contains( "effects" ) )
+		{
+			mappedCommand = QStringLiteral( "open mixer" );
+			setReasonIfEmpty( tr( "normalized mixer window name" ) );
+		}
+	}
+	const QString collapsed = normalizeName( mappedCommand );
+
+	// Convert inferred track-intent statements to explicit commands.
+	if( !collapsed.startsWith( "new" ) && !collapsed.startsWith( "create" ) )
+	{
+		if( collapsed.contains( "sampletrack" ) )
+		{
+			mappedCommand = QStringLiteral( "create sample track" );
+			setReasonIfEmpty( tr( "inferred sample track creation intent" ) );
+		}
+		else if( collapsed.contains( "instrumenttrack" ) )
+		{
+			mappedCommand = QStringLiteral( "create instrument track" );
+			setReasonIfEmpty( tr( "inferred instrument track creation intent" ) );
+		}
+		else if( collapsed.contains( "automationtrack" ) )
+		{
+			mappedCommand = QStringLiteral( "create automation track" );
+			setReasonIfEmpty( tr( "inferred automation track creation intent" ) );
+		}
+		else if( collapsed.contains( "patterntrack" ) )
+		{
+			mappedCommand = QStringLiteral( "create pattern track" );
+			setReasonIfEmpty( tr( "inferred pattern track creation intent" ) );
+		}
+	}
+
+	// "lets go 128 bpm" -> "set tempo to 128"
+	const QRegularExpression bpmPhrase( R"(\b(\d{2,3})\s*bpm\b)", QRegularExpression::CaseInsensitiveOption );
+	const auto bpmMatch = bpmPhrase.match( mappedCommand );
+	if( bpmMatch.hasMatch() && !normalizeName( mappedCommand ).contains( "settempo" ) )
+	{
+		mappedCommand = tr( "set tempo to %1" ).arg( bpmMatch.captured( 1 ) );
+		setReasonIfEmpty( tr( "inferred tempo set intent" ) );
+	}
+
+	// "divide into 16 segments" -> "divide into 16 equal segments"
+	if( QRegularExpression( R"(\bdivide\s+into\s+\d+\s+segments?\b)",
+			QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() &&
+		!QRegularExpression( R"(\bequal\b)", QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand.replace(
+			QRegularExpression( R"(\bsegments?\b)", QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "equal segments" ) );
+		setReasonIfEmpty( tr( "assumed equal segments" ) );
+	}
+
+	// "from download(s)" is metadata, not part of filename.
+	mappedCommand.replace(
+		QRegularExpression( R"(\bfrom\s+(?:my\s+)?downloads?(?:\s+folder)?\b)",
+			QRegularExpression::CaseInsensitiveOption ),
+		QString() );
+	mappedCommand = mappedCommand.simplified();
+
+	const QStringList knownTokens =
+	{
+		"open", "show", "new", "create", "make", "import", "load", "set", "add", "remove",
+		"mute", "unmute", "solo", "unsolo", "undo", "tempo", "bpm", "divide", "split",
+		"slice", "slicer", "track", "instrument", "sample", "automation", "pattern",
+		"mixer", "project", "downloads", "equal", "segments", "transient",
+		"song", "editor", "piano", "roll", "window"
+	};
+	auto editDistance = []( const QString& a, const QString& b )
+	{
+		const int n = a.size();
+		const int m = b.size();
+		if( n == 0 )
+		{
+			return m;
+		}
+		if( m == 0 )
+		{
+			return n;
+		}
+
+		QVector<int> prev( m + 1 );
+		QVector<int> curr( m + 1 );
+		for( int j = 0; j <= m; ++j )
+		{
+			prev[j] = j;
+		}
+		for( int i = 1; i <= n; ++i )
+		{
+			curr[0] = i;
+			for( int j = 1; j <= m; ++j )
+			{
+				const int cost = ( a[i - 1] == b[j - 1] ) ? 0 : 1;
+				curr[j] = qMin( qMin( curr[j - 1] + 1, prev[j] + 1 ), prev[j - 1] + cost );
+			}
+			prev.swap( curr );
+		}
+		return prev[m];
+	};
+	auto isSingleAdjacentTransposition = []( const QString& a, const QString& b )
+	{
+		if( a.size() != b.size() || a.size() < 2 )
+		{
+			return false;
+		}
+		int firstMismatch = -1;
+		int secondMismatch = -1;
+		for( int i = 0; i < a.size(); ++i )
+		{
+			if( a[i] != b[i] )
+			{
+				if( firstMismatch < 0 )
+				{
+					firstMismatch = i;
+				}
+				else if( secondMismatch < 0 )
+				{
+					secondMismatch = i;
+				}
+				else
+				{
+					return false;
+				}
+			}
+		}
+		if( firstMismatch < 0 || secondMismatch < 0 )
+		{
+			return false;
+		}
+		if( secondMismatch != firstMismatch + 1 )
+		{
+			return false;
+		}
+		return a[firstMismatch] == b[secondMismatch] && a[secondMismatch] == b[firstMismatch];
+	};
+
+	QStringList fuzzyTokens = tokenizeCommand( mappedCommand );
+	bool changedByFuzzy = false;
+	for( QString& token : fuzzyTokens )
+	{
+		const QString lowered = normalizeName( token );
+		if( lowered.size() < 4 || knownTokens.contains( lowered ) )
+		{
+			continue;
+		}
+
+		QString best;
+		int bestDistance = 2;
+		for( const QString& known : knownTokens )
+		{
+			int distance = editDistance( lowered, known );
+			if( distance > 1 && isSingleAdjacentTransposition( lowered, known ) )
+			{
+				distance = 1;
+			}
+			if( distance < bestDistance )
+			{
+				best = known;
+				bestDistance = distance;
+			}
+		}
+		if( bestDistance <= 1 && !best.isEmpty() )
+		{
+			token = best;
+			changedByFuzzy = true;
+		}
+	}
+	if( changedByFuzzy )
+	{
+		mappedCommand = fuzzyTokens.join( ' ' );
+		if( reason.isEmpty() )
+		{
+			reason = tr( "applied fuzzy token correction" );
+		}
+	}
+
+	// Final normalization after fuzzy correction.
+	if( QRegularExpression( R"(^\s*make\s+.+\btrack\b)",
+			QRegularExpression::CaseInsensitiveOption ).match( mappedCommand ).hasMatch() )
+	{
+		mappedCommand.replace( QRegularExpression( R"(^\s*make\b)", QRegularExpression::CaseInsensitiveOption ),
+			QStringLiteral( "create" ) );
+		setReasonIfEmpty( tr( "normalized create-track phrasing" ) );
+	}
+
+	mappedCommand = mappedCommand.simplified();
+
+	return normalizeName( mappedCommand ) != normalizeName( rawText );
+}
+
+bool AgentControlService::resolveWithOllama(
+	const QString& rawText,
+	QString& mappedCommand,
+	double& confidence,
+	QString& error ) const
+{
+	mappedCommand.clear();
+	confidence = 0.0;
+	error.clear();
+
+	const QString model = qEnvironmentVariable( "LMMS_OLLAMA_MODEL" ).trimmed();
+	if( model.isEmpty() )
+	{
+		error = tr( "LMMS_OLLAMA_MODEL is not set" );
+		return false;
+	}
+
+	const QString endpoint = qEnvironmentVariable( "LMMS_OLLAMA_URL" ).trimmed().isEmpty()
+		? QStringLiteral( "http://127.0.0.1:11434/api/chat" )
+		: qEnvironmentVariable( "LMMS_OLLAMA_URL" ).trimmed();
+
+	const QString systemPrompt =
+		QStringLiteral(
+			"You map noisy LMMS voice commands to the closest valid command. "
+			"Only map if familiar with these command families: open/show/new/create/import/load/set/add/remove/mute/solo/undo/tempo/slicer. "
+			"Return JSON only: {\"familiar\":true|false,\"command\":\"...\",\"confidence\":0.0-1.0}. "
+			"If unclear or unrelated, return familiar=false, empty command, low confidence." );
+
+	const QJsonObject payload
+	{
+		{ "model", model },
+		{ "stream", false },
+		{ "messages", QJsonArray
+			{
+				QJsonObject{ { "role", "system" }, { "content", systemPrompt } },
+				QJsonObject{ { "role", "user" }, { "content", rawText } }
+			}
+		}
+	};
+
+	QNetworkAccessManager manager;
+	QNetworkRequest request{ QUrl( endpoint ) };
+	request.setHeader( QNetworkRequest::ContentTypeHeader, QStringLiteral( "application/json" ) );
+
+	QNetworkReply *reply = manager.post( request, QJsonDocument( payload ).toJson( QJsonDocument::Compact ) );
+	QEventLoop loop;
+	QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
+	QTimer::singleShot( 2500, &loop, &QEventLoop::quit );
+	loop.exec();
+
+	if( reply->isRunning() )
+	{
+		reply->abort();
+		reply->deleteLater();
+		error = tr( "Ollama timed out" );
+		return false;
+	}
+
+	if( reply->error() != QNetworkReply::NoError )
+	{
+		error = reply->errorString();
+		reply->deleteLater();
+		return false;
+	}
+
+	const QByteArray body = reply->readAll();
+	reply->deleteLater();
+	const QJsonDocument outerDoc = QJsonDocument::fromJson( body );
+	if( !outerDoc.isObject() )
+	{
+		error = tr( "Invalid Ollama response" );
+		return false;
+	}
+
+	QString content = outerDoc.object().value( "message" ).toObject().value( "content" ).toString().trimmed();
+	if( content.isEmpty() )
+	{
+		error = tr( "Ollama returned empty content" );
+		return false;
+	}
+
+	// Accept wrapped JSON in markdown fences.
+	content.remove( QRegularExpression( R"(^```(?:json)?\s*)", QRegularExpression::CaseInsensitiveOption ) );
+	content.remove( QRegularExpression( R"(\s*```$)", QRegularExpression::CaseInsensitiveOption ) );
+	const QRegularExpression jsonBlock( R"(\{[\s\S]*\})" );
+	const auto match = jsonBlock.match( content );
+	if( match.hasMatch() )
+	{
+		content = match.captured( 0 );
+	}
+
+	const QJsonDocument mappedDoc = QJsonDocument::fromJson( content.toUtf8() );
+	if( !mappedDoc.isObject() )
+	{
+		error = tr( "Ollama content was not valid JSON" );
+		return false;
+	}
+
+	const QJsonObject mappedObj = mappedDoc.object();
+	if( !mappedObj.value( "familiar" ).toBool( false ) )
+	{
+		error = tr( "Ollama marked command as unfamiliar" );
+		return false;
+	}
+
+	mappedCommand = mappedObj.value( "command" ).toString().trimmed();
+	confidence = mappedObj.value( "confidence" ).toDouble( 0.0 );
+	if( mappedCommand.isEmpty() )
+	{
+		error = tr( "Ollama returned an empty command" );
+		return false;
+	}
+	return true;
+}
+
+bool AgentControlService::maybeRunTextAgentFallback(
+	const QString& rawText,
+	QString& result,
+	QString& error )
+{
+	result.clear();
+	error.clear();
+
+	const int enabled = qEnvironmentVariableIntValue( "LMMS_TEXT_AGENT_FALLBACK" );
+	if( enabled != 1 )
+	{
+		error = tr( "LMMS_TEXT_AGENT_FALLBACK is disabled" );
+		return false;
+	}
+
+	const QString scriptPath = qEnvironmentVariable( "LMMS_TEXT_AGENT_SCRIPT" ).trimmed();
+	if( scriptPath.isEmpty() )
+	{
+		error = tr( "LMMS_TEXT_AGENT_SCRIPT is not set" );
+		return false;
+	}
+	if( !QFileInfo::exists( scriptPath ) )
+	{
+		error = tr( "Text-agent script not found: %1" ).arg( scriptPath );
+		return false;
+	}
+
+	QProcess process;
+	process.start( scriptPath, QStringList{ rawText } );
+	if( !process.waitForStarted( 1000 ) )
+	{
+		error = tr( "Failed to start text-agent script" );
+		return false;
+	}
+	if( !process.waitForFinished( 5000 ) )
+	{
+		process.kill();
+		process.waitForFinished( 500 );
+		error = tr( "Text-agent fallback timed out" );
+		return false;
+	}
+	if( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 )
+	{
+		error = QString::fromUtf8( process.readAllStandardError() ).trimmed();
+		if( error.isEmpty() )
+		{
+			error = tr( "Text-agent script failed" );
+		}
+		return false;
+	}
+
+	const QString output = QString::fromUtf8( process.readAllStandardOutput() ).trimmed();
+	if( output.isEmpty() )
+	{
+		error = tr( "Text-agent returned empty output" );
+		return false;
+	}
+
+	QString mappedCommand = output;
+	if( output.startsWith( '{' ) )
+	{
+		const QJsonDocument doc = QJsonDocument::fromJson( output.toUtf8() );
+		if( doc.isObject() )
+		{
+			const QJsonObject obj = doc.object();
+			mappedCommand = obj.value( "command" ).toString().trimmed();
+			if( mappedCommand.isEmpty() )
+			{
+				mappedCommand = obj.value( "text" ).toString().trimmed();
+			}
+		}
+	}
+	else
+	{
+		mappedCommand = output.section( '\n', 0, 0 ).trimmed();
+	}
+
+	if( mappedCommand.isEmpty() )
+	{
+		error = tr( "Text-agent output did not contain a command" );
+		return false;
+	}
+	if( !isFamiliarIntentText( mappedCommand ) )
+	{
+		error = tr( "Planner suggested an unfamiliar command; ignored for safety" );
+		return false;
+	}
+
+	const QString mappedResult = dispatchCommandText( mappedCommand );
+	if( isUnknownResponse( mappedResult ) )
+	{
+		error = tr( "Planner suggestion was not executable: %1" ).arg( mappedCommand );
+		return false;
+	}
+
+	result = tr( "Planner interpreted as \"%1\". %2" ).arg( mappedCommand, mappedResult );
+	return true;
 }
 
 QString AgentControlService::handleJson( const QJsonObject& obj )
@@ -320,6 +1041,11 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		}
 		return false;
 	};
+
+	if( handleSlicerWorkflow( rawText, tokens, result, error ) )
+	{
+		return error.isEmpty() ? result : error;
+	}
 
 	// Keep direct command mode usable for quick tempo changes from the plugin UI.
 	// Natural-language planning still lives in the text/voice agent.
@@ -581,11 +1307,23 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 		}
 		if( tokens.size() >= 2 )
 		{
-			const QString fileName = joinTokens( tokens, 1 );
+			QString fileName = joinTokens( tokens, 1 );
+			fileName.remove( QRegularExpression(
+				R"(\bfrom\s+(?:my\s+)?downloads?(?:\s+folder)?\b.*$)",
+				QRegularExpression::CaseInsensitiveOption ) );
+			fileName = fileName.trimmed();
+
 			if( importAudioFile( fileName, error ) )
 			{
 				return tr( "Imported %1" ).arg( fileName );
 			}
+
+			const QString fuzzyDownloadsMatch = resolveDownloadsAudioQuery( fileName );
+			if( !fuzzyDownloadsMatch.isEmpty() && importAudioFile( fuzzyDownloadsMatch, error ) )
+			{
+				return tr( "Imported %1" ).arg( QFileInfo( fuzzyDownloadsMatch ).fileName() );
+			}
+
 			if( importFromDownloads( fileName, error ) )
 			{
 				return tr( "Imported %1" ).arg( fileName );
@@ -710,6 +1448,133 @@ QString AgentControlService::dispatchTokens( const QStringList& tokens, const QS
 	}
 
 	return tr( "Unknown command: %1. For natural-language tasks use lmmsagent/scripts/run_text_agent.sh" ).arg( rawText );
+}
+
+bool AgentControlService::handleSlicerWorkflow(
+	const QString& rawText,
+	const QStringList& tokens,
+	QString& result,
+	QString& error )
+{
+	if( tokens.isEmpty() )
+	{
+		return false;
+	}
+
+	const QString first = tokens[0].toLower();
+	const QString normalizedRaw = normalizeName( rawText );
+	const bool mentionsSlicer = normalizedRaw.contains( "slicer" ) ||
+		normalizedRaw.contains( "splicer" );
+	const bool mentionsImport = normalizedRaw.contains( "import" );
+	const bool mentionsDownloadFolder = normalizedRaw.contains( "fromdownloads" ) ||
+		normalizedRaw.contains( "frommydownloads" );
+	const bool mentionsTransientSlices = normalizedRaw.contains( "transient" ) ||
+		normalizedRaw.contains( "onset" );
+	const bool mentionsSegmentOrSlice = normalizedRaw.contains( "segment" ) ||
+		normalizedRaw.contains( "slice" );
+	const bool hasExplicitSegmentCount = QRegularExpression( R"(\b\d+\b)" ).match( rawText ).hasMatch();
+	const bool mentionsEqualSlices = normalizedRaw.contains( "equalsegment" ) ||
+		normalizedRaw.contains( "equalslice" ) ||
+		( mentionsSegmentOrSlice && !mentionsTransientSlices &&
+			( normalizedRaw.contains( "divideinto" ) || normalizedRaw.contains( "splitinto" ) || hasExplicitSegmentCount ) );
+
+	const bool openSlicerRequest = normalizedRaw.contains( "openslicer" ) ||
+		( first == "open" && tokens.size() >= 2 &&
+			( normalizeName( joinTokens( tokens, 1 ) ) == "slicer" ||
+			  normalizeName( joinTokens( tokens, 1 ) ) == "splicer" ) ) ||
+		( first == "slicer" && tokens.size() >= 2 &&
+			( tokens[1].compare( "open", Qt::CaseInsensitive ) == 0 ||
+			  tokens[1].compare( "show", Qt::CaseInsensitive ) == 0 ) );
+	const bool importIntoSlicerRequest = ( mentionsImport || mentionsDownloadFolder ||
+		normalizedRaw.contains( "intoslicer" ) ) && ( mentionsSlicer || openSlicerRequest );
+	const bool slicerSplitRequest = ( first == "divide" || first == "split" || first == "slice" ||
+		first == "slicer" || mentionsSlicer ) && ( mentionsEqualSlices || mentionsTransientSlices );
+
+	if( !openSlicerRequest && !importIntoSlicerRequest && !slicerSplitRequest )
+	{
+		return false;
+	}
+
+	QStringList steps;
+	if( openSlicerRequest )
+	{
+		InstrumentTrack *track = nullptr;
+		if( !ensureSlicerTrack( track, true, error ) )
+		{
+			return true;
+		}
+		if( !focusInstrumentTrackWindow( track, error ) )
+		{
+			return true;
+		}
+		steps << tr( "Opened slicer on track %1" ).arg( track->name() );
+	}
+
+	if( importIntoSlicerRequest )
+	{
+		QString importMessage;
+		const QString fileQuery = extractAudioQuery( rawText, tokens );
+		if( fileQuery.isEmpty() )
+		{
+			error = tr( "Could not detect an audio filename for slicer import" );
+			return true;
+		}
+		if( !loadFileIntoSlicer( fileQuery, importMessage, error ) )
+		{
+			return true;
+		}
+		steps << importMessage;
+	}
+
+	if( mentionsEqualSlices )
+	{
+		int segmentCount = 16;
+		const QRegularExpression beforeEqual( R"((\d+)\s+equal\s+(?:segments?|slices?))",
+			QRegularExpression::CaseInsensitiveOption );
+		const QRegularExpression afterEqual( R"(equal\s+(?:segments?|slices?)(?:\s+of)?\s+(\d+))",
+			QRegularExpression::CaseInsensitiveOption );
+
+		auto match = beforeEqual.match( rawText );
+		if( !match.hasMatch() )
+		{
+			match = afterEqual.match( rawText );
+		}
+		if( match.hasMatch() )
+		{
+			bool ok = false;
+			const int parsed = match.captured( 1 ).toInt( &ok );
+			if( ok )
+			{
+				segmentCount = parsed;
+			}
+		}
+		segmentCount = qBound( 1, segmentCount, 128 );
+
+		QString sliceMessage;
+		if( !sliceSlicerEqual( segmentCount, sliceMessage, error ) )
+		{
+			return true;
+		}
+		steps << sliceMessage;
+	}
+
+	if( mentionsTransientSlices )
+	{
+		QString sliceMessage;
+		if( !sliceSlicerByTransients( sliceMessage, error ) )
+		{
+			return true;
+		}
+		steps << sliceMessage;
+	}
+
+	if( steps.isEmpty() )
+	{
+		return false;
+	}
+
+	result = steps.join( ". " );
+	return true;
 }
 
 QJsonObject AgentControlService::dispatchTool( const QString& toolName, const QJsonObject& args )
@@ -1479,6 +2344,7 @@ bool AgentControlService::createInstrumentTrack( const QString& pluginName, QStr
 			track->loadInstrument( resolvedPlugin );
 		}
 	} );
+	m_lastLoadedInstrument = resolvedPlugin;
 	result = tr( "Queued instrument %1" ).arg( displayName );
 	return true;
 }
@@ -1512,6 +2378,7 @@ bool AgentControlService::importAudioFile( const QString& path, QString& error )
 
 	clip->setSampleFile( fullPath );
 	clip->updateLength();
+	m_lastImportedAudioPath = fullPath;
 	return true;
 }
 
@@ -1732,6 +2599,251 @@ InstrumentTrack* AgentControlService::findInstrumentTrack( const QString& trackN
 	return dynamic_cast<InstrumentTrack *>( findTrackByName( trackName ) );
 }
 
+InstrumentTrack* AgentControlService::findLastSlicerTrack() const
+{
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		return nullptr;
+	}
+
+	const auto &tracks = song->tracks();
+	for( auto it = tracks.rbegin(); it != tracks.rend(); ++it )
+	{
+		auto *instrumentTrack = dynamic_cast<InstrumentTrack *>( *it );
+		if( instrumentTrack == nullptr || instrumentTrack->instrument() == nullptr )
+		{
+			continue;
+		}
+
+		const QString pluginName = normalizeName( instrumentTrack->instrument()->nodeName() );
+		const QString displayName = normalizeName( instrumentTrack->instrumentName() );
+		if( pluginName == "slicert" || displayName.contains( "slicer" ) )
+		{
+			return instrumentTrack;
+		}
+	}
+
+	return nullptr;
+}
+
+bool AgentControlService::ensureSlicerTrack( InstrumentTrack*& track, bool createIfMissing, QString& error )
+{
+	track = nullptr;
+
+	if( !m_selectedTrackName.isEmpty() )
+	{
+		auto *selectedTrack = dynamic_cast<InstrumentTrack *>( findTrackByName( m_selectedTrackName ) );
+		if( selectedTrack != nullptr && selectedTrack->instrument() != nullptr &&
+			normalizeName( selectedTrack->instrument()->nodeName() ) == "slicert" )
+		{
+			track = selectedTrack;
+			return true;
+		}
+	}
+
+	track = findLastSlicerTrack();
+	if( track != nullptr )
+	{
+		m_selectedTrackName = track->name();
+		return true;
+	}
+
+	if( !createIfMissing )
+	{
+		error = tr( "No slicer track is available. Say 'open slicer' first." );
+		return false;
+	}
+
+	Song *song = Engine::getSong();
+	if( song == nullptr )
+	{
+		error = tr( "No active song" );
+		return false;
+	}
+
+	track = dynamic_cast<InstrumentTrack *>( Track::create( Track::Type::Instrument, song ) );
+	if( track == nullptr )
+	{
+		error = tr( "Failed to create slicer track" );
+		return false;
+	}
+
+	if( track->loadInstrument( "slicert" ) == nullptr )
+	{
+		error = tr( "Failed to load slicer instrument" );
+		return false;
+	}
+
+	m_selectedTrackName = track->name();
+	return true;
+}
+
+bool AgentControlService::focusInstrumentTrackWindow( InstrumentTrack* track, QString& error )
+{
+	if( track == nullptr )
+	{
+		error = tr( "No slicer track is available" );
+		return false;
+	}
+
+	auto *guiApp = gui::getGUI();
+	if( guiApp == nullptr || guiApp->songEditor() == nullptr || guiApp->songEditor()->m_editor == nullptr )
+	{
+		error = tr( "GUI is not ready" );
+		return false;
+	}
+
+	auto *songEditorWindow = guiApp->songEditor();
+	songEditorWindow->show();
+	if( songEditorWindow->parentWidget() )
+	{
+		songEditorWindow->parentWidget()->show();
+		songEditorWindow->parentWidget()->raise();
+		songEditorWindow->parentWidget()->activateWindow();
+	}
+
+	for( int attempt = 0; attempt < 8; ++attempt )
+	{
+		for( auto *trackView : songEditorWindow->m_editor->trackViews() )
+		{
+			if( trackView == nullptr || trackView->getTrack() != track )
+			{
+				continue;
+			}
+
+			auto *instrumentView = dynamic_cast<gui::InstrumentTrackView *>( trackView );
+			if( instrumentView == nullptr )
+			{
+				continue;
+			}
+
+			QMetaObject::invokeMethod( instrumentView, "toggleInstrumentWindow",
+				Qt::DirectConnection, Q_ARG( bool, true ) );
+			auto *trackWindow = instrumentView->getInstrumentTrackWindow();
+			if( trackWindow != nullptr )
+			{
+				trackWindow->show();
+				trackWindow->raise();
+				trackWindow->setFocus();
+				if( trackWindow->parentWidget() )
+				{
+					trackWindow->parentWidget()->show();
+					trackWindow->parentWidget()->raise();
+					trackWindow->parentWidget()->activateWindow();
+				}
+			}
+			return true;
+		}
+
+		QCoreApplication::processEvents( QEventLoop::AllEvents, 20 );
+		QThread::msleep( 60 );
+	}
+
+	error = tr( "Could not focus slicer window yet. Try again in a moment." );
+	return false;
+}
+
+bool AgentControlService::loadFileIntoSlicer( const QString& fileQuery, QString& result, QString& error )
+{
+	InstrumentTrack *track = nullptr;
+	if( !ensureSlicerTrack( track, true, error ) )
+	{
+		return false;
+	}
+
+	QString fullPath = canonicalPath( fileQuery );
+	if( fullPath.isEmpty() )
+	{
+		fullPath = resolveDownloadsAudioQuery( fileQuery );
+	}
+	if( fullPath.isEmpty() )
+	{
+		error = tr( "Audio file not found: %1" ).arg( fileQuery );
+		return false;
+	}
+	if( track->instrument() == nullptr )
+	{
+		error = tr( "Slicer instrument is not loaded" );
+		return false;
+	}
+
+	track->instrument()->loadFile( fullPath );
+	m_selectedTrackName = track->name();
+	m_lastImportedAudioPath = fullPath;
+	result = tr( "Loaded %1 into slicer" ).arg( QFileInfo( fullPath ).fileName() );
+	return true;
+}
+
+bool AgentControlService::sliceSlicerEqual( int segments, QString& result, QString& error )
+{
+	InstrumentTrack *track = nullptr;
+	if( !ensureSlicerTrack( track, false, error ) )
+	{
+		return false;
+	}
+	if( track->instrument() == nullptr || normalizeName( track->instrument()->nodeName() ) != "slicert" )
+	{
+		error = tr( "Selected track is not a slicer track" );
+		return false;
+	}
+
+	const int boundedSegments = qBound( 1, segments, 128 );
+	QDomDocument document;
+	QDomElement trackState = document.createElement( "track" );
+	document.appendChild( trackState );
+	track->saveTrackSpecificSettings( document, trackState, false );
+
+	QDomElement instrumentState = trackState.firstChildElement( "instrument" );
+	if( instrumentState.isNull() )
+	{
+		error = tr( "Slicer settings are not available" );
+		return false;
+	}
+
+	QDomElement pluginState = instrumentState.firstChildElement();
+	if( pluginState.isNull() )
+	{
+		error = tr( "Slicer plugin state is missing" );
+		return false;
+	}
+
+	pluginState.setAttribute( "totalSlices", boundedSegments + 1 );
+	for( int i = 0; i <= boundedSegments; ++i )
+	{
+		const double ratio = static_cast<double>( i ) / static_cast<double>( boundedSegments );
+		pluginState.setAttribute( QString( "slice_%1" ).arg( i ),
+			QString::number( ratio, 'f', 8 ) );
+	}
+
+	track->loadTrackSpecificSettings( trackState );
+	result = tr( "Set slicer to %1 equal segments" ).arg( boundedSegments );
+	return true;
+}
+
+bool AgentControlService::sliceSlicerByTransients( QString& result, QString& error )
+{
+	InstrumentTrack *track = nullptr;
+	if( !ensureSlicerTrack( track, false, error ) )
+	{
+		return false;
+	}
+	if( track->instrument() == nullptr || normalizeName( track->instrument()->nodeName() ) != "slicert" )
+	{
+		error = tr( "Selected track is not a slicer track" );
+		return false;
+	}
+
+	if( !QMetaObject::invokeMethod( track->instrument(), "updateSlices", Qt::DirectConnection ) )
+	{
+		error = tr( "Failed to trigger transient slice detection" );
+		return false;
+	}
+
+	result = tr( "Updated slicer using transient detection" );
+	return true;
+}
+
 SampleTrack* AgentControlService::createSampleTrack( const QString& name ) const
 {
 	Song *song = Engine::getSong();
@@ -1772,6 +2884,53 @@ bool AgentControlService::addSampleClip( SampleTrack *track, const QString& samp
 	return true;
 }
 
+QString AgentControlService::extractAudioQuery( const QString& rawText, const QStringList& tokens ) const
+{
+	const QString normalized = normalizeName( rawText );
+	if( ( normalized.contains( "thissample" ) || normalized.contains( "thisaudio" ) ||
+		normalized.contains( "thatsample" ) || normalized.contains( "thataudio" ) ) &&
+		!m_lastImportedAudioPath.isEmpty() && QFileInfo::exists( m_lastImportedAudioPath ) )
+	{
+		return m_lastImportedAudioPath;
+	}
+
+	const QRegularExpression quotedPathPattern(
+		R"(["']([^"']+\.(?:wav|wave|aif|aiff|flac|ogg|mp3|m4a))["'])",
+		QRegularExpression::CaseInsensitiveOption );
+	auto match = quotedPathPattern.match( rawText );
+	if( match.hasMatch() )
+	{
+		return match.captured( 1 ).trimmed();
+	}
+
+	const QRegularExpression fileWithExtPattern(
+		R"(([^\s,]+?\.(?:wav|wave|aif|aiff|flac|ogg|mp3|m4a)))",
+		QRegularExpression::CaseInsensitiveOption );
+	match = fileWithExtPattern.match( rawText );
+	if( match.hasMatch() )
+	{
+		return match.captured( 1 ).trimmed();
+	}
+
+	if( !tokens.isEmpty() && ( tokens[0].compare( "import", Qt::CaseInsensitive ) == 0 ||
+		tokens[0].compare( "load", Qt::CaseInsensitive ) == 0 ) )
+	{
+		QString query = joinTokens( tokens, 1 );
+		query.remove( QRegularExpression( R"(\b(?:into|to)\s+slicer\b)",
+			QRegularExpression::CaseInsensitiveOption ) );
+		query.remove( QRegularExpression( R"(\bfrom\s+(?:my\s+)?downloads?(?:\s+folder)?\b.*$)",
+			QRegularExpression::CaseInsensitiveOption ) );
+		query = query.trimmed();
+		if( !query.isEmpty() && query.compare( "audio", Qt::CaseInsensitive ) != 0 &&
+			query.compare( "file", Qt::CaseInsensitive ) != 0 )
+		{
+			return query;
+		}
+	}
+
+	return {};
+}
+
 QString AgentControlService::resolveDownloadsFile( const QString& fileName ) const
 {
 	if( fileName.isEmpty() )
@@ -1786,6 +2945,62 @@ QString AgentControlService::resolveDownloadsFile( const QString& fileName ) con
 	}
 	const QString absPath = QDir( downloads ).filePath( fileName );
 	return QFile::exists( absPath ) ? absPath : QString{};
+}
+
+QString AgentControlService::resolveDownloadsAudioQuery( const QString& query ) const
+{
+	QString cleaned = query.trimmed();
+	if( cleaned.isEmpty() )
+	{
+		return {};
+	}
+	cleaned.remove( '"' );
+	cleaned.remove( '\'' );
+	cleaned = cleaned.trimmed();
+
+	const QString direct = resolveDownloadsFile( cleaned );
+	if( !direct.isEmpty() )
+	{
+		return direct;
+	}
+
+	QString downloads = QStandardPaths::writableLocation( QStandardPaths::DownloadLocation );
+	if( downloads.isEmpty() )
+	{
+		downloads = QDir::homePath() + "/Downloads";
+	}
+	QDir downloadsDir( downloads );
+	if( !downloadsDir.exists() )
+	{
+		return {};
+	}
+
+	const QString wanted = normalizeName( cleaned );
+	QString partialMatch;
+	const QFileInfoList files = downloadsDir.entryInfoList( QDir::Files | QDir::Readable );
+	for( const QFileInfo& info : files )
+	{
+		const QString suffix = info.suffix().toLower();
+		if( suffix != "wav" && suffix != "wave" && suffix != "aif" && suffix != "aiff" &&
+			suffix != "flac" && suffix != "ogg" && suffix != "mp3" && suffix != "m4a" )
+		{
+			continue;
+		}
+
+		const QString fileName = normalizeName( info.fileName() );
+		const QString baseName = normalizeName( info.completeBaseName() );
+		if( !wanted.isEmpty() && ( fileName == wanted || baseName == wanted ) )
+		{
+			return info.absoluteFilePath();
+		}
+		if( partialMatch.isEmpty() && !wanted.isEmpty() &&
+			( fileName.contains( wanted ) || baseName.contains( wanted ) || wanted.contains( baseName ) ) )
+		{
+			partialMatch = info.absoluteFilePath();
+		}
+	}
+
+	return partialMatch;
 }
 
 QString AgentControlService::defaultKickSample() const

--- a/plugins/AgentControl/AgentControl.h
+++ b/plugins/AgentControl/AgentControl.h
@@ -1,0 +1,89 @@
+#ifndef LMMS_AGENT_CONTROL_H
+#define LMMS_AGENT_CONTROL_H
+
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QJsonObject>
+#include <QList>
+#include <QSet>
+#include <QStringList>
+
+#include "Track.h"
+#include "ToolPlugin.h"
+
+class QWidget;
+
+namespace lmms
+{
+
+class EffectChain;
+class InstrumentTrack;
+class SampleTrack;
+namespace gui
+{
+class AgentControlView;
+}
+
+class AgentControlPlugin : public ToolPlugin
+{
+	Q_OBJECT
+public:
+	AgentControlPlugin();
+	~AgentControlPlugin() override;
+
+	QString nodeName() const override;
+	void saveSettings(QDomDocument&, QDomElement&) override;
+	void loadSettings(const QDomElement&) override;
+	gui::PluginView* instantiateView(QWidget*) override;
+
+	QString handleCommand(const QString& text);
+	QString handleJson(const QJsonObject& obj);
+
+signals:
+	void logMessage(const QString& msg);
+	void commandResult(const QString& msg);
+
+private slots:
+	void onNewConnection();
+	void onSocketReady();
+	void onSocketClosed();
+
+private:
+	QString dispatchTokens(const QStringList& tokens, const QString& rawText);
+
+	bool importFromDownloads(const QString& fileName, QString& error);
+	bool importAudioFile(const QString& path, QString& error);
+	bool importProjectFile(const QString& path, QString& error);
+	bool addKickPattern(QString& error);
+
+	bool createTrack(Track::Type type, QString& result, QString& error);
+	bool createInstrumentTrack(const QString& pluginName, QString& result, QString& error);
+	bool showWindowCommand(const QString& windowName, QString& result, QString& error);
+	bool showToolCommand(const QString& toolName, QString& result, QString& error);
+	bool newProject(QString& result, QString& error);
+	bool openProject(const QString& path, QString& result, QString& error);
+	bool saveProject(QString& result, QString& error);
+	bool saveProjectAs(const QString& path, QString& result, QString& error);
+	bool addEffectToTrack(const QString& effectName, const QString& trackName, QString& result, QString& error);
+	bool removeEffectFromTrack(const QString& effectName, const QString& trackName, QString& result, QString& error);
+
+	Track* findTrackByName(const QString& trackName) const;
+	Track* findLastTrackOfTypes(const QList<Track::Type>& types) const;
+	InstrumentTrack* findInstrumentTrack(const QString& trackName) const;
+	SampleTrack* createSampleTrack(const QString& name) const;
+	EffectChain* effectChainForTrack(Track* track) const;
+
+	bool addSampleClip(SampleTrack* track, const QString& samplePath, int tickPos);
+	QString resolveDownloadsFile(const QString& fileName) const;
+	QString defaultKickSample() const;
+	QString canonicalPath(const QString& path) const;
+	QString joinTokens(const QStringList& tokens, int startIndex) const;
+	QString normalizeName(const QString& text) const;
+
+	QTcpServer m_server;
+	QSet<QTcpSocket*> m_clients;
+};
+
+} // namespace lmms
+
+#endif // LMMS_AGENT_CONTROL_H

--- a/plugins/AgentControl/AgentControl.h
+++ b/plugins/AgentControl/AgentControl.h
@@ -64,8 +64,31 @@ private:
 	bool isUnknownResponse(const QString& response) const;
 	bool isFamiliarIntentText(const QString& rawText) const;
 	bool applyHeuristicMappings(const QString& rawText, QString& mappedCommand, QString& reason) const;
-	bool resolveWithOllama(const QString& rawText, QString& mappedCommand, double& confidence, QString& error) const;
+	bool resolveWithOllama(
+		const QString& rawText,
+		QString& mappedCommand,
+		QString& intent,
+		QJsonObject& arguments,
+		QString& riskLevel,
+		double& confidence,
+		QString& reason,
+		QString& error ) const;
 	bool maybeRunTextAgentFallback(const QString& rawText, QString& result, QString& error);
+	QString inferIntentForCommand(const QString& commandText) const;
+	QString normalizedRiskForIntent(const QString& intent) const;
+	bool isIntentEnabled(const QString& intent) const;
+	bool commandNeedsConfirmation(
+		const QString& intent,
+		const QString& commandText,
+		const QString& riskHint = QString() ) const;
+	bool isConfirmationUtterance(const QString& rawText) const;
+	QString executeWithSafetyGate(
+		const QString& commandText,
+		const QString& source,
+		double confidence,
+		const QString& reason,
+		const QString& riskHint = QString() );
+	void emitTrace(const QString& stage, const QJsonObject& payload = QJsonObject());
 
 	QString dispatchTokens(const QStringList& tokens, const QString& rawText);
 	QJsonObject dispatchTool(const QString& toolName, const QJsonObject& args);
@@ -112,6 +135,9 @@ private:
 	bool importProjectFile(const QString& path, QString& error);
 	bool addKickPattern(QString& error);
 	bool addSnarePattern(QString& error);
+	bool addHiHatPattern(QString& error);
+	bool addCrashPattern(QString& error);
+	bool addRidePattern(QString& error);
 
 	bool createTrack(Track::Type type, QString& result, QString& error);
 	bool createInstrumentTrack(const QString& pluginName, QString& result, QString& error);
@@ -125,6 +151,8 @@ private:
 	bool showToolCommand(const QString& toolName, QString& result, QString& error);
 	bool newProject(QString& result, QString& error);
 	bool openProject(const QString& path, QString& result, QString& error);
+	void scheduleDeferredOpenProject(const QString& fullPath);
+	void processDeferredOpenProject();
 	bool saveProject(QString& result, QString& error);
 	bool saveProjectAs(const QString& path, QString& result, QString& error);
 	bool addEffectToTrack(const QString& effectName, const QString& trackName, QString& result, QString& error);
@@ -143,6 +171,9 @@ private:
 	QString resolveDownloadsAudioQuery(const QString& query) const;
 	QString defaultKickSample() const;
 	QString defaultSnareSample() const;
+	QString defaultHiHatSample() const;
+	QString defaultCrashSample() const;
+	QString defaultRideSample() const;
 	QString canonicalPath(const QString& path) const;
 	QString joinTokens(const QStringList& tokens, int startIndex) const;
 	QString normalizeName(const QString& text) const;
@@ -154,9 +185,14 @@ private:
 	int m_snapshotCounter = 0;
 	int m_actionCounter = 0;
 	bool m_projectTransitionQueued = false;
+	QString m_deferredOpenProjectPath;
+	int m_deferredOpenProjectRetries = 0;
 	QString m_selectedTrackName;
 	QString m_lastImportedAudioPath;
 	QString m_lastLoadedInstrument;
+	QString m_pendingConfirmationCommand;
+	QString m_pendingConfirmationIntent;
+	qint64 m_pendingConfirmationExpiresMs = 0;
 };
 
 class AgentControlPlugin : public ToolPlugin

--- a/plugins/AgentControl/AgentControl.h
+++ b/plugins/AgentControl/AgentControl.h
@@ -11,6 +11,7 @@
 #include "Track.h"
 #include "ToolPlugin.h"
 
+class QObject;
 class QWidget;
 
 namespace lmms
@@ -24,17 +25,12 @@ namespace gui
 class AgentControlView;
 }
 
-class AgentControlPlugin : public ToolPlugin
+class AgentControlService : public QObject
 {
 	Q_OBJECT
 public:
-	AgentControlPlugin();
-	~AgentControlPlugin() override;
-
-	QString nodeName() const override;
-	void saveSettings(QDomDocument&, QDomElement&) override;
-	void loadSettings(const QDomElement&) override;
-	gui::PluginView* instantiateView(QWidget*) override;
+	static AgentControlService* instance();
+	~AgentControlService() override;
 
 	QString handleCommand(const QString& text);
 	QString handleJson(const QJsonObject& obj);
@@ -49,6 +45,8 @@ private slots:
 	void onSocketClosed();
 
 private:
+	AgentControlService();
+
 	QString dispatchTokens(const QStringList& tokens, const QString& rawText);
 
 	bool importFromDownloads(const QString& fileName, QString& error);
@@ -82,6 +80,28 @@ private:
 
 	QTcpServer m_server;
 	QSet<QTcpSocket*> m_clients;
+};
+
+class AgentControlPlugin : public ToolPlugin
+{
+	Q_OBJECT
+public:
+	AgentControlPlugin();
+	~AgentControlPlugin() override;
+
+	static AgentControlService* service();
+
+	QString nodeName() const override;
+	void saveSettings(QDomDocument&, QDomElement&) override;
+	void loadSettings(const QDomElement&) override;
+	gui::PluginView* instantiateView(QWidget*) override;
+
+	QString handleCommand(const QString& text);
+	QString handleJson(const QJsonObject& obj);
+
+signals:
+	void logMessage(const QString& msg);
+	void commandResult(const QString& msg);
 };
 
 } // namespace lmms

--- a/plugins/AgentControl/AgentControl.h
+++ b/plugins/AgentControl/AgentControl.h
@@ -3,6 +3,9 @@
 
 #include <QTcpServer>
 #include <QTcpSocket>
+#include <QByteArray>
+#include <QHash>
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QList>
 #include <QSet>
@@ -34,6 +37,7 @@ public:
 
 	QString handleCommand(const QString& text);
 	QString handleJson(const QJsonObject& obj);
+	QJsonObject handleRequest(const QJsonObject& obj);
 
 signals:
 	void logMessage(const QString& msg);
@@ -45,14 +49,61 @@ private slots:
 	void onSocketClosed();
 
 private:
+	struct Snapshot
+	{
+		QString id;
+		QString label;
+		QJsonObject state;
+		int actionCounter = 0;
+	};
+
 	AgentControlService();
 
 	QString dispatchTokens(const QStringList& tokens, const QString& rawText);
+	QJsonObject dispatchTool(const QString& toolName, const QJsonObject& args);
+	QJsonObject projectStateObject() const;
+	QJsonObject trackObject(const Track* track, int index) const;
+	QJsonArray trackArray() const;
+	QJsonArray listPatternArray() const;
+	QJsonObject diffState(const QJsonObject& before, const QJsonObject& after) const;
+	QJsonObject successResponse(const QJsonObject& result = QJsonObject(),
+		const QJsonObject& stateDelta = QJsonObject(),
+		const QJsonArray& warnings = QJsonArray()) const;
+	QJsonObject errorResponse(const QString& errorCode, const QString& errorMessage,
+		const QJsonArray& warnings = QJsonArray()) const;
+	QString trackTypeName(Track::Type type) const;
+	Track* resolveTrackRef(const QJsonObject& args) const;
+	InstrumentTrack* resolveInstrumentTrack(const QJsonObject& args) const;
+	SampleTrack* resolveSampleTrack(const QJsonObject& args) const;
+	QString resolveInstrumentPlugin(const QString& pluginName, QString& displayName) const;
+	QString resolveEffectPlugin(const QString& effectName, QString& displayName) const;
+	QString toCommandResponseText(const QJsonObject& response) const;
+	QJsonArray effectArrayForTrack(Track* track) const;
+	QJsonArray availableWindows() const;
+	QJsonArray availableTools() const;
+	QJsonArray availableInstruments() const;
+	QJsonArray availableEffects() const;
+	QJsonArray searchProjectAudio(const QString& query) const;
+	bool createSnapshot(const QString& label, QJsonObject& result, QString& error);
+	bool rollbackSnapshot(const QString& snapshotId, QJsonObject& result, QString& error);
+	bool undoLastAction(QJsonObject& result, QString& error);
+	bool diffSinceSnapshot(const QString& snapshotId, QJsonObject& result, QString& error) const;
+	bool loadSampleToTrack(const QString& samplePath, const QString& trackName, QJsonObject& result, QString& error);
+	bool setTempoValue(int tempo, QJsonObject& result, QString& error);
+	bool renameTrack(const QString& trackName, const QString& newName, QJsonObject& result, QString& error);
+	bool selectTrack(const QString& trackName, QJsonObject& result, QString& error);
+	bool setTrackMute(const QString& trackName, bool mute, QJsonObject& result, QString& error);
+	bool setTrackSolo(const QString& trackName, bool solo, QJsonObject& result, QString& error);
+	bool createPatternClip(const QJsonObject& args, QJsonObject& result, QString& error);
+	bool addNotesToPattern(const QJsonObject& args, QJsonObject& result, QString& error);
+	bool addStepsToPattern(const QJsonObject& args, QJsonObject& result, QString& error);
+	int trackIndex(const Track* track) const;
 
 	bool importFromDownloads(const QString& fileName, QString& error);
 	bool importAudioFile(const QString& path, QString& error);
 	bool importProjectFile(const QString& path, QString& error);
 	bool addKickPattern(QString& error);
+	bool addSnarePattern(QString& error);
 
 	bool createTrack(Track::Type type, QString& result, QString& error);
 	bool createInstrumentTrack(const QString& pluginName, QString& result, QString& error);
@@ -74,12 +125,19 @@ private:
 	bool addSampleClip(SampleTrack* track, const QString& samplePath, int tickPos);
 	QString resolveDownloadsFile(const QString& fileName) const;
 	QString defaultKickSample() const;
+	QString defaultSnareSample() const;
 	QString canonicalPath(const QString& path) const;
 	QString joinTokens(const QStringList& tokens, int startIndex) const;
 	QString normalizeName(const QString& text) const;
 
 	QTcpServer m_server;
 	QSet<QTcpSocket*> m_clients;
+	QHash<QTcpSocket*, QByteArray> m_readBuffers;
+	QHash<QString, Snapshot> m_snapshots;
+	int m_snapshotCounter = 0;
+	int m_actionCounter = 0;
+	bool m_projectTransitionQueued = false;
+	QString m_selectedTrackName;
 };
 
 class AgentControlPlugin : public ToolPlugin

--- a/plugins/AgentControl/AgentControl.h
+++ b/plugins/AgentControl/AgentControl.h
@@ -59,6 +59,14 @@ private:
 
 	AgentControlService();
 
+	QString dispatchCommandText(const QString& rawText);
+	QStringList tokenizeCommand(const QString& rawText) const;
+	bool isUnknownResponse(const QString& response) const;
+	bool isFamiliarIntentText(const QString& rawText) const;
+	bool applyHeuristicMappings(const QString& rawText, QString& mappedCommand, QString& reason) const;
+	bool resolveWithOllama(const QString& rawText, QString& mappedCommand, double& confidence, QString& error) const;
+	bool maybeRunTextAgentFallback(const QString& rawText, QString& result, QString& error);
+
 	QString dispatchTokens(const QStringList& tokens, const QString& rawText);
 	QJsonObject dispatchTool(const QString& toolName, const QJsonObject& args);
 	QJsonObject projectStateObject() const;
@@ -107,6 +115,12 @@ private:
 
 	bool createTrack(Track::Type type, QString& result, QString& error);
 	bool createInstrumentTrack(const QString& pluginName, QString& result, QString& error);
+	bool handleSlicerWorkflow(const QString& rawText, const QStringList& tokens, QString& result, QString& error);
+	bool ensureSlicerTrack(InstrumentTrack*& track, bool createIfMissing, QString& error);
+	bool focusInstrumentTrackWindow(InstrumentTrack* track, QString& error);
+	bool loadFileIntoSlicer(const QString& fileQuery, QString& result, QString& error);
+	bool sliceSlicerEqual(int segments, QString& result, QString& error);
+	bool sliceSlicerByTransients(QString& result, QString& error);
 	bool showWindowCommand(const QString& windowName, QString& result, QString& error);
 	bool showToolCommand(const QString& toolName, QString& result, QString& error);
 	bool newProject(QString& result, QString& error);
@@ -119,11 +133,14 @@ private:
 	Track* findTrackByName(const QString& trackName) const;
 	Track* findLastTrackOfTypes(const QList<Track::Type>& types) const;
 	InstrumentTrack* findInstrumentTrack(const QString& trackName) const;
+	InstrumentTrack* findLastSlicerTrack() const;
 	SampleTrack* createSampleTrack(const QString& name) const;
 	EffectChain* effectChainForTrack(Track* track) const;
 
 	bool addSampleClip(SampleTrack* track, const QString& samplePath, int tickPos);
+	QString extractAudioQuery(const QString& rawText, const QStringList& tokens) const;
 	QString resolveDownloadsFile(const QString& fileName) const;
+	QString resolveDownloadsAudioQuery(const QString& query) const;
 	QString defaultKickSample() const;
 	QString defaultSnareSample() const;
 	QString canonicalPath(const QString& path) const;
@@ -138,6 +155,8 @@ private:
 	int m_actionCounter = 0;
 	bool m_projectTransitionQueued = false;
 	QString m_selectedTrackName;
+	QString m_lastImportedAudioPath;
+	QString m_lastLoadedInstrument;
 };
 
 class AgentControlPlugin : public ToolPlugin

--- a/plugins/AgentControl/AgentControlView.cpp
+++ b/plugins/AgentControl/AgentControlView.cpp
@@ -1,9 +1,14 @@
 #include "AgentControlView.h"
 
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QPushButton>
+#include <QStandardPaths>
 
 #include "AgentControl.h"
 
@@ -16,6 +21,9 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 	, m_input( new QLineEdit( this ) )
 	, m_log( new QTextEdit( this ) )
 	, m_status( new QLabel( tr( "Listening on 127.0.0.1:7777" ), this ) )
+	, m_voiceStartButton( new QPushButton( tr( "Start Voice" ), this ) )
+	, m_voiceStopButton( new QPushButton( tr( "Stop + Run" ), this ) )
+	, m_voiceRecordProcess( nullptr )
 {
 	setWindowTitle( tr( "Agent Control" ) );
 	setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
@@ -29,12 +37,23 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 	row->addWidget( m_input );
 	row->addWidget( runBtn );
 	layout->addLayout( row );
+	auto voiceRow = new QHBoxLayout();
+	voiceRow->addWidget( m_voiceStartButton );
+	voiceRow->addWidget( m_voiceStopButton );
+	layout->addLayout( voiceRow );
 	layout->addWidget( m_log );
 
 	connect( runBtn, &QPushButton::clicked, this, &AgentControlView::runCommand );
 	connect( m_input, &QLineEdit::returnPressed, this, &AgentControlView::runCommand );
+	connect( m_voiceStartButton, &QPushButton::clicked, this, &AgentControlView::startVoiceCapture );
+	connect( m_voiceStopButton, &QPushButton::clicked, this, &AgentControlView::stopVoiceCapture );
 	connect( m_plugin, &AgentControlPlugin::logMessage, this, &AgentControlView::appendLog );
 	connect( m_plugin, &AgentControlPlugin::commandResult, this, &AgentControlView::appendLog );
+	setVoiceUiState( false );
+	appendLog( tr( "Voice: ffmpeg=%1 whisper=%2 mic=%3" )
+		.arg( ffmpegPath() )
+		.arg( whisperPath() )
+		.arg( microphoneDevice() ) );
 
 	hide();
 	if( parentWidget() )
@@ -45,14 +64,228 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 
 void AgentControlView::runCommand()
 {
-	const QString text = m_input->text();
+	const QString text = m_input->text().trimmed();
+	if( text.isEmpty() )
+	{
+		appendLog( tr( "No command entered" ) );
+		return;
+	}
 	const QString result = m_plugin->handleCommand( text );
 	appendLog( text + " => " + result );
+	m_input->clear();
 }
 
 void AgentControlView::appendLog( const QString &text )
 {
 	m_log->append( text );
+}
+
+void AgentControlView::setVoiceUiState( bool recording )
+{
+	m_voiceStartButton->setEnabled( !recording );
+	m_voiceStopButton->setEnabled( recording );
+	if( recording )
+	{
+		m_status->setText( tr( "Recording voice command..." ) );
+	}
+	else
+	{
+		m_status->setText( tr( "Listening on 127.0.0.1:7777" ) );
+	}
+}
+
+QString AgentControlView::ffmpegPath() const
+{
+	const QString value = qEnvironmentVariable( "LMMS_FFMPEG_BIN" );
+	return value.isEmpty() ? QStringLiteral( "ffmpeg" ) : value;
+}
+
+QString AgentControlView::whisperPath() const
+{
+	const QString value = qEnvironmentVariable( "LMMS_WHISPER_CLI" );
+	return value.isEmpty() ? QStringLiteral( "whisper-cli" ) : value;
+}
+
+QString AgentControlView::microphoneDevice() const
+{
+#if defined( Q_OS_MACOS )
+	const QString fallback = QStringLiteral( "0" );
+#else
+	const QString fallback = QStringLiteral( "default" );
+#endif
+	const QString value = qEnvironmentVariable( "LMMS_MIC_DEVICE" );
+	return value.isEmpty() ? fallback : value;
+}
+
+QStringList AgentControlView::ffmpegCaptureArgs( const QString &outputPath ) const
+{
+	QStringList args;
+	args << QStringLiteral( "-hide_banner" )
+		<< QStringLiteral( "-loglevel" ) << QStringLiteral( "error" );
+#if defined( Q_OS_MACOS )
+	args << QStringLiteral( "-f" ) << QStringLiteral( "avfoundation" )
+		<< QStringLiteral( "-i" ) << QStringLiteral( ":" ) + microphoneDevice();
+#elif defined( Q_OS_LINUX )
+	args << QStringLiteral( "-f" ) << QStringLiteral( "pulse" )
+		<< QStringLiteral( "-i" ) << microphoneDevice();
+#else
+	args << QStringLiteral( "-f" ) << QStringLiteral( "avfoundation" )
+		<< QStringLiteral( "-i" ) << QStringLiteral( ":" ) + microphoneDevice();
+#endif
+	args << QStringLiteral( "-ac" ) << QStringLiteral( "1" )
+		<< QStringLiteral( "-ar" ) << QStringLiteral( "16000" )
+		<< QStringLiteral( "-y" ) << outputPath;
+	return args;
+}
+
+void AgentControlView::startVoiceCapture()
+{
+	if( m_voiceRecordProcess != nullptr )
+	{
+		appendLog( tr( "Voice capture is already running" ) );
+		return;
+	}
+
+	const QString tempDir = QStandardPaths::writableLocation( QStandardPaths::TempLocation );
+	if( tempDir.isEmpty() )
+	{
+		appendLog( tr( "Voice capture failed: no temp directory" ) );
+		return;
+	}
+	m_voiceAudioPath = QDir( tempDir ).filePath(
+		QStringLiteral( "lmms_agent_voice_%1.wav" )
+			.arg( QDateTime::currentMSecsSinceEpoch() ) );
+
+	m_voiceRecordProcess = new QProcess( this );
+	connect( m_voiceRecordProcess,
+		QOverload<QProcess::ProcessError>::of( &QProcess::errorOccurred ),
+		this,
+		&AgentControlView::voiceProcessError );
+
+	const QString ffmpeg = ffmpegPath();
+	m_voiceRecordProcess->start( ffmpeg, ffmpegCaptureArgs( m_voiceAudioPath ) );
+	if( !m_voiceRecordProcess->waitForStarted( 1500 ) )
+	{
+		appendLog( tr( "Voice capture failed: could not start %1" ).arg( ffmpeg ) );
+		m_voiceRecordProcess->deleteLater();
+		m_voiceRecordProcess = nullptr;
+		m_voiceAudioPath.clear();
+		setVoiceUiState( false );
+		return;
+	}
+
+	appendLog( tr( "Voice recording started. Click Stop + Run when done." ) );
+	setVoiceUiState( true );
+}
+
+void AgentControlView::stopVoiceCapture()
+{
+	if( m_voiceRecordProcess == nullptr )
+	{
+		appendLog( tr( "Voice capture is not running" ) );
+		setVoiceUiState( false );
+		return;
+	}
+
+	if( m_voiceRecordProcess->state() != QProcess::NotRunning )
+	{
+		m_voiceRecordProcess->write( "q\n" );
+		m_voiceRecordProcess->closeWriteChannel();
+		if( !m_voiceRecordProcess->waitForFinished( 2500 ) )
+		{
+			m_voiceRecordProcess->terminate();
+			if( !m_voiceRecordProcess->waitForFinished( 1500 ) )
+			{
+				m_voiceRecordProcess->kill();
+				m_voiceRecordProcess->waitForFinished( 1000 );
+			}
+		}
+	}
+
+	const QString ffmpegErrors = QString::fromUtf8( m_voiceRecordProcess->readAllStandardError() ).trimmed();
+	if( !ffmpegErrors.isEmpty() )
+	{
+		appendLog( tr( "ffmpeg: %1" ).arg( ffmpegErrors ) );
+	}
+
+	m_voiceRecordProcess->deleteLater();
+	m_voiceRecordProcess = nullptr;
+	setVoiceUiState( false );
+
+	const QFileInfo audioInfo( m_voiceAudioPath );
+	if( !audioInfo.exists() || audioInfo.size() <= 0 )
+	{
+		appendLog( tr( "Voice capture failed: no audio recorded" ) );
+		m_voiceAudioPath.clear();
+		return;
+	}
+
+	appendLog( tr( "Transcribing voice command..." ) );
+	const QString audioPath = m_voiceAudioPath;
+	m_voiceAudioPath.clear();
+	if( !runWhisperAndDispatch( audioPath ) )
+	{
+		appendLog( tr( "Voice command failed" ) );
+	}
+	QFile::remove( audioPath );
+	QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+}
+
+bool AgentControlView::runWhisperAndDispatch( const QString &audioPath )
+{
+	QProcess whisperProcess;
+	whisperProcess.start( whisperPath(),
+		QStringList{
+			QStringLiteral( "-f" ), audioPath,
+			QStringLiteral( "-otxt" ),
+			QStringLiteral( "-nt" ) } );
+	if( !whisperProcess.waitForStarted( 2000 ) )
+	{
+		appendLog( tr( "Could not start %1. Set LMMS_WHISPER_CLI." ).arg( whisperPath() ) );
+		return false;
+	}
+	if( !whisperProcess.waitForFinished( 60000 ) )
+	{
+		whisperProcess.kill();
+		whisperProcess.waitForFinished( 1000 );
+		appendLog( tr( "Whisper timed out" ) );
+		return false;
+	}
+
+	QString transcript = QString::fromUtf8( whisperProcess.readAllStandardOutput() ).trimmed();
+	if( transcript.isEmpty() )
+	{
+		QFile transcriptFile( audioPath + QStringLiteral( ".txt" ) );
+		if( transcriptFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
+		{
+			transcript = QString::fromUtf8( transcriptFile.readAll() ).trimmed();
+		}
+	}
+	if( transcript.isEmpty() )
+	{
+		const QString whisperErrors = QString::fromUtf8( whisperProcess.readAllStandardError() ).trimmed();
+		appendLog( tr( "Whisper returned no transcript%1" )
+			.arg( whisperErrors.isEmpty() ? QString() : QStringLiteral( ": " ) + whisperErrors ) );
+		return false;
+	}
+
+	appendLog( tr( "Heard: %1" ).arg( transcript ) );
+	m_input->setText( transcript );
+	runCommand();
+	return true;
+}
+
+void AgentControlView::voiceProcessError( QProcess::ProcessError error )
+{
+	if( m_voiceRecordProcess == nullptr )
+	{
+		return;
+	}
+
+	if( error == QProcess::FailedToStart )
+	{
+		appendLog( tr( "Voice capture failed to start. Ensure %1 is installed." ).arg( ffmpegPath() ) );
+	}
 }
 
 } // namespace lmms::gui

--- a/plugins/AgentControl/AgentControlView.cpp
+++ b/plugins/AgentControl/AgentControlView.cpp
@@ -4,11 +4,22 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QHttpMultiPart>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
+#include <QEventLoop>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLabel>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QStandardPaths>
+#include <QThread>
+#include <QTimer>
+#include <QUrl>
 
 #include "AgentControl.h"
 
@@ -22,8 +33,10 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 	, m_log( new QTextEdit( this ) )
 	, m_status( new QLabel( tr( "Listening on 127.0.0.1:7777" ), this ) )
 	, m_voiceStartButton( new QPushButton( tr( "Start Voice" ), this ) )
-	, m_voiceStopButton( new QPushButton( tr( "Stop + Run" ), this ) )
+	, m_voiceStopButton( new QPushButton( tr( "Stop Voice" ), this ) )
 	, m_voiceRecordProcess( nullptr )
+	, m_whisperServiceProcess( nullptr )
+	, m_voiceChunkTimer( new QTimer( this ) )
 {
 	setWindowTitle( tr( "Agent Control" ) );
 	setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
@@ -47,6 +60,9 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 	connect( m_input, &QLineEdit::returnPressed, this, &AgentControlView::runCommand );
 	connect( m_voiceStartButton, &QPushButton::clicked, this, &AgentControlView::startVoiceCapture );
 	connect( m_voiceStopButton, &QPushButton::clicked, this, &AgentControlView::stopVoiceCapture );
+	connect( m_voiceChunkTimer, &QTimer::timeout, this, &AgentControlView::processVoiceChunks );
+	const int configuredPollMs = qEnvironmentVariableIntValue( "LMMS_VOICE_POLL_MS" );
+	m_voiceChunkTimer->setInterval( configuredPollMs > 0 ? qMax( 200, configuredPollMs ) : 350 );
 	connect( m_plugin, &AgentControlPlugin::logMessage, this, &AgentControlView::appendLog );
 	connect( m_plugin, &AgentControlPlugin::commandResult, this, &AgentControlView::appendLog );
 	setVoiceUiState( false );
@@ -54,12 +70,52 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 		.arg( ffmpegPath() )
 		.arg( whisperPath() )
 		.arg( microphoneDevice() ) );
+	if( QFileInfo( whisperPath() ).fileName().toLower() == QStringLiteral( "whisper-cli" ) )
+	{
+		const QString modelPath = whisperModelPath();
+		appendLog( tr( "Whisper model: %1" )
+			.arg( modelPath.isEmpty() ? tr( "not found" ) : modelPath ) );
+	}
+	if( useWhisperService() )
+	{
+		appendLog( tr( "Whisper service mode enabled: %1 (model=%2)" )
+			.arg( whisperServiceBaseUrl(), whisperServiceModel() ) );
+	}
 
 	hide();
 	if( parentWidget() )
 	{
 		parentWidget()->hide();
 	}
+}
+
+AgentControlView::~AgentControlView()
+{
+	if( m_voiceChunkTimer != nullptr )
+	{
+		m_voiceChunkTimer->stop();
+	}
+	if( m_voiceRecordProcess != nullptr )
+	{
+		if( m_voiceRecordProcess->state() != QProcess::NotRunning )
+		{
+			m_voiceRecordProcess->terminate();
+			if( !m_voiceRecordProcess->waitForFinished( 500 ) )
+			{
+				m_voiceRecordProcess->kill();
+				m_voiceRecordProcess->waitForFinished( 500 );
+			}
+		}
+		m_voiceRecordProcess->deleteLater();
+		m_voiceRecordProcess = nullptr;
+	}
+	if( !m_voiceChunkDir.isEmpty() )
+	{
+		QDir chunkDir( m_voiceChunkDir );
+		chunkDir.removeRecursively();
+		m_voiceChunkDir.clear();
+	}
+	shutdownWhisperService();
 }
 
 void AgentControlView::runCommand()
@@ -86,7 +142,7 @@ void AgentControlView::setVoiceUiState( bool recording )
 	m_voiceStopButton->setEnabled( recording );
 	if( recording )
 	{
-		m_status->setText( tr( "Recording voice command..." ) );
+		m_status->setText( tr( "Voice listener running..." ) );
 	}
 	else
 	{
@@ -103,18 +159,321 @@ QString AgentControlView::ffmpegPath() const
 QString AgentControlView::whisperPath() const
 {
 	const QString value = qEnvironmentVariable( "LMMS_WHISPER_CLI" );
-	return value.isEmpty() ? QStringLiteral( "whisper-cli" ) : value;
+	if( !value.isEmpty() )
+	{
+		return value;
+	}
+
+	const QString localWrapper = QDir::home().filePath(
+		QStringLiteral( ".lmms/whisper/lmms-macos-transcribe" ) );
+	const QFileInfo wrapperInfo( localWrapper );
+	if( wrapperInfo.exists() && wrapperInfo.isExecutable() )
+	{
+		return localWrapper;
+	}
+
+	return QStringLiteral( "whisper-cli" );
+}
+
+QString AgentControlView::whisperModelPath() const
+{
+	const QString configured = qEnvironmentVariable( "LMMS_WHISPER_MODEL" );
+	if( !configured.isEmpty() && QFileInfo::exists( configured ) )
+	{
+		return configured;
+	}
+
+	const QStringList candidates =
+	{
+		QDir::home().filePath( QStringLiteral( ".lmms/whisper/ggml-base.en.bin" ) ),
+		QDir::home().filePath( QStringLiteral( ".lmms/whisper/ggml-tiny.en.bin" ) ),
+		QStringLiteral( "/opt/homebrew/share/whisper/ggml-base.en.bin" ),
+		QStringLiteral( "/opt/homebrew/share/whisper/ggml-small.en.bin" ),
+		QStringLiteral( "/opt/homebrew/share/whisper/ggml-tiny.en.bin" )
+	};
+	for( const QString& path : candidates )
+	{
+		if( QFileInfo::exists( path ) )
+		{
+			return path;
+		}
+	}
+	return {};
+}
+
+QString AgentControlView::whisperServiceBaseUrl() const
+{
+	const QString explicitUrl = qEnvironmentVariable( "LMMS_WHISPER_SERVICE_URL" ).trimmed();
+	if( !explicitUrl.isEmpty() )
+	{
+		return explicitUrl;
+	}
+
+	const QString host = qEnvironmentVariable( "LMMS_WHISPER_SERVICE_HOST" ).trimmed().isEmpty()
+		? QStringLiteral( "127.0.0.1" )
+		: qEnvironmentVariable( "LMMS_WHISPER_SERVICE_HOST" ).trimmed();
+	const int envPort = qEnvironmentVariableIntValue( "LMMS_WHISPER_SERVICE_PORT" );
+	const int port = envPort > 0 ? envPort : 50060;
+	return QStringLiteral( "http://%1:%2" ).arg( host ).arg( port );
+}
+
+QString AgentControlView::whisperServiceModel() const
+{
+	const QString model = qEnvironmentVariable( "LMMS_WHISPERKIT_MODEL" ).trimmed();
+	return model.isEmpty() ? QStringLiteral( "tiny" ) : model;
+}
+
+bool AgentControlView::useWhisperService() const
+{
+	const QString mode = qEnvironmentVariable( "LMMS_WHISPER_MODE" ).trimmed().toLower();
+	if( mode == QStringLiteral( "server" ) || mode == QStringLiteral( "service" ) ||
+		mode == QStringLiteral( "persistent" ) )
+	{
+		return true;
+	}
+	if( mode == QStringLiteral( "cli" ) || mode == QStringLiteral( "command" ) )
+	{
+		return false;
+	}
+	if( !qEnvironmentVariable( "LMMS_WHISPER_SERVICE_URL" ).trimmed().isEmpty() )
+	{
+		return true;
+	}
+
+#if defined( Q_OS_MACOS )
+	// Auto-enable local server mode on macOS when using WhisperKit wrapper.
+	return QFileInfo( whisperPath() ).fileName().toLower() == QStringLiteral( "lmms-macos-transcribe" ) &&
+		!QStandardPaths::findExecutable( QStringLiteral( "whisperkit-cli" ) ).isEmpty();
+#else
+	return false;
+#endif
+}
+
+bool AgentControlView::checkWhisperServiceHealth( int timeoutMs, QString& error ) const
+{
+	error.clear();
+
+	QNetworkAccessManager manager;
+	QNetworkRequest request{ QUrl( whisperServiceBaseUrl() + QStringLiteral( "/health" ) ) };
+	QNetworkReply *reply = manager.get( request );
+	QEventLoop loop;
+	QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
+	QTimer::singleShot( qMax( 200, timeoutMs ), &loop, &QEventLoop::quit );
+	loop.exec();
+
+	if( reply->isRunning() )
+	{
+		reply->abort();
+		error = tr( "whisper service health check timed out" );
+		reply->deleteLater();
+		return false;
+	}
+	if( reply->error() != QNetworkReply::NoError )
+	{
+		error = reply->errorString();
+		reply->deleteLater();
+		return false;
+	}
+	reply->deleteLater();
+	return true;
+}
+
+bool AgentControlView::ensureWhisperServiceReady( QString& error )
+{
+	error.clear();
+
+	if( !qEnvironmentVariable( "LMMS_WHISPER_SERVICE_URL" ).trimmed().isEmpty() )
+	{
+		return checkWhisperServiceHealth( 1200, error );
+	}
+
+	if( m_whisperServiceProcess != nullptr && m_whisperServiceProcess->state() != QProcess::NotRunning )
+	{
+		return checkWhisperServiceHealth( 1200, error );
+	}
+
+	const QString serviceBin = qEnvironmentVariable( "LMMS_WHISPER_SERVICE_BIN" ).trimmed().isEmpty()
+		? QStringLiteral( "whisperkit-cli" )
+		: qEnvironmentVariable( "LMMS_WHISPER_SERVICE_BIN" ).trimmed();
+
+	QString resolvedBin = serviceBin;
+	if( QFileInfo( serviceBin ).isRelative() )
+	{
+		const QString found = QStandardPaths::findExecutable( serviceBin );
+		if( !found.isEmpty() )
+		{
+			resolvedBin = found;
+		}
+	}
+	if( !QFileInfo::exists( resolvedBin ) )
+	{
+		error = tr( "whisperkit-cli not found for persistent mode" );
+		return false;
+	}
+
+	const QUrl baseUrl( whisperServiceBaseUrl() );
+	const QString host = baseUrl.host().isEmpty() ? QStringLiteral( "127.0.0.1" ) : baseUrl.host();
+	const int port = baseUrl.port() > 0 ? baseUrl.port() : 50060;
+
+	m_whisperServiceProcess = new QProcess( this );
+	m_whisperServiceProcess->setProcessChannelMode( QProcess::MergedChannels );
+	m_whisperServiceProcess->start(
+		resolvedBin,
+		QStringList{
+			QStringLiteral( "serve" ),
+			QStringLiteral( "--host" ), host,
+			QStringLiteral( "--port" ), QString::number( port ),
+			QStringLiteral( "--model" ), whisperServiceModel(),
+			QStringLiteral( "--without-timestamps" ),
+			QStringLiteral( "--chunking-strategy" ), QStringLiteral( "vad" ),
+			QStringLiteral( "--concurrent-worker-count" ), QStringLiteral( "2" )
+		} );
+	if( !m_whisperServiceProcess->waitForStarted( 2500 ) )
+	{
+		error = tr( "failed to start whisper service" );
+		m_whisperServiceProcess->deleteLater();
+		m_whisperServiceProcess = nullptr;
+		return false;
+	}
+
+	for( int attempt = 0; attempt < 25; ++attempt )
+	{
+		if( checkWhisperServiceHealth( 300, error ) )
+		{
+			return true;
+		}
+		QThread::msleep( 80 );
+	}
+
+	const QString serviceOutput = QString::fromUtf8( m_whisperServiceProcess->readAll() ).trimmed();
+	shutdownWhisperService();
+	error = tr( "whisper service failed to become healthy%1" )
+		.arg( serviceOutput.isEmpty() ? QString() : QStringLiteral( ": " ) + serviceOutput );
+	return false;
+}
+
+bool AgentControlView::transcribeViaWhisperService(
+	const QString &audioPath,
+	QString &transcript,
+	QString& error ) const
+{
+	transcript.clear();
+	error.clear();
+
+	QFileInfo fileInfo( audioPath );
+	if( !fileInfo.exists() || fileInfo.size() <= 0 )
+	{
+		error = tr( "audio file missing for service transcription" );
+		return false;
+	}
+
+	auto *file = new QFile( audioPath );
+	if( !file->open( QIODevice::ReadOnly ) )
+	{
+		delete file;
+		error = tr( "could not open audio for service transcription" );
+		return false;
+	}
+
+	auto *multi = new QHttpMultiPart( QHttpMultiPart::FormDataType );
+	QHttpPart filePart;
+	filePart.setHeader( QNetworkRequest::ContentDispositionHeader,
+		QStringLiteral( "form-data; name=\"file\"; filename=\"%1\"" ).arg( fileInfo.fileName() ) );
+	filePart.setHeader( QNetworkRequest::ContentTypeHeader, QStringLiteral( "audio/wav" ) );
+	filePart.setBodyDevice( file );
+	file->setParent( multi );
+	multi->append( filePart );
+
+	QHttpPart modelPart;
+	modelPart.setHeader( QNetworkRequest::ContentDispositionHeader,
+		QStringLiteral( "form-data; name=\"model\"" ) );
+	modelPart.setBody( whisperServiceModel().toUtf8() );
+	multi->append( modelPart );
+
+	QNetworkAccessManager manager;
+	QNetworkRequest request{ QUrl( whisperServiceBaseUrl() + QStringLiteral( "/v1/audio/transcriptions" ) ) };
+	QNetworkReply *reply = manager.post( request, multi );
+	multi->setParent( reply );
+
+	QEventLoop loop;
+	QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
+	QTimer::singleShot( 30000, &loop, &QEventLoop::quit );
+	loop.exec();
+
+	if( reply->isRunning() )
+	{
+		reply->abort();
+		error = tr( "whisper service transcription timed out" );
+		reply->deleteLater();
+		return false;
+	}
+	if( reply->error() != QNetworkReply::NoError )
+	{
+		error = reply->errorString();
+		reply->deleteLater();
+		return false;
+	}
+
+	const QByteArray body = reply->readAll();
+	reply->deleteLater();
+	const QJsonDocument doc = QJsonDocument::fromJson( body );
+	if( !doc.isObject() )
+	{
+		error = tr( "whisper service returned invalid JSON" );
+		return false;
+	}
+
+	transcript = doc.object().value( "text" ).toString().trimmed();
+	if( transcript.isEmpty() )
+	{
+		error = tr( "whisper service returned empty transcript" );
+		return false;
+	}
+	return true;
+}
+
+void AgentControlView::shutdownWhisperService()
+{
+	if( m_whisperServiceProcess == nullptr )
+	{
+		return;
+	}
+	if( m_whisperServiceProcess->state() != QProcess::NotRunning )
+	{
+		m_whisperServiceProcess->terminate();
+		if( !m_whisperServiceProcess->waitForFinished( 600 ) )
+		{
+			m_whisperServiceProcess->kill();
+			m_whisperServiceProcess->waitForFinished( 600 );
+		}
+	}
+	m_whisperServiceProcess->deleteLater();
+	m_whisperServiceProcess = nullptr;
+	m_whisperServiceReady = false;
 }
 
 QString AgentControlView::microphoneDevice() const
 {
 #if defined( Q_OS_MACOS )
-	const QString fallback = QStringLiteral( "0" );
+	// On many macOS setups device 0 is an aggregate/virtual mic; built-in mic is often 1.
+	const QString fallback = QStringLiteral( "1" );
 #else
 	const QString fallback = QStringLiteral( "default" );
 #endif
 	const QString value = qEnvironmentVariable( "LMMS_MIC_DEVICE" );
 	return value.isEmpty() ? fallback : value;
+}
+
+QString AgentControlView::voiceChunkDirPath() const
+{
+	const QString tempDir = QStandardPaths::writableLocation( QStandardPaths::TempLocation );
+	if( tempDir.isEmpty() )
+	{
+		return QString();
+	}
+	return QDir( tempDir ).filePath(
+		QStringLiteral( "lmms_agent_voice_session_%1" )
+			.arg( QDateTime::currentMSecsSinceEpoch() ) );
 }
 
 QStringList AgentControlView::ffmpegCaptureArgs( const QString &outputPath ) const
@@ -138,6 +497,32 @@ QStringList AgentControlView::ffmpegCaptureArgs( const QString &outputPath ) con
 	return args;
 }
 
+QStringList AgentControlView::ffmpegContinuousCaptureArgs( const QString &outputPattern ) const
+{
+	QStringList args;
+	const QString segmentSeconds = qEnvironmentVariable( "LMMS_VOICE_SEGMENT_SEC" ).trimmed();
+	args << QStringLiteral( "-hide_banner" )
+		<< QStringLiteral( "-loglevel" ) << QStringLiteral( "error" );
+#if defined( Q_OS_MACOS )
+	args << QStringLiteral( "-f" ) << QStringLiteral( "avfoundation" )
+		<< QStringLiteral( "-i" ) << QStringLiteral( ":" ) + microphoneDevice();
+#elif defined( Q_OS_LINUX )
+	args << QStringLiteral( "-f" ) << QStringLiteral( "pulse" )
+		<< QStringLiteral( "-i" ) << microphoneDevice();
+#else
+	args << QStringLiteral( "-f" ) << QStringLiteral( "avfoundation" )
+		<< QStringLiteral( "-i" ) << QStringLiteral( ":" ) + microphoneDevice();
+#endif
+	args << QStringLiteral( "-ac" ) << QStringLiteral( "1" )
+		<< QStringLiteral( "-ar" ) << QStringLiteral( "16000" )
+		<< QStringLiteral( "-f" ) << QStringLiteral( "segment" )
+		<< QStringLiteral( "-segment_time" ) << ( segmentSeconds.isEmpty() ? QStringLiteral( "1.6" ) : segmentSeconds )
+		<< QStringLiteral( "-segment_format" ) << QStringLiteral( "wav" )
+		<< QStringLiteral( "-reset_timestamps" ) << QStringLiteral( "1" )
+		<< QStringLiteral( "-y" ) << outputPattern;
+	return args;
+}
+
 void AgentControlView::startVoiceCapture()
 {
 	if( m_voiceRecordProcess != nullptr )
@@ -146,15 +531,25 @@ void AgentControlView::startVoiceCapture()
 		return;
 	}
 
-	const QString tempDir = QStandardPaths::writableLocation( QStandardPaths::TempLocation );
-	if( tempDir.isEmpty() )
+	m_voiceChunkDir = voiceChunkDirPath();
+	if( m_voiceChunkDir.isEmpty() )
 	{
 		appendLog( tr( "Voice capture failed: no temp directory" ) );
 		return;
 	}
-	m_voiceAudioPath = QDir( tempDir ).filePath(
-		QStringLiteral( "lmms_agent_voice_%1.wav" )
-			.arg( QDateTime::currentMSecsSinceEpoch() ) );
+	if( !QDir().mkpath( m_voiceChunkDir ) )
+	{
+		appendLog( tr( "Voice capture failed: could not create chunk directory" ) );
+		m_voiceChunkDir.clear();
+		return;
+	}
+
+	m_processedVoiceChunks.clear();
+	m_lastDispatchedTranscript.clear();
+	m_pendingTranscript.clear();
+	m_lastDispatchedAtMs = 0;
+	m_voiceAudioPath.clear();
+	m_whisperServiceReady = false;
 
 	m_voiceRecordProcess = new QProcess( this );
 	connect( m_voiceRecordProcess,
@@ -163,18 +558,35 @@ void AgentControlView::startVoiceCapture()
 		&AgentControlView::voiceProcessError );
 
 	const QString ffmpeg = ffmpegPath();
-	m_voiceRecordProcess->start( ffmpeg, ffmpegCaptureArgs( m_voiceAudioPath ) );
+	const QString outputPattern = QDir( m_voiceChunkDir ).filePath( QStringLiteral( "chunk_%06d.wav" ) );
+	m_voiceRecordProcess->start( ffmpeg, ffmpegContinuousCaptureArgs( outputPattern ) );
 	if( !m_voiceRecordProcess->waitForStarted( 1500 ) )
 	{
 		appendLog( tr( "Voice capture failed: could not start %1" ).arg( ffmpeg ) );
 		m_voiceRecordProcess->deleteLater();
 		m_voiceRecordProcess = nullptr;
-		m_voiceAudioPath.clear();
+		QDir( m_voiceChunkDir ).removeRecursively();
+		m_voiceChunkDir.clear();
 		setVoiceUiState( false );
 		return;
 	}
 
-	appendLog( tr( "Voice recording started. Click Stop + Run when done." ) );
+	if( useWhisperService() )
+	{
+		QString serviceError;
+		if( ensureWhisperServiceReady( serviceError ) )
+		{
+			m_whisperServiceReady = true;
+			appendLog( tr( "Whisper service is warm and ready." ) );
+		}
+		else
+		{
+			appendLog( tr( "Whisper service warmup failed: %1. Falling back to CLI transcription." ).arg( serviceError ) );
+		}
+	}
+
+	m_voiceChunkTimer->start();
+	appendLog( tr( "Voice listener started. Relevant commands execute automatically." ) );
 	setVoiceUiState( true );
 }
 
@@ -185,6 +597,11 @@ void AgentControlView::stopVoiceCapture()
 		appendLog( tr( "Voice capture is not running" ) );
 		setVoiceUiState( false );
 		return;
+	}
+
+	if( m_voiceChunkTimer != nullptr )
+	{
+		m_voiceChunkTimer->stop();
 	}
 
 	if( m_voiceRecordProcess->state() != QProcess::NotRunning )
@@ -212,67 +629,441 @@ void AgentControlView::stopVoiceCapture()
 	m_voiceRecordProcess = nullptr;
 	setVoiceUiState( false );
 
-	const QFileInfo audioInfo( m_voiceAudioPath );
-	if( !audioInfo.exists() || audioInfo.size() <= 0 )
+	// Process final chunk files after ffmpeg exits.
+	processVoiceChunks();
+
+	if( !m_voiceChunkDir.isEmpty() )
 	{
-		appendLog( tr( "Voice capture failed: no audio recorded" ) );
-		m_voiceAudioPath.clear();
+		QDir( m_voiceChunkDir ).removeRecursively();
+		m_voiceChunkDir.clear();
+	}
+	m_processedVoiceChunks.clear();
+	m_pendingTranscript.clear();
+	m_whisperServiceReady = false;
+	appendLog( tr( "Voice listener stopped." ) );
+}
+
+void AgentControlView::processVoiceChunks()
+{
+	if( m_voiceChunkDir.isEmpty() )
+	{
 		return;
 	}
 
-	appendLog( tr( "Transcribing voice command..." ) );
-	const QString audioPath = m_voiceAudioPath;
-	m_voiceAudioPath.clear();
-	if( !runWhisperAndDispatch( audioPath ) )
+	QDir chunkDir( m_voiceChunkDir );
+	if( !chunkDir.exists() )
 	{
-		appendLog( tr( "Voice command failed" ) );
+		return;
 	}
-	QFile::remove( audioPath );
-	QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+
+	const QStringList files = chunkDir.entryList(
+		QStringList{ QStringLiteral( "chunk_*.wav" ) },
+		QDir::Files,
+		QDir::Name );
+	const bool isRecording = m_voiceRecordProcess != nullptr &&
+		m_voiceRecordProcess->state() != QProcess::NotRunning;
+
+	for( int i = 0; i < files.size(); ++i )
+	{
+		const QString& fileName = files[i];
+		if( m_processedVoiceChunks.contains( fileName ) )
+		{
+			continue;
+		}
+		// Skip the newest segment while ffmpeg is still writing.
+		if( isRecording && i == files.size() - 1 )
+		{
+			continue;
+		}
+
+		const QString audioPath = chunkDir.filePath( fileName );
+		const QFileInfo audioInfo( audioPath );
+		if( !audioInfo.exists() || audioInfo.size() < 2048 )
+		{
+			continue;
+		}
+
+		m_processedVoiceChunks.insert( fileName );
+		QString transcript;
+		if( transcribeAudio( audioPath, transcript, true ) )
+		{
+			dispatchTranscript( transcript );
+		}
+
+		QFile::remove( audioPath );
+		QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+	}
+}
+
+bool AgentControlView::transcribeAudio(
+	const QString &audioPath,
+	QString &transcript,
+	bool quietNoTranscript )
+{
+	transcript.clear();
+	if( useWhisperService() )
+	{
+		QString serviceError;
+		if( !m_whisperServiceReady )
+		{
+			m_whisperServiceReady = ensureWhisperServiceReady( serviceError );
+			if( !m_whisperServiceReady && !quietNoTranscript && !serviceError.isEmpty() )
+			{
+				appendLog( tr( "Whisper service unavailable: %1. Falling back to CLI." ).arg( serviceError ) );
+			}
+		}
+		if( m_whisperServiceReady && transcribeViaWhisperService( audioPath, transcript, serviceError ) )
+		{
+			if( !quietNoTranscript )
+			{
+				appendLog( tr( "Whisper service transcription completed." ) );
+			}
+		}
+		else if( m_whisperServiceReady )
+		{
+			m_whisperServiceReady = false;
+			if( !quietNoTranscript && !serviceError.isEmpty() )
+			{
+				appendLog( tr( "Whisper service transcription failed: %1. Falling back to CLI." ).arg( serviceError ) );
+			}
+		}
+	}
+
+	if( transcript.isEmpty() )
+	{
+		const QString whisperCmd = whisperPath();
+		QStringList whisperArgs{
+			QStringLiteral( "-f" ), audioPath,
+			QStringLiteral( "-otxt" ),
+			QStringLiteral( "-nt" ) };
+
+		const QFileInfo whisperInfo( whisperCmd );
+		const QString binaryName = whisperInfo.fileName().toLower();
+		if( binaryName == QStringLiteral( "whisper-cli" ) )
+		{
+			const QString modelPath = whisperModelPath();
+			if( modelPath.isEmpty() )
+			{
+				if( !quietNoTranscript )
+				{
+					appendLog( tr( "No Whisper model found. Set LMMS_WHISPER_MODEL or LMMS_WHISPER_CLI." ) );
+				}
+				return false;
+			}
+			whisperArgs << QStringLiteral( "-m" ) << modelPath;
+		}
+
+		QProcess whisperProcess;
+		whisperProcess.start( whisperCmd, whisperArgs );
+		if( !whisperProcess.waitForStarted( 2000 ) )
+		{
+			if( !quietNoTranscript )
+			{
+				appendLog( tr( "Could not start %1. Set LMMS_WHISPER_CLI." ).arg( whisperCmd ) );
+			}
+			return false;
+		}
+		if( !whisperProcess.waitForFinished( 60000 ) )
+		{
+			whisperProcess.kill();
+			whisperProcess.waitForFinished( 1000 );
+			if( !quietNoTranscript )
+			{
+				appendLog( tr( "Whisper timed out" ) );
+			}
+			return false;
+		}
+
+		transcript = QString::fromUtf8( whisperProcess.readAllStandardOutput() ).trimmed();
+		if( transcript.isEmpty() )
+		{
+			QFile transcriptFile( audioPath + QStringLiteral( ".txt" ) );
+			if( transcriptFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
+			{
+				transcript = QString::fromUtf8( transcriptFile.readAll() ).trimmed();
+			}
+		}
+		if( transcript.isEmpty() )
+		{
+			const QString whisperErrors = QString::fromUtf8( whisperProcess.readAllStandardError() ).trimmed();
+			if( !quietNoTranscript )
+			{
+				appendLog( tr( "Whisper returned no transcript%1" )
+					.arg( whisperErrors.isEmpty() ? QString() : QStringLiteral( ": " ) + whisperErrors ) );
+				if( whisperErrors.contains( QStringLiteral( "whisperkit transcription failed" ), Qt::CaseInsensitive ) )
+				{
+					appendLog( tr( "No speech detected. Try speaking louder/longer and set LMMS_MIC_DEVICE (macOS often uses 1)." ) );
+				}
+			}
+			return false;
+		}
+	}
+
+	return !transcript.trimmed().isEmpty();
+}
+
+bool AgentControlView::looksLikeCommandTranscript( const QString& transcript ) const
+{
+	QString normalized = transcript.toLower().simplified();
+	if( normalized.isEmpty() )
+	{
+		return false;
+	}
+
+	normalized.remove( QRegularExpression(
+		R"(^(?:(?:hey|hi|yo|okay|ok|please|pls)\s+)*(?:(?:can|could|would)\s+(?:you|u)\s+)?(?:please|pls\s+)?(?:just\s+)?)",
+		QRegularExpression::CaseInsensitiveOption ) );
+	normalized = normalized.simplified();
+
+	const QStringList rawParts = normalized.split( ' ', Qt::SkipEmptyParts );
+	QStringList tokens;
+	for( QString token : rawParts )
+	{
+		token.remove( QRegularExpression( R"(^[^\w]+|[^\w]+$)" ) );
+		if( !token.isEmpty() )
+		{
+			tokens << token;
+		}
+	}
+	if( tokens.isEmpty() )
+	{
+		return false;
+	}
+
+	const QSet<QString> singleCommands = { QStringLiteral( "undo" ), QStringLiteral( "help" ) };
+	if( singleCommands.contains( tokens.first() ) )
+	{
+		return true;
+	}
+
+	const QSet<QString> actionKeywords =
+	{
+		QStringLiteral( "open" ), QStringLiteral( "show" ), QStringLiteral( "new" ),
+		QStringLiteral( "create" ), QStringLiteral( "make" ), QStringLiteral( "import" ),
+		QStringLiteral( "load" ), QStringLiteral( "set" ), QStringLiteral( "add" ),
+		QStringLiteral( "remove" ), QStringLiteral( "mute" ), QStringLiteral( "solo" ),
+		QStringLiteral( "undo" ), QStringLiteral( "tempo" ), QStringLiteral( "bpm" ),
+		QStringLiteral( "divide" ), QStringLiteral( "split" ), QStringLiteral( "slice" ),
+		QStringLiteral( "raise" ), QStringLiteral( "lower" ), QStringLiteral( "increase" ),
+		QStringLiteral( "decrease" )
+	};
+	const QSet<QString> domainKeywords =
+	{
+		QStringLiteral( "track" ), QStringLiteral( "instrument" ), QStringLiteral( "sample" ),
+		QStringLiteral( "automation" ), QStringLiteral( "pattern" ), QStringLiteral( "mixer" ),
+		QStringLiteral( "song" ), QStringLiteral( "editor" ), QStringLiteral( "slicer" ),
+		QStringLiteral( "segments" ), QStringLiteral( "transient" ), QStringLiteral( "kick" ),
+		QStringLiteral( "drums" ), QStringLiteral( "tempo" ), QStringLiteral( "bpm" )
+	};
+
+	const bool firstIsAction = actionKeywords.contains( tokens.first() );
+	bool hasAction = firstIsAction;
+	bool hasDomain = false;
+	for( const QString& token : tokens )
+	{
+		if( actionKeywords.contains( token ) )
+		{
+			hasAction = true;
+		}
+		if( domainKeywords.contains( token ) )
+		{
+			hasDomain = true;
+		}
+	}
+
+	if( firstIsAction && hasDomain )
+	{
+		return true;
+	}
+	if( ( hasAction || hasDomain ) && tokens.size() <= 8 )
+	{
+		return true;
+	}
+	if( QRegularExpression( R"(\b\d{2,3}\s*bpm\b)", QRegularExpression::CaseInsensitiveOption )
+		.match( normalized ).hasMatch() )
+	{
+		return true;
+	}
+	return false;
+}
+
+bool AgentControlView::dispatchTranscript( const QString& transcript )
+{
+	const QString cleanTranscript = transcript.trimmed();
+	if( cleanTranscript.isEmpty() )
+	{
+		return false;
+	}
+
+	QStringList candidates;
+	candidates << cleanTranscript;
+	if( !m_pendingTranscript.isEmpty() )
+	{
+		candidates << ( m_pendingTranscript + QStringLiteral( " " ) + cleanTranscript ).simplified();
+	}
+
+	for( const QString& candidate : candidates )
+	{
+		if( candidate.isEmpty() )
+		{
+			continue;
+		}
+		if( !looksLikeCommandTranscript( candidate ) )
+		{
+			continue;
+		}
+
+		QString commandText = candidate;
+		QString fastCommand;
+		if( canonicalizeFastCommand( candidate, fastCommand ) )
+		{
+			commandText = fastCommand;
+		}
+
+		const QString normalized = commandText.toLower().simplified();
+		const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+		if( normalized == m_lastDispatchedTranscript && nowMs - m_lastDispatchedAtMs < 2500 )
+		{
+			return false;
+		}
+
+		const QString result = m_plugin->handleCommand( commandText );
+		if( result.startsWith( QStringLiteral( "Unknown command:" ), Qt::CaseInsensitive ) ||
+			result.startsWith( QStringLiteral( "Unknown window:" ), Qt::CaseInsensitive ) ||
+			result.startsWith( QStringLiteral( "Unknown instrument:" ), Qt::CaseInsensitive ) )
+		{
+			continue;
+		}
+
+		appendLog( tr( "Heard: %1" ).arg( cleanTranscript ) );
+		if( commandText.compare( cleanTranscript, Qt::CaseInsensitive ) != 0 )
+		{
+			appendLog( tr( "Fast map: %1" ).arg( commandText ) );
+		}
+		appendLog( commandText + QStringLiteral( " => " ) + result );
+		m_lastDispatchedTranscript = normalized;
+		m_lastDispatchedAtMs = nowMs;
+		m_pendingTranscript.clear();
+		return true;
+	}
+
+	const QStringList tokens = cleanTranscript.toLower().simplified().split( ' ', Qt::SkipEmptyParts );
+	if( tokens.size() <= 3 )
+	{
+		m_pendingTranscript = cleanTranscript;
+	}
+	else
+	{
+		m_pendingTranscript = tokens.mid( qMax( 0, tokens.size() - 3 ) ).join( ' ' );
+	}
+	return false;
+}
+
+bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QString& command ) const
+{
+	command.clear();
+	const QString normalized = transcript.toLower().simplified();
+	if( normalized.isEmpty() )
+	{
+		return false;
+	}
+
+	if( normalized.contains( QStringLiteral( "open" ) ) &&
+		( normalized.contains( QStringLiteral( "slicer" ) ) || normalized.contains( QStringLiteral( "splicer" ) ) ) )
+	{
+		command = QStringLiteral( "open slicer" );
+		return true;
+	}
+	if( normalized == QStringLiteral( "slicer" ) || normalized == QStringLiteral( "splicer" ) )
+	{
+		command = QStringLiteral( "open slicer" );
+		return true;
+	}
+
+	if( normalized.contains( QStringLiteral( "import" ) ) &&
+		( normalized.contains( QStringLiteral( "slicer" ) ) || normalized.contains( QStringLiteral( "splicer" ) ) ) )
+	{
+		const QRegularExpression filePattern(
+			R"(\b([a-z0-9._-]+\.(?:wav|mp3|flac|aiff|ogg|m4a))\b)",
+			QRegularExpression::CaseInsensitiveOption );
+		const auto fileMatch = filePattern.match( normalized );
+		const QString fileName = fileMatch.hasMatch() ? fileMatch.captured( 1 ) : QStringLiteral( "sample.wav" );
+		command = QStringLiteral( "import %1 into slicer" ).arg( fileName );
+		return true;
+	}
+
+	if( ( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) &&
+		normalized.contains( QStringLiteral( "transient" ) ) )
+	{
+		command = QStringLiteral( "divide into transient segments" );
+		return true;
+	}
+
+	if( ( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) &&
+		normalized.contains( QStringLiteral( "equal" ) ) &&
+		normalized.contains( QStringLiteral( "segment" ) ) )
+	{
+		command = QStringLiteral( "divide into equal segments" );
+		return true;
+	}
+
+	if( ( normalized.contains( QStringLiteral( "create" ) ) || normalized.contains( QStringLiteral( "new" ) ) ||
+		  normalized.contains( QStringLiteral( "make" ) ) ) &&
+		normalized.contains( QStringLiteral( "instrument" ) ) &&
+		normalized.contains( QStringLiteral( "track" ) ) )
+	{
+		command = QStringLiteral( "create instrument track" );
+		return true;
+	}
+
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		normalized.contains( QStringLiteral( "piano" ) ) &&
+		( normalized.contains( QStringLiteral( "roll" ) ) || normalized.contains( QStringLiteral( "role" ) ) ) )
+	{
+		command = QStringLiteral( "open piano roll" );
+		return true;
+	}
+
+	if( normalized.contains( QStringLiteral( "add" ) ) &&
+		( normalized.contains( QStringLiteral( "kick" ) ) || normalized.contains( QStringLiteral( "808" ) ) ||
+		  normalized.contains( QStringLiteral( "drum" ) ) ) )
+	{
+		command = QStringLiteral( "add kick drums" );
+		return true;
+	}
+	if( normalized.contains( QStringLiteral( "kick" ) ) || normalized.contains( QStringLiteral( "808" ) ) )
+	{
+		command = QStringLiteral( "add kick drums" );
+		return true;
+	}
+
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		normalized.contains( QStringLiteral( "song" ) ) &&
+		( normalized.contains( QStringLiteral( "editor" ) ) || normalized.contains( QStringLiteral( "edit" ) ) ) )
+	{
+		command = QStringLiteral( "open song editor" );
+		return true;
+	}
+
+	const QRegularExpression bpmPattern( R"(\b(\d{2,3})\s*bpm\b)", QRegularExpression::CaseInsensitiveOption );
+	const auto bpmMatch = bpmPattern.match( normalized );
+	if( bpmMatch.hasMatch() )
+	{
+		command = QStringLiteral( "set tempo to %1" ).arg( bpmMatch.captured( 1 ) );
+		return true;
+	}
+
+	return false;
 }
 
 bool AgentControlView::runWhisperAndDispatch( const QString &audioPath )
 {
-	QProcess whisperProcess;
-	whisperProcess.start( whisperPath(),
-		QStringList{
-			QStringLiteral( "-f" ), audioPath,
-			QStringLiteral( "-otxt" ),
-			QStringLiteral( "-nt" ) } );
-	if( !whisperProcess.waitForStarted( 2000 ) )
+	QString transcript;
+	if( !transcribeAudio( audioPath, transcript, false ) )
 	{
-		appendLog( tr( "Could not start %1. Set LMMS_WHISPER_CLI." ).arg( whisperPath() ) );
 		return false;
 	}
-	if( !whisperProcess.waitForFinished( 60000 ) )
-	{
-		whisperProcess.kill();
-		whisperProcess.waitForFinished( 1000 );
-		appendLog( tr( "Whisper timed out" ) );
-		return false;
-	}
-
-	QString transcript = QString::fromUtf8( whisperProcess.readAllStandardOutput() ).trimmed();
-	if( transcript.isEmpty() )
-	{
-		QFile transcriptFile( audioPath + QStringLiteral( ".txt" ) );
-		if( transcriptFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
-		{
-			transcript = QString::fromUtf8( transcriptFile.readAll() ).trimmed();
-		}
-	}
-	if( transcript.isEmpty() )
-	{
-		const QString whisperErrors = QString::fromUtf8( whisperProcess.readAllStandardError() ).trimmed();
-		appendLog( tr( "Whisper returned no transcript%1" )
-			.arg( whisperErrors.isEmpty() ? QString() : QStringLiteral( ": " ) + whisperErrors ) );
-		return false;
-	}
-
-	appendLog( tr( "Heard: %1" ).arg( transcript ) );
-	m_input->setText( transcript );
-	runCommand();
-	return true;
+	return dispatchTranscript( transcript );
 }
 
 void AgentControlView::voiceProcessError( QProcess::ProcessError error )

--- a/plugins/AgentControl/AgentControlView.cpp
+++ b/plugins/AgentControl/AgentControlView.cpp
@@ -1,0 +1,58 @@
+#include "AgentControlView.h"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+
+#include "AgentControl.h"
+
+namespace lmms::gui
+{
+
+AgentControlView::AgentControlView( AgentControlPlugin *plugin )
+	: ToolPluginView( plugin )
+	, m_plugin( plugin )
+	, m_input( new QLineEdit( this ) )
+	, m_log( new QTextEdit( this ) )
+	, m_status( new QLabel( tr( "Listening on 127.0.0.1:7777" ), this ) )
+{
+	setWindowTitle( tr( "Agent Control" ) );
+	setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
+	m_log->setReadOnly( true );
+	m_input->setPlaceholderText( tr( "Try: import kick.wav or add 808" ) );
+
+	auto runBtn = new QPushButton( tr( "Run" ), this );
+	auto layout = new QVBoxLayout( this );
+	layout->addWidget( m_status );
+	auto row = new QHBoxLayout();
+	row->addWidget( m_input );
+	row->addWidget( runBtn );
+	layout->addLayout( row );
+	layout->addWidget( m_log );
+
+	connect( runBtn, &QPushButton::clicked, this, &AgentControlView::runCommand );
+	connect( m_input, &QLineEdit::returnPressed, this, &AgentControlView::runCommand );
+	connect( m_plugin, &AgentControlPlugin::logMessage, this, &AgentControlView::appendLog );
+	connect( m_plugin, &AgentControlPlugin::commandResult, this, &AgentControlView::appendLog );
+
+	hide();
+	if( parentWidget() )
+	{
+		parentWidget()->hide();
+	}
+}
+
+void AgentControlView::runCommand()
+{
+	const QString text = m_input->text();
+	const QString result = m_plugin->handleCommand( text );
+	appendLog( text + " => " + result );
+}
+
+void AgentControlView::appendLog( const QString &text )
+{
+	m_log->append( text );
+}
+
+} // namespace lmms::gui

--- a/plugins/AgentControl/AgentControlView.cpp
+++ b/plugins/AgentControl/AgentControlView.cpp
@@ -8,6 +8,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QEventLoop>
+#include <QElapsedTimer>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLabel>
@@ -20,6 +21,8 @@
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
+
+#include <cstdint>
 
 #include "AgentControl.h"
 
@@ -62,7 +65,7 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 	connect( m_voiceStopButton, &QPushButton::clicked, this, &AgentControlView::stopVoiceCapture );
 	connect( m_voiceChunkTimer, &QTimer::timeout, this, &AgentControlView::processVoiceChunks );
 	const int configuredPollMs = qEnvironmentVariableIntValue( "LMMS_VOICE_POLL_MS" );
-	m_voiceChunkTimer->setInterval( configuredPollMs > 0 ? qMax( 200, configuredPollMs ) : 350 );
+	m_voiceChunkTimer->setInterval( configuredPollMs > 0 ? qMax( 150, configuredPollMs ) : 250 );
 	connect( m_plugin, &AgentControlPlugin::logMessage, this, &AgentControlView::appendLog );
 	connect( m_plugin, &AgentControlPlugin::commandResult, this, &AgentControlView::appendLog );
 	setVoiceUiState( false );
@@ -81,6 +84,12 @@ AgentControlView::AgentControlView( AgentControlPlugin *plugin )
 		appendLog( tr( "Whisper service mode enabled: %1 (model=%2)" )
 			.arg( whisperServiceBaseUrl(), whisperServiceModel() ) );
 	}
+	appendLog( tr( "Wake mode: required=%1 phrases=%2 window_ms=%3" )
+		.arg( wakePhraseRequired() ? tr( "yes" ) : tr( "no" ) )
+		.arg( wakePhrases().join( ", " ) )
+		.arg( qEnvironmentVariableIntValue( "LMMS_WAKE_WINDOW_MS" ) > 0
+			? qEnvironmentVariableIntValue( "LMMS_WAKE_WINDOW_MS" )
+			: 8000 ) );
 
 	hide();
 	if( parentWidget() )
@@ -115,6 +124,9 @@ AgentControlView::~AgentControlView()
 		chunkDir.removeRecursively();
 		m_voiceChunkDir.clear();
 	}
+	m_voiceChunkStates.clear();
+	m_processingVoiceChunks = false;
+	m_reprocessVoiceChunks = false;
 	shutdownWhisperService();
 }
 
@@ -523,6 +535,224 @@ QStringList AgentControlView::ffmpegContinuousCaptureArgs( const QString &output
 	return args;
 }
 
+QString AgentControlView::normalizeTranscriptForCommand( const QString& transcript ) const
+{
+	QString normalized = transcript.trimmed().toLower();
+	normalized.replace( QRegularExpression( R"([\u2018\u2019])" ), QStringLiteral( "'" ) );
+	normalized.replace( QRegularExpression( R"([\u201c\u201d])" ), QStringLiteral( "\"" ) );
+	normalized.replace( QRegularExpression( R"(\s+)" ), QStringLiteral( " " ) );
+	return normalized.simplified();
+}
+
+bool AgentControlView::wakePhraseRequired() const
+{
+	const QString raw = qEnvironmentVariable( "LMMS_WAKE_REQUIRED" ).trimmed().toLower();
+	if( raw.isEmpty() )
+	{
+		return true;
+	}
+	return !( raw == QStringLiteral( "0" ) ||
+		raw == QStringLiteral( "false" ) ||
+		raw == QStringLiteral( "off" ) ||
+		raw == QStringLiteral( "no" ) );
+}
+
+QStringList AgentControlView::wakePhrases() const
+{
+	const QString configured = qEnvironmentVariable( "LMMS_WAKE_PHRASES" ).trimmed();
+	QStringList phrases;
+	if( configured.isEmpty() )
+	{
+		phrases << QStringLiteral( "hey lmms" );
+		phrases << QStringLiteral( "ok lmms" );
+	}
+	else
+	{
+		phrases = configured.split( ',', Qt::SkipEmptyParts );
+		for( QString& phrase : phrases )
+		{
+			phrase = normalizeTranscriptForCommand( phrase );
+		}
+	}
+	phrases.removeDuplicates();
+	return phrases;
+}
+
+bool AgentControlView::extractWakeCommand(
+	const QString& transcript,
+	QString& commandRemainder,
+	bool& wakeDetected ) const
+{
+	wakeDetected = false;
+	commandRemainder = normalizeTranscriptForCommand( transcript );
+	if( commandRemainder.isEmpty() )
+	{
+		return false;
+	}
+
+	for( const QString& wake : wakePhrases() )
+	{
+		if( wake.isEmpty() )
+		{
+			continue;
+		}
+		const int idx = commandRemainder.indexOf( wake );
+		if( idx < 0 )
+		{
+			continue;
+		}
+
+		wakeDetected = true;
+		commandRemainder.remove( idx, wake.size() );
+		commandRemainder = commandRemainder.simplified();
+		return true;
+	}
+	return false;
+}
+
+QStringList AgentControlView::splitCommandChain( const QString& transcript ) const
+{
+	QString chain = normalizeTranscriptForCommand( transcript );
+	chain.replace( QRegularExpression( R"(\b(?:and then|then|after that|next)\b)" ),
+		QStringLiteral( "|" ) );
+	chain.replace( QRegularExpression(
+		R"(\band\s+(?=(?:open|show|new|create|make|import|load|set|add|remove|mute|solo|undo|divide|split|slice|raise|lower|increase|decrease|save|export)\b))" ),
+		QStringLiteral( "|" ) );
+	chain.replace( QRegularExpression( R"([,;])" ), QStringLiteral( "|" ) );
+
+	QStringList segments;
+	for( const QString& segment : chain.split( '|', Qt::SkipEmptyParts ) )
+	{
+		const QString trimmed = segment.trimmed();
+		if( !trimmed.isEmpty() )
+		{
+			segments << trimmed;
+		}
+	}
+	return segments;
+}
+
+QString AgentControlView::applyContextHints( const QString& commandText ) const
+{
+	QString out = normalizeTranscriptForCommand( commandText );
+	if( out.isEmpty() )
+	{
+		return out;
+	}
+
+	if( !m_lastContextImportedFile.isEmpty() &&
+		( out.contains( QStringLiteral( "this sample" ) ) || out.contains( QStringLiteral( "that sample" ) ) ||
+		  out.contains( QStringLiteral( "this file" ) ) || out.contains( QStringLiteral( "that file" ) ) ||
+		  out.contains( QStringLiteral( "it " ) ) || out.endsWith( QStringLiteral( " it" ) ) ) )
+	{
+		out.replace( QRegularExpression( R"(\b(this|that)\s+(sample|file|audio)\b)" ), m_lastContextImportedFile );
+		out.replace( QRegularExpression( R"(\bit\b)" ), m_lastContextImportedFile );
+	}
+
+	return out.simplified();
+}
+
+void AgentControlView::updateVoiceContextFromCommand( const QString& commandText )
+{
+	const QString normalized = normalizeTranscriptForCommand( commandText );
+	if( normalized.contains( QStringLiteral( "slicer" ) ) )
+	{
+		m_lastContextPlugin = QStringLiteral( "slicer" );
+	}
+	if( normalized.contains( QStringLiteral( "piano roll" ) ) )
+	{
+		m_lastContextWindow = QStringLiteral( "piano roll" );
+	}
+	if( normalized.contains( QStringLiteral( "song editor" ) ) )
+	{
+		m_lastContextWindow = QStringLiteral( "song editor" );
+	}
+	if( normalized.contains( QStringLiteral( "instrument track" ) ) )
+	{
+		m_lastContextTrack = QStringLiteral( "instrument track" );
+	}
+	if( normalized.contains( QStringLiteral( "sample track" ) ) )
+	{
+		m_lastContextTrack = QStringLiteral( "sample track" );
+	}
+
+	const QRegularExpression filePattern(
+		R"(\b([a-z0-9._-]+\.(?:wav|wave|aif|aiff|flac|ogg|mp3|m4a))\b)",
+		QRegularExpression::CaseInsensitiveOption );
+	const auto match = filePattern.match( normalized );
+	if( match.hasMatch() )
+	{
+		m_lastContextImportedFile = match.captured( 1 );
+	}
+}
+
+bool AgentControlView::isLikelySilentWav( const QString& audioPath, double* meanAbs ) const
+{
+	if( meanAbs != nullptr )
+	{
+		*meanAbs = 0.0;
+	}
+
+	QFile file( audioPath );
+	if( !file.open( QIODevice::ReadOnly ) )
+	{
+		return false;
+	}
+	const QByteArray data = file.readAll();
+	if( data.size() <= 48 )
+	{
+		return true;
+	}
+
+	const int start = qMin( 44, data.size() );
+	const char* bytes = data.constData() + start;
+	const int sampleBytes = data.size() - start;
+	const int16_t* samples = reinterpret_cast<const int16_t*>( bytes );
+	const int sampleCount = sampleBytes / static_cast<int>( sizeof( int16_t ) );
+	if( sampleCount <= 0 )
+	{
+		return true;
+	}
+
+	const int stride = qMax( 1, sampleCount / 12000 );
+	qint64 totalAbs = 0;
+	int counted = 0;
+	for( int i = 0; i < sampleCount; i += stride )
+	{
+		totalAbs += qAbs( static_cast<int>( samples[i] ) );
+		++counted;
+	}
+	if( counted <= 0 )
+	{
+		return true;
+	}
+
+	const double avgAbs = static_cast<double>( totalAbs ) / static_cast<double>( counted );
+	if( meanAbs != nullptr )
+	{
+		*meanAbs = avgAbs;
+	}
+
+	const int threshold = qEnvironmentVariableIntValue( "LMMS_VOICE_SILENCE_ABS_THRESHOLD" ) > 0
+		? qEnvironmentVariableIntValue( "LMMS_VOICE_SILENCE_ABS_THRESHOLD" )
+		: 120;
+	return avgAbs < static_cast<double>( threshold );
+}
+
+void AgentControlView::appendTrace( const QString& stage, const QJsonObject& payload ) const
+{
+	if( qEnvironmentVariableIntValue( "LMMS_VOICE_TRACE" ) != 1 )
+	{
+		return;
+	}
+
+	QJsonObject event = payload;
+	event.insert( QStringLiteral( "stage" ), stage );
+	event.insert( QStringLiteral( "ts_ms" ), QString::number( QDateTime::currentMSecsSinceEpoch() ) );
+	const QString json = QString::fromUtf8( QJsonDocument( event ).toJson( QJsonDocument::Compact ) );
+	const_cast<AgentControlView*>( this )->appendLog( QStringLiteral( "TRACE %1" ).arg( json ) );
+}
+
 void AgentControlView::startVoiceCapture()
 {
 	if( m_voiceRecordProcess != nullptr )
@@ -544,12 +774,17 @@ void AgentControlView::startVoiceCapture()
 		return;
 	}
 
-	m_processedVoiceChunks.clear();
+	m_voiceChunkStates.clear();
+	m_processingVoiceChunks = false;
+	m_reprocessVoiceChunks = false;
 	m_lastDispatchedTranscript.clear();
 	m_pendingTranscript.clear();
 	m_lastDispatchedAtMs = 0;
+	m_wakeWindowUntilMs = 0;
 	m_voiceAudioPath.clear();
 	m_whisperServiceReady = false;
+	m_whisperServiceFailureCount = 0;
+	m_whisperServiceCooldownUntilMs = 0;
 
 	m_voiceRecordProcess = new QProcess( this );
 	connect( m_voiceRecordProcess,
@@ -586,6 +821,11 @@ void AgentControlView::startVoiceCapture()
 	}
 
 	m_voiceChunkTimer->start();
+	appendTrace( QStringLiteral( "voice_start" ), QJsonObject
+	{
+		{ "poll_ms", m_voiceChunkTimer->interval() },
+		{ "wake_required", wakePhraseRequired() }
+	} );
 	appendLog( tr( "Voice listener started. Relevant commands execute automatically." ) );
 	setVoiceUiState( true );
 }
@@ -637,9 +877,15 @@ void AgentControlView::stopVoiceCapture()
 		QDir( m_voiceChunkDir ).removeRecursively();
 		m_voiceChunkDir.clear();
 	}
-	m_processedVoiceChunks.clear();
+	m_voiceChunkStates.clear();
 	m_pendingTranscript.clear();
 	m_whisperServiceReady = false;
+	m_whisperServiceFailureCount = 0;
+	m_whisperServiceCooldownUntilMs = 0;
+	m_processingVoiceChunks = false;
+	m_reprocessVoiceChunks = false;
+	m_wakeWindowUntilMs = 0;
+	appendTrace( QStringLiteral( "voice_stop" ) );
 	appendLog( tr( "Voice listener stopped." ) );
 }
 
@@ -649,50 +895,120 @@ void AgentControlView::processVoiceChunks()
 	{
 		return;
 	}
-
-	QDir chunkDir( m_voiceChunkDir );
-	if( !chunkDir.exists() )
+	if( m_processingVoiceChunks )
 	{
+		m_reprocessVoiceChunks = true;
 		return;
 	}
 
-	const QStringList files = chunkDir.entryList(
-		QStringList{ QStringLiteral( "chunk_*.wav" ) },
-		QDir::Files,
-		QDir::Name );
-	const bool isRecording = m_voiceRecordProcess != nullptr &&
-		m_voiceRecordProcess->state() != QProcess::NotRunning;
-
-	for( int i = 0; i < files.size(); ++i )
+	m_processingVoiceChunks = true;
+	do
 	{
-		const QString& fileName = files[i];
-		if( m_processedVoiceChunks.contains( fileName ) )
+		m_reprocessVoiceChunks = false;
+
+		QDir chunkDir( m_voiceChunkDir );
+		if( !chunkDir.exists() )
 		{
-			continue;
-		}
-		// Skip the newest segment while ffmpeg is still writing.
-		if( isRecording && i == files.size() - 1 )
-		{
-			continue;
+			break;
 		}
 
-		const QString audioPath = chunkDir.filePath( fileName );
-		const QFileInfo audioInfo( audioPath );
-		if( !audioInfo.exists() || audioInfo.size() < 2048 )
+		const QStringList files = chunkDir.entryList(
+			QStringList{ QStringLiteral( "chunk_*.wav" ) },
+			QDir::Files,
+			QDir::Name );
+		const bool isRecording = m_voiceRecordProcess != nullptr &&
+			m_voiceRecordProcess->state() != QProcess::NotRunning;
+		const int minBytes = qEnvironmentVariableIntValue( "LMMS_VOICE_MIN_BYTES" ) > 0
+			? qEnvironmentVariableIntValue( "LMMS_VOICE_MIN_BYTES" )
+			: 4096;
+
+		for( int i = 0; i < files.size(); ++i )
 		{
-			continue;
+			const QString& fileName = files[i];
+			const VoiceChunkStatus state = m_voiceChunkStates.value( fileName, VoiceChunkStatus::Seen );
+			if( state == VoiceChunkStatus::Processing || state == VoiceChunkStatus::Done )
+			{
+				continue;
+			}
+			// Skip the newest segment while ffmpeg may still be writing to it.
+			if( isRecording && i == files.size() - 1 )
+			{
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Seen );
+				continue;
+			}
+
+			const QString audioPath = chunkDir.filePath( fileName );
+			const QFileInfo audioInfo( audioPath );
+			if( !audioInfo.exists() )
+			{
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Error );
+				continue;
+			}
+			if( audioInfo.size() < minBytes )
+			{
+				if( isRecording )
+				{
+					m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Seen );
+					continue;
+				}
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Done );
+				QFile::remove( audioPath );
+				QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+				continue;
+			}
+
+			m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Processing );
+
+			double avgAbs = 0.0;
+			if( isLikelySilentWav( audioPath, &avgAbs ) )
+			{
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Done );
+				appendTrace( QStringLiteral( "chunk_silent" ), QJsonObject
+				{
+					{ "file", fileName },
+					{ "avg_abs", avgAbs }
+				} );
+				QFile::remove( audioPath );
+				QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+				continue;
+			}
+
+			QString transcript;
+			if( transcribeAudio( audioPath, transcript, true ) )
+			{
+				dispatchTranscript( transcript );
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Done );
+			}
+			else
+			{
+				m_voiceChunkStates.insert( fileName, VoiceChunkStatus::Error );
+			}
+
+			QFile::remove( audioPath );
+			QFile::remove( audioPath + QStringLiteral( ".txt" ) );
 		}
 
-		m_processedVoiceChunks.insert( fileName );
-		QString transcript;
-		if( transcribeAudio( audioPath, transcript, true ) )
+		// Prevent unbounded state growth from removed segment files.
+		QSet<QString> currentFileSet;
+		for( const QString& name : files )
 		{
-			dispatchTranscript( transcript );
+			currentFileSet.insert( name );
 		}
-
-		QFile::remove( audioPath );
-		QFile::remove( audioPath + QStringLiteral( ".txt" ) );
+		for( auto it = m_voiceChunkStates.begin(); it != m_voiceChunkStates.end(); )
+		{
+			if( !currentFileSet.contains( it.key() ) &&
+				( it.value() == VoiceChunkStatus::Done || it.value() == VoiceChunkStatus::Error ) )
+			{
+				it = m_voiceChunkStates.erase( it );
+			}
+			else
+			{
+				++it;
+			}
+		}
 	}
+	while( m_reprocessVoiceChunks );
+	m_processingVoiceChunks = false;
 }
 
 bool AgentControlView::transcribeAudio(
@@ -701,10 +1017,17 @@ bool AgentControlView::transcribeAudio(
 	bool quietNoTranscript )
 {
 	transcript.clear();
+	QElapsedTimer timer;
+	timer.start();
 	if( useWhisperService() )
 	{
 		QString serviceError;
-		if( !m_whisperServiceReady )
+		const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+		if( nowMs < m_whisperServiceCooldownUntilMs )
+		{
+			serviceError = tr( "service cooldown active" );
+		}
+		if( serviceError.isEmpty() && !m_whisperServiceReady )
 		{
 			m_whisperServiceReady = ensureWhisperServiceReady( serviceError );
 			if( !m_whisperServiceReady && !quietNoTranscript && !serviceError.isEmpty() )
@@ -712,16 +1035,22 @@ bool AgentControlView::transcribeAudio(
 				appendLog( tr( "Whisper service unavailable: %1. Falling back to CLI." ).arg( serviceError ) );
 			}
 		}
-		if( m_whisperServiceReady && transcribeViaWhisperService( audioPath, transcript, serviceError ) )
+		if( serviceError.isEmpty() && m_whisperServiceReady &&
+			transcribeViaWhisperService( audioPath, transcript, serviceError ) )
 		{
+			m_whisperServiceFailureCount = 0;
+			m_whisperServiceCooldownUntilMs = 0;
 			if( !quietNoTranscript )
 			{
 				appendLog( tr( "Whisper service transcription completed." ) );
 			}
 		}
-		else if( m_whisperServiceReady )
+		else if( m_whisperServiceReady || !serviceError.isEmpty() )
 		{
 			m_whisperServiceReady = false;
+			m_whisperServiceFailureCount = qMin( m_whisperServiceFailureCount + 1, 8 );
+			const qint64 backoffMs = qMin<qint64>( 20000, 1000 * ( 1 << qMin( m_whisperServiceFailureCount, 4 ) ) );
+			m_whisperServiceCooldownUntilMs = QDateTime::currentMSecsSinceEpoch() + backoffMs;
 			if( !quietNoTranscript && !serviceError.isEmpty() )
 			{
 				appendLog( tr( "Whisper service transcription failed: %1. Falling back to CLI." ).arg( serviceError ) );
@@ -799,6 +1128,12 @@ bool AgentControlView::transcribeAudio(
 		}
 	}
 
+	appendTrace( QStringLiteral( "transcribe_complete" ), QJsonObject
+	{
+		{ "ms", timer.elapsed() },
+		{ "chars", transcript.size() },
+		{ "service_ready", m_whisperServiceReady }
+	} );
 	return !transcript.trimmed().isEmpty();
 }
 
@@ -889,83 +1224,158 @@ bool AgentControlView::looksLikeCommandTranscript( const QString& transcript ) c
 
 bool AgentControlView::dispatchTranscript( const QString& transcript )
 {
-	const QString cleanTranscript = transcript.trimmed();
+	const QString cleanTranscript = normalizeTranscriptForCommand( transcript );
 	if( cleanTranscript.isEmpty() )
 	{
 		return false;
 	}
 
-	QStringList candidates;
-	candidates << cleanTranscript;
-	if( !m_pendingTranscript.isEmpty() )
+	QString wakeFiltered = cleanTranscript;
+	bool wakeDetected = false;
+	extractWakeCommand( cleanTranscript, wakeFiltered, wakeDetected );
+
+	const int wakeWindowMs = qEnvironmentVariableIntValue( "LMMS_WAKE_WINDOW_MS" ) > 0
+		? qEnvironmentVariableIntValue( "LMMS_WAKE_WINDOW_MS" )
+		: 8000;
+	const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
+	if( wakeDetected )
 	{
-		candidates << ( m_pendingTranscript + QStringLiteral( " " ) + cleanTranscript ).simplified();
+		m_wakeWindowUntilMs = nowMs + qMax( 3000, wakeWindowMs );
+		appendTrace( QStringLiteral( "wake_detected" ), QJsonObject
+		{
+			{ "wake_until_ms", QString::number( m_wakeWindowUntilMs ) },
+			{ "raw", cleanTranscript }
+		} );
 	}
 
-	for( const QString& candidate : candidates )
+	const bool wakeActive = !wakePhraseRequired() || nowMs <= m_wakeWindowUntilMs;
+	const QString effectiveTranscript = wakeDetected ? wakeFiltered : cleanTranscript;
+	if( effectiveTranscript.isEmpty() )
 	{
-		if( candidate.isEmpty() )
+		return wakeDetected;
+	}
+	if( !wakeActive )
+	{
+		appendTrace( QStringLiteral( "ignored_no_wake" ), QJsonObject
+		{
+			{ "raw", cleanTranscript }
+		} );
+		return false;
+	}
+
+	const QStringList chain = splitCommandChain( effectiveTranscript );
+	bool anyExecuted = false;
+	for( const QString& segmentRaw : chain )
+	{
+		const QString segment = applyContextHints( segmentRaw );
+		if( segment.isEmpty() )
 		{
 			continue;
 		}
-		if( !looksLikeCommandTranscript( candidate ) )
+
+		QStringList candidates;
+		candidates << segment;
+		if( !m_pendingTranscript.isEmpty() )
 		{
-			continue;
+			candidates << ( m_pendingTranscript + QStringLiteral( " " ) + segment ).simplified();
 		}
 
-		QString commandText = candidate;
-		QString fastCommand;
-		if( canonicalizeFastCommand( candidate, fastCommand ) )
+		bool executedForSegment = false;
+		for( const QString& candidate : candidates )
 		{
-			commandText = fastCommand;
+			if( candidate.isEmpty() )
+			{
+				continue;
+			}
+			if( !looksLikeCommandTranscript( candidate ) )
+			{
+				continue;
+			}
+
+			QString commandText = candidate;
+			QString fastCommand;
+			if( canonicalizeFastCommand( candidate, fastCommand ) )
+			{
+				commandText = fastCommand;
+			}
+
+			const QString normalized = commandText.toLower().simplified();
+			if( normalized == m_lastDispatchedTranscript && nowMs - m_lastDispatchedAtMs < 2000 )
+			{
+				continue;
+			}
+
+			const QString result = m_plugin->handleCommand( commandText );
+			if( result.startsWith( QStringLiteral( "Unknown command:" ), Qt::CaseInsensitive ) ||
+				result.startsWith( QStringLiteral( "Unknown window:" ), Qt::CaseInsensitive ) ||
+				result.startsWith( QStringLiteral( "Unknown instrument:" ), Qt::CaseInsensitive ) )
+			{
+				continue;
+			}
+
+			appendLog( tr( "Heard: %1" ).arg( cleanTranscript ) );
+			if( commandText.compare( segment, Qt::CaseInsensitive ) != 0 )
+			{
+				appendLog( tr( "Mapped: %1" ).arg( commandText ) );
+			}
+			appendLog( commandText + QStringLiteral( " => " ) + result );
+			appendTrace( QStringLiteral( "segment_executed" ), QJsonObject
+			{
+				{ "segment", segment },
+				{ "command", commandText },
+				{ "result", result }
+			} );
+			m_lastDispatchedTranscript = normalized;
+			m_lastDispatchedAtMs = nowMs;
+			m_pendingTranscript.clear();
+			updateVoiceContextFromCommand( commandText );
+			executedForSegment = true;
+			anyExecuted = true;
+			break;
 		}
 
-		const QString normalized = commandText.toLower().simplified();
-		const qint64 nowMs = QDateTime::currentMSecsSinceEpoch();
-		if( normalized == m_lastDispatchedTranscript && nowMs - m_lastDispatchedAtMs < 2500 )
+		if( !executedForSegment )
 		{
-			return false;
+			const QStringList tokens = segment.toLower().simplified().split( ' ', Qt::SkipEmptyParts );
+			if( tokens.size() <= 4 )
+			{
+				m_pendingTranscript = segment;
+			}
+			else
+			{
+				m_pendingTranscript = tokens.mid( qMax( 0, tokens.size() - 4 ) ).join( ' ' );
+			}
 		}
-
-		const QString result = m_plugin->handleCommand( commandText );
-		if( result.startsWith( QStringLiteral( "Unknown command:" ), Qt::CaseInsensitive ) ||
-			result.startsWith( QStringLiteral( "Unknown window:" ), Qt::CaseInsensitive ) ||
-			result.startsWith( QStringLiteral( "Unknown instrument:" ), Qt::CaseInsensitive ) )
-		{
-			continue;
-		}
-
-		appendLog( tr( "Heard: %1" ).arg( cleanTranscript ) );
-		if( commandText.compare( cleanTranscript, Qt::CaseInsensitive ) != 0 )
-		{
-			appendLog( tr( "Fast map: %1" ).arg( commandText ) );
-		}
-		appendLog( commandText + QStringLiteral( " => " ) + result );
-		m_lastDispatchedTranscript = normalized;
-		m_lastDispatchedAtMs = nowMs;
-		m_pendingTranscript.clear();
-		return true;
 	}
 
-	const QStringList tokens = cleanTranscript.toLower().simplified().split( ' ', Qt::SkipEmptyParts );
-	if( tokens.size() <= 3 )
-	{
-		m_pendingTranscript = cleanTranscript;
-	}
-	else
-	{
-		m_pendingTranscript = tokens.mid( qMax( 0, tokens.size() - 3 ) ).join( ' ' );
-	}
-	return false;
+	return anyExecuted;
 }
 
 bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QString& command ) const
 {
 	command.clear();
-	const QString normalized = transcript.toLower().simplified();
+	const QString normalized = normalizeTranscriptForCommand( transcript );
 	if( normalized.isEmpty() )
 	{
 		return false;
+	}
+
+	if( normalized == QStringLiteral( "play" ) ||
+		normalized == QStringLiteral( "start playback" ) ||
+		normalized == QStringLiteral( "resume playback" ) )
+	{
+		command = QStringLiteral( "play" );
+		return true;
+	}
+	if( normalized == QStringLiteral( "pause" ) || normalized == QStringLiteral( "pause playback" ) )
+	{
+		command = QStringLiteral( "pause" );
+		return true;
+	}
+	if( normalized == QStringLiteral( "stop" ) || normalized == QStringLiteral( "stop playback" ) )
+	{
+		command = QStringLiteral( "stop" );
+		return true;
 	}
 
 	if( normalized.contains( QStringLiteral( "open" ) ) &&
@@ -987,9 +1397,29 @@ bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QStri
 			R"(\b([a-z0-9._-]+\.(?:wav|mp3|flac|aiff|ogg|m4a))\b)",
 			QRegularExpression::CaseInsensitiveOption );
 		const auto fileMatch = filePattern.match( normalized );
-		const QString fileName = fileMatch.hasMatch() ? fileMatch.captured( 1 ) : QStringLiteral( "sample.wav" );
+		QString fileName = fileMatch.hasMatch() ? fileMatch.captured( 1 ) : QString();
+		if( fileName.isEmpty() && !m_lastContextImportedFile.isEmpty() )
+		{
+			fileName = m_lastContextImportedFile;
+		}
+		if( fileName.isEmpty() )
+		{
+			fileName = QStringLiteral( "sample.wav" );
+		}
 		command = QStringLiteral( "import %1 into slicer" ).arg( fileName );
 		return true;
+	}
+	if( normalized.contains( QStringLiteral( "import" ) ) && normalized.contains( QStringLiteral( "download" ) ) )
+	{
+		const QRegularExpression filePattern(
+			R"(\b([a-z0-9._-]+\.(?:wav|mp3|flac|aiff|ogg|m4a|mid))\b)",
+			QRegularExpression::CaseInsensitiveOption );
+		const auto fileMatch = filePattern.match( normalized );
+		if( fileMatch.hasMatch() )
+		{
+			command = QStringLiteral( "import %1 from downloads" ).arg( fileMatch.captured( 1 ) );
+			return true;
+		}
 	}
 
 	if( ( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) &&
@@ -1006,6 +1436,31 @@ bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QStri
 		command = QStringLiteral( "divide into equal segments" );
 		return true;
 	}
+	if( ( normalized.contains( QStringLiteral( "divide" ) ) || normalized.contains( QStringLiteral( "split" ) ) ) &&
+		normalized.contains( QStringLiteral( "segment" ) ) )
+	{
+		const QRegularExpression countPattern( R"(\b(\d{1,3})\b)" );
+		const auto countMatch = countPattern.match( normalized );
+		if( countMatch.hasMatch() )
+		{
+			command = QStringLiteral( "divide into %1 equal segments" ).arg( countMatch.captured( 1 ) );
+		}
+		else
+		{
+			command = QStringLiteral( "divide into equal segments" );
+		}
+		return true;
+	}
+	if( normalized.contains( QStringLiteral( "split it into" ) ) ||
+		normalized.contains( QStringLiteral( "divide it into" ) ) )
+	{
+		const QRegularExpression countPattern( R"(\b(\d{1,3})\b)" );
+		const auto countMatch = countPattern.match( normalized );
+		command = countMatch.hasMatch()
+			? QStringLiteral( "divide into %1 equal segments" ).arg( countMatch.captured( 1 ) )
+			: QStringLiteral( "divide into equal segments" );
+		return true;
+	}
 
 	if( ( normalized.contains( QStringLiteral( "create" ) ) || normalized.contains( QStringLiteral( "new" ) ) ||
 		  normalized.contains( QStringLiteral( "make" ) ) ) &&
@@ -1015,12 +1470,60 @@ bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QStri
 		command = QStringLiteral( "create instrument track" );
 		return true;
 	}
+	if( ( normalized.contains( QStringLiteral( "create" ) ) || normalized.contains( QStringLiteral( "new" ) ) ||
+		  normalized.contains( QStringLiteral( "make" ) ) ) &&
+		normalized.contains( QStringLiteral( "sample" ) ) &&
+		normalized.contains( QStringLiteral( "track" ) ) )
+	{
+		command = QStringLiteral( "create sample track" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "create" ) ) || normalized.contains( QStringLiteral( "new" ) ) ) &&
+		normalized.contains( QStringLiteral( "automation" ) ) &&
+		normalized.contains( QStringLiteral( "track" ) ) )
+	{
+		command = QStringLiteral( "create automation track" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "create" ) ) || normalized.contains( QStringLiteral( "new" ) ) ) &&
+		normalized.contains( QStringLiteral( "pattern" ) ) &&
+		normalized.contains( QStringLiteral( "track" ) ) )
+	{
+		command = QStringLiteral( "create pattern track" );
+		return true;
+	}
 
 	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
 		normalized.contains( QStringLiteral( "piano" ) ) &&
 		( normalized.contains( QStringLiteral( "roll" ) ) || normalized.contains( QStringLiteral( "role" ) ) ) )
 	{
 		command = QStringLiteral( "open piano roll" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		( normalized.contains( QStringLiteral( "pattern editor" ) ) ||
+		  normalized.contains( QStringLiteral( "beat and bassline" ) ) ||
+		  normalized.contains( QStringLiteral( "beat+bassline" ) ) ) )
+	{
+		command = QStringLiteral( "open pattern editor" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		( normalized.contains( QStringLiteral( "mixer" ) ) || normalized.contains( QStringLiteral( "effects" ) ) ) )
+	{
+		command = QStringLiteral( "open mixer" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		normalized.contains( QStringLiteral( "controller rack" ) ) )
+	{
+		command = QStringLiteral( "open controller rack" );
+		return true;
+	}
+	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
+		normalized.contains( QStringLiteral( "project notes" ) ) )
+	{
+		command = QStringLiteral( "open project notes" );
 		return true;
 	}
 
@@ -1036,12 +1539,43 @@ bool AgentControlView::canonicalizeFastCommand( const QString& transcript, QStri
 		command = QStringLiteral( "add kick drums" );
 		return true;
 	}
+	if( normalized.contains( QStringLiteral( "add snare" ) ) )
+	{
+		command = QStringLiteral( "add snare" );
+		return true;
+	}
+	if( normalized.contains( QStringLiteral( "add effect " ) ) )
+	{
+		command = normalized;
+		return true;
+	}
+	if( normalized.contains( QStringLiteral( "remove effect " ) ) )
+	{
+		command = normalized;
+		return true;
+	}
 
 	if( ( normalized.contains( QStringLiteral( "open" ) ) || normalized.contains( QStringLiteral( "show" ) ) ) &&
 		normalized.contains( QStringLiteral( "song" ) ) &&
 		( normalized.contains( QStringLiteral( "editor" ) ) || normalized.contains( QStringLiteral( "edit" ) ) ) )
 	{
 		command = QStringLiteral( "open song editor" );
+		return true;
+	}
+	if( normalized == QStringLiteral( "new project" ) )
+	{
+		command = QStringLiteral( "new project" );
+		return true;
+	}
+	if( normalized == QStringLiteral( "save project" ) )
+	{
+		command = QStringLiteral( "save project" );
+		return true;
+	}
+	if( normalized.contains( QStringLiteral( "export song" ) ) ||
+		normalized.contains( QStringLiteral( "render song" ) ) )
+	{
+		command = QStringLiteral( "export song" );
 		return true;
 	}
 

--- a/plugins/AgentControl/AgentControlView.h
+++ b/plugins/AgentControl/AgentControlView.h
@@ -1,0 +1,39 @@
+#ifndef LMMS_AGENT_CONTROL_VIEW_H
+#define LMMS_AGENT_CONTROL_VIEW_H
+
+#include <QTextEdit>
+#include <QLineEdit>
+#include <QLabel>
+#include <QPushButton>
+
+#include "ToolPluginView.h"
+
+namespace lmms
+{
+class AgentControlPlugin;
+
+namespace gui
+{
+
+class AgentControlView : public ToolPluginView
+{
+	Q_OBJECT
+public:
+	explicit AgentControlView( AgentControlPlugin *plugin );
+
+private slots:
+	void runCommand();
+	void appendLog( const QString &text );
+
+private:
+	AgentControlPlugin *m_plugin;
+	QLineEdit *m_input;
+	QTextEdit *m_log;
+	QLabel *m_status;
+};
+
+} // namespace gui
+
+} // namespace lmms
+
+#endif // LMMS_AGENT_CONTROL_VIEW_H

--- a/plugins/AgentControl/AgentControlView.h
+++ b/plugins/AgentControl/AgentControlView.h
@@ -6,6 +6,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QProcess>
+#include <QJsonObject>
+#include <QHash>
 #include <QSet>
 #include <QTimer>
 
@@ -50,10 +52,27 @@ private:
 	QString microphoneDevice() const;
 	QStringList ffmpegCaptureArgs( const QString &outputPath ) const;
 	QStringList ffmpegContinuousCaptureArgs( const QString &outputPattern ) const;
+	QString normalizeTranscriptForCommand( const QString& transcript ) const;
 	bool looksLikeCommandTranscript( const QString& transcript ) const;
 	bool canonicalizeFastCommand( const QString& transcript, QString& command ) const;
+	bool wakePhraseRequired() const;
+	QStringList wakePhrases() const;
+	bool extractWakeCommand( const QString& transcript, QString& commandRemainder, bool& wakeDetected ) const;
+	QStringList splitCommandChain( const QString& transcript ) const;
+	QString applyContextHints( const QString& commandText ) const;
+	void updateVoiceContextFromCommand( const QString& commandText );
+	bool isLikelySilentWav( const QString& audioPath, double* meanAbs = nullptr ) const;
+	void appendTrace( const QString& stage, const QJsonObject& payload = QJsonObject() ) const;
 	bool dispatchTranscript( const QString& transcript );
 	bool runWhisperAndDispatch( const QString &audioPath );
+
+	enum class VoiceChunkStatus
+	{
+		Seen = 0,
+		Processing,
+		Done,
+		Error
+	};
 
 	AgentControlPlugin *m_plugin;
 	QLineEdit *m_input;
@@ -66,11 +85,20 @@ private:
 	QTimer *m_voiceChunkTimer;
 	QString m_voiceAudioPath;
 	QString m_voiceChunkDir;
-	QSet<QString> m_processedVoiceChunks;
+	QHash<QString, VoiceChunkStatus> m_voiceChunkStates;
 	QString m_lastDispatchedTranscript;
 	QString m_pendingTranscript;
+	QString m_lastContextPlugin;
+	QString m_lastContextTrack;
+	QString m_lastContextImportedFile;
+	QString m_lastContextWindow;
 	qint64 m_lastDispatchedAtMs = 0;
+	qint64 m_wakeWindowUntilMs = 0;
 	bool m_whisperServiceReady = false;
+	bool m_processingVoiceChunks = false;
+	bool m_reprocessVoiceChunks = false;
+	int m_whisperServiceFailureCount = 0;
+	qint64 m_whisperServiceCooldownUntilMs = 0;
 };
 
 } // namespace gui

--- a/plugins/AgentControl/AgentControlView.h
+++ b/plugins/AgentControl/AgentControlView.h
@@ -5,6 +5,7 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QPushButton>
+#include <QProcess>
 
 #include "ToolPluginView.h"
 
@@ -24,12 +25,26 @@ public:
 private slots:
 	void runCommand();
 	void appendLog( const QString &text );
+	void startVoiceCapture();
+	void stopVoiceCapture();
+	void voiceProcessError( QProcess::ProcessError error );
 
 private:
+	void setVoiceUiState( bool recording );
+	QString ffmpegPath() const;
+	QString whisperPath() const;
+	QString microphoneDevice() const;
+	QStringList ffmpegCaptureArgs( const QString &outputPath ) const;
+	bool runWhisperAndDispatch( const QString &audioPath );
+
 	AgentControlPlugin *m_plugin;
 	QLineEdit *m_input;
 	QTextEdit *m_log;
 	QLabel *m_status;
+	QPushButton *m_voiceStartButton;
+	QPushButton *m_voiceStopButton;
+	QProcess *m_voiceRecordProcess;
+	QString m_voiceAudioPath;
 };
 
 } // namespace gui

--- a/plugins/AgentControl/AgentControlView.h
+++ b/plugins/AgentControl/AgentControlView.h
@@ -6,6 +6,8 @@
 #include <QLabel>
 #include <QPushButton>
 #include <QProcess>
+#include <QSet>
+#include <QTimer>
 
 #include "ToolPluginView.h"
 
@@ -21,20 +23,36 @@ class AgentControlView : public ToolPluginView
 	Q_OBJECT
 public:
 	explicit AgentControlView( AgentControlPlugin *plugin );
+	~AgentControlView() override;
 
 private slots:
 	void runCommand();
 	void appendLog( const QString &text );
 	void startVoiceCapture();
 	void stopVoiceCapture();
+	void processVoiceChunks();
 	void voiceProcessError( QProcess::ProcessError error );
 
 private:
 	void setVoiceUiState( bool recording );
 	QString ffmpegPath() const;
 	QString whisperPath() const;
+	QString whisperModelPath() const;
+	QString whisperServiceBaseUrl() const;
+	QString whisperServiceModel() const;
+	QString voiceChunkDirPath() const;
+	bool useWhisperService() const;
+	bool ensureWhisperServiceReady( QString& error );
+	bool checkWhisperServiceHealth( int timeoutMs, QString& error ) const;
+	bool transcribeViaWhisperService( const QString &audioPath, QString &transcript, QString& error ) const;
+	bool transcribeAudio( const QString &audioPath, QString &transcript, bool quietNoTranscript );
+	void shutdownWhisperService();
 	QString microphoneDevice() const;
 	QStringList ffmpegCaptureArgs( const QString &outputPath ) const;
+	QStringList ffmpegContinuousCaptureArgs( const QString &outputPattern ) const;
+	bool looksLikeCommandTranscript( const QString& transcript ) const;
+	bool canonicalizeFastCommand( const QString& transcript, QString& command ) const;
+	bool dispatchTranscript( const QString& transcript );
 	bool runWhisperAndDispatch( const QString &audioPath );
 
 	AgentControlPlugin *m_plugin;
@@ -44,7 +62,15 @@ private:
 	QPushButton *m_voiceStartButton;
 	QPushButton *m_voiceStopButton;
 	QProcess *m_voiceRecordProcess;
+	QProcess *m_whisperServiceProcess;
+	QTimer *m_voiceChunkTimer;
 	QString m_voiceAudioPath;
+	QString m_voiceChunkDir;
+	QSet<QString> m_processedVoiceChunks;
+	QString m_lastDispatchedTranscript;
+	QString m_pendingTranscript;
+	qint64 m_lastDispatchedAtMs = 0;
+	bool m_whisperServiceReady = false;
 };
 
 } // namespace gui

--- a/plugins/AgentControl/CMakeLists.txt
+++ b/plugins/AgentControl/CMakeLists.txt
@@ -1,0 +1,11 @@
+INCLUDE(BuildPlugin)
+
+BUILD_PLUGIN(AgentControl
+    AgentControl.cpp
+    AgentControl.h
+    AgentControlView.cpp
+    AgentControlView.h
+    MOCFILES AgentControl.h AgentControlView.h
+)
+
+target_link_libraries(AgentControl Qt${QT_VERSION_MAJOR}::Network)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -352,7 +352,10 @@ void MainWindow::finalize()
 	m_toolsMenu = new QMenu( this );
 	for( const Plugin::Descriptor* desc : getPluginFactory()->descriptors(Plugin::Type::Tool) )
 	{
-		m_toolsMenu->addAction( desc->logo->pixmap(), desc->displayName );
+		const auto icon = desc->logo
+			? QIcon{desc->logo->pixmap()}
+			: QIcon{embed::getIconPixmap("icon_small")};
+		m_toolsMenu->addAction( icon, desc->displayName );
 		m_tools.push_back( ToolPlugin::instantiate( desc->name, /*this*/nullptr )
 						   ->createView(this) );
 	}

--- a/src/gui/ToolPluginView.cpp
+++ b/src/gui/ToolPluginView.cpp
@@ -43,7 +43,10 @@ ToolPluginView::ToolPluginView( ToolPlugin * _toolPlugin ) :
 	parentWidget()->setAttribute( Qt::WA_DeleteOnClose, false );
 
 	setWindowTitle( _toolPlugin->displayName() );
-	setWindowIcon( _toolPlugin->descriptor()->logo->pixmap() );
+	const auto icon = _toolPlugin->descriptor()->logo
+		? QIcon{_toolPlugin->descriptor()->logo->pixmap()}
+		: QIcon{embed::getIconPixmap("icon_small")};
+	setWindowIcon( icon );
 }
 
 


### PR DESCRIPTION
### Core Changes
* **`plugins/AgentControl/` (C++)**: Implements a localhost TCP tool server (`127.0.0.1:7777`) executing typed JSON tool actions (`get_project_state`, `create_track`, `load_sample`, `add_notes`). Includes built-in snapshotting, undo, and rollback capabilities for safety.
* **`lmms-agentd/` (Python Daemon)**: A persistent background runtime running on port `7781` handling request suppression (idempotency), caching, and local LLM orchestration (defaulting to `qwen2.5:7b-instruct` via Ollama).
* **Voice & Text Frontends**: Integrated text processing capabilities alongside a production-first voice layer utilizing `whisper.cpp` for local, continuous transcription gated by custom wake phrases (e.g., *"hey lmms"*).
* **Testing & Playbooks**: Added a full suite of validation scripts (`validate_voice_contracts.py`), a reproducible baseline benchmark (`benchmark_phase01.py`), and documentation mapping old manual workflows to modern agent playbooks.
