### PR TITLE
C++20 cleanup

### DIFF
--- a/include/LinkedModelGroups.h
+++ b/include/LinkedModelGroups.h
@@ -81,19 +81,13 @@ public:
 	template<class Functor>
 	void foreach_model(const Functor& ftor)
 	{
-		for (auto itr = m_models.begin(); itr != m_models.end(); ++itr)
-		{
-			ftor(itr->first, itr->second);
-		}
+		for (auto& [name, info] : m_models) { ftor(name, info); }
 	}
 
 	template<class Functor>
 	void foreach_model(const Functor& ftor) const
 	{
-		for (auto itr = m_models.cbegin(); itr != m_models.cend(); ++itr)
-		{
-			ftor(itr->first, itr->second);
-		}
+		for (const auto& [name, info] : m_models) { ftor(name, info); }
 	}
 
 	std::size_t modelNum() const { return m_models.size(); }

--- a/include/Lv2Manager.h
+++ b/include/Lv2Manager.h
@@ -133,16 +133,15 @@ public:
 
 	static bool pluginIsUnstable(const char* pluginUri)
 	{
-		return unstablePlugins.find(pluginUri) != unstablePlugins.end();
+		return unstablePlugins.contains(pluginUri);
 	}
 	static bool pluginIsOnlyUsefulWithUi(const char* pluginUri)
 	{
-		return pluginsOnlyUsefulWithUi.find(pluginUri) != pluginsOnlyUsefulWithUi.end();
+		return pluginsOnlyUsefulWithUi.contains(pluginUri);
 	}
 	static bool pluginIsUnstableWithBuffersizeLessEqual32(const char* pluginUri)
 	{
-		return unstablePluginsBuffersizeLessEqual32.find(pluginUri) !=
-			unstablePluginsBuffersizeLessEqual32.end();
+		return unstablePluginsBuffersizeLessEqual32.contains(pluginUri);
 	}
 
 	//! Whether the user generally wants a UI (and we generally support that)

--- a/include/PluginIssue.h
+++ b/include/PluginIssue.h
@@ -26,6 +26,7 @@
 #define LMMS_PLUGIN_ISSUE_H
 
 #include <QDebug>
+#include <compare>
 #include <string>
 
 namespace lmms
@@ -75,8 +76,7 @@ public:
 	{
 	}
 	PluginIssueType type() const { return m_issueType; }
-	bool operator==(const PluginIssue& other) const;
-	bool operator<(const PluginIssue& other) const;
+	auto operator<=>(const PluginIssue&) const = default;
 	friend QDebug operator<<(QDebug stream, const PluginIssue& iss);
 };
 

--- a/include/ProjectVersion.h
+++ b/include/ProjectVersion.h
@@ -29,6 +29,7 @@
 #include <QString>
 #include <QStringList>
 
+#include <compare>
 #include <limits>
 
 namespace lmms
@@ -71,12 +72,14 @@ private:
 /*
  * ProjectVersion v. ProjectVersion
  */
-inline bool operator<(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) < 0; }
-inline bool operator>(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) > 0; }
-inline bool operator<=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) <= 0; }
-inline bool operator>=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) >= 0; }
-inline bool operator==(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) == 0; }
-inline bool operator!=(const ProjectVersion & v1, const ProjectVersion & v2) { return ProjectVersion::compare(v1, v2) != 0; }
+inline std::strong_ordering operator<=>(const ProjectVersion& v1, const ProjectVersion& v2)
+{
+	return ProjectVersion::compare(v1, v2) <=> 0;
+}
+inline bool operator==(const ProjectVersion& v1, const ProjectVersion& v2)
+{
+	return ProjectVersion::compare(v1, v2) == 0;
+}
 
 
 } // namespace lmms

--- a/src/core/AudioBusHandle.cpp
+++ b/src/core/AudioBusHandle.cpp
@@ -27,6 +27,8 @@
 
 #include <QMutexLocker>
 
+#include <algorithm>
+
 #include "AudioDevice.h"
 #include "AudioEngine.h"
 #include "EffectChain.h"
@@ -259,8 +261,7 @@ void AudioBusHandle::addPlayHandle(PlayHandle* handle)
 void AudioBusHandle::removePlayHandle(PlayHandle* handle)
 {
 	QMutexLocker lockGuard(&m_playHandleLock);
-	PlayHandleList::Iterator it = std::find(m_playHandles.begin(), m_playHandles.end(), handle);
-	if (it != m_playHandles.end())
+	if (auto it = std::ranges::find(m_playHandles, handle); it != m_playHandles.end())
 	{
 		m_playHandles.erase(it);
 	}

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -37,6 +37,8 @@
 #include "NotePlayHandle.h"
 #include "ConfigManager.h"
 
+#include <algorithm>
+
 // platform-specific audio-interface-classes
 #include "AudioAlsa.h"
 #include "AudioJack.h"
@@ -213,7 +215,7 @@ void AudioEngine::renderStageNoteSetup()
 	ConstPlayHandleList::Iterator it_rem = m_playHandlesToRemove.begin();
 	while( it_rem != m_playHandlesToRemove.end() )
 	{
-		PlayHandleList::Iterator it = std::find( m_playHandles.begin(), m_playHandles.end(), *it_rem );
+		auto it = std::ranges::find(m_playHandles, *it_rem);
 
 		if( it != m_playHandles.end() )
 		{
@@ -449,8 +451,7 @@ void AudioEngine::removeAudioBusHandle(AudioBusHandle* busHandle)
 {
 	requestChangeInModel();
 
-	auto it = std::find(m_audioBusHandles.begin(), m_audioBusHandles.end(), busHandle);
-	if (it != m_audioBusHandles.end())
+	if (auto it = std::ranges::find(m_audioBusHandles, busHandle); it != m_audioBusHandles.end())
 	{
 		m_audioBusHandles.erase(it);
 	}
@@ -510,8 +511,7 @@ void AudioEngine::removePlayHandle(PlayHandle * ph)
 			}
 		}
 		// Now check m_playHandles
-		PlayHandleList::Iterator it = std::find(m_playHandles.begin(), m_playHandles.end(), ph);
-		if (it != m_playHandles.end())
+		if (auto it = std::ranges::find(m_playHandles, ph); it != m_playHandles.end())
 		{
 			m_playHandles.erase(it);
 			removedFromList = true;

--- a/src/core/ComboBoxModel.cpp
+++ b/src/core/ComboBoxModel.cpp
@@ -24,6 +24,7 @@
 
 #include "ComboBoxModel.h"
 
+#include <algorithm>
 #include <cassert>
 
 namespace lmms
@@ -58,14 +59,9 @@ void ComboBoxModel::clear()
 
 int ComboBoxModel::findText( const QString& txt ) const
 {
-	for( auto it = m_items.begin(); it != m_items.end(); ++it )
-	{
-		if( ( *it ).first == txt )
-		{
-			return it - m_items.begin();
-		}
-	}
-	return -1; 
+	const auto it = std::ranges::find(m_items, txt, &Item::first);
+	if (it == m_items.end()) { return -1; }
+	return std::distance(m_items.begin(), it);
 }
 
 

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -350,9 +350,8 @@ void ConfigManager::removeFavoriteItem(const QString& item)
 bool ConfigManager::isFavoriteItem(const QString& item)
 {
 	const auto& items = favoriteItems();
-	const auto it = std::find_if(items.begin(), items.end(),
+	return std::ranges::any_of(items,
 		[&](const auto& favoriteItem) { return QFileInfo{item} == QFileInfo{favoriteItem}; });
-	return it != items.end();
 }
 
 QString ConfigManager::value(const QString& cls, const QString& attribute, const QString& defaultVal) const

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -357,7 +357,7 @@ bool ConfigManager::isFavoriteItem(const QString& item)
 
 QString ConfigManager::value(const QString& cls, const QString& attribute, const QString& defaultVal) const
 {
-	if (m_settings.find(cls) != m_settings.end())
+	if (m_settings.contains(cls))
 	{
 		for (const auto& setting : m_settings[cls])
 		{

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -28,6 +28,8 @@
 
 #include <vector>
 
+#include <algorithm>
+
 #include "AudioEngine.h"
 #include "ControllerConnection.h"
 #include "ControllerDialog.h"
@@ -86,8 +88,7 @@ Controller::Controller( ControllerType _type, Model * _parent,
 
 Controller::~Controller()
 {
-	auto it = std::find(s_controllers.begin(), s_controllers.end(), this);
-	if (it != s_controllers.end())
+	if (auto it = std::ranges::find(s_controllers, this); it != s_controllers.end())
 	{
 		s_controllers.erase(it);
 	}

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -27,6 +27,7 @@
 #include <QDomElement>
 #include <QObject>
 
+#include <algorithm>
 
 #include "Song.h"
 #include "ControllerConnection.h"
@@ -77,8 +78,7 @@ ControllerConnection::~ControllerConnection()
 		m_controller->removeConnection( this );
 	}
 
-	auto it = std::find(s_connections.begin(), s_connections.end(), this);
-	if (it != s_connections.end()) { s_connections.erase(it); };
+	if (auto it = std::ranges::find(s_connections, this); it != s_connections.end()) { s_connections.erase(it); }
 
 	if( m_ownsController )
 	{
@@ -189,8 +189,7 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 		else
 		{
 			const auto& controllers = Engine::getSong()->controllers();
-			const auto it = std::find(controllers.begin(), controllers.end(), m_controller);
-			if (it != controllers.end())
+			if (const auto it = std::ranges::find(controllers, m_controller); it != controllers.end())
 			{
 				const int id = std::distance(controllers.begin(), it);
 				_this.setAttribute("id", id);

--- a/src/core/DataFile.cpp
+++ b/src/core/DataFile.cpp
@@ -598,8 +598,7 @@ bool DataFile::hasLocalPlugins(QDomElement parent /* = QDomElement()*/, bool fir
 
 DataFile::Type DataFile::type( const QString& typeName )
 {
-	const auto it = std::find_if(s_types.begin(), s_types.end(),
-		[&typeName](const TypeDescStruct& type) { return type.m_name == typeName; });
+	const auto it = std::ranges::find(s_types, typeName, &TypeDescStruct::m_name);
 	if (it != s_types.end()) { return it->m_type; }
 
 	// compat code

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -28,6 +28,8 @@
 #include <QDomElement>
 #include <cassert>
 
+#include <algorithm>
+
 #include "AudioBuffer.h"
 #include "Effect.h"
 #include "DummyEffect.h"
@@ -138,7 +140,7 @@ void EffectChain::removeEffect( Effect * _effect )
 {
 	Engine::audioEngine()->requestChangeInModel();
 
-	auto found = std::find(m_effects.begin(), m_effects.end(), _effect);
+	auto found = std::ranges::find(m_effects, _effect);
 	if( found == m_effects.end() )
 	{
 		Engine::audioEngine()->doneChangeInModel();
@@ -163,7 +165,7 @@ void EffectChain::moveDown( Effect * _effect )
 {
 	if (_effect != m_effects.back())
 	{
-		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
+		auto it = std::ranges::find(m_effects, _effect);
 		assert(it != m_effects.end());
 		std::swap(*std::next(it), *it);
 	}
@@ -176,7 +178,7 @@ void EffectChain::moveUp( Effect * _effect )
 {
 	if (_effect != m_effects.front())
 	{
-		auto it = std::find(m_effects.begin(), m_effects.end(), _effect);
+		auto it = std::ranges::find(m_effects, _effect);
 		assert(it != m_effects.end());
 		std::swap(*std::prev(it), *it);
 	}

--- a/src/core/LinkedModelGroups.cpp
+++ b/src/core/LinkedModelGroups.cpp
@@ -128,7 +128,7 @@ void LinkedModelGroup::clearModels()
 
 bool LinkedModelGroup::containsModel(const QString &name) const
 {
-	return m_models.find(name.toStdString()) != m_models.end();
+	return m_models.contains(name.toStdString());
 }
 
 

--- a/src/core/Mixer.cpp
+++ b/src/core/Mixer.cpp
@@ -35,6 +35,8 @@
 #include "SampleTrack.h"
 #include "TrackContainer.h" // For TrackContainer::TrackList typedef
 
+#include <algorithm>
+
 namespace lmms
 {
 
@@ -558,8 +560,7 @@ void Mixer::deleteChannelSend( MixerRoute * route )
 
 	auto removeFromMixerRoute = [route](MixerRouteVector& routeVec)
 	{
-		auto it = std::find(routeVec.begin(), routeVec.end(), route);
-		if (it != routeVec.end()) { routeVec.erase(it); }
+		if (auto it = std::ranges::find(routeVec, route); it != routeVec.end()) { routeVec.erase(it); }
 	};
 
 	// remove us from from's sends

--- a/src/core/PluginIssue.cpp
+++ b/src/core/PluginIssue.cpp
@@ -79,22 +79,6 @@ const char *PluginIssue::msgFor(const PluginIssueType &it)
 
 
 
-bool PluginIssue::operator==(const PluginIssue &other) const
-{
-	return (m_issueType == other.m_issueType) && (m_info == other.m_info);
-}
-
-
-
-
-bool PluginIssue::operator<(const PluginIssue &other) const
-{
-	return (m_issueType != other.m_issueType)
-			? m_issueType < other.m_issueType
-			: m_info < other.m_info;
-}
-
-
 QDebug operator<<(QDebug stream, const PluginIssue &iss)
 {
 	stream << PluginIssue::msgFor(iss.m_issueType);

--- a/src/core/ProjectRenderer.cpp
+++ b/src/core/ProjectRenderer.cpp
@@ -218,7 +218,7 @@ void ProjectRenderer::updateConsoleProgress()
 	prog[cols] = 0;
 
 	const auto activity = "|/-\\";
-	std::fill(buf.begin(), buf.end(), 0);
+	std::ranges::fill(buf, 0);
 	std::snprintf(buf.data(), buf.size(), "\r|%s|    %3d%%   %c  ", prog.data(), m_progress,
 							activity[rot] );
 	rot = ( rot+1 ) % 4;

--- a/src/core/SampleDecoder.cpp
+++ b/src/core/SampleDecoder.cpp
@@ -26,6 +26,7 @@
 
 #include <QFile>
 #include <QString>
+#include <algorithm>
 #include <memory>
 #include <sndfile.h>
 
@@ -204,17 +205,16 @@ auto SampleDecoder::supportedAudioTypes() -> const std::vector<AudioType>&
 			sfFormatInfo.format = simple;
 			sf_command(nullptr, SFC_GET_SIMPLE_FORMAT, &sfFormatInfo, sizeof(sfFormatInfo));
 
-			auto it = std::find_if(types.begin(), types.end(),
-				[&](const AudioType& type) { return sfFormatInfo.extension == type.extension; });
+			auto it = std::ranges::find(types, sfFormatInfo.extension, &AudioType::extension);
 			if (it != types.end()) { continue; }
 
 			auto name = std::string{sfFormatInfo.extension};
-			std::transform(name.begin(), name.end(), name.begin(), [](unsigned char ch) { return std::toupper(ch); });
+			std::ranges::transform(name, name.begin(), [](unsigned char ch) { return std::toupper(ch); });
 
 			types.push_back(AudioType{std::move(name), sfFormatInfo.extension});
 		}
 
-		std::sort(types.begin(), types.end(), [&](const AudioType& a, const AudioType& b) { return a.name < b.name; });
+		std::ranges::sort(types, {}, &AudioType::name);
 		return types;
 	}();
 	return s_audioTypes;

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1168,9 +1168,8 @@ void Song::loadProject( const QString & fileName )
 	ControllerConnection::finalizeConnections();
 
 	// Remove dummy controllers that was added for correct connections
-	m_controllers.erase(std::remove_if(m_controllers.begin(), m_controllers.end(),
-		[](Controller* c){return c->type() == Controller::ControllerType::Dummy;}),
-		m_controllers.end());
+	std::erase_if(m_controllers,
+		[](Controller* c){return c->type() == Controller::ControllerType::Dummy;});
 
 	// resolve all IDs so that autoModels are automated
 	AutomationClip::resolveAllIDs();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1425,7 +1425,7 @@ void Song::setProjectFileName(QString const & projectFileName)
 
 void Song::addController( Controller * controller )
 {
-	bool containsController = std::find(m_controllers.begin(), m_controllers.end(), controller) != m_controllers.end();
+	const bool containsController = std::ranges::find(m_controllers, controller) != m_controllers.end();
 	if (controller && !containsController)
 	{
 		m_controllers.push_back(controller);
@@ -1440,7 +1440,7 @@ void Song::addController( Controller * controller )
 
 void Song::removeController( Controller * controller )
 {
-	auto it = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	auto it = std::ranges::find(m_controllers, controller);
 	if (it != m_controllers.end())
 	{
 		m_controllers.erase(it);

--- a/src/core/StepRecorder.cpp
+++ b/src/core/StepRecorder.cpp
@@ -22,6 +22,8 @@
 
 #include <QKeyEvent>
 
+#include <vector>
+
 #include "MidiClip.h"
 #include "StepRecorderWidget.h"
 #include "PianoRoll.h"
@@ -304,7 +306,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 		}
 	}
 
-	m_curStepNotes.erase(std::remove_if(m_curStepNotes.begin(), m_curStepNotes.end(), [](auto stepNote)
+	std::erase_if(m_curStepNotes, [](auto stepNote)
 	{
 		bool shouldRemove = stepNote->isReleased() && stepNote->timeSinceReleased() >= REMOVE_RELEASED_NOTE_TIME_THRESHOLD_MS;
 		if (shouldRemove)
@@ -313,7 +315,7 @@ void StepRecorder::removeNotesReleasedForTooLong()
 		}
 
 		return shouldRemove;
-	}), m_curStepNotes.end());
+	});
 
 	if(notesRemoved)
 	{

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -32,6 +32,8 @@
 #include <QDomElement>
 #include <QVariant>
 
+#include <algorithm>
+
 #include "AutomationClip.h"
 #include "AutomationTrack.h"
 #include "ConfigManager.h"
@@ -356,10 +358,10 @@ Clip * Track::addClip( Clip * clip )
  */
 void Track::removeClip( Clip * clip )
 {
-	clipVector::iterator it = std::find( m_clips.begin(), m_clips.end(), clip );
-	if( it != m_clips.end() )
+	auto it = std::ranges::find(m_clips, clip);
+	if (it != m_clips.end())
 	{
-		m_clips.erase( it );
+		m_clips.erase(it);
 		if( Engine::getSong() )
 		{
 			Engine::getSong()->updateLength();
@@ -426,8 +428,8 @@ auto Track::getClip(std::size_t clipNum) -> Clip*
 int Track::getClipNum( const Clip * clip )
 {
 //	for( int i = 0; i < getTrackContentWidget()->numOfClips(); ++i )
-	clipVector::iterator it = std::find( m_clips.begin(), m_clips.end(), clip );
-	if( it != m_clips.end() )
+	auto it = std::ranges::find(m_clips, clip);
+	if (it != m_clips.end())
 	{
 /*		if( getClip( i ) == _clip )
 		{

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -29,6 +29,8 @@
 #include <QDomElement>
 #include <QWriteLocker>
 
+#include <algorithm>
+
 #include "AutomationClip.h"
 #include "embed.h"
 #include "TrackContainer.h"
@@ -196,7 +198,7 @@ void TrackContainer::removeTrack( Track * _track )
 	//   After checking that index != -1, we need to upgrade the lock to a write locker before changing m_tracks.
 	//   But since Qt offers no function to promote a read lock to a write lock, we must start with the write locker.
 	QWriteLocker lockTracksAccess(&m_tracksMutex);
-	auto it = std::find(m_tracks.begin(), m_tracks.end(), _track);
+	auto it = std::ranges::find(m_tracks, _track);
 	if (it != m_tracks.end())
 	{
 		// If the track is solo, all other tracks are muted. Change this before removing the solo track:
@@ -216,7 +218,7 @@ void TrackContainer::removeTrack( Track * _track )
 
 void TrackContainer::moveTrack(Track* track, int indexTo)
 {
-	m_tracks.erase(std::find(m_tracks.begin(), m_tracks.end(), track));
+	m_tracks.erase(std::ranges::find(m_tracks, track));
 	m_tracks.insert(m_tracks.begin() + indexTo, track);
 
 	emit trackMoved();

--- a/src/core/UpgradeExtendedNoteRange.cpp
+++ b/src/core/UpgradeExtendedNoteRange.cpp
@@ -66,7 +66,7 @@ static PatternAnalysisResult analyzeAutomationPattern(QDomElement const & automa
 		unsigned int const id = object.attribute("id").toUInt();
 
 			   // Check if the automated object is a base note.
-		if (automatedBaseNoteIds.find(id) != automatedBaseNoteIds.end())
+		if (automatedBaseNoteIds.contains(id))
 		{
 			hasBaseNoteAutomations = true;
 		}
@@ -315,7 +315,7 @@ static void fixAutomationTracks(QDomElement & song, std::set<unsigned int> const
 				{
 					unsigned int const id = object.attribute("id").toUInt();
 
-					if (automatedBaseNoteIds.find(id) != automatedBaseNoteIds.end())
+					if (automatedBaseNoteIds.contains(id))
 					{
 						QDomElement objectToRemove = object;
 						object = object.nextSiblingElement("object");
@@ -345,7 +345,7 @@ static void fixAutomationTracks(QDomElement & song, std::set<unsigned int> const
 				{
 					unsigned int const id = object.attribute("id").toUInt();
 
-					if (automatedBaseNoteIds.find(id) == automatedBaseNoteIds.end())
+					if (!automatedBaseNoteIds.contains(id))
 					{
 						QDomElement objectToRemove = object;
 						object = object.nextSiblingElement("object");

--- a/src/core/ValueBuffer.cpp
+++ b/src/core/ValueBuffer.cpp
@@ -13,7 +13,7 @@ ValueBuffer::ValueBuffer(int length)
 
 void ValueBuffer::fill(float value)
 {
-	std::fill(begin(), end(), value);
+	std::ranges::fill(*this, value);
 }
 
 float ValueBuffer::value(int offset) const

--- a/src/core/audio/AudioJack.cpp
+++ b/src/core/audio/AudioJack.cpp
@@ -346,7 +346,7 @@ void AudioJack::unregisterPort(AudioBusHandle* port)
 		{
 			if (m_portMap[port].ports[ch] != nullptr) { jack_port_unregister(m_client, m_portMap[port].ports[ch]); }
 		}
-		m_portMap.erase(m_portMap.find(port));
+		m_portMap.remove(port);
 	}
 #else
 	(void)port;

--- a/src/core/lv2/Lv2ControlBase.cpp
+++ b/src/core/lv2/Lv2ControlBase.cpp
@@ -207,7 +207,7 @@ std::size_t Lv2ControlBase::controlCount() const {
 
 bool Lv2ControlBase::hasNoteInput() const
 {
-	return std::any_of(m_procs.begin(), m_procs.end(),
+	return std::ranges::any_of(m_procs,
 		[](const auto& c) { return c->hasNoteInput(); });
 }
 

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -248,9 +248,8 @@ void Lv2Manager::initPlugins()
 
 		std::vector<PluginIssue> issues;
 		Plugin::Type type = Lv2ControlBase::check(curPlug, issues);
-		std::sort(issues.begin(), issues.end());
-		auto last = std::unique(issues.begin(), issues.end());
-		issues.erase(last, issues.end());
+		std::ranges::sort(issues);
+		issues.erase(std::ranges::unique(issues).begin(), issues.end());
 		if (m_debug && issues.size())
 		{
 			qDebug() << "Lv2 plugin"
@@ -268,7 +267,7 @@ void Lv2Manager::initPlugins()
 		if(issues.empty()) { ++pluginsLoaded; }
 		else
 		{
-			if(std::any_of(issues.begin(), issues.end(),
+			if (std::ranges::any_of(issues,
 				[](const PluginIssue& iss) {
 				return iss.type() == PluginIssueType::Blocked; }))
 			{

--- a/src/core/lv2/Lv2Manager.cpp
+++ b/src/core/lv2/Lv2Manager.cpp
@@ -320,7 +320,7 @@ void Lv2Manager::initPlugins()
 
 bool Lv2Manager::isFeatureSupported(const char *featName) const
 {
-	return m_supportedFeatureURIs.find(featName) != m_supportedFeatureURIs.end();
+	return m_supportedFeatureURIs.contains(featName);
 }
 
 

--- a/src/core/lv2/Lv2Options.cpp
+++ b/src/core/lv2/Lv2Options.cpp
@@ -40,7 +40,7 @@ std::set<LV2_URID> Lv2Options::s_supportedOptions;
 
 bool Lv2Options::isOptionSupported(LV2_URID key)
 {
-	return s_supportedOptions.find(key) != s_supportedOptions.end();
+	return s_supportedOptions.contains(key);
 }
 
 

--- a/src/core/lv2/Lv2Proc.cpp
+++ b/src/core/lv2/Lv2Proc.cpp
@@ -33,6 +33,7 @@
 #include <lv2/worker/worker.h>
 #include <QDebug>
 #include <QtGlobal>
+#include <algorithm>
 
 #include "AudioEngine.h"
 #include "AutomatableModel.h"
@@ -257,7 +258,7 @@ void Lv2Proc::copyModelsFromCore()
 			ffm.m_scalePointMap = &cv.m_scalePointMap;
 			cv.m_connectedModel->accept(ffm);
 			// dirty fix, needs better interpolation
-			std::fill(cv.m_buffer.begin(), cv.m_buffer.end(), ffm.m_res);
+			std::ranges::fill(cv.m_buffer, ffm.m_res);
 		}
 		void visit(Lv2Ports::AtomSeq& atomPort) override
 		{

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -27,6 +27,8 @@
 
 #include <array>
 
+#include <algorithm>
+
 #include "MidiPort.h"
 
 namespace lmms
@@ -73,10 +75,9 @@ void MidiClient::removePort( MidiPort* port )
 		return;
 	}
 
-	auto it = std::find(m_midiPorts.begin(), m_midiPorts.end(), port);
-	if( it != m_midiPorts.end() )
+	if (auto it = std::ranges::find(m_midiPorts, port); it != m_midiPorts.end())
 	{
-		m_midiPorts.erase( it );
+		m_midiPorts.erase(it);
 	}
 }
 

--- a/src/core/midi/MidiWinMM.cpp
+++ b/src/core/midi/MidiWinMM.cpp
@@ -204,7 +204,7 @@ void MidiWinMM::handleInputEvent( HMIDIIN hm, DWORD ev )
 	}
 
 	const MidiPortList & l = m_inputSubs[d];
-	for (MidiPortList::ConstIterator it = l.begin(); it != l.end(); ++it)
+	for (auto port : l)
 	{
 		switch (cmdtype)
 		{
@@ -214,11 +214,11 @@ void MidiWinMM::handleInputEvent( HMIDIIN hm, DWORD ev )
 			case MidiControlChange:
 			case MidiProgramChange:
 			case MidiChannelPressure:
-				(*it)->processInEvent(MidiEvent(cmdtype, chan, par1, par2 & 0xff, &hm));
+				port->processInEvent(MidiEvent(cmdtype, chan, par1, par2 & 0xff, &hm));
 				break;
 
 			case MidiPitchBend:
-				(*it)->processInEvent(MidiEvent(cmdtype, chan, par1 + par2 * 128, 0, &hm));
+				port->processInEvent(MidiEvent(cmdtype, chan, par1 + par2 * 128, 0, &hm));
 				break;
 
 			default:

--- a/src/gui/ControllerRackView.cpp
+++ b/src/gui/ControllerRackView.cpp
@@ -32,6 +32,8 @@
 #include <QMessageBox>
 #include <QVBoxLayout>
 
+#include <algorithm>
+
 #include "ControllerView.h"
 #include "DeprecationHelper.h"
 #include "embed.h"
@@ -139,7 +141,7 @@ void ControllerRackView::moveUp(ControllerView* view)
 {
 	if (view == m_controllerViews.first()) { return; }
 
-	const auto storedView = std::find(m_controllerViews.begin(), m_controllerViews.end(), view);
+	const auto storedView = std::ranges::find(m_controllerViews, view);
 	assert(storedView != m_controllerViews.end());
 
 	const auto index = std::distance(m_controllerViews.begin(), storedView);
@@ -153,7 +155,7 @@ void ControllerRackView::moveDown(ControllerView* view)
 {
 	if (view == m_controllerViews.last()) { return; }
 
-	const auto storedView = std::find(m_controllerViews.begin(), m_controllerViews.end(), view);
+	const auto storedView = std::ranges::find(m_controllerViews, view);
 	assert(storedView != m_controllerViews.end());
 	moveUp(*std::next(storedView));
 }
@@ -207,8 +209,7 @@ void ControllerRackView::removeController(Controller* removedController)
 
 	if (viewOfRemovedController )
 	{
-		m_controllerViews.erase( std::find( m_controllerViews.begin(),
-					m_controllerViews.end(), viewOfRemovedController ) );
+		m_controllerViews.erase(std::ranges::find(m_controllerViews, viewOfRemovedController));
 
 		delete viewOfRemovedController;
 		--m_nextIndex;

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -31,6 +31,8 @@
 #include <QScrollArea>
 #include <QVBoxLayout>
 
+#include <algorithm>
+
 #include "DeprecationHelper.h"
 #include "EffectSelectDialog.h"
 #include "EffectView.h"
@@ -133,7 +135,7 @@ void EffectRackView::moveDown( EffectView* view )
 	if( view != m_effectViews.last() )
 	{
 		// moving next effect up is the same
-		moveUp( *( std::find( m_effectViews.begin(), m_effectViews.end(), view ) + 1 ) );
+		moveUp(*std::next(std::ranges::find(m_effectViews, view)));
 	}
 }
 
@@ -143,7 +145,7 @@ void EffectRackView::moveDown( EffectView* view )
 void EffectRackView::deletePlugin( EffectView* view )
 {
 	Effect * e = view->effect();
-	m_effectViews.erase( std::find( m_effectViews.begin(), m_effectViews.end(), view ) );
+	m_effectViews.erase(std::ranges::find(m_effectViews, view));
 	delete view;
 	fxChain()->removeEffect( e );
 	e->deleteLater();

--- a/src/gui/FileSearchJob.cpp
+++ b/src/gui/FileSearchJob.cpp
@@ -27,6 +27,8 @@
 #include <QDirIterator>
 #include <QRegularExpression>
 
+#include <algorithm>
+
 #include "ThreadPool.h"
 
 namespace lmms::gui {
@@ -86,7 +88,7 @@ void FileSearchJob::runSearch(Task task)
 		{
 			const auto fileInfo = QFileInfo{dirIt.next()};
 			const auto fileName = fileInfo.fileName();
-			const auto containsToken = std::all_of(tokens.begin(), tokens.end(),
+			const auto containsToken = std::ranges::all_of(tokens,
 				[&](const auto& token) { return fileName.contains(token, Qt::CaseInsensitive); });
 
 			const auto validDir = fileInfo.isDir() && containsToken;

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -27,6 +27,8 @@
 #include <set>
 #include <cassert>
 
+#include <algorithm>
+
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
@@ -535,7 +537,7 @@ DataFile ClipView::createClipDataFiles(
 	{
 		// Insert into the dom under the "clips" element
 		Track* clipTrack = clipView->m_trackView->getTrack();
-		const auto trackIt = std::find(tc->tracks().begin(), tc->tracks().end(), clipTrack);
+		const auto trackIt = std::ranges::find(tc->tracks(), clipTrack);
 		assert(trackIt != tc->tracks().end());
 		int trackIndex = std::distance(tc->tracks().begin(), trackIt);
 		QDomElement clipElement = dataFile.createElement("clip");
@@ -550,7 +552,7 @@ DataFile ClipView::createClipDataFiles(
 
 	// Add extra metadata needed for calculations later
 
-	const auto initialTrackIt = std::find(tc->tracks().begin(), tc->tracks().end(), t);
+	const auto initialTrackIt = std::ranges::find(tc->tracks(), t);
 	if (initialTrackIt == tc->tracks().end())
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");

--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -288,23 +288,13 @@ void MidiClipView::mergeClips(QVector<ClipView*> clipvs)
 	track->saveJournallingState(false);
 
 	// Find the earliest position of all the selected ClipVs
-	const auto earliestClipV = std::min_element(clipvs.constBegin(), clipvs.constEnd(),
-		[](ClipView* a, ClipView* b)
-		{
-			return a->getClip()->startPosition() <
-				b->getClip()->startPosition();
-		}
-	);
+	const auto earliestClipV = std::ranges::min_element(clipvs, {},
+		[](ClipView* c) { return c->getClip()->startPosition(); });
 	const TimePos earliestPos = (*earliestClipV)->getClip()->startPosition();
 
 	// Find the latest position of all the selected ClipVs
-	const auto latestClipV = std::max_element(clipvs.constBegin(), clipvs.constEnd(),
-	[](ClipView* a, ClipView* b)
-	{
-		return a->getClip()->endPosition() <
-			b->getClip()->endPosition();
-	}
-	);
+	const auto latestClipV = std::ranges::max_element(clipvs, {},
+		[](ClipView* c) { return c->getClip()->endPosition(); });
 	const TimePos latestPos = (*latestClipV)->getClip()->endPosition();
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -526,10 +526,9 @@ void PianoRoll::markSemiTone(SemiToneMarkerAction i, bool fromMenu)
 			break;
 		case SemiToneMarkerAction::MarkCurrentSemiTone:
 		{
-			QList<int>::iterator it = std::find( m_markedSemiTones.begin(), m_markedSemiTones.end(), key );
-			if( it != m_markedSemiTones.end() )
+			if (auto it = std::ranges::find(m_markedSemiTones, key); it != m_markedSemiTones.end())
 			{
-				m_markedSemiTones.erase( it );
+				m_markedSemiTones.erase(it);
 			}
 			else
 			{
@@ -544,11 +543,9 @@ void PianoRoll::markSemiTone(SemiToneMarkerAction i, bool fromMenu)
 			if ( m_markedSemiTones.contains(key) )
 			{
 				// lets erase all of the ones that match this by octave
-				QList<int>::iterator i;
 				for (int octave : aok)
 				{
-					i = std::find(m_markedSemiTones.begin(), m_markedSemiTones.end(), octave);
-					if (i != m_markedSemiTones.end())
+					if (auto i = std::ranges::find(m_markedSemiTones, octave); i != m_markedSemiTones.end())
 					{
 						m_markedSemiTones.erase(i);
 					}
@@ -669,8 +666,8 @@ void PianoRoll::glueNotes()
 		m_midiClip->addJournalCheckPoint();
 
 		// Sort notes on key and then pos.
-		std::sort(selectedNotes.begin(), selectedNotes.end(),
-			[](const Note * note, const Note * compareNote) -> bool
+		std::ranges::sort(selectedNotes,
+			[](const Note* note, const Note* compareNote)
 			{
 				if (note->key() == compareNote->key())
 				{
@@ -734,11 +731,11 @@ void PianoRoll::fitNoteLengths(bool fill)
 	}
 	else if (!fill)
 	{
-		std::sort(notes.begin(), notes.end(), Note::lessThan);
+		std::ranges::sort(notes, Note::lessThan);
 	}
 	if (fill)
 	{
-		std::sort(notes.begin(), notes.end(), [](Note* n1, Note* n2) { return n1->endPos() < n2->endPos(); });
+		std::ranges::sort(notes, {}, [](Note* n) { return n->endPos(); });
 	}
 
 	int length;
@@ -2979,7 +2976,7 @@ void PianoRoll::setupSelectedChords()
 		if (note->pos() >= maxTime && maxTime != -1)
 		{
 			// Sort the notes by key before adding the chord to the vector
-			std::sort(currentChord.begin(), currentChord.end(), [](Note* a, Note* b){ return a->key() < b->key(); });
+			std::ranges::sort(currentChord, {}, &Note::key);
 			m_selectedChords.push_back(currentChord);
 			currentChord.clear();
 			maxTime = note->endPos();
@@ -3032,7 +3029,7 @@ void PianoRoll::updateStrumPos(QMouseEvent* me, bool initial, bool warp)
 				// if this is the clicked note, calculate it's ratio up the chord
 				if (note == clickedNote && chord.size() > 1)
 				{
-					m_strumHeightRatio = 1.f * std::distance(chord.begin(), std::find(chord.begin(), chord.end(), clickedNote)) / (chord.size() - 1);
+					m_strumHeightRatio = 1.f * std::distance(chord.begin(), std::ranges::find(chord, clickedNote)) / (chord.size() - 1);
 				}
 			}
 		}
@@ -4116,11 +4113,8 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 					volume_t vol = qBound<int>( MinVolume, n->getVolume() + step, MaxVolume );
 					n->setVolume( vol );
 				}
-				bool allVolumesEqual = std::all_of( nv.begin(), nv.end(),
-					[nv](const Note *note)
-					{
-						return note->getVolume() == nv[0]->getVolume();
-					});
+				const bool allVolumesEqual = std::ranges::all_of(nv,
+					[nv](const Note* note) { return note->getVolume() == nv[0]->getVolume(); });
 				if ( allVolumesEqual )
 				{
 					// show the volume hover-text only if all notes have the
@@ -4137,11 +4131,8 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 					panning_t pan = qBound(PanningLeft, static_cast<panning_t>(n->getPanning() + step), PanningRight);
 					n->setPanning(pan);
 				}
-				bool allPansEqual = std::all_of( nv.begin(), nv.end(),
-					[nv](const Note *note)
-					{
-						return note->getPanning() == nv[0]->getPanning();
-					});
+				const bool allPansEqual = std::ranges::all_of(nv,
+					[nv](const Note* note) { return note->getPanning() == nv[0]->getPanning(); });
 				if ( allPansEqual )
 				{
 					// show the pan hover-text only if all notes have the same

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -34,6 +34,8 @@
 #include <QSlider>
 #include <QTimeLine>
 
+#include <algorithm>
+
 #include "ActionGroup.h"
 #include "AudioDevice.h"
 #include "AudioEngine.h"
@@ -304,10 +306,8 @@ float SongEditor::getSnapSize() const
 	{
 		// Finds the closest available snap size
 		const float optimalSize = snapSize * DEFAULT_PIXELS_PER_BAR / pixelsPerBar();
-		return *std::min_element(PROPORTIONAL_SNAP_SIZES.begin(), PROPORTIONAL_SNAP_SIZES.end(), [optimalSize](float a, float b)
-		{
-			return std::abs(a - optimalSize) < std::abs(b - optimalSize);
-		});
+		return *std::ranges::min_element(PROPORTIONAL_SNAP_SIZES, {},
+			[optimalSize](float v) { return std::abs(v - optimalSize); });
 	}
 
 	return snapSize;
@@ -901,8 +901,7 @@ int SongEditor::trackIndexFromSelectionPoint(int yPos)
 
 int SongEditor::indexOfTrackView(const TrackView *tv)
 {
-	return static_cast<int>(std::distance(trackViews().begin(),
-										  std::find(trackViews().begin(), trackViews().end(), tv)));
+	return static_cast<int>(std::distance(trackViews().begin(), std::ranges::find(trackViews(), tv)));
 }
 
 

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -28,6 +28,8 @@
 #include <QPushButton>
 #include <QMessageBox>
 
+#include <algorithm>
+
 #include "AudioEngine.h"
 #include "ControllerConnectionDialog.h"
 #include "ControllerConnection.h"
@@ -259,7 +261,7 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			else
 			{
 				auto& controllers = Engine::getSong()->controllers();
-				auto it = std::find(controllers.begin(), controllers.end(), cc->getController());
+				auto it = std::ranges::find(controllers, cc->getController());
 
 				if (it != controllers.end())
 				{

--- a/src/gui/modals/EffectSelectDialog.cpp
+++ b/src/gui/modals/EffectSelectDialog.cpp
@@ -81,18 +81,18 @@ EffectSelectDialog::EffectSelectDialog(QWidget* parent) :
 	m_sourceModel.setHorizontalHeaderItem(0, new QStandardItem(tr("Name")));
 	m_sourceModel.setHorizontalHeaderItem(1, new QStandardItem(tr("Type")));
 	int row = 0;
-	for (EffectKeyList::ConstIterator it = m_effectKeys.begin(); it != m_effectKeys.end(); ++it)
+	for (const auto& key : m_effectKeys)
 	{
 		QString name;
 		QString type;
-		if (it->desc->subPluginFeatures)
+		if (key.desc->subPluginFeatures)
 		{
-			name = it->displayName();
-			type = it->desc->displayName;
+			name = key.displayName();
+			type = key.desc->displayName;
 		}
 		else
 		{
-			name = it->desc->displayName;
+			name = key.desc->displayName;
 			type = "LMMS";
 		}
 		m_sourceModel.setItem(row, 0, new QStandardItem(name));

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -32,6 +32,8 @@
 #include <QLineEdit>
 #include <QScrollArea>
 
+#include <algorithm>
+
 #include "AudioEngine.h"
 #include "embed.h"
 #include "Engine.h"
@@ -605,7 +607,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 
 	auto setSampleRate = [this, sampleRateLabel](int sampleRate)
 	{	
-		const auto it = std::find(SUPPORTED_SAMPLERATES.begin(), SUPPORTED_SAMPLERATES.end(), sampleRate);
+		const auto it = std::ranges::find(SUPPORTED_SAMPLERATES, sampleRate);
 		const auto index = it == SUPPORTED_SAMPLERATES.end() ? 0 : std::distance(SUPPORTED_SAMPLERATES.begin(), it);
 
 		m_sampleRate = SUPPORTED_SAMPLERATES[index];

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -29,6 +29,8 @@
 #include <QMenu>
 #include <QPainter>
 
+#include <algorithm>
+
 #include "AutomationClip.h"
 #include "Clipboard.h"
 #include "DataFile.h"
@@ -194,12 +196,9 @@ void TrackContentWidget::addClipView( ClipView * clipv )
  */
 void TrackContentWidget::removeClipView( ClipView * clipv )
 {
-	clipViewVector::iterator it = std::find( m_clipViews.begin(),
-						m_clipViews.end(),
-						clipv );
-	if( it != m_clipViews.end() )
+	if (auto it = std::ranges::find(m_clipViews, clipv); it != m_clipViews.end())
 	{
-		m_clipViews.erase( it );
+		m_clipViews.erase(it);
 		Engine::getSong()->setModified();
 	}
 }
@@ -384,10 +383,8 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	// Get the current track's index
 	const TrackContainer::TrackList& tracks = t->trackContainer()->tracks();
-	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
+	const auto currentTrackIt = std::ranges::find(tracks, t);
 	const int currentTrackIndex = currentTrackIt != tracks.end() ? std::distance(tracks.begin(), currentTrackIt) : -1;
-
-	// Don't paste if we're on the same bar and allowSameBar is false
 	auto sourceTrackContainerId = metadata.attributeNode( "trackContainerId" ).value().toUInt();
 	if( !allowSameBar && sourceTrackContainerId == t->trackContainer()->id() &&
 			clipPos == grabbedClipBar && currentTrackIndex == initialTrackIndex )
@@ -483,7 +480,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	// Snap the mouse position to the beginning of the dropped bar, in ticks
 	const TrackContainer::TrackList& tracks = getTrack()->trackContainer()->tracks();
-	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
+	const auto currentTrackIt = std::ranges::find(tracks, getTrack());
 	const int currentTrackIndex = currentTrackIt != tracks.end() ? std::distance(tracks.begin(), currentTrackIt) : -1;
 
 	bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();

--- a/src/gui/widgets/AutomatableButton.cpp
+++ b/src/gui/widgets/AutomatableButton.cpp
@@ -27,6 +27,8 @@
 
 #include <QMouseEvent>
 
+#include <algorithm>
+
 #include "CaptionMenu.h"
 #include "StringPairDrag.h"
 #include "KeyboardShortcuts.h"
@@ -229,7 +231,7 @@ void AutomatableButtonGroup::addButton( AutomatableButton * _btn )
 
 void AutomatableButtonGroup::removeButton( AutomatableButton * _btn )
 {
-	m_buttons.erase( std::find( m_buttons.begin(), m_buttons.end(), _btn ) );
+	m_buttons.erase(std::ranges::find(m_buttons, _btn));
 	_btn->m_group = nullptr;
 }
 

--- a/src/gui/widgets/TabBar.cpp
+++ b/src/gui/widgets/TabBar.cpp
@@ -98,10 +98,10 @@ TabButton * TabBar::addTab( QWidget * _w, const QString & _text, int _id,
 void TabBar::removeTab( int _id )
 {
 	// find tab-button and delete it
-	if( m_tabs.find( _id ) != m_tabs.end() )
+	if( m_tabs.contains( _id ) )
 	{
 		delete m_tabs[_id].first;
-		m_tabs.erase( m_tabs.find( _id ) );
+		m_tabs.remove( _id );
 	}
 }
 
@@ -143,7 +143,7 @@ int TabBar::activeTab()
 
 bool TabBar::tabState( int _id )
 {
-	if( m_tabs.find( _id ) == m_tabs.end() )
+	if( !m_tabs.contains( _id ) )
 	{
 		return( false );
 	}
@@ -155,7 +155,7 @@ bool TabBar::tabState( int _id )
 
 void TabBar::setTabState( int _id, bool _checked )
 {
-	if( m_tabs.find( _id ) != m_tabs.end() )
+	if( m_tabs.contains( _id ) )
 	{
 		m_tabs[_id].first->setChecked( _checked );
 	}
@@ -175,7 +175,7 @@ void TabBar::hideAll( int _exception )
 		}
 		it.value().second->hide();
 	}
-	if( m_tabs.find( _exception ) != m_tabs.end() )
+	if( m_tabs.contains( _exception ) )
 	{
 		if( tabState( _exception ) )
 		{

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -97,7 +97,7 @@ void MidiClip::resizeToFirstTrack()
 			if (track != m_instrumentTrack)
 			{
 				const auto& instrumentTrackClips = m_instrumentTrack->getClips();
-				const auto currentClipIt = std::find(instrumentTrackClips.begin(), instrumentTrackClips.end(), this);
+				const auto currentClipIt = std::ranges::find(instrumentTrackClips, this);
 				unsigned int currentClip = currentClipIt != instrumentTrackClips.end() ?
 					std::distance(instrumentTrackClips.begin(), currentClipIt) : -1;
 				m_steps = static_cast<MidiClip*>(track->getClip(currentClip))->m_steps;
@@ -186,7 +186,7 @@ Note * MidiClip::addNote( const Note & _new_note, const bool _quant_pos )
 	}
 
 	instrumentTrack()->lock();
-	m_notes.insert(std::upper_bound(m_notes.begin(), m_notes.end(), new_note, Note::lessThan), new_note);
+	m_notes.insert(std::ranges::upper_bound(m_notes, new_note, Note::lessThan), new_note);
 	instrumentTrack()->unlock();
 
 	checkType();
@@ -218,7 +218,7 @@ NoteVector::const_iterator MidiClip::removeNote(Note* note)
 {
 	instrumentTrack()->lock();
 
-	auto it = std::find(m_notes.begin(), m_notes.end(), note);
+	auto it = std::ranges::find(m_notes, note);
 	if (it != m_notes.end())
 	{
 		delete *it;
@@ -254,7 +254,7 @@ Note * MidiClip::noteAtStep(int step)
 void MidiClip::rearrangeAllNotes()
 {
 	// sort notes by start time
-	std::sort(m_notes.begin(), m_notes.end(), Note::lessThan);
+	std::ranges::sort(m_notes, Note::lessThan);
 }
 
 
@@ -314,8 +314,8 @@ void MidiClip::reverseNotes(const NoteVector& notes)
 	addJournalCheckPoint();
 
 	// Find the very first start position and the very last end position of all the notes.
-	TimePos firstPos = (*std::min_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return Note::lessThan(n1, n2); }))->pos();
-	TimePos lastPos = (*std::max_element(notes.begin(), notes.end(), [](const Note* n1, const Note* n2){ return n1->endPos() < n2->endPos(); }))->endPos();
+	TimePos firstPos = (*std::ranges::min_element(notes, Note::lessThan))->pos();
+	TimePos lastPos = (*std::ranges::max_element(notes, {}, [](const Note* n) { return n->endPos(); }))->endPos();
 
 	for (auto note : notes)
 	{
@@ -422,7 +422,7 @@ void MidiClip::setType( Type _new_clip_type )
 void MidiClip::checkType()
 {
 	// If all notes are StepNotes, we have a BeatClip
-	const auto beatClip = std::all_of(m_notes.begin(), m_notes.end(), [](auto note) { return note->type() == Note::Type::Step; });
+	const auto beatClip = std::ranges::all_of(m_notes, [](auto note) { return note->type() == Note::Type::Step; });
 
 	setType(beatClip ? Type::BeatClip : Type::MelodyClip);
 }


### PR DESCRIPTION
I've used Claude Code (Opus model) to find non-breaking C++20 modernization opportunities. Curious if you'd find it useful or rather distracting.

Current list of changes in separate commits:
- Use structured bindings and range-for loops in place of iterator/index-based loops
- Replace `std::find`/`find_if`/`any_of`/`all_of`/`sort`/`unique`/`fill`/`upper_bound`/`min_element`/`max_element` with `std::ranges` equivalents, using projections where they clarify intent
- Use `std::erase_if` in place of the erase-`remove_if` idiom
- Replace hand-written comparison operators with defaulted `operator<=>` in `ProjectVersion` and `PluginIssue`
- Use `.contains()` / `.remove()` for associative container lookups

