### PR TITLE
Don't hide BeatClip names

### DIFF
--- a/src/gui/clips/MidiClipView.cpp
+++ b/src/gui/clips/MidiClipView.cpp
@@ -602,8 +602,7 @@ void MidiClipView::paintEvent( QPaintEvent * )
 
 	// Check whether we will paint a text box and compute its potential height
 	// This is needed so we can paint the notes underneath it.
-	bool const drawName = !m_clip->name().isEmpty();
-	bool const drawTextBox = !beatClip && drawName;
+	bool const drawTextBox = !m_clip->name().isEmpty();
 
 	// TODO Warning! This might cause problems if ClipView::paintTextLabel changes
 	int textBoxHeight = 0;


### PR DESCRIPTION
Fixes #7808, supersedes #7836 and #8413.

Empty `MidiClip`s with a name currently don't display their name if they have no notes. This is because a `MidiClip` with no notes is considered to be a `BeatClip`, and `BeatClip`s are explicitly forbidden from displaying their names for some reason.

This patch is @bratpeki's work, taken from https://github.com/LMMS/lmms/pull/7836#issuecomment-4034808683. It's by far the simplest solution to this bug: allow `BeatClip`s to display their name if they have one. That way empty `MidiClip`s also show their set names.

If `BeatClip`s are really really not supposed to have names for whatever reason, then it shouldn't be possible to set their names in the first place, which is beyond the scope of this bugfix anyways.

I've already reviewed and tested this myself (since this is not my code) and believe this is ready for merge ASAP.