### PR TITLE
Fix FPE in Automation Editor on Startup

### DIFF
--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1840,8 +1840,15 @@ void AutomationEditor::updateYDelta()
 	}
 	else
 	{
-		int gridBottom = height() - SCROLLBAR_SIZE - 1;
-		m_y_delta = static_cast<float>(gridBottom - TOP_MARGIN) / (m_maxLevel - m_minLevel);
+		if (m_maxLevel - m_minLevel == 0)
+		{
+			m_y_delta = 0.0f;
+		}
+		else
+		{
+			int gridBottom = height() - SCROLLBAR_SIZE - 1;
+			m_y_delta = static_cast<float>(gridBottom - TOP_MARGIN) / (m_maxLevel - m_minLevel);
+		}
 	}
 }
 


### PR DESCRIPTION
After #7946 was merged, when starting up LMMS compiled with `-DWANT_DEBUG_FPE=ON`, it crashes because it divides by zero. This PR adds a check to prevent that.