### PR TITLE
Move `SampleThumbnail` into the `lmms::gui` namespace

### DIFF
--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -143,6 +143,6 @@ private:
 	inline static std::unordered_map<SampleThumbnailEntry, std::shared_ptr<ThumbnailCache>, Hash> s_sampleThumbnailCacheMap;
 };
 
-} // namespace lmms
+} // namespace lmms::gui
 
 #endif // LMMS_SAMPLE_THUMBNAIL_H

--- a/include/SampleThumbnail.h
+++ b/include/SampleThumbnail.h
@@ -37,8 +37,10 @@
 class QPainter;
 
 namespace lmms {
-
 class Sample;
+}
+
+namespace lmms::gui {
 
 /**
    Allows for visualizing sample data.

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -178,4 +178,4 @@ void SampleThumbnail::visualize(VisualizeParameters parameters, QPainter& painte
 	painter.restore();
 }
 
-} // namespace lmms
+} // namespace lmms::gui

--- a/src/gui/SampleThumbnail.cpp
+++ b/src/gui/SampleThumbnail.cpp
@@ -35,7 +35,7 @@ namespace {
 	constexpr auto AggregationPerZoomStep = 10;
 }
 
-namespace lmms {
+namespace lmms::gui {
 
 SampleThumbnail::Thumbnail::Thumbnail(std::vector<Peak> peaks, double samplesPerPeak)
 	: m_peaks(std::move(peaks))


### PR DESCRIPTION
A simple refactor I noticed that could be done.