### PR TITLE
Improve project load/save performance

### DIFF
--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -25,9 +25,11 @@
 #ifndef LMMS_AUTOMATABLE_MODEL_H
 #define LMMS_AUTOMATABLE_MODEL_H
 
+#include <atomic>
 #include <cmath>
 #include <QMap>
 #include <QMutex>
+#include <QPointer>
 
 #include "JournallingObject.h"
 #include "Model.h"
@@ -92,6 +94,59 @@ public:
 	virtual void accept(ConstModelVisitor& v) const = 0;
 
 public:
+	//! Ref-counted handle that allows an @a AutomatableModel to efficiently
+	//! keep track of the number of automation connections
+	class Connection
+	{
+	public:
+		friend class AutomatableModel;
+
+		Connection() = default;
+
+		Connection(const Connection& other);
+		Connection(Connection&& other) noexcept;
+		auto operator=(const Connection& other) -> Connection&;
+		auto operator=(Connection&& other) noexcept -> Connection&;
+
+		~Connection();
+
+		auto model() const -> AutomatableModel* { return m_model; }
+
+		void disconnect();
+
+		explicit operator bool() const noexcept { return m_model != nullptr; }
+
+		friend auto operator<=>(const Connection& lhs, const Connection& rhs) noexcept
+		{
+			return lhs.m_model <=> rhs.m_model;
+		}
+
+		friend auto operator==(const Connection& lhs, const Connection& rhs) noexcept
+		{
+			return lhs.m_model == rhs.m_model;
+		}
+
+		friend auto operator<=>(const Connection& lhs, const AutomatableModel* rhs) noexcept
+		{
+			return lhs.m_model <=> rhs;
+		}
+
+		friend auto operator==(const Connection& lhs, const AutomatableModel* rhs) noexcept
+		{
+			return lhs.m_model == rhs;
+		}
+
+	private:
+		//! Only @a AutomatableModel can create @a Connection objects
+		explicit Connection(AutomatableModel* model);
+
+		void reset(AutomatableModel* model);
+
+		QPointer<AutomatableModel> m_model;
+	};
+
+	auto createAutomationConnection() -> Connection { return Connection{this}; }
+
 	/**
 	   @brief Return this class casted to Target
 	   @test AutomatableModelTest.cpp
@@ -117,7 +172,11 @@ public:
 		return vis.result;
 	}
 
-	bool isAutomated() const;
+	bool isAutomated() const
+	{
+		return m_totalAutomationConnections.load(std::memory_order::acquire) > 0;
+	}
+
 	bool isAutomatedOrControlled() const
 	{
 		return isAutomated() || m_controllerConnection != nullptr;
@@ -419,6 +478,8 @@ private:
 	QMutex m_valueBufferMutex;
 
 	bool m_useControllerValue;
+
+	std::atomic<std::int32_t> m_totalAutomationConnections = 0;
 
 signals:
 	void initValueChanged( float val );

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -294,8 +294,6 @@ public:
 		return false;
 	}
 
-	float globalAutomationValueAt( const TimePos& time );
-
 	void setStrictStepSize( const bool b )
 	{
 		m_hasStrictStepSize = b;

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -314,6 +314,8 @@ public:
 		return m_useControllerValue;
 	}
 
+	static bool mustQuoteName(const QString& name);
+
 public slots:
 	virtual void reset();
 	void unlink();
@@ -353,8 +355,6 @@ private:
 		const Target* result = nullptr;
 		void visit(const Target& tar) { result = &tar; }
 	};
-
-	static bool mustQuoteName(const QString &name);
 
 	void saveSettings( QDomDocument& doc, QDomElement& element ) override
 	{

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -60,7 +60,7 @@ public:
 	} ;
 
 	using timeMap = QMap<int, AutomationNode>;
-	using objectVector = std::vector<QPointer<AutomatableModel>>;
+	using Connections = std::vector<AutomatableModel::Connection>;
 
 	using TimemapIterator = timeMap::const_iterator;
 
@@ -70,7 +70,7 @@ public:
 	bool addObject( AutomatableModel * _obj, bool _search_dup = true );
 
 	const AutomatableModel * firstObject() const;
-	const objectVector& objects() const;
+	const Connections& connections() const;
 
 	// progression-type stuff
 	inline ProgressionType progressionType() const
@@ -181,7 +181,6 @@ public:
 	gui::ClipView * createView( gui::TrackView * _tv ) override;
 
 
-	static bool isAutomated( const AutomatableModel * _m );
 	static AutomationClip * globalAutomationClip( AutomatableModel * _m );
 	static void resolveAllIDs();
 
@@ -229,7 +228,7 @@ private:
 
 	AutomationTrack * m_autoTrack;
 	std::vector<jo_id_t> m_idsToResolve;
-	objectVector m_objects;
+	Connections m_objects;
 	timeMap m_timeMap;	// actual values
 	timeMap m_oldTimeMap;	// old values for storing the values before setDragValue() is called.
 	float m_tension;

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -67,9 +67,11 @@ public:
 	AutomationClip( AutomationTrack * _auto_track );
 	~AutomationClip() override = default;
 
-	bool addObject( AutomatableModel * _obj, bool _search_dup = true );
+	bool addConnection(AutomatableModel* model, bool searchDuplicates = true);
+	void removeConnection(const AutomatableModel* model);
 
-	const AutomatableModel * firstObject() const;
+	//! @returns the first connection's model, or a dummy model if there are no connections
+	const AutomatableModel& connectedModel() const;
 	const Connections& connections() const;
 
 	// progression-type stuff
@@ -115,6 +117,9 @@ public:
 	 */
 	void resetTangents(const int tick0, const int tick1);
 
+	void generateTangents();
+	void generateTangents(timeMap::iterator it, int numToGenerate);
+
 	void recordValue(TimePos time, float value);
 
 	TimePos setDragValue( const TimePos & time,
@@ -142,12 +147,12 @@ public:
 
 	inline float getMin() const
 	{
-		return firstObject()->minValue<float>();
+		return connectedModel().minValue<float>();
 	}
 
 	inline float getMax() const
 	{
-		return firstObject()->maxValue<float>();
+		return connectedModel().maxValue<float>();
 	}
 
 	inline bool hasAutomation() const
@@ -195,11 +200,11 @@ public:
 		return new AutomationClip(*this);
 	}
 
-	void clearObjects() { m_objects.clear(); }
+	void clearConnections() { m_connections.clear(); }
 
 public slots:
 	void clear();
-	void objectDestroyed( lmms::jo_id_t );
+	void connectedModelDestroyed(lmms::jo_id_t id);
 	void flipY( int min, int max );
 	void flipY();
 	void flipX(int start = -1, int end = -1);
@@ -208,9 +213,7 @@ protected:
 	AutomationClip( const AutomationClip & _clip_to_copy );
 
 private:
-	void cleanObjects();
-	void generateTangents();
-	void generateTangents(timeMap::iterator it, int numToGenerate);
+	void cleanConnections();
 	float valueAt( timeMap::const_iterator v, int offset ) const;
 
 	/**
@@ -228,7 +231,7 @@ private:
 
 	AutomationTrack * m_autoTrack;
 	std::vector<jo_id_t> m_idsToResolve;
-	Connections m_objects;
+	Connections m_connections;
 	timeMap m_timeMap;	// actual values
 	timeMap m_oldTimeMap;	// old values for storing the values before setDragValue() is called.
 	float m_tension;
@@ -249,12 +252,7 @@ private:
 
 	static const float DEFAULT_MIN_VALUE;
 	static const float DEFAULT_MAX_VALUE;
-
-	friend class gui::AutomationClipView;
-	friend class AutomationNode;
-	friend class gui::AutomationEditor;
-
-} ;
+};
 
 //Short-hand functions to access node values in an automation clip;
 // replacement for CPP macros with the same purpose; could be refactored

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -182,7 +182,6 @@ public:
 
 
 	static bool isAutomated( const AutomatableModel * _m );
-	static std::vector<AutomationClip*> clipsForModel(const AutomatableModel* _m);
 	static AutomationClip * globalAutomationClip( AutomatableModel * _m );
 	static void resolveAllIDs();
 

--- a/include/AutomationClipView.h
+++ b/include/AutomationClipView.h
@@ -56,7 +56,7 @@ public slots:
 protected slots:
 	void resetName();
 	void changeName();
-	void disconnectObject( QAction * _a );
+	void disconnectModel(QAction* a);
 	void toggleRecording();
 	void flipY();
 	void flipX();

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -44,7 +44,7 @@ public:
 		m_autoClip(_copy.m_autoClip->clone())
 	{
 		m_autoClip->clearObjects();
-		m_autoClip->addObject(this);
+		m_autoClip->addObject(this, false);
 	}
 
 	~InlineAutomation() override
@@ -60,8 +60,7 @@ public:
 			// Prevent saving inline automation if there's just one node at the beginning of
 			// the clip, which has a InValue equal to the value of model (which is going
 			// to be saved anyways) and no offset between the InValue and OutValue
-			AutomationClip::timeMap::const_iterator firstNode =
-				m_autoClip->getTimeMap().begin();
+			AutomationClip::timeMap::const_iterator firstNode = m_autoClip->getTimeMap().cbegin();
 
 			if (isAtInitValue()
 				&& m_autoClip->getTimeMap().size() == 1
@@ -83,7 +82,7 @@ public:
 		if( m_autoClip == nullptr )
 		{
 			m_autoClip = std::make_unique<AutomationClip>(nullptr);
-			m_autoClip->addObject( this );
+			m_autoClip->addObject(this, false);
 		}
 		return m_autoClip.get();
 	}

--- a/include/InlineAutomation.h
+++ b/include/InlineAutomation.h
@@ -43,8 +43,8 @@ public:
 		FloatModel(_copy.value(), _copy.minValue(), _copy.maxValue(), _copy.step<float>()),
 		m_autoClip(_copy.m_autoClip->clone())
 	{
-		m_autoClip->clearObjects();
-		m_autoClip->addObject(this, false);
+		m_autoClip->clearConnections();
+		m_autoClip->addConnection(this, false);
 	}
 
 	~InlineAutomation() override
@@ -82,7 +82,7 @@ public:
 		if( m_autoClip == nullptr )
 		{
 			m_autoClip = std::make_unique<AutomationClip>(nullptr);
-			m_autoClip->addObject(this, false);
+			m_autoClip->addConnection(this, false);
 		}
 		return m_autoClip.get();
 	}

--- a/include/ProjectJournal.h
+++ b/include/ProjectJournal.h
@@ -89,13 +89,10 @@ public:
 
 	void clearJournal();
 	void stopAllJournalling();
-	JournallingObject * journallingObject( const jo_id_t _id )
+	JournallingObject* journallingObject(const jo_id_t id) const
 	{
-		if( m_joIDs.contains( _id ) )
-		{
-			return m_joIDs[_id];
-		}
-		return nullptr;
+		const auto it = m_joIDs.constFind(id);
+		return it != m_joIDs.cend() ? *it : nullptr;
 	}
 
 

--- a/plugins/CarlaBase/Carla.h
+++ b/plugins/CarlaBase/Carla.h
@@ -89,13 +89,6 @@ public:
 	{
 	}
 
-	// From AutomatableModel.h, it's private there.
-	inline static bool mustQuoteName(const QString &name)
-	{
-		QRegularExpression reg("^[A-Za-z0-9._-]+$");
-		return !reg.match(name).hasMatch();
-	}
-
 	inline void loadSettings(const QDomElement& element, const QString& name = QString("value")) override
 	{
 		AutomatableModel::loadSettings(element, name);

--- a/plugins/MidiImport/MidiImport.cpp
+++ b/plugins/MidiImport/MidiImport.cpp
@@ -171,7 +171,7 @@ public:
 		{
 			TimePos pPos = TimePos(time.getBar(), 0);
 			ap = dynamic_cast<AutomationClip*>(at->createClip(pPos));
-			ap->addObject(objModel);
+			ap->addConnection(objModel);
 		}
 
 		lastPos = time;
@@ -298,10 +298,10 @@ bool MidiImport::readSMF(TrackContainer* tc)
 	dt->setName(tr("MIDI Time Signature Denominator"));
 	auto timeSigNumeratorPat = new AutomationClip(nt);
 	timeSigNumeratorPat->setDisplayName(tr("Numerator"));
-	timeSigNumeratorPat->addObject(&timeSigMM.numeratorModel());
+	timeSigNumeratorPat->addConnection(&timeSigMM.numeratorModel());
 	auto timeSigDenominatorPat = new AutomationClip(dt);
 	timeSigDenominatorPat->setDisplayName(tr("Denominator"));
-	timeSigDenominatorPat->addObject(&timeSigMM.denominatorModel());
+	timeSigDenominatorPat->addConnection(&timeSigMM.denominatorModel());
 
 	// TODO: adjust these to Time.Sig changes
 	double beatsPerBar = 4;
@@ -326,7 +326,7 @@ bool MidiImport::readSMF(TrackContainer* tc)
 	tt->setName(tr("Tempo"));
 	auto tap = new AutomationClip(tt);
 	tap->setDisplayName(tr("Tempo"));
-	tap->addObject(&Engine::getSong()->tempoModel());
+	tap->addConnection(&Engine::getSong()->tempoModel());
 	if (tap)
 	{
 		tap->clear();

--- a/plugins/Vestige/Vestige.cpp
+++ b/plugins/Vestige/Vestige.cpp
@@ -230,7 +230,7 @@ void VestigeInstrument::loadSettings( const QDomElement & _this )
 			knobFModel[i] = new FloatModel( 0.0f, 0.0f, 1.0f, 0.01f, this, QString::number(i) );
 			knobFModel[i]->loadSettings(_this, paramStr.data());
 
-			if( !( knobFModel[ i ]->isAutomated() || knobFModel[ i ]->controllerConnection() ) )
+			if (!knobFModel[i]->isAutomatedOrControlled())
 			{
 				knobFModel[ i ]->setValue(LocaleHelper::toFloat(s_dumpValues.at(2)));
 				knobFModel[ i ]->setInitValue(LocaleHelper::toFloat(s_dumpValues.at(2)));
@@ -287,7 +287,8 @@ void VestigeInstrument::saveSettings( QDomDocument & _doc, QDomElement & _this )
 			auto paramStr = std::array<char, 35>{};
 			for( int i = 0; i < paramCount; i++ )
 			{
-				if (knobFModel[i]->isAutomated() || knobFModel[i]->controllerConnection()) {
+				if (knobFModel[i]->isAutomatedOrControlled())
+				{
 					std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 					knobFModel[i]->saveSettings(_doc, _this, paramStr.data());
 				}
@@ -1038,7 +1039,7 @@ void ManageVestigeInstrumentView::syncPlugin( void )
 	{
 		// only not automated knobs are synced from VST
 		// those auto-setted values are not jurnaled, tracked for undo / redo
-		if( !( m_vi->knobFModel[ i ]->isAutomated() || m_vi->knobFModel[ i ]->controllerConnection() ) )
+		if (!m_vi->knobFModel[i]->isAutomatedOrControlled())
 		{
 			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 			s_dumpValues = dump[paramStr.data()].split(":");
@@ -1060,8 +1061,7 @@ void ManageVestigeInstrumentView::displayAutomatedOnly( void )
 
 	for( int i = 0; i< m_vi->paramCount; i++ )
 	{
-
-		if( !( m_vi->knobFModel[ i ]->isAutomated() || m_vi->knobFModel[ i ]->controllerConnection() ) )
+		if (!m_vi->knobFModel[i]->isAutomatedOrControlled())
 		{
 			if (m_vstKnobs[i]->isVisible() && isAuto)
 			{

--- a/plugins/VstEffect/VstEffectControls.cpp
+++ b/plugins/VstEffect/VstEffectControls.cpp
@@ -92,8 +92,7 @@ void VstEffectControls::loadSettings( const QDomElement & _this )
 			knobFModel[i] = new FloatModel( 0.0f, 0.0f, 1.0f, 0.01f, this, QString::number(i) );
 			knobFModel[i]->loadSettings(_this, paramStr.data());
 
-			if( !( knobFModel[ i ]->isAutomated() ||
-						knobFModel[ i ]->controllerConnection() ) )
+			if (!knobFModel[i]->isAutomatedOrControlled())
 			{
 				knobFModel[ i ]->setValue(LocaleHelper::toFloat(s_dumpValues.at(2)));
 				knobFModel[ i ]->setInitValue(LocaleHelper::toFloat(s_dumpValues.at(2)));
@@ -135,7 +134,8 @@ void VstEffectControls::saveSettings( QDomDocument & _doc, QDomElement & _this )
 			auto paramStr = std::array<char, 35>{};
 			for( int i = 0; i < paramCount; i++ )
 			{
-				if (knobFModel[i]->isAutomated() || knobFModel[i]->controllerConnection()) {
+				if (knobFModel[i]->isAutomatedOrControlled())
+				{
 					std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 					knobFModel[i]->saveSettings(_doc, _this, paramStr.data());
 				}
@@ -448,8 +448,7 @@ void ManageVSTEffectView::syncPlugin()
 	{
 		// only not automated knobs are synced from VST
 		// those auto-setted values are not jurnaled, tracked for undo / redo
-		if( !( m_vi2->knobFModel[ i ]->isAutomated() ||
-					m_vi2->knobFModel[ i ]->controllerConnection() ) )
+		if (!m_vi2->knobFModel[i]->isAutomatedOrControlled())
 		{
 			std::snprintf(paramStr.data(), paramStr.size(), "param%d", i);
 			s_dumpValues = dump[paramStr.data()].split(":");
@@ -470,9 +469,7 @@ void ManageVSTEffectView::displayAutomatedOnly()
 
 	for( int i = 0; i< m_vi2->paramCount; i++ )
 	{
-
-		if( !( m_vi2->knobFModel[ i ]->isAutomated() ||
-					m_vi2->knobFModel[ i ]->controllerConnection() ) )
+		if (!m_vi2->knobFModel[i]->isAutomatedOrControlled())
 		{
 			if (m_vstKnobs[i]->isVisible() && isAuto)
 			{

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -84,15 +84,66 @@ AutomatableModel::~AutomatableModel()
 	emit destroyed( id() );
 }
 
-
-
-
-bool AutomatableModel::isAutomated() const
+AutomatableModel::Connection::Connection(AutomatableModel* model)
 {
-	return AutomationClip::isAutomated( this );
+	reset(model);
 }
 
+AutomatableModel::Connection::Connection(const Connection& other)
+{
+	reset(other.m_model);
+}
 
+AutomatableModel::Connection::Connection(Connection&& other) noexcept
+	: m_model{std::exchange(other.m_model, nullptr)}
+{}
+
+auto AutomatableModel::Connection::operator=(const Connection& other) -> Connection&
+{
+	if (this != &other)
+	{
+		reset(other.m_model);
+	}
+	return *this;
+}
+
+auto AutomatableModel::Connection::operator=(Connection&& other) noexcept -> Connection&
+{
+	if (this != &other)
+	{
+		reset(std::exchange(other.m_model, nullptr));
+	}
+	return *this;
+}
+
+AutomatableModel::Connection::~Connection()
+{
+	disconnect();
+}
+
+void AutomatableModel::Connection::reset(AutomatableModel* model)
+{
+	// Disconnect
+	if (m_model)
+	{
+		[[maybe_unused]] auto num = m_model->m_totalAutomationConnections.fetch_sub(1, std::memory_order::release);
+		assert(num >= 0);
+	}
+
+	m_model = model;
+
+	// Connect
+	if (model)
+	{
+		[[maybe_unused]] auto num = model->m_totalAutomationConnections.fetch_add(1, std::memory_order::acquire);
+		assert(num >= 0);
+	}
+}
+
+void AutomatableModel::Connection::disconnect()
+{
+	reset(nullptr);
+}
 
 bool AutomatableModel::mustQuoteName(const QString& name)
 {

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -96,7 +96,7 @@ bool AutomatableModel::isAutomated() const
 
 bool AutomatableModel::mustQuoteName(const QString& name)
 {
-	QRegularExpression reg("^[A-Za-z0-9._-]+$");
+	static const auto reg = QRegularExpression{"^[A-Za-z0-9._-]+$"};
 	return !reg.match(name).hasMatch();
 }
 

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -655,64 +655,6 @@ void AutomatableModel::reset()
 
 
 
-float AutomatableModel::globalAutomationValueAt( const TimePos& time )
-{
-	// get clips that connect to this model
-	auto clips = AutomationClip::clipsForModel(this);
-	if (clips.empty())
-	{
-		// if no such clips exist, return current value
-		return m_value;
-	}
-	else
-	{
-		// of those clips:
-		// find the clips which overlap with the time position
-		std::vector<AutomationClip*> clipsInRange;
-		for (const auto& clip : clips)
-		{
-			int s = clip->startPosition();
-			int e = clip->endPosition();
-			if (s <= time && e >= time) { clipsInRange.push_back(clip); }
-		}
-
-		AutomationClip * latestClip = nullptr;
-
-		if (!clipsInRange.empty())
-		{
-			// if there are more than one overlapping clips, just use the first one because
-			// multiple clip behaviour is undefined anyway
-			latestClip = clipsInRange[0];
-		}
-		else
-		// if we find no clips at the exact time, we need to search for the last clip before time and use that
-		{
-			int latestPosition = 0;
-
-			for (const auto& clip : clips)
-			{
-				int e = clip->endPosition();
-				if (e <= time && e > latestPosition)
-				{
-					latestPosition = e;
-					latestClip = clip;
-				}
-			}
-		}
-
-		if( latestClip )
-		{
-			// scale/fit the value appropriately and return it
-			const float value = latestClip->valueAt(time - latestClip->startPosition() + latestClip->startTimeOffset());
-			const float scaled_value = scaledValue( value );
-			return fittedValue( scaled_value );
-		}
-		// if we still find no clip, the value at that time is undefined so
-		// just return current value as the best we can do
-		else return m_value;
-	}
-}
-
 void AutomatableModel::setUseControllerValue(bool b)
 {
 	if (b)

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -963,47 +963,6 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
 }
 
 
-/**
- * @brief returns a list of all the automation clips that are connected to a specific model
- * @param _m the model we want to look for
- */
-std::vector<AutomationClip *> AutomationClip::clipsForModel(const AutomatableModel* _m)
-{
-	std::vector<AutomationClip *> clips;
-	auto l = combineAllTracks();
-
-	// go through all tracks...
-	for (const auto track : l)
-	{
-		// we want only automation tracks...
-		if (track->type() == Track::Type::Automation || track->type() == Track::Type::HiddenAutomation )
-		{
-			// go through all the clips...
-			for (const auto& trackClip : track->getClips())
-			{
-				auto a = dynamic_cast<AutomationClip*>(trackClip);
-				// check that the clip has automation
-				if( a && a->hasAutomation() )
-				{
-					// now check is the clip is connected to the model we want by going through all the connections
-					// of the clip
-					bool has_object = false;
-					for (const auto& object : a->m_objects)
-					{
-						if (object == _m)
-						{
-							has_object = true;
-						}
-					}
-					// if the clips is connected to the model, add it to the list
-					if (has_object) { clips.push_back(a); }
-				}
-			}
-		}
-	}
-	return clips;
-}
-
 
 
 AutomationClip * AutomationClip::globalAutomationClip(

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -48,7 +48,7 @@ const float AutomationClip::DEFAULT_MAX_VALUE = 1;
 AutomationClip::AutomationClip( AutomationTrack * _auto_track ) :
 	Clip( _auto_track ),
 	m_autoTrack( _auto_track ),
-	m_objects(),
+	m_connections(),
 	m_tension( 1.0 ),
 	m_progressionType( ProgressionType::Discrete ),
 	m_dragging( false ),
@@ -64,7 +64,7 @@ AutomationClip::AutomationClip( AutomationTrack * _auto_track ) :
 AutomationClip::AutomationClip( const AutomationClip & _clip_to_copy ) :
 	Clip(_clip_to_copy),
 	m_autoTrack( _clip_to_copy.m_autoTrack ),
-	m_objects( _clip_to_copy.m_objects ),
+	m_connections(_clip_to_copy.m_connections),
 	m_tension( _clip_to_copy.m_tension ),
 	m_progressionType(_clip_to_copy.m_progressionType),
 	m_dragging(false),
@@ -85,32 +85,40 @@ AutomationClip::AutomationClip( const AutomationClip & _clip_to_copy ) :
 	}
 }
 
-bool AutomationClip::addObject( AutomatableModel * _obj, bool _search_dup )
+bool AutomationClip::addConnection(AutomatableModel* model, bool searchForDuplicates)
 {
 	QMutexLocker m(&m_clipMutex);
 
-	assert(_obj != nullptr);
-	if (_search_dup && std::find(m_objects.begin(), m_objects.end(), _obj) != m_objects.end())
+	assert(model != nullptr);
+	if (searchForDuplicates && std::find(m_connections.begin(), m_connections.end(), model) != m_connections.end())
 	{
 		return false;
 	}
 
 	// the automation track is unconnected and there is nothing in the track
-	if (m_objects.empty() && hasAutomation() == false)
+	if (m_connections.empty() && hasAutomation() == false)
 	{
 		// then initialize first value
-		putValue( TimePos(0), _obj->inverseScaledValue( _obj->value<float>() ), false );
+		putValue(TimePos(0), model->inverseScaledValue(model->value<float>()), false);
 	}
 
-	m_objects.push_back(_obj->createAutomationConnection());
+	m_connections.push_back(model->createAutomationConnection());
 
-	connect( _obj, SIGNAL(destroyed(lmms::jo_id_t)),
-			this, SLOT(objectDestroyed(lmms::jo_id_t)),
-						Qt::DirectConnection );
+	connect(model, &AutomatableModel::destroyed,
+		this, &AutomationClip::connectedModelDestroyed,
+		Qt::DirectConnection);
 
 	emit dataChanged();
 
 	return true;
+}
+
+
+
+
+void AutomationClip::removeConnection(const AutomatableModel* model)
+{
+	std::erase(m_connections, model);
 }
 
 
@@ -149,25 +157,25 @@ void AutomationClip::setTension( QString _new_tension )
 
 
 
-const AutomatableModel * AutomationClip::firstObject() const
+const AutomatableModel& AutomationClip::connectedModel() const
 {
 	QMutexLocker m(&m_clipMutex);
 
 	AutomatableModel* model;
-	if (!m_objects.empty() && (model = m_objects.front().model()) != nullptr)
+	if (!m_connections.empty() && (model = m_connections.front().model()) != nullptr)
 	{
-		return model;
+		return *model;
 	}
 
 	static FloatModel fm(0, DEFAULT_MIN_VALUE, DEFAULT_MAX_VALUE, 0.001f);
-	return &fm;
+	return fm;
 }
 
 const AutomationClip::Connections& AutomationClip::connections() const
 {
 	QMutexLocker m(&m_clipMutex);
 
-	return m_objects;
+	return m_connections;
 }
 
 
@@ -232,7 +240,7 @@ TimePos AutomationClip::putValue(
 {
 	QMutexLocker m(&m_clipMutex);
 
-	cleanObjects();
+	cleanConnections();
 
 	TimePos newTime = quantPos ? Note::quantized(time, quantization()) : time;
 	newTime = std::max(TimePos(0), newTime);
@@ -288,7 +296,7 @@ TimePos AutomationClip::putValues(
 {
 	QMutexLocker m(&m_clipMutex);
 
-	cleanObjects();
+	cleanConnections();
 
 	TimePos newTime = quantPos ? Note::quantized(time, quantization()) : time;
 	newTime = std::max(TimePos(0), newTime);
@@ -328,7 +336,7 @@ void AutomationClip::removeNode(const TimePos & time)
 {
 	QMutexLocker m(&m_clipMutex);
 
-	cleanObjects();
+	cleanConnections();
 
 	m_timeMap.remove( time );
 	timeMap::iterator it = m_timeMap.lowerBound(time);
@@ -770,11 +778,9 @@ void AutomationClip::flipX(int start, int end)
 		tempMap[end] = AutomationNode(this, valueAt(start), valueAt(end), end);
 	}
 
-	m_timeMap.clear();
+	m_timeMap = std::move(tempMap);
 
-	m_timeMap = tempMap;
-
-	cleanObjects();
+	cleanConnections();
 
 	generateTangents();
 	emit dataChanged();
@@ -814,12 +820,12 @@ void AutomationClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		_this.appendChild( element );
 	}
 
-	for (const auto& object : m_objects)
+	for (const auto& connection : m_connections)
 	{
-		if (object)
+		if (connection)
 		{
 			QDomElement element = _doc.createElement( "object" );
-			element.setAttribute("id", ProjectJournal::idToSave(object.model()->id()));
+			element.setAttribute("id", ProjectJournal::idToSave(connection.model()->id()));
 			_this.appendChild(element);
 		}
 	}
@@ -916,9 +922,9 @@ QString AutomationClip::name() const
 	{
 		return Clip::name();
 	}
-	if (!m_objects.empty() && m_objects.front().model() != nullptr)
+	if (!m_connections.empty() && m_connections.front().model() != nullptr)
 	{
-		return m_objects.front().model()->fullDisplayName();
+		return m_connections.front().model()->fullDisplayName();
 	}
 	return tr( "Drag a control while pressing <%1>" ).arg(UI_COPY_KEY);
 }
@@ -945,15 +951,15 @@ AutomationClip * AutomationClip::globalAutomationClip(
 		auto a = dynamic_cast<AutomationClip*>(clip);
 		if( a )
 		{
-			for (const auto& object : a->m_objects)
+			for (const auto& connection : a->m_connections)
 			{
-				if (object == _m) { return a; }
+				if (connection == _m) { return a; }
 			}
 		}
 	}
 
 	auto a = new AutomationClip(t);
-	a->addObject( _m, false );
+	a->addConnection(_m, false);
 	return a;
 }
 
@@ -977,7 +983,7 @@ void AutomationClip::resolveAllIDs()
 						JournallingObject* o = Engine::projectJournal()->journallingObject(id);
 						if( o && dynamic_cast<AutomatableModel *>( o ) )
 						{
-							a->addObject( dynamic_cast<AutomatableModel *>( o ), false );
+							a->addConnection(dynamic_cast<AutomatableModel*>(o), false);
 						}
 						else
 						{
@@ -986,7 +992,7 @@ void AutomationClip::resolveAllIDs()
 							o = Engine::projectJournal()->journallingObject(ProjectJournal::idFromSave(id));
 							if( o && dynamic_cast<AutomatableModel *>( o ) )
 							{
-								a->addObject( dynamic_cast<AutomatableModel *>( o ), false );
+								a->addConnection(dynamic_cast<AutomatableModel*>(o), false);
 							}
 							else
 							{
@@ -995,7 +1001,7 @@ void AutomationClip::resolveAllIDs()
 								o = Engine::projectJournal()->journallingObject(ProjectJournal::idToSave(id));
 								if( o && dynamic_cast<AutomatableModel *>( o ) )
 								{
-									a->addObject( dynamic_cast<AutomatableModel *>( o ), false );
+									a->addConnection(dynamic_cast<AutomatableModel*>(o), false);
 								}
 							}
 						}
@@ -1023,7 +1029,7 @@ void AutomationClip::clear()
 
 
 
-void AutomationClip::objectDestroyed( jo_id_t _id )
+void AutomationClip::connectedModelDestroyed(jo_id_t id)
 {
 	QMutexLocker m(&m_clipMutex);
 
@@ -1031,18 +1037,12 @@ void AutomationClip::objectDestroyed( jo_id_t _id )
 	// when switching samplerate) and real deletions because in the latter
 	// case we had to remove ourselves if we're the global automation
 	// clip of the destroyed object
-	m_idsToResolve.push_back(_id);
+	m_idsToResolve.push_back(id);
 
-	for (auto objIt = m_objects.begin(); objIt != m_objects.end(); objIt++)
-	{
-		Q_ASSERT(objIt->model() != nullptr);
-		if (objIt->model()->id() == _id)
-		{
-			//Assign to objIt so that this loop work even break; is removed.
-			objIt = m_objects.erase( objIt );
-			break;
-		}
-	}
+	std::erase_if(m_connections, [id](const AutomatableModel::Connection& conn) {
+		assert(conn.model() != nullptr);
+		return conn.model()->id() == id;
+	});
 
 	emit dataChanged();
 }
@@ -1050,19 +1050,19 @@ void AutomationClip::objectDestroyed( jo_id_t _id )
 
 
 
-void AutomationClip::cleanObjects()
+void AutomationClip::cleanConnections()
 {
 	QMutexLocker m(&m_clipMutex);
 
-	for (auto it = m_objects.begin(); it != m_objects.end(); )
+	for (auto it = m_connections.begin(); it != m_connections.end(); )
 	{
-		if( *it )
+		if (it->model() != nullptr)
 		{
 			++it;
 		}
 		else
 		{
-			it = m_objects.erase( it );
+			it = m_connections.erase(it);
 		}
 	}
 }

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -89,6 +89,7 @@ bool AutomationClip::addObject( AutomatableModel * _obj, bool _search_dup )
 {
 	QMutexLocker m(&m_clipMutex);
 
+	assert(_obj != nullptr);
 	if (_search_dup && std::find(m_objects.begin(), m_objects.end(), _obj) != m_objects.end())
 	{
 		return false;
@@ -101,7 +102,7 @@ bool AutomationClip::addObject( AutomatableModel * _obj, bool _search_dup )
 		putValue( TimePos(0), _obj->inverseScaledValue( _obj->value<float>() ), false );
 	}
 
-	m_objects.push_back(_obj);
+	m_objects.push_back(_obj->createAutomationConnection());
 
 	connect( _obj, SIGNAL(destroyed(lmms::jo_id_t)),
 			this, SLOT(objectDestroyed(lmms::jo_id_t)),
@@ -153,7 +154,7 @@ const AutomatableModel * AutomationClip::firstObject() const
 	QMutexLocker m(&m_clipMutex);
 
 	AutomatableModel* model;
-	if (!m_objects.empty() && (model = m_objects.front()) != nullptr)
+	if (!m_objects.empty() && (model = m_objects.front().model()) != nullptr)
 	{
 		return model;
 	}
@@ -162,7 +163,7 @@ const AutomatableModel * AutomationClip::firstObject() const
 	return &fm;
 }
 
-const AutomationClip::objectVector& AutomationClip::objects() const
+const AutomationClip::Connections& AutomationClip::connections() const
 {
 	QMutexLocker m(&m_clipMutex);
 
@@ -818,7 +819,7 @@ void AutomationClip::saveSettings( QDomDocument & _doc, QDomElement & _this )
 		if (object)
 		{
 			QDomElement element = _doc.createElement( "object" );
-			element.setAttribute("id", ProjectJournal::idToSave(object->id()));
+			element.setAttribute("id", ProjectJournal::idToSave(object.model()->id()));
 			_this.appendChild(element);
 		}
 	}
@@ -915,9 +916,9 @@ QString AutomationClip::name() const
 	{
 		return Clip::name();
 	}
-	if (!m_objects.empty() && m_objects.front() != nullptr)
+	if (!m_objects.empty() && m_objects.front().model() != nullptr)
 	{
-		return m_objects.front()->fullDisplayName();
+		return m_objects.front().model()->fullDisplayName();
 	}
 	return tr( "Drag a control while pressing <%1>" ).arg(UI_COPY_KEY);
 }
@@ -930,36 +931,6 @@ gui::ClipView * AutomationClip::createView( gui::TrackView * _tv )
 	QMutexLocker m(&m_clipMutex);
 
 	return new gui::AutomationClipView( this, _tv );
-}
-
-
-
-
-
-bool AutomationClip::isAutomated( const AutomatableModel * _m )
-{
-	auto l = combineAllTracks();
-	for (const auto track : l)
-	{
-		if (track->type() == Track::Type::Automation || track->type() == Track::Type::HiddenAutomation)
-		{
-			for (const auto& clip : track->getClips())
-			{
-				const auto a = dynamic_cast<const AutomationClip*>(clip);
-				if( a && a->hasAutomation() )
-				{
-					for (const auto& object : a->m_objects)
-					{
-						if (object == _m)
-						{
-							return true;
-						}
-					}
-				}
-			}
-		}
-	}
-	return false;
 }
 
 
@@ -1064,8 +1035,8 @@ void AutomationClip::objectDestroyed( jo_id_t _id )
 
 	for (auto objIt = m_objects.begin(); objIt != m_objects.end(); objIt++)
 	{
-		Q_ASSERT( !(*objIt).isNull() );
-		if( (*objIt)->id() == _id )
+		Q_ASSERT(objIt->model() != nullptr);
+		if (objIt->model()->id() == _id)
 		{
 			//Assign to objIt so that this loop work even break; is removed.
 			objIt = m_objects.erase( objIt );
@@ -1083,7 +1054,7 @@ void AutomationClip::cleanObjects()
 {
 	QMutexLocker m(&m_clipMutex);
 
-	for( objectVector::iterator it = m_objects.begin(); it != m_objects.end(); )
+	for (auto it = m_objects.begin(); it != m_objects.end(); )
 	{
 		if( *it )
 		{

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -396,7 +396,7 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, f_c
 		TimePos relTime = timeStart - p->startPosition();
 		if (p->isRecording() && relTime >= 0 && relTime < p->length())
 		{
-			const AutomatableModel* recordedModel = p->firstObject();
+			const AutomatableModel& recordedModel = p->connectedModel();
 			// The automation system really needs to be reworked.
 			// For whatever reason, the values in an automation clip are stored in un-un-scaled format, so if you
 			// are automating a log knob, when you draw an curve, the values being stored are not the actual values the
@@ -404,9 +404,9 @@ void Song::processAutomations(const TrackList &tracklist, TimePos timeStart, f_c
 			// you can see that the true values are stored by their inverse scaled value....which is wrong, since they weren't scaled in the first place...?
 			// Anyhow, in the meantime before we redo the automation system, when recording automations, we have to get the inverseScaledValue
 			// and store that so that when playing it back, it scales the value correctly.
-			p->recordValue(relTime, recordedModel->inverseScaledValue(recordedModel->value<float>()));
+			p->recordValue(relTime, recordedModel.inverseScaledValue(recordedModel.value<float>()));
 
-			recordedModels << recordedModel;
+			recordedModels << &recordedModel;
 		}
 	}
 

--- a/src/core/TrackContainer.cpp
+++ b/src/core/TrackContainer.cpp
@@ -311,9 +311,9 @@ AutomatedValueMap TrackContainer::automatedValuesFromTracks(const TrackList &tra
 			}
 			float value = p->valueAt(relTime);
 
-			for (AutomatableModel* model : p->objects())
+			for (const auto& connection : p->connections())
 			{
-				valueMap[model] = value;
+				valueMap[connection.model()] = value;
 			}
 		}
 		else if (auto* pattern = dynamic_cast<PatternClip*>(clip))

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -101,18 +101,15 @@ void AutomationClipView::changeName()
 
 
 
-void AutomationClipView::disconnectObject( QAction * _a )
+void AutomationClipView::disconnectModel(QAction* a)
 {
-	JournallingObject * j = Engine::projectJournal()->
-				journallingObject( _a->data().toInt() );
-	if( j && dynamic_cast<AutomatableModel *>( j ) )
+	auto model = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(a->data().toInt()));
+	if (model != nullptr)
 	{
 		float oldMin = m_clip->getMin();
 		float oldMax = m_clip->getMax();
 
-		m_clip->m_objects.erase( std::find( m_clip->m_objects.begin(),
-					m_clip->m_objects.end(),
-				dynamic_cast<AutomatableModel *>( j ) ) );
+		m_clip->removeConnection(model);
 		update();
 
 		//If automation editor is opened, update its display after disconnection
@@ -121,8 +118,8 @@ void AutomationClipView::disconnectObject( QAction * _a )
 			getGUI()->automationEditor()->m_editor->updateAfterClipChange();
 		}
 
-		//if there is no more connection connected to the AutomationClip
-		if( m_clip->m_objects.size() == 0 )
+		//if there are no more models connected to the AutomationClip
+		if (m_clip->connections().empty())
 		{
 			//scale the points to fit the new min. and max. value
 			this->scaleTimemapToFit( oldMin, oldMax );
@@ -199,8 +196,7 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 				m->addAction( a );
 			}
 		}
-		connect( m, SIGNAL(triggered(QAction*)),
-				this, SLOT(disconnectObject(QAction*)));
+		connect(m, &QMenu::triggered, this, &AutomationClipView::disconnectModel);
 		_cm->addMenu( m );
 	}
 }
@@ -268,8 +264,8 @@ void AutomationClipView::paintEvent( QPaintEvent * )
 				/ (float) m_clip->length().getBar() :
 								pixelsPerBar();
 
-	const auto min = m_clip->firstObject()->minValue<float>();
-	const auto max = m_clip->firstObject()->maxValue<float>();
+	const auto min = m_clip->connectedModel().minValue<float>();
+	const auto max = m_clip->connectedModel().maxValue<float>();
 
 	const float y_scale = max - min;
 	const float h = ( height() - 2 * BORDER_WIDTH ) / y_scale;
@@ -431,7 +427,7 @@ void AutomationClipView::dropEvent( QDropEvent * _de )
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if( mod != nullptr )
 		{
-			bool added = m_clip->addObject( mod );
+			bool added = m_clip->addConnection(mod);
 			if ( !added )
 			{
 				TextFloat::displayMessage( mod->displayName(),
@@ -475,8 +471,8 @@ void AutomationClipView::scaleTimemapToFit( float oldMin, float oldMax )
 	// only the inValue is being considered and the outValue is being reset to the inValue (so discrete jumps
 	// are discarded). Possibly later we will want discrete jumps to be maintained so we will need to upgrade
 	// the logic to account for them.
-	for( AutomationClip::timeMap::iterator it = m_clip->m_timeMap.begin();
-		it != m_clip->m_timeMap.end(); ++it )
+	AutomationClip::timeMap& tm = m_clip->getTimeMap();
+	for (auto it = tm.begin(); it != tm.end(); ++it)
 	{
 		// If the values are out of the previous range, fix them so they are
 		// between oldMin and oldMax.

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -186,16 +186,16 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 						tr( "Flip Horizontally (Visible)" ),
 						this, SLOT(flipX()));
 	
-	if (!m_clip->m_objects.empty())
+	if (!m_clip->connections().empty())
 	{
 		_cm->addSeparator();
-		auto m = new QMenu(tr("%1 Connections").arg(m_clip->m_objects.size()), _cm);
-		for (const auto& object : m_clip->m_objects)
+		auto m = new QMenu(tr("%1 Connections").arg(m_clip->connections().size()), _cm);
+		for (const auto& connection : m_clip->connections())
 		{
-			if (object)
+			if (connection)
 			{
-				a = new QAction(tr("Disconnect \"%1\"").arg(object->fullDisplayName()), m);
-				a->setData(object->id());
+				a = new QAction(tr("Disconnect \"%1\"").arg(connection.model()->fullDisplayName()), m);
+				a->setData(connection.model()->id());
 				m->addAction( a );
 			}
 		}

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -218,9 +218,9 @@ void AutomationEditor::updateAfterClipChange()
 		return;
 	}
 
-	m_minLevel = m_clip->firstObject()->minValue<float>();
-	m_maxLevel = m_clip->firstObject()->maxValue<float>();
-	m_step = m_clip->firstObject()->step<float>();
+	m_minLevel = m_clip->connectedModel().minValue<float>();
+	m_maxLevel = m_clip->connectedModel().maxValue<float>();
+	m_step = m_clip->connectedModel().step<float>();
 	centerTopBottomScroll();
 
 	m_tensionModel->setValue( m_clip->getTension() );
@@ -349,8 +349,8 @@ bool AutomationEditor::fineTuneValue(timeMap::iterator node, bool editingOutValu
 		editingOutValue
 			? OUTVAL(node)
 			: INVAL(node),
-		m_clip->firstObject()->minValue<float>(),
-		m_clip->firstObject()->maxValue<float>(),
+		m_clip->connectedModel().minValue<float>(),
+		m_clip->connectedModel().maxValue<float>(),
 		3,
 		&ok
 	);
@@ -933,7 +933,7 @@ inline void AutomationEditor::drawCross( QPainter & p )
 	tt_pos.ry() -= 51;
 	tt_pos.rx() += 26;
 
-	float scaledLevel = m_clip->firstObject()->scaledValue( level );
+	float scaledLevel = m_clip->connectedModel().scaledValue(level);
 
 	// Limit the scaled-level tooltip to the grid
 	if( mouse_pos.x() >= 0 &&
@@ -1068,7 +1068,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		auto level = std::array{m_minLevel, m_maxLevel};
 		for (int i = 0; i < 2; ++i)
 		{
-			const QString& label = m_clip->firstObject()->displayValue(level[i]);
+			const auto label = m_clip->connectedModel().displayValue(level[i]);
 			p.setPen(QApplication::palette().color(QPalette::Active, QPalette::Shadow));
 			p.drawText(1, y[i] - font_height + 1, VALUES_WIDTH - 10, 2 * font_height, text_flags, label);
 			p.setPen(fgColor);
@@ -1087,7 +1087,7 @@ void AutomationEditor::paintEvent(QPaintEvent * pe )
 		}
 		for (; level <= m_topLevel; level += printable)
 		{
-			const QString& label = m_clip->firstObject()->displayValue(level);
+			const auto label = m_clip->connectedModel().displayValue(level);
 			int y = yCoordOfLevel(level);
 			p.setPen(QApplication::palette().color(QPalette::Active, QPalette::Shadow));
 			p.drawText(1, y - font_height + 1, VALUES_WIDTH - 10, 2 * font_height, text_flags, label);
@@ -2223,7 +2223,7 @@ void AutomationEditorWindow::dropEvent( QDropEvent *_de )
 		auto mod = dynamic_cast<AutomatableModel*>(Engine::projectJournal()->journallingObject(val.toInt()));
 		if (mod != nullptr)
 		{
-			bool added = m_editor->m_clip->addObject( mod );
+			bool added = m_editor->m_clip->addConnection(mod);
 			if ( !added )
 			{
 				TextFloat::displayMessage( mod->displayName(),

--- a/src/gui/tracks/AutomationTrackView.cpp
+++ b/src/gui/tracks/AutomationTrackView.cpp
@@ -77,7 +77,7 @@ void AutomationTrackView::dropEvent( QDropEvent * _de )
 
 			Clip * clip = getTrack()->createClip( pos );
 			auto autoClip = dynamic_cast<AutomationClip*>(clip);
-			autoClip->addObject( mod );
+			autoClip->addConnection(mod);
 		}
 	}
 

--- a/tests/src/tracks/AutomationTrackTest.cpp
+++ b/tests/src/tracks/AutomationTrackTest.cpp
@@ -99,17 +99,17 @@ private slots:
 		c1.putValue(0, 0.0, false);
 		c1.putValue(10, 1.0, false);
 		c1.movePosition(0);
-		c1.addObject(&model);
+		c1.addConnection(&model);
 
 		AutomationClip c2(&track);
 		c2.setProgressionType(AutomationClip::ProgressionType::Linear);
 		c2.putValue(0, 0.0, false);
 		c2.putValue(100, 1.0, false);
 		c2.movePosition(100);
-		c2.addObject(&model);
+		c2.addConnection(&model);
 
 		AutomationClip c3(&track);
-		c3.addObject(&model);
+		c3.addConnection(&model);
 		//XXX: Why is this even necessary?
 		c3.clear();
 
@@ -132,7 +132,7 @@ private slots:
 
 		AutomationClip c(&track);
 		c.setProgressionType(AutomationClip::ProgressionType::Linear);
-		c.addObject(&model);
+		c.addConnection(&model);
 
 		c.putValue(0, 0.0, false);
 		c.putValue(100, 1.0, false);
@@ -191,7 +191,7 @@ private slots:
 		c1->setProgressionType(AutomationClip::ProgressionType::Linear);
 		c1->putValue(0, 0.0, false);
 		c1->putValue(10, 1.0, false);
-		c1->addObject(&model);
+		c1->addConnection(&model);
 
 		QCOMPARE(patternStore->automatedValuesAt( 0, patternTrack.patternIndex())[&model], 0.0f);
 		QCOMPARE(patternStore->automatedValuesAt( 5, patternTrack.patternIndex())[&model], 0.5f);
@@ -229,8 +229,8 @@ private slots:
 		FloatModel model;
 		globalClip.setProgressionType(AutomationClip::ProgressionType::Discrete);
 		localClip.setProgressionType(AutomationClip::ProgressionType::Discrete);
-		globalClip.addObject(&model);
-		localClip.addObject(&model);
+		globalClip.addConnection(&model);
+		localClip.addConnection(&model);
 		globalClip.putValue(0, 100.0f, false);
 		localClip.putValue(0, 50.0f, false);
 


### PR DESCRIPTION
Makes a number of changes intended to improve the performance when loading/saving projects:
- Rewrote `AutomatableModel::isAutomated()` implementation, converting it from an O(N^3) algorithm that loops over all tracks, automation clips, and connections within automation clips to a simple O(1) lookup.
  - Using new `AutomatableModel::Connection` nested class which is a ref-counted handle for safely keeping track of connections
- Avoid reconstructing the regex object in every `AutomatableModel::mustQuoteName()` call
  - Also removed the duplicate implementation of this method in Carla
- Converted non-const double lookup in `ProjectJournal::journallingObject()` to a single const lookup
- Removed dead code related to global automation
- Simplified some code by using `AutomatableModel::isAutomatedOrControlled()`

TODO:
- [ ] Measure the performance impact of these changes. Projects with lots of automation clips and lots of `AutomatableModel`s should benefit the most. `AutomatableModel`s come primarily from plugins, so look for plugins with a lot of parameters, especially VST plugins since they call `AutomatableModel::isAutomated()` an extra time for each parameter when saving and loading the project.
- [ ] I tested the ref counting of `AutomatableModel::Connection` when adding/removing automation clips and connections, deleting tracks, cloning tracks, etc. and there were no issues, but we should double check that it doesn't introduce any regressions when loading/saving. 
- [ ] Check that I used the correct memory ordering in `AutomatableModel::Connection`
