### PR TITLE
Refactor integer endian conversions

### DIFF
--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -25,6 +25,8 @@
 #ifndef LMMS_AUDIO_DEVICE_H
 #define LMMS_AUDIO_DEVICE_H
 
+#include <span>
+
 #include <QMutex>
 #include <samplerate.h>
 

--- a/include/AudioDevice.h
+++ b/include/AudioDevice.h
@@ -71,13 +71,19 @@ public:
 	bool isRunning() const { return m_running.test(std::memory_order_acquire); }
 
 protected:
-	// convert a given audio-buffer to a buffer in signed 16-bit samples
-	// returns num of bytes in outbuf
-	int convertToS16(const SampleFrame* _ab, const f_cnt_t _frames, int_sample_t* _output_buffer,
-		const bool _convert_endian = false);
+	//! @brief Converts an interleaved @ref sample_t audio buffer to an interleaved little-endian @ref int_sample_t
+	//! buffer.
+	//!
+	//! @param[in] src The origin audio buffer
+	//! @param[out] dst The destination audio buffer. As there is no @ref int_sample_t equivalent of @ref SampleFrame,
+	//! this span must be exactly twice the length of @p src, as a @ref SampleFrame contains two @ref sample_t.
+	void toInt16le(std::span<const SampleFrame>&& src, std::span<int_sample_t>&& dst);
 
-	// clear given signed-int-16-buffer
-	void clearS16Buffer(int_sample_t* _outbuf, const f_cnt_t _frames);
+	//! @brief Converts a @ref sample_t audio buffer to a @ref int_sample_t buffer.
+	//!
+	//! @param[in] src The origin audio buffer
+	//! @param[out] dst The destination audio buffer.
+	void toInt16(std::span<const sample_t>&& src, std::span<int_sample_t>&& dst);
 
 	ch_cnt_t channels() const { return m_channels; }
 

--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -211,20 +211,7 @@ public:
 		m_masterGain = mo;
 	}
 
-
-	static inline sample_t clip(const sample_t s)
-	{
-		if (s > 1.0f)
-		{
-			return 1.0f;
-		}
-		else if (s < -1.0f)
-		{
-			return -1.0f;
-		}
-		return s;
-	}
-
+	static constexpr sample_t clip(sample_t s) { return std::clamp(s, sample_t{-1}, sample_t{+1}); }
 
 	bool criticalXRuns() const;
 

--- a/include/endian_handling.h
+++ b/include/endian_handling.h
@@ -2,6 +2,7 @@
  * endian_handling.h - handle endianness
  *
  * Copyright (c) 2005-2014 Tobias Doerffel <tobydox/at/users.sourceforge.net>
+ * Copyright (c) 2026 Fawn <rubiefawn@proton.me>
  *
  * This file is part of LMMS - https://lmms.io
  *
@@ -26,33 +27,28 @@
 #define LMMS_ENDIAN_HANDLING_H
 
 #include <cstdint>
-#include <QSysInfo>
-
+#include <bit>
 
 namespace lmms
 {
 
-
-inline bool isLittleEndian()
+constexpr std::int16_t swap16IfBE(std::int16_t i)
 {
-	return( QSysInfo::ByteOrder == QSysInfo::LittleEndian );
+	if constexpr (std::endian::native == std::endian::big)
+	{
+		return (i & 0x00ff) << 8 | (i & 0xff00) >> 8;
+	}
+	else { return i; }
 }
 
-
-inline int16_t swap16IfBE( int16_t i )
+constexpr std::int32_t swap32IfBE(std::int32_t i)
 {
-	return( isLittleEndian() ? i : ( ( i & 0xFF ) << 8) | ( ( i >> 8 ) & 0xFF ) );
+	if constexpr (std::endian::native == std::endian::big)
+	{
+		return (i & 0xff000000) >> 24 | (i & 0x00ff0000) >> 8 | (i & 0x0000ff00) << 8 | (i & 0x000000ff) << 24;
+	}
+	else { return i; }
 }
-
-
-inline int32_t swap32IfBE( int32_t i )
-{
-	return( isLittleEndian() ? i : ( ( i & 0xff000000 ) >> 24 ) |
-					( ( i & 0x00ff0000 ) >> 8 )  |
-					( ( i & 0x0000ff00 ) << 8 )  |
-					( ( i & 0x000000ff ) << 24 ) );
-}
-
 
 } // namespace lmms
 

--- a/src/core/audio/AudioAlsa.cpp
+++ b/src/core/audio/AudioAlsa.cpp
@@ -27,7 +27,6 @@
 
 #ifdef LMMS_HAVE_ALSA
 
-#include "endian_handling.h"
 #include "AudioEngine.h"
 #include "ConfigManager.h"
 

--- a/src/core/audio/AudioDevice.cpp
+++ b/src/core/audio/AudioDevice.cpp
@@ -26,6 +26,7 @@
 
 #include "AudioDevice.h"
 #include "AudioEngine.h"
+#include "endian_handling.h"
 
 namespace lmms
 {
@@ -90,49 +91,46 @@ void AudioDevice::renamePort(AudioBusHandle*)
 {
 }
 
-int AudioDevice::convertToS16(const SampleFrame* _ab,
-								const f_cnt_t _frames,
-								int_sample_t * _output_buffer,
-								const bool _convert_endian )
+
+void AudioDevice::toInt16le(std::span<const SampleFrame>&& src, std::span<int_sample_t>&& dst)
 {
-	if( _convert_endian )
-	{
-		for( f_cnt_t frame = 0; frame < _frames; ++frame )
-		{
-			for( ch_cnt_t chnl = 0; chnl < channels(); ++chnl )
-			{
-				auto temp = static_cast<int_sample_t>(AudioEngine::clip(_ab[frame][chnl]) * OUTPUT_SAMPLE_MULTIPLIER);
+	// FIXME: SampleFrame is hardcoded stereo (DEFAULT_CHANNELS) so this function cannot fully respect
+	// AudioDevice::m_channels.
+	assert(m_channels <= 2);
 
-				( _output_buffer + frame * channels() )[chnl] =
-						( temp & 0x00ff ) << 8 |
-						( temp & 0xff00 ) >> 8;
-			}
+	if (m_channels == 2)
+	{
+		assert(dst.size() == src.size() * 2); // Every SampleFrame corresponds to two int_sample_t
+		for (f_cnt_t frame = 0; frame < src.size(); ++frame)
+		{
+			const sample_t l = AudioEngine::clip(src[frame].left()) * OUTPUT_SAMPLE_MULTIPLIER;
+			const sample_t r = AudioEngine::clip(src[frame].right()) * OUTPUT_SAMPLE_MULTIPLIER;
+			dst[DEFAULT_CHANNELS * frame + 0] = swap16IfBE(static_cast<int_sample_t>(l));
+			dst[DEFAULT_CHANNELS * frame + 1] = swap16IfBE(static_cast<int_sample_t>(r));
 		}
 	}
-	else
+	else if (m_channels == 1) // Mixdown to mono if only one channel
 	{
-		for( f_cnt_t frame = 0; frame < _frames; ++frame )
+		assert(dst.size() == src.size()); // Every SampleFrame corresponds to one int_sample_t
+		for (f_cnt_t frame = 0; m_channels == 1 && frame < src.size(); ++frame)
 		{
-			for( ch_cnt_t chnl = 0; chnl < channels(); ++chnl )
-			{
-				(_output_buffer + frame * channels())[chnl]
-					= static_cast<int_sample_t>(AudioEngine::clip(_ab[frame][chnl]) * OUTPUT_SAMPLE_MULTIPLIER);
-			}
+			const sample_t m = AudioEngine::clip(src[frame].average()) * OUTPUT_SAMPLE_MULTIPLIER;
+			dst[frame] = swap16IfBE(static_cast<int_sample_t>(m));
 		}
 	}
-
-	return _frames * channels() * BYTES_PER_INT_SAMPLE;
 }
 
 
-
-
-void AudioDevice::clearS16Buffer( int_sample_t * _outbuf, const f_cnt_t _frames )
+void AudioDevice::toInt16(std::span<const sample_t>&& src, std::span<int_sample_t>&& dst)
 {
+	assert(dst.size() == src.size());
 
-	assert( _outbuf != nullptr );
-
-	memset( _outbuf, 0,  _frames * channels() * BYTES_PER_INT_SAMPLE );
+	for (f_cnt_t frame = 0; frame < src.size(); ++frame)
+	{
+		dst[DEFAULT_CHANNELS * frame] =
+			static_cast<int_sample_t>(AudioEngine::clip(src[frame]) * OUTPUT_SAMPLE_MULTIPLIER);
+	}
 }
+
 
 } // namespace lmms

--- a/src/core/audio/AudioFileFlac.cpp
+++ b/src/core/audio/AudioFileFlac.cpp
@@ -26,7 +26,6 @@
 #include <cmath>
 
 #include "AudioFileFlac.h"
-#include "endian_handling.h"
 #include "AudioEngine.h"
 
 namespace lmms
@@ -110,7 +109,7 @@ void AudioFileFlac::writeBuffer(const SampleFrame* _ab, f_cnt_t const frames)
 	else // integer PCM encoding
 	{
 		auto buf = std::vector<int_sample_t>(frames * channels());
-		convertToS16(_ab, frames, buf.data(), !isLittleEndian());
+		toInt16le(std::span{_ab, frames}, std::span{buf});
 		sf_writef_short(m_sf, static_cast<short*>(buf.data()), frames);
 	}
 

--- a/src/core/audio/AudioFileWave.cpp
+++ b/src/core/audio/AudioFileWave.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "AudioFileWave.h"
-#include "endian_handling.h"
 #include "AudioEngine.h"
 
 
@@ -112,11 +111,9 @@ void AudioFileWave::writeBuffer(const SampleFrame* _ab, const f_cnt_t _frames)
 	}
 	else
 	{
-		auto buf = new int_sample_t[_frames * channels()];
-		convertToS16(_ab, _frames, buf, !isLittleEndian());
-
-		sf_writef_short( m_sf, buf, _frames );
-		delete[] buf;
+		auto buf = std::vector<int_sample_t>(_frames * channels());
+		toInt16le(std::span{_ab, _frames}, std::span{buf});
+		sf_writef_short(m_sf, static_cast<short*>(buf.data()), _frames);
 	}
 }
 

--- a/src/core/audio/AudioOss.cpp
+++ b/src/core/audio/AudioOss.cpp
@@ -30,7 +30,6 @@
 #include <QFormLayout>
 #include <QLineEdit>
 
-#include "endian_handling.h"
 #include "LcdSpinBox.h"
 #include "AudioEngine.h"
 

--- a/src/core/audio/AudioSndio.cpp
+++ b/src/core/audio/AudioSndio.cpp
@@ -31,7 +31,6 @@
 #include <QFormLayout>
 #include <QLineEdit>
 
-#include "endian_handling.h"
 #include "LcdSpinBox.h"
 #include "AudioEngine.h"
 
@@ -139,12 +138,11 @@ void AudioSndio::run()
 	{
 		audioEngine()->renderNextBuffer({fbuf.data(), channels(), framesPerAudioBuffer});
 
-		// Sndio doesn't speak float, so convert samples to signed int.
-		// While convertToS16() exists, it is intentionally not used
-		// here. There is no need to convert endian-ness since sndio was
-		// initialized with SIO_LE_NATIVE, and there's no reason to
-		// also convert to SampleFrame.
-		for (auto i = 0u; i < samplesPerAudioBuffer; ++i)
+		// Sndio doesn't speak float, so convert samples to signed 16-bit integer.
+		// While AudioDevice::toInt16le() exists, it is intentionally not used here, as there is no need to convert
+		// endian-ness since sndio was initialized with SIO_LE_NATIVE (and there's no reason to also convert to
+		// SampleFrame.)
+		for (f_cnt_t i = 0; i < samplesPerAudioBuffer; ++i)
 		{
 			ibuf[i] = static_cast<int_sample_t>(AudioEngine::clip(fbuf[i]) * OUTPUT_SAMPLE_MULTIPLIER);
 		}


### PR DESCRIPTION
Just cleaning up some stuff that bothered me while working on #8407:

- Refactored `endian_handling.h` so that the utility functions therein check endianness of the target architecture during compile time, rather than during each and every call.
- Removed `#include "endian_handling.h"` from files that no longer use it.
- Refactored `AudioDevice::convertToS16()` to properly handle channel counts other than `DEFAULT_CHANNELS`. I'm not sure how often (if ever) this occurred in reality, but if the channel count for the `AudioDevice` was 1, it would only convert the left channel, and if it was greater than 2, it would carelessly index into the `SampleFrame` out of bounds. Now, it asserts that the channel count is less than or equal to 2, and if the channel count is 1, it downmixes to mono. Also renamed the method to `toInt16le()` since the resulting buffer will always be little-endian.
- Refactored `AudioEngine::clip()` to use `std::clamp()` and be `constexpr`.