### PR TITLE
Fix Default PianoRoll Zoom and Quantization

### DIFF
--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -333,7 +333,7 @@ PianoRoll::PianoRoll() :
 	{
 		m_zoomingYModel.addItem(QString("%1%").arg(zoomLevel * 100));
 	}
-	m_zoomingYModel.setInitValue(ConfigManager::inst()->value("ui", "pianorollzoomvertical", QString::number(m_zoomingModel.findText("100%"))).toInt());
+	m_zoomingYModel.setInitValue(ConfigManager::inst()->value("ui", "pianorollzoomvertical", QString::number(m_zoomingYModel.findText("100%"))).toInt());
 	zoomingYChanged();
 	connect(&m_zoomingYModel, SIGNAL(dataChanged()),
 					this, SLOT(zoomingYChanged()));
@@ -343,7 +343,7 @@ PianoRoll::PianoRoll() :
 	for (auto q : Quantizations) {
 		m_quantizeModel.addItem(QString("1/%1").arg(q));
 	}
-	m_quantizeModel.setInitValue(ConfigManager::inst()->value("ui", "pianorollquantization", QString::number(m_zoomingModel.findText("1/16"))).toInt());
+	m_quantizeModel.setInitValue(ConfigManager::inst()->value("ui", "pianorollquantization", QString::number(m_quantizeModel.findText("1/16"))).toInt());
 
 	connect( &m_quantizeModel, SIGNAL(dataChanged()),
 					this, SLOT(quantizeChanged()));


### PR DESCRIPTION
When #7854 was merged, the line for setting the default zoom of the piano roll was copy-pasted to also set the default vertical zoom and quantization. That way if no previous default had been saved, it would default to 100% horizontal zoom, 100% vertical zoom, and 1/16 quantization (which was the default behavior before the PR).

Unfortunately, the variable in expression it used to find the correct index of "100%" or "1/16" in the list was not correctly updated after copy-pasting, which caused the wrong defaults to be set. For example, in the vertical zoom dropdown, "100%" is index 2, but in the horizontal zoom, it's index 3. This caused the default vertical zoom to be 150%, not 100%. Likewise, since the horizontal zoom list doesn't contain "1/16", the quantization defaulted to index 0, which was "Note Lock".

This PR fixes those issues by correcting the variables names in those two lines.