### PR TITLE
Fix crash when opening Automation Editor after setting ghost notes

### DIFF
--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -33,6 +33,7 @@
 #include "ComboBoxModel.h"
 #include "Editor.h"
 #include "JournallingObject.h"
+#include "MidiClip.h"
 #include "SampleClip.h"
 #include "TimePos.h"
 #include "LmmsTypes.h"
@@ -43,9 +44,6 @@ class QScrollBar;
 
 namespace lmms
 {
-
-class MidiClip;
-
 namespace gui
 {
 
@@ -232,7 +230,7 @@ private:
 	float m_bottomLevel;
 	float m_topLevel;
 
-	MidiClip* m_ghostNotes = nullptr;
+	QPointer<MidiClip> m_ghostNotes = nullptr; // QPointer to set to nullptr on deletion
 	QPointer<SampleClip> m_ghostSample = nullptr; // QPointer to set to nullptr on deletion
 	bool m_renderSample = false;
 

--- a/include/AutomationEditor.h
+++ b/include/AutomationEditor.h
@@ -230,8 +230,9 @@ private:
 	float m_bottomLevel;
 	float m_topLevel;
 
-	QPointer<MidiClip> m_ghostNotes = nullptr; // QPointer to set to nullptr on deletion
-	QPointer<SampleClip> m_ghostSample = nullptr; // QPointer to set to nullptr on deletion
+	// QPointers to set to nullptr on deletion
+	QPointer<MidiClip> m_ghostNotes = nullptr; 
+	QPointer<SampleClip> m_ghostSample = nullptr;
 	bool m_renderSample = false;
 
 	void centerTopBottomScroll();


### PR DESCRIPTION
Fixes a crash when opening the Automation Editor with invalid ghost notes (or more specifically, when the editor draws the ghost notes). Setting ghost notes in the Automation Editor with a MIDI clip (but not a sample clip) sets a pointer to it, but deleting the clip or loading a new project makes the pointer invalid without setting to a null pointer.