### PR TITLE
Override autoscroll when manually scrolling

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -129,6 +129,7 @@ public:
 	inline void stopRecording()
 	{
 		m_recording = false;
+		m_autoscrollSuspended = false;
 	}
 
 	inline bool isRecording() const
@@ -388,6 +389,7 @@ private:
 
 	QScrollBar * m_leftRightScroll;
 	QScrollBar * m_topBottomScroll;
+	bool m_autoscrollSuspended = false;
 
 	void adjustLeftRightScoll(int value);
 

--- a/include/Song.h
+++ b/include/Song.h
@@ -185,7 +185,7 @@ public:
 			m_loopRenderCount = count;
 		m_loopRenderRemaining = m_loopRenderCount;
 	}
-    
+
 	inline int getLoopRenderCount() const
 	{
 		return m_loopRenderCount;

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -129,6 +129,7 @@ private:
 	Song * m_song;
 
 	QScrollBar * m_leftRightScroll;
+	bool m_autoscrollSuspended = false;
 
 	void adjustLeftRightScoll(int value);
 

--- a/include/SongEditor.h
+++ b/include/SongEditor.h
@@ -202,7 +202,6 @@ protected slots:
 	void updateSnapLabel();
 
 signals:
-	void playTriggered();
 	void resized();
 
 private:

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -653,7 +653,7 @@ void Song::stop()
 
 	auto& timeline = getTimeline();
 	m_paused = false;
-	m_recording = true;
+	m_recording = false;
 	m_playing = false;
 
 	switch (timeline.stopBehaviour())

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -135,8 +135,8 @@ AutomationEditor::AutomationEditor() :
 	// init scrollbars
 	m_leftRightScroll = new QScrollBar( Qt::Horizontal, this );
 	m_leftRightScroll->setSingleStep( 1 );
-	connect( m_leftRightScroll, SIGNAL(valueChanged(int)), this,
-						SLOT(horScrolled(int)));
+	connect(m_leftRightScroll, &QScrollBar::valueChanged, this, &AutomationEditor::horScrolled);
+	connect(m_leftRightScroll, &QScrollBar::sliderReleased, this, &AutomationEditor::updatePosition);
 
 	m_topBottomScroll = new QScrollBar( Qt::Vertical, this );
 	m_topBottomScroll->setSingleStep( 1 );
@@ -1785,10 +1785,9 @@ void AutomationEditor::setTension()
 void AutomationEditor::updatePosition()
 {
 	const TimePos& t = m_timeLine->timeline()->pos();
-	if( ( Engine::getSong()->isPlaying() &&
-			Engine::getSong()->playMode() ==
-					Song::PlayMode::AutomationClip ) ||
-							m_scrollBack == true )
+	if (((Engine::getSong()->isPlaying()
+		&& Engine::getSong()->playMode() == Song::PlayMode::AutomationClip) || m_scrollBack)
+		&& !m_leftRightScroll->isSliderDown()) // Manual scrolling overrides autoscroll
 	{
 		const int w = width() - VALUES_WIDTH;
 		if( t > m_currentPosition + w * TimePos::ticksPerBar() / m_ppb )

--- a/src/gui/editors/AutomationEditor.cpp
+++ b/src/gui/editors/AutomationEditor.cpp
@@ -1692,10 +1692,10 @@ void AutomationEditor::play()
 
 void AutomationEditor::stop()
 {
-	if( !validClip() )
-	{
-		return;
-	}
+	if (!validClip()) { return; }
+
+	m_scrollBack = true;
+
 	if (m_clip->getTrack() && inPatternEditor())
 	{
 		Engine::patternStore()->stop();
@@ -1704,7 +1704,6 @@ void AutomationEditor::stop()
 	{
 		Engine::getSong()->stop();
 	}
-	m_scrollBack = true;
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -309,8 +309,8 @@ PianoRoll::PianoRoll() :
 	// init scrollbars
 	m_leftRightScroll = new QScrollBar( Qt::Horizontal, this );
 	m_leftRightScroll->setSingleStep( 1 );
-	connect( m_leftRightScroll, SIGNAL(valueChanged(int)), this,
-						SLOT(horScrolled(int)));
+	connect(m_leftRightScroll, &QScrollBar::valueChanged, this, &PianoRoll::horScrolled);
+	connect(m_leftRightScroll, &QScrollBar::sliderReleased, this, &PianoRoll::updatePosition);
 
 	m_topBottomScroll = new QScrollBar( Qt::Vertical, this );
 	m_topBottomScroll->setSingleStep( 1 );
@@ -4838,8 +4838,11 @@ bool PianoRoll::deleteSelectedNotes()
 
 void PianoRoll::autoScroll( const TimePos & t )
 {
+	// Manual scrolling overrides autoscroll
+	if (m_leftRightScroll->isSliderDown()) { return; }
+
 	const int w = width() - m_whiteKeyWidth;
-	if (m_timeLine->autoScroll() == TimeLineWidget::AutoScrollState::Stepped) 
+	if (m_timeLine->autoScroll() == TimeLineWidget::AutoScrollState::Stepped)
 	{
 		if (t > m_currentPosition + w * TimePos::ticksPerBar() / m_ppb)
 		{

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -444,11 +444,6 @@ PianoRoll::PianoRoll() :
 
 	// trigger a redraw if keymap definitions change (different keys may become disabled)
 	connect(Engine::getSong(), SIGNAL(keymapListChanged(int)), this, SLOT(update()));
-
-	// Unsuspend autoscroll when timeline jumps
-	connect(&Engine::getSong()->getTimeline(Song::PlayMode::MidiClip), &Timeline::positionJumped, this, [this]() {
-		m_autoscrollSuspended = false;
-	});
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -444,6 +444,11 @@ PianoRoll::PianoRoll() :
 
 	// trigger a redraw if keymap definitions change (different keys may become disabled)
 	connect(Engine::getSong(), SIGNAL(keymapListChanged(int)), this, SLOT(update()));
+
+	// Unsuspend autoscroll when timeline jumps
+	connect(&Engine::getSong()->getTimeline(Song::PlayMode::MidiClip), &Timeline::positionJumped, this, [this]() {
+		m_autoscrollSuspended = false;
+	});
 }
 
 
@@ -459,6 +464,7 @@ PianoRoll::~PianoRoll()
 
 void PianoRoll::reset()
 {
+	m_autoscrollSuspended = false;
 	m_lastNoteVolume = DefaultVolume;
 	m_lastNotePanning = DefaultPanning;
 	clearGhostClip();
@@ -1425,6 +1431,7 @@ void PianoRoll::keyPressEvent(QKeyEvent* ke)
 				else
 				{
 					// scroll
+					m_autoscrollSuspended = true;
 					m_leftRightScroll->setValue( m_leftRightScroll->value() +
 						direction * cm_scrollAmtHoriz );
 
@@ -4055,6 +4062,7 @@ void PianoRoll::resizeEvent(QResizeEvent* re)
 
 void PianoRoll::adjustLeftRightScoll(int value)
 {
+	m_autoscrollSuspended = true;
 	m_leftRightScroll->setValue(m_leftRightScroll->value() -
 							value * 0.3f / m_zoomLevels[m_zoomingModel.value()]);
 }
@@ -4185,6 +4193,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 	}
 	else if( we->modifiers() & Qt::ControlModifier )
 	{
+		m_autoscrollSuspended = true;
 		int z = m_zoomingModel.value();
 		if(we->angleDelta().y() > 0)
 		{
@@ -4317,6 +4326,8 @@ Song::PlayMode PianoRoll::desiredPlayModeForAccompany() const
 
 void PianoRoll::play()
 {
+	m_autoscrollSuspended = false;
+
 	if( ! hasValidMidiClip() )
 	{
 		return;
@@ -4360,6 +4371,8 @@ void PianoRoll::record()
 
 void PianoRoll::recordAccompany()
 {
+	m_autoscrollSuspended = false;
+
 	if( Engine::getSong()->isPlaying() )
 	{
 		stop();
@@ -4422,6 +4435,7 @@ bool PianoRoll::toggleStepRecording()
 void PianoRoll::stop()
 {
 	m_scrollBack = true;
+	m_autoscrollSuspended = false;
 
 	Engine::getSong()->stop();
 	m_recording = false;
@@ -4840,7 +4854,7 @@ bool PianoRoll::deleteSelectedNotes()
 void PianoRoll::autoScroll( const TimePos & t )
 {
 	// Manual scrolling overrides autoscroll
-	if (m_leftRightScroll->isSliderDown()) { return; }
+	if (m_leftRightScroll->isSliderDown() || m_autoscrollSuspended) { return; }
 
 	const int w = width() - m_whiteKeyWidth;
 	if (m_timeLine->autoScroll() == TimeLineWidget::AutoScrollState::Stepped)

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -4421,9 +4421,10 @@ bool PianoRoll::toggleStepRecording()
 
 void PianoRoll::stop()
 {
+	m_scrollBack = true;
+
 	Engine::getSong()->stop();
 	m_recording = false;
-	m_scrollBack = m_timeLine->autoScroll() != TimeLineWidget::AutoScrollState::Disabled;
 
 	auto* songEditor = GuiApplication::instance()->songEditor()->m_editor;
 

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -235,11 +235,11 @@ SongEditor::SongEditor( Song * song ) :
 	m_leftRightScroll->setSingleStep(1);
 	m_leftRightScroll->setPageStep(20 * TimePos::ticksPerBar());
 	static_cast<QVBoxLayout *>( layout() )->addWidget( m_leftRightScroll );
-	connect( m_leftRightScroll, SIGNAL(valueChanged(int)),
-					this, SLOT(scrolled(int)));
-	connect( m_song, SIGNAL(lengthChanged(int)),
-			this, SLOT(updateScrollBar(int)));
-	connect(m_leftRightScroll, SIGNAL(valueChanged(int)),this, SLOT(updateRubberband()));
+	connect(m_leftRightScroll, &QScrollBar::valueChanged, this, &SongEditor::scrolled);
+	connect(m_leftRightScroll, &QScrollBar::valueChanged, this, &SongEditor::updateRubberband);
+	connect(m_leftRightScroll, &QScrollBar::sliderReleased, this, &SongEditor::updatePosition);
+	connect(m_song, &Song::lengthChanged, this, &SongEditor::updateScrollBar);
+
 	connect(contentWidget()->verticalScrollBar(), SIGNAL(valueChanged(int)),this, SLOT(updateRubberband()));
 	connect(m_timeLine, SIGNAL(selectionFinished()), this, SLOT(stopSelectRegion()));
 
@@ -762,8 +762,8 @@ void SongEditor::updatePosition()
 	const auto widgetWidth = compactTrackButtons ? DEFAULT_SETTINGS_WIDGET_WIDTH_COMPACT : DEFAULT_SETTINGS_WIDGET_WIDTH;
 	const auto trackOpWidth = compactTrackButtons ? TRACK_OP_WIDTH_COMPACT : TRACK_OP_WIDTH;
 
-	if ((m_song->isPlaying() && m_song->m_playMode == Song::PlayMode::Song)
-							|| m_scrollBack)
+	if (((m_song->isPlaying() && m_song->m_playMode == Song::PlayMode::Song) || m_scrollBack)
+		&& !m_leftRightScroll->isSliderDown()) // Manual scrolling overrides autoscroll
 	{
 		m_smoothScroll = ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt();
 		const int w = width() - widgetWidth

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -1036,11 +1036,6 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	connect(song, SIGNAL(projectLoaded()), this, SLOT(adjustUiAfterProjectLoad()));
 	connect(this, SIGNAL(resized()), m_editor, SLOT(updatePositionLine()));
-
-	// Unsuspend autoscroll when timeline jumps
-	connect(&Engine::getSong()->getTimeline(Song::PlayMode::Song), &Timeline::positionJumped, this, [this]() {
-		m_editor->m_autoscrollSuspended = false;
-	});
 }
 
 QSize SongEditorWindow::sizeHint() const
@@ -1091,7 +1086,6 @@ void SongEditorWindow::play()
 {
 	m_editor->m_autoscrollSuspended = false;
 
-	emit playTriggered();
 	if( Engine::getSong()->playMode() != Song::PlayMode::Song )
 	{
 		Engine::getSong()->playSong();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -1116,6 +1116,7 @@ void SongEditorWindow::recordAccompany()
 
 void SongEditorWindow::stop()
 {
+	m_editor->m_scrollBack = true;
 	m_editor->m_song->stop();
 	getGUI()->pianoRoll()->stopRecording();
 	m_editor->m_timeLine->setRecording(false);

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -531,6 +531,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ke )
 
 void SongEditor::adjustLeftRightScoll(int value)
 {
+	m_autoscrollSuspended = true;
 	m_leftRightScroll->setValue(m_leftRightScroll->value()
 						- value * DEFAULT_PIXELS_PER_BAR / pixelsPerBar());
 }
@@ -552,6 +553,7 @@ void SongEditor::wheelEvent( QWheelEvent * we )
 		m_zoomingModel->incValue(step * direction);
 
 		// scroll to zooming around cursor's tick
+		m_autoscrollSuspended = true;
 		int newTick = static_cast<int>(x / pixelsPerBar() * TimePos::ticksPerBar());
 		m_leftRightScroll->setValue(m_leftRightScroll->value() + tick - newTick);
 
@@ -763,7 +765,7 @@ void SongEditor::updatePosition()
 	const auto trackOpWidth = compactTrackButtons ? TRACK_OP_WIDTH_COMPACT : TRACK_OP_WIDTH;
 
 	if (((m_song->isPlaying() && m_song->m_playMode == Song::PlayMode::Song) || m_scrollBack)
-		&& !m_leftRightScroll->isSliderDown()) // Manual scrolling overrides autoscroll
+		&& !m_leftRightScroll->isSliderDown() && !m_autoscrollSuspended) // Manual scrolling overrides autoscroll
 	{
 		m_smoothScroll = ConfigManager::inst()->value( "ui", "smoothscroll" ).toInt();
 		const int w = width() - widgetWidth
@@ -1034,6 +1036,11 @@ SongEditorWindow::SongEditorWindow(Song* song) :
 
 	connect(song, SIGNAL(projectLoaded()), this, SLOT(adjustUiAfterProjectLoad()));
 	connect(this, SIGNAL(resized()), m_editor, SLOT(updatePositionLine()));
+
+	// Unsuspend autoscroll when timeline jumps
+	connect(&Engine::getSong()->getTimeline(Song::PlayMode::Song), &Timeline::positionJumped, this, [this]() {
+		m_editor->m_autoscrollSuspended = false;
+	});
 }
 
 QSize SongEditorWindow::sizeHint() const
@@ -1082,6 +1089,8 @@ void SongEditorWindow::changeEvent(QEvent *event)
 
 void SongEditorWindow::play()
 {
+	m_editor->m_autoscrollSuspended = false;
+
 	emit playTriggered();
 	if( Engine::getSong()->playMode() != Song::PlayMode::Song )
 	{
@@ -1106,6 +1115,7 @@ void SongEditorWindow::record()
 
 void SongEditorWindow::recordAccompany()
 {
+	m_editor->m_autoscrollSuspended = false;
 	m_editor->m_song->playAndRecord();
 	m_editor->m_timeLine->setRecording(true);
 	m_editor->m_positionLine->setRecording(true);
@@ -1116,6 +1126,7 @@ void SongEditorWindow::recordAccompany()
 
 void SongEditorWindow::stop()
 {
+	m_editor->m_autoscrollSuspended = false;
 	m_editor->m_scrollBack = true;
 	m_editor->m_song->stop();
 	getGUI()->pianoRoll()->stopRecording();


### PR DESCRIPTION
Overrides autoscroll while the user is manually adjusting the horizontal scrollbar in the Song Editor, Piano Roll, or Automation Editor in order to prevent an annoying UI bug where autoscroll fights with the user to set the viewport position.

Fixes #2236
