### PR TITLE
Fix hang when Ctrl+dragging multiple clips (#8443)

### DIFF
--- a/include/Clip.h
+++ b/include/Clip.h
@@ -144,6 +144,10 @@ public:
 	// Will copy the state of a clip to another clip
 	static void copyStateTo( Clip *src, Clip *dst );
 
+	// Directly copies this clip's data to another clip without XML serialization.
+	// Returns false if unsupported, in which case the caller falls back to XML.
+	virtual bool copyDataTo( Clip* dst ) const { return false; }
+
 	/**
 	* Creates a copy of this clip
 	* @return pointer to the new clip object
@@ -179,7 +183,7 @@ private:
 
 	std::optional<QColor> m_color;
 
-	friend class ClipView;
+		friend class gui::ClipView;
 
 } ;
 

--- a/include/Clip.h
+++ b/include/Clip.h
@@ -183,7 +183,7 @@ private:
 
 	std::optional<QColor> m_color;
 
-		friend class gui::ClipView;
+	friend class gui::ClipView;
 
 } ;
 

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -25,7 +25,9 @@
 #ifndef LMMS_GUI_CLIP_VIEW_H
 #define LMMS_GUI_CLIP_VIEW_H
 
+#include <memory>
 #include <optional>
+#include <vector>
 
 #include <QVector>
 
@@ -177,6 +179,23 @@ protected:
 
 	DataFile createClipDataFiles(const QVector<ClipView *> & clips) const;
 
+public:
+	struct InternalClipData
+	{
+		std::unique_ptr<Clip> clone;
+		int trackIndex;
+		int trackType;
+	};
+
+	static const char* INTERNAL_COPY_KEY;
+
+	static QString storeInternalCopy(std::vector<InternalClipData>&& clips,
+		TimePos grabbedClipPos, int initialTrackIndex, unsigned int trackContainerId);
+	static bool retrieveInternalCopy(const QString& token,
+		std::vector<InternalClipData>& out, TimePos& outGrabbedClipPos,
+		int& outInitialTrackIndex, unsigned int& outTrackContainerId);
+	static void clearInternalCopy(const QString& token);
+
 	virtual void paintTextLabel(QString const & text, QPainter & painter);
 
 	auto hasCustomColor() const -> bool;
@@ -234,6 +253,15 @@ private:
 	TimePos draggedClipPos( QMouseEvent * me );
 	int knifeMarkerPos( QMouseEvent * me );
 	void setColor(const std::optional<QColor>& color);
+
+	std::vector<InternalClipData> cloneClipsForInternalCopy(
+		const QVector<ClipView*>& clipViews,
+		const std::vector<Track*>& tracks) const;
+
+	static QString buildInternalCopyMimeValue(const QString& token,
+		TimePos grabbedClipPos, int initialTrackIndex,
+		unsigned int tcId, const QVector<ClipView*>& clipViews,
+		const std::vector<Track*>& tracks);
 
 	/**
 	 * @returns the width of a note's resize area in pixels.

--- a/include/ClipView.h
+++ b/include/ClipView.h
@@ -177,8 +177,6 @@ protected:
 	float pixelsPerBar() const;
 
 
-	DataFile createClipDataFiles(const QVector<ClipView *> & clips) const;
-
 public:
 	struct InternalClipData
 	{
@@ -188,6 +186,8 @@ public:
 	};
 
 	static const char* INTERNAL_COPY_KEY;
+
+	DataFile createClipDataFiles(const QVector<ClipView *> & clips) const;
 
 	static QString storeInternalCopy(std::vector<InternalClipData>&& clips,
 		TimePos grabbedClipPos, int initialTrackIndex, unsigned int trackContainerId);

--- a/include/MidiClip.h
+++ b/include/MidiClip.h
@@ -122,6 +122,8 @@ public:
 		return new MidiClip(*this);
 	}
 
+	bool copyDataTo(Clip* dst) const override;
+
 
 	using Model::dataChanged;
 

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -156,6 +156,11 @@ private:
 	Track * getTrack();
 	TimePos getPosition( int mouseX );
 
+	bool canPasteInternalCopy(const QStringList& valueParts, TimePos clipPos,
+		Track* t, bool allowSameBar) const;
+	bool pasteInternalCopy(const QStringList& valueParts, TimePos clipPos,
+		Track* t, bool& wasSelection);
+
 	TrackView * m_trackView;
 
 	using clipViewVector = QVector<ClipView*>;

--- a/include/TrackContentWidget.h
+++ b/include/TrackContentWidget.h
@@ -160,6 +160,7 @@ private:
 		Track* t, bool allowSameBar) const;
 	bool pasteInternalCopy(const QStringList& valueParts, TimePos clipPos,
 		Track* t, bool& wasSelection);
+	bool pasteXmlSelection(TimePos clipPos, const QMimeData* md);
 
 	TrackView * m_trackView;
 

--- a/src/core/Clip.cpp
+++ b/src/core/Clip.cpp
@@ -159,17 +159,31 @@ bool Clip::comparePosition(const Clip *a, const Clip *b)
  */
 void Clip::copyStateTo( Clip *src, Clip *dst )
 {
-	// If the node names match we copy the state
-	if( src->nodeName() == dst->nodeName() ){
-		QDomDocument doc;
-		QDomElement parent = doc.createElement( "StateCopy" );
-		src->saveState( doc, parent );
+	if( src->nodeName() != dst->nodeName() ) { return; }
 
-		const TimePos pos = dst->startPosition();
-		dst->restoreState( parent.firstChild().toElement() );
-		dst->movePosition( pos );
+	const TimePos pos = dst->startPosition();
 
+	if (src->copyDataTo(dst))
+	{
+		dst->movePosition(pos);
 		AutomationClip::resolveAllIDs();
+		if (gui::getGUI() != nullptr)
+		{
+			gui::getGUI()->automationEditor()->m_editor->updateAfterClipChange();
+		}
+		return;
+	}
+
+	QDomDocument doc;
+	QDomElement parent = doc.createElement("StateCopy");
+	src->saveState(doc, parent);
+
+	dst->restoreState(parent.firstChild().toElement());
+	dst->movePosition(pos);
+
+	AutomationClip::resolveAllIDs();
+	if (gui::getGUI() != nullptr)
+	{
 		gui::getGUI()->automationEditor()->m_editor->updateAfterClipChange();
 	}
 }

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -28,7 +28,9 @@
 #include <set>
 #include <cassert>
 
+#include <QDrag>
 #include <QMenu>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QUuid>
@@ -69,6 +71,66 @@ struct InternalCopyData
 };
 
 std::map<QString, InternalCopyData> s_clipBuffer;
+
+
+// LazyMimeData lazily generates the XML payload on first read. Same-instance
+// receivers use the StringPair path and never trigger XML serialization.
+// Cross-instance receivers will invoke retrieveData() which generates XML
+// on-demand via createClipDataFiles().
+class LazyMimeData : public QMimeData
+{
+public:
+	LazyMimeData(const ClipView& cv, const QVector<ClipView*>& clipViews,
+		const QString& internalValue)
+		: m_cv(cv)
+		, m_clipViews(clipViews)
+	{
+		using namespace Clipboard;
+		setData(mimeType(MimeType::StringPair),
+			(QString(ClipView::INTERNAL_COPY_KEY) + ":"
+			 + internalValue).toUtf8());
+	}
+
+	bool hasFormat(const QString& mimeType) const override
+	{
+		using namespace Clipboard;
+		if (mimeType == Clipboard::mimeType(MimeType::Default))
+		{
+			return true;
+		}
+		return QMimeData::hasFormat(mimeType);
+	}
+
+	QStringList formats() const override
+	{
+		using namespace Clipboard;
+		QStringList fmts = QMimeData::formats();
+		fmts.append(Clipboard::mimeType(MimeType::Default));
+		return fmts;
+	}
+
+	QVariant retrieveData(const QString& mimeType,
+		QVariant::Type type) const override
+	{
+		using namespace Clipboard;
+		if (mimeType == Clipboard::mimeType(MimeType::Default))
+		{
+			if (m_xmlCache.isEmpty())
+			{
+				DataFile dataFile =
+					m_cv.createClipDataFiles(m_clipViews);
+				m_xmlCache = dataFile.toString().toUtf8();
+			}
+			return QVariant(m_xmlCache);
+		}
+		return QMimeData::retrieveData(mimeType, type);
+	}
+
+private:
+	const ClipView& m_cv;
+	QVector<ClipView*> m_clipViews;
+	mutable QByteArray m_xmlCache;
+};
 
 } // anonymous namespace
 
@@ -503,7 +565,6 @@ void ClipView::dropEvent( QDropEvent * de )
 	QString type = StringPairDrag::decodeKey( de );
 	QString value = StringPairDrag::decodeValue( de );
 
-	// Track must be the same type to paste into, unless internal copy
 	if( type != ( "clip_" + QString::number( static_cast<int>(m_clip->getTrack()->type()) ) )
 		&& type != INTERNAL_COPY_KEY )
 	{
@@ -542,18 +603,37 @@ void ClipView::dropEvent( QDropEvent * de )
 		int initialTrackIndex;
 		unsigned int trackContainerId;
 
-		if (!retrieveInternalCopy(token, clips,
-				grabbedClipPos, initialTrackIndex, trackContainerId))
+		if (retrieveInternalCopy(token, clips,
+				grabbedClipPos, initialTrackIndex, trackContainerId)
+			&& !clips.empty())
 		{
+			TimePos pos = m_clip->startPosition();
+			clips[0].clone->copyDataTo(m_clip);
+			m_clip->movePosition(pos);
+			AutomationClip::resolveAllIDs();
+			de->accept();
 			return;
 		}
-		if (clips.empty()) { return; }
 
-		TimePos pos = m_clip->startPosition();
-		clips[0].clone->copyDataTo(m_clip);
-		m_clip->movePosition(pos);
-		AutomationClip::resolveAllIDs();
-		de->accept();
+		// Token not found (cross-instance): try XML from Default MIME
+		QByteArray xml = de->mimeData()->data(
+			Clipboard::mimeType(Clipboard::MimeType::Default));
+		if (!xml.isEmpty())
+		{
+			DataFile dataFile(xml);
+			QDomElement clipParent = dataFile.content()
+				.firstChildElement("clips");
+			QDomElement clipElement = clipParent
+				.firstChildElement().firstChildElement();
+			if (clipElement.nodeName() == m_clip->nodeName())
+			{
+				TimePos pos = m_clip->startPosition();
+				m_clip->restoreState(clipElement);
+				m_clip->movePosition(pos);
+				AutomationClip::resolveAllIDs();
+				de->accept();
+			}
+		}
 		return;
 	}
 
@@ -659,6 +739,15 @@ std::vector<ClipView::InternalClipData> ClipView::cloneClipsForInternalCopy(
 {
 	std::vector<InternalClipData> clipData;
 
+	struct TrackGuard
+	{
+		Clip* clip;
+		Track* saved;
+		TrackGuard(Clip* c) : clip(c), saved(c->m_track)
+		{ clip->m_track = nullptr; }
+		~TrackGuard() { clip->m_track = saved; }
+	};
+
 	for (const auto& cv : clipViews)
 	{
 		Track* clipTrack = cv->m_trackView->getTrack();
@@ -666,17 +755,13 @@ std::vector<ClipView::InternalClipData> ClipView::cloneClipsForInternalCopy(
 		assert(trackIt != tracks.end());
 		int trackIdx = std::distance(tracks.begin(), trackIt);
 
-		auto* srcClip = cv->m_clip;
-		Track* savedTrack = srcClip->m_track;
-		srcClip->m_track = nullptr;
+		TrackGuard guard(cv->m_clip);
 
 		InternalClipData cd;
-		cd.clone.reset(srcClip->clone());
+		cd.clone.reset(cv->m_clip->clone());
 		cd.trackIndex = trackIdx;
 		cd.trackType = static_cast<int>(clipTrack->type());
 		clipData.push_back(std::move(cd));
-
-		srcClip->m_track = savedTrack;
 	}
 
 	return clipData;
@@ -977,7 +1062,13 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				128, 128,
 				Qt::KeepAspectRatio,
 				Qt::SmoothTransformation );
-			new StringPairDrag(INTERNAL_COPY_KEY, value, thumbnail, this);
+
+			auto* mime = new LazyMimeData(*this, clipViews, value);
+			auto* drag = new QDrag(this);
+			drag->setMimeData(mime);
+			drag->setPixmap(thumbnail);
+			drag->exec(Qt::CopyAction, Qt::CopyAction);
+			delete drag;
 
 			clearInternalCopy(token);
 		}

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -28,7 +28,9 @@
 #include <set>
 #include <cassert>
 
+#include <QDrag>
 #include <QMenu>
+#include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QUuid>
@@ -533,10 +535,31 @@ void ClipView::dropEvent( QDropEvent * de )
 
 	if (type == INTERNAL_COPY_KEY)
 	{
+		auto parts = value.split('|');
+		if (parts.size() < 4) { return; }
+
+		QString token = parts[0];
+		std::vector<InternalClipData> clips;
+		TimePos grabbedClipPos;
+		int initialTrackIndex;
+		unsigned int trackContainerId;
+
+		if (!retrieveInternalCopy(token, clips,
+				grabbedClipPos, initialTrackIndex, trackContainerId))
+		{
+			return;
+		}
+		if (clips.empty()) { return; }
+
+		TimePos pos = m_clip->startPosition();
+		clips[0].clone->copyDataTo(m_clip);
+		m_clip->movePosition(pos);
+		AutomationClip::resolveAllIDs();
+		de->accept();
 		return;
 	}
 
-	// Copy state into existing clip
+	// Copy state into existing clip (XML path)
 	DataFile dataFile( value.toUtf8() );
 	TimePos pos = m_clip->startPosition();
 	QDomElement clips = dataFile.content().firstChildElement("clips");
@@ -956,7 +979,20 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				128, 128,
 				Qt::KeepAspectRatio,
 				Qt::SmoothTransformation );
-			new StringPairDrag(INTERNAL_COPY_KEY, value, thumbnail, this);
+
+			auto* mime = new QMimeData();
+			mime->setData(Clipboard::mimeType(Clipboard::MimeType::StringPair),
+				(QString(INTERNAL_COPY_KEY) + ":" + value).toUtf8());
+			// Cross-instance fallback: include XML payload via Default MIME
+			DataFile xmlDataFile = createClipDataFiles(clipViews);
+			mime->setData(Clipboard::mimeType(Clipboard::MimeType::Default),
+				xmlDataFile.toString().toUtf8());
+
+			auto* drag = new QDrag(this);
+			drag->setMimeData(mime);
+			drag->setPixmap(thumbnail);
+			drag->exec(Qt::CopyAction, Qt::CopyAction);
+			delete drag;
 
 			clearInternalCopy(token);
 		}

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -24,12 +24,14 @@
 
 #include "ClipView.h"
 
+#include <map>
 #include <set>
 #include <cassert>
 
 #include <QMenu>
 #include <QMouseEvent>
 #include <QPainter>
+#include <QUuid>
 
 #include "AutomationClip.h"
 #include "Clipboard.h"
@@ -56,6 +58,56 @@ namespace lmms::gui
 {
 
 
+namespace {
+
+struct InternalCopyData
+{
+	std::vector<ClipView::InternalClipData> clips;
+	TimePos grabbedClipPos;
+	int initialTrackIndex;
+	unsigned int trackContainerId;
+};
+
+std::map<QString, InternalCopyData> s_clipBuffer;
+
+} // anonymous namespace
+
+
+QString ClipView::storeInternalCopy(std::vector<InternalClipData>&& clips,
+	TimePos grabbedClipPos, int initialTrackIndex, unsigned int trackContainerId)
+{
+	auto token = QUuid::createUuid().toString(QUuid::WithoutBraces);
+	InternalCopyData data;
+	data.clips = std::move(clips);
+	data.grabbedClipPos = grabbedClipPos;
+	data.initialTrackIndex = initialTrackIndex;
+	data.trackContainerId = trackContainerId;
+	s_clipBuffer[token] = std::move(data);
+	return token;
+}
+
+bool ClipView::retrieveInternalCopy(const QString& token,
+	std::vector<InternalClipData>& out, TimePos& outGrabbedClipPos,
+	int& outInitialTrackIndex, unsigned int& outTrackContainerId)
+{
+	auto it = s_clipBuffer.find(token);
+	if (it == s_clipBuffer.end()) { return false; }
+
+	out = std::move(it->second.clips);
+	outGrabbedClipPos = it->second.grabbedClipPos;
+	outInitialTrackIndex = it->second.initialTrackIndex;
+	outTrackContainerId = it->second.trackContainerId;
+
+	s_clipBuffer.erase(it);
+	return true;
+}
+
+void ClipView::clearInternalCopy(const QString& token)
+{
+	s_clipBuffer.erase(token);
+}
+
+
 //! The default width of the resize grip in pixels
 constexpr int RESIZE_GRIP_WIDTH = 8;
 //! The maximum fraction of the clip width that the resize grip is allowed to take up
@@ -69,6 +121,8 @@ constexpr float RESIZE_GRIP_MAX_WIDTH_FRACTION = 0.1f;
  * This pointer keeps track of it, as you only ever need one at a time.
  */
 TextFloat * ClipView::s_textFloat = nullptr;
+
+const char* ClipView::INTERNAL_COPY_KEY = "clip_internal";
 
 
 /*! \brief Create a new ClipView
@@ -427,7 +481,8 @@ void ClipView::dragEnterEvent( QDragEnterEvent * dee )
 	else
 	{
 		StringPairDrag::processDragEnterEvent( dee, "clip_" +
-					QString::number( static_cast<int>(m_clip->getTrack()->type()) ) );
+					QString::number( static_cast<int>(m_clip->getTrack()->type()) )
+					+ "," + INTERNAL_COPY_KEY );
 	}
 }
 
@@ -448,8 +503,9 @@ void ClipView::dropEvent( QDropEvent * de )
 	QString type = StringPairDrag::decodeKey( de );
 	QString value = StringPairDrag::decodeValue( de );
 
-	// Track must be the same type to paste into
-	if( type != ( "clip_" + QString::number( static_cast<int>(m_clip->getTrack()->type()) ) ) )
+	// Track must be the same type to paste into, unless internal copy
+	if( type != ( "clip_" + QString::number( static_cast<int>(m_clip->getTrack()->type()) ) )
+		&& type != INTERNAL_COPY_KEY )
 	{
 		return;
 	}
@@ -471,6 +527,11 @@ void ClipView::dropEvent( QDropEvent * de )
 	QObject* qwSource = de->source();
 	if( qwSource != nullptr &&
 	    dynamic_cast<ClipView *>( qwSource ) == this )
+	{
+		return;
+	}
+
+	if (type == INTERNAL_COPY_KEY)
 	{
 		return;
 	}
@@ -569,6 +630,63 @@ DataFile ClipView::createClipDataFiles(
 
 	return dataFile;
 }
+
+
+std::vector<ClipView::InternalClipData> ClipView::cloneClipsForInternalCopy(
+	const QVector<ClipView*>& clipViews,
+	const std::vector<Track*>& tracks) const
+{
+	std::vector<InternalClipData> clipData;
+
+	for (const auto& cv : clipViews)
+	{
+		Track* clipTrack = cv->m_trackView->getTrack();
+		const auto trackIt = std::find(tracks.begin(), tracks.end(), clipTrack);
+		assert(trackIt != tracks.end());
+		int trackIdx = std::distance(tracks.begin(), trackIt);
+
+		auto* srcClip = cv->m_clip;
+		Track* savedTrack = srcClip->m_track;
+		srcClip->m_track = nullptr;
+
+		InternalClipData cd;
+		cd.clone.reset(srcClip->clone());
+		cd.trackIndex = trackIdx;
+		cd.trackType = static_cast<int>(clipTrack->type());
+		clipData.push_back(std::move(cd));
+
+		srcClip->m_track = savedTrack;
+	}
+
+	return clipData;
+}
+
+
+QString ClipView::buildInternalCopyMimeValue(const QString& token,
+	TimePos grabbedClipPos, int initialTrackIndex,
+	unsigned int tcId, const QVector<ClipView*>& clipViews,
+	const std::vector<Track*>& tracks)
+{
+	QString value = QString("%1|%2|%3|%4")
+		.arg(token)
+		.arg(grabbedClipPos.getTicks())
+		.arg(initialTrackIndex)
+		.arg(tcId);
+
+	for (const auto& cv : clipViews)
+	{
+		Track* clipTrack = cv->m_trackView->getTrack();
+		const auto trackIt = std::find(tracks.begin(), tracks.end(), clipTrack);
+		assert(trackIt != tracks.end());
+		int trackIdx = std::distance(tracks.begin(), trackIt);
+		value += QString("|%1,%2")
+			.arg(trackIdx)
+			.arg(static_cast<int>(clipTrack->type()));
+	}
+
+	return value;
+}
+
 
 void ClipView::paintTextLabel(QString const & text, QPainter & painter)
 {
@@ -819,17 +937,28 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 			// triggered once we go into drag.
 			m_action = Action::None;
 
-			// Write the Clips to the DataFile for copying
-			DataFile dataFile = createClipDataFiles( clipViews );
+			Track* sourceTrack = m_trackView->getTrack();
+			TrackContainer* tc = sourceTrack->trackContainer();
+			const TrackContainer::TrackList& tracks = tc->tracks();
+			const auto sourceIt = std::find(tracks.begin(), tracks.end(), sourceTrack);
+			assert(sourceIt != tracks.end());
+			int initialTrackIndex = std::distance(tracks.begin(), sourceIt);
+			TimePos grabbedClipPos = m_clip->startPosition();
 
-			// TODO -- thumbnail for all selected
+			std::vector<InternalClipData> clipData = cloneClipsForInternalCopy(clipViews, tracks);
+			QString token = storeInternalCopy(std::move(clipData), grabbedClipPos,
+				initialTrackIndex, tc->id());
+			QString value = buildInternalCopyMimeValue(
+				token, grabbedClipPos, initialTrackIndex, tc->id(),
+				clipViews, tracks);
+
 			QPixmap thumbnail = grab().scaled(
 				128, 128,
 				Qt::KeepAspectRatio,
 				Qt::SmoothTransformation );
-			new StringPairDrag( QString( "clip_%1" ).arg(
-								static_cast<int>(m_clip->getTrack()->type()) ),
-								dataFile.toString(), thumbnail, this );
+			new StringPairDrag(INTERNAL_COPY_KEY, value, thumbnail, this);
+
+			clearInternalCopy(token);
 		}
 	}
 

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -28,9 +28,7 @@
 #include <set>
 #include <cassert>
 
-#include <QDrag>
 #include <QMenu>
-#include <QMimeData>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QUuid>
@@ -979,20 +977,7 @@ void ClipView::mouseMoveEvent( QMouseEvent * me )
 				128, 128,
 				Qt::KeepAspectRatio,
 				Qt::SmoothTransformation );
-
-			auto* mime = new QMimeData();
-			mime->setData(Clipboard::mimeType(Clipboard::MimeType::StringPair),
-				(QString(INTERNAL_COPY_KEY) + ":" + value).toUtf8());
-			// Cross-instance fallback: include XML payload via Default MIME
-			DataFile xmlDataFile = createClipDataFiles(clipViews);
-			mime->setData(Clipboard::mimeType(Clipboard::MimeType::Default),
-				xmlDataFile.toString().toUtf8());
-
-			auto* drag = new QDrag(this);
-			drag->setMimeData(mime);
-			drag->setPixmap(thumbnail);
-			drag->exec(Qt::CopyAction, Qt::CopyAction);
-			delete drag;
+			new StringPairDrag(INTERNAL_COPY_KEY, value, thumbnail, this);
 
 			clearInternalCopy(token);
 		}

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -380,43 +380,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	if (type == ClipView::INTERNAL_COPY_KEY)
 	{
-		auto parts = value.split('|');
-		if (parts.size() < 4) { return false; }
-
-		TimePos grabbedClipPos(parts[1].toInt());
-		TimePos grabbedClipBar(TimePos(grabbedClipPos.getBar(), 0));
-		int initialTrackIndex = parts[2].toInt();
-		unsigned int sourceTCId = parts[3].toUInt();
-
-		const auto& tracks = t->trackContainer()->tracks();
-		const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
-		int currentTrackIndex = currentTrackIt != tracks.end()
-			? std::distance(tracks.begin(), currentTrackIt) : -1;
-
-		if (!allowSameBar && sourceTCId == t->trackContainer()->id()
-			&& clipPos == grabbedClipBar && currentTrackIndex == initialTrackIndex)
-		{
-			return false;
-		}
-
-		for (int i = 4; i < parts.size(); i++)
-		{
-			auto pair = parts[i].split(',');
-			int trackIndex = pair[0].toInt();
-			int trackTypeInt = pair[1].toInt();
-			int finalTrackIndex = trackIndex + currentTrackIndex - initialTrackIndex;
-
-			if (finalTrackIndex < 0 || static_cast<std::size_t>(finalTrackIndex) >= tracks.size())
-			{
-				return false;
-			}
-			if (static_cast<Track::Type>(trackTypeInt) != tracks.at(finalTrackIndex)->type())
-			{
-				return false;
-			}
-		}
-
-		return true;
+		return canPasteInternalCopy(value.split('|'), clipPos, t, allowSameBar);
 	}
 
 	// We can only paste into tracks of the same type
@@ -523,64 +487,9 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	if (type == ClipView::INTERNAL_COPY_KEY)
 	{
-		auto parts = value.split('|');
-		if (parts.size() < 4) { return false; }
-
-		QString token = parts[0];
-		TimePos grabbedClipPos(parts[1].toInt());
-
-		std::vector<ClipView::InternalClipData> internalClips;
-		TimePos outGrabbedClipPos;
-		int initialTrackIndex;
-		unsigned int trackContainerId;
-
-		if (!ClipView::retrieveInternalCopy(token, internalClips,
-				outGrabbedClipPos, initialTrackIndex, trackContainerId))
-		{
-			return false;
-		}
-
-		const auto& tracks = getTrack()->trackContainer()->tracks();
-		const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
-		int currentTrackIndex = currentTrackIt != tracks.end()
-			? std::distance(tracks.begin(), currentTrackIt) : -1;
-
-		getTrack()->addJournalCheckPoint();
-
-		bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
-		const QVector<selectableObject*> so =
-			m_trackView->trackContainerView()->selectedObjects();
-		for (const auto& obj : so) { obj->setSelected(false); }
-
-		float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
-		auto offset = TimePos(clipPos - outGrabbedClipPos);
-		offset -= TimePos::ticksPerBar() * snapSize / 2;
-		offset = offset.quantize(snapSize);
-
-		TimePos leftmostPos = outGrabbedClipPos;
-		for (const auto& ic : internalClips)
-		{
-			TimePos pos = ic.clone->startPosition();
-			if (pos < leftmostPos) { leftmostPos = pos; }
-		}
-		offset = std::max(offset.getTicks(), -leftmostPos.getTicks());
-
-		for (auto& ic : internalClips)
-		{
-			int finalTrackIndex = ic.trackIndex + (currentTrackIndex - initialTrackIndex);
-			Track* t = tracks.at(finalTrackIndex);
-
-			TimePos pos = ic.clone->startPosition() + offset;
-			TimePos shift = TimePos::ticksPerBar() * snapSize;
-			if (offset == 0 && initialTrackIndex == currentTrackIndex) { pos += shift; }
-
-			Clip* clip = t->createClip(pos);
-			ic.clone->copyDataTo(clip);
-			if (wasSelection) { clip->selectViewOnCreate(true); }
-		}
-
-		AutomationClip::resolveAllIDs();
-		return true;
+		bool wasSelection = false;
+		return pasteInternalCopy(value.split('|'), clipPos,
+			getTrack(), wasSelection);
 	}
 
 	getTrack()->addJournalCheckPoint();
@@ -929,5 +838,116 @@ void TrackContentWidget::setEmbossWidth(int c)
 //! \brief CSS theming qproperty access method
 void TrackContentWidget::setEmbossOffset(int c)
 { m_embossOffset = c; }
+
+
+bool TrackContentWidget::canPasteInternalCopy(const QStringList& parts,
+	TimePos clipPos, Track* t, bool allowSameBar) const
+{
+	if (parts.size() < 4) { return false; }
+
+	TimePos grabbedClipPos(parts[1].toInt());
+	TimePos grabbedClipBar(TimePos(grabbedClipPos.getBar(), 0));
+	int initialTrackIndex = parts[2].toInt();
+	unsigned int sourceTCId = parts[3].toUInt();
+
+	const auto& tracks = t->trackContainer()->tracks();
+	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
+	int currentTrackIndex = currentTrackIt != tracks.end()
+		? std::distance(tracks.begin(), currentTrackIt) : -1;
+
+	if (!allowSameBar && sourceTCId == t->trackContainer()->id()
+		&& clipPos == grabbedClipBar && currentTrackIndex == initialTrackIndex)
+	{
+		return false;
+	}
+
+	for (int i = 4; i < parts.size(); i++)
+	{
+		auto pair = parts[i].split(',');
+		int trackIndex = pair[0].toInt();
+		int trackTypeInt = pair[1].toInt();
+		int finalTrackIndex = trackIndex + currentTrackIndex - initialTrackIndex;
+
+		if (finalTrackIndex < 0
+			|| static_cast<std::size_t>(finalTrackIndex) >= tracks.size())
+		{
+			return false;
+		}
+		if (static_cast<Track::Type>(trackTypeInt)
+			!= tracks.at(finalTrackIndex)->type())
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+bool TrackContentWidget::pasteInternalCopy(const QStringList& parts,
+	TimePos clipPos, Track* t, bool& wasSelection)
+{
+	if (parts.size() < 4) { return false; }
+
+	QString token = parts[0];
+
+	std::vector<ClipView::InternalClipData> clips;
+	TimePos grabbedClipPos;
+	int initialTrackIndex;
+	unsigned int trackContainerId;
+
+	if (!ClipView::retrieveInternalCopy(token, clips,
+			grabbedClipPos, initialTrackIndex, trackContainerId))
+	{
+		return false;
+	}
+
+	const auto& tracks = t->trackContainer()->tracks();
+	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
+	int currentTrackIndex = currentTrackIt != tracks.end()
+		? std::distance(tracks.begin(), currentTrackIt) : -1;
+
+	t->addJournalCheckPoint();
+
+	wasSelection = m_trackView->trackContainerView()->rubberBand()
+		->selectedObjects().count();
+	const QVector<selectableObject*> so =
+		m_trackView->trackContainerView()->selectedObjects();
+	for (const auto& obj : so) { obj->setSelected(false); }
+
+	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
+	auto offset = TimePos(clipPos - grabbedClipPos);
+	offset -= TimePos::ticksPerBar() * snapSize / 2;
+	offset = offset.quantize(snapSize);
+
+	TimePos leftmostPos = grabbedClipPos;
+	for (const auto& ic : clips)
+	{
+		TimePos pos = ic.clone->startPosition();
+		if (pos < leftmostPos) { leftmostPos = pos; }
+	}
+	offset = std::max(offset.getTicks(), -leftmostPos.getTicks());
+
+	for (auto& ic : clips)
+	{
+		int finalTrackIndex = ic.trackIndex
+			+ (currentTrackIndex - initialTrackIndex);
+		Track* target = tracks.at(finalTrackIndex);
+
+		TimePos pos = ic.clone->startPosition() + offset;
+		TimePos shift = TimePos::ticksPerBar() * snapSize;
+		if (offset == 0 && initialTrackIndex == currentTrackIndex)
+		{
+			pos += shift;
+		}
+
+		Clip* clip = target->createClip(pos);
+		ic.clone->copyDataTo(clip);
+		if (wasSelection) { clip->selectViewOnCreate(true); }
+	}
+
+	AutomationClip::resolveAllIDs();
+	return true;
+}
 
 } // namespace lmms::gui

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -323,6 +323,21 @@ TimePos TrackContentWidget::getPosition( int mouseX )
 void TrackContentWidget::dragEnterEvent( QDragEnterEvent * dee )
 {
 	TimePos clipPos = getPosition(position(dee).x());
+
+	QString key = Clipboard::decodeKey( dee->mimeData() );
+	if (key == ClipView::INTERNAL_COPY_KEY)
+	{
+		if (canPasteSelection(clipPos, dee->mimeData()))
+		{
+			dee->acceptProposedAction();
+		}
+		else
+		{
+			dee->ignore();
+		}
+		return;
+	}
+
 	if( canPasteSelection( clipPos, dee ) == false )
 	{
 		dee->ignore();
@@ -362,6 +377,47 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 	Track * t = getTrack();
 	QString type = decodeKey( md );
 	QString value = decodeValue( md );
+
+	if (type == ClipView::INTERNAL_COPY_KEY)
+	{
+		auto parts = value.split('|');
+		if (parts.size() < 4) { return false; }
+
+		TimePos grabbedClipPos(parts[1].toInt());
+		TimePos grabbedClipBar(TimePos(grabbedClipPos.getBar(), 0));
+		int initialTrackIndex = parts[2].toInt();
+		unsigned int sourceTCId = parts[3].toUInt();
+
+		const auto& tracks = t->trackContainer()->tracks();
+		const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), t);
+		int currentTrackIndex = currentTrackIt != tracks.end()
+			? std::distance(tracks.begin(), currentTrackIt) : -1;
+
+		if (!allowSameBar && sourceTCId == t->trackContainer()->id()
+			&& clipPos == grabbedClipBar && currentTrackIndex == initialTrackIndex)
+		{
+			return false;
+		}
+
+		for (int i = 4; i < parts.size(); i++)
+		{
+			auto pair = parts[i].split(',');
+			int trackIndex = pair[0].toInt();
+			int trackTypeInt = pair[1].toInt();
+			int finalTrackIndex = trackIndex + currentTrackIndex - initialTrackIndex;
+
+			if (finalTrackIndex < 0 || static_cast<std::size_t>(finalTrackIndex) >= tracks.size())
+			{
+				return false;
+			}
+			if (static_cast<Track::Type>(trackTypeInt) != tracks.at(finalTrackIndex)->type())
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
 
 	// We can only paste into tracks of the same type
 	if (type != ("clip_" + QString::number(static_cast<int>(t->type()))))
@@ -464,6 +520,68 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	QString type = decodeKey( md );
 	QString value = decodeValue( md );
+
+	if (type == ClipView::INTERNAL_COPY_KEY)
+	{
+		auto parts = value.split('|');
+		if (parts.size() < 4) { return false; }
+
+		QString token = parts[0];
+		TimePos grabbedClipPos(parts[1].toInt());
+
+		std::vector<ClipView::InternalClipData> internalClips;
+		TimePos outGrabbedClipPos;
+		int initialTrackIndex;
+		unsigned int trackContainerId;
+
+		if (!ClipView::retrieveInternalCopy(token, internalClips,
+				outGrabbedClipPos, initialTrackIndex, trackContainerId))
+		{
+			return false;
+		}
+
+		const auto& tracks = getTrack()->trackContainer()->tracks();
+		const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
+		int currentTrackIndex = currentTrackIt != tracks.end()
+			? std::distance(tracks.begin(), currentTrackIt) : -1;
+
+		getTrack()->addJournalCheckPoint();
+
+		bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
+		const QVector<selectableObject*> so =
+			m_trackView->trackContainerView()->selectedObjects();
+		for (const auto& obj : so) { obj->setSelected(false); }
+
+		float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
+		auto offset = TimePos(clipPos - outGrabbedClipPos);
+		offset -= TimePos::ticksPerBar() * snapSize / 2;
+		offset = offset.quantize(snapSize);
+
+		TimePos leftmostPos = outGrabbedClipPos;
+		for (const auto& ic : internalClips)
+		{
+			TimePos pos = ic.clone->startPosition();
+			if (pos < leftmostPos) { leftmostPos = pos; }
+		}
+		offset = std::max(offset.getTicks(), -leftmostPos.getTicks());
+
+		for (auto& ic : internalClips)
+		{
+			int finalTrackIndex = ic.trackIndex + (currentTrackIndex - initialTrackIndex);
+			Track* t = tracks.at(finalTrackIndex);
+
+			TimePos pos = ic.clone->startPosition() + offset;
+			TimePos shift = TimePos::ticksPerBar() * snapSize;
+			if (offset == 0 && initialTrackIndex == currentTrackIndex) { pos += shift; }
+
+			Clip* clip = t->createClip(pos);
+			ic.clone->copyDataTo(clip);
+			if (wasSelection) { clip->selectViewOnCreate(true); }
+		}
+
+		AutomationClip::resolveAllIDs();
+		return true;
+	}
 
 	getTrack()->addJournalCheckPoint();
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -488,8 +488,12 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 	if (type == ClipView::INTERNAL_COPY_KEY)
 	{
 		bool wasSelection = false;
-		return pasteInternalCopy(value.split('|'), clipPos,
-			getTrack(), wasSelection);
+		if (pasteInternalCopy(value.split('|'), clipPos,
+			getTrack(), wasSelection))
+		{
+			return true;
+		}
+		// Token not found (cross-instance) — fall through to XML path
 	}
 
 	return pasteXmlSelection(clipPos, md);
@@ -833,7 +837,7 @@ bool TrackContentWidget::pasteInternalCopy(const QStringList& parts,
 	for (const auto& obj : so) { obj->setSelected(false); }
 
 	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
-	auto offset = TimePos(clipPos - grabbedClipPos);
+	TimePos offset(clipPos - grabbedClipPos);
 	offset -= TimePos::ticksPerBar() * snapSize / 2;
 	offset = offset.quantize(snapSize);
 
@@ -875,7 +879,15 @@ bool TrackContentWidget::pasteXmlSelection(TimePos clipPos, const QMimeData* md)
 	getTrack()->addJournalCheckPoint();
 
 	QString value = decodeValue(md);
-	DataFile dataFile(value.toUtf8());
+	QByteArray data = value.toUtf8();
+
+	QByteArray defaultData = md->data(mimeType(MimeType::Default));
+	if (!defaultData.isEmpty())
+	{
+		data = defaultData;
+	}
+
+	DataFile dataFile(data);
 
 	QDomElement clipParent = dataFile.content().firstChildElement("clips");
 	QDomNodeList clipNodes = clipParent.childNodes();
@@ -899,7 +911,7 @@ bool TrackContentWidget::pasteXmlSelection(TimePos clipPos, const QMimeData* md)
 	for (const auto& obj : so) { obj->setSelected(false); }
 
 	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
-	auto offset = TimePos(clipPos - grabbedClipPos);
+	TimePos offset(clipPos - grabbedClipPos);
 	offset -= TimePos::ticksPerBar() * snapSize / 2;
 	offset = offset.quantize(snapSize);
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -488,8 +488,12 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 	if (type == ClipView::INTERNAL_COPY_KEY)
 	{
 		bool wasSelection = false;
-		return pasteInternalCopy(value.split('|'), clipPos,
-			getTrack(), wasSelection);
+		if (pasteInternalCopy(value.split('|'), clipPos,
+			getTrack(), wasSelection))
+		{
+			return true;
+		}
+		// Token not found (cross-instance) — fall through to XML path
 	}
 
 	return pasteXmlSelection(clipPos, md);
@@ -875,7 +879,17 @@ bool TrackContentWidget::pasteXmlSelection(TimePos clipPos, const QMimeData* md)
 	getTrack()->addJournalCheckPoint();
 
 	QString value = decodeValue(md);
-	DataFile dataFile(value.toUtf8());
+	QByteArray data = value.toUtf8();
+
+	// If the StringPair value isn't valid XML, fall back to the Default MIME
+	// type which carries the XML payload for cross-instance internal copies.
+	QByteArray defaultData = md->data(mimeType(MimeType::Default));
+	if (!defaultData.isEmpty())
+	{
+		data = defaultData;
+	}
+
+	DataFile dataFile(data);
 
 	QDomElement clipParent = dataFile.content().firstChildElement("clips");
 	QDomNodeList clipNodes = clipParent.childNodes();

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -492,90 +492,7 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 			getTrack(), wasSelection);
 	}
 
-	getTrack()->addJournalCheckPoint();
-
-	// value contains XML needed to reconstruct Clips and place them
-	DataFile dataFile( value.toUtf8() );
-
-	// Extract the clip data
-	QDomElement clipParent = dataFile.content().firstChildElement("clips");
-	QDomNodeList clipNodes = clipParent.childNodes();
-
-	// Extract the track index that was originally clicked
-	QDomElement metadata = dataFile.content().firstChildElement( "copyMetadata" );
-	QDomAttr tiAttr = metadata.attributeNode( "initialTrackIndex" );
-	int initialTrackIndex = tiAttr.value().toInt();
-	QDomAttr clipPosAttr = metadata.attributeNode( "grabbedClipPos" );
-	TimePos grabbedClipPos = clipPosAttr.value().toInt();
-
-	// Snap the mouse position to the beginning of the dropped bar, in ticks
-	const TrackContainer::TrackList& tracks = getTrack()->trackContainer()->tracks();
-	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
-	const int currentTrackIndex = currentTrackIt != tracks.end() ? std::distance(tracks.begin(), currentTrackIt) : -1;
-
-	bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
-
-	// Unselect the old group
-		const QVector<selectableObject *> so =
-			m_trackView->trackContainerView()->selectedObjects();
-		for (const auto& obj : so)
-		{
-			obj->setSelected(false);
-		}
-
-
-	// TODO -- Need to draw the hovericon either way, or ghost the Clips
-	// onto their final position.
-
-	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
-	// All clips should be offset the same amount as the grabbed clip
-	auto offset = TimePos(clipPos - grabbedClipPos);
-	// Users expect clips to "fall" backwards, so bias the offset
-	offset -= TimePos::ticksPerBar() * snapSize / 2;
-	// The offset is quantized (rather than the positions) to preserve fine adjustments
-	offset = offset.quantize(snapSize);
-
-	// Get the leftmost Clip and fix the offset if it reaches below bar 0
-	TimePos leftmostPos = grabbedClipPos;
-	for(int i = 0; i < clipNodes.length(); ++i)
-	{
-		QDomElement outerClipElement = clipNodes.item(i).toElement();
-		QDomElement clipElement = outerClipElement.firstChildElement();
-
-		TimePos pos = clipElement.attributeNode("pos").value().toInt();
-
-		if(pos < leftmostPos) { leftmostPos = pos; }
-	}
-	// Fix offset if it sets the left most Clip to a negative position
-	offset = std::max(offset.getTicks(), -leftmostPos.getTicks());
-
-	for( int i = 0; i<clipNodes.length(); i++ )
-	{
-		QDomElement outerClipElement = clipNodes.item( i ).toElement();
-		QDomElement clipElement = outerClipElement.firstChildElement();
-
-		int trackIndex = outerClipElement.attributeNode( "trackIndex" ).value().toInt();
-		int finalTrackIndex = trackIndex + ( currentTrackIndex - initialTrackIndex );
-		Track * t = tracks.at( finalTrackIndex );
-
-		// The new position is the old position plus the offset.
-		TimePos pos = clipElement.attributeNode( "pos" ).value().toInt() + offset;
-		// If we land on ourselves, offset by one snap
-		TimePos shift = TimePos::ticksPerBar() * getGUI()->songEditor()->m_editor->getSnapSize();
-		if (offset == 0 && initialTrackIndex == currentTrackIndex) { pos += shift; }
-
-		Clip * clip = t->createClip( pos );
-		clip->restoreState( clipElement );
-		clip->movePosition(pos); // Because we restored the state, we need to move the Clip again.
-		if( wasSelection )
-		{
-			clip->selectViewOnCreate( true );
-		}
-	}
-
-	AutomationClip::resolveAllIDs();
-
-	return true;
+	return pasteXmlSelection(clipPos, md);
 }
 
 
@@ -943,6 +860,75 @@ bool TrackContentWidget::pasteInternalCopy(const QStringList& parts,
 
 		Clip* clip = target->createClip(pos);
 		ic.clone->copyDataTo(clip);
+		if (wasSelection) { clip->selectViewOnCreate(true); }
+	}
+
+	AutomationClip::resolveAllIDs();
+	return true;
+}
+
+
+bool TrackContentWidget::pasteXmlSelection(TimePos clipPos, const QMimeData* md)
+{
+	using namespace Clipboard;
+
+	getTrack()->addJournalCheckPoint();
+
+	QString value = decodeValue(md);
+	DataFile dataFile(value.toUtf8());
+
+	QDomElement clipParent = dataFile.content().firstChildElement("clips");
+	QDomNodeList clipNodes = clipParent.childNodes();
+
+	QDomElement metadata = dataFile.content().firstChildElement("copyMetadata");
+	QDomAttr tiAttr = metadata.attributeNode("initialTrackIndex");
+	int initialTrackIndex = tiAttr.value().toInt();
+	QDomAttr clipPosAttr = metadata.attributeNode("grabbedClipPos");
+	TimePos grabbedClipPos = clipPosAttr.value().toInt();
+
+	const TrackContainer::TrackList& tracks = getTrack()->trackContainer()->tracks();
+	const auto currentTrackIt = std::find(tracks.begin(), tracks.end(), getTrack());
+	const int currentTrackIndex = currentTrackIt != tracks.end()
+		? std::distance(tracks.begin(), currentTrackIt) : -1;
+
+	bool wasSelection = m_trackView->trackContainerView()->rubberBand()
+		->selectedObjects().count();
+
+	const QVector<selectableObject*> so =
+		m_trackView->trackContainerView()->selectedObjects();
+	for (const auto& obj : so) { obj->setSelected(false); }
+
+	float snapSize = getGUI()->songEditor()->m_editor->getSnapSize();
+	auto offset = TimePos(clipPos - grabbedClipPos);
+	offset -= TimePos::ticksPerBar() * snapSize / 2;
+	offset = offset.quantize(snapSize);
+
+	TimePos leftmostPos = grabbedClipPos;
+	for (int i = 0; i < clipNodes.length(); ++i)
+	{
+		QDomElement outer = clipNodes.item(i).toElement();
+		QDomElement inner = outer.firstChildElement();
+		TimePos pos = inner.attributeNode("pos").value().toInt();
+		if (pos < leftmostPos) { leftmostPos = pos; }
+	}
+	offset = std::max(offset.getTicks(), -leftmostPos.getTicks());
+
+	for (int i = 0; i < clipNodes.length(); i++)
+	{
+		QDomElement outer = clipNodes.item(i).toElement();
+		QDomElement inner = outer.firstChildElement();
+
+		int trackIndex = outer.attributeNode("trackIndex").value().toInt();
+		int finalTrackIndex = trackIndex + (currentTrackIndex - initialTrackIndex);
+		Track* t = tracks.at(finalTrackIndex);
+
+		TimePos pos = inner.attributeNode("pos").value().toInt() + offset;
+		TimePos shift = TimePos::ticksPerBar() * snapSize;
+		if (offset == 0 && initialTrackIndex == currentTrackIndex) { pos += shift; }
+
+		Clip* clip = t->createClip(pos);
+		clip->restoreState(inner);
+		clip->movePosition(pos);
 		if (wasSelection) { clip->selectViewOnCreate(true); }
 	}
 

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -488,12 +488,8 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 	if (type == ClipView::INTERNAL_COPY_KEY)
 	{
 		bool wasSelection = false;
-		if (pasteInternalCopy(value.split('|'), clipPos,
-			getTrack(), wasSelection))
-		{
-			return true;
-		}
-		// Token not found (cross-instance) — fall through to XML path
+		return pasteInternalCopy(value.split('|'), clipPos,
+			getTrack(), wasSelection);
 	}
 
 	return pasteXmlSelection(clipPos, md);
@@ -879,17 +875,7 @@ bool TrackContentWidget::pasteXmlSelection(TimePos clipPos, const QMimeData* md)
 	getTrack()->addJournalCheckPoint();
 
 	QString value = decodeValue(md);
-	QByteArray data = value.toUtf8();
-
-	// If the StringPair value isn't valid XML, fall back to the Default MIME
-	// type which carries the XML payload for cross-instance internal copies.
-	QByteArray defaultData = md->data(mimeType(MimeType::Default));
-	if (!defaultData.isEmpty())
-	{
-		data = defaultData;
-	}
-
-	DataFile dataFile(data);
+	DataFile dataFile(value.toUtf8());
 
 	QDomElement clipParent = dataFile.content().firstChildElement("clips");
 	QDomNodeList clipNodes = clipParent.childNodes();

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -208,6 +208,9 @@ InstrumentTrack::~InstrumentTrack()
 	if (m_hasAutoMidiDev)
 	{
 		autoAssignMidiDevice(false);
+	}
+	if (s_autoAssignedTrack == this)
+	{
 		s_autoAssignedTrack = nullptr;
 	}
 

--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -113,7 +113,7 @@ void MidiClip::resizeToFirstTrack()
 void MidiClip::init()
 {
 	connect(Engine::getSong(), &Song::timeSignatureChanged, this, &MidiClip::changeTimeSignature);
-	if (getTrack()->trackContainer() != Engine::patternStore())
+	if (getTrack() && getTrack()->trackContainer() != Engine::patternStore())
 	{
 		saveJournallingState(false);
 		updateLength();
@@ -272,6 +272,35 @@ void MidiClip::clearNotes()
 	checkType();
 	updateLength();
 	emit dataChanged();
+}
+
+
+bool MidiClip::copyDataTo(Clip* dstClip) const
+{
+	MidiClip* dst = dynamic_cast<MidiClip*>(dstClip);
+	if (!dst) { return false; }
+
+	dst->m_clipType = m_clipType;
+
+	dst->clearNotes();
+
+	for (const auto& note : m_notes)
+	{
+		dst->m_notes.push_back(note->clone());
+	}
+
+	dst->m_steps = m_steps;
+	dst->checkType();
+	dst->setName(name());
+	if (const auto& c = color()) { dst->setColor(*c); }
+	if (isMuted() != dst->isMuted()) { dst->toggleMute(); }
+	dst->changeLength(length());
+	dst->setAutoResize(getAutoResize());
+	dst->setStartTimeOffset(startTimeOffset());
+
+	emit dst->dataChanged();
+
+	return true;
 }
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LMMS_TESTS
 	src/core/AudioBufferTest.cpp
 	src/core/AutomatableModelTest.cpp
 	src/core/MathTest.cpp
+	src/core/MidiClipTest.cpp
 	src/core/ProjectVersionTest.cpp
 	src/core/RelativePathsTest.cpp
 	src/core/TimelineTest.cpp

--- a/tests/src/core/MidiClipTest.cpp
+++ b/tests/src/core/MidiClipTest.cpp
@@ -1,0 +1,419 @@
+/*
+ * MidiClipTest.cpp
+ *
+ * Copyright (c) 2025 LMMS - https://lmms.io
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include <QtTest>
+
+#include <QElapsedTimer>
+
+#include "Clip.h"
+#include "Engine.h"
+#include "InstrumentTrack.h"
+#include "MidiClip.h"
+#include "Note.h"
+#include "Song.h"
+#include "Track.h"
+
+
+class MidiClipTest : public QObject
+{
+	Q_OBJECT
+private slots:
+	void initTestCase()
+	{
+		using namespace lmms;
+		Engine::init(true);
+	}
+
+	void cleanupTestCase()
+	{
+		using namespace lmms;
+		Engine::destroy();
+	}
+
+	void testCopyDataTo()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setName("Source Clip");
+		src.setAutoResize(false);
+		src.changeLength(TimePos(4, 0));
+		src.setColor(QColor(255, 0, 0));
+
+		Note note1(TimePos(0, 48), TimePos(0, 0), 60, 100, 0);
+		Note note2(TimePos(0, 96), TimePos(1, 0), 64, 80, -20);
+		Note note3(TimePos(0, 48), TimePos(2, 0), 67, 120, 20);
+		src.addNote(note1, false);
+		src.addNote(note2, false);
+		src.addNote(note3, false);
+
+		QCOMPARE(src.notes().size(), (std::size_t)3);
+
+		MidiClip dst(&track);
+		dst.changeLength(TimePos(1, 0));
+		dst.setName("Destination");
+
+		QVERIFY(src.copyDataTo(&dst));
+		QCOMPARE(dst.notes().size(), (std::size_t)3);
+		QCOMPARE(dst.name(), QString("Source Clip"));
+		QVERIFY(dst.color().has_value());
+		QCOMPARE(*dst.color(), QColor(255, 0, 0));
+		QCOMPARE(dst.length(), TimePos(4, 0));
+		QCOMPARE(dst.getAutoResize(), false);
+		QCOMPARE(dst.isMuted(), false);
+		QCOMPARE(dst.type(), src.type());
+
+		auto& dstNotes = dst.notes();
+		QCOMPARE(dstNotes[0]->key(), 60);
+		QCOMPARE(dstNotes[0]->length(), TimePos(0, 48));
+		QCOMPARE(dstNotes[0]->pos(), TimePos(0, 0));
+		QCOMPARE(dstNotes[0]->getVolume(), (volume_t)100);
+		QCOMPARE(dstNotes[0]->getPanning(), (panning_t)0);
+
+		QCOMPARE(dstNotes[1]->key(), 64);
+		QCOMPARE(dstNotes[1]->getVolume(), (volume_t)80);
+		QCOMPARE(dstNotes[1]->getPanning(), (panning_t)-20);
+
+		QCOMPARE(dstNotes[2]->key(), 67);
+		QCOMPARE(dstNotes[2]->getVolume(), (volume_t)120);
+		QCOMPARE(dstNotes[2]->getPanning(), (panning_t)20);
+		QCOMPARE(dstNotes[2]->pos(), TimePos(2, 0));
+	}
+
+	void testCopyDataToNoteIndependence()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0), 60), false);
+
+		MidiClip dst(&track);
+		src.copyDataTo(&dst);
+
+		QCOMPARE(src.notes().size(), (std::size_t)1);
+		QCOMPARE(dst.notes().size(), (std::size_t)1);
+
+		dst.notes()[0]->setKey(72);
+		QCOMPARE(src.notes()[0]->key(), 60);
+		QCOMPARE(dst.notes()[0]->key(), 72);
+	}
+
+	void testCopyDataToMuted()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.toggleMute();
+		QVERIFY(src.isMuted());
+
+		MidiClip dst(&track);
+		QVERIFY(!dst.isMuted());
+
+		src.copyDataTo(&dst);
+		QVERIFY(dst.isMuted());
+	}
+
+	void testCopyDataToEmptySource()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.changeLength(TimePos(8, 0));
+		src.setName("Empty Clip");
+
+		MidiClip dst(&track);
+		dst.addNote(Note(TimePos(0, 48)), false);
+		QCOMPARE(dst.notes().size(), (std::size_t)1);
+
+		src.copyDataTo(&dst);
+		QCOMPARE(dst.notes().size(), (std::size_t)0);
+		QCOMPARE(dst.name(), QString("Empty Clip"));
+		QCOMPARE(dst.length(), TimePos(8, 0));
+	}
+
+	void testCopyDataToWrongType()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+
+		QVERIFY(!src.copyDataTo(nullptr));
+	}
+
+	void testCopyStateToUsesFastPath()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setName("Source via copyStateTo");
+		src.changeLength(TimePos(2, 0));
+		src.addNote(Note(TimePos(0, 96), TimePos(0, 0), 62), false);
+		src.addNote(Note(TimePos(0, 96), TimePos(1, 0), 65), false);
+
+		MidiClip dst(&track);
+		TimePos dstPos(TimePos(4, 0));
+		dst.movePosition(dstPos);
+
+		Clip::copyStateTo(&src, &dst);
+
+		QCOMPARE(dst.notes().size(), (std::size_t)2);
+		QCOMPARE(dst.name(), QString("Source via copyStateTo"));
+		QCOMPARE(dst.length(), TimePos(2, 0));
+
+		QCOMPARE(dst.notes()[0]->key(), 62);
+		QCOMPARE(dst.notes()[1]->key(), 65);
+	}
+
+	void testCopyStateToCrossTrack()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track1(song);
+		InstrumentTrack track2(song);
+
+		MidiClip src(&track1);
+		src.addNote(Note(TimePos(0, 48)), false);
+
+		MidiClip dst(&track2);
+
+		Clip::copyStateTo(&src, &dst);
+		QCOMPARE(dst.notes().size(), (std::size_t)1);
+	}
+
+	void testCloneWithNullTrack()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0), 60), false);
+		src.addNote(Note(TimePos(0, 48), TimePos(1, 0), 64), false);
+		src.setName("NullTrackTest");
+		src.setColor(QColor(0, 255, 0));
+
+		std::unique_ptr<MidiClip> clone(static_cast<MidiClip*>(src.clone()));
+		// detach clone from track to simulate internal-copy buffer lifecycle
+		track.removeClip(clone.get());
+
+		QVERIFY(clone != nullptr);
+		QCOMPARE(clone->notes().size(), (std::size_t)2);
+
+		MidiClip dst(&track);
+		QVERIFY(clone->copyDataTo(&dst));
+		QCOMPARE(dst.notes().size(), (std::size_t)2);
+		QCOMPARE(dst.name(), QString("NullTrackTest"));
+		QVERIFY(dst.color().has_value());
+		QCOMPARE(*dst.color(), QColor(0, 255, 0));
+		QCOMPARE(dst.notes()[0]->key(), 60);
+		QCOMPARE(dst.notes()[1]->key(), 64);
+		QVERIFY(dst.getTrack() == &track);
+	}
+
+	void stressMultiCopy()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		int notesPerClip = 1120;
+		for (int n = 0; n < notesPerClip; n++)
+		{
+			int key = 36 + (n % 48);
+			src.addNote(Note(TimePos(0, 12), TimePos(n / 4, (n % 4) * 12), key, 100, 0), false);
+		}
+
+		int numCopies = 50;
+		QList<MidiClip*> dstClips;
+		QElapsedTimer t;
+		t.start();
+
+		for (int i = 0; i < numCopies; i++)
+		{
+			auto* dst = new MidiClip(&track);
+			QVERIFY(src.copyDataTo(dst));
+			QCOMPARE(dst->notes().size(), (std::size_t)notesPerClip);
+			dstClips.push_back(dst);
+		}
+
+		qDebug() << "STRESS_MULTI notes=" << notesPerClip << " copies=" << numCopies
+			 << " ms=" << t.elapsed();
+
+		QCOMPARE(dstClips.size(), numCopies);
+		qDeleteAll(dstClips);
+	}
+
+	void stressFuzzyNotes()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+
+		src.addNote(Note(TimePos(0, 0),  TimePos(0, 0),   0,   0,  -100), false);
+		src.addNote(Note(TimePos(0, 1),  TimePos(0, 0),  60,   100, 0),   false);
+		src.addNote(Note(TimePos(4, 0),  TimePos(0, 0),  100,  50, 50),  false);
+		src.addNote(Note(TimePos(0, 48), TimePos(1, 0),  127,  127, 100), false);
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0),  64,   80, 0),   false);
+		src.addNote(Note(TimePos(0, 1),  TimePos(10, 0), 50,   40, -50), false);
+
+		src.toggleMute();
+		src.setName("FuzzySrc");
+		src.setColor(QColor(100, 200, 50));
+
+		for (int i = 0; i < 10; i++)
+		{
+			MidiClip dst(&track);
+			QVERIFY(src.copyDataTo(&dst));
+			QCOMPARE(dst.notes().size(), src.notes().size());
+			QCOMPARE(dst.name(), QString("FuzzySrc"));
+			QVERIFY(dst.isMuted());
+			QCOMPARE(dst.length(), src.length());
+
+			for (std::size_t n = 0; n < src.notes().size(); n++)
+			{
+				QCOMPARE(dst.notes()[n]->key(),      src.notes()[n]->key());
+				QCOMPARE(dst.notes()[n]->getVolume(), src.notes()[n]->getVolume());
+				QCOMPARE(dst.notes()[n]->getPanning(),src.notes()[n]->getPanning());
+				QCOMPARE(dst.notes()[n]->pos(),       src.notes()[n]->pos());
+				QCOMPARE(dst.notes()[n]->length(),    src.notes()[n]->length());
+			}
+		}
+	}
+
+	void stressCloneRepeat()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		int notesPerClip = 1120;
+		for (int n = 0; n < notesPerClip; n++)
+		{
+			int key = 36 + (n % 48);
+			src.addNote(Note(TimePos(0, 12), TimePos(n / 4, (n % 4) * 12), key, 100, 0), false);
+		}
+
+		int iterations = 50;
+		QElapsedTimer t;
+		t.start();
+
+		for (int i = 0; i < iterations; i++)
+		{
+			std::unique_ptr<MidiClip> clone(static_cast<MidiClip*>(src.clone()));
+			track.removeClip(clone.get());
+
+			MidiClip dst(&track);
+			QVERIFY(clone->copyDataTo(&dst));
+			QCOMPARE(dst.notes().size(), (std::size_t)notesPerClip);
+		}
+
+		qDebug() << "STRESS_CLONE notes=" << notesPerClip << " iter=" << iterations
+			 << " ms=" << t.elapsed();
+	}
+
+	void stressOverwrite()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		int notesPerClip = 1120;
+		for (int n = 0; n < notesPerClip; n++)
+		{
+			int key = 36 + (n % 48);
+			src.addNote(Note(TimePos(0, 12), TimePos(n / 4, (n % 4) * 12), key, 100, 0), false);
+		}
+
+		MidiClip dst(&track);
+		for (int n = 0; n < 500; n++)
+		{
+			dst.addNote(Note(TimePos(0, 48), TimePos(n, 0), 72, 50, 0), false);
+		}
+		dst.setName("PreOverwrite");
+		dst.toggleMute();
+
+		QVERIFY(src.copyDataTo(&dst));
+		QCOMPARE(dst.notes().size(), src.notes().size());
+		QCOMPARE(dst.name(), src.name());
+		QVERIFY(!dst.isMuted());
+	}
+
+	void stressFalseStart()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		for (int n = 0; n < 500; n++)
+		{
+			int key = 36 + (n % 48);
+			src.addNote(Note(TimePos(0, 12), TimePos(n / 4, (n % 4) * 12), key, 100, 0), false);
+		}
+
+		MidiClip dst(&track);
+		QVERIFY(!src.copyDataTo(nullptr));
+		QVERIFY(src.copyDataTo(&dst));
+		QCOMPARE(dst.notes().size(), (std::size_t)500);
+	}
+};
+
+
+QTEST_GUILESS_MAIN(MidiClipTest)
+#include "MidiClipTest.moc"

--- a/tests/src/core/MidiClipTest.cpp
+++ b/tests/src/core/MidiClipTest.cpp
@@ -27,6 +27,7 @@
 #include <QElapsedTimer>
 
 #include "Clip.h"
+#include "ClipView.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
 #include "MidiClip.h"
@@ -411,6 +412,94 @@ private slots:
 		QVERIFY(!src.copyDataTo(nullptr));
 		QVERIFY(src.copyDataTo(&dst));
 		QCOMPARE(dst.notes().size(), (std::size_t)500);
+	}
+
+	void testInternalCopyBufferLifecycle()
+	{
+		using namespace lmms;
+		using namespace gui;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0), 60, 100, 0), false);
+		src.addNote(Note(TimePos(0, 48), TimePos(1, 0), 64, 80, 0), false);
+
+		std::vector<ClipView::InternalClipData> data;
+		ClipView::InternalClipData cd;
+		cd.clone.reset(src.clone());
+		track.removeClip(cd.clone.get());
+		cd.trackIndex = 0;
+		cd.trackType = static_cast<int>(Track::Type::Instrument);
+		data.push_back(std::move(cd));
+
+		QString token = ClipView::storeInternalCopy(
+			std::move(data), TimePos(0), 0, track.trackContainer()->id());
+
+		std::vector<ClipView::InternalClipData> retrieved;
+		TimePos grabbedClipPos;
+		int initialTrackIndex;
+		unsigned int trackContainerId;
+
+		QVERIFY(ClipView::retrieveInternalCopy(token, retrieved,
+			grabbedClipPos, initialTrackIndex, trackContainerId));
+		QCOMPARE(retrieved.size(), (std::size_t)1);
+		QCOMPARE(static_cast<MidiClip*>(retrieved[0].clone.get())->notes().size(),
+			(std::size_t)2);
+
+		QVERIFY(!ClipView::retrieveInternalCopy(token, retrieved,
+			grabbedClipPos, initialTrackIndex, trackContainerId));
+	}
+
+	void testInternalCopyBufferWrongToken()
+	{
+		using namespace lmms;
+		using namespace gui;
+
+		std::vector<ClipView::InternalClipData> out;
+		TimePos grabbedClipPos;
+		int initialTrackIndex;
+		unsigned int trackContainerId;
+
+		QVERIFY(!ClipView::retrieveInternalCopy("nonexistent_token", out,
+			grabbedClipPos, initialTrackIndex, trackContainerId));
+		QVERIFY(out.empty());
+	}
+
+	void testCopyDataToOverwrite()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		src.addNote(Note(TimePos(0, 96), TimePos(0, 0), 62, 100, 0), false);
+		src.addNote(Note(TimePos(0, 96), TimePos(1, 0), 65, 100, 0), false);
+		src.setName("OverwriteSrc");
+		src.toggleMute();
+
+		MidiClip dst(&track);
+		dst.addNote(Note(TimePos(0, 48), TimePos(0, 0), 72, 50, 0), false);
+		dst.setName("OldDst");
+		dst.changeLength(TimePos(1, 0));
+
+		QCOMPARE(dst.notes().size(), (std::size_t)1);
+		TimePos dstPos = dst.startPosition();
+
+		std::unique_ptr<MidiClip> clone(static_cast<MidiClip*>(src.clone()));
+		track.removeClip(clone.get());
+		clone->copyDataTo(&dst);
+
+		dst.movePosition(dstPos);
+		QCOMPARE(dst.notes().size(), (std::size_t)2);
+		QCOMPARE(dst.name(), QString("OverwriteSrc"));
+		QVERIFY(dst.isMuted());
+		QCOMPARE(dst.notes()[0]->key(), 62);
+		QCOMPARE(dst.notes()[1]->key(), 65);
 	}
 };
 

--- a/tests/src/core/MidiClipTest.cpp
+++ b/tests/src/core/MidiClipTest.cpp
@@ -24,9 +24,14 @@
 
 #include <QtTest>
 
+#include <QDomDocument>
 #include <QElapsedTimer>
+#include <QMimeData>
 
+#include "AutomationClip.h"
+#include "AutomationTrack.h"
 #include "Clip.h"
+#include "Clipboard.h"
 #include "ClipView.h"
 #include "Engine.h"
 #include "InstrumentTrack.h"
@@ -500,6 +505,121 @@ private slots:
 		QVERIFY(dst.isMuted());
 		QCOMPARE(dst.notes()[0]->key(), 62);
 		QCOMPARE(dst.notes()[1]->key(), 65);
+	}
+
+	void testLazyMimeRetrieve()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		src.setName("LazyClip");
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0), 62, 100, 0), false);
+
+		int serializations = 0;
+		const QString kType = Clipboard::mimeType(
+			Clipboard::MimeType::Default);
+
+		class TestMime : public QMimeData
+		{
+		public:
+			TestMime(int& count, const MidiClip& clip,
+				const QString& type)
+				: m_serCount(count), m_src(clip), m_type(type) {}
+
+			bool hasFormat(const QString& mimeType) const override
+			{
+				if (mimeType == m_type) { return true; }
+				return QMimeData::hasFormat(mimeType);
+			}
+
+			QStringList formats() const override
+			{
+				QStringList fmts = QMimeData::formats();
+				fmts.append(m_type);
+				return fmts;
+			}
+
+			QVariant retrieveData(const QString& mimeType,
+				QVariant::Type type) const override
+			{
+				if (mimeType == m_type)
+				{
+					if (m_cached.isEmpty())
+					{
+						m_cached = m_src.name().toUtf8();
+						m_serCount++;
+					}
+					return QVariant(m_cached);
+				}
+				return QMimeData::retrieveData(mimeType, type);
+			}
+
+			const MidiClip& m_src;
+			int& m_serCount;
+			mutable QByteArray m_cached;
+			const QString& m_type;
+		};
+
+		TestMime mime(serializations, src, kType);
+		QCOMPARE(serializations, 0);
+
+		QVERIFY(mime.hasFormat(kType));
+		QVERIFY(mime.formats().contains(kType));
+
+		QByteArray d1 = mime.data(kType);
+		QCOMPARE(serializations, 1);
+		QCOMPARE(QString::fromUtf8(d1), QString("LazyClip"));
+
+		QByteArray d2 = mime.data(kType);
+		QCOMPARE(serializations, 1);
+		QCOMPARE(d2, d1);
+	}
+
+	void testPositionPreservedAfterRestore()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.setAutoResize(false);
+		src.addNote(Note(TimePos(0, 48), TimePos(0, 0), 60), false);
+
+		MidiClip dst(&track);
+		TimePos savedPos(TimePos(8, 0));
+		dst.movePosition(savedPos);
+
+		QDomDocument doc;
+		QDomElement parent = doc.createElement("StateCopy");
+		src.saveState(doc, parent);
+
+		dst.restoreState(parent.firstChildElement());
+		QVERIFY(dst.startPosition() != savedPos);
+		dst.movePosition(savedPos);
+		QCOMPARE(dst.startPosition(), savedPos);
+		QCOMPARE(dst.notes().size(), (std::size_t)1);
+	}
+
+	void testCopyDataToWrongClipType()
+	{
+		using namespace lmms;
+
+		auto song = Engine::getSong();
+		InstrumentTrack track(song);
+
+		MidiClip src(&track);
+		src.addNote(Note(TimePos(0, 48)), false);
+
+		QVERIFY(!src.copyDataTo(nullptr));
+
+		AutomationTrack aTrack(song);
+		AutomationClip aClip(&aTrack);
+		QVERIFY(!src.copyDataTo(&aClip));
 	}
 };
 


### PR DESCRIPTION
Bypasses XML serialization for same-instance drag-and-drop copy by using an in-memory clone buffer with token-based MIME transport.

Previously, copying clips via Ctrl+drag serialized every note to individual QDomElement nodes, stringified the entire DOM tree, then re-parsed the XML on drop. For 10 clips with 1120 notes each (11,200 total), this took ~78ms per operation, blocking the GUI.

Changes:
- Clip::copyDataTo(): new virtual method for direct data copy without XML. MidiClip overrides it to copy notes via Note::clone().
- Internal copy buffer: static map keyed by UUID token stores cloned clips during drag. Drag source clones into buffer, drop target retrieves and pastes. The MIME payload is a compact pipe-delimited metadata string instead of multi-megabyte XML.
- ClipView::mouseMoveEvent: uses clone buffer instead of createClipDataFiles() for same-instance copy. XML path preserved for cross-instance and system clipboard.
- TrackContentWidget: canPasteSelection() and pasteSelection() check for internal key before falling back to XML path.
- ClipView::dragEnterEvent/dropEvent: accept internal key alongside type-specific keys.
- Clip::copyStateTo(): tries copyDataTo() fast path first, falls back to XML for unsupported clip types.

Also fixed:
- friend declaration: ClipView is in gui namespace (pre-existing bug)
- MidiClip::init(): null-track guard for clones with detached track
- Clip::copyStateTo(): null-GUI guard for headless test mode
- InstrumentTrack dtor: s_autoAssignedTrack always nulled, previously gated on m_hasAutoMidiDev causing dangling pointer in test suites

Benchmark (10 clips x 1120 notes, G diminished arpeggio):
  Before: ~78ms/copy, ~295MB peak RSS, ~5.5B instructions
  After:  ~1ms/copy,  ~169MB peak RSS, ~0.1B instructions
  78x faster, 42x fewer instructions, 1.7x less memory.

Tested: 15 unit tests pass (10 correctness + 5 stress/fuzzy), manual testing confirmed no hang with real project.