### PR TITLE
Allow Ctrl-Drag Copying Tracks via TrackGrip

### DIFF
--- a/include/TrackGrip.h
+++ b/include/TrackGrip.h
@@ -42,7 +42,7 @@ class TrackGrip : public QWidget
 {
 	Q_OBJECT
 public:
-	TrackGrip(TrackView* trackView, QWidget* parent = 0);
+	TrackGrip(TrackView* trackView, QWidget* parent = nullptr);
 	~TrackGrip() override = default;
 
 signals:

--- a/include/TrackGrip.h
+++ b/include/TrackGrip.h
@@ -33,16 +33,16 @@ class QPixmap;
 namespace lmms
 {
 
-class Track;
-
 namespace gui
 {
+
+class TrackView;
 
 class TrackGrip : public QWidget
 {
 	Q_OBJECT
 public:
-	TrackGrip(Track* track, QWidget* parent = 0);
+	TrackGrip(TrackView* trackView, QWidget* parent = 0);
 	~TrackGrip() override = default;
 
 signals:
@@ -55,7 +55,7 @@ protected:
 	void paintEvent(QPaintEvent*) override;
 
 private:
-	Track* m_track = nullptr;
+	TrackView* m_trackView = nullptr;
 	bool m_isGrabbed = false;
 	static QPixmap* s_grabbedPixmap;
 	static QPixmap* s_releasedPixmap;

--- a/include/TrackOperationsWidget.h
+++ b/include/TrackOperationsWidget.h
@@ -46,7 +46,6 @@ public:
 	TrackGrip* getTrackGrip() const { return m_trackGrip; }
 
 protected:
-	void mousePressEvent( QMouseEvent * me ) override;
 	void paintEvent( QPaintEvent * pe ) override;
 	bool confirmRemoval();
 

--- a/src/gui/tracks/TrackGrip.cpp
+++ b/src/gui/tracks/TrackGrip.cpp
@@ -24,8 +24,12 @@
 
 #include "TrackGrip.h"
 
+#include "DataFile.h"
 #include "embed.h"
+#include "KeyboardShortcuts.h"
+#include "StringPairDrag.h"
 #include "Track.h"
+#include "TrackView.h"
 
 #include <QPainter>
 #include <QPixmap>
@@ -40,9 +44,9 @@ QPixmap* TrackGrip::s_releasedPixmap = nullptr;
 
 constexpr int c_margin = 2;
 
-TrackGrip::TrackGrip(Track* track, QWidget* parent) :
+TrackGrip::TrackGrip(TrackView* trackView, QWidget* parent) :
 	QWidget(parent),
-	m_track(track)
+	m_trackView(trackView)
 {
 	if (!s_grabbedPixmap)
 	{
@@ -63,14 +67,24 @@ TrackGrip::TrackGrip(Track* track, QWidget* parent) :
 
 void TrackGrip::mousePressEvent(QMouseEvent* m)
 {
-	m->accept();
+	// Allow the user to Ctrl-drag copy the track if it is not a pattern track
+	if (m->button() == Qt::LeftButton && m->modifiers() & KBD_COPY_MODIFIER && m_trackView->getTrack()->type() != Track::Type::Pattern)
+	{
+		m->accept();
+		DataFile dataFile(DataFile::Type::DragNDropData);
+		m_trackView->getTrack()->saveState(dataFile, dataFile.content());
+		new StringPairDrag(QString("track_%1").arg(static_cast<int>(m_trackView->getTrack()->type())), dataFile.toString(), m_trackView->getTrackSettingsWidget()->grab(), this);
+	}
+	else
+	{
+		m->accept();
 
-	m_isGrabbed = true;
-	setCursor(Qt::ClosedHandCursor);
+		m_isGrabbed = true;
+		setCursor(Qt::ClosedHandCursor);
 
-	emit grabbed();
-
-	update();
+		emit grabbed();
+		update();
+	}
 }
 
 void TrackGrip::mouseReleaseEvent(QMouseEvent* m)
@@ -90,8 +104,8 @@ void TrackGrip::paintEvent(QPaintEvent*)
 	QPainter p(this);
 
 	// Check if the color of the track should be used for the background
-	const auto color = m_track->color();
-	const auto muted = m_track->getMutedModel()->value();
+	const auto color = m_trackView->getTrack()->color();
+	const auto muted = m_trackView->getTrack()->getMutedModel()->value();
 
 	if (color.has_value() && !muted) 
 	{

--- a/src/gui/tracks/TrackGrip.cpp
+++ b/src/gui/tracks/TrackGrip.cpp
@@ -68,12 +68,19 @@ TrackGrip::TrackGrip(TrackView* trackView, QWidget* parent) :
 void TrackGrip::mousePressEvent(QMouseEvent* m)
 {
 	// Allow the user to Ctrl-drag copy the track if it is not a pattern track
-	if (m->button() == Qt::LeftButton && m->modifiers() & KBD_COPY_MODIFIER && m_trackView->getTrack()->type() != Track::Type::Pattern)
+	if (m->button() == Qt::LeftButton
+		&& m->modifiers() & KBD_COPY_MODIFIER
+		&& m_trackView->getTrack()->type() != Track::Type::Pattern)
 	{
 		m->accept();
 		DataFile dataFile(DataFile::Type::DragNDropData);
 		m_trackView->getTrack()->saveState(dataFile, dataFile.content());
-		new StringPairDrag(QString("track_%1").arg(static_cast<int>(m_trackView->getTrack()->type())), dataFile.toString(), m_trackView->getTrackSettingsWidget()->grab(), this);
+		new StringPairDrag(
+			QString("track_%1").arg(static_cast<int>(m_trackView->getTrack()->type())),
+			dataFile.toString(),
+			m_trackView->getTrackSettingsWidget()->grab(),
+			this
+		);
 	}
 	else
 	{

--- a/src/gui/tracks/TrackOperationsWidget.cpp
+++ b/src/gui/tracks/TrackOperationsWidget.cpp
@@ -37,7 +37,6 @@
 #include "AutomationTrackView.h"
 #include "ColorChooser.h"
 #include "ConfigManager.h"
-#include "DataFile.h"
 #include "embed.h"
 #include "Engine.h"
 #include "InstrumentTrackView.h"
@@ -77,7 +76,7 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 	layout->setSpacing(0);
 	layout->setAlignment(Qt::AlignTop);
 
-	m_trackGrip = new TrackGrip(m_trackView->getTrack(), this);
+	m_trackGrip = new TrackGrip(m_trackView, this);
 	layout->addWidget(m_trackGrip);
 
 	// This widget holds the gear icon and the mute and solo
@@ -119,35 +118,6 @@ TrackOperationsWidget::TrackOperationsWidget( TrackView * parent ) :
 	connect(m_trackView->getTrack(), SIGNAL(colorChanged()), this, SLOT(update()));
 }
 
-
-/*! \brief Respond to trackOperationsWidget mouse events
- *
- *  If it's the left mouse button, and Ctrl is held down, and we're
- *  not a Pattern Editor track, then start a new drag event to
- *  copy this track.
- *
- *  Otherwise, ignore all other events.
- *
- *  \param me The mouse event to respond to.
- */
-void TrackOperationsWidget::mousePressEvent( QMouseEvent * me )
-{
-	if (me->button() == Qt::LeftButton && me->modifiers() & KBD_COPY_MODIFIER &&
-		m_trackView->getTrack()->type() != Track::Type::Pattern)
-	{
-		DataFile dataFile( DataFile::Type::DragNDropData );
-		m_trackView->getTrack()->saveState( dataFile, dataFile.content() );
-		new StringPairDrag( QString( "track_%1" ).arg(
-					static_cast<int>(m_trackView->getTrack()->type()) ),
-			dataFile.toString(), m_trackView->getTrackSettingsWidget()->grab(),
-									this );
-	}
-	else if( me->button() == Qt::LeftButton )
-	{
-		// track-widget (parent-widget) initiates track-move
-		me->ignore();
-	}
-}
 
 
 /*!


### PR DESCRIPTION
This PR aims to address #7766 by making it possible to ctrl-drag on the TrackGrip (the patterned part on the very left edge of a track), to copy them, rather than having to carefully aim your mouse around the large settings/mute/solo buttons to copy a track.

https://github.com/user-attachments/assets/5e6d5e16-e9f2-467a-a87b-c8c31e46fd54

I made the constructor of `TrackGrip` take in the `TrackView` rather than the `Track`, since it is necessary to generate the drag preview image of the track. I think that is reasonable, since `TrackGrip` is in the GUI.