### PR TITLE
Revert Knife Tool Auto-Selecting Short Ends

### DIFF
--- a/src/tracks/MidiClip.cpp
+++ b/src/tracks/MidiClip.cpp
@@ -386,10 +386,6 @@ void MidiClip::splitNotesAlongLine(const NoteVector notes, TimePos pos1, int key
 			newNote2.setPos(keyIntercept);
 			newNote2.setLength(note->endPos() - keyIntercept);
 
-			// Select the short ends
-			if (newNote1.length() < newNote2.length()) { newNote1.setSelected(true); }
-			else { newNote2.setSelected(true); }
-
 			if (deleteShortEnds)
 			{
 				addNote(newNote1.length() >= newNote2.length() ? newNote1 : newNote2, false);


### PR DESCRIPTION
When #7953 was merged, the behavior of the knife tool was changed such that the short ends of the newly cut notes would automatically be selected. This was intended to make it easier to quickly cut off a section of a chord and drag it somewhere.

However, when only some notes are selected, the knife tool will only cut those notes. Imagine if a user is trying to shape the onset of a chord by making a few trims. After the first cut, the short ends will be selected, which means the user can't cut any of the other notes. The user would need to exit knife mode, unselect the notes, enter knife mode, and then cut again. A user on discord expressed dissatisfaction with the current state of the knife tool, which is why made this PR.