### PR TITLE
Fix crashes on project load with MIDI auto assignment feature

### DIFF
--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -1091,6 +1091,7 @@ void InstrumentTrack::autoAssignMidiDevice(bool assign)
 	if ( Engine::audioEngine()->midiClient()->isRaw() && device != "none" )
 	{
 		m_midiPort.setReadable( assign );
+		m_hasAutoMidiDev = assign;
 		return;
 	}
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -205,9 +205,12 @@ float InstrumentTrack::baseFreq() const
 InstrumentTrack::~InstrumentTrack()
 {
 	// De-assign midi device
-	if (m_hasAutoMidiDev)
+	if (s_autoAssignedTrack == this)
 	{
-		autoAssignMidiDevice(false);
+		if (m_hasAutoMidiDev)
+		{
+			autoAssignMidiDevice(false);
+		}
 		s_autoAssignedTrack = nullptr;
 	}
 


### PR DESCRIPTION
Fixes use-after-free when at least one of these are true while automatic MIDI assignment is active:
- Using a raw MIDI backend
- Target device set to `none` or a non-existent device

Fixes #8434.