### PR TITLE
Persist instrument and effect window state

### DIFF
--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -64,6 +64,7 @@ public:
 	void moveDown( Effect * _effect );
 	void moveUp( Effect * _effect );
 	bool processAudioBuffer(AudioBuffer& buffer);
+	bool hasVisibleEffectViewState() const;
 
 	void clear();
 

--- a/include/EffectView.h
+++ b/include/EffectView.h
@@ -29,6 +29,7 @@
 #include "AutomatableModel.h"
 #include "PluginView.h"
 #include "Effect.h"
+#include "SerializingObject.h"
 
 class QGraphicsOpacityEffect;
 class QGroupBox;
@@ -45,7 +46,7 @@ class LedCheckBox;
 class TempoSyncKnob;
 
 
-class EffectView : public PluginView
+class EffectView : public PluginView, public SerializingObjectHook
 {
 	Q_OBJECT
 public:
@@ -81,6 +82,8 @@ signals:
 	void deletedPlugin(EffectView* view);
 
 protected:
+	void saveSettings(QDomDocument& doc, QDomElement& element) override;
+	void loadSettings(const QDomElement& element) override;
 	void contextMenuEvent( QContextMenuEvent * _me ) override;
 	void paintEvent( QPaintEvent * _pe ) override;
 	void modelChanged() override;

--- a/include/SerializingObject.h
+++ b/include/SerializingObject.h
@@ -25,7 +25,9 @@
 #ifndef LMMS_SERIALIZING_OBJECT_H
 #define LMMS_SERIALIZING_OBJECT_H
 
+#include <QMap>
 #include <QString>
+#include <QStringList>
 
 #include "lmms_export.h"
 
@@ -54,6 +56,8 @@ public:
 	virtual QString nodeName() const = 0;
 
 	void setHook( SerializingObjectHook * _hook );
+	/** Returns a hook-owned attribute restored before the hook was available. */
+	QString deferredHookAttribute(const QString& name) const;
 
 	SerializingObjectHook* hook()
 	{
@@ -62,6 +66,9 @@ public:
 
 
 protected:
+	/** Defers these serialized attributes until a late-created hook attaches. */
+	void setHookAttributeNames(const QStringList& names);
+
 	// to be implemented by sub-objects
 	virtual void saveSettings( QDomDocument& doc, QDomElement& element ) = 0;
 	virtual void loadSettings( const QDomElement& element ) = 0;
@@ -69,6 +76,8 @@ protected:
 
 private:
 	SerializingObjectHook * m_hook;
+	QStringList m_hookAttributeNames;
+	QMap<QString, QString> m_deferredHookAttributes;
 
 } ;
 

--- a/src/core/Effect.cpp
+++ b/src/core/Effect.cpp
@@ -51,6 +51,7 @@ Effect::Effect( const Plugin::Descriptor * _desc,
 	m_autoQuitModel( 1.0f, 1.0f, 8000.0f, 100.0f, 1.0f, this, tr( "Decay" ) ),
 	m_autoQuitEnabled(ConfigManager::inst()->value("ui", "disableautoquit", "1").toInt() == 0)
 {
+	setHookAttributeNames({"visible", "maximized", "x", "y", "width", "height"});
 	m_wetDryModel.setCenterValue(0);
 
 	// Call the virtual method onEnabledChanged so that effects can react to changes,

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -25,6 +25,7 @@
 
 #include "EffectChain.h"
 
+#include <algorithm>
 #include <QDomElement>
 #include <cassert>
 
@@ -179,6 +180,16 @@ void EffectChain::moveUp( Effect * _effect )
 		assert(it != m_effects.end());
 		std::swap(*std::prev(it), *it);
 	}
+}
+
+
+
+
+bool EffectChain::hasVisibleEffectViewState() const
+{
+	return std::any_of(m_effects.cbegin(), m_effects.cend(), [](const Effect* effect) {
+		return effect->deferredHookAttribute("visible").toInt();
+	});
 }
 
 

--- a/src/core/SerializingObject.cpp
+++ b/src/core/SerializingObject.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include <QDomDocument>
 #include <QDomElement>
 
 #include "SerializingObject.h"
@@ -59,6 +60,13 @@ QDomElement SerializingObject::saveState( QDomDocument& doc, QDomElement& parent
 	{
 		hook()->saveSettings( doc, element );
 	}
+	else
+	{
+		for (auto it = m_deferredHookAttributes.cbegin(); it != m_deferredHookAttributes.cend(); ++it)
+		{
+			element.setAttribute(it.key(), it.value());
+		}
+	}
 
 	return element;
 }
@@ -69,10 +77,21 @@ QDomElement SerializingObject::saveState( QDomDocument& doc, QDomElement& parent
 void SerializingObject::restoreState( const QDomElement& element )
 {
 	loadSettings( element );
+	m_deferredHookAttributes.clear();
 
 	if( hook() )
 	{
 		hook()->loadSettings( element );
+	}
+	else
+	{
+		for (const auto& name : m_hookAttributeNames)
+		{
+			if (element.hasAttribute(name))
+			{
+				m_deferredHookAttributes.insert(name, element.attribute(name));
+			}
+		}
 	}
 }
 
@@ -91,7 +110,36 @@ void SerializingObject::setHook( SerializingObjectHook* hook )
 	if( m_hook )
 	{
 		m_hook->m_hookedIn = this;
+
+		if (!m_deferredHookAttributes.isEmpty())
+		{
+			QDomDocument doc;
+			QDomElement element = doc.createElement(nodeName());
+			doc.appendChild(element);
+			for (auto it = m_deferredHookAttributes.cbegin(); it != m_deferredHookAttributes.cend(); ++it)
+			{
+				element.setAttribute(it.key(), it.value());
+			}
+			m_deferredHookAttributes.clear();
+			m_hook->loadSettings(element);
+		}
 	}
+}
+
+
+
+
+QString SerializingObject::deferredHookAttribute(const QString& name) const
+{
+	return m_deferredHookAttributes.value(name);
+}
+
+
+
+
+void SerializingObject::setHookAttributeNames(const QStringList& names)
+{
+	m_hookAttributeNames = names;
 }
 
 

--- a/src/gui/EffectView.cpp
+++ b/src/gui/EffectView.cpp
@@ -99,6 +99,7 @@ EffectView::EffectView( Effect * _model, QWidget * _parent ) :
 	m_opacityEffect = new QGraphicsOpacityEffect(this);
 	m_opacityEffect->setOpacity(1);
 	setGraphicsEffect(m_opacityEffect);
+	effect()->setHook(this);
 
 	//move above vst effect view creation
 	//setModel( _model );
@@ -131,6 +132,24 @@ void EffectView::editControls()
 			effect()->controls()->setViewVisible( false );
 		}
 	}
+}
+
+
+
+
+void EffectView::saveSettings(QDomDocument&, QDomElement& element)
+{
+	if (m_subWindow) { MainWindow::saveWidgetState(m_subWindow, element); }
+}
+
+
+
+
+void EffectView::loadSettings(const QDomElement& element)
+{
+	if (!m_subWindow) { return; }
+	MainWindow::restoreWidgetState(m_subWindow, element);
+	effect()->controls()->setViewVisible(m_controlView->isVisible());
 }
 
 

--- a/src/gui/SampleTrackWindow.cpp
+++ b/src/gui/SampleTrackWindow.cpp
@@ -167,6 +167,7 @@ SampleTrackWindow::SampleTrackWindow(SampleTrackView* stv)
 
 	setWindowIcon(embed::getIconPixmap("sample_track"));
 	subWin->hide();
+	m_track->setHook(this);
 }
 
 

--- a/src/gui/instrument/InstrumentTrackWindow.cpp
+++ b/src/gui/instrument/InstrumentTrackWindow.cpp
@@ -293,6 +293,7 @@ InstrumentTrackWindow::InstrumentTrackWindow( InstrumentTrackView * _itv ) :
 	updateSubWindow();
 
 	subWin->hide();
+	m_track->setHook(this);
 }
 
 void InstrumentTrackWindow::resizeEvent(QResizeEvent * event) {

--- a/src/gui/tracks/InstrumentTrackView.cpp
+++ b/src/gui/tracks/InstrumentTrackView.cpp
@@ -39,6 +39,7 @@
 #include "AudioEngine.h"
 #include "ConfigManager.h"
 #include "Engine.h"
+#include "EffectChain.h"
 #include "FadeButton.h"
 #include "GuiApplication.h"
 #include "Instrument.h"
@@ -165,6 +166,11 @@ InstrumentTrackView::InstrumentTrackView( InstrumentTrack * _it, TrackContainerV
 	setModel( _it );
 
 	onInstrumentChanged();
+	if (_it->deferredHookAttribute("visible").toInt()
+		|| _it->audioBusHandle()->effects()->hasVisibleEffectViewState())
+	{
+		getInstrumentTrackWindow();
+	}
 }
 
 

--- a/src/gui/tracks/SampleTrackView.cpp
+++ b/src/gui/tracks/SampleTrackView.cpp
@@ -101,7 +101,6 @@ SampleTrackView::SampleTrackView( SampleTrack * _t, TrackContainerView* tcv ) :
 	setModel( _t );
 
 	m_window = new SampleTrackWindow(this);
-	m_window->toggleVisibility(false);
 }
 
 

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -72,6 +72,7 @@ InstrumentTrack::InstrumentTrack(TrackContainer* tc) :
 	m_piano(this),
 	m_microtuner()
 {
+	setHookAttributeNames({"tab", "visible", "maximized", "x", "y", "width", "height"});
 	m_pitchModel.setCenterValue( 0 );
 	m_pitchModel.setStrictStepSize(true);
 	m_panningModel.setCenterValue( DefaultPanning );

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -52,6 +52,7 @@ SampleTrack::SampleTrack(TrackContainer* tc) :
 	m_audioBusHandle(tr("Sample track"), true, &m_volumeModel, &m_panningModel, &m_mutedModel),
 	m_isPlaying(false)
 {
+	setHookAttributeNames({"visible", "maximized", "x", "y", "width", "height"});
 	setName(tr("Sample track"));
 	m_panningModel.setCenterValue(DefaultPanning);
 	m_mixerChannelModel.setRange(0, Engine::mixer()->numChannels()-1, 1);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(LMMS_TESTS
 	src/core/MathTest.cpp
 	src/core/ProjectVersionTest.cpp
 	src/core/RelativePathsTest.cpp
+	src/core/SerializingObjectTest.cpp
 	src/core/TimelineTest.cpp
 	src/tracks/AutomationTrackTest.cpp
 )

--- a/tests/src/core/SerializingObjectTest.cpp
+++ b/tests/src/core/SerializingObjectTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Ari Bradshaw
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ */
+
+#include "SerializingObject.h"
+
+#include <QDomDocument>
+#include <QtTest>
+
+namespace {
+
+class TestObject : public lmms::SerializingObject
+{
+public:
+	TestObject() { setHookAttributeNames({"visible", "x"}); }
+
+	QString nodeName() const override { return "test"; }
+	void setValue(int value) { m_value = value; }
+	int value() const { return m_value; }
+
+protected:
+	void saveSettings(QDomDocument&, QDomElement& element) override { element.setAttribute("value", m_value); }
+	void loadSettings(const QDomElement& element) override { m_value = element.attribute("value").toInt(); }
+
+private:
+	int m_value = 0;
+};
+
+class TestHook : public lmms::SerializingObjectHook
+{
+public:
+	void saveSettings(QDomDocument&, QDomElement& element) override
+	{
+		element.setAttribute("visible", visible);
+		element.setAttribute("x", x);
+	}
+
+	void loadSettings(const QDomElement& element) override
+	{
+		visible = element.attribute("visible").toInt();
+		x = element.attribute("x").toInt();
+		loaded = true;
+	}
+
+	int visible = 0;
+	int x = 0;
+	bool loaded = false;
+};
+
+} // namespace
+
+class SerializingObjectTest : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void restoresAttributesWhenHookAttaches()
+	{
+		QDomDocument input;
+		QVERIFY(input.setContent("<test value=\"7\" visible=\"1\" x=\"42\" ignored=\"8\"/>"));
+		TestObject object;
+		object.restoreState(input.documentElement());
+
+		QCOMPARE(object.value(), 7);
+		QCOMPARE(object.deferredHookAttribute("visible"), QString{"1"});
+		QCOMPARE(object.deferredHookAttribute("ignored"), QString{});
+
+		TestHook hook;
+		object.setHook(&hook);
+		QVERIFY(hook.loaded);
+		QCOMPARE(hook.visible, 1);
+		QCOMPARE(hook.x, 42);
+		QCOMPARE(object.deferredHookAttribute("visible"), QString{});
+	}
+
+	void savesDeferredAttributesWithoutAHook()
+	{
+		QDomDocument input;
+		QVERIFY(input.setContent("<test value=\"7\" visible=\"1\" x=\"42\" ignored=\"8\"/>"));
+		TestObject object;
+		object.restoreState(input.documentElement());
+		object.setValue(9);
+
+		QDomDocument output;
+		QDomElement parent = output.createElement("parent");
+		output.appendChild(parent);
+		const QDomElement saved = object.saveState(output, parent);
+
+		QCOMPARE(saved.attribute("value").toInt(), 9);
+		QCOMPARE(saved.attribute("visible").toInt(), 1);
+		QCOMPARE(saved.attribute("x").toInt(), 42);
+		QVERIFY(!saved.hasAttribute("ignored"));
+	}
+};
+
+QTEST_GUILESS_MAIN(SerializingObjectTest)
+#include "SerializingObjectTest.moc"


### PR DESCRIPTION
## Summary

- persist instrument, sample-track, and effect-control window state in project data
- bridge saved attributes until lazily created GUI hooks are available during project restoration
- avoid eagerly creating hidden instrument windows unless saved state or a child effect window requires them
- add focused coverage for immediate and deferred serialization hooks

Fixes #7842.

## Implementation notes

Core track and effect models are restored before their lazy GUI counterparts exist. The change adds a small deferred attribute bridge to `SerializingObject`, connects the existing instrument and sample-track window hooks, and adds save/load hooks for effect-control windows.

## Validation

- reduced LMMS CMake configuration completed on Windows with MinGW GCC 15.2 and Qt 6.11
- the `SerializingObjectTest` target compiled in a 266-step build, including all modified GUI and track sources
- `SerializingObjectTest`: 4 passed, 0 failed
- `git diff --check`: clean

## Validation limits

- the full LMMS test suite and multi-monitor window-restoration behavior were not manually exercised