### PR TITLE
Add a one-click copy action for About dialog version info

### DIFF
--- a/src/gui/modals/AboutDialog.cpp
+++ b/src/gui/modals/AboutDialog.cpp
@@ -28,6 +28,9 @@
 #include "embed.h"
 #include "versioninfo.h"
 
+#include <QClipboard>
+#include <QGuiApplication>
+
 
 namespace lmms::gui
 {
@@ -49,7 +52,11 @@ AboutDialog::AboutDialog(QWidget* parent) :
 					arg( LMMS_BUILDCONF_COMPILER_VERSION ) );
 	versionLabel->setTextInteractionFlags(
 					versionLabel->textInteractionFlags() |
-					Qt::TextSelectableByMouse );
+					Qt::TextSelectableByMouse |
+					Qt::TextSelectableByKeyboard );
+	connect(copyVersionButton, &QPushButton::clicked, this, [this] {
+		QGuiApplication::clipboard()->setText(versionLabel->text());
+	});
 
 	copyrightLabel->setText( copyrightLabel->text().
 					arg( LMMS_PROJECT_COPYRIGHT ) );

--- a/src/gui/modals/about_dialog.ui
+++ b/src/gui/modals/about_dialog.ui
@@ -51,6 +51,16 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="copyVersionButton">
+         <property name="toolTip">
+          <string>Copy version information to the clipboard</string>
+         </property>
+         <property name="text">
+          <string>Copy version info</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
## Summary
- Add a clearly labeled Copy version info button to the About dialog.
- Copy the rendered version/build details directly to the system clipboard.
- Allow keyboard selection of the existing version label as well as mouse selection.

## Verification
- about_dialog.ui parsed successfully as XML.
- git diff --check passed.
- CMake configure reached dependency discovery but could not continue because Qt 5.15 development files are not installed in this environment.

Fixes #7464.