### PR TITLE
Fix clip pasting into the pattern editor

### DIFF
--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -48,6 +48,7 @@
 #include "SongEditor.h"
 #include "StringPairDrag.h"
 #include "TextFloat.h"
+#include "Track.h"
 #include "TrackContainer.h"
 #include "TrackContainerView.h"
 #include "TrackView.h"
@@ -1238,8 +1239,14 @@ void ClipView::paste()
 
 	TrackContentWidget *tcw = getTrackView()->getTrackContentWidget();
 
-	if( tcw->pasteSelection( clipPos, getMimeData() ) )
+	if (tcw->pasteSelection(clipPos, getMimeData()))
 	{
+		Track* t = m_trackView->getTrack();
+		if (t->trackContainer() == Engine::patternStore())
+		{
+			// We swap index with the new clip so it is located in the rigth pattern
+			t->swapPositionOfClips(Engine::patternStore()->currentPattern(), t->numOfClips() - 1);
+		}
 		// If we succeed on the paste we delete the Clip we pasted on
 		remove();
 	}


### PR DESCRIPTION
fix #8511 

The implementation of clip pasting onto an other clip follow these steps:
- A new clip is created, sharing the same start position as the targeted clip.
- The content of the clipboard is unserialized into the newly created clip.
- The targeted clip, now replaced with the new one, is deleted. 
_(see: `ClipView::paste` & `TrackContentWidget::pasteSelection`)_

This have for consequence to change the index of clips inside the vector `Track::m_clips` : the clip we pasted into became the last element of the vector and all the elements that were after it were displaced as well.
**The issue is** that tracks living in the `PatternStore` (the track container of the pattern editor), relies on the index of clips in `Track::m_clips` to know which clip correspond to which pattern, hence the bug described in #8511.

This PR simply swap the positions of the targeted clip and its replacement to avoid this issue.