### PR TITLE
Fix inconsistent/mangled attribute order on save for .mmp files

### DIFF
--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -1216,6 +1216,13 @@ bool Song::saveProjectFile(const QString & filename, bool withResources)
 {
 	using gui::getGUI;
 
+	// ensure property order in file is consistent across saves
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
+	qSetGlobalQHashSeed(0);
+#else
+	QHashSeed::setDeterministicGlobalSeed();
+#endif
+
 	DataFile dataFile( DataFile::Type::SongProject );
 	m_savingProject = true;
 
@@ -1243,7 +1250,16 @@ bool Song::saveProjectFile(const QString & filename, bool withResources)
 
 	m_savingProject = false;
 
-	return dataFile.writeFile(filename, withResources);
+	bool writeStatus = dataFile.writeFile(filename, withResources);
+
+	// revert to a randomized global seed for Qt
+#if QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
+	qSetGlobalQHashSeed(-1);
+#else
+	QHashSeed::resetRandomGlobalSeed();
+#endif
+
+	return writeStatus;
 }
 
 


### PR DESCRIPTION
This fixes #8439.

Due to how Qt works internally, the attributes for each XML tag/element are randomized every time you open a project and save it.  This detracts from the usefulness of `.mmp` files, as it makes _every_ tag different each time you might need to open the file to fix/change things manually.  It also makes the file way less useful in version control, file history, and diffs (which is a relatively powerful untapped use-case for `.mmp` files imo).

In the original issue, I had submitted it as an enhancement request, but I think it's more accurate to classify it as a **bug report**, as it certainly wasn't intentional and is due to something Qt does internally, not LMMS; I'd reckon it just slipped under the radar.  Accordingly, I decided to implement the simple fix I had proposed in said issue and create this PR.