### PR TITLE
Fix `CONTRIBUTORS` file generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,18 +771,37 @@ LIST(SORT LMMS_INCLUDES)
 # Get list of all committers from git history, ordered by number of commits.
 # The CONTRIBUTORS file is used by AboutDialog. This information can be provided
 # with -DCONTRIBUTORS=/path/to/CONTRIBUTORS instead. For instance, to generate
-# this file for version 1.1.3, the command is:
-# 	git shortlog -sne v1.1.3 | cut -c8-
-FIND_PACKAGE(Git)
-IF(GIT_FOUND AND NOT CONTRIBUTORS)
-	SET(CONTRIBUTORS "${CMAKE_BINARY_DIR}/CONTRIBUTORS")
-	EXECUTE_PROCESS(
-		COMMAND "${GIT_EXECUTABLE}" shortlog -sne
-		COMMAND cut -c8-
-		OUTPUT_FILE "${CONTRIBUTORS}"
-		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-		TIMEOUT 1)
-ENDIF()
+# this file for version 1.2.2, the command is:
+#   git shortlog -sne v1.2.2 | cut -c8-
+if(NOT CONTRIBUTORS)
+	set(CONTRIBUTORS "${CMAKE_BINARY_DIR}/CONTRIBUTORS")
+	find_package(Git)
+	if(Git_FOUND)
+		# See https://stackoverflow.com/a/73086566/8704745
+		message(STATUS "Using Git to generate the CONTRIBUTORS file")
+		execute_process(
+			COMMAND "${GIT_EXECUTABLE}" log
+			COMMAND "${GIT_EXECUTABLE}" shortlog -sne
+			OUTPUT_VARIABLE _contributors
+			WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+			RESULT_VARIABLE _result
+			ERROR_VARIABLE _error
+			TIMEOUT 5
+		)
+		if(_result EQUAL 0)
+			string(REGEX REPLACE "[0-9\t ]+([^\r\n]+)" "\\1" _contributors "${_contributors}")
+			file(WRITE "${CONTRIBUTORS}" "${_contributors}")
+		else()
+			message(WARNING "Failed to generate the CONTRIBUTORS file, so copying doc/CONTRIBUTORS instead\n${_error}")
+			file(COPY "${CMAKE_SOURCE_DIR}/doc/CONTRIBUTORS" DESTINATION "${CMAKE_BINARY_DIR}")
+		endif()
+	else()
+		message(WARNING "Git was not found, so we'll copy doc/CONTRIBUTORS instead of generating it")
+		file(COPY "${CMAKE_SOURCE_DIR}/doc/CONTRIBUTORS" DESTINATION "${CMAKE_BINARY_DIR}")
+	endif()
+else()
+	message(STATUS "A CONTRIBUTORS file was provided, so we'll use that instead of generating it")
+endif()
 
 # we somehow have to make LMMS-binary depend on MOC-files
 ADD_FILE_DEPENDENCIES("${CMAKE_BINARY_DIR}/lmmsconfig.h")

--- a/cmake/modules/VersionInfo.cmake
+++ b/cmake/modules/VersionInfo.cmake
@@ -1,5 +1,5 @@
 FIND_PACKAGE(Git)
-IF(GIT_FOUND AND NOT FORCE_VERSION)
+IF(Git_FOUND AND NOT FORCE_VERSION)
 	SET(MAJOR_VERSION 0)
 	SET(MINOR_VERSION 0)
 	SET(PATCH_VERSION 0)
@@ -75,7 +75,7 @@ IF(GIT_FOUND AND NOT FORCE_VERSION)
 		LIST(GET TAG_LIST 1 VERSION_STAGE)
 		LIST(GET TAG_LIST 2 EXTRA_COMMITS)
 		# Prefer PR hash from above if present
-        if(NOT COMMIT_HASH)
+		if(NOT COMMIT_HASH)
 			list(GET TAG_LIST 3 COMMIT_HASH)
 			# Mimic github's hash style
 			string(SUBSTRING "${COMMIT_HASH}" 1 7 COMMIT_HASH)
@@ -120,7 +120,7 @@ ELSEIF(FORCE_VERSION)
 	ENDIF()
 
 	SET(VERSION             "${FORCE_VERSION}")
-ELSEIF(GIT_FOUND)
+ELSEIF(Git_FOUND)
 	MESSAGE(
 "Could not get project version.  Using release info from /CMakeLists.txt"
 	)
@@ -139,7 +139,7 @@ MESSAGE("\n"
 	"*   Release version           : ${VERSION_RELEASE}\n"
 	"*   Stage version             : ${VERSION_STAGE}\n"
 	"*   Build version             : ${VERSION_BUILD}\n"
-        "*\n\n"
+	"*\n\n"
 	"Optional Version Usage:\n"
 	"--------------------------\n"
 	"*   Override version:           -DFORCE_VERSION=x.x.x-x\n"

--- a/src/gui/embed.cpp
+++ b/src/gui/embed.cpp
@@ -125,7 +125,20 @@ auto getIconPixmap(std::string_view name, int width, int height, const char* con
 auto getText(std::string_view name) -> QString
 {
 	const auto resource = QResource{":/" + QString::fromUtf8(name.data(), name.size())};
-	return QString::fromUtf8(resource.uncompressedData());
+	if (!resource.isValid())
+	{
+		qWarning().nospace() << "Error loading text resource '"
+			<< QString::fromUtf8(name.data(), name.size()) << "'";
+		return {};
+	}
+	const auto data = resource.uncompressedData();
+	if (data.isNull())
+	{
+		qWarning().nospace() << "Error reading text resource '"
+			<< QString::fromUtf8(name.data(), name.size()) << "'";
+		return {};
+	}
+	return QString::fromUtf8(data);
 }
 
 } // namespace lmms::embed


### PR DESCRIPTION
The `CONTRIBUTORS` file generation step has issues:
- It doesn't work as intended on GitHub Actions due to [this quirk](https://stackoverflow.com/a/73086566/8704745) of `git shortlog`, causing the "Involved" tab of the About dialog to be empty for nightly builds.
- It assumes the existence of the `cut` command from Linux, causing silent errors on other platforms
- It uses the deprecated `GIT_FOUND` variable rather than `Git_FOUND`

This PR fixes the `git shortlog` call and converts the `cut` command usage to pure CMake, fixing the About dialog's "Involved" tab on all platforms.

I also improved the error handling in `embed::getText()` for good measure.