### PR TITLE
Fix the default frames per audio buffer

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -70,7 +70,7 @@ static thread_local bool s_renderingThread = false;
 AudioEngine::AudioEngine(bool renderOnly)
 	: m_renderOnly(renderOnly)
 	, m_framesPerAudioBuffer(std::clamp(
-		  static_cast<f_cnt_t>(ConfigManager::inst()->value("audioengine", "framesperaudiobuffer").toULongLong()),
+		  static_cast<f_cnt_t>(ConfigManager::inst()->value("audioengine", "framesperaudiobuffer", "256").toUInt()),
 		  MINIMUM_BUFFER_SIZE, MAXIMUM_BUFFER_SIZE))
 	, m_framesPerPeriod(std::min(m_framesPerAudioBuffer, DEFAULT_BUFFER_SIZE))
 	, m_baseSampleRate(

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -70,11 +70,12 @@ static thread_local bool s_renderingThread = false;
 AudioEngine::AudioEngine(bool renderOnly)
 	: m_renderOnly(renderOnly)
 	, m_framesPerAudioBuffer(std::clamp(
-		  static_cast<f_cnt_t>(ConfigManager::inst()->value("audioengine", "framesperaudiobuffer", "256").toUInt()),
-		  MINIMUM_BUFFER_SIZE, MAXIMUM_BUFFER_SIZE))
+		static_cast<f_cnt_t>(ConfigManager::inst()->value("audioengine", "framesperaudiobuffer",
+		QString::number(DEFAULT_BUFFER_SIZE)).toUInt()),
+		MINIMUM_BUFFER_SIZE, MAXIMUM_BUFFER_SIZE))
 	, m_framesPerPeriod(std::min(m_framesPerAudioBuffer, DEFAULT_BUFFER_SIZE))
 	, m_baseSampleRate(
-		  std::max(ConfigManager::inst()->value("audioengine", "samplerate").toInt(), SUPPORTED_SAMPLERATES.front()))
+		std::max(ConfigManager::inst()->value("audioengine", "samplerate").toInt(), SUPPORTED_SAMPLERATES.front()))
 	, m_inputBufferRead(0)
 	, m_inputBufferWrite(1)
 	, m_outputBufferRead(nullptr)

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -143,7 +143,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_disableAutoQuit(ConfigManager::inst()->value(
 			"ui", "disableautoquit", "1").toInt()),
 	m_bufferSize(ConfigManager::inst()->value(
-			"audioengine", "framesperaudiobuffer", "256").toInt()),
+			"audioengine", "framesperaudiobuffer", QString::number(DEFAULT_BUFFER_SIZE)).toInt()),
 	m_mixSanitization(ConfigManager::inst()->value(
 			"audioengine", "sanitizemix", "1").toInt()),
 	m_sampleRate(ConfigManager::inst()->value(

--- a/src/gui/modals/SetupDialog.cpp
+++ b/src/gui/modals/SetupDialog.cpp
@@ -143,7 +143,7 @@ SetupDialog::SetupDialog(ConfigTab tab_to_open) :
 	m_disableAutoQuit(ConfigManager::inst()->value(
 			"ui", "disableautoquit", "1").toInt()),
 	m_bufferSize(ConfigManager::inst()->value(
-			"audioengine", "framesperaudiobuffer").toInt()),
+			"audioengine", "framesperaudiobuffer", "256").toInt()),
 	m_mixSanitization(ConfigManager::inst()->value(
 			"audioengine", "sanitizemix", "1").toInt()),
 	m_sampleRate(ConfigManager::inst()->value(


### PR DESCRIPTION
When the `.lmmsrc.xml` file is created on first install, the "framesperaudiobuffer" value is not given an explicit default value, so an empty `QString` is used as a default, which is converted to 0 by `QString::toInt()` and then clamped to `MINIMUM_BUFFER_SIZE` which is 32. A value of 32 is not ideal and could be bad for performance.

This PR explicitly sets the default frames per audio buffer to `DEFAULT_BUFFER_SIZE` which is 256.
