### PR TITLE
Display Recently Opened Directories in File Dialogs

### DIFF
--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -207,9 +207,14 @@ public:
 		return m_workingDir + "recover.mmp";
 	}
 
-	inline const QStringList & recentlyOpenedProjects() const
+	inline const QStringList& recentlyOpenedProjects() const
 	{
 		return m_recentlyOpenedProjects;
+	}
+
+	inline const QStringList& recentlyOpenedDirectories() const
+	{
+		return m_recentlyOpenedDirectories;
 	}
 
 	const QStringList& favoriteItems() { return m_favoriteItems; }
@@ -238,7 +243,8 @@ public:
 	// Returns true if the working dir (e.g. ~/lmms) exists on disk.
 	bool hasWorkingDir() const;
 
-	void addRecentlyOpenedProject(const QString & _file);
+	void addRecentlyOpenedProject(const QString& file);
+	void addRecentlyOpenedDirectory(const QString& dir);
 
 	void addFavoriteItem(const QString& item);
 	void removeFavoriteItem(const QString& item);
@@ -304,6 +310,7 @@ private:
 	QString m_version;
 	unsigned int m_configVersion;
 	QStringList m_recentlyOpenedProjects;
+	QStringList m_recentlyOpenedDirectories;
 	QStringList m_favoriteItems;
 
 	using stringPairVector = std::vector<QPair<QString, QString>>;

--- a/include/FileDialog.h
+++ b/include/FileDialog.h
@@ -53,6 +53,8 @@ public:
 	static QString openAudioFile(const QString& previousFile = "");
 	static QString openWaveformFile(const QString& previousFile = "");
 	void clearSelection();
+	
+	void fileSelected(const QString &file);
 };
 
 

--- a/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
+++ b/plugins/AudioFileProcessor/AudioFileProcessorView.cpp
@@ -256,7 +256,7 @@ void AudioFileProcessorView::sampleUpdated()
 
 void AudioFileProcessorView::openAudioFile()
 {
-	QString af = FileDialog::openAudioFile();
+	QString af = FileDialog::openAudioFile(castModel<AudioFileProcessor>()->sample().sampleFile());
 	if (af.isEmpty()) { return; }
 
 	castModel<AudioFileProcessor>()->setAudioFile(af);

--- a/plugins/Patman/Patman.cpp
+++ b/plugins/Patman/Patman.cpp
@@ -490,46 +490,32 @@ PatmanView::PatmanView( Instrument * _instrument, QWidget * _parent ) :
 
 void PatmanView::openFile()
 {
-	FileDialog ofd( nullptr, tr( "Open patch file" ) );
-	ofd.setFileMode( FileDialog::ExistingFiles );
+	FileDialog ofd(nullptr, tr("Open patch file"));
+	ofd.setFileMode(FileDialog::ExistingFiles);
 
 	QStringList types;
-	types << tr( "Patch-Files (*.pat)" );
-	ofd.setNameFilters( types );
+	types << tr("Patch-Files (*.pat)");
+	ofd.setNameFilters(types);
 
-	if( m_pi->m_patchFile == "" )
+	if (m_pi->m_patchFile != "")
 	{
-		if( QDir( "/usr/share/midi/freepats" ).exists() )
-		{
-			ofd.setDirectory( "/usr/share/midi/freepats" );
-		}
-		else
-		{
-			ofd.setDirectory(
-				ConfigManager::inst()->userSamplesDir() );
-		}
+		QString f = PathUtil::toAbsolute(m_pi->m_patchFile);
+		ofd.setDirectory(QFileInfo(f).absolutePath());
+		ofd.selectFile(QFileInfo(f).fileName());
 	}
-	else if( QFileInfo( m_pi->m_patchFile ).isRelative() )
+	else if (QDir("/usr/share/midi/freepats").exists())
 	{
-		QString f = ConfigManager::inst()->userSamplesDir()
-							+ m_pi->m_patchFile;
-		if( QFileInfo( f ).exists() == false )
-		{
-			f = ConfigManager::inst()->factorySamplesDir()
-							+ m_pi->m_patchFile;
-		}
-
-		ofd.selectFile( f );
+		ofd.setDirectory("/usr/share/midi/freepats");
 	}
 	else
 	{
-		ofd.selectFile( m_pi->m_patchFile );
+		ofd.setDirectory(ConfigManager::inst()->userSamplesDir());
 	}
 
-	if( ofd.exec() == QDialog::Accepted && !ofd.selectedFiles().isEmpty() )
+	if (ofd.exec() == QDialog::Accepted && !ofd.selectedFiles().isEmpty())
 	{
 		QString f = ofd.selectedFiles()[0];
-		if( f != "" )
+		if (f != "")
 		{
 			m_pi->setFile( f );
 			Engine::getSong()->setModified();

--- a/plugins/SlicerT/SlicerTView.cpp
+++ b/plugins/SlicerT/SlicerTView.cpp
@@ -158,7 +158,7 @@ void SlicerTView::exportMidi()
 
 void SlicerTView::openFiles()
 {
-	const auto audioFile = FileDialog::openAudioFile();
+	const auto audioFile = FileDialog::openAudioFile(m_slicerTParent->getSampleName());
 	if (audioFile.isEmpty()) { return; }
 	m_slicerTParent->updateFile(audioFile);
 }

--- a/plugins/TripleOscillator/TripleOscillator.cpp
+++ b/plugins/TripleOscillator/TripleOscillator.cpp
@@ -136,7 +136,7 @@ OscillatorObject::OscillatorObject( Model * _parent, int _idx ) :
 
 void OscillatorObject::oscUserDefWaveDblClick()
 {
-	auto af = gui::FileDialog::openWaveformFile();
+	auto af = gui::FileDialog::openWaveformFile(m_sampleBuffer->audioFile());
 	if( af != "" )
 	{
 		m_sampleBuffer = SampleBuffer::fromFile(af);

--- a/plugins/VstBase/VstPlugin.cpp
+++ b/plugins/VstBase/VstPlugin.cpp
@@ -534,8 +534,16 @@ void VstPlugin::openPreset()
 {
 	gui::FileDialog ofd(nullptr, tr("Open Preset"), "", tr("VST Plugin Preset (*.fxp *.fxb)"));
 	ofd.setFileMode(gui::FileDialog::ExistingFiles);
+
+	if (p_name != "") // remember last directory
+	{
+		ofd.setDirectory(QFileInfo(p_name).absolutePath());
+	}
+
 	if (ofd.exec() == QDialog::Accepted && !ofd.selectedFiles().isEmpty())
 	{
+		p_name = ofd.selectedFiles()[0];
+
 		lock();
 		sendMessage(message(IdLoadPresetFile).addString(QSTR_TO_STDSTR(
 			QDir::toNativeSeparators(ofd.selectedFiles()[0]))));

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -316,7 +316,7 @@ void ConfigManager::createWorkingDir()
 
 
 
-void ConfigManager::addRecentlyOpenedProject(const QString & file)
+void ConfigManager::addRecentlyOpenedProject(const QString& file)
 {
 	QFileInfo recentFile(file);
 	if(recentFile.suffix().toLower() == "mmp" ||
@@ -331,6 +331,17 @@ void ConfigManager::addRecentlyOpenedProject(const QString & file)
 		m_recentlyOpenedProjects.push_front(file);
 		ConfigManager::inst()->saveConfigFile();
 	}
+}
+
+void ConfigManager::addRecentlyOpenedDirectory(const QString& dir)
+{
+	m_recentlyOpenedDirectories.removeAll(dir);
+	if(m_recentlyOpenedDirectories.size() > 50)
+	{
+		m_recentlyOpenedDirectories.removeFirst();
+	}
+	m_recentlyOpenedDirectories.push_back(dir);
+	ConfigManager::inst()->saveConfigFile();
 }
 
 void ConfigManager::addFavoriteItem(const QString& item)
@@ -488,6 +499,19 @@ void ConfigManager::loadConfigFile(const QString & configFile)
 						n = n.nextSibling();
 					}
 				}
+				else if(node.nodeName() == "recentdirectories")
+				{
+					m_recentlyOpenedDirectories.clear();
+					QDomNode n = node.firstChild();
+					while(!n.isNull())
+					{
+						if(n.isElement() && n.toElement().hasAttributes())
+						{
+							m_recentlyOpenedDirectories << n.toElement().attribute("path");
+						}
+						n = n.nextSibling();
+					}
+				}
 				else if (node.nodeName() == "favoriteitems")
 				{
 					m_favoriteItems.clear();
@@ -606,6 +630,11 @@ void ConfigManager::loadConfigFile(const QString & configFile)
 		file = PathUtil::toAbsolute(file);
 	}
 
+	for (auto& dir : m_recentlyOpenedDirectories)
+	{
+		dir = PathUtil::toAbsolute(dir);
+	}
+
 	for (auto& file : m_favoriteItems)
 	{
 		file = PathUtil::toAbsolute(file);
@@ -649,7 +678,6 @@ void ConfigManager::saveConfigFile()
 	}
 
 	QDomElement recent_files = doc.createElement("recentfiles");
-
 	for (const auto& recentlyOpenedProject : m_recentlyOpenedProjects)
 	{
 		QDomElement n = doc.createElement("file");
@@ -658,15 +686,22 @@ void ConfigManager::saveConfigFile()
 	}
 	lmms_config.appendChild(recent_files);
 
-	QDomElement favorite_items = doc.createElement("favoriteitems");
+	QDomElement recent_directories = doc.createElement("recentdirectories");
+	for (const auto& recentlyOpenedDirectory : m_recentlyOpenedDirectories)
+	{
+		QDomElement n = doc.createElement("dir");
+		n.setAttribute("path", PathUtil::toShortestRelative(recentlyOpenedDirectory));
+		recent_directories.appendChild(n);
+	}
+	lmms_config.appendChild(recent_directories);
 
+	QDomElement favorite_items = doc.createElement("favoriteitems");
 	for (const auto& favoriteItem : m_favoriteItems)
 	{
 		QDomElement n = doc.createElement("item");
 		n.setAttribute("path", PathUtil::toShortestRelative(favoriteItem));
 		favorite_items.appendChild(n);
 	}
-
 	lmms_config.appendChild(favorite_items);
 
 	QString xml = "<?xml version=\"1.0\"?>\n" + doc.toString(2);

--- a/src/gui/LfoControllerDialog.cpp
+++ b/src/gui/LfoControllerDialog.cpp
@@ -208,10 +208,11 @@ LfoControllerDialog::~LfoControllerDialog()
 
 void LfoControllerDialog::askUserDefWave()
 {
-	const auto fileName = FileDialog::openWaveformFile();
-	if (fileName.isEmpty()) { return; }
-
 	auto lfoModel = dynamic_cast<LfoController*>(model());
+
+	const auto fileName = FileDialog::openWaveformFile(lfoModel->m_userDefSampleBuffer->audioFile());
+	if (fileName.isEmpty()) { return; }
+	
 	auto& buffer = lfoModel->m_userDefSampleBuffer;
 	buffer = SampleBuffer::fromFile(fileName);
 

--- a/src/gui/clips/SampleClipView.cpp
+++ b/src/gui/clips/SampleClipView.cpp
@@ -188,7 +188,7 @@ void SampleClipView::mouseDoubleClickEvent( QMouseEvent * )
 {
 	if (m_trackView->trackContainerView()->knifeMode()) { return; }
 
-	const QString selectedAudioFile = FileDialog::openAudioFile();
+	const QString selectedAudioFile = FileDialog::openAudioFile(m_clip->sampleFile());
 
 	if (selectedAudioFile.isEmpty()) { return; }
 	

--- a/src/gui/modals/FileDialog.cpp
+++ b/src/gui/modals/FileDialog.cpp
@@ -37,7 +37,6 @@
 namespace lmms::gui
 {
 
-
 FileDialog::FileDialog( QWidget *parent, const QString &caption,
 					   const QString &directory, const QString &filter ) :
 	QFileDialog( parent, caption, directory, filter )
@@ -102,6 +101,18 @@ FileDialog::FileDialog( QWidget *parent, const QString &caption,
 #endif
 
 	setSidebarUrls(urls);
+
+	QStringList recentDirectories;
+	for (auto dir : ConfigManager::inst()->recentlyOpenedDirectories())
+	{
+		QFileInfo recentDir(dir);
+		if (recentDir.exists()) { recentDirectories.push_back(dir); }
+
+		if (recentDirectories.size() >= 10) { break; }
+	}
+	setHistory(recentDirectories);
+
+	connect(this, &QFileDialog::fileSelected, this, &FileDialog::fileSelected);
 }
 
 
@@ -196,5 +207,10 @@ QString FileDialog::openWaveformFile(const QString& previousFile)
 		previousFile.isEmpty() ? ConfigManager::inst()->factorySamplesDir() + "waveforms/10saw.flac" : previousFile);
 }
 
+void FileDialog::fileSelected(const QString &file)
+{
+	QString directoryPath = directory().absolutePath();
+	ConfigManager::inst()->addRecentlyOpenedDirectory(directoryPath);
+}
 
 } // namespace lmms::gui


### PR DESCRIPTION
This PR adds some functionality to display the last 10 recently opened directories in file dialogs. New directories are added to the list whenever a file is opened, and the list stores 40 additional directories in case some directories don't exist (similarly to the recently opened projects list).

<img width="665" height="478" alt="FileDialog" src="https://github.com/user-attachments/assets/a49d3901-1559-4d2e-be31-df00676dc6d3" />

# To Dos:
- [ ] Determine if a specific directory should be recorded based on context (e.g. opening a project vs. a SoundFont vs. a plugin), or record directories for all file dialogs
- [ ] Add functionality to immediately navigate to a previous directory for specific dialogs (e.g. Project Export when exporting files to the same place)