### PR TITLE
Fix hard-coded widget sizes not following display scaling

### DIFF
--- a/include/DpiHelper.h
+++ b/include/DpiHelper.h
@@ -1,0 +1,61 @@
+/*
+ * DpiHelper.h - helpers for scaling hard-coded design sizes to the display
+ *
+ * Copyright (c) 2026 Zachariah Markusson <zachariahmarkusson@gmail.com>
+ *
+ * This file is part of LMMS - https://lmms.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program (see COPYING); if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef LMMS_GUI_DPI_HELPER_H
+#define LMMS_GUI_DPI_HELPER_H
+
+#include <QGuiApplication>
+#include <QScreen>
+
+#include <cmath>
+
+namespace lmms::gui
+{
+
+//! Returns the factor by which the display scaling enlarges the UI, i.e. the
+//! device pixel ratio of the primary screen. Qt keeps widget geometry in
+//! device-independent pixels, so hard-coded design sizes have to be scaled by
+//! this factor to follow the display scaling. Returns 1.0 if there is no
+//! screen, e.g. when running headless.
+inline float displayScaleFactor()
+{
+	const auto screen = QGuiApplication::primaryScreen();
+	return screen ? static_cast<float>(screen->devicePixelRatio()) : 1.0f;
+}
+
+//! Scales a hard-coded design size in pixels to the current display scaling.
+inline int scaledPixels(int designPixels)
+{
+	return static_cast<int>(std::lround(designPixels * displayScaleFactor()));
+}
+
+//! Inverse of scaledPixels(): converts a display size back to a design size.
+inline int unscaledPixels(int displayPixels)
+{
+	return static_cast<int>(std::lround(displayPixels / displayScaleFactor()));
+}
+
+} // namespace lmms::gui
+
+#endif // LMMS_GUI_DPI_HELPER_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -39,6 +39,7 @@
 #include "AutomationEditor.h"
 #include "ControllerRackView.h"
 #include "DeprecationHelper.h"
+#include "DpiHelper.h"
 #include "embed.h"
 #include "Engine.h"
 #include "ExportProjectDialog.h"
@@ -191,7 +192,7 @@ MainWindow::MainWindow() :
 	// create global-toolbar at the top of our window
 	m_toolBar = new QWidget( main_widget );
 	m_toolBar->setObjectName( "mainToolbar" );
-	m_toolBar->setFixedHeight( 64 );
+	m_toolBar->setFixedHeight(scaledPixels(64));
 	m_toolBar->move( 0, 0 );
 
 	// add layout for organizing quite complex toolbar-layouting

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -43,6 +43,7 @@
 #include "ConfigManager.h"
 #include "CPULoadWidget.h"
 #include "DeprecationHelper.h"
+#include "DpiHelper.h"
 #include "embed.h"
 #include "GuiApplication.h"
 #include "LcdSpinBox.h"
@@ -160,7 +161,7 @@ SongEditor::SongEditor( Song * song ) :
 	m_masterVolumeSlider->setOrientation( Qt::Vertical );
 	m_masterVolumeSlider->setPageStep( 1 );
 	m_masterVolumeSlider->setTickPosition( QSlider::TicksLeft );
-	m_masterVolumeSlider->setFixedSize( 26, 60 );
+	m_masterVolumeSlider->setFixedSize(scaledPixels(26), scaledPixels(60));
 	m_masterVolumeSlider->setTickInterval( 50 );
 	m_masterVolumeSlider->setToolTip(tr("Master volume"));
 
@@ -185,14 +186,14 @@ SongEditor::SongEditor( Song * song ) :
 
 	auto master_pitch_lbl = new QLabel(tb);
 	master_pitch_lbl->setPixmap( embed::getIconPixmap( "master_pitch" ) );
-	master_pitch_lbl->setFixedHeight( 64 );
+	master_pitch_lbl->setFixedHeight(scaledPixels(64));
 
 	m_masterPitchSlider = new AutomatableSlider( tb, tr( "Global transposition" ) );
 	m_masterPitchSlider->setModel( &m_song->m_masterPitchModel );
 	m_masterPitchSlider->setOrientation( Qt::Vertical );
 	m_masterPitchSlider->setPageStep( 1 );
 	m_masterPitchSlider->setTickPosition( QSlider::TicksLeft );
-	m_masterPitchSlider->setFixedSize( 26, 60 );
+	m_masterPitchSlider->setFixedSize(scaledPixels(26), scaledPixels(60));
 	m_masterPitchSlider->setTickInterval( 12 );
 	m_masterPitchSlider->setToolTip(tr("Global transposition"));
 	connect( m_masterPitchSlider, SIGNAL(logicValueChanged(int)), this,

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -32,6 +32,7 @@
 #include "TrackContainer.h"
 #include "AudioEngine.h"
 #include "DataFile.h"
+#include "DpiHelper.h"
 #include "MainWindow.h"
 #include "FileBrowser.h"
 #include "ImportFilter.h"
@@ -485,7 +486,7 @@ unsigned int TrackContainerView::totalHeightOfTracks() const
 	unsigned int heightSum = 0;
 	for (auto & trackView : m_trackViews)
 	{
-		heightSum += trackView->getTrack()->getHeight();
+		heightSum += scaledPixels(trackView->getTrack()->getHeight());
 	}
 	return heightSum;
 }

--- a/src/gui/tracks/TrackView.cpp
+++ b/src/gui/tracks/TrackView.cpp
@@ -37,6 +37,7 @@
 #include "ConfigManager.h"
 #include "DataFile.h"
 #include "DeprecationHelper.h"
+#include "DpiHelper.h"
 #include "Engine.h"
 #include "FadeButton.h"
 #include "StringPairDrag.h"
@@ -81,7 +82,7 @@ TrackView::TrackView( Track * track, TrackContainerView * tcv ) :
 	layout->addWidget( &m_trackOperationsWidget );
 	layout->addWidget( &m_trackSettingsWidget );
 	layout->addWidget( &m_trackContentWidget, 1 );
-	setFixedHeight( m_track->getHeight() );
+	setFixedHeight(scaledPixels(m_track->getHeight()));
 
 	resizeEvent( nullptr );
 
@@ -200,7 +201,7 @@ void TrackView::modelChanged()
 	m_trackOperationsWidget.m_muteBtn->setModel( &m_track->m_mutedModel );
 	m_trackOperationsWidget.m_soloBtn->setModel( &m_track->m_soloModel );
 	ModelView::modelChanged();
-	setFixedHeight( m_track->getHeight() );
+	setFixedHeight(scaledPixels(m_track->getHeight()));
 }
 
 
@@ -264,11 +265,11 @@ void TrackView::mousePressEvent( QMouseEvent * me )
 	const auto pos = position(me);
 
 	// If previously dragged too small, restore on shift-leftclick
-	if( height() < DEFAULT_TRACK_HEIGHT &&
+	if( height() < scaledPixels(DEFAULT_TRACK_HEIGHT) &&
 		me->modifiers() & Qt::ShiftModifier &&
 		me->button() == Qt::LeftButton )
 	{
-		setFixedHeight( DEFAULT_TRACK_HEIGHT );
+		setFixedHeight(scaledPixels(DEFAULT_TRACK_HEIGHT));
 		m_track->setHeight( DEFAULT_TRACK_HEIGHT );
 	}
 
@@ -358,7 +359,7 @@ void TrackView::mouseMoveEvent( QMouseEvent * me )
 		resizeToHeight(pos.y());
 	}
 
-	if( height() < DEFAULT_TRACK_HEIGHT )
+	if( height() < scaledPixels(DEFAULT_TRACK_HEIGHT) )
 	{
 		setToolTip(m_track->m_name);
 	}
@@ -464,9 +465,9 @@ void TrackView::setIndicatorMute(FadeButton* indicator, bool muted)
 
 void TrackView::resizeToHeight(int h)
 {
-	setFixedHeight(qMax<int>(h, MINIMAL_TRACK_HEIGHT));
+	setFixedHeight(qMax<int>(h, scaledPixels(MINIMAL_TRACK_HEIGHT)));
 	m_trackContainerView->realignTracks();
-	m_track->setHeight(height());
+	m_track->setHeight(unscaledPixels(height()));
 }
 
 

--- a/src/gui/widgets/ComboBox.cpp
+++ b/src/gui/widgets/ComboBox.cpp
@@ -32,6 +32,7 @@
 #include <QScreen>
 
 #include "CaptionMenu.h"
+#include "DpiHelper.h"
 #include "FontHelper.h"
 #include "DeprecationHelper.h"
 
@@ -46,7 +47,7 @@ ComboBox::ComboBox( QWidget * _parent, const QString & _name ) :
 	m_menu( this ),
 	m_pressed( false )
 {
-	setFixedHeight( ComboBox::DEFAULT_HEIGHT );
+	setFixedHeight(scaledPixels(ComboBox::DEFAULT_HEIGHT));
 
 	setFont(adjustedToPixelSize(font(), DEFAULT_FONT_SIZE));
 


### PR DESCRIPTION
Qt keeps widget geometry in device-independent pixels, so the hard-coded
sizes in the UI do not follow the display scaling: the main toolbar stays
64 logical pixels at 200% scaling, track heights stay 32 logical pixels,
etc. On a HiDPI screen the affected widgets therefore look smaller than
intended (part of #2510).

This adds a small `DpiHelper` that exposes the primary screen's device
pixel ratio — the same value `embed.cpp` already uses for icon scaling —
and applies it to the most visible hard-coded sizes:

* track heights (`TrackView`, `TrackContainerView::totalHeightOfTracks`)
* `ComboBox` height
* main toolbar height (`MainWindow`)
* master volume/pitch sliders and the master pitch label (`SongEditor`)

Track heights keep their design value (32 px) in the model and in project
files; the scale factor is only applied where the value becomes widget
geometry, and converted back before being written to the model
(`TrackView::resizeToHeight`). At a scale factor of 1.0 the helper is the
identity, so nothing changes on non-HiDPI systems.

Verification:

* built with `-DWANT_QT6=ON` (Release, GCC, Qt 6, x86_64 Linux)
* offscreen test at `QT_SCALE_FACTOR=1`, `1.5` and `2.0` asserting the
  computed sizes (32→48→64, 22→33→44, 64→96→128, 26→39→52, 60→90→120)
* existing test suite still passes

Not addressed here (still hard-coded, from the HiDPI audit): the song
editor zooming slider and snapping combo box
(`SongEditor.cpp:1001`, `:1015`), transport/toolbar widgets, and the
VST/plugin windows discussed in #7683. The helper reads the primary
screen's ratio, so moving a window between differently-scaled screens is
not handled (same limitation as the existing icon scaling).

Fixes part of #2510.
Related: #7683 (not fixed by this patch).
